### PR TITLE
Teach reaper graph-v2 cleanup edges

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -25,6 +25,16 @@ var (
 	rawDurationIntervalRe = regexp.MustCompile(`(?i)\bINTERVAL\s+\{\{(?:max_age|purge_age|stale_issue_age)\}\}`)
 )
 
+const reaperGraphCleanupEdgeSQL = "d.type IN ('parent-child', 'tracks', 'blocks')"
+
+func containsReaperGraphCleanupEdgePredicate(text string) bool {
+	if strings.Contains(text, reaperGraphCleanupEdgeSQL) {
+		return true
+	}
+	return strings.Contains(text, "WISP_CLEANUP_EDGE_TYPES=\"'parent-child', 'tracks', 'blocks'\"") &&
+		strings.Contains(text, "d.type IN ($WISP_CLEANUP_EDGE_TYPES)")
+}
+
 func TestMaintenanceCheckBinariesTreatsGhAsOptional(t *testing.T) {
 	binDir := t.TempDir()
 	bashPath, err := exec.LookPath("bash")
@@ -2385,8 +2395,8 @@ func TestReaperParentIDIsParentChildDependencyProjection(t *testing.T) {
 	if strings.Contains(script, "parent_id") {
 		t.Fatalf("reaper queried parent_id directly; Dolt ParentID is projected from parent-child dependencies:\n%s", script)
 	}
-	if !strings.Contains(script, "wisp_dependencies d") || !strings.Contains(script, "d.type = 'parent-child'") {
-		t.Fatalf("reaper does not follow the canonical Dolt parent-child projection:\n%s", script)
+	if !strings.Contains(script, "wisp_dependencies d") || !containsReaperGraphCleanupEdgePredicate(script) {
+		t.Fatalf("reaper does not follow the canonical Dolt cleanup-edge projection:\n%s", script)
 	}
 }
 
@@ -2472,7 +2482,7 @@ exit 0
 	} else {
 		purgeSQL := log[purgeIdx:]
 		if !strings.Contains(purgeSQL, "child_wisp.status IN ('open', 'hooked', 'in_progress')") ||
-			!strings.Contains(purgeSQL, "d.type = 'parent-child'") ||
+			!containsReaperGraphCleanupEdgePredicate(purgeSQL) ||
 			!strings.Contains(purgeSQL, "SELECT DISTINCT d.depends_on_id") {
 			t.Errorf("reaper purge can delete closed parents with non-closed children:\n%s", purgeSQL)
 		}
@@ -3342,7 +3352,7 @@ exit 0
 	}
 	log := string(logData)
 	if strings.Contains(log, "UPDATE `beads`.wisps SET status='closed'") && !strings.Contains(log, "wisp_dependencies d") {
-		t.Fatalf("reaper closed non-closed wisps by age alone instead of using parent-child dependencies:\n%s", log)
+		t.Fatalf("reaper closed non-closed wisps by age alone instead of using cleanup-edge dependencies:\n%s", log)
 	}
 
 	gcData, err := os.ReadFile(gcLog)
@@ -3431,8 +3441,8 @@ exit 0
 	if !strings.Contains(log, "COUNT(DISTINCT w.id)") {
 		t.Fatalf("reaper stale-wisp close count can be join-multiplied:\n%s", log)
 	}
-	if !strings.Contains(log, "wisp_dependencies d") || !strings.Contains(log, "d.type = 'parent-child'") {
-		t.Fatalf("reaper stale-wisp close path does not use parent-child dependencies:\n%s", log)
+	if !strings.Contains(log, "wisp_dependencies d") || !containsReaperGraphCleanupEdgePredicate(log) {
+		t.Fatalf("reaper stale-wisp close path does not use graph cleanup-edge dependencies:\n%s", log)
 	}
 	if !strings.Contains(log, "d.depends_on_id = parent_wisp.id") || !strings.Contains(log, "d.depends_on_id = parent_issue.id") {
 		t.Fatalf("reaper stale-wisp close path does not use bd 1.0.4 dependency target column:\n%s", log)

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -25,14 +25,31 @@ var (
 	rawDurationIntervalRe = regexp.MustCompile(`(?i)\bINTERVAL\s+\{\{(?:max_age|purge_age|stale_issue_age)\}\}`)
 )
 
-const reaperGraphCleanupEdgeSQL = "d.type IN ('parent-child', 'tracks', 'blocks')"
+const (
+	reaperCloseCleanupEdgeSQL   = "(d.type = 'parent-child' OR (d.type = 'tracks' AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_bead_id\"')) = d.depends_on_id))"
+	reaperPurgeProtectEdgeSQL   = "d.type IN ('parent-child', 'tracks', 'blocks')"
+	reaperCloseCleanupPredicate = "WISP_CLOSE_EDGE_PREDICATE="
+	reaperPurgeProtectTypes     = "WISP_PURGE_PROTECT_EDGE_TYPES="
+)
 
-func containsReaperGraphCleanupEdgePredicate(text string) bool {
-	if strings.Contains(text, reaperGraphCleanupEdgeSQL) {
+func containsReaperCloseCleanupEdgePredicate(text string) bool {
+	if containsSQLFragment(text, reaperCloseCleanupEdgeSQL) {
 		return true
 	}
-	return strings.Contains(text, "WISP_CLEANUP_EDGE_TYPES=\"'parent-child', 'tracks', 'blocks'\"") &&
-		strings.Contains(text, "d.type IN ($WISP_CLEANUP_EDGE_TYPES)")
+	return strings.Contains(text, reaperCloseCleanupPredicate) &&
+		strings.Contains(text, "$WISP_CLOSE_EDGE_PREDICATE")
+}
+
+func containsReaperPurgeProtectEdgePredicate(text string) bool {
+	if containsSQLFragment(text, reaperPurgeProtectEdgeSQL) {
+		return true
+	}
+	return strings.Contains(text, reaperPurgeProtectTypes) &&
+		strings.Contains(text, "d.type IN ($WISP_PURGE_PROTECT_EDGE_TYPES)")
+}
+
+func containsSQLFragment(text, fragment string) bool {
+	return strings.Contains(strings.Join(strings.Fields(text), ""), strings.Join(strings.Fields(fragment), ""))
 }
 
 func TestMaintenanceCheckBinariesTreatsGhAsOptional(t *testing.T) {
@@ -2349,6 +2366,12 @@ func TestReaperFormulaSQLReflectsCurrentSchema(t *testing.T) {
 			t.Errorf("formula sql fence %d uses raw Go duration values in SQL INTERVAL; reaper.sh normalizes durations to integer hours:\n%s", i, fence)
 		}
 	}
+	if !containsReaperCloseCleanupEdgePredicate(formula) {
+		t.Fatalf("formula does not document the reaper close ownership predicate:\n%s", formula)
+	}
+	if !containsReaperPurgeProtectEdgePredicate(formula) {
+		t.Fatalf("formula does not document the reaper purge-protection predicate:\n%s", formula)
+	}
 }
 
 func TestReaperParentIDIsParentChildDependencyProjection(t *testing.T) {
@@ -2395,7 +2418,7 @@ func TestReaperParentIDIsParentChildDependencyProjection(t *testing.T) {
 	if strings.Contains(script, "parent_id") {
 		t.Fatalf("reaper queried parent_id directly; Dolt ParentID is projected from parent-child dependencies:\n%s", script)
 	}
-	if !strings.Contains(script, "wisp_dependencies d") || !containsReaperGraphCleanupEdgePredicate(script) {
+	if !strings.Contains(script, "wisp_dependencies d") || !containsReaperCloseCleanupEdgePredicate(script) {
 		t.Fatalf("reaper does not follow the canonical Dolt cleanup-edge projection:\n%s", script)
 	}
 }
@@ -2482,7 +2505,7 @@ exit 0
 	} else {
 		purgeSQL := log[purgeIdx:]
 		if !strings.Contains(purgeSQL, "child_wisp.status IN ('open', 'hooked', 'in_progress')") ||
-			!containsReaperGraphCleanupEdgePredicate(purgeSQL) ||
+			!containsReaperPurgeProtectEdgePredicate(purgeSQL) ||
 			!strings.Contains(purgeSQL, "SELECT DISTINCT d.depends_on_id") {
 			t.Errorf("reaper purge can delete closed parents with non-closed children:\n%s", purgeSQL)
 		}
@@ -3441,7 +3464,7 @@ exit 0
 	if !strings.Contains(log, "COUNT(DISTINCT w.id)") {
 		t.Fatalf("reaper stale-wisp close count can be join-multiplied:\n%s", log)
 	}
-	if !strings.Contains(log, "wisp_dependencies d") || !containsReaperGraphCleanupEdgePredicate(log) {
+	if !strings.Contains(log, "wisp_dependencies d") || !containsReaperCloseCleanupEdgePredicate(log) {
 		t.Fatalf("reaper stale-wisp close path does not use graph cleanup-edge dependencies:\n%s", log)
 	}
 	if !strings.Contains(log, "d.depends_on_id = parent_wisp.id") || !strings.Contains(log, "d.depends_on_id = parent_issue.id") {
@@ -3460,6 +3483,51 @@ exit 0
 	}
 	if !strings.Contains(string(gcData), "stale_wisps:2") || !strings.Contains(string(gcData), "closed_wisps:1") {
 		t.Fatalf("reaper summary did not report observed and closed wisp counts:\n%s", gcData)
+	}
+}
+
+func TestReaperClosesGraphWorkflowWispTrackedToClosedRoot(t *testing.T) {
+	doltLog, gcLog := runReaperCloseFixture(t, "tracks_owned_root")
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	if !containsReaperCloseCleanupEdgePredicate(log) {
+		t.Fatalf("reaper close path does not require graph-v2 tracks ownership:\n%s", log)
+	}
+	if !strings.Contains(log, "UPDATE `beads`.wisps SET status='closed'") {
+		t.Fatalf("reaper did not close stale graph workflow wisp tracked to a closed root:\n%s", log)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "stale_wisps:1") || !strings.Contains(string(gcData), "closed_wisps:1") {
+		t.Fatalf("reaper summary did not report tracked-root wisp close:\n%s", gcData)
+	}
+}
+
+func TestReaperDoesNotCloseStaleWispWithClosedBlocksPredecessor(t *testing.T) {
+	doltLog, gcLog := runReaperCloseFixture(t, "blocks_closed_predecessor")
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "UPDATE `beads`.wisps SET status='closed'") {
+		t.Fatalf("reaper closed a stale wisp through an ordinary closed blocks predecessor:\n%s", log)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "stale_wisps:1") || !strings.Contains(string(gcData), "closed_wisps:0") {
+		t.Fatalf("reaper summary did not keep closed blocks predecessor as non-closing:\n%s", gcData)
 	}
 }
 
@@ -5308,6 +5376,36 @@ func runScriptResult(t *testing.T, script string, env map[string]string) ([]byte
 	return cmd.CombinedOutput()
 }
 
+func runReaperCloseFixture(t *testing.T, fixture string) (doltLog string, gcLog string) {
+	t.Helper()
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog = filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog = filepath.Join(t.TempDir(), "gc.log")
+
+	writeReaperCloseFixtureDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":        doltLog,
+		"GC_CALL_LOG":          gcLog,
+		"GC_CITY":              cityDir,
+		"GC_CITY_PATH":         cityDir,
+		"GC_DOLT_HOST":         "127.0.0.1",
+		"GC_DOLT_PORT":         "3307",
+		"GC_DOLT_USER":         "root",
+		"GC_DOLT_PASSWORD":     "",
+		"REAPER_CLOSE_FIXTURE": fixture,
+		"PATH":                 binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+	return doltLog, gcLog
+}
+
 func writeExecutable(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
@@ -5407,6 +5505,67 @@ case "$*" in
   else
     printf 'COUNT(*)\n0\n'
   fi
+  ;;
+*"COUNT("*)
+  printf 'COUNT(*)\n0\n'
+  ;;
+*"SELECT id"*)
+  printf 'id\n'
+  ;;
+esac
+exit 0
+	`)
+}
+
+func writeReaperCloseFixtureDoltStub(t *testing.T, path string) {
+	t.Helper()
+	writeExecutable(t, path, `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+
+close_fixture_matches() {
+  case "${REAPER_CLOSE_FIXTURE:-}" in
+    tracks_owned_root)
+      printf '%s' "$*" | grep -F "d.type = 'tracks'" >/dev/null 2>&1 &&
+        printf '%s' "$*" | grep -F "gc.root_bead_id" >/dev/null 2>&1
+      ;;
+    blocks_closed_predecessor)
+      printf '%s' "$*" | grep -F "blocks" >/dev/null 2>&1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+case "$*" in
+*"SHOW DATABASES"*)
+  printf 'Database\nbeads\n'
+  ;;
+*"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+  printf 'Tables_in_db\nwisps\n'
+  ;;
+*"SHOW COLUMNS FROM"*"dependencies"*)
+  printf 'Field,Type,Null,Key,Default,Extra\n'
+  printf 'issue_id,varchar,NO,,,\n'
+  printf 'depends_on_id,varchar,NO,,,\n'
+  printf 'type,varchar,NO,,,\n'
+  ;;
+*"UPDATE "*"wisps SET status='closed'"*)
+  if close_fixture_matches "$*"; then
+    printf 'ROW_COUNT()\n1\n'
+  else
+    printf 'ROW_COUNT()\n0\n'
+  fi
+  ;;
+*"COUNT("*"wisps w"*"wisp_dependencies d"*)
+  if close_fixture_matches "$*"; then
+    printf 'COUNT(*)\n1\n'
+  else
+    printf 'COUNT(*)\n0\n'
+  fi
+  ;;
+*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+  printf 'COUNT(*)\n1\n'
   ;;
 *"COUNT("*)
   printf 'COUNT(*)\n0\n'

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# reaper — close stale wisps with closed parents, purge old closed data, auto-close stale and TTL-expired issues.
+# reaper — close stale wisps with closed parents/roots, purge old closed data, auto-close stale and TTL-expired issues.
 #
 # Replaces mol-dog-reaper formula. All operations are deterministic:
 # SQL queries with age thresholds, bd close/update commands, count
@@ -28,7 +28,10 @@ SESSION_STATE_PRUNE_AGE="${GC_REAPER_SESSION_STATE_PRUNE_AGE:-24h}"
 ALERT_THRESHOLD="${GC_REAPER_ALERT_THRESHOLD:-500}"
 MAIL_ALERT_THRESHOLD="${GC_REAPER_MAIL_ALERT_THRESHOLD:-0}"  # 0 = disabled
 DRY_RUN="${GC_REAPER_DRY_RUN:-}"
-WISP_CLEANUP_EDGE_TYPES="'parent-child', 'tracks', 'blocks'"
+# Closing follows only ownership edges. `blocks` is sequencing, not ownership;
+# purge protection may include it because that only prevents deletion.
+WISP_CLOSE_EDGE_PREDICATE="(d.type = 'parent-child' OR (d.type = 'tracks' AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_bead_id\"')) = d.depends_on_id))"
+WISP_PURGE_PROTECT_EDGE_TYPES="'parent-child', 'tracks', 'blocks'"
 
 # Convert Go durations to SQL INTERVAL hours for Dolt.
 duration_to_hours() {
@@ -359,8 +362,8 @@ while IFS= read -r DB; do
     DB_MUTATIONS=0
 
     # Step 1: Count stale non-closed wisps, then close only candidates whose
-    # explicit graph cleanup edge points to a closed parent. Wisps
-    # without a cleanup edge are reported but not closed by age alone.
+    # explicit ownership edge points to a closed parent/root. Wisps
+    # without an ownership edge are reported but not closed by age alone.
     get_sql_count "$DB" "stale non-closed wisp" "
         SELECT COUNT(*) FROM \`$DB\`.wisps
         WHERE status IN ('open', 'hooked', 'in_progress')
@@ -380,7 +383,7 @@ while IFS= read -r DB; do
             SELECT COUNT(DISTINCT w.id) FROM \`$DB\`.wisps w
             INNER JOIN \`$DB\`.wisp_dependencies d
                 ON d.issue_id = w.id
-                AND d.type IN ($WISP_CLEANUP_EDGE_TYPES)
+                AND $WISP_CLOSE_EDGE_PREDICATE
             LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
             LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
             WHERE w.status IN ('open', 'hooked', 'in_progress')
@@ -408,7 +411,7 @@ while IFS= read -r DB; do
                     SELECT w.id FROM \`$DB\`.wisps w
                     INNER JOIN \`$DB\`.wisp_dependencies d
                         ON d.issue_id = w.id
-                        AND d.type IN ($WISP_CLEANUP_EDGE_TYPES)
+                        AND $WISP_CLOSE_EDGE_PREDICATE
                     LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
                     LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
                     WHERE w.status IN ('open', 'hooked', 'in_progress')
@@ -441,7 +444,7 @@ while IFS= read -r DB; do
         AND id NOT IN (
             SELECT DISTINCT d.depends_on_id FROM \`$DB\`.wisp_dependencies d
             INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
-            WHERE d.type IN ($WISP_CLEANUP_EDGE_TYPES)
+            WHERE d.type IN ($WISP_PURGE_PROTECT_EDGE_TYPES)
             AND child_wisp.status IN ('open', 'hooked', 'in_progress')
         )
     "
@@ -455,7 +458,7 @@ while IFS= read -r DB; do
             AND id NOT IN (
                 SELECT DISTINCT d.depends_on_id FROM \`$DB\`.wisp_dependencies d
                 INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
-                WHERE d.type IN ($WISP_CLEANUP_EDGE_TYPES)
+                WHERE d.type IN ($WISP_PURGE_PROTECT_EDGE_TYPES)
                 AND child_wisp.status IN ('open', 'hooked', 'in_progress')
             )
         "; then

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -28,6 +28,7 @@ SESSION_STATE_PRUNE_AGE="${GC_REAPER_SESSION_STATE_PRUNE_AGE:-24h}"
 ALERT_THRESHOLD="${GC_REAPER_ALERT_THRESHOLD:-500}"
 MAIL_ALERT_THRESHOLD="${GC_REAPER_MAIL_ALERT_THRESHOLD:-0}"  # 0 = disabled
 DRY_RUN="${GC_REAPER_DRY_RUN:-}"
+WISP_CLEANUP_EDGE_TYPES="'parent-child', 'tracks', 'blocks'"
 
 # Convert Go durations to SQL INTERVAL hours for Dolt.
 duration_to_hours() {
@@ -358,8 +359,8 @@ while IFS= read -r DB; do
     DB_MUTATIONS=0
 
     # Step 1: Count stale non-closed wisps, then close only candidates whose
-    # explicit parent-child edge points to a closed parent. Wisps
-    # without a parent edge are reported but not closed by age alone.
+    # explicit graph cleanup edge points to a closed parent. Wisps
+    # without a cleanup edge are reported but not closed by age alone.
     get_sql_count "$DB" "stale non-closed wisp" "
         SELECT COUNT(*) FROM \`$DB\`.wisps
         WHERE status IN ('open', 'hooked', 'in_progress')
@@ -379,7 +380,7 @@ while IFS= read -r DB; do
             SELECT COUNT(DISTINCT w.id) FROM \`$DB\`.wisps w
             INNER JOIN \`$DB\`.wisp_dependencies d
                 ON d.issue_id = w.id
-                AND d.type = 'parent-child'
+                AND d.type IN ($WISP_CLEANUP_EDGE_TYPES)
             LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
             LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
             WHERE w.status IN ('open', 'hooked', 'in_progress')
@@ -407,7 +408,7 @@ while IFS= read -r DB; do
                     SELECT w.id FROM \`$DB\`.wisps w
                     INNER JOIN \`$DB\`.wisp_dependencies d
                         ON d.issue_id = w.id
-                        AND d.type = 'parent-child'
+                        AND d.type IN ($WISP_CLEANUP_EDGE_TYPES)
                     LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
                     LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
                     WHERE w.status IN ('open', 'hooked', 'in_progress')
@@ -440,7 +441,7 @@ while IFS= read -r DB; do
         AND id NOT IN (
             SELECT DISTINCT d.depends_on_id FROM \`$DB\`.wisp_dependencies d
             INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
-            WHERE d.type = 'parent-child'
+            WHERE d.type IN ($WISP_CLEANUP_EDGE_TYPES)
             AND child_wisp.status IN ('open', 'hooked', 'in_progress')
         )
     "
@@ -454,7 +455,7 @@ while IFS= read -r DB; do
             AND id NOT IN (
                 SELECT DISTINCT d.depends_on_id FROM \`$DB\`.wisp_dependencies d
                 INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
-                WHERE d.type = 'parent-child'
+                WHERE d.type IN ($WISP_CLEANUP_EDGE_TYPES)
                 AND child_wisp.status IN ('open', 'hooked', 'in_progress')
             )
         "; then

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -15,16 +15,17 @@ gc runtime drain-ack
 
 The drain-ack tells the controller this session is done.
 
-The Reaper Dog closes stale non-closed wisps only when parent-child
-dependency data proves the parent is closed, purges closed wisps
-older than the purge threshold, and auto-closes stale issues only in the city
+The Reaper Dog closes stale non-closed wisps only when ownership dependency
+data proves the parent or workflow root is closed, purges closed wisps older
+than the purge threshold, and auto-closes stale issues only in the city
 database where `bd close` is correctly scoped. This keeps the wisps table from
 growing unbounded without closing active wisps by age alone.
 
 Current behavior:
 - Observes open/hooked/in_progress wisps older than max_age (default 24h)
 - Closes only the subset whose parent-child dependency points to a closed
-  parent
+  parent, or whose graph-v2 `tracks` edge points to its `gc.root_bead_id`
+  workflow root after that root is closed
 - Purges (deletes) closed wisps past purge_age (default 7 days)
 - Auto-closes stale city issues open >30 days with no status change
 - Reports stale issue candidates in non-city databases without closing them
@@ -35,10 +36,13 @@ mail cleanup must go through `bd`, never Dolt. BD-backed mail retention is
 tracked separately as `ga-w9jfl5`; until that lands, Reaper intentionally does
 not delete mail. Wisp parentage is no longer carried on the wisps row; it
 lives in `wisp_dependencies` rows with `type='parent-child'` and a
-`depends_on_id` target column in the bd 1.0.4 schema. For the Dolt-backed bead
-store, `ParentID` is a projection from those parent-child dependencies, not a
-separate `parent_id` column for Reaper to query. Non-closed wisps without that
-parentage signal are reported only; they are not closed by age alone.
+`depends_on_id` target column in the bd 1.0.4 schema. Graph-v2 workflow wisps
+are owned through `tracks` edges from the child to the workflow root, with the
+child's `gc.root_bead_id` metadata matching `depends_on_id`. For the
+Dolt-backed bead store, `ParentID` is a projection from parent-child
+dependencies, not a separate `parent_id` column for Reaper to query.
+Non-closed wisps without an ownership signal are reported only; they are not
+closed by age alone.
 Legacy `mail_delete_age` overrides do not apply to Reaper and should be
 removed or moved to the BD-backed mail cleanup tool. Legacy `databases`
 overrides from earlier formula drafts are also no longer accepted; the script
@@ -49,7 +53,7 @@ database patterns.
 
 This is infrastructure work. You:
 1. Scan all production databases for candidates
-2. Report non-closed wisps past max_age and close only wisps whose parent is closed
+2. Report non-closed wisps past max_age and close only wisps whose parent/root is closed
 3. Purge (delete) closed wisps past purge_age
 4. Auto-close stale city issues (with exclusions)
 5. Report findings and flag anomalies
@@ -74,9 +78,13 @@ examples below use `<max_age_hours>`, `<purge_age_hours>`, and
 ## Safety
 
 Non-closed wisps are closed only when a parent-child dependency points to a
-closed parent. Wisps without a parent-child edge, or with an unresolved parent
-record, are observed, not closed by age alone. Purging deletes rows —
-irreversible but only targets already-closed wisps past retention. Auto-close
+closed parent, or when a graph-v2 `tracks` edge points to the child's own
+`gc.root_bead_id` workflow root and that root is closed. Ordinary `blocks`
+dependencies are sequencing edges and must never close a live wisp. Wisps
+without an ownership edge, or with an unresolved parent/root record, are
+observed, not closed by age alone. Purging deletes rows — irreversible but
+only targets already-closed wisps past retention. Its protection query may
+include `blocks` because over-protection only prevents deletion. Auto-close
 excludes P0/P1, epics, and issues with active dependencies. Non-city database
 issue candidates are report-only until the maintenance pack has an explicit
 DB-to-`BEADS_DIR` routing map for scoped `bd close`. If the canonical city
@@ -138,11 +146,17 @@ SELECT COUNT(*) FROM wisps
 WHERE status IN ('open', 'hooked', 'in_progress')
 AND created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR);
 
--- Schema-safe close candidates: stale child wisps with closed parent
+-- Schema-safe close candidates: stale child wisps with closed parent/root
 SELECT COUNT(DISTINCT w.id) FROM wisps w
 INNER JOIN wisp_dependencies d
   ON d.issue_id = w.id
-  AND d.type = 'parent-child'
+  AND (
+    d.type = 'parent-child'
+    OR (
+      d.type = 'tracks'
+      AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$."gc.root_bead_id"')) = d.depends_on_id
+    )
+  )
 LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
 LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
 WHERE w.status IN ('open', 'hooked', 'in_progress')
@@ -161,7 +175,7 @@ AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
 AND id NOT IN (
   SELECT DISTINCT d.depends_on_id FROM wisp_dependencies d
   INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
-  WHERE d.type = 'parent-child'
+  WHERE d.type IN ('parent-child', 'tracks', 'blocks')
   AND child_wisp.status IN ('open', 'hooked', 'in_progress')
 );
 
@@ -187,16 +201,17 @@ beads with Type=message; any mail cleanup goes through `bd`.
 
 [[steps]]
 id = "reap"
-title = "Close stale wisps with closed parents"
+title = "Close stale wisps with closed parents or roots"
 description = """
 Report wisps past max_age and close only the schema-safe subset whose
-parent-child dependency points to a closed parent.
+ownership dependency points to a closed parent or workflow root.
 
 Wisp parentage no longer lives on the wisps row (the schema has no
 `parent_id` column); parentage is in `wisp_dependencies` rows with
 `type='parent-child'` and `depends_on_id`. The SDK `ParentID` field is
-projected from those rows for Dolt-backed beads. Do not close non-closed wisps
-by age alone.
+projected from those rows for Dolt-backed beads. Graph-v2 workflow ownership
+uses a `tracks` edge from the child to the root and must match the child's
+`gc.root_bead_id` metadata. Do not close non-closed wisps by age alone.
 `wisp-compact.sh` promotes non-closed wisps past TTL for stuck detection.
 The close step repeats until no schema-safe candidates remain, so a stale
 multi-level child chain whose root is closed converges in one reaper run.
@@ -208,7 +223,7 @@ WHERE status IN ('open', 'hooked', 'in_progress')
 AND created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR);
 ```
 
-**2. Close only stale wisps with closed parents, repeating to a fixpoint:**
+**2. Close only stale wisps with closed parents or roots, repeating to a fixpoint:**
 ```sql
 UPDATE wisps SET status='closed', closed_at=NOW()
 WHERE status IN ('open', 'hooked', 'in_progress')
@@ -218,7 +233,13 @@ AND id IN (
     SELECT w.id FROM wisps w
     INNER JOIN wisp_dependencies d
       ON d.issue_id = w.id
-      AND d.type = 'parent-child'
+      AND (
+        d.type = 'parent-child'
+        OR (
+          d.type = 'tracks'
+          AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$."gc.root_bead_id"')) = d.depends_on_id
+        )
+      )
     LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
     LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
     WHERE w.status IN ('open', 'hooked', 'in_progress')
@@ -233,7 +254,7 @@ AND id IN (
 
 **3. Record results:**
 - Count stale non-closed wisps per database
-- Count closed-parent stale wisps closed per database
+- Count closed-parent/root stale wisps closed per database
 - Any errors encountered
 
 **4. Alert check:**
@@ -241,7 +262,7 @@ If stale non-message open wisps across all databases exceed
 {{alert_threshold}}, log a warning and consider escalating. Fresh workflow load
 can legitimately exceed the raw open-wisp threshold on busy cities.
 
-**Exit criteria:** Stale non-closed wisps counted; only stale wisps with closed parents closed."""
+**Exit criteria:** Stale non-closed wisps counted; only stale wisps with closed parents or roots closed."""
 
 [[steps]]
 id = "purge"
@@ -257,7 +278,7 @@ AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
 AND id NOT IN (
   SELECT DISTINCT d.depends_on_id FROM wisp_dependencies d
   INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
-  WHERE d.type = 'parent-child'
+  WHERE d.type IN ('parent-child', 'tracks', 'blocks')
   AND child_wisp.status IN ('open', 'hooked', 'in_progress')
 );
 ```
@@ -268,7 +289,8 @@ AND id NOT IN (
 
 **Safety:** Only deletes wisps that are already closed AND past the
 retention window, and never deletes a closed parent wisp while any
-non-closed child wisp still depends on it. Active wisps are never touched.
+non-closed child wisp still depends on it through cleanup or sequencing edges.
+Active wisps are never touched.
 Mail messages live as beads (Type=message), not in a SQL table — use `bd`
 for any mail cleanup, never DELETE FROM mail.
 
@@ -328,7 +350,7 @@ Generate summary and signal completion.
 **1. Generate report summary:**
 - Databases scanned
 - Stale non-closed wisps observed
-- Closed-parent stale wisps closed
+- Closed-parent/root stale wisps closed
 - Wisps purged (deleted old closed wisps)
 - City issues auto-closed (stale past {{stale_issue_age}}, excl. epics/P0-P1/deps)
 - Non-city stale issue candidates skipped as report-only


### PR DESCRIPTION
## Cause

The maintenance reaper only treated `wisp_dependencies.type = 'parent-child'` as a cleanup edge. Graph-v2 workflows also use `tracks` and `blocks` edges to connect cleanup-owned workflow rows, so stale child wisps could remain open and closed parents could be protected or purged incorrectly depending on which edge type represented the relationship.

## Fix

- Centralize the reaper cleanup-edge set as `parent-child`, `tracks`, and `blocks`.
- Use that edge set in the stale-wisp close path and in the closed-wisp purge protection path.
- Preserve the bd 1.0.4/1.0.5 generic dependency schema by continuing to use `depends_on_id` and by retaining the existing dependency schema gates.

## Verification

- `.githooks/pre-commit` ran successfully during commit, including `go vet ./...` and `./scripts/test-local-parallel fast`.
- `go test ./examples/gastown` passed.
- Focused reaper checks passed for current schema, parent projection, stale close behavior, chain closure, and dependency-target compatibility.
