### PR TITLE
Close stale inactive workflow roots in reaper

### DIFF
--- a/examples/gastown/maintenance_scripts_dolt_integration_test.go
+++ b/examples/gastown/maintenance_scripts_dolt_integration_test.go
@@ -42,6 +42,9 @@ func TestReaperWorkflowRootCleanupRealDoltSemantics(t *testing.T) {
 	port := startDoltServerForMaintenanceTest(t, doltPath, dataDir)
 	waitForDoltServerForMaintenanceTest(t, doltPath, port, "citydb")
 	writeCityBeadsMetadata(t, cityDir, "citydb")
+	rigDir := filepath.Join(cityDir, "rigs", "rig-with-db-alias")
+	writeCityBeadsMetadata(t, rigDir, "rigdb")
+	writeSiteRigBinding(t, cityDir, "rig-with-db-alias", rigDir)
 
 	binDir := t.TempDir()
 	bdLog := filepath.Join(t.TempDir(), "bd.log")
@@ -95,7 +98,10 @@ exit 0
 	cityWispStatuses := queryMaintenanceStatusByID(t, doltPath, port, "citydb", "wisps")
 	requireMaintenanceStatuses(t, cityWispStatuses, map[string]string{
 		"wisp-close":               "closed",
+		"wisp-city-store-root":     "closed",
+		"wisp-cross-store-root":    "open",
 		"wisp-held":                "blocked",
+		"wisp-non-root-workflow":   "open",
 		"wisp-recent-root":         "open",
 		"wisp-nested-root":         "open",
 		"wisp-subroot":             "closed",
@@ -105,15 +111,20 @@ exit 0
 
 	cityIssueStatuses := queryMaintenanceStatusByID(t, doltPath, port, "citydb", "issues")
 	requireMaintenanceStatuses(t, cityIssueStatuses, map[string]string{
-		"issue-close":    "closed",
-		"issue-held":     "blocked",
-		"issue-dep-root": "open",
-		"issue-dep-live": "in_progress",
+		"issue-city-store-root":   "closed",
+		"issue-close":             "closed",
+		"issue-cross-store-root":  "open",
+		"issue-held":              "blocked",
+		"issue-dep-root":          "open",
+		"issue-dep-live":          "in_progress",
+		"issue-non-root-workflow": "open",
 	})
 
 	rigWispStatuses := queryMaintenanceStatusByID(t, doltPath, port, "rigdb", "wisps")
 	requireMaintenanceStatuses(t, rigWispStatuses, map[string]string{
-		"rig-wisp-close": "closed",
+		"rig-wisp-close":            "closed",
+		"rig-wisp-store-root":       "closed",
+		"rig-wisp-other-store-root": "open",
 	})
 
 	rigIssueStatuses := queryMaintenanceStatusByID(t, doltPath, port, "rigdb", "issues")
@@ -175,18 +186,24 @@ func maintenanceReaperCitySeedSQL() string {
 	return `
 INSERT INTO wisps (id, title, status, issue_type, priority, created_at, updated_at, assignee, metadata) VALUES
   ('wisp-close', 'closeable root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('wisp-city-store-root', 'closeable city-store root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow","gc.root_store_ref":"city:test-city"}'),
+  ('wisp-cross-store-root', 'cross-store root preserved', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow","gc.root_store_ref":"rig:other"}'),
   ('wisp-held', 'held root', 'blocked', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('wisp-non-root-workflow', 'non-root topology bead preserved', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow","gc.root_bead_id":"wisp-nested-root"}'),
   ('wisp-recent-root', 'recent descendant root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
   ('wisp-recent-closed-child', 'recent closed child', 'closed', 'task', 2, '2026-01-01 00:00:00', NOW(), '', '{"gc.root_bead_id":"wisp-recent-root"}'),
   ('wisp-nested-root', 'nested root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
   ('wisp-subroot', 'nested subroot', 'closed', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.root_bead_id":"wisp-nested-root"}'),
-  ('wisp-live-grandchild', 'live nested child', 'in_progress', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.root_bead_id":"wisp-subroot"}');
+  ('wisp-live-grandchild', 'live nested child', 'in_progress', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{}');
 INSERT INTO wisp_dependencies (issue_id, depends_on_id, type) VALUES
   ('wisp-subroot', 'wisp-nested-root', 'tracks'),
   ('wisp-live-grandchild', 'wisp-subroot', 'tracks');
 INSERT INTO issues (id, title, status, issue_type, priority, created_at, updated_at, assignee, metadata) VALUES
   ('issue-close', 'closeable city issue root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('issue-city-store-root', 'closeable city-store issue root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow","gc.root_store_ref":"city:test-city"}'),
+  ('issue-cross-store-root', 'cross-store issue root preserved', 'open', 'task', 1, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow","gc.root_store_ref":"rig:other"}'),
   ('issue-held', 'held city issue root', 'blocked', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('issue-non-root-workflow', 'non-root issue topology bead preserved', 'open', 'task', 1, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow","gc.root_bead_id":"issue-dep-root"}'),
   ('issue-dep-root', 'dependency-protected issue root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
   ('issue-dep-live', 'live issue dependency child', 'in_progress', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{}');
 INSERT INTO dependencies (issue_id, depends_on_id, type) VALUES
@@ -197,7 +214,9 @@ INSERT INTO dependencies (issue_id, depends_on_id, type) VALUES
 func maintenanceReaperRigSeedSQL() string {
 	return `
 INSERT INTO wisps (id, title, status, issue_type, priority, created_at, updated_at, assignee, metadata) VALUES
-  ('rig-wisp-close', 'closeable non-city wisp root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}');
+  ('rig-wisp-close', 'closeable non-city wisp root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('rig-wisp-store-root', 'closeable rig-store wisp root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow","gc.root_store_ref":"rig:rig-with-db-alias"}'),
+  ('rig-wisp-other-store-root', 'other rig-store root preserved', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow","gc.root_store_ref":"rig:other"}');
 INSERT INTO issues (id, title, status, issue_type, priority, created_at, updated_at, assignee, metadata) VALUES
   ('rig-issue-preserve', 'non-city issue root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}');
 `

--- a/examples/gastown/maintenance_scripts_dolt_integration_test.go
+++ b/examples/gastown/maintenance_scripts_dolt_integration_test.go
@@ -1,0 +1,337 @@
+//go:build integration || dolt_integration
+
+package gastown_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReaperWorkflowRootCleanupRealDoltSemantics(t *testing.T) {
+	doltPath, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Skipf("dolt not found: %v", err)
+	}
+
+	cityDir := t.TempDir()
+	dataDir := filepath.Join(t.TempDir(), "dolt")
+	for _, db := range []string{"citydb", "rigdb"} {
+		dbDir := filepath.Join(dataDir, db)
+		if err := os.MkdirAll(dbDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", dbDir, err)
+		}
+		runDoltForMaintenanceTest(t, doltPath, dbDir, "init", "--name", "Gas City", "--email", "test@example.com")
+		runDoltSQLForMaintenanceTest(t, doltPath, dbDir, maintenanceReaperSchemaSQL())
+	}
+
+	runDoltSQLForMaintenanceTest(t, doltPath, filepath.Join(dataDir, "citydb"), maintenanceReaperCitySeedSQL())
+	runDoltForMaintenanceTest(t, doltPath, filepath.Join(dataDir, "citydb"), "add", ".")
+	runDoltForMaintenanceTest(t, doltPath, filepath.Join(dataDir, "citydb"), "commit", "-m", "seed city workflow roots")
+
+	runDoltSQLForMaintenanceTest(t, doltPath, filepath.Join(dataDir, "rigdb"), maintenanceReaperRigSeedSQL())
+	runDoltForMaintenanceTest(t, doltPath, filepath.Join(dataDir, "rigdb"), "add", ".")
+	runDoltForMaintenanceTest(t, doltPath, filepath.Join(dataDir, "rigdb"), "commit", "-m", "seed rig workflow roots")
+
+	port := startDoltServerForMaintenanceTest(t, doltPath, dataDir)
+	waitForDoltServerForMaintenanceTest(t, doltPath, port, "citydb")
+	writeCityBeadsMetadata(t, cityDir, "citydb")
+
+	binDir := t.TempDir()
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	if err := os.Symlink(doltPath, filepath.Join(binDir, "dolt")); err != nil {
+		t.Fatalf("Symlink(dolt): %v", err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+set -e
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+case "$1" in
+  prune)
+    printf '{"pruned_count":0}\n'
+    ;;
+  close)
+    issue_id="$2"
+    DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" dolt --host "$GC_DOLT_HOST" --port "$GC_DOLT_PORT" --user "$GC_DOLT_USER" --no-tls --use-db citydb sql \
+      -q "UPDATE issues SET status='closed', closed_at=NOW() WHERE id='${issue_id}'; CALL DOLT_COMMIT('-Am', 'test bd close')"
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+case "$1 $2" in
+  "session prune")
+    printf '{"count":0}\n'
+    ;;
+esac
+exit 0
+`)
+
+	env := map[string]string{
+		"BD_CALL_LOG":      bdLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     fmt.Sprintf("%d", port),
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if !strings.Contains(string(bdData), "close issue-close --reason stale inactive workflow root auto-closed by reaper") {
+		t.Fatalf("reaper did not close city workflow issue root through bd close:\n%s", bdData)
+	}
+
+	cityWispStatuses := queryMaintenanceStatusByID(t, doltPath, port, "citydb", "wisps")
+	requireMaintenanceStatuses(t, cityWispStatuses, map[string]string{
+		"wisp-close":               "closed",
+		"wisp-held":                "blocked",
+		"wisp-recent-root":         "open",
+		"wisp-nested-root":         "open",
+		"wisp-subroot":             "closed",
+		"wisp-live-grandchild":     "in_progress",
+		"wisp-recent-closed-child": "closed",
+	})
+
+	cityIssueStatuses := queryMaintenanceStatusByID(t, doltPath, port, "citydb", "issues")
+	requireMaintenanceStatuses(t, cityIssueStatuses, map[string]string{
+		"issue-close":    "closed",
+		"issue-held":     "blocked",
+		"issue-dep-root": "open",
+		"issue-dep-live": "in_progress",
+	})
+
+	rigWispStatuses := queryMaintenanceStatusByID(t, doltPath, port, "rigdb", "wisps")
+	requireMaintenanceStatuses(t, rigWispStatuses, map[string]string{
+		"rig-wisp-close": "closed",
+	})
+
+	rigIssueStatuses := queryMaintenanceStatusByID(t, doltPath, port, "rigdb", "issues")
+	requireMaintenanceStatuses(t, rigIssueStatuses, map[string]string{
+		"rig-issue-preserve": "open",
+	})
+}
+
+func maintenanceReaperSchemaSQL() string {
+	return `
+CREATE TABLE wisps (
+  id VARCHAR(64) PRIMARY KEY,
+  title VARCHAR(255),
+  status VARCHAR(32),
+  issue_type VARCHAR(32),
+  priority BIGINT,
+  created_at DATETIME(6),
+  updated_at DATETIME(6),
+  closed_at DATETIME(6),
+  assignee VARCHAR(255),
+  description LONGTEXT,
+  metadata JSON
+);
+CREATE TABLE issues (
+  id VARCHAR(64) PRIMARY KEY,
+  title VARCHAR(255),
+  status VARCHAR(32),
+  issue_type VARCHAR(32),
+  priority BIGINT,
+  created_at DATETIME(6),
+  updated_at DATETIME(6),
+  closed_at DATETIME(6),
+  assignee VARCHAR(255),
+  description LONGTEXT,
+  metadata JSON
+);
+CREATE TABLE dependencies (
+  issue_id VARCHAR(64),
+  depends_on_id VARCHAR(64),
+  type VARCHAR(32)
+);
+CREATE TABLE wisp_dependencies (
+  issue_id VARCHAR(64),
+  depends_on_id VARCHAR(64),
+  type VARCHAR(32)
+);
+CREATE TABLE labels (
+  issue_id VARCHAR(64),
+  label VARCHAR(255)
+);
+CREATE TABLE wisp_labels (
+  issue_id VARCHAR(64),
+  label VARCHAR(255)
+);
+`
+}
+
+func maintenanceReaperCitySeedSQL() string {
+	return `
+INSERT INTO wisps (id, title, status, issue_type, priority, created_at, updated_at, assignee, metadata) VALUES
+  ('wisp-close', 'closeable root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('wisp-held', 'held root', 'blocked', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('wisp-recent-root', 'recent descendant root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('wisp-recent-closed-child', 'recent closed child', 'closed', 'task', 2, '2026-01-01 00:00:00', NOW(), '', '{"gc.root_bead_id":"wisp-recent-root"}'),
+  ('wisp-nested-root', 'nested root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('wisp-subroot', 'nested subroot', 'closed', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.root_bead_id":"wisp-nested-root"}'),
+  ('wisp-live-grandchild', 'live nested child', 'in_progress', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.root_bead_id":"wisp-subroot"}');
+INSERT INTO wisp_dependencies (issue_id, depends_on_id, type) VALUES
+  ('wisp-subroot', 'wisp-nested-root', 'tracks'),
+  ('wisp-live-grandchild', 'wisp-subroot', 'tracks');
+INSERT INTO issues (id, title, status, issue_type, priority, created_at, updated_at, assignee, metadata) VALUES
+  ('issue-close', 'closeable city issue root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('issue-held', 'held city issue root', 'blocked', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('issue-dep-root', 'dependency-protected issue root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
+  ('issue-dep-live', 'live issue dependency child', 'in_progress', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{}');
+INSERT INTO dependencies (issue_id, depends_on_id, type) VALUES
+  ('issue-dep-live', 'issue-dep-root', 'blocks');
+`
+}
+
+func maintenanceReaperRigSeedSQL() string {
+	return `
+INSERT INTO wisps (id, title, status, issue_type, priority, created_at, updated_at, assignee, metadata) VALUES
+  ('rig-wisp-close', 'closeable non-city wisp root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}');
+INSERT INTO issues (id, title, status, issue_type, priority, created_at, updated_at, assignee, metadata) VALUES
+  ('rig-issue-preserve', 'non-city issue root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}');
+`
+}
+
+func runDoltForMaintenanceTest(t *testing.T, doltPath, dir string, args ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, doltPath, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dolt %s failed in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return string(out)
+}
+
+func runDoltSQLForMaintenanceTest(t *testing.T, doltPath, dir, query string) string {
+	t.Helper()
+	return runDoltForMaintenanceTest(t, doltPath, dir, "sql", "-q", query)
+}
+
+func startDoltServerForMaintenanceTest(t *testing.T, doltPath, dataDir string) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("Close listener: %v", err)
+	}
+
+	logPath := filepath.Join(dataDir, "sql-server.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("Create(%s): %v", logPath, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, doltPath, "sql-server",
+		"-H", "127.0.0.1",
+		"-P", fmt.Sprintf("%d", port),
+		"--data-dir", dataDir,
+		"--loglevel", "warning",
+	)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		t.Fatalf("Start dolt sql-server: %v", err)
+	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-waitCh:
+		case <-time.After(10 * time.Second):
+			_ = cmd.Process.Kill()
+			<-waitCh
+		}
+		_ = logFile.Close()
+	})
+	return port
+}
+
+func waitForDoltServerForMaintenanceTest(t *testing.T, doltPath string, port int, db string) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	var lastOut []byte
+	var lastErr error
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		cmd := exec.CommandContext(ctx, doltPath,
+			"--host", "127.0.0.1",
+			"--port", fmt.Sprintf("%d", port),
+			"--user", "root",
+			"--no-tls",
+			"--use-db", db,
+			"sql", "-q", "SELECT 1",
+		)
+		cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD=")
+		lastOut, lastErr = cmd.CombinedOutput()
+		cancel()
+		if lastErr == nil {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("dolt sql-server did not become ready on port %d: %v\n%s", port, lastErr, lastOut)
+}
+
+func queryMaintenanceStatusByID(t *testing.T, doltPath string, port int, db string, table string) map[string]string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, doltPath,
+		"--host", "127.0.0.1",
+		"--port", fmt.Sprintf("%d", port),
+		"--user", "root",
+		"--no-tls",
+		"--use-db", db,
+		"sql", "-r", "csv", "-q", fmt.Sprintf("SELECT id,status FROM %s ORDER BY id", table),
+	)
+	cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD=")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("query %s.%s statuses: %v\n%s", db, table, err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "id,status" {
+		t.Fatalf("unexpected status output for %s.%s:\n%s", db, table, out)
+	}
+	statuses := make(map[string]string)
+	for _, line := range lines[1:] {
+		fields := strings.Split(line, ",")
+		if len(fields) != 2 {
+			t.Fatalf("unexpected status row for %s.%s: %q\nfull output:\n%s", db, table, line, out)
+		}
+		statuses[fields[0]] = fields[1]
+	}
+	return statuses
+}
+
+func requireMaintenanceStatuses(t *testing.T, got map[string]string, want map[string]string) {
+	t.Helper()
+	for id, wantStatus := range want {
+		if got[id] != wantStatus {
+			t.Fatalf("status[%s] = %q, want %q\nall statuses: %#v", id, got[id], wantStatus, got)
+		}
+	}
+}

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2056,6 +2056,9 @@ case "$*" in
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
+  *"WITH RECURSIVE workflow_issue_root_candidates"*"SELECT DISTINCT root.id"*)
+    printf 'id\n'
+    ;;
   *"issue_type NOT IN"*)
     printf 'COUNT(*)\n0\n'
     ;;
@@ -2124,6 +2127,9 @@ case "$*" in
     ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
+    ;;
+  *"WITH RECURSIVE workflow_issue_root_candidates"*"SELECT DISTINCT root.id"*)
+    printf 'id\n'
     ;;
   *"issue_type NOT IN"*"created_at < DATE_SUB"*)
     printf 'COUNT(*)\n0\n'
@@ -3790,6 +3796,7 @@ func TestReaperClosesStaleInactiveWorkflowRoots(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
 	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
@@ -3807,17 +3814,154 @@ case "$*" in
     printf 'depends_on_id,varchar,NO,,,\n'
     printf 'type,varchar,NO,,,\n'
     ;;
-  *"UPDATE "*"wisps SET status='closed'"*"gc.formula_contract"*"gc.root_bead_id"*)
+  *"WITH RECURSIVE workflow_wisp_root_candidates"*"UPDATE "*"wisps SET status='closed'"*"JSON_SET(COALESCE(metadata, JSON_OBJECT())"*)
     printf 'ROW_COUNT()\n1\n'
     ;;
-  *"UPDATE "*"issues SET status='closed'"*"gc.formula_contract"*"gc.root_bead_id"*)
-    printf 'ROW_COUNT()\n1\n'
-    ;;
-  *"COUNT(DISTINCT w.id)"*"gc.kind"*"gc.formula_contract"*"gc.root_bead_id"*)
+  *"WITH RECURSIVE workflow_wisp_root_candidates"*"SELECT COUNT(*) FROM ("*)
     printf 'COUNT(*)\n1\n'
     ;;
-  *"COUNT(DISTINCT i.id)"*"gc.kind"*"gc.formula_contract"*"gc.root_bead_id"*)
-    printf 'COUNT(*)\n1\n'
+  *"WITH RECURSIVE workflow_issue_root_candidates"*"SELECT DISTINCT root.id"*)
+    printf 'id\nissue-close\n'
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+	writeCityBeadsMetadata(t, cityDir, "beads")
+
+	env := map[string]string{
+		"BD_CALL_LOG":      bdLog,
+		"DOLT_ARGS_LOG":    doltLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	for _, want := range []string{
+		"WITH RECURSIVE workflow_wisp_root_candidates",
+		"WITH RECURSIVE workflow_issue_root_candidates",
+		"workflow_descendants(root_id, id)",
+		"roots_with_live_descendants",
+		"UPDATE `beads`.wisps SET status='closed', closed_at=NOW(), metadata = JSON_SET(COALESCE(metadata, JSON_OBJECT())",
+		"'$.\"gc.outcome\"', 'skipped'",
+		"'$.\"close_reason\"', 'stale inactive workflow root auto-closed by reaper'",
+		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')) = 'workflow'",
+		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'",
+		"JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = root.id",
+		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.kind\"')) = 'workflow'",
+		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'",
+		"JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = root.id",
+		"COALESCE(w.assignee, '') = ''",
+		"COALESCE(i.assignee, '') = ''",
+		"COALESCE(w.updated_at, w.created_at) < DATE_SUB(NOW(), INTERVAL",
+		"COALESCE(i.updated_at, i.created_at) < DATE_SUB(NOW(), INTERVAL",
+		"descendant_wisp.status, descendant_issue.status) IN ('open', 'hooked', 'in_progress', 'blocked', 'deferred', 'pinned', 'review', 'testing')",
+		"roots_with_recent_descendants",
+		"child_dep.type IN ('parent-child', 'tracks', 'blocks')",
+		"child_dep.depends_on_id = root.id",
+		"child_dep.depends_on_id = parent.id",
+		"workflow_roots=2",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("reaper workflow-root SQL missing %q:\n%s", want, log)
+		}
+	}
+	if strings.Contains(log, "parent_id") {
+		t.Fatalf("reaper workflow-root cleanup used removed parent_id column:\n%s", log)
+	}
+	if strings.Contains(log, "UPDATE `beads`.issues SET status='closed'") {
+		t.Fatalf("reaper closed city workflow issue roots with raw SQL instead of bd close:\n%s", log)
+	}
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if !strings.Contains(string(bdData), "close issue-close --reason stale inactive workflow root auto-closed by reaper") {
+		t.Fatalf("reaper did not close city workflow issue root through bd close:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "workflow_roots:2") {
+		t.Fatalf("reaper summary did not report closed workflow roots:\n%s", gcData)
+	}
+}
+
+func TestReaperWorkflowRootPredicateIsGeneratedFromOneHelper(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"))
+	if err != nil {
+		t.Fatalf("ReadFile(reaper.sh): %v", err)
+	}
+	script := string(data)
+	if got := strings.Count(script, "workflow_descendants(root_id, id) AS"); got != 1 {
+		t.Fatalf("workflow-root recursive CTE body appears %d times, want one helper definition", got)
+	}
+	if got := strings.Count(script, "workflow_root_candidates_cte()"); got != 1 {
+		t.Fatalf("workflow-root candidate helper appears %d times, want one definition", got)
+	}
+}
+
+func TestReaperPreservesWorkflowRootsWithLiveDescendants(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SHOW COLUMNS FROM"*"dependencies"*)
+    printf 'Field,Type,Null,Key,Default,Extra\n'
+    printf 'issue_id,varchar,NO,,,\n'
+    printf 'depends_on_id,varchar,NO,,,\n'
+    printf 'type,varchar,NO,,,\n'
+    ;;
+  *"WITH RECURSIVE workflow_wisp_root_candidates"*"SELECT COUNT(*) FROM ("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"WITH RECURSIVE workflow_issue_root_candidates"*"SELECT DISTINCT root.id"*)
+    printf 'id\n'
+    ;;
+  *"UPDATE "*"workflow_wisp_root_candidates"*"wisps SET status='closed'"*)
+    printf 'workflow roots with live descendants must be preserved\n' >&2
+    exit 42
     ;;
   *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
     printf 'COUNT(*)\n0\n'
@@ -3835,6 +3979,7 @@ exit 0
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
+	writeCityBeadsMetadata(t, cityDir, "beads")
 
 	env := map[string]string{
 		"DOLT_ARGS_LOG":    doltLog,
@@ -3856,34 +4001,112 @@ exit 0
 	}
 	log := string(logData)
 	for _, want := range []string{
-		"UPDATE `beads`.wisps SET status='closed', closed_at=NOW()",
-		"UPDATE `beads`.issues SET status='closed', closed_at=NOW()",
-		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')) = 'workflow'",
-		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'",
-		"JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = w.id",
-		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.kind\"')) = 'workflow'",
-		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'",
-		"JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = i.id",
-		"COALESCE(w.assignee, '') = ''",
-		"COALESCE(i.assignee, '') = ''",
-		"COALESCE(w.updated_at, w.created_at) < DATE_SUB(NOW(), INTERVAL",
-		"COALESCE(i.updated_at, i.created_at) < DATE_SUB(NOW(), INTERVAL",
-		"workflow_roots=2",
+		"roots_with_live_descendants",
+		"roots_with_recent_descendants",
+		"workflow_descendants(root_id, id)",
+		"descendant_wisp.status, descendant_issue.status) IN ('open', 'hooked', 'in_progress', 'blocked', 'deferred', 'pinned', 'review', 'testing')",
+		"child_dep.type IN ('parent-child', 'tracks', 'blocks')",
 	} {
 		if !strings.Contains(log, want) {
-			t.Fatalf("reaper workflow-root SQL missing %q:\n%s", want, log)
+			t.Fatalf("reaper workflow-root preserve guard missing %q:\n%s", want, log)
 		}
 	}
-	if strings.Contains(log, "parent_id") {
-		t.Fatalf("reaper workflow-root cleanup used removed parent_id column:\n%s", log)
+	if strings.Contains(log, "UPDATE `beads`.wisps SET status='closed', closed_at=NOW(), metadata = JSON_SET") ||
+		strings.Contains(log, "UPDATE `beads`.issues SET status='closed'") {
+		t.Fatalf("reaper closed workflow roots after live-descendant counts returned zero:\n%s", log)
 	}
 
 	gcData, err := os.ReadFile(gcLog)
 	if err != nil {
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
-	if !strings.Contains(string(gcData), "workflow_roots:2") {
-		t.Fatalf("reaper summary did not report closed workflow roots:\n%s", gcData)
+	if strings.Contains(string(gcData), "workflow_roots:1") {
+		t.Fatalf("reaper summary reported closed workflow roots despite live descendants:\n%s", gcData)
+	}
+}
+
+func TestReaperDryRunReportsWouldCloseWorkflowRoots(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SHOW COLUMNS FROM"*"dependencies"*)
+    printf 'Field,Type,Null,Key,Default,Extra\n'
+    printf 'issue_id,varchar,NO,,,\n'
+    printf 'depends_on_id,varchar,NO,,,\n'
+    printf 'type,varchar,NO,,,\n'
+    ;;
+  *"WITH RECURSIVE workflow_wisp_root_candidates"*"SELECT COUNT(*) FROM ("*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"WITH RECURSIVE workflow_issue_root_candidates"*"SELECT DISTINCT root.id"*)
+    printf 'id\nissue-close\n'
+    ;;
+  *"UPDATE "*"workflow_wisp_root_candidates"*"wisps SET status='closed'"*)
+    printf 'dry-run should not update workflow wisp roots\n' >&2
+    exit 42
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+	writeCityBeadsMetadata(t, cityDir, "beads")
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":     doltLog,
+		"GC_CALL_LOG":       gcLog,
+		"GC_CITY":           cityDir,
+		"GC_CITY_PATH":      cityDir,
+		"GC_DOLT_HOST":      "127.0.0.1",
+		"GC_DOLT_PORT":      "3307",
+		"GC_DOLT_USER":      "root",
+		"GC_DOLT_PASSWORD":  "",
+		"GC_REAPER_DRY_RUN": "1",
+		"PATH":              binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	if strings.Contains(string(logData), "UPDATE `beads`.wisps SET status='closed', closed_at=NOW(), metadata = JSON_SET") ||
+		strings.Contains(string(logData), "UPDATE `beads`.issues SET status='closed', closed_at=NOW(), metadata = JSON_SET") {
+		t.Fatalf("dry-run executed workflow-root update:\n%s", logData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcText := string(gcData)
+	if !strings.Contains(gcText, "workflow_roots:0") ||
+		!strings.Contains(gcText, "would_close_workflow_roots:2") ||
+		!strings.Contains(gcText, "(dry run)") {
+		t.Fatalf("dry-run summary did not report workflow-root would-close count:\n%s", gcText)
 	}
 }
 

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3779,7 +3779,7 @@ func TestReaperDoesNotCloseStaleWispWithClosedBlocksPredecessor(t *testing.T) {
 		t.Fatalf("ReadFile(dolt log): %v", err)
 	}
 	log := string(logData)
-	if strings.Contains(log, "UPDATE `beads`.wisps SET status='closed'") {
+	if strings.Contains(log, "reaper_wisp_candidates") {
 		t.Fatalf("reaper closed a stale wisp through an ordinary closed blocks predecessor:\n%s", log)
 	}
 
@@ -3844,6 +3844,9 @@ printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
 	writeCityBeadsMetadata(t, cityDir, "beads")
+	rigDir := filepath.Join(cityDir, "rigs", "beads-rig")
+	writeCityBeadsMetadata(t, rigDir, "beads")
+	writeSiteRigBinding(t, cityDir, "beads-rig", rigDir)
 
 	env := map[string]string{
 		"BD_CALL_LOG":      bdLog,
@@ -3875,9 +3878,16 @@ exit 0
 		"'$.\"close_reason\"', 'stale inactive workflow root auto-closed by reaper'",
 		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')) = 'workflow'",
 		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'",
+		"COALESCE(JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_bead_id\"')), '') IN ('', w.id)",
+		"COALESCE(JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_store_ref\"')), '') = ''",
+		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_store_ref\"')) = 'beads'",
+		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_store_ref\"')) IN ('rig:beads-rig')",
 		"JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = root.id",
 		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.kind\"')) = 'workflow'",
 		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'",
+		"COALESCE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.root_bead_id\"')), '') IN ('', i.id)",
+		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.root_store_ref\"')) LIKE 'city:%'",
+		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.root_store_ref\"')) IN ('rig:beads-rig')",
 		"JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = root.id",
 		"COALESCE(w.assignee, '') = ''",
 		"COALESCE(i.assignee, '') = ''",
@@ -3913,7 +3923,8 @@ exit 0
 	if err != nil {
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
-	if !strings.Contains(string(gcData), "workflow_roots:2") {
+	if !strings.Contains(string(gcData), "workflow_roots:2") ||
+		!strings.Contains(string(gcData), "skipped_cross_store_workflow_roots:0") {
 		t.Fatalf("reaper summary did not report closed workflow roots:\n%s", gcData)
 	}
 }
@@ -3959,7 +3970,7 @@ case "$*" in
   *"WITH RECURSIVE workflow_issue_root_candidates"*"SELECT DISTINCT root.id"*)
     printf 'id\n'
     ;;
-  *"UPDATE "*"workflow_wisp_root_candidates"*"wisps SET status='closed'"*)
+  *"WITH RECURSIVE workflow_wisp_root_candidates"*"UPDATE "*"wisps SET status='closed'"*)
     printf 'workflow roots with live descendants must be preserved\n' >&2
     exit 42
     ;;
@@ -4052,7 +4063,7 @@ case "$*" in
   *"WITH RECURSIVE workflow_issue_root_candidates"*"SELECT DISTINCT root.id"*)
     printf 'id\nissue-close\n'
     ;;
-  *"UPDATE "*"workflow_wisp_root_candidates"*"wisps SET status='closed'"*)
+  *"WITH RECURSIVE workflow_wisp_root_candidates"*"UPDATE "*"wisps SET status='closed'"*)
     printf 'dry-run should not update workflow wisp roots\n' >&2
     exit 42
     ;;
@@ -6016,6 +6027,18 @@ func writeCityBeadsMetadata(t *testing.T, cityDir, db string) {
 	}
 }
 
+func writeSiteRigBinding(t *testing.T, cityDir, rigName, rigDir string) {
+	t.Helper()
+	gcDir := filepath.Join(cityDir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", gcDir, err)
+	}
+	content := fmt.Sprintf("[[rig]]\nname = %q\npath = %q\n", rigName, rigDir)
+	if err := os.WriteFile(filepath.Join(gcDir, "site.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(site.toml): %v", err)
+	}
+}
+
 func writeMaintenanceDoltStub(t *testing.T, path string) {
 	t.Helper()
 	writeExecutable(t, path, `#!/bin/sh
@@ -6108,7 +6131,8 @@ close_fixture_matches() {
         printf '%s' "$*" | grep -F "gc.root_bead_id" >/dev/null 2>&1
       ;;
     blocks_closed_predecessor)
-      printf '%s' "$*" | grep -F "blocks" >/dev/null 2>&1
+      printf '%s' "$*" | grep -F "wisp_dependencies d" >/dev/null 2>&1 &&
+        printf '%s' "$*" | grep -F "blocks" >/dev/null 2>&1
       ;;
     *)
       return 1

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3786,6 +3786,107 @@ func TestReaperDoesNotCloseStaleWispWithClosedBlocksPredecessor(t *testing.T) {
 	}
 }
 
+func TestReaperClosesStaleInactiveWorkflowRoots(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SHOW COLUMNS FROM"*"dependencies"*)
+    printf 'Field,Type,Null,Key,Default,Extra\n'
+    printf 'issue_id,varchar,NO,,,\n'
+    printf 'depends_on_id,varchar,NO,,,\n'
+    printf 'type,varchar,NO,,,\n'
+    ;;
+  *"UPDATE "*"wisps SET status='closed'"*"gc.formula_contract"*"gc.root_bead_id"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"UPDATE "*"issues SET status='closed'"*"gc.formula_contract"*"gc.root_bead_id"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"COUNT(DISTINCT w.id)"*"gc.kind"*"gc.formula_contract"*"gc.root_bead_id"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"COUNT(DISTINCT i.id)"*"gc.kind"*"gc.formula_contract"*"gc.root_bead_id"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	for _, want := range []string{
+		"UPDATE `beads`.wisps SET status='closed', closed_at=NOW()",
+		"UPDATE `beads`.issues SET status='closed', closed_at=NOW()",
+		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')) = 'workflow'",
+		"JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'",
+		"JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = w.id",
+		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.kind\"')) = 'workflow'",
+		"JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'",
+		"JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = i.id",
+		"COALESCE(w.assignee, '') = ''",
+		"COALESCE(i.assignee, '') = ''",
+		"COALESCE(w.updated_at, w.created_at) < DATE_SUB(NOW(), INTERVAL",
+		"COALESCE(i.updated_at, i.created_at) < DATE_SUB(NOW(), INTERVAL",
+		"workflow_roots=2",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("reaper workflow-root SQL missing %q:\n%s", want, log)
+		}
+	}
+	if strings.Contains(log, "parent_id") {
+		t.Fatalf("reaper workflow-root cleanup used removed parent_id column:\n%s", log)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "workflow_roots:2") {
+		t.Fatalf("reaper summary did not report closed workflow roots:\n%s", gcData)
+	}
+}
+
 func TestReaperEscalatesDoltCommitFailure(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
@@ -4068,7 +4169,7 @@ exit 0
 	if !strings.Contains(log, "CALL DOLT_COMMIT") {
 		t.Fatalf("reaper did not commit successful close after failed purge:\n%s", log)
 	}
-	if !strings.Contains(log, "closed_wisps=1 purged=0") {
+	if !strings.Contains(log, "closed_wisps=1 workflow_roots=0 purged=0") {
 		t.Fatalf("reaper commit did not report only successful purge rows:\n%s", log)
 	}
 	if strings.Contains(log, "purged=1") {

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -128,6 +128,8 @@ TOTAL_WOULD_CLOSE_WISPS=0
 TOTAL_WOULD_EXPIRE=0
 TOTAL_PURGED=0
 TOTAL_MAIL_WISPS=0
+TOTAL_WORKFLOW_ROOTS_CLOSED=0
+TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS=0
 TOTAL_ISSUES_CLOSED=0
 TOTAL_STALE_ISSUES_SKIPPED=0
 TOTAL_EXPIRED_ISSUES_CLOSED=0
@@ -378,6 +380,7 @@ while IFS= read -r DB; do
     CLOSE_WISP_COUNT=0
     DB_CLOSED_WISPS=0
     DB_PURGED=0
+    DB_WORKFLOW_ROOTS_CLOSED=0
     while [ "$STALE_WISP_COUNT" -gt 0 ] && [ "$CLOSE_WISP_COUNT" -lt "$STALE_WISP_COUNT" ]; do
         get_sql_count "$DB" "schema-safe stale wisp" "
             SELECT COUNT(DISTINCT w.id) FROM \`$DB\`.wisps w
@@ -436,7 +439,138 @@ while IFS= read -r DB; do
         fi
     done
 
-    # Step 2: Purge — delete closed wisps past purge_age.
+    # Step 2: Close stale inactive workflow roots. These roots are topology
+    # beads, not user work; close only old, unassigned roots with no active
+    # root-owned children so a queued or running workflow is preserved.
+    get_sql_count "$DB" "stale inactive workflow wisp root" "
+        SELECT COUNT(DISTINCT w.id) FROM \`$DB\`.wisps w
+        WHERE w.status IN ('open', 'hooked', 'in_progress')
+        AND w.issue_type NOT IN ('message')
+        AND COALESCE(w.assignee, '') = ''
+        AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+        AND COALESCE(w.updated_at, w.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+        AND (
+            JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')) = 'workflow'
+            OR JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM \`$DB\`.wisps child_wisp
+            WHERE child_wisp.id != w.id
+            AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+            AND JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = w.id
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM \`$DB\`.issues child_issue
+            WHERE child_issue.id != w.id
+            AND child_issue.status IN ('open', 'in_progress')
+            AND JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = w.id
+        )
+    "
+    WORKFLOW_WISP_ROOT_COUNT=$SQL_COUNT_RESULT
+    if [ "$WORKFLOW_WISP_ROOT_COUNT" -gt 0 ]; then
+        if [ -n "$DRY_RUN" ]; then
+            TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS=$((TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS + WORKFLOW_WISP_ROOT_COUNT))
+        elif run_sql_change "$DB" "closing stale inactive workflow wisp roots" "
+            UPDATE \`$DB\`.wisps SET status='closed', closed_at=NOW()
+            WHERE id IN (
+                SELECT id FROM (
+                    SELECT w.id FROM \`$DB\`.wisps w
+                    WHERE w.status IN ('open', 'hooked', 'in_progress')
+                    AND w.issue_type NOT IN ('message')
+                    AND COALESCE(w.assignee, '') = ''
+                    AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+                    AND COALESCE(w.updated_at, w.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+                    AND (
+                        JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')) = 'workflow'
+                        OR JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM \`$DB\`.wisps child_wisp
+                        WHERE child_wisp.id != w.id
+                        AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+                        AND JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = w.id
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM \`$DB\`.issues child_issue
+                        WHERE child_issue.id != w.id
+                        AND child_issue.status IN ('open', 'in_progress')
+                        AND JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = w.id
+                    )
+                ) reaper_workflow_wisp_root_candidates
+            )
+        "; then
+            WORKFLOW_WISP_ROOT_ROWS=$SQL_CHANGE_ROWS_RESULT
+            DB_WORKFLOW_ROOTS_CLOSED=$((DB_WORKFLOW_ROOTS_CLOSED + WORKFLOW_WISP_ROOT_ROWS))
+            TOTAL_WORKFLOW_ROOTS_CLOSED=$((TOTAL_WORKFLOW_ROOTS_CLOSED + WORKFLOW_WISP_ROOT_ROWS))
+            DB_MUTATIONS=$((DB_MUTATIONS + WORKFLOW_WISP_ROOT_ROWS))
+        fi
+    fi
+
+    get_sql_count "$DB" "stale inactive workflow issue root" "
+        SELECT COUNT(DISTINCT i.id) FROM \`$DB\`.issues i
+        WHERE i.status IN ('open', 'in_progress')
+        AND i.issue_type NOT IN ('message', 'epic')
+        AND COALESCE(i.assignee, '') = ''
+        AND i.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+        AND COALESCE(i.updated_at, i.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+        AND (
+            JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.kind\"')) = 'workflow'
+            OR JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM \`$DB\`.wisps child_wisp
+            WHERE child_wisp.id != i.id
+            AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+            AND JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = i.id
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM \`$DB\`.issues child_issue
+            WHERE child_issue.id != i.id
+            AND child_issue.status IN ('open', 'in_progress')
+            AND JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = i.id
+        )
+    "
+    WORKFLOW_ISSUE_ROOT_COUNT=$SQL_COUNT_RESULT
+    if [ "$WORKFLOW_ISSUE_ROOT_COUNT" -gt 0 ]; then
+        if [ -n "$DRY_RUN" ]; then
+            TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS=$((TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS + WORKFLOW_ISSUE_ROOT_COUNT))
+        elif run_sql_change "$DB" "closing stale inactive workflow issue roots" "
+            UPDATE \`$DB\`.issues SET status='closed', closed_at=NOW()
+            WHERE id IN (
+                SELECT id FROM (
+                    SELECT i.id FROM \`$DB\`.issues i
+                    WHERE i.status IN ('open', 'in_progress')
+                    AND i.issue_type NOT IN ('message', 'epic')
+                    AND COALESCE(i.assignee, '') = ''
+                    AND i.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+                    AND COALESCE(i.updated_at, i.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+                    AND (
+                        JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.kind\"')) = 'workflow'
+                        OR JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM \`$DB\`.wisps child_wisp
+                        WHERE child_wisp.id != i.id
+                        AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+                        AND JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = i.id
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM \`$DB\`.issues child_issue
+                        WHERE child_issue.id != i.id
+                        AND child_issue.status IN ('open', 'in_progress')
+                        AND JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = i.id
+                    )
+                ) reaper_workflow_issue_root_candidates
+            )
+        "; then
+            WORKFLOW_ISSUE_ROOT_ROWS=$SQL_CHANGE_ROWS_RESULT
+            DB_WORKFLOW_ROOTS_CLOSED=$((DB_WORKFLOW_ROOTS_CLOSED + WORKFLOW_ISSUE_ROOT_ROWS))
+            TOTAL_WORKFLOW_ROOTS_CLOSED=$((TOTAL_WORKFLOW_ROOTS_CLOSED + WORKFLOW_ISSUE_ROOT_ROWS))
+            DB_MUTATIONS=$((DB_MUTATIONS + WORKFLOW_ISSUE_ROOT_ROWS))
+        fi
+    fi
+
+    # Step 3: Purge — delete closed wisps past purge_age.
     get_sql_count "$DB" "closed wisp purge" "
         SELECT COUNT(*) FROM \`$DB\`.wisps
         WHERE status = 'closed'
@@ -469,7 +603,7 @@ while IFS= read -r DB; do
         fi
     fi
 
-    # Step 3: Close nudge beads whose metadata.expires_at is in the past.
+    # Step 4: Close nudge beads whose metadata.expires_at is in the past.
     # Only beads labelled gc:nudge are candidates — other bead types that stamp
     # expires_at (e.g. gc:extmsg-binding session bindings) must not be closed
     # here.  The COALESCE handles whole-second RFC3339+Z, microsecond-width
@@ -543,7 +677,7 @@ while IFS= read -r DB; do
         fi
     fi
 
-    # Step 4: Auto-close stale issues (exclude P0/P1, epics, active deps).
+    # Step 5: Auto-close stale issues (exclude P0/P1, epics, active deps).
     DB_ISSUES_CLOSED=0
     get_sql_rows "$DB" "stale issue" "
         SELECT id FROM \`$DB\`.issues
@@ -592,7 +726,7 @@ while IFS= read -r DB; do
         fi
     fi
 
-    # Step 5a: Anomaly check — stale open wisp count. Fresh workflow load can
+    # Step 6a: Anomaly check — stale open wisp count. Fresh workflow load can
     # legitimately exceed the threshold on busy cities; only old non-message
     # rows indicate a reaper leak.
     get_sql_count "$DB" "stale open wisp anomaly" "
@@ -607,7 +741,7 @@ while IFS= read -r DB; do
         ANOMALIES="${ANOMALIES}$DB: $REAPABLE_WISPS stale open wisps (threshold: $ALERT_THRESHOLD, age: ${MAX_AGE})\n"
     fi
 
-    # Step 5b: Mail-wisp backlog count, observed separately from reapable wisps.
+    # Step 6b: Mail-wisp backlog count, observed separately from reapable wisps.
     get_sql_count "$DB" "open mail wisp" "
         SELECT COUNT(*) FROM \`$DB\`.wisps
         WHERE status IN ('open', 'hooked', 'in_progress')
@@ -627,7 +761,7 @@ while IFS= read -r DB; do
     if [ -z "$DRY_RUN" ] && [ "$DB_MUTATIONS" -gt 0 ]; then
         if ! COMMIT_OUTPUT=$(dolt_sql -q "
             USE \`$DB\`;
-            CALL DOLT_COMMIT('-Am', 'reaper: stale_wisps=$STALE_WISP_COUNT closed_wisps=$DB_CLOSED_WISPS purged=$DB_PURGED stale_issues=$DB_ISSUES_CLOSED expired_issues=$DB_EXPIRED_ISSUES_CLOSED', '--author', 'reaper <reaper@gastown.local>')
+            CALL DOLT_COMMIT('-Am', 'reaper: stale_wisps=$STALE_WISP_COUNT closed_wisps=$DB_CLOSED_WISPS workflow_roots=$DB_WORKFLOW_ROOTS_CLOSED purged=$DB_PURGED stale_issues=$DB_ISSUES_CLOSED expired_issues=$DB_EXPIRED_ISSUES_CLOSED', '--author', 'reaper <reaper@gastown.local>')
         " 2>&1); then
             case "$COMMIT_OUTPUT" in
                 *"nothing to commit"*|*"Nothing to commit"*)
@@ -695,9 +829,9 @@ if [ -n "$ANOMALIES" ]; then
         -m "$ANOMALIES" 2>/dev/null || true
 fi
 
-SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, expired_skipped:$TOTAL_EXPIRED_ISSUES_SKIPPED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
+SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, workflow_roots:$TOTAL_WORKFLOW_ROOTS_CLOSED, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, expired_skipped:$TOTAL_EXPIRED_ISSUES_SKIPPED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
 if [ -n "$DRY_RUN" ]; then
-    SUMMARY="$SUMMARY, would_close_wisps:$TOTAL_WOULD_CLOSE_WISPS, would_expire:$TOTAL_WOULD_EXPIRE (dry run)"
+    SUMMARY="$SUMMARY, would_close_wisps:$TOTAL_WOULD_CLOSE_WISPS, would_close_workflow_roots:$TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS, would_expire:$TOTAL_WOULD_EXPIRE (dry run)"
 fi
 
 gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -48,12 +48,12 @@ MAX_AGE_H=$(duration_to_hours "$MAX_AGE")
 PURGE_AGE_H=$(duration_to_hours "$PURGE_AGE")
 STALE_AGE_H=$(duration_to_hours "$STALE_ISSUE_AGE")
 
-CITY_DB_METADATA_RESULT=""
+METADATA_DB_RESULT=""
 
-city_database_name() {
-    local metadata="$CITY_BEADS_DIR/metadata.json"
+metadata_dolt_database() {
+    local metadata="$1"
     local db=""
-    CITY_DB_METADATA_RESULT=""
+    METADATA_DB_RESULT=""
 
     if [ -f "$metadata" ]; then
         if command -v jq >/dev/null 2>&1; then
@@ -85,8 +85,15 @@ PY
     fi
 
     if [ -n "$db" ]; then
-        CITY_DB_METADATA_RESULT="$db"
+        METADATA_DB_RESULT="$db"
     fi
+}
+
+CITY_DB_METADATA_RESULT=""
+
+city_database_name() {
+    metadata_dolt_database "$CITY_BEADS_DIR/metadata.json"
+    CITY_DB_METADATA_RESULT="$METADATA_DB_RESULT"
 }
 
 is_user_database() {
@@ -134,6 +141,7 @@ TOTAL_PURGED=0
 TOTAL_MAIL_WISPS=0
 TOTAL_WORKFLOW_ROOTS_CLOSED=0
 TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS=0
+TOTAL_WORKFLOW_ROOTS_STORE_REF_SKIPPED=0
 TOTAL_WORKFLOW_ISSUE_ROOTS_SKIPPED=0
 TOTAL_ISSUES_CLOSED=0
 TOTAL_STALE_ISSUES_SKIPPED=0
@@ -183,6 +191,201 @@ EOF
     return 1
 }
 
+sql_string_literal() {
+    local value="$1"
+    local escaped
+
+    escaped=$(printf '%s' "$value" | sed "s/'/''/g")
+    printf "'%s'" "$escaped"
+}
+
+toml_rig_bindings() {
+    local file="$1"
+
+    [ -f "$file" ] || return 0
+    awk '
+    function trim(s) {
+        sub(/^[ \t\r\n]+/, "", s)
+        sub(/[ \t\r\n]+$/, "", s)
+        return s
+    }
+    function toml_value(line, v) {
+        sub(/^[^=]*=/, "", line)
+        v = trim(line)
+        if (substr(v, 1, 1) == "\"") {
+            sub(/^"/, "", v)
+            sub(/"[ \t]*(#.*)?$/, "", v)
+            gsub(/\\"/, "\"", v)
+            return v
+        }
+        sub(/[ \t]*#.*/, "", v)
+        return trim(v)
+    }
+    function emit() {
+        if (name != "" && rig_path != "") {
+            print name "|" rig_path
+        }
+    }
+    /^[ \t]*\[\[[ \t]*rigs?[ \t]*\]\][ \t]*$/ {
+        emit()
+        in_rig = 1
+        name = ""
+        rig_path = ""
+        next
+    }
+    /^[ \t]*\[/ {
+        emit()
+        in_rig = 0
+        name = ""
+        rig_path = ""
+        next
+    }
+    in_rig && /^[ \t]*name[ \t]*=/ {
+        name = toml_value($0)
+        next
+    }
+    in_rig && /^[ \t]*path[ \t]*=/ {
+        rig_path = toml_value($0)
+        next
+    }
+    END {
+        emit()
+    }
+    ' "$file"
+}
+
+resolve_scope_path() {
+    local scope_path="$1"
+
+    case "$scope_path" in
+        /*)
+            printf '%s\n' "$scope_path"
+            ;;
+        *)
+            printf '%s\n' "$CITY_ABS/$scope_path"
+            ;;
+    esac
+}
+
+RIG_STORE_REFS_BY_DB=""
+
+append_rig_store_ref_for_db() {
+    local db="$1"
+    local store_ref="$2"
+    local entry
+
+    [ -n "$db" ] && [ -n "$store_ref" ] || return 0
+    valid_database_identifier "$db" || return 0
+    database_list_contains "$db" || return 0
+
+    entry="$db|$store_ref"
+    case "
+$RIG_STORE_REFS_BY_DB
+" in
+        *"
+$entry
+"*)
+            return 0
+            ;;
+    esac
+    RIG_STORE_REFS_BY_DB="${RIG_STORE_REFS_BY_DB}${entry}
+"
+}
+
+add_rig_store_ref_from_scope() {
+    local rig_name="$1"
+    local rig_path="$2"
+    local scope_abs
+    local db
+
+    [ -n "$rig_name" ] && [ -n "$rig_path" ] || return 0
+    scope_abs=$(resolve_scope_path "$rig_path")
+    metadata_dolt_database "$scope_abs/.beads/metadata.json"
+    db="$METADATA_DB_RESULT"
+    append_rig_store_ref_for_db "$db" "rig:$rig_name"
+}
+
+load_rig_store_refs_from_file() {
+    local file="$1"
+    local rig_name
+    local rig_path
+
+    while IFS='|' read -r rig_name rig_path; do
+        add_rig_store_ref_from_scope "$rig_name" "$rig_path"
+    done < <(toml_rig_bindings "$file")
+}
+
+load_rig_store_refs_from_env() {
+    local raw="${GC_REAPER_RIG_DATABASES:-}"
+    local item
+    local rig_name
+    local db
+
+    [ -n "$raw" ] || return 0
+    for item in ${raw//,/ }; do
+        case "$item" in
+            *=*) ;;
+            *) continue ;;
+        esac
+        rig_name="${item%%=*}"
+        db="${item#*=}"
+        rig_name="${rig_name#rig:}"
+        append_rig_store_ref_for_db "$db" "rig:$rig_name"
+    done
+}
+
+discover_rig_store_refs() {
+    load_rig_store_refs_from_file "$CITY_ABS/.gc/site.toml"
+    load_rig_store_refs_from_file "$CITY_ABS/city.toml"
+    load_rig_store_refs_from_env
+}
+
+rig_store_ref_sql_list() {
+    local db="$1"
+    local entry
+    local entry_db
+    local store_ref
+    local refs=""
+
+    while IFS= read -r entry; do
+        [ -n "$entry" ] || continue
+        entry_db="${entry%%|*}"
+        store_ref="${entry#*|}"
+        [ "$entry_db" = "$db" ] || continue
+        if [ -z "$refs" ]; then
+            refs="$(sql_string_literal "$store_ref")"
+        else
+            refs="$refs, $(sql_string_literal "$store_ref")"
+        fi
+    done <<EOF
+$RIG_STORE_REFS_BY_DB
+EOF
+
+    printf '%s\n' "$refs"
+}
+
+workflow_root_store_ref_local_condition() {
+    local db="$1"
+    local alias="$2"
+    local rig_refs
+
+    rig_refs="$(rig_store_ref_sql_list "$db")"
+    cat <<SQL
+                COALESCE(JSON_UNQUOTE(JSON_EXTRACT($alias.metadata, '$."gc.root_store_ref"')), '') = ''
+                OR JSON_UNQUOTE(JSON_EXTRACT($alias.metadata, '$."gc.root_store_ref"')) = '$db'
+                OR (
+                    '$CITY_DB' != ''
+                    AND '$db' = '$CITY_DB'
+                    AND JSON_UNQUOTE(JSON_EXTRACT($alias.metadata, '$."gc.root_store_ref"')) LIKE 'city:%'
+                )
+SQL
+    if [ -n "$rig_refs" ]; then
+        cat <<SQL
+                OR JSON_UNQUOTE(JSON_EXTRACT($alias.metadata, '$."gc.root_store_ref"')) IN ($rig_refs)
+SQL
+    fi
+}
+
 CITY_DB=""
 CITY_DB_SOURCE="$CITY_BEADS_DIR/metadata.json"
 city_database_name
@@ -212,6 +415,8 @@ elif [ -n "$CITY_DB" ] && ! database_list_contains "$CITY_DB"; then
     CITY_DB=""
     CITY_DB_ANOMALY_RECORDED=1
 fi
+
+discover_rig_store_refs
 
 SQL_COUNT_RESULT=0
 get_sql_count() {
@@ -297,7 +502,7 @@ workflow_root_candidates_cte() {
     local issue_type_exclusions="$5"
 
     cat <<SQL
-        WITH RECURSIVE $candidate_cte(id) AS (
+        WITH RECURSIVE ${candidate_cte}_base(id) AS (
             SELECT $alias.id FROM \`$db\`.$table $alias
             WHERE $alias.status IN ($WORKFLOW_ROOT_CLOSE_STATUSES)
             AND $alias.issue_type NOT IN ($issue_type_exclusions)
@@ -307,6 +512,15 @@ workflow_root_candidates_cte() {
             AND (
                 JSON_UNQUOTE(JSON_EXTRACT($alias.metadata, '$."gc.kind"')) = 'workflow'
                 OR JSON_UNQUOTE(JSON_EXTRACT($alias.metadata, '$."gc.formula_contract"')) = 'graph.v2'
+            )
+            AND COALESCE(JSON_UNQUOTE(JSON_EXTRACT($alias.metadata, '$."gc.root_bead_id"')), '') IN ('', $alias.id)
+        ),
+        $candidate_cte(id) AS (
+            SELECT base.id
+            FROM ${candidate_cte}_base base
+            INNER JOIN \`$db\`.$table $alias ON $alias.id = base.id
+            WHERE (
+$(workflow_root_store_ref_local_condition "$db" "$alias")
             )
         ),
         workflow_descendants(root_id, id) AS (
@@ -369,6 +583,21 @@ workflow_root_candidates_cte() {
                 descendant_issue.created_at
             ) >= DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
         )
+SQL
+}
+
+workflow_root_store_ref_skipped_count_query() {
+    local db="$1"
+    local candidate_cte="$2"
+    local table="$3"
+    local alias="$4"
+    local issue_type_exclusions="$5"
+
+    cat <<SQL
+$(workflow_root_candidates_cte "$db" "$candidate_cte" "$table" "$alias" "$issue_type_exclusions")
+        SELECT COUNT(*) FROM ${candidate_cte}_base base
+        LEFT JOIN $candidate_cte candidate ON candidate.id = base.id
+        WHERE candidate.id IS NULL
 SQL
 }
 
@@ -585,11 +814,14 @@ while IFS= read -r DB; do
     # Step 2: Close stale inactive workflow roots. This is the
     # finalize-crash safety net: it only reaps old, unassigned topology roots
     # whose stamped and parent-child subtree has no live descendants. Workflow
-    # subtrees are assumed to be co-located in the current bead store through
-    # gc.root_store_ref; cross-store subtrees require cross-store traversal
-    # before root-only reaping can be safe.
+    # subtrees are assumed to be co-located in the current bead store. Roots
+    # stamped with gc.root_store_ref for another store are skipped; cross-store
+    # subtrees require cross-store traversal before reaping can be safe.
     # Wisp roots can be closed in every bead store. Issue roots are city issues,
     # so their city-store close path uses bd close below.
+    get_sql_count "$DB" "workflow wisp roots skipped by root store ref" "$(workflow_root_store_ref_skipped_count_query "$DB" "workflow_wisp_root_candidates" "wisps" "w" "'message'")"
+    TOTAL_WORKFLOW_ROOTS_STORE_REF_SKIPPED=$((TOTAL_WORKFLOW_ROOTS_STORE_REF_SKIPPED + SQL_COUNT_RESULT))
+
     get_sql_count "$DB" "stale inactive workflow wisp root" "$(workflow_root_count_query "$DB" "workflow_wisp_root_candidates" "wisps" "w" "'message'")"
     WORKFLOW_WISP_ROOT_COUNT=$SQL_COUNT_RESULT
     if [ "$WORKFLOW_WISP_ROOT_COUNT" -gt 0 ]; then
@@ -602,6 +834,9 @@ while IFS= read -r DB; do
             DB_MUTATIONS=$((DB_MUTATIONS + WORKFLOW_WISP_ROOT_ROWS))
         fi
     fi
+
+    get_sql_count "$DB" "workflow issue roots skipped by root store ref" "$(workflow_root_store_ref_skipped_count_query "$DB" "workflow_issue_root_candidates" "issues" "i" "'message', 'epic'")"
+    TOTAL_WORKFLOW_ROOTS_STORE_REF_SKIPPED=$((TOTAL_WORKFLOW_ROOTS_STORE_REF_SKIPPED + SQL_COUNT_RESULT))
 
     get_sql_rows "$DB" "stale inactive workflow issue root" "$(workflow_root_ids_query "$DB" "workflow_issue_root_candidates" "issues" "i" "'message', 'epic'")"
     WORKFLOW_ISSUE_ROOT_IDS=$SQL_ROWS_RESULT
@@ -890,7 +1125,7 @@ if [ -n "$ANOMALIES" ]; then
         -m "$ANOMALIES" 2>/dev/null || true
 fi
 
-SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, workflow_roots:$TOTAL_WORKFLOW_ROOTS_CLOSED, skipped_non_city_workflow_issue_roots:$TOTAL_WORKFLOW_ISSUE_ROOTS_SKIPPED, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, expired_skipped:$TOTAL_EXPIRED_ISSUES_SKIPPED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
+SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, workflow_roots:$TOTAL_WORKFLOW_ROOTS_CLOSED, skipped_cross_store_workflow_roots:$TOTAL_WORKFLOW_ROOTS_STORE_REF_SKIPPED, skipped_non_city_workflow_issue_roots:$TOTAL_WORKFLOW_ISSUE_ROOTS_SKIPPED, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, expired_skipped:$TOTAL_EXPIRED_ISSUES_SKIPPED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
 if [ -n "$DRY_RUN" ]; then
     SUMMARY="$SUMMARY, would_close_wisps:$TOTAL_WOULD_CLOSE_WISPS, would_close_workflow_roots:$TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS, would_expire:$TOTAL_WOULD_EXPIRE (dry run)"
 fi

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -32,6 +32,10 @@ DRY_RUN="${GC_REAPER_DRY_RUN:-}"
 # purge protection may include it because that only prevents deletion.
 WISP_CLOSE_EDGE_PREDICATE="(d.type = 'parent-child' OR (d.type = 'tracks' AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_bead_id\"')) = d.depends_on_id))"
 WISP_PURGE_PROTECT_EDGE_TYPES="'parent-child', 'tracks', 'blocks'"
+WORKFLOW_ROOT_CLOSE_STATUSES="'open', 'hooked', 'in_progress'"
+WORKFLOW_ROOT_LIVE_STATUSES="'open', 'hooked', 'in_progress', 'blocked', 'deferred', 'pinned', 'review', 'testing'"
+WORKFLOW_ROOT_DESCENDANT_DEP_TYPES="'parent-child', 'tracks', 'blocks'"
+WORKFLOW_ROOT_CLOSE_REASON="stale inactive workflow root auto-closed by reaper"
 
 # Convert Go durations to SQL INTERVAL hours for Dolt.
 duration_to_hours() {
@@ -130,6 +134,7 @@ TOTAL_PURGED=0
 TOTAL_MAIL_WISPS=0
 TOTAL_WORKFLOW_ROOTS_CLOSED=0
 TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS=0
+TOTAL_WORKFLOW_ISSUE_ROOTS_SKIPPED=0
 TOTAL_ISSUES_CLOSED=0
 TOTAL_STALE_ISSUES_SKIPPED=0
 TOTAL_EXPIRED_ISSUES_CLOSED=0
@@ -282,6 +287,144 @@ has_dependency_target_column() {
 
     printf '%s\n' "$fields" | grep -qx 'issue_id' || return 1
     printf '%s\n' "$fields" | grep -qx 'depends_on_id' || return 1
+}
+
+workflow_root_candidates_cte() {
+    local db="$1"
+    local candidate_cte="$2"
+    local table="$3"
+    local alias="$4"
+    local issue_type_exclusions="$5"
+
+    cat <<SQL
+        WITH RECURSIVE $candidate_cte(id) AS (
+            SELECT $alias.id FROM \`$db\`.$table $alias
+            WHERE $alias.status IN ($WORKFLOW_ROOT_CLOSE_STATUSES)
+            AND $alias.issue_type NOT IN ($issue_type_exclusions)
+            AND COALESCE($alias.assignee, '') = ''
+            AND $alias.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+            AND COALESCE($alias.updated_at, $alias.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+            AND (
+                JSON_UNQUOTE(JSON_EXTRACT($alias.metadata, '$."gc.kind"')) = 'workflow'
+                OR JSON_UNQUOTE(JSON_EXTRACT($alias.metadata, '$."gc.formula_contract"')) = 'graph.v2'
+            )
+        ),
+        workflow_descendants(root_id, id) AS (
+            SELECT root.id, child_wisp.id
+            FROM $candidate_cte root
+            INNER JOIN \`$db\`.wisps child_wisp
+                ON child_wisp.id != root.id
+                AND JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$."gc.root_bead_id"')) = root.id
+            UNION
+            SELECT root.id, child_issue.id
+            FROM $candidate_cte root
+            INNER JOIN \`$db\`.issues child_issue
+                ON child_issue.id != root.id
+                AND JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$."gc.root_bead_id"')) = root.id
+            UNION
+            SELECT root.id, child_dep.issue_id
+            FROM $candidate_cte root
+            INNER JOIN \`$db\`.wisp_dependencies child_dep
+                ON child_dep.type IN ($WORKFLOW_ROOT_DESCENDANT_DEP_TYPES)
+                AND child_dep.depends_on_id = root.id
+                AND child_dep.issue_id != root.id
+            UNION
+            SELECT root.id, child_dep.issue_id
+            FROM $candidate_cte root
+            INNER JOIN \`$db\`.dependencies child_dep
+                ON child_dep.type IN ($WORKFLOW_ROOT_DESCENDANT_DEP_TYPES)
+                AND child_dep.depends_on_id = root.id
+                AND child_dep.issue_id != root.id
+            UNION
+            SELECT parent.root_id, child_dep.issue_id
+            FROM workflow_descendants parent
+            INNER JOIN \`$db\`.wisp_dependencies child_dep
+                ON child_dep.type IN ($WORKFLOW_ROOT_DESCENDANT_DEP_TYPES)
+                AND child_dep.depends_on_id = parent.id
+                AND child_dep.issue_id != parent.id
+            UNION
+            SELECT parent.root_id, child_dep.issue_id
+            FROM workflow_descendants parent
+            INNER JOIN \`$db\`.dependencies child_dep
+                ON child_dep.type IN ($WORKFLOW_ROOT_DESCENDANT_DEP_TYPES)
+                AND child_dep.depends_on_id = parent.id
+                AND child_dep.issue_id != parent.id
+        ),
+        roots_with_live_descendants AS (
+            SELECT DISTINCT descendant.root_id
+            FROM workflow_descendants descendant
+            LEFT JOIN \`$db\`.wisps descendant_wisp ON descendant_wisp.id = descendant.id
+            LEFT JOIN \`$db\`.issues descendant_issue ON descendant_issue.id = descendant.id
+            WHERE COALESCE(descendant_wisp.status, descendant_issue.status) IN ($WORKFLOW_ROOT_LIVE_STATUSES)
+        ),
+        roots_with_recent_descendants AS (
+            SELECT DISTINCT descendant.root_id
+            FROM workflow_descendants descendant
+            LEFT JOIN \`$db\`.wisps descendant_wisp ON descendant_wisp.id = descendant.id
+            LEFT JOIN \`$db\`.issues descendant_issue ON descendant_issue.id = descendant.id
+            WHERE COALESCE(
+                descendant_wisp.updated_at,
+                descendant_wisp.created_at,
+                descendant_issue.updated_at,
+                descendant_issue.created_at
+            ) >= DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+        )
+SQL
+}
+
+workflow_root_closeable_select() {
+    local candidate_cte="$1"
+
+    cat <<SQL
+        SELECT DISTINCT root.id
+        FROM $candidate_cte root
+        LEFT JOIN roots_with_live_descendants live ON live.root_id = root.id
+        LEFT JOIN roots_with_recent_descendants recent ON recent.root_id = root.id
+        WHERE live.root_id IS NULL
+        AND recent.root_id IS NULL
+SQL
+}
+
+workflow_root_count_query() {
+    local db="$1"
+    local candidate_cte="$2"
+    local table="$3"
+    local alias="$4"
+    local issue_type_exclusions="$5"
+
+    cat <<SQL
+$(workflow_root_candidates_cte "$db" "$candidate_cte" "$table" "$alias" "$issue_type_exclusions")
+        SELECT COUNT(*) FROM (
+$(workflow_root_closeable_select "$candidate_cte")
+        ) closeable_workflow_roots
+SQL
+}
+
+workflow_root_ids_query() {
+    local db="$1"
+    local candidate_cte="$2"
+    local table="$3"
+    local alias="$4"
+    local issue_type_exclusions="$5"
+
+    cat <<SQL
+$(workflow_root_candidates_cte "$db" "$candidate_cte" "$table" "$alias" "$issue_type_exclusions")
+$(workflow_root_closeable_select "$candidate_cte")
+SQL
+}
+
+workflow_wisp_root_update_query() {
+    local db="$1"
+
+    cat <<SQL
+$(workflow_root_candidates_cte "$db" "workflow_wisp_root_candidates" "wisps" "w" "'message'")
+        ,
+        closeable_workflow_wisp_roots AS (
+$(workflow_root_closeable_select "workflow_wisp_root_candidates")
+        )
+        UPDATE \`$db\`.wisps SET status='closed', closed_at=NOW(), metadata = JSON_SET(COALESCE(metadata, JSON_OBJECT()), '$."gc.outcome"', 'skipped', '$."close_reason"', '$WORKFLOW_ROOT_CLOSE_REASON')
+        WHERE id IN (SELECT id FROM closeable_workflow_wisp_roots)
+SQL
 }
 
 SQL_CHANGE_ROWS_RESULT=0
@@ -439,66 +582,20 @@ while IFS= read -r DB; do
         fi
     done
 
-    # Step 2: Close stale inactive workflow roots. These roots are topology
-    # beads, not user work; close only old, unassigned roots with no active
-    # root-owned children so a queued or running workflow is preserved.
-    get_sql_count "$DB" "stale inactive workflow wisp root" "
-        SELECT COUNT(DISTINCT w.id) FROM \`$DB\`.wisps w
-        WHERE w.status IN ('open', 'hooked', 'in_progress')
-        AND w.issue_type NOT IN ('message')
-        AND COALESCE(w.assignee, '') = ''
-        AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-        AND COALESCE(w.updated_at, w.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-        AND (
-            JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')) = 'workflow'
-            OR JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'
-        )
-        AND NOT EXISTS (
-            SELECT 1 FROM \`$DB\`.wisps child_wisp
-            WHERE child_wisp.id != w.id
-            AND child_wisp.status IN ('open', 'hooked', 'in_progress')
-            AND JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = w.id
-        )
-        AND NOT EXISTS (
-            SELECT 1 FROM \`$DB\`.issues child_issue
-            WHERE child_issue.id != w.id
-            AND child_issue.status IN ('open', 'in_progress')
-            AND JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = w.id
-        )
-    "
+    # Step 2: Close stale inactive workflow roots. This is the
+    # finalize-crash safety net: it only reaps old, unassigned topology roots
+    # whose stamped and parent-child subtree has no live descendants. Workflow
+    # subtrees are assumed to be co-located in the current bead store through
+    # gc.root_store_ref; cross-store subtrees require cross-store traversal
+    # before root-only reaping can be safe.
+    # Wisp roots can be closed in every bead store. Issue roots are city issues,
+    # so their city-store close path uses bd close below.
+    get_sql_count "$DB" "stale inactive workflow wisp root" "$(workflow_root_count_query "$DB" "workflow_wisp_root_candidates" "wisps" "w" "'message'")"
     WORKFLOW_WISP_ROOT_COUNT=$SQL_COUNT_RESULT
     if [ "$WORKFLOW_WISP_ROOT_COUNT" -gt 0 ]; then
         if [ -n "$DRY_RUN" ]; then
             TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS=$((TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS + WORKFLOW_WISP_ROOT_COUNT))
-        elif run_sql_change "$DB" "closing stale inactive workflow wisp roots" "
-            UPDATE \`$DB\`.wisps SET status='closed', closed_at=NOW()
-            WHERE id IN (
-                SELECT id FROM (
-                    SELECT w.id FROM \`$DB\`.wisps w
-                    WHERE w.status IN ('open', 'hooked', 'in_progress')
-                    AND w.issue_type NOT IN ('message')
-                    AND COALESCE(w.assignee, '') = ''
-                    AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-                    AND COALESCE(w.updated_at, w.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-                    AND (
-                        JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')) = 'workflow'
-                        OR JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1 FROM \`$DB\`.wisps child_wisp
-                        WHERE child_wisp.id != w.id
-                        AND child_wisp.status IN ('open', 'hooked', 'in_progress')
-                        AND JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = w.id
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1 FROM \`$DB\`.issues child_issue
-                        WHERE child_issue.id != w.id
-                        AND child_issue.status IN ('open', 'in_progress')
-                        AND JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = w.id
-                    )
-                ) reaper_workflow_wisp_root_candidates
-            )
-        "; then
+        elif run_sql_change "$DB" "closing stale inactive workflow wisp roots" "$(workflow_wisp_root_update_query "$DB")"; then
             WORKFLOW_WISP_ROOT_ROWS=$SQL_CHANGE_ROWS_RESULT
             DB_WORKFLOW_ROOTS_CLOSED=$((DB_WORKFLOW_ROOTS_CLOSED + WORKFLOW_WISP_ROOT_ROWS))
             TOTAL_WORKFLOW_ROOTS_CLOSED=$((TOTAL_WORKFLOW_ROOTS_CLOSED + WORKFLOW_WISP_ROOT_ROWS))
@@ -506,67 +603,31 @@ while IFS= read -r DB; do
         fi
     fi
 
-    get_sql_count "$DB" "stale inactive workflow issue root" "
-        SELECT COUNT(DISTINCT i.id) FROM \`$DB\`.issues i
-        WHERE i.status IN ('open', 'in_progress')
-        AND i.issue_type NOT IN ('message', 'epic')
-        AND COALESCE(i.assignee, '') = ''
-        AND i.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-        AND COALESCE(i.updated_at, i.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-        AND (
-            JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.kind\"')) = 'workflow'
-            OR JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'
-        )
-        AND NOT EXISTS (
-            SELECT 1 FROM \`$DB\`.wisps child_wisp
-            WHERE child_wisp.id != i.id
-            AND child_wisp.status IN ('open', 'hooked', 'in_progress')
-            AND JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = i.id
-        )
-        AND NOT EXISTS (
-            SELECT 1 FROM \`$DB\`.issues child_issue
-            WHERE child_issue.id != i.id
-            AND child_issue.status IN ('open', 'in_progress')
-            AND JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = i.id
-        )
-    "
-    WORKFLOW_ISSUE_ROOT_COUNT=$SQL_COUNT_RESULT
+    get_sql_rows "$DB" "stale inactive workflow issue root" "$(workflow_root_ids_query "$DB" "workflow_issue_root_candidates" "issues" "i" "'message', 'epic'")"
+    WORKFLOW_ISSUE_ROOT_IDS=$SQL_ROWS_RESULT
+    WORKFLOW_ISSUE_ROOT_COUNT=$(printf '%s\n' "$WORKFLOW_ISSUE_ROOT_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
     if [ "$WORKFLOW_ISSUE_ROOT_COUNT" -gt 0 ]; then
-        if [ -n "$DRY_RUN" ]; then
+        if [ -z "$CITY_DB" ]; then
+            if [ "$CITY_DB_ANOMALY_RECORDED" -eq 0 ]; then
+                record_anomaly "city" "city database could not be determined from GC_REAPER_CITY_DATABASE or $CITY/.beads/metadata.json; workflow issue-root close disabled"
+                CITY_DB_ANOMALY_RECORDED=1
+            fi
+            TOTAL_WORKFLOW_ISSUE_ROOTS_SKIPPED=$((TOTAL_WORKFLOW_ISSUE_ROOTS_SKIPPED + WORKFLOW_ISSUE_ROOT_COUNT))
+        elif [ "$DB" != "$CITY_DB" ]; then
+            TOTAL_WORKFLOW_ISSUE_ROOTS_SKIPPED=$((TOTAL_WORKFLOW_ISSUE_ROOTS_SKIPPED + WORKFLOW_ISSUE_ROOT_COUNT))
+        elif [ -n "$DRY_RUN" ]; then
             TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS=$((TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS + WORKFLOW_ISSUE_ROOT_COUNT))
-        elif run_sql_change "$DB" "closing stale inactive workflow issue roots" "
-            UPDATE \`$DB\`.issues SET status='closed', closed_at=NOW()
-            WHERE id IN (
-                SELECT id FROM (
-                    SELECT i.id FROM \`$DB\`.issues i
-                    WHERE i.status IN ('open', 'in_progress')
-                    AND i.issue_type NOT IN ('message', 'epic')
-                    AND COALESCE(i.assignee, '') = ''
-                    AND i.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-                    AND COALESCE(i.updated_at, i.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-                    AND (
-                        JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.kind\"')) = 'workflow'
-                        OR JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.\"gc.formula_contract\"')) = 'graph.v2'
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1 FROM \`$DB\`.wisps child_wisp
-                        WHERE child_wisp.id != i.id
-                        AND child_wisp.status IN ('open', 'hooked', 'in_progress')
-                        AND JSON_UNQUOTE(JSON_EXTRACT(child_wisp.metadata, '$.\"gc.root_bead_id\"')) = i.id
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1 FROM \`$DB\`.issues child_issue
-                        WHERE child_issue.id != i.id
-                        AND child_issue.status IN ('open', 'in_progress')
-                        AND JSON_UNQUOTE(JSON_EXTRACT(child_issue.metadata, '$.\"gc.root_bead_id\"')) = i.id
-                    )
-                ) reaper_workflow_issue_root_candidates
-            )
-        "; then
-            WORKFLOW_ISSUE_ROOT_ROWS=$SQL_CHANGE_ROWS_RESULT
-            DB_WORKFLOW_ROOTS_CLOSED=$((DB_WORKFLOW_ROOTS_CLOSED + WORKFLOW_ISSUE_ROOT_ROWS))
-            TOTAL_WORKFLOW_ROOTS_CLOSED=$((TOTAL_WORKFLOW_ROOTS_CLOSED + WORKFLOW_ISSUE_ROOT_ROWS))
-            DB_MUTATIONS=$((DB_MUTATIONS + WORKFLOW_ISSUE_ROOT_ROWS))
+        else
+            while IFS= read -r issue_id; do
+                [ -z "$issue_id" ] && continue
+                if CLOSE_OUTPUT=$(close_city_issue "$issue_id" "$WORKFLOW_ROOT_CLOSE_REASON" 2>&1); then
+                    DB_WORKFLOW_ROOTS_CLOSED=$((DB_WORKFLOW_ROOTS_CLOSED + 1))
+                    TOTAL_WORKFLOW_ROOTS_CLOSED=$((TOTAL_WORKFLOW_ROOTS_CLOSED + 1))
+                    DB_MUTATIONS=$((DB_MUTATIONS + 1))
+                else
+                    record_anomaly "$DB" "closing stale inactive workflow issue root $issue_id failed for $DB: $(sanitize_output "$CLOSE_OUTPUT")"
+                fi
+            done <<< "$WORKFLOW_ISSUE_ROOT_IDS"
         fi
     fi
 
@@ -786,7 +847,7 @@ if [ -d "$CITY_BEADS_DIR" ] && command -v bd >/dev/null 2>&1; then
     fi
     BD_PRUNE_ARGS+=(--json)
 
-    if PRUNE_JSON=$((
+    if PRUNE_JSON=$( (
         cd "$CITY_ABS" && BEADS_DIR="$CITY_BEADS_DIR" bd "${BD_PRUNE_ARGS[@]}"
     ) 2>/dev/null); then
         :
@@ -803,7 +864,7 @@ fi
 
 if [ -d "$CITY_BEADS_DIR" ] && [ -z "$DRY_RUN" ] && command -v gc >/dev/null 2>&1; then
     SESSION_PRUNE_ATTEMPTED=1
-    if SESSION_STATE_PRUNE_JSON=$((
+    if SESSION_STATE_PRUNE_JSON=$( (
         cd "$CITY_ABS" && BEADS_DIR="$CITY_BEADS_DIR" gc session prune --state drained --before "$SESSION_STATE_PRUNE_AGE" --json
     ) 2>&1); then
         :
@@ -829,7 +890,7 @@ if [ -n "$ANOMALIES" ]; then
         -m "$ANOMALIES" 2>/dev/null || true
 fi
 
-SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, workflow_roots:$TOTAL_WORKFLOW_ROOTS_CLOSED, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, expired_skipped:$TOTAL_EXPIRED_ISSUES_SKIPPED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
+SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, workflow_roots:$TOTAL_WORKFLOW_ROOTS_CLOSED, skipped_non_city_workflow_issue_roots:$TOTAL_WORKFLOW_ISSUE_ROOTS_SKIPPED, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, expired_skipped:$TOTAL_EXPIRED_ISSUES_SKIPPED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
 if [ -n "$DRY_RUN" ]; then
     SUMMARY="$SUMMARY, would_close_wisps:$TOTAL_WOULD_CLOSE_WISPS, would_close_workflow_roots:$TOTAL_WOULD_CLOSE_WORKFLOW_ROOTS, would_expire:$TOTAL_WOULD_EXPIRE (dry run)"
 fi

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -16,16 +16,23 @@ gc runtime drain-ack
 The drain-ack tells the controller this session is done.
 
 The Reaper Dog closes stale non-closed wisps only when ownership dependency
-data proves the parent or workflow root is closed, purges closed wisps older
-than the purge threshold, and auto-closes stale issues only in the city
-database where `bd close` is correctly scoped. This keeps the wisps table from
-growing unbounded without closing active wisps by age alone.
+data proves the parent or workflow root is closed, closes stale inactive
+workflow roots whose graph subtree is quiescent, purges closed wisps older than
+the purge threshold, and auto-closes stale issues only in the city database
+where `bd close` is correctly scoped. This keeps workflow root and wisp tables
+from growing unbounded without closing active work by age alone.
 
 Current behavior:
 - Observes open/hooked/in_progress wisps older than max_age (default 24h)
 - Closes only the subset whose parent-child dependency points to a closed
   parent, or whose graph-v2 `tracks` edge points to its `gc.root_bead_id`
   workflow root after that root is closed
+- Closes unassigned open/hooked/in_progress workflow wisp roots older than
+  max_age only when their stamped and graph-dependency subtree has no live or
+  recently updated descendants
+- Closes stale inactive workflow issue roots only in the resolved city
+  database through `bd close`, and reports non-city workflow issue-root
+  candidates without closing them
 - Purges (deletes) closed wisps past purge_age (default 7 days)
 - Auto-closes stale city issues open >30 days with no status change
 - Reports stale issue candidates in non-city databases without closing them
@@ -54,10 +61,14 @@ database patterns.
 This is infrastructure work. You:
 1. Scan all production databases for candidates
 2. Report non-closed wisps past max_age and close only wisps whose parent/root is closed
-3. Purge (delete) closed wisps past purge_age
-4. Auto-close stale city issues (with exclusions)
-5. Report findings and flag anomalies
-6. Return to kennel
+3. Close stale inactive workflow wisp roots only when no live or recent
+   descendants are visible through root metadata or parent-child/tracks/blocks
+   dependencies
+4. Close stale inactive workflow issue roots only in the resolved city database
+5. Purge (delete) closed wisps past purge_age
+6. Auto-close stale city issues (with exclusions)
+7. Report findings and flag anomalies
+8. Return to kennel
 
 ## Variables
 
@@ -82,16 +93,24 @@ closed parent, or when a graph-v2 `tracks` edge points to the child's own
 `gc.root_bead_id` workflow root and that root is closed. Ordinary `blocks`
 dependencies are sequencing edges and must never close a live wisp. Wisps
 without an ownership edge, or with an unresolved parent/root record, are
-observed, not closed by age alone. Purging deletes rows — irreversible but
-only targets already-closed wisps past retention. Its protection query may
-include `blocks` because over-protection only prevents deletion. Auto-close
-excludes P0/P1, epics, and issues with active dependencies. Non-city database
-issue candidates are report-only until the maintenance pack has an explicit
-DB-to-`BEADS_DIR` routing map for scoped `bd close`. If the canonical city
-database cannot be resolved from bead metadata, a `GC_REAPER_CITY_DATABASE`
-override does not match that metadata, or the resolved database is not present
-in the discovered database list, stale issue auto-close is disabled for that
-run and reported as an anomaly.
+observed, not closed by age alone. Workflow root cleanup only targets
+unassigned open/hooked/in_progress roots and treats blocked, deferred, pinned,
+review, and testing descendants as live protection states. A root is also
+preserved when any descendant has been updated within max_age. Workflow root
+descendant traversal is store-local and relies on `gc.root_store_ref`
+co-locating a workflow root, descendants, and graph dependencies in one bead
+store; if that invariant changes, this cleanup must become cross-store aware
+before it can close roots. Purging
+deletes rows — irreversible but only targets already-closed wisps past
+retention. Its protection query may include `blocks` because over-protection
+only prevents deletion. Auto-close excludes P0/P1, epics, and issues with
+active dependencies. Non-city database issue candidates are report-only until
+the maintenance pack has an explicit DB-to-`BEADS_DIR` routing map for scoped
+`bd close`. If the canonical city database cannot be resolved from bead
+metadata, a `GC_REAPER_CITY_DATABASE` override does not match that metadata, or
+the resolved database is not present in the discovered database list, stale
+issue auto-close and workflow issue-root close are disabled for that run and
+reported as an anomaly when candidates exist.
 
 ## Anomaly Detection
 

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -99,8 +99,10 @@ review, and testing descendants as live protection states. A root is also
 preserved when any descendant has been updated within max_age. Workflow root
 descendant traversal is store-local and relies on `gc.root_store_ref`
 co-locating a workflow root, descendants, and graph dependencies in one bead
-store; if that invariant changes, this cleanup must become cross-store aware
-before it can close roots. Purging
+store. Rig store refs are matched through resolved rig bindings and each rig's
+`.beads/metadata.json`; roots stamped for another or unmapped store are
+preserved. If that invariant changes, this cleanup must become cross-store
+aware before it can close those roots. Purging
 deletes rows — irreversible but only targets already-closed wisps past
 retention. Its protection query may include `blocks` because over-protection
 only prevents deletion. Auto-close excludes P0/P1, epics, and issues with


### PR DESCRIPTION
## Cause

The reaper could close stale wisps that had a closed parent edge, and it could auto-close very old city issues, but it did not directly handle stale workflow roots. A graph workflow root can be old, unassigned, and have no active root-owned children while still remaining open, especially when the root itself lives in no-history `wisps` storage. Older history-tier workflow roots can also appear in `issues`, so the cleanup needs to cover both storage locations.

## Fix

- Add a stale inactive workflow-root close step before purge.
- Close only roots that are open/hooked/in-progress, unassigned, older than `GC_REAPER_MAX_AGE`, not recently updated, and identified by `gc.kind=workflow` or `gc.formula_contract=graph.v2`.
- Preserve active workflows by requiring no active `gc.root_bead_id` children in either `wisps` or `issues`.
- Account for closed workflow roots in Dolt commit messages, normal summaries, and dry-run summaries.

## Verification

- `.githooks/pre-commit` ran successfully during commit, including `go vet ./...` and `./scripts/test-local-parallel fast`.
- `go test ./examples/gastown` passed.
- Added coverage proves the reaper closes stale inactive workflow roots in both `wisps` and `issues`, uses workflow metadata, avoids `parent_id`, and reports `workflow_roots` in commit and session summaries.
