### PR TITLE
fix(controller): stamp pool-demand sentinel on formula-slung roots

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1316,13 +1316,15 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			counts[template]++
 		}
 
-		// Source 2: explicit pool-demand path. Two writers stamp the wisp
-		// when a.Pool != "" — doOrderRunWithJSON (cmd_order.go, the
-		// gc order run CLI path) and memoryOrderDispatcher.dispatchOne
-		// (order_dispatch.go, the supervisor's in-process cron path).
-		// Both write poolDemandMetadataPair() alongside the routing key,
-		// so cron-fired pool orders surface scale_check demand even when
-		// the wisp lands as a molecule that readyExcludeTypes filters out
+		// Source 2: explicit pool-demand path. Three writers stamp the
+		// wisp when it routes to a pool — doOrderRunWithJSON
+		// (cmd_order.go, the gc order run CLI path),
+		// memoryOrderDispatcher.dispatchOne (order_dispatch.go, the
+		// supervisor's in-process cron path), and slingFormula
+		// (internal/sling/sling_core.go, the gc sling --formula path —
+		// issue #2986). All write poolDemandMetadataPair() alongside the
+		// routing key, so pool-routed wisps surface scale_check demand
+		// even when they land as molecules that readyExcludeTypes filters out
 		// (per PR #1154 / issue #1039 — formula steps are not actionable
 		// work, the molecule is the container). The list filter is
 		// metadata-only (open + gc.pool_demand=<sentinel>); the

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/sling"
 )
 
 type listFailStore struct {
@@ -931,6 +932,80 @@ func TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag(t *testing.T
 	}
 }
 
+// TestDefaultScaleCheckCountsCountsFormulaSlungPoolDemand asserts the
+// gc sling --formula path end-to-end: slingFormula (internal/sling)
+// stamps poolDemandMetadataPair() on the wisp root when the target is a
+// multi-session pool, and defaultScaleCheckCounts must count that wisp
+// as demand. Without the stamp the wisp is a molecule that
+// readyExcludeTypes filters out of Ready(), both demand sources miss
+// it, and the pool never spawns a worker — sling reports routed:true
+// while the work sits unserved. Regression for
+// https://github.com/gastownhall/gascity/issues/2986.
+func TestDefaultScaleCheckCountsCountsFormulaSlungPoolDemand(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "quick-plan.toml"),
+		[]byte("formula = \"quick-plan\"\nversion = 1\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n"), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	a := config.Agent{Name: "dog", MaxActiveSessions: intPtr(3)}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{a},
+	}
+	cfg.FormulaLayers.City = []string{formulaDir}
+
+	result, err := sling.DoSling(sling.SlingOpts{
+		Target:        a,
+		BeadOrFormula: "quick-plan",
+		IsFormula:     true,
+	}, sling.SlingDeps{
+		CityName: "test-city",
+		CityPath: t.TempDir(),
+		Cfg:      cfg,
+		SP:       runtime.NewFake(),
+		Runner:   func(string, string, map[string]string) (string, error) { return "", nil },
+		Store:    backing,
+		StoreRef: "city:test-city",
+		Router:   storeMetadataRouter{store: backing},
+		Notify:   noopSlingNotifier{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("DoSling error: %v", err)
+	}
+
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "dog",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["dog"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1 (formula-slung wisp %s must count as pool demand)", "dog", got, result.BeadID)
+	}
+}
+
+// storeMetadataRouter mirrors cliBeadRouter's built-in routing write —
+// gc.routed_to on the bead — without the config plumbing, for fixtures.
+type storeMetadataRouter struct{ store beads.Store }
+
+func (r storeMetadataRouter) Route(_ context.Context, req sling.RouteRequest) error {
+	return r.store.SetMetadata(req.BeadID, "gc.routed_to", req.Target)
+}
+
+// noopSlingNotifier satisfies sling.Notifier for fixtures.
+type noopSlingNotifier struct{}
+
+func (noopSlingNotifier) PokeController(string)      {}
+func (noopSlingNotifier) PokeControlDispatch(string) {}
+
 func TestDefaultScaleCheckCountsPoolDemandUsesRoutedToBeforeRunTarget(t *testing.T) {
 	backing := &demandListCountingStore{Store: beads.NewMemStore()}
 	metadata := map[string]string{
@@ -1180,9 +1255,10 @@ func TestDefaultScaleCheckCountsIgnoresAssignedCronPoolDemand(t *testing.T) {
 // Option B design discussion on PR #2531. The trifecta defense:
 //   - readyExcludeTypes filters Type:"step" out of Ready() per PR #1154.
 //   - The metadata-list source only matches beads carrying
-//     poolDemandMetadataPair(), which only cmd_order.go and
-//     order_dispatch.go write (and only on the wisp ROOT, never on
-//     step children stamped by stampLegacyRecipeRouting).
+//     poolDemandMetadataPair(), which only cmd_order.go,
+//     order_dispatch.go, and slingFormula (internal/sling) write (and
+//     only on the wisp ROOT, never on step children stamped by
+//     stampLegacyRecipeRouting).
 //   - graph.v2 steps carry gc.kind=workflow plus gc.routed_to to the
 //     pool but no gc.pool_demand, so neither source counts them.
 //

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -713,14 +713,15 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 	if a.Pool != "" {
 		// poolDemandMetadataPair() returns the explicit, type-independent
 		// signal that this wisp counts as scale_check demand for the
-		// routed pool — see cmd/gc/pool_demand.go for the value-choice
-		// rationale (bd's --set-metadata write path infers JSON type
-		// from the string, so a numeric-looking value would round-trip
-		// as an integer and silently miss the supervisor's metadata
-		// equality match). Same pair is written by
-		// memoryOrderDispatcher.dispatchOne in order_dispatch.go so
-		// both the CLI (gc order run) and supervisor cron paths land
-		// matching beads.
+		// routed pool — see internal/sling/pool_demand.go for the
+		// value-choice rationale (bd's --set-metadata write path infers
+		// JSON type from the string, so a numeric-looking value would
+		// round-trip as an integer and silently miss the supervisor's
+		// metadata equality match). The same pair is written by
+		// memoryOrderDispatcher.dispatchOne in order_dispatch.go and by
+		// slingFormula in internal/sling, so the CLI (gc order run),
+		// supervisor cron, and gc sling --formula paths land matching
+		// beads.
 		update.Metadata = map[string]string{"gc.routed_to": pool}
 		for k, v := range poolDemandMetadataPair() {
 			update.Metadata[k] = v

--- a/cmd/gc/pool_demand.go
+++ b/cmd/gc/pool_demand.go
@@ -2,51 +2,22 @@
 
 package main
 
-// poolDemandMetadataKey is the bead-metadata flag set on a pooled order
-// wisp at creation time and read by the supervisor's default scale_check
-// path. It exists because PR #1154 added "molecule" and "step" to
-// readyExcludeTypes for queue hygiene (workflow containers and formula
-// scaffolding stay out of bd ready), leaving the supervisor's
-// defaultScaleCheckCounts with no Ready surface for cron-fired pool
-// orders. Rather than relax the type filter, the order-side writer
-// stamps this key on the wisp and the supervisor takes a second
-// metadata-filtered list as a separate demand source.
-//
-// Writers: doOrderRunWithJSON (cmd_order.go) and
-// memoryOrderDispatcher.dispatchOne (order_dispatch.go).
-// Reader: defaultScaleCheckCounts (build_desired_state.go).
-const poolDemandMetadataKey = "gc.pool_demand"
+import "github.com/gastownhall/gascity/internal/sling"
 
-// poolDemandMetadataValue is the literal value the writers stamp and the
-// reader's ListQuery.Metadata equality match looks up.
-//
-// The value is a stable non-numeric sentinel, not "1", because bd's
-// --set-metadata write path infers JSON type from the string — a
-// numeric-looking value like "1" lands in the SQL metadata column as
-// the JSON integer 1, and the cache's matchesMetadata (caching_store_reads.go)
-// does strict string equality, so a "1" writer paired with a "1" reader
-// silently misses every bead. Verified empirically when the first
-// iteration of this fix shipped with "1": post-build dolt rows showed
-// gc.pool_demand stored as INTEGER and scale_check_counts stayed at 0.
-//
-// Any future change to this value must (a) stay non-numeric to keep the
-// bd round-trip lossless and (b) update poolDemandMetadataPair()'s
-// returned map so writers and the equality-match reader stay in sync.
-const poolDemandMetadataValue = "order"
+// The pool-demand sentinel is defined canonically in internal/sling
+// (pool_demand.go) so that slingFormula — a third writer alongside the
+// two gc order paths in this package — can stamp the same pair without
+// an upward import. These aliases keep the cmd/gc writers and the
+// defaultScaleCheckCounts reader on the shared definition; see the
+// internal/sling doc comments for the key/value rationale (including
+// why the value must stay non-numeric).
+const (
+	poolDemandMetadataKey   = sling.PoolDemandMetadataKey
+	poolDemandMetadataValue = sling.PoolDemandMetadataValue
+)
 
-// poolDemandMetadataPair returns the metadata map a pool-order writer
-// must merge into its UpdateOpts.Metadata alongside the existing
-// gc.routed_to write. Writers compose with the routing key:
-//
-//	if a.Pool != "" {
-//	    update.Metadata = map[string]string{"gc.routed_to": pool}
-//	    for k, v := range poolDemandMetadataPair() {
-//	        update.Metadata[k] = v
-//	    }
-//	}
-//
-// The helper exists so adding a second flag in the future (e.g., a
-// per-trigger discriminator) does not require auditing every writer.
+// poolDemandMetadataPair forwards to sling.PoolDemandMetadataPair, the
+// canonical writer-side helper.
 func poolDemandMetadataPair() map[string]string {
-	return map[string]string{poolDemandMetadataKey: poolDemandMetadataValue}
+	return sling.PoolDemandMetadataPair()
 }

--- a/internal/sling/pool_demand.go
+++ b/internal/sling/pool_demand.go
@@ -1,0 +1,53 @@
+// Copyright (c) Gas City contributors. SPDX-License-Identifier: Apache-2.0
+
+package sling
+
+// PoolDemandMetadataKey is the bead-metadata flag set on a pool-routed
+// wisp at creation time and read by the supervisor's default scale_check
+// path. It exists because PR #1154 added "molecule" and "step" to
+// readyExcludeTypes for queue hygiene (workflow containers and formula
+// scaffolding stay out of bd ready), leaving the supervisor's
+// defaultScaleCheckCounts with no Ready surface for pool-routed wisps.
+// Rather than relax the type filter, each wisp writer stamps this key
+// and the supervisor takes a second metadata-filtered list as a
+// separate demand source.
+//
+// Writers: doOrderRunWithJSON (cmd/gc/cmd_order.go),
+// memoryOrderDispatcher.dispatchOne (cmd/gc/order_dispatch.go), and
+// slingFormula (sling_core.go) for `gc sling --formula` pool targets.
+// Reader: defaultScaleCheckCounts (cmd/gc/build_desired_state.go).
+const PoolDemandMetadataKey = "gc.pool_demand"
+
+// PoolDemandMetadataValue is the literal value the writers stamp and the
+// reader's ListQuery.Metadata equality match looks up.
+//
+// The value is a stable non-numeric sentinel, not "1", because bd's
+// --set-metadata write path infers JSON type from the string — a
+// numeric-looking value like "1" lands in the SQL metadata column as
+// the JSON integer 1, and the cache's matchesMetadata (caching_store_reads.go)
+// does strict string equality, so a "1" writer paired with a "1" reader
+// silently misses every bead. Verified empirically when the first
+// iteration of this fix shipped with "1": post-build dolt rows showed
+// gc.pool_demand stored as INTEGER and scale_check_counts stayed at 0.
+//
+// Any future change to this value must (a) stay non-numeric to keep the
+// bd round-trip lossless and (b) update PoolDemandMetadataPair()'s
+// returned map so writers and the equality-match reader stay in sync.
+const PoolDemandMetadataValue = "order"
+
+// PoolDemandMetadataPair returns the metadata map a pool-routed wisp
+// writer must merge into its UpdateOpts.Metadata alongside the existing
+// gc.routed_to write. Writers compose with the routing key:
+//
+//	if a.Pool != "" {
+//	    update.Metadata = map[string]string{"gc.routed_to": pool}
+//	    for k, v := range sling.PoolDemandMetadataPair() {
+//	        update.Metadata[k] = v
+//	    }
+//	}
+//
+// The helper exists so adding a second flag in the future (e.g., a
+// per-trigger discriminator) does not require auditing every writer.
+func PoolDemandMetadataPair() map[string]string {
+	return map[string]string{PoolDemandMetadataKey: PoolDemandMetadataValue}
+}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -246,6 +246,20 @@ func slingFormula(opts SlingOpts, deps SlingDeps) (SlingResult, error) {
 		wfResult.Deprecations = append(wfResult.Deprecations, inv.Deprecations...)
 		return wfResult, wfErr
 	}
+	// Pool targets discover work through the supervisor's scale_check, but
+	// the wisp root is a molecule that readyExcludeTypes filters out of
+	// Ready() (per PR #1154). Stamp PoolDemandMetadataPair() — the same
+	// sentinel the gc order run writers use — so defaultScaleCheckCounts
+	// counts the wisp and spawns a pool worker. Failure is fatal: a routed
+	// wisp without the sentinel sits unserved forever (issue #2986).
+	if agentutil.IsMultiSessionAgent(&a) {
+		for k, v := range PoolDemandMetadataPair() {
+			if err := deps.Store.SetMetadata(mResult.RootID, k, v); err != nil {
+				return SlingResult{Target: a.QualifiedName(), FormulaName: opts.BeadOrFormula},
+					fmt.Errorf("setting %s on wisp %s: %w", k, mResult.RootID, err)
+			}
+		}
+	}
 	result := SlingResult{Target: a.QualifiedName(), FormulaName: opts.BeadOrFormula, Deprecations: inv.Deprecations}
 	return finalize(opts, deps, mResult.RootID, method, result)
 }

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -1078,6 +1078,65 @@ func TestDoSlingFormulaToAgent(t *testing.T) {
 	}
 }
 
+// TestDoSlingFormulaToPoolStampsPoolDemand asserts that slinging a formula
+// to a multi-session pool target stamps PoolDemandMetadataPair() on the wisp
+// root. The wisp lands as a molecule that readyExcludeTypes filters out of
+// Ready() (per PR #1154), so without the sentinel defaultScaleCheckCounts
+// sees zero demand and the pool never spawns a worker. Regression for
+// https://github.com/gastownhall/gascity/issues/2986.
+func TestDoSlingFormulaToPoolStampsPoolDemand(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "polecat", MaxActiveSessions: intPtr(3)}
+
+	deps := testDeps(cfg, sp, runner.run)
+	result, err := DoSling(SlingOpts{
+		Target:        a,
+		BeadOrFormula: "code-review",
+		IsFormula:     true,
+	}, deps, nil)
+	if err != nil {
+		t.Fatalf("DoSling error: %v", err)
+	}
+	root, err := deps.Store.Get(result.BeadID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", result.BeadID, err)
+	}
+	for k, v := range PoolDemandMetadataPair() {
+		if got := root.Metadata[k]; got != v {
+			t.Errorf("wisp root %s = %q, want %q (pool-slung formula wisps must carry the demand sentinel so defaultScaleCheckCounts can count them despite readyExcludeTypes filtering molecules out of Ready())", k, got, v)
+		}
+	}
+}
+
+// TestDoSlingFormulaToSingleSessionAgentSkipsPoolDemand asserts the demand
+// sentinel is pool-only: a formula slung at a fixed single-session agent
+// (woken by nudge, not scale_check counts) must not carry gc.pool_demand.
+func TestDoSlingFormulaToSingleSessionAgentSkipsPoolDemand(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps := testDeps(cfg, sp, runner.run)
+	result, err := DoSling(SlingOpts{
+		Target:        a,
+		BeadOrFormula: "code-review",
+		IsFormula:     true,
+	}, deps, nil)
+	if err != nil {
+		t.Fatalf("DoSling error: %v", err)
+	}
+	root, err := deps.Store.Get(result.BeadID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", result.BeadID, err)
+	}
+	if got, ok := root.Metadata[PoolDemandMetadataKey]; ok {
+		t.Errorf("wisp root %s = %q, want absent (single-session agents are woken by nudge, not pool scale_check demand)", PoolDemandMetadataKey, got)
+	}
+}
+
 func TestBuildSlingFormulaVarsSeedsRoutingNamespace(t *testing.T) {
 	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), newFakeRunner().run)
 


### PR DESCRIPTION
Pool `scale_check` was blind to formula-slung pool-routed roots. `slingFormula` now stamps `poolDemandMetadataPair()` on pool-routed wisp roots so the controller's scale-check sees the demand.

Fixes #2986.