### PR TITLE
fix(dispatch): quarantine retry/ralph controls (no attempt sub-DAG)

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -4326,6 +4326,75 @@ func TestRunControlDispatcherQuarantinesMalformedFanoutScopeBody(t *testing.T) {
 	}
 }
 
+func TestRunControlDispatcherQuarantinesRalphControlMissingIteration(t *testing.T) {
+	clearGCEnv(t)
+
+	// A ralph control bead with no iteration sub-DAG — the unprocessable
+	// shape left behind by the pre-seed-fix ralph-in-ralph re-spawn gap.
+	// The dispatcher must quarantine it as a malformed control graph and
+	// return nil so the serve loop keeps draining the rest of the queue.
+	// Regression for gastownhall/gascity#2798.
+	store := beads.NewMemStore()
+	workflow, err := store.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	control, err := store.Create(beads.Bead{
+		Title: "inner loop",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":          "ralph",
+			"gc.root_bead_id":  workflow.ID,
+			"gc.step_ref":      "mol-test.outer.iteration.2.inner",
+			"gc.step_id":       "inner",
+			"gc.max_attempts":  "3",
+			"gc.control_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr); err != nil {
+		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
+	}
+
+	after, err := store.Get(control.ID)
+	if err != nil {
+		t.Fatalf("get control: %v", err)
+	}
+	if after.Status != "closed" {
+		t.Fatalf("control status = %q, want closed", after.Status)
+	}
+	if got := after.Metadata["gc.outcome"]; got != "fail" {
+		t.Fatalf("gc.outcome = %q, want fail", got)
+	}
+	if got := after.Metadata["gc.failure_reason"]; got != "malformed_control_graph" {
+		t.Fatalf("gc.failure_reason = %q, want malformed_control_graph", got)
+	}
+	if got := after.Metadata["gc.control_quarantined"]; got != "true" {
+		t.Fatalf("gc.control_quarantined = %q, want true", got)
+	}
+	if got := after.Metadata["gc.control_quarantine_reason"]; !strings.Contains(got, "no iteration found") {
+		t.Fatalf("gc.control_quarantine_reason = %q, want no iteration found", got)
+	}
+	if !slices.Contains(after.Labels, "gc:control-quarantined") {
+		t.Fatalf("labels = %#v, want gc:control-quarantined", after.Labels)
+	}
+	if got := stderr.String(); !strings.Contains(got, "control dispatch: quarantined bead="+control.ID) {
+		t.Fatalf("stderr = %q, want quarantine message", got)
+	}
+}
+
 func TestRunControlDispatcherQuarantinesGenericControlFailure(t *testing.T) {
 	clearGCEnv(t)
 

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -36,7 +36,13 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		return ControlResult{}, fmt.Errorf("%s: finding latest attempt: %w", bead.ID, err)
 	}
 	if attempt.ID == "" {
-		return ControlResult{}, fmt.Errorf("%s: no attempt found", bead.ID)
+		// A retry control with no attempt sub-DAG cannot become valid by
+		// waiting — the graph is malformed (missing seed or a seed attach
+		// marked molecule_failed). Classify for the dispatcher quarantine
+		// instead of fataling the serve loop. See gastownhall/gascity#2798.
+		opts.tracef("process-control bead=%s kind=retry quarantine reason=no_attempt_found root=%s",
+			bead.ID, bead.Metadata["gc.root_bead_id"])
+		return ControlResult{}, fmt.Errorf("%w: %s: no attempt found", ErrControlGraphMalformed, bead.ID)
 	}
 	if attempt.Status != "closed" {
 		if err := ensureBlockingDependency(store, bead.ID, attempt.ID); err != nil {
@@ -160,7 +166,14 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		return ControlResult{}, fmt.Errorf("%s: finding latest iteration: %w", bead.ID, err)
 	}
 	if iteration.ID == "" {
-		return ControlResult{}, fmt.Errorf("%s: no iteration found", bead.ID)
+		// A ralph control with no iteration sub-DAG cannot become valid by
+		// waiting — the graph is malformed (missing first-iteration seed or
+		// a seed attach marked molecule_failed). Classify for the dispatcher
+		// quarantine instead of fataling the serve loop, which crash-looped
+		// all dispatch for the rig. See gastownhall/gascity#2798.
+		opts.tracef("process-control bead=%s kind=ralph quarantine reason=no_iteration_found root=%s",
+			bead.ID, bead.Metadata["gc.root_bead_id"])
+		return ControlResult{}, fmt.Errorf("%w: %s: no iteration found", ErrControlGraphMalformed, bead.ID)
 	}
 	if iteration.Status != "closed" {
 		if err := ensureBlockingDependency(store, bead.ID, iteration.ID); err != nil {

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -733,6 +733,81 @@ func TestProcessRetryControlInvariantViolation(t *testing.T) {
 	}
 }
 
+func TestProcessRetryControlMissingAttemptIsGraphMalformed(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	// A retry control whose attempt sub-DAG is absent. Waiting cannot make
+	// an attempt appear, so the condition must classify as a malformed
+	// control graph so the dispatcher quarantines the bead instead of
+	// crash-looping the serve loop. See gastownhall/gascity#2798.
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review",
+		Metadata: map[string]string{
+			"gc.kind":          "retry",
+			"gc.root_bead_id":  root.ID,
+			"gc.step_ref":      "mol-test.review",
+			"gc.step_id":       "review",
+			"gc.max_attempts":  "3",
+			"gc.control_epoch": "1",
+		},
+	})
+
+	_, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if !errors.Is(err, ErrControlGraphMalformed) {
+		t.Fatalf("error = %v, want ErrControlGraphMalformed", err)
+	}
+}
+
+func TestProcessRalphControlMissingIterationIsGraphMalformed(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	// A ralph control whose first iteration was never seeded — the
+	// pre-seed-fix re-spawn gap, manual bead surgery, or a seed attach
+	// marked molecule_failed. Waiting cannot make an iteration appear, so
+	// the condition must classify as a malformed control graph for the
+	// dispatcher quarantine rather than fatal out of the serve loop.
+	// Regression for gastownhall/gascity#2798.
+	control := mustCreate(t, store, beads.Bead{
+		Title: "inner loop",
+		Metadata: map[string]string{
+			"gc.kind":          "ralph",
+			"gc.root_bead_id":  root.ID,
+			"gc.step_ref":      "mol-test.outer.iteration.2.inner",
+			"gc.step_id":       "inner",
+			"gc.max_attempts":  "3",
+			"gc.control_epoch": "1",
+		},
+	})
+
+	var traced []string
+	opts := ProcessOptions{Tracef: func(format string, args ...any) {
+		traced = append(traced, fmt.Sprintf(format, args...))
+	}}
+	_, err := processRalphControl(store, mustGet(t, store, control.ID), opts)
+	if !errors.Is(err, ErrControlGraphMalformed) {
+		t.Fatalf("error = %v, want ErrControlGraphMalformed", err)
+	}
+	found := false
+	for _, line := range traced {
+		if strings.Contains(line, control.ID) && strings.Contains(line, "no_iteration_found") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("trace lines = %#v, want structured warning naming bead %s and no_iteration_found", traced, control.ID)
+	}
+}
+
 func TestProcessRetryControlPendingAttemptAddsBlockingDep(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()


### PR DESCRIPTION
Part 2 of #2798 (nested ralph-in-ralph composition): quarantines the retry/ralph controls so they don't compose into an attempt sub-DAG.

Part of #2798.