### PR TITLE
fix(build): forward icu4c CGO paths in test scripts on macOS (ga-4s465g)

### DIFF
--- a/release-gates/ga-blx3e3-icu4c-cgo-paths-gate.md
+++ b/release-gates/ga-blx3e3-icu4c-cgo-paths-gate.md
@@ -1,0 +1,48 @@
+# Release Gate: ga-blx3e3 icu4c CGO path forwarding
+
+Date: 2026-06-05
+
+PR: https://github.com/gastownhall/gascity/pull/3130
+Deploy bead: ga-blx3e3
+Source review bead: ga-3e79wa
+Reviewed commit: 28e60b1654609f85bb59b584b0b77b03a2d3267e
+Branch: feat/ga-4s465g-mac-icu-cgo-paths
+
+Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this checkout or
+on `origin/main`; this gate uses the deployer release criteria from the role
+prompt.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-3e79wa` is closed with `VERDICT: PASS (fix-merge applied)`. PR comment https://github.com/gastownhall/gascity/pull/3130#issuecomment-4633957022 records the reviewer PASS and fixup commit. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `scripts/test-go-test-shard` and `scripts/test-integration-shard`. Both scripts now detect Homebrew `icu4c` on Darwin, append `CGO_CPPFLAGS`/`CGO_LDFLAGS` through the `env -i` boundary, and avoid duplicate include-path injection when nested. A targeted fake Darwin smoke passed for both scripts. |
+| 3 | Tests pass | PASS | `bash -n scripts/test-go-test-shard scripts/test-integration-shard` passed. `go vet ./...` passed. Targeted fake Darwin icu4c smoke passed. `LOCAL_TEST_JOBS=8 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel` passed. PR checks are green after rerunning a cancelled `Integration / rest-smoke-2-of-2` job; `gh pr checks 3130` shows `CI / required`, `CI / preflight`, `CI / integration`, CodeQL, and integration shards passing. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes contain one low finding, fixed in commit `28e60b1`. PR reviews list is empty and the only PR review-process comment is PASS. No unresolved HIGH findings found. |
+| 5 | Final branch is clean | PASS | Detached gate worktree was clean before writing this gate file; after committing this file, final status is verified clean before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` completed successfully before the gate commit. The branch touches only release-gate markdown after this file is added, so the clean merge result is preserved. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem theme: test runner scripts forwarding macOS icu4c CGO paths through clean test environments. No unrelated feature or package behavior is bundled. |
+
+## Test Commands
+
+```text
+bash -n scripts/test-go-test-shard scripts/test-integration-shard
+go vet ./...
+targeted fake-Darwin icu4c smoke for test-go-test-shard and test-integration-shard
+LOCAL_TEST_JOBS=8 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel
+gh pr checks 3130
+```
+
+## Notes
+
+The first local `make test-fast-parallel` run used the default high local
+parallelism and failed two unrelated timing-sensitive tests:
+
+- `internal/beads`: `TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand`
+- `cmd/gc`: `TestFindPortHolderPIDUsesProcBeforeLsof`
+
+Both exact tests passed when rerun directly, and the lower-parallel full fast
+baseline passed cleanly. The GitHub CI failure observed during gate evaluation
+was a cancelled `rest-smoke-2-of-2` job with no test assertion; rerunning failed
+jobs made the required CI checks pass.

--- a/scripts/test-go-test-shard
+++ b/scripts/test-go-test-shard
@@ -31,6 +31,22 @@ gomodcache_val="$(go env GOMODCACHE)"
 gotmpdir_val="$(go env GOTMPDIR)"
 goroot_val="$(go env GOROOT)"
 
+# macOS: icu4c (a transitive go-icu-regex/Dolt CGO dependency) is keg-only
+# under Homebrew, so its headers/libs are not on the default CGO search path.
+# Mirror the Makefile's detection here so tests run via this script see the
+# same CGO paths as `make`. No-op on Linux and when icu4c is not installed.
+# When invoked from test-integration-shard, CGO_CPPFLAGS/CGO_LDFLAGS may
+# already be set by that script; augment rather than replace them.
+cgo_cppflags="${CGO_CPPFLAGS:-}"
+cgo_ldflags="${CGO_LDFLAGS:-}"
+if [[ "$(uname)" == "Darwin" && -z "$cgo_cppflags" ]]; then
+  icu_prefix="$(brew --prefix icu4c 2>/dev/null || true)"
+  if [[ -n "$icu_prefix" ]]; then
+    cgo_cppflags="${cgo_cppflags:+$cgo_cppflags }-I${icu_prefix}/include"
+    cgo_ldflags="${cgo_ldflags:+$cgo_ldflags }-L${icu_prefix}/lib"
+  fi
+fi
+
 extra_env=()
 while IFS='=' read -r name _; do
   case "$name" in
@@ -67,7 +83,9 @@ run_go_test() {
     GOINSECURE="${GOINSECURE-}" \
     GOVCS="${GOVCS-}" \
     GOWORK="${GOWORK-}" \
-    GC_FAST_UNIT="${GC_FAST_UNIT:-0}"
+    GC_FAST_UNIT="${GC_FAST_UNIT:-0}" \
+    CGO_CPPFLAGS="${cgo_cppflags}" \
+    CGO_LDFLAGS="${cgo_ldflags}" \
     GC_TEST_SHARD_INDEX="${shard_index}" \
     GC_TEST_SHARD_TOTAL="${shard_total}"
   )

--- a/scripts/test-go-test-shard
+++ b/scripts/test-go-test-shard
@@ -36,12 +36,13 @@ goroot_val="$(go env GOROOT)"
 # Mirror the Makefile's detection here so tests run via this script see the
 # same CGO paths as `make`. No-op on Linux and when icu4c is not installed.
 # When invoked from test-integration-shard, CGO_CPPFLAGS/CGO_LDFLAGS may
-# already be set by that script; augment rather than replace them.
+# already be set by that script; the duplicate-safe guard below prevents
+# double-adding when this script runs as a child of test-integration-shard.
 cgo_cppflags="${CGO_CPPFLAGS:-}"
 cgo_ldflags="${CGO_LDFLAGS:-}"
-if [[ "$(uname)" == "Darwin" && -z "$cgo_cppflags" ]]; then
+if [[ "$(uname)" == "Darwin" ]]; then
   icu_prefix="$(brew --prefix icu4c 2>/dev/null || true)"
-  if [[ -n "$icu_prefix" ]]; then
+  if [[ -n "$icu_prefix" && "$cgo_cppflags" != *"-I${icu_prefix}/include"* ]]; then
     cgo_cppflags="${cgo_cppflags:+$cgo_cppflags }-I${icu_prefix}/include"
     cgo_ldflags="${cgo_ldflags:+$cgo_ldflags }-L${icu_prefix}/lib"
   fi

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -28,7 +28,7 @@ cgo_cppflags="${CGO_CPPFLAGS:-}"
 cgo_ldflags="${CGO_LDFLAGS:-}"
 if [[ "$(uname)" == "Darwin" ]]; then
   icu_prefix="$(brew --prefix icu4c 2>/dev/null || true)"
-  if [[ -n "$icu_prefix" ]]; then
+  if [[ -n "$icu_prefix" && "$cgo_cppflags" != *"-I${icu_prefix}/include"* ]]; then
     cgo_cppflags="${cgo_cppflags:+$cgo_cppflags }-I${icu_prefix}/include"
     cgo_ldflags="${cgo_ldflags:+$cgo_ldflags }-L${icu_prefix}/lib"
   fi

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -20,6 +20,23 @@ gomodcache_val="$(go env GOMODCACHE)"
 gotmpdir_val="$(go env GOTMPDIR)"
 goroot_val="$(go env GOROOT)"
 
+# macOS: icu4c (a transitive go-icu-regex/Dolt CGO dependency) is keg-only
+# under Homebrew, so its headers/libs are not on the default CGO search path.
+# Mirror the Makefile's detection here so tests run via this script see the
+# same CGO paths as `make`. No-op on Linux and when icu4c is not installed.
+cgo_cppflags="${CGO_CPPFLAGS:-}"
+cgo_ldflags="${CGO_LDFLAGS:-}"
+if [[ "$(uname)" == "Darwin" ]]; then
+  icu_prefix="$(brew --prefix icu4c 2>/dev/null || true)"
+  if [[ -n "$icu_prefix" ]]; then
+    cgo_cppflags="${cgo_cppflags:+$cgo_cppflags }-I${icu_prefix}/include"
+    cgo_ldflags="${cgo_ldflags:+$cgo_ldflags }-L${icu_prefix}/lib"
+  fi
+fi
+# Export so child scripts (e.g. test-go-test-shard) inherit the detected paths.
+export CGO_CPPFLAGS="${cgo_cppflags}"
+export CGO_LDFLAGS="${cgo_ldflags}"
+
 run_go_test() {
   env -i \
     PATH="${PATH}" \
@@ -49,6 +66,8 @@ run_go_test() {
     GOWORK="${GOWORK-}" \
     GC_BEADS="${GC_BEADS-}" \
     GC_FAST_UNIT=0 \
+    CGO_CPPFLAGS="${cgo_cppflags}" \
+    CGO_LDFLAGS="${cgo_ldflags}" \
     go test "$@"
 }
 


### PR DESCRIPTION
## What this changes

`test-go-test-shard` and `test-integration-shard` now reconstruct Homebrew `icu4c` CGO include and library paths on macOS after they scrub the environment with `env -i`. This prevents Dolt/go-icu-regex test builds from failing with `unicode/regex.h file not found` in the Mac integration package jobs.

The logic mirrors the existing Makefile behavior instead of widening the preserved environment. The integration shard exports the detected flags so child shard scripts inherit the same paths, and both scripts avoid double-adding the icu4c include path when nested.

## Review notes

- The change is scoped to `scripts/test-go-test-shard` and `scripts/test-integration-shard`.
- Linux and non-Homebrew macOS hosts remain no-op paths.
- No workflow, Makefile, Go package, or dashboard behavior changes are included.

## Test plan

- [x] `bash -n scripts/test-go-test-shard scripts/test-integration-shard`
- [x] `go vet ./...`
- [x] Targeted fake-Darwin smoke for icu4c flag append and nested duplicate avoidance
- [x] `LOCAL_TEST_JOBS=8 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel`
- [x] GitHub required checks green on `57063ba94`
- [x] Release gate: [`release-gates/ga-blx3e3-icu4c-cgo-paths-gate.md`](release-gates/ga-blx3e3-icu4c-cgo-paths-gate.md)