### PR TITLE
fix(skills): make materialize-skills pre_start non-fatal for unresolvable agents

### DIFF
--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -40,6 +40,7 @@ func newInternalCmd(stdout, stderr io.Writer) *cobra.Command {
 // build desired set → materialize. Never invoked by humans directly.
 func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 	var agentName, workdir, sharedCatalogSnapshot, sharedCatalogSnapshotFile string
+	var bestEffort bool
 	cmd := &cobra.Command{
 		Use:    "materialize-skills",
 		Short:  "Materialize skills for one agent into one workdir",
@@ -66,6 +67,17 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			agent, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
 			if !ok {
+				if bestEffort {
+					// Named/wisp session expansions pass a session identity
+					// (e.g. "rig/executor-vc-eswi4") that can't be resolved back
+					// to a config template. Skills materialization is best-effort
+					// session preparation, not a hard prerequisite, so in
+					// best-effort mode (the pre_start caller) warn and exit 0
+					// rather than failing the whole session start (the session
+					// runs without a freshly materialized skill catalog).
+					fmt.Fprintf(stderr, "gc internal materialize-skills: unknown agent %q; skipping (best-effort)\n", agentName) //nolint:errcheck // best-effort stderr
+					return nil
+				}
 				fmt.Fprintf(stderr, "gc internal materialize-skills: unknown agent %q\n", agentName) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
@@ -116,6 +128,7 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&workdir, "workdir", "", "agent working directory (skills materialize into workdir/.<vendor>/skills/)")
 	cmd.Flags().StringVar(&sharedCatalogSnapshot, "shared-catalog-snapshot", "", "base64-encoded shared catalog snapshot from the controller")
 	cmd.Flags().StringVar(&sharedCatalogSnapshotFile, "shared-catalog-snapshot-file", "", "path to a file containing the base64-encoded shared catalog snapshot (preferred over --shared-catalog-snapshot for large catalogs to avoid argv/env limits)")
+	cmd.Flags().BoolVar(&bestEffort, "best-effort", false, "warn and exit 0 instead of failing when the agent can't be resolved; used by pre_start so an unresolvable session identity (named/wisp expansion) doesn't make session start fatal")
 	return cmd
 }
 

--- a/cmd/gc/cmd_internal_materialize_skills_test.go
+++ b/cmd/gc/cmd_internal_materialize_skills_test.go
@@ -800,3 +800,40 @@ func writeMaterializeTestMayor(t *testing.T, cityDir, body string) {
 		t.Fatalf("WriteFile(%s): %v", filepath.Join("agents", "mayor", "agent.toml"), err)
 	}
 }
+
+// TestInternalMaterializeSkillsBestEffortSkipsUnknownAgent guards the pre_start
+// robustness fix: a session identity that can't be resolved to a config template
+// (named/wisp expansions like "rig/executor-vc-eswi4") must be FATAL for a direct
+// call but a warn-and-exit-0 skip under --best-effort, so the materialize-skills
+// pre_start command can't make session start fatal.
+func TestInternalMaterializeSkillsBestEffortSkipsUnknownAgent(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", "[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n")
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
+
+	workdir := t.TempDir()
+	const unresolvable = "rig/executor-vc-eswi4"
+
+	// Direct call (no --best-effort): unresolvable agent is fatal.
+	var so, se bytes.Buffer
+	if code := run([]string{"internal", "materialize-skills", "--agent", unresolvable, "--workdir", workdir}, &so, &se); code == 0 {
+		t.Fatalf("unknown agent without --best-effort: got exit 0, want non-zero; stderr=%q", se.String())
+	}
+
+	// --best-effort: warn and exit 0 so pre_start (session start) is not fatal.
+	so.Reset()
+	se.Reset()
+	if code := run([]string{"internal", "materialize-skills", "--best-effort", "--agent", unresolvable, "--workdir", workdir}, &so, &se); code != 0 {
+		t.Fatalf("unknown agent with --best-effort: exit %d, want 0; stderr=%q", code, se.String())
+	}
+	if !strings.Contains(se.String(), "best-effort") {
+		t.Fatalf("expected a best-effort skip warning on stderr, got %q", se.String())
+	}
+}

--- a/cmd/gc/skill_integration.go
+++ b/cmd/gc/skill_integration.go
@@ -387,7 +387,7 @@ func writeSkillBullets(b *strings.Builder, entries []materialize.SkillEntry, ori
 // setup) with "gc" as a fallback if the env var isn't available at
 // PreStart expansion time. Argument values are shell-quoted.
 func appendMaterializeSkillsPreStart(prestart []string, qualifiedName, workDir string) []string {
-	cmd := `"${GC_BIN:-gc}" internal materialize-skills --agent ` +
+	cmd := `"${GC_BIN:-gc}" internal materialize-skills --best-effort --agent ` +
 		shellquote.Join([]string{qualifiedName}) + ` --workdir ` + shellquote.Join([]string{workDir})
 	return append(prestart, cmd)
 }


### PR DESCRIPTION
## Problem

A pool/wisp/named-session expansion runs its `pre_start` with the **session identity** (e.g. `rig/executor-vc-eswi4`), which `resolveAgentIdentity` cannot map back to a config template — so `gc internal materialize-skills` exits 1. `runPreStart` treats any `pre_start` failure as **fatal**, so the session **never starts** and is reaped as "stuck-creating (tmux not found)". A pool can spawn **zero** sessions despite ample work, churning forever.

This failure mode is already acknowledged in `cmd/gc/agent_build_params.go`'s `templateNameFor` comment ("…can't map it back to the template, so `gc internal materialize-skills` exits 1").

## Change

Skills materialization is **best-effort** session preparation, not a hard prerequisite — a session can run without a freshly materialized catalog. Add a `--best-effort` flag to `gc internal materialize-skills` that **warns and exits 0** (instead of failing) when the agent can't be resolved, and pass it from the materialize-skills `pre_start` command (`appendMaterializeSkillsPreStart`).

- Direct/standalone callers (no flag) keep the strict exit-1 behavior (typo detection).
- Only the unresolvable-agent path is affected; real errors (missing flags, config load, write failures) stay fatal.

## Tests

`TestInternalMaterializeSkillsBestEffortSkipsUnknownAgent` — an unresolvable identity is fatal without the flag and a warn-and-exit-0 skip with `--best-effort`.

## Note

This flips the `pre_start` command shape, so already-running sessions will re-fingerprint and restart **once** on upgrade.