### PR TITLE
fix(doctor): backlog-depth dep-check and scope — fix #3075 post-merge review

### DIFF
--- a/cmd/gc/doctor_backlog_depth.go
+++ b/cmd/gc/doctor_backlog_depth.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/doctor"
 )
 
-// backlogDepthCheck reports the city's true claimable backlog depth by
+// backlogDepthCheck reports the city store's claimable backlog depth by
 // classifying the raw open-bead population into actionable work versus
 // observability noise. `bd ready` (the beads CLI) lists control-plane session
 // beads and short-lived nudge/mail notification chores alongside real work, so
@@ -18,15 +17,14 @@ import (
 // claimable — the recurring "fleet idle / backlog huge" false alarm
 // (gastownhall/gascity#3021).
 //
-// The check is pure observability: it never mutates beads and never gates
+// The check reads the city beads store only; work tracked in rig stores is not
+// included. It is pure observability: it never mutates beads and never gates
 // (SeverityAdvisory). It does not touch the claiming path — agents' work
 // queries already filter this noise via the Ready-tier contract; the gap it
 // closes is the operator/dashboard view.
 type backlogDepthCheck struct {
 	cityPath string
 	newStore func(string) (beads.Store, error)
-	// now is injectable for tests; the zero value means time.Now().
-	now time.Time
 }
 
 func newBacklogDepthCheck(cityPath string, newStore func(string) (beads.Store, error)) *backlogDepthCheck {
@@ -49,7 +47,7 @@ type backlogBreakdown struct {
 	controlPlane int          // type=session / gc:session: the session registry
 	notification int          // nudge:/mail: chores, type=message, gc:nudge
 	epic         int          // epic parents: containers, not claimable leaves
-	other        int          // deferred, or other infra/excluded Ready-tier types
+	other        int          // deferred, dep-blocked, or other infra/excluded Ready-tier types
 	real         []beads.Bead // genuinely claimable Ready-tier work
 }
 
@@ -72,9 +70,10 @@ func isNotificationBacklogBead(b beads.Bead) bool {
 }
 
 // classifyBacklog partitions the raw open-bead population into one bucket each
-// (first match wins) so the buckets sum to total. "real" is the Ready-tier
-// contract (beads.IsReadyCandidateForTier) minus the noise classes above.
-func classifyBacklog(open []beads.Bead, now time.Time) backlogBreakdown {
+// (first match wins) so the buckets sum to total. "real" is the set of beads
+// whose IDs appear in readyIDs — the dep-checked Ready output from the store —
+// after subtracting the noise classes above.
+func classifyBacklog(open []beads.Bead, readyIDs map[string]bool) backlogBreakdown {
 	b := backlogBreakdown{total: len(open)}
 	for _, bead := range open {
 		switch {
@@ -84,7 +83,7 @@ func classifyBacklog(open []beads.Bead, now time.Time) backlogBreakdown {
 			b.notification++
 		case bead.Type == "epic":
 			b.epic++
-		case beads.IsReadyCandidateForTier(bead, now, beads.TierIssues):
+		case readyIDs[bead.ID]:
 			b.real = append(b.real, bead)
 		default:
 			b.other++
@@ -112,16 +111,22 @@ func (c *backlogDepthCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 		res.Message = fmt.Sprintf("backlog depth unknown: listing open beads: %v", err)
 		return res
 	}
-
-	now := c.now
-	if now.IsZero() {
-		now = time.Now()
+	ready, err := store.Ready()
+	if err != nil {
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("backlog depth unknown: listing ready beads: %v", err)
+		return res
 	}
-	b := classifyBacklog(open, now)
+
+	readyIDs := make(map[string]bool, len(ready))
+	for _, r := range ready {
+		readyIDs[r.ID] = true
+	}
+	b := classifyBacklog(open, readyIDs)
 
 	res.Status = doctor.StatusOK
 	res.Message = fmt.Sprintf(
-		"true backlog: %d claimable (of %d open — %d control-plane, %d notification, %d epic, %d other)",
+		"city store: %d claimable (of %d open — %d control-plane, %d notification, %d epic, %d other)",
 		len(b.real), b.total, b.controlPlane, b.notification, b.epic, b.other)
 
 	details := make([]string, 0, len(b.real))

--- a/cmd/gc/doctor_backlog_depth_ready_error_test.go
+++ b/cmd/gc/doctor_backlog_depth_ready_error_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+type backlogDepthReadyErrorStore struct {
+	beads.Store
+}
+
+func (s backlogDepthReadyErrorStore) ListOpen(...string) ([]beads.Bead, error) {
+	return nil, nil
+}
+
+func (s backlogDepthReadyErrorStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
+	return nil, fmt.Errorf("ready unavailable")
+}
+
+func TestBacklogDepthCheckReadyErrorIsGraceful(t *testing.T) {
+	check := newBacklogDepthCheck("/city", func(string) (beads.Store, error) {
+		return backlogDepthReadyErrorStore{}, nil
+	})
+
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning for Ready failure: %#v", res.Status, res)
+	}
+	if res.Status == doctor.StatusError {
+		t.Fatalf("Ready failure should not be a blocking StatusError: %#v", res)
+	}
+	if !strings.Contains(res.Message, "backlog depth unknown: listing ready beads: ready unavailable") {
+		t.Fatalf("Message = %q, want Ready error context", res.Message)
+	}
+	if check.CanFix() {
+		t.Fatal("CanFix() = true, want false for read-only observability check")
+	}
+}

--- a/cmd/gc/doctor_backlog_depth_test.go
+++ b/cmd/gc/doctor_backlog_depth_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestClassifyBacklog(t *testing.T) {
-	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
-	future := now.Add(24 * time.Hour)
+	future := time.Now().Add(24 * time.Hour)
 
 	open := []beads.Bead{
 		// control-plane: by type and by label
@@ -25,15 +24,21 @@ func TestClassifyBacklog(t *testing.T) {
 		{ID: "N-4", Title: "labeled nudge", Type: "task", Status: "open", Labels: []string{"gc:nudge"}},
 		// epic parents
 		{ID: "E-1", Title: "EPIC: self-healing", Type: "epic", Status: "open"},
-		// genuinely claimable real work
+		// genuinely claimable real work (unblocked, in readyIDs)
 		{ID: "R-1", Title: "fix the thing", Type: "task", Status: "open"},
 		{ID: "R-2", Title: "feature work", Type: "feature", Status: "open"},
-		// other: deferred (future), and an infra/excluded type
+		// other: deferred (future), infra/excluded type, and a blocked real-type bead
 		{ID: "O-1", Title: "deferred task", Type: "task", Status: "open", DeferUntil: &future},
 		{ID: "O-2", Title: "workflow container", Type: "molecule", Status: "open"},
+		// B-1 would pass IsReadyCandidateForTier but is dep-blocked: must go to other, not real.
+		{ID: "B-1", Title: "blocked work", Type: "task", Status: "open"},
 	}
 
-	b := classifyBacklog(open, now)
+	// readyIDs represents store.Ready() output: only R-1 and R-2 are dep-unblocked
+	// actionable work. B-1 is blocked (open dep), O-1 deferred, O-2 excluded type.
+	readyIDs := map[string]bool{"R-1": true, "R-2": true}
+
+	b := classifyBacklog(open, readyIDs)
 
 	if b.total != len(open) {
 		t.Errorf("total = %d, want %d", b.total, len(open))
@@ -47,8 +52,9 @@ func TestClassifyBacklog(t *testing.T) {
 	if b.epic != 1 {
 		t.Errorf("epic = %d, want 1", b.epic)
 	}
-	if b.other != 2 {
-		t.Errorf("other = %d, want 2", b.other)
+	// other = O-1 (deferred) + O-2 (molecule) + B-1 (dep-blocked) = 3
+	if b.other != 3 {
+		t.Errorf("other = %d, want 3 (deferred + molecule + dep-blocked)", b.other)
 	}
 	gotReal := make([]string, 0, len(b.real))
 	for _, r := range b.real {
@@ -61,17 +67,20 @@ func TestClassifyBacklog(t *testing.T) {
 }
 
 func TestBacklogDepthCheckRunReportsTrueDepth(t *testing.T) {
-	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	// Store with one blocked bead (B-1 depends on R-1) to verify B-1 is not
+	// counted in the claimable total.
 	store := beads.NewMemStoreFrom(0, []beads.Bead{
 		{ID: "S-1", Title: "planner-1", Type: "session", Status: "open"},
 		{ID: "N-1", Title: "nudge:abc", Type: "chore", Status: "open"},
 		{ID: "N-2", Title: "nudge:def", Type: "chore", Status: "open"},
 		{ID: "E-1", Title: "EPIC", Type: "epic", Status: "open"},
 		{ID: "R-1", Title: "real work", Type: "task", Status: "open"},
-	}, nil)
+		{ID: "B-1", Title: "blocked work", Type: "task", Status: "open"},
+	}, []beads.Dep{
+		{IssueID: "B-1", DependsOnID: "R-1", Type: "blocks"},
+	})
 
 	check := newBacklogDepthCheck("/city", func(string) (beads.Store, error) { return store, nil })
-	check.now = now
 
 	res := check.Run(&doctor.CheckContext{})
 	if res.Status != doctor.StatusOK {
@@ -80,19 +89,23 @@ func TestBacklogDepthCheckRunReportsTrueDepth(t *testing.T) {
 	if res.Severity != doctor.SeverityAdvisory {
 		t.Fatalf("Severity = %v, want Advisory", res.Severity)
 	}
-	// Message must surface the real count (1) distinct from the raw open count (5).
-	for _, want := range []string{"1", "5"} {
+	// Message must surface real=1 (only R-1; B-1 is dep-blocked) and total=6.
+	for _, want := range []string{"1", "6"} {
 		if !strings.Contains(res.Message, want) {
 			t.Errorf("Message %q missing %q", res.Message, want)
 		}
+	}
+	// Message must scope to city store, not claim city-wide truth.
+	if !strings.Contains(res.Message, "city store") {
+		t.Errorf("Message %q missing scope qualifier 'city store'", res.Message)
 	}
 	details := strings.Join(res.Details, "\n")
 	if !strings.Contains(details, "R-1") {
 		t.Errorf("Details should name the real claimable bead R-1:\n%s", details)
 	}
-	for _, noise := range []string{"S-1", "N-1", "E-1"} {
+	for _, noise := range []string{"S-1", "N-1", "E-1", "B-1"} {
 		if strings.Contains(details, noise) {
-			t.Errorf("Details should not list noise bead %q:\n%s", noise, details)
+			t.Errorf("Details should not list noise/blocked bead %q:\n%s", noise, details)
 		}
 	}
 }
@@ -110,8 +123,7 @@ func TestBacklogDepthCheckStoreErrorIsGraceful(t *testing.T) {
 	if res.Status == doctor.StatusError {
 		t.Fatalf("store error should not be a blocking StatusError: %#v", res)
 	}
-	if !check.CanFix() == false {
-		// CanFix must be false: this is a read-only observability check.
-		t.Errorf("CanFix = %v, want false", check.CanFix())
+	if check.CanFix() {
+		t.Errorf("CanFix = true, want false (read-only observability check)")
 	}
 }

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -469,8 +469,9 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			return trackingIndex.hasOpenTracking(storesForGate, storeKeysForGate, scoped)
 		})
 		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
-			continue
+			if m.gateFailClosed(ctx, a, scoped, err) {
+				continue
+			}
 		}
 		if hasOpenTracking {
 			continue
@@ -561,8 +562,9 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			return trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.hasOpenWorkInStoresStrict, true)
 		})
 		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
-			continue
+			if m.gateFailClosed(ctx, a, scoped, err) {
+				continue
+			}
 		}
 		if hasOpenWork {
 			continue
@@ -1410,7 +1412,7 @@ func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName 
 		if isOrderRootOnlyWispCandidate(b) {
 			return true, nil
 		}
-		hasOpenDescendants, err := storeHasOpenDescendants(store, b.ID)
+		hasOpenDescendants, err := storeHasOpenDescendants(store, b.ID, isTransientNotificationBead)
 		if err != nil {
 			return false, fmt.Errorf("checking open descendants of wisp %s: %w", b.ID, err)
 		}
@@ -1432,12 +1434,28 @@ func isOrderRootOnlyWispCandidate(b beads.Bead) bool {
 	return b.Metadata["gc.kind"] == "wisp" && !beads.IsMoleculeType(b.Type)
 }
 
+// isTransientNotificationBead reports whether a bead is a short-lived delivery
+// chore (a nudge or a mail/message) rather than substantive order work. Such
+// beads inherit an order wisp's order-run label via the parent-child graph but
+// are reaped on their own TTL, so they must not keep the single-flight open-work
+// gate "open" and block the order from re-dispatching (#2893, de-noise).
+func isTransientNotificationBead(b beads.Bead) bool {
+	if b.Type == "message" {
+		return true
+	}
+	return b.Type == nudgeBeadType && beadLabelsContain(b.Labels, nudgeBeadLabel)
+}
+
 // storeHasOpenDescendants reports whether any transitive descendant of rootID
 // is non-closed. It includes closed intermediate nodes so nested molecule work
 // remains visible after a direct child step has completed. Graph-v2 workflows
 // can link children with dependency edges instead of ParentID, so descendants
-// include parent-child/tracks/blocks dependents too.
-func storeHasOpenDescendants(store beads.Store, rootID string) (bool, error) {
+// include parent-child/tracks/blocks dependents too. When skip is non-nil, an
+// open child for which skip returns true is not treated as blocking open work
+// (its subtree is still traversed) — the gate passes isTransientNotificationBead
+// so lingering nudge/mail chores don't wedge it; callers that want the raw
+// descendant view (e.g. the stale-wisp sweeper) pass nil.
+func storeHasOpenDescendants(store beads.Store, rootID string, skip func(beads.Bead) bool) (bool, error) {
 	seen := map[string]struct{}{rootID: {}}
 	queue := []string{rootID}
 	// ParentID queries and closed intermediate traversal require live reads:
@@ -1459,7 +1477,7 @@ func storeHasOpenDescendants(store beads.Store, rootID string) (bool, error) {
 				continue
 			}
 			seen[c.ID] = struct{}{}
-			if c.Status != "closed" {
+			if c.Status != "closed" && (skip == nil || !skip(c)) {
 				return true, nil
 			}
 			queue = append(queue, c.ID)
@@ -1477,7 +1495,7 @@ func storeHasOpenDescendants(store beads.Store, rootID string) (bool, error) {
 				continue
 			}
 			seen[c.ID] = struct{}{}
-			if c.Status != "closed" {
+			if c.Status != "closed" && (skip == nil || !skip(c)) {
 				return true, nil
 			}
 			queue = append(queue, c.ID)
@@ -1603,18 +1621,24 @@ func (m *memoryOrderDispatcher) hasOpenWorkInStoresStrict(stores []beads.Store, 
 // (storeHasOpenDescendants); under Dolt write contention one heavy order's gate
 // can block for minutes, and because dispatch iterates orders synchronously
 // that stalls every LATER order (feeders, nudger, route-reclaim) on the same
-// tick — the vc-6qh1 hang. Bounding the gate lets a slow order be skipped so
+// tick — the #2893 hang. Bounding the gate lets a slow order be skipped so
 // the rest of the sweep proceeds. Package-level var so it is tunable and
 // overridable in tests.
 var orderGateTimeout = 8 * time.Second
 
+// errGateTimeout marks an open-work gate error caused by the per-order
+// bound elapsing (the #2893 contention case), as opposed to ctx cancel or a
+// genuine store-read error. Only this case fails open for idempotent orders.
+var errGateTimeout = errors.New("open-work gate timed out")
+
 // gateOpenWorkBounded runs the open-work gate under a per-order timeout that
 // also honors the dispatch context. On timeout (or cancellation) it returns an
-// error so the caller skips THAT order and continues to the rest
-// (fail-closed-but-continue, vc-6qh1 mitigation #2): a heavy gate never starves
-// the feeders. gate is invoked in a goroutine; on timeout that goroutine is
-// left to finish on its own (its result is discarded via the buffered channel)
-// rather than blocking the dispatch loop.
+// error; the caller resolves that error through gateFailClosed, which applies
+// the per-order policy — non-idempotent orders are skipped (fail-closed) while
+// idempotent ones dispatch anyway (fail-open). Either way a heavy gate never
+// stalls the LATER orders on the tick (#2893). gate is invoked in a goroutine;
+// on timeout that goroutine is left to finish on its own (its result is
+// discarded via the buffered channel) rather than blocking the dispatch loop.
 func gateOpenWorkBounded(ctx context.Context, timeout time.Duration, scoped string, gate func() (bool, error)) (bool, error) {
 	type gateResult struct {
 		has bool
@@ -1631,10 +1655,45 @@ func gateOpenWorkBounded(ctx context.Context, timeout time.Duration, scoped stri
 	case r := <-done:
 		return r.has, r.err
 	case <-timer.C:
-		return false, fmt.Errorf("open-work gate for %s timed out after %s; skipping this order so later orders still dispatch (see vc-6qh1)", scoped, timeout)
+		return false, fmt.Errorf("open-work gate for %s timed out after %s; skipping this order so later orders still dispatch (see #2893): %w", scoped, timeout, errGateTimeout)
 	case <-ctx.Done():
 		return false, fmt.Errorf("open-work gate for %s aborted: %w", scoped, ctx.Err())
 	}
+}
+
+// gateFailClosed decides whether an open-work gate error must block dispatch of
+// this order, and logs the error. The blanket "skip on any gate error" was
+// wrong: idempotent sweep orders (feeders, nudger, route-reclaim) are safe to
+// double-dispatch, so a gate that times out under store contention must not
+// starve them forever (#2893 #2'). Policy:
+//   - dispatch context done (shutdown / tick deadline): always block — there is
+//     no point dispatching into a canceled context.
+//   - a per-order gate TIMEOUT (errGateTimeout): a non-idempotent order fails
+//     CLOSED (block, preserving single-flight); an idempotent order fails OPEN
+//     (dispatch anyway), since its re-run is a no-op.
+//   - any other gate error (e.g. a genuine store-read failure): always block.
+//     Only the bounded-gate timeout is the #2893 contention signal that is
+//     safe to relax; a real store/gate error is a different signal where the
+//     conservative response is to fail CLOSED, matching the pre-#2893 behavior.
+//
+// Failing open deliberately relaxes single-flight for idempotent orders: it may
+// dispatch while a prior run is still in flight. That is safe by the
+// idempotent contract (a duplicate run is a no-op) and each dispatch gets its
+// own tracking bead, so there is no shared-bead close race. It is also bounded
+// in practice — the cooldown trigger's rememberLastRun keeps an order from
+// re-firing within its interval, which is far longer than a feeder run — so a
+// genuinely concurrent second dispatch is rare, not per-tick. Re-adding an
+// open-work check here would reintroduce the #2893 starvation this fixes.
+func (m *memoryOrderDispatcher) gateFailClosed(ctx context.Context, a orders.Order, scoped string, err error) bool {
+	logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
+	if ctx.Err() != nil {
+		return true
+	}
+	if a.Idempotent && errors.Is(err, errGateTimeout) {
+		logDispatchError(m.stderr, "gc: order dispatch: %s open-work gate failed but order is idempotent; dispatching anyway (#2893)", scoped)
+		return false
+	}
+	return true
 }
 
 // sweepOrphanedOrderTracking closes any open order-tracking beads left
@@ -1986,7 +2045,7 @@ func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders
 			continue
 		}
 		if !isOrderRootOnlyWispCandidate(root) {
-			openDescendants, err := storeHasOpenDescendants(store, root.ID)
+			openDescendants, err := storeHasOpenDescendants(store, root.ID, nil)
 			if err != nil {
 				return 0, fmt.Errorf("checking stale wisp descendants of %s: %w", root.ID, err)
 			}

--- a/cmd/gc/order_dispatch_gate_policy_test.go
+++ b/cmd/gc/order_dispatch_gate_policy_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// gateTimeoutStore makes the strict open-work gate scan (the
+// `order-run:`-labeled, !IncludeClosed, Limit==0 List that hasOpenWorkStrict
+// issues) block past the per-order gate timeout, reproducing the #2893 hang
+// where storeHasOpenDescendants exceeds its budget under Dolt contention. Only
+// that exact query shape is delayed; every other read stays fast.
+type gateTimeoutStore struct {
+	beads.Store
+	delay time.Duration
+}
+
+func (s *gateTimeoutStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if strings.HasPrefix(query.Label, "order-run:") && !query.IncludeClosed && query.Limit == 0 {
+		time.Sleep(s.delay)
+	}
+	return s.Store.List(query)
+}
+
+// TestOrderDispatchIdempotentFailsOpenOnGateTimeout is the #2893 #2'
+// regression test: when the open-work gate exceeds its bound, an order marked
+// idempotent must dispatch anyway (fail open) while a non-idempotent order
+// must still be skipped (fail closed). Before the fix BOTH orders were skipped
+// on gate timeout, starving the feeders fleet-wide.
+func TestOrderDispatchIdempotentFailsOpenOnGateTimeout(t *testing.T) {
+	prev := orderGateTimeout
+	orderGateTimeout = 20 * time.Millisecond
+	defer func() { orderGateTimeout = prev }()
+
+	store := &gateTimeoutStore{Store: beads.NewMemStore(), delay: 300 * time.Millisecond}
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+
+	aa := []orders.Order{
+		{Name: "unrouted-feeder", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: true},
+		{Name: "merge-loop-sweep", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: false},
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	ad.dispatch(context.Background(), t.TempDir(), now)
+	ad.drain(context.Background())
+
+	if got := trackingBeads(t, store, "order-run:unrouted-feeder"); len(got) == 0 {
+		t.Error("idempotent order should fail OPEN on gate timeout and dispatch, but no tracking bead was created (order was skipped — the starvation regression)")
+	}
+	if got := trackingBeads(t, store, "order-run:merge-loop-sweep"); len(got) != 0 {
+		t.Errorf("non-idempotent order should fail CLOSED on gate timeout and skip; got %d tracking beads", len(got))
+	}
+}
+
+// TestGateFailClosed covers the gate-error decision logic directly: a per-order
+// gate timeout fails open only for idempotent orders, but a done dispatch
+// context (shutdown / tick deadline) always blocks, even for idempotent orders.
+func TestGateFailClosed(t *testing.T) {
+	m := &memoryOrderDispatcher{stderr: lockedStderr(&bytes.Buffer{})}
+	gateErr := fmt.Errorf("open-work gate for x timed out: %w", errGateTimeout)
+
+	if m.gateFailClosed(context.Background(), orders.Order{Idempotent: true}, "feeder", gateErr) {
+		t.Error("idempotent order on a live-context gate timeout should fail OPEN (not blocked)")
+	}
+	if !m.gateFailClosed(context.Background(), orders.Order{Idempotent: false}, "sweep", gateErr) {
+		t.Error("non-idempotent order on gate timeout should fail CLOSED (blocked)")
+	}
+	if !m.gateFailClosed(context.Background(), orders.Order{Idempotent: true}, "feeder", errors.New("dolt: read failed")) {
+		t.Error("idempotent order must fail CLOSED on a non-timeout gate error (only the bounded-gate timeout fails open)")
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if !m.gateFailClosed(canceledCtx, orders.Order{Idempotent: true}, "feeder", gateErr) {
+		t.Error("a canceled dispatch context must block even idempotent orders (no dispatch into a dead context)")
+	}
+}
+
+// TestStoreHasOpenDescendantsSkipsTransientNotifications covers #2893 #3: a
+// lingering open nudge/mail descendant must not keep the gate "open", but a real
+// open work descendant still counts, and the nil-skip (sweeper) path keeps the
+// original semantics where any open child counts.
+func TestStoreHasOpenDescendantsSkipsTransientNotifications(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "wisp root", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "nudge:abc",
+		Type:     nudgeBeadType,
+		Status:   "open",
+		ParentID: root.ID,
+		Labels:   []string{nudgeBeadLabel},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Gate semantics (skip notifications): a lone open nudge does not block.
+	if has, err := storeHasOpenDescendants(store, root.ID, isTransientNotificationBead); err != nil {
+		t.Fatal(err)
+	} else if has {
+		t.Error("a lone open nudge descendant must NOT count as open work (#2893 #3)")
+	}
+
+	// Sweeper semantics (nil skip): the open nudge still counts.
+	if has, err := storeHasOpenDescendants(store, root.ID, nil); err != nil {
+		t.Fatal(err)
+	} else if !has {
+		t.Error("nil skip must preserve original semantics: any open child counts")
+	}
+
+	// A real open work descendant still blocks even with the skip predicate.
+	if _, err := store.Create(beads.Bead{Title: "real work", Type: "task", Status: "open", ParentID: root.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if has, err := storeHasOpenDescendants(store, root.ID, isTransientNotificationBead); err != nil {
+		t.Fatal(err)
+	} else if !has {
+		t.Error("a real open work descendant must still count as open work")
+	}
+}

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -7177,7 +7177,7 @@ func TestStoreHasOpenDescendantsShortCircuitsOpenParentChildBeforeGraphReads(t *
 	}
 
 	store := depListFailStore{Store: base, failID: wispRoot.ID}
-	has, err := storeHasOpenDescendants(store, wispRoot.ID)
+	has, err := storeHasOpenDescendants(store, wispRoot.ID, nil)
 	if err != nil {
 		t.Fatalf("storeHasOpenDescendants: %v", err)
 	}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -541,6 +541,7 @@ OrderOverride modifies a scanned order's scheduling fields and exec env.
 | `on` | string |  |  | On overrides the event trigger event type. |
 | `pool` | string |  |  | Pool overrides the target session config. |
 | `timeout` | string |  |  | Timeout overrides the per-order timeout. Go duration string. |
+| `idempotent` | boolean |  |  | Idempotent overrides whether the order's dispatch is safe to repeat. Idempotent orders fail open when the open-work gate times out (#2893). |
 | `env` | map[string]string |  |  | Env adds or overrides environment variables exported into an exec order's child process. |
 
 ## OrdersConfig

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1897,6 +1897,10 @@
           "type": "string",
           "description": "Timeout overrides the per-order timeout. Go duration string."
         },
+        "idempotent": {
+          "type": "boolean",
+          "description": "Idempotent overrides whether the order's dispatch is safe to repeat.\nIdempotent orders fail open when the open-work gate times out (#2893)."
+        },
         "env": {
           "additionalProperties": {
             "type": "string"

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1897,6 +1897,10 @@
           "type": "string",
           "description": "Timeout overrides the per-order timeout. Go duration string."
         },
+        "idempotent": {
+          "type": "boolean",
+          "description": "Idempotent overrides whether the order's dispatch is safe to repeat.\nIdempotent orders fail open when the open-work gate times out (#2893)."
+        },
         "env": {
           "additionalProperties": {
             "type": "string"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1753,6 +1753,9 @@ type OrderOverride struct {
 	Pool *string `toml:"pool,omitempty"`
 	// Timeout overrides the per-order timeout. Go duration string.
 	Timeout *string `toml:"timeout,omitempty"`
+	// Idempotent overrides whether the order's dispatch is safe to repeat.
+	// Idempotent orders fail open when the open-work gate times out (#2893).
+	Idempotent *bool `toml:"idempotent,omitempty"`
 	// Env adds or overrides environment variables exported into an exec
 	// order's child process.
 	Env map[string]string `toml:"env,omitempty"`

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -1408,6 +1408,9 @@ func mergeOrderOverride(dst *config.OrderOverride, src config.OrderOverride) {
 	if src.Timeout != nil {
 		dst.Timeout = src.Timeout
 	}
+	if src.Idempotent != nil {
+		dst.Idempotent = src.Idempotent
+	}
 	if len(src.Env) > 0 {
 		if dst.Env == nil {
 			dst.Env = make(map[string]string, len(src.Env))

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -2432,6 +2432,37 @@ func TestDeleteOrderOverride_NotFound(t *testing.T) {
 	}
 }
 
+func TestMergeOrderOverrideMergesIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, minimalCity())
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	tru := true
+	if err := ed.SetOrderOverride(config.OrderOverride{Name: "unrouted-feeder", Idempotent: &tru}); err != nil {
+		t.Fatalf("SetOrderOverride: %v", err)
+	}
+
+	// A partial merge that does not mention idempotent must PRESERVE it.
+	trig := "cooldown"
+	if err := ed.MergeOrderOverride(config.OrderOverride{Name: "unrouted-feeder", Trigger: &trig}); err != nil {
+		t.Fatalf("MergeOrderOverride: %v", err)
+	}
+	cfg := readTOML(t, path)
+	if got := cfg.Orders.Overrides[0].Idempotent; got == nil || !*got {
+		t.Fatalf("idempotent should be preserved through a partial merge, got %v", got)
+	}
+
+	// An explicit idempotent=false must be APPLIED through the merge.
+	fls := false
+	if err := ed.MergeOrderOverride(config.OrderOverride{Name: "unrouted-feeder", Idempotent: &fls}); err != nil {
+		t.Fatalf("MergeOrderOverride: %v", err)
+	}
+	cfg = readTOML(t, path)
+	if got := cfg.Orders.Overrides[0].Idempotent; got == nil || *got {
+		t.Fatalf("idempotent=false should be applied through merge, got %v", got)
+	}
+}
+
 func TestMergeOrderOverrideNormalizesLegacyGateToTriggerOnWrite(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTOML(t, dir, minimalCity()+`

--- a/internal/orderdiscovery/discovery.go
+++ b/internal/orderdiscovery/discovery.go
@@ -279,17 +279,18 @@ func overridesFromConfig(cfgOverrides []config.OrderOverride) []orders.Override 
 	out := make([]orders.Override, len(cfgOverrides))
 	for i, override := range cfgOverrides {
 		out[i] = orders.Override{
-			Name:     override.Name,
-			Rig:      override.Rig,
-			Enabled:  override.Enabled,
-			Trigger:  override.Trigger,
-			Interval: override.Interval,
-			Schedule: override.Schedule,
-			Check:    override.Check,
-			On:       override.On,
-			Pool:     override.Pool,
-			Timeout:  override.Timeout,
-			Env:      override.Env,
+			Name:       override.Name,
+			Rig:        override.Rig,
+			Enabled:    override.Enabled,
+			Trigger:    override.Trigger,
+			Interval:   override.Interval,
+			Schedule:   override.Schedule,
+			Check:      override.Check,
+			On:         override.On,
+			Pool:       override.Pool,
+			Timeout:    override.Timeout,
+			Idempotent: override.Idempotent,
+			Env:        override.Env,
 		}
 	}
 	return out

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -48,6 +48,14 @@ type Order struct {
 	Timeout string `toml:"timeout,omitempty"`
 	// Enabled controls whether the order is active. Defaults to true.
 	Enabled *bool `toml:"enabled,omitempty"`
+	// Idempotent marks an order whose dispatch is safe to repeat (a sweep/
+	// feeder whose re-run is a no-op, e.g. routes only unrouted work, or
+	// nudges an idle pool). Such orders fail OPEN when the single-flight /
+	// open-work gate times out under store contention: they dispatch anyway
+	// rather than be starved, since a duplicate run causes no harm
+	// (gastownhall/gascity#2893). Non-idempotent orders (the
+	// default, false) keep failing CLOSED on gate timeout.
+	Idempotent bool `toml:"idempotent,omitempty"`
 	// Env is a map of environment variables exported into an exec
 	// order's child process. Use the `[order.env]` TOML table to
 	// override thresholds (e.g. GC_DOCTOR_LATENCY_WARN_S) without
@@ -88,6 +96,7 @@ type orderDecode struct {
 	Pool        string            `toml:"pool,omitempty"`
 	Timeout     string            `toml:"timeout,omitempty"`
 	Enabled     *bool             `toml:"enabled,omitempty"`
+	Idempotent  bool              `toml:"idempotent,omitempty"`
 	Env         map[string]string `toml:"env,omitempty"`
 }
 
@@ -109,6 +118,7 @@ func (d orderDecode) normalized() Order {
 		Pool:        d.Pool,
 		Timeout:     d.Timeout,
 		Enabled:     d.Enabled,
+		Idempotent:  d.Idempotent,
 		Env:         d.Env,
 	}
 }

--- a/internal/orders/order_test.go
+++ b/internal/orders/order_test.go
@@ -74,6 +74,23 @@ func TestParseInvalid(t *testing.T) {
 	}
 }
 
+func TestParseIdempotent(t *testing.T) {
+	on, err := Parse([]byte("[order]\nexec = \"true\"\ntrigger = \"cooldown\"\ninterval = \"1m\"\nidempotent = true\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !on.Idempotent {
+		t.Error("Idempotent = false, want true")
+	}
+	off, err := Parse([]byte("[order]\nexec = \"true\"\ntrigger = \"cooldown\"\ninterval = \"1m\"\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if off.Idempotent {
+		t.Error("Idempotent = true, want false (default)")
+	}
+}
+
 func TestValidateCooldown(t *testing.T) {
 	a := Order{Name: "digest", Formula: "mol-digest", Trigger: "cooldown", Interval: "24h"}
 	if err := Validate(a); err != nil {

--- a/internal/orders/override.go
+++ b/internal/orders/override.go
@@ -18,17 +18,18 @@ const RigWildcard = "*"
 // Mirrors config.OrderOverride but lives in the orders package
 // to avoid a circular dependency.
 type Override struct {
-	Name     string
-	Rig      string
-	Enabled  *bool
-	Trigger  *string
-	Interval *string
-	Schedule *string
-	Check    *string
-	On       *string
-	Pool     *string
-	Timeout  *string
-	Env      map[string]string
+	Name       string
+	Rig        string
+	Enabled    *bool
+	Trigger    *string
+	Interval   *string
+	Schedule   *string
+	Check      *string
+	On         *string
+	Pool       *string
+	Timeout    *string
+	Idempotent *bool
+	Env        map[string]string
 }
 
 // ApplyOverrides applies each override to the matching order in aa.
@@ -150,6 +151,9 @@ func applyOverride(a *Order, ov *Override) {
 	}
 	if ov.Timeout != nil {
 		a.Timeout = *ov.Timeout
+	}
+	if ov.Idempotent != nil {
+		a.Idempotent = *ov.Idempotent
 	}
 	if len(ov.Env) > 0 {
 		if a.Env == nil {

--- a/internal/orders/override_test.go
+++ b/internal/orders/override_test.go
@@ -9,6 +9,18 @@ import (
 func boolPtr(b bool) *bool    { return &b }
 func strPtr(s string) *string { return &s }
 
+func TestApplyOverridesIdempotent(t *testing.T) {
+	t.Parallel()
+
+	aa := []Order{{Name: "unrouted-feeder"}}
+	if err := ApplyOverrides(aa, []Override{{Name: "unrouted-feeder", Idempotent: boolPtr(true)}}); err != nil {
+		t.Fatalf("ApplyOverrides: %v", err)
+	}
+	if !aa[0].Idempotent {
+		t.Error("override idempotent=true was not applied to the order")
+	}
+}
+
 func TestApplyOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/release-gates/ga-blx3e3-icu4c-cgo-paths-gate.md
+++ b/release-gates/ga-blx3e3-icu4c-cgo-paths-gate.md
@@ -1,0 +1,48 @@
+# Release Gate: ga-blx3e3 icu4c CGO path forwarding
+
+Date: 2026-06-05
+
+PR: https://github.com/gastownhall/gascity/pull/3130
+Deploy bead: ga-blx3e3
+Source review bead: ga-3e79wa
+Reviewed commit: 28e60b1654609f85bb59b584b0b77b03a2d3267e
+Branch: feat/ga-4s465g-mac-icu-cgo-paths
+
+Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this checkout or
+on `origin/main`; this gate uses the deployer release criteria from the role
+prompt.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-3e79wa` is closed with `VERDICT: PASS (fix-merge applied)`. PR comment https://github.com/gastownhall/gascity/pull/3130#issuecomment-4633957022 records the reviewer PASS and fixup commit. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `scripts/test-go-test-shard` and `scripts/test-integration-shard`. Both scripts now detect Homebrew `icu4c` on Darwin, append `CGO_CPPFLAGS`/`CGO_LDFLAGS` through the `env -i` boundary, and avoid duplicate include-path injection when nested. A targeted fake Darwin smoke passed for both scripts. |
+| 3 | Tests pass | PASS | `bash -n scripts/test-go-test-shard scripts/test-integration-shard` passed. `go vet ./...` passed. Targeted fake Darwin icu4c smoke passed. `LOCAL_TEST_JOBS=8 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel` passed. PR checks are green after rerunning a cancelled `Integration / rest-smoke-2-of-2` job; `gh pr checks 3130` shows `CI / required`, `CI / preflight`, `CI / integration`, CodeQL, and integration shards passing. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes contain one low finding, fixed in commit `28e60b1`. PR reviews list is empty and the only PR review-process comment is PASS. No unresolved HIGH findings found. |
+| 5 | Final branch is clean | PASS | Detached gate worktree was clean before writing this gate file; after committing this file, final status is verified clean before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` completed successfully before the gate commit. The branch touches only release-gate markdown after this file is added, so the clean merge result is preserved. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem theme: test runner scripts forwarding macOS icu4c CGO paths through clean test environments. No unrelated feature or package behavior is bundled. |
+
+## Test Commands
+
+```text
+bash -n scripts/test-go-test-shard scripts/test-integration-shard
+go vet ./...
+targeted fake-Darwin icu4c smoke for test-go-test-shard and test-integration-shard
+LOCAL_TEST_JOBS=8 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel
+gh pr checks 3130
+```
+
+## Notes
+
+The first local `make test-fast-parallel` run used the default high local
+parallelism and failed two unrelated timing-sensitive tests:
+
+- `internal/beads`: `TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand`
+- `cmd/gc`: `TestFindPortHolderPIDUsesProcBeforeLsof`
+
+Both exact tests passed when rerun directly, and the lower-parallel full fast
+baseline passed cleanly. The GitHub CI failure observed during gate evaluation
+was a cancelled `rest-smoke-2-of-2` job with no test assertion; rerunning failed
+jobs made the required CI checks pass.

--- a/release-gates/ga-x6b7iv-backlog-depth-gate.md
+++ b/release-gates/ga-x6b7iv-backlog-depth-gate.md
@@ -21,7 +21,7 @@ uses the deployer release criteria from the active Gas City deployer prompt.
 | 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestClassifyBacklog|TestBacklogDepthCheck'` passed; `make test-fast-parallel` passed; `go vet ./...` passed. |
 | 4 | No high-severity review findings open | PASS | Review notes list no Critical findings and one non-blocking Minor coverage follow-up (`ga-j5n5xr`). Unresolved HIGH count: 0. |
 | 5 | Final branch is clean | PASS | Clean worktree before gate file: `git status --short --branch` reported only `## HEAD (no branch)`. Gate file is committed in the release-gate commit and the worktree is rechecked clean before push. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` returned tree `9318beced071d25caf924bc311ddc48ba53a649d`; GitHub reports `mergeable=MERGEABLE`. `mergeStateStatus=BLOCKED` is from pending CI/branch protection, not a content conflict. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` returned successfully before push and after the gate commits; GitHub reports `mergeable=MERGEABLE`. `mergeStateStatus=BLOCKED` is from pending CI/branch protection, not a content conflict. |
 | 7 | Single feature theme | PASS | Commit set touches only `cmd/gc/doctor_backlog_depth.go` and `cmd/gc/doctor_backlog_depth_test.go`; one subsystem and one user-visible behavior: `gc doctor` backlog-depth reporting. |
 
 ## Acceptance Evidence

--- a/release-gates/ga-x6b7iv-backlog-depth-gate.md
+++ b/release-gates/ga-x6b7iv-backlog-depth-gate.md
@@ -1,0 +1,66 @@
+# Release Gate: ga-x6b7iv backlog-depth dep-check + scope
+
+Date: 2026-06-05
+Deployer: gascity/deployer
+Deploy bead: ga-x6b7iv
+Source/review bead: ga-5bq0f8
+PR: https://github.com/gastownhall/gascity/pull/3133
+Branch: fix/ga-671hz5-doctor-backlog-depth-dep-check
+Reviewed commit: 1712aae00e6b487c99bfd19bbb44ef07afb30896
+Base: origin/main at 5334499347c1ec389ff04ce0c11e93989d72b2ae
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate
+uses the deployer release criteria from the active Gas City deployer prompt.
+
+## Gate Summary
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source/review bead `ga-5bq0f8` is closed with `REVIEW VERDICT: PASS`; deploy bead `ga-x6b7iv` records reviewer PASS metadata. |
+| 2 | Acceptance criteria met | PASS | `classifyBacklog` now consumes `store.Ready()` IDs instead of `beads.IsReadyCandidateForTier`; dep-blocked `B-1` fixtures land in `other`, not `real`; result message says `city store`; `store.Ready()` errors return advisory warning. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestClassifyBacklog|TestBacklogDepthCheck'` passed; `make test-fast-parallel` passed; `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes list no Critical findings and one non-blocking Minor coverage follow-up (`ga-j5n5xr`). Unresolved HIGH count: 0. |
+| 5 | Final branch is clean | PASS | Clean worktree before gate file: `git status --short --branch` reported only `## HEAD (no branch)`. Gate file is committed as the final release-gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` returned tree `00ef677235831dfc21a92867b8ac098f6d179fd5`; GitHub PR merge state is `CLEAN`. |
+| 7 | Single feature theme | PASS | Commit set touches only `cmd/gc/doctor_backlog_depth.go` and `cmd/gc/doctor_backlog_depth_test.go`; one subsystem and one user-visible behavior: `gc doctor` backlog-depth reporting. |
+
+## Acceptance Evidence
+
+- Claimable backlog count is dependency-aware: `Run` calls `store.Ready()`,
+  builds a `readyIDs` set, and `classifyBacklog` treats only those IDs as real
+  claimable work after filtering control-plane, notification, and epic beads.
+- Dep-blocked task-type beads no longer overcount claimable work: both
+  `TestClassifyBacklog` and `TestBacklogDepthCheckRunReportsTrueDepth` include
+  blocked bead `B-1` and assert it is excluded from claimable details.
+- Scope wording is accurate: the operator-facing message now starts with
+  `city store:` to avoid implying rig-wide coverage.
+- Observability remains non-blocking: store-open/list/ready failures return
+  advisory `StatusWarning` results, never a blocking `StatusError`.
+
+## Test Evidence
+
+```text
+$ go test ./cmd/gc -run 'TestClassifyBacklog|TestBacklogDepthCheck'
+ok  	github.com/gastownhall/gascity/cmd/gc	0.776s
+
+$ make test-fast-parallel
+[fsys-darwin-compile] ok
+[unit-cmd-gc-1-of-6] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-3-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-cmd-gc-6-of-6] ok
+[unit-core] ok
+All fast jobs passed
+
+$ go vet ./...
+PASS
+```
+
+## Files Reviewed
+
+```text
+cmd/gc/doctor_backlog_depth.go
+cmd/gc/doctor_backlog_depth_test.go
+```

--- a/release-gates/ga-x6b7iv-backlog-depth-gate.md
+++ b/release-gates/ga-x6b7iv-backlog-depth-gate.md
@@ -20,8 +20,8 @@ uses the deployer release criteria from the active Gas City deployer prompt.
 | 2 | Acceptance criteria met | PASS | `classifyBacklog` now consumes `store.Ready()` IDs instead of `beads.IsReadyCandidateForTier`; dep-blocked `B-1` fixtures land in `other`, not `real`; result message says `city store`; `store.Ready()` errors return advisory warning. |
 | 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestClassifyBacklog|TestBacklogDepthCheck'` passed; `make test-fast-parallel` passed; `go vet ./...` passed. |
 | 4 | No high-severity review findings open | PASS | Review notes list no Critical findings and one non-blocking Minor coverage follow-up (`ga-j5n5xr`). Unresolved HIGH count: 0. |
-| 5 | Final branch is clean | PASS | Clean worktree before gate file: `git status --short --branch` reported only `## HEAD (no branch)`. Gate file is committed as the final release-gate commit. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` returned tree `00ef677235831dfc21a92867b8ac098f6d179fd5`; GitHub PR merge state is `CLEAN`. |
+| 5 | Final branch is clean | PASS | Clean worktree before gate file: `git status --short --branch` reported only `## HEAD (no branch)`. Gate file is committed in the release-gate commit and the worktree is rechecked clean before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` returned tree `9318beced071d25caf924bc311ddc48ba53a649d`; GitHub reports `mergeable=MERGEABLE`. `mergeStateStatus=BLOCKED` is from pending CI/branch protection, not a content conflict. |
 | 7 | Single feature theme | PASS | Commit set touches only `cmd/gc/doctor_backlog_depth.go` and `cmd/gc/doctor_backlog_depth_test.go`; one subsystem and one user-visible behavior: `gc doctor` backlog-depth reporting. |
 
 ## Acceptance Evidence

--- a/scripts/test-go-test-shard
+++ b/scripts/test-go-test-shard
@@ -31,6 +31,23 @@ gomodcache_val="$(go env GOMODCACHE)"
 gotmpdir_val="$(go env GOTMPDIR)"
 goroot_val="$(go env GOROOT)"
 
+# macOS: icu4c (a transitive go-icu-regex/Dolt CGO dependency) is keg-only
+# under Homebrew, so its headers/libs are not on the default CGO search path.
+# Mirror the Makefile's detection here so tests run via this script see the
+# same CGO paths as `make`. No-op on Linux and when icu4c is not installed.
+# When invoked from test-integration-shard, CGO_CPPFLAGS/CGO_LDFLAGS may
+# already be set by that script; the duplicate-safe guard below prevents
+# double-adding when this script runs as a child of test-integration-shard.
+cgo_cppflags="${CGO_CPPFLAGS:-}"
+cgo_ldflags="${CGO_LDFLAGS:-}"
+if [[ "$(uname)" == "Darwin" ]]; then
+  icu_prefix="$(brew --prefix icu4c 2>/dev/null || true)"
+  if [[ -n "$icu_prefix" && "$cgo_cppflags" != *"-I${icu_prefix}/include"* ]]; then
+    cgo_cppflags="${cgo_cppflags:+$cgo_cppflags }-I${icu_prefix}/include"
+    cgo_ldflags="${cgo_ldflags:+$cgo_ldflags }-L${icu_prefix}/lib"
+  fi
+fi
+
 extra_env=()
 while IFS='=' read -r name _; do
   case "$name" in
@@ -67,7 +84,9 @@ run_go_test() {
     GOINSECURE="${GOINSECURE-}" \
     GOVCS="${GOVCS-}" \
     GOWORK="${GOWORK-}" \
-    GC_FAST_UNIT="${GC_FAST_UNIT:-0}"
+    GC_FAST_UNIT="${GC_FAST_UNIT:-0}" \
+    CGO_CPPFLAGS="${cgo_cppflags}" \
+    CGO_LDFLAGS="${cgo_ldflags}" \
     GC_TEST_SHARD_INDEX="${shard_index}" \
     GC_TEST_SHARD_TOTAL="${shard_total}"
   )

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -20,6 +20,23 @@ gomodcache_val="$(go env GOMODCACHE)"
 gotmpdir_val="$(go env GOTMPDIR)"
 goroot_val="$(go env GOROOT)"
 
+# macOS: icu4c (a transitive go-icu-regex/Dolt CGO dependency) is keg-only
+# under Homebrew, so its headers/libs are not on the default CGO search path.
+# Mirror the Makefile's detection here so tests run via this script see the
+# same CGO paths as `make`. No-op on Linux and when icu4c is not installed.
+cgo_cppflags="${CGO_CPPFLAGS:-}"
+cgo_ldflags="${CGO_LDFLAGS:-}"
+if [[ "$(uname)" == "Darwin" ]]; then
+  icu_prefix="$(brew --prefix icu4c 2>/dev/null || true)"
+  if [[ -n "$icu_prefix" && "$cgo_cppflags" != *"-I${icu_prefix}/include"* ]]; then
+    cgo_cppflags="${cgo_cppflags:+$cgo_cppflags }-I${icu_prefix}/include"
+    cgo_ldflags="${cgo_ldflags:+$cgo_ldflags }-L${icu_prefix}/lib"
+  fi
+fi
+# Export so child scripts (e.g. test-go-test-shard) inherit the detected paths.
+export CGO_CPPFLAGS="${cgo_cppflags}"
+export CGO_LDFLAGS="${cgo_ldflags}"
+
 run_go_test() {
   env -i \
     PATH="${PATH}" \
@@ -49,6 +66,8 @@ run_go_test() {
     GOWORK="${GOWORK-}" \
     GC_BEADS="${GC_BEADS-}" \
     GC_FAST_UNIT=0 \
+    CGO_CPPFLAGS="${cgo_cppflags}" \
+    CGO_LDFLAGS="${cgo_ldflags}" \
     go test "$@"
 }
 


### PR DESCRIPTION
## What this changes

`gc doctor` backlog-depth now counts only city-store beads that are actually dependency-ready as claimable work. Open task beads with unresolved blockers no longer inflate the claimable backlog; they are reported in the `other` bucket instead.

The operator-facing message is also scoped to `city store:` so it does not imply rig-wide coverage. This check remains advisory observability only: it does not mutate beads, gate dispatch, or change the claiming path.

## Why this design

The fix uses the existing `store.Ready()` contract as the source of dependency-aware readiness instead of duplicating dependency logic inside the doctor check. That keeps the doctor output aligned with the same readiness semantics used elsewhere in the beads layer.

## Review notes

- Main behavior is in `cmd/gc/doctor_backlog_depth.go`.
- Regression coverage is in `cmd/gc/doctor_backlog_depth_test.go`, including a dep-blocked open task fixture.
- `store.Ready()` failures remain non-blocking `StatusWarning` results because backlog-depth is advisory.
- The check still reads only the city beads store; rig stores are intentionally not included.

## Test plan

- [x] `go test ./cmd/gc -run 'TestClassifyBacklog|TestBacklogDepthCheck'`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-x6b7iv-backlog-depth-gate.md`](release-gates/ga-x6b7iv-backlog-depth-gate.md)