### PR TITLE
Fix doctor backlog-depth Ready handling

### DIFF
--- a/cmd/gc/doctor_backlog_depth.go
+++ b/cmd/gc/doctor_backlog_depth.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/doctor"
 )
 
-// backlogDepthCheck reports the city's true claimable backlog depth by
+// backlogDepthCheck reports the city store's claimable backlog depth by
 // classifying the raw open-bead population into actionable work versus
 // observability noise. `bd ready` (the beads CLI) lists control-plane session
 // beads and short-lived nudge/mail notification chores alongside real work, so
@@ -18,15 +17,14 @@ import (
 // claimable — the recurring "fleet idle / backlog huge" false alarm
 // (gastownhall/gascity#3021).
 //
-// The check is pure observability: it never mutates beads and never gates
+// The check reads the city beads store only; work tracked in rig stores is not
+// included. It is pure observability: it never mutates beads and never gates
 // (SeverityAdvisory). It does not touch the claiming path — agents' work
 // queries already filter this noise via the Ready-tier contract; the gap it
 // closes is the operator/dashboard view.
 type backlogDepthCheck struct {
 	cityPath string
 	newStore func(string) (beads.Store, error)
-	// now is injectable for tests; the zero value means time.Now().
-	now time.Time
 }
 
 func newBacklogDepthCheck(cityPath string, newStore func(string) (beads.Store, error)) *backlogDepthCheck {
@@ -49,7 +47,7 @@ type backlogBreakdown struct {
 	controlPlane int          // type=session / gc:session: the session registry
 	notification int          // nudge:/mail: chores, type=message, gc:nudge
 	epic         int          // epic parents: containers, not claimable leaves
-	other        int          // deferred, or other infra/excluded Ready-tier types
+	other        int          // deferred, dep-blocked, or other infra/excluded Ready-tier types
 	real         []beads.Bead // genuinely claimable Ready-tier work
 }
 
@@ -72,9 +70,10 @@ func isNotificationBacklogBead(b beads.Bead) bool {
 }
 
 // classifyBacklog partitions the raw open-bead population into one bucket each
-// (first match wins) so the buckets sum to total. "real" is the Ready-tier
-// contract (beads.IsReadyCandidateForTier) minus the noise classes above.
-func classifyBacklog(open []beads.Bead, now time.Time) backlogBreakdown {
+// (first match wins) so the buckets sum to total. "real" is the set of beads
+// whose IDs appear in readyIDs — the dep-checked Ready output from the store —
+// after subtracting the noise classes above.
+func classifyBacklog(open []beads.Bead, readyIDs map[string]bool) backlogBreakdown {
 	b := backlogBreakdown{total: len(open)}
 	for _, bead := range open {
 		switch {
@@ -84,7 +83,7 @@ func classifyBacklog(open []beads.Bead, now time.Time) backlogBreakdown {
 			b.notification++
 		case bead.Type == "epic":
 			b.epic++
-		case beads.IsReadyCandidateForTier(bead, now, beads.TierIssues):
+		case readyIDs[bead.ID]:
 			b.real = append(b.real, bead)
 		default:
 			b.other++
@@ -112,16 +111,22 @@ func (c *backlogDepthCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 		res.Message = fmt.Sprintf("backlog depth unknown: listing open beads: %v", err)
 		return res
 	}
-
-	now := c.now
-	if now.IsZero() {
-		now = time.Now()
+	ready, err := store.Ready()
+	if err != nil {
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("backlog depth unknown: listing ready beads: %v", err)
+		return res
 	}
-	b := classifyBacklog(open, now)
+
+	readyIDs := make(map[string]bool, len(ready))
+	for _, r := range ready {
+		readyIDs[r.ID] = true
+	}
+	b := classifyBacklog(open, readyIDs)
 
 	res.Status = doctor.StatusOK
 	res.Message = fmt.Sprintf(
-		"true backlog: %d claimable (of %d open — %d control-plane, %d notification, %d epic, %d other)",
+		"city store: %d claimable (of %d open — %d control-plane, %d notification, %d epic, %d other)",
 		len(b.real), b.total, b.controlPlane, b.notification, b.epic, b.other)
 
 	details := make([]string, 0, len(b.real))

--- a/cmd/gc/doctor_backlog_depth_ready_error_test.go
+++ b/cmd/gc/doctor_backlog_depth_ready_error_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+type backlogDepthReadyErrorStore struct {
+	beads.Store
+}
+
+func (s backlogDepthReadyErrorStore) ListOpen(...string) ([]beads.Bead, error) {
+	return nil, nil
+}
+
+func (s backlogDepthReadyErrorStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
+	return nil, fmt.Errorf("ready unavailable")
+}
+
+func TestBacklogDepthCheckReadyErrorIsGraceful(t *testing.T) {
+	check := newBacklogDepthCheck("/city", func(string) (beads.Store, error) {
+		return backlogDepthReadyErrorStore{}, nil
+	})
+
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning for Ready failure: %#v", res.Status, res)
+	}
+	if res.Status == doctor.StatusError {
+		t.Fatalf("Ready failure should not be a blocking StatusError: %#v", res)
+	}
+	if !strings.Contains(res.Message, "backlog depth unknown: listing ready beads: ready unavailable") {
+		t.Fatalf("Message = %q, want Ready error context", res.Message)
+	}
+	if check.CanFix() {
+		t.Fatal("CanFix() = true, want false for read-only observability check")
+	}
+}

--- a/cmd/gc/doctor_backlog_depth_test.go
+++ b/cmd/gc/doctor_backlog_depth_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestClassifyBacklog(t *testing.T) {
-	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
-	future := now.Add(24 * time.Hour)
+	future := time.Now().Add(24 * time.Hour)
 
 	open := []beads.Bead{
 		// control-plane: by type and by label
@@ -25,15 +24,21 @@ func TestClassifyBacklog(t *testing.T) {
 		{ID: "N-4", Title: "labeled nudge", Type: "task", Status: "open", Labels: []string{"gc:nudge"}},
 		// epic parents
 		{ID: "E-1", Title: "EPIC: self-healing", Type: "epic", Status: "open"},
-		// genuinely claimable real work
+		// genuinely claimable real work (unblocked, in readyIDs)
 		{ID: "R-1", Title: "fix the thing", Type: "task", Status: "open"},
 		{ID: "R-2", Title: "feature work", Type: "feature", Status: "open"},
-		// other: deferred (future), and an infra/excluded type
+		// other: deferred (future), infra/excluded type, and a blocked real-type bead
 		{ID: "O-1", Title: "deferred task", Type: "task", Status: "open", DeferUntil: &future},
 		{ID: "O-2", Title: "workflow container", Type: "molecule", Status: "open"},
+		// B-1 would pass IsReadyCandidateForTier but is dep-blocked: must go to other, not real.
+		{ID: "B-1", Title: "blocked work", Type: "task", Status: "open"},
 	}
 
-	b := classifyBacklog(open, now)
+	// readyIDs represents store.Ready() output: only R-1 and R-2 are dep-unblocked
+	// actionable work. B-1 is blocked (open dep), O-1 deferred, O-2 excluded type.
+	readyIDs := map[string]bool{"R-1": true, "R-2": true}
+
+	b := classifyBacklog(open, readyIDs)
 
 	if b.total != len(open) {
 		t.Errorf("total = %d, want %d", b.total, len(open))
@@ -47,8 +52,9 @@ func TestClassifyBacklog(t *testing.T) {
 	if b.epic != 1 {
 		t.Errorf("epic = %d, want 1", b.epic)
 	}
-	if b.other != 2 {
-		t.Errorf("other = %d, want 2", b.other)
+	// other = O-1 (deferred) + O-2 (molecule) + B-1 (dep-blocked) = 3
+	if b.other != 3 {
+		t.Errorf("other = %d, want 3 (deferred + molecule + dep-blocked)", b.other)
 	}
 	gotReal := make([]string, 0, len(b.real))
 	for _, r := range b.real {
@@ -61,17 +67,20 @@ func TestClassifyBacklog(t *testing.T) {
 }
 
 func TestBacklogDepthCheckRunReportsTrueDepth(t *testing.T) {
-	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	// Store with one blocked bead (B-1 depends on R-1) to verify B-1 is not
+	// counted in the claimable total.
 	store := beads.NewMemStoreFrom(0, []beads.Bead{
 		{ID: "S-1", Title: "planner-1", Type: "session", Status: "open"},
 		{ID: "N-1", Title: "nudge:abc", Type: "chore", Status: "open"},
 		{ID: "N-2", Title: "nudge:def", Type: "chore", Status: "open"},
 		{ID: "E-1", Title: "EPIC", Type: "epic", Status: "open"},
 		{ID: "R-1", Title: "real work", Type: "task", Status: "open"},
-	}, nil)
+		{ID: "B-1", Title: "blocked work", Type: "task", Status: "open"},
+	}, []beads.Dep{
+		{IssueID: "B-1", DependsOnID: "R-1", Type: "blocks"},
+	})
 
 	check := newBacklogDepthCheck("/city", func(string) (beads.Store, error) { return store, nil })
-	check.now = now
 
 	res := check.Run(&doctor.CheckContext{})
 	if res.Status != doctor.StatusOK {
@@ -80,19 +89,23 @@ func TestBacklogDepthCheckRunReportsTrueDepth(t *testing.T) {
 	if res.Severity != doctor.SeverityAdvisory {
 		t.Fatalf("Severity = %v, want Advisory", res.Severity)
 	}
-	// Message must surface the real count (1) distinct from the raw open count (5).
-	for _, want := range []string{"1", "5"} {
+	// Message must surface real=1 (only R-1; B-1 is dep-blocked) and total=6.
+	for _, want := range []string{"1", "6"} {
 		if !strings.Contains(res.Message, want) {
 			t.Errorf("Message %q missing %q", res.Message, want)
 		}
+	}
+	// Message must scope to city store, not claim city-wide truth.
+	if !strings.Contains(res.Message, "city store") {
+		t.Errorf("Message %q missing scope qualifier 'city store'", res.Message)
 	}
 	details := strings.Join(res.Details, "\n")
 	if !strings.Contains(details, "R-1") {
 		t.Errorf("Details should name the real claimable bead R-1:\n%s", details)
 	}
-	for _, noise := range []string{"S-1", "N-1", "E-1"} {
+	for _, noise := range []string{"S-1", "N-1", "E-1", "B-1"} {
 		if strings.Contains(details, noise) {
-			t.Errorf("Details should not list noise bead %q:\n%s", noise, details)
+			t.Errorf("Details should not list noise/blocked bead %q:\n%s", noise, details)
 		}
 	}
 }
@@ -110,8 +123,7 @@ func TestBacklogDepthCheckStoreErrorIsGraceful(t *testing.T) {
 	if res.Status == doctor.StatusError {
 		t.Fatalf("store error should not be a blocking StatusError: %#v", res)
 	}
-	if !check.CanFix() == false {
-		// CanFix must be false: this is a read-only observability check.
-		t.Errorf("CanFix = %v, want false", check.CanFix())
+	if check.CanFix() {
+		t.Errorf("CanFix = true, want false (read-only observability check)")
 	}
 }

--- a/release-gates/doctor-backlog-depth-ready-error-gate.md
+++ b/release-gates/doctor-backlog-depth-ready-error-gate.md
@@ -1,0 +1,34 @@
+# Release Gate: doctor backlog-depth Ready error coverage
+
+Date: 2026-06-05
+Deployer: gascity/deployer
+Primary deploy bead: ga-acgsbx
+PM deploy bead: ga-5gd6pa.2
+Source review bead: ga-04k6nl
+Source implementation bead: ga-j5n5xr
+
+## Candidate
+
+- Branch: `fix/ga-5gd6pa1-doctor-backlog-depth-ready-error`
+- Reviewed commit: `74475ca78c6fc6d42521063c7a40a8893844e652`
+- Existing PR: https://github.com/gastownhall/gascity/pull/3134
+- Reviewer-visible diff:
+  - `cmd/gc/doctor_backlog_depth.go`
+  - `cmd/gc/doctor_backlog_depth_ready_error_test.go`
+  - `cmd/gc/doctor_backlog_depth_test.go`
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-04k6nl` is closed with review verdict PASS. Reviewer notes cite commit `74475ca78c6fc6d42521063c7a40a8893844e652`, branch `fix/ga-5gd6pa1-doctor-backlog-depth-ready-error`, four passing doctor backlog-depth tests, `go vet ./cmd/gc/` clean, and no blockers. |
+| 2 | Acceptance criteria met | PASS | `ga-j5n5xr` requested `TestBacklogDepthCheckReadyErrorIsGraceful` for `store.Ready()` failures. The branch adds that test and verifies `StatusWarning`, not `StatusError`, the Ready error context, and `CanFix() == false`. The implementation now builds the claimable set from `store.Ready()` so dep-blocked beads are excluded from the real backlog count. `ga-5gd6pa.2` isolation criteria are met: the diff is limited to three doctor backlog-depth files and excludes order-dispatch, config/schema, macOS icu4c test-script, prior release-gate, and internal planning-doc changes. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestBacklogDepth|TestClassifyBacklog' -count=1` passed. `make test` passed with `observable go test: PASS log=/tmp/gascity-test.jsonl.hz6WVm`. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes on `ga-04k6nl` list no blockers or security findings; only one non-blocking nit about a defensive duplicate status check. |
+| 5 | Final branch is clean | PASS | Evaluated in clean detached deploy worktree at `74475ca78c6fc6d42521063c7a40a8893844e652`; no uncommitted changes before gate file creation. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree` against `origin/main` produced no conflict markers or unmerged conflict records. |
+| 7 | Single feature theme | PASS | Commit set touches only the doctor backlog-depth check and its tests. The change is one subsystem and one user-visible behavior: `gc doctor` backlog-depth now counts dep-ready work from the store and reports Ready lookup failures as advisory warnings. |
+
+## Deploy Decision
+
+PASS. Commit this gate checklist to the existing PR branch, push the branch, reuse PR #3134, close the deploy beads with the PR URL, and route a merge-request to mayor. Deployer does not merge.


### PR DESCRIPTION
## What this changes

`gc doctor` now counts backlog depth from the bead store's Ready query, so dependency-blocked beads no longer inflate the claimable-work count. The check still filters out session, notification, and epic/container noise, but it now uses the store's dependency-aware answer for the final "real work" bucket.

If the Ready lookup fails, backlog depth reports an advisory warning with the Ready error context instead of becoming a blocking doctor error. The output also scopes the count as the "city store" backlog, avoiding the old implication that rig-store work was included.

## Review notes

- The design keeps readiness rules in the bead store instead of duplicating dependency logic in `gc doctor`.
- Scope is limited to doctor backlog-depth logic and tests under `cmd/gc`.
- No config, API/schema, persistence format, or migration changes.

## Test plan

- [x] `go test ./cmd/gc -run 'TestBacklogDepth|TestClassifyBacklog' -count=1`
- [x] `make test`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/doctor-backlog-depth-ready-error-gate.md`](release-gates/doctor-backlog-depth-ready-error-gate.md)
