### PR TITLE
fix(beads): gate `bd list --skip-labels` behind bd 1.0.5+ version probe

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/telemetry"
@@ -218,6 +219,9 @@ type BdStore struct {
 	runner      CommandRunner   // injectable for testing
 	purgeRunner PurgeRunnerFunc // injectable for testing; nil uses exec default
 	idPrefix    string          // bead ID prefix owned by this store, without trailing "-"
+
+	skipLabelsOnce      sync.Once // guards the one-time bd version probe below
+	skipLabelsSupported bool      // whether bd accepts `bd list --skip-labels` (bd 1.0.5+)
 }
 
 const bdTransientWriteAttempts = 3
@@ -1707,7 +1711,7 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 			args = append(args, "--metadata-field", k+"="+serverQuery.Metadata[k])
 		}
 	}
-	if query.SkipLabels && serverQuery.Label == "" {
+	if query.SkipLabels && serverQuery.Label == "" && s.supportsSkipLabels() {
 		args = append(args, "--skip-labels")
 	}
 
@@ -1733,6 +1737,31 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 		return filtered, &PartialResultError{Op: "bd list", Err: parseErr}
 	}
 	return filtered, nil
+}
+
+// bdSkipLabelsMinVersion is the first bd release whose `bd list` accepts
+// --skip-labels (be-w3n-1). bd 1.0.4 — the supported floor — rejects the
+// flag and fails the entire list call (see 29d457fe9).
+const bdSkipLabelsMinVersion = "1.0.5"
+
+// supportsSkipLabels reports whether the bd binary backing this store accepts
+// `bd list --skip-labels`. The version probe runs through the store's runner
+// once and is cached for the store's lifetime; any probe or parse failure
+// degrades to false so listing falls back to normal label hydration instead
+// of a hard bd CLI error.
+func (s *BdStore) supportsSkipLabels() bool {
+	s.skipLabelsOnce.Do(func() {
+		out, err := s.runner(s.dir, "bd", "version")
+		if err != nil {
+			return
+		}
+		ver, err := parseBDVersion(string(out))
+		if err != nil {
+			return
+		}
+		s.skipLabelsSupported = bdVersionAtLeast(ver, bdSkipLabelsMinVersion)
+	})
+	return s.skipLabelsSupported
 }
 
 func bdListRequiresClientLimit(query, serverQuery ListQuery, clientFilteredAssignees bool) bool {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1777,12 +1777,23 @@ func TestBdStoreListEmptyOutputMeansNoBeads(t *testing.T) {
 	}
 }
 
-func TestBdStoreListSkipLabelsEmitsFlag(t *testing.T) {
+// skipLabelsProbeRunner wraps inner so `bd version` probes report the given
+// output, letting tests pin the bd version the store detects.
+func skipLabelsProbeRunner(versionOut string, versionErr error, inner beads.CommandRunner) beads.CommandRunner {
+	return func(dir, name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "version" {
+			return []byte(versionOut), versionErr
+		}
+		return inner(dir, name, args...)
+	}
+}
+
+func TestBdStoreListSkipLabelsEmitsFlagOnBd105(t *testing.T) {
 	var gotCmd string
-	runner := func(_, name string, args ...string) ([]byte, error) {
+	runner := skipLabelsProbeRunner("bd version 1.0.5 (abc1234)", nil, func(_, name string, args ...string) ([]byte, error) {
 		gotCmd = name + " " + strings.Join(args, " ")
 		return []byte(`[]`), nil
-	}
+	})
 	s := beads.NewBdStore("/city", runner)
 	if _, err := s.List(beads.ListQuery{AllowScan: true, SkipLabels: true}); err != nil {
 		t.Fatal(err)
@@ -1792,9 +1803,63 @@ func TestBdStoreListSkipLabelsEmitsFlag(t *testing.T) {
 	}
 }
 
+// TestBdStoreListSkipLabelsOmittedOnBd104 is the regression test for the
+// unconditional --skip-labels emit introduced in 994d544fc: bd 1.0.4 (the
+// supported floor) rejects the flag, so the store must fall back to normal
+// label hydration instead of failing the whole list call.
+func TestBdStoreListSkipLabelsOmittedOnBd104(t *testing.T) {
+	var gotCmd string
+	runner := skipLabelsProbeRunner("bd version 1.0.4 (ce242a879)", nil, func(_, name string, args ...string) ([]byte, error) {
+		gotCmd = name + " " + strings.Join(args, " ")
+		return []byte(`[]`), nil
+	})
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.List(beads.ListQuery{AllowScan: true, SkipLabels: true}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(gotCmd, "--skip-labels") {
+		t.Fatalf("bd list command = %q, bd 1.0.4 does not support --skip-labels", gotCmd)
+	}
+}
+
+func TestBdStoreListSkipLabelsOmittedWhenVersionProbeFails(t *testing.T) {
+	var gotCmd string
+	runner := skipLabelsProbeRunner("", fmt.Errorf("exec: bd: not found"), func(_, name string, args ...string) ([]byte, error) {
+		gotCmd = name + " " + strings.Join(args, " ")
+		return []byte(`[]`), nil
+	})
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.List(beads.ListQuery{AllowScan: true, SkipLabels: true}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(gotCmd, "--skip-labels") {
+		t.Fatalf("bd list command = %q, want --skip-labels omitted when version is unknown", gotCmd)
+	}
+}
+
+func TestBdStoreListSkipLabelsVersionProbedOnce(t *testing.T) {
+	probes := 0
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "version" {
+			probes++
+			return []byte("bd version 1.0.5 (abc1234)"), nil
+		}
+		return []byte(`[]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	for range 3 {
+		if _, err := s.List(beads.ListQuery{AllowScan: true, SkipLabels: true}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if probes != 1 {
+		t.Fatalf("bd version probed %d times across 3 List calls, want 1 (cached)", probes)
+	}
+}
+
 func TestBdStoreListAcceptsBdListEnvelope(t *testing.T) {
 	var gotCmd string
-	runner := func(_, name string, args ...string) ([]byte, error) {
+	runner := skipLabelsProbeRunner("bd version 1.0.5 (abc1234)", nil, func(_, name string, args ...string) ([]byte, error) {
 		gotCmd = name + " " + strings.Join(args, " ")
 		return []byte(`{
 			"issues": [
@@ -1803,7 +1868,7 @@ func TestBdStoreListAcceptsBdListEnvelope(t *testing.T) {
 			"meta": {"count": 1, "skip_labels": true},
 			"schema_version": 1
 		}`), nil
-	}
+	})
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.List(beads.ListQuery{AllowScan: true, SkipLabels: true})
 	if err != nil {

--- a/internal/beads/binary_versions.go
+++ b/internal/beads/binary_versions.go
@@ -61,6 +61,21 @@ func probeBinaryVersion(name string) (string, error) {
 	return string(out), nil
 }
 
+// bdVersionAtLeast reports whether version (a semantic-version token such as
+// parseBDVersion returns) is at or above minimum. Unparseable versions report
+// false so callers fail toward bd 1.0.4-compatible behavior.
+func bdVersionAtLeast(version, minimum string) bool {
+	v, err := doltversion.Parse(version)
+	if err != nil {
+		return false
+	}
+	m, err := doltversion.Parse(minimum)
+	if err != nil {
+		return false
+	}
+	return doltversion.Compare(v, m) >= 0
+}
+
 // parseBDVersion extracts the semantic version token from `bd version` output
 // (e.g. "bd version 1.0.4 (ce242a879)" -> "1.0.4"). Mirrors doltversion.Parse's
 // leniency: the "bd version " prefix, a leading "v", and any trailing

--- a/internal/beads/binary_versions_test.go
+++ b/internal/beads/binary_versions_test.go
@@ -38,6 +38,31 @@ func TestParseBDVersion(t *testing.T) {
 	}
 }
 
+func TestBDVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		name             string
+		version, minimum string
+		want             bool
+	}{
+		{name: "equal", version: "1.0.5", minimum: "1.0.5", want: true},
+		{name: "patch above", version: "1.0.6", minimum: "1.0.5", want: true},
+		{name: "minor above", version: "1.1.0", minimum: "1.0.5", want: true},
+		{name: "major above", version: "2.0.0", minimum: "1.0.5", want: true},
+		{name: "patch below", version: "1.0.4", minimum: "1.0.5", want: false},
+		{name: "major below", version: "0.9.9", minimum: "1.0.5", want: false},
+		{name: "unparseable version", version: "garbage", minimum: "1.0.5", want: false},
+		{name: "empty version", version: "", minimum: "1.0.5", want: false},
+		{name: "two-part version", version: "1.0", minimum: "1.0.5", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bdVersionAtLeast(tt.version, tt.minimum); got != tt.want {
+				t.Errorf("bdVersionAtLeast(%q, %q) = %v, want %v", tt.version, tt.minimum, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestProbeVersionsAgainstHostBinaries is a best-effort smoke test: when bd and
 // dolt are on PATH (as in CI and dev shells), the probes return a digit-led
 // version. Skips cleanly when a binary is absent so the suite stays hermetic.


### PR DESCRIPTION
**Regression from #3108** (`994d544fc`). That PR emits `bd list --skip-labels` unconditionally in `internal/beads/bdstore.go`, but the flag only exists on bd 1.0.5+. On bd 1.0.4 (the managed floor), every `CachingStore` prime (`PrimeActive` + reconciler) fails with `unknown flag: --skip-labels` → caches never reach `cacheLive` → the `/v0/city/.../sessions` and `/agents` API handlers fall back to thousands of live `bd` subprocesses per request (10-20s responses; dashboards reading those endpoints hang).

#3108 says it gates the flag "when bd 1.0.5+ is available," but the emit site has no version check.

**Fix:** probe bd's version once per store via the injected runner (cached with `sync.Once`); only append `--skip-labels` on bd 1.0.5+. Any probe/parse failure degrades to normal label hydration — restoring the bd 1.0.4 behavior from `29d457fe9`. Regression tests in `bdstore_test.go` + `binary_versions_test.go`. Net: 4 files, +140/-6.