### PR TITLE
docs: extract Gastown config recipes page and embed the worked example (#3136, #3088)

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -338,7 +338,7 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
   gc init --default-provider codex --bootstrap-profile k8s-cell /city
   gc init --name my-city
   gc init --from ~/elan --name elan /city
-  gc init --file examples/gastown.toml ~/bright-lights
+  gc init --file ./my-city.toml ~/bright-lights
   gc init --file city.toml --preserve-existing .`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(runCmd *cobra.Command, args []string) error {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -138,6 +138,7 @@
           "guides/capabilities-for-coding-agent-users",
           "guides/understanding-packs",
           "guides/shareable-packs",
+          "guides/gastown-config-recipes",
           "guides/using-json-from-gc",
           "guides/multi-agent-engineering-environment"
         ]

--- a/docs/getting-started/coming-from-gastown.md
+++ b/docs/getting-started/coming-from-gastown.md
@@ -26,7 +26,7 @@ This page is laid out as a deliberate sequence so you are never untangling sever
    4. [workflows](#workflows-→-gas-city-equivalents)
    5. [commands](#commands-→-gas-city-equivalents).
 
-The prose sections after the tables ([What Usually Maps Cleanly](#what-usually-maps-cleanly) and so on...) go deeper on the patterns that matter most.
+The prose sections after the tables ([What Usually Maps Cleanly](#what-usually-maps-cleanly) and so on...) go deeper on the patterns that matter most, before a short pointer to the [config recipes](/guides/gastown-config-recipes) and a closing ramp checklist.
 
 If you want the system-level mental model before any of this, read the [Architecture Overview](/concepts/architecture-overview) and the [Primitives Reference](/concepts/primitives) first.
 
@@ -364,131 +364,9 @@ City-scoped agents from the Gastown pack — `mayor`, `deacon`, `boot` — are a
 
 This replaces `gt session at mayor/` or `tmux attach -t gt-mayor` from Gas Town.
 
-## Common Gastown Overrides
+## Editing Gastown Config
 
-If you are using the Gastown pack, these are the most common local changes.
-
-### Register a rig
-
-Import the Gastown pack in the root pack, then bind rigs in `city.toml` and with `gc rig add`:
-
-```toml
-# pack.toml
-[pack]
-name = "my-city"
-schema = 2
-
-[imports.gastown]
-source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-```
-
-```toml
-# city.toml
-[[rigs]]
-name = "myproject"
-
-[rigs.imports.gastown]
-source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-```
-
-```bash
-gc rig add /path/to/myproject --name myproject
-```
-
-### Increase or shrink scalable polecat sessions
-
-This is the cleanest answer to "I want more or fewer polecats for this rig."
-
-```toml
-# city.toml
-[[rigs]]
-name = "myproject"
-
-[rigs.imports.gastown]
-source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-
-[[rigs.patches]]
-agent = "gastown.polecat"
-
-[rigs.patches.pool]
-max = 10
-```
-
-### Change the provider for one rig's polecats
-
-```toml
-# city.toml
-[[rigs]]
-name = "myproject"
-
-[rigs.imports.gastown]
-source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-
-[[rigs.patches]]
-agent = "gastown.polecat"
-provider = "codex"
-```
-
-You can combine that with session scale overrides, env, prompt changes, or hook changes on the same override block.
-
-### Change a city-scoped Gastown agent
-
-City-scoped agents such as `mayor`, `deacon`, and `boot` are easiest to tweak with patches:
-
-```toml
-[[patches.agent]]
-name = "gastown.mayor"
-provider = "codex"
-idle_timeout = "2h"
-```
-
-Use patches when the target is already a concrete city-scoped agent. Use `[[rigs.patches]]` when the target is a pack agent stamped per rig.
-
-### Add a named crew agent
-
-Crew is usually city-specific, so it often belongs in the root city pack rather than in the shared Gastown pack:
-
-```text
-agents/wolf/
-├── agent.toml
-└── prompt.template.md
-```
-
-```toml
-# agents/wolf/agent.toml
-scope = "rig"
-nudge = "Check your hook and mail, then act accordingly."
-work_dir = ".gc/worktrees/myproject/crew/wolf"
-idle_timeout = "4h"
-```
-
-That keeps the shared pack generic while still letting your city have named long-lived workers.
-
-### Change a prompt, overlay, or timeout without forking the pack
-
-This is what rig overrides are for:
-
-```toml
-# city.toml
-[[rigs]]
-name = "myproject"
-
-[rigs.imports.gastown]
-source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-
-[[rigs.patches]]
-agent = "gastown.refinery"
-idle_timeout = "4h"
-```
-
-For prompt or overlay replacement, patch the imported agent from your root city pack rather than editing the shared pack in place.
-
-If that change turns out to be broadly useful across cities, that is when it should move into the pack.
+Ready to make changes? The common Gastown config edits — registering rigs, scaling pools, swapping providers, patching agents, tweaking prompts — live in [Gastown on Gas City: Config Recipes](/guides/gastown-config-recipes).
 
 ## What Not To Port Literally
 

--- a/docs/getting-started/coming-from-gastown.md
+++ b/docs/getting-started/coming-from-gastown.md
@@ -390,5 +390,6 @@ If you already know Gas Town, this is the shortest path to becoming effective in
 3. Read [Tutorial 07 — Orders](/tutorials/07-orders) and mentally remap "plugins" to "orders".
 4. Read [Tutorial 05 — Formulas](/tutorials/05-formulas) and remember that formulas are resolved by Gas City but executed by the configured beads backend.
 5. Work through [Tutorial 02 — Agents](/tutorials/02-agents) and [Shareable Packs](/guides/shareable-packs) to see the PackV2 `agents/<name>/` layout end to end.
+6. Read [A Complete Gastown Example](/guides/gastown-config-recipes#a-complete-gastown-example) — the city, root pack, and nested pack assembled into one runnable topology.
 
-If you keep those five points straight, most of the Gas Town to Gas City ramp goes quickly.
+If you keep those points straight, most of the Gas Town to Gas City ramp goes quickly.

--- a/docs/guides/gastown-config-recipes.md
+++ b/docs/guides/gastown-config-recipes.md
@@ -133,3 +133,179 @@ idle_timeout = "4h"
 For prompt or overlay replacement, patch the imported agent from your root city pack rather than editing the shared pack in place.
 
 If that change turns out to be broadly useful across cities, that is when it should move into the pack.
+
+## A Complete Gastown Example
+
+The overrides above are fragments — single edits you splice into an existing
+config. This section assembles them into a full, runnable topology: the three
+files that express the whole Gastown pack on Gas City.
+
+Read them in order. The **city file** is the normal starting point — the
+deployment you boot. The **root pack** wires the Gastown import and the default
+rig binding behind it. The **nested pack** holds the reusable defaults — the
+roles, named sessions, and dog pool every Gastown city inherits.
+
+All three are PackV2 (`schema = 2`, `agents/<name>/`).
+
+### `city.toml` — the deployment
+
+```toml
+# Gas Town — expressed as a Gas City configuration.
+#
+# This proves the Gas City thesis: any orchestration pack is pure config.
+# Three composable packs:
+#   maintenance  — generic infrastructure: dog pool, shutdown dance, exec
+#                  orders (gate-sweep, orphan-sweep, prune-branches,
+#                  wisp-compact)
+#   dolt         — reusable Dolt database management (dog formulas + exec
+#                  orders + CLI commands), requires a dog pool from
+#                  maintenance
+#   gastown      — domain-specific coding workflow: mayor, deacon, boot,
+#                  witness, refinery, polecat, crew + digest orders
+#
+# City-scoped agents come from both packs: mayor, deacon, boot, plus the
+# effective dog definition from gastown. Maintenance still supplies the
+# fallback dog shape and shared dog formulas/prompts that gastown reuses.
+# Rig-scoped agents (witness, refinery, polecat) are stamped per-rig.
+#
+# The sibling pack.toml owns the Gastown import. This city owns the default
+# rig binding used by `gc rig add`.
+#
+# To use: save these three files into a city directory, then run
+#   gc start <city-dir>
+# Requires rigs to be registered: gc rig add <path>
+
+[workspace]
+name = "gastown"
+provider = "claude"
+global_fragments = ["command-glossary", "operational-awareness"]
+
+[providers.claude]
+base = "builtin:claude"
+
+[defaults.rig.imports.gastown]
+source = "packs/gastown"
+
+[daemon]
+patrol_interval = "30s"
+max_restarts = 5
+restart_window = "1h"
+shutdown_timeout = "5s"
+# Enable compiler-v2 formulas from imported packs. Legacy molecule formulas keep
+# molecule_id attachment semantics unless they declare a compiler-v2 requirement.
+formula_v2 = true
+
+# Register a rig to activate per-rig agents (witness, refinery, polecat):
+# [[rigs]]
+# name = "myproject"
+# path = "/path/to/your/project"
+
+# Crew members are persistent, individually named workers, so they can't be
+# pack-stamped. Each one is a directory agent under agents/<name>/ plus a
+# named session that keeps it alive. To add a crew member "wolf" bound to a
+# registered rig "myproject":
+#
+#   1. Create agents/wolf/agent.toml (relative paths resolve against this
+#      city directory):
+#
+#        scope = "rig"
+#        dir = "myproject"
+#        nudge = "Check your hook and mail, then act accordingly."
+#        work_dir = ".gc/worktrees/myproject/crew/wolf"
+#        idle_timeout = "4h"
+#        prompt_template = "packs/gastown/assets/prompts/crew.template.md"
+#        pre_start = ["{{.CityRoot}}/packs/gastown/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
+#
+#      tmux theming comes from the gastown pack's [global] session_live hooks,
+#      so crew members need no session_setup wiring of their own.
+#
+#   2. Keep the crew session alive by declaring a named session here. The
+#      dir must match the agent's so the session resolves to "myproject/wolf":
+#
+# [[named_session]]
+# template = "wolf"
+# dir = "myproject"
+# scope = "rig"
+# mode = "always"
+```
+
+### `pack.toml` — the root pack
+
+```toml
+# Gas Town root pack — wires the gastown pack at both city and rig scope.
+#
+# City-level: [imports.gastown] expands city-scoped agents (mayor, deacon,
+# boot) on city startup.
+#
+# Rig-level: [defaults.rig.imports.gastown] ensures every new rig
+# automatically imports rig-scoped agents (witness, refinery, polecat)
+# without hand-editing city.toml.
+
+[pack]
+name = "gastown"
+schema = 2
+
+[imports.gastown]
+source = "packs/gastown"
+```
+
+### `packs/gastown/pack.toml` — the reusable defaults
+
+```toml
+# Gas Town — domain-specific coding workflow pack.
+#
+# Gastown roles: mayor (coordinator), deacon (patrol), boot (watchdog),
+# plus rig-scoped agents (witness, refinery, polecat).
+# Dog (utility pool) is defined here with tmux theming; maintenance provides
+# the fallback (unthemed) dog. Mechanical housekeeping lives in maintenance.
+#
+# Referenced by both workspace.pack and rigs[].pack:
+#   workspace.pack → expands city-scoped agents only (mayor, deacon, boot)
+#   rigs[].pack    → expands rig agents only (witness, refinery, polecat)
+#
+# Crew members are individually named directory agents (agents/<name>/) plus a
+# named session; see the crew member note in the city file above.
+
+[pack]
+name = "gastown"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+
+[global]
+session_live = [
+    "{{.ConfigDir}}/assets/scripts/tmux-theme.sh {{.Session}} {{.Agent}} {{.ConfigDir}}",
+    "{{.ConfigDir}}/assets/scripts/tmux-keybindings.sh {{.ConfigDir}}",
+]
+
+[[patches.agent]]
+name = "dog"
+wake_mode = "fresh"
+work_dir = ".gc/agents/dogs/{{.AgentBase}}"
+
+[[named_session]]
+template = "mayor"
+scope = "city"
+mode = "always"
+
+[[named_session]]
+template = "deacon"
+scope = "city"
+mode = "always"
+
+[[named_session]]
+template = "boot"
+scope = "city"
+mode = "always"
+
+[[named_session]]
+template = "witness"
+scope = "rig"
+mode = "always"
+
+[[named_session]]
+template = "refinery"
+scope = "rig"
+mode = "on_demand"
+```

--- a/docs/guides/gastown-config-recipes.md
+++ b/docs/guides/gastown-config-recipes.md
@@ -105,6 +105,7 @@ agents/wolf/
 ```toml
 # agents/wolf/agent.toml
 scope = "rig"
+dir = "myproject"
 nudge = "Check your hook and mail, then act accordingly."
 work_dir = ".gc/worktrees/myproject/crew/wolf"
 idle_timeout = "4h"

--- a/docs/guides/gastown-config-recipes.md
+++ b/docs/guides/gastown-config-recipes.md
@@ -1,0 +1,135 @@
+---
+title: Gastown on Gas City — Config Recipes
+description: Task-oriented config overrides for running the Gastown pack on Gas City — register rigs, scale pools, swap providers, patch agents, and tweak prompts.
+---
+
+This page collects the common config edits for the Gastown pack — the changes
+you reach for *while editing files*. The conceptual migration story, including
+how Gas Town roles and mechanisms map onto Gas City primitives, lives in
+[Coming from Gas Town](/getting-started/coming-from-gastown).
+
+## Common Gastown Overrides
+
+If you are using the Gastown pack, these are the most common local changes.
+
+### Register a rig
+
+Import the Gastown pack in the root pack, then bind rigs in `city.toml` and with `gc rig add`:
+
+```toml
+# pack.toml
+[pack]
+name = "my-city"
+schema = 2
+
+[imports.gastown]
+source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
+version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
+```
+
+```toml
+# city.toml
+[[rigs]]
+name = "myproject"
+
+[rigs.imports.gastown]
+source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
+version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
+```
+
+```bash
+gc rig add /path/to/myproject --name myproject
+```
+
+### Increase or shrink scalable polecat sessions
+
+This is the cleanest answer to "I want more or fewer polecats for this rig."
+
+```toml
+# city.toml
+[[rigs]]
+name = "myproject"
+
+[rigs.imports.gastown]
+source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
+version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
+
+[[rigs.patches]]
+agent = "gastown.polecat"
+
+[rigs.patches.pool]
+max = 10
+```
+
+### Change the provider for one rig's polecats
+
+```toml
+# city.toml
+[[rigs]]
+name = "myproject"
+
+[rigs.imports.gastown]
+source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
+version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
+
+[[rigs.patches]]
+agent = "gastown.polecat"
+provider = "codex"
+```
+
+You can combine that with session scale overrides, env, prompt changes, or hook changes on the same override block.
+
+### Change a city-scoped Gastown agent
+
+City-scoped agents such as `mayor`, `deacon`, and `boot` are easiest to tweak with patches:
+
+```toml
+[[patches.agent]]
+name = "gastown.mayor"
+provider = "codex"
+idle_timeout = "2h"
+```
+
+Use patches when the target is already a concrete city-scoped agent. Use `[[rigs.patches]]` when the target is a pack agent stamped per rig.
+
+### Add a named crew agent
+
+Crew is usually city-specific, so it often belongs in the root city pack rather than in the shared Gastown pack:
+
+```text
+agents/wolf/
+├── agent.toml
+└── prompt.template.md
+```
+
+```toml
+# agents/wolf/agent.toml
+scope = "rig"
+nudge = "Check your hook and mail, then act accordingly."
+work_dir = ".gc/worktrees/myproject/crew/wolf"
+idle_timeout = "4h"
+```
+
+That keeps the shared pack generic while still letting your city have named long-lived workers.
+
+### Change a prompt, overlay, or timeout without forking the pack
+
+This is what rig overrides are for:
+
+```toml
+# city.toml
+[[rigs]]
+name = "myproject"
+
+[rigs.imports.gastown]
+source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
+version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
+
+[[rigs.patches]]
+agent = "gastown.refinery"
+idle_timeout = "4h"
+```
+
+For prompt or overlay replacement, patch the imported agent from your root city pack rather than editing the shared pack in place.
+
+If that change turns out to be broadly useful across cities, that is when it should move into the pack.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1702,7 +1702,7 @@ gc init
   gc init --default-provider codex --bootstrap-profile k8s-cell /city
   gc init --name my-city
   gc init --from ~/elan --name elan /city
-  gc init --file examples/gastown.toml ~/bright-lights
+  gc init --file ./my-city.toml ~/bright-lights
   gc init --file city.toml --preserve-existing .
 ```
 


### PR DESCRIPTION
Combines two tightly-coupled, docs-only changes from the User Docs Overhaul. #3136 is the base for #3088 — the example #3088 adds lives on the page #3136 creates — so they ship as one PR for a single review with full context.

## #3136 — extract config recipes into their own page

The Gastown config-override recipes (register a rig, scale pools, swap providers, patch agents, tweak prompts) move out of `coming-from-gastown.md` into a dedicated **Gastown on Gas City — Config Recipes** page (`docs/guides/gastown-config-recipes.md`), keeping the migration guide lean and conceptual. The guide now links across to the recipes page.

## #3088 — embed the real worked example

- Adds a `## A Complete Gastown Example` section to the recipes page, inlining the three real example assets from `examples/gastown/` (PackV2, `schema = 2`): the city deployment, the root pack, and the nested reusable-defaults pack — assembled into one runnable topology.
- Two `examples/`-path references inside the inlined assets are generalized so the embedded copy is self-contained (the whole point: no dangling repo paths in rendered docs). Every other line is inlined verbatim:
  - `city.toml` `# To use:` comment → `save these three files into a city directory, then run gc start <city-dir>` (was `gc start examples/gastown/`).
  - nested `packs/gastown/pack.toml` crew note → `see the crew member note in the city file above` (was `see the worked example in examples/gastown/city.toml`), which resolves correctly because the city file is rendered directly above it on the page.
- The migration guide gets a 6th Fast Ramp Checklist item linking to the embedded example (a resolvable Mintlify anchor, not a dangling repo path).
- Fixes the one remaining dangling `examples/` path in user-facing docs: `cmd/gc/cmd_init.go`'s example `gc init --file examples/gastown.toml ...` → `./my-city.toml`, with `docs/reference/cli.md` regenerated.

The example renders as inline content, so it is offline/PDF-safe. No bare `examples/`/`rigs/` asset path remains in user-facing docs.

## Verification

- `go test ./cmd/gc/ -run 'TestCLIDocsFreshness|TestGenDoc'` passes
- `go vet ./cmd/gc/` clean
- No bare `examples/` asset path remains in **user-facing** docs. `grep -rEn 'examples/gastown|examples/[a-z]+\.toml' docs/` returns only `docs/plans/durable-mouse-wheel-scrollback.md` — internal planning notes that aren't part of the rendered doc set and are unrelated to this change.

Closes #3136
Closes #3088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
