### PR TITLE
fix(api): resume MouseOn=false for polled pool agents (ga-c4w #1 regression)

### DIFF
--- a/internal/api/session_resolved_config_test.go
+++ b/internal/api/session_resolved_config_test.go
@@ -143,17 +143,20 @@ func TestSessionCreateHintsEnablesMouse(t *testing.T) {
 	}
 }
 
-// TestSessionResumeHintsEnablesMouse locks ga-c4w finding #2: an interactive
-// (API-created) session that is suspended/resumed or crash-restarted must keep
-// mouse-on so the tmux wheel still drives copy-mode scrollback after resume —
-// symmetric with sessionCreateHints. Without it the wheel works on first create
-// but is silently lost on the first resume. Headless agents are controller-owned
-// and re-resolve MouseOn via cmd/gc/template_resolve.go (mouse-off), so resume
-// mouse-on never reaches a polled agent.
+// TestSessionResumeHintsEnablesMouse locks ga-c4w finding #2 and its ga-g7go
+// follow-up: an interactive (session_origin=manual) session that is suspended/
+// resumed or crash-restarted must keep mouse-on so the tmux wheel still drives
+// copy-mode scrollback after resume — symmetric with sessionCreateHints. A
+// controller-polled pool/headless resume must resolve mouse-OFF instead: the
+// resume seam may not re-enable mouse on a polled agent. The earlier form proved
+// only the interactive case and let the unconditional MouseOn=true default leak
+// mouse-on onto resumed pool agents (ga-g7go).
 func TestSessionResumeHintsEnablesMouse(t *testing.T) {
-	hints := sessionResumeHints(&config.ResolvedProvider{Name: "stub"}, "", nil, nil)
-	if !hints.MouseOn {
-		t.Error("sessionResumeHints().MouseOn = false, want true (interactive wheel survives resume, ga-c4w)")
+	if hints := sessionResumeHints(&config.ResolvedProvider{Name: "stub"}, "", nil, nil, true); !hints.MouseOn {
+		t.Error("sessionResumeHints(interactive=true).MouseOn = false, want true (interactive wheel survives resume, ga-c4w)")
+	}
+	if hints := sessionResumeHints(&config.ResolvedProvider{Name: "stub"}, "", nil, nil, false); hints.MouseOn {
+		t.Error("sessionResumeHints(interactive=false).MouseOn = true, want false (polled pool agent stays mouse-off, ga-g7go)")
 	}
 }
 

--- a/internal/api/session_runtime.go
+++ b/internal/api/session_runtime.go
@@ -97,7 +97,21 @@ func legacySessionKind(metadata map[string]string) string {
 	return strings.TrimSpace(metadata["real_world_app_session_kind"])
 }
 
-func sessionResumeHints(resolved *config.ResolvedProvider, workDir string, sessionEnv map[string]string, mcpServers []runtime.MCPServerConfig) runtime.Config {
+// sessionResumeHints builds the resume runtime hints. The interactive flag gates
+// MouseOn: only an interactive, human-attached resume (session_origin=manual)
+// keeps the tmux wheel→copy-mode scrollback alive across suspend/resume +
+// crash-restart, symmetric with sessionCreateHints and the create path's
+// session_origin=="manual" gate in templateParamsToConfig (ga-c4w finding #2).
+//
+// A controller-polled pool/headless agent resolves mouse-OFF here. The resume
+// seam must never re-enable mouse on a polled session: the original assumption
+// that "headless agents re-resolve MouseOn mouse-off downstream via
+// template_resolve.go" does NOT hold for the API worker-factory resume path
+// (resolveWorkerSessionRuntimeWithMetadata builds runtime.Config directly and
+// never routes through template_resolve.go), so an unconditional MouseOn=true
+// leaked mouse-on onto resumed pool agents and broke ga-c4w's controller-poll
+// -safety invariant (regression ga-g7go).
+func sessionResumeHints(resolved *config.ResolvedProvider, workDir string, sessionEnv map[string]string, mcpServers []runtime.MCPServerConfig, interactive bool) runtime.Config {
 	return runtime.Config{
 		WorkDir:                workDir,
 		Lifecycle:              runtime.Lifecycle(resolved.Lifecycle),
@@ -106,16 +120,24 @@ func sessionResumeHints(resolved *config.ResolvedProvider, workDir string, sessi
 		ProcessNames:           resolved.ProcessNames,
 		EmitsPermissionWarning: resolved.EmitsPermissionWarning,
 		AcceptStartupDialogs:   resolved.AcceptStartupDialogs,
-		// ga-c4w finding #2: keep interactive (API-created) sessions mouse-on
-		// across suspend/resume + crash-restart, symmetric with sessionCreateHints.
-		// Without this the wheel→scrollback works on first create but is lost on
-		// the first resume. Headless agents are controller-owned and re-resolve
-		// MouseOn via cmd/gc/template_resolve.go (mouse-off), so this never enables
-		// mouse on a polled agent.
-		MouseOn:    true,
-		Env:        sessionEnv,
-		MCPServers: mcpServers,
+		MouseOn:                interactive,
+		Env:                    sessionEnv,
+		MCPServers:             mcpServers,
 	}
+}
+
+// sessionResumeInteractive reports whether a resumed session is interactive and
+// human-attached (session_origin=manual) versus a controller-polled pool/headless
+// agent. It mirrors the create-path gate templateParamsSessionOrigin(tp)=="manual"
+// in templateParamsToConfig so the resume seam resolves MouseOn the same way the
+// create seam does. Unknown/empty origins default to non-interactive: the safe
+// direction is never to enable mouse on a polled agent (ga-c4w poll-safety,
+// ga-g7go regression fix).
+func sessionResumeInteractive(metadata map[string]string) bool {
+	if metadata == nil {
+		return false
+	}
+	return strings.TrimSpace(metadata["session_origin"]) == "manual"
 }
 
 func resumeSessionIdentity(info session.Info, metadata map[string]string) string {
@@ -331,7 +353,7 @@ func (s *Server) buildSessionResume(info session.Info) (string, runtime.Config, 
 	resolvedInfo.ResumeStyle = resolved.ResumeStyle
 	resolvedInfo.ResumeCommand = resumeCommand
 	sessionEnv := cityAnchoredSessionEnv(s.state.CityPath(), resolved.Env)
-	return session.BuildResumeCommand(resolvedInfo), sessionResumeHints(resolved, workDir, sessionEnv, mcpServers), nil
+	return session.BuildResumeCommand(resolvedInfo), sessionResumeHints(resolved, workDir, sessionEnv, mcpServers, sessionResumeInteractive(metadata)), nil
 }
 
 func (s *Server) resolvedSessionRuntimeCommand(resolved *config.ResolvedProvider, transport, storedCommand string, metadata map[string]string) (string, error) {
@@ -454,7 +476,7 @@ func (s *Server) resolveWorkerSessionRuntimeWithMetadata(info session.Info, _ st
 		WorkDir:    firstNonEmptyString(info.WorkDir, workDir),
 		Provider:   firstNonEmptyString(info.Provider, resolved.Name),
 		SessionEnv: sessionEnv,
-		Hints:      sessionResumeHints(resolved, firstNonEmptyString(workDir, info.WorkDir), sessionEnv, mcpServers),
+		Hints:      sessionResumeHints(resolved, firstNonEmptyString(workDir, info.WorkDir), sessionEnv, mcpServers, sessionResumeInteractive(metadata)),
 		Resume: session.ProviderResume{
 			ResumeFlag:    firstNonEmptyString(resolved.ResumeFlag, info.ResumeFlag),
 			ResumeStyle:   firstNonEmptyString(resolved.ResumeStyle, info.ResumeStyle),

--- a/internal/api/worker_factory_test.go
+++ b/internal/api/worker_factory_test.go
@@ -572,6 +572,58 @@ func TestResolveWorkerSessionRuntimeFallsBackToStoredCommandWhenTemplateOverride
 	}
 }
 
+// TestResolveWorkerSessionRuntimeResolvesMouseOnlyForInteractiveResume locks the
+// ga-c4w controller-poll-safety invariant on the API worker-factory resume seam
+// (regression ga-g7go): a resumed pool/headless agent must resolve mouse-OFF so
+// the tmux wheel never re-enables on a controller-polled session, while an
+// interactive (session_origin=manual) resume keeps mouse-ON — symmetric with the
+// create path's session_origin=="manual" gate in templateParamsToConfig. This
+// exercises the real resolveWorkerSessionRuntimeWithMetadata -> sessionResumeHints
+// chain wired as the worker factory's ResolveSessionRuntime, not a contrived stub
+// that dodges the worker-factory path.
+func TestResolveWorkerSessionRuntimeResolvesMouseOnlyForInteractiveResume(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		metadata    map[string]string
+		wantMouseOn bool
+	}{
+		{
+			name:        "pool agent resume stays mouse-off",
+			metadata:    map[string]string{"session_origin": "worker"},
+			wantMouseOn: false,
+		},
+		{
+			name:        "interactive resume keeps mouse-on",
+			metadata:    map[string]string{"agent_name": "myrig/worker", "session_origin": "manual"},
+			wantMouseOn: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newSessionFakeState(t)
+			fs.cfg.Providers["test-agent"] = config.ProviderSpec{
+				Command:   "/bin/echo",
+				PathCheck: "true",
+			}
+
+			srv := New(fs)
+			runtimeCfg, err := srv.resolveWorkerSessionRuntimeWithMetadata(session.Info{
+				Template: "myrig/worker",
+				Provider: "test-agent",
+				WorkDir:  t.TempDir(),
+			}, "", tc.metadata)
+			if err != nil {
+				t.Fatalf("resolveWorkerSessionRuntimeWithMetadata: %v", err)
+			}
+			if runtimeCfg == nil {
+				t.Fatal("resolveWorkerSessionRuntimeWithMetadata() = nil")
+			}
+			if got := runtimeCfg.Hints.MouseOn; got != tc.wantMouseOn {
+				t.Errorf("Hints.MouseOn = %v, want %v (poll-safety: mouse-on only for interactive resume)", got, tc.wantMouseOn)
+			}
+		})
+	}
+}
+
 func TestResolveWorkerSessionRuntimeUsesProviderACPDefaultWithoutTemplateSessionOverride(t *testing.T) {
 	supportsACP := true
 	fs := newSessionFakeState(t)


### PR DESCRIPTION
## Summary

Post-merge regression fix for **ga-c4w / PR #3103**. `internal/api`
`sessionResumeHints` emitted `MouseOn: true` **unconditionally** for every
resumed session — including pool/headless agents resumed through the API worker
factory — re-enabling tmux mouse on controller-polled sessions and breaking
ga-c4w's controller-poll-safety invariant.

This is human reviewer **sjarmak's MAJOR #1** (review 4437810731), which was
dismissed and merged without a code fix.

## Root cause

`resolveWorkerSessionRuntimeWithMetadata` (wired as the worker factory's
`ResolveSessionRuntime` in `worker_factory.go`) calls `sessionResumeHints` and
builds `runtime.Config` **directly** — it never routes through
`cmd/gc/template_resolve.go`. So the in-code assumption that headless agents
"re-resolve MouseOn mouse-off downstream" did not hold for this path, and a
resumed pool agent got mouse **on**. `MouseOn` has exactly one consumer
(`internal/runtime/tmux/adapter.go`: `if !cfg.MouseOn { disableMouseAndActivity }`),
so `MouseOn=true` means mouse is not disabled.

## Fix

Gate `MouseOn` on an explicit interactive signal instead of hardcoding `true`:

- `sessionResumeHints(..., interactive bool)` sets `MouseOn: interactive`.
- `sessionResumeInteractive(metadata)` derives it from `session_origin == "manual"`,
  mirroring the create-path gate `templateParamsSessionOrigin(tp) == "manual"` in
  `templateParamsToConfig`.
- Both resume call sites (`buildSessionResume`, `resolveWorkerSessionRuntimeWithMetadata`)
  pass the metadata-derived signal.

Only interactive (human-attached) resumes keep mouse-on. Pool/headless resumes —
and any unknown/empty origin — resolve mouse-**off** (the safe direction: never
enable mouse on a polled agent).

## Test plan

- **RED→GREEN:** new `TestResolveWorkerSessionRuntimeResolvesMouseOnlyForInteractiveResume`
  exercises the real worker-factory resolver (`resolveWorkerSessionRuntimeWithMetadata`,
  not a stub) for both cases: pool agent (`session_origin=worker`) → `MouseOn=false`,
  interactive (`session_origin=manual`) → `MouseOn=true`. Failed first on the
  pool case (`MouseOn = true, want false`), passes after the fix.
- `TestSessionResumeHintsEnablesMouse` extended with the `interactive=false` →
  `MouseOn=false` case (previously proved only the true case).
- `go test ./internal/api/` green; `go vet ./internal/api/` clean.

Refs ga-g7go, ga-c4w #1 (sjarmak review 4437810731), PR #3103.
