### PR TITLE
fix(session): refresh resolved-provider metadata on provider switch

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -200,18 +200,26 @@ func stampResolvedProviderSessionMetadata(meta map[string]string, resolved *conf
 	}
 }
 
-func queueMissingResolvedProviderSessionMetadata(existing map[string]string, queue func(string, string), resolved *config.ResolvedProvider) {
+// queueChangedResolvedProviderSessionMetadata queues the resolved-provider
+// projection fields (provider, provider_kind, builtin_ancestor) whenever the
+// freshly resolved value differs from what is stored, mirroring the command
+// refresh so a provider switch in agent.toml is reflected on the session bead
+// (gc-rhp36). It is diff-gated (no write when unchanged, honoring the
+// write-if-changed reconcile contract) and never clobbers a stored value with
+// an empty resolved one — a transient resolution failure must not wipe good
+// metadata.
+func queueChangedResolvedProviderSessionMetadata(existing map[string]string, queue func(string, string), resolved *config.ResolvedProvider) {
 	if queue == nil || resolved == nil {
 		return
 	}
 	name := strings.TrimSpace(resolved.Name)
-	if existing["provider"] == "" && name != "" {
+	if name != "" && existing["provider"] != name {
 		queue("provider", name)
 	}
-	if family := resolvedProviderFamilyMetadata(resolved); existing["provider_kind"] == "" && family != "" {
+	if family := resolvedProviderFamilyMetadata(resolved); family != "" && existing["provider_kind"] != family {
 		queue("provider_kind", family)
 	}
-	if ancestor := strings.TrimSpace(resolved.BuiltinAncestor); existing["builtin_ancestor"] == "" && ancestor != "" && ancestor != name {
+	if ancestor := strings.TrimSpace(resolved.BuiltinAncestor); ancestor != "" && ancestor != name && existing["builtin_ancestor"] != ancestor {
 		queue("builtin_ancestor", ancestor)
 	}
 }
@@ -1339,26 +1347,29 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		if b.Metadata["continuation_epoch"] == "" {
 			queueMeta("continuation_epoch", strconv.Itoa(session.DefaultContinuationEpoch))
 		}
-		// Refresh command and resume fields. The stored command is used for
-		// `gc session attach` and — on legacy code paths — can act as the
-		// authoritative command source for respawn. If agent config changes
-		// (e.g., adding `[option_defaults] model = "opus"`), the freshly
-		// resolved tp.Command will differ from the stored value; sync here
-		// so the bead matches the current config. An empty tp.Command is
-		// ignored to avoid clobbering the stored value when resolution fails
-		// transiently.
+		// Refresh command, provider, and resume fields. The stored command is
+		// used for `gc session attach` and — on legacy code paths — can act as
+		// the authoritative command source for respawn. If agent config changes
+		// (e.g., adding `[option_defaults] model = "opus"`, or switching the
+		// agent's provider), the freshly resolved values differ from the stored
+		// ones; sync here so the bead matches the current config. Empty resolved
+		// values are ignored to avoid clobbering stored values when resolution
+		// fails transiently. The provider/resume projection fields follow the
+		// same diff-gated, clobber-safe refresh as command (gc-rhp36); without
+		// it they freeze at their creation-time provider after an agent.toml
+		// provider switch while command alone follows.
 		if tp.Command != "" && b.Metadata["command"] != tp.Command {
 			queueMeta("command", tp.Command)
 		}
 		if tp.ResolvedProvider != nil {
-			queueMissingResolvedProviderSessionMetadata(b.Metadata, queueMeta, tp.ResolvedProvider)
-			if b.Metadata["resume_flag"] == "" && tp.ResolvedProvider.ResumeFlag != "" {
+			queueChangedResolvedProviderSessionMetadata(b.Metadata, queueMeta, tp.ResolvedProvider)
+			if tp.ResolvedProvider.ResumeFlag != "" && b.Metadata["resume_flag"] != tp.ResolvedProvider.ResumeFlag {
 				queueMeta("resume_flag", tp.ResolvedProvider.ResumeFlag)
 			}
-			if b.Metadata["resume_style"] == "" && tp.ResolvedProvider.ResumeStyle != "" {
+			if tp.ResolvedProvider.ResumeStyle != "" && b.Metadata["resume_style"] != tp.ResolvedProvider.ResumeStyle {
 				queueMeta("resume_style", tp.ResolvedProvider.ResumeStyle)
 			}
-			if b.Metadata["resume_command"] == "" && tp.ResolvedProvider.ResumeCommand != "" {
+			if tp.ResolvedProvider.ResumeCommand != "" && b.Metadata["resume_command"] != tp.ResolvedProvider.ResumeCommand {
 				queueMeta("resume_command", tp.ResolvedProvider.ResumeCommand)
 			}
 		}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -4203,6 +4203,115 @@ func TestSyncSessionBeads_RefreshesStoredCommandOnConfigChange(t *testing.T) {
 	}
 }
 
+// TestSyncSessionBeads_RefreshesResolvedProviderMetadataOnProviderSwitch is the
+// gc-rhp36 guard. #1044 made the stored `command` refresh on config change, but
+// the resolved-provider projection fields (provider, provider_kind,
+// builtin_ancestor, resume_flag, resume_style, resume_command) were left
+// backfill-only on the observe path, so they freeze at their creation-time
+// values when agent.toml switches an agent's provider (e.g. the 2026-05-15
+// claude->omp switch on the mayor): `command` follows but `provider` does not.
+// Those stale fields are consumed by cmd_nudge.go, cmd_session_logs.go and
+// mcp_integration.go. This test extends #1044's refresh-on-change contract to
+// the resolved-provider fields.
+func TestSyncSessionBeads_RefreshesResolvedProviderMetadataOnProviderSwitch(t *testing.T) {
+	store := beads.NewMemStore()
+	// countingStore lets the churn tick assert that an unchanged sync writes
+	// nothing (diff-gated), the load-bearing property for #1205.
+	cs := &countingStore{Store: store}
+	clk := &clock.Fake{Time: time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	_ = sp.Start(context.TODO(), "mayor", runtime.Config{Command: "claude --dangerously-skip-permissions"})
+
+	// Tick 1: session created on the claude provider. provider_kind and
+	// builtin_ancestor derive from BuiltinAncestor (resolvedProviderFamilyMetadata),
+	// not the deprecated Kind field, so the literals omit Kind.
+	claudeCmd := "claude --dangerously-skip-permissions"
+	ds := map[string]TemplateParams{
+		"mayor": {
+			TemplateName: "mayor",
+			Command:      claudeCmd,
+			ResolvedProvider: &config.ResolvedProvider{
+				Name: "claude-max", BuiltinAncestor: "claude",
+				ResumeFlag: "--resume", ResumeStyle: "flag", ResumeCommand: "claude --resume",
+			},
+		},
+	}
+	var stderr bytes.Buffer
+	syncSessionBeads("", cs, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+
+	beads1 := allSessionBeads(t, cs)
+	if len(beads1) != 1 {
+		t.Fatalf("expected 1 bead after tick 1, got %d", len(beads1))
+	}
+	if got := beads1[0].Metadata["provider"]; got != "claude-max" {
+		t.Fatalf("tick 1: provider = %q, want claude-max", got)
+	}
+
+	// Tick 2: agent.toml provider switched to omp. The resolved provider now
+	// reports omp with deliberately DIFFERENT resume semantics (resume by
+	// session-id, not --resume). The divergent resume values are intentional:
+	// they exercise the generic refresh-on-change contract for a provider whose
+	// resume behavior differs from the prior one (#1655 makes resume_flag
+	// load-bearing in the stale-key recovery path). Do NOT "correct" them to
+	// match claude — in this deployment omp happens to share claude's --resume,
+	// but the bug is the frozen-projection mechanism, not the specific values.
+	ompCmd := "omp --hook .omp/hooks/gc-hook.ts"
+	ds["mayor"] = TemplateParams{
+		TemplateName: "mayor",
+		Command:      ompCmd,
+		ResolvedProvider: &config.ResolvedProvider{
+			Name: "omp-azure", BuiltinAncestor: "omp",
+			ResumeFlag: "-r", ResumeStyle: "session-id", ResumeCommand: "omp -r",
+		},
+	}
+	clk.Advance(3 * 24 * time.Hour)
+	syncSessionBeads("", cs, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+
+	got := allSessionBeads(t, cs)[0].Metadata
+	for _, c := range []struct{ key, want string }{
+		{"command", ompCmd},
+		{"provider", "omp-azure"},
+		{"provider_kind", "omp"},
+		{"builtin_ancestor", "omp"},
+		{"resume_flag", "-r"},
+		{"resume_style", "session-id"},
+		{"resume_command", "omp -r"},
+	} {
+		if got[c.key] != c.want {
+			t.Errorf("tick 2: %s = %q, want %q\ngc-rhp36: resolved-provider metadata must refresh on a provider switch, like command does (#1044)", c.key, got[c.key], c.want)
+		}
+	}
+
+	// Tick 3 (churn guard): re-running with the SAME resolved provider must queue
+	// no metadata and therefore write nothing. event_hooks defaults to true
+	// upstream, so an unconditional rewrite would forward a bead event every tick
+	// (the #1205 churn pathology). The refresh is diff-gated, so a no-op sync must
+	// not write.
+	writesBefore := cs.writes
+	clk.Advance(time.Minute)
+	syncSessionBeads("", cs, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+	if cs.writes != writesBefore {
+		t.Errorf("tick 3: unchanged sync wrote metadata (%d -> %d writes); the refresh must be diff-gated (#1205)", writesBefore, cs.writes)
+	}
+	if got := allSessionBeads(t, cs)[0].Metadata["provider"]; got != "omp-azure" {
+		t.Errorf("tick 3: provider changed on a no-op sync: got %q, want omp-azure", got)
+	}
+
+	// Tick 4 (clobber guard): a nil ResolvedProvider (transient resolution
+	// failure) must NOT wipe the cached values — mirror the `command != ""`
+	// guard that #1044 added.
+	ds["mayor"] = TemplateParams{TemplateName: "mayor", Command: ompCmd, ResolvedProvider: nil}
+	clk.Advance(time.Minute)
+	syncSessionBeads("", cs, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+	if got := allSessionBeads(t, cs)[0].Metadata["provider"]; got != "omp-azure" {
+		t.Errorf("tick 4: nil ResolvedProvider clobbered provider: got %q, want omp-azure", got)
+	}
+
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
 func TestSyncSessionBeadsWithSnapshot_RefreshesMissingNamedSessionFromStore(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## What

Completes the refresh-on-change contract #1044 established for the session bead's stored `command`. #1044 made `command` follow `agent.toml` changes on the reconciler's observe path, but left the resolved-provider projection fields (`provider`, `provider_kind`, `builtin_ancestor`, `resume_flag`, `resume_style`, `resume_command`) as **backfill-only** (set only when missing). So when an agent's `provider` is switched in `agent.toml`, the freshly resolved `command` follows but those fields freeze at their creation-time provider.

## Why it matters (not cosmetic)

The stale `provider` metadata is consumed by live code paths:
- `cmd/gc/cmd_nudge.go` builds `config.ResolvedProvider{Name: bead.Metadata["provider"]}` — a switched agent resolves the **prior** provider.
- `cmd/gc/cmd_session_logs.go` and `cmd/gc/mcp_integration.go` read it for log-path / MCP provider-kind resolution.
- Stale `resume_flag`/`resume_command` would feed the wrong value into the stale-key recovery path (`internal/session/chat.go`, #1655) for a provider whose resume semantics differ from the prior one.

It's also a prerequisite for #3117 (runtime-mutable per-agent-class provider override for quota failover): a config-edit-and-reload provider switch would otherwise leave the cached metadata stale on every failover.

## Fix

A new `queueChangedResolvedProviderSessionMetadata` (replacing the backfill-only `queueMissing…`) re-stamps the six fields when the freshly resolved value differs, and the three resume guards switch from `== ""` to `!= resolved`. Mirrors the existing `command` refresh at `session_beads.go`.

## Principle / safety

- **ZFC / transport-only:** keeps a cached projection of resolved config in sync with that config — same class of operation as the `command` refresh, no judgment. Lives inside the accepted "repair drift in place" contract (`session-model-unification.md`, *Config Drift and Restart*); these are non-fingerprinted fields, so the repair needs no runtime liveness and triggers no restart.
- **Diff-gated:** each field is written only when it differs from the stored value, so steady-state ticks produce zero writes (write-if-changed reconcile contract, #1205 — matters because `[beads].event_hooks` defaults to true). A test asserts the no-write property on an unchanged tick.
- **Clobber-safe:** an empty/nil resolved value never overwrites a stored value (mirrors the `command != ""` guard).
- **Fingerprint-safe:** `provider`/`resume_*`/`builtin_ancestor` are not in `runtime.CoreFingerprint`, so refreshing them cannot induce a drift restart.

## Known limitation

Switching *to* a fully-custom provider (empty `BuiltinAncestor`) leaves `provider_kind`/`builtin_ancestor` stale, because the clobber-safe rule can't distinguish "empty from transient failure" (must preserve) from "empty because genuinely custom" (should clear). `provider` itself always refreshes for any named provider, and all consumers fall back `provider_kind || provider`. The common builtin→builtin switch (e.g. claude→omp) is unaffected.

## Alternative considered

Removing the cache entirely and resolving fresh in the three consumers is the more ZFC-pure end-state, but a larger refactor that changes the persistence contract `gc session attach` / respawn depend on. Deferred; this PR completes the established refresh-on-change pattern.

## Tests

`TestSyncSessionBeads_RefreshesResolvedProviderMetadataOnProviderSwitch` extends the `TestSyncSessionBeads_*` harness (the #1044 test `RefreshesStoredCommandOnConfigChange` is the direct template): create on claude → switch to omp (all six fields refresh) → unchanged re-sync writes nothing (churn guard, via a counting store) → nil `ResolvedProvider` does not clobber.
