### PR TITLE
fix(bd_env): add currentResolvableManagedDoltPort fallback in resolvedRuntimeCityDoltTarget

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -864,6 +864,19 @@ func resolvedRuntimeCityDoltTarget(cityPath string, allowRecovery bool) (contrac
 			}
 		}
 	}
+	// Last-resort: when all other recovery paths have been exhausted but the
+	// managed Dolt lifecycle is owned, attempt to read the port directly from
+	// provider state using the symlink-aware validation path. This handles the
+	// case where currentPublishedOrRecoveredManagedDoltPort encounters a publish
+	// failure (e.g., write permission error, post-publish re-validation failure)
+	// while the server is still accessible.
+	if allowRecovery {
+		if owned, _ := managedDoltLifecycleOwned(cityPath); owned {
+			if port := currentResolvableManagedDoltPort(cityPath); port != "" {
+				return contract.DoltConnectionTarget{Host: defaultManagedDoltHost, Port: port}, true, nil
+			}
+		}
+	}
 	if recoveryErr != nil {
 		return contract.DoltConnectionTarget{}, false, recoveryErr
 	}

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -759,6 +759,61 @@ dolt.auto-start: false
 	requireErrorContains(t, err, "managed dolt lifecycle is not owned")
 }
 
+func TestResolvedRuntimeCityDoltTargetFallsBackToResolvablePortWhenPublishWriteFails(t *testing.T) {
+	// Regression test for ga-crh00: when publishManagedDoltRuntimeStateFromState
+	// cannot write dolt-state.json (e.g., write permission failure), the function
+	// must still return the port via the currentResolvableManagedDoltPort fallback
+	// rather than surfacing the publish error.
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("GC_DOLT_HOST")
+	_ = os.Unsetenv("GC_DOLT_PORT")
+	_ = os.Unsetenv("GC_DOLT_USER")
+	_ = os.Unsetenv("GC_DOLT_PASSWORD")
+
+	cityPath := t.TempDir()
+	writeMinimalCityToml(t, cityPath)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: demo
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := writeReachableProviderManagedDoltState(t, cityPath)
+
+	// Make the dolt state dir read-only to force publishManagedDoltRuntimeStateFromState
+	// to fail — it cannot write dolt-state.json to the read-only directory.
+	doltStateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.Chmod(doltStateDir, 0o555); err != nil {
+		t.Fatalf("chmod state dir read-only: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(doltStateDir, 0o755)
+	})
+
+	target, ok, err := resolvedRuntimeCityDoltTarget(cityPath, true)
+	if err != nil {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() error = %v, want fallback to resolvable port", err)
+	}
+	if !ok {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() ok = false, want fallback target")
+	}
+	if target.Port != strconv.Itoa(port) {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() port = %q, want %d", target.Port, port)
+	}
+	if target.Host != defaultManagedDoltHost {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() host = %q, want %q", target.Host, defaultManagedDoltHost)
+	}
+	if _, err := os.Stat(managedDoltStatePath(cityPath)); !os.IsNotExist(err) {
+		t.Fatalf("published state should remain absent when write was blocked, stat err = %v", err)
+	}
+}
+
 func TestResolvedRuntimeCityDoltTargetDoesNotMaskInvalidCanonicalConfigWithProviderState(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")


### PR DESCRIPTION
## What this changes

The supervisor's bd-backed store setup now has a final recovery path when publishing managed Dolt runtime state fails. Instead of handing bd an empty `BEADS_DOLT_SERVER_PORT` and letting it resolve to `:0`, it reads the current managed provider state through the existing symlink-aware validation path and returns that port when recovery is allowed.

This affects supervisor-spawned bd subprocesses used by cache priming and reconcile paths. Normal published-state behavior remains the first choice; the fallback only runs after other recovery paths fail and only when the city owns the managed Dolt lifecycle.

## Review notes

- `cmd/gc/bd_env.go`: new fallback inside `resolvedRuntimeCityDoltTarget`.
- `cmd/gc/bd_env_test.go`: regression coverage forces a publish write failure and verifies the fallback returns the managed port without writing state.
- No config shape, API, generated schema, dashboard, or migration changes.

## Test plan

- [x] `go test ./cmd/gc -run 'TestResolvedRuntimeCityDoltTargetFallsBackToResolvablePortWhenPublishWriteFails|TestBdRuntimeEnv' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-4febxl-bd-env-resolvable-port-fallback-gate.md`](https://github.com/quad341/gascity/blob/92168fc1cf80cccc75f1d629d4680392612a9fa6/release-gates/ga-4febxl-bd-env-resolvable-port-fallback-gate.md)