### PR TITLE
fix(config): resolve locked remote imports for tree-URL and ref'd includes

### DIFF
--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -97,28 +97,25 @@ func parseGitHubTreeURL(s string) (source, subpath, ref string) {
 // resolvePackRef resolves a pack reference to a local directory.
 // Handles local paths, GitHub tree URLs, and git source//sub#ref URLs.
 func resolvePackRef(ref, declDir, cityRoot string) (string, error) {
-	if isGitHubTreeURL(ref) {
-		source, subpath, gitRef := parseGitHubTreeURL(ref)
-		cacheDir, err := fetchRemoteInclude(source, gitRef, cityRoot)
-		if err != nil {
-			return "", err
-		}
-		if subpath != "" {
-			return filepath.Join(cacheDir, subpath), nil
-		}
-		return cacheDir, nil
-	}
-	if isRemoteInclude(ref) {
+	if isGitHubTreeURL(ref) || isRemoteInclude(ref) {
+		// parseRemoteInclude handles GitHub tree/blob URLs too
+		// (remotesource.Parse short-circuits to ParseGitHubTreeOrBlob),
+		// so a single parse covers both remote forms.
 		source, subpath, gitRef := parseRemoteInclude(ref)
-		if gitRef == "" {
-			if cacheDir, ok, err := resolveLockedRemoteImport(ref, cityRoot); err != nil {
-				return "", err
-			} else if ok {
-				if subpath != "" {
-					return filepath.Join(cacheDir, subpath), nil
-				}
-				return cacheDir, nil
+		// packs.lock is authoritative for any remote source string it
+		// records, with or without an embedded ref: gc import install /
+		// upgrade already resolved the authored source to a commit and
+		// populated the repo cache. Consulting the lock first keeps
+		// locked imports (including registry-recommended GitHub tree
+		// URLs) resolvable without the legacy include cache, which has
+		// no remaining writer.
+		if cacheDir, ok, err := resolveLockedRemoteImport(ref, cityRoot); err != nil {
+			return "", err
+		} else if ok {
+			if subpath != "" {
+				return filepath.Join(cacheDir, subpath), nil
 			}
+			return cacheDir, nil
 		}
 		cacheDir, err := fetchRemoteInclude(source, gitRef, cityRoot)
 		if err != nil {

--- a/internal/config/pack_include_test.go
+++ b/internal/config/pack_include_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -306,5 +307,90 @@ func TestValidateInstalledRemoteCacheLockedMemoizesSuccess(t *testing.T) {
 	}
 	if calls == first {
 		t.Fatalf("changed checkout should re-run git; calls stayed %d", calls)
+	}
+}
+
+// setupLockedPackRefTest fabricates a city with a packs.lock entry for ref and
+// a valid installed repo cache for it under a temp HOME, with git stubbed out.
+func setupLockedPackRefTest(t *testing.T, ref, commit string) (cityDir, cacheDir string) {
+	t.Helper()
+	ResetRemoteCacheValidationCache()
+	t.Cleanup(ResetRemoteCacheValidationCache)
+
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	t.Setenv("HOME", home)
+	cityDir = filepath.Join(dir, "city")
+	mustMkdirAll(t, cityDir, 0o755)
+	writeTestFile(t, cityDir, "packs.lock", fmt.Sprintf(`
+schema = 1
+
+[packs.%q]
+version = "sha:%s"
+commit = %q
+fetched = "2026-06-06T00:00:00Z"
+`, ref, commit, commit))
+
+	cacheDir = filepath.Join(home, ".gc", "cache", "repos", RepoCacheKey(ref, commit))
+	mustMkdirAll(t, filepath.Join(cacheDir, ".git"), 0o755)
+	if err := os.WriteFile(filepath.Join(cacheDir, ".git", "index"), []byte("idx"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := runRepoCacheGit
+	runRepoCacheGit = func(_ string, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "rev-parse" {
+			return commit + "\n", nil
+		}
+		return "", nil // status --porcelain: clean
+	}
+	t.Cleanup(func() { runRepoCacheGit = orig })
+	return cityDir, cacheDir
+}
+
+func TestResolvePackRefUsesLockedImportForGitHubTreeURL(t *testing.T) {
+	const ref = "https://github.com/example/packs/tree/main/gastown"
+	const commit = "abcdef1234567890abcdef1234567890abcdef12"
+	cityDir, cacheDir := setupLockedPackRefTest(t, ref, commit)
+
+	got, err := resolvePackRef(ref, cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("resolvePackRef: %v", err)
+	}
+	want := filepath.Join(cacheDir, "gastown")
+	if got != want {
+		t.Fatalf("resolvePackRef = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePackRefUsesLockedImportForRefRemoteInclude(t *testing.T) {
+	const ref = "git@github.com:example/packs//gastown#main"
+	const commit = "abcdef1234567890abcdef1234567890abcdef12"
+	cityDir, cacheDir := setupLockedPackRefTest(t, ref, commit)
+
+	got, err := resolvePackRef(ref, cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("resolvePackRef: %v", err)
+	}
+	want := filepath.Join(cacheDir, "gastown")
+	if got != want {
+		t.Fatalf("resolvePackRef = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePackRefFallsBackToIncludeCacheWhenUnlocked(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	t.Setenv("HOME", home)
+	cityDir := filepath.Join(dir, "city")
+	mustMkdirAll(t, cityDir, 0o755)
+
+	const ref = "https://github.com/example/packs/tree/main/gastown"
+	_, err := resolvePackRef(ref, cityDir, cityDir)
+	if err == nil {
+		t.Fatal("expected uncached include error for unlocked remote ref")
+	}
+	if !strings.Contains(err.Error(), "is not cached") {
+		t.Fatalf("error = %v, want legacy include-cache miss", err)
 	}
 }


### PR DESCRIPTION
## Summary

`resolvePackRef` sends GitHub tree URLs — the exact source form `gc pack registry show` recommends — straight to the legacy `.gc/cache/includes/` reader, which has no remaining writer, and only consults `packs.lock` for remote-include forms **without** an embedded ref. A rig import authored as a tree URL therefore fails every config compose:

```
gc status: expanding packs: rig "gc-packs" import "gastown": remote include
https://github.com/gastownhall/gascity-packs.git#main is not cached at
<city>/.gc/cache/includes/gascity-packs-9804dc7f46ea
```

Because expansion precedes fetching in every command path, this wedges **all** config-loading gc commands town-wide — including `gc pack fetch`, so there is no in-band recovery. Reproduced on a fresh v1.1.1 city: `gc rig add` with a tree-URL default import bricks the town on the spot. Residual gap from #949, which fixed the bootstrap path (#805) for ref-less sources only.

## Fix

Consult `resolveLockedRemoteImport` for **every** remote source form (tree URL, `#ref`'d, and ref-less alike) before falling back to the legacy include cache. `packs.lock` is authoritative for any exact source string it records: `gc import install`/`upgrade` already resolved the authored source to a commit and populated `~/.gc/cache/repos/`. The two remote branches collapse into one — `parseRemoteInclude` already handles tree/blob URLs via `remotesource.Parse`.

Include-cache fallback behavior for unlocked sources is unchanged.

## Testing

- New regression tests: lock-hit resolution for a GitHub tree URL and for a `#ref`'d ssh remote include; include-cache miss error preserved when no lock entry exists
- `go test ./internal/config/ -count=1` — ok
- `go test ./cmd/gc/ -run 'TestRigAdd|TestImport|TestPack' -count=1` — ok
- `make fmt-check lint-changed` — 0 issues
- `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)