### PR TITLE
docs(coordstore): preserve R2.1b adapter sweep methodology

### DIFF
--- a/docs/coordination-store/round2/R2.1b-adapter-sweep.md
+++ b/docs/coordination-store/round2/R2.1b-adapter-sweep.md
@@ -1,0 +1,157 @@
+# R2.1b - Coordination Store Adapter Sweep
+
+> Spike: `ga-aec8q.12`
+> Date: 2026-05-23 UTC
+> Harness: `internal/benchmarks/coordstore` from commit `1458f992a`
+> Workload: `RealWorldWorkload` unless otherwise noted
+
+## Summary
+
+The harness now has adapters for the requested candidate set:
+
+| Backend | Adapter | Run status |
+|---|---|---|
+| SQLite reference | `adapters/sqlite` | Existing R2.1 reference |
+| PostgreSQL | `adapters/postgres` | Added, env-gated by `COORDSTORE_POSTGRES_DSN` |
+| CouchDB | `adapters/couchdb` | Added, env-gated by `COORDSTORE_COUCHDB_URL` |
+| Embedded KV | `adapters/boltdb` | Added, bbolt persistence with hot in-process read model |
+| Dolt baseline | `adapters/dolt` | Added, env-gated by `COORDSTORE_DOLT_DSN` |
+| Author-store-core PoC | `adapters/authorcore` | Added, zero-fork in-process indexed core |
+
+Bottom line: the in-process candidates are the only shapes that comfortably meet the current latency budget on this machine. `authorcore` and `bbolt` passed all 9 measured real-world targets. SQLite missed only point-read p99 by a narrow margin in the last run. PostgreSQL, CouchDB, and Dolt all passed correctness, but their networked/write-through shapes miss the latency targets that matter for the HQ hot path.
+
+## Harness Setup
+
+Default local run:
+
+```sh
+go test ./internal/benchmarks/coordstore -run TestBenchmarkSuite -count=1 -v
+```
+
+Real-world local candidates:
+
+```sh
+COORDSTORE_BENCH=1 go test ./internal/benchmarks/coordstore -run TestBenchmarkSuiteRealWorld -count=1 -v
+```
+
+External candidates:
+
+```sh
+COORDSTORE_POSTGRES_DSN='postgres://coordstore:coordstore@127.0.0.1:55432/coordstore?sslmode=disable' \
+  COORDSTORE_BENCH=1 go test ./internal/benchmarks/coordstore -run 'TestBenchmarkSuiteRealWorld/postgres' -count=1 -v
+
+COORDSTORE_COUCHDB_URL='http://admin:coordstore@127.0.0.1:55984/coordstore_r21b' \
+  COORDSTORE_BENCH=1 go test ./internal/benchmarks/coordstore -run 'TestBenchmarkSuiteRealWorld/couchdb' -count=1 -v -timeout 10m
+
+COORDSTORE_DOLT_DSN='root@tcp(127.0.0.1:28231)/coordstore_r21b?parseTime=true&multiStatements=true' \
+  COORDSTORE_BENCH=1 go test ./internal/benchmarks/coordstore -run 'TestBenchmarkSuiteRealWorld/dolt' -count=1 -v -timeout 8m
+```
+
+Docker socket access was denied in this session, so Postgres and CouchDB were stood up with equivalent Podman containers:
+
+```sh
+podman run -d --name coordstore-r21b-postgres \
+  -e POSTGRES_PASSWORD=coordstore \
+  -e POSTGRES_USER=coordstore \
+  -e POSTGRES_DB=coordstore \
+  -p 127.0.0.1:55432:5432 docker.io/library/postgres:16-alpine
+
+podman run -d --name coordstore-r21b-couchdb \
+  -e COUCHDB_USER=admin \
+  -e COUCHDB_PASSWORD=coordstore \
+  -p 127.0.0.1:55984:5984 docker.io/library/couchdb:3
+```
+
+## Real-World Scorecard
+
+Targets:
+
+- Point read p99 <= 1 ms
+- Main filter scan p99 <= 10 ms
+- Ephemeral filter scan p99 <= 10 ms
+- Batch fetch p99 <= 5 ms
+- Create p99 <= 5 ms
+- Update p99 <= 5 ms
+- SetMetadataBatch p99 <= 5 ms
+- Ready p99 <= 10 ms
+- Mail poll throughput >= 150/s
+
+| Backend | Point | Main filter | Eph filter | Batch | Create | Update | SetMetadata | Ready | Mail poll | Pass |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| SQLite | 1.22 ms FAIL | 2.32 ms | 2.93 ms | 2.34 ms | 1.47 ms | 1.50 ms | 2.09 ms | 3.12 ms | 3728/s | 8/9 |
+| bbolt | 537 us | 4.37 ms | 2.04 ms | 768 us | 2.00 ms | 2.98 ms | 2.32 ms | 773 us | 4125/s | 9/9 |
+| authorcore | 282 us | 3.58 ms | 1.59 ms | 440 us | 1.85 ms | 3.64 ms | 2.12 ms | 742 us | 4142/s | 9/9 |
+| PostgreSQL | 3.15 ms FAIL | 2.72 ms | 208.83 ms FAIL | 1.83 ms | 251.13 ms FAIL | 16.75 ms FAIL | 23.53 ms FAIL | 3.78 ms | 1394/s | 4/9 |
+| CouchDB | 17.62 ms FAIL | 18.93 ms FAIL | 18.36 ms FAIL | 17.68 ms FAIL | 51.98 ms FAIL | 31.82 ms FAIL | 42.26 ms FAIL | 18.08 ms FAIL | 2444/s | 1/9 |
+| Dolt SQL | 16.23 ms FAIL | 16.39 ms FAIL | 12.97 ms FAIL | 11.93 ms FAIL | 22.10 ms FAIL | 21.77 ms FAIL | 30.22 ms FAIL | 16.46 ms FAIL | 2659/s | 1/9 |
+
+All rows above passed the harness correctness checks before the workload ran.
+
+The harness currently times `PrimeScan` separately from the scorecard table. Real-world `PrimeScan` counted the 200 open records seeded by `RealWorldWorkload`; it does not exercise the discovery target's 10k-open-record case.
+
+| Backend | PrimeScan over 200 open records |
+|---|---:|
+| SQLite | 751 us |
+| bbolt | 1.12 ms |
+| authorcore | 1.29 ms |
+| PostgreSQL | 538 us |
+| CouchDB | 1.34 ms |
+| Dolt SQL | 1.12 ms |
+
+## FR Coverage
+
+| FR | Requirement | SQLite | bbolt | authorcore | PostgreSQL | CouchDB | Dolt SQL |
+|---|---|---|---|---|---|---|---|
+| FR-1 | CRUD by stable string ID | Yes | Yes | Yes | Yes | Yes | Yes |
+| FR-2 | Filter scan | Yes | Yes | Yes | Yes | Yes | Yes |
+| FR-3 | Point read | Correct, target miss | Yes | Yes | Correct, target miss | Correct, target miss | Correct, target miss |
+| FR-4 | Batch-by-id fetch | Yes | Yes | Yes | Yes | Correct, target miss | Correct, target miss |
+| FR-5 | Atomic metadata batch | Yes | Yes | Yes | Correct, target miss | Correct, target miss | Correct, target miss |
+| FR-6 | Read-after-write | Yes | Yes | Yes | Yes | Yes | Yes |
+| FR-7 | Main + ephemeral tiers | Yes | Yes | Yes | Yes | Yes | Yes |
+| FR-8 | Ephemeral filter scan | Yes | Yes | Yes | Correct, target miss | Correct, target miss | Correct, target miss |
+| FR-9 | Ready semantics | Yes | Yes | Yes | Yes | Correct, target miss | Correct, target miss |
+| FR-10 | Dependency graph | Yes | Yes | Yes | Yes | Yes | Yes |
+| FR-11 | Metadata filters | Yes | Yes | Yes | Yes | Yes | Yes |
+| FR-12 | TTL expiry | Yes | Yes | Yes | Yes | Yes | Yes |
+| FR-13 | Append-only event log | Out of store scope | Out of store scope | Out of store scope | Out of store scope | Out of store scope | Out of store scope |
+| FR-14 | Advisory locks | Out of store scope | Out of store scope | Out of store scope | Out of store scope | Out of store scope | Out of store scope |
+| FR-15 | Prime scan | Correctness pass | Correctness pass | Correctness pass | Correctness pass | Correctness pass | Correctness pass |
+| FR-16 | Zero-fork access | Yes | Yes | Yes | No CLI fork; external service hop | No CLI fork; external service hop | No CLI fork; external service hop |
+| FR-17 | Cascade cleanup | Yes | Yes | Yes | Yes | Yes | Yes |
+| FR-18 | Recent scan | Yes | Yes | Yes | Yes | Yes | Yes |
+
+## Adapter Notes
+
+### SQLite
+
+The SQLite adapter remains the strongest off-the-shelf candidate. It missed the point-read p99 target in the final run by 220 us, while clearing the other eight measured targets. Earlier local runs passed all targets, so the miss appears close enough to machine variance that SQLite should remain a serious finalist.
+
+### bbolt
+
+The bbolt adapter persists records and deps to bbolt and serves reads from a hot in-process index. This shape passed every measured target after moving broad recency sorting outside the read lock and adding secondary indexes for hot filters. The tradeoff is ownership: the adapter is effectively an application store on top of bbolt, not a query engine we get for free.
+
+### authorcore
+
+The author-store-core PoC is a thin indexed in-memory adapter matching the round-2 author design's hot path. It passed all measured targets and is the cleanest demonstration that the HQ workload does not need a general database to meet the SLAs. It does not include the WAL/checkpoint durability layer proposed in R2.2, so it is a performance and API-shape PoC rather than a production implementation.
+
+### PostgreSQL
+
+PostgreSQL passed correctness and several read targets but missed point-read, ephemeral scan, and all write p99 targets in the real-world run. The adapter uses pooled `database/sql`, so this is not paying the `bd` CLI fork tax; the misses come from the networked database path and concurrent write/read contention under this workload.
+
+### CouchDB
+
+CouchDB passed correctness but is a poor fit for the current `StoreAdapter` shape. Seeding the real-world workload took materially longer because each `Create` is a document API write. During the workload, synchronous write-through also blocks hot reads in the adapter's consistency model, causing all latency targets except mail-poll throughput to fail.
+
+### Dolt SQL Baseline
+
+The Dolt baseline here uses Dolt's MySQL-compatible SQL server directly with a pooled Go client. That is already more favorable than today's production `bd` CLI fork-per-call path. Even with the fork tax removed, Dolt cleared only mail-poll throughput and missed every p99 latency target in the real-world run.
+
+## Recommendation Signal For R2.4
+
+The sweep supports narrowing R2.4 to SQLite vs. author-owned store:
+
+1. SQLite is the lowest-risk adopted backend and is close to or within all measured targets.
+2. The authorcore PoC shows the workload is easy to satisfy with a purpose-built indexed core, but production viability depends on implementing and testing WAL/checkpoint crash recovery.
+3. bbolt is viable only as a substrate for an owned store layer; by itself it does not avoid owning query/index semantics.
+4. PostgreSQL, CouchDB, and Dolt are not good HQ hot-path stores for this local coordination workload. They add service/process overhead without buying requirements HQ actually uses.


### PR DESCRIPTION
## What

Lands **only** `docs/coordination-store/round2/R2.1b-adapter-sweep.md` — the
R2.1b coordination-store adapter-sweep methodology (6-backend comparison, FR
coverage matrix, real-world latency scorecard) — to `main`.

## Why

The harness + 6 adapters from #2524 already exist on `main` under
`internal/benchmarks/coordstore`; the methodology doc was the only piece
missing. Preserving it here lets **#2524 close as superseded** without losing
the methodology, which keeps live value while epic `ga-aec8q` (right-size off
Dolt) stays open.

The benchmark *code* is slated for separate removal under `ga-xflp2c`; this doc
is the durable record of what that sweep measured and concluded.

## Scope

- Doc-only. No code changes. `git diff --stat` = 1 file, +157.
- Supersedes the doc portion of #2524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)