### PR TITLE
feat(providers): add grok (xAI Grok Build CLI) builtin provider

### DIFF
--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -9,8 +9,8 @@ description: Create a city, sling work to an agent, add a rig, and configure mul
 First, you'll need to install at least one CLI coding agent (which Gas City
 calls "providers") and make sure that they're on the PATH. Gas City supports
 many providers, including but not limited to Claude Code (`claude`), Codex
-(`codex`), Gemini (`gemini`), OpenCode (`opencode`), Groq (`groq`), and
-Cerebras (`cerebras`). Make sure you've configured each of your chosen
+(`codex`), Gemini (`gemini`), Grok Build (`grok`), OpenCode (`opencode`),
+Groq (`groq`), and Cerebras (`cerebras`). Make sure you've configured each of your chosen
 providers (the more the merrier!) with the appropriate token and/or API key so
 that they can each run and do things for you.
 
@@ -67,16 +67,17 @@ Choose your coding agent:
   1. Claude Code  (default)
   2. Codex CLI
   3. Gemini CLI
-  4. Cursor Agent
-  5. GitHub Copilot
-  6. Sourcegraph AMP
-  7. OpenCode
-  8. Groq (OpenCode)
-  9. Cerebras (OpenCode)
-  10. Auggie CLI
-  11. Pi Coding Agent
-  12. Oh My Pi (OMP)
-  13. Custom command
+  4. Grok Build
+  5. Cursor Agent
+  6. GitHub Copilot
+  7. Sourcegraph AMP
+  8. OpenCode
+  9. Groq (OpenCode)
+  10. Cerebras (OpenCode)
+  11. Auggie CLI
+  12. Pi Coding Agent
+  13. Oh My Pi (OMP)
+  14. Custom command
 Agent [1]:
 [1/8] Creating runtime scaffold
 [2/8] Installing hooks (Claude Code)

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -10,11 +10,11 @@ func TestBuiltinProviders(t *testing.T) {
 	order := BuiltinProviderOrder()
 
 	// Must have exactly 15 built-in providers.
-	if len(providers) != 15 {
-		t.Fatalf("len(BuiltinProviders()) = %d, want 15", len(providers))
+	if len(providers) != 16 {
+		t.Fatalf("len(BuiltinProviders()) = %d, want 16", len(providers))
 	}
-	if len(order) != 15 {
-		t.Fatalf("len(BuiltinProviderOrder()) = %d, want 15", len(order))
+	if len(order) != 16 {
+		t.Fatalf("len(BuiltinProviderOrder()) = %d, want 16", len(order))
 	}
 
 	// Every entry in order must exist in providers.
@@ -495,6 +495,48 @@ func TestBuiltinProvidersGroqOpenCodePreset(t *testing.T) {
 	}
 	if want := "opencode acp --model groq/openai/gpt-oss-120b"; launch.Command != want {
 		t.Fatalf("Command = %q, want %q", launch.Command, want)
+	}
+}
+
+func TestBuiltinProvidersGrokPreset(t *testing.T) {
+	p := BuiltinProviders()["grok"]
+	if p.Command != "grok" {
+		t.Errorf("Command = %q, want %q", p.Command, "grok")
+	}
+	if p.PromptMode != "none" {
+		t.Errorf("PromptMode = %q, want %q", p.PromptMode, "none")
+	}
+	if p.InstructionsFile != "AGENTS.md" {
+		t.Errorf("InstructionsFile = %q, want %q", p.InstructionsFile, "AGENTS.md")
+	}
+	if derefBool(p.SupportsACP) {
+		t.Error("SupportsACP = true, want false")
+	}
+	if derefBool(p.SupportsHooks) {
+		t.Error("SupportsHooks = true, want false")
+	}
+	if got, want := p.PermissionModes["unrestricted"], "--permission-mode bypassPermissions"; got != want {
+		t.Errorf("PermissionModes[unrestricted] = %q, want %q", got, want)
+	}
+	if p.OptionDefaults["permission_mode"] != "unrestricted" {
+		t.Errorf("OptionDefaults[permission_mode] = %q, want unrestricted", p.OptionDefaults["permission_mode"])
+	}
+	if p.ResumeFlag != "--resume" {
+		t.Errorf("ResumeFlag = %q, want %q", p.ResumeFlag, "--resume")
+	}
+	if p.TitleModel != "grok-composer-2.5-fast" {
+		t.Errorf("TitleModel = %q, want %q", p.TitleModel, "grok-composer-2.5-fast")
+	}
+
+	rp := specToResolved("grok", &p)
+	if got := rp.ProviderSessionCreateTransport(); got != "" {
+		t.Fatalf("ProviderSessionCreateTransport() = %q, want \"\" (no ACP)", got)
+	}
+	if got, want := rp.ResolveDefaultArgs(), []string{"--permission-mode", "bypassPermissions"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolveDefaultArgs() = %v, want %v", got, want)
+	}
+	if got, want := rp.TitleModelFlagArgs(), []string{"--model", "grok-composer-2.5-fast"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("TitleModelFlagArgs() = %v, want %v", got, want)
 	}
 }
 

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -532,10 +532,10 @@ func TestBuiltinProvidersGrokPreset(t *testing.T) {
 	if got := rp.ProviderSessionCreateTransport(); got != "" {
 		t.Fatalf("ProviderSessionCreateTransport() = %q, want \"\" (no ACP)", got)
 	}
-	if p.OptionDefaults["model"] != "grok-build" {
-		t.Errorf("OptionDefaults[model] = %q, want grok-build", p.OptionDefaults["model"])
+	if p.OptionDefaults["model"] != "grok-composer-2.5" {
+		t.Errorf("OptionDefaults[model] = %q, want grok-composer-2.5", p.OptionDefaults["model"])
 	}
-	if got, want := rp.ResolveDefaultArgs(), []string{"--permission-mode", "bypassPermissions", "--model", "grok-build"}; !reflect.DeepEqual(got, want) {
+	if got, want := rp.ResolveDefaultArgs(), []string{"--permission-mode", "bypassPermissions", "--model", "grok-composer-2.5"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("ResolveDefaultArgs() = %v, want %v", got, want)
 	}
 	if got, want := rp.TitleModelFlagArgs(), []string{"--model", "grok-composer-2.5-fast"}; !reflect.DeepEqual(got, want) {

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -532,7 +532,10 @@ func TestBuiltinProvidersGrokPreset(t *testing.T) {
 	if got := rp.ProviderSessionCreateTransport(); got != "" {
 		t.Fatalf("ProviderSessionCreateTransport() = %q, want \"\" (no ACP)", got)
 	}
-	if got, want := rp.ResolveDefaultArgs(), []string{"--permission-mode", "bypassPermissions"}; !reflect.DeepEqual(got, want) {
+	if p.OptionDefaults["model"] != "grok-build" {
+		t.Errorf("OptionDefaults[model] = %q, want grok-build", p.OptionDefaults["model"])
+	}
+	if got, want := rp.ResolveDefaultArgs(), []string{"--permission-mode", "bypassPermissions", "--model", "grok-build"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("ResolveDefaultArgs() = %v, want %v", got, want)
 	}
 	if got, want := rp.TitleModelFlagArgs(), []string{"--model", "grok-composer-2.5-fast"}; !reflect.DeepEqual(got, want) {

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -9,7 +9,7 @@ func TestBuiltinProviders(t *testing.T) {
 	providers := BuiltinProviders()
 	order := BuiltinProviderOrder()
 
-	// Must have exactly 15 built-in providers.
+	// Must have exactly 16 built-in providers.
 	if len(providers) != 16 {
 		t.Fatalf("len(BuiltinProviders()) = %d, want 16", len(providers))
 	}

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -275,6 +275,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		Command:     "grok",
 		OptionDefaults: map[string]string{
 			"permission_mode": "unrestricted",
+			"model":           "grok-build",
 		},
 		// The grok TUI accepts no positional or flag-delivered initial
 		// prompt (`-p/--single` is print-and-exit), so prompts are
@@ -328,6 +329,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
 					{Value: "grok-build", Label: "Grok Build", FlagArgs: []string{"--model", "grok-build"}, FlagAliases: [][]string{{"-m", "grok-build"}}},
+					{Value: "grok-composer-2.5", Label: "Grok Composer 2.5", FlagArgs: []string{"--model", "grok-composer-2.5"}, FlagAliases: [][]string{{"-m", "grok-composer-2.5"}}},
 					{Value: "grok-composer-2.5-fast", Label: "Grok Composer 2.5 Fast", FlagArgs: []string{"--model", "grok-composer-2.5-fast"}, FlagAliases: [][]string{{"-m", "grok-composer-2.5-fast"}}},
 				},
 			},

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -81,7 +81,7 @@ const (
 )
 
 var builtinProviderOrder = []string{
-	"claude", "codex", "gemini", "kimi", "kiro", "cursor", "copilot",
+	"claude", "codex", "gemini", "grok", "kimi", "kiro", "cursor", "copilot",
 	"amp", "opencode", "groq", "cerebras", "auggie", "pi", "omp", "antigravity",
 }
 
@@ -266,6 +266,69 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 					{Value: "", Label: "Default"},
 					{Value: "gemini-2.5-pro", Label: "Gemini 2.5 Pro", FlagArgs: []string{"--model", "gemini-2.5-pro"}, FlagAliases: [][]string{{"-m", "gemini-2.5-pro"}}},
 					{Value: "gemini-2.5-flash", Label: "Gemini 2.5 Flash", FlagArgs: []string{"--model", "gemini-2.5-flash"}, FlagAliases: [][]string{{"-m", "gemini-2.5-flash"}}},
+				},
+			},
+		},
+	},
+	"grok": {
+		DisplayName: "Grok Build",
+		Command:     "grok",
+		OptionDefaults: map[string]string{
+			"permission_mode": "unrestricted",
+		},
+		// The grok TUI accepts no positional or flag-delivered initial
+		// prompt (`-p/--single` is print-and-exit), so prompts are
+		// delivered via tmux send-keys.
+		PromptMode:       "none",
+		ReadyDelayMs:     5000,
+		ProcessNames:     []string{"grok"},
+		InstructionsFile: "AGENTS.md",
+		ResumeFlag:       "--resume",
+		ResumeStyle:      "flag",
+		PrintArgs:        []string{"-p"},
+		TitleModel:       "grok-composer-2.5-fast",
+		PermissionModes: map[string]string{
+			"default":      "--permission-mode default",
+			"auto-edit":    "--permission-mode acceptEdits",
+			"plan":         "--permission-mode plan",
+			"full-auto":    "--permission-mode dontAsk",
+			"unrestricted": "--permission-mode bypassPermissions",
+		},
+		OptionsSchema: []BuiltinProviderOption{
+			{
+				Key:     "permission_mode",
+				Label:   "Permission Mode",
+				Type:    "select",
+				Default: "unrestricted",
+				Choices: []BuiltinOptionChoice{
+					{Value: "default", Label: "Ask before actions", FlagArgs: []string{"--permission-mode", "default"}},
+					{Value: "auto-edit", Label: "Auto-approve edits", FlagArgs: []string{"--permission-mode", "acceptEdits"}},
+					{Value: "plan", Label: "Plan mode", FlagArgs: []string{"--permission-mode", "plan"}},
+					{Value: "full-auto", Label: "Full auto", FlagArgs: []string{"--permission-mode", "dontAsk"}},
+					{Value: "unrestricted", Label: "Bypass permissions", FlagArgs: []string{"--permission-mode", "bypassPermissions"}},
+				},
+			},
+			{
+				Key:   "effort",
+				Label: "Effort",
+				Type:  "select",
+				Choices: []BuiltinOptionChoice{
+					{Value: "", Label: "Default"},
+					{Value: "low", Label: "Low", FlagArgs: []string{"--effort", "low"}},
+					{Value: "medium", Label: "Medium", FlagArgs: []string{"--effort", "medium"}},
+					{Value: "high", Label: "High", FlagArgs: []string{"--effort", "high"}},
+					{Value: "xhigh", Label: "Extra High", FlagArgs: []string{"--effort", "xhigh"}},
+					{Value: "max", Label: "Max", FlagArgs: []string{"--effort", "max"}},
+				},
+			},
+			{
+				Key:   "model",
+				Label: "Model",
+				Type:  "select",
+				Choices: []BuiltinOptionChoice{
+					{Value: "", Label: "Default"},
+					{Value: "grok-build", Label: "Grok Build", FlagArgs: []string{"--model", "grok-build"}, FlagAliases: [][]string{{"-m", "grok-build"}}},
+					{Value: "grok-composer-2.5-fast", Label: "Grok Composer 2.5 Fast", FlagArgs: []string{"--model", "grok-composer-2.5-fast"}, FlagAliases: [][]string{{"-m", "grok-composer-2.5-fast"}}},
 				},
 			},
 		},

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -275,7 +275,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		Command:     "grok",
 		OptionDefaults: map[string]string{
 			"permission_mode": "unrestricted",
-			"model":           "grok-build",
+			"model":           "grok-composer-2.5",
 		},
 		// The grok TUI accepts no positional or flag-delivered initial
 		// prompt (`-p/--single` is print-and-exit), so prompts are

--- a/internal/worker/builtin/profiles_test.go
+++ b/internal/worker/builtin/profiles_test.go
@@ -8,11 +8,11 @@ func TestBuiltinProvidersAndOrder(t *testing.T) {
 	providers := BuiltinProviders()
 	order := BuiltinProviderOrder()
 
-	if len(providers) != 15 {
-		t.Fatalf("len(BuiltinProviders()) = %d, want 15", len(providers))
+	if len(providers) != 16 {
+		t.Fatalf("len(BuiltinProviders()) = %d, want 16", len(providers))
 	}
-	if len(order) != 15 {
-		t.Fatalf("len(BuiltinProviderOrder()) = %d, want 15", len(order))
+	if len(order) != 16 {
+		t.Fatalf("len(BuiltinProviderOrder()) = %d, want 16", len(order))
 	}
 
 	for _, name := range order {


### PR DESCRIPTION
## Summary

Adds **`grok`** (xAI's Grok Build CLI) as a first-class builtin provider, following the same recipe as the Groq/Cerebras presets (#1182/#1183) — minus the hooks plumbing, since grok has no gc hook overlay.

Grok Build's CLI deliberately mirrors Claude Code's surface (its own `--help` annotates flags with their Claude Code equivalents), so the `BuiltinProviderSpec` maps almost 1:1:

| Spec field | grok flag (verified v0.2.22) |
|---|---|
| `PermissionModes` | `--permission-mode {default, acceptEdits, plan, dontAsk, bypassPermissions}` |
| effort schema | `--effort low\|medium\|high\|xhigh\|max` — identical value set to claude's |
| model schema | `-m/--model`: `grok-build` (CLI default), `grok-composer-2.5-fast` (per `grok models`) |
| `ResumeFlag`/`ResumeStyle` | `-r/--resume [SESSION_ID]`, flag style |
| `PrintArgs` | `-p/--single` (single-turn print-and-exit) |
| `InstructionsFile` | `AGENTS.md` (cwd / repo-root / `~/.grok/AGENTS.md` precedence) |
| `PromptMode` | `"none"` — the TUI takes no positional or flag-delivered initial prompt, so tmux send-keys delivery |
| `ProcessNames` | `["grok"]` (native single binary, no node wrapper) |

No ACP: the binary has `agent stdio|headless|serve` modes but no `acp` subcommand, so `SupportsACP` stays false and `ProviderSessionCreateTransport()` returns `""`. No hooks overlay exists for grok, so `hooks.go`/`defaultInstallAgentHooksForProvider` are deliberately untouched.

## Changes

- `internal/worker/builtin/profiles.go` — `grok` spec + order list (15 → 16 providers)
- `internal/worker/builtin/profiles_test.go`, `internal/config/provider_test.go` — count bumps + `TestBuiltinProvidersGrokPreset` (spec fields, transport, `ResolveDefaultArgs`, `TitleModelFlagArgs`)
- `docs/tutorials/01-cities-and-rigs.md` — provider list + wizard menu renumber

`make generate` produced no schema/docs drift (no hooks-list changes). The init wizard picks the new provider up dynamically from `BuiltinProviderOrder()`.

## Testing

- `go test ./internal/worker/builtin/ ./internal/config/ ./internal/cityinit/ ./internal/hooks/ ./internal/session/ -count=1` — all ok
- `make fmt-check lint-changed` — 0 issues
- `go build ./...` — clean
- Flag surface verified against a live Grok Build v0.2.22 install on linux-x86_64 (`--help`, `grok models`, `grok agent --help`, `grok inspect`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)