### PR TITLE
fix(supervisor): consult launchd/systemd + API when socket ping fails (gascity#2984)

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -773,25 +773,54 @@ func waitForSupervisorExitUntil(sockPath string, deadline time.Time) error {
 
 func supervisorStatusWithOptions(stdout, _ io.Writer, asJSON bool) int {
 	sockPath, pid := runningSupervisorSocket()
+	running := pid > 0
+	pidSource := ""
+	if pid > 0 {
+		pidSource = "control_socket"
+	}
+	// Fallback liveness when the control socket is unreachable (gascity#2984):
+	// a launchd/systemd-managed supervisor may bind its socket at a path the
+	// CLI environment does not resolve. Trust the service manager, then the API.
+	if !running {
+		switch {
+		case supervisorServiceManagerActive():
+			running, pidSource = true, "service_manager"
+		case supervisorAPIReachable():
+			running, pidSource = true, "api"
+		}
+	}
 	if asJSON {
 		payload := map[string]any{
 			"schema_version": "1",
-			"running":        pid > 0,
+			"running":        running,
 			"pid":            pid,
 			"socket_path":    sockPath,
 			"checked_paths":  supervisorSocketPathCandidates(),
+		}
+		if pidSource != "" {
+			payload["pid_source"] = pidSource
+		}
+		if running && pid == 0 {
+			// Distinct diagnostic state (gascity#2984): running per service
+			// manager / API, but pid discovery via the socket failed.
+			payload["socket_status"] = "unreachable"
 		}
 		if err := writeCLIJSONLine(stdout, payload); err != nil {
 			return 1
 		}
 		return 0
 	}
-	if pid > 0 {
+	switch {
+	case pid > 0:
 		fmt.Fprintf(stdout, "Supervisor is running (PID %d)\n", pid) //nolint:errcheck
 		return 0
+	case running:
+		fmt.Fprintf(stdout, "Supervisor is running (pid unavailable: control socket unreachable; liveness confirmed via %s)\n", pidSource) //nolint:errcheck
+		return 0
+	default:
+		fmt.Fprintln(stdout, "Supervisor is not running") //nolint:errcheck
+		return 1
 	}
-	fmt.Fprintln(stdout, "Supervisor is not running") //nolint:errcheck
-	return 1
 }
 
 func newSupervisorReloadCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -119,15 +119,25 @@ var (
 		if err != nil {
 			return false
 		}
+		// Normalize wildcard binds to loopback before dialing, mirroring
+		// cmd_service.go: a 0.0.0.0/:: bind is not itself a dialable address
+		// (and 0.0.0.0 GETs fail on macOS).
+		bind := cfg.Supervisor.BindOrDefault()
+		switch bind {
+		case "", "0.0.0.0":
+			bind = "127.0.0.1"
+		case "::", "[::]":
+			bind = "::1"
+		}
 		url := fmt.Sprintf("http://%s/v0/cities",
-			net.JoinHostPort(cfg.Supervisor.BindOrDefault(), strconv.Itoa(cfg.Supervisor.PortOrDefault())))
+			net.JoinHostPort(bind, strconv.Itoa(cfg.Supervisor.PortOrDefault())))
 		client := &http.Client{Timeout: 750 * time.Millisecond}
 		resp, err := client.Get(url)
 		if err != nil {
 			return false
 		}
 		defer resp.Body.Close() //nolint:errcheck
-		return resp.StatusCode < 500
+		return resp.StatusCode >= 200 && resp.StatusCode < 300
 	}
 )
 

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	osuser "os/user"
@@ -91,6 +93,42 @@ var (
 	// It permits overwriting an existing service unit that references a
 	// different gc binary. Exposed as a var so tests can override it directly.
 	supervisorInstallForce bool
+
+	// supervisorServiceManagerActive reports whether the platform service
+	// manager (launchd on macOS, systemd --user on Linux) considers the
+	// supervisor running. Fallback liveness signal when the control-socket
+	// ping fails (gascity#2984).
+	supervisorServiceManagerActive = func() bool {
+		switch supervisorRuntimeGOOS {
+		case "darwin":
+			return supervisorLaunchdActive(supervisorLaunchdLabel())
+		case "linux":
+			if !supervisorSystemctlUserAvailable() {
+				return false
+			}
+			return supervisorSystemctlActive(supervisorSystemdServiceName())
+		default:
+			return false
+		}
+	}
+	// supervisorAPIReachable reports whether the supervisor HTTP API answers
+	// on its configured loopback address. Complements the service-manager
+	// signal for supervisors not managed by launchd/systemd (gascity#2984).
+	supervisorAPIReachable = func() bool {
+		cfg, err := supervisorLoadConfig(supervisor.ConfigPath())
+		if err != nil {
+			return false
+		}
+		url := fmt.Sprintf("http://%s/v0/cities",
+			net.JoinHostPort(cfg.Supervisor.BindOrDefault(), strconv.Itoa(cfg.Supervisor.PortOrDefault())))
+		client := &http.Client{Timeout: 750 * time.Millisecond}
+		resp, err := client.Get(url)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close() //nolint:errcheck
+		return resp.StatusCode < 500
+	}
 )
 
 const supervisorServiceFileMode os.FileMode = 0o600

--- a/cmd/gc/cmd_supervisor_status_json_test.go
+++ b/cmd/gc/cmd_supervisor_status_json_test.go
@@ -3,7 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/supervisor"
 )
 
 func TestSupervisorStatusJSON(t *testing.T) {
@@ -148,5 +154,52 @@ func TestSupervisorStatusJSON_NotRunningWhenAllSignalsDown(t *testing.T) {
 	}
 	if got := stdout.String(); got != "Supervisor is not running\n" {
 		t.Fatalf("stdout=%q, want %q", got, "Supervisor is not running\n")
+	}
+}
+
+// TestSupervisorAPIReachable_StatusFiltering drives the real
+// supervisorAPIReachable probe (not the boolean stub) against an httptest
+// server, asserting that only a 2xx on /v0/cities counts as reachable. A 404
+// (e.g. an unrelated local service on the configured port) must report false.
+func TestSupervisorAPIReachable_StatusFiltering(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code int
+		want bool
+	}{
+		{"ok_200", http.StatusOK, true},
+		{"notfound_404", http.StatusNotFound, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v0/cities" {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(tc.code)
+			}))
+			t.Cleanup(srv.Close)
+
+			u, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatalf("parse server URL: %v", err)
+			}
+			port, err := strconv.Atoi(u.Port())
+			if err != nil {
+				t.Fatalf("parse server port: %v", err)
+			}
+
+			origLoad := supervisorLoadConfig
+			supervisorLoadConfig = func(string) (supervisor.Config, error) {
+				return supervisor.Config{
+					Supervisor: supervisor.Section{Bind: u.Hostname(), Port: port},
+				}, nil
+			}
+			t.Cleanup(func() { supervisorLoadConfig = origLoad })
+
+			if got := supervisorAPIReachable(); got != tc.want {
+				t.Fatalf("supervisorAPIReachable() = %v, want %v (status %d)", got, tc.want, tc.code)
+			}
+		})
 	}
 }

--- a/cmd/gc/cmd_supervisor_status_json_test.go
+++ b/cmd/gc/cmd_supervisor_status_json_test.go
@@ -9,6 +9,15 @@ import (
 func TestSupervisorStatusJSON(t *testing.T) {
 	clearGCEnv(t)
 
+	// Stub fallback hooks so a live service manager or API on the test host
+	// cannot flip running=true and mask the socket-path-not-found path.
+	origSM := supervisorServiceManagerActive
+	supervisorServiceManagerActive = func() bool { return false }
+	t.Cleanup(func() { supervisorServiceManagerActive = origSM })
+	origAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = origAPI })
+
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"supervisor", "status", "--json"}, &stdout, &stderr)
 	if code != 0 {
@@ -36,5 +45,108 @@ func TestSupervisorStatusJSON(t *testing.T) {
 	}
 	if !payload.Running && payload.PID != 0 {
 		t.Fatalf("not running with pid = %d", payload.PID)
+	}
+}
+
+// TestSupervisorStatusJSON_RunningViaLaunchdWhenSocketDown verifies that when
+// the launchd service manager reports active but the control socket is
+// unreachable, status reports running=true with distinct diagnostic fields.
+// FAILS on HEAD (before the gascity#2984 fix); PASSES after.
+func TestSupervisorStatusJSON_RunningViaLaunchdWhenSocketDown(t *testing.T) {
+	clearGCEnv(t)
+
+	origGOOS := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "darwin"
+	t.Cleanup(func() { supervisorRuntimeGOOS = origGOOS })
+
+	origActive := supervisorLaunchdActive
+	supervisorLaunchdActive = func(string) bool { return true }
+	t.Cleanup(func() { supervisorLaunchdActive = origActive })
+
+	// supervisorServiceManagerActive calls supervisorLaunchdActive on darwin,
+	// so the real implementation works here — no need to stub it.
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"supervisor", "status", "--json"}, &stdout, &stderr)
+	var p struct {
+		Running      bool   `json:"running"`
+		PID          int    `json:"pid"`
+		PidSource    string `json:"pid_source"`
+		SocketStatus string `json:"socket_status"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &p); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout.String())
+	}
+	if !p.Running {
+		t.Fatalf("launchd active but status running=false (pid=%d exit=%d): %s", p.PID, code, stdout.String())
+	}
+	if p.PID == 0 && (p.PidSource != "service_manager" || p.SocketStatus != "unreachable") {
+		t.Fatalf("want distinct diagnostic state pid_source=service_manager socket_status=unreachable, got %+v", p)
+	}
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0", code)
+	}
+}
+
+// TestSupervisorStatusJSON_RunningViaAPIWhenSocketAndServiceDown verifies that
+// when both the socket and service manager are down but the HTTP API answers,
+// status reports running=true via the api fallback.
+func TestSupervisorStatusJSON_RunningViaAPIWhenSocketAndServiceDown(t *testing.T) {
+	clearGCEnv(t)
+
+	origSM := supervisorServiceManagerActive
+	supervisorServiceManagerActive = func() bool { return false }
+	t.Cleanup(func() { supervisorServiceManagerActive = origSM })
+
+	origAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return true }
+	t.Cleanup(func() { supervisorAPIReachable = origAPI })
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"supervisor", "status", "--json"}, &stdout, &stderr)
+	var p struct {
+		Running      bool   `json:"running"`
+		PID          int    `json:"pid"`
+		PidSource    string `json:"pid_source"`
+		SocketStatus string `json:"socket_status"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &p); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout.String())
+	}
+	if !p.Running {
+		t.Fatalf("API reachable but status running=false (exit=%d): %s", code, stdout.String())
+	}
+	if p.PidSource != "api" {
+		t.Fatalf("want pid_source=api, got %q", p.PidSource)
+	}
+	if p.SocketStatus != "unreachable" {
+		t.Fatalf("want socket_status=unreachable, got %q", p.SocketStatus)
+	}
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0", code)
+	}
+}
+
+// TestSupervisorStatusJSON_NotRunningWhenAllSignalsDown verifies that when
+// all three liveness signals (socket, service manager, API) are down,
+// the text path prints "Supervisor is not running" and exits 1.
+func TestSupervisorStatusJSON_NotRunningWhenAllSignalsDown(t *testing.T) {
+	clearGCEnv(t)
+
+	origSM := supervisorServiceManagerActive
+	supervisorServiceManagerActive = func() bool { return false }
+	t.Cleanup(func() { supervisorServiceManagerActive = origSM })
+
+	origAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = origAPI })
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"supervisor", "status"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit=%d, want 1; stdout=%q", code, stdout.String())
+	}
+	if got := stdout.String(); got != "Supervisor is not running\n" {
+		t.Fatalf("stdout=%q, want %q", got, "Supervisor is not running\n")
 	}
 }

--- a/internal/beads/boundary_test.go
+++ b/internal/beads/boundary_test.go
@@ -56,6 +56,10 @@ func TestNoBdExecOutsideBeads(t *testing.T) {
 			if base == ".git" || base == "vendor" || base == ".claude" || strings.HasPrefix(base, ".beads-src") {
 				return filepath.SkipDir
 			}
+			// Skip git worktrees embedded in the repo (have a .git file, not dir).
+			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if !strings.HasSuffix(path, ".go") {

--- a/internal/beads/contract/identity_test.go
+++ b/internal/beads/contract/identity_test.go
@@ -594,6 +594,10 @@ func TestNoExternalIdentityWriters(t *testing.T) {
 			if _, skip := skipDirs[d.Name()]; skip {
 				return filepath.SkipDir
 			}
+			// Skip git worktrees embedded in the repo (have a .git file, not dir).
+			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if !strings.HasSuffix(path, ".go") {

--- a/internal/builtinpacks/registry_test.go
+++ b/internal/builtinpacks/registry_test.go
@@ -141,9 +141,12 @@ func TestMaterializeSyntheticRepoProductionCallersStayInPackman(t *testing.T) {
 			switch entry.Name() {
 			case ".git", ".gc", "node_modules", "worktrees":
 				return filepath.SkipDir
-			default:
-				return nil
 			}
+			// Skip git worktrees embedded in the repo (have a .git file, not dir).
+			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil

--- a/internal/logutil/walkthrough_urls_test.go
+++ b/internal/logutil/walkthrough_urls_test.go
@@ -44,9 +44,12 @@ func TestWalkthroughURLStringsStayInContractFile(t *testing.T) {
 			switch d.Name() {
 			case ".git", ".gc", "node_modules":
 				return filepath.SkipDir
-			default:
-				return nil
 			}
+			// Skip git worktrees embedded in the repo (have a .git file, not dir).
+			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if !strings.HasSuffix(path, ".go") {
 			return nil

--- a/internal/pgauth/no_external_env_test.go
+++ b/internal/pgauth/no_external_env_test.go
@@ -41,6 +41,10 @@ func TestNoDirectPostgresEnvReadsOutsidePgauth(t *testing.T) {
 			if base == ".git" || base == "vendor" || base == ".claude" || base == ".beads" || base == "worktrees" || strings.HasPrefix(base, ".beads-src") || strings.HasPrefix(base, "node_modules") {
 				return filepath.SkipDir
 			}
+			// Skip git worktrees embedded in the repo (have a .git file, not dir).
+			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if !strings.HasSuffix(path, ".go") {


### PR DESCRIPTION
## Summary

- `gc supervisor status` false-negative when supervisor is managed by launchd/systemd and its socket path differs from the CLI's computed path: the status command now falls back to the platform service manager (launchd on macOS, systemd --user on Linux) then the HTTP API as additional liveness signals when the control-socket ping fails.
- Adds optional `pid_source` and `socket_status` fields to the JSON output to produce a distinct diagnostic state when the supervisor is detected via a fallback signal.
- Fixes boundary tests in 5 packages to skip embedded git worktrees (directories with a `.git` file rather than directory), which caused pre-existing false positives when agent worktrees (e.g. `.mayor-wt-3103/`) lived inside the repo root.

## Test plan

- [ ] `go test ./cmd/gc/ -count=1 -run 'TestSupervisorStatusJSON'` — all 4 subtests pass (1 existing + 3 new)
- [ ] `go vet ./cmd/gc/` — clean
- [ ] All cmd/gc shards pass in pre-commit hook
- [ ] Previously failing boundary tests (`TestNoBdExecOutsideBeads`, `TestNoExternalIdentityWriters`, `TestMaterializeSyntheticRepoProductionCallersStayInPackman`, `TestWalkthroughURLStringsStayInContractFile`, `TestNoDirectPostgresEnvReadsOutsidePgauth`) now pass

Closes gastownhall/gascity#2984
Bead: ga-7rhah8

🤖 Generated with [Claude Code](https://claude.com/claude-code)