### PR TITLE
fix(supervisor): consult service manager + API when socket ping fails (#2984)

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -773,25 +773,54 @@ func waitForSupervisorExitUntil(sockPath string, deadline time.Time) error {
 
 func supervisorStatusWithOptions(stdout, _ io.Writer, asJSON bool) int {
 	sockPath, pid := runningSupervisorSocket()
+	running := pid > 0
+	pidSource := ""
+	if pid > 0 {
+		pidSource = "control_socket"
+	}
+	// Fallback liveness when the control socket is unreachable (gascity#2984):
+	// a launchd/systemd-managed supervisor may bind its socket at a path the CLI
+	// environment does not resolve. Trust the service manager, then the API.
+	if !running {
+		switch {
+		case supervisorServiceManagerActive():
+			running, pidSource = true, "service_manager"
+		case supervisorAPIReachable():
+			running, pidSource = true, "api"
+		}
+	}
 	if asJSON {
 		payload := map[string]any{
 			"schema_version": "1",
-			"running":        pid > 0,
+			"running":        running,
 			"pid":            pid,
 			"socket_path":    sockPath,
 			"checked_paths":  supervisorSocketPathCandidates(),
+		}
+		if pidSource != "" {
+			payload["pid_source"] = pidSource
+		}
+		if running && pid == 0 {
+			// Distinct diagnostic state (gascity#2984 AC bullet 3): running per
+			// service manager / API, but pid discovery via the socket failed.
+			payload["socket_status"] = "unreachable"
 		}
 		if err := writeCLIJSONLine(stdout, payload); err != nil {
 			return 1
 		}
 		return 0
 	}
-	if pid > 0 {
+	switch {
+	case pid > 0:
 		fmt.Fprintf(stdout, "Supervisor is running (PID %d)\n", pid) //nolint:errcheck
 		return 0
+	case running:
+		fmt.Fprintf(stdout, "Supervisor is running (pid unavailable: control socket unreachable; liveness confirmed via %s)\n", pidSource) //nolint:errcheck
+		return 0
+	default:
+		fmt.Fprintln(stdout, "Supervisor is not running") //nolint:errcheck
+		return 1
 	}
-	fmt.Fprintln(stdout, "Supervisor is not running") //nolint:errcheck
-	return 1
 }
 
 func newSupervisorReloadCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	osuser "os/user"
@@ -91,6 +93,40 @@ var (
 	// It permits overwriting an existing service unit that references a
 	// different gc binary. Exposed as a var so tests can override it directly.
 	supervisorInstallForce bool
+	// supervisorServiceManagerActive reports whether the platform service manager
+	// (launchd on macOS, systemd --user on Linux) considers the supervisor running.
+	// Fallback liveness signal when the control-socket ping fails (gascity#2984).
+	supervisorServiceManagerActive = func() bool {
+		switch supervisorRuntimeGOOS {
+		case "darwin":
+			return supervisorLaunchdActive(supervisorLaunchdLabel())
+		case "linux":
+			if !supervisorSystemctlUserAvailable() {
+				return false
+			}
+			return supervisorSystemctlActive(supervisorSystemdServiceName())
+		default:
+			return false
+		}
+	}
+	// supervisorAPIReachable reports whether the supervisor HTTP API answers on its
+	// configured loopback address. Complements the service-manager signal for
+	// supervisors not managed by launchd/systemd (gascity#2984 AC bullet 2).
+	supervisorAPIReachable = func() bool {
+		cfg, err := supervisorLoadConfig(supervisor.ConfigPath())
+		if err != nil {
+			return false
+		}
+		url := fmt.Sprintf("http://%s/v0/cities",
+			net.JoinHostPort(cfg.Supervisor.BindOrDefault(), strconv.Itoa(cfg.Supervisor.PortOrDefault())))
+		client := &http.Client{Timeout: 750 * time.Millisecond}
+		resp, err := client.Get(url) //nolint:noctx
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close() //nolint:errcheck
+		return resp.StatusCode < 500
+	}
 )
 
 const supervisorServiceFileMode os.FileMode = 0o600

--- a/cmd/gc/cmd_supervisor_status_json_test.go
+++ b/cmd/gc/cmd_supervisor_status_json_test.go
@@ -8,6 +8,12 @@ import (
 
 func TestSupervisorStatusJSON(t *testing.T) {
 	clearGCEnv(t)
+	origSM := supervisorServiceManagerActive
+	supervisorServiceManagerActive = func() bool { return false }
+	t.Cleanup(func() { supervisorServiceManagerActive = origSM })
+	origAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = origAPI })
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"supervisor", "status", "--json"}, &stdout, &stderr)
@@ -36,5 +42,105 @@ func TestSupervisorStatusJSON(t *testing.T) {
 	}
 	if !payload.Running && payload.PID != 0 {
 		t.Fatalf("not running with pid = %d", payload.PID)
+	}
+}
+
+func TestSupervisorStatusJSON_RunningViaLaunchdWhenSocketDown(t *testing.T) {
+	clearGCEnv(t)
+	origGOOS := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "darwin"
+	t.Cleanup(func() { supervisorRuntimeGOOS = origGOOS })
+	origActive := supervisorLaunchdActive
+	supervisorLaunchdActive = func(string) bool { return true }
+	t.Cleanup(func() { supervisorLaunchdActive = origActive })
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"supervisor", "status", "--json"}, &stdout, &stderr)
+	var p struct {
+		Running      bool   `json:"running"`
+		PID          int    `json:"pid"`
+		PidSource    string `json:"pid_source"`
+		SocketStatus string `json:"socket_status"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &p); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout.String())
+	}
+	if !p.Running {
+		t.Fatalf("launchd active but status running=false (pid=%d exit=%d): %s", p.PID, code, stdout.String())
+	}
+	if p.PID == 0 && (p.PidSource != "service_manager" || p.SocketStatus != "unreachable") {
+		t.Fatalf("want pid_source=service_manager socket_status=unreachable, got %+v", p)
+	}
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0", code)
+	}
+}
+
+func TestSupervisorStatusJSON_RunningViaAPIWhenSocketAndServiceDown(t *testing.T) {
+	clearGCEnv(t)
+	origSM := supervisorServiceManagerActive
+	supervisorServiceManagerActive = func() bool { return false }
+	t.Cleanup(func() { supervisorServiceManagerActive = origSM })
+	origAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return true }
+	t.Cleanup(func() { supervisorAPIReachable = origAPI })
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"supervisor", "status", "--json"}, &stdout, &stderr)
+	var p struct {
+		Running      bool   `json:"running"`
+		PID          int    `json:"pid"`
+		PidSource    string `json:"pid_source"`
+		SocketStatus string `json:"socket_status"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &p); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout.String())
+	}
+	if !p.Running {
+		t.Fatalf("API reachable but status running=false (exit=%d): %s", code, stdout.String())
+	}
+	if p.PidSource != "api" {
+		t.Fatalf("pid_source = %q, want api", p.PidSource)
+	}
+	if p.SocketStatus != "unreachable" {
+		t.Fatalf("socket_status = %q, want unreachable", p.SocketStatus)
+	}
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0", code)
+	}
+}
+
+func TestSupervisorStatusJSON_NotRunningWhenAllSignalsDown(t *testing.T) {
+	clearGCEnv(t)
+	origSM := supervisorServiceManagerActive
+	supervisorServiceManagerActive = func() bool { return false }
+	t.Cleanup(func() { supervisorServiceManagerActive = origSM })
+	origAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = origAPI })
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"supervisor", "status", "--json"}, &stdout, &stderr)
+	var p struct {
+		Running bool `json:"running"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &p); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout.String())
+	}
+	if p.Running {
+		t.Fatalf("all signals down but status running=true: %s", stdout.String())
+	}
+	if code != 0 {
+		t.Fatalf("json path exit=%d, want 0", code)
+	}
+
+	// Text path: verify exit 1 and "Supervisor is not running"
+	var textStdout, textStderr bytes.Buffer
+	textCode := run([]string{"supervisor", "status"}, &textStdout, &textStderr)
+	if textCode != 1 {
+		t.Fatalf("text path exit=%d, want 1", textCode)
+	}
+	if textStdout.String() != "Supervisor is not running\n" {
+		t.Fatalf("text = %q, want \"Supervisor is not running\\n\"", textStdout.String())
 	}
 }


### PR DESCRIPTION
## Summary

- `gc supervisor status` derived liveness solely from a control-socket ping. On macOS, launchd may bind the supervisor's socket at a path the CLI environment does not resolve (different `HOME`/`GC_HOME` between launchd job and interactive shell), causing a deterministic ENOENT/ECONNREFUSED that reports `running:false` even when launchd says `state = running` and the HTTP API answers 200.
- Adds two testable fallback hooks (`supervisorServiceManagerActive`, `supervisorAPIReachable`) consulted in order when the socket ping yields `pid=0`. JSON output gains optional `pid_source` (control_socket | service_manager | api) and `socket_status` (unreachable) for the distinct diagnostic state. Text output emits a descriptive message naming the liveness source.
- Socket ping stays as the primary, fast, pid-bearing signal. Fallbacks are additive; schema version stays "1".

## Test plan

- [x] `go test ./cmd/gc/ -count=1 -run TestSupervisorStatusJSON` — all 4 tests pass (including 3 new: via-launchd, via-api, all-down)
- [x] Existing `TestSupervisorStatusJSON` made hermetic (both fallback hooks stubbed false)
- [x] `go vet ./cmd/gc/` clean
- [x] `go test ./cmd/gc/ -count=1 -run TestSupervisor` — no regressions
- [x] `make test` green

Closes ga-n1yt1b. Upstream issue: gastownhall/gascity#2984 (@azanar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)