### PR TITLE
feat(formulas): replace sleep backoff with clean idle exit in patrol formulas

### DIFF
--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -2086,6 +2086,7 @@ func TestControllerStateLegacyFileProviderUsesSharedCityStoreWithoutCreatingRigS
 }
 
 func TestControllerStateLegacyFileProviderSharesRigStoreHandle(t *testing.T) {
+	clearGCEnv(t)
 	t.Setenv("GC_BEADS", "file")
 
 	cityDir := t.TempDir()

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -3774,7 +3774,7 @@ func TestDeaconPatrolDetectsQueueStarvation(t *testing.T) {
 	)
 }
 
-func TestDeaconPatrolNextIterationBurnsCurrentBeforeBackoff(t *testing.T) {
+func TestDeaconPatrolNextIterationBurnsCurrentBeforeIdleExit(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-deacon-patrol.toml")
 	data, err := os.ReadFile(path)
@@ -3793,11 +3793,16 @@ func TestDeaconPatrolNextIterationBurnsCurrentBeforeBackoff(t *testing.T) {
 		`if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then`,
 		`if [ -n "$CURRENT_WISP" ]; then`,
 		`gc bd mol burn "$CURRENT_WISP" --force`,
-		`sleep {{event_timeout}}`,
-		`gc hook`,
+		`IDLE: no work, exiting turn.`,
 	)
 	if strings.Contains(section, "<this-wisp-id>") {
 		t.Fatal("next-iteration still uses placeholder burn target")
+	}
+	if strings.Contains(section, "sleep {{event_timeout}}") {
+		t.Fatal("next-iteration still contains sleep backoff — should use clean idle exit")
+	}
+	if strings.Contains(section, "gc hook") {
+		t.Fatal("next-iteration still calls gc hook — should use clean idle exit")
 	}
 }
 

--- a/examples/gastown/packs/gastown/agents/refinery/agent.toml
+++ b/examples/gastown/packs/gastown/agents/refinery/agent.toml
@@ -4,4 +4,5 @@ work_dir = ".gc/worktrees/{{.Rig}}/refinery"
 nudge = "Run 'gc prime' to check merge queue and begin processing."
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
 idle_timeout = "2h"
+sleep_after_idle = "300s"
 max_active_sessions = 1

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -444,19 +444,13 @@ Do not sleep with the current wisp still open. The backoff belongs to the
 already-assigned successor wisp; if the session restarts during the sleep, the
 successor remains the single resumable patrol item.
 
-**5. Wait before next cycle:**
-```bash
-sleep {{event_timeout}}
+**5. Exit this turn:**
+Write exactly:
 ```
-
-Previous implementation watched `gc events --type=bead.updated` for fast wake-up, but cache-reconcile fires that event constantly, turning the watch into a tight loop with no useful backoff. Fixed sleep gives predictable idle cost.
-
-**6. Re-enter the hook:**
-```bash
-gc hook
+IDLE: no work, exiting turn.
 ```
+Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
+The session_sleep policy will restart this session after the configured idle interval;
+the next wisp is already assigned and the restarted session resumes from it.
 
-The new wisp is ready. Re-read formula steps to start the next patrol cycle.
-
-**Exit criteria:** Next wisp poured and assigned, this wisp burned, backoff
-elapsed, and `gc hook` re-entered."""
+**Exit criteria:** Next wisp poured and assigned, this wisp burned, turn ended with IDLE signal."""

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -188,14 +188,14 @@ gc bd show $WORK --json | jq '.[0].metadata'
 The bead MUST have `metadata.branch`. If `metadata.target` is missing,
 use {{target_branch}} as default. Note the work bead ID and close this step.
 
-If NO work found: sleep before re-checking:
-```bash
-sleep {{event_timeout}}
+If NO work found:
+Write exactly:
 ```
-
-Re-check for assigned work. If found, close this step. Otherwise repeat the sleep.
-
-Note: previous implementation watched `gc events --type=bead.updated` for fast wake-up, but cache-reconcile fires that event constantly, turning the watch into a tight loop with no useful backoff. Fixed sleep gives predictable idle cost (~$0 vs ~$3.46/15min hot-loop measured 2026-04-29).
+IDLE: no work, exiting turn.
+```
+Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
+The session_sleep policy will restart this session after the configured idle interval.
+When restarted, re-read formula steps — this step stays open until a work bead is found.
 
 **Do not close this step until you have a work bead with branch metadata.**"""
 

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -515,19 +515,18 @@ NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{bin
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 
-**3. Wait before next cycle:**
-```bash
-sleep {{event_timeout}}
-```
-
-Previous implementation watched `gc events --type=bead.updated` for fast wake-up, but cache-reconcile fires that event constantly, turning the watch into a tight loop with no useful backoff. Fixed sleep gives predictable idle cost.
-
-**4. Burn this wisp:**
+**3. Burn this wisp:**
 ```bash
 gc bd mol burn <this-wisp-id> --force
 ```
 
-The new wisp is ready. Re-read formula steps to start
-the next patrol cycle.
+**4. Exit this turn:**
+Write exactly:
+```
+IDLE: no work, exiting turn.
+```
+Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
+The session_sleep policy will restart this session after the configured idle interval;
+the next wisp is already assigned and the restarted session resumes from it.
 
-**Exit criteria:** Next wisp poured, this wisp burned."""
+**Exit criteria:** Next wisp poured, this wisp burned, turn ended with IDLE signal."""

--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -17,16 +17,19 @@ func TestCustomTypesCheck_NoBeadsDir(t *testing.T) {
 }
 
 func TestCustomTypesCheck_MissingTypes(t *testing.T) {
-	// Scrub inherited beads env (BEADS_DIR / BEADS_ACTOR /
-	// GC_BEADS_SCOPE_ROOT) so the `bd config get` subprocess below
-	// resolves to the empty .beads/ in the temp dir instead of an
-	// outer gc city's beads database that a polecat/refinery worktree
-	// passes down via the environment. Without this, bd finds the
-	// outer city's store, reports all required types as present, and
-	// the check returns StatusOK — defeating the test's assertion.
-	// Same root cause class as ga-10qg / ga-766q; leak vector here is
-	// BEADS_DIR into a bd subprocess.
-	for _, key := range []string{"BEADS_DIR", "BEADS_ACTOR", "GC_BEADS_SCOPE_ROOT"} {
+	// Scrub inherited beads env so the `bd config get` subprocess below
+	// resolves to the empty .beads/ in the temp dir instead of an outer
+	// gc city's beads database. Without this, bd can reach a live dolt
+	// server (via GC_BEADS=bd + BEADS_DOLT_SERVER_PORT), reports all
+	// required types as present, and the check returns StatusOK —
+	// defeating the assertion. Clearing GC_BEADS and the dolt connection
+	// vars prevents bd from connecting even if testenv.init() has not
+	// yet added them to its LeakVectorVars scrub list.
+	for _, key := range []string{
+		"BEADS_DIR", "BEADS_ACTOR", "GC_BEADS_SCOPE_ROOT",
+		"GC_BEADS", "BEADS_DOLT_SERVER_PORT", "GC_DOLT_HOST", "GC_DOLT_PORT",
+		"BEADS_DOLT_SERVER_HOST",
+	} {
 		t.Setenv(key, "")
 	}
 

--- a/internal/runtime/k8s/testenv_helpers_test.go
+++ b/internal/runtime/k8s/testenv_helpers_test.go
@@ -4,16 +4,14 @@ import (
 	"testing"
 )
 
-// clearDoltAndCityEnv empties the GC_DOLT_* / GC_K8S_DOLT_* / GC_CITY_PATH env
-// vars for the duration of the test so the child scripts spawned via
-// runControllerScriptDeploy and runBeadsScript (which inherit the test
-// process's env through `os.Environ()`) do not observe a GC_DOLT_* leak from
-// the developer's shell. Each test's opts.Env continues to declare its own
-// desired state, which overrides the emptied values when cmd.Env is flattened.
-//
-// Shell scripts read these vars via `${VAR:-…}` / `[ -n "$VAR" ]` patterns, so
-// an empty string is treated the same as unset — good enough to make the tests
-// deterministic without needing a raw os.Unsetenv + manual cleanup.
+// clearDoltAndCityEnv empties the GC_DOLT_* / GC_K8S_DOLT_* / GC_CITY_PATH /
+// GC_BIN env vars for the duration of the test so the child scripts spawned
+// via runControllerScriptDeploy and runBeadsScript (which inherit the test
+// process's env through `os.Environ()`) do not observe leaks from the
+// developer's shell. GC_BIN is included because the test constructs its own
+// cmd.Env with a fake GC_BIN entry appended after os.Environ(); on Linux,
+// getenv() returns the first occurrence, so an inherited real GC_BIN would
+// shadow the test's fake binary if not cleared here first.
 func clearDoltAndCityEnv(t *testing.T) {
 	t.Helper()
 	for _, name := range []string{
@@ -22,6 +20,7 @@ func clearDoltAndCityEnv(t *testing.T) {
 		"GC_K8S_DOLT_HOST",
 		"GC_K8S_DOLT_PORT",
 		"GC_CITY_PATH",
+		"GC_BIN",
 	} {
 		t.Setenv(name, "")
 	}


### PR DESCRIPTION
## Summary

- Replaces `sleep {{event_timeout}}` in `mol-deacon-patrol`, `mol-witness-patrol`, and `mol-refinery-patrol` with a clean idle exit: agents write `IDLE: no work, exiting turn.` and stop immediately
- Deacon and witness now burn the current wisp before exiting (removing the old burn-after-sleep ordering); `gc hook` re-entry step removed since session exits cleanly
- Refinery exits from `find-work` on idle; the step stays open so the restarted session resumes cleanly
- Updates `TestDeaconPatrolNextIterationBurnsCurrentBeforeBackoff` → `TestDeaconPatrolNextIterationBurnsCurrentBeforeIdleExit` to assert burn precedes IDLE signal and that sleep/gc-hook are absent

## Problem

Patrol agents on the Claude Code harness accumulate context unboundedly. `sleep()` does not block the session turn on that harness — the agent stays alive and costs tokens for every cycle. Measured cost: ~$470/session on refinery over 3.5 days.

## Solution

The GC `session_sleep` / `sleep_after_idle` policy handles the restart interval. Agents exit cleanly (bounded context), the controller restarts them after the configured idle interval, and any queued work produces an immediate nudge wake-up.

Bead: ga-la6yf7.1

## Test plan

- [x] TOML parse validation — all 6 formula files parse cleanly
- [x] `go test ./examples/gastown/...` passes (`TestDeaconPatrolNextIterationBurnsCurrentBeforeIdleExit` verifies new behavior)
- [x] `go vet ./examples/gastown/...` clean
- [x] Pre-commit hook (`make test-fast-parallel`) passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---

## Why this change is going in — rationale (verified by investigation, 2026-06-07)

**Problem.** On the Claude Code harness an in-prompt `sleep {{event_timeout}}` does **not** block the session turn — patrol agents fall back to ScheduleWakeup/Monitor and re-invoke with the **full accumulated transcript every cycle**. Measured: **~$470/session on refinery over 3.5 days** of unbounded context growth.

**Fix.** Replace the in-prompt sleep with a clean turn exit (`IDLE: no work, exiting turn.`) and move the idle/restart interval to GC infrastructure (`sleep_after_idle` / `idle_timeout`) with `wake_mode=fresh`, so each restart resets context.

**Intended cadence is per-agent by design (not either/or):**
- Refinery (on-demand worker): ~300s via `sleep_after_idle=300s`.
- Deacon & witness (`mode=always` patrol): ~1h via `idle_timeout=1h`. Intentionally excluded from `sleep_after_idle` — a `mode=always` session with a non-off `sleep_after_idle` is a fatal config error (`internal/config/config.go`), documented in ga-la6yf7.2.

**Verified.** Diff confirmed correct against current main; refinery sleeps at ~300s (agent-level `sleep_after_idle` precedence) and `wake_mode=fresh` resets context. Origin: ga-la6yf7 / .1 / .2.
