### PR TITLE
fix(reconciler): recycle zombie sessions on start collision

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -211,6 +211,7 @@ type startResult struct {
 // session_key is set, CommitRefresh only on the async path).
 type startPhaseTimings struct {
 	StartCall         time.Duration // startPreparedStartCandidate total (provider Start + any ErrStateSync recovery)
+	ZombieRecycle     time.Duration // provider Stop of a running session whose agent process died (subset of StartCall; ga-yms)
 	StateSyncRecovery time.Duration // workerSessionTargetRunningWithConfig branch when provider Start returned ErrStateSync (subset of StartCall; gc-9ha)
 	PostStartObserve  time.Duration // staleKeyDetectDelay + workerObserveSessionTarget when session_key present
 	CommitRefresh     time.Duration // refreshAsyncStartResult bead reload (async path only)
@@ -227,12 +228,15 @@ type startPhaseTimings struct {
 // 0.5ms doesn't print as "...=0s" (which would be misleading and
 // defeat the elision intent). Sub-ms durations are dropped entirely.
 func (p startPhaseTimings) formatLog() string {
-	if p.StartCall == 0 && p.StateSyncRecovery == 0 && p.PostStartObserve == 0 && p.CommitRefresh == 0 {
+	if p.StartCall == 0 && p.ZombieRecycle == 0 && p.StateSyncRecovery == 0 && p.PostStartObserve == 0 && p.CommitRefresh == 0 {
 		return ""
 	}
 	var parts []string
 	if r := p.StartCall.Round(time.Millisecond); r > 0 {
 		parts = append(parts, fmt.Sprintf("start_call=%s", r))
+	}
+	if r := p.ZombieRecycle.Round(time.Millisecond); r > 0 {
+		parts = append(parts, fmt.Sprintf("zombie_recycle=%s", r))
 	}
 	if r := p.StateSyncRecovery.Round(time.Millisecond); r > 0 {
 		parts = append(parts, fmt.Sprintf("state_sync_recovery=%s", r))
@@ -1120,7 +1124,7 @@ func runPreparedStartCandidate(
 	defer cancel()
 	var phases startPhaseTimings
 	startCallBegin := time.Now()
-	startedFresh, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg)
+	startedFresh, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg, &phases)
 	startCtxErr := startCtx.Err()
 	// Split start_call into provider.Start and the ErrStateSync recovery
 	// branch (gc-9ha). The recovery branch hits the worker observation
@@ -1549,18 +1553,37 @@ func startPreparedStartCandidate(
 	store beads.Store,
 	sp runtime.Provider,
 	cfg *config.City,
+	phases *startPhaseTimings,
 ) (bool, error) {
 	name := item.candidate.name()
 	if sp != nil {
 		running, alive := observeRuntimeProviderLiveness(sp, name, item.cfg.ProcessNames)
 		if running {
-			if shouldRollbackPendingCreate(item.candidate.session) && !runningSessionMatchesPendingCreate(item.candidate.session, name, sp) {
-				return false, fmt.Errorf("%w: session %q", runtime.ErrSessionExists, name)
-			}
 			if alive {
+				if shouldRollbackPendingCreate(item.candidate.session) && !runningSessionMatchesPendingCreate(item.candidate.session, name, sp) {
+					return false, fmt.Errorf("%w: session %q", runtime.ErrSessionExists, name)
+				}
 				return false, nil
 			}
-			return false, fmt.Errorf("session %q died during startup", name)
+			// Zombie: the runtime container (e.g. tmux pane) is up but the
+			// agent process is gone — typically a session that survived a
+			// supervisor restart and whose CLI exited back to the wrapping
+			// shell. Failing here wedges the reconciler in a collide-loop:
+			// the stale session keeps the name occupied, every retry hits
+			// the same state, and templates depending on this session never
+			// start (ga-yms). A dead agent process has nothing left to
+			// preserve — identity mismatch included, since rolling a pending
+			// create back just recreates the bead next tick against the same
+			// zombie — so recycle it: stop the stale session and fall
+			// through to a fresh start.
+			recycleBegin := time.Now()
+			stopErr := sp.Stop(name)
+			if phases != nil {
+				phases.ZombieRecycle = time.Since(recycleBegin)
+			}
+			if stopErr != nil && !runtime.IsSessionGone(stopErr) {
+				return false, fmt.Errorf("recycling session %q with dead agent process: %w", name, stopErr)
+			}
 		}
 	}
 	if store == nil || item.candidate.session == nil || strings.TrimSpace(item.candidate.session.ID) == "" {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -5406,6 +5406,7 @@ func TestExecutePreparedStartWave_SkipsStaleKeyProbeWhenSessionAlreadyRunning(t 
 }
 
 func TestExecutePreparedStartWave_AlreadyRunningRequiresLiveProcess(t *testing.T) {
+	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	sp := &zombieAfterStartProvider{Fake: runtime.NewFake()}
 	if err := sp.Start(context.Background(), "test-agent", runtime.Config{ProcessNames: []string{"claude"}}); err != nil {
 		t.Fatalf("Start existing session: %v", err)
@@ -5444,11 +5445,139 @@ func TestExecutePreparedStartWave_AlreadyRunningRequiresLiveProcess(t *testing.T
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}
 	r := results[0]
+	// The dead agent process must not be silently adopted as alive: the
+	// stale session is recycled (stop + fresh start), and because the
+	// recycled start dies again with the same stale resume key, the
+	// post-start probe still reports the death so recordWakeFailure can
+	// clear the key for the next attempt.
+	if got := fakeRuntimeCallCount(sp.Fake, "Stop"); got != 1 {
+		t.Fatalf("Stop calls = %d, want 1 (zombie recycle)", got)
+	}
+	if got := fakeRuntimeCallCount(sp.Fake, "Start"); got != 2 {
+		t.Fatalf("Start calls = %d, want 2 (setup + recycled start)", got)
+	}
 	if r.err == nil {
-		t.Fatal("expected already-running dead agent process to fail liveness validation")
+		t.Fatal("expected recycled start that dies again to fail liveness validation")
 	}
 	if !strings.Contains(r.err.Error(), "died during startup") {
 		t.Fatalf("unexpected error: %v", r.err)
+	}
+}
+
+func TestExecutePreparedStartWave_RecyclesZombieSession(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "test-agent", runtime.Config{ProcessNames: []string{"claude"}}); err != nil {
+		t.Fatalf("Start existing session: %v", err)
+	}
+	// Simulate a session that survived a supervisor restart with its pane
+	// alive but its agent process gone (e.g. the CLI exited to the shell).
+	sp.Zombies["test-agent"] = true
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-102",
+				Metadata: map[string]string{
+					"session_name": "test-agent",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err != nil {
+		t.Fatalf("zombie session should be recycled, not wedge the start: %v", r.err)
+	}
+	if r.outcome != "success" {
+		t.Fatalf("outcome = %q, want success", r.outcome)
+	}
+	if got := fakeRuntimeCallCount(sp, "Stop"); got != 1 {
+		t.Fatalf("Stop calls = %d, want 1 (zombie recycle)", got)
+	}
+	if got := fakeRuntimeCallCount(sp, "Start"); got != 2 {
+		t.Fatalf("Start calls = %d, want 2 (setup + recycled start)", got)
+	}
+}
+
+func TestExecutePreparedStartWave_RecyclesZombieSessionDespitePendingCreateMismatch(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "test-agent", runtime.Config{ProcessNames: []string{"claude"}}); err != nil {
+		t.Fatalf("Start existing session: %v", err)
+	}
+	// The surviving session carries a previous incarnation's identity and
+	// its agent process is dead. Identity mismatch must not preempt the
+	// recycle: rolling the pending create back would just recreate the
+	// bead next tick and hit the same zombie forever.
+	if err := sp.SetMeta("test-agent", "GC_SESSION_ID", "gc-previous-incarnation"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	sp.Zombies["test-agent"] = true
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-103",
+				Metadata: map[string]string{
+					"session_name":         "test-agent",
+					"template":             "worker",
+					"pending_create_claim": "true",
+					"instance_token":       "tok-current",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err != nil {
+		t.Fatalf("zombie session should be recycled despite identity mismatch: %v", r.err)
+	}
+	if r.outcome != "success" {
+		t.Fatalf("outcome = %q, want success", r.outcome)
+	}
+	if got := fakeRuntimeCallCount(sp, "Stop"); got != 1 {
+		t.Fatalf("Stop calls = %d, want 1 (zombie recycle)", got)
+	}
+	if got := fakeRuntimeCallCount(sp, "Start"); got != 2 {
+		t.Fatalf("Start calls = %d, want 2 (setup + recycled start)", got)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_start_boundary_test.go
+++ b/cmd/gc/session_lifecycle_start_boundary_test.go
@@ -89,6 +89,7 @@ func TestStartPreparedStartCandidateUsesWorkerBoundaryForRuntimeOnlyTarget(t *te
 		nil,
 		sp,
 		nil,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("startPreparedStartCandidate: %v", err)

--- a/cmd/gc/session_reconciler_drift_resume_test.go
+++ b/cmd/gc/session_reconciler_drift_resume_test.go
@@ -83,7 +83,7 @@ func TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyOnContinua
 		t.Fatalf("prepareStartCandidateForCity: %v", err)
 	}
 
-	if _, err := startPreparedStartCandidate(context.Background(), *prepared, "", env.store, env.sp, cfg); err != nil {
+	if _, err := startPreparedStartCandidate(context.Background(), *prepared, "", env.store, env.sp, cfg, nil); err != nil {
 		t.Fatalf("startPreparedStartCandidate: %v", err)
 	}
 


### PR DESCRIPTION
## Problem

After a supervisor restart, tmux sessions survive (the tmux server is independent of the supervisor process). When such a surviving session's agent process is dead — e.g. the CLI exited back to the wrapping shell after an API error — the session reconciler wedges in a **permanent collide-loop**:

```
session lifecycle: op=start wave=0 session=gastown__mayor outcome=provider_error err=session died during startup
```

`startPreparedStartCandidate` pre-observes the runtime before starting. For `running && !alive` (pane up, agent process gone — a zombie) it returned a synthetic "died during startup" error **without ever invoking the provider's `Start`**. The tmux adapter's `ensureFreshSession` has exactly the right recovery for this state (kill the zombie, recreate fresh), but it was never reached, and nothing else ever changes the zombie's state:

- the adoption barrier skips sessions whose agent process is dead (`runAdoptionBarrier`: `!alive → continue`), so no bead adopts them
- the start path errors before any provider call, so nothing recycles them
- every reconciler tick retries the same start and hits the same wedge, in ~60ms

Observed in the field (2026-06-06, 18:57–19:45Z): four named sessions collide-looped for 40+ minutes after a `systemctl --user restart` of the supervisor; pool scale-up never ran because the pool templates' dependencies (the wedged named sessions) never came alive (`blocked_on_dependencies`). Recovery required manual `tmux kill-session` on the stale sessions + supervisor reload.

There is a second shape of the same wedge: a zombie occupying the name of a **pending create** with mismatched identity (`pending_create_claim` set, `runningSessionMatchesPendingCreate` false — e.g. a previous supervisor incarnation's session) returned `ErrSessionExists`, which rolls the pending create back. The next tick recreates the bead and hits the same zombie, forever.

## Fix

When the pre-start observation finds the name occupied by a session whose agent process is dead, **recycle it**: `sp.Stop(name)`, then fall through to the normal fresh start. This mirrors the proven manual recovery and the tmux adapter's own `ensureFreshSession` zombie contract, and is provider-agnostic (the stop is explicit at the lifecycle layer instead of delegated to provider-specific create-collision handling). A dead agent process has nothing left to preserve — identity mismatch included, since rolling a pending create back just recreates the bead against the same zombie.

Semantics preserved:

- **Live sessions are still adopted** with no provider `Start` — #2162's false-death-classification fix is untouched (`SkipsStaleKeyProbeWhenSessionAlreadyRunning`, `AlreadyRunningFalseNegativeUsesProcessAliveFallback` pass unmodified)
- **Live sessions with mismatched pending-create identity** still return `ErrSessionExists` (graceful race loss)
- **A dead agent process is still never silently adopted**: `AlreadyRunningRequiresLiveProcess` now asserts the recycle (Stop + fresh Start) and that a recycled start which dies again still reports "died during startup" so `recordWakeFailure` clears the stale resume key
- **Crash forensics ordering unchanged**: scrollback capture and rate-limit quarantine happen in the reconciler observation phase before start candidates execute (`ZombieCapturesScrollback`, `RateLimitScreenQuarantinesBeforeHeal`, and the rate-limit telemetry tests pass unmodified)

The recycle is observable in lifecycle logs as a new `zombie_recycle=` phase timing.

On the report's secondary concern (a wave-0 failure storm starving later waves / pool scaling): failed starts do **not** consume the wake budget — `commitStartResultTraced` returns false on every failure path — so the only starvation vector is `blocked_on_dependencies`, which is correct gating and resolves once the wedged dependencies recycle. No wave-loop change needed.

## Tests

- `TestExecutePreparedStartWave_RecyclesZombieSession` — zombie occupying the name → Stop + fresh Start, outcome `success` (previously: "died during startup" wedge)
- `TestExecutePreparedStartWave_RecyclesZombieSessionDespitePendingCreateMismatch` — zombie + mismatched pending-create identity → recycled (previously: `ErrSessionExists` rollback loop)
- `TestExecutePreparedStartWave_AlreadyRunningRequiresLiveProcess` — updated: asserts the recycle happens and stale-key death detection still fires on the recycled start (now gated behind `skipSlowCmdGCTest` like its sibling, since it waits through `staleKeyDetectDelay`)
- Full `cmd/gc` suite green; `make fmt-check`, `make lint-changed` (0 issues), `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)