### PR TITLE
fix(nudge): stop stale queued-nudge backlogs from wedging delivery to idle sessions

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -413,13 +413,17 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		}
 		return 1
 	}
+	deliveryStore := openNudgeBeadStore(target.cityPath)
 	items, rejected := splitQueuedNudgesForTarget(target, items)
 	if len(rejected) > 0 {
-		_ = recordQueuedNudgeFailure(target.cityPath, queuedNudgeIDs(rejected), errNudgeSessionFenceMismatch, time.Now())
+		_ = recordQueuedNudgeFailureWithStore(target.cityPath, deliveryStore, queuedNudgeIDs(rejected), errNudgeSessionFenceMismatch, time.Now())
 	}
-	deliveryStore := openNudgeBeadStore(target.cityPath)
-	items, blocked, err := splitQueuedNudgesForDelivery(deliveryStore, items)
+	candidates := items
+	items, blocked, err := splitQueuedNudgesForDelivery(deliveryStore, candidates)
 	if err != nil {
+		// Release the claims so the next drain or poller pass retries
+		// promptly instead of waiting out the in-flight lease.
+		_ = releaseQueuedNudgeClaims(target.cityPath, queuedNudgeIDs(candidates))
 		if inject {
 			fmt.Fprintf(stderr, "gc nudge drain: validating claimed nudges: %v\n", err) //nolint:errcheck
 			return 0
@@ -429,12 +433,10 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 	}
 	if len(blocked) > 0 {
 		if err := terminalizeBlockedQueuedNudges(target.cityPath, blocked); err != nil {
-			if inject {
-				fmt.Fprintf(stderr, "gc nudge drain: withdrawing blocked nudges: %v\n", err) //nolint:errcheck
-				return 0
-			}
+			// Best-effort: blocked-item bookkeeping must not abort delivery
+			// of the remaining items. The blocked items stay in-flight and
+			// lease expiry returns them to pending for a later pass.
 			fmt.Fprintf(stderr, "gc nudge drain: withdrawing blocked nudges: %v\n", err) //nolint:errcheck
-			return 1
 		}
 	}
 	if len(items) == 0 {
@@ -460,7 +462,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		_, writeErr = io.WriteString(stdout, out)
 	}
 	if writeErr != nil {
-		_ = recordQueuedNudgeFailure(target.cityPath, queuedNudgeIDs(items), writeErr, time.Now())
+		_ = recordQueuedNudgeFailureWithStore(target.cityPath, deliveryStore, queuedNudgeIDs(items), writeErr, time.Now())
 		if inject {
 			return 0
 		}
@@ -533,9 +535,23 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 	}
 	var missingSince time.Time
 	for {
-		obs, err := workerObserveNudgeTarget(target, store, sp)
+		obs, err := nudgeObserveTarget(target, store, sp)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc nudge poll: %v\n", err) //nolint:errcheck
+			// Transient observation failures (store hiccup, runtime probe
+			// race) must not kill the poller while queued work is pending:
+			// for an idle session this sidecar is the only delivery path, so
+			// exiting here strands the queue until something re-launches a
+			// poller. Reuse the missing-session grace window; persistent
+			// failures still exit once it elapses or the queue drains.
+			now := time.Now()
+			if shouldKeepNudgePollerAlive(target, missingSince, now) {
+				if missingSince.IsZero() {
+					missingSince = now
+				}
+				time.Sleep(interval)
+				continue
+			}
 			return 1
 		}
 		if !obs.Running {
@@ -1039,27 +1055,34 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store beads.Store, sp ru
 	if err != nil || len(items) == 0 {
 		return false, err
 	}
-	items, rejected := splitQueuedNudgesForTarget(target, items)
-	if len(rejected) > 0 {
-		if recErr := recordQueuedNudgeFailure(target.cityPath, queuedNudgeIDs(rejected), errNudgeSessionFenceMismatch, time.Now()); recErr != nil {
-			return false, recErr
-		}
-	}
 	deliveryStore := store
 	if deliveryStore == nil {
 		deliveryStore = openNudgeBeadStore(target.cityPath)
 	}
-	items, blocked, err := splitQueuedNudgesForDelivery(deliveryStore, items)
+	// Bookkeeping for fence-mismatched and blocked items is best-effort: a
+	// failure there must not abort delivery of the remaining claimable items.
+	// Items whose bookkeeping failed stay in-flight; lease expiry returns
+	// them to pending and a later pass retries.
+	var bookkeepErr error
+	items, rejected := splitQueuedNudgesForTarget(target, items)
+	if len(rejected) > 0 {
+		if recErr := recordQueuedNudgeFailureWithStore(target.cityPath, deliveryStore, queuedNudgeIDs(rejected), errNudgeSessionFenceMismatch, time.Now()); recErr != nil {
+			bookkeepErr = fmt.Errorf("dead-lettering fence-mismatched nudges: %w", recErr)
+		}
+	}
+	candidates := items
+	items, blocked, err := splitQueuedNudgesForDelivery(deliveryStore, candidates)
 	if err != nil {
-		return false, err
+		relErr := releaseQueuedNudgeClaims(target.cityPath, queuedNudgeIDs(candidates))
+		return false, errors.Join(bookkeepErr, err, relErr)
 	}
 	if len(blocked) > 0 {
-		if err := terminalizeBlockedQueuedNudges(target.cityPath, blocked); err != nil {
-			return false, err
+		if termErr := terminalizeBlockedQueuedNudges(target.cityPath, blocked); termErr != nil {
+			bookkeepErr = errors.Join(bookkeepErr, fmt.Errorf("withdrawing blocked nudges: %w", termErr))
 		}
 	}
 	if len(items) == 0 {
-		return false, nil
+		return false, bookkeepErr
 	}
 	var msg string
 	if target.sessionTransport() == "acp" {
@@ -1069,7 +1092,8 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store beads.Store, sp ru
 	}
 	handle, err := workerHandleForNudgeTarget(target, store, sp)
 	if err != nil {
-		return false, err
+		relErr := releaseQueuedNudgeClaims(target.cityPath, queuedNudgeIDs(items))
+		return false, errors.Join(bookkeepErr, err, relErr)
 	}
 	result, err := handle.Nudge(context.Background(), worker.NudgeRequest{
 		Text:     msg,
@@ -1081,21 +1105,25 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store beads.Store, sp ru
 		telemetry.RecordNudge(context.Background(), target.agentKey(), err)
 		if errors.Is(err, runtime.ErrSessionNotFound) {
 			if recErr := releaseQueuedNudgeClaims(target.cityPath, queuedNudgeIDs(items)); recErr != nil {
-				return false, recErr
+				return false, errors.Join(bookkeepErr, recErr)
 			}
-			return false, nil
+			return false, bookkeepErr
 		}
-		if recErr := recordQueuedNudgeFailure(target.cityPath, queuedNudgeIDs(items), err, time.Now()); recErr != nil {
-			return false, recErr
+		if recErr := recordQueuedNudgeFailureWithStore(target.cityPath, deliveryStore, queuedNudgeIDs(items), err, time.Now()); recErr != nil {
+			return false, errors.Join(bookkeepErr, recErr)
 		}
-		return false, nil
+		return false, bookkeepErr
 	}
 	if !result.Delivered {
-		return false, nil
+		// The runtime declined without an error (e.g. the session stopped
+		// between observation and delivery). Release the claims so the next
+		// pass retries promptly instead of waiting out the in-flight lease.
+		relErr := releaseQueuedNudgeClaims(target.cityPath, queuedNudgeIDs(items))
+		return false, errors.Join(bookkeepErr, relErr)
 	}
 	telemetry.RecordNudge(context.Background(), target.agentKey(), nil)
 	stampLastNudgeDeliveredAt(deliveryStore, target.sessionID, time.Now())
-	return true, ackQueuedNudges(target.cityPath, queuedNudgeIDs(items))
+	return true, errors.Join(bookkeepErr, ackQueuedNudges(target.cityPath, queuedNudgeIDs(items)))
 }
 
 func stampLastNudgeDeliveredAt(store beads.Store, sessionID string, t time.Time) {
@@ -1415,12 +1443,6 @@ func queuedNudgeClaimableForTarget(target nudgeTarget, item queuedNudge) bool {
 		return false
 	}
 	return true
-}
-
-func claimDueQueuedNudges(cityPath, agentName string, now time.Time) ([]queuedNudge, error) {
-	return claimDueQueuedNudgesMatching(cityPath, now, func(item queuedNudge) bool {
-		return item.Agent == agentName
-	})
 }
 
 func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, error) {
@@ -1766,21 +1788,28 @@ func releaseQueuedNudgeClaims(cityPath string, ids []string) error {
 }
 
 func recordQueuedNudgeFailure(cityPath string, ids []string, cause error, now time.Time) error {
-	_, err := recordQueuedNudgeFailureDetailed(cityPath, ids, cause, now)
+	return recordQueuedNudgeFailureWithStore(cityPath, nil, ids, cause, now)
+}
+
+func recordQueuedNudgeFailureWithStore(cityPath string, store beads.Store, ids []string, cause error, now time.Time) error {
+	_, err := recordQueuedNudgeFailureDetailed(cityPath, store, ids, cause, now)
 	return err
 }
 
-func recordQueuedNudgeFailureDetailed(cityPath string, ids []string, cause error, now time.Time) ([]queuedNudge, error) {
+func recordQueuedNudgeFailureDetailed(cityPath string, store beads.Store, ids []string, cause error, now time.Time) ([]queuedNudge, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	store := openNudgeBeadStore(cityPath)
+	if store == nil {
+		store = openNudgeBeadStore(cityPath)
+	}
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		want[id] = true
 	}
 	var deadLettered []queuedNudge
 	err := withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
+		deadLettered = deadLettered[:0]
 		if err := recoverExpiredInFlightNudges(state, store, now); err != nil {
 			return err
 		}
@@ -1824,15 +1853,24 @@ func recordQueuedNudgeFailureDetailed(cityPath string, ids []string, cause error
 		state.InFlight = inFlight
 		state.Pending = append(state.Pending, requeued...)
 		state.Dead = append(state.Dead, dead...)
-		for _, item := range dead {
-			if err := markQueuedNudgeTerminal(store, item, "failed", item.LastError, "", now); err != nil {
-				return err
-			}
-		}
 		sortQueuedNudges(state)
 		return nil
 	})
-	return deadLettered, err
+	if err != nil {
+		return nil, err
+	}
+	// Mark backing beads terminal outside the queue lock, best-effort. The
+	// dead-letter transition above is authoritative; a failed bead write must
+	// not roll it back, or the items bounce between InFlight and Pending
+	// forever and stale backlogs wedge every delivery pass that claims them.
+	// pruneDeadQueuedNudges repairs dead entries whose backing bead missed
+	// terminal state, so drift converges on later queue operations.
+	for _, item := range deadLettered {
+		if markErr := markQueuedNudgeTerminal(store, item, "failed", item.LastError, "", now); markErr != nil && nudgeWarningWriter != nil {
+			fmt.Fprintf(nudgeWarningWriter, "gc nudge: warning: marking dead-lettered nudge %q terminal: %v\n", item.ID, markErr) //nolint:errcheck
+		}
+	}
+	return deadLettered, nil
 }
 
 func failedQueuedNudge(item queuedNudge, cause error, now time.Time) (queuedNudge, bool) {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -26,6 +26,12 @@ import (
 
 func intPtrNudge(n int) *int { return &n }
 
+func claimDueWorkerNudges(cityPath string) ([]queuedNudge, error) {
+	return claimDueQueuedNudgesMatching(cityPath, time.Now(), func(item queuedNudge) bool {
+		return item.Agent == "worker"
+	})
+}
+
 func writeCorruptNudgeQueueState(t *testing.T, cityPath string) {
 	t.Helper()
 	statePath := nudgequeue.StatePath(cityPath)
@@ -2592,6 +2598,288 @@ func TestTryDeliverQueuedNudgesByPollerKeepsACPProviderMissRecoverable(t *testin
 	}
 }
 
+type failingTerminalNudgeStore struct {
+	*beads.MemStore
+	failID string
+}
+
+func (s *failingTerminalNudgeStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if id != "" && id == s.failID {
+		return fmt.Errorf("setting metadata on %q: dolt connection refused", id)
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
+func TestTryDeliverQueuedNudgesByPollerReleasesClaimsWhenDeliveryDeclined(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now().Add(-1 * time.Minute)
+	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "review the deploy logs", now)); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+	info, err := mgr.Create(context.Background(), "worker", "Worker", "codex", dir, "codex", nil, session.ProviderResume{}, runtime.Config{WorkDir: dir})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Start(context.Background(), info.ID, "", runtime.Config{WorkDir: dir}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	idleSince := time.Now().Add(-10 * time.Second)
+	fake.Activity = map[string]time.Time{info.SessionName: idleSince}
+	// The session stops between the poller's observation and its delivery
+	// attempt — the restart-churn race. The live-only nudge then reports
+	// Delivered=false without an error.
+	if err := fake.Stop(info.SessionName); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "worker"},
+		sessionID:   info.ID,
+		resolved:    &config.ResolvedProvider{Name: "codex"},
+		sessionName: info.SessionName,
+	}
+	obs := worker.LiveObservation{Running: true, LastActivity: &idleSince}
+
+	delivered, err := tryDeliverQueuedNudgesByPoller(target, store, fake, 3*time.Second, obs)
+	if err != nil {
+		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+	}
+	if delivered {
+		t.Fatal("delivered = true, want false when the runtime declined delivery")
+	}
+
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want 1/0/0 (declined delivery must release the claim, not strand it in-flight)",
+			len(pending), len(inFlight), len(dead))
+	}
+	if pending[0].Attempts != 0 {
+		t.Fatalf("attempts = %d, want 0 for a declined delivery", pending[0].Attempts)
+	}
+}
+
+func TestTryDeliverQueuedNudgesByPollerDeliversDespiteStaleFenceBeadMarkFailure(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now().Add(-1 * time.Minute)
+
+	store := &failingTerminalNudgeStore{MemStore: beads.NewMemStore()}
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+	info, err := mgr.Create(context.Background(), "worker", "Worker", "codex", dir, "codex", nil, session.ProviderResume{}, runtime.Config{WorkDir: dir})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Start(context.Background(), info.ID, "", runtime.Config{WorkDir: dir}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	idleSince := time.Now().Add(-10 * time.Second)
+	fake.Activity = map[string]time.Time{info.SessionName: idleSince}
+
+	stale := newQueuedNudgeWithOptions("worker", "stale fenced reminder", "session", now, queuedNudgeOptions{
+		SessionID:         info.ID,
+		ContinuationEpoch: "1",
+	})
+	if err := enqueueQueuedNudgeWithStore(dir, store, stale); err != nil {
+		t.Fatalf("enqueueQueuedNudgeWithStore(stale): %v", err)
+	}
+	fresh := newQueuedNudgeWithOptions("worker", "wake up and resume your wisp", "session", now, queuedNudgeOptions{
+		SessionID:         info.ID,
+		ContinuationEpoch: "2",
+	})
+	if err := enqueueQueuedNudgeWithStore(dir, store, fresh); err != nil {
+		t.Fatalf("enqueueQueuedNudgeWithStore(fresh): %v", err)
+	}
+	staleBead, ok, err := findQueuedNudgeBead(store, stale.ID)
+	if err != nil || !ok {
+		t.Fatalf("findQueuedNudgeBead(stale) = %v, ok=%v", err, ok)
+	}
+	// Terminal-marking the stale item's backing bead fails (store flake).
+	// Dead-lettering bookkeeping for stale items must not block delivery
+	// of the fence-matching item.
+	store.failID = staleBead.ID
+
+	var warnings bytes.Buffer
+	origWarn := nudgeWarningWriter
+	nudgeWarningWriter = &warnings
+	defer func() { nudgeWarningWriter = origWarn }()
+
+	target := nudgeTarget{
+		cityPath:          dir,
+		agent:             config.Agent{Name: "worker"},
+		sessionID:         info.ID,
+		continuationEpoch: "2",
+		resolved:          &config.ResolvedProvider{Name: "codex"},
+		sessionName:       info.SessionName,
+	}
+	obs := worker.LiveObservation{Running: true, LastActivity: &idleSince}
+
+	delivered, err := tryDeliverQueuedNudgesByPoller(target, store, fake, 3*time.Second, obs)
+	if err != nil {
+		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+	}
+	if !delivered {
+		t.Fatal("delivered = false, want the fence-matching nudge delivered despite stale-item bead-mark failure")
+	}
+
+	var nudgeCalls []runtime.Call
+	for _, call := range fake.Calls {
+		if call.Method == "Nudge" {
+			nudgeCalls = append(nudgeCalls, call)
+		}
+	}
+	if len(nudgeCalls) != 1 {
+		t.Fatalf("nudge calls = %d, want 1", len(nudgeCalls))
+	}
+	if !strings.Contains(nudgeCalls[0].Message, "wake up and resume your wisp") {
+		t.Fatalf("nudge message = %q, want fence-matching reminder", nudgeCalls[0].Message)
+	}
+	if strings.Contains(nudgeCalls[0].Message, "stale fenced reminder") {
+		t.Fatalf("nudge message = %q, must not deliver the fence-mismatched reminder", nudgeCalls[0].Message)
+	}
+
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 {
+		t.Fatalf("pending/inFlight = %d/%d, want 0/0", len(pending), len(inFlight))
+	}
+	if len(dead) != 1 || dead[0].ID != stale.ID {
+		t.Fatalf("dead = %+v, want exactly the stale fence-mismatched item", dead)
+	}
+	if !strings.Contains(warnings.String(), stale.ID) {
+		t.Fatalf("warnings = %q, want bead-mark failure surfaced for %s", warnings.String(), stale.ID)
+	}
+}
+
+func TestRecordQueuedNudgeFailureDeadLettersWhenTerminalBeadMarkFails(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now().Add(-1 * time.Minute)
+
+	store := &failingTerminalNudgeStore{MemStore: beads.NewMemStore()}
+	item := newQueuedNudgeWithOptions("worker", "stale fenced reminder", "session", now, queuedNudgeOptions{
+		SessionID:         "sess-1",
+		ContinuationEpoch: "1",
+	})
+	if err := enqueueQueuedNudgeWithStore(dir, store, item); err != nil {
+		t.Fatalf("enqueueQueuedNudgeWithStore: %v", err)
+	}
+	itemBead, ok, err := findQueuedNudgeBead(store, item.ID)
+	if err != nil || !ok {
+		t.Fatalf("findQueuedNudgeBead = %v, ok=%v", err, ok)
+	}
+	store.failID = itemBead.ID
+
+	claimed, err := claimDueWorkerNudges(dir)
+	if err != nil {
+		t.Fatalf("claimDueQueuedNudges: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("claimed = %d, want 1", len(claimed))
+	}
+
+	var warnings bytes.Buffer
+	origWarn := nudgeWarningWriter
+	nudgeWarningWriter = &warnings
+	defer func() { nudgeWarningWriter = origWarn }()
+
+	if err := recordQueuedNudgeFailureWithStore(dir, store, []string{item.ID}, errNudgeSessionFenceMismatch, time.Now()); err != nil {
+		t.Fatalf("recordQueuedNudgeFailureWithStore: %v (queue transition must commit despite bead-mark failure)", err)
+	}
+
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 1 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want 0/0/1", len(pending), len(inFlight), len(dead))
+	}
+	if !strings.Contains(warnings.String(), item.ID) {
+		t.Fatalf("warnings = %q, want bead-mark failure surfaced for %s", warnings.String(), item.ID)
+	}
+
+	// The backing bead missed its terminal state; the dead-letter repair
+	// pass owns convergence from here (see pruneDeadQueuedNudges).
+	b, err := store.Get(itemBead.ID)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", itemBead.ID, err)
+	}
+	if b.Metadata["state"] != "queued" {
+		t.Fatalf("bead state = %q, want still queued after failed terminal mark", b.Metadata["state"])
+	}
+}
+
+func TestCmdNudgePollSurvivesTransientObserveErrors(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	writeNamedSessionCityTOML(t, cityDir)
+	t.Setenv("GC_CITY", cityDir)
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	created, err := store.Create(beads.Bead{
+		Title:  "Session: worker",
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "worker-session",
+			"agent_name":   "worker",
+			"template":     "worker",
+			"state":        string(session.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create session: %v", err)
+	}
+	item := newQueuedNudgeWithOptions("worker", "resume your patrol wisp", "session", time.Now().Add(-time.Minute), queuedNudgeOptions{
+		SessionID: created.ID,
+	})
+	if err := enqueueQueuedNudgeWithStore(cityDir, store, item); err != nil {
+		t.Fatalf("enqueueQueuedNudgeWithStore: %v", err)
+	}
+
+	observeCalls := 0
+	origObserve := nudgeObserveTarget
+	nudgeObserveTarget = func(_ nudgeTarget, _ beads.Store, _ runtime.Provider) (worker.LiveObservation, error) {
+		observeCalls++
+		if observeCalls == 1 {
+			return worker.LiveObservation{}, fmt.Errorf("transient store hiccup")
+		}
+		// Queued work has drained; report the session gone so the poller exits.
+		if err := ackQueuedNudges(cityDir, []string{item.ID}); err != nil {
+			t.Errorf("ackQueuedNudges: %v", err)
+		}
+		return worker.LiveObservation{Running: false}, nil
+	}
+	defer func() { nudgeObserveTarget = origObserve }()
+
+	var stdout, stderr bytes.Buffer
+	code := cmdNudgePoll([]string{created.ID}, "worker-session", time.Millisecond, 0, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdNudgePoll = %d, want 0 (transient observe error with queued work pending must not kill the poller); stderr=%s", code, stderr.String())
+	}
+	if observeCalls < 2 {
+		t.Fatalf("observe calls = %d, want the poller to retry past the transient error", observeCalls)
+	}
+}
+
 func TestCmdNudgeDrainStampsLastNudgeDeliveredAt(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
@@ -2790,7 +3078,7 @@ func TestClaimDueQueuedNudgesClaimsOnceUntilAck(t *testing.T) {
 		t.Fatalf("enqueueQueuedNudge: %v", err)
 	}
 
-	claimed, err := claimDueQueuedNudges(dir, "worker", time.Now())
+	claimed, err := claimDueWorkerNudges(dir)
 	if err != nil {
 		t.Fatalf("claimDueQueuedNudges: %v", err)
 	}
@@ -2798,7 +3086,7 @@ func TestClaimDueQueuedNudgesClaimsOnceUntilAck(t *testing.T) {
 		t.Fatalf("claimed = %d, want 1", len(claimed))
 	}
 
-	claimedAgain, err := claimDueQueuedNudges(dir, "worker", time.Now())
+	claimedAgain, err := claimDueWorkerNudges(dir)
 	if err != nil {
 		t.Fatalf("claimDueQueuedNudges second pass: %v", err)
 	}
@@ -2953,7 +3241,7 @@ func TestRecordQueuedNudgeFailureRequeuesClaimedNudge(t *testing.T) {
 		t.Fatalf("enqueueQueuedNudge: %v", err)
 	}
 
-	claimed, err := claimDueQueuedNudges(dir, "worker", time.Now())
+	claimed, err := claimDueWorkerNudges(dir)
 	if err != nil {
 		t.Fatalf("claimDueQueuedNudges: %v", err)
 	}


### PR DESCRIPTION
## Summary

A queued nudge targeting a session sitting idle at an empty prompt — the state where injection should be trivially safe — could stay pending forever, with the queue showing zero attempts and zero dead letters.

Observed in production (2026-06-06): a deacon-style named session took an API 500 mid-patrol and dropped to an empty prompt. A witness wake nudge queued at 18:58Z never injected; an operator `gc session nudge` at 19:21Z queued and never injected either. The queue held **79 pending items for that one agent spanning continuation epochs 190–458** (current epoch 463 — every wake bumps the epoch, so each restart strands every undelivered fenced nudge), all with **zero attempts**, **zero dead letters**, and `last_nudge_delivered_at` ~20 hours old. The shared `deliver_after` timestamp across 71 items matched a single in-flight lease-expiry recovery pass: something claimed the whole backlog every couple of minutes and died before recording any outcome.

## Root causes

Three defects compounded in the claim→outcome pipeline (`cmd/gc/cmd_nudge.go`):

1. **Claims stranded in-flight on abort paths.** `tryDeliverQueuedNudgesByPoller` exited after a successful claim without releasing the claim or recording an attempt on several paths — handle-resolution errors, delivery-validation errors, and most often `result.Delivered == false`, which `NudgeWakeLiveOnly` returns whenever the session stops between observation and delivery (constant under restart churn). Items waited out the 2-minute lease, recovered to pending, and were re-claimed by the next pass. Unbounded starvation, invisible to attempt accounting (so `defaultQueuedNudgeMaxAttempts` never engaged).

2. **Stale-item bookkeeping gated fresh-item delivery.** Dead-lettering fence-mismatched (stale-epoch) items was a fail-closed batch transaction: one bead-store error while terminalizing dozens of stale backlog items rolled back the whole transition and aborted the pass, so the fence-matching wake nudge behind it was never attempted. The terminal bead writes also ran inside the queue flock — two bd round-trips per stale item while holding the city-wide queue lock.

3. **Poller death = no delivery path at all.** The per-session poller exited permanently on the first transient observation error (stderr discarded), and the hook drain only fires when the agent submits a prompt — which an idle-at-prompt session never does. In legacy dispatcher mode that leaves nothing to deliver the queue.

## Fix

- Release claims on every abort path that exits after claiming without recording an outcome, so retries happen on the next poll tick instead of after lease expiry.
- Make fence-mismatch and blocked-item bookkeeping best-effort: failures are joined into the returned error for visibility but no longer block delivery of the remaining claimable items (the affected items stay in-flight and lease recovery retries them).
- Commit the dead-letter queue transition before marking backing beads terminal, move those bead writes outside the queue lock, and downgrade marking failures to warnings. Queue state is authoritative; `pruneDeadQueuedNudges` already repairs dead entries whose backing bead missed terminal state (#2166), so drift converges on later queue operations. This mirrors the existing best-effort precedent in `pruneExpiredQueuedNudges`.
- Keep the poller alive through transient observation errors while queued work is pending, reusing the existing missing-session grace window; persistent failures still exit once it elapses or the queue drains.
- `cmdNudgeDrainWithFormat` gets the same structural treatment (release on validation error, continue past blocked-item bookkeeping failure, reuse the delivery store).
- Drop the test-only `claimDueQueuedNudges` wrapper flagged by `unparam` once its line range entered the lint diff.

Fence semantics are unchanged: stale-epoch items still dead-letter rather than deliver to a newer session generation (per #2164); they just can no longer take fresh deliveries down with them.

## Relationship to existing work

- #2164 (merged) introduced the fencing and poller/live-session alignment this builds on.
- #2166 (merged) added the dead-entry bead repair pass this fix relies on for convergence.
- #2165 (open) dead-letters items fenced to closed/replaced session beads — complementary; this PR addresses the orphaned-claim and bookkeeping-gates-delivery defects for live sessions.

## Tests

All TDD red→green against the prior implementation:

- `TestTryDeliverQueuedNudgesByPollerReleasesClaimsWhenDeliveryDeclined` — session stops between observation and delivery; the claim must return to pending, not strand in-flight (red: `pending/inFlight/dead = 0/1/0`).
- `TestTryDeliverQueuedNudgesByPollerDeliversDespiteStaleFenceBeadMarkFailure` — a stale-epoch item whose terminal bead write fails must not block delivery of the fence-matching item; stale item dead-letters, warning surfaced.
- `TestRecordQueuedNudgeFailureDeadLettersWhenTerminalBeadMarkFails` — the dead-letter queue transition commits despite the bead write failing; repair is deferred to `pruneDeadQueuedNudges`.
- `TestCmdNudgePollSurvivesTransientObserveErrors` — a transient observe error with queued work pending no longer kills the poller (red: immediate exit 1).

`make fmt-check`, `make lint-changed` (0 issues), `go vet`, and the nudge test surface pass; full `./cmd/gc` suite run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
