### PR TITLE
fix(controller): keep rig bead-cache reconcilers alive so restart rediscovers pool demand

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/supervisor"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
 )
 
@@ -190,28 +191,41 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 	}
 	// Full prime runs async — backfills remaining beads for List()
 	// callers (convergence reconcile, sweep, API handlers).
-	go func() {
-		log.Printf("caching-store: priming ...")
-		if err := cs.Prime(ctx); err != nil {
-			log.Printf("caching-store: prime FAILED: %v (reads will use bd subprocess)", err)
-			return
-		}
-		if ctx.Err() != nil {
-			return
-		}
-		cs.StartReconciler(ctx, beads.WithStaggerAuto(), os.Getenv("GC_AGENT"))
-	}()
+	go primeThenStartReconciler(ctx, cs, os.Getenv("GC_AGENT"))
 	if policyWrapped {
 		return wrapStoreWithBeadPolicies(cs, policyStore.cfg)
 	}
 	return cs
 }
 
+// primeThenStartReconciler runs the async full prime and then arms the
+// watchdog reconciler. The reconciler starts even when the prime fails:
+// its periodic full scan loads the same snapshot a successful prime
+// would and promotes the cache to live, so a transient prime failure at
+// startup heals on the next reconcile cycle. Without this, one failed
+// prime left the store serving its PrimeActive-era snapshot for the
+// life of the controller — kept fresh only by event-bus writes — so
+// storage-level state created before a restart (e.g. routed pool work
+// feeding scale-check demand) stayed invisible until something else
+// touched the bead. Only shutdown (ctx canceled) skips the reconciler.
+func primeThenStartReconciler(ctx context.Context, cs *beads.CachingStore, agentID string) {
+	log.Printf("caching-store: priming ...")
+	if err := cs.Prime(ctx); err != nil {
+		log.Printf("caching-store: prime FAILED: %v (reads use bd subprocess until the reconciler converges)", err)
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	cs.StartReconciler(ctx, beads.WithStaggerAuto(), agentID)
+}
+
 // buildStores creates bead stores for each rig in cfg.
 // Mail providers are NOT built here — all mail uses the city-level store.
-// Pure function of cfg — does not read or write cs fields (safe to call unlocked).
+// Does not read or write mutable cs fields (safe to call unlocked); reads
+// the runtime suspension state file to gate per-rig cache refresh.
 func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store {
 	cityProvider := rawBeadsProviderForScope(cs.cityPath, cs.cityPath)
+	suspState := loadSuspensionStateBestEffort(cs.cityPath)
 	stores := make(map[string]beads.Store, len(cfg.Rigs))
 
 	var sharedLegacyFileStore beads.Store
@@ -245,9 +259,24 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 			continue
 		}
 		store = cs.openRigStore(scopeProvider, rig.Name, scopeRoot, rig.EffectivePrefix(), cfg)
-		stores[rig.Name] = wrapWithCachingStore(cs.cacheCtx, store, cs.eventProv, !rig.Suspended)
+		stores[rig.Name] = wrapWithCachingStore(cs.cacheCtx, store, cs.eventProv, rigStoreBackgroundRefresh(suspState, rig))
 	}
 	return stores
+}
+
+// rigStoreBackgroundRefresh reports whether the controller should run
+// the continuous cache refresh (async full prime + watchdog reconciler)
+// for a rig's bead store. Suspended rigs skip it: they spawn no agents,
+// so nothing writes locally and reconciling them every cycle is pure
+// cost (gastownhall/gascity #1978 follow-up). Suspension here is the
+// EFFECTIVE state — the runtime suspend/resume override layered over the
+// rig's committable suspended_on_start default — not the deprecated raw
+// [[rigs]] suspended field alone. Gating on the raw field misfires both
+// ways: a rig resumed at runtime keeps refreshing only by accident of
+// which config spelling it used, and a suspended_on_start rig never gets
+// the skip at all.
+func rigStoreBackgroundRefresh(suspState suspensionstate.State, rig config.Rig) bool {
+	return !suspensionstate.EffectiveRigSuspended(suspState, rig.Name, rig.EffectiveSuspendedOnStart())
 }
 
 // openRigStore creates a bead store for a rig path using the given provider.
@@ -687,11 +716,18 @@ func storeMetadataSignature(cityPath string, cfg *config.City) string {
 	if cfg == nil {
 		return b.String()
 	}
+	// The per-rig refresh gate is part of the signature: the captured
+	// signature is compared against a recomputed one on reload
+	// (runtimeUpdateCanReuseCurrentStores), so a runtime suspend/resume
+	// flip invalidates store reuse and the next reload rebuilds stores
+	// with the correct background-refresh gate.
+	suspState := loadSuspensionStateBestEffort(cityPath)
 	for _, rig := range cfg.Rigs {
 		if strings.TrimSpace(rig.Path) == "" {
 			continue
 		}
-		appendScopeMetadataSignature("rig:"+rig.Name, rig.Path)
+		label := fmt.Sprintf("rig:%s:refresh=%t", rig.Name, rigStoreBackgroundRefresh(suspState, rig))
+		appendScopeMetadataSignature(label, rig.Path)
 	}
 	return b.String()
 }

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -3389,3 +3389,118 @@ var _ interface {
 	SuspendRig(string) error
 	ResumeRig(string) error
 } = (*controllerState)(nil)
+
+// fullScanFailingStore fails full-scan List calls (the async full-prime
+// path) while letting status-filtered List calls (PrimeActive) through,
+// modeling a backing store whose full prime fails at controller startup.
+type fullScanFailingStore struct {
+	beads.Store
+}
+
+func (s *fullScanFailingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.AllowScan {
+		return nil, fmt.Errorf("full scan unavailable")
+	}
+	return s.Store.List(query)
+}
+
+// TestPrimeThenStartReconcilerArmsReconcilerOnPrimeFailure asserts the
+// watchdog reconciler is started even when the async full prime fails.
+// Before this contract, a single failed prime at controller startup
+// permanently disabled reconciliation for that store: the cache served
+// its PrimeActive-era snapshot for the life of the supervisor, kept
+// fresh only by event-bus writes, so storage-level state created before
+// the restart (e.g. routed pool work) stayed invisible indefinitely.
+func TestPrimeThenStartReconcilerArmsReconcilerOnPrimeFailure(t *testing.T) {
+	backing := &fullScanFailingStore{Store: beads.NewMemStore()}
+	cs := beads.NewCachingStore(backing, nil)
+	cs.SetPrimeRetryDelayForTest(func(int) time.Duration { return 0 })
+	if err := cs.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// "armed" is the FNV stagger for this agent ID; a non-zero value can
+	// only have been written by StartReconciler.
+	primeThenStartReconciler(ctx, cs, "armed")
+
+	if got := cs.Stats().StaggerOffsetMs; got <= 0 {
+		t.Fatalf("StaggerOffsetMs = %d, want > 0 (reconciler must arm after failed prime)", got)
+	}
+}
+
+// TestPrimeThenStartReconcilerSkipsReconcilerOnShutdown asserts a
+// canceled context (controller shutdown mid-prime) does NOT arm the
+// reconciler — prime failure is recoverable, shutdown is not.
+func TestPrimeThenStartReconcilerSkipsReconcilerOnShutdown(t *testing.T) {
+	backing := &fullScanFailingStore{Store: beads.NewMemStore()}
+	cs := beads.NewCachingStore(backing, nil)
+	cs.SetPrimeRetryDelayForTest(func(int) time.Duration { return 0 })
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	primeThenStartReconciler(ctx, cs, "armed")
+
+	if got := cs.Stats().StaggerOffsetMs; got != 0 {
+		t.Fatalf("StaggerOffsetMs = %d, want 0 (reconciler must not arm after shutdown)", got)
+	}
+}
+
+// TestRigStoreBackgroundRefreshUsesEffectiveSuspension asserts the
+// background-refresh gate consults the EFFECTIVE rig suspension — the
+// runtime suspend/resume override layered over the rig's committable
+// suspended_on_start default — not the deprecated raw [[rigs]] suspended
+// field. A rig resumed at runtime must keep its cache reconciler across
+// supervisor restarts, and a suspended_on_start rig must actually get
+// the suspended-rig reconcile skip.
+func TestRigStoreBackgroundRefreshUsesEffectiveSuspension(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+	cases := []struct {
+		name     string
+		rig      config.Rig
+		override *bool // runtime suspension override; nil = no entry
+		want     bool
+	}{
+		{name: "active rig refreshes", rig: config.Rig{Name: "r"}, want: true},
+		{name: "suspended_on_start skips refresh", rig: config.Rig{Name: "r", SuspendedOnStart: true}, want: false},
+		{name: "deprecated suspended field skips refresh", rig: config.Rig{Name: "r", Suspended: true}, want: false},
+		{name: "suspended_on_start with runtime resume refreshes", rig: config.Rig{Name: "r", SuspendedOnStart: true}, override: boolPtr(false), want: true},
+		{name: "deprecated suspended with runtime resume refreshes", rig: config.Rig{Name: "r", Suspended: true}, override: boolPtr(false), want: true},
+		{name: "active rig with runtime suspend skips refresh", rig: config.Rig{Name: "r"}, override: boolPtr(true), want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var st suspensionstate.State
+			if tc.override != nil {
+				suspensionstate.SetRig(&st, tc.rig.Name, tc.override)
+			}
+			if got := rigStoreBackgroundRefresh(st, tc.rig); got != tc.want {
+				t.Fatalf("rigStoreBackgroundRefresh = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStoreMetadataSignatureChangesOnRigSuspensionFlip asserts the store
+// signature reflects effective rig suspension, so a runtime
+// suspend/resume flip invalidates runtimeUpdateCanReuseCurrentStores and
+// the next config reload rebuilds stores with the correct
+// background-refresh gate.
+func TestStoreMetadataSignatureChangesOnRigSuspensionFlip(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+	cfg := &config.City{Rigs: []config.Rig{{Name: "rig1", Path: rigDir, SuspendedOnStart: true}}}
+
+	before := storeMetadataSignature(cityDir, cfg)
+
+	resumed := false
+	if err := suspensionstate.SetRigSuspended(fsys.OSFS{}, cityDir, "rig1", &resumed); err != nil {
+		t.Fatalf("SetRigSuspended: %v", err)
+	}
+
+	after := storeMetadataSignature(cityDir, cfg)
+	if before == after {
+		t.Fatalf("signature unchanged across rig suspension flip:\n%s", before)
+	}
+}

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -259,6 +259,13 @@ func NewCachingStoreForTestWithPrefix(backing Store, idPrefix string, onChange f
 	return newCachingStore(backing, idPrefix, onChange)
 }
 
+// SetPrimeRetryDelayForTest overrides the inter-attempt backoff Prime
+// uses when the backing store's full scan fails, so tests can exercise
+// prime-failure paths without real multi-second sleeps. Test-only.
+func (c *CachingStore) SetPrimeRetryDelayForTest(fn func(attempt int) time.Duration) {
+	c.primeRetryDelay = fn
+}
+
 func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
 		backing:     backing,

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -374,9 +374,7 @@ func (c *CachingStore) runReconciliation() {
 		c.syncFailures = 0
 		c.depsComplete = nextDepsComplete
 		c.primePartialErr = nil
-		if c.state == cacheDegraded {
-			c.state = cacheLive
-		}
+		c.promoteLiveLocked()
 		durMs := float64(time.Since(start).Microseconds()) / 1000.0
 		c.stats.LastReconcileAt = now
 		c.stats.LastReconcileMs = durMs
@@ -474,9 +472,7 @@ func (c *CachingStore) runReconciliation() {
 	c.deletedSeq = make(map[string]uint64)
 	c.syncFailures = 0
 	c.primePartialErr = nil
-	if c.state == cacheDegraded {
-		c.state = cacheLive
-	}
+	c.promoteLiveLocked()
 
 	durMs := float64(time.Since(start).Microseconds()) / 1000.0
 	c.stats.LastReconcileAt = now
@@ -494,6 +490,21 @@ func (c *CachingStore) runReconciliation() {
 		log.Print(logLine)
 	}
 	c.notifyChanges(notifications)
+}
+
+// promoteLiveLocked marks the cache live after a clean full-scan
+// reconciliation. A successful reconcile loads the same complete active
+// snapshot (identical ListQuery and dep fetch) a successful Prime would,
+// so it promotes unconditionally — not just degraded→live but also
+// partial/uninitialized→live. This makes the reconciler a convergence
+// path for stores whose initial full prime failed or never ran: without
+// it such a store serves its PrimeActive-era snapshot indefinitely while
+// only event-bus writes update it, and storage-level state created
+// before the controller started (e.g. routed pool work awaiting pickup)
+// stays invisible until something happens to touch the bead. Caller must
+// hold c.mu (write lock).
+func (c *CachingStore) promoteLiveLocked() {
+	c.state = cacheLive
 }
 
 // reconcileSuccessLogLocked composes the per-reconcile success log line

--- a/internal/beads/caching_store_reconcile_internal_test.go
+++ b/internal/beads/caching_store_reconcile_internal_test.go
@@ -3,9 +3,11 @@ package beads
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 type reconcileRaceStore struct {
@@ -461,5 +463,169 @@ func TestRunReconciliationLogEmitsAgainAfterWindow(t *testing.T) {
 	count := strings.Count(out, "beads cache: reconciled")
 	if count != 2 {
 		t.Errorf("expected 2 reconciled lines after window elapsed, got %d:\n%s", count, out)
+	}
+}
+
+// failingScanStore fails full-scan List calls (the Prime path) while
+// letting status-filtered List calls (the PrimeActive path) through, so
+// tests can model a store whose initial full prime fails.
+type failingScanStore struct {
+	Store
+
+	mu       sync.Mutex
+	failScan bool
+}
+
+func (s *failingScanStore) setFailScan(fail bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failScan = fail
+}
+
+func (s *failingScanStore) List(query ListQuery) ([]Bead, error) {
+	if query.AllowScan {
+		s.mu.Lock()
+		fail := s.failScan
+		s.mu.Unlock()
+		if fail {
+			return nil, errors.New("full scan unavailable")
+		}
+	}
+	return s.Store.List(query)
+}
+
+// TestRunReconciliationPromotesPartialCacheToLive asserts that a clean
+// full-scan reconciliation promotes a PrimeActive-only (cachePartial)
+// cache to live. A reconcile loads the same complete active snapshot a
+// successful Prime would, so a store whose initial full prime failed must
+// converge to live through reconciliation instead of serving its
+// PrimeActive-era snapshot indefinitely.
+func TestRunReconciliationPromotesPartialCacheToLive(t *testing.T) {
+	mem := NewMemStore()
+	primed, err := mem.Create(Bead{Title: "present at prime-active"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cs := NewCachingStoreForTest(mem, nil)
+	if err := cs.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	if cs.IsLive() {
+		t.Fatal("cache live after PrimeActive alone, want partial")
+	}
+
+	// A bead created behind the cache's back (no event delivered) models
+	// storage-level state the partial snapshot missed.
+	missed, err := mem.Create(Bead{Title: "missed by prime-active"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cs.runReconciliation()
+
+	if !cs.IsLive() {
+		t.Fatal("cache not live after clean reconcile, want promoted to live")
+	}
+	got, ok := cs.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady not servable after reconcile promotion")
+	}
+	ids := make(map[string]bool, len(got))
+	for _, b := range got {
+		ids[b.ID] = true
+	}
+	if !ids[primed.ID] || !ids[missed.ID] {
+		t.Fatalf("CachedReady = %v, want both %s and %s", ids, primed.ID, missed.ID)
+	}
+}
+
+// TestRunReconciliationPromotesUnprimedCacheToLive asserts reconciliation
+// also converges a cache whose PrimeActive never succeeded
+// (cacheUninitialized), mirroring Prime's unconditional promotion.
+func TestRunReconciliationPromotesUnprimedCacheToLive(t *testing.T) {
+	mem := NewMemStore()
+	bead, err := mem.Create(Bead{Title: "storage-level work"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cs := NewCachingStoreForTest(mem, nil)
+
+	cs.runReconciliation()
+
+	if !cs.IsLive() {
+		t.Fatal("cache not live after clean reconcile from uninitialized state")
+	}
+	got, ok := cs.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady not servable after reconcile promotion")
+	}
+	if len(got) != 1 || got[0].ID != bead.ID {
+		t.Fatalf("CachedReady = %#v, want only %s", got, bead.ID)
+	}
+}
+
+// TestRunReconciliationDoesNotPromoteOnFailure asserts a failed reconcile
+// leaves a partial cache partial — promotion requires a clean full scan.
+func TestRunReconciliationDoesNotPromoteOnFailure(t *testing.T) {
+	mem := NewMemStore()
+	if _, err := mem.Create(Bead{Title: "present at prime-active"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing := &failingScanStore{Store: mem}
+	cs := NewCachingStoreForTest(backing, nil)
+	if err := cs.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	backing.setFailScan(true)
+
+	cs.runReconciliation()
+
+	if cs.IsLive() {
+		t.Fatal("cache promoted to live by a FAILED reconcile")
+	}
+}
+
+// TestPrimeFailureThenReconcileConverges is the end-to-end shape of the
+// recovery path: PrimeActive succeeds, the full Prime fails, and a later
+// clean reconciliation converges the cache to storage and promotes it
+// live so cached readers stop falling back.
+func TestPrimeFailureThenReconcileConverges(t *testing.T) {
+	mem := NewMemStore()
+	if _, err := mem.Create(Bead{Title: "present at prime-active"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing := &failingScanStore{Store: mem, failScan: true}
+	cs := NewCachingStoreForTest(backing, nil)
+	cs.primeRetryDelay = func(int) time.Duration { return 0 }
+	if err := cs.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	if err := cs.Prime(context.Background()); err == nil {
+		t.Fatal("Prime succeeded against failing scan store, want error")
+	}
+
+	missed, err := mem.Create(Bead{Title: "created while prime was failing"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	backing.setFailScan(false)
+	cs.runReconciliation()
+
+	if !cs.IsLive() {
+		t.Fatal("cache not live after reconcile recovered from failed prime")
+	}
+	got, err := cs.cachedReadyOnly(ReadyQuery{TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("cachedReadyOnly: %v", err)
+	}
+	found := false
+	for _, b := range got {
+		if b.ID == missed.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("cachedReadyOnly = %#v, want to include %s", got, missed.ID)
 	}
 }


### PR DESCRIPTION
## Problem

Pool demand routed to a non-HQ rig **before** a supervisor restart can stay invisible **after** it. Live incident (2026-06-06): a work bead sat open + unassigned + `gc.routed_to=<rig>/<pool>` in a rig store for ~2 hours post-restart. The controller's own demand probe (`bd ready --metadata-field gc.routed_to=... --unassigned`) returned it when run by hand, but no `scaleCheck: <pool> = N` line was ever computed, so the pool never woke. Supervisor logs showed `beads cache: reconciled rig=...` lines for the **HQ store only** across the whole window (671 lines, one store). Re-running `gc sling` on the bead — i.e. any write event reaching the event bus — made demand appear immediately and a polecat picked the work up.

That recovery asymmetry is the tell: the rig store's cache was being kept fresh **only by live event-bus writes**, serving a startup-era snapshot with no reconciler running. Storage-level state that predates the restart is exactly what such a cache never rediscovers.

## Three defects compounded

1. **A failed async prime permanently disabled the watchdog reconciler.** `wrapWithCachingStore`'s goroutine returned on `Prime` error before `StartReconciler` — one transient failure at startup (e.g. Dolt under load while five stores prime concurrently) and that store ran cache-partial with no reconciliation for the life of the supervisor, silently.

2. **Reconciliation could not promote a cache to live.** `runReconciliation` only promoted `degraded→live`. A store whose full prime failed (or never ran) stayed `cachePartial` even after arbitrarily many clean reconciles, so `ensureFullPrime` kept lazy-priming on every cached read and the cache never settled. A clean reconcile loads the **same complete active snapshot** a successful `Prime` would (identical `ListQuery` + dep fetch), so it now promotes unconditionally (`promoteLiveLocked`), making the reconciler a true convergence path. Persistent reconcile failure still degrades the cache after `maxCacheSyncFailures`, which pushes cached readers to live fallbacks — the ladder is now *reconciled-fresh → live-fallback*, never *confident-stale*.

3. **The suspended-rig refresh gate (#3097) read the deprecated raw `[[rigs]] suspended` field.** Effective suspension is the runtime suspend/resume override layered over `suspended_on_start` (`suspensionstate.EffectiveRigSuspended`). Gating on the raw field misfires both ways:
   - a rig with `suspended = true` resumed at runtime got **no** cache refresh while actively running agents (this incident class);
   - a rig spelled `suspended_on_start = true` never got the perf skip the gate was added for.

   `buildStores` now gates via `rigStoreBackgroundRefresh` (effective suspension), and the store metadata signature embeds the per-rig gate so a runtime suspend/resume flip invalidates `runtimeUpdateCanReuseCurrentStores` and the next reload rebuilds stores with the correct gate.

Net effect: every rig store the controller holds either reconciles from storage on every cycle, or is *effectively* suspended on purpose — and a restart rediscovers storage-level demand instead of depending on someone re-slinging the work.

## Changes

- `internal/beads/caching_store_reconcile.go` — `promoteLiveLocked`: clean reconcile promotes partial/uninitialized/degraded caches to live (mirrors `prime()`'s unconditional promotion).
- `internal/beads/caching_store.go` — `SetPrimeRetryDelayForTest` (test seam for prime-failure paths, alongside the existing `*ForTest` constructors).
- `cmd/gc/api_state.go` — goroutine body extracted as `primeThenStartReconciler`: reconciler arms even when prime fails (only shutdown skips); `rigStoreBackgroundRefresh` effective-suspension gate; signature embeds the gate.

## Tests

- `TestRunReconciliationPromotesPartialCacheToLive`, `...PromotesUnprimedCacheToLive`, `...DoesNotPromoteOnFailure`, `TestPrimeFailureThenReconcileConverges` (internal/beads)
- `TestPrimeThenStartReconcilerArmsReconcilerOnPrimeFailure`, `...SkipsReconcilerOnShutdown` (cmd/gc)
- `TestRigStoreBackgroundRefreshUsesEffectiveSuspension` (six-case truth table), `TestStoreMetadataSignatureChangesOnRigSuspensionFlip` (cmd/gc)

## Verification

- `go test ./internal/beads/ -count=1` green
- `GC_FAST_UNIT=1 go test ./cmd/gc/ -count=1` green
- `make fmt-check` and `make lint-changed` clean
- `go vet ./cmd/gc/ ./internal/beads/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
