### PR TITLE
feat(gc): sweepStaleNudgeMail core function + tests (ga-9zqt5o.1)

### DIFF
--- a/cmd/gc/nudge_mail_sweep.go
+++ b/cmd/gc/nudge_mail_sweep.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/nudgequeue"
+)
+
+const (
+	// nudgeMailSweepNudgeCloseReason is the close_reason stamped on stale nudge
+	// beads before close. The 20-character floor satisfies validation.on-close=error.
+	nudgeMailSweepNudgeCloseReason = "nudge gc-swept: stale nudge bead past gc retention window"
+
+	// nudgeMailSweepMailCloseReason is the close_reason stamped on read mail
+	// beads before close.
+	nudgeMailSweepMailCloseReason = "mail gc-swept: read mail bead past gc retention window"
+)
+
+// nudgeMailSweepResult holds per-category close counts from sweepStaleNudgeMail.
+type nudgeMailSweepResult struct {
+	NudgeClosed int
+	MailClosed  int
+}
+
+// sweepStaleNudgeMail closes stale consumed nudge beads and read mail beads.
+//
+// Nudge candidates are open beads with label gc:nudge created before now-nudgeTTL
+// whose nudge_id is not present in nudgeState.Pending or nudgeState.InFlight.
+// Terminal metadata is recorded before each close so the bead audit trail is intact.
+//
+// Mail candidates are open message beads with label "read" created before now-mailTTL.
+//
+// limit caps total closes (nudge + mail combined). Pass 0 for no cap.
+// Per-bead errors do not abort the sweep; they are returned via errors.Join so
+// the caller can report them without treating the sweep as fatal.
+func sweepStaleNudgeMail(store beads.Store, nudgeState *nudgequeue.State, now time.Time, nudgeTTL, mailTTL time.Duration, limit int) (nudgeMailSweepResult, error) {
+	var result nudgeMailSweepResult
+	var beadErrs []error
+
+	liveIDs := liveNudgeIDSet(nudgeState)
+
+	// Phase 1: close stale nudge beads.
+	nudgeCutoff := now.Add(-nudgeTTL)
+	nudgeQueryLimit := limit
+	if nudgeQueryLimit < 0 {
+		nudgeQueryLimit = 0
+	}
+	nudgeCandidates, err := store.List(beads.ListQuery{
+		Label:         nudgeBeadLabel,
+		CreatedBefore: nudgeCutoff,
+		Limit:         nudgeQueryLimit,
+		Sort:          beads.SortCreatedAsc,
+	})
+	if err != nil {
+		return result, fmt.Errorf("nudge-mail-sweep: listing stale nudge beads: %w", err)
+	}
+
+	for _, b := range nudgeCandidates {
+		if limit > 0 && result.NudgeClosed+result.MailClosed >= limit {
+			break
+		}
+		if b.Status != "open" {
+			continue
+		}
+		nudgeID := strings.TrimSpace(b.Metadata["nudge_id"])
+		if nudgeID != "" && liveIDs[nudgeID] {
+			continue
+		}
+		if err := store.SetMetadataBatch(b.ID, map[string]string{
+			"state":           "gc-swept",
+			"terminal_reason": "gc-swept-stale",
+			"commit_boundary": "gc-swept",
+			"terminal_at":     now.UTC().Format(time.RFC3339),
+			"close_reason":    nudgeMailSweepNudgeCloseReason,
+		}); err != nil {
+			beadErrs = append(beadErrs, fmt.Errorf("nudge %s: set metadata: %w", b.ID, err))
+			continue
+		}
+		if err := store.Close(b.ID); err != nil {
+			beadErrs = append(beadErrs, fmt.Errorf("nudge %s: close: %w", b.ID, err))
+			continue
+		}
+		result.NudgeClosed++
+	}
+
+	// Phase 2: close read mail beads.
+	mailCutoff := now.Add(-mailTTL)
+	remaining := limit - result.NudgeClosed - result.MailClosed
+	if limit == 0 || remaining > 0 {
+		mailQueryLimit := remaining
+		if limit == 0 {
+			mailQueryLimit = 0
+		}
+		mailCandidates, err := store.List(beads.ListQuery{
+			Type:          "message",
+			Label:         "read",
+			CreatedBefore: mailCutoff,
+			Limit:         mailQueryLimit,
+			Sort:          beads.SortCreatedAsc,
+		})
+		if err != nil {
+			return result, fmt.Errorf("nudge-mail-sweep: listing read mail beads: %w", err)
+		}
+		for _, b := range mailCandidates {
+			if limit > 0 && result.NudgeClosed+result.MailClosed >= limit {
+				break
+			}
+			if b.Status != "open" {
+				continue
+			}
+			if err := store.SetMetadata(b.ID, "close_reason", nudgeMailSweepMailCloseReason); err != nil {
+				beadErrs = append(beadErrs, fmt.Errorf("mail %s: set close_reason: %w", b.ID, err))
+				continue
+			}
+			if err := store.Close(b.ID); err != nil {
+				beadErrs = append(beadErrs, fmt.Errorf("mail %s: close: %w", b.ID, err))
+				continue
+			}
+			result.MailClosed++
+		}
+	}
+
+	return result, errors.Join(beadErrs...)
+}
+
+// liveNudgeIDSet returns the set of nudge IDs currently in pending or in-flight state.
+// Returns nil (no live IDs) when nudgeState is nil.
+func liveNudgeIDSet(state *nudgequeue.State) map[string]bool {
+	if state == nil {
+		return nil
+	}
+	live := make(map[string]bool, len(state.Pending)+len(state.InFlight))
+	for _, item := range state.Pending {
+		live[item.ID] = true
+	}
+	for _, item := range state.InFlight {
+		live[item.ID] = true
+	}
+	return live
+}

--- a/cmd/gc/nudge_mail_sweep_test.go
+++ b/cmd/gc/nudge_mail_sweep_test.go
@@ -1,0 +1,446 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/nudgequeue"
+)
+
+// nudgeSeed builds a seed Bead for NewMemStoreFrom representing an open nudge bead.
+// id must be unique within the seed slice.
+func nudgeSeed(id, nudgeID string, createdAt time.Time) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Type:   nudgeBeadType,
+		Status: "open",
+		Labels: []string{nudgeBeadLabel, "nudge:" + nudgeID},
+		Metadata: map[string]string{
+			"nudge_id": nudgeID,
+			"state":    "queued",
+		},
+		CreatedAt: createdAt,
+	}
+}
+
+// mailSeed builds a seed Bead for NewMemStoreFrom representing an open read mail bead.
+// id must be unique within the seed slice.
+func mailSeed(id string, createdAt time.Time) beads.Bead {
+	return beads.Bead{
+		ID:        id,
+		Type:      "message",
+		Status:    "open",
+		Labels:    []string{"read"},
+		CreatedAt: createdAt,
+	}
+}
+
+func TestSweepStaleNudgeMail_TTLBoundaries(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+	mailTTL := 30 * time.Minute // intentionally different from the default 60min
+
+	// Nudge beads: one just past TTL (should sweep), one not yet past (should skip).
+	// Mail beads: one just past TTL (should sweep), one not yet past (should skip).
+	seed := []beads.Bead{
+		nudgeSeed("nudge-old", "nudge-old", now.Add(-nudgeTTL-time.Second)),
+		nudgeSeed("nudge-fresh", "nudge-fresh", now.Add(-nudgeTTL+time.Second)),
+		mailSeed("mail-old", now.Add(-mailTTL-time.Second)),
+		mailSeed("mail-fresh", now.Add(-mailTTL+time.Second)),
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepStaleNudgeMail(store, nil, now, nudgeTTL, mailTTL, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeClosed != 1 {
+		t.Errorf("NudgeClosed = %d, want 1", result.NudgeClosed)
+	}
+	if result.MailClosed != 1 {
+		t.Errorf("MailClosed = %d, want 1", result.MailClosed)
+	}
+}
+
+func TestSweepStaleNudgeMail_PendingExclusion(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+
+	const pendingID = "nudge-pending"
+	const safeID = "nudge-safe"
+	seed := []beads.Bead{
+		nudgeSeed("bead-pending", pendingID, now.Add(-nudgeTTL-time.Second)),
+		nudgeSeed("bead-safe", safeID, now.Add(-nudgeTTL-time.Second)),
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	// pendingID is in the queue's Pending list — must NOT be swept.
+	state := &nudgequeue.State{
+		Pending: []nudgequeue.Item{{ID: pendingID}},
+	}
+
+	result, err := sweepStaleNudgeMail(store, state, now, nudgeTTL, time.Hour, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeClosed != 1 {
+		t.Errorf("NudgeClosed = %d, want 1 (only the non-pending nudge)", result.NudgeClosed)
+	}
+
+	// Confirm pendingID's bead is still open.
+	open, _ := store.ListOpen()
+	for _, b := range open {
+		if b.Metadata["nudge_id"] == pendingID {
+			return // still open — correct
+		}
+	}
+	t.Errorf("pending nudge bead should remain open but was swept")
+}
+
+func TestSweepStaleNudgeMail_InFlightExclusion(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+
+	const inFlightID = "nudge-inflight"
+	seed := []beads.Bead{
+		nudgeSeed("bead-inflight", inFlightID, now.Add(-nudgeTTL-time.Second)),
+		nudgeSeed("bead-safe", "nudge-safe", now.Add(-nudgeTTL-time.Second)),
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	// inFlightID is in InFlight — must NOT be swept.
+	state := &nudgequeue.State{
+		InFlight: []nudgequeue.Item{{ID: inFlightID}},
+	}
+
+	result, err := sweepStaleNudgeMail(store, state, now, nudgeTTL, time.Hour, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeClosed != 1 {
+		t.Errorf("NudgeClosed = %d, want 1 (only the non-in-flight nudge)", result.NudgeClosed)
+	}
+
+	// Confirm in-flight bead is still open.
+	open, _ := store.ListOpen()
+	for _, b := range open {
+		if b.Metadata["nudge_id"] == inFlightID {
+			return // still open — correct
+		}
+	}
+	t.Errorf("in-flight nudge bead was swept; it should be skipped")
+}
+
+func TestSweepStaleNudgeMail_OpenStatusFilter(t *testing.T) {
+	// AC2: already-closed mail beads do not produce a false failure.
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	mailTTL := 60 * time.Minute
+
+	seed := []beads.Bead{
+		// Pre-closed mail bead (already archived) — should not appear in the query.
+		{
+			ID:        "mail-pre-closed",
+			Type:      "message",
+			Status:    "closed",
+			Labels:    []string{"read"},
+			CreatedAt: now.Add(-mailTTL - time.Second),
+		},
+		// Open mail bead — should be swept.
+		mailSeed("mail-open", now.Add(-mailTTL-time.Second)),
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepStaleNudgeMail(store, nil, now, time.Minute, mailTTL, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.MailClosed != 1 {
+		t.Errorf("MailClosed = %d, want 1 (only the open mail bead)", result.MailClosed)
+	}
+}
+
+func TestSweepStaleNudgeMail_BudgetCap(t *testing.T) {
+	// AC3: budget cap of N stops closes after N total (nudge + mail combined).
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+	mailTTL := 60 * time.Minute
+	const budget = 3
+
+	// Create 2 stale nudge beads and 3 stale mail beads (total 5 candidates).
+	seed := make([]beads.Bead, 0, 5)
+	for i := 0; i < 2; i++ {
+		seed = append(seed, nudgeSeed(fmt.Sprintf("nudge-%d", i), fmt.Sprintf("nudge-%d", i), now.Add(-nudgeTTL-time.Second)))
+	}
+	for i := 0; i < 3; i++ {
+		seed = append(seed, mailSeed(fmt.Sprintf("mail-%d", i), now.Add(-mailTTL-time.Second)))
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepStaleNudgeMail(store, nil, now, nudgeTTL, mailTTL, budget)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	total := result.NudgeClosed + result.MailClosed
+	if total != budget {
+		t.Errorf("total closed = %d, want %d (budget cap)", total, budget)
+	}
+}
+
+func TestSweepStaleNudgeMail_BudgetZeroMeansUnlimited(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+	mailTTL := 60 * time.Minute
+
+	seed := make([]beads.Bead, 0, 20)
+	for i := 0; i < 10; i++ {
+		seed = append(seed, nudgeSeed(fmt.Sprintf("nudge-%d", i), fmt.Sprintf("nudge-%d", i), now.Add(-nudgeTTL-time.Second)))
+	}
+	for i := 0; i < 10; i++ {
+		seed = append(seed, mailSeed(fmt.Sprintf("mail-%d", i), now.Add(-mailTTL-time.Second)))
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepStaleNudgeMail(store, nil, now, nudgeTTL, mailTTL, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeClosed != 10 {
+		t.Errorf("NudgeClosed = %d, want 10", result.NudgeClosed)
+	}
+	if result.MailClosed != 10 {
+		t.Errorf("MailClosed = %d, want 10", result.MailClosed)
+	}
+}
+
+// nudgeSweepFailingClose wraps MemStore and forces Close to fail for specific bead IDs.
+type nudgeSweepFailingClose struct {
+	*beads.MemStore
+	failIDs map[string]bool
+}
+
+func (s *nudgeSweepFailingClose) Close(id string) error {
+	if s.failIDs[id] {
+		return fmt.Errorf("store returned ErrConflict for %s", id)
+	}
+	return s.MemStore.Close(id)
+}
+
+func TestSweepStaleNudgeMail_PerBeadCloseFailureContinues(t *testing.T) {
+	// AC4: individual close conflicts are reported and do not abort remaining candidates.
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+
+	// Three stale nudge beads; the middle one will fail to close.
+	const id1, id2 = "bead-1", "bead-2"
+	seed := []beads.Bead{
+		nudgeSeed(id1, "nudge-1", now.Add(-nudgeTTL-time.Second)),
+		nudgeSeed(id2, "nudge-2", now.Add(-nudgeTTL-time.Second)),
+		nudgeSeed("bead-3", "nudge-3", now.Add(-nudgeTTL-time.Second)),
+	}
+	mem := beads.NewMemStoreFrom(100, seed, nil)
+	store := &nudgeSweepFailingClose{
+		MemStore: mem,
+		failIDs:  map[string]bool{id2: true},
+	}
+
+	result, err := sweepStaleNudgeMail(store, nil, now, nudgeTTL, time.Hour, 0)
+
+	// The sweep should report the error for the failing bead.
+	if err == nil {
+		t.Fatal("expected non-nil error for close failure")
+	}
+	if !strings.Contains(err.Error(), id2) {
+		t.Errorf("error should mention failed bead ID %s, got: %v", id2, err)
+	}
+
+	// The sweep should still close the beads that did not fail.
+	if result.NudgeClosed != 2 {
+		t.Errorf("NudgeClosed = %d, want 2 (sweep continued past failure)", result.NudgeClosed)
+	}
+
+	// id1 and bead-3 should be closed; id2 should remain open.
+	open, _ := mem.ListOpen()
+	openIDs := make(map[string]bool)
+	for _, b := range open {
+		openIDs[b.ID] = true
+	}
+	if !openIDs[id2] {
+		t.Errorf("bead %s (close failed) should still be open", id2)
+	}
+	if openIDs[id1] {
+		t.Errorf("bead %s should be closed after successful sweep", id1)
+	}
+}
+
+// nudgeSweepFailingMeta wraps MemStore and forces SetMetadataBatch to fail for specific IDs.
+type nudgeSweepFailingMeta struct {
+	*beads.MemStore
+	failIDs map[string]bool
+}
+
+func (s *nudgeSweepFailingMeta) SetMetadataBatch(id string, kvs map[string]string) error {
+	if s.failIDs[id] {
+		return fmt.Errorf("metadata conflict for %s", id)
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
+func TestSweepStaleNudgeMail_PerBeadMetadataFailureContinues(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+
+	const id2 = "bead-2"
+	seed := []beads.Bead{
+		nudgeSeed("bead-1", "nudge-1", now.Add(-nudgeTTL-time.Second)),
+		nudgeSeed(id2, "nudge-2", now.Add(-nudgeTTL-time.Second)),
+		nudgeSeed("bead-3", "nudge-3", now.Add(-nudgeTTL-time.Second)),
+	}
+	mem := beads.NewMemStoreFrom(100, seed, nil)
+	store := &nudgeSweepFailingMeta{
+		MemStore: mem,
+		failIDs:  map[string]bool{id2: true},
+	}
+
+	result, err := sweepStaleNudgeMail(store, nil, now, nudgeTTL, time.Hour, 0)
+	if err == nil {
+		t.Fatal("expected non-nil error for metadata failure")
+	}
+	if !strings.Contains(err.Error(), id2) {
+		t.Errorf("error should mention failed bead ID %s, got: %v", id2, err)
+	}
+	if result.NudgeClosed != 2 {
+		t.Errorf("NudgeClosed = %d, want 2 (sweep continued past metadata failure)", result.NudgeClosed)
+	}
+}
+
+func TestSweepStaleNudgeMail_NudgeTerminalMetadata(t *testing.T) {
+	// AC4: nudge candidates record terminal metadata before close.
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+
+	const beadID = "nudge-abc"
+	seed := []beads.Bead{nudgeSeed(beadID, "nudge-abc", now.Add(-nudgeTTL-time.Second))}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepStaleNudgeMail(store, nil, now, nudgeTTL, time.Hour, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeClosed != 1 {
+		t.Fatalf("NudgeClosed = %d, want 1", result.NudgeClosed)
+	}
+
+	// Retrieve closed bead and check terminal metadata.
+	b, err := store.Get(beadID)
+	if err != nil {
+		t.Fatalf("get bead: %v", err)
+	}
+	if b.Metadata["state"] != "gc-swept" {
+		t.Errorf("state = %q, want %q", b.Metadata["state"], "gc-swept")
+	}
+	if b.Metadata["terminal_reason"] != "gc-swept-stale" {
+		t.Errorf("terminal_reason = %q, want %q", b.Metadata["terminal_reason"], "gc-swept-stale")
+	}
+	if b.Metadata["terminal_at"] == "" {
+		t.Error("terminal_at should be set")
+	}
+	if b.Metadata["close_reason"] != nudgeMailSweepNudgeCloseReason {
+		t.Errorf("close_reason = %q, want %q", b.Metadata["close_reason"], nudgeMailSweepNudgeCloseReason)
+	}
+	if b.Status != "closed" {
+		t.Errorf("status = %q, want closed", b.Status)
+	}
+}
+
+func TestSweepStaleNudgeMail_NilNudgeStateTreatsAllAsSafe(t *testing.T) {
+	// When nudgeState is nil, all stale nudge beads should be swept (no live ID set).
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+
+	seed := make([]beads.Bead, 3)
+	for i := range seed {
+		seed[i] = nudgeSeed(fmt.Sprintf("nudge-%d", i), fmt.Sprintf("nudge-%d", i), now.Add(-nudgeTTL-time.Second))
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepStaleNudgeMail(store, nil, now, nudgeTTL, time.Hour, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeClosed != 3 {
+		t.Errorf("NudgeClosed = %d, want 3", result.NudgeClosed)
+	}
+}
+
+func TestSweepStaleNudgeMail_BudgetSplitNudgeThenMail(t *testing.T) {
+	// Budget should be applied across nudge + mail phases combined.
+	// With budget=3 and 2 nudge + 5 mail: expect 2 nudge + 1 mail = 3 total.
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+	mailTTL := 60 * time.Minute
+
+	seed := make([]beads.Bead, 0, 7)
+	for i := 0; i < 2; i++ {
+		seed = append(seed, nudgeSeed(fmt.Sprintf("nudge-%d", i), fmt.Sprintf("nudge-%d", i), now.Add(-nudgeTTL-time.Second)))
+	}
+	for i := 0; i < 5; i++ {
+		seed = append(seed, mailSeed(fmt.Sprintf("mail-%d", i), now.Add(-mailTTL-time.Second)))
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepStaleNudgeMail(store, nil, now, nudgeTTL, mailTTL, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeClosed != 2 {
+		t.Errorf("NudgeClosed = %d, want 2", result.NudgeClosed)
+	}
+	if result.MailClosed != 1 {
+		t.Errorf("MailClosed = %d, want 1", result.MailClosed)
+	}
+}
+
+func TestSweepStaleNudgeMail_MultiplePerBeadErrors(t *testing.T) {
+	// Multiple per-bead errors should all be joined and returned.
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	nudgeTTL := 10 * time.Minute
+
+	const id1, id2 = "bead-1", "bead-2"
+	seed := []beads.Bead{
+		nudgeSeed(id1, "nudge-1", now.Add(-nudgeTTL-time.Second)),
+		nudgeSeed(id2, "nudge-2", now.Add(-nudgeTTL-time.Second)),
+	}
+	mem := beads.NewMemStoreFrom(100, seed, nil)
+	store := &nudgeSweepFailingClose{
+		MemStore: mem,
+		failIDs:  map[string]bool{id1: true, id2: true},
+	}
+
+	result, err := sweepStaleNudgeMail(store, nil, now, nudgeTTL, time.Hour, 0)
+	if err == nil {
+		t.Fatal("expected non-nil error when all beads fail")
+	}
+	// Both IDs should appear in the error.
+	errText := err.Error()
+	if !strings.Contains(errText, id1) {
+		t.Errorf("error should mention %s, got: %v", id1, err)
+	}
+	if !strings.Contains(errText, id2) {
+		t.Errorf("error should mention %s, got: %v", id2, err)
+	}
+	if result.NudgeClosed != 0 {
+		t.Errorf("NudgeClosed = %d, want 0 (all failed)", result.NudgeClosed)
+	}
+
+	// Verify errors.Join gives us individual unwrappable errors.
+	var errs []error
+	if unwrap, ok := err.(interface{ Unwrap() []error }); ok {
+		errs = unwrap.Unwrap()
+	}
+	if len(errs) < 2 {
+		t.Errorf("expected at least 2 joined errors, got %d", len(errs))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `sweepStaleNudgeMail` in `cmd/gc/nudge_mail_sweep.go`: two-phase sweep that closes stale consumed nudge beads (label `gc:nudge`, past TTL, not pending/in-flight in the nudge queue) and read mail beads (type `message`, label `read`, past TTL)
- Nudge beads get terminal metadata (`state`, `terminal_reason`, `terminal_at`, `commit_boundary`, `close_reason`) stamped before close for audit trail
- Budget cap (limit param) applies across both phases combined; `limit=0` means unlimited
- Per-bead errors accumulate via `errors.Join` — one bead failure does not abort the sweep
- Companion `nudge_mail_sweep_test.go` with 12 tests covering all acceptance criteria; uses `beads.NewMemStoreFrom` seed pattern for deterministic time control

## Test plan

- [x] `go test ./cmd/gc/... -run TestSweepStaleNudgeMail` — all 12 pass
- [x] `make test-fast-parallel` — all fast jobs pass
- [x] `go vet ./...` — clean
- [x] Pre-commit hook (`lint-changed`, vet, fast parallel) — 0 issues

Closes ga-9zqt5o.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)