### PR TITLE
fix(order-dispatch): close per-tick stores after in-flight goroutines drain (gascity#3157)

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -409,12 +409,25 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 	}
 
 	stores := make(map[string]beads.Store)
+	// inFlight counts the dispatchOne goroutines launched by THIS tick that
+	// still hold handles from `stores`. The per-tick handles must not be closed
+	// until those goroutines finish using them: on a native store, CloseStore is
+	// a one-way latch (internal/beads/native_dolt_store.go) and the goroutine's
+	// post-tick tracking-bead writes would hit a closed handle (gascity#3157).
+	// drain() only waits at controller exit/reload, not at end of tick, so the
+	// close is handed to a detached closer scoped to this tick's launches. The
+	// closer never blocks the tick; when nothing was launched it closes
+	// immediately (Wait returns at once on a zero count).
+	var inFlight sync.WaitGroup
 	defer func() {
-		for _, st := range stores {
-			if err := closeBeadStoreHandle(st); err != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: closing store: %v", err)
+		go func() {
+			inFlight.Wait()
+			for _, st := range stores {
+				if err := closeBeadStoreHandle(st); err != nil {
+					logDispatchError(m.stderr, "gc: order dispatch: closing store: %v", err)
+				}
 			}
-		}
+		}()
 	}()
 	trackingIndex := newOrderDispatchTrackingIndex()
 	budgetSpent := 0
@@ -595,7 +608,8 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		// drain can wait for tracking-bead outcome persistence before
 		// controller exit or config reload.
 		m.addInflight()
-		m.launchDispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
+		inFlight.Add(1)
+		m.launchDispatchOne(ctx, store, target, a, cityPath, trackingBead.ID, inFlight.Done)
 		if spendDispatchBudget(idx) {
 			return
 		}
@@ -606,15 +620,28 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 // EITHER the caller's tick ctx OR m.dispatchCtx is done — required so
 // cancel() reaches goroutines whose tick ctx was context.Background().
 // Falls back to the bare caller ctx when m.dispatchCtx is nil (test
-// sites that don't initialize the cancel fields).
-func (m *memoryOrderDispatcher) launchDispatchOne(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string) {
+// sites that don't initialize the cancel fields). onDone is invoked exactly
+// once after dispatchOne returns — i.e. after this goroutine's final store
+// call — so the caller can hold per-tick store handles open until the
+// goroutine releases them (gascity#3157). A nil onDone is treated as a no-op.
+func (m *memoryOrderDispatcher) launchDispatchOne(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string, onDone func()) {
+	if onDone == nil {
+		onDone = func() {}
+	}
 	if m.dispatchCtx == nil {
-		go m.dispatchOne(ctx, store, target, a, cityPath, trackingID)
+		go func() {
+			defer onDone()
+			m.dispatchOne(ctx, store, target, a, cityPath, trackingID)
+		}()
 		return
 	}
 	mergedCtx, cancelMerged := context.WithCancel(ctx)
 	stopAfter := context.AfterFunc(m.dispatchCtx, cancelMerged)
 	go func() {
+		// onDone runs last (registered first → LIFO), after dispatchOne has
+		// returned, so the per-tick store-close barrier only fires once this
+		// goroutine has made its final store call (gascity#3157).
+		defer onDone()
 		defer stopAfter()
 		defer cancelMerged()
 		m.dispatchOne(mergedCtx, store, target, a, cityPath, trackingID)

--- a/cmd/gc/order_dispatch_close_race_test.go
+++ b/cmd/gc/order_dispatch_close_race_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// latchedCloseStore models the one-way close latch of a native bead store
+// (internal/beads/native_dolt_store.go: once CloseStore nils the storage
+// handle, acquireStorage returns ErrStoreClosed forever — there is no reopen).
+// It records the first data operation attempted AFTER CloseStore ran, which is
+// exactly the use-after-close gascity#3157 reports. beads.MemStore hides the
+// bug because its handle has no CloseStore method, so closeBeadStoreHandle is a
+// no-op for MemStore-backed tests; this double makes the latch observable.
+type latchedCloseStore struct {
+	beads.Store
+
+	mu              sync.Mutex
+	closed          bool
+	useAfterCloseOp string
+	closedCh        chan struct{}
+	closeErr        error // mirrors NativeDoltStore.CloseStore returning storage.Close()'s error
+}
+
+func newLatchedCloseStore() *latchedCloseStore {
+	return &latchedCloseStore{Store: beads.NewMemStore(), closedCh: make(chan struct{})}
+}
+
+// guard records the first post-close operation and mimics the native store's
+// ErrStoreClosed once the handle has been closed.
+func (s *latchedCloseStore) guard(op string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		if s.useAfterCloseOp == "" {
+			s.useAfterCloseOp = op
+		}
+		return fmt.Errorf("native Dolt store: %w", beads.ErrStoreClosed)
+	}
+	return nil
+}
+
+func (s *latchedCloseStore) usedAfterClose() (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.useAfterCloseOp, s.useAfterCloseOp != ""
+}
+
+func (s *latchedCloseStore) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// CloseStore latches the store closed exactly like NativeDoltStore.CloseStore.
+func (s *latchedCloseStore) CloseStore() error {
+	s.mu.Lock()
+	already := s.closed
+	s.closed = true
+	s.mu.Unlock()
+	if !already {
+		close(s.closedCh)
+	}
+	return s.closeErr
+}
+
+func (s *latchedCloseStore) Create(b beads.Bead) (beads.Bead, error) {
+	if err := s.guard("Create"); err != nil {
+		return beads.Bead{}, err
+	}
+	return s.Store.Create(b)
+}
+
+func (s *latchedCloseStore) Get(id string) (beads.Bead, error) {
+	if err := s.guard("Get"); err != nil {
+		return beads.Bead{}, err
+	}
+	return s.Store.Get(id)
+}
+
+func (s *latchedCloseStore) Update(id string, opts beads.UpdateOpts) error {
+	if err := s.guard("Update"); err != nil {
+		return err
+	}
+	return s.Store.Update(id, opts)
+}
+
+func (s *latchedCloseStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	if err := s.guard("CloseAll"); err != nil {
+		return 0, err
+	}
+	return s.Store.CloseAll(ids, metadata)
+}
+
+func (s *latchedCloseStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if err := s.guard("List"); err != nil {
+		return nil, err
+	}
+	return s.Store.List(query)
+}
+
+// TestOrderDispatchDoesNotCloseStoreWhileDispatchInFlight reproduces
+// gascity#3157: memoryOrderDispatcher.dispatch opens per-tick bead stores and
+// closes them in a defer when the tick returns (order_dispatch.go:412-418), but
+// the async dispatchOne goroutine launched that same tick (:597-598) still holds
+// the handle. On a native store (one-way close latch) the goroutine's post-tick
+// writes — Update at :1127 and the deferred CloseAll at :933 — hit the closed
+// handle and fail with "native Dolt store: bead store closed".
+//
+// The test is deterministic: execRun parks the in-flight goroutine until the
+// test releases it AFTER dispatch() has returned. For a cooldown exec order,
+// dispatchExec performs no store operation before execRun, so the goroutine's
+// first store touch is forced to occur after the per-tick defer has run.
+func TestOrderDispatchDoesNotCloseStoreWhileDispatchInFlight(t *testing.T) {
+	store := newLatchedCloseStore()
+
+	released := make(chan struct{})
+	blockingExec := func(context.Context, string, string, []string) ([]byte, error) {
+		<-released
+		return []byte("ok"), nil
+	}
+
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name:     "race-exec",
+		Trigger:  "cooldown",
+		Interval: "5m",
+		Exec:     "true",
+	}}, store, nil, blockingExec, events.Discard)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	mad := ad.(*memoryOrderDispatcher)
+
+	mad.dispatch(context.Background(), t.TempDir(), time.Now())
+	// dispatch() has returned. With the bug, its defer already closed the store
+	// handle the in-flight goroutine still holds. Release the goroutine so it
+	// performs its tracking-bead writes against that handle.
+	close(released)
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if !mad.drain(drainCtx) {
+		t.Fatal("drain timed out waiting for in-flight dispatchOne to finish")
+	}
+
+	if op, used := store.usedAfterClose(); used {
+		t.Fatalf("dispatchOne issued %s on the order store after the per-tick defer closed it (gascity#3157 use-after-close race)", op)
+	}
+
+	// The fix must still close the per-tick store once the in-flight goroutine
+	// finishes — deferring the close must not silently turn into a handle leak.
+	deadline := time.Now().Add(2 * time.Second)
+	for !store.isClosed() {
+		if time.Now().After(deadline) {
+			t.Fatal("per-tick store was never closed after dispatch drained (handle leak)")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -8211,18 +8211,35 @@ func TestOrderDispatchSingleFlightLockFailsClosedOnPartialTierError(t *testing.T
 //
 // dispatch() must close every store handle it opens each pass via
 // closeBeadStoreHandle, which type-asserts for interface{ CloseStore() error }.
+// The close is deferred to a detached closer goroutine that runs once the
+// in-flight dispatchOne goroutines launched that tick have released the handles
+// (gascity#3157) — closing inline would race those goroutines on a native
+// store's one-way close latch. These tests therefore drain and then poll for
+// the close rather than asserting it synchronously at dispatch() return.
 
-// dispatchCloseStoreSpy wraps MemStore and counts CloseStore() calls. The
-// method is invoked by dispatch()'s deferred cleanup; not called concurrently.
+// dispatchCloseStoreSpy wraps MemStore and counts CloseStore() calls. CloseStore
+// runs on dispatch()'s detached closer goroutine, so access to the counter is
+// serialized through closeCount.
 type dispatchCloseStoreSpy struct {
 	*beads.MemStore
+	mu       sync.Mutex
 	closed   int
 	closeErr error
 }
 
 func (s *dispatchCloseStoreSpy) CloseStore() error {
+	s.mu.Lock()
 	s.closed++
+	s.mu.Unlock()
 	return s.closeErr
+}
+
+// closeCount returns how many times CloseStore has been called, synchronized
+// against the detached closer goroutine.
+func (s *dispatchCloseStoreSpy) closeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
 }
 
 // newDispatchCloseStoreSpyFn returns an orderStoreFunc that appends a fresh
@@ -8232,6 +8249,38 @@ func newDispatchCloseStoreSpyFn(spies *[]*dispatchCloseStoreSpy) orderStoreFunc 
 		spy := &dispatchCloseStoreSpy{MemStore: beads.NewMemStore()}
 		*spies = append(*spies, spy)
 		return spy, nil
+	}
+}
+
+// waitForDispatchCloseCounts drains the in-flight dispatchOne goroutines, then
+// waits for dispatch()'s detached closer to close every spied handle exactly
+// `want` times. The close lands shortly after drain() returns (gascity#3157),
+// so this polls with a deadline rather than asserting synchronously.
+func waitForDispatchCloseCounts(t *testing.T, m *memoryOrderDispatcher, spies []*dispatchCloseStoreSpy, want int) {
+	t.Helper()
+	drainCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if !m.drain(drainCtx) {
+		t.Fatal("drain timed out waiting for in-flight dispatchOne to finish")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		reached := true
+		for _, spy := range spies {
+			if spy.closeCount() < want {
+				reached = false
+				break
+			}
+		}
+		if reached || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	for i, spy := range spies {
+		if got := spy.closeCount(); got != want {
+			t.Errorf("store[%d]: CloseStore() called %d times, want %d", i, got, want)
+		}
 	}
 }
 
@@ -8256,12 +8305,7 @@ func TestDispatchClosesEveryOpenedStoreHandle(t *testing.T) {
 	if len(spies) == 0 {
 		t.Fatal("storeFn never called: expected at least one store to be opened")
 	}
-	for i, spy := range spies {
-		if spy.closed != 1 {
-			t.Errorf("store[%d]: CloseStore() called %d times, want 1", i, spy.closed)
-		}
-	}
-	time.Sleep(50 * time.Millisecond) // let dispatchOne goroutines finish
+	waitForDispatchCloseCounts(t, m, spies, 1)
 }
 
 func TestDispatchClosesRigAndLegacyCityStoreHandles(t *testing.T) {
@@ -8291,12 +8335,7 @@ func TestDispatchClosesRigAndLegacyCityStoreHandles(t *testing.T) {
 	if len(spies) != 2 {
 		t.Fatalf("storeFn called %d times, want 2 (rig + legacy city fallback)", len(spies))
 	}
-	for i, spy := range spies {
-		if spy.closed != 1 {
-			t.Errorf("store[%d]: CloseStore() called %d times, want 1", i, spy.closed)
-		}
-	}
-	time.Sleep(50 * time.Millisecond)
+	waitForDispatchCloseCounts(t, m, spies, 1)
 }
 
 func TestDispatchDeduplicatesStoreHandlesAcrossOrders(t *testing.T) {
@@ -8318,10 +8357,7 @@ func TestDispatchDeduplicatesStoreHandlesAcrossOrders(t *testing.T) {
 	if len(spies) != 1 {
 		t.Fatalf("storeFn called %d times, want 1 (same target deduped across orders)", len(spies))
 	}
-	if spies[0].closed != 1 {
-		t.Errorf("CloseStore() called %d times, want 1", spies[0].closed)
-	}
-	time.Sleep(50 * time.Millisecond)
+	waitForDispatchCloseCounts(t, m, spies, 1)
 }
 
 func TestDispatchClosesNoStoresWhenCitySuspended(t *testing.T) {


### PR DESCRIPTION
## Problem

`memoryOrderDispatcher.dispatch` (`cmd/gc/order_dispatch.go`) opens a fresh
`beads.Store` per scope each tick and closes **every** handle in a `defer` when
the tick returns — but the async `dispatchOne` goroutines launched that same
tick still hold those handles. On a **native store** (one-way close latch in
`internal/beads/native_dolt_store.go`: once `CloseStore` nils `storage`,
`acquireStorage` returns `ErrStoreClosed` forever), the goroutine's post-tick
tracking-bead writes hit the closed handle:

```
gc: order <name>: failed to label exec tracking bead <wisp>: native Dolt store: bead store closed
gc: order <name>: closing tracking bead <wisp>: closing order-tracking beads <wisp>: native Dolt store: bead store closed
```

Net effect on a native-Dolt city: error spam, orphaned `order-tracking` beads,
and scheduled orders going stale. `MemStore`/`bd`/`file` backends were
unaffected because their handle has no `CloseStore`, so `closeBeadStoreHandle`
is a no-op — which is why the regression (introduced by #2988, plugging a
per-tick handle leak by closing each tick) went unnoticed.

Reported in gastownhall/gascity#3157 (thanks @mmlac for the precise root-cause
writeup).

### Exact race

1. `dispatch` builds `stores` and defers closing all handles (`:411-418`).
2. A due order creates its tracking bead synchronously (`:583`), then
   `addInflight()` + `launchDispatchOne` → `go dispatchOne(...)` (`:597-598`,
   `:610-622`), handing the still-open `store` to the goroutine.
3. `dispatch` returns → the defer closes every handle.
4. The live goroutine then labels the bead (`:1127`) and, in its deferred
   cleanup, `closeOrderTrackingBead` → `store.CloseAll` (`:933`) — both on the
   now-closed handle.

`drain()` only waits on in-flight goroutines at controller exit/reload, never
at end of tick, so the per-tick defer has no barrier against them.

## Fix

Defer the per-tick close behind a `sync.WaitGroup` scoped to the goroutines
**that tick** launched:

- `launchDispatchOne` gains an `onDone func()` invoked exactly once **after**
  `dispatchOne` returns (i.e. after the goroutine's final store call).
- `dispatch`'s defer closes the handles from a **detached closer goroutine**
  that first waits on those callbacks. The closer never blocks the tick
  (preserving async dispatch), and when nothing was launched it closes
  immediately (`Wait` returns at once on a zero count).

No API changes, no new abstractions; the existing `drain`/`inflight` machinery
is untouched. Production change is confined to `cmd/gc/order_dispatch.go`.

## Testing

- **New deterministic regression test**
  `TestOrderDispatchDoesNotCloseStoreWhileDispatchInFlight`: a store double
  models the native one-way close latch and parks the in-flight goroutine until
  *after* `dispatch()` returns, then asserts no store op lands after
  `CloseStore`. It reproduces the issue's exact two-line error signature — **red
  before this change, green after**, under `-race`.
- Updated the #2988 close-count regression tests (`ga-anio6p`) for the
  now-deferred close: they drain then poll for the close, and the spy serializes
  its counter (the close now runs on the detached closer goroutine).
- `go vet ./...` clean; fast unit baseline (`scripts/test-local-parallel fast`)
  green; full `cmd/gc` `-race` sweep green except one **pre-existing, unrelated**
  data race in `session_reconciler.go:303` (drain-ack path) that reproduces on
  `origin/main` without this change.

## Out of scope (separate follow-ups the issue also lists)

- Reusing the controller's cached scope stores to stop per-tick opens (the
  connect/disconnect churn, gascity#2463).
- Dropping `NativeDoltStore`'s one-way close latch as defense in depth
  (reconnect-on-use).
- The controller store-rotation close path
  (`scheduleCloseReplacedBeadStoreHandles`), a second route to the same
  use-after-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)