### PR TITLE
docs(sling): clarify intentional source-routing for attached wisps (re #2848)

### DIFF
--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -4109,6 +4109,13 @@ func TestOnFormulaAttachesAndRoutes(t *testing.T) {
 	if b.Ref != "code-review" {
 		t.Errorf("wisp Ref = %q, want %q", b.Ref, "code-review")
 	}
+	// Attached wisps route the source bead, not the molecule root: the wisp
+	// root must stay unrouted so it is not independently claimed. Moving
+	// routed_to onto the molecule (gastownhall/gascity#2848) would orphan the
+	// work, since the attached root is privatized out of Ready().
+	if got := b.Metadata["gc.routed_to"]; got != "" {
+		t.Errorf("wisp root gc.routed_to = %q, want empty (attached wisp routes the source, not the molecule)", got)
+	}
 }
 
 func TestOnRootOnlyFormulaKeepsAttachedWispPrivate(t *testing.T) {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -360,6 +360,16 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 		}
 		result.WispRootID = wispRootID
 		result.FormulaName = opts.OnFormula
+		// Route the SOURCE bead, not wispRootID. An attached wisp (--on
+		// <formula>) is driven through its source bead: the source carries
+		// gc.routed_to + molecule_id and is the claimable unit of work, while
+		// the wisp root is deliberately left unrouted (and, when root-only,
+		// privatized out of Ready() by privatizeAttachedRootOnlyWisp).
+		// ApplyGraphRouting likewise stamps no routing on an attached recipe
+		// (graphroute: sourceBeadID != "" early-return). This is the
+		// intentional counterpart to slingFormula, which routes the standalone
+		// wisp root. Do not "fix" this to wispRootID — it would orphan the
+		// work. See gastownhall/gascity#2848 and TestOnFormulaAttachesAndRoutes.
 		return finalize(opts, deps, beadID, method, result)
 	}
 	runGraph := func() (pendingSourceWorkflowLaunch, error) {
@@ -462,6 +472,10 @@ func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 		}
 		result.WispRootID = wispRootID
 		result.FormulaName = defaultFormula
+		// Route the SOURCE bead, not wispRootID — see the matching note in
+		// slingOnFormula. The default formula attaches the wisp to the source
+		// bead, which stays the routed, claimable unit of work; the wisp root
+		// is intentionally left unrouted. Do not "fix" this to wispRootID.
 		return finalize(opts, deps, beadID, method, result)
 	}
 	runGraph := func() (pendingSourceWorkflowLaunch, error) {


### PR DESCRIPTION
## Summary

Investigation of #2848 (`gc sling <bead> --on <formula>` writes `gc.routed_to`
to the origin bead instead of the molecule) found that **this is working as
intended, not a bug** — so this PR adds documentation + a regression guard
rather than changing behavior. **No behavior change.**

### Why the current behavior is correct

Attached wisps are driven *through their source bead*:

- `slingOnFormula` / `slingDefaultFormula` route the **source** bead, which
  carries `gc.routed_to` + `molecule_id` and is the claimable unit of work.
- The attached wisp root is deliberately left **unrouted** and, when
  root-only, privatized out of `Ready()` by `privatizeAttachedRootOnlyWisp`.
- `graphroute.ApplyGraphRouting` likewise stamps **no** routing on an attached
  recipe (`sourceBeadID != ""` early-return).
- This is the intentional counterpart to `slingFormula` (standalone), which
  *does* route the wisp root (`mResult.RootID`).

Moving `routed_to` onto the molecule (the issue's "expected behavior") would
**orphan the work**: the molecule has no `routed_to`, and a root-only molecule
is excluded from `Ready()`, so no work query would ever surface it.

### The trap this prevents

The bare `finalize(opts, deps, beadID, ...)` in the two attached paths reads
like a missed copy of `slingFormula`'s `finalize(..., mResult.RootID, ...)`
(introduced for the standalone path only, in `dd471648b`). Without a comment,
a future change could "fix" it to `mResult.RootID` and silently break three
passing tests (`TestOnFormulaAttachesAndRoutes`,
`TestOnRootOnlyFormulaKeepsAttachedWispPrivate`,
`TestFormulaRootOnlyRoutesRunnableWispRoot`).

### Changes

- Comments at both attached-routing sites in `internal/sling/sling_core.go`
  explaining why the source bead (not the molecule root) is routed.
- A regression assertion in `TestOnFormulaAttachesAndRoutes` locking the
  attached wisp root as unrouted.

### Note on #2848

This PR intentionally does **not** close #2848 — that's a maintainer call on
how to respond to the reporter (@nagyv-cvio). It only hardens the code against
a wrong "fix."

🤖 Generated with [Claude Code](https://claude.com/claude-code)