### PR TITLE
feat(builtinpacks): hash manifest tracks binary-written files (ga-l83w5y.2, ga-l83w5y.3)

### DIFF
--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -20,6 +23,7 @@ import (
 
 const (
 	legacyOrderConfigFile = "order.toml"
+	packHashManifestFile  = ".gc-pack-hashes.json"
 )
 
 // builtinPacks lists all packs embedded in the gc binary. These are
@@ -63,7 +67,7 @@ func MaterializeBuiltinPacks(cityPath string) error {
 	for _, bp := range builtinPacks {
 		dst := filepath.Join(cityPath, citylayout.SystemPacksRoot, bp.Name)
 		_, isRequired := required[bp.Name]
-		desired, err := materializeFS(bp.FS, dst, !isRequired)
+		desired, err := materializeFS(bp.FS, dst, !isRequired, os.Stderr)
 		if err != nil {
 			return fmt.Errorf("materializing %s pack: %w", bp.Name, err)
 		}
@@ -355,25 +359,31 @@ func peekEventsProvider(tomlPath string) string {
 // materializeFS walks an embed.FS, writes all files to dstDir, and returns the
 // relative file paths that belong in the generated directory.
 //
-// When preserveOperatorEdits is true, existing regular files with the correct
-// mode are preserved verbatim — content is NOT overwritten even when it differs
-// from the embedded bytes. This protects operator-authored edits to non-required
-// pack files (formula TOMLs, command scripts, etc.) from being silently reverted
-// on every gc subcommand invocation (see gastownhall/gascity#2429). Operators
-// who want to pick up a fresh embedded version after a binary upgrade must delete
-// the on-disk file first.
+// When preserveOperatorEdits is true, a per-pack hash manifest
+// (.gc-pack-hashes.json) distinguishes stale embedded content from operator
+// edits. A file whose on-disk hash matches the last binary-written hash is
+// stale and refreshed silently. A file whose on-disk hash differs from the
+// manifest entry has been operator-edited and is preserved with a warning. A
+// file with no manifest entry is conservatively preserved without a warning
+// (migration path for cities without a prior manifest).
 //
-// When preserveOperatorEdits is false (required packs), the preservation skip is
-// disabled: every file is refreshed and validated against the embedded bytes, so
-// a stale or corrupt required pack is repaired rather than silently accepted.
+// When preserveOperatorEdits is false (required packs), every file is refreshed
+// and validated against the embedded bytes regardless of the manifest.
+//
+// The manifest is written after a successful walk even when the merged map is
+// empty; write failures are non-fatal and surface through w. The manifest file
+// itself is not included in the returned desired set.
 //
 // The remaining repair semantics are independent of the flag: missing files are
 // written (initial scaffolding), wrong-mode files are rewritten (e.g., script
 // that lost its +x bit), and non-regular files (symlinks, etc.) are replaced
 // with the embedded content.
-func materializeFS(embedded fs.FS, dstDir string, preserveOperatorEdits bool) (map[string]struct{}, error) {
+func materializeFS(embedded fs.FS, dstDir string, preserveOperatorEdits bool, w io.Writer) (map[string]struct{}, error) {
+	existingManifest := readPackHashManifest(dstDir)
+	pendingManifest := make(map[string]string)
 	desired := make(map[string]struct{})
-	err := fs.WalkDir(embedded, ".", func(path string, d fs.DirEntry, err error) error {
+
+	walkErr := fs.WalkDir(embedded, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -383,24 +393,37 @@ func materializeFS(embedded fs.FS, dstDir string, preserveOperatorEdits bool) (m
 		if d.IsDir() {
 			return os.MkdirAll(dst, 0o755)
 		}
-		desired[filepath.ToSlash(path)] = struct{}{}
+
+		rel := filepath.ToSlash(path)
+		desired[rel] = struct{}{}
 
 		perm := builtinpacks.MaterializedFileMode(path)
 
-		// Preserve operator-authored content for non-required packs. Skip the
-		// embedded write only when the existing on-disk entry is a regular file
-		// with the correct mode — that's a file the operator might have edited.
-		// Non-regular files (symlinks) and wrong-mode files still get repaired
-		// below, matching the prior contract. Mode comparison uses
+		// For non-required packs, use the hash manifest to distinguish stale
+		// embedded content from operator edits. Mode comparison uses
 		// fsys.ComparableMode (perm + setuid/setgid/sticky) so it agrees with
-		// the WriteFileIfContentOrModeChangedAtomic repair path below. Required
-		// packs (preserveOperatorEdits == false) skip this branch entirely so
-		// stale content is always refreshed.
+		// the WriteFileIfContentOrModeChangedAtomic repair path below.
 		if preserveOperatorEdits {
 			if info, statErr := os.Lstat(dst); statErr == nil {
 				if info.Mode().IsRegular() && fsys.ComparableMode(info.Mode()) == fsys.ComparableMode(perm) {
-					return nil
+					if knownHash, ok := existingManifest[rel]; ok {
+						onDiskData, readErr := os.ReadFile(dst)
+						if readErr != nil {
+							return fmt.Errorf("reading %s for hash comparison: %w", dst, readErr)
+						}
+						if sha256Hex(onDiskData) != knownHash {
+							// On-disk content differs from last binary-written hash: operator edit.
+							emitBuiltinPackRefreshWarning(w, fmt.Errorf("file %s has local edits; newer version available in the binary", rel))
+							pendingManifest[rel] = knownHash
+							return nil
+						}
+						// On-disk hash matches manifest: stale embed, fall through to refresh.
+					} else {
+						// No manifest entry: conservatively preserve without warning.
+						return nil
+					}
 				}
+				// Wrong mode or non-regular: fall through to repair.
 			} else if !os.IsNotExist(statErr) {
 				return fmt.Errorf("stat %s: %w", dst, statErr)
 			}
@@ -411,16 +434,58 @@ func materializeFS(embedded fs.FS, dstDir string, preserveOperatorEdits bool) (m
 			return fmt.Errorf("reading embedded %s: %w", path, err)
 		}
 
+		pendingManifest[rel] = sha256Hex(data)
+
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			return err
 		}
 
 		return fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, dst, data, perm)
 	})
-	if err != nil {
-		return nil, err
+
+	if walkErr != nil {
+		return nil, walkErr
 	}
+
+	if writeErr := writePackHashManifest(dstDir, pendingManifest); writeErr != nil {
+		emitBuiltinPackRefreshWarning(w, fmt.Errorf("could not write pack hash manifest: %w", writeErr))
+	}
+
 	return desired, nil
+}
+
+// sha256Hex returns the hex-encoded SHA-256 digest of data.
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// readPackHashManifest reads the pack hash manifest from dstDir. Returns an
+// empty map when the manifest is absent or contains invalid JSON.
+func readPackHashManifest(dstDir string) map[string]string {
+	data, err := os.ReadFile(filepath.Join(dstDir, packHashManifestFile))
+	if err != nil {
+		return map[string]string{}
+	}
+	var manifest map[string]string
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return map[string]string{}
+	}
+	if manifest == nil {
+		return map[string]string{}
+	}
+	return manifest
+}
+
+// writePackHashManifest writes manifest to dstDir/.gc-pack-hashes.json
+// atomically. The caller is responsible for treating write errors as non-fatal.
+func writePackHashManifest(dstDir string, manifest map[string]string) error {
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("marshaling pack hash manifest: %w", err)
+	}
+	dst := filepath.Join(dstDir, packHashManifestFile)
+	return fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, dst, data, 0o644)
 }
 
 func repairLegacyGcBeadsBdScript(cityPath string) error {
@@ -523,6 +588,11 @@ func pruneStaleGeneratedPackFiles(dstDir string, desired map[string]struct{}) er
 			_, ok := desired[path]
 			return ok
 		}) {
+			return nil
+		}
+		// Preserve the pack hash manifest and its atomic temp siblings — they
+		// are runtime metadata produced by materializeFS, not embedded content.
+		if rel == packHashManifestFile || strings.HasPrefix(rel, packHashManifestFile+".tmp.") {
 			return nil
 		}
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"io"
 	"os"
 	"os/exec"
@@ -838,6 +841,33 @@ func TestMaterializeBuiltinPacks_PruneIgnoresAtomicTempFilesForDesiredAssets(t *
 	}
 }
 
+func TestPruneStaleGeneratedPackFiles_PreservesPackHashManifestFiles(t *testing.T) {
+	dst := t.TempDir()
+
+	writeFileForTest(t, filepath.Join(dst, "kept.txt"), []byte("embedded"), 0o644)
+	writeFileForTest(t, filepath.Join(dst, testPackHashManifestFile), []byte(`{"kept.txt":"hash"}`), 0o644)
+	writeFileForTest(t, filepath.Join(dst, testPackHashManifestFile+".tmp.123.456"), []byte(`{"partial":true}`), 0o644)
+	writeFileForTest(t, filepath.Join(dst, "stale.txt"), []byte("stale"), 0o644)
+
+	desired := map[string]struct{}{"kept.txt": {}}
+	if err := pruneStaleGeneratedPackFiles(dst, desired); err != nil {
+		t.Fatalf("pruneStaleGeneratedPackFiles: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(dst, "kept.txt"),
+		filepath.Join(dst, testPackHashManifestFile),
+		filepath.Join(dst, testPackHashManifestFile+".tmp.123.456"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected prune to preserve %s: %v", filepath.Base(path), err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dst, "stale.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stale generated file still exists: %v", err)
+	}
+}
+
 func TestLoadCityConfigMaterializesBuiltinPacks(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
@@ -1486,6 +1516,281 @@ func TestBuiltinPackIncludes_AlwaysIncludesMaintenance(t *testing.T) {
 	}
 }
 
+const testPackHashManifestFile = ".gc-pack-hashes.json"
+
+func TestEmbedShadowingRefreshesUnmodifiedNonRequiredPackFile(t *testing.T) {
+	dst := t.TempDir()
+	const rel = "commands/health/run.sh"
+	const v1 = "#!/bin/sh\necho old-health\n"
+	const v2 = "#!/bin/sh\necho new-health\n"
+
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte(v1), Mode: 0o755},
+	}, dst, true, nil)
+	assertFileContentForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), v1)
+
+	var warnings bytes.Buffer
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte(v2), Mode: 0o755},
+	}, dst, true, &warnings)
+
+	assertFileContentForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), v2)
+	assertNoWarningForTest(t, warnings.String())
+	manifest := readPackHashManifestForTest(t, dst)
+	if got, want := manifest[rel], sha256HexForTest([]byte(v2)); got != want {
+		t.Fatalf("manifest[%q] = %q, want %q", rel, got, want)
+	}
+}
+
+func TestEmbedShadowingRequiredPackRefreshes(t *testing.T) {
+	dst := t.TempDir()
+	const rel = "skills/gc-work/SKILL.md"
+	const v1 = "old required content\n"
+	const v2 = "new required content\n"
+
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte(v1), Mode: 0o644},
+	}, dst, false, nil)
+
+	var warnings bytes.Buffer
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte(v2), Mode: 0o644},
+	}, dst, false, &warnings)
+
+	assertFileContentForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), v2)
+	assertNoWarningForTest(t, warnings.String())
+}
+
+func TestMaterializeFS_ManifestSeedsOnFirstWrite(t *testing.T) {
+	dst := t.TempDir()
+	embedded := fstest.MapFS{
+		"a.txt":     {Data: []byte("embedded-a"), Mode: 0o644},
+		"sub/b.txt": {Data: []byte("embedded-b"), Mode: 0o644},
+	}
+
+	desired := materializeFSForTest(t, embedded, dst, true, nil)
+	if _, ok := desired[testPackHashManifestFile]; ok {
+		t.Fatalf("desired set includes manifest metadata file %q", testPackHashManifestFile)
+	}
+
+	manifest := readPackHashManifestForTest(t, dst)
+	want := map[string]string{
+		"a.txt":     sha256HexForTest([]byte("embedded-a")),
+		"sub/b.txt": sha256HexForTest([]byte("embedded-b")),
+	}
+	assertManifestEqualsForTest(t, manifest, want)
+}
+
+func TestMaterializeFS_ManifestPreservesOperatorEdit(t *testing.T) {
+	dst := t.TempDir()
+	const rel = "commands/run.sh"
+	const original = "#!/bin/sh\necho original\n"
+	const updated = "#!/bin/sh\necho updated\n"
+	const operatorEdit = "#!/bin/sh\necho operator\n"
+
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte(original), Mode: 0o755},
+	}, dst, true, nil)
+	originalHash := readPackHashManifestForTest(t, dst)[rel]
+
+	writeFileForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), []byte(operatorEdit), 0o755)
+
+	var warnings bytes.Buffer
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte(updated), Mode: 0o755},
+	}, dst, true, &warnings)
+
+	assertFileContentForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), operatorEdit)
+	warningText := warnings.String()
+	for _, want := range []string{"local edits", "newer version available", rel} {
+		if !strings.Contains(warningText, want) {
+			t.Fatalf("warning = %q, want substring %q", warningText, want)
+		}
+	}
+
+	manifest := readPackHashManifestForTest(t, dst)
+	if got := manifest[rel]; got != originalHash {
+		t.Fatalf("manifest[%q] = %q, want original embedded hash %q", rel, got, originalHash)
+	}
+	for _, forbidden := range []string{sha256HexForTest([]byte(operatorEdit)), sha256HexForTest([]byte(updated))} {
+		if manifest[rel] == forbidden {
+			t.Fatalf("manifest[%q] was updated to %q, want preserved original hash %q", rel, forbidden, originalHash)
+		}
+	}
+}
+
+func TestMaterializeFS_ManifestConservativePreserveWithoutEntry(t *testing.T) {
+	dst := t.TempDir()
+	const rel = "config/default.toml"
+	const local = "operator-or-pre-fix-content\n"
+	writeFileForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), []byte(local), 0o644)
+
+	var warnings bytes.Buffer
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte("current embedded content\n"), Mode: 0o644},
+	}, dst, true, &warnings)
+
+	assertFileContentForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), local)
+	assertNoWarningForTest(t, warnings.String())
+	manifest := readPackHashManifestForTest(t, dst)
+	if _, ok := manifest[rel]; ok {
+		t.Fatalf("manifest contains conservative-preserved file %q: %#v", rel, manifest)
+	}
+	if len(manifest) != 0 {
+		t.Fatalf("manifest = %#v, want empty map for conservative preserve without entries", manifest)
+	}
+}
+
+func TestMaterializeFS_ManifestEmitsNoWarningOnStaleEmbed(t *testing.T) {
+	dst := t.TempDir()
+	const rel = "commands/sync/run.sh"
+	const v1 = "#!/bin/sh\necho sync-v1\n"
+	const v2 = "#!/bin/sh\necho sync-v2\n"
+
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte(v1), Mode: 0o755},
+	}, dst, true, nil)
+
+	var warnings bytes.Buffer
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte(v2), Mode: 0o755},
+	}, dst, true, &warnings)
+
+	assertFileContentForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), v2)
+	assertNoWarningForTest(t, warnings.String())
+	manifest := readPackHashManifestForTest(t, dst)
+	if got, want := manifest[rel], sha256HexForTest([]byte(v2)); got != want {
+		t.Fatalf("manifest[%q] = %q, want refreshed hash %q", rel, got, want)
+	}
+}
+
+func TestMaterializeFS_ManifestCorruptTreatedAsEmpty(t *testing.T) {
+	dst := t.TempDir()
+	const rel = "commands/doctor/run.sh"
+	const local = "#!/bin/sh\necho local\n"
+
+	writeFileForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), []byte(local), 0o755)
+	writeFileForTest(t, filepath.Join(dst, testPackHashManifestFile), []byte("{not-json"), 0o644)
+
+	var warnings bytes.Buffer
+	materializeFSForTest(t, fstest.MapFS{
+		rel: {Data: []byte("#!/bin/sh\necho embedded\n"), Mode: 0o755},
+	}, dst, true, &warnings)
+
+	assertFileContentForTest(t, filepath.Join(dst, filepath.FromSlash(rel)), local)
+	assertNoWarningForTest(t, warnings.String())
+	manifest := readPackHashManifestForTest(t, dst)
+	if len(manifest) != 0 {
+		t.Fatalf("manifest = %#v, want corrupt manifest treated as empty", manifest)
+	}
+}
+
+func TestMaterializeFS_ManifestWriteFailureIsNonFatal(t *testing.T) {
+	dst := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dst, testPackHashManifestFile), 0o755); err != nil {
+		t.Fatalf("Mkdir manifest path: %v", err)
+	}
+
+	var warnings bytes.Buffer
+	materializeFSForTest(t, fstest.MapFS{
+		"a.txt": {Data: []byte("embedded-a"), Mode: 0o644},
+	}, dst, true, &warnings)
+
+	assertFileContentForTest(t, filepath.Join(dst, "a.txt"), "embedded-a")
+	if !strings.Contains(warnings.String(), "pack hash manifest") {
+		t.Fatalf("warning = %q, want manifest write failure warning", warnings.String())
+	}
+}
+
+func TestMaterializeFS_ManifestPrunesStaleEntriesWhenEmbedFileRemoved(t *testing.T) {
+	dst := t.TempDir()
+	materializeFSForTest(t, fstest.MapFS{
+		"a.txt": {Data: []byte("embedded-a"), Mode: 0o644},
+		"b.txt": {Data: []byte("embedded-b"), Mode: 0o644},
+	}, dst, true, nil)
+
+	materializeFSForTest(t, fstest.MapFS{
+		"a.txt": {Data: []byte("embedded-a"), Mode: 0o644},
+	}, dst, true, nil)
+
+	manifest := readPackHashManifestForTest(t, dst)
+	want := map[string]string{"a.txt": sha256HexForTest([]byte("embedded-a"))}
+	assertManifestEqualsForTest(t, manifest, want)
+	if _, err := os.Stat(filepath.Join(dst, "b.txt")); err != nil {
+		t.Fatalf("b.txt should remain on disk for pruneStaleGeneratedPackFiles to handle: %v", err)
+	}
+}
+
+func materializeFSForTest(t *testing.T, embedded fstest.MapFS, dstDir string, preserveOperatorEdits bool, warnings io.Writer) map[string]struct{} {
+	t.Helper()
+	desired, err := materializeFS(embedded, dstDir, preserveOperatorEdits, warnings)
+	if err != nil {
+		t.Fatalf("materializeFS: %v", err)
+	}
+	return desired
+}
+
+func readPackHashManifestForTest(t *testing.T, dstDir string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dstDir, testPackHashManifestFile))
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", testPackHashManifestFile, err)
+	}
+	var manifest map[string]string
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("manifest JSON = %q, want object: %v", data, err)
+	}
+	if manifest == nil {
+		return map[string]string{}
+	}
+	return manifest
+}
+
+func assertManifestEqualsForTest(t *testing.T, got, want map[string]string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("manifest = %#v, want %#v", got, want)
+	}
+	for key, wantHash := range want {
+		if gotHash := got[key]; gotHash != wantHash {
+			t.Fatalf("manifest[%q] = %q, want %q; full manifest %#v", key, gotHash, wantHash, got)
+		}
+	}
+}
+
+func sha256HexForTest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func writeFileForTest(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func assertFileContentForTest(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("content %s = %q, want %q", filepath.Base(path), got, want)
+	}
+}
+
+func assertNoWarningForTest(t *testing.T, got string) {
+	t.Helper()
+	if got != "" {
+		t.Fatalf("warning = %q, want none", got)
+	}
+}
+
 // TestMaterializeFS_PreservesExistingFiles asserts that an existing on-disk
 // file is not overwritten by a subsequent materialize call. This is the
 // regression guard for gastownhall/gascity#2429 — `gc bd …` subcommands
@@ -1503,10 +1808,7 @@ func TestMaterializeFS_PreservesExistingFiles(t *testing.T) {
 	}
 
 	// Initial materialize: writes all three files since dst is empty.
-	desired, err := materializeFS(embedded, dst, true)
-	if err != nil {
-		t.Fatalf("first materializeFS: %v", err)
-	}
+	desired := materializeFSForTest(t, embedded, dst, true, nil)
 	for _, wantPath := range []string{"a.txt", "b.txt", "sub/c.txt"} {
 		if _, ok := desired[wantPath]; !ok {
 			t.Fatalf("desired set missing %q", wantPath)
@@ -1528,9 +1830,7 @@ func TestMaterializeFS_PreservesExistingFiles(t *testing.T) {
 	}
 
 	// Second materialize: should NOT overwrite the operator's edit.
-	if _, err := materializeFS(embedded, dst, true); err != nil {
-		t.Fatalf("second materializeFS: %v", err)
-	}
+	materializeFSForTest(t, embedded, dst, true, nil)
 	got, err := os.ReadFile(filepath.Join(dst, "b.txt"))
 	if err != nil {
 		t.Fatalf("read b.txt after second materialize: %v", err)
@@ -1557,9 +1857,7 @@ func TestMaterializeFS_PreservesExistingFiles(t *testing.T) {
 	if err := os.Remove(filepath.Join(dst, "b.txt")); err != nil {
 		t.Fatalf("remove b.txt: %v", err)
 	}
-	if _, err := materializeFS(embedded, dst, true); err != nil {
-		t.Fatalf("third materializeFS: %v", err)
-	}
+	materializeFSForTest(t, embedded, dst, true, nil)
 	got, err = os.ReadFile(filepath.Join(dst, "b.txt"))
 	if err != nil {
 		t.Fatalf("read b.txt after third materialize: %v", err)

--- a/internal/beads/boundary_test.go
+++ b/internal/beads/boundary_test.go
@@ -53,7 +53,7 @@ func TestNoBdExecOutsideBeads(t *testing.T) {
 		}
 		if info.IsDir() {
 			base := filepath.Base(path)
-			if base == ".git" || base == "vendor" || base == ".claude" || base == "worktrees" || strings.HasPrefix(base, ".beads-src") || strings.HasPrefix(base, "worktree-") {
+			if base == ".git" || base == "vendor" || base == ".claude" || base == ".gc" || base == "worktrees" || strings.HasPrefix(base, ".beads-src") || strings.HasPrefix(base, "worktree-") {
 				return filepath.SkipDir
 			}
 			// Skip git worktrees embedded in the repo (have a .git file, not dir).

--- a/internal/pgauth/no_external_env_test.go
+++ b/internal/pgauth/no_external_env_test.go
@@ -38,7 +38,7 @@ func TestNoDirectPostgresEnvReadsOutsidePgauth(t *testing.T) {
 		}
 		if info.IsDir() {
 			base := filepath.Base(path)
-			if base == ".git" || base == "vendor" || base == ".claude" || base == ".beads" || base == "worktrees" || strings.HasPrefix(base, ".beads-src") || strings.HasPrefix(base, "node_modules") {
+			if base == ".git" || base == "vendor" || base == ".claude" || base == ".beads" || base == ".gc" || base == "worktrees" || strings.HasPrefix(base, ".beads-src") || strings.HasPrefix(base, "node_modules") {
 				return filepath.SkipDir
 			}
 			// Skip git worktrees embedded in the repo (have a .git file, not dir).


### PR DESCRIPTION
## Summary

- Adds a per-pack `.gc-pack-hashes.json` sidecar that records SHA-256 hashes of every file `materializeFS` writes to disk. This enables distinguishing stale embedded content from operator edits.
- **Hash matches manifest**: stale embed → refresh silently. Fixes the stuck-on-old-content problem.
- **Hash differs from manifest**: operator-edited → preserve with a warning so the operator knows a newer version is available.
- **No manifest entry**: conservative preserve without warning (migration path for existing cities).
- Required packs (`preserveOperatorEdits=false`) ignore the manifest; every file is always refreshed.
- `pruneStaleGeneratedPackFiles` preserves the manifest file and its atomic-write temp siblings (`.gc-pack-hashes.json.tmp.*`).
- Manifest write failures are non-fatal and route through the existing warning path.
- Also fixes `TestNoBdExecOutsideBeads` and `TestNoDirectPostgresEnvReadsOutsidePgauth` to skip `.gc/` directories (city runtime state should not be scanned for source code violations).

Implements ga-l83w5y.2 (hash manifest reconciliation) and ga-l83w5y.3 (manifest preservation + stale-key pruning).

## Test plan

- [ ] All 10 new manifest tests pass (`TestMaterializeFS_Manifest*` + `TestPruneStaleGeneratedPackFiles_PreservesPackHashManifestFiles`)
- [ ] Full fast unit suite passes (`make test-fast-parallel`)
- [ ] `go vet ./...` clean