### PR TITLE
feat(doctor): add rig root-branch advisory check (ga-iq13bl.1)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -330,6 +330,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 			}
 			register(doctor.NewRigPathCheck(rig))
 			register(doctor.NewRigGitCheck(rig))
+			register(doctor.NewRigRootBranchCheck(rig))
 			register(doctor.NewRigBDSplitStoreCheck(cityPath, rig))
 			register(doctor.NewRigBeadsCheck(cityPath, rig, storeFactory))
 			register(newDoctorRigDoltServerCheck(cityPath, rig, !rigUsesManagedBdStoreContract(cityPath, rig) || gcDoltSkip()))

--- a/internal/doctor/checks_rig_root_branch.go
+++ b/internal/doctor/checks_rig_root_branch.go
@@ -1,0 +1,97 @@
+package doctor
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+const defaultBranchFallback = "main"
+
+// RigRootBranchCheck warns when a rig's working tree is on a different branch
+// than its configured default branch. SeverityAdvisory; WarmupEligible.
+type RigRootBranchCheck struct {
+	rig     config.Rig
+	gitPath func(name string) (string, error) // injectable for tests
+}
+
+// NewRigRootBranchCheck creates a rig root-branch check for the given rig.
+func NewRigRootBranchCheck(rig config.Rig) *RigRootBranchCheck {
+	return &RigRootBranchCheck{rig: rig, gitPath: exec.LookPath}
+}
+
+// Name returns the check identifier.
+func (c *RigRootBranchCheck) Name() string { return "rig:" + c.rig.Name + ":root-branch" }
+
+// WarmupEligible returns true so this check runs during gc start warm-up.
+func (c *RigRootBranchCheck) WarmupEligible() bool { return true }
+
+// CanFix returns false; branch switches require operator judgment.
+func (c *RigRootBranchCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *RigRootBranchCheck) Fix(_ *CheckContext) error { return nil }
+
+// Run checks whether the rig's HEAD is on its configured default branch.
+func (c *RigRootBranchCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name(), Severity: SeverityAdvisory}
+
+	defaultBranch := c.rig.EffectiveDefaultBranch()
+	if defaultBranch == "" {
+		defaultBranch = defaultBranchFallback
+	}
+
+	gitBin, err := c.gitPath("git")
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("rig %q: unable to determine branch — git unavailable or path is not a git repo", c.rig.Name)
+		return r
+	}
+
+	branchOut, err := runGitCommand(gitBin, c.rig.Path, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("rig %q: unable to determine branch — git unavailable or path is not a git repo", c.rig.Name)
+		return r
+	}
+
+	currentBranch := strings.TrimSpace(branchOut)
+	if currentBranch == defaultBranch {
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("rig %q HEAD=%s (matches default)", c.rig.Name, currentBranch)
+		return r
+	}
+
+	r.Status = StatusWarning
+	r.Message = fmt.Sprintf("rig %q is on %s (expected: %s)", c.rig.Name, currentBranch, defaultBranch)
+	r.FixHint = fmt.Sprintf("git -C %q checkout %s", c.rig.Path, defaultBranch)
+
+	if dirty, _ := isGitDirty(gitBin, c.rig.Path); dirty {
+		r.Details = []string{"working tree is dirty — git pull will fail"}
+	}
+	return r
+}
+
+// runGitCommand executes a git subcommand in dir and returns trimmed stdout.
+func runGitCommand(gitBin, dir string, args ...string) (string, error) {
+	cmd := exec.Command(gitBin, args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// isGitDirty reports whether the working tree has uncommitted changes.
+func isGitDirty(gitBin, dir string) (bool, error) {
+	cmd := exec.Command(gitBin, "status", "--porcelain")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}

--- a/internal/doctor/checks_rig_root_branch_test.go
+++ b/internal/doctor/checks_rig_root_branch_test.go
@@ -1,0 +1,199 @@
+package doctor
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// RED tests for RigRootBranchCheck (ga-l0jx0r). They fail to compile until
+// the builder-provided check lands in internal/doctor/checks_rig_root_branch.go.
+
+func TestRigRootBranchCheck_HeadMatchesDefaultBranch_OK(t *testing.T) {
+	rigPath := initGitRepoOnBranch(t, "main")
+	c := NewRigRootBranchCheck(config.Rig{
+		Name:          "testrig",
+		Path:          rigPath,
+		DefaultBranch: "main",
+	})
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "matches default") {
+		t.Errorf("message = %q, want mention of matching default branch", r.Message)
+	}
+	if r.FixHint != "" {
+		t.Errorf("FixHint = %q, want empty for OK result", r.FixHint)
+	}
+}
+
+func TestRigRootBranchCheck_HeadDiffersFromDefaultClean_WarnsAdvisory(t *testing.T) {
+	rigPath := initGitRepoOnBranch(t, "feature")
+	c := NewRigRootBranchCheck(config.Rig{
+		Name:          "testrig",
+		Path:          rigPath,
+		DefaultBranch: "main",
+	})
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d (%s), want StatusWarning", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("severity = %d, want SeverityAdvisory", r.Severity)
+	}
+	if !strings.Contains(r.Message, "feature") || !strings.Contains(r.Message, "main") {
+		t.Errorf("message = %q, want current and default branch names", r.Message)
+	}
+	if r.FixHint == "" || !strings.Contains(r.FixHint, "checkout main") {
+		t.Errorf("FixHint = %q, want checkout hint for default branch", r.FixHint)
+	}
+	if len(r.Details) != 0 {
+		t.Errorf("Details = %v, want none for clean tree", r.Details)
+	}
+}
+
+func TestRigRootBranchCheck_HeadDiffersFromDefaultDirty_WarnsWithDirtyDetail(t *testing.T) {
+	rigPath := initGitRepoOnBranch(t, "feature")
+	if err := os.WriteFile(filepath.Join(rigPath, "dirty.txt"), []byte("dirty\n"), 0o600); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+	c := NewRigRootBranchCheck(config.Rig{
+		Name:          "testrig",
+		Path:          rigPath,
+		DefaultBranch: "main",
+	})
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d (%s), want StatusWarning", r.Status, r.Message)
+	}
+	if len(r.Details) == 0 {
+		t.Fatalf("Details = %v, want dirty working tree detail", r.Details)
+	}
+	foundDirty := false
+	for _, detail := range r.Details {
+		if strings.Contains(detail, "dirty") {
+			foundDirty = true
+		}
+	}
+	if !foundDirty {
+		t.Errorf("Details = %v, want detail mentioning dirty working tree", r.Details)
+	}
+}
+
+func TestRigRootBranchCheck_NotGitRepository_WarnsUnableToDetermine(t *testing.T) {
+	c := NewRigRootBranchCheck(config.Rig{
+		Name:          "testrig",
+		Path:          t.TempDir(),
+		DefaultBranch: "main",
+	})
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d (%s), want StatusWarning", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("severity = %d, want SeverityAdvisory", r.Severity)
+	}
+	if !strings.Contains(r.Message, "unable to determine branch") {
+		t.Errorf("message = %q, want unable-to-determine warning", r.Message)
+	}
+}
+
+func TestRigRootBranchCheck_GitUnavailable_WarnsUnableToDetermine(t *testing.T) {
+	c := NewRigRootBranchCheck(config.Rig{
+		Name:          "testrig",
+		Path:          t.TempDir(),
+		DefaultBranch: "main",
+	})
+	c.gitPath = func(string) (string, error) {
+		return "", errors.New("git unavailable")
+	}
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d (%s), want StatusWarning", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("severity = %d, want SeverityAdvisory", r.Severity)
+	}
+	if !strings.Contains(r.Message, "unable to determine branch") {
+		t.Errorf("message = %q, want unable-to-determine warning", r.Message)
+	}
+}
+
+func TestRigRootBranchCheck_DefaultBranchUnsetFallsBackToMain(t *testing.T) {
+	rigPath := initGitRepoOnBranch(t, "main")
+	c := NewRigRootBranchCheck(config.Rig{
+		Name: "testrig",
+		Path: rigPath,
+	})
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK when unset default falls back to main", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "HEAD=main") {
+		t.Errorf("message = %q, want HEAD=main", r.Message)
+	}
+}
+
+func TestRigRootBranchCheck_NonMainDefaultBranchMatches_OK(t *testing.T) {
+	rigPath := initGitRepoOnBranch(t, "develop")
+	c := NewRigRootBranchCheck(config.Rig{
+		Name:          "testrig",
+		Path:          rigPath,
+		DefaultBranch: "develop",
+	})
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK for non-main default branch", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "HEAD=develop") {
+		t.Errorf("message = %q, want HEAD=develop", r.Message)
+	}
+}
+
+func initGitRepoOnBranch(t *testing.T, branch string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	runGitForRigRootBranchTest(t, dir, "init")
+	runGitForRigRootBranchTest(t, dir, "checkout", "-b", branch)
+	runGitForRigRootBranchTest(t, dir, "config", "user.name", "Rig Root Branch Test")
+	runGitForRigRootBranchTest(t, dir, "config", "user.email", "rig-root-branch@example.invalid")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("initial\n"), 0o600); err != nil {
+		t.Fatalf("write initial file: %v", err)
+	}
+	runGitForRigRootBranchTest(t, dir, "add", "README.md")
+	runGitForRigRootBranchTest(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func runGitForRigRootBranchTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}

--- a/release-gates/ga-wfyuv7-rig-root-branch-check-gate.md
+++ b/release-gates/ga-wfyuv7-rig-root-branch-check-gate.md
@@ -1,0 +1,51 @@
+# Release Gate: ga-wfyuv7
+
+## Summary
+
+- Bead: `ga-wfyuv7` — needs-deploy: RigRootBranchCheck doctor advisory check
+- Source bead: `ga-2mv0np`
+- Reviewed commits:
+  - `42debce64` — feat(doctor): add rig root-branch advisory check
+  - `717420fcd1b9bce16cf8b809f22777605fb042b7` — test(doctor): cover rig root branch check
+- Source branch: `builder/ga-iq13bl.1-doctor-rig-branch`
+- Scope: doctor advisory check for rig branch/default-branch drift
+- Gate result: PASS
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree. This gate uses
+the deployer release-gate criteria from the agent contract and the test
+tier guidance in `TESTING.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-2mv0np` is closed with `REVIEW VERDICT: PASS` from `gascity/reviewer` for commits `42debce64` and `717420fcd`. |
+| 2 | Acceptance criteria met | PASS | Adds `RigRootBranchCheck` with name `rig:<name>:root-branch`, `SeverityAdvisory`, `WarmupEligible=true`, `CanFix=false`, injectable git path for tests, and wiring through `buildDoctorChecks` in `cmd/gc/cmd_doctor.go`. Tests cover matching branch, clean drift, dirty drift, non-git path, missing git, unset default fallback, and non-main default branch. |
+| 3 | Tests pass | PASS | `go test ./internal/doctor -run 'TestRigRootBranchCheck' -count=1` passed. `go build ./cmd/gc/...` passed. `make test-fast-parallel` passed all fast shards. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer recorded two low-severity non-blocking findings only: optional dirty-check error detail is dropped, and unavailable-git/non-git messages share wording. No high-severity findings are open. |
+| 5 | Final branch is clean | PASS | Evaluation worktree was clean before writing this gate; final status is checked after the gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | Branch is behind `origin/main` by one commit, but `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reported a clean merge with no conflict markers. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem: doctor checks and the `cmd/gc` doctor check registration. |
+
+## Test Commands
+
+```text
+go test ./internal/doctor -run 'TestRigRootBranchCheck' -count=1
+go build ./cmd/gc/...
+make test-fast-parallel
+go vet ./...
+```
+
+## Acceptance Evidence
+
+Implemented surface:
+
+- `internal/doctor/checks_rig_root_branch.go` defines the advisory branch drift check.
+- `cmd/gc/cmd_doctor.go` registers the check for rigs.
+- `internal/doctor/checks_rig_root_branch_test.go` covers all seven reviewed decision paths.
+
+Unchanged surface:
+
+- No HTTP API schema, dashboard, or generated type changes.
+- No automatic fixing behavior; `CanFix=false`.
+- Git interactions are read-only (`rev-parse` and `status --porcelain`).


### PR DESCRIPTION
## What this changes

`gc doctor` now includes an advisory rig check that warns when a rig checkout is on a branch other than its configured default branch. The same check is warmup-eligible, so `gc start` can surface branch drift before operators run into stale or surprising rig state.

The check is intentionally read-only. It reports the current branch, expected default branch, and dirty working-tree detail when available, but it does not checkout, pull, or otherwise mutate a rig.

## Review notes

- New check: `internal/doctor/checks_rig_root_branch.go`.
- Registration surface: `cmd/gc/cmd_doctor.go`.
- Severity is advisory, `WarmupEligible=true`, and `CanFix=false`.
- Default branch falls back to `main` when the rig does not configure one.
- Git operations are read-only: `rev-parse --abbrev-ref HEAD` and `status --porcelain`.

## Test plan

- [x] `go test ./internal/doctor -run 'TestRigRootBranchCheck' -count=1`
- [x] `go build ./cmd/gc/...`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-wfyuv7-rig-root-branch-check-gate.md`](release-gates/ga-wfyuv7-rig-root-branch-check-gate.md)
