### PR TITLE
feat(doctor): add text advisory indicator to per-check output (ga-iq13bl.2)

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -129,7 +129,11 @@ func printResult(w io.Writer, r *CheckResult, verbose bool) {
 	if r.Fixed {
 		suffix = " (fixed)"
 	}
-	fmt.Fprintf(w, "  %s %s — %s%s\n", icon, r.Name, r.Message, suffix) //nolint:errcheck // best-effort output
+	advisorySuffix := ""
+	if r.Status != StatusOK && !r.Fixed && r.Severity == SeverityAdvisory {
+		advisorySuffix = " (advisory)"
+	}
+	fmt.Fprintf(w, "  %s %s — %s%s%s\n", icon, r.Name, r.Message, advisorySuffix, suffix) //nolint:errcheck // best-effort output
 	if verbose {
 		for _, d := range r.Details {
 			fmt.Fprintf(w, "      %s\n", d) //nolint:errcheck // best-effort output

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -470,6 +470,54 @@ func TestDoctor_BlockingFailedSeverityAccounting(t *testing.T) {
 	}
 }
 
+// TestDoctor_AdvisoryPerCheckLine verifies the per-check output line includes
+// "(advisory)" when the result has SeverityAdvisory and StatusWarning/Error,
+// and that the suffix is absent for OK results and for blocking failures.
+func TestDoctor_AdvisoryPerCheckLine(t *testing.T) {
+	tests := []struct {
+		name       string
+		check      *mockCheck
+		wantLabel  string
+		wantAbsent string
+	}{
+		{
+			name:      "advisory-warning-has-suffix",
+			check:     &mockCheck{name: "check-a", status: StatusWarning, severity: SeverityAdvisory, msg: "heads up"},
+			wantLabel: "(advisory)",
+		},
+		{
+			name:      "advisory-error-has-suffix",
+			check:     &mockCheck{name: "check-b", status: StatusError, severity: SeverityAdvisory, msg: "note"},
+			wantLabel: "(advisory)",
+		},
+		{
+			name:       "advisory-ok-no-suffix",
+			check:      &mockCheck{name: "check-c", status: StatusOK, severity: SeverityAdvisory, msg: "fine"},
+			wantAbsent: "(advisory)",
+		},
+		{
+			name:       "blocking-warning-no-suffix",
+			check:      &mockCheck{name: "check-d", status: StatusWarning, severity: SeverityBlocking, msg: "bad"},
+			wantAbsent: "(advisory)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Doctor{}
+			d.Register(tt.check)
+			var buf bytes.Buffer
+			d.Run(&CheckContext{CityPath: "/tmp"}, &buf, false)
+			out := buf.String()
+			if tt.wantLabel != "" && !strings.Contains(out, tt.wantLabel) {
+				t.Errorf("output = %q, want %q in line", out, tt.wantLabel)
+			}
+			if tt.wantAbsent != "" && strings.Contains(out, tt.wantAbsent) {
+				t.Errorf("output = %q, must not contain %q", out, tt.wantAbsent)
+			}
+		})
+	}
+}
+
 // TestPrintSummary_AdvisoryRenderedSeparately confirms advisory failures get
 // their own component in the summary line so operators can tell at a glance
 // that a doctor pass had non-blocking findings.


### PR DESCRIPTION
## Summary

- `printResult` in `internal/doctor/doctor.go` now appends `(advisory)` to the per-check output line when the result has `SeverityAdvisory`, `Status != StatusOK`, and was not fixed
- Operators can distinguish advisory warnings from blocking failures without relying solely on the summary count
- No change to exit codes, summary counts, or the `gc doctor --json` output shape

## Test plan

- [x] `go test ./internal/doctor/... ./cmd/gc/...` passes
- [x] Pre-commit hook (golangci-lint + fast test suite) passes

Ref: ga-iq13bl.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)