### PR TITLE
fix(build): guard Linux system CGO fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
            -X main.date=$(BUILD_TIME)
 
+unique_words = $(if $1,$(firstword $1) $(call unique_words,$(filter-out $(firstword $1),$1)))
+
 # macOS: icu4c (a transitive Dolt / go-icu-regex CGO build dependency) is
 # keg-only under Homebrew, so its headers/libs are not on the default CGO
 # search path. Point CGO at them when icu4c is present. This is a no-op on
@@ -51,7 +53,7 @@ ifneq ($(wildcard $(SYS_USR_INCLUDE)/unicode/uregex.h),)
 ifeq ($(shell $(CC) -E -Wp,-v -x c /dev/null 2>&1 | sed 's/^[[:space:]]*//' | grep -F -x -q "$(SYS_USR_INCLUDE)" && echo yes),)
 SYS_USR_MULTIARCH_CANDIDATES := $(strip $(shell dpkg-architecture -q DEB_HOST_MULTIARCH 2>/dev/null) $(shell $(CC) -print-multiarch 2>/dev/null))
 SYS_USR_LIB_CANDIDATES := $(foreach arch,$(SYS_USR_MULTIARCH_CANDIDATES),$(SYS_USR_LIB_ROOT)/$(arch)) $(SYS_USR_LIB64_ROOT) $(SYS_USR_LIB_ROOT)
-SYS_USR_LIB_DIRS := $(sort $(strip $(foreach dir,$(SYS_USR_LIB_CANDIDATES),$(if $(wildcard $(dir)),$(dir)))))
+SYS_USR_LIB_DIRS := $(strip $(call unique_words,$(strip $(foreach dir,$(SYS_USR_LIB_CANDIDATES),$(if $(wildcard $(dir)),$(dir))))))
 $(info Linux system CGO fallback active: adding -I$(SYS_USR_INCLUDE) $(addprefix -L,$(SYS_USR_LIB_DIRS)); set SYS_USR_CGO_FALLBACK=0 to disable)
 CGO_CPPFLAGS += -I$(SYS_USR_INCLUDE)
 CGO_LDFLAGS += $(addprefix -L,$(SYS_USR_LIB_DIRS))

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,11 @@ endif
 # Linux: some non-system compilers (Nix, Flox, etc.) don't search /usr/include
 # or /usr/lib by default. If system ICU headers exist but the compiler doesn't
 # see them, intentionally let system paths participate in the whole CGO build.
+# Set SYS_USR_CGO_FALLBACK=0 to disable this fallback for hermetic or cross-CGO
+# builds.
 ifeq ($(shell uname),Linux)
+SYS_USR_CGO_FALLBACK ?= 1
+ifneq ($(SYS_USR_CGO_FALLBACK),0)
 SYS_USR_INCLUDE ?= /usr/include
 SYS_USR_LIB_ROOT ?= /usr/lib
 SYS_USR_LIB64_ROOT ?= /usr/lib64
@@ -47,11 +51,13 @@ ifneq ($(wildcard $(SYS_USR_INCLUDE)/unicode/uregex.h),)
 ifeq ($(shell $(CC) -E -Wp,-v -x c /dev/null 2>&1 | sed 's/^[[:space:]]*//' | grep -F -x -q "$(SYS_USR_INCLUDE)" && echo yes),)
 SYS_USR_MULTIARCH_CANDIDATES := $(strip $(shell dpkg-architecture -q DEB_HOST_MULTIARCH 2>/dev/null) $(shell $(CC) -print-multiarch 2>/dev/null))
 SYS_USR_LIB_CANDIDATES := $(foreach arch,$(SYS_USR_MULTIARCH_CANDIDATES),$(SYS_USR_LIB_ROOT)/$(arch)) $(SYS_USR_LIB64_ROOT) $(SYS_USR_LIB_ROOT)
-SYS_USR_LIB_DIRS := $(strip $(foreach dir,$(SYS_USR_LIB_CANDIDATES),$(if $(wildcard $(dir)),$(dir))))
+SYS_USR_LIB_DIRS := $(sort $(strip $(foreach dir,$(SYS_USR_LIB_CANDIDATES),$(if $(wildcard $(dir)),$(dir)))))
+$(info Linux system CGO fallback active: adding -I$(SYS_USR_INCLUDE) $(addprefix -L,$(SYS_USR_LIB_DIRS)); set SYS_USR_CGO_FALLBACK=0 to disable)
 CGO_CPPFLAGS += -I$(SYS_USR_INCLUDE)
 CGO_LDFLAGS += $(addprefix -L,$(SYS_USR_LIB_DIRS))
 export CGO_CPPFLAGS
 export CGO_LDFLAGS
+endif
 endif
 endif
 endif

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -23,3 +23,78 @@ sed_i() {
         sed -i "$@"
     fi
 }
+
+append_word_once() {
+    local var_name="$1"
+    local word="$2"
+    local current="${!var_name:-}"
+
+    case " $current " in
+        *" $word "*)
+            return 0
+            ;;
+    esac
+
+    printf -v "$var_name" '%s' "${current:+$current }$word"
+}
+
+configure_linux_system_cgo_fallback() {
+    [[ "${SYS_USR_CGO_FALLBACK:-1}" != "0" ]] || return 0
+
+    local sys_usr_include="${SYS_USR_INCLUDE:-/usr/include}"
+    local sys_usr_lib_root="${SYS_USR_LIB_ROOT:-/usr/lib}"
+    local sys_usr_lib64_root="${SYS_USR_LIB64_ROOT:-/usr/lib64}"
+    local cc_bin="${CC:-cc}"
+
+    [[ -f "$sys_usr_include/unicode/uregex.h" ]] || return 0
+    if "$cc_bin" -E -Wp,-v -x c /dev/null 2>&1 |
+        sed 's/^[[:space:]]*//' |
+        grep -F -x -q "$sys_usr_include"; then
+        return 0
+    fi
+
+    append_word_once cgo_cppflags "-I$sys_usr_include"
+
+    local -a candidates=()
+    local arch dir seen_dirs=""
+    while IFS= read -r arch; do
+        [[ -n "$arch" ]] || continue
+        candidates+=("$sys_usr_lib_root/$arch")
+    done < <(
+        {
+            dpkg-architecture -q DEB_HOST_MULTIARCH 2>/dev/null || true
+            "$cc_bin" -print-multiarch 2>/dev/null || true
+        }
+    )
+    candidates+=("$sys_usr_lib64_root" "$sys_usr_lib_root")
+
+    for dir in "${candidates[@]}"; do
+        [[ -d "$dir" ]] || continue
+        case " $seen_dirs " in
+            *" $dir "*)
+                continue
+                ;;
+        esac
+        seen_dirs="${seen_dirs:+$seen_dirs }$dir"
+        append_word_once cgo_ldflags "-L$dir"
+    done
+}
+
+configure_cgo_platform_paths() {
+    cgo_cppflags="${cgo_cppflags:-${CGO_CPPFLAGS:-}}"
+    cgo_ldflags="${cgo_ldflags:-${CGO_LDFLAGS:-}}"
+
+    case "$(uname)" in
+        Darwin)
+            local icu_prefix
+            icu_prefix="$(brew --prefix icu4c 2>/dev/null || true)"
+            if [[ -n "$icu_prefix" ]]; then
+                append_word_once cgo_cppflags "-I${icu_prefix}/include"
+                append_word_once cgo_ldflags "-L${icu_prefix}/lib"
+            fi
+            ;;
+        Linux)
+            configure_linux_system_cgo_fallback
+            ;;
+    esac
+}

--- a/scripts/makefile_cgo_test.go
+++ b/scripts/makefile_cgo_test.go
@@ -209,6 +209,7 @@ printf '%s\n' '#include <...> search starts here:' ' /nix/store/include' 'End of
 	if count := countExactField(ldflags, "-L"+sysLib); count != 1 {
 		t.Fatalf("system lib dir appears %d times, want 1:\n%s", count, out)
 	}
+	assertFieldsInOrder(t, ldflags, "-L"+multiarchLib, "-L"+sysLib)
 }
 
 func TestMakefileLinuxCGOPathsTreatNestedIncludeAsMissingSystemRoot(t *testing.T) {
@@ -366,4 +367,19 @@ func countExactField(fields, want string) int {
 		}
 	}
 	return count
+}
+
+func assertFieldsInOrder(t *testing.T, fields string, want ...string) {
+	t.Helper()
+	allFields := strings.Fields(fields)
+	next := 0
+	for _, field := range allFields {
+		if field == want[next] {
+			next++
+			if next == len(want) {
+				return
+			}
+		}
+	}
+	t.Fatalf("fields are not in required order %v:\n%s", want, fields)
 }

--- a/scripts/makefile_cgo_test.go
+++ b/scripts/makefile_cgo_test.go
@@ -55,11 +55,159 @@ printf '%s\n' '#include <...> search starts here:' ' /nix/store/include' 'End of
 	assertContains(t, out, "-L"+filepath.Join(sysLib, "riscv64-linux-gnu"))
 	assertContains(t, out, "-L"+sysLib64)
 	assertContains(t, out, "-L"+sysLib)
+	assertContains(t, out, "Linux system CGO fallback active:")
 	if strings.Contains(out, "x86_64-linux-gnu") {
 		t.Fatalf("CGO paths should not hardcode the x86_64 Debian fallback:\n%s", out)
 	}
 	if strings.Contains(out, "ambient") {
-		t.Fatalf("Makefile CGO tests should not inherit ambient CGO flags:\n%s", out)
+		t.Fatalf("Makefile CGO test helper should filter ambient CGO flags:\n%s", out)
+	}
+}
+
+func TestMakefileLinuxCGOPathsCanBeDisabled(t *testing.T) {
+	repoRoot := repoRoot(t)
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	sysInclude := filepath.Join(tmp, "sysinclude")
+	if err := os.MkdirAll(filepath.Join(sysInclude, "unicode"), 0o755); err != nil {
+		t.Fatalf("mkdir unicode include: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sysInclude, "unicode", "uregex.h"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write ICU header: %v", err)
+	}
+	sysLib := filepath.Join(tmp, "syslib")
+	if err := os.MkdirAll(sysLib, 0o755); err != nil {
+		t.Fatalf("mkdir syslib: %v", err)
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "uname"), "#!/usr/bin/env sh\necho Linux\n")
+	writeExecutable(t, filepath.Join(binDir, "dpkg-architecture"), "#!/usr/bin/env sh\necho x86_64-linux-gnu\n")
+	writeExecutable(t, filepath.Join(binDir, "cc"), `#!/usr/bin/env sh
+case " $* " in
+  *" -print-multiarch "*)
+    echo x86_64-linux-gnu
+    exit 0
+    ;;
+esac
+printf '%s\n' '#include <...> search starts here:' ' /nix/store/include' 'End of search list.' >&2
+`)
+
+	out := runMakefileCGOPrintTarget(t, repoRoot, tmp, binDir,
+		"SYS_USR_INCLUDE="+sysInclude,
+		"SYS_USR_LIB_ROOT="+sysLib,
+		"SYS_USR_LIB64_ROOT="+filepath.Join(tmp, "syslib64"),
+		"SYS_USR_CGO_FALLBACK=0",
+		"CC=cc",
+	)
+	if out != "CGO_CPPFLAGS=\nCGO_LDFLAGS=\n" {
+		t.Fatalf("CGO flags should stay empty when the Linux system fallback is disabled:\n%s", out)
+	}
+	assertNotContains(t, out, "Linux system CGO fallback active:")
+}
+
+func TestMakefileLinuxCGOPathsStayEmptyWhenCompilerSeesSystemRoot(t *testing.T) {
+	repoRoot := repoRoot(t)
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	sysInclude := filepath.Join(tmp, "sysinclude")
+	if err := os.MkdirAll(filepath.Join(sysInclude, "unicode"), 0o755); err != nil {
+		t.Fatalf("mkdir unicode include: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sysInclude, "unicode", "uregex.h"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write ICU header: %v", err)
+	}
+	sysLib := filepath.Join(tmp, "syslib")
+	if err := os.MkdirAll(sysLib, 0o755); err != nil {
+		t.Fatalf("mkdir syslib: %v", err)
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "uname"), "#!/usr/bin/env sh\necho Linux\n")
+	writeExecutable(t, filepath.Join(binDir, "dpkg-architecture"), `#!/usr/bin/env sh
+touch "$(dirname "$0")/dpkg.ran"
+echo x86_64-linux-gnu
+`)
+	writeExecutable(t, filepath.Join(binDir, "cc"), `#!/usr/bin/env sh
+case " $* " in
+  *" -print-multiarch "*)
+    touch "$(dirname "$0")/cc-multiarch.ran"
+    echo x86_64-linux-gnu
+    exit 0
+    ;;
+esac
+printf '%s\n' '#include <...> search starts here:' ' `+sysInclude+`' 'End of search list.' >&2
+`)
+
+	out := runMakefileCGOPrintTarget(t, repoRoot, tmp, binDir,
+		"SYS_USR_INCLUDE="+sysInclude,
+		"SYS_USR_LIB_ROOT="+sysLib,
+		"SYS_USR_LIB64_ROOT="+filepath.Join(tmp, "syslib64"),
+		"CC=cc",
+	)
+	if out != "CGO_CPPFLAGS=\nCGO_LDFLAGS=\n" {
+		t.Fatalf("CGO flags should stay empty when the compiler already sees the system include root:\n%s", out)
+	}
+	for _, name := range []string{"dpkg.ran", "cc-multiarch.ran"} {
+		if _, err := os.Stat(filepath.Join(binDir, name)); err == nil {
+			t.Fatalf("Makefile should not run %s when the compiler already sees the system include root", strings.TrimSuffix(name, ".ran"))
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+	}
+	assertNotContains(t, out, "Linux system CGO fallback active:")
+}
+
+func TestMakefileLinuxCGOPathsDeduplicateSystemLibDirs(t *testing.T) {
+	repoRoot := repoRoot(t)
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	sysInclude := filepath.Join(tmp, "sysinclude")
+	if err := os.MkdirAll(filepath.Join(sysInclude, "unicode"), 0o755); err != nil {
+		t.Fatalf("mkdir unicode include: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sysInclude, "unicode", "uregex.h"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write ICU header: %v", err)
+	}
+	sysLib := filepath.Join(tmp, "syslib")
+	multiarchLib := filepath.Join(sysLib, "x86_64-linux-gnu")
+	for _, dir := range []string{multiarchLib, sysLib} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "uname"), "#!/usr/bin/env sh\necho Linux\n")
+	writeExecutable(t, filepath.Join(binDir, "dpkg-architecture"), "#!/usr/bin/env sh\necho x86_64-linux-gnu\n")
+	writeExecutable(t, filepath.Join(binDir, "cc"), `#!/usr/bin/env sh
+case " $* " in
+  *" -print-multiarch "*)
+    echo x86_64-linux-gnu
+    exit 0
+    ;;
+esac
+printf '%s\n' '#include <...> search starts here:' ' /nix/store/include' 'End of search list.' >&2
+`)
+
+	out := runMakefileCGOPrintTarget(t, repoRoot, tmp, binDir,
+		"SYS_USR_INCLUDE="+sysInclude,
+		"SYS_USR_LIB_ROOT="+sysLib,
+		"SYS_USR_LIB64_ROOT="+sysLib,
+		"CC=cc",
+	)
+	ldflags := strings.TrimPrefix(lineWithPrefix(t, out, "CGO_LDFLAGS="), "CGO_LDFLAGS=")
+	if count := countExactField(ldflags, "-L"+multiarchLib); count != 1 {
+		t.Fatalf("multiarch lib dir appears %d times, want 1:\n%s", count, out)
+	}
+	if count := countExactField(ldflags, "-L"+sysLib); count != 1 {
+		t.Fatalf("system lib dir appears %d times, want 1:\n%s", count, out)
 	}
 }
 
@@ -190,4 +338,32 @@ func assertContains(t *testing.T, haystack, needle string) {
 	if !strings.Contains(haystack, needle) {
 		t.Fatalf("output missing %q:\n%s", needle, haystack)
 	}
+}
+
+func assertNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Fatalf("output contains %q:\n%s", needle, haystack)
+	}
+}
+
+func lineWithPrefix(t *testing.T, output, prefix string) string {
+	t.Helper()
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return line
+		}
+	}
+	t.Fatalf("output missing line prefix %q:\n%s", prefix, output)
+	return ""
+}
+
+func countExactField(fields, want string) int {
+	count := 0
+	for _, field := range strings.Fields(fields) {
+		if field == want {
+			count++
+		}
+	}
+	return count
 }

--- a/scripts/shard_cgo_test.go
+++ b/scripts/shard_cgo_test.go
@@ -1,0 +1,225 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestShardScriptsApplyLinuxCGOFallback(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		script string
+		args   []string
+	}{
+		{
+			name:   "go-test-shard",
+			script: "test-go-test-shard",
+			args:   []string{"./cmd/gc", "1", "1"},
+		},
+		{
+			name:   "integration-shard",
+			script: "test-integration-shard",
+			args:   []string{"bdstore"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repoRoot := repoRoot(t)
+			fixture := newShardCGOFixture(t)
+
+			cmd := exec.Command(filepath.Join(repoRoot, "scripts", tt.script), tt.args...)
+			cmd.Dir = repoRoot
+			cmd.Env = fixture.env(t)
+
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s failed: %v\n%s", tt.script, err, out)
+			}
+
+			got := readCapturedGoEnv(t, fixture.capturePath)
+			if got["CGO_CPPFLAGS"] != "-I"+fixture.sysInclude {
+				t.Fatalf("CGO_CPPFLAGS=%q, want %q", got["CGO_CPPFLAGS"], "-I"+fixture.sysInclude)
+			}
+			assertFieldsInOrder(t, got["CGO_LDFLAGS"],
+				"-L"+fixture.multiarchLib,
+				"-L"+fixture.sysLib64,
+				"-L"+fixture.sysLib,
+			)
+			for _, flag := range []string{"-L" + fixture.multiarchLib, "-L" + fixture.sysLib64, "-L" + fixture.sysLib} {
+				if count := countExactField(got["CGO_LDFLAGS"], flag); count != 1 {
+					t.Fatalf("%s appears %d times, want 1 in CGO_LDFLAGS=%q", flag, count, got["CGO_LDFLAGS"])
+				}
+			}
+		})
+	}
+}
+
+func TestShardScriptsDisableLinuxCGOFallback(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		script string
+		args   []string
+	}{
+		{
+			name:   "go-test-shard",
+			script: "test-go-test-shard",
+			args:   []string{"./cmd/gc", "1", "1"},
+		},
+		{
+			name:   "integration-shard",
+			script: "test-integration-shard",
+			args:   []string{"bdstore"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repoRoot := repoRoot(t)
+			fixture := newShardCGOFixture(t)
+
+			cmd := exec.Command(filepath.Join(repoRoot, "scripts", tt.script), tt.args...)
+			cmd.Dir = repoRoot
+			cmd.Env = append(fixture.env(t), "SYS_USR_CGO_FALLBACK=0")
+
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s failed: %v\n%s", tt.script, err, out)
+			}
+
+			got := readCapturedGoEnv(t, fixture.capturePath)
+			if got["CGO_CPPFLAGS"] != "" {
+				t.Fatalf("CGO_CPPFLAGS=%q, want empty", got["CGO_CPPFLAGS"])
+			}
+			if got["CGO_LDFLAGS"] != "" {
+				t.Fatalf("CGO_LDFLAGS=%q, want empty", got["CGO_LDFLAGS"])
+			}
+		})
+	}
+}
+
+type shardCGOFixture struct {
+	tmp          string
+	binDir       string
+	capturePath  string
+	sysInclude   string
+	sysLib       string
+	sysLib64     string
+	multiarchLib string
+}
+
+func newShardCGOFixture(t *testing.T) shardCGOFixture {
+	t.Helper()
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	sysInclude := filepath.Join(tmp, "sysinclude")
+	if err := os.MkdirAll(filepath.Join(sysInclude, "unicode"), 0o755); err != nil {
+		t.Fatalf("mkdir unicode include: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sysInclude, "unicode", "uregex.h"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write ICU header: %v", err)
+	}
+
+	sysLib := filepath.Join(tmp, "syslib")
+	sysLib64 := filepath.Join(tmp, "syslib64")
+	multiarchLib := filepath.Join(sysLib, "riscv64-linux-gnu")
+	for _, dir := range []string{multiarchLib, sysLib64, sysLib} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "uname"), "#!/usr/bin/env sh\necho Linux\n")
+	writeExecutable(t, filepath.Join(binDir, "dpkg-architecture"), "#!/usr/bin/env sh\necho riscv64-linux-gnu\n")
+	writeExecutable(t, filepath.Join(binDir, "cc"), `#!/usr/bin/env sh
+case " $* " in
+  *" -print-multiarch "*)
+    echo riscv64-linux-gnu
+    exit 0
+    ;;
+esac
+printf '%s\n' '#include <...> search starts here:' ' /nix/store/include' 'End of search list.' >&2
+`)
+	capturePath := filepath.Join(tmp, "go-env.capture")
+	writeExecutable(t, filepath.Join(binDir, "go"), `#!/usr/bin/env bash
+set -euo pipefail
+
+fake_go_root=`+shellQuote(tmp)+`
+fake_go_capture=`+shellQuote(capturePath)+`
+
+case "$1" in
+  env)
+    case "$2" in
+      GOPATH) echo "$fake_go_root/gopath" ;;
+      GOCACHE) echo "$fake_go_root/gocache" ;;
+      GOMODCACHE) echo "$fake_go_root/gomodcache" ;;
+      GOTMPDIR) echo "" ;;
+      GOROOT) echo "$fake_go_root/goroot" ;;
+      *) echo "unexpected go env key: $2" >&2; exit 1 ;;
+    esac
+    ;;
+  test)
+    for arg in "$@"; do
+      if [[ "$arg" == "-list" ]]; then
+        echo TestSynthetic
+        exit 0
+      fi
+    done
+    {
+      printf 'CGO_CPPFLAGS=%s\n' "${CGO_CPPFLAGS-}"
+      printf 'CGO_LDFLAGS=%s\n' "${CGO_LDFLAGS-}"
+    } >> "$fake_go_capture"
+    ;;
+  *)
+    echo "unexpected go command: $*" >&2
+    exit 1
+    ;;
+esac
+`)
+
+	return shardCGOFixture{
+		tmp:          tmp,
+		binDir:       binDir,
+		capturePath:  capturePath,
+		sysInclude:   sysInclude,
+		sysLib:       sysLib,
+		sysLib64:     sysLib64,
+		multiarchLib: multiarchLib,
+	}
+}
+
+func (f shardCGOFixture) env(t *testing.T) []string {
+	t.Helper()
+	return []string{
+		"PATH=" + f.binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"HOME=" + filepath.Join(f.tmp, "home"),
+		"SYS_USR_INCLUDE=" + f.sysInclude,
+		"SYS_USR_LIB_ROOT=" + f.sysLib,
+		"SYS_USR_LIB64_ROOT=" + f.sysLib64,
+		"CC=cc",
+	}
+}
+
+func readCapturedGoEnv(t *testing.T, path string) map[string]string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read captured go env: %v", err)
+	}
+	got := make(map[string]string)
+	for _, line := range strings.Split(string(content), "\n") {
+		if line == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			t.Fatalf("captured env line missing '=': %q", line)
+		}
+		got[key] = value
+	}
+	return got
+}

--- a/scripts/test-go-test-shard
+++ b/scripts/test-go-test-shard
@@ -22,6 +22,7 @@ fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
+source "$repo_root/scripts/lib/common.sh"
 
 timeout="${GO_TEST_TIMEOUT:-20m}"
 
@@ -31,22 +32,13 @@ gomodcache_val="$(go env GOMODCACHE)"
 gotmpdir_val="$(go env GOTMPDIR)"
 goroot_val="$(go env GOROOT)"
 
-# macOS: icu4c (a transitive go-icu-regex/Dolt CGO dependency) is keg-only
-# under Homebrew, so its headers/libs are not on the default CGO search path.
-# Mirror the Makefile's detection here so tests run via this script see the
-# same CGO paths as `make`. No-op on Linux and when icu4c is not installed.
-# When invoked from test-integration-shard, CGO_CPPFLAGS/CGO_LDFLAGS may
-# already be set by that script; the duplicate-safe guard below prevents
-# double-adding when this script runs as a child of test-integration-shard.
+# Mirror the Makefile's CGO path detection here so tests run via this script
+# see the same system dependency paths as `make`. When invoked from
+# test-integration-shard, CGO_CPPFLAGS/CGO_LDFLAGS may already be set by that
+# script; the helper avoids double-adding duplicate words.
 cgo_cppflags="${CGO_CPPFLAGS:-}"
 cgo_ldflags="${CGO_LDFLAGS:-}"
-if [[ "$(uname)" == "Darwin" ]]; then
-  icu_prefix="$(brew --prefix icu4c 2>/dev/null || true)"
-  if [[ -n "$icu_prefix" && "$cgo_cppflags" != *"-I${icu_prefix}/include"* ]]; then
-    cgo_cppflags="${cgo_cppflags:+$cgo_cppflags }-I${icu_prefix}/include"
-    cgo_ldflags="${cgo_ldflags:+$cgo_ldflags }-L${icu_prefix}/lib"
-  fi
-fi
+configure_cgo_platform_paths
 
 extra_env=()
 while IFS='=' read -r name _; do

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -10,6 +10,7 @@ fi
 shard="$1"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
+source "$repo_root/scripts/lib/common.sh"
 
 timeout="${GO_TEST_TIMEOUT:-30m}"
 pkg="./test/integration"
@@ -20,19 +21,11 @@ gomodcache_val="$(go env GOMODCACHE)"
 gotmpdir_val="$(go env GOTMPDIR)"
 goroot_val="$(go env GOROOT)"
 
-# macOS: icu4c (a transitive go-icu-regex/Dolt CGO dependency) is keg-only
-# under Homebrew, so its headers/libs are not on the default CGO search path.
-# Mirror the Makefile's detection here so tests run via this script see the
-# same CGO paths as `make`. No-op on Linux and when icu4c is not installed.
+# Mirror the Makefile's CGO path detection here so tests run via this script
+# see the same system dependency paths as `make`.
 cgo_cppflags="${CGO_CPPFLAGS:-}"
 cgo_ldflags="${CGO_LDFLAGS:-}"
-if [[ "$(uname)" == "Darwin" ]]; then
-  icu_prefix="$(brew --prefix icu4c 2>/dev/null || true)"
-  if [[ -n "$icu_prefix" && "$cgo_cppflags" != *"-I${icu_prefix}/include"* ]]; then
-    cgo_cppflags="${cgo_cppflags:+$cgo_cppflags }-I${icu_prefix}/include"
-    cgo_ldflags="${cgo_ldflags:+$cgo_ldflags }-L${icu_prefix}/lib"
-  fi
-fi
+configure_cgo_platform_paths
 # Export so child scripts (e.g. test-go-test-shard) inherit the detected paths.
 export CGO_CPPFLAGS="${cgo_cppflags}"
 export CGO_LDFLAGS="${cgo_ldflags}"

--- a/test/integration/gc_live_contract_test.go
+++ b/test/integration/gc_live_contract_test.go
@@ -403,8 +403,13 @@ description = "Read and complete {{issue}}."
 		Items []beads.Bead `json:"items"`
 		Total int          `json:"total"`
 	}](t, baseURL, validator, http.MethodGet, cityBase+"/beads?label=real-world-app-contract&limit=50&all=true&rig="+url.QueryEscape(rigName), nil, http.StatusOK)
-	if list.Total < 3 || !beadListContains(list.Items, rootBead.ID) || !beadListContains(list.Items, siblingBead.ID) {
-		t.Fatalf("filtered beads = %+v, want root and sibling", list)
+	if list.Total < 3 || !beadListContains(list.Items, rootBead.ID) || !beadListContains(list.Items, childBead.ID) || !beadListContains(list.Items, siblingBead.ID) {
+		t.Fatalf("filtered beads = %+v, want root, child, and sibling", list)
+	}
+	if listedChild, ok := findLiveContractBead(list.Items, childBead.ID); !ok {
+		t.Fatalf("filtered beads = %+v, want child %s", list, childBead.ID)
+	} else if listedChild.Status != "in_progress" {
+		t.Fatalf("filtered child status = %q, want in_progress", listedChild.Status)
 	}
 	if listedSibling, ok := findLiveContractBead(list.Items, siblingBead.ID); ok && listedSibling.ParentID != rootBead.ID {
 		t.Fatalf("filtered sibling parent = %q, want %q", listedSibling.ParentID, rootBead.ID)


### PR DESCRIPTION
Post-merge remediation for #3107.

## Summary
- Add `SYS_USR_CGO_FALLBACK=0` as an explicit opt-out for the Linux system ICU fallback.
- Emit a one-line diagnostic only when the fallback injects system CGO paths.
- Deduplicate discovered system library directories before appending `-L` flags.
- Tighten the live contract test so `all=true` must include the non-open child bead.

## Tests
- `go test ./scripts -run TestMakefileLinuxCGO -count=1`
- `go test ./scripts -count=1`
- `go test -tags integration ./test/integration -run TestGCLiveContract_BeadsAndEvents -count=1`
- `make test`
- `go vet ./...`
- pre-commit hook: passed sharded fast tests
