### PR TITLE
feat(lint): warn on gc.output_json in graph.v2 formula steps (ga-paqwas.2)

### DIFF
--- a/cmd/gc/cmd_lint.go
+++ b/cmd/gc/cmd_lint.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/promptmeta"
 	"github.com/spf13/cobra"
@@ -184,6 +185,7 @@ func lintPack(packDir string) lintPackReport {
 	for _, warning := range loaded.Warnings {
 		out.Diagnostics = append(out.Diagnostics, diagnosticFromWarning(filepath.Join(packDir, "pack.toml"), warning))
 	}
+	out.Diagnostics = append(out.Diagnostics, lintFormulaFiles(packDir)...)
 	targets, diagnostics := collectLintPromptTargets(packDir, loaded)
 	out.Diagnostics = append(out.Diagnostics, diagnostics...)
 	for _, target := range targets {
@@ -389,6 +391,32 @@ func lintFirstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// lintFormulaFiles checks all formula TOML files in the packDir/formulas/
+// directory for graph.v2 steps that use gc.output_json instead of drain.
+func lintFormulaFiles(packDir string) []lintDiagnostic {
+	formulaDir := filepath.Join(packDir, "formulas")
+	entries, err := os.ReadDir(formulaDir)
+	if err != nil {
+		return nil // no formulas/ dir is normal
+	}
+	parser := formula.NewParser(formulaDir)
+	var diagnostics []lintDiagnostic
+	for _, entry := range entries {
+		if entry.IsDir() || !formula.IsTOMLFilename(entry.Name()) {
+			continue
+		}
+		filePath := filepath.Join(formulaDir, entry.Name())
+		f, err := parser.ParseFile(filePath)
+		if err != nil {
+			continue // parse errors are not this check's responsibility
+		}
+		for _, msg := range formula.GraphV2OutputJSONWarnings(f) {
+			diagnostics = append(diagnostics, diagnosticFromWarning(filePath, msg))
+		}
+	}
+	return diagnostics
 }
 
 func diagnosticFromError(path string, err error) lintDiagnostic {

--- a/cmd/gc/cmd_lint_test.go
+++ b/cmd/gc/cmd_lint_test.go
@@ -326,6 +326,88 @@ func appendLintFile(t *testing.T, path, content string) {
 	}
 }
 
+func TestLintFormulaOutputJSONWarning(t *testing.T) {
+	packDir := t.TempDir()
+	writeLintPack(t, packDir, "mypack", "worker", "prompts/worker.template.md")
+	writeLintFile(t, filepath.Join(packDir, "prompts", "worker.template.md"), "hello {{.AgentName}}\n")
+
+	formulaDir := filepath.Join(packDir, "formulas")
+	writeLintFile(t, filepath.Join(formulaDir, "legacy.formula.toml"), strings.TrimSpace(`
+formula = "legacy-fanout"
+version = 1
+contract = "graph.v2"
+[[steps]]
+id = "worker"
+prompt = "do work"
+[steps.metadata]
+"gc.output_json_required" = "true"
+`)+"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"lint", packDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc lint = %d, want 0 (warnings-only exits 0)\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "gc.output_json is legacy") {
+		t.Errorf("stderr = %q, want gc.output_json warning", stderr.String())
+	}
+}
+
+func TestLintFormulaNoWarningForDrain(t *testing.T) {
+	packDir := t.TempDir()
+	writeLintPack(t, packDir, "mypack", "worker", "prompts/worker.template.md")
+	writeLintFile(t, filepath.Join(packDir, "prompts", "worker.template.md"), "hello {{.AgentName}}\n")
+
+	formulaDir := filepath.Join(packDir, "formulas")
+	writeLintFile(t, filepath.Join(formulaDir, "drain.formula.toml"), strings.TrimSpace(`
+formula = "drain-fanout"
+version = 1
+contract = "graph.v2"
+[[steps]]
+id = "worker"
+prompt = "do work"
+[steps.drain]
+context = "separate"
+formula = "mol-do-work"
+member_access = "exclusive"
+`)+"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"lint", packDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc lint = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "gc.output_json") {
+		t.Errorf("stderr = %q, must not warn about gc.output_json for drain formula", stderr.String())
+	}
+}
+
+func TestLintFormulaNoWarningForGraphV1(t *testing.T) {
+	packDir := t.TempDir()
+	writeLintPack(t, packDir, "mypack", "worker", "prompts/worker.template.md")
+	writeLintFile(t, filepath.Join(packDir, "prompts", "worker.template.md"), "hello {{.AgentName}}\n")
+
+	formulaDir := filepath.Join(packDir, "formulas")
+	writeLintFile(t, filepath.Join(formulaDir, "v1.formula.toml"), strings.TrimSpace(`
+formula = "v1-fanout"
+version = 1
+[[steps]]
+id = "worker"
+prompt = "do work"
+[steps.metadata]
+"gc.output_json_required" = "true"
+`)+"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"lint", packDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc lint = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "gc.output_json") {
+		t.Errorf("stderr = %q, must not warn about gc.output_json for graph.v1 formula", stderr.String())
+	}
+}
+
 func validateLintJSONSchema(t *testing.T, data []byte) {
 	t.Helper()
 	rawSchema, err := readBuiltinSchema([]string{"lint"}, jsonSchemaResultRole)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -129,7 +129,11 @@ func printResult(w io.Writer, r *CheckResult, verbose bool) {
 	if r.Fixed {
 		suffix = " (fixed)"
 	}
-	fmt.Fprintf(w, "  %s %s — %s%s\n", icon, r.Name, r.Message, suffix) //nolint:errcheck // best-effort output
+	advisorySuffix := ""
+	if r.Status != StatusOK && !r.Fixed && r.Severity == SeverityAdvisory {
+		advisorySuffix = " (advisory)"
+	}
+	fmt.Fprintf(w, "  %s %s — %s%s%s\n", icon, r.Name, r.Message, advisorySuffix, suffix) //nolint:errcheck // best-effort output
 	if verbose {
 		for _, d := range r.Details {
 			fmt.Fprintf(w, "      %s\n", d) //nolint:errcheck // best-effort output

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -470,6 +470,54 @@ func TestDoctor_BlockingFailedSeverityAccounting(t *testing.T) {
 	}
 }
 
+// TestDoctor_AdvisoryPerCheckLine verifies the per-check output line includes
+// "(advisory)" when the result has SeverityAdvisory and StatusWarning/Error,
+// and that the suffix is absent for OK results and for blocking failures.
+func TestDoctor_AdvisoryPerCheckLine(t *testing.T) {
+	tests := []struct {
+		name       string
+		check      *mockCheck
+		wantLabel  string
+		wantAbsent string
+	}{
+		{
+			name:      "advisory-warning-has-suffix",
+			check:     &mockCheck{name: "check-a", status: StatusWarning, severity: SeverityAdvisory, msg: "heads up"},
+			wantLabel: "(advisory)",
+		},
+		{
+			name:      "advisory-error-has-suffix",
+			check:     &mockCheck{name: "check-b", status: StatusError, severity: SeverityAdvisory, msg: "note"},
+			wantLabel: "(advisory)",
+		},
+		{
+			name:       "advisory-ok-no-suffix",
+			check:      &mockCheck{name: "check-c", status: StatusOK, severity: SeverityAdvisory, msg: "fine"},
+			wantAbsent: "(advisory)",
+		},
+		{
+			name:       "blocking-warning-no-suffix",
+			check:      &mockCheck{name: "check-d", status: StatusWarning, severity: SeverityBlocking, msg: "bad"},
+			wantAbsent: "(advisory)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Doctor{}
+			d.Register(tt.check)
+			var buf bytes.Buffer
+			d.Run(&CheckContext{CityPath: "/tmp"}, &buf, false)
+			out := buf.String()
+			if tt.wantLabel != "" && !strings.Contains(out, tt.wantLabel) {
+				t.Errorf("output = %q, want %q in line", out, tt.wantLabel)
+			}
+			if tt.wantAbsent != "" && strings.Contains(out, tt.wantAbsent) {
+				t.Errorf("output = %q, must not contain %q", out, tt.wantAbsent)
+			}
+		})
+	}
+}
+
 // TestPrintSummary_AdvisoryRenderedSeparately confirms advisory failures get
 // their own component in the summary line so operators can tell at a glance
 // that a doctor pass had non-blocking findings.

--- a/internal/formula/graphv2_validation.go
+++ b/internal/formula/graphv2_validation.go
@@ -785,3 +785,31 @@ func isGraphV2ReservedVarName(name string) bool {
 	_, ok := graphV2ReservedVarNames[strings.TrimSpace(name)]
 	return ok
 }
+
+// GraphV2OutputJSONWarnings returns one warning string per step in a graph.v2
+// formula that sets gc.output_json_required without using drain. graph.v1
+// formulas and steps that use drain are not flagged — drain is the graph.v2
+// canonical fan-out primitive.
+func GraphV2OutputJSONWarnings(f *Formula) []string {
+	if !UsesGraphCompiler(f) {
+		return nil
+	}
+	var warnings []string
+	collectOutputJSONWarnings(f.Steps, f.Formula, &warnings)
+	return warnings
+}
+
+func collectOutputJSONWarnings(steps []*Step, formulaName string, out *[]string) {
+	for _, step := range steps {
+		if step.Drain == nil && strings.TrimSpace(step.Metadata["gc.output_json_required"]) == "true" {
+			*out = append(*out, fmt.Sprintf(
+				"formula %s step %s: gc.output_json is legacy; use drain in graph.v2 formulas (see: engdocs/drain-fanout.md)",
+				formulaName, step.ID,
+			))
+		}
+		collectOutputJSONWarnings(step.Children, formulaName, out)
+		if step.Loop != nil {
+			collectOutputJSONWarnings(step.Loop.Body, formulaName, out)
+		}
+	}
+}

--- a/internal/formula/graphv2_validation_test.go
+++ b/internal/formula/graphv2_validation_test.go
@@ -669,6 +669,110 @@ func TestValidateGraphV2RecipeRejectsDrainWithGate(t *testing.T) {
 	}
 }
 
+func TestGraphV2OutputJSONWarnings(t *testing.T) {
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	defer SetFormulaV2Enabled(prev)
+
+	tests := []struct {
+		name      string
+		toml      string
+		wantCount int
+		wantMsg   string
+	}{
+		{
+			name: "graph.v2 step with output_json_required warns",
+			toml: `
+formula = "legacy-fanout"
+version = 1
+contract = "graph.v2"
+[[steps]]
+id = "worker"
+prompt = "do work"
+[steps.metadata]
+"gc.output_json_required" = "true"
+`,
+			wantCount: 1,
+			wantMsg:   "gc.output_json is legacy; use drain in graph.v2 formulas",
+		},
+		{
+			name: "graph.v1 step with output_json_required does not warn",
+			toml: `
+formula = "v1-fanout"
+version = 1
+[[steps]]
+id = "worker"
+prompt = "do work"
+[steps.metadata]
+"gc.output_json_required" = "true"
+`,
+			wantCount: 0,
+		},
+		{
+			name: "graph.v2 step using drain does not warn",
+			toml: `
+formula = "drain-fanout"
+version = 1
+contract = "graph.v2"
+[[steps]]
+id = "worker"
+prompt = "do work"
+[steps.drain]
+context = "separate"
+formula = "mol-do-work"
+member_access = "exclusive"
+`,
+			wantCount: 0,
+		},
+		{
+			name: "graph.v2 step with no fan-out does not warn",
+			toml: `
+formula = "no-fanout"
+version = 1
+contract = "graph.v2"
+[[steps]]
+id = "worker"
+prompt = "do work"
+`,
+			wantCount: 0,
+		},
+		{
+			name: "warning includes step id and formula name",
+			toml: `
+formula = "my-formula"
+version = 1
+contract = "graph.v2"
+[[steps]]
+id = "my-step"
+prompt = "do work"
+[steps.metadata]
+"gc.output_json_required" = "true"
+`,
+			wantCount: 1,
+			wantMsg:   "formula my-formula step my-step",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeGraphV2Formula(t, dir, "f.formula.toml", tt.toml)
+			p := NewParser(dir)
+			f, err := p.ParseFile(filepath.Join(dir, "f.formula.toml"))
+			if err != nil {
+				t.Fatalf("ParseFile: %v", err)
+			}
+			got := GraphV2OutputJSONWarnings(f)
+			if len(got) != tt.wantCount {
+				t.Errorf("warnings count = %d, want %d; got: %v", len(got), tt.wantCount, got)
+			}
+			if tt.wantMsg != "" && len(got) > 0 && !strings.Contains(got[0], tt.wantMsg) {
+				t.Errorf("warning = %q, want to contain %q", got[0], tt.wantMsg)
+			}
+		})
+	}
+}
+
 func writeGraphV2Formula(t *testing.T, dir, name, contents string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(strings.TrimSpace(contents)+"\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary

- Adds `formula.GraphV2OutputJSONWarnings` in `internal/formula/graphv2_validation.go` — walks a formula's step tree and returns one warning string per graph.v2 step that sets `gc.output_json_required` without using drain
- `gc lint` now calls this for every `.toml` file in a pack's `formulas/` directory, emitting non-fatal warnings
- Warnings-only lint exits 0; errors still exit 1
- Warning copy: `gc.output_json is legacy; use drain in graph.v2 formulas (see: engdocs/drain-fanout.md)`

No-warn cases: graph.v1 formulas, steps using drain, steps with no fan-out at all.

## Test plan

- [x] `TestGraphV2OutputJSONWarnings` — 5 subtests covering graph.v2 + output_json_required warns, graph.v1 no-warn, drain no-warn, no-fanout no-warn, warning includes step id and formula name
- [x] `TestLintFormulaOutputJSONWarning` — integration: gc lint exits 0, warning appears in stderr
- [x] `TestLintFormulaNoWarningForDrain` — drain formula: no warning emitted
- [x] `TestLintFormulaNoWarningForGraphV1` — graph.v1 formula: no warning emitted
- [x] `make test` passes (pre-commit hook)

Ref: ga-paqwas.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)