### PR TITLE
fix(test): increase 1s timeouts to 5s in api_state_test.go (ga-0idf2l)

### DIFF
--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -2914,7 +2914,7 @@ func TestControllerStateEstablishesBeadEventCursorBeforePrimingStores(t *testing
 
 	select {
 	case <-ep.latestCalled:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("event watcher did not establish an initial cursor")
 	}
 	select {
@@ -2929,7 +2929,7 @@ func TestControllerStateEstablishesBeadEventCursorBeforePrimingStores(t *testing
 	close(ep.allowLatest)
 	select {
 	case <-returned:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("newControllerState did not return after the initial event cursor was established")
 	}
 }
@@ -3015,7 +3015,7 @@ func TestControllerStateBeadEventWatcherRetriesSetupErrors(t *testing.T) {
 
 	select {
 	case <-ep.failed:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("bead event watcher did not attempt initial watch")
 	}
 

--- a/release-gates/ga-nhwmeb-fix-timing-test-flakes-gate.md
+++ b/release-gates/ga-nhwmeb-fix-timing-test-flakes-gate.md
@@ -1,0 +1,48 @@
+# Release Gate: ga-nhwmeb
+
+## Summary
+
+- Bead: `ga-nhwmeb` — needs-deploy: fix timing test flakes in api_state_test.go
+- Source bead: `ga-ca05s0`
+- Reviewed commit: `388d432e89552f6dff2fd04e6335107fd3ae2a6e`
+- Source branch: `builder/ga-0idf2l-fix-timing-test-flakes`
+- Scope: test-only timeout bump in `cmd/gc/api_state_test.go`
+- Gate result: PASS
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree. This gate uses
+the deployer release-gate criteria from the agent contract and the test
+tier guidance in `TESTING.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-ca05s0` contains `REVIEW VERDICT: PASS` from `gascity/reviewer` for commit `388d432e8`. |
+| 2 | Acceptance criteria met | PASS | Diff changes exactly three tight `time.After(time.Second)` deadlines to `time.After(5 * time.Second)` in `cmd/gc/api_state_test.go`; no production files changed. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestControllerStateEstablishesBeadEventCursorBeforePrimingStores|TestControllerStateBeadEventWatcherRetriesSetupErrors' -count=1` passed. `make test-fast-parallel` passed all fast shards. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes report "No findings. Clean pass." |
+| 5 | Final branch is clean | PASS | Evaluation worktree was clean before writing this gate; final status is checked after the gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reported a clean merge for the single changed file. |
+| 7 | Single feature theme | PASS | Commit set touches only `cmd/gc/api_state_test.go` and only increases flaky test deadlines in one controller-state test area. |
+
+## Test Commands
+
+```text
+go test ./cmd/gc -run 'TestControllerStateEstablishesBeadEventCursorBeforePrimingStores|TestControllerStateBeadEventWatcherRetriesSetupErrors' -count=1
+make test-fast-parallel
+go vet ./...
+```
+
+## Acceptance Evidence
+
+Changed deadlines:
+
+- `TestControllerStateEstablishesBeadEventCursorBeforePrimingStores`: initial event cursor wait from 1s to 5s.
+- `TestControllerStateEstablishesBeadEventCursorBeforePrimingStores`: controller return wait from 1s to 5s.
+- `TestControllerStateBeadEventWatcherRetriesSetupErrors`: initial watch attempt wait from 1s to 5s.
+
+Unchanged surface:
+
+- No production code changed.
+- No API schema or dashboard files changed.
+- No security-sensitive path changed.


### PR DESCRIPTION
## What this changes

The controller-state tests in `cmd/gc/api_state_test.go` get more realistic wait windows for asynchronous watcher setup. Three selects that previously failed after one second now wait up to five seconds, which matches the rest of the timing-sensitive controller tests and avoids false failures under heavy parallel pre-commit load.

This does not change production behavior. It only changes test deadlines around event cursor establishment and bead event watcher retry setup.

## Review notes

- Test-only change in `cmd/gc/api_state_test.go`.
- No API schema, dashboard, config, runtime, or production controller logic changes.
- The larger timeout is bounded and only affects failure detection in the affected tests.

## Test plan

- [x] `go test ./cmd/gc -run 'TestControllerStateEstablishesBeadEventCursorBeforePrimingStores|TestControllerStateBeadEventWatcherRetriesSetupErrors' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-nhwmeb-fix-timing-test-flakes-gate.md`](release-gates/ga-nhwmeb-fix-timing-test-flakes-gate.md)
