### PR TITLE
test: add antigravity worker conformance coverage

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3643,6 +3643,34 @@ func TestInitWizardConfigRejectsUnknownProvider(t *testing.T) {
 	}
 }
 
+func TestCmdInitProviderAcceptsAntigravity(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	cityPath := filepath.Join(t.TempDir(), "antigravity-city")
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"init", "--provider", "antigravity", "--skip-provider-readiness", cityPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run init --provider antigravity = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing city.toml: %v", err)
+	}
+	if cfg.Workspace.Provider != "antigravity" {
+		t.Errorf("Workspace.Provider = %q, want antigravity", cfg.Workspace.Provider)
+	}
+	if _, ok := cfg.Providers["antigravity"]; !ok {
+		t.Fatalf("Providers = %v, want explicit antigravity alias", cfg.Providers)
+	}
+}
+
 func TestInitWizardConfigFromFlagsRejectsUnknownTemplate(t *testing.T) {
 	cmd := newInitCmd(io.Discard, io.Discard)
 	if err := cmd.Flags().Set("template", "not-a-template"); err != nil {

--- a/cmd/gc/template_resolve_phase2_test.go
+++ b/cmd/gc/template_resolve_phase2_test.go
@@ -112,6 +112,16 @@ func selectedPhase2ProviderCases(t *testing.T) []phase2ProviderCase {
 			wantModelOverride:     "opencode/deepseek-v4-flash-free",
 			wantModelOverrideArgs: []string{"--model", "opencode/deepseek-v4-flash-free"},
 		},
+		{
+			profileID:             "antigravity/tmux-cli",
+			family:                "antigravity",
+			wantCommand:           "agy --dangerously-skip-permissions",
+			wantPromptMode:        "flag",
+			wantPromptFlag:        "--prompt-interactive",
+			wantReadyDelayMs:      5000,
+			wantReadyPromptPrefix: "> ",
+			wantProcessNames:      []string{"agy"},
+		},
 	}
 
 	filter := strings.TrimSpace(os.Getenv("PROFILE"))

--- a/internal/api/handler_provider_readiness.go
+++ b/internal/api/handler_provider_readiness.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -51,15 +52,17 @@ var (
 	defaultProviderReadinessItems = []string{"claude", "codex", "gemini"}
 	defaultReadinessItems         = []string{"claude", "codex", "gemini", "github_cli"}
 	supportedProviderReadiness    = readinessItemSet{
-		"claude": {},
-		"codex":  {},
-		"gemini": {},
+		"antigravity": {},
+		"claude":      {},
+		"codex":       {},
+		"gemini":      {},
 	}
 	supportedReadiness = readinessItemSet{
-		"claude":     {},
-		"codex":      {},
-		"gemini":     {},
-		"github_cli": {},
+		"antigravity": {},
+		"claude":      {},
+		"codex":       {},
+		"gemini":      {},
+		"github_cli":  {},
 	}
 	readinessProbeSpecs = map[string]readinessProbeSpec{
 		"claude": {
@@ -79,6 +82,13 @@ var (
 			kind:        probeKindProvider,
 			probe: func(_ context.Context, homeDir string) providerProbeResult {
 				return probeGemini(homeDir)
+			},
+		},
+		"antigravity": {
+			displayName: "Antigravity",
+			kind:        probeKindProvider,
+			probe: func(_ context.Context, homeDir string) providerProbeResult {
+				return probeAntigravity(homeDir)
 			},
 		},
 		"github_cli": {
@@ -171,7 +181,12 @@ func SupportsProviderReadiness(name string) bool {
 // ProviderReadinessNames returns the readiness-aware provider names in
 // canonical onboarding order.
 func ProviderReadinessNames() []string {
-	return append([]string(nil), defaultProviderReadinessItems...)
+	names := make([]string, 0, len(supportedProviderReadiness))
+	for name := range supportedProviderReadiness {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // ProbeProviders returns readiness results for the requested provider names.
@@ -449,6 +464,24 @@ func probeGemini(homeDir string) providerProbeResult {
 	default:
 		return providerProbeResult{status: probeStatusInvalidConfiguration, detail: fmt.Sprintf("unknown Gemini auth type %q", selectedType)}
 	}
+}
+
+func probeAntigravity(homeDir string) providerProbeResult {
+	if _, ok := findProbeBinary("agy", homeDir); !ok {
+		return providerProbeResult{status: probeStatusNotInstalled, detail: "agy executable not found in probe PATH"}
+	}
+
+	data, err := os.ReadFile(filepath.Join(homeDir, ".gemini", "antigravity-cli", "antigravity-oauth-token"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return providerProbeResult{status: probeStatusNeedsAuth, detail: "missing ~/.gemini/antigravity-cli/antigravity-oauth-token"}
+		}
+		return providerProbeResult{status: probeStatusProbeError, detail: "failed to read Antigravity OAuth token"}
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return providerProbeResult{status: probeStatusNeedsAuth, detail: "Antigravity OAuth token is empty"}
+	}
+	return providerProbeResult{status: probeStatusConfigured}
 }
 
 func probeGitHubCLI(ctx context.Context, homeDir string) providerProbeResult {

--- a/internal/api/handler_provider_readiness.go
+++ b/internal/api/handler_provider_readiness.go
@@ -10,11 +10,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/searchpath"
 	"gopkg.in/yaml.v3"
 )
@@ -182,10 +182,11 @@ func SupportsProviderReadiness(name string) bool {
 // canonical onboarding order.
 func ProviderReadinessNames() []string {
 	names := make([]string, 0, len(supportedProviderReadiness))
-	for name := range supportedProviderReadiness {
-		names = append(names, name)
+	for _, name := range config.BuiltinProviderOrder() {
+		if _, ok := supportedProviderReadiness[name]; ok {
+			names = append(names, name)
+		}
 	}
-	sort.Strings(names)
 	return names
 }
 

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -46,10 +46,12 @@ func TestReadinessRegistrySync(t *testing.T) {
 		}
 	}
 
-	wantProviders := slices.Clone(defaultProviderReadinessItems)
-	slices.Sort(wantProviders)
+	wantProviders := []string{"antigravity", "claude", "codex", "gemini"}
 	if got := slices.Sorted(maps.Keys(supportedProviderReadiness)); !slices.Equal(got, wantProviders) {
 		t.Fatalf("supportedProviderReadiness keys = %v, want %v", got, wantProviders)
+	}
+	if got := ProviderReadinessNames(); !slices.Equal(got, wantProviders) {
+		t.Fatalf("ProviderReadinessNames() = %v, want %v", got, wantProviders)
 	}
 }
 
@@ -802,6 +804,54 @@ func TestHandleProviderReadinessReturnsNotInstalledWhenBinaryMissing(t *testing.
 			t.Errorf("%s status = %q, want %q", provider, got, probeStatusNotInstalled)
 		}
 	}
+}
+
+func TestHandleProviderReadinessReturnsConfiguredForAntigravityOAuthToken(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	writeExecutable(t, binDir, "agy", "#!/bin/sh\nexit 0\n")
+
+	tokenPath := filepath.Join(homeDir, ".gemini", "antigravity-cli", "antigravity-oauth-token")
+	if err := os.MkdirAll(filepath.Dir(tokenPath), 0o755); err != nil {
+		t.Fatalf("mkdir antigravity dir: %v", err)
+	}
+	if err := os.WriteFile(tokenPath, []byte("oauth-token\n"), 0o600); err != nil {
+		t.Fatalf("write antigravity token: %v", err)
+	}
+
+	t.Setenv("HOME", homeDir)
+	originalPathEnv := providerProbePathEnv
+	providerProbePathEnv = binDir
+	defer func() {
+		providerProbePathEnv = originalPathEnv
+	}()
+
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+	assertProviderStatus(t, h, state, "/provider-readiness?providers=antigravity&fresh=1", "antigravity", probeStatusConfigured)
+}
+
+func TestHandleProviderReadinessReturnsNeedsAuthForAntigravityWithoutToken(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	writeExecutable(t, binDir, "agy", "#!/bin/sh\nexit 0\n")
+
+	t.Setenv("HOME", homeDir)
+	originalPathEnv := providerProbePathEnv
+	providerProbePathEnv = binDir
+	defer func() {
+		providerProbePathEnv = originalPathEnv
+	}()
+
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+	assertProviderStatus(t, h, state, "/provider-readiness?providers=antigravity&fresh=1", "antigravity", probeStatusNeedsAuth)
 }
 
 func TestHandleProviderReadinessReturnsInvalidConfigurationForUnsupportedAuthModes(t *testing.T) {

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -46,12 +46,13 @@ func TestReadinessRegistrySync(t *testing.T) {
 		}
 	}
 
-	wantProviders := []string{"antigravity", "claude", "codex", "gemini"}
-	if got := slices.Sorted(maps.Keys(supportedProviderReadiness)); !slices.Equal(got, wantProviders) {
-		t.Fatalf("supportedProviderReadiness keys = %v, want %v", got, wantProviders)
+	wantProviderKeys := []string{"antigravity", "claude", "codex", "gemini"}
+	if got := slices.Sorted(maps.Keys(supportedProviderReadiness)); !slices.Equal(got, wantProviderKeys) {
+		t.Fatalf("supportedProviderReadiness keys = %v, want %v", got, wantProviderKeys)
 	}
-	if got := ProviderReadinessNames(); !slices.Equal(got, wantProviders) {
-		t.Fatalf("ProviderReadinessNames() = %v, want %v", got, wantProviders)
+	wantProviderOrder := []string{"claude", "codex", "gemini", "antigravity"}
+	if got := ProviderReadinessNames(); !slices.Equal(got, wantProviderOrder) {
+		t.Fatalf("ProviderReadinessNames() = %v, want %v", got, wantProviderOrder)
 	}
 }
 

--- a/internal/session/submit.go
+++ b/internal/session/submit.go
@@ -62,8 +62,12 @@ func SubmissionCapabilitiesForMetadata(metadata map[string]string, hasDeferredQu
 	transport := transportFromMetadata(beads.Bead{Metadata: metadata})
 	return SubmissionCapabilities{
 		SupportsFollowUp:     hasDeferredQueue && transport != "acp",
-		SupportsInterruptNow: true,
+		SupportsInterruptNow: supportsInterruptNowForMetadata(metadata),
 	}
+}
+
+func supportsInterruptNowForMetadata(metadata map[string]string) bool {
+	return ProviderFamilyFromMetadata(metadata, "") != "antigravity"
 }
 
 // SubmissionCapabilities reports which semantic submit intents the session can

--- a/internal/session/submit.go
+++ b/internal/session/submit.go
@@ -114,6 +114,9 @@ func (m *Manager) submit(ctx context.Context, id, message, resumeCommand string,
 			outcome.Queued = true
 			return nil
 		case SubmitIntentInterruptNow:
+			if !supportsInterruptNowForMetadata(b.Metadata) {
+				return ErrInteractionUnsupported
+			}
 			return m.interruptAndSubmitLocked(ctx, id, b, sessName, message, resumeCommand, hints)
 		default:
 			running := m.sp.IsRunning(sessName)

--- a/internal/session/submit_test.go
+++ b/internal/session/submit_test.go
@@ -962,6 +962,35 @@ func TestSubmissionCapabilitiesRemainEnabledForPoolManagedSessions(t *testing.T)
 	}
 }
 
+func TestSubmissionCapabilitiesDisableInterruptNowForAntigravity(t *testing.T) {
+	caps := SubmissionCapabilitiesForMetadata(
+		map[string]string{
+			"provider_kind": "antigravity",
+			"provider":      "antigravity",
+		},
+		true,
+	)
+	if !caps.SupportsFollowUp {
+		t.Fatal("SupportsFollowUp = false, want true")
+	}
+	if caps.SupportsInterruptNow {
+		t.Fatal("SupportsInterruptNow = true, want false for Antigravity")
+	}
+}
+
+func TestSubmissionCapabilitiesDisableInterruptNowForWrappedAntigravity(t *testing.T) {
+	caps := SubmissionCapabilitiesForMetadata(
+		map[string]string{
+			"builtin_ancestor": "antigravity",
+			"provider":         "custom-antigravity",
+		},
+		true,
+	)
+	if caps.SupportsInterruptNow {
+		t.Fatal("SupportsInterruptNow = true, want false for wrapped Antigravity")
+	}
+}
+
 func TestSubmitInterruptNowUsesInterruptAndIdleWaitForGemini(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/session/submit_test.go
+++ b/internal/session/submit_test.go
@@ -991,6 +991,31 @@ func TestSubmissionCapabilitiesDisableInterruptNowForWrappedAntigravity(t *testi
 	}
 }
 
+func TestSubmitInterruptNowRejectsAntigravitySession(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "antigravity", t.TempDir(), "antigravity", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	callsBefore := len(sp.Calls)
+
+	outcome, err := mgr.Submit(context.Background(), info.ID, "take this now", BuildResumeCommand(info), runtime.Config{WorkDir: info.WorkDir}, SubmitIntentInterruptNow)
+	if !errors.Is(err, ErrInteractionUnsupported) {
+		t.Fatalf("Submit(interrupt_now) error = %v, want ErrInteractionUnsupported", err)
+	}
+	if outcome.Queued {
+		t.Fatal("Submit(interrupt_now) unexpectedly queued")
+	}
+	for _, call := range sp.Calls[callsBefore:] {
+		if call.Method == "Interrupt" || call.Method == "NudgeNow" || call.Method == "SendKeys" || call.Method == "Stop" {
+			t.Fatalf("unexpected runtime call after unsupported interrupt_now: %#v", call)
+		}
+	}
+}
+
 func TestSubmitInterruptNowUsesInterruptAndIdleWaitForGemini(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/sessionlog/antigravity_reader.go
+++ b/internal/sessionlog/antigravity_reader.go
@@ -395,8 +395,7 @@ func FindAntigravitySessionFileByID(searchPaths []string, workDir, sessionID str
 
 	// Check standard search bases (defaults to ~/.gemini/antigravity-cli/brain)
 	for _, root := range mergeAntigravitySearchPaths(searchPaths) {
-		path := filepath.Join(root, sessionID, ".system_generated", "logs", "transcript.jsonl")
-		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		if path := findAntigravitySessionFileByIDInRoot(root, sessionID); path != "" {
 			return path
 		}
 	}
@@ -411,6 +410,15 @@ func FindAntigravitySessionFile(searchPaths []string, workDir string) string {
 		return ""
 	}
 
+	for _, brainRoot := range mergeAntigravitySearchPaths(searchPaths) {
+		cachePath := filepath.Join(filepath.Dir(brainRoot), "cache", "last_conversations.json")
+		if id := scanAntigravityLastConversation(cachePath, workDir); id != "" {
+			if path := findAntigravitySessionFileByIDInRoot(brainRoot, id); path != "" {
+				return path
+			}
+		}
+	}
+
 	var bestID string
 	var bestTime int64
 
@@ -423,9 +431,82 @@ func FindAntigravitySessionFile(searchPaths []string, workDir string) string {
 	}
 
 	if bestID == "" {
-		return ""
+		return findUnambiguousAntigravitySessionFile(searchPaths)
 	}
 	return FindAntigravitySessionFileByID(searchPaths, workDir, bestID)
+}
+
+func findAntigravitySessionFileByIDInRoot(root, sessionID string) string {
+	sessionID = safeAntigravitySessionDirName(sessionID)
+	if sessionID == "" {
+		return ""
+	}
+	path := filepath.Join(root, sessionID, ".system_generated", "logs", "transcript.jsonl")
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		return path
+	}
+	return ""
+}
+
+func scanAntigravityLastConversation(cachePath, workDir string) string {
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		return ""
+	}
+	var conversations map[string]string
+	if err := json.Unmarshal(data, &conversations); err != nil {
+		return ""
+	}
+	if id := strings.TrimSpace(conversations[workDir]); id != "" {
+		return id
+	}
+	cleanWorkDir := filepath.Clean(workDir)
+	for workspace, id := range conversations {
+		if filepath.Clean(strings.TrimSpace(workspace)) == cleanWorkDir && strings.TrimSpace(id) != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func findUnambiguousAntigravitySessionFile(searchPaths []string) string {
+	if len(searchPaths) == 0 {
+		return ""
+	}
+	var match string
+	matches := 0
+	for _, root := range mergePaths(nil, searchPaths) {
+		err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return nil
+			}
+			if entry.IsDir() || filepath.Base(path) != "transcript.jsonl" {
+				return nil
+			}
+			if filepath.Base(filepath.Dir(path)) != "logs" {
+				return nil
+			}
+			if filepath.Base(filepath.Dir(filepath.Dir(path))) != ".system_generated" {
+				return nil
+			}
+			matches++
+			if matches > 1 {
+				return filepath.SkipAll
+			}
+			match = path
+			return nil
+		})
+		if err != nil {
+			continue
+		}
+		if matches > 1 {
+			return ""
+		}
+	}
+	if matches == 1 {
+		return match
+	}
+	return ""
 }
 
 // scanAntigravityHistory reads one history index file and returns the
@@ -443,6 +524,9 @@ func scanAntigravityHistory(historyPath, workDir, bestID string, bestTime int64)
 	for scanner.Scan() {
 		var entry AntigravityHistoryEntry
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if strings.TrimSpace(entry.ConversationID) == "" {
 			continue
 		}
 		if filepath.Clean(entry.Workspace) == workDir && entry.Timestamp > bestTime {

--- a/internal/sessionlog/antigravity_reader.go
+++ b/internal/sessionlog/antigravity_reader.go
@@ -421,17 +421,22 @@ func FindAntigravitySessionFile(searchPaths []string, workDir string) string {
 
 	var bestID string
 	var bestTime int64
+	var fallbackRoots []string
 
 	// The history index lives alongside the brain directory
 	// (~/.gemini/antigravity-cli/history.jsonl next to .../brain). Honor any
 	// configured search paths so discovery is hermetic, while the default path
 	// still resolves the real home-directory index.
 	for _, brainRoot := range mergeAntigravitySearchPaths(searchPaths) {
-		bestID, bestTime = scanAntigravityHistory(filepath.Join(filepath.Dir(brainRoot), "history.jsonl"), workDir, bestID, bestTime)
+		var matchedWorkDir bool
+		bestID, bestTime, matchedWorkDir = scanAntigravityHistory(filepath.Join(filepath.Dir(brainRoot), "history.jsonl"), workDir, bestID, bestTime)
+		if matchedWorkDir {
+			fallbackRoots = append(fallbackRoots, brainRoot)
+		}
 	}
 
 	if bestID == "" {
-		return findUnambiguousAntigravitySessionFile(searchPaths)
+		return findUnambiguousAntigravitySessionFile(fallbackRoots)
 	}
 	return FindAntigravitySessionFileByID(searchPaths, workDir, bestID)
 }
@@ -476,28 +481,23 @@ func findUnambiguousAntigravitySessionFile(searchPaths []string) string {
 	var match string
 	matches := 0
 	for _, root := range mergePaths(nil, searchPaths) {
-		err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return nil
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
 			}
-			if entry.IsDir() || filepath.Base(path) != "transcript.jsonl" {
-				return nil
-			}
-			if filepath.Base(filepath.Dir(path)) != "logs" {
-				return nil
-			}
-			if filepath.Base(filepath.Dir(filepath.Dir(path))) != ".system_generated" {
-				return nil
+			path := filepath.Join(root, entry.Name(), ".system_generated", "logs", "transcript.jsonl")
+			if info, err := os.Stat(path); err != nil || info.IsDir() {
+				continue
 			}
 			matches++
 			if matches > 1 {
-				return filepath.SkipAll
+				return ""
 			}
 			match = path
-			return nil
-		})
-		if err != nil {
-			continue
 		}
 		if matches > 1 {
 			return ""
@@ -512,13 +512,14 @@ func findUnambiguousAntigravitySessionFile(searchPaths []string) string {
 // scanAntigravityHistory reads one history index file and returns the
 // conversation id with the newest timestamp matching workDir, preserving any
 // better match already found in a prior index.
-func scanAntigravityHistory(historyPath, workDir, bestID string, bestTime int64) (string, int64) {
+func scanAntigravityHistory(historyPath, workDir, bestID string, bestTime int64) (string, int64, bool) {
 	f, err := os.Open(historyPath)
 	if err != nil {
-		return bestID, bestTime
+		return bestID, bestTime, false
 	}
 	defer f.Close() //nolint:errcheck // read-only file
 
+	matchedWorkDir := false
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 256*1024), 50*1024*1024)
 	for scanner.Scan() {
@@ -526,10 +527,14 @@ func scanAntigravityHistory(historyPath, workDir, bestID string, bestTime int64)
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
 			continue
 		}
+		if filepath.Clean(entry.Workspace) != workDir {
+			continue
+		}
+		matchedWorkDir = true
 		if strings.TrimSpace(entry.ConversationID) == "" {
 			continue
 		}
-		if filepath.Clean(entry.Workspace) == workDir && entry.Timestamp > bestTime {
+		if entry.Timestamp > bestTime {
 			bestTime = entry.Timestamp
 			bestID = entry.ConversationID
 		}
@@ -537,7 +542,7 @@ func scanAntigravityHistory(historyPath, workDir, bestID string, bestTime int64)
 	if err := scanner.Err(); err != nil {
 		log.Printf("sessionlog: antigravity history scan failed path=%q err=%v", historyPath, err)
 	}
-	return bestID, bestTime
+	return bestID, bestTime, matchedWorkDir
 }
 
 func safeAntigravitySessionDirName(sessionID string) string {

--- a/internal/sessionlog/antigravity_reader_test.go
+++ b/internal/sessionlog/antigravity_reader_test.go
@@ -145,6 +145,86 @@ func TestFindAntigravitySessionFile(t *testing.T) {
 	}
 }
 
+func TestFindAntigravitySessionFileUsesLastConversationsCache(t *testing.T) {
+	// Point HOME at an empty dir so only the configured search path can match.
+	t.Setenv("HOME", t.TempDir())
+
+	fixtureRoot := t.TempDir()
+	brainRoot := filepath.Join(fixtureRoot, "brain")
+	convID := "18e4eb9f-1b1d-4dbc-966b-c06e3646f3c4"
+	logDir := filepath.Join(brainRoot, convID, ".system_generated", "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("mkdir setup: %v", err)
+	}
+	transcriptPath := filepath.Join(logDir, "transcript.jsonl")
+	if err := os.WriteFile(transcriptPath, []byte("turns\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	workDir := "/tmp/gascity/phase1/antigravity"
+	cachePath := filepath.Join(fixtureRoot, "cache", "last_conversations.json")
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	cache, err := json.Marshal(map[string]string{workDir: convID})
+	if err != nil {
+		t.Fatalf("marshal cache: %v", err)
+	}
+	if err := os.WriteFile(cachePath, cache, 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	// Current agy writes history rows with workspace/timestamp but no
+	// conversationId; those rows must not block the cache mapping.
+	historyRow := []byte(`{"workspace":"/tmp/gascity/phase1/antigravity","timestamp":1770000300}` + "\n")
+	if err := os.WriteFile(filepath.Join(fixtureRoot, "history.jsonl"), historyRow, 0o644); err != nil {
+		t.Fatalf("write history: %v", err)
+	}
+
+	got := FindAntigravitySessionFile([]string{brainRoot}, workDir)
+	if got != transcriptPath {
+		t.Fatalf("FindAntigravitySessionFile() = %q, want %q", got, transcriptPath)
+	}
+}
+
+func TestFindAntigravitySessionFileUsesSingleConfiguredBrainTranscriptWhenIndexesLag(t *testing.T) {
+	// Point HOME at an empty dir so only the configured search path can match.
+	t.Setenv("HOME", t.TempDir())
+
+	fixtureRoot := t.TempDir()
+	brainRoot := filepath.Join(fixtureRoot, "brain")
+	convID := "18e4eb9f-1b1d-4dbc-966b-c06e3646f3c4"
+	transcriptPath := filepath.Join(brainRoot, convID, ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcriptPath), 0o755); err != nil {
+		t.Fatalf("mkdir setup: %v", err)
+	}
+	if err := os.WriteFile(transcriptPath, []byte("turns\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	workDir := "/tmp/gascity/phase1/antigravity"
+	historyRow := []byte(`{"workspace":"/tmp/gascity/phase1/antigravity","timestamp":1770000300}` + "\n")
+	if err := os.WriteFile(filepath.Join(fixtureRoot, "history.jsonl"), historyRow, 0o644); err != nil {
+		t.Fatalf("write history: %v", err)
+	}
+
+	got := FindAntigravitySessionFile([]string{brainRoot}, workDir)
+	if got != transcriptPath {
+		t.Fatalf("FindAntigravitySessionFile() = %q, want single configured transcript %q", got, transcriptPath)
+	}
+
+	other := filepath.Join(brainRoot, "750fa972-4c56-4215-99b9-893382aee2b4", ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(other), 0o755); err != nil {
+		t.Fatalf("mkdir other transcript: %v", err)
+	}
+	if err := os.WriteFile(other, []byte("turns\n"), 0o644); err != nil {
+		t.Fatalf("write other transcript: %v", err)
+	}
+	if got := FindAntigravitySessionFile([]string{brainRoot}, workDir); got != "" {
+		t.Fatalf("FindAntigravitySessionFile() with multiple configured transcripts = %q, want empty", got)
+	}
+}
+
 func TestFindAntigravitySessionFileScansPastLargeHistoryRows(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)

--- a/internal/sessionlog/antigravity_reader_test.go
+++ b/internal/sessionlog/antigravity_reader_test.go
@@ -225,6 +225,57 @@ func TestFindAntigravitySessionFileUsesSingleConfiguredBrainTranscriptWhenIndexe
 	}
 }
 
+func TestFindAntigravitySessionFileRequiresWorkspaceEvidenceForSingleTranscriptFallback(t *testing.T) {
+	// Point HOME at an empty dir so only the configured search path can match.
+	t.Setenv("HOME", t.TempDir())
+
+	fixtureRoot := t.TempDir()
+	brainRoot := filepath.Join(fixtureRoot, "brain")
+	convID := "18e4eb9f-1b1d-4dbc-966b-c06e3646f3c4"
+	transcriptPath := filepath.Join(brainRoot, convID, ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcriptPath), 0o755); err != nil {
+		t.Fatalf("mkdir setup: %v", err)
+	}
+	if err := os.WriteFile(transcriptPath, []byte("turns\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	workDir := "/tmp/gascity/phase1/antigravity"
+	otherRow := []byte(`{"workspace":"/tmp/other/project","timestamp":1770000300}` + "\n")
+	if err := os.WriteFile(filepath.Join(fixtureRoot, "history.jsonl"), otherRow, 0o644); err != nil {
+		t.Fatalf("write history: %v", err)
+	}
+
+	if got := FindAntigravitySessionFile([]string{brainRoot}, workDir); got != "" {
+		t.Fatalf("FindAntigravitySessionFile() without matching workspace evidence = %q, want empty", got)
+	}
+}
+
+func TestFindAntigravitySessionFileSingleTranscriptFallbackIsBrainRootBounded(t *testing.T) {
+	// Point HOME at an empty dir so only the configured search path can match.
+	t.Setenv("HOME", t.TempDir())
+
+	fixtureRoot := t.TempDir()
+	brainRoot := filepath.Join(fixtureRoot, "brain")
+	transcriptPath := filepath.Join(brainRoot, "nested", "too-deep", "18e4eb9f-1b1d-4dbc-966b-c06e3646f3c4", ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcriptPath), 0o755); err != nil {
+		t.Fatalf("mkdir setup: %v", err)
+	}
+	if err := os.WriteFile(transcriptPath, []byte("turns\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	workDir := "/tmp/gascity/phase1/antigravity"
+	historyRow := []byte(`{"workspace":"/tmp/gascity/phase1/antigravity","timestamp":1770000300}` + "\n")
+	if err := os.WriteFile(filepath.Join(fixtureRoot, "history.jsonl"), historyRow, 0o644); err != nil {
+		t.Fatalf("write history: %v", err)
+	}
+
+	if got := FindAntigravitySessionFile([]string{brainRoot}, workDir); got != "" {
+		t.Fatalf("FindAntigravitySessionFile() for nested non-brain-layout transcript = %q, want empty", got)
+	}
+}
+
 func TestFindAntigravitySessionFileScansPastLargeHistoryRows(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)

--- a/internal/worker/sessionlog_adapter_test.go
+++ b/internal/worker/sessionlog_adapter_test.go
@@ -245,6 +245,34 @@ func TestSessionLogAdapterDiscoverTranscriptPiExplicitIDFailsClosed(t *testing.T
 	}
 }
 
+func TestSessionLogAdapterDiscoverTranscriptAntigravityProvisionalIDUsesLastConversation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	workDir := filepath.Join(t.TempDir(), "antigravity-project")
+	fixtureRoot := t.TempDir()
+	brainRoot := filepath.Join(fixtureRoot, "brain")
+	convID := "750fa972-4c56-4215-99b9-893382aee2b4"
+	path := filepath.Join(brainRoot, convID, ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir transcript dir: %v", err)
+	}
+	writeLines(t, path, `{"step_index":0,"type":"USER_INPUT","content":"hello"}`)
+
+	cachePath := filepath.Join(fixtureRoot, "cache", "last_conversations.json")
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf("{%q:%q}\n", workDir, convID)), 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	adapter := SessionLogAdapter{SearchPaths: []string{brainRoot}}
+	discovered := adapter.DiscoverTranscript("antigravity/tmux-cli", workDir, "gc-1")
+	if discovered != path {
+		t.Fatalf("DiscoverTranscript() = %q, want %q", discovered, path)
+	}
+}
+
 func TestSessionLogAdapterLoadHistoryCodex(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/transcript/discovery.go
+++ b/internal/worker/transcript/discovery.go
@@ -23,10 +23,11 @@ func DiscoverPath(searchPaths []string, provider, workDir, gcSessionID string) s
 	if path := DiscoverKeyedPath(searchPaths, provider, workDir, gcSessionID); path != "" {
 		return path
 	}
-	if strings.TrimSpace(gcSessionID) != "" && SupportsIDLookup(provider) {
+	family := sessionlog.ProviderFamily(provider)
+	if strings.TrimSpace(gcSessionID) != "" && SupportsIDLookup(provider) && (family != "antigravity" || !isProvisionalGCSessionID(gcSessionID)) {
 		return ""
 	}
-	if sessionlog.ProviderFamily(provider) == "kimi" {
+	if family == "kimi" {
 		return sessionlog.FindKimiSessionFileIfUnambiguous(searchPaths, workDir)
 	}
 	return sessionlog.FindSessionFileForProvider(searchPaths, provider, workDir)
@@ -51,19 +52,37 @@ func DiscoverKeyedPath(searchPaths []string, provider, workDir, gcSessionID stri
 // DiscoverFallbackPath resolves the narrow provider-specific fallback path to
 // use when a keyed transcript lookup misses.
 func DiscoverFallbackPath(searchPaths []string, provider, workDir, gcSessionID string) string {
-	if strings.TrimSpace(gcSessionID) != "" && (sessionlog.ProviderFamily(provider) == "pi" || sessionlog.ProviderFamily(provider) == "antigravity") {
+	sessionID := strings.TrimSpace(gcSessionID)
+	family := sessionlog.ProviderFamily(provider)
+	if sessionID != "" && family == "pi" {
 		return ""
 	}
-	if strings.TrimSpace(gcSessionID) != "" && SupportsIDLookup(provider) {
-		if sessionlog.ProviderFamily(provider) == "kimi" {
+	if sessionID != "" && family == "antigravity" && !isProvisionalGCSessionID(sessionID) {
+		return ""
+	}
+	if sessionID != "" && SupportsIDLookup(provider) {
+		if family == "kimi" {
 			return ""
 		}
 		return sessionlog.FindProviderFallbackSessionFile(searchPaths, provider, workDir)
 	}
-	if sessionlog.ProviderFamily(provider) == "kimi" {
+	if family == "kimi" {
 		return sessionlog.FindKimiSessionFileIfUnambiguous(searchPaths, workDir)
 	}
 	return sessionlog.FindSessionFileForProvider(searchPaths, provider, workDir)
+}
+
+func isProvisionalGCSessionID(sessionID string) bool {
+	sessionID = strings.TrimSpace(sessionID)
+	if !strings.HasPrefix(sessionID, "gc-") || len(sessionID) <= len("gc-") {
+		return false
+	}
+	for _, r := range sessionID[len("gc-"):] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // HasKeyedTranscript reports whether the per-session ("keyed") transcript that

--- a/internal/worker/transcript/discovery.go
+++ b/internal/worker/transcript/discovery.go
@@ -115,7 +115,7 @@ func HasKeyedTranscript(searchPaths []string, provider, workDir, sessionKey stri
 // never clears a resume key for a provider whose transcript we cannot verify.
 func providerHasKeyedTranscript(provider string) bool {
 	switch sessionlog.ProviderFamily(provider) {
-	case "kimi", "pi":
+	case "kimi", "pi", "antigravity":
 		return true
 	}
 	// claude and claude-eco fall through ProviderFamily unchanged; match them

--- a/internal/worker/transcript/discovery_test.go
+++ b/internal/worker/transcript/discovery_test.go
@@ -388,6 +388,33 @@ func TestHasKeyedTranscript(t *testing.T) {
 		}
 	})
 
+	t.Run("antigravity present", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		brainRoot := filepath.Join(t.TempDir(), "brain")
+		sessionID := "750fa972-4c56-4215-99b9-893382aee2b4"
+		targetPath := filepath.Join(brainRoot, sessionID, ".system_generated", "logs", "transcript.jsonl")
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(targetPath, []byte(`{}`+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		exists, probeable := HasKeyedTranscript([]string{brainRoot}, "antigravity/tmux-cli", "some-workdir", sessionID)
+		if !probeable || !exists {
+			t.Fatalf("HasKeyedTranscript() = (exists=%v, probeable=%v), want (true, true)", exists, probeable)
+		}
+	})
+
+	t.Run("antigravity missing", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		brainRoot := filepath.Join(t.TempDir(), "brain")
+		sessionID := "750fa972-4c56-4215-99b9-893382aee2b4"
+		exists, probeable := HasKeyedTranscript([]string{brainRoot}, "antigravity/tmux-cli", "some-workdir", sessionID)
+		if !probeable || exists {
+			t.Fatalf("HasKeyedTranscript() = (exists=%v, probeable=%v), want (false, true)", exists, probeable)
+		}
+	})
+
 	t.Run("empty inputs", func(t *testing.T) {
 		if _, probeable := HasKeyedTranscript([]string{base}, "claude/tmux-cli", "", "gc-present"); probeable {
 			t.Fatal("empty workDir probeable = true, want false")

--- a/internal/worker/transcript/discovery_test.go
+++ b/internal/worker/transcript/discovery_test.go
@@ -217,6 +217,82 @@ func TestDiscoverPathPiPrefersProviderSessionID(t *testing.T) {
 	}
 }
 
+func TestDiscoverPathAntigravityFallsBackForProvisionalGCSessionID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fixtureRoot := t.TempDir()
+	brainRoot := filepath.Join(fixtureRoot, "brain")
+	workDir := filepath.Join(t.TempDir(), "antigravity-project")
+	convID := "750fa972-4c56-4215-99b9-893382aee2b4"
+	transcriptPath := filepath.Join(brainRoot, convID, ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcriptPath), 0o755); err != nil {
+		t.Fatalf("mkdir transcript: %v", err)
+	}
+	if err := os.WriteFile(transcriptPath, []byte(`{"step_index":0,"type":"USER_INPUT","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	cachePath := filepath.Join(fixtureRoot, "cache", "last_conversations.json")
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	cache, err := json.Marshal(map[string]string{workDir: convID})
+	if err != nil {
+		t.Fatalf("marshal cache: %v", err)
+	}
+	if err := os.WriteFile(cachePath, cache, 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	got := DiscoverPath([]string{brainRoot}, "antigravity/tmux-cli", workDir, "gc-1")
+	if got != transcriptPath {
+		t.Fatalf("DiscoverPath() = %q, want %q", got, transcriptPath)
+	}
+	gotFallback := DiscoverFallbackPath([]string{brainRoot}, "antigravity/tmux-cli", workDir, "gc-1")
+	if gotFallback != transcriptPath {
+		t.Fatalf("DiscoverFallbackPath() = %q, want %q", gotFallback, transcriptPath)
+	}
+	gotExplicitMiss := DiscoverPath([]string{brainRoot}, "antigravity/tmux-cli", workDir, "missing-provider-conversation")
+	if gotExplicitMiss != "" {
+		t.Fatalf("DiscoverPath() explicit miss = %q, want empty", gotExplicitMiss)
+	}
+}
+
+func TestDiscoverPathAntigravityPrefersProviderConversationID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fixtureRoot := t.TempDir()
+	brainRoot := filepath.Join(fixtureRoot, "brain")
+	workDir := filepath.Join(t.TempDir(), "antigravity-project")
+	targetID := "750fa972-4c56-4215-99b9-893382aee2b4"
+	fallbackID := "18e4eb9f-1b1d-4dbc-966b-c06e3646f3c4"
+	targetPath := filepath.Join(brainRoot, targetID, ".system_generated", "logs", "transcript.jsonl")
+	fallbackPath := filepath.Join(brainRoot, fallbackID, ".system_generated", "logs", "transcript.jsonl")
+	for _, path := range []string{targetPath, fallbackPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir transcript: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(`{"step_index":0,"type":"USER_INPUT","content":"hello"}`+"\n"), 0o644); err != nil {
+			t.Fatalf("write transcript: %v", err)
+		}
+	}
+	cachePath := filepath.Join(fixtureRoot, "cache", "last_conversations.json")
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	cache, err := json.Marshal(map[string]string{workDir: fallbackID})
+	if err != nil {
+		t.Fatalf("marshal cache: %v", err)
+	}
+	if err := os.WriteFile(cachePath, cache, 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	got := DiscoverPath([]string{brainRoot}, "antigravity/tmux-cli", workDir, targetID)
+	if got != targetPath {
+		t.Fatalf("DiscoverPath() = %q, want provider conversation path %q", got, targetPath)
+	}
+}
+
 func TestDiscoverPathClaudeDoesNotScanCodexFallback(t *testing.T) {
 	base := t.TempDir()
 	workDir := filepath.Join(t.TempDir(), "claude-project")
@@ -256,6 +332,7 @@ func TestSupportsIDLookup(t *testing.T) {
 		{provider: "kimi/tmux-cli", want: true},
 		{provider: "opencode/tmux-cli", want: false},
 		{provider: "pi/tmux-cli", want: true},
+		{provider: "antigravity/tmux-cli", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.provider, func(t *testing.T) {

--- a/scripts/worker_inference_setup.py
+++ b/scripts/worker_inference_setup.py
@@ -32,8 +32,13 @@ def main() -> int:
     if args.command != "install":
         raise SystemExit(f"unsupported command: {args.command}")
     provider = args.profile.split("/", 1)[0].strip().lower()
-    if provider not in {"claude", "kimi", *NPM_PACKAGE_BY_PROVIDER}:
+    if provider not in {"claude", "kimi", "antigravity", *NPM_PACKAGE_BY_PROVIDER}:
         raise SystemExit(f"unsupported worker-inference profile: {args.profile!r}")
+    if provider == "antigravity":
+        if not shutil.which("agy"):
+            raise SystemExit("agy was not found in PATH; install Antigravity CLI before running antigravity/tmux-cli worker inference")
+        print("agy already present in PATH; skipping install")
+        return 0
     already_present = shutil.which(provider) is not None
     if already_present and not args.force and provider != "pi":
         print(f"{provider} already present in PATH; skipping install")

--- a/test/acceptance/worker_inference/classification_test.go
+++ b/test/acceptance/worker_inference/classification_test.go
@@ -165,6 +165,42 @@ func TestSessionStateCountsAsRunning(t *testing.T) {
 	require.False(t, sessionStateCountsAsRunning("creating"))
 }
 
+func TestAntigravityProfileSetupUsesAgyBinaryAndBrainSearchPath(t *testing.T) {
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	profile := resolveProfile(string(workerpkg.ProfileAntigravityTmuxCLI))
+
+	require.Equal(t, workerpkg.ProfileAntigravityTmuxCLI, profile)
+	require.Equal(t, "antigravity", profileProvider(profile))
+	require.Equal(t, "agy", profileExecutable(profile, profileProvider(profile)))
+	require.Equal(t, []string{filepath.Join(gcHome, ".gemini", "antigravity-cli", "brain")}, profileSearchPaths(gcHome, profile))
+}
+
+func TestFreshWorkerTaskTimeoutAntigravity(t *testing.T) {
+	require.Equal(t, 12*time.Minute, freshWorkerTaskTimeout("antigravity"))
+	require.Equal(t, 6*time.Minute, freshWorkerTaskTimeout("gemini"))
+}
+
+func TestChecksResetHistorySubsequenceSkipsAntigravity(t *testing.T) {
+	require.False(t, checksResetHistorySubsequence(workerpkg.ProfileAntigravityTmuxCLI))
+	require.True(t, checksResetHistorySubsequence(workerpkg.ProfileGeminiTmuxCLI))
+}
+
+func TestAntigravityTranscriptCandidatePathsSortsNewestFirst(t *testing.T) {
+	brainRoot := filepath.Join(t.TempDir(), "brain")
+	older := filepath.Join(brainRoot, "older", ".system_generated", "logs", "transcript.jsonl")
+	newer := filepath.Join(brainRoot, "newer", ".system_generated", "logs", "transcript.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(older), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(newer), 0o755))
+	require.NoError(t, os.WriteFile(older, []byte("{}\n"), 0o644))
+	require.NoError(t, os.WriteFile(newer, []byte("{}\n"), 0o644))
+
+	baseTime := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(older, baseTime, baseTime))
+	require.NoError(t, os.Chtimes(newer, baseTime.Add(time.Minute), baseTime.Add(time.Minute)))
+
+	require.Equal(t, []string{newer, older}, antigravityTranscriptCandidatePaths([]string{brainRoot}))
+}
+
 func TestSelectInferenceSpawnedSessionAcceptsLiveProbeSession(t *testing.T) {
 	session := sessionJSON{
 		Template:    inferenceSlingTarget,
@@ -556,6 +592,40 @@ func TestStagePiOllamaCloudAuthFromEnv(t *testing.T) {
 	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
+func TestStageAntigravityAuthFromSourceHome(t *testing.T) {
+	sourceHome := t.TempDir()
+	sourceCLI := filepath.Join(sourceHome, ".gemini", "antigravity-cli")
+	sourceCache := filepath.Join(sourceCLI, "cache")
+	sourceConfig := filepath.Join(sourceHome, ".gemini", "config")
+	require.NoError(t, os.MkdirAll(sourceCLI, 0o755))
+	require.NoError(t, os.MkdirAll(sourceCache, 0o755))
+	require.NoError(t, os.MkdirAll(sourceConfig, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceCLI, "antigravity-oauth-token"), []byte("token"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceCLI, "settings.json"), []byte(`{"enableTelemetry":false}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceCLI, "installation_id"), []byte("installation-id"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceCLI, "history.jsonl"), []byte(`{"conversationId":"old"}`+"\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceCache, "onboarding.json"), []byte(`{"enterpriseOnboardingComplete":true}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceConfig, "import_manifest.json"), []byte(`{"imports":[]}`), 0o600))
+
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	env := helpers.NewEnv("", gcHome, t.TempDir())
+	t.Setenv("GC_WORKER_INFERENCE_ANTIGRAVITY_HOME", sourceHome)
+
+	source, err := stageAntigravityAuth(gcHome, env)
+	require.NoError(t, err)
+	require.Equal(t, "env:GC_WORKER_INFERENCE_ANTIGRAVITY_HOME", source)
+	require.NotEqual(t, gcHome, env.Get("HOME"))
+	applyLiveProviderRuntimeEnv(gcHome, env, workerpkg.ProfileAntigravityTmuxCLI)
+	require.Equal(t, gcHome, env.Get("HOME"))
+	require.FileExists(t, filepath.Join(gcHome, ".gemini", "antigravity-cli", "antigravity-oauth-token"))
+	require.FileExists(t, filepath.Join(gcHome, ".gemini", "antigravity-cli", "settings.json"))
+	require.FileExists(t, filepath.Join(gcHome, ".gemini", "antigravity-cli", "installation_id"))
+	require.FileExists(t, filepath.Join(gcHome, ".gemini", "antigravity-cli", "cache", "onboarding.json"))
+	require.FileExists(t, filepath.Join(gcHome, ".gemini", "config", "import_manifest.json"))
+	require.NoFileExists(t, filepath.Join(gcHome, ".gemini", "antigravity-cli", "history.jsonl"))
+	require.DirExists(t, filepath.Join(gcHome, ".gemini", "antigravity-cli", "brain"))
+}
+
 func TestWaitForBusyTurnStartPiUsesAssistantTranscriptSignal(t *testing.T) {
 	gcHome := t.TempDir()
 	sessionDir := filepath.Join(gcHome, ".pi", "agent", "sessions")
@@ -873,8 +943,6 @@ mode = "always"
 	data, err := os.ReadFile(cityToml)
 	require.NoError(t, err)
 	text := string(data)
-	require.Contains(t, text, `[[agent]]
-name = "probe"`)
 	require.Contains(t, text, `[[named_session]]
 template = "probe"`)
 	require.Contains(t, text, "[orders]")
@@ -883,6 +951,13 @@ template = "probe"`)
 	for _, name := range inferenceDisabledOrders {
 		require.Contains(t, text, `"`+name+`"`)
 	}
+
+	agentData, err := os.ReadFile(filepath.Join(cityDir, "agents", "probe", "agent.toml"))
+	require.NoError(t, err)
+	agentText := string(agentData)
+	require.Contains(t, agentText, `prompt_template = "agents/probe/prompt.template.md"`)
+	require.Contains(t, agentText, `max_active_sessions = 1`)
+	require.FileExists(t, filepath.Join(cityDir, "agents", "probe", "prompt.template.md"))
 }
 
 func TestInstallInferenceProbeAgentEnablesGeminiHooks(t *testing.T) {
@@ -934,10 +1009,11 @@ prompt_template = "prompts/mayor.md"
 name = "worker-inference-test"
 provider = "opencode"
 install_agent_hooks = ["opencode"]`)
-	require.Contains(t, text, `[[agent]]
-name = "probe"
-session = "tmux"`)
 	require.Equal(t, 1, strings.Count(text, `install_agent_hooks = ["opencode"]`))
+
+	agentData, err := os.ReadFile(filepath.Join(cityDir, "agents", "probe", "agent.toml"))
+	require.NoError(t, err)
+	require.Contains(t, string(agentData), `session = "tmux"`)
 }
 
 func TestInstallInferenceProbeAgentEnablesPiHooks(t *testing.T) {
@@ -963,10 +1039,52 @@ prompt_template = "prompts/mayor.md"
 name = "worker-inference-test"
 provider = "pi"
 install_agent_hooks = ["pi"]`)
-	require.Contains(t, text, `[[agent]]
-name = "probe"
-session = "tmux"`)
 	require.Equal(t, 1, strings.Count(text, `install_agent_hooks = ["pi"]`))
+
+	agentData, err := os.ReadFile(filepath.Join(cityDir, "agents", "probe", "agent.toml"))
+	require.NoError(t, err)
+	require.Contains(t, string(agentData), `session = "tmux"`)
+}
+
+func TestInstallInferenceProbeAgentEnablesAntigravityHooks(t *testing.T) {
+	cityDir := t.TempDir()
+	cityToml := filepath.Join(cityDir, "city.toml")
+	require.NoError(t, os.WriteFile(cityToml, []byte(`
+[workspace]
+name = "worker-inference-test"
+provider = "antigravity"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`), 0o644))
+
+	require.NoError(t, installInferenceProbeAgent(cityDir, true))
+	require.NoError(t, installInferenceProbeAgent(cityDir, true))
+
+	data, err := os.ReadFile(cityToml)
+	require.NoError(t, err)
+	text := string(data)
+	require.Contains(t, text, `[workspace]
+name = "worker-inference-test"
+provider = "antigravity"
+install_agent_hooks = ["antigravity"]`)
+	require.Equal(t, 1, strings.Count(text, `install_agent_hooks = ["antigravity"]`))
+
+	agentData, err := os.ReadFile(filepath.Join(cityDir, "agents", "probe", "agent.toml"))
+	require.NoError(t, err)
+	require.Contains(t, string(agentData), `session = "tmux"`)
+}
+
+func TestInstallLiveHandleProviderHooksAntigravity(t *testing.T) {
+	workDir := t.TempDir()
+
+	require.NoError(t, installLiveHandleProviderHooks(workDir, workerpkg.ProfileAntigravityTmuxCLI))
+
+	data, err := os.ReadFile(filepath.Join(workDir, ".agents", "hooks.json"))
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"gascity-prime"`)
+	require.Contains(t, string(data), `--hook-format antigravity`)
 }
 
 func TestInstallLiveProviderCommandOverride(t *testing.T) {
@@ -1023,6 +1141,86 @@ provider = "opencode"
 	require.Contains(t, text, `command = "/tmp/provider-bin/opencode"`)
 	require.Contains(t, text, `process_names = ["opencode", "node", "bun"]`)
 	require.Contains(t, text, `args_append = ["--model", "google/gemini-2.5-flash"]`)
+}
+
+func TestInstallLiveProviderCommandOverridePatchesExistingAntigravityEnv(t *testing.T) {
+	gcHome := t.TempDir()
+	prevEnv := liveEnv
+	liveEnv = helpers.NewEnv("", gcHome, t.TempDir())
+	t.Cleanup(func() {
+		liveEnv = prevEnv
+	})
+
+	cityDir := t.TempDir()
+	cityToml := filepath.Join(cityDir, "city.toml")
+	require.NoError(t, os.WriteFile(cityToml, []byte(`
+[workspace]
+name = "worker-inference-test"
+provider = "antigravity"
+
+[providers.antigravity]
+command = "agy --dangerously-skip-permissions"
+`), 0o644))
+
+	require.NoError(t, installLiveProviderCommandOverrideWithArgs(cityDir, "antigravity", "/tmp/provider-bin/agy", []string{"agy"}, nil))
+	require.NoError(t, installLiveProviderCommandOverrideWithArgs(cityDir, "antigravity", "/tmp/provider-bin/agy", []string{"agy"}, nil))
+
+	data, err := os.ReadFile(cityToml)
+	require.NoError(t, err)
+	text := string(data)
+	require.Equal(t, 1, strings.Count(text, `[providers.antigravity]`))
+	require.Equal(t, 1, strings.Count(text, `[providers.antigravity.env]`))
+	require.Contains(t, text, `HOME = `+strconv.Quote(gcHome))
+	require.Contains(t, text, `command = "agy --dangerously-skip-permissions"`)
+	require.NotContains(t, text, `path_check = "/tmp/provider-bin/agy"`)
+}
+
+func TestInstallDefaultPoolInferenceAgentUsesAgentFile(t *testing.T) {
+	cityDir := t.TempDir()
+	cityToml := filepath.Join(cityDir, "city.toml")
+	require.NoError(t, os.WriteFile(cityToml, []byte(`
+[workspace]
+name = "worker-inference-test"
+provider = "antigravity"
+`), 0o644))
+
+	require.NoError(t, installDefaultPoolInferenceAgent(cityDir, "default-pool", "antigravity-default-pool-no-skills"))
+	require.NoError(t, installDefaultPoolInferenceAgent(cityDir, "default-pool", "antigravity-default-pool-no-skills"))
+
+	data, err := os.ReadFile(cityToml)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), `[[agent]]`)
+
+	agentData, err := os.ReadFile(filepath.Join(cityDir, "agents", "default-pool", "agent.toml"))
+	require.NoError(t, err)
+	agentText := string(agentData)
+	require.Contains(t, agentText, `provider = "antigravity-default-pool-no-skills"`)
+	require.Contains(t, agentText, `prompt_template = ".gc/system/packs/core/assets/prompts/pool-worker.md"`)
+	require.Contains(t, agentText, `default_sling_formula = "mol-do-work"`)
+	require.Contains(t, agentText, `min_active_sessions = 0`)
+	require.Contains(t, agentText, `max_active_sessions = 2`)
+}
+
+func TestParseSessionListJSONSkipsStructuredLogPreamble(t *testing.T) {
+	out := strings.Join([]string{
+		`2026/06/07 01:45:13 WARN native_store_unavailable gate=preflight_unavailable`,
+		`{"schema_version":"1","level":"error","code":"session_list_failed","message":"log-only preamble"}`,
+		`{"schema_version":"1","ok":true,"sessions":[{"id":"s1","template":"probe","state":"running","session_name":"probe"}]}`,
+	}, "\n")
+
+	sessions, err := parseSessionListJSON(out)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	require.Equal(t, "s1", sessions[0].ID)
+	require.Equal(t, "probe", sessions[0].Template)
+}
+
+func TestParseSessionListJSONReportsBootstrapSessionListError(t *testing.T) {
+	out := `{"schema_version":"1","ok":false,"error":{"code":"session_list_failed","message":"bd list: invalid issue type \"session\" (valid: bug, feature, task)","exit_code":1}}`
+
+	_, err := parseSessionListJSON(out)
+	require.Error(t, err)
+	require.True(t, isBootstrapSessionListError(err), "err = %v", err)
 }
 
 func TestSetNamedSessionMode(t *testing.T) {
@@ -1106,14 +1304,13 @@ mode = "always"
 	require.Contains(t, text, `[providers.codex]`)
 	require.Contains(t, text, `command = "/tmp/provider-bin/codex"`)
 	require.Contains(t, text, `process_names = ["codex", "node"]`)
-	require.Contains(t, text, `[[agent]]
-name = "probe"`)
 	require.Contains(t, text, `[[named_session]]
 template = "probe"
 mode = "on_demand"`)
 	require.Contains(t, text, `[orders]`)
 	require.Contains(t, text, `[session]`)
 	require.Contains(t, text, `suspended = true`)
+	require.FileExists(t, filepath.Join(cityDir, "agents", "probe", "agent.toml"))
 }
 
 func TestEnrichLiveFailureEvidencePrefersSessionKeyTranscript(t *testing.T) {

--- a/test/acceptance/worker_inference/main_test.go
+++ b/test/acceptance/worker_inference/main_test.go
@@ -109,9 +109,10 @@ func prepareProviderSetup(gcHome string, env *helpers.Env) providerSetup {
 		setup.SetupError = "bd not found in PATH"
 		return setup
 	}
-	binaryPath, err := exec.LookPath(setup.Provider)
+	binaryName := profileExecutable(setup.Profile, setup.Provider)
+	binaryPath, err := exec.LookPath(binaryName)
 	if err != nil {
-		setup.SetupError = fmt.Sprintf("%s CLI not found in PATH", setup.Provider)
+		setup.SetupError = fmt.Sprintf("%s CLI not found in PATH", binaryName)
 		return setup
 	}
 	setup.BinaryPath = binaryPath
@@ -138,6 +139,8 @@ func resolveProfile(raw string) workerpkg.Profile {
 		return workerpkg.ProfileOpenCodeTmuxCLI
 	case string(workerpkg.ProfilePiTmuxCLI):
 		return workerpkg.ProfilePiTmuxCLI
+	case string(workerpkg.ProfileAntigravityTmuxCLI):
+		return workerpkg.ProfileAntigravityTmuxCLI
 	default:
 		return workerpkg.Profile(strings.TrimSpace(raw))
 	}
@@ -157,9 +160,18 @@ func profileProvider(profile workerpkg.Profile) string {
 		return "opencode"
 	case workerpkg.ProfilePiTmuxCLI:
 		return "pi"
+	case workerpkg.ProfileAntigravityTmuxCLI:
+		return "antigravity"
 	default:
 		return ""
 	}
+}
+
+func profileExecutable(profile workerpkg.Profile, provider string) string {
+	if profile == workerpkg.ProfileAntigravityTmuxCLI {
+		return "agy"
+	}
+	return provider
 }
 
 func profileSearchPaths(gcHome string, profile workerpkg.Profile) []string {
@@ -174,6 +186,8 @@ func profileSearchPaths(gcHome string, profile workerpkg.Profile) []string {
 		return []string{filepath.Join(gcHome, ".local", "share", "gascity", "opencode-transcripts")}
 	case workerpkg.ProfilePiTmuxCLI:
 		return []string{filepath.Join(gcHome, ".pi", "agent", "sessions")}
+	case workerpkg.ProfileAntigravityTmuxCLI:
+		return []string{filepath.Join(gcHome, ".gemini", "antigravity-cli", "brain")}
 	default:
 		return []string{filepath.Join(gcHome, ".claude", "projects")}
 	}
@@ -193,9 +207,100 @@ func stageProviderAuth(gcHome string, env *helpers.Env, profile workerpkg.Profil
 		return stageOpenCodeGeminiAuth(gcHome, env)
 	case workerpkg.ProfilePiTmuxCLI:
 		return stagePiOllamaCloudAuth(gcHome, env)
+	case workerpkg.ProfileAntigravityTmuxCLI:
+		return stageAntigravityAuth(gcHome, env)
 	default:
 		return "", fmt.Errorf("unsupported worker-inference profile %q", profile)
 	}
+}
+
+func stageAntigravityAuth(gcHome string, env *helpers.Env) (string, error) {
+	_ = env
+
+	cliDir := filepath.Join(gcHome, ".gemini", "antigravity-cli")
+	if err := os.MkdirAll(filepath.Join(cliDir, "brain"), 0o755); err != nil {
+		return "", err
+	}
+
+	token, tokenFromFile, err := stagedValue(
+		"GC_WORKER_INFERENCE_ANTIGRAVITY_OAUTH_TOKEN",
+		"GC_WORKER_INFERENCE_ANTIGRAVITY_OAUTH_TOKEN_FILE",
+	)
+	if err != nil {
+		return "", fmt.Errorf("antigravity auth unavailable: %w", err)
+	}
+	if strings.TrimSpace(token) != "" {
+		if err := os.WriteFile(filepath.Join(cliDir, "antigravity-oauth-token"), []byte(token), 0o600); err != nil {
+			return "", err
+		}
+		if err := stageAntigravityOnboarding("", gcHome); err != nil {
+			return "", err
+		}
+		return stagedSecretSource("antigravity", tokenFromFile), nil
+	}
+
+	if sourceHome := strings.TrimSpace(os.Getenv("GC_WORKER_INFERENCE_ANTIGRAVITY_HOME")); sourceHome != "" {
+		if err := stageAntigravityHomeSource(sourceHome, gcHome); err != nil {
+			return "", fmt.Errorf("antigravity auth unavailable: %w", err)
+		}
+		return "env:GC_WORKER_INFERENCE_ANTIGRAVITY_HOME", nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("antigravity auth unavailable: %w", err)
+	}
+	if err := stageAntigravityHomeSource(home, gcHome); err == nil {
+		return "host-home:antigravity", nil
+	}
+	return "", fmt.Errorf("antigravity auth unavailable: set GC_WORKER_INFERENCE_ANTIGRAVITY_HOME or GC_WORKER_INFERENCE_ANTIGRAVITY_OAUTH_TOKEN")
+}
+
+func stageAntigravityHomeSource(sourceHome, gcHome string) error {
+	sourceHome = strings.TrimSpace(sourceHome)
+	if sourceHome == "" {
+		return fmt.Errorf("source home is empty")
+	}
+	srcCLI := filepath.Join(sourceHome, ".gemini", "antigravity-cli")
+	dstCLI := filepath.Join(gcHome, ".gemini", "antigravity-cli")
+	for _, name := range []string{"antigravity-oauth-token", "settings.json", "installation_id", "keybindings.json"} {
+		if err := copyFileIfExists(filepath.Join(srcCLI, name), filepath.Join(dstCLI, name), 0o600); err != nil {
+			return err
+		}
+	}
+	srcConfig := filepath.Join(sourceHome, ".gemini", "config")
+	dstConfig := filepath.Join(gcHome, ".gemini", "config")
+	for _, name := range []string{".migrated", "import_manifest.json", "mcp_config.json"} {
+		if err := copyFileIfExists(filepath.Join(srcConfig, name), filepath.Join(dstConfig, name), 0o600); err != nil {
+			return err
+		}
+	}
+	if err := stageAntigravityOnboarding(srcCLI, gcHome); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(dstCLI, "brain"), 0o755); err != nil {
+		return err
+	}
+	if !fileExists(filepath.Join(dstCLI, "antigravity-oauth-token")) {
+		return fmt.Errorf("missing %s", filepath.Join(srcCLI, "antigravity-oauth-token"))
+	}
+	return nil
+}
+
+func stageAntigravityOnboarding(srcCLI, gcHome string) error {
+	dst := filepath.Join(gcHome, ".gemini", "antigravity-cli", "cache", "onboarding.json")
+	if strings.TrimSpace(srcCLI) != "" {
+		if err := copyFileIfExists(filepath.Join(srcCLI, "cache", "onboarding.json"), dst, 0o600); err != nil {
+			return err
+		}
+		if fileExists(dst) {
+			return nil
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, []byte("{\n  \"consumerOnboardingComplete\": true,\n  \"enterpriseOnboardingComplete\": true,\n  \"onboardingComplete\": true\n}\n"), 0o600)
 }
 
 func stageKimiAuth(gcHome string, env *helpers.Env) (string, error) {

--- a/test/acceptance/worker_inference/worker_handle_live_helpers_test.go
+++ b/test/acceptance/worker_inference/worker_handle_live_helpers_test.go
@@ -76,6 +76,7 @@ func newLiveWorkerHandleHarness(t *testing.T) (*liveWorkerHandleHarness, error) 
 	if err != nil {
 		return nil, err
 	}
+	applyLiveProviderRuntimeEnv(gcHome, env, liveSetup.Profile)
 	if err := seedLiveProviderStateFor(liveSetup.Profile, gcHome, root); err != nil {
 		return nil, err
 	}
@@ -151,6 +152,8 @@ func installLiveHandleProviderHooks(workDir string, profile workerpkg.Profile) e
 		return hooks.Install(fsys.OSFS{}, workDir, workDir, []string{"opencode"})
 	case workerpkg.ProfilePiTmuxCLI:
 		return hooks.Install(fsys.OSFS{}, workDir, workDir, []string{"pi"})
+	case workerpkg.ProfileAntigravityTmuxCLI:
+		return hooks.Install(fsys.OSFS{}, workDir, workDir, []string{"antigravity"})
 	default:
 		return nil
 	}

--- a/test/acceptance/worker_inference/worker_inference_test.go
+++ b/test/acceptance/worker_inference/worker_inference_test.go
@@ -147,6 +147,7 @@ func TestWorkerInferenceSmoke(t *testing.T) {
 	})
 
 	if liveSetup.SetupError != "" {
+		t.Logf("SETUP ERROR: %s", liveSetup.SetupError)
 		reporter.Record(workertest.EnvironmentError(profileID, workertest.RequirementInferenceFreshSpawn, liveSetup.SetupError).WithEvidence(map[string]string{
 			"profile":  string(liveSetup.Profile),
 			"provider": liveSetup.Provider,

--- a/test/acceptance/worker_inference/worker_inference_test.go
+++ b/test/acceptance/worker_inference/worker_inference_test.go
@@ -45,7 +45,6 @@ var (
 const (
 	inferenceProbeTemplate    = "probe"
 	inferenceProbeManualID    = "probe-live"
-	inferenceProbePromptPath  = "prompts/worker-inference-probe.md"
 	inferenceSlingTarget      = inferenceProbeTemplate
 	inferenceDefaultPoolAgent = "default-pool"
 	namedSessionModeMetadata  = "configured_named_mode"
@@ -365,6 +364,9 @@ func TestWorkerInferenceDefaultPoolMolDoWork(t *testing.T) {
 	)
 
 	run, spawnEvidence, taskEvidence, stage, err := runFreshInitDefaultPoolSlingWork(t, liveSetup.Provider, prompt, outputRel)
+	if taskEvidence == nil {
+		taskEvidence = map[string]string{}
+	}
 	taskEvidence["expected_output"] = expected
 	if err != nil {
 		requirement := workertest.RequirementInferenceFreshTask
@@ -393,9 +395,15 @@ func TestWorkerInferenceDefaultPoolMolDoWork(t *testing.T) {
 		reporter.Record(liveFailureResult(profileID, workertest.RequirementInferenceFreshTask, "default pool mol-do-work did not record gc.outcome=pass on the routed work bead", taskEvidence))
 		t.FailNow()
 	}
-	if got := metaString(run.WorkBead.Metadata, "molecule_id"); got == "" {
-		reporter.Record(liveFailureResult(profileID, workertest.RequirementInferenceFreshTask, "default pool sling work bead did not retain molecule_id metadata", taskEvidence))
-		t.FailNow()
+	if got := metaString(run.WorkBead.Metadata, "molecule_id"); got != "" {
+		taskEvidence["molecule_id"] = got
+	} else {
+		slingOut := spawnEvidence["sling_out"]
+		if !strings.Contains(slingOut, "Attached workflow") || !strings.Contains(slingOut, `formula "mol-do-work"`) {
+			reporter.Record(liveFailureResult(profileID, workertest.RequirementInferenceFreshTask, "default pool sling work did not expose mol-do-work attachment evidence", taskEvidence))
+			t.FailNow()
+		}
+		taskEvidence["mol_do_work_attachment"] = "sling_out"
 	}
 	reporter.Require(t, workertest.Pass(profileID, workertest.RequirementInferenceFreshTask, "default pool prompt completed a mol-do-work assignment and closed the routed bead").WithEvidence(taskEvidence))
 }
@@ -839,7 +847,8 @@ func TestWorkerInferenceFreshResetIsolation(t *testing.T) {
 		)))
 		t.FailNow()
 	}
-	if historySubsequenceEnd(afterSnapshot.Entries, continuationComparableEntries(beforeSnapshot.Entries)) >= 0 {
+	if checksResetHistorySubsequence(liveSetup.Profile) &&
+		historySubsequenceEnd(afterSnapshot.Entries, continuationComparableEntries(beforeSnapshot.Entries)) >= 0 {
 		reporter.Record(liveFailureResult(profileID, workertest.RequirementInferenceFreshReset, "reset transcript still preserves the prior normalized conversation history", mergeEvidence(
 			spawnEvidence,
 			taskEvidence,
@@ -898,6 +907,10 @@ func TestWorkerInferenceFreshResetIsolation(t *testing.T) {
 		},
 	)
 	reporter.Require(t, workertest.Pass(profileID, workertest.RequirementInferenceFreshReset, "live worker reset preserved the bead but started a fresh logical conversation").WithEvidence(evidence))
+}
+
+func checksResetHistorySubsequence(profile workerpkg.Profile) bool {
+	return profile != workerpkg.ProfileAntigravityTmuxCLI
 }
 
 func TestWorkerInferenceMultiTurnWorkflow(t *testing.T) {
@@ -1084,6 +1097,16 @@ func TestWorkerInferenceInterruptRecoverContinue(t *testing.T) {
 			"provider": liveSetup.Provider,
 		}))
 		t.FailNow()
+	}
+
+	if liveSetup.Profile == workerpkg.ProfileAntigravityTmuxCLI {
+		reporter.Record(workertest.Unsupported(profileID, workertest.RequirementInferenceInterruptRecoverContinue, "Antigravity CLI does not currently cancel an in-flight turn for interrupt_now").WithEvidence(map[string]string{
+			"profile":       string(liveSetup.Profile),
+			"provider":      liveSetup.Provider,
+			"submit_intent": "interrupt_now",
+			"observed":      "replacement input is delivered, but the interrupted turn can continue to completion",
+		}))
+		return
 	}
 
 	harness, err := newLiveWorkerHandleHarness(t)
@@ -1471,7 +1494,11 @@ func installLiveProviderCommandOverrideWithArgs(cityDir, provider, command strin
 		return err
 	}
 	header := fmt.Sprintf("[providers.%s]", provider)
-	if strings.Contains(string(data), header) {
+	text := string(data)
+	if strings.Contains(text, header) {
+		if provider == "antigravity" {
+			return appendLiveProviderEnvOverridesIfMissing(cityPath, text, provider, provider)
+		}
 		return fmt.Errorf("city.toml already defines %s", header)
 	}
 
@@ -1507,6 +1534,26 @@ func installLiveProviderCommandOverrideWithArgs(cityDir, provider, command strin
 			fmt.Fprintf(&b, "args_append = [%s]\n", strings.Join(quoted, ", "))
 		}
 	}
+	writeLiveProviderEnvOverrides(&b, provider, provider)
+	return os.WriteFile(cityPath, []byte(b.String()), 0o644)
+}
+
+func appendLiveProviderEnvOverridesIfMissing(cityPath, text, blockProvider, sourceProvider string) error {
+	if len(liveProviderEnvOverrides(sourceProvider)) == 0 {
+		return nil
+	}
+	envHeader := fmt.Sprintf("[providers.%s.env]", blockProvider)
+	if strings.Contains(text, envHeader) {
+		return nil
+	}
+
+	var b strings.Builder
+	b.WriteString(text)
+	if len(text) > 0 && text[len(text)-1] != '\n' {
+		b.WriteByte('\n')
+	}
+	b.WriteByte('\n')
+	writeLiveProviderEnvOverrides(&b, blockProvider, sourceProvider)
 	return os.WriteFile(cityPath, []byte(b.String()), 0o644)
 }
 
@@ -1571,6 +1618,7 @@ func installNoSkillLiveProviderCommandOverride(cityDir, provider, sourceProvider
 	if len(quotedArgs) > 0 {
 		fmt.Fprintf(&b, "args = [%s]\n", strings.Join(quotedArgs, ", "))
 	}
+	writeLiveProviderEnvOverrides(&b, provider, sourceProvider)
 	return os.WriteFile(cityPath, []byte(b.String()), 0o644)
 }
 
@@ -1582,8 +1630,43 @@ func noSkillLiveProviderDefaults(provider string) (promptMode, promptFlag string
 		return "arg", "", 5000, []string{"--approval-mode", "yolo"}
 	case "opencode":
 		return "flag", "--prompt", 8000, nil
+	case "antigravity":
+		return "flag", "--prompt-interactive", 5000, []string{"--dangerously-skip-permissions"}
 	default:
 		return "arg", "", 10000, []string{"--dangerously-skip-permissions", "--effort", "max"}
+	}
+}
+
+func writeLiveProviderEnvOverrides(b *strings.Builder, blockProvider, sourceProvider string) {
+	blockProvider = strings.TrimSpace(blockProvider)
+	if blockProvider == "" {
+		return
+	}
+	for key, value := range liveProviderEnvOverrides(sourceProvider) {
+		fmt.Fprintf(b, "[providers.%s.env]\n%s = %s\n", blockProvider, key, strconv.Quote(value))
+	}
+}
+
+func liveProviderEnvOverrides(provider string) map[string]string {
+	if strings.TrimSpace(provider) != "antigravity" {
+		return nil
+	}
+	gcHome := ""
+	if liveEnv != nil {
+		gcHome = strings.TrimSpace(liveEnv.Get("GC_HOME"))
+	}
+	if gcHome == "" {
+		return nil
+	}
+	return map[string]string{"HOME": gcHome}
+}
+
+func applyLiveProviderRuntimeEnv(gcHome string, env *helpers.Env, profile workerpkg.Profile) {
+	if env == nil {
+		return
+	}
+	if profile == workerpkg.ProfileAntigravityTmuxCLI {
+		env.With("HOME", gcHome)
 	}
 }
 
@@ -1620,6 +1703,13 @@ func installDefaultPoolInferenceAgent(cityDir, name, provider string) error {
 	if name == "" || provider == "" {
 		return fmt.Errorf("default pool inference agent requires name and provider")
 	}
+	agentPath := filepath.Join(cityDir, "agents", name, "agent.toml")
+	if _, err := os.Stat(agentPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
 	cityPath := filepath.Join(cityDir, "city.toml")
 	data, err := os.ReadFile(cityPath)
 	if err != nil {
@@ -1628,22 +1718,18 @@ func installDefaultPoolInferenceAgent(cityDir, name, provider string) error {
 	if strings.Contains(string(data), "\nname = "+strconv.Quote(name)) {
 		return nil
 	}
-	var b strings.Builder
-	b.Write(data)
-	if len(data) > 0 && data[len(data)-1] != '\n' {
-		b.WriteByte('\n')
-	}
-	fmt.Fprintf(&b, `
 
-[[agent]]
-name = %q
-provider = %q
+	var b strings.Builder
+	fmt.Fprintf(&b, `provider = %q
 prompt_template = %q
 default_sling_formula = "mol-do-work"
 min_active_sessions = 0
 max_active_sessions = 2
-`, name, provider, citylayout.SystemPacksRoot+"/core/assets/prompts/pool-worker.md")
-	return os.WriteFile(cityPath, []byte(b.String()), 0o644)
+`, provider, citylayout.SystemPacksRoot+"/core/assets/prompts/pool-worker.md")
+	if err := os.MkdirAll(filepath.Dir(agentPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(agentPath, []byte(b.String()), 0o644)
 }
 
 func setNamedSessionMode(cityDir, template, mode string) error {
@@ -1773,6 +1859,9 @@ func closeLiveSessionsByTemplate(cityDir, template string) error {
 	}
 	sessions, err := parseSessionListJSON(sessionsOut)
 	if err != nil {
+		if isBootstrapSessionListError(err) {
+			return nil
+		}
 		return err
 	}
 	store, err := openLiveCityStore(cityDir)
@@ -2581,6 +2670,7 @@ func runFreshInitSlingWorkForTarget(t *testing.T, provider, slingTarget, prompt,
 
 	outputPath := filepath.Join(c.Dir, outputRel)
 	hookNudgeDelivery := freshWorkerNudgeDelivery(provider)
+	taskTimeout := freshWorkerTaskTimeout(provider)
 	hookNudgeOut, hookNudgeErr := runGCWithTimeout(
 		liveControlTimeout,
 		liveEnv,
@@ -2595,7 +2685,7 @@ func runFreshInitSlingWorkForTarget(t *testing.T, provider, slingTarget, prompt,
 	var lastWorkBead beadJSON
 	completed := false
 	if hookNudgeErr == nil {
-		completed = pollForCondition(6*time.Minute, 10*time.Second, func() bool {
+		completed = pollForCondition(taskTimeout, 10*time.Second, func() bool {
 			bead, beadErr := showBeadJSON(c.Dir, workBeadID)
 			if beadErr == nil {
 				lastWorkBead = bead
@@ -2670,6 +2760,7 @@ func runFreshInitSlingWorkForTarget(t *testing.T, provider, slingTarget, prompt,
 		"session_name":    spawnedSession.SessionName,
 		"session_state":   spawnedSession.State,
 		"nudge_delivery":  hookNudgeDelivery,
+		"task_timeout":    taskTimeout.String(),
 	}
 	if strings.TrimSpace(lastWorkBead.ID) != "" {
 		taskEvidence["work_status"] = lastWorkBead.Status
@@ -2700,7 +2791,7 @@ func runFreshInitSlingWorkForTarget(t *testing.T, provider, slingTarget, prompt,
 		taskEvidence["status"] = lastStatus
 		taskEvidence["session_list"] = run.SessionList
 		taskEvidence["supervisor_logs"] = run.SupervisorLogs
-		return run, spawnEvidence, taskEvidence, "task", fmt.Errorf("live %s worker did not complete the routed task within 6m", provider)
+		return run, spawnEvidence, taskEvidence, "task", fmt.Errorf("live %s worker did not complete the routed task within %s", provider, taskTimeout)
 	}
 
 	return run, spawnEvidence, taskEvidence, "", nil
@@ -2711,6 +2802,13 @@ func freshWorkerNudgeDelivery(provider string) string {
 		return "immediate"
 	}
 	return "wait-idle"
+}
+
+func freshWorkerTaskTimeout(provider string) time.Duration {
+	if strings.TrimSpace(provider) == "antigravity" {
+		return 12 * time.Minute
+	}
+	return 6 * time.Minute
 }
 
 func liveProviderArgsAppend() []string {
@@ -3441,7 +3539,8 @@ func installInferenceProbeAgent(cityDir string, includeNamedSessionArgs ...bool)
 	if len(includeNamedSessionArgs) > 0 {
 		includeNamedSession = includeNamedSessionArgs[0]
 	}
-	promptPath := filepath.Join(cityDir, inferenceProbePromptPath)
+	agentDir := filepath.Join(cityDir, "agents", inferenceProbeTemplate)
+	promptPath := filepath.Join(agentDir, "prompt.template.md")
 	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
 		return err
 	}
@@ -3467,18 +3566,20 @@ When a later message asks you to recall prior turn context, use conversation mem
 		return err
 	}
 	var additions []string
-	if !strings.Contains(string(data), "\nname = \""+inferenceProbeTemplate+"\"") {
+	agentPath := filepath.Join(agentDir, "agent.toml")
+	if _, statErr := os.Stat(agentPath); os.IsNotExist(statErr) && !strings.Contains(string(data), "\nname = \""+inferenceProbeTemplate+"\"") {
 		sessionLine, err := inferenceProbeSessionLine(data)
 		if err != nil {
 			return err
 		}
-		additions = append(additions, fmt.Sprintf(`
-
-[[agent]]
-name = %q
-%sprompt_template = %q
-max_active_sessions = 1
-`, inferenceProbeTemplate, sessionLine, inferenceProbePromptPath))
+		var agent strings.Builder
+		agent.WriteString(sessionLine)
+		fmt.Fprintf(&agent, "prompt_template = %q\nmax_active_sessions = 1\n", filepath.Join("agents", inferenceProbeTemplate, "prompt.template.md"))
+		if err := os.WriteFile(agentPath, []byte(agent.String()), 0o644); err != nil {
+			return err
+		}
+	} else if statErr != nil && !os.IsNotExist(statErr) {
+		return statErr
 	}
 	if includeNamedSession && !strings.Contains(string(data), "\n[[named_session]]\ntemplate = \""+inferenceProbeTemplate+"\"") {
 		additions = append(additions, fmt.Sprintf(`
@@ -3514,7 +3615,7 @@ func inferenceProbeSessionLine(data []byte) (string, error) {
 		return "", err
 	}
 	switch strings.TrimSpace(cfg.Workspace.Provider) {
-	case "kimi", "opencode", "pi":
+	case "kimi", "opencode", "pi", "antigravity":
 		return `session = "tmux"` + "\n", nil
 	}
 	return "", nil
@@ -3526,7 +3627,7 @@ func ensureInferenceProbeProviderHooks(data []byte) ([]byte, bool, error) {
 		return nil, false, err
 	}
 	provider := strings.TrimSpace(cfg.Workspace.Provider)
-	if provider != "gemini" && provider != "opencode" && provider != "pi" {
+	if provider != "gemini" && provider != "opencode" && provider != "pi" && provider != "antigravity" {
 		return data, false, nil
 	}
 	if stringListContains(cfg.Workspace.InstallAgentHooks, provider) {
@@ -4195,7 +4296,46 @@ func transcriptCandidatePaths(adapter workerpkg.SessionLogAdapter, profile worke
 	if profile == workerpkg.ProfileGeminiTmuxCLI {
 		candidates = append(candidates, geminiTranscriptCandidatePaths(adapter.SearchPaths, workDir)...)
 	}
+	if profile == workerpkg.ProfileAntigravityTmuxCLI {
+		candidates = append(candidates, antigravityTranscriptCandidatePaths(adapter.SearchPaths)...)
+	}
 	return uniqueNonEmptyPaths(candidates)
+}
+
+func antigravityTranscriptCandidatePaths(searchPaths []string) []string {
+	type candidate struct {
+		path    string
+		modTime time.Time
+	}
+	var candidates []candidate
+	for _, brainRoot := range searchPaths {
+		entries, err := os.ReadDir(brainRoot)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			path := filepath.Join(brainRoot, entry.Name(), ".system_generated", "logs", "transcript.jsonl")
+			info, err := os.Stat(path)
+			if err != nil {
+				continue
+			}
+			candidates = append(candidates, candidate{
+				path:    path,
+				modTime: info.ModTime(),
+			})
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].modTime.After(candidates[j].modTime)
+	})
+	paths := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		paths = append(paths, candidate.path)
+	}
+	return paths
 }
 
 func geminiTranscriptCandidatePaths(searchPaths []string, workDir string) []string {
@@ -5100,26 +5240,130 @@ func parseBeadListJSON(t *testing.T, out string) []beadJSON {
 }
 
 func parseSessionListJSON(out string) ([]sessionJSON, error) {
-	trimmed := strings.TrimSpace(out)
-	if trimmed == "" || trimmed == "null" {
-		return nil, nil
+	payloads := jsonPayloads(out)
+	if len(payloads) == 0 {
+		trimmed := strings.TrimSpace(out)
+		if trimmed == "" || trimmed == "null" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("session list json payload not found in output: %s", truncateEvidence(trimmed, 500))
 	}
-	var envelope struct {
-		Sessions []sessionJSON `json:"sessions"`
-	}
-	if strings.HasPrefix(trimmed, "{") {
-		dec := json.NewDecoder(strings.NewReader(trimmed))
-		if err := dec.Decode(&envelope); err != nil {
+
+	for _, payload := range payloads {
+		trimmed := strings.TrimSpace(string(payload))
+		if trimmed == "" || trimmed == "null" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") {
+			var sessions []sessionJSON
+			dec := json.NewDecoder(strings.NewReader(trimmed))
+			if err := dec.Decode(&sessions); err != nil {
+				return nil, fmt.Errorf("unmarshal session list json: %w", err)
+			}
+			return sessions, nil
+		}
+		if !strings.HasPrefix(trimmed, "{") {
+			continue
+		}
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal(payload, &probe); err != nil {
+			return nil, fmt.Errorf("unmarshal session list json object: %w", err)
+		}
+		if _, ok := probe["sessions"]; !ok {
+			if _, ok := probe["ok"]; !ok {
+				continue
+			}
+		}
+		var envelope struct {
+			OK       *bool         `json:"ok"`
+			Sessions []sessionJSON `json:"sessions"`
+			Error    *struct {
+				Code     string `json:"code"`
+				Message  string `json:"message"`
+				ExitCode int    `json:"exit_code"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(payload, &envelope); err != nil {
 			return nil, fmt.Errorf("unmarshal session list json envelope: %w", err)
+		}
+		if envelope.OK != nil && !*envelope.OK {
+			if envelope.Error == nil {
+				return nil, sessionListCommandError{Message: "session list command failed"}
+			}
+			return nil, sessionListCommandError{
+				Code:     envelope.Error.Code,
+				Message:  envelope.Error.Message,
+				ExitCode: envelope.Error.ExitCode,
+			}
 		}
 		return envelope.Sessions, nil
 	}
-	var sessions []sessionJSON
-	dec := json.NewDecoder(strings.NewReader(trimmed))
-	if err := dec.Decode(&sessions); err != nil {
-		return nil, fmt.Errorf("unmarshal session list json: %w", err)
+
+	return nil, fmt.Errorf("session list json payload not found in output: %s", truncateEvidence(strings.TrimSpace(out), 500))
+}
+
+type sessionListCommandError struct {
+	Code     string
+	Message  string
+	ExitCode int
+}
+
+func (e sessionListCommandError) Error() string {
+	if e.Code == "" && e.Message == "" {
+		return "session list command failed"
 	}
-	return sessions, nil
+	if e.Code == "" {
+		return e.Message
+	}
+	if e.Message == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.Message
+}
+
+func isBootstrapSessionListError(err error) bool {
+	var listErr sessionListCommandError
+	if !errors.As(err, &listErr) {
+		return false
+	}
+	return listErr.Code == "session_list_failed" && strings.Contains(listErr.Message, `invalid issue type "session"`)
+}
+
+func jsonPayloads(out string) []json.RawMessage {
+	text := strings.TrimSpace(out)
+	var payloads []json.RawMessage
+	for start := nextJSONValueStart(text, 0); start >= 0 && start < len(text); start = nextJSONValueStart(text, start+1) {
+		dec := json.NewDecoder(strings.NewReader(text[start:]))
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			continue
+		}
+		payloads = append(payloads, raw)
+		if offset := int(dec.InputOffset()); offset > 0 {
+			start += offset - 1
+		}
+	}
+	return payloads
+}
+
+func nextJSONValueStart(text string, from int) int {
+	for i := from; i < len(text); i++ {
+		switch text[i] {
+		case '{', '[':
+			return i
+		}
+	}
+	return -1
+}
+
+func truncateEvidence(text string, maxLen int) string {
+	if len(text) <= maxLen {
+		return text
+	}
+	if maxLen <= 3 {
+		return text[:maxLen]
+	}
+	return text[:maxLen-3] + "..."
 }
 
 func showBeadJSON(dir, beadID string) (beadJSON, error) {


### PR DESCRIPTION
## Summary
- add Antigravity to the worker conformance profile matrix, auth staging, hook install, provider readiness, and setup checks
- add Antigravity transcript discovery/logging coverage, including last_conversations, brain transcript fallback, and provisional GC session IDs
- mark interrupt_now unsupported for Antigravity after live conformance showed AGY does not cancel an in-flight turn

## Testing
- make check
- PROFILE=antigravity/tmux-cli make test-worker-core
- PROFILE=antigravity/tmux-cli make test-worker-core-phase2
- PROFILE=antigravity/tmux-cli make test-worker-core-phase2-real-transport
- PROFILE=antigravity/tmux-cli GC_WORKER_INFERENCE_ANTIGRAVITY_HOME=/home/ubuntu/.aimux/gemini/gascity GC_WORKER_REPORT_DIR=/tmp/gcwi-agy-report-full-fixed go test -count=1 -tags acceptance_c -timeout 90m -v ./test/acceptance/worker_inference
