### PR TITLE
ci: upgrade dorny/paths-filter v3 → v4.0.1 (ga-bsldwr)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       suite_mode: ${{ steps.coverage.outputs.suite_mode }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -76,7 +76,7 @@ jobs:
           repository: ${{ inputs.head_repo || github.repository }}
           ref: ${{ inputs.head_sha || github.sha }}
           persist-credentials: false
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary

- Upgrades `dorny/paths-filter` from v3 (d1c1ffe, Node.js 20) to v4.0.1 (fbd0ab8, Node.js 24) in both `.github/workflows/ci.yml` and `.github/workflows/review-formulas.yml`
- v4 is a runtime-only upgrade: no API changes, same filter syntax
- Fixes the `fatal: shallow file has changed since we read it` flake seen in CI run [27078301060](https://github.com/gastownhall/gascity/actions/runs/27078301060/job/79919443484)

## Motivation

GitHub is forcing Node.js 20 actions to Node.js 24 starting **2026-06-16** (10 days). Without this update, `dorny/paths-filter` will be running on an unsupported Node.js runtime. The v4.0.0 changelog is a single commit: "feat: update action runtime to node24".

## Test plan

- [ ] CI passes on this PR (routing step should succeed and the Node.js 20 deprecation warning should be gone for `dorny/paths-filter`)
- [ ] Verify `review-formulas routing` job passes without the shallow-file error

🤖 Generated with [Claude Code](https://claude.com/claude-code)