### PR TITLE
ci: extend Go-stdlib CVE bypass to 2026-07-07

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,8 +1,10 @@
 vulnerabilities:
-  # Go stdlib CVEs disclosed 2026-05-12 (Go 1.26.2). Fixed in Go 1.25.10
-  # and 1.26.3 upstream. Our own gc binary builds against Go 1.26.3 (see
-  # go.mod), but the upstream gh and dolt distributions still ship a
-  # 1.26.2 stdlib until cli/cli and dolthub/dolt cut new releases.
+  # Go stdlib CVEs disclosed 2026-05-12. Fixed in Go 1.25.10 / 1.26.3 for
+  # the first batch; Go 1.26.4 / 1.25.11 for CVE-2026-42504. As of
+  # 2026-06-07: cli/cli v2.93.0 specifies toolchain go1.26.3; dolthub/dolt
+  # v2.1.4 uses go 1.26.2. Neither meets the Go 1.26.4+ bar for 42504.
+  # gc itself builds against Go 1.26.3 (go.mod). Durable fix tracked in
+  # ga-frh27v; remove entries once all binaries are rebuilt against 1.26.4+.
   - id: CVE-2026-33811
     paths:
       - "usr/bin/gh"
@@ -10,7 +12,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
+    expired_at: 2026-07-07
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-33814
     paths:
@@ -19,7 +21,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
+    expired_at: 2026-07-07
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-39820
     paths:
@@ -28,7 +30,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
+    expired_at: 2026-07-07
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-39823
     paths:
@@ -37,7 +39,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
+    expired_at: 2026-07-07
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-39825
     paths:
@@ -46,7 +48,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
+    expired_at: 2026-07-07
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-39826
     paths:
@@ -55,7 +57,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
+    expired_at: 2026-07-07
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-39836
     paths:
@@ -64,7 +66,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
+    expired_at: 2026-07-07
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-42499
     paths:
@@ -73,7 +75,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
+    expired_at: 2026-07-07
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-42504
     paths:
@@ -83,7 +85,7 @@ vulnerabilities:
       - "usr/local/bin/dolt"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
+    expired_at: 2026-07-07
     statement: Go stdlib MIME-header DoS (CVE-2026-42504), fixed in Go 1.26.4 / 1.25.11. Upstream gh, bd, br, dolt, and kubectl still embed an older Go stdlib; gc is our own binary (built with Go 1.26.3) and will be addressed by bumping to Go 1.26.4+ (tracked separately); remove entry once all binaries are rebuilt.
   - id: CVE-2026-41602
     paths:

--- a/release-gates/ga-85ytyr-trivy-cve-bypass-extension-gate.md
+++ b/release-gates/ga-85ytyr-trivy-cve-bypass-extension-gate.md
@@ -25,7 +25,7 @@ binary paths. The checklist itself is the only post-test branch addition.
 | 3 | Tests pass | PASS | `make test` passed in clean worktree `/tmp/gascity-deploy-ga-85ytyr.rgvElz`. `go vet ./...` passed. |
 | 4 | No high-severity review findings open | PASS | Review notes for `ga-sli97h` report `Blockers: None`; security finding is acknowledged and time-bounded, with durable fix tracked separately in `ga-frh27v`. |
 | 5 | Final branch is clean | PASS | Pre-gate-file status was clean. After adding this checklist and committing it, `git status --short` must remain clean before push. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-base origin/main HEAD` returned `f158b382320b68e743adc6696b1662918e632f11`; `git merge-tree origin/main HEAD` completed without conflicts; GitHub PR #3190 reports `mergeStateStatus: CLEAN`. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base origin/main HEAD` returned `f158b382320b68e743adc6696b1662918e632f11`; `git merge-tree origin/main HEAD` completed without conflicts. After the gate commit, GitHub PR #3190 reports `mergeable: MERGEABLE`; `mergeStateStatus: BLOCKED` reflects pending required checks, not a merge conflict. |
 | 7 | Single feature theme | PASS | Commit set touches one subsystem/file: container vulnerability scan bypass policy in `.trivyignore.yaml`. No unrelated behavior or package changes are included. |
 
 ## Commands
@@ -38,6 +38,7 @@ make test
 go vet ./...
 git merge-tree origin/main HEAD
 gh pr view 3190 --json mergeStateStatus
+gh pr view 3190 --json mergeable,statusCheckRollup
 ```
 
 ## Verdict

--- a/release-gates/ga-85ytyr-trivy-cve-bypass-extension-gate.md
+++ b/release-gates/ga-85ytyr-trivy-cve-bypass-extension-gate.md
@@ -1,0 +1,45 @@
+# Release Gate: ga-85ytyr trivy CVE bypass extension
+
+Date: 2026-06-07
+
+Bead: ga-85ytyr
+Source review bead: ga-sli97h
+PR: https://github.com/gastownhall/gascity/pull/3190
+Feature branch: builder/ga-kgge4f-trivy-bypass-extend
+Implementation commit tested: fa4aa602b95921216dd6126fe904ce45b935d5ed
+Base: origin/main at f158b382320b68e743adc6696b1662918e632f11
+
+## Summary
+
+One-file CI scan policy update in `.trivyignore.yaml`: the nine Go-stdlib CVE
+bypass entries that expired on 2026-06-12 now expire on 2026-07-07. The change
+does not add new CVE IDs and keeps the suppressions tied to the same upstream
+binary paths. The checklist itself is the only post-test branch addition.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-sli97h` shows `REVIEW VERDICT: PASS`, close reason `pass`, commit `fa4aa602b95921216dd6126fe904ce45b935d5ed`, and branch `builder/ga-kgge4f-trivy-bypass-extend`. |
+| 2 | Acceptance criteria met | PASS | Diff from `origin/main..fa4aa602` modifies only `.trivyignore.yaml`. Focused check passed: CVE ID list unchanged, all nine target CVEs have `expired_at: 2026-07-07`, and no `expired_at: 2026-06-12` remains. |
+| 3 | Tests pass | PASS | `make test` passed in clean worktree `/tmp/gascity-deploy-ga-85ytyr.rgvElz`. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-sli97h` report `Blockers: None`; security finding is acknowledged and time-bounded, with durable fix tracked separately in `ga-frh27v`. |
+| 5 | Final branch is clean | PASS | Pre-gate-file status was clean. After adding this checklist and committing it, `git status --short` must remain clean before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base origin/main HEAD` returned `f158b382320b68e743adc6696b1662918e632f11`; `git merge-tree origin/main HEAD` completed without conflicts; GitHub PR #3190 reports `mergeStateStatus: CLEAN`. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem/file: container vulnerability scan bypass policy in `.trivyignore.yaml`. No unrelated behavior or package changes are included. |
+
+## Commands
+
+```text
+bd show ga-sli97h
+git diff --name-status origin/main..fa4aa602b95921216dd6126fe904ce45b935d5ed
+python3 <focused .trivyignore.yaml suppression check>
+make test
+go vet ./...
+git merge-tree origin/main HEAD
+gh pr view 3190 --json mergeStateStatus
+```
+
+## Verdict
+
+PASS. The branch is eligible for PR update and merge-authority handoff.


### PR DESCRIPTION
## What this changes

This extends the expiration date for nine Go standard-library vulnerability suppressions in `.trivyignore.yaml` from `2026-06-12` to `2026-07-07`. The suppressed CVE IDs and binary paths stay the same; this does not add new vulnerabilities to the bypass list.

The affected entries cover upstream binaries that are still built with Go versions below the fixed levels required by these CVEs. The suppressions remain time-bounded so the container scan keeps failing again if the upstream rebuild work does not land before July 7.

## Review notes

- The only changed product file is `.trivyignore.yaml`; the release-gate markdown is deploy evidence.
- `gc` remains included only for `CVE-2026-42504`, because that CVE requires a Go 1.26.4+ rebuild.
- The durable fix is still to rebuild the affected images once upstream binaries are available with fixed Go toolchains.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] Focused suppression check: CVE ID list unchanged, all nine target entries expire `2026-07-07`, no `2026-06-12` expiry remains
- [x] Release gate: [`release-gates/ga-85ytyr-trivy-cve-bypass-extension-gate.md`](release-gates/ga-85ytyr-trivy-cve-bypass-extension-gate.md)
