### PR TITLE
fix: guard orphan sweep reset races (follow-up to #3140)

### DIFF
--- a/cmd/gc/bead_policy_store.go
+++ b/cmd/gc/bead_policy_store.go
@@ -33,6 +33,8 @@ type beadPolicyGraphStore struct {
 	applier beads.GraphApplyStore
 }
 
+var _ beads.ConditionalAssignmentReleaser = (*beadPolicyStore)(nil)
+
 func wrapStoreWithBeadPolicies(store beads.Store, cfg *config.City) beads.Store {
 	if store == nil {
 		return nil
@@ -153,6 +155,14 @@ func (s *beadPolicyStore) ListOpen(status ...string) ([]beads.Bead, error) {
 		AllowScan: true,
 		TierMode:  beads.TierBoth,
 	})
+}
+
+func (s *beadPolicyStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	releaser, ok := s.Store.(beads.ConditionalAssignmentReleaser)
+	if !ok {
+		return false, beads.ErrConditionalReleaseUnsupported
+	}
+	return releaser.ReleaseIfCurrent(id, expectedAssignee)
 }
 
 func (s *beadPolicyStore) policyForCreate(b beads.Bead) (string, string) {

--- a/cmd/gc/bead_policy_store_test.go
+++ b/cmd/gc/bead_policy_store_test.go
@@ -42,6 +42,38 @@ func underlyingPolicyStoreForTest(store beads.Store) beads.Store {
 	return base
 }
 
+func TestBeadPolicyStorePreservesConditionalAssignmentReleaser(t *testing.T) {
+	backing := beads.NewMemStore()
+	wrapped := wrapStoreWithBeadPolicies(backing, nil)
+	releaser, ok := wrapped.(beads.ConditionalAssignmentReleaser)
+	if !ok {
+		t.Fatalf("wrapped store implements ConditionalAssignmentReleaser = false")
+	}
+	bead, err := wrapped.Create(beads.Bead{Title: "work", Assignee: "worker-1"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	status := "in_progress"
+	if err := wrapped.Update(bead.ID, beads.UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update status: %v", err)
+	}
+
+	released, err := releaser.ReleaseIfCurrent(bead.ID, "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent released = false, want true")
+	}
+	got, err := wrapped.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("released bead = %+v, want open and unassigned", got)
+	}
+}
+
 func (s *captureGraphStore) ApplyGraphPlan(_ context.Context, plan *beads.GraphApplyPlan) (*beads.GraphApplyResult, error) {
 	next := *plan
 	s.plan = &next

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -37,6 +37,8 @@ var bdHeartbeatNow = time.Now
 // (gastownhall/gascity#2079) because both subcommands flow through doBd.
 const bdSilentFallbackExitCode = 4
 
+const bdSilentFallbackUserMessage = "gc bd: managed Dolt unreachable; bd fell back to on-disk auto-import mode. If this command wrote data, that write was NOT persisted. Restart the managed Dolt server (or check connectivity) and retry. (See gastownhall/gascity#2080.)"
+
 // bdStderrScanLimit caps how much of bd's stderr gc retains to scan for the
 // silent-fallback marker. bd emits the marker pair while opening the store —
 // before it runs the subcommand — so the marker, when present, always lands
@@ -79,7 +81,9 @@ in the arguments.
 All arguments after "gc bd" are forwarded to bd unchanged, except the
 gc-only "heartbeat <issue-id>" subcommand, which rewrites to
 "update <issue-id> --set-metadata gc.last_heartbeat_at=<RFC3339 UTC now>"
-so long-running workers can signal liveness to the dashboard.
+so long-running workers can signal liveness to the dashboard, and
+"release-if-current <issue-id> <assignee>", which conditionally resets an
+in-progress assignment only when the bead still has that assignee.
 
 gc bd forces BD_EXPORT_AUTO=false to prevent bd's git auto-export hook
 from wedging the wrapper after printing command output. If you need
@@ -88,7 +92,8 @@ auto-export behavior, invoke bd directly.`,
   gc bd --rig my-project create "New task"
   gc bd show my-project-abc          # auto-detects rig from bead prefix
   gc bd list --rig my-project -s open
-  gc bd heartbeat my-project-abc     # stamp gc.last_heartbeat_at=now`,
+  gc bd heartbeat my-project-abc     # stamp gc.last_heartbeat_at=now
+  gc bd release-if-current my-project-abc worker-1`,
 		DisableFlagParsing: true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			// Plumb doBd's numeric exit code through exitForCode so the
@@ -211,6 +216,13 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if id, expectedAssignee, ok, err := parseBdReleaseIfCurrentArgs(bdArgs); ok || err != nil {
+		if err != nil {
+			fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return doBdReleaseIfCurrent(cityPath, target, id, expectedAssignee, stdout, stderr)
+	}
 	if provider := rawBeadsProviderForScope(target.ScopeRoot, cityPath); !providerUsesBdStoreContract(provider) {
 		fmt.Fprintf(stderr, "gc bd: only supported for bd-backed beads providers (resolved %q for %s)\n", provider, target.ScopeRoot) //nolint:errcheck // best-effort stderr
 		if hint := bdProviderMismatchHint(target.ScopeRoot, provider); hint != "" {
@@ -280,10 +292,53 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	// mask it. (Root cause fixed upstream in beads post-#3691; this surfaces
 	// the symptom for deployments still on stable bd builds.)
 	if bdOutputIndicatesSilentFallback(stderrScan.String()) {
-		fmt.Fprintln(stderr, "gc bd: managed Dolt unreachable; bd fell back to on-disk auto-import mode. If this command wrote data, that write was NOT persisted. Restart the managed Dolt server (or check connectivity) and retry. (See gastownhall/gascity#2080.)") //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, bdSilentFallbackUserMessage) //nolint:errcheck // best-effort stderr
 		return bdSilentFallbackExitCode
 	}
 
+	return 0
+}
+
+func parseBdReleaseIfCurrentArgs(args []string) (id, expectedAssignee string, ok bool, err error) {
+	if len(args) == 0 || args[0] != "release-if-current" {
+		return "", "", false, nil
+	}
+	if len(args) != 3 || invalidBdReleaseIfCurrentArg(args[1]) || invalidBdReleaseIfCurrentArg(args[2]) {
+		return "", "", true, fmt.Errorf("usage: gc bd release-if-current <issue-id> <assignee>")
+	}
+	return args[1], args[2], true, nil
+}
+
+func invalidBdReleaseIfCurrentArg(value string) bool {
+	return value == "" || strings.IndexFunc(value, unicode.IsSpace) >= 0
+}
+
+func doBdReleaseIfCurrent(cityPath string, target execStoreTarget, id, expectedAssignee string, stdout, stderr io.Writer) int {
+	store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc bd release-if-current: opening store: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	releaser, ok := store.(beads.ConditionalAssignmentReleaser)
+	if !ok {
+		fmt.Fprintf(stderr, "gc bd release-if-current: %v for %T\n", beads.ErrConditionalReleaseUnsupported, store) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	released, err := releaser.ReleaseIfCurrent(id, expectedAssignee)
+	if err != nil {
+		if errors.Is(err, beads.ErrBDSilentFallback) {
+			fmt.Fprintf(stderr, "gc bd release-if-current: %v\n", err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintln(stderr, bdSilentFallbackUserMessage)          //nolint:errcheck // best-effort stderr
+			return bdSilentFallbackExitCode
+		}
+		fmt.Fprintf(stderr, "gc bd release-if-current: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if released {
+		fmt.Fprintln(stdout, "released") //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	fmt.Fprintln(stdout, "skipped") //nolint:errcheck // best-effort stdout
 	return 0
 }
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1941,6 +1941,26 @@ func TestGcBdSurfacesSilentFallbackAsLoudError_ClosePath(t *testing.T) {
 	}
 }
 
+func TestGcBdSurfacesSilentFallbackAsLoudError_ReleaseIfCurrentPath(t *testing.T) {
+	silentFallbackTestSetup(t, silentFallbackFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"release-if-current", "demo-abc", "worker-1"}, &stdout, &stderr)
+	if got != bdSilentFallbackExitCode {
+		t.Fatalf("doBd(release-if-current) = %d, want %d (silent-fallback exit code); stderr=%q stdout=%q",
+			got, bdSilentFallbackExitCode, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "managed Dolt unreachable") {
+		t.Fatalf("stderr missing loud-fail message; stderr=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "auto-importing") {
+		t.Fatalf("original bd stderr not passed through; stderr=%q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "released") {
+		t.Fatalf("release-if-current reported success despite silent fallback; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
 // TestGcBdHappyPathExitsZeroWithoutFallbackMarker is the inverse: a clean
 // bd run that produces no auto-import marker must NOT be converted into the
 // loud-fail. This guards against false positives where bd's stderr happens
@@ -2154,4 +2174,160 @@ func TestRewriteBdHeartbeatArgs(t *testing.T) {
 			t.Fatalf("rewriteBdHeartbeatArgs(%q) = %q, want passthrough", in, out)
 		}
 	})
+}
+
+func TestParseBdReleaseIfCurrentArgs(t *testing.T) {
+	id, assignee, ok, err := parseBdReleaseIfCurrentArgs([]string{"release-if-current", "gc-abc", "worker-1"})
+	if err != nil {
+		t.Fatalf("parseBdReleaseIfCurrentArgs unexpected error: %v", err)
+	}
+	if !ok || id != "gc-abc" || assignee != "worker-1" {
+		t.Fatalf("parseBdReleaseIfCurrentArgs = (%q, %q, %v), want gc-abc worker-1 true", id, assignee, ok)
+	}
+	if _, _, ok, err := parseBdReleaseIfCurrentArgs([]string{"list"}); ok || err != nil {
+		t.Fatalf("non-release command parsed as release: ok=%v err=%v", ok, err)
+	}
+	for _, args := range [][]string{
+		{"release-if-current"},
+		{"release-if-current", "gc-abc"},
+		{"release-if-current", "gc-abc", "worker-1", "extra"},
+		{"release-if-current", "", "worker-1"},
+		{"release-if-current", "gc abc", "worker-1"},
+		{"release-if-current", "gc-abc", "worker 1"},
+	} {
+		if _, _, ok, err := parseBdReleaseIfCurrentArgs(args); !ok || err == nil {
+			t.Fatalf("parseBdReleaseIfCurrentArgs(%q) = ok=%v err=%v, want release usage error", args, ok, err)
+		}
+	}
+}
+
+func TestDoBdReleaseIfCurrentUpdatesOnlyMatchingAssignment(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n\n[beads]\nprovider = \"file\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	created, err := store.Create(beads.Bead{Title: "work", Assignee: "worker-1"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Update(created.ID, beads.UpdateOpts{Status: strPtr("in_progress")}); err != nil {
+		t.Fatalf("Update status: %v", err)
+	}
+
+	target := execStoreTarget{ScopeRoot: cityDir, ScopeKind: "city", Prefix: "gc"}
+	var stdout, stderr bytes.Buffer
+	if got := doBdReleaseIfCurrent(cityDir, target, created.ID, "worker-2", &stdout, &stderr); got != 0 {
+		t.Fatalf("doBdReleaseIfCurrent wrong assignee = %d, want 0; stderr=%q", got, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "skipped" {
+		t.Fatalf("wrong-assignee output = %q, want skipped", stdout.String())
+	}
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after skipped release: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-1" {
+		t.Fatalf("skipped release mutated bead: %+v", got)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if got := doBdReleaseIfCurrent(cityDir, target, created.ID, "worker-1", &stdout, &stderr); got != 0 {
+		t.Fatalf("doBdReleaseIfCurrent matching assignee = %d, want 0; stderr=%q", got, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "released" {
+		t.Fatalf("matching-assignee output = %q, want released", stdout.String())
+	}
+	got, err = store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after release: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("released bead = %+v, want open and unassigned", got)
+	}
+}
+
+func TestDoBdReleaseIfCurrentWorksForBdStoreFallback(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	defer func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	}()
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir rig .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatalf("write rig metadata: %v", err)
+	}
+	fakeBin := t.TempDir()
+	sqlLog := filepath.Join(fakeBin, "sql.log")
+	fakeBD := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"sql\" ] && [ \"$2\" = \"--json\" ]; then\n" +
+		"  printf '%s\\n' \"$3\" > " + strconv.Quote(sqlLog) + "\n" +
+		"  printf '{\"rows_affected\":1,\"schema_version\":1}\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"printf 'unexpected bd args:' >&2\n" +
+		"printf ' %s' \"$@\" >&2\n" +
+		"printf '\\n' >&2\n" +
+		"exit 2\n"
+	if err := os.WriteFile(filepath.Join(fakeBin, "bd"), []byte(fakeBD), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setCwd(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_BEADS_FORCE_FALLBACK", "1")
+
+	store, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	if _, ok := underlyingPolicyStoreForTest(store).(*beads.BdStore); !ok {
+		t.Fatalf("openStoreAtForCity returned %T, want policy-wrapped *beads.BdStore", underlyingPolicyStoreForTest(store))
+	}
+
+	target := execStoreTarget{ScopeRoot: rigDir, ScopeKind: "rig", Prefix: "fe"}
+	var stdout, stderr bytes.Buffer
+	if got := doBdReleaseIfCurrent(cityDir, target, "fe-abc", "worker-1", &stdout, &stderr); got != 0 {
+		t.Fatalf("doBdReleaseIfCurrent = %d, want 0; stderr=%q", got, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "released" {
+		t.Fatalf("output = %q, want released", stdout.String())
+	}
+	query, err := os.ReadFile(sqlLog)
+	if err != nil {
+		t.Fatalf("read SQL log: %v", err)
+	}
+	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'fe-abc' AND status = 'in_progress' AND assignee = 'worker-1'"
+	if strings.TrimSpace(string(query)) != wantQuery {
+		t.Fatalf("SQL query = %q, want %q", strings.TrimSpace(string(query)), wantQuery)
+	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -255,7 +255,9 @@ in the arguments.
 All arguments after "gc bd" are forwarded to bd unchanged, except the
 gc-only "heartbeat &lt;issue-id&gt;" subcommand, which rewrites to
 "update &lt;issue-id&gt; --set-metadata gc.last_heartbeat_at=&lt;RFC3339 UTC now&gt;"
-so long-running workers can signal liveness to the dashboard.
+so long-running workers can signal liveness to the dashboard, and
+"release-if-current &lt;issue-id&gt; &lt;assignee&gt;", which conditionally resets an
+in-progress assignment only when the bead still has that assignee.
 
 gc bd forces BD_EXPORT_AUTO=false to prevent bd's git auto-export hook
 from wedging the wrapper after printing command output. If you need
@@ -273,6 +275,7 @@ gc bd --rig my-project list
   gc bd show my-project-abc          # auto-detects rig from bead prefix
   gc bd list --rig my-project -s open
   gc bd heartbeat my-project-abc     # stamp gc.last_heartbeat_at=now
+  gc bd release-if-current my-project-abc worker-1
 ```
 
 ## gc beads

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -222,7 +222,8 @@ EOF
 EOF
 	      exit 0
 	    fi
-	    if [ "$2" = "update" ]; then
+	    if [ "$2" = "release-if-current" ]; then
+	      printf 'released\n'
 	      exit 0
 	    fi
     ;;
@@ -253,11 +254,11 @@ exit 1
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
 	log := string(logData)
-	if !strings.Contains(log, "bd update ga-orphan --status=open --assignee=") {
+	if !strings.Contains(log, "bd release-if-current ga-orphan project/gastown.missing") {
 		t.Fatalf("orphan bead was not reset:\n%s", log)
 	}
 	for _, preserved := range []string{"ga-valid", "ga-pool"} {
-		if strings.Contains(log, "bd update "+preserved+" ") {
+		if strings.Contains(log, "bd release-if-current "+preserved+" ") {
 			t.Fatalf("valid assignee %s was reset:\n%s", preserved, log)
 		}
 	}
@@ -326,7 +327,8 @@ EOF
 EOF
 	      exit 0
 	    fi
-	    if [ "$2" = "update" ]; then
+	    if [ "$2" = "release-if-current" ]; then
+	      printf 'released\n'
 	      exit 0
 	    fi
     ;;
@@ -360,11 +362,11 @@ exit 1
 	if !strings.Contains(log, "config show") {
 		t.Fatalf("fallback config show path was not exercised:\n%s", log)
 	}
-	if !strings.Contains(log, "bd update ga-orphan --status=open --assignee=") {
+	if !strings.Contains(log, "bd release-if-current ga-orphan gastown.missing") {
 		t.Fatalf("orphan bead was not reset:\n%s", log)
 	}
 	for _, preserved := range []string{"ga-valid", "ga-pool"} {
-		if strings.Contains(log, "bd update "+preserved+" ") {
+		if strings.Contains(log, "bd release-if-current "+preserved+" ") {
 			t.Fatalf("valid assignee %s was reset:\n%s", preserved, log)
 		}
 	}
@@ -651,6 +653,106 @@ exit 1
 	}
 }
 
+func TestOrphanSweepUsesConditionalResetAfterRevalidation(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      cat <<'EOF'
+[
+  {"id":"ga-raced-after-show","status":"in_progress","assignee":"project__worker-gc-mc-wisp-raced"}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "show" ] && [ "$3" = "ga-raced-after-show" ] && [ "$4" = "--json" ]; then
+      cat <<'EOF'
+[
+  {"id":"ga-raced-after-show","status":"in_progress","assignee":"project__worker-gc-mc-wisp-raced","metadata":{}}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "show" ] && [ "$3" = "mc-wisp-raced" ] && [ "$4" = "--json" ]; then
+      cat <<'EOF'
+[
+  {"id":"mc-wisp-raced","status":"closed","issue_type":"session","metadata":{"state":"closed"}}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "release-if-current" ] && [ "$3" = "ga-raced-after-show" ] && [ "$4" = "project__worker-gc-mc-wisp-raced" ]; then
+      printf 'skipped\n'
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if strings.Contains(string(out), "orphan-sweep: reset") {
+		t.Fatalf("conditional reset skip was counted as a reset:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "bd show ga-raced-after-show --json") {
+		t.Fatalf("work bead was not revalidated before reset:\n%s", log)
+	}
+	if !strings.Contains(log, "bd release-if-current ga-raced-after-show project__worker-gc-mc-wisp-raced") {
+		t.Fatalf("work bead reset did not use conditional helper:\n%s", log)
+	}
+	if strings.Contains(log, "bd update ga-raced-after-show ") {
+		t.Fatalf("stale bead was reset with unconditional update:\n%s", log)
+	}
+}
+
 func TestOrphanSweepUsesSessionBeadShowWhenSessionListLags(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
@@ -749,6 +851,218 @@ exit 1
 	}
 }
 
+func TestOrphanSweepPreservesWorkWhenSessionBeadProbeErrors(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      cat <<'EOF'
+[
+  {"id":"ga-session-probe-error","status":"in_progress","assignee":"project__worker-gc-mc-wisp-live123"}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "show" ] && [ "$3" = "ga-session-probe-error" ] && [ "$4" = "--json" ]; then
+      cat <<'EOF'
+[
+  {"id":"ga-session-probe-error","status":"in_progress","assignee":"project__worker-gc-mc-wisp-live123","metadata":{"gc.session_name":"project__worker-gc-mc-wisp-live123"}}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "show" ] && [ "$3" = "mc-wisp-live123" ] && [ "$4" = "--json" ]; then
+      printf 'transient read failure\n' >&2
+      exit 2
+    fi
+    if [ "$2" = "release-if-current" ]; then
+      printf 'released\n'
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if !strings.Contains(string(out), "orphan-sweep: reset 0 orphaned beads, skipped 1 unverifiable") {
+		t.Fatalf("unexpected orphan-sweep output:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "bd show mc-wisp-live123 --json") {
+		t.Fatalf("session bead candidate was not probed:\n%s", log)
+	}
+	if strings.Contains(log, "bd release-if-current ga-session-probe-error ") {
+		t.Fatalf("session probe error fell through to reset:\n%s", log)
+	}
+}
+
+func TestOrphanSweepUsesDirectSessionBeadCandidatesWhenSessionListLags(t *testing.T) {
+	tests := []struct {
+		name      string
+		workID    string
+		assignee  string
+		sessionID string
+	}{
+		{
+			name:      "bare session bead assignee",
+			workID:    "ga-bare-session-bead",
+			assignee:  "mc-live-rig-asleep",
+			sessionID: "mc-live-rig-asleep",
+		},
+		{
+			name:      "generic mc suffix",
+			workID:    "ga-generic-mc-suffix",
+			assignee:  "project__worker-gc-mc-live-rig-asleep",
+			sessionID: "mc-live-rig-asleep",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cityDir := t.TempDir()
+			binDir := t.TempDir()
+			gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+			writeExecutable(t, filepath.Join(binDir, "gc"), fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> "$GC_CALL_LOG"
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      cat <<'EOF'
+[
+  {"id":%q,"status":"in_progress","assignee":%q}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "show" ] && [ "$3" = %q ] && [ "$4" = "--json" ]; then
+      cat <<'EOF'
+[
+  {"id":%q,"status":"in_progress","assignee":%q}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "show" ] && [ "$3" = %q ] && [ "$4" = "--json" ]; then
+      cat <<'EOF'
+[
+  {"id":%q,"status":"open","issue_type":"session","metadata":{"state":"active","session_name":%q}}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`, tt.workID, tt.assignee, tt.workID, tt.workID, tt.assignee, tt.sessionID, tt.sessionID, tt.assignee))
+
+			env := map[string]string{
+				"GC_CITY":      cityDir,
+				"GC_CITY_PATH": cityDir,
+				"GC_CALL_LOG":  gcLog,
+				"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+			}
+
+			script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+			cmd := exec.Command(script)
+			cmd.Env = mergeTestEnv(env)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+			}
+			if strings.Contains(string(out), "orphan-sweep: reset") {
+				t.Fatalf("unexpected orphan reset output:\n%s", out)
+			}
+
+			logData, err := os.ReadFile(gcLog)
+			if err != nil {
+				t.Fatalf("ReadFile(gc log): %v", err)
+			}
+			log := string(logData)
+			for _, want := range []string{
+				"bd show " + tt.workID + " --json",
+				"bd show " + tt.sessionID + " --json",
+			} {
+				if !strings.Contains(log, want) {
+					t.Fatalf("missing required gc call %q:\n%s", want, log)
+				}
+			}
+			if strings.Contains(log, "bd update "+tt.workID+" ") {
+				t.Fatalf("session-list lag caused live assigned work to reset:\n%s", log)
+			}
+		})
+	}
+}
+
 func TestOrphanSweepPreservesRigScopedLiveEphemeralSessionAssigneesFromCurrentSchema(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
@@ -825,7 +1139,8 @@ EOF
 EOF
 	      exit 0
 	    fi
-	    if [ "$2" = "update" ]; then
+	    if [ "$2" = "release-if-current" ]; then
+	      printf 'released\n'
 	      exit 0
 	    fi
     ;;
@@ -859,14 +1174,14 @@ exit 1
 	if !strings.Contains(log, "--rig project session list --json") {
 		t.Fatalf("rig-scoped session list was not queried:\n%s", log)
 	}
-	if !strings.Contains(log, "bd update ga-rig-orphan --status=open --assignee=") {
+	if !strings.Contains(log, "bd release-if-current ga-rig-orphan missing-rig-session") {
 		t.Fatalf("rig orphan bead was not reset:\n%s", log)
 	}
-	if !strings.Contains(log, "bd update ga-rig-closed-default-filtered --status=open --assignee=") {
+	if !strings.Contains(log, "bd release-if-current ga-rig-closed-default-filtered project__worker-gc-closed") {
 		t.Fatalf("closed/default-filtered session assignee was not reset:\n%s", log)
 	}
 	for _, preserved := range []string{"ga-rig-live-by-session-name", "ga-rig-live-by-id"} {
-		if strings.Contains(log, "bd update "+preserved+" ") {
+		if strings.Contains(log, "bd release-if-current "+preserved+" ") {
 			t.Fatalf("rig live ephemeral session assignee %s was reset:\n%s", preserved, log)
 		}
 	}
@@ -948,7 +1263,8 @@ EOF
 EOF
 	      exit 0
 	    fi
-	    if [ "$2" = "update" ]; then
+	    if [ "$2" = "release-if-current" ]; then
+	      printf 'released\n'
 	      exit 0
 	    fi
     ;;
@@ -980,12 +1296,15 @@ exit 1
 	}
 	log := string(logData)
 	for _, preserved := range []string{"ga-live-by-id", "ga-live-by-session-name"} {
-		if strings.Contains(log, "bd update "+preserved+" ") {
+		if strings.Contains(log, "bd release-if-current "+preserved+" ") {
 			t.Fatalf("forward-compatible PascalCase session assignee %s was reset:\n%s", preserved, log)
 		}
 	}
-	for _, reset := range []string{"ga-closed-session", "ga-missing-session"} {
-		if !strings.Contains(log, "bd update "+reset+" --status=open --assignee=") {
+	for reset, assignee := range map[string]string{
+		"ga-closed-session":  "vgc-closed",
+		"ga-missing-session": "missing-session",
+	} {
+		if !strings.Contains(log, "bd release-if-current "+reset+" "+assignee) {
 			t.Fatalf("expected %s to be reset:\n%s", reset, log)
 		}
 	}
@@ -1068,7 +1387,8 @@ EOF
 EOF
 	      exit 0
 	    fi
-	    if [ "$2" = "update" ]; then
+	    if [ "$2" = "release-if-current" ]; then
+	      printf 'released\n'
 	      exit 0
 	    fi
     ;;
@@ -1099,12 +1419,15 @@ exit 1
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
 	log := string(logData)
-	for _, reset := range []string{"ga-hq-orphan", "ga-healthy-orphan"} {
-		if !strings.Contains(log, "bd update "+reset+" --status=open --assignee=") {
+	for reset, assignee := range map[string]string{
+		"ga-hq-orphan":      "missing-hq-session",
+		"ga-healthy-orphan": "missing-healthy-session",
+	} {
+		if !strings.Contains(log, "bd release-if-current "+reset+" "+assignee) {
 			t.Fatalf("expected %s to be reset after partial rig failure:\n%s", reset, log)
 		}
 	}
-	if strings.Contains(log, "bd update ga-broken-orphan ") {
+	if strings.Contains(log, "bd release-if-current ga-broken-orphan ") {
 		t.Fatalf("bead from rig with unknown session liveness was reset:\n%s", log)
 	}
 }
@@ -1244,11 +1567,11 @@ func TestOrphanSweepPreservesProtectedInProgressEphemeralMoleculeWisp(t *testing
 			}
 			log := string(logData)
 			lines := nonEmptyLogLines(log)
-			orphanUpdate := "bd update " + tt.orphanID + " --status=open --assignee="
+			orphanUpdate := "bd release-if-current " + tt.orphanID + " " + tt.orphanAssignee
 			if got := countExactLine(lines, orphanUpdate); got != 1 {
 				t.Fatalf("orphan update count = %d, want 1 for %q\n%s", got, orphanUpdate, orphanSweepFailureContext(out, gcLog))
 			}
-			if strings.Contains(log, "bd update "+tt.protectedID+" ") {
+			if strings.Contains(log, "bd release-if-current "+tt.protectedID+" ") {
 				t.Fatalf("protected wisp %s was reset\n%s", tt.protectedID, orphanSweepFailureContext(out, gcLog))
 			}
 			if strings.Contains(log, "UNEXPECTED:") {
@@ -1318,12 +1641,16 @@ if [ "$*" = "session list --json" ]; then
   fi
   exit 0
 fi
-if [ "$*" = "bd update $ORPHAN_SWEEP_ORPHAN_ID --status=open --assignee=" ]; then
+if [ "$*" = "bd release-if-current $ORPHAN_SWEEP_ORPHAN_ID $ORPHAN_SWEEP_ORPHAN_ASSIGNEE" ]; then
+  printf 'released\n'
   exit 0
 fi
 if [ "$*" = "bd show $ORPHAN_SWEEP_ORPHAN_ID --json" ]; then
   printf '[{"id":"%s","status":"in_progress","assignee":"%s","metadata":{}}]\n' "$ORPHAN_SWEEP_ORPHAN_ID" "$ORPHAN_SWEEP_ORPHAN_ASSIGNEE"
   exit 0
+fi
+if [ "$*" = "bd show $ORPHAN_SWEEP_ORPHAN_ASSIGNEE --json" ]; then
+  exit 1
 fi
 printf 'UNEXPECTED: %s\n' "$*" >> "$GC_CALL_LOG"
 printf 'UNEXPECTED: %s\n' "$*" >&2

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -19,8 +19,6 @@ esac
 # shellcheck disable=SC1091
 . "$__SCRIPT_DIR/_bd_trace.sh" "orphan-sweep"
 
-CITY="${GC_CITY:-.}"
-
 # Step 1: Collect in-progress beads from HQ and every rig whose session
 # liveness can be determined.
 # `gc bd list` without --rig is HQ-scoped from the city cwd, so per-rig
@@ -184,13 +182,21 @@ work_bead_still_resettable() {
     current_status=$(printf '%s\n' "$CURRENT_BEAD_JSON" | jq -r "$first_bead_jq | .status // empty" 2>/dev/null) || return 1
     current_assignee=$(printf '%s\n' "$CURRENT_BEAD_JSON" | jq -r "$first_bead_jq | .assignee // empty" 2>/dev/null) || return 1
 
-    [ "$current_status" = "in_progress" ] || return 1
-    [ "$current_assignee" = "$expected_assignee" ] || return 1
+    [ "$current_status" = "in_progress" ] || return 2
+    [ "$current_assignee" = "$expected_assignee" ] || return 2
 }
 
 session_bead_candidates() {
     local assignee="$1"
     local work_json="$2"
+
+    if [ -n "$assignee" ]; then
+        printf '%s\n' "$assignee"
+    fi
+
+    if [[ "$assignee" == *-mc-* ]]; then
+        printf 'mc-%s\n' "${assignee##*-mc-}"
+    fi
 
     printf '%s\n' "$work_json" | jq -r "$first_bead_jq | [
         .metadata[\"gc.session_id\"],
@@ -201,17 +207,35 @@ session_bead_candidates() {
     printf '%s\n' "$assignee" | grep -Eo '[[:alnum:]]+-wisp-[[:alnum:]][[:alnum:]-]*$' || true
 }
 
+session_probe_failure_is_unverifiable() {
+    local session_id="$1"
+    local assignee="$2"
+
+    [ "$session_id" != "$assignee" ] && return 0
+    [[ "$session_id" == mc-* ]] && return 0
+    return 1
+}
+
 session_bead_shows_live_assignment() {
     local assignee="$1"
     local work_json="$2"
     local session_id
     local session_json
     local live_match
+    local probe_failed=0
 
     while IFS= read -r session_id; do
         [ -n "$session_id" ] || continue
-        session_json=$(gc bd show "$session_id" --json 2>/dev/null) || continue
-        live_match=$(printf '%s\n' "$session_json" | jq -r --arg assignee "$assignee" --arg session_id "$session_id" "
+        if ! session_json=$(gc bd show "$session_id" --json 2>/dev/null); then
+            if session_probe_failure_is_unverifiable "$session_id" "$assignee"; then
+                probe_failed=1
+            fi
+            continue
+        fi
+        # Any live session bead at a probed candidate preserves the work. The
+        # CLI does not expose every Go-side identity field, so the fail-safe
+        # direction is to treat candidate liveness as sufficient.
+        if ! live_match=$(printf '%s\n' "$session_json" | jq -r --arg assignee "$assignee" --arg session_id "$session_id" "
             $first_bead_jq
             | select((.issue_type // \"\") == \"session\")
             | select((.status // \"\") != \"closed\")
@@ -227,13 +251,32 @@ session_bead_shows_live_assignment() {
                 or (\$assignee | contains(\$session_id))
             )
             | .id // empty
-        " 2>/dev/null) || live_match=""
+        " 2>/dev/null); then
+            probe_failed=1
+            continue
+        fi
         if [ -n "$live_match" ]; then
             return 0
         fi
     done < <(session_bead_candidates "$assignee" "$work_json")
 
+    [ "$probe_failed" -eq 0 ] || return 2
     return 1
+}
+
+reset_orphan_if_current() {
+    local bead_id="$1"
+    local expected_assignee="$2"
+    local reset_output
+    local reset_state
+
+    reset_output=$(gc bd release-if-current "$bead_id" "$expected_assignee" 2>/dev/null) || return 1
+    reset_state=$(printf '%s\n' "$reset_output" | awk 'NF { print $1; exit }')
+    case "$reset_state" in
+        released) return 0 ;;
+        skipped) return 2 ;;
+        *) return 1 ;;
+    esac
 }
 
 # Step 3: Find orphaned beads (assigned to non-existent agents).
@@ -266,23 +309,44 @@ is_known_agent() {
 }
 
 ORPHANED=0
+UNVERIFIABLE=0
 # Process substitution (not a pipe) keeps the loop body in the parent
 # shell so $ORPHANED survives for the summary message below.
 while IFS=$'\t' read -r bead_id assignee; do
     if ! is_known_agent "$assignee"; then
-        if ! work_bead_still_resettable "$bead_id" "$assignee"; then
+        if work_bead_still_resettable "$bead_id" "$assignee"; then
+            :
+        else
+            recheck_status=$?
+            if [ "$recheck_status" != "2" ]; then
+                UNVERIFIABLE=$((UNVERIFIABLE + 1))
+            fi
             continue
         fi
         if session_bead_shows_live_assignment "$assignee" "$CURRENT_BEAD_JSON"; then
             continue
+        else
+            session_status=$?
+            if [ "$session_status" = "2" ]; then
+                UNVERIFIABLE=$((UNVERIFIABLE + 1))
+                continue
+            fi
         fi
-        # `gc bd update` auto-resolves the bead's prefix to the right rig
-        # store, so HQ and rig beads update in the correct database.
-        gc bd update "$bead_id" --status=open --assignee="" 2>/dev/null || true
-        ORPHANED=$((ORPHANED + 1))
+        if reset_orphan_if_current "$bead_id" "$assignee"; then
+            ORPHANED=$((ORPHANED + 1))
+        else
+            reset_status=$?
+            if [ "$reset_status" != "2" ]; then
+                UNVERIFIABLE=$((UNVERIFIABLE + 1))
+            fi
+        fi
     fi
 done < <(echo "$IN_PROGRESS" | jq -r '.[] | select(.assignee != null and .assignee != "") | "\(.id)\t\(.assignee)"' 2>/dev/null)
 
-if [ "$ORPHANED" -gt 0 ]; then
-    echo "orphan-sweep: reset $ORPHANED orphaned beads"
+if [ "$ORPHANED" -gt 0 ] || [ "$UNVERIFIABLE" -gt 0 ]; then
+    SUMMARY="orphan-sweep: reset $ORPHANED orphaned beads"
+    if [ "$UNVERIFIABLE" -gt 0 ]; then
+        SUMMARY="$SUMMARY, skipped $UNVERIFIABLE unverifiable"
+    fi
+    echo "$SUMMARY"
 fi

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -126,6 +126,11 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 				args, float64(time.Since(start).Milliseconds()),
 				err, out, stderr.String())
 		}
+		if err == nil && name == "bd" && bdOutputIndicatesSilentFallback(stderr.String()) {
+			fallbackErr := fmt.Errorf("%w: %s", ErrBDSilentFallback, strings.TrimSpace(stderr.String()))
+			trace("error", fallbackErr)
+			return out, fallbackErr
+		}
 		if ctx.Err() == context.DeadlineExceeded {
 			timeoutErr := fmt.Errorf("timed out after %s", timeout)
 			trace("timeout", timeoutErr)
@@ -201,6 +206,17 @@ func bdStdoutErrorDetail(out []byte) string {
 	return strings.TrimSpace(env.Error)
 }
 
+const (
+	bdSilentFallbackMarkerImport  = "auto-importing"
+	bdSilentFallbackMarkerEmptyDB = "into empty database"
+)
+
+func bdOutputIndicatesSilentFallback(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.Contains(lower, bdSilentFallbackMarkerImport) &&
+		strings.Contains(lower, bdSilentFallbackMarkerEmptyDB)
+}
+
 // PurgeRunnerFunc executes a bd purge command with custom dir and env.
 // Unlike CommandRunner, this supports environment variable manipulation
 // needed by bd purge (BEADS_DIR override).
@@ -223,6 +239,8 @@ type BdStore struct {
 }
 
 const bdTransientWriteAttempts = 3
+
+var _ ConditionalAssignmentReleaser = (*BdStore)(nil)
 
 // BdStoreOption configures optional bd CLI behavior for a BdStore.
 type BdStoreOption func(*BdStore)
@@ -897,6 +915,180 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 		return fmt.Errorf("updating bead %q: %w", id, err)
 	}
 	return nil
+}
+
+// ReleaseIfCurrent clears an in-progress assignment only when the bead still
+// has the expected assignee.
+func (s *BdStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	query := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
+		" WHERE id = " + bdSQLStringLiteral(id) +
+		" AND status = 'in_progress'" +
+		" AND assignee = " + bdSQLStringLiteral(expectedAssignee)
+	out, err := s.runBDTransientWriteOutput("sql", "--json", query)
+	if err != nil {
+		if isBdSQLUnsupportedInEmbeddedMode(err) {
+			return s.releaseIfCurrentViaEmbeddedDoltSQL(id, expectedAssignee)
+		}
+		return false, fmt.Errorf("bd release-if-current: %w", err)
+	}
+	var result struct {
+		RowsAffected int `json:"rows_affected"`
+	}
+	if err := json.Unmarshal(extractJSON(out), &result); err != nil {
+		return false, fmt.Errorf("bd release-if-current: parsing SQL result: %w", err)
+	}
+	return result.RowsAffected > 0, nil
+}
+
+func (s *BdStore) releaseIfCurrentViaEmbeddedDoltSQL(id, expectedAssignee string) (bool, error) {
+	doltDir, ok, err := s.embeddedDoltDir()
+	if err != nil {
+		return false, fmt.Errorf("bd release-if-current embedded fallback: %w", err)
+	}
+	if !ok {
+		return false, fmt.Errorf("bd release-if-current embedded fallback: %w", ErrConditionalReleaseUnsupported)
+	}
+	query := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
+		" WHERE id = " + bdSQLStringLiteral(id) +
+		" AND status = 'in_progress'" +
+		" AND assignee = " + bdSQLStringLiteral(expectedAssignee) +
+		"; SELECT ROW_COUNT() AS rows_affected"
+	out, err := s.runner(doltDir, "dolt", "sql", "-r", "json", "-q", query)
+	if err != nil {
+		return false, fmt.Errorf("bd release-if-current embedded fallback: dolt sql: %w", err)
+	}
+	rowsAffected, err := parseDoltRowsAffected(out)
+	if err != nil {
+		return false, fmt.Errorf("bd release-if-current embedded fallback: parsing SQL result: %w", err)
+	}
+	return rowsAffected > 0, nil
+}
+
+func (s *BdStore) embeddedDoltDir() (string, bool, error) {
+	metaPath := filepath.Join(s.dir, ".beads", "metadata.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	var meta struct {
+		Backend      string `json:"backend"`
+		Database     string `json:"database"`
+		DoltMode     string `json:"dolt_mode"`
+		DoltDatabase string `json:"dolt_database"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", false, fmt.Errorf("parsing metadata.json: %w", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(meta.Backend), "dolt") &&
+		!strings.EqualFold(strings.TrimSpace(meta.Database), "dolt") {
+		return "", false, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(meta.DoltMode), "embedded") {
+		return "", false, nil
+	}
+	database := strings.TrimSpace(meta.DoltDatabase)
+	if database == "" {
+		return "", false, errors.New("metadata.json missing dolt_database")
+	}
+	if database != filepath.Base(database) {
+		return "", false, fmt.Errorf("metadata.json dolt_database %q must be a database name, not a path", database)
+	}
+	return filepath.Join(s.dir, ".beads", "embeddeddolt", database), true, nil
+}
+
+func parseDoltRowsAffected(out []byte) (int, error) {
+	data := bytes.TrimSpace(extractJSON(out))
+	found := false
+	rowsAffected := 0
+	for len(data) > 0 {
+		start := bytes.IndexAny(data, "{[")
+		if start < 0 {
+			break
+		}
+		data = data[start:]
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return 0, err
+		}
+		if got, ok, err := doltRowsAffectedFromJSON(raw); err != nil {
+			return 0, err
+		} else if ok {
+			rowsAffected = got
+			found = true
+		}
+		consumed := decoder.InputOffset()
+		if consumed <= 0 || int(consumed) > len(data) {
+			return 0, errors.New("could not advance through dolt JSON output")
+		}
+		data = data[consumed:]
+	}
+	if !found {
+		return 0, errors.New("missing rows_affected row")
+	}
+	return rowsAffected, nil
+}
+
+func doltRowsAffectedFromJSON(raw json.RawMessage) (int, bool, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return 0, false, nil
+	}
+	if trimmed[0] == '[' {
+		var results []doltRowsAffectedResult
+		if err := json.Unmarshal(trimmed, &results); err != nil {
+			return 0, false, err
+		}
+		found := false
+		rowsAffected := 0
+		for _, result := range results {
+			if got, ok := result.rowsAffected(); ok {
+				rowsAffected = got
+				found = true
+			}
+		}
+		return rowsAffected, found, nil
+	}
+	var result doltRowsAffectedResult
+	if err := json.Unmarshal(trimmed, &result); err != nil {
+		return 0, false, err
+	}
+	rowsAffected, ok := result.rowsAffected()
+	return rowsAffected, ok, nil
+}
+
+type doltRowsAffectedResult struct {
+	Rows []struct {
+		RowsAffected *int `json:"rows_affected"`
+	} `json:"rows"`
+}
+
+func (r doltRowsAffectedResult) rowsAffected() (int, bool) {
+	for _, row := range r.Rows {
+		if row.RowsAffected != nil {
+			return *row.RowsAffected, true
+		}
+	}
+	return 0, false
+}
+
+func isBdSQLUnsupportedInEmbeddedMode(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "bd sql") &&
+		strings.Contains(msg, "not yet supported") &&
+		strings.Contains(msg, "embedded mode")
+}
+
+func bdSQLStringLiteral(value string) string {
+	// bd sql runs against Dolt/MySQL string-literal semantics.
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 // Claim atomically claims an open bead through bd update --claim.

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2987,6 +2987,279 @@ func TestBdStoreSetMetadataBatchCLINotFound(t *testing.T) {
 	}
 }
 
+func TestBdStoreReadPathsSurfaceSilentFallbackMarkerPair(t *testing.T) {
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	script := `#!/bin/sh
+echo "auto-importing 220929 bytes from .beads/issues.jsonl into empty database..." >&2
+case "$1" in
+  show)
+    printf '[{"id":"bd-42","title":"fallback read","status":"open","issue_type":"task","created_at":"2026-06-07T00:00:00Z"}]'
+    ;;
+  list)
+    printf '[]'
+    ;;
+  *)
+    echo "unexpected bd command: $*" >&2
+    exit 2
+    ;;
+esac
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	runner := beads.ExecCommandRunnerWithEnv(nil)
+	s := beads.NewBdStore(t.TempDir(), runner)
+
+	if _, err := s.Get("bd-42"); !errors.Is(err, beads.ErrBDSilentFallback) {
+		t.Fatalf("Get error = %v, want ErrBDSilentFallback", err)
+	}
+	if _, err := s.List(beads.ListQuery{AllowScan: true}); !errors.Is(err, beads.ErrBDSilentFallback) {
+		t.Fatalf("List error = %v, want ErrBDSilentFallback", err)
+	}
+}
+
+func TestBdStoreReadPathsRequireCompleteSilentFallbackMarkerPair(t *testing.T) {
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	script := `#!/bin/sh
+echo "auto-importing schema into initialized local store" >&2
+case "$1" in
+  show)
+    printf '[{"id":"bd-42","title":"normal read","status":"open","issue_type":"task","created_at":"2026-06-07T00:00:00Z"}]'
+    ;;
+  list)
+    printf '[{"id":"bd-42","title":"normal read","status":"open","issue_type":"task","created_at":"2026-06-07T00:00:00Z"}]'
+    ;;
+  *)
+    echo "unexpected bd command: $*" >&2
+    exit 2
+    ;;
+esac
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	runner := beads.ExecCommandRunnerWithEnv(nil)
+	s := beads.NewBdStore(t.TempDir(), runner)
+
+	got, err := s.Get("bd-42")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != "bd-42" {
+		t.Fatalf("Get ID = %q, want bd-42", got.ID)
+	}
+	list, err := s.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "bd-42" {
+		t.Fatalf("List = %+v, want bd-42", list)
+	}
+}
+
+func TestBdStoreReleaseIfCurrentUsesGuardedSQL(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return []byte(`{"rows_affected":1,"schema_version":1}`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-'1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent released = false, want true")
+	}
+	if gotName != "bd" {
+		t.Fatalf("runner name = %q, want bd", gotName)
+	}
+	if len(gotArgs) != 3 || gotArgs[0] != "sql" || gotArgs[1] != "--json" {
+		t.Fatalf("args = %q, want bd sql --json <query>", gotArgs)
+	}
+	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-''1'"
+	if gotArgs[2] != wantQuery {
+		t.Fatalf("SQL query = %q, want %q", gotArgs[2], wantQuery)
+	}
+}
+
+func TestBdStoreReleaseIfCurrentSQLLiteralEscapesBackslash(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = append([]string(nil), args...)
+		return []byte(`{"rows_affected":1,"schema_version":1}`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+
+	if _, err := s.ReleaseIfCurrent("bd-\\42", "worker-\\1"); err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-\\\\42' AND status = 'in_progress' AND assignee = 'worker-\\\\1'"
+	if gotArgs[2] != wantQuery {
+		t.Fatalf("SQL query = %q, want %q", gotArgs[2], wantQuery)
+	}
+}
+
+func TestBdStoreReleaseIfCurrentFallsBackWhenEmbeddedBdSQLUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"demo"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile metadata: %v", err)
+	}
+	var calls []string
+	runner := func(callDir, name string, args ...string) ([]byte, error) {
+		call := callDir + ": " + name + " " + strings.Join(args, " ")
+		calls = append(calls, call)
+		switch {
+		case name == "bd" && len(args) >= 1 && args[0] == "sql":
+			return nil, fmt.Errorf("exit status 1: Error: 'bd sql' is not yet supported in embedded mode")
+		case name == "dolt" && len(args) == 5 && args[0] == "sql" && args[1] == "-r" && args[2] == "json" && args[3] == "-q":
+			return []byte(`{"rows":[{"rows_affected":1}]}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected call %s", call)
+		}
+	}
+	s := beads.NewBdStore(dir, runner)
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent released = false, want true")
+	}
+	wantCalls := []string{
+		dir + ": bd sql --json UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-1'",
+		filepath.Join(dir, ".beads", "embeddeddolt", "demo") + ": dolt sql -r json -q UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-1'; SELECT ROW_COUNT() AS rows_affected",
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+	}
+}
+
+func TestBdStoreReleaseIfCurrentEmbeddedFallbackParsesDoltRowsAffectedShapes(t *testing.T) {
+	realOutput, err := os.ReadFile(filepath.Join("testdata", "dolt_release_if_current_rows_affected.json"))
+	if err != nil {
+		t.Fatalf("ReadFile fixture: %v", err)
+	}
+	tests := []struct {
+		name string
+		out  []byte
+	}{
+		{
+			name: "real dolt sql rows affected fixture",
+			out:  realOutput,
+		},
+		{
+			name: "multi result stream",
+			out: []byte(`{"rows":[]}
+{"rows":[{"rows_affected":1}]}
+`),
+		},
+		{
+			name: "array wrapped result sets",
+			out:  []byte(`[{"rows":[]},{"rows":[{"rows_affected":1}]}]`),
+		},
+		{
+			name: "trailing non json output",
+			out:  append(append([]byte("warning: using local dolt\n"), realOutput...), []byte("\nQuery OK, 1 row affected\n")...),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := embeddedDoltReleaseIfCurrentStore(t, tt.out)
+
+			released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+			if err != nil {
+				t.Fatalf("ReleaseIfCurrent: %v", err)
+			}
+			if !released {
+				t.Fatal("ReleaseIfCurrent released = false, want true")
+			}
+		})
+	}
+}
+
+func TestBdStoreReleaseIfCurrentEmbeddedFallbackSkipsWrongAssignee(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"demo"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile metadata: %v", err)
+	}
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		switch {
+		case name == "bd" && len(args) >= 1 && args[0] == "sql":
+			return nil, fmt.Errorf("exit status 1: Error: 'bd sql' is not yet supported in embedded mode")
+		case name == "dolt" && len(args) == 5 && args[0] == "sql" && args[1] == "-r" && args[2] == "json" && args[3] == "-q":
+			return []byte(`{"rows":[{"rows_affected":0}]}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command %s %q", name, args)
+		}
+	}
+	s := beads.NewBdStore(dir, runner)
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released = true, want false")
+	}
+}
+
+func embeddedDoltReleaseIfCurrentStore(t *testing.T, doltOut []byte) *beads.BdStore {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"demo"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile metadata: %v", err)
+	}
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		switch {
+		case name == "bd" && len(args) >= 1 && args[0] == "sql":
+			return nil, fmt.Errorf("exit status 1: Error: 'bd sql' is not yet supported in embedded mode")
+		case name == "dolt" && len(args) == 5 && args[0] == "sql" && args[1] == "-r" && args[2] == "json" && args[3] == "-q":
+			return doltOut, nil
+		default:
+			return nil, fmt.Errorf("unexpected command %s %q", name, args)
+		}
+	}
+	return beads.NewBdStore(dir, runner)
+}
+
+func TestBdStoreReleaseIfCurrentSkipsWhenRowsAffectedIsZero(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd sql --json UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-1'`: {
+			out: []byte(`{"rows_affected":0,"schema_version":1}`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released = true, want false")
+	}
+}
+
 // --- ListByLabel ---
 
 func TestBdStoreListByLabel(t *testing.T) {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -23,6 +23,18 @@ var ErrStoreClosed = errors.New("bead store closed")
 // concurrent reparent before the caller's projection wait could converge.
 var ErrParentProjectionSuperseded = errors.New("parent projection superseded by concurrent update")
 
+// ErrConditionalReleaseUnsupported reports that a store cannot atomically
+// release an assignment based on the current status and assignee.
+var ErrConditionalReleaseUnsupported = errors.New("conditional assignment release unsupported")
+
+// ErrBDSilentFallback reports that a bd-backed store operation saw bd exit
+// successfully after falling back to on-disk JSONL auto-import mode. BdStore
+// surfaces this as an error for reads and writes because the command may have
+// observed or mutated an empty fallback database instead of the configured
+// backend. Detection requires bd's paired fallback markers: "auto-importing"
+// and "into empty database".
+var ErrBDSilentFallback = errors.New("bd silent fallback to on-disk auto-import")
+
 // Bead is a single unit of work in Gas City. Everything is a bead: tasks,
 // mail, molecules, convoys.
 type Bead struct {
@@ -70,6 +82,13 @@ type UpdateOpts struct {
 	Labels       []string // append these labels (nil = no change)
 	RemoveLabels []string // remove these labels (nil = no change)
 	Metadata     map[string]string
+}
+
+// ConditionalAssignmentReleaser is implemented by stores that can release an
+// in-progress assignment only when the current status and assignee still match
+// the expected snapshot.
+type ConditionalAssignmentReleaser interface {
+	ReleaseIfCurrent(id, expectedAssignee string) (bool, error)
 }
 
 // Tx is the write surface available inside a Store.Tx callback.

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -80,6 +80,8 @@ type CachingStore struct {
 	applyEventBeforeCommitForTest func()
 }
 
+var _ ConditionalAssignmentReleaser = (*CachingStore)(nil)
+
 type cacheState int
 
 const (

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -126,6 +126,51 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 	return nil
 }
 
+// ReleaseIfCurrent clears an in-progress assignment through the backing store
+// and refreshes the cache only when the conditional release succeeds.
+func (c *CachingStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	releaser, ok := c.backing.(ConditionalAssignmentReleaser)
+	if !ok {
+		return false, ErrConditionalReleaseUnsupported
+	}
+	released, err := releaser.ReleaseIfCurrent(id, expectedAssignee)
+	if err != nil || !released {
+		return released, err
+	}
+
+	fresh, refreshed := c.refreshBeadAfterWrite(id, "refresh bead after release-if-current")
+	var updated Bead
+	notify := false
+	c.mu.Lock()
+	c.noteLocalMutationLocked(id)
+	if refreshed {
+		c.beads[id] = cloneBead(fresh)
+		c.deps[id] = depsFromBeadFields(fresh)
+		delete(c.dirty, id)
+		delete(c.deletedSeq, id)
+		updated = cloneBead(fresh)
+		notify = true
+	} else if b, ok := c.beads[id]; ok {
+		b.Status = "open"
+		b.Assignee = ""
+		b.UpdatedAt = time.Now()
+		c.beads[id] = b
+		c.dirty[id] = struct{}{}
+		delete(c.deletedSeq, id)
+		updated = cloneBead(b)
+		notify = true
+	} else {
+		c.dirty[id] = struct{}{}
+	}
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+	c.mu.Unlock()
+	if notify {
+		c.notifyChange("bead.updated", updated)
+	}
+	return true, nil
+}
+
 // Close marks a bead as closed in the backing store and cache.
 func (c *CachingStore) Close(id string) error {
 	// Idempotence: if the cached bead status is already "closed" AND the

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -3,6 +3,7 @@ package beads
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 )
 
@@ -15,6 +16,7 @@ type countingBackingStore struct {
 	setMetadataBatchCalls int
 	updateCalls           int
 	closeCalls            int
+	releaseIfCurrentCalls int
 }
 
 func (c *countingBackingStore) SetMetadata(id, key, value string) error {
@@ -37,6 +39,15 @@ func (c *countingBackingStore) Close(id string) error {
 	return c.Store.Close(id)
 }
 
+func (c *countingBackingStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	c.releaseIfCurrentCalls++
+	releaser, ok := c.Store.(ConditionalAssignmentReleaser)
+	if !ok {
+		return false, ErrConditionalReleaseUnsupported
+	}
+	return releaser.ReleaseIfCurrent(id, expectedAssignee)
+}
+
 type txPreservingBackingStore struct {
 	Store
 	txCalls     int
@@ -47,6 +58,31 @@ type cacheWriteNotification struct {
 	eventType string
 	beadID    string
 	payload   json.RawMessage
+}
+
+type releaseRefreshFailOnceStore struct {
+	Store
+	failNextGet bool
+}
+
+func (s *releaseRefreshFailOnceStore) Get(id string) (Bead, error) {
+	if s.failNextGet {
+		s.failNextGet = false
+		return Bead{}, errors.New("injected refresh failure")
+	}
+	return s.Store.Get(id)
+}
+
+func (s *releaseRefreshFailOnceStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	releaser, ok := s.Store.(ConditionalAssignmentReleaser)
+	if !ok {
+		return false, ErrConditionalReleaseUnsupported
+	}
+	released, err := releaser.ReleaseIfCurrent(id, expectedAssignee)
+	if released && err == nil {
+		s.failNextGet = true
+	}
+	return released, err
 }
 
 func (s *txPreservingBackingStore) Update(id string, opts UpdateOpts) error {
@@ -173,6 +209,91 @@ func TestCachingStoreSetMetadataBatchNotifiesBeadUpdated(t *testing.T) {
 	}
 	if updated.Metadata["review"] != "fixed" {
 		t.Fatalf("notification metadata = %#v, want review=fixed", updated.Metadata)
+	}
+}
+
+func TestCachingStoreReleaseIfCurrentDelegatesAndRefreshesCache(t *testing.T) {
+	t.Parallel()
+
+	status := "in_progress"
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "task", Assignee: "worker-1"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := backing.Update(bead.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update status: %v", err)
+	}
+
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	events = nil
+
+	released, err := cache.ReleaseIfCurrent(bead.ID, "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent released = false, want true")
+	}
+	if backing.releaseIfCurrentCalls != 1 {
+		t.Fatalf("backing ReleaseIfCurrent calls = %d, want 1", backing.releaseIfCurrentCalls)
+	}
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("cache Get: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("cached bead = %+v, want open and unassigned", got)
+	}
+	if !stringSliceContains(events, "bead.updated:"+bead.ID) {
+		t.Fatalf("events = %v, want bead.updated for released bead", events)
+	}
+}
+
+func TestCachingStoreReleaseIfCurrentKeepsDirtyWhenRefreshFails(t *testing.T) {
+	t.Parallel()
+
+	status := "in_progress"
+	backing := &releaseRefreshFailOnceStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "task", Assignee: "worker-1"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := backing.Update(bead.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update status: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	released, err := cache.ReleaseIfCurrent(bead.ID, "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent released = false, want true")
+	}
+	cache.mu.Lock()
+	_, dirty := cache.dirty[bead.ID]
+	cache.mu.Unlock()
+	if !dirty {
+		t.Fatal("released bead was not kept dirty after refresh failure")
+	}
+
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("cache Get after dirty refresh: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("cached bead after dirty refresh = %+v, want open and unassigned", got)
 	}
 }
 

--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -30,6 +30,8 @@ type FileStore struct {
 	freshness fileFreshness
 }
 
+var _ ConditionalAssignmentReleaser = (*FileStore)(nil)
+
 type fileFreshness struct {
 	known   bool
 	exists  bool
@@ -223,6 +225,30 @@ func (fs *FileStore) Update(id string, opts UpdateOpts) error {
 		return err
 	}
 	return nil
+}
+
+// ReleaseIfCurrent clears an in-progress assignment only when the bead still
+// has the expected assignee, while holding the file-store write lock.
+func (fs *FileStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return false, err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return false, err
+	}
+	snap := fs.snapshotLocked()
+	released, err := fs.MemStore.ReleaseIfCurrent(id, expectedAssignee)
+	if err != nil || !released {
+		return released, err
+	}
+	if err := fs.save(); err != nil {
+		fs.restoreFrom(snap.seq, snap.beads, snap.deps)
+		return false, err
+	}
+	return true, nil
 }
 
 // Close delegates to MemStore.Close and flushes to disk.

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -19,6 +19,8 @@ type MemStore struct {
 	seq   int
 }
 
+var _ ConditionalAssignmentReleaser = (*MemStore)(nil)
+
 // NewMemStore returns a new empty MemStore.
 func NewMemStore() *MemStore {
 	return &MemStore{}
@@ -161,6 +163,26 @@ func (m *MemStore) Update(id string, opts UpdateOpts) error {
 		}
 	}
 	return fmt.Errorf("updating bead %q: %w", id, ErrNotFound)
+}
+
+// ReleaseIfCurrent clears an in-progress assignment only when the bead still
+// has the expected assignee.
+func (m *MemStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := range m.beads {
+		if m.beads[i].ID != id {
+			continue
+		}
+		if m.beads[i].Status != "in_progress" || m.beads[i].Assignee != expectedAssignee {
+			return false, nil
+		}
+		m.beads[i].Status = "open"
+		m.beads[i].Assignee = ""
+		m.beads[i].UpdatedAt = time.Now()
+		return true, nil
+	}
+	return false, nil
 }
 
 // Close sets a bead's status to "closed". Returns a wrapped ErrNotFound if

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -2,6 +2,7 @@ package beads_test
 
 import (
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -37,6 +38,125 @@ func TestMemStoreSetMetadataNotFound(t *testing.T) {
 	}
 	if !errors.Is(err, beads.ErrNotFound) {
 		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMemStoreReleaseIfCurrent(t *testing.T) {
+	s := beads.NewMemStore()
+	b, err := s.Create(beads.Bead{Title: "work", Assignee: "worker-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Update(b.ID, beads.UpdateOpts{Status: strPtr("in_progress")}); err != nil {
+		t.Fatal(err)
+	}
+
+	released, err := s.ReleaseIfCurrent(b.ID, "worker-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released a bead with the wrong assignee")
+	}
+	got, err := s.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-1" {
+		t.Fatalf("wrong-assignee release mutated bead: %+v", got)
+	}
+
+	released, err = s.ReleaseIfCurrent(b.ID, "worker-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent did not release matching in-progress assignment")
+	}
+	got, err = s.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("released bead = %+v, want open and unassigned", got)
+	}
+}
+
+func TestMemStoreReleaseIfCurrentSkipsMissingAndWrongStatus(t *testing.T) {
+	s := beads.NewMemStore()
+
+	released, err := s.ReleaseIfCurrent("missing", "worker-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released missing bead")
+	}
+
+	b, err := s.Create(beads.Bead{Title: "open work", Assignee: "worker-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	released, err = s.ReleaseIfCurrent(b.ID, "worker-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released non-in-progress bead")
+	}
+	got, err := s.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "open" || got.Assignee != "worker-1" {
+		t.Fatalf("wrong-status release mutated bead: %+v", got)
+	}
+}
+
+func TestMemStoreReleaseIfCurrentDoesNotClobberConcurrentClaim(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		s := beads.NewMemStore()
+		b, err := s.Create(beads.Bead{Title: "work", Assignee: "worker-1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Update(b.ID, beads.UpdateOpts{Status: strPtr("in_progress")}); err != nil {
+			t.Fatal(err)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		var releaseErr error
+		var updateErr error
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, releaseErr = s.ReleaseIfCurrent(b.ID, "worker-1")
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			updateErr = s.Update(b.ID, beads.UpdateOpts{
+				Status:   strPtr("in_progress"),
+				Assignee: strPtr("worker-2"),
+			})
+		}()
+		close(start)
+		wg.Wait()
+		if releaseErr != nil {
+			t.Fatalf("ReleaseIfCurrent: %v", releaseErr)
+		}
+		if updateErr != nil {
+			t.Fatalf("Update fresh claim: %v", updateErr)
+		}
+		got, err := s.Get(b.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != "in_progress" || got.Assignee != "worker-2" {
+			t.Fatalf("concurrent release clobbered fresh claim: %+v", got)
+		}
 	}
 }
 

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -120,10 +120,11 @@ type NativeDoltStore struct {
 }
 
 var (
-	_ Store                    = (*NativeDoltStore)(nil)
-	_ GraphApplyStore          = (*NativeDoltStore)(nil)
-	_ StorageGraphApplyStore   = (*NativeDoltStore)(nil)
-	_ EphemeralGraphApplyStore = (*NativeDoltStore)(nil)
+	_ Store                         = (*NativeDoltStore)(nil)
+	_ ConditionalAssignmentReleaser = (*NativeDoltStore)(nil)
+	_ GraphApplyStore               = (*NativeDoltStore)(nil)
+	_ StorageGraphApplyStore        = (*NativeDoltStore)(nil)
+	_ EphemeralGraphApplyStore      = (*NativeDoltStore)(nil)
 )
 
 func newNativeDoltStoreWithStorage(storage beadslib.Storage, actor string) *NativeDoltStore {
@@ -482,6 +483,44 @@ func (s *NativeDoltStore) Update(id string, opts UpdateOpts) error {
 		return nativeStoreError(id, err)
 	}
 	return nil
+}
+
+// ReleaseIfCurrent clears an in-progress assignment only when the bead still
+// has the expected assignee inside one native Dolt transaction.
+func (s *NativeDoltStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	storage, release, err := s.acquireStorage()
+	if err != nil {
+		return false, err
+	}
+	defer release()
+	ctx, cancel := nativeDoltOperationContext(context.TODO())
+	defer cancel()
+	released := false
+	err = storage.RunInTransaction(ctx, fmt.Sprintf("gc: release bead %s if current", id), func(tx beadslib.Transaction) error {
+		issue, err := tx.GetIssue(ctx, id)
+		if err != nil {
+			err = nativeStoreError(id, err)
+			if errors.Is(err, ErrNotFound) {
+				return nil
+			}
+			return err
+		}
+		if issue == nil || issue.Status != beadslib.StatusInProgress || issue.Assignee != expectedAssignee {
+			return nil
+		}
+		if err := tx.UpdateIssue(ctx, id, map[string]interface{}{
+			"status":   "open",
+			"assignee": "",
+		}, s.actor); err != nil {
+			return nativeStoreError(id, err)
+		}
+		released = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return released, nil
 }
 
 // Close sets a bead's status to closed through the upstream beads storage layer.

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -127,6 +127,48 @@ func TestNativeDoltStoreCreateGetPreservesNoHistory(t *testing.T) {
 	}
 }
 
+func TestNativeDoltStoreReleaseIfCurrent(t *testing.T) {
+	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	created, err := store.Create(Bead{Title: "native release", Assignee: "worker-1"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	status := "in_progress"
+	if err := store.Update(created.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update status: %v", err)
+	}
+
+	released, err := store.ReleaseIfCurrent(created.ID, "worker-2")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent wrong assignee: %v", err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released a bead with the wrong assignee")
+	}
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after skipped release: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-1" {
+		t.Fatalf("skipped release mutated bead: %+v", got)
+	}
+
+	released, err = store.ReleaseIfCurrent(created.ID, "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent matching assignee: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent did not release matching in-progress assignment")
+	}
+	got, err = store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after release: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("released bead = %+v, want open and unassigned", got)
+	}
+}
+
 func TestNativeDoltStoreCreatePropagatesUpstreamError(t *testing.T) {
 	wantErr := errors.New("create failed")
 	storage := &nativeDoltStorageSpy{

--- a/internal/beads/sqlite_store.go
+++ b/internal/beads/sqlite_store.go
@@ -40,6 +40,8 @@ type SQLiteStoreOptions struct {
 	disableRetentionSweeper bool
 }
 
+var _ ConditionalAssignmentReleaser = (*SQLiteStore)(nil)
+
 // SQLiteStoreOption customizes OpenSQLiteStore.
 type SQLiteStoreOption func(*SQLiteStoreOptions)
 
@@ -535,6 +537,42 @@ func (s *SQLiteStore) Update(id string, opts UpdateOpts) error {
 		}
 		return tx.Commit()
 	})
+}
+
+// ReleaseIfCurrent clears an in-progress assignment only when the bead still
+// has the expected assignee.
+func (s *SQLiteStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	var released bool
+	err := retryOnBusy(func() error {
+		ctx := context.Background()
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("sqlite release-if-current: begin tx: %w", err)
+		}
+		defer tx.Rollback() //nolint:errcheck
+		b, err := s.getTx(ctx, tx, id)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return nil
+			}
+			return err
+		}
+		if b.Status != "in_progress" || b.Assignee != expectedAssignee {
+			return nil
+		}
+		b.Status = "open"
+		b.Assignee = ""
+		b.UpdatedAt = time.Now()
+		if err := s.upsertBeadTx(ctx, tx, b); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		released = true
+		return nil
+	})
+	return released, err
 }
 
 func (s *SQLiteStore) getTx(ctx context.Context, tx *sql.Tx, id string) (Bead, error) {

--- a/internal/beads/sqlite_store_test.go
+++ b/internal/beads/sqlite_store_test.go
@@ -40,6 +40,78 @@ func TestSQLiteStoreCreatesAndGets(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreReleaseIfCurrent(t *testing.T) {
+	s, err := OpenSQLiteStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() {
+		if c, ok := s.(interface{ CloseStore() error }); ok {
+			c.CloseStore() //nolint:errcheck
+		}
+	}()
+
+	created, err := s.Create(Bead{Title: "work", Assignee: "worker-1"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	status := "in_progress"
+	if err := s.Update(created.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update status: %v", err)
+	}
+
+	releaser := s.(ConditionalAssignmentReleaser)
+	released, err := releaser.ReleaseIfCurrent(created.ID, "worker-2")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent wrong assignee: %v", err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released a bead with the wrong assignee")
+	}
+	got, err := s.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after skipped release: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-1" {
+		t.Fatalf("skipped release mutated bead: %+v", got)
+	}
+
+	released, err = releaser.ReleaseIfCurrent("missing", "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent missing id: %v", err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released missing bead")
+	}
+
+	openBead, err := s.Create(Bead{Title: "open work", Assignee: "worker-1"})
+	if err != nil {
+		t.Fatalf("Create open bead: %v", err)
+	}
+	released, err = releaser.ReleaseIfCurrent(openBead.ID, "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent wrong status: %v", err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released non-in-progress bead")
+	}
+
+	released, err = releaser.ReleaseIfCurrent(created.ID, "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent matching assignee: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent did not release matching in-progress assignment")
+	}
+	got, err = s.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after release: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("released bead = %+v, want open and unassigned", got)
+	}
+}
+
 func TestSQLiteStoreReady(t *testing.T) {
 	s, err := OpenSQLiteStore(t.TempDir())
 	if err != nil {

--- a/internal/beads/testdata/dolt_release_if_current_rows_affected.json
+++ b/internal/beads/testdata/dolt_release_if_current_rows_affected.json
@@ -1,0 +1,1 @@
+{"rows": [{"rows_affected":1}]}


### PR DESCRIPTION
Maintainer follow-up to #3140.

Original PR: https://github.com/gastownhall/gascity/pull/3140
Original title: fix: revalidate orphan-sweep candidates
Original state: MERGED
Configured workflow base: main
Original GitHub base: main
Base mismatch: none

PR #3140 has already merged with the contributor's orphan-sweep revalidation
change. This follow-up carries the maintainer-side fix commit from the adopted
review/fix loop: `fix: guard orphan sweep reset races`.

The follow-up adds the guarded `gc bd release-if-current` path, propagates the
conditional release contract through the store wrappers, preserves bd
silent-fallback detection, and adds regression coverage for the orphan-sweep
race cases reviewed in the adoption workflow.

Validation already run locally:

- `git diff --check`
- commit hook: lint-changed, generated docs/schema/reference files,
  `go vet ./...`, `./scripts/test-local-parallel fast`, and
  `go test ./test/docsync`
- `go test ./internal/beads -run 'Test.*(ReleaseIfCurrent|SilentFallback|RowsAffected)'`
- `go test ./cmd/gc -run 'Test(BeadPolicyStorePreservesConditionalAssignmentReleaser|GcBdSurfacesSilentFallbackAsLoudError_ReleaseIfCurrentPath|ParseBdReleaseIfCurrentArgs|DoBdReleaseIfCurrentUpdatesOnlyMatchingAssignment|DoBdReleaseIfCurrentWorksForBdStoreFallback)'`
- `go test ./examples/gastown -run 'TestOrphanSweep'`
