### PR TITLE
fix: reject hidden-root formula slings to pools

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1550,6 +1550,10 @@ func readyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([
 	if err != nil && !beads.IsPartialResult(err) {
 		rows = nil
 	}
+	// The live Ready read is the cross-process freshness replacement for the
+	// retired gc.pool_demand sentinel. Each controller demand group pays at
+	// most one live backing-store Ready query per reconciliation pass and shares
+	// that result across every template backed by the same store.
 	liveRows, liveErr := handles.Live.Ready(query)
 	if liveErr == nil {
 		// A complete live read is authoritative; cached rows only preserve

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -7289,7 +7289,7 @@ func TestDoSlingCrossRigFormulaExempt(t *testing.T) {
 		Workspace: config.Workspace{Name: "test-city"},
 		Rigs:      []config.Rig{{Name: "hello-world", Path: "/tmp/hw"}},
 	}
-	a := config.Agent{Name: "polecat", Dir: "hello-world"}
+	a := config.Agent{Name: "polecat", Dir: "hello-world", MaxActiveSessions: intPtr(1)}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
 	deps.StoreRef = "rig:hello-world"
@@ -7598,11 +7598,26 @@ func TestDefaultFormulaExplicitOnOverrides(t *testing.T) {
 func TestDefaultFormulaExplicitFormulaOverrides(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
-	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	dir := testFormulaDir(t)
+	if err := os.WriteFile(filepath.Join(dir, "explicit-root-only.toml"), []byte(`
+formula = "explicit-root-only"
+version = 1
+phase = "vapor"
+
+[[steps]]
+id = "work"
+title = "Work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		FormulaLayers: config.FormulaLayers{City: []string{dir}},
+	}
 	a := config.Agent{Name: "polecat", Dir: "hw", DefaultSlingFormula: strPtr("mol-polecat-work")}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
-	opts := testOpts(a, "code-review")
+	opts := testOpts(a, "explicit-root-only")
 	opts.IsFormula = true
 	code := doSling(opts, deps, nil, stdout, stderr)
 
@@ -7617,8 +7632,8 @@ func TestDefaultFormulaExplicitFormulaOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store.Get(gc-1): %v", err)
 	}
-	if b.Ref != "code-review" {
-		t.Errorf("bead Ref = %q, want explicit code-review", b.Ref)
+	if b.Ref != "explicit-root-only" {
+		t.Errorf("bead Ref = %q, want explicit-root-only", b.Ref)
 	}
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1166,21 +1166,10 @@ func prepareOrderWispRecipe(ctx context.Context, store beads.Store, a orders.Ord
 }
 
 func poolOrderRouteVisibilityWarning(a orders.Order, recipe *formula.Recipe) string {
-	if strings.TrimSpace(a.Pool) == "" || poolOrderRecipeHasReadySurface(recipe) {
+	if strings.TrimSpace(a.Pool) == "" || formula.RecipeHasReadySurface(recipe) {
 		return ""
 	}
 	return fmt.Sprintf("warning: pool order %q uses formula %q whose root is a molecule container, not Ready-visible work; scale-from-zero pools will not wake for this wisp. Convert the formula to phase=\"vapor\"/root-only or graph.v2 before routing it to a pool.", a.ScopedName(), a.Formula)
-}
-
-func poolOrderRecipeHasReadySurface(recipe *formula.Recipe) bool {
-	if recipe == nil {
-		return false
-	}
-	if recipe.RootOnly {
-		return true
-	}
-	root := recipe.RootStep()
-	return root != nil && root.Metadata["gc.kind"] == "workflow"
 }
 
 func redactOrderEnvError(err error, env []string) string {

--- a/internal/formula/recipe.go
+++ b/internal/formula/recipe.go
@@ -114,6 +114,19 @@ func (r *Recipe) RootStep() *RecipeStep {
 	return &r.Steps[0]
 }
 
+// RecipeHasReadySurface reports whether instantiating recipe creates a root
+// bead that Ready queries can see and route directly.
+func RecipeHasReadySurface(recipe *Recipe) bool {
+	if recipe == nil {
+		return false
+	}
+	if recipe.RootOnly {
+		return true
+	}
+	root := recipe.RootStep()
+	return root != nil && root.Metadata["gc.kind"] == "workflow"
+}
+
 // StepByID returns the step with the given ID, or nil if not found.
 func (r *Recipe) StepByID(id string) *RecipeStep {
 	for i := range r.Steps {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -239,6 +239,7 @@ func validateExistingBeadInQuerier(beadID, storeRef string, querier BeadQuerier)
 func slingFormula(opts SlingOpts, deps SlingDeps) (SlingResult, error) {
 	a := opts.Target
 	method := "formula"
+	searchPaths := SlingFormulaSearchPaths(deps, a)
 	inv, isGraph, err := prepareGraphV2FormulaInvocation(context.Background(), opts.BeadOrFormula, "", opts, deps, a)
 	if err != nil {
 		return SlingResult{Target: a.QualifiedName()}, fmt.Errorf("instantiating formula %q: %w", opts.BeadOrFormula, err)
@@ -247,7 +248,14 @@ func slingFormula(opts SlingOpts, deps SlingDeps) (SlingResult, error) {
 	if isGraph {
 		formulaVars = inv.Vars
 	}
-	mResult, err := InstantiateSlingFormula(context.Background(), opts.BeadOrFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(context.Background(), opts.BeadOrFormula, searchPaths, formulaVars)
+	if err != nil {
+		return SlingResult{Target: a.QualifiedName()}, fmt.Errorf("instantiating formula %q: %w", opts.BeadOrFormula, err)
+	}
+	if a.SupportsMultipleSessions() && !formula.RecipeHasReadySurface(recipe) {
+		return SlingResult{Target: a.QualifiedName(), FormulaName: opts.BeadOrFormula, Deprecations: inv.Deprecations}, fmt.Errorf("formula %q root is a molecule container, not Ready-visible work; scale-from-zero pools will not wake for this wisp. Convert the formula to phase=\"vapor\"/root-only or graph.v2 before routing it to a pool", opts.BeadOrFormula)
+	}
+	mResult, err := InstantiateSlingFormula(context.Background(), opts.BeadOrFormula, searchPaths, molecule.Options{
 		Title: opts.Title,
 		Vars:  formulaVars,
 	}, "", opts.ScopeKind, opts.ScopeRef, a, deps, opts.Force)

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -1078,27 +1078,62 @@ func TestDoSlingFormulaToAgent(t *testing.T) {
 	}
 }
 
-func TestDoSlingFormulaToPoolSkipsDeprecatedPoolDemand(t *testing.T) {
+func TestDoSlingFormulaToPoolRejectsLegacyMoleculeRoot(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	a := config.Agent{Name: "polecat", MaxActiveSessions: intPtr(3)}
 
 	deps := testDeps(cfg, sp, runner.run)
-	result, err := DoSling(SlingOpts{
+	_, err := DoSling(SlingOpts{
 		Target:        a,
 		BeadOrFormula: "code-review",
+		IsFormula:     true,
+	}, deps, nil)
+	if err == nil {
+		t.Fatal("DoSling error = nil, want legacy molecule-root pool rejection")
+	}
+	if !strings.Contains(err.Error(), "root is a molecule container") {
+		t.Fatalf("DoSling error = %q, want Ready-visible root guidance", err.Error())
+	}
+}
+
+func TestDoSlingFormulaToPoolAllowsRootOnlyReadySurface(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "root-only.toml"), []byte(`
+formula = "root-only"
+version = 1
+phase = "vapor"
+
+[[steps]]
+id = "work"
+title = "Work"
+`), 0o644); err != nil {
+		t.Fatalf("write root-only formula: %v", err)
+	}
+
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		FormulaLayers: config.FormulaLayers{City: []string{formulaDir}},
+	}
+	a := config.Agent{Name: "agent-a", MaxActiveSessions: intPtr(3)}
+
+	deps := testDeps(cfg, sp, runner.run)
+	result, err := DoSling(SlingOpts{
+		Target:        a,
+		BeadOrFormula: "root-only",
 		IsFormula:     true,
 	}, deps, nil)
 	if err != nil {
 		t.Fatalf("DoSling error: %v", err)
 	}
-	root, err := deps.Store.Get(result.BeadID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", result.BeadID, err)
+	if result.Method != "formula" {
+		t.Errorf("Method = %q, want formula", result.Method)
 	}
-	if got, ok := root.Metadata["gc.pool_demand"]; ok {
-		t.Errorf("wisp root gc.pool_demand = %q, want absent", got)
+	if result.BeadID == "" {
+		t.Fatal("expected non-empty root-only wisp ID")
 	}
 }
 


### PR DESCRIPTION
## Summary

Post-merge follow-up for #3132.

- Reject `gc sling --formula` to multi-session pool targets when the compiled formula root is a legacy molecule container that `Ready()` cannot surface.
- Share the Ready-visible formula-root predicate between order dispatch and sling.
- Document the live backing-store `Ready()` demand read as the replacement for the retired pool-demand sentinel.

## Tests

- `go test ./internal/sling -run 'TestDoSlingFormulaToPool|TestDoSlingFormulaToSingleSessionAgentSkipsPoolDemand' -count=1`
- `go test ./internal/formula -count=1`
- `go test ./cmd/gc -run 'TestDefaultScaleCheckCounts|TestOrderRun|TestOrderDispatch|TestMergeReadyRowsByID' -count=1`
- `go test ./internal/sling -count=1`
- `GC_FAST_UNIT=1 go test ./cmd/gc -run 'TestCmdSling.*Formula|TestOrderRun|TestOrderDispatch|TestDefaultScaleCheckCounts|TestMergeReadyRowsByID' -count=1`
- `GC_FAST_UNIT=1 GO_TEST_COUNT=1 ./scripts/test-go-test-shard ./cmd/gc 4 6`
- `GC_FAST_UNIT=1 GO_TEST_COUNT=1 ./scripts/test-go-test-shard ./cmd/gc 3 6`
- `make test-fast-parallel`
- `go vet ./...`
- `.githooks/pre-commit`
