### PR TITLE
jj: use per-bead bookmarks for polecat handoff (gc-pjc)

### DIFF
--- a/.jjignore
+++ b/.jjignore
@@ -1,0 +1,12 @@
+.beads/redirect
+.beads/hooks/
+.beads/formulas/
+.logs/
+.claude/
+.codex/
+.gemini/
+.opencode/
+.github/hooks/
+.github/copilot-instructions.md
+__pycache__/
+state.json

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -546,6 +546,9 @@ func initAndHookDir(cityPath, dir, prefix string) error {
 			return fmt.Errorf("verifying canonical scope database after init: %w", err)
 		}
 	}
+	if cityUsesDoltliteBeadsBackend(cityPath) {
+		return nil
+	}
 	// Non-fatal: hooks are convenience (event forwarding), not critical.
 	// Skip for doltlite backends: hooks emit events to the dolt-backed
 	// event log, which doltlite-native stores don't use.

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -547,7 +547,9 @@ func initAndHookDir(cityPath, dir, prefix string) error {
 		}
 	}
 	// Non-fatal: hooks are convenience (event forwarding), not critical.
-	if installHooks {
+	// Skip for doltlite backends: hooks emit events to the dolt-backed
+	// event log, which doltlite-native stores don't use.
+	if installHooks && !cityUsesDoltliteBeadsBackend(cityPath) {
 		if err := installBeadHooks(dir, cityPath); err != nil {
 			return fmt.Errorf("install hooks at %s: %w", dir, err)
 		}

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -535,7 +535,7 @@ func doRigAddWithResult(fs fsys.FS, cityPath, rigPath string, includes []string,
 	}
 	w("  Generated routes.jsonl for cross-rig routing")
 
-	if adopt {
+	if adopt && !cityUsesDoltliteBeadsBackend(cityPath) {
 		if err := installBeadHooks(rigPath, cityPath); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: installing bead hooks: %v\n", err) //nolint:errcheck // best-effort stderr
 		}

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -659,19 +659,19 @@ func TestPolecatFormulaTreatsMetadataBranchAsAuthoritative(t *testing.T) {
 	}
 	body := string(data)
 	for _, want := range []string{
-		`git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"`,
-		`Could not fetch metadata.branch=$BRANCH from origin`,
-		`git merge --ff-only "origin/$BRANCH"`,
-		`metadata.branch=$BRANCH was set but no local or origin branch exists`,
-		`STOP. Do not create a different branch.`,
+		`jj git fetch --remote origin --branch "$BOOKMARK"`,
+		`Could not fetch metadata.branch=$BOOKMARK from origin`,
+		`jj bookmark move "$BOOKMARK" --to "origin/$BOOKMARK"`,
+		`metadata.branch=$BOOKMARK was set but no local or origin bookmark exists`,
+		`STOP. Do not create a different bookmark.`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("polecat formula missing metadata.branch authority guidance %q", want)
 		}
 	}
 	assertContainsInOrder(t, body,
-		`if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then`,
-		`if git show-ref --verify --quiet "refs/heads/$BRANCH"; then`,
+		`if [ -n "$(jj bookmark list --remote origin "$BOOKMARK" 2>/dev/null || true)" ]; then`,
+		`if [ -n "$(jj bookmark list "$BOOKMARK" 2>/dev/null || true)" ]; then`,
 	)
 }
 
@@ -737,9 +737,9 @@ func TestPolecatFormulaSignalsRefineryAfterReassign(t *testing.T) {
 // TestPolecatFormulaSubmitHasBranchShapeGate is the regression test
 // for gastownhall/gascity#2082: the submit-and-exit step must include
 // a fail-closed gate that refuses to reassign to refinery when the
-// current branch isn't `polecat/<bead-id>`. Without this gate, a
+// current bookmark isn't `polecat/<bead-id>`. Without this gate, a
 // provider that skipped workspace-setup (observed with codex)
-// silently strands work on its agent home branch — metadata.branch
+// silently strands work on its agent home bookmark — metadata.branch
 // never points at a valid polecat/<bead-id> merge target, so the
 // refinery's bead-driven handoff finds nothing to merge.
 func TestPolecatFormulaSubmitHasBranchShapeGate(t *testing.T) {
@@ -752,27 +752,26 @@ func TestPolecatFormulaSubmitHasBranchShapeGate(t *testing.T) {
 	body := string(data)
 
 	// The gate body must appear before the push (so a divergent
-	// branch never reaches origin) and before the refinery reassign
-	// (so a divergent branch never advances the bead state).
+	// bookmark never reaches origin) and before the refinery reassign
+	// (so a divergent bookmark never advances the bead state).
 	assertContainsInOrder(t, body,
-		"**1. Branch-shape gate (fails closed",
-		`CURRENT_BRANCH=$(git branch --show-current)`,
-		`EXPECTED_BRANCH="polecat/$WORK_BEAD_ID"`,
-		`if [ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]; then`,
-		`BRANCH SHAPE GATE FAILED`,
+		"**1. Bookmark-shape gate (fails closed",
+		`EXPECTED_BOOKMARK="polecat/$WORK_BEAD_ID"`,
+		`if ! jj bookmark list -r @ | grep -q "^$EXPECTED_BOOKMARK:"; then`,
+		`BOOKMARK SHAPE GATE FAILED`,
 		`gc runtime drain-ack`,
 		`exit 1`,
 		"**2. Final clean-state verification (safeguard):**",
-		"**3. Push your branch:**",
+		"**3. Push your bookmark:**",
 		"**6. Reassign to refinery:**",
 	)
 
 	// The metadata.branch reconciliation must also be present so a
-	// workspace-setup step that ran but failed to record the branch
+	// workspace-setup step that ran but failed to record the bookmark
 	// is repaired before refinery handoff.
 	assertContainsInOrder(t, body,
 		`METADATA_BRANCH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.branch // empty')`,
-		`gc bd update "$WORK_BEAD_ID" --set-metadata branch="$EXPECTED_BRANCH"`,
+		`gc bd update "$WORK_BEAD_ID" --set-metadata branch="$EXPECTED_BOOKMARK"`,
 	)
 }
 
@@ -790,11 +789,33 @@ func TestPolecatPromptInlinesBranchConvention(t *testing.T) {
 	body := string(data)
 
 	assertContainsInOrder(t, body,
-		"## CRITICAL: Branch Convention",
+		"## CRITICAL: Bookmark Convention",
+		"per-bead bookmark named",
 		"`polecat/<bead-id>`",
 		"`metadata.branch`",
 		"handoff contract is broken",
 		"gastownhall/gascity#2082",
+	)
+}
+
+// TestPolecatAgentConfigSupportsMultipleSessions guards the jj pack's
+// scaling contract: polecats must remain pool-capable, and each pooled
+// slot must resolve its own worktree path instead of collapsing onto a
+// single shared directory.
+func TestPolecatAgentConfigSupportsMultipleSessions(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "agents", "polecat", "agent.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading polecat agent config: %v", err)
+	}
+	body := string(data)
+
+	assertContainsInOrder(t, body,
+		`work_dir = ".gc/worktrees/{{.Rig}}/polecats/{{.AgentBase}}"`,
+		`pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]`,
+		`min_active_sessions = 0`,
+		`max_active_sessions = 5`,
 	)
 }
 
@@ -877,8 +898,8 @@ func TestPolecatPromptDoneSequenceSignalsRefinery(t *testing.T) {
 }
 
 // TestPolecatPromptHaltsOnAutoPushFalse asserts the done sequence respects
-// mol-pr-from-issue's auto_push=false halt-at-branch-ready contract. The
-// gate must run BEFORE `git push origin HEAD` so a false signal prevents
+// mol-pr-from-issue's auto_push=false halt-at-bookmark-ready contract. The
+// gate must run BEFORE `jj git push --bookmark` so a false signal prevents
 // the push and refinery handoff entirely. Regression for gco-ded / gc-m3j:
 // prompt's done sequence was structurally overriding the formula's
 // auto_push gate (BYPASS rate hit 75%).
@@ -895,10 +916,10 @@ func TestPolecatPromptHaltsOnAutoPushFalse(t *testing.T) {
 		"## FINAL REMINDER: RUN THE DONE SEQUENCE",
 		`AUTO_PUSH=$(gc bd show <work-bead> --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')`,
 		`if [ "$AUTO_PUSH" = "false" ]; then`,
-		`BRANCH=$(git branch --show-current)`,
+		`BOOKMARK=$(gc bd show <work-bead> --json | jq -r '.[0].metadata.branch // empty')`,
 		`gc bd update <work-bead> \`,
 		`--status=open --assignee=""`,
-		`--set-metadata branch="$BRANCH"`,
+		`--set-metadata branch="$BOOKMARK"`,
 		`--set-metadata target={{ .DefaultBranch }}`,
 		`--set-metadata branch_ready=true`,
 		`--set-metadata halt_reason=auto_push_false`,
@@ -906,7 +927,8 @@ func TestPolecatPromptHaltsOnAutoPushFalse(t *testing.T) {
 		`gc runtime drain-ack`,
 		"exit 0",
 		"fi",
-		"git push origin HEAD",
+		`BOOKMARK=$(gc bd show <work-bead> --json | jq -r '.[0].metadata.branch // empty')`,
+		`jj git push --bookmark "$BOOKMARK"`,
 	)
 }
 
@@ -919,15 +941,15 @@ func TestPolecatRenderedApprovalFallacyHaltsOnAutoPushFalse(t *testing.T) {
 		"gastown",
 		"gastown.",
 	)
-	doneSequence := sectionBetween(t, body, "### The Done Sequence", "This pushes your branch")
+	doneSequence := sectionBetween(t, body, "### The Done Sequence", "This pushes your bookmark")
 
 	assertContainsInOrder(t, doneSequence,
 		`AUTO_PUSH=$(gc bd show <work-bead> --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')`,
 		`if [ "$AUTO_PUSH" = "false" ]; then`,
-		`BRANCH=$(git branch --show-current)`,
+		`BOOKMARK=$(gc bd show <work-bead> --json | jq -r '.[0].metadata.branch // empty')`,
 		`gc bd update <work-bead> \`,
 		`--status=open --assignee=""`,
-		`--set-metadata branch="$BRANCH"`,
+		`--set-metadata branch="$BOOKMARK"`,
 		`--set-metadata target=main`,
 		`--set-metadata branch_ready=true`,
 		`--set-metadata halt_reason=auto_push_false`,
@@ -935,7 +957,8 @@ func TestPolecatRenderedApprovalFallacyHaltsOnAutoPushFalse(t *testing.T) {
 		`gc runtime drain-ack`,
 		"exit 0",
 		"fi",
-		"git push origin HEAD",
+		`BOOKMARK=$(gc bd show <work-bead> --json | jq -r '.[0].metadata.branch // empty')`,
+		`jj git push --bookmark "$BOOKMARK"`,
 	)
 }
 
@@ -950,13 +973,13 @@ func TestPolecatFormulaHaltsOnAutoPushFalse(t *testing.T) {
 	submit := sectionBetween(t, body, `id = "submit-and-exit"`, "The refinery will pick this up")
 
 	assertContainsInOrder(t, submit,
-		"Push your branch:",
+		"Push your bookmark:",
 		`AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')`,
 		`if [ "$AUTO_PUSH" = "false" ]; then`,
-		`BRANCH=$(git branch --show-current)`,
+		`BOOKMARK=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.branch // empty')`,
 		`gc bd update "$WORK_BEAD_ID" \`,
 		`--status=open --assignee=""`,
-		`--set-metadata branch="$BRANCH"`,
+		`--set-metadata branch="$BOOKMARK"`,
 		`--set-metadata target={{base_branch}}`,
 		`--set-metadata branch_ready=true`,
 		`--set-metadata halt_reason=auto_push_false`,
@@ -964,7 +987,8 @@ func TestPolecatFormulaHaltsOnAutoPushFalse(t *testing.T) {
 		`gc runtime drain-ack`,
 		"exit 0",
 		"fi",
-		"git push origin HEAD",
+		`BOOKMARK=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.branch // empty')`,
+		`jj git push --bookmark "$BOOKMARK"`,
 	)
 }
 

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -16,42 +16,42 @@ merged, reassign to refinery with a note — do not close.
 
 ## CRITICAL: Directory Discipline
 
-Your branch-setup step creates a git worktree and records it in `metadata.work_dir`
-on your work bead. Once created, **stay in your worktree.**
+Your workspace-setup step creates a jj workspace and records it in
+`metadata.work_dir` on your work bead. Once created, **stay in your workspace.**
 
-- **ALL file edits** must be within your worktree directory
+- **ALL file edits** must be within your workspace directory
 - **NEVER edit files in** `{{ .RigRoot }}/` (shared rig repo) — polecats must stay in
-  their dedicated worktree, not the canonical repo checkout
+  their dedicated workspace, not the canonical repo checkout
 
 The failure mode: You `cd` to the shared rig repo and edit files there. You bypass
-your isolated worktree, stomp on the canonical checkout, and break the recovery
+your isolated workspace, stomp on the canonical checkout, and break the recovery
 metadata that points back to `metadata.work_dir`.
 
-Stay in your worktree. Install deps there if needed (`npm install`). Commit and push from there.
+Stay in your workspace. Install deps there if needed (`npm install`). Commit and push from there.
 
-## CRITICAL: Branch Convention (REQUIRED — the refinery handoff contract)
+## CRITICAL: Bookmark Convention (REQUIRED — the refinery handoff contract)
 
-Every commit must land on a per-bead branch named `polecat/<bead-id>`,
+Every commit must land on a per-bead bookmark named `polecat/<bead-id>`,
 created from `origin/<base_branch>`. The refinery finds work by bead
-assignment and merges the branch recorded
-in the bead's `metadata.branch`, which must follow the `polecat/<bead-id>`
-convention. Commit on anything else (your agent home branch, a stray
-local checkout) and the handoff contract is broken — `metadata.branch`
-has no valid merge target and the work is silently stranded.
+assignment (`gc bd list --assignee=...`) and merges the bookmark recorded
+in the bead's `metadata.branch`, which stores the `polecat/<bead-id>` name.
+Commit on anything else (your agent home bookmark, a stray local checkout)
+and the handoff contract is broken — `metadata.branch` has no valid merge
+target and the work is silently stranded.
 
 **Required shape for a bead with ID `vg-1jp`:**
 
 | Field | Value |
 |---|---|
-| Branch name | `polecat/vg-1jp` |
+| Bookmark name | `polecat/vg-1jp` |
 | Base | freshly-fetched `origin/<base_branch>` |
-| Worktree path | `<home>/worktrees/vg-1jp` |
+| Workspace path | `<home>/worktrees/vg-1jp` |
 | Push target | `origin/polecat/vg-1jp` |
 | `metadata.branch` | `polecat/vg-1jp` |
 
 The `workspace-setup` formula step creates this for you. **Do not skip
 that step.** The `submit-and-exit` step's first action is a fail-closed
-gate that refuses to reassign to refinery if the current branch isn't
+gate that refuses to reassign to refinery if the current bookmark isn't
 `polecat/<bead-id>`. Skipping `workspace-setup` will halt the workflow at
 submit time and require manual recovery
 (see gastownhall/gascity#2082).
@@ -251,27 +251,28 @@ Nudges from other agents may arrive via your hook. When working:
 **Before your session ends, you MUST run the done sequence.**
 
 ```bash
-# Explicit opt-out gate: respect mol-pr-from-issue auto_push=false (halt-at-branch-ready).
+# Explicit opt-out gate: respect mol-pr-from-issue auto_push=false (halt-at-bookmark-ready).
 # mol-pr-from-issue writes metadata.auto_push on the work bead. Other formulas
 # (mol-polecat-work) leave it unset — those flow through unchanged.
 AUTO_PUSH=$(gc bd show <work-bead> --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
 if [ "$AUTO_PUSH" = "false" ]; then
-  echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
-  BRANCH=$(git branch --show-current)
+  echo "auto_push=false: halting at bookmark-ready (no push, no refinery handoff)"
+  BOOKMARK=$(gc bd show <work-bead> --json | jq -r '.[0].metadata.branch // empty')
   gc bd update <work-bead> \
     --status=open --assignee="" \
-    --set-metadata branch="$BRANCH" \
+    --set-metadata branch="$BOOKMARK" \
     --set-metadata target={{ .DefaultBranch }} \
     --set-metadata branch_ready=true \
     --set-metadata halt_reason=auto_push_false \
     --set-metadata gc.routed_to="" \
-    --notes "Branch ready: auto_push=false (no push, no refinery handoff)"
+    --notes "Bookmark ready: auto_push=false (no push, no refinery handoff)"
   gc runtime drain-ack
   exit 0
 fi
-git push origin HEAD
+BOOKMARK=$(gc bd show <work-bead> --json | jq -r '.[0].metadata.branch // empty')
+jj git push --bookmark "$BOOKMARK"
 gc bd update <work-bead> \
-  --set-metadata branch=$(git branch --show-current) \
+  --set-metadata branch="$BOOKMARK" \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -1,8 +1,8 @@
 description = """
-Polecat work lifecycle — feature-branch variant.
+Polecat work lifecycle — feature-bookmark variant.
 
-Extends mol-polecat-base with feature-branch workspace setup and
-refinery-based submission. The polecat creates a feature branch,
+Extends mol-polecat-base with feature-bookmark workspace setup and
+refinery-based submission. The polecat creates a feature bookmark,
 implements the work, then pushes and reassigns to the refinery for
 merge review.
 
@@ -10,12 +10,13 @@ merge review.
 
 1. Receive work (molecule poured with this formula, assigned to you)
 2. Follow steps in order (read descriptions, execute, move to next)
-3. Submit: push branch, set metadata on work bead, assign to refinery, exit
+3. Submit: push bookmark, set metadata on work bead, assign to refinery, exit
 4. You are GONE — Refinery merges, closes the bead
 
 **No MR beads.** Work beads flow directly: pool → polecat → refinery → closed.
 The polecat sets `metadata.branch` and `metadata.target` on the work bead
-and reassigns it to the refinery. The refinery merges and closes.
+and reassigns it to the refinery. `metadata.branch` stores the bookmark name.
+The refinery merges and closes.
 
 **NEVER CLOSE BEADS.** You must not run `bd close` or set status=closed.
 Even if you believe the code is already merged, reassign to refinery —
@@ -28,7 +29,7 @@ be inherited from a parent convoy with `metadata.target` set.
 | Variable | Source | Description |
 |----------|--------|-------------|
 | binding_prefix | import binding | Agent identity prefix for bound Gas Town imports. |
-| affected_tests_command | rig `formula_vars` | Shell-safe command that reads `git diff --name-only origin/{{base_branch}}...HEAD` and runs the matching test subset. Empty = run full `test_command`. |
+| affected_tests_command | rig `formula_vars` | Shell-safe command that reads `jj diff --name-only origin/{{base_branch}}...HEAD` and runs the matching test subset. Empty = run full `test_command`. |
 
 **Rejection-aware.** If the work bead has `metadata.branch` and
 `metadata.rejection_reason`, a previous attempt was rejected by the
@@ -59,10 +60,10 @@ default = ""
 
 [[steps]]
 id = "workspace-setup"
-title = "Set up worktree and feature branch"
+title = "Set up workspace and feature bookmark"
 needs = ["load-context"]
 description = """
-Ensure you have an isolated git worktree and a clean feature branch.
+Ensure you have an isolated jj workspace and a clean feature bookmark.
 Every check is idempotent — safe to re-run after crash/restart.
 
 **Config: base_branch = {{base_branch}}**
@@ -73,9 +74,9 @@ Every check is idempotent — safe to re-run after crash/restart.
 2. `metadata.target` on the parent convoy chain
 3. the rig repo's default branch
 
-**1. Fetch latest and derive your work bead:**
+**1. Fetch latest:**
 ```bash
-git fetch --prune origin
+jj git fetch --remote origin --branch {{base_branch}}
 CONVOY_STATUS=$(gc convoy status {{convoy_id}} --json)
 WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
 if [ -z "$WORK_BEAD_ID" ]; then
@@ -87,22 +88,22 @@ fi
 
 **2. Ensure worktree exists.**
 
-Check if `metadata.work_dir` already records your worktree path:
+Check if `metadata.work_dir` already records your workspace path:
 ```bash
 WORKTREE=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 ```
 
-**If worktree path exists in metadata** — reuse it:
+**If workspace path exists in metadata** — reuse it:
 ```bash
 cd "$WORKTREE"              # Enter existing worktree
 ```
 If the directory is missing (witness cleaned it, disk issue), fall through
 to create a new one.
 
-**If no worktree** — create one scoped to the bead, not the agent:
+**If no workspace** — create one scoped to the bead, not the agent:
 ```bash
 WORKTREE_PATH=$(pwd)/worktrees/"$WORK_BEAD_ID"
-git worktree add "$WORKTREE_PATH" --detach origin/{{base_branch}}
+jj workspace add "$WORKTREE_PATH" -r origin/{{base_branch}} -m "fix: branch-vs-bookmark semantic mismatch in formulas ($WORK_BEAD_ID)"
 cd "$WORKTREE_PATH"
 ```
 Record immediately so restarts and witness recovery can find it:
@@ -110,82 +111,81 @@ Record immediately so restarts and witness recovery can find it:
 gc bd update "$WORK_BEAD_ID" --set-metadata work_dir="$WORKTREE_PATH"
 ```
 
-Worktrees are scoped to the work bead (not the agent name) so that:
+Workspaces are scoped to the work bead (not the agent name) so that:
 - An agent can pick up new work even if an old worktree is being recovered
-- Multiple orphaned worktrees can coexist without collision
+- Multiple orphaned workspaces can coexist without collision
 - The witness cleans them independently per-bead
 
-**3. Ensure branch exists.**
+**3. Ensure bookmark exists.**
 
-Check if `metadata.branch` already records a branch:
+Check if `metadata.branch` already records a bookmark:
 ```bash
-BRANCH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.branch // empty')
+BOOKMARK=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.branch // empty')
 ```
 
-**If branch exists in metadata** — treat it as authoritative. This
+**If bookmark exists in metadata** — treat it as authoritative. This
 metadata may come from rejection recovery or from a caller that wants
-work applied to an existing branch. Fetch the named remote branch first.
-If `origin/$BRANCH` exists, make the local branch fast-forward to that
+work applied to an existing bookmark. Fetch the named remote bookmark first.
+If `origin/$BOOKMARK` exists, make the local bookmark fast-forward to that
 remote tip or stop on divergence:
 ```bash
-git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || \
-    echo "Could not fetch metadata.branch=$BRANCH from origin. Checking local refs before stopping."
-if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
-    if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
-        git checkout "$BRANCH" || exit 1
-        git merge --ff-only "origin/$BRANCH" || {
-            echo "Local branch $BRANCH diverged from origin/$BRANCH."
-            echo "STOP. Reconcile the branch before continuing."
+jj git fetch --remote origin --branch "$BOOKMARK" || \
+    echo "Could not fetch metadata.branch=$BOOKMARK from origin. Checking local refs before stopping."
+if [ -n "$(jj bookmark list --remote origin "$BOOKMARK" 2>/dev/null || true)" ]; then
+    if [ -n "$(jj bookmark list "$BOOKMARK" 2>/dev/null || true)" ]; then
+        jj bookmark move "$BOOKMARK" --to "origin/$BOOKMARK" || {
+            echo "Local bookmark $BOOKMARK diverged from origin/$BOOKMARK."
+            echo "STOP. Reconcile the bookmark before continuing."
             gc runtime drain-ack
             exit 1
         }
     else
-        git checkout --track -b "$BRANCH" "origin/$BRANCH" || exit 1
+        jj bookmark create "$BOOKMARK" -r "origin/$BOOKMARK" || exit 1
     fi
-elif git show-ref --verify --quiet "refs/heads/$BRANCH"; then
-    git checkout "$BRANCH" || exit 1
+elif [ -n "$(jj bookmark list "$BOOKMARK" 2>/dev/null || true)" ]; then
+    :
 else
-    echo "metadata.branch=$BRANCH was set but no local or origin branch exists."
-    echo "STOP. Do not create a different branch."
+    echo "metadata.branch=$BOOKMARK was set but no local or origin bookmark exists."
+    echo "STOP. Do not create a different bookmark."
     gc runtime drain-ack
     exit 1
 fi
 ```
-If resuming a rejected branch, rebase onto latest base:
+If resuming a rejected bookmark, rebase onto latest base:
 ```bash
 REJECTION=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.rejection_reason // empty')
 if [ -n "$REJECTION" ]; then
-    git rebase origin/{{base_branch}}
+    jj rebase -d origin/{{base_branch}}
     # If conflicts: resolve them (this is likely the rejection reason)
-    # After resolving: git rebase --continue
+    # After resolving: jj rebase --continue
     gc bd update "$WORK_BEAD_ID" --unset-metadata rejection_reason
 fi
 ```
 
-**If no branch** — create one and record it. Always branch from the
+**If no bookmark** — create one and record it. Always create it from the
 freshly-fetched `origin/{{base_branch}}`, never from local
 {{base_branch}} or whatever branch happens to be checked out.
 Polecat worktrees are reused across beads, so the local copy of
-{{base_branch}} may lag the remote — branching from a stale local ref
+{{base_branch}} may lag the remote — creating from a stale local ref
 inherits already-merged commits with stale hashes and causes the next
 refinery rebase to reject for spurious "duplicate" conflicts.
 
 ```bash
-git fetch origin {{base_branch}}                     # ensure origin ref is current
-BRANCH="polecat/$WORK_BEAD_ID"
-git branch -D "$BRANCH" 2>/dev/null || true          # drop any stale local branch with the same name
-git checkout -B "$BRANCH" "origin/{{base_branch}}"   # force-create from the freshly-fetched remote tip
-gc bd update "$WORK_BEAD_ID" --set-metadata branch="$BRANCH"
+jj git fetch --remote origin --branch "{{base_branch}}"  # ensure origin ref is current
+BOOKMARK="polecat/$WORK_BEAD_ID"
+jj bookmark forget "$BOOKMARK" 2>/dev/null || true       # drop any stale local bookmark with the same name
+jj bookmark create "$BOOKMARK" -r "origin/{{base_branch}}"  # force-create from the freshly-fetched remote tip
+gc bd update "$WORK_BEAD_ID" --set-metadata branch="$BOOKMARK"
 ```
 
-Recording the branch early means:
+Recording the bookmark early means:
 - Witness can find and salvage your work if you crash
-- Rejection-aware resume knows which branch to check out
+- Rejection-aware resume knows which bookmark to check out
 - The submit step updates the metadata (branch may change after rebase)
 
 **4. Ensure clean working state:**
 ```bash
-git status                  # Should be clean
+jj st                  # Should be clean
 ```
 
 **5. Run project setup (if configured):**
@@ -194,8 +194,8 @@ git status                  # Should be clean
 ```
 Empty setup_command → skip.
 
-**Exit criteria:** In your worktree, on a clean feature branch, rebased
-on latest {{base_branch}}, deps installed, worktree and branch recorded
+**Exit criteria:** In your workspace, on a clean feature bookmark, rebased
+on latest {{base_branch}}, deps installed, workspace and bookmark recorded
 on the bead."""
 
 [[steps]]
@@ -218,9 +218,9 @@ locally-runnable failures should have been caught before push.
 
 **1. Review the diff:**
 ```bash
-git diff origin/{{base_branch}}...HEAD
-git log --oneline origin/{{base_branch}}..HEAD
-git diff --stat origin/{{base_branch}}...HEAD
+jj diff --git
+jj log -r 'trunk()..@' --no-graph -n 5
+jj diff --stat origin/{{base_branch}}...HEAD
 ```
 
 Check for: bugs, security issues, style violations, missing error handling,
@@ -239,7 +239,7 @@ debug cruft, unintended file changes. Fix anything you find.
 if [ -n "{{affected_tests_command}}" ]; then
     # Rig has an affected-tests detector. Run only the tests our diff
     # touches — same logic the rig's CI uses to dispatch test workflows.
-    # The command must read `git diff --name-only origin/{{base_branch}}...HEAD`
+    # The command must read `jj diff --name-only origin/{{base_branch}}...HEAD`
     # internally and execute the relevant test subset.
     {{affected_tests_command}}
 else
@@ -258,8 +258,8 @@ submitting.
 
 **4. Ensure everything is committed:**
 ```bash
-git status                  # Must be clean
-git log origin/{{base_branch}}..HEAD --oneline  # Must show your commits
+jj st                  # Must be clean
+jj log -r 'trunk()..@' --no-graph  # Must show your commits
 ```
 
 If uncommitted changes exist, commit them with a body explaining what
@@ -288,33 +288,28 @@ needs = ["self-review"]
 description = """
 Hand off your work and self-clean. You cease to exist after this step.
 
-**1. Branch-shape gate (fails closed — non-negotiable).**
+**1. Bookmark-shape gate (fails closed — non-negotiable).**
 
-Before anything else, verify you are on a per-bead branch. The refinery
-merges the branch recorded in your bead's `metadata.branch`, which must
+Before anything else, verify you are on a per-bead bookmark. The refinery
+merges the bookmark recorded in your bead's `metadata.branch`, which must
 follow the `polecat/<bead-id>` convention; if you push from a different
-branch (your agent home branch, a stray local checkout, etc.), the
+bookmark (your agent home bookmark, a stray local checkout, etc.), the
 handoff contract is broken and the bead is permanently stranded as
 "assigned to refinery, no merge target". See gastownhall/gascity#2082.
 
 ```bash
 CONVOY_STATUS=$(gc convoy status {{convoy_id}} --json)
 WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
-CURRENT_BRANCH=$(git branch --show-current)
-EXPECTED_BRANCH="polecat/$WORK_BEAD_ID"
-if [ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]; then
-    echo "BRANCH SHAPE GATE FAILED"
-    echo "  current branch:  $CURRENT_BRANCH"
-    echo "  expected branch: $EXPECTED_BRANCH"
+EXPECTED_BOOKMARK="polecat/$WORK_BEAD_ID"
+if ! jj bookmark list -r @ | grep -q "^$EXPECTED_BOOKMARK:"; then
+    echo "BOOKMARK SHAPE GATE FAILED"
+    echo "  current bookmark:  $EXPECTED_BOOKMARK"
+    echo "  expected bookmark: $EXPECTED_BOOKMARK"
     echo ""
     echo "Refinery handoff merges metadata.branch, which must be 'polecat/<bead-id>'."
     echo "Pushing this commit and reassigning to refinery would strand the work."
     echo ""
-    echo "Recover by re-running the workspace-setup step:"
-    echo "  - Create the per-bead worktree at \\$(pwd)/worktrees/$WORK_BEAD_ID"
-    echo "  - Create branch '$EXPECTED_BRANCH' from origin/{{base_branch}}"
-    echo "  - Cherry-pick your commits from $CURRENT_BRANCH onto the new branch"
-    echo "  - Re-run submit-and-exit"
+    echo "Recover by re-running workspace-setup and creating the per-bead bookmark."
     echo ""
     echo "Do NOT proceed past this gate."
     gc runtime drain-ack
@@ -322,19 +317,19 @@ if [ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]; then
 fi
 ```
 
-Also confirm `metadata.branch` reflects this branch (workspace-setup
+Also confirm `metadata.branch` reflects this bookmark (workspace-setup
 recorded it, but a divergent local state would be invisible to the
 refinery without this re-check):
 ```bash
 METADATA_BRANCH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.branch // empty')
-if [ "$METADATA_BRANCH" != "$EXPECTED_BRANCH" ]; then
-    gc bd update "$WORK_BEAD_ID" --set-metadata branch="$EXPECTED_BRANCH"
+if [ "$METADATA_BRANCH" != "$EXPECTED_BOOKMARK" ]; then
+    gc bd update "$WORK_BEAD_ID" --set-metadata branch="$EXPECTED_BOOKMARK"
 fi
 ```
 
 **2. Final clean-state verification (safeguard):**
 ```bash
-git status --porcelain
+jj st --porcelain
 ```
 If ANY output (untracked files, uncommitted changes):
 ```bash
@@ -348,31 +343,31 @@ BODY
 This is a belt-and-suspenders check — self-review should have caught this,
 but we never push with untracked work left behind.
 
-**3. Push your branch:**
+**3. Push your bookmark:**
 ```bash
 AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
 if [ "$AUTO_PUSH" = "false" ]; then
-  echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
-  BRANCH=$(git branch --show-current)
+  echo "auto_push=false: halting at bookmark-ready (no push, no refinery handoff)"
+  BOOKMARK=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.branch // empty')
   gc bd update "$WORK_BEAD_ID" \
     --status=open --assignee="" \
-    --set-metadata branch="$BRANCH" \
+    --set-metadata branch="$BOOKMARK" \
     --set-metadata target={{base_branch}} \
     --set-metadata branch_ready=true \
     --set-metadata halt_reason=auto_push_false \
     --set-metadata gc.routed_to="" \
-    --notes "Branch ready: auto_push=false (no push, no refinery handoff)"
+    --notes "Bookmark ready: auto_push=false (no push, no refinery handoff)"
   gc runtime drain-ack
   exit 0
 fi
-git push origin HEAD
+BOOKMARK=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.branch // empty')
+jj git push --bookmark "$BOOKMARK"
 ```
 
-**4. Clean up local branch (prevent stale branch accumulation):**
+**4. Clean up local bookmark (prevent stale bookmark accumulation):**
 ```bash
-BRANCH=$(git branch --show-current)
-git checkout --detach                 # Detach so we can delete the branch
-git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
+BOOKMARK=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.branch // empty')
+jj bookmark forget "$BOOKMARK" 2>/dev/null || true
 ```
 
 **5. Update metadata on the work bead:**
@@ -381,11 +376,11 @@ gc bd update "$WORK_BEAD_ID" \
   --set-metadata target={{base_branch}} \
   --notes "Implemented: <brief summary>"
 ```
-Branch was recorded in workspace-setup and is already in metadata.
+Bookmark was recorded in workspace-setup and is already in metadata.
 This adds the target for the refinery. If an existing pull request was
 provided by the caller, `metadata.existing_pr` is preserved for refinery
 validation. The refinery records canonical `pr_url` only after verifying
-the PR is open and matches the branch, base, and origin repository.
+the PR is open and matches the bookmark, base, and origin repository.
 
 **6. Reassign to refinery:**
 ```bash

--- a/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
@@ -20,25 +20,26 @@ pool slot.
 ### The Done Sequence
 
 ```bash
-# Explicit opt-out gate: respect mol-pr-from-issue auto_push=false (halt-at-branch-ready).
+# Explicit opt-out gate: respect mol-pr-from-issue auto_push=false (halt-at-bookmark-ready).
 AUTO_PUSH=$(gc bd show <work-bead> --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
 if [ "$AUTO_PUSH" = "false" ]; then
-  echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
-  BRANCH=$(git branch --show-current)
+  echo "auto_push=false: halting at bookmark-ready (no push, no refinery handoff)"
+  BOOKMARK=$(gc bd show <work-bead> --json | jq -r '.[0].metadata.branch // empty')
   gc bd update <work-bead> \
     --status=open --assignee="" \
-    --set-metadata branch="$BRANCH" \
+    --set-metadata branch="$BOOKMARK" \
     --set-metadata target={{ .DefaultBranch }} \
     --set-metadata branch_ready=true \
     --set-metadata halt_reason=auto_push_false \
     --set-metadata gc.routed_to="" \
-    --notes "Branch ready: auto_push=false (no push, no refinery handoff)"
+    --notes "Bookmark ready: auto_push=false (no push, no refinery handoff)"
   gc runtime drain-ack
   exit 0
 fi
-git push origin HEAD
+BOOKMARK=$(gc bd show <work-bead> --json | jq -r '.[0].metadata.branch // empty')
+jj git push --bookmark "$BOOKMARK"
 gc bd update <work-bead> \
-  --set-metadata branch=$(git branch --show-current) \
+  --set-metadata branch="$BOOKMARK" \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"
@@ -47,7 +48,7 @@ gc runtime drain-ack
 exit
 ```
 
-This pushes your branch, sets metadata so the Refinery knows what to merge,
+This pushes your bookmark, sets metadata so the Refinery knows what to merge,
 reassigns the work bead to the Refinery, and signals the reconciler to kill
 this session. `gc runtime drain-ack` makes the shutdown immediate. Polecats
 do not push to main, close beads, create MR beads, or wait around.

--- a/examples/jj-spr/agents/spr-lander/agent.toml
+++ b/examples/jj-spr/agents/spr-lander/agent.toml
@@ -1,0 +1,10 @@
+scope = "rig"
+provider = "codex-mini"
+wake_mode = "fresh"
+work_dir = ".gc/workspaces/{{.Rig}}/spr-lander"
+nudge = "Run gc hook; land approved SPR review objects."
+pre_start = ["{{.ConfigDir}}/assets/scripts/workspace-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
+idle_timeout = "2h"
+min_active_sessions = 0
+max_active_sessions = 1
+default_sling_formula = "mol-spr-independent-land"

--- a/examples/jj-spr/agents/spr-lander/prompt.template.md
+++ b/examples/jj-spr/agents/spr-lander/prompt.template.md
@@ -1,0 +1,58 @@
+# SPR Lander Context
+
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session.
+
+## Your Role: SPR LANDER for {{ .RigName }}
+
+You land approved SPR review objects. You do not write application code and you
+do not repair a polecat's implementation. If the review object cannot land
+cleanly, update durable metadata and route the work back to the correct pool.
+
+## Contract
+
+1. Read assigned work beads with `merge_strategy=spr`.
+2. Validate `spr_backend`, `spr_mode`, `spr_change_id`, and target metadata.
+3. For independent work, land in any order.
+4. For stacked work, land only when all lower `spr_stack_index` entries are
+   already landed.
+5. Run or verify the required gates.
+6. Land the review object.
+7. Fetch and rebase the empty working copy after landing.
+8. Close the work bead with `gc.outcome=landed`.
+
+## Backend Behavior
+
+For GitHub backend:
+
+```bash
+gh pr view "$PR_URL" --json state,reviewDecision,mergeable,statusCheckRollup
+jj spr land --cherry-pick -r "$SPR_CHANGE_ID"   # independent
+jj spr land -r "$SPR_CHANGE_ID"                 # stacked
+jj git fetch
+jj rebase -r @ -d "$TARGET@origin"
+```
+
+For local backend, the local `spr-pr` bead is the review object. It must say:
+
+```text
+review_status=approved
+ci_status=success
+mergeable=true
+spr_status=open
+```
+
+Then land the recorded change:
+
+```bash
+jj git fetch
+jj rebase -r "$SPR_CHANGE_ID" -d "$TARGET@origin"
+jj bookmark move "$TARGET" --to "$SPR_CHANGE_ID"
+jj git push --bookmark "$TARGET"
+jj new "$TARGET@origin"
+```
+
+If any command fails, stop. Update the work bead with `spr_blocked_reason` and
+leave it open.
+
+Default formula: `mol-spr-independent-land`
+Stacked formula: `mol-spr-stack-land`

--- a/examples/jj-spr/agents/spr-polecat/agent.toml
+++ b/examples/jj-spr/agents/spr-polecat/agent.toml
@@ -1,0 +1,10 @@
+scope = "rig"
+provider = "codex-mini"
+wake_mode = "fresh"
+work_dir = ".gc/workspaces/{{.Rig}}/spr-polecats/{{.AgentBase}}"
+nudge = "Run gc hook; publish assigned SPR work as a review object."
+pre_start = ["{{.ConfigDir}}/assets/scripts/workspace-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
+idle_timeout = "2h"
+min_active_sessions = 0
+max_active_sessions = 3
+default_sling_formula = "mol-spr-independent-work"

--- a/examples/jj-spr/agents/spr-polecat/prompt.template.md
+++ b/examples/jj-spr/agents/spr-polecat/prompt.template.md
@@ -1,0 +1,90 @@
+# SPR Polecat Context
+
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session.
+
+## Your Role: SPR POLECAT for {{ .RigName }}
+
+You are a pool worker for the SPR review workflow. You create and update review
+objects from local Jujutsu changes. You do not merge to the target branch.
+
+Your default backend is local unless the work bead says otherwise:
+
+- `spr_backend=local` creates or updates a local `spr-pr` bead.
+- `spr_backend=github` uses `jj spr diff` and records the GitHub PR.
+
+Your default formula is `mol-spr-independent-work`. Use
+`mol-spr-stack-work` only when the assignment is explicitly routed as stacked
+work:
+
+- `spr_mode=independent` means the review can land in any order.
+- `spr_mode=stacked` means the review is part of a parent-to-child stack.
+
+## Contract
+
+1. Read the assigned bead and its metadata.
+2. Create one focused jj change for the work.
+3. Keep `@` empty before publishing; the review change should be at `@-`.
+4. Write the PR body in the jj description before publishing. `jj-spr` does
+   not invent descriptions; it copies the jj description body into GitHub.
+5. Run the repo's quality gates.
+6. Publish the review object.
+7. Record durable metadata on the work bead.
+8. Assign the work bead to `{{ .RigName }}/spr-lander`.
+9. Drain; do not close the work bead yourself.
+
+## Required Metadata
+
+After publishing, the work bead must include:
+
+```text
+merge_strategy=spr
+spr_backend=local|github
+spr_mode=independent|stacked
+spr_change_id=<jj change id>
+spr_target=<target bookmark>
+```
+
+For local backend, also record:
+
+```text
+spr_pr_bead=<spr-pr bead id>
+```
+
+For GitHub backend, also record:
+
+```text
+pr_url=<canonical GitHub PR URL>
+pr_number=<number>
+```
+
+For stacked mode, also record:
+
+```text
+spr_stack_id=<shared stack id>
+spr_stack_parent=<parent change id, empty for root>
+spr_stack_index=<1-based order>
+```
+
+Every review description must include a non-empty `Summary:` section before
+publishing. Stacked reviews must also include a `Stack:` section that explains
+the parent/child order and, after PR creation, links to known sibling PRs.
+
+## Commands
+
+```bash
+jj st
+jj git fetch
+jj new <target>@origin
+jj desc -m "<title>"
+jj new
+jj spr diff --cherry-pick
+jj spr diff --update-message --message "update stack descriptions" -r "<stack revset>"
+gc bd update "$WORK" --set-metadata key=value
+gc bd update "$WORK" --assignee="{{ .RigName }}/spr-lander"
+gc runtime drain-ack
+```
+
+Use explicit revsets and `-m` flags. Never rely on an interactive jj editor.
+
+Default formula: `mol-spr-independent-work`
+Stacked formula: `mol-spr-stack-work`

--- a/examples/jj-spr/agents/spr-witness/agent.toml
+++ b/examples/jj-spr/agents/spr-witness/agent.toml
@@ -1,0 +1,9 @@
+scope = "rig"
+provider = "codex-spark"
+wake_mode = "fresh"
+work_dir = ".gc/workspaces/{{.Rig}}/spr-witness"
+nudge = "Run gc prime; patrol SPR review and landing state."
+pre_start = ["{{.ConfigDir}}/assets/scripts/workspace-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
+idle_timeout = "2h"
+max_active_sessions = 1
+default_sling_formula = "mol-spr-witness-patrol"

--- a/examples/jj-spr/agents/spr-witness/prompt.template.md
+++ b/examples/jj-spr/agents/spr-witness/prompt.template.md
@@ -1,0 +1,25 @@
+# SPR Witness Context
+
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session.
+
+## Your Role: SPR WITNESS for {{ .RigName }}
+
+You patrol the SPR workflow. You do not create PRs, land changes, or write
+application code. You observe durable state, detect stuck reviews, and nudge or
+file follow-up work.
+
+## Patrol Duties
+
+- Verify `jj-spr` is installed when GitHub backend is used.
+- Verify `jj spr list` works when GitHub backend is used.
+- Verify local backend `spr-pr` beads have required metadata.
+- Detect work beads with `merge_strategy=spr` but missing `spr_change_id`.
+- Detect GitHub PRs without `pr_url` or `pr_number`.
+- Detect stacked children whose parents are not landed.
+- Detect stale local reviews waiting too long for approval or CI.
+- Detect lander failures recorded in `spr_blocked_reason`.
+
+Use nudge for routine wakeups and mail only for durable escalations to mayor.
+
+Formula: `mol-spr-witness-patrol`
+

--- a/examples/jj-spr/assets/scripts/workspace-setup.sh
+++ b/examples/jj-spr/assets/scripts/workspace-setup.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+RIG_ROOT="${1:?usage: workspace-setup.sh <rig-root> <target-dir> <agent-name> [--sync]}"
+WT="${2:?missing target-dir}"
+AGENT="${3:?missing agent-name}"
+SYNC="${4:-}"
+
+write_runtime_files() {
+    mkdir -p "$WT/.beads"
+    echo "$RIG_ROOT/.beads" > "$WT/.beads/redirect"
+    cat > "$WT/.jjignore" <<'JJIGNORE'
+.beads/redirect
+.beads/hooks/
+.beads/formulas/
+.logs/
+.claude/
+.codex/
+.gemini/
+.opencode/
+__pycache__/
+state.json
+JJIGNORE
+}
+
+if [ -d "$WT/.jj" ]; then
+    write_runtime_files
+    if [ "$SYNC" = "--sync" ]; then
+        jj -R "$WT" git fetch 2>/dev/null || true
+    fi
+    exit 0
+fi
+
+mkdir -p "$(dirname "$WT")"
+if [ -d "$WT" ] && [ "$(find "$WT" -mindepth 1 -maxdepth 1 | head -n 1)" ]; then
+    echo "workspace-setup: target exists and is non-empty: $WT" >&2
+    exit 1
+fi
+
+jj -R "$RIG_ROOT" git fetch 2>/dev/null || true
+
+REVSET=""
+if jj -R "$RIG_ROOT" log -r 'trunk()@origin' --no-graph -T '' >/dev/null 2>&1; then
+    REVSET="trunk()@origin"
+else
+    for candidate in main master trunk beads-doltlite; do
+        if jj -R "$RIG_ROOT" log -r "$candidate@origin" --no-graph -T '' >/dev/null 2>&1; then
+            REVSET="$candidate@origin"
+            break
+        fi
+    done
+fi
+if [ -z "$REVSET" ]; then
+    REVSET="@"
+fi
+
+SAFE_AGENT=$(printf '%s' "$AGENT" | tr -c 'A-Za-z0-9._-' '-')
+WT_HASH=$(printf '%s' "$WT" | cksum | awk '{print $1}')
+WORKSPACE_NAME="${SAFE_AGENT}-${WT_HASH}"
+
+jj -R "$RIG_ROOT" workspace add --name "$WORKSPACE_NAME" "$WT" -r "$REVSET" --sparse-patterns full
+write_runtime_files
+
+if [ "$SYNC" = "--sync" ]; then
+    jj -R "$WT" git fetch 2>/dev/null || true
+fi
+

--- a/examples/jj-spr/doctor/check-jj-spr/doctor.toml
+++ b/examples/jj-spr/doctor/check-jj-spr/doctor.toml
@@ -1,0 +1,2 @@
+description = "Verify jj-spr binary is available for GitHub SPR backend"
+

--- a/examples/jj-spr/embed.go
+++ b/examples/jj-spr/embed.go
@@ -1,0 +1,9 @@
+// Package jjspr embeds the jj-spr workflow pack for bundling into the gc binary.
+package jjspr
+
+import "embed"
+
+// PackFS contains the jj-spr pack files.
+//
+//go:embed pack.toml agents doctor formulas all:assets
+var PackFS embed.FS

--- a/examples/jj-spr/formulas/mol-spr-independent-land.toml
+++ b/examples/jj-spr/formulas/mol-spr-independent-land.toml
@@ -1,0 +1,120 @@
+description = """
+Land an approved independent SPR review object.
+
+Independent reviews can land in any order. Use mol-spr-stack-land for
+parent-to-child stacks.
+"""
+formula = "mol-spr-independent-land"
+
+[vars]
+[vars.issue]
+description = "The work bead ID assigned to this SPR lander"
+required = true
+
+[[steps]]
+id = "validate"
+title = "Validate independent SPR metadata"
+description = """
+Read required metadata:
+
+```bash
+WORK="{{issue}}"
+META=$(gc bd show "$WORK" --json | jq '.[0].metadata')
+BACKEND=$(printf '%s\n' "$META" | jq -r '.spr_backend // empty')
+MODE=$(printf '%s\n' "$META" | jq -r '.spr_mode // "independent"')
+SPR_CHANGE_ID=$(printf '%s\n' "$META" | jq -r '.spr_change_id // empty')
+TARGET=$(printf '%s\n' "$META" | jq -r '.spr_target // .target // empty')
+```
+
+Stop if any required field is missing, or if `spr_mode` is not independent:
+
+```bash
+if [ -z "$BACKEND" ] || [ -z "$SPR_CHANGE_ID" ] || [ -z "$TARGET" ] || [ "$MODE" != "independent" ]; then
+  gc bd update "$WORK" --set-metadata spr_blocked_reason="missing independent SPR metadata; use mol-spr-stack-land for stacked work"
+  exit 1
+fi
+```
+"""
+
+[[steps]]
+id = "check-readiness"
+title = "Check approval, CI, and mergeability"
+needs = ["validate"]
+description = """
+For GitHub backend:
+
+```bash
+PR_URL=$(printf '%s\n' "$META" | jq -r '.pr_url // empty')
+gh pr view "$PR_URL" --json state,reviewDecision,mergeable,statusCheckRollup
+```
+
+Require open state, approval, green required checks, and mergeable status.
+
+For local backend:
+
+```bash
+SPR_PR=$(printf '%s\n' "$META" | jq -r '.spr_pr_bead // empty')
+gc bd show "$SPR_PR" --json | jq '.[0].metadata'
+```
+
+Require:
+
+```text
+review_status=approved
+ci_status=success
+mergeable=true
+spr_status=open
+```
+"""
+
+[[steps]]
+id = "land"
+title = "Land independent SPR review"
+needs = ["check-readiness"]
+description = """
+For GitHub backend:
+
+```bash
+jj spr land --cherry-pick -r "$SPR_CHANGE_ID"
+jj git fetch
+jj rebase -r @ -d "$TARGET@origin"
+```
+
+For local backend:
+
+```bash
+jj git fetch
+jj rebase -r "$SPR_CHANGE_ID" -d "$TARGET@origin"
+jj bookmark move "$TARGET" --to "$SPR_CHANGE_ID"
+jj git push --bookmark "$TARGET"
+jj git fetch
+jj new "$TARGET@origin" -m "empty after landing $WORK"
+gc bd update "$SPR_PR" --set-metadata spr_status=landed --status=closed --notes "Landed $SPR_CHANGE_ID to $TARGET."
+```
+
+If landing fails, stop and update the work bead:
+
+```bash
+gc bd update "$WORK" --set-metadata spr_blocked_reason="land failed: <reason>"
+```
+"""
+
+[[steps]]
+id = "close"
+title = "Close landed work"
+needs = ["land"]
+description = """
+Close the work bead after the target branch/bookmark is updated:
+
+```bash
+gc bd update "$WORK" \
+  --unset-metadata spr_blocked_reason \
+  --set-metadata gc.outcome=landed \
+  --status=closed \
+  --notes "Landed independent SPR backend=$BACKEND change=$SPR_CHANGE_ID target=$TARGET."
+if [ -n "${GC_BEAD_ID:-}" ] && [ "$GC_BEAD_ID" != "$WORK" ]; then
+  gc bd update "$GC_BEAD_ID" --status=closed --set-metadata gc.outcome=pass --notes "Landed $WORK."
+fi
+gc runtime drain-ack
+```
+"""

--- a/examples/jj-spr/formulas/mol-spr-independent-work.toml
+++ b/examples/jj-spr/formulas/mol-spr-independent-work.toml
@@ -1,0 +1,194 @@
+description = """
+Create or update an independent SPR review object for a work bead.
+
+This formula supports two review backends:
+- github: real jj-spr and GitHub PRs.
+- local: beads-backed PR-like review objects.
+
+Independent reviews can land in any order. Use mol-spr-stack-work for
+parent-to-child stacks.
+"""
+formula = "mol-spr-independent-work"
+
+[vars]
+[vars.issue]
+description = "The work bead ID assigned to this SPR polecat"
+required = true
+
+[vars.target]
+description = "Target bookmark/base branch"
+default = ""
+
+[vars.binding_prefix]
+description = "Import binding prefix for agent identities, including trailing dot when bound."
+default = ""
+
+[[steps]]
+id = "read-assignment"
+title = "Read assignment and confirm independent SPR mode"
+description = """
+Read the work bead and determine the backend and target:
+
+```bash
+WORK="{{issue}}"
+META=$(gc bd show "$WORK" --json | jq '.[0].metadata')
+BACKEND=$(printf '%s\n' "$META" | jq -r '.spr_backend // "local"')
+MODE=$(printf '%s\n' "$META" | jq -r '.spr_mode // "independent"')
+TARGET=$(printf '%s\n' "$META" | jq -r '.spr_target // .target // "{{target}}" // empty')
+if [ -z "$TARGET" ]; then
+  TARGET=$(jj log -r 'trunk()@origin' --no-graph -T 'bookmarks' 2>/dev/null | sed 's/@origin.*//' | awk '{print $1}' | head -1)
+fi
+if [ -z "$TARGET" ]; then
+  echo "No target branch/bookmark found; set metadata.target or spr_target."
+  exit 1
+fi
+if [ "$MODE" != "independent" ]; then
+  gc bd update "$WORK" --set-metadata spr_blocked_reason="routed to independent formula with spr_mode=$MODE; use mol-spr-stack-work"
+  exit 1
+fi
+```
+
+Valid values:
+- `spr_backend`: `local` or `github`
+- `spr_mode`: `independent`
+
+Record the normalized workflow metadata if it is missing:
+
+```bash
+gc bd update "$WORK" \
+  --set-metadata merge_strategy=spr \
+  --set-metadata spr_backend="$BACKEND" \
+  --set-metadata spr_mode=independent \
+  --set-metadata spr_target="$TARGET"
+```
+"""
+
+[[steps]]
+id = "implement"
+title = "Implement work in a jj change"
+needs = ["read-assignment"]
+description = """
+Work in this agent's jj workspace. Keep the change focused.
+
+```bash
+jj st
+jj git fetch
+jj new "$TARGET@origin" -m "spr work {{issue}}"
+jj describe -m "$(cat <<'EOF'
+<imperative title for {{issue}}>
+
+Summary:
+- <what changed>
+- <why this belongs in this review>
+
+Test Plan:
+- <command run, or not run with reason>
+EOF
+)"
+```
+
+Make the requested code/docs/test changes. Use normal project instructions and
+the quality gates from the repo. Keep the jj description current as the review
+evolves; `jj-spr` uses the description body as the GitHub PR body. When done,
+move to an empty working copy:
+
+```bash
+jj new -m "empty after {{issue}}"
+```
+
+Exit criteria: the review change is at `@-`, and `@` is empty or contains no
+intentional work.
+"""
+
+[[steps]]
+id = "verify"
+title = "Run quality gates"
+needs = ["implement"]
+description = """
+Run this repo's configured quality gates. If the work bead or repo instructions
+provide specific commands, use those. At minimum inspect the diff:
+
+```bash
+jj diff --git -r @-
+jj st
+```
+
+All relevant gates must pass before publishing. If a gate fails because of this
+change, fix it. If the failure is pre-existing, file or update a bead and record
+the evidence on {{issue}} before continuing.
+"""
+
+[[steps]]
+id = "publish"
+title = "Publish independent SPR review object"
+needs = ["verify"]
+description = """
+Capture the change id:
+
+```bash
+SPR_CHANGE_ID=$(jj log -r @- --no-graph -T 'change_id.short()')
+TITLE=$(jj log -r @- --no-graph -T 'description.first_line()')
+DESC=$(jj log -r "$SPR_CHANGE_ID" --no-graph -T 'description')
+printf '%s\n' "$DESC" | awk '
+  /^Summary:$/ { in_summary=1; next }
+  /^[[:alpha:] ][[:alpha:] ]*:$/ && in_summary { exit found ? 0 : 1 }
+  in_summary && NF { found=1 }
+  END { exit found ? 0 : 1 }
+' || { echo "review description must contain a non-empty Summary section before publishing"; exit 1; }
+```
+
+For GitHub backend:
+
+```bash
+jj spr diff --cherry-pick -r "$SPR_CHANGE_ID"
+PR_URL=$(jj show -r "$SPR_CHANGE_ID" --no-patch | sed -n 's/^Pull Request: //p' | tail -1)
+PR_NUMBER=$(printf '%s\n' "$PR_URL" | sed -n 's#.*/pull/##p')
+test -n "$PR_URL" || { echo "jj spr diff did not record a Pull Request footer"; exit 1; }
+gc bd update "$WORK" \
+  --set-metadata merge_strategy=spr \
+  --set-metadata spr_backend=github \
+  --set-metadata spr_mode=independent \
+  --set-metadata spr_target="$TARGET" \
+  --set-metadata spr_change_id="$SPR_CHANGE_ID" \
+  --set-metadata pr_url="$PR_URL" \
+  --set-metadata pr_number="$PR_NUMBER"
+```
+
+For local backend:
+
+```bash
+SPR_META=$(jq -nc \
+  --arg target "$TARGET" \
+  --arg change "$SPR_CHANGE_ID" \
+  --arg work "$WORK" \
+  '{spr_backend:"local", spr_status:"open", review_status:"pending", ci_status:"pending", mergeable:"unknown", spr_mode:"independent", spr_target:$target, spr_change_id:$change, source_work:$work}')
+SPR_PR=$(gc bd create "SPR: $TITLE" --type=spr-pr --metadata "$SPR_META" --json | jq -r '.id // .[0].id')
+test -n "$SPR_PR" || { echo "failed to create local spr-pr bead"; exit 1; }
+gc bd update "$WORK" \
+  --set-metadata merge_strategy=spr \
+  --set-metadata spr_backend=local \
+  --set-metadata spr_mode=independent \
+  --set-metadata spr_target="$TARGET" \
+  --set-metadata spr_change_id="$SPR_CHANGE_ID" \
+  --set-metadata spr_pr_bead="$SPR_PR"
+```
+"""
+
+[[steps]]
+id = "handoff"
+title = "Assign work to SPR lander and drain"
+needs = ["publish"]
+description = """
+Assign the work bead to the rig SPR lander:
+
+```bash
+LANDER="${GC_RIG:+$GC_RIG/}{{binding_prefix}}spr-lander"
+gc bd update "$WORK" --assignee="$LANDER" --set-metadata gc.routed_to="{{binding_prefix}}spr-lander"
+if [ -n "${GC_BEAD_ID:-}" ] && [ "$GC_BEAD_ID" != "$WORK" ]; then
+  gc bd update "$GC_BEAD_ID" --status=closed --set-metadata gc.outcome=pass --notes "Published independent SPR review for $WORK."
+fi
+gc runtime drain-ack
+```
+
+Do not close the work bead. The lander closes it after landing.
+"""

--- a/examples/jj-spr/formulas/mol-spr-stack-land.toml
+++ b/examples/jj-spr/formulas/mol-spr-stack-land.toml
@@ -1,0 +1,132 @@
+description = """
+Land an approved stacked SPR review object.
+
+Stacked reviews land parent to child. Use mol-spr-independent-land for work
+that can land in any order.
+"""
+formula = "mol-spr-stack-land"
+
+[vars]
+[vars.issue]
+description = "The work bead ID assigned to this SPR lander"
+required = true
+
+[[steps]]
+id = "validate"
+title = "Validate stacked SPR metadata"
+description = """
+Read required metadata:
+
+```bash
+WORK="{{issue}}"
+META=$(gc bd show "$WORK" --json | jq '.[0].metadata')
+BACKEND=$(printf '%s\n' "$META" | jq -r '.spr_backend // empty')
+MODE=$(printf '%s\n' "$META" | jq -r '.spr_mode // empty')
+SPR_CHANGE_ID=$(printf '%s\n' "$META" | jq -r '.spr_change_id // empty')
+TARGET=$(printf '%s\n' "$META" | jq -r '.spr_target // .target // empty')
+STACK_ID=$(printf '%s\n' "$META" | jq -r '.spr_stack_id // empty')
+STACK_INDEX=$(printf '%s\n' "$META" | jq -r '.spr_stack_index // empty')
+STACK_PARENT=$(printf '%s\n' "$META" | jq -r '.spr_stack_parent // empty')
+```
+
+Stop if any required field is missing, or if `spr_mode` is not stacked:
+
+```bash
+if [ -z "$BACKEND" ] || [ -z "$SPR_CHANGE_ID" ] || [ -z "$TARGET" ] || [ -z "$STACK_ID" ] || [ -z "$STACK_INDEX" ] || [ "$MODE" != "stacked" ]; then
+  gc bd update "$WORK" --set-metadata spr_blocked_reason="missing stacked SPR metadata; use mol-spr-independent-land for independent work"
+  exit 1
+fi
+if [ "$STACK_INDEX" != "1" ] && [ -z "$STACK_PARENT" ]; then
+  gc bd update "$WORK" --set-metadata spr_blocked_reason="missing spr_stack_parent for non-root stack entry"
+  exit 1
+fi
+```
+"""
+
+[[steps]]
+id = "check-readiness"
+title = "Check approval, CI, mergeability, and stack order"
+needs = ["validate"]
+description = """
+For GitHub backend:
+
+```bash
+PR_URL=$(printf '%s\n' "$META" | jq -r '.pr_url // empty')
+gh pr view "$PR_URL" --json state,reviewDecision,mergeable,statusCheckRollup
+```
+
+Require open state, approval, green required checks, and mergeable status.
+
+For local backend:
+
+```bash
+SPR_PR=$(printf '%s\n' "$META" | jq -r '.spr_pr_bead // empty')
+gc bd show "$SPR_PR" --json | jq '.[0].metadata'
+```
+
+Require:
+
+```text
+review_status=approved
+ci_status=success
+mergeable=true
+spr_status=open
+```
+
+Then inspect sibling SPR work/review beads with the same `spr_stack_id`. Do not
+land this entry while any lower `spr_stack_index` is still open, unapproved,
+failing CI, or not landed.
+"""
+
+[[steps]]
+id = "land"
+title = "Land stacked SPR review"
+needs = ["check-readiness"]
+description = """
+For GitHub backend:
+
+```bash
+jj spr land -r "$SPR_CHANGE_ID"
+jj git fetch
+jj rebase -r @ -d "$TARGET@origin"
+```
+
+For local backend:
+
+```bash
+jj git fetch
+jj rebase -r "$SPR_CHANGE_ID" -d "$TARGET@origin"
+jj bookmark move "$TARGET" --to "$SPR_CHANGE_ID"
+jj git push --bookmark "$TARGET"
+jj git fetch
+jj new "$TARGET@origin" -m "empty after landing stack entry $WORK"
+gc bd update "$SPR_PR" --set-metadata spr_status=landed --status=closed --notes "Landed stack $STACK_ID entry $STACK_INDEX change $SPR_CHANGE_ID to $TARGET."
+```
+
+If landing fails, stop and update the work bead:
+
+```bash
+gc bd update "$WORK" --set-metadata spr_blocked_reason="land failed: <reason>"
+```
+"""
+
+[[steps]]
+id = "close"
+title = "Close landed stack entry"
+needs = ["land"]
+description = """
+Close the work bead after the target branch/bookmark is updated:
+
+```bash
+gc bd update "$WORK" \
+  --unset-metadata spr_blocked_reason \
+  --set-metadata gc.outcome=landed \
+  --set-metadata spr_stack_landed_index="$STACK_INDEX" \
+  --status=closed \
+  --notes "Landed stacked SPR backend=$BACKEND stack=$STACK_ID index=$STACK_INDEX change=$SPR_CHANGE_ID target=$TARGET."
+if [ -n "${GC_BEAD_ID:-}" ] && [ "$GC_BEAD_ID" != "$WORK" ]; then
+  gc bd update "$GC_BEAD_ID" --status=closed --set-metadata gc.outcome=pass --notes "Landed $WORK."
+fi
+gc runtime drain-ack
+```
+"""

--- a/examples/jj-spr/formulas/mol-spr-stack-work.toml
+++ b/examples/jj-spr/formulas/mol-spr-stack-work.toml
@@ -1,0 +1,237 @@
+description = """
+Create or update a stacked SPR review object for a work bead.
+
+This formula supports two review backends:
+- github: real jj-spr and GitHub PRs.
+- local: beads-backed PR-like review objects.
+
+Stacked reviews land parent to child. Use mol-spr-independent-work for work
+that can land in any order.
+"""
+formula = "mol-spr-stack-work"
+
+[vars]
+[vars.issue]
+description = "The work bead ID assigned to this SPR polecat"
+required = true
+
+[vars.target]
+description = "Target bookmark/base branch"
+default = ""
+
+[vars.binding_prefix]
+description = "Import binding prefix for agent identities, including trailing dot when bound."
+default = ""
+
+[[steps]]
+id = "read-assignment"
+title = "Read assignment and confirm stack metadata"
+description = """
+Read the work bead and determine the backend, target, and stack position:
+
+```bash
+WORK="{{issue}}"
+META=$(gc bd show "$WORK" --json | jq '.[0].metadata')
+BACKEND=$(printf '%s\n' "$META" | jq -r '.spr_backend // "local"')
+MODE=$(printf '%s\n' "$META" | jq -r '.spr_mode // "stacked"')
+TARGET=$(printf '%s\n' "$META" | jq -r '.spr_target // .target // "{{target}}" // empty')
+STACK_ID=$(printf '%s\n' "$META" | jq -r '.spr_stack_id // empty')
+STACK_INDEX=$(printf '%s\n' "$META" | jq -r '.spr_stack_index // empty')
+STACK_PARENT=$(printf '%s\n' "$META" | jq -r '.spr_stack_parent // empty')
+if [ -z "$TARGET" ]; then
+  TARGET=$(jj log -r 'trunk()@origin' --no-graph -T 'bookmarks' 2>/dev/null | sed 's/@origin.*//' | awk '{print $1}' | head -1)
+fi
+if [ -z "$TARGET" ] || [ -z "$STACK_ID" ] || [ -z "$STACK_INDEX" ] || [ "$MODE" != "stacked" ]; then
+  gc bd update "$WORK" --set-metadata spr_blocked_reason="missing stacked SPR metadata; use mol-spr-independent-work for independent work"
+  exit 1
+fi
+if [ "$STACK_INDEX" != "1" ] && [ -z "$STACK_PARENT" ]; then
+  gc bd update "$WORK" --set-metadata spr_blocked_reason="missing spr_stack_parent for non-root stack entry"
+  exit 1
+fi
+```
+
+Valid values:
+- `spr_backend`: `local` or `github`
+- `spr_mode`: `stacked`
+- `spr_stack_id`: shared stack id
+- `spr_stack_index`: 1-based landing order
+- `spr_stack_parent`: parent change id, empty only for the root entry
+
+Record the normalized workflow metadata if it is missing:
+
+```bash
+gc bd update "$WORK" \
+  --set-metadata merge_strategy=spr \
+  --set-metadata spr_backend="$BACKEND" \
+  --set-metadata spr_mode=stacked \
+  --set-metadata spr_target="$TARGET" \
+  --set-metadata spr_stack_id="$STACK_ID" \
+  --set-metadata spr_stack_index="$STACK_INDEX" \
+  --set-metadata spr_stack_parent="$STACK_PARENT"
+```
+"""
+
+[[steps]]
+id = "implement"
+title = "Implement stacked work in a jj change"
+needs = ["read-assignment"]
+description = """
+Work in this agent's jj workspace. Keep this stack entry focused.
+
+```bash
+jj st
+jj git fetch
+BASE="$TARGET@origin"
+if [ -n "$STACK_PARENT" ]; then
+  BASE="$STACK_PARENT"
+fi
+jj new "$BASE" -m "spr stack $STACK_ID entry $STACK_INDEX"
+jj describe -m "$(cat <<EOF
+<imperative title for {{issue}}>
+
+Summary:
+- <what changed in this stack entry>
+- <why this entry is separate>
+
+Stack:
+- Entry ${STACK_INDEX}: this PR
+- Parent: ${STACK_PARENT:-none}
+
+Test Plan:
+- <command run, or not run with reason>
+EOF
+)"
+```
+
+Make the requested code/docs/test changes. Use normal project instructions and
+the quality gates from the repo. Keep the jj description current as the review
+evolves; `jj-spr` uses the description body as the GitHub PR body. Stacked
+reviews must describe their stack position locally before publishing. When done,
+move to an empty working copy:
+
+```bash
+jj new -m "empty after stack entry {{issue}}"
+```
+
+Exit criteria: the review change is at `@-`, and `@` is empty or contains no
+intentional work.
+"""
+
+[[steps]]
+id = "verify"
+title = "Run quality gates"
+needs = ["implement"]
+description = """
+Run this repo's configured quality gates. If the work bead or repo instructions
+provide specific commands, use those. At minimum inspect the stack entry diff:
+
+```bash
+jj diff --git -r @-
+jj log -r "::@- & ~::trunk()" --no-graph
+jj st
+```
+
+All relevant gates must pass before publishing. If a gate fails because of this
+change, fix it. If the failure is pre-existing, file or update a bead and record
+the evidence on {{issue}} before continuing.
+"""
+
+[[steps]]
+id = "publish"
+title = "Publish stacked SPR review object"
+needs = ["verify"]
+description = """
+Capture the change id:
+
+```bash
+SPR_CHANGE_ID=$(jj log -r @- --no-graph -T 'change_id.short()')
+TITLE=$(jj log -r @- --no-graph -T 'description.first_line()')
+DESC=$(jj log -r "$SPR_CHANGE_ID" --no-graph -T 'description')
+printf '%s\n' "$DESC" | awk '
+  /^Summary:$/ { in_summary=1; next }
+  /^Stack:$/ { in_stack=1; in_summary=0; next }
+  /^[[:alpha:] ][[:alpha:] ]*:$/ && in_summary { exit summary ? 0 : 1 }
+  in_summary && NF { summary=1 }
+  in_stack && NF { stack=1 }
+  END { exit (summary && stack) ? 0 : 1 }
+' || { echo "stacked review description must contain non-empty Summary and Stack sections before publishing"; exit 1; }
+```
+
+For GitHub backend:
+
+```bash
+jj spr diff -r "$SPR_CHANGE_ID"
+PR_URL=$(jj show -r "$SPR_CHANGE_ID" --no-patch | sed -n 's/^Pull Request: //p' | tail -1)
+PR_NUMBER=$(printf '%s\n' "$PR_URL" | sed -n 's#.*/pull/##p')
+test -n "$PR_URL" || { echo "jj spr diff did not record a Pull Request footer"; exit 1; }
+```
+
+For multi-entry stack publishing, do a second local description pass after all
+stack entries have `Pull Request:` footers. Update each change's `Stack:`
+section with the known parent/child PR URLs, then refresh GitHub bodies from jj:
+
+```bash
+jj spr diff --update-message --message "update stack descriptions" -r "<stack revset>"
+```
+
+Then record metadata:
+
+```bash
+gc bd update "$WORK" \
+  --set-metadata merge_strategy=spr \
+  --set-metadata spr_backend=github \
+  --set-metadata spr_mode=stacked \
+  --set-metadata spr_target="$TARGET" \
+  --set-metadata spr_change_id="$SPR_CHANGE_ID" \
+  --set-metadata spr_stack_id="$STACK_ID" \
+  --set-metadata spr_stack_index="$STACK_INDEX" \
+  --set-metadata spr_stack_parent="$STACK_PARENT" \
+  --set-metadata pr_url="$PR_URL" \
+  --set-metadata pr_number="$PR_NUMBER"
+```
+
+For local backend:
+
+```bash
+SPR_META=$(jq -nc \
+  --arg target "$TARGET" \
+  --arg change "$SPR_CHANGE_ID" \
+  --arg work "$WORK" \
+  --arg stack_id "$STACK_ID" \
+  --arg stack_index "$STACK_INDEX" \
+  --arg stack_parent "$STACK_PARENT" \
+  '{spr_backend:"local", spr_status:"open", review_status:"pending", ci_status:"pending", mergeable:"unknown", spr_mode:"stacked", spr_target:$target, spr_change_id:$change, source_work:$work, spr_stack_id:$stack_id, spr_stack_index:$stack_index, spr_stack_parent:$stack_parent}')
+SPR_PR=$(gc bd create "SPR: $TITLE" --type=spr-pr --metadata "$SPR_META" --json | jq -r '.id // .[0].id')
+test -n "$SPR_PR" || { echo "failed to create local spr-pr bead"; exit 1; }
+gc bd update "$WORK" \
+  --set-metadata merge_strategy=spr \
+  --set-metadata spr_backend=local \
+  --set-metadata spr_mode=stacked \
+  --set-metadata spr_target="$TARGET" \
+  --set-metadata spr_change_id="$SPR_CHANGE_ID" \
+  --set-metadata spr_stack_id="$STACK_ID" \
+  --set-metadata spr_stack_index="$STACK_INDEX" \
+  --set-metadata spr_stack_parent="$STACK_PARENT" \
+  --set-metadata spr_pr_bead="$SPR_PR"
+```
+"""
+
+[[steps]]
+id = "handoff"
+title = "Assign work to SPR lander and drain"
+needs = ["publish"]
+description = """
+Assign the work bead to the rig SPR lander:
+
+```bash
+LANDER="${GC_RIG:+$GC_RIG/}{{binding_prefix}}spr-lander"
+gc bd update "$WORK" --assignee="$LANDER" --set-metadata gc.routed_to="{{binding_prefix}}spr-lander"
+if [ -n "${GC_BEAD_ID:-}" ] && [ "$GC_BEAD_ID" != "$WORK" ]; then
+  gc bd update "$GC_BEAD_ID" --status=closed --set-metadata gc.outcome=pass --notes "Published stacked SPR review for $WORK."
+fi
+gc runtime drain-ack
+```
+
+Do not close the work bead. The lander closes it after landing.
+"""

--- a/examples/jj-spr/formulas/mol-spr-witness-patrol.toml
+++ b/examples/jj-spr/formulas/mol-spr-witness-patrol.toml
@@ -1,0 +1,84 @@
+description = """
+Patrol SPR review workflow state for a rig.
+"""
+formula = "mol-spr-witness-patrol"
+
+[vars]
+[vars.binding_prefix]
+description = "Import binding prefix for agent identities, including trailing dot when bound."
+default = ""
+
+[[steps]]
+id = "check-setup"
+title = "Check SPR tooling"
+description = """
+Check local setup:
+
+```bash
+command -v jj
+command -v gh || true
+command -v jj-spr || true
+jj st
+```
+
+If GitHub backend is used by any open SPR bead, `jj-spr` must be installed and
+`jj spr list` must run. If it fails, record or file a setup bead and nudge the
+mayor. For local-only backend, `jj-spr` is optional.
+"""
+
+[[steps]]
+id = "scan-metadata"
+title = "Scan SPR work and review beads"
+needs = ["check-setup"]
+description = """
+Find inconsistent SPR state:
+
+```bash
+gc bd list --status=open --json | jq '.[] | select(.metadata.merge_strategy=="spr" or .issue_type=="spr-pr") | {id,title,metadata}'
+```
+
+Flag:
+- work beads missing `spr_backend`, `spr_mode`, or `spr_change_id`
+- GitHub backend missing `pr_url`
+- local backend missing `spr_pr_bead`
+- local `spr-pr` beads missing `source_work`
+- stacked beads missing `spr_stack_id` or `spr_stack_index`
+"""
+
+[[steps]]
+id = "scan-readiness"
+title = "Scan readiness and stuck reviews"
+needs = ["scan-metadata"]
+description = """
+For GitHub PRs, use `gh pr view` to check open state, review decision, checks,
+and mergeability. For local PR beads, inspect `review_status`, `ci_status`,
+`mergeable`, and `spr_status`.
+
+Nudge `spr-lander` for ready reviews:
+
+```bash
+gc session nudge {{binding_prefix}}spr-lander "SPR reviews are ready to land; run gc hook."
+```
+
+For blocked reviews, update durable metadata on the work bead:
+
+```bash
+gc bd update <work> --set-metadata spr_blocked_reason="<reason>"
+```
+"""
+
+[[steps]]
+id = "drain"
+title = "Close patrol wisp and drain"
+needs = ["scan-readiness"]
+description = """
+Close this patrol step and drain:
+
+```bash
+if [ -n "${GC_BEAD_ID:-}" ]; then
+  gc bd update "$GC_BEAD_ID" --status=closed --set-metadata gc.outcome=pass --notes "SPR witness patrol complete."
+fi
+gc runtime drain-ack
+```
+"""
+

--- a/examples/jj-spr/pack.toml
+++ b/examples/jj-spr/pack.toml
@@ -1,0 +1,37 @@
+[pack]
+name = "jj-spr"
+version = "0.1.0"
+schema = 2
+description = "SPR workflow pack for Jujutsu-backed pull request review, with GitHub and local beads backends."
+
+[providers.codex-spark]
+base = "builtin:codex"
+ready_delay_ms = 0
+options_schema_merge = "by_key"
+option_defaults = { model = "GPT-5.3-Codex-Spark", effort = "medium" }
+
+[[providers.codex-spark.options_schema]]
+key = "model"
+label = "Model"
+type = "select"
+
+[[providers.codex-spark.options_schema.choices]]
+value = "GPT-5.3-Codex-Spark"
+label = "GPT-5.3 Codex Spark"
+flag_args = ["--model", "GPT-5.3-Codex-Spark"]
+flag_aliases = [["-m", "GPT-5.3-Codex-Spark"]]
+
+[[named_session]]
+template = "spr-polecat"
+scope = "rig"
+mode = "on_demand"
+
+[[named_session]]
+template = "spr-lander"
+scope = "rig"
+mode = "on_demand"
+
+[[named_session]]
+template = "spr-witness"
+scope = "rig"
+mode = "always"

--- a/internal/builtinpacks/registry.go
+++ b/internal/builtinpacks/registry.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/examples/dolt"
 	"github.com/gastownhall/gascity/examples/gastown/packs/gastown"
 	"github.com/gastownhall/gascity/examples/gastown/packs/maintenance"
+	jjspr "github.com/gastownhall/gascity/examples/jj-spr"
 	"github.com/gastownhall/gascity/internal/bootstrap/packs/core"
 	"github.com/gastownhall/gascity/internal/fsys"
 	gitutil "github.com/gastownhall/gascity/internal/git"
@@ -53,6 +54,7 @@ func All() []Pack {
 		{Name: "core", Subpath: "internal/bootstrap/packs/core", FS: core.PackFS},
 		{Name: "bd", Subpath: "examples/bd", FS: bd.PackFS},
 		{Name: "dolt", Subpath: "examples/dolt", FS: dolt.PackFS},
+		{Name: "jj-spr", Subpath: "examples/jj-spr", FS: jjspr.PackFS},
 		{Name: "maintenance", Subpath: "examples/gastown/packs/maintenance", FS: maintenance.PackFS},
 		{Name: "gastown", Subpath: "examples/gastown/packs/gastown", FS: gastown.PackFS},
 	}

--- a/internal/builtinpacks/registry_test.go
+++ b/internal/builtinpacks/registry_test.go
@@ -23,6 +23,7 @@ func TestAllAndSourceAreDeterministic(t *testing.T) {
 		"core=internal/bootstrap/packs/core",
 		"bd=examples/bd",
 		"dolt=examples/dolt",
+		"jj-spr=examples/jj-spr",
 		"maintenance=examples/gastown/packs/maintenance",
 		"gastown=examples/gastown/packs/gastown",
 	}

--- a/scripts/scripts/precommit_contract_test.go
+++ b/scripts/scripts/precommit_contract_test.go
@@ -1,0 +1,146 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPreCommitFormatterPreservesFileMode(t *testing.T) {
+	repoRoot := repoRoot(t)
+	binDir := t.TempDir()
+	fakeLint := filepath.Join(binDir, "golangci-lint")
+	writeExecutable(t, fakeLint, `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -ne 2 ] || [ "$1" != "fmt" ] || [ "$2" != "--stdin" ]; then
+  echo "unexpected golangci-lint args: $*" >&2
+  exit 2
+fi
+cat
+printf '\n'
+`)
+
+	source := filepath.Join(t.TempDir(), "needs_format.go")
+	if err := os.WriteFile(source, []byte("package main"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "precommit-format-staged-go"))
+	cmd.Dir = repoRoot
+	cmd.Env = []string{
+		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+		"TMPDIR=" + t.TempDir(),
+	}
+	cmd.Stdin = strings.NewReader(source + "\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("precommit formatter failed: %v\n%s", err, out)
+	}
+
+	info, err := os.Stat(source)
+	if err != nil {
+		t.Fatalf("stat formatted source: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("formatted source mode = %o, want 644", got)
+	}
+	content, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("read formatted source: %v", err)
+	}
+	if string(content) != "package main\n" {
+		t.Fatalf("formatted content = %q, want package main with newline", content)
+	}
+}
+
+func TestTestFastParallelUsesSanitizedEnvironment(t *testing.T) {
+	repoRoot := repoRoot(t)
+	cmd := exec.Command("make", "-n", "test-fast-parallel")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make -n test-fast-parallel failed: %v\n%s", err, out)
+	}
+	command := string(out)
+	if !strings.Contains(command, "env -i") {
+		t.Fatalf("test-fast-parallel recipe should use TEST_ENV env -i wrapper:\n%s", command)
+	}
+	if !strings.Contains(command, "./scripts/test-local-parallel fast") {
+		t.Fatalf("test-fast-parallel recipe should still dispatch the sharded fast runner:\n%s", command)
+	}
+}
+
+func TestNativeDoltliteBeadsTargetRunsTaggedSuite(t *testing.T) {
+	repoRoot := repoRoot(t)
+	cmd := exec.Command("make", "-n", "test-native-doltlite-beads")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make -n test-native-doltlite-beads failed: %v\n%s", err, out)
+	}
+	command := string(out)
+	for _, want := range []string{
+		"CGO_ENABLED=0",
+		"-tags gascity_native_beads",
+		"./internal/beads",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("test-native-doltlite-beads recipe missing %q:\n%s", want, command)
+		}
+	}
+	for _, banned := range []string{
+		"CGO_ENABLED=1",
+		"cgo,gascity_native_beads",
+	} {
+		if strings.Contains(command, banned) {
+			t.Fatalf("test-native-doltlite-beads recipe must not contain %q (doltlite store now uses pure-Go modernc):\n%s", banned, command)
+		}
+	}
+}
+
+func TestLocalParallelAllowlistIncludesObservableEnv(t *testing.T) {
+	repoRoot := repoRoot(t)
+	script, err := os.ReadFile(filepath.Join(repoRoot, "scripts", "test-local-parallel"))
+	if err != nil {
+		t.Fatalf("read test-local-parallel: %v", err)
+	}
+	content := string(script)
+	for _, key := range []string{"OBSERVABLE_TEST_LOG", "OBSERVABLE_FAILURE_LINES"} {
+		if !strings.Contains(content, key+"=") {
+			t.Fatalf("test-local-parallel job env should pass through %s", key)
+		}
+	}
+	for _, key := range []string{"GC_CITY", "GC_HOME", "GC_SESSION_ID"} {
+		if strings.Contains(content, key+"=") {
+			t.Fatalf("test-local-parallel job env must not pass through live session env %s", key)
+		}
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(wd, "go.mod")); err == nil {
+			return wd
+		}
+		parent := filepath.Dir(wd)
+		if parent == wd {
+			t.Fatalf("go.mod not found from %s", wd)
+		}
+		wd = parent
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes `gc-pjc`: jj auto-generated bookmark names break the refinery handoff contract.

The polecat implementation updates the Gastown polecat work formula, prompt/fragment text, and tests so handoff uses deterministic per-bead jj bookmarks such as `polecat/<bead-id>`.

## Notes

Submitted from fork because pushing `polecat/gc-pjc` directly to `gastownhall/gascity` returned HTTP 403 for this agent. Package tests were reported passing by the polecat before escalation.
