### PR TITLE
fix(beads): cap bd query timeout so reload/doctor degrade (#3191)

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -37,6 +37,14 @@ var (
 	// bdGraphApplyCommandTimeout bounds atomic graph creation below callers'
 	// outer command budgets so transient Dolt stalls can retry or fall back.
 	bdGraphApplyCommandTimeout = 45 * time.Second
+	// bdQueryCommandTimeout bounds the `bd query` subcommand, which reads the
+	// ephemeral (wisp) tier. gc reload and gc doctor run a sequence of these
+	// ephemeral/order-run reads; under the 120s general timeout an
+	// intermittently slow child blocked those commands for minutes (#3191).
+	// A bound well below that lets the runner kill the slow child quickly so
+	// the tier-merge degrades to the durable tier and the lookups continue
+	// instead of blocking. Normal ephemeral reads return in ~2s.
+	bdQueryCommandTimeout = 30 * time.Second
 	// bdSlowTelemetryThreshold is fixed in production via telemetry.BDSlowThreshold:
 	// high enough to avoid normal bd list calls, but below the wrapper timeout.
 	bdSlowTelemetryThreshold = telemetry.BDSlowThreshold
@@ -177,6 +185,8 @@ func bdCommandTimeoutFor(name string, args []string) time.Duration {
 	switch args[0] {
 	case "count", "list", "ready", "show", "stats":
 		return bdReadCommandTimeout
+	case "query":
+		return bdQueryCommandTimeout
 	default:
 		return bdCommandTimeout
 	}

--- a/internal/beads/bdstore_exec_internal_test.go
+++ b/internal/beads/bdstore_exec_internal_test.go
@@ -62,6 +62,22 @@ func TestBDCommandTimeoutForGraphApply(t *testing.T) {
 	}
 }
 
+// TestBDCommandTimeoutForQuery pins the dedicated, shorter bound on the
+// ephemeral `bd query` subcommand (#3191). The bound must be below the general
+// timeout so gc reload / gc doctor kill a slow ephemeral child and degrade to
+// the durable tier instead of blocking.
+func TestBDCommandTimeoutForQuery(t *testing.T) {
+	if got := bdCommandTimeoutFor("bd", []string{"query", "--json", "ephemeral=true", "--limit", "1"}); got != bdQueryCommandTimeout {
+		t.Fatalf("bd query timeout = %s, want %s", got, bdQueryCommandTimeout)
+	}
+	if bdQueryCommandTimeout >= bdCommandTimeout {
+		t.Fatalf("bd query timeout %s must be below general timeout %s", bdQueryCommandTimeout, bdCommandTimeout)
+	}
+	if bdQueryCommandTimeout >= bdReadCommandTimeout {
+		t.Fatalf("bd query timeout %s must be below read timeout %s", bdQueryCommandTimeout, bdReadCommandTimeout)
+	}
+}
+
 func TestExecCommandRunnerEmitsBDSlowForLongBDCommand(t *testing.T) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh unavailable")


### PR DESCRIPTION
## What

`gc reload` (controller reload tick) and `gc doctor` (order-firing check) run a
sequence of order-run / ephemeral lookups that resolve to the `bd query`
subcommand (emitted only by `BdStore.listEphemeral`). `bdCommandTimeoutFor`
classified `query` under the default branch, giving it the 120s general
timeout, so an intermittently slow ephemeral child blocked ~120s per call and a
few stacked into the observed 175s / 240s hangs.

## Why / fix

Add a dedicated `bdQueryCommandTimeout` (30s, well below the 120s general
timeout) and route `bd query` to it. The runner kills the slow child on
deadline (`exec.CommandContext` + `cmd.Cancel`); `mergeListTierResults` then
degrades to the durable (`bd list`) tier, and the order-run lookups continue
instead of blocking. Order-run beads live in both tiers, so the degraded result
is still correct. Normal ephemeral reads (~2s) are far below the bound, so
normal-path behavior is unchanged.

Test: `TestBDCommandTimeoutForQuery` pins the dedicated bound and asserts it is
below both the general and read timeouts.

Refs #3191.