### PR TITLE
Add order-tracking retention visibility

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -257,6 +257,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		} else if n > 0 {
 			fmt.Fprintf(p.Stderr, "gc start: closed %d orphaned order-tracking beads\n", n) //nolint:errcheck // best-effort stderr
 		}
+		warnIfClosedOrderTrackingBacklogLarge(sweepStore, p.Stderr)
 	}()
 
 	od, orderSnapshot := buildOrderDispatcherWithSnapshot(p.CityPath, p.Cfg, p.Rec, p.Stderr, "gc start: order scan")
@@ -1383,6 +1384,41 @@ func (cr *CityRuntime) runOrderTrackingRetentionWatchdog(now time.Time) {
 	if deleted > 0 && cr.stderr != nil {
 		fmt.Fprintf(cr.stderr, "%s: order-tracking retention watchdog: pruned %d closed bead(s)\n", cr.logPrefix, deleted) //nolint:errcheck // best-effort stderr
 	}
+}
+
+const (
+	// orderTrackingRetentionStartupWarnThreshold is the minimum number of closed
+	// order-tracking beads in the city store that triggers a startup advisory.
+	// The watchdog prunes automatically; this warning surfaces cities that have
+	// accumulated a visible backlog before the first watchdog cycle completes.
+	orderTrackingRetentionStartupWarnThreshold = 100
+	// orderTrackingRetentionStartupListLimit caps the startup List query so the
+	// advisory does not scan unbounded closed-bead history on large stores.
+	orderTrackingRetentionStartupListLimit = 1001
+)
+
+// warnIfClosedOrderTrackingBacklogLarge writes a one-line advisory to stderr
+// when the city store holds more than orderTrackingRetentionStartupWarnThreshold
+// closed order-tracking beads. It is best-effort: a nil store or a List error is
+// silently ignored so startup is never blocked.
+func warnIfClosedOrderTrackingBacklogLarge(store beads.Store, stderr io.Writer) {
+	if store == nil {
+		return
+	}
+	closed, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+		Status:   "closed",
+		Label:    labelOrderTracking,
+		TierMode: beads.TierBoth,
+		Limit:    orderTrackingRetentionStartupListLimit,
+	})
+	if err != nil || len(closed) <= orderTrackingRetentionStartupWarnThreshold {
+		return
+	}
+	countStr := fmt.Sprintf("%d", len(closed))
+	if len(closed) >= orderTrackingRetentionStartupListLimit {
+		countStr = "≥1001"
+	}
+	fmt.Fprintf(stderr, "gc start: %s closed order-tracking beads detected — retention watchdog will prune automatically (7d TTL default; configure: [beads.policies.order_tracking].delete_after_close). For immediate cleanup: gc order sweep-tracking\n", countStr) //nolint:errcheck // best-effort stderr
 }
 
 func (cr *CityRuntime) runNudgeMailSweepWatchdog(now time.Time) {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -83,8 +83,9 @@ type CityRuntime struct {
 	orderRescanLast         time.Time
 	trace                   *sessionReconcilerTraceManager
 
-	orderSweepWatchdogLast     time.Time
-	nudgeMailSweepWatchdogLast time.Time
+	orderSweepWatchdogLast             time.Time
+	orderTrackingRetentionWatchdogLast time.Time
+	nudgeMailSweepWatchdogLast         time.Time
 
 	rec events.Recorder
 	cs  *controllerState // nil when controller-managed bead stores are unavailable
@@ -1222,6 +1223,7 @@ func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) {
 	now := time.Now()
 	cr.rescanOrderDispatcherIfDue(ctx, cityRoot, now)
 	cr.runOrderTrackingSweepWatchdog(now)
+	cr.runOrderTrackingRetentionWatchdog(now)
 	cr.runNudgeMailSweepWatchdog(now)
 	if cr.od != nil {
 		cr.od.dispatch(ctx, cityRoot, now)
@@ -1352,6 +1354,37 @@ func (cr *CityRuntime) runOrderTrackingSweepWatchdog(now time.Time) {
 	}
 }
 
+// runOrderTrackingRetentionWatchdog deletes closed order-tracking beads that
+// are past their TTL (defaulting to 7d) and beyond the retain-10 floor, at
+// most once every orderTrackingRetentionWatchdogInterval. It deletes at most
+// orderTrackingRetentionWatchdogDeleteBudget beads per invocation.
+func (cr *CityRuntime) runOrderTrackingRetentionWatchdog(now time.Time) {
+	if !cr.orderTrackingRetentionWatchdogLast.IsZero() &&
+		now.Sub(cr.orderTrackingRetentionWatchdogLast) < orderTrackingRetentionWatchdogInterval {
+		return
+	}
+	cr.orderTrackingRetentionWatchdogLast = now
+
+	stores, _, closeOpened, storeErr := cr.orderTrackingSweepStores()
+	defer closeOpened()
+	if len(stores) == 0 {
+		if storeErr != nil && cr.stderr != nil {
+			fmt.Fprintf(cr.stderr, "%s: order-tracking retention watchdog: %v\n", cr.logPrefix, storeErr) //nolint:errcheck // best-effort stderr
+		}
+		return
+	}
+
+	policy := orderTrackingRetentionPolicyForConfig(cr.cfg)
+	deleted, sweepErr := sweepClosedOrderTrackingRetentionAcrossStoresBounded(
+		stores, now, policy, nil, orderTrackingRetentionWatchdogDeleteBudget)
+	if err := errors.Join(storeErr, sweepErr); err != nil && cr.stderr != nil {
+		fmt.Fprintf(cr.stderr, "%s: order-tracking retention watchdog: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
+	}
+	if deleted > 0 && cr.stderr != nil {
+		fmt.Fprintf(cr.stderr, "%s: order-tracking retention watchdog: pruned %d closed bead(s)\n", cr.logPrefix, deleted) //nolint:errcheck // best-effort stderr
+	}
+}
+
 func (cr *CityRuntime) runNudgeMailSweepWatchdog(now time.Time) {
 	if !cr.nudgeMailSweepWatchdogLast.IsZero() && now.Sub(cr.nudgeMailSweepWatchdogLast) < nudgeMailSweepWatchdogInterval {
 		return
@@ -1385,7 +1418,7 @@ func (cr *CityRuntime) runNudgeMailSweepWatchdog(now time.Time) {
 	}
 }
 
-func (cr *CityRuntime) orderTrackingSweepStores() ([]beads.Store, []orderTrackingSweepTarget, func(), error) {
+func (cr *CityRuntime) orderTrackingSweepStores() ([]beads.Store, []orderTrackingSweepTarget, func(), error) { //nolint:unparam // targets slice returned for callers that need sweep scope metadata; current call sites discard it
 	targets := orderTrackingSweepTargetsForConfig(cr.cityPath, cr.cfg)
 	rigStores := cr.rigBeadStores()
 	var freshlyOpened []beads.Store

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -6288,3 +6288,67 @@ func TestOrderTrackingRetentionWatchdog_StampsLastAfterFiring(t *testing.T) {
 		t.Fatalf("orderTrackingRetentionWatchdogLast = %v, want unchanged %v", cr.orderTrackingRetentionWatchdogLast, now)
 	}
 }
+
+func TestWarnIfClosedOrderTrackingBacklogLarge_SilentAtThreshold(t *testing.T) {
+	// 100 closed beads: at the threshold, no warning (fires only when > 100).
+	seed := make([]beads.Bead, 100)
+	for i := range seed {
+		seed[i] = beads.Bead{
+			ID:     fmt.Sprintf("ot-%03d", i),
+			Status: "closed",
+			Labels: []string{labelOrderTracking},
+		}
+	}
+	store := beads.NewMemStoreFrom(200, seed, nil)
+	var buf bytes.Buffer
+	warnIfClosedOrderTrackingBacklogLarge(store, &buf)
+	if buf.Len() > 0 {
+		t.Fatalf("got unexpected warning at count=100: %q", buf.String())
+	}
+}
+
+func TestWarnIfClosedOrderTrackingBacklogLarge_FiresAboveThreshold(t *testing.T) {
+	// 101 closed beads: above the threshold, warning must fire.
+	seed := make([]beads.Bead, 101)
+	for i := range seed {
+		seed[i] = beads.Bead{
+			ID:     fmt.Sprintf("ot-%03d", i),
+			Status: "closed",
+			Labels: []string{labelOrderTracking},
+		}
+	}
+	store := beads.NewMemStoreFrom(200, seed, nil)
+	var buf bytes.Buffer
+	warnIfClosedOrderTrackingBacklogLarge(store, &buf)
+	got := buf.String()
+	if !strings.Contains(got, "101") {
+		t.Fatalf("warning = %q, want count 101", got)
+	}
+	if !strings.Contains(got, "gc start:") {
+		t.Fatalf("warning = %q, missing 'gc start:' prefix", got)
+	}
+}
+
+func TestWarnIfClosedOrderTrackingBacklogLarge_CapFormatAtLimit(t *testing.T) {
+	// 1001 closed beads: at the list limit, count displays as "≥1001".
+	seed := make([]beads.Bead, 1001)
+	for i := range seed {
+		seed[i] = beads.Bead{
+			ID:     fmt.Sprintf("ot-%04d", i),
+			Status: "closed",
+			Labels: []string{labelOrderTracking},
+		}
+	}
+	store := beads.NewMemStoreFrom(1100, seed, nil)
+	var buf bytes.Buffer
+	warnIfClosedOrderTrackingBacklogLarge(store, &buf)
+	got := buf.String()
+	if !strings.Contains(got, "≥1001") {
+		t.Fatalf("warning = %q, want ≥1001 cap format", got)
+	}
+}
+
+func TestWarnIfClosedOrderTrackingBacklogLarge_SilentOnNilStore(_ *testing.T) {
+	// nil store: must not panic.
+	warnIfClosedOrderTrackingBacklogLarge(nil, io.Discard)
+}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -6139,3 +6139,152 @@ func TestCityRuntimeClearActiveReloadIfRespectsIdentity(t *testing.T) {
 		t.Fatalf("activeReload = %p, want nil after identity-matched clear", gotAfter)
 	}
 }
+
+func TestOrderTrackingRetentionWatchdog_SkipsWhenIntervalNotElapsed(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	// Seed 11 eligible beads (8 days old > 7d default TTL) so deletion would occur if the watchdog runs.
+	seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+1)
+	for i := range minClosedOrderTrackingRetained + 1 {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("skip-%02d", i),
+			Title:     "order:skip",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-8*24*time.Hour + time.Duration(i)*time.Minute),
+			Labels:    []string{"order-run:skip", labelOrderTracking},
+			Ephemeral: true,
+		})
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		standaloneCityStore: store,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+		logPrefix:           "gc test",
+		// Set last to now-1s: interval has not elapsed.
+		orderTrackingRetentionWatchdogLast: now.Add(-time.Second),
+	}
+	cr.runOrderTrackingRetentionWatchdog(now)
+
+	// Bead skip-00 should still exist (watchdog skipped).
+	if _, err := store.Get("skip-00"); err != nil {
+		t.Fatalf("skip-00 should be preserved when watchdog skips: %v", err)
+	}
+}
+
+func TestOrderTrackingRetentionWatchdog_PrunesEligibleBeads(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	// Beads are 8 days old (> 7d default TTL). The 2 oldest exceed the retain-10 floor.
+	seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+2)
+	for i := range minClosedOrderTrackingRetained + 2 {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("prune-%02d", i),
+			Title:     "order:prune",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-8*24*time.Hour + time.Duration(i)*time.Minute),
+			Labels:    []string{"order-run:prune", labelOrderTracking},
+			Ephemeral: true,
+		})
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		standaloneCityStore: store,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+		logPrefix:           "gc test",
+		// Zero last: watchdog fires immediately.
+	}
+	cr.runOrderTrackingRetentionWatchdog(now)
+
+	// 2 oldest beads (prune-00, prune-01) should be deleted.
+	for _, id := range []string{"prune-00", "prune-01"} {
+		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
+			t.Fatalf("Get(%s) err = %v, want ErrNotFound (should be pruned)", id, err)
+		}
+	}
+	// Remaining 10 beads (retain floor) should be preserved.
+	for i := 2; i < minClosedOrderTrackingRetained+2; i++ {
+		id := fmt.Sprintf("prune-%02d", i)
+		if _, err := store.Get(id); err != nil {
+			t.Fatalf("%s should be preserved at retain floor: %v", id, err)
+		}
+	}
+}
+
+func TestOrderTrackingRetentionWatchdog_LogsPrunedCount(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	// Beads are 8 days old (> 7d default TTL). One exceeds the retain-10 floor.
+	seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+1)
+	for i := range minClosedOrderTrackingRetained + 1 {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("log-%02d", i),
+			Title:     "order:log",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-8*24*time.Hour + time.Duration(i)*time.Minute),
+			Labels:    []string{"order-run:log", labelOrderTracking},
+			Ephemeral: true,
+		})
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+	var stderrBuf bytes.Buffer
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		standaloneCityStore: store,
+		stdout:              io.Discard,
+		stderr:              &stderrBuf,
+		logPrefix:           "gc test",
+	}
+	cr.runOrderTrackingRetentionWatchdog(now)
+
+	got := stderrBuf.String()
+	if !strings.Contains(got, "pruned") {
+		t.Fatalf("stderr = %q, want 'pruned' in output", got)
+	}
+	if !strings.Contains(got, "1") {
+		t.Fatalf("stderr = %q, want pruned count in output", got)
+	}
+}
+
+func TestOrderTrackingRetentionWatchdog_NilCfgSkipsWithoutPanic(_ *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	cr := &CityRuntime{
+		cityName:  "test-city",
+		cfg:       nil, // nil cfg: watchdog must not panic
+		stdout:    io.Discard,
+		stderr:    io.Discard,
+		logPrefix: "gc test",
+	}
+	// Must not panic.
+	cr.runOrderTrackingRetentionWatchdog(now)
+}
+
+func TestOrderTrackingRetentionWatchdog_StampsLastAfterFiring(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store := beads.NewMemStore()
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		standaloneCityStore: store,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+		logPrefix:           "gc test",
+	}
+	cr.runOrderTrackingRetentionWatchdog(now)
+
+	if !cr.orderTrackingRetentionWatchdogLast.Equal(now) {
+		t.Fatalf("orderTrackingRetentionWatchdogLast = %v, want %v", cr.orderTrackingRetentionWatchdogLast, now)
+	}
+	// Second call within the interval must not update the timestamp.
+	later := now.Add(time.Minute)
+	cr.runOrderTrackingRetentionWatchdog(later)
+	if !cr.orderTrackingRetentionWatchdogLast.Equal(now) {
+		t.Fatalf("orderTrackingRetentionWatchdogLast = %v, want unchanged %v", cr.orderTrackingRetentionWatchdogLast, now)
+	}
+}

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -283,6 +283,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(newV2RoutedToNamespaceCheck(cfg, cityPath, storeFactory))
 		register(newRunTargetRoutedToBackfillCheck(cfg, cityPath, storeFactory))
 		register(newBacklogDepthCheck(cityPath, storeFactory))
+		register(newOrderTrackingRetentionCheck(cityPath, storeFactory))
 		register(&sessionModelDoctorCheck{cfg: cfg, cityPath: cityPath, newStore: storeFactory})
 	}
 	register(newDoctorDoltServerCheck(cityPath, opts.SkipCityDoltCheck))

--- a/cmd/gc/doctor_order_tracking_retention.go
+++ b/cmd/gc/doctor_order_tracking_retention.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+const (
+	orderTrackingRetentionCheckThreshold = 500
+	orderTrackingRetentionCheckListLimit = 501
+)
+
+// orderTrackingRetentionCheck reports the count of closed order-tracking beads
+// in the city store and warns when retention sweeps are overdue. The controller
+// watchdog prunes these automatically (7d TTL default); the check surfaces
+// cities where the watchdog has not yet run or where the backlog is large enough
+// to be operationally visible. It is pure observability and never gates.
+type orderTrackingRetentionCheck struct {
+	cityPath string
+	newStore func(string) (beads.Store, error)
+}
+
+// newOrderTrackingRetentionCheck constructs an orderTrackingRetentionCheck.
+func newOrderTrackingRetentionCheck(cityPath string, newStore func(string) (beads.Store, error)) *orderTrackingRetentionCheck {
+	return &orderTrackingRetentionCheck{cityPath: cityPath, newStore: newStore}
+}
+
+// Name implements doctor.Check.
+func (c *orderTrackingRetentionCheck) Name() string { return "order-tracking-retention" }
+
+// CanFix implements doctor.Check.
+func (c *orderTrackingRetentionCheck) CanFix() bool { return false }
+
+// Fix implements doctor.Check.
+func (c *orderTrackingRetentionCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+// WarmupEligible implements doctor.Check.
+func (c *orderTrackingRetentionCheck) WarmupEligible() bool { return false }
+
+// Run implements doctor.Check.
+func (c *orderTrackingRetentionCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	res := &doctor.CheckResult{Name: c.Name(), Severity: doctor.SeverityAdvisory}
+	if c.newStore == nil || strings.TrimSpace(c.cityPath) == "" {
+		res.Status = doctor.StatusOK
+		res.Message = "order-tracking retention: no bead store configured"
+		return res
+	}
+	store, err := c.newStore(c.cityPath)
+	if err != nil {
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("order-tracking retention unknown: opening city bead store: %v", err)
+		return res
+	}
+	entries, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+		Status:   "closed",
+		Label:    labelOrderTracking,
+		TierMode: beads.TierBoth,
+		Limit:    orderTrackingRetentionCheckListLimit,
+	})
+	if err != nil {
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("order-tracking retention unknown: listing closed beads: %v", err)
+		return res
+	}
+	count := len(entries)
+	if count >= orderTrackingRetentionCheckThreshold {
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("%d closed order-tracking beads: retention watchdog will prune automatically (7d TTL default; configure [beads.policies.order_tracking].delete_after_close)", count)
+		return res
+	}
+	res.Status = doctor.StatusOK
+	res.Message = fmt.Sprintf("%d closed order-tracking beads", count)
+	return res
+}

--- a/cmd/gc/doctor_order_tracking_retention.go
+++ b/cmd/gc/doctor_order_tracking_retention.go
@@ -67,8 +67,12 @@ func (c *orderTrackingRetentionCheck) Run(_ *doctor.CheckContext) *doctor.CheckR
 	}
 	count := len(entries)
 	if count >= orderTrackingRetentionCheckThreshold {
+		countStr := fmt.Sprintf("%d", count)
+		if count >= orderTrackingRetentionCheckListLimit {
+			countStr = "≥" + fmt.Sprintf("%d", orderTrackingRetentionCheckListLimit)
+		}
 		res.Status = doctor.StatusWarning
-		res.Message = fmt.Sprintf("%d closed order-tracking beads: retention watchdog will prune automatically (7d TTL default; configure [beads.policies.order_tracking].delete_after_close)", count)
+		res.Message = fmt.Sprintf("%s closed order-tracking beads: retention watchdog will prune automatically (7d TTL default; configure [beads.policies.order_tracking].delete_after_close)", countStr)
 		return res
 	}
 	res.Status = doctor.StatusOK

--- a/cmd/gc/doctor_order_tracking_retention_test.go
+++ b/cmd/gc/doctor_order_tracking_retention_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func makeClosedOrderTrackingBeads(n int) []beads.Bead {
+	out := make([]beads.Bead, n)
+	for i := range out {
+		out[i] = beads.Bead{
+			ID:     fmt.Sprintf("ot-%04d", i),
+			Status: "closed",
+			Labels: []string{labelOrderTracking},
+		}
+	}
+	return out
+}
+
+func TestOrderTrackingRetentionCheck_OKWhenBelowThreshold(t *testing.T) {
+	store := beads.NewMemStoreFrom(600, makeClosedOrderTrackingBeads(499), nil)
+	check := newOrderTrackingRetentionCheck("/city", func(string) (beads.Store, error) { return store, nil })
+
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK at 499 beads: %s", res.Status, res.Message)
+	}
+}
+
+func TestOrderTrackingRetentionCheck_WarningAtThreshold(t *testing.T) {
+	store := beads.NewMemStoreFrom(600, makeClosedOrderTrackingBeads(500), nil)
+	check := newOrderTrackingRetentionCheck("/city", func(string) (beads.Store, error) { return store, nil })
+
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("Status = %v, want Warning at 500 beads: %s", res.Status, res.Message)
+	}
+	if !strings.Contains(res.Message, "500") {
+		t.Errorf("Message %q missing count 500", res.Message)
+	}
+}
+
+func TestOrderTrackingRetentionCheck_WarningAboveThreshold(t *testing.T) {
+	store := beads.NewMemStoreFrom(700, makeClosedOrderTrackingBeads(600), nil)
+	check := newOrderTrackingRetentionCheck("/city", func(string) (beads.Store, error) { return store, nil })
+
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("Status = %v, want Warning above threshold: %s", res.Status, res.Message)
+	}
+}
+
+func TestOrderTrackingRetentionCheck_OKWhenNoStore(t *testing.T) {
+	check := newOrderTrackingRetentionCheck("", nil)
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK (no store configured means no beads): %s", res.Status, res.Message)
+	}
+}
+
+func TestOrderTrackingRetentionCheck_WarningOnStoreOpenError(t *testing.T) {
+	check := newOrderTrackingRetentionCheck("/city", func(string) (beads.Store, error) {
+		return nil, fmt.Errorf("store unreachable")
+	})
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("Status = %v, want Warning on store open error: %s", res.Status, res.Message)
+	}
+	if res.Severity != doctor.SeverityAdvisory {
+		t.Fatalf("Severity = %v, want Advisory (observability only): %s", res.Severity, res.Message)
+	}
+}
+
+func TestOrderTrackingRetentionCheck_CheckMetadata(t *testing.T) {
+	check := newOrderTrackingRetentionCheck("/city", func(string) (beads.Store, error) {
+		return beads.NewMemStore(), nil
+	})
+	if check.Name() != "order-tracking-retention" {
+		t.Errorf("Name() = %q, want order-tracking-retention", check.Name())
+	}
+	if check.CanFix() {
+		t.Error("CanFix() = true, want false (read-only observability check)")
+	}
+	if check.WarmupEligible() {
+		t.Error("WarmupEligible() = true, want false")
+	}
+}
+
+func TestOrderTrackingRetentionCheck_RegisteredInBuildDoctorChecks(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{}
+	checks := buildDoctorChecks(cityPath, cfg, nil, buildDoctorChecksOpts{
+		SkipCityDoltCheck:    true,
+		SkipManagedDoltCheck: true,
+	})
+	for _, c := range checks {
+		if c.Name() == "order-tracking-retention" {
+			return
+		}
+	}
+	t.Fatal("order-tracking-retention check not found in buildDoctorChecks output")
+}

--- a/cmd/gc/doctor_order_tracking_retention_test.go
+++ b/cmd/gc/doctor_order_tracking_retention_test.go
@@ -55,6 +55,20 @@ func TestOrderTrackingRetentionCheck_WarningAboveThreshold(t *testing.T) {
 	}
 }
 
+func TestOrderTrackingRetentionCheck_CapFormatAtListLimit(t *testing.T) {
+	// 501 closed beads (the list cap): count displays as "≥501", not exact.
+	store := beads.NewMemStoreFrom(700, makeClosedOrderTrackingBeads(501), nil)
+	check := newOrderTrackingRetentionCheck("/city", func(string) (beads.Store, error) { return store, nil })
+
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("Status = %v, want Warning at list cap: %s", res.Status, res.Message)
+	}
+	if !strings.Contains(res.Message, "≥501") {
+		t.Fatalf("Message = %q, want ≥501 cap format", res.Message)
+	}
+}
+
 func TestOrderTrackingRetentionCheck_OKWhenNoStore(t *testing.T) {
 	check := newOrderTrackingRetentionCheck("", nil)
 	res := check.Run(&doctor.CheckContext{})

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -76,6 +76,14 @@ const (
 	orderTrackingHistoryIndexLimit   = 2048
 	defaultMaxOrderDispatchesPerTick = 4
 	orderTrackingSweepCloseBudget    = 4
+
+	// orderTrackingRetentionWatchdogInterval is the minimum time between
+	// controller-driven closed-bead retention sweeps. 15 minutes balances
+	// effective cleanup against per-tick overhead.
+	orderTrackingRetentionWatchdogInterval = 15 * time.Minute
+	// orderTrackingRetentionWatchdogDeleteBudget bounds the number of
+	// closed order-tracking beads deleted per watchdog invocation.
+	orderTrackingRetentionWatchdogDeleteBudget = 100
 )
 
 var (
@@ -2031,6 +2039,38 @@ func sweepClosedOrderTrackingRetentionAcrossStores(stores []beads.Store, now tim
 	return result, errors.Join(errs...)
 }
 
+// sweepClosedOrderTrackingRetentionAcrossStoresBounded is the watchdog variant
+// of sweepClosedOrderTrackingRetentionAcrossStores. It stops once the total
+// deletion count across all stores reaches limit, returning the partial deleted
+// count with a nil error on budget exhaustion. Store errors are returned as
+// normal; deletion errors within budget are propagated.
+func sweepClosedOrderTrackingRetentionAcrossStoresBounded(stores []beads.Store, now time.Time, policy orderTrackingRetentionPolicy, onlyOrders map[string]struct{}, limit int) (int, error) { //nolint:unparam // onlyOrders is nil at all current call sites; preserved for API parity with the unbounded variant
+	if limit <= 0 {
+		return 0, nil
+	}
+	deleted := 0
+	var errs []error
+	for i, store := range stores {
+		if store == nil {
+			continue
+		}
+		remaining := limit - deleted
+		if remaining <= 0 {
+			break
+		}
+		// Borrow the per-store function but cap via a patched policy that limits
+		// the deleteAfterClose so the store-level function returns early once
+		// the budget is spent. We implement budget enforcement by limiting via
+		// a bounded wrapper around the per-store call.
+		n, err := sweepClosedOrderTrackingRetentionBounded(store, now, policy, onlyOrders, remaining)
+		deleted += n
+		if err != nil {
+			errs = append(errs, fmt.Errorf("pruning closed order-tracking %s: %w", orderTrackingSweepStoreLabel(store, i), err))
+		}
+	}
+	return deleted, errors.Join(errs...)
+}
+
 func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy orderTrackingRetentionPolicy, onlyOrders map[string]struct{}) (int, error) {
 	if store == nil {
 		return 0, fmt.Errorf("bead store unavailable")
@@ -2083,6 +2123,79 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 			continue
 		}
 		for _, entry := range entries[policy.retainLast:] {
+			if !orderTrackingClosedReferenceTime(entry).Before(cutoff) {
+				continue
+			}
+			if err := deleteWorkflowBead(store, entry.ID); err != nil {
+				deleteErr = errors.Join(deleteErr, fmt.Errorf("deleting closed order-tracking bead %q: %w", entry.ID, err))
+				continue
+			}
+			deleted++
+		}
+	}
+	return deleted, deleteErr
+}
+
+// sweepClosedOrderTrackingRetentionBounded is the per-store bounded variant of
+// sweepClosedOrderTrackingRetention. It stops deleting once limit deletions have
+// occurred within this store call. On budget exhaustion it returns the partial
+// count with a nil error; delete errors are still propagated.
+func sweepClosedOrderTrackingRetentionBounded(store beads.Store, now time.Time, policy orderTrackingRetentionPolicy, onlyOrders map[string]struct{}, limit int) (int, error) {
+	if store == nil {
+		return 0, fmt.Errorf("bead store unavailable")
+	}
+	if policy.deleteAfterClose <= 0 || limit <= 0 {
+		return 0, nil
+	}
+	if policy.retainLast < minClosedOrderTrackingRetained {
+		policy.retainLast = minClosedOrderTrackingRetained
+	}
+	entries, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+		Status:   "closed",
+		Label:    labelOrderTracking,
+		Sort:     beads.SortCreatedDesc,
+		TierMode: beads.TierBoth,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("listing closed order-tracking beads: %w", err)
+	}
+
+	byOrder := make(map[string][]beads.Bead)
+	for _, entry := range entries {
+		scopedName, ok := orderTrackingRetentionBucket(entry, onlyOrders)
+		if len(onlyOrders) > 0 {
+			if !ok {
+				continue
+			}
+		}
+		if !ok {
+			scopedName = legacyOrderTrackingRetentionBucket
+		}
+		byOrder[scopedName] = append(byOrder[scopedName], entry)
+	}
+
+	cutoff := now.Add(-policy.deleteAfterClose)
+	deleted := 0
+	var deleteErr error
+	for _, entries := range byOrder {
+		if deleted >= limit {
+			break
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			left := orderTrackingClosedReferenceTime(entries[i])
+			right := orderTrackingClosedReferenceTime(entries[j])
+			if left.Equal(right) {
+				return entries[i].ID > entries[j].ID
+			}
+			return left.After(right)
+		})
+		if len(entries) <= policy.retainLast {
+			continue
+		}
+		for _, entry := range entries[policy.retainLast:] {
+			if deleted >= limit {
+				break
+			}
 			if !orderTrackingClosedReferenceTime(entry).Before(cutoff) {
 				continue
 			}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -2058,10 +2058,8 @@ func sweepClosedOrderTrackingRetentionAcrossStoresBounded(stores []beads.Store, 
 		if remaining <= 0 {
 			break
 		}
-		// Borrow the per-store function but cap via a patched policy that limits
-		// the deleteAfterClose so the store-level function returns early once
-		// the budget is spent. We implement budget enforcement by limiting via
-		// a bounded wrapper around the per-store call.
+		// Enforce the global budget by passing the remaining allowance to the
+		// per-store bounded sweep, which stops deleting once it is spent.
 		n, err := sweepClosedOrderTrackingRetentionBounded(store, now, policy, onlyOrders, remaining)
 		deleted += n
 		if err != nil {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -8424,3 +8424,131 @@ func TestDispatchClosesNoStoresWhenCitySuspended(t *testing.T) {
 		t.Errorf("storeFn called %d times, want 0 when city is suspended", len(spies))
 	}
 }
+
+func TestSweepClosedOrderTrackingRetentionAcrossStoresBounded_HonorsBudgetAcrossStores(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	policy := orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}
+	// Each store gets minClosedOrderTrackingRetained+3 beads (48h old, past 24h TTL), so 3 are eligible per store.
+	makeStore := func(prefix string) *beads.MemStore {
+		seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+3)
+		for i := range minClosedOrderTrackingRetained + 3 {
+			seed = append(seed, beads.Bead{
+				ID:        fmt.Sprintf("%s-%02d", prefix, i),
+				Title:     "order:" + prefix,
+				Status:    "closed",
+				Type:      "task",
+				CreatedAt: now.Add(-48*time.Hour + time.Duration(i)*time.Minute),
+				Labels:    []string{"order-run:" + prefix, labelOrderTracking},
+				Ephemeral: true,
+			})
+		}
+		return beads.NewMemStoreFrom(100, seed, nil)
+	}
+	storeA := makeStore("alpha")
+	storeB := makeStore("beta")
+
+	// limit=4: budget spans both stores (3 eligible each = 6 total), stops at 4.
+	deleted, err := sweepClosedOrderTrackingRetentionAcrossStoresBounded(
+		[]beads.Store{storeA, storeB}, now, policy, nil, 4)
+	if err != nil {
+		t.Fatalf("sweepClosedOrderTrackingRetentionAcrossStoresBounded: %v", err)
+	}
+	if deleted != 4 {
+		t.Fatalf("deleted = %d, want 4 (budget limit)", deleted)
+	}
+}
+
+func TestSweepClosedOrderTrackingRetentionAcrossStoresBounded_ReturnsPartialCountWithNilErrorOnBudgetExhaustion(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	policy := orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}
+	seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+5)
+	for i := range minClosedOrderTrackingRetained + 5 {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("ga-%02d", i),
+			Title:     "order:ga",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-48*time.Hour + time.Duration(i)*time.Minute),
+			Labels:    []string{"order-run:ga", labelOrderTracking},
+			Ephemeral: true,
+		})
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	// limit=2, 5 eligible: returns 2 with nil error.
+	deleted, err := sweepClosedOrderTrackingRetentionAcrossStoresBounded(
+		[]beads.Store{store}, now, policy, nil, 2)
+	if err != nil {
+		t.Fatalf("sweepClosedOrderTrackingRetentionAcrossStoresBounded: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2 (budget limit)", deleted)
+	}
+}
+
+func TestSweepClosedOrderTrackingRetentionAcrossStoresBounded_DoesNotBypassRetainFloor(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	policy := orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}
+	// Exactly minClosedOrderTrackingRetained beads — all at the floor, none eligible.
+	seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained)
+	for i := range minClosedOrderTrackingRetained {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("floor-%02d", i),
+			Title:     "order:floor",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-48*time.Hour + time.Duration(i)*time.Minute),
+			Labels:    []string{"order-run:floor", labelOrderTracking},
+			Ephemeral: true,
+		})
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	deleted, err := sweepClosedOrderTrackingRetentionAcrossStoresBounded(
+		[]beads.Store{store}, now, policy, nil, 100)
+	if err != nil {
+		t.Fatalf("sweepClosedOrderTrackingRetentionAcrossStoresBounded: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted = %d, want 0 (retain-10 floor must hold)", deleted)
+	}
+}
+
+func TestSweepClosedOrderTrackingRetentionAcrossStoresBounded_ZeroLimitDeletesNothing(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	policy := orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}
+	seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+3)
+	for i := range minClosedOrderTrackingRetained + 3 {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("zero-%02d", i),
+			Title:     "order:zero",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-48*time.Hour + time.Duration(i)*time.Minute),
+			Labels:    []string{"order-run:zero", labelOrderTracking},
+			Ephemeral: true,
+		})
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	deleted, err := sweepClosedOrderTrackingRetentionAcrossStoresBounded(
+		[]beads.Store{store}, now, policy, nil, 0)
+	if err != nil {
+		t.Fatalf("sweepClosedOrderTrackingRetentionAcrossStoresBounded: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted = %d, want 0 (limit=0 means no budget)", deleted)
+	}
+}

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -53,6 +53,7 @@ beads-store
 v2-routed-to-namespace
 run-target-routed-to-backfill
 backlog-depth
+order-tracking-retention
 session-model
 dolt-server
 dolt-noms-size

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -254,7 +254,7 @@ BeadPolicyConfig holds storage and retention defaults for a named bead use.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `storage` | string |  |  | Storage selects the intended persistence tier: "history", "no_history", or "ephemeral". Creation paths apply this incrementally as they opt in. Enum: `history`, `no_history`, `ephemeral` |
-| `delete_after_close` | string |  |  | DeleteAfterClose deletes matching GC-owned beads after they have been closed for this duration. Accepts Go duration syntax plus whole-day "d" units, e.g. "7d" or "1d12h". Empty means the policy is not GC-managed. |
+| `delete_after_close` | string |  |  | DeleteAfterClose deletes matching GC-owned beads after they have been closed for this duration. Accepts Go duration syntax plus whole-day "d" units, e.g. "7d" or "1d12h". Empty defers to any controller-managed default for the policy type (e.g. order_tracking defaults to 7d). |
 
 ## BeadsConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -951,7 +951,7 @@
         },
         "delete_after_close": {
           "type": "string",
-          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". Empty means the policy is not GC-managed."
+          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". Empty defers to any controller-managed\ndefault for the policy type (e.g. order_tracking defaults to 7d)."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -951,7 +951,7 @@
         },
         "delete_after_close": {
           "type": "string",
-          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". Empty means the policy is not GC-managed."
+          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". Empty defers to any controller-managed\ndefault for the policy type (e.g. order_tracking defaults to 7d)."
         }
       },
       "additionalProperties": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1356,7 +1356,8 @@ type BeadPolicyConfig struct {
 	Storage string `toml:"storage,omitempty" jsonschema:"enum=history,enum=no_history,enum=ephemeral"`
 	// DeleteAfterClose deletes matching GC-owned beads after they have been
 	// closed for this duration. Accepts Go duration syntax plus whole-day "d"
-	// units, e.g. "7d" or "1d12h". Empty means the policy is not GC-managed.
+	// units, e.g. "7d" or "1d12h". Empty defers to any controller-managed
+	// default for the policy type (e.g. order_tracking defaults to 7d).
 	DeleteAfterClose string `toml:"delete_after_close,omitempty"`
 }
 

--- a/release-gates/ga-2aejra-order-tracking-visibility-gate.md
+++ b/release-gates/ga-2aejra-order-tracking-visibility-gate.md
@@ -1,0 +1,66 @@
+# Release Gate: Order-Tracking Retention Visibility
+
+Date: 2026-06-07
+Deploy bead: ga-2aejra
+Source implementation bead: ga-0op21n.1
+Source review bead: ga-ny8cxu
+Dependency deploy bead: ga-f0efcs
+Branch: release/ga-2aejra-order-tracking-visibility
+Base checked: origin/main fc4fd18021e0d6e257fece81693d60eb35694b9b
+Final code commits:
+
+| Commit | Source | Purpose |
+|---|---|---|
+| f64a9b940 | ga-tjp87g.1 / ga-f0efcs | Adds the controller retention watchdog and bounded closed order-tracking sweep. |
+| f58fdcf26 | PR #3198 follow-up | Corrects the bounded sweep budget-enforcement comment. |
+| c355da6c6 | ga-0op21n.1 / ga-ny8cxu | Adds startup backlog visibility and the `gc doctor` advisory check. |
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the deployer prompt criteria and the deploy bead acceptance checklist.
+
+## Scope
+
+The source builder branch `builder/ga-0op21n-order-tracking-visibility` was behind current `origin/main`. The release branch was rebuilt from current `origin/main` and cherry-picked the already-gated watchdog work plus the reviewed visibility commit, yielding one clean order-tracking retention release unit.
+
+The release diff contains one feature theme:
+
+| Path | Purpose |
+|---|---|
+| `cmd/gc/city_runtime.go` | Runs the retention watchdog during controller dispatch and prints a best-effort startup warning when closed order-tracking backlog is large. |
+| `cmd/gc/order_dispatch.go` | Adds bounded closed order-tracking retention sweep helpers. |
+| `cmd/gc/cmd_doctor.go` | Registers the order-tracking retention advisory check. |
+| `cmd/gc/doctor_order_tracking_retention.go` | Implements the advisory `gc doctor` check. |
+| `internal/config/config.go` | Documents the controller-managed closed tracking bead retention default. |
+| `docs/reference/config.md`, `docs/schema/city-schema.*` | Regenerated config reference/schema for the retention default description. |
+| `cmd/gc/*_test.go`, `cmd/gc/testdata/doctor_check_names.golden` | Covers watchdog, startup warning, doctor behavior, and registration/golden updates. |
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-ny8cxu` is closed with `VERDICT: PASS` for `builder/ga-0op21n-order-tracking-visibility` at `3ccdcd3d4`; dependency `bd show ga-f0efcs` is closed with gate PASS and PR #3198. |
+| 2 | Acceptance criteria met | PASS | See acceptance evidence below. The release branch does not use `builder/ga-uzijoh-mac-ci-timeout-fix`; both dependency beads are complete; the branch is derived from current `origin/main` and contains only order-tracking retention watchdog/visibility work. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed on rerun with `TMPDIR=/home/jaword/tmp/gascity-deploy-ga-2aejra-testtmp LOCAL_TEST_JOBS=12 CMD_GC_PROCESS_TOTAL=6`; `go vet ./...` passed; `make check-schema` passed. An earlier fast run failed during compilation because `/tmp` ran out of space, with no assertion failure. |
+| 4 | No high-severity review findings open | PASS | Review bead `ga-ny8cxu` reports `BLOCKERS: none`; only one non-blocking advisory about documenting the threshold difference. Dependency bead `ga-f0efcs` records gate PASS. Unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` showed `release/ga-2aejra-order-tracking-visibility...origin/main [ahead 3]` with no uncommitted changes before writing this gate. |
+| 6 | Branch diverges cleanly from main | PASS | Branch was created with `git worktree add -B release/ga-2aejra-order-tracking-visibility ... origin/main`; `git merge-base --is-ancestor origin/main HEAD` exited 0 before writing this gate. |
+| 7 | Single feature theme | PASS | All code and docs changes are one order-tracking retention feature: controller pruning, startup backlog visibility, and an advisory doctor check over the same closed tracking bead backlog. The watchdog and visibility pieces are coupled because the warning/check surfaces the backlog the controller retention path manages. |
+
+## Acceptance Evidence
+
+| Deploy bead criterion | Result | Evidence |
+|---|---|---|
+| Do not open or update a PR from `builder/ga-uzijoh-mac-ci-timeout-fix`. | PASS | The release branch is `release/ga-2aejra-order-tracking-visibility`, rebuilt from `origin/main`; the stale CI-timeout branch was not used. |
+| Wait for `ga-ny8cxu` to close with reviewer PASS for the clean visibility branch. | PASS | `bd show ga-ny8cxu` is closed with `VERDICT: PASS` for `builder/ga-0op21n-order-tracking-visibility` at `3ccdcd3d4`. |
+| Wait for `ga-f0efcs` to complete the clean watchdog deploy path, or record why visibility can safely proceed as a stacked unit. | PASS | `bd show ga-f0efcs` is closed with PR #3198. This branch includes the same watchdog feature plus the visibility commit as one stacked order-tracking retention release unit, so it remains self-contained if PR #3198 has not merged yet. |
+| Run the standard deploy gate against a branch containing only order-tracking retention work. | PASS | This gate ran on `release/ga-2aejra-order-tracking-visibility`, whose commits are the watchdog, watchdog comment correction, and visibility/doctor check. |
+| On PASS, open a PR scoped to order-tracking retention visibility and route a merge-request to mayor/mpr. | PENDING | This gate artifact is being committed before PR creation; PR URL and merge-request evidence will be recorded in the bead notes after push/PR creation. |
+| On FAIL, record the gate artifact and route back to PM without opening a PR. | N/A | Gate result is PASS. |
+
+## Test Evidence
+
+- PASS: `TMPDIR=/home/jaword/tmp/gascity-deploy-ga-2aejra-testtmp LOCAL_TEST_JOBS=12 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel`
+- PASS: `TMPDIR=/home/jaword/tmp/gascity-deploy-ga-2aejra-testtmp go vet ./...`
+- PASS: `TMPDIR=/home/jaword/tmp/gascity-deploy-ga-2aejra-testtmp make check-schema`
+- Environmental retry note: an initial `make test-fast-parallel` using `/tmp` failed with `no space left on device` during Go compile/link output. The passing rerun moved temp files to `/home` and lowered parallelism; no code assertion failure was observed.
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

Gas City now prunes closed order-tracking beads from the controller path. The retention watchdog runs during order dispatch, no more than once every 15 minutes, deletes at most 100 closed tracking beads per pass, and preserves the retain-10-per-order floor while honoring `[beads.policies.order_tracking].delete_after_close`.

Operators also get backlog visibility for that same data: startup prints a one-line advisory when a city has more than 100 closed order-tracking beads, and `gc doctor` includes an advisory-only `order-tracking-retention` check that reports the closed backlog and warns at larger counts. The doctor check does not fix or gate anything; it is observability for retention lag.

## Review notes

- This branch includes the retention watchdog and the visibility/doctor check together so the warning/check reports on the same backlog that the controller now prunes.
- The new doctor check is advisory-only, `CanFix=false`, and not warmup-eligible.
- The config schema/reference changes clarify the existing closed tracking bead retention default; there is no new config field and no OpenAPI change.
- Startup visibility is best-effort: startup ignores bead-store open/list errors, while `gc doctor` reports those errors as warnings.

## Test plan

- [x] `TMPDIR=/home/jaword/tmp/gascity-deploy-ga-2aejra-testtmp LOCAL_TEST_JOBS=12 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel`
- [x] `TMPDIR=/home/jaword/tmp/gascity-deploy-ga-2aejra-testtmp go vet ./...`
- [x] `TMPDIR=/home/jaword/tmp/gascity-deploy-ga-2aejra-testtmp make check-schema`
- [x] Release gate: [`release-gates/ga-2aejra-order-tracking-visibility-gate.md`](release-gates/ga-2aejra-order-tracking-visibility-gate.md)