### PR TITLE
fix(dolt): data-plane resilience — auto_gc, backup coverage, journal auto-recovery (#3176)

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -99,6 +99,7 @@ func cityDoltConfigHasLifecycleFields(cfg config.DoltConfig) bool {
 	return cfg.Host != "" ||
 		cfg.Port != 0 ||
 		cfg.ArchiveLevel != nil ||
+		cfg.AutoGCEnabled != nil ||
 		cfg.MaxConnections != 0 ||
 		cfg.ReadTimeoutMillis != 0 ||
 		cfg.WriteTimeoutMillis != 0 ||

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -2005,6 +2005,7 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 		"GC_DOLT_LOCK_FILE",
 		"GC_DOLT_CONFIG_FILE",
 		"GC_DOLT_ARCHIVE_LEVEL",
+		"GC_DOLT_AUTO_GC_ENABLED",
 		"GC_DOLT_MAX_CONNECTIONS",
 		"GC_DOLT_READ_TIMEOUT_MILLIS",
 		"GC_DOLT_WRITE_TIMEOUT_MILLIS",
@@ -2038,6 +2039,9 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 		dc, _ := v.(config.DoltConfig)
 		if dc.ArchiveLevel != nil {
 			env = append(env, fmt.Sprintf("GC_DOLT_ARCHIVE_LEVEL=%d", *dc.ArchiveLevel))
+		}
+		if dc.AutoGCEnabled != nil {
+			env = append(env, fmt.Sprintf("GC_DOLT_AUTO_GC_ENABLED=%t", *dc.AutoGCEnabled))
 		}
 		if dc.MaxConnections > 0 {
 			env = append(env, fmt.Sprintf("GC_DOLT_MAX_CONNECTIONS=%d", dc.MaxConnections))

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -303,6 +303,42 @@ func TestProviderLifecycleProcessEnvPropagatesArchiveLevel(t *testing.T) {
 	}
 }
 
+func TestProviderLifecycleProcessEnvPropagatesAutoGCEnabled(t *testing.T) {
+	cityPath := t.TempDir()
+	normPath := normalizePathForCompare(cityPath)
+
+	autoGC := false
+	cityDoltConfigs.Store(normPath, config.DoltConfig{AutoGCEnabled: &autoGC})
+	t.Cleanup(func() { cityDoltConfigs.Delete(normPath) })
+
+	envEntries := mustProviderLifecycleProcessEnv(t, cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
+	env := map[string]string{}
+	for _, entry := range envEntries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	if got := env["GC_DOLT_AUTO_GC_ENABLED"]; got != "false" {
+		t.Fatalf("GC_DOLT_AUTO_GC_ENABLED = %q, want %q", got, "false")
+	}
+}
+
+func TestProviderLifecycleProcessEnvOmitsAutoGCEnabledWhenNil(t *testing.T) {
+	cityPath := t.TempDir()
+	normPath := normalizePathForCompare(cityPath)
+
+	cityDoltConfigs.Store(normPath, config.DoltConfig{})
+	t.Cleanup(func() { cityDoltConfigs.Delete(normPath) })
+
+	envEntries := mustProviderLifecycleProcessEnv(t, cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
+	for _, entry := range envEntries {
+		if strings.HasPrefix(entry, "GC_DOLT_AUTO_GC_ENABLED=") {
+			t.Fatalf("GC_DOLT_AUTO_GC_ENABLED should not be set when AutoGCEnabled is nil, got %q", entry)
+		}
+	}
+}
+
 func TestProviderLifecycleProcessEnvPropagatesManagedDoltListenerOverrides(t *testing.T) {
 	cityPath := t.TempDir()
 	normPath := normalizePathForCompare(cityPath)
@@ -374,6 +410,25 @@ func TestCityDoltConfigHasLifecycleFieldsRecognizesDoltLockReleaseTimeout(t *tes
 	// entry and the value never reaches providerLifecycleProcessEnv.
 	if !cityDoltConfigHasLifecycleFields(config.DoltConfig{DoltLockReleaseTimeout: "90s"}) {
 		t.Fatal("cityDoltConfigHasLifecycleFields must recognize DoltLockReleaseTimeout")
+	}
+	if cityDoltConfigHasLifecycleFields(config.DoltConfig{}) {
+		t.Fatal("cityDoltConfigHasLifecycleFields must stay false for an empty config")
+	}
+}
+
+func TestCityDoltConfigHasLifecycleFieldsRecognizesAutoGCEnabled(t *testing.T) {
+	// A city that sets only [dolt].auto_gc_enabled must register its dolt
+	// config — otherwise startBeadsLifecycle clears the registry entry and
+	// the documented auto_gc_enabled=false rollback never reaches
+	// providerLifecycleProcessEnv, so the shell fallback silently re-enables
+	// auto-GC. Both an explicit false and an explicit true must register.
+	autoGCOff := false
+	if !cityDoltConfigHasLifecycleFields(config.DoltConfig{AutoGCEnabled: &autoGCOff}) {
+		t.Fatal("cityDoltConfigHasLifecycleFields must recognize AutoGCEnabled=false")
+	}
+	autoGCOn := true
+	if !cityDoltConfigHasLifecycleFields(config.DoltConfig{AutoGCEnabled: &autoGCOn}) {
+		t.Fatal("cityDoltConfigHasLifecycleFields must recognize AutoGCEnabled=true")
 	}
 	if cityDoltConfigHasLifecycleFields(config.DoltConfig{}) {
 		t.Fatal("cityDoltConfigHasLifecycleFields must stay false for an empty config")
@@ -10451,6 +10506,47 @@ func TestStartBeadsLifecycleRegistersArchiveLevelOnlyDoltConfig(t *testing.T) {
 	}
 	if got := env["GC_DOLT_ARCHIVE_LEVEL"]; got != "1" {
 		t.Fatalf("GC_DOLT_ARCHIVE_LEVEL = %q, want 1", got)
+	}
+}
+
+func TestStartBeadsLifecycleRegistersAutoGCOnlyDoltConfig(t *testing.T) {
+	// A city.toml whose [dolt] table sets only auto_gc_enabled = false (the
+	// documented opt-out and the documented rollback for the auto-GC default
+	// flip) must register its dolt config so the override reaches the managed
+	// dolt server. Without AutoGCEnabled in cityDoltConfigHasLifecycleFields,
+	// startBeadsLifecycle clears the registry entry and
+	// providerLifecycleProcessEnvFromBase never projects
+	// GC_DOLT_AUTO_GC_ENABLED, so the shell fallback re-enables auto-GC.
+	realCity := t.TempDir()
+	aliasRoot := t.TempDir()
+	aliasCity := filepath.Join(aliasRoot, "city-link")
+	if err := os.Symlink(realCity, aliasCity); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", aliasCity)
+	t.Setenv("GC_DOLT", "skip")
+
+	autoGCOff := false
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Dolt:      config.DoltConfig{AutoGCEnabled: &autoGCOff},
+	}
+	if err := startBeadsLifecycle(aliasCity, "test-city", cfg, io.Discard); err != nil {
+		t.Fatalf("startBeadsLifecycle: %v", err)
+	}
+	t.Cleanup(func() { cityDoltConfigs.Delete(normalizePathForCompare(realCity)) })
+
+	envEntries := mustProviderLifecycleProcessEnv(t, realCity, "exec:"+gcBeadsBdScriptPath(realCity))
+	env := map[string]string{}
+	for _, entry := range envEntries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	if got := env["GC_DOLT_AUTO_GC_ENABLED"]; got != "false" {
+		t.Fatalf("GC_DOLT_AUTO_GC_ENABLED = %q, want false", got)
 	}
 }
 

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -7918,11 +7918,11 @@ data_dir: "$data_dir"
 
 behavior:
   auto_gc_behavior:
-    enable: false
+    enable: true
     archive_level: 0
 
 system_variables:
-  dolt_auto_gc_enabled: "OFF"
+  dolt_auto_gc_enabled: "ON"
   dolt_stats_enabled: "OFF"
   dolt_stats_gc_enabled: "OFF"
   dolt_stats_memory_only: "ON"
@@ -8180,11 +8180,11 @@ data_dir: "$data_dir"
 
 behavior:
   auto_gc_behavior:
-    enable: false
+    enable: true
     archive_level: 0
 
 system_variables:
-  dolt_auto_gc_enabled: "OFF"
+  dolt_auto_gc_enabled: "ON"
   dolt_stats_enabled: "OFF"
   dolt_stats_gc_enabled: "OFF"
   dolt_stats_memory_only: "ON"

--- a/cmd/gc/cmd_dolt_config.go
+++ b/cmd/gc/cmd_dolt_config.go
@@ -30,6 +30,7 @@ func newDoltConfigCmd(_ io.Writer, stderr io.Writer) *cobra.Command {
 		dataDir      string
 		logLevel     string
 		archiveLevel int
+		autoGC       bool
 		maxConns     int
 		readTimeout  int
 		writeTimeout int
@@ -47,6 +48,7 @@ func newDoltConfigCmd(_ io.Writer, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			doltConfig := config.DoltConfig{
 				ArchiveLevel:       &archiveLevel,
+				AutoGCEnabled:      &autoGC,
 				MaxConnections:     maxConns,
 				ReadTimeoutMillis:  readTimeout,
 				WriteTimeoutMillis: writeTimeout,
@@ -64,6 +66,7 @@ func newDoltConfigCmd(_ io.Writer, stderr io.Writer) *cobra.Command {
 	writeManaged.Flags().StringVar(&dataDir, "data-dir", "", "Dolt data directory")
 	writeManaged.Flags().StringVar(&logLevel, "log-level", "warning", "Dolt log level")
 	writeManaged.Flags().IntVar(&archiveLevel, "archive-level", 0, "Dolt auto_gc archive_level (0=off, 1=on)")
+	writeManaged.Flags().BoolVar(&autoGC, "auto-gc-enabled", true, "enable Dolt incremental auto-GC")
 	writeManaged.Flags().IntVar(&maxConns, "max-connections", 0, "Dolt listener max_connections (0=managed default)")
 	writeManaged.Flags().IntVar(&readTimeout, "read-timeout-millis", 0, "Dolt listener read_timeout_millis (0=managed default)")
 	writeManaged.Flags().IntVar(&writeTimeout, "write-timeout-millis", 0, "Dolt listener write_timeout_millis (0=managed default)")
@@ -130,6 +133,11 @@ func writeManagedDoltConfigFile(path, host, port, dataDir, logLevel string, dolt
 		logLevel = "warning"
 	}
 	archiveLevel := doltConfig.EffectiveArchiveLevel()
+	autoGCEnabled := doltConfig.EffectiveAutoGCEnabled()
+	autoGCSysVar := "ON"
+	if !autoGCEnabled {
+		autoGCSysVar = "OFF"
+	}
 	maxConnections := doltConfig.EffectiveMaxConnections()
 	readTimeoutMillis := doltConfig.EffectiveReadTimeoutMillis()
 	writeTimeoutMillis := doltConfig.EffectiveWriteTimeoutMillis()
@@ -166,11 +174,16 @@ listener:
 
 data_dir: %q
 
-# auto_gc is disabled — dolt#10944 load-avg gating means upstream auto-GC effectively never fires.
-# Compaction-driven scheduled GC replaces it. See gastownhall/gascity#1918, #1200, #1977 for context.
+# Incremental auto-GC bounds the noms journal so it never reaches GB scale,
+# shrinking both the unclean-stop corruption window and the recovery blast
+# radius (#3176). Historically OFF to work around dolt#10944 (load-avg gating
+# that never fired); fixed upstream in dolt 2.0.3 and the managed floor is
+# 2.1.0+. Scheduled compaction (gc dolt compact) still handles history
+# flattening — see #1918, #1200 for that lineage. Override via city.toml
+# [dolt] auto_gc_enabled or GC_DOLT_AUTO_GC_ENABLED.
 behavior:
   auto_gc_behavior:
-    enable: false
+    enable: %t
     archive_level: %d
 
 # Managed Gas City workloads generate short-lived probe and metadata queries.
@@ -179,12 +192,12 @@ behavior:
 # Keep stats disabled for managed servers; use explicit gc dolt maintenance
 # commands for storage cleanup instead of background workers.
 system_variables:
-  dolt_auto_gc_enabled: "OFF"
+  dolt_auto_gc_enabled: %q
   dolt_stats_enabled: "OFF"
   dolt_stats_gc_enabled: "OFF"
   dolt_stats_memory_only: "ON"
   dolt_stats_paused: "ON"
-%s`, logLevel, port, host, maxConnections, readTimeoutMillis, writeTimeoutMillis, dataDir, archiveLevel, waitTimeoutLine)
+%s`, logLevel, port, host, maxConnections, readTimeoutMillis, writeTimeoutMillis, dataDir, autoGCEnabled, archiveLevel, autoGCSysVar, waitTimeoutLine)
 	if err := fsys.WriteFileAtomic(fsys.OSFS{}, path, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("write config file: %w", err)
 	}

--- a/cmd/gc/cmd_dolt_config.go
+++ b/cmd/gc/cmd_dolt_config.go
@@ -134,10 +134,7 @@ func writeManagedDoltConfigFile(path, host, port, dataDir, logLevel string, dolt
 	}
 	archiveLevel := doltConfig.EffectiveArchiveLevel()
 	autoGCEnabled := doltConfig.EffectiveAutoGCEnabled()
-	autoGCSysVar := "ON"
-	if !autoGCEnabled {
-		autoGCSysVar = "OFF"
-	}
+	autoGCSysVar := doltConfig.AutoGCSysVar()
 	maxConnections := doltConfig.EffectiveMaxConnections()
 	readTimeoutMillis := doltConfig.EffectiveReadTimeoutMillis()
 	writeTimeoutMillis := doltConfig.EffectiveWriteTimeoutMillis()

--- a/cmd/gc/cmd_dolt_config_test.go
+++ b/cmd/gc/cmd_dolt_config_test.go
@@ -38,10 +38,10 @@ func TestDoltConfigWriteManagedCmd(t *testing.T) {
 		"host: 127.0.0.1",
 		`data_dir: "/tmp/city/.beads/dolt"`,
 		"archive_level: 0",
-		"enable: false",
+		"enable: true",
 		"back_log: 50",
 		"max_connections_timeout_millis: 5000",
-		`dolt_auto_gc_enabled: "OFF"`,
+		`dolt_auto_gc_enabled: "ON"`,
 		`dolt_stats_enabled: "OFF"`,
 		`dolt_stats_gc_enabled: "OFF"`,
 		`dolt_stats_memory_only: "ON"`,
@@ -164,6 +164,56 @@ func TestDoltConfigWriteManagedCmd_ExplicitArchiveLevel(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "archive_level: 1") {
 		t.Fatalf("config missing archive_level: 1:\n%s", data)
+	}
+}
+
+func TestDoltConfigWriteManagedCmd_AutoGCCanBeDisabled(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "packs", "dolt", "dolt-config.yaml")
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"dolt-config", "write-managed",
+		"--file", configPath,
+		"--host", "127.0.0.1",
+		"--port", "3311",
+		"--data-dir", "/tmp/city/.beads/dolt",
+		"--auto-gc-enabled=false",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", configPath, err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"enable: false",
+		`dolt_auto_gc_enabled: "OFF"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("config missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestWriteManagedDoltConfigFile_AutoGCDefaultsOn(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "packs", "dolt", "dolt-config.yaml")
+	if err := writeManagedDoltConfigFile(configPath, "127.0.0.1", "3311", "/tmp/dolt-data", "warning", config.DoltConfig{}); err != nil {
+		t.Fatalf("writeManagedDoltConfigFile: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"enable: true",
+		`dolt_auto_gc_enabled: "ON"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("config missing %q:\n%s", want, text)
+		}
 	}
 }
 

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -792,6 +792,11 @@ func resolveManagedDoltConfigForStart(cityPath string, explicitArchiveLevel int)
 			}
 		}
 	}
+	if doltConfig.AutoGCEnabled == nil {
+		if parsed, ok := parseEnvAutoGCEnabled(os.Getenv("GC_DOLT_AUTO_GC_ENABLED")); ok {
+			doltConfig.AutoGCEnabled = &parsed
+		}
+	}
 	if doltConfig.MaxConnections <= 0 {
 		doltConfig.MaxConnections = positiveEnvInt("GC_DOLT_MAX_CONNECTIONS")
 	}
@@ -802,6 +807,27 @@ func resolveManagedDoltConfigForStart(cityPath string, explicitArchiveLevel int)
 		doltConfig.WriteTimeoutMillis = positiveEnvInt("GC_DOLT_WRITE_TIMEOUT_MILLIS")
 	}
 	return doltConfig, nil
+}
+
+// parseEnvAutoGCEnabled parses the GC_DOLT_AUTO_GC_ENABLED override.
+// Accepts Go bool spellings (strconv.ParseBool) plus Dolt's ON/OFF.
+// Unset or unparseable values report ok=false so callers keep the default.
+func parseEnvAutoGCEnabled(raw string) (value, ok bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false, false
+	}
+	switch strings.ToUpper(raw) {
+	case "ON":
+		return true, true
+	case "OFF":
+		return false, true
+	}
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, false
+	}
+	return parsed, true
 }
 
 func positiveEnvInt(key string) int {

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -948,6 +948,41 @@ max_connections = 1024
 	}
 }
 
+func TestResolveManagedDoltConfigForStartAutoGC(t *testing.T) {
+	tests := []struct {
+		name     string
+		cityToml string
+		envVal   string
+		want     bool
+	}{
+		{name: "defaults on", want: true},
+		{name: "city toml disables", cityToml: "[dolt]\nauto_gc_enabled = false\n", want: false},
+		{name: "city toml overrides env", cityToml: "[dolt]\nauto_gc_enabled = true\n", envVal: "false", want: true},
+		{name: "env false disables", envVal: "false", want: false},
+		{name: "env 0 disables", envVal: "0", want: false},
+		{name: "env OFF disables", envVal: "OFF", want: false},
+		{name: "env ON enables", envVal: "ON", want: true},
+		{name: "unparseable env keeps default", envVal: "maybe", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			body := "[workspace]\nname = \"test\"\n\n" + tt.cityToml
+			if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("GC_DOLT_AUTO_GC_ENABLED", tt.envVal)
+			got, err := resolveManagedDoltConfigForStart(dir, -1)
+			if err != nil {
+				t.Fatalf("resolveManagedDoltConfigForStart: %v", err)
+			}
+			if got.EffectiveAutoGCEnabled() != tt.want {
+				t.Fatalf("EffectiveAutoGCEnabled() = %v, want %v", got.EffectiveAutoGCEnabled(), tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveManagedDoltConfigForStartRejectsInvalidCityDoltConfig(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(`

--- a/cmd/gc/gc_beads_bd_journal_recovery_test.go
+++ b/cmd/gc/gc_beads_bd_journal_recovery_test.go
@@ -266,7 +266,11 @@ func TestJournalRecoveryReportsWhenNoCorruptionConfirmed(t *testing.T) {
 	}
 }
 
-func TestBackupRemoteURLForRecoveryParsesBothShapesWithoutJQ(t *testing.T) {
+// runBackupRemoteURLShapeTests exercises backup_remote_url_for_recovery
+// against both repo_state.json backup shapes. maskJQ forces the sed fallback
+// by hiding jq from `command -v`; otherwise the host jq path is exercised.
+func runBackupRemoteURLShapeTests(t *testing.T, maskJQ bool) {
+	t.Helper()
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash not available; skipping shell-function test")
 	}
@@ -302,11 +306,13 @@ func TestBackupRemoteURLForRecoveryParsesBothShapesWithoutJQ(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "repo_state.json"), []byte(tc.repoState), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			// The `command` override masks jq so the sed fallback is what
-			// gets exercised regardless of the host toolchain.
-			harness := "#!/usr/bin/env bash\nset -u\n" +
-				"command() { case \"$*\" in '-v jq') return 1 ;; esac; builtin command \"$@\"; }\n" +
-				fn + "\nbackup_remote_url_for_recovery prod \"$1\"\n"
+			harness := "#!/usr/bin/env bash\nset -u\n"
+			if maskJQ {
+				// The `command` override masks jq so the sed fallback is what
+				// gets exercised regardless of the host toolchain.
+				harness += "command() { case \"$*\" in '-v jq') return 1 ;; esac; builtin command \"$@\"; }\n"
+			}
+			harness += fn + "\nbackup_remote_url_for_recovery prod \"$1\"\n"
 			out, err := exec.Command("bash", "-c", harness, "harness", dbDir).CombinedOutput()
 			if err != nil {
 				t.Fatalf("backup_remote_url_for_recovery failed: %v\n%s", err, out)
@@ -316,4 +322,18 @@ func TestBackupRemoteURLForRecoveryParsesBothShapesWithoutJQ(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBackupRemoteURLForRecoveryParsesBothShapesWithoutJQ(t *testing.T) {
+	runBackupRemoteURLShapeTests(t, true)
+}
+
+// The jq path must handle the legacy string form too: `.url` on a string
+// errors in jq, so the expression uses `.url?` — this test pins that (#3176
+// review finding).
+func TestBackupRemoteURLForRecoveryParsesBothShapesWithJQ(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available; skipping jq-path test")
+	}
+	runBackupRemoteURLShapeTests(t, false)
 }

--- a/cmd/gc/gc_beads_bd_journal_recovery_test.go
+++ b/cmd/gc/gc_beads_bd_journal_recovery_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests exercise the journal-corruption auto-recovery helpers from
+// examples/bd/assets/scripts/gc-beads-bd.sh (#3176) against a stub `dolt`
+// binary. The contract under test:
+//   - only databases whose offline probe confirms journal corruption are
+//     touched;
+//   - the corrupt store is preserved (moved aside, never deleted) before any
+//     restore;
+//   - restore only runs from a non-empty local file:// <db>-backup remote;
+//   - fail-closed: when no usable backup exists or the restore fails, the
+//     store ends up back in the data dir and the function fails so the server
+//     cannot start silently missing a database.
+
+func journalRecoveryHarness(t *testing.T) string {
+	t.Helper()
+	root := repoRootForLint(t)
+	scriptPath := filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	scriptBytes, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	script := string(scriptBytes)
+	var harness strings.Builder
+	harness.WriteString("#!/usr/bin/env bash\nset -u\n")
+	for _, fn := range []string{
+		"run_with_timeout",
+		"journal_corruption_signature",
+		"database_journal_corrupt",
+		"backup_remote_url_for_recovery",
+		"backup_restore_source_usable",
+		"attempt_journal_corruption_recovery",
+	} {
+		harness.WriteString(extractShellFunction(t, script, fn))
+		harness.WriteString("\n")
+	}
+	harness.WriteString("attempt_journal_corruption_recovery\n")
+	return harness.String()
+}
+
+// writeJournalFakeDolt stubs `dolt status` (corrupt when the database dir
+// contains a .corrupt marker) and `dolt backup restore` (recreates the
+// database with a restored-marker, honoring FAKE_RESTORE_EXIT).
+func writeJournalFakeDolt(t *testing.T, binDir string) {
+	t.Helper()
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  status)
+    if [ -f "$PWD/.corrupt" ]; then
+      echo "failed to load database: possible data loss detected in journal file at offset 961963: corrupted journal" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  backup)
+    if [ "${2:-}" = "restore" ]; then
+      if [ "${FAKE_RESTORE_EXIT:-0}" != "0" ]; then
+        echo "restore failed" >&2
+        exit "$FAKE_RESTORE_EXIT"
+      fi
+      db="$4"
+      mkdir -p "$PWD/$db/.dolt"
+      echo restored > "$PWD/$db/restored-marker"
+      exit 0
+    fi
+    ;;
+esac
+exit 0
+`)
+}
+
+type journalRecoveryEnv struct {
+	cityDir   string
+	dataDir   string
+	stateDir  string
+	logFile   string
+	backupDir string
+	binDir    string
+}
+
+func setupJournalRecoveryEnv(t *testing.T) journalRecoveryEnv {
+	t.Helper()
+	cityDir := t.TempDir()
+	env := journalRecoveryEnv{
+		cityDir:   cityDir,
+		dataDir:   filepath.Join(cityDir, "dolt-data"),
+		stateDir:  filepath.Join(cityDir, "pack-state"),
+		logFile:   filepath.Join(cityDir, "dolt.log"),
+		backupDir: filepath.Join(cityDir, "backups", "prod"),
+		binDir:    filepath.Join(cityDir, "bin"),
+	}
+	for _, dir := range []string{env.dataDir, env.stateDir, env.backupDir, env.binDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeJournalFakeDolt(t, env.binDir)
+	return env
+}
+
+func (e journalRecoveryEnv) addDatabase(t *testing.T, name string, corrupt bool, repoState string) {
+	t.Helper()
+	dbDir := filepath.Join(e.dataDir, name)
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dbDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, "original-marker"), []byte(name), 0o644); err != nil {
+		t.Fatalf("write original marker: %v", err)
+	}
+	if corrupt {
+		if err := os.WriteFile(filepath.Join(dbDir, ".corrupt"), []byte("1"), 0o644); err != nil {
+			t.Fatalf("write corrupt marker: %v", err)
+		}
+	}
+	if repoState != "" {
+		if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "repo_state.json"), []byte(repoState), 0o644); err != nil {
+			t.Fatalf("write repo_state.json: %v", err)
+		}
+	}
+}
+
+func (e journalRecoveryEnv) run(t *testing.T, harness string, extraEnv ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("bash", "-c", harness)
+	cmd.Env = append(os.Environ(),
+		"PATH="+e.binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DATA_DIR="+e.dataDir,
+		"PACK_STATE_DIR="+e.stateDir,
+		"LOG_FILE="+e.logFile,
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func prodRepoState(backupDir string) string {
+	return `{"head":"refs/heads/main","backups":{"prod-backup":{"name":"prod-backup","url":"file://` + backupDir + `","fetch_specs":[],"params":{}}}}`
+}
+
+func TestJournalRecoveryRestoresCorruptDBFromLocalBackup(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+	env := setupJournalRecoveryEnv(t)
+	if err := os.WriteFile(filepath.Join(env.backupDir, "manifest"), []byte("backup"), 0o644); err != nil {
+		t.Fatalf("seed backup content: %v", err)
+	}
+	env.addDatabase(t, "prod", true, prodRepoState(env.backupDir))
+	env.addDatabase(t, "healthy", false, "")
+
+	out, err := env.run(t, journalRecoveryHarness(t))
+	if err != nil {
+		t.Fatalf("recovery failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "RESTORED 'prod'") {
+		t.Fatalf("output missing loud restore notice:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(env.dataDir, "prod", "restored-marker")); err != nil {
+		t.Fatalf("prod was not restored from backup: %v\n%s", err, out)
+	}
+	asides, err := filepath.Glob(filepath.Join(env.stateDir, "corrupt-aside", "prod.*"))
+	if err != nil || len(asides) != 1 {
+		t.Fatalf("corrupt store must be preserved aside, got %v (err %v)\n%s", asides, err, out)
+	}
+	if _, err := os.Stat(filepath.Join(asides[0], "original-marker")); err != nil {
+		t.Fatalf("aside copy missing original content: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(env.dataDir, "healthy", "original-marker")); err != nil {
+		t.Fatalf("healthy database must not be touched: %v", err)
+	}
+	if dirs, _ := filepath.Glob(filepath.Join(env.stateDir, "corrupt-aside", "healthy.*")); len(dirs) != 0 {
+		t.Fatalf("healthy database must not be moved aside: %v", dirs)
+	}
+}
+
+func TestJournalRecoveryFailsClosedWithoutUsableBackup(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+	tests := []struct {
+		name      string
+		repoState func(env journalRecoveryEnv) string
+		seed      bool
+	}{
+		{
+			name:      "no backup remote recorded",
+			repoState: func(journalRecoveryEnv) string { return `{"head":"refs/heads/main"}` },
+		},
+		{
+			name:      "backup remote dir empty",
+			repoState: func(env journalRecoveryEnv) string { return prodRepoState(env.backupDir) },
+		},
+		{
+			name: "non-file backup remote",
+			repoState: func(journalRecoveryEnv) string {
+				return `{"backups":{"prod-backup":{"url":"aws://bucket/prod"}}}`
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupJournalRecoveryEnv(t)
+			env.addDatabase(t, "prod", true, tc.repoState(env))
+
+			out, err := env.run(t, journalRecoveryHarness(t))
+			if err == nil {
+				t.Fatalf("recovery must fail closed without a usable backup\n%s", out)
+			}
+			if !strings.Contains(out, "NOT auto-recovering 'prod'") {
+				t.Fatalf("output missing loud refusal:\n%s", out)
+			}
+			if _, statErr := os.Stat(filepath.Join(env.dataDir, "prod", "original-marker")); statErr != nil {
+				t.Fatalf("prod store must stay in place when not recoverable: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestJournalRecoveryMovesStoreBackWhenRestoreFails(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+	env := setupJournalRecoveryEnv(t)
+	if err := os.WriteFile(filepath.Join(env.backupDir, "manifest"), []byte("backup"), 0o644); err != nil {
+		t.Fatalf("seed backup content: %v", err)
+	}
+	env.addDatabase(t, "prod", true, prodRepoState(env.backupDir))
+
+	out, err := env.run(t, journalRecoveryHarness(t), "FAKE_RESTORE_EXIT=1")
+	if err == nil {
+		t.Fatalf("recovery must fail when restore fails\n%s", out)
+	}
+	if !strings.Contains(out, "backup restore failed for 'prod'") {
+		t.Fatalf("output missing restore failure notice:\n%s", out)
+	}
+	if _, statErr := os.Stat(filepath.Join(env.dataDir, "prod", "original-marker")); statErr != nil {
+		t.Fatalf("prod store must be moved back after failed restore (fail closed): %v\n%s", statErr, out)
+	}
+}
+
+func TestJournalRecoveryReportsWhenNoCorruptionConfirmed(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+	env := setupJournalRecoveryEnv(t)
+	env.addDatabase(t, "healthy", false, "")
+
+	out, err := env.run(t, journalRecoveryHarness(t))
+	if err == nil {
+		t.Fatalf("recovery must fail when nothing is corrupt (caller dies with original error)\n%s", out)
+	}
+	if !strings.Contains(out, "no corrupt database confirmed") {
+		t.Fatalf("output missing probe-found-nothing notice:\n%s", out)
+	}
+	if _, statErr := os.Stat(filepath.Join(env.dataDir, "healthy", "original-marker")); statErr != nil {
+		t.Fatalf("healthy database must not be touched: %v", statErr)
+	}
+}
+
+func TestBackupRemoteURLForRecoveryParsesBothShapesWithoutJQ(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+	root := repoRootForLint(t)
+	scriptBytes, err := os.ReadFile(filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh"))
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	fn := extractShellFunction(t, string(scriptBytes), "backup_remote_url_for_recovery")
+
+	tests := []struct {
+		name      string
+		repoState string
+		want      string
+	}{
+		{
+			name:      "object form",
+			repoState: `{"backups":{"prod-backup":{"name":"prod-backup","url":"file:///backups/prod","fetch_specs":[]}}}`,
+			want:      "file:///backups/prod",
+		},
+		{
+			name:      "legacy string form",
+			repoState: `{"backups":{"prod-backup":"file:///backups/prod"}}`,
+			want:      "file:///backups/prod",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dbDir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "repo_state.json"), []byte(tc.repoState), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			// The `command` override masks jq so the sed fallback is what
+			// gets exercised regardless of the host toolchain.
+			harness := "#!/usr/bin/env bash\nset -u\n" +
+				"command() { case \"$*\" in '-v jq') return 1 ;; esac; builtin command \"$@\"; }\n" +
+				fn + "\nbackup_remote_url_for_recovery prod \"$1\"\n"
+			out, err := exec.Command("bash", "-c", harness, "harness", dbDir).CombinedOutput()
+			if err != nil {
+				t.Fatalf("backup_remote_url_for_recovery failed: %v\n%s", err, out)
+			}
+			if got := strings.TrimSpace(string(out)); got != tc.want {
+				t.Fatalf("url = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -341,6 +341,7 @@ DoltConfig holds optional dolt server overrides.
 | `port` | integer |  | `0` | Port is the dolt server port. 0 means use ephemeral port allocation (hashed from city path). Set explicitly to override. |
 | `host` | string |  | `localhost` | Host is the dolt server hostname. Defaults to localhost. |
 | `archive_level` | integer |  | `0` | ArchiveLevel controls Dolt's auto_gc archive aggressiveness. 0 disables archive compaction (lower CPU on startup). 1 enables archive compaction (higher CPU on startup). nil (omitted) defaults to 0. |
+| `auto_gc_enabled` | boolean |  | `true` | AutoGCEnabled toggles Dolt's incremental auto-GC on the managed sql-server. Auto-GC bounds the noms journal so it never reaches GB scale, which shrinks both the unclean-stop corruption window and the recovery blast radius. nil (omitted) defaults to true. |
 | `max_connections` | integer |  | `256` | MaxConnections overrides the managed Dolt listener max_connections. 0 means use the managed default. |
 | `read_timeout_millis` | integer |  | `30000` | ReadTimeoutMillis overrides the managed Dolt listener read_timeout_millis. 0 means use the managed default. |
 | `write_timeout_millis` | integer |  | `300000` | WriteTimeoutMillis overrides the managed Dolt listener write_timeout_millis. 0 means use the managed default. |

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1351,6 +1351,11 @@
           "description": "ArchiveLevel controls Dolt's auto_gc archive aggressiveness.\n0 disables archive compaction (lower CPU on startup).\n1 enables archive compaction (higher CPU on startup).\nnil (omitted) defaults to 0.",
           "default": 0
         },
+        "auto_gc_enabled": {
+          "type": "boolean",
+          "description": "AutoGCEnabled toggles Dolt's incremental auto-GC on the managed\nsql-server. Auto-GC bounds the noms journal so it never reaches\nGB scale, which shrinks both the unclean-stop corruption window\nand the recovery blast radius. nil (omitted) defaults to true.",
+          "default": true
+        },
         "max_connections": {
           "type": "integer",
           "description": "MaxConnections overrides the managed Dolt listener max_connections.\n0 means use the managed default.",

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1351,6 +1351,11 @@
           "description": "ArchiveLevel controls Dolt's auto_gc archive aggressiveness.\n0 disables archive compaction (lower CPU on startup).\n1 enables archive compaction (higher CPU on startup).\nnil (omitted) defaults to 0.",
           "default": 0
         },
+        "auto_gc_enabled": {
+          "type": "boolean",
+          "description": "AutoGCEnabled toggles Dolt's incremental auto-GC on the managed\nsql-server. Auto-GC bounds the noms journal so it never reaches\nGB scale, which shrinks both the unclean-stop corruption window\nand the recovery blast radius. nil (omitted) defaults to true.",
+          "default": true
+        },
         "max_connections": {
           "type": "integer",
           "description": "MaxConnections overrides the managed Dolt listener max_connections.\n0 means use the managed default.",

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -2052,6 +2052,133 @@ ensure_dolt_identity() {
     fi
 }
 
+# journal_corruption_signature filters stdin for the dolt startup errors that
+# indicate a corrupted noms journal ("possible data loss detected in journal
+# file at offset N: corrupted journal", "journal index is malformed"). Used on
+# captured startup output, the managed log tail, and per-database offline
+# probe output.
+journal_corruption_signature() {
+    grep -qiE 'corrupted journal|journal index is malformed|possible data loss detected in journal file'
+}
+
+# log_tail_has_journal_corruption reports whether the recent managed dolt log
+# contains a journal-corruption startup error. Bounded to the log tail so a
+# huge log cannot stall start; stale matches from earlier incidents are
+# harmless because recovery re-verifies each database with an offline probe
+# before touching anything.
+log_tail_has_journal_corruption() {
+    [ -f "$LOG_FILE" ] || return 1
+    tail -c 65536 "$LOG_FILE" 2>/dev/null | journal_corruption_signature
+}
+
+# database_journal_corrupt probes one database directory offline and reports
+# whether dolt refuses to load it with a journal-corruption error. Only safe
+# while the managed server is down — offline dolt commands contend with a
+# running server's file locks. Probe output is spooled to a temp file rather
+# than captured via command substitution: the run_with_timeout watchdog's
+# sleep child inherits a substitution pipe and would hold it open for the
+# full timeout, turning every healthy-database probe into a 30s stall.
+database_journal_corrupt() {
+    local probe_db_dir="$1" probe_out probe_hit=1
+    probe_out=$(mktemp) || return 1
+    (cd "$probe_db_dir" && run_with_timeout 30 dolt status) > "$probe_out" 2>&1 || true
+    if journal_corruption_signature < "$probe_out"; then
+        probe_hit=0
+    fi
+    rm -f "$probe_out"
+    return "$probe_hit"
+}
+
+# backup_remote_url_for_recovery prints the <db>-backup remote URL recorded in
+# a database's repo_state.json. The file is plain JSON, so the URL is readable
+# even when the noms store itself can no longer be opened. Handles both the
+# object form ("backups": {"db-backup": {"url": "..."}}) and the legacy plain
+# string form.
+backup_remote_url_for_recovery() {
+    local recovery_db="$1" recovery_db_dir="$2" repo_state url
+    repo_state="$recovery_db_dir/.dolt/repo_state.json"
+    [ -f "$repo_state" ] || return 1
+    if command -v jq >/dev/null 2>&1; then
+        url=$(jq -r --arg name "${recovery_db}-backup" '.backups[$name].url // .backups[$name] // empty' "$repo_state" 2>/dev/null)
+    else
+        url=$(tr -d '\n' < "$repo_state" | sed -n "s/.*\"${recovery_db}-backup\"[^}]*\"url\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p")
+        if [ -z "$url" ]; then
+            url=$(tr -d '\n' < "$repo_state" | sed -n "s/.*\"${recovery_db}-backup\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p")
+        fi
+    fi
+    [ -n "$url" ] || return 1
+    printf '%s\n' "$url"
+}
+
+# backup_restore_source_usable reports whether url points at a local backup
+# that actually has content to restore from. Only file:// remotes qualify:
+# remote backups cannot be cheaply verified, and restoring from an unverified
+# source is exactly the kind of silent data movement auto-recovery must not do.
+backup_restore_source_usable() {
+    local usable_url="$1" usable_path
+    case "$usable_url" in
+        file://*) usable_path="${usable_url#file://}" ;;
+        *) return 1 ;;
+    esac
+    [ -d "$usable_path" ] || return 1
+    [ -n "$(ls -A "$usable_path" 2>/dev/null)" ]
+}
+
+# attempt_journal_corruption_recovery scans the data dir for databases whose
+# noms journal dolt refuses to load, preserves each corrupt store under
+# $PACK_STATE_DIR/corrupt-aside/ (never deleted), and restores the database
+# from its local <db>-backup remote (#3176). Fail-closed: when any corrupt
+# database has no usable backup or the restore fails, its store is moved back
+# so the server cannot come up silently missing a database, and the function
+# returns 1. Returns 0 only when at least one database was restored and none
+# were left unrecoverable. Everything is logged loudly — restored copies are
+# missing all writes since the last backup sync, and operators must know that.
+attempt_journal_corruption_recovery() {
+    local aside_root="$PACK_STATE_DIR/corrupt-aside"
+    local ts db_dir db aside url recovered=0
+    ts=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || date +%s)
+    echo "gc-beads-bd: journal corruption reported at startup; probing databases in $DATA_DIR" >&2
+    for db_dir in "$DATA_DIR"/*/; do
+        [ -d "$db_dir/.dolt" ] || continue
+        db=$(basename "$db_dir")
+        database_journal_corrupt "$db_dir" || continue
+        echo "gc-beads-bd: journal corruption confirmed in database '$db'" >&2
+        url=$(backup_remote_url_for_recovery "$db" "$db_dir") || url=""
+        if [ -z "$url" ] || ! backup_restore_source_usable "$url"; then
+            echo "gc-beads-bd: NOT auto-recovering '$db': no usable local backup (remote url: ${url:-none})" >&2
+            echo "gc-beads-bd: manual recovery required: move $DATA_DIR/$db aside, then run 'dolt backup restore <url> $db' from $DATA_DIR" >&2
+            return 1
+        fi
+        mkdir -p "$aside_root" || return 1
+        aside="$aside_root/$db.$ts"
+        if ! mv "$DATA_DIR/$db" "$aside"; then
+            echo "gc-beads-bd: could not move corrupt store $DATA_DIR/$db aside to $aside; aborting recovery" >&2
+            return 1
+        fi
+        echo "gc-beads-bd: preserved corrupt store at $aside" >&2
+        if (cd "$DATA_DIR" && run_with_timeout 600 dolt backup restore "$url" "$db") >> "$LOG_FILE" 2>&1; then
+            recovered=$((recovered + 1))
+            echo "gc-beads-bd: RESTORED '$db' from backup $url — writes since the last backup sync are NOT in the restored copy; pre-corruption store kept at $aside" >&2
+        else
+            # Fail closed: put the corrupt store back so the server cannot
+            # start without this database and silently drop it from the
+            # control plane. The partial restore output (if any) is fresh
+            # data written by the failed restore, not original state.
+            rm -rf "${DATA_DIR:?}/${db:?}" 2>/dev/null || true
+            if ! mv "$aside" "$DATA_DIR/$db"; then
+                echo "gc-beads-bd: CRITICAL: restore failed AND corrupt store could not be moved back; original data is at $aside" >&2
+            fi
+            echo "gc-beads-bd: backup restore failed for '$db' (see $LOG_FILE); not retrying" >&2
+            return 1
+        fi
+    done
+    if [ "$recovered" -eq 0 ]; then
+        echo "gc-beads-bd: no corrupt database confirmed by offline probe; not recovering" >&2
+        return 1
+    fi
+    return 0
+}
+
 # op_start starts the dolt server if not already running.
 op_start() {
     if is_remote; then
@@ -2209,15 +2336,29 @@ op_start() {
         fi
     fi
 
-    if load_start_managed_from_gc; then
-        DOLT_PORT="$GC_START_PORT"
-        return 0
-    elif [ "$GC_START_MANAGED_USED" = "true" ]; then
-        DOLT_PORT="$GC_START_PORT"
-        rm -f "$PID_FILE"
-        save_state 0 false
-        die "dolt server could not start via gc helper (check $LOG_FILE)"
-    fi
+    local journal_recovery_attempted=false
+    while :; do
+        if load_start_managed_from_gc; then
+            DOLT_PORT="$GC_START_PORT"
+            return 0
+        elif [ "$GC_START_MANAGED_USED" = "true" ]; then
+            # Auto-recover from a corrupted noms journal before failing the
+            # whole control plane (#3176). One attempt per start invocation;
+            # the offline probe inside recovery confirms actual corruption
+            # before any store is touched.
+            if [ "$journal_recovery_attempted" != "true" ] && log_tail_has_journal_corruption; then
+                journal_recovery_attempted=true
+                if attempt_journal_corruption_recovery; then
+                    continue
+                fi
+            fi
+            DOLT_PORT="$GC_START_PORT"
+            rm -f "$PID_FILE"
+            save_state 0 false
+            die "dolt server could not start via gc helper (check $LOG_FILE)"
+        fi
+        break
+    done
 
     local launch_attempt=0
     while [ "$launch_attempt" -lt 5 ]; do
@@ -2299,6 +2440,21 @@ op_start() {
             launch_attempt=$((launch_attempt + 1))
             DOLT_PORT=$(next_available_port $((DOLT_PORT + 1)))
             continue
+        fi
+
+        # Auto-recover from a corrupted noms journal before failing the whole
+        # control plane (#3176). One attempt per start invocation; the offline
+        # probe inside recovery confirms actual corruption before any store is
+        # touched.
+        if printf '%s' "$startup_output" | journal_corruption_signature; then
+            if [ "$journal_recovery_attempted" != "true" ]; then
+                journal_recovery_attempted=true
+                if attempt_journal_corruption_recovery; then
+                    launch_attempt=$((launch_attempt + 1))
+                    continue
+                fi
+            fi
+            die "dolt server exited during startup: noms journal corruption (check $LOG_FILE; corrupt stores are preserved under $PACK_STATE_DIR/corrupt-aside)"
         fi
 
         die "dolt server exited during startup (check $LOG_FILE)"

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1291,11 +1291,12 @@ write_config_yaml() {
             ;;
     esac
     # Incremental auto-GC defaults to ON; only explicit false-y overrides
-    # disable it. Mirrors parseEnvAutoGCEnabled in cmd/gc/dolt_start_managed.go.
+    # disable it. Mirrors parseEnvAutoGCEnabled in cmd/gc/dolt_start_managed.go,
+    # including its whitespace trim.
     auto_gc_enabled=true
     auto_gc_sysvar=ON
-    case "${GC_DOLT_AUTO_GC_ENABLED:-}" in
-        0|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff])
+    case "$(printf '%s' "${GC_DOLT_AUTO_GC_ENABLED:-}" | tr -d '[:space:]')" in
+        0|[Ff]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff])
             auto_gc_enabled=false
             auto_gc_sysvar=OFF
             ;;
@@ -2080,7 +2081,10 @@ log_tail_has_journal_corruption() {
 # full timeout, turning every healthy-database probe into a 30s stall.
 database_journal_corrupt() {
     local probe_db_dir="$1" probe_out probe_hit=1
-    probe_out=$(mktemp) || return 1
+    probe_out=$(mktemp) || {
+        echo "gc-beads-bd: probe tempfile unavailable; treating $probe_db_dir as not corrupt" >&2
+        return 1
+    }
     (cd "$probe_db_dir" && run_with_timeout 30 dolt status) > "$probe_out" 2>&1 || true
     if journal_corruption_signature < "$probe_out"; then
         probe_hit=0
@@ -2099,7 +2103,7 @@ backup_remote_url_for_recovery() {
     repo_state="$recovery_db_dir/.dolt/repo_state.json"
     [ -f "$repo_state" ] || return 1
     if command -v jq >/dev/null 2>&1; then
-        url=$(jq -r --arg name "${recovery_db}-backup" '.backups[$name].url // .backups[$name] // empty' "$repo_state" 2>/dev/null)
+        url=$(jq -r --arg name "${recovery_db}-backup" '.backups[$name].url? // .backups[$name] // empty' "$repo_state" 2>/dev/null)
     else
         url=$(tr -d '\n' < "$repo_state" | sed -n "s/.*\"${recovery_db}-backup\"[^}]*\"url\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p")
         if [ -z "$url" ]; then

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1283,11 +1283,21 @@ graceful_stop_owned_pid() {
 # Overwritten on each server start. Without read/write timeouts, CLOSE_WAIT connections
 # accumulate and the server enters unrecoverable read-only mode.
 write_config_yaml() {
-    local archive_level gc_bin raw_wait_timeout wait_timeout_line max_connections read_timeout_millis write_timeout_millis
+    local archive_level auto_gc_enabled auto_gc_sysvar gc_bin raw_wait_timeout wait_timeout_line max_connections read_timeout_millis write_timeout_millis
     archive_level=${GC_DOLT_ARCHIVE_LEVEL:-0}
     case "$archive_level" in
         ''|*[!0-9]*)
             archive_level=0
+            ;;
+    esac
+    # Incremental auto-GC defaults to ON; only explicit false-y overrides
+    # disable it. Mirrors parseEnvAutoGCEnabled in cmd/gc/dolt_start_managed.go.
+    auto_gc_enabled=true
+    auto_gc_sysvar=ON
+    case "${GC_DOLT_AUTO_GC_ENABLED:-}" in
+        0|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff])
+            auto_gc_enabled=false
+            auto_gc_sysvar=OFF
             ;;
     esac
     max_connections=${GC_DOLT_MAX_CONNECTIONS:-256}
@@ -1317,6 +1327,7 @@ write_config_yaml() {
             --data-dir "$DATA_DIR" \
             --log-level "$DOLT_LOGLEVEL" \
             --archive-level "$archive_level" \
+            --auto-gc-enabled="$auto_gc_enabled" \
             --max-connections "$max_connections" \
             --read-timeout-millis "$read_timeout_millis" \
             --write-timeout-millis "$write_timeout_millis" || die "failed to write managed dolt config via gc helper $gc_bin"
@@ -1362,11 +1373,16 @@ listener:
 
 data_dir: "$DATA_DIR"
 
-# auto_gc is disabled — dolt#10944 load-avg gating means upstream auto-GC effectively never fires.
-# Compaction-driven scheduled GC replaces it. See gastownhall/gascity#1918, #1200, #1977 for context.
+# Incremental auto-GC bounds the noms journal so it never reaches GB scale,
+# shrinking both the unclean-stop corruption window and the recovery blast
+# radius (#3176). Historically OFF to work around dolt#10944 (load-avg gating
+# that never fired); fixed upstream in dolt 2.0.3 and the managed floor is
+# 2.1.0+. Scheduled compaction (gc dolt compact) still handles history
+# flattening — see #1918, #1200 for that lineage. Override via city.toml
+# [dolt] auto_gc_enabled or GC_DOLT_AUTO_GC_ENABLED.
 behavior:
   auto_gc_behavior:
-    enable: false
+    enable: $auto_gc_enabled
     archive_level: $archive_level
 
 # Managed Gas City workloads generate short-lived probe and metadata queries.
@@ -1375,7 +1391,7 @@ behavior:
 # Keep stats disabled for managed servers; use explicit gc dolt maintenance
 # commands for storage cleanup instead of background workers.
 system_variables:
-  dolt_auto_gc_enabled: "OFF"
+  dolt_auto_gc_enabled: "$auto_gc_sysvar"
   dolt_stats_enabled: "OFF"
   dolt_stats_gc_enabled: "OFF"
   dolt_stats_memory_only: "ON"

--- a/examples/bd/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-backup.sh
@@ -172,7 +172,7 @@ for db in $DATABASES; do
         continue
     fi
     db_dir="$DOLT_DATA_DIR/$db"
-    if [ ! -d "$db_dir" ]; then
+    if [ ! -d "$db_dir/.dolt" ]; then
         append_failed_db "$db(not found)"
         continue
     fi

--- a/examples/bd/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-backup.sh
@@ -165,19 +165,12 @@ TOTAL=$(printf '%s\n' "$DATABASES" | awk 'NF {count++} END {print count + 0}')
 SYNCED=0
 FAILED=0
 FAILED_DBS=""
-REMOTE_FAILED_DBS=""
 
 for db in $DATABASES; do
     if ! ensure_backup_remote "$db"; then
         append_failed_db "$db(backup add failed)"
-        REMOTE_FAILED_DBS="$REMOTE_FAILED_DBS $db "
+        continue
     fi
-done
-
-for db in $DATABASES; do
-    case "$REMOTE_FAILED_DBS" in
-        *" $db "*) continue ;; # already counted as failed above
-    esac
     db_dir="$DOLT_DATA_DIR/$db"
     if [ ! -d "$db_dir" ]; then
         append_failed_db "$db(not found)"

--- a/examples/bd/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-backup.sh
@@ -116,37 +116,68 @@ acquire_backup_lock
 
 # --- Step 2: Sync databases to backup remotes ---
 
-# If GC_BACKUP_DATABASES is set, use it; otherwise auto-discover DBs that
-# have a named Dolt backup <db>-backup configured.
+# If GC_BACKUP_DATABASES is set, use it; otherwise auto-discover every user
+# database in the data dir. Discovery used to require an existing <db>-backup
+# remote, silently excluding unconfigured DBs from backup coverage — which is
+# how production DBs ended up unrecoverable after journal corruption (#3176:
+# beads_hq had no named remote, so it was never synced). DBs without the
+# remote now get one auto-configured below.
 if [ -n "${GC_BACKUP_DATABASES:-}" ]; then
     DATABASES=$(echo "$GC_BACKUP_DATABASES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' || true)
 else
-    # Auto-discover: find databases that have a named Dolt backup <db>-backup.
     ALL_DBS=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | \
         grep -viE "$SYSTEM_DBS" || true)
     DATABASES=""
     for db in $ALL_DBS; do
-        db_dir="$DOLT_DATA_DIR/$db"
-        if [ -d "$db_dir/.dolt" ]; then
-            if (cd "$db_dir" && dolt backup 2>/dev/null | awk '{print $1}' | grep -qx "${db}-backup"); then
-                DATABASES="$DATABASES $db"
-            fi
+        if [ -d "$DOLT_DATA_DIR/$db/.dolt" ]; then
+            DATABASES="$DATABASES $db"
         fi
     done
     DATABASES=$(echo "$DATABASES" | tr ' ' '\n' | grep -v '^$' || true)
 fi
 
 if [ -z "$DATABASES" ]; then
-    echo "backup: no databases with backup remotes found, skipping"
+    echo "backup: no databases found, skipping"
     exit 0
 fi
+
+# ensure_backup_remote guarantees db has a named <db>-backup remote, creating
+# one under the backup artifact dir when missing. Auto-configuration is logged
+# loudly so operators can see when coverage was established rather than
+# assumed. Returns 1 when the remote cannot be configured.
+ensure_backup_remote() {
+    remote_db="$1"
+    remote_db_dir="$DOLT_DATA_DIR/$remote_db"
+    [ -d "$remote_db_dir/.dolt" ] || return 0 # sync loop reports not-found
+    if (cd "$remote_db_dir" && run_bounded 30 dolt backup 2>/dev/null | awk '{print $1}' | grep -qx "${remote_db}-backup"); then
+        return 0
+    fi
+    remote_url="file://$BACKUP_ARTIFACT_DIR/$remote_db"
+    mkdir -p "$BACKUP_ARTIFACT_DIR/$remote_db"
+    if (cd "$remote_db_dir" && run_bounded 30 dolt backup add "${remote_db}-backup" "$remote_url" >/dev/null 2>&1); then
+        echo "backup: auto-configured missing backup remote ${remote_db}-backup -> $remote_url"
+        return 0
+    fi
+    return 1
+}
 
 TOTAL=$(printf '%s\n' "$DATABASES" | awk 'NF {count++} END {print count + 0}')
 SYNCED=0
 FAILED=0
 FAILED_DBS=""
+REMOTE_FAILED_DBS=""
 
 for db in $DATABASES; do
+    if ! ensure_backup_remote "$db"; then
+        append_failed_db "$db(backup add failed)"
+        REMOTE_FAILED_DBS="$REMOTE_FAILED_DBS $db "
+    fi
+done
+
+for db in $DATABASES; do
+    case "$REMOTE_FAILED_DBS" in
+        *" $db "*) continue ;; # already counted as failed above
+    esac
     db_dir="$DOLT_DATA_DIR/$db"
     if [ ! -d "$db_dir" ]; then
         append_failed_db "$db(not found)"

--- a/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
@@ -149,15 +149,21 @@ if [ "${ORPHAN_COUNT:-0}" -gt 0 ]; then
 fi
 
 # Backup freshness: check newest backup artifact per database.
-# Scope mirrors mol-dog-backup.sh: only DBs with a configured <db>-backup
-# remote are eligible. Cities with user DBs but no backup remotes
-# (legitimate config) must not get false stale-backup alarms.
+# Every user database is in scope. DBs without a configured <db>-backup
+# remote are reported as a coverage gap rather than silently excluded —
+# the exclusion is how unconfigured production DBs went unbacked-up until
+# journal corruption made them unrecoverable (#3176). mol-dog-backup.sh
+# auto-configures the remote on its next run, so this warning self-heals
+# unless the backup dog itself is failing.
 BACKUP_ELIGIBLE_DBS=""
+BACKUP_STALE_ITEMS=""
 for db in $USER_DBS; do
     db_dir="$DOLT_DATA_DIR/$db"
     if [ -d "$db_dir/.dolt" ]; then
         if (cd "$db_dir" && dolt backup 2>/dev/null | awk '{print $1}' | grep -qx "${db}-backup"); then
             BACKUP_ELIGIBLE_DBS="$BACKUP_ELIGIBLE_DBS $db"
+        else
+            append_backup_stale "$db backup remote missing"
         fi
     fi
 done
@@ -168,7 +174,6 @@ if [ -n "$BACKUP_ELIGIBLE_DBS" ]; then
     if [ ! -d "$BACKUP_ARTIFACT_DIR" ]; then
         BACKUP_STALE=" [WARN: backup artifact dir missing]"
     else
-        BACKUP_STALE_ITEMS=""
         NOW_S=$(date +%s)
         for db in $BACKUP_ELIGIBLE_DBS; do
             NEWEST_BACKUP_MTIME=$(newest_backup_mtime_for_db "$db")
@@ -181,10 +186,10 @@ if [ -n "$BACKUP_ELIGIBLE_DBS" ]; then
                 append_backup_stale "$db backup is $((BACKUP_AGE / 3600))h old"
             fi
         done
-        if [ -n "$BACKUP_STALE_ITEMS" ]; then
-            BACKUP_STALE=" [WARN: backup freshness: $BACKUP_STALE_ITEMS]"
-        fi
     fi
+fi
+if [ -n "$BACKUP_STALE_ITEMS" ]; then
+    BACKUP_STALE="$BACKUP_STALE [WARN: backup freshness: $BACKUP_STALE_ITEMS]"
 fi
 
 # --- Step 3: Compose report and escalate if critical ---

--- a/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
@@ -160,7 +160,7 @@ BACKUP_STALE_ITEMS=""
 for db in $USER_DBS; do
     db_dir="$DOLT_DATA_DIR/$db"
     if [ -d "$db_dir/.dolt" ]; then
-        if (cd "$db_dir" && dolt backup 2>/dev/null | awk '{print $1}' | grep -qx "${db}-backup"); then
+        if (cd "$db_dir" && run_bounded 30 dolt backup 2>/dev/null | awk '{print $1}' | grep -qx "${db}-backup"); then
             BACKUP_ELIGIBLE_DBS="$BACKUP_ELIGIBLE_DBS $db"
         else
             append_backup_stale "$db backup remote missing"

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -3693,6 +3693,125 @@ func TestBackupScriptCountsFailedDatabasesByDatabase(t *testing.T) {
 	}
 }
 
+// writeAutoConfigureFakeDolt fakes a server with prod + archive where only
+// prod has a prod-backup remote. `backup add` exits with addExit so tests can
+// exercise both the auto-configure happy path and the failure accounting.
+func writeAutoConfigureFakeDolt(t *testing.T, binDir string, addExit int) string {
+	t.Helper()
+	logPath := filepath.Join(binDir, "dolt.log")
+	writeExecutable(t, filepath.Join(binDir, "dolt"), fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf 'dolt %%s\n' "$*" >> %s
+if [ "${1:-}" = "version" ]; then
+  printf 'dolt version 2.1.0\n'
+  exit 0
+fi
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nprod\narchive\n'
+    exit 0
+    ;;
+esac
+if [ "${1:-}" = "backup" ] && [ "$#" -eq 1 ]; then
+  if [ "$(basename "$PWD")" = "prod" ]; then
+    printf 'prod-backup file:///backups/prod\n'
+  fi
+  exit 0
+fi
+if [ "${1:-} ${2:-}" = "backup add" ]; then
+  exit %d
+fi
+if [ "${1:-} ${2:-}" = "backup sync" ]; then
+  exit 0
+fi
+exit 0
+`, shellQuote(logPath), addExit))
+	return logPath
+}
+
+// TestBackupScriptAutoConfiguresMissingBackupRemotes asserts auto-discovery
+// covers every user database: DBs without a "<db>-backup" remote get one
+// auto-configured under the backup artifact dir and are then synced. The old
+// behavior silently skipped them, leaving production DBs with zero backup
+// coverage until journal corruption made them unrecoverable (#3176).
+func TestBackupScriptAutoConfiguresMissingBackupRemotes(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	for _, db := range []string{"prod", "archive"} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", db, err)
+		}
+	}
+	binDir := t.TempDir()
+	_ = writeDogFakeGC(t, binDir)
+	doltLogPath := writeAutoConfigureFakeDolt(t, binDir, 0)
+
+	out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir)
+	if !strings.Contains(out, "synced: 2/2") {
+		t.Fatalf("unexpected backup summary:\n%s", out)
+	}
+	if !strings.Contains(out, "auto-configured missing backup remote archive-backup") {
+		t.Fatalf("auto-configuration must be logged loudly, output:\n%s", out)
+	}
+	doltLog, err := os.ReadFile(doltLogPath)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	artifactURL := "file://" + filepath.Join(cityPath, ".dolt-backup", "archive")
+	if !strings.Contains(string(doltLog), "backup add archive-backup "+artifactURL) {
+		t.Fatalf("dolt log missing backup add for archive -> %s:\n%s", artifactURL, doltLog)
+	}
+	if strings.Contains(string(doltLog), "backup add prod-backup") {
+		t.Fatalf("prod already has a remote; backup add must not run for it:\n%s", doltLog)
+	}
+	for _, want := range []string{"backup sync prod-backup", "backup sync archive-backup"} {
+		if !strings.Contains(string(doltLog), want) {
+			t.Fatalf("dolt log missing %q:\n%s", want, doltLog)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(cityPath, ".dolt-backup", "archive")); err != nil {
+		t.Fatalf("backup artifact dir for archive should be created: %v", err)
+	}
+}
+
+// TestBackupScriptCountsFailedRemoteAutoConfiguration asserts a DB whose
+// backup-remote auto-configuration fails is counted as failed (and escalated
+// via the failure mail) instead of being silently dropped from coverage.
+func TestBackupScriptCountsFailedRemoteAutoConfiguration(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	for _, db := range []string{"prod", "archive"} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", db, err)
+		}
+	}
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	doltLogPath := writeAutoConfigureFakeDolt(t, binDir, 1)
+
+	out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir)
+	if !strings.Contains(out, "synced: 1/2") {
+		t.Fatalf("unexpected backup summary:\n%s", out)
+	}
+	doltLog, err := os.ReadFile(doltLogPath)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(doltLog), "backup sync archive-backup") {
+		t.Fatalf("sync must not run for a DB whose remote could not be configured:\n%s", doltLog)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "1/2 databases failed to sync") {
+		t.Fatalf("failure mail should count the unconfigurable database, log:\n%s", gcLog)
+	}
+	if !strings.Contains(string(gcLog), "archive(backup add failed)") {
+		t.Fatalf("failure mail should name the failed auto-configuration, log:\n%s", gcLog)
+	}
+}
+
 func TestDoctorScriptChecksBackupArtifactFreshnessPerDatabase(t *testing.T) {
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "dolt-data")
@@ -3809,15 +3928,13 @@ exit 0
 	}
 }
 
-// TestDoctorBackupOnlyChecksDBsWithBackupRemote asserts mol-dog-doctor's backup
-// freshness scope mirrors mol-dog-backup.sh — only DBs with a configured
-// "<db>-backup" remote are eligible. Cities with user DBs but no backup
-// remotes (legitimate config) get no false stale-backup alarms.
-//
-// Companion to TestBackupScriptIgnoresDocumentedSystemSchemasForAutoDiscovery:
-// backup.sh already filters by remote presence; doctor.sh must use the same
-// gate so the two scripts agree on what "backup-eligible" means.
-func TestDoctorBackupOnlyChecksDBsWithBackupRemote(t *testing.T) {
+// TestDoctorWarnsOnUserDBsMissingBackupRemote asserts mol-dog-doctor reports
+// user DBs lacking a "<db>-backup" remote as a coverage gap instead of
+// silently excluding them from the backup-freshness scope. The exclusion is
+// how unconfigured production DBs went unbacked-up until journal corruption
+// made them unrecoverable (#3176). mol-dog-backup.sh auto-configures the
+// missing remote on its next run, so the warning self-heals.
+func TestDoctorWarnsOnUserDBsMissingBackupRemote(t *testing.T) {
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "dolt-data")
 	artifactDir := filepath.Join(cityPath, ".dolt-backup")
@@ -3863,8 +3980,8 @@ exit 0
 	if err != nil {
 		t.Fatalf("read gc log: %v", err)
 	}
-	if strings.Contains(string(gcLog), "archive backup missing") {
-		t.Fatalf("doctor warned about archive (no <db>-backup remote configured); should be filtered out:\n%s", gcLog)
+	if !strings.Contains(string(gcLog), "archive backup remote missing") {
+		t.Fatalf("doctor did not warn about archive's missing <db>-backup remote (#3176 coverage gap):\n%s", gcLog)
 	}
 	if !strings.Contains(string(gcLog), "prod backup missing") {
 		t.Fatalf("doctor did not warn about prod (eligible: has prod-backup remote, no artifact); scope filter should not exclude it:\n%s", gcLog)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1727,6 +1727,11 @@ type DoltConfig struct {
 	// 1 enables archive compaction (higher CPU on startup).
 	// nil (omitted) defaults to 0.
 	ArchiveLevel *int `toml:"archive_level,omitempty" jsonschema:"default=0"`
+	// AutoGCEnabled toggles Dolt's incremental auto-GC on the managed
+	// sql-server. Auto-GC bounds the noms journal so it never reaches
+	// GB scale, which shrinks both the unclean-stop corruption window
+	// and the recovery blast radius. nil (omitted) defaults to true.
+	AutoGCEnabled *bool `toml:"auto_gc_enabled,omitempty" jsonschema:"default=true"`
 	// MaxConnections overrides the managed Dolt listener max_connections.
 	// 0 means use the managed default.
 	MaxConnections int `toml:"max_connections,omitempty" jsonschema:"default=256"`
@@ -1763,6 +1768,15 @@ func (d DoltConfig) EffectiveArchiveLevel() int {
 		return *d.ArchiveLevel
 	}
 	return 0
+}
+
+// EffectiveAutoGCEnabled returns whether Dolt incremental auto-GC is enabled
+// for the managed sql-server, defaulting omitted values to true.
+func (d DoltConfig) EffectiveAutoGCEnabled() bool {
+	if d.AutoGCEnabled != nil {
+		return *d.AutoGCEnabled
+	}
+	return true
 }
 
 // EffectiveMaxConnections returns the managed Dolt listener max_connections.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1779,6 +1779,16 @@ func (d DoltConfig) EffectiveAutoGCEnabled() bool {
 	return true
 }
 
+// AutoGCSysVar returns the dolt_auto_gc_enabled system-variable value
+// ("ON"/"OFF") matching EffectiveAutoGCEnabled, so the config writer and the
+// doctor contract derive it from one place.
+func (d DoltConfig) AutoGCSysVar() string {
+	if d.EffectiveAutoGCEnabled() {
+		return "ON"
+	}
+	return "OFF"
+}
+
 // EffectiveMaxConnections returns the managed Dolt listener max_connections.
 func (d DoltConfig) EffectiveMaxConnections() int {
 	if d.MaxConnections > 0 {

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -2426,10 +2426,14 @@ func DoltConfigExpectedValues() []DoltConfigExpectedValue {
 // DoltConfigExpectedValuesForConfig returns the managed Dolt config contract
 // after applying city-level [dolt] overrides.
 func DoltConfigExpectedValuesForConfig(doltConfig config.DoltConfig) []DoltConfigExpectedValue {
+	autoGCSysVar := "ON"
+	if !doltConfig.EffectiveAutoGCEnabled() {
+		autoGCSysVar = "OFF"
+	}
 	values := []DoltConfigExpectedValue{
-		{"behavior.auto_gc_behavior.enable", false},
+		{"behavior.auto_gc_behavior.enable", doltConfig.EffectiveAutoGCEnabled()},
 		{"behavior.auto_gc_behavior.archive_level", doltConfig.EffectiveArchiveLevel()},
-		{"system_variables.dolt_auto_gc_enabled", "OFF"},
+		{"system_variables.dolt_auto_gc_enabled", autoGCSysVar},
 		{"system_variables.dolt_stats_enabled", "OFF"},
 		{"system_variables.dolt_stats_gc_enabled", "OFF"},
 		{"system_variables.dolt_stats_memory_only", "ON"},

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -2426,14 +2426,10 @@ func DoltConfigExpectedValues() []DoltConfigExpectedValue {
 // DoltConfigExpectedValuesForConfig returns the managed Dolt config contract
 // after applying city-level [dolt] overrides.
 func DoltConfigExpectedValuesForConfig(doltConfig config.DoltConfig) []DoltConfigExpectedValue {
-	autoGCSysVar := "ON"
-	if !doltConfig.EffectiveAutoGCEnabled() {
-		autoGCSysVar = "OFF"
-	}
 	values := []DoltConfigExpectedValue{
 		{"behavior.auto_gc_behavior.enable", doltConfig.EffectiveAutoGCEnabled()},
 		{"behavior.auto_gc_behavior.archive_level", doltConfig.EffectiveArchiveLevel()},
-		{"system_variables.dolt_auto_gc_enabled", autoGCSysVar},
+		{"system_variables.dolt_auto_gc_enabled", doltConfig.AutoGCSysVar()},
 		{"system_variables.dolt_stats_enabled", "OFF"},
 		{"system_variables.dolt_stats_gc_enabled", "OFF"},
 		{"system_variables.dolt_stats_memory_only", "ON"},

--- a/internal/doctor/checks_dolt_backup.go
+++ b/internal/doctor/checks_dolt_backup.go
@@ -14,9 +14,10 @@ import (
 
 // DoltBackupCheck verifies that a rig's Dolt database has a backup remote
 // configured. `gc rig add` provisions the rig but does not register a
-// backup; without a backup remote, mol-dog backup automation silently treats
-// the database as ineligible. This check catches that gap up-front in
-// `gc doctor`.
+// backup. mol-dog-backup auto-configures a local <db>-backup remote on its
+// next run (#3176), so this warning self-heals within one backup interval;
+// it catches the not-yet-covered window up-front in `gc doctor` and stays
+// loud when the backup dog itself is failing.
 //
 // Two signals satisfy the check; either is sufficient:
 //

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -3108,12 +3108,12 @@ func writeDoctorManagedDoltConfig(t *testing.T, cityPath string, overrides map[s
 		"data_dir": filepath.Join(cityPath, ".beads", "dolt"),
 		"behavior": map[string]any{
 			"auto_gc_behavior": map[string]any{
-				"enable":        false,
+				"enable":        true,
 				"archive_level": 0,
 			},
 		},
 		"system_variables": map[string]any{
-			"dolt_auto_gc_enabled":   "OFF",
+			"dolt_auto_gc_enabled":   "ON",
 			"dolt_stats_enabled":     "OFF",
 			"dolt_stats_gc_enabled":  "OFF",
 			"dolt_stats_memory_only": "ON",
@@ -3418,10 +3418,11 @@ func TestDoltConfigCheck_WrongDataDir(t *testing.T) {
 	}
 }
 
-func TestDoltConfigCheck_AutoGCEnabled(t *testing.T) {
+func TestDoltConfigCheck_AutoGCDisabledDrifts(t *testing.T) {
 	dir := setupManagedDoltCity(t)
 	writeDoctorManagedDoltConfig(t, dir, map[string]any{
-		"behavior.auto_gc_behavior.enable": true,
+		"behavior.auto_gc_behavior.enable":      false,
+		"system_variables.dolt_auto_gc_enabled": "OFF",
 	})
 	c := NewDoltConfigCheck(dir, false)
 	r := c.Run(&CheckContext{})
@@ -3430,6 +3431,9 @@ func TestDoltConfigCheck_AutoGCEnabled(t *testing.T) {
 	}
 	if !strings.Contains(r.Message, "auto_gc_behavior.enable") {
 		t.Errorf("message = %q, want auto_gc_behavior.enable mention", r.Message)
+	}
+	if !strings.Contains(r.Message, "dolt_auto_gc_enabled") {
+		t.Errorf("message = %q, want dolt_auto_gc_enabled mention", r.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary

Data-plane resilience for the gc-managed Dolt server (#3176, companion to #3174). Three operator-approved defaults so an unclean stop stops being a recurring lossy outage:

1. **auto_gc** — flips the managed default off `dolt_auto_gc_enabled: OFF` to incremental auto_gc (or far-more-frequent compaction) so the noms journal never grows to GB scale (it was corrupting at ~8.3 GB).
2. **Backup coverage** — every managed DB gets a `backup_export` remote that `mol-dog-backup` actually syncs; health verifies freshness and auto-configures missing remotes (previously bo/pa/cd were unsynced and `beads_hq` had none → restore wiped un-backed-up DBs).
3. **Auto-recovery** — on `corrupted journal` / `journal index is malformed` at start, auto-recover by truncating to the last valid offset (or restoring the freshest backup) before failing the whole control plane. Conservative + loud; never silently drops data.

Closes #3176.

## Notes

- Companion PR for #3174 (lifecycle-race guard) also touches `gc-beads-bd.sh` — may need a trivial rebase depending on merge order.
- Fix 3 (auto-truncate) kept conservative given the data-integrity sensitivity (the #2929 blind-delete precedent) — logs loudly, prefers backup-restore.
