### PR TITLE
fix(ci): lazy UNIT_COVER_PKGS + 15m timeout for make test (ga-c8y6bl)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ TEST_ENV = env -i \
 ## cache input hashes over local working files.
 ## Wrapped in $(TEST_ENV) — see comment above for why.
 test: test-fsys-darwin-compile
-	$(TEST_ENV) GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...
+	$(TEST_ENV) GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 -timeout 15m ./...
 
 LOCAL_TEST_JOBS ?= $(shell nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)
 
@@ -523,7 +523,7 @@ check-docs:
 # Packages for coverage — exclude noise:
 #   session/tmux: integration-test-only, not meaningful for unit coverage
 #   beadstest: conformance helper, runs under internal/beads coverage
-UNIT_COVER_PKGS := $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /session/tmux -e /beadstest)
+UNIT_COVER_PKGS = $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /session/tmux -e /beadstest)
 
 ## test-cover: run fast unit-test coverage without the integration-tagged package sweep
 ## The skipped cmd/gc process-backed scenarios remain covered by


### PR DESCRIPTION
## Root cause

`UNIT_COVER_PKGS :=` in the Makefile uses eager (`:=`) assignment, which causes `$(shell go list ./...)` to run **on every `make` invocation** — including the six `TestMakefileLinuxCGO*` tests added in #3182. Each `runMakefileCGOPrintTarget` call spawns `make print-cgo-flags`, which triggered a full `go list ./...` module-graph walk (~24s per test, competing for CPU with `cmd/gc` tests running in parallel at `-p=4`). This pushed the `cmd/gc` package over Go's default 10-minute test timeout on the Mac CI nightly run.

Secondary effect on Linux: `HOME=<tmpdir>` in tests caused `go list` to write to a fresh module cache under the temp dir; those read-only module files blocked `t.TempDir()` cleanup with `permission denied`.

## Fix

1. **`UNIT_COVER_PKGS :=` → `UNIT_COVER_PKGS =`** (lazy/deferred assignment): `go list ./...` now only runs when a target that uses `UNIT_COVER_PKGS` is actually built (i.e., `make test-cover` / `make cover`). The six `TestMakefileLinuxCGO*` tests drop from ~24s each to ~0.07s.

2. **`-timeout 15m` added to `make test`**: belt-and-suspenders to prevent future borderline timing on Mac from hitting the 10-minute hard wall. Aligns with the 20-minute default in `test-go-test-shard`.

## Verification

```
go test ./scripts -run TestMakefileLinuxCGO -count=1 -v  # all 6 pass in <0.2s total
go vet ./scripts/...                                      # clean
```

## Context

This is a re-land of the CI fix from #3194, which was reverted by #3209 because it was bundled with an unrelated retention feature. This PR contains **only** the Makefile fix — no retention changes. The retention feature shipped separately in #3202.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)