### PR TITLE
fix(formula): enforce gc.on_fail=abort_scope (field written but never consumed) (#1657)

### DIFF
--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -73,7 +73,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: resolving source step %q: %w", bead.ID, sourceRef, err)
 	}
-	if scopeMemberOutcomeFailed(source) {
+	if beadOutcomeFailed(source) {
 		if err := setOutcomeAndClose(store, bead.ID, "fail"); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing failed fanout: %w", bead.ID, err)
 		}

--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -73,7 +73,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: resolving source step %q: %w", bead.ID, sourceRef, err)
 	}
-	if source.Metadata[beadmeta.OutcomeMetadataKey] == "fail" {
+	if scopeMemberOutcomeFailed(source) {
 		if err := setOutcomeAndClose(store, bead.ID, "fail"); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing failed fanout: %w", bead.ID, err)
 		}

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -305,7 +305,7 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		return ControlResult{}, ErrControlPending
 	}
 
-	if subject.Metadata[beadmeta.OutcomeMetadataKey] == "fail" {
+	if scopeMemberOutcomeFailed(subject) {
 		snapshot, err := loadScopeSnapshotForControl(store, rootID, scopeRef, body, subject, bead.ID, opts)
 		if err != nil {
 			return ControlResult{}, err
@@ -628,6 +628,30 @@ func (s scopeSnapshot) skipOpenScopeMembers(store beads.Store, skipControlID str
 	}
 
 	return skipped, nil
+}
+
+// scopeMemberOutcomeFailed reports whether a closed scope member counts as
+// failed for scope-abort purposes. gc.outcome=fail is always a failure. For
+// members that opted into gc.on_fail=abort_scope, the worker-result contract
+// is fail-closed (mirroring the retry metadata firewall in
+// classifyRetryAttempt): a bare close with no gc.outcome, or an unknown
+// gc.outcome value, is treated as a failure rather than as success.
+// Retry-managed attempt subjects are exempt — their contract violations are
+// classified by retry-eval as transient retries, not scope aborts.
+func scopeMemberOutcomeFailed(subject beads.Bead) bool {
+	outcome := strings.TrimSpace(subject.Metadata[beadmeta.OutcomeMetadataKey])
+	if outcome == "fail" {
+		return true
+	}
+	if subject.Metadata[beadmeta.OnFailMetadataKey] != "abort_scope" || isRetryAttemptSubject(subject) {
+		return false
+	}
+	switch outcome {
+	case "pass", "skipped":
+		return false
+	default:
+		return true
+	}
 }
 
 func isRetryAttemptSubject(subject beads.Bead) bool {
@@ -1067,7 +1091,7 @@ func reconcileTerminalScopedMemberWithOptions(store beads.Store, bead beads.Bead
 		return ControlResult{}, fmt.Errorf("%s: loading scope body for %s: %w", bead.ID, scopeRef, err)
 	}
 
-	if bead.Metadata[beadmeta.OutcomeMetadataKey] == "fail" {
+	if scopeMemberOutcomeFailed(bead) {
 		snapshot, err := loadScopeSnapshotWithBody(store, rootID, scopeRef, body)
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: loading scope snapshot for %s: %w", bead.ID, scopeRef, err)

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -643,7 +643,7 @@ func beadOutcomeFailed(subject beads.Bead) bool {
 	if outcome == "fail" {
 		return true
 	}
-	if subject.Metadata[beadmeta.OnFailMetadataKey] != "abort_scope" || isRetryAttemptSubject(subject) {
+	if strings.TrimSpace(subject.Metadata[beadmeta.OnFailMetadataKey]) != "abort_scope" || isRetryAttemptSubject(subject) {
 		return false
 	}
 	switch outcome {

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -305,7 +305,7 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		return ControlResult{}, ErrControlPending
 	}
 
-	if scopeMemberOutcomeFailed(subject) {
+	if beadOutcomeFailed(subject) {
 		snapshot, err := loadScopeSnapshotForControl(store, rootID, scopeRef, body, subject, bead.ID, opts)
 		if err != nil {
 			return ControlResult{}, err
@@ -630,15 +630,15 @@ func (s scopeSnapshot) skipOpenScopeMembers(store beads.Store, skipControlID str
 	return skipped, nil
 }
 
-// scopeMemberOutcomeFailed reports whether a closed scope member counts as
-// failed for scope-abort purposes. gc.outcome=fail is always a failure. For
-// members that opted into gc.on_fail=abort_scope, the worker-result contract
-// is fail-closed (mirroring the retry metadata firewall in
-// classifyRetryAttempt): a bare close with no gc.outcome, or an unknown
-// gc.outcome value, is treated as a failure rather than as success.
+// beadOutcomeFailed reports whether a closed bead counts as failed for
+// scope-abort and outcome-aggregation purposes. gc.outcome=fail is always a
+// failure. For beads that opted into gc.on_fail=abort_scope, the
+// worker-result contract is fail-closed (mirroring the retry metadata
+// firewall in classifyRetryAttempt): a bare close with no gc.outcome, or an
+// unknown gc.outcome value, is treated as a failure rather than as success.
 // Retry-managed attempt subjects are exempt — their contract violations are
 // classified by retry-eval as transient retries, not scope aborts.
-func scopeMemberOutcomeFailed(subject beads.Bead) bool {
+func beadOutcomeFailed(subject beads.Bead) bool {
 	outcome := strings.TrimSpace(subject.Metadata[beadmeta.OutcomeMetadataKey])
 	if outcome == "fail" {
 		return true
@@ -1091,7 +1091,7 @@ func reconcileTerminalScopedMemberWithOptions(store beads.Store, bead beads.Bead
 		return ControlResult{}, fmt.Errorf("%s: loading scope body for %s: %w", bead.ID, scopeRef, err)
 	}
 
-	if scopeMemberOutcomeFailed(bead) {
+	if beadOutcomeFailed(bead) {
 		snapshot, err := loadScopeSnapshotWithBody(store, rootID, scopeRef, body)
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: loading scope snapshot for %s: %w", bead.ID, scopeRef, err)
@@ -1456,7 +1456,7 @@ func resolveFinalizeOutcome(store beads.Store, beadID string) (string, error) {
 		if blocker.Status != "closed" {
 			return "", fmt.Errorf("%w: blocker %s is still open", errFinalizePending, blocker.ID)
 		}
-		if blocker.Metadata[beadmeta.OutcomeMetadataKey] == "fail" {
+		if beadOutcomeFailed(blocker) {
 			outcome = "fail"
 		}
 	}

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -2070,6 +2070,56 @@ func TestProcessWorkflowFinalizeClosesWorkflow(t *testing.T) {
 	}
 }
 
+// Regression test for gastownhall/gascity#1657, finalize sibling site: a
+// workflow-finalize blocker with gc.on_fail=abort_scope that closed bare (no
+// gc.outcome) must fail the workflow instead of finalizing it green.
+func TestProcessWorkflowFinalizeAbortScopeBareCloseFailsWorkflow(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	sink := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "sink step",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.on_fail":      "abort_scope",
+			"close_reason":    "FAIL: subagent returned non-zero",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+
+	mustDepAdd(t, store, finalizer.ID, sink.ID, "blocks")
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-fail" {
+		t.Fatalf("workflow result = %+v, want processed workflow-fail", result)
+	}
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	if rootAfter.Status != "closed" || rootAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("workflow = status %q outcome %q, want closed/fail", rootAfter.Status, rootAfter.Metadata["gc.outcome"])
+	}
+}
+
 func TestProcessWorkflowFinalizeClosesOpenSpecSidecars(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -637,6 +637,64 @@ func TestProcessScopeCheckAbortScopeAffirmativeAndLegacyOutcomes(t *testing.T) {
 	}
 }
 
+// Retry-managed attempt subjects are exempt from the fail-closed abort_scope
+// contract: a bare-closed nested-retry attempt (gc.logical_bead_id +
+// gc.attempt, with the opt-in hardcoded at dispatch) must keep routing
+// through retry-eval as a transient contract violation, not abort its
+// iteration scope. An explicit gc.outcome=fail still counts as failed. The
+// opt-in match itself is whitespace-tolerant so formula-authored variants
+// cannot silently keep the legacy lenient contract.
+func TestBeadOutcomeFailedRetryAttemptExemptionAndOptInTrim(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		meta map[string]string
+		want bool
+	}{
+		{
+			name: "bare-closed retry attempt is exempt from fail-closed",
+			meta: map[string]string{
+				"gc.on_fail":         "abort_scope",
+				"gc.logical_bead_id": "ga-logical-1",
+				"gc.attempt":         "1",
+			},
+			want: false,
+		},
+		{
+			name: "explicit fail on retry attempt still counts as failed",
+			meta: map[string]string{
+				"gc.on_fail":         "abort_scope",
+				"gc.logical_bead_id": "ga-logical-1",
+				"gc.attempt":         "1",
+				"gc.outcome":         "fail",
+			},
+			want: true,
+		},
+		{
+			name: "whitespace-padded opt-in still fail-closes a bare close",
+			meta: map[string]string{
+				"gc.on_fail": " abort_scope ",
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			subject := beads.Bead{
+				ID:       "ga-subject-1",
+				Status:   "closed",
+				Metadata: tc.meta,
+			}
+			if got := beadOutcomeFailed(subject); got != tc.want {
+				t.Fatalf("beadOutcomeFailed = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSkipOpenScopeMembersBatchesDependencyChecksAndUpdates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -446,6 +446,197 @@ func TestProcessScopeCheckAbortsScopeOnFailure(t *testing.T) {
 	}
 }
 
+// scopeCheckAbortScopeFixture builds the canonical scope topology used by the
+// gc.on_fail=abort_scope contract tests: a scope body, a closed subject member
+// (metadata supplied by the caller), the subject's scope-check control, and a
+// downstream member + control wired the way graph compile rewires them
+// (downstream blocks on the subject's scope-check, not on the subject).
+func scopeCheckAbortScopeFixture(t *testing.T, store beads.Store, subjectMeta map[string]string) (control, futureMember, futureControl, body beads.Bead) {
+	t.Helper()
+	body = mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": "wf-1",
+			"gc.step_ref":     "demo.body",
+		},
+	})
+	meta := map[string]string{
+		"gc.root_bead_id": "wf-1",
+		"gc.scope_ref":    "body",
+		"gc.scope_role":   "member",
+	}
+	for k, v := range subjectMeta {
+		meta[k] = v
+	}
+	subject := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:    "preflight",
+		Type:     "task",
+		Status:   "closed",
+		Metadata: meta,
+	})
+	control = mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize scope for preflight",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	futureMember = mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "implement",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.on_fail":      "abort_scope",
+		},
+	})
+	futureControl = mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize scope for implement",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	mustDepAdd(t, store, control.ID, subject.ID, "blocks")
+	mustDepAdd(t, store, body.ID, control.ID, "blocks")
+	mustDepAdd(t, store, futureMember.ID, control.ID, "blocks")
+	mustDepAdd(t, store, futureControl.ID, futureMember.ID, "blocks")
+	return control, futureMember, futureControl, body
+}
+
+// Regression test for gastownhall/gascity#1657: a scoped step that opted into
+// gc.on_fail=abort_scope and closes without an affirmative gc.outcome (the
+// worker-result contract violation — e.g. `bd close --reason "FAIL: ..."`)
+// must abort the scope. Downstream steps must be closed as skipped and must
+// NOT appear in ready-work queries, so no pool worker can claim and run them.
+func TestProcessScopeCheckAbortScopeNormalizesFailureContract(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		subjectMeta map[string]string
+	}{
+		{
+			name: "bare close without outcome",
+			subjectMeta: map[string]string{
+				"gc.on_fail":   "abort_scope",
+				"close_reason": "FAIL: subagent returned non-zero",
+			},
+		},
+		{
+			name: "unknown outcome value",
+			subjectMeta: map[string]string{
+				"gc.on_fail": "abort_scope",
+				"gc.outcome": "banana",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := beads.NewMemStore()
+			control, futureMember, futureControl, body := scopeCheckAbortScopeFixture(t, store, tc.subjectMeta)
+
+			result, err := ProcessControl(store, mustGetBead(t, store, control.ID), ProcessOptions{})
+			if err != nil {
+				t.Fatalf("ProcessControl(scope-check): %v", err)
+			}
+			if !result.Processed || result.Action != "scope-fail" {
+				t.Fatalf("result = %+v, want processed scope-fail", result)
+			}
+			if result.Skipped != 2 {
+				t.Fatalf("skipped = %d, want 2", result.Skipped)
+			}
+
+			bodyAfter := mustGetBead(t, store, body.ID)
+			if bodyAfter.Status != "closed" || bodyAfter.Metadata["gc.outcome"] != "fail" {
+				t.Fatalf("body = status %q outcome %q, want closed/fail", bodyAfter.Status, bodyAfter.Metadata["gc.outcome"])
+			}
+			for _, beadID := range []string{futureMember.ID, futureControl.ID} {
+				member := mustGetBead(t, store, beadID)
+				if member.Status != "closed" || member.Metadata["gc.outcome"] != "skipped" {
+					t.Fatalf("%s = status %q outcome %q, want closed/skipped", beadID, member.Status, member.Metadata["gc.outcome"])
+				}
+			}
+			// The issue's repro assertion: with the subject's scope-check
+			// closed, the downstream member's dependencies are satisfied —
+			// only its skipped close keeps it out of ready-work queries.
+			if mustReadyContains(t, store, futureMember.ID) {
+				t.Fatalf("downstream member %s is claimable after abort_scope failure", futureMember.ID)
+			}
+		})
+	}
+}
+
+// Scoped members that did NOT opt into gc.on_fail=abort_scope keep the
+// legacy lenient contract: a bare close advances the scope, and an
+// affirmative pass never aborts even with the opt-in present.
+func TestProcessScopeCheckAbortScopeAffirmativeAndLegacyOutcomes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		subjectMeta map[string]string
+	}{
+		{
+			name:        "bare close without on_fail keeps legacy pass behavior",
+			subjectMeta: map[string]string{"close_reason": "FAIL: subagent returned non-zero"},
+		},
+		{
+			name: "pass outcome with abort_scope does not abort",
+			subjectMeta: map[string]string{
+				"gc.on_fail": "abort_scope",
+				"gc.outcome": "pass",
+			},
+		},
+		{
+			name: "skipped outcome with abort_scope does not abort",
+			subjectMeta: map[string]string{
+				"gc.on_fail": "abort_scope",
+				"gc.outcome": "skipped",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := beads.NewMemStore()
+			control, futureMember, _, body := scopeCheckAbortScopeFixture(t, store, tc.subjectMeta)
+
+			result, err := ProcessControl(store, mustGetBead(t, store, control.ID), ProcessOptions{})
+			if err != nil {
+				t.Fatalf("ProcessControl(scope-check): %v", err)
+			}
+			if !result.Processed || result.Action != "continue" {
+				t.Fatalf("result = %+v, want processed continue", result)
+			}
+			memberAfter := mustGetBead(t, store, futureMember.ID)
+			if memberAfter.Status != "open" {
+				t.Fatalf("downstream member status = %q, want open", memberAfter.Status)
+			}
+			bodyAfter := mustGetBead(t, store, body.ID)
+			if bodyAfter.Status != "open" {
+				t.Fatalf("body status = %q, want open while members remain", bodyAfter.Status)
+			}
+			if !mustReadyContains(t, store, futureMember.ID) {
+				t.Fatalf("downstream member %s should be claimable after scope continues", futureMember.ID)
+			}
+		})
+	}
+}
+
 func TestSkipOpenScopeMembersBatchesDependencyChecksAndUpdates(t *testing.T) {
 	t.Parallel()
 
@@ -1369,6 +1560,73 @@ func TestReconcileTerminalScopedMemberReusesResolvedBodyForFailingScope(t *testi
 	}
 	if got := openAfter.Metadata["gc.outcome"]; got != "skipped" {
 		t.Fatalf("open step outcome = %q, want skipped", got)
+	}
+}
+
+// Regression test for gastownhall/gascity#1657, reconcile-path symmetry: a
+// scoped member with gc.on_fail=abort_scope reconciled after a bare close
+// (no gc.outcome) must abort the scope instead of treating the close as pass.
+func TestReconcileTerminalScopedMemberAbortScopeBareCloseAbortsScope(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	body := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "demo.body",
+		},
+	})
+	failed := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "failed step",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.on_fail":      "abort_scope",
+			"close_reason":    "FAIL: subagent returned non-zero",
+		},
+	})
+	openStep := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "later step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+		},
+	})
+
+	result, err := reconcileTerminalScopedMember(store, failed)
+	if err != nil {
+		t.Fatalf("reconcileTerminalScopedMember(bare close): %v", err)
+	}
+	if result.Action != "scope-fail" {
+		t.Fatalf("action = %q, want scope-fail", result.Action)
+	}
+	if result.Skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", result.Skipped)
+	}
+	bodyAfter := mustGetBead(t, store, body.ID)
+	if bodyAfter.Status != "closed" || bodyAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("body = status %q outcome %q, want closed/fail", bodyAfter.Status, bodyAfter.Metadata["gc.outcome"])
+	}
+	openAfter := mustGetBead(t, store, openStep.ID)
+	if openAfter.Status != "closed" || openAfter.Metadata["gc.outcome"] != "skipped" {
+		t.Fatalf("open step = status %q outcome %q, want closed/skipped", openAfter.Status, openAfter.Metadata["gc.outcome"])
 	}
 }
 
@@ -7141,6 +7399,59 @@ func TestProcessFanoutFailsWhenSourceFailed(t *testing.T) {
 	result, err := ProcessControl(store, fanout, ProcessOptions{})
 	if err != nil {
 		t.Fatalf("ProcessControl(fanout fail): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-fail" {
+		t.Fatalf("result = %+v, want processed fanout-fail", result)
+	}
+
+	fanoutAfter := mustGetBead(t, store, fanout.ID)
+	if fanoutAfter.Status != "closed" || fanoutAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("fanout = status %q outcome %q, want closed/fail", fanoutAfter.Status, fanoutAfter.Metadata["gc.outcome"])
+	}
+}
+
+// Regression test for gastownhall/gascity#1657, fanout sibling site: a fanout
+// whose abort_scope source closed bare (no gc.outcome) must fail instead of
+// attempting expansion against the missing required output.
+func TestProcessFanoutFailsWhenAbortScopeSourceClosedBare(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "survey",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "demo.survey",
+			"gc.on_fail":      "abort_scope",
+			"close_reason":    "FAIL: subagent returned non-zero",
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for survey",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.control_for":  "demo.survey",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout bare-failed source): %v", err)
 	}
 	if !result.Processed || result.Action != "fanout-fail" {
 		t.Fatalf("result = %+v, want processed fanout-fail", result)


### PR DESCRIPTION
## Summary

Enforces `gc.on_fail=abort_scope`. The field was written (`internal/formula/ralph.go`, `internal/dispatch/control.go`) but never consumed, so after a scoped step failed, downstream steps still claimed and ran. This wires the enforcement: when a scoped step fails and its `gc.on_fail=abort_scope`, the remaining scope is aborted — downstream steps do not claim/run.

Closes #1657.

## Test

Regression test: a downstream step does **not** run after an `abort_scope` step fails.
