### PR TITLE
fix(rig): sync managed-Dolt config on adopt

### DIFF
--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -89,7 +89,9 @@ The rig's agents won't spawn until explicitly resumed with "gc rig resume".
 
 Use --adopt to register a directory that already has a fully initialized
 .beads/ directory (must include both metadata.json and config.yaml).
-Skips beads init; the git repo check remains informational.`,
+For managed-Dolt rigs, runs an idempotent config sync (registers types.custom
+and other config into the DB, never destructively reinitializes). The git repo
+check remains informational.`,
 		Example: `  gc rig add /path/to/project
   gc rig add /path/to/project --name myrig
   gc rig add /path/to/project --prefix r1
@@ -491,16 +493,21 @@ func doRigAddWithResult(fs fsys.FS, cityPath, rigPath string, includes []string,
 		}
 	}
 
+	deferred := false
 	if adopt {
 		if err := prepareRigAdoptProviderState(cityPath, rigPath); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: prepare adopted rig store: %v\n", err) //nolint:errcheck // best-effort stderr
 			return config.Rig{}, 1
 		}
+		if cityUsesBdStoreContract(cityPath) {
+			deferred, err = initDirIfReady(cityPath, rigPath, prefix)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+				return config.Rig{}, 1
+			}
+		}
 		w("  Adopted existing beads database")
-	}
-
-	deferred := false
-	if !adopt {
+	} else {
 		deferred, err = initDirIfReady(cityPath, rigPath, prefix)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -2758,6 +2758,105 @@ func TestDoRigAdd_AdoptWithoutPrefixMismatch(t *testing.T) {
 	}
 }
 
+// TestDoRigAdd_AdoptWithBdContractInvokesInitAndHook verifies that --adopt on
+// a managed-Dolt (bd-contract) city invokes the init/hook machinery to
+// register types.custom and other config into the adopted store's DB.
+// Regression for ga-fg1ht3: the adopt branch previously skipped the init
+// path entirely, leaving the DB config table out of sync with config.yaml.
+func TestDoRigAdd_AdoptWithBdContractInvokesInitAndHook(t *testing.T) {
+	cityPath := t.TempDir()
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
+	t.Setenv("GC_BEADS", "exec:"+filepath.Join(cityPath, "gc-beads-bd"))
+	t.Setenv("GC_DOLT", "")
+
+	// Stub lifecycle hooks — no real Dolt in unit tests. Record that the
+	// init path was invoked with the adopted rig dir.
+	origEnsure := initDirIfReadyEnsureBeadsProvider
+	origInit := initDirIfReadyInitAndHookDir
+	t.Cleanup(func() {
+		initDirIfReadyEnsureBeadsProvider = origEnsure
+		initDirIfReadyInitAndHookDir = origInit
+	})
+	initDirIfReadyEnsureBeadsProvider = func(_ string) error { return nil }
+
+	var initCalls []string
+	initDirIfReadyInitAndHookDir = func(_, dir, _ string) error {
+		initCalls = append(initCalls, dir)
+		return nil
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "adopted-rig")
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"name":"adopted-rig","issue_prefix":"ar"}`
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configYaml := "issue_prefix: ar\n" +
+		"types.custom: molecule,convoy,session,merge-request,agent,role,rig,spec,convergence,step\n"
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "config.yaml"), []byte(configYaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "ar", "", false, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd --adopt returned %d, stderr: %s", code, stderr.String())
+	}
+	if len(initCalls) == 0 {
+		t.Fatalf("ga-fg1ht3: --adopt on bd-contract city must invoke initAndHookDir to register types.custom; initCalls=%v", initCalls)
+	}
+	found := false
+	for _, dir := range initCalls {
+		if samePath(dir, rigPath) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("initAndHookDir called but not for adopted rig path %q; calls=%v", rigPath, initCalls)
+	}
+	if !strings.Contains(stdout.String(), "Adopted existing beads database") {
+		t.Errorf("stdout should mention adoption: %s", stdout.String())
+	}
+}
+
+// TestDoRigAdd_AdoptWithBdContractProvider_NonAdoptControlInvokesInit is a
+// control: the same stubbed harness wired through a NON-adopt add also calls
+// initAndHookDir, proving that the empty-initCalls failure above (pre-fix) was
+// real (adopt invoked init 0 times), not a harness artifact.
+func TestDoRigAdd_AdoptWithBdContractProvider_NonAdoptControlInvokesInit(t *testing.T) {
+	cityPath := t.TempDir()
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
+	t.Setenv("GC_BEADS", "exec:"+filepath.Join(cityPath, "gc-beads-bd"))
+	t.Setenv("GC_DOLT", "")
+
+	origEnsure := initDirIfReadyEnsureBeadsProvider
+	origInit := initDirIfReadyInitAndHookDir
+	t.Cleanup(func() {
+		initDirIfReadyEnsureBeadsProvider = origEnsure
+		initDirIfReadyInitAndHookDir = origInit
+	})
+	initDirIfReadyEnsureBeadsProvider = func(_ string) error { return nil }
+
+	var initCalls []string
+	initDirIfReadyInitAndHookDir = func(_, dir, _ string) error {
+		initCalls = append(initCalls, dir)
+		return nil
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "fresh-rig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "fr", "", false, false, &stdout, &stderr)
+	if len(initCalls) == 0 {
+		t.Fatalf("control: non-adopt rig add invoked initAndHookDir 0 times; stub not wired in? stderr=%s", stderr.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Six-row read-path routing matrix for `gc rig list` (ADR 0001, ga-h6w).
 // ---------------------------------------------------------------------------

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2636,7 +2636,9 @@ The rig's agents won't spawn until explicitly resumed with "gc rig resume".
 
 Use --adopt to register a directory that already has a fully initialized
 .beads/ directory (must include both metadata.json and config.yaml).
-Skips beads init; the git repo check remains informational.
+For managed-Dolt rigs, runs an idempotent config sync (registers types.custom
+and other config into the DB, never destructively reinitializes). The git repo
+check remains informational.
 
 ```
 gc rig add <path> [flags]

--- a/release-gates/ga-pftmco-2-adopt-types-custom-registration-gate.md
+++ b/release-gates/ga-pftmco-2-adopt-types-custom-registration-gate.md
@@ -1,0 +1,38 @@
+# Release Gate: ga-pftmco.2 adopt types.custom registration
+
+Status: PASS
+Date: 2026-06-07
+
+## Scope
+
+- Deploy bead: ga-pftmco.2
+- Source review bead: ga-bcip1f
+- Clean branch: origin/work/ga-pftmco-adopt-fix
+- Clean branch commit: cc17578e37f67a7137f23adb4de7bbbaae3ae614
+- Reviewed source commit: 255fae84175e8e287b53c3959b7667e8954f9aa3
+- Base checked: origin/main 9ac732cd80335f8157861419f8f24202903d78b1
+- Manifest note: docs/PROJECT_MANIFEST.md was not present in this checkout, so this gate uses the deployer role release criteria.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-bcip1f` contains `Review verdict: PASS` for reviewed commit `255fae84175e8e287b53c3959b7667e8954f9aa3`. The review lists only two INFO findings and no blocking findings. |
+| 2 | Acceptance criteria met | PASS | `bd show ga-pftmco.1` records clean branch `work/ga-pftmco-adopt-fix`, cherry-picked commit `cc17578e37f67a7137f23adb4de7bbbaae3ae614`, base `origin/main` `9ac732cd8`, and verification that the forbidden files are absent. Deployer diff check against current `origin/main` shows exactly `cmd/gc/cmd_rig.go`, `cmd/gc/cmd_rig_test.go`, and `docs/reference/cli.md`; no `internal/api/handler_status_test.go` or `release-gates/fix-status-degrade-wall-bounds-gate.md` entries are present. The code routes managed-Dolt `gc rig add --adopt` through `initDirIfReady`, preserving adopt validation while syncing DB config such as `types.custom`. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc/... -run 'TestDoRigAdd_Adopt'` passed. `make test-fast-parallel` passed all 8 fast jobs. `go vet ./...` exited clean. `go build -o /tmp/gc-ga-pftmco-2 ./cmd/gc` passed, and `/tmp/gc-ga-pftmco-2 rig add --help` shows the managed-Dolt idempotent config sync help text. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes on ga-bcip1f list two INFO findings: deferred-path output asymmetry and a hard-to-test non-destructive reinit guarantee. No HIGH, blocking, security, or correctness findings are recorded. |
+| 5 | Final branch is clean | PASS | The isolated release worktree was clean at candidate checkout (`git status --short --branch` printed only `## HEAD (no branch)`). After committing this gate file, deployer rechecks the worktree before push; the committed gate file is the only deployer-added change. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base HEAD origin/main` equals `9ac732cd80335f8157861419f8f24202903d78b1`, the current `origin/main`; the release branch is a direct descendant of main. |
+| 7 | Single feature theme | PASS | `git diff --name-status origin/main...HEAD` touches one subsystem and its docs: `cmd/gc/cmd_rig.go`, `cmd/gc/cmd_rig_test.go`, and `docs/reference/cli.md`. The diff is one feature theme: managed-Dolt adopt registration of `types.custom` and matching CLI documentation. |
+
+## Diff Evidence
+
+```text
+M	cmd/gc/cmd_rig.go
+M	cmd/gc/cmd_rig_test.go
+M	docs/reference/cli.md
+```
+
+```text
+3 files changed, 114 insertions(+), 6 deletions(-)
+```


### PR DESCRIPTION
## What this changes

`gc rig add --adopt` now keeps managed-Dolt rig stores in sync with the config already present in their `.beads` directory. When a city uses the bd store contract, adopt runs the existing idempotent init path so config rows such as `types.custom` are registered in the adopted Dolt database. This fixes adopted rigs whose `config.yaml` advertised custom bead types but whose DB did not know about them.

The CLI help and reference docs now say adopt performs this managed-Dolt config sync instead of saying it always skips beads init.

## Review notes

- The behavior change is limited to `gc rig add --adopt` when `cityUsesBdStoreContract(cityPath)` is true; non-adopt setup still uses the same init path as before.
- The implementation reuses `initDirIfReady` instead of adding a second config writer, so deferred mode and provider initialization stay centralized.
- No HTTP API, dashboard, schema, or generated client surfaces changed.
- The user-facing success line remains `Adopted existing beads database`; the new help text carries the detail about config sync.

Internal tracking: ga-pftmco.2.

## Test plan

- [x] `go test ./cmd/gc/... -run 'TestDoRigAdd_Adopt'`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build -o /tmp/gc-ga-pftmco-2 ./cmd/gc`; `/tmp/gc-ga-pftmco-2 rig add --help` shows the managed-Dolt config sync text
- [x] Release gate: [`release-gates/ga-pftmco-2-adopt-types-custom-registration-gate.md`](release-gates/ga-pftmco-2-adopt-types-custom-registration-gate.md)
