### PR TITLE
fix(supervisor): deterministic + faster bounded /beads reads and /formulas/feed (#3208)

### DIFF
--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -537,6 +538,88 @@ type projectionConflictStore struct {
 func (s *projectionConflictStore) WaitForParentProjection(_ context.Context, _, _, _ string) error {
 	s.waitCalls++
 	return beads.ErrParentProjectionSuperseded
+}
+
+// TestBeadListBoundedReadIsStableOrderedPrefixAcrossRigs pins the #3208
+// contract: a limit-bounded GET /beads returns a deterministic prefix of one
+// global (created_at DESC, id DESC) total order across rig stores — not a
+// per-rig concatenation — and a truncated response carries next_cursor so
+// the remainder is fetchable.
+func TestBeadListBoundedReadIsStableOrderedPrefixAcrossRigs(t *testing.T) {
+	state := newFakeState(t)
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	mk := func(id string, minutes int) beads.Bead {
+		return beads.Bead{
+			ID:        id,
+			Title:     id,
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: base.Add(time.Duration(minutes) * time.Minute),
+		}
+	}
+	// Creation times interleave across the two rigs so per-rig concatenation
+	// and the global total order disagree.
+	state.stores["arig"] = beads.NewMemStoreFrom(0, []beads.Bead{
+		mk("aa-1", 1), mk("aa-3", 3), mk("aa-5", 5),
+	}, nil)
+	state.stores["zrig"] = beads.NewMemStoreFrom(0, []beads.Bead{
+		mk("zz-2", 2), mk("zz-4", 4), mk("zz-6", 6),
+	}, nil)
+	h := newTestCityHandler(t, state)
+
+	type listResp struct {
+		Items      []beads.Bead `json:"items"`
+		Total      int          `json:"total"`
+		NextCursor string       `json:"next_cursor"`
+	}
+	get := func(url string) listResp {
+		t.Helper()
+		req := httptest.NewRequest("GET", cityURL(state, url), nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET %s = %d, want 200: %s", url, rec.Code, rec.Body.String())
+		}
+		var resp listResp
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode %s: %v", url, err)
+		}
+		return resp
+	}
+	ids := func(items []beads.Bead) []string {
+		out := make([]string, 0, len(items))
+		for _, b := range items {
+			out = append(out, b.ID)
+		}
+		return out
+	}
+
+	first := get("/beads?limit=4")
+	wantFirst := []string{"zz-6", "aa-5", "zz-4", "aa-3"}
+	if got := ids(first.Items); !slices.Equal(got, wantFirst) {
+		t.Fatalf("bounded page ids = %v, want global order %v", got, wantFirst)
+	}
+	if first.Total != 6 {
+		t.Fatalf("total = %d, want 6", first.Total)
+	}
+	if first.NextCursor == "" {
+		t.Fatalf("truncated bounded read returned no next_cursor; remainder is unfetchable")
+	}
+
+	// The same bounded read must return the same page — the #3208 symptom
+	// was per-call-different subsets.
+	if again := get("/beads?limit=4"); !slices.Equal(ids(again.Items), wantFirst) {
+		t.Fatalf("repeat bounded page ids = %v, want %v (non-deterministic page)", ids(again.Items), wantFirst)
+	}
+
+	rest := get("/beads?limit=4&cursor=" + first.NextCursor)
+	wantRest := []string{"zz-2", "aa-1"}
+	if got := ids(rest.Items); !slices.Equal(got, wantRest) {
+		t.Fatalf("continuation ids = %v, want %v", got, wantRest)
+	}
+	if rest.NextCursor != "" {
+		t.Fatalf("final page next_cursor = %q, want empty", rest.NextCursor)
+	}
 }
 
 func TestBeadListFiltering(t *testing.T) {

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -28,30 +28,6 @@ type (
 
 var statusStoreReadTimeout = time.Second
 
-// statusResponseCacheTTL bounds how long a built /status body is reused.
-//
-// Unlike the shared response cache (which keys on the event sequence and so
-// misses on every poll of a busy city — the sequence advances each tick),
-// /status keys its cache entry on a TIME bucket of this width. /status is a
-// coarse operator overview where a few seconds of staleness is acceptable
-// (the response already reports X-GC-Cache-Age-S), so on a busy city the
-// dashboard's high-frequency polls hit the cache instead of rebuilding the
-// O(store-size) body every time (gascity#3186). Strict-freshness callers
-// (blocking ?index=&wait= requests) bypass this cache; see humaHandleStatus.
-var statusResponseCacheTTL = 2 * time.Second
-
-// statusCacheBucket returns a monotonically increasing generation that only
-// changes once per statusResponseCacheTTL window. Passing it where the shared
-// cache expects an event index makes /status's cache entry survive across the
-// event-sequence churn of a busy city while still expiring on a wall-clock TTL.
-func statusCacheBucket(now time.Time) uint64 {
-	ttl := statusResponseCacheTTL
-	if ttl <= 0 {
-		return uint64(now.UnixNano())
-	}
-	return uint64(now.UnixNano() / int64(ttl))
-}
-
 // StatusInput is the Huma input for GET /v0/status.
 type StatusInput struct {
 	CityScope
@@ -87,7 +63,7 @@ func (s *Server) humaHandleStatus(ctx context.Context, input *StatusInput) (*Ind
 	// on a busy city the sequence advances every poll, so an index-keyed
 	// entry would miss on nearly every request and force a full O(store-size)
 	// rebuild (gascity#3186). The bucket changes only once per
-	// statusResponseCacheTTL, so high-frequency dashboard polls reuse the
+	// timeBucketResponseCacheTTL, so high-frequency dashboard polls reuse the
 	// built body. The ?lite variant caches under its own key (the shared
 	// cache map keys on the string key, so the suffix is enough).
 	//
@@ -98,7 +74,7 @@ func (s *Server) humaHandleStatus(ctx context.Context, input *StatusInput) (*Ind
 	if input.Lite {
 		cacheKey = "status?lite"
 	}
-	bucket := statusCacheBucket(time.Now())
+	bucket := responseCacheTimeBucket(time.Now())
 	if !blocking {
 		if body, ok := cachedResponseAs[StatusBody](s, cacheKey, bucket); ok {
 			return &IndexOutput[StatusBody]{Index: index, CacheAgeS: cacheAgeSeconds(store), Body: body}, nil

--- a/internal/api/handler_status_test.go
+++ b/internal/api/handler_status_test.go
@@ -661,9 +661,9 @@ func TestBuildStatusBodyLiteOmitsExpensiveBlocks(t *testing.T) {
 func TestHandleStatusLiteSkipsWorkScanAndCachesSeparately(t *testing.T) {
 	// Pin a wide TTL so every request lands in the same time bucket; this test
 	// asserts cache-key separation, not TTL expiry.
-	oldTTL := statusResponseCacheTTL
-	statusResponseCacheTTL = time.Hour
-	t.Cleanup(func() { statusResponseCacheTTL = oldTTL })
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = time.Hour
+	t.Cleanup(func() { timeBucketResponseCacheTTL = oldTTL })
 
 	state := newFakeState(t)
 	store := &countingStore{Store: beads.NewMemStore()}

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -3,15 +3,22 @@ package api
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
 // humaHandleBeadList is the Huma-typed handler for GET /v0/beads.
+//
+// Bounded reads are a deterministic prefix of one total order: every
+// per-store query and the cross-rig merge sort by (created_at DESC, id DESC),
+// so the same request returns the same page on every call and a truncated
+// response always carries next_cursor for the remainder (#3208).
 func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (*ListOutput[beads.Bead], error) {
 	bp := input.toBlockingParams()
-	if bp.isBlocking() {
+	blocking := bp.isBlocking()
+	if blocking {
 		waitForChange(ctx, s.state.EventProvider(), bp)
 	}
 
@@ -30,6 +37,27 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	if input.Cursor != "" {
 		pp.Offset = decodeCursor(input.Cursor)
 		pp.IsPaging = true
+	}
+
+	// all=true reads bypass the CachingStore (closed history lives only in
+	// the backing store) and are O(full history) per rig — seconds on a
+	// large city. Key their response cache on a time bucket so concurrent
+	// pollers share one rebuild per TTL window instead of stacking slow
+	// reads (#3208, same lever as /status in gascity#3186). Open-only reads
+	// are served from the in-memory cache and stay uncached here; blocking
+	// callers bypass so the body reflects the event they waited for.
+	cacheKey := ""
+	var bucket uint64
+	if input.All && !blocking {
+		cacheKey = cacheKeyFor("beads", input)
+		bucket = responseCacheTimeBucket(time.Now())
+		if body, ok := cachedResponseAs[ListBody[beads.Bead]](s, cacheKey, bucket); ok {
+			return &ListOutput[beads.Bead]{
+				Index:     s.latestIndex(),
+				CacheAgeS: cacheAgeSeconds(cityStore),
+				Body:      body,
+			}, nil
+		}
 	}
 
 	stores := s.state.BeadStores()
@@ -57,6 +85,10 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 				Assignee:      assignee,
 				IncludeClosed: input.All,
 				Live:          input.Status == "in_progress",
+				// Explicit sort: with SortDefault the CachingStore returns
+				// map-iteration order, so a bounded read truncated an
+				// arbitrary, per-call-different subset (#3208).
+				Sort: beads.SortCreatedDesc,
 			}
 			if !query.HasFilter() {
 				query.AllowScan = true
@@ -93,40 +125,51 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	if all == nil {
 		all = []beads.Bead{}
 	}
+	// Per-store results are each (created_at, id)-ordered, but the rig
+	// concatenation above is not: re-sort so the merged set has one global
+	// total order and a bounded read is a deterministic prefix of it (#3208).
+	beads.SortBeads(all, beads.SortCreatedDesc)
 
 	index := s.latestIndex()
 	cacheAge := cacheAgeSeconds(cityStore)
-	if !pp.IsPaging {
-		total := len(all)
-		if pp.Limit < len(all) {
-			all = all[:pp.Limit]
+	var body ListBody[beads.Bead]
+	if pp.IsPaging {
+		page, total, nextCursor := paginate(all, pp)
+		if page == nil {
+			page = []beads.Bead{}
 		}
-		return &ListOutput[beads.Bead]{
-			Index:     index,
-			CacheAgeS: cacheAge,
-			Body: ListBody[beads.Bead]{
-				Items:         all,
-				Total:         total,
-				Partial:       pa.partial(),
-				PartialErrors: pa.messages(),
-			},
-		}, nil
-	}
-
-	page, total, nextCursor := paginate(all, pp)
-	if page == nil {
-		page = []beads.Bead{}
-	}
-	return &ListOutput[beads.Bead]{
-		Index:     index,
-		CacheAgeS: cacheAge,
-		Body: ListBody[beads.Bead]{
+		body = ListBody[beads.Bead]{
 			Items:         page,
 			Total:         total,
 			NextCursor:    nextCursor,
 			Partial:       pa.partial(),
 			PartialErrors: pa.messages(),
-		},
+		}
+	} else {
+		total := len(all)
+		nextCursor := ""
+		if pp.Limit < len(all) {
+			// A truncated first page carries the continuation cursor too:
+			// without it the remainder of a limit-bounded read is
+			// unfetchable by design (#3208).
+			all = all[:pp.Limit]
+			nextCursor = encodeCursor(pp.Limit)
+		}
+		body = ListBody[beads.Bead]{
+			Items:         all,
+			Total:         total,
+			NextCursor:    nextCursor,
+			Partial:       pa.partial(),
+			PartialErrors: pa.messages(),
+		}
+	}
+	if cacheKey != "" {
+		s.storeResponse(cacheKey, bucket, body)
+	}
+	return &ListOutput[beads.Bead]{
+		Index:     index,
+		CacheAgeS: cacheAge,
+		Body:      body,
 	}, nil
 }
 

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -36,7 +36,6 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	}
 	if input.Cursor != "" {
 		pp.Offset = decodeCursor(input.Cursor)
-		pp.IsPaging = true
 	}
 
 	// all=true reads bypass the CachingStore (closed history lives only in
@@ -132,36 +131,19 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 
 	index := s.latestIndex()
 	cacheAge := cacheAgeSeconds(cityStore)
-	var body ListBody[beads.Bead]
-	if pp.IsPaging {
-		page, total, nextCursor := paginate(all, pp)
-		if page == nil {
-			page = []beads.Bead{}
-		}
-		body = ListBody[beads.Bead]{
-			Items:         page,
-			Total:         total,
-			NextCursor:    nextCursor,
-			Partial:       pa.partial(),
-			PartialErrors: pa.messages(),
-		}
-	} else {
-		total := len(all)
-		nextCursor := ""
-		if pp.Limit < len(all) {
-			// A truncated first page carries the continuation cursor too:
-			// without it the remainder of a limit-bounded read is
-			// unfetchable by design (#3208).
-			all = all[:pp.Limit]
-			nextCursor = encodeCursor(pp.Limit)
-		}
-		body = ListBody[beads.Bead]{
-			Items:         all,
-			Total:         total,
-			NextCursor:    nextCursor,
-			Partial:       pa.partial(),
-			PartialErrors: pa.messages(),
-		}
+	// A non-cursor request is offset-0 paging: a truncated first page carries
+	// the continuation cursor too, otherwise the remainder of a limit-bounded
+	// read is unfetchable by design (#3208).
+	page, total, nextCursor := paginate(all, pp)
+	if page == nil {
+		page = []beads.Bead{}
+	}
+	body := ListBody[beads.Bead]{
+		Items:         page,
+		Total:         total,
+		NextCursor:    nextCursor,
+		Partial:       pa.partial(),
+		PartialErrors: pa.messages(),
 	}
 	if cacheKey != "" {
 		s.storeResponse(cacheKey, bucket, body)

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -40,11 +40,13 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 
 	// all=true reads bypass the CachingStore (closed history lives only in
 	// the backing store) and are O(full history) per rig — seconds on a
-	// large city. Key their response cache on a time bucket so concurrent
-	// pollers share one rebuild per TTL window instead of stacking slow
-	// reads (#3208, same lever as /status in gascity#3186). Open-only reads
-	// are served from the in-memory cache and stay uncached here; blocking
-	// callers bypass so the body reflects the event they waited for.
+	// large city. Key their response cache on a time bucket so polls within
+	// a TTL window reuse the first completed rebuild instead of each
+	// rebuilding (#3208, same lever as /status in gascity#3186; there is no
+	// single-flight, so simultaneous misses on a cold bucket still rebuild
+	// independently). Open-only reads are served from the in-memory cache
+	// and stay uncached here; blocking callers bypass so the body reflects
+	// the event they waited for.
 	cacheKey := ""
 	var bucket uint64
 	if input.All && !blocking {
@@ -124,10 +126,14 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	if all == nil {
 		all = []beads.Bead{}
 	}
-	// Per-store results are each (created_at, id)-ordered, but the rig
-	// concatenation above is not: re-sort so the merged set has one global
-	// total order and a bounded read is a deterministic prefix of it (#3208).
-	beads.SortBeads(all, beads.SortCreatedDesc)
+	// Per-store results are each (created_at, id)-ordered, but the
+	// concatenation across rigs and assignee terms is not: re-sort so the
+	// merged set has one global total order and a bounded read is a
+	// deterministic prefix of it (#3208). A single (rig, assignee) source is
+	// already in canonical order — skip the redundant hot-path sort.
+	if len(rigNames)*len(assigneeTerms) > 1 {
+		beads.SortBeads(all, beads.SortCreatedDesc)
+	}
 
 	index := s.latestIndex()
 	cacheAge := cacheAgeSeconds(cityStore)

--- a/internal/api/huma_handlers_formulas.go
+++ b/internal/api/huma_handlers_formulas.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 )
@@ -195,10 +196,17 @@ func (s *Server) humaHandleFormulaFeed(_ context.Context, input *FormulaFeedInpu
 	}
 
 	limit := normalizeFeedLimit(input.Limit)
-	index := s.latestIndex()
 
+	// The feed body is O(store history) to build (a full active scan plus a
+	// closed-history workflow-roots scan per rig). Key its cache entry on a
+	// time bucket, not the event index: on a busy city the index advances
+	// every tick, so the index-keyed entry missed on nearly every poll and
+	// the slow body was rebuilt per request — the #3208 feed latency. The
+	// endpoint has no blocking variant, so there is no strict-freshness
+	// caller to bypass for (same lever as /status in gascity#3186).
 	cacheKey := "formula-feed?" + scopeKind + "|" + scopeRef + "|" + strconv.Itoa(input.Limit)
-	if body, ok := cachedResponseAs[formulaFeedBody](s, cacheKey, index); ok {
+	bucket := responseCacheTimeBucket(time.Now())
+	if body, ok := cachedResponseAs[formulaFeedBody](s, cacheKey, bucket); ok {
 		return &struct {
 			Body formulaFeedBody
 		}{Body: body}, nil
@@ -225,7 +233,7 @@ func (s *Server) humaHandleFormulaFeed(_ context.Context, input *FormulaFeedInpu
 		body.PartialErrors = projections.PartialErrors
 	}
 
-	s.storeResponse(cacheKey, index, body)
+	s.storeResponse(cacheKey, bucket, body)
 
 	return &struct {
 		Body formulaFeedBody

--- a/internal/api/response_cache.go
+++ b/internal/api/response_cache.go
@@ -11,6 +11,30 @@ import (
 
 var responseCacheTTL = 2 * time.Second
 
+// timeBucketResponseCacheTTL bounds how long a built body is reused by the
+// endpoints that key their response-cache entry on a TIME bucket rather than
+// the event sequence: /status (gascity#3186), /formulas/feed, and bounded
+// all=true /beads reads (#3208). The shared index-keyed cache misses on every
+// poll of a busy city — the sequence advances each tick — so O(store-size)
+// bodies were rebuilt per request. These are coarse views where a few seconds
+// of staleness is acceptable (responses report X-GC-Cache-Age-S where a
+// CachingStore backs them); strict-freshness callers (blocking ?index=&wait=
+// requests) bypass the time cache at each handler.
+var timeBucketResponseCacheTTL = 2 * time.Second
+
+// responseCacheTimeBucket returns a monotonically increasing generation that
+// only changes once per timeBucketResponseCacheTTL window. Passing it where
+// the shared cache expects an event index makes an entry survive across the
+// event-sequence churn of a busy city while still expiring on a wall-clock
+// TTL.
+func responseCacheTimeBucket(now time.Time) uint64 {
+	ttl := timeBucketResponseCacheTTL
+	if ttl <= 0 {
+		return uint64(now.UnixNano())
+	}
+	return uint64(now.UnixNano() / int64(ttl))
+}
+
 // responseCacheMaxEntries caps the in-memory cache. Query-parameter
 // combinations (Rig, Pool, blocking index, etc.) produce a wide but
 // bounded key space; a hostile or buggy client could still exhaust

--- a/internal/api/response_cache_test.go
+++ b/internal/api/response_cache_test.go
@@ -57,9 +57,9 @@ func TestHandleStatusCachesAcrossIndexChanges(t *testing.T) {
 	// bucket; this isolates the "index churn must not bust the cache" property
 	// from wall-clock bucket-boundary timing. The TTL-expiry/staleness bound is
 	// covered separately by TestHandleStatusCacheExpiresOnTTL.
-	oldTTL := statusResponseCacheTTL
-	statusResponseCacheTTL = time.Hour
-	t.Cleanup(func() { statusResponseCacheTTL = oldTTL })
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = time.Hour
+	t.Cleanup(func() { timeBucketResponseCacheTTL = oldTTL })
 
 	state := newFakeState(t)
 	store := &countingStore{Store: beads.NewMemStore()}
@@ -104,12 +104,12 @@ func TestHandleStatusCachesAcrossIndexChanges(t *testing.T) {
 }
 
 // TestHandleStatusCacheExpiresOnTTL verifies the staleness bound: once the
-// time bucket rolls over, the next /status rebuilds. Drives statusCacheBucket
+// time bucket rolls over, the next /status rebuilds. Drives responseCacheTimeBucket
 // directly by collapsing the TTL so the test stays fast and deterministic.
 func TestHandleStatusCacheExpiresOnTTL(t *testing.T) {
-	oldTTL := statusResponseCacheTTL
-	statusResponseCacheTTL = time.Nanosecond // every request lands in a new bucket
-	t.Cleanup(func() { statusResponseCacheTTL = oldTTL })
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = time.Nanosecond // every request lands in a new bucket
+	t.Cleanup(func() { timeBucketResponseCacheTTL = oldTTL })
 
 	state := newFakeState(t)
 	store := &countingStore{Store: beads.NewMemStore()}
@@ -254,5 +254,177 @@ func TestHandleOrdersFeedCachesUntilIndexChanges(t *testing.T) {
 	}
 	if cityStore.listByLabelCalls != 2 {
 		t.Fatalf("city ListByLabel calls after index change = %d, want 2", cityStore.listByLabelCalls)
+	}
+}
+
+// newFormulaFeedCacheFixture seeds a rig store with one graph.v2 workflow
+// root so /formulas/feed has a body to build, and returns the wrapped store
+// whose listCalls counts feed rebuilds.
+func newFormulaFeedCacheFixture(t *testing.T) (*fakeState, *countingStore, http.Handler) {
+	t.Helper()
+	state := newFakeState(t)
+	rigStore := &countingStore{Store: beads.NewMemStore()}
+	state.stores["myrig"] = rigStore
+	if _, err := rigStore.Create(beads.Bead{
+		Title: "Adopt PR",
+		Ref:   "mol-adopt-pr-v2",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.workflow_id":      "wf-123",
+			"gc.scope_kind":       "rig",
+			"gc.scope_ref":        "myrig",
+		},
+	}); err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	return state, rigStore, newTestCityHandler(t, state)
+}
+
+// TestHandleFormulaFeedCachesAcrossIndexChanges pins the #3208 feed-latency
+// fix: /formulas/feed keys its response cache on a wall-clock TTL bucket, not
+// the event sequence, so a busy city (whose sequence advances every poll) no
+// longer rebuilds the O(store-history) feed body on every request.
+func TestHandleFormulaFeedCachesAcrossIndexChanges(t *testing.T) {
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = time.Hour
+	t.Cleanup(func() { timeBucketResponseCacheTTL = oldTTL })
+
+	state, rigStore, h := newFormulaFeedCacheFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/formulas/feed?scope_kind=rig&scope_ref=myrig"), nil)
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("feed #%d = %d, want 200", i, rec.Code)
+		}
+	}
+	if rigStore.listCalls != 1 {
+		t.Fatalf("rig List calls after cached repeat = %d, want 1", rigStore.listCalls)
+	}
+
+	// A moving event sequence — the busy-city scenario from #3208 — must
+	// keep hitting the time-bucketed cache, not force a rebuild per poll.
+	for i := 0; i < 5; i++ {
+		state.eventProv.Record(events.Event{Type: events.BeadCreated, Actor: "human"})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("feed after event %d = %d, want 200", i, rec.Code)
+		}
+	}
+	if rigStore.listCalls != 1 {
+		t.Fatalf("rig List calls across index churn = %d, want 1 (feed must key on time bucket)", rigStore.listCalls)
+	}
+}
+
+// TestHandleFormulaFeedCacheExpiresOnTTL verifies the feed's staleness bound:
+// once the time bucket rolls over, the next request rebuilds.
+func TestHandleFormulaFeedCacheExpiresOnTTL(t *testing.T) {
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = time.Nanosecond // every request lands in a new bucket
+	t.Cleanup(func() { timeBucketResponseCacheTTL = oldTTL })
+
+	state, rigStore, h := newFormulaFeedCacheFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/formulas/feed?scope_kind=rig&scope_ref=myrig"), nil)
+	for i := 0; i < 3; i++ {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("feed #%d = %d, want 200", i, rec.Code)
+		}
+	}
+	if rigStore.listCalls < 2 {
+		t.Fatalf("rig List calls with expiring TTL = %d, want >= 2", rigStore.listCalls)
+	}
+}
+
+// TestHandleBeadListAllCachesAcrossIndexChanges pins the #3208 large-read
+// lever: all=true /beads reads (which bypass the CachingStore and scan full
+// history per rig) key their response cache on a time bucket, so concurrent
+// pollers share one rebuild per TTL window. Open-only reads stay uncached.
+func TestHandleBeadListAllCachesAcrossIndexChanges(t *testing.T) {
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = time.Hour
+	t.Cleanup(func() { timeBucketResponseCacheTTL = oldTTL })
+
+	state := newFakeState(t)
+	store := &countingStore{Store: beads.NewMemStore()}
+	state.stores["myrig"] = store
+	if _, err := store.Create(beads.Bead{Title: "task one", Type: "task"}); err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/beads?all=true"), nil)
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("beads all #%d = %d, want 200", i, rec.Code)
+		}
+	}
+	if store.listCalls != 1 {
+		t.Fatalf("List calls after cached all=true repeat = %d, want 1", store.listCalls)
+	}
+
+	state.eventProv.Record(events.Event{Type: events.BeadCreated, Actor: "human"})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("beads all after event = %d, want 200", rec.Code)
+	}
+	if store.listCalls != 1 {
+		t.Fatalf("List calls across index churn = %d, want 1 (all=true must key on time bucket)", store.listCalls)
+	}
+
+	// Open-only reads are served from the store every time — they hit the
+	// in-memory CachingStore in production and must stay fresh.
+	openReq := httptest.NewRequest(http.MethodGet, cityURL(state, "/beads"), nil)
+	for i := 0; i < 2; i++ {
+		rec = httptest.NewRecorder()
+		h.ServeHTTP(rec, openReq)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("open beads #%d = %d, want 200", i, rec.Code)
+		}
+	}
+	if store.listCalls != 3 {
+		t.Fatalf("List calls after open-only reads = %d, want 3 (open reads must not be response-cached)", store.listCalls)
+	}
+}
+
+// TestHandleBeadListAllBlockingBypassesTimeCache verifies the preserved
+// strict-freshness path on /beads: a blocking ?index=&wait= all=true request
+// must rebuild the body rather than be served an entry built before the
+// event it waited for.
+func TestHandleBeadListAllBlockingBypassesTimeCache(t *testing.T) {
+	state := newFakeState(t)
+	store := &countingStore{Store: beads.NewMemStore()}
+	state.stores["myrig"] = store
+	if _, err := store.Create(beads.Bead{Title: "task one", Type: "task"}); err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/beads?all=true"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("priming beads all = %d, want 200", rec.Code)
+	}
+	if store.listCalls != 1 {
+		t.Fatalf("List calls after priming = %d, want 1", store.listCalls)
+	}
+
+	blockReq := httptest.NewRequest(http.MethodGet, cityURL(state, "/beads?all=true&index=0&wait=1s"), nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, blockReq)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("blocking beads all = %d, want 200", rec.Code)
+	}
+	if store.listCalls != 2 {
+		t.Fatalf("List calls after blocking request = %d, want 2 (blocking must bypass time cache)", store.listCalls)
 	}
 }

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -248,6 +248,11 @@ func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
 		}
 		openBeads = append(openBeads, cloneBead(b))
 	}
+	// Sort candidates before the limit-bounded loop below: c.beads is a map,
+	// so without this a Limit cuts an arbitrary, per-call-different subset —
+	// the #3208 bug class. Canonical ready order matches the SQL-backed
+	// ready readers.
+	sortBeadsReadyOrder(openBeads)
 
 	result := make([]Bead, 0, len(openBeads))
 	for _, b := range openBeads {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3360,3 +3360,63 @@ func hasDep(deps []Dep, dependsOnID string) bool {
 	}
 	return false
 }
+
+// TestCachingStoreReadyReturnsCanonicalOrder pins the (priority, created_at,
+// id) ascending ready order on the cache-served paths (#3208): c.beads is a
+// map, so without an explicit sort Ready/CachedReady returned a different
+// order on every call and disagreed with the SQL-backed ready readers.
+func TestCachingStoreReadyReturnsCanonicalOrder(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// Creation order scrambles priorities so neither insertion order nor any
+	// single-key order matches the canonical (priority, created_at, id) one.
+	for i, priority := range []int{3, 0, 2, 1, 4, 2, 0, 1} {
+		p := priority
+		if _, err := cache.Create(Bead{Title: fmt.Sprintf("ready-%d", i), Priority: &p}); err != nil {
+			t.Fatalf("Create ready-%d: %v", i, err)
+		}
+	}
+	// MemStore assigns sequential ids gc-1..gc-8 with non-decreasing
+	// created_at, so canonical order groups by priority, then insertion.
+	want := []string{"gc-2", "gc-7", "gc-4", "gc-8", "gc-3", "gc-6", "gc-1", "gc-5"}
+
+	readyIDs := func(rows []Bead) []string {
+		ids := make([]string, len(rows))
+		for i, b := range rows {
+			ids[i] = b.ID
+		}
+		return ids
+	}
+
+	got, err := cache.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if ids := readyIDs(got); !reflect.DeepEqual(ids, want) {
+		t.Fatalf("Ready order = %v, want %v", ids, want)
+	}
+
+	cached, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if ids := readyIDs(cached); !reflect.DeepEqual(ids, want) {
+		t.Fatalf("CachedReady order = %v, want %v", ids, want)
+	}
+
+	// A bounded read must cut the canonical prefix, not an arbitrary
+	// map-iteration subset.
+	limited, err := cache.cachedReadyOnly(ReadyQuery{Limit: 3})
+	if err != nil {
+		t.Fatalf("cachedReadyOnly limit 3: %v", err)
+	}
+	if ids := readyIDs(limited); !reflect.DeepEqual(ids, want[:3]) {
+		t.Fatalf("cachedReadyOnly limit-3 order = %v, want %v", ids, want[:3])
+	}
+}

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -442,6 +442,10 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 				result = append(result, cloneBead(b))
 			}
 		}
+		// c.beads is a map, so the scan above yields a different order per
+		// call; impose the canonical ready order so cache-served results
+		// match the SQL-backed ready readers (#3208).
+		sortBeadsReadyOrder(result)
 		return result, nil
 	}
 	c.mu.RUnlock()
@@ -486,6 +490,9 @@ func (c *CachingStore) CachedReady() ([]Bead, bool) {
 			result = append(result, cloneBead(b))
 		}
 	}
+	// Map-scan order is nondeterministic; match the canonical ready order of
+	// the SQL-backed ready readers (#3208).
+	sortBeadsReadyOrder(result)
 	return result, true
 }
 

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -307,7 +307,9 @@ func (s *DoltliteReadStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		q.Limit = rq.Limit
 	}
 	readyWhere, readyArgs := s.doltliteReadyIssueWhere(doltliteIssueTables)
-	out, err := s.queryIssuesOrdered(q, readyWhere, readyArgs, q.Limit, "ORDER BY COALESCE(i.priority, 2) ASC, i.created_at ASC")
+	// The id tiebreaker keeps a LIMIT deterministic when rows share
+	// (priority, created_at) — same bug class as queryIssueTable (#3208).
+	out, err := s.queryIssuesOrdered(q, readyWhere, readyArgs, q.Limit, "ORDER BY COALESCE(i.priority, 2) ASC, i.created_at ASC, i.id ASC")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -920,12 +920,15 @@ func (s *DoltliteReadStore) queryIssueTable(query ListQuery, tables doltliteTabl
 	if len(where) > 0 {
 		sqlText += " WHERE " + strings.Join(where, " AND ")
 	}
+	// The id tiebreaker matches sortBeadsForQuery's (created_at, id) total
+	// order so a SQL LIMIT cuts a deterministic prefix even when rows share
+	// a created_at timestamp (#3208).
 	if orderBy != "" {
 		sqlText += " " + orderBy
 	} else if query.Sort == SortCreatedAsc {
-		sqlText += " ORDER BY i.created_at ASC"
+		sqlText += " ORDER BY i.created_at ASC, i.id ASC"
 	} else {
-		sqlText += " ORDER BY i.created_at DESC"
+		sqlText += " ORDER BY i.created_at DESC, i.id DESC"
 	}
 	if limit > 0 {
 		sqlText += fmt.Sprintf(" LIMIT %d", limit)

--- a/internal/beads/doltlite_read_store_test.go
+++ b/internal/beads/doltlite_read_store_test.go
@@ -767,6 +767,56 @@ func TestDoltliteReadStoreFiltersPluralAssigneesAcrossTiers(t *testing.T) {
 	}
 }
 
+// TestDoltliteReadStoreLimitCutsDeterministicPrefixOnCreatedAtTies pins the
+// (created_at, id) total order at the SQL layer (#3208): when rows share a
+// created_at timestamp, a LIMIT-bounded read must cut the same prefix on
+// every call. Without the id tiebreaker in ORDER BY, SQLite resolves ties in
+// unspecified (rowid/insertion) order and the bounded subset is arbitrary.
+func TestDoltliteReadStoreLimitCutsDeterministicPrefixOnCreatedAtTies(t *testing.T) {
+	store, closeStore := newTestDoltliteReadStore(t)
+	defer closeStore()
+	writer := openTestDoltliteWriter(t, store.db)
+	defer writer.Close() //nolint:errcheck // test cleanup
+
+	tie := doltliteSQLiteTime(time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC))
+	// Insert in an order (c, a, b) that differs from both id directions so
+	// an insertion-ordered tie-cut cannot accidentally match the contract.
+	for _, id := range []string{"gc-tie-c", "gc-tie-a", "gc-tie-b"} {
+		if _, err := writer.Exec(`INSERT INTO issues (
+			id, title, status, issue_type, priority, created_at, updated_at,
+			assignee, description, design, acceptance_criteria, notes, metadata
+		) VALUES (?, ?, 'open', 'task', 2, ?, ?, 'rig/tie-order', '', '', '', '', '{}')`,
+			id, id, tie, tie); err != nil {
+			t.Fatalf("insert tie issue %s: %v", id, err)
+		}
+	}
+
+	descTop2, err := store.List(ListQuery{
+		Assignee:   "rig/tie-order",
+		Sort:       SortCreatedDesc,
+		Limit:      2,
+		SkipLabels: true,
+	})
+	if err != nil {
+		t.Fatalf("List desc limit 2: %v", err)
+	}
+	if got := testBeadIDs(descTop2); !slices.Equal(got, []string{"gc-tie-c", "gc-tie-b"}) {
+		t.Fatalf("desc limit-2 ids = %v, want [gc-tie-c gc-tie-b]", got)
+	}
+
+	ascAll, err := store.List(ListQuery{
+		Assignee:   "rig/tie-order",
+		Sort:       SortCreatedAsc,
+		SkipLabels: true,
+	})
+	if err != nil {
+		t.Fatalf("List asc: %v", err)
+	}
+	if got := testBeadIDs(ascAll); !slices.Equal(got, []string{"gc-tie-a", "gc-tie-b", "gc-tie-c"}) {
+		t.Fatalf("asc ids = %v, want [gc-tie-a gc-tie-b gc-tie-c]", got)
+	}
+}
+
 func TestDoltliteCachingStoreLiveFastReadDoesNotEraseDependencyCache(t *testing.T) {
 	store, closeStore := newTestDoltliteReadStore(t)
 	defer closeStore()

--- a/internal/beads/doltlite_read_store_test.go
+++ b/internal/beads/doltlite_read_store_test.go
@@ -817,6 +817,38 @@ func TestDoltliteReadStoreLimitCutsDeterministicPrefixOnCreatedAtTies(t *testing
 	}
 }
 
+// TestDoltliteReadStoreReadyLimitCutsDeterministicPrefixOnTies pins the same
+// (#3208) tie-cut contract for the Ready path, whose custom ORDER BY
+// (priority, created_at) also needs the id tiebreaker for a deterministic
+// LIMIT prefix when rows share both keys.
+func TestDoltliteReadStoreReadyLimitCutsDeterministicPrefixOnTies(t *testing.T) {
+	store, closeStore := newTestDoltliteReadStore(t)
+	defer closeStore()
+	writer := openTestDoltliteWriter(t, store.db)
+	defer writer.Close() //nolint:errcheck // test cleanup
+
+	tie := doltliteSQLiteTime(time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC))
+	// Insert in an order (c, a, b) that differs from both id directions so
+	// an insertion-ordered tie-cut cannot accidentally match the contract.
+	for _, id := range []string{"gc-rtie-c", "gc-rtie-a", "gc-rtie-b"} {
+		if _, err := writer.Exec(`INSERT INTO issues (
+			id, title, status, issue_type, priority, created_at, updated_at,
+			assignee, description, design, acceptance_criteria, notes, metadata
+		) VALUES (?, ?, 'open', 'task', 2, ?, ?, 'rig/rtie-order', '', '', '', '', '{}')`,
+			id, id, tie, tie); err != nil {
+			t.Fatalf("insert ready tie issue %s: %v", id, err)
+		}
+	}
+
+	top2, err := store.Ready(ReadyQuery{Assignee: "rig/rtie-order", Limit: 2})
+	if err != nil {
+		t.Fatalf("Ready limit 2: %v", err)
+	}
+	if got := testBeadIDs(top2); !slices.Equal(got, []string{"gc-rtie-a", "gc-rtie-b"}) {
+		t.Fatalf("ready limit-2 ids = %v, want [gc-rtie-a gc-rtie-b]", got)
+	}
+}
+
 func TestDoltliteCachingStoreLiveFastReadDoesNotEraseDependencyCache(t *testing.T) {
 	store, closeStore := newTestDoltliteReadStore(t)
 	defer closeStore()

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -234,6 +234,14 @@ func applyListQuery(items []Bead, q ListQuery) []Bead {
 	return ApplyListQuery(items, q)
 }
 
+// SortBeads sorts items into the canonical (created_at, id) total order for
+// the given direction. SortDefault leaves the slice order unchanged. Callers
+// that merge results across stores use this to impose one deterministic
+// global order on the merged set (#3208).
+func SortBeads(items []Bead, order SortOrder) {
+	sortBeadsForQuery(items, order)
+}
+
 func sortBeadsForQuery(items []Bead, order SortOrder) {
 	switch order {
 	case SortCreatedAsc:

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -242,6 +242,31 @@ func SortBeads(items []Bead, order SortOrder) {
 	sortBeadsForQuery(items, order)
 }
 
+// sortBeadsReadyOrder sorts ready results into the canonical
+// (priority, created_at, id) ascending order used by the SQL-backed ready
+// readers (a nil priority sorts as 2, matching their COALESCE(i.priority, 2)),
+// so a bounded ready read cuts the same deterministic prefix regardless of
+// which store path served it (#3208).
+func sortBeadsReadyOrder(items []Bead) {
+	sort.Slice(items, func(i, j int) bool {
+		pi, pj := readySortPriority(items[i]), readySortPriority(items[j])
+		if pi != pj {
+			return pi < pj
+		}
+		if !items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].CreatedAt.Before(items[j].CreatedAt)
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func readySortPriority(b Bead) int {
+	if b.Priority == nil {
+		return 2
+	}
+	return *b.Priority
+}
+
 func sortBeadsForQuery(items []Bead, order SortOrder) {
 	switch order {
 	case SortCreatedAsc:


### PR DESCRIPTION
## Summary

Makes the supervisor read path that backs the dashboard runs view **deterministic and fast** (#3208, #1896 family).

- **Stable ordering + cursor** on bounded `/beads` reads and the cross-rig aggregation, so a `limit`-bounded page is a deterministic prefix (previously an unordered 500-of-N page → different beads/rigs per call → the dashboard runs count flapping 6↔345 and a permanent false "partial").
- **Reduced `/formulas/feed` and large `/beads` latency** so reads stay under typical client budgets instead of timing out and forcing clients onto the volatile bounded fallback.

Closes #3208. Same read-path family as #1896 (ref).

## Test

Deterministic-bounded-read test (repeated reads return the same prefix) + latency/bounded-slice coverage.
