### PR TITLE
fix(beads): mirror bd ready projection in cache

### DIFF
--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -2229,6 +2229,7 @@ export interface components {
             ephemeral?: boolean;
             from?: string;
             id: string;
+            is_blocked?: boolean;
             issue_type: string;
             labels?: string[] | null;
             metadata?: {

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -262,6 +262,7 @@ export type Bead = {
     ephemeral?: boolean;
     from?: string;
     id: string;
+    is_blocked?: boolean;
     issue_type: string;
     labels?: Array<string> | null;
     metadata?: {

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -11379,6 +11379,10 @@ export type GetV0CityByCityNameStatusData = {
          * How long to block waiting for changes (Go duration string, e.g. 30s). Default 30s, max 2m.
          */
         wait?: string;
+        /**
+         * When true, omit the expensive store-health, session-count, and work-count blocks for low-cost dashboard polls.
+         */
+        lite?: boolean;
     };
     url: '/v0/city/{cityName}/status';
 };

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -842,6 +842,9 @@
           "id": {
             "type": "string"
           },
+          "is_blocked": {
+            "type": "boolean"
+          },
           "issue_type": {
             "type": "string"
           },

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -842,6 +842,9 @@
           "id": {
             "type": "string"
           },
+          "is_blocked": {
+            "type": "boolean"
+          },
           "issue_type": {
             "type": "string"
           },

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -569,6 +569,7 @@ type Bead struct {
 	Ephemeral    *bool              `json:"ephemeral,omitempty"`
 	From         *string            `json:"from,omitempty"`
 	Id           string             `json:"id"`
+	IsBlocked    *bool              `json:"is_blocked,omitempty"`
 	IssueType    string             `json:"issue_type"`
 	Labels       *[]string          `json:"labels,omitempty"`
 	Metadata     *map[string]string `json:"metadata,omitempty"`

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -842,6 +842,9 @@
           "id": {
             "type": "string"
           },
+          "is_blocked": {
+            "type": "boolean"
+          },
           "issue_type": {
             "type": "string"
           },

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/telemetry"
@@ -30,7 +31,7 @@ type CommandRunner func(dir, name string, args ...string) ([]byte, error)
 var (
 	bdCommandTimeout = 120 * time.Second
 	// bdReadCommandTimeout bounds bd read-only subcommands (count, list,
-	// ready, show, stats). Default matches bdCommandTimeout to preserve
+	// ready, show, sql, stats, version). Default matches bdCommandTimeout to preserve
 	// pre-bounded behavior; lowered in follow-up work after slow read
 	// paths are identified.
 	bdReadCommandTimeout = 120 * time.Second
@@ -188,7 +189,7 @@ func bdCommandTimeoutFor(name string, args []string) time.Duration {
 		return bdGraphApplyCommandTimeout
 	}
 	switch args[0] {
-	case "count", "list", "ready", "show", "stats":
+	case "count", "list", "ready", "show", "sql", "stats", "version":
 		return bdReadCommandTimeout
 	case "query":
 		return bdQueryCommandTimeout
@@ -246,6 +247,10 @@ type BdStore struct {
 	idPrefix    string          // bead ID prefix owned by this store, without trailing "-"
 
 	listSkipLabelsEnabled bool // whether bd list may receive --skip-labels
+
+	readyProjectionMu      sync.Mutex
+	readyProjectionChecked bool
+	readyProjectionEnabled bool
 }
 
 const bdTransientWriteAttempts = 3
@@ -520,6 +525,7 @@ type bdIssue struct {
 	Ephemeral    bool         `json:"ephemeral,omitempty"`
 	NoHistory    bool         `json:"no_history,omitempty"`
 	DeferUntil   *time.Time   `json:"defer_until,omitempty"`
+	IsBlocked    optionalBool `json:"is_blocked,omitempty"`
 }
 
 type bdIssueDep struct {
@@ -671,6 +677,7 @@ func (b *bdIssue) toBead() Bead {
 		Ephemeral:    b.Ephemeral,
 		NoHistory:    b.NoHistory,
 		DeferUntil:   cloneTimePtr(b.DeferUntil),
+		IsBlocked:    b.IsBlocked.ptr(),
 	}
 }
 
@@ -737,6 +744,52 @@ func mapBdStatus(s string) string {
 	default:
 		return "open"
 	}
+}
+
+type optionalBool struct {
+	set   bool
+	value bool
+}
+
+func (b *optionalBool) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		*b = optionalBool{}
+		return nil
+	}
+	var boolValue bool
+	if err := json.Unmarshal(data, &boolValue); err == nil {
+		b.set = true
+		b.value = boolValue
+		return nil
+	}
+	var intValue int
+	if err := json.Unmarshal(data, &intValue); err == nil {
+		b.set = true
+		b.value = intValue != 0
+		return nil
+	}
+	var stringValue string
+	if err := json.Unmarshal(data, &stringValue); err == nil {
+		switch strings.ToLower(strings.TrimSpace(stringValue)) {
+		case "1", "t", "true", "y", "yes":
+			b.set = true
+			b.value = true
+			return nil
+		case "0", "f", "false", "n", "no":
+			b.set = true
+			b.value = false
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid bool value %q", string(data))
+}
+
+func (b optionalBool) ptr() *bool {
+	if !b.set {
+		return nil
+	}
+	return cloneBoolPtr(&b.value)
 }
 
 // Create persists a new bead via bd create.

--- a/internal/beads/bdstore_exec_internal_test.go
+++ b/internal/beads/bdstore_exec_internal_test.go
@@ -48,6 +48,12 @@ func TestBDCommandTimeoutForReadCommands(t *testing.T) {
 	if got := bdCommandTimeoutFor("bd", []string{"ready", "--json"}); got != bdReadCommandTimeout {
 		t.Fatalf("bd ready timeout = %s, want %s", got, bdReadCommandTimeout)
 	}
+	if got := bdCommandTimeoutFor("bd", []string{"sql", "select 1", "--json"}); got != bdReadCommandTimeout {
+		t.Fatalf("bd sql timeout = %s, want %s", got, bdReadCommandTimeout)
+	}
+	if got := bdCommandTimeoutFor("bd", []string{"version"}); got != bdReadCommandTimeout {
+		t.Fatalf("bd version timeout = %s, want %s", got, bdReadCommandTimeout)
+	}
 	if got := bdCommandTimeoutFor("bd", []string{"update", "gc-1", "--status", "open"}); got != bdCommandTimeout {
 		t.Fatalf("bd update timeout = %s, want %s", got, bdCommandTimeout)
 	}

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -1,0 +1,125 @@
+package beads
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/deps"
+)
+
+const bdReadyProjectionMinVersion = "1.0.5"
+
+type bdReadyProjectionRow struct {
+	ID        string       `json:"id"`
+	IsBlocked optionalBool `json:"is_blocked"`
+}
+
+func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
+	if len(items) == 0 {
+		return items, nil
+	}
+	ids := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if item.ID == "" || item.Status == "closed" || item.IsBlocked != nil {
+			continue
+		}
+		if _, ok := seen[item.ID]; ok {
+			continue
+		}
+		seen[item.ID] = struct{}{}
+		ids = append(ids, item.ID)
+	}
+	if len(ids) == 0 {
+		return items, nil
+	}
+	enabled, err := s.bdReadyProjectionEnabled()
+	if err != nil {
+		return items, err
+	}
+	if !enabled {
+		return items, nil
+	}
+
+	projection, err := s.fetchReadyProjection(ids)
+	if err != nil {
+		return items, err
+	}
+	enriched := make([]Bead, len(items))
+	copy(enriched, items)
+	var missing []string
+	for i := range enriched {
+		if enriched[i].ID == "" || enriched[i].Status == "closed" || enriched[i].IsBlocked != nil {
+			continue
+		}
+		blocked, ok := projection[enriched[i].ID]
+		if !ok {
+			missing = append(missing, enriched[i].ID)
+			continue
+		}
+		enriched[i].IsBlocked = cloneBoolPtr(&blocked)
+	}
+	if len(missing) > 0 {
+		return items, fmt.Errorf("bd ready projection missing is_blocked for %d active beads (first %s)", len(missing), missing[0])
+	}
+	return enriched, nil
+}
+
+func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
+	s.readyProjectionMu.Lock()
+	defer s.readyProjectionMu.Unlock()
+	if s.readyProjectionChecked {
+		return s.readyProjectionEnabled, nil
+	}
+	out, err := s.runner(s.dir, "bd", "version")
+	if err != nil {
+		return false, fmt.Errorf("bd ready projection version gate: %w", err)
+	}
+	version, err := parseBDVersion(string(out))
+	if err != nil {
+		return false, fmt.Errorf("bd ready projection version gate: %w", err)
+	}
+	s.readyProjectionEnabled = deps.CompareVersions(version, bdReadyProjectionMinVersion) >= 0
+	s.readyProjectionChecked = true
+	return s.readyProjectionEnabled, nil
+}
+
+func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
+	result := make(map[string]bool, len(ids))
+	for start := 0; start < len(ids); start += 500 {
+		end := start + 500
+		if end > len(ids) {
+			end = len(ids)
+		}
+		query := readyProjectionSQL(ids[start:end])
+		out, err := s.runner(s.dir, "bd", "sql", query, "--json")
+		if err != nil {
+			return nil, fmt.Errorf("bd sql ready projection: %w", err)
+		}
+		var rows []bdReadyProjectionRow
+		if err := json.Unmarshal(extractJSON(out), &rows); err != nil {
+			return nil, fmt.Errorf("bd sql ready projection: parsing JSON: %w", err)
+		}
+		for _, row := range rows {
+			if row.ID == "" || !row.IsBlocked.set {
+				continue
+			}
+			result[row.ID] = row.IsBlocked.value
+		}
+	}
+	return result, nil
+}
+
+func readyProjectionSQL(ids []string) string {
+	quoted := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		quoted = append(quoted, "'"+strings.ReplaceAll(id, "'", "''")+"'")
+	}
+	inClause := strings.Join(quoted, ",")
+	return "select id,is_blocked from issues where id in (" + inClause + ") " +
+		"union all select id,is_blocked from wisps where id in (" + inClause + ")"
+}

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -3,7 +3,6 @@ package beads
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/gastownhall/gascity/internal/deps"
 )
@@ -87,39 +86,37 @@ func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
 
 func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 	result := make(map[string]bool, len(ids))
-	for start := 0; start < len(ids); start += 500 {
-		end := start + 500
-		if end > len(ids) {
-			end = len(ids)
+	wanted := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			wanted[id] = struct{}{}
 		}
-		query := readyProjectionSQL(ids[start:end])
-		out, err := s.runner(s.dir, "bd", "sql", query, "--json")
-		if err != nil {
-			return nil, fmt.Errorf("bd sql ready projection: %w", err)
+	}
+	if len(wanted) == 0 {
+		return result, nil
+	}
+
+	out, err := s.runner(s.dir, "bd", "sql", readyProjectionSQL(), "--json")
+	if err != nil {
+		return nil, fmt.Errorf("bd sql ready projection: %w", err)
+	}
+	var rows []bdReadyProjectionRow
+	if err := json.Unmarshal(extractJSON(out), &rows); err != nil {
+		return nil, fmt.Errorf("bd sql ready projection: parsing JSON: %w", err)
+	}
+	for _, row := range rows {
+		if row.ID == "" || !row.IsBlocked.set {
+			continue
 		}
-		var rows []bdReadyProjectionRow
-		if err := json.Unmarshal(extractJSON(out), &rows); err != nil {
-			return nil, fmt.Errorf("bd sql ready projection: parsing JSON: %w", err)
+		if _, ok := wanted[row.ID]; !ok {
+			continue
 		}
-		for _, row := range rows {
-			if row.ID == "" || !row.IsBlocked.set {
-				continue
-			}
-			result[row.ID] = row.IsBlocked.value
-		}
+		result[row.ID] = row.IsBlocked.value
 	}
 	return result, nil
 }
 
-func readyProjectionSQL(ids []string) string {
-	quoted := make([]string, 0, len(ids))
-	for _, id := range ids {
-		if id == "" {
-			continue
-		}
-		quoted = append(quoted, "'"+strings.ReplaceAll(id, "'", "''")+"'")
-	}
-	inClause := strings.Join(quoted, ",")
-	return "select id,is_blocked from issues where id in (" + inClause + ") " +
-		"union all select id,is_blocked from wisps where id in (" + inClause + ")"
+func readyProjectionSQL() string {
+	return "select id,is_blocked from issues where status in ('open','in_progress') " +
+		"union all select id,is_blocked from wisps where status in ('open','in_progress')"
 }

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -117,6 +117,5 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 }
 
 func readyProjectionSQL() string {
-	return "select id,is_blocked from issues where status <> 'closed' " +
-		"union all select id,is_blocked from wisps where status <> 'closed'"
+	return "select id,is_blocked from issues union all select id,is_blocked from wisps"
 }

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -117,6 +117,6 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 }
 
 func readyProjectionSQL() string {
-	return "select id,is_blocked from issues where status in ('open','in_progress') " +
-		"union all select id,is_blocked from wisps where status in ('open','in_progress')"
+	return "select id,is_blocked from issues where status <> 'closed' " +
+		"union all select id,is_blocked from wisps where status <> 'closed'"
 }

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -47,20 +47,15 @@ func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 	}
 	enriched := make([]Bead, len(items))
 	copy(enriched, items)
-	var missing []string
 	for i := range enriched {
 		if enriched[i].ID == "" || enriched[i].Status == "closed" || enriched[i].IsBlocked != nil {
 			continue
 		}
 		blocked, ok := projection[enriched[i].ID]
 		if !ok {
-			missing = append(missing, enriched[i].ID)
 			continue
 		}
 		enriched[i].IsBlocked = cloneBoolPtr(&blocked)
-	}
-	if len(missing) > 0 {
-		return items, fmt.Errorf("bd ready projection missing is_blocked for %d active beads (first %s)", len(missing), missing[0])
 	}
 	return enriched, nil
 }
@@ -68,6 +63,8 @@ func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
 	s.readyProjectionMu.Lock()
 	defer s.readyProjectionMu.Unlock()
+	// Probe the bd version once per process. Operators must restart gc after
+	// changing bd versions to re-evaluate ready-projection support.
 	if s.readyProjectionChecked {
 		return s.readyProjectionEnabled, nil
 	}
@@ -96,6 +93,8 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 		return result, nil
 	}
 
+	// bd exposes this as a full active-row projection. The ids argument is a
+	// cache-side allow-list so callers can keep their requested surface bounded.
 	out, err := s.runner(s.dir, "bd", "sql", readyProjectionSQL(), "--json")
 	if err != nil {
 		return nil, fmt.Errorf("bd sql ready projection: %w", err)
@@ -117,5 +116,5 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 }
 
 func readyProjectionSQL() string {
-	return "select id,is_blocked from issues union all select id,is_blocked from wisps"
+	return "select id,is_blocked from issues where status <> 'closed' union all select id,is_blocked from wisps where status <> 'closed'"
 }

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1743,6 +1743,34 @@ func TestBdStoreList(t *testing.T) {
 	}
 }
 
+func TestBdStoreListDecodesIsBlockedProjection(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd list --json --include-infra --include-gates --limit 0`: {
+			out: []byte(`[
+				{"id":"bd-blocked","title":"blocked","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","is_blocked":1},
+				{"id":"bd-ready","title":"ready","status":"open","issue_type":"task","created_at":"2025-01-15T10:31:00Z","is_blocked":false}
+			]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.ListOpen()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListOpen() returned %d beads, want 2", len(got))
+	}
+	if got[0].IsBlocked == nil || !*got[0].IsBlocked {
+		t.Fatalf("got[0].IsBlocked = %v, want true", got[0].IsBlocked)
+	}
+	if got[1].IsBlocked == nil || *got[1].IsBlocked {
+		t.Fatalf("got[1].IsBlocked = %v, want false", got[1].IsBlocked)
+	}
+}
+
 func TestBdStoreListEmpty(t *testing.T) {
 	runner := fakeRunner(map[string]struct {
 		out []byte

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -68,6 +68,10 @@ type Bead struct {
 	// nil or past means ready). Create paths preserve it; UpdateOpts does not
 	// mutate it.
 	DeferUntil *time.Time `json:"defer_until,omitempty"`
+	// IsBlocked carries bd's denormalized ready-work projection. Nil means the
+	// store did not provide the projection and cached ready falls back to
+	// dependency-derived readiness for backward compatibility.
+	IsBlocked *bool `json:"is_blocked,omitempty"`
 }
 
 // UpdateOpts specifies which fields to change. Nil pointers are skipped.
@@ -116,6 +120,14 @@ func cloneIntPtr(v *int) *int {
 }
 
 func cloneTimePtr(v *time.Time) *time.Time {
+	if v == nil {
+		return nil
+	}
+	cloned := *v
+	return &cloned
+}
+
+func cloneBoolPtr(v *bool) *bool {
 	if v == nil {
 		return nil
 	}

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -874,6 +874,10 @@ type listDependencyCompletenessStore interface {
 	listIncludesCompleteDependencies() bool
 }
 
+type cacheDependencySnapshotStore interface {
+	dependencySnapshotForCache(ids []string) (map[string][]Dep, bool, error)
+}
+
 type readyProjectionEnrichmentStore interface {
 	enrichReadyProjectionForCache([]Bead) ([]Bead, error)
 }
@@ -886,10 +890,14 @@ func (c *CachingStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, erro
 }
 
 func (c *CachingStore) fetchDepsForBeads(beadMap map[string]Bead) (map[string][]Dep, bool, error) {
+	ids := beadIDs(beadMap)
+	if backing, ok := c.backing.(cacheDependencySnapshotStore); ok {
+		return backing.dependencySnapshotForCache(ids)
+	}
 	if backing, ok := c.backing.(listDependencyCompletenessStore); ok {
 		return depsFromBeads(beadMap, nil, false), backing.listIncludesCompleteDependencies(), nil
 	}
-	return c.fetchDepsForIDs(beadIDs(beadMap))
+	return c.fetchDepsForIDs(ids)
 }
 
 func (c *CachingStore) fetchDepsForIDs(ids []string) (map[string][]Dep, bool, error) {

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -370,6 +370,12 @@ func (c *CachingStore) PrimeActive() error {
 		}
 		all = append(all, beads...)
 	}
+	if enriched, err := c.enrichReadyProjectionForCache(all); err != nil {
+		partialErr = errors.Join(partialErr, err)
+		c.recordProblem("prime active ready projection", err)
+	} else {
+		all = enriched
+	}
 
 	beadMap := make(map[string]Bead, len(all))
 	for _, b := range all {
@@ -482,6 +488,12 @@ func (c *CachingStore) prime(ctx context.Context) error {
 	}
 	if err != nil {
 		return fmt.Errorf("prime list: %w", err)
+	}
+	if enriched, enrichErr := c.enrichReadyProjectionForCache(all); enrichErr != nil {
+		c.recordProblem("prime ready projection", enrichErr)
+		partialErr = errors.Join(partialErr, enrichErr)
+	} else {
+		all = enriched
 	}
 	if err := c.cacheContextErr(ctx); err != nil {
 		return err
@@ -860,6 +872,17 @@ func beadIDs(beadMap map[string]Bead) []string {
 
 type listDependencyCompletenessStore interface {
 	listIncludesCompleteDependencies() bool
+}
+
+type readyProjectionEnrichmentStore interface {
+	enrichReadyProjectionForCache([]Bead) ([]Bead, error)
+}
+
+func (c *CachingStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
+	if backing, ok := c.backing.(readyProjectionEnrichmentStore); ok {
+		return backing.enrichReadyProjectionForCache(items)
+	}
+	return items, nil
 }
 
 func (c *CachingStore) fetchDepsForBeads(beadMap map[string]Bead) (map[string][]Dep, bool, error) {

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -346,8 +346,8 @@ func (c *CachingStore) noteLocalMutationLocked(ids ...string) uint64 {
 	return seq
 }
 
-// PrimeActive loads all non-closed beads (open + in_progress) across both
-// persistent issues and ephemeral wisps into the cache. These are fast indexed
+// PrimeActive loads the common active bead statuses (open + in_progress) across
+// both persistent issues and ephemeral wisps into the cache. These are fast indexed
 // queries that populate enough data for
 // startup paths without waiting for a full scan. The cache enters
 // cachePartial state: filtered active queries and Get hit cache for primed

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -610,7 +610,8 @@ func beadChanged(old, fresh Bead, skipLabels bool) bool {
 		old.Ref != fresh.Ref ||
 		old.Description != fresh.Description ||
 		old.Ephemeral != fresh.Ephemeral ||
-		!timePtrEqual(old.DeferUntil, fresh.DeferUntil) {
+		!timePtrEqual(old.DeferUntil, fresh.DeferUntil) ||
+		!boolPtrEqual(old.IsBlocked, fresh.IsBlocked) {
 		return true
 	}
 	if !maps.Equal(old.Metadata, fresh.Metadata) {
@@ -630,6 +631,17 @@ func depsChanged(old, fresh []Dep) bool {
 }
 
 func intPtrEqual(left, right *int) bool {
+	switch {
+	case left == nil && right == nil:
+		return true
+	case left == nil || right == nil:
+		return false
+	default:
+		return *left == *right
+	}
+}
+
+func boolPtrEqual(left, right *bool) bool {
 	switch {
 	case left == nil && right == nil:
 		return true

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -222,6 +222,9 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		}
 		c.updateStatsLocked()
 		mutated = true
+		if c.clearDependentReadyProjectionsLocked(b.ID) {
+			mutated = true
+		}
 	case "bead.updated":
 		existing, cached := c.beads[b.ID]
 		if !cached || beadChanged(existing, b, false) {
@@ -235,6 +238,9 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			c.noteMutationLocked(b.ID)
 			mutated = true
 		}
+		if hasCacheEventField(fields, "status") && c.clearDependentReadyProjectionsLocked(b.ID) {
+			mutated = true
+		}
 	case "bead.closed":
 		c.noteMutationLocked(b.ID)
 		if _, exists := c.beads[b.ID]; !exists {
@@ -245,6 +251,9 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		delete(c.dirty, b.ID)
 		delete(c.deletedSeq, b.ID)
 		mutated = true
+		if c.clearDependentReadyProjectionsLocked(b.ID) {
+			mutated = true
+		}
 	case "bead.deleted":
 		c.noteMutationLocked(b.ID)
 		delete(c.beads, b.ID)
@@ -255,6 +264,9 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		c.deletedSeq[b.ID] = c.mutationSeq
 		c.updateStatsLocked()
 		mutated = true
+		if c.clearDependentReadyProjectionsLocked(b.ID) {
+			mutated = true
+		}
 	default:
 		return
 	}
@@ -284,6 +296,9 @@ func (c *CachingStore) updateEventDepsLocked(eventType string, b Bead, fields ma
 			delete(c.deps, b.ID)
 			mutated = true
 		}
+		if c.clearReadyProjectionLocked(b.ID) {
+			mutated = true
+		}
 		if c.depsComplete {
 			c.depsComplete = false
 			mutated = true
@@ -311,12 +326,14 @@ func (c *CachingStore) setEventDepsLocked(id string, deps []Dep) bool {
 			return false
 		}
 		c.deps[id] = cloneDeps(deps)
+		c.clearReadyProjectionLocked(id)
 		return true
 	}
 	if c.depsComplete && len(deps) == 0 {
-		return false
+		return c.clearReadyProjectionLocked(id)
 	}
 	c.deps[id] = cloneDeps(deps)
+	c.clearReadyProjectionLocked(id)
 	return true
 }
 
@@ -331,10 +348,64 @@ func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 	}
 	c.noteMutationLocked(beadID)
 	c.deps[beadID] = cloneDeps(deps)
+	c.clearReadyProjectionLocked(beadID)
 	delete(c.dirty, beadID)
 	delete(c.deletedSeq, beadID)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
+}
+
+func (c *CachingStore) clearReadyProjectionLocked(id string) bool {
+	b, ok := c.beads[id]
+	if !ok || b.IsBlocked == nil {
+		return false
+	}
+	b.IsBlocked = nil
+	c.beads[id] = b
+	return true
+}
+
+func (c *CachingStore) clearAllReadyProjectionsLocked() bool {
+	cleared := make([]string, 0)
+	for id := range c.beads {
+		if c.clearReadyProjectionLocked(id) {
+			cleared = append(cleared, id)
+		}
+	}
+	if len(cleared) == 0 {
+		return false
+	}
+	c.noteMutationLocked(cleared...)
+	return true
+}
+
+func (c *CachingStore) clearDependentReadyProjectionsLocked(dependsOnID string) bool {
+	if dependsOnID == "" {
+		return false
+	}
+	if !c.depsComplete {
+		return c.clearAllReadyProjectionsLocked()
+	}
+	cleared := make([]string, 0)
+	for id, deps := range c.deps {
+		if _, ok := c.beads[id]; !ok {
+			continue
+		}
+		for _, dep := range deps {
+			if dep.DependsOnID != dependsOnID || !isReadyBlockingDependencyType(dep.Type) {
+				continue
+			}
+			if c.clearReadyProjectionLocked(id) {
+				cleared = append(cleared, id)
+			}
+			break
+		}
+	}
+	if len(cleared) == 0 {
+		return false
+	}
+	c.noteMutationLocked(cleared...)
+	return true
 }
 
 func mergeCacheEventPatch(base, patch Bead, fields map[string]json.RawMessage) Bead {
@@ -387,6 +458,9 @@ func mergeCacheEventPatch(base, patch Bead, fields map[string]json.RawMessage) B
 	if hasCacheEventField(fields, "defer_until") {
 		merged.DeferUntil = cloneTimePtr(patch.DeferUntil)
 	}
+	if hasCacheEventField(fields, "is_blocked") {
+		merged.IsBlocked = cloneBoolPtr(patch.IsBlocked)
+	}
 	return merged
 }
 
@@ -430,6 +504,9 @@ func cacheEventConflictsCurrent(current, patch Bead, fields map[string]json.RawM
 		return true
 	}
 	if hasCacheEventField(fields, "defer_until") && !timePtrEqual(current.DeferUntil, patch.DeferUntil) {
+		return true
+	}
+	if hasCacheEventField(fields, "is_blocked") && !boolPtrEqual(current.IsBlocked, patch.IsBlocked) {
 		return true
 	}
 	return false

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -264,7 +264,7 @@ func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
 		default:
 			return nil, fmt.Errorf("reading ready deps from cache: %w", ErrCacheUnavailable)
 		}
-		if !cachedBeadReady(statusByID, deps) {
+		if !cachedBeadReady(b, statusByID, deps) {
 			continue
 		}
 		result = append(result, cloneBead(b))

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3060,8 +3060,8 @@ func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
 			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
 				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
 			}
-			if !strings.Contains(query, "status <> 'closed'") {
-				t.Fatalf("ready projection SQL = %q, want non-closed active projection", query)
+			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
+				t.Fatalf("ready projection SQL = %q, want unfiltered row projection", query)
 			}
 			return []byte(`[
 				{"id":"bd-ready","is_blocked":0},
@@ -3104,7 +3104,7 @@ func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
 	}
 }
 
-func TestCachingStoreBdPrimeProjectsIsBlockedForAllNonClosedBD105(t *testing.T) {
+func TestCachingStoreBdPrimeProjectsIsBlockedForAllBDRowsBD105(t *testing.T) {
 	t.Parallel()
 
 	var sqlCalls int
@@ -3124,8 +3124,8 @@ func TestCachingStoreBdPrimeProjectsIsBlockedForAllNonClosedBD105(t *testing.T) 
 			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
 				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
 			}
-			if strings.Contains(query, "status in ('open','in_progress')") || !strings.Contains(query, "status <> 'closed'") {
-				t.Fatalf("ready projection SQL = %q, want every non-closed row", query)
+			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
+				t.Fatalf("ready projection SQL = %q, want every row", query)
 			}
 			return []byte(`[
 				{"id":"bd-ready","is_blocked":0},

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -2902,6 +2902,12 @@ func TestCachingStoreBdPrimeAndReconcileSkipFullDepScan(t *testing.T) {
 			readyCalls++
 			return issueJSON, nil
 		}
+		if len(args) > 0 && args[0] == "version" {
+			return []byte("bd version 1.0.4\n"), nil
+		}
+		if len(args) > 0 && args[0] == "sql" {
+			t.Fatalf("unexpected ready projection SQL under bd 1.0.4: %v", args)
+		}
 		if len(args) > 0 && args[0] == "list" {
 			return issueJSON, nil
 		}
@@ -2935,6 +2941,12 @@ func TestCachingStoreBdPrimeActiveUsesListDependenciesForCachedReady(t *testing.
 			depListCalls++
 			t.Fatalf("unexpected dep scan command: %v", args)
 		}
+		if len(args) > 0 && args[0] == "version" {
+			return []byte("bd version 1.0.4\n"), nil
+		}
+		if len(args) > 0 && args[0] == "sql" {
+			t.Fatalf("unexpected ready projection SQL under bd 1.0.4: %v", args)
+		}
 		if len(args) > 0 && args[0] == "list" {
 			argLine := strings.Join(args, " ")
 			if strings.Contains(argLine, "--status=open") {
@@ -2967,6 +2979,125 @@ func TestCachingStoreBdPrimeActiveUsesListDependenciesForCachedReady(t *testing.
 	}
 	if depListCalls != 0 {
 		t.Fatalf("dep list calls = %d, want 0", depListCalls)
+	}
+}
+
+func TestCachingStoreCachedReadyHonorsProjectedIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	blocked := true
+	backing := &completeEmbeddedDepsStore{
+		beads: []Bead{
+			{ID: "bd-ready", Title: "ready", Status: "open", Type: "task"},
+			{ID: "bd-blocked", Title: "blocked", Status: "open", Type: "task", IsBlocked: &blocked},
+		},
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	readyByID := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if !readyByID["bd-ready"] || readyByID["bd-blocked"] {
+		t.Fatalf("CachedReady ids = %v, want ready included and projected blocked excluded", readyByID)
+	}
+}
+
+func TestCachingStoreCachedReadyFallsBackToLegacyDepsWhenProjectionMissing(t *testing.T) {
+	t.Parallel()
+
+	backing := &completeEmbeddedDepsStore{
+		beads: []Bead{{
+			ID:     "bd-waiting",
+			Title:  "waiting",
+			Status: "open",
+			Type:   "task",
+			Dependencies: []Dep{{
+				IssueID:     "bd-waiting",
+				DependsOnID: "bd-closed-or-missing",
+				Type:        "blocks",
+			}},
+		}},
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(ready) != 1 || ready[0].ID != "bd-waiting" {
+		t.Fatalf("CachedReady = %+v, want legacy missing/closed blocker treated as non-blocking", ready)
+	}
+}
+
+func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
+	t.Parallel()
+
+	var sqlCalls int
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) == 0 {
+			t.Fatal("empty bd command")
+		}
+		switch args[0] {
+		case "version":
+			return []byte("bd version 1.0.5 (test)\n"), nil
+		case "sql":
+			sqlCalls++
+			query := args[1]
+			if !strings.Contains(query, "'bd-ready'") || !strings.Contains(query, "'bd-blocked'") {
+				t.Fatalf("ready projection SQL = %q, want both active ids", query)
+			}
+			return []byte(`[
+				{"id":"bd-ready","is_blocked":0},
+				{"id":"bd-blocked","is_blocked":1}
+			]`), nil
+		case "list":
+			argLine := strings.Join(args, " ")
+			if strings.Contains(argLine, "--status=open") {
+				return []byte(`[
+					{"id":"bd-ready","title":"ready","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
+					{"id":"bd-blocked","title":"blocked","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:01Z","labels":["task"],"metadata":{}}
+				]`), nil
+			}
+			return []byte(`[]`), nil
+		case "query":
+			return []byte(`[]`), nil
+		case "dep":
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		return []byte(`[]`), nil
+	}
+	cache := NewCachingStoreForTest(NewBdStore("/city", runner), nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	readyByID := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if !readyByID["bd-ready"] || readyByID["bd-blocked"] {
+		t.Fatalf("CachedReady ids = %v, want bd-ready only", readyByID)
+	}
+	if sqlCalls != 1 {
+		t.Fatalf("bd sql calls = %d, want 1", sqlCalls)
 	}
 }
 
@@ -3252,6 +3383,11 @@ func (r *cachingStoreBdDepRunner) run(_, name string, args ...string) ([]byte, e
 		return r.listOutput(), nil
 	case "ready":
 		return []byte(`[]`), nil
+	case "version":
+		return []byte("bd version 1.0.4\n"), nil
+	case "sql":
+		r.t.Fatalf("unexpected ready projection SQL under bd 1.0.4: %v", args)
+		return nil, nil
 	case "dep":
 		return r.runDep(args[1:]...)
 	default:

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3057,8 +3057,11 @@ func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
 		case "sql":
 			sqlCalls++
 			query := args[1]
-			if !strings.Contains(query, "'bd-ready'") || !strings.Contains(query, "'bd-blocked'") {
-				t.Fatalf("ready projection SQL = %q, want both active ids", query)
+			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
+				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
+			}
+			if !strings.Contains(query, "status in ('open','in_progress')") {
+				t.Fatalf("ready projection SQL = %q, want active status projection", query)
 			}
 			return []byte(`[
 				{"id":"bd-ready","is_blocked":0},

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3060,8 +3060,8 @@ func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
 			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
 				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
 			}
-			if !strings.Contains(query, "status in ('open','in_progress')") {
-				t.Fatalf("ready projection SQL = %q, want active status projection", query)
+			if !strings.Contains(query, "status <> 'closed'") {
+				t.Fatalf("ready projection SQL = %q, want non-closed active projection", query)
 			}
 			return []byte(`[
 				{"id":"bd-ready","is_blocked":0},
@@ -3101,6 +3101,74 @@ func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
 	}
 	if sqlCalls != 1 {
 		t.Fatalf("bd sql calls = %d, want 1", sqlCalls)
+	}
+}
+
+func TestCachingStoreBdPrimeProjectsIsBlockedForAllNonClosedBD105(t *testing.T) {
+	t.Parallel()
+
+	var sqlCalls int
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) == 0 {
+			t.Fatal("empty bd command")
+		}
+		switch args[0] {
+		case "version":
+			return []byte("bd version 1.0.5 (test)\n"), nil
+		case "sql":
+			sqlCalls++
+			query := args[1]
+			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
+				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
+			}
+			if strings.Contains(query, "status in ('open','in_progress')") || !strings.Contains(query, "status <> 'closed'") {
+				t.Fatalf("ready projection SQL = %q, want every non-closed row", query)
+			}
+			return []byte(`[
+				{"id":"bd-ready","is_blocked":0},
+				{"id":"bd-blocked-status","is_blocked":0},
+				{"id":"bd-deferred-status","is_blocked":1}
+			]`), nil
+		case "list":
+			return []byte(`[
+				{"id":"bd-ready","title":"ready","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
+				{"id":"bd-blocked-status","title":"blocked status","status":"blocked","issue_type":"task","created_at":"2026-01-01T00:00:01Z","labels":["task"],"metadata":{}},
+				{"id":"bd-deferred-status","title":"deferred status","status":"deferred","issue_type":"task","created_at":"2026-01-01T00:00:02Z","ephemeral":true,"labels":["task"],"metadata":{}}
+			]`), nil
+		case "query":
+			return []byte(`[]`), nil
+		case "dep":
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		return []byte(`[]`), nil
+	}
+
+	cache := NewCachingStoreForTest(NewBdStore("/city", runner), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if sqlCalls != 1 {
+		t.Fatalf("bd sql calls = %d, want 1", sqlCalls)
+	}
+	if stats := cache.Stats(); stats.ProblemCount != 0 {
+		t.Fatalf("cache problem count = %d, want 0", stats.ProblemCount)
+	}
+	blocked, err := cache.Get("bd-blocked-status")
+	if err != nil {
+		t.Fatalf("Get(blocked status): %v", err)
+	}
+	if blocked.IsBlocked == nil || *blocked.IsBlocked {
+		t.Fatalf("blocked-status IsBlocked = %v, want false projection", blocked.IsBlocked)
+	}
+	deferred, err := cache.Get("bd-deferred-status")
+	if err != nil {
+		t.Fatalf("Get(deferred status): %v", err)
+	}
+	if deferred.IsBlocked == nil || !*deferred.IsBlocked {
+		t.Fatalf("deferred-status IsBlocked = %v, want true projection", deferred.IsBlocked)
 	}
 }
 

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3010,6 +3010,263 @@ func TestCachingStoreCachedReadyHonorsProjectedIsBlocked(t *testing.T) {
 	}
 }
 
+func TestCachingStoreApplyEventMergesProjectedIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	unblocked := false
+	backing := &completeEmbeddedDepsStore{
+		beads: []Bead{{
+			ID:        "bd-event",
+			Title:     "event",
+			Status:    "open",
+			Type:      "task",
+			IsBlocked: &unblocked,
+		}},
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	ready, ok := cache.CachedReady()
+	if !ok || len(ready) != 1 || ready[0].ID != "bd-event" {
+		t.Fatalf("CachedReady before event = %+v, ok=%v, want bd-event ready", ready, ok)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"bd-event","status":"open","is_blocked":true}`))
+
+	ready, ok = cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after is_blocked event")
+	}
+	if len(ready) != 0 {
+		t.Fatalf("CachedReady after is_blocked event = %+v, want no ready beads", ready)
+	}
+	got, err := cache.Get("bd-event")
+	if err != nil {
+		t.Fatalf("Get after event: %v", err)
+	}
+	if got.IsBlocked == nil || !*got.IsBlocked {
+		t.Fatalf("IsBlocked after event = %v, want true", got.IsBlocked)
+	}
+}
+
+func TestCachingStoreApplyCloseEventClearsDependentProjectedIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	blockedProjection := true
+	backing := NewMemStore()
+	blocker, err := backing.Create(Bead{
+		Title:  "blocker",
+		Status: "open",
+		Type:   "task",
+	})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	blocked, err := backing.Create(Bead{
+		Title:     "blocked",
+		Status:    "open",
+		Type:      "task",
+		Needs:     []string{blocker.ID},
+		IsBlocked: &blockedProjection,
+	})
+	if err != nil {
+		t.Fatalf("Create blocked: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable before close event")
+	}
+	readyByID := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if !readyByID[blocker.ID] || readyByID[blocked.ID] {
+		t.Fatalf("CachedReady before close ids = %v, want blocker ready and dependent blocked", readyByID)
+	}
+
+	if err := backing.Close(blocker.ID); err != nil {
+		t.Fatalf("Close backing blocker: %v", err)
+	}
+	payload, err := json.Marshal(map[string]string{
+		"id":     blocker.ID,
+		"status": "closed",
+	})
+	if err != nil {
+		t.Fatalf("marshal close event: %v", err)
+	}
+	cache.ApplyEvent("bead.closed", payload)
+
+	ready, ok = cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after close event")
+	}
+	readyByID = make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if !readyByID[blocked.ID] {
+		t.Fatalf("CachedReady after close ids = %v, want dependent unblocked by closed blocker", readyByID)
+	}
+	got, err := cache.Get(blocked.ID)
+	if err != nil {
+		t.Fatalf("Get blocked after close event: %v", err)
+	}
+	if got.IsBlocked != nil {
+		t.Fatalf("dependent IsBlocked after close event = %v, want nil fallback to cached deps", got.IsBlocked)
+	}
+}
+
+func TestCachingStoreApplyCloseEventClearsProjectedIsBlockedWhenDepsIncomplete(t *testing.T) {
+	t.Parallel()
+
+	blockedProjection := true
+	mem := NewMemStore()
+	backing := &incompleteDependencyStore{Store: mem}
+	blocker, err := backing.Create(Bead{
+		Title:  "blocker",
+		Status: "open",
+		Type:   "task",
+	})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	blocked, err := backing.Create(Bead{
+		Title:     "blocked",
+		Status:    "open",
+		Type:      "task",
+		IsBlocked: &blockedProjection,
+	})
+	if err != nil {
+		t.Fatalf("Create blocked: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable before close event")
+	}
+	readyByID := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if !readyByID[blocker.ID] || readyByID[blocked.ID] {
+		t.Fatalf("CachedReady before close ids = %v, want blocker ready and projected dependent blocked", readyByID)
+	}
+
+	if err := backing.Close(blocker.ID); err != nil {
+		t.Fatalf("Close backing blocker: %v", err)
+	}
+	payload, err := json.Marshal(map[string]string{
+		"id":     blocker.ID,
+		"status": "closed",
+	})
+	if err != nil {
+		t.Fatalf("marshal close event: %v", err)
+	}
+	cache.ApplyEvent("bead.closed", payload)
+
+	ready, ok = cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after close event")
+	}
+	readyByID = make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if !readyByID[blocked.ID] {
+		t.Fatalf("CachedReady after close ids = %v, want projected dependent to fall back to cached deps", readyByID)
+	}
+	got, err := cache.Get(blocked.ID)
+	if err != nil {
+		t.Fatalf("Get blocked after close event: %v", err)
+	}
+	if got.IsBlocked != nil {
+		t.Fatalf("dependent IsBlocked after close event = %v, want nil fallback when dependency coverage is incomplete", got.IsBlocked)
+	}
+}
+
+func TestCachingStoreApplyEventRejectsStaleProjectedIsBlockedConflict(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		currentBlocked bool
+		staleBlocked   bool
+	}{
+		{name: "true_to_false", currentBlocked: true, staleBlocked: false},
+		{name: "false_to_true", currentBlocked: false, staleBlocked: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			currentBlocked := tc.currentBlocked
+			backing := NewMemStore()
+			bead, err := backing.Create(Bead{
+				Title:     "before event",
+				Status:    "open",
+				Type:      "task",
+				IsBlocked: &currentBlocked,
+			})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			cache := NewCachingStoreForTest(backing, nil)
+			if err := cache.Prime(context.Background()); err != nil {
+				t.Fatalf("Prime: %v", err)
+			}
+
+			currentTitle := "current event"
+			if err := backing.Update(bead.ID, UpdateOpts{Title: &currentTitle}); err != nil {
+				t.Fatalf("Update backing title: %v", err)
+			}
+			titleEvent, err := json.Marshal(map[string]string{
+				"id":    bead.ID,
+				"title": currentTitle,
+			})
+			if err != nil {
+				t.Fatalf("marshal title event: %v", err)
+			}
+			cache.ApplyEvent("bead.updated", titleEvent)
+
+			cache.mu.RLock()
+			_, locallyMutated := cache.beadSeq[bead.ID]
+			cache.mu.RUnlock()
+			if !locallyMutated {
+				t.Fatal("precondition: prior applied event did not mark bead mutated")
+			}
+
+			staleEvent, err := json.Marshal(struct {
+				ID        string `json:"id"`
+				IsBlocked bool   `json:"is_blocked"`
+			}{
+				ID:        bead.ID,
+				IsBlocked: tc.staleBlocked,
+			})
+			if err != nil {
+				t.Fatalf("marshal stale event: %v", err)
+			}
+			cache.ApplyEvent("bead.updated", staleEvent)
+
+			cache.mu.RLock()
+			cached := cloneBead(cache.beads[bead.ID])
+			cache.mu.RUnlock()
+			if cached.IsBlocked == nil || *cached.IsBlocked != currentBlocked {
+				t.Fatalf("cached IsBlocked after stale event = %v, want %v", cached.IsBlocked, currentBlocked)
+			}
+		})
+	}
+}
+
 func TestCachingStoreCachedReadyFallsBackToLegacyDepsWhenProjectionMissing(t *testing.T) {
 	t.Parallel()
 
@@ -3060,12 +3317,12 @@ func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
 			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
 				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
 			}
-			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
-				t.Fatalf("ready projection SQL = %q, want unfiltered row projection", query)
+			if !strings.Contains(query, "status <> 'closed'") || !strings.Contains(query, "from issues where") || !strings.Contains(query, "from wisps where") {
+				t.Fatalf("ready projection SQL = %q, want active row projection", query)
 			}
 			return []byte(`[
-				{"id":"bd-ready","is_blocked":0},
-				{"id":"bd-blocked","is_blocked":1}
+					{"id":"bd-ready","is_blocked":0},
+					{"id":"bd-blocked","is_blocked":1}
 			]`), nil
 		case "list":
 			argLine := strings.Join(args, " ")
@@ -3104,6 +3361,318 @@ func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
 	}
 }
 
+func TestCachingStoreBdReconcileAppliesFreshListWhenReadyProjectionErrors(t *testing.T) {
+	t.Parallel()
+
+	var sqlFails bool
+	listTitle := "before reconcile"
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) == 0 {
+			t.Fatal("empty bd command")
+		}
+		switch args[0] {
+		case "version":
+			return []byte("bd version 1.0.5 (test)\n"), nil
+		case "sql":
+			if sqlFails {
+				return nil, errors.New("projection unavailable")
+			}
+			return []byte(`[{"id":"bd-1","is_blocked":1}]`), nil
+		case "list":
+			return []byte(fmt.Sprintf(`[
+				{"id":"bd-1","title":%q,"status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}}
+			]`, listTitle)), nil
+		case "query":
+			return []byte(`[]`), nil
+		case "dep":
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		return []byte(`[]`), nil
+	}
+
+	cache := NewCachingStoreForTest(NewBdStore("/city", runner), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	initial, err := cache.Get("bd-1")
+	if err != nil {
+		t.Fatalf("Get initial: %v", err)
+	}
+	if initial.IsBlocked == nil || !*initial.IsBlocked {
+		t.Fatalf("initial IsBlocked = %v, want true projection", initial.IsBlocked)
+	}
+
+	listTitle = "after reconcile"
+	sqlFails = true
+	cache.runReconciliation()
+
+	got, err := cache.Get("bd-1")
+	if err != nil {
+		t.Fatalf("Get after reconcile: %v", err)
+	}
+	if got.Title != listTitle {
+		t.Fatalf("Title after reconcile = %q, want %q", got.Title, listTitle)
+	}
+	if got.IsBlocked == nil || !*got.IsBlocked {
+		t.Fatalf("IsBlocked after failed projection reconcile = %v, want prior true projection preserved", got.IsBlocked)
+	}
+	stats := cache.Stats()
+	if !strings.Contains(stats.LastProblem, "reconcile ready projection") {
+		t.Fatalf("LastProblem = %q, want reconcile ready projection", stats.LastProblem)
+	}
+}
+
+func TestCachingStoreBdReconcileDropsPreservedReadyProjectionWhenDepsChange(t *testing.T) {
+	t.Parallel()
+
+	var sqlFails bool
+	listNeeds := "[]"
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) == 0 {
+			t.Fatal("empty bd command")
+		}
+		switch args[0] {
+		case "version":
+			return []byte("bd version 1.0.5 (test)\n"), nil
+		case "sql":
+			if sqlFails {
+				return nil, errors.New("projection unavailable")
+			}
+			return []byte(`[
+				{"id":"bd-blocked","is_blocked":0},
+				{"id":"bd-blocker","is_blocked":0}
+			]`), nil
+		case "list":
+			return []byte(fmt.Sprintf(`[
+				{"id":"bd-blocked","title":"blocked","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{},"needs":%s},
+				{"id":"bd-blocker","title":"blocker","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:01Z","labels":["task"],"metadata":{}}
+			]`, listNeeds)), nil
+		case "query":
+			return []byte(`[]`), nil
+		case "dep":
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		return []byte(`[]`), nil
+	}
+
+	cache := NewCachingStoreForTest(NewBdStore("/city", runner), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	initial, err := cache.Get("bd-blocked")
+	if err != nil {
+		t.Fatalf("Get initial: %v", err)
+	}
+	if initial.IsBlocked == nil || *initial.IsBlocked {
+		t.Fatalf("initial IsBlocked = %v, want false projection", initial.IsBlocked)
+	}
+
+	listNeeds = `["bd-blocker"]`
+	sqlFails = true
+	cache.runReconciliation()
+
+	got, err := cache.Get("bd-blocked")
+	if err != nil {
+		t.Fatalf("Get after reconcile: %v", err)
+	}
+	if got.IsBlocked != nil {
+		t.Fatalf("IsBlocked after dependency-changing failed projection reconcile = %v, want nil fallback", got.IsBlocked)
+	}
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after reconcile")
+	}
+	readyByID := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if readyByID["bd-blocked"] || !readyByID["bd-blocker"] {
+		t.Fatalf("CachedReady after reconcile ids = %v, want bd-blocker only", readyByID)
+	}
+}
+
+func TestCachingStoreBdReconcileDropsPreservedReadyProjectionWhenDepTargetStatusChanges(t *testing.T) {
+	t.Parallel()
+
+	var sqlFails bool
+	blockerListed := true
+	blockerStatus := "closed"
+	showBlockerStatus := "closed"
+	projectionBlocked := false
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) == 0 {
+			t.Fatal("empty bd command")
+		}
+		switch args[0] {
+		case "version":
+			return []byte("bd version 1.0.5 (test)\n"), nil
+		case "sql":
+			if sqlFails {
+				return nil, errors.New("projection unavailable")
+			}
+			blocked := 0
+			if projectionBlocked {
+				blocked = 1
+			}
+			return []byte(fmt.Sprintf(`[{"id":"bd-blocked","is_blocked":%d}]`, blocked)), nil
+		case "list":
+			blocked := `{"id":"bd-blocked","title":"blocked","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{},"needs":["bd-blocker"]}`
+			if blockerListed {
+				return []byte(fmt.Sprintf(`[%s,{"id":"bd-blocker","title":"blocker","status":%q,"issue_type":"task","created_at":"2026-01-01T00:00:01Z","labels":["task"],"metadata":{}}]`, blocked, blockerStatus)), nil
+			}
+			return []byte(fmt.Sprintf(`[%s]`, blocked)), nil
+		case "show":
+			id := args[len(args)-1]
+			if id != "bd-blocker" {
+				return []byte(`[]`), nil
+			}
+			return []byte(fmt.Sprintf(`[{"id":"bd-blocker","title":"blocker","status":%q,"issue_type":"task","created_at":"2026-01-01T00:00:01Z","labels":["task"],"metadata":{}}]`, showBlockerStatus)), nil
+		case "query":
+			return []byte(`[]`), nil
+		case "dep":
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		return []byte(`[]`), nil
+	}
+
+	cache := NewCachingStoreForTest(NewBdStore("/city", runner), nil)
+	blockerStatus = "open"
+	projectionBlocked = true
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	initial, err := cache.Get("bd-blocked")
+	if err != nil {
+		t.Fatalf("Get initial: %v", err)
+	}
+	if initial.IsBlocked == nil || !*initial.IsBlocked {
+		t.Fatalf("initial IsBlocked = %v, want true projection", initial.IsBlocked)
+	}
+
+	blockerListed = false
+	showBlockerStatus = "closed"
+	projectionBlocked = false
+	cache.runReconciliation()
+
+	closedTarget, err := cache.Get("bd-blocker")
+	if err != nil {
+		t.Fatalf("Get closed blocker after reconcile: %v", err)
+	}
+	if closedTarget.Status != "closed" {
+		t.Fatalf("blocker status after close reconcile = %q, want closed", closedTarget.Status)
+	}
+	unblocked, err := cache.Get("bd-blocked")
+	if err != nil {
+		t.Fatalf("Get unblocked after close reconcile: %v", err)
+	}
+	if unblocked.IsBlocked == nil || *unblocked.IsBlocked {
+		t.Fatalf("IsBlocked after close reconcile = %v, want false projection", unblocked.IsBlocked)
+	}
+
+	blockerListed = true
+	blockerStatus = "open"
+	sqlFails = true
+	cache.runReconciliation()
+
+	got, err := cache.Get("bd-blocked")
+	if err != nil {
+		t.Fatalf("Get after reconcile: %v", err)
+	}
+	if got.IsBlocked != nil {
+		t.Fatalf("IsBlocked after dependency target status change = %v, want nil fallback", got.IsBlocked)
+	}
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after reconcile")
+	}
+	readyByID := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if readyByID["bd-blocked"] || !readyByID["bd-blocker"] {
+		t.Fatalf("CachedReady after reconcile ids = %v, want bd-blocker only", readyByID)
+	}
+}
+
+func TestCachingStoreBdPrimeActiveToleratesMissingReadyProjectionRowsBD105(t *testing.T) {
+	t.Parallel()
+
+	var sqlCalls int
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) == 0 {
+			t.Fatal("empty bd command")
+		}
+		switch args[0] {
+		case "version":
+			return []byte("bd version 1.0.5 (test)\n"), nil
+		case "sql":
+			sqlCalls++
+			query := args[1]
+			if !strings.Contains(query, "status <> 'closed'") {
+				t.Fatalf("ready projection SQL = %q, want active row filter", query)
+			}
+			return []byte(`[
+				{"id":"bd-ready","is_blocked":0}
+			]`), nil
+		case "list":
+			argLine := strings.Join(args, " ")
+			if strings.Contains(argLine, "--status=open") {
+				return []byte(`[
+					{"id":"bd-ready","title":"ready","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
+					{"id":"bd-raced-closed","title":"raced closed","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:01Z","labels":["task"],"metadata":{}}
+				]`), nil
+			}
+			return []byte(`[]`), nil
+		case "query":
+			return []byte(`[]`), nil
+		case "dep":
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		return []byte(`[]`), nil
+	}
+	cache := NewCachingStoreForTest(NewBdStore("/city", runner), nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after missing projection row")
+	}
+	readyByID := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if !readyByID["bd-ready"] || !readyByID["bd-raced-closed"] {
+		t.Fatalf("CachedReady ids = %v, want projected ready and missing-row fallback ready", readyByID)
+	}
+	raced, err := cache.Get("bd-raced-closed")
+	if err != nil {
+		t.Fatalf("Get raced closed: %v", err)
+	}
+	if raced.IsBlocked != nil {
+		t.Fatalf("raced closed IsBlocked = %v, want nil fallback", raced.IsBlocked)
+	}
+	if stats := cache.Stats(); stats.ProblemCount != 0 {
+		t.Fatalf("cache problem count = %d, want 0; last problem %q", stats.ProblemCount, stats.LastProblem)
+	}
+	if sqlCalls != 1 {
+		t.Fatalf("bd sql calls = %d, want 1", sqlCalls)
+	}
+}
+
 func TestCachingStoreBdPrimeProjectsIsBlockedForAllBDRowsBD105(t *testing.T) {
 	t.Parallel()
 
@@ -3124,12 +3693,12 @@ func TestCachingStoreBdPrimeProjectsIsBlockedForAllBDRowsBD105(t *testing.T) {
 			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
 				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
 			}
-			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
-				t.Fatalf("ready projection SQL = %q, want every row", query)
+			if !strings.Contains(query, "status <> 'closed'") || !strings.Contains(query, "from issues where") || !strings.Contains(query, "from wisps where") {
+				t.Fatalf("ready projection SQL = %q, want every active row", query)
 			}
 			return []byte(`[
-				{"id":"bd-ready","is_blocked":0},
-				{"id":"bd-blocked-status","is_blocked":0},
+					{"id":"bd-ready","is_blocked":0},
+					{"id":"bd-blocked-status","is_blocked":0},
 				{"id":"bd-deferred-status","is_blocked":1}
 			]`), nil
 		case "list":
@@ -3425,6 +3994,14 @@ func (s *completeEmbeddedDepsStore) List(query ListQuery) ([]Bead, error) {
 func (s *completeEmbeddedDepsStore) DepList(string, string) ([]Dep, error) {
 	s.depListCalls++
 	return nil, errors.New("unexpected per-ID DepList")
+}
+
+type incompleteDependencyStore struct {
+	Store
+}
+
+func (s *incompleteDependencyStore) listIncludesCompleteDependencies() bool {
+	return false
 }
 
 type cachingStoreBdDepRunner struct {

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -473,7 +473,7 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 
 		var result []Bead
 		for _, b := range openBeads {
-			if cachedBeadReady(statusByID, depsByID[b.ID]) {
+			if cachedBeadReady(b, statusByID, depsByID[b.ID]) {
 				result = append(result, cloneBead(b))
 			}
 		}
@@ -521,7 +521,7 @@ func (c *CachingStore) CachedReady() ([]Bead, bool) {
 		default:
 			return nil, false
 		}
-		if cachedBeadReady(statusByID, deps) {
+		if cachedBeadReady(b, statusByID, deps) {
 			result = append(result, cloneBead(b))
 		}
 	}
@@ -531,7 +531,10 @@ func (c *CachingStore) CachedReady() ([]Bead, bool) {
 	return result, true
 }
 
-func cachedBeadReady(statusByID map[string]string, deps []Dep) bool {
+func cachedBeadReady(b Bead, statusByID map[string]string, deps []Dep) bool {
+	if b.IsBlocked != nil {
+		return !*b.IsBlocked
+	}
 	for _, dep := range deps {
 		if !isReadyBlockingDependencyType(dep.Type) {
 			continue

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -271,6 +271,21 @@ func (c *CachingStore) runReconciliation() {
 		c.mu.Unlock()
 		return
 	}
+	enriched, enrichErr := c.enrichReadyProjectionForCache(fresh)
+	if enrichErr != nil {
+		c.mu.Lock()
+		c.syncFailures++
+		if c.syncFailures >= maxCacheSyncFailures && (c.state == cacheLive || c.state == cachePartial) {
+			c.state = cacheDegraded
+		}
+		c.recordProblemLocked("reconcile ready projection", enrichErr)
+		c.recordReconcileLatencyLocked(bdLatency)
+		c.recomputeCadenceLocked()
+		c.updateStatsLocked()
+		c.mu.Unlock()
+		return
+	}
+	fresh = enriched
 
 	freshByID := make(map[string]Bead, len(fresh))
 	for _, b := range fresh {

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -94,9 +94,10 @@ func beadCountCadence(total int) time.Duration {
 	}
 }
 
-// recordReconcileLatencyLocked appends a bd-list duration sample to the
-// rolling latency window, dropping the oldest sample once the window is
-// full. Caller must hold c.mu (write lock).
+// recordReconcileLatencyLocked appends a reconcile read sample to the rolling
+// latency window, dropping the oldest sample once the window is full. Success
+// samples include backing.List plus ready-projection enrichment. Caller must
+// hold c.mu (write lock).
 func (c *CachingStore) recordReconcileLatencyLocked(d time.Duration) {
 	if len(c.latencyWindow) < cacheLatencyWindowSize {
 		c.latencyWindow = append(c.latencyWindow, d)
@@ -257,8 +258,8 @@ func (c *CachingStore) runReconciliation() {
 
 	bdStart := time.Now()
 	fresh, err := c.backing.List(ListQuery{AllowScan: true, SkipLabels: true, TierMode: TierBoth})
-	bdLatency := time.Since(bdStart)
 	if err != nil {
+		bdLatency := time.Since(bdStart)
 		c.mu.Lock()
 		c.syncFailures++
 		if (IsPartialResult(err) || c.syncFailures >= maxCacheSyncFailures) && (c.state == cacheLive || c.state == cachePartial) {
@@ -272,20 +273,13 @@ func (c *CachingStore) runReconciliation() {
 		return
 	}
 	enriched, enrichErr := c.enrichReadyProjectionForCache(fresh)
+	bdLatency := time.Since(bdStart)
+	projectionFailed := enrichErr != nil
 	if enrichErr != nil {
-		c.mu.Lock()
-		c.syncFailures++
-		if c.syncFailures >= maxCacheSyncFailures && (c.state == cacheLive || c.state == cachePartial) {
-			c.state = cacheDegraded
-		}
-		c.recordProblemLocked("reconcile ready projection", enrichErr)
-		c.recordReconcileLatencyLocked(bdLatency)
-		c.recomputeCadenceLocked()
-		c.updateStatsLocked()
-		c.mu.Unlock()
-		return
+		c.recordProblem("reconcile ready projection", enrichErr)
+	} else {
+		fresh = enriched
 	}
-	fresh = enriched
 
 	freshByID := make(map[string]Bead, len(fresh))
 	for _, b := range fresh {
@@ -302,6 +296,9 @@ func (c *CachingStore) runReconciliation() {
 
 	c.mu.Lock()
 	now := time.Now()
+	if projectionFailed {
+		c.preserveCachedReadyProjectionLocked(freshByID, depMap, useFreshDeps)
+	}
 	if c.mutationSeq != startSeq {
 		var adds, removes, updates int64
 		notifications := make([]cacheNotification, 0, len(freshByID))
@@ -639,4 +636,45 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) map[str
 		c.mu.Unlock()
 	}
 	return confirmedClosed
+}
+
+func (c *CachingStore) preserveCachedReadyProjectionLocked(items map[string]Bead, depMap map[string][]Dep, useFreshDeps bool) {
+	for id, item := range items {
+		if item.IsBlocked != nil {
+			continue
+		}
+		cached, ok := c.beads[id]
+		if !ok || cached.IsBlocked == nil {
+			continue
+		}
+		freshDeps := c.depsForReconcileLocked(id, item, depMap, useFreshDeps)
+		if depsChanged(c.deps[id], freshDeps) {
+			continue
+		}
+		if c.readyBlockingDependencyTargetStatusChangedLocked(freshDeps, items) {
+			continue
+		}
+		item.IsBlocked = cloneBoolPtr(cached.IsBlocked)
+		items[id] = item
+	}
+}
+
+func (c *CachingStore) readyBlockingDependencyTargetStatusChangedLocked(deps []Dep, items map[string]Bead) bool {
+	for _, dep := range deps {
+		if !isReadyBlockingDependencyType(dep.Type) {
+			continue
+		}
+		cachedTarget, cachedOK := c.beads[dep.DependsOnID]
+		freshTarget, freshOK := items[dep.DependsOnID]
+		if !freshOK {
+			continue
+		}
+		if !cachedOK {
+			return true
+		}
+		if cachedTarget.Status != freshTarget.Status {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -85,6 +85,7 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 			delete(c.beadSeq, id)
 			delete(c.localBeadAt, id)
 			c.deletedSeq[id] = seq
+			c.clearDependentReadyProjectionsLocked(id)
 			c.markFreshLocked(time.Now())
 			c.updateStatsLocked()
 			c.mu.Unlock()
@@ -97,6 +98,9 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 			fresh = applyUpdateOptsToBead(current, opts)
 			c.beads[id] = cloneBead(fresh)
 			c.deps[id] = depsFromBeadFields(fresh)
+			if opts.Status != nil {
+				c.clearDependentReadyProjectionsLocked(id)
+			}
 			c.dirty[id] = struct{}{}
 			delete(c.deletedSeq, id)
 			c.updateStatsLocked()
@@ -116,6 +120,9 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 	c.noteLocalMutationLocked(id)
 	c.beads[id] = cloneBead(fresh)
 	c.deps[id] = depsFromBeadFields(fresh)
+	if opts.Status != nil {
+		c.clearDependentReadyProjectionsLocked(id)
+	}
 	delete(c.dirty, id)
 	delete(c.deletedSeq, id)
 	c.markFreshLocked(time.Now())
@@ -162,6 +169,7 @@ func (c *CachingStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, erro
 	} else {
 		c.dirty[id] = struct{}{}
 	}
+	c.clearDependentReadyProjectionsLocked(id)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	c.mu.Unlock()
@@ -203,12 +211,13 @@ func (c *CachingStore) Close(id string) error {
 		delete(c.deletedSeq, id)
 		closed = cloneBead(b)
 		found = true
-		c.markFreshLocked(time.Now())
-		c.updateStatsLocked()
 	} else if found {
 		c.beads[id] = cloneBead(closed)
 		delete(c.dirty, id)
 		delete(c.deletedSeq, id)
+	}
+	dependentProjectionCleared := c.clearDependentReadyProjectionsLocked(id)
+	if found || dependentProjectionCleared {
 		c.markFreshLocked(time.Now())
 		c.updateStatsLocked()
 	}
@@ -245,12 +254,13 @@ func (c *CachingStore) Reopen(id string) error {
 		delete(c.deletedSeq, id)
 		reopened = cloneBead(b)
 		found = true
-		c.markFreshLocked(time.Now())
-		c.updateStatsLocked()
 	} else if found {
 		c.beads[id] = cloneBead(reopened)
 		delete(c.dirty, id)
 		delete(c.deletedSeq, id)
+	}
+	dependentProjectionCleared := c.clearDependentReadyProjectionsLocked(id)
+	if found || dependentProjectionCleared {
 		c.markFreshLocked(time.Now())
 		c.updateStatsLocked()
 	}
@@ -302,6 +312,7 @@ func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, 
 		delete(c.deletedSeq, item.id)
 		if item.bead.Status == "closed" {
 			delete(c.deps, item.id)
+			c.clearDependentReadyProjectionsLocked(item.id)
 		}
 		if hadPrevious && previous.Status != "closed" && item.bead.Status == "closed" {
 			notifications = append(notifications, cacheNotification{
@@ -557,10 +568,17 @@ func (c *CachingStore) refreshTxTouchedBeads(ids []string, closed map[string]str
 		if item.found {
 			previous, hadPrevious := c.beads[item.id]
 			fresh := cloneBead(item.bead)
+			statusChanged := item.closed || fresh.Status == "closed"
+			if hadPrevious && previous.Status != fresh.Status {
+				statusChanged = true
+			}
 			c.beads[item.id] = fresh
 			c.deps[item.id] = depsFromBeadFields(fresh)
 			delete(c.dirty, item.id)
 			delete(c.deletedSeq, item.id)
+			if statusChanged {
+				c.clearDependentReadyProjectionsLocked(item.id)
+			}
 			eventType := "bead.updated"
 			if fresh.Status == "closed" {
 				eventType = "bead.closed"
@@ -579,6 +597,7 @@ func (c *CachingStore) refreshTxTouchedBeads(ids []string, closed map[string]str
 				c.beads[item.id] = b
 				delete(c.dirty, item.id)
 				delete(c.deletedSeq, item.id)
+				c.clearDependentReadyProjectionsLocked(item.id)
 				notifications = append(notifications, cacheNotification{
 					eventType: "bead.closed",
 					bead:      cloneBead(b),
@@ -762,6 +781,7 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 	if refreshed {
 		c.beads[issueID] = cloneBead(fresh)
 		c.deps[issueID] = cloneDeps(deps)
+		c.clearReadyProjectionLocked(issueID)
 		delete(c.dirty, issueID)
 		delete(c.deletedSeq, issueID)
 		c.markFreshLocked(time.Now())
@@ -785,6 +805,7 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 		if d.DependsOnID == dependsOnID {
 			cachedDeps[i].Type = depType
 			c.deps[issueID] = cachedDeps
+			c.clearReadyProjectionLocked(issueID)
 			delete(c.dirty, issueID)
 			delete(c.deletedSeq, issueID)
 			c.markFreshLocked(time.Now())
@@ -794,6 +815,7 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 		}
 	}
 	c.deps[issueID] = append(cachedDeps, Dep{IssueID: issueID, DependsOnID: dependsOnID, Type: depType})
+	c.clearReadyProjectionLocked(issueID)
 	delete(c.dirty, issueID)
 	delete(c.deletedSeq, issueID)
 	c.markFreshLocked(time.Now())
@@ -814,6 +836,7 @@ func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
 	if refreshed {
 		c.beads[issueID] = cloneBead(fresh)
 		c.deps[issueID] = cloneDeps(deps)
+		c.clearReadyProjectionLocked(issueID)
 		delete(c.dirty, issueID)
 		delete(c.deletedSeq, issueID)
 		c.markFreshLocked(time.Now())
@@ -836,6 +859,7 @@ func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
 	for i, d := range cachedDeps {
 		if d.DependsOnID == dependsOnID {
 			c.deps[issueID] = append(cachedDeps[:i], cachedDeps[i+1:]...)
+			c.clearReadyProjectionLocked(issueID)
 			delete(c.dirty, issueID)
 			delete(c.deletedSeq, issueID)
 			break
@@ -862,6 +886,7 @@ func (c *CachingStore) Delete(id string) error {
 	delete(c.beadSeq, id)
 	delete(c.localBeadAt, id)
 	c.deletedSeq[id] = seq
+	c.clearDependentReadyProjectionsLocked(id)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	c.mu.Unlock()

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -158,6 +158,62 @@ func TestCachingStoreTxDelegatesToBackingTxAndRefreshesCache(t *testing.T) {
 	assertTxPreservedBead(t, cached)
 }
 
+func TestCachingStoreTxCloseClearsDependentProjectedIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	blockedProjection := true
+	backing := NewMemStore()
+	blocker, err := backing.Create(Bead{
+		Title:  "blocker",
+		Status: "open",
+		Type:   "task",
+	})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	blocked, err := backing.Create(Bead{
+		Title:     "blocked",
+		Status:    "open",
+		Type:      "task",
+		Needs:     []string{blocker.ID},
+		IsBlocked: &blockedProjection,
+	})
+	if err != nil {
+		t.Fatalf("Create blocked: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if err := cache.Tx("close blocker", func(tx Tx) error {
+		return tx.Close(blocker.ID)
+	}); err != nil {
+		t.Fatalf("Tx close blocker: %v", err)
+	}
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after tx close")
+	}
+	readyByID := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if !readyByID[blocked.ID] {
+		t.Fatalf("CachedReady after tx close ids = %v, want dependent unblocked by closed blocker", readyByID)
+	}
+
+	got, err := cache.Get(blocked.ID)
+	if err != nil {
+		t.Fatalf("Get blocked after tx close: %v", err)
+	}
+	if got.IsBlocked != nil {
+		t.Fatalf("dependent IsBlocked after tx close = %v, want nil fallback to cached deps", got.IsBlocked)
+	}
+}
+
 func assertTxPreservedBead(t *testing.T, got Bead) {
 	t.Helper()
 	if got.Title != "preserve title" {

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -681,6 +681,8 @@ func (s *DoltliteReadStore) dependencySnapshotForCache(ids []string) (map[string
 }
 
 func (s *DoltliteReadStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
+	// Native DoltLite snapshots do not carry bd's denormalized is_blocked
+	// projection, so cached ready intentionally keeps the nil fallback.
 	return items, nil
 }
 

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -672,6 +672,18 @@ func (s *DoltliteReadStore) DepListBatch(ids []string) (map[string][]Dep, error)
 	return result, nil
 }
 
+func (s *DoltliteReadStore) dependencySnapshotForCache(ids []string) (map[string][]Dep, bool, error) {
+	deps, err := s.DepListBatch(ids)
+	if err != nil {
+		return deps, false, err
+	}
+	return deps, true, nil
+}
+
+func (s *DoltliteReadStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
+	return items, nil
+}
+
 func (s *DoltliteReadStore) queryDeps(where, value string) ([]Dep, error) {
 	var deps []Dep
 	for _, table := range []string{"dependencies", "wisp_dependencies"} {

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -64,6 +64,7 @@ func (m *MemStore) snapshot() (int, []Bead, []Dep) {
 func cloneBead(b Bead) Bead {
 	b.Priority = cloneIntPtr(b.Priority)
 	b.DeferUntil = cloneTimePtr(b.DeferUntil)
+	b.IsBlocked = cloneBoolPtr(b.IsBlocked)
 	b.Metadata = maps.Clone(b.Metadata)
 	b.Labels = slices.Clone(b.Labels)
 	b.Needs = slices.Clone(b.Needs)


### PR DESCRIPTION
## Summary
- propagate bd 1.0.5 `is_blocked` ready projection into cached bead rows
- prefer projected readiness in `CachedReady`, preserving legacy dependency-derived behavior for older bd versions
- enrich BdStore cache prime/reconcile via version-gated `bd sql` across issues and wisps

## Root Cause
The reconciler pool-demand path used cached ready work. bd 1.0.5 moved ready semantics into the denormalized `is_blocked` projection, but Gas City cache did not carry that value, so active blocked rows could be counted as ready even when `bd ready` excluded them.

## Tests
- `go test ./internal/beads -count=1`
- `go test ./cmd/gc -run 'TestDefaultScaleCheckCounts|TestCollectAssignedWorkBeadsUsesCachedReadyReadModel|Test.*CachedReady|Test.*ScaleCheck' -count=1`\n- pre-commit hook: lint-changed, go vet, fast local shards, dashboard build/typecheck\n