### PR TITLE
fix(beads/preflight): degrade (not block) native store when bd context is unreachable

### DIFF
--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -149,7 +149,11 @@ func (c PreflightChecker) checkBDContextAgreement(metadata preflightMetadata, ct
 	details := PreflightDetails{MetadataBackend: metadata.Backend}
 	details.BDContextBackend = ctx.Backend
 	if err != nil {
-		return NewPreflightCheckResult(PreflightCheckBDContextAgreement, PreflightCheckFail, "bd context is unreachable", details)
+		// Unreachable bd context (e.g. a non-git city root where `bd context`
+		// cannot run) is not evidence of backend DISAGREEMENT — only that we
+		// cannot cross-verify. Degrade (opt-in) rather than hard-block; a real
+		// mismatch is still caught below once bd context is readable.
+		return NewPreflightCheckResult(PreflightCheckBDContextAgreement, PreflightCheckWarn, "bd context is unreachable; cannot cross-verify backend agreement", details)
 	}
 	if details.MetadataBackend == "" || details.BDContextBackend == "" {
 		return NewPreflightCheckResult(PreflightCheckBDContextAgreement, PreflightCheckFail, "bd context agreement cannot be determined", details)
@@ -167,7 +171,10 @@ func (c PreflightChecker) checkDoltModeSafe(metadata preflightMetadata, ctx Pref
 		BDContextDoltMode: ctx.DoltMode,
 	}
 	if err != nil {
-		return NewPreflightCheckResult(PreflightCheckDoltModeSafe, PreflightCheckFail, "bd context is unreachable", details)
+		// Unreachable bd context cannot confirm dolt server mode; degrade
+		// (opt-in) rather than hard-block. embedded mode is still rejected
+		// below once bd context is readable.
+		return NewPreflightCheckResult(PreflightCheckDoltModeSafe, PreflightCheckWarn, "bd context is unreachable; cannot confirm dolt server mode", details)
 	}
 	if metadata.Backend != "dolt" || ctx.Backend != "dolt" {
 		return NewPreflightCheckResult(PreflightCheckDoltModeSafe, PreflightCheckPass, "Dolt mode check is not required for non-dolt backend", details)
@@ -212,7 +219,10 @@ func (c PreflightChecker) checkVersionCompat(ctx PreflightBDContext, err error) 
 		SchemaVersion:       ctx.SchemaVersion,
 	}
 	if err != nil {
-		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckFail, "bd context is unreachable", details)
+		// Unreachable bd context cannot confirm bd/beads version parity; degrade
+		// (opt-in) rather than hard-block. A real version skew is still caught
+		// below once bd context is readable.
+		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckWarn, "bd context is unreachable; cannot confirm bd/beads version compatibility", details)
 	}
 	if ctx.SchemaVersion <= 0 {
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckFail, "bd context did not report a schema version", details)

--- a/internal/beads/contract/preflight_checker_test.go
+++ b/internal/beads/contract/preflight_checker_test.go
@@ -82,6 +82,46 @@ func TestPreflightBlocksNativeOnContextDisagreement(t *testing.T) {
 	assertCheckState(t, result, PreflightCheckBDContextAgreement, PreflightCheckFail)
 }
 
+// An UNREACHABLE bd context (e.g. a non-git city root where `bd context` cannot
+// run) is not evidence of a backend disagreement — it only means the native
+// store's bd-context cross-checks cannot be verified. It must DEGRADE eligibility
+// (operator opt-in) rather than hard-BLOCK it, so the bd-context-derived checks
+// report WARN, not FAIL. (A real disagreement, with a readable bd context, still
+// blocks — see TestPreflightBlocksNativeOnContextDisagreement.)
+func TestPreflightDegradesNativeOnUnreachableBDContext(t *testing.T) {
+	scope := "/city"
+	fs := fsys.NewFake()
+	fs.Dirs[filepath.Join(scope, ".beads")] = true
+	fs.Files[filepath.Join(scope, ".beads", "metadata.json")] = []byte(`{
+		"backend": "dolt",
+		"dolt_mode": "server",
+		"dolt_database": "gascity",
+		"project_id": "gc-local"
+	}`)
+	checker := PreflightChecker{
+		FS:                  fs,
+		Provider:            "bd",
+		BeadsLibraryVersion: "1.0.4",
+		BDContext: func(string) (PreflightBDContext, error) {
+			return PreflightBDContext{}, errors.New("bd context unavailable: not a git repository")
+		},
+		DatabaseProjectID: func(string) (string, bool, error) {
+			return "gc-local", true, nil
+		},
+	}
+
+	result, err := checker.Check(scope)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	// Unreachable (not disagreeing) bd context => DEGRADED + opt-in, never BLOCKED.
+	assertPreflightVerdict(t, result, PreflightVerdictDegraded, false)
+	assertCheckState(t, result, PreflightCheckBDContextAgreement, PreflightCheckWarn)
+	assertCheckState(t, result, PreflightCheckDoltModeSafe, PreflightCheckWarn)
+	assertCheckState(t, result, PreflightCheckVersionCompat, PreflightCheckWarn)
+}
+
 func TestPreflightBlocksNativeOnIdentityMismatch(t *testing.T) {
 	scope := "/city"
 	checker := testPreflightChecker(preflightMetadataJSON(`{


### PR DESCRIPTION
## Problem

The native (in-process) beads store eliminates the per-operation `bd`→`dolt` subprocess forks that dominate control-plane fork/CPU load on busy cities. Whether it engages is decided by a preflight that runs three **bd-context cross-checks** — `bd_context_agreement`, `dolt_mode_safe`, `version_compat` (`internal/beads/contract/preflight_checker.go`).

All three **hard-FAIL** when the bd-context reader returns an error:

```go
if err != nil {
    return NewPreflightCheckResult(..., PreflightCheckFail, "bd context is unreachable", details)
}
```

A **non-git city root** makes that reader error, because `bd context` requires a git repository — which surfaces as the deterministic `native_store_unavailable gate=bd_context_agreement reason="bd context is unreachable"` WARN on every city-scope command. Since **any FAIL forces the aggregate verdict to `BLOCKED`**, the native store can never engage — or even be opted into — at a non-git city root, *regardless of whether the dolt backend is healthy and in agreement.*

## Root cause

An **unreachable** bd context is not evidence of a backend **disagreement** — it only means the cross-check **cannot be performed**. The checks conflate "cannot verify" with "verified failure", turning a can't-tell into a hard blocker.

## Fix

For the unreachable case (`err != nil`) the three bd-context-derived checks now return `WARN` → aggregate verdict `DEGRADED` (operator opt-in) instead of `FAIL` → `BLOCKED`. The genuine-failure branches are unchanged and still hard-FAIL once bd context is readable:
- backend disagreement (`metadata.Backend != bd_context.Backend`)
- embedded dolt mode
- bd/beads version skew

## Tests

- **New** `TestPreflightDegradesNativeOnUnreachableBDContext`: unreachable bd context + healthy dolt metadata → verdict `DEGRADED`, the three checks `WARN`.
- **Unchanged** `TestPreflightBlocksNativeOnContextDisagreement`: a *readable* bd context reporting a different backend still → `BLOCKED` — confirming the fix discriminates can't-verify from verified-disagreement.
- Full `./internal/beads/...` suite green.

## Scope / follow-ups

This is the eligibility-**correctness** fix only. It does **not** by itself activate the native store: the factory is still `ELIGIBLE`-only, so a `DEGRADED` opt-in path, routing the `gc bd` CLI store selection through the native factory, and bd-hooks/event-coverage are separate follow-ups. This change removes the false `BLOCKED` so those can proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
