### PR TITLE
Persist Codex hook session keys

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -45,12 +45,15 @@ const primeHookReadTimeout = 500 * time.Millisecond
 var primeStdin = func() *os.File { return os.Stdin }
 
 type primeHookInput struct {
-	Source string `json:"source"`
+	Source        string `json:"source"`
+	SessionID     string `json:"session_id"`
+	HookEventName string `json:"hook_event_name"`
 }
 
 type primeHookContext struct {
-	Source        string
-	HookEventName string
+	Source            string
+	HookEventName     string
+	ProviderSessionID string
 }
 
 // newPrimeCmd creates the "gc prime [agent-name]" command.
@@ -187,7 +190,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		if !hookMode {
 			return
 		}
-		persistPrimeHookProviderSessionKey()
+		persistPrimeHookProviderSessionKey(hookContext.ProviderSessionID)
 	}
 	if !strictMode {
 		runHookSideEffects()
@@ -473,20 +476,18 @@ func readPrimeHookContext() primeHookContext {
 		Source:        strings.TrimSpace(os.Getenv("GC_HOOK_SOURCE")),
 		HookEventName: strings.TrimSpace(os.Getenv("GC_HOOK_EVENT_NAME")),
 	}
-	if shouldReadPrimeHookStdin() {
-		if input := readPrimeHookStdin(); input != nil {
-			if source := strings.TrimSpace(input.Source); source != "" {
-				ctx.Source = source
-			}
+	if input := readPrimeHookStdin(); input != nil {
+		if source := strings.TrimSpace(input.Source); source != "" {
+			ctx.Source = source
+		}
+		if event := strings.TrimSpace(input.HookEventName); event != "" {
+			ctx.HookEventName = event
+		}
+		if providerSessionID := strings.TrimSpace(input.SessionID); providerSessionID != "" {
+			ctx.ProviderSessionID = providerSessionID
 		}
 	}
 	return ctx
-}
-
-func shouldReadPrimeHookStdin() bool {
-	hasEnvSessionID := strings.TrimSpace(os.Getenv("GC_SESSION_ID")) != "" ||
-		strings.TrimSpace(os.Getenv("CLAUDE_SESSION_ID")) != ""
-	return !hasEnvSessionID
 }
 
 func readPrimeHookStdin() *primeHookInput {
@@ -530,11 +531,16 @@ func readPrimeHookStdin() *primeHookInput {
 	return &input
 }
 
-func persistPrimeHookProviderSessionKey() {
+func persistPrimeHookProviderSessionKey(hookProviderSessionID string) {
 	gcSessionID := strings.TrimSpace(os.Getenv("GC_SESSION_ID"))
 	providerSessionID := strings.TrimSpace(os.Getenv("GC_PROVIDER_SESSION_ID"))
 	if providerSessionID == "" {
 		providerSessionID = strings.TrimSpace(os.Getenv("GEMINI_SESSION_ID"))
+	}
+	fromHookStdin := false
+	if providerSessionID == "" {
+		providerSessionID = strings.TrimSpace(hookProviderSessionID)
+		fromHookStdin = providerSessionID != ""
 	}
 	if gcSessionID == "" || providerSessionID == "" || gcSessionID == providerSessionID {
 		return
@@ -549,6 +555,9 @@ func persistPrimeHookProviderSessionKey() {
 	}
 	sessionBead, err := store.Get(gcSessionID)
 	if err != nil {
+		return
+	}
+	if fromHookStdin && sessionProviderFamily(sessionBead) != "codex" {
 		return
 	}
 	if existing := strings.TrimSpace(sessionBead.Metadata["session_key"]); existing != "" {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -7141,6 +7141,151 @@ prompt_template = "prompts/probe.md"
 	}
 }
 
+func TestDoPrimeCodexHookPersistsProviderSessionKeyFromHookStdin(t *testing.T) {
+	dir, sessionID := setupPrimeHookProviderSessionKeyTest(t, "codex", `[providers.codex]
+base = "builtin:codex"`)
+	setPrimeHookStdinJSON(t, map[string]string{
+		"session_id":      "019ea3bd-ebb6-7530-a8b5-48b6c43e9153",
+		"transcript_path": "/home/ubuntu/.aimux/codex/codex7/sessions/2026/06/07/rollout-2026-06-07T20-19-53-019ea3bd-ebb6-7530-a8b5-48b6c43e9153.jsonl",
+		"hook_event_name": "SessionStart",
+		"source":          "startup",
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	updatedStore, err := openCityStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := updatedStore.Get(sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(updated.Metadata["session_key"]); got != "019ea3bd-ebb6-7530-a8b5-48b6c43e9153" {
+		t.Fatalf("session_key = %q, want Codex provider session id from hook stdin", got)
+	}
+}
+
+func TestDoPrimeHookIgnoresProviderSessionKeyFromHookStdinForNonCodex(t *testing.T) {
+	dir, sessionID := setupPrimeHookProviderSessionKeyTest(t, "claude", `[providers.claude]
+base = "builtin:claude"`)
+	setPrimeHookStdinJSON(t, map[string]string{
+		"session_id":      "claude-provider-session",
+		"hook_event_name": "SessionStart",
+		"source":          "startup",
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	updatedStore, err := openCityStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := updatedStore.Get(sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(updated.Metadata["session_key"]); got != "" {
+		t.Fatalf("session_key = %q, want empty for non-Codex hook stdin session id", got)
+	}
+}
+
+func setupPrimeHookProviderSessionKeyTest(t *testing.T, provider, providerConfig string) (string, string) {
+	t.Helper()
+
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_PROVIDER_SESSION_ID", "")
+	t.Setenv("GEMINI_SESSION_ID", "")
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptsDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptsDir, "probe.md"), []byte("probe prompt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toml := fmt.Sprintf(`[workspace]
+name = "test-city"
+provider = %q
+
+%s
+
+[[agent]]
+name = "probe"
+prompt_template = "prompts/probe.md"
+`, provider, providerConfig)
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openCityStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionBead, err := store.Create(beads.Bead{
+		Title: "probe",
+		Type:  "task",
+		Labels: []string{
+			"gc:session",
+			"template:probe",
+		},
+		Metadata: map[string]string{
+			"template":     "probe",
+			"provider":     provider,
+			"session_name": "probe",
+			"state":        "active",
+			"work_dir":     dir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_AGENT", "probe")
+	t.Setenv("GC_SESSION_ID", sessionBead.ID)
+
+	return dir, sessionBead.ID
+}
+
+func setPrimeHookStdinJSON(t *testing.T, payload map[string]string) {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldPrimeStdin := primeStdin
+	primeStdin = func() *os.File { return reader }
+	t.Cleanup(func() {
+		primeStdin = oldPrimeStdin
+		_ = reader.Close()
+	})
+	if err := json.NewEncoder(writer).Encode(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDoPrimeHookFallsBackToGCTemplateForManualSessionAlias(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()

--- a/internal/worker/handle_test.go
+++ b/internal/worker/handle_test.go
@@ -963,7 +963,7 @@ func TestSessionHandleHistoryLoadsNormalizedTranscript(t *testing.T) {
 	}
 }
 
-func TestSessionHandleHistoryPersistsCodexResumeKeyForLaterRestart(t *testing.T) {
+func TestSessionHandleHistoryDoesNotPersistCodexResumeKeyFromTranscript(t *testing.T) {
 	base := t.TempDir()
 	dayDir := filepath.Join(base, "2026", "04", "14")
 	if err := os.MkdirAll(dayDir, 0o755); err != nil {
@@ -1004,19 +1004,19 @@ func TestSessionHandleHistoryPersistsCodexResumeKeyForLaterRestart(t *testing.T)
 	if err != nil {
 		t.Fatalf("History: %v", err)
 	}
-	if history.GCSessionID != resumeID {
-		t.Fatalf("History().GCSessionID = %q, want %q", history.GCSessionID, resumeID)
+	if history.GCSessionID == resumeID {
+		t.Fatalf("History().GCSessionID = %q, want Gas City session id, not transcript-derived Codex resume id", history.GCSessionID)
 	}
-	if history.LogicalConversationID != resumeID {
-		t.Fatalf("History().LogicalConversationID = %q, want %q", history.LogicalConversationID, resumeID)
+	if history.LogicalConversationID == resumeID {
+		t.Fatalf("History().LogicalConversationID = %q, want non-Codex-derived logical id", history.LogicalConversationID)
 	}
 
 	bead, err := store.Get(handle.sessionID)
 	if err != nil {
 		t.Fatalf("store.Get(%q): %v", handle.sessionID, err)
 	}
-	if bead.Metadata["session_key"] != resumeID {
-		t.Fatalf("session_key = %q, want %q", bead.Metadata["session_key"], resumeID)
+	if got := bead.Metadata["session_key"]; got != "" {
+		t.Fatalf("session_key = %q, want empty; Codex resume keys come from SessionStart hook stdin", got)
 	}
 
 	if err := handle.Stop(context.Background()); err != nil {
@@ -1031,12 +1031,12 @@ func TestSessionHandleHistoryPersistsCodexResumeKeyForLaterRestart(t *testing.T)
 		t.Fatalf("runtime calls = %#v, want second Start", sp.Calls)
 	}
 	wantResume := "codex resume " + resumeID
-	if !strings.Contains(secondStart.Config.Command, wantResume) {
-		t.Fatalf("second start command = %q, want %q", secondStart.Config.Command, wantResume)
+	if strings.Contains(secondStart.Config.Command, wantResume) {
+		t.Fatalf("second start command = %q, must not use transcript-derived Codex resume command %q", secondStart.Config.Command, wantResume)
 	}
 }
 
-func TestSessionHandleStatePersistsCodexResumeKeyWithoutPrimingHistoryCache(t *testing.T) {
+func TestSessionHandleStateDoesNotPersistCodexResumeKeyWithoutPrimingHistoryCache(t *testing.T) {
 	base := t.TempDir()
 	dayDir := filepath.Join(base, "2026", "04", "14")
 	if err := os.MkdirAll(dayDir, 0o755); err != nil {
@@ -1088,8 +1088,8 @@ func TestSessionHandleStatePersistsCodexResumeKeyWithoutPrimingHistoryCache(t *t
 	if err != nil {
 		t.Fatalf("store.Get(%q): %v", handle.sessionID, err)
 	}
-	if bead.Metadata["session_key"] != resumeID {
-		t.Fatalf("session_key = %q, want %q", bead.Metadata["session_key"], resumeID)
+	if got := bead.Metadata["session_key"]; got != "" {
+		t.Fatalf("session_key = %q, want empty; Codex resume keys come from SessionStart hook stdin", got)
 	}
 
 	if err := handle.Stop(context.Background()); err != nil {
@@ -1104,8 +1104,8 @@ func TestSessionHandleStatePersistsCodexResumeKeyWithoutPrimingHistoryCache(t *t
 		t.Fatalf("runtime calls = %#v, want second Start", sp.Calls)
 	}
 	wantResume := "codex resume " + resumeID
-	if !strings.Contains(secondStart.Config.Command, wantResume) {
-		t.Fatalf("second start command = %q, want %q", secondStart.Config.Command, wantResume)
+	if strings.Contains(secondStart.Config.Command, wantResume) {
+		t.Fatalf("second start command = %q, must not use transcript-derived Codex resume command %q", secondStart.Config.Command, wantResume)
 	}
 }
 

--- a/internal/worker/provider_resume.go
+++ b/internal/worker/provider_resume.go
@@ -1,13 +1,10 @@
 package worker
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/sessionlog"
 )
-
-var codexThreadIDPattern = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 
 func derivedResumeSessionKey(provider, providerSessionID string) string {
 	providerSessionID = strings.TrimSpace(providerSessionID)
@@ -18,12 +15,5 @@ func derivedResumeSessionKey(provider, providerSessionID string) string {
 	if providerFamily == "kimi" || providerFamily == "opencode" || providerFamily == "pi" || providerFamily == "antigravity" {
 		return providerSessionID
 	}
-	if providerFamily != "codex" {
-		return ""
-	}
-	matches := codexThreadIDPattern.FindAllString(providerSessionID, -1)
-	if len(matches) == 0 {
-		return ""
-	}
-	return matches[len(matches)-1]
+	return ""
 }

--- a/internal/worker/provider_resume_test.go
+++ b/internal/worker/provider_resume_test.go
@@ -16,11 +16,11 @@ func TestDerivedResumeSessionKeyKimiUsesProviderSessionID(t *testing.T) {
 	}
 }
 
-func TestDerivedResumeSessionKeyCodexExtractsThreadID(t *testing.T) {
+func TestDerivedResumeSessionKeyCodexStaysEmpty(t *testing.T) {
 	threadID := "019e1b65-5457-7301-a550-57a3d0d0919a"
 	got := derivedResumeSessionKey("codex/tmux-cli", "rollout-2026-05-12T08-54-46-"+threadID+".jsonl")
-	if got != threadID {
-		t.Fatalf("derivedResumeSessionKey(codex) = %q, want %q", got, threadID)
+	if got != "" {
+		t.Fatalf("derivedResumeSessionKey(codex) = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- read Codex SessionStart hook stdin even when GC_SESSION_ID is set
- persist stdin session_id as session_key only for Codex-family session beads
- remove Codex transcript filename resume-key derivation while keeping non-Codex history-derived resume backstops

## Tests
- go test ./cmd/gc -run 'TestDoPrimeCodexHookPersistsProviderSessionKeyFromHookStdin|TestDoPrimeHookIgnoresProviderSessionKeyFromHookStdinForNonCodex|TestDoPrimeGeminiHookPersistsProviderSessionKey|TestDoPrimeHookPersistsGenericProviderSessionKey' -count=1\n- go test ./internal/worker -run 'TestDerivedResumeSessionKey|TestSessionHandleHistoryDoesNotPersistCodexResumeKeyFromTranscript|TestSessionHandleStateDoesNotPersistCodexResumeKeyWithoutPrimingHistoryCache' -count=1\n- go test ./cmd/gc -count=1\n- go test ./internal/worker -count=1\n- make test-fast-parallel\n- go vet ./...\n- .githooks/pre-commit\n