### PR TITLE
fix(dolt-health): honor live-set so live rig DBs aren't orphans

### DIFF
--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -167,19 +167,18 @@ if [ -d "$data_dir" ] && [ "$server_reachable" = true ]; then
     case "$commits" in
       ''|*[!0-9]*) commits=0 ;;
     esac
-    # Count open beads (best-effort).
-    open_beads=0
-    while IFS= read -r meta; do
-      [ -f "$meta" ] || continue
-      db=$(metadata_db "$meta")
-      if [ "$db" = "$name" ]; then
-        beads_dir="$(dirname "$meta")"
-        if [ -f "$beads_dir/beads.jsonl" ]; then
-          open_beads=$(grep -c '"status":"open"' "$beads_dir/beads.jsonl" 2>/dev/null || echo 0)
-        fi
-        break
-      fi
-    done < "$_meta_cache"
+    # Count open beads from the running server (authoritative). Under managed
+    # Dolt the beads live in the server's `issues` table, not an on-disk
+    # beads.jsonl — that file is absent or stale, so the old file grep reported
+    # open_beads=0 for every live database (#3200). 0 on timeout, error, or a
+    # database without an `issues` table (a non-beads DB) — same fail-soft
+    # contract as the commit count above.
+    open_csv=$(run_bounded 5 dolt $conn_args sql --result-format csv \
+      -q "USE \`$name\`; SELECT COUNT(*) FROM issues WHERE status='open';" 2>/dev/null || true)
+    open_beads=$(printf '%s\n' "$open_csv" | grep -E '^[0-9]+$' | head -1)
+    case "$open_beads" in
+      ''|*[!0-9]*) open_beads=0 ;;
+    esac
     db_info="$db_info$name|$commits|$open_beads
 "
   done
@@ -205,20 +204,56 @@ if [ -n "$newest_backup" ]; then
 fi
 
 # Find orphan databases.
+#
+# Authoritative source: `gc dolt-cleanup` (HYPHEN — the Go-side command,
+# dry-run by default, rig-protected). Its dry-run drop candidates
+# (`dropped.names`) are the real orphans: every registered rig DB is excluded
+# via city config, so a live rig DB is never listed. The previous
+# metadata-only scan flagged every live rig DB as an orphan whenever a rig's
+# metadata.json was sparse or unreachable (e.g. externally-pathed rigs) — a
+# false positive the deacon patrol could act on destructively (#3200). Reuse
+# the cleanup authority; fall back to the metadata scan only when gc/jq are
+# unavailable (gc itself may be the failure this patrol is detecting).
 orphan_list=""
 orphan_count=0
 if [ -d "$data_dir" ]; then
-  referenced=""
-  while IFS= read -r meta; do
-    [ -f "$meta" ] || continue
-    db=$(metadata_db "$meta")
-    [ -n "$db" ] && referenced="$referenced $db "
-  done < "$_meta_cache"
-  for d in "$data_dir"/*/; do
-    [ ! -d "$d/.dolt" ] && continue
-    name="$(basename "$d")"
-    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
-    case "$referenced" in *" $name "*) continue ;; esac
+  orphan_names=""
+  cleanup_ok=false
+  if command -v gc >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    cleanup_json=$(run_bounded 10 gc dolt-cleanup --json 2>/dev/null) || true
+    if [ -n "$cleanup_json" ] && printf '%s' "$cleanup_json" | jq -e '.dropped.names' >/dev/null 2>&1; then
+      orphan_names=$(printf '%s' "$cleanup_json" | jq -r '.dropped.names[]? // empty' 2>/dev/null)
+      cleanup_ok=true
+    fi
+  fi
+
+  if [ "$cleanup_ok" != true ]; then
+    # Fallback: approximate orphans from rig metadata (every DB whose name is
+    # not referenced by a rig's metadata.json dolt_database). Less reliable
+    # than the cleanup authority — used only when gc/jq are unavailable.
+    referenced=""
+    while IFS= read -r meta; do
+      [ -f "$meta" ] || continue
+      db=$(metadata_db "$meta")
+      [ -n "$db" ] && referenced="$referenced $db "
+    done < "$_meta_cache"
+    for d in "$data_dir"/*/; do
+      [ ! -d "$d/.dolt" ] && continue
+      name="$(basename "$d")"
+      case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
+      case "$referenced" in *" $name "*) continue ;; esac
+      orphan_names="$orphan_names$name
+"
+    done
+  fi
+
+  # Materialize the orphan list with on-disk sizes, from whichever source
+  # produced the names. Only names that still exist as a Dolt database
+  # directory are reported.
+  for name in $orphan_names; do
+    [ -n "$name" ] || continue
+    d="$data_dir/$name"
+    [ -d "$d/.dolt" ] || continue
     size_kb=$(du -sk "$d" 2>/dev/null | cut -f1)
     size_bytes=$(( ${size_kb:-0} * 1024 ))
     if [ "$size_bytes" -ge 1048576 ]; then

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -213,6 +213,103 @@ func TestHealthScriptDoesNotInvokeDoltLog(t *testing.T) {
 	}
 }
 
+// TestHealthOrphansFromCleanupAuthority pins #3200: the orphan list is
+// sourced from `gc dolt-cleanup --json` (.dropped.names), the rig-protected
+// dry-run authority — never from health's own metadata scan, which flagged
+// every live rig DB as an orphan when rig metadata was sparse/unreachable. A
+// live rig DB present on disk but absent from dropped.names must NOT appear in
+// orphans (acting on that false positive could delete a live rig ledger).
+func TestHealthOrphansFromCleanupAuthority(t *testing.T) {
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed; skipping")
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; skipping")
+	}
+	if _, errT := exec.LookPath("timeout"); errT != nil {
+		if _, errG := exec.LookPath("gtimeout"); errG != nil {
+			t.Skip("neither timeout nor gtimeout installed; skipping")
+		}
+	}
+
+	// TCP-reachable but never speaks MySQL → server.reachable=false, so the
+	// per-database (open_beads) probe is skipped and we exercise the orphan
+	// path in isolation.
+	port, cleanup := startDeadTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	// Dolt data dir: three live rig DBs plus one genuine orphan.
+	dataDir := t.TempDir()
+	for _, db := range []string{"hq", "gco", "tga", "stale_orphan"} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir db %s: %v", db, err)
+		}
+	}
+
+	// Stub `gc` on PATH. `gc dolt-cleanup --json` returns the rig-protected
+	// dry-run authority: stale_orphan is the only drop candidate; the live rig
+	// DBs are protected. Any other gc call (e.g. `gc rig list`) is a no-op.
+	binDir := t.TempDir()
+	stub := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"dolt-cleanup\" ]; then\n" +
+		"  printf '%s' '{\"ok\":true,\"rigs_protected\":[{\"rig\":\"gchq\",\"db\":\"hq\"},{\"rig\":\"gco\",\"db\":\"gco\"},{\"rig\":\"tga\",\"db\":\"tga\"}],\"dropped\":{\"count\":1,\"names\":[\"stale_orphan\"]}}'\n" +
+		"fi\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gc"), []byte(stub), 0o755); err != nil {
+		t.Fatalf("write gc stub: %v", err)
+	}
+
+	root := repoRoot(t)
+	script := filepath.Join(root, healthScript)
+	cmd := exec.Command("sh", script, "--json")
+	cmd.Env = append(filteredEnv("GC_DOLT_PORT", "PATH", "GC_DOLT_DATA_DIR"),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+strconv.Itoa(port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_HEALTH_SKIP_ZOMBIE_SCAN=1",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("health.sh --json failed: %v\n%s", err, out)
+	}
+
+	var report struct {
+		Orphans []struct {
+			Name string `json:"name"`
+		} `json:"orphans"`
+	}
+	if err := json.Unmarshal(out, &report); err != nil {
+		t.Fatalf("parse health JSON: %v\n%s", err, out)
+	}
+	got := make([]string, 0, len(report.Orphans))
+	for _, o := range report.Orphans {
+		got = append(got, o.Name)
+	}
+	if len(got) != 1 || got[0] != "stale_orphan" {
+		t.Errorf("orphans = %v, want [stale_orphan] (from cleanup authority)", got)
+	}
+	for _, o := range got {
+		switch o {
+		case "hq", "gco", "tga":
+			t.Errorf("live rig DB %q misclassified as orphan", o)
+		}
+	}
+}
+
 func TestRuntimeScriptPortPrecedence(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -319,7 +319,7 @@ are wedged (the latter is what first prompted this check to exist).
 | `databases[].commits > 50000` | 50 k | Compactor dog may have stalled |
 | `backups.dolt_stale == true` | >30 min | Backup dog may have failed |
 | `processes.zombie_count > 0` | any | Zombie Dolt servers detected |
-| `orphans` non-empty | any | Orphan databases accumulating |
+| `orphans` non-empty | any | Advisory only — NEVER act on this count directly; verify with `gc dolt-cleanup` (hyphen, dry-run) first |
 
 **Step 3: React to alerts**
 
@@ -352,12 +352,26 @@ Kill zombie Dolt servers not on the expected port:
 kill <zombie_pid>
 ```
 
-**Orphan DBs:**
-Run cleanup:
+**Orphan DBs (`orphans` non-empty):**
+Do NOT act on the health `orphans` count directly — the reporter can
+false-positive live rig databases as orphans, and a forced removal on that
+count would destroy a live rig ledger (unrecoverable). Confirm against the
+rig-protected dry-run authority first:
 ```bash
-gc dolt cleanup
+gc dolt-cleanup --json    # hyphen, Go-side: dry-run, rig-protected
 ```
-If orphan count exceeds safety limit, escalate to mayor.
+Real orphans are exactly the databases it lists under `dropped.names`
+(`rigs_protected` are already excluded). If `dropped.names` is empty, there
+is nothing to clean — the health `orphans` entries are live rig DBs (a
+reporter false-positive); log and move on. `gc dolt-cleanup` (hyphen,
+the Go-side command) is dry-run by default; removal happens only under
+`--force`. Do NOT rely on the `gc dolt cleanup` (space) pack-script's
+defaults — always use the hyphen command for orphan inspection/cleanup.
+Reclaim confirmed orphans only via human-approved
+`gc dolt-cleanup --force` escalated to mayor — never run a destructive
+`--force` automatically from this step, and never
+`gc dolt cleanup --force --server-down-ok` against a reachable server (it can
+`rm -rf` an open database and corrupt NBS, #1549).
 
 **If everything is healthy:**
 Log `Dolt health: OK` and move on.


### PR DESCRIPTION
## Summary

`gc dolt health --json` misclassified **live, registered rig databases** as
orphans and reported `open_beads=0` for every rig DB on a managed-Dolt city.
Because the deacon patrol keys a cleanup action off that orphans count, the
false positive was a latent data-loss path.

`gc dolt-cleanup` (hyphen, Go-side, dry-run default) classifies the same
databases correctly (`would_drop=0`, all rigs protected) — so the bug was
isolated to the `gc dolt health` reporter, not the data.

## Changes

**Reporter (`examples/dolt/commands/health/run.sh`):**
- **Orphans** now come from the authoritative `gc dolt-cleanup --json`
  `.dropped.names` (the rig-protected, dry-run-by-default authority that
  already excludes every registered rig DB), with a bounded call and a
  fallback to the previous metadata scan only when `gc`/`jq` are unavailable.
  The old metadata-only scan flagged every live rig DB as an orphan whenever a
  rig's `metadata.json` was sparse or unreachable (externally-pathed rigs).
- **open_beads** is now counted from the running server
  (`SELECT COUNT(*) FROM issues WHERE status='open'`) instead of an on-disk
  `beads.jsonl` that managed Dolt never writes (so the old grep always
  returned 0). Fails soft to 0 on timeout / a DB without an `issues` table.

**Patrol guidance (`examples/gastown/.../mol-deacon-patrol.toml`):**
- The deacon `dolt-health` step no longer runs `gc dolt cleanup` (the space
  form — an import subcommand that deletes immediately, no dry-run) on the
  health orphans count. It now verifies via `gc dolt-cleanup` (hyphen,
  dry-run, rig-protected), acts only on confirmed `dropped.names`, and
  reclaims only via human-approved `gc dolt-cleanup --force`.

The health JSON shape is unchanged (`orphans[].{name,size}`,
`databases[].{name,commits,open_beads}`).

## Tests

- `examples/dolt/health_test.go`: new `TestHealthOrphansFromCleanupAuthority`
  stubs `gc dolt-cleanup --json` and asserts orphans come from its
  `dropped.names` (live rig DBs never misclassified). Existing
  `TestHealthScriptIsBounded` / `TestHealthScriptDoesNotInvokeDoltLog` stay
  green (the new open-beads count uses `issues`, not `dolt log`).
- Verified against a live multi-rig city: `orphans=[]` (was every rig DB),
  `open_beads` real (hq=122, gco=52, ggp=36, cc=8, tga=6, bds=2, sc=1).

## Out of scope

The same reporter's liveness false-negative (`server.reachable=false` while
`SELECT 1` succeeds) is tracked separately, not addressed here.

## Rebase / reconciliation note

This branch was rebased onto current `main`, which includes #3156
(`feat(formulas): replace sleep backoff with clean idle exit in patrol
formulas`). #3156 edits the same `mol-deacon-patrol.toml`, in a different
region:
- **#3156 (base):** the patrol-loop / next-iteration step — replaces the
  in-prompt `sleep {{event_timeout}}` with a clean `IDLE: no work, exiting
  turn.` exit (burn-before-exit; `gc hook` re-entry removed).
- **This PR (delta):** the `dolt-health` step's "Orphan DBs" reaction +
  threshold row only.

The two are non-overlapping and both survive verbatim: the deacon still
idle-exits per #3156, and the dolt-health step now carries the corrected
cleanup-gate guidance. `go test ./examples/gastown/...` (which exercises
#3156's `TestDeaconPatrolNextIterationBurnsCurrentBeforeIdleExit`) and the
dolt-health suite both pass on the rebased base.

Note: an earlier draft of the patrol guidance and commit message wrongly
described `gc dolt cleanup` (space) as "deletes immediately, no dry-run."
Corrected here — both `gc dolt cleanup` (space) and `gc dolt-cleanup`
(hyphen) are dry-run by default; only `--force` removes (and
`--force --server-down-ok` against a reachable server can `rm -rf` an open
DB, #1549). The guidance now warns against the destructive `--force` forms.

Closes #3200.
