### PR TITLE
fix(reaper): use split dependency target columns

### DIFF
--- a/examples/gastown/maintenance_scripts_dolt_integration_test.go
+++ b/examples/gastown/maintenance_scripts_dolt_integration_test.go
@@ -163,12 +163,16 @@ CREATE TABLE issues (
 );
 CREATE TABLE dependencies (
   issue_id VARCHAR(64),
-  depends_on_id VARCHAR(64),
+  depends_on_issue_id VARCHAR(64),
+  depends_on_wisp_id VARCHAR(64),
+  depends_on_external VARCHAR(64),
   type VARCHAR(32)
 );
 CREATE TABLE wisp_dependencies (
   issue_id VARCHAR(64),
-  depends_on_id VARCHAR(64),
+  depends_on_issue_id VARCHAR(64),
+  depends_on_wisp_id VARCHAR(64),
+  depends_on_external VARCHAR(64),
   type VARCHAR(32)
 );
 CREATE TABLE labels (
@@ -195,7 +199,7 @@ INSERT INTO wisps (id, title, status, issue_type, priority, created_at, updated_
   ('wisp-nested-root', 'nested root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
   ('wisp-subroot', 'nested subroot', 'closed', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.root_bead_id":"wisp-nested-root"}'),
   ('wisp-live-grandchild', 'live nested child', 'in_progress', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{}');
-INSERT INTO wisp_dependencies (issue_id, depends_on_id, type) VALUES
+INSERT INTO wisp_dependencies (issue_id, depends_on_wisp_id, type) VALUES
   ('wisp-subroot', 'wisp-nested-root', 'tracks'),
   ('wisp-live-grandchild', 'wisp-subroot', 'tracks');
 INSERT INTO issues (id, title, status, issue_type, priority, created_at, updated_at, assignee, metadata) VALUES
@@ -206,7 +210,7 @@ INSERT INTO issues (id, title, status, issue_type, priority, created_at, updated
   ('issue-non-root-workflow', 'non-root issue topology bead preserved', 'open', 'task', 1, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow","gc.root_bead_id":"issue-dep-root"}'),
   ('issue-dep-root', 'dependency-protected issue root', 'open', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{"gc.kind":"workflow"}'),
   ('issue-dep-live', 'live issue dependency child', 'in_progress', 'task', 2, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '', '{}');
-INSERT INTO dependencies (issue_id, depends_on_id, type) VALUES
+INSERT INTO dependencies (issue_id, depends_on_issue_id, type) VALUES
   ('issue-dep-live', 'issue-dep-root', 'blocks');
 `
 }

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	reaperCloseCleanupEdgeSQL   = "(d.type = 'parent-child' OR (d.type = 'tracks' AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_bead_id\"')) = d.depends_on_id))"
+	reaperCloseCleanupEdgeSQL   = "(d.type = 'parent-child' OR (d.type = 'tracks' AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_bead_id\"')) = COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)))"
 	reaperPurgeProtectEdgeSQL   = "d.type IN ('parent-child', 'tracks', 'blocks')"
 	reaperCloseCleanupPredicate = "WISP_CLOSE_EDGE_PREDICATE="
 	reaperPurgeProtectTypes     = "WISP_PURGE_PROTECT_EDGE_TYPES="
@@ -3089,8 +3089,8 @@ func TestReaperFormulaSQLReflectsCurrentSchema(t *testing.T) {
 		if strings.Contains(fence, "parent_id") {
 			t.Errorf("formula sql fence %d references parent_id (column does not exist in wisps):\n%s", i, fence)
 		}
-		if strings.Contains(fence, "depends_on_wisp_id") || strings.Contains(fence, "depends_on_issue_id") {
-			t.Errorf("formula sql fence %d references split dependency target columns; bd 1.0.4 uses depends_on_id:\n%s", i, fence)
+		if strings.Contains(fence, "depends_on_id") && !strings.Contains(fence, "depends_on_issue_id") && !strings.Contains(fence, "depends_on_wisp_id") {
+			t.Errorf("formula sql fence %d references removed depends_on_id column; schema uses typed split columns:\n%s", i, fence)
 		}
 		if strings.Contains(fence, "LEFT JOIN wisps parent ON") {
 			t.Errorf("formula sql fence %d still has the broken parent self-join:\n%s", i, fence)
@@ -3198,9 +3198,9 @@ exit 0
 	if strings.Contains(log, "parent_id") {
 		t.Errorf("reaper SQL references parent_id (column does not exist in wisps):\n%s", log)
 	}
-	for _, notWant := range []string{"depends_on_wisp_id", "depends_on_issue_id"} {
-		if strings.Contains(log, notWant) {
-			t.Errorf("reaper SQL references split dependency target column %q; bd 1.0.4 uses depends_on_id:\n%s", notWant, log)
+	for _, want := range []string{"depends_on_wisp_id", "depends_on_issue_id"} {
+		if !strings.Contains(log, want) {
+			t.Errorf("reaper SQL missing split dependency target column %q; schema uses typed columns:\n%s", want, log)
 		}
 	}
 	// mail was removed: not a SQL table; messages are beads with type=message.
@@ -3211,7 +3211,7 @@ exit 0
 		"SHOW COLUMNS FROM `beads`.dependencies",
 		"SHOW COLUMNS FROM `beads`.wisp_dependencies",
 		"FROM `beads`.wisp_dependencies d",
-		"SELECT DISTINCT d.depends_on_id",
+		"SELECT DISTINCT d.depends_on_wisp_id",
 	} {
 		if !strings.Contains(log, want) {
 			t.Errorf("reaper SQL missing %q:\n%s", want, log)
@@ -3242,7 +3242,7 @@ exit 0
 		purgeSQL := log[purgeIdx:]
 		if !strings.Contains(purgeSQL, "child_wisp.status IN ('open', 'hooked', 'in_progress')") ||
 			!containsReaperPurgeProtectEdgePredicate(purgeSQL) ||
-			!strings.Contains(purgeSQL, "SELECT DISTINCT d.depends_on_id") {
+			!strings.Contains(purgeSQL, "SELECT DISTINCT d.depends_on_wisp_id") {
 			t.Errorf("reaper purge can delete closed parents with non-closed children:\n%s", purgeSQL)
 		}
 	}
@@ -3293,7 +3293,7 @@ exit 0
 		t.Fatalf("reaper did not probe dependency target columns:\n%s", log)
 	}
 	if strings.Contains(log, "FROM `beads`.wisp_dependencies d") || strings.Contains(log, "JOIN `beads`.wisp_dependencies d") {
-		t.Fatalf("reaper ran dependency-aware queries against schema without depends_on_id:\n%s", log)
+		t.Fatalf("reaper ran dependency-aware queries against schema without typed dependency target columns:\n%s", log)
 	}
 
 	// A silently-skipped DB may make no gc calls at all, so a missing
@@ -3302,7 +3302,7 @@ exit 0
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
-	if strings.Contains(string(gcData), "dependencies table lacks depends_on_id") {
+	if strings.Contains(string(gcData), "dependencies table lacks") {
 		t.Errorf("reaper escalated the dependency schema as an anomaly; the target-column gate must skip silently:\n%s", gcData)
 	}
 }
@@ -3353,6 +3353,72 @@ exit 0
 	}
 	if strings.Contains(string(gcData), "wisp_dependencies") {
 		t.Errorf("reaper escalated the missing wisp dependency table as an anomaly; the schema gate must skip silently:\n%s", gcData)
+	}
+}
+
+func TestReaperSplitSchemaQueriesUseSplitColumns(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":               doltLog,
+		"GC_CALL_LOG":                 gcLog,
+		"DOLT_DBS":                    "beads",
+		"DOLT_DEPENDENCY_SCHEMA":      "split",
+		"DOLT_WISP_DEPENDENCY_SCHEMA": "split",
+		"GC_CITY":                     cityDir,
+		"GC_CITY_PATH":                cityDir,
+		"GC_DOLT_HOST":                "127.0.0.1",
+		"GC_DOLT_PORT":                "3307",
+		"GC_DOLT_USER":                "root",
+		"GC_DOLT_PASSWORD":            "",
+		"DOLT_PURGE_COUNT":            "1",
+		"PATH":                        binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+
+	for _, want := range []string{
+		"SHOW COLUMNS FROM `beads`.dependencies",
+		"SHOW COLUMNS FROM `beads`.wisp_dependencies",
+		"FROM `beads`.wisp_dependencies d",
+	} {
+		if !strings.Contains(log, want) {
+			t.Errorf("reaper split-schema log missing %q:\n%s", want, log)
+		}
+	}
+
+	for _, splitCol := range []string{"depends_on_issue_id", "depends_on_wisp_id"} {
+		if !strings.Contains(log, splitCol) {
+			t.Errorf("reaper split-schema log missing split column %q:\n%s", splitCol, log)
+		}
+	}
+
+	// With split schema, queries against dependencies must not use the removed depends_on_id column.
+	// Filter out SHOW COLUMNS lines (which contain the table name, not the column reference in queries).
+	var queryLines []string
+	for _, line := range strings.Split(log, "\n") {
+		if !strings.Contains(line, "SHOW COLUMNS") {
+			queryLines = append(queryLines, line)
+		}
+	}
+	queryLog := strings.Join(queryLines, "\n")
+	if strings.Contains(queryLog, "d.depends_on_id") {
+		t.Errorf("reaper split-schema queries reference removed column d.depends_on_id:\n%s", queryLog)
 	}
 }
 
@@ -4203,8 +4269,8 @@ exit 0
 	if !strings.Contains(log, "wisp_dependencies d") || !containsReaperCloseCleanupEdgePredicate(log) {
 		t.Fatalf("reaper stale-wisp close path does not use graph cleanup-edge dependencies:\n%s", log)
 	}
-	if !strings.Contains(log, "d.depends_on_id = parent_wisp.id") || !strings.Contains(log, "d.depends_on_id = parent_issue.id") {
-		t.Fatalf("reaper stale-wisp close path does not use bd 1.0.4 dependency target column:\n%s", log)
+	if !strings.Contains(log, "d.depends_on_wisp_id = parent_wisp.id") || !strings.Contains(log, "d.depends_on_issue_id = parent_issue.id") {
+		t.Fatalf("reaper stale-wisp close path does not use typed dependency target columns:\n%s", log)
 	}
 	if strings.Contains(log, "parent_wisp.id IS NULL AND parent_issue.id IS NULL") {
 		t.Fatalf("reaper closes stale wisps when parent liveness is unresolved:\n%s", log)
@@ -4286,7 +4352,9 @@ case "$*" in
   *"SHOW COLUMNS FROM"*"dependencies"*)
     printf 'Field,Type,Null,Key,Default,Extra\n'
     printf 'issue_id,varchar,NO,,,\n'
-    printf 'depends_on_id,varchar,NO,,,\n'
+    printf 'depends_on_issue_id,varchar,YES,,,\n'
+    printf 'depends_on_wisp_id,varchar,YES,,,\n'
+    printf 'depends_on_external,varchar,YES,,,\n'
     printf 'type,varchar,NO,,,\n'
     ;;
   *"WITH RECURSIVE workflow_wisp_root_candidates"*"UPDATE "*"wisps SET status='closed'"*"JSON_SET(COALESCE(metadata, JSON_OBJECT())"*)
@@ -4371,8 +4439,8 @@ exit 0
 		"descendant_wisp.status, descendant_issue.status) IN ('open', 'hooked', 'in_progress', 'blocked', 'deferred', 'pinned', 'review', 'testing')",
 		"roots_with_recent_descendants",
 		"child_dep.type IN ('parent-child', 'tracks', 'blocks')",
-		"child_dep.depends_on_id = root.id",
-		"child_dep.depends_on_id = parent.id",
+		"COALESCE(child_dep.depends_on_issue_id, child_dep.depends_on_wisp_id, child_dep.depends_on_external) = root.id",
+		"COALESCE(child_dep.depends_on_issue_id, child_dep.depends_on_wisp_id, child_dep.depends_on_external) = parent.id",
 		"workflow_roots=2",
 	} {
 		if !strings.Contains(log, want) {
@@ -4436,7 +4504,9 @@ case "$*" in
   *"SHOW COLUMNS FROM"*"dependencies"*)
     printf 'Field,Type,Null,Key,Default,Extra\n'
     printf 'issue_id,varchar,NO,,,\n'
-    printf 'depends_on_id,varchar,NO,,,\n'
+    printf 'depends_on_issue_id,varchar,YES,,,\n'
+    printf 'depends_on_wisp_id,varchar,YES,,,\n'
+    printf 'depends_on_external,varchar,YES,,,\n'
     printf 'type,varchar,NO,,,\n'
     ;;
   *"WITH RECURSIVE workflow_wisp_root_candidates"*"SELECT COUNT(*) FROM ("*)
@@ -4529,7 +4599,9 @@ case "$*" in
   *"SHOW COLUMNS FROM"*"dependencies"*)
     printf 'Field,Type,Null,Key,Default,Extra\n'
     printf 'issue_id,varchar,NO,,,\n'
-    printf 'depends_on_id,varchar,NO,,,\n'
+    printf 'depends_on_issue_id,varchar,YES,,,\n'
+    printf 'depends_on_wisp_id,varchar,YES,,,\n'
+    printf 'depends_on_external,varchar,YES,,,\n'
     printf 'type,varchar,NO,,,\n'
     ;;
   *"WITH RECURSIVE workflow_wisp_root_candidates"*"SELECT COUNT(*) FROM ("*)
@@ -6544,7 +6616,7 @@ case "$*" in
   ;;
 *"SHOW COLUMNS FROM"*"dependencies"*)
   printf 'Field,Type,Null,Key,Default,Extra\n'
-  dependency_schema="${DOLT_DEPENDENCY_SCHEMA:-generic}"
+  dependency_schema="${DOLT_DEPENDENCY_SCHEMA:-split}"
   case "$*" in
     *"wisp_dependencies"*) dependency_schema="${DOLT_WISP_DEPENDENCY_SCHEMA:-$dependency_schema}" ;;
   esac
@@ -6562,7 +6634,9 @@ case "$*" in
     printf 'type,varchar,NO,,,\n'
   else
     printf 'issue_id,varchar,NO,,,\n'
-    printf 'depends_on_id,varchar,NO,,,\n'
+    printf 'depends_on_issue_id,varchar,YES,,,\n'
+    printf 'depends_on_wisp_id,varchar,YES,,,\n'
+    printf 'depends_on_external,varchar,YES,,,\n'
     printf 'type,varchar,NO,,,\n'
   fi
   ;;
@@ -6625,7 +6699,9 @@ case "$*" in
 *"SHOW COLUMNS FROM"*"dependencies"*)
   printf 'Field,Type,Null,Key,Default,Extra\n'
   printf 'issue_id,varchar,NO,,,\n'
-  printf 'depends_on_id,varchar,NO,,,\n'
+  printf 'depends_on_issue_id,varchar,YES,,,\n'
+  printf 'depends_on_wisp_id,varchar,YES,,,\n'
+  printf 'depends_on_external,varchar,YES,,,\n'
   printf 'type,varchar,NO,,,\n'
   ;;
 *"UPDATE "*"wisps SET status='closed'"*)

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -30,7 +30,7 @@ MAIL_ALERT_THRESHOLD="${GC_REAPER_MAIL_ALERT_THRESHOLD:-0}"  # 0 = disabled
 DRY_RUN="${GC_REAPER_DRY_RUN:-}"
 # Closing follows only ownership edges. `blocks` is sequencing, not ownership;
 # purge protection may include it because that only prevents deletion.
-WISP_CLOSE_EDGE_PREDICATE="(d.type = 'parent-child' OR (d.type = 'tracks' AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_bead_id\"')) = d.depends_on_id))"
+WISP_CLOSE_EDGE_PREDICATE="(d.type = 'parent-child' OR (d.type = 'tracks' AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.root_bead_id\"')) = COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)))"
 WISP_PURGE_PROTECT_EDGE_TYPES="'parent-child', 'tracks', 'blocks'"
 WORKFLOW_ROOT_CLOSE_STATUSES="'open', 'hooked', 'in_progress'"
 WORKFLOW_ROOT_LIVE_STATUSES="'open', 'hooked', 'in_progress', 'blocked', 'deferred', 'pinned', 'review', 'testing'"
@@ -491,7 +491,9 @@ has_dependency_target_column() {
     fi
 
     printf '%s\n' "$fields" | grep -qx 'issue_id' || return 1
-    printf '%s\n' "$fields" | grep -qx 'depends_on_id' || return 1
+    printf '%s\n' "$fields" | grep -qx 'depends_on_issue_id' || return 1
+    printf '%s\n' "$fields" | grep -qx 'depends_on_wisp_id' || return 1
+    printf '%s\n' "$fields" | grep -qx 'depends_on_external' || return 1
 }
 
 workflow_root_candidates_cte() {
@@ -540,28 +542,28 @@ $(workflow_root_store_ref_local_condition "$db" "$alias")
             FROM $candidate_cte root
             INNER JOIN \`$db\`.wisp_dependencies child_dep
                 ON child_dep.type IN ($WORKFLOW_ROOT_DESCENDANT_DEP_TYPES)
-                AND child_dep.depends_on_id = root.id
+                AND COALESCE(child_dep.depends_on_issue_id, child_dep.depends_on_wisp_id, child_dep.depends_on_external) = root.id
                 AND child_dep.issue_id != root.id
             UNION
             SELECT root.id, child_dep.issue_id
             FROM $candidate_cte root
             INNER JOIN \`$db\`.dependencies child_dep
                 ON child_dep.type IN ($WORKFLOW_ROOT_DESCENDANT_DEP_TYPES)
-                AND child_dep.depends_on_id = root.id
+                AND COALESCE(child_dep.depends_on_issue_id, child_dep.depends_on_wisp_id, child_dep.depends_on_external) = root.id
                 AND child_dep.issue_id != root.id
             UNION
             SELECT parent.root_id, child_dep.issue_id
             FROM workflow_descendants parent
             INNER JOIN \`$db\`.wisp_dependencies child_dep
                 ON child_dep.type IN ($WORKFLOW_ROOT_DESCENDANT_DEP_TYPES)
-                AND child_dep.depends_on_id = parent.id
+                AND COALESCE(child_dep.depends_on_issue_id, child_dep.depends_on_wisp_id, child_dep.depends_on_external) = parent.id
                 AND child_dep.issue_id != parent.id
             UNION
             SELECT parent.root_id, child_dep.issue_id
             FROM workflow_descendants parent
             INNER JOIN \`$db\`.dependencies child_dep
                 ON child_dep.type IN ($WORKFLOW_ROOT_DESCENDANT_DEP_TYPES)
-                AND child_dep.depends_on_id = parent.id
+                AND COALESCE(child_dep.depends_on_issue_id, child_dep.depends_on_wisp_id, child_dep.depends_on_external) = parent.id
                 AND child_dep.issue_id != parent.id
         ),
         roots_with_live_descendants AS (
@@ -759,8 +761,8 @@ while IFS= read -r DB; do
             INNER JOIN \`$DB\`.wisp_dependencies d
                 ON d.issue_id = w.id
                 AND $WISP_CLOSE_EDGE_PREDICATE
-            LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
-            LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
+            LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
+            LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_issue_id = parent_issue.id
             WHERE w.status IN ('open', 'hooked', 'in_progress')
             AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
             AND (
@@ -787,8 +789,8 @@ while IFS= read -r DB; do
                     INNER JOIN \`$DB\`.wisp_dependencies d
                         ON d.issue_id = w.id
                         AND $WISP_CLOSE_EDGE_PREDICATE
-                    LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
-                    LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
+                    LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
+                    LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_issue_id = parent_issue.id
                     WHERE w.status IN ('open', 'hooked', 'in_progress')
                     AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
                     AND (
@@ -872,7 +874,7 @@ while IFS= read -r DB; do
         WHERE status = 'closed'
         AND closed_at < DATE_SUB(NOW(), INTERVAL $PURGE_AGE_H HOUR)
         AND id NOT IN (
-            SELECT DISTINCT d.depends_on_id FROM \`$DB\`.wisp_dependencies d
+            SELECT DISTINCT d.depends_on_wisp_id FROM \`$DB\`.wisp_dependencies d
             INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
             WHERE d.type IN ($WISP_PURGE_PROTECT_EDGE_TYPES)
             AND child_wisp.status IN ('open', 'hooked', 'in_progress')
@@ -886,7 +888,7 @@ while IFS= read -r DB; do
             WHERE status = 'closed'
             AND closed_at < DATE_SUB(NOW(), INTERVAL $PURGE_AGE_H HOUR)
             AND id NOT IN (
-                SELECT DISTINCT d.depends_on_id FROM \`$DB\`.wisp_dependencies d
+                SELECT DISTINCT d.depends_on_wisp_id FROM \`$DB\`.wisp_dependencies d
                 INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
                 WHERE d.type IN ($WISP_PURGE_PROTECT_EDGE_TYPES)
                 AND child_wisp.status IN ('open', 'hooked', 'in_progress')
@@ -987,10 +989,10 @@ while IFS= read -r DB; do
         )
         AND id NOT IN (
             SELECT DISTINCT d.issue_id FROM \`$DB\`.dependencies d
-            INNER JOIN \`$DB\`.issues i ON d.depends_on_id = i.id
+            INNER JOIN \`$DB\`.issues i ON d.depends_on_issue_id = i.id
             WHERE i.status IN ('open', 'in_progress')
             UNION
-            SELECT DISTINCT d.depends_on_id FROM \`$DB\`.dependencies d
+            SELECT DISTINCT d.depends_on_issue_id FROM \`$DB\`.dependencies d
             INNER JOIN \`$DB\`.issues i ON d.issue_id = i.id
             WHERE i.status IN ('open', 'in_progress')
         )

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -42,10 +42,11 @@ Mail is NOT a SQL table — mail messages are beads (Type=message). Any
 mail cleanup must go through `bd`, never Dolt. BD-backed mail retention is
 tracked separately as `ga-w9jfl5`; until that lands, Reaper intentionally does
 not delete mail. Wisp parentage is no longer carried on the wisps row; it
-lives in `wisp_dependencies` rows with `type='parent-child'` and a
-`depends_on_id` target column in the bd 1.0.4 schema. Graph-v2 workflow wisps
-are owned through `tracks` edges from the child to the workflow root, with the
-child's `gc.root_bead_id` metadata matching `depends_on_id`. For the
+lives in `wisp_dependencies` rows with `type='parent-child'` and the split
+typed target columns (`depends_on_issue_id`, `depends_on_wisp_id`,
+`depends_on_external`). Graph-v2 workflow wisps are owned through `tracks`
+edges from the child to the workflow root, with the child's `gc.root_bead_id`
+metadata matching the typed target via COALESCE. For the
 Dolt-backed bead store, `ParentID` is a projection from parent-child
 dependencies, not a separate `parent_id` column for Reaper to query.
 Non-closed wisps without an ownership signal are reported only; they are not
@@ -175,11 +176,11 @@ INNER JOIN wisp_dependencies d
     d.type = 'parent-child'
     OR (
       d.type = 'tracks'
-      AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$."gc.root_bead_id"')) = d.depends_on_id
+      AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$."gc.root_bead_id"')) = COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)
     )
   )
-LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
-LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
+LEFT JOIN wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
+LEFT JOIN issues parent_issue ON d.depends_on_issue_id = parent_issue.id
 WHERE w.status IN ('open', 'hooked', 'in_progress')
 AND w.created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
 AND (
@@ -194,7 +195,7 @@ SELECT COUNT(*) FROM wisps
 WHERE status = 'closed'
 AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
 AND id NOT IN (
-  SELECT DISTINCT d.depends_on_id FROM wisp_dependencies d
+  SELECT DISTINCT d.depends_on_wisp_id FROM wisp_dependencies d
   INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
   WHERE d.type IN ('parent-child', 'tracks', 'blocks')
   AND child_wisp.status IN ('open', 'hooked', 'in_progress')
@@ -229,10 +230,12 @@ ownership dependency points to a closed parent or workflow root.
 
 Wisp parentage no longer lives on the wisps row (the schema has no
 `parent_id` column); parentage is in `wisp_dependencies` rows with
-`type='parent-child'` and `depends_on_id`. The SDK `ParentID` field is
+`type='parent-child'` and the typed target columns (`depends_on_issue_id`,
+`depends_on_wisp_id`, `depends_on_external`). The SDK `ParentID` field is
 projected from those rows for Dolt-backed beads. Graph-v2 workflow ownership
 uses a `tracks` edge from the child to the root and must match the child's
-`gc.root_bead_id` metadata. Do not close non-closed wisps by age alone.
+`gc.root_bead_id` metadata via COALESCE over the typed target. Do not close
+non-closed wisps by age alone.
 `wisp-compact.sh` promotes non-closed wisps past TTL for stuck detection.
 The close step repeats until no schema-safe candidates remain, so a stale
 multi-level child chain whose root is closed converges in one reaper run.
@@ -258,11 +261,11 @@ AND id IN (
         d.type = 'parent-child'
         OR (
           d.type = 'tracks'
-          AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$."gc.root_bead_id"')) = d.depends_on_id
+          AND JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$."gc.root_bead_id"')) = COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)
         )
       )
-    LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
-    LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
+    LEFT JOIN wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
+    LEFT JOIN issues parent_issue ON d.depends_on_issue_id = parent_issue.id
     WHERE w.status IN ('open', 'hooked', 'in_progress')
     AND w.created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
     AND (
@@ -297,7 +300,7 @@ DELETE FROM wisps
 WHERE status = 'closed'
 AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
 AND id NOT IN (
-  SELECT DISTINCT d.depends_on_id FROM wisp_dependencies d
+  SELECT DISTINCT d.depends_on_wisp_id FROM wisp_dependencies d
   INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
   WHERE d.type IN ('parent-child', 'tracks', 'blocks')
   AND child_wisp.status IN ('open', 'hooked', 'in_progress')
@@ -341,10 +344,10 @@ AND issue_type != 'epic'
 AND id NOT IN (
   -- Exclude issues with active dependencies
   SELECT DISTINCT d.issue_id FROM dependencies d
-  INNER JOIN issues i ON d.depends_on_id = i.id
+  INNER JOIN issues i ON d.depends_on_issue_id = i.id
   WHERE i.status IN ('open', 'in_progress')
   UNION
-  SELECT DISTINCT d.depends_on_id FROM dependencies d
+  SELECT DISTINCT d.depends_on_issue_id FROM dependencies d
   INNER JOIN issues i ON d.issue_id = i.id
   WHERE i.status IN ('open', 'in_progress')
 )

--- a/release-gates/ga-1l42us-reaper-split-schema-gate.md
+++ b/release-gates/ga-1l42us-reaper-split-schema-gate.md
@@ -1,0 +1,68 @@
+# Release Gate: ga-1l42us reaper split schema
+
+Branch: `release/ga-1l42us-reaper-split-schema`
+Base: `origin/main` at `7d17197bcd42629bddd788d2be1463f2d9e6dc7c`
+Release commit before gate checklist: `b19a3db191f504bd9b57f15cbac358f4a377069c`
+Reviewed source commit: `be98b23c317517b6b9147005dac2c0e68b817bd0`
+Source branch: `work/ga-pftmco-adopt-fix`
+Source bead: `ga-fa7rkq`
+Deploy bead: `ga-1l42us`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses
+the deployer release criteria table plus the bead-specific release handoff.
+
+## Scope
+
+The maintenance reaper no longer checks the removed `depends_on_id` generated
+column before running per-database cleanup. The gate now requires the current
+split dependency target columns, and every maintenance query that follows
+dependency edges uses `depends_on_issue_id`, `depends_on_wisp_id`, and
+`depends_on_external` as appropriate.
+
+Changed in this branch:
+
+- `examples/gastown/packs/maintenance/assets/scripts/reaper.sh`: updates the
+  dependency schema gate, the reusable close-edge predicate, and all per-site
+  dependency joins/selects to use split target columns.
+- `examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml`: keeps the
+  formula SQL and prose aligned with the split dependency schema.
+- `examples/gastown/maintenance_scripts_test.go`: updates mock Dolt stubs and
+  assertions, and adds coverage that split-schema reaper queries do not use
+  `d.depends_on_id`.
+- `examples/gastown/maintenance_scripts_dolt_integration_test.go`: updates the
+  integration fixture DDL and seed rows for the split dependency columns.
+
+The release commit is the same patch as the reviewed commit after rebase onto
+current `origin/main`:
+
+- `git patch-id --stable < <(git show be98b23c3)` -> `0dd7e23d00f9139a429d4da774849041c315748c`
+- `git patch-id --stable < <(git show b19a3db19)` -> `0dd7e23d00f9139a429d4da774849041c315748c`
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-fa7rkq` is closed with close reason `pass` and notes headed `REVIEWER VERDICT: PASS` for commit `be98b23c3` on `work/ga-pftmco-adopt-fix`. The deploy handoff `ga-1l42us` also records reviewed + passed status. |
+| 2 | Acceptance criteria met | PASS | `reaper.sh` has no `depends_on_id` hits and requires `depends_on_issue_id`, `depends_on_wisp_id`, and `depends_on_external` in `has_dependency_target_column`. The reusable close-edge predicate and the test constant are byte-identical. The formula SQL and integration fixtures use the split dependency schema. Remaining `depends_on_id` references are confined to bd CLI JSON projection tests and legacy error text, not maintenance SQL. |
+| 3 | Tests pass | PASS | See test log below. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-fa7rkq` report no blockers and no HIGH findings; deploy handoff includes no open finding references. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before adding this gate; final cleanliness is verified after committing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` returned `rc=0`; `git diff --check $(git merge-base HEAD origin/main)..HEAD` returned no whitespace/errors. |
+| 7 | Single feature theme | PASS | One subsystem/theme: the Gas Town maintenance reaper and its tests/formula now target the current split dependency schema. The commit touches only four `examples/gastown` maintenance files. |
+
+## Test Log
+
+- PASS: `go test ./examples/gastown/ -run 'Reaper|Maintenance'`
+  - `ok github.com/gastownhall/gascity/examples/gastown 16.363s`
+- PASS: `go test ./examples/gastown/`
+  - `ok github.com/gastownhall/gascity/examples/gastown 24.921s`
+- PASS: `make test-fast-parallel`
+  - `All fast jobs passed`
+- PASS: `go vet ./...`
+
+## Notes For Mayor
+
+The original remote feature branch still points at reviewed commit `be98b23c3`,
+while this release branch carries the same patch rebased on current
+`origin/main` as `b19a3db19`. The deploy branch is used to avoid force-pushing
+the divergent `work/ga-pftmco-adopt-fix` remote branch.


### PR DESCRIPTION
## What this changes

The Gas Town maintenance reaper now recognizes the current split dependency schema when it scans each Beads/Dolt database. Instead of looking for the removed `depends_on_id` generated column and silently skipping cleanup, it gates on `depends_on_issue_id`, `depends_on_wisp_id`, and `depends_on_external`, then uses those typed columns in the dependency joins that protect active workflow wisps and stale issue relationships.

This keeps the script, the maintenance formula, and the test Dolt fixtures aligned with migration 0043 and bd 1.0.5+ stores.

## Review notes

- The changed runtime surface is `examples/gastown/packs/maintenance/assets/scripts/reaper.sh`.
- `examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml` mirrors the same SQL shape for formula-driven maintenance.
- Remaining `depends_on_id` references are test/projection or legacy error-message coverage, not active maintenance SQL.
- The release branch carries the reviewed patch rebased onto current `origin/main`; the gate file records the reviewed source SHA and matching patch ID.

## Test plan

- [x] `go test ./examples/gastown/ -run 'Reaper|Maintenance'`
- [x] `go test ./examples/gastown/`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-1l42us-reaper-split-schema-gate.md`](release-gates/ga-1l42us-reaper-split-schema-gate.md)
