### PR TITLE
fix(session): .gc/settings.json content changes no longer cascade stale-session drains (ga-zfm)

### DIFF
--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1134,9 +1134,18 @@ func stageHookFiles(copyFiles []runtime.CopyEntry, cityPath, workDir string, hoo
 			}
 		}
 		if !alreadyStaged {
+			// .gc/settings.json uses path-only fingerprinting (Probed: false) so
+			// that binary-upgrade rewrites of the managed settings file do not
+			// cascade stale-session drains. The legacy hooks/claude.json path is
+			// user-authored and uses content hashing. (ga-zfm)
+			probed := settingsRel != path.Join(".gc", "settings.json")
+			var contentHash string
+			if probed {
+				contentHash = runtime.HashPathContent(settingsAbs)
+			}
 			copyFiles = append(copyFiles, runtime.CopyEntry{
 				Src: settingsAbs, RelDst: settingsRel,
-				Probed: true, ContentHash: runtime.HashPathContent(settingsAbs),
+				Probed: probed, ContentHash: contentHash,
 			})
 		}
 	}

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -1001,11 +1001,13 @@ func TestStageHookFilesIncludesCanonicalClaudeHook(t *testing.T) {
 			if entry.Src != settingsPath {
 				t.Fatalf("stageHookFiles() staged %q, want %q", entry.Src, settingsPath)
 			}
-			if !entry.Probed {
-				t.Fatal("stageHookFiles() .gc/settings.json not marked Probed")
+			// .gc/settings.json must NOT be probed: binary-upgrade rewrites of the
+			// managed settings file must not cascade stale-session drains. (ga-zfm)
+			if entry.Probed {
+				t.Fatal("stageHookFiles() .gc/settings.json must not be marked Probed; content changes are ambient")
 			}
-			if entry.ContentHash == "" {
-				t.Fatal("stageHookFiles() .gc/settings.json has empty ContentHash")
+			if entry.ContentHash != "" {
+				t.Fatal("stageHookFiles() .gc/settings.json must have empty ContentHash when not probed")
 			}
 			return
 		}
@@ -1040,6 +1042,57 @@ func TestStageHookFilesFallsBackToLegacyClaudeHook(t *testing.T) {
 		}
 	}
 	t.Fatal("stageHookFiles() did not stage hooks/claude.json")
+}
+
+// TestRuntimeSettingsContentChangeDoesNotCascadeStaleSession is a regression
+// test for ga-zfm: a gc binary upgrade rewrites .gc/settings.json, which must
+// not produce a different CopyFiles fingerprint for previously-started sessions.
+// The fix marks .gc/settings.json as Probed:false so only the path is hashed.
+func TestRuntimeSettingsContentChangeDoesNotCascadeStaleSession(t *testing.T) {
+	cityDir := filepath.Join(t.TempDir(), "city")
+	workDir := filepath.Join(cityDir, "worker")
+	settingsPath := filepath.Join(cityDir, ".gc", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Write settings with "v1" content (before binary upgrade).
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":{"v1":true}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile v1: %v", err)
+	}
+	before := stageHookFiles(nil, cityDir, workDir, []string{"claude"})
+
+	// Simulate binary upgrade: rewrite settings with new embedded defaults.
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":{"v2":true}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile v2: %v", err)
+	}
+	after := stageHookFiles(nil, cityDir, workDir, []string{"claude"})
+
+	// Locate the settings entry in both results.
+	settingsRel := path.Join(".gc", "settings.json")
+	find := func(entries []runtime.CopyEntry) runtime.CopyEntry {
+		for _, e := range entries {
+			if e.RelDst == settingsRel {
+				return e
+			}
+		}
+		t.Fatalf("stageHookFiles: .gc/settings.json not staged")
+		return runtime.CopyEntry{}
+	}
+	eBefore := find(before)
+	eAfter := find(after)
+
+	// Content hash must be empty (not probed) and must be identical before/after
+	// so that CoreFingerprint produces the same hash regardless of file content.
+	if eBefore.Probed || eAfter.Probed {
+		t.Error(".gc/settings.json must not be marked Probed; content changes are ambient")
+	}
+	if eBefore.ContentHash != "" || eAfter.ContentHash != "" {
+		t.Error(".gc/settings.json ContentHash must be empty when not probed")
+	}
+	if eBefore.Src != eAfter.Src || eBefore.RelDst != eAfter.RelDst {
+		t.Errorf("Src/RelDst changed: before={%q %q} after={%q %q}", eBefore.Src, eBefore.RelDst, eAfter.Src, eAfter.RelDst)
+	}
 }
 
 func TestStageHookFilesDoesNotStageClaudeSkillsDir(t *testing.T) {

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -186,9 +186,19 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		command = command + " " + sa
 		settingsFile, relDst := claudeSettingsSource(p.cityPath)
 		if settingsFile != "" {
+			// .gc/settings.json is managed by gc (regenerated on binary upgrade).
+			// Using path-only fingerprinting prevents content changes from
+			// cascading stale-session drains to unrelated productive sessions.
+			// The legacy hooks/claude.json path is user-authored, so it uses
+			// content hashing to detect intentional changes. (ga-zfm)
+			probed := relDst != path.Join(".gc", "settings.json")
+			var contentHash string
+			if probed {
+				contentHash = runtime.HashPathContent(settingsFile)
+			}
 			copyFiles = append(copyFiles, runtime.CopyEntry{
 				Src: settingsFile, RelDst: relDst,
-				Probed: true, ContentHash: runtime.HashPathContent(settingsFile),
+				Probed: probed, ContentHash: contentHash,
 			})
 		}
 	}

--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -36,7 +36,11 @@ type BreakdownCopyEntry struct {
 // different prefix) and silently rebaseline them instead of triggering a
 // false-positive drain. Bump this constant whenever the inputs to or the
 // algorithm of any Fingerprint helper change.
-const FingerprintVersion = "v3"
+//
+// v4: .gc/settings.json is no longer probed in CopyFiles; its fingerprint
+// contribution is path-based only. Content changes to the managed runtime
+// settings file no longer trigger stale-session cascades. (ga-zfm)
+const FingerprintVersion = "v4"
 
 // ConfigFingerprint returns a deterministic hash of the Config fields that
 // define an agent's behavioral identity. Changes to these fields indicate

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -834,7 +834,7 @@ func TestIsLegacyOrMismatchedVersion(t *testing.T) {
 		{"empty stored (handled by separate gate, not legacy/mismatch)", "", false},
 		{"current version prefix", current, false},
 		{"v0 prefix (older mismatched version)", "v0:" + bareHex, true},
-		{"v4 prefix (future mismatched version)", "v4:" + bareHex, true},
+		{"v5 prefix (future mismatched version)", "v5:" + bareHex, true},
 		{"vX prefix (non-numeric, treated as legacy)", "vX:" + bareHex, true},
 		{"v01 prefix (different literal version, mismatch)", "v01:" + bareHex, true},
 		{"non-v prefix (e.g. xyz, treated as legacy)", "xyz:" + bareHex, true},


### PR DESCRIPTION
## Problem

When the `gc` binary is upgraded, `hooks.Install` rewrites `.gc/settings.json` with new embedded defaults. Because this file was marked `Probed:true` in `CopyFiles`, its `ContentHash` contributed to `CoreFingerprint`. The result: every live session saw fingerprint drift on the next reconcile tick and was drained as stale — killing unrelated productive work.

Evidence from the incident:
- Closed session `gm-s7b7py7`: `CopyFiles=7293e1e7fbc03c6f`
- New session `gm-6qd9e3i`: `CopyFiles=0759dab14c18133a`
- `.gc/settings.json` modified at 08:26:21, cascade reap at 08:27:35

## Fix

Mark `.gc/settings.json` as `Probed:false` so only its path contributes to the fingerprint. Content changes to the managed runtime settings file are now "ambient" — picked up by future sessions, not causing restarts of running ones.

The user-authored `hooks/claude.json` fallback path remains content-probed so intentional hook changes still trigger restarts.

Bump `FingerprintVersion` v3→v4 so existing sessions with `v3:*` stored hashes are silently rebaselined (no drain) on the first post-upgrade reconcile tick.

## Changes

- `internal/runtime/fingerprint.go`: `FingerprintVersion` v3→v4 with doc comment
- `cmd/gc/template_resolve.go`: settings.json CopyEntry uses path-only fingerprinting
- `cmd/gc/cmd_start.go:stageHookFiles`: same fix
- `internal/runtime/fingerprint_test.go`: update "future mismatched" test case (v4→v5)
- `cmd/gc/cmd_start_test.go`: update assertions + add regression test `TestRuntimeSettingsContentChangeDoesNotCascadeStaleSession`

## Exit criteria

- A new session spawning in gc-management city does NOT reap unrelated productive sessions.
- Tested: `TestStageHookFilesIncludesCanonicalClaudeHook`, `TestRuntimeSettingsContentChangeDoesNotCascadeStaleSession`, `TestIsLegacyOrMismatchedVersion`, `TestFingerprintVersionedOutputFormat`, all drift/reconciler tests — all pass.

---

Closes ga-zfm (polecat-pr).