### PR TITLE
fix(city-runtime): reply to manual reload before order dispatch

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1004,7 +1004,7 @@ func (cr *CityRuntime) tick(
 			// reloads still reply after applySoftReloadAcceptance. This
 			// condition is the exact negation of the soft-acceptance guard
 			// below.
-			if !(manualReload.soft &&
+			if !(manualReload.soft && //nolint:staticcheck // QF1001: explicit negation of the soft-acceptance guard below, kept for readability
 				(manualReply.Outcome == reloadOutcomeApplied || manualReply.Outcome == reloadOutcomeNoChange)) {
 				completeManualReload()
 			}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -993,6 +993,21 @@ func (cr *CityRuntime) tick(
 		manualReply = cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, trace, source)
 		if manualReload != nil {
 			manualReloadCompleted = true
+			// #3206 defense-in-depth: a manual reload's reply is already final
+			// here unless soft-reload acceptance will amend it from
+			// post-reconcile state. For every other manual reload, send the
+			// reply now — before dispatchOrders and the session-reconcile
+			// phases — so reload-reply latency does not scale with order count.
+			// AUTO ticks (manualReload == nil) are unaffected and keep the
+			// dispatch-before-reply ordering. The end-of-tick
+			// completeManualReload() is idempotent, so soft Applied/NoChange
+			// reloads still reply after applySoftReloadAcceptance. This
+			// condition is the exact negation of the soft-acceptance guard
+			// below.
+			if !(manualReload.soft &&
+				(manualReply.Outcome == reloadOutcomeApplied || manualReply.Outcome == reloadOutcomeNoChange)) {
+				completeManualReload()
+			}
 		}
 	}
 	if ctx.Err() != nil {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -4571,7 +4571,12 @@ func TestCityRuntimeReloadKeepsRegisteredAliasForEffectiveIdentity(t *testing.T)
 	}
 }
 
-func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
+// TestCityRuntimeManualHardReloadRepliesBeforeDispatch pins #3206: a manual
+// hard reload's reply is sent BEFORE dispatchOrders and the session-reconcile
+// phases, so reload-reply latency is independent of order count. (Soft
+// Applied/NoChange reloads still reply after applySoftReloadAcceptance — see
+// TestCityRuntimeSoftReloadAcceptsDriftForAppliedAndNoChange.)
+func TestCityRuntimeManualHardReloadRepliesBeforeDispatch(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -4583,6 +4588,16 @@ func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
 	dirty.Store(true)
 	sp := runtime.NewFake()
 	var stdout bytes.Buffer
+
+	// recordingOrderDispatcher is a pure in-process fake (no order subprocesses),
+	// so it carries none of the tempdir-cleanup races the real dispatcher would.
+	od := &recordingOrderDispatcher{
+		onDispatch: func(context.Context, string, time.Time) {
+			if len(doneCh) == 0 {
+				t.Error("dispatchOrders ran before the manual hard-reload reply was sent (#3206)")
+			}
+		},
+	}
 	cr := newTestCityRuntime(t, CityRuntimeParams{
 		CityPath:    cityPath,
 		CityName:    "test-city",
@@ -4592,10 +4607,8 @@ func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
 		Cfg:         cfg,
 		SP:          sp,
 		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
-			select {
-			case reply := <-doneCh:
-				t.Fatalf("manual reload replied before desired-state rebuild: %+v", reply)
-			default:
+			if len(doneCh) == 0 {
+				t.Error("desired-state rebuild ran before the manual hard-reload reply was sent (#3206)")
 			}
 			return DesiredStateResult{State: map[string]TemplateParams{}}
 		},
@@ -4604,22 +4617,23 @@ func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
 		Stdout: &stdout,
 		Stderr: io.Discard,
 	})
-	// This test asserts reload reply timing only; order subprocesses add
-	// unrelated tempdir cleanup races after the tick has completed.
-	cr.od = nil
-	cr.activeReload = &reloadRequest{doneCh: doneCh}
+	cr.od = od
+	cr.activeReload = &reloadRequest{doneCh: doneCh} // hard reload (soft=false)
 	lastProviderName := "fake"
 	var prevPoolRunning map[string]bool
 
 	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "poke")
 
+	if !od.called.Load() {
+		t.Fatal("order dispatcher was not called")
+	}
 	select {
 	case reply := <-doneCh:
 		if reply.Outcome != reloadOutcomeNoChange {
 			t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeNoChange)
 		}
 	default:
-		t.Fatal("manual reload did not reply after tick completion")
+		t.Fatal("manual reload did not reply")
 	}
 	if cr.activeReload != nil {
 		t.Fatal("activeReload was not cleared")

--- a/cmd/gc/fs_pressure_test.go
+++ b/cmd/gc/fs_pressure_test.go
@@ -558,10 +558,12 @@ func TestCityRuntimeManualReloadBypassesFSPressureSkipUntilDemandRefresh(t *test
 		SP:          sp,
 		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
 			buildCalls.Add(1)
-			select {
-			case reply := <-doneCh:
-				t.Fatalf("manual reload replied before desired-state rebuild under FS pressure: %+v", reply)
-			default:
+			// #3206: a manual hard reload replies before the desired-state
+			// rebuild — reply latency is independent of the reconcile phases.
+			// The FS-pressure bypass itself (the rebuild still runs) is asserted
+			// by buildCalls==1 + the absence of a skip event below.
+			if len(doneCh) == 0 {
+				t.Error("manual hard reload reply was not sent before the desired-state rebuild (#3206)")
 			}
 			return DesiredStateResult{State: map[string]TemplateParams{}}
 		},


### PR DESCRIPTION
## Summary

A manual `gc reload` reply was sent only at the end of the controller tick — after `dispatchOrders` and the session-reconcile phases — so its latency scaled with order count even though the reply value is computed early by `reloadConfigTraced`. Defense-in-depth follow-up to #3201/#3205.

Send the already-computed reply before `dispatchOrders` for every manual reload except the soft-reload Applied/NoChange case, whose reply is amended from post-reconcile state by `applySoftReloadAcceptance`. AUTO ticks (`manualReload == nil`) keep the dispatch-before-reply ordering, so due cooldown/cron formulas are still not starved. `completeManualReload` is idempotent, so the end-of-tick call is a no-op for early-replied reloads and still fires for the soft-accepted case.

## Scope

`cmd/gc/city_runtime.go` + tests only (3 files / 59 LOC, config-free). Branch cut fresh from `upstream/main`.

## Test plan

- `make check` green (captain shepherd-check, sha-matched)
- New test `TestCityRuntimeManualHardReloadRepliesBeforeDispatch` + affected reload/FS-pressure tests pass after rebase onto upstream tip

Refs #3206. Refs #3201. Refs #3191.