### PR TITLE
test(api): de-flake status degrade tests with a sync signal

### DIFF
--- a/internal/api/handler_status_test.go
+++ b/internal/api/handler_status_test.go
@@ -303,25 +303,27 @@ func TestHandleStatusDegradesWhenReadModelStoreStalls(t *testing.T) {
 	statusStoreReadTimeout = 20 * time.Millisecond
 	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
 
-	const stallDelay = 750 * time.Millisecond
+	// The store stays blocked for the whole assertion, so the handler can only
+	// produce a response by honoring its degrade timeout — proven by Partial +
+	// the timeout diagnostic, with no fragile wall-clock bound (#3204).
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
 	state := newFakeState(t)
-	stallingStore := &delayedListStore{
-		Store: beads.NewMemStore(),
-		delay: stallDelay,
-	}
+	stallingStore := &blockingListStore{Store: beads.NewMemStore(), release: release}
 	state.cityBeadStore = stallingStore
 	state.stores["myrig"] = stallingStore
 	h := newTestCityHandler(t, state)
 
 	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
 	rec := httptest.NewRecorder()
-	start := time.Now()
-	h.ServeHTTP(rec, req)
-	elapsed := time.Since(start)
-
-	if elapsed > stallDelay {
-		t.Fatalf("status handler took %s, want bounded degraded response (< stall %s)", elapsed, stallDelay)
+	served := make(chan struct{})
+	go func() { h.ServeHTTP(rec, req); close(served) }()
+	select {
+	case <-served:
+	case <-time.After(10 * time.Second): // hang guard (~500x the degrade timeout), not a timing bound
+		t.Fatal("status handler did not return while the read model was stalled; degrade timeout not honored")
 	}
+
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
@@ -342,23 +344,25 @@ func TestHandleStatusDegradesWhenMailCountStalls(t *testing.T) {
 	statusStoreReadTimeout = 20 * time.Millisecond
 	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
 
-	const stallDelay = 750 * time.Millisecond
+	// The provider stays blocked for the whole assertion, so the handler can
+	// only produce a response by honoring its degrade timeout — proven by
+	// Partial + the timeout diagnostic, with no fragile wall-clock bound (#3204).
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
 	state := newFakeState(t)
-	state.cityMailProv = &delayedMailCountProvider{
-		Provider: state.cityMailProv,
-		delay:    stallDelay,
-	}
+	state.cityMailProv = &blockingMailCountProvider{Provider: state.cityMailProv, release: release}
 	h := newTestCityHandler(t, state)
 
 	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
 	rec := httptest.NewRecorder()
-	start := time.Now()
-	h.ServeHTTP(rec, req)
-	elapsed := time.Since(start)
-
-	if elapsed > stallDelay {
-		t.Fatalf("status handler took %s, want bounded degraded response (< stall %s)", elapsed, stallDelay)
+	served := make(chan struct{})
+	go func() { h.ServeHTTP(rec, req); close(served) }()
+	select {
+	case <-served:
+	case <-time.After(10 * time.Second): // hang guard (~500x the degrade timeout), not a timing bound
+		t.Fatal("status handler did not return while the mail count was stalled; degrade timeout not honored")
 	}
+
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
@@ -713,23 +717,28 @@ func TestHandleStatusLiteSkipsWorkScanAndCachesSeparately(t *testing.T) {
 	}
 }
 
-type delayedListStore struct {
+// blockingListStore blocks List until release is closed, then delegates. Used
+// to hold a read "stalled" for the entire degrade assertion via a
+// synchronization signal instead of a fragile wall-clock sleep (#3204).
+type blockingListStore struct {
 	beads.Store
-	delay time.Duration
+	release <-chan struct{}
 }
 
-func (s *delayedListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	time.Sleep(s.delay)
+func (s *blockingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	<-s.release
 	return s.Store.List(query)
 }
 
-type delayedMailCountProvider struct {
+// blockingMailCountProvider blocks Count until release is closed, then
+// delegates (#3204).
+type blockingMailCountProvider struct {
 	mail.Provider
-	delay time.Duration
+	release <-chan struct{}
 }
 
-func (p *delayedMailCountProvider) Count(recipient string) (int, int, error) {
-	time.Sleep(p.delay)
+func (p *blockingMailCountProvider) Count(recipient string) (int, int, error) {
+	<-p.release
 	return p.Provider.Count(recipient)
 }
 


### PR DESCRIPTION
## Summary

Two timing-bound tests in `internal/api/handler_status_test.go` flaked under
host load on a clean `main` baseline:

- `TestHandleStatusDegradesWhenReadModelStoreStalls`
- `TestHandleStatusDegradesWhenMailCountStalls`

Both stall a backing read, then asserted the handler returned within an
**absolute wall bound** (500ms, later relaxed to 750ms). The degrade logic
fires at the 20ms internal `statusStoreReadTimeout`, but the handler's
wall-clock *return* (goroutine scheduling + context-cancel + JSON encode)
reached ~1s under load — so the bound flaked on busy CI / multi-tenant dev
boxes, independent of any code under test. Raising the bound only moves the
flake.

## Fix (test-only)

Replace the `time.Sleep`-based stall with a **synchronization signal** and
assert the degrade *outcome* instead of wall time:

- The two local test doubles become `blockingListStore` / `blockingMailCountProvider`,
  which block on a `release` channel until the test closes it in `t.Cleanup`.
  The backend is therefore provably still blocked throughout the assertion.
- The test asserts `Partial == true` + the timeout diagnostic — which the
  handler can only produce by honoring its degrade timeout, since the backend
  never returned a real result. No wall-clock timing assertion remains.
- `ServeHTTP` runs under a generous 10s hang-guard (~500× the 20ms degrade
  timeout) — a regression detector for "degrade timeout not honored", not a
  load-sensitive timing bound.

The degrade behavior under test is unchanged; the abandoned read goroutine is
released in cleanup (the handler's `done` channel is buffered, so its
post-release send never blocks). Verified deterministic: `-count=50 -race`
green.

No production code changes.

Closes #3204. Refs #3201.
