### PR TITLE
feat(jj-pack): add jj-vcs skill

### DIFF
--- a/examples/gastown/packs/gastown-jj/pack.toml
+++ b/examples/gastown/packs/gastown-jj/pack.toml
@@ -1,0 +1,4 @@
+[pack]
+name = "gastown-jj"
+schema = 2
+description = "Jujutsu workflow skills for Gas Town agents."

--- a/examples/gastown/packs/gastown-jj/skills/jj-vcs/LICENSE
+++ b/examples/gastown/packs/gastown-jj/skills/jj-vcs/LICENSE
@@ -1,0 +1,195 @@
+Copyright (C) 2026 Aleksei Zakhlestin
+Licensed under the EUPL
+
+EUROPEAN UNION PUBLIC LICENCE v. 1.2 
+EUPL © the European Union 2007, 2016 
+
+This European Union Public Licence (the ‘EUPL’) applies to the Work (as defined below) which is provided under the 
+terms of this Licence. Any use of the Work, other than as authorised under this Licence is prohibited (to the extent such 
+use is covered by a right of the copyright holder of the Work). 
+The Work is provided under the terms of this Licence when the Licensor (as defined below) has placed the following 
+notice immediately following the copyright notice for the Work: 
+                          Licensed under the EUPL 
+or has expressed by any other means his willingness to license under the EUPL. 
+
+1.Definitions 
+In this Licence, the following terms have the following meaning: 
+— ‘The Licence’:this Licence. 
+— ‘The Original Work’:the work or software distributed or communicated by the Licensor under this Licence, available 
+as Source Code and also as Executable Code as the case may be. 
+— ‘Derivative Works’:the works or software that could be created by the Licensee, based upon the Original Work or 
+modifications thereof. This Licence does not define the extent of modification or dependence on the Original Work 
+required in order to classify a work as a Derivative Work; this extent is determined by copyright law applicable in 
+the country mentioned in Article 15. 
+— ‘The Work’:the Original Work or its Derivative Works. 
+— ‘The Source Code’:the human-readable form of the Work which is the most convenient for people to study and 
+modify. 
+— ‘The Executable Code’:any code which has generally been compiled and which is meant to be interpreted by 
+a computer as a program. 
+— ‘The Licensor’:the natural or legal person that distributes or communicates the Work under the Licence. 
+— ‘Contributor(s)’:any natural or legal person who modifies the Work under the Licence, or otherwise contributes to 
+the creation of a Derivative Work. 
+— ‘The Licensee’ or ‘You’:any natural or legal person who makes any usage of the Work under the terms of the 
+Licence. 
+— ‘Distribution’ or ‘Communication’:any act of selling, giving, lending, renting, distributing, communicating, 
+transmitting, or otherwise making available, online or offline, copies of the Work or providing access to its essential 
+functionalities at the disposal of any other natural or legal person. 
+
+2.Scope of the rights granted by the Licence 
+The Licensor hereby grants You a worldwide, royalty-free, non-exclusive, sublicensable licence to do the following, for 
+the duration of copyright vested in the Original Work: 
+— use the Work in any circumstance and for all usage, 
+— reproduce the Work, 
+— modify the Work, and make Derivative Works based upon the Work, 
+— communicate to the public, including the right to make available or display the Work or copies thereof to the public 
+and perform publicly, as the case may be, the Work, 
+— distribute the Work or copies thereof, 
+— lend and rent the Work or copies thereof, 
+— sublicense rights in the Work or copies thereof. 
+Those rights can be exercised on any media, supports and formats, whether now known or later invented, as far as the 
+applicable law permits so. 
+In the countries where moral rights apply, the Licensor waives his right to exercise his moral right to the extent allowed 
+by law in order to make effective the licence of the economic rights here above listed. 
+The Licensor grants to the Licensee royalty-free, non-exclusive usage rights to any patents held by the Licensor, to the 
+extent necessary to make use of the rights granted on the Work under this Licence. 
+
+3.Communication of the Source Code 
+The Licensor may provide the Work either in its Source Code form, or as Executable Code. If the Work is provided as 
+Executable Code, the Licensor provides in addition a machine-readable copy of the Source Code of the Work along with 
+each copy of the Work that the Licensor distributes or indicates, in a notice following the copyright notice attached to 
+the Work, a repository where the Source Code is easily and freely accessible for as long as the Licensor continues to 
+distribute or communicate the Work. 
+
+4.Limitations on copyright 
+Nothing in this Licence is intended to deprive the Licensee of the benefits from any exception or limitation to the 
+exclusive rights of the rights owners in the Work, of the exhaustion of those rights or of other applicable limitations 
+thereto. 
+
+5.Obligations of the Licensee 
+The grant of the rights mentioned above is subject to some restrictions and obligations imposed on the Licensee. Those 
+obligations are the following: 
+
+Attribution right: The Licensee shall keep intact all copyright, patent or trademarks notices and all notices that refer to 
+the Licence and to the disclaimer of warranties. The Licensee must include a copy of such notices and a copy of the 
+Licence with every copy of the Work he/she distributes or communicates. The Licensee must cause any Derivative Work 
+to carry prominent notices stating that the Work has been modified and the date of modification. 
+
+Copyleft clause: If the Licensee distributes or communicates copies of the Original Works or Derivative Works, this 
+Distribution or Communication will be done under the terms of this Licence or of a later version of this Licence unless 
+the Original Work is expressly distributed only under this version of the Licence — for example by communicating 
+‘EUPL v. 1.2 only’. The Licensee (becoming Licensor) cannot offer or impose any additional terms or conditions on the 
+Work or Derivative Work that alter or restrict the terms of the Licence. 
+
+Compatibility clause: If the Licensee Distributes or Communicates Derivative Works or copies thereof based upon both 
+the Work and another work licensed under a Compatible Licence, this Distribution or Communication can be done 
+under the terms of this Compatible Licence. For the sake of this clause, ‘Compatible Licence’ refers to the licences listed 
+in the appendix attached to this Licence. Should the Licensee's obligations under the Compatible Licence conflict with 
+his/her obligations under this Licence, the obligations of the Compatible Licence shall prevail. 
+
+Provision of Source Code: When distributing or communicating copies of the Work, the Licensee will provide 
+a machine-readable copy of the Source Code or indicate a repository where this Source will be easily and freely available 
+for as long as the Licensee continues to distribute or communicate the Work. 
+
+Legal Protection: This Licence does not grant permission to use the trade names, trademarks, service marks, or names 
+of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and 
+reproducing the content of the copyright notice. 
+
+6.Chain of Authorship 
+The original Licensor warrants that the copyright in the Original Work granted hereunder is owned by him/her or 
+licensed to him/her and that he/she has the power and authority to grant the Licence. 
+Each Contributor warrants that the copyright in the modifications he/she brings to the Work are owned by him/her or 
+licensed to him/her and that he/she has the power and authority to grant the Licence. 
+Each time You accept the Licence, the original Licensor and subsequent Contributors grant You a licence to their contributions 
+to the Work, under the terms of this Licence. 
+
+7.Disclaimer of Warranty 
+The Work is a work in progress, which is continuously improved by numerous Contributors. It is not a finished work 
+and may therefore contain defects or ‘bugs’ inherent to this type of development. 
+For the above reason, the Work is provided under the Licence on an ‘as is’ basis and without warranties of any kind 
+concerning the Work, including without limitation merchantability, fitness for a particular purpose, absence of defects or 
+errors, accuracy, non-infringement of intellectual property rights other than copyright as stated in Article 6 of this 
+Licence. 
+This disclaimer of warranty is an essential part of the Licence and a condition for the grant of any rights to the Work. 
+
+8.Disclaimer of Liability 
+Except in the cases of wilful misconduct or damages directly caused to natural persons, the Licensor will in no event be 
+liable for any direct or indirect, material or moral, damages of any kind, arising out of the Licence or of the use of the 
+Work, including without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, loss 
+of data or any commercial damage, even if the Licensor has been advised of the possibility of such damage. However, 
+the Licensor will be liable under statutory product liability laws as far such laws apply to the Work. 
+
+9.Additional agreements 
+While distributing the Work, You may choose to conclude an additional agreement, defining obligations or services 
+consistent with this Licence. However, if accepting obligations, You may act only on your own behalf and on your sole 
+responsibility, not on behalf of the original Licensor or any other Contributor, and only if You agree to indemnify, 
+defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against such Contributor by 
+the fact You have accepted any warranty or additional liability. 
+
+10.Acceptance of the Licence 
+The provisions of this Licence can be accepted by clicking on an icon ‘I agree’ placed under the bottom of a window 
+displaying the text of this Licence or by affirming consent in any other similar way, in accordance with the rules of 
+applicable law. Clicking on that icon indicates your clear and irrevocable acceptance of this Licence and all of its terms 
+and conditions. 
+Similarly, you irrevocably accept this Licence and all of its terms and conditions by exercising any rights granted to You 
+by Article 2 of this Licence, such as the use of the Work, the creation by You of a Derivative Work or the Distribution 
+or Communication by You of the Work or copies thereof. 
+
+11.Information to the public 
+In case of any Distribution or Communication of the Work by means of electronic communication by You (for example, 
+by offering to download the Work from a remote location) the distribution channel or media (for example, a website) 
+must at least provide to the public the information requested by the applicable law regarding the Licensor, the Licence 
+and the way it may be accessible, concluded, stored and reproduced by the Licensee. 
+
+12.Termination of the Licence 
+The Licence and the rights granted hereunder will terminate automatically upon any breach by the Licensee of the terms 
+of the Licence. 
+Such a termination will not terminate the licences of any person who has received the Work from the Licensee under 
+the Licence, provided such persons remain in full compliance with the Licence. 
+
+13.Miscellaneous 
+Without prejudice of Article 9 above, the Licence represents the complete agreement between the Parties as to the 
+Work. 
+If any provision of the Licence is invalid or unenforceable under applicable law, this will not affect the validity or 
+enforceability of the Licence as a whole. Such provision will be construed or reformed so as necessary to make it valid 
+and enforceable. 
+The European Commission may publish other linguistic versions or new versions of this Licence or updated versions of 
+the Appendix, so far this is required and reasonable, without reducing the scope of the rights granted by the Licence. 
+New versions of the Licence will be published with a unique version number. 
+All linguistic versions of this Licence, approved by the European Commission, have identical value. Parties can take 
+advantage of the linguistic version of their choice. 
+
+14.Jurisdiction 
+Without prejudice to specific agreement between parties, 
+— any litigation resulting from the interpretation of this License, arising between the European Union institutions, 
+bodies, offices or agencies, as a Licensor, and any Licensee, will be subject to the jurisdiction of the Court of Justice 
+of the European Union, as laid down in article 272 of the Treaty on the Functioning of the European Union, 
+— any litigation arising between other parties and resulting from the interpretation of this License, will be subject to 
+the exclusive jurisdiction of the competent court where the Licensor resides or conducts its primary business. 
+
+15.Applicable Law 
+Without prejudice to specific agreement between parties, 
+— this Licence shall be governed by the law of the European Union Member State where the Licensor has his seat, 
+resides or has his registered office, 
+— this licence shall be governed by Belgian law if the Licensor has no seat, residence or registered office inside 
+a European Union Member State. 
+
+
+                                                         Appendix 
+
+‘Compatible Licences’ according to Article 5 EUPL are: 
+— GNU General Public License (GPL) v. 2, v. 3 
+— GNU Affero General Public License (AGPL) v. 3 
+— Open Software License (OSL) v. 2.1, v. 3.0 
+— Eclipse Public License (EPL) v. 1.0 
+— CeCILL v. 2.0, v. 2.1 
+— Mozilla Public Licence (MPL) v. 2 
+— GNU Lesser General Public Licence (LGPL) v. 2.1, v. 3 
+— Creative Commons Attribution-ShareAlike v. 3.0 Unported (CC BY-SA 3.0) for works other than software 
+— European Union Public Licence (EUPL) v. 1.1, v. 1.2 
+— Québec Free and Open-Source Licence — Reciprocity (LiLiQ-R) or Strong Reciprocity (LiLiQ-R+) 
+
+The European Commission may update this Appendix to later versions of the above licences without producing 
+a new version of the EUPL, as long as they provide the rights granted in Article 2 of this Licence and protect the 
+covered Source Code from exclusive appropriation. 
+All other changes or additions to this Appendix require the production of a new EUPL version. 
+

--- a/examples/gastown/packs/gastown-jj/skills/jj-vcs/README.md
+++ b/examples/gastown/packs/gastown-jj/skills/jj-vcs/README.md
@@ -1,0 +1,57 @@
+# Opinionated Jujutsu (jj) skill for Agents
+
+I am an avid user of [Jujutsu](https://github.com/martinvonz/jj) VCS for couple of years. You might have read my [blog post](https://thisalex.com/posts/2025-04-20/) about it. This is my opinionated skill for using it with Agents.
+
+## Key features
+
+- Agents know how to write [good commit messages](https://cbea.ms/git-commit/) and how to chose a proper [gitmoji](https://gitmoji.dev/).
+- Agents never push to remote repositories — _I always verify the changes before publication and so should you_.
+- Agents are discouraged from deleting their failed attempts. Those are kept in separate branches for future reference — _because jj makes it really easy_.
+- Agents know how to distribute hunks of code across multiple commits if you ask them to.
+- Agents are not added as co-authors — _I as a person am fully responsible for the changes and do not plan to shift the blame to the tool_.
+
+## Installation
+
+> **Quick start:** Give your agent this page URL and ask it to install the jj-vcs skill. It will read the instructions below and handle the rest.
+
+_(you can use `git clone` instead of `jj git clone --colocate` in the following commands if you prefer)_
+
+### Claude Code
+
+```bash
+jj git clone --colocate https://codeberg.org/thisalex/jj-skill.git ~/.claude/skills/jj-vcs
+```
+
+### Zed / Codex / Pi
+
+```bash
+mkdir -p ~/.agents/skills
+jj git clone --colocate https://codeberg.org/thisalex/jj-skill.git ~/.agents/skills/jj-vcs
+```
+
+### Hermes
+
+```bash
+mkdir -p ~/.hermes/skills
+jj git clone --colocate https://codeberg.org/thisalex/jj-skill.git ~/.hermes/skills/jj-vcs
+```
+
+### Other agents
+
+The skill follows the [Agent Skills](https://agentskills.io) format. `SKILL.md` is the entry point; other `.md` files are referenced from it when needed. Check your agent's documentation for the correct skills directory and clone there.
+
+### Recommended: add a reinforcement to your global instructions
+
+The skill works on its own, but agents may skip loading it if they think they already know jj. Adding a line to your global instructions (e.g. `CLAUDE.md`, `.cursor/rules`, etc.) ensures the skill is always loaded:
+
+```
+Always load the jj-vcs skill when starting any programming task.
+Do not rely on general knowledge for jj workflow or message format —
+the skill contains the required policies.
+```
+
+## Support me
+
+[☕ Buy me a coffee](https://www.buymeacoffee.com/thisalex)
+
+p.s. This readme is written by human. All of the mdashes are inserted manually with ❤️.

--- a/examples/gastown/packs/gastown-jj/skills/jj-vcs/SKILL.md
+++ b/examples/gastown/packs/gastown-jj/skills/jj-vcs/SKILL.md
@@ -1,0 +1,462 @@
+---
+name: jj-vcs
+description: >
+  Enforce Jujutsu (jj) workflow and commit message policy.
+  Required before writing any commit message. Covers jj commands,
+  commit message format rules, workflow patterns, and error handling.
+  Triggers on: version control, commits, history, jj commands,
+  .jj directory present, git operations, git commands, making changes to code,
+  describe, commit message, rename change, rename commit, reword.
+category: development
+allowed-tools: Bash
+---
+
+# jj — Jujutsu Version Control
+
+## Intention
+
+**You must track your work in version control.** The user needs a log of changes to review your progress, understand your decisions, and evaluate different approaches. Each logical step should be a separate commit. This is not optional — it's how you demonstrate your work.
+
+## Overview
+
+jj (Jujutsu) is a Git-compatible version control system. Works on top of Git repositories with simpler mental model.
+
+**In this project, use jj instead of git.** If you think about using git commands — use jj equivalents instead.
+
+**Key principles:**
+- Working copy is always a commit — no staging area
+- Each step starts with `jj new`, describe when done with `jj describe`
+- Never destroy work — branch instead of undo
+- Never use git commands in jj repo
+- Suppress pagers and ANSI colors: prefix jj commands with `--no-pager --color=never` to keep output clean for agent consumption
+
+## Initialization
+
+If project has `.git` but no `.jj`:
+```bash
+jj git init --colocate
+```
+
+## Core Workflow
+
+### 0. Check the current change
+```bash
+jj st
+```
+If `@` is already `(empty) (no description set)` then start editing directly (step 2). Otherwise create a new change with `jj new` (step 1).
+
+### 1. Start new work
+```bash
+jj new                      # create empty commit on top of current
+jj new -m "brief intent"    # with initial description (optional)
+```
+
+### 2. Make changes
+Edit files normally. Changes automatically tracked in current commit.
+
+### 3. Describe when done
+```bash
+jj describe -m "🦺 Add input validation for email field"
+```
+
+### 4. Repeat
+```bash
+jj new                      # start next piece of work
+```
+
+## Commit Message Format
+
+Based on [cbea.ms/git-commit](https://cbea.ms/git-commit/). The diff shows *what* changed; the message explains *why*.
+
+### Subject line (required)
+
+- ≤ 50 characters (72 absolute max — GitHub truncates beyond that)
+- Capitalize first word, no trailing period
+- **Imperative mood**: "Add feature" not "Added feature" or "Adding feature"
+- Test: the sentence "If applied, this commit will **[subject]**" must read naturally
+- If summarizing is hard, the commit probably contains too many changes — split it
+- Subject describes the *outcome*, not the implementation — no flags, file names, or CLI arguments; save those for the body
+- A reader unfamiliar with the codebase should understand the intent from the subject alone — no jargon, tool names, or acronyms without context
+
+### Body (usually unnecessary)
+
+Most commits need **only a subject line**. Add a body only when:
+- The *reason* for the change isn't obvious from the diff
+- You chose one approach over another and want to record *why*
+- The commit marks a failed attempt (⚗️) and you need to explain what went wrong
+- The subject references a tool, library, or concept that an unfamiliar reader wouldn't recognize — add a link or brief explanation in the body
+
+When you do write a body:
+- Separate from subject with a blank line
+- Wrap at 72 characters
+- Explain **what problem existed** and **why this solution** — not how the code works
+- Bullet points (with `-`) are fine
+
+### Gitmoji
+
+Prefix the subject line with a [gitmoji](https://gitmoji.dev/) that describes the nature of the change. The emoji goes before the text, separated by a space. The 50-char limit applies to the full subject including the emoji.
+
+```bash
+# Examples:
+jj describe -m "✨ Add email format validation"
+jj describe -m "🐛 Fix login timeout on slow connections"
+jj describe -m "♻️ Extract helper function for validation"
+```
+
+**Full reference**: see [gitmoji-reference.md](gitmoji-reference.md) in this skill directory. Consult it when choosing the emoji — don't guess.
+
+### Anti-patterns
+
+```bash
+# WRONG — restating the diff as a changelog:
+jj describe -m "Add French locale translation
+
+Add full FTL translation for French (fr, config ID 4).
+Validated: Fluent syntax clean, correct encoding, no missing keys.
+Config: added to default.json and checkFluentFiles.ts.
+Switcher keys added to all existing locale files."
+
+# RIGHT — subject says it all:
+jj describe -m "🌐 Add French locale translation"
+```
+
+```bash
+# WRONG — body explains How instead of Why:
+jj describe -m "Fix login timeout
+
+Set socket timeout to 30s in HttpClient config.
+Added retry logic with exponential backoff."
+
+# RIGHT — body explains Why:
+jj describe -m "🐛 Fix login timeout
+
+Users on slow connections were getting dropped after the
+default 5s timeout. 30s matches the load balancer ceiling."
+```
+
+```bash
+# WRONG — non-imperative, has trailing period:
+jj describe -m "Fixed the bug with validation."
+
+# WRONG — too vague:
+jj describe -m "Update code"
+
+# RIGHT:
+jj describe -m "🦺 Validate email format on signup form"
+```
+
+```bash
+# WRONG — comma joins two changes, unfamiliar name unexplained:
+jj describe -m "✨ Add Roogle search, update config parser"
+
+# RIGHT — single intent, unfamiliar tool explained in body:
+jj describe -m "✨ Add full-text search via Roogle
+
+Roogle (https://example.com/roogle) indexes Rust docs
+for offline search. Replaces the grep-based approach."
+```
+
+## Checking Status and History
+
+```bash
+jj st                       # current status
+jj log                      # view history
+jj diff                     # see current changes
+```
+
+### Reading `jj log` output
+```
+@  qvlmxkoz user 2025-12-06 15:30
+│  (empty) (no description set)
+○  pzlwrkmv user 2025-12-06 15:25
+│  Add input validation
+○  rstqwxyz user 2025-12-06 15:20
+│  Extract helper function
+◆  zzzzzzzz root()
+```
+
+- `@` — current position (working copy)
+- `qvlmxkoz` — change ID (stable, use for references)
+- `(empty)` — commit has no file changes
+- `(no description set)` — needs `jj describe`
+
+## Finding Where to Continue
+
+1. Run `jj log` to see history
+2. Find last meaningful commit (has description, no ⚗️ marker)
+3. Start from there: `jj new <change-id>`
+
+## Granularity
+
+- Each change should be **atomic** — one logical unit
+- **Separate refactoring from functional changes**
+- Not too small, not too large
+
+Good:
+```
+1. "♻️ Extract helper function for validation"  ← refactoring
+2. "🦺 Add email format validation"              ← validation
+```
+
+## Preserving Work History
+
+**The core rule: never overwrite your own failed attempt with a new approach.**
+
+When you try something and it doesn't work, the previous attempt has diagnostic value — the user may find insights, partial solutions, or useful context in what you tried. Overwriting it destroys that evidence.
+
+### Who initiated the change?
+
+| Initiator | Scenario | What to do |
+|-----------|----------|------------|
+| **User** asked to modify a change | Feedback, correction, "change X to Y" | `jj edit` — user sees what's happening and directed it |
+| **Agent** fixes a trivial mistake | Forgot an import, typo, obvious omission | `jj edit` — no diagnostic value in the broken version |
+| **Agent** changes strategy | Approach A failed, switching to B | **Branch.** Describe A with ⚗️, `jj new` from before A |
+
+**The litmus test**: before rewriting a change you made, ask — *would comparing the old version with the new one be useful to the user?* If possibly yes — branch. Extra history is cheap; lost work is not.
+
+**Don't rationalize.** "I'm just improving my previous approach" when you're actually replacing the strategy is the exact failure mode this rule prevents. The words "try a different approach", "start over", "rethink" in your own reasoning are the signal. When in doubt, branch.
+
+### When an approach fails
+
+1. Describe what went wrong:
+```bash
+jj describe -m "⚗️ Add Redis caching
+
+Connection failed in tests — config not available
+in CI environment. Need different approach."
+```
+
+2. Go back and start fresh branch:
+```bash
+jj new <change-id-before-attempt>
+```
+
+Result — all attempts preserved:
+```
+A → B → C (failed attempt with ⚗️, preserved)
+      ↘ D → E (new attempt from B)
+```
+
+## Splitting and Moving Changes
+
+Sometimes a commit needs to be reorganized after the fact:
+- It mixes unrelated changes (refactoring + feature)
+- It's too large and should be broken into atomic units
+- Some changes belong in a different commit
+
+### File-Level Operations
+
+**Split a commit by files** — changes to listed files go into the first commit, everything else into the second:
+```bash
+jj split -r <change-id> path/to/file1 path/to/file2 -m "First part description"
+# Run jj log to find the second commit's change ID
+jj log
+# The second commit keeps the original description; update if needed
+jj describe -r <second-change-id> -m "Second part description"
+```
+
+**Move files between commits**:
+```bash
+jj squash --from <source> --into <destination> path/to/file -u
+# -u keeps destination's description unchanged
+```
+
+When both source and destination already have descriptions, omitting `-u` opens an editor to merge the two messages — which **hangs a headless/no-TTY agent session**. Always pass `-u` unless you deliberately want to set a new combined message with `-m`.
+
+### Squash and `-m`
+
+`jj squash` without `-m` preserves the parent's existing description. **Only use `-m` when setting a new description** (e.g., parent had no description). When squashing a fix into an already-described change, always omit `-m` — otherwise you silently overwrite the user's message.
+
+### Hunk-Level Operations (jjc)
+
+For splitting, dropping, or moving individual hunks between commits, use `jjc` — a non-interactive, scriptable tool for hunk-level operations.
+
+```bash
+# 1. List hunks in a revision
+jjc hunks                          # hunks in @
+jjc hunks -r <change-id>           # hunks in a specific revision
+jjc hunks --full                   # with context lines and line numbers
+
+# 2. Pick hunks into a new commit (like jj split, but non-interactive)
+jjc pick a1b -m "♻️ Extract helper"             # whole hunk by ID prefix
+jjc pick a1b#2 -m "🐛 Fix off-by-one"           # single change atom
+jjc pick a1b@15-20 -m "♻️ Refactor validation"  # by target line range
+jjc pick a1b c3d -m "msg"                        # multiple hunks
+
+# 3. Drop hunks (revert to parent content)
+jjc drop a1b
+
+# 4. Fold hunks into another revision
+jjc fold a1b --into <target-rev>
+```
+
+If `jjc` is not available, check [line-level-split-fallback.md](line-level-split-fallback.md) — it has installation instructions (ask the user first) and a manual `jj split --tool` fallback.
+
+### Moving Hunk-Level Changes Between Commits
+
+To move specific hunks from commit X into commit Y:
+```bash
+# With jjc — one step:
+jjc fold a1b --into <target-rev>
+
+# Without jjc — two steps:
+# 1. Split to isolate the hunks (see fallback doc)
+# 2. jj squash --from <split-result> --into <target> -u
+```
+
+**New work that belongs in an earlier commit**: make the edit at the top of the stack (`@`), then move the hunk down with `jjc fold <hunk> --into <target>`. Don't `jj edit <earlier-commit>` to write it there directly — early commits often have an incomplete `.gitignore` (build dirs not yet ignored), so editing there can pull build artifacts into the commit. The top of the stack has the full `.gitignore` and avoids the trap.
+
+### Reordering Changes
+
+To move a change to a different position in history:
+```bash
+# Move change X to come right before change Y (Y becomes child of X)
+jj rebase -r <change-id> --before <target-id>
+
+# Move change X to come right after change Y (X becomes child of Y)
+jj rebase -r <change-id> --after <target-id>
+```
+
+With `-r`, only the specified change moves — its descendants are rebased onto its former parent, filling the "hole".
+
+### Linter and Formatter Results
+
+Formatter/lint fixes are **not separate logical work** — they belong in the change that introduced the code, not in a commit of their own.
+
+**Single change** — fixes are in `@`, original work in parent:
+```bash
+jj squash    # folds @ into parent, keeps parent's description
+```
+
+**Across a stack of changes** — use `jj fix`, not a manual per-commit pass. It runs the configured tool over a revision and all its descendants parent-first, recreating each commit with the fix applied. It **never creates new conflicts**: each descendant gets the same tool applied to its own version of the file.
+
+```bash
+# Configure the tool once (repo or user config). The tool reads stdin,
+# writes stdout; $path expands to the file's repo path:
+#   [fix.tools.rustfmt]
+#   command  = ["rustfmt", "--emit=stdout"]
+#   patterns = ["glob:'**/*.rs'"]
+
+jj fix -s <earliest-change-id>   # fix this rev + all its descendants
+jj fix                           # default revset: reachable(@, mutable())
+jj op show -p                    # review what fix changed
+```
+
+**Gotchas:**
+- Tools must read **stdin → stdout**. Many formatters default to in-place editing — pass the stdout flag explicitly (`rustfmt --emit=stdout`, `black -`, `prettier --stdin-filepath $path`). The real file path is *not* on disk for the tool.
+- Pass the config path explicitly if the tool needs it — it can't infer project config from a stdin stream.
+- Output must be **deterministic**: jj dedupes identical file content across commits and runs the tool only once.
+
+Editing deep history is cheaper than it looks — cost scales with *line overlap*, not the number of descendants. jj rebases descendants automatically; you only do manual work where a descendant actually touches the same lines `jj fix` rewrote.
+
+If no formatter is configured for `jj fix`, fall back to a manual change **before** your work stack (`jj new <parent-of-A>`, run the tool, describe), then resolve any conflicts in the rebased A'/B'/C' bottom-up.
+
+### Safety
+
+**Before** any split or move:
+```bash
+jj op log -n 1    # record current operation state
+```
+
+**After** any split or move — verify both halves:
+```bash
+jj log                          # check commit graph looks correct
+jj diff -r <first-change-id>    # verify first commit has intended changes
+jj diff -r <second-change-id>   # verify second commit has the rest
+```
+
+**Recovery** — if something went wrong:
+```bash
+jj undo    # reverts the last jj operation cleanly
+```
+
+This is the **one case** where `jj undo` is permitted. See Anti-patterns below.
+
+## Conflicts
+
+In jj, conflicts are **not blocking**. Operations like rebase, squash, and split always succeed — if conflicts arise, they are recorded inside the commit. You can defer resolution and keep working.
+
+For detecting, reading markers, and resolving conflicts (including stacks), see [conflicts.md](conflicts.md).
+
+## Anti-patterns
+
+### Never use git commands
+```bash
+# WRONG — don't use in jj repo:
+git add, git commit, git status
+git checkout, git branch
+git log
+
+# RIGHT — use jj equivalents:
+jj st, jj log, jj new, jj describe
+```
+
+### Never destroy work
+```bash
+# WRONG — don't use for regular workflow:
+jj undo        # reverses last operation, loses recent work
+jj abandon     # discards a change
+
+# WRONG — agent rewrites its own failed approach:
+jj edit <change-with-approach-A>
+# ... replaces with approach B — A is now lost
+
+# RIGHT — branch and preserve:
+jj describe -m "⚗️ ..."    # mark the failed attempt
+jj new <change-id-before>   # branch from earlier point
+```
+
+See **Preserving Work History** for the full rule — `jj edit` is fine when the user requested the change or the agent fixes a trivial mistake.
+
+**Exceptions**:
+- `jj undo` is permitted to recover from a failed `jj split` or `jj squash --from/--into` operation. See Safety under "Splitting and Moving Changes".
+- `jj abandon` is the correct tool for removing an orphan empty commit — a change that is both `(empty)` and `(no description set)` with no descendants.
+
+### Never leave commits undescribed
+```bash
+# WRONG:
+jj new
+# ... work ...
+jj new          # forgot to describe!
+
+# RIGHT:
+jj new
+# ... work ...
+jj describe -m "What was done"
+jj new          # now start next
+```
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Initialize | `jj git init --colocate` |
+| Status | `jj st` |
+| History | `jj log` |
+| Diff | `jj diff` |
+| Start new work | `jj new` |
+| Describe commit | `jj describe -m "message"` |
+| Continue from point | `jj new <change-id>` |
+| Modify existing change | `jj edit <change-id>` (see Preserving Work History) |
+| Split by files | `jj split -r X <paths> -m "msg"` |
+| Pick hunks | `jjc pick <hunk> -m "msg"` |
+| Drop hunks | `jjc drop <hunk>` |
+| Fold hunks | `jjc fold <hunk> --into <rev>` |
+| Squash into parent | `jj squash` (keeps parent's description) |
+| Move between commits | `jj squash --from X --into Y <paths> -u` |
+| Reorder change | `jj rebase -r X --before Y` / `--after Y` |
+| Find conflicts | `jj log -r 'conflicts()'` |
+| List conflicted files | `jj resolve --list` |
+| Keep one side | `jj resolve --tool :ours <path>` |
+| Operation history | `jj op log -n 5` |
+| Undo last operation | `jj undo` (split/move recovery only) |
+
+## Sources
+
+- [jj Documentation](https://docs.jj-vcs.dev/latest/)
+- [Git command table](https://docs.jj-vcs.dev/latest/git-command-table/)
+- [Commit message guide](https://cbea.ms/git-commit/)
+
+## License
+
+EUPL 1.2 — see [LICENSE](LICENSE).

--- a/examples/gastown/packs/gastown-jj/skills/jj-vcs/conflicts.md
+++ b/examples/gastown/packs/gastown-jj/skills/jj-vcs/conflicts.md
@@ -1,0 +1,90 @@
+# Conflict Resolution in jj
+
+## Detecting Conflicts
+
+```bash
+jj log -r 'conflicts()'       # find all conflicted changes
+jj resolve --list              # list conflicted files in @
+jj resolve --list -r <id>      # list conflicted files in a specific change
+```
+
+`jj log` marks conflicted changes with `(conflict)`. `jj status` shows a warning with the list of conflicted files.
+
+## Conflict Markers
+
+jj's default marker style (`"diff"`) shows diffs to apply — this is hard to parse. For easier resolution, use `"snapshot"` style which shows full content of each side:
+
+```
+<<<<<<< conflict 1 of 1
++++++++ side #1
+apple
+grapefruit
+orange
+------- base
+apple
+grape
+orange
++++++++ side #2
+APPLE
+GRAPE
+ORANGE
+>>>>>>> conflict 1 of 1 ends
+```
+
+- `+++++++` — full content of a side
+- `-------` — full content of the common base
+- Choose the correct content or combine sides, then remove all markers
+
+To set snapshot style: `jj config set --user ui.conflict-marker-style "snapshot"`
+
+If you encounter markers with diff-like `+`/`-` lines instead of full content blocks, the repo uses the default `"diff"` style. Set `"snapshot"` first for easier resolution.
+
+## Resolving Conflicts
+
+**Edit the file directly** — remove all conflict markers, write the correct content. jj auto-detects the resolution when it snapshots the working copy (no special command needed).
+
+**Workflow** (either `jj edit` directly, or `jj new` + edit + `jj squash`):
+```bash
+# 1. Create a resolution change on top of the conflicted one
+jj new <conflicted-change-id>
+
+# 2. Read the conflicted file, edit it to remove markers and write correct content
+
+# 3. Verify
+jj diff
+
+# 4. Squash the resolution into the conflicted change
+#    Do NOT describe the resolution change — leave it empty so jj
+#    preserves the original change's description automatically
+jj squash
+```
+
+**Quick resolution** — keep one side entirely, applied directly to the conflicted change:
+```bash
+jj resolve -r <conflicted-change-id> --tool :ours <path>      # keep side #1
+jj resolve -r <conflicted-change-id> --tool :theirs <path>    # keep side #2
+```
+
+In a rebase conflict: side #1 (`:ours`) is the content from the rebased commit, side #2 (`:theirs`) is the content from the destination. Examine the conflict markers to confirm which side is which before choosing.
+
+## Resolving Conflicts in a Stack
+
+When a rebase or insertion creates conflicts in multiple descendants, **resolve from the bottom up**. Resolving a parent often auto-resolves its descendants.
+
+```bash
+# 1. Find the earliest conflicted change
+jj log -r 'conflicts()'
+
+# 2. Resolve the earliest one (see workflow above)
+jj new <earliest-conflicted>
+# ... edit files ...
+jj squash
+
+# 3. Check if descendants are now resolved — squashing may auto-resolve them,
+#    but can also create new conflicts in descendants. Either way, check:
+jj log -r 'conflicts()'
+
+# 4. If conflicts remain, repeat from step 2 for the next one up the stack
+```
+
+jj auto-rebases all descendants after each resolution. A single resolution at the root of the conflict often clears the entire stack.

--- a/examples/gastown/packs/gastown-jj/skills/jj-vcs/gitmoji-reference.md
+++ b/examples/gastown/packs/gastown-jj/skills/jj-vcs/gitmoji-reference.md
@@ -1,0 +1,81 @@
+# Gitmoji Reference
+
+Full list from [gitmoji.dev](https://gitmoji.dev/).
+
+| Emoji | Code | Description |
+|-------|------|-------------|
+| 🎨 | `:art:` | Improve structure / format of the code |
+| ⚡️ | `:zap:` | Improve performance |
+| 🔥 | `:fire:` | Remove code or files |
+| 🐛 | `:bug:` | Fix a bug |
+| 🚑️ | `:ambulance:` | Critical hotfix |
+| ✨ | `:sparkles:` | Introduce new features |
+| 📝 | `:memo:` | Add or update documentation |
+| 🚀 | `:rocket:` | Deploy stuff |
+| 💄 | `:lipstick:` | Add or update the UI and style files |
+| 🎉 | `:tada:` | Begin a project |
+| ✅ | `:white_check_mark:` | Add, update, or pass tests |
+| 🔒️ | `:lock:` | Fix security or privacy issues |
+| 🔐 | `:closed_lock_with_key:` | Add or update secrets |
+| 🔖 | `:bookmark:` | Release / Version tags |
+| 🚨 | `:rotating_light:` | Fix compiler / linter warnings |
+| 🚧 | `:construction:` | Work in progress |
+| 💚 | `:green_heart:` | Fix CI Build |
+| ⬇️ | `:arrow_down:` | Downgrade dependencies |
+| ⬆️ | `:arrow_up:` | Upgrade dependencies |
+| 📌 | `:pushpin:` | Pin dependencies to specific versions |
+| 👷 | `:construction_worker:` | Add or update CI build system |
+| 📈 | `:chart_with_upwards_trend:` | Add or update analytics or track code |
+| ♻️ | `:recycle:` | Refactor code |
+| ➕ | `:heavy_plus_sign:` | Add a dependency |
+| ➖ | `:heavy_minus_sign:` | Remove a dependency |
+| 🔧 | `:wrench:` | Add or update configuration files |
+| 🔨 | `:hammer:` | Add or update development scripts |
+| 🌐 | `:globe_with_meridians:` | Internationalization and localization |
+| ✏️ | `:pencil2:` | Fix typos |
+| 💩 | `:poop:` | Write bad code that needs to be improved |
+| ⏪️ | `:rewind:` | Revert changes |
+| 🔀 | `:twisted_rightwards_arrows:` | Merge branches |
+| 📦️ | `:package:` | Add or update compiled files or packages |
+| 👽️ | `:alien:` | Update code due to external API changes |
+| 🚚 | `:truck:` | Move or rename resources (e.g.: files, paths, routes) |
+| 📄 | `:page_facing_up:` | Add or update license |
+| 💥 | `:boom:` | Introduce breaking changes |
+| 🍱 | `:bento:` | Add or update assets |
+| ♿️ | `:wheelchair:` | Improve accessibility |
+| 💡 | `:bulb:` | Add or update comments in source code |
+| 🍻 | `:beers:` | Write code drunkenly |
+| 💬 | `:speech_balloon:` | Add or update text and literals |
+| 🗃️ | `:card_file_box:` | Perform database related changes |
+| 🔊 | `:loud_sound:` | Add or update logs |
+| 🔇 | `:mute:` | Remove logs |
+| 👥 | `:busts_in_silhouette:` | Add or update contributor(s) |
+| 🚸 | `:children_crossing:` | Improve user experience / usability |
+| 🏗️ | `:building_construction:` | Make architectural changes |
+| 📱 | `:iphone:` | Work on responsive design |
+| 🤡 | `:clown_face:` | Mock things |
+| 🥚 | `:egg:` | Add or update an easter egg |
+| 🙈 | `:see_no_evil:` | Add or update a .gitignore file |
+| 📸 | `:camera_flash:` | Add or update snapshots |
+| ⚗️ | `:alembic:` | Perform experiments |
+| 🔍️ | `:mag:` | Improve SEO |
+| 🏷️ | `:label:` | Add or update types |
+| 🌱 | `:seedling:` | Add or update seed files |
+| 🚩 | `:triangular_flag_on_post:` | Add, update, or remove feature flags |
+| 🥅 | `:goal_net:` | Catch errors |
+| 💫 | `:dizzy:` | Add or update animations and transitions |
+| 🗑️ | `:wastebasket:` | Deprecate code that needs to be cleaned up |
+| 🛂 | `:passport_control:` | Work on code related to authorization, roles and permissions |
+| 🩹 | `:adhesive_bandage:` | Simple fix for a non-critical issue |
+| 🧐 | `:monocle_face:` | Data exploration/inspection |
+| ⚰️ | `:coffin:` | Remove dead code |
+| 🧪 | `:test_tube:` | Add a failing test |
+| 👔 | `:necktie:` | Add or update business logic |
+| 🩺 | `:stethoscope:` | Add or update healthcheck |
+| 🧱 | `:bricks:` | Infrastructure related changes |
+| 🧑‍💻 | `:technologist:` | Improve developer experience |
+| 💸 | `:money_with_wings:` | Add sponsorships or money related infrastructure |
+| 🧵 | `:thread:` | Add or update code related to multithreading or concurrency |
+| 🦺 | `:safety_vest:` | Add or update code related to validation |
+| ✈️ | `:airplane:` | Improve offline support |
+| 🦖 | `:t-rex:` | Code that adds backwards compatibility |

--- a/examples/gastown/packs/gastown-jj/skills/jj-vcs/line-level-split-fallback.md
+++ b/examples/gastown/packs/gastown-jj/skills/jj-vcs/line-level-split-fallback.md
@@ -1,0 +1,121 @@
+# Line-Level Split Fallback
+
+This document covers two things:
+1. Installing `jjc` (the preferred tool for hunk-level operations)
+2. Manual `jj split --tool` approach (when jjc is unavailable)
+
+## Installing jjc
+
+**Before installing, ask the user.** Don't install tools without consent. Explain what jjc gives you:
+
+> jjc is a non-interactive hunk-level tool for jj. It lets me split, drop, and move individual hunks by ID — without writing temporary scripts. Without it I can still do line-level splits, but the process is more manual and error-prone (see below). Want me to install it?
+
+If the user declines, skip to the manual approach below.
+
+### Prerequisites
+
+- **jj v0.41.0+** — check with `jj --version`
+- **Rust toolchain** — check with `cargo --version`
+
+If `cargo` is not found, the user needs to install the Rust toolchain first. **This is a separate decision — ask the user how they prefer to install Rust** (rustup, Homebrew, Nix, system package manager, etc.). Point them to https://rustup.rs if they have no preference.
+
+### Install
+
+```bash
+cargo install --git https://tangled.sh/akashina.tngl.sh/jjc
+```
+
+Compiles from source — may take a few minutes on first run.
+
+After installation, verify: `jjc --help`
+
+Project page: https://tangled.org/akashina.tngl.sh/jjc
+
+## Manual Line-Level Split (jj split --tool)
+
+For splitting changes **within a single file** — keeping some hunks in one commit and moving the rest to another — use a custom diff editor script.
+
+### Protocol
+
+jj passes two directories to the script:
+- `$1` (`left`) — parent commit state (read-only)
+- `$2` (`right`) — current commit state (writable)
+
+Modify files in `$2` to contain only the changes wanted in the **first** commit. Whatever you revert toward `$1` goes into the **second** commit.
+
+### Step-by-step
+
+1. Inspect the changes:
+```bash
+jj diff -r <change-id>
+```
+
+2. Decide which hunks belong in commit 1 vs commit 2.
+
+3. Write a temporary tool script:
+```bash
+#!/bin/bash
+left="$1"    # parent state (read-only)
+right="$2"   # current state (writable) — edit this
+
+# To REVERT a file entirely (move ALL its changes to commit 2):
+cp "$left/path/to/file.rs" "$right/path/to/file.rs"
+
+# To KEEP a file entirely in commit 1:
+# (do nothing — leave $right as-is)
+
+# To keep SOME lines in commit 1 (line-level split):
+# Write the desired partial state for commit 1:
+cat > "$right/path/to/file.rs" << 'FILECONTENT'
+... file content with only the changes wanted in commit 1 ...
+FILECONTENT
+```
+
+4. Run the split (the script must exit 0 — non-zero aborts the split):
+```bash
+chmod +x /tmp/jj-split-tool.sh
+jj split -r <change-id> --tool /tmp/jj-split-tool.sh -m "First part"
+```
+
+5. Clean up, find the second commit, and describe it:
+```bash
+rm /tmp/jj-split-tool.sh
+jj log    # find the second commit's change ID
+jj describe -r <second-change-id> -m "Second part"
+```
+
+6. Verify (see Safety in SKILL.md).
+
+**Note**: `-m` sets the description for the first commit. The second commit keeps the original description from before the split. If the original had no description, neither will the second commit.
+
+### Example
+
+A commit changes both `src/utils.ts` (refactors a helper) and `src/validation.ts` (adds email validation). Split into two atomic commits:
+
+```bash
+# 1. Check what changed
+jj diff -r qvlmxkoz
+
+# 2. Write tool script that keeps only the utils.ts refactoring
+#    by reverting validation.ts back to parent state
+cat > /tmp/jj-split-tool.sh << 'EOF'
+#!/bin/bash
+cp "$1/src/validation.ts" "$2/src/validation.ts"
+EOF
+
+# 3. Split
+chmod +x /tmp/jj-split-tool.sh
+jj split -r qvlmxkoz --tool /tmp/jj-split-tool.sh -m "♻️ Extract helper function for validation"
+rm /tmp/jj-split-tool.sh
+
+# 4. Describe the second commit (has the validation changes)
+jj describe -r <new-change-id> -m "🦺 Add email format validation"
+```
+
+### Moving line-level changes between commits (manual)
+
+1. Line-level split commit X (see above) to isolate the target changes
+2. Move the isolated commit into Y:
+```bash
+jj squash --from <split-result> --into <target> -u
+```


### PR DESCRIPTION
## Purpose

Add the Codeberg jj-vcs skill to the Gas Town jj pack using Gas City skill catalog conventions.

## What Changed

- Adds `examples/gastown/packs/gastown-jj/pack.toml` so the jj pack is a valid importable pack.
- Installs the full cloned `jj-vcs` skill under `examples/gastown/packs/gastown-jj/skills/jj-vcs/`.
- Keeps the referenced files beside `SKILL.md`: `conflicts.md`, `gitmoji-reference.md`, `line-level-split-fallback.md`, `README.md`, and `LICENSE`.

## Hunk Tool Note

The skill references `jjc` for hunk-level operations. That is different from `jj-hunk`, which uses JSON/YAML selection specs with commands like `jj-hunk list`, `commit`, `split`, and `squash`. Both are non-interactive hunk-selection tools for jj, but their CLIs and selector models differ.

## Verification

- `go test ./internal/config -run 'TestLoadWithIncludes_RootPackImportedSharedSkillsCompose|TestLoadWithIncludes_CityPackCommandsUsePackNameBinding' -count=1`
- `go test ./cmd/gc -run 'TestSkillListImportedSharedCatalog|TestSkillListCityCatalog' -count=1`
- Direct `gc skill list --json` probe against a temp city importing this pack reports `gastown-jj.jj-vcs`.
