### PR TITLE
fix(mail/exec): always set stdin on exec provider subprocesses

### DIFF
--- a/internal/mail/exec/exec.go
+++ b/internal/mail/exec/exec.go
@@ -223,6 +223,9 @@ func (p *Provider) ensureRunning() {
 //
 // Exit code 2 is treated as success (unknown operation — forward compatible).
 // Any other non-zero exit code returns an error wrapping stderr.
+//
+// Stdin is always explicitly set so the script never inherits the caller's
+// stdin (which would break shell loops over gc mail archive / delete).
 func (p *Provider) run(stdinData []byte, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
 	defer cancel()
@@ -233,10 +236,7 @@ func (p *Provider) run(stdinData []byte, args ...string) (string, error) {
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-
-	if stdinData != nil {
-		cmd.Stdin = bytes.NewReader(stdinData)
-	}
+	cmd.Stdin = bytes.NewReader(stdinData) // nil → empty reader → script reads EOF
 
 	err := cmd.Run()
 	if err != nil {

--- a/release-gates/mail-exec-stdin-isolation-gate.md
+++ b/release-gates/mail-exec-stdin-isolation-gate.md
@@ -1,0 +1,54 @@
+# Release Gate: mail exec stdin isolation
+
+Bead: ga-tsvwf7
+Source review bead: ga-k4jzoi
+Branch: fix/mail-exec-stdin-isolation
+Reviewed commit: 4d8ee225bc7d9d611f90efcd9552e9d83434c8f6
+Base: origin/main at 0dae71e3b33218250a23a3c35b889e325aaa9fe7
+Gate run: 2026-06-08
+
+## Summary
+
+The reviewed change updates `internal/mail/exec.Provider.run` so every exec
+provider subprocess gets an explicit stdin reader. `nil` input now becomes an
+empty reader that returns EOF, preventing scripts from inheriting the caller's
+stdin during archive/delete/check/read operations. Non-empty stdin paths still
+use the same `bytes.NewReader(stdinData)` behavior as before.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-k4jzoi` shows the review bead closed with `VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | `git diff origin/main..HEAD -- internal/mail/exec/exec.go` shows `cmd.Stdin = bytes.NewReader(stdinData)` is unconditional, with no other files changed. This satisfies the stdin-isolation fix while preserving non-nil stdin behavior. |
+| 3 | Tests pass | PASS | `go test ./internal/mail/exec/...` passed. `go vet ./internal/mail/exec/...` passed. `make test-fast-parallel` passed all fast shards. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-k4jzoi` list security/correctness/style as PASS and no HIGH findings. The only noted gaps are follow-up tests tracked in `ga-0mhj1r`. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean on `fix/mail-exec-stdin-isolation` before adding this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base HEAD origin/main` equals `origin/main` and `git merge-tree --write-tree origin/main HEAD` completed cleanly. |
+| 7 | Single feature theme | PASS | Commit set is one commit touching only `internal/mail/exec/exec.go`; the change is a single mail exec provider stdin-isolation fix. |
+
+## Commands
+
+```text
+go test ./internal/mail/exec/...
+ok  	github.com/gastownhall/gascity/internal/mail/exec	20.574s
+
+go vet ./internal/mail/exec/...
+PASS
+
+make test-fast-parallel
+[unit-cmd-gc-1-of-6] ok
+[unit-core] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-3-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-6-of-6] ok
+All fast jobs passed
+
+go vet ./...
+PASS
+
+git merge-tree --write-tree origin/main HEAD
+PASS
+```


### PR DESCRIPTION
## What this changes

The exec mail provider now gives every helper script an explicit stdin stream. Operations that do not send a payload, such as archive/delete/check/read/count, pass an empty reader that reaches EOF immediately. Payload operations such as send/reply keep passing their existing bytes.

This prevents `gc mail archive` and `gc mail delete` calls backed by an `exec:` provider from consuming the caller's terminal or pipeline input when they run inside shell loops.

## Review notes

- Implementation surface is `internal/mail/exec.Provider.run`; no config, API, schema, or dashboard changes.
- The behavior is default-on because it only constrains child-process stdin to the provider operation's input.
- Follow-up regression coverage for subprocess stdin isolation is tracked separately; this PR keeps the runtime fix narrow.

## Test plan

- [x] `go test ./internal/mail/exec/...`
- [x] `go vet ./internal/mail/exec/...`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/mail-exec-stdin-isolation-gate.md`](release-gates/mail-exec-stdin-isolation-gate.md)