### PR TITLE
fix(test): shorten tmux socket paths to fit macOS 104-byte limit

### DIFF
--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -34,13 +34,7 @@ func uniqueCityName() string {
 	if _, err := rand.Read(b); err != nil {
 		panic("generating random city name: " + err.Error())
 	}
-	hex := fmt.Sprintf("%x", b)
-	parts := make([]string, 0, len(hex)+1)
-	parts = append(parts, "gctest")
-	for _, r := range hex {
-		parts = append(parts, string(r))
-	}
-	return strings.Join(parts, "-")
+	return fmt.Sprintf("gctest-%x", b)
 }
 
 // setupCity creates a city directory, initializes it, writes a city.toml

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -96,7 +96,23 @@ func TestMain(m *testing.M) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	if err := tmuxtest.ConfigureProcessEnv(filepath.Join(tmpDir, "tmux")); err != nil {
+	// Create the tmux socket root under /tmp rather than $TMPDIR.
+	// On macOS, $TMPDIR is ~80 chars (/private/var/folders/…/T/); nesting
+	// tmux sockets inside it pushes socket paths past macOS's 104-byte limit.
+	// /tmp is world-writable on macOS, Linux, and CI runners.
+	tmuxSocketParent, tmuxParentErr := os.MkdirTemp("/tmp", "gct-")
+	tmuxSocketRoot := filepath.Join(tmpDir, "tmux")
+	if tmuxParentErr == nil {
+		tmuxSocketRoot = filepath.Join(tmuxSocketParent, "tmux")
+		if err := os.MkdirAll(tmuxSocketRoot, 0o700); err != nil {
+			os.RemoveAll(tmuxSocketParent)
+			tmuxSocketParent = ""
+			tmuxSocketRoot = filepath.Join(tmpDir, "tmux")
+		} else {
+			defer os.RemoveAll(tmuxSocketParent)
+		}
+	}
+	if err := tmuxtest.ConfigureProcessEnv(tmuxSocketRoot); err != nil {
 		panic("integration: configuring tmux test env: " + err.Error())
 	}
 

--- a/test/tmuxtest/guard.go
+++ b/test/tmuxtest/guard.go
@@ -70,7 +70,7 @@ func RequireTmux(t testing.TB) {
 // sessions matching that city via t.Cleanup.
 type Guard struct {
 	t          testing.TB
-	cityName   string // "gctest-<nibble>-<nibble>-..."
+	cityName   string // "gctest-<8hex>"
 	socketName string // tmux socket for isolation (defaults to cityName)
 }
 
@@ -89,13 +89,7 @@ func NewGuardWithSocket(t testing.TB, socketName string) *Guard {
 	if _, err := rand.Read(b); err != nil {
 		t.Fatalf("tmuxtest: generating random city name: %v", err)
 	}
-	hex := fmt.Sprintf("%x", b)
-	parts := make([]string, 0, len(hex)+1)
-	parts = append(parts, "gctest")
-	for _, r := range hex {
-		parts = append(parts, string(r))
-	}
-	cityName := strings.Join(parts, "-")
+	cityName := fmt.Sprintf("gctest-%x", b)
 	if socketName == "" {
 		socketName = cityName
 	}

--- a/test/tmuxtest/guard_test.go
+++ b/test/tmuxtest/guard_test.go
@@ -1,6 +1,8 @@
 package tmuxtest
 
 import (
+	"crypto/rand"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -84,6 +86,7 @@ func TestTmuxSocketRootPatternsCoverKnownRuntimePrefixes(t *testing.T) {
 	tests := []struct {
 		name    string
 		runName string
+		direct  bool // true = activeRoot is namespace/runName/tmux (no "runtime" level)
 		want    string
 	}{
 		{
@@ -111,15 +114,51 @@ func TestTmuxSocketRootPatternsCoverKnownRuntimePrefixes(t *testing.T) {
 			runName: "gc-acceptance-123",
 			want:    filepath.Join(namespace, "gc-acceptance-*", "runtime", "tmux"),
 		},
+		{
+			name:    "integration direct",
+			runName: "gc-integration-123",
+			direct:  true,
+			want:    filepath.Join(namespace, "gc-integration-*", "tmux"),
+		},
+		{
+			// gct- is the short-path tmux socket root created by the integration
+			// test suite when $TMPDIR is too long (e.g., macOS).
+			name:    "gct short root",
+			runName: "gct-1234567890",
+			direct:  true,
+			want:    filepath.Join(namespace, "gct*", "tmux"),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			activeRoot := filepath.Join(namespace, tt.runName, "runtime", "tmux")
+			var activeRoot string
+			if tt.direct {
+				activeRoot = filepath.Join(namespace, tt.runName, "tmux")
+			} else {
+				activeRoot = filepath.Join(namespace, tt.runName, "runtime", "tmux")
+			}
 			got := tmuxSocketRootPatterns(activeRoot)
 			if !slices.Contains(got, tt.want) {
 				t.Fatalf("tmuxSocketRootPatterns(%q) = %v, want %q", activeRoot, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewGuardWithSocketCityNameFormat(t *testing.T) {
+	// City name must be "gctest-<8hex>" (no per-character hyphens).
+	// macOS's UNIX socket path limit is 104 bytes; per-char hyphenation
+	// creates names like "gctest-4-f-d-9-6-0-8-c" (22 chars) instead of
+	// "gctest-4fd9608c" (15 chars), which pushes socket paths over the limit.
+	for range 100 {
+		b := make([]byte, 4)
+		if _, err := rand.Read(b); err != nil {
+			t.Fatal(err)
+		}
+		name := fmt.Sprintf("gctest-%x", b)
+		if len(name) != 15 {
+			t.Fatalf("city name %q has length %d, want 15", name, len(name))
+		}
 	}
 }


### PR DESCRIPTION
## Summary

All Mac integration tests were failing with `File name too long` on tmux socket connections. Two compounding issues pushed socket paths past macOS's 104-byte UNIX domain socket limit (`UNIX_PATH_MAX`):

- **Bug 1 (city name format)**: `uniqueCityName()` in both `guard.go` and `helpers_test.go` was generating names like `gctest-4-f-d-9-6-0-8-c` (22 chars, per-character hyphens) instead of the documented `gctest-<8hex>` compact format (15 chars). The comment said `gctest-<8hex>` but the code looped over individual hex characters.
- **Bug 2 (tmux socket root under $TMPDIR)**: The tmux socket root sat inside `$TMPDIR` which on macOS CI is ~80 chars (`/private/var/folders/…/T/`). Combined path: `$TMPDIR` (52) + `gc-integration-*` (26) + `tmux/` (5) + `tmux-<uid>/` (9) + socket name (22) = **114 chars** → exceeds 104-byte limit.

## Fix

1. **City name format**: `fmt.Sprintf("gctest-%x", b)` — compact hex, no per-character hyphens. Fixes both `guard.go` and `helpers_test.go`.

2. **Tmux socket root**: `integration_test.go` TestMain now creates the socket root under `/tmp` (world-writable on macOS, Linux, and CI) using a `gct-*` prefix. The guard's existing `strings.HasPrefix(runName, "gct")` case already handles orphan-sweeping for this prefix.

Resulting socket path: `/tmp/gct-XXXXXXXXXX/tmux/tmux-501/gctest-aabbccdd` = ~57 chars ✓

## Test plan

- [x] `go test ./test/tmuxtest/ -v` — all guard tests pass including two new cases
- [x] `make test-fast-parallel` — clean pass
- [x] `go vet ./...` — clean

Closes ga-eaonum and related Mac CI shards (ga-m8ozj7, ga-v0chjo, ga-ejrqud, ga-rfa96z, ga-ekh6rf, ga-n8ockf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)