### PR TITLE
test(mail): regression coverage for multi-ID JSON archive + exec stdin isolation (ga-0mhj1r)

### DIFF
--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -2536,6 +2536,58 @@ func TestMailArchiveMultiSuccess(t *testing.T) {
 	}
 }
 
+func TestMailArchiveManyJSONEmitsBatchShape(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	for i := 0; i < 3; i++ {
+		if _, err := mp.Send("human", "mayor", "", "batch"); err != nil {
+			t.Fatalf("Send %d: %v", i, err)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doMailArchiveManyJSON(mp, events.Discard, []string{"gc-1", "gc-2", "gc-3"}, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailArchiveManyJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if _, ok := raw["id"]; ok {
+		t.Fatalf("batch archive JSON included singular id field: %s", stdout.String())
+	}
+
+	var got struct {
+		SchemaVersion string   `json:"schema_version"`
+		OK            bool     `json:"ok"`
+		Command       string   `json:"command"`
+		Action        string   `json:"action"`
+		IDs           []string `json:"ids"`
+		Count         int      `json:"count"`
+		AlreadyDone   bool     `json:"already_done"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal JSON result: %v", err)
+	}
+	if got.SchemaVersion != "1" || !got.OK || got.Command != "mail.archive" || got.Action != "archive" {
+		t.Fatalf("unexpected envelope: %+v", got)
+	}
+	if strings.Join(got.IDs, ",") != "gc-1,gc-2,gc-3" {
+		t.Fatalf("ids = %v, want [gc-1 gc-2 gc-3]", got.IDs)
+	}
+	if got.Count != 3 {
+		t.Fatalf("count = %d, want 3", got.Count)
+	}
+	if got.AlreadyDone {
+		t.Fatal("already_done = true, want false")
+	}
+}
+
 func TestMailArchiveMultiPartialFailure(t *testing.T) {
 	mp := mail.NewFake()
 	m1, _ := mp.Send("human", "mayor", "", "one")

--- a/internal/mail/exec/exec_test.go
+++ b/internal/mail/exec/exec_test.go
@@ -2,6 +2,7 @@ package exec //nolint:revive // internal package, always imported with alias
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,6 +164,62 @@ func TestArchive(t *testing.T) {
 
 	if err := p.Archive("m-1"); err != nil {
 		t.Fatalf("Archive: %v", err)
+	}
+}
+
+func TestArchiveDoesNotConsumeCallerStdin(t *testing.T) {
+	dir := t.TempDir()
+	stdinLog := filepath.Join(dir, "stdin.log")
+	script := writeScript(t, dir, `
+op="$1"
+if IFS= read -r line; then
+  printf '%s:%s\n' "$op" "$line" >> "`+stdinLog+`"
+else
+  printf '%s:EOF\n' "$op" >> "`+stdinLog+`"
+fi
+
+case "$op" in
+  ensure-running|archive) ;;
+  *) exit 2 ;;
+esac
+`)
+	p := NewProvider(script)
+
+	callerStdinPath := filepath.Join(dir, "caller-stdin")
+	if err := os.WriteFile(callerStdinPath, []byte("caller-owned\nsecond-line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	callerStdin, err := os.Open(callerStdinPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer callerStdin.Close() //nolint:errcheck
+
+	originalStdin := os.Stdin
+	os.Stdin = callerStdin
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+	})
+
+	if err := p.Archive("m-1"); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	data, err := os.ReadFile(stdinLog)
+	if err != nil {
+		t.Fatalf("read stdin log: %v", err)
+	}
+	got := string(data)
+	want := "ensure-running:EOF\narchive:EOF\n"
+	if got != want {
+		t.Fatalf("script stdin log = %q, want %q", got, want)
+	}
+	pos, err := callerStdin.Seek(0, io.SeekCurrent)
+	if err != nil {
+		t.Fatalf("caller stdin position: %v", err)
+	}
+	if pos != 0 {
+		t.Fatalf("caller stdin offset = %d, want 0", pos)
 	}
 }
 

--- a/release-gates/ga-yr2atp-mail-regression-gate.md
+++ b/release-gates/ga-yr2atp-mail-regression-gate.md
@@ -19,7 +19,7 @@ commands documented in TESTING.md.
 |---|-----------|--------|----------|
 | 1 | Review PASS present | PASS | Review bead ga-fez44r is closed with close reason `pass` and notes contain `REVIEWER VERDICT: PASS`. |
 | 2 | Acceptance criteria met | PASS | `go test ./cmd/gc -run TestMailArchiveManyJSONEmitsBatchShape -count=1` passed; `go test ./internal/mail/exec -run TestArchiveDoesNotConsumeCallerStdin -count=1` passed. The tests assert batch JSON archive shape and exec-provider stdin isolation. |
-| 3 | Tests pass | PASS | `make test-fast-parallel` passed all fast jobs; `go vet ./...` completed cleanly. GitHub PR #3238 checks were also green at gate time. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed all fast jobs; `go vet ./...` completed cleanly. |
 | 4 | No high-severity review findings open | PASS | Review bead ga-fez44r lists no unresolved HIGH findings. GitHub PR #3238 has no review comments or reviews. |
 | 5 | Final branch is clean | PASS | Clean deploy worktree at PR head before gate file creation; final clean status verified after the gate commit. |
 | 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` completed successfully after the gate commit. GitHub reports PR #3238 merge state `CLEAN`. |

--- a/release-gates/ga-yr2atp-mail-regression-gate.md
+++ b/release-gates/ga-yr2atp-mail-regression-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: ga-yr2atp mail regression coverage
+
+Date: 2026-06-08
+
+Deploy bead: ga-yr2atp
+Source bead: ga-0mhj1r
+Review bead: ga-fez44r
+Branch: builder/ga-0mhj1r
+Reviewed commit: bad5eb9d1712c879c1a740732c245cf11171ef53
+Existing PR: https://github.com/gastownhall/gascity/pull/3238
+
+Note: docs/PROJECT_MANIFEST.md is not present in this worktree. This gate uses
+the deployer release criteria from the active Gas City role prompt and the test
+commands documented in TESTING.md.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-fez44r is closed with close reason `pass` and notes contain `REVIEWER VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | `go test ./cmd/gc -run TestMailArchiveManyJSONEmitsBatchShape -count=1` passed; `go test ./internal/mail/exec -run TestArchiveDoesNotConsumeCallerStdin -count=1` passed. The tests assert batch JSON archive shape and exec-provider stdin isolation. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed all fast jobs; `go vet ./...` completed cleanly. GitHub PR #3238 checks were also green at gate time. |
+| 4 | No high-severity review findings open | PASS | Review bead ga-fez44r lists no unresolved HIGH findings. GitHub PR #3238 has no review comments or reviews. |
+| 5 | Final branch is clean | PASS | Clean deploy worktree at PR head before gate file creation; final clean status verified after the gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` completed successfully after the gate commit. GitHub reports PR #3238 merge state `CLEAN`. |
+| 7 | Single feature theme | PASS | Commit set is one mail regression-test theme touching only `cmd/gc/cmd_mail_test.go` and `internal/mail/exec/exec_test.go`. |
+
+## Change Set
+
+| Commit | Subject | Paths |
+|--------|---------|-------|
+| bad5eb9d1712c879c1a740732c245cf11171ef53 | test: cover mail archive regressions | `cmd/gc/cmd_mail_test.go`, `internal/mail/exec/exec_test.go` |
+
+## Local Commands
+
+```text
+make test-fast-parallel
+go vet ./...
+go test ./cmd/gc -run TestMailArchiveManyJSONEmitsBatchShape -count=1
+go test ./internal/mail/exec -run TestArchiveDoesNotConsumeCallerStdin -count=1
+git merge-tree --write-tree origin/main HEAD
+```


### PR DESCRIPTION
## What this changes

This adds regression coverage for two mail behaviors that operators depend on:
batch JSON archive output from `gc mail archive` and stdin isolation in the
`exec:` mail provider.

The CLI test locks the batch JSON shape for multi-ID archive calls: callers get
an `ids` array, `count`, and `already_done` value, with no accidental singular
`id` field. The exec-provider test proves archive startup and archive delivery
do not drain the caller's `os.Stdin`, so wrapper commands and parent processes
can keep using their own stdin after mail archive operations.

No production code, config, API, or generated assets change in this PR.

## Review notes

- `cmd/gc/cmd_mail_test.go` covers the externally visible JSON response shape.
- `internal/mail/exec/exec_test.go` covers subprocess stdin wiring for the
  exec mail provider.
- This is test-only regression coverage for behavior already implemented on
  main.

## Test plan

- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go test ./cmd/gc -run TestMailArchiveManyJSONEmitsBatchShape -count=1`
- [x] `go test ./internal/mail/exec -run TestArchiveDoesNotConsumeCallerStdin -count=1`
- [x] Release gate: [`release-gates/ga-yr2atp-mail-regression-gate.md`](release-gates/ga-yr2atp-mail-regression-gate.md)
