### PR TITLE
Route work option metadata through OptionsSchema

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -282,6 +282,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewBeadsStoreCheck(cityPath, storeFactory))
 		register(newV2RoutedToNamespaceCheck(cfg, cityPath, storeFactory))
 		register(newRunTargetRoutedToBackfillCheck(cfg, cityPath, storeFactory))
+		register(newWorkOptionMetadataMigrationCheck(cfg, cityPath, storeFactory))
 		register(newBacklogDepthCheck(cityPath, storeFactory))
 		register(newOrderTrackingRetentionCheck(cityPath, storeFactory))
 		register(&sessionModelDoctorCheck{cfg: cfg, cityPath: cityPath, newStore: storeFactory})

--- a/cmd/gc/doctor_warmup_test.go
+++ b/cmd/gc/doctor_warmup_test.go
@@ -18,6 +18,7 @@ func TestCommandDoctorChecksWarmupEligibleDefaultsFalse(t *testing.T) {
 		&mcpSharedTargetDoctorCheck{},
 		&sessionModelDoctorCheck{},
 		&v2RoutedToNamespaceCheck{},
+		&workOptionMetadataMigrationCheck{},
 		v2FormulasDirCheck{},
 		v2AgentFormatCheck{},
 		v2DefaultRigImportFormatCheck{},

--- a/cmd/gc/doctor_work_option_metadata.go
+++ b/cmd/gc/doctor_work_option_metadata.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+type workOptionMetadataMigrationCheck struct {
+	cfg      *config.City
+	cityPath string
+	newStore func(string) (beads.Store, error)
+}
+
+func newWorkOptionMetadataMigrationCheck(cfg *config.City, cityPath string, newStore func(string) (beads.Store, error)) *workOptionMetadataMigrationCheck {
+	return &workOptionMetadataMigrationCheck{cfg: cfg, cityPath: cityPath, newStore: newStore}
+}
+
+func (c *workOptionMetadataMigrationCheck) Name() string {
+	return "work-option-metadata-migration"
+}
+
+func (c *workOptionMetadataMigrationCheck) CanFix() bool { return true }
+
+func (c *workOptionMetadataMigrationCheck) WarmupEligible() bool { return false }
+
+type workOptionLegacyKey struct {
+	legacy    string
+	canonical string
+}
+
+var workOptionLegacyKeys = []workOptionLegacyKey{
+	{legacy: "gc.model", canonical: dispatchOptionMetadataKey("model")},
+	{legacy: "gc.reasoning", canonical: dispatchOptionMetadataKey("effort")},
+}
+
+type workOptionMetadataMigration struct {
+	legacy      string
+	canonical   string
+	value       string
+	canonicalOK bool
+}
+
+type workOptionMigrationTarget struct {
+	label      string
+	store      beads.Store
+	beadID     string
+	migrations []workOptionMetadataMigration
+}
+
+func (c *workOptionMetadataMigrationCheck) collect() (targets []workOptionMigrationTarget, skipped []string) {
+	scopes := []struct{ label, path string }{{"city", c.cityPath}}
+	if c.cfg != nil {
+		for _, rig := range c.cfg.Rigs {
+			if rig.Suspended || strings.TrimSpace(rig.Path) == "" {
+				continue
+			}
+			scopes = append(scopes, struct{ label, path string }{"rig " + rig.Name, rig.Path})
+		}
+	}
+	for _, sc := range scopes {
+		if c.newStore == nil || strings.TrimSpace(sc.path) == "" {
+			continue
+		}
+		store, err := c.newStore(sc.path)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s skipped: opening bead store: %v", sc.label, err))
+			continue
+		}
+		items, err := store.List(beads.ListQuery{Type: "task", Sort: beads.SortCreatedAsc})
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s skipped: listing task beads: %v", sc.label, err))
+			continue
+		}
+		for _, b := range items {
+			migrations := workOptionMetadataMigrations(b)
+			if len(migrations) == 0 {
+				continue
+			}
+			targets = append(targets, workOptionMigrationTarget{
+				label:      sc.label,
+				store:      store,
+				beadID:     b.ID,
+				migrations: migrations,
+			})
+		}
+	}
+	return targets, skipped
+}
+
+func workOptionMetadataMigrations(b beads.Bead) []workOptionMetadataMigration {
+	if b.Metadata == nil {
+		return nil
+	}
+	var migrations []workOptionMetadataMigration
+	for _, key := range workOptionLegacyKeys {
+		value := strings.TrimSpace(b.Metadata[key.legacy])
+		if value == "" {
+			continue
+		}
+		migrations = append(migrations, workOptionMetadataMigration{
+			legacy:      key.legacy,
+			canonical:   key.canonical,
+			value:       value,
+			canonicalOK: strings.TrimSpace(b.Metadata[key.canonical]) != "",
+		})
+	}
+	return migrations
+}
+
+func (c *workOptionMetadataMigrationCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	targets, skipped := c.collect()
+	if len(targets) == 0 && len(skipped) == 0 {
+		return okCheck(c.Name(), "no live task beads use legacy work option metadata")
+	}
+	details := make([]string, 0, len(targets)+len(skipped))
+	for _, tgt := range targets {
+		details = append(details, fmt.Sprintf("%s bead %s has %s", tgt.label, tgt.beadID, describeWorkOptionMigrations(tgt.migrations)))
+	}
+	details = append(details, skipped...)
+	sort.Strings(details)
+	if len(targets) == 0 {
+		return warnCheck(c.Name(),
+			fmt.Sprintf("work option metadata migration skipped %d scope(s)", len(skipped)),
+			"fix bead store access, then rerun gc doctor",
+			details)
+	}
+	return warnCheck(c.Name(),
+		fmt.Sprintf("%d live task bead(s) use legacy work option metadata", len(targets)),
+		"run gc doctor --fix to migrate gc.model/gc.reasoning to opt_model/opt_effort",
+		details)
+}
+
+func describeWorkOptionMigrations(migrations []workOptionMetadataMigration) string {
+	parts := make([]string, 0, len(migrations))
+	for _, migration := range migrations {
+		parts = append(parts, fmt.Sprintf("%s -> %s", migration.legacy, migration.canonical))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (c *workOptionMetadataMigrationCheck) Fix(_ *doctor.CheckContext) error {
+	targets, skipped := c.collect()
+	for _, tgt := range targets {
+		kvs := make(map[string]string, len(tgt.migrations)*2)
+		for _, migration := range tgt.migrations {
+			if !migration.canonicalOK {
+				kvs[migration.canonical] = migration.value
+			}
+			kvs[migration.legacy] = ""
+		}
+		if err := tgt.store.SetMetadataBatch(tgt.beadID, kvs); err != nil {
+			return fmt.Errorf("%s bead %s: migrate work option metadata: %w", tgt.label, tgt.beadID, err)
+		}
+	}
+	if len(skipped) > 0 {
+		return fmt.Errorf("work-option-metadata-migration skipped %d scope(s): %s", len(skipped), strings.Join(skipped, "; "))
+	}
+	return nil
+}

--- a/cmd/gc/doctor_work_option_metadata.go
+++ b/cmd/gc/doctor_work_option_metadata.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -8,6 +9,8 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
 )
 
 type workOptionMetadataMigrationCheck struct {
@@ -38,6 +41,11 @@ var workOptionLegacyKeys = []workOptionLegacyKey{
 	{legacy: "gc.reasoning", canonical: dispatchOptionMetadataKey("effort")},
 }
 
+const (
+	legacyPerDispatchModelSourceKey = "gc.per_dispatch_model"
+	templateOverridesMetadataKey    = "template_overrides"
+)
+
 type workOptionMetadataMigration struct {
 	legacy      string
 	canonical   string
@@ -45,18 +53,27 @@ type workOptionMetadataMigration struct {
 	canonicalOK bool
 }
 
+type workOptionSessionCleanup struct {
+	source                     string
+	removeAutoStampedModel     bool
+	updatedTemplateOverrides   string
+	updateTemplateOverridesKey bool
+}
+
 type workOptionMigrationTarget struct {
-	label      string
-	store      beads.Store
-	beadID     string
-	migrations []workOptionMetadataMigration
+	label          string
+	store          beads.Store
+	beadID         string
+	migrations     []workOptionMetadataMigration
+	sessionCleanup *workOptionSessionCleanup
 }
 
 func (c *workOptionMetadataMigrationCheck) collect() (targets []workOptionMigrationTarget, skipped []string) {
 	scopes := []struct{ label, path string }{{"city", c.cityPath}}
 	if c.cfg != nil {
+		suspState, _ := loadSuspensionState(fsys.OSFS{}, c.cityPath)
 		for _, rig := range c.cfg.Rigs {
-			if rig.Suspended || strings.TrimSpace(rig.Path) == "" {
+			if suspensionstate.EffectiveRigSuspended(suspState, rig.Name, rig.EffectiveSuspendedOnStart()) || strings.TrimSpace(rig.Path) == "" {
 				continue
 			}
 			scopes = append(scopes, struct{ label, path string }{"rig " + rig.Name, rig.Path})
@@ -88,6 +105,23 @@ func (c *workOptionMetadataMigrationCheck) collect() (targets []workOptionMigrat
 				migrations: migrations,
 			})
 		}
+		sessions, err := loadSessionBeads(store)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s skipped: listing session beads: %v", sc.label, err))
+			continue
+		}
+		for _, b := range sessions {
+			cleanup := workOptionSessionCleanupMigration(b)
+			if cleanup == nil {
+				continue
+			}
+			targets = append(targets, workOptionMigrationTarget{
+				label:          sc.label,
+				store:          store,
+				beadID:         b.ID,
+				sessionCleanup: cleanup,
+			})
+		}
 	}
 	return targets, skipped
 }
@@ -112,14 +146,49 @@ func workOptionMetadataMigrations(b beads.Bead) []workOptionMetadataMigration {
 	return migrations
 }
 
+func workOptionSessionCleanupMigration(b beads.Bead) *workOptionSessionCleanup {
+	if b.Metadata == nil {
+		return nil
+	}
+	source := strings.TrimSpace(b.Metadata[legacyPerDispatchModelSourceKey])
+	if source == "" {
+		return nil
+	}
+	cleanup := &workOptionSessionCleanup{source: source}
+	rawOverrides := strings.TrimSpace(b.Metadata[templateOverridesMetadataKey])
+	if rawOverrides == "" {
+		return cleanup
+	}
+	var overrides map[string]string
+	if err := json.Unmarshal([]byte(rawOverrides), &overrides); err != nil || len(overrides) == 0 {
+		return cleanup
+	}
+	if strings.TrimSpace(overrides["model"]) != source {
+		return cleanup
+	}
+	delete(overrides, "model")
+	cleanup.removeAutoStampedModel = true
+	cleanup.updateTemplateOverridesKey = true
+	if len(overrides) == 0 {
+		return cleanup
+	}
+	raw, err := json.Marshal(overrides)
+	if err != nil {
+		cleanup.updateTemplateOverridesKey = false
+		return cleanup
+	}
+	cleanup.updatedTemplateOverrides = string(raw)
+	return cleanup
+}
+
 func (c *workOptionMetadataMigrationCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 	targets, skipped := c.collect()
 	if len(targets) == 0 && len(skipped) == 0 {
-		return okCheck(c.Name(), "no live task beads use legacy work option metadata")
+		return okCheck(c.Name(), "no live beads use legacy work option metadata")
 	}
 	details := make([]string, 0, len(targets)+len(skipped))
 	for _, tgt := range targets {
-		details = append(details, fmt.Sprintf("%s bead %s has %s", tgt.label, tgt.beadID, describeWorkOptionMigrations(tgt.migrations)))
+		details = append(details, fmt.Sprintf("%s bead %s has %s", tgt.label, tgt.beadID, describeWorkOptionMigrationTarget(tgt)))
 	}
 	details = append(details, skipped...)
 	sort.Strings(details)
@@ -130,9 +199,16 @@ func (c *workOptionMetadataMigrationCheck) Run(_ *doctor.CheckContext) *doctor.C
 			details)
 	}
 	return warnCheck(c.Name(),
-		fmt.Sprintf("%d live task bead(s) use legacy work option metadata", len(targets)),
-		"run gc doctor --fix to migrate gc.model/gc.reasoning to opt_model/opt_effort",
+		fmt.Sprintf("%d live bead(s) use legacy work option metadata", len(targets)),
+		"run gc doctor --fix to migrate gc.model/gc.reasoning and clear stale session per-dispatch model overrides",
 		details)
+}
+
+func describeWorkOptionMigrationTarget(tgt workOptionMigrationTarget) string {
+	if tgt.sessionCleanup != nil {
+		return describeWorkOptionSessionCleanup(*tgt.sessionCleanup)
+	}
+	return describeWorkOptionMigrations(tgt.migrations)
 }
 
 func describeWorkOptionMigrations(migrations []workOptionMetadataMigration) string {
@@ -141,6 +217,13 @@ func describeWorkOptionMigrations(migrations []workOptionMetadataMigration) stri
 		parts = append(parts, fmt.Sprintf("%s -> %s", migration.legacy, migration.canonical))
 	}
 	return strings.Join(parts, ", ")
+}
+
+func describeWorkOptionSessionCleanup(cleanup workOptionSessionCleanup) string {
+	if cleanup.removeAutoStampedModel {
+		return legacyPerDispatchModelSourceKey + " and auto-stamped template_overrides.model"
+	}
+	return legacyPerDispatchModelSourceKey
 }
 
 func (c *workOptionMetadataMigrationCheck) Fix(_ *doctor.CheckContext) error {
@@ -152,6 +235,12 @@ func (c *workOptionMetadataMigrationCheck) Fix(_ *doctor.CheckContext) error {
 				kvs[migration.canonical] = migration.value
 			}
 			kvs[migration.legacy] = ""
+		}
+		if cleanup := tgt.sessionCleanup; cleanup != nil {
+			kvs[legacyPerDispatchModelSourceKey] = ""
+			if cleanup.updateTemplateOverridesKey {
+				kvs[templateOverridesMetadataKey] = cleanup.updatedTemplateOverrides
+			}
 		}
 		if err := tgt.store.SetMetadataBatch(tgt.beadID, kvs); err != nil {
 			return fmt.Errorf("%s bead %s: migrate work option metadata: %w", tgt.label, tgt.beadID, err)

--- a/cmd/gc/doctor_work_option_metadata_test.go
+++ b/cmd/gc/doctor_work_option_metadata_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func TestWorkOptionMetadataMigrationCheckFixesLegacyTaskMetadata(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: rigDir}}}
+
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "LEG-1", Title: "legacy work", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.model": "gpt-5", "gc.reasoning": "high",
+		}},
+		{ID: "OPT-1", Title: "canonical wins", Type: "task", Status: "in_progress", Metadata: map[string]string{
+			"gc.model": "legacy-model", "opt_model": "canonical-model", "gc.reasoning": "legacy-effort", "opt_effort": "canonical-effort",
+		}},
+		{ID: "CLOSED-1", Title: "closed work", Type: "task", Status: "closed", Metadata: map[string]string{
+			"gc.model": "closed-model", "gc.reasoning": "closed-effort",
+		}},
+		{ID: "MSG-1", Title: "message", Type: "message", Status: "open", Metadata: map[string]string{
+			"gc.model": "message-model", "gc.reasoning": "message-effort",
+		}},
+		{ID: "EMPTY-1", Title: "empty legacy", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.model": "   ", "gc.reasoning": "",
+		}},
+	}, nil)
+	rigStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "RIG-1", Title: "rig work", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.reasoning": "medium",
+		}},
+	}, nil)
+	stores := map[string]beads.Store{cityDir: cityStore, rigDir: rigStore}
+	check := newWorkOptionMetadataMigrationCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		store, ok := stores[path]
+		if !ok {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return store, nil
+	})
+
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("Run status = %v, want warning: %#v", res.Status, res)
+	}
+	details := strings.Join(res.Details, "\n")
+	for _, want := range []string{"LEG-1", "OPT-1", "RIG-1", "gc.model -> opt_model", "gc.reasoning -> opt_effort"} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("details missing %q:\n%s", want, details)
+		}
+	}
+	for _, notWant := range []string{"CLOSED-1", "MSG-1", "EMPTY-1"} {
+		if strings.Contains(details, notWant) {
+			t.Fatalf("details should not mention %q:\n%s", notWant, details)
+		}
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res2 := check.Run(&doctor.CheckContext{}); res2.Status != doctor.StatusOK {
+		t.Fatalf("post-fix Run status = %v, want OK: %#v", res2.Status, res2)
+	}
+
+	leg, err := cityStore.Get("LEG-1")
+	if err != nil {
+		t.Fatalf("get LEG-1: %v", err)
+	}
+	if got := leg.Metadata["opt_model"]; got != "gpt-5" {
+		t.Errorf("LEG-1 opt_model = %q, want gpt-5", got)
+	}
+	if got := leg.Metadata["opt_effort"]; got != "high" {
+		t.Errorf("LEG-1 opt_effort = %q, want high", got)
+	}
+	if got := leg.Metadata["gc.model"]; got != "" {
+		t.Errorf("LEG-1 gc.model = %q, want tombstone", got)
+	}
+	if got := leg.Metadata["gc.reasoning"]; got != "" {
+		t.Errorf("LEG-1 gc.reasoning = %q, want tombstone", got)
+	}
+
+	opt, err := cityStore.Get("OPT-1")
+	if err != nil {
+		t.Fatalf("get OPT-1: %v", err)
+	}
+	if got := opt.Metadata["opt_model"]; got != "canonical-model" {
+		t.Errorf("OPT-1 opt_model = %q, want canonical-model", got)
+	}
+	if got := opt.Metadata["opt_effort"]; got != "canonical-effort" {
+		t.Errorf("OPT-1 opt_effort = %q, want canonical-effort", got)
+	}
+	if got := opt.Metadata["gc.model"]; got != "" {
+		t.Errorf("OPT-1 gc.model = %q, want tombstone", got)
+	}
+	if got := opt.Metadata["gc.reasoning"]; got != "" {
+		t.Errorf("OPT-1 gc.reasoning = %q, want tombstone", got)
+	}
+
+	rig, err := rigStore.Get("RIG-1")
+	if err != nil {
+		t.Fatalf("get RIG-1: %v", err)
+	}
+	if got := rig.Metadata["opt_effort"]; got != "medium" {
+		t.Errorf("RIG-1 opt_effort = %q, want medium", got)
+	}
+
+	closed, err := cityStore.Get("CLOSED-1")
+	if err != nil {
+		t.Fatalf("get CLOSED-1: %v", err)
+	}
+	if got := closed.Metadata["opt_model"]; got != "" {
+		t.Errorf("CLOSED-1 opt_model = %q, want untouched", got)
+	}
+	msg, err := cityStore.Get("MSG-1")
+	if err != nil {
+		t.Fatalf("get MSG-1: %v", err)
+	}
+	if got := msg.Metadata["opt_model"]; got != "" {
+		t.Errorf("MSG-1 opt_model = %q, want untouched", got)
+	}
+}
+
+func TestWorkOptionMetadataMigrationCheckCleanStore(t *testing.T) {
+	cityDir := t.TempDir()
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "T-1", Title: "work", Type: "task", Status: "open", Metadata: map[string]string{
+			"opt_model": "gpt-5", "opt_effort": "high",
+		}},
+	}, nil)
+	check := newWorkOptionMetadataMigrationCheck(nil, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return store, nil
+	})
+	if !check.CanFix() {
+		t.Fatal("CanFix() = false, want true")
+	}
+	if res := check.Run(&doctor.CheckContext{}); res.Status != doctor.StatusOK {
+		t.Fatalf("Run status = %v, want OK: %#v", res.Status, res)
+	}
+}
+
+func TestWorkOptionMetadataMigrationFixReportsSkippedScopes(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: rigDir}}}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "T-1", Title: "work", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.model": "gpt-5",
+		}},
+	}, nil)
+	check := newWorkOptionMetadataMigrationCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path == rigDir {
+			return nil, errors.New("permission denied")
+		}
+		return cityStore, nil
+	})
+
+	err := check.Fix(&doctor.CheckContext{})
+	if err == nil {
+		t.Fatal("Fix error = nil, want skipped scope error")
+	}
+	if got := err.Error(); !strings.Contains(got, "rig repo skipped") || !strings.Contains(got, "permission denied") {
+		t.Fatalf("Fix error = %q, want rig open failure detail", got)
+	}
+	got, getErr := cityStore.Get("T-1")
+	if getErr != nil {
+		t.Fatalf("get T-1: %v", getErr)
+	}
+	if got.Metadata["opt_model"] != "gpt-5" || got.Metadata["gc.model"] != "" {
+		t.Fatalf("city fix was not applied before reporting skipped rig: metadata=%+v", got.Metadata)
+	}
+}
+
+func TestBuildDoctorChecksRegistersWorkOptionMetadataMigration(t *testing.T) {
+	checks := buildDoctorChecks(t.TempDir(), &config.City{}, nil, buildDoctorChecksOpts{
+		Stderr:               io.Discard,
+		SkipCityDoltCheck:    true,
+		SkipManagedDoltCheck: true,
+	})
+	for _, check := range checks {
+		if check.Name() == "work-option-metadata-migration" {
+			return
+		}
+	}
+	t.Fatal("buildDoctorChecks did not register work-option-metadata-migration")
+}

--- a/cmd/gc/doctor_work_option_metadata_test.go
+++ b/cmd/gc/doctor_work_option_metadata_test.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
 )
 
 func TestWorkOptionMetadataMigrationCheckFixesLegacyTaskMetadata(t *testing.T) {
@@ -150,6 +154,101 @@ func TestWorkOptionMetadataMigrationCheckCleanStore(t *testing.T) {
 	}
 }
 
+func TestWorkOptionMetadataMigrationClearsStaleSessionAutoStampedModel(t *testing.T) {
+	cityDir := t.TempDir()
+	store := beads.NewMemStore()
+	candidate := newOptionSessionCandidate(
+		t,
+		store,
+		map[string]string{"model": "opus"},
+		map[string]string{"model": "sonnet", "effort": "high"},
+	)
+	if err := store.SetMetadata(candidate.session.ID, "gc.per_dispatch_model", "sonnet"); err != nil {
+		t.Fatalf("SetMetadata(gc.per_dispatch_model): %v", err)
+	}
+	check := newWorkOptionMetadataMigrationCheck(nil, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return store, nil
+	})
+
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("Run status = %v, want warning: %#v", res.Status, res)
+	}
+	details := strings.Join(res.Details, "\n")
+	for _, want := range []string{candidate.session.ID, "gc.per_dispatch_model", "template_overrides.model"} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("details missing %q:\n%s", want, details)
+		}
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res2 := check.Run(&doctor.CheckContext{}); res2.Status != doctor.StatusOK {
+		t.Fatalf("post-fix Run status = %v, want OK: %#v", res2.Status, res2)
+	}
+	session, err := store.Get(candidate.session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got := strings.TrimSpace(session.Metadata["gc.per_dispatch_model"]); got != "" {
+		t.Fatalf("gc.per_dispatch_model = %q, want tombstone", got)
+	}
+	wantOverrides := map[string]string{"effort": "high"}
+	if got := storedSessionOverrides(t, store, candidate.session.ID); !reflect.DeepEqual(got, wantOverrides) {
+		t.Fatalf("template_overrides = %v, want %v", got, wantOverrides)
+	}
+
+	candidate.session = &session
+	prepared, err := buildPreparedStart(candidate, &config.City{}, store)
+	if err != nil {
+		t.Fatalf("buildPreparedStart: %v", err)
+	}
+	if !strings.Contains(prepared.cfg.Command, "--model claude-opus-4-8") {
+		t.Fatalf("prepared command = %q, want work opt_model opus after stale session cleanup", prepared.cfg.Command)
+	}
+	if strings.Contains(prepared.cfg.Command, "claude-sonnet-4-6") {
+		t.Fatalf("prepared command = %q, stale session model should not win", prepared.cfg.Command)
+	}
+}
+
+func TestWorkOptionMetadataMigrationPreservesExplicitSessionModelWhenMarkerDiffers(t *testing.T) {
+	cityDir := t.TempDir()
+	raw, err := json.Marshal(map[string]string{"model": "sonnet"})
+	if err != nil {
+		t.Fatalf("Marshal(template_overrides): %v", err)
+	}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "SESSION-1", Title: "worker", Type: sessionBeadType, Status: "open", Labels: []string{sessionBeadLabel}, Metadata: map[string]string{
+			"template_overrides":    string(raw),
+			"gc.per_dispatch_model": "opus",
+		}},
+	}, nil)
+	check := newWorkOptionMetadataMigrationCheck(nil, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return store, nil
+	})
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	got, err := store.Get("SESSION-1")
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Metadata["template_overrides"] != string(raw) {
+		t.Fatalf("template_overrides = %q, want preserved %q", got.Metadata["template_overrides"], string(raw))
+	}
+	if got.Metadata["gc.per_dispatch_model"] != "" {
+		t.Fatalf("gc.per_dispatch_model = %q, want tombstone", got.Metadata["gc.per_dispatch_model"])
+	}
+}
+
 func TestWorkOptionMetadataMigrationFixReportsSkippedScopes(t *testing.T) {
 	cityDir := t.TempDir()
 	rigDir := t.TempDir()
@@ -179,6 +278,51 @@ func TestWorkOptionMetadataMigrationFixReportsSkippedScopes(t *testing.T) {
 	}
 	if got.Metadata["opt_model"] != "gpt-5" || got.Metadata["gc.model"] != "" {
 		t.Fatalf("city fix was not applied before reporting skipped rig: metadata=%+v", got.Metadata)
+	}
+}
+
+func TestWorkOptionMetadataMigrationSkipsEffectivelySuspendedRigs(t *testing.T) {
+	cityDir := t.TempDir()
+	startSuspendedDir := t.TempDir()
+	runtimeSuspendedDir := t.TempDir()
+	activeDir := t.TempDir()
+	suspend := true
+	if err := suspensionstate.SetRigSuspended(fsys.OSFS{}, cityDir, "runtime-suspended", &suspend); err != nil {
+		t.Fatalf("SetRigSuspended: %v", err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{
+		{Name: "start-suspended", Path: startSuspendedDir, SuspendedOnStart: true},
+		{Name: "runtime-suspended", Path: runtimeSuspendedDir},
+		{Name: "active", Path: activeDir},
+	}}
+	cityStore := beads.NewMemStore()
+	activeStore := beads.NewMemStore()
+	stores := map[string]beads.Store{
+		cityDir:   cityStore,
+		activeDir: activeStore,
+	}
+	var opened []string
+	check := newWorkOptionMetadataMigrationCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		opened = append(opened, path)
+		store, ok := stores[path]
+		if !ok {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return store, nil
+	})
+
+	if res := check.Run(&doctor.CheckContext{}); res.Status != doctor.StatusOK {
+		t.Fatalf("Run status = %v, want OK: %#v", res.Status, res)
+	}
+	for _, notWant := range []string{startSuspendedDir, runtimeSuspendedDir} {
+		if containsString(opened, notWant) {
+			t.Fatalf("opened suspended rig store %q; opened=%v", notWant, opened)
+		}
+	}
+	for _, want := range []string{cityDir, activeDir} {
+		if !containsString(opened, want) {
+			t.Fatalf("did not open active scope %q; opened=%v", want, opened)
+		}
 	}
 }
 

--- a/cmd/gc/per_dispatch_model_test.go
+++ b/cmd/gc/per_dispatch_model_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -9,27 +10,37 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
-// modelSchemaProvider returns a ResolvedProvider that exposes a "model" option
-// with two choices, matching the shape of the builtin claude/codex schemas.
-func modelSchemaProvider() *config.ResolvedProvider {
+// optionSchemaProvider returns a ResolvedProvider with two OptionsSchema keys.
+// Work beads request per-dispatch values for these keys via opt_<key> metadata.
+func optionSchemaProvider() *config.ResolvedProvider {
 	return &config.ResolvedProvider{
 		Name:    "claude",
 		Command: "claude",
-		OptionsSchema: []config.ProviderOption{{
-			Key:   "model",
-			Label: "Model",
-			Choices: []config.OptionChoice{
-				{Value: "opus", FlagArgs: []string{"--model", "claude-opus-4-8"}},
-				{Value: "sonnet", FlagArgs: []string{"--model", "claude-sonnet-4-6"}},
+		OptionsSchema: []config.ProviderOption{
+			{
+				Key:   "model",
+				Label: "Model",
+				Choices: []config.OptionChoice{
+					{Value: "opus", FlagArgs: []string{"--model", "claude-opus-4-8"}},
+					{Value: "sonnet", FlagArgs: []string{"--model", "claude-sonnet-4-6"}},
+				},
 			},
-		}},
+			{
+				Key:   "effort",
+				Label: "Effort",
+				Choices: []config.OptionChoice{
+					{Value: "low", FlagArgs: []string{"--effort", "low"}},
+					{Value: "high", FlagArgs: []string{"--effort", "high"}},
+				},
+			},
+		},
 	}
 }
 
-// newModelSessionCandidate builds an in-progress work bead carrying gc.model
-// assigned to a session bead, plus the matching startCandidate. The work bead's
-// assignee is the session_name so taskWorkDirAssignees resolves it.
-func newModelSessionCandidate(t *testing.T, store beads.Store, gcModel string, sessionOverrides map[string]string) startCandidate {
+// newOptionSessionCandidate builds an in-progress work bead assigned to a
+// session. workOptions are written as opt_<key> metadata, matching the existing
+// explicit option metadata convention used for session beads.
+func newOptionSessionCandidate(t *testing.T, store beads.Store, workOptions, sessionOverrides map[string]string) startCandidate {
 	t.Helper()
 	const sessionName = "worker"
 	meta := map[string]string{
@@ -55,8 +66,8 @@ func newModelSessionCandidate(t *testing.T, store beads.Store, gcModel string, s
 	}
 
 	workMeta := map[string]string{}
-	if gcModel != "" {
-		workMeta["gc.model"] = gcModel
+	for key, value := range workOptions {
+		workMeta[dispatchOptionMetadataKey(key)] = value
 	}
 	work, err := store.Create(beads.Bead{
 		Title:    "do the work",
@@ -78,12 +89,12 @@ func newModelSessionCandidate(t *testing.T, store beads.Store, gcModel string, s
 			TemplateName:     "worker",
 			SessionName:      sessionName,
 			Command:          "claude",
-			ResolvedProvider: modelSchemaProvider(),
+			ResolvedProvider: optionSchemaProvider(),
 		},
 	}
 }
 
-func sessionModelOverride(t *testing.T, store beads.Store, id string) string {
+func storedSessionOverrides(t *testing.T, store beads.Store, id string) map[string]string {
 	t.Helper()
 	b, err := store.Get(id)
 	if err != nil {
@@ -95,109 +106,56 @@ func sessionModelOverride(t *testing.T, store beads.Store, id string) string {
 			t.Fatalf("unmarshal template_overrides: %v", err)
 		}
 	}
-	return parsed["model"]
+	return parsed
 }
 
-// setAssignedWorkModel updates the gc.model metadata on the in-progress work
-// bead(s) assigned to assignee, simulating a later dispatch advising a
-// different (or, with gcModel=="", no) model on the same session.
-func setAssignedWorkModel(t *testing.T, store beads.Store, assignee, gcModel string) {
+func storedSessionMetadata(t *testing.T, store beads.Store, id string) map[string]string {
 	t.Helper()
-	assigned, err := store.List(beads.ListQuery{
-		Assignee: assignee,
-		Status:   "in_progress",
-		Live:     true,
-		TierMode: beads.TierBoth,
-	})
+	b, err := store.Get(id)
 	if err != nil {
-		t.Fatalf("List(assigned work): %v", err)
+		t.Fatalf("Get(session): %v", err)
 	}
-	if len(assigned) == 0 {
-		t.Fatalf("no in-progress work assigned to %q", assignee)
-	}
-	for _, b := range assigned {
-		if err := store.SetMetadata(b.ID, "gc.model", gcModel); err != nil {
-			t.Fatalf("SetMetadata(gc.model): %v", err)
-		}
-	}
+	return b.Metadata
 }
 
-func TestMaybeApplyPerDispatchModelOverride_SwitchesModelAcrossDispatches(t *testing.T) {
+func TestBuildPreparedStart_ExplicitOverrideWinsPerKey(t *testing.T) {
 	store := beads.NewMemStore()
-	candidate := newModelSessionCandidate(t, store, "opus", nil)
+	candidate := newOptionSessionCandidate(
+		t,
+		store,
+		map[string]string{"model": "opus", "effort": "high"},
+		map[string]string{"model": "sonnet"},
+	)
 
-	// First dispatch stamps opus.
-	maybeApplyPerDispatchModelOverride(candidate, &config.City{}, store)
-	if got := sessionModelOverride(t, store, candidate.session.ID); got != "opus" {
-		t.Fatalf("after first dispatch model = %q, want %q", got, "opus")
+	prepared, err := buildPreparedStart(candidate, &config.City{}, store)
+	if err != nil {
+		t.Fatalf("buildPreparedStart: %v", err)
 	}
-
-	// A later dispatch on the same session advises sonnet; the auto-stamped
-	// model must flip rather than leak the prior choice forward.
-	setAssignedWorkModel(t, store, "worker", "sonnet")
-	maybeApplyPerDispatchModelOverride(candidate, &config.City{}, store)
-	if got := sessionModelOverride(t, store, candidate.session.ID); got != "sonnet" {
-		t.Fatalf("after second dispatch model = %q, want %q", got, "sonnet")
+	if !strings.Contains(prepared.cfg.Command, "--model claude-sonnet-4-6") {
+		t.Fatalf("prepared command = %q, want explicit --model claude-sonnet-4-6", prepared.cfg.Command)
 	}
-	if got := candidate.session.Metadata[perDispatchModelSourceKey]; got != "sonnet" {
-		t.Fatalf("provenance = %q, want %q", got, "sonnet")
+	if strings.Contains(prepared.cfg.Command, "claude-opus-4-8") {
+		t.Fatalf("prepared command = %q, work opt_model should not override explicit model", prepared.cfg.Command)
 	}
-}
-
-func TestMaybeApplyPerDispatchModelOverride_ClearsWhenNextDispatchHasNoModel(t *testing.T) {
-	store := beads.NewMemStore()
-	candidate := newModelSessionCandidate(t, store, "opus", nil)
-
-	// First dispatch stamps opus.
-	maybeApplyPerDispatchModelOverride(candidate, &config.City{}, store)
-	if got := sessionModelOverride(t, store, candidate.session.ID); got != "opus" {
-		t.Fatalf("after first dispatch model = %q, want %q", got, "opus")
+	if !strings.Contains(prepared.cfg.Command, "--effort high") {
+		t.Fatalf("prepared command = %q, want work opt_effort high", prepared.cfg.Command)
 	}
-
-	// A later dispatch advises no model; the auto-stamped override must be
-	// cleared so the agent falls back to its configured default.
-	setAssignedWorkModel(t, store, "worker", "")
-	maybeApplyPerDispatchModelOverride(candidate, &config.City{}, store)
-	if got := sessionModelOverride(t, store, candidate.session.ID); got != "" {
-		t.Fatalf("after clearing dispatch model = %q, want empty", got)
-	}
-	if got := candidate.session.Metadata[perDispatchModelSourceKey]; got != "" {
-		t.Fatalf("provenance = %q, want cleared", got)
+	wantPersisted := map[string]string{"model": "sonnet"}
+	if got := storedSessionOverrides(t, store, candidate.session.ID); !reflect.DeepEqual(got, wantPersisted) {
+		t.Fatalf("persisted overrides = %v, want unchanged %v", got, wantPersisted)
 	}
 }
 
-func TestMaybeApplyPerDispatchModelOverride_ExplicitOverrideStillWinsAfterRouting(t *testing.T) {
-	store := beads.NewMemStore()
-	// Session carries a genuine explicit override (no provenance marker) and a
-	// work bead advises a different model.
-	candidate := newModelSessionCandidate(t, store, "opus", map[string]string{"model": "sonnet"})
-
-	maybeApplyPerDispatchModelOverride(candidate, &config.City{}, store)
-
-	if got := sessionModelOverride(t, store, candidate.session.ID); got != "sonnet" {
-		t.Fatalf("model = %q, want explicit %q (routing must not replace it)", got, "sonnet")
-	}
-	if _, ok := candidate.session.Metadata[perDispatchModelSourceKey]; ok {
-		t.Fatalf("provenance marker set on explicit override: %q", candidate.session.Metadata[perDispatchModelSourceKey])
-	}
-}
-
-func TestWorkRoutingModel(t *testing.T) {
-	if got := WorkRoutingModel(beads.Bead{}); got != "" {
-		t.Fatalf("WorkRoutingModel(empty) = %q, want empty", got)
-	}
-	if got := WorkRoutingModel(beads.Bead{Metadata: map[string]string{"gc.model": "  opus  "}}); got != "opus" {
-		t.Fatalf("WorkRoutingModel = %q, want trimmed %q", got, "opus")
-	}
-}
-
-func TestResolveTaskModelReadsAssignedWorkBead(t *testing.T) {
+func TestResolveTaskOptionOverridesReadsAssignedWorkBead(t *testing.T) {
 	store := beads.NewMemStore()
 	work, err := store.Create(beads.Bead{
 		Title:    "active step",
 		Type:     "task",
 		Assignee: "worker-session",
-		Metadata: map[string]string{"gc.model": "sonnet"},
+		Metadata: map[string]string{
+			"opt_model":  "sonnet",
+			"opt_effort": "high",
+		},
 	})
 	if err != nil {
 		t.Fatalf("Create(work): %v", err)
@@ -207,73 +165,35 @@ func TestResolveTaskModelReadsAssignedWorkBead(t *testing.T) {
 		t.Fatalf("mark in_progress: %v", err)
 	}
 
-	if got := resolveTaskModel(store, "worker-session"); got != "sonnet" {
-		t.Fatalf("resolveTaskModel = %q, want %q", got, "sonnet")
+	want := map[string]string{"model": "sonnet", "effort": "high"}
+	if got := resolveTaskOptionOverrides(store, optionSchemaProvider(), "worker-session"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveTaskOptionOverrides = %v, want %v", got, want)
 	}
-	// Open (not in_progress) work is ignored, matching resolveTaskWorkDir.
 	open := "open"
 	if err := store.Update(work.ID, beads.UpdateOpts{Status: &open}); err != nil {
 		t.Fatalf("reopen work: %v", err)
 	}
-	if got := resolveTaskModel(store, "worker-session"); got != "" {
-		t.Fatalf("resolveTaskModel(open work) = %q, want empty", got)
+	if got := resolveTaskOptionOverrides(store, optionSchemaProvider(), "worker-session"); len(got) != 0 {
+		t.Fatalf("resolveTaskOptionOverrides(open work) = %v, want empty", got)
 	}
 }
 
-func TestMaybeApplyPerDispatchModelOverride_StampsWorkBeadModel(t *testing.T) {
+func TestResolveTaskOptionOverrides_InvalidValueIgnoredPerKey(t *testing.T) {
 	store := beads.NewMemStore()
-	candidate := newModelSessionCandidate(t, store, "opus", nil)
+	candidate := newOptionSessionCandidate(t, store, map[string]string{"model": "definitely-not-a-choice", "effort": "high"}, nil)
 
-	maybeApplyPerDispatchModelOverride(candidate, &config.City{}, store)
-
-	// Persisted on the bead so config-drift hashing sees the same override.
-	if got := sessionModelOverride(t, store, candidate.session.ID); got != "opus" {
-		t.Fatalf("persisted template_overrides model = %q, want %q", got, "opus")
-	}
-	// Mirrored in memory for the in-flight start.
-	if got := candidate.session.Metadata["template_overrides"]; !strings.Contains(got, `"model":"opus"`) {
-		t.Fatalf("in-memory template_overrides = %q, want model:opus", got)
+	want := map[string]string{"effort": "high"}
+	if got := resolveTaskOptionOverrides(store, optionSchemaProvider(), taskWorkDirAssignees(candidate, &config.City{})...); !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveTaskOptionOverrides = %v, want %v", got, want)
 	}
 }
 
-func TestMaybeApplyPerDispatchModelOverride_ExplicitOverrideWins(t *testing.T) {
+// TestBuildPreparedStartAppliesWorkBeadOptionsToCommand proves the end-to-end
+// path: work bead opt_<key> metadata becomes provider CLI flags through
+// OptionsSchema, without adding a dedicated field per option.
+func TestBuildPreparedStartAppliesWorkBeadOptionsToCommand(t *testing.T) {
 	store := beads.NewMemStore()
-	candidate := newModelSessionCandidate(t, store, "opus", map[string]string{"model": "sonnet"})
-
-	maybeApplyPerDispatchModelOverride(candidate, &config.City{}, store)
-
-	if got := sessionModelOverride(t, store, candidate.session.ID); got != "sonnet" {
-		t.Fatalf("model = %q, want explicit %q (routing metadata must not win)", got, "sonnet")
-	}
-}
-
-func TestMaybeApplyPerDispatchModelOverride_NoWorkModelIsNoOp(t *testing.T) {
-	store := beads.NewMemStore()
-	candidate := newModelSessionCandidate(t, store, "", nil)
-
-	maybeApplyPerDispatchModelOverride(candidate, &config.City{}, store)
-
-	if _, ok := candidate.session.Metadata["template_overrides"]; ok {
-		t.Fatalf("template_overrides set despite no gc.model: %q", candidate.session.Metadata["template_overrides"])
-	}
-}
-
-func TestMaybeApplyPerDispatchModelOverride_InvalidModelIgnored(t *testing.T) {
-	store := beads.NewMemStore()
-	candidate := newModelSessionCandidate(t, store, "definitely-not-a-choice", nil)
-
-	maybeApplyPerDispatchModelOverride(candidate, &config.City{}, store)
-
-	if got, ok := candidate.session.Metadata["template_overrides"]; ok {
-		t.Fatalf("invalid gc.model was applied: %q", got)
-	}
-}
-
-// TestBuildPreparedStartAppliesWorkBeadModelToCommand proves the end-to-end
-// seam: a work bead's gc.model becomes a --model flag on the launch command.
-func TestBuildPreparedStartAppliesWorkBeadModelToCommand(t *testing.T) {
-	store := beads.NewMemStore()
-	candidate := newModelSessionCandidate(t, store, "opus", nil)
+	candidate := newOptionSessionCandidate(t, store, map[string]string{"model": "opus", "effort": "high"}, nil)
 
 	prepared, err := buildPreparedStart(candidate, &config.City{}, store)
 	if err != nil {
@@ -281,5 +201,15 @@ func TestBuildPreparedStartAppliesWorkBeadModelToCommand(t *testing.T) {
 	}
 	if !strings.Contains(prepared.cfg.Command, "--model claude-opus-4-8") {
 		t.Fatalf("prepared command = %q, want --model claude-opus-4-8", prepared.cfg.Command)
+	}
+	if !strings.Contains(prepared.cfg.Command, "--effort high") {
+		t.Fatalf("prepared command = %q, want --effort high", prepared.cfg.Command)
+	}
+	metadata := storedSessionMetadata(t, store, candidate.session.ID)
+	if got := strings.TrimSpace(metadata["template_overrides"]); got != "" {
+		t.Fatalf("template_overrides persisted from work options: %q", got)
+	}
+	if got := strings.TrimSpace(metadata["opt_model"]); got != "" {
+		t.Fatalf("opt_model persisted on session from work option: %q", got)
 	}
 }

--- a/cmd/gc/per_dispatch_model_test.go
+++ b/cmd/gc/per_dispatch_model_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
 // optionSchemaProvider returns a ResolvedProvider with two OptionsSchema keys.
@@ -211,5 +213,30 @@ func TestBuildPreparedStartAppliesWorkBeadOptionsToCommand(t *testing.T) {
 	}
 	if got := strings.TrimSpace(metadata["opt_model"]); got != "" {
 		t.Fatalf("opt_model persisted on session from work option: %q", got)
+	}
+}
+
+func TestBuildPreparedStartInitialMessageOnlyMatchesDriftHash(t *testing.T) {
+	store := beads.NewMemStore()
+	candidate := newOptionSessionCandidate(t, store, nil, map[string]string{"initial_message": "hello"})
+	resolved := claudeEffortResolvedProvider()
+	defaultArgs := resolved.ResolveDefaultArgs()
+	if len(defaultArgs) == 0 {
+		t.Fatal("claude provider default args are empty")
+	}
+	candidate.tp.ResolvedProvider = resolved
+	candidate.tp.Command = "claude " + shellquote.Join(defaultArgs) + " --settings /tmp/city/.gc/settings.json"
+
+	prepared, err := buildPreparedStart(candidate, &config.City{}, store)
+	if err != nil {
+		t.Fatalf("buildPreparedStart: %v", err)
+	}
+	want := runtime.CoreFingerprint(sessionCoreConfigForHash(candidate.tp, *candidate.session))
+	if prepared.coreHash != want {
+		t.Fatalf("prepared coreHash = %s, want drift hash %s\nprepared command: %q\ndrift command:    %q",
+			prepared.coreHash,
+			want,
+			prepared.cfg.Command,
+			sessionCoreConfigForHash(candidate.tp, *candidate.session).Command)
 	}
 }

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -771,122 +771,6 @@ func refreshConfiguredNamedStartCandidate(
 	return candidate
 }
 
-// perDispatchModelSourceKey records, on a session bead, the routing model that
-// maybeApplyPerDispatchModelOverride auto-stamped into template_overrides. Its
-// presence distinguishes an auto-stamped model (which a later dispatch may
-// switch or clear) from a genuine operator/dashboard override (which routing
-// metadata must never touch). An empty/absent value means "not auto-stamped".
-const perDispatchModelSourceKey = "gc.per_dispatch_model"
-
-// maybeApplyPerDispatchModelOverride reconciles the per-dispatch model requested
-// by a candidate session's assigned work bead (its advisory "gc.model" metadata)
-// with the session's own template_overrides, so the existing override pipeline
-// turns it into a --model flag at launch. Because sessions go asleep and
-// re-spawn to claim new work, this runs on every start and must be able to
-// switch or clear a model it previously stamped, not only stamp it once.
-//
-// Precedence, given the parsed template_overrides ("existing"), the prior
-// provenance marker ("prev", see perDispatchModelSourceKey), and the model
-// advised by the current work bead ("model"):
-//   - the resolved provider must expose a "model" option in its schema, else
-//     this is a no-op;
-//   - an explicit operator/dashboard model (existing["model"] set with no
-//     provenance marker) always wins — routing metadata never overrides it;
-//   - a previously auto-stamped model is re-resolved: a new valid model
-//     replaces it, an absent model clears it (falling back to the agent's
-//     configured default), and an invalid model leaves the prior value in
-//     place;
-//   - with nothing stamped yet, a valid advised model is stamped.
-//
-// An unknown/invalid gc.model value is logged and ignored rather than failing
-// the start, so an advisory value the running provider doesn't recognize never
-// blocks a session from launching. The override and its provenance are
-// persisted on the session bead (not just applied in memory) so config-drift
-// hashing via sessionCoreConfigForHash and the launch command stay consistent.
-func maybeApplyPerDispatchModelOverride(candidate startCandidate, cfg *config.City, store beads.Store) {
-	session := candidate.session
-	if store == nil || session == nil || session.ID == "" {
-		return
-	}
-	tp := candidate.tp
-	if tp.ResolvedProvider == nil || len(tp.ResolvedProvider.OptionsSchema) == 0 {
-		return
-	}
-	existing, err := sessionpkg.ParseTemplateOverrides(session.Metadata)
-	if err != nil {
-		// A malformed template_overrides blob is repaired by the existing
-		// override pipeline; don't compound it here.
-		return
-	}
-	_, hasModel := existing["model"]
-	prev := strings.TrimSpace(session.Metadata[perDispatchModelSourceKey])
-
-	// A genuine operator/dashboard override carries no auto-stamp provenance
-	// and always wins over routing metadata.
-	if hasModel && prev == "" {
-		return
-	}
-
-	model := resolveTaskModel(store, taskWorkDirAssignees(candidate, cfg)...)
-
-	// Work on a private copy so a marshal/persist failure never mutates the
-	// session's in-memory overrides.
-	overrides := make(map[string]string, len(existing))
-	for k, v := range existing {
-		overrides[k] = v
-	}
-
-	if model == "" {
-		// Nothing advised this dispatch. Clear a prior auto-stamp so the agent
-		// falls back to its configured default; otherwise there is nothing to do.
-		if prev == "" {
-			return
-		}
-		delete(overrides, "model")
-		if err := persistPerDispatchModelOverride(session, store, overrides, ""); err != nil {
-			log.Printf("session %s: clearing per-dispatch model override: %v", session.ID, err)
-		}
-		return
-	}
-
-	// Validate against the resolved provider's schema before persisting. An
-	// invalid value would otherwise surface only as a template_overrides
-	// resolution error at launch, so log and ignore it, leaving any prior
-	// auto-stamped model in place.
-	if _, err := config.ResolveExplicitOptions(tp.ResolvedProvider.OptionsSchema, map[string]string{"model": model}); err != nil {
-		log.Printf("session %s: ignoring work bead gc.model=%q: %v", session.ID, model, err)
-		return
-	}
-	overrides["model"] = model
-	if err := persistPerDispatchModelOverride(session, store, overrides, model); err != nil {
-		log.Printf("session %s: persisting per-dispatch model override: %v", session.ID, err)
-	}
-}
-
-// persistPerDispatchModelOverride writes the session's template_overrides blob
-// and the per-dispatch provenance marker together, then mirrors both into the
-// in-memory session bead so the in-flight start and config-drift hashing stay
-// consistent with what was persisted. A source of "" clears the provenance
-// marker, recording that no model is currently auto-stamped.
-func persistPerDispatchModelOverride(session *beads.Bead, store beads.Store, overrides map[string]string, source string) error {
-	raw, err := json.Marshal(overrides)
-	if err != nil {
-		return err
-	}
-	if err := store.SetMetadataBatch(session.ID, map[string]string{
-		"template_overrides":      string(raw),
-		perDispatchModelSourceKey: source,
-	}); err != nil {
-		return err
-	}
-	if session.Metadata == nil {
-		session.Metadata = make(map[string]string, 2)
-	}
-	session.Metadata["template_overrides"] = string(raw)
-	session.Metadata[perDispatchModelSourceKey] = source
-	return nil
-}
-
 func buildPreparedStart(
 	candidate startCandidate,
 	cfg *config.City,
@@ -905,72 +789,36 @@ func buildPreparedStartWithWorkDirResolver(
 	tp := candidate.tp
 	agentCfg := templateParamsToConfig(tp)
 
-	// Per-dispatch model: fold a work bead's advisory "gc.model" metadata into
-	// this session's template_overrides before they are applied below. The
-	// model-advisor pack and the mol-review-quorum formula already write
-	// gc.model on work beads; persisting it as a per-session override here is
-	// what makes an advised model take effect per task/shape instead of only
-	// per agent. An explicit per-session model override always wins, so an
-	// operator/dashboard choice is never overridden by routing metadata, and
-	// the session bead remains the single source of truth so config-drift
-	// hashing (sessionCoreConfigForHash) stays consistent with the launch
-	// command. Default behavior is unchanged when no work bead carries
-	// gc.model.
-	maybeApplyPerDispatchModelOverride(candidate, cfg, store)
-
-	// Fold a per-dispatch reasoning effort from the session's assigned work
-	// bead (gc.reasoning metadata) into template_overrides["effort"], mirroring
-	// how schema option overrides are carried. Only providers with an "effort"
-	// option (codex) consume it; for codex this becomes
-	// `-c model_reasoning_effort=<effort>` via the existing resolution below.
-	// An explicit session-level effort override wins over the dispatch default.
-	// This knob is independent of the per-dispatch model above; both run here.
-	applyDispatchReasoningOverride(candidate, cfg, store)
-
 	// Apply template_overrides from bead metadata. These are per-session
 	// schema option overrides (e.g., {"model":"opus","effort":"high"}) that
 	// override the agent's default CLI flags for specific options.
 	// Build complete options: effective defaults + explicit overrides so
 	// unoverridden defaults are preserved when replaceSchemaFlags strips all
 	// schema flags.
-	if rawOverrides := session.Metadata["template_overrides"]; rawOverrides != "" {
-		if tp.ResolvedProvider != nil && len(tp.ResolvedProvider.OptionsSchema) > 0 {
-			var overrides map[string]string
-			if err := json.Unmarshal([]byte(rawOverrides), &overrides); err != nil {
-				log.Printf("session %s: invalid template_overrides JSON: %v", session.ID, err)
-			} else if len(overrides) > 0 {
-				fullOptions := make(map[string]string)
-				hasSchemaOverride := false
-				for k, v := range tp.ResolvedProvider.EffectiveDefaults {
-					fullOptions[k] = v
-				}
-				for k, v := range overrides {
-					if k == "initial_message" {
-						continue // handled separately below, not a schema option
-					}
-					fullOptions[k] = v
-					hasSchemaOverride = true
-				}
-				args, resolveErr := config.ResolveExplicitOptions(tp.ResolvedProvider.OptionsSchema, fullOptions)
-				if resolveErr != nil {
-					log.Printf("session %s: template_overrides resolution error: %v", session.ID, resolveErr)
-				} else if len(args) > 0 {
-					agentCfg.Command = replaceSchemaFlags(agentCfg.Command, tp.ResolvedProvider.OptionsSchema, args)
-				}
-				if hasSchemaOverride {
-					if command, err := config.BuildProviderResumeCommand(tp.ResolvedProvider, overrides); err == nil && strings.TrimSpace(command) != "" {
-						resolved := *tp.ResolvedProvider
-						resolved.ResumeCommand = command
-						tp.ResolvedProvider = &resolved
-					}
-				}
-			}
-		}
-	}
+	sessionOverrides := parseSessionTemplateOverridesForLaunch(session)
+	applySchemaOptionOverridesForLaunch(&agentCfg, &tp, session.ID, sessionOverrides)
 
 	coreHash := runtime.CoreFingerprint(agentCfg)
 	coreBreakdown := runtime.CoreFingerprintBreakdown(agentCfg)
 	liveHash := runtime.LiveFingerprint(agentCfg)
+
+	// Work beads may carry one-shot provider option overrides as opt_<key>
+	// metadata, where <key> is an OptionsSchema key such as "model" or
+	// "effort". Apply them after core/live hash calculation because they are
+	// dispatch inputs from the current work bead, not durable session config.
+	// Explicit session template_overrides still win per key.
+	dispatchOptions := resolveTaskOptionOverrides(store, tp.ResolvedProvider, taskWorkDirAssignees(candidate, cfg)...)
+	if len(dispatchOptions) > 0 {
+		launchOverrides := make(map[string]string, len(dispatchOptions)+len(sessionOverrides))
+		for k, v := range dispatchOptions {
+			launchOverrides[k] = v
+		}
+		for k, v := range sessionOverrides {
+			launchOverrides[k] = v
+		}
+		applySchemaOptionOverridesForLaunch(&agentCfg, &tp, session.ID, launchOverrides)
+	}
+
 	if wd := resolvePreparedTaskWorkDir(candidate, cfg, store, workDirResolver); wd != "" {
 		agentCfg.WorkDir = wd
 	} else if wd := session.Metadata["work_dir"]; wd != "" {
@@ -1103,46 +951,58 @@ func buildPreparedStartWithWorkDirResolver(
 	}, nil
 }
 
-// applyDispatchReasoningOverride reads the per-dispatch reasoning effort from
-// the session's assigned work bead and folds it into the in-memory session
-// template_overrides under the "effort" key, so the normal override resolution
-// (both fresh-start and resume command building) emits the provider's reasoning
-// flag. It is a no-op when the provider has no "effort" option, when no work
-// bead carries gc.reasoning, or when the session already pins an explicit
-// effort override (the more specific session value wins). The persisted bead is
-// not mutated; only the in-memory copy used for this launch is updated.
-func applyDispatchReasoningOverride(candidate startCandidate, cfg *config.City, store beads.Store) {
-	session := candidate.session
+func parseSessionTemplateOverridesForLaunch(session *beads.Bead) map[string]string {
 	if session == nil {
+		return nil
+	}
+	rawOverrides := strings.TrimSpace(session.Metadata["template_overrides"])
+	if rawOverrides == "" {
+		return nil
+	}
+	var overrides map[string]string
+	if err := json.Unmarshal([]byte(rawOverrides), &overrides); err != nil {
+		log.Printf("session %s: invalid template_overrides JSON: %v", session.ID, err)
+		return nil
+	}
+	return overrides
+}
+
+func applySchemaOptionOverridesForLaunch(agentCfg *runtime.Config, tp *TemplateParams, sessionID string, overrides map[string]string) {
+	if agentCfg == nil || tp == nil || len(overrides) == 0 {
 		return
 	}
-	tp := candidate.tp
-	effort := resolveDispatchReasoningEffort(store, tp.ResolvedProvider, taskWorkDirAssignees(candidate, cfg)...)
-	if effort == "" {
+	resolved := tp.ResolvedProvider
+	if resolved == nil || len(resolved.OptionsSchema) == 0 {
 		return
 	}
-	overrides := map[string]string{}
-	if raw := strings.TrimSpace(session.Metadata["template_overrides"]); raw != "" {
-		if err := json.Unmarshal([]byte(raw), &overrides); err != nil {
-			// Malformed override metadata is logged and surfaced by the main
-			// resolution block below; don't fold on top of unparseable JSON.
-			return
+	fullOptions := make(map[string]string, len(resolved.EffectiveDefaults)+len(overrides))
+	hasSchemaOverride := false
+	for k, v := range resolved.EffectiveDefaults {
+		fullOptions[k] = v
+	}
+	for k, v := range overrides {
+		if k == "initial_message" {
+			continue
 		}
+		fullOptions[k] = v
+		hasSchemaOverride = true
 	}
-	if _, ok := overrides["effort"]; ok {
-		// Explicit session-level effort override takes precedence over the
-		// per-dispatch default.
+	if !hasSchemaOverride {
 		return
 	}
-	overrides["effort"] = effort
-	merged, err := json.Marshal(overrides)
-	if err != nil {
+	args, resolveErr := config.ResolveExplicitOptions(resolved.OptionsSchema, fullOptions)
+	if resolveErr != nil {
+		log.Printf("session %s: template option resolution error: %v", sessionID, resolveErr)
 		return
 	}
-	if session.Metadata == nil {
-		session.Metadata = map[string]string{}
+	if len(args) > 0 {
+		agentCfg.Command = replaceSchemaFlags(agentCfg.Command, resolved.OptionsSchema, args)
 	}
-	session.Metadata["template_overrides"] = string(merged)
+	if command, err := config.BuildProviderResumeCommand(resolved, overrides); err == nil && strings.TrimSpace(command) != "" {
+		dup := *resolved
+		dup.ResumeCommand = command
+		tp.ResolvedProvider = &dup
+	}
 }
 
 func resolvePreparedTaskWorkDir(

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -809,7 +809,7 @@ func buildPreparedStartWithWorkDirResolver(
 	// Explicit session template_overrides still win per key.
 	dispatchOptions := resolveTaskOptionOverrides(store, tp.ResolvedProvider, taskWorkDirAssignees(candidate, cfg)...)
 	if len(dispatchOptions) > 0 {
-		launchOverrides := make(map[string]string, len(dispatchOptions)+len(sessionOverrides))
+		launchOverrides := make(map[string]string, len(dispatchOptions))
 		for k, v := range dispatchOptions {
 			launchOverrides[k] = v
 		}
@@ -975,8 +975,7 @@ func applySchemaOptionOverridesForLaunch(agentCfg *runtime.Config, tp *TemplateP
 	if resolved == nil || len(resolved.OptionsSchema) == 0 {
 		return
 	}
-	fullOptions := make(map[string]string, len(resolved.EffectiveDefaults)+len(overrides))
-	hasSchemaOverride := false
+	fullOptions := make(map[string]string, len(resolved.EffectiveDefaults))
 	for k, v := range resolved.EffectiveDefaults {
 		fullOptions[k] = v
 	}
@@ -985,10 +984,6 @@ func applySchemaOptionOverridesForLaunch(agentCfg *runtime.Config, tp *TemplateP
 			continue
 		}
 		fullOptions[k] = v
-		hasSchemaOverride = true
-	}
-	if !hasSchemaOverride {
-		return
 	}
 	args, resolveErr := config.ResolveExplicitOptions(resolved.OptionsSchema, fullOptions)
 	if resolveErr != nil {

--- a/cmd/gc/session_reasoning_effort_test.go
+++ b/cmd/gc/session_reasoning_effort_test.go
@@ -8,10 +8,9 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
-// codexReasoningResolvedProvider builds a ResolvedProvider backed by the real
-// builtin codex schema so the effort option (low/medium/high/xhigh ->
-// `-c model_reasoning_effort=<v>`) matches production exactly.
-func codexReasoningResolvedProvider() *config.ResolvedProvider {
+// codexEffortResolvedProvider builds a ResolvedProvider backed by the real
+// builtin codex schema so opt_effort uses production flag args.
+func codexEffortResolvedProvider() *config.ResolvedProvider {
 	codex := config.BuiltinProviders()["codex"]
 	return &config.ResolvedProvider{
 		Name:              "codex",
@@ -22,7 +21,7 @@ func codexReasoningResolvedProvider() *config.ResolvedProvider {
 	}
 }
 
-func claudeReasoningResolvedProvider() *config.ResolvedProvider {
+func claudeEffortResolvedProvider() *config.ResolvedProvider {
 	claude := config.BuiltinProviders()["claude"]
 	return &config.ResolvedProvider{
 		Name:              "claude",
@@ -33,10 +32,9 @@ func claudeReasoningResolvedProvider() *config.ResolvedProvider {
 	}
 }
 
-// newReasoningSessionWithWork creates a session bead plus an in-progress work
-// bead assigned to that session carrying the given gc.reasoning value, and
-// returns a start candidate plus the store wired for buildPreparedStart.
-func newReasoningSessionWithWork(t *testing.T, rp *config.ResolvedProvider, baseCommand, reasoning string) (startCandidate, *config.City, beads.Store) {
+// newOptionSessionWithWork creates a session bead plus an in-progress work bead
+// assigned to that session carrying opt_<key> option metadata.
+func newOptionSessionWithWork(t *testing.T, rp *config.ResolvedProvider, baseCommand string, options map[string]string) (startCandidate, *config.City, beads.Store) {
 	t.Helper()
 	store := beads.NewMemStore()
 	session, err := store.Create(beads.Bead{
@@ -53,8 +51,8 @@ func newReasoningSessionWithWork(t *testing.T, rp *config.ResolvedProvider, base
 		t.Fatalf("Create(session): %v", err)
 	}
 	workMeta := map[string]string{}
-	if reasoning != "" {
-		workMeta[dispatchReasoningMetadataKey] = reasoning
+	for key, value := range options {
+		workMeta[dispatchOptionMetadataKey(key)] = value
 	}
 	work, err := store.Create(beads.Bead{
 		Title:    "do the work",
@@ -64,8 +62,6 @@ func newReasoningSessionWithWork(t *testing.T, rp *config.ResolvedProvider, base
 	if err != nil {
 		t.Fatalf("Create(work): %v", err)
 	}
-	// MemStore.Create forces status=open; transition to in_progress so it is
-	// discovered by the same query resolveTaskWorkDir uses in production.
 	if err := store.Update(work.ID, beads.UpdateOpts{Status: ptrString("in_progress")}); err != nil {
 		t.Fatalf("Update(work status): %v", err)
 	}
@@ -79,8 +75,8 @@ func newReasoningSessionWithWork(t *testing.T, rp *config.ResolvedProvider, base
 	return startCandidate{session: &session, tp: tp, order: 0}, cfg, store
 }
 
-func TestBuildPreparedStart_CodexReasoningEffortPresent(t *testing.T) {
-	candidate, cfg, store := newReasoningSessionWithWork(t, codexReasoningResolvedProvider(), "codex", "high")
+func TestBuildPreparedStart_CodexDispatchEffortOptionPresent(t *testing.T) {
+	candidate, cfg, store := newOptionSessionWithWork(t, codexEffortResolvedProvider(), "codex", map[string]string{"effort": "high"})
 
 	prepared, err := buildPreparedStart(candidate, cfg, store)
 	if err != nil {
@@ -94,61 +90,23 @@ func TestBuildPreparedStart_CodexReasoningEffortPresent(t *testing.T) {
 	}
 }
 
-func TestBuildPreparedStart_CodexReasoningEffortAbsent(t *testing.T) {
-	// No gc.reasoning on the work bead: the launcher must not synthesize a
-	// reasoning flag. The base command stays untouched (the codex default
-	// effort is only applied by the launch-command builder, not here).
-	candidate, cfg, store := newReasoningSessionWithWork(t, codexReasoningResolvedProvider(), "codex", "")
+func TestBuildPreparedStart_ProviderEffortOptionUsesProviderSchema(t *testing.T) {
+	candidate, cfg, store := newOptionSessionWithWork(t, claudeEffortResolvedProvider(), "claude", map[string]string{"effort": "high"})
 
 	prepared, err := buildPreparedStart(candidate, cfg, store)
 	if err != nil {
 		t.Fatalf("buildPreparedStart: %v", err)
 	}
+	if !strings.Contains(prepared.cfg.Command, "--effort high") {
+		t.Fatalf("command %q should contain claude --effort high", prepared.cfg.Command)
+	}
 	if strings.Contains(prepared.cfg.Command, "model_reasoning_effort") {
-		t.Fatalf("command %q should not contain a reasoning flag when gc.reasoning is absent", prepared.cfg.Command)
+		t.Fatalf("command %q should not contain codex reasoning flags for claude", prepared.cfg.Command)
 	}
 }
 
-func TestBuildPreparedStart_CodexReasoningEffortInvalidSkipped(t *testing.T) {
-	// An out-of-range value is skipped (logged) rather than crashing or being
-	// injected verbatim.
-	candidate, cfg, store := newReasoningSessionWithWork(t, codexReasoningResolvedProvider(), "codex", "ludicrous")
-
-	prepared, err := buildPreparedStart(candidate, cfg, store)
-	if err != nil {
-		t.Fatalf("buildPreparedStart: %v", err)
-	}
-	if strings.Contains(prepared.cfg.Command, "model_reasoning_effort") {
-		t.Fatalf("command %q should not contain a reasoning flag for an invalid effort", prepared.cfg.Command)
-	}
-	if strings.Contains(prepared.cfg.Command, "ludicrous") {
-		t.Fatalf("command %q should never echo an invalid effort value", prepared.cfg.Command)
-	}
-}
-
-func TestBuildPreparedStart_NonCodexProviderNeverAddsReasoning(t *testing.T) {
-	// A valid-looking effort on a non-codex provider (claude has no reasoning
-	// option) must never produce a model_reasoning_effort flag.
-	candidate, cfg, store := newReasoningSessionWithWork(t, claudeReasoningResolvedProvider(), "claude", "high")
-
-	prepared, err := buildPreparedStart(candidate, cfg, store)
-	if err != nil {
-		t.Fatalf("buildPreparedStart: %v", err)
-	}
-	if strings.Contains(prepared.cfg.Command, "model_reasoning_effort") {
-		t.Fatalf("command %q should never contain model_reasoning_effort for a non-codex provider", prepared.cfg.Command)
-	}
-	// claude has its own unrelated `--effort` option; gc.reasoning must not
-	// leak into it either. The base command must be untouched.
-	if strings.Contains(prepared.cfg.Command, "--effort") {
-		t.Fatalf("command %q should not inject claude --effort from gc.reasoning", prepared.cfg.Command)
-	}
-}
-
-func TestBuildPreparedStart_ExplicitEffortOverrideWinsOverDispatch(t *testing.T) {
-	// A session-level template_overrides effort is more specific than the
-	// per-dispatch gc.reasoning default and must win.
-	candidate, cfg, store := newReasoningSessionWithWork(t, codexReasoningResolvedProvider(), "codex", "high")
+func TestBuildPreparedStart_ExplicitEffortOverrideWinsOverDispatchOption(t *testing.T) {
+	candidate, cfg, store := newOptionSessionWithWork(t, codexEffortResolvedProvider(), "codex", map[string]string{"effort": "high"})
 	candidate.session.Metadata["template_overrides"] = `{"effort":"low"}`
 
 	prepared, err := buildPreparedStart(candidate, cfg, store)
@@ -164,24 +122,3 @@ func TestBuildPreparedStart_ExplicitEffortOverrideWinsOverDispatch(t *testing.T)
 }
 
 func ptrString(s string) *string { return &s }
-
-func TestResolveDispatchReasoningEffort_NonCodexReturnsEmpty(t *testing.T) {
-	store := beads.NewMemStore()
-	work, err := store.Create(beads.Bead{
-		Title:    "w",
-		Assignee: "agent-x",
-		Metadata: map[string]string{dispatchReasoningMetadataKey: "high"},
-	})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	if err := store.Update(work.ID, beads.UpdateOpts{Status: ptrString("in_progress")}); err != nil {
-		t.Fatalf("Update(status): %v", err)
-	}
-	if got := resolveDispatchReasoningEffort(store, claudeReasoningResolvedProvider(), "agent-x"); got != "" {
-		t.Fatalf("resolveDispatchReasoningEffort(non-codex) = %q, want empty", got)
-	}
-	if got := resolveDispatchReasoningEffort(store, codexReasoningResolvedProvider(), "agent-x"); got != "high" {
-		t.Fatalf("resolveDispatchReasoningEffort(codex) = %q, want high", got)
-	}
-}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -3716,160 +3716,73 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 	return ""
 }
 
-// resolveTaskModel returns the per-dispatch model choice requested by the
-// work bead a candidate session is about to claim. It mirrors
-// resolveTaskWorkDir: it scans the in-progress work beads assigned to the
-// candidate's identifiers and returns the first non-empty WorkRoutingModel
-// (the advisory "gc.model" metadata written by the model-advisor pack and the
-// mol-review-quorum formula). An empty result means "no per-dispatch model"
-// and leaves the agent's configured default model untouched.
-func resolveTaskModel(store beads.Store, assignees ...string) string {
-	if store == nil {
-		return ""
-	}
-	seen := make(map[string]bool, len(assignees))
-	for _, assignee := range assignees {
-		assignee = strings.TrimSpace(assignee)
-		if assignee == "" || seen[assignee] {
-			continue
-		}
-		seen[assignee] = true
-		assigned, err := store.List(beads.ListQuery{
-			Assignee: assignee,
-			Status:   "in_progress",
-			Live:     true,
-			TierMode: beads.TierBoth,
-			Sort:     beads.SortCreatedDesc,
-		})
-		if err != nil {
-			continue
-		}
-		for _, b := range assigned {
-			if model := WorkRoutingModel(b); model != "" {
-				return model
-			}
-		}
-	}
-	return ""
+const dispatchOptionMetadataPrefix = "opt_"
+
+func dispatchOptionMetadataKey(key string) string {
+	return dispatchOptionMetadataPrefix + key
 }
 
-// dispatchReasoningMetadataKey is the work-bead metadata key that carries a
-// per-dispatch reasoning effort. It mirrors how other gc.* dispatch metadata
-// (e.g. gc.run_target) rides on the work bead and is folded into the session at
-// launch. Only providers that expose a reasoning "effort" option (codex)
-// consume it; see resolveDispatchReasoningEffort.
-const dispatchReasoningMetadataKey = "gc.reasoning"
-
-// isCodexProvider reports whether the resolved provider is the codex CLI or
-// derives from it. It prefers BuiltinAncestor (the canonical resolved family)
-// and falls back to the provider Name so callers that build a ResolvedProvider
-// without walking the builtin chain are still matched.
-func isCodexProvider(rp *config.ResolvedProvider) bool {
-	if rp == nil {
-		return false
-	}
-	return rp.BuiltinAncestor == "codex" || rp.Name == "codex"
-}
-
-// resolveDispatchReasoningEffort returns the reasoning effort requested by the
-// session's in-progress assigned work bead via the gc.reasoning metadata key,
-// validated against the provider's "effort" option schema. It mirrors
-// resolveTaskWorkDir: query each assignee identifier's in-progress work and use
-// the newest match. Providers without an "effort" option (everything but codex)
-// always return "" so the flag is never added. An invalid value is skipped and
-// logged rather than crashing — the launcher then falls back to the model
-// default.
-func resolveDispatchReasoningEffort(store beads.Store, rp *config.ResolvedProvider, assignees ...string) string {
-	if store == nil || rp == nil {
-		return ""
-	}
-	// gc.reasoning maps to codex's `-c model_reasoning_effort=<effort>` only.
-	// Other providers (e.g. claude) expose an unrelated "effort" option
-	// (`--effort`); never fold the dispatch reasoning value into those.
-	if !isCodexProvider(rp) {
-		return ""
-	}
-	effortOpt := providerEffortOption(rp)
-	if effortOpt == nil {
-		// Codex with no effort schema (custom strip): nothing to validate
-		// against, so emit nothing.
-		return ""
-	}
-	seen := make(map[string]bool, len(assignees))
-	for _, assignee := range assignees {
-		assignee = strings.TrimSpace(assignee)
-		if assignee == "" || seen[assignee] {
-			continue
-		}
-		seen[assignee] = true
-		assigned, err := store.List(beads.ListQuery{
-			Assignee: assignee,
-			Status:   "in_progress",
-			Live:     true,
-			TierMode: beads.TierBoth,
-			Sort:     beads.SortCreatedDesc,
-		})
-		if err != nil {
-			continue
-		}
-		for _, b := range assigned {
-			raw := strings.TrimSpace(b.Metadata[dispatchReasoningMetadataKey])
-			if raw == "" {
-				continue
-			}
-			if !effortChoiceIsValid(effortOpt, raw) {
-				log.Printf("work %s: invalid %s %q (want one of %s); skipping reasoning override",
-					b.ID, dispatchReasoningMetadataKey, raw, strings.Join(effortChoiceValues(effortOpt), ", "))
-				continue
-			}
-			return raw
-		}
-	}
-	return ""
-}
-
-// providerEffortOption returns the provider's "effort" option schema entry, or
-// nil when the provider exposes no reasoning-effort knob.
-func providerEffortOption(rp *config.ResolvedProvider) *config.ProviderOption {
-	if rp == nil {
+// resolveTaskOptionOverrides returns provider option choices requested by the
+// newest in-progress work bead assigned to the candidate's identifiers. Work
+// beads use the same opt_<OptionsSchema key> metadata convention as session
+// beads, so a provider can consume opt_model, opt_effort, or future schema
+// options without a new gc.* field. Values are validated against the resolved
+// provider OptionsSchema and invalid values are skipped.
+func resolveTaskOptionOverrides(store beads.Store, rp *config.ResolvedProvider, assignees ...string) map[string]string {
+	if store == nil || rp == nil || len(rp.OptionsSchema) == 0 {
 		return nil
 	}
-	for i := range rp.OptionsSchema {
-		if rp.OptionsSchema[i].Key == "effort" {
-			return &rp.OptionsSchema[i]
+	seen := make(map[string]bool, len(assignees))
+	for _, assignee := range assignees {
+		assignee = strings.TrimSpace(assignee)
+		if assignee == "" || seen[assignee] {
+			continue
+		}
+		seen[assignee] = true
+		assigned, err := store.List(beads.ListQuery{
+			Assignee: assignee,
+			Status:   "in_progress",
+			Live:     true,
+			TierMode: beads.TierBoth,
+			Sort:     beads.SortCreatedDesc,
+		})
+		if err != nil {
+			continue
+		}
+		for _, b := range assigned {
+			overrides, sawOptions := workBeadOptionOverrides(b, rp)
+			if sawOptions {
+				return overrides
+			}
 		}
 	}
 	return nil
 }
 
-// effortChoiceIsValid reports whether value is a declared, non-empty choice of
-// the effort option (for codex: low, medium, high, xhigh). The empty "Default"
-// choice is intentionally rejected as an explicit override value.
-func effortChoiceIsValid(opt *config.ProviderOption, value string) bool {
-	if opt == nil || value == "" {
-		return false
+func workBeadOptionOverrides(b beads.Bead, rp *config.ResolvedProvider) (map[string]string, bool) {
+	if rp == nil {
+		return nil, false
 	}
-	for _, choice := range opt.Choices {
-		if choice.Value == value {
-			return true
-		}
-	}
-	return false
-}
-
-// effortChoiceValues lists the non-empty effort choice values for diagnostics.
-func effortChoiceValues(opt *config.ProviderOption) []string {
-	if opt == nil {
-		return nil
-	}
-	values := make([]string, 0, len(opt.Choices))
-	for _, choice := range opt.Choices {
-		if choice.Value == "" {
+	overrides := make(map[string]string)
+	sawOptions := false
+	for _, opt := range rp.OptionsSchema {
+		metadataKey := dispatchOptionMetadataKey(opt.Key)
+		raw, ok := b.Metadata[metadataKey]
+		if !ok {
 			continue
 		}
-		values = append(values, choice.Value)
+		sawOptions = true
+		value := strings.TrimSpace(raw)
+		if value == "" {
+			continue
+		}
+		if _, err := config.ResolveExplicitOptions(rp.OptionsSchema, map[string]string{opt.Key: value}); err != nil {
+			log.Printf("work %s: ignoring %s=%q: %v", b.ID, metadataKey, value, err)
+			continue
+		}
+		overrides[opt.Key] = value
 	}
-	return values
+	return overrides, sawOptions
 }
 
 type assignedTaskWorkDir struct {

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -52,6 +52,7 @@ bd-split-store
 beads-store
 v2-routed-to-namespace
 run-target-routed-to-backfill
+work-option-metadata-migration
 backlog-depth
 order-tracking-retention
 session-model

--- a/cmd/gc/work_routing_metadata.go
+++ b/cmd/gc/work_routing_metadata.go
@@ -34,14 +34,3 @@ func routedToAndLegacyWorkflowCandidates(b beads.Bead) []string {
 	}
 	return []string{routedTo}
 }
-
-// WorkRoutingModel returns the advisory per-dispatch model choice carried by a
-// work bead in its "gc.model" metadata, or "" when none is set. This is the
-// key the model-advisor pack and the mol-review-quorum formula already write;
-// it is consumed at session spawn so an advised model applies per task/shape
-// rather than only per agent. The value is a provider OptionsSchema "model"
-// choice value (e.g. "opus", "sonnet"); validation against the resolved
-// provider's schema happens at the spawn site.
-func WorkRoutingModel(b beads.Bead) string {
-	return strings.TrimSpace(b.Metadata["gc.model"])
-}

--- a/internal/bootstrap/packs/core/formulas/mol-review-quorum.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-review-quorum.toml
@@ -96,7 +96,7 @@ retryable infrastructure issue occurs, close with `gc.outcome=fail`,
 `gc.failure_class=transient`, and a stable `gc.failure_reason`. For
 non-retryable input or contract failures, use `gc.failure_class=hard`.
 """
-metadata = { "gc.run_target" = "{{lane_one_target}}", "gc.provider" = "{{lane_one_provider}}", "gc.model" = "{{lane_one_model}}", "gc.review_quorum_lane" = "{{lane_one_id}}", "gc.reviewer_model" = "{{lane_one_model}}", "gc.output_json_schema" = "review-quorum.lane.v1", "gc.output_json_required" = "true" }
+metadata = { "gc.run_target" = "{{lane_one_target}}", "gc.provider" = "{{lane_one_provider}}", "opt_model" = "{{lane_one_model}}", "gc.review_quorum_lane" = "{{lane_one_id}}", "gc.reviewer_model" = "{{lane_one_model}}", "gc.output_json_schema" = "review-quorum.lane.v1", "gc.output_json_required" = "true" }
 
 [steps.retry]
 max_attempts = 3
@@ -142,7 +142,7 @@ retryable infrastructure issue occurs, close with `gc.outcome=fail`,
 `gc.failure_class=transient`, and a stable `gc.failure_reason`. For
 non-retryable input or contract failures, use `gc.failure_class=hard`.
 """
-metadata = { "gc.run_target" = "{{lane_two_target}}", "gc.provider" = "{{lane_two_provider}}", "gc.model" = "{{lane_two_model}}", "gc.review_quorum_lane" = "{{lane_two_id}}", "gc.reviewer_model" = "{{lane_two_model}}", "gc.output_json_schema" = "review-quorum.lane.v1", "gc.output_json_required" = "true" }
+metadata = { "gc.run_target" = "{{lane_two_target}}", "gc.provider" = "{{lane_two_provider}}", "opt_model" = "{{lane_two_model}}", "gc.review_quorum_lane" = "{{lane_two_id}}", "gc.reviewer_model" = "{{lane_two_model}}", "gc.output_json_schema" = "review-quorum.lane.v1", "gc.output_json_required" = "true" }
 
 [steps.retry]
 max_attempts = 3

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -1277,8 +1277,8 @@ func TestCompileReviewQuorumCoreFormula(t *testing.T) {
 		if got := attempt.Metadata["gc.provider"]; !strings.HasPrefix(got, "{{lane_") {
 			t.Fatalf("%s attempt gc.provider = %q, want lane provider placeholder", stepID, got)
 		}
-		if got := attempt.Metadata["gc.model"]; !strings.HasPrefix(got, "{{lane_") {
-			t.Fatalf("%s attempt gc.model = %q, want lane model placeholder", stepID, got)
+		if got := attempt.Metadata["opt_model"]; !strings.HasPrefix(got, "{{lane_") {
+			t.Fatalf("%s attempt opt_model = %q, want lane model placeholder", stepID, got)
 		}
 		if !strings.Contains(attempt.Description, "{{base_ref}}") {
 			t.Fatalf("%s attempt description missing base_ref prompt placeholder", stepID)

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -239,13 +239,13 @@ func TestBuildRecipeApplyPlanReviewQuorumSubstitutesSynthesisTarget(t *testing.T
 		"mol-review-quorum.review-lane-one.attempt.1": {
 			"gc.run_target":         "target-a",
 			"gc.provider":           "provider-a",
-			"gc.model":              "model-a",
+			"opt_model":             "model-a",
 			"gc.review_quorum_lane": "primary",
 		},
 		"mol-review-quorum.review-lane-two.attempt.1": {
 			"gc.run_target":         "target-b",
 			"gc.provider":           "provider-b",
-			"gc.model":              "model-b",
+			"opt_model":             "model-b",
 			"gc.review_quorum_lane": "secondary",
 		},
 	}


### PR DESCRIPTION
## Summary
- replace one-off work-bead gc.model/gc.reasoning launch handling with generic opt_<OptionsSchema key> metadata
- update review quorum formula metadata from gc.model to opt_model
- add gc doctor / gc doctor --fix migration for live task beads carrying legacy gc.model/gc.reasoning metadata

## Tests
- go test ./cmd/gc -run 'Test(WorkOptionMetadataMigration|BuildDoctorChecksRegistersWorkOptionMetadataMigration|BuildDoctorChecks_NameSetUnchanged|ResolveTaskOptionOverrides|BuildPreparedStart_(ExplicitOverrideWinsPerKey|CodexDispatchEffortOptionPresent|ProviderEffortOptionUsesProviderSchema|ExplicitEffortOverrideWinsOverDispatchOption)|BuildPreparedStartAppliesWorkBeadOptionsToCommand)'
- go test ./internal/formula ./internal/molecule -run 'Test(CompileReviewQuorumCoreFormula|BuildRecipeApplyPlanReviewQuorumSubstitutesSynthesisTarget)'
- make test-fast-parallel
- go vet ./...
