### PR TITLE
fix(test): explicit /tmp/gct-* cleanup before os.Exit + doc comment (#3237 follow-up)

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -228,6 +228,9 @@ func TestMain(m *testing.M) {
 	}
 
 	_ = os.RemoveAll(tmpDir)
+	if tmuxSocketParent != "" {
+		_ = os.RemoveAll(tmuxSocketParent)
+	}
 	os.Exit(code)
 }
 

--- a/test/tmuxtest/guard.go
+++ b/test/tmuxtest/guard.go
@@ -101,7 +101,7 @@ func NewGuardWithSocket(t testing.TB, socketName string) *Guard {
 	return g
 }
 
-// CityName returns the unique city name (e.g., "gctest-a-1-b-2-c-3-d-4").
+// CityName returns the unique city name (e.g., "gctest-<8hex>").
 func (g *Guard) CityName() string {
 	return g.cityName
 }


### PR DESCRIPTION
## Summary

Two mechanical items the fix-executor missed from the `fix-merge` of #3237:

- **Dead defer cleanup**: `defer os.RemoveAll(tmuxSocketParent)` in `TestMain` is dead code — `os.Exit` bypasses defers, so `/tmp/gct-*` dirs leak on every integration run. Added explicit `if tmuxSocketParent != "" { _ = os.RemoveAll(tmuxSocketParent) }` before `os.Exit`, mirroring the existing `_ = os.RemoveAll(tmpDir)` pattern already in the file.
- **Doc comment**: `CityName()` method comment still showed the old per-character hyphenated example (`"gctest-a-1-b-2-c-3-d-4"`). Updated to `"gctest-<8hex>"` to match the struct-field comment already fixed in #3237.

Both were identified by the ensemble review for #3237 but not applied before merge.

## Test plan

- `go vet -tags integration ./test/integration/... ./test/tmuxtest/...` — clean
- `go test ./test/tmuxtest/ -run 'TmuxSocketRootPatterns|NewGuardWithSocketCityNameFormat' -v` — PASS
- `go build -tags integration ./test/...` — clean
- Full fast unit suite (`make test-fast-parallel`) — all pass

Closes the fix-executor gap from #3237.