### PR TITLE
fix(test): clean up /tmp/gct-* on all early TestMain exit paths

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -120,6 +120,9 @@ func TestMain(m *testing.M) {
 	if !subprocess {
 		if _, err := exec.LookPath("tmux"); err != nil {
 			_ = os.RemoveAll(tmpDir)
+			if tmuxSocketParent != "" {
+				_ = os.RemoveAll(tmuxSocketParent)
+			}
 			os.Exit(0)
 		}
 		// Pre-sweep: kill this run's root plus stale sibling orphans.
@@ -171,6 +174,10 @@ func TestMain(m *testing.M) {
 		realBDBinary, err = exec.LookPath("bd")
 		if err != nil {
 			// bd not available — skip all integration tests.
+			_ = os.RemoveAll(tmpDir)
+			if tmuxSocketParent != "" {
+				_ = os.RemoveAll(tmuxSocketParent)
+			}
 			os.Exit(0)
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to #3241: the two early skip exits in `TestMain` (tmux missing, bd missing) were also missing the `tmuxSocketParent` cleanup — `os.Exit` bypasses defers.

- **Tmux-missing exit** (line ~123): already cleaned `tmpDir` but not `tmuxSocketParent`
- **bd-missing exit** (line ~174): cleaned neither `tmpDir` nor `tmuxSocketParent`

Added the matching explicit cleanup before each `os.Exit(0)`, mirroring the pattern established in #3241 for the main exit path.

## Changes

- `test/integration/integration_test.go`: add explicit `os.RemoveAll` before two early `os.Exit(0)` paths

## Test plan

- `go vet -tags integration ./test/integration/...` — clean
- `go build -tags integration ./test/...` — clean
- `make test-fast-parallel` — all pass

Identified by Codex's review of #3241.