### PR TITLE
docs(agents): automation must open PRs to upstream, never merge to fork main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,3 +481,11 @@ These apply to all code in this project — frontend and server:
   Take advantage of that feedback to fix those errors!
 - **Use Centralized Semantic Constant Values** using enums and constants instead
   of spreading magic numbers throughout the code.
+
+### Automation must never merge to the fork's `main`
+
+This is a fork. The refinery, polecats, and any automation MUST NOT merge or push
+to `origin/main`. Every change ships as a pull request to `upstream` from a
+dedicated branch created off `upstream/main` (see `CONTRIBUTING.md`, "Never open a
+PR from your fork's `main` branch"). Automation that merges to the fork's `main` is
+a defect — open a PR instead.


### PR DESCRIPTION
Mirrors `CONTRIBUTING.md`'s existing human guidance ("Never open a PR from your fork's `main` branch; use a dedicated branch per PR") as an explicit directive for **automation** (refinery / polecats), which had no matching rule and was merging changes directly to the fork's `main`.

Adds a short "Automation must never merge to the fork's `main`" section to `AGENTS.md`: every change ships as a PR to `upstream` from a dedicated branch off `upstream/main`.
