### PR TITLE
test(tier_c): isolate Dolt DB prefixes across acceptance tests

### DIFF
--- a/test/acceptance/tier_c/tierc_test.go
+++ b/test/acceptance/tier_c/tierc_test.go
@@ -446,7 +446,11 @@ func setupThrowawayRepo(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
 	originDir := filepath.Join(root, "origin.git")
-	repoDir := filepath.Join(root, "repo")
+	// Derive a unique name from the test name so each test gets a distinct
+	// Dolt DB prefix. All tests share the same DOLT_ROOT_PATH; a hardcoded
+	// "repo" name would give every test the "re" prefix, causing bd init to
+	// fail on pre-existing dirty tables when a prior test's supervisor crashed.
+	repoDir := filepath.Join(root, uniqueRigName(t.Name()))
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -462,6 +466,41 @@ func setupThrowawayRepo(t *testing.T) string {
 	gitCmd(t, repoDir, "commit", "-m", "initial commit")
 	gitCmd(t, repoDir, "push", "-u", "origin", "main")
 	return repoDir
+}
+
+// uniqueRigName returns a short rig directory name derived from the test name.
+// It produces a name of ≤3 chars (CamelCase initials of the last _-component),
+// which DeriveBeadsPrefix returns unchanged as the Dolt DB prefix. This ensures
+// tests sharing the same DOLT_ROOT_PATH get distinct databases and bd init cannot
+// encounter pre-existing dirty tables left by a previous test's crashed supervisor.
+func uniqueRigName(testName string) string {
+	// Use the last _-separated component, e.g. "TestGastown_PolecatLifecycle" → "PolecatLifecycle".
+	if i := strings.LastIndex(testName, "_"); i >= 0 {
+		testName = testName[i+1:]
+	} else if strings.HasPrefix(testName, "Test") {
+		testName = testName[4:]
+	}
+	// Extract CamelCase initials as lowercase.
+	var initials strings.Builder
+	for i, r := range testName {
+		if i == 0 || (r >= 'A' && r <= 'Z') {
+			if r >= 'A' && r <= 'Z' {
+				initials.WriteByte(byte(r - 'A' + 'a'))
+			} else {
+				initials.WriteRune(r)
+			}
+		}
+	}
+	abbrev := initials.String()
+	if abbrev == "" {
+		return "rig"
+	}
+	// ≤3 chars: DeriveBeadsPrefix returns it as-is → unique DB prefix.
+	// >3 chars: truncate to 3 (still unique among the small set of tests here).
+	if len(abbrev) > 3 {
+		abbrev = abbrev[:3]
+	}
+	return abbrev
 }
 
 func newGastownAcceptanceCity(t *testing.T) *helpers.City {

--- a/test/acceptance/tier_c/tierc_test.go
+++ b/test/acceptance/tier_c/tierc_test.go
@@ -934,6 +934,25 @@ func TestTierCEnvAuthDoesNotMirrorAuthTokenIntoAPIKey(t *testing.T) {
 	require.True(t, hasEnvAuth)
 }
 
+func TestUniqueRigName(t *testing.T) {
+	cases := []struct {
+		testName string
+		want     string
+	}{
+		{"TestSwarm_SlingWorkCoderCommits", "swc"},
+		{"TestGastown_PolecatImplementsRefineryMerges", "pir"},
+		{"TestGastown_PolecatLifecycle", "pl"},
+		{"TestGastown_MayorDispatchPipeline", "mdp"},
+		{"TestStandalone", "s"}, // no underscore: strips "Test", single initial
+		{"", "rig"},             // empty input falls back to "rig"
+	}
+	for _, tc := range cases {
+		if got := uniqueRigName(tc.testName); got != tc.want {
+			t.Errorf("uniqueRigName(%q) = %q, want %q", tc.testName, got, tc.want)
+		}
+	}
+}
+
 func stageClaudeOAuth(realHome, gcHome string) error {
 	srcClaudeDir := filepath.Join(realHome, ".claude")
 	dstClaudeDir := filepath.Join(gcHome, ".claude")


### PR DESCRIPTION
## What this changes

Tier C acceptance tests now create throwaway rig clones with short names derived from each test name instead of always using `repo`. Because `DeriveBeadsPrefix` preserves names of three characters or fewer, the affected tests now use distinct Dolt DB prefixes: `swc`, `pir`, `pl`, and `mdp`.

This prevents a failed or crashed Tier C test from leaving dirty Dolt tables under a prefix that a later test reuses, which was causing `bd init` failures in `TestGastown_MayorDispatchPipeline`.

## Review notes

- Change is limited to `test/acceptance/tier_c/tierc_test.go`.
- `uniqueRigName` intentionally uses the final underscore-delimited test component and truncates CamelCase initials to three characters to match `DeriveBeadsPrefix` behavior.
- No production runtime, config, API schema, or dashboard behavior changes.

## Test plan

- [x] `go test -tags acceptance_c ./test/acceptance/tier_c -run 'TestUniqueRigName|TestTierCEnvAuthDoesNotMirrorAuthTokenIntoAPIKey' -count=1`
- [x] `go vet -tags acceptance_c ./test/acceptance/tier_c`
- [x] `go vet ./...`
- [x] `make test-fast-parallel` (clean rerun; first run hit a transient unchanged `internal/runtime/tmux` test and recovery checks passed)
