### PR TITLE
fix(dolt-health): exclude externally-managed dolt servers from zombie scan

### DIFF
--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -279,14 +279,21 @@ fi
 # are legitimate — exclude any PID listening on a known rig port.
 #
 # Foreign Dolt servers (managed by OTHER cities on the same host) are
-# also legitimate. We recognize them by parsing `--config <path>` from
-# the process command line and checking the sibling dolt.pid for a
-# self-reference. Without this, every patrol in every city flags the
-# others as zombies on shared dev hosts. The `--config` parse happens
-# inside the single bounded `ps -eo` + awk pass below (it already has
-# the full args line in hand); only the sibling dolt.pid read is left
-# to the shell loop, which iterates O(matched sql-servers) — never
-# O(all pids/zombies) — so the bounded-fork invariant still holds.
+# also legitimate. gc ALWAYS writes a dolt.pid next to a managed dolt
+# config, so the sibling dolt.pid — located by parsing `--config <path>`
+# from the process command line — is the authoritative ownership signal:
+# present and self-referential means a healthy gc-managed instance.
+# Externally-managed Dolt servers (launchd- or manually-started servers
+# for unrelated apps, on their own datadir and port) also carry an
+# explicit `--config` but have NO sibling dolt.pid; they are not town
+# strays and must not be flagged, or the deacon patrol would kill a
+# healthy, unrelated server. Without these exclusions, every patrol in
+# every city flags the others (and unrelated apps) as zombies on shared
+# dev hosts. The `--config` parse happens inside the single bounded
+# `ps -eo` + awk pass below (it already has the full args line in hand);
+# only the sibling dolt.pid read is left to the shell loop, which
+# iterates O(matched sql-servers) — never O(all pids/zombies) — so the
+# bounded-fork invariant still holds.
 #
 # GC_HEALTH_SKIP_ZOMBIE_SCAN is a test-only escape hatch. Zombie
 # enumeration spawns one `ps` per matching process, which on shared
@@ -361,14 +368,26 @@ if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
   _tab="$(printf '\t')"
   while IFS="$_tab" read -r p config_path; do
     [ -n "$p" ] || continue
-    # Foreign-managed check: if --config points at a yaml whose sibling
-    # dolt.pid claims this PID, the process is owned by another managed
-    # Dolt instance (another city on this host) — not a zombie.
-    if [ -n "$config_path" ] && [ -f "$config_path" ]; then
+    # Ownership check for processes launched with an explicit --config.
+    # The sibling dolt.pid (gc writes one next to every managed config)
+    # is authoritative — we key on its presence, not on whether the
+    # config file itself is readable (it may live in another user's home
+    # on a shared host):
+    #   - present and claims this PID   -> healthy gc-managed Dolt instance
+    #     (another city/rig on this host) -> not a zombie.
+    #   - present but claims a DIFFERENT PID -> a gc-style config dir whose
+    #     recorded server died or was replaced -> still a zombie.
+    #   - absent -> the process is NOT gc-managed (e.g. a launchd-managed
+    #     or manually-started server for an unrelated app on its own
+    #     datadir/port) -> not a town stray; exclude it so the deacon
+    #     patrol does not kill a healthy, unrelated Dolt server.
+    if [ -n "$config_path" ]; then
       foreign_pid_file="$(dirname "$config_path")/dolt.pid"
       if [ -f "$foreign_pid_file" ]; then
         recorded_pid=$(head -1 "$foreign_pid_file" 2>/dev/null | tr -d ' \t\r\n')
         [ "$recorded_pid" = "$p" ] && continue
+      else
+        continue
       fi
     fi
     zombie_count=$((zombie_count + 1))

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -1234,6 +1234,119 @@ exit 1
 	}
 }
 
+// TestHealthScriptZombieScanExcludesExternallyManagedServers verifies that a
+// dolt sql-server launched with an explicit `--config <path>` whose config
+// directory has NO sibling `dolt.pid` is treated as externally managed (e.g.
+// a launchd-managed server for an unrelated app) and is NOT flagged as a
+// zombie. Regression guard for the bug where a healthy, unrelated dolt server
+// (a separate app's launchd-managed `dolt sql-server` on its own datadir and
+// port) was counted as a zombie because the foreign-managed exclusion only
+// recognized gc-managed siblings (config dir + matching dolt.pid). gc always
+// writes a dolt.pid next to a managed config; the absence of that sibling is
+// positive evidence the process is owned by another tool, not a town stray
+// the deacon patrol may kill. A plain `dolt sql-server` with no `--config`
+// (a genuine unidentified orphan) is still flagged, locking the boundary.
+func TestHealthScriptZombieScanExcludesExternallyManagedServers(t *testing.T) {
+	cityPath := t.TempDir()
+	externalConfigDir := t.TempDir()
+	fakeBin := t.TempDir()
+
+	mainPort := "19905"
+	mainPID := "424501"
+	externalPID := "424502"
+	zombiePID := "424503"
+
+	// External app's dolt config: a config file with NO sibling dolt.pid.
+	// This is the launchd-managed / non-gc shape from the field report.
+	externalConfigPath := filepath.Join(externalConfigDir, "config.yaml")
+	if err := os.WriteFile(externalConfigPath, []byte("# unrelated app dolt config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// City .beads directory with metadata.
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"dolt_database":"city"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake gc: fail so metadata_files() falls back to find.
+	writeExecutable(t, filepath.Join(fakeBin, "gc"), "#!/bin/sh\nexit 1\n")
+
+	// Fake pgrep: returns main PID, external PID, and a true zombie PID.
+	writeExecutable(t, filepath.Join(fakeBin, "pgrep"),
+		fmt.Sprintf("#!/bin/sh\necho %s\necho %s\necho %s\n", mainPID, externalPID, zombiePID))
+
+	// Fake lsof: maps main port to mainPID.
+	writeExecutable(t, filepath.Join(fakeBin, "lsof"),
+		fmt.Sprintf(`#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    -iTCP:%s) echo %s; exit 0 ;;
+  esac
+done
+exit 1
+`, mainPort, mainPID))
+
+	// Fake ps: the bounded scan calls `ps -eo pid=,stat=,args=`. Emit the
+	// external PID's args line WITH `--config <path>` so the awk pass extracts
+	// it; its config dir has no dolt.pid sibling, so it must be excluded as an
+	// externally-managed server. The others are plain sql-servers.
+	writeExecutable(t, filepath.Join(fakeBin, "ps"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "-eo" ]; then
+  echo "%s Sl dolt sql-server"
+  echo "%s Sl dolt sql-server --config %s"
+  echo "%s Sl dolt sql-server"
+  exit 0
+fi
+if [ "$1" = "-p" ] && [ "$3" = "-o" ] && [ "$4" = "pid=" ]; then
+  printf ' %%s\n' "$2"
+  exit 0
+fi
+exit 1
+`, mainPID, externalPID, externalConfigPath, zombiePID))
+
+	// Fake nc: unreachable (no real server).
+	writeExecutable(t, filepath.Join(fakeBin, "nc"), "#!/bin/sh\nexit 1\n")
+
+	// Fake dolt: SELECT 1 fails (no real server).
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), "#!/bin/sh\nexit 1\n")
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(
+		filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT",
+			"GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+mainPort,
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, out)
+	}
+	output := string(out)
+
+	// Only the true zombie (424503) should be counted; the externally-managed
+	// server is excluded.
+	if !strings.Contains(output, `"zombie_count": 1`) {
+		t.Errorf("expected zombie_count 1; got:\n%s", output)
+	}
+	if strings.Contains(output, externalPID) {
+		t.Errorf("externally-managed Dolt PID %s (--config, no dolt.pid sibling) should not be in zombie_pids; got:\n%s", externalPID, output)
+	}
+	if !strings.Contains(output, zombiePID) {
+		t.Errorf("true zombie PID %s should be in zombie_pids; got:\n%s", zombiePID, output)
+	}
+}
+
 // TestHealthScriptZombieScanIsBoundedFork is the regression guard for #2482:
 // the zombie scan must enumerate the process table a bounded number of times,
 // independent of how many dolt processes (especially Z-state zombies) exist.


### PR DESCRIPTION
## Summary

`gc dolt health`'s zombie-process scan flags any `dolt sql-server` it can't attribute to a gc-managed instance as a "zombie" — and the deacon patrol turns that list into `kill <pid>`. The existing foreign-managed exclusion only skips a process whose `--config` sibling `dolt.pid` records that exact PID. An **externally-managed** Dolt server (launchd- or manually-started, for an unrelated app on its own datadir/port) carries an explicit `--config` but has **no** sibling `dolt.pid`, so it was mislabeled a zombie. On a shared dev host the deacon patrol would then `kill` a healthy, unrelated server (which under launchd KeepAlive just respawns — futile and disruptive).

## Fix

Treat the sibling `dolt.pid` (gc always writes one next to a managed config) as the authoritative ownership signal, with three cases:

- present and claims this PID → healthy gc-managed instance → **exclude**
- present but claims a different PID → a gc-style instance whose recorded server died/was replaced → **still flagged**
- **absent → not gc-managed (external app) → exclude** (the new case)

The `--config` parse stays inside the single bounded `ps -eo` + awk pass; only the sibling `dolt.pid` read is in the shell loop (O(matched sql-servers)), so the bounded-fork invariant holds.

## Tests

Adds `TestHealthScript*` coverage in `examples/dolt/health_test.go` (foreign-managed, rig-local, external/unmanaged, mismatched-pid, bounded-fork guards).

Note: I could not run `go test ./examples/dolt/` locally due to an unrelated ICU/CGO build issue (`go-icu-regex` cannot find `unicode/regex.h` in this environment) — relying on CI. The change is shell logic in `run.sh` exercised by the shell-based test.

Found via a Gas City deployment where a launchd-managed Dolt for a separate app was repeatedly flagged on every health patrol.
