### PR TITLE
fix(beads): disable bd auto-backup (backup_export) for managed scopes

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -695,6 +695,26 @@ func appendBdCLIRemoteSyncOptOutEnvKeys(keys []string) []string {
 	return keys
 }
 
+// bdAutoBackupOptOutEnvKeys disables bd's PersistentPostRun auto-backup —
+// the hardcoded "backup_export" Dolt remote bd syncs on (almost) every
+// invocation. A stuck-looping backup_export sync was the root cause of the
+// 2026-06-08 town-wide Dolt wedge (ga-0eq): it saturated the commit path
+// while oscillating not-found/already-exists. gc never relies on this path
+// (managed backups run through mol-dog-backup), so it is pure downside here.
+// BD_BACKUP_ENABLED is the key bd's BD-prefixed Viper env binding consumes
+// today; keep BEADS_BACKUP_ENABLED as a compatibility alias only.
+var bdAutoBackupOptOutEnvKeys = [...]string{
+	"BD_BACKUP_ENABLED",
+	"BEADS_BACKUP_ENABLED",
+}
+
+func appendBdAutoBackupOptOutEnvKeys(keys []string) []string {
+	for _, key := range bdAutoBackupOptOutEnvKeys {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 var (
 	beadsExecCommandRunnerWithEnv             = beads.ExecCommandRunnerWithEnv
 	processEnvSnapshotExcludingNativeDoltOpen = beads.ProcessEnvSnapshotExcludingNativeDoltOpen
@@ -705,6 +725,7 @@ var recoverManagedBDCommand = func(cityPath string) error {
 	overrides := cityRuntimeEnvMapForCity(cityPath)
 	setProjectedDoltEnvEmpty(overrides)
 	applyBdCLIRemoteSyncOptOut(overrides)
+	applyBdAutoBackupOptOut(overrides)
 	environ := mergeRuntimeEnv(processEnvSnapshotExcludingNativeDoltOpen(), overrides)
 	environ = append(environ, providerLifecycleDoltPathEnv(cityPath)...)
 	if gcBin := resolveProviderLifecycleGCBinary(); gcBin != "" {
@@ -1250,6 +1271,13 @@ func bdRuntimeEnvWithError(cityPath string) (map[string]string, error) {
 	// large datasets.
 	env["BD_EXPORT_AUTO"] = "false"
 	applyBdCLIRemoteSyncOptOut(env)
+	// Suppress bd's PersistentPostRun auto-backup (the "backup_export" Dolt
+	// remote). Like BD_EXPORT_AUTO above, the env var is the bulletproof
+	// per-invocation guard: it covers fresh rig scopes whose config has not
+	// been canonicalized and overrides any drifted backup.enabled:true. A
+	// stuck-looping backup_export sync wedged the whole town on 2026-06-08
+	// (ga-0eq); managed backups run through mol-dog-backup, not this path.
+	applyBdAutoBackupOptOut(env)
 	// Opt-in: route bd through the pooling db-proxy (no-op unless [beads] proxied
 	// and bd supports it). Covers agent AND controller bd calls (rig env builds
 	// on this base).
@@ -1310,6 +1338,7 @@ func cityRuntimeProcessEnvWithError(cityPath string) ([]string, error) {
 	if cityUsesBdStoreContract(cityPath) {
 		source := map[string]string{"BEADS_DOLT_AUTO_START": "0"}
 		applyBdCLIRemoteSyncOptOut(source)
+		applyBdAutoBackupOptOut(source)
 		if usedPostgres, err := applyCityPostgresBackendEnv(source, cityPath); err != nil {
 			clearProjectedDoltEnv(source)
 			clearProjectedPostgresEnv(source)
@@ -1340,6 +1369,19 @@ func applyBdCLIRemoteSyncOptOut(env map[string]string) {
 		return
 	}
 	for _, key := range bdCLIRemoteSyncOptOutEnvKeys {
+		env[key] = "false"
+	}
+}
+
+// applyBdAutoBackupOptOut forces bd's PersistentPostRun auto-backup off for
+// gc-managed bd invocations. It overrides any ambient or per-scope config
+// value so a fresh or drifted rig store cannot re-enable the destructive
+// backup_export sync (ga-0eq). See bdAutoBackupOptOutEnvKeys.
+func applyBdAutoBackupOptOut(env map[string]string) {
+	if env == nil {
+		return
+	}
+	for _, key := range bdAutoBackupOptOutEnvKeys {
 		env[key] = "false"
 	}
 }
@@ -1443,6 +1485,7 @@ func mergeRuntimeEnv(environ []string, overrides map[string]string) []string {
 		"GC_RIG_ROOT",
 	}
 	keys = appendBdCLIRemoteSyncOptOutEnvKeys(keys)
+	keys = appendBdAutoBackupOptOutEnvKeys(keys)
 	if len(overrides) > 0 {
 		for key := range overrides {
 			if !containsString(keys, key) {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -407,6 +407,96 @@ func TestRecoverManagedBDCommandDisablesCLIRemoteSync(t *testing.T) {
 	}
 }
 
+// The auto-backup opt-out tests mirror the CLI-remote-sync opt-out tests
+// above. They guard against recurrence of the 2026-06-08 town-wide Dolt
+// wedge (ga-0eq), whose root cause was bd's PersistentPostRun auto-backup
+// (the hardcoded "backup_export" Dolt remote) stuck-looping and saturating
+// the commit path. gc-managed bd invocations must force BD_BACKUP_ENABLED
+// off at every env-projection site, overriding any ambient/config value so
+// a fresh or drifted rig scope cannot re-enable it.
+
+func TestBdRuntimeEnvDisablesAutoBackup(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("BD_BACKUP_ENABLED", "true")
+	t.Setenv("BEADS_BACKUP_ENABLED", "true")
+
+	env := mustBdRuntimeEnv(t, t.TempDir())
+	if got := env["BD_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BD_BACKUP_ENABLED = %q, want false", got)
+	}
+	if got := env["BEADS_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BEADS_BACKUP_ENABLED = %q, want false", got)
+	}
+}
+
+func TestCityRuntimeProcessEnvDisablesAutoBackup(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("BD_BACKUP_ENABLED", "true")
+	t.Setenv("BEADS_BACKUP_ENABLED", "true")
+
+	values := envEntriesMap(mustCityRuntimeProcessEnv(t, t.TempDir()))
+	if got := values["BD_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BD_BACKUP_ENABLED = %q, want false", got)
+	}
+	if got := values["BEADS_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BEADS_BACKUP_ENABLED = %q, want false", got)
+	}
+}
+
+func TestSessionBackendEnvDisablesAutoBackup(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("BD_BACKUP_ENABLED", "true")
+	t.Setenv("BEADS_BACKUP_ENABLED", "true")
+
+	env := mustSessionBackendEnv(t, t.TempDir(), "", nil)
+	if got := env["BD_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BD_BACKUP_ENABLED = %q, want false", got)
+	}
+	if got := env["BEADS_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BEADS_BACKUP_ENABLED = %q, want false", got)
+	}
+}
+
+func TestRecoverManagedBDCommandDisablesAutoBackup(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("BD_BACKUP_ENABLED", "true")
+	t.Setenv("BEADS_BACKUP_ENABLED", "true")
+
+	cityPath := t.TempDir()
+	envFile := filepath.Join(cityPath, "recover-env.txt")
+	scriptPath := gcBeadsBdScriptPath(cityPath)
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\n" +
+		"printf 'BD_BACKUP_ENABLED=%s\\n' \"$BD_BACKUP_ENABLED\" > \"" + envFile + "\"\n" +
+		"printf 'BEADS_BACKUP_ENABLED=%s\\n' \"$BEADS_BACKUP_ENABLED\" >> \"" + envFile + "\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := recoverManagedBDCommand(cityPath); err != nil {
+		t.Fatalf("recoverManagedBDCommand() error = %v", err)
+	}
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	if got := values["BD_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BD_BACKUP_ENABLED = %q, want false", got)
+	}
+	if got := values["BEADS_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BEADS_BACKUP_ENABLED = %q, want false", got)
+	}
+}
+
 func TestBdRuntimeEnvExternalHostSkipsLocalState(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT_HOST", "remote.example.com")
@@ -4952,6 +5042,11 @@ func TestProjectedKeysCoverage(t *testing.T) {
 	for _, key := range bdCLIRemoteSyncOptOutEnvKeys {
 		if !projectedKeyStripped(key) {
 			t.Errorf("bdCLIRemoteSyncOptOutEnvKeys[%q] is not in mergeRuntimeEnv strip list - symmetry broken", key)
+		}
+	}
+	for _, key := range bdAutoBackupOptOutEnvKeys {
+		if !projectedKeyStripped(key) {
+			t.Errorf("bdAutoBackupOptOutEnvKeys[%q] is not in mergeRuntimeEnv strip list - symmetry broken", key)
 		}
 	}
 }

--- a/cmd/gc/store_target_exec.go
+++ b/cmd/gc/store_target_exec.go
@@ -18,11 +18,12 @@ type execStoreTarget struct {
 }
 
 func execProjectedBackendEnvKeys() []string {
-	keys := make([]string, 0, len(projectedBeadsBackendEnvKeys)+len(projectedDoltEnvKeys)+len(projectedPostgresEnvKeys)+len(bdCLIRemoteSyncOptOutEnvKeys))
+	keys := make([]string, 0, len(projectedBeadsBackendEnvKeys)+len(projectedDoltEnvKeys)+len(projectedPostgresEnvKeys)+len(bdCLIRemoteSyncOptOutEnvKeys)+len(bdAutoBackupOptOutEnvKeys))
 	keys = append(keys, projectedBeadsBackendEnvKeys...)
 	keys = append(keys, projectedDoltEnvKeys...)
 	keys = append(keys, projectedPostgresEnvKeys...)
 	keys = appendBdCLIRemoteSyncOptOutEnvKeys(keys)
+	keys = appendBdAutoBackupOptOutEnvKeys(keys)
 	return keys
 }
 
@@ -31,6 +32,7 @@ func setExecProjectedBackendEnvEmpty(env map[string]string) {
 		env[key] = ""
 	}
 	applyBdCLIRemoteSyncOptOut(env)
+	applyBdAutoBackupOptOut(env)
 }
 
 func copyExecProjectedBackendEnv(dst, src map[string]string) {

--- a/cmd/gc/store_target_exec_test.go
+++ b/cmd/gc/store_target_exec_test.go
@@ -117,6 +117,24 @@ func envSliceValue(env []string, key string) string {
 	return ""
 }
 
+func TestSetExecProjectedBackendEnvEmptyDisablesAutoBackup(t *testing.T) {
+	// The exec-store projection is the 5th bd env-projection site (alongside
+	// bdRuntimeEnv, cityRuntimeProcessEnv, sessionBackendEnv, and recovery).
+	// It must force bd's PersistentPostRun auto-backup off (ga-0eq), even when
+	// the ambient env tries to enable it.
+	env := map[string]string{
+		"BD_BACKUP_ENABLED":    "true",
+		"BEADS_BACKUP_ENABLED": "true",
+	}
+	setExecProjectedBackendEnvEmpty(env)
+	if got := env["BD_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BD_BACKUP_ENABLED = %q, want false", got)
+	}
+	if got := env["BEADS_BACKUP_ENABLED"]; got != "false" {
+		t.Fatalf("BEADS_BACKUP_ENABLED = %q, want false", got)
+	}
+}
+
 func TestProviderUsesBdStoreContract(t *testing.T) {
 	tests := []struct {
 		provider string

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -624,6 +624,7 @@ func sessionBackendEnvWithError(cityPath, rigRoot string, rigs []config.Rig) (ma
 		"BEADS_DOLT_AUTO_START": "0",
 	}
 	applyBdCLIRemoteSyncOptOut(env)
+	applyBdAutoBackupOptOut(env)
 	// Explicit empty values let tmux unset stale Dolt vars inherited from
 	// the server environment when the current city/rig does not use them.
 	setProjectedDoltEnvEmpty(env)

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -485,6 +485,12 @@ func EnsureCanonicalConfig(fs fsys.FS, path string, state ConfigState) (bool, er
 	// datasets. BD_EXPORT_AUTO env-var suppression only covers gc's own calls,
 	// so bake it into the on-disk config too.
 	changed = setBool(root, "export.auto", false) || changed
+	// Managed scopes back up through mol-dog-backup; bd's PersistentPostRun
+	// auto-backup (the "backup_export" Dolt remote) is redundant and, when its
+	// remote state breaks, stuck-loops and saturates the commit path — the
+	// root cause of the 2026-06-08 town-wide wedge (ga-0eq). BD_BACKUP_ENABLED
+	// env-var suppression only covers gc's own calls, so bake it in too.
+	changed = setBool(root, "backup.enabled", false) || changed
 	if state.EndpointOrigin != "" {
 		changed = setString(root, "gc.endpoint_origin", string(state.EndpointOrigin)) || changed
 	}
@@ -610,6 +616,7 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 	replacements := map[string]string{
 		"dolt.auto-start": "dolt.auto-start: false",
 		"export.auto":     "export.auto: false",
+		"backup.enabled":  "backup.enabled: false",
 	}
 	if prefix != "" {
 		replacements["issue_prefix"] = "issue_prefix: " + prefix
@@ -695,6 +702,7 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		"issue-prefix",
 		"dolt.auto-start",
 		"export.auto",
+		"backup.enabled",
 		"gc.endpoint_origin",
 		"gc.endpoint_status",
 		"dolt.host",

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -114,6 +114,7 @@ func TestEnsureCanonicalConfigCreatesManagedShape(t *testing.T) {
 		"issue-prefix: gc",
 		"dolt.auto-start: false",
 		"export.auto: false",
+		"backup.enabled: false",
 		"dolt:",
 		"disable-event-flush: true",
 		"gc.endpoint_origin: managed_city",
@@ -313,6 +314,79 @@ func TestEnsureCanonicalConfigForcesAutoExportOff(t *testing.T) {
 		}
 		if !strings.Contains(text, "export.auto: false") {
 			t.Fatalf("config should force export.auto: false:\n%s", text)
+		}
+	})
+}
+
+func TestEnsureCanonicalConfigForcesAutoBackupOff(t *testing.T) {
+	// bd's PersistentPostRun auto-backup (the hardcoded "backup_export" Dolt
+	// remote) syncs on nearly every invocation. A stuck-looping backup_export
+	// sync saturated the commit path and wedged the whole town on 2026-06-08
+	// (ga-0eq). Managed scopes back up through mol-dog-backup, so this must be
+	// forced off at config time — not just via BD_BACKUP_ENABLED env-var
+	// suppression, which leaks when bd is invoked outside the gc wrapper
+	// (agents, humans, bd setup) or before a rig scope is canonicalized.
+	t.Run("sets false when key is absent", func(t *testing.T) {
+		fs := fsys.OSFS{}
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		input := strings.Join([]string{
+			"issue-prefix: gc",
+			"dolt.auto-start: false",
+			"",
+		}, "\n")
+		if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := EnsureCanonicalConfig(fs, path, ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: EndpointOriginManagedCity,
+			EndpointStatus: EndpointStatusVerified,
+		}); err != nil {
+			t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+		}
+
+		data, err := fs.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(data), "backup.enabled: false") {
+			t.Fatalf("config should force backup.enabled: false:\n%s", data)
+		}
+	})
+
+	t.Run("overrides explicit true", func(t *testing.T) {
+		fs := fsys.OSFS{}
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		input := strings.Join([]string{
+			"issue-prefix: gc",
+			"backup.enabled: true",
+			"",
+		}, "\n")
+		if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := EnsureCanonicalConfig(fs, path, ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: EndpointOriginManagedCity,
+			EndpointStatus: EndpointStatusVerified,
+		}); err != nil {
+			t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+		}
+
+		data, err := fs.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(data)
+		if strings.Contains(text, "backup.enabled: true") {
+			t.Fatalf("config should scrub backup.enabled: true:\n%s", text)
+		}
+		if !strings.Contains(text, "backup.enabled: false") {
+			t.Fatalf("config should force backup.enabled: false:\n%s", text)
 		}
 	})
 }

--- a/internal/orders/env.go
+++ b/internal/orders/env.go
@@ -16,8 +16,10 @@ func ValidateExecEnvOverrides(a Order) error {
 func IsReservedExecEnvKey(key string) bool {
 	switch key {
 	case
+		"BD_BACKUP_ENABLED",
 		"BD_EXPORT_AUTO",
 		"BEADS_ACTOR",
+		"BEADS_BACKUP_ENABLED",
 		"BEADS_CREDENTIALS_FILE",
 		"BEADS_DIR",
 		"BEADS_DOLT_AUTO_START",

--- a/internal/orders/env_test.go
+++ b/internal/orders/env_test.go
@@ -1,0 +1,24 @@
+package orders
+
+import "testing"
+
+// TestReservedExecEnvKeysIncludeBdAutoBackup guards ga-0eq: the controller
+// forces bd's PersistentPostRun auto-backup off via BD_BACKUP_ENABLED, so an
+// order's [order.env] must not be able to re-enable the destructive
+// backup_export sync that wedged the town on 2026-06-08.
+func TestReservedExecEnvKeysIncludeBdAutoBackup(t *testing.T) {
+	for _, key := range []string{"BD_BACKUP_ENABLED", "BEADS_BACKUP_ENABLED"} {
+		if !IsReservedExecEnvKey(key) {
+			t.Errorf("IsReservedExecEnvKey(%q) = false, want true", key)
+		}
+	}
+}
+
+// TestValidateExecEnvOverridesRejectsBdAutoBackup confirms the reservation is
+// enforced end-to-end through the order validation path.
+func TestValidateExecEnvOverridesRejectsBdAutoBackup(t *testing.T) {
+	order := Order{Name: "o", Env: map[string]string{"BD_BACKUP_ENABLED": "true"}}
+	if err := ValidateExecEnvOverrides(order); err == nil {
+		t.Fatal("ValidateExecEnvOverrides() = nil, want error for reserved BD_BACKUP_ENABLED override")
+	}
+}


### PR DESCRIPTION
## Summary

bd's `PersistentPostRun` auto-backup syncs to a hardcoded `backup_export` Dolt remote on nearly every invocation. When that remote's state breaks (e.g. "no common ancestor"), the sync **stuck-loops** (not-found / already-exists, ~every 30s) and saturates Dolt's commit path.

In a Gas City deployment this was the **root cause of a town-wide Dolt wedge** — bd reads/writes failed everywhere, and the managed Dolt server's process went into uninterruptible I/O (`STAT U`). Managed (gc-managed) scopes already back up via `mol-dog-backup`, so bd's auto-backup path is pure downside there.

## Fix

Disable bd auto-backup for managed scopes, using the same defense-in-depth gascity already applies to bd's auto-export:

- **Env guard** — force `BD_BACKUP_ENABLED=false` (+ `BEADS_BACKUP_ENABLED` alias) at every bd env-projection site (`bdRuntimeEnv`, `cityRuntimeProcessEnv`, `sessionBackendEnv`, exec-store, managed-BD recovery), and add it to the `mergeRuntimeEnv` strip list.
- **Canonical config** — bake `backup.enabled: false` into every managed `.beads/config.yaml` (both the YAML and text-fallback writers).

## Tests

Adds coverage in `cmd/gc/bd_env_test.go`, `cmd/gc/store_target_exec_test.go`, `internal/beads/contract/files_test.go`, and `internal/orders/env_test.go` (env projection + config bake).

Note: I could not run `go test` locally due to an unrelated ICU/CGO build issue in this environment (`go-icu-regex` cannot find `unicode/regex.h`) — relying on CI.
