### PR TITLE
fix(order-dispatch): protect tracking index cache from concurrent writes

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -288,6 +288,7 @@ type memoryOrderDispatcher struct {
 }
 
 type orderDispatchTrackingIndex struct {
+	mu      sync.Mutex
 	entries map[string]map[string]orderTrackingSummary
 	errs    map[string]error
 }
@@ -829,6 +830,8 @@ func (idx *orderDispatchTrackingIndex) lastRunForStore(store beads.Store, storeK
 
 func (idx *orderDispatchTrackingIndex) historyEntriesForStore(store beads.Store, storeKey string) (map[string]orderTrackingSummary, error) {
 	key := storeKey + "\x00history"
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
 	if err, ok := idx.errs[key]; ok {
 		return nil, err
 	}
@@ -858,6 +861,8 @@ func (idx *orderDispatchTrackingIndex) historyEntriesForStore(store beads.Store,
 }
 
 func (idx *orderDispatchTrackingIndex) entriesForStore(store beads.Store, storeKey string) (map[string]orderTrackingSummary, error) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
 	if err, ok := idx.errs[storeKey]; ok {
 		return nil, err
 	}

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -8523,6 +8523,32 @@ func TestSweepClosedOrderTrackingRetentionAcrossStoresBounded_DoesNotBypassRetai
 	}
 }
 
+// TestOrderDispatchTrackingIndexConcurrentEntriesForStore verifies that
+// concurrent calls to entriesForStore and historyEntriesForStore on the same
+// index do not race. Before the mutex fix, -race detected writes to idx.entries
+// and idx.errs from multiple goroutines simultaneously (e.g. when a
+// gateOpenWorkBounded timeout fires and the orphaned goroutine races a new one).
+func TestOrderDispatchTrackingIndexConcurrentEntriesForStore(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	idx := newOrderDispatchTrackingIndex()
+
+	const workers = 20
+	var wg sync.WaitGroup
+	wg.Add(workers * 2)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = idx.entriesForStore(store, "key-open")
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = idx.historyEntriesForStore(store, "key-history")
+		}()
+	}
+	wg.Wait()
+}
+
 func TestSweepClosedOrderTrackingRetentionAcrossStoresBounded_ZeroLimitDeletesNothing(t *testing.T) {
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
 	policy := orderTrackingRetentionPolicy{

--- a/release-gates/ga-w6apie-order-dispatch-tracking-index-race-gate.md
+++ b/release-gates/ga-w6apie-order-dispatch-tracking-index-race-gate.md
@@ -1,0 +1,52 @@
+# Release Gate: order dispatch tracking index race
+
+Bead: ga-w6apie
+Source bug: ga-8x5zv4
+Review bead: ga-5v7yyh
+Branch: builder/ga-8x5zv4
+Reviewed commit: 082f504a48bb70ae527591a9fa1a14c10b3343b2
+Gate worktree: /tmp/gascity-deploy-ga-w6apie.WOQJfR
+Gate date: 2026-06-08
+
+## Manifest
+
+`docs/PROJECT_MANIFEST.md` is absent on `origin/main` and this branch, so no
+repo-specific Release Criteria section was available. This gate uses the
+deployer criteria plus the repo quality gates in `AGENTS.md` and `TESTING.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-5v7yyh` contains `REVIEW VERDICT: PASS`; deploy wrapper `ga-w6apie` says reviewed and passed by `gascity/reviewer`. |
+| 2 | Acceptance criteria met | PASS | `orderDispatchTrackingIndex` has `mu sync.Mutex`; `historyEntriesForStore` and `entriesForStore` lock before reading/writing `idx.entries` and `idx.errs`; source bug `ga-8x5zv4` is closed with the expected exit contract. |
+| 3 | Tests pass | PASS | See test evidence below. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-5v7yyh` list correctness/test/security PASS and only one non-blocking style nit; no HIGH findings. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty before writing this gate; rechecked after committing the gate before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` returned success on the reviewed branch. |
+| 7 | Single feature theme | PASS | Commit `082f504a4` changes only `cmd/gc/order_dispatch.go` and `cmd/gc/order_dispatch_test.go` for the order-dispatch tracking-index race. |
+
+## Acceptance Evidence
+
+- The fix is scoped to the order dispatch tracking index in `cmd/gc`.
+- `cmd/gc/order_dispatch.go` adds a mutex to `orderDispatchTrackingIndex`.
+- `historyEntriesForStore` and `entriesForStore` hold that mutex across the
+  cache read/check/write path.
+- `cmd/gc/order_dispatch_test.go` adds
+  `TestOrderDispatchTrackingIndexConcurrentEntriesForStore`, which exercises
+  concurrent open-entry and history-entry cache access.
+
+## Test Evidence
+
+| Command | Result | Summary |
+|---------|--------|---------|
+| `go test -race ./cmd/gc -run TestOrderDispatchTrackingIndexConcurrentEntriesForStore -count=5` | PASS | `ok github.com/gastownhall/gascity/cmd/gc 1.367s` |
+| `make test-fast-parallel` | PASS | 8 fast jobs passed: `fsys-darwin-compile`, `unit-core`, and `unit-cmd-gc-1-of-6` through `unit-cmd-gc-6-of-6`. |
+| `go vet ./...` | PASS | No output; exit 0. |
+| `go build -o /tmp/gc-ga-w6apie ./cmd/gc` | PASS | CLI binary built successfully. |
+| `/tmp/gc-ga-w6apie --help` | PASS | Help text rendered and exited 0. |
+
+## Deploy Decision
+
+PASS. Open a pull request for `builder/ga-8x5zv4` and route the merge request
+to mayor/mpr. Do not merge from the deployer seat.


### PR DESCRIPTION
## What this changes

Order dispatch now protects its tracking-index cache from concurrent map writes. The cache is shared while order gate checks run under bounded timeouts; when an earlier timed-out gate goroutine keeps running, a later gate can otherwise populate the same maps at the same time.

The fix adds a mutex to `orderDispatchTrackingIndex` and holds it through the read/check/write path for both open tracking entries and recent tracking history entries. That keeps the existing cache behavior and avoids replacing the maps with a broader concurrency abstraction for a narrow race.

## Review notes

- The changed runtime surface is `cmd/gc/order_dispatch.go`, specifically the tracking-index cache used by order open-work gates.
- The lock is held through cache-miss store reads. That is intentionally conservative because cache misses are bounded to a store/key and the race is in the full populate path.
- No config, API, schema, or dashboard surface changes.

## Test plan

- [x] `go test -race ./cmd/gc -run TestOrderDispatchTrackingIndexConcurrentEntriesForStore -count=5`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build -o /tmp/gc-ga-w6apie ./cmd/gc`
- [x] `/tmp/gc-ga-w6apie --help`
- [x] Release gate: [`release-gates/ga-w6apie-order-dispatch-tracking-index-race-gate.md`](release-gates/ga-w6apie-order-dispatch-tracking-index-race-gate.md)
