### PR TITLE
fix(docgen): skip hidden dirs in schema comment walk

### DIFF
--- a/internal/docgen/schema.go
+++ b/internal/docgen/schema.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/invopop/jsonschema"
@@ -30,12 +31,38 @@ func ModuleRoot() (string, error) {
 	}
 }
 
+// addGoCommentsFiltered calls r.AddGoComments for each visible (non-hidden)
+// top-level directory under root, skipping any directory whose name begins
+// with ".". CWD must already be set to root before calling.
+//
+// This avoids the TOCTOU failure where .gc/*/pr-checkout/ dirs are deleted by
+// mpr cleanup while filepath.Walk is in progress: r.AddGoComments("module",
+// ".") walks the entire tree including .gc/; if a directory disappears
+// mid-scan the walk surfaces an I/O error that propagates up and fails schema
+// generation. By enumerating only visible top-level dirs, we never enter .gc/.
+func addGoCommentsFiltered(r *jsonschema.Reflector, module, root string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", root, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if err := r.AddGoComments(module, entry.Name()); err != nil {
+			return fmt.Errorf("extracting Go comments from %s: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
 // newReflector creates a jsonschema.Reflector configured for TOML field
 // names with Go doc comments extracted from the source tree.
 //
-// AddGoComments requires the path parameter to be "." with the working
-// directory set to the module root, so that filepath.Walk produces paths
-// like "internal/config" which gopath.Join maps to the correct import path.
+// AddGoComments requires CWD to be set to the module root so that
+// filepath.Walk produces paths like "internal/config" which map to the
+// correct import paths. Hidden directories (names beginning with ".") are
+// excluded via addGoCommentsFiltered.
 func newReflector() (*jsonschema.Reflector, error) {
 	root, err := ModuleRoot()
 	if err != nil {
@@ -55,7 +82,7 @@ func newReflector() (*jsonschema.Reflector, error) {
 	r := &jsonschema.Reflector{
 		FieldNameTag: "toml",
 	}
-	if err := r.AddGoComments("github.com/gastownhall/gascity", "."); err != nil {
+	if err := addGoCommentsFiltered(r, "github.com/gastownhall/gascity", "."); err != nil {
 		return nil, fmt.Errorf("extracting Go comments: %w", err)
 	}
 	return r, nil

--- a/internal/docgen/schema_test.go
+++ b/internal/docgen/schema_test.go
@@ -2,8 +2,12 @@ package docgen
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/invopop/jsonschema"
 )
 
 // defProperties extracts the properties map for a named $defs entry.
@@ -312,6 +316,49 @@ func TestPackSchemaAliasFieldHidden(t *testing.T) {
 	props := defProperties(t, raw, "PackConfig")
 	if _, ok := props["agents"]; ok {
 		t.Errorf("PackConfig should hide the legacy %q alias (jsonschema:\"-\") for agent_defaults", "agents")
+	}
+}
+
+// TestAddGoCommentsFilteredSkipsHiddenDirs verifies that addGoCommentsFiltered
+// does not enter directories whose name begins with ".". This guards against
+// the TOCTOU failure where .gc/*/pr-checkout/ dirs are deleted by mpr cleanup
+// while a schema-gen walk is in progress: if the hidden dir is unreadable or
+// disappears mid-walk, a plain r.AddGoComments(".", ...) surfaces an I/O error;
+// the filtered variant must skip hidden dirs entirely so no such error occurs.
+func TestAddGoCommentsFilteredSkipsHiddenDirs(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Visible source dir with a Go struct — should be processed normally.
+	if err := os.MkdirAll(filepath.Join(tmp, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	goSrc := "package pkg\n\n// Widget is a widget.\ntype Widget struct{}\n"
+	if err := os.WriteFile(filepath.Join(tmp, "pkg", "widget.go"), []byte(goSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hidden dir made unreadable: if walked it triggers "permission denied".
+	gcDir := filepath.Join(tmp, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(gcDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(gcDir, 0o755) })
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(orig) }()
+
+	r := &jsonschema.Reflector{FieldNameTag: "toml"}
+	if err := addGoCommentsFiltered(r, "example.com/test", "."); err != nil {
+		t.Errorf("addGoCommentsFiltered failed with unreadable hidden dir: %v", err)
 	}
 }
 

--- a/release-gates/ga-5emkl7-docgen-hidden-dirs-gate.md
+++ b/release-gates/ga-5emkl7-docgen-hidden-dirs-gate.md
@@ -1,0 +1,76 @@
+# Release Gate: docgen hidden directory schema walk fix
+
+Date: 2026-06-08
+Deployer: gascity/deployer
+Deploy bead: ga-5emkl7
+Source bug: ga-79qhoy
+Review bead: ga-onhynn
+Feature branch: builder/ga-79qhoy
+Reviewed commit: 72e838e125a49dc617ba0cfbe9bfda647c550e8e
+Base checked: origin/main at 544bf47df80e63abff7b30553e1407f435d6e264
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate
+uses the deployer release criteria from the active Gas City deployer prompt.
+
+## Gate Summary
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-onhynn` is closed with `Review Verdict: PASS` for commit `72e838e125a49dc617ba0cfbe9bfda647c550e8e`; deploy bead `ga-5emkl7` records reviewer PASS evidence. |
+| 2 | Acceptance criteria met | PASS | Source bug `ga-79qhoy` required excluding `.gc/` from schema comment walks. The commit replaces repo-wide `AddGoComments(".", ...)` with `addGoCommentsFiltered`, which enumerates visible top-level directories only and skips names beginning with `.`. |
+| 3 | Tests pass | PASS | Focused docgen regression passed; `make test` passed with observable log `/tmp/gascity-test.jsonl.ELhVPS`; `go vet ./...` passed; `go build ./cmd/gc` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes list PASS for style, design, security, and test coverage. No blockers or high-severity findings are listed. Unresolved HIGH count: 0. |
+| 5 | Final branch is clean | PASS | Feature worktree `builder/worktrees/ga-79qhoy` was clean before writing this gate: `git status --short --branch` reported only `## builder/ga-79qhoy...origin/builder/ga-79qhoy`. Final cleanliness is rechecked after committing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main builder/ga-79qhoy) origin/main builder/ga-79qhoy` completed with a merged result and no conflict markers. `git diff --check origin/main...builder/ga-79qhoy` produced no output. |
+| 7 | Single feature theme | PASS | The commit set touches only `internal/docgen/schema.go` and `internal/docgen/schema_test.go`; one subsystem and one behavior: schema generation no longer walks transient hidden runtime directories. |
+
+## Acceptance Evidence
+
+- `newReflector` now calls `addGoCommentsFiltered` instead of walking the
+  entire module root with `r.AddGoComments("github.com/gastownhall/gascity", ".")`.
+- `addGoCommentsFiltered` reads the module root, processes visible top-level
+  directories, and skips hidden directories such as `.gc/`, preventing schema
+  generation from entering MPR checkout directories that can disappear mid-walk.
+- `TestAddGoCommentsFilteredSkipsHiddenDirs` creates an unreadable hidden
+  directory and verifies the filtered comment walk succeeds.
+- Existing city and pack schema tests still pass.
+
+## Test Evidence
+
+```text
+$ go test ./internal/docgen -run 'TestAddGoCommentsFilteredSkipsHiddenDirs|TestCitySchema|TestPackSchema|TestAddGoComments' -count=1
+ok  	github.com/gastownhall/gascity/internal/docgen	6.846s
+
+$ make test
+observable go test: PASS log=/tmp/gascity-test.jsonl.ELhVPS
+
+$ go vet ./...
+PASS
+
+$ go build ./cmd/gc
+PASS
+```
+
+## Commands Run
+
+```text
+gh auth status
+bd show ga-5emkl7
+bd show ga-onhynn
+bd show ga-79qhoy
+git show --stat --name-only --oneline 72e838e12
+git diff --name-only origin/main...builder/ga-79qhoy
+git diff --check origin/main...builder/ga-79qhoy
+git merge-tree $(git merge-base origin/main builder/ga-79qhoy) origin/main builder/ga-79qhoy
+go test ./internal/docgen -run 'TestAddGoCommentsFilteredSkipsHiddenDirs|TestCitySchema|TestPackSchema|TestAddGoComments' -count=1
+make test
+go vet ./...
+go build ./cmd/gc
+```
+
+## Files Reviewed
+
+```text
+internal/docgen/schema.go
+internal/docgen/schema_test.go
+```

--- a/release-gates/ga-5emkl7-docgen-hidden-dirs-gate.md
+++ b/release-gates/ga-5emkl7-docgen-hidden-dirs-gate.md
@@ -9,6 +9,7 @@ PR: https://github.com/gastownhall/gascity/pull/3255
 Feature branch: builder/ga-79qhoy
 Reviewed commit: 72e838e125a49dc617ba0cfbe9bfda647c550e8e
 Base checked: origin/main at 544bf47df80e63abff7b30553e1407f435d6e264
+Post-push base rechecked: origin/main at 4111f8fb55fa24afec413719519b385014f15310
 
 Note: `docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate
 uses the deployer release criteria from the active Gas City deployer prompt.
@@ -22,7 +23,7 @@ uses the deployer release criteria from the active Gas City deployer prompt.
 | 3 | Tests pass | PASS | Focused docgen regression passed; `make test` passed with observable log `/tmp/gascity-test.jsonl.ELhVPS`; `go vet ./...` passed; `go build ./cmd/gc` passed. |
 | 4 | No high-severity review findings open | PASS | Review notes list PASS for style, design, security, and test coverage. No blockers or high-severity findings are listed. Unresolved HIGH count: 0. |
 | 5 | Final branch is clean | PASS | Feature worktree `builder/worktrees/ga-79qhoy` was clean before writing this gate: `git status --short --branch` reported only `## builder/ga-79qhoy...origin/builder/ga-79qhoy`. Final cleanliness is rechecked after committing this gate file. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main builder/ga-79qhoy) origin/main builder/ga-79qhoy` completed with a merged result and no conflict markers. `git diff --check origin/main...builder/ga-79qhoy` produced no output. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main builder/ga-79qhoy) origin/main builder/ga-79qhoy` completed with a merged result and no conflict markers against initial base `544bf47df80e63abff7b30553e1407f435d6e264` and post-push base `4111f8fb55fa24afec413719519b385014f15310`. `git diff --check origin/main...builder/ga-79qhoy` produced no output. |
 | 7 | Single feature theme | PASS | The commit set touches only `internal/docgen/schema.go` and `internal/docgen/schema_test.go`; one subsystem and one behavior: schema generation no longer walks transient hidden runtime directories. |
 
 ## Acceptance Evidence

--- a/release-gates/ga-5emkl7-docgen-hidden-dirs-gate.md
+++ b/release-gates/ga-5emkl7-docgen-hidden-dirs-gate.md
@@ -5,6 +5,7 @@ Deployer: gascity/deployer
 Deploy bead: ga-5emkl7
 Source bug: ga-79qhoy
 Review bead: ga-onhynn
+PR: https://github.com/gastownhall/gascity/pull/3255
 Feature branch: builder/ga-79qhoy
 Reviewed commit: 72e838e125a49dc617ba0cfbe9bfda647c550e8e
 Base checked: origin/main at 544bf47df80e63abff7b30553e1407f435d6e264


### PR DESCRIPTION
## What this changes

Schema generation no longer walks hidden top-level directories like `.gc/` when collecting Go doc comments for the generated city and pack schemas. This prevents intermittent `GenerateCitySchema` / `GeneratePackSchema` failures when MPR or other runtime cleanup removes transient checkout directories while the schema walk is in progress.

The implementation keeps comment extraction explicit: it enumerates visible top-level directories and calls `jsonschema.Reflector.AddGoComments` for each one, rather than catching ENOENTs from a repo-wide walk. That avoids masking real errors in visible source directories while excluding runtime state.

## Review notes

- Look at `internal/docgen/schema.go` for the directory-filtering boundary.
- Hidden top-level directories are skipped; visible source directories still fail closed on read/comment extraction errors.
- The regression test uses an unreadable hidden directory to prove hidden runtime paths are not entered.
- No config, schema shape, HTTP/API, or dashboard surface changes.

## Test plan

- [x] `go test ./internal/docgen -run 'TestAddGoCommentsFilteredSkipsHiddenDirs|TestCitySchema|TestPackSchema|TestAddGoComments' -count=1`
- [x] `make test`
- [x] `go vet ./...`
- [x] `go build ./cmd/gc`
- [x] Release gate: [`release-gates/ga-5emkl7-docgen-hidden-dirs-gate.md`](release-gates/ga-5emkl7-docgen-hidden-dirs-gate.md)
