### PR TITLE
feat(config): make args patchable via [[rigs.patches]] and [[patches.agent]] (ga-qfr6ri)

### DIFF
--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -2065,6 +2065,7 @@ export interface components {
         };
         AgentPatch: {
             AppendFragments: string[] | null;
+            Args: string[] | null;
             Attach: boolean | null;
             DefaultSlingFormula: string | null;
             DependsOn: string[] | null;

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -59,6 +59,7 @@ export type AgentOutputResponse = {
 
 export type AgentPatch = {
     AppendFragments: Array<string> | null;
+    Args: Array<string> | null;
     Attach: boolean | null;
     DefaultSlingFormula: string | null;
     DependsOn: Array<string> | null;
@@ -11378,6 +11379,10 @@ export type GetV0CityByCityNameStatusData = {
          * How long to block waiting for changes (Go duration string, e.g. 30s). Default 30s, max 2m.
          */
         wait?: string;
+        /**
+         * When true, omit the expensive store-health, session-count, and work-count blocks for low-cost dashboard polls.
+         */
+        lite?: boolean;
     };
     url: '/v0/city/{cityName}/status';
 };

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -156,6 +156,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `session` | string |  |  | Session overrides the session transport ("acp"). |
 | `provider` | string |  |  | Provider overrides the provider name. |
+| `args` | []string |  |  | Args overrides the provider's default arguments. Leave unset to keep the pack-defined args; set to an empty list to clear them; set to a populated list to replace them entirely (full replace, not append). |
 | `start_command` | string |  |  | StartCommand overrides the start command. |
 | `lifecycle` | string |  |  | Lifecycle overrides the runtime lifecycle ("one_shot" or empty). Enum: `one_shot` |
 | `nudge` | string |  |  | Nudge overrides the nudge text. |
@@ -211,6 +212,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `session` | string |  |  | Session overrides the session transport ("acp" or "tmux"). |
 | `provider` | string |  |  | Provider overrides the provider name. |
+| `args` | []string |  |  | Args overrides the provider's default arguments. Leave unset to keep the pack-defined args; set to an empty list to clear them; set to a populated list to replace them entirely (full replace, not append). |
 | `start_command` | string |  |  | StartCommand overrides the start command. |
 | `lifecycle` | string |  |  | Lifecycle overrides the runtime lifecycle ("one_shot" or empty). Enum: `one_shot` |
 | `nudge` | string |  |  | Nudge overrides the nudge text. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -460,6 +460,13 @@
           "type": "string",
           "description": "Provider overrides the provider name."
         },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider's default arguments. Leave unset to keep\nthe pack-defined args; set to an empty list to clear them; set to a\npopulated list to replace them entirely (full replace, not append)."
+        },
         "start_command": {
           "type": "string",
           "description": "StartCommand overrides the start command."
@@ -729,6 +736,13 @@
         "provider": {
           "type": "string",
           "description": "Provider overrides the provider name."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider's default arguments. Leave unset to keep\nthe pack-defined args; set to an empty list to clear them; set to a\npopulated list to replace them entirely (full replace, not append)."
         },
         "start_command": {
           "type": "string",

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -460,6 +460,13 @@
           "type": "string",
           "description": "Provider overrides the provider name."
         },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider's default arguments. Leave unset to keep\nthe pack-defined args; set to an empty list to clear them; set to a\npopulated list to replace them entirely (full replace, not append)."
+        },
         "start_command": {
           "type": "string",
           "description": "StartCommand overrides the start command."
@@ -729,6 +736,13 @@
         "provider": {
           "type": "string",
           "description": "Provider overrides the provider name."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider's default arguments. Leave unset to keep\nthe pack-defined args; set to an empty list to clear them; set to a\npopulated list to replace them entirely (full replace, not append)."
         },
         "start_command": {
           "type": "string",

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -159,6 +159,15 @@
               "null"
             ]
           },
+          "Args": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "Attach": {
             "type": [
               "boolean",
@@ -497,6 +506,7 @@
           "PromptTemplate",
           "Session",
           "Provider",
+          "Args",
           "StartCommand",
           "Lifecycle",
           "Nudge",

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -159,6 +159,15 @@
               "null"
             ]
           },
+          "Args": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "Attach": {
             "type": [
               "boolean",
@@ -497,6 +506,7 @@
           "PromptTemplate",
           "Session",
           "Provider",
+          "Args",
           "StartCommand",
           "Lifecycle",
           "Nudge",

--- a/docs/schema/pack-schema.json
+++ b/docs/schema/pack-schema.json
@@ -419,6 +419,13 @@
           "type": "string",
           "description": "Provider overrides the provider name."
         },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider's default arguments. Leave unset to keep\nthe pack-defined args; set to an empty list to clear them; set to a\npopulated list to replace them entirely (full replace, not append)."
+        },
         "start_command": {
           "type": "string",
           "description": "StartCommand overrides the start command."

--- a/docs/schema/pack-schema.txt
+++ b/docs/schema/pack-schema.txt
@@ -419,6 +419,13 @@
           "type": "string",
           "description": "Provider overrides the provider name."
         },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider's default arguments. Leave unset to keep\nthe pack-defined args; set to an empty list to clear them; set to a\npopulated list to replace them entirely (full replace, not append)."
+        },
         "start_command": {
           "type": "string",
           "description": "StartCommand overrides the start command."

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -390,6 +390,7 @@ type AgentOutputResponse struct {
 // AgentPatch defines model for AgentPatch.
 type AgentPatch struct {
 	AppendFragments         *[]string         `json:"AppendFragments"`
+	Args                    *[]string         `json:"Args"`
 	Attach                  *bool             `json:"Attach"`
 	DefaultSlingFormula     *string           `json:"DefaultSlingFormula"`
 	DependsOn               *[]string         `json:"DependsOn"`

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -159,6 +159,15 @@
               "null"
             ]
           },
+          "Args": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "Attach": {
             "type": [
               "boolean",
@@ -497,6 +506,7 @@
           "PromptTemplate",
           "Session",
           "Provider",
+          "Args",
           "StartCommand",
           "Lifecycle",
           "Nudge",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -601,6 +601,10 @@ type AgentOverride struct {
 	Session *string `toml:"session,omitempty"`
 	// Provider overrides the provider name.
 	Provider *string `toml:"provider,omitempty"`
+	// Args overrides the provider's default arguments. Leave unset to keep
+	// the pack-defined args; set to an empty list to clear them; set to a
+	// populated list to replace them entirely (full replace, not append).
+	Args *[]string `toml:"args,omitempty"`
 	// StartCommand overrides the start command.
 	StartCommand *string `toml:"start_command,omitempty"`
 	// Lifecycle overrides the runtime lifecycle ("one_shot" or empty).

--- a/internal/config/field_sync_test.go
+++ b/internal/config/field_sync_test.go
@@ -23,7 +23,6 @@ func TestAgentFieldSync(t *testing.T) {
 		// Provider-level fields: set during ResolveProvider, not typically
 		// overridden per-rig. Agent-level overrides happen in the Agent
 		// struct itself (which feeds into ResolveProvider).
-		"Args":                         "provider field, set via ResolveProvider",
 		"PromptMode":                   "provider field, set via ResolveProvider",
 		"PromptFlag":                   "provider field, set via ResolveProvider",
 		"ReadyDelayMs":                 "provider field, set via ResolveProvider",
@@ -180,6 +179,7 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 		PromptTemplate:          strVal("prompts/test.md"),
 		Session:                 strVal("acp"),
 		Provider:                strVal("claude"),
+		Args:                    Fragments("--custom-arg"),
 		StartCommand:            strVal("claude --dangerously"),
 		Lifecycle:               strVal(AgentLifecycleOneShot),
 		Nudge:                   strVal("wake up"),
@@ -333,6 +333,7 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 		PromptTemplate:          strVal("prompts/test.md"),
 		Session:                 strVal("acp"),
 		Provider:                strVal("claude"),
+		Args:                    Fragments("--custom-arg"),
 		StartCommand:            strVal("claude --dangerously"),
 		Lifecycle:               strVal(AgentLifecycleOneShot),
 		Nudge:                   strVal("wake up"),

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -2637,6 +2637,9 @@ func applyAgentOverride(a *Agent, ov *AgentOverride) {
 	if ov.Provider != nil {
 		a.Provider = *ov.Provider
 	}
+	if ov.Args != nil {
+		a.Args = append([]string(nil), (*ov.Args)...)
+	}
 	if ov.StartCommand != nil {
 		a.StartCommand = *ov.StartCommand
 	}

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -51,6 +51,10 @@ type AgentPatch struct {
 	Session *string `toml:"session,omitempty"`
 	// Provider overrides the provider name.
 	Provider *string `toml:"provider,omitempty"`
+	// Args overrides the provider's default arguments. Leave unset to keep
+	// the pack-defined args; set to an empty list to clear them; set to a
+	// populated list to replace them entirely (full replace, not append).
+	Args *[]string `toml:"args,omitempty"`
 	// StartCommand overrides the start command.
 	StartCommand *string `toml:"start_command,omitempty"`
 	// Lifecycle overrides the runtime lifecycle ("one_shot" or empty).
@@ -446,6 +450,9 @@ func applyAgentPatchFields(a *Agent, p *AgentPatch) {
 	}
 	if p.Provider != nil {
 		a.Provider = *p.Provider
+	}
+	if p.Args != nil {
+		a.Args = append([]string(nil), (*p.Args)...)
 	}
 	if p.StartCommand != nil {
 		a.StartCommand = *p.StartCommand

--- a/release-gates/ga-qfr6ri-args-patchable-gate.md
+++ b/release-gates/ga-qfr6ri-args-patchable-gate.md
@@ -1,0 +1,88 @@
+# Release Gate: ga-qfr6ri Args Patchability
+
+Evaluated: 2026-06-09T03:00:55Z
+
+Feature branch: `builder/ga-0mhj1r`
+Focused handoff commit: `51a9ad911a30da9fbc5f6b25410d8370090d3115`
+Base: `origin/main` at `ad1dd4e25d0b985733723c31b493c1a04f4803d3`
+PR: https://github.com/gastownhall/gascity/pull/3256
+
+`docs/PROJECT_MANIFEST.md` is absent on both `origin/main` and the focused
+feature commit, so this gate uses the deployer release criteria, the
+repository testing guidance in `TESTING.md`, and the API/dashboard invariants
+from `engdocs/architecture/api-control-plane.md` and
+`engdocs/contributors/huma-usage.md`.
+
+## Scope
+
+This is the rerun gate for the focused args patchability candidate. The prior
+deploy gate failed criterion 7 because PR #3256 bundled an unrelated overlay
+bare-hook lint helper. The focused candidate at `51a9ad911` is one commit over
+current `origin/main`; `git diff --name-only origin/main..51a9ad911` contains
+only config structs/apply logic, field-sync/apply tests, generated API/schema
+artifacts, generated dashboard types, and config docs. It does not include
+`internal/overlay/lint.go` or `internal/overlay/lint_test.go`.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-1xxum0` is closed with `Review Verdict: PASS` for the args patchability feature in PR #3256. The rerun handoff bead `ga-q7y8lr.1` records that the PR branch was focused to `51a9ad911` by removing the unrelated overlay lint helper while preserving the reviewed args patchability package. |
+| 2 | Acceptance criteria met | PASS | Source bead `ga-qfr6ri` acceptance path A is implemented: `AgentOverride.Args` and `AgentPatch.Args` accept `args` in `[[rigs.patches]]` and `[[patches.agent]]`; nil keeps existing args, empty list clears, populated list fully replaces. `applyAgentOverride` and `applyAgentPatchFields` deep-copy the slice. Config docs, schemas, OpenAPI, Go client, and dashboard generated types include the field. |
+| 3 | Tests pass | PASS | Local release checks passed: focused config tests, OpenAPI/client sync tests, schema freshness, `make test-fast-parallel`, `go vet ./...`, `make dashboard-check`, and a local Vite preview smoke. |
+| 4 | No high-severity review findings open | PASS | Review notes list no blockers or HIGH findings. The previous deploy concern was scope contamination, not a technical high-severity finding, and the focused candidate removes the unrelated overlay files. |
+| 5 | Final branch is clean | PASS | Clean deploy worktree before adding this checklist: `git status --short --branch` reported only `## HEAD (no branch)`. Dashboard generation/build left no diff. The gate commit contains this checklist as the only deployer-added file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` produced no conflicts or conflict markers. GitHub reports PR #3256 `mergeable: MERGEABLE`. |
+| 7 | Single feature theme | PASS | The candidate is one commit touching the config patchability path and its required generated/doc artifacts. `internal/overlay/lint.go` and `internal/overlay/lint_test.go` are absent from `origin/main..51a9ad911`, resolving the prior independent-feature failure. |
+
+## Test Evidence
+
+```text
+go test ./internal/config/... -run 'TestAgentFieldSync|TestApplyAgentPatchCoversAllFields|TestApplyAgentOverrideCoversAllFields' -count=1
+ok  	github.com/gastownhall/gascity/internal/config	0.036s
+```
+
+```text
+go test ./internal/api/... -run 'TestOpenAPISpecInSync|TestGeneratedClientInSync' -count=1
+ok  	github.com/gastownhall/gascity/internal/api	0.078s
+ok  	github.com/gastownhall/gascity/internal/api/genclient	5.632s
+```
+
+```text
+go test ./test/docsync -run TestSchemaFreshness -count=1
+ok  	github.com/gastownhall/gascity/test/docsync	1.900s
+```
+
+```text
+make test-fast-parallel
+[unit-core] ok
+[unit-cmd-gc-1-of-6] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-3-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-cmd-gc-6-of-6] ok
+All fast jobs passed
+```
+
+```text
+go vet ./...
+PASS (no output)
+```
+
+```text
+make dashboard-check
+npm run gen: PASS
+npm run build: PASS
+npm run typecheck: PASS
+go test ./cmd/gc/dashboard/...: PASS
+```
+
+```text
+npm run preview -- --host 127.0.0.1 --strictPort --port <ephemeral>
+dashboard preview served /
+```
+
+## Decision
+
+PASS. PR #3256 is ready for merge authority review; deployer must not merge.


### PR DESCRIPTION
## What this changes

`args` is now patchable through both `[[rigs.patches]]` and `[[patches.agent]]`. Operators can leave `args` unset to keep the pack/provider arguments, set `args = []` to clear inherited arguments, or set a populated list to fully replace them.

This gives mixed-provider cities a direct escape hatch for inherited argv that does not apply to the patched provider, without requiring wrapper binaries just to strip incompatible flags.

## Review notes

- `AgentOverride.Args` and `AgentPatch.Args` use pointer-to-slice presence semantics, matching the existing patch/override pattern for distinguishing unset from empty.
- `applyAgentOverride` and `applyAgentPatchFields` deep-copy args into the resolved agent to avoid slice aliasing.
- OpenAPI, generated Go client, generated dashboard TypeScript, JSON schemas, and config reference docs are regenerated.
- The unrelated overlay bare-hook lint helper from the earlier PR shape is not included in this focused candidate.
- No runtime migration is required.

## Test plan

- [x] `go test ./internal/config/... -run 'TestAgentFieldSync|TestApplyAgentPatchCoversAllFields|TestApplyAgentOverrideCoversAllFields' -count=1`
- [x] `go test ./internal/api/... -run 'TestOpenAPISpecInSync|TestGeneratedClientInSync' -count=1`
- [x] `go test ./test/docsync -run TestSchemaFreshness -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `make dashboard-check`
- [x] Local dashboard preview smoke with `npm run preview -- --host 127.0.0.1 --strictPort --port <ephemeral>`
- [x] Release gate: [`release-gates/ga-qfr6ri-args-patchable-gate.md`](release-gates/ga-qfr6ri-args-patchable-gate.md)