### PR TITLE
fix(reconciler): reap idle ephemeral pool seats, claim-state guarded

### DIFF
--- a/cmd/gc/session_reaper_test.go
+++ b/cmd/gc/session_reaper_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// --- claim-state predicate (the load-bearing guard primitive) ---
+
+// TestSessionHasInProgressClaimedWork distinguishes "owns a claimed
+// (in_progress) step" (never reapable) from "owns only open/routed work or
+// nothing" (reapable) — the correctness core of the pool-seat reaper guard.
+func TestSessionHasInProgressClaimedWork(t *testing.T) {
+	mk := func(status string) (beads.Store, string) {
+		store := beads.NewMemStore()
+		assignee := "ga-session-abc"
+		b, err := store.Create(beads.Bead{Title: "step", Type: "task"})
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if err := store.Update(b.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+			t.Fatalf("update: %v", err)
+		}
+		return store, assignee
+	}
+
+	// open routed-but-unclaimed work: NOT in_progress (reapable), but IS open-assigned.
+	store, assignee := mk("open")
+	if has, err := sessionHasInProgressClaimedWorkInStoreByIdentifiers(store, []string{assignee}); err != nil || has {
+		t.Fatalf("open work: in_progress-claimed = %v (err %v), want false", has, err)
+	}
+	if has, err := sessionHasOpenAssignedWorkInStoreByIdentifiers(store, []string{assignee}); err != nil || !has {
+		t.Fatalf("open work: open-assigned = %v (err %v), want true", has, err)
+	}
+
+	// in_progress claimed work: the seat owns a step in flight — never reap.
+	store, assignee = mk("in_progress")
+	if has, err := sessionHasInProgressClaimedWorkInStoreByIdentifiers(store, []string{assignee}); err != nil || !has {
+		t.Fatalf("in_progress work: in_progress-claimed = %v (err %v), want true", has, err)
+	}
+
+	// no work at all: reapable.
+	empty := beads.NewMemStore()
+	if has, err := sessionHasInProgressClaimedWorkInStoreByIdentifiers(empty, []string{"ga-session-zzz"}); err != nil || has {
+		t.Fatalf("no work: in_progress-claimed = %v (err %v), want false", has, err)
+	}
+}
+
+// --- slot-free reason ---
+
+func TestIsPoolSessionSlotFreeable_ReapedCompleted(t *testing.T) {
+	freeable := beads.Bead{Metadata: map[string]string{"state": "asleep", "sleep_reason": "reaped-completed"}}
+	if !isPoolSessionSlotFreeable(freeable) {
+		t.Fatal("sleep_reason=reaped-completed must free the pool slot")
+	}
+	held := beads.Bead{Metadata: map[string]string{"state": "asleep", "sleep_reason": "wait-hold"}}
+	if isPoolSessionSlotFreeable(held) {
+		t.Fatal("sleep_reason=wait-hold must NOT free the slot")
+	}
+}
+
+// --- reconciler triggers ---
+
+// setupEphemeralSeat creates a live, ephemeral pool seat idle past the reap
+// debounce. The caller optionally assigns it in_progress work.
+func setupEphemeralSeat(t *testing.T) (*reconcilerTestEnv, beads.Bead) {
+	t.Helper()
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "arch"}}}
+	env.addDesired("arch", "arch", true) // running in the provider
+	session := env.createSessionBead("arch", "arch")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		poolManagedMetadataKey: boolMetadata(true),
+		"pool_slot":            "1",
+	})
+	// Last activity well past ephemeralReapDebounce → idle.
+	env.sp.SetActivity("arch", env.clk.Now().Add(-5*time.Minute))
+	return env, session
+}
+
+// TestReconcile_EphemeralSeatCompletedStepIsReaped: an ephemeral seat that
+// finished its step (owns no in_progress work) and went idle is reaped
+// (trigger 1: a completed ephemeral seat).
+func TestReconcile_EphemeralSeatCompletedStepIsReaped(t *testing.T) {
+	env, session := setupEphemeralSeat(t)
+
+	env.reconcile([]beads.Bead{session})
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["sleep_reason"] != "reaped-completed" && got.Status != "closed" {
+		t.Fatalf("idle ephemeral seat with no claimed work must be reaped; got status=%q sleep_reason=%q",
+			got.Status, got.Metadata["sleep_reason"])
+	}
+}
+
+// TestReconcile_EphemeralSeatWithInProgressStepNeverReaped is the LOAD-BEARING
+// guard: a seat mid-step (owns an in_progress claimed step) must NEVER be
+// reaped even when its last-activity is stale (e.g. a long model call), per the
+// claim-state predicate (the mid-grade false-positive reap).
+func TestReconcile_EphemeralSeatWithInProgressStepNeverReaped(t *testing.T) {
+	env, session := setupEphemeralSeat(t)
+
+	// The seat owns an in_progress claimed step.
+	work, err := env.store.Create(beads.Bead{Title: "grade step", Type: "task"})
+	if err != nil {
+		t.Fatalf("create work: %v", err)
+	}
+	st, assignee := "in_progress", session.ID
+	if err := env.store.Update(work.ID, beads.UpdateOpts{Status: &st, Assignee: &assignee}); err != nil {
+		t.Fatalf("update work: %v", err)
+	}
+
+	env.reconcile([]beads.Bead{session})
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status == "closed" || got.Metadata["sleep_reason"] == "reaped-completed" {
+		t.Fatalf("seat holding an in_progress step must NOT be reaped; got status=%q sleep_reason=%q",
+			got.Status, got.Metadata["sleep_reason"])
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2149,11 +2149,25 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 		}
 
-		// Idle timeout: restart sessions idle longer than configured threshold.
+		// Idle timeout / pool-seat reap: stop sessions idle longer than the
+		// configured threshold (idle_timeout), and — for ephemeral pool seats —
+		// reap promptly after a short debounce once they own no claimed work.
 		// Pass the agent template so the tracker can fall back to a per-template
 		// timeout for pool sessions whose bead-derived runtime names are not
 		// registered directly.
-		if it != nil && alive && it.checkIdle(name, tp.TemplateName, sp, clk.Now()) {
+		idleKill := it != nil && it.checkIdle(name, tp.TemplateName, sp, clk.Now())
+		// An ephemeral "one step per run" seat that finished
+		// its step but never exited leaks its pool slot. Reap it on a short
+		// debounce. Cheap in-memory idle check here; the claim-state store query
+		// is lazy (below) so we don't add per-tick dolt load (a busy shared dolt store).
+		ephemeralReap := isEphemeralSessionBead(*session) && ephemeralSeatIdlePastReapDebounce(sp, name, clk)
+		if alive && (idleKill || ephemeralReap) {
+			reapReason := "idle-timeout"
+			decisionReason := "idle_timeout"
+			if ephemeralReap && !idleKill {
+				reapReason = "reaped-completed"
+				decisionReason = "reaped_completed"
+			}
 			blocker := lifecycleTimerBlocker(session.Metadata, clk.Now())
 			switch {
 			case blocker != "":
@@ -2176,32 +2190,52 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				}
 				continue
 			default:
-				fmt.Fprintf(stderr, "session reconciler: idle timeout for %s\n", tp.DisplayName()) //nolint:errcheck // best-effort stderr
-				if trace != nil {
-					trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, "idle_timeout", "stop", nil, nil, "")
+				// CLAIM-STATE GUARD (load-bearing):
+				// never reap/idle-kill a seat that owns an in_progress claimed
+				// step — e.g. a critique seat mid-grade whose last-activity has
+				// gone stale during a long model call. Computed lazily (a store
+				// query) only now that a stop is otherwise warranted, to avoid
+				// per-tick dolt load.
+				hasInProgress, ipErr := sessionHasInProgressClaimedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
+				if ipErr != nil {
+					// Fail closed: a transient store blip must not kill a seat
+					// that may hold in-flight work. Mirrors the max-age path.
+					fmt.Fprintf(stderr, "session reconciler: checking claimed work for idle %s: %v\n", name, ipErr) //nolint:errcheck // best-effort stderr
+					hasInProgress = true
 				}
-				if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
-					fmt.Fprintf(stderr, "session reconciler: stopping idle %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
-				} else {
-					_ = sp.ClearScrollback(name)
-					rec.Record(events.Event{
-						Type:    events.SessionIdleKilled,
-						Actor:   "gc",
-						Subject: tp.DisplayName(),
-					})
-					telemetry.RecordAgentIdleKill(context.Background(), tp.DisplayName())
-					// Mark for immediate re-wake on this same tick by clearing
-					// last_woke_at and setting state to asleep. The wake logic
-					// below will pick it up.
-					batch := sessionpkg.SleepPatch(clk.Now(), "idle-timeout")
-					_ = store.SetMetadataBatch(session.ID, batch)
-					if session.Metadata == nil {
-						session.Metadata = make(map[string]string, len(batch))
+				switch {
+				case hasInProgress:
+					if trace != nil {
+						trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, "claimed_work", "deferred_busy", nil, nil, "")
 					}
-					for key, value := range batch {
-						session.Metadata[key] = value
+				default:
+					fmt.Fprintf(stderr, "session reconciler: %s for %s\n", decisionReason, tp.DisplayName()) //nolint:errcheck // best-effort stderr
+					if trace != nil {
+						trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, decisionReason, "stop", nil, nil, "")
 					}
-					alive = false
+					if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
+						fmt.Fprintf(stderr, "session reconciler: stopping idle %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
+					} else {
+						_ = sp.ClearScrollback(name)
+						rec.Record(events.Event{
+							Type:    events.SessionIdleKilled,
+							Actor:   "gc",
+							Subject: tp.DisplayName(),
+						})
+						telemetry.RecordAgentIdleKill(context.Background(), tp.DisplayName())
+						// Mark for immediate re-wake on this same tick by clearing
+						// last_woke_at and setting state to asleep. The wake logic
+						// below will pick it up.
+						batch := sessionpkg.SleepPatch(clk.Now(), reapReason)
+						_ = store.SetMetadataBatch(session.ID, batch)
+						if session.Metadata == nil {
+							session.Metadata = make(map[string]string, len(batch))
+						}
+						for key, value := range batch {
+							session.Metadata[key] = value
+						}
+						alive = false
+					}
 				}
 			}
 			// Fall through to wakeReasons — it will re-wake immediately if config present
@@ -2640,6 +2674,34 @@ func sessionHasOpenAssignedWorkForReachableStore(
 	return sessionHasOpenAssignedWorkInStoreByIdentifiers(rigStore, identifiers)
 }
 
+// sessionHasInProgressClaimedWorkForReachableStore mirrors
+// sessionHasOpenAssignedWorkForReachableStore but checks ONLY in_progress
+// (claimed) work — the pool-seat reaper's "never reap a seat that owns a
+// claimed step" guard. A seat mid-step (e.g. a critique seat in a long model
+// call whose last-activity has gone stale) holds an in_progress step and must
+// never be reaped; a seat with only open/routed work, or nothing, is reapable.
+func sessionHasInProgressClaimedWorkForReachableStore(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	session beads.Bead,
+) (bool, error) {
+	identifiers := sessionAssignmentIdentifiersForConfig(session, cfg)
+	storeRef, ok := assignedWorkStoreRefForSession(cityPath, cfg, session)
+	if !ok {
+		return sessionHasInProgressClaimedWorkInStores(store, rigStores, identifiers)
+	}
+	if storeRef == "" {
+		return sessionHasInProgressClaimedWorkInStoreByIdentifiers(store, identifiers)
+	}
+	rigStore, ok := rigStores[storeRef]
+	if !ok || rigStore == nil {
+		return false, fmt.Errorf("rig store %q unavailable for session %q", storeRef, session.Metadata["session_name"])
+	}
+	return sessionHasInProgressClaimedWorkInStoreByIdentifiers(rigStore, identifiers)
+}
+
 // sessionHasAwakeAssignedWorkForReachableStore reports whether assigned work
 // should keep a session awake: in-progress work always counts, while open work
 // counts only when it is ready: unblocked, not deferred, and not ready-excluded.
@@ -2997,6 +3059,48 @@ func sessionHasAwakeAssignedWorkInStores(store beads.Store, rigStores map[string
 		}
 	}
 	return false, nil
+}
+
+// sessionHasInProgressClaimedWorkInStoreByIdentifiers reports whether the
+// session OWNS a claimed (in_progress) work bead — the in_progress-only variant
+// of the assigned-work check, built on the shared status-filtered leaf.
+func sessionHasInProgressClaimedWorkInStoreByIdentifiers(store beads.Store, identifiers []string) (bool, error) {
+	return sessionHasAssignedWorkInStoreByIdentifiersForStatuses(store, identifiers, []string{"in_progress"})
+}
+
+func sessionHasInProgressClaimedWorkInStores(store beads.Store, rigStores map[string]beads.Store, identifiers []string) (bool, error) {
+	if has, err := sessionHasInProgressClaimedWorkInStoreByIdentifiers(store, identifiers); err != nil || has {
+		return has, err
+	}
+	for _, rs := range rigStores {
+		if has, err := sessionHasInProgressClaimedWorkInStoreByIdentifiers(rs, identifiers); err != nil || has {
+			return has, err
+		}
+	}
+	return false, nil
+}
+
+// ephemeralReapDebounce is the short idle window after which an ephemeral pool
+// seat that owns no claimed (in_progress) work is reaped (the leaked-slot fix:
+// an ephemeral "one step per run" seat that finished its step but never exited,
+// leaking its slot). Distinct from the per-template idle_timeout (hours), which
+// is the slow backstop. Short so a finished seat frees its
+// slot promptly; long enough that a freshly-spawned seat can claim its routed
+// step before this fires.
+const ephemeralReapDebounce = 15 * time.Second
+
+// ephemeralSeatIdlePastReapDebounce reports whether the seat's last observed
+// activity is older than ephemeralReapDebounce. It reads the runtime provider's
+// activity timestamp (no store/dolt round-trip), so it is cheap to evaluate
+// every tick — the load-bearing claim-state check is done lazily only after
+// this gate passes. A zero/unknown timestamp returns false: be conservative and
+// never reap a seat we cannot prove is idle.
+func ephemeralSeatIdlePastReapDebounce(sp runtime.Provider, name string, clk clock.Clock) bool {
+	la, err := workerSessionTargetLastActivityWithConfig("", nil, sp, nil, name)
+	if err != nil || la.IsZero() {
+		return false
+	}
+	return clk.Now().Sub(la) > ephemeralReapDebounce
 }
 
 func sessionHasOpenAssignedWorkInStoreByIdentifiers(store beads.Store, identifiers []string) (bool, error) {

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -43,7 +43,7 @@ func isPoolSessionSlotFreeable(session beads.Bead) bool {
 	}
 	reason := strings.TrimSpace(session.Metadata["sleep_reason"])
 	switch reason {
-	case "idle", "idle-timeout", sleepReasonCityStop, "failed-create", sleepReasonRuntimeMissing:
+	case "idle", "idle-timeout", "reaped-completed", sleepReasonCityStop, "failed-create", sleepReasonRuntimeMissing:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Problem

Ephemeral "one step per run" pool seats (architect/critique floor workers) sometimes finish their routed step but the harness never exits — it stays **alive** and idle, holding its pool slot. With `max_active_sessions`, N such leaked seats wedge the whole pool: routed steps stay ready+unclaimed, 0 in-progress, and no replacement spawns.

**No mechanism in `main` reaps an alive, step-closed, claim-less, idle floor seat promptly.** I traced each:

| Mechanism | Why it doesn't cover this case |
|---|---|
| Idle-timeout kill (`session_reconciler.go`, idle-timeout block) | Opt-in (nil tracker if no `idle_timeout` is set, `cmd_start.go` `buildIdleTracker`); fires at the per-template timeout (typically hours), and **never** if unset. It also has no claim-state guard, so it can reap a seat mid-step when last-activity is stale (cf. #1029). |
| Progress-stall recycler (`recordResetStallIfDue`) | Disabled by default (`ProgressStallTimeoutDuration`=0), 5m floor when enabled, and #3113 **explicitly exempts min-floor idle workers** — exactly these seats. It respawns in place (`restart_requested`); it does not free the slot. |
| Max-session-age | Wall-clock age, typically hours; not idle-driven. |
| Drain-ack / orphan-drain (`finalizeDrainAckStopPendingSessions`) | A min-active floor seat stays *desired*, so it is never orphan-drained; and a one-step-and-park seat never sends `drain-ack`. |
| #3158 zombie/start-collision recycle | Triggers on `running && !alive` (dead process); our seat is alive. |
| #3022 idle-connection reaping | Reaps dolt/bd *connections*, not sessions. |
| reaper.sh (maintenance) | Prunes *closed* session beads / drained sessions; never an alive seat. |

So a finished floor seat sits until the opt-in `idle_timeout` (often 1h) — or **forever** if unset.

## Change

Extend the existing idle-timeout kill block (the single stop path that already flows into the pool-slot close gate) with two triggers, both gated by a claim-state check:

- **Prompt reap:** an ephemeral seat idle past a short debounce (`ephemeralReapDebounce`, 15s) with **no in_progress claimed step** is reaped (`sleep_reason=reaped-completed`), freeing its slot.
- **Backstop:** the existing `idle_timeout` kill now also requires no in_progress claimed step — closing the #1029 mid-step-reap hazard.

The reap query is computed lazily (only once a stop is otherwise warranted), so it adds no per-tick store load.

## Why it is safe and non-overlapping

- **Claim-state guard:** a seat mid-step (e.g. a critique seat in a long model call whose last-activity has gone stale) owns an in_progress step and is never reaped.
- **Complementary to the progress-stall recycler, not overlapping:** that respawns parked sessions in place (default-off, 5m+, min-floor-*exempt*); this frees finished floor seats (default-on, 15s, min-floor-*targeted*). Opposite intents on different states.
- Disjoint from #3158 (dead process), #3022 (connections), and reaper.sh (closed beads).

## Implementation notes

- Reuses the canonical `sessionHasAssignedWorkInStoreByIdentifiersForStatuses` leaf. The new `sessionHasInProgressClaimedWorkForReachableStore` is the in_progress, single-reachable-store sibling of the existing `sessionHasOpenAssignedWorkForReachableStore` the max-age block uses — deliberately distinct from the cross-store `sessionHasInProgressAssignedWorkForConfig` the progress-stall path uses.
- `isPoolSessionSlotFreeable` gains `reaped-completed` as a freeable reason.

## Tests

- Claim-state predicate: open vs in_progress.
- `reaped-completed` is slot-freeable.
- Reconciler: a completed ephemeral seat is reaped; **a seat holding an in_progress step is never reaped** even with a stale last-activity (the load-bearing guard).

`go build ./cmd/gc`, `go vet ./cmd/gc`, and the reconciler suite pass.

## Note

`ephemeralReapDebounce` is a 15s constant. The comparable knobs (`idle_timeout`, `progress_stall_timeout`) are config-driven — happy to lift this to a `[session]` config key with a 15s default if you'd prefer.

Refs #2460, #1029.
