### PR TITLE
fix(reconciler): drop racy poke-failure stderr write in drain-ack async stop goroutine

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -219,9 +219,12 @@ func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provi
 		// closes it on a subsequent tick. Poke the controller so finalize +
 		// pool respawn runs on the next event-driven tick instead of waiting up
 		// to a full patrol interval (ga-ryhnhd). Mirrors the drain-ack CLI poke.
-		if perr := drainAckAsyncStopPokeController(cityPath); perr != nil {
-			fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s: poke failed: %v\n", name, perr) //nolint:errcheck
-		}
+		// Poke is best-effort: a failure is not logged because the goroutine may
+		// outlive its reconcile invocation and write to stderr concurrently with
+		// the caller's subsequent writes on the same writer (data race on
+		// non-goroutine-safe buffers). The controller reconciles on the next
+		// patrol tick regardless.
+		_ = drainAckAsyncStopPokeController(cityPath)
 	}()
 }
 

--- a/release-gates/ga-foi9wc-gate.md
+++ b/release-gates/ga-foi9wc-gate.md
@@ -1,0 +1,59 @@
+# Release Gate: ga-foi9wc
+
+Evaluated: 2026-06-09T02:52:30Z
+
+Feature branch: `builder/ga-g7oo57`
+Reviewed commit: `0536d7d6f0a408efda5ed9fde240b7bdfec4bf70`
+Base: `origin/main` at `ad1dd4e25d0b985733723c31b493c1a04f4803d3`
+PR: https://github.com/gastownhall/gascity/pull/3261
+
+`docs/PROJECT_MANIFEST.md` is absent on both `origin/main` and the reviewed
+feature commit, so this gate uses the deployer release criteria and the
+repository testing guidance in `TESTING.md`.
+
+## Scope
+
+This is a single-bead release for a focused reconciler race fix. The commit
+changes only `cmd/gc/session_reconciler.go`, replacing a goroutine stderr write
+on best-effort controller poke failure with an intentional ignored result. The
+controller still reconciles on the next patrol tick if the poke misses.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-adhaks` is closed with `Review verdict: PASS` for PR #3261, branch `builder/ga-g7oo57`, commit `0536d7d6f`. |
+| 2 | Acceptance criteria met | PASS | Source bead `ga-g7oo57` required the drain-ack live-store error reproducer to stop failing under `-race`. `go test ./cmd/gc/ -run '^TestReconcileSessionBeads_DrainAckLiveStoreErrorFailsClosed$' -race -count=5` passed locally. Diff removes the racy goroutine `fmt.Fprintf(stderr, ...)` on poke failure while preserving best-effort poke semantics. |
+| 3 | Tests pass | PASS | Local release checks passed: targeted race reproducer, `make test-fast-parallel` (`All fast jobs passed`), and `go vet ./...`. |
+| 4 | No high-severity review findings open | PASS | Review notes list no blockers and no HIGH findings. The only finding is INFO/pre-existing for panic-recovery stderr output, explicitly out of scope. |
+| 5 | Final branch is clean | PASS | Clean deploy worktree before adding this checklist: `git status --short --branch` reported only `## HEAD (no branch)`. The gate commit contains this checklist as the only deployer-added file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main 0536d7d6f) origin/main 0536d7d6f` reported a clean merge, and GitHub reports PR #3261 `mergeable: MERGEABLE`. |
+| 7 | Single feature theme | PASS | Commit set is one commit touching one reconciler file; it is a single cmd/gc session reconciler race fix with no independent feature themes. |
+
+## Test Evidence
+
+```text
+go test ./cmd/gc/ -run '^TestReconcileSessionBeads_DrainAckLiveStoreErrorFailsClosed$' -race -count=5
+ok  	github.com/gastownhall/gascity/cmd/gc	1.346s
+```
+
+```text
+make test-fast-parallel
+[unit-core] ok
+[unit-cmd-gc-3-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-6-of-6] ok
+[unit-cmd-gc-1-of-6] ok
+All fast jobs passed
+```
+
+```text
+go vet ./...
+PASS (no output)
+```
+
+## Decision
+
+PASS. Open/reroute PR #3261 for merge authority review; deployer must not merge.


### PR DESCRIPTION
## What this changes

`queueDrainAckAsyncStop` no longer writes controller-poke failures to stderr from its background goroutine after an async drain-ack stop. The poke remains best-effort: if it fails, the controller still finalizes and respawns pools on the next patrol tick.

This removes a data race against caller-provided stderr writers such as `bytes.Buffer` during reconciler tests. The removed output was not part of a user-facing contract, and no test asserts on poke-failure stderr.

## Review notes

- Review `cmd/gc/session_reconciler.go` around `queueDrainAckAsyncStop`; the intentional `_ = drainAckAsyncStopPokeController(cityPath)` preserves best-effort poke behavior while dropping non-essential logging from the goroutine.
- No API, config, schema, dashboard, or migration changes.
- The pre-existing panic-recovery stderr write noted by review is not changed here.

## Test plan

- [x] `go test ./cmd/gc/ -run '^TestReconcileSessionBeads_DrainAckLiveStoreErrorFailsClosed$' -race -count=5`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-foi9wc-gate.md`](release-gates/ga-foi9wc-gate.md)