### PR TITLE
fix(compact): downgrade concurrent-writer DELETE to defer instead of quarantine

### DIFF
--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -19,10 +19,10 @@
 #   2. Soft-reset to the root commit; all data stays staged.
 #   3. Commit everything as a single "compaction: flatten history" commit.
 #   4. Re-check post-flatten row counts, table value hashes, and database
-#      value hash. Row-count decreases fail before full GC. Row-count
-#      increases are treated as concurrent-writer evidence and allowed to
-#      continue only when table and database value hashes stay stable. Any
-#      value-hash drift, table-list drift, or row-count decrease is
+#      value hash. Row-count increases are treated as concurrent-writer
+#      evidence and allowed to continue only when table and database value
+#      hashes stay stable. Same-count table hash drift, table-list drift,
+#      or row-count decrease without a proven concurrent writer is
 #      quarantined before full GC.
 #   4a. Local-verify HEAD-stability gate. The pre-flight stability loop cannot
 #      close the residual window between its final HEAD check and the flatten,
@@ -32,15 +32,16 @@
 #      otherwise looks identical to the ambiguous gain+drift corruption signal.
 #      Quarantining that false positive blocks all future GC of the db and
 #      starves DOLT_GC until host memory is exhausted. So, mirroring the remote-
-#      push path's HEAD-stability defer, the gain+drift case is downgraded from
-#      a blocking quarantine to a skip-and-retry-next-run ONLY when a concurrent
-#      writer is proven. A writer is proven (and distinguished from the flatten's
-#      OWN commit) when either HEAD captured immediately before the mutating
-#      reset differs from the stable pre-flight HEAD (a writer landed in the
-#      preflight->reset window, before the flatten committed), or HEAD captured
-#      after verify moved past the flatten's own commit (a writer landed during/
-#      after verify). All other failures — and gain+drift with a stable HEAD —
-#      still quarantine. Probe failure leaves the race unproven and quarantines.
+#      push path's HEAD-stability defer, gain+drift and row-count-decrease
+#      cases are downgraded from a blocking quarantine to a skip-and-retry-
+#      next-run ONLY when a concurrent writer is proven. A writer is proven
+#      (and distinguished from the flatten's OWN commit) when either HEAD
+#      captured immediately before the mutating reset differs from the stable
+#      pre-flight HEAD (a writer landed in the preflight->reset window, before
+#      the flatten committed), or HEAD captured after verify moved past the
+#      flatten's own commit (a writer landed during/after verify). All other
+#      failures — and gain+drift or row-decrease with a stable HEAD — still
+#      quarantine. Probe failure leaves the race unproven and quarantines.
 #   5. Run CALL DOLT_GC('--full') to reclaim chunks orphaned by the flatten.
 #
 # Remote push failures are recorded in compact-pending-push markers and do not
@@ -790,6 +791,7 @@ verify_counts() {
   verify_counts_saw_gain_hash_drift=0
   verify_counts_gain_drift_tables=""
   verify_counts_saw_row_decrease=0
+  verify_counts_saw_decrease_hash_drift=0
   verify_counts_saw_same_count_hash_drift=0
   verify_counts_saw_table_list_change=0
   verify_counts_saw_probe_failure=0
@@ -846,11 +848,13 @@ verify_counts() {
       continue
     fi
     table_gained_rows=0
+    table_had_row_decrease=0
     if [ "$actual" != "$expected" ]; then
       if [ "$actual" -lt "$expected" ]; then
         printf 'compact: db=%s row count decreased after flatten table=%s before=%s after=%s\n' \
           "$db" "$t" "$expected" "$actual" >&2
         verify_counts_saw_row_decrease=1
+        table_had_row_decrease=1
         if [ "$fail" -ne 1 ]; then
           fail=1
           verify_counts_failure_reason="post-flatten row count decreased"
@@ -874,6 +878,10 @@ verify_counts() {
           verify_counts_failure_reason="post-flatten table value hash changed with row-count increase"
           verify_counts_failure_guidance="row-count increase plus table value hash drift cannot prove row preservation; investigate before re-running"
         fi
+      elif [ "$table_had_row_decrease" = "1" ]; then
+        verify_counts_saw_decrease_hash_drift=1
+        printf 'compact: db=%s table=%s value hash changed with row-count decrease before=%s after=%s\n' \
+          "$db" "$t" "$expected_hash" "$actual_hash" >&2
       else
         printf 'compact: db=%s table=%s value hash changed after flatten without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
@@ -1469,6 +1477,7 @@ flatten_database() {
   verify_counts_saw_gain_hash_drift=0
   verify_counts_gain_drift_tables=""
   verify_counts_saw_row_decrease=0
+  verify_counts_saw_decrease_hash_drift=0
   verify_counts_saw_same_count_hash_drift=0
   verify_counts_saw_table_list_change=0
   verify_counts_saw_probe_failure=0
@@ -1961,8 +1970,31 @@ flatten_database() {
       rm -f "$preflight_tmp"
       return 0
     fi
+    # Downgrade quarantine -> defer for concurrent-writer DELETE. A concurrent
+    # DELETE during the flatten window legitimately reduces row counts and shifts
+    # table value hashes. Safe to defer when a concurrent writer is proven and no
+    # other anomaly (unexplained same-count hash drift, table-list change, probe
+    # failure, or gain+drift) prevents safe deferral.
     if [ "$writer_race_detected" = "1" ] && \
-       [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ]; then
+       [ "${verify_counts_saw_row_decrease:-0}" = "1" ] && \
+       [ "${verify_counts_saw_same_count_hash_drift:-0}" != "1" ] && \
+       [ "${verify_counts_saw_gain_hash_drift:-0}" != "1" ] && \
+       [ "${verify_counts_saw_table_list_change:-0}" != "1" ] && \
+       [ "${verify_counts_saw_probe_failure:-0}" != "1" ]; then
+      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — row-count decrease is concurrent-writer DELETE, not corruption; deferring, will retry next run\n' \
+        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
+      if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+        "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+        "$compacted_from_head" "$local_branch" "$remote_branch"; then
+        rm -f "$preflight_tmp"
+        return 1
+      fi
+      rm -f "$preflight_tmp"
+      return 0
+    fi
+    if [ "$writer_race_detected" = "1" ] && \
+       { [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] || \
+         [ "${verify_counts_saw_row_decrease:-0}" = "1" ]; }; then
       printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s), but additional integrity failure category prevents defer; quarantine unchanged\n' \
         "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
     fi

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -169,6 +169,8 @@ func (f compactScriptFixture) run(t *testing.T, mode string, extraEnv ...string)
 		"GC_FAKE_DOLT_COUNT_FILE",
 		"GC_FAKE_DOLT_STATE_FILE",
 		"GC_FAKE_DOLT_HASH_STATE_FILE",
+		"GC_PACK_STATE_DIR",
+		"GC_CITY_RUNTIME_DIR",
 	),
 		"PATH="+f.binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+f.cityPath,
@@ -593,7 +595,7 @@ case "$query" in
     # probe, which reports writercommit so HEAD has moved past the flatten's own
     # commit. verify_counts still sees compactcommit (gain+drift) because it does
     # not probe HEAD and the "$(current_head)" gates read the real state.
-    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       calls_file="$state_file.postverify-head-calls"
       calls=0
       if [ -f "$calls_file" ]; then
@@ -651,7 +653,7 @@ case "$query" in
       print_cell ""
       exit 0
     fi
-    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "remote_writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "remote_writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "row_count_decreases_with_hash_change" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-beads-after-writer
       exit 0
     fi
@@ -745,7 +747,7 @@ case "$query" in
     fi
     if { [ "$mode" = "row_count_gain_with_stable_hashes" ] || [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "remote_writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ]; } && [ "$calls" -gt 1 ]; then
       print_cell 11
-    elif [ "$mode" = "row_count_decreases" ] && [ "$calls" -gt 1 ]; then
+    elif { [ "$mode" = "row_count_decreases" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "row_count_decreases_with_hash_change" ]; } && [ "$calls" -gt 1 ]; then
       print_cell 9
     else
       print_cell 10
@@ -4056,5 +4058,68 @@ exit 1
 	}
 	if strings.Contains(out, "server unreachable on port 3307 (escalated)") {
 		t.Fatalf("doctor claimed escalation success after mail failure, output:\n%s", out)
+	}
+}
+
+// A concurrent DELETE proven via HEAD movement produces a row-count decrease
+// plus table-value-hash change. The new verify_counts_saw_decrease_hash_drift
+// flag ensures these are NOT classified as same-count hash drift, so the
+// writer-race defer path fires: exit 0, no quarantine, pending-GC marker written.
+func TestCompactScriptDefersWhenWriterDeletesRows(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "row_count_decreases_with_writer_race", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("concurrent-DELETE defer must exit 0 (skip, not failure): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "row-count decrease is concurrent-writer DELETE, not corruption") {
+		t.Fatalf("output missing concurrent-DELETE defer message:\n%s", out)
+	}
+	if !strings.Contains(out, "deferring, will retry next run") {
+		t.Fatalf("output missing defer confirmation:\n%s", out)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(quarantine); !os.IsNotExist(statErr) {
+		t.Fatalf("concurrent-DELETE defer must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if reason := compactMarkerValue(t, pendingGC, "reason"); reason != "writer race during flatten deferred full GC" {
+		t.Fatalf("concurrent-DELETE defer should record pending-GC retry marker, got reason %q", reason)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("concurrent-DELETE defer must skip GC this run:\n%s", string(data))
+	}
+}
+
+// Control: a row-count decrease with a STABLE HEAD (no proven concurrent writer)
+// must still quarantine. This guards the defer gate so it cannot fire on
+// unexplained data loss.
+func TestCompactScriptStillQuarantinesRowDecreaseWithStableHead(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	// row_count_decreases_with_hash_change: count drops + hash changes, HEAD stays
+	// at compactcommit (no writer proven) — should quarantine, not defer.
+	out, err := fixture.run(t, "row_count_decreases_with_hash_change", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stable-HEAD row-decrease must remain a blocking failure:\n%s", out)
+	}
+	if strings.Contains(out, "writer race detected") {
+		t.Fatalf("stable HEAD must not be misclassified as a writer race:\n%s", out)
+	}
+	if !strings.Contains(out, "post-flatten INTEGRITY check failed") {
+		t.Fatalf("stable-HEAD row-decrease should escalate as an integrity failure:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("stable-HEAD row-decrease must write quarantine marker: %v", err)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("stable-HEAD row-decrease must block full GC:\n%s", string(data))
 	}
 }

--- a/release-gates/ga-mb7y1f-compact-concurrent-delete-gate.md
+++ b/release-gates/ga-mb7y1f-compact-concurrent-delete-gate.md
@@ -1,0 +1,49 @@
+# Release Gate: compact concurrent DELETE downgrade
+
+Bead: `ga-mb7y1f`
+Source bead: `ga-czj02f`
+Review bead: `ga-1rbe9r`
+PR: https://github.com/gastownhall/gascity/pull/3262
+Head under test: `1617ed0335f6a9018a65c9572513851e11ae283a`
+Base: `origin/main` at `890b31c8c916538ad313d2616301fd2530aa675f`
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate
+uses the deployer release criteria supplied in the agent instructions.
+
+## Summary
+
+PASS. The change is limited to the Dolt compact script and its compact-script
+tests. It fixes the concurrent-writer DELETE false-positive quarantine by
+separating row-decrease hash drift from same-count hash drift, and downgrades
+only the proven writer-race row-decrease-only case to skip-and-retry.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-1rbe9r` records `REVIEWER VERDICT: PASS (pending arch-hold clearance)` for commit `1617ed033` on branch `builder/ga-czj02f`. |
+| 2 | Acceptance criteria met | PASS | `examples/dolt/commands/compact/run.sh` adds `verify_counts_saw_decrease_hash_drift` and leaves same-count drift separate (`run.sh:794`, `run.sh:881`, `run.sh:888`). The row-decrease-only writer-race downgrade calls `defer_writer_race_after_flatten` while excluding same-count drift, table-list changes, and probe failures (`run.sh:1932`, `run.sh:1937`, `run.sh:1958`, `run.sh:1964`). Coverage added for both the positive writer-race defer and stable-HEAD quarantine negative control (`dog_exec_scripts_test.go:4068`, `dog_exec_scripts_test.go:4100`). |
+| 3 | Tests pass | PASS | `go test ./examples/dolt/... -run TestCompactScript` passed: `ok github.com/gastownhall/gascity/examples/dolt 45.658s`. `make test-fast-parallel` passed: all fast jobs passed. `go vet ./...` passed. `gh pr checks 3262` reports required CI pass, including `CI / preflight`, `CI / integration`, `CI / required`, CodeQL, and integration shards. |
+| 4 | No high-severity review findings open | PASS | Review bead `ga-1rbe9r` lists no unresolved HIGH findings and closes with PASS. `gh pr view 3262 --json reviews,comments` returned no GitHub review threads or comments. |
+| 5 | Final branch is clean | PASS | Gate worktree was clean before this checklist was added: `git status --short --branch` returned only `## HEAD (no branch)`. Final clean state is rechecked after committing the gate file before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `260260b638bc4e3ef59a33df7639174a094ca7d1`. GitHub reports `mergeStateStatus: CLEAN`. |
+| 7 | Single feature theme | PASS | Commit set touches only `examples/dolt/commands/compact/run.sh` and `examples/dolt/dog_exec_scripts_test.go`. Both commits implement and test the same Dolt compact row-decrease writer-race behavior. |
+
+## PR And Hold State
+
+- PR head: `builder/ga-czj02f` at `1617ed0335f6a9018a65c9572513851e11ae283a`.
+- PR state: open, not draft, merge state `CLEAN`.
+- PR labels at gate time: `kind/bug`, `priority/p1`, `status/reviewing`.
+- Arch-hold: the review bead records that an arch-hold existed during review.
+  At deploy gate time, GitHub reports clean merge state and no hold label is
+  present. Merge authority remains mayor/mpr; deployer does not merge.
+
+## Local Commands
+
+```text
+go test ./examples/dolt/... -run TestCompactScript
+make test-fast-parallel
+go vet ./...
+git merge-tree --write-tree origin/main HEAD
+gh pr checks 3262
+```


### PR DESCRIPTION
## What this changes

`gc dolt compact` no longer hard-quarantines a database when the post-flatten verification sees a row-count decrease that is explained by a concurrent writer DELETE. When HEAD movement proves a writer race and the only anomaly is the row decrease, compaction now records the pending-GC marker and defers the actual GC to a later run instead of blocking future compaction.

The existing safety behavior remains in place for unexplained drift: stable-HEAD row decreases, same-count hash drift, table-list changes, probe failures, and mixed anomaly cases still quarantine.

## Review notes

- Main behavior change is in `examples/dolt/commands/compact/run.sh`: row-decrease hash drift is tracked separately from same-count hash drift so the defer path can distinguish expected concurrent DELETEs from corruption signals.
- Regression coverage is in `examples/dolt/dog_exec_scripts_test.go`, including a positive concurrent-writer DELETE defer case and a stable-HEAD negative control that still quarantines.
- No config, API, schema, dashboard, or migration surface changes.

## Test plan

- [x] `go test ./examples/dolt/... -run TestCompactScript`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] GitHub required CI on PR #3262
- [x] Release gate: [`release-gates/ga-mb7y1f-compact-concurrent-delete-gate.md`](release-gates/ga-mb7y1f-compact-concurrent-delete-gate.md)