### PR TITLE
fix(order-dispatch): guard orderDispatchTrackingIndex against concurrent gate goroutines

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -288,6 +288,14 @@ type memoryOrderDispatcher struct {
 }
 
 type orderDispatchTrackingIndex struct {
+	// mu guards entries and errs. dispatch shares ONE index across every
+	// order's open-work gate, and gateOpenWorkBounded runs each gate in a
+	// goroutine it abandons on timeout/ctx-cancel (#2893) — so multiple gate
+	// goroutines touch these maps concurrently. The lock is held only around
+	// the map reads/writes below, never across the listCanonical* bd calls, so
+	// one slow or contended store read cannot stall sibling gates (the property
+	// gateOpenWorkBounded exists to preserve).
+	mu      sync.Mutex
 	entries map[string]map[string]orderTrackingSummary
 	errs    map[string]error
 }
@@ -829,16 +837,22 @@ func (idx *orderDispatchTrackingIndex) lastRunForStore(store beads.Store, storeK
 
 func (idx *orderDispatchTrackingIndex) historyEntriesForStore(store beads.Store, storeKey string) (map[string]orderTrackingSummary, error) {
 	key := storeKey + "\x00history"
+	idx.mu.Lock()
 	if err, ok := idx.errs[key]; ok {
+		idx.mu.Unlock()
 		return nil, err
 	}
 	if entries, ok := idx.entries[key]; ok {
+		idx.mu.Unlock()
 		return entries, nil
 	}
+	idx.mu.Unlock()
 	items, err := listCanonicalRecentOrderTrackingHistoryBeads(store)
 	if err != nil {
 		wrapped := fmt.Errorf("listing order-tracking history: %w", err)
+		idx.mu.Lock()
 		idx.errs[key] = wrapped
+		idx.mu.Unlock()
 		return nil, wrapped
 	}
 	entries := make(map[string]orderTrackingSummary)
@@ -853,21 +867,31 @@ func (idx *orderDispatchTrackingIndex) historyEntriesForStore(store beads.Store,
 		}
 		entries[scopedName] = summary
 	}
+	// A sibling gate goroutine may have populated this key while we listed;
+	// both computed the same result from the same store, so last writer wins.
+	idx.mu.Lock()
 	idx.entries[key] = entries
+	idx.mu.Unlock()
 	return entries, nil
 }
 
 func (idx *orderDispatchTrackingIndex) entriesForStore(store beads.Store, storeKey string) (map[string]orderTrackingSummary, error) {
+	idx.mu.Lock()
 	if err, ok := idx.errs[storeKey]; ok {
+		idx.mu.Unlock()
 		return nil, err
 	}
 	if entries, ok := idx.entries[storeKey]; ok {
+		idx.mu.Unlock()
 		return entries, nil
 	}
+	idx.mu.Unlock()
 	items, err := listCanonicalOpenOrderTrackingBeads(store)
 	if err != nil {
 		wrapped := fmt.Errorf("listing order-tracking beads: %w", err)
+		idx.mu.Lock()
 		idx.errs[storeKey] = wrapped
+		idx.mu.Unlock()
 		return nil, wrapped
 	}
 	entries := make(map[string]orderTrackingSummary)
@@ -882,7 +906,11 @@ func (idx *orderDispatchTrackingIndex) entriesForStore(store beads.Store, storeK
 		}
 		entries[scopedName] = summary
 	}
+	// A sibling gate goroutine may have populated this key while we listed;
+	// both computed the same result from the same store, so last writer wins.
+	idx.mu.Lock()
 	idx.entries[storeKey] = entries
+	idx.mu.Unlock()
 	return entries, nil
 }
 

--- a/cmd/gc/order_dispatch_tracking_index_race_test.go
+++ b/cmd/gc/order_dispatch_tracking_index_race_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestOrderDispatchTrackingIndexConcurrentGatesAreRaceFree reproduces the
+// concurrent-map-writes crash that flaked the `cmd/gc process` shard on
+// unrelated PRs (gascity#3256, gascity#3261).
+//
+// memoryOrderDispatcher.dispatch builds ONE shared orderDispatchTrackingIndex
+// (order_dispatch.go: trackingIndex := newOrderDispatchTrackingIndex()) and
+// consults it from every order's open-work gate. gateOpenWorkBounded runs each
+// gate in its own goroutine and, on a per-order timeout OR ctx cancellation,
+// returns WITHOUT waiting for that goroutine (by design, to avoid stalling
+// later orders — #2893). The dispatch loop then spawns the next order's gate
+// goroutine. Those orphaned goroutines call hasOpenTracking / lastRunFunc
+// concurrently, and both write the index's unguarded `entries`/`errs` maps in
+// entriesForStore and historyEntriesForStore -> "fatal error: concurrent map
+// writes". On ctx cancel the loop orphans every remaining gate at once, so the
+// racing writers pile up — in CI a burst of "open-work gate ... aborted:
+// context canceled" immediately precedes the crash.
+//
+// The test hammers a single shared index from many goroutines through the same
+// public entry points the dispatch loop uses (hasOpenTracking + the lastRunFunc
+// closure), with a small key fan-out so reads and writes collide on the same
+// map. Under `-race` the unsynchronized access is reported deterministically;
+// making orderDispatchTrackingIndex guard its maps with a mutex fixes it.
+func TestOrderDispatchTrackingIndexConcurrentGatesAreRaceFree(t *testing.T) {
+	idx := newOrderDispatchTrackingIndex()
+	stores := []beads.Store{beads.NewMemStore()}
+
+	const (
+		goroutines = 64
+		keyFanout  = 8
+		iterations = 16
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	start := make(chan struct{})
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			// A small fan-out of shared store keys: goroutines sharing a key
+			// race their cache writes, and goroutines on other keys read/write
+			// the same backing map concurrently.
+			storeKeys := []string{fmt.Sprintf("store-%d", g%keyFanout)}
+			lastRun := idx.lastRunFunc(stores, storeKeys, nil)
+			<-start // release all goroutines together to maximize overlap
+			for i := 0; i < iterations; i++ {
+				if _, err := idx.hasOpenTracking(stores, storeKeys, "order-x"); err != nil {
+					t.Errorf("hasOpenTracking: %v", err)
+					return
+				}
+				if _, err := lastRun("order-x"); err != nil {
+					t.Errorf("lastRunFunc: %v", err)
+					return
+				}
+			}
+		}(g)
+	}
+	close(start)
+	wg.Wait()
+}

--- a/release-gates/ga-9rc1br-4-order-dispatch-tracking-index-race-gate.md
+++ b/release-gates/ga-9rc1br-4-order-dispatch-tracking-index-race-gate.md
@@ -1,0 +1,58 @@
+# Release Gate: Order-Dispatch Tracking Index Race Fix
+
+Date: 2026-06-09
+Deploy bead: ga-9rc1br.4
+Implementation bead: ga-9rc1br.2
+Test bead: ga-9rc1br.1
+Review bead: ga-9rc1br.3
+GitHub PR: https://github.com/gastownhall/gascity/pull/3263
+Branch: fix/order-dispatch-tracking-index-race
+Reviewed commit: fd24007417b7234101d22406406e48e4287ee7f3
+Base checked: origin/main 9f4ac3e981f6f5d44948a302c03b6302fd5e2e2c
+Merge base: 4e8a6a04cf06ad28c8f6cd2e0edad8917402718b
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the deployer prompt criteria and the deploy bead acceptance checklist.
+
+## Scope
+
+The deploy branch contains one reviewed feature theme: making the order-dispatch tracking index safe when bounded open-work gates continue running concurrently after timeout or context cancellation.
+
+The release diff before this gate artifact contains only:
+
+| Path | Purpose |
+|---|---|
+| `cmd/gc/order_dispatch.go` | Adds a mutex to `orderDispatchTrackingIndex` and keeps lock scope limited to cached map access, not bd list calls. |
+| `cmd/gc/order_dispatch_tracking_index_race_test.go` | Adds a race regression that drives concurrent `hasOpenTracking` and `lastRunFunc` access through one shared index. |
+
+No `internal/molecule/*` paths, formula-hash implementation changes, or prior `ga-9rc1br` formula-hash gate artifacts are included in this release diff.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-9rc1br.3` is closed with close reason `pass`, notes `PASS: reviewer verdict 2026-06-09`, and reviewed commit `fd2400741` on `fix/order-dispatch-tracking-index-race`. |
+| 2 | Acceptance criteria met | PASS | See acceptance evidence below. The branch is the reviewer-passed order-dispatch commit, diff scope is two `cmd/gc` files, and the PR is scoped to the tracking-index concurrency fix. |
+| 3 | Tests pass | PASS | Focused `go test -race` regression passed; `make test-fast-parallel` passed on rerun with short `TMPDIR`; `go vet ./...` passed. GitHub PR #3263 also reports `mergeStateStatus: CLEAN` and green CI rollup for reviewed commit `fd2400741`. |
+| 4 | No high-severity review findings open | PASS | Review bead `ga-9rc1br.3` records `NO blockers`; unresolved HIGH findings count is 0. GitHub PR #3263 has no review comments or PR comments. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` showed `## HEAD (no branch)` with no uncommitted changes before writing this gate artifact. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `8365b0eb685050377778dfd35998ec2538ae7a3b`; GitHub reports PR #3263 `mergeStateStatus: CLEAN`. |
+| 7 | Single feature theme | PASS | The commit set is one commit touching only `cmd/gc/order_dispatch.go` and one targeted race test. All behavior is the order-dispatch tracking-index concurrency fix. |
+
+## Acceptance Evidence
+
+| Deploy bead criterion | Result | Evidence |
+|---|---|---|
+| Gate runs against a reviewer-passed branch/commit for the order-dispatch tracking-index fix. | PASS | Gate ran on `fd2400741`, the exact commit recorded in review bead `ga-9rc1br.3` as PASS. |
+| Final diff excludes `internal/molecule/*` and formula-hash release-gate artifacts from `ga-9rc1br`. | PASS | `git diff --name-status origin/main...HEAD` before the gate showed only `cmd/gc/order_dispatch.go` and `cmd/gc/order_dispatch_tracking_index_race_test.go`. |
+| Standard deploy gate criteria pass, including single feature theme. | PASS | All seven deploy gate criteria above are PASS. |
+| On PASS, opens or updates a PR scoped only to order-dispatch concurrency and routes the merge request to mayor/mpr; no direct merge from an agent session. | PASS | PR #3263 is the existing scoped PR for this branch. This gate commit updates that PR; merge authority remains mayor/mpr and is routed by bead notes/mail after push. |
+| On FAIL, records gate artifact and routes back to PM/reviewer with exact failing criteria. | N/A | Gate result is PASS. |
+
+## Test Evidence
+
+- PASS: `TMPDIR=/home/jaword/tmp/gascity-deploy-ga-9rc1br4-testtmp go test -race $(go list -f '{{range .GoFiles}}{{printf "cmd/gc/%s " .}}{{end}}' ./cmd/gc) cmd/gc/order_dispatch_tracking_index_race_test.go -run TestOrderDispatchTrackingIndexConcurrentGatesAreRaceFree -count=1`
+- PASS: `TMPDIR=/home/jaword/t/g9 LOCAL_TEST_JOBS=12 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel`
+- PASS: `TMPDIR=/home/jaword/t/g9 go vet ./...`
+- Environmental retry note: an initial `make test-fast-parallel` run failed only because `TMPDIR=/home/jaword/tmp/gascity-deploy-ga-9rc1br4-testtmp` made `TestStartVeryLongSocketDirFallsBackToTempDir` generate a subprocess socket path longer than the test's 100-character limit. The same command passed with the shorter temp root `/home/jaword/t/g9`.
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

`gc` order dispatch now protects the shared `orderDispatchTrackingIndex` used by bounded open-work gates. When a gate times out or the dispatcher context is canceled, the gate goroutine can keep running while later gates start; before this change those goroutines could write the same cache maps concurrently and crash with `fatal error: concurrent map writes`.

The fix adds a mutex around the index's cached map reads and writes. The lock is intentionally kept off the bd list calls, so a slow store read still does not stall sibling gates. A focused race test drives the same `hasOpenTracking` and `lastRunFunc` paths concurrently through one shared index.

## Review notes

- Code surface is limited to `cmd/gc/order_dispatch.go` plus `cmd/gc/order_dispatch_tracking_index_race_test.go`.
- No config, API, schema, migration, dashboard, or molecule behavior changes.
- The lock protects only in-memory tracking-index maps; it is not held while querying bead history/open work.

## Test plan

- [x] `go test -race $(go list -f '{{range .GoFiles}}{{printf "cmd/gc/%s " .}}{{end}}' ./cmd/gc) cmd/gc/order_dispatch_tracking_index_race_test.go -run TestOrderDispatchTrackingIndexConcurrentGatesAreRaceFree -count=1`
- [x] `TMPDIR=/home/jaword/t/g9 LOCAL_TEST_JOBS=12 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel`
- [x] `TMPDIR=/home/jaword/t/g9 go vet ./...`
- [x] Release gate: [`release-gates/ga-9rc1br-4-order-dispatch-tracking-index-race-gate.md`](release-gates/ga-9rc1br-4-order-dispatch-tracking-index-race-gate.md)
