### PR TITLE
fix(molecule): stamp gc.formula_hash/source on apply-plan root beads

### DIFF
--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -190,6 +190,18 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 					}
 				}
 			}
+			if recipe.ContentHash != "" {
+				if node.Metadata == nil {
+					node.Metadata = make(map[string]string, 2)
+				}
+				node.Metadata["gc.formula_hash"] = recipe.ContentHash
+			}
+			if recipe.FormulaSource != "" {
+				if node.Metadata == nil {
+					node.Metadata = make(map[string]string, 1)
+				}
+				node.Metadata["gc.formula_source"] = recipe.FormulaSource
+			}
 		} else {
 			// graph.v2 workflows and their retry/Ralph attempt sub-recipes
 			// use step beads as independently routable actionable work, not

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -194,13 +194,13 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				if node.Metadata == nil {
 					node.Metadata = make(map[string]string, 2)
 				}
-				node.Metadata["gc.formula_hash"] = recipe.ContentHash
+				node.Metadata[beadmeta.FormulaHashMetadataKey] = recipe.ContentHash
 			}
 			if recipe.FormulaSource != "" {
 				if node.Metadata == nil {
 					node.Metadata = make(map[string]string, 1)
 				}
-				node.Metadata["gc.formula_source"] = recipe.FormulaSource
+				node.Metadata[beadmeta.FormulaSourceMetadataKey] = recipe.FormulaSource
 			}
 		} else {
 			// graph.v2 workflows and their retry/Ralph attempt sub-recipes

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2888,6 +2888,71 @@ func TestBuildRecipeApplyPlan_PreserveRootTypeKeepsTaskRoot(t *testing.T) {
 	}
 }
 
+func TestBuildRecipeApplyPlanStampsFormulaHash(t *testing.T) {
+	recipe := &formula.Recipe{
+		Name:          "mol-hash-check",
+		Description:   "Test hash stamping",
+		ContentHash:   "abc123def456",
+		FormulaSource: "/path/to/mol-hash-check.toml",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-hash-check", Title: "Root", Type: "molecule", IsRoot: true},
+			{ID: "mol-hash-check.step-a", Title: "Step A", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "mol-hash-check.step-a", DependsOnID: "mol-hash-check", Type: "parent-child"},
+		},
+	}
+
+	plan, _, rootKey, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+	if rootKey != "mol-hash-check" {
+		t.Fatalf("rootKey = %q, want mol-hash-check", rootKey)
+	}
+
+	root := nodeByKey(plan.Nodes, "mol-hash-check")
+	if root == nil {
+		t.Fatal("root node missing")
+	}
+	if got := root.Metadata["gc.formula_hash"]; got != "abc123def456" {
+		t.Errorf("gc.formula_hash = %q, want %q", got, "abc123def456")
+	}
+	if got := root.Metadata["gc.formula_source"]; got != "/path/to/mol-hash-check.toml" {
+		t.Errorf("gc.formula_source = %q, want %q", got, "/path/to/mol-hash-check.toml")
+	}
+
+	stepA := nodeByKey(plan.Nodes, "mol-hash-check.step-a")
+	if stepA == nil {
+		t.Fatal("step-a node missing")
+	}
+	if _, ok := stepA.Metadata["gc.formula_hash"]; ok {
+		t.Error("non-root node should not have gc.formula_hash")
+	}
+}
+
+func TestBuildRecipeApplyPlanNoHashWhenEmpty(t *testing.T) {
+	recipe := &formula.Recipe{
+		Name: "mol-no-hash",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-no-hash", Title: "Root", Type: "molecule", IsRoot: true},
+		},
+	}
+
+	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+
+	root := nodeByKey(plan.Nodes, "mol-no-hash")
+	if root == nil {
+		t.Fatal("root node missing")
+	}
+	if _, ok := root.Metadata["gc.formula_hash"]; ok {
+		t.Error("gc.formula_hash should not be set when ContentHash is empty")
+	}
+}
+
 func TestInstantiateStampsFormulaHash(t *testing.T) {
 	store := beads.NewMemStore()
 	recipe := &formula.Recipe{

--- a/release-gates/ga-5m7zmq-formula-hash-apply-plan-gate.md
+++ b/release-gates/ga-5m7zmq-formula-hash-apply-plan-gate.md
@@ -1,0 +1,43 @@
+# Release Gate: apply-plan formula hash/source stamping
+
+Bead: ga-5m7zmq
+Source review bead: ga-wderad
+PR: https://github.com/gastownhall/gascity/pull/3265
+Candidate branch: builder/ga-gcqi4i
+Candidate head: bdc71e659feee8b90dafc3f9df9f34d674b8d09f
+Base checked: origin/main at 91e64b9a1f9291494e058ad1390e8d16d93557c3
+Merge base: f12b2939ff783ea295ff551aee67c72b6fdea87b
+
+## Summary
+
+PASS. The change is a single internal molecule apply-plan fix: root nodes built by `buildRecipeApplyPlan` now receive the same `gc.formula_hash` and `gc.formula_source` metadata that the sequential `Instantiate` path already stamps. The associated tests cover hash/source stamping, empty-value behavior, and the non-root invariant.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-wderad` reports `REVIEW VERDICT: PASS`; review bead is closed with reason `pass`. |
+| 2 | Acceptance criteria met | PASS | `internal/molecule/graph_apply.go` stamps `gc.formula_hash` and `gc.formula_source` only when non-empty and only on the root node. `internal/molecule/molecule_test.go` adds `TestBuildRecipeApplyPlanStampsFormulaHash` and `TestBuildRecipeApplyPlanNoHashWhenEmpty`; the package test passes. |
+| 3 | Tests pass | PASS | `go test ./internal/molecule` passed. `go vet ./...` passed. `make test` passed with observable log `/tmp/gascity-test.jsonl.nEGIgs`. GitHub PR checks for #3265 are also green at the reviewed head. |
+| 4 | No high-severity review findings open | PASS | Review notes list no blocking or high-severity findings. PR review list is empty; the only current human PR comment asks for an opinion, not a blocking finding. The old Blacksmith failure comment is minimized as outdated and current checks are successful. |
+| 5 | Final branch is clean | PASS | Clean worktree was used for the gate. After committing this gate file, `git status --short --branch` was rechecked and was clean. |
+| 6 | Branch diverges cleanly from main | PASS | `gh pr view 3265` reports `mergeStateStatus: CLEAN`. Local `git merge-tree $(git merge-base origin/main origin/builder/ga-gcqi4i) origin/main origin/builder/ga-gcqi4i` produced a clean merge result with no conflicts. |
+| 7 | Single feature theme | PASS | Triple-dot diff from the PR merge-base touches only `internal/molecule/graph_apply.go` and `internal/molecule/molecule_test.go`; the commit set is one molecule metadata-stamping fix. |
+
+## Local Commands
+
+```text
+go test ./internal/molecule
+go vet ./...
+make test
+git diff --stat origin/main...origin/builder/ga-gcqi4i
+git merge-tree $(git merge-base origin/main origin/builder/ga-gcqi4i) origin/main origin/builder/ga-gcqi4i
+```
+
+## Commit Set
+
+| Commit | Purpose |
+|--------|---------|
+| 55cc80184a911e7eaf6108d0d7b4ea3dbec34c4f | Implement root apply-plan formula hash/source metadata stamping. |
+| bdc71e659feee8b90dafc3f9df9f34d674b8d09f | Add molecule tests for root stamping, empty values, and non-root behavior. |
+


### PR DESCRIPTION
## What this changes

Molecule apply-plan root beads now keep the formula identity that produced them. When `gc formula cook` applies a graph plan, the root bead gets `gc.formula_hash` and `gc.formula_source` metadata, so later formula-version checks can identify which formula definition created the work.

This brings the graph apply-plan path into parity with the existing sequential `Instantiate` path. The behavior is limited to root bead creation; child dependency wiring, child bead metadata, and order dispatch are not changed.

## Review notes

- Main implementation is in `internal/molecule/graph_apply.go`.
- Coverage is in `internal/molecule/molecule_test.go` for root stamping, empty-value behavior, and the non-root invariant.
- The metadata keys already existed in the sequential path; this PR fills in the missing graph apply-plan path rather than adding a new metadata contract.

## Test plan

- [x] `go test ./internal/molecule`
- [x] `go vet ./...`
- [x] `make test`
- [x] Release gate: [`release-gates/ga-5m7zmq-formula-hash-apply-plan-gate.md`](release-gates/ga-5m7zmq-formula-hash-apply-plan-gate.md)
