### PR TITLE
fix(dolt): add `gc dolt compact --gc-only` reclaim path for stranded DBs (ga-zrs)

### DIFF
--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -68,6 +68,39 @@ If `gc doctor` reports a clean `dolt-noms-size` and agents come back up
 cleanly, the recovery is complete. You may delete the `.dolt.bak-*`
 directory at your leisure once you are confident in the new store.
 
+## Reclaiming a database stranded below the compaction threshold
+
+`gc dolt compact` skips any database with fewer commits than the threshold
+(default 2000, `GC_DOLT_COMPACT_THRESHOLD_COMMITS`). A database can fall *below*
+that threshold yet still carry orphaned chunks — most commonly after a prior
+flatten squashed its history but the post-flatten full GC was deferred (a
+concurrent writer raced the flatten), quarantined and later cleared, or
+otherwise never completed. Scheduled compaction then skips the database forever
+and the space is never reclaimed. The skip is visible in the compactor log as:
+
+```
+compact: db=<database> commits=<n> below_threshold=<t> oldgen_archives=present pending_gc=absent — skip ...
+```
+
+Use the operator-invoked reclaim path to recover such a database without waiting
+for its commit count to climb back over the threshold:
+
+```bash
+# Reclaim one stranded database. Runs CALL DOLT_GC('--full') with no flatten,
+# bypassing the commit-count threshold.
+gc dolt compact --gc-only --only-db <database>
+
+# Preview first, mutating nothing.
+gc dolt compact --gc-only --only-db <database> --dry-run
+```
+
+`--gc-only` refuses any database under an integrity-quarantine marker; resolve
+the underlying reason (see **Compact Quarantine Reasons** below) before
+reclaiming. Unlike the full `dolt gc --archive-level=1` procedure above,
+`--gc-only` runs against the live managed server and does not require stopping
+the city — though quiescing writers still makes the GC faster and more
+thorough.
+
 ## Expected Outcome
 
 DoltHub's archive format typically delivers ~30% compression on top of

--- a/examples/bd/dolt/commands/compact/help.md
+++ b/examples/bd/dolt/commands/compact/help.md
@@ -1,0 +1,40 @@
+# gc dolt compact
+
+Flatten Dolt commit history on managed databases to reduce storage, then run a
+full garbage collection to reclaim the orphaned chunks. Without flags, compact
+runs in scheduled mode: it skips any database below the commit-count threshold
+(default 2000, `GC_DOLT_COMPACT_THRESHOLD_COMMITS`), flattens the rest, verifies
+row preservation, and runs `CALL DOLT_GC('--full')`.
+
+## Flags
+
+- `--gc-only` — Reclaim orphaned chunks via `CALL DOLT_GC('--full')` on each
+  database **regardless of commit count**, skipping the flatten path entirely.
+  This is the sanctioned reclaim path for a database stranded *below* the
+  flatten threshold with orphaned `oldgen` archives — for example after a prior
+  flatten dropped its commit count below the threshold but its post-flatten full
+  GC was deferred or never ran, so scheduled compaction skips it forever and the
+  disk space is never reclaimed. Unlike a bare working-set GC, `--full` rewrites
+  `oldgen`, so the orphaned history is actually freed. Refuses any database that
+  carries an integrity-quarantine marker.
+
+- `--only-db <name>` — Restrict the run to the named database. Repeatable, and
+  augments `GC_DOLT_COMPACT_ONLY_DBS`. Use this to reclaim a single stranded
+  database without touching the rest of the store.
+
+- `--dry-run` — Print the intended actions without issuing any
+  `DOLT_RESET` / `DOLT_COMMIT` / `DOLT_GC`.
+
+## Examples
+
+```bash
+# Recover a single database that scheduled compaction skips because it fell
+# below the commit threshold but still holds orphaned oldgen chunks.
+gc dolt compact --gc-only --only-db hq
+
+# Preview what a full reclaim pass would touch, without mutating Dolt.
+gc dolt compact --gc-only --dry-run
+```
+
+See `docs/troubleshooting/dolt-bloat-recovery.md` for the full bloat-recovery
+runbook, including when to stop writers and take a safety backup first.

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -117,6 +117,70 @@
 set -eu
 
 : "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
+
+# CLI flags. The discovered-command bridge forwards `gc dolt compact` argv here
+# with flag-parsing disabled, so this script owns its option parsing. Flags map
+# onto the GC_DOLT_COMPACT_* environment defaults (and the gc_only mode) read
+# below, giving operators a discoverable, sanctioned reclaim path without
+# exporting environment variables. --help is intercepted by the bridge.
+#   --gc-only          reclaim orphaned chunks via CALL DOLT_GC('--full') on
+#                      each database, bypassing the commit-count threshold and
+#                      the flatten path — recovery for a database stranded below
+#                      the threshold with orphaned oldgen archives.
+#   --only-db <name>   restrict to the named database (repeatable; augments
+#                      GC_DOLT_COMPACT_ONLY_DBS).
+#   --dry-run          print intended actions without mutating Dolt.
+gc_only=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --gc-only)
+      gc_only=1
+      shift
+      ;;
+    --only-db)
+      if [ "$#" -lt 2 ]; then
+        printf 'compact: --only-db requires a database name\n' >&2
+        exit 2
+      fi
+      if [ -n "${GC_DOLT_COMPACT_ONLY_DBS:-}" ]; then
+        GC_DOLT_COMPACT_ONLY_DBS="${GC_DOLT_COMPACT_ONLY_DBS},$2"
+      else
+        GC_DOLT_COMPACT_ONLY_DBS="$2"
+      fi
+      shift 2
+      ;;
+    --only-db=*)
+      only_db_flag_value="${1#--only-db=}"
+      if [ -z "$only_db_flag_value" ]; then
+        printf 'compact: --only-db requires a database name\n' >&2
+        exit 2
+      fi
+      if [ -n "${GC_DOLT_COMPACT_ONLY_DBS:-}" ]; then
+        GC_DOLT_COMPACT_ONLY_DBS="${GC_DOLT_COMPACT_ONLY_DBS},${only_db_flag_value}"
+      else
+        GC_DOLT_COMPACT_ONLY_DBS="${only_db_flag_value}"
+      fi
+      shift
+      ;;
+    --dry-run)
+      GC_DOLT_COMPACT_DRY_RUN=1
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      printf 'compact: unknown flag %s (supported: --gc-only, --only-db <name>, --dry-run)\n' "$1" >&2
+      exit 2
+      ;;
+    *)
+      printf 'compact: unexpected argument %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+done
+
 : "${GC_DOLT_PORT:=}"
 gc_dolt_port_input="$GC_DOLT_PORT"
 gc_dolt_host_input="${GC_DOLT_HOST:-}"
@@ -236,6 +300,11 @@ case "$bare_gc_input" in
     exit 2
     ;;
 esac
+
+if [ "$gc_only" = "1" ] && [ "$bare_gc" = "1" ]; then
+  printf 'compact: --gc-only cannot be combined with bare GC (GC_DOLT_COMPACT_BARE_GC) — choose one reclaim mode\n' >&2
+  exit 2
+fi
 
 case "$threshold_commits" in
   ''|*[!0-9]*)
@@ -1684,7 +1753,7 @@ flatten_database() {
 
   if [ "$count" -lt "$threshold_commits" ]; then
     if oldgen_has_files "$db"; then
-      printf 'compact: db=%s commits=%s below_threshold=%s oldgen_archives=present pending_gc=absent — skip\n' \
+      printf 'compact: db=%s commits=%s below_threshold=%s oldgen_archives=present pending_gc=absent — skip (run "gc dolt compact --gc-only" to reclaim if these archives are orphaned)\n' \
         "$db" "$count" "$threshold_commits"
       return 0
     fi
@@ -2207,6 +2276,49 @@ bare_gc_database() {
   return 0
 }
 
+# gc_only_database — reclaim orphaned chunks on one database via a full
+# CALL DOLT_GC('--full'), with no flatten and no commit-count threshold. This is
+# the operator-invoked reclaim path (--gc-only) for a database stranded below
+# the flatten threshold with orphaned oldgen archives: a prior flatten dropped
+# its commit count below the threshold but the post-flatten full GC was
+# deferred, quarantined-then-cleared, or otherwise never ran, so the scheduled
+# threshold-gated compactor skips it forever and never reclaims the orphaned
+# chunks. Unlike bare-GC (working-set CALL DOLT_GC()), --full rewrites oldgen so
+# the orphaned history is actually reclaimed (see
+# docs/troubleshooting/dolt-bloat-recovery.md). Honors GC_DOLT_COMPACT_ONLY_DBS,
+# GC_DOLT_COMPACT_DRY_RUN, and the per-db quarantine marker; does NOT write
+# pending-GC / pending-push markers (those are flatten-remediation state).
+gc_only_database() {
+  db="$1"
+
+  if [ -n "$only_dbs" ]; then
+    case ",$only_dbs," in
+      *,"$db",*) ;;
+      *)
+        printf 'compact: db=%s not in GC_DOLT_COMPACT_ONLY_DBS — skip\n' "$db"
+        return 0
+        ;;
+    esac
+  fi
+
+  if has_compact_marker "$quarantine_dir" "$db"; then
+    quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
+    quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
+    quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
+    printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s — manual intervention required before compaction or GC\n' \
+      "$db" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" >&2
+    return 1
+  fi
+
+  if [ -n "$dry_run" ]; then
+    printf 'compact: db=%s — dry-run (would reclaim via DOLT_GC --full)\n' "$db"
+    return 0
+  fi
+
+  start=$(date +%s)
+  run_full_gc "$db" "gc-only reclaim" "gc-only reclaim" "$start"
+}
+
 # shellcheck disable=SC2317
 cleanup() {
   if [ "$flock_acquired" = "1" ]; then
@@ -2376,6 +2488,21 @@ main() {
   done < "$_db_tmp"
 
   failed_count=0
+  if [ "$gc_only" = "1" ]; then
+    while IFS= read -r db; do
+      [ -n "$db" ] || continue
+      if ! gc_only_database "$db"; then
+        failed_count=$((failed_count + 1))
+      fi
+    done < "$_unique_db_tmp"
+
+    if [ "$failed_count" -gt 0 ]; then
+      printf 'compact: %s database(s) failed gc-only reclaim\n' "$failed_count" >&2
+      exit 1
+    fi
+    exit 0
+  fi
+
   if [ "$bare_gc" = "1" ]; then
     while IFS= read -r db; do
       [ -n "$db" ] || continue

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -154,7 +154,13 @@ func newCompactScriptFixture(t *testing.T) compactScriptFixture {
 
 func (f compactScriptFixture) run(t *testing.T, mode string, extraEnv ...string) (string, error) {
 	t.Helper()
-	cmd := exec.Command("sh", filepath.Join(f.root, "commands", "compact", "run.sh"))
+	return f.runWithArgs(t, mode, nil, extraEnv...)
+}
+
+func (f compactScriptFixture) runWithArgs(t *testing.T, mode string, args []string, extraEnv ...string) (string, error) {
+	t.Helper()
+	scriptArgs := append([]string{filepath.Join(f.root, "commands", "compact", "run.sh")}, args...)
+	cmd := exec.Command("sh", scriptArgs...)
 	cmd.Env = append(filteredEnv(
 		"PATH",
 		"GC_CITY_PATH",
@@ -3305,6 +3311,170 @@ func TestCompactScriptBareGCDisabledWhenEnvFalsy(t *testing.T) {
 	}
 	if strings.Contains(string(logData), "DOLT_GC") {
 		t.Fatalf("falsy bare-gc + below threshold must not call DOLT_GC:\n%s", logData)
+	}
+}
+
+// --gc-only reclaim flag (ga-zrs): an operator-invoked CALL DOLT_GC('--full')
+// per database that bypasses the commit-count threshold and the flatten path.
+// This is the sanctioned reclaim path for a database stranded below the flatten
+// threshold with orphaned oldgen archives — the catch-22 where a prior flatten
+// dropped commits below threshold so scheduled compaction skips it forever and
+// never reclaims the orphaned chunks. Unlike bare-GC (working-set DOLT_GC()),
+// --full rewrites oldgen so the orphaned history is actually reclaimed.
+
+func TestCompactScriptGCOnlyFlagReclaimsBelowThresholdWithFullGC(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.runWithArgs(t, "below_threshold", []string{"--gc-only"},
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("gc-only reclaim failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "db=beads gc-only reclaim duration=") || !strings.Contains(out, "— ok") {
+		t.Fatalf("gc-only output missing reclaim success line:\n%s", out)
+	}
+	if strings.Contains(out, "below_threshold=") {
+		t.Fatalf("gc-only must bypass the threshold gate:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	for _, forbidden := range []string{"DOLT_RESET", "DOLT_COMMIT", "DOLT_PUSH", "DOLT_FETCH"} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("gc-only must not issue %s:\n%s", forbidden, log)
+		}
+	}
+	if !strings.Contains(log, "CALL DOLT_GC('--full')") {
+		t.Fatalf("gc-only must issue full CALL DOLT_GC('--full'):\n%s", log)
+	}
+}
+
+func TestCompactScriptGCOnlyFlagHonorsOnlyDBFlag(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	if err := os.MkdirAll(filepath.Join(fixture.dataDir, "cache", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir cache db: %v", err)
+	}
+	out, err := fixture.runWithArgs(t, "success", []string{"--gc-only", "--only-db", "beads"},
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("gc-only allowlist reclaim failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "db=cache not in GC_DOLT_COMPACT_ONLY_DBS") {
+		t.Fatalf("gc-only output missing allowlist skip:\n%s", out)
+	}
+	if !strings.Contains(out, "db=beads gc-only reclaim duration=") {
+		t.Fatalf("gc-only output missing reclaim success for allowlisted db:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "db=cache query=") {
+		t.Fatalf("non-allowlisted database should not receive dolt queries:\n%s", log)
+	}
+	if !strings.Contains(log, "db=beads query=CALL DOLT_GC('--full')") {
+		t.Fatalf("allowlisted database was not reclaimed with full GC:\n%s", log)
+	}
+}
+
+func TestCompactScriptGCOnlyFlagDryRunSkipsMutations(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.runWithArgs(t, "success", []string{"--gc-only", "--dry-run"},
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("gc-only dry-run failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "dry-run (would reclaim via DOLT_GC --full)") {
+		t.Fatalf("gc-only dry-run output missing explanation:\n%s", out)
+	}
+	if logData, err := os.ReadFile(fixture.doltLog); err == nil {
+		if strings.Contains(string(logData), "DOLT_GC") {
+			t.Fatalf("gc-only dry-run must not issue DOLT_GC:\n%s", logData)
+		}
+	}
+}
+
+func TestCompactScriptGCOnlyFlagRefusesQuarantinedDatabase(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	quarantineMarker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if err := os.MkdirAll(filepath.Dir(quarantineMarker), 0o755); err != nil {
+		t.Fatalf("mkdir quarantine dir: %v", err)
+	}
+	if err := os.WriteFile(quarantineMarker, []byte("db=beads\nreason=test\ncreated_at=2026-05-01T00:00:00Z\n"), 0o600); err != nil {
+		t.Fatalf("write quarantine marker: %v", err)
+	}
+	out, err := fixture.runWithArgs(t, "success", []string{"--gc-only"},
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("gc-only must fail when quarantine marker exists:\n%s", out)
+	}
+	if !strings.Contains(out, "integrity quarantine marker exists") {
+		t.Fatalf("gc-only output missing quarantine explanation:\n%s", out)
+	}
+	if logData, err := os.ReadFile(fixture.doltLog); err == nil {
+		if strings.Contains(string(logData), "DOLT_GC") {
+			t.Fatalf("quarantined database must not be reclaimed:\n%s", logData)
+		}
+	}
+}
+
+func TestCompactScriptGCOnlyFlagSurfacesDoltGCFailure(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.runWithArgs(t, "gc_failure", []string{"--gc-only"},
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("gc-only must fail when DOLT_GC fails:\n%s", out)
+	}
+	if !strings.Contains(out, "gc exploded") {
+		t.Fatalf("gc-only output missing Dolt GC stderr:\n%s", out)
+	}
+	if !strings.Contains(out, "1 database(s) failed gc-only reclaim") {
+		t.Fatalf("gc-only output missing per-run failure tally:\n%s", out)
+	}
+	// gc-only reclaim must NOT write flatten-bookkeeping markers — those
+	// describe flatten remediation state that the reclaim path never enters.
+	for _, dir := range []string{"compact-pending-gc", "compact-pending-push", "compact-quarantine"} {
+		marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", dir, "beads")
+		if _, err := os.Stat(marker); !os.IsNotExist(err) {
+			t.Fatalf("gc-only failure must not write %s marker, stat err=%v", dir, err)
+		}
+	}
+}
+
+func TestCompactScriptGCOnlyFlagRejectsBareGCEnvCombination(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.runWithArgs(t, "success", []string{"--gc-only"},
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_BARE_GC=1")
+	if err == nil {
+		t.Fatalf("compact must reject --gc-only combined with bare GC:\n%s", out)
+	}
+	if !strings.Contains(out, "--gc-only cannot be combined with bare GC") {
+		t.Fatalf("output missing mutual-exclusion diagnostic:\n%s", out)
+	}
+}
+
+func TestCompactScriptRejectsUnknownFlag(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.runWithArgs(t, "success", []string{"--bogus"})
+	if err == nil {
+		t.Fatalf("compact must reject an unknown flag:\n%s", out)
+	}
+	if !strings.Contains(out, "unknown flag --bogus") {
+		t.Fatalf("output missing unknown-flag diagnostic:\n%s", out)
+	}
+}
+
+func TestCompactScriptOnlyDBFlagRequiresValue(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.runWithArgs(t, "success", []string{"--gc-only", "--only-db"})
+	if err == nil {
+		t.Fatalf("compact must reject --only-db without a value:\n%s", out)
+	}
+	if !strings.Contains(out, "--only-db requires a database name") {
+		t.Fatalf("output missing --only-db value diagnostic:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Problem

`gc dolt compact` skips any database below the commit-count threshold (default
2000, `GC_DOLT_COMPACT_THRESHOLD_COMMITS`). After a flatten drops a busy
database below that threshold, scheduled compaction skips it forever and never
reclaims the now-orphaned `oldgen` chunks — a catch-22 with **no sanctioned
reclaim path**.

This is reachable in normal operation: the post-flatten integrity check
correctly refuses to GC when a concurrent writer races the flatten (no data
lost), but that refusal is exactly what strands the database below threshold
with disk space unreclaimed (observed: a town store stuck at ~1.7G of orphaned
chunks; `compact` then reports `commits=3 below_threshold=2000 — skip`).

## Fix

Add an operator-invoked reclaim path: **`gc dolt compact --gc-only`** runs
`CALL DOLT_GC('--full')` on each database **regardless of commit count**,
skipping the flatten path entirely. Unlike a bare working-set `DOLT_GC()`,
`--full` rewrites `oldgen` so the orphaned history is actually reclaimed (per
`docs/troubleshooting/dolt-bloat-recovery.md`).

It honors `--only-db <name>` and `--dry-run`, refuses quarantined databases, and
writes no flatten-remediation markers. The scheduled threshold-gated hot path is
**unchanged** — an existing test enforces that a healthy below-threshold database
with `oldgen` present is still skipped, so the reclaim stays operator-invoked;
the skip line now points operators at the new flag.

The discovered-command bridge runs pack commands with cobra flag-parsing
disabled and execs the script with raw argv, so `run.sh` owns a small POSIX flag
parser that maps flags onto the existing `GC_DOLT_COMPACT_*` variables.

## Files

- `examples/dolt/commands/compact/run.sh` — POSIX flag parser + `--gc-only` reclaim path
- `examples/dolt/commands/compact/help.md` — surfaced via `gc dolt compact --help`
- `examples/dolt/dog_exec_scripts_test.go` — flag-parsing + gc-only behavior coverage
- `docs/troubleshooting/dolt-bloat-recovery.md` — bloat-recovery runbook section

## Testing

- `make vet` clean
- `golangci-lint` 0 issues
- `check-docs` ok
- compact tests pass in isolation (CGO+ICU build of `examples/dolt` confirmed)

## Notes

Tracks bead `ga-zrs`. Delivered as a fork PR because the rig's polecat credential
lacks write access to `gastownhall/gascity`; this rig is local-only (file upstream
manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
