### PR TITLE
fix(beads): reject limited Counter queries after #3258

### DIFF
--- a/internal/beads/caching_store_count_test.go
+++ b/internal/beads/caching_store_count_test.go
@@ -62,6 +62,42 @@ func TestCachingStoreCountServedFromCache(t *testing.T) {
 	}
 }
 
+func TestCachingStoreCountRejectsLimitedCleanCacheQuery(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	mustCreate := func(title string) {
+		t.Helper()
+		if _, err := mem.Create(beads.Bead{Title: title, Type: "task"}); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+	mustCreate("first open task")
+	mustCreate("second open task")
+
+	backing := &countingBackingStore{Store: mem, countResult: 99}
+	cs := beads.NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	query := beads.ListQuery{Status: "open", AllowScan: true, Limit: 1}
+	listed, err := cs.List(query)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("List len = %d, want 1", len(listed))
+	}
+
+	_, err = cs.Count(context.Background(), query)
+	if !errors.Is(err, beads.ErrCountUnsupported) {
+		t.Fatalf("Count error = %v, want ErrCountUnsupported", err)
+	}
+	if backing.countCalls != 0 {
+		t.Fatalf("backing.Count called %d times, want 0", backing.countCalls)
+	}
+}
+
 func TestCachingStoreCountDelegatesBeforePrime(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -107,10 +107,15 @@ func liveListQuery(query ListQuery) ListQuery {
 // from the in-memory cache when it is live and clean; everything else
 // (Live queries, ParentID lookups, closed history, dirty/unprimed cache)
 // delegates to the backing store's Counter. Backing stores without a
-// Counter return ErrCountUnsupported so callers can fall back to List.
+// Counter return ErrCountUnsupported so callers can fall back to List. Limited
+// queries are unsupported because Count must match List cardinality, including
+// List's post-sort limit cap.
 func (c *CachingStore) Count(ctx context.Context, query ListQuery, excludeTypes ...string) (int, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return 0, fmt.Errorf("counting beads: %w", ErrQueryRequiresScan)
+	}
+	if query.Limit > 0 {
+		return 0, fmt.Errorf("counting beads: %w", ErrCountUnsupported)
 	}
 	if !query.Live && query.ParentID == "" && !query.IncludesClosed() {
 		c.mu.RLock()

--- a/internal/beads/doltlite_count.go
+++ b/internal/beads/doltlite_count.go
@@ -23,12 +23,14 @@ import (
 // both tiers also return ErrCountUnsupported because a union count would
 // double-count ids that List dedupes, and CreatedBefore/ParentID filters
 // return ErrCountUnsupported because List applies them with Go-side semantics a
-// single COUNT cannot reproduce. UpdatedBefore is also excluded, but as an
-// over-conservative exclusion pending cleanup of the duplicate SQL/Go filter:
-// queryIssueTable already emits an exact COALESCE(updated_at, created_at)
-// predicate for it, so a COUNT could reproduce it — the redundant Go-side
-// re-filter is what currently keeps it out. Callers fall back to List for those
-// shapes, exactly as the Counter contract specifies.
+// single COUNT cannot reproduce. Limited queries are excluded because the
+// Counter contract is List cardinality parity, not full-result total
+// cardinality. UpdatedBefore is also excluded, but as an over-conservative
+// exclusion pending cleanup of the duplicate SQL/Go filter: queryIssueTable
+// already emits an exact COALESCE(updated_at, created_at) predicate for it, so
+// a COUNT could reproduce it — the redundant Go-side re-filter is what
+// currently keeps it out. Callers fall back to List for those shapes, exactly
+// as the Counter contract specifies.
 func (s *DoltliteReadStore) Count(ctx context.Context, query ListQuery, excludeTypes ...string) (int, error) {
 	if err := query.Validate(); err != nil {
 		return 0, err
@@ -64,6 +66,9 @@ func doltliteCountSupported(query ListQuery) bool {
 		return false
 	}
 	if !query.CreatedBefore.IsZero() || !query.UpdatedBefore.IsZero() {
+		return false
+	}
+	if query.Limit > 0 {
 		return false
 	}
 	return true

--- a/internal/beads/doltlite_count_test.go
+++ b/internal/beads/doltlite_count_test.go
@@ -111,6 +111,7 @@ func TestDoltliteCountUnsupportedShapes(t *testing.T) {
 	}{
 		{name: "metadata filter", query: ListQuery{Metadata: map[string]string{"gc.routed_to": "rig/polecat"}}},
 		{name: "parent filter", query: ListQuery{ParentID: "gc-parent"}},
+		{name: "limited query", query: ListQuery{AllowScan: true, Limit: 1}},
 		{name: "created before", query: ListQuery{AllowScan: true, CreatedBefore: time.Now().Add(time.Hour)}},
 		{name: "tier both", query: ListQuery{Label: "tier-test", TierMode: TierBoth}},
 		{name: "tier wisps", query: ListQuery{Label: "tier-test", TierMode: TierWisps}},


### PR DESCRIPTION
Follow-up to #3258.

## What

PR #3258 has already merged. This follow-up carries the maintainer-side adoption-review fixup only: reject limited `Count` queries in the CachingStore and DoltLite count paths so optional `Counter` implementations cannot over-report cardinality relative to `List`, with focused regression coverage.

## Context

- Original PR: https://github.com/gastownhall/gascity/pull/3258
- Original title: perf(api): hydration-free bounded reads for beads(all=true) + feed label trim (#3253)
- Original state: MERGED
- Configured workflow base: main
- Original GitHub base: main
- Base mismatch: none
- Original merge commit: ef78bedb15cb2d5d8d3c08d9c5337c1aa85a4b4e

## Review and validation

The adoption review approved this follow-up after validating both count-parity fixes:

- `CachingStore.Count` rejects `Limit > 0` before cache counting or backend delegation.
- `doltliteCountSupported` rejects `Limit > 0`, preventing SQL `COUNT(*)` from over-reporting relative to capped `List` results.
- Focused local validation during review covered the CachingStore limited-count regression and the native DoltLite count tests.

The original contributor change set has already landed in #3258; this PR contains only the maintainer fixup needed after the review/fix loop.
