### PR TITLE
fix(native-store): allow gc-owned bd hooks with native store

### DIFF
--- a/internal/beads/factory.go
+++ b/internal/beads/factory.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -29,6 +30,13 @@ const (
 	nativeForceFallbackGate  = "force_fallback"
 	nativeHooksGate          = "bd_hooks"
 	nativeUnavailableMessage = "native_store_unavailable"
+
+	// gcHookStampPrefix is the comment prefix gc embeds in every hook script
+	// it installs. Hooks bearing this stamp are gc's own event-forwarding
+	// hooks; they do not block native-store eligibility because bd-CLI
+	// operations (e.g., agent writes) still invoke them for autoclose, and
+	// the controller cache covers the same bead events for gc's own writes.
+	gcHookStampPrefix = "# gc-hook-stamp: "
 )
 
 // BeadsDiagnostic summarizes native-store selection for status surfaces.
@@ -199,14 +207,30 @@ func diagnosticFromPreflight(result contract.PreflightResult) BeadsDiagnostic {
 	return diag
 }
 
+// scopeHasExecutableBdHooks reports whether any of the standard bd hooks
+// (on_create, on_update, on_close) are executable and NOT installed by gc.
+// GC's own stamped forwarder hooks are exempt: the controller-cache event
+// path already covers bead events for gc's own writes, and bd-CLI operations
+// (e.g., agent writes via bd close) still fire those hooks for autoclose.
 func scopeHasExecutableBdHooks(scopeRoot string) bool {
 	for _, name := range []string{"on_create", "on_update", "on_close"} {
-		info, err := os.Stat(filepath.Join(scopeRoot, ".beads", "hooks", name))
-		if err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+		path := filepath.Join(scopeRoot, ".beads", "hooks", name)
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+			continue
+		}
+		content, err := os.ReadFile(path)
+		if err != nil || !isGCStampedHook(content) {
 			return true
 		}
 	}
 	return false
+}
+
+// isGCStampedHook reports whether the hook content contains the gc-hook-stamp
+// marker, meaning the hook was installed by gc as a bead event forwarder.
+func isGCStampedHook(content []byte) bool {
+	return bytes.Contains(content, []byte(gcHookStampPrefix))
 }
 
 func forceNativeFallback() bool {

--- a/internal/beads/factory.go
+++ b/internal/beads/factory.go
@@ -227,10 +227,17 @@ func scopeHasExecutableBdHooks(scopeRoot string) bool {
 	return false
 }
 
-// isGCStampedHook reports whether the hook content contains the gc-hook-stamp
-// marker, meaning the hook was installed by gc as a bead event forwarder.
+// isGCStampedHook reports whether the hook content contains a gc-hook-stamp
+// line, meaning the hook was installed by gc as a bead event forwarder. The
+// marker must begin a line (matching cmd/gc/hooks.go's stamp format) so an
+// incidental occurrence in a comment or echo body cannot exempt a non-gc hook.
 func isGCStampedHook(content []byte) bool {
-	return bytes.Contains(content, []byte(gcHookStampPrefix))
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		if bytes.HasPrefix(bytes.TrimSpace(line), []byte(gcHookStampPrefix)) {
+			return true
+		}
+	}
+	return false
 }
 
 func forceNativeFallback() bool {

--- a/internal/beads/factory_test.go
+++ b/internal/beads/factory_test.go
@@ -259,6 +259,47 @@ func TestOpenStoreAtForCityExecutableHooksBlockNativeStore(t *testing.T) {
 	}
 }
 
+func TestOpenStoreAtForCityGCStampedHooksDoNotBlockNativeStore(t *testing.T) {
+	scope := t.TempDir()
+	hooksDir := filepath.Join(scope, ".beads", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gcHookContent := "#!/bin/sh\n# gc-hook-stamp: 2026-01-01 abc123\nbd event emit bead.created\n"
+	for _, name := range []string{"on_create", "on_update", "on_close"} {
+		if err := os.WriteFile(filepath.Join(hooksDir, name), []byte(gcHookContent), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	native := NewMemStore()
+
+	result, err := OpenStoreAtForCity(context.Background(), StoreOpenOptions{
+		ScopeRoot:        scope,
+		Provider:         "bd",
+		PreflightChecker: factoryPreflightChecker(scope, factoryPreflightDoltMetadata(), contract.PreflightBDContext{Backend: "dolt", DoltMode: "server"}),
+		OpenBdStore: func() (Store, error) {
+			t.Fatal("OpenBdStore called: gc-stamped hooks should not block native store")
+			return nil, nil
+		},
+		OpenNativeStore: func() (Store, error) {
+			return native, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("OpenStoreAtForCity() error = %v", err)
+	}
+	if result.Store != native {
+		t.Fatalf("Store = %T, want native store; gc-stamped hooks must not block it", result.Store)
+	}
+	if result.Diagnostic.Store != storeNameNativeDoltStore {
+		t.Fatalf("diagnostic store = %q, want %q", result.Diagnostic.Store, storeNameNativeDoltStore)
+	}
+	if !result.Diagnostic.NativeStoreEligible {
+		t.Fatalf("native_store_eligible = false, want true; preflight_gate=%q reason=%q",
+			result.Diagnostic.PreflightGate, result.Diagnostic.PreflightReason)
+	}
+}
+
 func factoryPreflightChecker(scope, metadata string, ctx contract.PreflightBDContext) contract.PreflightChecker {
 	files := fsys.NewFake()
 	files.Dirs[filepath.Join(scope, ".beads")] = true

--- a/internal/beads/factory_test.go
+++ b/internal/beads/factory_test.go
@@ -300,6 +300,40 @@ func TestOpenStoreAtForCityGCStampedHooksDoNotBlockNativeStore(t *testing.T) {
 	}
 }
 
+func TestOpenStoreAtForCityEmbeddedStampMarkerStillBlocksNativeStore(t *testing.T) {
+	scope := t.TempDir()
+	hooksDir := filepath.Join(scope, ".beads", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Marker appears only inside an echo body, not as a stamp line.
+	hook := "#!/bin/sh\necho \"not really # gc-hook-stamp: spoofed\"\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(hooksDir, "on_create"), []byte(hook), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fallback := NewMemStore()
+
+	result, err := OpenStoreAtForCity(context.Background(), StoreOpenOptions{
+		ScopeRoot:        scope,
+		Provider:         "bd",
+		PreflightChecker: factoryPreflightChecker(scope, factoryPreflightDoltMetadata(), contract.PreflightBDContext{Backend: "dolt", DoltMode: "server"}),
+		OpenBdStore:      func() (Store, error) { return fallback, nil },
+		OpenNativeStore: func() (Store, error) {
+			t.Fatal("OpenNativeStore called for embedded-marker non-gc hook")
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("OpenStoreAtForCity() error = %v", err)
+	}
+	if result.Store != fallback {
+		t.Fatalf("Store = %T, want fallback store", result.Store)
+	}
+	if result.Diagnostic.PreflightGate != nativeHooksGate {
+		t.Fatalf("preflight_gate = %q, want %q", result.Diagnostic.PreflightGate, nativeHooksGate)
+	}
+}
+
 func factoryPreflightChecker(scope, metadata string, ctx contract.PreflightBDContext) contract.PreflightChecker {
 	files := fsys.NewFake()
 	files.Dirs[filepath.Join(scope, ".beads")] = true

--- a/release-gates/ga-z0p232-native-store-gc-hooks-gate.md
+++ b/release-gates/ga-z0p232-native-store-gc-hooks-gate.md
@@ -1,0 +1,47 @@
+# Release Gate: native-store gc-stamped bd hooks
+
+Bead: ga-z0p232
+Source review bead: ga-97ahsp
+Branch: builder/ga-exfzfw
+Reviewed commit: 22105c206c3e40c0e1d4ead7954014b81be7fc8b
+PR: https://github.com/gastownhall/gascity/pull/3270
+Gate date: 2026-06-09
+
+## Summary
+
+PASS. This is a single-theme native-store selection fix. Gas City now ignores
+the executable bd hook scripts it installs itself when deciding whether native
+in-process bead storage is safe, while preserving the existing fallback for
+non-stamped third-party hooks.
+
+`docs/PROJECT_MANIFEST.md` is not present on this branch; this gate uses the
+deployer role release criteria and the repository testing guidance in
+`TESTING.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-97ahsp is closed with close reason `pass`; notes contain `Review verdict: PASS`; reviewer reported no blockers. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `internal/beads/factory.go` and `internal/beads/factory_test.go`. Existing non-stamped hook fallback remains covered by `TestOpenStoreAtForCityExecutableHooksBlockNativeStore`; new gc-stamped hook path is covered by `TestOpenStoreAtForCityGCStampedHooksDoNotBlockNativeStore`. Focused command passed: `go test ./internal/beads -run 'TestOpenStoreAtForCity(ExecutableHooksBlockNativeStore|GCStampedHooksDoNotBlockNativeStore)'`. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` initially reported two non-deterministic local failures; both failed tests passed on direct `-count=1` rerun, and a clean full `make test-fast-parallel` retry passed all fast jobs. `go vet ./...` passed. GitHub PR #3270 shows CI required checks passing. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list no blockers and no security concerns; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | Clean detached gate worktree started at `origin/builder/ga-exfzfw`; only this gate file is added for the gate commit. Final cleanliness is verified after commit before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded with tree `c35ded2c9ca2adf51bf1888955f3942eebc6e361`; PR #3270 merge state is CLEAN. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem and behavior: native bead store preflight handling for gc-owned bd hooks. |
+
+## Test Details
+
+- PASS: `go test ./internal/beads -run 'TestOpenStoreAtForCity(ExecutableHooksBlockNativeStore|GCStampedHooksDoNotBlockNativeStore)'`
+- PASS after retry: `make test-fast-parallel`
+- PASS: `go vet ./...`
+
+## Initial Fast-Gate Retry Note
+
+The first `make test-fast-parallel` run failed in:
+
+- `internal/beads`: `TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand`
+- `internal/runtime/tmux`: `TestDoStartSession_TreatsDeadlineAfterReadyAsSuccessWhenSessionAlive`
+
+Both failed tests passed immediately when rerun directly with `-count=1`, and
+the full fast-parallel command passed on the next run.

--- a/release-gates/ga-z0p232-native-store-gc-hooks-gate.md
+++ b/release-gates/ga-z0p232-native-store-gc-hooks-gate.md
@@ -26,8 +26,8 @@ deployer role release criteria and the repository testing guidance in
 | 2 | Acceptance criteria met | PASS | Diff is limited to `internal/beads/factory.go` and `internal/beads/factory_test.go`. Existing non-stamped hook fallback remains covered by `TestOpenStoreAtForCityExecutableHooksBlockNativeStore`; new gc-stamped hook path is covered by `TestOpenStoreAtForCityGCStampedHooksDoNotBlockNativeStore`. Focused command passed: `go test ./internal/beads -run 'TestOpenStoreAtForCity(ExecutableHooksBlockNativeStore|GCStampedHooksDoNotBlockNativeStore)'`. |
 | 3 | Tests pass | PASS | `make test-fast-parallel` initially reported two non-deterministic local failures; both failed tests passed on direct `-count=1` rerun, and a clean full `make test-fast-parallel` retry passed all fast jobs. `go vet ./...` passed. GitHub PR #3270 shows CI required checks passing. |
 | 4 | No high-severity review findings open | PASS | Reviewer notes list no blockers and no security concerns; unresolved HIGH findings count is 0. |
-| 5 | Final branch is clean | PASS | Clean detached gate worktree started at `origin/builder/ga-exfzfw`; only this gate file is added for the gate commit. Final cleanliness is verified after commit before push. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded with tree `c35ded2c9ca2adf51bf1888955f3942eebc6e361`; PR #3270 merge state is CLEAN. |
+| 5 | Final branch is clean | PASS | Clean detached gate worktree started at `origin/builder/ga-exfzfw`; after committing gate evidence, `git status --short --branch` showed no modified or untracked files. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded against the current `origin/main`; PR #3270 has no merge conflict and is blocked only by post-push checks while they run. |
 | 7 | Single feature theme | PASS | Commit set touches one subsystem and behavior: native bead store preflight handling for gc-owned bd hooks. |
 
 ## Test Details


### PR DESCRIPTION
## What this changes

Gas City installs `.beads/hooks/on_create`, `.beads/hooks/on_update`, and `.beads/hooks/on_close` as part of normal city startup and reconcile work. The native bead-store preflight now recognizes those gc-owned hook scripts by their `# gc-hook-stamp:` marker, so gc's own event-forwarding hooks no longer force the system back onto the slower per-call `bd` CLI path.

Operator-installed executable bd hooks are still treated as a native-store blocker. That preserves the conservative fallback for third-party hooks while allowing the hooks that gc manages itself to coexist with the native in-process store.

## Review notes

- The main behavior is in `internal/beads/factory.go`, where executable hook files are read before deciding whether the `bd_hooks` gate should block native store startup.
- The trust boundary is unchanged: operator-controlled non-stamped hook scripts still force fallback.
- No config, schema, API, or dashboard surface changes are introduced.

## Test plan

- [x] `go test ./internal/beads -run 'TestOpenStoreAtForCity(ExecutableHooksBlockNativeStore|GCStampedHooksDoNotBlockNativeStore)'`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-z0p232-native-store-gc-hooks-gate.md`](release-gates/ga-z0p232-native-store-gc-hooks-gate.md)
