### PR TITLE
Hydrate bundled locked imports before config load

### DIFF
--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -27,6 +27,9 @@ func loadCityConfigWithBuiltinPacks(cityPath string, includes ...string) (*confi
 }
 
 func cityConfigIncludesWithBuiltinPacks(cityPath string, includes ...string) ([]string, error) {
+	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+		return nil, err
+	}
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {
 		return nil, fmt.Errorf("materializing builtin packs: %w", err)
 	}

--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -27,13 +27,10 @@ func loadCityConfigWithBuiltinPacks(cityPath string, includes ...string) (*confi
 }
 
 func cityConfigIncludesWithBuiltinPacks(cityPath string, includes ...string) ([]string, error) {
-	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+	builtinIncludes, err := builtinPackIncludesForConfigLoad(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), resolveLoadCityConfigWarningWriter())
+	if err != nil {
 		return nil, err
 	}
-	if err := MaterializeBuiltinPacks(cityPath); err != nil {
-		return nil, fmt.Errorf("materializing builtin packs: %w", err)
-	}
-	builtinIncludes := builtinPackIncludes(cityPath)
 	allIncludes := make([]string, 0, len(includes)+len(builtinIncludes))
 	allIncludes = append(allIncludes, includes...)
 	allIncludes = append(allIncludes, builtinIncludes...)

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"golang.org/x/term"
 )
@@ -111,11 +110,7 @@ func supervisorCityStopTimeout(cityPath string) time.Duration {
 }
 
 func effectiveCityName(cityPath string) (string, error) {
-	if err := MaterializeBuiltinPacks(cityPath); err != nil {
-		return "", fmt.Errorf("materializing builtin packs: %w", err)
-	}
-	tomlPath := filepath.Join(cityPath, "city.toml")
-	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	cfg, _, err := loadCityConfigWithBuiltinPacks(cityPath)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -596,6 +596,22 @@ func TestLoadStartCityConfigInstallsLockedBundledRemoteImportBeforeLoad(t *testi
 	assertPublicGastownSyntheticCache(t, gcHome)
 }
 
+func TestLoadCityConfigInstallsLockedBundledRemoteImportBeforeLoad(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("HOME", gcHome)
+	cityPath := writeCityWithLockedPublicGastownImport(t)
+
+	cfg, err := loadCityConfig(cityPath)
+	if err != nil {
+		t.Fatalf("loadCityConfig returned error: %v", err)
+	}
+	if cfg.Workspace.Name != "bright-lights" {
+		t.Fatalf("workspace name = %q, want %q", cfg.Workspace.Name, "bright-lights")
+	}
+	assertPublicGastownSyntheticCache(t, gcHome)
+}
+
 func TestLoadStartCityConfigBuiltinGastownMayorHasNoStartupNudge(t *testing.T) {
 	cityPath := writeCityWithUnmaterializedGastownImport(t)
 

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/packman"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/supervisor"
 )
@@ -487,6 +488,53 @@ source = ".gc/system/packs/gastown"
 	return cityPath
 }
 
+func writeCityWithLockedPublicGastownImport(t *testing.T) string {
+	t.Helper()
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	packToml := `[pack]
+name = "bright-lights"
+schema = 2
+
+[imports.gastown]
+source = "` + config.PublicGastownPackSource + `"
+version = "` + config.PublicGastownPackVersion + `"
+`
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte(packToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	commit := strings.TrimPrefix(config.PublicGastownPackVersion, "sha:")
+	lockToml := strings.Join([]string{
+		"schema = 1",
+		"",
+		`[packs."` + config.PublicGastownPackSource + `"]`,
+		`version = "` + config.PublicGastownPackVersion + `"`,
+		`commit = "` + commit + `"`,
+		`fetched = "2026-01-01T00:00:00Z"`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(cityPath, packman.LockfileName), []byte(lockToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cityPath
+}
+
+func assertPublicGastownSyntheticCache(t *testing.T, home string) {
+	t.Helper()
+
+	commit := strings.TrimPrefix(config.PublicGastownPackVersion, "sha:")
+	cacheDir := filepath.Join(home, ".gc", "cache", "repos", packman.RepoCacheKey(config.PublicGastownPackSource, commit), "gastown")
+	if _, err := os.Stat(filepath.Join(cacheDir, "pack.toml")); err != nil {
+		t.Fatalf("expected public gastown synthetic cache at %s: %v", cacheDir, err)
+	}
+}
+
 func TestEffectiveCityNameMaterializesBuiltinPackImportsBeforeLoad(t *testing.T) {
 	cityPath := writeCityWithUnmaterializedGastownImport(t)
 
@@ -530,6 +578,22 @@ func TestLoadStartCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *testing.
 	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); err != nil {
 		t.Fatalf("expected gastown builtin pack to be materialized before start config load: %v", err)
 	}
+}
+
+func TestLoadStartCityConfigInstallsLockedBundledRemoteImportBeforeLoad(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("HOME", gcHome)
+	cityPath := writeCityWithLockedPublicGastownImport(t)
+
+	cfg, _, err := loadStartCityConfig(cityPath)
+	if err != nil {
+		t.Fatalf("loadStartCityConfig returned error: %v", err)
+	}
+	if cfg.Workspace.Name != "bright-lights" {
+		t.Fatalf("workspace name = %q, want %q", cfg.Workspace.Name, "bright-lights")
+	}
+	assertPublicGastownSyntheticCache(t, gcHome)
 }
 
 func TestLoadStartCityConfigBuiltinGastownMayorHasNoStartupNudge(t *testing.T) {
@@ -591,6 +655,30 @@ func TestLoadConfigCommandCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *
 	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); err != nil {
 		t.Fatalf("expected gastown builtin pack to be materialized before config command load: %v", err)
 	}
+}
+
+func TestRegisterCityWithSupervisorInstallsLockedBundledRemoteImportBeforeNameLoad(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("HOME", gcHome)
+	cityPath := writeCityWithLockedPublicGastownImport(t)
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int { return 0 },
+		func() int { return 0 },
+		func(string) (bool, string, bool) { return false, "", false },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+
+	var stdout, stderr bytes.Buffer
+	code := registerCityWithSupervisor(cityPath, &stdout, &stderr, "gc register", true)
+	if code != 0 {
+		t.Fatalf("registerCityWithSupervisor code = %d, want 0: %s", code, stderr.String())
+	}
+	assertPublicGastownSyntheticCache(t, gcHome)
 }
 
 func TestRegisterCityWithSupervisorNameOverrideMaterializesBuiltinPackImports(t *testing.T) {

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -84,11 +84,22 @@ func MaterializeBuiltinPacks(cityPath string) error {
 	return nil
 }
 
+// builtinPackIncludesForConfigLoad is the shared config-load boundary for
+// builtin pack readiness: it hydrates the shared repo cache for bundled
+// imports pinned in packs.lock and materializes the builtin system packs
+// before returning the auto-include paths. Every production loader —
+// loadCityConfig, loadCityConfigFS, and cityConfigIncludesWithBuiltinPacks —
+// routes through it so any gc command self-heals a cold repo cache instead of
+// failing with "run \"gc import install\"" after a binary upgrade or cache
+// eviction.
 func builtinPackIncludesForConfigLoad(fs fsys.FS, tomlPath string, warningWriter io.Writer) ([]string, error) {
 	if !usesOSFS(fs) {
 		return nil, nil
 	}
 	cityPath := filepath.Dir(tomlPath)
+	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+		return nil, err
+	}
 	if err := ensureBuiltinPacksReadyForConfigLoad(cityPath, warningWriter); err != nil {
 		return nil, err
 	}

--- a/cmd/gc/legacy_pack_preflight.go
+++ b/cmd/gc/legacy_pack_preflight.go
@@ -25,6 +25,13 @@ func ensureLegacyNamedPacksCached(cityPath string) error {
 	return nil
 }
 
+// ensureBundledLockedRemoteImportsCached hydrates the shared repo cache for
+// every bundled pack source pinned in packs.lock so config load can resolve
+// locked bundled imports without network access or a prior "gc import
+// install". A cache that already validates is skipped lock-free; only on
+// validation failure does the preflight take the write-locked
+// packman.EnsureRepoInCache repair path, which revalidates under the lock
+// (a concurrent repair between the two checks is therefore benign).
 func ensureBundledLockedRemoteImportsCached(cityPath string) error {
 	lock, err := readImportLockfile(fsys.OSFS{}, cityPath)
 	if err != nil {
@@ -45,6 +52,13 @@ func ensureBundledLockedRemoteImportsCached(cityPath string) error {
 		pack := lock.Packs[source]
 		if strings.TrimSpace(pack.Commit) == "" {
 			return fmt.Errorf("lock entry %q is missing commit", source)
+		}
+		cachePath, err := packman.RepoCachePath(source, pack.Commit)
+		if err != nil {
+			return fmt.Errorf("resolving cache path for bundled import %q from packs.lock: %w", source, err)
+		}
+		if builtinpacks.ValidateSyntheticRepo(cachePath, pack.Commit) == nil {
+			continue
 		}
 		if _, err := packman.EnsureRepoInCache(source, pack.Commit); err != nil {
 			return fmt.Errorf("caching bundled import %q from packs.lock: %w", source, err)

--- a/cmd/gc/legacy_pack_preflight.go
+++ b/cmd/gc/legacy_pack_preflight.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
+	"sort"
+	"strings"
 
+	"github.com/gastownhall/gascity/internal/builtinpacks"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/packman"
@@ -16,6 +20,34 @@ func ensureLegacyNamedPacksCached(cityPath string) error {
 	if quickCfg, qErr := config.Load(fsys.OSFS{}, tomlPath); qErr == nil && len(quickCfg.Packs) > 0 {
 		if err := config.FetchPacks(quickCfg.Packs, cityPath); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func ensureBundledLockedRemoteImportsCached(cityPath string) error {
+	lock, err := readImportLockfile(fsys.OSFS{}, cityPath)
+	if err != nil {
+		return err
+	}
+	if len(lock.Packs) == 0 {
+		return nil
+	}
+
+	sources := make([]string, 0, len(lock.Packs))
+	for source := range lock.Packs {
+		if builtinpacks.IsSource(source) {
+			sources = append(sources, source)
+		}
+	}
+	sort.Strings(sources)
+	for _, source := range sources {
+		pack := lock.Packs[source]
+		if strings.TrimSpace(pack.Commit) == "" {
+			return fmt.Errorf("lock entry %q is missing commit", source)
+		}
+		if _, err := packman.EnsureRepoInCache(source, pack.Commit); err != nil {
+			return fmt.Errorf("caching bundled import %q from packs.lock: %w", source, err)
 		}
 	}
 	return nil

--- a/cmd/gc/legacy_pack_preflight_test.go
+++ b/cmd/gc/legacy_pack_preflight_test.go
@@ -1,12 +1,99 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/packman"
 )
+
+func TestEnsureBundledLockedRemoteImportsCachedHydratesBundledLockEntry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cityPath := t.TempDir()
+	source := config.PublicGastownPackSource
+	commit := strings.TrimPrefix(config.PublicGastownPackVersion, "sha:")
+	writePreflightImportLock(t, cityPath, source, commit)
+
+	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+		t.Fatalf("ensureBundledLockedRemoteImportsCached returned error: %v", err)
+	}
+
+	cacheDir := filepath.Join(home, ".gc", "cache", "repos", packman.RepoCacheKey(source, commit))
+	if _, err := os.Stat(filepath.Join(cacheDir, ".gc-bundled-pack-cache.toml")); err != nil {
+		t.Fatalf("bundled cache marker stat error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "gastown", "pack.toml")); err != nil {
+		t.Fatalf("bundled pack root stat error: %v", err)
+	}
+}
+
+func TestEnsureBundledLockedRemoteImportsCachedValidatesWarmCacheWithoutWriteLock(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cityPath := t.TempDir()
+	source := config.PublicGastownPackSource
+	commit := strings.TrimPrefix(config.PublicGastownPackVersion, "sha:")
+	writePreflightImportLock(t, cityPath, source, commit)
+
+	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+		t.Fatalf("cold hydration returned error: %v", err)
+	}
+
+	// Hold the exclusive repo-cache lock while rerunning the preflight. A warm
+	// cache must validate lock-free; blocking here means the preflight took the
+	// write-locked repair path even though the cache already validates.
+	root := filepath.Join(home, ".gc", "cache", "repos")
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		_, err := config.WithRepoCacheWriteLock(root, func() (string, error) {
+			close(locked)
+			<-release
+			return "", nil
+		})
+		lockDone <- err
+	}()
+	<-locked
+	defer func() {
+		close(release)
+		if err := <-lockDone; err != nil {
+			t.Errorf("releasing repo cache write lock: %v", err)
+		}
+	}()
+
+	warm := make(chan error, 1)
+	go func() { warm <- ensureBundledLockedRemoteImportsCached(cityPath) }()
+	select {
+	case err := <-warm:
+		if err != nil {
+			t.Fatalf("warm hydration returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("warm hydration blocked on the repo-cache write lock; want lock-free validation when the cache already validates")
+	}
+}
+
+func TestEnsureBundledLockedRemoteImportsCachedRejectsBundledLockEntryWithoutCommit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cityPath := t.TempDir()
+	source := config.PublicGastownPackSource
+	writePreflightImportLock(t, cityPath, source, "")
+
+	err := ensureBundledLockedRemoteImportsCached(cityPath)
+	if err == nil {
+		t.Fatal("ensureBundledLockedRemoteImportsCached succeeded, want missing commit error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("lock entry %q is missing commit", source)) {
+		t.Fatalf("error = %v, want missing commit detail", err)
+	}
+}
 
 func TestEnsureBundledLockedRemoteImportsCachedSkipsNonBundledLockEntries(t *testing.T) {
 	home := t.TempDir()
@@ -28,5 +115,19 @@ fetched = "2026-01-01T00:00:00Z"
 	}
 	if _, err := os.Stat(filepath.Join(home, ".gc", "cache", "repos")); !os.IsNotExist(err) {
 		t.Fatalf("non-bundled lock entry should not create shared repo cache, stat err = %v", err)
+	}
+}
+
+func writePreflightImportLock(t *testing.T, cityPath, source, commit string) {
+	t.Helper()
+	lockToml := fmt.Sprintf(`schema = 1
+
+[packs.%q]
+version = "1.0.0"
+commit = %q
+fetched = "2026-01-01T00:00:00Z"
+`, source, commit)
+	if err := os.WriteFile(filepath.Join(cityPath, packman.LockfileName), []byte(lockToml), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cmd/gc/legacy_pack_preflight_test.go
+++ b/cmd/gc/legacy_pack_preflight_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/packman"
+)
+
+func TestEnsureBundledLockedRemoteImportsCachedSkipsNonBundledLockEntries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cityPath := t.TempDir()
+	lockToml := `schema = 1
+
+[packs."https://example.com/external.git//pack"]
+version = "1.0.0"
+commit = "abc123def456abc123def456abc123def456abc123de"
+fetched = "2026-01-01T00:00:00Z"
+`
+	if err := os.WriteFile(filepath.Join(cityPath, packman.LockfileName), []byte(lockToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+		t.Fatalf("ensureBundledLockedRemoteImportsCached returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".gc", "cache", "repos")); !os.IsNotExist(err) {
+		t.Fatalf("non-bundled lock entry should not create shared repo cache, stat err = %v", err)
+	}
+}

--- a/internal/config/bundled_import_test.go
+++ b/internal/config/bundled_import_test.go
@@ -115,6 +115,16 @@ func TestResolveImportPackRefAcceptsPublicGastownSyntheticCache(t *testing.T) {
 	}
 }
 
+func TestPublicGastownPackSourceMapsToBundledGastownPack(t *testing.T) {
+	name, ok := builtinpacks.NameForSource(PublicGastownPackSource)
+	if !ok {
+		t.Fatalf("PublicGastownPackSource %q is not recognized as a bundled pack source", PublicGastownPackSource)
+	}
+	if name != "gastown" {
+		t.Fatalf("PublicGastownPackSource maps to bundled pack %q, want gastown", name)
+	}
+}
+
 func TestResolveLockedRemoteImportSurfacesInvalidBundledMarker(t *testing.T) {
 	home, cityDir := setupBundledImportTest(t)
 	source := bundledPackSource()


### PR DESCRIPTION
## Summary
- hydrate only bundled locked imports from packs.lock before config include resolution
- keep arbitrary remote imports on the explicit gc import install path
- route supervisor effective city-name loading through the shared config loader
- add regressions for bundled public gastown startup/register cache hydration and source recognition

## Tests
- go test ./cmd/gc -run 'TestEnsureBundledLockedRemoteImportsCachedSkipsNonBundledLockEntries|TestLoadStartCityConfigInstallsLockedBundledRemoteImportBeforeLoad|TestRegisterCityWithSupervisorInstallsLockedBundledRemoteImportBeforeNameLoad|TestEffectiveCityNameMaterializesBuiltinPackImportsBeforeLoad|TestLoadSupervisorCityConfigMaterializesBuiltinPackImportsBeforeLoad|TestLoadStartCityConfigMaterializesBuiltinPackImportsBeforeLoad|TestLoadConfigCommandCityConfigMaterializesBuiltinPackImportsBeforeLoad|TestRegisterCityWithSupervisorNameOverrideMaterializesBuiltinPackImports'\n- go test ./internal/config -run 'TestPublicGastownPackSourceMapsToBundledGastownPack|TestResolveImportPackRefAcceptsPublicGastownSyntheticCache|TestResolveLockedRemoteImportAcceptsBundledSyntheticCache|TestResolveInstalledRemoteImportAcceptsBundledSyntheticCache'\n- go test ./internal/packman -run 'Bundled|Synthetic|InstallLocked|RepoCacheKey'\n- go test ./internal/config ./internal/packman ./internal/builtinpacks\n- go vet ./cmd/gc ./internal/config ./internal/packman ./internal/builtinpacks\n- go test ./cmd/gc\n- pre-commit hook: lint-changed, generate/check-schema, go vet ./..., make test-fast-parallel\n