### PR TITLE
fix(overlay): normalize bare Claude hook entries + lint guard

### DIFF
--- a/cmd/gc/cmd_lint.go
+++ b/cmd/gc/cmd_lint.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/overlay"
 	"github.com/gastownhall/gascity/internal/promptmeta"
 	"github.com/spf13/cobra"
 )
@@ -191,6 +192,7 @@ func lintPack(packDir string) lintPackReport {
 	for _, target := range targets {
 		out.Diagnostics = append(out.Diagnostics, lintPrompt(packDir, loaded.PackDirs, loaded.Providers, target)...)
 	}
+	out.Diagnostics = append(out.Diagnostics, lintClaudeOverlayHookShape(packDir)...)
 	out.OK = lintErrorCount(out.Diagnostics) == 0
 	return out
 }
@@ -518,4 +520,44 @@ func formatLintDiagnostic(diagnostic lintDiagnostic) string {
 		return fmt.Sprintf("%s: %s: %s", path, diagnostic.Severity, message)
 	}
 	return fmt.Sprintf("%s: %s", path, message)
+}
+
+// lintClaudeOverlayHookShape walks a pack for .claude/settings.json overlay
+// files and flags any top-level hook entry using the invalid bare shape.
+// Claude Code requires the wrapped {"matcher": ..., "hooks": [...]} form; a bare
+// {"type": "command", "command": ...} entry projects to a settings file that
+// fails Claude's schema (and `claude doctor`).
+func lintClaudeOverlayHookShape(packDir string) []lintDiagnostic {
+	var diagnostics []lintDiagnostic
+	_ = filepath.WalkDir(packDir, func(path string, entry iofs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if entry.IsDir() {
+			if path != packDir && lintSkipDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() != "settings.json" || filepath.Base(filepath.Dir(path)) != ".claude" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			diagnostics = append(diagnostics, diagnosticFromError(path, err))
+			return nil
+		}
+		bare, err := overlay.FindBareHookEntries(data)
+		if err != nil {
+			diagnostics = append(diagnostics, diagnosticFromError(path, err))
+			return nil
+		}
+		for _, b := range bare {
+			diagnostics = append(diagnostics, newLintDiagnostic(path, 0, fmt.Sprintf(
+				"hooks.%s[%d] is a bare hook entry; Claude settings require the wrapped form {\"matcher\": ..., \"hooks\": [...]}",
+				b.Category, b.Index)))
+		}
+		return nil
+	})
+	return diagnostics
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -518,7 +518,7 @@ func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSo
 		return nil, claudeSettingsSourceNone, fmt.Errorf("upgrading Claude settings from %s: %w", overridePath, upgradeErr)
 	}
 
-	merged, err := overlay.MergeSettingsJSON(base, upgradedOverride)
+	merged, err := overlay.MergeSettingsJSON(base, upgradedOverride, overlay.WithWrapBareHooks())
 	if err != nil {
 		if overlay.IsOverlayObjectShapeError(err) {
 			return nil, claudeSettingsSourceNone, fmt.Errorf("invalid Claude settings override at %s: Claude settings override is not a JSON object; expected a JSON object; fix or remove the file to proceed with install: %w", overridePath, err)

--- a/internal/overlay/lint.go
+++ b/internal/overlay/lint.go
@@ -1,0 +1,60 @@
+package overlay
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// BareHookEntry locates a top-level hook entry in a Claude settings document
+// that uses the invalid bare shape — one with neither a "matcher" nor a
+// "hooks" key.
+type BareHookEntry struct {
+	Category string
+	Index    int
+}
+
+// FindBareHookEntries parses a .claude/settings.json document and returns every
+// top-level hook entry that is bare, e.g. {"type": "command", "command": ...}.
+// Claude Code requires the wrapped {"matcher": ..., "hooks": [...]} shape, so a
+// bare entry is a pack-authoring mistake that produces an invalid settings file
+// once projected. Categories are scanned in sorted order for deterministic
+// output. A document that isn't a JSON object yields a parse error; a document
+// with no "hooks" object yields no findings.
+func FindBareHookEntries(data []byte) ([]BareHookEntry, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	hooks, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+
+	categories := make([]string, 0, len(hooks))
+	for category := range hooks {
+		categories = append(categories, category)
+	}
+	sort.Strings(categories)
+
+	var bare []BareHookEntry
+	for _, category := range categories {
+		arr, ok := hooks[category].([]any)
+		if !ok {
+			continue
+		}
+		for i, entry := range arr {
+			m, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			if _, hasHooks := m["hooks"]; hasHooks {
+				continue
+			}
+			if _, hasMatcher := m["matcher"]; hasMatcher {
+				continue
+			}
+			bare = append(bare, BareHookEntry{Category: category, Index: i})
+		}
+	}
+	return bare, nil
+}

--- a/internal/overlay/lint_test.go
+++ b/internal/overlay/lint_test.go
@@ -1,0 +1,65 @@
+package overlay
+
+import "testing"
+
+func TestFindBareHookEntries_FlagsBareEntry(t *testing.T) {
+	data := []byte(`{"hooks":{"PreToolUse":[
+		{"matcher":"Bash","hooks":[{"type":"command","command":"ok"}]},
+		{"type":"command","command":"bare"}
+	]}}`)
+	bare, err := FindBareHookEntries(data)
+	if err != nil {
+		t.Fatalf("FindBareHookEntries: %v", err)
+	}
+	if len(bare) != 1 {
+		t.Fatalf("bare entries = %d, want 1", len(bare))
+	}
+	if bare[0].Category != "PreToolUse" || bare[0].Index != 1 {
+		t.Errorf("got %+v, want {PreToolUse 1}", bare[0])
+	}
+}
+
+func TestFindBareHookEntries_AllWrappedIsClean(t *testing.T) {
+	data := []byte(`{"hooks":{"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"ok"}]}]}}`)
+	bare, err := FindBareHookEntries(data)
+	if err != nil {
+		t.Fatalf("FindBareHookEntries: %v", err)
+	}
+	if len(bare) != 0 {
+		t.Errorf("bare entries = %d, want 0", len(bare))
+	}
+}
+
+func TestFindBareHookEntries_NoHooksObject(t *testing.T) {
+	bare, err := FindBareHookEntries([]byte(`{"editorMode":"vim"}`))
+	if err != nil {
+		t.Fatalf("FindBareHookEntries: %v", err)
+	}
+	if len(bare) != 0 {
+		t.Errorf("bare entries = %d, want 0", len(bare))
+	}
+}
+
+func TestFindBareHookEntries_MultipleCategoriesSorted(t *testing.T) {
+	data := []byte(`{"hooks":{
+		"PreToolUse":[{"type":"command","command":"a"}],
+		"Stop":[{"type":"command","command":"b"}]
+	}}`)
+	bare, err := FindBareHookEntries(data)
+	if err != nil {
+		t.Fatalf("FindBareHookEntries: %v", err)
+	}
+	if len(bare) != 2 {
+		t.Fatalf("bare entries = %d, want 2", len(bare))
+	}
+	// Deterministic, sorted by category: PreToolUse before Stop.
+	if bare[0].Category != "PreToolUse" || bare[1].Category != "Stop" {
+		t.Errorf("categories not sorted: %+v", bare)
+	}
+}
+
+func TestFindBareHookEntries_InvalidJSON(t *testing.T) {
+	if _, err := FindBareHookEntries([]byte(`not json`)); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}

--- a/internal/overlay/merge.go
+++ b/internal/overlay/merge.go
@@ -20,6 +20,18 @@ var mergeablePaths = map[string]bool{
 	filepath.Join(".github", "hooks", "gascity.json"): true,
 }
 
+// wrapBareHookPaths is the set of settings files whose top-level hook entries
+// must use the wrapped {"matcher": ..., "hooks": [...]} shape. For these files
+// a bare entry such as {"type": "command", "command": "..."} is schema-invalid
+// at the top level, so it is normalized into wrapped form during merge.
+//
+// Only Claude Code's .claude/settings.json is included here. Codex and Cursor
+// hooks.json legitimately use bare {"command": ...}/{"bash": ...} entries and
+// must NOT be wrapped.
+var wrapBareHookPaths = map[string]bool{
+	filepath.Join(".claude", "settings.json"): true,
+}
+
 var (
 	errBaseNotObject    = errors.New("base JSON is not an object")
 	errOverlayNotObject = errors.New("overlay JSON is not an object")
@@ -35,6 +47,30 @@ func IsOverlayObjectShapeError(err error) bool {
 // that should be JSON-merged rather than overwritten.
 func IsMergeablePath(relPath string) bool {
 	return mergeablePaths[filepath.Clean(relPath)]
+}
+
+// WrapsBareHooks reports whether relPath is a settings file that requires
+// wrapped hook entries, so bare/flat entries should be normalized into
+// {"matcher": "", "hooks": [entry]} form during merge.
+func WrapsBareHooks(relPath string) bool {
+	return wrapBareHookPaths[filepath.Clean(relPath)]
+}
+
+// MergeOption configures MergeSettingsJSON.
+type MergeOption func(*mergeConfig)
+
+type mergeConfig struct {
+	wrapBareHooks bool
+}
+
+// WithWrapBareHooks normalizes bare/flat hook entries (e.g.
+// {"type": "command", "command": "..."}) into the wrapped
+// {"matcher": "", "hooks": [entry]} shape that Claude settings require. Pass it
+// when merging a .claude/settings.json (see WrapsBareHooks). Without it the
+// merge preserves entry shapes verbatim, which is correct for Codex/Cursor
+// hooks.json.
+func WithWrapBareHooks() MergeOption {
+	return func(c *mergeConfig) { c.wrapBareHooks = true }
 }
 
 // MergeSettingsJSON performs a deep merge of base and overlay JSON documents.
@@ -54,9 +90,18 @@ func IsMergeablePath(relPath string) bool {
 //     overlay re-projecting an already-present command is a no-op instead of
 //     an unbounded append.
 //     5. else → no identity, always append
+//   - With WithWrapBareHooks, a final pass over the merged hooks normalizes any
+//     bare entry (one with neither a "matcher" nor a "hooks" key) into
+//     {"matcher": "", "hooks": [entry]}. This runs after the keyed merge so no
+//     entries are dropped or reordered; it only fixes the shape Claude requires.
 //
 // Returns pretty-printed JSON.
-func MergeSettingsJSON(base, overlay []byte) ([]byte, error) {
+func MergeSettingsJSON(base, overlay []byte, opts ...MergeOption) ([]byte, error) {
+	var cfg mergeConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	baseDoc, err := parseSettingsObject("base", base, errBaseNotObject)
 	if err != nil {
 		return nil, err
@@ -80,6 +125,15 @@ func MergeSettingsJSON(base, overlay []byte) ([]byte, error) {
 		} else {
 			// Non-hook keys: last writer wins.
 			result[k] = v
+		}
+	}
+
+	// For wrap-style providers, normalize any bare hook entry into wrapped form.
+	// Done after the merge so identity/merge semantics, ordering, and entry
+	// count are untouched — this only fixes the shape (Claude validity).
+	if cfg.wrapBareHooks {
+		if hooks, ok := result["hooks"].(map[string]any); ok {
+			result["hooks"] = wrapBareHookEntries(hooks)
 		}
 	}
 
@@ -240,6 +294,48 @@ func innerHooksKey(inner any) (string, bool) {
 		return "", false
 	}
 	return "inner:" + string(bytes.TrimRight(canon, "\n")), true
+}
+
+// wrapBareHookEntries returns a copy of a hooks map in which every bare
+// top-level entry — one with neither a "matcher" nor a "hooks" key, e.g.
+// {"type": "command", "command": "..."} — is normalized into the wrapped
+// {"matcher": "", "hooks": [entry]} shape that Claude settings require.
+// Already-wrapped entries are left unchanged. No entries are added or removed.
+func wrapBareHookEntries(hooks map[string]any) map[string]any {
+	out := make(map[string]any, len(hooks))
+	for category, v := range hooks {
+		arr, ok := toSliceAny(v)
+		if !ok {
+			out[category] = v
+			continue
+		}
+		normalized := make([]any, len(arr))
+		for i, entry := range arr {
+			normalized[i] = normalizeHookEntry(entry)
+		}
+		out[category] = normalized
+	}
+	return out
+}
+
+// normalizeHookEntry wraps a bare hook entry into {"matcher": "", "hooks":
+// [entry]} form. Entries that already carry a "matcher" or "hooks" key (or are
+// not JSON objects) are returned unchanged.
+func normalizeHookEntry(entry any) any {
+	m, ok := entry.(map[string]any)
+	if !ok {
+		return entry
+	}
+	if _, hasHooks := m["hooks"]; hasHooks {
+		return entry
+	}
+	if _, hasMatcher := m["matcher"]; hasMatcher {
+		return entry
+	}
+	return map[string]any{
+		"matcher": "",
+		"hooks":   []any{entry},
+	}
 }
 
 // toMapStringAny attempts to convert v to map[string]any.

--- a/internal/overlay/merge_test.go
+++ b/internal/overlay/merge_test.go
@@ -628,3 +628,160 @@ func TestMergeSettingsJSON_EmptyArrayPreservesBase(t *testing.T) {
 		t.Errorf("SessionStart entries = %d, want 1 (base preserved with empty overlay)", len(arr))
 	}
 }
+
+func TestWrapsBareHooks(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{".claude/settings.json", true},
+		// Other providers keep bare entries verbatim.
+		{".gemini/settings.json", false},
+		{".codex/hooks.json", false},
+		{".cursor/hooks.json", false},
+		{".github/hooks/gascity.json", false},
+		{"settings.json", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := WrapsBareHooks(tt.path); got != tt.want {
+			t.Errorf("WrapsBareHooks(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+// preToolUse is a small helper to pull the PreToolUse array out of a merged
+// settings document.
+func preToolUse(t *testing.T, merged []byte) []any {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal(merged, &doc); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	hooks, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("no hooks map in result: %s", merged)
+	}
+	arr, ok := hooks["PreToolUse"].([]any)
+	if !ok {
+		t.Fatalf("no PreToolUse array in result: %s", merged)
+	}
+	return arr
+}
+
+func innerCommand(t *testing.T, entry any) string {
+	t.Helper()
+	m, ok := entry.(map[string]any)
+	if !ok {
+		t.Fatalf("entry is not an object: %v", entry)
+	}
+	inner, ok := m["hooks"].([]any)
+	if !ok || len(inner) == 0 {
+		t.Fatalf("entry has no wrapped hooks array: %v", m)
+	}
+	return inner[0].(map[string]any)["command"].(string)
+}
+
+func TestMergeSettingsJSON_WrapBareHooks_NormalizesOverlayBareEntry(t *testing.T) {
+	// A bare {type,command} entry from the overlay is the exact shape the ubs
+	// pack shipped; with WithWrapBareHooks it must become valid Claude form.
+	base := `{}`
+	over := `{"hooks":{"PreToolUse":[{"type":"command","command":"scan"}]}}`
+
+	result, err := MergeSettingsJSON([]byte(base), []byte(over), WithWrapBareHooks())
+	if err != nil {
+		t.Fatalf("MergeSettingsJSON: %v", err)
+	}
+	arr := preToolUse(t, result)
+	if len(arr) != 1 {
+		t.Fatalf("PreToolUse entries = %d, want 1", len(arr))
+	}
+	entry := arr[0].(map[string]any)
+	if entry["matcher"] != "" {
+		t.Errorf("matcher = %v, want empty string", entry["matcher"])
+	}
+	if got := innerCommand(t, entry); got != "scan" {
+		t.Errorf("inner command = %q, want scan", got)
+	}
+}
+
+func TestMergeSettingsJSON_WrapBareHooks_NormalizesBaseBareEntry(t *testing.T) {
+	// Models the accumulated agent file: a stale bare entry already in the
+	// destination (base) plus the overlay's wrapped entry. After merge both
+	// must be valid (carry a "hooks" array) — no /doctor error.
+	base := `{"hooks":{"PreToolUse":[{"type":"command","command":"scan"}]}}`
+	over := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"scan"}]}]}}`
+
+	result, err := MergeSettingsJSON([]byte(base), []byte(over), WithWrapBareHooks())
+	if err != nil {
+		t.Fatalf("MergeSettingsJSON: %v", err)
+	}
+	arr := preToolUse(t, result)
+	if len(arr) != 2 {
+		t.Fatalf("PreToolUse entries = %d, want 2", len(arr))
+	}
+	for i, e := range arr {
+		m := e.(map[string]any)
+		if _, ok := m["hooks"]; !ok {
+			t.Errorf("entry[%d] = %v lacks a hooks array (invalid Claude shape)", i, m)
+		}
+	}
+}
+
+func TestMergeSettingsJSON_WrapBareHooks_PreservesDistinctBareEntries(t *testing.T) {
+	// Two distinct bare commands must both survive (no collapse / data loss).
+	base := `{"hooks":{"PreToolUse":[{"type":"command","command":"a"}]}}`
+	over := `{"hooks":{"PreToolUse":[{"type":"command","command":"b"}]}}`
+
+	result, err := MergeSettingsJSON([]byte(base), []byte(over), WithWrapBareHooks())
+	if err != nil {
+		t.Fatalf("MergeSettingsJSON: %v", err)
+	}
+	arr := preToolUse(t, result)
+	if len(arr) != 2 {
+		t.Fatalf("PreToolUse entries = %d, want 2 (no data loss)", len(arr))
+	}
+	seen := map[string]bool{}
+	for _, e := range arr {
+		seen[innerCommand(t, e)] = true
+	}
+	if !seen["a"] || !seen["b"] {
+		t.Errorf("expected both commands a and b preserved, got %v", seen)
+	}
+}
+
+func TestMergeSettingsJSON_WrapBareHooks_LeavesWrappedUnchanged(t *testing.T) {
+	base := `{}`
+	over := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"scan"}]}]}}`
+
+	result, err := MergeSettingsJSON([]byte(base), []byte(over), WithWrapBareHooks())
+	if err != nil {
+		t.Fatalf("MergeSettingsJSON: %v", err)
+	}
+	arr := preToolUse(t, result)
+	if len(arr) != 1 {
+		t.Fatalf("PreToolUse entries = %d, want 1", len(arr))
+	}
+	if arr[0].(map[string]any)["matcher"] != "Bash" {
+		t.Errorf("matcher = %v, want Bash (already-wrapped entry must be unchanged)", arr[0].(map[string]any)["matcher"])
+	}
+}
+
+func TestMergeSettingsJSON_NoWrap_LeavesBareEntries(t *testing.T) {
+	// Without the option, Codex/Cursor-style bare entries are preserved verbatim
+	// (merged by command identity), never wrapped.
+	base := `{"hooks":{"PreToolUse":[{"command":"lint.sh"}]}}`
+	over := `{"hooks":{"PreToolUse":[{"command":"lint.sh","on":"always"}]}}`
+
+	result, err := MergeSettingsJSON([]byte(base), []byte(over))
+	if err != nil {
+		t.Fatalf("MergeSettingsJSON: %v", err)
+	}
+	arr := preToolUse(t, result)
+	if len(arr) != 1 {
+		t.Fatalf("PreToolUse entries = %d, want 1 (replaced by identity)", len(arr))
+	}
+	if _, wrapped := arr[0].(map[string]any)["hooks"]; wrapped {
+		t.Errorf("bare entry was wrapped without WithWrapBareHooks: %v", arr[0])
+	}
+}

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -108,7 +108,7 @@ func copyDirRecursive(srcBase, dstBase, rel string, stderr io.Writer, preserveEx
 				continue
 			}
 		}
-		if err := copyOrMergeFile(src, dst, IsMergeablePath(entryRel)); err != nil {
+		if err := copyOrMergeFile(src, dst, IsMergeablePath(entryRel), WrapsBareHooks(entryRel)); err != nil {
 			fmt.Fprintf(stderr, "overlay: %v\n", err) //nolint:errcheck
 		}
 	}
@@ -173,7 +173,7 @@ func copyDirWithSkipRecursive(srcBase, dstBase, rel string, skip SkipFunc) error
 
 		src := filepath.Join(srcBase, entryRel)
 		dst := filepath.Join(dstBase, entryRel)
-		if err := copyOrMergeFile(src, dst, IsMergeablePath(entryRel)); err != nil {
+		if err := copyOrMergeFile(src, dst, IsMergeablePath(entryRel), WrapsBareHooks(entryRel)); err != nil {
 			return err
 		}
 	}
@@ -284,27 +284,35 @@ func providerPreserveExisting(providerName string) preserveExistingFunc {
 }
 
 // copyOrMergeFile copies src to dst, optionally merging JSON if merge is true
-// and dst already exists. Falls back to plain copy on any merge error.
-func copyOrMergeFile(src, dst string, merge bool) error {
+// and dst already exists. When wrapBareHooks is true (Claude settings), bare
+// hook entries in the result are normalized into wrapped form, both when
+// merging and when creating the file fresh. Falls back to plain copy on any
+// merge error.
+func copyOrMergeFile(src, dst string, merge, wrapBareHooks bool) error {
 	if !merge {
 		return copyFile(src, dst)
 	}
 	// Only merge if destination already exists.
 	dstInfo, dstErr := os.Stat(dst)
 	if dstErr != nil {
-		// Destination doesn't exist or can't be stat'd — canonicalize the
-		// mergeable source JSON before creating it.
-		return copyCanonicalJSONFile(src, dst, 0)
+		// Destination doesn't exist or can't be stat'd — canonicalize (and
+		// normalize hook shape for wrap-style files) the source before
+		// creating it.
+		return createCanonicalSettingsFile(src, dst, wrapBareHooks)
 	}
 	dstData, err := os.ReadFile(dst)
 	if err != nil {
-		return copyCanonicalJSONFile(src, dst, 0)
+		return createCanonicalSettingsFile(src, dst, wrapBareHooks)
 	}
 	srcData, err := os.ReadFile(src)
 	if err != nil {
-		return copyCanonicalJSONFile(src, dst, 0)
+		return createCanonicalSettingsFile(src, dst, wrapBareHooks)
 	}
-	merged, err := MergeSettingsJSON(dstData, srcData)
+	var opts []MergeOption
+	if wrapBareHooks {
+		opts = append(opts, WithWrapBareHooks())
+	}
+	merged, err := MergeSettingsJSON(dstData, srcData, opts...)
 	if err != nil {
 		// Merge failed — fall back to overwrite.
 		return copyFile(src, dst)
@@ -315,6 +323,33 @@ func copyOrMergeFile(src, dst string, merge bool) error {
 	}
 	// Preserve the destination file's permissions.
 	return os.WriteFile(dst, merged, dstInfo.Mode().Perm())
+}
+
+// createCanonicalSettingsFile writes dst from src's canonicalized JSON. For
+// wrap-style files (wrapBareHooks) it also normalizes bare hook entries into
+// wrapped form by merging the source over an empty object. Falls back to a
+// plain canonical copy if the source can't be read or isn't a JSON object.
+func createCanonicalSettingsFile(src, dst string, wrapBareHooks bool) error {
+	if !wrapBareHooks {
+		return copyCanonicalJSONFile(src, dst, 0)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return copyCanonicalJSONFile(src, dst, 0)
+	}
+	out, err := MergeSettingsJSON([]byte("{}"), data, WithWrapBareHooks())
+	if err != nil {
+		// Source isn't a mergeable JSON object — fall back to canonical copy.
+		return copyCanonicalJSONFile(src, dst, 0)
+	}
+	info, err := os.Stat(src)
+	if err != nil {
+		return copyCanonicalJSONFile(src, dst, 0)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("creating parent for %q: %w", dst, err)
+	}
+	return os.WriteFile(dst, out, info.Mode().Perm())
 }
 
 func copyCanonicalJSONFile(src, dst string, mode fs.FileMode) error {

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -4,7 +4,6 @@ package overlay
 import (
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -331,20 +330,20 @@ func copyOrMergeFile(src, dst string, merge, wrapBareHooks bool) error {
 // plain canonical copy if the source can't be read or isn't a JSON object.
 func createCanonicalSettingsFile(src, dst string, wrapBareHooks bool) error {
 	if !wrapBareHooks {
-		return copyCanonicalJSONFile(src, dst, 0)
+		return copyCanonicalJSONFile(src, dst)
 	}
 	data, err := os.ReadFile(src)
 	if err != nil {
-		return copyCanonicalJSONFile(src, dst, 0)
+		return copyCanonicalJSONFile(src, dst)
 	}
 	out, err := MergeSettingsJSON([]byte("{}"), data, WithWrapBareHooks())
 	if err != nil {
 		// Source isn't a mergeable JSON object — fall back to canonical copy.
-		return copyCanonicalJSONFile(src, dst, 0)
+		return copyCanonicalJSONFile(src, dst)
 	}
 	info, err := os.Stat(src)
 	if err != nil {
-		return copyCanonicalJSONFile(src, dst, 0)
+		return copyCanonicalJSONFile(src, dst)
 	}
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return fmt.Errorf("creating parent for %q: %w", dst, err)
@@ -352,7 +351,7 @@ func createCanonicalSettingsFile(src, dst string, wrapBareHooks bool) error {
 	return os.WriteFile(dst, out, info.Mode().Perm())
 }
 
-func copyCanonicalJSONFile(src, dst string, mode fs.FileMode) error {
+func copyCanonicalJSONFile(src, dst string) error {
 	data, err := os.ReadFile(src)
 	if err != nil {
 		return copyFile(src, dst)
@@ -361,17 +360,14 @@ func copyCanonicalJSONFile(src, dst string, mode fs.FileMode) error {
 	if err != nil {
 		return copyFile(src, dst)
 	}
-	if mode == 0 {
-		info, err := os.Stat(src)
-		if err != nil {
-			return copyFile(src, dst)
-		}
-		mode = info.Mode()
+	info, err := os.Stat(src)
+	if err != nil {
+		return copyFile(src, dst)
 	}
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return fmt.Errorf("creating parent for %q: %w", dst, err)
 	}
-	return os.WriteFile(dst, canonical, mode.Perm())
+	return os.WriteFile(dst, canonical, info.Mode().Perm())
 }
 
 // copyFile copies a single file preserving permissions.


### PR DESCRIPTION
Clean, single-commit, conflict-free version of #2847 (which accumulated ~100 commits and went stale/CONFLICTING).

Normalizes bare Claude hook entries (`{"type":"command","command":"…"}`) into the wrapped `{"matcher":"","hooks":[…]}` shape Claude Code requires. Applied at both projection sites (overlay merge + `installClaude` fresh-copy path), plus a `gc lint` guard (`overlay.FindBareHookEntries`).

Without it, gc projects bare hook entries into `.claude/settings.json` that Claude Code's schema rejects (`hooks.PreToolUse.N.hooks: Expected array, but received undefined`), re-injected on every reconcile.

Verified in production (fremont): after deploy, the city `.gc/settings.json` + all per-agent `.claude/settings.json` re-project wrapped and `gc doctor` is clean of the error.

Supersedes #2847.