### PR TITLE
Improve registry cache recovery diagnostics

### DIFF
--- a/cmd/gc/cmd_pack_registry.go
+++ b/cmd/gc/cmd_pack_registry.go
@@ -423,6 +423,7 @@ func doPackRegistryRefresh(name string, jsonOutput bool, stdout, stderr io.Write
 		if err != nil {
 			failures = append(failures, packRegistryFailureJSON{Name: reg.Name, Message: err.Error()})
 			fmt.Fprintf(stderr, "gc pack registry refresh: %s: %v\n", reg.Name, err) //nolint:errcheck
+			writeRegistryCacheRecoveryHint(stderr, home, reg, err)
 			continue
 		}
 		refreshed = append(refreshed, packRegistryRefreshJSON{Name: reg.Name, PackCount: len(catalog.Packs)})
@@ -452,6 +453,11 @@ func doPackRegistryRefresh(name string, jsonOutput bool, stdout, stderr io.Write
 type registrySearchResult struct {
 	registry string
 	pack     packregistry.CatalogPack
+}
+
+type registryCacheUnavailable struct {
+	reg packregistry.Registry
+	err error
 }
 
 func doPackRegistrySearch(query, registry string, refresh bool, limit int, all bool, jsonOutput bool, stdout, stderr io.Writer) int {
@@ -487,6 +493,7 @@ func doPackRegistrySearch(query, registry string, refresh bool, limit int, all b
 			failures++
 			cacheFailures = append(cacheFailures, packRegistryFailureJSON{Name: reg.Name, Message: err.Error()})
 			fmt.Fprintf(stderr, "warning: registry %s cache unavailable: %v\n", reg.Name, err) //nolint:errcheck
+			writeRegistryCacheRecoveryHint(stderr, home, reg, err)
 			continue
 		}
 		warnStaleRegistryCache(home, reg.Name, stderr)
@@ -590,7 +597,7 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 		qualified = true
 	}
 	matches := []registrySearchResult{}
-	unavailable := []string{}
+	unavailable := []registryCacheUnavailable{}
 	for _, reg := range regs {
 		if refresh {
 			if _, err := packregistry.RefreshRegistry(context.Background(), home, reg, packregistry.FetchOptions{}); err != nil {
@@ -599,7 +606,7 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 		}
 		catalog, err := readPackRegistryCatalogForCommand(context.Background(), home, reg, !refresh)
 		if err != nil {
-			unavailable = append(unavailable, reg.Name)
+			unavailable = append(unavailable, registryCacheUnavailable{reg: reg, err: err})
 			continue
 		}
 		warnStaleRegistryCache(home, reg.Name, stderr)
@@ -610,11 +617,13 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 		}
 	}
 	if !qualified && len(unavailable) > 0 {
-		fmt.Fprintf(stderr, "gc pack registry show: registry %s unavailable; qualify the pack name after refreshing registries\n", strings.Join(unavailable, ", ")) //nolint:errcheck
+		writeRegistryCacheUnavailableWarnings(stderr, home, unavailable)
+		fmt.Fprintf(stderr, "gc pack registry show: registry %s unavailable; qualify the pack name after refreshing registries\n", strings.Join(registryCacheUnavailableNames(unavailable), ", ")) //nolint:errcheck
 		return 1
 	}
 	if qualified && len(unavailable) > 0 && len(matches) == 0 {
-		fmt.Fprintf(stderr, "gc pack registry show: registry %s cache unavailable\n", strings.Join(unavailable, ", ")) //nolint:errcheck
+		writeRegistryCacheUnavailableWarnings(stderr, home, unavailable)
+		fmt.Fprintf(stderr, "gc pack registry show: registry %s cache unavailable\n", strings.Join(registryCacheUnavailableNames(unavailable), ", ")) //nolint:errcheck
 		return 1
 	}
 	if len(matches) == 0 {
@@ -728,6 +737,33 @@ func readPackRegistryCatalogForCommand(ctx context.Context, home string, reg pac
 		return packregistry.Catalog{}, err
 	}
 	return packregistry.RefreshRegistry(ctx, home, reg, packregistry.FetchOptions{})
+}
+
+func registryCacheUnavailableNames(unavailable []registryCacheUnavailable) []string {
+	names := make([]string, 0, len(unavailable))
+	for _, item := range unavailable {
+		names = append(names, item.reg.Name)
+	}
+	return names
+}
+
+func writeRegistryCacheUnavailableWarnings(stderr io.Writer, home string, unavailable []registryCacheUnavailable) {
+	for _, item := range unavailable {
+		if !packregistry.IsInvalidCachedCatalog(item.err) {
+			continue
+		}
+		fmt.Fprintf(stderr, "warning: registry %s cache unavailable: %v\n", item.reg.Name, item.err) //nolint:errcheck
+		writeRegistryCacheRecoveryHint(stderr, home, item.reg, item.err)
+	}
+}
+
+func writeRegistryCacheRecoveryHint(stderr io.Writer, home string, reg packregistry.Registry, err error) {
+	if !packregistry.IsInvalidCachedCatalog(err) {
+		return
+	}
+	removeCmd := shellquote.Join([]string{"rm", "-f", packregistry.CachePath(home, reg.Name)})
+	refreshCmd := shellquote.Join([]string{"gc", "pack", "registry", "refresh", reg.Name})
+	fmt.Fprintf(stderr, "Recovery: cached catalog for registry %q is unreadable or invalid. Run %s, then %s.\n", reg.Name, removeCmd, refreshCmd) //nolint:errcheck
 }
 
 func warnStaleRegistryCache(home, registry string, stderr io.Writer) {

--- a/cmd/gc/cmd_pack_registry.go
+++ b/cmd/gc/cmd_pack_registry.go
@@ -407,6 +407,7 @@ func doPackRegistryRefresh(name string, jsonOutput bool, stdout, stderr io.Write
 		if err != nil {
 			failures = append(failures, packRegistryFailureJSON{Name: reg.Name, Message: err.Error()})
 			fmt.Fprintf(stderr, "gc pack registry refresh: %s: %v\n", reg.Name, err) //nolint:errcheck
+			writeRegistryCacheRecoveryHint(stderr, home, reg, err)
 			continue
 		}
 		refreshed = append(refreshed, packRegistryRefreshJSON{Name: reg.Name, PackCount: len(catalog.Packs)})
@@ -436,6 +437,11 @@ func doPackRegistryRefresh(name string, jsonOutput bool, stdout, stderr io.Write
 type registrySearchResult struct {
 	registry string
 	pack     packregistry.CatalogPack
+}
+
+type registryCacheUnavailable struct {
+	reg packregistry.Registry
+	err error
 }
 
 func doPackRegistrySearch(query, registry string, refresh bool, limit int, all bool, jsonOutput bool, stdout, stderr io.Writer) int {
@@ -471,6 +477,7 @@ func doPackRegistrySearch(query, registry string, refresh bool, limit int, all b
 			failures++
 			cacheFailures = append(cacheFailures, packRegistryFailureJSON{Name: reg.Name, Message: err.Error()})
 			fmt.Fprintf(stderr, "warning: registry %s cache unavailable: %v\n", reg.Name, err) //nolint:errcheck
+			writeRegistryCacheRecoveryHint(stderr, home, reg, err)
 			continue
 		}
 		warnStaleRegistryCache(home, reg.Name, stderr)
@@ -572,7 +579,7 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 		qualified = true
 	}
 	matches := []registrySearchResult{}
-	unavailable := []string{}
+	unavailable := []registryCacheUnavailable{}
 	for _, reg := range regs {
 		if refresh {
 			if _, err := packregistry.RefreshRegistry(context.Background(), home, reg, packregistry.FetchOptions{}); err != nil {
@@ -581,7 +588,7 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 		}
 		catalog, err := readPackRegistryCatalogForCommand(context.Background(), home, reg, !refresh)
 		if err != nil {
-			unavailable = append(unavailable, reg.Name)
+			unavailable = append(unavailable, registryCacheUnavailable{reg: reg, err: err})
 			continue
 		}
 		warnStaleRegistryCache(home, reg.Name, stderr)
@@ -592,11 +599,13 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 		}
 	}
 	if !qualified && len(unavailable) > 0 {
-		fmt.Fprintf(stderr, "gc pack registry show: registry %s unavailable; qualify the pack name after refreshing registries\n", strings.Join(unavailable, ", ")) //nolint:errcheck
+		writeRegistryCacheUnavailableWarnings(stderr, home, unavailable)
+		fmt.Fprintf(stderr, "gc pack registry show: registry %s unavailable; qualify the pack name after refreshing registries\n", strings.Join(registryCacheUnavailableNames(unavailable), ", ")) //nolint:errcheck
 		return 1
 	}
 	if qualified && len(unavailable) > 0 && len(matches) == 0 {
-		fmt.Fprintf(stderr, "gc pack registry show: registry %s cache unavailable\n", strings.Join(unavailable, ", ")) //nolint:errcheck
+		writeRegistryCacheUnavailableWarnings(stderr, home, unavailable)
+		fmt.Fprintf(stderr, "gc pack registry show: registry %s cache unavailable\n", strings.Join(registryCacheUnavailableNames(unavailable), ", ")) //nolint:errcheck
 		return 1
 	}
 	if len(matches) == 0 {
@@ -669,6 +678,33 @@ func readPackRegistryCatalogForCommand(ctx context.Context, home string, reg pac
 		return packregistry.Catalog{}, err
 	}
 	return packregistry.RefreshRegistry(ctx, home, reg, packregistry.FetchOptions{})
+}
+
+func registryCacheUnavailableNames(unavailable []registryCacheUnavailable) []string {
+	names := make([]string, 0, len(unavailable))
+	for _, item := range unavailable {
+		names = append(names, item.reg.Name)
+	}
+	return names
+}
+
+func writeRegistryCacheUnavailableWarnings(stderr io.Writer, home string, unavailable []registryCacheUnavailable) {
+	for _, item := range unavailable {
+		if !packregistry.IsInvalidCachedCatalog(item.err) {
+			continue
+		}
+		fmt.Fprintf(stderr, "warning: registry %s cache unavailable: %v\n", item.reg.Name, item.err) //nolint:errcheck
+		writeRegistryCacheRecoveryHint(stderr, home, item.reg, item.err)
+	}
+}
+
+func writeRegistryCacheRecoveryHint(stderr io.Writer, home string, reg packregistry.Registry, err error) {
+	if !packregistry.IsInvalidCachedCatalog(err) {
+		return
+	}
+	removeCmd := shellquote.Join([]string{"rm", "-f", packregistry.CachePath(home, reg.Name)})
+	refreshCmd := shellquote.Join([]string{"gc", "pack", "registry", "refresh", reg.Name})
+	fmt.Fprintf(stderr, "Recovery: cached catalog for registry %q is unreadable or invalid. Run %s, then %s.\n", reg.Name, removeCmd, refreshCmd) //nolint:errcheck
 }
 
 func warnStaleRegistryCache(home, registry string, stderr io.Writer) {

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -605,6 +605,68 @@ func TestPackRegistrySearchRefreshFallsBackToCache(t *testing.T) {
 	}
 }
 
+func TestPackRegistryCorruptCacheDiagnosticsIncludeRecovery(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
+	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
+	var stdout, stderr bytes.Buffer
+	if code := doPackRegistryAdd("main", catalogDir, false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("add main: %d %s", code, stderr.String())
+	}
+	cachePath := packregistry.CachePath(home, "main")
+	if err := os.WriteFile(cachePath, []byte("not = valid = toml"), 0o644); err != nil {
+		t.Fatalf("corrupt cache: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func(stdout, stderr *bytes.Buffer) int
+	}{
+		{
+			name: "refresh",
+			run: func(stdout, stderr *bytes.Buffer) int {
+				return doPackRegistryRefresh("main", false, stdout, stderr)
+			},
+		},
+		{
+			name: "search",
+			run: func(stdout, stderr *bytes.Buffer) int {
+				return doPackRegistrySearch("light", "main", false, 50, false, false, stdout, stderr)
+			},
+		},
+		{
+			name: "show",
+			run: func(stdout, stderr *bytes.Buffer) int {
+				return doPackRegistryShow("main:lighthouse", false, false, stdout, stderr)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout.Reset()
+			stderr.Reset()
+			if code := tc.run(&stdout, &stderr); code == 0 {
+				t.Fatalf("%s succeeded with corrupt cache stdout=%q stderr=%q", tc.name, stdout.String(), stderr.String())
+			}
+			assertPackRegistryCorruptCacheRecovery(t, stderr.String(), cachePath)
+		})
+	}
+}
+
+func assertPackRegistryCorruptCacheRecovery(t *testing.T, stderr, cachePath string) {
+	t.Helper()
+	for _, want := range []string{
+		"cached catalog for registry \"main\" is unreadable or invalid",
+		"rm -f",
+		cachePath,
+		"gc pack registry refresh main",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+}
+
 func TestPackRegistryShowUnqualifiedFailsClosedWithUnavailableRegistry(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -463,6 +463,68 @@ func TestPackRegistrySearchRefreshFallsBackToCache(t *testing.T) {
 	}
 }
 
+func TestPackRegistryCorruptCacheDiagnosticsIncludeRecovery(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
+	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
+	var stdout, stderr bytes.Buffer
+	if code := doPackRegistryAdd("main", catalogDir, false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("add main: %d %s", code, stderr.String())
+	}
+	cachePath := packregistry.CachePath(home, "main")
+	if err := os.WriteFile(cachePath, []byte("not = valid = toml"), 0o644); err != nil {
+		t.Fatalf("corrupt cache: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func(stdout, stderr *bytes.Buffer) int
+	}{
+		{
+			name: "refresh",
+			run: func(stdout, stderr *bytes.Buffer) int {
+				return doPackRegistryRefresh("main", false, stdout, stderr)
+			},
+		},
+		{
+			name: "search",
+			run: func(stdout, stderr *bytes.Buffer) int {
+				return doPackRegistrySearch("light", "main", false, 50, false, false, stdout, stderr)
+			},
+		},
+		{
+			name: "show",
+			run: func(stdout, stderr *bytes.Buffer) int {
+				return doPackRegistryShow("main:lighthouse", false, false, stdout, stderr)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout.Reset()
+			stderr.Reset()
+			if code := tc.run(&stdout, &stderr); code == 0 {
+				t.Fatalf("%s succeeded with corrupt cache stdout=%q stderr=%q", tc.name, stdout.String(), stderr.String())
+			}
+			assertPackRegistryCorruptCacheRecovery(t, stderr.String(), cachePath)
+		})
+	}
+}
+
+func assertPackRegistryCorruptCacheRecovery(t *testing.T, stderr, cachePath string) {
+	t.Helper()
+	for _, want := range []string{
+		"cached catalog for registry \"main\" is unreadable or invalid",
+		"rm -f",
+		cachePath,
+		"gc pack registry refresh main",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+}
+
 func TestPackRegistryShowUnqualifiedFailsClosedWithUnavailableRegistry(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)

--- a/internal/packregistry/catalog.go
+++ b/internal/packregistry/catalog.go
@@ -44,6 +44,8 @@ var (
 	hashRE         = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 	windowsPathRE  = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
 	windowsUNCPath = regexp.MustCompile(`^\\\\[^\\]+\\[^\\]+`)
+
+	errInvalidCachedCatalog = errors.New("invalid cached registry catalog")
 )
 
 // Catalog is the parsed contents of a registry catalog.
@@ -329,9 +331,12 @@ func ReadCachedCatalog(home, registryName string) (Catalog, []byte, error) {
 	}
 	catalog, err := ParseCatalog(data)
 	if err != nil {
-		return Catalog{}, data, err
+		return Catalog{}, data, invalidCachedCatalogError(err)
 	}
-	return catalog, data, ValidateCatalog(catalog, false)
+	if err := ValidateCatalog(catalog, false); err != nil {
+		return catalog, data, invalidCachedCatalogError(err)
+	}
+	return catalog, data, nil
 }
 
 // ReadCachedRegistryCatalog reads and validates a cached catalog using registry metadata.
@@ -347,9 +352,21 @@ func ReadCachedRegistryCatalog(home string, reg Registry) (Catalog, []byte, erro
 	}
 	catalog, err := ParseCatalog(data)
 	if err != nil {
-		return Catalog{}, data, err
+		return Catalog{}, data, invalidCachedCatalogError(err)
 	}
-	return catalog, data, ValidateCatalog(catalog, source.Remote)
+	if err := ValidateCatalog(catalog, source.Remote); err != nil {
+		return catalog, data, invalidCachedCatalogError(err)
+	}
+	return catalog, data, nil
+}
+
+// IsInvalidCachedCatalog reports whether err came from unreadable cached catalog contents.
+func IsInvalidCachedCatalog(err error) bool {
+	return errors.Is(err, errInvalidCachedCatalog)
+}
+
+func invalidCachedCatalogError(err error) error {
+	return fmt.Errorf("%w: %w", errInvalidCachedCatalog, err)
 }
 
 // RefreshRegistry fetches a registry catalog and updates the local cache.

--- a/internal/packregistry/catalog.go
+++ b/internal/packregistry/catalog.go
@@ -38,6 +38,8 @@ var (
 	hashRE         = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 	windowsPathRE  = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
 	windowsUNCPath = regexp.MustCompile(`^\\\\[^\\]+\\[^\\]+`)
+
+	errInvalidCachedCatalog = errors.New("invalid cached registry catalog")
 )
 
 // Catalog is the parsed contents of a registry catalog.
@@ -278,9 +280,12 @@ func ReadCachedCatalog(home, registryName string) (Catalog, []byte, error) {
 	}
 	catalog, err := ParseCatalog(data)
 	if err != nil {
-		return Catalog{}, data, err
+		return Catalog{}, data, invalidCachedCatalogError(err)
 	}
-	return catalog, data, ValidateCatalog(catalog, false)
+	if err := ValidateCatalog(catalog, false); err != nil {
+		return catalog, data, invalidCachedCatalogError(err)
+	}
+	return catalog, data, nil
 }
 
 // ReadCachedRegistryCatalog reads and validates a cached catalog using registry metadata.
@@ -296,9 +301,21 @@ func ReadCachedRegistryCatalog(home string, reg Registry) (Catalog, []byte, erro
 	}
 	catalog, err := ParseCatalog(data)
 	if err != nil {
-		return Catalog{}, data, err
+		return Catalog{}, data, invalidCachedCatalogError(err)
 	}
-	return catalog, data, ValidateCatalog(catalog, source.Remote)
+	if err := ValidateCatalog(catalog, source.Remote); err != nil {
+		return catalog, data, invalidCachedCatalogError(err)
+	}
+	return catalog, data, nil
+}
+
+// IsInvalidCachedCatalog reports whether err came from unreadable cached catalog contents.
+func IsInvalidCachedCatalog(err error) bool {
+	return errors.Is(err, errInvalidCachedCatalog)
+}
+
+func invalidCachedCatalogError(err error) error {
+	return fmt.Errorf("%w: %w", errInvalidCachedCatalog, err)
 }
 
 // RefreshRegistry fetches a registry catalog and updates the local cache.

--- a/internal/packregistry/catalog_test.go
+++ b/internal/packregistry/catalog_test.go
@@ -494,3 +494,23 @@ func TestReadCachedRegistryCatalogUsesRegistrySourceTrustBoundary(t *testing.T) 
 		t.Fatalf("ReadCachedRegistryCatalog rejected local registry cache: %v", err)
 	}
 }
+
+func TestIsInvalidCachedCatalogClassification(t *testing.T) {
+	home := t.TempDir()
+	if err := WriteCatalogCache(home, "main", []byte("not = valid = toml")); err != nil {
+		t.Fatalf("WriteCatalogCache(parse-invalid): %v", err)
+	}
+	if _, _, err := ReadCachedCatalog(home, "main"); !IsInvalidCachedCatalog(err) {
+		t.Fatalf("parse failure not classified as invalid cached catalog: %v", err)
+	}
+	semantic := strings.Replace(validCatalog, `source_kind = "git"`, `source_kind = "svn"`, 1)
+	if err := WriteCatalogCache(home, "main", []byte(semantic)); err != nil {
+		t.Fatalf("WriteCatalogCache(validate-invalid): %v", err)
+	}
+	if _, _, err := ReadCachedCatalog(home, "main"); !IsInvalidCachedCatalog(err) {
+		t.Fatalf("validation failure not classified as invalid cached catalog: %v", err)
+	}
+	if _, _, err := ReadCachedCatalog(home, "missing"); IsInvalidCachedCatalog(err) {
+		t.Fatalf("missing cache misclassified as invalid cached catalog: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Classify invalid cached registry catalogs so CLI commands can distinguish corrupt cache from ordinary fetch/search misses.
- Add recovery guidance for `gc pack registry refresh`, `search`, and `show` when a cached registry catalog is unreadable/invalid.
- Keep the scope to registry-cache UX only; no install/sync/materialization behavior and no registry-location semantics changed.

## Verification

Focused gates passed locally on this branch:

- `CGO_ENABLED=0 go test ./cmd/gc -run TestPackRegistryCorruptCacheDiagnosticsIncludeRecovery -count=1`
- `CGO_ENABLED=0 go test ./cmd/gc -run 'TestPackRegistry' -count=1`
- `CGO_ENABLED=0 go test ./internal/packregistry -count=1`
- `git diff --check`

Pre-commit hook status:

- `.githooks` is active.
- First commit attempt failed before tests because the sanitized hook environment could not find ICU headers (`unicode/regex.h`).
- Retried with `CGO_ENABLED=0`; hook passed lint/generation/vet and then failed broad `test-fast-parallel` in unrelated cmd/gc shards (examples: pack-release path containment expectations, supervisor timeout, detached tmux probe timing). The focused registry tests above pass.

## Scope Guard

This assumes the canonical public registry remains in `gascity-packs`, but does not move or redefine `registry.toml` placement. It only improves recovery text when the local cached catalog is corrupt.
