### PR TITLE
fix(dolt): replace GNU-only date -Is in stale-db cleanup formula

### DIFF
--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -104,7 +104,7 @@ append_report_note() {
   local title="$1"
   local file="$2"
   if [ -s "$file" ]; then
-    if ! bd update "$WORK_BEAD" --append-notes "$(printf '## %s %s\n\n```json\n%s\n```' "$title" "$(date -Is)" "$(cat "$file")")"; then
+    if ! bd update "$WORK_BEAD" --append-notes "$(printf '## %s %s\n\n```json\n%s\n```' "$title" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$(cat "$file")")"; then
       echo "failed to append ${title} report; continuing to drain-ack" >&2
     fi
   fi


### PR DESCRIPTION
## Summary

- `append_report_note()` in `examples/dolt/formulas/mol-dog-stale-db.toml` stamps report-note headers with `$(date -Is)`. The seconds-precision argument to `-I` is a GNU coreutils extension. BSD `date` on macOS rejects it with `date: invalid argument 's' for -I`, so the substitution expands to empty and the `## <title> <timestamp>` note header is written with a blank timestamp on macOS hosts. The script's `set -euo pipefail` cannot catch it because the failure happens inside a nested command substitution.
- This change replaces it with `date -u +"%Y-%m-%dT%H:%M:%SZ"`, which behaves identically on BSD and GNU date. It is the same timestamp form already used in `examples/bd/assets/scripts/gc-beads-bd.sh`, so the pack stays consistent. This was the only `date -I` usage across the repo's packs.

## Testing

- [x] `go test ./examples/dolt/...` passes (includes `stale_db_formula_test.go`)
- [x] `go test ./cmd/gc/` (env-isolated like `make test`, with `GC_FAST_UNIT=1`) shows no regressions from this change: the only failures are four tests that fail identically on the untouched base commit on this host, verified by running the same suite on pristine `main` and diffing the failure sets. The pre-existing failures are `TestPackReleaseValidateRejectsHashMismatch` / `TestPackReleaseValidateSkipsWithdrawnByDefault` (path-containment check trips over the macOS `/tmp` symlink, `pack path "../../../../../tmp/..." must stay within the repository`) and the two `TestBdRuntimeEnv*ManagedCityProjectsHostOverride` tests.
- [x] Verified on macOS BSD date: the new form prints `2026-06-09T19:58:55Z`, while the old `date -Is` fails with `date: invalid argument 's' for -I`

## Checklist

- [x] Linked an issue, or explained why one is not needed: no upstream issue exists; this is a one-line portability fix first observed running the dolt pack's stale-db cleanup on a macOS deployment
- [x] Added or updated tests for behavior changes: none added; the existing `stale_db_formula_test.go` covers the formula, and the change only swaps the timestamp format inside a report-note header
- [x] Updated docs for user-facing changes: n/a, no user-facing surface changed
- [x] Called out breaking changes or migration notes: none

---
> Generated by the operator's software factory.
> • City: `factory-main` · Agent: `local-core.builder-1`
> • On behalf of: @benw5483
