### PR TITLE
fix(dolt): portable ms clock for doctor probe — perl/python3 fallbacks on BSD/macOS

### DIFF
--- a/examples/dolt/assets/scripts/latency.sh
+++ b/examples/dolt/assets/scripts/latency.sh
@@ -7,20 +7,49 @@
 # to 0s or 1s depending on whether it straddles a wall-clock second tick —
 # producing false latency WARNs (and MEDIUM advisory mail) at a 1s threshold.
 
+# _now_ms_plausible VALUE — exit 0 when VALUE looks like an epoch-millisecond
+# reading: all digits, at least 13 of them (epoch-ms is 13 digits from
+# 2001-09-09 through 2286-11-20).
+_now_ms_plausible() {
+  case "${1:-}" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "${#1}" -ge 13 ]
+}
+
 # now_ms — echo the current time in epoch milliseconds.
-# GNU/coreutils date supports %3N (3-digit nanoseconds = milliseconds). On
-# platforms whose date lacks %N (e.g. BSD/macOS without coreutils), fall back
-# to second-resolution * 1000 — no worse than the prior whole-second behavior.
+#
+# Implementation cascade; the first plausible reading wins:
+#   1. date +%s%3N      — GNU/coreutils date (%3N = milliseconds). BSD/macOS
+#                         date has no %N and prints a literal '3N' suffix,
+#                         which the plausibility check rejects.
+#   2. perl Time::HiRes — core module since perl 5.8; present on stock macOS
+#                         and virtually every Linux.
+#   3. python3          — time.time() carries sub-millisecond resolution.
+#   4. date +%s × 1000  — whole seconds; no worse than the pre-fix behavior.
+#
+# The cascade exists because a GNU-only implementation silently degrades to
+# whole seconds on BSD/macOS, where a sub-second probe that straddles a
+# wall-clock second tick measures 1000ms and false-trips the default 1000ms
+# warn threshold — the same advisory storm the millisecond rewrite was meant
+# to stop, in different units.
 now_ms() {
   _now_ms_v=$(date +%s%3N 2>/dev/null)
-  case "$_now_ms_v" in
-    ''|*[!0-9]*) _now_ms_v="" ;;   # %3N printed literally: no ms support
-  esac
-  if [ -n "$_now_ms_v" ] && [ "${#_now_ms_v}" -ge 13 ]; then
-    printf '%s\n' "$_now_ms_v"     # epoch-ms is 13+ digits from 2001..2286
-  else
-    printf '%s\n' "$(( $(date +%s) * 1000 ))"
+  if _now_ms_plausible "$_now_ms_v"; then
+    printf '%s\n' "$_now_ms_v"
+    return 0
   fi
+  _now_ms_v=$(perl -MTime::HiRes=time -e 'printf "%.0f\n", time() * 1000' 2>/dev/null)
+  if _now_ms_plausible "$_now_ms_v"; then
+    printf '%s\n' "$_now_ms_v"
+    return 0
+  fi
+  _now_ms_v=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null)
+  if _now_ms_plausible "$_now_ms_v"; then
+    printf '%s\n' "$_now_ms_v"
+    return 0
+  fi
+  printf '%s\n' "$(( $(date +%s) * 1000 ))"
 }
 
 # latency_should_warn ELAPSED_MS THRESHOLD_MS — exit 0 (warn) when measured

--- a/test/dolt/latency_test.sh
+++ b/test/dolt/latency_test.sh
@@ -51,6 +51,68 @@ while [ "$i" -lt 30 ]; do
 done
 if [ "$warned" -eq 0 ]; then pass "30 fast probes -> 0 false warns"; else bad "$warned/30 fast probes false-warned"; fi
 
+# --- Fallback-cascade coverage ---------------------------------------------
+# A PATH shim emulates BSD/macOS date: '+%s%3N' prints a literal '3N' suffix
+# (no %N support); every other format defers to the real date. This forces
+# now_ms off the GNU-date branch on any platform, so the perl/python3
+# fallbacks are exercised even on GNU/Linux CI.
+
+SHIM_DIR=$(mktemp -d)
+trap 'rm -rf "$SHIM_DIR"' EXIT
+REAL_DATE=$(command -v date)
+
+mkdir -p "$SHIM_DIR/bsd"
+cat > "$SHIM_DIR/bsd/date" <<EOF
+#!/bin/sh
+if [ "\${1:-}" = "+%s%3N" ]; then
+  printf '%s3N\n' "\$("$REAL_DATE" +%s)"
+else
+  exec "$REAL_DATE" "\$@"
+fi
+EOF
+chmod +x "$SHIM_DIR/bsd/date"
+
+# Without GNU date, a sub-second clock must still come from perl or python3.
+if command -v perl >/dev/null 2>&1 || command -v python3 >/dev/null 2>&1; then
+  d=$( (
+    PATH="$SHIM_DIR/bsd:$PATH"; export PATH
+    s=$(now_ms); sleep 0.05; e=$(now_ms); echo $((e - s))
+  ) )
+  if [ "$d" -ge 5 ] && [ "$d" -le 800 ]; then
+    pass "BSD-date shim: perl/python3 fallback keeps sub-second resolution (${d}ms)"
+  else
+    bad "BSD-date shim: got ${d}ms for a 50ms sleep, want 5..800 (fallback degraded to whole seconds)"
+  fi
+else
+  echo "SKIP: neither perl nor python3 on PATH; cannot exercise sub-second fallbacks"
+fi
+
+# With GNU date, perl, and python3 all unavailable, now_ms must degrade to
+# whole seconds (a plausible epoch reading ending in 000) rather than emit
+# garbage or crash.
+mkdir -p "$SHIM_DIR/bare"
+cp "$SHIM_DIR/bsd/date" "$SHIM_DIR/bare/date"
+for tool in perl python3; do
+  printf '#!/bin/sh\nexit 127\n' > "$SHIM_DIR/bare/$tool"
+  chmod +x "$SHIM_DIR/bare/$tool"
+done
+v=$( (PATH="$SHIM_DIR/bare:$PATH"; export PATH; now_ms) )
+case "$v" in
+  *[!0-9]*|'')
+    bad "exhausted-cascade now_ms emitted non-numeric output: '$v'"
+    ;;
+  *000)
+    if [ "${#v}" -ge 13 ]; then
+      pass "exhausted cascade degrades to whole-second epoch-ms ($v)"
+    else
+      bad "exhausted-cascade now_ms too short for epoch-ms: '$v'"
+    fi
+    ;;
+  *)
+    bad "exhausted-cascade now_ms not whole-second-quantized: '$v'"
+    ;;
+esac
+
 echo "----"
 if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "FAILURES PRESENT"; fi
 exit "$fail"


### PR DESCRIPTION
## Summary

- `now_ms` — the mol-dog-doctor latency clock introduced by the millisecond-resolution fix — relies on GNU `date %3N` and silently degrades to whole seconds on BSD/macOS, where `date` has no `%N`. A sub-second probe that straddles a wall-clock second tick measures 1000ms, meets the default 1000ms threshold, and mails a MEDIUM advisory: the same false-WARN storm the millisecond rewrite was meant to stop, in different units. On one production macOS factory, ~120 identical advisories buried two real HIGH escalations.
- This change makes `now_ms` a portability cascade: GNU `date %3N` → `perl Time::HiRes` (core module since perl 5.8, present on stock macOS) → `python3 time.time()` → whole seconds. A shared plausibility check (all digits, at least 13 of them) rejects partial readings such as BSD date printing a literal `3N` suffix.
- `test/dolt/latency_test.sh` gains cascade coverage. A PATH shim emulating BSD date proves sub-second resolution survives without GNU date, which exercises the perl/python3 branch even on GNU/Linux CI. A second shim disabling `date %N`, `perl`, and `python3` together proves the exhausted cascade still degrades gracefully to whole-second epoch-ms.

## Before / after on a darwin host

Before (current main, BSD `date`):

```
FAIL: now_ms resolution: got 0ms, want 5..800 (whole-second clock yields 0 or 1000)
FAIL: 2/30 fast probes false-warned
```

After: all seven checks pass, including the two new cascade checks.

## Test plan

- [ ] `sh test/dolt/latency_test.sh` passes on GNU/Linux (GNU-date branch, plus both shimmed fallback branches)
- [ ] `sh test/dolt/latency_test.sh` passes on macOS (perl branch; previously failed 2 of 5 checks)
- [ ] `go test ./examples/dolt/` passes

---
> Generated by the operator's software factory.
> • City: `factory-main` · Agent: `local-core.builder-2`
> • On behalf of: @benw5483
