### PR TITLE
fix(preflight): pass version_compat for source builds reporting "(devel)"

### DIFF
--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -227,8 +227,17 @@ func (c PreflightChecker) checkVersionCompat(ctx PreflightBDContext, err error) 
 	if ctx.SchemaVersion <= 0 {
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckFail, "bd context did not report a schema version", details)
 	}
-	if ctx.BDVersion == "" || libraryVersion == "" || libraryVersion == "(devel)" {
+	if ctx.BDVersion == "" {
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckWarn, "bd/beads version compatibility could not be confirmed", details)
+	}
+	if libraryVersion == "" || libraryVersion == "(devel)" {
+		// A local-path/replace (source) build of the linked beads library
+		// reports no module version ("(devel)") even though gc and bd are
+		// built from the same source. The schema version is validated above
+		// and is the real compatibility signal, so an unconfirmable library
+		// version must not take the native store offline — only a *confirmed*
+		// mismatch (below) should.
+		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckPass, "bd/beads schema compatible; linked library version unconfirmed (source build)", details)
 	}
 	if strings.TrimPrefix(ctx.BDVersion, "v") != libraryVersion {
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckFail, "bd version differs from linked beads library version", details)

--- a/internal/beads/contract/preflight_checker_test.go
+++ b/internal/beads/contract/preflight_checker_test.go
@@ -358,3 +358,36 @@ func assertPreflightReadOnly(t *testing.T, fs *fsys.Fake) {
 		}
 	}
 }
+
+// TestCheckVersionCompatSourceBuild verifies that a source (local-path/replace)
+// build of the linked beads library — which reports "(devel)" as its module
+// version — does not take the native store offline. The schema version is the
+// real compatibility signal; only a *confirmed* version mismatch should fail.
+func TestCheckVersionCompatSourceBuild(t *testing.T) {
+	validCtx := func(bdVersion string) PreflightBDContext {
+		return PreflightBDContext{Backend: "dolt", DoltMode: "server", BDVersion: bdVersion, SchemaVersion: 50}
+	}
+	tests := []struct {
+		name       string
+		libVersion string
+		ctx        PreflightBDContext
+		want       PreflightCheckState
+	}{
+		{"source build reports (devel) — schema is the signal, pass", "(devel)", validCtx("1.0.5"), PreflightCheckPass},
+		{"confirmed version mismatch still fails", "1.0.5", validCtx("1.0.4"), PreflightCheckFail},
+		{"matching versions pass", "1.0.5", validCtx("1.0.5"), PreflightCheckPass},
+		{"missing bd version is unconfirmable — warn", "1.0.5", validCtx(""), PreflightCheckWarn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := PreflightChecker{BeadsLibraryVersion: tt.libVersion}
+			got := c.checkVersionCompat(tt.ctx, nil)
+			if got.ID != PreflightCheckVersionCompat {
+				t.Fatalf("ID = %q, want %q", got.ID, PreflightCheckVersionCompat)
+			}
+			if got.State != tt.want {
+				t.Fatalf("state = %q, want %q (summary: %q)", got.State, tt.want, got.Summary)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`checkVersionCompat` took the native store offline whenever the linked beads
library version was unconfirmable — including `"(devel)"`, which is exactly
what a local-path/`replace` (source) build of beads reports even when `gc` and
`bd` are built from the same source tree. The schema version is validated
separately just above and is the real compatibility signal, so an unconfirmable
*library* version should not gate the native store; only a **confirmed** version
mismatch should.

This splits the prior single `WARN` condition:

- a missing **bd-reported** version (`ctx.BDVersion == ""`) still `WARN`s — genuinely unconfirmable;
- an empty / `"(devel)"` **linked library** version with a valid schema now `PASS`es (source build);
- the confirmed-mismatch (`FAIL`) and matching (`PASS`) paths are unchanged.

Rebased on current `main`, so it composes cleanly with the recent
unreachable-`bd context` → `WARN` degrade change (that handles the `err != nil`
case; this handles the `"(devel)"` library-version case).

### Why it matters

A coordinator built from source (local `replace` on the beads module) reports
`(devel)` and was being pushed to a degraded/native-store-offline verdict on an
otherwise healthy, schema-matched dolt store — observed taking the native store
offline during a source-build deploy. Schema parity already proves
compatibility there.

## Testing

- [x] `go test ./internal/beads/contract/` — passes, incl. new `TestCheckVersionCompatSourceBuild`
- [x] `gofmt -l` clean
- [ ] `make check` / `make test-integration` — not run; this is a pure-logic change to one preflight check plus a table test, no runtime/controller/workflow behavior changed

New test `TestCheckVersionCompatSourceBuild` covers: `(devel)` library + valid bd → PASS; confirmed mismatch → FAIL; matching → PASS; missing bd version → WARN.

## Checklist

- [x] Added a test for the behavior change
- [ ] No linked issue — surfaced during a source-build deploy of gc; happy to file one if preferred
- [x] No breaking changes (only relaxes a degrade→pass for a source-build signal; confirmed mismatch still FAILs)
