### PR TITLE
fix(providers): add Claude Fable (claude-fable-5) to the claude provider model schema

### DIFF
--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -146,6 +146,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 					{Value: "", Label: "Default"},
 					{Value: "opus", Label: "Opus", FlagArgs: []string{"--model", "claude-opus-4-8"}, FlagAliases: [][]string{{"-m", "claude-opus-4-8"}}},
 					{Value: "opus-4-7", Label: "Opus 4.7", FlagArgs: []string{"--model", "claude-opus-4-7"}, FlagAliases: [][]string{{"-m", "claude-opus-4-7"}}},
+					{Value: "fable", Label: "Fable", FlagArgs: []string{"--model", "claude-fable-5"}, FlagAliases: [][]string{{"-m", "claude-fable-5"}}},
 					{Value: "sonnet", Label: "Sonnet", FlagArgs: []string{"--model", "claude-sonnet-4-6"}, FlagAliases: [][]string{{"-m", "claude-sonnet-4-6"}}},
 					{Value: "haiku", Label: "Haiku", FlagArgs: []string{"--model", "claude-haiku-4-5-20251001"}, FlagAliases: [][]string{{"-m", "claude-haiku-4-5-20251001"}}},
 				},


### PR DESCRIPTION
Agents that pin a model via option_defaults (model = X) validate against the claude provider's model choice list, which only had opus/opus-4-7/sonnet/haiku. A worker pinning model=fable (e.g. a Claude-Fable-tier pool) silently failed validation and fell back to the default model (Opus) - the wrong model ran with no error or warning. This adds a fable -> --model claude-fable-5 choice so model=fable resolves correctly (fable is available in the latest Claude CLI). Verified locally: a pool with option_defaults model=fable now launches 'claude --model claude-fable-5'.