### PR TITLE
feat(doctor): add SupervisorHTTPCheck that probes supervisor HTTP API

### DIFF
--- a/internal/doctor/checks_supervisor_http.go
+++ b/internal/doctor/checks_supervisor_http.go
@@ -1,0 +1,121 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/supervisor"
+)
+
+// httpDoer abstracts the HTTP client so tests can inject a mock.
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// SupervisorHTTPCheck verifies that the supervisor HTTP API is reachable on
+// its configured port. The check is skipped when the supervisor unix socket
+// is already known to be down so the operator sees one clear problem rather
+// than two.
+type SupervisorHTTPCheck struct {
+	supervisorRunning bool
+	loadConfig        func(string) (supervisor.Config, error)
+	configPath        func() string
+	client            httpDoer
+}
+
+// NewSupervisorHTTPCheck returns a check configured to probe the supervisor
+// HTTP API. supervisorRunning should come from the unix-socket probe result.
+func NewSupervisorHTTPCheck(supervisorRunning bool) *SupervisorHTTPCheck {
+	return &SupervisorHTTPCheck{
+		supervisorRunning: supervisorRunning,
+		loadConfig:        supervisor.LoadConfig,
+		configPath:        supervisor.ConfigPath,
+		client:            &http.Client{Timeout: 3 * time.Second},
+	}
+}
+
+// Name returns the check identifier.
+func (c *SupervisorHTTPCheck) Name() string { return "supervisor-http-api" }
+
+// CanFix reports that this check does not support automatic remediation.
+func (c *SupervisorHTTPCheck) CanFix() bool { return false }
+
+// Fix is a no-op; CanFix returns false.
+func (c *SupervisorHTTPCheck) Fix(_ *CheckContext) error { return nil }
+
+// Run checks that the supervisor HTTP API is reachable on its configured port.
+func (c *SupervisorHTTPCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if !c.supervisorRunning {
+		r.Status = StatusOK
+		r.Message = "supervisor socket not running — HTTP API check skipped"
+		return r
+	}
+
+	cfg, err := c.loadConfig(c.configPath())
+	if err != nil {
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("cannot load supervisor config: %v", err)
+		return r
+	}
+	port := cfg.Supervisor.PortOrDefault()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		fmt.Sprintf("http://127.0.0.1:%d/v0/cities", port), nil)
+	if err != nil {
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("supervisor HTTP API on port %d: %v", port, err)
+		return r
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if isConnectionRefused(err) {
+			r.Status = StatusError
+			r.Message = fmt.Sprintf("supervisor HTTP API on port %d: connection refused", port)
+			return r
+		}
+		if isTimeout(err) {
+			r.Status = StatusError
+			r.Message = fmt.Sprintf("supervisor HTTP API on port %d: timeout", port)
+			return r
+		}
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("supervisor HTTP API on port %d: %v", port, err)
+		return r
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort body close
+
+	if resp.StatusCode/100 != 2 {
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("supervisor HTTP API on port %d: non-2xx HTTP %d", port, resp.StatusCode)
+		return r
+	}
+
+	r.Status = StatusOK
+	r.Message = fmt.Sprintf("supervisor socket OK, HTTP API reachable on port %d", port)
+	return r
+}
+
+func isConnectionRefused(err error) bool {
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	return strings.Contains(err.Error(), "connection refused")
+}
+
+func isTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -166,6 +166,10 @@ func (c *SkillCollisionCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *SupervisorHTTPCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *WorktreeCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the

--- a/release-gates/ga-yswaif-supervisor-http-check-gate.md
+++ b/release-gates/ga-yswaif-supervisor-http-check-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: SupervisorHTTPCheck
+
+- Deploy bead: ga-yswaif
+- Source review bead: ga-3psuyr
+- PR: https://github.com/gastownhall/gascity/pull/3282
+- Branch: builder/ga-rle1j4.3-doctor-supervisor
+- Reviewed commit: 03e810006143fc9328d4ed3d35e8d44b99c21423
+- Base checked: origin/main at 4d9c7272e0f3f2b7e59eb6a02793850c4fdc4ed4
+- Gate date: 2026-06-10 UTC
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead ga-3psuyr is closed with `REVIEWER VERDICT: PASS`; PR #3282 contains reviewer PASS comment and all pre-gate CI checks clean. |
+| 2 | Acceptance criteria met | PASS | Change adds `SupervisorHTTPCheck`, probes `/v0/cities` on the configured supervisor HTTP port, skips when the supervisor socket is already down, reports connection refused/timeouts/non-2xx responses distinctly, and marks the check `WarmupEligible() == false`. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed locally. `go vet ./...` passed locally. `gh pr view 3282` showed prior CI clean before the gate commit; deployer monitors post-gate GitHub checks before routing the merge request. |
+| 4 | No high-severity review findings open | PASS | Reviewer recorded one LOW test-coverage finding with a follow-up bead and informational notes only; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` in the clean gate worktree showed no uncommitted implementation changes before this gate file was added. |
+| 6 | Branch diverges cleanly from main | PASS | `origin/main` advanced to 4d9c7272 after review, leaving this branch ahead 1 and behind 1. `git merge-tree $(git merge-base HEAD origin/main) origin/main HEAD` produced no conflict markers. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem: `internal/doctor`. The change is scoped to the supervisor HTTP doctor check and its warm-up eligibility. |
+
+## Command Evidence
+
+```text
+$ make test-fast-parallel
+All fast jobs passed
+
+$ go vet ./...
+PASS
+
+$ git status --short --branch
+## builder/ga-rle1j4.3-doctor-supervisor...origin/main [ahead 1, behind 1]
+
+$ git merge-tree $(git merge-base HEAD origin/main) origin/main HEAD
+clean-merge-tree
+
+$ git diff --name-only origin/main...HEAD
+internal/doctor/checks_supervisor_http.go
+internal/doctor/warmup_eligible.go
+
+$ git log --oneline origin/main..HEAD
+03e810006 feat(doctor): add SupervisorHTTPCheck that probes supervisor HTTP API
+```


### PR DESCRIPTION
## Summary

- **`internal/doctor`**: Add `SupervisorHTTPCheck` that probes the supervisor HTTP API on its configured port; skips gracefully when the unix socket is not running
- Registers `WarmupEligible() = false` so the check is excluded from `gc start` warm-up scans

## Context

Extracted from PR #3267 (`builder/ga-f43cns`) as a single-theme split per the release gate failure diagnosis in ga-rle1j4. Original PR bundled multiple independent themes; this PR contains only the supervisor HTTP doctor check.

Refs: ga-rle1j4, ga-rws585, PR #3267

## Test plan

- [x] `go vet ./...` — clean
- [x] `make test-fast-parallel` — all 6 cmd/gc shards pass, unit-core passes
- [ ] PR CI: all required checks expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)