### PR TITLE
feat(beads): add BeadsLibStore wrapping BdStore with env isolation

### DIFF
--- a/internal/beads/libstore.go
+++ b/internal/beads/libstore.go
@@ -1,0 +1,31 @@
+package beads
+
+import "path/filepath"
+
+// BeadsLibStore is a bd-backed Store scoped to a specific directory and bead
+// ID prefix. It wraps BdStore with an env-isolated CommandRunner that sets
+// BEADS_DIR and BEADS_DOLT_AUTO_START for all bd CLI invocations.
+//
+// Use NewBeadsLibStore to construct one. Call Shutdown when done to release
+// any in-process state (the dolt server itself is managed externally by bd).
+type BeadsLibStore struct { //nolint:revive // name intentional: disambiguates from BdStore and CachingStore in this package
+	*BdStore
+	dir string
+}
+
+// NewBeadsLibStore opens a BeadsLibStore rooted at dir. bd CLI calls will use
+// BEADS_DIR=dir/.beads and BEADS_DOLT_AUTO_START=1 so they reach the dolt
+// server started by "bd init --server" in that directory.
+func NewBeadsLibStore(dir, idPrefix string) (*BeadsLibStore, error) {
+	beadsDir := filepath.Join(dir, ".beads")
+	runner := ExecCommandRunnerWithEnv(map[string]string{
+		"BEADS_DIR":             beadsDir,
+		"BEADS_DOLT_AUTO_START": "1",
+	})
+	bd := NewBdStoreWithPrefix(dir, runner, idPrefix)
+	return &BeadsLibStore{BdStore: bd, dir: dir}, nil
+}
+
+// Shutdown releases any in-process state held by the store. The dolt server
+// that backs bd is managed externally and is not stopped here.
+func (s *BeadsLibStore) Shutdown() error { return nil }

--- a/release-gates/ga-fbzvjk-beads-libstore-gate.md
+++ b/release-gates/ga-fbzvjk-beads-libstore-gate.md
@@ -1,0 +1,35 @@
+# Release Gate: BeadsLibStore
+
+- Deploy bead: ga-fbzvjk
+- Source review bead: ga-pjiitc
+- PR: https://github.com/gastownhall/gascity/pull/3283
+- Branch: builder/ga-rle1j4.4-beads-libstore
+- Reviewed commit: cf0e1aa6781495d87f36ec60bc793dcc9f7d5867
+- Base checked: origin/main at 91e64b9a159811484a50341f5596f664aa424d3d
+- Gate date: 2026-06-10 UTC
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead ga-pjiitc is closed with `REVIEWER VERDICT: PASS`; PR #3283 contains reviewer PASS comment and all CI checks clean. |
+| 2 | Acceptance criteria met | PASS | Change adds `internal/beads/libstore.go`, a thin `BdStore` wrapper that scopes `BEADS_DIR` to `dir/.beads`, sets `BEADS_DOLT_AUTO_START=1`, accepts the configured bead ID prefix, and documents the no-op `Shutdown` behavior. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed locally. `go vet ./...` passed locally. `gh pr checks 3283 --watch=false` showed no failing or pending checks; CI required, preflight, integration, bdstore, worker, and pack compatibility checks passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer recorded only informational findings and "None significant"; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` in the clean gate worktree showed only the expected branch state before this gate file was added; no uncommitted implementation changes were present. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base HEAD origin/main) origin/main HEAD` produced no conflict markers. PR #3283 merge state is `CLEAN`. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem and one file: `internal/beads/libstore.go`. The change is scoped to exposing a library-friendly beads store wrapper. |
+
+## Command Evidence
+
+```text
+$ make test-fast-parallel
+All fast jobs passed
+
+$ go vet ./...
+PASS
+
+$ git diff --name-only origin/main...HEAD
+internal/beads/libstore.go
+
+$ git log --oneline origin/main..HEAD
+cf0e1aa67 feat(beads): add BeadsLibStore wrapping BdStore with env isolation
+```


### PR DESCRIPTION
## Summary

- **`internal/beads`**: Add `BeadsLibStore` wrapping `BdStore` with an env-isolated `CommandRunner` (`BEADS_DIR`, `BEADS_DOLT_AUTO_START`) for library use cases where the caller controls the database directory independently of the shell environment

## Context

Extracted from PR #3267 (`builder/ga-f43cns`) as a single-theme split per the release gate failure diagnosis in ga-rle1j4. Original PR bundled multiple independent themes; this PR contains only the BeadsLibStore.

Refs: ga-rle1j4, ga-rws585, PR #3267

## Test plan

- [x] `go vet ./...` — clean
- [x] `make test-fast-parallel` — all 6 cmd/gc shards pass, unit-core passes
- [ ] PR CI: all required checks expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)