### PR TITLE
feat(providers): add Claude Fable 5 to the builtin claude model choices

### DIFF
--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -144,6 +144,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:  "select",
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
+					{Value: "fable-5", Label: "Fable 5", FlagArgs: []string{"--model", "claude-fable-5"}, FlagAliases: [][]string{{"-m", "claude-fable-5"}}},
 					{Value: "opus", Label: "Opus", FlagArgs: []string{"--model", "claude-opus-4-8"}, FlagAliases: [][]string{{"-m", "claude-opus-4-8"}}},
 					{Value: "opus-4-7", Label: "Opus 4.7", FlagArgs: []string{"--model", "claude-opus-4-7"}, FlagAliases: [][]string{{"-m", "claude-opus-4-7"}}},
 					{Value: "sonnet", Label: "Sonnet", FlagArgs: []string{"--model", "claude-sonnet-4-6"}, FlagAliases: [][]string{{"-m", "claude-sonnet-4-6"}}},


### PR DESCRIPTION
Anthropic released **Claude Fable 5** (`claude-fable-5`) on 2026-06-09 ([announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5)). The builtin claude provider's `model` option allows only `opus/opus-4-7/sonnet/haiku`, so agent templates targeting the new model fail at session spawn with `invalid value for model: claude-fable-5`.

This adds a `fable-5` choice mapping to `--model claude-fable-5` (plus the `-m` alias form), matching the existing entry shape.

**Validated live** on a 5-rig production city: after this change, a gascity-spawned session's process argv shows `claude --model claude-fable-5` and the session self-reports *model: Fable 5, ID: claude-fable-5* via mail. `go build` + `gofmt` clean.