### PR TITLE
fix(wisp-gc): collect plain task wisps in the wisp tier

### DIFF
--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -133,6 +134,31 @@ func closedWispGCEntries(store beads.Store) ([]beads.Bead, error) {
 		return nil, fmt.Errorf("listing closed wisp roots: %w", err)
 	}
 	appendUnique(wisps)
+
+	// Plain task wisps — sling/convoy trackers, loose step beads — live in
+	// the wisp tier but are neither Type=molecule nor tagged gc.kind=wisp,
+	// so the two selectors above never see them: they accumulate without
+	// bound on a busy coordination DB, inflating every ephemeral-tier scan.
+	// Everything in the wisp tier is ephemeral by definition, so a CLOSED
+	// wisp-tier bead past TTL is collectable. Two ownership exclusions:
+	// messages belong to read-mail retention (mailRetentionTTL), and
+	// order-tracking beads belong to `gc order sweep-tracking` + the
+	// [beads.policies.order_tracking].delete_after_close policy.
+	tierWisps, err := store.List(beads.ListQuery{Status: "closed", TierMode: beads.TierWisps})
+	if err != nil {
+		return nil, fmt.Errorf("listing closed wisp-tier beads: %w", err)
+	}
+	collectable := make([]beads.Bead, 0, len(tierWisps))
+	for _, item := range tierWisps {
+		if item.Type == "message" {
+			continue
+		}
+		if slices.Contains(item.Labels, labelOrderTracking) {
+			continue
+		}
+		collectable = append(collectable, item)
+	}
+	appendUnique(collectable)
 	return entries, nil
 }
 

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -815,3 +815,44 @@ func assertDeletedIDs(t *testing.T, deleted []string, want ...string) {
 }
 
 var _ beads.Store = (*gcTestStore)(nil)
+
+func TestWispGC_PurgesPlainTaskWispsInWispTier(t *testing.T) {
+	now := time.Now()
+	expired := now.Add(-2 * time.Hour)
+
+	// The regression case: an order-tracking-style plain task wisp — lives in
+	// the wisp tier, is neither Type=molecule nor tagged gc.kind=wisp, and
+	// previously matched no GC selector (accumulating without bound).
+	tracking := makeGCBead("trk-1", expired, "closed", "task")
+	tracking.Ephemeral = true
+
+	freshTracking := makeGCBead("trk-2", now.Add(-10*time.Minute), "closed", "task")
+	freshTracking.Ephemeral = true
+
+	openWisp := makeGCBead("trk-3", expired, "open", "task")
+	openWisp.Ephemeral = true
+
+	// Messages are owned by read-mail retention, never the TTL path.
+	message := makeGCBead("msg-1", expired, "closed", "message")
+	message.Ephemeral = true
+
+	// A persistent-tier closed task is a real issue — must never be collected.
+	persistent := makeGCBead("task-1", expired, "closed", "task")
+
+	// Order-tracking wisps belong to sweep-tracking + the order_tracking
+	// delete_after_close policy, never the TTL path.
+	orderTracking := makeGCBeadWithLabels("ot-1", expired, "closed", "task", labelOrderTracking)
+	orderTracking.Ephemeral = true
+
+	store := newGCStore([]beads.Bead{tracking, freshTracking, openWisp, message, persistent, orderTracking})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (only the expired closed plain task wisp)", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "trk-1")
+}


### PR DESCRIPTION
## Problem

On a busy coordination DB, **closed plain task wisps accumulate without bound** in the wisp tier. The wisp GC has two selectors for collectable closed beads:

- `Type=="molecule"` (closed molecule roots)
- `Metadata["gc.kind"]=="wisp"` (explicitly-tagged wisp roots)

But sling/convoy trackers, loose step beads, and other plain task beads created in the wisp tier are **neither** `Type=="molecule"` **nor** tagged `gc.kind=wisp`. The two selectors never see them, so they live forever — closed, expired, but uncollected — inflating every ephemeral-tier scan (`bd ready`, reconcile ticks, dispatch polls all get slower as the wisp table grows).

In production we saw the wisp table grow into the thousands of closed-but-uncollectable task wisps purely from normal sling/convoy churn.

## Fix

Add a third selector to `closedWispGCEntries`: list **all** closed wisp-tier beads (`TierMode: TierWisps`), since everything in the wisp tier is ephemeral by definition — a closed wisp-tier bead past TTL is collectable. Two ownership exclusions so we don't poach beads another retention path owns:

- `Type=="message"` → owned by read-mail retention (`mailRetentionTTL` / `readMessageWispGCEntries`)
- `labelOrderTracking`-labeled → owned by `gc order sweep-tracking` + the `[beads.policies.order_tracking].delete_after_close` policy

Everything else (closed, in the wisp tier, past `WispTTL`) is collected through the existing closure-aware delete path, so step/child beads are torn down with their roots exactly as molecules are.

## Tests

- New `TestWispGC_PurgesPlainTaskWispsInWispTier` (discriminating: **RED** without the new selector — a closed task wisp survives — **GREEN** with it) plus preservation assertions: order-tracking beads, message wisps, fresh (under-TTL) wisps, open wisps, and non-wisp-tier beads are all left untouched.
- Full `cmd/gc` suite green.
- Deployed on a live city: a planted closed task wisp backdated past TTL was collected on the next GC tick; no regression in molecule/mail/order-tracking collection.
