### PR TITLE
fix(api): route Huma session close through the worker boundary (ga-frfj2d)

### DIFF
--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1273,6 +1273,50 @@ func TestHumaSessionCloseWithdrawsOverflowQueuedWaitNudges(t *testing.T) {
 	assertQueuedWaitNudgesWithdrawn(t, fs, firstNudgeID, laterPageNudgeID)
 }
 
+// Regression test for ga-frfj2d: the Huma close handler must route through
+// worker.Handle.CloseDetailed (the worker boundary), like the legacy close
+// handler, instead of constructing a session.Manager directly. The worker
+// boundary emits a "close" worker operation event; the direct manager
+// bypass did not.
+func TestHumaSessionCloseEmitsWorkerCloseOperationEvent(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "Close Op Event")
+
+	w := httptest.NewRecorder()
+	r := newPostRequest(cityURL(fs, "/session/")+info.ID+"/close", nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var closeOps []WorkerOperationEventPayload
+	for _, event := range fs.eventProv.(*events.Fake).Events {
+		if event.Type != events.WorkerOperation {
+			continue
+		}
+		var payload WorkerOperationEventPayload
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal worker operation payload: %v", err)
+		}
+		if payload.Operation == "close" {
+			closeOps = append(closeOps, payload)
+		}
+	}
+	if len(closeOps) != 1 {
+		t.Fatalf("got %d close worker operation events, want 1 (Huma close must route through the worker boundary)", len(closeOps))
+	}
+	if closeOps[0].SessionID != info.ID {
+		t.Errorf("close operation session_id = %q, want %q", closeOps[0].SessionID, info.ID)
+	}
+	if closeOps[0].Result != "succeeded" {
+		t.Errorf("close operation result = %q, want %q", closeOps[0].Result, "succeeded")
+	}
+}
+
 func TestLegacySessionCloseContinuesAfterWaitLookupLimit(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -812,12 +812,11 @@ func (s *Server) humaHandleSessionSuspend(ctx context.Context, input *SessionIDI
 
 // humaHandleSessionClose is the Huma-typed handler for POST /v0/session/{id}/close.
 
-func (s *Server) humaHandleSessionClose(_ context.Context, input *SessionCloseInput) (*OKResponse, error) {
+func (s *Server) humaHandleSessionClose(ctx context.Context, input *SessionCloseInput) (*OKResponse, error) {
 	store := s.state.CityBeadStore()
 	if store == nil {
 		return nil, huma.Error503ServiceUnavailable("no bead store configured")
 	}
-	mgr := s.sessionManager(store)
 
 	id, err := s.resolveSessionIDWithConfig(store, input.ID)
 	if err != nil {
@@ -830,7 +829,11 @@ func (s *Server) humaHandleSessionClose(_ context.Context, input *SessionCloseIn
 		strings.Contains(strings.TrimSpace(b.Metadata[apiNamedSessionIdentityKey]), "/") {
 		return nil, huma.Error409Conflict("configured always-on named sessions cannot be closed while config-managed")
 	}
-	closeResult, err := mgr.CloseDetailed(id)
+	handle, err := s.workerHandleForSession(store, id)
+	if err != nil {
+		return nil, humaSessionManagerError(err)
+	}
+	closeResult, err := handle.CloseDetailed(ctx)
 	if err != nil {
 		return nil, humaSessionManagerError(err)
 	}

--- a/internal/api/worker_boundary_close_test.go
+++ b/internal/api/worker_boundary_close_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestAPINonTestFilesCloseSessionsViaWorkerBoundary guards the session close
+// path in internal/api against worker-boundary bypasses (ga-frfj2d), mirroring
+// cmd/gc's TestGCNonTestFilesStayOnWorkerBoundary. Close must go through
+// worker.Handle.CloseDetailed, not a directly constructed session.Manager.
+//
+// internal/api still constructs session.Manager values for other handlers
+// (see "Active migrations / Worker boundary" in the root AGENTS.md), so this
+// test only forbids direct manager *close* calls. The single pinned exception
+// is the session-create rollback in handler_session_create.go, which closes a
+// half-created session before any worker handle exists for it.
+func TestAPINonTestFilesCloseSessionsViaWorkerBoundary(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(currentFile)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q): %v", dir, err)
+	}
+	allowed := map[string][]string{
+		// Pre-existing rollback path: closes the session the manager itself
+		// just created when post-create wiring fails. Pinned, not expandable.
+		"handler_session_create.go": {"sessionManager(store).Close("},
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q): %v", path, err)
+		}
+		content := string(data)
+		for _, needle := range []string{
+			"mgr.CloseDetailed(",
+			"mgr.Close(",
+			"sessionManager(store).CloseDetailed(",
+			"sessionManager(store).Close(",
+		} {
+			if !strings.Contains(content, needle) {
+				continue
+			}
+			if closeBoundaryExempt(allowed[name], needle) {
+				continue
+			}
+			t.Errorf("%s contains forbidden direct session.Manager close %q; route through worker.Handle.CloseDetailed instead", path, needle)
+		}
+	}
+}
+
+func closeBoundaryExempt(needles []string, needle string) bool {
+	for _, n := range needles {
+		if n == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

Bead **ga-frfj2d** (design review ga-unpr2y attempt 17, boundary lane): the Huma close handler bypassed the worker boundary. `internal/worker/handle.go` is the canonical boundary for session lifecycle operations, and `cmd/gc` is guarded by `TestGCNonTestFilesStayOnWorkerBoundary`, but `internal/api` was unguarded — and the Huma close handler constructed a `session.Manager` and called `mgr.CloseDetailed` directly.

## Root cause

`internal/api/huma_handlers_sessions_command.go:820,833` (origin/main): `humaHandleSessionClose` did `mgr := s.sessionManager(store)` then `mgr.CloseDetailed(id)`, while the legacy handler for the same endpoint (`internal/api/handler_sessions.go:357-362`) already routed through `s.workerHandleForSession(store, id)` + `handle.CloseDetailed(r.Context())`. Besides violating the active worker-boundary migration, the bypass meant Huma closes never emitted the `worker.operation` "close" event that boundary-routed closes record.

## Fix (resolution option 1 — reroute)

Route `humaHandleSessionClose` through `workerHandleForSession` + `handle.CloseDetailed(ctx)`, exactly matching the legacy handler. Everything else is preserved: response shape (`OKResponse` / `status: ok`), the always-on named-session 409 guard, `withdrawQueuedWaitNudges`, and the optional `delete` semantics. The lookup error surface is identical because `worker.Factory.SessionByID` (`internal/worker/factory.go:100`, via `Manager.GetWithBead`) and `Manager.CloseDetailed` (`internal/session/manager.go:888`) share the same `loadSessionBead(id, true)` loader — including idempotent already-closed handling. `workerHandleForSession` errors map through `humaSessionManagerError`, the Huma analogue of the legacy path's `writeSessionManagerError`.

## Proof (red -> green)

Both new tests fail on origin/main for the right reason and pass after the fix:

- `TestHumaSessionCloseEmitsWorkerCloseOperationEvent` — red: `got 0 close worker operation events, want 1`; green after reroute. Asserts exactly one `worker.operation` event with `operation=close`, `result=succeeded`, matching session_id.
- `TestAPINonTestFilesCloseSessionsViaWorkerBoundary` — red: flags `huma_handlers_sessions_command.go` for `mgr.CloseDetailed(`; green after reroute. Guard mirrors cmd/gc's boundary guard, scoped to direct manager close calls in `internal/api`, with the session-create rollback (`rollbackCreatedSession`, `handler_session_create.go`) pinned as the single documented exception so close-path bypasses cannot silently multiply.

## Gates

- gofmt on touched files: clean
- `make lint-changed LINT_CHANGED_SCOPE=staged`: 0 issues
- `go vet ./...`: clean
- `go test ./internal/api/` (full package): ok
- `go run ./cmd/genspec`, `go generate ./internal/api/genclient`, `go run ./cmd/genschema`: no artifact diffs (no wire-type changes, so no `make dashboard-check` needed)
- `make test-fast-parallel`: fails only on pre-existing machine-environment failures (live city state under /tmp, bead ga-xvmrwm) — the 5 known tests plus 7 more in the same no-city class (`TestCmdCityStatusJSONConfigErrorIsStructured`, `TestDoPrimeStrictNoCity`, `TestImportAddCommandIgnoresInheritedLiveEnv`, `TestImportAddCommandWorksInStandalonePackDir`, `TestRigAnywhere_ResolveContext`, `TestRunDashboardServeAllowsNoCityWithAPIOverride`, `TestRunDashboardServeAllowsNoCityWithSupervisor`), all verified failing identically on a pristine origin/main checkout on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)