### PR TITLE
fix(controller): cycle alive on_demand session on bead-reassign (#1893)

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -118,6 +118,7 @@ func buildAwakeInputFromReconciler(
 			RestartRequested:       strings.TrimSpace(b.Metadata["restart_requested"]) == "true",
 			ContinuationResetPending: strings.TrimSpace(b.Metadata["continuation_reset_pending"]) == "true" &&
 				strings.TrimSpace(b.Metadata[session.ResetCommittedAtKey]) != "",
+			CurrentlyProcessingBeadID: strings.TrimSpace(b.Metadata[session.CurrentBeadIDKey]),
 		}
 		bead.HeldUntil = lifecycle.HeldUntil
 		bead.QuarantinedUntil = lifecycle.QuarantinedUntil

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -55,26 +55,27 @@ type AwakeNamedSession struct {
 
 // AwakeSessionBead represents an open session bead from the store.
 type AwakeSessionBead struct {
-	ID                       string
-	SessionName              string
-	Template                 string
-	State                    string // "creating", "active", "asleep", "drained", "closed"
-	SleepReason              string
-	ManualSession            bool
-	PendingCreate            bool      // controller claimed this bead for initial start
-	ExplicitWake             bool      // explicit durable wake request is pending
-	DependencyOnly           bool      // only wakeable via dependency gate
-	NamedIdentity            string    // non-empty for named session beads
-	ConfiguredNamedSession   bool      // configured_named_session metadata is true
-	Pinned                   bool      // pin_awake durable wake reason
-	Drained                  bool      // state=="drained" or sleep_reason=="drained"
-	WaitHold                 bool      // user-issued gc wait in progress
-	HeldUntil                time.Time // zero = not held
-	QuarantinedUntil         time.Time // zero = not quarantined
-	IdleSince                time.Time // zero = unknown/not idle
-	CreatedAt                time.Time // bead creation time (for grace period checks)
-	RestartRequested         bool      // restart_requested metadata is still active
-	ContinuationResetPending bool      // continuation_reset_pending metadata is set
+	ID                        string
+	SessionName               string
+	Template                  string
+	State                     string // "creating", "active", "asleep", "drained", "closed"
+	SleepReason               string
+	ManualSession             bool
+	PendingCreate             bool      // controller claimed this bead for initial start
+	ExplicitWake              bool      // explicit durable wake request is pending
+	DependencyOnly            bool      // only wakeable via dependency gate
+	NamedIdentity             string    // non-empty for named session beads
+	ConfiguredNamedSession    bool      // configured_named_session metadata is true
+	Pinned                    bool      // pin_awake durable wake reason
+	Drained                   bool      // state=="drained" or sleep_reason=="drained"
+	WaitHold                  bool      // user-issued gc wait in progress
+	HeldUntil                 time.Time // zero = not held
+	QuarantinedUntil          time.Time // zero = not quarantined
+	IdleSince                 time.Time // zero = unknown/not idle
+	CreatedAt                 time.Time // bead creation time (for grace period checks)
+	RestartRequested          bool      // restart_requested metadata is still active
+	ContinuationResetPending  bool      // continuation_reset_pending metadata is set
+	CurrentlyProcessingBeadID string    // work bead the session is currently processing
 }
 
 // AwakeWorkBead represents a work bead with an assignee.
@@ -90,6 +91,17 @@ type AwakeDecision struct {
 	ShouldWake      bool
 	Reason          string // human-readable reason for debugging
 	HasAssignedWork bool   // underlying assigned-work demand before wake reason overrides
+	// AssignedWorkBeadID identifies the work bead that anchored the
+	// assigned-work decision for this session, when one applies. Callers
+	// use it to persist currently_processing_bead_id and to detect when an
+	// alive session has been reassigned to a different bead.
+	AssignedWorkBeadID string
+	// RequiresFreshCycle is true when an alive session's recorded
+	// currently_processing_bead_id differs from AssignedWorkBeadID. The
+	// reconciler combines this with wake_mode=fresh to trigger a
+	// restart-style cycle so the next wake starts a fresh conversation on
+	// the newly assigned bead.
+	RequiresFreshCycle bool
 }
 
 // ComputeAwakeSet determines which sessions should be awake.
@@ -268,7 +280,15 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	// ready open work assigned to it must stay awake. Open work must carry
 	// Ready=true so a blocked routed assignment cannot become wake demand if
 	// a future caller accidentally broadens the collection query.
-	assignedWorkDemand := make(map[string]bool)
+	//
+	// When the session bead records currently_processing_bead_id, prefer the
+	// matching work bead as the anchor so crash recovery brings a session
+	// back to the bead it last owned even when other beads share the
+	// assignee. If no candidate matches the recorded current bead, fall back
+	// to the first matching work bead and flag the divergence — the
+	// reconciler reads this to decide whether to cycle the conversation for
+	// wake_mode=fresh.
+	assignedAnchor := make(map[string]string) // sessionName → matched work bead ID
 	for _, bead := range input.SessionBeads {
 		if bead.State == "closed" {
 			continue
@@ -276,17 +296,39 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		if agent, ok := lookupAgent(bead.Template); ok && agent.Suspended {
 			continue
 		}
+		var (
+			fallback   string
+			haveExact  bool
+			anchorBead string
+			recorded   = bead.CurrentlyProcessingBeadID
+			matchedAny = false
+		)
 		for _, wb := range input.WorkBeads {
 			assignee := strings.TrimSpace(wb.Assignee)
 			if assignee == "" || !workBeadHasAwakeDemand(wb) {
 				continue
 			}
-			if sessionAssigneeMatches(input.NamedSessions, bead, assignee) {
-				assignedWorkDemand[bead.SessionName] = true
-				desired[bead.SessionName] = "assigned-work"
+			if !sessionAssigneeMatches(input.NamedSessions, bead, assignee) {
+				continue
+			}
+			matchedAny = true
+			if recorded != "" && wb.ID == recorded {
+				anchorBead = wb.ID
+				haveExact = true
 				break
 			}
+			if fallback == "" {
+				fallback = wb.ID
+			}
 		}
+		if !matchedAny {
+			continue
+		}
+		if !haveExact {
+			anchorBead = fallback
+		}
+		desired[bead.SessionName] = "assigned-work"
+		assignedAnchor[bead.SessionName] = anchorBead
 	}
 
 	// Min-active-sessions wake: keep min_active_sessions pool sessions warm
@@ -340,8 +382,15 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 
 	for _, bead := range input.SessionBeads {
 		name := bead.SessionName
+		anchor, hasAssignedWork := assignedAnchor[name]
 		decision := AwakeDecision{
-			HasAssignedWork: assignedWorkDemand[name],
+			HasAssignedWork: hasAssignedWork,
+		}
+		if hasAssignedWork {
+			decision.AssignedWorkBeadID = anchor
+			if bead.CurrentlyProcessingBeadID != "" && anchor != bead.CurrentlyProcessingBeadID {
+				decision.RequiresFreshCycle = true
+			}
 		}
 
 		// Desired set (demand-driven wake). wait_hold suppresses normal

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -2150,3 +2150,128 @@ func TestScaledPool_NotAffectedByRunningOverride(t *testing.T) {
 	})
 	assertAsleep(t, result, "polecat-mc-1")
 }
+
+// ---------------------------------------------------------------------------
+// currently_processing_bead_id divergence (#1893)
+// ---------------------------------------------------------------------------
+
+func TestAssignedWork_RecordsAnchorBeadID(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery",
+			State: "active", NamedIdentity: "hello-world/refinery",
+		}},
+		WorkBeads:       []AwakeWorkBead{{ID: "wb-77", Assignee: "hello-world/refinery", Status: "in_progress"}},
+		RunningSessions: map[string]bool{"hello-world--refinery": true},
+		Now:             now,
+	})
+	d := result["hello-world--refinery"]
+	if d.AssignedWorkBeadID != "wb-77" {
+		t.Fatalf("AssignedWorkBeadID = %q, want %q", d.AssignedWorkBeadID, "wb-77")
+	}
+	if d.RequiresFreshCycle {
+		t.Fatalf("RequiresFreshCycle = true, want false (no recorded current bead)")
+	}
+}
+
+func TestAssignedWork_SameAsCurrentBead_NoFreshCycle(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery",
+			State: "active", NamedIdentity: "hello-world/refinery",
+			CurrentlyProcessingBeadID: "wb-77",
+		}},
+		WorkBeads:       []AwakeWorkBead{{ID: "wb-77", Assignee: "hello-world/refinery", Status: "in_progress"}},
+		RunningSessions: map[string]bool{"hello-world--refinery": true},
+		Now:             now,
+	})
+	d := result["hello-world--refinery"]
+	if d.AssignedWorkBeadID != "wb-77" {
+		t.Fatalf("AssignedWorkBeadID = %q, want %q", d.AssignedWorkBeadID, "wb-77")
+	}
+	if d.RequiresFreshCycle {
+		t.Fatalf("RequiresFreshCycle = true, want false — recorded bead still anchors")
+	}
+}
+
+func TestAssignedWork_DifferentBead_EmitsFreshCycle(t *testing.T) {
+	// Patrol formula reassigned the witness from wb-1 to wb-2. Only wb-2 is
+	// visible to the reconciler (wb-1 was burned/closed). The recorded
+	// current bead no longer appears among the assigned work, so the new
+	// bead becomes the anchor and the divergence fires fresh-cycle.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "gascity/witness"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "gascity/witness", Template: "gascity/witness", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "gascity--witness", Template: "gascity/witness",
+			State: "active", NamedIdentity: "gascity/witness",
+			CurrentlyProcessingBeadID: "wb-1",
+		}},
+		WorkBeads:       []AwakeWorkBead{{ID: "wb-2", Assignee: "gascity/witness", Status: "in_progress"}},
+		RunningSessions: map[string]bool{"gascity--witness": true},
+		Now:             now,
+	})
+	d := result["gascity--witness"]
+	if d.AssignedWorkBeadID != "wb-2" {
+		t.Fatalf("AssignedWorkBeadID = %q, want %q", d.AssignedWorkBeadID, "wb-2")
+	}
+	if !d.RequiresFreshCycle {
+		t.Fatal("RequiresFreshCycle = false, want true — assigned bead differs from recorded current")
+	}
+}
+
+func TestAssignedWork_PrefersRecordedCurrentBeadOverOthers(t *testing.T) {
+	// Crash recovery: two work beads are assigned to the same session, and
+	// the bead recorded as the current one is among them. ComputeAwakeSet
+	// must pick the recorded bead as the anchor — otherwise the agent
+	// would restart on whichever bead happened to be listed first and
+	// abandon the work it was last actively processing.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "gascity/witness"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "gascity/witness", Template: "gascity/witness", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "gascity--witness", Template: "gascity/witness",
+			State: "asleep", NamedIdentity: "gascity/witness",
+			CurrentlyProcessingBeadID: "wb-current",
+		}},
+		WorkBeads: []AwakeWorkBead{
+			{ID: "wb-other", Assignee: "gascity/witness", Status: "open", Ready: true},
+			{ID: "wb-current", Assignee: "gascity/witness", Status: "open", Ready: true},
+		},
+		Now: now,
+	})
+	d := result["gascity--witness"]
+	if d.AssignedWorkBeadID != "wb-current" {
+		t.Fatalf("AssignedWorkBeadID = %q, want wb-current — recorded current bead must win the anchor selection", d.AssignedWorkBeadID)
+	}
+	if d.RequiresFreshCycle {
+		t.Fatal("RequiresFreshCycle = true, want false — recorded bead still in assigned set")
+	}
+}
+
+func TestAssignedWork_NoRecordedCurrent_FirstMatchAnchors(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "gascity/witness"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "gascity/witness", Template: "gascity/witness", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "gascity--witness", Template: "gascity/witness",
+			State: "asleep", NamedIdentity: "gascity/witness",
+		}},
+		WorkBeads: []AwakeWorkBead{
+			{ID: "wb-a", Assignee: "gascity/witness", Status: "in_progress"},
+			{ID: "wb-b", Assignee: "gascity/witness", Status: "in_progress"},
+		},
+		Now: now,
+	})
+	d := result["gascity--witness"]
+	if d.AssignedWorkBeadID != "wb-a" {
+		t.Fatalf("AssignedWorkBeadID = %q, want wb-a (first match when no current bead recorded)", d.AssignedWorkBeadID)
+	}
+	if d.RequiresFreshCycle {
+		t.Fatal("RequiresFreshCycle = true, want false — no recorded current means no divergence")
+	}
+}

--- a/cmd/gc/session_bead_cycle.go
+++ b/cmd/gc/session_bead_cycle.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// recordCurrentBeadIDOnWake persists the work bead a session is being woken
+// for. The reconciler writes this whenever a session is brought up (asleep
+// → awake or alive cycle) so that subsequent reconciler ticks can detect
+// when the assignee has been pointed at a different bead. The metadata
+// survives session restart, so crash recovery can resume the same bead
+// instead of jumping to a sibling assignment.
+func recordCurrentBeadIDOnWake(session *beads.Bead, store beads.Store, beadID string, stderr io.Writer) {
+	if session == nil || store == nil {
+		return
+	}
+	beadID = strings.TrimSpace(beadID)
+	if beadID == "" {
+		return
+	}
+	if session.Metadata[sessionpkg.CurrentBeadIDKey] == beadID {
+		return
+	}
+	if err := store.SetMetadata(session.ID, sessionpkg.CurrentBeadIDKey, beadID); err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "session reconciler: recording %s for %s: %v\n", sessionpkg.CurrentBeadIDKey, session.Metadata["session_name"], err) //nolint:errcheck
+		}
+		return
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string, 1)
+	}
+	session.Metadata[sessionpkg.CurrentBeadIDKey] = beadID
+}
+
+// cycleAliveSessionForFreshReassign tears down a live wake_mode=fresh
+// session whose assigned bead has changed, then primes the bead so the
+// next reconciler tick wakes the session on a brand-new conversation.
+// Returns true when the cycle ran; the caller must `continue` so it does
+// not double-process the drain/idle bookkeeping for a session it just
+// killed.
+//
+// The teardown path mirrors the agent-initiated restart handoff
+// (`gc runtime request-restart`): kill the process, reset the named-session
+// circuit breaker (a cycle is deliberate, not a crash — accumulated breaker
+// state must not block the post-cycle wake), optionally rotate session_key
+// for providers that accept --session-id, then apply RestartRequestPatch so
+// the next wake observes firstStart=true and uses the fresh-wake
+// conversation reset. We also update currently_processing_bead_id to the
+// new anchor so the divergence check does not refire on the next tick.
+func cycleAliveSessionForFreshReassign(
+	session *beads.Bead,
+	tp TemplateParams,
+	sp runtime.Provider,
+	store beads.Store,
+	cfg *config.City,
+	cb *sessionCircuitBreaker,
+	name string,
+	newBeadID string,
+	now time.Time,
+	stdout, stderr io.Writer,
+	trace *sessionReconcilerTraceCycle,
+) bool {
+	if session == nil || store == nil {
+		return false
+	}
+	newBeadID = strings.TrimSpace(newBeadID)
+	if newBeadID == "" {
+		return false
+	}
+	prevBeadID := strings.TrimSpace(session.Metadata[sessionpkg.CurrentBeadIDKey])
+	if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "session reconciler: stopping fresh-cycle %s: %v\n", name, err) //nolint:errcheck
+		}
+		return false
+	}
+	if identity := namedSessionIdentity(*session); identity != "" {
+		if err := resetSessionCircuitBreakerState(store, session.ID, identity, cb); err != nil {
+			if stderr != nil {
+				fmt.Fprintf(stderr, "session reconciler: clearing session circuit breaker for fresh-cycle %s: %v\n", name, err) //nolint:errcheck
+			}
+			return false
+		}
+	}
+	newSessionKey, hasCapability := freshRestartSessionKey(tp, session.Metadata)
+	batch := sessionpkg.RestartRequestPatch(newSessionKey, now)
+	if hasCapability && newSessionKey == "" {
+		batch["session_key"] = ""
+	}
+	batch[sessionpkg.CurrentBeadIDKey] = newBeadID
+	if err := store.SetMetadataBatch(session.ID, batch); err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "session reconciler: recording fresh-cycle handoff for %s: %v\n", name, err) //nolint:errcheck
+		}
+		return false
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string, len(batch))
+	}
+	for key, value := range batch {
+		// The durable reset commit marker is for the next reconciler
+		// pass; keeping it out of this tick's in-memory bead mirrors the
+		// restart-requested handoff above so on-demand sessions are not
+		// force-woken without demand within the same tick.
+		if key == sessionpkg.ResetCommittedAtKey {
+			continue
+		}
+		session.Metadata[key] = value
+	}
+	if stdout != nil {
+		fmt.Fprintf(stdout, "Cycled fresh-mode session '%s' for bead reassign: %s → %s\n", name, prevBeadID, newBeadID) //nolint:errcheck
+	}
+	if trace != nil {
+		trace.recordDecision("reconciler.session.bead_reassign_cycle", tp.TemplateName, name, "fresh_cycle", "restart", traceRecordPayload{
+			"previous_bead_id": prevBeadID,
+			"new_bead_id":      newBeadID,
+		}, nil, "")
+	}
+	return true
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2361,6 +2361,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					"should_wake": shouldWake,
 				}, nil, "")
 			}
+			recordCurrentBeadIDOnWake(target.session, store, decision.AssignedWorkBeadID, stderr)
 			startCandidates = append(startCandidates, startCandidate{
 				session: target.session,
 				tp:      target.tp,
@@ -2369,6 +2370,24 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 
 		if shouldWake && target.alive {
+			// Bead-reassignment cycle: when an alive named session is
+			// reassigned to a different bead than the one it's currently
+			// processing, wake_mode=fresh requires a brand-new conversation
+			// on the new bead. ComputeAwakeSet signals this via
+			// RequiresFreshCycle; honor it by routing through the same
+			// restart-handoff machinery as `gc runtime request-restart`.
+			// See #1893 (controller: alive on_demand session ignores
+			// bd update --assignee).
+			if decision.RequiresFreshCycle && target.session.Metadata["wake_mode"] == "fresh" {
+				if cycleAliveSessionForFreshReassign(target.session, target.tp, sp, store, cfg, cb, name, decision.AssignedWorkBeadID, clk.Now(), stdout, stderr, trace) {
+					continue
+				}
+			}
+			// Stamp currently_processing_bead_id so the next divergence
+			// check has a baseline. Backfills legacy sessions that were
+			// already alive before this metadata existed and refreshes the
+			// record after the agent picks up its next bead in resume mode.
+			recordCurrentBeadIDOnWake(target.session, store, decision.AssignedWorkBeadID, stderr)
 			// Session is correctly awake. Cancel any non-drift drain
 			// (handles scale-back-up: agent returns to desired set while draining).
 			cancelSessionDrain(*target.session, sp, dt)

--- a/cmd/gc/session_reconciler_bead_reassign_test.go
+++ b/cmd/gc/session_reconciler_bead_reassign_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// TestReconcileSessionBeads_AliveFreshModeReassignCyclesConversation verifies
+// the fix for gastownhall/gascity#1893: an alive on_demand named session
+// running wake_mode=fresh must cycle its conversation when bd update points
+// the assignee at a new bead. The session keeps the same bead identifier in
+// the store (it's a named session) but its conversation lineage is reset so
+// the next wake starts fresh on the newly assigned bead.
+func TestReconcileSessionBeads_AliveFreshModeReassignCyclesConversation(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "witness", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "witness", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "witness")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "witness",
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "witness",
+		namedSessionModeMetadata:     "on_demand",
+		"template":                   "witness",
+		"state":                      "active",
+		"wake_mode":                  "fresh",
+		"session_key":                "conversation-A",
+		sessionpkg.CurrentBeadIDKey:  "wb-A",
+	})
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := env.sp.SetMeta(sessionName, "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	// Patrol formula poured wb-B and pointed the witness's assignee at it;
+	// wb-A is gone (closed/burned), so the reconciler only sees wb-B.
+	workBead := beads.Bead{ID: "wb-B", Title: "next witness wisp", Type: "task", Status: "in_progress", Assignee: "witness"}
+
+	reconcileSessionBeadsWithAssignedWork(env, []beads.Bead{session}, []beads.Bead{workBead})
+
+	if env.sp.IsRunning(sessionName) {
+		t.Fatal("session should have been killed by fresh-cycle")
+	}
+	got, _ := env.store.Get(session.ID)
+	if got.Metadata[sessionpkg.CurrentBeadIDKey] != "wb-B" {
+		t.Fatalf("%s = %q, want wb-B", sessionpkg.CurrentBeadIDKey, got.Metadata[sessionpkg.CurrentBeadIDKey])
+	}
+	if got.Metadata["started_config_hash"] != "" {
+		t.Fatalf("started_config_hash = %q, want empty so the next wake takes the first-start path", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want true", got.Metadata["continuation_reset_pending"])
+	}
+	if got.Metadata["session_key"] == "" || got.Metadata["session_key"] == "conversation-A" {
+		t.Fatalf("session_key = %q, want rotated key", got.Metadata["session_key"])
+	}
+}
+
+// TestReconcileSessionBeads_AliveResumeModeReassignKeepsConversation verifies
+// that wake_mode=resume sessions DO NOT cycle on bead reassign — the
+// existing conversation is preserved and the agent picks up the new bead
+// from its work query at its next prompt boundary.
+func TestReconcileSessionBeads_AliveResumeModeReassignKeepsConversation(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "witness", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "witness", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "witness")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "witness",
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "witness",
+		namedSessionModeMetadata:     "on_demand",
+		"template":                   "witness",
+		"state":                      "active",
+		// wake_mode unset (default = resume)
+		"session_key":               "conversation-A",
+		sessionpkg.CurrentBeadIDKey: "wb-A",
+	})
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := env.sp.SetMeta(sessionName, "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	workBead := beads.Bead{ID: "wb-B", Title: "next witness wisp", Type: "task", Status: "in_progress", Assignee: "witness"}
+
+	reconcileSessionBeadsWithAssignedWork(env, []beads.Bead{session}, []beads.Bead{workBead})
+
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatal("resume-mode session should still be running — divergence must not cycle non-fresh sessions")
+	}
+	got, _ := env.store.Get(session.ID)
+	if got.Metadata["session_key"] != "conversation-A" {
+		t.Fatalf("session_key = %q, want conversation-A preserved", got.Metadata["session_key"])
+	}
+	if got.Metadata["continuation_reset_pending"] == "true" {
+		t.Fatalf("continuation_reset_pending = true, want unset for resume mode (no cycle should have run)")
+	}
+}
+
+// TestReconcileSessionBeads_AsleepWakeRecordsCurrentBead pins the recording
+// half of the contract: when an asleep session is woken because of an
+// assigned bead, the reconciler must stamp currently_processing_bead_id
+// onto the session bead. Without this, the next reassign cycle would have
+// no recorded current bead to compare against.
+func TestReconcileSessionBeads_AsleepWakeRecordsCurrentBead(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "witness", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "witness", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "witness")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "witness",
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "witness",
+		namedSessionModeMetadata:     "on_demand",
+		"template":                   "witness",
+		"state":                      "asleep",
+		"wake_mode":                  "fresh",
+	})
+
+	workBead := beads.Bead{ID: "wb-77", Title: "witness wisp", Type: "task", Status: "in_progress", Assignee: "witness"}
+
+	reconcileSessionBeadsWithAssignedWork(env, []beads.Bead{session}, []beads.Bead{workBead})
+
+	got, _ := env.store.Get(session.ID)
+	if got.Metadata[sessionpkg.CurrentBeadIDKey] != "wb-77" {
+		t.Fatalf("%s = %q, want wb-77 recorded at wake", sessionpkg.CurrentBeadIDKey, got.Metadata[sessionpkg.CurrentBeadIDKey])
+	}
+}
+
+// TestReconcileSessionBeads_RecoveryPrefersRecordedBead pins crash-recovery
+// behavior: when a session is asleep with a recorded current bead AND
+// multiple beads are assigned, the reconciler must anchor on the recorded
+// bead so the agent resumes the work it was last actively processing.
+func TestReconcileSessionBeads_RecoveryPrefersRecordedBead(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "witness", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "witness", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "witness")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "witness",
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "witness",
+		namedSessionModeMetadata:     "on_demand",
+		"template":                   "witness",
+		"state":                      "asleep",
+		"wake_mode":                  "fresh",
+		sessionpkg.CurrentBeadIDKey:  "wb-current",
+	})
+
+	other := beads.Bead{ID: "wb-other", Title: "other wisp", Type: "task", Status: "open", Assignee: "witness"}
+	current := beads.Bead{ID: "wb-current", Title: "current wisp", Type: "task", Status: "in_progress", Assignee: "witness"}
+
+	reconcileSessionBeadsWithAssignedWork(env, []beads.Bead{session}, []beads.Bead{other, current})
+
+	got, _ := env.store.Get(session.ID)
+	if got.Metadata[sessionpkg.CurrentBeadIDKey] != "wb-current" {
+		t.Fatalf("%s = %q, want wb-current preserved across restart", sessionpkg.CurrentBeadIDKey, got.Metadata[sessionpkg.CurrentBeadIDKey])
+	}
+}
+
+// reconcileSessionBeadsWithAssignedWork is a test-only wrapper that mirrors
+// restartRequestTestEnv.reconcile but threads assignedWorkBeads through so
+// ComputeAwakeSet sees the work demand. Tests for assigned-work-driven
+// behavior need this hook; the existing helper in
+// session_reconciler_restart_request_test.go intentionally passes nil.
+func reconcileSessionBeadsWithAssignedWork(env *restartRequestTestEnv, sessions []beads.Bead, assignedWork []beads.Bead) {
+	poolDesired := make(map[string]int)
+	for _, tp := range env.desiredState {
+		if tp.TemplateName != "" {
+			poolDesired[tp.TemplateName]++
+		}
+	}
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	_ = reconcileSessionBeads(
+		context.Background(),
+		sessions,
+		env.desiredState,
+		cfgNames,
+		env.cfg,
+		env.sp,
+		env.store,
+		nil,
+		assignedWork,
+		nil,
+		env.dt,
+		poolDesired,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+}

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -5,6 +5,13 @@ import (
 	"time"
 )
 
+// CurrentBeadIDKey records the work bead a session is currently processing.
+// The reconciler writes it whenever a session is brought up for a specific
+// work bead. ComputeAwakeSet uses it to detect when an alive session has been
+// reassigned to a different bead — the trigger for a fresh-wake conversation
+// cycle under wake_mode=fresh.
+const CurrentBeadIDKey = "currently_processing_bead_id"
+
 var freshWakeConversationResetKeys = []string{
 	"session_key",
 	"started_config_hash",


### PR DESCRIPTION
## Fixes #1893

Re-lands the option-A approach from #2610 (closed unmerged after the branch drifted; original by @brandonmartin), ported onto current `main`.

## Problem

An alive named on_demand session with `wake_mode = "fresh"` ignores `bd update --assignee` pointing it at a new bead. `ComputeAwakeSet` keeps the session in the desired set — `"assigned-work"` is indifferent to which bead is current — and the fresh-wake reset fires only on sleep→awake transitions, so the session keeps the previous bead's conversation and the reassignment is never surfaced.

## Fix

Track the bead a session is currently processing in session metadata (`currently_processing_bead_id`).

- `ComputeAwakeSet` prefers the recorded bead as the assigned-work anchor — crash recovery brings a session back to the bead it last owned rather than an arbitrary sibling — and flags `RequiresFreshCycle` when the anchor diverges from the recorded bead.
- The reconciler honors the flag for `wake_mode = "fresh"` sessions by routing through the same teardown as `gc runtime request-restart`: kill, reset the named-session circuit breaker, rotate `session_key` where the provider supports it, apply `RestartRequestPatch`, and stamp the new bead id so the divergence check does not refire.
- `wake_mode = "resume"` sessions continue uninterrupted.

## Port notes (what changed vs #2610)

- `RestartRequestPatch` two-arg form; the `reset_committed_at` stamp it now writes makes the post-cycle re-wake durable through the reset-pending pass.
- Mirrors the restart-requested handoff's deliberate skip of `reset_committed_at` when copying the patch into the current tick's in-memory bead, so on-demand sessions are not force-woken without demand within the same tick.
- Mirrors the restart path's circuit-breaker reset — a cycle is deliberate, not a crash; accumulated breaker state must not block the post-cycle wake.
- Anchor decisions key off a dedicated `assignedAnchor` map populated inside the assigned-work pass; `desired[name]` can now be overwritten by the later reset-pending and min-active passes, so `HasAssignedWork` derives from the anchor map rather than the final desired reason.
- The assigned-work loop keeps `lookupAgent` rig-scoped base-name resolution for the suspended check.
- The `mol-refinery-patrol.toml` hunks from the original branch are excluded — they belong to an unrelated refinery fix, and that formula's public home is now `gastownhall/gascity-packs`.

## Test coverage

- `cmd/gc/compute_awake_set_test.go` — anchor preference, divergence flagging, and recorded-bead recovery (5 new tests).
- `cmd/gc/session_reconciler_bead_reassign_test.go` — full reconciler flow: fresh-mode reassign cycles, resume-mode reassign stays, asleep wake records the current bead, recovery prefers the recorded bead (4 new tests).
- Validation on this branch: `go build ./...` clean, `go vet ./cmd/gc` clean, full `go test ./cmd/gc` (403s) and `./internal/session` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
