### PR TITLE
fix(dispatch): project drain member dependencies

### DIFF
--- a/engdocs/drain-fanout.md
+++ b/engdocs/drain-fanout.md
@@ -114,6 +114,26 @@ Depends on `on_item_failure`:
   with a partial-success outcome after all items finish.
 - `"skip_remaining"` — no new items start after the first failure.
 
+**Q: Do drain items respect dependencies between convoy members?**
+
+Yes. New drains materialize members in dependency order, and a member that
+depends on another in-manifest member gets its item workflow blocked on that
+blocker's item-workflow root from creation time. Dependencies on beads outside
+the drain manifest are embedded as-is and represent genuine waits.
+
+Two upgrade-path caveats for drain manifests persisted before dependency
+ordering existed:
+
+- Enforcement is best-effort: in separate context a dependent item can start
+  inside a bounded window before the projection sweep wires its blocker edge;
+  in shared context a dependent-first legacy manifest order runs the dependent
+  before its blocker, permanently for that drain (the pre-ordering concurrency
+  semantics).
+- A drain stalled by an intermediate pre-fix build that embedded raw
+  source-member dependency edges does not heal automatically. Run
+  `gc convoy control <drain-id>` once; the control pass repairs the embedded
+  edges and the drain resumes.
+
 **Q: Is there a `max_units` limit?**
 
 In v0, `max_units` must be between 1 and 100. If unset, the drain expands

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -126,7 +126,11 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 		}
 
 		if row.ItemRootID == "" {
-			rootID, created, err := ensureDrainItemRoot(store, bead, unit, member, len(members), row, itemFormula, parentVars, opts)
+			blockerIDs, err := drainProjectedBlockerIDs(store, member.ID, drainRootByMember(manifest))
+			if err != nil {
+				return ControlResult{}, fmt.Errorf("%s: listing source dependencies for member %s: %w", bead.ID, member.ID, err)
+			}
+			rootID, created, err := ensureDrainItemRoot(store, bead, unit, member, len(members), row, itemFormula, parentVars, blockerIDs, opts)
 			if err != nil {
 				if errors.Is(err, errDrainInvalidItemFormula) {
 					return closeDrainItemFormulaFailure(store, bead, manifest, err)
@@ -144,6 +148,12 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: wiring drain item root %s: %w", bead.ID, row.ItemRootID, err)
+		}
+		if err := ensureDrainRowDependencyProjection(store, bead, manifest, member.ID, row.ItemRootID); err != nil {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
+				return ControlResult{}, ErrControlPending
+			}
+			return ControlResult{}, fmt.Errorf("%s: projecting drain dependencies for member %s: %w", bead.ID, member.ID, err)
 		}
 		row.Status = "wired"
 		if err := persistDrainManifest(store, bead.ID, manifest, map[string]string{beadmeta.DrainStateMetadataKey: "expanding"}); err != nil {
@@ -398,7 +408,7 @@ func advanceSharedDrain(store beads.Store, bead beads.Bead, manifest drainManife
 		if err := reserveDrainMember(store, bead, member); err != nil {
 			return closeDrainReservationFailure(store, bead, manifest, err)
 		}
-		created, err := materializeDrainRow(store, bead, manifest.ParentConvoyID, members, row, member, itemFormula, parentVars, opts)
+		created, err := materializeDrainRow(store, bead, manifest, members, row, member, itemFormula, parentVars, opts)
 		if err != nil {
 			if errors.Is(err, errDrainInvalidItemFormula) {
 				return closeDrainItemFormulaFailure(store, bead, manifest, err)
@@ -426,11 +436,11 @@ func advanceSharedDrain(store beads.Store, bead beads.Bead, manifest drainManife
 	return closeDrainWithManifest(store, bead.ID, manifest, "succeeded", "pass", "drain-succeeded")
 }
 
-func materializeDrainRow(store beads.Store, control beads.Bead, parentConvoyID string, members []beads.Bead, row *drainManifestRow, member beads.Bead, itemFormula string, parentVars map[string]string, opts ProcessOptions) (int, error) {
+func materializeDrainRow(store beads.Store, control beads.Bead, manifest drainManifest, members []beads.Bead, row *drainManifestRow, member beads.Bead, itemFormula string, parentVars map[string]string, opts ProcessOptions) (int, error) {
 	createdCount := 0
 	var unit beads.Bead
 	if row.UnitConvoyID == "" {
-		createdUnit, created, err := ensureDrainUnitConvoy(store, control, parentConvoyID, len(members), *row, member)
+		createdUnit, created, err := ensureDrainUnitConvoy(store, control, manifest.ParentConvoyID, len(members), *row, member)
 		if err != nil {
 			return 0, err
 		}
@@ -448,7 +458,11 @@ func materializeDrainRow(store beads.Store, control beads.Bead, parentConvoyID s
 		unit = reloaded
 	}
 	if row.ItemRootID == "" {
-		rootID, created, err := ensureDrainItemRoot(store, control, unit, member, len(members), row, itemFormula, parentVars, opts)
+		blockerIDs, err := drainProjectedBlockerIDs(store, member.ID, drainRootByMember(manifest))
+		if err != nil {
+			return 0, fmt.Errorf("%s: listing source dependencies for member %s: %w", control.ID, member.ID, err)
+		}
+		rootID, created, err := ensureDrainItemRoot(store, control, unit, member, len(members), row, itemFormula, parentVars, blockerIDs, opts)
 		if err != nil {
 			return 0, err
 		}
@@ -464,11 +478,47 @@ func materializeDrainRow(store beads.Store, control beads.Bead, parentConvoyID s
 		}
 		return 0, fmt.Errorf("%s: wiring drain item root %s: %w", control.ID, row.ItemRootID, err)
 	}
+	if err := ensureDrainRowDependencyProjection(store, control, manifest, member.ID, row.ItemRootID); err != nil {
+		if controllerSpawnBoundaryPending(store, control.ID, err, opts) {
+			return 0, ErrControlPending
+		}
+		return 0, fmt.Errorf("%s: projecting drain dependencies for member %s: %w", control.ID, member.ID, err)
+	}
 	row.Status = "wired"
 	return createdCount, nil
 }
 
 func ensureDrainDependencyProjection(store beads.Store, control beads.Bead, manifest drainManifest) error {
+	for _, row := range manifest.Rows {
+		memberID := strings.TrimSpace(row.MemberID)
+		rootID := strings.TrimSpace(row.ItemRootID)
+		if memberID == "" || rootID == "" {
+			continue
+		}
+		if err := ensureDrainRowDependencyProjection(store, control, manifest, memberID, rootID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureDrainRowDependencyProjection(store beads.Store, control beads.Bead, manifest drainManifest, memberID, rootID string) error {
+	blockerIDs, err := drainProjectedBlockerIDs(store, memberID, drainRootByMember(manifest))
+	if err != nil {
+		return fmt.Errorf("%s: listing source dependencies for member %s: %w", control.ID, memberID, err)
+	}
+	for _, blockerID := range blockerIDs {
+		if blockerID == rootID {
+			continue
+		}
+		if err := ensureDrainWorkflowBlocksOn(store, rootID, blockerID); err != nil {
+			return fmt.Errorf("%s: wiring item workflow %s for member %s to blocker %s: %w", control.ID, rootID, memberID, blockerID, err)
+		}
+	}
+	return nil
+}
+
+func drainRootByMember(manifest drainManifest) map[string]string {
 	rootByMember := make(map[string]string, len(manifest.Rows))
 	for _, row := range manifest.Rows {
 		memberID := strings.TrimSpace(row.MemberID)
@@ -478,26 +528,7 @@ func ensureDrainDependencyProjection(store beads.Store, control beads.Bead, mani
 		}
 		rootByMember[memberID] = rootID
 	}
-	for _, row := range manifest.Rows {
-		memberID := strings.TrimSpace(row.MemberID)
-		rootID := strings.TrimSpace(row.ItemRootID)
-		if memberID == "" || rootID == "" {
-			continue
-		}
-		blockerIDs, err := drainProjectedBlockerIDs(store, memberID, rootByMember)
-		if err != nil {
-			return fmt.Errorf("%s: listing source dependencies for member %s: %w", control.ID, memberID, err)
-		}
-		for _, blockerID := range blockerIDs {
-			if blockerID == rootID {
-				continue
-			}
-			if err := ensureDrainWorkflowBlocksOn(store, rootID, blockerID); err != nil {
-				return fmt.Errorf("%s: wiring item workflow %s for member %s to blocker %s: %w", control.ID, rootID, memberID, blockerID, err)
-			}
-		}
-	}
-	return nil
+	return rootByMember
 }
 
 func drainProjectedBlockerIDs(store beads.Store, memberID string, rootByMember map[string]string) ([]string, error) {
@@ -699,7 +730,7 @@ func trackDrainMember(store beads.Store, unitConvoyID string, member beads.Bead)
 	return convoycore.TrackItem(store, unitConvoyID, member.ID)
 }
 
-func ensureDrainItemRoot(store beads.Store, control, unit, member beads.Bead, count int, row *drainManifestRow, itemFormula string, parentVars map[string]string, opts ProcessOptions) (string, bool, error) {
+func ensureDrainItemRoot(store beads.Store, control, unit, member beads.Bead, count int, row *drainManifestRow, itemFormula string, parentVars map[string]string, blockerIDs []string, opts ProcessOptions) (string, bool, error) {
 	unlock := graphv2.LockKey(row.ItemRootKey)
 	defer unlock()
 	if err := closeFailedDrainItemRoots(store, control.ID, row.ItemRootKey); err != nil {
@@ -749,6 +780,7 @@ func ensureDrainItemRoot(store beads.Store, control, unit, member beads.Bead, co
 	}
 	result, err := molecule.Instantiate(context.Background(), store, recipe, molecule.Options{
 		Vars:             runtimeVars,
+		ExternalDeps:     drainWorkflowExternalDeps(recipe, blockerIDs),
 		PriorityOverride: member.Priority,
 	})
 	if err != nil {
@@ -761,6 +793,37 @@ func ensureDrainItemRoot(store beads.Store, control, unit, member beads.Bead, co
 		return "", false, fmt.Errorf("%s: instantiating drain item formula %q: %w", control.ID, itemFormula, err)
 	}
 	return result.RootID, true, nil
+}
+
+func drainWorkflowExternalDeps(recipe *formula.Recipe, blockerIDs []string) []molecule.ExternalDep {
+	if recipe == nil || len(recipe.Steps) == 0 || len(blockerIDs) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(recipe.Steps)*len(blockerIDs))
+	deps := make([]molecule.ExternalDep, 0, len(recipe.Steps)*len(blockerIDs))
+	for _, step := range recipe.Steps {
+		stepID := strings.TrimSpace(step.ID)
+		if stepID == "" {
+			continue
+		}
+		for _, blockerID := range blockerIDs {
+			blockerID = strings.TrimSpace(blockerID)
+			if blockerID == "" {
+				continue
+			}
+			key := stepID + "\x00" + blockerID
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			deps = append(deps, molecule.ExternalDep{
+				StepID:      stepID,
+				DependsOnID: blockerID,
+				Type:        "blocks",
+			})
+		}
+	}
+	return deps
 }
 
 func drainItemRuntimeVars(recipe *formula.Recipe, vars map[string]string) map[string]string {

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -236,7 +236,11 @@ func loadOrBuildDrainManifest(store beads.Store, bead beads.Bead, parentConvoyID
 		}
 		return drainManifest{}, nil, errDrainLimitExceeded
 	}
-	return buildDrainManifest(bead, parentConvoyID, itemFormula, members), members, nil
+	orderedMembers, err := orderDrainMembersByDependencies(store, members)
+	if err != nil {
+		return drainManifest{}, nil, fmt.Errorf("%s: ordering drain members for %s: %w", bead.ID, parentConvoyID, err)
+	}
+	return buildDrainManifest(bead, parentConvoyID, itemFormula, orderedMembers), orderedMembers, nil
 }
 
 var (
@@ -667,6 +671,82 @@ func buildDrainManifest(bead beads.Bead, parentConvoyID, itemFormula string, mem
 		})
 	}
 	return drainManifest{Version: 1, Context: context, ParentConvoyID: parentConvoyID, Formula: itemFormula, Rows: rows}
+}
+
+func orderDrainMembersByDependencies(store beads.Store, members []beads.Bead) ([]beads.Bead, error) {
+	if len(members) < 2 {
+		return members, nil
+	}
+	memberByID := make(map[string]beads.Bead, len(members))
+	for _, member := range members {
+		memberID := strings.TrimSpace(member.ID)
+		if memberID == "" {
+			continue
+		}
+		memberByID[memberID] = member
+	}
+	blockersByMember := make(map[string]map[string]bool, len(members))
+	for _, member := range members {
+		memberID := strings.TrimSpace(member.ID)
+		if memberID == "" {
+			continue
+		}
+		deps, err := store.DepList(memberID, "down")
+		if err != nil {
+			return nil, fmt.Errorf("listing source dependencies for member %s: %w", memberID, err)
+		}
+		for _, dep := range deps {
+			if !beads.IsReadyBlockingDependencyType(dep.Type) {
+				continue
+			}
+			blockerID := strings.TrimSpace(dep.DependsOnID)
+			if blockerID == "" || blockerID == memberID {
+				continue
+			}
+			if _, ok := memberByID[blockerID]; !ok {
+				continue
+			}
+			if blockersByMember[memberID] == nil {
+				blockersByMember[memberID] = make(map[string]bool)
+			}
+			blockersByMember[memberID][blockerID] = true
+		}
+	}
+	ordered := make([]beads.Bead, 0, len(members))
+	emitted := make(map[string]bool, len(members))
+	for len(ordered) < len(members) {
+		progressed := false
+		for _, member := range members {
+			memberID := strings.TrimSpace(member.ID)
+			if emitted[memberID] {
+				continue
+			}
+			blocked := false
+			for blockerID := range blockersByMember[memberID] {
+				if !emitted[blockerID] {
+					blocked = true
+					break
+				}
+			}
+			if blocked {
+				continue
+			}
+			ordered = append(ordered, member)
+			emitted[memberID] = true
+			progressed = true
+		}
+		if !progressed {
+			cycleMembers := make([]string, 0, len(members)-len(ordered))
+			for _, member := range members {
+				memberID := strings.TrimSpace(member.ID)
+				if memberID != "" && !emitted[memberID] {
+					cycleMembers = append(cycleMembers, memberID)
+				}
+			}
+			return nil, fmt.Errorf("source dependency cycle among drain members: %s", strings.Join(cycleMembers, ", "))
+		}
+	}
+	return ordered, nil
 }
 
 func ensureDrainUnitConvoy(store beads.Store, control beads.Bead, parentConvoyID string, count int, row drainManifestRow, member beads.Bead) (beads.Bead, bool, error) {

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -150,6 +150,12 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 			return ControlResult{}, fmt.Errorf("%s: recording drain progress: %w", bead.ID, err)
 		}
 	}
+	if err := ensureDrainDependencyProjection(store, bead, manifest); err != nil {
+		if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
+			return ControlResult{}, ErrControlPending
+		}
+		return ControlResult{}, fmt.Errorf("%s: projecting drain dependencies: %w", bead.ID, err)
+	}
 	if err := persistDrainManifest(store, bead.ID, manifest, map[string]string{
 		beadmeta.DrainStateMetadataKey:          "expanded",
 		beadmeta.DrainParentConvoyIDMetadataKey: parentConvoyID,
@@ -399,6 +405,12 @@ func advanceSharedDrain(store beads.Store, bead beads.Bead, manifest drainManife
 			}
 			return ControlResult{}, err
 		}
+		if err := ensureDrainDependencyProjection(store, bead, manifest); err != nil {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
+				return ControlResult{}, ErrControlPending
+			}
+			return ControlResult{}, fmt.Errorf("%s: projecting shared drain dependencies: %w", bead.ID, err)
+		}
 		if err := persistDrainManifest(store, bead.ID, manifest, map[string]string{
 			beadmeta.DrainStateMetadataKey:          "expanded",
 			beadmeta.DrainParentConvoyIDMetadataKey: manifest.ParentConvoyID,
@@ -454,6 +466,87 @@ func materializeDrainRow(store beads.Store, control beads.Bead, parentConvoyID s
 	}
 	row.Status = "wired"
 	return createdCount, nil
+}
+
+func ensureDrainDependencyProjection(store beads.Store, control beads.Bead, manifest drainManifest) error {
+	rootByMember := make(map[string]string, len(manifest.Rows))
+	for _, row := range manifest.Rows {
+		memberID := strings.TrimSpace(row.MemberID)
+		rootID := strings.TrimSpace(row.ItemRootID)
+		if memberID == "" || rootID == "" {
+			continue
+		}
+		rootByMember[memberID] = rootID
+	}
+	for _, row := range manifest.Rows {
+		memberID := strings.TrimSpace(row.MemberID)
+		rootID := strings.TrimSpace(row.ItemRootID)
+		if memberID == "" || rootID == "" {
+			continue
+		}
+		blockerIDs, err := drainProjectedBlockerIDs(store, memberID, rootByMember)
+		if err != nil {
+			return fmt.Errorf("%s: listing source dependencies for member %s: %w", control.ID, memberID, err)
+		}
+		for _, blockerID := range blockerIDs {
+			if blockerID == rootID {
+				continue
+			}
+			if err := ensureDrainWorkflowBlocksOn(store, rootID, blockerID); err != nil {
+				return fmt.Errorf("%s: wiring item workflow %s for member %s to blocker %s: %w", control.ID, rootID, memberID, blockerID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func drainProjectedBlockerIDs(store beads.Store, memberID string, rootByMember map[string]string) ([]string, error) {
+	deps, err := store.DepList(memberID, "down")
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(deps))
+	blockerIDs := make([]string, 0, len(deps))
+	for _, dep := range deps {
+		if !beads.IsReadyBlockingDependencyType(dep.Type) {
+			continue
+		}
+		dependsOnID := strings.TrimSpace(dep.DependsOnID)
+		if dependsOnID == "" || dependsOnID == memberID {
+			continue
+		}
+		blockerID := dependsOnID
+		if projectedRootID := strings.TrimSpace(rootByMember[dependsOnID]); projectedRootID != "" {
+			blockerID = projectedRootID
+		}
+		if seen[blockerID] {
+			continue
+		}
+		seen[blockerID] = true
+		blockerIDs = append(blockerIDs, blockerID)
+	}
+	return blockerIDs, nil
+}
+
+func ensureDrainWorkflowBlocksOn(store beads.Store, rootID, blockerID string) error {
+	rootID = strings.TrimSpace(rootID)
+	blockerID = strings.TrimSpace(blockerID)
+	if rootID == "" || blockerID == "" || rootID == blockerID {
+		return nil
+	}
+	workflowBeads, err := listByWorkflowRoot(store, rootID)
+	if err != nil {
+		return err
+	}
+	for _, bead := range workflowBeads {
+		if strings.TrimSpace(bead.ID) == "" || bead.ID == blockerID {
+			continue
+		}
+		if err := ensureBlockingDependency(store, bead.ID, blockerID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func recordDrainRowOutcome(row *drainManifestRow, root beads.Bead) bool {

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -126,7 +126,7 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 		}
 
 		if row.ItemRootID == "" {
-			blockerIDs, err := drainProjectedBlockerIDs(store, member.ID, drainRootByMember(manifest))
+			blockerIDs, err := drainProjectedBlockerIDs(store, member.ID, manifest)
 			if err != nil {
 				return ControlResult{}, fmt.Errorf("%s: listing source dependencies for member %s: %w", bead.ID, member.ID, err)
 			}
@@ -312,6 +312,15 @@ func completeDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		}
 		return advanceSharedDrain(store, bead, manifest, members, manifest.Formula, parentVars, opts)
 	}
+	// Re-running the projection here lets manifests whose item workflows were
+	// wired to source members by earlier builds heal while the drain waits on
+	// open item roots; expansion never revisits an expanded drain.
+	if err := ensureDrainDependencyProjection(store, bead, manifest); err != nil {
+		if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
+			return ControlResult{}, ErrControlPending
+		}
+		return ControlResult{}, fmt.Errorf("%s: repairing drain dependency projection: %w", bead.ID, err)
+	}
 	if strings.TrimSpace(bead.Metadata[beadmeta.DrainStateMetadataKey]) != "completing" {
 		if err := store.SetMetadata(bead.ID, beadmeta.DrainStateMetadataKey, "completing"); err != nil {
 			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
@@ -382,6 +391,16 @@ func completeDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 func advanceSharedDrain(store beads.Store, bead beads.Bead, manifest drainManifest, members []beads.Bead, itemFormula string, parentVars map[string]string, opts ProcessOptions) (ControlResult, error) {
 	if len(manifest.Rows) == 0 {
 		return closeDrainWithManifest(store, bead.ID, manifest, "succeeded", "pass", "drain-succeeded")
+	}
+	// Repair materialized rows before waiting on them: a row wired to a
+	// source member by an earlier build never closes (drains do not close
+	// source members), and in shared mode its blocker row is not even
+	// materialized until this row's root closes.
+	if err := ensureDrainDependencyProjection(store, bead, manifest); err != nil {
+		if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
+			return ControlResult{}, ErrControlPending
+		}
+		return ControlResult{}, fmt.Errorf("%s: repairing shared drain dependency projection: %w", bead.ID, err)
 	}
 	onItemFailure := drainOnItemFailure(bead)
 	for i := range manifest.Rows {
@@ -462,7 +481,7 @@ func materializeDrainRow(store beads.Store, control beads.Bead, manifest drainMa
 		unit = reloaded
 	}
 	if row.ItemRootID == "" {
-		blockerIDs, err := drainProjectedBlockerIDs(store, member.ID, drainRootByMember(manifest))
+		blockerIDs, err := drainProjectedBlockerIDs(store, member.ID, manifest)
 		if err != nil {
 			return 0, fmt.Errorf("%s: listing source dependencies for member %s: %w", control.ID, member.ID, err)
 		}
@@ -507,7 +526,7 @@ func ensureDrainDependencyProjection(store beads.Store, control beads.Bead, mani
 }
 
 func ensureDrainRowDependencyProjection(store beads.Store, control beads.Bead, manifest drainManifest, memberID, rootID string) error {
-	blockerIDs, err := drainProjectedBlockerIDs(store, memberID, drainRootByMember(manifest))
+	blockerIDs, err := drainProjectedBlockerIDs(store, memberID, manifest)
 	if err != nil {
 		return fmt.Errorf("%s: listing source dependencies for member %s: %w", control.ID, memberID, err)
 	}
@@ -518,6 +537,9 @@ func ensureDrainRowDependencyProjection(store beads.Store, control beads.Bead, m
 		if err := ensureDrainWorkflowBlocksOn(store, rootID, blockerID); err != nil {
 			return fmt.Errorf("%s: wiring item workflow %s for member %s to blocker %s: %w", control.ID, rootID, memberID, blockerID, err)
 		}
+	}
+	if err := repairDrainWorkflowSourceMemberDeps(store, manifest, memberID, rootID); err != nil {
+		return fmt.Errorf("%s: repairing source-member dependencies on item workflow %s for member %s: %w", control.ID, rootID, memberID, err)
 	}
 	return nil
 }
@@ -535,7 +557,21 @@ func drainRootByMember(manifest drainManifest) map[string]string {
 	return rootByMember
 }
 
-func drainProjectedBlockerIDs(store beads.Store, memberID string, rootByMember map[string]string) ([]string, error) {
+func drainManifestMemberIDs(manifest drainManifest) map[string]bool {
+	memberIDs := make(map[string]bool, len(manifest.Rows))
+	for _, row := range manifest.Rows {
+		memberID := strings.TrimSpace(row.MemberID)
+		if memberID == "" {
+			continue
+		}
+		memberIDs[memberID] = true
+	}
+	return memberIDs
+}
+
+func drainProjectedBlockerIDs(store beads.Store, memberID string, manifest drainManifest) ([]string, error) {
+	rootByMember := drainRootByMember(manifest)
+	manifestMembers := drainManifestMemberIDs(manifest)
 	deps, err := store.DepList(memberID, "down")
 	if err != nil {
 		return nil, err
@@ -553,6 +589,14 @@ func drainProjectedBlockerIDs(store beads.Store, memberID string, rootByMember m
 		blockerID := dependsOnID
 		if projectedRootID := strings.TrimSpace(rootByMember[dependsOnID]); projectedRootID != "" {
 			blockerID = projectedRootID
+		} else if manifestMembers[dependsOnID] {
+			// An in-manifest member without a materialized item root must not
+			// be embedded as a blocker: drains do not close source members,
+			// so that edge would never release. Manifests persisted before
+			// dependency ordering can reach this state on resume; the
+			// manifest-wide sweep wires the item-root dependency once the
+			// blocker's root exists.
+			continue
 		}
 		if seen[blockerID] {
 			continue
@@ -579,6 +623,41 @@ func ensureDrainWorkflowBlocksOn(store beads.Store, rootID, blockerID string) er
 		}
 		if err := ensureBlockingDependency(store, bead.ID, blockerID); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// repairDrainWorkflowSourceMemberDeps removes ready-blocking dependencies
+// that earlier builds embedded from item workflow beads onto other manifest
+// source members. Drains do not close source members, so such an edge stalls
+// the item workflow permanently; the projected item-root dependency wired by
+// ensureDrainRowDependencyProjection before this repair supersedes it.
+func repairDrainWorkflowSourceMemberDeps(store beads.Store, manifest drainManifest, memberID, rootID string) error {
+	manifestMembers := drainManifestMemberIDs(manifest)
+	workflowBeads, err := listByWorkflowRoot(store, rootID)
+	if err != nil {
+		return err
+	}
+	for _, bead := range workflowBeads {
+		if strings.TrimSpace(bead.ID) == "" {
+			continue
+		}
+		deps, err := store.DepList(bead.ID, "down")
+		if err != nil {
+			return fmt.Errorf("listing dependencies for item workflow bead %s: %w", bead.ID, err)
+		}
+		for _, dep := range deps {
+			if !beads.IsReadyBlockingDependencyType(dep.Type) {
+				continue
+			}
+			dependsOnID := strings.TrimSpace(dep.DependsOnID)
+			if dependsOnID == "" || dependsOnID == memberID || !manifestMembers[dependsOnID] {
+				continue
+			}
+			if err := store.DepRemove(bead.ID, dependsOnID); err != nil {
+				return fmt.Errorf("removing source-member dependency %s from item workflow bead %s: %w", dependsOnID, bead.ID, err)
+			}
 		}
 	}
 	return nil
@@ -879,8 +958,8 @@ func drainWorkflowExternalDeps(recipe *formula.Recipe, blockerIDs []string) []mo
 	if recipe == nil || len(recipe.Steps) == 0 || len(blockerIDs) == 0 {
 		return nil
 	}
-	seen := make(map[string]bool, len(recipe.Steps)*len(blockerIDs))
-	deps := make([]molecule.ExternalDep, 0, len(recipe.Steps)*len(blockerIDs))
+	seen := make(map[string]bool)
+	var deps []molecule.ExternalDep
 	for _, step := range recipe.Steps {
 		stepID := strings.TrimSpace(step.ID)
 		if stepID == "" {

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -170,6 +170,61 @@ func TestProcessDrainSeparateCreatesDependentItemWorkflowsBlocked(t *testing.T) 
 	}
 }
 
+func TestProcessDrainSeparateTopologicallyOrdersMembersBeforeCreation(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	prevGraphApply := molecule.IsGraphApplyEnabled()
+	molecule.SetGraphApplyEnabled(false)
+	t.Cleanup(func() { molecule.SetGraphApplyEnabled(prevGraphApply) })
+
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	mem, drain, blocker, dependent := seedReverseOrderedDrainWorkflow(t)
+	mustDepAdd(t, mem, dependent.ID, blocker.ID, "blocks")
+
+	var blockerRootID string
+	var dependentRootID string
+	dependentRootCreatedBlocked := false
+	dependentWorkCreatedBlocked := false
+	store := &createObservingStore{
+		Store: mem,
+		onCreate: func(created beads.Bead) {
+			if created.Metadata["gc.drain_member_id"] == blocker.ID && created.Metadata["gc.kind"] == "workflow" {
+				blockerRootID = created.ID
+			}
+			if created.Metadata["gc.drain_member_id"] == dependent.ID && created.Metadata["gc.kind"] == "workflow" {
+				dependentRootID = created.ID
+				dependentRootCreatedBlocked = blockerRootID != "" && beadNeedsContains(created.Needs, blockerRootID)
+			}
+			if dependentRootID != "" && strings.HasPrefix(created.Title, "Work ") && (created.ParentID == dependentRootID || created.Metadata["gc.root_bead_id"] == dependentRootID) {
+				dependentWorkCreatedBlocked = blockerRootID != "" && beadNeedsContains(created.Needs, blockerRootID)
+			}
+		},
+	}
+
+	result, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(drain expand): %v", err)
+	}
+	if result.Action != "drain-expanded" {
+		t.Fatalf("result = %+v, want drain-expanded", result)
+	}
+
+	manifest := mustDrainManifest(t, mustGetBead(t, mem, drain.ID))
+	if len(manifest.Rows) != 2 {
+		t.Fatalf("manifest rows = %d, want 2", len(manifest.Rows))
+	}
+	if manifest.Rows[0].MemberID != blocker.ID || manifest.Rows[1].MemberID != dependent.ID {
+		t.Fatalf("manifest order = [%s, %s], want blocker %s before dependent %s", manifest.Rows[0].MemberID, manifest.Rows[1].MemberID, blocker.ID, dependent.ID)
+	}
+	if !dependentRootCreatedBlocked {
+		t.Fatalf("dependent item root was created without a blocks need on blocker root %s", blockerRootID)
+	}
+	if !dependentWorkCreatedBlocked {
+		t.Fatalf("dependent item work step was created without a blocks need on blocker root %s", blockerRootID)
+	}
+	assertHasBlockingDep(t, mem, manifest.Rows[1].ItemRootID, manifest.Rows[0].ItemRootID)
+}
+
 func TestProcessDrainSeparateSucceedsForEmptyInputConvoy(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 	dir := t.TempDir()
@@ -1116,6 +1171,55 @@ func seedDrainWorkflow(t *testing.T) (*beads.MemStore, beads.Bead) {
 		t.Fatal(err)
 	}
 	return store, drain
+}
+
+func seedReverseOrderedDrainWorkflow(t *testing.T) (*beads.MemStore, beads.Bead, beads.Bead, beads.Bead) {
+	t.Helper()
+	store := beads.NewMemStore()
+	parent, err := store.Create(beads.Bead{Title: "parent", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocker, err := store.Create(beads.Bead{Title: "blocker", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dependent, err := store.Create(beads.Bead{Title: "dependent", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, member := range []beads.Bead{dependent, blocker} {
+		if err := convoycore.TrackItem(store, parent.ID, member.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root, err := store.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.input_convoy_id":  parent.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	drain, err := store.Create(beads.Bead{
+		Title: "drain",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                "drain",
+			"gc.root_bead_id":        root.ID,
+			"gc.drain_context":       "separate",
+			"gc.drain_formula":       "drain-item",
+			"gc.drain_member_access": "read",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, drain, blocker, dependent
 }
 
 func writeDrainItemFormula(t *testing.T, dir string) {

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -12,6 +12,7 @@ import (
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/graphv2"
+	"github.com/gastownhall/gascity/internal/molecule"
 )
 
 func TestProcessDrainSeparateExpandsConvoyIntoUnitRoots(t *testing.T) {
@@ -107,6 +108,65 @@ func TestProcessDrainSeparateProjectsMemberDependenciesOntoItemWorkflows(t *test
 	}
 	if beadListContainsID(ready, secondWork.ID) {
 		t.Fatalf("second item work step %s should not be ready while %s is open; ready=%+v", secondWork.ID, firstRow.ItemRootID, ready)
+	}
+}
+
+func TestProcessDrainSeparateCreatesDependentItemWorkflowsBlocked(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	prevGraphApply := molecule.IsGraphApplyEnabled()
+	molecule.SetGraphApplyEnabled(false)
+	t.Cleanup(func() { molecule.SetGraphApplyEnabled(prevGraphApply) })
+
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	mem, drain := seedDrainWorkflow(t)
+	parentRoot := mustGetBead(t, mem, drain.Metadata["gc.root_bead_id"])
+	members, err := convoycore.Members(mem, parentRoot.Metadata["gc.input_convoy_id"], false)
+	if err != nil {
+		t.Fatalf("Members: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("members = %d, want 2", len(members))
+	}
+	firstMember := members[0]
+	secondMember := members[1]
+	mustDepAdd(t, mem, secondMember.ID, firstMember.ID, "blocks")
+
+	var firstRootID string
+	var secondRootID string
+	secondRootCreatedBlocked := false
+	secondWorkCreatedBlocked := false
+	store := &createObservingStore{
+		Store: mem,
+		onCreate: func(created beads.Bead) {
+			if created.Metadata["gc.drain_member_id"] == firstMember.ID && created.Metadata["gc.kind"] == "workflow" {
+				firstRootID = created.ID
+			}
+			if firstRootID == "" {
+				return
+			}
+			if created.Metadata["gc.drain_member_id"] == secondMember.ID && created.Metadata["gc.kind"] == "workflow" {
+				secondRootID = created.ID
+				secondRootCreatedBlocked = beadNeedsContains(created.Needs, firstRootID)
+			}
+			if secondRootID != "" && strings.HasPrefix(created.Title, "Work ") && (created.ParentID == secondRootID || created.Metadata["gc.root_bead_id"] == secondRootID) {
+				secondWorkCreatedBlocked = beadNeedsContains(created.Needs, firstRootID)
+			}
+		},
+	}
+
+	result, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(drain expand): %v", err)
+	}
+	if result.Action != "drain-expanded" {
+		t.Fatalf("result = %+v, want drain-expanded", result)
+	}
+	if !secondRootCreatedBlocked {
+		t.Fatalf("second item root was created without a blocks need on first root %s", firstRootID)
+	}
+	if !secondWorkCreatedBlocked {
+		t.Fatalf("second item work step was created without a blocks need on first root %s", firstRootID)
 	}
 }
 
@@ -912,6 +972,28 @@ type recordingDrainUnitStore struct {
 func (s *recordingDrainUnitStore) ListByMetadata(filters map[string]string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
 	s.listMetadataOpts = append(s.listMetadataOpts, opts)
 	return s.Store.ListByMetadata(filters, limit, opts...)
+}
+
+type createObservingStore struct {
+	beads.Store
+	onCreate func(beads.Bead)
+}
+
+func (s *createObservingStore) Create(b beads.Bead) (beads.Bead, error) {
+	created, err := s.Store.Create(b)
+	if err == nil && s.onCreate != nil {
+		s.onCreate(created)
+	}
+	return created, err
+}
+
+func beadNeedsContains(needs []string, id string) bool {
+	for _, need := range needs {
+		if need == id || need == "blocks:"+id {
+			return true
+		}
+	}
+	return false
 }
 
 func TestEnsureDrainUnitConvoyLooksAcrossBothTiers(t *testing.T) {

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -56,6 +56,60 @@ func TestProcessDrainSeparateExpandsConvoyIntoUnitRoots(t *testing.T) {
 	}
 }
 
+func TestProcessDrainSeparateProjectsMemberDependenciesOntoItemWorkflows(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t)
+	parentRoot := mustGetBead(t, store, drain.Metadata["gc.root_bead_id"])
+	members, err := convoycore.Members(store, parentRoot.Metadata["gc.input_convoy_id"], false)
+	if err != nil {
+		t.Fatalf("Members: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("members = %d, want 2", len(members))
+	}
+	firstMember := members[0]
+	secondMember := members[1]
+	mustDepAdd(t, store, secondMember.ID, firstMember.ID, "blocks")
+
+	result, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(drain expand): %v", err)
+	}
+	if result.Action != "drain-expanded" {
+		t.Fatalf("result = %+v, want drain-expanded", result)
+	}
+
+	drain = mustGetBead(t, store, drain.ID)
+	manifest := mustDrainManifest(t, drain)
+	rowByMember := make(map[string]drainManifestRow, len(manifest.Rows))
+	for _, row := range manifest.Rows {
+		rowByMember[row.MemberID] = row
+	}
+	firstRow := rowByMember[firstMember.ID]
+	secondRow := rowByMember[secondMember.ID]
+	if firstRow.ItemRootID == "" || secondRow.ItemRootID == "" {
+		t.Fatalf("missing item roots: first=%+v second=%+v", firstRow, secondRow)
+	}
+
+	assertHasBlockingDep(t, store, secondRow.ItemRootID, firstRow.ItemRootID)
+	secondWork := mustFindDrainItemWorkStep(t, store, secondRow.ItemRootID)
+	assertHasBlockingDep(t, store, secondWork.ID, firstRow.ItemRootID)
+
+	firstWork := mustFindDrainItemWorkStep(t, store, firstRow.ItemRootID)
+	ready, err := store.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if !beadListContainsID(ready, firstWork.ID) {
+		t.Fatalf("first item work step %s should be ready; ready=%+v", firstWork.ID, ready)
+	}
+	if beadListContainsID(ready, secondWork.ID) {
+		t.Fatalf("second item work step %s should not be ready while %s is open; ready=%+v", secondWork.ID, firstRow.ItemRootID, ready)
+	}
+}
+
 func TestProcessDrainSeparateSucceedsForEmptyInputConvoy(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 	dir := t.TempDir()
@@ -1081,4 +1135,33 @@ func assertFormulaStepMetadata(t *testing.T, store beads.Store, rootID, key, wan
 		}
 	}
 	t.Fatalf("no child of %s has metadata %s=%q; beads=%+v", rootID, key, want, all)
+}
+
+func mustFindDrainItemWorkStep(t *testing.T, store beads.Store, rootID string) beads.Bead {
+	t.Helper()
+	all, err := listByWorkflowRoot(store, rootID)
+	if err != nil {
+		t.Fatalf("listByWorkflowRoot(%s): %v", rootID, err)
+	}
+	for _, bead := range all {
+		if bead.ID != rootID && strings.HasPrefix(bead.Title, "Work ") {
+			return bead
+		}
+	}
+	t.Fatalf("no drain item work step found under %s; beads=%+v", rootID, all)
+	return beads.Bead{}
+}
+
+func assertHasBlockingDep(t *testing.T, store beads.Store, issueID, dependsOnID string) {
+	t.Helper()
+	deps, err := store.DepList(issueID, "down")
+	if err != nil {
+		t.Fatalf("DepList(%s): %v", issueID, err)
+	}
+	for _, dep := range deps {
+		if dep.Type == "blocks" && dep.DependsOnID == dependsOnID {
+			return
+		}
+	}
+	t.Fatalf("dependencies for %s = %+v, want blocks dependency on %s", issueID, deps, dependsOnID)
 }

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -894,6 +894,203 @@ func TestProcessDrainReplayClosesFailedItemRootBeforeRecreate(t *testing.T) {
 	}
 }
 
+func TestProcessDrainReplayConvoyOrderedManifestBlocksOnItemRootNotSourceMember(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain, blocker, dependent := seedReverseOrderedDrainWorkflow(t)
+	mustDepAdd(t, store, dependent.ID, blocker.ID, "blocks")
+	root := mustGetBead(t, store, drain.Metadata["gc.root_bead_id"])
+	parentConvoyID := root.Metadata["gc.input_convoy_id"]
+	// Simulate a manifest persisted by a pre-ordering build: rows in convoy
+	// order, with the dependent member materializing before its blocker.
+	manifest := buildDrainManifest(drain, parentConvoyID, "drain-item",
+		[]beads.Bead{mustGetBead(t, store, dependent.ID), mustGetBead(t, store, blocker.ID)})
+	if len(manifest.Rows) != 2 || manifest.Rows[0].MemberID != dependent.ID || manifest.Rows[1].MemberID != blocker.ID {
+		t.Fatalf("manifest rows = %+v, want convoy order [dependent %s, blocker %s]", manifest.Rows, dependent.ID, blocker.ID)
+	}
+	if err := persistDrainManifest(store, drain.ID, manifest, map[string]string{"gc.drain_state": "expanding"}); err != nil {
+		t.Fatalf("persist manifest: %v", err)
+	}
+
+	result, err := ProcessControl(store, mustGetBead(t, store, drain.ID), ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(drain replay): %v", err)
+	}
+	if result.Action != "drain-expanded" {
+		t.Fatalf("result = %+v, want drain-expanded", result)
+	}
+
+	replayed := mustDrainManifest(t, mustGetBead(t, store, drain.ID))
+	rowByMember := make(map[string]drainManifestRow, len(replayed.Rows))
+	for _, row := range replayed.Rows {
+		rowByMember[row.MemberID] = row
+	}
+	dependentRow := rowByMember[dependent.ID]
+	blockerRow := rowByMember[blocker.ID]
+	if dependentRow.ItemRootID == "" || blockerRow.ItemRootID == "" {
+		t.Fatalf("missing item roots: dependent=%+v blocker=%+v", dependentRow, blockerRow)
+	}
+
+	assertHasBlockingDep(t, store, dependentRow.ItemRootID, blockerRow.ItemRootID)
+	dependentWork := mustFindDrainItemWorkStep(t, store, dependentRow.ItemRootID)
+	assertHasBlockingDep(t, store, dependentWork.ID, blockerRow.ItemRootID)
+	assertNoBlockingDep(t, store, dependentRow.ItemRootID, blocker.ID)
+	assertNoBlockingDep(t, store, dependentWork.ID, blocker.ID)
+
+	blockerWork := mustFindDrainItemWorkStep(t, store, blockerRow.ItemRootID)
+	if !mustReadyContains(t, store, blockerWork.ID) {
+		t.Fatalf("blocker item work step %s should be ready", blockerWork.ID)
+	}
+	if mustReadyContains(t, store, dependentWork.ID) {
+		t.Fatalf("dependent item work step %s should not be ready while blocker root %s is open", dependentWork.ID, blockerRow.ItemRootID)
+	}
+}
+
+func TestProcessDrainCompleteRepairsEmbeddedSourceMemberDeps(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t)
+	parentRoot := mustGetBead(t, store, drain.Metadata["gc.root_bead_id"])
+	members, err := convoycore.Members(store, parentRoot.Metadata["gc.input_convoy_id"], false)
+	if err != nil {
+		t.Fatalf("Members: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("members = %d, want 2", len(members))
+	}
+	firstMember := members[0]
+	secondMember := members[1]
+	mustDepAdd(t, store, secondMember.ID, firstMember.ID, "blocks")
+
+	if _, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil {
+		t.Fatalf("ProcessControl(drain expand): %v", err)
+	}
+	manifest := mustDrainManifest(t, mustGetBead(t, store, drain.ID))
+	rowByMember := make(map[string]drainManifestRow, len(manifest.Rows))
+	for _, row := range manifest.Rows {
+		rowByMember[row.MemberID] = row
+	}
+	firstRow := rowByMember[firstMember.ID]
+	secondRow := rowByMember[secondMember.ID]
+	secondWork := mustFindDrainItemWorkStep(t, store, secondRow.ItemRootID)
+	// Simulate edges embedded by a build that fell back to source members on
+	// a convoy-ordered manifest.
+	mustDepAdd(t, store, secondRow.ItemRootID, firstMember.ID, "blocks")
+	mustDepAdd(t, store, secondWork.ID, firstMember.ID, "blocks")
+
+	if _, err := ProcessControl(store, mustGetBead(t, store, drain.ID), ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil && !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl(drain complete): %v", err)
+	}
+
+	assertNoBlockingDep(t, store, secondRow.ItemRootID, firstMember.ID)
+	assertNoBlockingDep(t, store, secondWork.ID, firstMember.ID)
+	assertHasBlockingDep(t, store, secondRow.ItemRootID, firstRow.ItemRootID)
+	assertHasBlockingDep(t, store, secondWork.ID, firstRow.ItemRootID)
+}
+
+func TestProcessDrainSharedRepairsEmbeddedSourceMemberDeps(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain, blocker, dependent := seedReverseOrderedDrainWorkflow(t)
+	if err := store.SetMetadata(drain.ID, "gc.drain_context", "shared"); err != nil {
+		t.Fatalf("SetMetadata(shared): %v", err)
+	}
+	mustDepAdd(t, store, dependent.ID, blocker.ID, "blocks")
+	root := mustGetBead(t, store, drain.Metadata["gc.root_bead_id"])
+	parentConvoyID := root.Metadata["gc.input_convoy_id"]
+	// Simulate a manifest persisted by a pre-ordering build: rows in convoy
+	// order, with the dependent member materializing before its blocker.
+	manifest := buildDrainManifest(mustGetBead(t, store, drain.ID), parentConvoyID, "drain-item",
+		[]beads.Bead{mustGetBead(t, store, dependent.ID), mustGetBead(t, store, blocker.ID)})
+	if manifest.Context != "shared" {
+		t.Fatalf("manifest context = %q, want shared", manifest.Context)
+	}
+	if len(manifest.Rows) != 2 || manifest.Rows[0].MemberID != dependent.ID || manifest.Rows[1].MemberID != blocker.ID {
+		t.Fatalf("manifest rows = %+v, want convoy order [dependent %s, blocker %s]", manifest.Rows, dependent.ID, blocker.ID)
+	}
+	if err := persistDrainManifest(store, drain.ID, manifest, map[string]string{"gc.drain_state": "expanding"}); err != nil {
+		t.Fatalf("persist manifest: %v", err)
+	}
+
+	if _, err := ProcessControl(store, mustGetBead(t, store, drain.ID), ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil && !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl(shared advance): %v", err)
+	}
+	replayed := mustDrainManifest(t, mustGetBead(t, store, drain.ID))
+	dependentRow := replayed.Rows[0]
+	if dependentRow.MemberID != dependent.ID || dependentRow.ItemRootID == "" {
+		t.Fatalf("row 0 = %+v, want materialized dependent %s", dependentRow, dependent.ID)
+	}
+	dependentWork := mustFindDrainItemWorkStep(t, store, dependentRow.ItemRootID)
+	// Simulate the stall left by a build that embedded the source member: the
+	// blocker's item root cannot exist until this row's root closes.
+	mustDepAdd(t, store, dependentRow.ItemRootID, blocker.ID, "blocks")
+	mustDepAdd(t, store, dependentWork.ID, blocker.ID, "blocks")
+	if mustReadyContains(t, store, dependentWork.ID) {
+		t.Fatalf("dependent item work step %s should be blocked before repair", dependentWork.ID)
+	}
+
+	if _, err := ProcessControl(store, mustGetBead(t, store, drain.ID), ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil && !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl(shared repair): %v", err)
+	}
+
+	assertNoBlockingDep(t, store, dependentRow.ItemRootID, blocker.ID)
+	assertNoBlockingDep(t, store, dependentWork.ID, blocker.ID)
+	if !mustReadyContains(t, store, dependentWork.ID) {
+		t.Fatalf("dependent item work step %s should be ready after repair", dependentWork.ID)
+	}
+}
+
+func TestProcessDrainSharedMaterializesInDependencyOrderAndBlocksOnItemRoot(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain, blocker, dependent := seedReverseOrderedDrainWorkflow(t)
+	if err := store.SetMetadata(drain.ID, "gc.drain_context", "shared"); err != nil {
+		t.Fatalf("SetMetadata(shared): %v", err)
+	}
+	mustDepAdd(t, store, dependent.ID, blocker.ID, "blocks")
+
+	result, err := ProcessControl(store, mustGetBead(t, store, drain.ID), ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(shared first): %v", err)
+	}
+	if result.Action != "drain-shared-advanced" {
+		t.Fatalf("Action = %q, want drain-shared-advanced", result.Action)
+	}
+	manifest := mustDrainManifest(t, mustGetBead(t, store, drain.ID))
+	if len(manifest.Rows) != 2 || manifest.Rows[0].MemberID != blocker.ID || manifest.Rows[1].MemberID != dependent.ID {
+		t.Fatalf("manifest rows = %+v, want dependency order [blocker %s, dependent %s]", manifest.Rows, blocker.ID, dependent.ID)
+	}
+	blockerRow := manifest.Rows[0]
+	if blockerRow.ItemRootID == "" || manifest.Rows[1].ItemRootID != "" {
+		t.Fatalf("rows = %+v, want only blocker item root materialized", manifest.Rows)
+	}
+
+	if err := updateMetadataAndClose(store, blockerRow.ItemRootID, map[string]string{"gc.outcome": "pass"}); err != nil {
+		t.Fatalf("close blocker root pass: %v", err)
+	}
+	if _, err := ProcessControl(store, mustGetBead(t, store, drain.ID), ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil && !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl(shared second): %v", err)
+	}
+	manifest = mustDrainManifest(t, mustGetBead(t, store, drain.ID))
+	dependentRow := manifest.Rows[1]
+	if dependentRow.MemberID != dependent.ID || dependentRow.ItemRootID == "" {
+		t.Fatalf("row 1 = %+v, want materialized dependent %s", dependentRow, dependent.ID)
+	}
+
+	dependentWork := mustFindDrainItemWorkStep(t, store, dependentRow.ItemRootID)
+	assertHasBlockingDep(t, store, dependentRow.ItemRootID, blockerRow.ItemRootID)
+	assertHasBlockingDep(t, store, dependentWork.ID, blockerRow.ItemRootID)
+	assertNoBlockingDep(t, store, dependentRow.ItemRootID, blocker.ID)
+	assertNoBlockingDep(t, store, dependentWork.ID, blocker.ID)
+	if !mustReadyContains(t, store, dependentWork.ID) {
+		t.Fatalf("dependent item work step %s should be ready once blocker root %s closed", dependentWork.ID, blockerRow.ItemRootID)
+	}
+}
+
 func TestProcessDrainPassesParentRuntimeVarsToItemFormula(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 	dir := t.TempDir()
@@ -1350,4 +1547,17 @@ func assertHasBlockingDep(t *testing.T, store beads.Store, issueID, dependsOnID 
 		}
 	}
 	t.Fatalf("dependencies for %s = %+v, want blocks dependency on %s", issueID, deps, dependsOnID)
+}
+
+func assertNoBlockingDep(t *testing.T, store beads.Store, issueID, dependsOnID string) {
+	t.Helper()
+	deps, err := store.DepList(issueID, "down")
+	if err != nil {
+		t.Fatalf("DepList(%s): %v", issueID, err)
+	}
+	for _, dep := range deps {
+		if beads.IsReadyBlockingDependencyType(dep.Type) && dep.DependsOnID == dependsOnID {
+			t.Fatalf("dependencies for %s = %+v, want no blocking dependency on %s", issueID, deps, dependsOnID)
+		}
+	}
 }

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -132,11 +132,16 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 	graphWorkflow := preservesGraphActionTypes(recipe)
 	rootKey := recipe.Steps[0].ID
 	rootIncluded := false
+	externalDepsByStep, err := groupExternalDeps(opts.ExternalDeps)
+	if err != nil {
+		return nil, false, "", err
+	}
+	recipeParentByStep := recipeParentDeps(recipe.Deps)
 
 	plan := &beads.GraphApplyPlan{
 		CommitMessage: fmt.Sprintf("gc: instantiate %s", recipe.Name),
 		Nodes:         make([]beads.GraphApplyNode, 0, len(recipe.Steps)),
-		Edges:         make([]beads.GraphApplyEdge, 0, len(recipe.Deps)),
+		Edges:         make([]beads.GraphApplyEdge, 0, len(recipe.Deps)+len(opts.ExternalDeps)),
 	}
 
 	for i, step := range recipe.Steps {
@@ -206,6 +211,19 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 			if node.Assignee != "" {
 				node.AssignAfterCreate = true
 			}
+		}
+		for _, dep := range externalDepsByStep[step.ID] {
+			if dep.Type == "parent-child" && recipeParentByStep[step.ID] != "" {
+				continue
+			}
+			if dep.Type == "parent-child" {
+				node.ParentID = dep.DependsOnID
+			}
+			plan.Edges = append(plan.Edges, beads.GraphApplyEdge{
+				FromKey: step.ID,
+				ToID:    dep.DependsOnID,
+				Type:    dep.Type,
+			})
 		}
 		// Same residual-var guard as Instantiate — see #618.
 		if strings.Contains(node.Title, "{{") {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -30,6 +30,11 @@ type Options struct {
 	// these values take precedence.
 	Vars map[string]string
 
+	// ExternalDeps wires recipe steps to already-existing bead IDs.
+	// These deps are embedded at create time so readiness and assignment are
+	// correct before the recipe becomes visible to workers.
+	ExternalDeps []ExternalDep
+
 	// ParentID attaches the molecule to an existing bead. When set, the
 	// root bead's ParentID is set to this value.
 	ParentID string
@@ -504,6 +509,11 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 	embeddedDeps := make(map[string]bool)
 	pendingAssignees := make(map[string]string)
 	graphWorkflow := preservesGraphActionTypes(recipe)
+	externalDepsByStep, err := groupExternalDeps(opts.ExternalDeps)
+	if err != nil {
+		return nil, err
+	}
+	recipeParentByStep := recipeParentDeps(recipe.Deps)
 
 	for i, step := range recipe.Steps {
 		// For RootOnly recipes, only create the root bead.
@@ -531,6 +541,16 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				b.Needs = append(b.Needs, dep.Type+":"+dependsOnBeadID)
 			}
 			embeddedDeps[dep.StepID+"|"+dep.DependsOnID+"|"+dep.Type] = true
+		}
+		for _, dep := range externalDepsByStep[step.ID] {
+			if dep.Type == "parent-child" {
+				continue
+			}
+			if dep.Type == "blocks" {
+				b.Needs = append(b.Needs, dep.DependsOnID)
+			} else {
+				b.Needs = append(b.Needs, dep.Type+":"+dep.DependsOnID)
+			}
 		}
 		// Root bead overrides.
 		if step.IsRoot {
@@ -571,6 +591,12 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 					if parentBeadID, ok := idMapping[dep.DependsOnID]; ok {
 						b.ParentID = parentBeadID
 					}
+					break
+				}
+			}
+			for _, dep := range externalDepsByStep[step.ID] {
+				if b.ParentID == "" && recipeParentByStep[step.ID] == "" && dep.Type == "parent-child" && dep.DependsOnID != "" {
+					b.ParentID = dep.DependsOnID
 					break
 				}
 			}
@@ -661,6 +687,24 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			if err := store.DepAdd(fromID, toID, dep.Type); err != nil {
 				markFailed(store, createdIDs)
 				return nil, fmt.Errorf("wiring dep %s->%s: %w", dep.StepID, dep.DependsOnID, err)
+			}
+		}
+	}
+	for stepID, deps := range externalDepsByStep {
+		if recipeParentByStep[stepID] != "" {
+			continue
+		}
+		fromID, fromOK := idMapping[stepID]
+		if !fromOK {
+			continue
+		}
+		for _, dep := range deps {
+			if dep.Type != "parent-child" {
+				continue
+			}
+			if err := store.DepAdd(fromID, dep.DependsOnID, dep.Type); err != nil {
+				markFailed(store, createdIDs)
+				return nil, fmt.Errorf("wiring external dep %s->%s: %w", stepID, dep.DependsOnID, err)
 			}
 		}
 	}

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -183,6 +183,21 @@ func assertGraphPlanEdgeCount(t *testing.T, plan *beads.GraphApplyPlan, fromKey,
 	}
 }
 
+func assertStoreDep(t *testing.T, store beads.Store, issueID, dependsOnID, depType string) {
+	t.Helper()
+
+	deps, err := store.DepList(issueID, "down")
+	if err != nil {
+		t.Fatalf("DepList(%s): %v", issueID, err)
+	}
+	for _, dep := range deps {
+		if dep.DependsOnID == dependsOnID && dep.Type == depType {
+			return
+		}
+	}
+	t.Fatalf("dependencies for %s = %+v, want %s dependency on %s", issueID, deps, depType, dependsOnID)
+}
+
 func TestBuildRecipeApplyPlanReviewQuorumSubstitutesSynthesisTarget(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 
@@ -481,6 +496,41 @@ func TestInstantiateSimple(t *testing.T) {
 	}
 }
 
+func TestInstantiateExternalDepsCreateBlockingDeps(t *testing.T) {
+	store := beads.NewMemStore()
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(false)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+	blocker, err := store.Create(beads.Bead{Title: "Blocker", Type: "task"})
+	if err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{ID: "wf", Title: "Workflow", Type: "task", IsRoot: true, Metadata: map[string]string{"gc.kind": "workflow"}},
+			{ID: "wf.step", Title: "Work", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf.step", DependsOnID: "wf", Type: "parent-child"},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{
+		ExternalDeps: []ExternalDep{
+			{StepID: "wf", DependsOnID: blocker.ID, Type: "blocks"},
+			{StepID: "wf.step", DependsOnID: blocker.ID, Type: "blocks"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	assertStoreDep(t, store, result.RootID, blocker.ID, "blocks")
+	assertStoreDep(t, store, result.IDMapping["wf.step"], blocker.ID, "blocks")
+}
+
 func TestInstantiateUsesGraphApplyStoreWhenAvailable(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
 	prev := IsGraphApplyEnabled()
@@ -526,6 +576,42 @@ func TestInstantiateUsesGraphApplyStoreWhenAvailable(t *testing.T) {
 	if !hasParentChild {
 		t.Fatalf("edges = %+v, want at least one parent-child edge", store.plan.Edges)
 	}
+}
+
+func TestInstantiateGraphApplyIncludesExternalDeps(t *testing.T) {
+	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+	blocker, err := store.Create(beads.Bead{Title: "Blocker", Type: "task"})
+	if err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{ID: "wf", Title: "Workflow", Type: "task", IsRoot: true, Metadata: map[string]string{"gc.kind": "workflow"}},
+			{ID: "wf.step", Title: "Work", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf.step", DependsOnID: "wf", Type: "parent-child"},
+		},
+	}
+
+	if _, err := Instantiate(context.Background(), store, recipe, Options{
+		ExternalDeps: []ExternalDep{
+			{StepID: "wf", DependsOnID: blocker.ID, Type: "blocks"},
+			{StepID: "wf.step", DependsOnID: blocker.ID, Type: "blocks"},
+		},
+	}); err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if store.plan == nil {
+		t.Fatal("ApplyGraphPlan was not called")
+	}
+	assertGraphPlanEdgeCount(t, store.plan, "wf", "", blocker.ID, "blocks", 1)
+	assertGraphPlanEdgeCount(t, store.plan, "wf.step", "", blocker.ID, "blocks", 1)
 }
 
 func TestInstantiateRetriesTransientGraphApplyBeforeFallback(t *testing.T) {


### PR DESCRIPTION
## Summary
- project source convoy member blocking dependencies onto generated drain item workflows
- wire generated item workflow roots and descendants to prior generated item roots when source members depend on each other
- add regression coverage for ready-state gating after drain expansion

## Verification
- go test ./internal/dispatch -run TestProcessDrainSeparateProjectsMemberDependenciesOntoItemWorkflows -count=1
- go test ./internal/dispatch -count=1
- go vet ./internal/dispatch

Note: make test-fast-parallel currently fails on unrelated cmd/gc baseline tests that reproduce on untouched origin/main.