### PR TITLE
perf(status-line): count unread mail via the count-only endpoint

### DIFF
--- a/examples/gastown/packs/gastown/assets/scripts/status-line.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/status-line.sh
@@ -27,8 +27,8 @@ fi
 # Count pending work items (non-empty lines from gc hook).
 w=$(gc hook "$agent" 2>/dev/null | grep -c . || true)
 
-# Count unread mail (first word of gc mail check output is the count).
-m=$(gc mail check "$agent" 2>/dev/null | awk '{print $1+0}' || true)
+# Count unread mail via the count-only endpoint (cheaper than mail check).
+m=$(gc mail count "$agent" --json 2>/dev/null | jq -r '.unread // 0' 2>/dev/null || echo 0)
 
 # Format: agent | hook-icon N | mail-icon N  (omit segments that are 0)
 printf '%s' "$agent"


### PR DESCRIPTION
The example gastown status-line script invoked `gc mail check` and used
awk to extract only the unread count, forcing the server to return full
message bodies that were immediately discarded. Swap to `gc mail count
--json` + jq, which hits the count-only endpoint and cuts per-tick
latency materially on loaded hosts.

## Why this PR

The status-line script runs on every tmux status refresh, so a needless
full-mailbox fetch per tick adds avoidable server load on busy hosts.
`gc mail count --json` is the purpose-built count-only path; switching to
it removes the wasted payload with no change to the displayed unread count.
