### PR TITLE
chore(go.mod): bump minimum Go version to 1.26.4 (CVE-2026-42504)

### DIFF
--- a/.github/actions/setup-gascity-macos/action.yml
+++ b/.github/actions/setup-gascity-macos/action.yml
@@ -5,7 +5,7 @@ inputs:
   go-version:
     description: Go version to install. Default matches setup-gascity-ubuntu; bump both together.
     required: false
-    default: "1.26.3"
+    default: "1.26.4"
   node-version:
     description: Node.js version to install
     required: false

--- a/.github/actions/setup-gascity-ubuntu/action.yml
+++ b/.github/actions/setup-gascity-ubuntu/action.yml
@@ -5,7 +5,7 @@ inputs:
   go-version:
     description: Go version to install
     required: false
-    default: "1.26.3"
+    default: "1.26.4"
   node-version:
     description: Node.js version to install
     required: false

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gastownhall/gascity
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/release-gates/ga-j4imaw-go1264-cve-2026-42504-gate.md
+++ b/release-gates/ga-j4imaw-go1264-cve-2026-42504-gate.md
@@ -1,0 +1,59 @@
+# Release Gate: ga-j4imaw Go 1.26.4 CVE-2026-42504
+
+Date: 2026-06-10
+
+Deploy bead: ga-j4imaw
+Source implementation bead: ga-yzu3ka
+Source review bead: ga-k4yukn
+PR: https://github.com/gastownhall/gascity/pull/3297
+Feature branch: builder/ga-yzu3ka
+Implementation head tested: d58e088674e73af02642438aac3e78ed8ed582d7
+Base: origin/main at 1ec0ebc5ede7c451d77e42b1126567ab89202d11
+
+## Summary
+
+This change raises Gas City's Go module floor from 1.26.3 to 1.26.4 so the
+`gc` binary is built with the Go stdlib fix for CVE-2026-42504. The related
+CI composite actions for Ubuntu and macOS are also bumped to 1.26.4 so jobs
+that run with `GOTOOLCHAIN=local` install a toolchain that satisfies
+`go.mod`.
+
+The repository at this PR head does not contain `docs/PROJECT_MANIFEST.md`, so
+this gate uses the deployer role's release gate criteria and the test runner
+guidance in `TESTING.md`.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-k4yukn` is closed with close reason `pass`. Review notes say `fix-merge`, identify the CI action mismatch, and record the fix commits `8c2de4c8a` and `d58e08867`. `gh pr view 3297 --comments` includes `Review: PASS (fix-merge applied)`. |
+| 2 | Acceptance criteria met | PASS | `go.mod:3` is `go 1.26.4`; `.github/actions/setup-gascity-ubuntu/action.yml:8` and `.github/actions/setup-gascity-macos/action.yml:8` both default to `"1.26.4"`. `go mod tidy && git diff --exit-code -- go.mod go.sum` passed, so `go.sum` needs no update. `go vet ./...` and `make test-fast-parallel` passed. Follow-up `ga-frh27v` is open and explicitly notes that after PR #3297 merges, `usr/local/bin/gc` can be removed from the `.trivyignore.yaml` CVE-2026-42504 entry. PR #3297 is open on the clean branch `builder/ga-yzu3ka`. |
+| 3 | Tests pass | PASS | Local commands passed in clean verification worktree `/home/jaword/projects/gc-management/.gc/worktrees/gascity/deploy-ga-j4imaw-go1264-gate`: `go version` reported `go1.26.4-X:nodwarf5 linux/amd64`; `go vet ./...` passed; `make test-fast-parallel` passed all 8 fast jobs. GitHub `gh pr checks 3297` shows all non-skipped checks passing, including `CI / required`, `CI / preflight`, `CI / integration`, `Preflight / static checks`, `Check`, `CodeQL`, `Image vulnerabilities`, and `Trivy`. |
+| 4 | No high-severity review findings open | PASS | Review notes list one blocking CI/build-configuration finding, and the fix-merge commits resolved it. Security review says the PR reduces attack surface and introduces no OWASP Top 10 concerns. No unresolved HIGH findings remain in the bead notes or PR comments. |
+| 5 | Final branch is clean | PASS | Verification worktree status was clean before writing this checklist. This checklist is the only gate addition and must be committed before push; after the gate commit, `git status --short` must be clean. |
+| 6 | Branch diverges cleanly from main | PASS | `gh pr view 3297 --json mergeStateStatus,headRefOid,baseRefOid` reports `mergeStateStatus: CLEAN`, head `d58e088674e73af02642438aac3e78ed8ed582d7`, and base `1ec0ebc5ede7c451d77e42b1126567ab89202d11`. `git merge-tree origin/main HEAD` completed without conflicts. |
+| 7 | Single feature theme | PASS | The commit set touches one release/security theme: the Go toolchain floor for the module and the matching CI composite action defaults. Diff scope is limited to `go.mod`, `.github/actions/setup-gascity-ubuntu/action.yml`, and `.github/actions/setup-gascity-macos/action.yml`. |
+
+## Commands
+
+```text
+bd show ga-j4imaw
+bd show ga-k4yukn
+bd show ga-yzu3ka
+bd show ga-frh27v
+gh pr view 3297 --repo gastownhall/gascity --json number,title,state,url,headRefName,headRefOid,baseRefName,baseRefOid,mergeStateStatus,statusCheckRollup,commits,files
+gh pr view 3297 --repo gastownhall/gascity --comments
+gh pr checks 3297 --repo gastownhall/gascity
+git diff --name-only origin/main...d58e088674e73af02642438aac3e78ed8ed582d7
+git diff --check origin/main...HEAD
+rg -n '(^go 1\.26\.4$|default: "1\.26\.4")' go.mod .github/actions/setup-gascity-ubuntu/action.yml .github/actions/setup-gascity-macos/action.yml
+go mod tidy && git diff --exit-code -- go.mod go.sum
+go vet ./...
+make test-fast-parallel
+git merge-tree origin/main HEAD
+```
+
+## Verdict
+
+PASS. PR #3297 is eligible for merge-authority handoff after this checklist is
+committed and pushed to `builder/ga-yzu3ka`.


### PR DESCRIPTION
## What this changes

Gas City's Go module floor moves from `1.26.3` to `1.26.4`, so the `gc`
binary is built with the Go stdlib fix for CVE-2026-42504.

The Ubuntu and macOS `setup-gascity` composite action defaults also move to
`1.26.4`. Those defaults matter for jobs that run with `GOTOOLCHAIN=local` and
do not pass `go-version-file`; without the matching action defaults, CI can
install an older Go toolchain than `go.mod` now requires.

## Review notes

- `go.sum` is intentionally unchanged; `go mod tidy` is clean.
- `.trivyignore.yaml` is intentionally unchanged in this PR. After this lands,
  `usr/local/bin/gc` can be removed from the CVE-2026-42504 suppression, while
  upstream `gh` and `dolt` suppressions remain until those binaries are rebuilt
  with a patched Go release.
- This does not change runtime behavior beyond selecting the patched Go
  toolchain for builds.

## Test plan

- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] GitHub PR checks: `CI / required`, `CI / preflight`, `CI / integration`,
      `CodeQL`, `Image vulnerabilities`, `Trivy`
- [x] Release gate:
      [`release-gates/ga-j4imaw-go1264-cve-2026-42504-gate.md`](release-gates/ga-j4imaw-go1264-cve-2026-42504-gate.md)
