### PR TITLE
fix(reconciler): defer drain-ack stops during partial store queries

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1314,6 +1314,28 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			default:
 				if dops != nil {
 					if acked, _ := dops.isDrainAcked(name); acked {
+						// gc-hz0nu: every drain-acked decision below depends on the
+						// store-derived desired-state / assigned-work view. During a
+						// partial store query (transient Dolt failure) that view is
+						// incomplete, so an ack minted from it cannot be trusted to
+						// mean "orphaned". Defer the whole decision until the store is
+						// healthy — the same protection the plain drain path applies
+						// just below. Stopping a live session here on degraded data is
+						// what killed coordinator sessions on 2026-06-09.
+						if storeQueryPartial {
+							fmt.Fprintf(stdout, "Skipping drain-ack stop for '%s': store query partial (transient failure)\n", name) //nolint:errcheck
+							if trace != nil {
+								template := normalizedSessionTemplate(*session, cfg)
+								if template == "" {
+									template = session.Metadata["template"]
+								}
+								trace.recordDecision("reconciler.session.drain_ack", template, name, "store_query_partial", "deferred", traceRecordPayload{
+									"store_query_partial": true,
+									"provider_alive":      providerAlive,
+								}, nil, "")
+							}
+							continue
+						}
 						ackReason := assignedWorkDrainCancelReason(*session, sp, dt, name)
 						hasAssignedWork, assignedErr := sessionHasAwakeAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
 						if assignedErr != nil {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1519,6 +1519,23 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						continue
 					}
 					ackReason, reconcilerOwnedAck := reconcilerDrainAckMatchesSession(*session, sp, name)
+					// gc-kkgak: a reconciler-owned drain ack is minted from the
+					// desired-state / assigned-work view. During a partial store
+					// query that view is unreliable, so defer the reconciler-owned
+					// cancel/stop decision until the store is healthy — same
+					// rationale as gc-hz0nu's orphan branch. Agent-sourced handoff
+					// acks are not reconciler-owned and fall through to stop
+					// promptly: their intent is explicit, not derived from the store.
+					if reconcilerOwnedAck && storeQueryPartial {
+						fmt.Fprintf(stdout, "Skipping reconciler drain-ack stop for '%s': store query partial (transient failure)\n", name) //nolint:errcheck
+						if trace != nil {
+							trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "store_query_partial", "deferred", traceRecordPayload{
+								"store_query_partial":  true,
+								"reconciler_owned_ack": true,
+							}, nil, "")
+						}
+						continue
+					}
 					if reconcilerOwnedAck && assignedWorkDrainReasonCancelable(ackReason) {
 						hasAssignedWork, assignedErr := sessionHasAwakeAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
 						if assignedErr != nil {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -956,6 +956,131 @@ func TestReconcileSessionBeads_DrainAckedOrphanStopDeferredWhenStoreQueryPartial
 	}
 }
 
+// TestReconcileSessionBeads_PreserveNamedReconcilerAckStopDeferredWhenStoreQueryPartial
+// is the gc-kkgak regression guard for the second (preserveNamed/named-session)
+// drain-ack block. A RECONCILER-owned drain ack is minted from the
+// desired-state/assigned-work view; under a partial store query that view is
+// unreliable, so the reconciler-owned stop must defer until the store is
+// healthy — the same reasoning as gc-hz0nu's orphan branch. Without the guard
+// the named session is async-stopped on degraded data.
+func TestReconcileSessionBeads_PreserveNamedReconcilerAckStopDeferredWhenStoreQueryPartial(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+	// Reconciler-owned ack (source=reconciler), generation matches the bead's "1".
+	if err := setReconcilerDrainAckMetadata(env.sp, "worker", &drainState{reason: "orphaned", generation: 1}); err != nil {
+		t.Fatalf("setReconcilerDrainAckMetadata: %v", err)
+	}
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		true, // storeQueryPartial
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["state_reason"] == sessionpkg.DrainAckStopPendingReason {
+		t.Fatalf("reconciler-owned drain-ack marked stop-pending under storeQueryPartial; must defer (gc-kkgak)")
+	}
+	if got.Metadata["state"] == string(sessionpkg.StateDraining) {
+		t.Fatalf("state = draining under storeQueryPartial; reconciler-owned stop must defer (gc-kkgak)")
+	}
+}
+
+// TestReconcileSessionBeads_AgentAckStopProceedsDespiteStoreQueryPartial locks
+// the other half of gc-kkgak: an agent-sourced drain ack (NOT reconciler-owned —
+// an explicit `gc runtime drain-ack` handoff) must still stop promptly even
+// under storeQueryPartial. The agent's intent is explicit, not derived from the
+// degraded store, so the partial-store guard must not swallow it.
+func TestReconcileSessionBeads_AgentAckStopProceedsDespiteStoreQueryPartial(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+	// Plain agent ack: GC_DRAIN_ACK set, but no reconciler source metadata.
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		true, // storeQueryPartial — must NOT defer an agent-sourced ack
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["state_reason"] != sessionpkg.DrainAckStopPendingReason {
+		t.Fatalf("agent-sourced drain-ack was deferred under storeQueryPartial (state_reason=%q); handoff acks must stop unconditionally (gc-kkgak)", got.Metadata["state_reason"])
+	}
+}
+
 func TestQueueDrainAckAsyncStopTracksShutdownWait(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := newBlockingStopProvider()

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -887,6 +887,75 @@ func TestReconcileSessionBeads_DrainAckMarksStopPendingAndStopsAsync(t *testing.
 	}
 }
 
+// TestReconcileSessionBeads_DrainAckedOrphanStopDeferredWhenStoreQueryPartial is
+// the gc-hz0nu regression guard. During a transient store outage the desired /
+// assigned-work view is incomplete, so a live session can be misjudged as
+// orphaned and a drain ack minted from that degraded view. The drain-acked stop
+// path must NOT kill the session in that window — it has to defer, exactly like
+// the plain orphan-drain path already does when storeQueryPartial is set.
+// Without the guard this session gets marked stop-pending and async-stopped,
+// which is what killed king/dalinar/omp-crew/boot on 2026-06-09.
+func TestReconcileSessionBeads_DrainAckedOrphanStopDeferredWhenStoreQueryPartial(t *testing.T) {
+	env := newReconcilerTestEnv()
+	// "worker" is neither desired nor configured-named -> falls to the orphan
+	// (default) branch; provider is alive so the branch would async-stop it.
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "other"}}}
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,  // empty: not desired
+		map[string]bool{}, // not configured-named: not preserveNamed
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		true, // storeQueryPartial: store is degraded, ack can't be trusted
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["state_reason"] == sessionpkg.DrainAckStopPendingReason {
+		t.Fatalf("drain-acked orphan marked stop-pending under storeQueryPartial; must defer until the store is healthy (gc-hz0nu)")
+	}
+	if got.Metadata["state"] == string(sessionpkg.StateDraining) {
+		t.Fatalf("state = draining under storeQueryPartial; live session must be preserved (gc-hz0nu)")
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = closed under storeQueryPartial; live session must be preserved (gc-hz0nu)")
+	}
+}
+
 func TestQueueDrainAckAsyncStopTracksShutdownWait(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := newBlockingStopProvider()


### PR DESCRIPTION
## Problem

During a Dolt degradation window (2026-06-09, qlandia city), the session reconciler killed four unrelated long-lived sessions (two coordinators, two crew) within ~90s with "drain acknowledged by agent". The drains were minted from a desired-state view built from partial store data: the `storeQueryPartial` guard protected the plain-drain branch but **both** drain-acked stop paths (`isDrainAcked -> markDrainAckStopPending -> queueDrainAckAsyncStop`) ran before it.

## Fix (two commits, two call sites)

- **a72c29535** — orphan/`default` branch: gate the entire drain-acked cancel/stop decision on `storeQueryPartial`; defer until the store is healthy. Emits a `reconciler.session.drain_ack / store_query_partial / deferred` trace decision.
- **a96bbbabb** — preserveNamed branch: defer only **reconciler-owned** acks (`GC_DRAIN_ACK_SOURCE=reconciler`, via `reconcilerDrainAckMatchesSession`) under `storeQueryPartial`. Agent-sourced handoff acks still stop unconditionally — locked by a companion test.

Conservative semantics: a genuinely orphaned acked session is cleaned up one healthy tick later; the harm avoided is killing a live coordinator mid-outage.

## Tests

- `TestReconcileSessionBeads_DrainAckedOrphanStopDeferredWhenStoreQueryPartial` — RED without guard, GREEN with.
- Companion test asserting agent-sourced acks are NOT deferred under partial store.
- `go build`, `go vet`, `golangci-lint` (0 issues in changed file), reconciler test surface (`-run 'TestReconcile|TestQueueDrainAck|TestFinalizeDrainAck|TestDrain'`) all green (CGO_ENABLED=0).

## Tracking

Beads (qlandia): gc-hz0nu (orphan path), gc-kkgak (preserveNamed path). Related follow-ups not in this PR: gc-sklcz (stale reset_committed_at forces fresh session instead of --resume), gc-bssdb (baseline-mode drain-ack trace records).