### PR TITLE
fix(native-store/#3248): drop gc-installed bd forwarder hooks, run autoclose in-process

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -8,3 +8,6 @@ export.auto: false
 gc.endpoint_origin: inherited_city
 gc.endpoint_status: verified
 types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step
+dolt:
+  disable-event-flush: true
+backup.enabled: false

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -446,12 +446,22 @@ func maintenanceStartupLine(interval time.Duration, active bool) string {
 	return fmt.Sprintf("store-maintenance: loop started interval=%s mode=%s", interval, mode)
 }
 
+// beadCloseAutocloseDispatch controls how convoy/wisp/molecule autoclose are
+// dispatched after a bead.closed event. Default launches a background goroutine
+// (best-effort, non-blocking). Tests swap to a synchronous call for
+// deterministic assertions.
+var beadCloseAutocloseDispatch = func(fn func()) { go fn() }
+
 func (cs *controllerState) applyBeadEventToStores(evt events.Event) {
 	if len(evt.Payload) == 0 {
 		return
 	}
 	cs.mu.RLock()
 	stores := cs.beadEventStoresLocked(evt)
+	var storeRef string
+	if evt.Type == events.BeadClosed {
+		storeRef = cs.autocloseStoreRefLocked(evt.Subject)
+	}
 	cs.mu.RUnlock()
 
 	for _, store := range stores {
@@ -462,6 +472,47 @@ func (cs *controllerState) applyBeadEventToStores(evt events.Event) {
 	if evt.Actor != "cache-reconcile" {
 		cs.Poke()
 	}
+	if evt.Type == events.BeadClosed && evt.Subject != "" && len(stores) > 0 {
+		cs.runBeadCloseAutoclose(evt.Subject, stores[0], storeRef)
+	}
+}
+
+// autocloseStoreRefLocked returns the storeRef string for the store that owns
+// beadID. Called under cs.mu read lock.
+func (cs *controllerState) autocloseStoreRefLocked(beadID string) string {
+	if cs.cfg == nil {
+		return ""
+	}
+	cityPath := cs.cityPath
+	cityName := loadedCityName(cs.cfg, cityPath)
+	if prefix := config.EffectiveHQPrefix(cs.cfg); prefix != "" && strings.HasPrefix(beadID, prefix+"-") {
+		return workflowStoreRefForDir(cityPath, cityPath, cityName, cs.cfg)
+	}
+	for _, rig := range cs.cfg.Rigs {
+		if prefix := rig.EffectivePrefix(); prefix != "" && strings.HasPrefix(beadID, prefix+"-") {
+			rigPath := rig.Path
+			if !filepath.IsAbs(rigPath) {
+				rigPath = filepath.Join(cityPath, rigPath)
+			}
+			return workflowStoreRefForDir(rigPath, cityPath, cityName, cs.cfg)
+		}
+	}
+	return ""
+}
+
+// runBeadCloseAutoclose dispatches convoy/wisp/molecule autoclose for a closed
+// bead via the controller's store. Replaces the shell on_close hook chain that
+// spawned gc subprocesses per bead write (gastownhall/gascity#3248).
+func (cs *controllerState) runBeadCloseAutoclose(beadID string, store beads.Store, storeRef string) {
+	rec := events.Discard
+	if cs.eventProv != nil {
+		rec = cs.eventProv
+	}
+	beadCloseAutocloseDispatch(func() {
+		doConvoyAutocloseWith(store, rec, beadID, os.Stderr, os.Stderr)
+		doWispAutocloseWith(store, beadID, os.Stderr)
+		doMoleculeAutocloseWith(store, storeRef, rec, beadID, os.Stderr)
+	})
 }
 
 func (cs *controllerState) beadEventStoresLocked(evt events.Event) []beads.Store {

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -3826,3 +3826,78 @@ func TestControllerStateSuspendRestoresSymlinkedAgentTomlTargetWhenRefreshFails(
 		t.Fatal("SuspendAgent should not mark config dirty after rollback")
 	}
 }
+
+// TestApplyBeadEventToStoresTriggersConvoyAutoclose verifies that a
+// bead.closed event processed by the controller triggers convoy autoclose via
+// the in-process path, without spawning a gc subprocess.
+func TestApplyBeadEventToStoresTriggersConvoyAutoclose(t *testing.T) {
+	prev := beadCloseAutocloseDispatch
+	beadCloseAutocloseDispatch = func(fn func()) { fn() } // synchronous in tests
+	t.Cleanup(func() { beadCloseAutocloseDispatch = prev })
+
+	backing := beads.NewMemStore()
+	// gc-1: convoy, gc-2 and gc-3 are child members tracked by the convoy
+	convoy, err := backing.Create(beads.Bead{Title: "batch", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("Create convoy: %v", err)
+	}
+	childA, err := backing.Create(beads.Bead{Title: "task A", ParentID: convoy.ID})
+	if err != nil {
+		t.Fatalf("Create childA: %v", err)
+	}
+	childB, err := backing.Create(beads.Bead{Title: "task B", ParentID: convoy.ID})
+	if err != nil {
+		t.Fatalf("Create childB: %v", err)
+	}
+
+	// Close childA first; convoy still has an open child.
+	if err := backing.Close(childA.ID); err != nil {
+		t.Fatalf("Close childA: %v", err)
+	}
+
+	// Prime the CachingStore so it knows about all beads.
+	cached := beads.NewCachingStoreForTest(backing, nil)
+	if err := cached.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// Close childB in the backing store only (simulates an agent bd close).
+	if err := backing.Close(childB.ID); err != nil {
+		t.Fatalf("Close childB: %v", err)
+	}
+	// Update the cache to reflect the close (normally done by the event watcher).
+	if err := cached.Update(childB.ID, beads.UpdateOpts{Status: stringPtr("closed")}); err != nil {
+		t.Fatalf("Update childB in cache: %v", err)
+	}
+
+	closedPayload, err := json.Marshal(beads.Bead{
+		ID:     childB.ID,
+		Title:  "task B",
+		Status: "closed",
+		Type:   "task",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	cs := &controllerState{
+		beadStores: map[string]beads.Store{"test": cached},
+		pokeCh:     make(chan struct{}, 1),
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadClosed,
+		Actor:   "agent",
+		Subject: childB.ID,
+		Payload: closedPayload,
+	})
+
+	// Convoy should now be auto-closed since all children are terminal.
+	got, err := backing.Get(convoy.ID)
+	if err != nil {
+		t.Fatalf("Get convoy: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Errorf("convoy status = %q after all children closed, want %q", got.Status, "closed")
+	}
+}

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -495,25 +495,16 @@ func normalizeCanonicalBdScopeFilesForInit(cityPath, dir, prefix, doltDatabase s
 }
 
 // initAndHookDir is the atomic unit of bead store initialization:
-// init the directory, then install event hooks. The ordering matters
-// because init (bd init) may recreate .beads/ and wipe existing hooks.
+// init the directory, then remove any stale gc-managed bead event hooks.
+// The ordering matters because init (bd init) may recreate .beads/ and
+// wipe existing hooks. installBeadHooks only removes gc-stamped hooks and
+// is always safe to run regardless of event_hooks config.
 func initAndHookDir(cityPath, dir, prefix string) error {
-	// Honor [beads] event_hooks=false: skip installing the bd write hooks
-	// (on_create/on_update/on_close). Those hooks fork a full `gc event emit`
-	// per bead write — a real CPU/connection-churn source under load — and a
-	// city that opts out of them must not have them silently reinstalled on
-	// every reconcile. Default (unset) stays true. Load failure → default true.
-	installHooks := true
-	if cfg, err := loadCityConfig(cityPath, io.Discard); err == nil {
-		installHooks = cfg.Beads.EventHooksEnabled()
-	}
 	if usesPostgres, err := scopeUsesPostgresBackendForInit(cityPath, dir); err != nil {
 		return err
 	} else if usesPostgres {
-		if installHooks {
-			if err := installBeadHooks(dir, cityPath); err != nil {
-				return fmt.Errorf("install hooks at %s: %w", dir, err)
-			}
+		if err := installBeadHooks(dir, cityPath); err != nil {
+			return fmt.Errorf("install hooks at %s: %w", dir, err)
 		}
 		return nil
 	}
@@ -549,10 +540,8 @@ func initAndHookDir(cityPath, dir, prefix string) error {
 		}
 	}
 	// Non-fatal: hooks are convenience (event forwarding), not critical.
-	if installHooks {
-		if err := installBeadHooks(dir, cityPath); err != nil {
-			return fmt.Errorf("install hooks at %s: %w", dir, err)
-		}
+	if err := installBeadHooks(dir, cityPath); err != nil {
+		return fmt.Errorf("install hooks at %s: %w", dir, err)
 	}
 	return nil
 }

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -5189,8 +5189,8 @@ exit 99
 	if !ok || state.Backend != "postgres" || state.PostgresDatabase != "beads_pg" {
 		t.Fatalf("metadata state = %+v, ok=%v; want postgres metadata preserved", state, ok)
 	}
-	if _, err := os.Stat(filepath.Join(cityPath, ".beads", "hooks", "on_create")); err != nil {
-		t.Fatalf("expected hooks installed for postgres scope: %v", err)
+	if _, err := os.Stat(filepath.Join(cityPath, ".beads", "hooks", "on_create")); !os.IsNotExist(err) {
+		t.Fatalf("gc must not install bd event hooks for postgres scope (stat err=%v)", err)
 	}
 }
 
@@ -5357,8 +5357,8 @@ exit 99
 	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "metadata.json")); !os.IsNotExist(err) {
 		t.Fatalf("inherited postgres rig should not be pinned with local metadata, stat err = %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); err != nil {
-		t.Fatalf("expected hooks installed for inherited postgres rig: %v", err)
+	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); !os.IsNotExist(err) {
+		t.Fatalf("gc must not install bd event hooks for inherited postgres rig (stat err=%v)", err)
 	}
 }
 
@@ -5401,8 +5401,8 @@ exit 99
 			if string(data) != tc.metadata {
 				t.Fatalf("metadata = %s, want preserved %s", data, tc.metadata)
 			}
-			if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); err != nil {
-				t.Fatalf("expected hooks installed for inherited postgres rig: %v", err)
+			if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); !os.IsNotExist(err) {
+				t.Fatalf("gc must not install bd event hooks for inherited postgres rig (stat err=%v)", err)
 			}
 		})
 	}
@@ -5462,8 +5462,8 @@ esac
 	if _, err := os.Stat(initArgsFile); err != nil {
 		t.Fatalf("expected bd init attempt, stat err = %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); err != nil {
-		t.Fatalf("expected hooks installed for adopted rig: %v", err)
+	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); !os.IsNotExist(err) {
+		t.Fatalf("gc must not install bd event hooks for adopted rig (stat err=%v)", err)
 	}
 }
 
@@ -5520,8 +5520,8 @@ esac
 	if _, err := os.Stat(providerArgsFile); err != nil {
 		t.Fatalf("expected provider init attempt, stat err = %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); err != nil {
-		t.Fatalf("expected hooks installed for adopted rig: %v", err)
+	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); !os.IsNotExist(err) {
+		t.Fatalf("gc must not install bd event hooks for adopted canonical exec rig (stat err=%v)", err)
 	}
 }
 

--- a/cmd/gc/hooks.go
+++ b/cmd/gc/hooks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,19 +13,58 @@ import (
 // in-process and runs convoy/wisp/molecule autoclose natively.
 var beadEventHookNames = []string{"on_create", "on_update", "on_close"}
 
+// hookStampLine returns the version-stamp comment embedded in gc-managed hook
+// scripts so that installBeadHooks can distinguish them from user-authored hooks.
+func hookStampLine() string {
+	return fmt.Sprintf("# gc-hook-stamp: %s %s", date, commit)
+}
+
+// isGCManagedHook reports whether the hook content was written by gc (i.e.
+// contains a gc-hook-stamp line). Only gc-managed hooks are removed during
+// cleanup; user-authored hooks with the same filename are left untouched.
+func isGCManagedHook(content []byte) bool {
+	return parseHookStampDate(content) != ""
+}
+
+// parseHookStampDate extracts the build date from a hook script's stamp line.
+// Returns empty string if no stamp is found.
+func parseHookStampDate(content []byte) string {
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if bytes.HasPrefix(line, []byte("# gc-hook-stamp: ")) {
+			parts := bytes.Fields(line)
+			if len(parts) >= 3 {
+				return string(parts[2])
+			}
+		}
+	}
+	return ""
+}
+
 // installBeadHooks removes any gc-installed bead event-forwarding hooks from
 // dir/.beads/hooks/. The hook subprocess chain (gc event emit + gc convoy
 // autoclose + gc wisp autoclose + gc molecule autoclose) is replaced by the
 // controller's in-process CachingStore event path, which emits the same events
 // via its onChange callback and runs autoclose in runBeadCloseAutoclose.
 //
-// Non-gc hooks (e.g. git pre-commit hooks) in the directory are left
-// untouched. This function is idempotent: it is safe to call when the hooks
-// do not exist.
+// Only hooks that carry a gc-hook-stamp are removed; user-authored hooks with
+// the same filename are left untouched. This function is idempotent: it is
+// safe to call when the hooks do not exist.
 func installBeadHooks(dir, _ string) error {
 	hooksDir := filepath.Join(dir, ".beads", "hooks")
 	for _, filename := range beadEventHookNames {
-		if err := os.Remove(filepath.Join(hooksDir, filename)); err != nil && !os.IsNotExist(err) {
+		hookPath := filepath.Join(hooksDir, filename)
+		content, err := os.ReadFile(hookPath)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("reading bead event hook %s: %w", filename, err)
+		}
+		if !isGCManagedHook(content) {
+			continue
+		}
+		if err := os.Remove(hookPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing bead event hook %s: %w", filename, err)
 		}
 	}

--- a/cmd/gc/hooks.go
+++ b/cmd/gc/hooks.go
@@ -1,220 +1,31 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-// beadEventHooksEnabled reports whether the per-write bead event-forwarding
-// hooks should be installed for cityPath. Defaults to true; a city opts out
-// with [beads] event_hooks = false once it has confirmed the controller's
-// native cache-events cover bead observation. Failure to load config falls
-// back to the safe default (install) so a transient read error never silently
-// drops event forwarding.
-func beadEventHooksEnabled(cityPath string) bool {
-	if strings.TrimSpace(cityPath) == "" {
-		return true
-	}
-	cfg, err := loadCityConfig(cityPath, io.Discard)
-	if err != nil || cfg == nil {
-		return true
-	}
-	return cfg.Beads.EventHooksEnabled()
-}
+// beadEventHookNames lists the gc-installed bd event-forwarding hook names
+// removed by installBeadHooks. These hooks previously spawned a gc subprocess
+// per bead write; the controller's CachingStore now emits the same events
+// in-process and runs convoy/wisp/molecule autoclose natively.
+var beadEventHookNames = []string{"on_create", "on_update", "on_close"}
 
-// beadHooks maps bd hook filenames to the Gas City event types they emit.
-var beadHooks = map[string]string{
-	"on_create": "bead.created",
-	"on_close":  "bead.closed",
-	"on_update": "bead.updated",
-}
-
-// hookStampLine returns a version-stamp comment for hook scripts. The stamp
-// embeds the build date and commit so that installBeadHooks can enforce
-// forward-only writes — a stale gc binary will not overwrite hooks installed
-// by a newer binary.
-func hookStampLine() string {
-	return fmt.Sprintf("# gc-hook-stamp: %s %s", date, commit)
-}
-
-// parseHookStampDate extracts the build date from a hook script's stamp line.
-// Returns empty string if no stamp is found.
-func parseHookStampDate(content []byte) string {
-	for _, line := range bytes.Split(content, []byte("\n")) {
-		line = bytes.TrimSpace(line)
-		if bytes.HasPrefix(line, []byte("# gc-hook-stamp: ")) {
-			parts := bytes.Fields(line)
-			if len(parts) >= 3 {
-				return string(parts[2])
-			}
-		}
-	}
-	return ""
-}
-
-// hookCityBlock returns the shell fragment that defines CITY_PATH and the
-// matching --city argument to gc event emit. When cityPath is empty the
-// fragment is empty — preserving the original "walk up from cwd" behavior
-// for callers that have not yet been updated to thread the city path.
+// installBeadHooks removes any gc-installed bead event-forwarding hooks from
+// dir/.beads/hooks/. The hook subprocess chain (gc event emit + gc convoy
+// autoclose + gc wisp autoclose + gc molecule autoclose) is replaced by the
+// controller's in-process CachingStore event path, which emits the same events
+// via its onChange callback and runs autoclose in runBeadCloseAutoclose.
 //
-// The cityPath is embedded at install time so the hook script does not
-// depend on the bd write's cwd being a descendant of the city. Sibling-rig
-// topologies (rig at /Code/foo, city at /Code/bar) used to silently drop
-// events because findCity walked up from the rig and never reached the city.
-func hookCityBlock(cityPath string) (def, arg string) {
-	if cityPath == "" {
-		return "", ""
-	}
-	return fmt.Sprintf("CITY_PATH=%s\n", shellSingleQuote(cityPath)), ` --city "$CITY_PATH"`
-}
-
-func shellSingleQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
-}
-
-// hookScript returns the shell script content for a bd hook that forwards
-// events to the Gas City event log via gc event emit. Failures are
-// captured to ${BEADS_DIR}/hooks.log so silent breakage (missing gc on
-// PATH, store-resolution errors) is diagnosable after the fact.
-//
-// When cityPath is non-empty it is baked into the script as
-// a shell-quoted CITY_PATH and gc event emit is invoked with --city
-// "$CITY_PATH". This avoids the findCity walk-up that fails when
-// the bd write's cwd is a sibling (not a descendant) of the city.
-func hookScript(eventType, cityPath string) string {
-	cityDef, cityArg := hookCityBlock(cityPath)
-	return fmt.Sprintf(`#!/bin/sh
-%[1]s
-# Installed by gc — forwards bd events to Gas City event log.
-# Args: $1=issue_id  $2=event_type  stdin=issue JSON
-GC_BIN="${GC_BIN:-gc}"
-HOOK_LOG="${BEADS_DIR:-.beads}/hooks.log"
-%[5]sDATA=$(cat)
-PAYLOAD=$(printf '{"bead":%%s}' "$DATA")
-title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
-# Tag subprocess bd calls so the bd-trace can attribute them to the
-# hook cascade (best-effort; ignored when GC_BD_TRACE is unset).
-export GC_BD_TRACE_SCOPE="hook:%[2]s"
-(
-  "$GC_BIN"%[6]s event emit %[2]s --subject "$1" --message "$title" --payload "$PAYLOAD" --bead-payload "$1" 2>>"$HOOK_LOG" \
-    || echo "[$(date -u +%%FT%%TZ)] %[3]s $1: gc event emit %[2]s failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
-    || true
-) </dev/null >/dev/null 2>&1 &
-`, hookStampLine(), eventType, hookNameFromEventType(eventType), "", cityDef, cityArg)
-}
-
-// hookNameFromEventType maps event types back to the hook filename
-// (e.g. "bead.created" → "on_create") so diagnostic log lines name the
-// hook the operator can grep for.
-func hookNameFromEventType(eventType string) string {
-	for hook, evt := range beadHooks {
-		if evt == eventType {
-			return hook
-		}
-	}
-	return "hook"
-}
-
-// closeHookScript returns the on_close hook script. It forwards the
-// bead.closed event, triggers convoy autoclose for the closed bead's
-// parent convoy (if any), and auto-closes any open molecule/wisp
-// children attached to the closed bead. Workflow-control watches the city
-// event stream directly, so the close hook no longer sends a separate poke.
-//
-// Failures of any of the three gc invocations are logged with a dated
-// diagnostic line to ${BEADS_DIR}/hooks.log. Without this, missing gc
-// or a store-resolution error here leaves no record at all and the
-// cascade-close of sling scaffolding fails invisibly.
-//
-// When cityPath is non-empty it is baked into the script as
-// a shell-quoted CITY_PATH and the gc invocations carry --city "$CITY_PATH".
-func closeHookScript(cityPath string) string {
-	cityDef, cityArg := hookCityBlock(cityPath)
-	return fmt.Sprintf(`#!/bin/sh
-%[1]s
-# Installed by gc — forwards bd close events, auto-closes completed convoys,
-# and auto-closes orphaned wisps.
-# Args: $1=issue_id  $2=event_type  stdin=issue JSON
-GC_BIN="${GC_BIN:-gc}"
-HOOK_LOG="${BEADS_DIR:-.beads}/hooks.log"
-%[2]sDATA=$(cat)
-PAYLOAD=$(printf '{"bead":%%s}' "$DATA")
-title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
-# Tag subprocess bd calls so the bd-trace can attribute them to the
-# hook cascade (best-effort; ignored when GC_BD_TRACE is unset).
-export GC_BD_TRACE_SCOPE="hook:bead.closed"
-(
-  "$GC_BIN"%[3]s event emit bead.closed --subject "$1" --message "$title" --payload "$PAYLOAD" --bead-payload "$1" 2>>"$HOOK_LOG" \
-    || echo "[$(date -u +%%FT%%TZ)] on_close $1: gc event emit bead.closed failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
-    || true
-  # Auto-close parent convoy if all siblings are now closed.
-  "$GC_BIN"%[3]s convoy autoclose "$1" 2>>"$HOOK_LOG" \
-    || echo "[$(date -u +%%FT%%TZ)] on_close $1: gc convoy autoclose failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
-    || true
-  # Auto-close open molecule/wisp children so they don't outlive the parent.
-  "$GC_BIN"%[3]s wisp autoclose "$1" 2>>"$HOOK_LOG" \
-    || echo "[$(date -u +%%FT%%TZ)] on_close $1: gc wisp autoclose failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
-    || true
-  # Auto-close parent molecule when all step children are terminal (#1039).
-  "$GC_BIN"%[3]s molecule autoclose "$1" 2>>"$HOOK_LOG" \
-    || echo "[$(date -u +%%FT%%TZ)] on_close $1: gc molecule autoclose failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
-    || true
-) </dev/null >/dev/null 2>&1 &
-`, hookStampLine(), cityDef, cityArg)
-}
-
-// installBeadHooks writes bd hook scripts into dir/.beads/hooks/ so that
-// bd mutations (create, close, update) emit events to the Gas City event
-// log. Forward-only — a stale gc binary will not overwrite hooks installed
-// by a newer binary. Returns nil on success.
-//
-// cityPath is baked into each generated hook script so gc event emit
-// can resolve the city without walking up from the bd write's cwd. When
-// cityPath is "" the scripts are generated without the --city flag,
-// preserving the legacy "walk up from cwd" behavior; this is appropriate
-// for tests and for callers that genuinely don't know the city yet.
-func installBeadHooks(dir, cityPath string) error {
+// Non-gc hooks (e.g. git pre-commit hooks) in the directory are left
+// untouched. This function is idempotent: it is safe to call when the hooks
+// do not exist.
+func installBeadHooks(dir, _ string) error {
 	hooksDir := filepath.Join(dir, ".beads", "hooks")
-	if !beadEventHooksEnabled(cityPath) {
-		// Opted out: ensure the event-forwarding hooks are absent so the
-		// native store's bd_hooks gate can clear and no per-write `gc`
-		// subprocess fires. Only the event hooks (beadHooks) are removed;
-		// git hooks and anything else in the directory are left untouched.
-		for filename := range beadHooks {
-			if err := os.Remove(filepath.Join(hooksDir, filename)); err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("removing disabled bead event hook %s: %w", filename, err)
-			}
-		}
-		return nil
-	}
-	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
-		return fmt.Errorf("creating hooks directory: %w", err)
-	}
-
-	for filename, eventType := range beadHooks {
-		path := filepath.Join(hooksDir, filename)
-		content := hookScript(eventType, cityPath)
-		if filename == "on_close" {
-			content = closeHookScript(cityPath)
-		}
-
-		if existing, err := os.ReadFile(path); err == nil {
-			if date != "unknown" {
-				onDiskDate := parseHookStampDate(existing)
-				if onDiskDate != "" && onDiskDate != "unknown" && date < onDiskDate {
-					continue
-				}
-			}
-		}
-
-		if err := fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, path, []byte(content), 0o755); err != nil {
-			return fmt.Errorf("writing hook %s: %w", filename, err)
+	for _, filename := range beadEventHookNames {
+		if err := os.Remove(filepath.Join(hooksDir, filename)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing bead event hook %s: %w", filename, err)
 		}
 	}
 	return nil

--- a/cmd/gc/hooks.go
+++ b/cmd/gc/hooks.go
@@ -19,11 +19,19 @@ func hookStampLine() string {
 	return fmt.Sprintf("# gc-hook-stamp: %s %s", date, commit)
 }
 
-// isGCManagedHook reports whether the hook content was written by gc (i.e.
-// contains a gc-hook-stamp line). Only gc-managed hooks are removed during
-// cleanup; user-authored hooks with the same filename are left untouched.
+// isGCManagedHook reports whether the hook content was written by gc.
+// It recognizes both the current gc-hook-stamp format and the legacy
+// "# Installed by gc" marker used before stamping was introduced.
+// Only gc-managed hooks are removed during cleanup; user-authored hooks
+// with the same filename are left untouched.
 func isGCManagedHook(content []byte) bool {
-	return parseHookStampDate(content) != ""
+	if parseHookStampDate(content) != "" {
+		return true
+	}
+	// Legacy hooks written by older gc versions use "# Installed by gc"
+	// as the first marker line and invoke "$GC_BIN" event emit per write.
+	return bytes.Contains(content, []byte("# Installed by gc")) &&
+		bytes.Contains(content, []byte(`"$GC_BIN" event emit`))
 }
 
 // parseHookStampDate extracts the build date from a hook script's stamp line.

--- a/cmd/gc/hooks_test.go
+++ b/cmd/gc/hooks_test.go
@@ -18,7 +18,8 @@ func TestInstallBeadHooksRemovesExistingHooks(t *testing.T) {
 	}
 	for _, name := range beadEventHookNames {
 		p := filepath.Join(hooksDir, name)
-		if err := os.WriteFile(p, []byte("#!/bin/sh\necho old\n"), 0o755); err != nil {
+		gcContent := []byte("#!/bin/sh\n" + hookStampLine() + "\nexit 0\n")
+		if err := os.WriteFile(p, gcContent, 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -65,6 +66,34 @@ func TestInstallBeadHooksIdempotentNoHooks(t *testing.T) {
 	}
 	if err := installBeadHooks(dir, ""); err != nil {
 		t.Fatalf("second installBeadHooks: %v", err)
+	}
+}
+
+// TestInstallBeadHooksPreservesUserOwnedSameNameHook verifies that a hook file
+// with a standard bd hook name (e.g. on_create) but no gc-hook-stamp is not
+// removed by installBeadHooks — only gc-installed hooks are cleaned up.
+func TestInstallBeadHooksPreservesUserOwnedSameNameHook(t *testing.T) {
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".beads", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userHook := filepath.Join(hooksDir, "on_create")
+	userContent := []byte("#!/bin/sh\n# user-authored lifecycle hook\nexit 0\n")
+	if err := os.WriteFile(userHook, userContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installBeadHooks(dir, ""); err != nil {
+		t.Fatalf("installBeadHooks: %v", err)
+	}
+
+	got, err := os.ReadFile(userHook)
+	if err != nil {
+		t.Fatalf("user-authored on_create hook was deleted: %v", err)
+	}
+	if string(got) != string(userContent) {
+		t.Errorf("user-authored on_create hook was modified; want %q got %q", userContent, got)
 	}
 }
 

--- a/cmd/gc/hooks_test.go
+++ b/cmd/gc/hooks_test.go
@@ -97,6 +97,54 @@ func TestInstallBeadHooksPreservesUserOwnedSameNameHook(t *testing.T) {
 	}
 }
 
+// TestInstallBeadHooksRemovesLegacyUnstampedHook verifies that hooks written
+// by older gc versions (using "# Installed by gc" without a gc-hook-stamp)
+// are also removed by installBeadHooks, so pre-stamp deployments converge.
+func TestInstallBeadHooksRemovesLegacyUnstampedHook(t *testing.T) {
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".beads", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyContent := []byte("#!/bin/sh\n# Installed by gc\n\"$GC_BIN\" event emit --bead \"$BEADS_BEAD_ID\" on_close\n")
+	hookPath := filepath.Join(hooksDir, "on_close")
+	if err := os.WriteFile(hookPath, legacyContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installBeadHooks(dir, ""); err != nil {
+		t.Fatalf("installBeadHooks: %v", err)
+	}
+
+	if _, err := os.Stat(hookPath); !os.IsNotExist(err) {
+		t.Errorf("legacy unstamped gc hook should be removed (stat err=%v)", err)
+	}
+}
+
+// TestInstallBeadHooksPreservesUserOwnedLegacyNamedHook verifies that a
+// user-authored hook that happens to mention "gc" in its body but does NOT
+// carry the legacy gc pattern is left untouched.
+func TestInstallBeadHooksPreservesUserOwnedLegacyNamedHook(t *testing.T) {
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".beads", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userContent := []byte("#!/bin/sh\n# Installed by gc\n# user-extended hook, not the old forwarder pattern\nmy-tool notify\n")
+	hookPath := filepath.Join(hooksDir, "on_create")
+	if err := os.WriteFile(hookPath, userContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installBeadHooks(dir, ""); err != nil {
+		t.Fatalf("installBeadHooks: %v", err)
+	}
+
+	if _, err := os.Stat(hookPath); err != nil {
+		t.Errorf("user hook with only the marker comment (no forwarder body) must be preserved: %v", err)
+	}
+}
+
 // TestInstallBeadHooksInitIntegration verifies that gc init does NOT install
 // bd event-forwarding hooks; autoclose now runs in the controller.
 func TestInstallBeadHooksInitIntegration(t *testing.T) {

--- a/cmd/gc/hooks_test.go
+++ b/cmd/gc/hooks_test.go
@@ -3,545 +3,73 @@ package main
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 )
 
-func TestHookScriptsContainStamp(t *testing.T) {
-	oldDate, oldCommit := date, commit
-	t.Cleanup(func() { date, commit = oldDate, oldCommit })
-
-	date = "2026-04-29T10:00:00Z"
-	commit = "abc1234"
-
-	for name, eventType := range beadHooks {
-		t.Run(name, func(t *testing.T) {
-			var content string
-			if name == "on_close" {
-				content = closeHookScript("")
-			} else {
-				content = hookScript(eventType, "")
-			}
-			if !strings.Contains(content, "# gc-hook-stamp: 2026-04-29T10:00:00Z abc1234") {
-				t.Errorf("hook %s missing stamp line:\n%s", name, content)
-			}
-		})
-	}
-}
-
-func TestParseHookStampDate(t *testing.T) {
-	tests := []struct {
-		name    string
-		content string
-		want    string
-	}{
-		{"with stamp", "#!/bin/sh\n# gc-hook-stamp: 2026-04-29T10:00:00Z abc1234\n", "2026-04-29T10:00:00Z"},
-		{"no stamp", "#!/bin/sh\n# Installed by gc\n", ""},
-		{"empty", "", ""},
-		{"unknown date", "#!/bin/sh\n# gc-hook-stamp: unknown unknown\n", "unknown"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := parseHookStampDate([]byte(tt.content))
-			if got != tt.want {
-				t.Errorf("parseHookStampDate() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
-// TestHookScriptEmbedsCityPath verifies that hook scripts generated with an
-// explicit cityPath embed CITY_PATH and pass --city "$CITY_PATH" to
-// gc event emit. This is the fix for sibling-rig topologies where the
-// bd write's cwd is not a descendant of the city: findCity walks up and
-// fails, so gc event emit silently drops the event unless --city is set.
-func TestHookScriptEmbedsCityPath(t *testing.T) {
-	const cityPath = "/some/city"
-	for name, eventType := range beadHooks {
-		t.Run(name, func(t *testing.T) {
-			var content string
-			if name == "on_close" {
-				content = closeHookScript(cityPath)
-			} else {
-				content = hookScript(eventType, cityPath)
-			}
-			if !strings.Contains(content, `CITY_PATH='/some/city'`) {
-				t.Errorf("hook %s missing CITY_PATH definition:\n%s", name, content)
-			}
-			if !strings.Contains(content, `--city "$CITY_PATH"`) {
-				t.Errorf("hook %s does not pass --city \"$CITY_PATH\" to gc event emit:\n%s", name, content)
-			}
-			if !strings.Contains(content, `--bead-payload "$1"`) {
-				t.Errorf("hook %s missing bead payload fallback with cityPath:\n%s", name, content)
-			}
-		})
-	}
-}
-
-// TestHookScriptOmitsCityFlagWhenEmpty verifies that an empty cityPath
-// produces a hook script without the --city flag — preserving the
-// original "walk up from cwd" behavior for callers that have not yet
-// been updated to thread the city path.
-func TestHookScriptOmitsCityFlagWhenEmpty(t *testing.T) {
-	for name, eventType := range beadHooks {
-		t.Run(name, func(t *testing.T) {
-			var content string
-			if name == "on_close" {
-				content = closeHookScript("")
-			} else {
-				content = hookScript(eventType, "")
-			}
-			if strings.Contains(content, "--city") {
-				t.Errorf("hook %s emitted --city flag with empty cityPath:\n%s", name, content)
-			}
-			if strings.Contains(content, "CITY_PATH=") {
-				t.Errorf("hook %s emitted CITY_PATH= with empty cityPath:\n%s", name, content)
-			}
-		})
-	}
-}
-
-// TestInstallBeadHooksThreadsCityPath verifies that installBeadHooks
-// passes the cityPath argument through to the generated hook scripts.
-func TestInstallBeadHooksThreadsCityPath(t *testing.T) {
+// TestInstallBeadHooksRemovesExistingHooks verifies that installBeadHooks
+// removes any existing on_create/on_update/on_close hooks, cleaning up
+// deployments that were installed by an older gc binary.
+func TestInstallBeadHooksRemovesExistingHooks(t *testing.T) {
 	dir := t.TempDir()
-	cityPath := filepath.Join(dir, "city")
-	if err := installBeadHooks(dir, cityPath); err != nil {
-		t.Fatalf("installBeadHooks: %v", err)
-	}
-
-	for _, filename := range []string{"on_create", "on_close", "on_update"} {
-		t.Run(filename, func(t *testing.T) {
-			path := filepath.Join(dir, ".beads", "hooks", filename)
-			data, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatalf("ReadFile: %v", err)
-			}
-			content := string(data)
-			wantDef := "CITY_PATH='" + cityPath + "'"
-			if !strings.Contains(content, wantDef) {
-				t.Errorf("hook %s missing %q:\n%s", filename, wantDef, content)
-			}
-			if !strings.Contains(content, `--city "$CITY_PATH"`) {
-				t.Errorf("hook %s does not pass --city \"$CITY_PATH\":\n%s", filename, content)
-			}
-			if !strings.Contains(content, `--bead-payload "$1"`) {
-				t.Errorf("hook %s missing bead payload fallback:\n%s", filename, content)
-			}
-		})
-	}
-}
-
-// TestInstallBeadHooksDisabledByConfig verifies that with
-// [beads] event_hooks = false, installBeadHooks removes the per-write
-// event-forwarding hooks (leaving git hooks) and does not reinstall them —
-// so a deployment whose controller cache-events already observe bead changes
-// avoids the `gc event emit` churn and clears the native-store bd_hooks gate.
-func TestInstallBeadHooksDisabledByConfig(t *testing.T) {
-	cityPath := t.TempDir()
-	writeSchema2RigCity(t, cityPath, "test-city",
-		"[workspace]\nname = \"test-city\"\n\n[beads]\nevent_hooks = false\n", "")
-
-	hooksDir := filepath.Join(cityPath, ".beads", "hooks")
+	hooksDir := filepath.Join(dir, ".beads", "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	eventHook := filepath.Join(hooksDir, "on_create")
-	gitHook := filepath.Join(hooksDir, "pre-commit")
-	for _, p := range []string{eventHook, gitHook} {
-		if err := os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	for _, name := range beadEventHookNames {
+		p := filepath.Join(hooksDir, name)
+		if err := os.WriteFile(p, []byte("#!/bin/sh\necho old\n"), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	if err := installBeadHooks(cityPath, cityPath); err != nil {
-		t.Fatalf("installBeadHooks: %v", err)
-	}
-
-	if _, err := os.Stat(eventHook); !os.IsNotExist(err) {
-		t.Errorf("on_create event hook should be removed when event_hooks=false (stat err=%v)", err)
-	}
-	if _, err := os.Stat(gitHook); err != nil {
-		t.Errorf("git hook pre-commit must be left untouched: %v", err)
-	}
-}
-
-// TestInstallBeadHooksEnabledByDefault verifies that without the opt-out, the
-// event hooks install exactly as before (default true).
-func TestInstallBeadHooksEnabledByDefault(t *testing.T) {
-	cityPath := t.TempDir()
-	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\nname = \"test-city\"\n", "")
-	if err := installBeadHooks(cityPath, cityPath); err != nil {
-		t.Fatalf("installBeadHooks: %v", err)
-	}
-	for _, fn := range []string{"on_create", "on_update", "on_close"} {
-		if _, err := os.Stat(filepath.Join(cityPath, ".beads", "hooks", fn)); err != nil {
-			t.Errorf("default install should write %s: %v", fn, err)
-		}
-	}
-}
-
-func TestGeneratedHookPassesLiteralCityPath(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
-	parent := t.TempDir()
-	runDir := filepath.Join(parent, "external-rig")
-	if err := os.MkdirAll(runDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	cityPath := filepath.Join(parent, "city with spaces $HOME $(touch shell-expansion-marker) `touch backtick-expansion-marker` and ' quote")
-	if err := os.MkdirAll(cityPath, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	recordPath := filepath.Join(parent, "gc-argv.txt")
-	mockGC := writeNamedTestScript(t, "mock-gc.sh", `#!/bin/sh
-{
-  i=0
-  for arg do
-    i=$((i + 1))
-    printf 'arg%d=%s\n' "$i" "$arg"
-  done
-} >> "$GC_ARG_RECORD"
-`)
-
-	if err := installBeadHooks(runDir, cityPath); err != nil {
-		t.Fatalf("installBeadHooks: %v", err)
-	}
-	hookPath := filepath.Join(runDir, ".beads", "hooks", "on_create")
-
-	cmd := exec.Command("sh", hookPath, "bead-1", "bead.created")
-	cmd.Dir = runDir
-	cmd.Stdin = strings.NewReader(`{"title":"hook argv test"}`)
-	cmd.Env = sanitizedBaseEnv(
-		"BEADS_DIR="+filepath.Join(runDir, ".beads"),
-		"GC_ARG_RECORD="+recordPath,
-		"GC_BIN="+mockGC,
-		"HOME=/expanded-home",
-	)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("hook exec failed: %v\nout: %s", err, out)
-	}
-
-	var content string
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(recordPath)
-		if err == nil && len(data) > 0 {
-			content = string(data)
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if content == "" {
-		t.Fatalf("mock gc did not record argv at %s", recordPath)
-	}
-
-	if !strings.Contains(content, "arg1=--city\n") || !strings.Contains(content, "arg2="+cityPath+"\n") {
-		t.Fatalf("hook did not pass literal city path.\nwant arg2=%q\nrecorded:\n%s", cityPath, content)
-	}
-	for _, marker := range []string{"shell-expansion-marker", "backtick-expansion-marker"} {
-		if _, err := os.Stat(filepath.Join(runDir, marker)); err == nil {
-			t.Fatalf("hook executed shell expansion command and created %s", marker)
-		} else if !os.IsNotExist(err) {
-			t.Fatalf("stat marker %s: %v", marker, err)
-		}
-	}
-}
-
-func TestInstallBeadHooksForwardOnly(t *testing.T) {
-	oldDate, oldCommit := date, commit
-	t.Cleanup(func() { date, commit = oldDate, oldCommit })
-
-	dir := t.TempDir()
-
-	// Install with a "newer" binary.
-	date = "2026-06-01T00:00:00Z"
-	commit = "new1111"
 	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("newer install: %v", err)
+		t.Fatalf("installBeadHooks: %v", err)
 	}
 
-	path := filepath.Join(dir, ".beads", "hooks", "on_create")
-	newerContent, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	if !strings.Contains(string(newerContent), "2026-06-01") {
-		t.Fatalf("newer hook missing expected stamp")
-	}
-
-	// Now run with an "older" binary — should NOT overwrite.
-	date = "2025-01-01T00:00:00Z"
-	commit = "old2222"
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("older install: %v", err)
-	}
-
-	afterContent, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	if !bytes.Equal(newerContent, afterContent) {
-		t.Errorf("stale binary overwrote newer hook.\nwant stamp from 2026-06-01, got:\n%s", afterContent)
+	for _, name := range beadEventHookNames {
+		if _, err := os.Stat(filepath.Join(hooksDir, name)); !os.IsNotExist(err) {
+			t.Errorf("hook %s should be removed after installBeadHooks (stat err=%v)", name, err)
+		}
 	}
 }
 
-func TestInstallBeadHooksUpgradesLegacyHooks(t *testing.T) {
-	oldDate, oldCommit := date, commit
-	t.Cleanup(func() { date, commit = oldDate, oldCommit })
-
+// TestInstallBeadHooksLeavesNonGCHooks verifies that non-gc hooks (e.g., git
+// pre-commit) are not removed when installBeadHooks runs.
+func TestInstallBeadHooksLeavesNonGCHooks(t *testing.T) {
 	dir := t.TempDir()
 	hooksDir := filepath.Join(dir, ".beads", "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-
-	// Write a legacy hook (no stamp).
-	legacy := "#!/bin/sh\n# Installed by gc — old version\necho old\n"
-	if err := os.WriteFile(filepath.Join(hooksDir, "on_create"), []byte(legacy), 0o755); err != nil {
+	gitHook := filepath.Join(hooksDir, "pre-commit")
+	if err := os.WriteFile(gitHook, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	date = "2026-01-01T00:00:00Z"
-	commit = "aaa1111"
 	if err := installBeadHooks(dir, ""); err != nil {
 		t.Fatalf("installBeadHooks: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(hooksDir, "on_create"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(data), "gc-hook-stamp") {
-		t.Errorf("legacy hook was not upgraded to stamped version:\n%s", data)
+	if _, err := os.Stat(gitHook); err != nil {
+		t.Errorf("non-gc hook pre-commit must be left untouched: %v", err)
 	}
 }
 
-func TestInstallBeadHooksDevBuildAlwaysWrites(t *testing.T) {
-	oldDate, oldCommit := date, commit
-	t.Cleanup(func() { date, commit = oldDate, oldCommit })
-
-	dir := t.TempDir()
-
-	// Install with a stamped binary.
-	date = "2099-01-01T00:00:00Z"
-	commit = "future1"
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("stamped install: %v", err)
-	}
-
-	// Dev build (unknown date) should still overwrite — dev builds always win.
-	date = "unknown"
-	commit = "unknown"
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("dev install: %v", err)
-	}
-
-	path := filepath.Join(dir, ".beads", "hooks", "on_create")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(data), "gc-hook-stamp: unknown unknown") {
-		t.Errorf("dev build did not overwrite stamped hook:\n%s", data)
-	}
-}
-
-func TestInstallBeadHooksCreatesScripts(t *testing.T) {
+// TestInstallBeadHooksIdempotentNoHooks verifies that installBeadHooks
+// succeeds when no hooks exist (no directory, no files).
+func TestInstallBeadHooksIdempotentNoHooks(t *testing.T) {
 	dir := t.TempDir()
 	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("installBeadHooks: %v", err)
+		t.Fatalf("installBeadHooks on empty dir: %v", err)
 	}
-
-	hooksDir := filepath.Join(dir, ".beads", "hooks")
-
-	for _, tc := range []struct {
-		filename  string
-		eventType string
-	}{
-		{"on_create", "bead.created"},
-		{"on_close", "bead.closed"},
-		{"on_update", "bead.updated"},
-	} {
-		t.Run(tc.filename, func(t *testing.T) {
-			path := filepath.Join(hooksDir, tc.filename)
-			fi, err := os.Stat(path)
-			if err != nil {
-				t.Fatalf("hook %s not created: %v", tc.filename, err)
-			}
-			// Check executable permission.
-			if fi.Mode()&0o111 == 0 {
-				t.Errorf("hook %s not executable: %v", tc.filename, fi.Mode())
-			}
-
-			data, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatalf("reading hook %s: %v", tc.filename, err)
-			}
-			content := string(data)
-
-			// Starts with shebang.
-			if !strings.HasPrefix(content, "#!/bin/sh") {
-				t.Errorf("hook %s missing shebang: %q", tc.filename, content[:min(len(content), 20)])
-			}
-			// Contains the correct event type.
-			if !strings.Contains(content, tc.eventType) {
-				t.Errorf("hook %s missing event type %q:\n%s", tc.filename, tc.eventType, content)
-			}
-			// Contains gc event emit.
-			if !strings.Contains(content, `GC_BIN="${GC_BIN:-gc}"`) {
-				t.Errorf("hook %s missing GC_BIN fallback:\n%s", tc.filename, content)
-			}
-			if !strings.Contains(content, `"$GC_BIN" event emit`) {
-				t.Errorf("hook %s missing '\"$GC_BIN\" event emit':\n%s", tc.filename, content)
-			}
-			if !strings.Contains(content, `PAYLOAD=$(printf '{"bead":%s}' "$DATA")`) {
-				t.Errorf("hook %s does not wrap bd JSON as BeadEventPayload:\n%s", tc.filename, content)
-			}
-			if !strings.Contains(content, `--payload "$PAYLOAD"`) {
-				t.Errorf("hook %s emits raw DATA instead of wrapped PAYLOAD:\n%s", tc.filename, content)
-			}
-			if !strings.Contains(content, `--bead-payload "$1"`) {
-				t.Errorf("hook %s missing bead payload fallback for empty hook stdin:\n%s", tc.filename, content)
-			}
-			// Best-effort: stderr redirected, || true.
-			if !strings.Contains(content, "|| true") {
-				t.Errorf("hook %s missing '|| true' (best-effort):\n%s", tc.filename, content)
-			}
-			if !strings.Contains(content, `) </dev/null >/dev/null 2>&1 &`) {
-				t.Errorf("hook %s missing detached background redirect:\n%s", tc.filename, content)
-			}
-			// Failure diagnostics: stderr captured to a log file, and
-			// non-zero exit produces a dated diagnostic line.
-			if !strings.Contains(content, `HOOK_LOG="${BEADS_DIR:-.beads}/hooks.log"`) {
-				t.Errorf("hook %s missing HOOK_LOG definition:\n%s", tc.filename, content)
-			}
-			if !strings.Contains(content, `2>>"$HOOK_LOG"`) {
-				t.Errorf("hook %s does not capture gc stderr to HOOK_LOG:\n%s", tc.filename, content)
-			}
-			if !strings.Contains(content, `>>"$HOOK_LOG" 2>/dev/null`) {
-				t.Errorf("hook %s missing failure-diagnostic echo into HOOK_LOG:\n%s", tc.filename, content)
-			}
-			// on_close hook must also trigger convoy autoclose and wisp autoclose.
-			if tc.filename == "on_close" {
-				if !strings.Contains(content, `"$GC_BIN" convoy autoclose`) {
-					t.Errorf("on_close hook missing '\"$GC_BIN\" convoy autoclose':\n%s", content)
-				}
-				if !strings.Contains(content, `"$GC_BIN" wisp autoclose`) {
-					t.Errorf("on_close hook missing '\"$GC_BIN\" wisp autoclose':\n%s", content)
-				}
-			}
-		})
+	if err := installBeadHooks(dir, ""); err != nil {
+		t.Fatalf("second installBeadHooks: %v", err)
 	}
 }
 
-func TestInstallBeadHooksIdempotent(t *testing.T) {
-	dir := t.TempDir()
-
-	// Install twice — should not error.
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("first install: %v", err)
-	}
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("second install: %v", err)
-	}
-
-	// Verify hooks still correct after second install.
-	path := filepath.Join(dir, ".beads", "hooks", "on_create")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("reading hook: %v", err)
-	}
-	if !strings.Contains(string(data), "bead.created") {
-		t.Errorf("hook content wrong after idempotent install")
-	}
-}
-
-func TestInstallBeadHooksDoesNotRewriteUnchangedHooks(t *testing.T) {
-	dir := t.TempDir()
-
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("first install: %v", err)
-	}
-
-	path := filepath.Join(dir, ".beads", "hooks", "on_create")
-	past := time.Unix(123456789, 0)
-	if err := os.Chtimes(path, past, past); err != nil {
-		t.Fatalf("Chtimes: %v", err)
-	}
-
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("second install: %v", err)
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !info.ModTime().Equal(past) {
-		t.Fatalf("unchanged hook was rewritten: modtime = %s, want %s", info.ModTime(), past)
-	}
-}
-
-func TestInstallBeadHooksReplacesMatchingSymlink(t *testing.T) {
-	dir := t.TempDir()
-
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("first install: %v", err)
-	}
-
-	path := filepath.Join(dir, ".beads", "hooks", "on_create")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile(%s): %v", path, err)
-	}
-	target := filepath.Join(dir, "outside-hook")
-	if err := os.WriteFile(target, data, 0o755); err != nil {
-		t.Fatalf("WriteFile(%s): %v", target, err)
-	}
-	if err := os.Remove(path); err != nil {
-		t.Fatalf("Remove(%s): %v", path, err)
-	}
-	if err := os.Symlink(target, path); err != nil {
-		t.Skipf("Symlink: %v", err)
-	}
-
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("second install: %v", err)
-	}
-
-	info, err := os.Lstat(path)
-	if err != nil {
-		t.Fatalf("Lstat(%s): %v", path, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		t.Fatalf("matching symlink was preserved, want regular file")
-	}
-}
-
-func TestInstallBeadHooksCreatesDirectories(t *testing.T) {
-	dir := t.TempDir()
-	// No pre-existing .beads/ directory.
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("installBeadHooks: %v", err)
-	}
-
-	fi, err := os.Stat(filepath.Join(dir, ".beads", "hooks"))
-	if err != nil {
-		t.Fatalf(".beads/hooks not created: %v", err)
-	}
-	if !fi.IsDir() {
-		t.Error(".beads/hooks is not a directory")
-	}
-}
-
+// TestInstallBeadHooksInitIntegration verifies that gc init does NOT install
+// bd event-forwarding hooks; autoclose now runs in the controller.
 func TestInstallBeadHooksInitIntegration(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
@@ -560,74 +88,16 @@ func TestInstallBeadHooksInitIntegration(t *testing.T) {
 		t.Fatalf("gc init = %d; stderr: %s", code, stderr.String())
 	}
 
-	// Verify hooks were installed at city root.
-	hookPath := filepath.Join(cityPath, ".beads", "hooks", "on_create")
-	if _, err := os.Stat(hookPath); err != nil {
-		t.Errorf("gc init did not install bd hooks: %v", err)
-	}
-}
-
-// TestCloseHookLogsFailureDiagnostic runs the installed on_close hook
-// under sh with a deliberately broken GC_BIN and asserts that a dated
-// diagnostic line lands in BEADS_DIR/hooks.log for each of the three
-// gc invocations the hook is supposed to make. This is the visibility
-// gap the script's `>/dev/null 2>&1 || true` pattern hid.
-func TestCloseHookLogsFailureDiagnostic(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
-	dir := t.TempDir()
-	if err := installBeadHooks(dir, ""); err != nil {
-		t.Fatalf("installBeadHooks: %v", err)
-	}
-	hookPath := filepath.Join(dir, ".beads", "hooks", "on_close")
-	beadsDir := filepath.Join(dir, ".beads")
-
-	cmd := exec.Command("sh", hookPath, "test-bead-id", "bead.closed")
-	cmd.Stdin = strings.NewReader(`{"title":"hook diagnostic test"}`)
-	cmd.Env = append(os.Environ(),
-		"GC_BIN=/nonexistent/gc-bin-for-test",
-		"BEADS_DIR="+beadsDir,
-	)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("hook exec failed: %v\nout: %s", err, out)
-	}
-
-	// Hook detaches into background; poll briefly for the log to be flushed.
-	logPath := filepath.Join(beadsDir, "hooks.log")
-	deadline := time.Now().Add(3 * time.Second)
-	var content string
-	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(logPath)
-		if err == nil && len(data) > 0 {
-			content = string(data)
-			// Wait until all three failure markers have been emitted, since
-			// the three gc calls run sequentially.
-			if strings.Contains(content, "gc event emit") &&
-				strings.Contains(content, "gc convoy autoclose") &&
-				strings.Contains(content, "gc wisp autoclose") {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if content == "" {
-		t.Fatalf("hooks.log not written or empty under %s", beadsDir)
-	}
-	for _, want := range []string{
-		"test-bead-id",
-		"/nonexistent/gc-bin-for-test",
-		"gc event emit bead.closed failed",
-		"gc convoy autoclose failed",
-		"gc wisp autoclose failed",
-	} {
-		if !strings.Contains(content, want) {
-			t.Errorf("hooks.log missing %q:\n%s", want, content)
+	for _, name := range beadEventHookNames {
+		hookPath := filepath.Join(cityPath, ".beads", "hooks", name)
+		if _, err := os.Stat(hookPath); !os.IsNotExist(err) {
+			t.Errorf("gc init must not install bd event hook %s (stat err=%v)", name, err)
 		}
 	}
 }
 
+// TestInstallBeadHooksRigAddIntegration verifies that gc rig add does NOT
+// install bd event-forwarding hooks.
 func TestInstallBeadHooksRigAddIntegration(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
@@ -652,9 +122,10 @@ func TestInstallBeadHooksRigAddIntegration(t *testing.T) {
 		t.Fatalf("gc rig add = %d; stderr: %s", code, stderr.String())
 	}
 
-	// Verify hooks were installed at rig path.
-	hookPath := filepath.Join(rigPath, ".beads", "hooks", "on_create")
-	if _, err := os.Stat(hookPath); err != nil {
-		t.Errorf("gc rig add did not install bd hooks: %v", err)
+	for _, name := range beadEventHookNames {
+		hookPath := filepath.Join(rigPath, ".beads", "hooks", name)
+		if _, err := os.Stat(hookPath); !os.IsNotExist(err) {
+			t.Errorf("gc rig add must not install bd event hook %s (stat err=%v)", name, err)
+		}
 	}
 }

--- a/cmd/gc/lifecycle_coordination_test.go
+++ b/cmd/gc/lifecycle_coordination_test.go
@@ -109,13 +109,14 @@ func assertSingleStopWithBenignNoise(t *testing.T, ops []string) {
 	}
 }
 
-// assertHooksExist checks that all bead hooks exist at the given directory.
-func assertHooksExist(t *testing.T, dir, context string) {
+// assertHooksAbsent checks that gc-installed bead event hooks are absent at dir.
+// installBeadHooks now removes these hooks; they must not exist after any gc operation.
+func assertHooksAbsent(t *testing.T, dir, context string) {
 	t.Helper()
 	for _, hook := range []string{"on_create", "on_close", "on_update"} {
 		path := filepath.Join(dir, ".beads", "hooks", hook)
-		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("hook %s missing at %s (%s): %v", hook, dir, context, err)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("hook %s must be absent at %s (%s): stat err=%v", hook, dir, context, err)
 		}
 	}
 }
@@ -161,7 +162,7 @@ func TestLifecycleCoordination_InitRigAddStart(t *testing.T) {
 	ops := readOpLog(t, logFile)
 	assertOpSubsequence(t, ops, "probe", "start", "init "+cityPath)
 	cityInitOps := len(ops)
-	assertHooksExist(t, cityPath, "after city init")
+	assertHooksAbsent(t, cityPath, "after city init")
 
 	// Phase 2: gc rig add — initDirIfReady for rig.
 	rigPrefix := "mr"
@@ -179,17 +180,10 @@ func TestLifecycleCoordination_InitRigAddStart(t *testing.T) {
 	}
 	assertOpSubsequence(t, ops[cityInitOps:], "probe", "start", "init "+rigPath)
 	rigInitOps := len(ops)
-	assertHooksExist(t, rigPath, "after rig add")
+	assertHooksAbsent(t, rigPath, "after rig add")
 
-	// Phase 3: Simulate hook wipe (bd init recreates .beads/).
-	if err := os.RemoveAll(filepath.Join(cityPath, ".beads", "hooks")); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.RemoveAll(filepath.Join(rigPath, ".beads", "hooks")); err != nil {
-		t.Fatal(err)
-	}
-
-	// Phase 4: gc start — startBeadsLifecycle reinstalls everything.
+	// Phase 3: gc start — startBeadsLifecycle re-runs provider init and removes
+	// any stale gc hooks. No hooks are installed since autoclose runs in-process.
 	cfg := testCityConfig(cityName, []config.Rig{
 		{Name: "myrig", Path: rigPath, Prefix: rigPrefix},
 	})
@@ -203,9 +197,9 @@ func TestLifecycleCoordination_InitRigAddStart(t *testing.T) {
 	}
 	assertOpSubsequence(t, ops[rigInitOps:], "start", "init "+cityPath, "init "+rigPath)
 
-	// Verify hooks reinstalled at both paths after start.
-	assertHooksExist(t, cityPath, "after start")
-	assertHooksExist(t, rigPath, "after start")
+	// Verify gc hooks are absent at both paths after start.
+	assertHooksAbsent(t, cityPath, "after start")
+	assertHooksAbsent(t, rigPath, "after start")
 }
 
 // TestLifecycleCoordination_StartOrder verifies that start precedes any
@@ -352,7 +346,7 @@ func TestLifecycleCoordination_InitDirIfReadySkipsProviderForPostgresCityAndRig(
 	if deferred {
 		t.Fatal("initDirIfReady(city) deferred = true, want false")
 	}
-	assertHooksExist(t, cityPath, "after postgres city init")
+	assertHooksAbsent(t, cityPath, "after postgres city init")
 
 	deferred, err = initDirIfReady(cityPath, rigPath, "pg")
 	if err != nil {
@@ -361,7 +355,7 @@ func TestLifecycleCoordination_InitDirIfReadySkipsProviderForPostgresCityAndRig(
 	if deferred {
 		t.Fatal("initDirIfReady(rig) deferred = true, want false")
 	}
-	assertHooksExist(t, rigPath, "after postgres rig add")
+	assertHooksAbsent(t, rigPath, "after postgres rig add")
 
 	if ensureCalls != 0 {
 		t.Fatalf("managed Dolt provider start calls = %d, want 0", ensureCalls)

--- a/cmd/gc/molecule_autoclose_test.go
+++ b/cmd/gc/molecule_autoclose_test.go
@@ -269,23 +269,6 @@ func TestCloseMoleculeWithReasonTrimsWhitespace(t *testing.T) {
 	}
 }
 
-// TestCloseHookScriptIncludesMoleculeAutoclose asserts the bd close
-// hook script wired by gc forwards bead closes to `gc molecule
-// autoclose` alongside the existing convoy and wisp autoclose calls.
-// Without this wiring the new code is unreachable in production.
-func TestCloseHookScriptIncludesMoleculeAutoclose(t *testing.T) {
-	script := closeHookScript("")
-	if !strings.Contains(script, "molecule autoclose") {
-		t.Fatalf("close hook script missing 'molecule autoclose' dispatch:\n%s", script)
-	}
-	// Sanity: the existing siblings are still present.
-	for _, sib := range []string{"convoy autoclose", "wisp autoclose", "bead.closed"} {
-		if !strings.Contains(script, sib) {
-			t.Errorf("close hook script missing %q (regression in sibling wiring):\n%s", sib, script)
-		}
-	}
-}
-
 // TestMoleculeAutocloseClosesWorkflowRootOnSourceBeadClose is the headline
 // regression: a graph.v2 workflow wisp (issue_type "task", not
 // "molecule") with no expanded step children orphans when the worker closes

--- a/release-gates/ga-5mgv67-native-store-hook-autoclose-gate.md
+++ b/release-gates/ga-5mgv67-native-store-hook-autoclose-gate.md
@@ -1,0 +1,67 @@
+# Release gate - native-store hook removal and in-process autoclose
+
+Gate bead: `ga-5mgv67`  
+Source build bead: `ga-frmdxd.2`  
+Review bead: `ga-4lpx1z`  
+PR: https://github.com/gastownhall/gascity/pull/3303  
+Branch: `builder/ga-frmdxd.2`  
+Head under gate: `b4ededa76015ac514cefd36f856dd418599ec57b`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, matching prior
+release-gate precedent in this repo. This gate uses the active deployer release
+criteria plus `TESTING.md` and the acceptance criteria recorded on
+`ga-frmdxd.2`.
+
+## Release Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-4lpx1z` notes record `Review Verdict: PASS` from `gascity/reviewer` for PR #3303 and cover architecture, race analysis, security, and test coverage. |
+| 2 | Acceptance criteria met | PASS | `ga-frmdxd.2` required a current-main branch containing only the native-store hook/autoclose scope from commit `630cef370`. `origin/main..HEAD` is a single commit, `b4ededa76`, and the diff is limited to `.beads/config.yaml`, `cmd/gc/api_state.go`, `cmd/gc/api_state_test.go`, `cmd/gc/hooks.go`, `cmd/gc/hooks_test.go`, `cmd/gc/beads_provider_lifecycle_test.go`, `cmd/gc/lifecycle_coordination_test.go`, and `cmd/gc/molecule_autoclose_test.go`. Emergency relay, `SupervisorHTTPCheck`, and pack-release symlink paths are absent. |
+| 3 | Tests pass | PASS | Local gate commands passed: `make test-fast-parallel` on rerun; `go test ./internal/beads -run TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand -count=10 -v`; `go vet ./...`; `go build ./...`; focused `go test ./cmd/gc -run 'Test.*(Hook\|Hooks\|Autoclose\|Lifecycle\|BeadProvider)' -count=1`. GitHub PR #3303 reports required CI green at the reviewed head. |
+| 4 | No high-severity review findings open | PASS | Review bead `ga-4lpx1z` lists no open HIGH findings; GitHub PR #3303 has no PR review/comment threads. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before writing this gate file: `## builder/ga-frmdxd.2...origin/main [ahead 1]`. After this file is committed, the branch contains the reviewed native-store change plus this gate artifact. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded with tree `24636aa8318ff16b4fc2ee0cab576f022abb92ec`; GitHub reports PR #3303 merge state `CLEAN`. |
+| 7 | Single feature theme | PASS | The commit set is one deploy lane: stop installing/removing gc-managed bd forwarder hooks and run bead-close autoclose in-process for native-store/#3248. The emergency/doctor/pack-release lane was split to PR #3302 and is absent here. |
+
+## Test Notes
+
+The first `make test-fast-parallel` run failed in an unrelated
+`internal/beads` timing-sensitive test:
+
+```text
+TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand: bd.slow records = 1, want 0 for fast bd command
+```
+
+The exact failed test then passed 10/10 with `go test ./internal/beads -run
+TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand -count=10 -v`, and a full
+`make test-fast-parallel` rerun passed all shards. The release criterion is
+marked PASS based on the passing exact retry plus the passing full rerun.
+
+## Acceptance Evidence
+
+`ga-frmdxd.2` acceptance criteria:
+
+| Acceptance criterion | Result | Evidence |
+|----------------------|--------|----------|
+| Branch is based on current `origin/main` and contains only native-store hook/autoclose scope from `630cef370`. | PASS | `origin/main..HEAD` contains one commit, `b4ededa76`, and the diff paths are confined to hook/autoclose state and tests. |
+| Scope is described as dropping gc-installed bd forwarder hooks and running autoclose in-process for native-store/#3248. | PASS | PR #3303 title and review bead describe that exact scope; implementation removes hook installation and routes bead-close autoclose through `applyBeadEventToStores`. |
+| Diff excludes emergency relay, `SupervisorHTTPCheck`, and macOS pack-release symlink changes. | PASS | Diff paths do not include `internal/emergency`, `internal/doctor/checks_supervisor_http.go`, doctor golden/API schema generated files, or `cmd/gc/cmd_pack_release.go`. |
+| PR description links split context and explains criterion-7 deploy split. | PASS | PR #3303 already carries split context; deployer will update the body with reviewer-facing release notes and link this gate. |
+| Relevant focused tests plus fast baseline, vet, and build pass. | PASS | All commands listed in release criterion 3 passed after the transient fast-baseline retry. |
+| Builder routes architecture/test-plan follow-up if extraction expands scope. | PASS | Extraction stayed within the native-store hook/autoclose scope; no extra follow-up was required by the reviewer. |
+| Builder handed off through normal review/deploy path and did not merge directly. | PASS | `ga-4lpx1z` is closed PASS by reviewer; `ga-5mgv67` was routed to deployer as `needs-deploy`; PR #3303 remains open. |
+
+## Diff Summary
+
+```text
+.beads/config.yaml
+cmd/gc/api_state.go
+cmd/gc/api_state_test.go
+cmd/gc/beads_provider_lifecycle_test.go
+cmd/gc/hooks.go
+cmd/gc/hooks_test.go
+cmd/gc/lifecycle_coordination_test.go
+cmd/gc/molecule_autoclose_test.go
+```
+

--- a/release-gates/ga-5mgv67-native-store-hook-autoclose-gate.md
+++ b/release-gates/ga-5mgv67-native-store-hook-autoclose-gate.md
@@ -1,10 +1,10 @@
 # Release gate - native-store hook removal and in-process autoclose
 
-Gate bead: `ga-5mgv67`  
-Source build bead: `ga-frmdxd.2`  
-Review bead: `ga-4lpx1z`  
-PR: https://github.com/gastownhall/gascity/pull/3303  
-Branch: `builder/ga-frmdxd.2`  
+Gate bead: `ga-5mgv67`
+Source build bead: `ga-frmdxd.2`
+Review bead: `ga-4lpx1z`
+PR: https://github.com/gastownhall/gascity/pull/3303
+Branch: `builder/ga-frmdxd.2`
 Head under gate: `b4ededa76015ac514cefd36f856dd418599ec57b`
 
 `docs/PROJECT_MANIFEST.md` is not present in this checkout, matching prior
@@ -64,4 +64,3 @@ cmd/gc/hooks_test.go
 cmd/gc/lifecycle_coordination_test.go
 cmd/gc/molecule_autoclose_test.go
 ```
-

--- a/release-gates/ga-ms9iyc-native-store-hook-autoclose-gate.md
+++ b/release-gates/ga-ms9iyc-native-store-hook-autoclose-gate.md
@@ -1,0 +1,55 @@
+# Release Gate: native-store hook removal and in-process autoclose re-review
+
+- Deploy bead: `ga-ms9iyc`
+- Source bead: `ga-2ri4x3`
+- PR: https://github.com/gastownhall/gascity/pull/3303
+- Branch: `builder/ga-frmdxd.2`
+- Reviewed head: `7c95489881edb30c17006ed7a9e5bad31e8c0ffe`
+- Base checked: `origin/main` at `60e402be98f7f1487c618a1f92590df88247299f`
+- Gate date: 2026-06-12 UTC
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate uses the
+active deployer release criteria plus `TESTING.md` and the acceptance evidence
+recorded on `ga-2ri4x3`.
+
+## Release Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-2ri4x3` notes record `Review Verdict: PASS (pass 4 - final)` for commit `7c9548988` on PR #3303 after the prior HIGH hook-removal finding was resolved. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/hooks.go` now removes only gc-stamped hook files via `isGCManagedHook`; `cmd/gc/hooks_test.go` covers stamped removal and preservation of user-authored same-name hooks; `cmd/gc/api_state.go` dispatches bead-close autoclose in-process; `cmd/gc/api_state_test.go` covers convoy autoclose through the event path; `cmd/gc/city_discovery.go` ignores `/tmp/.gc` runtime roots. |
+| 3 | Tests pass | PASS | Local gate commands passed on `builder/ga-frmdxd.2`: `make test-fast-parallel`; `go vet ./...`; `go build ./...`. |
+| 4 | No high-severity review findings open | PASS | The final review notes on `ga-2ri4x3` state that the blocker is resolved and all findings from passes 1-3 are resolved. PR #3303 has no review/comment threads. |
+| 5 | Final branch is clean | PASS | Clean before gate write: `git status --short --branch` reported only `## builder/ga-frmdxd.2...origin/builder/ga-frmdxd.2`. This gate file and the whitespace cleanup in the older gate file are the only deployer changes to commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded with tree `10ee78557fc8b3f17a483ebe4ef88f55f74d937d`; GitHub reports PR #3303 mergeable. |
+| 7 | Single feature theme | PASS | The branch is one `cmd/gc` lifecycle theme: remove unsafe gc-managed bead hook installation/removal behavior, keep native-store autoclose in-process, and keep test/CLI city discovery from resolving `/tmp/.gc` runtime state as a project city. The emergency relay, doctor check, and pack-release symlink work are absent from this PR. |
+
+## Commands
+
+```text
+make test-fast-parallel
+go vet ./...
+go build ./...
+git merge-tree --write-tree origin/main HEAD
+git diff --check origin/main...HEAD
+```
+
+`git diff --check origin/main...HEAD` initially reported trailing whitespace in
+the older `ga-5mgv67` gate file already on the PR branch. This gate commit
+removes that whitespace so the final branch passes the check.
+
+## Diff Summary
+
+```text
+.beads/config.yaml
+cmd/gc/api_state.go
+cmd/gc/api_state_test.go
+cmd/gc/beads_provider_lifecycle_test.go
+cmd/gc/city_discovery.go
+cmd/gc/hooks.go
+cmd/gc/hooks_test.go
+cmd/gc/lifecycle_coordination_test.go
+cmd/gc/molecule_autoclose_test.go
+release-gates/ga-5mgv67-native-store-hook-autoclose-gate.md
+release-gates/ga-ms9iyc-native-store-hook-autoclose-gate.md
+```

--- a/release-gates/ga-rjqmi0-native-store-hook-autoclose-gate.md
+++ b/release-gates/ga-rjqmi0-native-store-hook-autoclose-gate.md
@@ -1,0 +1,72 @@
+# Release Gate: native-store hook removal and in-process autoclose
+
+- Deploy bead: `ga-rjqmi0`
+- Review bead: `ga-xjqji2`
+- Source bead: `ga-xjqji2`
+- PR: https://github.com/gastownhall/gascity/pull/3303
+- Branch: `builder/ga-frmdxd.2`
+- Reviewed head: `39a22bf36b421edcdd59a78d3a7a327d3dc61593`
+- Base checked locally: `origin/main` at `2315679e25a9b196710edfcaf502496cee576cfc`
+- Gate date: 2026-06-13
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate uses the
+active deployer release criteria plus `TESTING.md` and the acceptance evidence
+recorded on `ga-xjqji2`.
+
+## Release Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-xjqji2` is closed with `Review Verdict: PASS` for `39a22bf36b421edcdd59a78d3a7a327d3dc61593` on PR #3303. |
+| 2 | Acceptance criteria met | PASS | Reviewer notes state all four acceptance criteria are met: gc-installed hooks are removed idempotently, user-authored same-name hooks are preserved, autoclose fires in-process on `BeadClosed`, and `/tmp` runtime state is not resolved as a project city. The diff implements those behaviors in `cmd/gc/hooks.go`, `cmd/gc/api_state.go`, and `cmd/gc/city_discovery.go` with matching tests. |
+| 3 | Tests pass | PASS | Final local gate run passed from clean detached worktree `/home/jaword/projects/gc-management/.gc/worktrees/gascity/deploy-ga-rjqmi0-test`: `LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=3 make test-fast-parallel`, `TMPDIR=/home/jaword/tmp/gascity-test-tmp go vet ./...`, and `TMPDIR=/home/jaword/tmp/gascity-test-tmp go build ./...`. `git diff --check origin/main...HEAD` passed. GitHub checks for PR #3303 are green, including CI, CodeQL, integration shards, and `cmd/gc process` shards. |
+| 4 | No high-severity review findings open | PASS | `ga-xjqji2` reports no blockers. The only non-info finding is LOW on the implicit `stores[0]` ownership assumption; reviewer marked it non-blocking. |
+| 5 | Final branch is clean | PASS | `git status -sb` on `deploy/ga-rjqmi0-gate` reported only `## deploy/ga-rjqmi0-gate...origin/builder/ga-frmdxd.2` before writing this gate file. After this file is committed, the branch contains the reviewed PR head plus this gate artifact. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded with tree `99fe8c242a274d619bc531e9e01048b0c19d02e1`; GitHub reports PR #3303 `mergeStateStatus=CLEAN`. |
+| 7 | Single feature theme | PASS | The branch is one native-store lifecycle theme: remove gc-managed `bd` forwarder hook installation/removal, preserve user hooks, and run convoy/wisp/molecule autoclose from the controller event path. The existing release-gate files on the branch are prior gate artifacts for this same PR; the product-code diff stays within `.beads/config.yaml` and `cmd/gc` hook/autoclose/city-discovery surfaces. |
+
+## Acceptance Evidence
+
+| Acceptance criterion | Result | Evidence |
+|----------------------|--------|----------|
+| gc-installed hooks are removed on `installBeadHooks` and the operation is idempotent. | PASS | `cmd/gc/hooks.go` removes stamped gc-managed hook files instead of writing hook scripts; `cmd/gc/hooks_test.go` covers hook removal and missing-hook success. |
+| User-authored hooks with the same names are preserved. | PASS | `isGCManagedHook` checks the gc stamp before removal; tests cover user-owned `on_create`, `on_update`, and `on_close` preservation. |
+| Autoclose fires in-process on `BeadClosed`. | PASS | `cmd/gc/api_state.go` dispatches convoy, wisp, and molecule autoclose from `applyBeadEventToStores`; `TestApplyBeadEventToStoresTriggersConvoyAutoclose` covers the event path with synchronous dispatch. |
+| `/tmp` supervisor runtime state is not treated as a project city. | PASS | `cmd/gc/city_discovery.go` ignores implicit system temp runtime roots; reviewer notes confirm the `/tmp` city discovery fix. |
+
+## Commands
+
+```text
+LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=3 make test-fast-parallel
+TMPDIR=/home/jaword/tmp/gascity-test-tmp go vet ./...
+TMPDIR=/home/jaword/tmp/gascity-test-tmp go build ./...
+git diff --check origin/main...HEAD
+git merge-tree --write-tree origin/main HEAD
+gh pr checks 3303 --repo gastownhall/gascity
+```
+
+## Test Notes
+
+An initial default-parallel local run in `/tmp/gascity-deploy-ga-rjqmi0` failed
+because `/tmp` was 98% full and Go compiler/linker temp writes hit `no space
+left on device`. After clearing generated `go-build*` temp directories, a
+reduced retry from the same `/tmp` source checkout failed path-sensitive
+`cmd/gc` city-discovery/supervisor tests. The final gate result comes from the
+same commit in a detached `/home` worktree, where the fast sharded baseline
+passed.
+
+## Diff Summary
+
+```text
+.beads/config.yaml
+cmd/gc/api_state.go
+cmd/gc/api_state_test.go
+cmd/gc/beads_provider_lifecycle_test.go
+cmd/gc/city_discovery.go
+cmd/gc/hooks.go
+cmd/gc/hooks_test.go
+cmd/gc/lifecycle_coordination_test.go
+cmd/gc/molecule_autoclose_test.go
+release-gates/ga-5mgv67-native-store-hook-autoclose-gate.md
+release-gates/ga-ms9iyc-native-store-hook-autoclose-gate.md
+```


### PR DESCRIPTION
## What this changes

Gas City no longer installs its own `bd` forwarder hooks into city and rig `.beads/hooks` directories. During hook setup it removes only old gc-managed hook files, so existing workspaces converge away from the shell-hook path without deleting user-authored `bd` hooks that happen to use the same names.

Bead-close autoclose now runs in-process from the controller event path when a `bead.closed` event is applied. That keeps convoy/molecule autoclose behavior working for the native store path without depending on external hook execution.

The design moves this behavior to the same process that already observes bead lifecycle events, which avoids recursive CLI calls and keeps hook directories reserved for user or backend-owned behavior.

## Review notes

- Hook removal is idempotent and treats missing files as success.
- User-owned `on_create`, `on_update`, and `on_close` hooks are preserved unless they carry a gc hook stamp.
- The diff intentionally touches `.beads/config.yaml` along with `cmd/gc` hook, lifecycle, city-discovery, and autoclose tests.
- No new network surface is introduced.
- The emergency relay, doctor check, and pack-release macOS symlink work from the split source PR are not included here.

## Test plan

- [x] `LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=3 make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] GitHub CI and CodeQL on the reviewed implementation head
- [x] Release gate: [`release-gates/ga-rjqmi0-native-store-hook-autoclose-gate.md`](release-gates/ga-rjqmi0-native-store-hook-autoclose-gate.md)