### PR TITLE
fix(beads): force bd auto-backup opt-out at the exec choke point + stale-backup doctor check

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -310,6 +310,10 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 	// invocation without retention. This check warns before the directory
 	// fills the disk and cascades into broken dolt writes.
 	register(doctor.NewBdBackupSizeCheckForConfig(cityPath, cfg, cfgErr))
+	// Stale bd backup state: corrupt-store quarantines that were never
+	// reclaimed and dolt-backup.json registrations pointing at deleted
+	// paths (ga-yfbs28).
+	register(doctor.NewBdBackupStateCheckForConfig(cityPath, cfg, cfgErr))
 	// Worktree checks deliberately run even when cfgErr != nil — they
 	// only need the city path, and a broken city.toml is exactly when
 	// silent disk-fill is most likely. The zero-value DoctorConfig

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -64,6 +64,7 @@ dolt-version
 events-log
 events-log-size
 bd-backup-size
+bd-backup-state
 worktree-disk-size
 nested-worktree-prune
 custom-types:city

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -109,12 +109,7 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 		cmd.Cancel = func() error {
 			return killCommandTree(cmd)
 		}
-		baseEnv := processEnvSnapshotExcludingNativeDoltOpen()
-		if len(env) > 0 {
-			cmd.Env = mergeEnv(baseEnv, env)
-		} else {
-			cmd.Env = baseEnv
-		}
+		cmd.Env = execEnvFor(name, processEnvSnapshotExcludingNativeDoltOpen(), env)
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
 		out, err := cmd.Output()
@@ -445,6 +440,29 @@ func truncateRawOutput(data []byte, maxBytes int) string {
 		return string(trimmed)
 	}
 	return string(trimmed[:maxBytes]) + "...(truncated)"
+}
+
+// bdAutoBackupOptOutEnvKey disables bd's PersistentPostRun auto-backup (the
+// hardcoded "backup_export" Dolt remote synced into <root>/.beads/backup on
+// nearly every bd invocation, with no retention). A stuck-looping
+// backup_export sync was the root cause of the 2026-06-08 town-wide wedge
+// (ga-0eq), and the unrotated archives reached 210GB on one dev store
+// (ga-yfbs28). gc's projected envs already opt out (cmd/gc applyBdAutoBackupOptOut);
+// injecting it here covers every other runner-spawned bd call — hook claim,
+// store bridge, t3bridge, libstore, provider lifecycle — current and future.
+const bdAutoBackupOptOutEnvKey = "BD_BACKUP_ENABLED"
+
+// execEnvFor assembles the child environment for a runner exec. For bd
+// commands the auto-backup opt-out is injected as a baseline, replacing any
+// value inherited from the parent process (matching the unconditional
+// projected-env opt-out policy); an explicit per-call override still wins
+// because mergeEnv applies overrides last. Non-bd commands (e.g. direct dolt
+// queries) pass through untouched.
+func execEnvFor(name string, baseEnv []string, overrides map[string]string) []string {
+	if name == "bd" {
+		baseEnv = append(envWithout(baseEnv, bdAutoBackupOptOutEnvKey), bdAutoBackupOptOutEnvKey+"=false")
+	}
+	return mergeEnv(baseEnv, overrides)
 }
 
 // envWithout returns a copy of environ with all entries for the given key removed.

--- a/internal/beads/bdstore_env_internal_test.go
+++ b/internal/beads/bdstore_env_internal_test.go
@@ -1,0 +1,77 @@
+package beads
+
+import (
+	"strings"
+	"testing"
+)
+
+func envValues(env []string, key string) []string {
+	var out []string
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			out = append(out, strings.TrimPrefix(e, prefix))
+		}
+	}
+	return out
+}
+
+func TestExecEnvForBd_InjectsAutoBackupOptOut(t *testing.T) {
+	// Every bd subprocess spawned through the runner must carry the
+	// auto-backup opt-out (ga-yfbs28): bd's PersistentPostRun backup_export
+	// sync has no retention and stuck-loops on broken remote state (the
+	// 2026-06-08 town-wide wedge, ga-0eq). The projected-env opt-out only
+	// covers gc env projections; this is the choke point for everything
+	// else (hook claim, store bridge, t3bridge, libstore, provider
+	// lifecycle).
+	base := []string{"PATH=/usr/bin"}
+	got := execEnvFor("bd", base, nil)
+	if vals := envValues(got, "BD_BACKUP_ENABLED"); len(vals) != 1 || vals[0] != "false" {
+		t.Errorf("BD_BACKUP_ENABLED values = %v, want exactly [false]", vals)
+	}
+}
+
+func TestExecEnvForBd_OverridesInheritedEnable(t *testing.T) {
+	// A BD_BACKUP_ENABLED=true inherited from the parent process must not
+	// leak through: gc policy forces the opt-out on gc-managed bd calls,
+	// matching applyBdAutoBackupOptOut's unconditional projection.
+	base := []string{"PATH=/usr/bin", "BD_BACKUP_ENABLED=true"}
+	got := execEnvFor("bd", base, nil)
+	if vals := envValues(got, "BD_BACKUP_ENABLED"); len(vals) != 1 || vals[0] != "false" {
+		t.Errorf("BD_BACKUP_ENABLED values = %v, want exactly [false] (inherited true must be replaced)", vals)
+	}
+}
+
+func TestExecEnvForBd_ExplicitCallerOverrideWins(t *testing.T) {
+	// An explicit per-call override is a deliberate caller decision (e.g. a
+	// backup-focused test fixture) and must beat the injected baseline.
+	base := []string{"PATH=/usr/bin"}
+	got := execEnvFor("bd", base, map[string]string{"BD_BACKUP_ENABLED": "true"})
+	if vals := envValues(got, "BD_BACKUP_ENABLED"); len(vals) != 1 || vals[0] != "true" {
+		t.Errorf("BD_BACKUP_ENABLED values = %v, want exactly [true] (explicit override wins)", vals)
+	}
+}
+
+func TestExecEnvForBd_MergesOtherOverrides(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "HOME=/home/u"}
+	got := execEnvFor("bd", base, map[string]string{"BEADS_DIR": "/x/.beads"})
+	if vals := envValues(got, "BEADS_DIR"); len(vals) != 1 || vals[0] != "/x/.beads" {
+		t.Errorf("BEADS_DIR values = %v, want [/x/.beads]", vals)
+	}
+	if vals := envValues(got, "BD_BACKUP_ENABLED"); len(vals) != 1 || vals[0] != "false" {
+		t.Errorf("BD_BACKUP_ENABLED values = %v, want [false] alongside other overrides", vals)
+	}
+	if vals := envValues(got, "HOME"); len(vals) != 1 || vals[0] != "/home/u" {
+		t.Errorf("HOME values = %v, want [/home/u] preserved", vals)
+	}
+}
+
+func TestExecEnvForNonBd_LeavesEnvAlone(t *testing.T) {
+	// The runner also execs dolt directly; non-bd commands keep the
+	// caller-visible environment untouched.
+	base := []string{"PATH=/usr/bin", "BD_BACKUP_ENABLED=true"}
+	got := execEnvFor("dolt", base, nil)
+	if vals := envValues(got, "BD_BACKUP_ENABLED"); len(vals) != 1 || vals[0] != "true" {
+		t.Errorf("BD_BACKUP_ENABLED values = %v, want [true] untouched for non-bd commands", vals)
+	}
+}

--- a/internal/doctor/checks_bd_backup_state.go
+++ b/internal/doctor/checks_bd_backup_state.go
@@ -1,0 +1,176 @@
+package doctor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// BdBackupStateCheck flags stale bd backup state that accumulates silently:
+//
+//   - corrupt-store quarantine directories (.beads/*.corrupt-*): bd renames a
+//     corrupt Dolt store aside on detection and nothing ever reclaims it — a
+//     1.8GB quarantine sat unnoticed from 2026-05-27 to 2026-06-10
+//     (ga-yfbs28). Quarantines deserve a diagnosis and then deletion, not
+//     indefinite disk residency.
+//   - a .beads/dolt-backup.json registration whose file:// backup_url points
+//     at a path that no longer exists (e.g. a deleted mktemp dir): syncs
+//     then fall back to the live .beads/backup directory while the
+//     registration still looks healthy.
+//
+// The check reports only; cleanup is operator policy (archive-then-remove
+// for quarantines, re-register or delete for stale registrations).
+type BdBackupStateCheck struct {
+	cityPath   string
+	scopeRoots []string
+}
+
+// NewBdBackupStateCheckForConfig creates a backup-state check across the city
+// and all managed rig scope roots, using preloaded city config to avoid
+// reparsing city.toml during doctor registration.
+func NewBdBackupStateCheckForConfig(cityPath string, cfg *config.City, cfgErr error) *BdBackupStateCheck {
+	return &BdBackupStateCheck{
+		cityPath:   cityPath,
+		scopeRoots: managedDoltScopeRootsForConfig(cityPath, cfg, cfgErr),
+	}
+}
+
+// NewBdBackupStateCheckForScopeRoots creates a backup-state check over an
+// explicit scope-root list. Used by tests.
+func NewBdBackupStateCheckForScopeRoots(cityPath string, scopeRoots []string) *BdBackupStateCheck {
+	return &BdBackupStateCheck{cityPath: cityPath, scopeRoots: scopeRoots}
+}
+
+// Name returns the check identifier.
+func (c *BdBackupStateCheck) Name() string { return "bd-backup-state" }
+
+// Run scans each scope's .beads directory for corrupt-store quarantines and
+// stale backup registrations.
+func (c *BdBackupStateCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+
+	var findings []string
+	for _, target := range c.stateScanTargets() {
+		findings = append(findings, scanBdBackupState(target.Label, target.BeadsDir)...)
+	}
+
+	if len(findings) == 0 {
+		r.Status = StatusOK
+		r.Message = "no corrupt-store quarantines or stale backup registrations"
+		return r
+	}
+	r.Status = StatusWarning
+	r.Message = strings.Join(findings, "; ")
+	r.FixHint = "archive then remove quarantines (tar -czf <name>.tgz <dir> && rm -rf <dir>); " +
+		"delete or re-register stale dolt-backup.json files"
+	return r
+}
+
+// CanFix returns false: quarantine forensics and backup re-registration are
+// operator decisions.
+func (c *BdBackupStateCheck) CanFix() bool { return false }
+
+// Fix is a no-op; the check is report-only.
+func (c *BdBackupStateCheck) Fix(_ *CheckContext) error { return nil }
+
+type bdBackupStateTarget struct {
+	Label    string
+	BeadsDir string
+}
+
+func (c *BdBackupStateCheck) stateScanTargets() []bdBackupStateTarget {
+	scopeRoots := c.scopeRoots
+	if len(scopeRoots) == 0 {
+		scopeRoots = managedDoltScopeRoots(c.cityPath)
+	}
+	if len(scopeRoots) == 0 {
+		scopeRoots = []string{c.cityPath}
+	}
+
+	seen := make(map[string]struct{}, len(scopeRoots))
+	targets := make([]bdBackupStateTarget, 0, len(scopeRoots))
+	for _, scopeRoot := range scopeRoots {
+		scopeRoot = strings.TrimSpace(scopeRoot)
+		if scopeRoot == "" {
+			continue
+		}
+		scopeRoot = filepath.Clean(scopeRoot)
+		if _, ok := seen[scopeRoot]; ok {
+			continue
+		}
+		seen[scopeRoot] = struct{}{}
+		targets = append(targets, bdBackupStateTarget{
+			Label:    bdBackupScopeLabel(c.cityPath, scopeRoot),
+			BeadsDir: filepath.Join(scopeRoot, ".beads"),
+		})
+	}
+	return targets
+}
+
+// scanBdBackupState inspects one scope's .beads directory and returns
+// human-readable findings. A missing .beads directory is not a finding.
+func scanBdBackupState(label, beadsDir string) []string {
+	var findings []string
+
+	entries, err := os.ReadDir(beadsDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return []string{fmt.Sprintf("%s: read %s: %v", label, beadsDir, err)}
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.Contains(entry.Name(), ".corrupt-") {
+			continue
+		}
+		path := filepath.Join(beadsDir, entry.Name())
+		size, _, err := duDirBytes(path)
+		if err != nil {
+			findings = append(findings, fmt.Sprintf("%s: corrupt-store quarantine %s (size unknown: %v)", label, entry.Name(), err))
+			continue
+		}
+		findings = append(findings, fmt.Sprintf("%s: corrupt-store quarantine %s (%s)", label, entry.Name(), formatGB(size)))
+	}
+
+	if finding, ok := staleBackupRegistration(label, beadsDir); ok {
+		findings = append(findings, finding)
+	}
+	return findings
+}
+
+// staleBackupRegistration reports a dolt-backup.json whose file:// backup_url
+// points at a path that no longer exists. Non-file URLs (remote backups)
+// cannot be liveness-checked from this host and are never flagged.
+func staleBackupRegistration(label, beadsDir string) (string, bool) {
+	path := filepath.Join(beadsDir, "dolt-backup.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var reg struct {
+		BackupURL string `json:"backup_url"`
+	}
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return fmt.Sprintf("%s: dolt-backup.json is unparseable: %v", label, err), true
+	}
+	u, err := url.Parse(reg.BackupURL)
+	if err != nil || u.Scheme != "file" {
+		return "", false
+	}
+	backupPath := filepath.FromSlash(u.Path)
+	if backupPath == "" {
+		return "", false
+	}
+	if _, err := os.Stat(backupPath); errors.Is(err, fs.ErrNotExist) {
+		return fmt.Sprintf("%s: dolt-backup.json registers backup_url %q whose path no longer exists", label, reg.BackupURL), true
+	}
+	return "", false
+}

--- a/internal/doctor/checks_bd_backup_state_test.go
+++ b/internal/doctor/checks_bd_backup_state_test.go
@@ -1,0 +1,138 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeBackupStateFixture(t *testing.T, root string, files map[string]string, dirs ...string) {
+	t.Helper()
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, content := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestBdBackupStateCheck_CleanScopeIsOK(t *testing.T) {
+	city := t.TempDir()
+	writeBackupStateFixture(t, city, nil, ".beads/dolt")
+
+	check := NewBdBackupStateCheckForScopeRoots(city, []string{city})
+	r := check.Run(nil)
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v (%s), want OK", r.Status, r.Message)
+	}
+}
+
+func TestBdBackupStateCheck_FlagsCorruptQuarantine(t *testing.T) {
+	// A corruption event quarantines the store as .beads/<name>.corrupt-<ts>
+	// and nothing ever reclaims it: a 1.8GB quarantine sat unnoticed from
+	// 2026-05-27 to 2026-06-10 (ga-yfbs28). Doctor must surface it.
+	city := t.TempDir()
+	writeBackupStateFixture(t, city, map[string]string{
+		".beads/dolt.corrupt-20260527T145828Z/ga/noms/chunk": "x",
+	}, ".beads/dolt")
+
+	check := NewBdBackupStateCheckForScopeRoots(city, []string{city})
+	r := check.Run(nil)
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v (%s), want Warning", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "dolt.corrupt-20260527T145828Z") {
+		t.Errorf("Message = %q, want quarantine dir named", r.Message)
+	}
+	if r.FixHint == "" {
+		t.Error("FixHint empty; operators need the archive-then-remove recipe")
+	}
+}
+
+func TestBdBackupStateCheck_FlagsStaleBackupRegistration(t *testing.T) {
+	// dolt-backup.json pointing at a deleted path means backup syncs fall
+	// back to the live .beads/backup dir while the registration looks
+	// healthy. Observed live: backup_url=file:///data/tmp/tmp.y9AoDggtwt/...
+	// (a long-deleted mktemp dir).
+	city := t.TempDir()
+	writeBackupStateFixture(t, city, map[string]string{
+		".beads/dolt-backup.json": `{"backup_url":"file:///nonexistent/tmp.gone/.beads/backup","backup_name":"default"}`,
+	}, ".beads/dolt")
+
+	check := NewBdBackupStateCheckForScopeRoots(city, []string{city})
+	r := check.Run(nil)
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v (%s), want Warning", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "dolt-backup.json") {
+		t.Errorf("Message = %q, want stale registration named", r.Message)
+	}
+}
+
+func TestBdBackupStateCheck_LiveBackupRegistrationIsOK(t *testing.T) {
+	city := t.TempDir()
+	backupDir := filepath.Join(city, "backups")
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeBackupStateFixture(t, city, map[string]string{
+		".beads/dolt-backup.json": `{"backup_url":"file://` + backupDir + `","backup_name":"default"}`,
+	}, ".beads/dolt")
+
+	check := NewBdBackupStateCheckForScopeRoots(city, []string{city})
+	r := check.Run(nil)
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v (%s), want OK for live registration", r.Status, r.Message)
+	}
+}
+
+func TestBdBackupStateCheck_NonFileBackupURLIsOK(t *testing.T) {
+	// Remote (non-file) backup URLs cannot be liveness-checked from this
+	// host; the check must not guess.
+	city := t.TempDir()
+	writeBackupStateFixture(t, city, map[string]string{
+		".beads/dolt-backup.json": `{"backup_url":"https://dolthub.com/some/remote","backup_name":"default"}`,
+	}, ".beads/dolt")
+
+	check := NewBdBackupStateCheckForScopeRoots(city, []string{city})
+	r := check.Run(nil)
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v (%s), want OK for non-file URL", r.Status, r.Message)
+	}
+}
+
+func TestBdBackupStateCheck_MissingBeadsDirIsOK(t *testing.T) {
+	city := t.TempDir()
+	check := NewBdBackupStateCheckForScopeRoots(city, []string{city})
+	r := check.Run(nil)
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v (%s), want OK when scope has no .beads", r.Status, r.Message)
+	}
+}
+
+func TestBdBackupStateCheck_AggregatesAcrossScopes(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "beads")
+	writeBackupStateFixture(t, city, nil, ".beads/dolt")
+	writeBackupStateFixture(t, rig, map[string]string{
+		".beads/dolt.corrupt-20260601T000000Z/x": "x",
+	}, ".beads/dolt")
+
+	check := NewBdBackupStateCheckForScopeRoots(city, []string{city, rig})
+	r := check.Run(nil)
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v (%s), want Warning from rig scope", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "dolt.corrupt-20260601T000000Z") {
+		t.Errorf("Message = %q, want rig quarantine named", r.Message)
+	}
+}

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -14,6 +14,10 @@ func (c *BdBackupSizeCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *BdBackupStateCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *BeadsRoleCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the


### PR DESCRIPTION
## Problem

bd's `PersistentPostRun` auto-backup (hardcoded `backup_export` Dolt remote → `<root>/.beads/backup`) has **no retention** and stuck-loops when its remote state breaks — the root cause of the 2026-06-08 town-wide wedge (`ga-0eq`). One dev store accumulated **210GB** of unrotated archives: 126GB on May 17, **73.6GB on Jun 8 alone** (105 files).

The `BD_BACKUP_ENABLED=false` opt-out only existed on gc env-*projection* paths (`applyBdAutoBackupOptOut` in `cmd/gc/bd_env.go` + `template_resolve.go` + `store_target_exec.go`). Every other runner-spawned bd call inherited the parent process env with no opt-out:

- `cmd/gc/cmd_hook_claim.go` (hook claim store)
- `cmd/gc/cmd_bd_store_bridge.go` (store bridge)
- `cmd/gc/beads_provider_lifecycle.go:957`
- `internal/runtime/t3bridge/provider.go:1699`
- `internal/beads/libstore.go`

Bead: `ga-yfbs28`.

## Fix

Inject the opt-out **once at the choke point they all share** — `ExecCommandRunnerWithEnv` in `internal/beads/bdstore.go` — for `bd` commands only:

- baseline replaces any value inherited from the parent process (matches the unconditional projected-env policy)
- an explicit per-call override still wins (`mergeEnv` applies overrides last)
- non-bd commands (direct dolt queries) pass through untouched

Current and **future** call sites are covered without each having to remember the opt-out.

## Also: `bd-backup-state` doctor check

Flags what currently accumulates silently (report-only, no autofix):

- corrupt-store quarantine dirs (`.beads/*.corrupt-*`) with sizes — a 1.8GB quarantine sat unnoticed May 27 → Jun 10
- `dolt-backup.json` registrations whose `file://` backup_url points at a nonexistent path (observed live: a deleted mktemp dir, silently redirecting syncs to the live `.beads/backup`)

## Testing

- New env-helper tests: opt-out injected, inherited `true` replaced, explicit caller override wins, other overrides merge, non-bd untouched
- New doctor check tests: clean scope OK, quarantine flagged with size + fix hint, stale file:// registration flagged, live registration OK, remote URL never guessed, multi-scope aggregation
- `doctor_check_names.golden` updated (name-set guard)
- `go test ./internal/beads ./internal/doctor`, `go test ./cmd/gc -run Doctor`, `go vet` clean, pre-commit fast shards pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)