### PR TITLE
fix(beads): pin the reconcile scan to active-only and surface oversized scans

### DIFF
--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -463,7 +463,7 @@ func (c *CachingStore) prime(ctx context.Context) error {
 	var err error
 	var partialErr error
 	for attempt := 1; attempt <= 3; attempt++ {
-		all, err = c.backing.List(ListQuery{AllowScan: true, SkipLabels: true, TierMode: TierBoth}) // active beads only
+		all, err = c.backing.List(cacheFullScanQuery()) // active beads only; see cacheFullScanQuery
 		if err == nil {
 			break
 		}

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -8,6 +8,8 @@ import (
 	"math"
 	"sort"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/telemetry"
 )
 
 // cacheLatencyWindowSize is the size of the rolling window of bd-list
@@ -27,6 +29,36 @@ const cacheLatencyWindowSize = 10
 // a quarter of the small cadence is evidence of sustained backend
 // pressure.
 const cacheLatencyHighWaterMark = cacheReconcileIntervalSmall / 4
+
+// cacheReconcileScanWarnThreshold is the active-bead count at which a
+// reconcile full scan emits beads.cache.scan_large telemetry. Sits between
+// the bead-count cadence thresholds (MEDIUM at 1000, LARGE at 5000): healthy
+// large rigs above the MEDIUM floor stay quiet, while a store drifting toward
+// LARGE warns before every cycle pays multi-second, multi-MB bd round-trips
+// (ga-698fl2: a dev store silently reached 3,272 active beads / ~11MB of
+// JSON / ~2s bd latency per cycle).
+const cacheReconcileScanWarnThreshold = 2500
+
+// recordCacheScanLarge emits the over-threshold scan-size telemetry; a var so
+// internal tests can intercept emission.
+var recordCacheScanLarge = telemetry.RecordCacheScanLarge
+
+// cacheFullScanQuery is the single query shape Prime and the reconciler use
+// to load the cache's authoritative snapshot. The reconcile diff treats the
+// result as the COMPLETE active universe: any cached bead absent from it is
+// re-verified per ID (recoverMissingFromList) and then evicted with a
+// synthetic bead.closed event. Two bounds follow from that authority:
+//
+//   - Limit must stay unset (0). A bounded list would route every active
+//     bead beyond the limit through the per-bead Get recovery path on every
+//     cycle — O(active−limit) bd round-trips — and synthesize false
+//     bead.closed evictions whenever those Gets degrade.
+//   - IncludeClosed is pinned false. The scan cost is O(active beads) by
+//     design; closed history grows without bound and would multiply the
+//     per-cycle bd payload without changing the diff result.
+func cacheFullScanQuery() ListQuery {
+	return ListQuery{AllowScan: true, SkipLabels: true, IncludeClosed: false, TierMode: TierBoth}
+}
 
 func (c *CachingStore) reconcileLoop(ctx context.Context, stagger time.Duration) {
 	if stagger > 0 {
@@ -257,7 +289,7 @@ func (c *CachingStore) runReconciliation() {
 	c.mu.RUnlock()
 
 	bdStart := time.Now()
-	fresh, err := c.backing.List(ListQuery{AllowScan: true, SkipLabels: true, TierMode: TierBoth})
+	fresh, err := c.backing.List(cacheFullScanQuery())
 	if err != nil {
 		bdLatency := time.Since(bdStart)
 		c.mu.Lock()
@@ -271,6 +303,10 @@ func (c *CachingStore) runReconciliation() {
 		c.updateStatsLocked()
 		c.mu.Unlock()
 		return
+	}
+	if len(fresh) >= cacheReconcileScanWarnThreshold {
+		recordCacheScanLarge(context.Background(), c.idPrefix, len(fresh),
+			cacheReconcileScanWarnThreshold, time.Since(bdStart))
 	}
 	enriched, enrichErr := c.enrichReadyProjectionForCache(fresh)
 	bdLatency := time.Since(bdStart)

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -40,7 +40,9 @@ const cacheLatencyHighWaterMark = cacheReconcileIntervalSmall / 4
 const cacheReconcileScanWarnThreshold = 2500
 
 // recordCacheScanLarge emits the over-threshold scan-size telemetry; a var so
-// internal tests can intercept emission.
+// internal tests can intercept emission. Swaps are unsynchronized: tests that
+// replace it must stay sequential (no t.Parallel) and must not leave a
+// reconcile loop running across the swap.
 var recordCacheScanLarge = telemetry.RecordCacheScanLarge
 
 // cacheFullScanQuery is the single query shape Prime and the reconciler use

--- a/internal/beads/caching_store_scan_internal_test.go
+++ b/internal/beads/caching_store_scan_internal_test.go
@@ -1,0 +1,235 @@
+package beads
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// queryRecordingStore wraps a Store and records every ListQuery it serves so
+// tests can assert the exact scan scope the cache requests from the backing
+// store.
+type queryRecordingStore struct {
+	Store
+
+	mu      sync.Mutex
+	queries []ListQuery
+}
+
+func (s *queryRecordingStore) List(query ListQuery) ([]Bead, error) {
+	s.mu.Lock()
+	s.queries = append(s.queries, query)
+	s.mu.Unlock()
+	return s.Store.List(query)
+}
+
+func (s *queryRecordingStore) recorded() []ListQuery {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]ListQuery(nil), s.queries...)
+}
+
+func (s *queryRecordingStore) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.queries = nil
+}
+
+// TestCacheFullScanQueryShape pins the exact shape of the full-scan query the
+// reconciler and Prime issue. The reconcile diff treats the result as the
+// complete active universe, so Limit must stay unset and closed beads must
+// stay excluded; see cacheFullScanQuery for the full rationale.
+func TestCacheFullScanQueryShape(t *testing.T) {
+	q := cacheFullScanQuery()
+	if !q.AllowScan {
+		t.Error("AllowScan = false, want true (full scan is intentional)")
+	}
+	if !q.SkipLabels {
+		t.Error("SkipLabels = false, want true (reconciler is label-blind)")
+	}
+	if q.TierMode != TierBoth {
+		t.Errorf("TierMode = %v, want TierBoth", q.TierMode)
+	}
+	if q.IncludeClosed {
+		t.Error("IncludeClosed = true, want false (scan is O(active beads) by design)")
+	}
+	if q.Status != "" {
+		t.Errorf("Status = %q, want empty (status filters would shrink the authoritative set)", q.Status)
+	}
+	if q.IncludesClosed() {
+		t.Error("IncludesClosed() = true, want false")
+	}
+	if q.Limit != 0 {
+		t.Errorf("Limit = %d, want 0 (a partial list would cause false evictions)", q.Limit)
+	}
+}
+
+// TestReconcileScanNeverRequestsClosedBeads asserts the reconcile cycle never
+// asks the backing store for closed beads. The reconcile full scan is bounded
+// at O(active beads); on a store carrying as much closed history as active
+// work, an IncludeClosed scan would multiply the per-cycle bd payload without
+// changing the diff result.
+func TestReconcileScanNeverRequestsClosedBeads(t *testing.T) {
+	mem := NewMemStore()
+	open, err := mem.Create(Bead{Title: "active"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	closed, err := mem.Create(Bead{Title: "history"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mem.Close(closed.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	backing := &queryRecordingStore{Store: mem}
+	cs := NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.reset()
+
+	cs.runReconciliation()
+
+	queries := backing.recorded()
+	scans := 0
+	for _, q := range queries {
+		if q.IncludesClosed() {
+			t.Errorf("reconcile issued a query including closed beads: %+v", q)
+		}
+		if q.AllowScan {
+			scans++
+			if q.Limit != 0 {
+				t.Errorf("reconcile full scan set Limit = %d, want 0 (result is the authoritative active set)", q.Limit)
+			}
+		}
+	}
+	if scans == 0 {
+		t.Fatalf("reconcile issued no full scan; queries = %+v", queries)
+	}
+
+	// The active-only scan still converges the cache: the open bead is
+	// cached, the closed one is not.
+	cs.mu.RLock()
+	_, openCached := cs.beads[open.ID]
+	_, closedCached := cs.beads[closed.ID]
+	cs.mu.RUnlock()
+	if !openCached {
+		t.Errorf("open bead %s missing from cache after reconcile", open.ID)
+	}
+	if closedCached {
+		t.Errorf("closed bead %s cached after reconcile, want excluded", closed.ID)
+	}
+}
+
+// TestPrimeScanNeverRequestsClosedBeads asserts the full Prime path shares
+// the same pinned active-only scan scope as the reconciler.
+func TestPrimeScanNeverRequestsClosedBeads(t *testing.T) {
+	mem := NewMemStore()
+	closed, err := mem.Create(Bead{Title: "history"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mem.Close(closed.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	backing := &queryRecordingStore{Store: mem}
+	cs := NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	queries := backing.recorded()
+	scans := 0
+	for _, q := range queries {
+		if q.IncludesClosed() {
+			t.Errorf("prime issued a query including closed beads: %+v", q)
+		}
+		if q.AllowScan {
+			scans++
+			if q.Limit != 0 {
+				t.Errorf("prime full scan set Limit = %d, want 0", q.Limit)
+			}
+		}
+	}
+	if scans == 0 {
+		t.Fatalf("prime issued no full scan; queries = %+v", queries)
+	}
+}
+
+// captureCacheScanTelemetry intercepts the reconcile scan-size telemetry seam
+// for the duration of the test and returns the recorded calls.
+type cacheScanTelemetryCall struct {
+	rig       string
+	beadCount int
+	threshold int
+	elapsed   time.Duration
+}
+
+func captureCacheScanTelemetry(t *testing.T) *[]cacheScanTelemetryCall {
+	t.Helper()
+	var calls []cacheScanTelemetryCall
+	prev := recordCacheScanLarge
+	recordCacheScanLarge = func(_ context.Context, rig string, beadCount, threshold int, elapsed time.Duration) {
+		calls = append(calls, cacheScanTelemetryCall{rig: rig, beadCount: beadCount, threshold: threshold, elapsed: elapsed})
+	}
+	t.Cleanup(func() { recordCacheScanLarge = prev })
+	return &calls
+}
+
+// TestReconcileEmitsScanSizeTelemetryOverThreshold asserts a reconcile scan
+// at or above cacheReconcileScanWarnThreshold emits the scan-size telemetry,
+// making O(active beads) growth visible instead of silent (ga-698fl2: a dev
+// store reached 3,272 active beads / ~11MB of JSON per scan unnoticed).
+func TestReconcileEmitsScanSizeTelemetryOverThreshold(t *testing.T) {
+	calls := captureCacheScanTelemetry(t)
+
+	mem := NewMemStore()
+	for i := 0; i < cacheReconcileScanWarnThreshold; i++ {
+		if _, err := mem.Create(Bead{Title: fmt.Sprintf("bead %d", i)}); err != nil {
+			t.Fatalf("Create %d: %v", i, err)
+		}
+	}
+	cs := NewCachingStoreForTestWithPrefix(mem, "test-rig", nil)
+
+	cs.runReconciliation()
+
+	if len(*calls) != 1 {
+		t.Fatalf("scan telemetry calls = %d, want 1", len(*calls))
+	}
+	got := (*calls)[0]
+	if got.beadCount != cacheReconcileScanWarnThreshold {
+		t.Errorf("beadCount = %d, want %d", got.beadCount, cacheReconcileScanWarnThreshold)
+	}
+	if got.threshold != cacheReconcileScanWarnThreshold {
+		t.Errorf("threshold = %d, want %d", got.threshold, cacheReconcileScanWarnThreshold)
+	}
+	if got.rig != "test-rig" {
+		t.Errorf("rig = %q, want %q", got.rig, "test-rig")
+	}
+	if got.elapsed < 0 {
+		t.Errorf("elapsed = %v, want >= 0", got.elapsed)
+	}
+}
+
+// TestReconcileSkipsScanSizeTelemetryUnderThreshold asserts a small scan emits
+// no scan-size telemetry, so healthy stores stay quiet.
+func TestReconcileSkipsScanSizeTelemetryUnderThreshold(t *testing.T) {
+	calls := captureCacheScanTelemetry(t)
+
+	mem := NewMemStore()
+	if _, err := mem.Create(Bead{Title: "small store"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cs := NewCachingStoreForTest(mem, nil)
+
+	cs.runReconciliation()
+
+	if len(*calls) != 0 {
+		t.Fatalf("scan telemetry calls = %d, want 0; calls = %+v", len(*calls), *calls)
+	}
+}

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -522,6 +522,22 @@ func RecordBDSlow(ctx context.Context, args []string, dir, agentID string) {
 	emit(ctx, "bd.slow", otellog.SeverityWarn, kvs...)
 }
 
+// RecordCacheScanLarge records a beads-cache reconcile full scan whose
+// result size crossed the caller's warn threshold. The reconcile scan is
+// O(active beads) by design and is otherwise silent, so this event makes
+// store growth visible before it degrades every reconcile cycle. rig is the
+// cache's bead ID prefix; beadCount is the number of beads the scan
+// returned; threshold is the warn threshold that fired; elapsed is the
+// wall-clock duration of the backing list call.
+func RecordCacheScanLarge(ctx context.Context, rig string, beadCount, threshold int, elapsed time.Duration) {
+	emit(ctx, "beads.cache.scan_large", otellog.SeverityWarn,
+		otellog.String("rig", strings.TrimSpace(rig)),
+		otellog.Int64("bead_count", int64(beadCount)),
+		otellog.Int64("threshold", int64(threshold)),
+		otellog.Int64("elapsed_ms", elapsed.Milliseconds()),
+	)
+}
+
 // ── Phase 2 recording functions ──────────────────────────────────────────
 
 // RecordPoolSpawn records a pool member instance being spawned (metrics + log event).

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -526,12 +526,18 @@ func RecordBDSlow(ctx context.Context, args []string, dir, agentID string) {
 // result size crossed the caller's warn threshold. The reconcile scan is
 // O(active beads) by design and is otherwise silent, so this event makes
 // store growth visible before it degrades every reconcile cycle. rig is the
-// cache's bead ID prefix; beadCount is the number of beads the scan
+// cache's bead ID prefix; an empty prefix is recorded as "(no-prefix)" to
+// match the reconciler's success-log label, so prefix-less stores group
+// cleanly in telemetry backends. beadCount is the number of beads the scan
 // returned; threshold is the warn threshold that fired; elapsed is the
 // wall-clock duration of the backing list call.
 func RecordCacheScanLarge(ctx context.Context, rig string, beadCount, threshold int, elapsed time.Duration) {
+	rig = strings.TrimSpace(rig)
+	if rig == "" {
+		rig = "(no-prefix)"
+	}
 	emit(ctx, "beads.cache.scan_large", otellog.SeverityWarn,
-		otellog.String("rig", strings.TrimSpace(rig)),
+		otellog.String("rig", rig),
 		otellog.Int64("bead_count", int64(beadCount)),
 		otellog.Int64("threshold", int64(threshold)),
 		otellog.Int64("elapsed_ms", elapsed.Milliseconds()),

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	otellog "go.opentelemetry.io/otel/log"
 	otellogglobal "go.opentelemetry.io/otel/log/global"
@@ -258,6 +259,34 @@ func TestRecordBDSlowEmitsSanitizedWarnEvent(t *testing.T) {
 	}
 	if got := attrs["timestamp"].AsString(); got == "" {
 		t.Fatal("bd.slow timestamp is empty")
+	}
+}
+
+func TestRecordCacheScanLargeEmitsWarnEvent(t *testing.T) {
+	resetInstruments(t)
+	exp := installRecordingLogExporter(t)
+
+	RecordCacheScanLarge(context.Background(), "test-rig", 3272, 2500, 2100*time.Millisecond)
+
+	rec := exp.recordByBody("beads.cache.scan_large")
+	if rec == nil {
+		t.Fatal("RecordCacheScanLarge did not emit beads.cache.scan_large")
+	}
+	if got := rec.Severity(); got != otellog.SeverityWarn {
+		t.Fatalf("beads.cache.scan_large severity = %v, want WARN", got)
+	}
+	attrs := recordAttrs(*rec)
+	if got := attrs["rig"].AsString(); got != "test-rig" {
+		t.Fatalf("beads.cache.scan_large rig = %q, want test-rig", got)
+	}
+	if got := attrs["bead_count"].AsInt64(); got != 3272 {
+		t.Fatalf("beads.cache.scan_large bead_count = %d, want 3272", got)
+	}
+	if got := attrs["threshold"].AsInt64(); got != 2500 {
+		t.Fatalf("beads.cache.scan_large threshold = %d, want 2500", got)
+	}
+	if got := attrs["elapsed_ms"].AsInt64(); got != 2100 {
+		t.Fatalf("beads.cache.scan_large elapsed_ms = %d, want 2100", got)
 	}
 }
 

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -290,6 +290,22 @@ func TestRecordCacheScanLargeEmitsWarnEvent(t *testing.T) {
 	}
 }
 
+func TestRecordCacheScanLargeNormalizesEmptyRig(t *testing.T) {
+	resetInstruments(t)
+	exp := installRecordingLogExporter(t)
+
+	RecordCacheScanLarge(context.Background(), "  ", 2600, 2500, 150*time.Millisecond)
+
+	rec := exp.recordByBody("beads.cache.scan_large")
+	if rec == nil {
+		t.Fatal("RecordCacheScanLarge did not emit beads.cache.scan_large")
+	}
+	attrs := recordAttrs(*rec)
+	if got := attrs["rig"].AsString(); got != "(no-prefix)" {
+		t.Fatalf("beads.cache.scan_large rig = %q, want (no-prefix)", got)
+	}
+}
+
 func TestRecordBeadStoreHealth(t *testing.T) {
 	resetInstruments(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Problem

The CachingStore reconcile cycle (and `Prime`) issue a full backing scan — `bd list --json --limit 0` — every cycle, with the scan scope left implicit. On the dev store that triggered `ga-698fl2`, the scan had silently grown to **3,272 active beads / ~11MB of JSON / ~2s of bd round-trip per cycle**, and nothing would have warned before it doubled again.

## Why the obvious fix is wrong

The reconcile diff treats the list result as the **authoritative active universe**: any cached bead absent from the result is re-verified per ID and then evicted with a synthetic `bead.closed` event. So:

- **A `Limit` is unsafe.** A bounded list would push every active bead beyond the limit through the per-bead `Get` recovery path each cycle — O(active−limit) extra bd round-trips — and synthesize **false `bead.closed` evictions** whenever those Gets degrade.
- **`IncludeClosed` must stay false.** The scan is O(active) by design; the dev store carries 3,197 closed beads that would have doubled the payload without changing the diff result.

Neither bound was pinned anywhere — both were one refactor away from regressing.

## Fix

- Extract `cacheFullScanQuery()` shared by `Prime` and the reconciler, with the authority rationale documented at the definition.
- Pin both bounds with tests that record the **exact `ListQuery` reaching the backing store** (`Limit == 0`, never `IncludeClosed`), plus convergence assertions (open bead cached, closed bead excluded).
- Emit `beads.cache.scan_large` warn telemetry when a scan returns ≥ 2500 beads (between the MEDIUM/1000 and LARGE/5000 cadence thresholds), with rig, bead count, threshold, and elapsed ms — so O(active) growth is visible instead of discovered by accident.

## Testing

- New: query-shape pin, reconcile/Prime never request closed beads (recording-store harness), telemetry fires at threshold / stays quiet under it, telemetry attrs asserted via the recording log exporter
- `go test ./internal/beads ./internal/telemetry` ok, `-race` on cache/reconcile paths ok, `go vet` clean, pre-commit fast shards pass

Bead: `ga-698fl2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)