### PR TITLE
fix(supervisor): fail loudly on duplicate API-port collision (ga-ceq)

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -325,17 +325,73 @@ func supervisorAddrInUse(err error) bool {
 }
 
 // supervisorPortInUseMessage returns the loud, actionable diagnostic emitted
-// when the API port is already held by another supervisor. It names the
-// address and both remedies so a duplicate install fails legibly instead of
-// emitting an opaque "bind: address already in use" on every restart.
+// when the API port is already held by another gc supervisor (confirmed by
+// supervisorRespondingGCSupervisor). It names the address and both remedies
+// so a duplicate install fails legibly instead of emitting an opaque "bind:
+// address already in use" on every restart.
+//
+// The restart-behavior line is platform-conditioned: on systemd,
+// RestartPreventExitStatus (see supervisorExitCodePortInUse) actually stops
+// the restart loop, but launchd's KeepAlive has no per-exit-code equivalent —
+// any nonzero exit is "Crashed" and gets restarted regardless — so claiming
+// "without restart" on darwin would be false.
 func supervisorPortInUseMessage(addr, configPath string) string {
+	restartBehavior := "This instance is a duplicate and is exiting without restart."
+	if supervisorRuntimeGOOS == "darwin" {
+		restartBehavior = "This instance is a duplicate. launchd will keep restarting it " +
+			"regardless of exit code (macOS has no RestartPreventExitStatus equivalent) " +
+			"until you resolve the collision below."
+	}
 	return fmt.Sprintf(
 		"gc supervisor: API address %s is already in use.\n"+
 			"Another gc supervisor already owns this port — only one supervisor may run per machine.\n"+
-			"This instance is a duplicate and is exiting without restart. To resolve, either:\n"+
+			"%s To resolve, either:\n"+
 			"  - stop the other supervisor (gc supervisor stop) before starting this one, or\n"+
 			"  - give this supervisor its own port: set [supervisor] port = <N> in %s\n",
-		addr, configPath)
+		addr, restartBehavior, configPath)
+}
+
+// supervisorHealthProbeTimeout bounds how long we wait for a /health response
+// when confirming that an EADDRINUSE binder is actually another gc
+// supervisor. Short enough to not stall startup on a dead or foreign binder.
+// Overridable for tests.
+var supervisorHealthProbeTimeout = 2 * time.Second
+
+// supervisorRespondingGCSupervisor reports whether the process bound to addr
+// answers like a gc supervisor. Overridable for tests.
+//
+// EADDRINUSE only proves *something* is bound to addr — it does not prove
+// that something is another gc supervisor. The genuine same-GC_HOME
+// duplicate is already caught earlier by acquireSupervisorLock's exclusive
+// flock, so by the time we reach the port collision, the binder is either a
+// different user's gc supervisor (a true duplicate) or an unrelated foreign
+// process that happens to hold the shared port. Only a positive /health
+// identification justifies the exit-3 duplicate path (and, on systemd,
+// refusing to restart); anything else falls through to the current
+// self-healing exit-1 behavior so a transient or foreign binder recovers via
+// normal restart instead of a sticky outage.
+var supervisorRespondingGCSupervisor = func(addr string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), supervisorHealthProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+addr+"/health", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort close
+	if resp.StatusCode/100 != 2 {
+		return false
+	}
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&body); err != nil {
+		return false
+	}
+	return body.Status == "ok"
 }
 
 // supervisorHardExit terminates the supervisor immediately. It intentionally
@@ -1333,7 +1389,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	addr := net.JoinHostPort(bind, strconv.Itoa(port))
 	apiLis, apiErr := net.Listen("tcp", addr)
 	if apiErr != nil {
-		if supervisorAddrInUse(apiErr) {
+		if supervisorAddrInUse(apiErr) && supervisorRespondingGCSupervisor(addr) {
 			fmt.Fprint(stderr, supervisorPortInUseMessage(addr, supervisor.ConfigPath())) //nolint:errcheck
 			return supervisorExitCodePortInUse
 		}

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -310,6 +310,34 @@ var supervisorLoadConfig = supervisor.LoadConfig
 // the escalation.
 const supervisorHardExitCodeRepeatedShutdown = 130
 
+// supervisorExitCodePortInUse is returned when the API port is already bound
+// by another supervisor. Only one supervisor may own the port machine-wide, so
+// a collision means this process is a duplicate install. The generated systemd
+// unit lists this code in RestartPreventExitStatus so the duplicate exits once
+// with a clear diagnostic instead of crash-looping on the shared port forever.
+const supervisorExitCodePortInUse = 3
+
+// supervisorAddrInUse reports whether err indicates the listen address was
+// already bound (EADDRINUSE) — the signature of a second supervisor competing
+// for the shared API port, as opposed to any other listen failure.
+func supervisorAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
+}
+
+// supervisorPortInUseMessage returns the loud, actionable diagnostic emitted
+// when the API port is already held by another supervisor. It names the
+// address and both remedies so a duplicate install fails legibly instead of
+// emitting an opaque "bind: address already in use" on every restart.
+func supervisorPortInUseMessage(addr, configPath string) string {
+	return fmt.Sprintf(
+		"gc supervisor: API address %s is already in use.\n"+
+			"Another gc supervisor already owns this port — only one supervisor may run per machine.\n"+
+			"This instance is a duplicate and is exiting without restart. To resolve, either:\n"+
+			"  - stop the other supervisor (gc supervisor stop) before starting this one, or\n"+
+			"  - give this supervisor its own port: set [supervisor] port = <N> in %s\n",
+		addr, configPath)
+}
+
 // supervisorHardExit terminates the supervisor immediately. It intentionally
 // bypasses graceful cleanup and may leave managed sessions or child processes
 // alive for operator recovery. Overridable for tests.
@@ -1305,6 +1333,10 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	addr := net.JoinHostPort(bind, strconv.Itoa(port))
 	apiLis, apiErr := net.Listen("tcp", addr)
 	if apiErr != nil {
+		if supervisorAddrInUse(apiErr) {
+			fmt.Fprint(stderr, supervisorPortInUseMessage(addr, supervisor.ConfigPath())) //nolint:errcheck
+			return supervisorExitCodePortInUse
+		}
 		fmt.Fprintf(stderr, "gc supervisor: api: listen %s failed: %v\n", addr, apiErr) //nolint:errcheck
 		return 1
 	}

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -996,6 +996,10 @@ type supervisorServiceData struct {
 	SafeName      string
 	Path          string
 	ExtraEnv      []supervisorServiceEnvVar
+	// PortInUseExitCode is the exit code the supervisor returns on a duplicate
+	// API-port collision; the systemd unit lists it in RestartPreventExitStatus
+	// so a duplicate install does not crash-loop on the shared port.
+	PortInUseExitCode int
 }
 
 type supervisorServiceEnvVar struct {
@@ -1016,14 +1020,15 @@ func buildSupervisorServiceData() (*supervisorServiceData, error) {
 		xdgRuntimeDir = ""
 	}
 	return &supervisorServiceData{
-		GCPath:        gcPath,
-		LogPath:       supervisorLogPath(),
-		GCHome:        home,
-		XDGRuntimeDir: xdgRuntimeDir,
-		LaunchdLabel:  supervisorLaunchdLabel(),
-		SafeName:      sanitizeServiceName(filepath.Base(home)),
-		Path:          searchpath.ExpandPath(homeDir, goruntime.GOOS, os.Getenv("PATH")),
-		ExtraEnv:      supervisorServiceExtraEnv(),
+		GCPath:            gcPath,
+		LogPath:           supervisorLogPath(),
+		GCHome:            home,
+		XDGRuntimeDir:     xdgRuntimeDir,
+		LaunchdLabel:      supervisorLaunchdLabel(),
+		SafeName:          sanitizeServiceName(filepath.Base(home)),
+		Path:              searchpath.ExpandPath(homeDir, goruntime.GOOS, os.Getenv("PATH")),
+		ExtraEnv:          supervisorServiceExtraEnv(),
+		PortInUseExitCode: supervisorExitCodePortInUse,
 	}, nil
 }
 
@@ -1370,6 +1375,9 @@ KillMode=process
 ExecStart={{systemdpath .GCPath}} supervisor run
 Restart=always
 RestartSec=5s
+# A duplicate supervisor that loses the shared API port exits with this code.
+# Restarting it would just crash-loop forever (see ga-ceq), so don't.
+RestartPreventExitStatus={{.PortInUseExitCode}}
 StandardOutput=append:{{.LogPath}}
 StandardError=append:{{.LogPath}}
 Environment=GC_HOME="{{.GCHome}}"

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -1316,6 +1316,15 @@ func supervisorSystemdServiceName() string {
 	return defaultSupervisorSystemdUnit
 }
 
+// supervisorLaunchdTemplate has no equivalent of systemd's
+// RestartPreventExitStatus: launchd's KeepAlive dict below has no
+// per-exit-code / LastExitStatus key, so a duplicate supervisor that exits
+// with supervisorExitCodePortInUse (see cmd_supervisor.go) is still
+// "Crashed" (any nonzero exit) and gets restarted regardless of exit code.
+// The port-in-use message is worded accordingly on darwin (see
+// supervisorPortInUseMessage) instead of falsely claiming "without restart".
+// Real macOS duplicate-instance suppression is a different mechanism and is
+// tracked separately: gc-s53wv.
 const supervisorLaunchdTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/cmd/gc/cmd_supervisor_portcollision_test.go
+++ b/cmd/gc/cmd_supervisor_portcollision_test.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // TestSupervisorAddrInUse verifies that only EADDRINUSE (the signature of a
@@ -52,6 +56,122 @@ func TestSupervisorPortInUseMessage(t *testing.T) {
 			t.Errorf("port-in-use message missing %q; got:\n%s", want, msg)
 		}
 	}
+}
+
+// TestSupervisorPortInUseMessageDarwinDoesNotClaimWithoutRestart verifies
+// the MAJOR-A fix: launchd's KeepAlive has no per-exit-code equivalent of
+// systemd's RestartPreventExitStatus, so a duplicate supervisor on macOS is
+// still restarted regardless of exit code. Claiming "without restart" there
+// would be unconditionally false.
+func TestSupervisorPortInUseMessageDarwinDoesNotClaimWithoutRestart(t *testing.T) {
+	old := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "darwin"
+	t.Cleanup(func() { supervisorRuntimeGOOS = old })
+
+	msg := supervisorPortInUseMessage("127.0.0.1:8372", "/home/someone/.gc/supervisor.toml")
+	if strings.Contains(msg, "without restart") {
+		t.Errorf("darwin port-in-use message falsely claims restart suppression; got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "launchd") || !strings.Contains(msg, "regardless of exit code") {
+		t.Errorf("darwin port-in-use message should explain launchd's restart-regardless-of-exit-code behavior; got:\n%s", msg)
+	}
+}
+
+// TestSupervisorPortInUseMessageLinuxClaimsWithoutRestart is the systemd-side
+// counterpart: RestartPreventExitStatus genuinely stops the restart there, so
+// the message should say so.
+func TestSupervisorPortInUseMessageLinuxClaimsWithoutRestart(t *testing.T) {
+	old := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "linux"
+	t.Cleanup(func() { supervisorRuntimeGOOS = old })
+
+	msg := supervisorPortInUseMessage("127.0.0.1:8372", "/home/someone/.gc/supervisor.toml")
+	if !strings.Contains(msg, "without restart") {
+		t.Errorf("linux port-in-use message should claim restart suppression; got:\n%s", msg)
+	}
+}
+
+// TestSupervisorRespondingGCSupervisor verifies the /health liveness gate
+// used to discriminate a true duplicate gc supervisor (which answers
+// {"status":"ok"}) from a foreign or non-responding binder that merely
+// happens to hold the shared API port (gc-r0k40, MAJOR-B).
+func TestSupervisorRespondingGCSupervisor(t *testing.T) {
+	t.Run("responding gc supervisor", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/health" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"status":"ok","version":"1.2.3"}`) //nolint:errcheck
+		}))
+		defer srv.Close()
+
+		addr := strings.TrimPrefix(srv.URL, "http://")
+		if !supervisorRespondingGCSupervisor(addr) {
+			t.Errorf("supervisorRespondingGCSupervisor(%q) = false, want true", addr)
+		}
+	})
+
+	t.Run("foreign HTTP responder", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"hello":"world"}`) //nolint:errcheck
+		}))
+		defer srv.Close()
+
+		addr := strings.TrimPrefix(srv.URL, "http://")
+		if supervisorRespondingGCSupervisor(addr) {
+			t.Errorf("supervisorRespondingGCSupervisor(%q) = true, want false (not a gc supervisor payload)", addr)
+		}
+	})
+
+	t.Run("non-2xx responder", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		addr := strings.TrimPrefix(srv.URL, "http://")
+		if supervisorRespondingGCSupervisor(addr) {
+			t.Errorf("supervisorRespondingGCSupervisor(%q) = true, want false (non-2xx)", addr)
+		}
+	})
+
+	t.Run("nothing listening", func(t *testing.T) {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := lis.Addr().String()
+		if err := lis.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if supervisorRespondingGCSupervisor(addr) {
+			t.Errorf("supervisorRespondingGCSupervisor(%q) = true, want false (connection refused)", addr)
+		}
+	})
+
+	t.Run("timeout is bounded", func(t *testing.T) {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lis.Close() //nolint:errcheck
+
+		old := supervisorHealthProbeTimeout
+		supervisorHealthProbeTimeout = 100 * time.Millisecond
+		t.Cleanup(func() { supervisorHealthProbeTimeout = old })
+
+		addr := lis.Addr().String()
+		start := time.Now()
+		if supervisorRespondingGCSupervisor(addr) {
+			t.Errorf("supervisorRespondingGCSupervisor(%q) = true, want false (unaccepted connection)", addr)
+		}
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Errorf("supervisorRespondingGCSupervisor took %s, want bounded by supervisorHealthProbeTimeout", elapsed)
+		}
+	})
 }
 
 // TestSupervisorSystemdTemplatePreventsRestartOnPortCollision verifies the

--- a/cmd/gc/cmd_supervisor_portcollision_test.go
+++ b/cmd/gc/cmd_supervisor_portcollision_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestSupervisorAddrInUse verifies that only EADDRINUSE (the signature of a
+// second supervisor competing for the shared API port) is classified as a
+// port collision — other listen errors must fall through to the generic path.
+func TestSupervisorAddrInUse(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"address in use", syscall.EADDRINUSE, true},
+		{"wrapped address in use", &net.OpError{Op: "listen", Err: syscall.EADDRINUSE}, true},
+		{"connection refused", syscall.ECONNREFUSED, false},
+		{"permission denied", syscall.EACCES, false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := supervisorAddrInUse(tc.err); got != tc.want {
+				t.Fatalf("supervisorAddrInUse(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSupervisorPortInUseMessage verifies the diagnostic is loud and
+// actionable: it names the address, states only one supervisor may run, and
+// points the operator at both remedies (stop the other / pick another port).
+func TestSupervisorPortInUseMessage(t *testing.T) {
+	const addr = "127.0.0.1:8372"
+	const cfg = "/home/someone/.gc/supervisor.toml"
+	msg := supervisorPortInUseMessage(addr, cfg)
+
+	for _, want := range []string{
+		addr,
+		cfg,
+		"already in use",
+		"only one supervisor",
+		"gc supervisor stop",
+		"port =",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("port-in-use message missing %q; got:\n%s", want, msg)
+		}
+	}
+}
+
+// TestSupervisorSystemdTemplatePreventsRestartOnPortCollision verifies the
+// generated systemd unit lists the duplicate-port exit code in
+// RestartPreventExitStatus, so a duplicate install exits once instead of
+// crash-looping on the shared port forever (the ga-ceq regression).
+func TestSupervisorSystemdTemplatePreventsRestartOnPortCollision(t *testing.T) {
+	data := &supervisorServiceData{
+		GCPath:            "/usr/local/bin/gc",
+		LogPath:           "/home/someone/.gc/supervisor.log",
+		GCHome:            "/home/someone/.gc",
+		Path:              "/usr/bin",
+		PortInUseExitCode: supervisorExitCodePortInUse,
+	}
+	content, err := renderSupervisorTemplate(supervisorSystemdTemplate, data)
+	if err != nil {
+		t.Fatalf("render systemd template: %v", err)
+	}
+	want := "RestartPreventExitStatus=" + strconv.Itoa(supervisorExitCodePortInUse)
+	if !strings.Contains(content, want) {
+		t.Fatalf("systemd unit missing %q; got:\n%s", want, content)
+	}
+	// Genuine crashes must still restart — Restart=always stays in force.
+	if !strings.Contains(content, "Restart=always") {
+		t.Fatalf("systemd unit lost Restart=always; got:\n%s", content)
+	}
+}

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -6,8 +6,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"os/user"
@@ -4233,6 +4236,78 @@ func TestRunSupervisorFailsWhenAPIPortUnavailable(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "api: listen") {
 		t.Fatalf("stderr = %q, want API listen failure", stderr.String())
+	}
+}
+
+// TestRunSupervisorPortCollisionWithForeignHTTPBinderFallsThroughToExit1
+// covers the /health gate's discrimination case that the bare-listener test
+// above cannot: a binder that DOES speak HTTP on the shared port but is not
+// a gc supervisor (no {"status":"ok"} payload). EADDRINUSE alone must not be
+// treated as proof of a duplicate gc supervisor — only a positive /health
+// identification does (gc-r0k40, MAJOR-B).
+func TestRunSupervisorPortCollisionWithForeignHTTPBinderFallsThroughToExit1(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	foreign := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"hello":"world"}`) //nolint:errcheck
+	}))
+	defer foreign.Close()
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(foreign.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split foreign server addr: %v", err)
+	}
+	cfg := []byte("[supervisor]\nport = " + port + "\n")
+	if err := os.WriteFile(supervisor.ConfigPath(), cfg, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runSupervisor(&stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("runSupervisor code = %d, want 1 (foreign binder, not a duplicate); stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "api: listen") {
+		t.Fatalf("stderr = %q, want API listen failure", stderr.String())
+	}
+}
+
+// TestRunSupervisorPortCollisionWithRespondingGCSupervisorExitsDuplicate
+// covers the true-duplicate case: the binder on the shared port answers
+// /health like a gc supervisor, so runSupervisor must take the exit-3
+// duplicate path (gc-r0k40, MAJOR-B).
+func TestRunSupervisorPortCollisionWithRespondingGCSupervisorExitsDuplicate(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"ok","version":"1.2.3","build_id":"deadbeef"}`) //nolint:errcheck
+	}))
+	defer other.Close()
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(other.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split other server addr: %v", err)
+	}
+	cfg := []byte("[supervisor]\nport = " + port + "\n")
+	if err := os.WriteFile(supervisor.ConfigPath(), cfg, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runSupervisor(&stdout, &stderr)
+	if code != supervisorExitCodePortInUse {
+		t.Fatalf("runSupervisor code = %d, want %d (duplicate gc supervisor); stderr=%q", code, supervisorExitCodePortInUse, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "already in use") {
+		t.Fatalf("stderr = %q, want port-in-use message", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Problem (ga-ceq)

Two `gc supervisor run` instances on one machine both bind the hardcoded
`127.0.0.1:8372`. The per-`GC_HOME` flock (`acquireSupervisorLock`) and
`supervisorAlive()` are keyed on the **per-user** `RuntimeDir`, so neither
detects a *different user's* supervisor — the shared TCP port is the only
cross-user contention. The loser hit `EADDRINUSE` at `net.Listen`, printed a
generic one-liner, exited 1, and systemd restarted it every 5s **forever**
(~202k restarts over a 13-day boot; contributed log/CPU noise to an OOM reboot).

## Fix

Make the collision self-diagnosing instead of a silent crash-loop:

- **Detect `EADDRINUSE` specifically** (`supervisorAddrInUse`, via
  `errors.Is` so it unwraps `net.OpError`) and emit a loud, actionable
  diagnostic (`supervisorPortInUseMessage`) naming the address and both
  remedies (stop the other supervisor / set `[supervisor] port`).
- **Distinct exit code** `supervisorExitCodePortInUse = 3` for the
  duplicate-bind case; all other listen errors keep the generic exit 1 and
  still restart.
- **Generated systemd unit sets `RestartPreventExitStatus=3`**, so a duplicate
  install exits once with a clear message instead of crash-looping. The code is
  threaded through `supervisorServiceData` (single source of truth);
  `Restart=always` still covers genuine crashes.

The API port was already configurable via `~/.gc/supervisor.toml`; this closes
the "fail loudly" half so duplicate installs surface immediately.

## Tests

`cmd/gc/cmd_supervisor_portcollision_test.go` (TDD, red→green):
- `TestSupervisorAddrInUse` — only `EADDRINUSE` (incl. wrapped `net.OpError`)
  classifies as a collision; `ECONNREFUSED`/`EACCES`/nil do not.
- `TestSupervisorPortInUseMessage` — diagnostic names the address, config path,
  and both remedies.
- `TestSupervisorSystemdTemplatePreventsRestartOnPortCollision` — rendered unit
  contains `RestartPreventExitStatus=3` and retains `Restart=always`.

`go vet ./cmd/gc/` clean. Existing systemd/install template tests pass. (Two
pre-existing `TestUnloadSupervisorService*` failures in this sandbox are
environment-only — they mock `systemctl` — and fail identically without this
change.)

## Notes

- Operational side of ga-ceq (which supervisor owns the machine) is handled
  separately; this PR is the durable code fix so the class of bug can't recur.
- Security-reviewed (rafter): no findings of consequence — diagnostic exposes
  only an operator-owned loopback address + a fixed config path; the template
  substitution is a compile-time int constant (no injection surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #1920 — same "two supervisors, one shared port → restart flap, no preflight" class. This PR addresses the supervisor **API-port** (8372) collision; the filed issue is the **Dolt-port** variant.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
