### PR TITLE
fix(runtime): retain tmux session liveness when the process snapshot fails

### DIFF
--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -62,6 +62,13 @@ type processSnapshot struct {
 type runtimeStateSnapshot struct {
 	Sessions  map[string]sessionRuntimeState
 	Processes processSnapshot
+	// ProcessesAvailable reports whether the OS process-table snapshot was
+	// fetched successfully. tmux list-panes establishes session liveness on its
+	// own; the process snapshot is only a secondary refinement (matching pane
+	// PIDs to processNames). When the full-OS ps scan loses the CPU race to a
+	// busy fleet it is marked unavailable rather than discarding the
+	// authoritative tmux liveness, and processAlive degrades optimistically.
+	ProcessesAvailable bool
 }
 
 // StateCache caches tmux runtime state to avoid spawning N subprocess calls per
@@ -260,9 +267,19 @@ func (f *tmuxFetcher) FetchState(ctx context.Context) (runtimeStateSnapshot, err
 	}
 	processes, err := fetchProcessSnapshot(ctx)
 	if err != nil {
-		return runtimeStateSnapshot{}, err
+		// Degrade, do NOT discard: tmux list-panes above already established
+		// session liveness. The process snapshot is a secondary refinement
+		// (matching pane PIDs to processNames). A full-OS ps scan that loses the
+		// CPU race to a busy/KO fleet must never throw away authoritative tmux
+		// liveness — that is what was starving the controller's reconcile and
+		// cold-pool-spawner. Keep the sessions; mark process detail unavailable
+		// so processAlive degrades optimistically instead of reporting dead.
+		log.Printf("tmux state cache: process snapshot degraded, retaining tmux session liveness: %v", err)
+		state.ProcessesAvailable = false
+		return state, nil
 	}
 	state.Processes = processes
+	state.ProcessesAvailable = true
 	return state, nil
 }
 
@@ -274,6 +291,13 @@ func (s runtimeStateSnapshot) processAlive(sessionName string, processNames []st
 	names := processNameSet(processNames)
 	if len(names) == 0 {
 		return false
+	}
+	if !s.ProcessesAvailable {
+		// The OS process snapshot failed (e.g. the ps scan timed out under
+		// fleet load). tmux confirms the session/pane is alive; we cannot verify
+		// the inner process, so degrade optimistically rather than report it
+		// dead. A failed secondary probe must never trigger a reap/respawn.
+		return true
 	}
 	for _, pane := range session.Panes {
 		if pane.processAlive(names, s.Processes) {

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -196,6 +196,7 @@ func TestStateCache_ProcessAliveUsesFreshSnapshot(t *testing.T) {
 				Command: "claude",
 				Args:    "claude --dangerously-skip-permissions",
 			}}),
+			ProcessesAvailable: true,
 		},
 	}
 	cache := NewStateCache(f, 2*time.Second)
@@ -211,6 +212,37 @@ func TestStateCache_ProcessAliveUsesFreshSnapshot(t *testing.T) {
 	}
 	if got := f.getCalls(); got != 1 {
 		t.Fatalf("fetch calls = %d, want 1 across ProcessAlive and IsRunning", got)
+	}
+}
+
+// TestStateCache_DegradedProcessSnapshotRetainsLiveness asserts the control
+// plane stays correct when the OS process-table snapshot is unavailable (the
+// ps scan lost the CPU race to a busy fleet). tmux already proved the session
+// is alive, so IsRunning must stay true and ProcessAlive must degrade
+// optimistically (NOT report the process dead, which would wrongly reap it).
+func TestStateCache_DegradedProcessSnapshotRetainsLiveness(t *testing.T) {
+	f := &mockFetcher{
+		state: runtimeStateSnapshot{
+			Sessions: map[string]sessionRuntimeState{
+				"agent-1": {
+					Running: true,
+					Panes:   []paneRuntimeState{{Command: "bash", PID: "101"}},
+				},
+			},
+			// Processes empty + ProcessesAvailable=false models a failed ps scan.
+			ProcessesAvailable: false,
+		},
+	}
+	cache := NewStateCache(f, 2*time.Second)
+
+	if !cache.IsRunning("agent-1") {
+		t.Fatal("IsRunning(agent-1) = false under degraded snapshot, want true (tmux liveness retained)")
+	}
+	if !cache.ProcessAlive("agent-1", []string{"claude"}) {
+		t.Fatal("ProcessAlive(agent-1, claude) = false under degraded snapshot, want true (optimistic degrade, never report dead)")
+	}
+	if cache.IsRunning("agent-2") {
+		t.Fatal("IsRunning(agent-2) = true, want false for an absent session even when degraded")
 	}
 }
 
@@ -230,6 +262,7 @@ func TestStateCache_ProcessAliveMatchesShellDescendantFromSnapshot(t *testing.T)
 				{PID: "101", PPID: "1", Command: "bash", Args: "bash -lc codex"},
 				{PID: "102", PPID: "101", Command: "node", Args: "node /usr/local/bin/codex"},
 			}),
+			ProcessesAvailable: true,
 		},
 	}
 	cache := NewStateCache(f, 2*time.Second)
@@ -258,6 +291,7 @@ func TestProviderObserveLivenessUsesCacheProcessSnapshot(t *testing.T) {
 				{PID: "101", PPID: "1", Command: "bash", Args: "bash -lc codex"},
 				{PID: "102", PPID: "101", Command: "node", Args: "node /usr/local/bin/codex"},
 			}),
+			ProcessesAvailable: true,
 		},
 	}
 	provider := &Provider{cache: NewStateCache(f, time.Hour)}


### PR DESCRIPTION
## Summary

`tmux.FetchState` determined session liveness two ways: a cheap, authoritative `tmux list-panes`, plus a full-OS `ps` scan used only to refine pane→process liveness. On **any** failure of the `ps` scan it discarded the *entire* snapshot and returned an error.

Under a busy fleet the full-OS scan loses the CPU race and exceeds the 3s fetch timeout, so the cache goes stale and — after `staleTTL` — reports **all sessions not-running**. That starves the reconciler and pool spawners: rig pools never spawn even with idle capacity. A single busy/wedged session can break the whole control plane.

**Fix:** on process-snapshot failure, keep the tmux-derived session liveness and mark processes unavailable (`ProcessesAvailable=false`) instead of discarding the snapshot. `processAlive` then degrades optimistically (never reports a tmux-live pane dead on an unverifiable secondary probe), and `IsRunning` — the spawn/reconcile gate — depends only on tmux, making it immune to the `ps`-scan storm.

Behavior is unchanged on the happy path; this only changes the degraded path from "fail closed (everything dead)" to "fail open on the secondary signal, keep the authoritative one."

## Testing

- [x] `go test ./internal/runtime/tmux/` passes locally, including the new `TestStateCache_DegradedProcessSnapshotRetainsLiveness`
- [x] `go vet ./internal/runtime/tmux/`, `go build ./...`
- [ ] Full `make check` / integration suite — CI

## Checklist

- [x] Added tests for the behavior change
- [x] No user-facing API or docs change
- [ ] No breaking changes / migration notes
