### PR TITLE
perf(reconciler): collapse per-assignee Ready fan-out to one scope read

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1233,6 +1233,7 @@ func collectAssignedWorkBeadsWithStores(
 	}
 
 	readyResults := make([]storeAssignedWorkResult, len(stores))
+	readyLimit := assignedWorkReadyLimit(cfg)
 	for idx, source := range stores {
 		idx, source := idx, source
 		wg.Add(1)
@@ -1242,18 +1243,29 @@ func collectAssignedWorkBeadsWithStores(
 			var err error
 			var errs []error
 			if len(assignees) == 0 {
-				ready, err = liveReadyForControllerDemandQuery(source.store, beads.ReadyQuery{Limit: assignedWorkReadyLimit(cfg)})
+				ready, err = liveReadyForControllerDemandQuery(source.store, beads.ReadyQuery{Limit: readyLimit})
 				if err != nil {
 					errs = append(errs, fmt.Errorf("Ready(): %w", err))
 				}
 			} else {
-				for _, assignee := range assignees {
-					part, partErr := liveReadyForControllerDemandQuery(source.store, beads.ReadyQuery{Assignee: assignee, Limit: assignedWorkReadyLimit(cfg)})
-					if partErr != nil {
-						errs = append(errs, fmt.Errorf("Ready(assignee=%q): %w", assignee, partErr))
-					}
-					ready = append(ready, part...)
+				// Collapse the per-assignee Ready fan-out into a single live
+				// scope read, then partition the result in memory. The former
+				// loop issued one backing-store Ready query per assignee, which
+				// for a BdStore-backed scope is one bd subprocess per assignee
+				// per reconcile pass (≈ stores × open sessions per tick). The
+				// per-assignee Assignee filter is an exact-match post-filter on
+				// every store implementation, so reading the scope once and
+				// keeping only ready beads whose assignee is in the requested set
+				// yields the identical bead output while paying a single read.
+				// Limit 0 means unbounded so partitionReadyByAssignee can reapply
+				// the old per-assignee Limit cap in memory rather than truncating
+				// the shared read before partitioning.
+				var readErr error
+				ready, readErr = liveReadyForControllerDemandQuery(source.store, beads.ReadyQuery{Limit: 0})
+				if readErr != nil {
+					errs = append(errs, fmt.Errorf("Ready(scope): %w", readErr))
 				}
+				ready = partitionReadyByAssignee(ready, assignees, readyLimit)
 			}
 			var readyBeads []beads.Bead
 			var readyStores []beads.Store
@@ -1846,6 +1858,51 @@ func liveReadyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery
 	query.TierMode = beads.TierBoth
 	handles := beads.HandlesFor(store)
 	return handles.Live.Ready(query)
+}
+
+// partitionReadyByAssignee selects, from a single unfiltered scope Ready read,
+// the ready beads whose assignee is in assignees, preserving the bead set and
+// ordering the former per-assignee Ready fan-out produced. Beads are emitted in
+// assignees order (each assignee's matches in store-read order), and perLimit
+// caps each assignee's contribution exactly as the old per-assignee
+// ReadyQuery.Limit did (perLimit <= 0 means unbounded). A bead is attributed to
+// the first assignee in assignees that it matches, so a bead is never duplicated
+// across groups even when assignee identities overlap.
+func partitionReadyByAssignee(ready []beads.Bead, assignees []string, perLimit int) []beads.Bead {
+	if len(ready) == 0 || len(assignees) == 0 {
+		return nil
+	}
+	trimmed := make([]string, len(assignees))
+	wanted := make(map[string]struct{}, len(assignees))
+	for i, a := range assignees {
+		a = strings.TrimSpace(a)
+		trimmed[i] = a
+		if a != "" {
+			wanted[a] = struct{}{}
+		}
+	}
+	if len(wanted) == 0 {
+		return nil
+	}
+	byAssignee := make(map[string][]beads.Bead)
+	for _, b := range ready {
+		assignee := strings.TrimSpace(b.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if _, ok := wanted[assignee]; !ok {
+			continue
+		}
+		if perLimit > 0 && len(byAssignee[assignee]) >= perLimit {
+			continue
+		}
+		byAssignee[assignee] = append(byAssignee[assignee], b)
+	}
+	out := make([]beads.Bead, 0, len(ready))
+	for _, assignee := range trimmed {
+		out = append(out, byAssignee[assignee]...)
+	}
+	return out
 }
 
 func mergeReadyRowsByID(primary, secondary []beads.Bead) []beads.Bead {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1257,9 +1257,27 @@ func collectAssignedWorkBeadsWithStores(
 				// every store implementation, so reading the scope once and
 				// keeping only ready beads whose assignee is in the requested set
 				// yields the identical bead output while paying a single read.
-				// Limit 0 means unbounded so partitionReadyByAssignee can reapply
+				//
+				// Fault contract (unchanged by the collapse): the per-assignee
+				// loop did NOT isolate faults. BdStore.Ready parses the whole
+				// subprocess output and applies --assignee as a client-side
+				// post-filter, so a corrupt/unreadable bead in the scope already
+				// failed every per-assignee query and already marked the whole
+				// scope partial. The single read has identical fault behavior —
+				// it just drops the N−1 redundant spawns. A PartialResultError
+				// suppresses this tick's drain decisions for the scope; a
+				// transient bad bead is a one-tick conservative skip (demand
+				// recomputes next tick), while a persistently corrupt bead
+				// suppresses whole-scope drain every tick until it is fixed
+				// (true before and after this change).
+				//
+				// Limit 0 is unbounded so partitionReadyByAssignee can reapply
 				// the old per-assignee Limit cap in memory rather than truncating
-				// the shared read before partitioning.
+				// the shared read before partitioning. The trade is that the read
+				// now pulls the whole ready set for the scope into memory once per
+				// tick instead of capping per assignee at the store; acceptable
+				// because the prior fan-out already materialized a superset
+				// (K capped reads ≥ one uncapped read of the same scope).
 				var readErr error
 				ready, readErr = liveReadyForControllerDemandQuery(source.store, beads.ReadyQuery{Limit: 0})
 				if readErr != nil {

--- a/cmd/gc/build_desired_state_ready_fanout_test.go
+++ b/cmd/gc/build_desired_state_ready_fanout_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// makeSleepySession builds an open, asleep pool session bead whose assignee
+// identity (its session_name) drives one entry in the controller-demand
+// ready-assignee set.
+func makeSleepySession(t *testing.T, store beads.Store, sessionName string) beads.Bead {
+	t.Helper()
+	b, err := store.Create(beads.Bead{
+		Title:  "session " + sessionName,
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": sessionName,
+			"template":     "worker",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead %q: %v", sessionName, err)
+	}
+	return b
+}
+
+// makeReadyWork builds an open ready task assigned to assignee.
+func makeReadyWork(t *testing.T, store beads.Store, title, assignee string) beads.Bead {
+	t.Helper()
+	b, err := store.Create(beads.Bead{
+		Title:    title,
+		Type:     "task",
+		Status:   "open",
+		Assignee: assignee,
+	})
+	if err != nil {
+		t.Fatalf("create work bead %q: %v", title, err)
+	}
+	return b
+}
+
+func sortedIDs(in []beads.Bead) []string {
+	ids := make([]string, 0, len(in))
+	for _, b := range in {
+		ids = append(ids, b.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// TestCollectAssignedWorkBeads_ReadyFanOutCollapsesToOneReadPerScope is the
+// core P2.5 (#3218) guarantee: for a scope with K ready-assignees the
+// desired-state builder must issue exactly ONE live Ready read against the
+// backing store, not K. The former per-assignee fan-out scaled as
+// stores × open sessions and was the dominant idle bd-subprocess amplifier.
+func TestCollectAssignedWorkBeads_ReadyFanOutCollapsesToOneReadPerScope(t *testing.T) {
+	store := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+
+	const k = 4
+	var sessions []beads.Bead
+	var wantIDs []string
+	for i := 0; i < k; i++ {
+		name := "worker-" + string(rune('a'+i))
+		sessions = append(sessions, makeSleepySession(t, store, name))
+		work := makeReadyWork(t, store, "ready for "+name, name)
+		wantIDs = append(wantIDs, work.ID)
+	}
+	// Ready work for an assignee that has no session bead must NOT be collected:
+	// it is outside the demand assignee set. This guards the in-memory filter.
+	makeReadyWork(t, store, "ready for stranger", "worker-no-session")
+	// Ready unassigned work is never assigned work and must be excluded too.
+	makeReadyWork(t, store, "ready unassigned", "")
+
+	snapshot := newSessionBeadSnapshot(sessions)
+
+	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+
+	// Exactly one live Ready read per scope — the collapse invariant.
+	if len(store.readyQueries) != 1 {
+		t.Fatalf("Ready read count = %d (queries=%#v), want exactly 1 per scope for %d assignees", len(store.readyQueries), store.readyQueries, k)
+	}
+	if store.readyQueries[0].Assignee != "" {
+		t.Fatalf("collapsed Ready query carried an Assignee filter %q, want a single unfiltered scope read", store.readyQueries[0].Assignee)
+	}
+	if store.readyQueries[0].TierMode != beads.TierBoth {
+		t.Fatalf("collapsed Ready query TierMode = %v, want TierBoth", store.readyQueries[0].TierMode)
+	}
+
+	sort.Strings(wantIDs)
+	if gotIDs := sortedIDs(got); !equalStringSlices(gotIDs, wantIDs) {
+		t.Fatalf("collected ready IDs = %v, want exactly the per-assignee set %v", gotIDs, wantIDs)
+	}
+}
+
+// TestPartitionReadyByAssignee_MatchesPerAssigneeFilter verifies the in-memory
+// partition reproduces, bead-for-bead, what the old per-assignee
+// Ready(Assignee=…) fan-out would have returned from the same ready set:
+// only beads whose assignee is in the demand set, capped per assignee, in
+// assignee order, and never duplicated.
+func TestPartitionReadyByAssignee_MatchesPerAssigneeFilter(t *testing.T) {
+	ready := []beads.Bead{
+		{ID: "a1", Assignee: "alice"},
+		{ID: "b1", Assignee: "bob"},
+		{ID: "a2", Assignee: "alice"},
+		{ID: "x1", Assignee: "stranger"}, // not in demand set
+		{ID: "c1", Assignee: "carol"},
+		{ID: "u1", Assignee: ""}, // unassigned, never attributed
+		{ID: "a3", Assignee: "alice"},
+	}
+	assignees := []string{"alice", "bob", "carol"}
+
+	t.Run("unbounded preserves order and excludes strangers/unassigned", func(t *testing.T) {
+		got := partitionReadyByAssignee(ready, assignees, 0)
+		want := []string{"a1", "a2", "a3", "b1", "c1"}
+		if gotIDs := idSlice(got); !equalStringSlices(gotIDs, want) {
+			t.Fatalf("got %v, want %v (assignee order, strangers/unassigned excluded)", gotIDs, want)
+		}
+	})
+
+	t.Run("per-assignee limit caps each group like the old per-query Limit", func(t *testing.T) {
+		got := partitionReadyByAssignee(ready, assignees, 2)
+		// alice capped at 2 (a1,a2 — a3 dropped); bob/carol unaffected.
+		want := []string{"a1", "a2", "b1", "c1"}
+		if gotIDs := idSlice(got); !equalStringSlices(gotIDs, want) {
+			t.Fatalf("got %v, want %v (alice capped at 2)", gotIDs, want)
+		}
+	})
+
+	t.Run("empty inputs return nil", func(t *testing.T) {
+		if got := partitionReadyByAssignee(nil, assignees, 0); got != nil {
+			t.Fatalf("nil ready: got %#v, want nil", got)
+		}
+		if got := partitionReadyByAssignee(ready, nil, 0); got != nil {
+			t.Fatalf("nil assignees: got %#v, want nil", got)
+		}
+	})
+}
+
+func idSlice(in []beads.Bead) []string {
+	out := make([]string, 0, len(in))
+	for _, b := range in {
+		out = append(out, b.ID)
+	}
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/gc/build_desired_state_ready_fanout_test.go
+++ b/cmd/gc/build_desired_state_ready_fanout_test.go
@@ -105,6 +105,34 @@ func TestCollectAssignedWorkBeads_ReadyFanOutCollapsesToOneReadPerScope(t *testi
 // Ready(Assignee=…) fan-out would have returned from the same ready set:
 // only beads whose assignee is in the demand set, capped per assignee, in
 // assignee order, and never duplicated.
+// TestCollectAssignedWorkBeads_CollapsedReadPropagatesPartial covers the
+// collapsed single-scope-read branch (len(assignees) > 0) under a partial
+// backing-store read — the path the former per-assignee fan-out never had a
+// direct test for. A PartialResultError on the unfiltered scope read must
+// surface as partial == true so the caller suppresses that tick's drain
+// decisions, while the beads that survived the partial read are still
+// returned (a partial read is degraded, not empty).
+func TestCollectAssignedWorkBeads_CollapsedReadPropagatesPartial(t *testing.T) {
+	store := &partialAssignedWorkStore{MemStore: beads.NewMemStore()}
+
+	session := makeSleepySession(t, store, "worker-a")
+	work := makeReadyWork(t, store, "ready for worker-a", "worker-a")
+
+	// Inject the partial only after the fixture's beads exist, so Create()
+	// during setup stays clean and the partial lands on the collapsed read.
+	store.partialReady = true
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{session})
+
+	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	if !partial {
+		t.Fatal("collapsed scope read returned a PartialResultError but partial was not propagated")
+	}
+	if gotIDs := sortedIDs(got); !equalStringSlices(gotIDs, []string{work.ID}) {
+		t.Fatalf("collected ready IDs = %v under a partial read, want the surviving assigned bead %v", gotIDs, []string{work.ID})
+	}
+}
+
 func TestPartitionReadyByAssignee_MatchesPerAssigneeFilter(t *testing.T) {
 	ready := []beads.Bead{
 		{ID: "a1", Assignee: "alice"},

--- a/cmd/gc/build_desired_state_ready_fanout_test.go
+++ b/cmd/gc/build_desired_state_ready_fanout_test.go
@@ -78,7 +78,7 @@ func TestCollectAssignedWorkBeads_ReadyFanOutCollapsesToOneReadPerScope(t *testi
 
 	snapshot := newSessionBeadSnapshot(sessions)
 
-	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -124,7 +124,7 @@ func TestCollectAssignedWorkBeads_CollapsedReadPropagatesPartial(t *testing.T) {
 
 	snapshot := newSessionBeadSnapshot([]beads.Bead{session})
 
-	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
 	if !partial {
 		t.Fatal("collapsed scope read returned a PartialResultError but partial was not propagated")
 	}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -2513,14 +2513,18 @@ func TestCollectAssignedWorkBeadsWithStores_SkipSetIsStoreScopedAcrossSameID(t *
 		t.Fatalf("worker-rig ready bead %q was dropped: the same-ID city ready bead collapsed the skip set and suppressed worker-rig's store-scoped Ready probe; collected=%#v", rigReadyWork.ID, gotIDs)
 	}
 
-	rigProbedForRigAssignee := false
-	for _, query := range rigStore.readyQueries {
-		if query.Assignee == "worker-rig" {
-			rigProbedForRigAssignee = true
-		}
-	}
-	if !rigProbedForRigAssignee {
+	// Post-collapse (#3218/#3312) the rig store gets a single unfiltered scope
+	// read, not a per-assignee "worker-rig" query. The store-scoping this test
+	// guards — the same-ID city ready bead must not suppress worker-rig's probe —
+	// is proven by rigReadyWork being collected above; here just assert the rig
+	// store was probed at all, with the unfiltered collapse shape.
+	if len(rigStore.readyQueries) == 0 {
 		t.Fatalf("rig Ready queries = %#v, want a probe for worker-rig despite the same-ID city ready bead", rigStore.readyQueries)
+	}
+	for _, query := range rigStore.readyQueries {
+		if query.Assignee != "" {
+			t.Fatalf("rig Ready query carried Assignee %q, want a single unfiltered scope read post-collapse", query.Assignee)
+		}
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -215,10 +215,17 @@ func (s *controllerDemandPartialStore) Ready(query ...beads.ReadyQuery) ([]beads
 	}
 	// The collapsed assigned-work scope read (P2.5 / #3218) and the
 	// pool/scale-check controller-demand reads now share the same unfiltered
-	// (Assignee=="" && Limit==0) shape. This fixture models a partial on the
-	// downstream scale-check/pool-demand read only; the first Ready call is the
-	// assigned-work collapse read, which must stay clean so the named
-	// scale_check partial does not escalate to StoreQueryPartial.
+	// (Assignee=="" && Limit==0) shape, so this fixture distinguishes them by
+	// call ordinal: the first Ready call is the assigned-work collapse read,
+	// which must stay clean so the named scale_check partial does not escalate
+	// to StoreQueryPartial. The ordinal is not silently fragile to a reorder —
+	// it is guarded by divergent observable outcomes: an assigned-work partial
+	// sets result.StoreQueryPartial, while a scale_check partial sets only
+	// ScaleCheckPartialTemplates. If a future reorder made the assigned-work
+	// read the one that receives the injected partial, the caller's
+	// StoreQueryPartial assertion (asserted false in
+	// TestBuildDesiredState_NamedScaleCheckPartialDoesNotRetainGenericPoolSession)
+	// would flip true and fail the test rather than pass against the wrong call.
 	s.assignedWorkReadSeen++
 	if s.assignedWorkReadSeen == 1 {
 		return rows, nil

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -2224,15 +2224,17 @@ func TestCollectAssignedWorkBeads_ReadyProbeExcludesFutureNamedSessionRuntimeAss
 	if len(storeRefs) != 0 {
 		t.Fatalf("storeRefs = %#v, want none", storeRefs)
 	}
-	queried := make(map[string]bool)
-	for _, query := range rigStore.readyQueries {
-		queried[query.Assignee] = true
+	// Post-collapse (#3218/#3312) the demand path issues a single unfiltered
+	// scope read, not a per-assignee fan-out, so the future runtime assignee is
+	// excluded by the in-memory partition (proven by len(got)==0 above) rather
+	// than by omitting a per-assignee query. Assert the collapse invariant:
+	// exactly one unfiltered scope read. The exclusion semantics this test name
+	// guards are carried by the result assertions, not the query shape.
+	if len(rigStore.readyQueries) != 1 {
+		t.Fatalf("rig Ready read count = %d (queries=%#v), want exactly 1 unfiltered scope read per scope", len(rigStore.readyQueries), rigStore.readyQueries)
 	}
-	if queried[runtimeName] {
-		t.Fatalf("rig Ready queries = %#v, must not include future runtime assignee %q", rigStore.readyQueries, runtimeName)
-	}
-	if !queried[identity] {
-		t.Fatalf("rig Ready queries = %#v, want canonical named-session assignee %q", rigStore.readyQueries, identity)
+	if rigStore.readyQueries[0].Assignee != "" {
+		t.Fatalf("collapsed Ready query carried Assignee %q, want a single unfiltered scope read", rigStore.readyQueries[0].Assignee)
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -202,12 +202,26 @@ type partialAssignedWorkStore struct {
 
 type controllerDemandPartialStore struct {
 	*beads.MemStore
+	// assignedWorkReadSeen counts Ready calls so the fixture can let the first
+	// (collapsed assigned-work) read pass clean and inject a partial only on the
+	// later pool/scale-check controller-demand reads.
+	assignedWorkReadSeen int
 }
 
 func (s *controllerDemandPartialStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
 	rows, err := s.MemStore.Ready(query...)
 	if err != nil {
 		return nil, err
+	}
+	// The collapsed assigned-work scope read (P2.5 / #3218) and the
+	// pool/scale-check controller-demand reads now share the same unfiltered
+	// (Assignee=="" && Limit==0) shape. This fixture models a partial on the
+	// downstream scale-check/pool-demand read only; the first Ready call is the
+	// assigned-work collapse read, which must stay clean so the named
+	// scale_check partial does not escalate to StoreQueryPartial.
+	s.assignedWorkReadSeen++
+	if s.assignedWorkReadSeen == 1 {
+		return rows, nil
 	}
 	if len(query) == 0 || (query[0].Assignee == "" && query[0].Limit == 0) {
 		return rows, &beads.PartialResultError{Op: "bd ready", Err: errors.New("skipped corrupt controller demand bead")}
@@ -2060,15 +2074,16 @@ func TestCollectAssignedWorkBeads_ReadyProbeStillRunsForOtherAssignees(t *testin
 			t.Fatalf("collected work IDs = %#v, want %s", gotIDs, want)
 		}
 	}
-	queried := make(map[string]bool)
-	for _, query := range store.readyQueries {
-		queried[query.Assignee] = true
+	// The per-assignee Ready fan-out is collapsed to a single unfiltered scope
+	// read (P2.5 / #3218); the assignee set is applied in memory. The
+	// active-assignee exclusion is now observable in the bead output above
+	// (readyWork is collected, activeWork via the in-progress pass), not in the
+	// query shape. Assert the collapse invariant on the read itself.
+	if len(store.readyQueries) != 1 {
+		t.Fatalf("Ready read count = %d (queries=%#v), want exactly 1 collapsed scope read", len(store.readyQueries), store.readyQueries)
 	}
-	if queried["worker-active"] || queried[activeSession.ID] {
-		t.Fatalf("Ready queries = %#v, want no probe for active assignee", store.readyQueries)
-	}
-	if !queried["worker-ready"] {
-		t.Fatalf("Ready queries = %#v, want probe for worker-ready", store.readyQueries)
+	if store.readyQueries[0].Assignee != "" {
+		t.Fatalf("collapsed Ready query carried Assignee %q, want an unfiltered scope read", store.readyQueries[0].Assignee)
 	}
 }
 
@@ -2118,12 +2133,14 @@ func TestCollectAssignedWorkBeads_ReadyProbeIncludesActiveSessionAssignees(t *te
 	if len(got) != 1 || got[0].ID != readyWork.ID {
 		t.Fatalf("got = %#v, want ready active-session work %s", got, readyWork.ID)
 	}
-	queried := make(map[string]bool)
-	for _, query := range store.readyQueries {
-		queried[query.Assignee] = true
+	// The active session's ready work is now selected by the in-memory assignee
+	// partition over a single collapsed scope read (P2.5 / #3218); its inclusion
+	// is observable in the bead output above, not in a per-assignee query.
+	if len(store.readyQueries) != 1 {
+		t.Fatalf("Ready read count = %d (queries=%#v), want exactly 1 collapsed scope read", len(store.readyQueries), store.readyQueries)
 	}
-	if !queried["worker-active"] {
-		t.Fatalf("Ready queries = %#v, want probe for active session assignee", store.readyQueries)
+	if store.readyQueries[0].Assignee != "" {
+		t.Fatalf("collapsed Ready query carried Assignee %q, want an unfiltered scope read", store.readyQueries[0].Assignee)
 	}
 }
 


### PR DESCRIPTION
## Summary

The controller demand path issued one backing-store `Ready` query **per ready-assignee** per reconcile pass. The default backing store is **BdStore**, where each query is a separate `bd` subprocess — so this scales as `stores × ready-assignees` per tick and is the dominant idle read-path amplifier under large session counts (hundreds of idle sessions ⇒ hundreds of `bd` spawns/tick just to recompute demand).

This reads the scope **once** (unfiltered) and partitions the result in memory by the demand assignee set. The per-assignee `Assignee` filter is an exact-match post-filter on every store implementation, so the bead set and ordering are reproduced bead-for-bead; `partitionReadyByAssignee` reapplies the former per-assignee `Limit` cap in memory.

### Fault contract (unchanged by the collapse)

An earlier draft of this PR claimed the per-assignee fan-out provided per-assignee fault isolation that the single read gives up. **That was wrong, and the description + code comment have been corrected.** The per-assignee loop never isolated faults: `BdStore.Ready` parses the whole subprocess output (`parseIssuesTolerant`) and applies `--assignee` as a client-side post-filter, so a corrupt/unreadable bead in the scope **already** failed every per-assignee query and **already** marked the whole scope `PARTIAL` (`StoreQueryPartial`). The single collapsed read has **identical** fault behavior — it just drops the N−1 redundant `bd` spawns.

The actual contract:
- A `PartialResultError` on the scope read suppresses that tick's drain decisions for the scope, returning the beads that survived the partial read.
- A **transient** bad bead is a one-tick conservative skip (demand recomputes next tick).
- A **persistently** corrupt bead suppresses whole-scope drain every tick until it is fixed — true both before and after this change.

The named/pool **scale-check partial detection** that drives pool retention runs on its own per-pool reads and is unaffected.

**Net:** an **N→1 reduction in `bd` subprocess spawns per scope per tick** with no change to fault semantics. The trade is that the scope read now pulls the whole ready set into memory once per tick (`Limit: 0`) instead of capping per assignee at the store — acceptable because the prior fan-out already materialized a superset (K capped reads ≥ one uncapped read of the same scope). Documented at the call site.

## Testing

- [x] `go build ./...`, `golangci-lint` (0 issues)
- [x] `go test ./cmd/gc/` desired-state suite passes, incl. `ReadyProbe*`, `NamedScaleCheckPartialDoesNotRetainGenericPoolSession`, and `build_desired_state_ready_fanout_test.go` (one read per scope; partition reproduces the per-assignee filter bead-for-bead)
- [x] **New:** `TestCollectAssignedWorkBeads_CollapsedReadPropagatesPartial` covers the collapsed `len(assignees) > 0` branch under a `PartialResultError` on the unfiltered scope read — asserts `partial == true` propagates and the surviving beads are still returned
- [ ] Full `make check` — CI

## Checklist

- [x] Tests updated to the new contract; partial-path coverage added
- [x] Fault-contract framing corrected (no false isolation claim)
- [x] No API/migration changes

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2463 — collapses the reconciler demand path's per-ready-assignee Ready fan-out (one bd subprocess each) into a single scope read partitioned in memory (N→1 per scope per tick), cutting idle controller bd-subprocess spawns at the Gas-City layer this issue calls out as most beneficial.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
