### PR TITLE
feat(gc import): reference-aware cache prune + stop counting gitignored artifacts as dirty

### DIFF
--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -92,6 +92,7 @@ func newImportCmd(stdout, stderr io.Writer) *cobra.Command {
 		newImportListCmd(stdout, stderr),
 		newImportWhyCmd(stdout, stderr),
 		newImportMigrateCmd(stdout, stderr),
+		newImportPruneCmd(stdout, stderr),
 	)
 	return cmd
 }

--- a/cmd/gc/cmd_import_prune.go
+++ b/cmd/gc/cmd_import_prune.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
+	"github.com/gastownhall/gascity/internal/supervisor"
+	"github.com/spf13/cobra"
+)
+
+const defaultPruneKeepDays = 7
+
+func newImportPruneCmd(stdout, stderr io.Writer) *cobra.Command {
+	var (
+		apply     bool
+		allCities bool
+		keepDays  int
+	)
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove unreferenced clones from the global pack cache",
+		Long: `Remove unreferenced clones from the machine-wide pack cache.
+
+The pack cache (~/.gc/cache/repos) is shared by every city on the machine and
+is keyed by (source, commit), so commit churn accumulates stale clones over
+time. A clone is "referenced" when some city's packs.lock still pins it; prune
+keeps every referenced clone and removes only the rest.
+
+By default prune considers every city in the supervisor registry plus the city
+resolved from the current directory; pass --all-cities to reference the full
+registry set and ignore the current directory. Prune is a dry run unless
+--apply is given. The --keep-days guard never removes an unreferenced clone
+whose directory was modified more recently than N days ago, protecting
+in-flight installs from a race.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if doImportPrune(allCities, apply, keepDays, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "Delete unreferenced clones (default: dry run)")
+	cmd.Flags().BoolVar(&allCities, "all-cities", false, "Reference every city in the supervisor registry, ignoring the current directory")
+	cmd.Flags().IntVar(&keepDays, "keep-days", defaultPruneKeepDays, "Never prune unreferenced clones modified within this many days")
+	return cmd
+}
+
+func doImportPrune(allCities, apply bool, keepDays int, stdout, stderr io.Writer) int {
+	if keepDays < 0 {
+		fmt.Fprintln(stderr, "gc import prune: --keep-days must be >= 0") //nolint:errcheck
+		return 1
+	}
+
+	cityRoots, err := pruneReferenceCityRoots(allCities)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc import prune: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	referenced, err := pruneReferencedCacheKeys(cityRoots)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc import prune: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	// Cache root resolves via the production helper (os.UserHomeDir-based), the
+	// same computation pack_include.go uses. It deliberately ignores GC_HOME.
+	cacheRoot, err := packman.RepoCacheRoot()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc import prune: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	result, err := packman.Prune(cacheRoot, referenced, keepDays, apply)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc import prune: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	mode := "dry-run"
+	if result.Applied {
+		mode = "applied"
+	}
+	fmt.Fprintf(stdout, "%d referenced, %d unreferenced (%s) [%s]\n", len(result.Kept), len(result.Pruned), formatBytes(result.FreedBytes), mode) //nolint:errcheck
+	for _, e := range result.Pruned {
+		fmt.Fprintf(stdout, "  %s %s\n", e.Name, formatBytes(e.Bytes)) //nolint:errcheck
+	}
+	return 0
+}
+
+// pruneReferenceCityRoots returns the set of city roots whose packs.lock files
+// define the referenced set. When allCities is false the current city (resolved
+// from cwd or --city) is always included alongside the registry; when no city
+// resolves and the registry is empty, prune errors so it never deletes clones a
+// city outside the registry still pins.
+func pruneReferenceCityRoots(allCities bool) ([]string, error) {
+	seen := make(map[string]bool)
+	var roots []string
+	add := func(path string) {
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		roots = append(roots, path)
+	}
+
+	entries, err := supervisor.NewRegistry(supervisor.RegistryPath()).List()
+	if err != nil {
+		return nil, fmt.Errorf("reading supervisor registry: %w", err)
+	}
+	for _, e := range entries {
+		add(e.Path)
+	}
+
+	if !allCities {
+		if cityPath, err := resolveImportRoot(); err == nil {
+			add(cityPath)
+		} else if len(roots) == 0 {
+			return nil, fmt.Errorf("no cities to reference: %w", err)
+		}
+	}
+
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("no cities found to reference; register a city or run from a city directory")
+	}
+	sort.Strings(roots)
+	return roots, nil
+}
+
+// pruneReferencedCacheKeys reads every city's packs.lock and returns the set of
+// RepoCacheKey directory names those locks still pin. A city with no packs.lock
+// contributes nothing (not an error).
+func pruneReferencedCacheKeys(cityRoots []string) (map[string]bool, error) {
+	referenced := make(map[string]bool)
+	for _, cityRoot := range cityRoots {
+		lock, err := packman.ReadLockfile(fsys.OSFS{}, cityRoot)
+		if err != nil {
+			return nil, fmt.Errorf("reading packs.lock for %q: %w", cityRoot, err)
+		}
+		for source, pack := range lock.Packs {
+			if pack.Commit == "" {
+				continue
+			}
+			referenced[packman.RepoCacheKey(source, pack.Commit)] = true
+		}
+	}
+	return referenced, nil
+}

--- a/cmd/gc/cmd_import_prune_test.go
+++ b/cmd/gc/cmd_import_prune_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/packman"
+	"github.com/gastownhall/gascity/internal/supervisor"
+)
+
+// writePruneCacheClone creates a fake cache clone directory with the given mtime.
+func writePruneCacheClone(t *testing.T, cacheRoot, name string, mtime time.Time) string {
+	t.Helper()
+	dir := filepath.Join(cacheRoot, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chtimes(dir, mtime, mtime); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	return dir
+}
+
+// pruneTestCacheRoot isolates the os.UserHomeDir-based pack cache into a temp
+// HOME and returns the resolved cache root, creating it. clearGCEnv must already
+// have run so GC_HOME (the supervisor registry home) is isolated separately.
+func pruneTestCacheRoot(t *testing.T) string {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	root, err := packman.RepoCacheRoot()
+	if err != nil {
+		t.Fatalf("RepoCacheRoot: %v", err)
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", root, err)
+	}
+	return root
+}
+
+// registerPruneCity writes a minimal city with a packs.lock pinning source@commit
+// and registers it in the supervisor registry.
+func registerPruneCity(t *testing.T, name, source, commit string) {
+	t.Helper()
+	cityDir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll city: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \""+name+"\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile city.toml: %v", err)
+	}
+	lock := "schema = 1\n\n[packs.\"" + source + "\"]\ncommit = \"" + commit + "\"\nversion = \"1.0.0\"\n"
+	if err := os.WriteFile(filepath.Join(cityDir, packman.LockfileName), []byte(lock), 0o644); err != nil {
+		t.Fatalf("WriteFile packs.lock: %v", err)
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityDir, name); err != nil {
+		t.Fatalf("Register(%q): %v", name, err)
+	}
+}
+
+func TestDoImportPruneDryRunReportsWithoutDeleting(t *testing.T) {
+	clearGCEnv(t)
+	cacheRoot := pruneTestCacheRoot(t)
+
+	source := "https://github.com/example/repo"
+	commit := "abc123"
+	registerPruneCity(t, "alpha", source, commit)
+
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	refDir := writePruneCacheClone(t, cacheRoot, packman.RepoCacheKey(source, commit), old)
+	orphanDir := writePruneCacheClone(t, cacheRoot, "orphankey0000", old)
+
+	var stdout, stderr bytes.Buffer
+	if rc := doImportPrune(true, false, 7, &stdout, &stderr); rc != 0 {
+		t.Fatalf("doImportPrune rc=%d stderr=%s", rc, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "1 referenced, 1 unreferenced") {
+		t.Fatalf("unexpected summary: %q", out)
+	}
+	if !strings.Contains(out, "[dry-run]") {
+		t.Fatalf("expected dry-run marker: %q", out)
+	}
+	// Dry run deletes nothing.
+	for _, dir := range []string{refDir, orphanDir} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("dry-run removed %q: %v", dir, err)
+		}
+	}
+}
+
+func TestDoImportPruneApplyRemovesUnreferencedOnly(t *testing.T) {
+	clearGCEnv(t)
+	cacheRoot := pruneTestCacheRoot(t)
+
+	source := "https://github.com/example/repo"
+	commit := "abc123"
+	registerPruneCity(t, "beta", source, commit)
+
+	now := time.Now()
+	old := now.Add(-30 * 24 * time.Hour)
+	recent := now.Add(-1 * time.Hour)
+
+	refDir := writePruneCacheClone(t, cacheRoot, packman.RepoCacheKey(source, commit), old)
+	orphanOld := writePruneCacheClone(t, cacheRoot, "orphanold0000", old)
+	orphanFresh := writePruneCacheClone(t, cacheRoot, "orphanfresh00", recent)
+
+	var stdout, stderr bytes.Buffer
+	if rc := doImportPrune(true, true, 7, &stdout, &stderr); rc != 0 {
+		t.Fatalf("doImportPrune rc=%d stderr=%s", rc, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "[applied]") {
+		t.Fatalf("expected applied marker: %q", out)
+	}
+	if _, err := os.Stat(orphanOld); !os.IsNotExist(err) {
+		t.Fatalf("expected orphan-old deleted, stat err=%v", err)
+	}
+	for _, dir := range []string{refDir, orphanFresh} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("apply removed protected dir %q: %v", dir, err)
+		}
+	}
+}
+
+func TestDoImportPruneRejectsNegativeKeepDays(t *testing.T) {
+	clearGCEnv(t)
+	var stdout, stderr bytes.Buffer
+	if rc := doImportPrune(true, false, -1, &stdout, &stderr); rc == 0 {
+		t.Fatalf("expected non-zero rc for negative keep-days")
+	}
+	if !strings.Contains(stderr.String(), "keep-days") {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1580,6 +1580,7 @@ gc import
 | [gc import check](#gc-import-check) | Validate installed pack import state |
 | [gc import install](#gc-import-install) | Install imports from pack.toml and packs.lock |
 | [gc import list](#gc-import-list) | List imported packs |
+| [gc import prune](#gc-import-prune) | Remove unreferenced clones from the global pack cache |
 | [gc import remove](#gc-import-remove) | Remove a pack import |
 | [gc import upgrade](#gc-import-upgrade) | Upgrade imported packs within their constraints |
 | [gc import why](#gc-import-why) | Explain why an import is present |
@@ -1650,6 +1651,32 @@ gc import list [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--tree` | bool |  | Show the import dependency tree |
+
+## gc import prune
+
+Remove unreferenced clones from the machine-wide pack cache.
+
+The pack cache (~/.gc/cache/repos) is shared by every city on the machine and
+is keyed by (source, commit), so commit churn accumulates stale clones over
+time. A clone is "referenced" when some city's packs.lock still pins it; prune
+keeps every referenced clone and removes only the rest.
+
+By default prune considers every city in the supervisor registry plus the city
+resolved from the current directory; pass --all-cities to reference the full
+registry set and ignore the current directory. Prune is a dry run unless
+--apply is given. The --keep-days guard never removes an unreferenced clone
+whose directory was modified more recently than N days ago, protecting
+in-flight installs from a race.
+
+```
+gc import prune [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--all-cities` | bool |  | Reference every city in the supervisor registry, ignoring the current directory |
+| `--apply` | bool |  | Delete unreferenced clones (default: dry run) |
+| `--keep-days` | int | `7` | Never prune unreferenced clones modified within this many days |
 
 ## gc import remove
 

--- a/internal/config/bundled_import_test.go
+++ b/internal/config/bundled_import_test.go
@@ -191,7 +191,7 @@ content_hash = "sha256:deadbeef"
 		switch strings.Join(args, " ") {
 		case "rev-parse HEAD":
 			return commit, nil
-		case "status --porcelain --ignored":
+		case "status --porcelain":
 			return "", nil
 		default:
 			t.Fatalf("unexpected git args %q", strings.Join(args, " "))

--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -204,7 +204,7 @@ func resolveInstalledRemoteImport(source, cityRoot string) (string, error) {
 // remoteCacheValidationCache memoizes successful remote-cache validations. The
 // installed remote pack cache is a commit-pinned, gc-managed checkout: validating
 // it costs a repo-cache flock plus two git execs (`rev-parse HEAD` and
-// `status --porcelain --ignored`, the latter walking the whole tree), and config
+// `status --porcelain`, the latter walking the whole tree), and config
 // load runs it for every remote import on every reconcile (per rig, per pool).
 // Since the cache is immutable for a given commit unless `gc import install`
 // rewrites it, cache the success keyed by (cacheDir, commit) + a cheap stat
@@ -297,7 +297,12 @@ func validateLockedRemoteCache(source, cacheDir, commit string) error {
 	if !gitutil.SameCommit(head, commit) {
 		return fmt.Errorf("cached import %s is checked out at %s, expected %s; run \"gc import install\"", source, strings.TrimSpace(head), commit)
 	}
-	status, err := runRepoCacheGit(cacheDir, "status", "--porcelain", "--ignored")
+	// Intentionally NOT --ignored: gitignored build artifacts that land in the
+	// cache in place (Python __pycache__/*.pyc from a cached pack's scripts, a
+	// stray .DS_Store, etc.) are not local edits to the pack and must not trip
+	// this gate — otherwise the city wedges behind a perpetual "run gc import
+	// install" loop (vp-gny3). Reinstall's `git clean -ffdx` still clears them.
+	status, err := runRepoCacheGit(cacheDir, "status", "--porcelain")
 	if err != nil {
 		return fmt.Errorf("checking cached import %s worktree status: %w", source, err)
 	}

--- a/internal/packman/bundled_test.go
+++ b/internal/packman/bundled_test.go
@@ -172,7 +172,7 @@ func TestEnsureBundledCacheMaterializeFailureIncludesRecoveryCause(t *testing.T)
 		switch strings.Join(args, " ") {
 		case "rev-parse HEAD":
 			return commit, nil
-		case "status --porcelain --ignored":
+		case "status --porcelain":
 			return "", nil
 		default:
 			return "", fmt.Errorf("unexpected git call: %v", args)

--- a/internal/packman/cache.go
+++ b/internal/packman/cache.go
@@ -187,7 +187,13 @@ func checkoutExistingCache(cachePath, commit string) error {
 }
 
 func cachedRepoDirty(cachePath string) (bool, error) {
-	status, err := runGit(cachePath, "status", "--porcelain", "--ignored")
+	// Intentionally NOT --ignored: gitignored build artifacts written into
+	// the cache in place (e.g. Python __pycache__/*.pyc from running a cached
+	// pack's scripts, or a stray .DS_Store) are not local modifications to the
+	// pack's tracked content and must not count as "dirty" — they recur and
+	// would otherwise wedge the city behind a perpetual "run gc import install"
+	// gate (vp-gny3). A reinstall's `git clean -ffdx` still clears them.
+	status, err := runGit(cachePath, "status", "--porcelain")
 	if err != nil {
 		return false, fmt.Errorf("checking cached repo worktree status: %w", err)
 	}

--- a/internal/packman/cache_test.go
+++ b/internal/packman/cache_test.go
@@ -70,7 +70,7 @@ func TestEnsureRepoInCacheUsesExistingCloneWhenCheckoutMatches(t *testing.T) {
 		if reflect.DeepEqual(args, []string{"rev-parse", "HEAD"}) {
 			return "abc123", nil
 		}
-		if reflect.DeepEqual(args, []string{"status", "--porcelain", "--ignored"}) {
+		if reflect.DeepEqual(args, []string{"status", "--porcelain"}) {
 			return "", nil
 		}
 		return "", fmt.Errorf("unexpected git call: %v", args)
@@ -86,7 +86,7 @@ func TestEnsureRepoInCacheUsesExistingCloneWhenCheckoutMatches(t *testing.T) {
 	}
 	want := [][]string{
 		{"rev-parse", "HEAD"},
-		{"status", "--porcelain", "--ignored"},
+		{"status", "--porcelain"},
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("git calls = %#v, want %#v", calls, want)
@@ -138,7 +138,7 @@ func TestEnsureRepoInCacheRepairsDirtyMatchingCheckout(t *testing.T) {
 	}
 	want := [][]string{
 		{"rev-parse", "HEAD"},
-		{"status", "--porcelain", "--ignored"},
+		{"status", "--porcelain"},
 		{"reset", "--hard", "--quiet", "abc123"},
 		{"clean", "-ffdx", "--quiet"},
 	}
@@ -244,7 +244,7 @@ func TestEnsureRepoInCacheReclonesInvalidExistingCache(t *testing.T) {
 	}
 	want := [][]string{
 		{"rev-parse", "HEAD"},
-		{"status", "--porcelain", "--ignored"},
+		{"status", "--porcelain"},
 		{"clone", "--quiet", "https://github.com/example/repo", path},
 		{"checkout", "--quiet", "abc123"},
 	}

--- a/internal/packman/prune.go
+++ b/internal/packman/prune.go
@@ -1,0 +1,159 @@
+package packman
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// PruneEntry describes a single clone directory in the global pack cache and
+// the prune decision made for it.
+type PruneEntry struct {
+	// Name is the cache directory name (a RepoCacheKey hash).
+	Name string
+	// Path is the absolute path to the clone directory.
+	Path string
+	// Bytes is the on-disk size of the clone directory.
+	Bytes int64
+	// ModTime is the directory's modification time, used by the keep-days guard.
+	ModTime time.Time
+	// Referenced reports whether some city's packs.lock pins this clone.
+	Referenced bool
+}
+
+// PruneResult summarizes a prune pass over the global pack cache.
+type PruneResult struct {
+	// Kept lists clones retained because they are referenced or protected by
+	// the keep-days guard.
+	Kept []PruneEntry
+	// Pruned lists clones classified as unreferenced and eligible for removal.
+	// When Applied is false these were only reported, not deleted.
+	Pruned []PruneEntry
+	// FreedBytes is the total size of the Pruned entries.
+	FreedBytes int64
+	// Applied reports whether the Pruned entries were actually deleted.
+	Applied bool
+}
+
+// classifyPruneEntries enumerates clone directories under cacheRoot and labels
+// each KEEP or PRUNE. A clone is PRUNE only when it is unreferenced AND its
+// mtime is older than keepDays days before now; otherwise it is KEEP. keepDays
+// of zero disables the age guard. The lock file and any non-directory entries
+// are ignored. cacheRoot need not exist (an absent cache prunes nothing).
+func classifyPruneEntries(cacheRoot string, referenced map[string]bool, keepDays int, now time.Time) ([]PruneEntry, []PruneEntry, error) {
+	dirents, err := os.ReadDir(cacheRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("reading repo cache root %q: %w", cacheRoot, err)
+	}
+
+	var keep, prune []PruneEntry
+	cutoff := now.Add(-time.Duration(keepDays) * 24 * time.Hour)
+	for _, d := range dirents {
+		if !d.IsDir() {
+			continue
+		}
+		name := d.Name()
+		path := filepath.Join(cacheRoot, name)
+		info, err := d.Info()
+		if err != nil {
+			return nil, nil, fmt.Errorf("stat repo cache entry %q: %w", path, err)
+		}
+		size, err := dirSize(path)
+		if err != nil {
+			return nil, nil, err
+		}
+		entry := PruneEntry{
+			Name:       name,
+			Path:       path,
+			Bytes:      size,
+			ModTime:    info.ModTime(),
+			Referenced: referenced[name],
+		}
+		// Referenced clones are always kept; unreferenced clones newer than the
+		// keep-days cutoff are kept to avoid racing an in-flight install.
+		if entry.Referenced || (keepDays > 0 && entry.ModTime.After(cutoff)) {
+			keep = append(keep, entry)
+			continue
+		}
+		prune = append(prune, entry)
+	}
+	sort.Slice(keep, func(i, j int) bool { return keep[i].Name < keep[j].Name })
+	sort.Slice(prune, func(i, j int) bool { return prune[i].Name < prune[j].Name })
+	return keep, prune, nil
+}
+
+// Prune removes unreferenced clones from the global pack cache root. referenced
+// maps RepoCacheKey directory names that any city still pins to true. A clone is
+// removed only when unreferenced AND older than keepDays days (keepDays of zero
+// disables the age guard). When apply is false the result reports what would be
+// removed without deleting anything. The shared repo-cache write lock is held
+// across enumeration and deletion so prune never races a concurrent install.
+func Prune(cacheRoot string, referenced map[string]bool, keepDays int, apply bool) (PruneResult, error) {
+	var result PruneResult
+	run := func() error {
+		keep, prune, err := classifyPruneEntries(cacheRoot, referenced, keepDays, time.Now())
+		if err != nil {
+			return err
+		}
+		result.Kept = keep
+		result.Pruned = prune
+		result.Applied = apply
+		for _, e := range prune {
+			result.FreedBytes += e.Bytes
+		}
+		if !apply {
+			return nil
+		}
+		for _, e := range prune {
+			if err := os.RemoveAll(e.Path); err != nil {
+				return fmt.Errorf("removing unreferenced cache clone %q: %w", e.Path, err)
+			}
+		}
+		return nil
+	}
+	// WithRepoCacheReadLock no-ops when cacheRoot is absent; take the exclusive
+	// write lock only when we may delete, otherwise the shared read lock.
+	if apply {
+		if _, err := config.WithRepoCacheWriteLock(cacheRoot, func() (string, error) {
+			return "", run()
+		}); err != nil {
+			return PruneResult{}, err
+		}
+		return result, nil
+	}
+	if err := config.WithRepoCacheReadLock(cacheRoot, run); err != nil {
+		return PruneResult{}, err
+	}
+	return result, nil
+}
+
+// dirSize returns the total size in bytes of all regular files under root.
+func dirSize(root string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("sizing %q: %w", root, err)
+	}
+	return total, nil
+}

--- a/internal/packman/prune_test.go
+++ b/internal/packman/prune_test.go
@@ -1,0 +1,180 @@
+package packman
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+)
+
+// writeCacheClone creates a fake clone dir with a single file and the given mtime.
+func writeCacheClone(t *testing.T, cacheRoot, name string, mtime time.Time) string {
+	t.Helper()
+	dir := filepath.Join(cacheRoot, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chtimes(dir, mtime, mtime); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	return dir
+}
+
+func names(entries []PruneEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestClassifyPruneEntries(t *testing.T) {
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-30 * 24 * time.Hour)
+	recent := now.Add(-1 * time.Hour)
+
+	tests := []struct {
+		name       string
+		clones     map[string]time.Time // dir name -> mtime
+		referenced map[string]bool
+		keepDays   int
+		wantKeep   []string
+		wantPrune  []string
+	}{
+		{
+			name:       "referenced kept even when old",
+			clones:     map[string]time.Time{"ref": old, "orphan": old},
+			referenced: map[string]bool{"ref": true},
+			keepDays:   7,
+			wantKeep:   []string{"ref"},
+			wantPrune:  []string{"orphan"},
+		},
+		{
+			name:       "recent unreferenced protected by keep-days",
+			clones:     map[string]time.Time{"fresh": recent, "stale": old},
+			referenced: map[string]bool{},
+			keepDays:   7,
+			wantKeep:   []string{"fresh"},
+			wantPrune:  []string{"stale"},
+		},
+		{
+			name:       "keep-days zero disables age guard",
+			clones:     map[string]time.Time{"fresh": recent, "stale": old},
+			referenced: map[string]bool{},
+			keepDays:   0,
+			wantKeep:   nil,
+			wantPrune:  []string{"fresh", "stale"},
+		},
+		{
+			name:       "all referenced",
+			clones:     map[string]time.Time{"a": old, "b": recent},
+			referenced: map[string]bool{"a": true, "b": true},
+			keepDays:   7,
+			wantKeep:   []string{"a", "b"},
+			wantPrune:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cacheRoot := t.TempDir()
+			for name, mtime := range tt.clones {
+				writeCacheClone(t, cacheRoot, name, mtime)
+			}
+			keep, prune, err := classifyPruneEntries(cacheRoot, tt.referenced, tt.keepDays, now)
+			if err != nil {
+				t.Fatalf("classifyPruneEntries: %v", err)
+			}
+			if got := names(keep); !equalStrings(got, tt.wantKeep) {
+				t.Errorf("kept = %v, want %v", got, tt.wantKeep)
+			}
+			if got := names(prune); !equalStrings(got, tt.wantPrune) {
+				t.Errorf("pruned = %v, want %v", got, tt.wantPrune)
+			}
+		})
+	}
+}
+
+func TestClassifyPruneEntriesMissingRoot(t *testing.T) {
+	keep, prune, err := classifyPruneEntries(filepath.Join(t.TempDir(), "absent"), nil, 7, time.Now())
+	if err != nil {
+		t.Fatalf("classifyPruneEntries on missing root: %v", err)
+	}
+	if len(keep) != 0 || len(prune) != 0 {
+		t.Fatalf("missing root should yield no entries, got keep=%d prune=%d", len(keep), len(prune))
+	}
+}
+
+func TestPruneDryRunDeletesNothing(t *testing.T) {
+	cacheRoot := t.TempDir()
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	orphan := writeCacheClone(t, cacheRoot, "orphan", old)
+	ref := writeCacheClone(t, cacheRoot, "ref", old)
+
+	result, err := Prune(cacheRoot, map[string]bool{"ref": true}, 7, false)
+	if err != nil {
+		t.Fatalf("Prune dry-run: %v", err)
+	}
+	if result.Applied {
+		t.Fatal("dry-run reported Applied=true")
+	}
+	if got := names(result.Pruned); !equalStrings(got, []string{"orphan"}) {
+		t.Fatalf("pruned candidates = %v, want [orphan]", got)
+	}
+	if result.FreedBytes <= 0 {
+		t.Fatalf("FreedBytes = %d, want > 0", result.FreedBytes)
+	}
+	// Nothing actually removed.
+	for _, dir := range []string{orphan, ref} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("dry-run removed %q: %v", dir, err)
+		}
+	}
+}
+
+func TestPruneApplyRemovesOnlyUnreferencedAndOld(t *testing.T) {
+	cacheRoot := t.TempDir()
+	now := time.Now()
+	old := now.Add(-30 * 24 * time.Hour)
+	recent := now.Add(-1 * time.Hour)
+
+	orphanOld := writeCacheClone(t, cacheRoot, "orphan-old", old)
+	orphanFresh := writeCacheClone(t, cacheRoot, "orphan-fresh", recent)
+	referenced := writeCacheClone(t, cacheRoot, "ref", old)
+
+	result, err := Prune(cacheRoot, map[string]bool{"ref": true}, 7, true)
+	if err != nil {
+		t.Fatalf("Prune apply: %v", err)
+	}
+	if !result.Applied {
+		t.Fatal("apply reported Applied=false")
+	}
+	if got := names(result.Pruned); !equalStrings(got, []string{"orphan-old"}) {
+		t.Fatalf("pruned = %v, want [orphan-old]", got)
+	}
+	if _, err := os.Stat(orphanOld); !os.IsNotExist(err) {
+		t.Fatalf("orphan-old should be deleted, stat err = %v", err)
+	}
+	for _, dir := range []string{orphanFresh, referenced} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("apply removed protected dir %q: %v", dir, err)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Two cache-hygiene fixes for the global pack cache (`~/.gc`):

1. **`gc import prune`** — a reference-aware command to clean the global pack cache. It enumerates cached repo clones, determines which are still referenced by installed packs, and prunes the rest. Dry-run by default (lists what *would* be removed); `--apply` to delete, `--keep-days N` to retain recently-touched clones. Cache clones accumulated unbounded (hundreds of stale repos) with no supported way to reclaim them.

2. **Don't count gitignored artifacts as cache-dirty** — the cache freshness check ran `git status --porcelain --ignored`, so gitignored build artifacts written into a cached pack clone (e.g. Python `.pyc`) counted as local modifications and blocked cache reuse with a spurious "cached import has local worktree changes". Dropping `--ignored` means only *tracked* changes mark the cache dirty.

## Testing

- [x] `go test ./internal/packman/ ./internal/config/ ./cmd/gc/` (prune reference-awareness, dry-run/apply, keep-days, cache-dirty gate) pass locally
- [x] `go build ./...`
- [ ] `make check-docs` for the regenerated `docs/reference/cli.md` — CI

## Checklist

- [x] Added tests for both behaviors
- [x] Updated `docs/reference/cli.md` for the new command
- [ ] No breaking changes
