### PR TITLE
feat(dolt): resolve live managed-Dolt port from state, not the port file

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -1359,6 +1359,16 @@ func doltPortReachable(port string) bool {
 // operators can see that their on-disk port file is being reconciled to the
 // canonical managed port. scopeLabel may be empty for silent callers; warn may
 // be nil or io.Discard to suppress warnings entirely.
+//
+// TODO(scale-P1.7): root-cause the surviving port-file writer. bd owns the
+// authoritative writes to .beads/dolt-server.port (gc only mirrors the
+// managed port here), and a writer that outlived the vp-w7tc pooling fix has
+// clobbered the file with a proxy's ephemeral port in production (incident
+// class 4). gc no longer reads this file for endpoint resolution anywhere —
+// resolution is live-state only (dolt_port_live.go) and the
+// port-file-consistency doctor check hard-fails on any mismatch — so the
+// file survives purely as a raw-bd compatibility mirror. Schedule its
+// removal once bd's direct-mode discovery resolves endpoints without it.
 func writeDoltPortFile(dir, port, scopeLabel string, warn io.Writer) {
 	if dir == "" || port == "" {
 		return

--- a/cmd/gc/beads_proxied_overlay.go
+++ b/cmd/gc/beads_proxied_overlay.go
@@ -36,6 +36,13 @@ const (
 // beads' internal/configfile, so this small mirror serializes the same JSON
 // schema (.beads/proxied_server_client_info.json) that bd reads to learn which
 // external dolt sql-server the proxy should front.
+//
+// Status-file demotion (city-scale plan P1.7): like .beads/dolt-server.port,
+// this file is a bd-facing status file. gc writes and removes it here but
+// NEVER reads it back for endpoint resolution — gc-side resolution is
+// live-state only (dolt_port_live.go). The port-file-consistency doctor
+// check hard-fails when this file's external endpoint disagrees with the
+// live managed listener.
 type proxiedServerClientInfo struct {
 	External *proxiedServerExternal `json:"external,omitempty"`
 }

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -210,6 +210,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		if workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs) {
 			register(newDoltTopologyCheck(cityPath, cfg))
 			register(newDoltDriftCheck(cityPath, cfg))
+			register(newPortFileConsistencyCheck(cityPath, cfg))
 		}
 		register(doctor.NewConfigValidCheck(cfg))
 		register(doctor.NewLegacySuspendedFieldCheck(cfg))

--- a/cmd/gc/cmd_doctor_portfile.go
+++ b/cmd/gc/cmd_doctor_portfile.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+// portFileConsistencyCheck flags Dolt endpoint status files that disagree
+// with the live managed listener (city-scale plan P1.7, incident class 4).
+//
+// .beads/dolt-server.port and .beads/proxied_server_client_info.json are
+// status files: bd reads them, but gc resolves endpoints exclusively from
+// live state (see dolt_port_live.go) and only mirrors values into them. A
+// surviving writer has clobbered the port file with a proxy's ephemeral
+// port in production (vp-w7tc), so any disagreement with the live listener
+// is hard-red at zero tolerated mismatches — a lying file means raw bd
+// clients are about to talk to the wrong (or no) server.
+type portFileConsistencyCheck struct {
+	cityPath string
+	cfg      *config.City
+	// livePort resolves the live managed dolt port; seam for tests.
+	// Defaults to newLiveDoltPortResolver().resolve.
+	livePort func(cityPath string) (liveDoltPortResolution, error)
+}
+
+func newPortFileConsistencyCheck(cityPath string, cfg *config.City) *portFileConsistencyCheck {
+	return &portFileConsistencyCheck{
+		cityPath: cityPath,
+		cfg:      cfg,
+		livePort: newLiveDoltPortResolver().resolve,
+	}
+}
+
+// Name implements doctor.Check.
+func (c *portFileConsistencyCheck) Name() string { return "port-file-consistency" }
+
+// portFileScope is one directory whose .beads status files get compared
+// against the live listener.
+type portFileScope struct {
+	label string
+	dir   string
+}
+
+// Run implements doctor.Check.
+func (c *portFileConsistencyCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	r := &doctor.CheckResult{Name: c.Name()}
+	if c.cfg == nil || !workspaceUsesManagedBdStoreContract(c.cityPath, c.cfg.Rigs) {
+		r.Status = doctor.StatusOK
+		r.Message = "not using bd-backed Dolt topology"
+		return r
+	}
+
+	scopes := []portFileScope{{label: "city", dir: c.cityPath}}
+	for i := range c.cfg.Rigs {
+		rig := c.cfg.Rigs[i]
+		if strings.TrimSpace(rig.Path) == "" || !rigUsesManagedBdStoreContract(c.cityPath, rig) {
+			continue
+		}
+		scopes = append(scopes, portFileScope{label: fmt.Sprintf("rig %q", rig.Name), dir: rig.Path})
+	}
+
+	live, liveErr := c.livePort(c.cityPath)
+	if liveErr != nil || !validDoltPort(live.Port) {
+		files := statusFilesPresent(scopes)
+		if len(files) == 0 {
+			r.Status = doctor.StatusOK
+			r.Message = "no live managed Dolt listener and no Dolt endpoint status files"
+			return r
+		}
+		r.Status = doctor.StatusWarning
+		plural := ""
+		if len(files) != 1 {
+			plural = "s"
+		}
+		r.Message = fmt.Sprintf("cannot verify %d Dolt endpoint status file%s: no live managed Dolt listener resolved", len(files), plural)
+		r.Details = files
+		r.FixHint = "status files are never trusted by gc; if the managed Dolt should be running, start the city (`gc start`), then re-run doctor to verify the mirrors"
+		return r
+	}
+
+	var mismatches []string
+	for _, scope := range scopes {
+		mismatches = append(mismatches, scopePortFileMismatches(scope, live.Port)...)
+	}
+	if len(mismatches) > 0 {
+		r.Status = doctor.StatusError
+		plural := ""
+		if len(mismatches) != 1 {
+			plural = "es"
+		}
+		r.Message = fmt.Sprintf("%d Dolt endpoint status-file mismatch%s against the live listener (port %d via %s)", len(mismatches), plural, live.Port, live.Source)
+		r.Details = mismatches
+		r.FixHint = "gc never trusts these status files (they are bd compatibility mirrors); `gc start` reconciles them to the managed port — a recurring mismatch means a surviving writer is clobbering them (vp-w7tc lineage) and must be root-caused, not tolerated"
+		return r
+	}
+
+	r.Status = doctor.StatusOK
+	r.Message = fmt.Sprintf("Dolt endpoint status files agree with the live listener (port %d)", live.Port)
+	return r
+}
+
+// CanFix implements doctor.Check.
+func (c *portFileConsistencyCheck) CanFix() bool { return false }
+
+// Fix implements doctor.Check.
+func (c *portFileConsistencyCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+// WarmupEligible implements doctor.Check. The check stays out of the
+// `gc start` warm-up scan: during startup the managed Dolt may not be
+// serving yet and the mirrors are about to be re-synced, so a warm-up run
+// would warn spuriously. It runs on demand via `gc doctor` (and is the
+// intended payload for the scheduled doctor subset in city-scale plan 1.9).
+func (c *portFileConsistencyCheck) WarmupEligible() bool { return false }
+
+// statusFilesPresent lists the Dolt endpoint status files that exist under
+// the given scopes.
+func statusFilesPresent(scopes []portFileScope) []string {
+	var out []string
+	for _, scope := range scopes {
+		for _, name := range []string{"dolt-server.port", proxiedServerClientInfoFile} {
+			path := filepath.Join(scope.dir, ".beads", name)
+			if _, err := os.Stat(path); err == nil {
+				out = append(out, fmt.Sprintf("%s: %s", scope.label, path))
+			}
+		}
+	}
+	return out
+}
+
+// scopePortFileMismatches compares one scope's status files against the live
+// port and returns one detail line per disagreement. Missing files are fine
+// (nothing to disagree); unparseable content counts as a mismatch because a
+// raw bd client reading it cannot reach the live server either.
+func scopePortFileMismatches(scope portFileScope, livePort int) []string {
+	var out []string
+	portFile := filepath.Join(scope.dir, ".beads", "dolt-server.port")
+	if data, err := os.ReadFile(portFile); err == nil {
+		text := strings.TrimSpace(string(data))
+		port, convErr := strconv.Atoi(text)
+		switch {
+		case convErr != nil || !validDoltPort(port):
+			out = append(out, fmt.Sprintf("%s: %s contains %q, not a valid port (live listener is %d)", scope.label, portFile, text, livePort))
+		case port != livePort:
+			out = append(out, fmt.Sprintf("%s: %s says %d but the live listener is %d", scope.label, portFile, port, livePort))
+		}
+	}
+
+	infoFile := filepath.Join(scope.dir, ".beads", proxiedServerClientInfoFile)
+	if data, err := os.ReadFile(infoFile); err == nil {
+		var info proxiedServerClientInfo
+		if jsonErr := json.Unmarshal(data, &info); jsonErr != nil {
+			out = append(out, fmt.Sprintf("%s: %s is unparseable: %v (live listener is %d)", scope.label, infoFile, jsonErr, livePort))
+		} else if info.External != nil && info.External.Port > 0 && info.External.Port != livePort {
+			out = append(out, fmt.Sprintf("%s: %s external endpoint says %d but the live listener is %d", scope.label, infoFile, info.External.Port, livePort))
+		}
+	}
+	return out
+}

--- a/cmd/gc/cmd_doctor_portfile_test.go
+++ b/cmd/gc/cmd_doctor_portfile_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+// portFileFixture builds a managed bd-store city with one rig and returns
+// the paths plus a config naming the rig.
+func portFileFixture(t *testing.T) (cityDir, rigDir string, cfg *config.City) {
+	t.Helper()
+	cityDir = t.TempDir()
+	rigDir = filepath.Join(t.TempDir(), "alpha")
+	for _, dir := range []string{cityDir, rigDir} {
+		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg = &config.City{
+		Workspace: config.Workspace{Name: "portfile-test"},
+		Rigs:      []config.Rig{{Name: "alpha", Path: rigDir, Prefix: "al"}},
+	}
+	return cityDir, rigDir, cfg
+}
+
+func livePortFixed() func(string) (liveDoltPortResolution, error) {
+	return func(string) (liveDoltPortResolution, error) {
+		return liveDoltPortResolution{Port: 28231, Source: liveDoltHandleSource}, nil
+	}
+}
+
+func livePortUnavailable() func(string) (liveDoltPortResolution, error) {
+	return func(string) (liveDoltPortResolution, error) {
+		return liveDoltPortResolution{}, errors.New("no live managed dolt endpoint")
+	}
+}
+
+func writeScopeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".beads", name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runPortFileCheck(t *testing.T, cityDir string, cfg *config.City, livePort func(string) (liveDoltPortResolution, error)) *doctor.CheckResult {
+	t.Helper()
+	check := newPortFileConsistencyCheck(cityDir, cfg)
+	check.livePort = livePort
+	return check.Run(&doctor.CheckContext{})
+}
+
+func TestPortFileConsistency_MatchingFilesOK(t *testing.T) {
+	cityDir, rigDir, cfg := portFileFixture(t)
+	writeScopeFile(t, cityDir, "dolt-server.port", "28231\n")
+	writeScopeFile(t, rigDir, "dolt-server.port", "28231\n")
+
+	r := runPortFileCheck(t, cityDir, cfg, livePortFixed())
+	if r.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK; message=%q details=%v", r.Status, r.Message, r.Details)
+	}
+}
+
+func TestPortFileConsistency_CityPortFileMismatchIsError(t *testing.T) {
+	cityDir, _, cfg := portFileFixture(t)
+	writeScopeFile(t, cityDir, "dolt-server.port", "29000\n")
+
+	r := runPortFileCheck(t, cityDir, cfg, livePortFixed())
+	if r.Status != doctor.StatusError {
+		t.Fatalf("Status = %v, want Error; message=%q", r.Status, r.Message)
+	}
+	joined := strings.Join(r.Details, "\n")
+	if !strings.Contains(joined, "29000") || !strings.Contains(joined, "28231") {
+		t.Errorf("Details missing both ports: %v", r.Details)
+	}
+	if !strings.Contains(joined, "dolt-server.port") {
+		t.Errorf("Details missing file name: %v", r.Details)
+	}
+}
+
+func TestPortFileConsistency_RigPortFileMismatchIsError(t *testing.T) {
+	cityDir, rigDir, cfg := portFileFixture(t)
+	writeScopeFile(t, cityDir, "dolt-server.port", "28231\n")
+	writeScopeFile(t, rigDir, "dolt-server.port", "29000\n")
+
+	r := runPortFileCheck(t, cityDir, cfg, livePortFixed())
+	if r.Status != doctor.StatusError {
+		t.Fatalf("Status = %v, want Error; message=%q", r.Status, r.Message)
+	}
+	if joined := strings.Join(r.Details, "\n"); !strings.Contains(joined, "alpha") {
+		t.Errorf("Details missing rig scope attribution: %v", r.Details)
+	}
+}
+
+func TestPortFileConsistency_UnparseablePortFileIsError(t *testing.T) {
+	cityDir, _, cfg := portFileFixture(t)
+	writeScopeFile(t, cityDir, "dolt-server.port", "not-a-port\n")
+
+	r := runPortFileCheck(t, cityDir, cfg, livePortFixed())
+	if r.Status != doctor.StatusError {
+		t.Fatalf("Status = %v, want Error for unparseable port file", r.Status)
+	}
+}
+
+func TestPortFileConsistency_ProxiedClientInfoMismatchIsError(t *testing.T) {
+	cityDir, _, cfg := portFileFixture(t)
+	writeScopeFile(t, cityDir, "proxied_server_client_info.json", `{"external":{"host":"127.0.0.1","port":29000,"user":"root"}}`)
+
+	r := runPortFileCheck(t, cityDir, cfg, livePortFixed())
+	if r.Status != doctor.StatusError {
+		t.Fatalf("Status = %v, want Error; message=%q", r.Status, r.Message)
+	}
+	if joined := strings.Join(r.Details, "\n"); !strings.Contains(joined, "proxied_server_client_info.json") {
+		t.Errorf("Details missing client-info file name: %v", r.Details)
+	}
+}
+
+func TestPortFileConsistency_ProxiedClientInfoMatchingOK(t *testing.T) {
+	cityDir, _, cfg := portFileFixture(t)
+	writeScopeFile(t, cityDir, "proxied_server_client_info.json", `{"external":{"host":"127.0.0.1","port":28231,"user":"root"}}`)
+
+	r := runPortFileCheck(t, cityDir, cfg, livePortFixed())
+	if r.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK; message=%q details=%v", r.Status, r.Message, r.Details)
+	}
+}
+
+func TestPortFileConsistency_NoLiveListenerWithFilesWarns(t *testing.T) {
+	cityDir, _, cfg := portFileFixture(t)
+	writeScopeFile(t, cityDir, "dolt-server.port", "28231\n")
+
+	r := runPortFileCheck(t, cityDir, cfg, livePortUnavailable())
+	if r.Status != doctor.StatusWarning {
+		t.Fatalf("Status = %v, want Warning when status files exist but no live listener resolves", r.Status)
+	}
+}
+
+func TestPortFileConsistency_NoLiveListenerNoFilesOK(t *testing.T) {
+	cityDir, _, cfg := portFileFixture(t)
+
+	r := runPortFileCheck(t, cityDir, cfg, livePortUnavailable())
+	if r.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK; message=%q", r.Status, r.Message)
+	}
+}
+
+func TestPortFileConsistency_NotBdStoreWorkspaceOK(t *testing.T) {
+	cityDir := t.TempDir() // no .beads/metadata.json anywhere
+	cfg := &config.City{Workspace: config.Workspace{Name: "plain"}}
+
+	r := runPortFileCheck(t, cityDir, cfg, livePortFixed())
+	if r.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK for non-bd workspace", r.Status)
+	}
+}

--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -193,13 +193,20 @@ type cleanupOptions struct {
 	PortResolution PortResolution
 	Rigs           []resolverRig
 	FS             fsys.FS
-	JSON           bool
-	Probe          bool
-	Force          bool
-	Host           string
-	HomeDir        string
-	TempDir        string
-	MaxOrphanDBs   int
+	// CityPath roots the live managed-dolt resolution (runtime handle +
+	// process table) used by the port resolver, the reaper's protected-port
+	// set, and the purge scoping. Empty disables the live steps.
+	CityPath string
+	// LiveResolve overrides the live managed-dolt resolution chain in
+	// tests. Nil uses newLiveDoltPortResolver().resolve.
+	LiveResolve  func(cityPath string) (liveDoltPortResolution, error)
+	JSON         bool
+	Probe        bool
+	Force        bool
+	Host         string
+	HomeDir      string
+	TempDir      string
+	MaxOrphanDBs int
 
 	// StalePrefixes overrides defaultStaleDatabasePrefixes when non-empty.
 	// Set by tests; production passes nil and falls back to the built-in.
@@ -318,10 +325,10 @@ func cleanupPortResolution(opts cleanupOptions) PortResolution {
 		return opts.PortResolution
 	}
 	return ResolveDoltPort(PortResolverInput{
-		Flag:     opts.Flag,
-		CityPort: opts.CityPort,
-		Rigs:     opts.Rigs,
-		FS:       opts.FS,
+		Flag:        opts.Flag,
+		CityPort:    opts.CityPort,
+		CityPath:    opts.CityPath,
+		LiveResolve: opts.LiveResolve,
 	})
 }
 
@@ -364,7 +371,7 @@ func runReapStage(report *CleanupReport, opts cleanupOptions) {
 		return
 	}
 
-	rigPorts := protectedDoltPortsForReap(opts)
+	rigPorts := protectedDoltPortsForReap(opts, procs)
 	tempDir := opts.TempDir
 	if tempDir == "" {
 		tempDir = os.TempDir()
@@ -456,8 +463,33 @@ func runReapStage(report *CleanupReport, opts cleanupOptions) {
 	report.Summary.BytesFreedRSS = sumReapTargetRSS(plan.Reap, gone)
 }
 
-func protectedDoltPortsForReap(opts cleanupOptions) map[int]string {
-	ports := loadRigDoltPorts(opts.Rigs, opts.FS)
+// protectedDoltPortsForReap builds the reaper's protected port set from live
+// state (city-scale plan P1.7): the managed city dolt resolved via the live
+// chain, the ports of every discovered dolt process whose --config/--data-dir
+// argv sits under a registered rig root, and the resolved cleanup port. It
+// deliberately does NOT read <rigRoot>/.beads/dolt-server.port: that status
+// file has lied in production, and a lying file fails to protect the REAL
+// listener — live state cannot.
+func protectedDoltPortsForReap(opts cleanupOptions, procs []DoltProcInfo) map[int]string {
+	ports := map[int]string{}
+	liveResolve := opts.LiveResolve
+	if liveResolve == nil {
+		liveResolve = newLiveDoltPortResolver().resolve
+	}
+	if live, err := liveResolve(opts.CityPath); err == nil && validDoltPort(live.Port) {
+		ports[live.Port] = "managed city dolt"
+	}
+	for _, proc := range procs {
+		owner, ok := doltProcRigOwner(proc, opts.Rigs)
+		if !ok {
+			continue
+		}
+		for _, port := range proc.Ports {
+			if validDoltPort(port) {
+				ports[port] = owner
+			}
+		}
+	}
 	if opts.PortResolution.Port <= 0 {
 		return ports
 	}
@@ -543,7 +575,7 @@ func fatalPortResolutionAttempt(resolution PortResolution) (PortResolutionAttemp
 		if attempt.Status != "error" {
 			continue
 		}
-		if attempt.Source != flagDoltPortSource && attempt.Source != cityConfigDoltPortSource && !isRigPortFileSource(attempt.Source) {
+		if attempt.Source != flagDoltPortSource && attempt.Source != cityConfigDoltPortSource && !isLiveDoltPortSource(attempt.Source) {
 			continue
 		}
 		if attempt.Detail != "" {
@@ -554,8 +586,8 @@ func fatalPortResolutionAttempt(resolution PortResolution) (PortResolutionAttemp
 	return PortResolutionAttempt{}, nil
 }
 
-func isRigPortFileSource(source string) bool {
-	return filepath.Base(source) == "dolt-server.port" && filepath.Base(filepath.Dir(source)) == ".beads"
+func isLiveDoltPortSource(source string) bool {
+	return source == liveDoltHandleSource || source == liveDoltProcessSource
 }
 
 func appendProtectedPID(report *CleanupReport, pid int) {
@@ -816,14 +848,16 @@ func newDoltCleanupCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Find and remove orphaned Dolt databases (Go-side core)",
 		Long: `gc dolt-cleanup is the Go-side implementation of the operational Dolt
 cleanup tool. It resolves the Dolt server port via the AD-04 chain
-(--port > city dolt.port > <rigRoot>/.beads/dolt-server.port > 3307),
-drops stale test/agent databases, calls DOLT_PURGE_DROPPED_DATABASES
-to reclaim disk, and reaps orphaned dolt sql-server processes left
-over from leaked test harnesses. Invalid explicit ports and unreadable
-or invalid city/rig port settings fail closed before cleanup stages run;
-only absent rig port files can reach the legacy default. The legacy
-default is a connection fallback only; it does not protect port 3307
-from orphan-process reaping.
+(--port > city dolt.port > live managed dolt [runtime handle, then
+process table] > 3307); .beads/dolt-server.port is a bd compatibility
+status file and is never consulted. It drops stale test/agent
+databases, calls DOLT_PURGE_DROPPED_DATABASES to reclaim disk, and
+reaps orphaned dolt sql-server processes left over from leaked test
+harnesses. Invalid explicit ports, invalid city port settings, and
+live-resolution errors (ambiguous listeners, discovery failures) fail
+closed before cleanup stages run; only a clean live-resolution miss can
+reach the legacy default. The legacy default is a connection fallback
+only; it does not protect port 3307 from orphan-process reaping.
 
 Dry-run by default. Pass --force to actually drop, purge, and kill.
 Pass --max-orphan-dbs with --force to refuse all destructive cleanup
@@ -880,6 +914,7 @@ can still return successfully after emitting the report.`,
 				CityPort:     cfg.Dolt.Port,
 				Rigs:         rigs,
 				FS:           fsys.OSFS{},
+				CityPath:     cityPath,
 				JSON:         jsonOut,
 				Probe:        probe,
 				Force:        force,
@@ -893,7 +928,7 @@ can still return successfully after emitting the report.`,
 			// right address. Failed opens are reported by runDoltCleanup inside
 			// the typed cleanup envelope.
 			resolution := ResolveDoltPort(PortResolverInput{
-				Flag: opts.Flag, CityPort: opts.CityPort, Rigs: opts.Rigs, FS: opts.FS,
+				Flag: opts.Flag, CityPort: opts.CityPort, CityPath: opts.CityPath,
 			})
 			opts.PortResolution = resolution
 			host := opts.Host
@@ -1035,12 +1070,11 @@ func resolveRigDoltDatabase(r resolverRig, fs fsys.FS) rigDoltDatabaseResolution
 	}
 }
 
-// loadResolverRigs builds the resolver's rig list from a city config. The HQ
-// rig (the city itself) is added first so it wins the AD-04 §4.1 tie when
-// multiple <rigRoot>/.beads/dolt-server.port files exist; non-HQ rigs follow
-// in city.toml order. Paths are resolved to absolute form via
-// resolveRigPaths so the resolver's filesystem reads work regardless of how
-// the rig was registered.
+// loadResolverRigs builds the cleanup command's rig list from a city config.
+// The HQ rig (the city itself) is added first so HQ-first ordering holds for
+// rig protections; non-HQ rigs follow in city.toml order. Paths are resolved
+// to absolute form via resolveRigPaths so per-rig filesystem reads and
+// process-table path matching work regardless of how the rig was registered.
 func loadResolverRigs(cityPath string, cfg *config.City) []resolverRig {
 	rigs := make([]config.Rig, len(cfg.Rigs))
 	copy(rigs, cfg.Rigs)

--- a/cmd/gc/cmd_dolt_cleanup_test.go
+++ b/cmd/gc/cmd_dolt_cleanup_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"syscall"
 	"testing"
@@ -118,18 +117,19 @@ func TestRunDoltCleanupRejectsNegativeMaxOrphanDBs(t *testing.T) {
 
 func TestRunDoltCleanup_JSONOutputsResolvedPort(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
 
 	rigs := []resolverRig{{Name: "hq", Path: "/city", HQ: true}}
 
 	var stdout, stderr bytes.Buffer
 	opts := cleanupOptions{
-		Flag:     "",
-		CityPort: 0,
-		Rigs:     rigs,
-		FS:       fs,
-		JSON:     true,
-		Probe:    false, // skip TCP probe in unit tests
+		Flag:        "",
+		CityPort:    0,
+		Rigs:        rigs,
+		FS:          fs,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolve(),
+		JSON:        true,
+		Probe:       false, // skip TCP probe in unit tests
 	}
 	code := runDoltCleanup(opts, &stdout, &stderr)
 	if code != 0 {
@@ -176,16 +176,17 @@ func TestRunDoltCleanup_HumanOutputShowsPortAndFallbackWarning(t *testing.T) {
 
 func TestRunDoltCleanup_FlagOverridesEverything(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
 
 	var stdout, stderr bytes.Buffer
 	opts := cleanupOptions{
-		Flag:     "9999",
-		CityPort: 4242,
-		Rigs:     []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
-		FS:       fs,
-		JSON:     true,
-		Probe:    false,
+		Flag:        "9999",
+		CityPort:    4242,
+		Rigs:        []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
+		FS:          fs,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolve(),
+		JSON:        true,
+		Probe:       false,
 	}
 	code := runDoltCleanup(opts, &stdout, &stderr)
 	if code != 0 {
@@ -362,36 +363,25 @@ func TestRunDoltCleanup_InvalidCityConfigPortIsFatal(t *testing.T) {
 	}
 }
 
-func TestRunDoltCleanup_BadRigPortFileIsFatal(t *testing.T) {
+func TestRunDoltCleanup_LiveResolutionErrorIsFatal(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
-		setup     func(*fsys.Fake)
+		resolve   func(string) (liveDoltPortResolution, error)
 		wantError string
 	}{
 		{
-			name:      "empty",
-			setup:     func(fs *fsys.Fake) { fs.Files["/city/.beads/dolt-server.port"] = []byte("\n") },
-			wantError: "empty",
+			name:      "ambiguous listeners",
+			resolve:   fakeLiveResolveError("ambiguous live dolt listeners for /city on ports [28231 29000]; pass --port to disambiguate"),
+			wantError: "ambiguous",
 		},
 		{
-			name:      "malformed",
-			setup:     func(fs *fsys.Fake) { fs.Files["/city/.beads/dolt-server.port"] = []byte("not-a-port\n") },
-			wantError: "invalid port",
-		},
-		{
-			name:      "out of range",
-			setup:     func(fs *fsys.Fake) { fs.Files["/city/.beads/dolt-server.port"] = []byte("70000\n") },
-			wantError: "65535",
-		},
-		{
-			name:      "unreadable",
-			setup:     func(fs *fsys.Fake) { fs.Errors["/city/.beads/dolt-server.port"] = os.ErrPermission },
-			wantError: "permission",
+			name:      "discovery failure",
+			resolve:   fakeLiveResolveError("discover dolt processes: ps exploded"),
+			wantError: "ps exploded",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fs := fsys.NewFake()
-			tc.setup(fs)
 			client := &fakeCleanupDoltClient{
 				databases: []string{"testdb_abc"},
 			}
@@ -399,11 +389,13 @@ func TestRunDoltCleanup_BadRigPortFileIsFatal(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			opts := cleanupOptions{
-				Rigs:       []resolverRig{{Name: "city", Path: "/city", HQ: true}},
-				FS:         fs,
-				JSON:       true,
-				Force:      true,
-				DoltClient: client,
+				Rigs:        []resolverRig{{Name: "city", Path: "/city", HQ: true}},
+				FS:          fs,
+				CityPath:    "/city",
+				LiveResolve: tc.resolve,
+				JSON:        true,
+				Force:       true,
+				DoltClient:  client,
 				DiscoverProcesses: func() ([]DoltProcInfo, error) {
 					return []DoltProcInfo{{PID: 4444, Argv: []string{"dolt", "sql-server", "--config", "/tmp/TestX/config.yaml"}}}, nil
 				},
@@ -415,7 +407,7 @@ func TestRunDoltCleanup_BadRigPortFileIsFatal(t *testing.T) {
 			}
 			code := runDoltCleanup(opts, &stdout, &stderr)
 			if code == 0 {
-				t.Fatalf("exit=0, want bad rig port file to fail closed\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+				t.Fatalf("exit=0, want live resolution error to fail closed\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
 			}
 
 			var r CleanupReport
@@ -423,10 +415,10 @@ func TestRunDoltCleanup_BadRigPortFileIsFatal(t *testing.T) {
 				t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
 			}
 			if len(client.dropped) != 0 {
-				t.Fatalf("DropDatabase called after bad rig port file: %v", client.dropped)
+				t.Fatalf("DropDatabase called after live resolution error: %v", client.dropped)
 			}
 			if len(killed) != 0 {
-				t.Fatalf("KillProcess called after bad rig port file: %v", killed)
+				t.Fatalf("KillProcess called after live resolution error: %v", killed)
 			}
 			if r.Port.Resolved != 0 {
 				t.Fatalf("Port.Resolved = %d, want 0 for unresolved fatal port", r.Port.Resolved)
@@ -438,7 +430,7 @@ func TestRunDoltCleanup_BadRigPortFileIsFatal(t *testing.T) {
 				}
 			}
 			if !foundPortError {
-				t.Fatalf("Errors missing fatal rig port-file entry containing %q: %+v", tc.wantError, r.Errors)
+				t.Fatalf("Errors missing fatal live-resolution entry containing %q: %+v", tc.wantError, r.Errors)
 			}
 		})
 	}
@@ -580,7 +572,6 @@ func TestRunDoltCleanup_RigsProtectedFromRegistry(t *testing.T) {
 
 func TestRunDoltCleanup_DryRunReportsReapPlanWithoutKilling(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
 
 	procs := []DoltProcInfo{
 		{PID: 1138290, Ports: []int{28231}, Argv: []string{"dolt", "sql-server"}},
@@ -656,7 +647,6 @@ func TestRunDoltCleanup_DryRunAllowsProcessTempRootTestConfig(t *testing.T) {
 
 func TestRunDoltCleanup_ForceKillsOrphans(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
 
 	procs := []DoltProcInfo{
 		{PID: 1138290, Ports: []int{28231}, Argv: []string{"dolt", "sql-server"}, StartTimeTicks: 10},
@@ -830,18 +820,19 @@ func TestRunDoltCleanup_ForceCountsPostSIGTERMGoneAsReaped(t *testing.T) {
 
 func TestRunDoltCleanup_ForceRevalidatesPIDBeforeSIGTERM(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
 
 	discoverCalls := 0
 	var signals []syscall.Signal
 
 	var stdout, stderr bytes.Buffer
 	opts := cleanupOptions{
-		Rigs:    []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
-		FS:      fs,
-		JSON:    true,
-		Force:   true,
-		HomeDir: "/home/u",
+		Rigs:        []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
+		FS:          fs,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolve(),
+		JSON:        true,
+		Force:       true,
+		HomeDir:     "/home/u",
 		DiscoverProcesses: func() ([]DoltProcInfo, error) {
 			discoverCalls++
 			if discoverCalls == 1 {
@@ -1042,18 +1033,19 @@ func TestRunDoltCleanup_ForceSkipsSIGKILLWhenRevalidationDiscoverErrors(t *testi
 
 func TestRunDoltCleanup_ForceSkipsSIGKILLWhenProcessBecomesProtected(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
 
 	discoverCalls := 0
 	var signals []syscall.Signal
 
 	var stdout, stderr bytes.Buffer
 	opts := cleanupOptions{
-		Rigs:    []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
-		FS:      fs,
-		JSON:    true,
-		Force:   true,
-		HomeDir: "/home/u",
+		Rigs:        []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
+		FS:          fs,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolve(),
+		JSON:        true,
+		Force:       true,
+		HomeDir:     "/home/u",
 		DiscoverProcesses: func() ([]DoltProcInfo, error) {
 			discoverCalls++
 			proc := DoltProcInfo{

--- a/cmd/gc/dolt_cleanup_discovery.go
+++ b/cmd/gc/dolt_cleanup_discovery.go
@@ -9,37 +9,54 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-// loadRigDoltPorts reads each rig's <rigRoot>/.beads/dolt-server.port file and
-// returns a port→rig-name map for the reaper's protection check. Missing or
-// malformed files are silently skipped — they just won't contribute to the
-// protected set, and the reaper will fall back to its config-path filter.
+// doltProcRigOwner reports which registered rig owns a discovered dolt
+// sql-server process, matched by the process's --data-dir or --config argv
+// path sitting under the rig root. This is the live-state replacement for
+// the former <rigRoot>/.beads/dolt-server.port protection read (city-scale
+// plan P1.7): a status file can lie about a rig's port, but a live process
+// whose data lives under the rig root cannot.
 //
-// If two rigs claim the same port (pathological — operator misconfiguration),
-// the later-listed rig wins. The function is still safe: any port match
-// protects, regardless of which rig name is attributed.
-func loadRigDoltPorts(rigs []resolverRig, fs fsys.FS) map[int]string {
-	out := map[int]string{}
-	for _, rig := range rigs {
-		path := filepath.Join(rig.Path, ".beads", "dolt-server.port")
-		data, err := fs.ReadFile(path)
-		if err != nil {
-			continue
-		}
-		text := strings.TrimSpace(string(data))
-		if text == "" {
-			continue
-		}
-		port, err := strconv.Atoi(text)
-		if err != nil || !validDoltPort(port) {
-			continue
-		}
-		out[port] = rig.Name
+// If two rigs both contain a candidate path (nested roots — operator
+// misconfiguration), the first-listed rig wins. The reaper is still safe:
+// any match protects, regardless of which rig name is attributed.
+func doltProcRigOwner(p DoltProcInfo, rigs []resolverRig) (string, bool) {
+	var candidates []string
+	if cfg := extractConfigPath(p.Argv); cfg != "" {
+		candidates = append(candidates, cfg)
 	}
-	return out
+	if dd, ok := argvFlagValue(p.Argv, "--data-dir"); ok && dd != "" {
+		candidates = append(candidates, dd)
+	}
+	if len(candidates) == 0 {
+		return "", false
+	}
+	for _, rig := range rigs {
+		root := normalizePathForCompare(strings.TrimSpace(rig.Path))
+		if root == "" || root == "." || root == string(filepath.Separator) {
+			continue
+		}
+		for _, candidate := range candidates {
+			if pathUnderRoot(candidate, root) {
+				return rig.Name, true
+			}
+		}
+	}
+	return "", false
+}
+
+// pathUnderRoot reports whether path equals root or sits underneath it,
+// using the same normalization as samePath.
+func pathUnderRoot(path, root string) bool {
+	normalized := normalizePathForCompare(path)
+	if normalized == "" {
+		return false
+	}
+	if normalized == root {
+		return true
+	}
+	return strings.HasPrefix(normalized, root+string(filepath.Separator))
 }
 
 // procEnumerationTimeout caps the per-PID I/O during /proc walks so a stuck

--- a/cmd/gc/dolt_cleanup_discovery_test.go
+++ b/cmd/gc/dolt_cleanup_discovery_test.go
@@ -4,72 +4,88 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-func TestLoadRigDoltPorts_ReadsAllRigs(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
-	fs.Files["/rig-a/.beads/dolt-server.port"] = []byte("28232\n")
-	fs.Files["/rig-b/.beads/dolt-server.port"] = []byte("28233\n")
-
+func TestDoltProcRigOwner_MatchesDataDirUnderRigRoot(t *testing.T) {
 	rigs := []resolverRig{
 		{Name: "hq", Path: "/city", HQ: true},
 		{Name: "alpha", Path: "/rig-a"},
-		{Name: "beta", Path: "/rig-b"},
 	}
 
-	got := loadRigDoltPorts(rigs, fs)
-	want := map[int]string{
-		28231: "hq",
-		28232: "alpha",
-		28233: "beta",
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("loadRigDoltPorts = %v, want %v", got, want)
+	proc := DoltProcInfo{Argv: []string{"dolt", "sql-server", "--data-dir", "/rig-a/.beads/dolt"}}
+	owner, ok := doltProcRigOwner(proc, rigs)
+	if !ok || owner != "alpha" {
+		t.Errorf("doltProcRigOwner = (%q, %v), want (alpha, true)", owner, ok)
 	}
 }
 
-func TestLoadRigDoltPorts_SkipsMissingAndMalformed(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/rig-a/.beads/dolt-server.port"] = []byte("28232\n")
-	fs.Files["/rig-b/.beads/dolt-server.port"] = []byte("not-a-port\n")
-	fs.Files["/rig-c/.beads/dolt-server.port"] = []byte("\n")
-	// /rig-d has no port file at all.
+func TestDoltProcRigOwner_MatchesConfigUnderRigRoot(t *testing.T) {
+	rigs := []resolverRig{{Name: "hq", Path: "/city", HQ: true}}
 
-	rigs := []resolverRig{
-		{Name: "alpha", Path: "/rig-a"},
-		{Name: "beta", Path: "/rig-b"},
-		{Name: "gamma", Path: "/rig-c"},
-		{Name: "delta", Path: "/rig-d"},
-	}
-
-	got := loadRigDoltPorts(rigs, fs)
-	want := map[int]string{
-		28232: "alpha",
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("loadRigDoltPorts = %v, want %v", got, want)
+	proc := DoltProcInfo{Argv: []string{"dolt", "sql-server", "--config", "/city/.gc/runtime/packs/dolt/config.yaml"}}
+	owner, ok := doltProcRigOwner(proc, rigs)
+	if !ok || owner != "hq" {
+		t.Errorf("doltProcRigOwner = (%q, %v), want (hq, true)", owner, ok)
 	}
 }
 
-func TestLoadRigDoltPorts_DuplicatePortsLastWins(t *testing.T) {
-	// Pathological: two rigs claim the same port. Last write wins so the
-	// reaper still protects on port match (it just attributes to the
-	// later-listed rig). Acceptable behavior; documented in the function.
-	fs := fsys.NewFake()
-	fs.Files["/rig-a/.beads/dolt-server.port"] = []byte("28232\n")
-	fs.Files["/rig-b/.beads/dolt-server.port"] = []byte("28232\n")
-
+func TestDoltProcRigOwner_IgnoresForeignAndPathlessProcesses(t *testing.T) {
 	rigs := []resolverRig{
+		{Name: "hq", Path: "/city", HQ: true},
 		{Name: "alpha", Path: "/rig-a"},
-		{Name: "beta", Path: "/rig-b"},
 	}
 
-	got := loadRigDoltPorts(rigs, fs)
-	if got[28232] == "" {
-		t.Errorf("expected port 28232 to be in map, got %v", got)
+	for _, tc := range []struct {
+		name string
+		argv []string
+	}{
+		{"foreign data dir", []string{"dolt", "sql-server", "--data-dir", "/elsewhere/dolt"}},
+		{"foreign config", []string{"dolt", "sql-server", "--config", "/tmp/TestX/config.yaml"}},
+		{"no path flags", []string{"dolt", "sql-server"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if owner, ok := doltProcRigOwner(DoltProcInfo{Argv: tc.argv}, rigs); ok {
+				t.Errorf("doltProcRigOwner = (%q, true), want no owner", owner)
+			}
+		})
+	}
+}
+
+func TestDoltProcRigOwner_FirstListedRigWinsOnNestedRoots(t *testing.T) {
+	// Pathological: nested rig roots both contain the candidate path. The
+	// first-listed rig wins; the reaper is still safe because any match
+	// protects regardless of attribution.
+	rigs := []resolverRig{
+		{Name: "outer", Path: "/work"},
+		{Name: "inner", Path: "/work/rig-a"},
+	}
+
+	proc := DoltProcInfo{Argv: []string{"dolt", "sql-server", "--data-dir", "/work/rig-a/.beads/dolt"}}
+	owner, ok := doltProcRigOwner(proc, rigs)
+	if !ok || owner != "outer" {
+		t.Errorf("doltProcRigOwner = (%q, %v), want (outer, true)", owner, ok)
+	}
+}
+
+func TestPathUnderRoot(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		root string
+		want bool
+	}{
+		{"direct child", "/city/.beads/dolt", "/city", true},
+		{"equal", "/city", "/city", true},
+		{"sibling prefix is not containment", "/cityscape/.beads", "/city", false},
+		{"outside", "/elsewhere/dolt", "/city", false},
+		{"empty path", "", "/city", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pathUnderRoot(tc.path, normalizePathForCompare(tc.root)); got != tc.want {
+				t.Errorf("pathUnderRoot(%q, %q) = %v, want %v", tc.path, tc.root, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/dolt_cleanup_human_test.go
+++ b/cmd/gc/dolt_cleanup_human_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestRunDoltCleanup_HumanOutputShowsAllWireframeSections(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
 	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
+	putCanonicalCityConfig(fs)
 	putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
 		"db_old/data": 4096,
 	})
@@ -30,6 +30,8 @@ func TestRunDoltCleanup_HumanOutputShowsAllWireframeSections(t *testing.T) {
 	opts := cleanupOptions{
 		Rigs:              rigs,
 		FS:                fs,
+		CityPath:          "/city",
+		LiveResolve:       fakeLiveResolve(),
 		JSON:              false, // human mode
 		DoltClient:        client,
 		HomeDir:           "/home/u",

--- a/cmd/gc/dolt_cleanup_port.go
+++ b/cmd/gc/dolt_cleanup_port.go
@@ -1,14 +1,9 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
-
-	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 // LegacyDefaultDoltPort is the historical hard-coded port used by the
@@ -22,18 +17,19 @@ const flagDoltPortSource = "--port flag"
 const cityConfigDoltPortSource = "city config dolt.port"
 
 // PortResolverInput bundles the inputs needed for the dolt port discovery
-// chain (per AD-04 §4.1).
+// chain (per AD-04 §4.1, live-state revision per city-scale plan P1.7).
 type PortResolverInput struct {
 	// Flag carries the --port flag value (empty if not provided).
 	Flag string
 	// CityPort is the city.toml [dolt] port. Zero means "not set".
 	CityPort int
-	// Rigs is the list of registered rigs, in the order
-	// returned by the registry. The HQ rig is preferred when picking
-	// between candidate <rigRoot>/.beads/dolt-server.port files.
-	Rigs []resolverRig
-	// FS is used for reading rig port files.
-	FS fsys.FS
+	// CityPath roots the live managed-dolt resolution steps (runtime
+	// handle, then process-table discovery). Empty records both live
+	// sources as not-provided.
+	CityPath string
+	// LiveResolve overrides the live resolution chain in tests. Nil uses
+	// newLiveDoltPortResolver().resolve.
+	LiveResolve func(cityPath string) (liveDoltPortResolution, error)
 }
 
 // resolverRig is the minimum rig info needed by ResolveDoltPort. It is
@@ -64,13 +60,20 @@ type PortResolutionAttempt struct {
 	Detail string
 }
 
-// ResolveDoltPort applies the discovery chain (AD-04 §4.1):
+// ResolveDoltPort applies the discovery chain (AD-04 §4.1, revised by the
+// city-scale plan P1.7 port-file de-authority):
 //
-//	--port flag > city.toml dolt.port > <rigRoot>/.beads/dolt-server.port (HQ first) > legacy default 3307
+//	--port flag > city.toml dolt.port > live managed dolt (runtime handle, then process table) > legacy default 3307
+//
+// <rigRoot>/.beads/dolt-server.port is deliberately NOT in the chain: it is
+// a bd compatibility status file whose surviving writer has clobbered it in
+// production (vp-w7tc, incident class 4); see dolt_port_live.go.
 //
 // Returns a PortResolution; Fallback is true only when the legacy default
 // is selected. Never returns an error — caller decides whether the warn
-// state is fatal.
+// state is fatal. A live-step error (ambiguous listeners, discovery
+// failure) stops the chain with Port 0 instead of falling through to the
+// legacy default, mirroring the historical bad-port-file hard stop.
 func ResolveDoltPort(in PortResolverInput) PortResolution {
 	res := PortResolution{}
 
@@ -92,15 +95,18 @@ func ResolveDoltPort(in PortResolverInput) PortResolution {
 	}
 	res.Tried = append(res.Tried, attempt)
 
-	for _, rig := range orderRigsHQFirst(in.Rigs) {
-		path := filepath.Join(rig.Path, ".beads", "dolt-server.port")
-		attempt, port, ok := tryRigPortFile(in.FS, path)
-		res.Tried = append(res.Tried, attempt)
-		if ok {
-			res.Port = port
-			res.Source = attempt.Source
-			return res
-		}
+	liveResolve := in.LiveResolve
+	if liveResolve == nil {
+		liveResolve = newLiveDoltPortResolver().resolve
+	}
+	live, liveErr := liveResolve(in.CityPath)
+	res.Tried = append(res.Tried, live.Attempts...)
+	if liveErr == nil && validDoltPort(live.Port) {
+		res.Port = live.Port
+		res.Source = live.Source
+		return res
+	}
+	for _, attempt := range live.Attempts {
 		if attempt.Status == "error" {
 			res.Source = attempt.Source
 			return res
@@ -156,44 +162,6 @@ func tryCityConfigPort(port int) (PortResolutionAttempt, int, bool) {
 		}, 0, false
 	}
 	return PortResolutionAttempt{Source: src, Status: "found", Detail: strconv.Itoa(port)}, port, true
-}
-
-func tryRigPortFile(fs fsys.FS, path string) (PortResolutionAttempt, int, bool) {
-	data, err := fs.ReadFile(path)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return PortResolutionAttempt{
-				Source: path,
-				Status: "error",
-				Detail: fmt.Sprintf("read port file: %v", err),
-			}, 0, false
-		}
-		return PortResolutionAttempt{Source: path, Status: "not-found"}, 0, false
-	}
-	text := strings.TrimSpace(string(data))
-	if text == "" {
-		return PortResolutionAttempt{
-			Source: path,
-			Status: "error",
-			Detail: "file is empty",
-		}, 0, false
-	}
-	port, err := strconv.Atoi(text)
-	if err != nil {
-		return PortResolutionAttempt{
-			Source: path,
-			Status: "error",
-			Detail: fmt.Sprintf("invalid port %q: %v", text, err),
-		}, 0, false
-	}
-	if !validDoltPort(port) {
-		return PortResolutionAttempt{
-			Source: path,
-			Status: "error",
-			Detail: invalidDoltPortMessage(port),
-		}, 0, false
-	}
-	return PortResolutionAttempt{Source: path, Status: "found", Detail: strconv.Itoa(port)}, port, true
 }
 
 func validDoltPort(port int) bool {

--- a/cmd/gc/dolt_cleanup_port_test.go
+++ b/cmd/gc/dolt_cleanup_port_test.go
@@ -1,21 +1,57 @@
 package main
 
 import (
-	"os"
+	"errors"
 	"strings"
 	"testing"
-
-	"github.com/gastownhall/gascity/internal/fsys"
 )
 
+// fakeLiveResolve returns a LiveResolve seam that resolves to the given port
+// via the managed-handle source.
+func fakeLiveResolve() func(string) (liveDoltPortResolution, error) {
+	return func(string) (liveDoltPortResolution, error) {
+		return liveDoltPortResolution{
+			Port:   28231,
+			Source: liveDoltHandleSource,
+			Attempts: []PortResolutionAttempt{
+				{Source: liveDoltHandleSource, Status: "found", Detail: "live"},
+			},
+		}, nil
+	}
+}
+
+// fakeLiveResolveMiss returns a LiveResolve seam where neither live source
+// finds an endpoint (clean not-found, no errors).
+func fakeLiveResolveMiss() func(string) (liveDoltPortResolution, error) {
+	return func(string) (liveDoltPortResolution, error) {
+		return liveDoltPortResolution{
+			Attempts: []PortResolutionAttempt{
+				{Source: liveDoltHandleSource, Status: "not-found"},
+				{Source: liveDoltProcessSource, Status: "not-found"},
+			},
+		}, errNoLiveDoltEndpoint
+	}
+}
+
+// fakeLiveResolveError returns a LiveResolve seam whose process-table step
+// fails hard (e.g. ambiguous listeners).
+func fakeLiveResolveError(detail string) func(string) (liveDoltPortResolution, error) {
+	return func(string) (liveDoltPortResolution, error) {
+		return liveDoltPortResolution{
+			Attempts: []PortResolutionAttempt{
+				{Source: liveDoltHandleSource, Status: "not-found"},
+				{Source: liveDoltProcessSource, Status: "error", Detail: detail},
+			},
+		}, errors.New(detail)
+	}
+}
+
 func TestResolveDoltPort_FlagWins(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
 	in := PortResolverInput{
-		Flag:     "9999",
-		CityPort: 4242,
-		Rigs:     []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
-		FS:       fs,
+		Flag:        "9999",
+		CityPort:    4242,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolve(),
 	}
 
 	got := ResolveDoltPort(in)
@@ -32,11 +68,11 @@ func TestResolveDoltPort_FlagWins(t *testing.T) {
 }
 
 func TestResolveDoltPort_FlagInvalidFallsThrough(t *testing.T) {
-	fs := fsys.NewFake()
 	in := PortResolverInput{
-		Flag:     "not-a-number",
-		CityPort: 4242,
-		FS:       fs,
+		Flag:        "not-a-number",
+		CityPort:    4242,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolveMiss(),
 	}
 
 	got := ResolveDoltPort(in)
@@ -53,13 +89,11 @@ func TestResolveDoltPort_FlagInvalidFallsThrough(t *testing.T) {
 	}
 }
 
-func TestResolveDoltPort_CityConfigBeatsRigFile(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
+func TestResolveDoltPort_CityConfigBeatsLiveResolution(t *testing.T) {
 	in := PortResolverInput{
-		CityPort: 4242,
-		Rigs:     []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
-		FS:       fs,
+		CityPort:    4242,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolve(),
 	}
 
 	got := ResolveDoltPort(in)
@@ -72,57 +106,54 @@ func TestResolveDoltPort_CityConfigBeatsRigFile(t *testing.T) {
 	}
 }
 
-func TestResolveDoltPort_HQRigPortFileWins(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
-	fs.Files["/elsewhere/.beads/dolt-server.port"] = []byte("19999\n")
+func TestResolveDoltPort_LiveResolutionWins(t *testing.T) {
 	in := PortResolverInput{
-		Rigs: []resolverRig{
-			{Name: "ext", Path: "/elsewhere", HQ: false},
-			{Name: "hq", Path: "/city", HQ: true},
-		},
-		FS: fs,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolve(),
 	}
 
 	got := ResolveDoltPort(in)
 
 	if got.Port != 28231 {
-		t.Errorf("Port = %d, want 28231 (HQ rig)", got.Port)
+		t.Errorf("Port = %d, want 28231 (live managed dolt)", got.Port)
 	}
-	if got.Source != "/city/.beads/dolt-server.port" {
-		t.Errorf("Source = %q, want HQ port-file path", got.Source)
+	if got.Source != liveDoltHandleSource {
+		t.Errorf("Source = %q, want %q", got.Source, liveDoltHandleSource)
 	}
 	if got.Fallback {
 		t.Errorf("Fallback = true, want false")
 	}
 }
 
-func TestResolveDoltPort_NonHQRigUsedWhenHQAbsent(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/elsewhere/.beads/dolt-server.port"] = []byte("19999\n")
+func TestResolveDoltPort_ProcessTableSourceThreadsThrough(t *testing.T) {
 	in := PortResolverInput{
-		Rigs: []resolverRig{
-			{Name: "ext", Path: "/elsewhere", HQ: false},
-			{Name: "hq", Path: "/city", HQ: true},
+		CityPath: "/city",
+		LiveResolve: func(string) (liveDoltPortResolution, error) {
+			return liveDoltPortResolution{
+				Port:   19999,
+				Source: liveDoltProcessSource,
+				Attempts: []PortResolutionAttempt{
+					{Source: liveDoltHandleSource, Status: "not-found"},
+					{Source: liveDoltProcessSource, Status: "found", Detail: "19999"},
+				},
+			}, nil
 		},
-		FS: fs,
 	}
 
 	got := ResolveDoltPort(in)
 
 	if got.Port != 19999 {
-		t.Errorf("Port = %d, want 19999 (non-HQ rig)", got.Port)
+		t.Errorf("Port = %d, want 19999", got.Port)
 	}
-	if got.Source != "/elsewhere/.beads/dolt-server.port" {
-		t.Errorf("Source = %q, want non-HQ port-file path", got.Source)
+	if got.Source != liveDoltProcessSource {
+		t.Errorf("Source = %q, want %q", got.Source, liveDoltProcessSource)
 	}
 }
 
 func TestResolveDoltPort_LegacyFallbackWhenNothingResolves(t *testing.T) {
-	fs := fsys.NewFake()
 	in := PortResolverInput{
-		Rigs: []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
-		FS:   fs,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolveMiss(),
 	}
 
 	got := ResolveDoltPort(in)
@@ -139,21 +170,21 @@ func TestResolveDoltPort_LegacyFallbackWhenNothingResolves(t *testing.T) {
 }
 
 func TestResolveDoltPort_TriedRecordsAllSources(t *testing.T) {
-	fs := fsys.NewFake()
 	in := PortResolverInput{
-		Rigs: []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
-		FS:   fs,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolveMiss(),
 	}
 
 	got := ResolveDoltPort(in)
 
-	if len(got.Tried) < 4 {
-		t.Fatalf("Tried = %d entries, want at least 4 (flag, config, rig file, legacy)", len(got.Tried))
+	if len(got.Tried) < 5 {
+		t.Fatalf("Tried = %d entries, want at least 5 (flag, config, live handle, process table, legacy)", len(got.Tried))
 	}
 	wantSources := []string{
 		"--port flag",
 		"city config dolt.port",
-		"/city/.beads/dolt-server.port",
+		liveDoltHandleSource,
+		liveDoltProcessSource,
 		"legacy default",
 	}
 	for i, want := range wantSources {
@@ -163,90 +194,73 @@ func TestResolveDoltPort_TriedRecordsAllSources(t *testing.T) {
 	}
 }
 
-func TestResolveDoltPort_BadRigPortFileStopsBeforeLegacyFallback(t *testing.T) {
-	for _, tc := range []struct {
-		name       string
-		setup      func(*fsys.Fake)
-		wantDetail string
-	}{
-		{
-			name:       "empty",
-			setup:      func(fs *fsys.Fake) { fs.Files["/city/.beads/dolt-server.port"] = []byte("\n") },
-			wantDetail: "empty",
-		},
-		{
-			name:       "malformed",
-			setup:      func(fs *fsys.Fake) { fs.Files["/city/.beads/dolt-server.port"] = []byte("not-a-port\n") },
-			wantDetail: "invalid port",
-		},
-		{
-			name:       "out of range",
-			setup:      func(fs *fsys.Fake) { fs.Files["/city/.beads/dolt-server.port"] = []byte("70000\n") },
-			wantDetail: "must be between 1 and 65535",
-		},
-		{
-			name:       "unreadable",
-			setup:      func(fs *fsys.Fake) { fs.Errors["/city/.beads/dolt-server.port"] = os.ErrPermission },
-			wantDetail: "permission",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			fs := fsys.NewFake()
-			tc.setup(fs)
-			in := PortResolverInput{
-				Rigs: []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
-				FS:   fs,
-			}
-
-			got := ResolveDoltPort(in)
-
-			if got.Port != 0 {
-				t.Errorf("Port = %d, want unresolved zero port", got.Port)
-			}
-			if got.Fallback {
-				t.Errorf("Fallback = true, want false for bad rig port file")
-			}
-			if got.Source != "/city/.beads/dolt-server.port" {
-				t.Errorf("Source = %q, want bad rig-port-file path", got.Source)
-			}
-			for _, attempt := range got.Tried {
-				if attempt.Source == "legacy default" {
-					t.Fatalf("legacy default was tried after bad rig port file: %+v", got.Tried)
-				}
-				if attempt.Source == "/city/.beads/dolt-server.port" {
-					if attempt.Status != "error" {
-						t.Errorf("rig-port-file attempt status = %q, want error", attempt.Status)
-					}
-					if !strings.Contains(attempt.Detail, tc.wantDetail) {
-						t.Errorf("rig-port-file detail = %q, want substring %q", attempt.Detail, tc.wantDetail)
-					}
-					return
-				}
-			}
-			t.Errorf("did not find /city/.beads/dolt-server.port in Tried entries: %+v", got.Tried)
-		})
-	}
-}
-
-func TestResolveDoltPort_NoRigsFalse_FallsThroughDirectly(t *testing.T) {
-	fs := fsys.NewFake()
+func TestResolveDoltPort_NeverReadsPortFile(t *testing.T) {
 	in := PortResolverInput{
-		FS: fs,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolveMiss(),
 	}
 
 	got := ResolveDoltPort(in)
 
+	for _, attempt := range got.Tried {
+		if strings.Contains(attempt.Source, "dolt-server.port") {
+			t.Fatalf("resolver consulted the dolt-server.port status file: %+v", got.Tried)
+		}
+	}
+}
+
+func TestResolveDoltPort_LiveResolutionErrorStopsBeforeLegacyFallback(t *testing.T) {
+	in := PortResolverInput{
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolveError("ambiguous live dolt listeners on ports [28231 29000]"),
+	}
+
+	got := ResolveDoltPort(in)
+
+	if got.Port != 0 {
+		t.Errorf("Port = %d, want unresolved zero port", got.Port)
+	}
+	if got.Fallback {
+		t.Errorf("Fallback = true, want false for live resolution error")
+	}
+	if got.Source != liveDoltProcessSource {
+		t.Errorf("Source = %q, want %q", got.Source, liveDoltProcessSource)
+	}
+	for _, attempt := range got.Tried {
+		if attempt.Source == "legacy default" {
+			t.Fatalf("legacy default was tried after live resolution error: %+v", got.Tried)
+		}
+		if attempt.Source == liveDoltProcessSource {
+			if attempt.Status != "error" {
+				t.Errorf("process-table attempt status = %q, want error", attempt.Status)
+			}
+			if !strings.Contains(attempt.Detail, "ambiguous") {
+				t.Errorf("process-table detail = %q, want ambiguity detail", attempt.Detail)
+			}
+			return
+		}
+	}
+	t.Errorf("did not find %s in Tried entries: %+v", liveDoltProcessSource, got.Tried)
+}
+
+func TestResolveDoltPort_NoCityPathFallsThroughDirectly(t *testing.T) {
+	got := ResolveDoltPort(PortResolverInput{
+		LiveResolve: func(cityPath string) (liveDoltPortResolution, error) {
+			return newLiveDoltPortResolver().resolve(cityPath)
+		},
+	})
+
 	if got.Port != 3307 || !got.Fallback {
-		t.Errorf("expected legacy fallback with no rigs, got %+v", got)
+		t.Errorf("expected legacy fallback with no city path, got %+v", got)
 	}
 }
 
 func TestResolveDoltPort_FlagZeroRejected(t *testing.T) {
-	fs := fsys.NewFake()
 	in := PortResolverInput{
-		Flag:     "0",
-		CityPort: 4242,
-		FS:       fs,
+		Flag:        "0",
+		CityPort:    4242,
+		CityPath:    "/city",
+		LiveResolve: fakeLiveResolveMiss(),
 	}
 
 	got := ResolveDoltPort(in)

--- a/cmd/gc/dolt_cleanup_purge.go
+++ b/cmd/gc/dolt_cleanup_purge.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
@@ -119,51 +120,39 @@ func runPurgeStage(report *CleanupReport, opts cleanupOptions) {
 	report.Purge.OK = allOK
 }
 
+// rigSharesResolvedDoltServer reports whether a rig's beads scope resolves
+// to the same dolt server the cleanup run is connected to. The decision
+// comes from the canonical scope config plus live managed runtime state
+// (contract.ResolveDoltConnectionTarget) — never from the rig's
+// .beads/dolt-server.port mirror, which is a bd compatibility status file
+// with a history of lying (city-scale plan P1.7).
+//
+// Failure semantics: an invalid canonical config fails closed (the rig is
+// excluded from purge accounting). A scope that merely cannot be resolved
+// right now (legacy scope without canonical config, stopped managed dolt —
+// contract.IsManagedRuntimeUnavailable) is treated as sharing only when the
+// cleanup port itself came from the legacy fallback or the city config,
+// preserving the conservative pre-P1.7 missing-port-file semantics.
 func rigSharesResolvedDoltServer(rig resolverRig, opts cleanupOptions) bool {
 	if opts.PortResolution.Port <= 0 || opts.FS == nil {
 		return true
 	}
-	port, state := rigPortFileValue(rig, opts.FS)
-	switch state {
-	case rigPortFileValid:
-		return port == opts.PortResolution.Port
-	case rigPortFileMissing:
-		return opts.PortResolution.Fallback || cityConfigPortSelectsRig(rig, opts)
-	default:
-		return false
+	if strings.TrimSpace(opts.CityPath) != "" {
+		target, err := contract.ResolveDoltConnectionTarget(opts.FS, opts.CityPath, rig.Path)
+		switch {
+		case err == nil:
+			port, perr := strconv.Atoi(strings.TrimSpace(target.Port))
+			return perr == nil && port == opts.PortResolution.Port
+		case !contract.IsManagedRuntimeUnavailable(err):
+			return false
+		}
 	}
+	return opts.PortResolution.Fallback || cityConfigPortSelectsRig(rig, opts)
 }
 
 func cityConfigPortSelectsRig(_ resolverRig, opts cleanupOptions) bool {
 	return opts.PortResolution.Source == cityConfigDoltPortSource &&
 		opts.CityPort == opts.PortResolution.Port
-}
-
-type rigPortFileState int
-
-const (
-	rigPortFileMissing rigPortFileState = iota
-	rigPortFileInvalid
-	rigPortFileValid
-)
-
-func rigPortFileValue(rig resolverRig, fs fsys.FS) (int, rigPortFileState) {
-	data, err := fs.ReadFile(filepath.Join(rig.Path, ".beads", "dolt-server.port"))
-	if err != nil {
-		if errors.Is(err, iofs.ErrNotExist) {
-			return 0, rigPortFileMissing
-		}
-		return 0, rigPortFileInvalid
-	}
-	text := strings.TrimSpace(string(data))
-	if text == "" {
-		return 0, rigPortFileInvalid
-	}
-	port, err := strconv.Atoi(text)
-	if err != nil || !validDoltPort(port) {
-		return 0, rigPortFileInvalid
-	}
-	return port, rigPortFileValid
 }
 
 // sumBytesUnder walks the given root recursively and returns the total

--- a/cmd/gc/dolt_cleanup_purge_test.go
+++ b/cmd/gc/dolt_cleanup_purge_test.go
@@ -50,6 +50,27 @@ func parentDir(p string) string {
 	return ""
 }
 
+// putCanonicalCityConfig writes a city_canonical scope config into the fake
+// FS so contract.ResolveDoltConnectionTarget resolves the city endpoint from
+// config alone (no managed runtime state, no network).
+func putCanonicalCityConfig(fs *fsys.Fake) {
+	fs.Files["/city/.beads/config.yaml"] = []byte("issue_prefix: gc\n" +
+		"gc.endpoint_origin: city_canonical\n" +
+		"gc.endpoint_status: verified\n" +
+		"dolt.host: 127.0.0.1\n" +
+		"dolt.port: \"28231\"\n")
+}
+
+// putExplicitRigConfig writes an explicit-endpoint rig scope config into the
+// fake FS.
+func putExplicitRigConfig(fs *fsys.Fake, rigPath, port string) {
+	fs.Files[rigPath+"/.beads/config.yaml"] = []byte("issue_prefix: r\n" +
+		"gc.endpoint_origin: explicit\n" +
+		"gc.endpoint_status: verified\n" +
+		"dolt.host: 127.0.0.1\n" +
+		"dolt.port: \"" + port + "\"\n")
+}
+
 func TestRunDoltCleanup_DryRunComputesPurgeBytesFromDroppedDirs(t *testing.T) {
 	fs := fsys.NewFake()
 	// City rig has 3 dropped databases on disk, total 3000 bytes.
@@ -351,12 +372,12 @@ func TestRunDoltCleanup_ForceSkipsPurgeForMissingRigDatabases(t *testing.T) {
 func TestRunDoltCleanup_ForceSkipsPurgeBytesForRigsOnDifferentPort(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231")
+	putCanonicalCityConfig(fs)
 	putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
 		"db_a/data.bin": 100,
 	})
 	fs.Files["/rigs/other/.beads/metadata.json"] = []byte(`{"dolt_database":"other_db"}`)
-	fs.Files["/rigs/other/.beads/dolt-server.port"] = []byte("28232")
+	putExplicitRigConfig(fs, "/rigs/other", "28232")
 	putFakeDirTree(fs, "/rigs/other/.beads/dolt/.dolt_dropped_databases", map[string]int64{
 		"db_b/data.bin": 200,
 	})
@@ -375,6 +396,8 @@ func TestRunDoltCleanup_ForceSkipsPurgeBytesForRigsOnDifferentPort(t *testing.T)
 	opts := cleanupOptions{
 		Rigs:              rigs,
 		FS:                fs,
+		CityPath:          "/city",
+		PortResolution:    PortResolution{Port: 28231, Source: liveDoltHandleSource},
 		JSON:              true,
 		Force:             true,
 		DoltClient:        client,
@@ -407,12 +430,12 @@ func TestRunDoltCleanup_ForceSkipsPurgeBytesForRigsOnDifferentPort(t *testing.T)
 func TestRunDoltCleanup_DryRunSkipsPurgeBytesForRigsOnDifferentPort(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231")
+	putCanonicalCityConfig(fs)
 	putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
 		"db_a/data.bin": 100,
 	})
 	fs.Files["/rigs/other/.beads/metadata.json"] = []byte(`{"dolt_database":"other_db"}`)
-	fs.Files["/rigs/other/.beads/dolt-server.port"] = []byte("28232")
+	putExplicitRigConfig(fs, "/rigs/other", "28232")
 	putFakeDirTree(fs, "/rigs/other/.beads/dolt/.dolt_dropped_databases", map[string]int64{
 		"db_b/data.bin": 200,
 	})
@@ -424,6 +447,8 @@ func TestRunDoltCleanup_DryRunSkipsPurgeBytesForRigsOnDifferentPort(t *testing.T
 			{Name: "other", Path: "/rigs/other"},
 		},
 		FS:                fs,
+		CityPath:          "/city",
+		PortResolution:    PortResolution{Port: 28231, Source: liveDoltHandleSource},
 		JSON:              true,
 		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
 	}
@@ -537,34 +562,42 @@ func TestRunDoltCleanup_ForcePurgesCityConfigPortRigWithoutPortFile(t *testing.T
 	}
 }
 
-func TestRunDoltCleanup_DryRunSkipsPurgeBytesForInvalidRigPortWithCityConfig(t *testing.T) {
-	portFile := "/rigs/unknown/.beads/dolt-server.port"
-	tests := []struct {
+// invalidRigEndpointConfigCases enumerates canonical rig configs that must
+// fail closed in rigSharesResolvedDoltServer (excluded from purge accounting)
+// even when the city-config port would otherwise vouch for unresolvable rigs.
+func invalidRigEndpointConfigCases() []struct {
+	name  string
+	setup func(*fsys.Fake)
+} {
+	configFile := "/rigs/unknown/.beads/config.yaml"
+	return []struct {
 		name  string
 		setup func(*fsys.Fake)
 	}{
 		{
-			name: "unreadable",
+			name: "explicit without port",
 			setup: func(fs *fsys.Fake) {
-				fs.Files[portFile] = []byte("28231")
-				fs.Errors[portFile] = os.ErrPermission
+				fs.Files[configFile] = []byte("issue_prefix: r\ngc.endpoint_origin: explicit\ngc.endpoint_status: verified\n")
 			},
 		},
 		{
-			name: "malformed",
+			name: "bind-address host",
 			setup: func(fs *fsys.Fake) {
-				fs.Files[portFile] = []byte("not-a-port")
+				fs.Files[configFile] = []byte("issue_prefix: r\ngc.endpoint_origin: explicit\ngc.endpoint_status: verified\ndolt.host: 0.0.0.0\ndolt.port: \"28231\"\n")
 			},
 		},
 		{
-			name: "out-of-range",
+			name: "unreadable config",
 			setup: func(fs *fsys.Fake) {
-				fs.Files[portFile] = []byte("70000")
+				fs.Files[configFile] = []byte("gc.endpoint_origin: explicit\n")
+				fs.Errors[configFile] = os.ErrPermission
 			},
 		},
 	}
+}
 
-	for _, tt := range tests {
+func TestRunDoltCleanup_DryRunSkipsPurgeBytesForInvalidRigEndpointConfigWithCityConfig(t *testing.T) {
+	for _, tt := range invalidRigEndpointConfigCases() {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := fsys.NewFake()
 			fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
@@ -584,6 +617,7 @@ func TestRunDoltCleanup_DryRunSkipsPurgeBytesForInvalidRigPortWithCityConfig(t *
 					{Name: "unknown", Path: "/rigs/unknown"},
 				},
 				CityPort:          28231,
+				CityPath:          "/city",
 				PortResolution:    PortResolution{Port: 28231, Source: cityConfigDoltPortSource},
 				FS:                fs,
 				JSON:              true,
@@ -607,34 +641,8 @@ func TestRunDoltCleanup_DryRunSkipsPurgeBytesForInvalidRigPortWithCityConfig(t *
 	}
 }
 
-func TestRunDoltCleanup_ForceSkipsPurgeForInvalidRigPortWithCityConfig(t *testing.T) {
-	portFile := "/rigs/unknown/.beads/dolt-server.port"
-	tests := []struct {
-		name  string
-		setup func(*fsys.Fake)
-	}{
-		{
-			name: "unreadable",
-			setup: func(fs *fsys.Fake) {
-				fs.Files[portFile] = []byte("28231")
-				fs.Errors[portFile] = os.ErrPermission
-			},
-		},
-		{
-			name: "malformed",
-			setup: func(fs *fsys.Fake) {
-				fs.Files[portFile] = []byte("not-a-port")
-			},
-		},
-		{
-			name: "out-of-range",
-			setup: func(fs *fsys.Fake) {
-				fs.Files[portFile] = []byte("70000")
-			},
-		},
-	}
-
-	for _, tt := range tests {
+func TestRunDoltCleanup_ForceSkipsPurgeForInvalidRigEndpointConfigWithCityConfig(t *testing.T) {
+	for _, tt := range invalidRigEndpointConfigCases() {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := fsys.NewFake()
 			fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
@@ -660,6 +668,7 @@ func TestRunDoltCleanup_ForceSkipsPurgeForInvalidRigPortWithCityConfig(t *testin
 					{Name: "unknown", Path: "/rigs/unknown"},
 				},
 				CityPort:          28231,
+				CityPath:          "/city",
 				PortResolution:    PortResolution{Port: 28231, Source: cityConfigDoltPortSource},
 				FS:                fs,
 				JSON:              true,
@@ -693,10 +702,14 @@ func TestRunDoltCleanup_ForceSkipsPurgeForInvalidRigPortWithCityConfig(t *testin
 	}
 }
 
-func TestRunDoltCleanup_ForceSkipsPurgeWhenRigPortIsUnknownWithResolvedPort(t *testing.T) {
+func TestRunDoltCleanup_ForceSkipsPurgeWhenScopeSharingUnproven(t *testing.T) {
+	// No canonical configs anywhere and no managed runtime state: nothing
+	// proves which scopes share the resolved server, and the resolution
+	// source is neither the legacy fallback nor the city config. Every scope
+	// must be excluded from purge accounting — the old port-file vouching is
+	// gone (city-scale plan P1.7).
 	fs := fsys.NewFake()
 	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
-	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231")
 	putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
 		"db_a/data.bin": 100,
 	})
@@ -718,6 +731,8 @@ func TestRunDoltCleanup_ForceSkipsPurgeWhenRigPortIsUnknownWithResolvedPort(t *t
 			{Name: "unknown", Path: "/rigs/unknown"},
 		},
 		FS:                fs,
+		CityPath:          "/city",
+		PortResolution:    PortResolution{Port: 28231, Source: liveDoltHandleSource},
 		JSON:              true,
 		Force:             true,
 		DoltClient:        client,
@@ -732,16 +747,76 @@ func TestRunDoltCleanup_ForceSkipsPurgeWhenRigPortIsUnknownWithResolvedPort(t *t
 	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
 		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
 	}
-	if r.Purge.BytesReclaimed != 100 {
-		t.Fatalf("Purge.BytesReclaimed = %d, want only proven resolved-server bytes", r.Purge.BytesReclaimed)
+	if r.Purge.BytesReclaimed != 0 {
+		t.Fatalf("Purge.BytesReclaimed = %d, want 0 when no scope provably shares the resolved server", r.Purge.BytesReclaimed)
 	}
-	wantPurged := []string{"hq"}
-	if !equalStringSlice(purgedNames, wantPurged) {
-		t.Fatalf("purged DBs = %v, want %v", purgedNames, wantPurged)
+	if len(purgedNames) != 0 {
+		t.Fatalf("purged DBs = %v, want none", purgedNames)
 	}
 	if r.Summary.ErrorsTotal != 0 {
 		t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
 	}
+}
+
+func TestRigSharesResolvedDoltServer_ContractResolutionDecides(t *testing.T) {
+	resolved := PortResolution{Port: 28231, Source: liveDoltHandleSource}
+
+	t.Run("city scope with canonical endpoint shares", func(t *testing.T) {
+		fs := fsys.NewFake()
+		putCanonicalCityConfig(fs)
+		opts := cleanupOptions{FS: fs, CityPath: "/city", PortResolution: resolved}
+		if !rigSharesResolvedDoltServer(resolverRig{Name: "city", Path: "/city", HQ: true}, opts) {
+			t.Error("city scope on the resolved canonical port must share")
+		}
+	})
+
+	t.Run("inherited rig under canonical city shares", func(t *testing.T) {
+		fs := fsys.NewFake()
+		putCanonicalCityConfig(fs)
+		opts := cleanupOptions{FS: fs, CityPath: "/city", PortResolution: resolved}
+		// Rig has no canonical config: it inherits the city endpoint, which
+		// provably matches the resolved port.
+		if !rigSharesResolvedDoltServer(resolverRig{Name: "r", Path: "/rigs/r"}, opts) {
+			t.Error("inherited rig under canonical city must share")
+		}
+	})
+
+	t.Run("explicit rig on a different port does not share", func(t *testing.T) {
+		fs := fsys.NewFake()
+		putCanonicalCityConfig(fs)
+		putExplicitRigConfig(fs, "/rigs/r", "28232")
+		opts := cleanupOptions{FS: fs, CityPath: "/city", PortResolution: resolved}
+		if rigSharesResolvedDoltServer(resolverRig{Name: "r", Path: "/rigs/r"}, opts) {
+			t.Error("explicit rig on another port must not share")
+		}
+	})
+
+	t.Run("invalid rig config fails closed", func(t *testing.T) {
+		fs := fsys.NewFake()
+		putCanonicalCityConfig(fs)
+		fs.Files["/rigs/r/.beads/config.yaml"] = []byte("issue_prefix: r\ngc.endpoint_origin: explicit\n")
+		opts := cleanupOptions{FS: fs, CityPath: "/city", PortResolution: resolved}
+		if rigSharesResolvedDoltServer(resolverRig{Name: "r", Path: "/rigs/r"}, opts) {
+			t.Error("invalid canonical rig config must fail closed")
+		}
+	})
+
+	t.Run("unresolvable managed scope keeps conservative fallback semantics", func(t *testing.T) {
+		fs := fsys.NewFake()
+		opts := cleanupOptions{
+			FS:             fs,
+			CityPath:       "/city",
+			CityPort:       28231,
+			PortResolution: PortResolution{Port: 28231, Source: cityConfigDoltPortSource},
+		}
+		if !rigSharesResolvedDoltServer(resolverRig{Name: "r", Path: "/rigs/r"}, opts) {
+			t.Error("city-config-selected port must vouch for unresolvable scopes")
+		}
+		opts.PortResolution = PortResolution{Port: 28231, Source: liveDoltHandleSource}
+		if rigSharesResolvedDoltServer(resolverRig{Name: "r", Path: "/rigs/r"}, opts) {
+			t.Error("non-fallback, non-city-config sources must not vouch for unresolvable scopes")
+		}
+	})
 }
 
 // fakeCleanupDoltClientCustomPurge is like fakeCleanupDoltClient but lets a

--- a/cmd/gc/dolt_port_live.go
+++ b/cmd/gc/dolt_port_live.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Live managed-dolt port resolution (city-scale plan P1.7, incident class 4).
+//
+// .beads/dolt-server.port and .beads/proxied_server_client_info.json are
+// status files. gc never trusts them for endpoint resolution: the port file
+// is a compatibility mirror for raw bd (bd owns the writes), and it has lied
+// in production — a surviving writer clobbered it with a proxy's ephemeral
+// port (vp-w7tc) even after the pooling fix. The resolution order here is
+// live state only:
+//
+//  1. managed-server live handle — published/provider Dolt runtime state,
+//     validated against the live process (PID alive, port reachable,
+//     data-dir match) by currentResolvableManagedDoltPort.
+//  2. process-table discovery — a live `dolt sql-server` listener whose
+//     --config or --data-dir argv matches the city's managed runtime layout.
+//  3. error — never the status files.
+
+// Live source labels recorded in PortResolutionAttempt.Source for the two
+// live resolution steps.
+const (
+	liveDoltHandleSource  = "managed dolt runtime state"
+	liveDoltProcessSource = "live dolt process table"
+)
+
+// errNoLiveDoltEndpoint reports that no live managed dolt endpoint could be
+// resolved from runtime state or the process table. It is deliberately NOT
+// recoverable via .beads/dolt-server.port: that file is a status file and is
+// never consulted (city-scale plan P1.7).
+var errNoLiveDoltEndpoint = errors.New("no live managed dolt endpoint")
+
+// liveDoltPortResolution is the outcome of the live resolution chain.
+// Attempts records every source consulted, in order and in the same shape
+// the cleanup port resolver reports, so callers can splice the trail into
+// operator-facing fallback warnings.
+type liveDoltPortResolution struct {
+	Port     int
+	Source   string
+	Attempts []PortResolutionAttempt
+}
+
+// liveDoltPortResolver resolves the managed dolt SQL port for a city from
+// live state only. The function fields are seams for unit tests; production
+// callers construct it via newLiveDoltPortResolver.
+type liveDoltPortResolver struct {
+	// managedHandlePort returns the validated managed-server port from the
+	// live runtime handle, or "" when unavailable.
+	managedHandlePort func(cityPath string) string
+	// runtimeLayout resolves the city's managed dolt runtime layout (data
+	// dir and config file) used to match process-table candidates.
+	runtimeLayout func(cityPath string) (managedDoltRuntimeLayout, error)
+	// discoverProcesses enumerates live `dolt sql-server` processes with
+	// their listening ports (lsof/ps on hosts without /proc).
+	discoverProcesses func() ([]DoltProcInfo, error)
+}
+
+// newLiveDoltPortResolver returns the production resolver wired to the
+// managed runtime handle and the process-table discovery helpers.
+func newLiveDoltPortResolver() liveDoltPortResolver {
+	return liveDoltPortResolver{
+		managedHandlePort: currentResolvableManagedDoltPort,
+		runtimeLayout:     resolveManagedDoltRuntimeLayout,
+		discoverProcesses: discoverDoltProcesses,
+	}
+}
+
+// resolve runs the live resolution chain for cityPath. On success the
+// returned resolution carries the port and the winning source; on failure
+// the error explains why and the attempt trail records every source
+// consulted. A nil error implies a valid Port.
+func (r liveDoltPortResolver) resolve(cityPath string) (liveDoltPortResolution, error) {
+	res := liveDoltPortResolution{}
+	if strings.TrimSpace(cityPath) == "" {
+		res.Attempts = append(res.Attempts,
+			PortResolutionAttempt{Source: liveDoltHandleSource, Status: "not-provided"},
+			PortResolutionAttempt{Source: liveDoltProcessSource, Status: "not-provided"},
+		)
+		return res, fmt.Errorf("%w: no city path provided", errNoLiveDoltEndpoint)
+	}
+
+	// Step 1: managed-server live handle.
+	if raw := strings.TrimSpace(r.managedHandlePort(cityPath)); raw != "" {
+		port, err := strconv.Atoi(raw)
+		if err == nil && validDoltPort(port) {
+			res.Attempts = append(res.Attempts, PortResolutionAttempt{
+				Source: liveDoltHandleSource,
+				Status: "found",
+				Detail: raw,
+			})
+			res.Port = port
+			res.Source = liveDoltHandleSource
+			return res, nil
+		}
+		res.Attempts = append(res.Attempts, PortResolutionAttempt{
+			Source: liveDoltHandleSource,
+			Status: "error",
+			Detail: fmt.Sprintf("invalid managed runtime port %q", raw),
+		})
+	} else {
+		res.Attempts = append(res.Attempts, PortResolutionAttempt{Source: liveDoltHandleSource, Status: "not-found"})
+	}
+
+	// Step 2: process-table discovery scoped to the managed runtime layout.
+	layout, err := r.runtimeLayout(cityPath)
+	if err != nil {
+		res.Attempts = append(res.Attempts, PortResolutionAttempt{
+			Source: liveDoltProcessSource,
+			Status: "error",
+			Detail: fmt.Sprintf("resolve managed dolt runtime layout: %v", err),
+		})
+		return res, fmt.Errorf("resolving managed dolt runtime layout for %s: %w", cityPath, err)
+	}
+	procs, err := r.discoverProcesses()
+	if err != nil {
+		res.Attempts = append(res.Attempts, PortResolutionAttempt{
+			Source: liveDoltProcessSource,
+			Status: "error",
+			Detail: fmt.Sprintf("discover dolt processes: %v", err),
+		})
+		return res, fmt.Errorf("discovering dolt processes for %s: %w", cityPath, err)
+	}
+	ports := map[int]struct{}{}
+	for _, proc := range procs {
+		if !doltProcMatchesManagedLayout(proc, layout) {
+			continue
+		}
+		for _, port := range proc.Ports {
+			if validDoltPort(port) {
+				ports[port] = struct{}{}
+			}
+		}
+	}
+	switch len(ports) {
+	case 0:
+		res.Attempts = append(res.Attempts, PortResolutionAttempt{Source: liveDoltProcessSource, Status: "not-found"})
+		return res, fmt.Errorf("%w for %s", errNoLiveDoltEndpoint, cityPath)
+	case 1:
+		for port := range ports {
+			res.Attempts = append(res.Attempts, PortResolutionAttempt{
+				Source: liveDoltProcessSource,
+				Status: "found",
+				Detail: strconv.Itoa(port),
+			})
+			res.Port = port
+			res.Source = liveDoltProcessSource
+		}
+		return res, nil
+	default:
+		sorted := make([]int, 0, len(ports))
+		for port := range ports {
+			sorted = append(sorted, port)
+		}
+		sort.Ints(sorted)
+		detail := fmt.Sprintf("ambiguous live dolt listeners for %s on ports %v; pass --port to disambiguate", cityPath, sorted)
+		res.Attempts = append(res.Attempts, PortResolutionAttempt{
+			Source: liveDoltProcessSource,
+			Status: "error",
+			Detail: detail,
+		})
+		return res, errors.New(detail)
+	}
+}
+
+// doltProcMatchesManagedLayout reports whether a discovered dolt sql-server
+// process serves the city's managed runtime layout, matched by its --config
+// or --data-dir argv value (path-normalized via samePath).
+func doltProcMatchesManagedLayout(p DoltProcInfo, layout managedDoltRuntimeLayout) bool {
+	if cfg := extractConfigPath(p.Argv); cfg != "" && strings.TrimSpace(layout.ConfigFile) != "" && samePath(cfg, layout.ConfigFile) {
+		return true
+	}
+	if dd, ok := argvFlagValue(p.Argv, "--data-dir"); ok && dd != "" && strings.TrimSpace(layout.DataDir) != "" && samePath(dd, layout.DataDir) {
+		return true
+	}
+	return false
+}

--- a/cmd/gc/dolt_port_live_test.go
+++ b/cmd/gc/dolt_port_live_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func fakeLayoutFn(layout managedDoltRuntimeLayout) func(string) (managedDoltRuntimeLayout, error) {
+	return func(string) (managedDoltRuntimeLayout, error) { return layout, nil }
+}
+
+func testManagedLayout() managedDoltRuntimeLayout {
+	return managedDoltRuntimeLayout{
+		DataDir:    "/city/.beads/dolt",
+		ConfigFile: "/city/.gc/runtime/packs/dolt/config.yaml",
+	}
+}
+
+func attemptStatuses(attempts []PortResolutionAttempt) []string {
+	out := make([]string, 0, len(attempts))
+	for _, a := range attempts {
+		out = append(out, a.Source+":"+a.Status)
+	}
+	return out
+}
+
+func TestLiveDoltPortResolver_ManagedHandleWins(t *testing.T) {
+	r := liveDoltPortResolver{
+		managedHandlePort: func(cityPath string) string {
+			if cityPath != "/city" {
+				t.Errorf("managedHandlePort cityPath = %q, want /city", cityPath)
+			}
+			return "28231"
+		},
+		runtimeLayout: fakeLayoutFn(testManagedLayout()),
+		discoverProcesses: func() ([]DoltProcInfo, error) {
+			t.Error("process table consulted although the managed handle resolved")
+			return nil, nil
+		},
+	}
+
+	got, err := r.resolve("/city")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Port != 28231 {
+		t.Errorf("Port = %d, want 28231", got.Port)
+	}
+	if got.Source != liveDoltHandleSource {
+		t.Errorf("Source = %q, want %q", got.Source, liveDoltHandleSource)
+	}
+	if len(got.Attempts) != 1 || got.Attempts[0].Status != "found" {
+		t.Errorf("Attempts = %v, want single found entry", attemptStatuses(got.Attempts))
+	}
+}
+
+func TestLiveDoltPortResolver_ProcessTableByConfigPath(t *testing.T) {
+	layout := testManagedLayout()
+	r := liveDoltPortResolver{
+		managedHandlePort: func(string) string { return "" },
+		runtimeLayout:     fakeLayoutFn(layout),
+		discoverProcesses: func() ([]DoltProcInfo, error) {
+			return []DoltProcInfo{
+				// Foreign server: different config, must be ignored.
+				{PID: 1, Ports: []int{4000}, Argv: []string{"dolt", "sql-server", "--config", "/elsewhere/config.yaml"}},
+				{PID: 2, Ports: []int{28231}, Argv: []string{"dolt", "sql-server", "--config", layout.ConfigFile}},
+			}, nil
+		},
+	}
+
+	got, err := r.resolve("/city")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Port != 28231 {
+		t.Errorf("Port = %d, want 28231", got.Port)
+	}
+	if got.Source != liveDoltProcessSource {
+		t.Errorf("Source = %q, want %q", got.Source, liveDoltProcessSource)
+	}
+	want := []string{
+		liveDoltHandleSource + ":not-found",
+		liveDoltProcessSource + ":found",
+	}
+	if fmt.Sprint(attemptStatuses(got.Attempts)) != fmt.Sprint(want) {
+		t.Errorf("Attempts = %v, want %v", attemptStatuses(got.Attempts), want)
+	}
+}
+
+func TestLiveDoltPortResolver_ProcessTableByDataDir(t *testing.T) {
+	layout := testManagedLayout()
+	r := liveDoltPortResolver{
+		managedHandlePort: func(string) string { return "" },
+		runtimeLayout:     fakeLayoutFn(layout),
+		discoverProcesses: func() ([]DoltProcInfo, error) {
+			return []DoltProcInfo{
+				{PID: 2, Ports: []int{19999}, Argv: []string{"dolt", "sql-server", "--data-dir", layout.DataDir}},
+			}, nil
+		},
+	}
+
+	got, err := r.resolve("/city")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Port != 19999 || got.Source != liveDoltProcessSource {
+		t.Errorf("got %+v, want port 19999 from %q", got, liveDoltProcessSource)
+	}
+}
+
+func TestLiveDoltPortResolver_NoLiveEndpointErrors(t *testing.T) {
+	r := liveDoltPortResolver{
+		managedHandlePort: func(string) string { return "" },
+		runtimeLayout:     fakeLayoutFn(testManagedLayout()),
+		discoverProcesses: func() ([]DoltProcInfo, error) {
+			return []DoltProcInfo{
+				// Listener with a foreign data dir: not ours.
+				{PID: 1, Ports: []int{4000}, Argv: []string{"dolt", "sql-server", "--data-dir", "/elsewhere/dolt"}},
+			}, nil
+		},
+	}
+
+	got, err := r.resolve("/city")
+	if !errors.Is(err, errNoLiveDoltEndpoint) {
+		t.Fatalf("err = %v, want errNoLiveDoltEndpoint", err)
+	}
+	if got.Port != 0 {
+		t.Errorf("Port = %d, want 0", got.Port)
+	}
+	want := []string{
+		liveDoltHandleSource + ":not-found",
+		liveDoltProcessSource + ":not-found",
+	}
+	if fmt.Sprint(attemptStatuses(got.Attempts)) != fmt.Sprint(want) {
+		t.Errorf("Attempts = %v, want %v", attemptStatuses(got.Attempts), want)
+	}
+}
+
+func TestLiveDoltPortResolver_MatchingProcessWithoutPortsIsNotFound(t *testing.T) {
+	layout := testManagedLayout()
+	r := liveDoltPortResolver{
+		managedHandlePort: func(string) string { return "" },
+		runtimeLayout:     fakeLayoutFn(layout),
+		discoverProcesses: func() ([]DoltProcInfo, error) {
+			// Matching process that is not (yet) listening.
+			return []DoltProcInfo{{PID: 2, Argv: []string{"dolt", "sql-server", "--data-dir", layout.DataDir}}}, nil
+		},
+	}
+
+	_, err := r.resolve("/city")
+	if !errors.Is(err, errNoLiveDoltEndpoint) {
+		t.Fatalf("err = %v, want errNoLiveDoltEndpoint", err)
+	}
+}
+
+func TestLiveDoltPortResolver_AmbiguousListenersError(t *testing.T) {
+	layout := testManagedLayout()
+	r := liveDoltPortResolver{
+		managedHandlePort: func(string) string { return "" },
+		runtimeLayout:     fakeLayoutFn(layout),
+		discoverProcesses: func() ([]DoltProcInfo, error) {
+			return []DoltProcInfo{
+				{PID: 2, Ports: []int{28231}, Argv: []string{"dolt", "sql-server", "--data-dir", layout.DataDir}},
+				{PID: 3, Ports: []int{29000}, Argv: []string{"dolt", "sql-server", "--config", layout.ConfigFile}},
+			}, nil
+		},
+	}
+
+	got, err := r.resolve("/city")
+	if err == nil {
+		t.Fatalf("resolve succeeded with ambiguous listeners: %+v", got)
+	}
+	if errors.Is(err, errNoLiveDoltEndpoint) {
+		t.Fatalf("ambiguity reported as no-endpoint: %v", err)
+	}
+	if !strings.Contains(err.Error(), "28231") || !strings.Contains(err.Error(), "29000") {
+		t.Errorf("error %q does not name the candidate ports", err)
+	}
+	last := got.Attempts[len(got.Attempts)-1]
+	if last.Source != liveDoltProcessSource || last.Status != "error" {
+		t.Errorf("last attempt = %+v, want process-table error", last)
+	}
+}
+
+func TestLiveDoltPortResolver_DiscoveryFailureErrors(t *testing.T) {
+	r := liveDoltPortResolver{
+		managedHandlePort: func(string) string { return "" },
+		runtimeLayout:     fakeLayoutFn(testManagedLayout()),
+		discoverProcesses: func() ([]DoltProcInfo, error) {
+			return nil, errors.New("ps exploded")
+		},
+	}
+
+	got, err := r.resolve("/city")
+	if err == nil {
+		t.Fatal("resolve succeeded although discovery failed")
+	}
+	last := got.Attempts[len(got.Attempts)-1]
+	if last.Source != liveDoltProcessSource || last.Status != "error" || !strings.Contains(last.Detail, "ps exploded") {
+		t.Errorf("last attempt = %+v, want process-table discovery error", last)
+	}
+}
+
+func TestLiveDoltPortResolver_InvalidHandleValueFallsThrough(t *testing.T) {
+	layout := testManagedLayout()
+	r := liveDoltPortResolver{
+		managedHandlePort: func(string) string { return "not-a-port" },
+		runtimeLayout:     fakeLayoutFn(layout),
+		discoverProcesses: func() ([]DoltProcInfo, error) {
+			return []DoltProcInfo{{PID: 2, Ports: []int{28231}, Argv: []string{"dolt", "sql-server", "--data-dir", layout.DataDir}}}, nil
+		},
+	}
+
+	got, err := r.resolve("/city")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Port != 28231 || got.Source != liveDoltProcessSource {
+		t.Errorf("got %+v, want process-table fallback after invalid handle value", got)
+	}
+	if got.Attempts[0].Status != "error" {
+		t.Errorf("handle attempt = %+v, want recorded error", got.Attempts[0])
+	}
+}
+
+func TestLiveDoltPortResolver_EmptyCityPathErrors(t *testing.T) {
+	r := newLiveDoltPortResolver()
+
+	got, err := r.resolve("")
+	if !errors.Is(err, errNoLiveDoltEndpoint) {
+		t.Fatalf("err = %v, want errNoLiveDoltEndpoint", err)
+	}
+	for _, a := range got.Attempts {
+		if a.Status != "not-provided" {
+			t.Errorf("attempt %+v, want not-provided", a)
+		}
+	}
+}
+
+func TestDoltProcMatchesManagedLayout(t *testing.T) {
+	layout := testManagedLayout()
+	cases := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		{"config space form", []string{"dolt", "sql-server", "--config", layout.ConfigFile}, true},
+		{"config equals form", []string{"dolt", "sql-server", "--config=" + layout.ConfigFile}, true},
+		{"data-dir space form", []string{"dolt", "sql-server", "--data-dir", layout.DataDir}, true},
+		{"data-dir equals form", []string{"dolt", "sql-server", "--data-dir=" + layout.DataDir}, true},
+		{"foreign config", []string{"dolt", "sql-server", "--config", "/other/config.yaml"}, false},
+		{"foreign data dir", []string{"dolt", "sql-server", "--data-dir", "/other/dolt"}, false},
+		{"no flags", []string{"dolt", "sql-server"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := doltProcMatchesManagedLayout(DoltProcInfo{Argv: tc.argv}, layout); got != tc.want {
+				t.Errorf("doltProcMatchesManagedLayout(%v) = %v, want %v", tc.argv, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -17,6 +17,7 @@ implicit-import-cache
 deprecated-attachment-fields
 dolt-topology
 dolt-drift
+port-file-consistency
 config-valid
 legacy-suspended-field
 config-refs


### PR DESCRIPTION
## Summary

Managed-Dolt tooling treated the on-disk `dolt-server.port` file as the authoritative source of the running server's port. That file goes stale on crash/restart (or when a proxy rewrites it), so cleanup could target the wrong port and the doctor had no way to flag the drift. This is the "port-file de-authority" change: resolve the live port from process/runtime state and demote the file to a hint.

Three commits, smallest-first:

1. **`feat(dolt)`** — a live managed-Dolt port resolver (`dolt_port_live.go`): derives the actual listening port from process state rather than the file, returning a typed `liveDoltPortResolution`.
2. **`feat(dolt-cleanup)`** — cleanup resolves and protects via that live state, never the port file, so it can't kill/keep the wrong server.
3. **`feat(doctor)`** — a `port-file-consistency` doctor check that compares the file against live resolution and reports drift; plus a writer TODO and a client-info log demotion.

## Testing

- [x] `go test ./cmd/gc/` port-file checks pass locally (`PortFile`/`DoltPort`/`LivePort`/`CleanupPort`: fixed/unavailable/error live-resolution fakes)
- [x] `go vet ./cmd/gc/`, `go build ./...`
- [ ] Full `make check` — CI

## Checklist

- [x] Added tests for each layer
- [x] No user-facing API change (new doctor check only)
- [ ] No breaking changes
