### PR TITLE
fix(orders): scope digest-generate to city to stop non-firing per-rig copies

### DIFF
--- a/examples/gastown/packs/gastown/orders/digest-generate.toml
+++ b/examples/gastown/packs/gastown/orders/digest-generate.toml
@@ -1,5 +1,12 @@
 [order]
 description = "Generate daily code digest across all rigs"
+# City-scoped: one digest already covers every rig, so register a single
+# city-level instance instead of one per importing rig. Without this, the
+# gastown pack's per-rig import projects a digest-generate order onto every
+# rig; those per-rig instances never fire (only the city instance reaches the
+# city-level `dog` pool), so they sit perpetually overdue and trip the
+# order-firing-current doctor check.
+scope = "city"
 formula = "mol-digest-generate"
 trigger = "cooldown"
 interval = "24h"


### PR DESCRIPTION
## Problem

The per-rig `digest-generate` order never fires. On a live city it showed **~85h overdue on every rig** (24h interval) and was the sole failure flagged by `gc doctor`'s `order-firing-current` check, while daily digests kept being generated normally.

## Root cause

`examples/gastown/packs/gastown/orders/digest-generate.toml` has no `scope`, so it defaults to **rig-scoped**. The `gastown` pack is imported per-rig, so `orderdiscovery.ScanAll` stamps a `digest-generate` instance onto **every** rig (`.Rig = rigName`) in addition to the city-level instance.

Only the **city-level** instance actually fires — it's the one that reaches the city-level `dog` pool. The per-rig instances are projected and reported "due" by `gc order check` / the doctor, but the rig dispatchers never fire them. Verified on a live city: the only digest events in any dispatcher trace are `order.fired subject=digest-generate` (no `:rig:` suffix); there are zero `digest-generate:rig:<rig>` events.

So the per-rig copies are structurally redundant — one digest already covers all rigs — and they only generate perpetual false-overdue noise plus a doctor failure.

## Fix

Mark the order `scope = "city"`. Per `Order.IsCityScoped()` and `orderdiscovery.ScanAll`'s `cityScopedSeen` dedup, the order is then registered **exactly once** at the city level and the per-rig projections are dropped:

```go
// internal/orderdiscovery/discovery.go
if aa[i].IsCityScoped() {
    if cityScopedSeen[aa[i].Name] { continue } // dedup per-rig copies
    cityScopedSeen[aa[i].Name] = true
    promotedCityOrders = append(promotedCityOrders, aa[i]) // Rig left empty
    continue
}
aa[i].Rig = rigName // <- the per-rig instances this fix removes
```

`cityScopedSeen` is seeded from `cityOrders`, so the already-firing city-level instance is preserved — there is no window where the digest stops firing.

## Blast radius

- One-line semantic change (plus an explanatory comment) to a single order TOML.
- `scope = "city"` is already validated (`orders.Validate`: `case "", "city", "rig"`) and exercised for agents/named-sessions; this is its first use on an order in-tree, but the order path (`IsCityScoped` → `discovery.go`) is wired and covered.
- No test references the real `digest-generate` order (the order tests use a synthetic `digest`/`mol-digest` fixture), so none should need updating.

## Verification

After this change, `gc order check` lists a single city-level `digest-generate` (no per-rig rows), and `gc doctor`'s `order-firing-current` check no longer reports per-rig digest staleness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
