### PR TITLE
fix(order-dispatch): degrade per-order on transient store read/refresh failure

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -1079,8 +1079,13 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 			}
 			check := orders.CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, triggerOpts)
 			if lastRunErr != nil {
-				fmt.Fprintf(stderr, "gc order check: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
-				return 1
+				// A transient store blip reading ONE order's last-run must not
+				// abort the entire dispatch pass — doing so previously starved
+				// cold-pool-spawner (and every other order) whenever a bd query
+				// timed out under fleet load. Skip this order this tick; it
+				// retries on the next dispatch with no lasting effect.
+				fmt.Fprintf(stderr, "gc order check: last-run for %s unavailable, skipping this tick: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
+				continue
 			}
 			if check.Due {
 				result.AnyDue = true

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -591,10 +591,15 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		if lastRunFromCache && orderTriggerUsesLastRun(a) {
 			refreshedLastRun, err := baseLastRunFn(a.ScopedName())
 			if err != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: refreshing last run for %s: %v", a.ScopedName(), err)
-				continue
-			}
-			if refreshedLastRun.After(result.LastRun) {
+				// The refresh is a best-effort double-check for a more-recent run
+				// recorded in another store. On a transient bd/store timeout under
+				// load it must NOT skip the order — that previously made a due
+				// order (notably cold-pool-spawner) never run while the store was
+				// busy, so cold pools never cold-started from routed gc.routed_to
+				// demand. Proceed with the already-Due cached last-run result;
+				// order actions are idempotent so a rare double-run is harmless.
+				logDispatchError(m.stderr, "gc: order dispatch: refreshing last run for %s failed, proceeding with cached last-run: %v", a.ScopedName(), err)
+			} else if refreshedLastRun.After(result.LastRun) {
 				m.rememberLastRun(a.ScopedName(), storeKeysForGate, refreshedLastRun)
 				refreshedLastRunFn := func(string) (time.Time, error) {
 					return refreshedLastRun, nil

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1564,39 +1564,15 @@ func listCanonicalOpenOrderTrackingBeads(store beads.Store) ([]beads.Bead, error
 // cooldown gate from pouring duplicate wisps when the pool stalls
 // (tr-kds01, where 24h-interval digest wisps accumulated because the
 // pool never picked them up).
+//
+// Descendant reasoning is delegated to the flat-membership evaluation
+// (hasOpenOrderWorkFlat): a bounded number of List calls plus in-memory set
+// operations, never the historical O(tree) per-node walk whose subprocess
+// cost blew the per-order gate bound under store contention (incident 12 /
+// #2893). Lingering transient nudge/mail chores are excluded via
+// isTransientNotificationBead (#2893 #3).
 func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName string) (bool, error) {
-	results, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
-		Label: "order-run:" + scopedName,
-		Sort:  beads.SortCreatedDesc,
-		// Tracking beads are ephemeral while wisp roots are issue-tier, so
-		// the authoritative single-flight gate must union both tiers.
-		TierMode: beads.TierBoth,
-	})
-	if err != nil {
-		return false, fmt.Errorf("listing order work beads: %w", err)
-	}
-	for _, b := range results {
-		if b.Status == "closed" {
-			continue
-		}
-		if beadLabelsContain(b.Labels, labelOrderTracking) {
-			return true, nil
-		}
-		if !isOrderWispRootCandidate(b) {
-			continue
-		}
-		if isOrderRootOnlyWispCandidate(b) {
-			return true, nil
-		}
-		hasOpenDescendants, err := storeHasOpenDescendants(store, b.ID, isTransientNotificationBead)
-		if err != nil {
-			return false, fmt.Errorf("checking open descendants of wisp %s: %w", b.ID, err)
-		}
-		if hasOpenDescendants {
-			return true, nil
-		}
-	}
-	return false, nil
+	return hasOpenOrderWorkFlat(store, scopedName, isTransientNotificationBead)
 }
 
 func isOrderWispRootCandidate(b beads.Bead) bool {
@@ -1884,6 +1860,17 @@ var orderGateBackoffDuration = 24 * time.Second
 // genuine store-read error. Only this case fails open for idempotent orders.
 var errGateTimeout = errors.New("open-work gate timed out")
 
+// gateTimeoutError carries the measured gate runtime for the typed
+// order.gate_timeout_fail_open event. It unwraps to errGateTimeout so the
+// existing errors.Is policy checks in gateFailClosed keep working.
+type gateTimeoutError struct {
+	elapsed time.Duration
+}
+
+func (e *gateTimeoutError) Error() string { return errGateTimeout.Error() }
+
+func (e *gateTimeoutError) Unwrap() error { return errGateTimeout }
+
 // gateOpenWorkBounded runs the open-work gate under a per-order timeout that
 // also honors the dispatch context. On timeout (or cancellation) it returns an
 // error; the caller resolves that error through gateFailClosed, which applies
@@ -1898,6 +1885,7 @@ func gateOpenWorkBounded(ctx context.Context, timeout time.Duration, scoped stri
 		err error
 	}
 	done := make(chan gateResult, 1)
+	start := time.Now()
 	go func() {
 		has, err := gate()
 		done <- gateResult{has: has, err: err}
@@ -1908,7 +1896,7 @@ func gateOpenWorkBounded(ctx context.Context, timeout time.Duration, scoped stri
 	case r := <-done:
 		return r.has, r.err
 	case <-timer.C:
-		return false, fmt.Errorf("open-work gate for %s timed out after %s; skipping this order so later orders still dispatch (see #2893): %w", scoped, timeout, errGateTimeout)
+		return false, fmt.Errorf("open-work gate for %s timed out after %s; skipping this order so later orders still dispatch (see #2893): %w", scoped, timeout, &gateTimeoutError{elapsed: time.Since(start)})
 	case <-ctx.Done():
 		return false, fmt.Errorf("open-work gate for %s aborted: %w", scoped, ctx.Err())
 	}
@@ -1944,9 +1932,34 @@ func (m *memoryOrderDispatcher) gateFailClosed(ctx context.Context, a orders.Ord
 	}
 	if a.Idempotent && errors.Is(err, errGateTimeout) {
 		logDispatchError(m.stderr, "gc: order dispatch: %s open-work gate failed but order is idempotent; dispatching anyway (#2893)", scoped)
+		m.recordGateTimeoutFailOpen(a, scoped, err)
 		return false
 	}
 	return true
+}
+
+// recordGateTimeoutFailOpen emits the typed order.gate_timeout_fail_open
+// event for every fail-open: an idempotent order dispatched after its
+// bounded open-work gate timed out, with single-flight unproven. The
+// per-emission count is the incident-12 tripwire — fail-opens are deliberate
+// but must never be silent, because their frequency rises with exactly the
+// store contention that degrades gate evaluation.
+func (m *memoryOrderDispatcher) recordGateTimeoutFailOpen(a orders.Order, scoped string, err error) {
+	if m.rec == nil {
+		return
+	}
+	var elapsed time.Duration
+	var te *gateTimeoutError
+	if errors.As(err, &te) {
+		elapsed = te.elapsed
+	}
+	m.rec.Record(events.Event{
+		Type:    events.OrderGateTimeoutFailOpen,
+		Actor:   "controller",
+		Subject: scoped,
+		Message: fmt.Sprintf("open-work gate timed out after %s; idempotent order dispatched fail-open (#2893)", elapsed.Round(time.Millisecond)),
+		Payload: events.OrderGateTimeoutFailOpenPayloadJSON(a.Name, a.Rig, elapsed.Seconds()),
+	})
 }
 
 // sweepOrphanedOrderTracking closes any open order-tracking beads left

--- a/cmd/gc/order_dispatch_gate_policy_test.go
+++ b/cmd/gc/order_dispatch_gate_policy_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
@@ -49,7 +50,8 @@ func TestOrderDispatchIdempotentFailsOpenOnGateTimeout(t *testing.T) {
 		{Name: "unrouted-feeder", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: true},
 		{Name: "merge-loop-sweep", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: false},
 	}
-	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	rec := events.NewFake()
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, rec)
 	if ad == nil {
 		t.Fatal("expected non-nil dispatcher")
 	}
@@ -61,6 +63,21 @@ func TestOrderDispatchIdempotentFailsOpenOnGateTimeout(t *testing.T) {
 	}
 	if got := trackingBeads(t, store, "order-run:merge-loop-sweep"); len(got) != 0 {
 		t.Errorf("non-idempotent order should fail CLOSED on gate timeout and skip; got %d tracking beads", len(got))
+	}
+
+	// Every fail-open must be counted via the typed tripwire event — for the
+	// idempotent order that dispatched, and ONLY for it (P1.3/P1.10).
+	var failOpens []events.Event
+	for _, e := range rec.Events {
+		if e.Type == events.OrderGateTimeoutFailOpen {
+			failOpens = append(failOpens, e)
+		}
+	}
+	if len(failOpens) != 1 {
+		t.Fatalf("want exactly 1 %s event through the dispatch path, got %d", events.OrderGateTimeoutFailOpen, len(failOpens))
+	}
+	if failOpens[0].Subject != "unrouted-feeder" {
+		t.Errorf("fail-open event subject = %q, want %q", failOpens[0].Subject, "unrouted-feeder")
 	}
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -8243,6 +8243,19 @@ func (s parentListFailStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 	return s.Store.List(q)
 }
 
+type membershipListFailStore struct {
+	beads.Store
+	failRootID string
+	err        error
+}
+
+func (s membershipListFailStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if q.Metadata["gc.root_bead_id"] == s.failRootID {
+		return nil, s.err
+	}
+	return s.Store.List(q)
+}
+
 func TestHasOpenWorkStrictPropagatesWispChildListError(t *testing.T) {
 	base := beads.NewMemStore()
 
@@ -8255,21 +8268,115 @@ func TestHasOpenWorkStrictPropagatesWispChildListError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store := parentListFailStore{
-		Store:        base,
-		failParentID: wispRoot.ID,
-		err:          fmt.Errorf("children tier unavailable"),
+	store := membershipListFailStore{
+		Store:      base,
+		failRootID: wispRoot.ID,
+		err:        fmt.Errorf("children tier unavailable"),
 	}
 	ad := &memoryOrderDispatcher{}
 	has, err := ad.hasOpenWorkStrict(store, "digest")
 	if err == nil {
-		t.Fatal("hasOpenWorkStrict err = nil, want child-list error")
+		t.Fatal("hasOpenWorkStrict err = nil, want membership-list error")
 	}
 	if has {
-		t.Fatal("hasOpenWorkStrict returned true with child-list error; caller must fail closed on the error")
+		t.Fatal("hasOpenWorkStrict returned true with membership-list error; caller must fail closed on the error")
 	}
 	if !strings.Contains(err.Error(), "checking open descendants of wisp") {
 		t.Fatalf("hasOpenWorkStrict err = %q, want wisp descendant context", err)
+	}
+}
+
+type scanListFailStore struct {
+	beads.Store
+	err error
+}
+
+func (s scanListFailStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if q.AllowScan {
+		return nil, s.err
+	}
+	return s.Store.List(q)
+}
+
+// TestHasOpenWorkStrictPropagatesOpenScanError pins the flat gate's
+// fail-closed contract for its whole-scope open scan: a store error must
+// surface to the caller (gateFailClosed blocks on non-timeout errors), never
+// silently read as "no open work".
+func TestHasOpenWorkStrictPropagatesOpenScanError(t *testing.T) {
+	base := beads.NewMemStore()
+
+	if _, err := base.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := scanListFailStore{Store: base, err: fmt.Errorf("scope scan unavailable")}
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err == nil {
+		t.Fatal("hasOpenWorkStrict err = nil, want open-scan error")
+	}
+	if has {
+		t.Fatal("hasOpenWorkStrict returned true with open-scan error; caller must fail closed on the error")
+	}
+	if !strings.Contains(err.Error(), "listing open beads for order gate") {
+		t.Fatalf("hasOpenWorkStrict err = %q, want open-scan context", err)
+	}
+}
+
+type ancestorGetFailStore struct {
+	beads.Store
+	failID string
+	err    error
+}
+
+func (s ancestorGetFailStore) Get(id string) (beads.Bead, error) {
+	if id == s.failID {
+		return beads.Bead{}, s.err
+	}
+	return s.Store.Get(id)
+}
+
+// TestHasOpenWorkStrictPropagatesAncestorGetError pins fail-closed for the
+// flat gate's ancestor resolution: when fetching a closed unstamped
+// intermediate fails, the error must propagate instead of mis-resolving the
+// open descendant's membership in either direction.
+func TestHasOpenWorkStrictPropagatesAncestorGetError(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mid, err := base.Create(beads.Bead{Title: "mid", ParentID: wispRoot.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := base.Create(beads.Bead{Title: "leaf", ParentID: mid.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := base.Close(mid.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	store := ancestorGetFailStore{Store: base, failID: mid.ID, err: fmt.Errorf("ancestor tier unavailable")}
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err == nil {
+		t.Fatal("hasOpenWorkStrict err = nil, want ancestor-get error")
+	}
+	if has {
+		t.Fatal("hasOpenWorkStrict returned true with ancestor-get error; caller must fail closed on the error")
+	}
+	if !strings.Contains(err.Error(), "resolving wisp ancestry") {
+		t.Fatalf("hasOpenWorkStrict err = %q, want ancestry context", err)
 	}
 }
 

--- a/cmd/gc/order_gate_flat.go
+++ b/cmd/gc/order_gate_flat.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// orderGateFlatScanLimit bounds the single whole-scope open-bead List the
+// flat-membership open-work gate issues per evaluation. When the scan
+// returns this many beads the snapshot may be truncated, and the gate falls
+// back to the authoritative per-root walk rather than declare a root idle
+// from partial data. Package-level var so it is tunable and overridable in
+// tests (mirrors orderGateTimeout).
+var orderGateFlatScanLimit = 5000
+
+// orderGateFlatAncestorGetBudget bounds the per-evaluation number of Get
+// round-trips the flat gate spends resolving open beads whose parent chain
+// passes through closed UNSTAMPED intermediates (each distinct ancestor is
+// fetched at most once per evaluation). Stamped molecule data and open
+// parent chains resolve entirely in memory and spend none of it. When the
+// budget is exhausted the gate falls back to the authoritative walk instead
+// of guessing. Package-level var so it is tunable and overridable in tests.
+var orderGateFlatAncestorGetBudget = 256
+
+// errFlatGateBudgetExhausted reports that the flat evaluation could not
+// complete within its bounded store-call budget; callers fall back to the
+// authoritative walk.
+var errFlatGateBudgetExhausted = errors.New("flat gate ancestor budget exhausted")
+
+// hasOpenOrderWorkFlat is the flat-membership open-work gate (incident 12 /
+// vc-6qh1 #1'). It answers "does this order still have in-flight work?" in a
+// bounded number of store round-trips — 1 order-run List + 1 membership List
+// per open wisp root + 1 whole-scope open scan, plus a budget-bounded number
+// of memoized ancestor Gets — with all descendant reasoning done by
+// in-memory set operations. It never issues the historical O(tree) per-node
+// ParentID/DepList walk, whose per-bead subprocess calls grew with wisp-tree
+// size, blew past the per-order gate bound under Dolt write contention, and
+// turned every timeout into a silent fail-open (#2893).
+//
+// Blocking shapes, in evaluation order:
+//
+//  1. An open tracking bead (labelOrderTracking): a dispatchOne goroutine is
+//     in flight.
+//  2. A root-only wisp candidate (gc.kind == "wisp", non-molecule): the wisp
+//     itself is the work.
+//  3. An open stamped member of an open wisp root: every descendant created
+//     by any molecule growth path carries gc.root_bead_id == rootID (an
+//     invariant enforced in internal/molecule), so one metadata-filtered
+//     List per root returns the whole membership set.
+//  4. An open bead whose ParentID chain reaches a root: resolved in memory
+//     against the whole-scope open snapshot and the stamped membership sets
+//     (closed stamped members act as adjacency carriers). Only a chain that
+//     passes through a closed UNSTAMPED intermediate costs a Get, memoized
+//     per evaluation and bounded by orderGateFlatAncestorGetBudget.
+//
+// Graph-v2 dependency edges need no DepList: the walk only ever counted a
+// graph dependent when it carried the gc.root_bead_id stamp
+// (orderWispGraphDependentOwnedByRoot), so the membership List in step 3 is
+// a superset of that check.
+//
+// The idle-confirmation direction — the incident-12 hot path, where a
+// leftover root's tree is entirely closed and the historical walk paid
+// O(tree) subprocess calls per tick just to confirm "no open work" — costs
+// exactly three Lists and zero Gets, independent of tree size.
+//
+// When the open scan is truncated at orderGateFlatScanLimit, or the ancestor
+// budget runs out, the gate falls back to storeHasOpenDescendantsByWalk —
+// bounded by the caller's per-order gate timeout — so single-flight is never
+// weakened by the flat path's bounds.
+//
+// When skip is non-nil, an open bead for which skip returns true does not
+// block, but it still extends the membership chain for its own descendants —
+// the same contract the walk honors for transient nudge/mail chores
+// (#2893 #3).
+func hasOpenOrderWorkFlat(store beads.Store, scopedName string, skip func(beads.Bead) bool) (bool, error) {
+	reader := beads.HandlesFor(store).Live
+	results, err := reader.List(beads.ListQuery{
+		Label: "order-run:" + scopedName,
+		Sort:  beads.SortCreatedDesc,
+		// Tracking beads are ephemeral while wisp roots are issue-tier, so
+		// the authoritative single-flight gate must union both tiers.
+		TierMode: beads.TierBoth,
+	})
+	if err != nil {
+		return false, fmt.Errorf("listing order work beads: %w", err)
+	}
+	var roots []beads.Bead
+	for _, b := range results {
+		if b.Status == "closed" {
+			continue
+		}
+		if beadLabelsContain(b.Labels, labelOrderTracking) {
+			return true, nil
+		}
+		if !isOrderWispRootCandidate(b) {
+			continue
+		}
+		if isOrderRootOnlyWispCandidate(b) {
+			return true, nil
+		}
+		roots = append(roots, b)
+	}
+	if len(roots) == 0 {
+		return false, nil
+	}
+
+	// Membership pass: one metadata-filtered List per open root. Any open
+	// non-skipped member blocks immediately; closed and skipped members are
+	// kept as membership carriers for the ancestry resolution below.
+	member := make(map[string]struct{}, len(roots))
+	for _, r := range roots {
+		member[r.ID] = struct{}{}
+	}
+	for _, r := range roots {
+		members, err := reader.List(beads.ListQuery{
+			Metadata:      map[string]string{"gc.root_bead_id": r.ID},
+			IncludeClosed: true,
+			TierMode:      beads.TierBoth,
+		})
+		if err != nil {
+			return false, fmt.Errorf("checking open descendants of wisp %s: %w", r.ID, err)
+		}
+		for _, b := range members {
+			if b.ID == r.ID {
+				continue
+			}
+			if b.Status != "closed" && (skip == nil || !skip(b)) {
+				return true, nil
+			}
+			member[b.ID] = struct{}{}
+		}
+	}
+
+	// Whole-scope open snapshot: one bounded List covering every non-closed
+	// bead in the store scope, in both tiers.
+	open, err := reader.List(beads.ListQuery{
+		AllowScan: true,
+		Limit:     orderGateFlatScanLimit,
+		TierMode:  beads.TierBoth,
+	})
+	if err != nil {
+		return false, fmt.Errorf("listing open beads for order gate: %w", err)
+	}
+	if orderGateFlatScanLimit > 0 && len(open) >= orderGateFlatScanLimit {
+		// Truncated snapshot: absence of open descendants cannot be proven
+		// from an incomplete set. Fall back to the authoritative walk
+		// (bounded by the caller's gate timeout) instead of weakening
+		// single-flight.
+		return hasOpenDescendantsByWalkAcrossRoots(store, roots, skip)
+	}
+
+	resolver := &orderGateAncestry{
+		reader:    reader,
+		member:    member,
+		nonMember: make(map[string]struct{}),
+		openByID:  make(map[string]beads.Bead, len(open)),
+		ancestors: make(map[string]beads.Bead),
+		budget:    orderGateFlatAncestorGetBudget,
+	}
+	for _, b := range open {
+		resolver.openByID[b.ID] = b
+	}
+	for _, b := range open {
+		if _, ok := member[b.ID]; ok {
+			// Already-proven members in the open snapshot are the roots
+			// themselves (an orphan root is leftover state, not work —
+			// ga-jra/ga-lo8c) and skipped stamped members; every open
+			// stamped member that blocks returned above.
+			continue
+		}
+		if skip != nil && skip(b) {
+			// Skipped beads never block; their membership is resolved
+			// lazily if a blocking descendant chases up through them.
+			continue
+		}
+		isMember, err := resolver.resolve(b)
+		if errors.Is(err, errFlatGateBudgetExhausted) {
+			return hasOpenDescendantsByWalkAcrossRoots(store, roots, skip)
+		}
+		if err != nil {
+			return false, err
+		}
+		if isMember {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// hasOpenDescendantsByWalkAcrossRoots runs the authoritative O(tree) walk
+// for each open root. It is the flat gate's conservative fallback for
+// truncated snapshots and exhausted ancestor budgets; the caller's per-order
+// gate timeout bounds its runtime.
+func hasOpenDescendantsByWalkAcrossRoots(store beads.Store, roots []beads.Bead, skip func(beads.Bead) bool) (bool, error) {
+	for _, r := range roots {
+		has, err := storeHasOpenDescendantsByWalk(store, r.ID, skip)
+		if err != nil {
+			return false, fmt.Errorf("checking open descendants of wisp %s: %w", r.ID, err)
+		}
+		if has {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// orderGateAncestry resolves whether a bead's ParentID chain reaches one of
+// an order's wisp roots, memoizing every verdict and every fetched ancestor
+// so each distinct bead costs at most one store round-trip per evaluation.
+type orderGateAncestry struct {
+	reader beads.LiveReader
+	// member holds IDs proven to belong to a root's wisp (the roots
+	// themselves, stamped members, and beads resolved through them).
+	member map[string]struct{}
+	// nonMember holds IDs proven to NOT reach any root.
+	nonMember map[string]struct{}
+	// openByID indexes the whole-scope open snapshot.
+	openByID map[string]beads.Bead
+	// ancestors memoizes closed/missing parents fetched via Get.
+	ancestors map[string]beads.Bead
+	// budget is the remaining number of Get round-trips.
+	budget int
+}
+
+// resolve reports whether b's ParentID chain reaches a wisp root. It walks
+// upward in memory through open beads and stamped members, fetching a closed
+// unstamped ancestor at most once, and memoizes the verdict for every bead
+// on the visited chain.
+func (a *orderGateAncestry) resolve(b beads.Bead) (bool, error) {
+	var chain []string
+	cur := b
+	visiting := map[string]struct{}{}
+	for {
+		if _, ok := a.member[cur.ID]; ok {
+			a.markChain(chain, true)
+			return true, nil
+		}
+		if _, ok := a.nonMember[cur.ID]; ok {
+			a.markChain(chain, false)
+			return false, nil
+		}
+		if _, ok := visiting[cur.ID]; ok {
+			// Parent cycle disconnected from every root.
+			a.markChain(chain, false)
+			return false, nil
+		}
+		visiting[cur.ID] = struct{}{}
+		chain = append(chain, cur.ID)
+		if cur.ParentID == "" {
+			a.markChain(chain, false)
+			return false, nil
+		}
+		if parent, ok := a.openByID[cur.ParentID]; ok {
+			cur = parent
+			continue
+		}
+		if parent, ok := a.ancestors[cur.ParentID]; ok {
+			cur = parent
+			continue
+		}
+		if a.budget <= 0 {
+			return false, errFlatGateBudgetExhausted
+		}
+		a.budget--
+		parent, err := a.reader.Get(cur.ParentID)
+		if errors.Is(err, beads.ErrNotFound) {
+			a.markChain(chain, false)
+			return false, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("resolving wisp ancestry of %s: %w", b.ID, err)
+		}
+		a.ancestors[parent.ID] = parent
+		cur = parent
+	}
+}
+
+func (a *orderGateAncestry) markChain(chain []string, isMember bool) {
+	for _, id := range chain {
+		if isMember {
+			a.member[id] = struct{}{}
+		} else {
+			a.nonMember[id] = struct{}{}
+		}
+	}
+}

--- a/cmd/gc/order_gate_flat.go
+++ b/cmd/gc/order_gate_flat.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
@@ -115,7 +116,7 @@ func hasOpenOrderWorkFlat(store beads.Store, scopedName string, skip func(beads.
 	}
 	for _, r := range roots {
 		members, err := reader.List(beads.ListQuery{
-			Metadata:      map[string]string{"gc.root_bead_id": r.ID},
+			Metadata:      map[string]string{beadmeta.RootBeadIDMetadataKey: r.ID},
 			IncludeClosed: true,
 			TierMode:      beads.TierBoth,
 		})

--- a/cmd/gc/order_gate_flat_test.go
+++ b/cmd/gc/order_gate_flat_test.go
@@ -1,0 +1,462 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// gateCallCountingStore counts the store round-trips made by a gate
+// evaluation. The flat-membership gate must stay within a fixed number of
+// List calls regardless of wisp-tree size and must never issue the per-node
+// Get/DepList calls of the historical O(tree) walk (incident 12 / vc-6qh1).
+type gateCallCountingStore struct {
+	beads.Store
+	lists    int
+	gets     int
+	depLists int
+}
+
+func (s *gateCallCountingStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.lists++
+	return s.Store.List(q)
+}
+
+func (s *gateCallCountingStore) Get(id string) (beads.Bead, error) {
+	s.gets++
+	return s.Store.Get(id)
+}
+
+func (s *gateCallCountingStore) DepList(id, direction string) ([]beads.Dep, error) {
+	s.depLists++
+	return s.Store.DepList(id, direction)
+}
+
+func mustCreate(t *testing.T, store beads.Store, b beads.Bead) beads.Bead {
+	t.Helper()
+	created, err := store.Create(b)
+	if err != nil {
+		t.Fatalf("creating bead %q: %v", b.Title, err)
+	}
+	return created
+}
+
+func mustClose(t *testing.T, store beads.Store, id string) {
+	t.Helper()
+	if err := store.Close(id); err != nil {
+		t.Fatalf("closing bead %s: %v", id, err)
+	}
+}
+
+// TestHasOpenWorkStrictFlatEvaluation is the correctness table for the
+// flat-membership open-work gate: every blocking and non-blocking shape the
+// historical walk handled must evaluate identically through the flat path.
+func TestHasOpenWorkStrictFlatEvaluation(t *testing.T) {
+	const scoped = "digest"
+	orderRunLabel := "order-run:" + scoped
+
+	cases := []struct {
+		name string
+		seed func(t *testing.T, store beads.Store)
+		want bool
+	}{
+		{
+			name: "no order beads",
+			seed: func(_ *testing.T, _ beads.Store) {},
+			want: false,
+		},
+		{
+			name: "open tracking bead blocks",
+			seed: func(t *testing.T, store beads.Store) {
+				mustCreate(t, store, beads.Bead{
+					Title:  "order:" + scoped,
+					Labels: []string{orderRunLabel, labelOrderTracking},
+				})
+			},
+			want: true,
+		},
+		{
+			name: "orphan open wisp root with no members does not block",
+			seed: func(t *testing.T, store beads.Store) {
+				mustCreate(t, store, beads.Bead{
+					Title:  "mol-digest",
+					Type:   "molecule",
+					Labels: []string{orderRunLabel},
+				})
+			},
+			want: false,
+		},
+		{
+			name: "root-only wisp candidate blocks",
+			seed: func(t *testing.T, store beads.Store) {
+				mustCreate(t, store, beads.Bead{
+					Title:    "wisp-digest",
+					Labels:   []string{orderRunLabel},
+					Metadata: map[string]string{"gc.kind": "wisp"},
+				})
+			},
+			want: true,
+		},
+		{
+			name: "open stamped member blocks",
+			seed: func(t *testing.T, store beads.Store) {
+				root := mustCreate(t, store, beads.Bead{
+					Title:  "mol-digest",
+					Type:   "molecule",
+					Labels: []string{orderRunLabel},
+				})
+				mustCreate(t, store, beads.Bead{
+					Title:    "step",
+					Metadata: map[string]string{"gc.root_bead_id": root.ID},
+				})
+			},
+			want: true,
+		},
+		{
+			name: "all-closed stamped members do not block",
+			seed: func(t *testing.T, store beads.Store) {
+				root := mustCreate(t, store, beads.Bead{
+					Title:  "mol-digest",
+					Type:   "molecule",
+					Labels: []string{orderRunLabel},
+				})
+				member := mustCreate(t, store, beads.Bead{
+					Title:    "step",
+					Metadata: map[string]string{"gc.root_bead_id": root.ID},
+				})
+				mustClose(t, store, member.ID)
+			},
+			want: false,
+		},
+		{
+			name: "open unstamped ParentID child blocks",
+			seed: func(t *testing.T, store beads.Store) {
+				root := mustCreate(t, store, beads.Bead{
+					Title:  "mol-digest",
+					Type:   "molecule",
+					Labels: []string{orderRunLabel},
+				})
+				mustCreate(t, store, beads.Bead{
+					Title:    "step",
+					ParentID: root.ID,
+				})
+			},
+			want: true,
+		},
+		{
+			name: "deep unstamped open chain blocks",
+			seed: func(t *testing.T, store beads.Store) {
+				root := mustCreate(t, store, beads.Bead{
+					Title:  "mol-digest",
+					Type:   "molecule",
+					Labels: []string{orderRunLabel},
+				})
+				c1 := mustCreate(t, store, beads.Bead{Title: "c1", ParentID: root.ID})
+				mustCreate(t, store, beads.Bead{Title: "c2", ParentID: c1.ID})
+			},
+			want: true,
+		},
+		{
+			name: "open child under closed stamped intermediate blocks",
+			seed: func(t *testing.T, store beads.Store) {
+				root := mustCreate(t, store, beads.Bead{
+					Title:  "mol-digest",
+					Type:   "molecule",
+					Labels: []string{orderRunLabel},
+				})
+				mid := mustCreate(t, store, beads.Bead{
+					Title:    "mid",
+					Metadata: map[string]string{"gc.root_bead_id": root.ID},
+				})
+				mustClose(t, store, mid.ID)
+				mustCreate(t, store, beads.Bead{Title: "leaf", ParentID: mid.ID})
+			},
+			want: true,
+		},
+		{
+			name: "lone transient nudge does not block",
+			seed: func(t *testing.T, store beads.Store) {
+				root := mustCreate(t, store, beads.Bead{
+					Title:  "mol-digest",
+					Type:   "molecule",
+					Labels: []string{orderRunLabel},
+				})
+				mustCreate(t, store, beads.Bead{
+					Title:    "nudge:agent",
+					Type:     nudgeBeadType,
+					ParentID: root.ID,
+					Labels:   []string{nudgeBeadLabel},
+				})
+			},
+			want: false,
+		},
+		{
+			name: "real work under skipped nudge blocks",
+			seed: func(t *testing.T, store beads.Store) {
+				root := mustCreate(t, store, beads.Bead{
+					Title:  "mol-digest",
+					Type:   "molecule",
+					Labels: []string{orderRunLabel},
+				})
+				nudge := mustCreate(t, store, beads.Bead{
+					Title:    "nudge:agent",
+					Type:     nudgeBeadType,
+					ParentID: root.ID,
+					Labels:   []string{nudgeBeadLabel},
+				})
+				mustCreate(t, store, beads.Bead{Title: "real work", ParentID: nudge.ID})
+			},
+			want: true,
+		},
+		{
+			name: "unrelated open beads do not block",
+			seed: func(t *testing.T, store beads.Store) {
+				mustCreate(t, store, beads.Bead{
+					Title:  "mol-digest",
+					Type:   "molecule",
+					Labels: []string{orderRunLabel},
+				})
+				other := mustCreate(t, store, beads.Bead{
+					Title:  "mol-other",
+					Type:   "molecule",
+					Labels: []string{"order-run:other"},
+				})
+				mustCreate(t, store, beads.Bead{Title: "other step", ParentID: other.ID})
+				mustCreate(t, store, beads.Bead{Title: "free-floating task"})
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			tc.seed(t, store)
+			ad := &memoryOrderDispatcher{}
+			got, err := ad.hasOpenWorkStrict(store, scoped)
+			if err != nil {
+				t.Fatalf("hasOpenWorkStrict: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("hasOpenWorkStrict = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHasOpenWorkStrictBoundedStoreCalls is the incident-12 cost guard: the
+// gate must evaluate an N-bead wisp tree in a fixed number of List calls
+// (roots + membership + one whole-scope open scan) with zero per-node
+// Get/DepList round-trips — for both the blocking (open chain) and the
+// idle-confirmation (all-closed tree) directions. The historical walk issued
+// O(N) subprocess calls for the idle case, which is exactly the load shape
+// that blew past the gate timeout under Dolt contention (#2893, vc-6qh1).
+func TestHasOpenWorkStrictBoundedStoreCalls(t *testing.T) {
+	const n = 60
+	const maxLists = 3
+
+	build := func(t *testing.T, store beads.Store, closeChain bool) {
+		root := mustCreate(t, store, beads.Bead{
+			Title:  "mol-digest",
+			Type:   "molecule",
+			Labels: []string{"order-run:digest"},
+		})
+		parent := root.ID
+		ids := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			c := mustCreate(t, store, beads.Bead{Title: "step", ParentID: parent})
+			ids = append(ids, c.ID)
+			parent = c.ID
+		}
+		if closeChain {
+			for _, id := range ids {
+				mustClose(t, store, id)
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		name       string
+		closeChain bool
+		want       bool
+	}{
+		{name: "open chain blocks", closeChain: false, want: true},
+		{name: "all-closed tree confirms idle", closeChain: true, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			counting := &gateCallCountingStore{Store: beads.NewMemStore()}
+			build(t, counting.Store, tc.closeChain)
+
+			ad := &memoryOrderDispatcher{}
+			got, err := ad.hasOpenWorkStrict(counting, "digest")
+			if err != nil {
+				t.Fatalf("hasOpenWorkStrict: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("hasOpenWorkStrict = %v, want %v", got, tc.want)
+			}
+			if counting.lists > maxLists {
+				t.Errorf("gate issued %d List calls for a %d-bead tree, want <= %d (flat evaluation must not scale store calls with tree size)", counting.lists, n, maxLists)
+			}
+			if counting.gets != 0 || counting.depLists != 0 {
+				t.Errorf("gate issued %d Get / %d DepList calls, want 0/0 (no per-node walk)", counting.gets, counting.depLists)
+			}
+		})
+	}
+}
+
+// TestHasOpenWorkStrictTruncatedScanFallsBackToWalk pins the overflow rule:
+// when the whole-scope open scan hits its limit, the snapshot is incomplete
+// and the gate must fall back to the authoritative walk instead of declaring
+// the root idle from partial data — single-flight is never weakened by the
+// flat path's bound.
+func TestHasOpenWorkStrictTruncatedScanFallsBackToWalk(t *testing.T) {
+	prev := orderGateFlatScanLimit
+	orderGateFlatScanLimit = 2
+	defer func() { orderGateFlatScanLimit = prev }()
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{
+		Title:  "mol-digest",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	// Open work reachable only through a closed UNSTAMPED intermediate: the
+	// truncated in-memory closure cannot see it, so only the walk fallback
+	// can find it.
+	mid := mustCreate(t, store, beads.Bead{Title: "mid", ParentID: root.ID})
+	mustCreate(t, store, beads.Bead{Title: "leaf", ParentID: mid.ID})
+	mustClose(t, store, mid.ID)
+	// Unrelated open beads push the open scan past the truncation limit.
+	for i := 0; i < 4; i++ {
+		mustCreate(t, store, beads.Bead{Title: "noise"})
+	}
+
+	ad := &memoryOrderDispatcher{}
+	got, err := ad.hasOpenWorkStrict(store, "digest")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if !got {
+		t.Fatal("truncated open scan must fall back to the walk and find the open leaf under the closed unstamped intermediate")
+	}
+}
+
+// TestHasOpenWorkStrictAncestorBudgetFallsBackToWalk pins the second
+// overflow rule: when ancestor resolution would exceed its Get budget, the
+// gate falls back to the authoritative walk instead of guessing — the open
+// descendant must still block.
+func TestHasOpenWorkStrictAncestorBudgetFallsBackToWalk(t *testing.T) {
+	prevBudget := orderGateFlatAncestorGetBudget
+	orderGateFlatAncestorGetBudget = 0
+	defer func() { orderGateFlatAncestorGetBudget = prevBudget }()
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{
+		Title:  "mol-digest",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	mid := mustCreate(t, store, beads.Bead{Title: "mid", ParentID: root.ID})
+	mustCreate(t, store, beads.Bead{Title: "leaf", ParentID: mid.ID})
+	mustClose(t, store, mid.ID)
+
+	ad := &memoryOrderDispatcher{}
+	got, err := ad.hasOpenWorkStrict(store, "digest")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if !got {
+		t.Fatal("exhausted ancestor budget must fall back to the walk and find the open leaf")
+	}
+}
+
+// TestGateFailOpenEmitsTypedEvent pins the incident-12 tripwire: every
+// fail-open (idempotent order dispatched on gate timeout) must emit a typed
+// order.gate_timeout_fail_open event carrying order, scope, and elapsed — a
+// rising count is the early warning that store contention is degrading gate
+// evaluation. Fail-closed outcomes and non-timeout errors must NOT emit it.
+func TestGateFailOpenEmitsTypedEvent(t *testing.T) {
+	slowGate := func() (bool, error) {
+		time.Sleep(200 * time.Millisecond)
+		return false, nil
+	}
+	_, timeoutErr := gateOpenWorkBounded(context.Background(), time.Millisecond, "digest:rig:demo", slowGate)
+	if timeoutErr == nil || !errors.Is(timeoutErr, errGateTimeout) {
+		t.Fatalf("expected gate timeout error, got %v", timeoutErr)
+	}
+
+	t.Run("idempotent timeout fails open and emits", func(t *testing.T) {
+		rec := events.NewFake()
+		m := &memoryOrderDispatcher{stderr: lockedStderr(io.Discard), rec: rec}
+		a := orders.Order{Name: "digest", Rig: "demo", Idempotent: true}
+		if m.gateFailClosed(context.Background(), a, a.ScopedName(), timeoutErr) {
+			t.Fatal("idempotent order on gate timeout should fail OPEN")
+		}
+		var got []events.Event
+		for _, e := range rec.Events {
+			if e.Type == events.OrderGateTimeoutFailOpen {
+				got = append(got, e)
+			}
+		}
+		if len(got) != 1 {
+			t.Fatalf("want exactly 1 %s event, got %d", events.OrderGateTimeoutFailOpen, len(got))
+		}
+		e := got[0]
+		if e.Subject != "digest:rig:demo" {
+			t.Errorf("event subject = %q, want %q", e.Subject, "digest:rig:demo")
+		}
+		var payload events.OrderGateTimeoutFailOpenPayload
+		if err := json.Unmarshal(e.Payload, &payload); err != nil {
+			t.Fatalf("decoding payload: %v", err)
+		}
+		if payload.Order != "digest" {
+			t.Errorf("payload.Order = %q, want %q", payload.Order, "digest")
+		}
+		if payload.Scope != "demo" {
+			t.Errorf("payload.Scope = %q, want %q", payload.Scope, "demo")
+		}
+		if payload.ElapsedSeconds <= 0 {
+			t.Errorf("payload.ElapsedSeconds = %v, want > 0", payload.ElapsedSeconds)
+		}
+	})
+
+	t.Run("non-idempotent timeout fails closed without event", func(t *testing.T) {
+		rec := events.NewFake()
+		m := &memoryOrderDispatcher{stderr: lockedStderr(io.Discard), rec: rec}
+		a := orders.Order{Name: "sweep", Idempotent: false}
+		if !m.gateFailClosed(context.Background(), a, a.ScopedName(), timeoutErr) {
+			t.Fatal("non-idempotent order on gate timeout should fail CLOSED")
+		}
+		if len(rec.Events) != 0 {
+			t.Errorf("fail-closed must not emit events, got %d", len(rec.Events))
+		}
+	})
+
+	t.Run("non-timeout error never emits", func(t *testing.T) {
+		rec := events.NewFake()
+		m := &memoryOrderDispatcher{stderr: lockedStderr(io.Discard), rec: rec}
+		a := orders.Order{Name: "digest", Idempotent: true}
+		if !m.gateFailClosed(context.Background(), a, a.ScopedName(), errors.New("dolt: read failed")) {
+			t.Fatal("a real store error must fail CLOSED even for idempotent orders")
+		}
+		if len(rec.Events) != 0 {
+			t.Errorf("non-timeout errors must not emit events, got %d", len(rec.Events))
+		}
+	})
+
+	t.Run("nil recorder does not panic", func(t *testing.T) {
+		m := &memoryOrderDispatcher{stderr: lockedStderr(io.Discard)}
+		a := orders.Order{Name: "digest", Idempotent: true}
+		if m.gateFailClosed(context.Background(), a, a.ScopedName(), timeoutErr) {
+			t.Fatal("idempotent order on gate timeout should fail OPEN")
+		}
+	})
+}

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -2240,6 +2240,9 @@
             "$ref": "#/components/schemas/NoPayload"
           },
           {
+            "$ref": "#/components/schemas/OrderGateTimeoutFailOpenPayload"
+          },
+          {
             "$ref": "#/components/schemas/OutboundChannelMismatchPayload"
           },
           {
@@ -4653,6 +4656,26 @@
           "scoped_name",
           "due",
           "reason"
+        ],
+        "type": "object"
+      },
+      "OrderGateTimeoutFailOpenPayload": {
+        "additionalProperties": false,
+        "properties": {
+          "elapsed_s": {
+            "format": "double",
+            "type": "number"
+          },
+          "order": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "order",
+          "elapsed_s"
         ],
         "type": "object"
       },
@@ -8153,6 +8176,7 @@
             "order.completed": "#/components/schemas/TypedEventStreamEnvelopeOrderCompleted",
             "order.failed": "#/components/schemas/TypedEventStreamEnvelopeOrderFailed",
             "order.fired": "#/components/schemas/TypedEventStreamEnvelopeOrderFired",
+            "order.gate_timeout_fail_open": "#/components/schemas/TypedEventStreamEnvelopeOrderGateTimeoutFailOpen",
             "pg.credential_resolved": "#/components/schemas/TypedEventStreamEnvelopePgCredentialResolved",
             "project.identity.stamped": "#/components/schemas/TypedEventStreamEnvelopeProjectIdentityStamped",
             "provider.swapped": "#/components/schemas/TypedEventStreamEnvelopeProviderSwapped",
@@ -8308,6 +8332,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeOrderFired"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeOrderGateTimeoutFailOpen"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopePgCredentialResolved"
@@ -9247,6 +9274,7 @@
                 "order.fired",
                 "order.completed",
                 "order.failed",
+                "order.gate_timeout_fail_open",
                 "provider.swapped",
                 "worker.operation",
                 "project.identity.stamped",
@@ -10613,6 +10641,57 @@
           "payload"
         ],
         "title": "TypedEventStreamEnvelope order.fired",
+        "type": "object"
+      },
+      "TypedEventStreamEnvelopeOrderGateTimeoutFailOpen": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/OrderGateTimeoutFailOpenPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "order.gate_timeout_fail_open",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope order.gate_timeout_fail_open",
         "type": "object"
       },
       "TypedEventStreamEnvelopePgCredentialResolved": {
@@ -12139,6 +12218,7 @@
             "order.completed": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderCompleted",
             "order.failed": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderFailed",
             "order.fired": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderFired",
+            "order.gate_timeout_fail_open": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen",
             "pg.credential_resolved": "#/components/schemas/TypedTaggedEventStreamEnvelopePgCredentialResolved",
             "project.identity.stamped": "#/components/schemas/TypedTaggedEventStreamEnvelopeProjectIdentityStamped",
             "provider.swapped": "#/components/schemas/TypedTaggedEventStreamEnvelopeProviderSwapped",
@@ -12294,6 +12374,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderFired"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopePgCredentialResolved"
@@ -13296,6 +13379,7 @@
                 "order.fired",
                 "order.completed",
                 "order.failed",
+                "order.gate_timeout_fail_open",
                 "provider.swapped",
                 "worker.operation",
                 "project.identity.stamped",
@@ -14767,6 +14851,61 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope order.fired",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/OrderGateTimeoutFailOpenPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "order.gate_timeout_fail_open",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope order.gate_timeout_fail_open",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopePgCredentialResolved": {

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -2240,6 +2240,9 @@
             "$ref": "#/components/schemas/NoPayload"
           },
           {
+            "$ref": "#/components/schemas/OrderGateTimeoutFailOpenPayload"
+          },
+          {
             "$ref": "#/components/schemas/OutboundChannelMismatchPayload"
           },
           {
@@ -4653,6 +4656,26 @@
           "scoped_name",
           "due",
           "reason"
+        ],
+        "type": "object"
+      },
+      "OrderGateTimeoutFailOpenPayload": {
+        "additionalProperties": false,
+        "properties": {
+          "elapsed_s": {
+            "format": "double",
+            "type": "number"
+          },
+          "order": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "order",
+          "elapsed_s"
         ],
         "type": "object"
       },
@@ -8153,6 +8176,7 @@
             "order.completed": "#/components/schemas/TypedEventStreamEnvelopeOrderCompleted",
             "order.failed": "#/components/schemas/TypedEventStreamEnvelopeOrderFailed",
             "order.fired": "#/components/schemas/TypedEventStreamEnvelopeOrderFired",
+            "order.gate_timeout_fail_open": "#/components/schemas/TypedEventStreamEnvelopeOrderGateTimeoutFailOpen",
             "pg.credential_resolved": "#/components/schemas/TypedEventStreamEnvelopePgCredentialResolved",
             "project.identity.stamped": "#/components/schemas/TypedEventStreamEnvelopeProjectIdentityStamped",
             "provider.swapped": "#/components/schemas/TypedEventStreamEnvelopeProviderSwapped",
@@ -8308,6 +8332,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeOrderFired"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeOrderGateTimeoutFailOpen"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopePgCredentialResolved"
@@ -9247,6 +9274,7 @@
                 "order.fired",
                 "order.completed",
                 "order.failed",
+                "order.gate_timeout_fail_open",
                 "provider.swapped",
                 "worker.operation",
                 "project.identity.stamped",
@@ -10613,6 +10641,57 @@
           "payload"
         ],
         "title": "TypedEventStreamEnvelope order.fired",
+        "type": "object"
+      },
+      "TypedEventStreamEnvelopeOrderGateTimeoutFailOpen": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/OrderGateTimeoutFailOpenPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "order.gate_timeout_fail_open",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope order.gate_timeout_fail_open",
         "type": "object"
       },
       "TypedEventStreamEnvelopePgCredentialResolved": {
@@ -12139,6 +12218,7 @@
             "order.completed": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderCompleted",
             "order.failed": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderFailed",
             "order.fired": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderFired",
+            "order.gate_timeout_fail_open": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen",
             "pg.credential_resolved": "#/components/schemas/TypedTaggedEventStreamEnvelopePgCredentialResolved",
             "project.identity.stamped": "#/components/schemas/TypedTaggedEventStreamEnvelopeProjectIdentityStamped",
             "provider.swapped": "#/components/schemas/TypedTaggedEventStreamEnvelopeProviderSwapped",
@@ -12294,6 +12374,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderFired"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopePgCredentialResolved"
@@ -13296,6 +13379,7 @@
                 "order.fired",
                 "order.completed",
                 "order.failed",
+                "order.gate_timeout_fail_open",
                 "provider.swapped",
                 "worker.operation",
                 "project.identity.stamped",
@@ -14767,6 +14851,61 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope order.fired",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/OrderGateTimeoutFailOpenPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "order.gate_timeout_fail_open",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope order.gate_timeout_fail_open",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopePgCredentialResolved": {

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2032,6 +2032,13 @@ type OrderCheckResponse struct {
 	ScopedName     string  `json:"scoped_name"`
 }
 
+// OrderGateTimeoutFailOpenPayload defines model for OrderGateTimeoutFailOpenPayload.
+type OrderGateTimeoutFailOpenPayload struct {
+	ElapsedS float64 `json:"elapsed_s"`
+	Order    string  `json:"order"`
+	Scope    *string `json:"scope,omitempty"`
+}
+
 // OrderHistoryDetailResponse defines model for OrderHistoryDetailResponse.
 type OrderHistoryDetailResponse struct {
 	BeadId    string    `json:"bead_id"`
@@ -4013,6 +4020,21 @@ type TypedEventStreamEnvelopeOrderFired struct {
 	Workflow  *WorkflowEventProjection `json:"workflow,omitempty"`
 }
 
+// TypedEventStreamEnvelopeOrderGateTimeoutFailOpen defines model for TypedEventStreamEnvelopeOrderGateTimeoutFailOpen.
+type TypedEventStreamEnvelopeOrderGateTimeoutFailOpen struct {
+	Actor     string                          `json:"actor"`
+	Message   *string                         `json:"message,omitempty"`
+	Payload   OrderGateTimeoutFailOpenPayload `json:"payload"`
+	RunId     *string                         `json:"run_id,omitempty"`
+	Seq       int64                           `json:"seq"`
+	SessionId *string                         `json:"session_id,omitempty"`
+	StepId    *string                         `json:"step_id,omitempty"`
+	Subject   *string                         `json:"subject,omitempty"`
+	Ts        time.Time                       `json:"ts"`
+	Type      string                          `json:"type"`
+	Workflow  *WorkflowEventProjection        `json:"workflow,omitempty"`
+}
+
 // TypedEventStreamEnvelopePgCredentialResolved defines model for TypedEventStreamEnvelopePgCredentialResolved.
 type TypedEventStreamEnvelopePgCredentialResolved struct {
 	Actor     string                            `json:"actor"`
@@ -5123,6 +5145,22 @@ type TypedTaggedEventStreamEnvelopeOrderFired struct {
 	Ts        time.Time                `json:"ts"`
 	Type      string                   `json:"type"`
 	Workflow  *WorkflowEventProjection `json:"workflow,omitempty"`
+}
+
+// TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen defines model for TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen.
+type TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen struct {
+	Actor     string                          `json:"actor"`
+	City      string                          `json:"city"`
+	Message   *string                         `json:"message,omitempty"`
+	Payload   OrderGateTimeoutFailOpenPayload `json:"payload"`
+	RunId     *string                         `json:"run_id,omitempty"`
+	Seq       int64                           `json:"seq"`
+	SessionId *string                         `json:"session_id,omitempty"`
+	StepId    *string                         `json:"step_id,omitempty"`
+	Subject   *string                         `json:"subject,omitempty"`
+	Ts        time.Time                       `json:"ts"`
+	Type      string                          `json:"type"`
+	Workflow  *WorkflowEventProjection        `json:"workflow,omitempty"`
 }
 
 // TypedTaggedEventStreamEnvelopePgCredentialResolved defines model for TypedTaggedEventStreamEnvelopePgCredentialResolved.
@@ -7210,6 +7248,32 @@ func (t *EventPayload) MergeNoPayload(v NoPayload) error {
 	return err
 }
 
+// AsOrderGateTimeoutFailOpenPayload returns the union data inside the EventPayload as a OrderGateTimeoutFailOpenPayload
+func (t EventPayload) AsOrderGateTimeoutFailOpenPayload() (OrderGateTimeoutFailOpenPayload, error) {
+	var body OrderGateTimeoutFailOpenPayload
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOrderGateTimeoutFailOpenPayload overwrites any union data inside the EventPayload as the provided OrderGateTimeoutFailOpenPayload
+func (t *EventPayload) FromOrderGateTimeoutFailOpenPayload(v OrderGateTimeoutFailOpenPayload) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOrderGateTimeoutFailOpenPayload performs a merge with any union data inside the EventPayload, using the provided OrderGateTimeoutFailOpenPayload
+func (t *EventPayload) MergeOrderGateTimeoutFailOpenPayload(v OrderGateTimeoutFailOpenPayload) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsOutboundChannelMismatchPayload returns the union data inside the EventPayload as a OutboundChannelMismatchPayload
 func (t EventPayload) AsOutboundChannelMismatchPayload() (OutboundChannelMismatchPayload, error) {
 	var body OutboundChannelMismatchPayload
@@ -9080,6 +9144,34 @@ func (t *TypedEventStreamEnvelope) MergeTypedEventStreamEnvelopeOrderFired(v Typ
 	return err
 }
 
+// AsTypedEventStreamEnvelopeOrderGateTimeoutFailOpen returns the union data inside the TypedEventStreamEnvelope as a TypedEventStreamEnvelopeOrderGateTimeoutFailOpen
+func (t TypedEventStreamEnvelope) AsTypedEventStreamEnvelopeOrderGateTimeoutFailOpen() (TypedEventStreamEnvelopeOrderGateTimeoutFailOpen, error) {
+	var body TypedEventStreamEnvelopeOrderGateTimeoutFailOpen
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromTypedEventStreamEnvelopeOrderGateTimeoutFailOpen overwrites any union data inside the TypedEventStreamEnvelope as the provided TypedEventStreamEnvelopeOrderGateTimeoutFailOpen
+func (t *TypedEventStreamEnvelope) FromTypedEventStreamEnvelopeOrderGateTimeoutFailOpen(v TypedEventStreamEnvelopeOrderGateTimeoutFailOpen) error {
+	v.Type = "order.gate_timeout_fail_open"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeTypedEventStreamEnvelopeOrderGateTimeoutFailOpen performs a merge with any union data inside the TypedEventStreamEnvelope, using the provided TypedEventStreamEnvelopeOrderGateTimeoutFailOpen
+func (t *TypedEventStreamEnvelope) MergeTypedEventStreamEnvelopeOrderGateTimeoutFailOpen(v TypedEventStreamEnvelopeOrderGateTimeoutFailOpen) error {
+	v.Type = "order.gate_timeout_fail_open"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsTypedEventStreamEnvelopePgCredentialResolved returns the union data inside the TypedEventStreamEnvelope as a TypedEventStreamEnvelopePgCredentialResolved
 func (t TypedEventStreamEnvelope) AsTypedEventStreamEnvelopePgCredentialResolved() (TypedEventStreamEnvelopePgCredentialResolved, error) {
 	var body TypedEventStreamEnvelopePgCredentialResolved
@@ -10018,6 +10110,8 @@ func (t TypedEventStreamEnvelope) ValueByDiscriminator() (interface{}, error) {
 		return t.AsTypedEventStreamEnvelopeOrderFailed()
 	case "order.fired":
 		return t.AsTypedEventStreamEnvelopeOrderFired()
+	case "order.gate_timeout_fail_open":
+		return t.AsTypedEventStreamEnvelopeOrderGateTimeoutFailOpen()
 	case "pg.credential_resolved":
 		return t.AsTypedEventStreamEnvelopePgCredentialResolved()
 	case "project.identity.stamped":
@@ -11239,6 +11333,34 @@ func (t *TypedTaggedEventStreamEnvelope) MergeTypedTaggedEventStreamEnvelopeOrde
 	return err
 }
 
+// AsTypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen returns the union data inside the TypedTaggedEventStreamEnvelope as a TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen
+func (t TypedTaggedEventStreamEnvelope) AsTypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen() (TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen, error) {
+	var body TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromTypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen overwrites any union data inside the TypedTaggedEventStreamEnvelope as the provided TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen
+func (t *TypedTaggedEventStreamEnvelope) FromTypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen(v TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen) error {
+	v.Type = "order.gate_timeout_fail_open"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeTypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen performs a merge with any union data inside the TypedTaggedEventStreamEnvelope, using the provided TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen
+func (t *TypedTaggedEventStreamEnvelope) MergeTypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen(v TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen) error {
+	v.Type = "order.gate_timeout_fail_open"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsTypedTaggedEventStreamEnvelopePgCredentialResolved returns the union data inside the TypedTaggedEventStreamEnvelope as a TypedTaggedEventStreamEnvelopePgCredentialResolved
 func (t TypedTaggedEventStreamEnvelope) AsTypedTaggedEventStreamEnvelopePgCredentialResolved() (TypedTaggedEventStreamEnvelopePgCredentialResolved, error) {
 	var body TypedTaggedEventStreamEnvelopePgCredentialResolved
@@ -12177,6 +12299,8 @@ func (t TypedTaggedEventStreamEnvelope) ValueByDiscriminator() (interface{}, err
 		return t.AsTypedTaggedEventStreamEnvelopeOrderFailed()
 	case "order.fired":
 		return t.AsTypedTaggedEventStreamEnvelopeOrderFired()
+	case "order.gate_timeout_fail_open":
+		return t.AsTypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen()
 	case "pg.credential_resolved":
 		return t.AsTypedTaggedEventStreamEnvelopePgCredentialResolved()
 	case "project.identity.stamped":

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -2240,6 +2240,9 @@
             "$ref": "#/components/schemas/NoPayload"
           },
           {
+            "$ref": "#/components/schemas/OrderGateTimeoutFailOpenPayload"
+          },
+          {
             "$ref": "#/components/schemas/OutboundChannelMismatchPayload"
           },
           {
@@ -4653,6 +4656,26 @@
           "scoped_name",
           "due",
           "reason"
+        ],
+        "type": "object"
+      },
+      "OrderGateTimeoutFailOpenPayload": {
+        "additionalProperties": false,
+        "properties": {
+          "elapsed_s": {
+            "format": "double",
+            "type": "number"
+          },
+          "order": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "order",
+          "elapsed_s"
         ],
         "type": "object"
       },
@@ -8153,6 +8176,7 @@
             "order.completed": "#/components/schemas/TypedEventStreamEnvelopeOrderCompleted",
             "order.failed": "#/components/schemas/TypedEventStreamEnvelopeOrderFailed",
             "order.fired": "#/components/schemas/TypedEventStreamEnvelopeOrderFired",
+            "order.gate_timeout_fail_open": "#/components/schemas/TypedEventStreamEnvelopeOrderGateTimeoutFailOpen",
             "pg.credential_resolved": "#/components/schemas/TypedEventStreamEnvelopePgCredentialResolved",
             "project.identity.stamped": "#/components/schemas/TypedEventStreamEnvelopeProjectIdentityStamped",
             "provider.swapped": "#/components/schemas/TypedEventStreamEnvelopeProviderSwapped",
@@ -8308,6 +8332,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeOrderFired"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeOrderGateTimeoutFailOpen"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopePgCredentialResolved"
@@ -9247,6 +9274,7 @@
                 "order.fired",
                 "order.completed",
                 "order.failed",
+                "order.gate_timeout_fail_open",
                 "provider.swapped",
                 "worker.operation",
                 "project.identity.stamped",
@@ -10613,6 +10641,57 @@
           "payload"
         ],
         "title": "TypedEventStreamEnvelope order.fired",
+        "type": "object"
+      },
+      "TypedEventStreamEnvelopeOrderGateTimeoutFailOpen": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/OrderGateTimeoutFailOpenPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "order.gate_timeout_fail_open",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope order.gate_timeout_fail_open",
         "type": "object"
       },
       "TypedEventStreamEnvelopePgCredentialResolved": {
@@ -12139,6 +12218,7 @@
             "order.completed": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderCompleted",
             "order.failed": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderFailed",
             "order.fired": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderFired",
+            "order.gate_timeout_fail_open": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen",
             "pg.credential_resolved": "#/components/schemas/TypedTaggedEventStreamEnvelopePgCredentialResolved",
             "project.identity.stamped": "#/components/schemas/TypedTaggedEventStreamEnvelopeProjectIdentityStamped",
             "provider.swapped": "#/components/schemas/TypedTaggedEventStreamEnvelopeProviderSwapped",
@@ -12294,6 +12374,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderFired"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopePgCredentialResolved"
@@ -13296,6 +13379,7 @@
                 "order.fired",
                 "order.completed",
                 "order.failed",
+                "order.gate_timeout_fail_open",
                 "provider.swapped",
                 "worker.operation",
                 "project.identity.stamped",
@@ -14767,6 +14851,61 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope order.fired",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeOrderGateTimeoutFailOpen": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/OrderGateTimeoutFailOpenPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "order.gate_timeout_fail_open",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope order.gate_timeout_fail_open",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopePgCredentialResolved": {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -118,11 +118,17 @@ const (
 
 	// Non-terminal city lifecycle events recorded in the per-city
 	// event log during init/unregister for diagnostics.
-	CityCreated                     = "city.created"
-	CityUnregisterRequested         = "city.unregister_requested"
-	OrderFired                      = "order.fired"
-	OrderCompleted                  = "order.completed"
-	OrderFailed                     = "order.failed"
+	CityCreated             = "city.created"
+	CityUnregisterRequested = "city.unregister_requested"
+	OrderFired              = "order.fired"
+	OrderCompleted          = "order.completed"
+	OrderFailed             = "order.failed"
+	// OrderGateTimeoutFailOpen fires when an idempotent order's bounded
+	// open-work gate times out and the dispatcher fails OPEN — dispatching
+	// without having proven single-flight. Each emission is one fail-open;
+	// a rising count is the early-warning tripwire that store contention
+	// is degrading gate evaluation (incident 12 / #2893).
+	OrderGateTimeoutFailOpen        = "order.gate_timeout_fail_open"
 	ProviderSwapped                 = "provider.swapped"
 	WorkerOperation                 = "worker.operation"
 	ProjectIdentityStamped          = "project.identity.stamped"
@@ -220,7 +226,7 @@ var KnownEventTypes = []string{
 	RequestResultSessionCreate, RequestResultSessionMessage,
 	RequestResultSessionSubmit, RequestFailed,
 	CityCreated, CityUnregisterRequested,
-	OrderFired, OrderCompleted, OrderFailed,
+	OrderFired, OrderCompleted, OrderFailed, OrderGateTimeoutFailOpen,
 	ProviderSwapped, WorkerOperation, ProjectIdentityStamped, SupervisorFSPressureSkippedTick,
 	MoleculeResolved,
 	SupervisorStarted, SupervisorShutdownRequested, SupervisorRequest,

--- a/internal/events/payloads.go
+++ b/internal/events/payloads.go
@@ -81,6 +81,39 @@ func init() {
 	RegisterPayload(BeadWorktreeReaped, BeadWorktreeReapedPayload{})
 	RegisterPayload(BeadWorktreeReapSkipped, BeadWorktreeReapSkippedPayload{})
 	RegisterPayload(BeadClaimRejected, BeadClaimRejectedPayload{})
+	RegisterPayload(OrderGateTimeoutFailOpen, OrderGateTimeoutFailOpenPayload{})
+}
+
+// OrderGateTimeoutFailOpenPayload is the typed payload for
+// order.gate_timeout_fail_open events. The order dispatcher emits one per
+// fail-open: an idempotent order whose bounded open-work gate timed out was
+// dispatched anyway (single-flight unproven). Operators count these as the
+// incident-12 tripwire — a rising rate means store contention is degrading
+// gate evaluation and the flat-membership path (or the store) needs
+// attention before silent fail-opens amplify.
+type OrderGateTimeoutFailOpenPayload struct {
+	// Order is the order's bare name without rig qualification.
+	Order string `json:"order"`
+	// Scope is the rig name the order is scoped to; empty for city-level
+	// orders.
+	Scope string `json:"scope,omitempty"`
+	// ElapsedSeconds is how long the gate ran before the per-order bound
+	// elapsed; 0 when the emitter could not measure it.
+	ElapsedSeconds float64 `json:"elapsed_s"`
+}
+
+// IsEventPayload marks OrderGateTimeoutFailOpenPayload as an events.Payload variant.
+func (OrderGateTimeoutFailOpenPayload) IsEventPayload() {}
+
+// OrderGateTimeoutFailOpenPayloadJSON builds the JSON wire form for
+// attachment to an Event.Payload field.
+func OrderGateTimeoutFailOpenPayloadJSON(order, scope string, elapsedSeconds float64) json.RawMessage {
+	b, _ := json.Marshal(OrderGateTimeoutFailOpenPayload{
+		Order:          order,
+		Scope:          scope,
+		ElapsedSeconds: elapsedSeconds,
+	})
+	return b
 }
 
 // StoreDiskWarnPayload is the typed payload for gc.store.disk_warn events.


### PR DESCRIPTION
## Summary

> **Stacked on #3315** (`perf(orders)`: flat-membership gate). Review/merge that first — its 2 commits appear in this diff until it lands, after which GitHub reduces this PR to just the 2 commits below.

The order-dispatch pass read each order's last-run time from the store before deciding whether the order is due. A **transient** store read/refresh error on one order aborted handling in a way that starved the whole pass — including SDK-critical cooldown orders like the cold-pool spawner, which then never ran, so pools never cold-started even with capacity. Two fixes:

1. **`fix(order-dispatch)`** — a transient last-run *read* error skips that **one** order this tick instead of returning an error that drops the entire dispatch pass.
2. **`fix(order-dispatch)`** — on a last-run *refresh* failure, proceed with the cached due-result instead of skipping the order, so a momentary `bd` timeout can't indefinitely prevent a due cooldown order from running.

Net: one order's transient store hiccup degrades to "retry next tick," never "stall every order."

## Testing

- [x] `go build ./...`, `go vet ./cmd/gc/`
- [x] `go test ./cmd/gc/` order-dispatch tests pass locally (transient-read skip-one, refresh-failure proceed-with-cached)
- [ ] Full `make check` — CI

## Checklist

- [x] Added/extended tests for both degraded paths
- [x] No behavior change on the happy path
- [ ] No breaking changes