### PR TITLE
fix(runtime): recognize gemini's "> " prompt in startup dialog readiness (#2874)

### DIFF
--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -943,7 +943,7 @@ func containsPromptIndicator(content string) bool {
 		if trimmed == "" {
 			continue
 		}
-		for _, prefix := range []string{"\u276f", "\u203a"} {
+		for _, prefix := range []string{"\u276f", "\u203a", ">"} {
 			rest, ok := strings.CutPrefix(trimmed, prefix+" ")
 			if trimmed == prefix || (ok && !isNumberedMenuRow(rest)) {
 				return true

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -726,7 +726,13 @@ func TestContainsPromptIndicator(t *testing.T) {
 		{name: "claude prompt with text", content: "❯ run tests", want: true},
 		{name: "boxed grok prompt", content: "│ ❯ ", want: true},
 		{name: "boxed grok prompt with text", content: "│ ❯ start working", want: true},
+		// gemini renders an ASCII "> " prompt followed by placeholder text
+		// (gastownhall/gascity#2874); the dialog poller must see it as ready so
+		// it stops burning the 8s-per-handler budget and the start deadline.
+		{name: "gemini ascii prompt with placeholder", content: "> Type your message or @path/to/file", want: true},
+		{name: "boxed gemini ascii prompt", content: "│ > Type your message or @path/to/file              │", want: true},
 		{name: "codex numbered menu row", content: "› 1. Update now (runs `bun install -g @openai/codex`)", want: false},
+		{name: "ascii numbered menu row", content: "> 1. Update now", want: false},
 		{name: "empty content", content: "", want: false},
 		{name: "no prompt", content: "loading...", want: false},
 		{name: "blank lines only", content: "\n\n", want: false},


### PR DESCRIPTION
## Summary

`builtin:gemini` fresh sessions fail `start_call` with `context deadline exceeded` after ~66s (#2874), while *adopted* sessions work indefinitely.

**Root cause (proven):** `doStartSession` Step 3 runs the 7-handler startup-dialog poller (`AcceptStartupDialogsWithTimeout`, 8s/handler ≈ 56s). Each handler early-returns only on a known Claude/Codex dialog **or** when `containsPromptIndicator` reports a ready prompt. `containsPromptIndicator` recognized `❯`/`›` as prompt **prefixes** but treated `>` only as an end-of-line **suffix**, so gemini's `> Type your message …` prompt — the gemini profile itself declares `ReadyPromptPrefix: "> "` — was never recognized. With no Claude/Codex dialog and an unrecognized prompt, all 7 handlers burn their full 8s and blow `doStartSession`'s start-context deadline, so GC kills the live pane. Adopted sessions skip `doStartSession` via the `IsRunning` short-circuit and are unaffected. `ready_delay_ms` had no effect because the hang is in the dialog poller, not the readiness probe — all consistent with the report.

This is the same failure class the code already documents for grok ("the startup-dialog handlers never early-return … burn their full timeout, blowing doStartSession's start-context deadline"). Grok was fixed with box-border stripping; gemini's `> ` glyph still wasn't recognized.

## Fix

Recognize a leading ASCII `> ` prompt prefix in `containsPromptIndicator`, reusing the existing `isNumberedMenuRow` guard so menu rows like `> 1. …` are still treated as dialogs and dismissed.

```diff
-		for _, prefix := range []string{"❯", "›"} {
+		for _, prefix := range []string{"❯", "›", ">"} {
```

## Verification

- New `TestContainsPromptIndicator` cases reproduce the bug (gemini prompt-with-placeholder + boxed form) and pass with the fix; the ASCII numbered-menu guard case stays `false`.
- Full `internal/runtime` package tests green, including the existing cross-provider Claude/Codex/grok dialog suite (no regression). `go vet` / `go build` / `gofmt` clean.
- ⚠️ **Still needs end-to-end confirmation on a live Gemini CLI 0.44.x.** If gemini also surfaces a workspace-trust dialog on fresh start (the report's manual workaround used `--skip-trust`), that is a separate path the trust-dialog handler must match — worth checking during verification.

Thanks @spudtheimpaler for the unusually thorough report — the adopt-vs-fresh contrast and the "`ready_delay_ms` has no effect" detail were exactly what localized this.

Addresses #2874. Refs: ga-er7u7g

🤖 Generated with [Claude Code](https://claude.com/claude-code)