### PR TITLE
fix(dolt): raise rig-list discovery bound to 30s in compact and health

### DIFF
--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -223,6 +223,14 @@ fi
 
 _run_bounded_warned_no_timeout=""
 
+# Wall-clock bound (seconds) for `gc rig list --json` rig discovery, shared
+# by the compact and health commands and tunable via
+# GC_DOLT_RIG_LIST_TIMEOUT_SECS. The bound must absorb a slow-but-healthy gc
+# on a busy host (~16s observed): discovery callers degrade to a city-only
+# filesystem scan on timeout, which silently drops external rig databases
+# (gascity#2740).
+GC_DOLT_RIG_LIST_TIMEOUT_SECS="${GC_DOLT_RIG_LIST_TIMEOUT_SECS:-30}"
+
 # run_bounded SECS CMD...  — Run CMD with a wall-clock timeout. Exits
 # 124 on timeout (coreutils convention). Uses --kill-after=2 so an
 # uncooperative child that ignores SIGTERM (e.g. a dolt client stuck

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -314,10 +314,16 @@ quarantine_dir="$PACK_STATE_DIR/compact-quarantine"
 
 # DB discovery uses rig metadata.json files first (authoritative), with a
 # filesystem-scan fallback when gc itself is unavailable.
+#
+# The rig-list bound must absorb a slow-but-healthy gc on a busy host
+# (~16s observed): the fallback scan only sees the city directory, so a
+# premature timeout silently drops every external rig database from
+# compaction (gascity#2740).
+rig_list_timeout=30
 metadata_files() {
   printf '%s\n' "$GC_CITY_PATH/.beads/metadata.json"
   if command -v gc >/dev/null 2>&1; then
-    if rig_json=$(run_bounded 5 gc rig list --json 2>/dev/null); then
+    if rig_json=$(run_bounded "$rig_list_timeout" gc rig list --json 2>/dev/null); then
       rig_paths=$(printf '%s\n' "$rig_json" \
         | if command -v jq >/dev/null 2>&1; then
             jq -r '.rigs[].path' 2>/dev/null
@@ -333,7 +339,7 @@ metadata_files() {
     else
       rig_status=$?
       if [ "$rig_status" -eq 124 ]; then
-        printf 'compact: gc rig list timed out after 5s; falling back to local filesystem metadata scan\n' >&2
+        printf 'compact: gc rig list timed out after %ss; falling back to local filesystem metadata scan\n' "$rig_list_timeout" >&2
       else
         printf 'compact: gc rig list failed rc=%s; falling back to local filesystem metadata scan\n' "$rig_status" >&2
       fi

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -67,6 +67,10 @@
 #     (default: 120) — wall-clock bound for remote compare-and-push
 #                     after local compaction. Push failures are recorded for
 #                     repair but do not fail local compaction.
+#   GC_DOLT_RIG_LIST_TIMEOUT_SECS
+#     (default: 30) — wall-clock bound for `gc rig list --json` rig
+#                     discovery. Shared with the health command; the
+#                     default lives in runtime.sh.
 #   GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS
 #     (default: 172800) — maximum age for automatic pending remote-push retry.
 #                       Older markers require manual review before push.
@@ -257,6 +261,14 @@ case "$push_timeout" in
     ;;
 esac
 
+case "$GC_DOLT_RIG_LIST_TIMEOUT_SECS" in
+  ''|*[!0-9]*|0)
+    printf 'compact: invalid GC_DOLT_RIG_LIST_TIMEOUT_SECS=%s (must be a positive integer)\n' \
+      "$GC_DOLT_RIG_LIST_TIMEOUT_SECS" >&2
+    exit 2
+    ;;
+esac
+
 case "$pending_push_max_age_secs" in
   ''|*[!0-9]*)
     printf 'compact: invalid GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS=%s (must be a non-negative integer)\n' \
@@ -318,8 +330,9 @@ quarantine_dir="$PACK_STATE_DIR/compact-quarantine"
 # The rig-list bound must absorb a slow-but-healthy gc on a busy host
 # (~16s observed): the fallback scan only sees the city directory, so a
 # premature timeout silently drops every external rig database from
-# compaction (gascity#2740).
-rig_list_timeout=30
+# compaction (gascity#2740). The default lives in runtime.sh, shared with
+# the health command.
+rig_list_timeout="$GC_DOLT_RIG_LIST_TIMEOUT_SECS"
 metadata_files() {
   printf '%s\n' "$GC_CITY_PATH/.beads/metadata.json"
   if command -v gc >/dev/null 2>&1; then

--- a/examples/bd/dolt/commands/health/run.sh
+++ b/examples/bd/dolt/commands/health/run.sh
@@ -18,8 +18,11 @@ metadata_files() {
   if command -v gc >/dev/null 2>&1; then
     # Bound the gc rig list call: if gc is itself in a bad state (the
     # failure mode this patrol is meant to detect) we must not block
-    # here. Degrade to the fallback rig scan below.
-    rig_paths=$(run_bounded 5 gc rig list --json 2>/dev/null \
+    # here. Degrade to the fallback rig scan below. The bound must absorb
+    # a slow-but-healthy gc on a busy host (~16s observed) because the
+    # fallback scan only sees the city directory and silently drops
+    # external rig databases (gascity#2740).
+    rig_paths=$(run_bounded 30 gc rig list --json 2>/dev/null \
       | if command -v jq >/dev/null 2>&1; then
           jq -r '.rigs[].path' 2>/dev/null
         else

--- a/examples/bd/dolt/commands/health/run.sh
+++ b/examples/bd/dolt/commands/health/run.sh
@@ -5,7 +5,7 @@
 # beads, backup freshness, orphan databases, and zombie Dolt processes.
 #
 # Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_HOST, GC_DOLT_USER,
-#              GC_DOLT_PASSWORD
+#              GC_DOLT_PASSWORD, GC_DOLT_RIG_LIST_TIMEOUT_SECS
 set -e
 
 : "${GC_DOLT_USER:=root}"
@@ -18,11 +18,12 @@ metadata_files() {
   if command -v gc >/dev/null 2>&1; then
     # Bound the gc rig list call: if gc is itself in a bad state (the
     # failure mode this patrol is meant to detect) we must not block
-    # here. Degrade to the fallback rig scan below. The bound must absorb
-    # a slow-but-healthy gc on a busy host (~16s observed) because the
+    # here. Degrade to the fallback rig scan below. The bound (default in
+    # runtime.sh, shared with the compact command) must absorb a
+    # slow-but-healthy gc on a busy host (~16s observed) because the
     # fallback scan only sees the city directory and silently drops
     # external rig databases (gascity#2740).
-    rig_paths=$(run_bounded 30 gc rig list --json 2>/dev/null \
+    rig_paths=$(run_bounded "$GC_DOLT_RIG_LIST_TIMEOUT_SECS" gc rig list --json 2>/dev/null \
       | if command -v jq >/dev/null 2>&1; then
           jq -r '.rigs[].path' 2>/dev/null
         else

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -876,6 +876,30 @@ func TestCompactScriptDefaultThresholdIs2000(t *testing.T) {
 	}
 }
 
+func TestCompactScriptToleratesSlowRigListDiscovery(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	// `gc rig list --json` regularly takes longer than the old 5s discovery
+	// bound on busy hosts. When the bound expires the script silently falls
+	// back to a city-only filesystem scan that misses external rig
+	// databases, so they are never compacted (gascity#2740). Answer after
+	// 7s and require discovery to still use the rig list.
+	writeExecutable(t, filepath.Join(fixture.binDir, "gc"), `#!/bin/sh
+if [ "${1:-}" = "rig" ] && [ "${2:-}" = "list" ]; then
+  sleep 7
+  printf '{"rigs":[]}\n'
+  exit 0
+fi
+exit 0
+`)
+	out, err := fixture.run(t, "success")
+	if err != nil {
+		t.Fatalf("compact failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "falling back to local filesystem metadata scan") {
+		t.Fatalf("rig list answering within 30s must not trigger the filesystem fallback:\n%s", out)
+	}
+}
+
 func TestCompactScriptFlattensAndVerifies(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	out, err := fixture.run(t, "success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -172,6 +172,7 @@ func (f compactScriptFixture) run(t *testing.T, mode string, extraEnv ...string)
 		"GC_DOLT_COMPACT_ONLY_DBS",
 		"GC_DOLT_COMPACT_REMOTE",
 		"GC_DOLT_COMPACT_BARE_GC",
+		"GC_DOLT_RIG_LIST_TIMEOUT_SECS",
 		"GC_FAKE_DOLT_COMPACT_MODE",
 		"GC_FAKE_DOLT_COUNT_FILE",
 		"GC_FAKE_DOLT_STATE_FILE",

--- a/examples/bd/dolt/health_test.go
+++ b/examples/bd/dolt/health_test.go
@@ -122,8 +122,17 @@ func TestHealthScriptIsBounded(t *testing.T) {
 	root := repoRoot(t)
 	script := filepath.Join(root, healthScript)
 
+	// Stub gc on PATH: metadata_files would otherwise call the real gc
+	// with the 30s rig-list bound from runtime.sh, leaving this budget
+	// hostage to host `gc rig list` latency — worst exactly on the busy
+	// hosts this hang guard is for. The bounded dolt probe is what this
+	// test measures; rig discovery is incidental.
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "gc"), "#!/bin/sh\nexit 1\n")
+
 	cmd := exec.Command("sh", script)
 	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
 		"GC_DOLT_HOST=127.0.0.1",
@@ -149,8 +158,9 @@ func TestHealthScriptIsBounded(t *testing.T) {
 	var buf strings.Builder
 	go func() { _, _ = io.Copy(&buf, stdout) }()
 
-	// The script has per-call 5s timeouts. Allow generous slack for
-	// CI jitter, but fail hard well before "indefinite hang".
+	// With gc stubbed out, the largest per-call bound left is the 5s
+	// dolt probe. Allow generous slack for CI jitter, but fail hard
+	// well before "indefinite hang".
 	const budget = 45 * time.Second
 	select {
 	case err := <-done:
@@ -306,6 +316,101 @@ func TestHealthOrphansFromCleanupAuthority(t *testing.T) {
 		switch o {
 		case "hq", "gco", "tga":
 			t.Errorf("live rig DB %q misclassified as orphan", o)
+		}
+	}
+}
+
+// TestHealthScriptToleratesSlowRigListDiscovery pins the health half of
+// gascity#2740: `gc rig list --json` regularly takes longer than the old 5s
+// discovery bound on busy hosts. When the bound expires, metadata_files
+// silently degrades to a city-only filesystem scan that cannot see
+// externally-pathed rigs, so their metadata drops out of downstream
+// consumers — surfacing here as a live external rig DB misclassified as an
+// orphan, a false positive automation may act on. Answer rig list after 7s
+// with an external rig and require the result to be consumed.
+func TestHealthScriptToleratesSlowRigListDiscovery(t *testing.T) {
+	if _, errT := exec.LookPath("timeout"); errT != nil {
+		if _, errG := exec.LookPath("gtimeout"); errG != nil {
+			t.Skip("neither timeout nor gtimeout installed; skipping")
+		}
+	}
+
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	// External rig OUTSIDE the city directory: only the rig-list result can
+	// discover it — the fallback find scan is rooted at the city path.
+	extRig := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(extRig, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir external rig: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(extRig, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_database":"extdb"}`), 0o644); err != nil {
+		t.Fatalf("write external rig metadata: %v", err)
+	}
+
+	// Data dir holds the city DB and the external rig's DB.
+	dataDir := t.TempDir()
+	for _, db := range []string{"hq", "extdb"} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir db %s: %v", db, err)
+		}
+	}
+
+	binDir := t.TempDir()
+	// Fake gc: `rig list` answers after 7s — past the old 5s bound, inside
+	// the 30s one — naming the external rig. Everything else (notably
+	// `gc dolt-cleanup`) fails, so orphan detection takes the metadata
+	// referenced-set fallback, which protects extdb only when the rig-list
+	// result was consumed instead of the city-only scan.
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+if [ "${1:-}" = "rig" ] && [ "${2:-}" = "list" ]; then
+  sleep 7
+  printf '{"rigs":[{"path": "`+extRig+`"}]}\n'
+  exit 0
+fi
+exit 1
+`)
+	// No live server: lsof/nc fail, so the bounded dolt probe is skipped.
+	writeExecutable(t, filepath.Join(binDir, "lsof"), "#!/bin/sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(binDir, "nc"), "#!/bin/sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(binDir, "dolt"), "#!/bin/sh\nexit 1\n")
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(filteredEnv("GC_DOLT_PORT", "PATH", "GC_DOLT_DATA_DIR", "GC_DOLT_RIG_LIST_TIMEOUT_SECS"),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT=3306",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_HEALTH_SKIP_ZOMBIE_SCAN=1",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("health.sh --json failed: %v\n%s", err, out)
+	}
+
+	var report struct {
+		Orphans []struct {
+			Name string `json:"name"`
+		} `json:"orphans"`
+	}
+	if err := json.Unmarshal(out, &report); err != nil {
+		t.Fatalf("parse health JSON: %v\n%s", err, out)
+	}
+	for _, o := range report.Orphans {
+		if o.Name == "extdb" {
+			t.Fatalf("external rig DB extdb misclassified as orphan: a rig list answering within the 30s bound must be consumed, not dropped for the city-only fallback scan\n%s", out)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Raise the `gc rig list --json` discovery bound in `examples/bd/dolt/commands/compact/run.sh` and `examples/bd/dolt/commands/health/run.sh` from 5s to 30s.
- Parameterize the compact timeout message so it always reports the actual bound.
- Add `TestCompactScriptToleratesSlowRigListDiscovery`: a fake `gc` answers `rig list --json` after 7s and the test asserts the filesystem fallback does not fire.

## Problem

On busy hosts `gc rig list --json` regularly takes longer than 5s (~16s observed on the maintainer-city host while diagnosing #2740). When the bound expires, both scripts silently degrade to a filesystem metadata scan rooted at `$GC_CITY_PATH` — which cannot see rigs that live outside the city directory. For compaction this means every external rig database is silently dropped from discovery on every run, so they are never flattened or GC'd and grow unbounded. This is one of the root causes behind #2740 (9.5G `ga`, 41.7k commits, never compacted).

The failure is invisible in order history: the script exits 0 after compacting only the city-local databases.

## Solution

30s absorbs a slow-but-healthy `gc` while still bounding the patrol when `gc` itself is wedged (the failure mode the health patrol exists to detect). The fallback scan is unchanged and still engages on timeout or `gc` failure.

## Testing

- `go test ./examples/bd/dolt` (full package, passes)
- New test fails on the old 5s bound, passes with 30s

Part of the operational follow-up to #2740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)