### PR TITLE
fix(gc): project canonical scope dolt env into pack command runs

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -280,6 +280,26 @@ func canonicalScopeDoltTarget(cityPath, scopeRoot string) (contract.DoltConnecti
 	return target, true, nil
 }
 
+// canonicalScopeDoltProjectionAuthoritative reports whether canonical
+// Dolt projection would resolve auth for the city scope: the scope
+// backend is not postgres and the scope config resolves authoritative —
+// the same ResolveScopeConfigState gate applyOrderExecCanonicalDoltEnv
+// and its managed fallback apply before calling
+// applyCanonicalDoltAuthEnv. Callers that feed ambient environments
+// into the projection use this to strip untrusted password mirrors
+// from the resolution input without breaking the strict no-op
+// pass-through for non-authoritative scopes.
+func canonicalScopeDoltProjectionAuthoritative(cityPath string) bool {
+	if scopeBackendIsPostgres(cityPath, cityPath) {
+		return false
+	}
+	resolved, err := contract.ResolveScopeConfigState(fsys.OSFS{}, cityPath, cityPath, "")
+	if err != nil {
+		return false
+	}
+	return resolved.Kind == contract.ScopeConfigAuthoritative
+}
+
 func applyCanonicalDoltTargetEnv(env map[string]string, target contract.DoltConnectionTarget) {
 	if env == nil {
 		return

--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -166,6 +166,7 @@ func runDiscoveredCommand(entry config.DiscoveredCommand, cityPath, cityName str
 		"GC_PACK_NAME="+entry.PackName,
 		"GC_CITY_NAME="+cityName,
 	)
+	cmd.Env = mergeCanonicalScopeDoltEnv(cmd.Env, cityPath)
 
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
@@ -176,6 +177,53 @@ func runDiscoveredCommand(entry config.DiscoveredCommand, cityPath, cityName str
 		return 1
 	}
 	return 0
+}
+
+// mergeCanonicalScopeDoltEnv projects the city's canonical Dolt
+// connection into a pack command's environment the same way order
+// dispatch does (applyOrderExecCanonicalDoltEnv), so a directly invoked
+// pack command (e.g. `gc dolt compact`) targets the same server as its
+// scheduled order. Without this, a city configured with an external
+// Dolt endpoint runs pack scripts against stale ambient GC_DOLT_* values
+// or the inactive managed runtime. When the city has no authoritative
+// scope config the environment is returned unchanged and pack scripts
+// keep resolving the managed runtime themselves.
+func mergeCanonicalScopeDoltEnv(environ []string, cityPath string) []string {
+	resolved := make(map[string]string, len(environ))
+	for _, entry := range environ {
+		if key, value, ok := strings.Cut(entry, "="); ok {
+			resolved[key] = value
+		}
+	}
+	before := make(map[string]string, len(resolved))
+	for key, value := range resolved {
+		before[key] = value
+	}
+	applyOrderExecCanonicalDoltEnv(cityPath, cityPath, resolved)
+
+	out := environ
+	removed := make([]string, 0, len(before))
+	for key := range before {
+		if _, ok := resolved[key]; !ok {
+			removed = append(removed, key)
+		}
+	}
+	sort.Strings(removed)
+	for _, key := range removed {
+		out = removeEnvKey(out, key)
+	}
+	changed := make([]string, 0, len(resolved))
+	for key, value := range resolved {
+		if prev, ok := before[key]; !ok || prev != value {
+			changed = append(changed, key)
+		}
+	}
+	sort.Strings(changed)
+	for _, key := range changed {
+		out = removeEnvKey(out, key)
+		out = append(out, key+"="+resolved[key])
+	}
+	return out
 }
 
 func tryDiscoveredCommandFallback(args []string, cfg *config.City, cityPath string, stdout, stderr io.Writer) bool {

--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -188,6 +188,22 @@ func runDiscoveredCommand(entry config.DiscoveredCommand, cityPath, cityName str
 // or the inactive managed runtime. When the city has no authoritative
 // scope config the environment is returned unchanged and pack scripts
 // keep resolving the managed runtime themselves.
+//
+// Pack commands are a city-level surface: the projection intentionally
+// targets the city scope even when the invoking shell carries a
+// rig-scoped projection, matching what the same command would see when
+// dispatched as a city order.
+//
+// Unlike the order path, whose resolution input is a freshly built env
+// map, the input here is the raw ambient environment. Ambient password
+// mirrors are parent-shell state — possibly projected for a different
+// scope — and doltauth.ResolveScopedFromEnv would trust a map-provided
+// BEADS_DOLT_PASSWORD as already-resolved auth ahead of the endpoint's
+// credentials-file lookup. They are therefore stripped from the
+// resolution input, gated on the same authoritativeness check the
+// projection itself applies so the non-authoritative pass-through stays
+// a strict no-op. The operator overrides are unaffected: doltauth reads
+// GC_DOLT_PASSWORD via os.Getenv, not from the resolution map.
 func mergeCanonicalScopeDoltEnv(environ []string, cityPath string) []string {
 	resolved := make(map[string]string, len(environ))
 	for _, entry := range environ {
@@ -198,6 +214,9 @@ func mergeCanonicalScopeDoltEnv(environ []string, cityPath string) []string {
 	before := make(map[string]string, len(resolved))
 	for key, value := range resolved {
 		before[key] = value
+	}
+	if canonicalScopeDoltProjectionAuthoritative(cityPath) {
+		clearProjectedDoltPasswordEnv(resolved)
 	}
 	applyOrderExecCanonicalDoltEnv(cityPath, cityPath, resolved)
 

--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -99,6 +99,111 @@ echo "args=$*"
 	}
 }
 
+func TestRunDiscoveredCommand_ProjectsCanonicalExternalDoltEnv(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: city_canonical",
+		"gc.endpoint_status: verified",
+		"dolt.host: 127.0.0.1",
+		"dolt.port: 4406",
+		"dolt.user: city-user",
+		"",
+	}, "\n"))
+
+	packDir := filepath.Join(dir, "pack")
+	sourceDir := filepath.Join(packDir, "commands", "compact")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(sourceDir, "run.sh")
+	script := `#!/bin/sh
+echo "managed=$GC_DOLT_MANAGED_LOCAL"
+echo "host=$GC_DOLT_HOST"
+echo "port=$GC_DOLT_PORT"
+echo "user=$GC_DOLT_USER"
+echo "beadsport=$BEADS_DOLT_SERVER_PORT"
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale ambient values from a parent session must lose to the city's
+	// canonical endpoint, exactly as they do on the order-dispatch path.
+	t.Setenv("GC_DOLT_PORT", "9999")
+	t.Setenv("GC_DOLT_MANAGED_LOCAL", "1")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "9999")
+
+	entry := config.DiscoveredCommand{
+		BindingName: "dolt",
+		PackName:    "dolt",
+		Command:     []string{"compact"},
+		RunScript:   scriptPath,
+		PackDir:     packDir,
+		SourceDir:   sourceDir,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDiscoveredCommand(entry, dir, "testcity", nil, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"managed=0",
+		"host=127.0.0.1",
+		"port=4406",
+		"user=city-user",
+		"beadsport=4406",
+	} {
+		if !strings.Contains(out, want+"\n") {
+			t.Fatalf("stdout missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunDiscoveredCommand_KeepsAmbientDoltEnvWithoutScopeConfig(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "pack")
+	sourceDir := filepath.Join(packDir, "commands", "compact")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(sourceDir, "run.sh")
+	script := `#!/bin/sh
+echo "port=$GC_DOLT_PORT"
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without an authoritative scope config the operator-seeded ambient
+	// value must pass through untouched.
+	t.Setenv("GC_DOLT_PORT", "7777")
+
+	entry := config.DiscoveredCommand{
+		BindingName: "dolt",
+		PackName:    "dolt",
+		Command:     []string{"compact"},
+		RunScript:   scriptPath,
+		PackDir:     packDir,
+		SourceDir:   sourceDir,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDiscoveredCommand(entry, dir, "testcity", nil, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "port=7777\n") {
+		t.Fatalf("ambient GC_DOLT_PORT must pass through without scope config, got:\n%s", stdout.String())
+	}
+}
+
 func TestRunDiscoveredCommand_PrefersEntryPackDir(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "actual-pack")

--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -204,6 +204,144 @@ echo "port=$GC_DOLT_PORT"
 	}
 }
 
+func TestRunDiscoveredCommand_AmbientBeadsDoltPasswordLosesToCredentialsFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: city_canonical",
+		"gc.endpoint_status: verified",
+		"dolt.host: 127.0.0.1",
+		"dolt.port: 4406",
+		"dolt.user: city-user",
+		"",
+	}, "\n"))
+	credentialsPath := filepath.Join(dir, "credentials")
+	writeFile(t, credentialsPath, strings.Join([]string{
+		"[127.0.0.1:4406]",
+		"password = cred-file-pass",
+		"",
+	}, "\n"))
+
+	packDir := filepath.Join(dir, "pack")
+	sourceDir := filepath.Join(packDir, "commands", "compact")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(sourceDir, "run.sh")
+	script := `#!/bin/sh
+echo "password=$GC_DOLT_PASSWORD"
+echo "beadspass=$BEADS_DOLT_PASSWORD"
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A stale BEADS_DOLT_PASSWORD mirrored into the parent session for a
+	// different scope must not be treated as already-resolved auth for
+	// the city's canonical endpoint; the endpoint's credentials-file
+	// password must win. GC_DOLT_PASSWORD stays neutral so the operator
+	// override (read via os.Getenv) does not shadow the lookup.
+	t.Setenv("BEADS_DOLT_PASSWORD", "stale-cross-scope-pass")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_CREDENTIALS_FILE", credentialsPath)
+
+	entry := config.DiscoveredCommand{
+		BindingName: "dolt",
+		PackName:    "dolt",
+		Command:     []string{"compact"},
+		RunScript:   scriptPath,
+		PackDir:     packDir,
+		SourceDir:   sourceDir,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDiscoveredCommand(entry, dir, "testcity", nil, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"password=cred-file-pass",
+		"beadspass=cred-file-pass",
+	} {
+		if !strings.Contains(out, want+"\n") {
+			t.Fatalf("stdout missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunDiscoveredCommand_RemovesAmbientDoltEnvDeletedByProjection(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: managed_city",
+		"",
+	}, "\n"))
+
+	packDir := filepath.Join(dir, "pack")
+	sourceDir := filepath.Join(packDir, "commands", "compact")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(sourceDir, "run.sh")
+	// ${VAR+set} distinguishes unset from set-but-empty: the projection
+	// must delete these keys, not blank them.
+	script := `#!/bin/sh
+echo "managed=$GC_DOLT_MANAGED_LOCAL"
+echo "gchost=${GC_DOLT_HOST+set}"
+echo "gcport=${GC_DOLT_PORT+set}"
+echo "mirrorhost=${BEADS_DOLT_SERVER_HOST+set}"
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A managed-local canonical city deletes the host key (and its
+	// BEADS mirror) instead of projecting a value; stale ambient
+	// entries must be stripped from the child environment, not passed
+	// through.
+	t.Setenv("GC_DOLT_HOST", "stale.example")
+	t.Setenv("GC_DOLT_PORT", "9999")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "stale.example")
+	t.Setenv("BEADS_CREDENTIALS_FILE", filepath.Join(dir, "no-credentials"))
+
+	entry := config.DiscoveredCommand{
+		BindingName: "dolt",
+		PackName:    "dolt",
+		Command:     []string{"compact"},
+		RunScript:   scriptPath,
+		PackDir:     packDir,
+		SourceDir:   sourceDir,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDiscoveredCommand(entry, dir, "testcity", nil, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "managed=1\n") {
+		t.Fatalf("projection did not run (want managed=1), got:\n%s", out)
+	}
+	for _, want := range []string{
+		"gchost=",
+		"gcport=",
+		"mirrorhost=",
+	} {
+		if !strings.Contains(out, want+"\n") {
+			t.Fatalf("stale ambient key not removed (want %q line), got:\n%s", want, out)
+		}
+	}
+}
+
 func TestRunDiscoveredCommand_PrefersEntryPackDir(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "actual-pack")


### PR DESCRIPTION
## Summary

- `runDiscoveredCommand` now projects the city's canonical Dolt connection into the pack command's environment via the same `applyOrderExecCanonicalDoltEnv` helper that exec order dispatch uses.
- When the city has no authoritative scope config the environment is returned unchanged, preserving managed-runtime self-resolution (state files) and operator-seeded `GC_DOLT_PORT`.
- Adds `TestRunDiscoveredCommand_ProjectsCanonicalExternalDoltEnv` (stale ambient `GC_DOLT_PORT`/`GC_DOLT_MANAGED_LOCAL` must lose to the configured endpoint) and `TestRunDiscoveredCommand_KeepsAmbientDoltEnvWithoutScopeConfig`.

## Problem

A city configured with an external Dolt endpoint (`gc.endpoint_origin: city_canonical` plus `dolt.host`/`dolt.port` in `.beads/config.yaml`) already gets `GC_DOLT_MANAGED_LOCAL=0` and the canonical host/port projected into **exec order dispatch**. Directly invoked pack commands took a different path: `runDiscoveredCommand` passed raw `os.Environ()` through, so the dolt pack scripts saw stale ambient `GC_DOLT_*` values or the inactive pack-managed runtime and skipped:

```
compact: GC_DOLT_PORT=3307 does not match managed runtime port=<inactive> for data_dir=... — skip
```

Observed on the maintainer-city host while diagnosing #2740: the scheduled `mol-dog-compactor` order resolved the external server correctly, but the documented operator invocation `gc dolt compact` skipped on every run (exit 0, so the skip was easy to miss). The same asymmetry affects every dolt pack command (`doctor`, `health`, `backup`, `sync`).

## Solution

Reuse the existing canonical projection rather than teaching each script a second resolution path: build an env map from the command's environment, run `applyOrderExecCanonicalDoltEnv` over it (city scope), and fold only the changed/removed keys back into the exec env. Order dispatch and direct CLI invocation now agree on the endpoint by construction.

## Testing

- `go test ./cmd/gc -run 'TestRunDiscoveredCommand|TestAddDiscoveredCommands|TestTryDiscoveredCommandFallback'` (all pass; new external-env test fails without the fix)
- `go test ./cmd/gc -run 'CanonicalDolt|OrderExecEnv'` (passes)
- `go vet ./cmd/gc`, `go build ./...` clean
- Note: a handful of unrelated `cmd/gc` no-city tests (`TestDoStartRequiresInitializedCity` etc.) fail on this host both on this branch **and on pristine origin/main** due to local artifacts (a stray `/tmp/city.toml` from concurrent agent work); CI is authoritative for those.

Part of the operational follow-up to #2740. Companion PR: #3326 (rig-list discovery bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)