### PR TITLE
fix(session-gc): reap phantom session beads + O(1) reconciler snapshot

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -572,6 +572,9 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		if reapStaleSessionBeads(cr.sessionsBeadStore().Store, cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
 			sessionBeads = cr.loadSessionBeadSnapshot()
 		}
+		if reapPhantomSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
+			sessionBeads = cr.loadSessionBeadSnapshot()
+		}
 		result := cr.buildDesiredState(sessionBeads, startupTrace)
 		sessionBeads = cr.loadSessionBeadSnapshot()
 		result = refreshDesiredStateWithSessionBeads(
@@ -1135,6 +1138,14 @@ func (cr *CityRuntime) tick(
 		sessionBeads = cr.loadSessionBeadSnapshot()
 		recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.after_reap", phaseStart, traceSessionSnapshotFields(sessionBeads))
 	}
+	phaseStart = time.Now()
+	phantomReaped := reapPhantomSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr)
+	recordPhase(TraceSiteControllerTickPhase, "reap_phantom_session_beads", phaseStart, map[string]any{"reaped": phantomReaped})
+	if phantomReaped > 0 {
+		phaseStart = time.Now()
+		sessionBeads = cr.loadSessionBeadSnapshot()
+		recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.after_phantom_reap", phaseStart, traceSessionSnapshotFields(sessionBeads))
+	}
 	if cr.cfg.Daemon.AutoReapClosedBeadWorktreesEnabled() {
 		phaseStart = time.Now()
 		beadWorktreesReaped := reapClosedBeadWorktrees(cr.cityPath, cr.cfg, cr.rigBeadStores(), cr.rec, cr.stderr)
@@ -1476,7 +1487,8 @@ func (cr *CityRuntime) runOrderTrackingRetentionWatchdog(now time.Time) {
 
 	policy := orderTrackingRetentionPolicyForConfig(cr.cfg)
 	deleted, sweepErr := sweepClosedOrderTrackingRetentionAcrossStoresBounded(
-		stores, now, policy, nil, orderTrackingRetentionWatchdogDeleteBudget)
+		stores, now, policy, nil, orderTrackingRetentionWatchdogDeleteBudget,
+	)
 	if err := errors.Join(storeErr, sweepErr); err != nil && cr.stderr != nil {
 		fmt.Fprintf(cr.stderr, "%s: order-tracking retention watchdog: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 	}
@@ -2188,7 +2200,8 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		poolDesired = retainScaleCheckPartialPoolDesired(
 			cr.cfg,
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-				cr.cfg, poolWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace)),
+				cr.cfg, poolWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace,
+			)),
 			sessionBeads,
 			result.PoolScaleCheckPartialTemplates,
 		)
@@ -2884,7 +2897,8 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 	poolDesired := retainScaleCheckPartialPoolDesired(
 		filteredCfg,
 		PoolDesiredCounts(ComputePoolDesiredStates(
-			filteredCfg, poolWorkBeads, open, wfcResult.ScaleCheckCounts)),
+			filteredCfg, poolWorkBeads, open, wfcResult.ScaleCheckCounts,
+		)),
 		newSessionBeadSnapshot(open),
 		wfcResult.PoolScaleCheckPartialTemplates,
 	)
@@ -3077,7 +3091,8 @@ func (cr *CityRuntime) loadDemandSnapshot(
 		result.PoolDesiredCounts = retainScaleCheckPartialPoolDesired(
 			cr.cfg,
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-				cr.cfg, poolWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace)),
+				cr.cfg, poolWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace,
+			)),
 			sessionBeads,
 			result.PoolScaleCheckPartialTemplates,
 		)

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1970,6 +1970,83 @@ func reapStaleSessionBeads(
 	return reaped
 }
 
+// reapPhantomSessionBeads closes open session beads that are phantom asleep
+// records — sessions the controller spawned but that were never adopted by a
+// real tmux session. A bead is a reapable phantom when:
+//   - state == "asleep" (visible as an idle pool slot)
+//   - last_woke_at == "" (never reached preWakeCommit, so it holds no claims)
+//   - session name NOT in the runtime visible set (no live tmux session)
+//   - NOT a configured named-session bead
+//   - NOT under active drain
+//
+// This is NOT reapStaleSessionBeads' domain: that function targets creating
+// state; this function targets asleep state. The two are complementary.
+//
+// Safety: if ListRunning returns any error (partial or hard), the GC pass is
+// skipped entirely — we do not reap under uncertainty.
+//
+// Returns the number of beads reaped.
+func reapPhantomSessionBeads(
+	store beads.Store,
+	sp runtime.Provider,
+	dt *drainTracker,
+	clk clock.Clock,
+	stderr io.Writer,
+) int {
+	if store == nil || sp == nil {
+		return 0
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	// O(1) list instead of O(n) per-session IsRunning calls. Any error
+	// (partial or hard) means we cannot trust the visible set — skip the
+	// pass entirely rather than reaping under uncertainty.
+	listed, listErr := sp.ListRunning("")
+	if listErr != nil {
+		return 0
+	}
+	visibleSet := make(map[string]bool, len(listed))
+	for _, sn := range listed {
+		sn = strings.TrimSpace(sn)
+		if sn != "" {
+			visibleSet[sn] = true
+		}
+	}
+
+	open, err := loadSessionBeads(store)
+	if err != nil {
+		fmt.Fprintf(stderr, "reapPhantomSessionBeads: %v\n", err) //nolint:errcheck
+		return 0
+	}
+	now := clk.Now()
+	reaped := 0
+	for _, b := range open {
+		state := strings.TrimSpace(b.Metadata["state"])
+		if state != "asleep" {
+			continue
+		}
+		if strings.TrimSpace(b.Metadata["last_woke_at"]) != "" {
+			continue
+		}
+		if isNamedSessionBead(b) {
+			continue
+		}
+		if dt != nil && dt.get(b.ID) != nil {
+			continue
+		}
+		sn := strings.TrimSpace(b.Metadata["session_name"])
+		if sn == "" || visibleSet[sn] {
+			continue
+		}
+		if closeBead(store, b.ID, "phantom-session", now.UTC(), stderr) {
+			fmt.Fprintf(stderr, "WARN: reconciler: reaped phantom session bead %s — tmux session %q never adopted\n", b.ID, sn) //nolint:errcheck
+			reaped++
+		}
+	}
+	return reaped
+}
+
 func cleanupDeadRuntimeSessionCorpses(
 	store beads.Store,
 	_ map[string]beads.Store,

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -8419,3 +8419,25 @@ func (p *phantomTestProvider) ListRunning(prefix string) ([]string, error) {
 	}
 	return names, nil
 }
+
+func TestControllerRuntimeReapsPhantomSessionBeadsAfterStaleSessionReap(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "city_runtime.go"))
+	if err != nil {
+		t.Fatalf("read city_runtime.go: %v", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	staleReapCalls := 0
+	for i, line := range lines {
+		if !strings.Contains(line, "reapStaleSessionBeads(") {
+			continue
+		}
+		staleReapCalls++
+		phantomReapLine := nextLineContaining(lines, i, "reapPhantomSessionBeads(")
+		if phantomReapLine == -1 {
+			t.Errorf("city_runtime.go:%d reapStaleSessionBeads is not followed by reapPhantomSessionBeads", i+1)
+		}
+	}
+	if staleReapCalls == 0 {
+		t.Fatal("city_runtime.go contains no reapStaleSessionBeads calls")
+	}
+}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -8199,3 +8199,223 @@ func TestPendingPoolSessionName_SanitizesDottedTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestReapPhantomSessionBeads(t *testing.T) {
+	newPhantomBead := func(name, state, lastWokeAt string, named bool) beads.Bead {
+		meta := map[string]string{
+			"session_name": name,
+			"state":        state,
+		}
+		if lastWokeAt != "" {
+			meta["last_woke_at"] = lastWokeAt
+		}
+		if named {
+			meta["configured_named_session"] = "true"
+		}
+		return beads.Bead{
+			Status:   "open",
+			Type:     sessionBeadType,
+			Labels:   []string{sessionBeadLabel},
+			Metadata: meta,
+		}
+	}
+
+	tests := []struct {
+		name          string
+		beads         []beads.Bead
+		running       []string // session names present in the runtime (ListRunning returns these)
+		drainingIndex []int    // indices into beads slice with active drain entries
+		listErr       error    // injected ListRunning error (nil = success)
+		nilStore      bool
+		nilSP         bool
+		wantReaped    int
+		wantOpen      int
+	}{
+		{
+			name: "reaps_asleep_never_woken_not_visible",
+			beads: []beads.Bead{
+				newPhantomBead("worker-1", "asleep", "", false),
+			},
+			running:    nil,
+			wantReaped: 1,
+			wantOpen:   0,
+		},
+		{
+			name: "keeps_asleep_was_woken_once",
+			beads: []beads.Bead{
+				newPhantomBead("worker-1", "asleep", "2026-01-01T00:00:00Z", false),
+			},
+			running:    nil,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "keeps_creating_state",
+			beads: []beads.Bead{
+				newPhantomBead("worker-1", "creating", "", false),
+			},
+			running:    nil,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "keeps_awake_state",
+			beads: []beads.Bead{
+				newPhantomBead("worker-1", "awake", "", false),
+			},
+			running:    nil,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "keeps_named_session_bead",
+			beads: []beads.Bead{
+				newPhantomBead("mayor", "asleep", "", true),
+			},
+			running:    nil,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "keeps_draining_bead",
+			beads: []beads.Bead{
+				newPhantomBead("worker-1", "asleep", "", false),
+			},
+			running:       nil,
+			drainingIndex: []int{0},
+			wantReaped:    0,
+			wantOpen:      1,
+		},
+		{
+			name: "keeps_bead_visible_in_runtime",
+			beads: []beads.Bead{
+				newPhantomBead("worker-1", "asleep", "", false),
+			},
+			running:    []string{"worker-1"},
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "skips_on_partial_list_error",
+			beads: []beads.Bead{
+				newPhantomBead("worker-1", "asleep", "", false),
+			},
+			running:    nil,
+			listErr:    &runtime.PartialListError{Err: errors.New("remote backend down")},
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "skips_on_hard_list_error",
+			beads: []beads.Bead{
+				newPhantomBead("worker-1", "asleep", "", false),
+			},
+			running:    nil,
+			listErr:    errors.New("tmux unreachable"),
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name:       "nil_store_returns_zero",
+			nilStore:   true,
+			wantReaped: 0,
+		},
+		{
+			name:       "nil_sp_returns_zero",
+			nilSP:      true,
+			wantReaped: 0,
+		},
+		{
+			name: "reaps_only_asleep_never_woken_among_mixed_beads",
+			beads: []beads.Bead{
+				newPhantomBead("worker-1", "asleep", "", false),    // phantom → reap
+				newPhantomBead("worker-2", "asleep", "now", false), // was woken → keep
+				newPhantomBead("worker-3", "creating", "", false),  // wrong domain → keep
+				newPhantomBead("worker-4", "asleep", "", false),    // in visible set → keep
+			},
+			running:    []string{"worker-4"},
+			wantReaped: 1,
+			wantOpen:   3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var store beads.Store
+			var createdIDs []string
+			if !tc.nilStore {
+				ms := beads.NewMemStore()
+				for _, b := range tc.beads {
+					created, err := ms.Create(b)
+					if err != nil {
+						t.Fatalf("setup: create bead: %v", err)
+					}
+					createdIDs = append(createdIDs, created.ID)
+				}
+				store = ms
+			}
+
+			var sp runtime.Provider
+			if !tc.nilSP {
+				sp = newPhantomTestProvider(tc.running, tc.listErr)
+			}
+
+			dt := newDrainTracker()
+			for _, idx := range tc.drainingIndex {
+				if idx < len(createdIDs) {
+					dt.set(createdIDs[idx], &drainState{reason: "user"})
+				}
+			}
+
+			var stderr bytes.Buffer
+			got := reapPhantomSessionBeads(store, sp, dt, clock.Real{}, &stderr)
+			if got != tc.wantReaped {
+				t.Errorf("reapPhantomSessionBeads() = %d, want %d; stderr=%q", got, tc.wantReaped, stderr.String())
+			}
+
+			if store == nil {
+				return
+			}
+			open, err := loadSessionBeads(store)
+			if err != nil {
+				t.Fatalf("loadSessionBeads: %v", err)
+			}
+			if len(open) != tc.wantOpen {
+				t.Errorf("open beads = %d, want %d", len(open), tc.wantOpen)
+			}
+		})
+	}
+}
+
+// phantomTestProvider is a minimal provider for TestReapPhantomSessionBeads that
+// supports configurable ListRunning results and errors.
+type phantomTestProvider struct {
+	*runtime.Fake
+	listErr error
+	visible map[string]bool
+}
+
+func newPhantomTestProvider(running []string, listErr error) *phantomTestProvider {
+	p := &phantomTestProvider{
+		Fake:    runtime.NewFake(),
+		listErr: listErr,
+		visible: make(map[string]bool, len(running)),
+	}
+	for _, name := range running {
+		p.visible[name] = true
+	}
+	return p
+}
+
+func (p *phantomTestProvider) ListRunning(prefix string) ([]string, error) {
+	if p.listErr != nil {
+		return nil, p.listErr
+	}
+	var names []string
+	for name := range p.visible {
+		if strings.HasPrefix(name, prefix) {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1156,6 +1156,23 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 		rollbackPendingCreate(session, sessFront, clk.Now().UTC(), stderr)
 	}
+	// O(1) tmux ls snapshot instead of O(n) per-session has-session probes.
+	// With 80+ phantoms the per-session path saturates the 50 ms probe budget
+	// → partial status → the spawn/phantom vicious cycle (vp-g0z1).
+	var listedRunning []string
+	var listRunErr error
+	if sp != nil {
+		listedRunning, listRunErr = sp.ListRunning("")
+	}
+	listRunPartial := listRunErr != nil && runtime.IsPartialListError(listRunErr)
+	visibleSet := make(map[string]bool, len(listedRunning))
+	if listRunErr == nil || listRunPartial {
+		for _, sn := range listedRunning {
+			if sn = strings.TrimSpace(sn); sn != "" {
+				visibleSet[sn] = true
+			}
+		}
+	}
 	phaseStart = time.Now()
 	for i := range ordered {
 		if ctx != nil && ctx.Err() != nil {
@@ -1196,9 +1213,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// Handle BEFORE heal/stability to avoid false crash detection —
 		// a running session that leaves the desired set is not a crash.
 		if !desired {
-			providerAlive, err := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, session.ID)
-			if err != nil {
-				providerAlive = false
+			var (
+				providerAlive bool
+				err           error
+			)
+			if listRunErr == nil || listRunPartial {
+				providerAlive = visibleSet[name]
+			} else {
+				providerAlive, err = workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, session.ID)
+				if err != nil {
+					providerAlive = false
+				}
 			}
 			// Run this before configured named-session preservation. A stale
 			// state=creating bead with an expired pending-create lease would

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -10173,6 +10173,33 @@ func TestPoolDesiredLimitsWakeWork(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_UsesVisibilitySnapshotForOrphanedSessions(t *testing.T) {
+	env := newReconcilerTestEnv()
+	// N=5 asleep session beads, none in desired state — these are the phantom
+	// accumulation scenario that drives probe timeout.
+	var sessions []beads.Bead
+	for i := 0; i < 5; i++ {
+		name := fmt.Sprintf("phantom-%d", i)
+		sessions = append(sessions, env.createSessionBead(name, "worker"))
+	}
+	// Fake runtime has no running sessions — all five are true phantoms.
+
+	env.reconcile(sessions)
+
+	if got := env.sp.CountCalls("ListRunning", ""); got != 1 {
+		t.Errorf("ListRunning calls = %d, want 1 (one O(1) snapshot per tick)", got)
+	}
+	isRunningCalls := 0
+	for _, c := range env.sp.SnapshotCalls() {
+		if c.Method == "IsRunning" {
+			isRunningCalls++
+		}
+	}
+	if isRunningCalls != 0 {
+		t.Errorf("IsRunning calls = %d, want 0 (must use visibleSet map, not per-session probe)", isRunningCalls)
+	}
+}
+
 // PR #209 -- skipped for now. Drained beads don't block capacity (all
 // selection paths skip them). Closing would break gc attach on drained
 // sessions. Tracked as a future cleanup task.


### PR DESCRIPTION
## Summary

Fixes a status-probe-timeout → partial-status → dispatch-suppression cycle caused by phantom session beads accumulating in the controller's session store.

**Root cause:** the session store can track far more "live" sessions than tmux actually has — the surplus are `asleep` phantom beads (never adopted, `last_woke_at` empty). The per-session probe calls `tmux has-session` once per bead (O(n)), saturating the probe budget with one goroutine per phantom → partial status → the reconciler reports control-dispatchers stopped → work sits unclaimed.

**Fix (three parts):**

- `reapPhantomSessionBeads` (`session_beads.go`): closes `asleep` beads with empty `last_woke_at` that have no live tmux session; skips GC when the running-session list is partial (safety guard).
- Wired into both startup and the main tick after the existing stale-session reap, with a snapshot reload when anything is reaped.
- Reconciler now takes a single `ListRunning("")` snapshot before the loop instead of an O(n) per-session `has-session` call (N phantoms → N goroutines → 0); falls back to per-session probe on a non-partial list error.

## Benefit
Phantom beads no longer blow the probe budget, so status stays complete and dispatch keeps flowing.

## Test plan

- [x] `TestReapPhantomSessionBeads` — all guard conditions
- [x] `TestControllerRuntimeReapsPhantomSessionBeadsAfterStaleSessionReap` — wire-in ordering
- [x] `TestReconcileSessionBeads_UsesVisibilitySnapshotForOrphanedSessions` — ListRunning called once, no per-phantom probe
