### PR TITLE
fix(reload): refresh bundled pack caches before config reload

### DIFF
--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gastownhall/gascity/internal/convergence"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
 	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/supervisor"
@@ -895,6 +896,15 @@ func reloadWarningsFromError(err error) []string {
 func tryReloadConfig(tomlPath, lockedWorkspaceName, cityRoot string) (*reloadResult, error) {
 	if err := ensureLegacyNamedPacksCached(cityRoot); err != nil {
 		return nil, fmt.Errorf("fetching packs: %w", err)
+	}
+	// Re-materialize any bundled pack synthetic caches that were written by a
+	// different binary version. The config loader's strict content-hash check
+	// rejects caches whose hash was produced by a binary whose embedded pack
+	// content differs from the running controller (e.g., after "gc import install"
+	// runs with a newer on-disk binary). EnsureBundledPacksCurrent repairs stale
+	// caches from the running binary's embedded packs before the loader validates.
+	if err := packman.EnsureBundledPacksCurrent(cityRoot); err != nil {
+		return nil, fmt.Errorf("refreshing bundled pack caches: %w", err)
 	}
 
 	if err := ensureBuiltinPacksForConfigLoad(fsys.OSFS{}, tomlPath, resolveLoadCityConfigWarningWriter()); err != nil {

--- a/internal/config/bundled_import_test.go
+++ b/internal/config/bundled_import_test.go
@@ -125,6 +125,55 @@ func TestPublicGastownPackSourceMapsToBundledGastownPack(t *testing.T) {
 	}
 }
 
+func TestResolvePackRefServesLockedImportEvenWithGitRef(t *testing.T) {
+	// Regression test: a workspace.includes entry with an explicit "#ref"
+	// (e.g., "#main") previously bypassed the import lock and required the
+	// city-local .gc/cache/includes/ directory to exist. After the fix,
+	// resolvePackRef checks the lock first regardless of the gitRef.
+	home, cityDir := setupBundledImportTest(t)
+	const source = "https://github.com/example/mypack.git"
+	const commit = "abc123def456abc123def456abc123def456abc123de"
+
+	// Write packs.lock so the source is treated as installed.
+	writeTestFile(t, cityDir, "packs.lock", fmt.Sprintf(`
+schema = 1
+
+[packs.%q]
+version = "1.0.0"
+commit = %q
+fetched = "2026-01-01T00:00:00Z"
+`, source, commit))
+
+	// Populate the shared repo cache with a fake git checkout.
+	cacheRoot := filepath.Join(home, ".gc", "cache", "repos")
+	cacheDir := filepath.Join(cacheRoot, RepoCacheKey(source, commit))
+	mustMkdirAll(t, filepath.Join(cacheDir, ".git"), 0o755)
+	writeTestFile(t, cacheDir, ".git/index", "idx")
+	writeTestFile(t, cacheDir, "pack.toml", "[pack]\nname = \"mypack\"\nschema = 1\n")
+
+	// Stub the git rev-parse / status calls used by validateInstalledRemoteCache.
+	orig := runRepoCacheGit
+	runRepoCacheGit = func(_ string, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "rev-parse" {
+			return commit + "\n", nil
+		}
+		return "", nil // status --porcelain: clean
+	}
+	t.Cleanup(func() { runRepoCacheGit = orig })
+
+	// With a "#main" gitRef the old code skipped the lock entirely and
+	// went to fetchRemoteInclude (which would fail with "not cached at ...").
+	refWithGitRef := source + "#main"
+
+	got, err := resolvePackRef(refWithGitRef, cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("resolvePackRef(%q): %v", refWithGitRef, err)
+	}
+	if got != cacheDir {
+		t.Fatalf("resolvePackRef = %q, want %q", got, cacheDir)
+	}
+}
+
 func TestResolveLockedRemoteImportSurfacesInvalidBundledMarker(t *testing.T) {
 	home, cityDir := setupBundledImportTest(t)
 	source := bundledPackSource()

--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -109,13 +109,26 @@ func resolvePackRef(ref, declDir, cityRoot string) (string, error) {
 		// locked imports (including registry-recommended GitHub tree
 		// URLs) resolvable without the legacy include cache, which has
 		// no remaining writer.
-		if cacheDir, ok, err := resolveLockedRemoteImport(ref, cityRoot); err != nil {
-			return "", err
-		} else if ok {
-			if subpath != "" {
-				return filepath.Join(cacheDir, subpath), nil
+		//
+		// The lock may key the import either under the verbatim authored
+		// ref (e.g. a GitHub tree URL) or under the base clone URL (e.g. a
+		// "src.git#ref" form whose ref is normalized away at install
+		// time). Try the authored ref first, then fall back to the base
+		// source so both lock-key shapes resolve from the shared repo
+		// cache.
+		lockKeys := []string{ref}
+		if source != ref {
+			lockKeys = append(lockKeys, source)
+		}
+		for _, key := range lockKeys {
+			if cacheDir, ok, err := resolveLockedRemoteImport(key, cityRoot); err != nil {
+				return "", err
+			} else if ok {
+				if subpath != "" {
+					return filepath.Join(cacheDir, subpath), nil
+				}
+				return cacheDir, nil
 			}
-			return cacheDir, nil
 		}
 		cacheDir, err := fetchRemoteInclude(source, gitRef, cityRoot)
 		if err != nil {

--- a/internal/packman/install.go
+++ b/internal/packman/install.go
@@ -97,6 +97,42 @@ func InstallLocked(cityRoot string) (*Lockfile, error) {
 	return lock, nil
 }
 
+// EnsureBundledPacksCurrent repairs any bundled pack synthetic caches that were
+// written by a different binary version. Each call to EnsureRepoInCache for a
+// bundled source validates the cache against the running binary's embedded
+// content and re-materializes it when the hashes differ. This prevents the
+// config loader's strict content-hash check from failing after a binary upgrade
+// where the running controller and the most-recently-installed binary differ.
+//
+// Callers that need to ensure all packs (including remote git clones) are
+// present should use InstallLocked instead.
+func EnsureBundledPacksCurrent(cityRoot string) error {
+	lock, err := ReadLockfile(fsys.OSFS{}, cityRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No lockfile; nothing to repair.
+		}
+		return err
+	}
+	sources := make([]string, 0, len(lock.Packs))
+	for source := range lock.Packs {
+		if builtinpacks.IsSource(source) {
+			sources = append(sources, source)
+		}
+	}
+	sort.Strings(sources)
+	for _, source := range sources {
+		pack := lock.Packs[source]
+		if pack.Commit == "" {
+			continue
+		}
+		if _, err := EnsureRepoInCache(source, pack.Commit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SyncLock resolves the reachable remote-import closure and returns the updated lock.
 func SyncLock(cityRoot string, imports map[string]config.Import, mode InstallMode) (*Lockfile, error) {
 	return syncLock(cityRoot, imports, mode, nil)

--- a/internal/packman/install_test.go
+++ b/internal/packman/install_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/builtinpacks"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
@@ -644,6 +645,99 @@ func TestSyncLockAllowsMultipleSubpathsFromSameRepoWithSharedClone(t *testing.T)
 	}
 	if lock.Packs["file:///tmp/repo.git//packs/b"].Commit != "aaaa" {
 		t.Fatalf("subpath b commit = %q, want aaaa", lock.Packs["file:///tmp/repo.git//packs/b"].Commit)
+	}
+}
+
+func TestEnsureBundledPacksCurrentRepairsStaleSyntheticCache(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+
+	source, ok := builtinpacks.Source("core")
+	if !ok {
+		t.Fatal("no bundled core source")
+	}
+	commit := "abc123def456abc123def456abc123def456abc123de"
+	if err := WriteLockfile(fsys.OSFS{}, city, &Lockfile{
+		Schema: LockfileSchema,
+		Packs:  map[string]LockedPack{source: {Version: "1.0.0", Commit: commit}},
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	// Write a synthetic cache with a stale content hash, simulating a cache
+	// produced by a different binary version (the binary-upgrade skew case).
+	cacheDir, err := RepoCachePath(source, commit)
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+		t.Fatalf("MaterializeSyntheticRepo: %v", err)
+	}
+	staleMarker := `.gc-bundled-pack-cache.toml`
+	stalePath := filepath.Join(cacheDir, staleMarker)
+	staleData := `schema = 1
+repository = "https://github.com/gastownhall/gascity.git"
+commit = "` + commit + `"
+content_hash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+`
+	if err := os.WriteFile(stalePath, []byte(staleData), 0o644); err != nil {
+		t.Fatalf("WriteFile(stale marker): %v", err)
+	}
+	// Confirm the cache is stale before the repair.
+	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, commit); err == nil {
+		t.Fatal("expected stale cache to fail validation before repair")
+	}
+
+	if err := EnsureBundledPacksCurrent(city); err != nil {
+		t.Fatalf("EnsureBundledPacksCurrent: %v", err)
+	}
+
+	// After repair the cache must pass validation.
+	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, commit); err != nil {
+		t.Fatalf("ValidateSyntheticRepo after repair: %v", err)
+	}
+}
+
+func TestEnsureBundledPacksCurrentSkipsNonBundledPacks(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
+
+	// Non-bundled pack in packs.lock — should not be cloned by
+	// EnsureBundledPacksCurrent.
+	if err := WriteLockfile(fsys.OSFS{}, city, &Lockfile{
+		Schema: LockfileSchema,
+		Packs: map[string]LockedPack{
+			"https://example.com/a.git": {Version: "1.0.0", Commit: "aaaa"},
+		},
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	var cloned []string
+	prev := runGit
+	runGit = func(_ string, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "clone" {
+			cloned = append(cloned, args[len(args)-2])
+		}
+		return prev("", args...)
+	}
+	t.Cleanup(func() { runGit = prev })
+
+	if err := EnsureBundledPacksCurrent(city); err != nil {
+		t.Fatalf("EnsureBundledPacksCurrent: %v", err)
+	}
+	if len(cloned) != 0 {
+		t.Fatalf("cloned %d non-bundled repos, want 0", len(cloned))
+	}
+}
+
+func TestEnsureBundledPacksCurrentNoLockfile(t *testing.T) {
+	city := t.TempDir()
+	if err := EnsureBundledPacksCurrent(city); err != nil {
+		t.Fatalf("EnsureBundledPacksCurrent with no lockfile: %v", err)
 	}
 }
 


### PR DESCRIPTION
- Repairs stale bundled synthetic pack caches after binary upgrades before strict config reload validation.
- Lets locked imports resolve from `packs.lock` even when the include uses an explicit git ref.
- Validation: `CGO_ENABLED=0 go test ./internal/packman ./internal/config`; focused `cmd/gc` reload tests; `go vet ./...` with ICU paths. Note local raw CGO tests were blocked by ICU header/linker environment.