### PR TITLE
fix(gastown): verify polecat push before refinery handoff

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -909,6 +909,12 @@ func TestPolecatPromptHaltsOnAutoPushFalse(t *testing.T) {
 		"exit 0",
 		"fi",
 		"git push origin HEAD",
+		`REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')`,
+		`LOCAL_HEAD=$(git rev-parse HEAD)`,
+		`PUSH VERIFICATION FAILED`,
+		`gc runtime drain-ack`,
+		"exit 1",
+		`gc bd update <work-bead> \`,
 	)
 }
 
@@ -938,6 +944,12 @@ func TestPolecatRenderedApprovalFallacyHaltsOnAutoPushFalse(t *testing.T) {
 		"exit 0",
 		"fi",
 		"git push origin HEAD",
+		`REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')`,
+		`LOCAL_HEAD=$(git rev-parse HEAD)`,
+		`PUSH VERIFICATION FAILED`,
+		`gc runtime drain-ack`,
+		"exit 1",
+		`gc bd update <work-bead> \`,
 	)
 }
 
@@ -967,6 +979,13 @@ func TestPolecatFormulaHaltsOnAutoPushFalse(t *testing.T) {
 		"exit 0",
 		"fi",
 		"git push origin HEAD",
+		"PUSH_EXIT=$?",
+		`REMOTE_REF=$(git ls-remote origin "refs/heads/$CURRENT_BRANCH" 2>/dev/null | awk '{print $1}')`,
+		`LOCAL_HEAD=$(git rev-parse HEAD)`,
+		`PUSH VERIFICATION FAILED`,
+		`gc runtime drain-ack`,
+		"exit 1",
+		"```",
 	)
 }
 

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -269,7 +269,16 @@ if [ "$AUTO_PUSH" = "false" ]; then
   gc runtime drain-ack
   exit 0
 fi
-git push origin HEAD
+git push origin HEAD && {
+  BRANCH=$(git branch --show-current)
+  REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')
+  LOCAL_HEAD=$(git rev-parse HEAD)
+  if [ -z "$REMOTE_REF" ] || [ "$REMOTE_REF" != "$LOCAL_HEAD" ]; then
+    echo "PUSH VERIFICATION FAILED: origin/$BRANCH does not match local HEAD. Aborting handoff."
+    gc runtime drain-ack
+    exit 1
+  fi
+} || { echo "PUSH FAILED. Aborting handoff — bead stays with polecat."; gc runtime drain-ack; exit 1; }
 gc bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -366,6 +366,34 @@ if [ "$AUTO_PUSH" = "false" ]; then
   exit 0
 fi
 git push origin HEAD
+PUSH_EXIT=$?
+if [ $PUSH_EXIT -ne 0 ]; then
+    echo "PUSH FAILED (exit $PUSH_EXIT)"
+    echo "Branch '$CURRENT_BRANCH' was NOT pushed to origin."
+    echo "Aborting handoff — bead stays with polecat."
+    echo ""
+    echo "Diagnose the push failure (network, auth, force-needed?) and re-run submit-and-exit."
+    gc runtime drain-ack
+    exit 1
+fi
+# Verify the ref is reachable on origin before trusting the push succeeded.
+REMOTE_REF=$(git ls-remote origin "refs/heads/$CURRENT_BRANCH" 2>/dev/null | awk '{print $1}')
+LOCAL_HEAD=$(git rev-parse HEAD)
+if [ -z "$REMOTE_REF" ]; then
+    echo "PUSH VERIFICATION FAILED"
+    echo "  git push exited 0 but 'git ls-remote' returned no ref for '$CURRENT_BRANCH' on origin."
+    echo "  Branch is local-only. Aborting handoff."
+    gc runtime drain-ack
+    exit 1
+fi
+if [ "$REMOTE_REF" != "$LOCAL_HEAD" ]; then
+    echo "PUSH VERIFICATION FAILED"
+    echo "  origin/$CURRENT_BRANCH = $REMOTE_REF"
+    echo "  local HEAD             = $LOCAL_HEAD"
+    echo "  Branch tip on origin does not match local HEAD. Aborting handoff."
+    gc runtime drain-ack
+    exit 1
+fi
 ```
 
 **4. Clean up local branch (prevent stale branch accumulation):**

--- a/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
@@ -36,7 +36,16 @@ if [ "$AUTO_PUSH" = "false" ]; then
   gc runtime drain-ack
   exit 0
 fi
-git push origin HEAD
+git push origin HEAD && {
+  BRANCH=$(git branch --show-current)
+  REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')
+  LOCAL_HEAD=$(git rev-parse HEAD)
+  if [ -z "$REMOTE_REF" ] || [ "$REMOTE_REF" != "$LOCAL_HEAD" ]; then
+    echo "PUSH VERIFICATION FAILED: origin/$BRANCH does not match local HEAD. Aborting handoff."
+    gc runtime drain-ack
+    exit 1
+  fi
+} || { echo "PUSH FAILED. Aborting handoff — bead stays with polecat."; gc runtime drain-ack; exit 1; }
 gc bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \


### PR DESCRIPTION
- Makes polecat done sequence fail closed if `git push` fails or origin branch ref does not match local HEAD.
- Prevents reassigning work to refinery with a local-only or stale branch.
- Applies to formula, prompt, and approval-fallacy fragment, with tests.
- Validation: `CGO_ENABLED=0 go test ./examples/gastown -run ...` targeted polecat tests.