### PR TITLE
fix(dolt): derive doctor connection cap from server settings

### DIFF
--- a/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
@@ -20,7 +20,6 @@ USER="${GC_DOLT_USER:-root}"
 # precedence; otherwise derive from the legacy seconds knob (default 1s ->
 # 1000ms) for backward compatibility.
 LATENCY_WARN_MS="${GC_DOCTOR_LATENCY_WARN_MS:-$(( ${GC_DOCTOR_LATENCY_WARN_S:-1} * 1000 ))}"
-CONN_MAX="${GC_DOCTOR_CONN_MAX:-50}"
 CONN_WARN_PCT="${GC_DOCTOR_CONN_WARN_PCT:-80}"
 BACKUP_STALE_S="${GC_DOCTOR_BACKUP_STALE_S:-43200}"  # 2x 6h backup interval
 BACKUP_ARTIFACT_DIR="${GC_BACKUP_ARTIFACT_DIR:-$GC_CITY_PATH/.dolt-backup}"
@@ -30,6 +29,18 @@ dolt_sql() {
         run_bounded 10 \
         dolt --host "$HOST" --port "$PORT" --user "$USER" --no-tls sql "$@"
 }
+
+# CONN_MAX: explicit override > server @@GLOBAL.max_connections > fallback.
+if [ -n "${GC_DOCTOR_CONN_MAX:-}" ]; then
+    CONN_MAX="$GC_DOCTOR_CONN_MAX"
+else
+    _server_max=$(dolt_sql -r csv -q "SELECT @@GLOBAL.max_connections" 2>/dev/null | tail -1 || true)
+    case "${_server_max:-}" in
+        ''|*[!0-9]*) CONN_MAX=256 ;;
+        *) CONN_MAX="$_server_max" ;;
+    esac
+    unset _server_max
+fi
 
 file_mtime() {
     file_path="$1"

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -3949,6 +3949,82 @@ exit 0
 	}
 }
 
+func TestDoctorScriptUsesServerMaxConnections(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		extraEnv  []string
+		want      string
+		wantQuery bool
+	}{
+		{
+			name:      "server value",
+			extraEnv:  []string{"GC_FAKE_MAX_CONNECTIONS=512", "GC_FAKE_CONN_COUNT=220"},
+			want:      "conns: 220/512",
+			wantQuery: true,
+		},
+		{
+			name:      "explicit override",
+			extraEnv:  []string{"GC_DOCTOR_CONN_MAX=100", "GC_FAKE_MAX_CONNECTIONS=512", "GC_FAKE_CONN_COUNT=70"},
+			want:      "conns: 70/100",
+			wantQuery: false,
+		},
+		{
+			name:      "malformed server value fallback",
+			extraEnv:  []string{"GC_FAKE_MAX_CONNECTIONS=not-a-number", "GC_FAKE_CONN_COUNT=220"},
+			want:      "conns: 220/256",
+			wantQuery: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			dataDir := filepath.Join(cityPath, "dolt-data")
+			if err := os.MkdirAll(dataDir, 0o755); err != nil {
+				t.Fatalf("mkdir data dir: %v", err)
+			}
+
+			binDir := t.TempDir()
+			queryLogPath := filepath.Join(binDir, "dolt-queries.log")
+			writeDogFakeGC(t, binDir)
+			writeExecutable(t, filepath.Join(binDir, "dolt"), fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%%s\n' "$*" >> %s
+case "$*" in
+  *"SELECT active_branch()"*)
+    printf 'active_branch()\nmain\n'
+    exit 0
+    ;;
+  *"SELECT @@GLOBAL.max_connections"*)
+    printf '@@GLOBAL.max_connections\n%%s\n' "${GC_FAKE_MAX_CONNECTIONS:-512}"
+    exit 0
+    ;;
+  *"COUNT(*) FROM information_schema.PROCESSLIST"*)
+    printf 'COUNT(*)\n%%s\n' "${GC_FAKE_CONN_COUNT:-1}"
+    exit 0
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\n'
+    exit 0
+    ;;
+esac
+exit 0
+`, shellQuote(queryLogPath)))
+
+			out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir, tc.extraEnv...)
+			if !strings.Contains(out, tc.want) {
+				t.Fatalf("doctor summary mismatch: want %q, output:\n%s", tc.want, out)
+			}
+			queryLog, err := os.ReadFile(queryLogPath)
+			if err != nil {
+				t.Fatalf("read fake dolt query log: %v", err)
+			}
+			hasQuery := strings.Contains(string(queryLog), "SELECT @@GLOBAL.max_connections")
+			if hasQuery != tc.wantQuery {
+				t.Fatalf("max_connections query presence = %v, want %v, log:\n%s", hasQuery, tc.wantQuery, queryLog)
+			}
+		})
+	}
+}
+
 // TestDoctorScriptAdvisoryMailUsesGenericEscalation asserts the latency-WARN
 // advisory path goes through the generic escalation recipient.
 func TestDoctorScriptAdvisoryMailUsesGenericEscalation(t *testing.T) {


### PR DESCRIPTION
- Replaces hardcoded doctor connection cap with precedence: `GC_DOCTOR_CONN_MAX` > `@@GLOBAL.max_connections` > fallback `256`.
- Uses hermetic test coverage against the real doctor script.
- Validation: `bash -n examples/bd/dolt/assets/scripts/mol-dog-doctor.sh`; `CGO_ENABLED=0 go test ./examples/bd/dolt -run TestDoctorScriptUsesServerMaxConnections`.