### PR TITLE
feat: add registry publish login flows

### DIFF
--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/packman"
 	"github.com/gastownhall/gascity/internal/pricing"
 	"github.com/spf13/cobra"
@@ -1582,6 +1583,10 @@ func canonicalizeLocalGitImportSource(targetDir string) (string, bool, error) {
 
 func localGitRepoRoot(targetDir string) (string, bool, error) {
 	cmd := exec.Command("git", "-C", targetDir, "rev-parse", "--show-toplevel")
+	// Strip git-locating env vars (GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, ...)
+	// so the toplevel resolves from targetDir, not a parent repo leaked through
+	// a pre-commit hook or nested worktree tooling.
+	cmd.Env = git.SanitizedEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		text := string(out)
@@ -1600,6 +1605,10 @@ func localGitRepoRoot(targetDir string) (string, bool, error) {
 func defaultImportHeadCommit(source string) (string, error) {
 	cloneURL := config.NormalizeRemoteSource(source)
 	cmd := exec.Command("git", "ls-remote", cloneURL, "HEAD")
+	// Strip git-locating env vars so a leaked GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE
+	// (or config injection) from a parent pre-commit hook or worktree tooling
+	// cannot perturb how this remote HEAD probe runs.
+	cmd.Env = git.SanitizedEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("resolving HEAD for %q: %w", source, err)

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -3110,3 +3110,75 @@ func gitOutputImportE(t *testing.T, dir string, args ...string) (string, error) 
 	}
 	return strings.TrimSpace(string(out)), nil
 }
+
+// TestLocalGitRepoRootIgnoresPoisonedGitEnv proves localGitRepoRoot resolves
+// the toplevel of the requested targetDir even when git-locating environment
+// variables point at an unrelated repository. Running gc inside a pre-commit
+// hook or nested worktree tooling exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE
+// for the parent repo; the import probe must strip those so the local import
+// target is resolved from its own working directory.
+func TestLocalGitRepoRootIgnoresPoisonedGitEnv(t *testing.T) {
+	repo := t.TempDir()
+	mustGitImport(t, repo, "init")
+	// Capture git's own resolved toplevel before poisoning so symlink
+	// normalization matches localGitRepoRoot's later result.
+	wantRoot := gitOutputImport(t, repo, "rev-parse", "--show-toplevel")
+
+	poison := t.TempDir()
+	mustGitImport(t, poison, "init")
+	t.Setenv("GIT_DIR", filepath.Join(poison, ".git"))
+	t.Setenv("GIT_WORK_TREE", poison)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(poison, ".git", "index"))
+
+	got, ok, err := localGitRepoRoot(repo)
+	if err != nil {
+		t.Fatalf("localGitRepoRoot with poisoned git env: %v", err)
+	}
+	if !ok {
+		t.Fatalf("localGitRepoRoot ok = false, want true for an initialized repo")
+	}
+	if got != wantRoot {
+		t.Fatalf("localGitRepoRoot = %q, want %q (must ignore poisoned GIT_DIR)", got, wantRoot)
+	}
+}
+
+// TestDefaultImportHeadCommitIgnoresPoisonedGitEnv proves defaultImportHeadCommit
+// resolves the HEAD of the requested source under a poisoned git environment.
+// `git ls-remote <url>` lists refs from the explicit URL, so the sanitized
+// environment is defense-in-depth (against config injection or a future change
+// that relies on local repo discovery); the resolved HEAD must still be the
+// requested source's, never the leaked parent's.
+func TestDefaultImportHeadCommitIgnoresPoisonedGitEnv(t *testing.T) {
+	repo := t.TempDir()
+	mustGitImport(t, repo, "init")
+	if err := os.WriteFile(filepath.Join(repo, "f.txt"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	mustGitImport(t, repo, "add", ".")
+	mustGitImport(t, repo, "commit", "-m", "initial")
+	wantHead := gitOutputImport(t, repo, "rev-parse", "HEAD")
+
+	// A second repo whose HEAD differs from the source.
+	poison := t.TempDir()
+	mustGitImport(t, poison, "init")
+	if err := os.WriteFile(filepath.Join(poison, "p.txt"), []byte("poison\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(poison): %v", err)
+	}
+	mustGitImport(t, poison, "add", ".")
+	mustGitImport(t, poison, "commit", "-m", "poison")
+	poisonHead := gitOutputImport(t, poison, "rev-parse", "HEAD")
+	if poisonHead == wantHead {
+		t.Fatalf("poison HEAD unexpectedly equals source HEAD %s", wantHead)
+	}
+	t.Setenv("GIT_DIR", filepath.Join(poison, ".git"))
+	t.Setenv("GIT_WORK_TREE", poison)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(poison, ".git", "index"))
+
+	got, err := defaultImportHeadCommit(repo)
+	if err != nil {
+		t.Fatalf("defaultImportHeadCommit with poisoned git env: %v", err)
+	}
+	if got != wantHead {
+		t.Fatalf("defaultImportHeadCommit = %q, want %q (must resolve the requested source)", got, wantHead)
+	}
+}

--- a/cmd/gc/cmd_pack_release.go
+++ b/cmd/gc/cmd_pack_release.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/packregistry"
 	"github.com/gastownhall/gascity/internal/remotesource"
 	"github.com/spf13/cobra"
@@ -273,6 +274,10 @@ func resolveLocalPackReleaseSource(source, packPath string) (repoDir, resolvedPa
 
 func localGitRoot(path string) (string, error) {
 	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
+	// Strip git-locating env vars (GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, ...)
+	// so the toplevel resolves from path, not a parent repo leaked through a
+	// pre-commit hook or nested worktree tooling.
+	cmd.Env = git.SanitizedEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("resolving local git root for %q: %s: %w", path, strings.TrimSpace(string(out)), err)
@@ -349,38 +354,16 @@ func runPackReleaseGitCommand(dir string, args ...string) error {
 	if dir != "" {
 		cmd.Dir = dir
 	}
-	for _, env := range os.Environ() {
-		key, _, ok := strings.Cut(env, "=")
-		if ok && packReleaseGitEnvBlacklist[key] {
-			continue
-		}
-		cmd.Env = append(cmd.Env, env)
-	}
-	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	// Use the shared hermetic git environment so the isolated release-repo cache
+	// commands run with the canonical blacklist plus the discovery/config
+	// isolation and config pins, instead of a hand-maintained duplicate that can
+	// silently drift from git.HermeticEnv().
+	cmd.Env = git.HermeticEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
 	}
 	return nil
-}
-
-var packReleaseGitEnvBlacklist = map[string]bool{
-	"GIT_DIR":                          true,
-	"GIT_WORK_TREE":                    true,
-	"GIT_INDEX_FILE":                   true,
-	"GIT_OBJECT_DIRECTORY":             true,
-	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
-	"GIT_COMMON_DIR":                   true,
-	"GIT_CEILING_DIRECTORIES":          true,
-	"GIT_DISCOVERY_ACROSS_FILESYSTEM":  true,
-	"GIT_NAMESPACE":                    true,
-	"GIT_CONFIG":                       true,
-	"GIT_CONFIG_GLOBAL":                true,
-	"GIT_CONFIG_SYSTEM":                true,
-	"GIT_CONFIG_NOSYSTEM":              true,
-	"GIT_CONFIG_COUNT":                 true,
-	"GIT_EXEC_PATH":                    true,
-	"GIT_PAGER":                        true,
 }
 
 func normalizePackReleasePath(raw string) (string, error) {

--- a/cmd/gc/cmd_pack_release_test.go
+++ b/cmd/gc/cmd_pack_release_test.go
@@ -200,3 +200,50 @@ func outputPackReleaseGit(t *testing.T, dir string, args ...string) string {
 	}
 	return string(out)
 }
+
+// TestLocalGitRootIgnoresPoisonedGitEnv proves localGitRoot resolves the
+// toplevel of the requested path even when git-locating environment variables
+// point at an unrelated repository. Running gc inside a pre-commit hook or
+// nested worktree tooling exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE for the
+// parent repo; the pack-release git subprocesses must strip those so the path
+// is resolved from its own working directory.
+func TestLocalGitRootIgnoresPoisonedGitEnv(t *testing.T) {
+	repo, _ := initPackReleaseRepo(t)
+	// Capture git's own resolved toplevel before poisoning so symlink
+	// normalization matches localGitRoot's later result.
+	wantRoot := strings.TrimSpace(outputPackReleaseGit(t, repo, "rev-parse", "--show-toplevel"))
+
+	// A second, unrelated repo whose git-locating env vars would redirect
+	// resolution to its own toplevel if inherited.
+	poison := t.TempDir()
+	runPackReleaseGit(t, poison, "init")
+	t.Setenv("GIT_DIR", filepath.Join(poison, ".git"))
+	t.Setenv("GIT_WORK_TREE", poison)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(poison, ".git", "index"))
+
+	got, err := localGitRoot(repo)
+	if err != nil {
+		t.Fatalf("localGitRoot with poisoned git env: %v", err)
+	}
+	if got != wantRoot {
+		t.Fatalf("localGitRoot = %q, want %q (must ignore poisoned GIT_DIR)", got, wantRoot)
+	}
+}
+
+// TestRunPackReleaseGitCommandIgnoresPoisonedGitEnv proves the isolated
+// release-repo cache git commands ignore leaked git-locating environment
+// variables. A poisoned GIT_DIR pointing at a path with no repository would
+// make `git status` fail if inherited; the sanitized environment must drop it
+// so the command operates on the requested dir.
+func TestRunPackReleaseGitCommandIgnoresPoisonedGitEnv(t *testing.T) {
+	repo, _ := initPackReleaseRepo(t)
+
+	missing := filepath.Join(t.TempDir(), "nonexistent")
+	t.Setenv("GIT_DIR", missing)
+	t.Setenv("GIT_WORK_TREE", missing)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(missing, "index"))
+
+	if err := runPackReleaseGitCommand(repo, "status", "--porcelain"); err != nil {
+		t.Fatalf("runPackReleaseGitCommand with poisoned git env: %v", err)
+	}
+}

--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -1,0 +1,576 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/spf13/cobra"
+)
+
+const defaultRegistryPublishURL = "https://registry.gascity.com"
+
+var registryPublishHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+func newRegistryCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry",
+		Short: "Publish packs to Gas City Registry",
+		Long:  "Publish packs to the hosted Gas City Registry.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newRegistryPublishCmd(stdout, stderr))
+	return cmd
+}
+
+type registryPublishOptions struct {
+	RegistryURL   string
+	Version       string
+	Ref           string
+	Description   string
+	SessionCookie string
+	CSRFToken     string
+	DryRun        bool
+	Validate      bool
+	DevAuth       bool
+	DevAuthHandle string
+}
+
+func newRegistryPublishCmd(stdout, stderr io.Writer) *cobra.Command {
+	opts := registryPublishOptions{
+		RegistryURL:   registryFirstNonEmpty(os.Getenv("GC_REGISTRY_URL"), defaultRegistryPublishURL),
+		SessionCookie: os.Getenv("GC_REGISTRY_SESSION"),
+		CSRFToken:     os.Getenv("GC_REGISTRY_CSRF_TOKEN"),
+		Validate:      true,
+		DevAuthHandle: "local-cli",
+	}
+	cmd := &cobra.Command{
+		Use:   "publish <path-to-pack-root>",
+		Short: "Submit a pack publish request",
+		Long: `Submit a pack publish request to Gas City Registry.
+
+The command requires a clean Git checkout whose current HEAD matches its
+configured upstream branch, then submits the GitHub repository, commit, pack
+path, pack name, and version to the registry API.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if doRegistryPublish(args[0], opts, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", opts.RegistryURL, "registry app base URL")
+	cmd.Flags().StringVar(&opts.Version, "version", "", "release version; defaults to [pack].version")
+	cmd.Flags().StringVar(&opts.Ref, "ref", "", "release ref label; defaults to the upstream branch name")
+	cmd.Flags().StringVar(&opts.Description, "description", "", "release description; defaults to [pack].description")
+	cmd.Flags().StringVar(&opts.SessionCookie, "session-cookie", opts.SessionCookie, "registry_session cookie value or Cookie header")
+	cmd.Flags().StringVar(&opts.CSRFToken, "csrf-token", opts.CSRFToken, "registry CSRF token")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print the publish request without submitting")
+	cmd.Flags().BoolVar(&opts.Validate, "validate", opts.Validate, "ask the registry to validate the request immediately")
+	cmd.Flags().BoolVar(&opts.DevAuth, "dev-auth", false, "create a local dev-auth session before submitting; localhost only")
+	cmd.Flags().StringVar(&opts.DevAuthHandle, "dev-auth-handle", opts.DevAuthHandle, "dev-auth handle when --dev-auth is used")
+	return cmd
+}
+
+func doRegistryPublish(packRoot string, opts registryPublishOptions, stdout, stderr io.Writer) int {
+	request, err := buildRegistryPublishRequest(packRoot, opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	baseURL, err := normalizeRegistryPublishBaseURL(opts.RegistryURL)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	if opts.DryRun {
+		writeRegistryPublishDryRun(stdout, baseURL, request)
+		return 0
+	}
+
+	auth := registryPublishAuth{
+		SessionCookie: strings.TrimSpace(opts.SessionCookie),
+		CSRFToken:     strings.TrimSpace(opts.CSRFToken),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	if opts.DevAuth {
+		var err error
+		auth, err = registryPublishDevAuth(ctx, registryPublishHTTPClient, baseURL, opts.DevAuthHandle)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+			return 1
+		}
+	}
+	if auth.SessionCookie == "" || auth.CSRFToken == "" {
+		fmt.Fprintln(stderr, "gc registry publish: authentication required; set GC_REGISTRY_SESSION and GC_REGISTRY_CSRF_TOKEN, pass --session-cookie/--csrf-token, or use --dev-auth against a local registry") //nolint:errcheck
+		return 1
+	}
+
+	submitted, err := submitRegistryPublishRequest(ctx, registryPublishHTTPClient, baseURL, request, auth, opts.Validate)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	writeRegistryPublishSubmitted(stdout, baseURL, submitted)
+	return 0
+}
+
+type registryPublishRequest struct {
+	RepoURL              string `json:"repoUrl"`
+	Commit               string `json:"commit"`
+	PackPath             string `json:"packPath"`
+	RequestedName        string `json:"requestedName"`
+	RequestedVersion     string `json:"requestedVersion"`
+	RequestedRef         string `json:"requestedRef,omitempty"`
+	RequestedDescription string `json:"requestedDescription,omitempty"`
+}
+
+type registryPublishSubmitted struct {
+	ID               string
+	Status           string
+	RequestedName    string
+	RequestedVersion string
+	Repository       string
+	StatusReason     string
+	ValidationError  string
+	Hash             string
+}
+
+type registryPackManifest struct {
+	Pack struct {
+		Name        string `toml:"name"`
+		Version     string `toml:"version"`
+		Description string `toml:"description"`
+	} `toml:"pack"`
+}
+
+func buildRegistryPublishRequest(packRoot string, opts registryPublishOptions) (registryPublishRequest, error) {
+	absPackRoot, err := filepath.Abs(packRoot)
+	if err != nil {
+		return registryPublishRequest{}, fmt.Errorf("resolving pack root: %w", err)
+	}
+	if resolved, evalErr := filepath.EvalSymlinks(absPackRoot); evalErr == nil {
+		absPackRoot = resolved
+	}
+	manifest, err := readRegistryPackManifest(absPackRoot)
+	if err != nil {
+		return registryPublishRequest{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	repoRoot, err := gitOutput(ctx, absPackRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return registryPublishRequest{}, fmt.Errorf("pack root must be inside a Git repository: %w", err)
+	}
+	if resolved, evalErr := filepath.EvalSymlinks(repoRoot); evalErr == nil {
+		repoRoot = resolved
+	}
+	status, err := gitOutput(ctx, repoRoot, "status", "--porcelain=v1", "--untracked-files=all")
+	if err != nil {
+		return registryPublishRequest{}, fmt.Errorf("checking Git status: %w", err)
+	}
+	if strings.TrimSpace(status) != "" {
+		return registryPublishRequest{}, errors.New("working tree has uncommitted or untracked changes; commit, stash, or remove them before publishing")
+	}
+	commit, err := gitOutput(ctx, repoRoot, "rev-parse", "HEAD")
+	if err != nil {
+		return registryPublishRequest{}, fmt.Errorf("resolving HEAD: %w", err)
+	}
+	if !fullGitSHARE.MatchString(commit) {
+		return registryPublishRequest{}, fmt.Errorf("HEAD resolved to %q, not a full lowercase Git SHA", commit)
+	}
+	upstream, err := gitOutput(ctx, repoRoot, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	if err != nil {
+		return registryPublishRequest{}, errors.New("current branch has no upstream; run `git push -u` before publishing")
+	}
+	upstreamCommit, err := gitOutput(ctx, repoRoot, "rev-parse", "@{u}")
+	if err != nil {
+		return registryPublishRequest{}, fmt.Errorf("resolving upstream %s: %w", upstream, err)
+	}
+	if upstreamCommit != commit {
+		return registryPublishRequest{}, fmt.Errorf("HEAD %s is not pushed to upstream %s (%s)", shortCommit(commit), upstream, shortCommit(upstreamCommit))
+	}
+	remoteName, upstreamBranch, err := splitGitUpstream(upstream)
+	if err != nil {
+		return registryPublishRequest{}, err
+	}
+	remoteURL, err := gitOutput(ctx, repoRoot, "remote", "get-url", remoteName)
+	if err != nil {
+		return registryPublishRequest{}, fmt.Errorf("reading remote %q URL: %w", remoteName, err)
+	}
+	repoURL, err := normalizeGitHubRemoteURL(remoteURL)
+	if err != nil {
+		return registryPublishRequest{}, err
+	}
+	packPath, err := registryPublishPackPath(repoRoot, absPackRoot)
+	if err != nil {
+		return registryPublishRequest{}, err
+	}
+
+	version := strings.TrimSpace(registryFirstNonEmpty(opts.Version, manifest.Pack.Version))
+	if version == "" {
+		return registryPublishRequest{}, errors.New("release version is required; set [pack].version or pass --version")
+	}
+	ref := strings.TrimSpace(registryFirstNonEmpty(opts.Ref, upstreamBranch))
+	description := strings.TrimSpace(registryFirstNonEmpty(opts.Description, manifest.Pack.Description))
+	return registryPublishRequest{
+		RepoURL:              repoURL,
+		Commit:               commit,
+		PackPath:             packPath,
+		RequestedName:        strings.TrimSpace(manifest.Pack.Name),
+		RequestedVersion:     version,
+		RequestedRef:         ref,
+		RequestedDescription: description,
+	}, nil
+}
+
+func readRegistryPackManifest(packRoot string) (registryPackManifest, error) {
+	packToml := filepath.Join(packRoot, "pack.toml")
+	data, err := os.ReadFile(packToml)
+	if err != nil {
+		return registryPackManifest{}, fmt.Errorf("reading %s: %w", packToml, err)
+	}
+	var manifest registryPackManifest
+	if err := toml.Unmarshal(data, &manifest); err != nil {
+		return registryPackManifest{}, fmt.Errorf("parsing %s: %w", packToml, err)
+	}
+	manifest.Pack.Name = strings.TrimSpace(manifest.Pack.Name)
+	if manifest.Pack.Name == "" {
+		return registryPackManifest{}, fmt.Errorf("%s is missing [pack].name", packToml)
+	}
+	return manifest, nil
+}
+
+func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr := new(exec.ExitError); errors.As(err, &exitErr) {
+			msg := strings.TrimSpace(string(exitErr.Stderr))
+			if msg != "" {
+				return "", errors.New(msg)
+			}
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+var fullGitSHARE = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func splitGitUpstream(upstream string) (remote, branch string, err error) {
+	parts := strings.SplitN(strings.TrimSpace(upstream), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unsupported upstream %q", upstream)
+	}
+	return parts[0], parts[1], nil
+}
+
+func normalizeGitHubRemoteURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimSuffix(raw, ".git")
+	switch {
+	case strings.HasPrefix(raw, "git@github.com:"):
+		path := strings.TrimPrefix(raw, "git@github.com:")
+		return normalizeGitHubOwnerRepo(path)
+	case strings.HasPrefix(raw, "ssh://"):
+		u, err := url.Parse(raw)
+		if err != nil {
+			return "", fmt.Errorf("parsing Git remote URL: %w", err)
+		}
+		if strings.EqualFold(u.Hostname(), "github.com") {
+			return normalizeGitHubOwnerRepo(strings.TrimPrefix(u.Path, "/"))
+		}
+	case strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://"):
+		u, err := url.Parse(raw)
+		if err != nil {
+			return "", fmt.Errorf("parsing Git remote URL: %w", err)
+		}
+		if strings.EqualFold(u.Hostname(), "github.com") {
+			return normalizeGitHubOwnerRepo(strings.TrimPrefix(u.Path, "/"))
+		}
+	}
+	return "", fmt.Errorf("publish requires a GitHub remote, got %q", raw)
+}
+
+var githubOwnerRepoRE = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+
+func normalizeGitHubOwnerRepo(path string) (string, error) {
+	path = strings.Trim(strings.TrimSuffix(path, ".git"), "/")
+	if !githubOwnerRepoRE.MatchString(path) {
+		return "", fmt.Errorf("invalid GitHub owner/repo path %q", path)
+	}
+	return "https://github.com/" + path, nil
+}
+
+func registryPublishPackPath(repoRoot, packRoot string) (string, error) {
+	rel, err := filepath.Rel(repoRoot, packRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolving pack path relative to repository: %w", err)
+	}
+	if rel == "." {
+		return ".", nil
+	}
+	if strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+		return "", errors.New("pack root is not inside the Git repository")
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func normalizeRegistryPublishBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		raw = defaultRegistryPublishURL
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid registry URL %q", raw)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return "", fmt.Errorf("registry URL must use http or https: %q", raw)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+type registryPublishAuth struct {
+	SessionCookie string
+	CSRFToken     string
+}
+
+func registryPublishDevAuth(ctx context.Context, client *http.Client, baseURL, handle string) (registryPublishAuth, error) {
+	if !isLocalRegistryURL(baseURL) {
+		return registryPublishAuth{}, errors.New("--dev-auth is only allowed for localhost registry URLs")
+	}
+	handle = strings.TrimSpace(handle)
+	if handle == "" {
+		handle = "local-cli"
+	}
+	loginURL := baseURL + "/api/dev/sign-in?handle=" + url.QueryEscape(handle) + "&redirect=/api/me"
+	devClient := *client
+	devClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, loginURL, nil)
+	if err != nil {
+		return registryPublishAuth{}, err
+	}
+	resp, err := devClient.Do(req)
+	if err != nil {
+		return registryPublishAuth{}, fmt.Errorf("creating dev auth session: %w", err)
+	}
+	defer resp.Body.Close()
+	var sessionCookie string
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == "registry_session" {
+			sessionCookie = cookie.Value
+			break
+		}
+	}
+	if sessionCookie == "" {
+		return registryPublishAuth{}, fmt.Errorf("creating dev auth session: registry returned HTTP %d without registry_session cookie", resp.StatusCode)
+	}
+	csrf, err := registryPublishFetchCSRF(ctx, client, baseURL, sessionCookie)
+	if err != nil {
+		return registryPublishAuth{}, err
+	}
+	return registryPublishAuth{SessionCookie: sessionCookie, CSRFToken: csrf}, nil
+}
+
+func registryPublishFetchCSRF(ctx context.Context, client *http.Client, baseURL, sessionCookie string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/me", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Cookie", registryPublishCookieHeader(sessionCookie))
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching registry session: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetching registry session: HTTP %d", resp.StatusCode)
+	}
+	var payload struct {
+		CSRFToken string `json:"csrfToken"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decoding registry session: %w", err)
+	}
+	if strings.TrimSpace(payload.CSRFToken) == "" {
+		return "", errors.New("registry session did not include a CSRF token")
+	}
+	return payload.CSRFToken, nil
+}
+
+func isLocalRegistryURL(baseURL string) bool {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func submitRegistryPublishRequest(ctx context.Context, client *http.Client, baseURL string, payload registryPublishRequest, auth registryPublishAuth, validate bool) (registryPublishSubmitted, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return registryPublishSubmitted{}, err
+	}
+	endpoint := baseURL + "/api/publish-requests"
+	if validate {
+		endpoint += "?validate=1"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return registryPublishSubmitted{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-CSRF-Token", auth.CSRFToken)
+	req.Header.Set("Cookie", registryPublishCookieHeader(auth.SessionCookie))
+	resp, err := client.Do(req)
+	if err != nil {
+		return registryPublishSubmitted{}, fmt.Errorf("submitting publish request: %w", err)
+	}
+	defer resp.Body.Close()
+	var raw registryPublishAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return registryPublishSubmitted{}, fmt.Errorf("decoding registry response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if raw.Error.Message != "" {
+			return registryPublishSubmitted{}, fmt.Errorf("registry rejected publish request (%s): %s", raw.Error.Code, raw.Error.Message)
+		}
+		return registryPublishSubmitted{}, fmt.Errorf("registry rejected publish request: HTTP %d", resp.StatusCode)
+	}
+	request := raw.PublishRequest
+	if request.ID == "" && raw.Direct.ID != "" {
+		request = raw.Direct
+	}
+	if request.ID == "" {
+		return registryPublishSubmitted{}, errors.New("registry response did not include a publish request")
+	}
+	return registryPublishSubmitted{
+		ID:               request.ID,
+		Status:           request.Status,
+		RequestedName:    registryFirstNonEmpty(request.RequestedName, payload.RequestedName),
+		RequestedVersion: registryFirstNonEmpty(request.RequestedVersion, payload.RequestedVersion),
+		Repository:       request.Repository.FullName,
+		StatusReason:     request.StatusReason,
+		ValidationError:  request.ValidationError,
+		Hash:             request.RegistryEntry.Release.Hash,
+	}, nil
+}
+
+type registryPublishAPIResponse struct {
+	PublishRequest registryPublishAPIRequest `json:"publishRequest"`
+	Direct         registryPublishAPIRequest `json:"-"`
+	Error          struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type registryPublishAPIRequest struct {
+	ID               string `json:"id"`
+	Status           string `json:"status"`
+	RequestedName    string `json:"requestedName"`
+	RequestedVersion string `json:"requestedVersion"`
+	StatusReason     string `json:"statusReason"`
+	ValidationError  string `json:"validationError"`
+	Repository       struct {
+		FullName string `json:"fullName"`
+	} `json:"repository"`
+	RegistryEntry struct {
+		Release struct {
+			Hash string `json:"hash"`
+		} `json:"release"`
+	} `json:"registryEntry"`
+}
+
+func (r *registryPublishAPIResponse) UnmarshalJSON(data []byte) error {
+	type alias registryPublishAPIResponse
+	var wrapped alias
+	if err := json.Unmarshal(data, &wrapped); err != nil {
+		return err
+	}
+	*r = registryPublishAPIResponse(wrapped)
+	var direct registryPublishAPIRequest
+	if err := json.Unmarshal(data, &direct); err == nil && direct.ID != "" {
+		r.Direct = direct
+	}
+	return nil
+}
+
+func registryPublishCookieHeader(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.Contains(value, "=") {
+		return value
+	}
+	return "registry_session=" + url.QueryEscape(value)
+}
+
+func writeRegistryPublishDryRun(stdout io.Writer, baseURL string, request registryPublishRequest) {
+	fmt.Fprintf(stdout, "Registry: %s\n", baseURL)                                        //nolint:errcheck
+	fmt.Fprintf(stdout, "Repository: %s\n", request.RepoURL)                              //nolint:errcheck
+	fmt.Fprintf(stdout, "Commit: %s\n", request.Commit)                                   //nolint:errcheck
+	fmt.Fprintf(stdout, "Pack path: %s\n", request.PackPath)                              //nolint:errcheck
+	fmt.Fprintf(stdout, "Pack: %s %s\n", request.RequestedName, request.RequestedVersion) //nolint:errcheck
+	if request.RequestedRef != "" {
+		fmt.Fprintf(stdout, "Ref: %s\n", request.RequestedRef) //nolint:errcheck
+	}
+	if request.RequestedDescription != "" {
+		fmt.Fprintf(stdout, "Description: %s\n", request.RequestedDescription) //nolint:errcheck
+	}
+	fmt.Fprintln(stdout, "Dry run: publish request was not submitted.") //nolint:errcheck
+}
+
+func writeRegistryPublishSubmitted(stdout io.Writer, baseURL string, result registryPublishSubmitted) {
+	fmt.Fprintf(stdout, "Submitted publish request %s to %s\n", result.ID, baseURL)     //nolint:errcheck
+	fmt.Fprintf(stdout, "Pack: %s %s\n", result.RequestedName, result.RequestedVersion) //nolint:errcheck
+	if result.Repository != "" {
+		fmt.Fprintf(stdout, "Repository: %s\n", result.Repository) //nolint:errcheck
+	}
+	fmt.Fprintf(stdout, "Status: %s\n", result.Status) //nolint:errcheck
+	if result.Hash != "" {
+		fmt.Fprintf(stdout, "Hash: %s\n", result.Hash) //nolint:errcheck
+	}
+	if result.StatusReason != "" {
+		fmt.Fprintf(stdout, "Message: %s\n", result.StatusReason) //nolint:errcheck
+	} else if result.ValidationError != "" {
+		fmt.Fprintf(stdout, "Message: %s\n", result.ValidationError) //nolint:errcheck
+	}
+}
+
+func registryFirstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/git"
 	"github.com/spf13/cobra"
 )
 
@@ -60,10 +61,6 @@ type registryPublishOptions struct {
 
 func newRegistryPublishCmd(stdout, stderr io.Writer) *cobra.Command {
 	opts := registryPublishOptions{
-		RegistryURL:   registryFirstNonEmpty(os.Getenv("GC_REGISTRY_URL"), defaultRegistryPublishURL),
-		Token:         os.Getenv("GC_REGISTRY_TOKEN"),
-		SessionCookie: os.Getenv("GC_REGISTRY_SESSION"),
-		CSRFToken:     os.Getenv("GC_REGISTRY_CSRF_TOKEN"),
 		Validate:      true,
 		DevAuthHandle: "local-cli",
 	}
@@ -76,36 +73,66 @@ The command requires a clean Git checkout whose current HEAD matches its
 configured upstream branch, then submits the GitHub repository, commit, pack
 path, pack name, and version to the registry API.`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			if doRegistryPublish(args[0], opts, stdout, stderr) != 0 {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if doRegistryPublish(cmd.Context(), args[0], opts, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", opts.RegistryURL, "registry app base URL")
+	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", "", "registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then "+defaultRegistryPublishURL)
 	cmd.Flags().StringVar(&opts.Name, "name", "", "registry pack name; defaults to [pack].name")
 	cmd.Flags().StringVar(&opts.Version, "version", "", "release version; defaults to [pack].version")
 	cmd.Flags().StringVar(&opts.Ref, "ref", "", "release ref label; defaults to the upstream branch name")
 	cmd.Flags().StringVar(&opts.Description, "description", "", "release description; defaults to [pack].description")
-	cmd.Flags().StringVar(&opts.Token, "token", opts.Token, "registry API token; defaults to GC_REGISTRY_TOKEN")
-	cmd.Flags().StringVar(&opts.SessionCookie, "session-cookie", opts.SessionCookie, "registry_session cookie value or Cookie header")
-	cmd.Flags().StringVar(&opts.CSRFToken, "csrf-token", opts.CSRFToken, "registry CSRF token")
+	cmd.Flags().StringVar(&opts.Token, "token", "", "registry API token; defaults to GC_REGISTRY_TOKEN")
+	cmd.Flags().StringVar(&opts.SessionCookie, "session-cookie", "", "registry_session cookie value or Cookie header; defaults to GC_REGISTRY_SESSION")
+	cmd.Flags().StringVar(&opts.CSRFToken, "csrf-token", "", "registry CSRF token; defaults to GC_REGISTRY_CSRF_TOKEN")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print the publish request without submitting")
-	cmd.Flags().BoolVar(&opts.Validate, "validate", opts.Validate, "ask the registry to validate the request immediately")
+	cmd.Flags().BoolVar(&opts.Validate, "validate", opts.Validate, "ask the registry to validate the request immediately; a rejected validation exits non-zero")
 	cmd.Flags().BoolVar(&opts.DevAuth, "dev-auth", false, "create a local dev-auth session before submitting; localhost only")
 	cmd.Flags().StringVar(&opts.DevAuthHandle, "dev-auth-handle", opts.DevAuthHandle, "dev-auth handle when --dev-auth is used")
 	return cmd
 }
 
-func doRegistryPublish(packRoot string, opts registryPublishOptions, stdout, stderr io.Writer) int {
-	request, err := buildRegistryPublishRequest(packRoot, opts)
+func doRegistryPublish(ctx context.Context, packRoot string, opts registryPublishOptions, stdout, stderr io.Writer) int {
+	// Secrets resolve at execution time, never as flag defaults, so help
+	// output cannot render credential values from the environment.
+	opts.Token = registryFirstNonEmpty(opts.Token, os.Getenv("GC_REGISTRY_TOKEN"))
+	opts.SessionCookie = registryFirstNonEmpty(opts.SessionCookie, os.Getenv("GC_REGISTRY_SESSION"))
+	opts.CSRFToken = registryFirstNonEmpty(opts.CSRFToken, os.Getenv("GC_REGISTRY_CSRF_TOKEN"))
+
+	baseURL, err := resolveRegistryPublishBaseURL(opts.RegistryURL)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
 		return 1
 	}
 
-	baseURL, err := normalizeRegistryPublishBaseURL(opts.RegistryURL)
+	// Resolve the publish auth mode before building the request. The GitHub
+	// Actions repo/ref fallback lets a detached or upstream-less CI checkout skip
+	// the local pushed-HEAD proof, but that is only sound when this publish
+	// actually authenticates through the GitHub Actions OIDC mint path: the mint
+	// exchange is what proves the run really executed in GitHub Actions for this
+	// repository and commit. Any pre-supplied credential (--token, env token,
+	// stored login token, --session-cookie/--csrf-token, or --dev-auth) skips the
+	// OIDC mint, so it must keep proving HEAD is pushed to its upstream and must
+	// not trust spoofable GITHUB_*/ACTIONS_* environment variables.
+	auth := registryPublishAuth{
+		Token:         strings.TrimSpace(opts.Token),
+		SessionCookie: strings.TrimSpace(opts.SessionCookie),
+		CSRFToken:     strings.TrimSpace(opts.CSRFToken),
+	}
+	if !auth.hasCredentials() && !opts.DevAuth {
+		configuredToken, err := readRegistryConfiguredToken(baseURL)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		auth.Token = strings.TrimSpace(configuredToken)
+	}
+	useGitHubActionsOIDC := !auth.hasCredentials() && !opts.DevAuth && registryGitHubActionsOIDCAvailable()
+
+	request, err := buildRegistryPublishRequest(ctx, packRoot, opts, useGitHubActionsOIDC)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
 		return 1
@@ -116,20 +143,7 @@ func doRegistryPublish(packRoot string, opts registryPublishOptions, stdout, std
 		return 0
 	}
 
-	auth := registryPublishAuth{
-		Token:         strings.TrimSpace(opts.Token),
-		SessionCookie: strings.TrimSpace(opts.SessionCookie),
-		CSRFToken:     strings.TrimSpace(opts.CSRFToken),
-	}
-	if auth.Token == "" && auth.SessionCookie == "" && auth.CSRFToken == "" && !opts.DevAuth {
-		configuredToken, err := readRegistryConfiguredToken(baseURL)
-		if err != nil {
-			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
-			return 1
-		}
-		auth.Token = configuredToken
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 	if opts.DevAuth {
 		var err error
@@ -139,7 +153,7 @@ func doRegistryPublish(packRoot string, opts registryPublishOptions, stdout, std
 			return 1
 		}
 	}
-	if !auth.hasCredentials() && registryGitHubActionsOIDCAvailable() {
+	if useGitHubActionsOIDC {
 		oidcToken, err := registryRequestGitHubActionsOIDCToken(ctx, registryPublishHTTPClient, registryGitHubActionsAudience)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
@@ -163,6 +177,12 @@ func doRegistryPublish(packRoot string, opts registryPublishOptions, stdout, std
 		return 1
 	}
 	writeRegistryPublishSubmitted(stdout, baseURL, submitted)
+	if opts.Validate {
+		if failure := registryPublishValidationFailure(submitted); failure != "" {
+			fmt.Fprintf(stderr, "gc registry publish: validation failed: %s\n", failure) //nolint:errcheck
+			return 1
+		}
+	}
 	return 0
 }
 
@@ -195,7 +215,7 @@ type registryPackManifest struct {
 	} `toml:"pack"`
 }
 
-func buildRegistryPublishRequest(packRoot string, opts registryPublishOptions) (registryPublishRequest, error) {
+func buildRegistryPublishRequest(ctx context.Context, packRoot string, opts registryPublishOptions, allowGitHubActionsFallback bool) (registryPublishRequest, error) {
 	absPackRoot, err := filepath.Abs(packRoot)
 	if err != nil {
 		return registryPublishRequest{}, fmt.Errorf("resolving pack root: %w", err)
@@ -208,7 +228,7 @@ func buildRegistryPublishRequest(packRoot string, opts registryPublishOptions) (
 		return registryPublishRequest{}, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	repoRoot, err := gitOutput(ctx, absPackRoot, "rev-parse", "--show-toplevel")
 	if err != nil {
@@ -231,26 +251,7 @@ func buildRegistryPublishRequest(packRoot string, opts registryPublishOptions) (
 	if !fullGitSHARE.MatchString(commit) {
 		return registryPublishRequest{}, fmt.Errorf("HEAD resolved to %q, not a full lowercase Git SHA", commit)
 	}
-	upstream, err := gitOutput(ctx, repoRoot, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
-	if err != nil {
-		return registryPublishRequest{}, errors.New("current branch has no upstream; run `git push -u` before publishing")
-	}
-	upstreamCommit, err := gitOutput(ctx, repoRoot, "rev-parse", "@{u}")
-	if err != nil {
-		return registryPublishRequest{}, fmt.Errorf("resolving upstream %s: %w", upstream, err)
-	}
-	if upstreamCommit != commit {
-		return registryPublishRequest{}, fmt.Errorf("HEAD %s is not pushed to upstream %s (%s)", shortCommit(commit), upstream, shortCommit(upstreamCommit))
-	}
-	remoteName, upstreamBranch, err := splitGitUpstream(upstream)
-	if err != nil {
-		return registryPublishRequest{}, err
-	}
-	remoteURL, err := gitOutput(ctx, repoRoot, "remote", "get-url", remoteName)
-	if err != nil {
-		return registryPublishRequest{}, fmt.Errorf("reading remote %q URL: %w", remoteName, err)
-	}
-	repoURL, err := normalizeGitHubRemoteURL(remoteURL)
+	repoRef, err := resolveRegistryPublishRepoRef(ctx, repoRoot, commit, opts, allowGitHubActionsFallback)
 	if err != nil {
 		return registryPublishRequest{}, err
 	}
@@ -267,10 +268,10 @@ func buildRegistryPublishRequest(packRoot string, opts registryPublishOptions) (
 	if name == "" {
 		return registryPublishRequest{}, errors.New("pack name is required; set [pack].name or pass --name")
 	}
-	ref := strings.TrimSpace(registryFirstNonEmpty(opts.Ref, upstreamBranch))
+	ref := repoRef.Ref
 	description := strings.TrimSpace(registryFirstNonEmpty(opts.Description, manifest.Pack.Description))
 	return registryPublishRequest{
-		RepoURL:              repoURL,
+		RepoURL:              repoRef.RepoURL,
 		Commit:               commit,
 		PackPath:             packPath,
 		RequestedName:        name,
@@ -280,6 +281,101 @@ func buildRegistryPublishRequest(packRoot string, opts registryPublishOptions) (
 	}, nil
 }
 
+// registryPublishRepoRef carries the GitHub repository URL and release ref
+// label for a publish request. They come from the local upstream tracking
+// branch, or from GitHub Actions runner metadata when a detached or
+// upstream-less CI checkout has no `@{u}` but a trusted OIDC environment.
+type registryPublishRepoRef struct {
+	RepoURL string
+	Ref     string
+}
+
+// resolveRegistryPublishRepoRef resolves the GitHub repository URL and release
+// ref for a publish request. It prefers the local upstream tracking branch and
+// verifies HEAD is pushed there. When the branch has no upstream, it falls back
+// to GitHub Actions runner metadata only if allowGitHubActionsFallback is set,
+// which the caller enables exclusively for the GitHub Actions OIDC mint path.
+// A publish carrying any other (non-OIDC) credential keeps requiring a pushed
+// upstream, so spoofable GITHUB_*/ACTIONS_* environment variables cannot skip
+// the pushed-HEAD proof.
+func resolveRegistryPublishRepoRef(ctx context.Context, repoRoot, commit string, opts registryPublishOptions, allowGitHubActionsFallback bool) (registryPublishRepoRef, error) {
+	upstream, err := gitOutput(ctx, repoRoot, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	if err != nil {
+		if allowGitHubActionsFallback {
+			if ghRef, ok := registryGitHubActionsRepoRef(commit, opts); ok {
+				return ghRef, nil
+			}
+		}
+		return registryPublishRepoRef{}, errors.New("current branch has no upstream; run `git push -u` before publishing")
+	}
+	upstreamCommit, err := gitOutput(ctx, repoRoot, "rev-parse", "@{u}")
+	if err != nil {
+		return registryPublishRepoRef{}, fmt.Errorf("resolving upstream %s: %w", upstream, err)
+	}
+	if upstreamCommit != commit {
+		return registryPublishRepoRef{}, fmt.Errorf("HEAD %s is not pushed to upstream %s (%s)", shortCommit(commit), upstream, shortCommit(upstreamCommit))
+	}
+	remoteName, upstreamBranch, err := splitGitUpstream(upstream)
+	if err != nil {
+		return registryPublishRepoRef{}, err
+	}
+	remoteURL, err := gitOutput(ctx, repoRoot, "remote", "get-url", remoteName)
+	if err != nil {
+		return registryPublishRepoRef{}, fmt.Errorf("reading remote %q URL: %w", remoteName, err)
+	}
+	repoURL, err := normalizeGitHubRemoteURL(remoteURL)
+	if err != nil {
+		return registryPublishRepoRef{}, err
+	}
+	return registryPublishRepoRef{
+		RepoURL: repoURL,
+		Ref:     strings.TrimSpace(registryFirstNonEmpty(opts.Ref, upstreamBranch)),
+	}, nil
+}
+
+// registryGitHubActionsRepoRef derives the publish repository URL and ref from
+// GitHub Actions runner metadata. It returns ok=false unless the OIDC request
+// environment is present, the runner identifies the repository, and the
+// runner's commit SHA matches the local HEAD, so stale or spoofed metadata
+// cannot redirect a publish to the wrong repository or commit. Environment
+// presence alone is not a trust signal: callers must restrict this fallback to
+// the GitHub Actions OIDC mint path, where the minted token is exchanged with
+// the registry and proves the run actually executed in GitHub Actions. Callers
+// fall back to the upstream requirement when ok is false.
+func registryGitHubActionsRepoRef(commit string, opts registryPublishOptions) (registryPublishRepoRef, bool) {
+	if !registryGitHubActionsOIDCAvailable() {
+		return registryPublishRepoRef{}, false
+	}
+	repoSlug := strings.TrimSpace(os.Getenv("GITHUB_REPOSITORY"))
+	if repoSlug == "" {
+		return registryPublishRepoRef{}, false
+	}
+	// The runner's commit must be present and match the checked-out HEAD so
+	// publish records the exact tree the workflow built, never an unrelated or
+	// unverified commit. An absent GITHUB_SHA falls back to the upstream
+	// requirement rather than trusting unconfirmed runner metadata.
+	sha := strings.TrimSpace(os.Getenv("GITHUB_SHA"))
+	if sha == "" || !strings.EqualFold(sha, commit) {
+		return registryPublishRepoRef{}, false
+	}
+	serverURL := strings.TrimSpace(os.Getenv("GITHUB_SERVER_URL"))
+	if serverURL == "" {
+		serverURL = "https://github.com"
+	}
+	repoURL, err := normalizeGitHubRemoteURL(strings.TrimRight(serverURL, "/") + "/" + repoSlug)
+	if err != nil {
+		return registryPublishRepoRef{}, false
+	}
+	return registryPublishRepoRef{
+		RepoURL: repoURL,
+		Ref:     strings.TrimSpace(registryFirstNonEmpty(opts.Ref, os.Getenv("GITHUB_REF_NAME"))),
+	}, true
+}
+
+// readRegistryPackManifest loads pack.toml from packRoot. It does not require
+// [pack].name: buildRegistryPublishRequest applies the --name fallback first
+// and reports a missing name only when neither the manifest nor the flag
+// supplies one, so the advertised --name override actually takes effect.
 func readRegistryPackManifest(packRoot string) (registryPackManifest, error) {
 	packToml := filepath.Join(packRoot, "pack.toml")
 	data, err := os.ReadFile(packToml)
@@ -291,15 +387,16 @@ func readRegistryPackManifest(packRoot string) (registryPackManifest, error) {
 		return registryPackManifest{}, fmt.Errorf("parsing %s: %w", packToml, err)
 	}
 	manifest.Pack.Name = strings.TrimSpace(manifest.Pack.Name)
-	if manifest.Pack.Name == "" {
-		return registryPackManifest{}, fmt.Errorf("%s is missing [pack].name", packToml)
-	}
 	return manifest, nil
 }
 
 func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
+	// Strip git-locating env vars (GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, ...)
+	// so publish introspection resolves dir, not a parent repo leaked through a
+	// pre-commit hook or nested worktree tooling.
+	cmd.Env = git.SanitizedEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr := new(exec.ExitError); errors.As(err, &exitErr) {
@@ -368,10 +465,25 @@ func registryPublishPackPath(repoRoot, packRoot string) (string, error) {
 	if rel == "." {
 		return ".", nil
 	}
-	if strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
 		return "", errors.New("pack root is not inside the Git repository")
 	}
 	return filepath.ToSlash(rel), nil
+}
+
+// resolveRegistryPublishBaseURL resolves the registry base URL from the
+// explicit flag value, the GC_REGISTRY_URL environment variable, the stored
+// login default, then defaultRegistryPublishURL, and normalizes the winner.
+func resolveRegistryPublishBaseURL(explicit string) (string, error) {
+	raw := registryFirstNonEmpty(explicit, os.Getenv("GC_REGISTRY_URL"))
+	if raw == "" {
+		cfg, err := loadRegistryCLIConfig(registryCLIConfigPath())
+		if err != nil {
+			return "", err
+		}
+		raw = cfg.DefaultRegistryURL
+	}
+	return normalizeRegistryPublishBaseURL(raw)
 }
 
 func normalizeRegistryPublishBaseURL(raw string) (string, error) {
@@ -383,7 +495,16 @@ func normalizeRegistryPublishBaseURL(raw string) (string, error) {
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return "", fmt.Errorf("invalid registry URL %q", raw)
 	}
-	if u.Scheme != "https" && u.Scheme != "http" {
+	switch u.Scheme {
+	case "https":
+	case "http":
+		// publish, login, and whoami carry bearer tokens, session cookies, and
+		// CSRF tokens. Cleartext http only stays off the wire for a loopback
+		// host, so reject http for any non-local registry.
+		if !isLocalRegistryHost(u.Hostname()) {
+			return "", fmt.Errorf("registry URL must use https for non-local hosts: %q", raw)
+		}
+	default:
 		return "", fmt.Errorf("registry URL must use http or https: %q", raw)
 	}
 	u.Path = strings.TrimRight(u.Path, "/")
@@ -453,14 +574,14 @@ func registryPublishFetchCSRF(ctx context.Context, client *http.Client, baseURL,
 		return "", fmt.Errorf("fetching registry session: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("fetching registry session: HTTP %d", resp.StatusCode)
-	}
 	var payload struct {
 		CSRFToken string `json:"csrfToken"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", fmt.Errorf("decoding registry session: %w", err)
+	if err := registryDecodeJSONResponse(resp, &payload); err != nil {
+		return "", fmt.Errorf("fetching registry session: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetching registry session: HTTP %d", resp.StatusCode)
 	}
 	if strings.TrimSpace(payload.CSRFToken) == "" {
 		return "", errors.New("registry session did not include a CSRF token")
@@ -473,8 +594,18 @@ func isLocalRegistryURL(baseURL string) bool {
 	if err != nil {
 		return false
 	}
-	host := strings.ToLower(u.Hostname())
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return isLocalRegistryHost(u.Hostname())
+}
+
+// isLocalRegistryHost reports whether host is a loopback host that may exchange
+// registry credentials over cleartext http.
+func isLocalRegistryHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
 }
 
 func submitRegistryPublishRequest(ctx context.Context, client *http.Client, baseURL string, payload registryPublishRequest, auth registryPublishAuth, validate bool) (registryPublishSubmitted, error) {
@@ -504,8 +635,8 @@ func submitRegistryPublishRequest(ctx context.Context, client *http.Client, base
 	}
 	defer func() { _ = resp.Body.Close() }()
 	var raw registryPublishAPIResponse
-	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
-		return registryPublishSubmitted{}, fmt.Errorf("decoding registry response: %w", err)
+	if err := registryDecodeJSONResponse(resp, &raw); err != nil {
+		return registryPublishSubmitted{}, fmt.Errorf("submitting publish request: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if raw.Error.Message != "" {
@@ -572,12 +703,48 @@ func (r *registryPublishAPIResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// registryPublishCookieHeader renders the Cookie header for a --session-cookie
+// input. Only explicitly header-shaped values pass through verbatim; bare
+// session values are wrapped unescaped so legal cookie characters such as
+// base64 `=` padding survive the round trip back to the registry.
 func registryPublishCookieHeader(value string) string {
 	value = strings.TrimSpace(value)
-	if strings.Contains(value, "=") {
+	if strings.HasPrefix(value, "registry_session=") || strings.Contains(value, ";") {
 		return value
 	}
-	return "registry_session=" + url.QueryEscape(value)
+	return "registry_session=" + value
+}
+
+// registryDecodeJSONResponse decodes a bounded registry response body into
+// out. Registries sit behind proxies and CDNs that answer with HTML or empty
+// bodies, so a non-2xx response that fails to decode reports the HTTP status
+// instead of a JSON syntax error.
+func registryDecodeJSONResponse(resp *http.Response, out any) error {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("reading registry response: %w", err)
+	}
+	decodeErr := json.Unmarshal(body, out)
+	if decodeErr == nil {
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if snippet := registryResponseSnippet(body); snippet != "" {
+			return fmt.Errorf("registry returned HTTP %d: %s", resp.StatusCode, snippet)
+		}
+		return fmt.Errorf("registry returned HTTP %d", resp.StatusCode)
+	}
+	return fmt.Errorf("decoding registry response (HTTP %d): %w", resp.StatusCode, decodeErr)
+}
+
+// registryResponseSnippet condenses a non-JSON response body for error text.
+func registryResponseSnippet(body []byte) string {
+	s := strings.Join(strings.Fields(string(body)), " ")
+	const maxRunes = 200
+	if runes := []rune(s); len(runes) > maxRunes {
+		s = string(runes[:maxRunes]) + "..."
+	}
+	return s
 }
 
 func writeRegistryPublishDryRun(stdout io.Writer, baseURL string, request registryPublishRequest) {
@@ -610,6 +777,38 @@ func writeRegistryPublishSubmitted(stdout io.Writer, baseURL string, result regi
 	} else if result.ValidationError != "" {
 		fmt.Fprintf(stdout, "Message: %s\n", result.ValidationError) //nolint:errcheck
 	}
+}
+
+// registryPublishValidationRejectedStatuses lists publish-request statuses that
+// represent a terminal validation rejection. A `gc registry publish --validate`
+// run that lands in one of these states failed validation; statuses outside
+// this set (for example queued or pending-review states) are not treated as
+// failures, so a successfully queued request still exits zero.
+var registryPublishValidationRejectedStatuses = map[string]bool{
+	"rejected": true,
+	"invalid":  true,
+	"failed":   true,
+	"error":    true,
+	"denied":   true,
+}
+
+// registryPublishValidationFailure reports a human-readable reason when a
+// validated publish request did not pass registry validation, or "" when it
+// did. A populated ValidationError is always a failure; otherwise a terminal
+// rejected/invalid status is treated as a failure so `gc registry publish
+// --validate` exits non-zero instead of masking a pack the registry rejected
+// inside a 2xx response as a successful publish.
+func registryPublishValidationFailure(result registryPublishSubmitted) string {
+	if msg := strings.TrimSpace(result.ValidationError); msg != "" {
+		return msg
+	}
+	if registryPublishValidationRejectedStatuses[strings.ToLower(strings.TrimSpace(result.Status))] {
+		if reason := strings.TrimSpace(result.StatusReason); reason != "" {
+			return fmt.Sprintf("status %q: %s", result.Status, reason)
+		}
+		return fmt.Sprintf("status %q", result.Status)
+	}
+	return ""
 }
 
 func registryFirstNonEmpty(values ...string) string {

--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -45,6 +45,7 @@ func newRegistryCmd(stdout, stderr io.Writer) *cobra.Command {
 
 type registryPublishOptions struct {
 	RegistryURL   string
+	Name          string
 	Version       string
 	Ref           string
 	Description   string
@@ -83,6 +84,7 @@ path, pack name, and version to the registry API.`,
 		},
 	}
 	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", opts.RegistryURL, "registry app base URL")
+	cmd.Flags().StringVar(&opts.Name, "name", "", "registry pack name; defaults to [pack].name")
 	cmd.Flags().StringVar(&opts.Version, "version", "", "release version; defaults to [pack].version")
 	cmd.Flags().StringVar(&opts.Ref, "ref", "", "release ref label; defaults to the upstream branch name")
 	cmd.Flags().StringVar(&opts.Description, "description", "", "release description; defaults to [pack].description")
@@ -261,13 +263,17 @@ func buildRegistryPublishRequest(packRoot string, opts registryPublishOptions) (
 	if version == "" {
 		return registryPublishRequest{}, errors.New("release version is required; set [pack].version or pass --version")
 	}
+	name := strings.TrimSpace(registryFirstNonEmpty(opts.Name, manifest.Pack.Name))
+	if name == "" {
+		return registryPublishRequest{}, errors.New("pack name is required; set [pack].name or pass --name")
+	}
 	ref := strings.TrimSpace(registryFirstNonEmpty(opts.Ref, upstreamBranch))
 	description := strings.TrimSpace(registryFirstNonEmpty(opts.Description, manifest.Pack.Description))
 	return registryPublishRequest{
 		RepoURL:              repoURL,
 		Commit:               commit,
 		PackPath:             packPath,
-		RequestedName:        strings.TrimSpace(manifest.Pack.Name),
+		RequestedName:        name,
 		RequestedVersion:     version,
 		RequestedRef:         ref,
 		RequestedDescription: description,

--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -20,7 +20,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultRegistryPublishURL = "https://registry.gascity.com"
+const (
+	defaultRegistryPublishURL     = "https://registry.gascity.com"
+	registryGitHubActionsAudience = "gascity-registry"
+)
 
 var registryPublishHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
@@ -34,7 +37,9 @@ func newRegistryCmd(stdout, stderr io.Writer) *cobra.Command {
 			return cmd.Help()
 		},
 	}
+	cmd.AddCommand(newRegistryLoginCmd(stdout, stderr))
 	cmd.AddCommand(newRegistryPublishCmd(stdout, stderr))
+	cmd.AddCommand(newRegistryWhoamiCmd(stdout, stderr))
 	return cmd
 }
 
@@ -114,6 +119,14 @@ func doRegistryPublish(packRoot string, opts registryPublishOptions, stdout, std
 		SessionCookie: strings.TrimSpace(opts.SessionCookie),
 		CSRFToken:     strings.TrimSpace(opts.CSRFToken),
 	}
+	if auth.Token == "" && auth.SessionCookie == "" && auth.CSRFToken == "" && !opts.DevAuth {
+		configuredToken, err := readRegistryConfiguredToken(baseURL)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		auth.Token = configuredToken
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 	if opts.DevAuth {
@@ -124,8 +137,21 @@ func doRegistryPublish(packRoot string, opts registryPublishOptions, stdout, std
 			return 1
 		}
 	}
+	if !auth.hasCredentials() && registryGitHubActionsOIDCAvailable() {
+		oidcToken, err := registryRequestGitHubActionsOIDCToken(ctx, registryPublishHTTPClient, registryGitHubActionsAudience)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		publishToken, err := registryMintGitHubActionsPublishToken(ctx, registryPublishHTTPClient, baseURL, request, oidcToken)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		auth.Token = publishToken
+	}
 	if !auth.hasCredentials() {
-		fmt.Fprintln(stderr, "gc registry publish: authentication required; set GC_REGISTRY_TOKEN, pass --token, set GC_REGISTRY_SESSION and GC_REGISTRY_CSRF_TOKEN, or use --dev-auth against a local registry") //nolint:errcheck
+		fmt.Fprintln(stderr, "gc registry publish: authentication required; run `gc registry login`, set GC_REGISTRY_TOKEN, pass --token, set GC_REGISTRY_SESSION and GC_REGISTRY_CSRF_TOKEN, or use --dev-auth against a local registry") //nolint:errcheck
 		return 1
 	}
 
@@ -392,7 +418,7 @@ func registryPublishDevAuth(ctx context.Context, client *http.Client, baseURL, h
 	if err != nil {
 		return registryPublishAuth{}, fmt.Errorf("creating dev auth session: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	var sessionCookie string
 	for _, cookie := range resp.Cookies() {
 		if cookie.Name == "registry_session" {
@@ -420,7 +446,7 @@ func registryPublishFetchCSRF(ctx context.Context, client *http.Client, baseURL,
 	if err != nil {
 		return "", fmt.Errorf("fetching registry session: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("fetching registry session: HTTP %d", resp.StatusCode)
 	}
@@ -470,7 +496,7 @@ func submitRegistryPublishRequest(ctx context.Context, client *http.Client, base
 	if err != nil {
 		return registryPublishSubmitted{}, fmt.Errorf("submitting publish request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	var raw registryPublishAPIResponse
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		return registryPublishSubmitted{}, fmt.Errorf("decoding registry response: %w", err)

--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -43,6 +43,7 @@ type registryPublishOptions struct {
 	Version       string
 	Ref           string
 	Description   string
+	Token         string
 	SessionCookie string
 	CSRFToken     string
 	DryRun        bool
@@ -54,6 +55,7 @@ type registryPublishOptions struct {
 func newRegistryPublishCmd(stdout, stderr io.Writer) *cobra.Command {
 	opts := registryPublishOptions{
 		RegistryURL:   registryFirstNonEmpty(os.Getenv("GC_REGISTRY_URL"), defaultRegistryPublishURL),
+		Token:         os.Getenv("GC_REGISTRY_TOKEN"),
 		SessionCookie: os.Getenv("GC_REGISTRY_SESSION"),
 		CSRFToken:     os.Getenv("GC_REGISTRY_CSRF_TOKEN"),
 		Validate:      true,
@@ -79,6 +81,7 @@ path, pack name, and version to the registry API.`,
 	cmd.Flags().StringVar(&opts.Version, "version", "", "release version; defaults to [pack].version")
 	cmd.Flags().StringVar(&opts.Ref, "ref", "", "release ref label; defaults to the upstream branch name")
 	cmd.Flags().StringVar(&opts.Description, "description", "", "release description; defaults to [pack].description")
+	cmd.Flags().StringVar(&opts.Token, "token", opts.Token, "registry API token; defaults to GC_REGISTRY_TOKEN")
 	cmd.Flags().StringVar(&opts.SessionCookie, "session-cookie", opts.SessionCookie, "registry_session cookie value or Cookie header")
 	cmd.Flags().StringVar(&opts.CSRFToken, "csrf-token", opts.CSRFToken, "registry CSRF token")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print the publish request without submitting")
@@ -107,6 +110,7 @@ func doRegistryPublish(packRoot string, opts registryPublishOptions, stdout, std
 	}
 
 	auth := registryPublishAuth{
+		Token:         strings.TrimSpace(opts.Token),
 		SessionCookie: strings.TrimSpace(opts.SessionCookie),
 		CSRFToken:     strings.TrimSpace(opts.CSRFToken),
 	}
@@ -120,8 +124,8 @@ func doRegistryPublish(packRoot string, opts registryPublishOptions, stdout, std
 			return 1
 		}
 	}
-	if auth.SessionCookie == "" || auth.CSRFToken == "" {
-		fmt.Fprintln(stderr, "gc registry publish: authentication required; set GC_REGISTRY_SESSION and GC_REGISTRY_CSRF_TOKEN, pass --session-cookie/--csrf-token, or use --dev-auth against a local registry") //nolint:errcheck
+	if !auth.hasCredentials() {
+		fmt.Fprintln(stderr, "gc registry publish: authentication required; set GC_REGISTRY_TOKEN, pass --token, set GC_REGISTRY_SESSION and GC_REGISTRY_CSRF_TOKEN, or use --dev-auth against a local registry") //nolint:errcheck
 		return 1
 	}
 
@@ -357,8 +361,14 @@ func normalizeRegistryPublishBaseURL(raw string) (string, error) {
 }
 
 type registryPublishAuth struct {
+	Token         string
 	SessionCookie string
 	CSRFToken     string
+}
+
+func (a registryPublishAuth) hasCredentials() bool {
+	return strings.TrimSpace(a.Token) != "" ||
+		(strings.TrimSpace(a.SessionCookie) != "" && strings.TrimSpace(a.CSRFToken) != "")
 }
 
 func registryPublishDevAuth(ctx context.Context, client *http.Client, baseURL, handle string) (registryPublishAuth, error) {
@@ -450,8 +460,12 @@ func submitRegistryPublishRequest(ctx context.Context, client *http.Client, base
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-CSRF-Token", auth.CSRFToken)
-	req.Header.Set("Cookie", registryPublishCookieHeader(auth.SessionCookie))
+	if strings.TrimSpace(auth.Token) != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(auth.Token))
+	} else {
+		req.Header.Set("X-CSRF-Token", auth.CSRFToken)
+		req.Header.Set("Cookie", registryPublishCookieHeader(auth.SessionCookie))
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return registryPublishSubmitted{}, fmt.Errorf("submitting publish request: %w", err)

--- a/cmd/gc/cmd_registry_auth.go
+++ b/cmd/gc/cmd_registry_auth.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/gchome"
 	"github.com/spf13/cobra"
 )
 
@@ -51,10 +52,8 @@ type registryLoginOptions struct {
 
 func newRegistryLoginCmd(stdout, stderr io.Writer) *cobra.Command {
 	opts := registryLoginOptions{
-		RegistryURL: registryFirstNonEmpty(os.Getenv("GC_REGISTRY_URL"), defaultRegistryPublishURL),
-		Token:       os.Getenv("GC_REGISTRY_TOKEN"),
-		Label:       "GC CLI login",
-		Timeout:     15 * time.Minute,
+		Label:   "GC CLI login",
+		Timeout: 15 * time.Minute,
 	}
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -64,15 +63,15 @@ func newRegistryLoginCmd(stdout, stderr io.Writer) *cobra.Command {
 By default this opens a browser for GitHub or Google Workspace sign-in. Use
 --device for headless shells, or --token to store an existing registry token.`,
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			if doRegistryLogin(opts, stdout, stderr) != 0 {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if doRegistryLogin(cmd.Context(), opts, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", opts.RegistryURL, "registry app base URL")
-	cmd.Flags().StringVar(&opts.Token, "token", opts.Token, "registry API token; defaults to GC_REGISTRY_TOKEN")
+	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", "", "registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then "+defaultRegistryPublishURL)
+	cmd.Flags().StringVar(&opts.Token, "token", "", "registry API token; defaults to GC_REGISTRY_TOKEN")
 	cmd.Flags().StringVar(&opts.Label, "label", opts.Label, "label for the registry API token")
 	cmd.Flags().BoolVar(&opts.Device, "device", false, "use device-code login instead of browser callback login")
 	cmd.Flags().BoolVar(&opts.NoBrowser, "no-browser", false, "print the browser login URL instead of opening it")
@@ -82,36 +81,36 @@ By default this opens a browser for GitHub or Google Workspace sign-in. Use
 
 func newRegistryWhoamiCmd(stdout, stderr io.Writer) *cobra.Command {
 	opts := registryLoginOptions{
-		RegistryURL: registryFirstNonEmpty(os.Getenv("GC_REGISTRY_URL"), defaultRegistryPublishURL),
-		Token:       os.Getenv("GC_REGISTRY_TOKEN"),
-		Timeout:     30 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "Show the authenticated registry account",
 		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			if doRegistryWhoami(opts, stdout, stderr) != 0 {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if doRegistryWhoami(cmd.Context(), opts, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", opts.RegistryURL, "registry app base URL")
-	cmd.Flags().StringVar(&opts.Token, "token", opts.Token, "registry API token; defaults to GC_REGISTRY_TOKEN or stored login")
+	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", "", "registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then "+defaultRegistryPublishURL)
+	cmd.Flags().StringVar(&opts.Token, "token", "", "registry API token; defaults to GC_REGISTRY_TOKEN or stored login")
 	return cmd
 }
 
-func doRegistryLogin(opts registryLoginOptions, stdout, stderr io.Writer) int {
-	baseURL, err := normalizeRegistryPublishBaseURL(opts.RegistryURL)
+func doRegistryLogin(ctx context.Context, opts registryLoginOptions, stdout, stderr io.Writer) int {
+	baseURL, err := resolveRegistryPublishBaseURL(opts.RegistryURL)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc registry login: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
 
-	token := strings.TrimSpace(opts.Token)
+	// Secrets resolve at execution time, never as flag defaults, so help
+	// output cannot render credential values from the environment.
+	token := strings.TrimSpace(registryFirstNonEmpty(opts.Token, os.Getenv("GC_REGISTRY_TOKEN")))
 	if token == "" {
 		if opts.Device {
 			token, err = registryDeviceLogin(ctx, registryPublishHTTPClient, baseURL, opts.Label, stdout)
@@ -137,13 +136,15 @@ func doRegistryLogin(opts registryLoginOptions, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func doRegistryWhoami(opts registryLoginOptions, stdout, stderr io.Writer) int {
-	baseURL, err := normalizeRegistryPublishBaseURL(opts.RegistryURL)
+func doRegistryWhoami(ctx context.Context, opts registryLoginOptions, stdout, stderr io.Writer) int {
+	baseURL, err := resolveRegistryPublishBaseURL(opts.RegistryURL)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc registry whoami: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	token := strings.TrimSpace(opts.Token)
+	// Secrets resolve at execution time, never as flag defaults, so help
+	// output cannot render credential values from the environment.
+	token := strings.TrimSpace(registryFirstNonEmpty(opts.Token, os.Getenv("GC_REGISTRY_TOKEN")))
 	if token == "" {
 		token, err = readRegistryConfiguredToken(baseURL)
 		if err != nil {
@@ -155,7 +156,7 @@ func doRegistryWhoami(opts registryLoginOptions, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "gc registry whoami: not logged in; run `gc registry login`") //nolint:errcheck
 		return 1
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
 	user, err := registryFetchCurrentUser(ctx, registryPublishHTTPClient, baseURL, token)
 	if err != nil {
@@ -166,15 +167,14 @@ func doRegistryWhoami(opts registryLoginOptions, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func registryCLIConfigPath() (string, error) {
+// registryCLIConfigPath resolves the hosted-registry auth config file path.
+// GC_REGISTRY_CONFIG_PATH wins; otherwise the file lives under the canonical
+// Gas City state root so isolated runs and tests stay sandboxed.
+func registryCLIConfigPath() string {
 	if override := strings.TrimSpace(os.Getenv(registryCLIConfigEnv)); override != "" {
-		return override, nil
+		return override
 	}
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return "", fmt.Errorf("resolving user config directory: %w", err)
-	}
-	return filepath.Join(dir, "gascity", "registry.json"), nil
+	return filepath.Join(gchome.Default(), "registry.json")
 }
 
 func loadRegistryCLIConfig(path string) (registryCLIConfig, error) {
@@ -204,21 +204,34 @@ func saveRegistryCLIConfig(path string, cfg registryCLIConfig) error {
 		return err
 	}
 	data = append(data, '\n')
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating registry config directory: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	// A fresh 0600 temp file renamed over the target keeps the write atomic
+	// and sheds any looser permissions from a pre-existing config file.
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("writing registry config: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("writing registry config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("writing registry config: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		_ = os.Remove(tmp.Name())
 		return fmt.Errorf("writing registry config: %w", err)
 	}
 	return nil
 }
 
 func readRegistryConfiguredToken(baseURL string) (string, error) {
-	path, err := registryCLIConfigPath()
-	if err != nil {
-		return "", err
-	}
-	cfg, err := loadRegistryCLIConfig(path)
+	cfg, err := loadRegistryCLIConfig(registryCLIConfigPath())
 	if err != nil {
 		return "", err
 	}
@@ -230,10 +243,7 @@ func readRegistryConfiguredToken(baseURL string) (string, error) {
 }
 
 func writeRegistryConfiguredToken(baseURL, token string) error {
-	path, err := registryCLIConfigPath()
-	if err != nil {
-		return err
-	}
+	path := registryCLIConfigPath()
 	cfg, err := loadRegistryCLIConfig(path)
 	if err != nil {
 		return err
@@ -268,8 +278,8 @@ func registryFetchCurrentUser(ctx context.Context, client *http.Client, baseURL,
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return registryCurrentUser{}, fmt.Errorf("decoding registry login: %w", err)
+	if err := registryDecodeJSONResponse(resp, &payload); err != nil {
+		return registryCurrentUser{}, fmt.Errorf("checking registry login: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if payload.Error.Message != "" {
@@ -295,11 +305,48 @@ func registryBrowserLogin(ctx context.Context, baseURL, label string, stdout io.
 		return "", err
 	}
 	resultCh := make(chan browserLoginResult, 1)
-	mux := http.NewServeMux()
 	server := &http.Server{
-		Handler:           mux,
+		Handler:           registryBrowserLoginHandler(state, resultCh),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	// Bound shutdown so a lingering keep-alive connection cannot hang the CLI.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			_ = server.Close()
+		}
+	}()
+
+	callbackURL := "http://" + listener.Addr().String() + "/callback"
+	authURL := baseURL + "/cli/auth?" + url.Values{
+		"redirect_uri": {callbackURL},
+		"state":        {state},
+		"label":        {label},
+	}.Encode()
+	if openBrowser {
+		if err := openRegistryURL(authURL); err != nil {
+			fmt.Fprintf(stdout, "Open this URL to finish registry login:\n%s\n", authURL) //nolint:errcheck
+		} else {
+			fmt.Fprintf(stdout, "Opened browser for registry login.\n%s\n", authURL) //nolint:errcheck
+		}
+	} else {
+		fmt.Fprintf(stdout, "Open this URL to finish registry login:\n%s\n", authURL) //nolint:errcheck
+	}
+
+	return resolveRegistryBrowserLoginResult(ctx, baseURL, resultCh)
+}
+
+// registryBrowserLoginHandler builds the local callback server used by browser
+// login. The /callback route serves the page that forwards the URL-fragment
+// credentials; the /token route rejects non-POST requests, malformed bodies, a
+// CSRF state mismatch, and a missing token before delivering the captured
+// result to resultCh with a non-blocking send.
+func registryBrowserLoginHandler(state string, resultCh chan<- browserLoginResult) http.Handler {
+	mux := http.NewServeMux()
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = io.WriteString(w, registryBrowserCallbackHTML())
@@ -329,27 +376,14 @@ func registryBrowserLogin(ctx context.Context, baseURL, label string, stdout io.
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"ok":true}`)
 	})
-	go func() {
-		_ = server.Serve(listener)
-	}()
-	defer server.Shutdown(context.Background()) //nolint:errcheck
+	return mux
+}
 
-	callbackURL := "http://" + listener.Addr().String() + "/callback"
-	authURL := baseURL + "/cli/auth?" + url.Values{
-		"redirect_uri": {callbackURL},
-		"state":        {state},
-		"label":        {label},
-	}.Encode()
-	if openBrowser {
-		if err := openRegistryURL(authURL); err != nil {
-			fmt.Fprintf(stdout, "Open this URL to finish registry login:\n%s\n", authURL) //nolint:errcheck
-		} else {
-			fmt.Fprintf(stdout, "Opened browser for registry login.\n%s\n", authURL) //nolint:errcheck
-		}
-	} else {
-		fmt.Fprintf(stdout, "Open this URL to finish registry login:\n%s\n", authURL) //nolint:errcheck
-	}
-
+// resolveRegistryBrowserLoginResult blocks until the callback delivers a result
+// or ctx is done. It rejects a result whose registry does not match the login
+// target so a stray callback cannot redirect the stored token to another
+// registry.
+func resolveRegistryBrowserLoginResult(ctx context.Context, baseURL string, resultCh <-chan browserLoginResult) (string, error) {
 	select {
 	case result := <-resultCh:
 		if result.Registry != "" && result.Registry != baseURL {
@@ -425,8 +459,8 @@ func registryDeviceLogin(ctx context.Context, client *http.Client, baseURL, labe
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&code); err != nil {
-		return "", fmt.Errorf("decoding device login: %w", err)
+	if err := registryDecodeJSONResponse(resp, &code); err != nil {
+		return "", fmt.Errorf("requesting device login: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if code.Error.Message != "" {
@@ -493,8 +527,8 @@ func registryPollDeviceToken(ctx context.Context, client *http.Client, baseURL, 
 		Error       string `json:"error"`
 		Interval    int    `json:"interval"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", 0, false, fmt.Errorf("decoding device login poll: %w", err)
+	if err := registryDecodeJSONResponse(resp, &payload); err != nil {
+		return "", 0, false, fmt.Errorf("polling device login: %w", err)
 	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 && payload.AccessToken != "" {
 		return payload.AccessToken, 0, false, nil
@@ -548,8 +582,8 @@ func registryRequestGitHubActionsOIDCToken(ctx context.Context, client *http.Cli
 	var payload struct {
 		Value string `json:"value"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", fmt.Errorf("decoding GitHub Actions OIDC token: %w", err)
+	if err := registryDecodeJSONResponse(resp, &payload); err != nil {
+		return "", fmt.Errorf("requesting GitHub Actions OIDC token: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", fmt.Errorf("GitHub Actions OIDC request failed: HTTP %d", resp.StatusCode)
@@ -589,8 +623,8 @@ func registryMintGitHubActionsPublishToken(ctx context.Context, client *http.Cli
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", fmt.Errorf("decoding GitHub Actions publish token: %w", err)
+	if err := registryDecodeJSONResponse(resp, &payload); err != nil {
+		return "", fmt.Errorf("minting GitHub Actions publish token: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if payload.Error.Message != "" {

--- a/cmd/gc/cmd_registry_auth.go
+++ b/cmd/gc/cmd_registry_auth.go
@@ -1,0 +1,624 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const registryCLIConfigEnv = "GC_REGISTRY_CONFIG_PATH"
+
+type registryCLIConfig struct {
+	DefaultRegistryURL string                            `json:"defaultRegistryUrl,omitempty"`
+	Registries         map[string]registryCLIConfigEntry `json:"registries"`
+}
+
+type registryCLIConfigEntry struct {
+	Token     string `json:"token"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+type registryCurrentUser struct {
+	ID          string `json:"id"`
+	Handle      string `json:"handle"`
+	DisplayName string `json:"displayName"`
+}
+
+type registryLoginOptions struct {
+	RegistryURL string
+	Token       string
+	Label       string
+	Device      bool
+	NoBrowser   bool
+	Timeout     time.Duration
+}
+
+func newRegistryLoginCmd(stdout, stderr io.Writer) *cobra.Command {
+	opts := registryLoginOptions{
+		RegistryURL: registryFirstNonEmpty(os.Getenv("GC_REGISTRY_URL"), defaultRegistryPublishURL),
+		Token:       os.Getenv("GC_REGISTRY_TOKEN"),
+		Label:       "GC CLI login",
+		Timeout:     15 * time.Minute,
+	}
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Log in to Gas City Registry",
+		Long: `Log in to Gas City Registry and store a local API token.
+
+By default this opens a browser for GitHub or Google Workspace sign-in. Use
+--device for headless shells, or --token to store an existing registry token.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if doRegistryLogin(opts, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", opts.RegistryURL, "registry app base URL")
+	cmd.Flags().StringVar(&opts.Token, "token", opts.Token, "registry API token; defaults to GC_REGISTRY_TOKEN")
+	cmd.Flags().StringVar(&opts.Label, "label", opts.Label, "label for the registry API token")
+	cmd.Flags().BoolVar(&opts.Device, "device", false, "use device-code login instead of browser callback login")
+	cmd.Flags().BoolVar(&opts.NoBrowser, "no-browser", false, "print the browser login URL instead of opening it")
+	cmd.Flags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "maximum time to wait for interactive login")
+	return cmd
+}
+
+func newRegistryWhoamiCmd(stdout, stderr io.Writer) *cobra.Command {
+	opts := registryLoginOptions{
+		RegistryURL: registryFirstNonEmpty(os.Getenv("GC_REGISTRY_URL"), defaultRegistryPublishURL),
+		Token:       os.Getenv("GC_REGISTRY_TOKEN"),
+		Timeout:     30 * time.Second,
+	}
+	cmd := &cobra.Command{
+		Use:   "whoami",
+		Short: "Show the authenticated registry account",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if doRegistryWhoami(opts, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", opts.RegistryURL, "registry app base URL")
+	cmd.Flags().StringVar(&opts.Token, "token", opts.Token, "registry API token; defaults to GC_REGISTRY_TOKEN or stored login")
+	return cmd
+}
+
+func doRegistryLogin(opts registryLoginOptions, stdout, stderr io.Writer) int {
+	baseURL, err := normalizeRegistryPublishBaseURL(opts.RegistryURL)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc registry login: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	defer cancel()
+
+	token := strings.TrimSpace(opts.Token)
+	if token == "" {
+		if opts.Device {
+			token, err = registryDeviceLogin(ctx, registryPublishHTTPClient, baseURL, opts.Label, stdout)
+		} else {
+			token, err = registryBrowserLogin(ctx, baseURL, opts.Label, stdout, !opts.NoBrowser)
+		}
+		if err != nil {
+			fmt.Fprintf(stderr, "gc registry login: %v\n", err) //nolint:errcheck
+			return 1
+		}
+	}
+
+	user, err := registryFetchCurrentUser(ctx, registryPublishHTTPClient, baseURL, token)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc registry login: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	if err := writeRegistryConfiguredToken(baseURL, token); err != nil {
+		fmt.Fprintf(stderr, "gc registry login: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	fmt.Fprintf(stdout, "Logged in to %s as @%s\n", baseURL, user.Handle) //nolint:errcheck
+	return 0
+}
+
+func doRegistryWhoami(opts registryLoginOptions, stdout, stderr io.Writer) int {
+	baseURL, err := normalizeRegistryPublishBaseURL(opts.RegistryURL)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc registry whoami: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	token := strings.TrimSpace(opts.Token)
+	if token == "" {
+		token, err = readRegistryConfiguredToken(baseURL)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc registry whoami: %v\n", err) //nolint:errcheck
+			return 1
+		}
+	}
+	if token == "" {
+		fmt.Fprintln(stderr, "gc registry whoami: not logged in; run `gc registry login`") //nolint:errcheck
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	defer cancel()
+	user, err := registryFetchCurrentUser(ctx, registryPublishHTTPClient, baseURL, token)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc registry whoami: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	fmt.Fprintf(stdout, "@%s (%s)\n", user.Handle, user.ID) //nolint:errcheck
+	return 0
+}
+
+func registryCLIConfigPath() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(registryCLIConfigEnv)); override != "" {
+		return override, nil
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving user config directory: %w", err)
+	}
+	return filepath.Join(dir, "gascity", "registry.json"), nil
+}
+
+func loadRegistryCLIConfig(path string) (registryCLIConfig, error) {
+	cfg := registryCLIConfig{Registries: map[string]registryCLIConfigEntry{}}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, nil
+		}
+		return cfg, fmt.Errorf("reading registry config: %w", err)
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("parsing registry config: %w", err)
+	}
+	if cfg.Registries == nil {
+		cfg.Registries = map[string]registryCLIConfigEntry{}
+	}
+	return cfg, nil
+}
+
+func saveRegistryCLIConfig(path string, cfg registryCLIConfig) error {
+	if cfg.Registries == nil {
+		cfg.Registries = map[string]registryCLIConfigEntry{}
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("creating registry config directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing registry config: %w", err)
+	}
+	return nil
+}
+
+func readRegistryConfiguredToken(baseURL string) (string, error) {
+	path, err := registryCLIConfigPath()
+	if err != nil {
+		return "", err
+	}
+	cfg, err := loadRegistryCLIConfig(path)
+	if err != nil {
+		return "", err
+	}
+	entry, ok := cfg.Registries[baseURL]
+	if !ok {
+		return "", nil
+	}
+	return strings.TrimSpace(entry.Token), nil
+}
+
+func writeRegistryConfiguredToken(baseURL, token string) error {
+	path, err := registryCLIConfigPath()
+	if err != nil {
+		return err
+	}
+	cfg, err := loadRegistryCLIConfig(path)
+	if err != nil {
+		return err
+	}
+	if cfg.Registries == nil {
+		cfg.Registries = map[string]registryCLIConfigEntry{}
+	}
+	cfg.DefaultRegistryURL = baseURL
+	cfg.Registries[baseURL] = registryCLIConfigEntry{
+		Token:     strings.TrimSpace(token),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	return saveRegistryCLIConfig(path, cfg)
+}
+
+func registryFetchCurrentUser(ctx context.Context, client *http.Client, baseURL, token string) (registryCurrentUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/me", nil)
+	if err != nil {
+		return registryCurrentUser{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(token))
+	resp, err := client.Do(req)
+	if err != nil {
+		return registryCurrentUser{}, fmt.Errorf("checking registry login: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var payload struct {
+		User  registryCurrentUser `json:"user"`
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return registryCurrentUser{}, fmt.Errorf("decoding registry login: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if payload.Error.Message != "" {
+			return registryCurrentUser{}, fmt.Errorf("registry rejected token (%s): %s", payload.Error.Code, payload.Error.Message)
+		}
+		return registryCurrentUser{}, fmt.Errorf("registry rejected token: HTTP %d", resp.StatusCode)
+	}
+	if strings.TrimSpace(payload.User.ID) == "" {
+		return registryCurrentUser{}, errors.New("registry token did not authenticate a user")
+	}
+	return payload.User, nil
+}
+
+func registryBrowserLogin(ctx context.Context, baseURL, label string, stdout io.Writer, openBrowser bool) (string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("starting local login callback: %w", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	state, err := randomRegistryState()
+	if err != nil {
+		return "", err
+	}
+	resultCh := make(chan browserLoginResult, 1)
+	mux := http.NewServeMux()
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, registryBrowserCallbackHTML())
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var payload browserLoginResult
+		if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&payload); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if payload.State != state {
+			http.Error(w, "bad state", http.StatusForbidden)
+			return
+		}
+		if strings.TrimSpace(payload.Token) == "" {
+			http.Error(w, "missing token", http.StatusBadRequest)
+			return
+		}
+		select {
+		case resultCh <- payload:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	defer server.Shutdown(context.Background()) //nolint:errcheck
+
+	callbackURL := "http://" + listener.Addr().String() + "/callback"
+	authURL := baseURL + "/cli/auth?" + url.Values{
+		"redirect_uri": {callbackURL},
+		"state":        {state},
+		"label":        {label},
+	}.Encode()
+	if openBrowser {
+		if err := openRegistryURL(authURL); err != nil {
+			fmt.Fprintf(stdout, "Open this URL to finish registry login:\n%s\n", authURL) //nolint:errcheck
+		} else {
+			fmt.Fprintf(stdout, "Opened browser for registry login.\n%s\n", authURL) //nolint:errcheck
+		}
+	} else {
+		fmt.Fprintf(stdout, "Open this URL to finish registry login:\n%s\n", authURL) //nolint:errcheck
+	}
+
+	select {
+	case result := <-resultCh:
+		if result.Registry != "" && result.Registry != baseURL {
+			return "", fmt.Errorf("registry callback returned %q, want %q", result.Registry, baseURL)
+		}
+		return result.Token, nil
+	case <-ctx.Done():
+		return "", errors.New("timed out waiting for browser login")
+	}
+}
+
+type browserLoginResult struct {
+	Token    string `json:"token"`
+	Registry string `json:"registry"`
+	State    string `json:"state"`
+}
+
+func registryBrowserCallbackHTML() string {
+	return `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Gas City CLI Login</title></head>
+<body>
+<main style="font-family: system-ui, sans-serif; max-width: 48rem; margin: 3rem auto; line-height: 1.5;">
+<h1>Completing Gas City CLI login</h1>
+<p id="status">Sending credentials to the local CLI callback.</p>
+</main>
+<script>
+const status = document.getElementById("status");
+const params = new URLSearchParams(window.location.hash.slice(1));
+fetch("/token", {
+  method: "POST",
+  headers: {"Content-Type": "application/json"},
+  body: JSON.stringify({
+    token: params.get("token") || "",
+    registry: params.get("registry") || "",
+    state: params.get("state") || ""
+  })
+}).then((response) => {
+  status.textContent = response.ok ? "Login complete. You can return to your terminal." : "Login failed. Return to your terminal and try again.";
+}).catch(() => {
+  status.textContent = "Login failed. Return to your terminal and try again.";
+});
+</script>
+</body>
+</html>`
+}
+
+func registryDeviceLogin(ctx context.Context, client *http.Client, baseURL, label string, stdout io.Writer) (string, error) {
+	body, err := json.Marshal(map[string]string{"label": label})
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/cli/device/code", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("requesting device login: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var code struct {
+		DeviceCode              string `json:"device_code"`
+		UserCode                string `json:"user_code"`
+		VerificationURI         string `json:"verification_uri"`
+		VerificationURIComplete string `json:"verification_uri_complete"`
+		ExpiresIn               int    `json:"expires_in"`
+		Interval                int    `json:"interval"`
+		Error                   struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&code); err != nil {
+		return "", fmt.Errorf("decoding device login: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if code.Error.Message != "" {
+			return "", fmt.Errorf("registry rejected device login (%s): %s", code.Error.Code, code.Error.Message)
+		}
+		return "", fmt.Errorf("registry rejected device login: HTTP %d", resp.StatusCode)
+	}
+	if code.DeviceCode == "" || code.UserCode == "" {
+		return "", errors.New("registry did not return a device code")
+	}
+	if code.Interval <= 0 {
+		code.Interval = 5
+	}
+	deadline := time.Now().Add(time.Duration(code.ExpiresIn+30) * time.Second)
+	fmt.Fprintf(stdout, "Open %s and enter code %s\n", code.VerificationURI, code.UserCode) //nolint:errcheck
+	if code.VerificationURIComplete != "" {
+		fmt.Fprintf(stdout, "Direct link: %s\n", code.VerificationURIComplete) //nolint:errcheck
+	}
+
+	for {
+		if time.Now().After(deadline) {
+			return "", errors.New("device login expired")
+		}
+		select {
+		case <-time.After(time.Duration(code.Interval) * time.Second):
+		case <-ctx.Done():
+			return "", errors.New("timed out waiting for device login")
+		}
+		token, pollInterval, pending, err := registryPollDeviceToken(ctx, client, baseURL, code.DeviceCode)
+		if err != nil {
+			return "", err
+		}
+		if token != "" {
+			return token, nil
+		}
+		if pollInterval > 0 {
+			code.Interval = pollInterval
+		}
+		if !pending {
+			return "", errors.New("device login failed")
+		}
+	}
+}
+
+func registryPollDeviceToken(ctx context.Context, client *http.Client, baseURL, deviceCode string) (token string, interval int, pending bool, err error) {
+	body, err := json.Marshal(map[string]string{"device_code": deviceCode})
+	if err != nil {
+		return "", 0, false, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/cli/device/token", bytes.NewReader(body))
+	if err != nil {
+		return "", 0, false, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", 0, false, fmt.Errorf("polling device login: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var payload struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		Error       string `json:"error"`
+		Interval    int    `json:"interval"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", 0, false, fmt.Errorf("decoding device login poll: %w", err)
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 && payload.AccessToken != "" {
+		return payload.AccessToken, 0, false, nil
+	}
+	switch payload.Error {
+	case "authorization_pending":
+		return "", payload.Interval, true, nil
+	case "slow_down":
+		if payload.Interval <= 0 {
+			payload.Interval = 10
+		}
+		return "", payload.Interval, true, nil
+	case "access_denied":
+		return "", 0, false, errors.New("device login denied")
+	case "expired_token":
+		return "", 0, false, errors.New("device login expired")
+	default:
+		return "", 0, false, fmt.Errorf("device login failed: HTTP %d", resp.StatusCode)
+	}
+}
+
+func registryGitHubActionsOIDCAvailable() bool {
+	return strings.TrimSpace(os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")) != "" &&
+		strings.TrimSpace(os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")) != ""
+}
+
+func registryRequestGitHubActionsOIDCToken(ctx context.Context, client *http.Client, audience string) (string, error) {
+	requestURL := strings.TrimSpace(os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"))
+	requestToken := strings.TrimSpace(os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
+	if requestURL == "" || requestToken == "" {
+		return "", errors.New("GitHub Actions OIDC environment is not available")
+	}
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing GitHub Actions OIDC URL: %w", err)
+	}
+	query := u.Query()
+	query.Set("audience", audience)
+	u.RawQuery = query.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+requestToken)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("requesting GitHub Actions OIDC token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var payload struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decoding GitHub Actions OIDC token: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("GitHub Actions OIDC request failed: HTTP %d", resp.StatusCode)
+	}
+	if strings.TrimSpace(payload.Value) == "" {
+		return "", errors.New("GitHub Actions OIDC response did not include a token")
+	}
+	return payload.Value, nil
+}
+
+func registryMintGitHubActionsPublishToken(ctx context.Context, client *http.Client, baseURL string, request registryPublishRequest, oidcToken string) (string, error) {
+	body, err := json.Marshal(struct {
+		registryPublishRequest
+		GitHubOIDCToken string `json:"githubOidcToken"`
+	}{
+		registryPublishRequest: request,
+		GitHubOIDCToken:        oidcToken,
+	})
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/publish-tokens/github-actions/mint", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("minting GitHub Actions publish token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var payload struct {
+		AccessToken string `json:"access_token"`
+		Error       struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decoding GitHub Actions publish token: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if payload.Error.Message != "" {
+			return "", fmt.Errorf("registry rejected GitHub Actions publish token (%s): %s", payload.Error.Code, payload.Error.Message)
+		}
+		return "", fmt.Errorf("registry rejected GitHub Actions publish token: HTTP %d", resp.StatusCode)
+	}
+	if strings.TrimSpace(payload.AccessToken) == "" {
+		return "", errors.New("registry did not return a GitHub Actions publish token")
+	}
+	return payload.AccessToken, nil
+}
+
+func openRegistryURL(rawURL string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", rawURL).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL).Start()
+	default:
+		return exec.Command("xdg-open", rawURL).Start()
+	}
+}
+
+func randomRegistryState() (string, error) {
+	var buf [24]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("generating auth state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf[:]), nil
+}

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildRegistryPublishRequestUsesCleanPushedGitHubHead(t *testing.T) {
@@ -158,6 +159,168 @@ func TestSubmitRegistryPublishRequestSendsBearerToken(t *testing.T) {
 	}
 	if submitted.ID != "prq_token" {
 		t.Fatalf("submitted = %+v", submitted)
+	}
+}
+
+func TestRegistryLoginStoresVerifiedToken(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "registry.json")
+	t.Setenv(registryCLIConfigEnv, configPath)
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/me" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer gcr_manual_token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"user":{"id":"usr_test","handle":"publisher","displayName":"Publisher"}}`))
+	}))
+	defer server.Close()
+	registryPublishHTTPClient = server.Client()
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryLogin(registryLoginOptions{
+		RegistryURL: server.URL,
+		Token:       "gcr_manual_token",
+		Timeout:     time.Second,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryLogin = %d, stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Logged in") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	token, err := readRegistryConfiguredToken(server.URL)
+	if err != nil {
+		t.Fatalf("readRegistryConfiguredToken: %v", err)
+	}
+	if token != "gcr_manual_token" {
+		t.Fatalf("stored token = %q", token)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("Stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("config mode = %o, want 0600", got)
+	}
+}
+
+func TestDoRegistryPublishUsesStoredLoginToken(t *testing.T) {
+	_, packDir := setupRegistryPublishRepo(t)
+	configPath := filepath.Join(t.TempDir(), "registry.json")
+	t.Setenv(registryCLIConfigEnv, configPath)
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer gcr_stored_token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"publishRequest": {
+				"id": "prq_stored",
+				"status": "pending_review",
+				"requestedName": "demo-pack",
+				"requestedVersion": "0.2.0",
+				"repository": {"fullName": "gastownhall/demo-packs"}
+			}
+		}`))
+	}))
+	defer server.Close()
+	registryPublishHTTPClient = server.Client()
+	if err := writeRegistryConfiguredToken(server.URL, "gcr_stored_token"); err != nil {
+		t.Fatalf("writeRegistryConfiguredToken: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(packDir, registryPublishOptions{
+		RegistryURL: server.URL,
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryPublish = %d, stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "prq_stored") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestDoRegistryPublishUsesGitHubActionsOIDC(t *testing.T) {
+	_, packDir := setupRegistryPublishRepo(t)
+	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "actions-request-token")
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	var sawMint bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/actions/oidc":
+			if got := r.Header.Get("Authorization"); got != "Bearer actions-request-token" {
+				t.Fatalf("OIDC Authorization = %q", got)
+			}
+			if got := r.URL.Query().Get("audience"); got != registryGitHubActionsAudience {
+				t.Fatalf("audience = %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":"github-oidc-jwt"}`))
+		case "/api/publish-tokens/github-actions/mint":
+			var payload struct {
+				registryPublishRequest
+				GitHubOIDCToken string `json:"githubOidcToken"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("Decode mint: %v", err)
+			}
+			if payload.GitHubOIDCToken != "github-oidc-jwt" {
+				t.Fatalf("githubOidcToken = %q", payload.GitHubOIDCToken)
+			}
+			if payload.RequestedName != "demo-pack" || payload.RequestedVersion != "0.2.0" {
+				t.Fatalf("mint payload = %+v", payload.registryPublishRequest)
+			}
+			sawMint = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"gcr_actions_publish","token_type":"bearer"}`))
+		case "/api/publish-requests":
+			if !sawMint {
+				t.Fatalf("publish happened before mint")
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer gcr_actions_publish" {
+				t.Fatalf("Authorization = %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"publishRequest": {
+					"id": "prq_actions",
+					"status": "pending_review",
+					"requestedName": "demo-pack",
+					"requestedVersion": "0.2.0",
+					"repository": {"fullName": "gastownhall/demo-packs"}
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", server.URL+"/actions/oidc")
+	registryPublishHTTPClient = server.Client()
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(packDir, registryPublishOptions{
+		RegistryURL: server.URL,
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryPublish = %d, stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "prq_actions") {
+		t.Fatalf("stdout = %q", stdout.String())
 	}
 }
 

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -115,6 +115,52 @@ func TestSubmitRegistryPublishRequestSendsAuthenticatedPayload(t *testing.T) {
 	}
 }
 
+func TestSubmitRegistryPublishRequestSendsBearerToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer gcr_test_token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("X-CSRF-Token"); got != "" {
+			t.Fatalf("csrf = %q, want empty with bearer auth", got)
+		}
+		if got := r.Header.Get("Cookie"); got != "" {
+			t.Fatalf("cookie = %q, want empty with bearer auth", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"publishRequest": {
+				"id": "prq_token",
+				"status": "pending_review",
+				"requestedName": "demo-pack",
+				"requestedVersion": "0.2.0",
+				"repository": {"fullName": "gastownhall/demo-packs"}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	submitted, err := submitRegistryPublishRequest(
+		t.Context(),
+		server.Client(),
+		server.URL,
+		registryPublishRequest{
+			RepoURL:          "https://github.com/gastownhall/demo-packs",
+			Commit:           strings.Repeat("1", 40),
+			PackPath:         "packs/demo",
+			RequestedName:    "demo-pack",
+			RequestedVersion: "0.2.0",
+		},
+		registryPublishAuth{Token: "gcr_test_token"},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("submitRegistryPublishRequest: %v", err)
+	}
+	if submitted.ID != "prq_token" {
+		t.Fatalf("submitted = %+v", submitted)
+	}
+}
+
 func TestRegistryPublishDevAuthFetchesLocalSession(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -16,7 +20,7 @@ import (
 func TestBuildRegistryPublishRequestUsesCleanPushedGitHubHead(t *testing.T) {
 	repo, packDir := setupRegistryPublishRepo(t)
 
-	request, err := buildRegistryPublishRequest(packDir, registryPublishOptions{})
+	request, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, false)
 	if err != nil {
 		t.Fatalf("buildRegistryPublishRequest: %v", err)
 	}
@@ -45,12 +49,12 @@ func TestBuildRegistryPublishRequestUsesCleanPushedGitHubHead(t *testing.T) {
 func TestBuildRegistryPublishRequestAcceptsWebFormFieldOverrides(t *testing.T) {
 	_, packDir := setupRegistryPublishRepo(t)
 
-	request, err := buildRegistryPublishRequest(packDir, registryPublishOptions{
+	request, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{
 		Name:        "renamed-demo-pack",
 		Version:     "1.2.3",
 		Ref:         "release/v1.2.3",
 		Description: "Operator supplied release note.",
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("buildRegistryPublishRequest: %v", err)
 	}
@@ -75,9 +79,88 @@ func TestBuildRegistryPublishRequestRejectsDirtyTree(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	_, err := buildRegistryPublishRequest(packDir, registryPublishOptions{})
+	_, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, false)
 	if err == nil || !strings.Contains(err.Error(), "working tree") {
 		t.Fatalf("err = %v, want dirty working tree error", err)
+	}
+}
+
+func TestBuildRegistryPublishRequestNameFlagSatisfiesMissingManifestName(t *testing.T) {
+	const manifestWithoutName = `[pack]
+version = "0.2.0"
+schema = 2
+description = "Demo pack for registry publishing."
+`
+	_, packDir := setupRegistryPublishRepoManifest(t, manifestWithoutName)
+
+	request, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{
+		Name: "flag-supplied-name",
+	}, false)
+	if err != nil {
+		t.Fatalf("buildRegistryPublishRequest: %v", err)
+	}
+	if request.RequestedName != "flag-supplied-name" {
+		t.Fatalf("RequestedName = %q, want flag-supplied-name", request.RequestedName)
+	}
+}
+
+func TestBuildRegistryPublishRequestRequiresNameWithoutFlagOrManifest(t *testing.T) {
+	const manifestWithoutName = `[pack]
+version = "0.2.0"
+schema = 2
+`
+	_, packDir := setupRegistryPublishRepoManifest(t, manifestWithoutName)
+
+	_, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, false)
+	if err == nil || !strings.Contains(err.Error(), "pack name is required") {
+		t.Fatalf("err = %v, want pack name required error", err)
+	}
+}
+
+// TestBuildRegistryPublishRequestIgnoresPoisonedGitEnv proves the publish
+// request is derived from the pack repository even when git-locating
+// environment variables point elsewhere. Running `gc registry publish` inside a
+// pre-commit hook or nested worktree tooling exports GIT_DIR/GIT_WORK_TREE/
+// GIT_INDEX_FILE for an unrelated repository; the publish git subprocesses must
+// strip those so status, HEAD, upstream, and remote URL are read from the pack
+// repo rather than the leaked parent.
+func TestBuildRegistryPublishRequestIgnoresPoisonedGitEnv(t *testing.T) {
+	repo, packDir := setupRegistryPublishRepo(t)
+	wantCommit := runRegistryPublishGit(t, repo, "rev-parse", "HEAD")
+
+	// A second, unrelated repo whose git-locating env vars, if inherited by the
+	// publish subprocesses, would redirect resolution away from the pack repo.
+	poison := t.TempDir()
+	runRegistryPublishGit(t, poison, "init", "-b", "main")
+	runRegistryPublishGit(t, poison, "config", "user.email", "poison@example.com")
+	runRegistryPublishGit(t, poison, "config", "user.name", "Poison Repo")
+	if err := os.WriteFile(filepath.Join(poison, "POISON"), []byte("not the pack repo\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(poison): %v", err)
+	}
+	runRegistryPublishGit(t, poison, "add", ".")
+	runRegistryPublishGit(t, poison, "commit", "-m", "poison commit")
+	poisonCommit := runRegistryPublishGit(t, poison, "rev-parse", "HEAD")
+	if poisonCommit == wantCommit {
+		t.Fatalf("poison repo HEAD unexpectedly equals pack repo HEAD %s", wantCommit)
+	}
+
+	// Poison only after both repos are built so setup is unaffected.
+	t.Setenv("GIT_DIR", filepath.Join(poison, ".git"))
+	t.Setenv("GIT_WORK_TREE", poison)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(poison, ".git", "index"))
+
+	request, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, false)
+	if err != nil {
+		t.Fatalf("buildRegistryPublishRequest with poisoned git env: %v", err)
+	}
+	if request.Commit != wantCommit {
+		t.Fatalf("Commit = %q, want pack repo HEAD %q (must ignore poisoned GIT_DIR)", request.Commit, wantCommit)
+	}
+	if request.RepoURL != "https://github.com/gastownhall/demo-packs" {
+		t.Fatalf("RepoURL = %q, want pack repo remote", request.RepoURL)
+	}
+	if request.PackPath != "packs/demo" {
+		t.Fatalf("PackPath = %q, want packs/demo", request.PackPath)
 	}
 }
 
@@ -209,7 +292,7 @@ func TestRegistryLoginStoresVerifiedToken(t *testing.T) {
 	registryPublishHTTPClient = server.Client()
 
 	var stdout, stderr bytes.Buffer
-	code := doRegistryLogin(registryLoginOptions{
+	code := doRegistryLogin(t.Context(), registryLoginOptions{
 		RegistryURL: server.URL,
 		Token:       "gcr_manual_token",
 		Timeout:     time.Second,
@@ -240,6 +323,7 @@ func TestDoRegistryPublishUsesStoredLoginToken(t *testing.T) {
 	_, packDir := setupRegistryPublishRepo(t)
 	configPath := filepath.Join(t.TempDir(), "registry.json")
 	t.Setenv(registryCLIConfigEnv, configPath)
+	clearRegistryEnv(t)
 	oldClient := registryPublishHTTPClient
 	defer func() { registryPublishHTTPClient = oldClient }()
 
@@ -265,7 +349,7 @@ func TestDoRegistryPublishUsesStoredLoginToken(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRegistryPublish(packDir, registryPublishOptions{
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
 		RegistryURL: server.URL,
 		Validate:    true,
 	}, &stdout, &stderr)
@@ -277,9 +361,144 @@ func TestDoRegistryPublishUsesStoredLoginToken(t *testing.T) {
 	}
 }
 
+// TestDoRegistryPublishValidateFailsOnValidationError covers the registry
+// returning a 2xx publish response that nonetheless reports a validation
+// rejection. With --validate, that must exit non-zero so CI cannot treat a
+// failed validation as a successful publish (gastownhall/gascity#3343 review
+// attempt-8 major).
+func TestDoRegistryPublishValidateFailsOnValidationError(t *testing.T) {
+	_, packDir := setupRegistryPublishRepo(t)
+	configPath := filepath.Join(t.TempDir(), "registry.json")
+	t.Setenv(registryCLIConfigEnv, configPath)
+	clearRegistryEnv(t)
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"publishRequest": {
+				"id": "prq_invalid",
+				"status": "rejected",
+				"requestedName": "demo-pack",
+				"requestedVersion": "0.2.0",
+				"validationError": "pack.toml is missing a description"
+			}
+		}`))
+	}))
+	defer server.Close()
+	registryPublishHTTPClient = server.Client()
+	if err := writeRegistryConfiguredToken(server.URL, "gcr_stored_token"); err != nil {
+		t.Fatalf("writeRegistryConfiguredToken: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: server.URL,
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doRegistryPublish = 0, want non-zero on validation rejection; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "validation failed") ||
+		!strings.Contains(stderr.String(), "pack.toml is missing a description") {
+		t.Fatalf("stderr = %q, want it to report the validation failure", stderr.String())
+	}
+}
+
+// TestDoRegistryPublishValidateFailsOnRejectedStatus covers a 2xx publish
+// response with a terminal rejected status and no explicit validationError.
+// --validate must still exit non-zero.
+func TestDoRegistryPublishValidateFailsOnRejectedStatus(t *testing.T) {
+	_, packDir := setupRegistryPublishRepo(t)
+	configPath := filepath.Join(t.TempDir(), "registry.json")
+	t.Setenv(registryCLIConfigEnv, configPath)
+	clearRegistryEnv(t)
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"publishRequest": {
+				"id": "prq_denied",
+				"status": "invalid",
+				"statusReason": "name already published at a higher version",
+				"requestedName": "demo-pack",
+				"requestedVersion": "0.2.0"
+			}
+		}`))
+	}))
+	defer server.Close()
+	registryPublishHTTPClient = server.Client()
+	if err := writeRegistryConfiguredToken(server.URL, "gcr_stored_token"); err != nil {
+		t.Fatalf("writeRegistryConfiguredToken: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: server.URL,
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doRegistryPublish = 0, want non-zero on rejected status; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "validation failed") ||
+		!strings.Contains(stderr.String(), "name already published") {
+		t.Fatalf("stderr = %q, want it to report the rejected status reason", stderr.String())
+	}
+}
+
+// TestDoRegistryPublishStoredTokenSurvivesPartialCookieEnv covers a lone
+// GC_REGISTRY_SESSION (cookie without CSRF). That is not a usable credential,
+// so it must not suppress loading a valid stored login token
+// (gastownhall/gascity#3343 review attempt-8 minor).
+func TestDoRegistryPublishStoredTokenSurvivesPartialCookieEnv(t *testing.T) {
+	_, packDir := setupRegistryPublishRepo(t)
+	configPath := filepath.Join(t.TempDir(), "registry.json")
+	t.Setenv(registryCLIConfigEnv, configPath)
+	clearRegistryEnv(t)
+	t.Setenv("GC_REGISTRY_SESSION", "stale-session-cookie")
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer gcr_stored_token" {
+			t.Fatalf("Authorization = %q, want stored bearer token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"publishRequest": {
+				"id": "prq_partial",
+				"status": "pending_review",
+				"requestedName": "demo-pack",
+				"requestedVersion": "0.2.0"
+			}
+		}`))
+	}))
+	defer server.Close()
+	registryPublishHTTPClient = server.Client()
+	if err := writeRegistryConfiguredToken(server.URL, "gcr_stored_token"); err != nil {
+		t.Fatalf("writeRegistryConfiguredToken: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: server.URL,
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryPublish = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "prq_partial") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
 func TestDoRegistryPublishUsesGitHubActionsOIDC(t *testing.T) {
 	_, packDir := setupRegistryPublishRepo(t)
 	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	clearRegistryEnv(t)
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "actions-request-token")
 	oldClient := registryPublishHTTPClient
 	defer func() { registryPublishHTTPClient = oldClient }()
@@ -339,7 +558,7 @@ func TestDoRegistryPublishUsesGitHubActionsOIDC(t *testing.T) {
 	registryPublishHTTPClient = server.Client()
 
 	var stdout, stderr bytes.Buffer
-	code := doRegistryPublish(packDir, registryPublishOptions{
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
 		RegistryURL: server.URL,
 		Validate:    true,
 	}, &stdout, &stderr)
@@ -349,6 +568,300 @@ func TestDoRegistryPublishUsesGitHubActionsOIDC(t *testing.T) {
 	if !strings.Contains(stdout.String(), "prq_actions") {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
+}
+
+func TestDoRegistryPublishUsesGitHubActionsOIDCWithoutUpstream(t *testing.T) {
+	packDir, headSHA := setupRegistryPublishRepoDetached(t)
+	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	clearRegistryEnv(t)
+	// A detached actions/checkout has no `@{u}`; the runner metadata is the
+	// authoritative repository and ref source for the publish request.
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "actions-request-token")
+	t.Setenv("GITHUB_REPOSITORY", "gastownhall/demo-packs")
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	t.Setenv("GITHUB_SHA", headSHA)
+	t.Setenv("GITHUB_REF_NAME", "main")
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	var sawMint bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/actions/oidc":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":"github-oidc-jwt"}`))
+		case "/api/publish-tokens/github-actions/mint":
+			var payload struct {
+				registryPublishRequest
+				GitHubOIDCToken string `json:"githubOidcToken"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("Decode mint: %v", err)
+			}
+			if payload.RepoURL != "https://github.com/gastownhall/demo-packs" {
+				t.Fatalf("mint repoUrl = %q", payload.RepoURL)
+			}
+			if payload.Commit != headSHA {
+				t.Fatalf("mint commit = %q, want %q", payload.Commit, headSHA)
+			}
+			if payload.RequestedRef != "main" {
+				t.Fatalf("mint requestedRef = %q", payload.RequestedRef)
+			}
+			sawMint = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"gcr_actions_publish","token_type":"bearer"}`))
+		case "/api/publish-requests":
+			if !sawMint {
+				t.Fatalf("publish happened before mint")
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer gcr_actions_publish" {
+				t.Fatalf("Authorization = %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"publishRequest": {
+					"id": "prq_actions_detached",
+					"status": "pending_review",
+					"requestedName": "demo-pack",
+					"requestedVersion": "0.2.0",
+					"repository": {"fullName": "gastownhall/demo-packs"}
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", server.URL+"/actions/oidc")
+	registryPublishHTTPClient = server.Client()
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: server.URL,
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryPublish = %d, stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "prq_actions_detached") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestDoRegistryPublishWithoutUpstreamOrActionsFails(t *testing.T) {
+	packDir, _ := setupRegistryPublishRepoDetached(t)
+	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	clearRegistryEnv(t)
+	// No GitHub Actions OIDC environment: a detached checkout must still report
+	// the upstream requirement rather than silently deriving a repository.
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
+	t.Setenv("GITHUB_REPOSITORY", "gastownhall/demo-packs")
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: "https://registry.example.com",
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doRegistryPublish = 0, want failure; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "current branch has no upstream") {
+		t.Fatalf("stderr = %q, want upstream requirement", stderr.String())
+	}
+}
+
+// roundTripperFunc adapts a function to http.RoundTripper so a test can assert
+// that no network call is made on a path that must fail locally.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// failingRegistryHTTPClient installs an HTTP client that fails the test on any
+// request and restores the previous client at cleanup. Use it to prove a
+// publish is rejected locally before contacting the registry or OIDC endpoint.
+func failingRegistryHTTPClient(t *testing.T) {
+	t.Helper()
+	old := registryPublishHTTPClient
+	t.Cleanup(func() { registryPublishHTTPClient = old })
+	registryPublishHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected network call to %s", r.URL)
+			return nil, context.Canceled
+		}),
+	}
+}
+
+// setSpoofedGitHubActionsEnv sets GitHub Actions runner and OIDC-request
+// environment variables that match a detached HEAD. These values are trivially
+// spoofable outside CI, so a publish that does not authenticate through the OIDC
+// mint path must not let them skip the pushed-HEAD requirement.
+func setSpoofedGitHubActionsEnv(t *testing.T, headSHA string) {
+	t.Helper()
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "actions-request-token")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://example.test/oidc")
+	t.Setenv("GITHUB_REPOSITORY", "gastownhall/demo-packs")
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	t.Setenv("GITHUB_SHA", headSHA)
+	t.Setenv("GITHUB_REF_NAME", "main")
+}
+
+// TestBuildRegistryPublishRequestDetachedRequiresUpstreamWithoutOIDCMint proves
+// the request builder consults the GitHub Actions repo/ref fallback only when
+// the caller is on the OIDC mint path. With the fallback disabled, a detached
+// checkout must still require a pushed upstream even though spoofable runner
+// metadata is present; with it enabled, the runner metadata resolves the repo.
+func TestBuildRegistryPublishRequestDetachedRequiresUpstreamWithoutOIDCMint(t *testing.T) {
+	packDir, headSHA := setupRegistryPublishRepoDetached(t)
+	setSpoofedGitHubActionsEnv(t, headSHA)
+
+	if _, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, false); err == nil ||
+		!strings.Contains(err.Error(), "current branch has no upstream") {
+		t.Fatalf("err = %v, want no-upstream error when GitHub Actions fallback is disabled", err)
+	}
+
+	request, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, true)
+	if err != nil {
+		t.Fatalf("buildRegistryPublishRequest(allow=true): %v", err)
+	}
+	if request.RepoURL != "https://github.com/gastownhall/demo-packs" {
+		t.Fatalf("RepoURL = %q, want runner-derived repo", request.RepoURL)
+	}
+	if request.RequestedRef != "main" {
+		t.Fatalf("RequestedRef = %q, want main", request.RequestedRef)
+	}
+	if request.Commit != headSHA {
+		t.Fatalf("Commit = %q, want %q", request.Commit, headSHA)
+	}
+}
+
+// TestDoRegistryPublishDetachedWithExplicitTokenRequiresUpstream proves that a
+// detached/no-upstream publish carrying an explicit --token does not take the
+// GitHub Actions repo/ref fallback even when the Actions environment is present.
+// The token short-circuits the OIDC mint path, so the publish must fail the
+// upstream requirement locally rather than trusting spoofable runner metadata.
+func TestDoRegistryPublishDetachedWithExplicitTokenRequiresUpstream(t *testing.T) {
+	packDir, headSHA := setupRegistryPublishRepoDetached(t)
+	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	clearRegistryEnv(t)
+	setSpoofedGitHubActionsEnv(t, headSHA)
+	failingRegistryHTTPClient(t)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: "https://registry.example.com",
+		Token:       "gcr_explicit_token",
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doRegistryPublish = 0, want failure; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "current branch has no upstream") {
+		t.Fatalf("stderr = %q, want upstream requirement despite spoofed Actions env", stderr.String())
+	}
+}
+
+// TestDoRegistryPublishDetachedWithStoredTokenRequiresUpstream is the stored
+// login token analog: a detached/no-upstream publish that authenticates with a
+// stored token must also keep proving HEAD is pushed and must not be redirected
+// by spoofable GitHub Actions runner metadata.
+func TestDoRegistryPublishDetachedWithStoredTokenRequiresUpstream(t *testing.T) {
+	packDir, headSHA := setupRegistryPublishRepoDetached(t)
+	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	clearRegistryEnv(t)
+	setSpoofedGitHubActionsEnv(t, headSHA)
+	failingRegistryHTTPClient(t)
+	if err := writeRegistryConfiguredToken("https://registry.example.com", "gcr_stored_token"); err != nil {
+		t.Fatalf("writeRegistryConfiguredToken: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: "https://registry.example.com",
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doRegistryPublish = 0, want failure; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "current branch has no upstream") {
+		t.Fatalf("stderr = %q, want upstream requirement despite spoofed Actions env", stderr.String())
+	}
+}
+
+func TestRegistryGitHubActionsRepoRef(t *testing.T) {
+	const headSHA = "0123456789abcdef0123456789abcdef01234567"
+	setActionsEnv := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://example.test/oidc")
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "req-token")
+		t.Setenv("GITHUB_REPOSITORY", "gastownhall/demo-packs")
+		t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+		t.Setenv("GITHUB_SHA", headSHA)
+		t.Setenv("GITHUB_REF_NAME", "main")
+	}
+
+	t.Run("derives repo and ref from runner metadata", func(t *testing.T) {
+		setActionsEnv(t)
+		got, ok := registryGitHubActionsRepoRef(headSHA, registryPublishOptions{})
+		if !ok {
+			t.Fatal("ok = false, want true")
+		}
+		if got.RepoURL != "https://github.com/gastownhall/demo-packs" {
+			t.Fatalf("RepoURL = %q", got.RepoURL)
+		}
+		if got.Ref != "main" {
+			t.Fatalf("Ref = %q", got.Ref)
+		}
+	})
+
+	t.Run("flag ref overrides runner ref", func(t *testing.T) {
+		setActionsEnv(t)
+		got, ok := registryGitHubActionsRepoRef(headSHA, registryPublishOptions{Ref: "v1.2.3"})
+		if !ok || got.Ref != "v1.2.3" {
+			t.Fatalf("got = %+v, ok = %v", got, ok)
+		}
+	})
+
+	t.Run("default server url when unset", func(t *testing.T) {
+		setActionsEnv(t)
+		t.Setenv("GITHUB_SERVER_URL", "")
+		got, ok := registryGitHubActionsRepoRef(headSHA, registryPublishOptions{})
+		if !ok || got.RepoURL != "https://github.com/gastownhall/demo-packs" {
+			t.Fatalf("got = %+v, ok = %v", got, ok)
+		}
+	})
+
+	t.Run("no OIDC environment", func(t *testing.T) {
+		setActionsEnv(t)
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
+		if _, ok := registryGitHubActionsRepoRef(headSHA, registryPublishOptions{}); ok {
+			t.Fatal("ok = true, want false without OIDC environment")
+		}
+	})
+
+	t.Run("missing repository", func(t *testing.T) {
+		setActionsEnv(t)
+		t.Setenv("GITHUB_REPOSITORY", "")
+		if _, ok := registryGitHubActionsRepoRef(headSHA, registryPublishOptions{}); ok {
+			t.Fatal("ok = true, want false without GITHUB_REPOSITORY")
+		}
+	})
+
+	t.Run("commit mismatch", func(t *testing.T) {
+		setActionsEnv(t)
+		t.Setenv("GITHUB_SHA", "ffffffffffffffffffffffffffffffffffffffff")
+		if _, ok := registryGitHubActionsRepoRef(headSHA, registryPublishOptions{}); ok {
+			t.Fatal("ok = true, want false when GITHUB_SHA != HEAD")
+		}
+	})
+
+	t.Run("missing commit sha", func(t *testing.T) {
+		setActionsEnv(t)
+		t.Setenv("GITHUB_SHA", "")
+		if _, ok := registryGitHubActionsRepoRef(headSHA, registryPublishOptions{}); ok {
+			t.Fatal("ok = true, want false when GITHUB_SHA is unset")
+		}
+	})
 }
 
 func TestRegistryPublishDevAuthFetchesLocalSession(t *testing.T) {
@@ -385,8 +898,10 @@ func TestRegistryPublishDevAuthFetchesLocalSession(t *testing.T) {
 
 func TestDoRegistryPublishDryRunPrintsRequest(t *testing.T) {
 	_, packDir := setupRegistryPublishRepo(t)
+	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	clearRegistryEnv(t)
 	var stdout, stderr bytes.Buffer
-	code := doRegistryPublish(packDir, registryPublishOptions{
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
 		RegistryURL: "http://127.0.0.1:8080",
 		DryRun:      true,
 	}, &stdout, &stderr)
@@ -406,11 +921,838 @@ func TestDoRegistryPublishDryRunPrintsRequest(t *testing.T) {
 	}
 }
 
+func TestRegistryHelpDoesNotLeakEnvironmentSecrets(t *testing.T) {
+	t.Setenv("GC_REGISTRY_TOKEN", "s3cr3t-token")
+	t.Setenv("GC_REGISTRY_SESSION", "s3cr3t-session")
+	t.Setenv("GC_REGISTRY_CSRF_TOKEN", "s3cr3t-csrf")
+
+	for _, sub := range []string{"publish", "login", "whoami"} {
+		var help bytes.Buffer
+		cmd := newRegistryCmd(io.Discard, io.Discard)
+		cmd.SetOut(&help)
+		cmd.SetErr(&help)
+		cmd.SetArgs([]string{sub, "--help"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("registry %s --help: %v", sub, err)
+		}
+		if strings.Contains(help.String(), "s3cr3t") {
+			t.Fatalf("registry %s --help leaks environment secrets:\n%s", sub, help.String())
+		}
+	}
+}
+
+func TestDoRegistryPublishUsesEnvironmentToken(t *testing.T) {
+	_, packDir := setupRegistryPublishRepo(t)
+	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	clearRegistryEnv(t)
+	t.Setenv("GC_REGISTRY_TOKEN", "gcr_env_token")
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer gcr_env_token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"publishRequest": {
+				"id": "prq_env",
+				"status": "pending_review",
+				"requestedName": "demo-pack",
+				"requestedVersion": "0.2.0",
+				"repository": {"fullName": "gastownhall/demo-packs"}
+			}
+		}`))
+	}))
+	defer server.Close()
+	registryPublishHTTPClient = server.Client()
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: server.URL,
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryPublish = %d, stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "prq_env") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestDoRegistryWhoamiUsesStoredDefaultRegistryURL(t *testing.T) {
+	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	clearRegistryEnv(t)
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/me" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer gcr_default_token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"user":{"id":"usr_test","handle":"publisher","displayName":"Publisher"}}`))
+	}))
+	defer server.Close()
+	registryPublishHTTPClient = server.Client()
+	if err := writeRegistryConfiguredToken(server.URL, "gcr_default_token"); err != nil {
+		t.Fatalf("writeRegistryConfiguredToken: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryWhoami(t.Context(), registryLoginOptions{Timeout: time.Second}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryWhoami = %d, stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "@publisher") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestDoRegistryWhoamiRejectsNonLocalHTTPRegistry(t *testing.T) {
+	t.Setenv(registryCLIConfigEnv, filepath.Join(t.TempDir(), "registry.json"))
+	clearRegistryEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryWhoami(t.Context(), registryLoginOptions{
+		RegistryURL: "http://registry.example",
+		Token:       "gcr_should_not_be_sent",
+		Timeout:     time.Second,
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doRegistryWhoami = 0, want rejection of cleartext registry; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "https") {
+		t.Fatalf("stderr = %q, want https requirement for non-local registry", stderr.String())
+	}
+}
+
+func TestRegistryCLIConfigPathUsesGCHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GC_HOME", home)
+	t.Setenv(registryCLIConfigEnv, "")
+	if got, want := registryCLIConfigPath(), filepath.Join(home, "registry.json"); got != want {
+		t.Fatalf("registryCLIConfigPath() = %q, want %q", got, want)
+	}
+
+	override := filepath.Join(t.TempDir(), "custom", "registry.json")
+	t.Setenv(registryCLIConfigEnv, override)
+	if got := registryCLIConfigPath(); got != override {
+		t.Fatalf("registryCLIConfigPath() override = %q, want %q", got, override)
+	}
+}
+
+func TestSaveRegistryCLIConfigAtomicallyTightensPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cfg := registryCLIConfig{
+		DefaultRegistryURL: "https://registry.example",
+		Registries: map[string]registryCLIConfigEntry{
+			"https://registry.example": {Token: "gcr_atomic_token", UpdatedAt: "2026-06-13T00:00:00Z"},
+		},
+	}
+	if err := saveRegistryCLIConfig(path, cfg); err != nil {
+		t.Fatalf("saveRegistryCLIConfig: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("config mode = %o, want 0600 after rewriting a 0644 file", got)
+	}
+	loaded, err := loadRegistryCLIConfig(path)
+	if err != nil {
+		t.Fatalf("loadRegistryCLIConfig: %v", err)
+	}
+	if loaded.DefaultRegistryURL != "https://registry.example" || loaded.Registries["https://registry.example"].Token != "gcr_atomic_token" {
+		t.Fatalf("loaded = %+v", loaded)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("temp files left behind: %v", entries)
+	}
+}
+
+func TestRegistryFetchCurrentUserReportsHTTPStatusForNonJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("<html><body>Bad gateway</body></html>"))
+	}))
+	defer server.Close()
+
+	_, err := registryFetchCurrentUser(t.Context(), server.Client(), server.URL, "tok")
+	if err == nil || !strings.Contains(err.Error(), "HTTP 502") {
+		t.Fatalf("err = %v, want HTTP 502 in error", err)
+	}
+	if strings.Contains(err.Error(), "invalid character") {
+		t.Fatalf("err = %v, want status reported before JSON decode failure", err)
+	}
+}
+
+func TestSubmitRegistryPublishRequestReportsHTTPStatusForNonJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("<html>upstream unavailable</html>"))
+	}))
+	defer server.Close()
+
+	_, err := submitRegistryPublishRequest(
+		t.Context(),
+		server.Client(),
+		server.URL,
+		registryPublishRequest{
+			RepoURL:          "https://github.com/gastownhall/demo-packs",
+			Commit:           strings.Repeat("1", 40),
+			PackPath:         ".",
+			RequestedName:    "demo-pack",
+			RequestedVersion: "0.2.0",
+		},
+		registryPublishAuth{Token: "tok"},
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "HTTP 503") {
+		t.Fatalf("err = %v, want HTTP 503 in error", err)
+	}
+}
+
+func TestRegistryPublishFetchCSRFReturnsToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/me" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		cookie, err := r.Cookie("registry_session")
+		if err != nil || cookie.Value != "session-csrf" {
+			t.Fatalf("cookie = %v %v", cookie, err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"csrfToken":"csrf-token"}`))
+	}))
+	defer server.Close()
+
+	csrf, err := registryPublishFetchCSRF(t.Context(), server.Client(), server.URL, "session-csrf")
+	if err != nil {
+		t.Fatalf("registryPublishFetchCSRF: %v", err)
+	}
+	if csrf != "csrf-token" {
+		t.Fatalf("csrf = %q, want csrf-token", csrf)
+	}
+}
+
+func TestRegistryPublishFetchCSRFReportsHTTPStatusForNonJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("<html><body>Bad gateway</body></html>"))
+	}))
+	defer server.Close()
+
+	_, err := registryPublishFetchCSRF(t.Context(), server.Client(), server.URL, "session-csrf")
+	if err == nil || !strings.Contains(err.Error(), "HTTP 502") {
+		t.Fatalf("err = %v, want HTTP 502 in error", err)
+	}
+	if strings.Contains(err.Error(), "invalid character") {
+		t.Fatalf("err = %v, want status reported before JSON decode failure", err)
+	}
+	if !strings.Contains(err.Error(), "Bad gateway") {
+		t.Fatalf("err = %v, want bounded response snippet in error", err)
+	}
+}
+
+func TestRegistryPublishFetchCSRFRejectsMissingToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"csrfToken":"   "}`))
+	}))
+	defer server.Close()
+
+	_, err := registryPublishFetchCSRF(t.Context(), server.Client(), server.URL, "session-csrf")
+	if err == nil || !strings.Contains(err.Error(), "did not include a CSRF token") {
+		t.Fatalf("err = %v, want missing CSRF token error", err)
+	}
+}
+
+func TestRegistryPublishCookieHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare value", "abc", "registry_session=abc"},
+		{"bare value with base64 padding", "abc==", "registry_session=abc=="},
+		{"bare value trimmed", "  abc  ", "registry_session=abc"},
+		{"full session pair", "registry_session=xyz", "registry_session=xyz"},
+		{"session pair with extra cookie", "registry_session=xyz; other=1", "registry_session=xyz; other=1"},
+		{"foreign multi-cookie header", "a=b; c=d", "a=b; c=d"},
+	}
+	for _, tc := range cases {
+		if got := registryPublishCookieHeader(tc.in); got != tc.want {
+			t.Errorf("%s: registryPublishCookieHeader(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeGitHubRemoteURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"scp-like with .git", "git@github.com:gastownhall/demo-packs.git", "https://github.com/gastownhall/demo-packs", false},
+		{"scp-like without .git", "git@github.com:gastownhall/demo-packs", "https://github.com/gastownhall/demo-packs", false},
+		{"ssh scheme", "ssh://git@github.com/gastownhall/demo-packs.git", "https://github.com/gastownhall/demo-packs", false},
+		{"https with .git", "https://github.com/gastownhall/demo-packs.git", "https://github.com/gastownhall/demo-packs", false},
+		{"http", "http://github.com/gastownhall/demo-packs", "https://github.com/gastownhall/demo-packs", false},
+		{"https trailing slash", "https://github.com/gastownhall/demo-packs/", "https://github.com/gastownhall/demo-packs", false},
+		{"non-github https", "https://gitlab.com/owner/repo", "", true},
+		{"non-github ssh", "ssh://git@bitbucket.org/owner/repo", "", true},
+		{"missing repo segment", "git@github.com:invalid", "", true},
+		{"extra path segment", "https://github.com/owner/repo/extra", "", true},
+	}
+	for _, tc := range cases {
+		got, err := normalizeGitHubRemoteURL(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: normalizeGitHubRemoteURL(%q) = %q, want error", tc.name, tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: normalizeGitHubRemoteURL(%q): %v", tc.name, tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: normalizeGitHubRemoteURL(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeRegistryPublishBaseURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"empty uses production default", "", defaultRegistryPublishURL, false},
+		{"trailing slash trimmed", "https://reg.example/", "https://reg.example", false},
+		{"path query fragment trimmed", "https://reg.example/app/?q=1#frag", "https://reg.example/app", false},
+		{"local http allowed", "http://localhost:3000", "http://localhost:3000", false},
+		{"loopback ip http allowed", "http://127.0.0.1:8080", "http://127.0.0.1:8080", false},
+		{"non-local http rejected", "http://registry.example", "", true},
+		{"non-http scheme rejected", "ftp://reg.example", "", true},
+		{"missing scheme rejected", "not a url", "", true},
+		{"missing host rejected", "https://", "", true},
+	}
+	for _, tc := range cases {
+		got, err := normalizeRegistryPublishBaseURL(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: normalizeRegistryPublishBaseURL(%q) = %q, want error", tc.name, tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: normalizeRegistryPublishBaseURL(%q): %v", tc.name, tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: normalizeRegistryPublishBaseURL(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSplitGitUpstream(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		wantRemote string
+		wantBranch string
+		wantErr    bool
+	}{
+		{"simple", "origin/main", "origin", "main", false},
+		{"branch with slash", "origin/feature/x", "origin", "feature/x", false},
+		{"no branch", "origin", "", "", true},
+		{"empty remote", "/main", "", "", true},
+		{"empty branch", "origin/", "", "", true},
+		{"empty", "", "", "", true},
+	}
+	for _, tc := range cases {
+		remote, branch, err := splitGitUpstream(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: splitGitUpstream(%q) = (%q, %q), want error", tc.name, tc.in, remote, branch)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: splitGitUpstream(%q): %v", tc.name, tc.in, err)
+			continue
+		}
+		if remote != tc.wantRemote || branch != tc.wantBranch {
+			t.Errorf("%s: splitGitUpstream(%q) = (%q, %q), want (%q, %q)", tc.name, tc.in, remote, branch, tc.wantRemote, tc.wantBranch)
+		}
+	}
+}
+
+func TestRegistryPublishPackPath(t *testing.T) {
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	cases := []struct {
+		name     string
+		packRoot string
+		want     string
+		wantErr  bool
+	}{
+		{"repo root", repoRoot, ".", false},
+		{"nested pack", filepath.Join(repoRoot, "packs", "demo"), "packs/demo", false},
+		{"dot-dot-prefixed name inside repo", filepath.Join(repoRoot, "..foo"), "..foo", false},
+		{"outside repo", filepath.Join(repoRoot, "..", "elsewhere"), "", true},
+	}
+	for _, tc := range cases {
+		got, err := registryPublishPackPath(repoRoot, tc.packRoot)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: registryPublishPackPath(%q) = %q, want error", tc.name, tc.packRoot, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: registryPublishPackPath(%q): %v", tc.name, tc.packRoot, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: registryPublishPackPath(%q) = %q, want %q", tc.name, tc.packRoot, got, tc.want)
+		}
+	}
+}
+
+func TestRegistryPollDeviceToken(t *testing.T) {
+	cases := []struct {
+		name         string
+		status       int
+		body         string
+		wantToken    string
+		wantInterval int
+		wantPending  bool
+		wantErr      string
+	}{
+		{"authorization pending", http.StatusBadRequest, `{"error":"authorization_pending","interval":7}`, "", 7, true, ""},
+		{"slow down applies default interval", http.StatusBadRequest, `{"error":"slow_down"}`, "", 10, true, ""},
+		{"access denied", http.StatusBadRequest, `{"error":"access_denied"}`, "", 0, false, "device login denied"},
+		{"expired token", http.StatusBadRequest, `{"error":"expired_token"}`, "", 0, false, "device login expired"},
+		{"success", http.StatusOK, `{"access_token":"gcr_device_token","token_type":"bearer"}`, "gcr_device_token", 0, false, ""},
+		{"unknown error", http.StatusBadRequest, `{"error":"weird"}`, "", 0, false, "device login failed: HTTP 400"},
+		{"proxy html error", http.StatusBadGateway, `<html>bad gateway</html>`, "", 0, false, "HTTP 502"},
+	}
+	for _, tc := range cases {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(tc.status)
+			_, _ = w.Write([]byte(tc.body))
+		}))
+		token, interval, pending, err := registryPollDeviceToken(t.Context(), server.Client(), server.URL, "device-code-test")
+		server.Close()
+		if tc.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("%s: err = %v, want %q", tc.name, err, tc.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: registryPollDeviceToken: %v", tc.name, err)
+			continue
+		}
+		if token != tc.wantToken || interval != tc.wantInterval || pending != tc.wantPending {
+			t.Errorf("%s: got (token=%q, interval=%d, pending=%v), want (token=%q, interval=%d, pending=%v)",
+				tc.name, token, interval, pending, tc.wantToken, tc.wantInterval, tc.wantPending)
+		}
+	}
+}
+
+// TestRegistryDeviceLoginCompletesAfterPending drives the device-code login
+// orchestration end to end: it requests a device code, prints the verification
+// instructions, polls through an authorization_pending response, and returns the
+// access token once the registry approves. This covers gc registry login
+// --device above the registryPollDeviceToken helper unit test.
+func TestRegistryDeviceLoginCompletesAfterPending(t *testing.T) {
+	var mu sync.Mutex
+	var codeRequests, tokenRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/cli/device/code":
+			var payload struct {
+				Label string `json:"label"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Errorf("decode device code request: %v", err)
+			}
+			if payload.Label != "GC CLI login" {
+				t.Errorf("label = %q, want GC CLI login", payload.Label)
+			}
+			mu.Lock()
+			codeRequests++
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{
+				"device_code": "dev-code-123",
+				"user_code": "WXYZ-1234",
+				"verification_uri": "https://registry.example/device",
+				"verification_uri_complete": "https://registry.example/device?code=WXYZ-1234",
+				"expires_in": 60,
+				"interval": 1
+			}`))
+		case "/api/cli/device/token":
+			var payload struct {
+				DeviceCode string `json:"device_code"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Errorf("decode device token request: %v", err)
+			}
+			if payload.DeviceCode != "dev-code-123" {
+				t.Errorf("device_code = %q, want dev-code-123", payload.DeviceCode)
+			}
+			mu.Lock()
+			tokenRequests++
+			attempt := tokenRequests
+			mu.Unlock()
+			if attempt == 1 {
+				// First poll: not yet authorized. The CLI must keep polling.
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"authorization_pending","interval":1}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"access_token":"gcr_device_login","token_type":"bearer"}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	token, err := registryDeviceLogin(t.Context(), server.Client(), server.URL, "GC CLI login", &stdout)
+	if err != nil {
+		t.Fatalf("registryDeviceLogin: %v", err)
+	}
+	if token != "gcr_device_login" {
+		t.Fatalf("token = %q, want gcr_device_login", token)
+	}
+	mu.Lock()
+	gotCode, gotToken := codeRequests, tokenRequests
+	mu.Unlock()
+	if gotCode != 1 {
+		t.Fatalf("device code requests = %d, want 1", gotCode)
+	}
+	if gotToken < 2 {
+		t.Fatalf("device token polls = %d, want >= 2 (pending then success)", gotToken)
+	}
+	for _, want := range []string{"WXYZ-1234", "https://registry.example/device"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestRegistryBrowserLoginHandlerRejectsInvalidCallbacks(t *testing.T) {
+	const state = "test-state-token"
+	cases := []struct {
+		name       string
+		method     string
+		body       string
+		wantStatus int
+	}{
+		{"non-post method", http.MethodGet, "", http.StatusMethodNotAllowed},
+		{"malformed json", http.MethodPost, "{not json", http.StatusBadRequest},
+		{"state mismatch", http.MethodPost, `{"token":"gcr_tok","state":"wrong-state"}`, http.StatusForbidden},
+		{"missing token", http.MethodPost, `{"token":"   ","state":"test-state-token"}`, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resultCh := make(chan browserLoginResult, 1)
+			server := httptest.NewServer(registryBrowserLoginHandler(state, resultCh))
+			defer server.Close()
+
+			var body io.Reader
+			if tc.body != "" {
+				body = strings.NewReader(tc.body)
+			}
+			req, err := http.NewRequestWithContext(t.Context(), tc.method, server.URL+"/token", body)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			resp, err := server.Client().Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+			select {
+			case got := <-resultCh:
+				t.Fatalf("invalid callback delivered a result: %+v", got)
+			default:
+			}
+		})
+	}
+}
+
+func TestRegistryBrowserLoginHandlerDeliversValidCallback(t *testing.T) {
+	const state = "test-state-token"
+	resultCh := make(chan browserLoginResult, 1)
+	server := httptest.NewServer(registryBrowserLoginHandler(state, resultCh))
+	defer server.Close()
+
+	body := `{"token":"gcr_browser_token","registry":"https://registry.example","state":"test-state-token"}`
+	resp, err := server.Client().Post(server.URL+"/token", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	select {
+	case got := <-resultCh:
+		if got.Token != "gcr_browser_token" || got.Registry != "https://registry.example" {
+			t.Fatalf("delivered result = %+v", got)
+		}
+	default:
+		t.Fatal("valid callback did not deliver a result")
+	}
+}
+
+func TestRegistryBrowserLoginHandlerServesCallbackPage(t *testing.T) {
+	server := httptest.NewServer(registryBrowserLoginHandler("state", make(chan browserLoginResult, 1)))
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/callback")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	page, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !strings.Contains(string(page), "Gas City CLI Login") {
+		t.Fatalf("callback page = %q", string(page))
+	}
+}
+
+func TestResolveRegistryBrowserLoginResult(t *testing.T) {
+	const baseURL = "https://registry.example"
+
+	t.Run("matching registry returns token", func(t *testing.T) {
+		ch := make(chan browserLoginResult, 1)
+		ch <- browserLoginResult{Token: "gcr_tok", Registry: baseURL}
+		token, err := resolveRegistryBrowserLoginResult(t.Context(), baseURL, ch)
+		if err != nil || token != "gcr_tok" {
+			t.Fatalf("token=%q err=%v", token, err)
+		}
+	})
+
+	t.Run("empty registry returns token", func(t *testing.T) {
+		ch := make(chan browserLoginResult, 1)
+		ch <- browserLoginResult{Token: "gcr_tok"}
+		token, err := resolveRegistryBrowserLoginResult(t.Context(), baseURL, ch)
+		if err != nil || token != "gcr_tok" {
+			t.Fatalf("token=%q err=%v", token, err)
+		}
+	})
+
+	t.Run("mismatched registry rejected", func(t *testing.T) {
+		ch := make(chan browserLoginResult, 1)
+		ch <- browserLoginResult{Token: "gcr_tok", Registry: "https://evil.example"}
+		_, err := resolveRegistryBrowserLoginResult(t.Context(), baseURL, ch)
+		if err == nil || !strings.Contains(err.Error(), "registry callback returned") {
+			t.Fatalf("err = %v, want registry mismatch", err)
+		}
+	})
+
+	t.Run("canceled context times out", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := resolveRegistryBrowserLoginResult(ctx, baseURL, make(chan browserLoginResult, 1))
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("err = %v, want timeout", err)
+		}
+	})
+}
+
+func TestRegistryBrowserLoginReturnsTokenEndToEnd(t *testing.T) {
+	const baseURL = "https://registry.example"
+	out := &registrySyncBuffer{}
+	type loginResult struct {
+		token string
+		err   error
+	}
+	done := make(chan loginResult, 1)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	go func() {
+		token, err := registryBrowserLogin(ctx, baseURL, "GC CLI login", out, false)
+		done <- loginResult{token: token, err: err}
+	}()
+
+	tokenURL, state := waitForRegistryCallbackTokenURL(t, out)
+	body := `{"token":"gcr_e2e_token","registry":"` + baseURL + `","state":"` + state + `"}`
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Post(tokenURL, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST token: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("token POST status = %d, want 200", resp.StatusCode)
+	}
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("registryBrowserLogin: %v", got.err)
+		}
+		if got.token != "gcr_e2e_token" {
+			t.Fatalf("token = %q, want gcr_e2e_token", got.token)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("registryBrowserLogin did not return after callback")
+	}
+}
+
+// registrySyncBuffer is an io.Writer safe for concurrent writes from the login
+// goroutine and reads from the test goroutine.
+type registrySyncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *registrySyncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *registrySyncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// waitForRegistryCallbackTokenURL polls the login output until the printed auth
+// URL appears, then returns the local /token endpoint and CSRF state parsed
+// from its redirect_uri and state query parameters.
+func waitForRegistryCallbackTokenURL(t *testing.T, out *registrySyncBuffer) (tokenURL, state string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, line := range strings.Split(out.String(), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.Contains(line, "/cli/auth?") {
+				continue
+			}
+			parsed, err := url.Parse(line)
+			if err != nil {
+				t.Fatalf("parse auth URL %q: %v", line, err)
+			}
+			q := parsed.Query()
+			redirect := q.Get("redirect_uri")
+			stateParam := q.Get("state")
+			if redirect == "" || stateParam == "" {
+				continue
+			}
+			return strings.TrimSuffix(redirect, "/callback") + "/token", stateParam
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("registry auth URL not printed; output:\n%s", out.String())
+	return "", ""
+}
+
+// clearRegistryEnv neutralizes ambient registry credentials so direct
+// do-function calls resolve exactly what each test configures.
+func clearRegistryEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"GC_REGISTRY_URL", "GC_REGISTRY_TOKEN", "GC_REGISTRY_SESSION", "GC_REGISTRY_CSRF_TOKEN"} {
+		t.Setenv(key, "")
+	}
+}
+
+const registryPublishDemoManifest = `[pack]
+name = "demo-pack"
+version = "0.2.0"
+schema = 2
+description = "Demo pack for registry publishing."
+`
+
 func setupRegistryPublishRepo(t *testing.T) (repo string, packDir string) {
+	t.Helper()
+	return setupRegistryPublishRepoManifest(t, registryPublishDemoManifest)
+}
+
+// setupRegistryPublishRepoManifest builds a committed pack repo with the given
+// pack.toml body and a pushed origin/main upstream pointing at a GitHub remote,
+// so buildRegistryPublishRequest resolves a clean, pushed HEAD.
+func setupRegistryPublishRepoManifest(t *testing.T, manifest string) (repo string, packDir string) {
+	t.Helper()
+	repo, packDir = writeRegistryPublishPackRepoManifest(t, manifest)
+	root := filepath.Dir(repo)
+	remote := filepath.Join(root, "remote.git")
+	runRegistryPublishGit(t, root, "init", "--bare", remote)
+	runRegistryPublishGit(t, repo, "remote", "add", "origin", remote)
+	runRegistryPublishGit(t, repo, "push", "-u", "origin", "HEAD:main")
+	runRegistryPublishGit(t, repo, "remote", "set-url", "origin", "git@github.com:gastownhall/demo-packs.git")
+	return repo, packDir
+}
+
+// setupRegistryPublishRepoDetached builds a committed pack repo whose HEAD is
+// detached, so the branch has no `@{u}` upstream. This mirrors an
+// actions/checkout CI checkout, where publish must fall back to GitHub Actions
+// runner metadata instead of an upstream tracking branch.
+func setupRegistryPublishRepoDetached(t *testing.T) (packDir string, headSHA string) {
+	t.Helper()
+	var repo string
+	repo, packDir = writeRegistryPublishPackRepo(t)
+	headSHA = runRegistryPublishGit(t, repo, "rev-parse", "HEAD")
+	runRegistryPublishGit(t, repo, "checkout", "--detach", "HEAD")
+	return packDir, headSHA
+}
+
+// writeRegistryPublishPackRepo initializes a Git repo containing a single demo
+// pack and commits it, returning the repo root and the pack directory. It does
+// not configure a remote or upstream; callers add whatever publish topology
+// they need.
+func writeRegistryPublishPackRepo(t *testing.T) (repo string, packDir string) {
+	t.Helper()
+	return writeRegistryPublishPackRepoManifest(t, registryPublishDemoManifest)
+}
+
+// writeRegistryPublishPackRepoManifest initializes a Git repo containing a
+// single demo pack whose pack.toml holds the given body, commits it, and
+// returns the repo root and the pack directory.
+func writeRegistryPublishPackRepoManifest(t *testing.T, manifest string) (repo string, packDir string) {
 	t.Helper()
 	root := t.TempDir()
 	repo = filepath.Join(root, "repo")
-	remote := filepath.Join(root, "remote.git")
 	if err := os.MkdirAll(filepath.Join(repo, "packs", "demo"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(repo): %v", err)
 	}
@@ -418,20 +1760,11 @@ func setupRegistryPublishRepo(t *testing.T) (repo string, packDir string) {
 	runRegistryPublishGit(t, repo, "config", "user.email", "publisher@example.com")
 	runRegistryPublishGit(t, repo, "config", "user.name", "Pack Publisher")
 	packDir = filepath.Join(repo, "packs", "demo")
-	if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte(`[pack]
-name = "demo-pack"
-version = "0.2.0"
-schema = 2
-description = "Demo pack for registry publishing."
-`), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte(manifest), 0o644); err != nil {
 		t.Fatalf("WriteFile(pack.toml): %v", err)
 	}
 	runRegistryPublishGit(t, repo, "add", ".")
 	runRegistryPublishGit(t, repo, "commit", "-m", "add demo pack")
-	runRegistryPublishGit(t, root, "init", "--bare", remote)
-	runRegistryPublishGit(t, repo, "remote", "add", "origin", remote)
-	runRegistryPublishGit(t, repo, "push", "-u", "origin", "HEAD:main")
-	runRegistryPublishGit(t, repo, "remote", "set-url", "origin", "git@github.com:gastownhall/demo-packs.git")
 	return repo, packDir
 }
 

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildRegistryPublishRequestUsesCleanPushedGitHubHead(t *testing.T) {
+	repo, packDir := setupRegistryPublishRepo(t)
+
+	request, err := buildRegistryPublishRequest(packDir, registryPublishOptions{})
+	if err != nil {
+		t.Fatalf("buildRegistryPublishRequest: %v", err)
+	}
+
+	commit := runRegistryPublishGit(t, repo, "rev-parse", "HEAD")
+	if request.RepoURL != "https://github.com/gastownhall/demo-packs" {
+		t.Fatalf("RepoURL = %q", request.RepoURL)
+	}
+	if request.Commit != commit {
+		t.Fatalf("Commit = %q, want %q", request.Commit, commit)
+	}
+	if request.PackPath != "packs/demo" {
+		t.Fatalf("PackPath = %q", request.PackPath)
+	}
+	if request.RequestedName != "demo-pack" || request.RequestedVersion != "0.2.0" {
+		t.Fatalf("pack identity = %s %s", request.RequestedName, request.RequestedVersion)
+	}
+	if request.RequestedRef != "main" {
+		t.Fatalf("RequestedRef = %q", request.RequestedRef)
+	}
+	if request.RequestedDescription != "Demo pack for registry publishing." {
+		t.Fatalf("RequestedDescription = %q", request.RequestedDescription)
+	}
+}
+
+func TestBuildRegistryPublishRequestRejectsDirtyTree(t *testing.T) {
+	_, packDir := setupRegistryPublishRepo(t)
+	if err := os.WriteFile(filepath.Join(packDir, "README.md"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := buildRegistryPublishRequest(packDir, registryPublishOptions{})
+	if err == nil || !strings.Contains(err.Error(), "working tree") {
+		t.Fatalf("err = %v, want dirty working tree error", err)
+	}
+}
+
+func TestSubmitRegistryPublishRequestSendsAuthenticatedPayload(t *testing.T) {
+	var got registryPublishRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/api/publish-requests" || r.URL.Query().Get("validate") != "1" {
+			t.Fatalf("url = %s", r.URL.String())
+		}
+		if r.Header.Get("X-CSRF-Token") != "csrf-test" {
+			t.Fatalf("csrf = %q", r.Header.Get("X-CSRF-Token"))
+		}
+		cookie, err := r.Cookie("registry_session")
+		if err != nil || cookie.Value != "session-test" {
+			t.Fatalf("cookie = %v %v", cookie, err)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("Decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"publishRequest": {
+				"id": "prq_test",
+				"status": "pending_review",
+				"requestedName": "demo-pack",
+				"requestedVersion": "0.2.0",
+				"repository": {"fullName": "gastownhall/demo-packs"},
+				"registryEntry": {"release": {"hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	submitted, err := submitRegistryPublishRequest(
+		t.Context(),
+		server.Client(),
+		server.URL,
+		registryPublishRequest{
+			RepoURL:          "https://github.com/gastownhall/demo-packs",
+			Commit:           strings.Repeat("1", 40),
+			PackPath:         "packs/demo",
+			RequestedName:    "demo-pack",
+			RequestedVersion: "0.2.0",
+			RequestedRef:     "main",
+		},
+		registryPublishAuth{SessionCookie: "session-test", CSRFToken: "csrf-test"},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("submitRegistryPublishRequest: %v", err)
+	}
+	if got.RequestedName != "demo-pack" || got.RequestedVersion != "0.2.0" {
+		t.Fatalf("submitted body = %+v", got)
+	}
+	if submitted.ID != "prq_test" || submitted.Status != "pending_review" {
+		t.Fatalf("submitted = %+v", submitted)
+	}
+	if submitted.Hash == "" {
+		t.Fatalf("submitted hash missing: %+v", submitted)
+	}
+}
+
+func TestRegistryPublishDevAuthFetchesLocalSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/dev/sign-in":
+			if r.URL.Query().Get("handle") != "cli-test" {
+				t.Fatalf("handle = %q", r.URL.Query().Get("handle"))
+			}
+			http.SetCookie(w, &http.Cookie{Name: "registry_session", Value: "session-dev", Path: "/"})
+			w.Header().Set("Location", "/api/me")
+			w.WriteHeader(http.StatusFound)
+		case "/api/me":
+			cookie, err := r.Cookie("registry_session")
+			if err != nil || cookie.Value != "session-dev" {
+				t.Fatalf("cookie = %v %v", cookie, err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"csrfToken":"csrf-dev"}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	auth, err := registryPublishDevAuth(t.Context(), server.Client(), server.URL, "cli-test")
+	if err != nil {
+		t.Fatalf("registryPublishDevAuth: %v", err)
+	}
+	if auth.SessionCookie != "session-dev" || auth.CSRFToken != "csrf-dev" {
+		t.Fatalf("auth = %+v", auth)
+	}
+}
+
+func TestDoRegistryPublishDryRunPrintsRequest(t *testing.T) {
+	_, packDir := setupRegistryPublishRepo(t)
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(packDir, registryPublishOptions{
+		RegistryURL: "http://127.0.0.1:8080",
+		DryRun:      true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryPublish = %d, stderr=%q", code, stderr.String())
+	}
+	for _, want := range []string{
+		"Registry: http://127.0.0.1:8080",
+		"Repository: https://github.com/gastownhall/demo-packs",
+		"Pack path: packs/demo",
+		"Pack: demo-pack 0.2.0",
+		"Dry run: publish request was not submitted.",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func setupRegistryPublishRepo(t *testing.T) (repo string, packDir string) {
+	t.Helper()
+	root := t.TempDir()
+	repo = filepath.Join(root, "repo")
+	remote := filepath.Join(root, "remote.git")
+	if err := os.MkdirAll(filepath.Join(repo, "packs", "demo"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(repo): %v", err)
+	}
+	runRegistryPublishGit(t, repo, "init", "-b", "main")
+	runRegistryPublishGit(t, repo, "config", "user.email", "publisher@example.com")
+	runRegistryPublishGit(t, repo, "config", "user.name", "Pack Publisher")
+	packDir = filepath.Join(repo, "packs", "demo")
+	if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte(`[pack]
+name = "demo-pack"
+version = "0.2.0"
+schema = 2
+description = "Demo pack for registry publishing."
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	runRegistryPublishGit(t, repo, "add", ".")
+	runRegistryPublishGit(t, repo, "commit", "-m", "add demo pack")
+	runRegistryPublishGit(t, root, "init", "--bare", remote)
+	runRegistryPublishGit(t, repo, "remote", "add", "origin", remote)
+	runRegistryPublishGit(t, repo, "push", "-u", "origin", "HEAD:main")
+	runRegistryPublishGit(t, repo, "remote", "set-url", "origin", "git@github.com:gastownhall/demo-packs.git")
+	return repo, packDir
+}
+
+func runRegistryPublishGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, string(out))
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -42,6 +42,33 @@ func TestBuildRegistryPublishRequestUsesCleanPushedGitHubHead(t *testing.T) {
 	}
 }
 
+func TestBuildRegistryPublishRequestAcceptsWebFormFieldOverrides(t *testing.T) {
+	_, packDir := setupRegistryPublishRepo(t)
+
+	request, err := buildRegistryPublishRequest(packDir, registryPublishOptions{
+		Name:        "renamed-demo-pack",
+		Version:     "1.2.3",
+		Ref:         "release/v1.2.3",
+		Description: "Operator supplied release note.",
+	})
+	if err != nil {
+		t.Fatalf("buildRegistryPublishRequest: %v", err)
+	}
+
+	if request.RequestedName != "renamed-demo-pack" {
+		t.Fatalf("RequestedName = %q", request.RequestedName)
+	}
+	if request.RequestedVersion != "1.2.3" {
+		t.Fatalf("RequestedVersion = %q", request.RequestedVersion)
+	}
+	if request.RequestedRef != "release/v1.2.3" {
+		t.Fatalf("RequestedRef = %q", request.RequestedRef)
+	}
+	if request.RequestedDescription != "Operator supplied release note." {
+		t.Fatalf("RequestedDescription = %q", request.RequestedDescription)
+	}
+}
+
 func TestBuildRegistryPublishRequestRejectsDirtyTree(t *testing.T) {
 	_, packDir := setupRegistryPublishRepo(t)
 	if err := os.WriteFile(filepath.Join(packDir, "README.md"), []byte("dirty\n"), 0o644); err != nil {

--- a/cmd/gc/jsonl_archive_doctor_check.go
+++ b/cmd/gc/jsonl_archive_doctor_check.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/git"
 )
 
 // jsonlArchiveState mirrors the keys the jsonl-export.sh script persists in
@@ -51,6 +52,11 @@ func (c *jsonlArchiveDoctorCheck) git(dir string, args ...string) ([]byte, error
 		return c.runGit(dir, args...)
 	}
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	// Strip leaked GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE (and related) variables
+	// so the archive remote query resolves from the archive repo passed via -C,
+	// not a parent repository inherited from a pre-commit hook or nested worktree
+	// (which would report push-mode health for the wrong repository).
+	cmd.Env = git.SanitizedEnv()
 	return cmd.Output()
 }
 

--- a/cmd/gc/jsonl_archive_doctor_check_test.go
+++ b/cmd/gc/jsonl_archive_doctor_check_test.go
@@ -108,6 +108,38 @@ func TestJsonlArchiveDoctorCheck_LocalOnlyWarning(t *testing.T) {
 	}
 }
 
+// TestJsonlArchiveDoctorCheck_ArchiveHasOriginIgnoresPoisonedGitEnv proves the
+// archive remote query resolves from the archive repo passed via -C even when
+// git-locating environment variables point at an unrelated repository. Running
+// gc doctor inside a pre-commit hook or nested worktree exports
+// GIT_DIR/GIT_WORK_TREE for the parent repo; without git.SanitizedEnv() the
+// leaked GIT_DIR redirects `git -C <archive> remote -v` to the poisoned repo, so
+// the check would report push-mode health for the wrong repository.
+func TestJsonlArchiveDoctorCheck_ArchiveHasOriginIgnoresPoisonedGitEnv(t *testing.T) {
+	cityDir := t.TempDir()
+	archiveDir := filepath.Join(cityDir, "archive")
+	// Archive repo has an origin remote → push mode.
+	initBareArchiveRepo(t, archiveDir, true)
+
+	// Unrelated repo with no origin whose git-locating env vars would make
+	// archiveHasOrigin read its (empty) remote list if inherited.
+	poison := t.TempDir()
+	initBareArchiveRepo(t, poison, false)
+	t.Setenv("GIT_DIR", filepath.Join(poison, ".git"))
+	t.Setenv("GIT_WORK_TREE", poison)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(poison, ".git", "index"))
+
+	// Real git path (no runGit stub) exercises cmd.Env = git.SanitizedEnv().
+	check := newJsonlArchiveDoctorCheck(cityDir)
+	hasOrigin, err := check.archiveHasOrigin(archiveDir)
+	if err != nil {
+		t.Fatalf("archiveHasOrigin with poisoned git env: %v", err)
+	}
+	if !hasOrigin {
+		t.Fatalf("archiveHasOrigin = false, want true (must query archive repo via -C, not poisoned GIT_DIR)")
+	}
+}
+
 func TestJsonlArchiveDoctorCheck_PushModeHealthyWithTimestamp(t *testing.T) {
 	cityDir := t.TempDir()
 	stateDir := t.TempDir()

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -261,6 +261,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		newImportCmd(stdout, stderr),
 		newConfigCmd(stdout, stderr),
 		newPackCmd(stdout, stderr),
+		newRegistryCmd(stdout, stderr),
 		newLintCmd(stdout, stderr),
 		newDoctorCmd(stdout, stderr),
 		newHookCmd(stdout, stderr),

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,6 +57,7 @@ gc [flags]
 | [gc prime](#gc-prime) | Output the behavioral prompt for an agent |
 | [gc prompt](#gc-prompt) | Author and inspect agent prompt templates |
 | [gc register](#gc-register) | Register a city with the machine-wide supervisor |
+| [gc registry](#gc-registry) | Publish packs to Gas City Registry |
 | [gc reload](#gc-reload) | Reload the current city's config without restarting the city/controller |
 | [gc restart](#gc-restart) | Restart all agent sessions in the city |
 | [gc resume](#gc-resume) | Resume a suspended city |
@@ -2698,6 +2699,43 @@ gc register [path] [flags]
 | `--json` | bool |  | emit JSONL summary |
 | `--name` | string |  | machine-local alias for this city registration |
 | `--yes` | bool |  | bypass the cross-city supervisor cycle confirmation prompt (warning is still printed for the audit trail) |
+
+## gc registry
+
+Publish packs to the hosted Gas City Registry.
+
+```
+gc registry
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc registry publish](#gc-registry-publish) | Submit a pack publish request |
+
+## gc registry publish
+
+Submit a pack publish request to Gas City Registry.
+
+The command requires a clean Git checkout whose current HEAD matches its
+configured upstream branch, then submits the GitHub repository, commit, pack
+path, pack name, and version to the registry API.
+
+```
+gc registry publish <path-to-pack-root> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--csrf-token` | string |  | registry CSRF token |
+| `--description` | string |  | release description; defaults to [pack].description |
+| `--dev-auth` | bool |  | create a local dev-auth session before submitting; localhost only |
+| `--dev-auth-handle` | string | `local-cli` | dev-auth handle when --dev-auth is used |
+| `--dry-run` | bool |  | print the publish request without submitting |
+| `--ref` | string |  | release ref label; defaults to the upstream branch name |
+| `--registry-url` | string | `https://registry.gascity.com` | registry app base URL |
+| `--session-cookie` | string |  | registry_session cookie value or Cookie header |
+| `--validate` | bool | `true` | ask the registry to validate the request immediately |
+| `--version` | string |  | release version; defaults to [pack].version |
 
 ## gc reload
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2710,7 +2710,29 @@ gc registry
 
 | Subcommand | Description |
 |------------|-------------|
+| [gc registry login](#gc-registry-login) | Log in to Gas City Registry |
 | [gc registry publish](#gc-registry-publish) | Submit a pack publish request |
+| [gc registry whoami](#gc-registry-whoami) | Show the authenticated registry account |
+
+## gc registry login
+
+Log in to Gas City Registry and store a local API token.
+
+By default this opens a browser for GitHub or Google Workspace sign-in. Use
+--device for headless shells, or --token to store an existing registry token.
+
+```
+gc registry login [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--device` | bool |  | use device-code login instead of browser callback login |
+| `--label` | string | `GC CLI login` | label for the registry API token |
+| `--no-browser` | bool |  | print the browser login URL instead of opening it |
+| `--registry-url` | string | `https://registry.gascity.com` | registry app base URL |
+| `--timeout` | duration | `15m0s` | maximum time to wait for interactive login |
+| `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN |
 
 ## gc registry publish
 
@@ -2737,6 +2759,19 @@ gc registry publish <path-to-pack-root> [flags]
 | `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN |
 | `--validate` | bool | `true` | ask the registry to validate the request immediately |
 | `--version` | string |  | release version; defaults to [pack].version |
+
+## gc registry whoami
+
+Show the authenticated registry account
+
+```
+gc registry whoami [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--registry-url` | string | `https://registry.gascity.com` | registry app base URL |
+| `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN or stored login |
 
 ## gc reload
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2730,7 +2730,7 @@ gc registry login [flags]
 | `--device` | bool |  | use device-code login instead of browser callback login |
 | `--label` | string | `GC CLI login` | label for the registry API token |
 | `--no-browser` | bool |  | print the browser login URL instead of opening it |
-| `--registry-url` | string | `https://registry.gascity.com` | registry app base URL |
+| `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
 | `--timeout` | duration | `15m0s` | maximum time to wait for interactive login |
 | `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN |
 
@@ -2748,17 +2748,17 @@ gc registry publish <path-to-pack-root> [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--csrf-token` | string |  | registry CSRF token |
+| `--csrf-token` | string |  | registry CSRF token; defaults to GC_REGISTRY_CSRF_TOKEN |
 | `--description` | string |  | release description; defaults to [pack].description |
 | `--dev-auth` | bool |  | create a local dev-auth session before submitting; localhost only |
 | `--dev-auth-handle` | string | `local-cli` | dev-auth handle when --dev-auth is used |
 | `--dry-run` | bool |  | print the publish request without submitting |
 | `--name` | string |  | registry pack name; defaults to [pack].name |
 | `--ref` | string |  | release ref label; defaults to the upstream branch name |
-| `--registry-url` | string | `https://registry.gascity.com` | registry app base URL |
-| `--session-cookie` | string |  | registry_session cookie value or Cookie header |
+| `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
+| `--session-cookie` | string |  | registry_session cookie value or Cookie header; defaults to GC_REGISTRY_SESSION |
 | `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN |
-| `--validate` | bool | `true` | ask the registry to validate the request immediately |
+| `--validate` | bool | `true` | ask the registry to validate the request immediately; a rejected validation exits non-zero |
 | `--version` | string |  | release version; defaults to [pack].version |
 
 ## gc registry whoami
@@ -2771,7 +2771,7 @@ gc registry whoami [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--registry-url` | string | `https://registry.gascity.com` | registry app base URL |
+| `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
 | `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN or stored login |
 
 ## gc reload

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2734,6 +2734,7 @@ gc registry publish <path-to-pack-root> [flags]
 | `--ref` | string |  | release ref label; defaults to the upstream branch name |
 | `--registry-url` | string | `https://registry.gascity.com` | registry app base URL |
 | `--session-cookie` | string |  | registry_session cookie value or Cookie header |
+| `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN |
 | `--validate` | bool | `true` | ask the registry to validate the request immediately |
 | `--version` | string |  | release version; defaults to [pack].version |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2753,6 +2753,7 @@ gc registry publish <path-to-pack-root> [flags]
 | `--dev-auth` | bool |  | create a local dev-auth session before submitting; localhost only |
 | `--dev-auth-handle` | string | `local-cli` | dev-auth handle when --dev-auth is used |
 | `--dry-run` | bool |  | print the publish request without submitting |
+| `--name` | string |  | registry pack name; defaults to [pack].name |
 | `--ref` | string |  | release ref label; defaults to the upstream branch name |
 | `--registry-url` | string | `https://registry.gascity.com` | registry app base URL |
 | `--session-cookie` | string |  | registry_session cookie value or Cookie header |

--- a/internal/api/branch_resolver_test.go
+++ b/internal/api/branch_resolver_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestApiBranchResolverIgnoresPoisonedGitEnv proves DefaultBranch resolves the
+// origin/HEAD of the targeted directory's repository even when the process
+// environment leaks GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE from a parent repo or
+// a pre-commit hook. Without gitpkg.SanitizedEnv() on the symbolic-ref
+// subprocess, the leaked GIT_DIR redirects git away from dir and DefaultBranch
+// returns "". Regression guard for gastownhall/gascity#3343 (review attempt-8
+// blocker on the unsanitized API branch resolver).
+func TestApiBranchResolverIgnoresPoisonedGitEnv(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available in PATH")
+	}
+	repo := t.TempDir()
+	runResolverGit(t, repo, "init", "-b", "main")
+	// Point origin/HEAD at origin/main without needing a real remote; the
+	// symbolic ref's target need not exist for symbolic-ref --short to read it.
+	runResolverGit(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+	// Poison the environment after setup so the setup commands stay clean.
+	t.Setenv("GIT_DIR", filepath.Join(t.TempDir(), "poison.git"))
+	t.Setenv("GIT_WORK_TREE", t.TempDir())
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(t.TempDir(), "poison.index"))
+
+	r := apiBranchResolver{}
+	if got := r.DefaultBranch(repo); got != "main" {
+		t.Fatalf("DefaultBranch under poisoned GIT_* env = %q, want %q", got, "main")
+	}
+}
+
+func runResolverGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/execenv"
+	gitpkg "github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/sling"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
@@ -390,8 +391,12 @@ func (r apiBranchResolver) DefaultBranch(dir string) string {
 	}
 	// Best-effort: read git's origin/HEAD ref for the default branch.
 	// Falls back to empty string if git is unavailable.
-	out, err := exec.CommandContext(context.Background(), "git", "-C", dir,
-		"symbolic-ref", "--short", "refs/remotes/origin/HEAD").Output()
+	cmd := exec.CommandContext(context.Background(), "git", "-C", dir,
+		"symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	// Sanitize the environment so a leaked GIT_DIR from a parent repo or hook
+	// cannot redirect resolution to the wrong repository's default branch.
+	cmd.Env = gitpkg.SanitizedEnv()
+	out, err := cmd.Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/config/pack_fetch.go
+++ b/internal/config/pack_fetch.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/git"
 )
 
 // packCacheDir is the subdirectory under .gc/cache/ where remote packs are cached.
@@ -220,30 +221,15 @@ func packDirHash(dir string) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-// gitEnvBlacklist lists git environment variables that must be stripped
-// so subprocess git commands use the intended workDir, not a parent repo.
-var fetchGitEnvBlacklist = map[string]bool{
-	"GIT_DIR":                          true,
-	"GIT_WORK_TREE":                    true,
-	"GIT_INDEX_FILE":                   true,
-	"GIT_OBJECT_DIRECTORY":             true,
-	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
-}
-
-// runGit executes a git command with a clean environment.
-// If dir is non-empty, the command runs in that directory.
+// runGit executes a git command with a sanitized environment, so leaked GIT_*
+// variables from a parent repository or a pre-commit hook cannot redirect it
+// away from dir. If dir is non-empty, the command runs in that directory.
 func runGit(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
-	// Build clean env: inherit everything except git-specific vars.
-	for _, e := range os.Environ() {
-		if k, _, ok := strings.Cut(e, "="); ok && fetchGitEnvBlacklist[k] {
-			continue
-		}
-		cmd.Env = append(cmd.Env, e)
-	}
+	cmd.Env = git.SanitizedEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)

--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -333,37 +333,12 @@ func defaultRunRepoCacheGit(dir string, args ...string) (string, error) {
 	}, args...)
 	cmd := exec.Command("git", cmdArgs...)
 	cmd.Dir = dir
-	for _, e := range os.Environ() {
-		if k, _, ok := strings.Cut(e, "="); ok && repoCacheGitEnvBlacklist[k] {
-			continue
-		}
-		cmd.Env = append(cmd.Env, e)
-	}
-	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	cmd.Env = gitutil.HermeticEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
 	}
 	return strings.TrimSpace(string(out)), nil
-}
-
-var repoCacheGitEnvBlacklist = map[string]bool{
-	"GIT_DIR":                          true,
-	"GIT_WORK_TREE":                    true,
-	"GIT_INDEX_FILE":                   true,
-	"GIT_OBJECT_DIRECTORY":             true,
-	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
-	"GIT_COMMON_DIR":                   true,
-	"GIT_CEILING_DIRECTORIES":          true,
-	"GIT_DISCOVERY_ACROSS_FILESYSTEM":  true,
-	"GIT_NAMESPACE":                    true,
-	"GIT_CONFIG":                       true,
-	"GIT_CONFIG_GLOBAL":                true,
-	"GIT_CONFIG_SYSTEM":                true,
-	"GIT_CONFIG_NOSYSTEM":              true,
-	"GIT_CONFIG_COUNT":                 true,
-	"GIT_EXEC_PATH":                    true,
-	"GIT_PAGER":                        true,
 }
 
 // RepoCacheKey computes the sha256 cache key for a remote source+commit pair.

--- a/internal/doctor/checks_rig_root_branch.go
+++ b/internal/doctor/checks_rig_root_branch.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/git"
 )
 
 const defaultBranchFallback = "main"
@@ -78,6 +79,10 @@ func (c *RigRootBranchCheck) Run(_ *CheckContext) *CheckResult {
 func runGitCommand(gitBin, dir string, args ...string) (string, error) {
 	cmd := exec.Command(gitBin, args...)
 	cmd.Dir = dir
+	// Strip leaked GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE (and related) variables
+	// so the branch resolves from dir, not a parent repository inherited from a
+	// pre-commit hook or nested worktree (which would warn on the wrong repo).
+	cmd.Env = git.SanitizedEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -89,6 +94,9 @@ func runGitCommand(gitBin, dir string, args ...string) (string, error) {
 func isGitDirty(gitBin, dir string) (bool, error) {
 	cmd := exec.Command(gitBin, "status", "--porcelain")
 	cmd.Dir = dir
+	// Strip leaked git-locating variables so dirty-state resolves from dir, not a
+	// parent repository inherited from a pre-commit hook or nested worktree.
+	cmd.Env = git.SanitizedEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return false, err

--- a/internal/doctor/checks_rig_root_branch_test.go
+++ b/internal/doctor/checks_rig_root_branch_test.go
@@ -170,6 +170,54 @@ func TestRigRootBranchCheck_NonMainDefaultBranchMatches_OK(t *testing.T) {
 	}
 }
 
+// TestRigRootBranchCheck_IgnoresPoisonedGitEnv proves the rig root-branch check
+// resolves the rig's own branch and dirty state even when git-locating
+// environment variables point at an unrelated repository. Running gc doctor (or
+// gc start warm-up) inside a pre-commit hook or nested worktree exports
+// GIT_DIR/GIT_WORK_TREE for the parent repo; without git.SanitizedEnv() the
+// leaked vars make rev-parse and status report the poisoned repo, so the check
+// would clear (or warn on) the wrong repository.
+func TestRigRootBranchCheck_IgnoresPoisonedGitEnv(t *testing.T) {
+	// Rig is on a non-default branch with a dirty working tree.
+	rigPath := initGitRepoOnBranch(t, "feature")
+	if err := os.WriteFile(filepath.Join(rigPath, "dirty.txt"), []byte("dirty\n"), 0o600); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	// Unrelated repo on the default branch with a clean tree. Both repos must be
+	// created before poisoning so their own git commands are not redirected. If
+	// the poison vars leak, runGitCommand reads "main" (== default) and isGitDirty
+	// reads a clean tree, wrongly yielding StatusOK with no dirty detail.
+	poison := initGitRepoOnBranch(t, "main")
+	t.Setenv("GIT_DIR", filepath.Join(poison, ".git"))
+	t.Setenv("GIT_WORK_TREE", poison)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(poison, ".git", "index"))
+
+	c := NewRigRootBranchCheck(config.Rig{
+		Name:          "testrig",
+		Path:          rigPath,
+		DefaultBranch: "main",
+	})
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d (%s), want StatusWarning (runGitCommand must read rig branch via cmd.Dir, not poisoned GIT_DIR)", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "feature") {
+		t.Errorf("message = %q, want rig branch 'feature'", r.Message)
+	}
+	foundDirty := false
+	for _, detail := range r.Details {
+		if strings.Contains(detail, "dirty") {
+			foundDirty = true
+		}
+	}
+	if !foundDirty {
+		t.Errorf("Details = %v, want dirty detail (isGitDirty must read rig tree, not poisoned GIT_WORK_TREE)", r.Details)
+	}
+}
+
 func initGitRepoOnBranch(t *testing.T, branch string) string {
 	t.Helper()
 	if _, err := exec.LookPath("git"); err != nil {

--- a/internal/formula/source.go
+++ b/internal/formula/source.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/gastownhall/gascity/internal/git"
 )
 
 // Source abstracts how formula files are located and read. The default
@@ -125,6 +127,10 @@ func (g *GitRefSource) repoTopAndRelPath(path string) (string, string, bool) {
 	if !cached {
 		cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 		cmd.Dir = queryDir
+		// Sanitize the environment so a leaked GIT_DIR/GIT_WORK_TREE from a
+		// parent repo or pre-commit hook cannot redirect resolution away from
+		// queryDir's own repository.
+		cmd.Env = git.SanitizedEnv()
 		out, runErr := cmd.Output()
 		if runErr != nil {
 			g.toplevelCache[cacheKey] = ""
@@ -171,6 +177,7 @@ func (g *GitRefSource) Stat(path string) bool {
 	// '-' being parsed as an option.
 	cmd := exec.Command("git", "cat-file", "-t", "--end-of-options", g.ref+":"+rel)
 	cmd.Dir = top
+	cmd.Env = git.SanitizedEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return false
@@ -188,6 +195,7 @@ func (g *GitRefSource) ReadFile(path string) ([]byte, error) {
 	// '-' being parsed as an option.
 	cmd := exec.Command("git", "cat-file", "blob", "--end-of-options", g.ref+":"+rel)
 	cmd.Dir = top
+	cmd.Env = git.SanitizedEnv()
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -219,6 +227,7 @@ func (g *GitRefSource) ListDir(dir string) ([]string, error) {
 	// GC_FORMULA_REF that begins with '-'.
 	cmd := exec.Command("git", "ls-tree", "-z", "--end-of-options", tree)
 	cmd.Dir = top
+	cmd.Env = git.SanitizedEnv()
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {

--- a/internal/formula/source_test.go
+++ b/internal/formula/source_test.go
@@ -451,6 +451,55 @@ func TestResolveWithSourcePrecedence(t *testing.T) {
 	}
 }
 
+// TestGitRefSourceIgnoresPoisonedGitEnv proves the GitRefSource subprocesses
+// resolve against the repository that contains the queried path even when the
+// process environment leaks GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE from a parent
+// repo or a pre-commit hook. Without git.SanitizedEnv() assigned to each
+// subprocess, the leaked GIT_DIR redirects git away from the intended repo and
+// every lookup misses. Regression guard for gastownhall/gascity#3343 (review
+// attempt-8 blocker on unsanitized formula git subprocesses).
+func TestGitRefSourceIgnoresPoisonedGitEnv(t *testing.T) {
+	gitOK(t)
+	root := initRepo(t)
+	commitFile(t, root, "formulas/demo.toml", "formula = \"demo\"\n")
+	commitOnBranch(t, root, "main", "add demo formula")
+
+	// Poison the environment the way a pre-commit hook or nested worktree
+	// would. These all point away from the repo that holds the formula, so an
+	// unsanitized subprocess would resolve the wrong (or no) repository. Set
+	// them only after repo setup so the setup commands stay clean.
+	t.Setenv("GIT_DIR", filepath.Join(t.TempDir(), "poison.git"))
+	t.Setenv("GIT_WORK_TREE", t.TempDir())
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(t.TempDir(), "poison.index"))
+
+	src := NewGitRefSource("HEAD")
+	target := filepath.Join(root, "formulas", "demo.toml")
+
+	if !src.Stat(target) {
+		t.Fatal("Stat reported the committed formula as absent under poisoned GIT_* env")
+	}
+	data, err := src.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile under poisoned GIT_* env: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != `formula = "demo"` {
+		t.Fatalf("ReadFile = %q, want %q", got, `formula = "demo"`)
+	}
+	names, err := src.ListDir(filepath.Join(root, "formulas"))
+	if err != nil {
+		t.Fatalf("ListDir under poisoned GIT_* env: %v", err)
+	}
+	found := false
+	for _, n := range names {
+		if n == "demo.toml" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ListDir = %v, want it to contain demo.toml", names)
+	}
+}
+
 // --- helpers ---
 
 func gitOK(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -300,6 +300,71 @@ var gitEnvBlacklist = map[string]bool{
 	"GIT_SHALLOW_FILE":                 true,
 }
 
+// hermeticGitEnvExtra lists git environment variables stripped by HermeticEnv
+// in addition to gitEnvBlacklist. These are repository-discovery,
+// config-location, and pager/exec-path variables that a hermetic cache clone
+// must not inherit from the parent process. They are kept separate from
+// gitEnvBlacklist because SanitizedEnv deliberately preserves some of them: for
+// example GIT_CEILING_DIRECTORIES is required by ordinary repo-discovery checks
+// such as IsRepo, which would climb out of a non-repo directory if it were
+// stripped. Cache clones, by contrast, want maximum isolation.
+var hermeticGitEnvExtra = map[string]bool{
+	"GIT_CEILING_DIRECTORIES":         true,
+	"GIT_DISCOVERY_ACROSS_FILESYSTEM": true,
+	"GIT_NAMESPACE":                   true,
+	"GIT_CONFIG_SYSTEM":               true,
+	"GIT_CONFIG_GLOBAL":               true,
+	"GIT_CONFIG_NOSYSTEM":             true,
+	"GIT_EXEC_PATH":                   true,
+	"GIT_PAGER":                       true,
+}
+
+// SanitizedEnv returns a copy of the current process environment with
+// git-specific variables removed. Subprocess git invocations should run with
+// this environment so they operate on their own working directory instead of a
+// parent repository leaked through GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, and
+// related variables (for example when gc runs inside a pre-commit hook or
+// nested worktree tooling). Callers outside this package that shell out to git
+// directly should assign this to cmd.Env.
+func SanitizedEnv() []string {
+	return sanitizeGitEnv(os.Environ())
+}
+
+// HermeticEnv returns a process environment for git subprocesses that must run
+// hermetically against a cached clone, isolated from ambient system, global,
+// and parent-repository git state. It strips everything SanitizedEnv removes
+// plus the repository-discovery, config-location, and pager/exec-path variables
+// in hermeticGitEnvExtra, then pins GIT_CONFIG_NOSYSTEM=1 and
+// GIT_CONFIG_GLOBAL=/dev/null so the clone reads no system or user git config.
+// Cache and fetch runners that previously maintained their own duplicate
+// blacklists should assign this to cmd.Env instead.
+func HermeticEnv() []string {
+	environ := os.Environ()
+	cleaned := make([]string, 0, len(environ)+2)
+	for _, e := range environ {
+		if k, _, ok := strings.Cut(e, "="); ok && (gitEnvBlacklist[k] || hermeticGitEnvExtra[k]) {
+			continue
+		}
+		cleaned = append(cleaned, e)
+	}
+	cleaned = append(cleaned, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	return cleaned
+}
+
+// sanitizeGitEnv returns environ with git-specific variables removed. It is the
+// single filtering implementation shared by SanitizedEnv and runCtx so the
+// blacklist has exactly one enforcement path.
+func sanitizeGitEnv(environ []string) []string {
+	cleaned := make([]string, 0, len(environ))
+	for _, e := range environ {
+		if k, _, ok := strings.Cut(e, "="); ok && gitEnvBlacklist[k] {
+			continue
+		}
+		cleaned = append(cleaned, e)
+	}
+	return cleaned
+}
+
 // run executes a git command in the working directory. Git environment
 // variables from the parent process are stripped to prevent interference
 // (e.g., when called from a pre-commit hook context).
@@ -312,12 +377,7 @@ func (g *Git) runCtx(ctx context.Context, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = g.workDir
 	// Build clean env: inherit everything except git-specific vars.
-	for _, e := range os.Environ() {
-		if k, _, ok := strings.Cut(e, "="); ok && gitEnvBlacklist[k] {
-			continue
-		}
-		cmd.Env = append(cmd.Env, e)
-	}
+	cmd.Env = sanitizeGitEnv(os.Environ())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -40,6 +40,84 @@ func runGit(t *testing.T, dir string, args ...string) {
 	}
 }
 
+func TestSanitizeGitEnvStripsGitLocatingVariables(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"GIT_DIR=/poison/.git",
+		"GIT_WORK_TREE=/poison",
+		"GIT_INDEX_FILE=/poison/.git/index",
+		"GIT_OBJECT_DIRECTORY=/poison/.git/objects",
+		"HOME=/home/user",
+		"GIT_AUTHOR_NAME=keep-me",
+	}
+	got := sanitizeGitEnv(in)
+	for _, e := range got {
+		if k, _, _ := strings.Cut(e, "="); gitEnvBlacklist[k] {
+			t.Errorf("sanitizeGitEnv kept blacklisted var %q", k)
+		}
+	}
+	want := map[string]bool{"PATH": true, "HOME": true, "GIT_AUTHOR_NAME": true}
+	if len(got) != len(want) {
+		t.Fatalf("sanitizeGitEnv returned %d vars %v, want %d", len(got), got, len(want))
+	}
+	for _, e := range got {
+		k, _, _ := strings.Cut(e, "=")
+		if !want[k] {
+			t.Errorf("sanitizeGitEnv dropped expected var %q", k)
+		}
+	}
+}
+
+func TestSanitizedEnvStripsPoisonedProcessEnv(t *testing.T) {
+	t.Setenv("GIT_DIR", "/poison/.git")
+	t.Setenv("GIT_WORK_TREE", "/poison")
+	t.Setenv("GIT_INDEX_FILE", "/poison/.git/index")
+	for _, e := range SanitizedEnv() {
+		switch k, _, _ := strings.Cut(e, "="); k {
+		case "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE":
+			t.Errorf("SanitizedEnv leaked git-locating var %q", k)
+		}
+	}
+}
+
+func TestHermeticEnvStripsDiscoveryAndConfigVarsAndPinsHermeticConfig(t *testing.T) {
+	// SanitizedEnv-covered locating vars plus HermeticEnv-only discovery and
+	// config-location vars must all be removed; the hermetic config pins must be
+	// appended.
+	t.Setenv("GIT_DIR", "/poison/.git")
+	t.Setenv("GIT_CEILING_DIRECTORIES", "/poison")
+	t.Setenv("GIT_DISCOVERY_ACROSS_FILESYSTEM", "1")
+	t.Setenv("GIT_NAMESPACE", "poison")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/poison/system")
+	t.Setenv("GIT_EXEC_PATH", "/poison/exec")
+	t.Setenv("GIT_PAGER", "poison-pager")
+	t.Setenv("PATH", "/usr/bin")
+
+	got := HermeticEnv()
+	stripped := map[string]bool{
+		"GIT_DIR": true, "GIT_CEILING_DIRECTORIES": true,
+		"GIT_DISCOVERY_ACROSS_FILESYSTEM": true, "GIT_NAMESPACE": true,
+		"GIT_CONFIG_SYSTEM": true, "GIT_EXEC_PATH": true, "GIT_PAGER": true,
+	}
+	seen := map[string]string{}
+	for _, e := range got {
+		k, v, _ := strings.Cut(e, "=")
+		if stripped[k] {
+			t.Errorf("HermeticEnv leaked %q", k)
+		}
+		seen[k] = v
+	}
+	if seen["GIT_CONFIG_NOSYSTEM"] != "1" {
+		t.Errorf("HermeticEnv GIT_CONFIG_NOSYSTEM = %q, want 1", seen["GIT_CONFIG_NOSYSTEM"])
+	}
+	if seen["GIT_CONFIG_GLOBAL"] != "/dev/null" {
+		t.Errorf("HermeticEnv GIT_CONFIG_GLOBAL = %q, want /dev/null", seen["GIT_CONFIG_GLOBAL"])
+	}
+	if _, ok := seen["PATH"]; !ok {
+		t.Error("HermeticEnv dropped non-git var PATH")
+	}
+}
+
 func TestIsRepo(t *testing.T) {
 	repo := initTestRepo(t)
 	g := New(repo)

--- a/internal/packman/cache.go
+++ b/internal/packman/cache.go
@@ -263,35 +263,10 @@ func defaultRunGit(dir string, args ...string) (string, error) {
 	if dir != "" {
 		cmd.Dir = dir
 	}
-	for _, e := range os.Environ() {
-		if k, _, ok := strings.Cut(e, "="); ok && fetchGitEnvBlacklist[k] {
-			continue
-		}
-		cmd.Env = append(cmd.Env, e)
-	}
-	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	cmd.Env = gitutil.HermeticEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
 	}
 	return strings.TrimSpace(string(out)), nil
-}
-
-var fetchGitEnvBlacklist = map[string]bool{
-	"GIT_DIR":                          true,
-	"GIT_WORK_TREE":                    true,
-	"GIT_INDEX_FILE":                   true,
-	"GIT_OBJECT_DIRECTORY":             true,
-	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
-	"GIT_COMMON_DIR":                   true,
-	"GIT_CEILING_DIRECTORIES":          true,
-	"GIT_DISCOVERY_ACROSS_FILESYSTEM":  true,
-	"GIT_NAMESPACE":                    true,
-	"GIT_CONFIG":                       true,
-	"GIT_CONFIG_GLOBAL":                true,
-	"GIT_CONFIG_SYSTEM":                true,
-	"GIT_CONFIG_NOSYSTEM":              true,
-	"GIT_CONFIG_COUNT":                 true,
-	"GIT_EXEC_PATH":                    true,
-	"GIT_PAGER":                        true,
 }

--- a/internal/packregistry/content_hash.go
+++ b/internal/packregistry/content_hash.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/git"
 )
 
 // PackContentHash returns the canonical sha256 content hash for one pack
@@ -238,36 +238,10 @@ func runRegistryGitBytes(dir string, args ...string) ([]byte, error) {
 	}, args...)
 	cmd := exec.Command("git", cmdArgs...)
 	cmd.Dir = dir
-	for _, env := range os.Environ() {
-		key, _, ok := strings.Cut(env, "=")
-		if ok && registryGitEnvBlacklist[key] {
-			continue
-		}
-		cmd.Env = append(cmd.Env, env)
-	}
-	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	cmd.Env = git.HermeticEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
 	}
 	return out, nil
-}
-
-var registryGitEnvBlacklist = map[string]bool{
-	"GIT_DIR":                          true,
-	"GIT_WORK_TREE":                    true,
-	"GIT_INDEX_FILE":                   true,
-	"GIT_OBJECT_DIRECTORY":             true,
-	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
-	"GIT_COMMON_DIR":                   true,
-	"GIT_CEILING_DIRECTORIES":          true,
-	"GIT_DISCOVERY_ACROSS_FILESYSTEM":  true,
-	"GIT_NAMESPACE":                    true,
-	"GIT_CONFIG":                       true,
-	"GIT_CONFIG_GLOBAL":                true,
-	"GIT_CONFIG_SYSTEM":                true,
-	"GIT_CONFIG_NOSYSTEM":              true,
-	"GIT_CONFIG_COUNT":                 true,
-	"GIT_EXEC_PATH":                    true,
-	"GIT_PAGER":                        true,
 }


### PR DESCRIPTION
## Summary
- add `gc registry login` and `gc registry whoami`
- store registry API tokens in a local 0600 config file
- let `gc registry publish` use stored tokens and GitHub Actions OIDC publish tokens
- keep session/CSRF and dev-auth publish paths for local testing

## Tests
- `go test ./cmd/gc -run 'Test(BuildRegistryPublishRequest|SubmitRegistryPublishRequest|RegistryPublishDevAuth|DoRegistryPublish|RegistryLogin|CLIDocumentation|GenDoc|.*Docs|GeneratedCLI)' -count=1`\n- pre-commit fast suite: lint-changed, generated docs/schema, go vet, fast local test shards, docsync\n\n## Deployment note\nThe registry backend side is already deployed to `registry.gascity.com`; this PR gets the matching `gc` CLI commands into the main Gas City binary.