### PR TITLE
feat(telemetry): honor OTEL_RESOURCE_ATTRIBUTES and OTEL_EXPORTER_OTLP_ENDPOINT (ga-frei6b)

### DIFF
--- a/internal/telemetry/subprocess.go
+++ b/internal/telemetry/subprocess.go
@@ -1,27 +1,100 @@
 package telemetry
 
 import (
+	"fmt"
 	"os"
 	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
 )
+
+// gcIdentityAttrs returns the GC identity resource attributes (gc.agent,
+// gc.rig, gc.city) parsed from the GC context vars in the current process
+// environment. Empty when no GC context vars are set.
+func gcIdentityAttrs() []attribute.KeyValue {
+	var attrs []attribute.KeyValue
+	agent := os.Getenv("GC_ALIAS")
+	if agent == "" {
+		agent = os.Getenv("GC_AGENT")
+	}
+	if agent != "" {
+		attrs = append(attrs, attribute.String("gc.agent", agent))
+	}
+	if v := os.Getenv("GC_RIG"); v != "" {
+		attrs = append(attrs, attribute.String("gc.rig", v))
+	}
+	if v := os.Getenv("GC_CITY"); v != "" {
+		attrs = append(attrs, attribute.String("gc.city", v))
+	}
+	return attrs
+}
 
 // buildGCResourceAttrs builds the OTEL_RESOURCE_ATTRIBUTES value from GC context
 // vars present in the current process environment.
 // Returns "" when no GC vars are found.
 func buildGCResourceAttrs() string {
-	var attrs []string
-	if v := os.Getenv("GC_ALIAS"); v != "" {
-		attrs = append(attrs, "gc.agent="+v)
-	} else if v := os.Getenv("GC_AGENT"); v != "" {
-		attrs = append(attrs, "gc.agent="+v)
+	identity := gcIdentityAttrs()
+	pairs := make([]string, 0, len(identity))
+	for _, kv := range identity {
+		pairs = append(pairs, string(kv.Key)+"="+kv.Value.AsString())
 	}
-	if v := os.Getenv("GC_RIG"); v != "" {
-		attrs = append(attrs, "gc.rig="+v)
+	return strings.Join(pairs, ",")
+}
+
+// gcResourceAttrKeys are the identity keys gc injects into
+// OTEL_RESOURCE_ATTRIBUTES for the processes it spawns.
+var gcResourceAttrKeys = map[string]bool{
+	"gc.agent": true,
+	"gc.rig":   true,
+	"gc.city":  true,
+}
+
+// stripGCResourceAttrs removes gc identity pairs (gc.agent, gc.rig, gc.city)
+// from a comma-separated OTEL_RESOURCE_ATTRIBUTES value. Other pairs pass
+// through untouched, including malformed segments, which the env detector
+// already tolerates downstream.
+func stripGCResourceAttrs(attrs string) string {
+	if attrs == "" {
+		return ""
 	}
-	if v := os.Getenv("GC_CITY"); v != "" {
-		attrs = append(attrs, "gc.city="+v)
+	var kept []string
+	for _, segment := range strings.Split(attrs, ",") {
+		key, _, hasValue := strings.Cut(segment, "=")
+		if hasValue && gcResourceAttrKeys[strings.TrimSpace(key)] {
+			continue
+		}
+		kept = append(kept, segment)
 	}
-	return strings.Join(attrs, ",")
+	return strings.Join(kept, ",")
+}
+
+// resourceAttrsForChildren returns the OTEL_RESOURCE_ATTRIBUTES value gc hands
+// to spawned processes: any pre-existing value with previously injected GC
+// identity pairs stripped and the current process's GC context labels
+// appended. Stripping first keeps the merge idempotent when gc has already
+// rewritten its own environment (SetProcessOTELAttrs) and stops a spawning
+// agent's identity from surviving into the labels handed to other agents'
+// sessions. Returns "" when neither source has attributes.
+func resourceAttrsForChildren() string {
+	existing := stripGCResourceAttrs(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"))
+	gcAttrs := buildGCResourceAttrs()
+	switch {
+	case existing == "":
+		return gcAttrs
+	case gcAttrs == "":
+		return existing
+	default:
+		return existing + "," + gcAttrs
+	}
+}
+
+// setenvWarn sets an environment variable and reports failures to stderr.
+// Telemetry env propagation is best-effort: a failed write must not abort
+// gc, but staying silent would make a missing-telemetry diagnosis impossible.
+func setenvWarn(key, value string) {
+	if err := os.Setenv(key, value); err != nil {
+		fmt.Fprintf(os.Stderr, "gc: telemetry: setting %s: %v\n", key, err) //nolint:errcheck // best-effort stderr
+	}
 }
 
 // SetProcessOTELAttrs sets OTEL-related variables in the current process
@@ -30,28 +103,29 @@ func buildGCResourceAttrs() string {
 //
 // Sets:
 //   - OTEL_RESOURCE_ATTRIBUTES — GC context labels (gc.agent, gc.rig, gc.city)
-//   - BD_OTEL_METRICS_URL      — bd's own metrics var (mirrors GC_OTEL_METRICS_URL)
-//   - BD_OTEL_LOGS_URL         — bd's own logs var   (mirrors GC_OTEL_LOGS_URL)
+//     merged into any pre-existing value; previously injected GC labels are
+//     replaced, not duplicated
+//   - BD_OTEL_METRICS_URL      — bd's own metrics var (resolved metrics endpoint)
+//   - BD_OTEL_LOGS_URL         — bd's own logs var   (resolved logs endpoint)
 //   - CLAUDE_CODE_ENABLE_TELEMETRY=1 — enables Claude Code's built-in telemetry
 //
 // Called once at gc startup when telemetry is active.
-// No-op when GC_OTEL_METRICS_URL is not set.
+// No-op when telemetry is not active — the same activation rule as Init,
+// including the OTEL_EXPORTER_OTLP_ENDPOINT fallback.
 func SetProcessOTELAttrs() {
-	metricsURL := os.Getenv(EnvMetricsURL)
-	if metricsURL == "" {
+	metricsURL, logsURL, enabled := resolveEndpoints()
+	if !enabled {
 		return
 	}
-	if attrs := buildGCResourceAttrs(); attrs != "" {
-		_ = os.Setenv("OTEL_RESOURCE_ATTRIBUTES", attrs)
+	if buildGCResourceAttrs() != "" {
+		setenvWarn("OTEL_RESOURCE_ATTRIBUTES", resourceAttrsForChildren())
 	}
-	// Mirror GC vars into bd's own var names so bd subprocesses
-	// emit their metrics to the same VictoriaMetrics instance.
-	_ = os.Setenv("BD_OTEL_METRICS_URL", metricsURL)
-	if logsURL := os.Getenv(EnvLogsURL); logsURL != "" {
-		_ = os.Setenv("BD_OTEL_LOGS_URL", logsURL)
-	}
+	// Mirror the resolved endpoints into bd's own var names so bd
+	// subprocesses emit to the same collectors as gc itself.
+	setenvWarn("BD_OTEL_METRICS_URL", metricsURL)
+	setenvWarn("BD_OTEL_LOGS_URL", logsURL)
 	// Enable Claude Code's built-in telemetry for agent sessions.
-	_ = os.Setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "1")
+	setenvWarn("CLAUDE_CODE_ENABLE_TELEMETRY", "1")
 }
 
 // OTELEnvForSubprocess returns OTEL environment variables to inject into bd
@@ -59,41 +133,45 @@ func SetProcessOTELAttrs() {
 //
 // Complements SetProcessOTELAttrs for callers that construct cmd.Env manually
 // so the vars aren't lost when the explicit env slice is built from scratch.
+// No gc code path builds cmd.Env from scratch today, so this helper has no
+// production caller; it is kept as SDK surface for embedders that do. The
+// active propagation paths are SetProcessOTELAttrs (inherited process env)
+// and OTELEnvMap (session env merging).
 //
-// Returns nil when GC telemetry is not active (GC_OTEL_METRICS_URL not set).
+// Returns nil when telemetry is not active — the same activation rule as
+// Init, including the OTEL_EXPORTER_OTLP_ENDPOINT fallback.
 func OTELEnvForSubprocess() []string {
-	metricsURL := os.Getenv(EnvMetricsURL)
-	if metricsURL == "" {
+	metricsURL, logsURL, enabled := resolveEndpoints()
+	if !enabled {
 		return nil
 	}
 	var env []string
-	if attrs := buildGCResourceAttrs(); attrs != "" {
+	if attrs := resourceAttrsForChildren(); attrs != "" {
 		env = append(env, "OTEL_RESOURCE_ATTRIBUTES="+attrs)
 	}
-	env = append(env, "BD_OTEL_METRICS_URL="+metricsURL)
-	if logsURL := os.Getenv(EnvLogsURL); logsURL != "" {
-		env = append(env, "BD_OTEL_LOGS_URL="+logsURL)
-	}
-	env = append(env, "CLAUDE_CODE_ENABLE_TELEMETRY=1")
+	env = append(env,
+		"BD_OTEL_METRICS_URL="+metricsURL,
+		"BD_OTEL_LOGS_URL="+logsURL,
+		"CLAUDE_CODE_ENABLE_TELEMETRY=1",
+	)
 	return env
 }
 
 // OTELEnvMap returns OTEL environment variables as a map for Gas City's
-// mergeEnv() pattern. Returns nil when telemetry is not active.
+// mergeEnv() pattern. Returns nil when telemetry is not active — the same
+// activation rule as Init, including the OTEL_EXPORTER_OTLP_ENDPOINT fallback.
 func OTELEnvMap() map[string]string {
-	metricsURL := os.Getenv(EnvMetricsURL)
-	if metricsURL == "" {
+	metricsURL, logsURL, enabled := resolveEndpoints()
+	if !enabled {
 		return nil
 	}
 	m := map[string]string{
 		"BD_OTEL_METRICS_URL":          metricsURL,
+		"BD_OTEL_LOGS_URL":             logsURL,
 		"CLAUDE_CODE_ENABLE_TELEMETRY": "1",
 	}
-	if attrs := buildGCResourceAttrs(); attrs != "" {
+	if attrs := resourceAttrsForChildren(); attrs != "" {
 		m["OTEL_RESOURCE_ATTRIBUTES"] = attrs
-	}
-	if logsURL := os.Getenv(EnvLogsURL); logsURL != "" {
-		m["BD_OTEL_LOGS_URL"] = logsURL
 	}
 	return m
 }

--- a/internal/telemetry/subprocess_test.go
+++ b/internal/telemetry/subprocess_test.go
@@ -59,11 +59,76 @@ func TestBuildGCResourceAttrs_PrefersAlias(t *testing.T) {
 	}
 }
 
+func TestStripGCResourceAttrs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no gc pairs", "team=platform,deployment.environment=prod", "team=platform,deployment.environment=prod"},
+		{"only gc pairs", "gc.agent=a,gc.rig=r,gc.city=c", ""},
+		{"mixed", "team=platform,gc.agent=a,env=prod,gc.rig=r", "team=platform,env=prod"},
+		{"malformed trailing comma preserved", "team=platform,", "team=platform,"},
+		{"gc key without value preserved", "gc.agent,team=platform", "gc.agent,team=platform"},
+		{"spaced gc key stripped", "team=platform, gc.agent=a", "team=platform"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripGCResourceAttrs(tc.in); got != tc.want {
+				t.Errorf("stripGCResourceAttrs(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResourceAttrsForChildren_ReplacesInheritedSpawnerIdentity(t *testing.T) {
+	// A session env created by another agent carries that agent's identity
+	// labels; the merge must replace them with this process's own labels
+	// instead of appending duplicates or forwarding the spawner's identity.
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "team=platform,gc.agent=mayor,gc.rig=tower")
+	t.Setenv("GC_ALIAS", "polecat-1")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_RIG", "refinery")
+	t.Setenv("GC_CITY", "")
+
+	want := "team=platform,gc.agent=polecat-1,gc.rig=refinery"
+	if got := resourceAttrsForChildren(); got != want {
+		t.Errorf("resourceAttrsForChildren() = %q, want %q", got, want)
+	}
+}
+
 func TestOTELEnvMap_Disabled(t *testing.T) {
 	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "")
 	m := OTELEnvMap()
 	if m != nil {
 		t.Errorf("expected nil when telemetry disabled, got %v", m)
+	}
+}
+
+func TestOTELEnvMap_StandardEndpointOnly(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "http://collector:4318")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_CITY", "")
+
+	m := OTELEnvMap()
+	if m == nil {
+		t.Fatal("expected non-nil map when OTEL_EXPORTER_OTLP_ENDPOINT is set")
+	}
+	if want := "http://collector:4318/v1/metrics"; m["BD_OTEL_METRICS_URL"] != want {
+		t.Errorf("BD_OTEL_METRICS_URL = %q, want %q", m["BD_OTEL_METRICS_URL"], want)
+	}
+	if want := "http://collector:4318/v1/logs"; m["BD_OTEL_LOGS_URL"] != want {
+		t.Errorf("BD_OTEL_LOGS_URL = %q, want %q", m["BD_OTEL_LOGS_URL"], want)
+	}
+	if m["CLAUDE_CODE_ENABLE_TELEMETRY"] != "1" {
+		t.Errorf("CLAUDE_CODE_ENABLE_TELEMETRY = %q", m["CLAUDE_CODE_ENABLE_TELEMETRY"])
 	}
 }
 
@@ -90,7 +155,9 @@ func TestOTELEnvMap_Enabled(t *testing.T) {
 	}
 }
 
-func TestOTELEnvMap_NoLogsURL(t *testing.T) {
+func TestOTELEnvMap_NoLogsURL_FallsBackToDefault(t *testing.T) {
+	// The resolved logs endpoint mirrors what the main provider uses, so bd
+	// emits to the same collector as gc when GC_OTEL_LOGS_URL is unset.
 	t.Setenv(EnvMetricsURL, "http://localhost:8428/opentelemetry/api/v1/push")
 	t.Setenv(EnvLogsURL, "")
 	t.Setenv("GC_ALIAS", "")
@@ -99,8 +166,8 @@ func TestOTELEnvMap_NoLogsURL(t *testing.T) {
 	t.Setenv("GC_CITY", "")
 
 	m := OTELEnvMap()
-	if _, ok := m["BD_OTEL_LOGS_URL"]; ok {
-		t.Error("BD_OTEL_LOGS_URL should not be present when GC_OTEL_LOGS_URL is empty")
+	if got := m["BD_OTEL_LOGS_URL"]; got != DefaultLogsURL {
+		t.Errorf("BD_OTEL_LOGS_URL = %q, want DefaultLogsURL %q", got, DefaultLogsURL)
 	}
 }
 
@@ -119,11 +186,76 @@ func TestOTELEnvMap_WithResourceAttrs(t *testing.T) {
 	}
 }
 
+func TestOTELEnvMap_MergesExistingResourceAttrs(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "http://localhost:8428/opentelemetry/api/v1/push")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "team=platform,deployment.environment=prod")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "mayor")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_CITY", "")
+
+	m := OTELEnvMap()
+	want := "team=platform,deployment.environment=prod,gc.agent=mayor"
+	if got := m["OTEL_RESOURCE_ATTRIBUTES"]; got != want {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want %q", got, want)
+	}
+}
+
+func TestOTELEnvMap_PreservesUserAttrsWithoutGCContext(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "http://localhost:8428/opentelemetry/api/v1/push")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "team=platform")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_CITY", "")
+
+	m := OTELEnvMap()
+	if got := m["OTEL_RESOURCE_ATTRIBUTES"]; got != "team=platform" {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want user value preserved", got)
+	}
+}
+
 func TestOTELEnvForSubprocess_Disabled(t *testing.T) {
 	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "")
 	env := OTELEnvForSubprocess()
 	if env != nil {
 		t.Errorf("expected nil when telemetry disabled, got %v", env)
+	}
+}
+
+func TestOTELEnvForSubprocess_StandardEndpointOnly(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "http://collector:4318")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "team=platform")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "mayor")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_CITY", "")
+
+	env := OTELEnvForSubprocess()
+	if env == nil {
+		t.Fatal("expected non-nil env when OTEL_EXPORTER_OTLP_ENDPOINT is set")
+	}
+	want := map[string]bool{
+		"BD_OTEL_METRICS_URL=http://collector:4318/v1/metrics":  false,
+		"BD_OTEL_LOGS_URL=http://collector:4318/v1/logs":        false,
+		"OTEL_RESOURCE_ATTRIBUTES=team=platform,gc.agent=mayor": false,
+		"CLAUDE_CODE_ENABLE_TELEMETRY=1":                        false,
+	}
+	for _, e := range env {
+		if _, ok := want[e]; ok {
+			want[e] = true
+		}
+	}
+	for entry, seen := range want {
+		if !seen {
+			t.Errorf("expected %q in subprocess env, got %v", entry, env)
+		}
 	}
 }
 
@@ -159,6 +291,8 @@ func TestOTELEnvForSubprocess_BothURLs(t *testing.T) {
 
 func TestSetProcessOTELAttrs_Disabled(t *testing.T) {
 	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "")
 	t.Setenv("BD_OTEL_METRICS_URL", "")
 	t.Setenv("BD_OTEL_LOGS_URL", "")
 
@@ -166,6 +300,31 @@ func TestSetProcessOTELAttrs_Disabled(t *testing.T) {
 
 	if v := os.Getenv("BD_OTEL_METRICS_URL"); v != "" {
 		t.Errorf("BD_OTEL_METRICS_URL should not be set when telemetry disabled, got %q", v)
+	}
+}
+
+func TestSetProcessOTELAttrs_StandardEndpointOnly(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "http://collector:4318")
+	t.Setenv("BD_OTEL_METRICS_URL", "")
+	t.Setenv("BD_OTEL_LOGS_URL", "")
+	t.Setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_CITY", "")
+
+	SetProcessOTELAttrs()
+
+	if got, want := os.Getenv("BD_OTEL_METRICS_URL"), "http://collector:4318/v1/metrics"; got != want {
+		t.Errorf("BD_OTEL_METRICS_URL = %q, want %q", got, want)
+	}
+	if got, want := os.Getenv("BD_OTEL_LOGS_URL"), "http://collector:4318/v1/logs"; got != want {
+		t.Errorf("BD_OTEL_LOGS_URL = %q, want %q", got, want)
+	}
+	if got := os.Getenv("CLAUDE_CODE_ENABLE_TELEMETRY"); got != "1" {
+		t.Errorf("CLAUDE_CODE_ENABLE_TELEMETRY = %q, want %q", got, "1")
 	}
 }
 
@@ -209,5 +368,83 @@ func TestSetProcessOTELAttrs_SetsResourceAttrs(t *testing.T) {
 	}
 	if !strings.Contains(got, "gc.agent=mayor") {
 		t.Errorf("expected gc.agent in OTEL_RESOURCE_ATTRIBUTES, got %q", got)
+	}
+}
+
+func TestSetProcessOTELAttrs_MergesExistingResourceAttrs(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "http://localhost:8428/opentelemetry/api/v1/push")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "mayor")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_CITY", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "team=platform")
+
+	SetProcessOTELAttrs()
+
+	want := "team=platform,gc.agent=mayor"
+	if got := os.Getenv("OTEL_RESOURCE_ATTRIBUTES"); got != want {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want merged %q", got, want)
+	}
+}
+
+func TestSetProcessOTELAttrs_RepeatedMergeIsIdempotent(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "http://localhost:8428/opentelemetry/api/v1/push")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv("BD_OTEL_METRICS_URL", "")
+	t.Setenv("BD_OTEL_LOGS_URL", "")
+	t.Setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "mayor")
+	t.Setenv("GC_RIG", "tower")
+	t.Setenv("GC_CITY", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "team=platform")
+
+	SetProcessOTELAttrs()
+	SetProcessOTELAttrs()
+
+	want := "team=platform,gc.agent=mayor,gc.rig=tower"
+	if got := os.Getenv("OTEL_RESOURCE_ATTRIBUTES"); got != want {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES after repeated merge = %q, want %q", got, want)
+	}
+}
+
+func TestSetProcessOTELAttrs_ThenOTELEnvMap_NoDuplicateLabels(t *testing.T) {
+	// gc startup calls SetProcessOTELAttrs, then the session-env path calls
+	// OTELEnvMap in the same process; the map value must not accumulate a
+	// second copy of the GC labels from the already-mutated process env.
+	t.Setenv(EnvMetricsURL, "http://localhost:8428/opentelemetry/api/v1/push")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv("BD_OTEL_METRICS_URL", "")
+	t.Setenv("BD_OTEL_LOGS_URL", "")
+	t.Setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "mayor")
+	t.Setenv("GC_RIG", "tower")
+	t.Setenv("GC_CITY", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "team=platform")
+
+	SetProcessOTELAttrs()
+	m := OTELEnvMap()
+
+	want := "team=platform,gc.agent=mayor,gc.rig=tower"
+	if got := m["OTEL_RESOURCE_ATTRIBUTES"]; got != want {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want %q", got, want)
+	}
+}
+
+func TestSetProcessOTELAttrs_PreservesUserAttrsWithoutGCContext(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "http://localhost:8428/opentelemetry/api/v1/push")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_CITY", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "team=platform")
+
+	SetProcessOTELAttrs()
+
+	if got := os.Getenv("OTEL_RESOURCE_ATTRIBUTES"); got != "team=platform" {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want user value untouched", got)
 	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -8,6 +8,13 @@
 //	GC_OTEL_METRICS_URL  (default: http://localhost:8428/opentelemetry/api/v1/push)
 //	GC_OTEL_LOGS_URL     (default: http://localhost:9428/insert/opentelemetry/v1/logs)
 //
+// When both GC_OTEL_*_URL vars are unset, the standard OpenTelemetry
+// OTEL_EXPORTER_OTLP_ENDPOINT is honored as a fallback: signal URLs are
+// derived by appending the OTLP/HTTP paths /v1/metrics and /v1/logs.
+// Standard resource env vars (OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME)
+// are merged into the exported resource; explicitly passed service
+// name/version take precedence on conflict.
+//
 // Telemetry is best-effort: initialization errors are returned but do not
 // affect normal gc operation — callers should log and continue.
 //
@@ -18,6 +25,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -38,6 +46,12 @@ const (
 
 	// EnvLogsURL is the env var for the VictoriaLogs OTLP endpoint.
 	EnvLogsURL = "GC_OTEL_LOGS_URL"
+
+	// EnvOTLPEndpoint is the standard OpenTelemetry base endpoint env var.
+	// It is honored as a fallback when neither GC_OTEL_METRICS_URL nor
+	// GC_OTEL_LOGS_URL is set: signal URLs are derived from it by appending
+	// the standard OTLP/HTTP paths /v1/metrics and /v1/logs.
+	EnvOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
 
 	// DefaultMetricsURL is VictoriaMetrics' OTLP push endpoint.
 	DefaultMetricsURL = "http://localhost:8428/opentelemetry/api/v1/push"
@@ -90,29 +104,6 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// newResource builds the OTel resource shared by the metric and log
-// providers. service.instance.id (a fresh UUID, per the OTel semantic
-// conventions) is required for correctness, not just attribution: gc
-// counters are cumulative per process, and many gc processes run
-// concurrently on one host — without a unique instance id their
-// snapshots interleave on a single series, so rate queries over the
-// merged series are meaningless.
-func newResource(ctx context.Context, serviceName, serviceVersion string) (*resource.Resource, error) {
-	instanceID, err := uuid.NewRandom()
-	if err != nil {
-		return nil, fmt.Errorf("generating service.instance.id: %w", err)
-	}
-	return resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName(serviceName),
-			semconv.ServiceVersion(serviceVersion),
-			semconv.ServiceInstanceID(instanceID.String()),
-		),
-		resource.WithHost(),
-		resource.WithOS(),
-	)
-}
-
 // ResetForTest resets the global init state so tests can re-initialize.
 // Must be called only from tests, after Shutdown.
 func ResetForTest() {
@@ -122,32 +113,23 @@ func ResetForTest() {
 	globalProvider = nil
 }
 
-// Init initializes OTel metric and log providers.
+// resolveEndpoints determines the metric and log OTLP endpoints from the
+// environment. enabled is false when no telemetry env var is set.
 //
-// Idempotent: subsequent calls return the provider created on the first call.
-//
-// Returns (nil, nil) if neither GC_OTEL_METRICS_URL nor GC_OTEL_LOGS_URL is set,
-// so that telemetry is strictly opt-in. Set either variable to activate.
-//
-// When active, defaults are used for any unset endpoint:
-//
-//	metrics → http://localhost:8428/opentelemetry/api/v1/push
-//	logs    → http://localhost:9428/insert/opentelemetry/v1/logs
-func Init(ctx context.Context, serviceName, serviceVersion string) (*Provider, error) {
-	initMu.Lock()
-	defer initMu.Unlock()
-	if initDone {
-		return globalProvider, nil
-	}
+// GC_OTEL_METRICS_URL / GC_OTEL_LOGS_URL take precedence: when at least one
+// is set, the unset one falls back to its package default. When both are
+// unset, the standard OTEL_EXPORTER_OTLP_ENDPOINT is used as the base URL
+// for both signals with /v1/metrics and /v1/logs appended.
+func resolveEndpoints() (metricsURL, logsURL string, enabled bool) {
+	metricsURL = os.Getenv(EnvMetricsURL)
+	logsURL = os.Getenv(EnvLogsURL)
 
-	metricsURL := os.Getenv(EnvMetricsURL)
-	logsURL := os.Getenv(EnvLogsURL)
-
-	// Both unset → telemetry disabled, not an error.
 	if metricsURL == "" && logsURL == "" {
-		initDone = true
-		globalProvider = nil
-		return nil, nil
+		base := strings.TrimRight(os.Getenv(EnvOTLPEndpoint), "/")
+		if base == "" {
+			return "", "", false
+		}
+		return base + "/v1/metrics", base + "/v1/logs", true
 	}
 	if metricsURL == "" {
 		metricsURL = DefaultMetricsURL
@@ -155,10 +137,77 @@ func Init(ctx context.Context, serviceName, serviceVersion string) (*Provider, e
 	if logsURL == "" {
 		logsURL = DefaultLogsURL
 	}
+	return metricsURL, logsURL, true
+}
+
+// newResource builds the OTel resource attached to exported metrics and logs.
+//
+// Standard resource env vars (OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME)
+// are honored via resource.WithFromEnv and override detected host/OS
+// attributes; the explicitly passed service name/version win on conflict.
+// service.instance.id (a fresh UUID, per the OTel semantic conventions) is
+// required for correctness, not just attribution: gc counters are cumulative
+// per process, and many gc processes run concurrently on one host — without
+// a unique instance id their snapshots interleave on a single series, so
+// rate queries over the merged series are meaningless. It is applied with
+// the service identity, after WithFromEnv, so an inherited
+// OTEL_RESOURCE_ATTRIBUTES value can never override per-process uniqueness.
+func newResource(ctx context.Context, serviceName, serviceVersion string) (*resource.Resource, error) {
+	instanceID, err := uuid.NewRandom()
+	if err != nil {
+		return nil, fmt.Errorf("generating service.instance.id: %w", err)
+	}
+	res, err := resource.New(ctx,
+		resource.WithHost(),
+		resource.WithOS(),
+		resource.WithFromEnv(),
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion(serviceVersion),
+			semconv.ServiceInstanceID(instanceID.String()),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating OTel resource: %w", err)
+	}
+	return res, nil
+}
+
+// Init initializes OTel metric and log providers.
+//
+// Idempotent: subsequent calls return the provider created on the first call.
+//
+// Returns (nil, nil) if none of GC_OTEL_METRICS_URL, GC_OTEL_LOGS_URL, and
+// OTEL_EXPORTER_OTLP_ENDPOINT is set, so that telemetry is strictly opt-in.
+// Set any of them to activate.
+//
+// When a GC_OTEL_*_URL var activates telemetry, defaults are used for the
+// unset endpoint:
+//
+//	metrics → http://localhost:8428/opentelemetry/api/v1/push
+//	logs    → http://localhost:9428/insert/opentelemetry/v1/logs
+//
+// When only OTEL_EXPORTER_OTLP_ENDPOINT is set, both signal URLs are derived
+// from it per the OTLP/HTTP convention (base + /v1/metrics, base + /v1/logs).
+func Init(ctx context.Context, serviceName, serviceVersion string) (*Provider, error) {
+	initMu.Lock()
+	defer initMu.Unlock()
+	if initDone {
+		return globalProvider, nil
+	}
+
+	metricsURL, logsURL, enabled := resolveEndpoints()
+
+	// No endpoint env var set → telemetry disabled, not an error.
+	if !enabled {
+		initDone = true
+		globalProvider = nil
+		return nil, nil
+	}
 
 	res, err := newResource(ctx, serviceName, serviceVersion)
 	if err != nil {
-		return nil, fmt.Errorf("creating OTel resource: %w", err)
+		return nil, err
 	}
 
 	p := &Provider{resource: res}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -11,9 +11,21 @@
 // When both GC_OTEL_*_URL vars are unset, the standard OpenTelemetry
 // OTEL_EXPORTER_OTLP_ENDPOINT is honored as a fallback: signal URLs are
 // derived by appending the OTLP/HTTP paths /v1/metrics and /v1/logs.
+// The per-signal OTEL_EXPORTER_OTLP_METRICS_ENDPOINT and
+// OTEL_EXPORTER_OTLP_LOGS_ENDPOINT vars are not consulted.
 // Standard resource env vars (OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME)
 // are merged into the exported resource; explicitly passed service
-// name/version take precedence on conflict.
+// name/version take precedence on conflict. Setting OTEL_SDK_DISABLED=true
+// keeps telemetry off regardless of any endpoint var.
+//
+// gc re-injects GC_-prefixed vars and the derived BD_OTEL_* vars into the
+// agent session environments it creates, but not the standard
+// OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_SDK_DISABLED vars: nested sessions
+// see those only through ambient inheritance (tmux server env, shell
+// profiles). Standard-endpoint deployments that want nested gc and Claude
+// Code sessions to keep exporting should set the vars machine-wide, e.g.
+// in shell profiles or the supervisor service env
+// (GC_SUPERVISOR_ENV=OTEL_EXPORTER_OTLP_ENDPOINT).
 //
 // Telemetry is best-effort: initialization errors are returned but do not
 // affect normal gc operation — callers should log and continue.
@@ -23,6 +35,7 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -50,8 +63,17 @@ const (
 	// EnvOTLPEndpoint is the standard OpenTelemetry base endpoint env var.
 	// It is honored as a fallback when neither GC_OTEL_METRICS_URL nor
 	// GC_OTEL_LOGS_URL is set: signal URLs are derived from it by appending
-	// the standard OTLP/HTTP paths /v1/metrics and /v1/logs.
+	// the standard OTLP/HTTP paths /v1/metrics and /v1/logs. The per-signal
+	// OTEL_EXPORTER_OTLP_{METRICS,LOGS}_ENDPOINT vars are not consulted, and
+	// the derived URLs override the exporter's own env handling.
 	EnvOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+	// EnvSDKDisabled is the standard OpenTelemetry kill switch. When set to
+	// "true" (case-insensitive), telemetry stays disabled regardless of any
+	// endpoint var — the escape hatch for environments where
+	// OTEL_EXPORTER_OTLP_ENDPOINT is exported machine-wide for other
+	// applications.
+	EnvSDKDisabled = "OTEL_SDK_DISABLED"
 
 	// DefaultMetricsURL is VictoriaMetrics' OTLP push endpoint.
 	DefaultMetricsURL = "http://localhost:8428/opentelemetry/api/v1/push"
@@ -120,7 +142,12 @@ func ResetForTest() {
 // is set, the unset one falls back to its package default. When both are
 // unset, the standard OTEL_EXPORTER_OTLP_ENDPOINT is used as the base URL
 // for both signals with /v1/metrics and /v1/logs appended.
+// OTEL_SDK_DISABLED=true disables telemetry regardless of endpoint vars.
 func resolveEndpoints() (metricsURL, logsURL string, enabled bool) {
+	if strings.EqualFold(os.Getenv(EnvSDKDisabled), "true") {
+		return "", "", false
+	}
+
 	metricsURL = os.Getenv(EnvMetricsURL)
 	logsURL = os.Getenv(EnvLogsURL)
 
@@ -144,7 +171,10 @@ func resolveEndpoints() (metricsURL, logsURL string, enabled bool) {
 //
 // Standard resource env vars (OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME)
 // are honored via resource.WithFromEnv and override detected host/OS
-// attributes; the explicitly passed service name/version win on conflict.
+// attributes. The process's own GC identity labels (gc.agent, gc.rig,
+// gc.city from the GC context vars) are applied after the env detector so
+// they win over identity labels inherited from a spawning process; the
+// explicitly passed service name/version win last on conflict.
 // service.instance.id (a fresh UUID, per the OTel semantic conventions) is
 // required for correctness, not just attribution: gc counters are cumulative
 // per process, and many gc processes run concurrently on one host — without
@@ -152,23 +182,33 @@ func resolveEndpoints() (metricsURL, logsURL string, enabled bool) {
 // rate queries over the merged series are meaningless. It is applied with
 // the service identity, after WithFromEnv, so an inherited
 // OTEL_RESOURCE_ATTRIBUTES value can never override per-process uniqueness.
+// Malformed OTEL_RESOURCE_ATTRIBUTES segments are dropped, not fatal: the
+// detector reports them via resource.ErrPartialResource alongside a usable
+// resource, and the OTel spec says to continue with the valid attributes.
 func newResource(ctx context.Context, serviceName, serviceVersion string) (*resource.Resource, error) {
 	instanceID, err := uuid.NewRandom()
 	if err != nil {
 		return nil, fmt.Errorf("generating service.instance.id: %w", err)
 	}
-	res, err := resource.New(ctx,
+	opts := []resource.Option{
 		resource.WithHost(),
 		resource.WithOS(),
 		resource.WithFromEnv(),
-		resource.WithAttributes(
-			semconv.ServiceName(serviceName),
-			semconv.ServiceVersion(serviceVersion),
-			semconv.ServiceInstanceID(instanceID.String()),
-		),
-	)
+	}
+	if identity := gcIdentityAttrs(); len(identity) > 0 {
+		opts = append(opts, resource.WithAttributes(identity...))
+	}
+	opts = append(opts, resource.WithAttributes(
+		semconv.ServiceName(serviceName),
+		semconv.ServiceVersion(serviceVersion),
+		semconv.ServiceInstanceID(instanceID.String()),
+	))
+	res, err := resource.New(ctx, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("creating OTel resource: %w", err)
+		if !errors.Is(err, resource.ErrPartialResource) {
+			return nil, fmt.Errorf("creating OTel resource: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "gc: telemetry: %v (continuing with partial resource)\n", err) //nolint:errcheck // best-effort stderr
 	}
 	return res, nil
 }
@@ -179,7 +219,8 @@ func newResource(ctx context.Context, serviceName, serviceVersion string) (*reso
 //
 // Returns (nil, nil) if none of GC_OTEL_METRICS_URL, GC_OTEL_LOGS_URL, and
 // OTEL_EXPORTER_OTLP_ENDPOINT is set, so that telemetry is strictly opt-in.
-// Set any of them to activate.
+// Set any of them to activate. OTEL_SDK_DISABLED=true forces (nil, nil)
+// even when an endpoint var is set.
 //
 // When a GC_OTEL_*_URL var activates telemetry, defaults are used for the
 // unset endpoint:

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -122,6 +122,7 @@ func TestInit_BothURLsUnset_ReturnsNil(t *testing.T) {
 	resetInitState(t)
 	t.Setenv(EnvMetricsURL, "")
 	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "")
 
 	p, err := Init(context.Background(), "test-svc", "0.0.1")
 	if err != nil {
@@ -136,6 +137,7 @@ func TestInit_Idempotent(t *testing.T) {
 	resetInitState(t)
 	t.Setenv(EnvMetricsURL, "")
 	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "")
 
 	p1, _ := Init(context.Background(), "test-svc", "0.0.1")
 	p2, _ := Init(context.Background(), "test-svc", "0.0.1")
@@ -181,6 +183,152 @@ func TestProvider_Shutdown_Empty(t *testing.T) {
 	p := &Provider{}
 	if err := p.Shutdown(context.Background()); err != nil {
 		t.Errorf("Shutdown with no fns should not error: %v", err)
+	}
+}
+
+func TestInit_OTLPEndpointFallbackEnablesTelemetry(t *testing.T) {
+	resetInitState(t)
+	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	// Unroutable port; OTLP HTTP exporters connect lazily so Init succeeds.
+	t.Setenv(EnvOTLPEndpoint, "http://127.0.0.1:1")
+
+	p, err := Init(context.Background(), "test-svc", "0.0.1")
+	if err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider when OTEL_EXPORTER_OTLP_ENDPOINT is set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// Best-effort flush to a dead endpoint; the export error is expected.
+	_ = p.Shutdown(ctx)
+}
+
+func TestResolveEndpoints_GCVarsWinOverOTLPEndpoint(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "http://vm:8428/opentelemetry/api/v1/push")
+	t.Setenv(EnvLogsURL, "http://vl:9428/insert/opentelemetry/v1/logs")
+	t.Setenv(EnvOTLPEndpoint, "http://collector:4318")
+
+	metricsURL, logsURL, enabled := resolveEndpoints()
+	if !enabled {
+		t.Fatal("expected telemetry enabled")
+	}
+	if metricsURL != "http://vm:8428/opentelemetry/api/v1/push" {
+		t.Errorf("metricsURL = %q, want GC_OTEL_METRICS_URL value", metricsURL)
+	}
+	if logsURL != "http://vl:9428/insert/opentelemetry/v1/logs" {
+		t.Errorf("logsURL = %q, want GC_OTEL_LOGS_URL value", logsURL)
+	}
+}
+
+func TestResolveEndpoints_OTLPEndpointFallback(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "http://collector:4318")
+
+	metricsURL, logsURL, enabled := resolveEndpoints()
+	if !enabled {
+		t.Fatal("expected telemetry enabled via OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if want := "http://collector:4318/v1/metrics"; metricsURL != want {
+		t.Errorf("metricsURL = %q, want %q", metricsURL, want)
+	}
+	if want := "http://collector:4318/v1/logs"; logsURL != want {
+		t.Errorf("logsURL = %q, want %q", logsURL, want)
+	}
+}
+
+func TestResolveEndpoints_OTLPEndpointTrailingSlash(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "http://collector:4318/")
+
+	metricsURL, logsURL, enabled := resolveEndpoints()
+	if !enabled {
+		t.Fatal("expected telemetry enabled via OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if want := "http://collector:4318/v1/metrics"; metricsURL != want {
+		t.Errorf("metricsURL = %q, want %q", metricsURL, want)
+	}
+	if want := "http://collector:4318/v1/logs"; logsURL != want {
+		t.Errorf("logsURL = %q, want %q", logsURL, want)
+	}
+}
+
+func TestResolveEndpoints_PartialGCVarsKeepDefaults(t *testing.T) {
+	// When at least one GC_OTEL_*_URL is set, the unset one falls back to the
+	// package default, not to OTEL_EXPORTER_OTLP_ENDPOINT — existing behavior
+	// is unchanged.
+	t.Setenv(EnvMetricsURL, "http://vm:8428/opentelemetry/api/v1/push")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "http://collector:4318")
+
+	metricsURL, logsURL, enabled := resolveEndpoints()
+	if !enabled {
+		t.Fatal("expected telemetry enabled")
+	}
+	if metricsURL != "http://vm:8428/opentelemetry/api/v1/push" {
+		t.Errorf("metricsURL = %q, want GC_OTEL_METRICS_URL value", metricsURL)
+	}
+	if logsURL != DefaultLogsURL {
+		t.Errorf("logsURL = %q, want DefaultLogsURL %q", logsURL, DefaultLogsURL)
+	}
+}
+
+func TestResolveEndpoints_AllUnset_Disabled(t *testing.T) {
+	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "")
+
+	_, _, enabled := resolveEndpoints()
+	if enabled {
+		t.Error("expected telemetry disabled when no endpoint env var is set")
+	}
+}
+
+func TestNewResource_HonorsOTELResourceAttributes(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=prod,gc.city=testcity")
+
+	res, err := newResource(context.Background(), "test-svc", "0.0.1")
+	if err != nil {
+		t.Fatalf("newResource error: %v", err)
+	}
+
+	attrs := make(map[string]string)
+	for _, kv := range res.Attributes() {
+		attrs[string(kv.Key)] = kv.Value.Emit()
+	}
+	if got := attrs["deployment.environment"]; got != "prod" {
+		t.Errorf("deployment.environment = %q, want %q", got, "prod")
+	}
+	if got := attrs["gc.city"]; got != "testcity" {
+		t.Errorf("gc.city = %q, want %q", got, "testcity")
+	}
+	if got := attrs["service.name"]; got != "test-svc" {
+		t.Errorf("service.name = %q, want %q", got, "test-svc")
+	}
+}
+
+func TestNewResource_ExplicitServiceIdentityWinsOverEnv(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=env-svc,service.version=9.9.9")
+
+	res, err := newResource(context.Background(), "test-svc", "0.0.1")
+	if err != nil {
+		t.Fatalf("newResource error: %v", err)
+	}
+
+	attrs := make(map[string]string)
+	for _, kv := range res.Attributes() {
+		attrs[string(kv.Key)] = kv.Value.Emit()
+	}
+	if got := attrs["service.name"]; got != "test-svc" {
+		t.Errorf("service.name = %q, want explicit %q to win over env", got, "test-svc")
+	}
+	if got := attrs["service.version"]; got != "0.0.1" {
+		t.Errorf("service.version = %q, want explicit %q to win over env", got, "0.0.1")
 	}
 }
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -289,8 +289,40 @@ func TestResolveEndpoints_AllUnset_Disabled(t *testing.T) {
 	}
 }
 
+func TestResolveEndpoints_SDKDisabledWinsOverEndpoints(t *testing.T) {
+	// Case-insensitive per the OTel spec for boolean env vars; beats both
+	// the GC vars and the standard endpoint fallback.
+	t.Setenv(EnvSDKDisabled, "TRUE")
+	t.Setenv(EnvMetricsURL, "http://vm:8428/opentelemetry/api/v1/push")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "http://collector:4318")
+
+	_, _, enabled := resolveEndpoints()
+	if enabled {
+		t.Error("expected telemetry disabled when OTEL_SDK_DISABLED=true")
+	}
+}
+
+func TestResolveEndpoints_SDKDisabledFalseKeepsTelemetryOn(t *testing.T) {
+	t.Setenv(EnvSDKDisabled, "false")
+	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "http://collector:4318")
+
+	_, _, enabled := resolveEndpoints()
+	if !enabled {
+		t.Error("expected telemetry enabled when OTEL_SDK_DISABLED is not true")
+	}
+}
+
 func TestNewResource_HonorsOTELResourceAttributes(t *testing.T) {
 	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=prod,gc.city=testcity")
+	// No GC context vars: inherited gc.* labels flow through unchanged, as
+	// in a process without an identity of its own (controller topology).
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_CITY", "")
 
 	res, err := newResource(context.Background(), "test-svc", "0.0.1")
 	if err != nil {
@@ -312,6 +344,33 @@ func TestNewResource_HonorsOTELResourceAttributes(t *testing.T) {
 	}
 }
 
+func TestNewResource_OwnGCIdentityWinsOverInheritedEnv(t *testing.T) {
+	// A session env carries the spawning agent's identity labels via
+	// OTEL_RESOURCE_ATTRIBUTES; a gc process with its own GC context must
+	// export its own identity, not the spawner's.
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "gc.agent=a,team=platform")
+	t.Setenv("GC_ALIAS", "b")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_CITY", "")
+
+	res, err := newResource(context.Background(), "test-svc", "0.0.1")
+	if err != nil {
+		t.Fatalf("newResource error: %v", err)
+	}
+
+	attrs := make(map[string]string)
+	for _, kv := range res.Attributes() {
+		attrs[string(kv.Key)] = kv.Value.Emit()
+	}
+	if got := attrs["gc.agent"]; got != "b" {
+		t.Errorf("gc.agent = %q, want own identity %q to win over inherited env", got, "b")
+	}
+	if got := attrs["team"]; got != "platform" {
+		t.Errorf("team = %q, want %q preserved", got, "platform")
+	}
+}
+
 func TestNewResource_ExplicitServiceIdentityWinsOverEnv(t *testing.T) {
 	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=env-svc,service.version=9.9.9")
 
@@ -330,6 +389,69 @@ func TestNewResource_ExplicitServiceIdentityWinsOverEnv(t *testing.T) {
 	if got := attrs["service.version"]; got != "0.0.1" {
 		t.Errorf("service.version = %q, want explicit %q to win over env", got, "0.0.1")
 	}
+}
+
+func TestNewResource_ExplicitServiceNameWinsOverOTELServiceName(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "env-svc")
+
+	res, err := newResource(context.Background(), "test-svc", "0.0.1")
+	if err != nil {
+		t.Fatalf("newResource error: %v", err)
+	}
+
+	for _, kv := range res.Attributes() {
+		if string(kv.Key) == "service.name" && kv.Value.Emit() != "test-svc" {
+			t.Errorf("service.name = %q, want explicit %q to win over OTEL_SERVICE_NAME", kv.Value.Emit(), "test-svc")
+		}
+	}
+}
+
+func TestNewResource_ToleratesMalformedResourceAttributes(t *testing.T) {
+	// A trailing comma makes the env detector report ErrPartialResource
+	// alongside a usable resource; the malformed segment is dropped and the
+	// valid attributes survive.
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=prod,")
+
+	res, err := newResource(context.Background(), "test-svc", "0.0.1")
+	if err != nil {
+		t.Fatalf("newResource error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected non-nil resource for partial detection")
+	}
+
+	attrs := make(map[string]string)
+	for _, kv := range res.Attributes() {
+		attrs[string(kv.Key)] = kv.Value.Emit()
+	}
+	if got := attrs["deployment.environment"]; got != "prod" {
+		t.Errorf("deployment.environment = %q, want %q", got, "prod")
+	}
+	if got := attrs["service.name"]; got != "test-svc" {
+		t.Errorf("service.name = %q, want %q", got, "test-svc")
+	}
+}
+
+func TestInit_MalformedResourceAttributesStillReturnsProvider(t *testing.T) {
+	resetInitState(t)
+	t.Setenv(EnvMetricsURL, "")
+	t.Setenv(EnvLogsURL, "")
+	t.Setenv(EnvOTLPEndpoint, "http://127.0.0.1:1")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "a=b,")
+
+	p, err := Init(context.Background(), "test-svc", "0.0.1")
+	if err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider despite malformed OTEL_RESOURCE_ATTRIBUTES")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// Best-effort flush to a dead endpoint; the export error is expected.
+	_ = p.Shutdown(ctx)
 }
 
 func TestProvider_Shutdown_ConcurrentSafe(t *testing.T) {


### PR DESCRIPTION
## Problem

Bead: ga-frei6b (design ref: maintainer-city-production.md section 5 item 5).

`internal/telemetry` only understood its own `GC_OTEL_METRICS_URL` / `GC_OTEL_LOGS_URL` pair:

- `OTEL_RESOURCE_ATTRIBUTES` was ignored, so operator-supplied resource labels (e.g. `deployment.environment`) never appeared on exported metrics/logs.
- The standard `OTEL_EXPORTER_OTLP_ENDPOINT` could not activate telemetry, so deployments configured the OpenTelemetry-standard way exported nothing.

## Fix

- Build the OTel resource with `resource.WithFromEnv()` so `OTEL_RESOURCE_ATTRIBUTES` / `OTEL_SERVICE_NAME` are merged into the exported resource. Env attrs override detected host/OS attrs; the explicitly passed service name/version win on conflict (documented in `newResource`).
- New `resolveEndpoints()`: when both `GC_OTEL_*_URL` vars are unset, fall back to `OTEL_EXPORTER_OTLP_ENDPOINT`, deriving per-signal URLs by appending the OTLP/HTTP `/v1/metrics` and `/v1/logs` paths (trailing slash tolerated).
- Existing env vars unchanged: either `GC_OTEL_*_URL` set still activates telemetry and fills the unset one from the package default; both set ignore the standard var entirely.

## Testing

TDD: new tests written first and observed failing (undefined `resolveEndpoints` / `EnvOTLPEndpoint` / `newResource`), then implementation added and observed passing.

- `go test ./internal/telemetry/... -count=1` — pass (new: `TestInit_OTLPEndpointFallbackEnablesTelemetry`, `TestResolveEndpoints_*` x5, `TestNewResource_*` x2; existing disabled-path tests hardened to clear `OTEL_EXPORTER_OTLP_ENDPOINT`)
- `go vet ./...` clean, `go build ./...` clean
- Full `make test` fast suite in isolation sandbox — pass (exit 0, no failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)