### PR TITLE
perf(dispatch): size-gated rotation for control-dispatcher trace log (ga-361vjg)

### DIFF
--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -182,6 +182,7 @@ func workflowTracef(format string, args ...any) {
 	if path == "" {
 		return
 	}
+	maybeRotateWorkflowTrace(path)
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		workflowTraceWarnOpenFailure(path, err)

--- a/cmd/gc/workflow_trace_rotation.go
+++ b/cmd/gc/workflow_trace_rotation.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Workflow trace rotation tunables. The control dispatcher's --serve loop
+// traces every sweep, so without a cap the trace file grows unbounded
+// (823MB observed in production, ga-361vjg). This mirrors the size-gated
+// rotation on events.FileRecorder — a write that finds the active file at
+// or over the cap rotates it aside first — but uses plain numbered copies
+// because the trace is free-form text, not a seq-stamped JSONL event log.
+// Vars (not consts) so tests can lower the threshold.
+var (
+	// workflowTraceMaxBytes is the size threshold above which the next
+	// trace write rotates the active file. Non-positive disables rotation.
+	workflowTraceMaxBytes int64 = 200 * 1024 * 1024 // 200 MiB
+
+	// workflowTraceKeepRotated is how many rotated copies to keep
+	// (<path>.1 .. <path>.N); the oldest is dropped on rotation.
+	workflowTraceKeepRotated = 2
+)
+
+// maybeRotateWorkflowTrace applies size-gated rotation to the workflow
+// trace log before a write. Rotation is best-effort: failures are warned
+// once per path via the workflow trace warning sink and never block the
+// trace write itself. Concurrent writers may race the rename cascade; the
+// worst case is a rotated copy aging out one slot early, which is
+// acceptable for a diagnostic trace.
+func maybeRotateWorkflowTrace(path string) {
+	if workflowTraceMaxBytes <= 0 {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() || info.Size() < workflowTraceMaxBytes {
+		return
+	}
+	if err := rotateWorkflowTrace(path, workflowTraceKeepRotated); err != nil {
+		workflowTraceWarnRotateFailure(path, err)
+	}
+}
+
+// rotateWorkflowTrace shifts numbered rotations up one slot
+// (<path>.N-1 → <path>.N, ..., <path>.1 → <path>.2) and then moves the
+// active file to <path>.1, dropping whatever was in the last slot. The
+// next trace write recreates the active file.
+func rotateWorkflowTrace(path string, keep int) error {
+	if keep < 1 {
+		keep = 1
+	}
+	for i := keep - 1; i >= 1; i-- {
+		src := fmt.Sprintf("%s.%d", path, i)
+		dst := fmt.Sprintf("%s.%d", path, i+1)
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("shifting rotated workflow trace %q to %q: %w", src, dst, err)
+		}
+	}
+	if err := os.Rename(path, path+".1"); err != nil {
+		return fmt.Errorf("rotating active workflow trace %q: %w", path, err)
+	}
+	return nil
+}
+
+// workflowTraceWarnRotateFailure surfaces a failed trace rotation on the
+// active warning sink, deduped per path so a persistently failing rotation
+// warns once per command invocation instead of once per trace line.
+func workflowTraceWarnRotateFailure(path string, err error) {
+	if strings.TrimSpace(path) == "" || err == nil {
+		return
+	}
+	workflowTraceWarnings.mu.Lock()
+	writer := workflowTraceWarnings.writer
+	workflowTraceWarnings.mu.Unlock()
+	workflowTraceWarnf(writer, "trace-rotate:"+normalizePathForCompare(path), "gc convoy control --serve: warning: rotating workflow trace %q: %v\n", path, err)
+}

--- a/cmd/gc/workflow_trace_rotation_test.go
+++ b/cmd/gc/workflow_trace_rotation_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setWorkflowTraceCap lowers the size-gated rotation threshold for the
+// duration of a test and restores the default afterwards.
+func setWorkflowTraceCap(t *testing.T, maxBytes int64) {
+	t.Helper()
+	prev := workflowTraceMaxBytes
+	workflowTraceMaxBytes = maxBytes
+	t.Cleanup(func() { workflowTraceMaxBytes = prev })
+}
+
+func TestWorkflowTracefRotatesWhenTraceExceedsCap(t *testing.T) {
+	tracePath := filepath.Join(t.TempDir(), "control-dispatcher-trace.log")
+	t.Setenv("GC_WORKFLOW_TRACE", tracePath)
+	setWorkflowTraceCap(t, 1)
+
+	workflowTracef("first generation line")
+	// The active file now exceeds the 1-byte cap, so the next write must
+	// rotate it aside before appending.
+	workflowTracef("second generation line")
+
+	rotated, err := os.ReadFile(tracePath + ".1")
+	if err != nil {
+		t.Fatalf("read rotated trace: %v", err)
+	}
+	if !strings.Contains(string(rotated), "first generation line") {
+		t.Fatalf("rotated trace = %q, want first generation line", rotated)
+	}
+	active, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read active trace: %v", err)
+	}
+	if strings.Contains(string(active), "first generation line") {
+		t.Fatalf("active trace = %q, want first generation rotated out", active)
+	}
+	if !strings.Contains(string(active), "second generation line") {
+		t.Fatalf("active trace = %q, want second generation line", active)
+	}
+}
+
+func TestWorkflowTracefDoesNotRotateBelowCap(t *testing.T) {
+	tracePath := filepath.Join(t.TempDir(), "control-dispatcher-trace.log")
+	t.Setenv("GC_WORKFLOW_TRACE", tracePath)
+	setWorkflowTraceCap(t, 1<<20)
+
+	workflowTracef("line one")
+	workflowTracef("line two")
+
+	if _, err := os.Stat(tracePath + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("stat rotated trace = %v, want not-exist below cap", err)
+	}
+	active, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read active trace: %v", err)
+	}
+	if !strings.Contains(string(active), "line one") || !strings.Contains(string(active), "line two") {
+		t.Fatalf("active trace = %q, want both lines retained", active)
+	}
+}
+
+func TestWorkflowTracefKeepsBoundedRotations(t *testing.T) {
+	tracePath := filepath.Join(t.TempDir(), "control-dispatcher-trace.log")
+	t.Setenv("GC_WORKFLOW_TRACE", tracePath)
+	setWorkflowTraceCap(t, 1)
+
+	workflowTracef("generation one")
+	workflowTracef("generation two")
+	workflowTracef("generation three")
+	// Fourth write rotates a third time; generation one falls off the end.
+	workflowTracef("generation four")
+
+	one, err := os.ReadFile(tracePath + ".1")
+	if err != nil {
+		t.Fatalf("read trace .1: %v", err)
+	}
+	if !strings.Contains(string(one), "generation three") {
+		t.Fatalf("trace .1 = %q, want generation three", one)
+	}
+	two, err := os.ReadFile(tracePath + ".2")
+	if err != nil {
+		t.Fatalf("read trace .2: %v", err)
+	}
+	if !strings.Contains(string(two), "generation two") {
+		t.Fatalf("trace .2 = %q, want generation two", two)
+	}
+	if _, err := os.Stat(tracePath + ".3"); !os.IsNotExist(err) {
+		t.Fatalf("stat trace .3 = %v, want not-exist (keep %d rotations)", err, workflowTraceKeepRotated)
+	}
+	active, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read active trace: %v", err)
+	}
+	if !strings.Contains(string(active), "generation four") {
+		t.Fatalf("active trace = %q, want generation four", active)
+	}
+}
+
+func TestWorkflowTracefWarnsOnceWhenRotationFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("directory permissions do not block root")
+	}
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "control-dispatcher-trace.log")
+	t.Setenv("GC_WORKFLOW_TRACE", tracePath)
+	setWorkflowTraceCap(t, 1)
+
+	workflowTracef("first generation line")
+
+	// Make the directory read-only so the rotation rename fails while
+	// appends to the existing file still succeed.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod trace dir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(dir, 0o755); err != nil {
+			t.Errorf("restore trace dir perms: %v", err)
+		}
+	})
+
+	var stderr bytes.Buffer
+	restoreWarnings := useWorkflowTraceWarnings(&stderr)
+	defer restoreWarnings()
+
+	workflowTracef("second generation line")
+	workflowTracef("third generation line")
+
+	got := stderr.String()
+	if count := strings.Count(got, "rotating workflow trace"); count != 1 {
+		t.Fatalf("rotation warning count = %d, want 1; stderr=%q", count, got)
+	}
+	if !strings.Contains(got, tracePath) {
+		t.Fatalf("stderr = %q, want trace path %q", got, tracePath)
+	}
+	// Writes must keep flowing into the un-rotated active file.
+	active, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read active trace: %v", err)
+	}
+	if !strings.Contains(string(active), "third generation line") {
+		t.Fatalf("active trace = %q, want appends to continue after failed rotation", active)
+	}
+}


### PR DESCRIPTION
## Problem

`workflowTracef` in `cmd/gc/dispatch_runtime.go` appends to `control-dispatcher-trace.log` with plain `O_APPEND` and no cap. A long-running `gc convoy control --serve` loop traces every sweep, so the file grows without bound — 823MB observed in production (ga-361vjg).

## Fix

Mirror the size-gated rotation mechanism on `events.FileRecorder` for the trace path: a trace write that finds the active file at or over the 200MiB cap first shifts numbered copies (`path` → `path.1` → `path.2`) and drops the oldest, keeping two rotated generations.

Numbered plain-file copies are used instead of reusing `FileRecorder.rotateLocked` directly because that path is event-log specific (JSONL seq windows, `events.rotated` anchor events, gzip seq-stamped archives) while the trace is free-form text — there is no rotation core that extracts cleanly.

Rotation is best-effort: failures warn once per path through the existing workflow-trace warning sink and never block the trace write.

## Testing

TDD: the three positive rotation tests (`TestWorkflowTracefRotatesWhenTraceExceedsCap`, `TestWorkflowTracefKeepsBoundedRotations`, `TestWorkflowTracefWarnsOnceWhenRotationFails`) were verified to fail with the implementation wiring reverted, then pass with it.

- `go test ./cmd/gc/ -run TestWorkflowTracef` — all pass
- `go build ./...`, `go vet ./...` — clean
- `make test` (full unit suite, isolated sandbox) — PASS

Bead: ga-361vjg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Release coordination

The maintainer-city production host currently runs an interim logrotate stanza (observability role) for `control-dispatcher-trace.log`. Once this PR ships, gc's own rotation manages the same `<path>.N` numbered namespace, so two independent rotators would double-shift generations and effective retention becomes whichever policy is looser. **When the release containing this PR deploys, retire (or scope down) the observability role's logrotate stanza for `control-dispatcher-trace.log`** (infra repo: `docs/architecture/maintainer-city-production.md:175`, `:443`). Tracked on ga-361vjg.
