### PR TITLE
fix(config): write city.toml rewrites through symlinks, refuse key loss (ga-lurp5d)

### DIFF
--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -1169,6 +1169,14 @@ func (v2WorkspaceNameCheck) Fix(ctx *doctor.CheckContext) error {
 		prefix = rawPrefix
 	}
 
+	// Resolve where the rewrite must land before touching anything:
+	// city.toml may be a symlink that the rename must write through, and
+	// the rewrite is refused outright if it would drop unrecognized keys
+	// (ga-lurp5d).
+	writePath, err := config.ResolveCityRewritePath(fsys.OSFS{}, filepath.Join(ctx.CityPath, "city.toml"))
+	if err != nil {
+		return err
+	}
 	// Write the site binding first. If the city.toml rewrite fails
 	// afterwards, runtime identity remains stable and `gc doctor` will
 	// continue warning about the still-present legacy fields rather than
@@ -1182,7 +1190,7 @@ func (v2WorkspaceNameCheck) Fix(ctx *doctor.CheckContext) error {
 	if err != nil {
 		return err
 	}
-	return fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, filepath.Join(ctx.CityPath, "city.toml"), content, 0o644)
+	return fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, writePath, content, 0o644)
 }
 
 func (v2WorkspaceNameCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -1449,6 +1449,48 @@ prefix = "lc"
 	}
 }
 
+// Regression test for ga-lurp5d: the workspace-identity fix rewrites
+// city.toml; when city.toml is a symlink (e.g., into a checked-out repo)
+// the rewrite must write through the link instead of replacing it with a
+// regular file.
+func TestV2WorkspaceNameFixWritesThroughCityTomlSymlink(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkoutDir, "city.toml")
+	if err := os.WriteFile(target, []byte("[workspace]\nname = \"legacy-city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(cityDir, "city.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	d := &doctor.Doctor{}
+	registerV2DeprecationChecks(d)
+	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, true)
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("city.toml symlink was replaced by a %v entry; fix must write through the link", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if strings.Contains(string(data), "legacy-city") {
+		t.Fatalf("workspace identity should be migrated out of the symlink target:\n%s", data)
+	}
+}
+
 func TestV2DeprecationChecksWarnOnLegacyTemplateSuffix(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -361,11 +361,17 @@ func writeCityAndRigSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City, 
 	if err != nil {
 		return err
 	}
-	snapshot, err := snapshotCityAndSiteFiles(fs, tomlPath, SiteBindingPath(cityRoot))
+	// cityRoot intentionally stays the symlink's directory even when
+	// city.toml links elsewhere: that is where the city's .gc/ state lives.
+	writePath, err := ResolveCityRewritePath(fs, tomlPath)
 	if err != nil {
 		return err
 	}
-	if err := fsys.WriteFileIfChangedAtomic(fs, tomlPath, content, 0o644); err != nil {
+	snapshot, err := snapshotCityAndSiteFiles(fs, writePath, SiteBindingPath(cityRoot))
+	if err != nil {
+		return err
+	}
+	if err := fsys.WriteFileIfChangedAtomic(fs, writePath, content, 0o644); err != nil {
 		return err
 	}
 	if err := persistRigSiteBindings(fs, cityRoot, cfg.Rigs, removedRigNames); err != nil {
@@ -375,6 +381,57 @@ func writeCityAndRigSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City, 
 		return fmt.Errorf("writing .gc/site.toml failed; restored city.toml and previous site binding, fix the site binding write error and retry: %w", err)
 	}
 	return nil
+}
+
+// ResolveCityRewritePath returns the path an edit-rewrite of city.toml must
+// write to. city.toml may be a symlink (e.g., into a checked-out repo):
+// renaming a temp file over the link would replace the link itself, so the
+// rewrite must follow the chain and write at the final target instead. It
+// also refuses the rewrite when the current on-disk content would lose keys
+// in the round-trip (see guardCityRewriteKeyLoss). Every code path that
+// rewrites an existing city.toml must resolve through this helper.
+func ResolveCityRewritePath(fs fsys.FS, tomlPath string) (string, error) {
+	writePath, err := fsys.ResolveSymlinks(fs, tomlPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s for rewrite: %w", tomlPath, err)
+	}
+	if err := guardCityRewriteKeyLoss(fs, writePath); err != nil {
+		return "", err
+	}
+	return writePath, nil
+}
+
+// guardCityRewriteKeyLoss refuses to rewrite a city.toml whose current
+// on-disk content contains keys this gc binary does not recognize: the
+// struct round-trip would silently drop them (ga-lurp5d dropped
+// agent_defaults.provider and beads.bd_compatibility in production this
+// way). A missing file is fine — there is nothing to lose. An unparsable
+// file is also refused: callers load the config from this same path before
+// mutating it, so unparsable content here means the file changed underneath
+// us and a rewrite would destroy whatever is there now.
+func guardCityRewriteKeyLoss(fs fsys.FS, path string) error {
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading %s before rewrite: %w", path, err)
+	}
+	var cfg City
+	md, err := toml.Decode(string(data), &cfg)
+	if err != nil {
+		return fmt.Errorf("refusing to rewrite %s: current content does not parse, rewriting would destroy it: %w", path, err)
+	}
+	undecoded := md.Undecoded()
+	if len(undecoded) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(undecoded))
+	for _, key := range undecoded {
+		keys = append(keys, key.String())
+	}
+	sort.Strings(keys)
+	return fmt.Errorf("refusing to rewrite %s: it contains keys this gc binary does not recognize and the rewrite would silently drop them: %s (upgrade gc or remove the keys, then retry)", path, strings.Join(keys, ", "))
 }
 
 func rigNameSet(names []string) map[string]struct{} {

--- a/internal/config/site_binding_rewrite_test.go
+++ b/internal/config/site_binding_rewrite_test.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// Regression test for ga-lurp5d: rewriting a city.toml that is a symlink
+// (e.g., into a checked-out repo) must write through the link — temp file in
+// the target's directory, rename over the target — instead of replacing the
+// link with a regular file.
+func TestWriteCityAndRigSiteBindingsForEditWritesThroughSymlink(t *testing.T) {
+	cases := []struct {
+		name       string
+		linkTarget func(target, linkDir string) string
+	}{
+		{name: "absolute link", linkTarget: func(target, _ string) string { return target }},
+		{name: "relative link", linkTarget: func(target, linkDir string) string {
+			rel, err := filepath.Rel(linkDir, target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return rel
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			checkoutDir := filepath.Join(dir, "checkout")
+			if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(checkoutDir, "city.toml")
+			if err := os.WriteFile(target, []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cityDir := filepath.Join(dir, "city")
+			if err := os.MkdirAll(cityDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			link := filepath.Join(cityDir, "city.toml")
+			linkTarget := tc.linkTarget(target, cityDir)
+			if err := os.Symlink(linkTarget, link); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := Load(fsys.OSFS{}, link)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			cfg.Workspace.Name = "renamed-city"
+
+			if err := WriteCityAndRigSiteBindingsForEdit(fsys.OSFS{}, link, cfg); err != nil {
+				t.Fatalf("WriteCityAndRigSiteBindingsForEdit: %v", err)
+			}
+
+			info, err := os.Lstat(link)
+			if err != nil {
+				t.Fatalf("Lstat link: %v", err)
+			}
+			if info.Mode()&os.ModeSymlink == 0 {
+				t.Fatalf("city.toml symlink was replaced by a %v entry; rewrite must write through the link", info.Mode())
+			}
+			gotTarget, err := os.Readlink(link)
+			if err != nil {
+				t.Fatalf("Readlink: %v", err)
+			}
+			if gotTarget != linkTarget {
+				t.Fatalf("link target = %q, want %q", gotTarget, linkTarget)
+			}
+			data, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatalf("ReadFile target: %v", err)
+			}
+			if !strings.Contains(string(data), `name = "renamed-city"`) {
+				t.Fatalf("target content = %q, want updated workspace name written through the link", data)
+			}
+		})
+	}
+}
+
+// Regression test for ga-lurp5d: a gc binary that does not recognize keys in
+// the on-disk city.toml must refuse the rewrite instead of silently dropping
+// them (observed in prod: agent_defaults.provider and beads.bd_compatibility
+// eaten by an older binary's round-trip).
+func TestWriteCityAndRigSiteBindingsForEditRefusesToDropUnknownKeys(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte("[workspace]\nname = \"test-city\"\n\n[beads]\nfuture_unknown_knob = \"keep-me\"\n")
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	cfg.Workspace.Name = "renamed-city"
+
+	err = WriteCityAndRigSiteBindingsForEdit(fsys.OSFS{}, cityPath, cfg)
+	if err == nil {
+		t.Fatal("WriteCityAndRigSiteBindingsForEdit succeeded, want refusal for unknown key")
+	}
+	if !strings.Contains(err.Error(), "beads.future_unknown_knob") {
+		t.Fatalf("error = %v, want mention of beads.future_unknown_knob", err)
+	}
+	current, readErr := os.ReadFile(cityPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile: %v", readErr)
+	}
+	if !bytes.Equal(current, original) {
+		t.Fatalf("city.toml was rewritten despite refusal:\n%s", current)
+	}
+}
+
+// A brand-new city.toml (no existing file) must still be writable: the
+// unknown-key guard only applies when there is existing content to lose.
+func TestWriteCityAndRigSiteBindingsForEditAllowsFreshWrite(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	cfg := &City{Workspace: Workspace{Name: "test-city"}}
+
+	if err := WriteCityAndRigSiteBindingsForEdit(fsys.OSFS{}, cityPath, cfg); err != nil {
+		t.Fatalf("WriteCityAndRigSiteBindingsForEdit: %v", err)
+	}
+	data, err := os.ReadFile(cityPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), `name = "test-city"`) {
+		t.Fatalf("city.toml = %q, want workspace name", data)
+	}
+}

--- a/internal/fsys/resolve_symlinks.go
+++ b/internal/fsys/resolve_symlinks.go
@@ -1,0 +1,48 @@
+package fsys
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// maxSymlinkDepth bounds symlink chain resolution, mirroring the kernel's
+// nested-link limit so cycles fail instead of looping forever.
+const maxSymlinkDepth = 40
+
+// ResolveSymlinks follows any chain of symlinks at path and returns the
+// final non-symlink path. Relative link targets are resolved against the
+// directory of the link that contains them. A path (or dangling link
+// target) that does not exist is returned as-is so callers can create it.
+//
+// Use this before an atomic temp-file + rename write: renaming over a
+// symlink replaces the link itself, so writers that must preserve links
+// resolve the target first and write there instead.
+func ResolveSymlinks(fs FS, path string) (string, error) {
+	for range maxSymlinkDepth {
+		info, err := fs.Lstat(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return path, nil
+			}
+			return "", fmt.Errorf("resolving symlinks for %s: %w", path, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return path, nil
+		}
+		rl, ok := fs.(readlinkFS)
+		if !ok {
+			return "", fmt.Errorf("resolving symlinks for %s: filesystem does not support Readlink", path)
+		}
+		target, err := rl.Readlink(path)
+		if err != nil {
+			return "", fmt.Errorf("resolving symlinks for %s: %w", path, err)
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(path), target)
+		}
+		path = target
+	}
+	return "", fmt.Errorf("resolving symlinks for %s: too many levels of symbolic links", path)
+}

--- a/internal/fsys/resolve_symlinks_test.go
+++ b/internal/fsys/resolve_symlinks_test.go
@@ -1,0 +1,162 @@
+package fsys_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestResolveSymlinks_RegularFileReturnsPathUnchanged(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte("data")
+
+	got, err := fsys.ResolveSymlinks(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("ResolveSymlinks: %v", err)
+	}
+	if got != "/city/city.toml" {
+		t.Fatalf("got %q, want /city/city.toml", got)
+	}
+}
+
+func TestResolveSymlinks_MissingPathReturnsPathUnchanged(t *testing.T) {
+	fs := fsys.NewFake()
+
+	got, err := fsys.ResolveSymlinks(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("ResolveSymlinks: %v", err)
+	}
+	if got != "/city/city.toml" {
+		t.Fatalf("got %q, want /city/city.toml", got)
+	}
+}
+
+func TestResolveSymlinks_FollowsAbsoluteLink(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/checkout/city.toml"] = []byte("data")
+	fs.Symlinks["/city/city.toml"] = "/checkout/city.toml"
+
+	got, err := fsys.ResolveSymlinks(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("ResolveSymlinks: %v", err)
+	}
+	if got != "/checkout/city.toml" {
+		t.Fatalf("got %q, want /checkout/city.toml", got)
+	}
+}
+
+func TestResolveSymlinks_ResolvesRelativeLinkAgainstLinkDir(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/checkout/city.toml"] = []byte("data")
+	fs.Symlinks["/city/city.toml"] = "../checkout/city.toml"
+
+	got, err := fsys.ResolveSymlinks(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("ResolveSymlinks: %v", err)
+	}
+	if got != "/checkout/city.toml" {
+		t.Fatalf("got %q, want /checkout/city.toml", got)
+	}
+}
+
+func TestResolveSymlinks_FollowsChains(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/final/city.toml"] = []byte("data")
+	fs.Symlinks["/city/city.toml"] = "/mid/city.toml"
+	fs.Symlinks["/mid/city.toml"] = "/final/city.toml"
+
+	got, err := fsys.ResolveSymlinks(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("ResolveSymlinks: %v", err)
+	}
+	if got != "/final/city.toml" {
+		t.Fatalf("got %q, want /final/city.toml", got)
+	}
+}
+
+func TestResolveSymlinks_DanglingLinkReturnsTarget(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Symlinks["/city/city.toml"] = "/checkout/city.toml"
+
+	got, err := fsys.ResolveSymlinks(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("ResolveSymlinks: %v", err)
+	}
+	if got != "/checkout/city.toml" {
+		t.Fatalf("got %q, want /checkout/city.toml", got)
+	}
+}
+
+func TestResolveSymlinks_CycleErrors(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Symlinks["/a"] = "/b"
+	fs.Symlinks["/b"] = "/a"
+
+	_, err := fsys.ResolveSymlinks(fs, "/a")
+	if err == nil {
+		t.Fatal("ResolveSymlinks on a cycle succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "too many levels of symbolic links") {
+		t.Fatalf("error = %v, want symlink-depth error", err)
+	}
+}
+
+// noReadlinkFS wraps an FS but does not expose Readlink, simulating a
+// filesystem implementation without symlink-target support.
+type noReadlinkFS struct {
+	inner fsys.FS
+}
+
+func (f noReadlinkFS) MkdirAll(path string, perm os.FileMode) error {
+	return f.inner.MkdirAll(path, perm)
+}
+
+func (f noReadlinkFS) WriteFile(name string, data []byte, perm os.FileMode) error {
+	return f.inner.WriteFile(name, data, perm)
+}
+func (f noReadlinkFS) ReadFile(name string) ([]byte, error)       { return f.inner.ReadFile(name) }
+func (f noReadlinkFS) Stat(name string) (os.FileInfo, error)      { return f.inner.Stat(name) }
+func (f noReadlinkFS) Lstat(name string) (os.FileInfo, error)     { return f.inner.Lstat(name) }
+func (f noReadlinkFS) ReadDir(name string) ([]os.DirEntry, error) { return f.inner.ReadDir(name) }
+func (f noReadlinkFS) Rename(oldpath, newpath string) error       { return f.inner.Rename(oldpath, newpath) }
+func (f noReadlinkFS) Remove(name string) error                   { return f.inner.Remove(name) }
+func (f noReadlinkFS) Chmod(name string, mode os.FileMode) error  { return f.inner.Chmod(name, mode) }
+
+func TestResolveSymlinks_ErrorsWhenFSCannotReadlink(t *testing.T) {
+	fake := fsys.NewFake()
+	fake.Symlinks["/city/city.toml"] = "/checkout/city.toml"
+
+	_, err := fsys.ResolveSymlinks(noReadlinkFS{inner: fake}, "/city/city.toml")
+	if err == nil {
+		t.Fatal("ResolveSymlinks succeeded, want error for FS without Readlink")
+	}
+	if !strings.Contains(err.Error(), "Readlink") {
+		t.Fatalf("error = %v, want mention of missing Readlink support", err)
+	}
+}
+
+func TestResolveSymlinks_OSFS(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "checkout", "city.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "city.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fsys.ResolveSymlinks(fsys.OSFS{}, link)
+	if err != nil {
+		t.Fatalf("ResolveSymlinks: %v", err)
+	}
+	if got != target {
+		t.Fatalf("got %q, want %q", got, target)
+	}
+}


### PR DESCRIPTION
## Problem

At 2026-06-11T00:43Z a `gc` config rewrite destroyed a production `city.toml` (bead **ga-lurp5d**, evidence copy `/data/tmp/city.toml.gc-rewrite-20260611T0043`) in two ways:

1. **Symlink clobbered.** `city.toml` was a symlink into a checked-out repo. The atomic temp-file + rename placed the temp file next to the link and renamed over it, replacing the SYMLINK with a regular file.
2. **Silent field loss.** The struct round-trip dropped fields the writing binary did not recognize — `agent_defaults.provider` and `beads.bd_compatibility` — while serializing zero-values.

## Fix

- **`fsys.ResolveSymlinks`** (new): follows a symlink chain (bounded at 40 hops, relative targets resolved against the link's directory, dangling/missing paths returned as-is) so writers can put the temp file in the TARGET's directory and rename over the target, preserving the link.
- **`config.ResolveCityRewritePath`** (new): combines symlink resolution with a guard that refuses the rewrite — with a clear error naming the offending keys — when the current on-disk content contains keys this binary does not recognize (`toml.MetaData.Undecoded`), or no longer parses. A missing file still writes fine.
- Wired into both existing rewrite paths: `writeCityAndRigSiteBindingsForEdit` (the funnel behind `gc init` / `gc rig` / `gc agent` / configedit) and the doctor v2 workspace-identity `--fix` (the one direct `WriteFileIfChangedAtomic` bypass). `.gc/` state stays keyed to the symlink's directory.

Full comment/format-preserving round-trips are intentionally out of scope; the guard converts silent data loss into a refusal the operator can act on.

## Testing

TDD: regression tests were written first and shown failing against the pre-fix writer (symlink replaced by a regular file; unknown key silently dropped), then passing with the fix.

- `go test ./internal/fsys/ -run TestResolveSymlinks` — chain/relative/dangling/cycle/no-Readlink/OS coverage
- `go test ./internal/config/ -run TestWriteCityAndRigSiteBindingsForEdit` — write-through-symlink (absolute + relative links), unknown-key refusal leaves file untouched, fresh write still allowed
- `go test ./cmd/gc/ -run TestV2WorkspaceNameFixWritesThroughCityTomlSymlink` — doctor `--fix` preserves the link
- `go vet ./...` clean; full `make test` passed in the isolation sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)