### PR TITLE
fix(cmd/gc): stop orphan sweep from deleting live test roots across PID namespaces (ga-djbcqt)

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -168,6 +168,13 @@ func configureFSPressureForTests() {
 	}
 }
 
+// testTempRootAliveSentinel pins the alive-sentinel flock on this process's
+// test temp root for the binary's lifetime. The reference must stay live:
+// the runtime finalizes unreachable os.Files, which would close the
+// descriptor and release the lock, letting cross-namespace sweepers reclaim
+// an active root (ga-djbcqt).
+var testTempRootAliveSentinel *os.File
+
 func TestMain(m *testing.M) {
 	// testscript re-executes the test binary as "gc" or "bd" for each txtar
 	// command. On that path we must not create a new temp root — the parent
@@ -192,18 +199,18 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv(managedDoltTestParentPIDEnv, fmt.Sprintf("%d", os.Getpid())); err != nil {
 		panic(err)
 	}
-	// Sweep stale testTempRoot dirs in system /tmp before creating a new one.
-	// Sharded cmd/gc runs use a separate prefix so concurrent worktrees with
-	// older test harnesses cannot remove this package's active root.
-	testTempRootPrefix := cmdGCTestTempRootPrefix()
-	sweepOrphanPIDPrefixedDirs(os.TempDir(), testTempRootPrefix)
-	testTempRoot, err := os.MkdirTemp("/tmp", pidPrefixedTempPattern(testTempRootPrefix))
+	// Sweep stale testTempRoot dirs under the inherited temp dir (honoring
+	// TMPDIR) before creating a new one there. Sharded cmd/gc runs use a
+	// separate prefix so concurrent worktrees with older test harnesses
+	// cannot remove this package's active root. The root's alive sentinel
+	// flock must stay held for the binary's lifetime: sweepers in other
+	// processes — including other PID namespaces — probe it instead of
+	// trusting PID visibility (ga-djbcqt).
+	testTempRoot, sentinel, err := createActiveTestTempRoot(cmdGCTestTempRootPrefix())
 	if err != nil {
 		panic(err)
 	}
-	if err := os.WriteFile(filepath.Join(testTempRoot, testActiveTempRootMarker), []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o644); err != nil {
-		panic(err)
-	}
+	testTempRootAliveSentinel = sentinel
 	if err := os.Setenv("TMPDIR", testTempRoot); err != nil {
 		panic(err)
 	}

--- a/cmd/gc/test_orphan_sweep_branches_test.go
+++ b/cmd/gc/test_orphan_sweep_branches_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 )
 
 const testNonLivePID = 2147483647
@@ -21,6 +22,16 @@ func nonLivePID(t *testing.T) int {
 
 func pidPrefixedTestDir(root, prefix string, pid int) string {
 	return filepath.Join(root, prefix+strconv.Itoa(pid)+"-fixture")
+}
+
+// backdatePastSweepAge ages a fixture dir past the sweep's minimum-age guard
+// so tests exercise the liveness branches rather than the age guard.
+func backdatePastSweepAge(t *testing.T, path string) {
+	t.Helper()
+	old := time.Now().Add(-2 * testOrphanSweepMinAge)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatalf("Chtimes(%s): %v", path, err)
+	}
 }
 
 func TestCmdGCTempRootPrefixKeepsControllerSocketLegacy(t *testing.T) {
@@ -135,6 +146,7 @@ func TestSweepOrphanSkipsCurrentPID(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	backdatePastSweepAge(t, dir)
 	sweepOrphanPIDPrefixedDirs(root, "pfx")
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		t.Error("sweepOrphanPIDPrefixedDirs removed the current process PID directory")
@@ -154,6 +166,7 @@ func TestSweepOrphanPreservesLivePID(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	backdatePastSweepAge(t, dir)
 	sweepOrphanPIDPrefixedDirs(root, "pfx")
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		t.Errorf("sweepOrphanPIDPrefixedDirs removed directory for live PID %d", cmd.Process.Pid)
@@ -167,6 +180,7 @@ func TestSweepOrphanRemovesStalePIDDirectory(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	backdatePastSweepAge(t, dir)
 	sweepOrphanPIDPrefixedDirs(root, "pfx")
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Errorf("sweepOrphanPIDPrefixedDirs did not remove stale PID %d directory", pid)
@@ -183,6 +197,7 @@ func TestSweepOrphanSkipsMarkedActiveRoot(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, testActiveTempRootMarker), []byte("active\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	backdatePastSweepAge(t, dir)
 	sweepOrphanPIDPrefixedDirs(root, "pfx")
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		t.Errorf("sweepOrphanPIDPrefixedDirs removed marked active root for stale PID %d", pid)
@@ -206,6 +221,8 @@ func TestSweepOrphanIsIdempotent(t *testing.T) {
 	if err := os.MkdirAll(staleDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	backdatePastSweepAge(t, selfDir)
+	backdatePastSweepAge(t, staleDir)
 
 	sweepOrphanPIDPrefixedDirs(root, "pfx")
 	sweepOrphanPIDPrefixedDirs(root, "pfx") // second call must be safe
@@ -245,6 +262,7 @@ func TestSweepOrphanAllPrefixesStabilize(t *testing.T) {
 			if err := os.MkdirAll(d, 0o755); err != nil {
 				t.Fatalf("MkdirAll %s: %v", d, err)
 			}
+			backdatePastSweepAge(t, d)
 		}
 	}
 
@@ -316,7 +334,9 @@ func TestTestscriptCommandInvocationDoesNotLeakTempRoot(t *testing.T) {
 
 			pid := cmd.ProcessState.Pid()
 			for _, prefix := range []string{testCmdGCTempRootPrefix, testCmdGCShardTempRootPrefix} {
-				matches, err := filepath.Glob(filepath.Join("/tmp", fmt.Sprintf("%s%d-*", prefix, pid)))
+				// A leaked root would be created under the inherited
+				// TMPDIR (os.TempDir()), not hardcoded /tmp.
+				matches, err := filepath.Glob(filepath.Join(os.TempDir(), fmt.Sprintf("%s%d-*", prefix, pid)))
 				if err != nil {
 					t.Fatalf("Glob: %v", err)
 				}
@@ -331,6 +351,124 @@ func TestTestscriptCommandInvocationDoesNotLeakTempRoot(t *testing.T) {
 	}
 }
 
+// TestSweepOrphanSkipsDirYoungerThanMinAge verifies the minimum-age guard:
+// a freshly created dir must survive the sweep even when its PID looks dead
+// and it has no sentinel, closing the window between MkdirTemp and sentinel
+// acquisition (ga-djbcqt).
+func TestSweepOrphanSkipsDirYoungerThanMinAge(t *testing.T) {
+	root := t.TempDir()
+	pid := nonLivePID(t)
+	dir := pidPrefixedTestDir(root, "pfx", pid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sweepOrphanPIDPrefixedDirs(root, "pfx")
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Errorf("sweepOrphanPIDPrefixedDirs removed dir younger than %v for stale PID %d", testOrphanSweepMinAge, pid)
+	}
+}
+
+// TestSweepOrphanSkipsHeldSentinelEvenWhenPIDLooksDead simulates the
+// cross-PID-namespace incident (ga-djbcqt): from inside a bwrap
+// --unshare-pid sandbox every host PID looks dead, but the host creator
+// still holds the flock on the alive sentinel. The sweep must trust the
+// lock, not PID visibility.
+func TestSweepOrphanSkipsHeldSentinelEvenWhenPIDLooksDead(t *testing.T) {
+	root := t.TempDir()
+	pid := nonLivePID(t) // creator's PID "looks dead", as across namespaces
+	dir := pidPrefixedTestDir(root, "pfx", pid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel, err := holdAliveSentinel(dir)
+	if err != nil {
+		t.Fatalf("holdAliveSentinel: %v", err)
+	}
+	t.Cleanup(func() { _ = sentinel.Close() })
+	backdatePastSweepAge(t, dir)
+
+	sweepOrphanPIDPrefixedDirs(root, "pfx")
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Errorf("sweepOrphanPIDPrefixedDirs removed dir with held alive sentinel for dead-looking PID %d", pid)
+	}
+}
+
+// TestSweepOrphanRemovesDirWithFreeSentinel verifies the reclaim path: when
+// the sentinel exists but nobody holds its lock, the creator is gone and the
+// dir is removable — even though the active-root marker is still present
+// (crashed runs never remove their marker).
+func TestSweepOrphanRemovesDirWithFreeSentinel(t *testing.T) {
+	root := t.TempDir()
+	pid := nonLivePID(t)
+	dir := pidPrefixedTestDir(root, "pfx", pid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, testActiveTempRootMarker), []byte("active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, testAliveSentinelName), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	backdatePastSweepAge(t, dir)
+
+	sweepOrphanPIDPrefixedDirs(root, "pfx")
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("sweepOrphanPIDPrefixedDirs did not remove dir with free alive sentinel for stale PID %d", pid)
+	}
+}
+
+// TestCreateActiveTestTempRootHonorsTMPDIR verifies the TestMain fixture root
+// is created under the inherited TMPDIR instead of hardcoded /tmp, so gate
+// runners can isolate concurrent runs (ga-djbcqt).
+func TestCreateActiveTestTempRootHonorsTMPDIR(t *testing.T) {
+	parent := t.TempDir()
+	t.Setenv("TMPDIR", parent)
+
+	root, sentinel, err := createActiveTestTempRoot("pfx")
+	if err != nil {
+		t.Fatalf("createActiveTestTempRoot: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sentinel.Close()
+		_ = os.RemoveAll(root)
+	})
+
+	if filepath.Dir(root) != parent {
+		t.Errorf("createActiveTestTempRoot created %s; want a child of TMPDIR %s", root, parent)
+	}
+	if _, err := os.Stat(filepath.Join(root, testActiveTempRootMarker)); err != nil {
+		t.Errorf("active-root marker missing: %v", err)
+	}
+	exists, held := aliveSentinelHeld(root)
+	if !exists || !held {
+		t.Errorf("aliveSentinelHeld(%s) = (exists=%v, held=%v); want (true, true)", root, exists, held)
+	}
+}
+
+// TestCreateActiveTestTempRootSentinelFreeAfterClose verifies the sentinel
+// lock dies with its holder: once the creator's handle closes (as on process
+// death), the probe reports the root reclaimable.
+func TestCreateActiveTestTempRootSentinelFreeAfterClose(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	root, sentinel, err := createActiveTestTempRoot("pfx")
+	if err != nil {
+		t.Fatalf("createActiveTestTempRoot: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+
+	if err := sentinel.Close(); err != nil {
+		t.Fatalf("close sentinel: %v", err)
+	}
+	exists, held := aliveSentinelHeld(root)
+	if !exists || held {
+		t.Errorf("aliveSentinelHeld(%s) after close = (exists=%v, held=%v); want (true, false)", root, exists, held)
+	}
+}
+
 func TestSweepOrphanRemovesStaleCmdGCTempRootInSystemTmp(t *testing.T) {
 	prefix := fmt.Sprintf("%s%d-test-", testCmdGCTempRootPrefix, os.Getpid())
 	pid := nonLivePID(t)
@@ -340,6 +478,7 @@ func TestSweepOrphanRemovesStaleCmdGCTempRootInSystemTmp(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	backdatePastSweepAge(t, root)
 
 	sweepOrphanPIDPrefixedDirs("/tmp", prefix)
 

--- a/cmd/gc/test_orphan_sweep_branches_test.go
+++ b/cmd/gc/test_orphan_sweep_branches_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -466,6 +468,78 @@ func TestCreateActiveTestTempRootSentinelFreeAfterClose(t *testing.T) {
 	exists, held := aliveSentinelHeld(root)
 	if !exists || held {
 		t.Errorf("aliveSentinelHeld(%s) after close = (exists=%v, held=%v); want (true, false)", root, exists, held)
+	}
+}
+
+// captureSweepStderr runs fn with os.Stderr redirected to a pipe and returns
+// what fn wrote. Safe here because this test does not call t.Parallel, so no
+// parallel test can write to the swapped stderr.
+func captureSweepStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+	fn()
+	os.Stderr = old
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stderr pipe writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	_ = r.Close()
+	if err != nil {
+		t.Fatalf("reading captured stderr: %v", err)
+	}
+	return string(out)
+}
+
+// TestSweepOrphanLogsRemovalReason verifies every removal emits one stderr
+// line naming the removed path and the branch that justified it, so a future
+// recurrence of ga-djbcqt is attributable without gate-log forensics.
+func TestSweepOrphanLogsRemovalReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, dir string)
+		wantReason string
+	}{
+		{
+			name: "free sentinel",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, testAliveSentinelName), nil, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantReason: "free sentinel",
+		},
+		{
+			name:       "legacy dir without sentinel",
+			setup:      func(*testing.T, string) {},
+			wantReason: "legacy: pid dead, no active marker",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			pid := nonLivePID(t)
+			dir := pidPrefixedTestDir(root, "pfx", pid)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			tt.setup(t, dir)
+			backdatePastSweepAge(t, dir)
+
+			got := captureSweepStderr(t, func() { sweepOrphanPIDPrefixedDirs(root, "pfx") })
+
+			if _, err := os.Stat(dir); !os.IsNotExist(err) {
+				t.Fatalf("sweepOrphanPIDPrefixedDirs did not remove %s: %v", dir, err)
+			}
+			if !strings.Contains(got, dir) || !strings.Contains(got, tt.wantReason) {
+				t.Errorf("sweep stderr = %q; want it to name %q with reason %q", got, dir, tt.wantReason)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/test_orphan_sweep_test.go
+++ b/cmd/gc/test_orphan_sweep_test.go
@@ -162,6 +162,7 @@ func sweepOrphanPIDPrefixedDirs(root, prefix string) {
 		}
 		path := filepath.Join(root, e.Name())
 		exists, held := aliveSentinelHeld(path)
+		var reason string
 		switch {
 		case held:
 			// Creator (possibly in another PID namespace) is still alive.
@@ -170,6 +171,7 @@ func sweepOrphanPIDPrefixedDirs(root, prefix string) {
 			// Sentinel present but unlocked: the creator is gone. Remove
 			// even though the active-root marker is still there — crashed
 			// runs never clear their marker.
+			reason = "free sentinel"
 		default:
 			// Legacy dir without a sentinel: fall back to PID liveness and
 			// the active-root marker.
@@ -179,7 +181,11 @@ func sweepOrphanPIDPrefixedDirs(root, prefix string) {
 			if _, err := os.Stat(filepath.Join(path, testActiveTempRootMarker)); err == nil {
 				continue
 			}
+			reason = "legacy: pid dead, no active marker"
 		}
+		// Name each removal so a recurrence of ga-djbcqt is attributable
+		// from run logs instead of gate-log forensics.
+		fmt.Fprintf(os.Stderr, "cmd/gc test sweep: removing %s (%s)\n", path, reason)
 		_ = os.RemoveAll(path)
 	}
 }

--- a/cmd/gc/test_orphan_sweep_test.go
+++ b/cmd/gc/test_orphan_sweep_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 )
 
 const (
@@ -20,7 +23,78 @@ const (
 	testGCHomeDirPrefix          = "gascity-gc-home-pid"
 	testRuntimeDirPrefix         = "gascity-runtime-pid"
 	testProviderStubDirPrefix    = "gascity-provider-stubs-pid"
+	// testAliveSentinelName is a lock file inside each test temp root. The
+	// creating process holds an exclusive flock on it for its lifetime;
+	// sweepers probe the lock instead of trusting PID visibility, which lies
+	// across PID namespaces (ga-djbcqt: bwrap --unshare-pid sandboxes see
+	// every host PID as dead while sharing the host /tmp).
+	testAliveSentinelName = ".gc-test-alive.lock"
 )
+
+// testOrphanSweepMinAge is the minimum age before a PID-prefixed dir becomes
+// a sweep candidate. It closes the window where a sibling run has created its
+// dir but not yet acquired the alive sentinel.
+const testOrphanSweepMinAge = time.Hour
+
+// holdAliveSentinel creates <dir>/.gc-test-alive.lock and takes an exclusive
+// flock on it. The caller must keep the returned file referenced for as long
+// as the dir must stay protected: the runtime finalizes unreachable os.Files,
+// which closes the descriptor and releases the lock.
+func holdAliveSentinel(dir string) (*os.File, error) {
+	f, err := os.OpenFile(filepath.Join(dir, testAliveSentinelName), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening alive sentinel in %q: %w", dir, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("locking alive sentinel in %q: %w", dir, err)
+	}
+	return f, nil
+}
+
+// aliveSentinelHeld probes <dir>'s alive sentinel. exists reports whether the
+// sentinel file is present; held reports whether some process still holds its
+// flock. Probe failures are reported as held so the sweep stays conservative.
+func aliveSentinelHeld(dir string) (exists, held bool) {
+	f, err := os.OpenFile(filepath.Join(dir, testAliveSentinelName), os.O_RDWR, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, false
+		}
+		return true, true
+	}
+	defer f.Close() //nolint:errcheck
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return true, true
+	}
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return true, false
+}
+
+// createActiveTestTempRoot sweeps stale prefix-matching roots under the
+// inherited temp dir (honoring TMPDIR rather than hardcoding /tmp, so gate
+// runners can isolate concurrent runs), creates this process's test temp
+// root there, writes the active-root marker, and acquires the alive sentinel
+// lock. The caller must keep the returned file referenced for the lifetime
+// of the process so the flock is not released by a finalizer.
+func createActiveTestTempRoot(prefix string) (string, *os.File, error) {
+	parent := os.TempDir()
+	sweepOrphanPIDPrefixedDirs(parent, prefix)
+	root, err := os.MkdirTemp(parent, pidPrefixedTempPattern(prefix))
+	if err != nil {
+		return "", nil, fmt.Errorf("creating test temp root under %q: %w", parent, err)
+	}
+	if err := os.WriteFile(filepath.Join(root, testActiveTempRootMarker), []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o644); err != nil {
+		_ = os.RemoveAll(root)
+		return "", nil, fmt.Errorf("writing active test temp root marker: %w", err)
+	}
+	sentinel, err := holdAliveSentinel(root)
+	if err != nil {
+		_ = os.RemoveAll(root)
+		return "", nil, err
+	}
+	return root, sentinel, nil
+}
 
 func pidPrefixedTempPattern(prefix string) string {
 	return prefix + strconv.Itoa(os.Getpid()) + "-*"
@@ -55,16 +129,25 @@ func pidFromPrefixedDirName(name, prefix string) (int, bool) {
 	return pid, true
 }
 
-// sweepOrphanPIDPrefixedDirs removes <root>/<prefix><PID> dirs whose PID
-// is no longer alive, including MkdirTemp names such as <prefix><PID>-<random>.
+// sweepOrphanPIDPrefixedDirs removes <root>/<prefix><PID> dirs whose creator
+// is gone, including MkdirTemp names such as <prefix><PID>-<random>.
 // Best-effort; ignores errors. Used by test setup to clean leftover test
 // fixtures from prior crashed/SIGKILL'd runs.
+//
+// Liveness is decided by the alive sentinel flock when present: flock state
+// is visible across PID namespaces, whereas pidAlive reports every host PID
+// as dead from inside a bwrap --unshare-pid sandbox that shares the host
+// /tmp (ga-djbcqt). PID liveness and the active-root marker are only a
+// fallback for legacy dirs without a sentinel. Dirs younger than
+// testOrphanSweepMinAge are never touched, covering the window before a
+// sibling run's sentinel exists.
 func sweepOrphanPIDPrefixedDirs(root, prefix string) {
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		return
 	}
 	self := os.Getpid()
+	now := time.Now()
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
@@ -73,12 +156,29 @@ func sweepOrphanPIDPrefixedDirs(root, prefix string) {
 		if !ok || pid <= 0 || pid == self {
 			continue
 		}
-		if pidAlive(pid) {
+		info, err := e.Info()
+		if err != nil || now.Sub(info.ModTime()) < testOrphanSweepMinAge {
 			continue
 		}
 		path := filepath.Join(root, e.Name())
-		if _, err := os.Stat(filepath.Join(path, testActiveTempRootMarker)); err == nil {
+		exists, held := aliveSentinelHeld(path)
+		switch {
+		case held:
+			// Creator (possibly in another PID namespace) is still alive.
 			continue
+		case exists:
+			// Sentinel present but unlocked: the creator is gone. Remove
+			// even though the active-root marker is still there — crashed
+			// runs never clear their marker.
+		default:
+			// Legacy dir without a sentinel: fall back to PID liveness and
+			// the active-root marker.
+			if pidAlive(pid) {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(path, testActiveTempRootMarker)); err == nil {
+				continue
+			}
 		}
 		_ = os.RemoveAll(path)
 	}


### PR DESCRIPTION
## Problem

`cmd/gc` TestMain creates its test temp root as `/tmp/gct<pid>-*` (hardcoded `/tmp`, ignoring `TMPDIR`), and `sweepOrphanPIDPrefixedDirs` removes any `gct<pid>-*` dir whose PID looks dead. City agents run cmd/gc tests inside bwrap sandboxes with `--unshare-pid` while sharing the host `/tmp`: from inside the namespace EVERY host PID looks dead, so a sandboxed run `rm -rf`'d the host gate's ACTIVE test roots mid-run. Reproduced twice on 2026-06-11 — 94 then 335 phantom cmd/gc failures, all `stat /tmp/gct<pid>-...: no such file or directory` (bead ga-djbcqt). Likely cause of longstanding cmd/gc flakiness on this host.

## Fix

Both directions from the bead:

1. **Liveness no longer trusts PID visibility.** The creating test binary holds an exclusive `flock` on `<root>/.gc-test-alive.lock` for its lifetime (`holdAliveSentinel`, pinned in a package-level var so the runtime's `os.File` finalizer can't release it). Sweepers probe the lock (`aliveSentinelHeld`) and only remove roots whose sentinel lock is FREE — flock state lives on the inode, so it is visible across PID namespaces where `/proc`-based `pidAlive` lies. `pidAlive` + the active-root marker remain as the fallback for legacy dirs without a sentinel, and a one-hour minimum-age guard (`testOrphanSweepMinAge`) covers the window between `MkdirTemp` and sentinel acquisition.
2. **TestMain honors the inherited `TMPDIR`** as the parent for the test temp root (`createActiveTestTempRoot` uses `os.TempDir()` instead of hardcoded `/tmp`), still pointing `TMPDIR` at the new root afterwards as before.

## Testing

TDD failing-first proved by temporarily reverting the sweep decision logic and the `os.TempDir()` parent to origin/main behavior (keeping the new helpers so the package compiles) and running the new tests:

- `TestSweepOrphanSkipsHeldSentinelEvenWhenPIDLooksDead` — FAIL before (simulates the cross-namespace incident: PID looks dead but sentinel held → must skip), PASS after
- `TestSweepOrphanRemovesDirWithFreeSentinel` — FAIL before (sentinel free → reclaim even with stale active-root marker), PASS after
- `TestSweepOrphanSkipsDirYoungerThanMinAge` — FAIL before, PASS after
- `TestCreateActiveTestTempRootHonorsTMPDIR` — FAIL before, PASS after
- `TestCreateActiveTestTempRootSentinelFreeAfterClose` — exercises the new sentinel helpers (lock dies with its holder)

Gates: `go build ./...` and `go vet ./...` clean; pre-commit hook (golangci lint + `make test-fast-parallel`) passed; full `make test` passed inside a bwrap `--unshare-pid` + private-`/tmp` sandbox (exit 0).

Bead: ga-djbcqt

🤖 Generated with [Claude Code](https://claude.com/claude-code)