### PR TITLE
feat(workspacesvc): reap orphaned proxy_process survivors before spawn (ga-mukg0s)

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -209,6 +209,12 @@ func supervisorWorkspaceServiceStateRoots(scope supervisorWorkspaceServiceCleanu
 	return roots
 }
 
+// cleanupSupervisorWorkspaceServices terminates workspace-service processes
+// owned by this supervisor's GC_HOME/registry scope. A second sweep with
+// different matching rules (service-name + state-root + exact-argv +
+// ppid 1) runs before every proxy_process spawn — see
+// internal/workspacesvc/orphan_reap.go. Keep the two mechanisms in mind
+// when changing either.
 func cleanupSupervisorWorkspaceServices(scope supervisorWorkspaceServiceCleanupScope) error {
 	procs, err := findSupervisorWorkspaceServiceProcesses(scope)
 	if err != nil {

--- a/internal/pidutil/pidutil.go
+++ b/internal/pidutil/pidutil.go
@@ -50,7 +50,7 @@ func AliveWithCmdline(pid int, match func([]string) bool) bool {
 	if runtime.GOOS != "linux" {
 		return true
 	}
-	argv, err := procCmdline(pid)
+	argv, err := Cmdline(pid)
 	if err != nil {
 		return false
 	}
@@ -97,24 +97,35 @@ func ArgvHasFlagValue(argv []string, flag, value string) bool {
 	return false
 }
 
-func procCmdline(pid int) ([]string, error) {
+// Cmdline returns a PID's command line from /proc, normalized through
+// NormalizeArgv. It returns an error on hosts without /proc cmdline support
+// or when the process record is unreadable.
+func Cmdline(pid int) ([]string, error) {
 	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
 	if err != nil {
 		return nil, err
 	}
-	data = []byte(strings.TrimRight(string(data), "\x00"))
-	if len(data) == 0 {
+	trimmed := strings.TrimRight(string(data), "\x00")
+	if trimmed == "" {
 		return nil, nil
 	}
-	parts := strings.Split(string(data), "\x00")
-	out := parts[:0]
-	for _, part := range parts {
-		if strings.TrimSpace(part) == "" {
+	return NormalizeArgv(strings.Split(trimmed, "\x00")), nil
+}
+
+// NormalizeArgv returns argv with empty and whitespace-only arguments
+// dropped — the rule Cmdline applies to /proc command lines. Callers
+// comparing a configured argv against Cmdline output must pass the
+// configured side through this helper first so both sides share the same
+// argument shape.
+func NormalizeArgv(argv []string) []string {
+	out := make([]string, 0, len(argv))
+	for _, arg := range argv {
+		if strings.TrimSpace(arg) == "" {
 			continue
 		}
-		out = append(out, part)
+		out = append(out, arg)
 	}
-	return out, nil
+	return out
 }
 
 func psReportsZombie(pid int) bool {

--- a/internal/pidutil/pidutil_test.go
+++ b/internal/pidutil/pidutil_test.go
@@ -72,6 +72,36 @@ func TestAliveWithCmdlineAcceptsMatchingLivePID(t *testing.T) {
 	}
 }
 
+func TestCmdlineReturnsOwnArgv(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("cmdline detection uses /proc on linux")
+	}
+
+	argv, err := Cmdline(os.Getpid())
+	if err != nil {
+		t.Fatalf("Cmdline(%d): %v", os.Getpid(), err)
+	}
+	if len(argv) == 0 || !strings.Contains(filepath.Base(argv[0]), "pidutil") {
+		t.Fatalf("Cmdline(%d) = %v, want test binary argv", os.Getpid(), argv)
+	}
+}
+
+func TestNormalizeArgv(t *testing.T) {
+	got := NormalizeArgv([]string{"cut", "", "-d", " ", "\t ", "-f", "1"})
+	want := []string{"cut", "-d", "-f", "1"}
+	if len(got) != len(want) {
+		t.Fatalf("NormalizeArgv = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("NormalizeArgv = %q, want %q", got, want)
+		}
+	}
+	if out := NormalizeArgv(nil); len(out) != 0 {
+		t.Fatalf("NormalizeArgv(nil) = %q, want empty", out)
+	}
+}
+
 func TestArgvContainsSequence(t *testing.T) {
 	argv := []string{"gc", "nudge", "poll", "--city", "/tmp/city"}
 	cases := []struct {

--- a/internal/workspacesvc/orphan_reap.go
+++ b/internal/workspacesvc/orphan_reap.go
@@ -1,0 +1,181 @@
+package workspacesvc
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Orphaned service processes are survivors of a previous supervisor hard
+// exit: the supervisor died without closing its proxy_process children, so
+// they re-parented to init (ppid 1) and kept running. Every subsequent
+// supervisor start then spawned a fresh duplicate next to them (observed in
+// production: ~39 accumulated duplicates, ga-mukg0s). The sweep below runs
+// before each proxy_process spawn and terminates those survivors so
+// duplicates never accumulate.
+//
+// Matching queries live process-table state only — no pid or status files.
+// A process is reaped only when all three hold:
+//
+//  1. it has re-parented to init (ppid 1), so no live supervisor owns it;
+//  2. its command line is exactly the service's configured command; and
+//  3. its environment carries GC_SERVICE_NAME=<service>, proving a gc
+//     supervisor spawned it as this service rather than a coincidental
+//     same-argv process.
+
+// orphanReapTermWait bounds how long the sweep waits after SIGTERM before
+// escalating to SIGKILL.
+const orphanReapTermWait = proxyProcessShutdownWait
+
+// reapOrphanedServiceProcesses terminates orphaned survivors of previous
+// hard exits that match the service's command-line signature. Best-effort:
+// scan or signal failures are logged and never block the spawn; on hosts
+// without /proc the sweep is a no-op.
+func reapOrphanedServiceProcesses(serviceName string, command []string) {
+	pids := findOrphanedServiceProcesses(serviceName, command)
+	if len(pids) == 0 {
+		return
+	}
+	log.Printf("workspacesvc: terminating %d orphaned process(es) for service %q: %v", len(pids), serviceName, pids)
+	terminateOrphanedProcesses(serviceName, pids)
+}
+
+// findOrphanedServiceProcesses scans /proc for ppid-1 processes whose
+// command line equals command and whose environment marks them as spawns of
+// serviceName. Processes that exit mid-scan or whose records are unreadable
+// are skipped.
+func findOrphanedServiceProcesses(serviceName string, command []string) []int {
+	if len(command) == 0 {
+		return nil
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	self := os.Getpid()
+	var pids []int
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid == self {
+			continue
+		}
+		if ppid, err := processParentPID(pid); err != nil || ppid != 1 {
+			continue
+		}
+		if !processCmdlineEquals(pid, command) {
+			continue
+		}
+		if !processEnvironHasServiceMarker(pid, serviceName) {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// terminateOrphanedProcesses sends SIGTERM to each pid (preferring its
+// process group, which the spawn path creates via Setpgid), waits briefly,
+// then SIGKILLs stragglers.
+func terminateOrphanedProcesses(serviceName string, pids []int) {
+	for _, pid := range pids {
+		signalProcessOrGroup(pid, syscall.SIGTERM)
+	}
+	remaining := pids
+	deadline := time.Now().Add(orphanReapTermWait)
+	for time.Now().Before(deadline) {
+		remaining = liveProcesses(remaining)
+		if len(remaining) == 0 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	remaining = liveProcesses(remaining)
+	if len(remaining) == 0 {
+		return
+	}
+	log.Printf("workspacesvc: SIGKILL %d orphaned straggler(s) for service %q: %v", len(remaining), serviceName, remaining)
+	for _, pid := range remaining {
+		signalProcessOrGroup(pid, syscall.SIGKILL)
+	}
+}
+
+// signalProcessOrGroup signals the process group led by pid, falling back
+// to the process itself when pid is not a group leader.
+func signalProcessOrGroup(pid int, sig syscall.Signal) {
+	if err := syscall.Kill(-pid, sig); err == nil {
+		return
+	}
+	_ = syscall.Kill(pid, sig)
+}
+
+// liveProcesses filters pids down to those that still exist.
+func liveProcesses(pids []int) []int {
+	live := pids[:0]
+	for _, pid := range pids {
+		if err := syscall.Kill(pid, 0); err == nil || err == syscall.EPERM {
+			live = append(live, pid)
+		}
+	}
+	return live
+}
+
+// processParentPID reads the parent pid from /proc/<pid>/stat. The comm
+// field may contain spaces and parentheses, so parsing starts after the
+// last ')'.
+func processParentPID(pid int) (int, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, err
+	}
+	idx := bytes.LastIndexByte(data, ')')
+	if idx < 0 {
+		return 0, fmt.Errorf("malformed stat for pid %d", pid)
+	}
+	fields := strings.Fields(string(data[idx+1:]))
+	if len(fields) < 2 {
+		return 0, fmt.Errorf("malformed stat for pid %d", pid)
+	}
+	return strconv.Atoi(fields[1])
+}
+
+// processCmdlineEquals reports whether /proc/<pid>/cmdline equals command
+// argv-for-argv.
+func processCmdlineEquals(pid int, command []string) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return false
+	}
+	argv := strings.Split(strings.TrimRight(string(data), "\x00"), "\x00")
+	if len(argv) != len(command) {
+		return false
+	}
+	for i := range argv {
+		if argv[i] != command[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// processEnvironHasServiceMarker reports whether the process was spawned
+// with GC_SERVICE_NAME=<serviceName>. /proc/<pid>/environ is readable only
+// for same-uid processes, which doubles as the ownership check; unreadable
+// or unmarked processes are never reaped.
+func processEnvironHasServiceMarker(pid int, serviceName string) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return false
+	}
+	marker := "GC_SERVICE_NAME=" + serviceName
+	for _, kv := range strings.Split(string(data), "\x00") {
+		if kv == marker {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workspacesvc/orphan_reap.go
+++ b/internal/workspacesvc/orphan_reap.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/pidutil"
 )
 
 // Orphaned service processes are survivors of a previous supervisor hard
@@ -20,57 +22,121 @@ import (
 // duplicates never accumulate.
 //
 // Matching queries live process-table state only — no pid or status files.
-// A process is reaped only when all three hold:
+// A process is signaled only while every rule of the orphan identity holds
+// (see orphanIdentity.matchesLive):
 //
-//  1. it has re-parented to init (ppid 1), so no live supervisor owns it;
-//  2. its command line is exactly the service's configured command; and
-//  3. its environment carries GC_SERVICE_NAME=<service>, proving a gc
-//     supervisor spawned it as this service rather than a coincidental
-//     same-argv process.
+//  1. it is alive and not a zombie;
+//  2. it has re-parented to init (ppid 1), so no live supervisor owns it;
+//  3. its command line is exactly the service's configured command; and
+//  4. its environment carries GC_SERVICE_NAME=<service> and
+//     GC_SERVICE_STATE_ROOT=<this instance's state root>, proving a gc
+//     supervisor spawned it as this city's instance of the service rather
+//     than a coincidental same-argv process or a sibling city's
+//     still-serving orphan of the same service.
+//
+// Rule 2 is only meaningful when the sweeping process is not itself init,
+// so the sweep is skipped entirely when running as pid 1 (see
+// findOrphanedServiceProcessesFrom).
+//
+// A separately-scoped cleanup with different matching rules
+// (GC_HOME/registry scoping instead of service-name + state-root +
+// exact-argv + ppid 1) runs at supervisor start and warm refresh — see
+// cleanupSupervisorWorkspaceServices in cmd/gc/cmd_supervisor_lifecycle.go.
+// Keep the two mechanisms in mind when changing either.
 
 // orphanReapTermWait bounds how long the sweep waits after SIGTERM before
 // escalating to SIGKILL.
 const orphanReapTermWait = proxyProcessShutdownWait
 
+// orphanIdentity is the full identity a process must match before the sweep
+// may signal it: the service's name, the spawning instance's absolute state
+// root, and the configured command.
+type orphanIdentity struct {
+	serviceName string
+	stateRoot   string
+	command     []string
+}
+
+// newOrphanIdentity builds the sweep identity for one service instance.
+// stateRoot must be the instance's absolute state root — the value the
+// spawn path exports as GC_SERVICE_STATE_ROOT. command is normalized with
+// the same empty/whitespace-argument rule pidutil.Cmdline applies to live
+// process command lines, so a configured command containing such arguments
+// still matches its own orphans.
+func newOrphanIdentity(serviceName, stateRoot string, command []string) orphanIdentity {
+	return orphanIdentity{
+		serviceName: serviceName,
+		stateRoot:   stateRoot,
+		command:     pidutil.NormalizeArgv(command),
+	}
+}
+
+// matchesLive reports whether pid currently satisfies every identity rule:
+// alive and not a zombie, re-parented to init (ppid 1), command line equal
+// to the service command, and environment carrying both the service-name
+// and state-root markers. The same predicate runs at scan time, on every
+// escalation wait pass, and immediately before SIGKILL — mirroring
+// cleanupSupervisorWorkspaceServices's re-read-before-kill precedent — so a
+// pid recycled at any point is dropped rather than signaled. Any read
+// failure counts as a mismatch: the sweep never signals a process it cannot
+// prove is still the orphan.
+func (id orphanIdentity) matchesLive(pid int) bool {
+	if !pidutil.Alive(pid) {
+		return false
+	}
+	if ppid, err := processParentPID(pid); err != nil || ppid != 1 {
+		return false
+	}
+	if !processCmdlineEquals(pid, id.command) {
+		return false
+	}
+	return processEnvironMatchesService(pid, id.serviceName, id.stateRoot)
+}
+
 // reapOrphanedServiceProcesses terminates orphaned survivors of previous
-// hard exits that match the service's command-line signature. Best-effort:
-// scan or signal failures are logged and never block the spawn; on hosts
-// without /proc the sweep is a no-op.
-func reapOrphanedServiceProcesses(serviceName string, command []string) {
-	pids := findOrphanedServiceProcesses(serviceName, command)
+// hard exits that match the service instance's identity. Best-effort: scan
+// or signal failures are logged and never block the spawn; on hosts without
+// /proc the sweep is a no-op.
+func reapOrphanedServiceProcesses(id orphanIdentity) {
+	pids := findOrphanedServiceProcesses(id)
 	if len(pids) == 0 {
 		return
 	}
-	log.Printf("workspacesvc: terminating %d orphaned process(es) for service %q: %v", len(pids), serviceName, pids)
-	terminateOrphanedProcesses(serviceName, pids)
+	log.Printf("workspacesvc: terminating %d orphaned process(es) for service %q: %v", len(pids), id.serviceName, pids)
+	terminateOrphanedProcesses(id, pids)
 }
 
-// findOrphanedServiceProcesses scans /proc for ppid-1 processes whose
-// command line equals command and whose environment marks them as spawns of
-// serviceName. Processes that exit mid-scan or whose records are unreadable
-// are skipped.
-func findOrphanedServiceProcesses(serviceName string, command []string) []int {
-	if len(command) == 0 {
+// findOrphanedServiceProcesses scans /proc for processes matching id.
+// Processes that exit mid-scan or whose records are unreadable are skipped.
+func findOrphanedServiceProcesses(id orphanIdentity) []int {
+	return findOrphanedServiceProcessesFrom(os.Getpid(), id)
+}
+
+// findOrphanedServiceProcessesFrom is the scan body with the sweeping
+// process's pid made explicit so tests can cover the pid-1 guard. When the
+// sweeper is itself init (pid 1 — gc as a container entrypoint), every live
+// supervised child also has ppid 1, so the orphan test would match healthy
+// processes (including a sibling city's children and publication-context
+// replacements started before the old instance closes). Orphans of a
+// previous supervisor cannot exist in that case — pid 1 dying tears down
+// the pid namespace — so the sweep finds nothing by definition. An identity
+// without a state root is incomplete and matches nothing rather than
+// matching too broadly.
+func findOrphanedServiceProcessesFrom(self int, id orphanIdentity) []int {
+	if len(id.command) == 0 || id.stateRoot == "" || self == 1 {
 		return nil
 	}
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return nil
 	}
-	self := os.Getpid()
 	var pids []int
 	for _, entry := range entries {
 		pid, err := strconv.Atoi(entry.Name())
 		if err != nil || pid == self {
 			continue
 		}
-		if ppid, err := processParentPID(pid); err != nil || ppid != 1 {
-			continue
-		}
-		if !processCmdlineEquals(pid, command) {
-			continue
-		}
-		if !processEnvironHasServiceMarker(pid, serviceName) {
+		if !id.matchesLive(pid) {
 			continue
 		}
 		pids = append(pids, pid)
@@ -80,44 +146,64 @@ func findOrphanedServiceProcesses(serviceName string, command []string) []int {
 
 // terminateOrphanedProcesses sends SIGTERM to each pid (preferring its
 // process group, which the spawn path creates via Setpgid), waits briefly,
-// then SIGKILLs stragglers.
-func terminateOrphanedProcesses(serviceName string, pids []int) {
+// then SIGKILLs stragglers. The full identity is re-verified on every wait
+// pass and once more immediately before SIGKILL, so a pid recycled after
+// SIGTERM is dropped rather than SIGKILLed.
+func terminateOrphanedProcesses(id orphanIdentity, pids []int) {
 	for _, pid := range pids {
 		signalProcessOrGroup(pid, syscall.SIGTERM)
 	}
 	remaining := pids
 	deadline := time.Now().Add(orphanReapTermWait)
 	for time.Now().Before(deadline) {
-		remaining = liveProcesses(remaining)
+		remaining = liveMatchingOrphans(remaining, id)
 		if len(remaining) == 0 {
 			return
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	remaining = liveProcesses(remaining)
+	remaining = liveMatchingOrphans(remaining, id)
 	if len(remaining) == 0 {
 		return
 	}
-	log.Printf("workspacesvc: SIGKILL %d orphaned straggler(s) for service %q: %v", len(remaining), serviceName, remaining)
+	log.Printf("workspacesvc: SIGKILL %d orphaned straggler(s) for service %q: %v", len(remaining), id.serviceName, remaining)
 	for _, pid := range remaining {
 		signalProcessOrGroup(pid, syscall.SIGKILL)
 	}
 }
 
 // signalProcessOrGroup signals the process group led by pid, falling back
-// to the process itself when pid is not a group leader.
+// to the process itself when pid is not a group leader. Unsafe targets are
+// refused outright.
 func signalProcessOrGroup(pid int, sig syscall.Signal) {
+	if unsafeSignalTarget(pid) {
+		log.Printf("workspacesvc: refusing to signal unsafe orphan-reap target pid %d", pid)
+		return
+	}
 	if err := syscall.Kill(-pid, sig); err == nil {
 		return
 	}
 	_ = syscall.Kill(pid, sig)
 }
 
-// liveProcesses filters pids down to those that still exist.
-func liveProcesses(pids []int) []int {
+// unsafeSignalTarget reports whether pid must never be signaled: init,
+// nonpositive pids (kill(2) broadcast and current-group semantics), and the
+// sweeper's own process group. The scan cannot produce such pids today;
+// this mirrors processgroup.Terminate's refusal so kill-adjacent code stays
+// safe under future refactors.
+func unsafeSignalTarget(pid int) bool {
+	return pid <= 1 || pid == syscall.Getpgrp()
+}
+
+// liveMatchingOrphans filters pids down to those that still match the full
+// orphan identity. Re-checking here — not just at scan time — keeps a
+// recycled same-uid pid (and via kill(-pid) its group) from being
+// SIGKILLed, and lets a slow-reaped zombie drop out instead of pinning the
+// full escalation wait.
+func liveMatchingOrphans(pids []int, id orphanIdentity) []int {
 	live := pids[:0]
 	for _, pid := range pids {
-		if err := syscall.Kill(pid, 0); err == nil || err == syscall.EPERM {
+		if id.matchesLive(pid) {
 			live = append(live, pid)
 		}
 	}
@@ -143,14 +229,18 @@ func processParentPID(pid int) (int, error) {
 	return strconv.Atoi(fields[1])
 }
 
-// processCmdlineEquals reports whether /proc/<pid>/cmdline equals command
-// argv-for-argv.
+// processCmdlineEquals reports whether the process's command line equals
+// command argv-for-argv.
 func processCmdlineEquals(pid int, command []string) bool {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	argv, err := pidutil.Cmdline(pid)
 	if err != nil {
 		return false
 	}
-	argv := strings.Split(strings.TrimRight(string(data), "\x00"), "\x00")
+	return argvEquals(argv, command)
+}
+
+// argvEquals reports whether argv equals command argv-for-argv.
+func argvEquals(argv, command []string) bool {
 	if len(argv) != len(command) {
 		return false
 	}
@@ -162,20 +252,31 @@ func processCmdlineEquals(pid int, command []string) bool {
 	return true
 }
 
-// processEnvironHasServiceMarker reports whether the process was spawned
-// with GC_SERVICE_NAME=<serviceName>. /proc/<pid>/environ is readable only
-// for same-uid processes, which doubles as the ownership check; unreadable
-// or unmarked processes are never reaped.
-func processEnvironHasServiceMarker(pid int, serviceName string) bool {
+// processEnvironMatchesService reports whether the process was spawned with
+// both GC_SERVICE_NAME=<serviceName> and GC_SERVICE_STATE_ROOT=<stateRoot>.
+// The state root scopes matching to this city's instance of the service: it
+// is config-derived — stable across supervisor restarts but unique per
+// city+service — so a sibling city running the same service name and
+// command never matches. (GC_SERVICE_SOCKET would not work as the ownership
+// key: it is freshly allocated per instance, so no orphan would ever
+// match.) /proc/<pid>/environ is readable only for same-uid processes,
+// which doubles as the ownership check; unreadable or unmarked processes
+// are never reaped.
+func processEnvironMatchesService(pid int, serviceName, stateRoot string) bool {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
 	if err != nil {
 		return false
 	}
-	marker := "GC_SERVICE_NAME=" + serviceName
+	nameMarker := "GC_SERVICE_NAME=" + serviceName
+	rootMarker := "GC_SERVICE_STATE_ROOT=" + stateRoot
+	var nameOK, rootOK bool
 	for _, kv := range strings.Split(string(data), "\x00") {
-		if kv == marker {
-			return true
+		switch kv {
+		case nameMarker:
+			nameOK = true
+		case rootMarker:
+			rootOK = true
 		}
 	}
-	return false
+	return nameOK && rootOK
 }

--- a/internal/workspacesvc/orphan_reap_test.go
+++ b/internal/workspacesvc/orphan_reap_test.go
@@ -1,0 +1,208 @@
+package workspacesvc
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// spawnOrphanForTest spawns argv detached through an intermediate shell so
+// the child re-parents to init (ppid 1), simulating a service process that
+// survived a supervisor hard exit. extraEnv entries are appended to the
+// orphan's environment. Skips the test on hosts where a child-subreaper
+// intercepts re-parenting, since the production filter requires ppid 1.
+func spawnOrphanForTest(t *testing.T, argv []string, extraEnv []string) int {
+	t.Helper()
+	args := append([]string{"-c", `"$@" >/dev/null 2>&1 & echo $!`, "gc-orphan-spawner"}, argv...)
+	cmd := exec.Command("sh", args...)
+	cmd.Env = append(os.Environ(), extraEnv...)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("spawn orphan: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse orphan pid from %q: %v", out, err)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		ppid, err := processParentPIDForTest(pid)
+		if err != nil {
+			t.Fatalf("orphan %d exited before re-parenting: %v", pid, err)
+		}
+		if ppid == 1 {
+			return pid
+		}
+		if time.Now().After(deadline) {
+			t.Skipf("orphan %d re-parented to %d, not init; host has a child subreaper", pid, ppid)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func processParentPIDForTest(pid int) (int, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(string(data[strings.LastIndexByte(string(data), ')')+1:]))
+	if len(fields) < 2 {
+		return 0, fmt.Errorf("malformed stat for pid %d", pid)
+	}
+	return strconv.Atoi(fields[1])
+}
+
+func processAliveForTest(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+func waitProcessGoneForTest(t *testing.T, pid int, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !processAliveForTest(pid) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return !processAliveForTest(pid)
+}
+
+func TestReapOrphanedServiceProcessesKillsPPID1CommandMatch(t *testing.T) {
+	marker := fmt.Sprintf("86340.0%d", os.Getpid())
+	command := []string{"sleep", marker}
+	pid := spawnOrphanForTest(t, command, []string{"GC_SERVICE_NAME=orphan-reap-test"})
+
+	reapOrphanedServiceProcesses("orphan-reap-test", command)
+
+	if !waitProcessGoneForTest(t, pid, 3*time.Second) {
+		t.Fatalf("orphan %d still alive after reap", pid)
+	}
+}
+
+func TestReapOrphanedServiceProcessesSkipsNonMatches(t *testing.T) {
+	marker := fmt.Sprintf("86341.0%d", os.Getpid())
+	command := []string{"sleep", marker}
+
+	// Same argv, but the environ marker names a different service: another
+	// service's orphan must not be reaped by this service's sweep.
+	otherService := spawnOrphanForTest(t, command, []string{"GC_SERVICE_NAME=some-other-service"})
+	// Same argv, no GC_SERVICE_NAME marker at all: not provably a gc
+	// service spawn, so it must survive.
+	unmarked := spawnOrphanForTest(t, command, nil)
+	// Matching argv and marker but still parented to this test process:
+	// a live supervised child, not an orphan.
+	supervised := exec.Command(command[0], command[1:]...)
+	supervised.Env = append(os.Environ(), "GC_SERVICE_NAME=orphan-reap-test")
+	if err := supervised.Start(); err != nil {
+		t.Fatalf("start supervised child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = supervised.Process.Kill()
+		_ = supervised.Wait()
+	})
+	// Orphan with the right marker but a different argv.
+	differentArgv := spawnOrphanForTest(t, []string{"sleep", marker, "0"}, []string{"GC_SERVICE_NAME=orphan-reap-test"})
+
+	reapOrphanedServiceProcesses("orphan-reap-test", command)
+
+	// Give any wrongly-issued SIGTERM time to land before asserting.
+	time.Sleep(200 * time.Millisecond)
+	for name, pid := range map[string]int{
+		"other-service orphan":  otherService,
+		"unmarked process":      unmarked,
+		"supervised child":      supervised.Process.Pid,
+		"different-argv orphan": differentArgv,
+	} {
+		if !processAliveForTest(pid) {
+			t.Errorf("%s (pid %d) was killed; reap matched too broadly", name, pid)
+		}
+	}
+}
+
+// TestProxyProcessStartReapsOrphanedDuplicates verifies the spawn-path
+// wiring: before a proxy_process child is spawned, survivors of a previous
+// supervisor hard exit running the same service command are terminated so
+// duplicates never accumulate (ga-mukg0s; ~39 observed in production).
+func TestProxyProcessStartReapsOrphanedDuplicates(t *testing.T) {
+	t.Setenv("GC_SERVICE_HELPER", "1")
+	setHelperPassthrough(t)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("Executable: %v", err)
+	}
+	command := []string{exe, "-test.run=^TestProxyProcessHelper$", "--"}
+
+	// The orphan is a literal leftover service instance: same binary, same
+	// argv, GC_SERVICE_NAME marker in its environment, serving on a stale
+	// socket, re-parented to init.
+	orphanDir, err := os.MkdirTemp("", "gcorph")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(orphanDir) })
+	orphanSocket := orphanDir + "/o.sock"
+	orphanPID := spawnOrphanForTest(t, command, []string{
+		"GC_SERVICE_HELPER=1",
+		"GC_SERVICE_NAME=bridge",
+		"GC_SERVICE_SOCKET=" + orphanSocket,
+	})
+	// Wait until the orphan is serving so it provably lingers on its own.
+	dialDeadline := time.Now().Add(5 * time.Second)
+	for {
+		if conn, err := net.DialTimeout("unix", orphanSocket, 100*time.Millisecond); err == nil {
+			_ = conn.Close()
+			break
+		}
+		if time.Now().After(dialDeadline) {
+			t.Fatalf("orphan helper (pid %d) never started serving", orphanPID)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	rt := &testRuntime{
+		cityPath: t.TempDir(),
+		cityName: "test-city",
+		cfg: &config.City{
+			Services: []config.Service{{
+				Name: "bridge",
+				Kind: "proxy_process",
+				Process: config.ServiceProcessConfig{
+					Command:    command,
+					HealthPath: "/healthz",
+				},
+			}},
+		},
+		sp:    runtime.NewFake(),
+		store: beads.NewMemStore(),
+	}
+	mgr := NewManager(rt)
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup
+
+	if !waitProcessGoneForTest(t, orphanPID, 5*time.Second) {
+		t.Fatalf("orphaned duplicate (pid %d) still alive after service start", orphanPID)
+	}
+	status, ok := mgr.Get("bridge")
+	if !ok {
+		t.Fatal("service status missing")
+	}
+	if status.LocalState != "ready" {
+		t.Fatalf("LocalState = %q, want ready (reason=%q)", status.LocalState, status.Reason)
+	}
+}

--- a/internal/workspacesvc/orphan_reap_test.go
+++ b/internal/workspacesvc/orphan_reap_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -13,16 +14,33 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/pidutil"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
+
+// requireProcFS skips tests that depend on Linux /proc semantics, mirroring
+// the production sweep's silent no-op on hosts without /proc (such as the
+// macOS `make test` lane).
+func requireProcFS(t *testing.T) {
+	t.Helper()
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("no /proc on this host; orphan reaping is a no-op")
+	}
+}
 
 // spawnOrphanForTest spawns argv detached through an intermediate shell so
 // the child re-parents to init (ppid 1), simulating a service process that
 // survived a supervisor hard exit. extraEnv entries are appended to the
-// orphan's environment. Skips the test on hosts where a child-subreaper
-// intercepts re-parenting, since the production filter requires ppid 1.
+// orphan's environment. It returns only once the orphan's
+// /proc/<pid>/cmdline reads as argv: right after spawn the exec transition
+// can transiently expose an empty or stale command line, which would make
+// identity matching flaky for callers asserting on a live match. Skips the
+// test on hosts without /proc and on hosts where a child-subreaper
+// intercepts re-parenting, since the production filter requires ppid 1 read
+// from /proc.
 func spawnOrphanForTest(t *testing.T, argv []string, extraEnv []string) int {
 	t.Helper()
+	requireProcFS(t)
 	args := append([]string{"-c", `"$@" >/dev/null 2>&1 & echo $!`, "gc-orphan-spawner"}, argv...)
 	cmd := exec.Command("sh", args...)
 	cmd.Env = append(os.Environ(), extraEnv...)
@@ -43,10 +61,23 @@ func spawnOrphanForTest(t *testing.T, argv []string, extraEnv []string) int {
 			t.Fatalf("orphan %d exited before re-parenting: %v", pid, err)
 		}
 		if ppid == 1 {
-			return pid
+			break
 		}
 		if time.Now().After(deadline) {
 			t.Skipf("orphan %d re-parented to %d, not init; host has a child subreaper", pid, ppid)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	want := pidutil.NormalizeArgv(argv)
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		got, err := pidutil.Cmdline(pid)
+		if err == nil && argvEquals(got, want) {
+			return pid
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("orphan %d cmdline never became %q (last read %q, err %v)", pid, want, got, err)
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
@@ -83,10 +114,14 @@ func waitProcessGoneForTest(t *testing.T, pid int, timeout time.Duration) bool {
 
 func TestReapOrphanedServiceProcessesKillsPPID1CommandMatch(t *testing.T) {
 	marker := fmt.Sprintf("86340.0%d", os.Getpid())
+	stateRoot := t.TempDir()
 	command := []string{"sleep", marker}
-	pid := spawnOrphanForTest(t, command, []string{"GC_SERVICE_NAME=orphan-reap-test"})
+	pid := spawnOrphanForTest(t, command, []string{
+		"GC_SERVICE_NAME=orphan-reap-test",
+		"GC_SERVICE_STATE_ROOT=" + stateRoot,
+	})
 
-	reapOrphanedServiceProcesses("orphan-reap-test", command)
+	reapOrphanedServiceProcesses(newOrphanIdentity("orphan-reap-test", stateRoot, command))
 
 	if !waitProcessGoneForTest(t, pid, 3*time.Second) {
 		t.Fatalf("orphan %d still alive after reap", pid)
@@ -95,18 +130,34 @@ func TestReapOrphanedServiceProcessesKillsPPID1CommandMatch(t *testing.T) {
 
 func TestReapOrphanedServiceProcessesSkipsNonMatches(t *testing.T) {
 	marker := fmt.Sprintf("86341.0%d", os.Getpid())
+	stateRoot := t.TempDir()
 	command := []string{"sleep", marker}
 
-	// Same argv, but the environ marker names a different service: another
-	// service's orphan must not be reaped by this service's sweep.
-	otherService := spawnOrphanForTest(t, command, []string{"GC_SERVICE_NAME=some-other-service"})
-	// Same argv, no GC_SERVICE_NAME marker at all: not provably a gc
-	// service spawn, so it must survive.
+	// Same argv and state root, but the environ marker names a different
+	// service: another service's orphan must not be reaped by this
+	// service's sweep.
+	otherService := spawnOrphanForTest(t, command, []string{
+		"GC_SERVICE_NAME=some-other-service",
+		"GC_SERVICE_STATE_ROOT=" + stateRoot,
+	})
+	// Same argv, no gc markers at all: not provably a gc service spawn, so
+	// it must survive.
 	unmarked := spawnOrphanForTest(t, command, nil)
-	// Matching argv and marker but still parented to this test process:
+	// Same argv and service name but a different state root: a sibling
+	// city's orphan of the same service (same name, same command, same
+	// uid) may still be serving that city and must never be reaped by
+	// this city's sweep.
+	siblingCity := spawnOrphanForTest(t, command, []string{
+		"GC_SERVICE_NAME=orphan-reap-test",
+		"GC_SERVICE_STATE_ROOT=" + stateRoot + "-other-city",
+	})
+	// Matching argv and markers but still parented to this test process:
 	// a live supervised child, not an orphan.
 	supervised := exec.Command(command[0], command[1:]...)
-	supervised.Env = append(os.Environ(), "GC_SERVICE_NAME=orphan-reap-test")
+	supervised.Env = append(os.Environ(),
+		"GC_SERVICE_NAME=orphan-reap-test",
+		"GC_SERVICE_STATE_ROOT="+stateRoot,
+	)
 	if err := supervised.Start(); err != nil {
 		t.Fatalf("start supervised child: %v", err)
 	}
@@ -114,22 +165,131 @@ func TestReapOrphanedServiceProcessesSkipsNonMatches(t *testing.T) {
 		_ = supervised.Process.Kill()
 		_ = supervised.Wait()
 	})
-	// Orphan with the right marker but a different argv.
-	differentArgv := spawnOrphanForTest(t, []string{"sleep", marker, "0"}, []string{"GC_SERVICE_NAME=orphan-reap-test"})
+	// Orphan with the right markers but a different argv.
+	differentArgv := spawnOrphanForTest(t, []string{"sleep", marker, "0"}, []string{
+		"GC_SERVICE_NAME=orphan-reap-test",
+		"GC_SERVICE_STATE_ROOT=" + stateRoot,
+	})
 
-	reapOrphanedServiceProcesses("orphan-reap-test", command)
+	reapOrphanedServiceProcesses(newOrphanIdentity("orphan-reap-test", stateRoot, command))
 
 	// Give any wrongly-issued SIGTERM time to land before asserting.
 	time.Sleep(200 * time.Millisecond)
 	for name, pid := range map[string]int{
 		"other-service orphan":  otherService,
 		"unmarked process":      unmarked,
+		"sibling-city orphan":   siblingCity,
 		"supervised child":      supervised.Process.Pid,
 		"different-argv orphan": differentArgv,
 	} {
 		if !processAliveForTest(pid) {
 			t.Errorf("%s (pid %d) was killed; reap matched too broadly", name, pid)
 		}
+	}
+}
+
+// TestReapOrphanedServiceProcessesMatchesWhitespaceOnlyCommandArgs pins the
+// configured-command normalization: a service command containing an
+// interior whitespace-only argument must still match — and reap — its own
+// orphans, because pidutil.Cmdline drops such arguments from the process
+// side and newOrphanIdentity applies the same rule to the configured side.
+func TestReapOrphanedServiceProcessesMatchesWhitespaceOnlyCommandArgs(t *testing.T) {
+	marker := fmt.Sprintf("86344.0%d", os.Getpid())
+	stateRoot := t.TempDir()
+	// The two-command script keeps the shell wrapper alive (no single-exec
+	// optimization) so its argv — including the whitespace-only positional
+	// argument — stays visible in /proc; marker makes the argv unique.
+	command := []string{"sh", "-c", "sleep 60; : " + marker, "gc-ws-arg", " "}
+	pid := spawnOrphanForTest(t, command, []string{
+		"GC_SERVICE_NAME=orphan-reap-test",
+		"GC_SERVICE_STATE_ROOT=" + stateRoot,
+	})
+
+	reapOrphanedServiceProcesses(newOrphanIdentity("orphan-reap-test", stateRoot, command))
+
+	if !waitProcessGoneForTest(t, pid, 3*time.Second) {
+		t.Fatalf("orphan %d with whitespace-only command argument survived reap", pid)
+	}
+}
+
+// TestFindOrphanedServiceProcessesSkipsWhenSweeperIsInit covers the pid-1
+// guard: when the sweeping process is itself init (gc as a container
+// entrypoint), ppid 1 marks live supervised children rather than orphans, so
+// the sweep must find nothing instead of matching healthy processes.
+func TestFindOrphanedServiceProcessesSkipsWhenSweeperIsInit(t *testing.T) {
+	marker := fmt.Sprintf("86342.0%d", os.Getpid())
+	stateRoot := t.TempDir()
+	command := []string{"sleep", marker}
+	id := newOrphanIdentity("orphan-reap-test", stateRoot, command)
+	pid := spawnOrphanForTest(t, command, []string{
+		"GC_SERVICE_NAME=orphan-reap-test",
+		"GC_SERVICE_STATE_ROOT=" + stateRoot,
+	})
+
+	// Sanity: a normal (non-init) sweeper sees the seeded orphan.
+	found := false
+	for _, got := range findOrphanedServiceProcessesFrom(os.Getpid(), id) {
+		if got == pid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("normal sweep did not find seeded orphan %d", pid)
+	}
+
+	if got := findOrphanedServiceProcessesFrom(1, id); len(got) != 0 {
+		t.Fatalf("pid-1 sweep returned %v, want none", got)
+	}
+	if !processAliveForTest(pid) {
+		t.Fatalf("orphan %d died during find-only sweeps", pid)
+	}
+}
+
+// TestLiveMatchingOrphansDropsIdentityMismatch covers the escalation-wait
+// identity re-check: a pid that no longer satisfies the full orphan
+// identity — recycled to a different command, claimed by a different
+// service, or owned by a different city's state root — must be dropped from
+// the kill list rather than retained for SIGKILL, while a pid that still
+// matches is kept. spawnOrphanForTest returns only once the orphan's
+// command line is visible in /proc, so the keep case cannot race the exec
+// transition.
+func TestLiveMatchingOrphansDropsIdentityMismatch(t *testing.T) {
+	marker := fmt.Sprintf("86343.0%d", os.Getpid())
+	stateRoot := t.TempDir()
+	command := []string{"sleep", marker}
+	pid := spawnOrphanForTest(t, command, []string{
+		"GC_SERVICE_NAME=orphan-reap-test",
+		"GC_SERVICE_STATE_ROOT=" + stateRoot,
+	})
+
+	for name, id := range map[string]orphanIdentity{
+		"command mismatch":    newOrphanIdentity("orphan-reap-test", stateRoot, []string{"sleep", "not-" + marker}),
+		"service mismatch":    newOrphanIdentity("some-other-service", stateRoot, command),
+		"state-root mismatch": newOrphanIdentity("orphan-reap-test", stateRoot+"-other-city", command),
+	} {
+		if got := liveMatchingOrphans([]int{pid}, id); len(got) != 0 {
+			t.Errorf("%s: liveMatchingOrphans kept pid %d: %v", name, pid, got)
+		}
+	}
+
+	if got := liveMatchingOrphans([]int{pid}, newOrphanIdentity("orphan-reap-test", stateRoot, command)); len(got) != 1 {
+		t.Fatalf("liveMatchingOrphans dropped live matching pid %d: %v", pid, got)
+	}
+}
+
+// TestUnsafeSignalTarget covers the refusal guard shared with
+// internal/processgroup: init, nonpositive pids (kill(2) broadcast and
+// current-group semantics), and the sweeper's own process group must never
+// be signaled.
+func TestUnsafeSignalTarget(t *testing.T) {
+	for _, pid := range []int{-1, 0, 1, syscall.Getpgrp()} {
+		if !unsafeSignalTarget(pid) {
+			t.Errorf("unsafeSignalTarget(%d) = false, want true", pid)
+		}
+	}
+	if pid := syscall.Getpgrp() + 1; unsafeSignalTarget(pid) {
+		t.Errorf("unsafeSignalTarget(%d) = true for an ordinary pid, want false", pid)
 	}
 }
 
@@ -146,9 +306,26 @@ func TestProxyProcessStartReapsOrphanedDuplicates(t *testing.T) {
 	}
 	command := []string{exe, "-test.run=^TestProxyProcessHelper$", "--"}
 
+	cityPath := t.TempDir()
+	svc := config.Service{
+		Name: "bridge",
+		Kind: "proxy_process",
+		Process: config.ServiceProcessConfig{
+			Command:    command,
+			HealthPath: "/healthz",
+		},
+	}
+	// The orphan's state root must be the same instance-derived path the
+	// manager will compute, or the ownership-scoped sweep would (correctly)
+	// skip it as another city's process.
+	absStateRoot := svc.StateRootOrDefault()
+	if !filepath.IsAbs(absStateRoot) {
+		absStateRoot = filepath.Join(cityPath, absStateRoot)
+	}
+
 	// The orphan is a literal leftover service instance: same binary, same
-	// argv, GC_SERVICE_NAME marker in its environment, serving on a stale
-	// socket, re-parented to init.
+	// argv, service-name and state-root markers in its environment, serving
+	// on a stale socket, re-parented to init.
 	orphanDir, err := os.MkdirTemp("", "gcorph")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
@@ -158,6 +335,7 @@ func TestProxyProcessStartReapsOrphanedDuplicates(t *testing.T) {
 	orphanPID := spawnOrphanForTest(t, command, []string{
 		"GC_SERVICE_HELPER=1",
 		"GC_SERVICE_NAME=bridge",
+		"GC_SERVICE_STATE_ROOT=" + absStateRoot,
 		"GC_SERVICE_SOCKET=" + orphanSocket,
 	})
 	// Wait until the orphan is serving so it provably lingers on its own.
@@ -174,17 +352,10 @@ func TestProxyProcessStartReapsOrphanedDuplicates(t *testing.T) {
 	}
 
 	rt := &testRuntime{
-		cityPath: t.TempDir(),
+		cityPath: cityPath,
 		cityName: "test-city",
 		cfg: &config.City{
-			Services: []config.Service{{
-				Name: "bridge",
-				Kind: "proxy_process",
-				Process: config.ServiceProcessConfig{
-					Command:    command,
-					HealthPath: "/healthz",
-				},
-			}},
+			Services: []config.Service{svc},
 		},
 		sp:    runtime.NewFake(),
 		store: beads.NewMemStore(),

--- a/internal/workspacesvc/proxy_process.go
+++ b/internal/workspacesvc/proxy_process.go
@@ -192,8 +192,9 @@ func (p *proxyProcessInstance) Close() error {
 func (p *proxyProcessInstance) start(now time.Time) error {
 	// Survivors of a previous supervisor hard exit keep running re-parented
 	// to init; spawning next to them accumulates duplicates (ga-mukg0s).
-	// Best-effort sweep before every spawn; see orphan_reap.go.
-	reapOrphanedServiceProcesses(p.svc.Name, p.svc.Process.Command)
+	// Best-effort sweep before every spawn, scoped to this instance's state
+	// root so sibling cities' orphans are untouched; see orphan_reap.go.
+	reapOrphanedServiceProcesses(newOrphanIdentity(p.svc.Name, p.absStateRoot, p.svc.Process.Command))
 
 	logFile, err := os.OpenFile(filepath.Join(p.absStateRoot, "logs", "service.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640)
 	if err != nil {

--- a/internal/workspacesvc/proxy_process.go
+++ b/internal/workspacesvc/proxy_process.go
@@ -190,6 +190,11 @@ func (p *proxyProcessInstance) Close() error {
 }
 
 func (p *proxyProcessInstance) start(now time.Time) error {
+	// Survivors of a previous supervisor hard exit keep running re-parented
+	// to init; spawning next to them accumulates duplicates (ga-mukg0s).
+	// Best-effort sweep before every spawn; see orphan_reap.go.
+	reapOrphanedServiceProcesses(p.svc.Name, p.svc.Process.Command)
+
 	logFile, err := os.OpenFile(filepath.Join(p.absStateRoot, "logs", "service.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640)
 	if err != nil {
 		return fmt.Errorf("open service log: %w", err)


### PR DESCRIPTION
## Problem

When the supervisor hard-exits, its `proxy_process` children re-parent to init (ppid 1) and keep running. Every subsequent supervisor start spawns a fresh duplicate next to them, so duplicates accumulate without bound — production observed ~39 stale discord/github-intake processes (ga-mukg0s). The ansible `gc-orphan-sweep.sh` ExecStartPre is a stopgap that only runs at unit start, not on supervisor-internal restarts.

## Fix

Before each `proxy_process` spawn (`proxyProcessInstance.start`), sweep the live process table — no pid or status files — and terminate survivors of previous hard exits. A process is reaped only when all three hold:

1. it has re-parented to init (ppid 1), so no live supervisor owns it;
2. its `/proc/<pid>/cmdline` is exactly the service's configured command; and
3. its environment carries `GC_SERVICE_NAME=<service>` — the marker the spawn path itself sets — proving a gc supervisor spawned it as this service rather than a coincidental same-argv process. The environ read is only possible for same-uid processes, which doubles as an ownership check.

Termination is SIGTERM to the process group (the spawn path uses `Setpgid`), a bounded wait, then SIGKILL for stragglers. The sweep is best-effort: scan or signal failures are logged and never block the spawn; hosts without `/proc` no-op.

## Testing

TDD, failing-first proven both directions:

- `TestProxyProcessStartReapsOrphanedDuplicates` (spawn-path wiring): with the one-line `start()` hook stashed, fails with `orphaned duplicate (pid N) still alive after service start`; passes with it.
- `TestReapOrphanedServiceProcessesKillsPPID1CommandMatch`: with the reap logic neutered, fails with `orphan N still alive after reap`; passes with it.
- `TestReapOrphanedServiceProcessesSkipsNonMatches`: negative coverage — other-service orphans, unmarked same-argv processes, supervised (non-orphan) children, and different-argv orphans all survive the sweep.
- `go build ./...` and `go vet ./...` clean; full `internal/workspacesvc` package passes; full `make test` passes in the isolation sandbox.

Bead: ga-mukg0s

🤖 Generated with [Claude Code](https://claude.com/claude-code)