### PR TITLE
feat(tmux): wrap pane commands in a systemd user scope via GC_AGENT_SLICE (ga-ez4kyc)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -166,7 +166,8 @@
           "schema/index",
           "reference/system-packs",
           "reference/exec-session-provider",
-          "reference/exec-beads-provider"
+          "reference/exec-beads-provider",
+          "reference/tmux-agent-slice"
         ]
       },
       {

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -16,6 +16,7 @@ description: CLI, config, formula, and provider reference material.
 - [Formula Files](/reference/formula)
 - [Exec Session Provider](/reference/exec-session-provider)
 - [Exec Beads Provider](/reference/exec-beads-provider)
+- [Tmux Agent Slice (GC_AGENT_SLICE)](/reference/tmux-agent-slice)
 
 The config and CLI references are generated from code and should be regenerated
 when the schema or Cobra surface changes. The API and `gc events` contracts are

--- a/docs/reference/tmux-agent-slice.md
+++ b/docs/reference/tmux-agent-slice.md
@@ -1,0 +1,100 @@
+---
+title: "Tmux Agent Slice (GC_AGENT_SLICE)"
+---
+
+Setting the `GC_AGENT_SLICE` environment variable to a systemd user slice
+(for example `gascity-agents.slice`) makes the tmux session provider wrap
+every pane's initial command in a transient systemd user scope:
+
+```
+systemd-run --user --scope --slice=<slice> --collect --quiet -- sh -c '<command>'
+```
+
+Default-off: when the variable is unset or empty, pane commands run
+unwrapped exactly as before.
+
+## Why
+
+systemd-enabled tmux builds (stock Ubuntu) move every pane into a transient
+`tmux-spawn-*.scope` under the default user slice, so agent processes escape
+whatever slice the tmux server itself runs in. Wrapping the pane command
+re-parents the agent's process tree into a dedicated user slice where
+resource weights (`CPUWeight`, `MemoryHigh`, ...) can be applied to all
+agents collectively.
+
+## Scope and activation
+
+- **Tmux provider only.** The subprocess and exec session providers spawn
+  children of the gc process directly, so those already inherit gc's own
+  cgroup; only tmux panes escape and need re-parenting.
+- **Env var, not `city.toml`.** This is a host-level deployment knob, not
+  per-city configuration: it is set by whatever supervises the gc process
+  (a systemd unit, shell profile, or CI environment) and applies to every
+  city served by that process. The slice it names is host systemd state
+  that must exist on the user manager, outside any city's config layering.
+- **Keep the value stable for the process lifetime.** The availability
+  probe runs at most once per tmux provider instance, for the first
+  non-empty value that instance sees; a value changed while gc is running
+  is embedded in later wrapper commands without being re-probed. gc
+  constructs provider instances both long-lived (the controller's
+  reconcile loop) and fresh per operation (template session starts), so a
+  changed or repaired slice takes effect on some spawn paths and not
+  others. Restart gc to converge every path on one verdict.
+
+## Probe and fallback
+
+Before its first wrapped spawn, each tmux provider instance probes
+`systemd-run --user --scope --slice=<slice> --collect --quiet -- true`
+(bounded at 5 seconds). If the probe fails — no `systemd-run` binary, no
+reachable user manager, or an invalid slice — that instance logs one
+warning and every pane command it spawns runs unwrapped:
+
+```
+tmux agent slice: GC_AGENT_SLICE="..." set but transient user scopes are unavailable; pane commands run unwrapped: ...
+```
+
+Because operations like template session starts construct fresh provider
+instances, a persistently broken host repeats this warning as new
+instances probe, while long-lived instances (the controller's reconcile
+loop) keep their first verdict until restart.
+
+The probe runs in the gc process's environment, while pane commands execute
+with the tmux server's environment. gc normally spawns the tmux server
+itself, so the two match; if you point gc at a pre-existing tmux server
+whose global environment lacks a reachable user bus (`XDG_RUNTIME_DIR`,
+`DBUS_SESSION_BUS_ADDRESS`), wrapped spawns can fail even after a
+successful probe. The systemd-run error is visible in the dead pane's
+captured output in startup diagnostics.
+
+## User-manager lifecycle coupling
+
+Wrapped agents live under the user's `user@<uid>.service` manager. Ending
+that user session — `loginctl terminate-user`, or logging out without
+lingering — kills every agent scope. For unattended hosts, enable
+lingering so the user manager (and the agents) survive logout:
+
+```bash
+loginctl enable-linger <user>
+```
+
+## Resource attribution
+
+Scopes are created with systemd auto-generated names (`run-rNNNNNNNN.scope`),
+so `systemd-cgls --user` shows anonymous units under the slice rather than
+per-agent names. To attribute a scope to an agent session, list the
+processes inside it:
+
+```bash
+systemd-cgls --user --unit <slice>
+ps -o pid,args --forest -g <pid-from-cgls>
+```
+
+The agent command line (and its tmux session name, via `tmux list-panes -a
+-F '#{session_name} #{pane_pid}'`) identifies the owner.
+
+## Detection
+
+A wrapped pane reports `pane_current_command = "systemd-run"` instead of
+the agent process name. All gc liveness, zombie-cleanup, and pane-finding
+paths handle this by walking pane process descendants, so health patrol
+and nudge targeting behave the same with wrapping on or off.

--- a/internal/runtime/tmux/agent_slice.go
+++ b/internal/runtime/tmux/agent_slice.go
@@ -1,0 +1,106 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/shellquote"
+)
+
+// AgentSliceEnv names the environment variable that, when set to a systemd
+// user slice (e.g. "gascity-agents.slice"), makes the tmux provider wrap
+// every pane's initial command in a transient systemd user scope:
+//
+//	systemd-run --user --scope --slice=<slice> --collect --quiet -- sh -c '<command>'
+//
+// Rationale: systemd-enabled tmux builds (stock Ubuntu) move every pane into
+// a transient tmux-spawn-*.scope under the default user slice, so agent
+// processes escape whatever slice the tmux server itself runs in. Wrapping
+// the pane command re-parents the agent's process tree into a dedicated user
+// slice where resource weights can be applied. Default-off: when unset, pane
+// commands run unwrapped exactly as before.
+const AgentSliceEnv = "GC_AGENT_SLICE"
+
+// agentSliceProbeTimeout bounds the one-time systemd-run availability probe.
+// Test-overridable.
+var agentSliceProbeTimeout = 5 * time.Second
+
+// probeAgentSliceSupport verifies that systemd-run exists and the systemd
+// user manager responds by running a no-op command in a transient scope on
+// the target slice. This exercises the exact mechanism used for pane
+// commands, so success here means pane wrapping will work.
+func probeAgentSliceSupport(slice string) error {
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		return fmt.Errorf("systemd-run not found: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), agentSliceProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "systemd-run",
+		"--user", "--scope", "--slice="+slice, "--collect", "--quiet", "--", "true")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return fmt.Errorf("systemd user manager probe failed: %w: %s", err, msg)
+		}
+		return fmt.Errorf("systemd user manager probe failed: %w", err)
+	}
+	return nil
+}
+
+// agentSliceWrapper decides whether pane commands are wrapped in a transient
+// systemd user scope. The availability probe runs at most once per Tmux
+// instance; on failure it warns once and all subsequent commands run
+// unwrapped (graceful fallback).
+type agentSliceWrapper struct {
+	probe func(slice string) error // test seam; nil means probeAgentSliceSupport
+	warn  io.Writer                // test seam; nil means os.Stderr
+	once  sync.Once
+	ok    bool
+}
+
+// wrap returns command wrapped for the given slice, or command unchanged
+// when slice is empty, command is empty, or transient user scopes are
+// unavailable on this host.
+func (w *agentSliceWrapper) wrap(slice, command string) string {
+	if slice == "" || command == "" {
+		return command
+	}
+	w.once.Do(func() {
+		probe := w.probe
+		if probe == nil {
+			probe = probeAgentSliceSupport
+		}
+		if err := probe(slice); err != nil {
+			out := w.warn
+			if out == nil {
+				out = os.Stderr
+			}
+			_, _ = fmt.Fprintf(out, "gc: %s=%q set but transient user scopes are unavailable; pane commands run unwrapped: %v\n",
+				AgentSliceEnv, slice, err)
+			return
+		}
+		w.ok = true
+	})
+	if !w.ok {
+		return command
+	}
+	return shellquote.Join([]string{
+		"systemd-run", "--user", "--scope", "--slice=" + slice,
+		"--collect", "--quiet", "--", "sh", "-c", command,
+	})
+}
+
+// wrapPaneCommand applies the GC_AGENT_SLICE systemd user-scope wrapper to a
+// pane's initial command. See [AgentSliceEnv]. The environment variable is
+// read per call but the availability probe result is cached, so the first
+// non-empty slice value decides whether wrapping is active for this Tmux.
+func (t *Tmux) wrapPaneCommand(command string) string {
+	return t.agentSlice.wrap(os.Getenv(AgentSliceEnv), command)
+}

--- a/internal/runtime/tmux/agent_slice.go
+++ b/internal/runtime/tmux/agent_slice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -31,10 +32,33 @@ const AgentSliceEnv = "GC_AGENT_SLICE"
 // Test-overridable.
 var agentSliceProbeTimeout = 5 * time.Second
 
+// wrapperCommands lists pane-root wrapper binaries produced by pane-command
+// wrapping. A wrapped pane reports the wrapper as pane_current_command for
+// the pane's whole lifetime, so command-wait and detection paths must treat
+// these like shells: the agent is identified through descendant inspection,
+// never by the pane command itself.
+var wrapperCommands = []string{"systemd-run"}
+
+// isWrapperCommand reports whether cmd is a known pane-root wrapper binary
+// (see wrapperCommands).
+func isWrapperCommand(cmd string) bool {
+	for _, w := range wrapperCommands {
+		if cmd == w {
+			return true
+		}
+	}
+	return false
+}
+
 // probeAgentSliceSupport verifies that systemd-run exists and the systemd
 // user manager responds by running a no-op command in a transient scope on
-// the target slice. This exercises the exact mechanism used for pane
-// commands, so success here means pane wrapping will work.
+// the target slice. The probe runs in the gc process's environment, while
+// pane commands execute with the tmux server's environment. gc normally
+// spawns the tmux server itself, so the server inherits gc's environment
+// and the probe is representative — but a pre-existing server whose global
+// environment lacks a reachable user bus (XDG_RUNTIME_DIR,
+// DBUS_SESSION_BUS_ADDRESS) can still fail wrapped spawns after a
+// successful probe here.
 func probeAgentSliceSupport(slice string) error {
 	if _, err := exec.LookPath("systemd-run"); err != nil {
 		return fmt.Errorf("systemd-run not found: %w", err)
@@ -60,7 +84,7 @@ func probeAgentSliceSupport(slice string) error {
 // unwrapped (graceful fallback).
 type agentSliceWrapper struct {
 	probe func(slice string) error // test seam; nil means probeAgentSliceSupport
-	warn  io.Writer                // test seam; nil means os.Stderr
+	warn  io.Writer                // test seam; nil means the standard logger
 	once  sync.Once
 	ok    bool
 }
@@ -78,12 +102,13 @@ func (w *agentSliceWrapper) wrap(slice, command string) string {
 			probe = probeAgentSliceSupport
 		}
 		if err := probe(slice); err != nil {
-			out := w.warn
-			if out == nil {
-				out = os.Stderr
-			}
-			_, _ = fmt.Fprintf(out, "gc: %s=%q set but transient user scopes are unavailable; pane commands run unwrapped: %v\n",
+			msg := fmt.Sprintf("%s=%q set but transient user scopes are unavailable; pane commands run unwrapped: %v",
 				AgentSliceEnv, slice, err)
+			if w.warn != nil {
+				_, _ = fmt.Fprintln(w.warn, "gc: "+msg)
+			} else {
+				log.Printf("tmux agent slice: %s", msg)
+			}
 			return
 		}
 		w.ok = true

--- a/internal/runtime/tmux/agent_slice_test.go
+++ b/internal/runtime/tmux/agent_slice_test.go
@@ -1,9 +1,15 @@
 package tmux
 
 import (
+	"context"
 	"errors"
+	"os"
+	osexec "os/exec"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newSliceTestTmux returns a Tmux backed by a fakeExecutor with the agent
@@ -118,10 +124,20 @@ func TestAgentSliceProbeFailureFallsBackPlainWithWarning(t *testing.T) {
 		t.Fatalf("NewSessionWithCommand (second): %v", err)
 	}
 
-	for i, call := range exec.calls[:2] {
-		if call[len(call)-1] != "claude" && call[0] == "new-session" {
-			t.Fatalf("call %d pane command = %q, want plain %q", i, call[len(call)-1], "claude")
+	// Recorded argv carries global flags first (-u, optional -L <socket>);
+	// scan for the new-session token rather than relying on position.
+	newSessionCalls := 0
+	for i, call := range exec.calls {
+		if !slices.Contains(call, "new-session") {
+			continue
 		}
+		newSessionCalls++
+		if got := call[len(call)-1]; got != "claude" {
+			t.Fatalf("new-session call %d pane command = %q, want plain %q", i, got, "claude")
+		}
+	}
+	if newSessionCalls != 2 {
+		t.Fatalf("recorded %d new-session calls, want 2 (assertion must not pass vacuously)", newSessionCalls)
 	}
 	if probeCalls != 1 {
 		t.Fatalf("probe called %d times, want 1 (result must be cached)", probeCalls)
@@ -162,4 +178,145 @@ func TestAgentSliceQuotesEmbeddedSingleQuotes(t *testing.T) {
 	if got != want {
 		t.Fatalf("pane command = %q, want %q", got, want)
 	}
+}
+
+// TestFindAgentPane_WrappedPane pins the detection contract for panes whose
+// root command is a wrapper such as systemd-run (GC_AGENT_SLICE): none of the
+// direct-name, shell-descendant, or version-as-argv[0] checks match the
+// wrapper process, so FindAgentPane must identify the agent through the
+// unconditional descendant walk, mirroring IsRuntimeRunning.
+func TestFindAgentPane_WrappedPane(t *testing.T) {
+	// Real process tree: the test binary spawns "sleep 60", standing in for
+	// systemd-run spawning the agent. The fake executor reports the pane
+	// command as "systemd-run" with the test binary's PID, so only the
+	// descendant fallback can identify the agent pane.
+	agent := osexec.Command("sleep", "60")
+	if err := agent.Start(); err != nil {
+		t.Fatalf("starting agent stand-in: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = agent.Process.Kill()
+		_ = agent.Wait()
+	})
+
+	panePID := strconv.Itoa(os.Getpid())
+	deadline := time.Now().Add(5 * time.Second)
+	for !hasDescendantWithNames(panePID, []string{"sleep"}, 0) {
+		if time.Now().After(deadline) {
+			t.Fatal("sleep child never became visible to the process-tree walk")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	exec := &fakeExecutor{outs: []string{
+		// list-panes -s: a user's split pane plus the wrapped agent pane.
+		// The bogus PID has no live process, so the first pane cannot match.
+		"%1\tvim\t999999999\n%2\tsystemd-run\t" + panePID,
+		// show-environment GT_PROCESS_NAMES
+		"GT_PROCESS_NAMES=sleep",
+	}}
+	tm := NewTmux()
+	tm.exec = exec
+
+	paneID, err := tm.FindAgentPane("gc-test-wrapped")
+	if err != nil {
+		t.Fatalf("FindAgentPane: %v", err)
+	}
+	if paneID != "%2" {
+		t.Fatalf("FindAgentPane = %q, want %q (wrapped agent pane via descendant fallback)", paneID, "%2")
+	}
+}
+
+// wrappedWaitExecutor simulates a pane whose root command is the systemd-run
+// wrapper for the pane's whole lifetime. The agent descendant becomes visible
+// to the process-tree walk only after livePIDAfter pane-PID requests: earlier
+// requests return a dead PID with no descendants, modeling the startup window
+// where systemd-run exists but the agent has not exec'd yet.
+type wrappedWaitExecutor struct {
+	deadPID      string
+	livePID      string
+	livePIDAfter int
+	pidRequests  int
+}
+
+func (e *wrappedWaitExecutor) execute(args []string) (string, error) {
+	// args carry global flags first (-u, optional -L <socket>); scan for the
+	// subcommand token.
+	for _, a := range args {
+		switch a {
+		case "display-message":
+			switch args[len(args)-1] {
+			case "#{pane_current_command}":
+				return "systemd-run", nil
+			case "#{pane_pid}":
+				e.pidRequests++
+				if e.pidRequests <= e.livePIDAfter {
+					return e.deadPID, nil
+				}
+				return e.livePID, nil
+			}
+			return "", nil
+		case "show-environment":
+			return "GT_PROCESS_NAMES=sleep", nil
+		}
+	}
+	return "", nil
+}
+
+func (e *wrappedWaitExecutor) executeCtx(_ context.Context, args []string) (string, error) {
+	return e.execute(args)
+}
+
+// TestWaitForCommand_WrappedPane pins the startup-wait contract for wrapper
+// roots (systemd-run under GC_AGENT_SLICE): the pane reports the wrapper as
+// pane_current_command for its whole lifetime, so WaitForCommand must not
+// treat first sight of the wrapper as "agent command appeared". It must keep
+// polling until the agent is detectable as a pane descendant, and time out
+// when no agent ever appears.
+func TestWaitForCommand_WrappedPane(t *testing.T) {
+	// Real process tree: the test binary spawns "sleep 60" standing in for
+	// the agent, as in TestFindAgentPane_WrappedPane.
+	agent := osexec.Command("sleep", "60")
+	if err := agent.Start(); err != nil {
+		t.Fatalf("starting agent stand-in: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = agent.Process.Kill()
+		_ = agent.Wait()
+	})
+
+	livePID := strconv.Itoa(os.Getpid())
+	deadline := time.Now().Add(5 * time.Second)
+	for !hasDescendantWithNames(livePID, []string{"sleep"}, 0) {
+		if time.Now().After(deadline) {
+			t.Fatal("sleep child never became visible to the process-tree walk")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Run("times out when no agent descendant ever appears", func(t *testing.T) {
+		exec := &wrappedWaitExecutor{deadPID: "999999999", livePID: "999999999"}
+		tm := NewTmux()
+		tm.exec = exec
+
+		err := tm.WaitForCommand(context.Background(), "gc-test-wrapped-wait", supportedShells, 250*time.Millisecond)
+		if err == nil {
+			t.Fatal("WaitForCommand returned nil on wrapper sighting; want timeout while no agent descendant exists")
+		}
+	})
+
+	t.Run("returns once the agent descendant appears", func(t *testing.T) {
+		// The first two liveness probes see a dead pane PID (agent not yet
+		// exec'd inside the scope); later probes see the live tree.
+		exec := &wrappedWaitExecutor{deadPID: "999999999", livePID: livePID, livePIDAfter: 2}
+		tm := NewTmux()
+		tm.exec = exec
+
+		if err := tm.WaitForCommand(context.Background(), "gc-test-wrapped-wait", supportedShells, 10*time.Second); err != nil {
+			t.Fatalf("WaitForCommand: %v (agent descendant was live)", err)
+		}
+		if exec.pidRequests < 3 {
+			t.Fatalf("pane PID requested %d times, want >= 3 (wait must keep polling until the descendant appears)", exec.pidRequests)
+		}
+	})
 }

--- a/internal/runtime/tmux/agent_slice_test.go
+++ b/internal/runtime/tmux/agent_slice_test.go
@@ -1,0 +1,165 @@
+package tmux
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// newSliceTestTmux returns a Tmux backed by a fakeExecutor with the agent
+// slice probe stubbed to succeed, plus the executor for argv inspection.
+func newSliceTestTmux(t *testing.T) (*Tmux, *fakeExecutor) {
+	t.Helper()
+	exec := &fakeExecutor{}
+	tm := NewTmux()
+	tm.exec = exec
+	tm.agentSlice.probe = func(string) error { return nil }
+	tm.agentSlice.warn = &strings.Builder{}
+	return tm, exec
+}
+
+func TestAgentSliceWrapsNewSessionWithCommand(t *testing.T) {
+	t.Setenv(AgentSliceEnv, "gascity-agents.slice")
+	tm, exec := newSliceTestTmux(t)
+
+	if err := tm.NewSessionWithCommand("gc-test-slice", "/work", "exec env GT_ROLE=crew claude"); err != nil {
+		t.Fatalf("NewSessionWithCommand: %v", err)
+	}
+	if len(exec.calls) == 0 {
+		t.Fatal("no tmux calls recorded")
+	}
+	args := exec.calls[0]
+	got := args[len(args)-1]
+	want := "systemd-run --user --scope --slice=gascity-agents.slice --collect --quiet -- sh -c 'exec env GT_ROLE=crew claude'"
+	if got != want {
+		t.Fatalf("pane command = %q, want %q", got, want)
+	}
+}
+
+func TestAgentSliceWrapsNewSessionWithCommandAndEnv(t *testing.T) {
+	t.Setenv(AgentSliceEnv, "gascity-agents.slice")
+	tm, exec := newSliceTestTmux(t)
+
+	env := map[string]string{"LANG": "en_US.UTF-8", "LC_ALL": ""}
+	if err := tm.NewSessionWithCommandAndEnv("gc-test-slice-env", "/work", "claude", env); err != nil {
+		t.Fatalf("NewSessionWithCommandAndEnv: %v", err)
+	}
+	if len(exec.calls) == 0 {
+		t.Fatal("no tmux calls recorded")
+	}
+	args := exec.calls[0]
+	got := args[len(args)-1]
+	// The env -u prefix must end up INSIDE the scope wrapper so the unset
+	// still applies to the agent process.
+	want := "systemd-run --user --scope --slice=gascity-agents.slice --collect --quiet -- sh -c 'env -u LC_ALL claude'"
+	if got != want {
+		t.Fatalf("pane command = %q, want %q", got, want)
+	}
+	// The -e session env flags must survive wrapping.
+	joined := strings.Join(args, "\x00")
+	if !strings.Contains(joined, "\x00-e\x00LANG=en_US.UTF-8\x00") {
+		t.Fatalf("new-session args missing LANG -e flag: %v", args)
+	}
+}
+
+func TestAgentSliceWrapsRespawnPane(t *testing.T) {
+	t.Setenv(AgentSliceEnv, "gascity-agents.slice")
+	tm, exec := newSliceTestTmux(t)
+
+	if err := tm.RespawnPane("%0", "claude --resume"); err != nil {
+		t.Fatalf("RespawnPane: %v", err)
+	}
+	args := exec.calls[0]
+	got := args[len(args)-1]
+	want := "systemd-run --user --scope --slice=gascity-agents.slice --collect --quiet -- sh -c 'claude --resume'"
+	if got != want {
+		t.Fatalf("respawn command = %q, want %q", got, want)
+	}
+
+	if err := tm.RespawnPaneWithWorkDir("%0", "/work", "claude --resume"); err != nil {
+		t.Fatalf("RespawnPaneWithWorkDir: %v", err)
+	}
+	args = exec.calls[1]
+	if got := args[len(args)-1]; got != want {
+		t.Fatalf("respawn-with-workdir command = %q, want %q", got, want)
+	}
+}
+
+func TestAgentSliceUnsetLeavesCommandPlain(t *testing.T) {
+	t.Setenv(AgentSliceEnv, "")
+	tm, exec := newSliceTestTmux(t)
+
+	if err := tm.NewSessionWithCommand("gc-test-plain", "/work", "claude"); err != nil {
+		t.Fatalf("NewSessionWithCommand: %v", err)
+	}
+	args := exec.calls[0]
+	if got := args[len(args)-1]; got != "claude" {
+		t.Fatalf("pane command = %q, want plain %q", got, "claude")
+	}
+}
+
+func TestAgentSliceProbeFailureFallsBackPlainWithWarning(t *testing.T) {
+	t.Setenv(AgentSliceEnv, "gascity-agents.slice")
+	probeCalls := 0
+	exec := &fakeExecutor{}
+	tm := NewTmux()
+	tm.exec = exec
+	var warnings strings.Builder
+	tm.agentSlice.probe = func(string) error {
+		probeCalls++
+		return errors.New("user manager not responding")
+	}
+	tm.agentSlice.warn = &warnings
+
+	if err := tm.NewSessionWithCommand("gc-test-fallback", "/work", "claude"); err != nil {
+		t.Fatalf("NewSessionWithCommand: %v", err)
+	}
+	if err := tm.NewSessionWithCommand("gc-test-fallback2", "/work", "claude"); err != nil {
+		t.Fatalf("NewSessionWithCommand (second): %v", err)
+	}
+
+	for i, call := range exec.calls[:2] {
+		if call[len(call)-1] != "claude" && call[0] == "new-session" {
+			t.Fatalf("call %d pane command = %q, want plain %q", i, call[len(call)-1], "claude")
+		}
+	}
+	if probeCalls != 1 {
+		t.Fatalf("probe called %d times, want 1 (result must be cached)", probeCalls)
+	}
+	if !strings.Contains(warnings.String(), "user manager not responding") {
+		t.Fatalf("warning output missing probe error: %q", warnings.String())
+	}
+	if !strings.Contains(warnings.String(), AgentSliceEnv) {
+		t.Fatalf("warning output missing env var name: %q", warnings.String())
+	}
+}
+
+func TestAgentSliceEmptyCommandNotWrapped(t *testing.T) {
+	t.Setenv(AgentSliceEnv, "gascity-agents.slice")
+	tm, exec := newSliceTestTmux(t)
+
+	// Empty command + env-only session must keep the empty trailing arg so
+	// tmux still starts the default shell.
+	if err := tm.NewSessionWithCommandAndEnv("gc-test-empty", "/work", "", map[string]string{"LANG": "C"}); err != nil {
+		t.Fatalf("NewSessionWithCommandAndEnv: %v", err)
+	}
+	args := exec.calls[0]
+	if got := args[len(args)-1]; got != "" {
+		t.Fatalf("pane command = %q, want empty", got)
+	}
+}
+
+func TestAgentSliceQuotesEmbeddedSingleQuotes(t *testing.T) {
+	t.Setenv(AgentSliceEnv, "gascity-agents.slice")
+	tm, exec := newSliceTestTmux(t)
+
+	if err := tm.NewSessionWithCommand("gc-test-quote", "/work", "claude --msg 'hi there'"); err != nil {
+		t.Fatalf("NewSessionWithCommand: %v", err)
+	}
+	args := exec.calls[0]
+	got := args[len(args)-1]
+	want := `systemd-run --user --scope --slice=gascity-agents.slice --collect --quiet -- sh -c 'claude --msg '\''hi there'\'''`
+	if got != want {
+		t.Fatalf("pane command = %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/tmux/main_test.go
+++ b/internal/runtime/tmux/main_test.go
@@ -1,0 +1,17 @@
+package tmux
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain neutralizes ambient GC_AGENT_SLICE for the whole package. The
+// variable activates real pane-command wrapping inside any test process on
+// hosts that export it, which would break exact-argv and pane-command
+// assertions across both the unit and integration tiers. Tests that exercise
+// wrapping opt back in per-test with t.Setenv. This file is untagged so the
+// neutralization applies to every build of the package.
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv(AgentSliceEnv)
+	os.Exit(m.Run())
+}

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -787,3 +787,19 @@ func TestIsNoServerErrorRecognizesSentinel(t *testing.T) {
 		t.Fatal("isNoServerError(ErrNoServer) = false, want true")
 	}
 }
+
+// TestProcessAliveWrappedPane pins the wrapped-pane liveness contract
+// (GC_AGENT_SLICE): a pane whose root command is systemd-run — not an agent
+// name, a shell, or a known interpreter — still counts as alive when the
+// agent runs as its descendant, via processAlive's unconditional descendant
+// fallback.
+func TestProcessAliveWrappedPane(t *testing.T) {
+	snapshot := newProcessSnapshot([]processRuntimeState{
+		{PID: "100", PPID: "1", Command: "systemd-run", Args: "systemd-run --user --scope --slice=gascity-agents.slice --collect --quiet -- sh -c claude"},
+		{PID: "101", PPID: "100", Command: "claude", Args: "claude"},
+	})
+	pane := paneRuntimeState{Command: "systemd-run", PID: "100"}
+	if !pane.processAlive(processNameSet([]string{"claude"}), snapshot) {
+		t.Fatal("processAlive = false for systemd-run pane with claude child, want true (descendant fallback)")
+	}
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -1864,15 +1864,16 @@ func (t *Tmux) FindAgentPane(session string) (string, error) {
 			}
 		}
 
-		// Shell with agent descendant
-		for _, shell := range supportedShells {
-			if paneCmd == shell && hasDescendantWithNames(panePID, processNames, 0) {
-				return paneID, nil
-			}
-		}
-
 		// Version-as-argv[0] (e.g., "2.1.30") — check real binary name
 		if processMatchesNames(panePID, processNames) {
+			return paneID, nil
+		}
+
+		// Descendant walk: agents under shells ("bash -c 'exec claude'")
+		// or wrapper roots (systemd-run when GC_AGENT_SLICE is set) keep
+		// the shell/wrapper as pane_current_command — same unconditional
+		// descendant fallback as IsRuntimeRunning.
+		if hasDescendantWithNames(panePID, processNames, 0) {
 			return paneID, nil
 		}
 	}
@@ -2496,10 +2497,17 @@ func (t *Tmux) resolveSessionProcessNames(session string) []string {
 // Useful for waiting until a shell has started a new process (e.g., claude).
 // Returns nil when a non-excluded command is detected, or error on timeout.
 //
+// Known pane-root wrappers (see wrapperCommands, e.g. systemd-run under
+// GC_AGENT_SLICE) are treated as excluded regardless of excludeCommands: a
+// wrapped pane reports the wrapper as pane_current_command for the pane's
+// whole lifetime, so first sight of the wrapper does not mean the agent
+// command has appeared.
+//
 // Includes an IsAgentAlive fallback: when the pane command stays as a shell
-// (e.g., "bash"), the agent may be running as a descendant process via a
-// wrapper script (e.g., "bash -c 'exec claude'"). In this case, pane_current_command
-// never changes from "bash", but IsAgentAlive detects the descendant.
+// (e.g., "bash") or a wrapper root, the agent may be running as a descendant
+// process (e.g., "bash -c 'exec claude'", or systemd-run's scope child). In
+// these cases pane_current_command never changes, but IsAgentAlive detects
+// the descendant.
 func (t *Tmux) WaitForCommand(ctx context.Context, session string, excludeCommands []string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -2517,8 +2525,10 @@ func (t *Tmux) WaitForCommand(ctx context.Context, session string, excludeComman
 			}
 			continue
 		}
-		// Check if current command is NOT in the exclude list
-		excluded := false
+		// Check if current command is NOT in the exclude list. Wrapper
+		// roots count as excluded: they hide the agent command for the
+		// pane's lifetime, so they must never satisfy the wait directly.
+		excluded := isWrapperCommand(cmd)
 		for _, exc := range excludeCommands {
 			if cmd == exc {
 				excluded = true
@@ -2528,8 +2538,9 @@ func (t *Tmux) WaitForCommand(ctx context.Context, session string, excludeComman
 		if !excluded {
 			return nil
 		}
-		// Fallback: if pane command is still a shell, check whether the
-		// agent is running as a descendant (handles bash-wrapped agents).
+		// Fallback: the pane command is still a shell or a wrapper root;
+		// check whether the agent is running as a descendant (handles
+		// bash-wrapped agents and systemd-run scope children).
 		if t.IsAgentAlive(session) {
 			return nil
 		}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -226,6 +226,10 @@ type Tmux struct {
 	// (see discountPokeActivity).
 	pokeMu sync.Mutex
 	pokes  map[string]pokeInfo
+
+	// agentSlice wraps pane commands in a transient systemd user scope when
+	// GC_AGENT_SLICE is set (see AgentSliceEnv in agent_slice.go).
+	agentSlice agentSliceWrapper
 }
 
 // pokeInfo records a gc-initiated send-keys ("poke", e.g. a wake or nudge) to a
@@ -403,7 +407,7 @@ func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 		args = append(args, "-c", workDir)
 	}
 	// Add the command as the last argument - tmux runs it as the pane's initial process
-	args = append(args, command)
+	args = append(args, t.wrapPaneCommand(command))
 	_, err := t.run(args...)
 	if err != nil {
 		return err
@@ -463,7 +467,7 @@ func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env ma
 		command = "env" + prefix + " " + command
 	}
 	// Add the command as the last argument
-	args = append(args, command)
+	args = append(args, t.wrapPaneCommand(command))
 	_, err := t.run(args...)
 	if err != nil {
 		return err
@@ -3125,7 +3129,7 @@ func (t *Tmux) SetMailClickBinding(_ string) error {
 // This is used for "hot reload" of agent sessions - instantly restart in place.
 // The pane parameter should be a pane ID (e.g., "%0") or session:window.pane format.
 func (t *Tmux) RespawnPane(pane, command string) error {
-	_, err := t.run("respawn-pane", "-k", "-t", pane, command)
+	_, err := t.run("respawn-pane", "-k", "-t", pane, t.wrapPaneCommand(command))
 	return err
 }
 
@@ -3137,7 +3141,7 @@ func (t *Tmux) RespawnPaneWithWorkDir(pane, workDir, command string) error {
 	if workDir != "" {
 		args = append(args, "-c", workDir)
 	}
-	args = append(args, command)
+	args = append(args, t.wrapPaneCommand(command))
 	_, err := t.run(args...)
 	return err
 }


### PR DESCRIPTION
## Problem

Stock Ubuntu tmux builds ship systemd integration that moves every pane into a transient user scope (`tmux-spawn-*.scope`, "tmux child pane N launched by process M") under the default user slice at spawn time. Even though `gascity-supervisor.service` and the tmux server run in `gascity-prod.slice`, the pane processes — i.e. every agent — escape into `user-1000.slice` (113/114 observed on the prod host). This defeats the design's resource contract for agent compute and blocks applying dev resource caps (`user-1000.slice` MemoryHigh/CPUWeight) without throttling prod agents. Full evidence: bead **ga-ez4kyc**.

## Fix

At the SDK spawn layer (`internal/runtime/tmux`): when `GC_AGENT_SLICE=<user-slice-name>` is set, the tmux provider wraps each pane's initial command in

```
systemd-run --user --scope --slice=<slice> --collect --quiet -- sh -c '<command>'
```

re-parenting the agent's process tree into a dedicated user slice where resource weights can apply. Covered spawn paths: `NewSessionWithCommand`, `NewSessionWithCommandAndEnv`, `RespawnPane`, `RespawnPaneWithWorkDir` (the auto-restart hook's bare `respawn-pane -k` reuses the pane's original — already wrapped — command).

- **Default-off:** with the env unset, pane commands are byte-for-byte unchanged.
- **Graceful fallback:** a once-per-`Tmux` probe runs `systemd-run --user --scope --slice=<slice> --collect --quiet -- true`; if `systemd-run` is missing or the user manager doesn't respond, a warning is logged to stderr once and all pane commands run unwrapped.
- Commands are quoted via the existing `internal/shellquote` package, and `env -u` unset prefixes land inside the wrapper so they still apply to the agent process.

## Ops note

To activate in production, ops will set `GC_AGENT_SLICE=gascity-agents.slice` in the supervisor environment and define that user slice (with desired CPU/memory weights) via ansible. The design doc §4 addendum can land once this is deployed.

## Testing

TDD: the new tests in `internal/runtime/tmux/agent_slice_test.go` were verified failing-first by neutering `wrapPaneCommand` (5 of 7 fail with plain argv where wrapped argv is expected), then passing with the implementation.

- `go test ./internal/runtime/tmux/` — pass (incl. 7 new `TestAgentSlice*` tests inspecting generated tmux argv via the fake executor)
- `go build ./...`, `go vet ./...` — clean
- Full `make test` in the isolation sandbox — pass
- Pre-commit hook (lint-changed 0 issues, vet, fast shards) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)