### PR TITLE
feat(supervisor): systemd-delegated lifecycle via GC_SUPERVISOR_SYSTEMD_UNIT (ga-z2l4q4)

### DIFF
--- a/cmd/gc/cmd_start_drift.go
+++ b/cmd/gc/cmd_start_drift.go
@@ -272,9 +272,9 @@ func runStartDriftCheck(cityPath string, stdout, stderr io.Writer) (int, bool) {
 			PackDrifted:  res.PackDrift,
 		})
 		if flags.KillSwitchActive {
-			fmt.Fprintln(stderr, "error: supervisor binary drift; auto-restart disabled by [daemon].auto_restart_on_drift in city.toml. Restart manually with 'systemctl --user restart gascity-supervisor'.") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "error: supervisor binary drift; auto-restart disabled by [daemon].auto_restart_on_drift in city.toml. Restart manually with '%s'.\n", supervisorRestartGuidance()) //nolint:errcheck // best-effort stderr
 		} else {
-			fmt.Fprintln(stderr, "error: supervisor binary drift; rerun 'gc start' (or 'systemctl --user restart gascity-supervisor') to apply changes.") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "error: supervisor binary drift; rerun 'gc start' (or '%s') to apply changes.\n", supervisorRestartGuidance()) //nolint:errcheck // best-effort stderr
 		}
 		return 1, false
 	case res.Restart:
@@ -284,11 +284,16 @@ func runStartDriftCheck(cityPath string, stdout, stderr io.Writer) (int, bool) {
 			SupervisorID: status.BuildID,
 			PackDrifted:  res.PackDrift,
 		})
+		delegation, delegated, derr := supervisorSystemdDelegation()
+		if derr != nil {
+			fmt.Fprintf(stderr, "error: cannot auto-restart supervisor: %v\n", derr) //nolint:errcheck // best-effort stderr
+			return 1, false
+		}
 		serviceName := supervisorSystemdServiceName()
-		systemdManaged := supervisorSystemctlActive(serviceName)
+		systemdManaged := !delegated && supervisorSystemctlActive(serviceName)
 		launchdLabel := supervisorLaunchdLabel()
-		launchdManaged := supervisorRuntimeGOOS == "darwin" && supervisorLaunchdActive(launchdLabel)
-		if exeErr != nil && !systemdManaged && !launchdManaged {
+		launchdManaged := !delegated && supervisorRuntimeGOOS == "darwin" && supervisorLaunchdActive(launchdLabel)
+		if exeErr != nil && !delegated && !systemdManaged && !launchdManaged {
 			// We can't safely auto-restart a supervisor whose
 			// /proc/<pid>/exe we can't read — the kernel readlink is
 			// the only reliable way to learn which binary to spawn,
@@ -317,6 +322,8 @@ func runStartDriftCheck(cityPath string, stdout, stderr io.Writer) (int, bool) {
 		}
 		mode := "direct"
 		switch {
+		case delegated:
+			mode = "systemd-delegated"
 		case systemdManaged:
 			mode = "systemd-managed"
 		case launchdManaged:
@@ -324,15 +331,24 @@ func runStartDriftCheck(cityPath string, stdout, stderr io.Writer) (int, bool) {
 		}
 		fmt.Fprintf(stdout, "Restarting supervisor (%s)...", mode) //nolint:errcheck // best-effort stdout
 		t0 := time.Now()
-		if err := restartSupervisor(spec, restartHelpersHook()); err != nil {
-			fmt.Fprintln(stdout)                                               //nolint:errcheck // best-effort stdout
-			fmt.Fprintf(stderr, "error: supervisor restart failed: %v\n", err) //nolint:errcheck // best-effort stderr
+		var restartErr error
+		if delegated {
+			// try-restart: restart only if the unit is running. The drift
+			// path only fires when a supervisor is alive, and a stopped
+			// delegated unit must stay stopped — its operator owns starts.
+			restartErr = runDelegatedSystemctl(delegation, "try-restart")
+		} else {
+			restartErr = restartSupervisor(spec, restartHelpersHook())
+		}
+		if restartErr != nil {
+			fmt.Fprintln(stdout)                                                      //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stderr, "error: supervisor restart failed: %v\n", restartErr) //nolint:errcheck // best-effort stderr
 			return 1, false
 		}
 		// Wait for the new supervisor to come up.
 		if err := PollReady(newHTTPSupervisorClient(baseURL), driftReadyTimeout); err != nil {
-			fmt.Fprintln(stdout)                                                                                                                                                              //nolint:errcheck // best-effort stdout
-			fmt.Fprintf(stderr, "error: supervisor restart timed out after %s; check 'systemctl --user status gascity-supervisor' for details. Last known pid=%d.\n", driftReadyTimeout, pid) //nolint:errcheck // best-effort stderr
+			fmt.Fprintln(stdout)                                                                                                                                                  //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stderr, "error: supervisor restart timed out after %s; check '%s' for details. Last known pid=%d.\n", driftReadyTimeout, supervisorStatusGuidance(), pid) //nolint:errcheck // best-effort stderr
 			return 1, false
 		}
 		fmt.Fprintf(stdout, " ready (%s).\n", humanizeReadyDuration(time.Since(t0))) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_start_drift.go
+++ b/cmd/gc/cmd_start_drift.go
@@ -351,6 +351,35 @@ func runStartDriftCheck(cityPath string, stdout, stderr io.Writer) (int, bool) {
 			fmt.Fprintf(stderr, "error: supervisor restart timed out after %s; check '%s' for details. Last known pid=%d.\n", driftReadyTimeout, supervisorStatusGuidance(), pid) //nolint:errcheck // best-effort stderr
 			return 1, false
 		}
+		if delegated {
+			// `try-restart` no-ops successfully when the unit is inactive,
+			// and PollReady answers from whatever process serves /health —
+			// the OLD supervisor when the unit never managed it. A unit can
+			// also genuinely replace the process while its ExecStart still
+			// launches the drifted binary. Require evidence that the drift
+			// actually cleared — not merely that the process changed — and
+			// treat an unverifiable post-restart probe as failure, instead
+			// of reporting "ready" while a stale supervisor keeps serving.
+			vctx, vcancel := context.WithTimeout(context.Background(), 2*time.Second)
+			verifyStatus, verifyErr := newHTTPSupervisorClient(baseURL).Status(vctx)
+			vcancel()
+			if verifyErr != nil {
+				fmt.Fprintln(stdout)                                                                                                                                              //nolint:errcheck // best-effort stdout
+				fmt.Fprintf(stderr, "error: cannot verify supervisor after '%s': %v; check '%s'\n", delegation.commandHint("try-restart"), verifyErr, supervisorStatusGuidance()) //nolint:errcheck // best-effort stderr
+				return 1, false
+			}
+			verifyPID := supervisorAliveHook()
+			if verifyPID == pid && verifyStatus.BuildID == status.BuildID {
+				fmt.Fprintln(stdout)                                                                                                                                                                                                                                                                                                                    //nolint:errcheck // best-effort stdout
+				fmt.Fprintf(stderr, "error: supervisor was not replaced by '%s': PID %d still serving build %s; it is not managed by delegated unit %s — stop it with 'gc supervisor stop' (%s unset), or fix the delegation env\n", delegation.commandHint("try-restart"), verifyPID, verifyStatus.BuildID, delegation.Unit, supervisorSystemdUnitEnv) //nolint:errcheck // best-effort stderr
+				return 1, false
+			}
+			if DetectBinaryDrift(commit, verifyStatus) {
+				fmt.Fprintln(stdout)                                                                                                                                                                                                                                                                                                           //nolint:errcheck // best-effort stdout
+				fmt.Fprintf(stderr, "error: supervisor restarted by '%s' but still serves drifted build %s (local build %s); unit %s's ExecStart does not launch the updated gc binary — point the unit at the new binary, or fix the delegation env\n", delegation.commandHint("try-restart"), verifyStatus.BuildID, commit, delegation.Unit) //nolint:errcheck // best-effort stderr
+				return 1, false
+			}
+		}
 		fmt.Fprintf(stdout, " ready (%s).\n", humanizeReadyDuration(time.Since(t0))) //nolint:errcheck // best-effort stdout
 
 		// Re-print the Supervisor: line so the operator's last memory

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -97,7 +97,14 @@ request — shutdown continues asynchronously. Pass --wait to block
 until the supervisor socket is no longer answering, which is what
 most callers that need deterministic cleanup want (e.g., integration
 tests that then expect to remove temp directories without racing
-against lingering supervisor / controller subprocesses).`,
+against lingering supervisor / controller subprocesses).
+
+When GC_SUPERVISOR_SYSTEMD_UNIT is set, stop is delegated to
+'systemctl [--user] stop <unit>' instead of the control-socket stop.
+The systemctl invocation is synchronous and bounded by --wait-timeout
+whether or not --wait is set, gc then verifies a previously-running
+supervisor actually exited (failing with its PID when the unit does
+not manage it), and stop with nothing running still exits 1.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if stopSupervisorWithWaitJSON(stdout, stderr, wait, waitTimeout, jsonOut) != 0 {
@@ -107,7 +114,7 @@ against lingering supervisor / controller subprocesses).`,
 		},
 	}
 	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the supervisor to finish stopping all managed cities and release its socket before returning")
-	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Second, "Maximum time to wait when --wait is set")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Second, "Maximum time to wait when --wait is set (in delegated mode, bounds the synchronous systemctl stop regardless of --wait)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
 	return cmd
 }
@@ -696,6 +703,11 @@ func stopSupervisor(stdout, stderr io.Writer) int {
 // It also unloads the platform service (without removing the unit file) after
 // the supervisor acknowledges the destructive socket stop, so launchd/systemd
 // will not restart it when the process exits.
+//
+// When GC_SUPERVISOR_SYSTEMD_UNIT is set, the stop is redirected to the
+// delegated unit instead of the socket protocol. Callers that must stop
+// gc's OWN supervisor regardless of delegation (e.g. uninstall cleaning
+// up gc's legacy unit) use stopSupervisorViaSocket directly.
 func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout time.Duration) int {
 	return stopSupervisorWithWaitJSON(stdout, stderr, wait, waitTimeout, false)
 }
@@ -707,8 +719,20 @@ func stopSupervisorWithWaitJSON(stdout, stderr io.Writer, wait bool, waitTimeout
 		return 1
 	}
 	if delegated {
-		return delegatedSupervisorStop(delegation, stdout, stderr, wait, jsonOut)
+		return delegatedSupervisorStop(delegation, stdout, stderr, wait, waitTimeout, jsonOut)
 	}
+	return stopSupervisorViaSocketJSON(stdout, stderr, wait, waitTimeout, jsonOut)
+}
+
+// stopSupervisorViaSocket drives the control-socket stop protocol against
+// gc's own supervisor, ignoring any configured systemd delegation. It is
+// the stop path for internal cleanup of gc-owned services (uninstall),
+// which must never stop the operator's delegated unit as a side effect.
+func stopSupervisorViaSocket(stdout, stderr io.Writer, wait bool, waitTimeout time.Duration) int {
+	return stopSupervisorViaSocketJSON(stdout, stderr, wait, waitTimeout, false)
+}
+
+func stopSupervisorViaSocketJSON(stdout, stderr io.Writer, wait bool, waitTimeout time.Duration, jsonOut bool) int {
 	sockPath, _ := runningSupervisorSocket()
 	if sockPath == "" {
 		fmt.Fprintln(stderr, "gc supervisor stop: supervisor is not running") //nolint:errcheck
@@ -832,12 +856,22 @@ func waitForSupervisorExitUntil(sockPath string, deadline time.Time) error {
 	}
 }
 
-func supervisorStatusWithOptions(stdout, _ io.Writer, asJSON bool) int {
+func supervisorStatusWithOptions(stdout, stderr io.Writer, asJSON bool) int {
 	sockPath, pid := runningSupervisorSocket()
 	running := pid > 0
 	pidSource := ""
 	if pid > 0 {
 		pidSource = "control_socket"
+	}
+	// A broken delegation env (e.g. a GC_SUPERVISOR_SYSTEMD_SCOPE typo) must
+	// surface here: status is the first command operators and monitoring run
+	// against a delegated supervisor, every mutating lifecycle sibling
+	// hard-errors on the same typo, and the service-manager fallback below
+	// skips its unit probe when the scope is unparseable — without this
+	// diagnostic, the config error reads as a bare "not running".
+	_, _, delegationErr := supervisorSystemdDelegation()
+	if delegationErr != nil {
+		fmt.Fprintf(stderr, "gc supervisor status: warning: %v\n", delegationErr) //nolint:errcheck
 	}
 	// Fallback liveness when the control socket is unreachable (gascity#2984):
 	// a launchd/systemd-managed supervisor may bind its socket at a path the
@@ -865,6 +899,9 @@ func supervisorStatusWithOptions(stdout, _ io.Writer, asJSON bool) int {
 			// Distinct diagnostic state (gascity#2984): running per service
 			// manager / API, but pid discovery via the socket failed.
 			payload["socket_status"] = "unreachable"
+		}
+		if delegationErr != nil {
+			payload["config_error"] = delegationErr.Error()
 		}
 		if err := writeCLIJSONLine(stdout, payload); err != nil {
 			return 1

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -701,6 +701,14 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 }
 
 func stopSupervisorWithWaitJSON(stdout, stderr io.Writer, wait bool, waitTimeout time.Duration, jsonOut bool) int {
+	delegation, delegated, err := supervisorSystemdDelegation()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	if delegated {
+		return delegatedSupervisorStop(delegation, stdout, stderr, wait, jsonOut)
+	}
 	sockPath, _ := runningSupervisorSocket()
 	if sockPath == "" {
 		fmt.Fprintln(stderr, "gc supervisor stop: supervisor is not running") //nolint:errcheck

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -97,8 +97,23 @@ var (
 	// supervisorServiceManagerActive reports whether the platform service
 	// manager (launchd on macOS, systemd --user on Linux) considers the
 	// supervisor running. Fallback liveness signal when the control-socket
-	// ping fails (gascity#2984).
+	// ping fails (gascity#2984). With GC_SUPERVISOR_SYSTEMD_UNIT set, the
+	// delegated unit is the only authoritative service-manager signal —
+	// gc's own user unit is irrelevant, and a system-scope unit (whose
+	// socket is typically unreachable from the operator's shell) must not
+	// be gated on per-user manager availability; the is-active probe
+	// degrades to false on its own when the manager is unreachable.
 	supervisorServiceManagerActive = func() bool {
+		d, delegated, err := supervisorSystemdDelegation()
+		if err != nil {
+			// Invalid scope: report nothing rather than probing a unit the
+			// operator did not configure; lifecycle commands surface the
+			// configuration error itself.
+			return false
+		}
+		if delegated {
+			return delegatedUnitActive(d)
+		}
 		switch supervisorRuntimeGOOS {
 		case "darwin":
 			return supervisorLaunchdActive(supervisorLaunchdLabel())
@@ -550,7 +565,13 @@ func ensureSupervisorRunning(stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "gc: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		return waitForSupervisorReady(stderr)
+		if waitForSupervisorPID() != 0 {
+			return 0
+		}
+		// A delegated supervisor logs to the journal, not gc's fork-mode
+		// log file — point readiness-timeout diagnostics at the unit.
+		fmt.Fprintf(stderr, "gc: supervisor did not become ready after '%s'; check '%s'\n", delegation.commandHint("start"), delegation.commandHint("status")) //nolint:errcheck // best-effort stderr
+		return 1
 	}
 	if msg, blocked := platformSupervisorHomeOverrideError(); blocked {
 		fmt.Fprintf(stderr, "gc supervisor start: %s\n", msg) //nolint:errcheck // best-effort stderr
@@ -844,6 +865,18 @@ starts on login.`,
 }
 
 func doSupervisorInstall(stdout, stderr io.Writer) int {
+	delegation, delegated, err := supervisorSystemdDelegation()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if delegated {
+		// The operator-managed unit owns the supervisor lifecycle;
+		// installing gc's own service alongside it would leave two
+		// service managers fighting over one supervisor.
+		fmt.Fprintf(stderr, "gc supervisor install: %s is set (delegated to unit %q); gc does not install its own service files in delegated mode. Unset %s to manage gc's own service.\n", supervisorSystemdUnitEnv, delegation.Unit, supervisorSystemdUnitEnv) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	if msg, blocked := platformSupervisorHomeOverrideError(); blocked {
 		fmt.Fprintf(stderr, "gc supervisor install: %s\n", msg) //nolint:errcheck // best-effort stderr
 		return 1
@@ -885,6 +918,17 @@ preserved sessions, then retry uninstall.`,
 }
 
 func doSupervisorUninstall(stdout, stderr io.Writer) int {
+	delegation, delegated, derr := supervisorSystemdDelegation()
+	if derr != nil {
+		fmt.Fprintf(stderr, "gc supervisor uninstall: %v\n", derr) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if delegated {
+		// Uninstall is a legitimate migration step (removing gc's legacy
+		// unit after delegating), so warn rather than refuse: only
+		// gc-owned service files are touched, never the delegated unit.
+		fmt.Fprintf(stderr, "gc supervisor uninstall: warning: %s is set (delegated to unit %q); uninstall removes only gc's own service files and does not touch the delegated unit\n", supervisorSystemdUnitEnv, delegation.Unit) //nolint:errcheck // best-effort stderr
+	}
 	data, err := buildSupervisorServiceData()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc supervisor uninstall: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1744,7 +1788,10 @@ func uninstallSupervisorLaunchd(_ *supervisorServiceData, stdout, stderr io.Writ
 	path := supervisorLaunchdPlistPath()
 	active := supervisorLaunchdActive(supervisorLaunchdLabel())
 	if sockPath, _ := runningSupervisorSocket(); sockPath != "" {
-		if code := stopSupervisorWithWait(stdout, stderr, true, 30*time.Second); code != 0 {
+		// Socket-protocol stop, never the delegated redirect: uninstall is
+		// cleaning up gc's OWN service and must not stop an operator's
+		// delegated unit (or require systemctl on darwin) as a side effect.
+		if code := stopSupervisorViaSocket(stdout, stderr, true, 30*time.Second); code != 0 {
 			return code
 		}
 	} else if active {
@@ -1987,7 +2034,10 @@ func uninstallSupervisorSystemd(_ *supervisorServiceData, stdout, stderr io.Writ
 			fmt.Fprintf(stderr, "gc supervisor uninstall: systemd service %s is active but the control socket is unavailable; run 'gc supervisor start' to re-adopt sessions, then retry uninstall\n", service) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		if code := stopSupervisorWithWait(stdout, stderr, true, 30*time.Second); code != 0 {
+		// Socket-protocol stop, never the delegated redirect: uninstall is
+		// cleaning up gc's OWN unit and must not stop an operator's
+		// delegated unit as a side effect.
+		if code := stopSupervisorViaSocket(stdout, stderr, true, 30*time.Second); code != 0 {
 			return code
 		}
 	}

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -459,6 +459,14 @@ func doSupervisorStart(stdout, stderr io.Writer) int {
 }
 
 func doSupervisorStartJSON(stdout, stderr io.Writer, jsonOut bool) int {
+	delegation, delegated, err := supervisorSystemdDelegation()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc supervisor start: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if delegated {
+		return delegatedSupervisorStart(delegation, stdout, stderr, jsonOut)
+	}
 	if msg, blocked := platformSupervisorHomeOverrideError(); blocked {
 		fmt.Fprintf(stderr, "gc supervisor start: %s\n", msg) //nolint:errcheck // best-effort stderr
 		return 1
@@ -527,6 +535,23 @@ func doSupervisorStartJSON(stdout, stderr io.Writer, jsonOut bool) int {
 }
 
 func ensureSupervisorRunning(stdout, stderr io.Writer) int {
+	delegation, delegated, err := supervisorSystemdDelegation()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if delegated {
+		// The operator-managed unit owns install and start; never write
+		// or load gc's own service files in delegated mode.
+		if supervisorAliveHook() != 0 {
+			return 0
+		}
+		if err := runDelegatedSystemctl(delegation, "start"); err != nil {
+			fmt.Fprintf(stderr, "gc: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return waitForSupervisorReady(stderr)
+	}
 	if msg, blocked := platformSupervisorHomeOverrideError(); blocked {
 		fmt.Fprintf(stderr, "gc supervisor start: %s\n", msg) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/supervisor_systemd_delegate.go
+++ b/cmd/gc/supervisor_systemd_delegate.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Operator-facing env vars for systemd-delegated supervisor lifecycle.
+//
+// When GC_SUPERVISOR_SYSTEMD_UNIT names a systemd unit, `gc supervisor
+// start`/`gc supervisor stop` and the `gc start` drift auto-restart path
+// shell out to `systemctl {start,stop,try-restart} <unit>` instead of
+// forking `gc supervisor run`, driving the destructive control-socket
+// stop, or installing gc's own user service files. The delegated unit
+// owns the supervisor lifecycle; gc only requests transitions and waits
+// for readiness.
+//
+// GC_SUPERVISOR_SYSTEMD_SCOPE selects the manager the unit lives in:
+// "system" (the default) or "user" (systemctl --user).
+const (
+	supervisorSystemdUnitEnv  = "GC_SUPERVISOR_SYSTEMD_UNIT"
+	supervisorSystemdScopeEnv = "GC_SUPERVISOR_SYSTEMD_SCOPE"
+)
+
+// systemdDelegation names the operator-managed systemd unit that owns the
+// supervisor lifecycle, plus the manager scope it lives in ("system" or
+// "user").
+type systemdDelegation struct {
+	Unit  string
+	Scope string
+}
+
+// supervisorSystemdDelegation reads the delegation env vars. ok is false
+// when GC_SUPERVISOR_SYSTEMD_UNIT is unset or blank. An unrecognized
+// scope value is an error rather than a silent fallback so a typo cannot
+// quietly target the system manager.
+func supervisorSystemdDelegation() (systemdDelegation, bool, error) {
+	unit := strings.TrimSpace(os.Getenv(supervisorSystemdUnitEnv))
+	if unit == "" {
+		return systemdDelegation{}, false, nil
+	}
+	scope := strings.TrimSpace(os.Getenv(supervisorSystemdScopeEnv))
+	switch scope {
+	case "":
+		scope = "system"
+	case "system", "user":
+	default:
+		return systemdDelegation{}, false, fmt.Errorf("invalid %s=%q: want \"system\" or \"user\"", supervisorSystemdScopeEnv, scope)
+	}
+	return systemdDelegation{Unit: unit, Scope: scope}, true, nil
+}
+
+// systemctlArgs returns the systemctl argument vector (without the
+// leading program name) for verb against the delegated unit.
+func (d systemdDelegation) systemctlArgs(verb string) []string {
+	if d.Scope == "user" {
+		return []string{"--user", verb, d.Unit}
+	}
+	return []string{verb, d.Unit}
+}
+
+// commandHint renders the operator-facing systemctl command line for verb
+// against the delegated unit, e.g. "systemctl restart gascity.service".
+func (d systemdDelegation) commandHint(verb string) string {
+	return "systemctl " + strings.Join(d.systemctlArgs(verb), " ")
+}
+
+// runDelegatedSystemctl invokes systemctl (resolved via PATH) for verb
+// against the delegated unit, folding any output into the returned error
+// so operators see systemd's own diagnostic.
+func runDelegatedSystemctl(d systemdDelegation, verb string) error {
+	args := d.systemctlArgs(verb)
+	out, err := exec.Command("systemctl", args...).CombinedOutput()
+	if err != nil {
+		if msg := strings.TrimSpace(string(out)); msg != "" {
+			return fmt.Errorf("systemctl %s: %w: %s", strings.Join(args, " "), err, msg)
+		}
+		return fmt.Errorf("systemctl %s: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+// supervisorRestartGuidance returns the systemctl command operators
+// should run to restart the supervisor by hand: the delegated unit's
+// command when GC_SUPERVISOR_SYSTEMD_UNIT is configured, otherwise gc's
+// default user unit. Used by drift remediation messages.
+func supervisorRestartGuidance() string {
+	if d, ok, err := supervisorSystemdDelegation(); err == nil && ok {
+		return d.commandHint("restart")
+	}
+	return "systemctl --user restart gascity-supervisor"
+}
+
+// supervisorStatusGuidance is supervisorRestartGuidance for `systemctl
+// status`.
+func supervisorStatusGuidance() string {
+	if d, ok, err := supervisorSystemdDelegation(); err == nil && ok {
+		return d.commandHint("status")
+	}
+	return "systemctl --user status gascity-supervisor"
+}
+
+// delegatedSupervisorStart starts the supervisor by asking the
+// operator-managed systemd unit to start, then waits for the control
+// socket to answer — the same readiness contract as the fork path.
+func delegatedSupervisorStart(d systemdDelegation, stdout, stderr io.Writer, jsonOut bool) int {
+	if pid := supervisorAliveHook(); pid != 0 {
+		fmt.Fprintf(stderr, "gc supervisor start: supervisor already running (PID %d)\n", pid) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := runDelegatedSystemctl(d, "start"); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor start: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	deadline := time.Now().Add(supervisorReadyTimeout)
+	for time.Now().Before(deadline) {
+		if pid := supervisorAliveHook(); pid != 0 {
+			if jsonOut {
+				return writeLifecycleActionJSONOrExit(stdout, stderr, "gc supervisor start", lifecycleActionJSON{
+					Command:       "supervisor start",
+					Action:        "start",
+					Message:       "Supervisor started.",
+					SupervisorPID: pid,
+				})
+			}
+			fmt.Fprintf(stdout, "Supervisor started (PID %d)\n", pid) //nolint:errcheck // best-effort stdout
+			return 0
+		}
+		time.Sleep(supervisorReadyPollInterval)
+	}
+	fmt.Fprintf(stderr, "gc supervisor start: supervisor did not become ready after '%s'; check '%s'\n", d.commandHint("start"), d.commandHint("status")) //nolint:errcheck // best-effort stderr
+	return 1
+}
+
+// delegatedSupervisorStop stops the supervisor by asking the
+// operator-managed systemd unit to stop. systemctl blocks until the unit
+// has stopped, so the control-socket wait protocol is unnecessary; the
+// destructive socket stop and service unload are intentionally skipped
+// because the delegated unit owns the lifecycle (and its restart policy).
+func delegatedSupervisorStop(d systemdDelegation, stdout, stderr io.Writer, wait bool, jsonOut bool) int {
+	if err := runDelegatedSystemctl(d, "stop"); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if jsonOut {
+		return writeSupervisorStopSuccess(stdout, stderr, wait)
+	}
+	fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck // best-effort stdout
+	return 0
+}

--- a/cmd/gc/supervisor_systemd_delegate.go
+++ b/cmd/gc/supervisor_systemd_delegate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -16,15 +17,39 @@ import (
 // shell out to `systemctl {start,stop,try-restart} <unit>` instead of
 // forking `gc supervisor run`, driving the destructive control-socket
 // stop, or installing gc's own user service files. The delegated unit
-// owns the supervisor lifecycle; gc only requests transitions and waits
-// for readiness.
+// owns the supervisor lifecycle; gc only requests transitions and
+// verifies their effect.
+//
+// Delegated-mode contract differences from the fork path:
+//
+//   - `gc supervisor stop` runs `systemctl stop <unit>` synchronously,
+//     bounded by --wait-timeout whether or not --wait is set, then
+//     verifies a previously-live supervisor actually exited. A live
+//     supervisor that the unit does not manage fails the stop with its
+//     PID instead of reporting a false "Supervisor stopped.". With no
+//     live supervisor and an inactive unit, stop keeps the legacy
+//     "supervisor is not running" exit-1 contract.
+//   - `gc supervisor install`/`gc supervisor uninstall` never write or
+//     load gc-owned service files for the delegated unit; install
+//     refuses to run, and uninstall only touches gc's own legacy unit.
+//   - `gc supervisor status` probes the delegated unit (not gc's own
+//     user unit) when the control socket is unreachable.
 //
 // GC_SUPERVISOR_SYSTEMD_SCOPE selects the manager the unit lives in:
-// "system" (the default) or "user" (systemctl --user).
+// "system" (the default) or "user" (systemctl --user). An invalid scope
+// is a hard error on every lifecycle path, never a silent fallback.
 const (
 	supervisorSystemdUnitEnv  = "GC_SUPERVISOR_SYSTEMD_UNIT"
 	supervisorSystemdScopeEnv = "GC_SUPERVISOR_SYSTEMD_SCOPE"
 )
+
+// delegatedStopVerifyTimeout bounds the post-stop liveness check in
+// delegatedSupervisorStop. `systemctl stop` completes the unit's stop job
+// synchronously, so a supervisor managed by the unit is already gone when
+// systemctl returns; this budget only covers control-socket teardown
+// slop. A supervisor still answering after it is one the unit never
+// managed. Package var so tests can shrink the wait.
+var delegatedStopVerifyTimeout = 5 * time.Second
 
 // systemdDelegation names the operator-managed systemd unit that owns the
 // supervisor lifecycle, plus the manager scope it lives in ("system" or
@@ -63,19 +88,64 @@ func (d systemdDelegation) systemctlArgs(verb string) []string {
 	return []string{verb, d.Unit}
 }
 
+// systemctlIsActiveArgs returns the argument vector for a quiet
+// is-active probe of the delegated unit at its configured scope.
+func (d systemdDelegation) systemctlIsActiveArgs() []string {
+	if d.Scope == "user" {
+		return []string{"--user", "is-active", "--quiet", d.Unit}
+	}
+	return []string{"is-active", "--quiet", d.Unit}
+}
+
 // commandHint renders the operator-facing systemctl command line for verb
 // against the delegated unit, e.g. "systemctl restart gascity.service".
 func (d systemdDelegation) commandHint(verb string) string {
 	return "systemctl " + strings.Join(d.systemctlArgs(verb), " ")
 }
 
+// delegatedUnitActive reports whether the delegated unit is currently
+// active, via `systemctl [--user] is-active --quiet <unit>` resolved on
+// PATH. A missing systemctl binary or unreachable manager reads as
+// inactive.
+//
+// Decision: delegated paths exec PATH-resolved systemctl directly instead
+// of routing through the supervisorSystemctlRun hook, and the PATH-shim
+// fake systemctl (argv-recording) is the canonical test seam for them.
+// The bounded stop needs CommandContext+WaitDelay semantics the hook
+// cannot express, and the shim exercises the real exec path end to end.
+func delegatedUnitActive(d systemdDelegation) bool {
+	return exec.Command("systemctl", d.systemctlIsActiveArgs()...).Run() == nil
+}
+
 // runDelegatedSystemctl invokes systemctl (resolved via PATH) for verb
 // against the delegated unit, folding any output into the returned error
 // so operators see systemd's own diagnostic.
 func runDelegatedSystemctl(d systemdDelegation, verb string) error {
+	return runDelegatedSystemctlTimeout(d, verb, 0)
+}
+
+// runDelegatedSystemctlTimeout is runDelegatedSystemctl bounded by
+// timeout (unbounded when timeout <= 0). systemctl runs unit jobs
+// synchronously, so the bound keeps a wedged unit from holding the CLI
+// past its advertised budget; the unit's own job keeps running inside
+// systemd after the CLI gives up waiting.
+func runDelegatedSystemctlTimeout(d systemdDelegation, verb string, timeout time.Duration) error {
 	args := d.systemctlArgs(verb)
-	out, err := exec.Command("systemctl", args...).CombinedOutput()
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, "systemctl", args...)
+	// Don't let an inherited pipe from a systemctl child stretch the wait
+	// past the kill triggered by the context deadline.
+	cmd.WaitDelay = time.Second
+	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("systemctl %s: timed out after %s", strings.Join(args, " "), timeout)
+		}
 		if msg := strings.TrimSpace(string(out)); msg != "" {
 			return fmt.Errorf("systemctl %s: %w: %s", strings.Join(args, " "), err, msg)
 		}
@@ -87,9 +157,15 @@ func runDelegatedSystemctl(d systemdDelegation, verb string) error {
 // supervisorRestartGuidance returns the systemctl command operators
 // should run to restart the supervisor by hand: the delegated unit's
 // command when GC_SUPERVISOR_SYSTEMD_UNIT is configured, otherwise gc's
-// default user unit. Used by drift remediation messages.
+// default user unit. An invalid delegation scope yields guidance naming
+// the bad value rather than silently pointing at the default unit. Used
+// by drift remediation messages.
 func supervisorRestartGuidance() string {
-	if d, ok, err := supervisorSystemdDelegation(); err == nil && ok {
+	d, ok, err := supervisorSystemdDelegation()
+	switch {
+	case err != nil:
+		return fmt.Sprintf("fix %v", err)
+	case ok:
 		return d.commandHint("restart")
 	}
 	return "systemctl --user restart gascity-supervisor"
@@ -98,7 +174,11 @@ func supervisorRestartGuidance() string {
 // supervisorStatusGuidance is supervisorRestartGuidance for `systemctl
 // status`.
 func supervisorStatusGuidance() string {
-	if d, ok, err := supervisorSystemdDelegation(); err == nil && ok {
+	d, ok, err := supervisorSystemdDelegation()
+	switch {
+	case err != nil:
+		return fmt.Sprintf("fix %v", err)
+	case ok:
 		return d.commandHint("status")
 	}
 	return "systemctl --user status gascity-supervisor"
@@ -137,14 +217,40 @@ func delegatedSupervisorStart(d systemdDelegation, stdout, stderr io.Writer, jso
 }
 
 // delegatedSupervisorStop stops the supervisor by asking the
-// operator-managed systemd unit to stop. systemctl blocks until the unit
-// has stopped, so the control-socket wait protocol is unnecessary; the
-// destructive socket stop and service unload are intentionally skipped
-// because the delegated unit owns the lifecycle (and its restart policy).
-func delegatedSupervisorStop(d systemdDelegation, stdout, stderr io.Writer, wait bool, jsonOut bool) int {
-	if err := runDelegatedSystemctl(d, "stop"); err != nil {
+// operator-managed systemd unit to stop. The systemctl invocation is
+// synchronous and bounded by waitTimeout; the destructive socket stop and
+// service unload are intentionally skipped because the delegated unit
+// owns the lifecycle (and its restart policy).
+//
+// `systemctl stop` succeeds without doing anything when the running
+// supervisor is not managed by the unit (the common hazard mid-migration,
+// e.g. a legacy forked supervisor still holding the control socket), so a
+// supervisor that was alive before the stop must be verifiably gone
+// afterwards or the command fails with its PID. With no live supervisor
+// and an inactive unit, the legacy "supervisor is not running" exit-1
+// contract is preserved.
+func delegatedSupervisorStop(d systemdDelegation, stdout, stderr io.Writer, wait bool, waitTimeout time.Duration, jsonOut bool) int {
+	if waitTimeout <= 0 {
+		waitTimeout = 30 * time.Second
+	}
+	pidBefore := supervisorAliveHook()
+	if pidBefore == 0 && !delegatedUnitActive(d) {
+		fmt.Fprintf(stderr, "gc supervisor stop: supervisor is not running (delegated unit %s is inactive)\n", d.Unit) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := runDelegatedSystemctlTimeout(d, "stop", waitTimeout); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if pidBefore != 0 {
+		deadline := time.Now().Add(delegatedStopVerifyTimeout)
+		for supervisorAliveHook() != 0 && time.Now().Before(deadline) {
+			time.Sleep(supervisorReadyPollInterval)
+		}
+		if pid := supervisorAliveHook(); pid != 0 {
+			fmt.Fprintf(stderr, "gc supervisor stop: supervisor still running (PID %d) outside delegated unit %s after '%s'; it is not managed by that unit — stop it with %s unset, or fix the delegation env\n", pid, d.Unit, d.commandHint("stop"), supervisorSystemdUnitEnv) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 	if jsonOut {
 		return writeSupervisorStopSuccess(stdout, stderr, wait)

--- a/cmd/gc/supervisor_systemd_delegate_test.go
+++ b/cmd/gc/supervisor_systemd_delegate_test.go
@@ -1,0 +1,438 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installFakeDelegatedSystemctl writes an executable `systemctl` shim into a fresh
+// temp dir, prepends that dir to PATH, and returns the path of the file
+// the shim appends its argv into (one line per invocation). The shim
+// prints stderrMsg to stderr (when non-empty) and exits with exitCode, so
+// tests can model both healthy and failing systemctl runs without a real
+// systemd anywhere near the test.
+func installFakeDelegatedSystemctl(t *testing.T, exitCode int, stderrMsg string) string {
+	t.Helper()
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "systemctl-args")
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\n", argsFile)
+	if stderrMsg != "" {
+		script += fmt.Sprintf("echo %q >&2\n", stderrMsg)
+	}
+	script += fmt.Sprintf("exit %d\n", exitCode)
+	if err := os.WriteFile(filepath.Join(dir, "systemctl"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake systemctl: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsFile
+}
+
+// readRecordedSystemctlArgs returns the argv lines the fake systemctl
+// recorded, one invocation per element.
+func readRecordedSystemctlArgs(t *testing.T, argsFile string) []string {
+	t.Helper()
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("reading recorded systemctl args: %v", err)
+	}
+	var lines []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, strings.TrimSpace(line))
+		}
+	}
+	return lines
+}
+
+// stubSupervisorAliveAfterSystemctl makes supervisorAliveHook report a
+// running supervisor only once the fake systemctl has been invoked
+// (i.e., once argsFile exists), modeling a delegated unit that brings
+// the supervisor up in response to `systemctl start`.
+func stubSupervisorAliveAfterSystemctl(t *testing.T, argsFile string, pid int) {
+	t.Helper()
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int {
+		if _, err := os.Stat(argsFile); err == nil {
+			return pid
+		}
+		return 0
+	}
+}
+
+func TestSupervisorSystemdDelegationFromEnv(t *testing.T) {
+	cases := []struct {
+		name    string
+		unit    string
+		scope   string
+		wantOK  bool
+		wantErr bool
+		want    systemdDelegation
+	}{
+		{name: "unset env yields no delegation"},
+		{name: "blank unit yields no delegation", unit: "   "},
+		{
+			name:   "default scope is system",
+			unit:   "gascity-prod.service",
+			wantOK: true,
+			want:   systemdDelegation{Unit: "gascity-prod.service", Scope: "system"},
+		},
+		{
+			name:   "explicit system scope",
+			unit:   "gascity-prod.service",
+			scope:  "system",
+			wantOK: true,
+			want:   systemdDelegation{Unit: "gascity-prod.service", Scope: "system"},
+		},
+		{
+			name:   "explicit user scope",
+			unit:   "gascity-prod.service",
+			scope:  "user",
+			wantOK: true,
+			want:   systemdDelegation{Unit: "gascity-prod.service", Scope: "user"},
+		},
+		{
+			name:    "invalid scope is an error not a silent system fallback",
+			unit:    "gascity-prod.service",
+			scope:   "remote",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(supervisorSystemdUnitEnv, tc.unit)
+			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+			got, ok, err := supervisorSystemdDelegation()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("supervisorSystemdDelegation() err = nil, want scope error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("supervisorSystemdDelegation() err = %v, want nil", err)
+			}
+			if ok != tc.wantOK {
+				t.Fatalf("supervisorSystemdDelegation() ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("supervisorSystemdDelegation() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSystemdDelegationCommandShapes(t *testing.T) {
+	sys := systemdDelegation{Unit: "u.service", Scope: "system"}
+	usr := systemdDelegation{Unit: "u.service", Scope: "user"}
+	if got := strings.Join(sys.systemctlArgs("start"), " "); got != "start u.service" {
+		t.Errorf("system scope start args = %q, want %q", got, "start u.service")
+	}
+	if got := strings.Join(usr.systemctlArgs("stop"), " "); got != "--user stop u.service" {
+		t.Errorf("user scope stop args = %q, want %q", got, "--user stop u.service")
+	}
+	if got := sys.commandHint("restart"); got != "systemctl restart u.service" {
+		t.Errorf("system scope hint = %q, want %q", got, "systemctl restart u.service")
+	}
+	if got := usr.commandHint("restart"); got != "systemctl --user restart u.service" {
+		t.Errorf("user scope hint = %q, want %q", got, "systemctl --user restart u.service")
+	}
+}
+
+func TestSupervisorStartDelegatesToSystemctl(t *testing.T) {
+	cases := []struct {
+		name     string
+		scope    string
+		wantArgs string
+	}{
+		{name: "system scope", scope: "", wantArgs: "start gascity-prod.service"},
+		{name: "user scope", scope: "user", wantArgs: "--user start gascity-prod.service"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GC_HOME", t.TempDir())
+			t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+			argsFile := installFakeDelegatedSystemctl(t, 0, "")
+			stubSupervisorAliveAfterSystemctl(t, argsFile, 4242)
+
+			var stdout, stderr bytes.Buffer
+			if code := doSupervisorStart(&stdout, &stderr); code != 0 {
+				t.Fatalf("doSupervisorStart code = %d, want 0; stderr=%q", code, stderr.String())
+			}
+			lines := readRecordedSystemctlArgs(t, argsFile)
+			if len(lines) != 1 || lines[0] != tc.wantArgs {
+				t.Fatalf("systemctl invocations = %v, want exactly [%q]", lines, tc.wantArgs)
+			}
+			if !strings.Contains(stdout.String(), "Supervisor started (PID 4242)") {
+				t.Errorf("stdout = %q, want ready line with PID 4242", stdout.String())
+			}
+		})
+	}
+}
+
+func TestSupervisorStartDelegatedSystemctlFailureSurfacesError(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	installFakeDelegatedSystemctl(t, 5, "Unit gascity-prod.service not found.")
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 0 }
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorStart(&stdout, &stderr); code != 1 {
+		t.Fatalf("doSupervisorStart code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "systemctl start gascity-prod.service") {
+		t.Errorf("stderr = %q, want failing systemctl command named", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Unit gascity-prod.service not found.") {
+		t.Errorf("stderr = %q, want systemctl output included", stderr.String())
+	}
+}
+
+func TestSupervisorStartDelegationInvalidScopeFails(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	t.Setenv(supervisorSystemdScopeEnv, "remote")
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorStart(&stdout, &stderr); code != 1 {
+		t.Fatalf("doSupervisorStart code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), supervisorSystemdScopeEnv) {
+		t.Errorf("stderr = %q, want %s named", stderr.String(), supervisorSystemdScopeEnv)
+	}
+}
+
+func TestSupervisorStopDelegatesToSystemctl(t *testing.T) {
+	cases := []struct {
+		name     string
+		scope    string
+		wantArgs string
+	}{
+		{name: "system scope", scope: "", wantArgs: "stop gascity-prod.service"},
+		{name: "user scope", scope: "user", wantArgs: "--user stop gascity-prod.service"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Fresh GC_HOME with no supervisor socket: the legacy stop path
+			// would fail with "supervisor is not running"; the delegated
+			// path must not touch the control socket at all.
+			t.Setenv("GC_HOME", t.TempDir())
+			t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+			argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+			var stdout, stderr bytes.Buffer
+			if code := stopSupervisorWithWait(&stdout, &stderr, false, 0); code != 0 {
+				t.Fatalf("stopSupervisorWithWait code = %d, want 0; stderr=%q", code, stderr.String())
+			}
+			lines := readRecordedSystemctlArgs(t, argsFile)
+			if len(lines) != 1 || lines[0] != tc.wantArgs {
+				t.Fatalf("systemctl invocations = %v, want exactly [%q]", lines, tc.wantArgs)
+			}
+			if !strings.Contains(stdout.String(), "Supervisor stopped.") {
+				t.Errorf("stdout = %q, want %q", stdout.String(), "Supervisor stopped.")
+			}
+		})
+	}
+}
+
+func TestSupervisorStopDelegatedSystemctlFailureSurfacesError(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	installFakeDelegatedSystemctl(t, 4, "Interactive authentication required.")
+
+	var stdout, stderr bytes.Buffer
+	if code := stopSupervisorWithWait(&stdout, &stderr, false, 0); code != 1 {
+		t.Fatalf("stopSupervisorWithWait code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "systemctl stop gascity-prod.service") {
+		t.Errorf("stderr = %q, want failing systemctl command named", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Interactive authentication required.") {
+		t.Errorf("stderr = %q, want systemctl output included", stderr.String())
+	}
+}
+
+func TestEnsureSupervisorRunningDelegatesToSystemctl(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+	stubSupervisorAliveAfterSystemctl(t, argsFile, 4242)
+
+	var stdout, stderr bytes.Buffer
+	if code := ensureSupervisorRunning(&stdout, &stderr); code != 0 {
+		t.Fatalf("ensureSupervisorRunning code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	// Exactly one `systemctl start <unit>` call: install (daemon-reload,
+	// enable, ...) must never run in delegated mode, and the fake records
+	// every systemctl invocation, so extra lines would expose it.
+	lines := readRecordedSystemctlArgs(t, argsFile)
+	if len(lines) != 1 || lines[0] != "start gascity-prod.service" {
+		t.Fatalf("systemctl invocations = %v, want exactly [%q]", lines, "start gascity-prod.service")
+	}
+}
+
+func TestEnsureSupervisorRunningDelegatedAlreadyRunningSkipsSystemctl(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 99 }
+
+	var stdout, stderr bytes.Buffer
+	if code := ensureSupervisorRunning(&stdout, &stderr); code != 0 {
+		t.Fatalf("ensureSupervisorRunning code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(argsFile); !os.IsNotExist(err) {
+		t.Fatalf("systemctl was invoked for an already-running supervisor; recorded args: %v",
+			readRecordedSystemctlArgs(t, argsFile))
+	}
+}
+
+// TestRunStartDriftCheck_DelegatedRestartUsesTryRestart pins the drift
+// auto-restart path under GC_SUPERVISOR_SYSTEMD_UNIT: the restart is a
+// single `systemctl try-restart <unit>` and none of gc's own restart
+// machinery (user-unit systemctl, launchctl, SIGTERM+respawn) fires.
+func TestRunStartDriftCheck_DelegatedRestartUsesTryRestart(t *testing.T) {
+	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
+	setCommit("new-build-id")
+
+	oldDry, oldNoAR := dryRunMode, noAutoRestartMode
+	dryRunMode, noAutoRestartMode = false, false
+	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
+
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	oldHelpers := restartHelpersHook
+	t.Cleanup(func() { restartHelpersHook = oldHelpers })
+	restartHelpersHook = func() restartHelpers {
+		return restartHelpers{
+			Systemctl: func(...string) error {
+				t.Error("delegated drift restart must not use gc's systemd-managed branch")
+				return nil
+			},
+			Launchctl: func(...string) error {
+				t.Error("delegated drift restart must not use launchctl")
+				return nil
+			},
+			Kill: func(int) error {
+				t.Error("delegated drift restart must not SIGTERM the supervisor")
+				return nil
+			},
+			WaitExit: func(int) error { return nil },
+			Spawn: func(string, ...string) error {
+				t.Error("delegated drift restart must not respawn the supervisor directly")
+				return nil
+			},
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if !cont {
+		t.Fatalf("cont = false after delegated restart; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	lines := readRecordedSystemctlArgs(t, argsFile)
+	if len(lines) != 1 || lines[0] != "try-restart gascity-prod.service" {
+		t.Fatalf("systemctl invocations = %v, want exactly [%q]", lines, "try-restart gascity-prod.service")
+	}
+	if !strings.Contains(stdout.String(), "Restarting supervisor (systemd-delegated)") {
+		t.Errorf("stdout = %q, want systemd-delegated restart mode line", stdout.String())
+	}
+}
+
+// TestRunStartDriftCheck_KillSwitchGuidance pins the operator remediation
+// text on the kill-switch arm: the default text references gc's own user
+// unit, and a configured GC_SUPERVISOR_SYSTEMD_UNIT/_SCOPE replaces it
+// with the delegated unit's systemctl command.
+func TestRunStartDriftCheck_KillSwitchGuidance(t *testing.T) {
+	cases := []struct {
+		name  string
+		unit  string
+		scope string
+		want  string
+	}{
+		{
+			name: "default guidance names gc's user unit",
+			want: "Restart manually with 'systemctl --user restart gascity-supervisor'.",
+		},
+		{
+			name: "delegated system unit",
+			unit: "gascity-prod.service",
+			want: "Restart manually with 'systemctl restart gascity-prod.service'.",
+		},
+		{
+			name:  "delegated user unit",
+			unit:  "gascity-prod.service",
+			scope: "user",
+			want:  "Restart manually with 'systemctl --user restart gascity-prod.service'.",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath, setCommit := driftCheckEnv(t, "old-build-id")
+			setCommit("new-build-id")
+
+			oldDry, oldNoAR := dryRunMode, noAutoRestartMode
+			dryRunMode, noAutoRestartMode = false, false
+			t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
+
+			t.Setenv(supervisorSystemdUnitEnv, tc.unit)
+			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+
+			cityToml := "[workspace]\nname = \"drift-guidance\"\n\n[daemon]\nauto_restart_on_drift = false\n"
+			if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+				t.Fatalf("writing city.toml: %v", err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
+			if exitCode != 1 {
+				t.Fatalf("exitCode = %d, want 1 (kill switch); stderr=%q", exitCode, stderr.String())
+			}
+			if cont {
+				t.Fatalf("cont = true on kill-switch drift; should be terminal")
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Errorf("stderr = %q, want guidance %q", stderr.String(), tc.want)
+			}
+		})
+	}
+}
+
+// TestRunStartDriftCheck_NoAutoRestartGuidanceUsesDelegatedUnit pins the
+// --no-auto-restart remediation text under delegation.
+func TestRunStartDriftCheck_NoAutoRestartGuidanceUsesDelegatedUnit(t *testing.T) {
+	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
+	setCommit("new-build-id")
+
+	oldDry, oldNoAR := dryRunMode, noAutoRestartMode
+	dryRunMode, noAutoRestartMode = false, true
+	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
+
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+
+	var stdout, stderr bytes.Buffer
+	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
+	if exitCode != 1 || cont {
+		t.Fatalf("(exitCode, cont) = (%d, %v), want (1, false); stderr=%q", exitCode, cont, stderr.String())
+	}
+	want := "rerun 'gc start' (or 'systemctl restart gascity-prod.service') to apply changes."
+	if !strings.Contains(stderr.String(), want) {
+		t.Errorf("stderr = %q, want guidance %q", stderr.String(), want)
+	}
+}

--- a/cmd/gc/supervisor_systemd_delegate_test.go
+++ b/cmd/gc/supervisor_systemd_delegate_test.go
@@ -2,28 +2,61 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 // installFakeDelegatedSystemctl writes an executable `systemctl` shim into a fresh
 // temp dir, prepends that dir to PATH, and returns the path of the file
 // the shim appends its argv into (one line per invocation). The shim
-// prints stderrMsg to stderr (when non-empty) and exits with exitCode, so
-// tests can model both healthy and failing systemctl runs without a real
-// systemd anywhere near the test.
+// prints stderrMsg to stderr (when non-empty) and exits with exitCode for
+// mutating verbs, so tests can model both healthy and failing systemctl
+// runs without a real systemd anywhere near the test. `is-active` probes
+// are special-cased to exit 0 (unit active) without printing stderrMsg,
+// keeping unit state independent of the mutating verb's outcome.
 func installFakeDelegatedSystemctl(t *testing.T, exitCode int, stderrMsg string) string {
+	t.Helper()
+	return installFakeDelegatedSystemctlWithUnitState(t, exitCode, stderrMsg, 0)
+}
+
+// installFakeDelegatedSystemctlWithUnitState is installFakeDelegatedSystemctl
+// with an explicit exit code for `is-active` probes (0 = active, non-zero
+// = inactive).
+func installFakeDelegatedSystemctlWithUnitState(t *testing.T, exitCode int, stderrMsg string, isActiveExit int) string {
 	t.Helper()
 	dir := t.TempDir()
 	argsFile := filepath.Join(dir, "systemctl-args")
 	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\n", argsFile)
+	script += fmt.Sprintf("case \" $* \" in *\" is-active \"*) exit %d ;; esac\n", isActiveExit)
 	if stderrMsg != "" {
 		script += fmt.Sprintf("echo %q >&2\n", stderrMsg)
 	}
 	script += fmt.Sprintf("exit %d\n", exitCode)
+	if err := os.WriteFile(filepath.Join(dir, "systemctl"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake systemctl: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsFile
+}
+
+// installFakeDelegatedSystemctlHangingStop installs a shim whose `stop`
+// invocation hangs (exec sleep) so tests can prove the CLI bounds the
+// systemctl wait. is-active probes report active; other verbs succeed.
+func installFakeDelegatedSystemctlHangingStop(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "systemctl-args")
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\ncase \" $* \" in *\" is-active \"*) exit 0 ;; *\" stop \"*) exec sleep 5 ;; esac\nexit 0\n", argsFile)
 	if err := os.WriteFile(filepath.Join(dir, "systemctl"), []byte(script), 0o755); err != nil {
 		t.Fatalf("writing fake systemctl: %v", err)
 	}
@@ -62,6 +95,21 @@ func stubSupervisorAliveAfterSystemctl(t *testing.T, argsFile string, pid int) {
 		}
 		return 0
 	}
+}
+
+// decodeLifecycleJSONLine parses the single JSONL summary line a
+// delegated --json lifecycle action emits.
+func decodeLifecycleJSONLine(t *testing.T, out string) map[string]any {
+	t.Helper()
+	line := strings.TrimSpace(out)
+	if line == "" || strings.ContainsRune(line, '\n') {
+		t.Fatalf("expected exactly one JSON line, got %q", out)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(line), &payload); err != nil {
+		t.Fatalf("unmarshaling %q: %v", line, err)
+	}
+	return payload
 }
 
 func TestSupervisorSystemdDelegationFromEnv(t *testing.T) {
@@ -141,6 +189,12 @@ func TestSystemdDelegationCommandShapes(t *testing.T) {
 	if got := usr.commandHint("restart"); got != "systemctl --user restart u.service" {
 		t.Errorf("user scope hint = %q, want %q", got, "systemctl --user restart u.service")
 	}
+	if got := strings.Join(sys.systemctlIsActiveArgs(), " "); got != "is-active --quiet u.service" {
+		t.Errorf("system scope is-active args = %q, want %q", got, "is-active --quiet u.service")
+	}
+	if got := strings.Join(usr.systemctlIsActiveArgs(), " "); got != "--user is-active --quiet u.service" {
+		t.Errorf("user scope is-active args = %q, want %q", got, "--user is-active --quiet u.service")
+	}
 }
 
 func TestSupervisorStartDelegatesToSystemctl(t *testing.T) {
@@ -172,6 +226,25 @@ func TestSupervisorStartDelegatesToSystemctl(t *testing.T) {
 				t.Errorf("stdout = %q, want ready line with PID 4242", stdout.String())
 			}
 		})
+	}
+}
+
+func TestSupervisorStartDelegatedJSON(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+	stubSupervisorAliveAfterSystemctl(t, argsFile, 4242)
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorStartJSON(&stdout, &stderr, true); code != 0 {
+		t.Fatalf("doSupervisorStartJSON code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	payload := decodeLifecycleJSONLine(t, stdout.String())
+	if payload["ok"] != true || payload["command"] != "supervisor start" || payload["action"] != "start" {
+		t.Errorf("payload = %v, want ok=true command=%q action=%q", payload, "supervisor start", "start")
+	}
+	if pid, _ := payload["supervisor_pid"].(float64); int(pid) != 4242 {
+		t.Errorf("payload supervisor_pid = %v, want 4242", payload["supervisor_pid"])
 	}
 }
 
@@ -212,18 +285,30 @@ func TestSupervisorStartDelegationInvalidScopeFails(t *testing.T) {
 
 func TestSupervisorStopDelegatesToSystemctl(t *testing.T) {
 	cases := []struct {
-		name     string
-		scope    string
-		wantArgs string
+		name      string
+		scope     string
+		wantProbe string
+		wantStop  string
 	}{
-		{name: "system scope", scope: "", wantArgs: "stop gascity-prod.service"},
-		{name: "user scope", scope: "user", wantArgs: "--user stop gascity-prod.service"},
+		{
+			name:      "system scope",
+			scope:     "",
+			wantProbe: "is-active --quiet gascity-prod.service",
+			wantStop:  "stop gascity-prod.service",
+		},
+		{
+			name:      "user scope",
+			scope:     "user",
+			wantProbe: "--user is-active --quiet gascity-prod.service",
+			wantStop:  "--user stop gascity-prod.service",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Fresh GC_HOME with no supervisor socket: the legacy stop path
 			// would fail with "supervisor is not running"; the delegated
-			// path must not touch the control socket at all.
+			// path trusts the active unit instead and never drives the
+			// destructive control-socket stop protocol.
 			t.Setenv("GC_HOME", t.TempDir())
 			t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
 			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
@@ -234,13 +319,140 @@ func TestSupervisorStopDelegatesToSystemctl(t *testing.T) {
 				t.Fatalf("stopSupervisorWithWait code = %d, want 0; stderr=%q", code, stderr.String())
 			}
 			lines := readRecordedSystemctlArgs(t, argsFile)
-			if len(lines) != 1 || lines[0] != tc.wantArgs {
-				t.Fatalf("systemctl invocations = %v, want exactly [%q]", lines, tc.wantArgs)
+			if len(lines) != 2 || lines[0] != tc.wantProbe || lines[1] != tc.wantStop {
+				t.Fatalf("systemctl invocations = %v, want exactly [%q %q]", lines, tc.wantProbe, tc.wantStop)
 			}
 			if !strings.Contains(stdout.String(), "Supervisor stopped.") {
 				t.Errorf("stdout = %q, want %q", stdout.String(), "Supervisor stopped.")
 			}
 		})
+	}
+}
+
+func TestSupervisorStopDelegatedJSON(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	installFakeDelegatedSystemctl(t, 0, "")
+
+	var stdout, stderr bytes.Buffer
+	if code := stopSupervisorWithWaitJSON(&stdout, &stderr, false, 0, true); code != 0 {
+		t.Fatalf("stopSupervisorWithWaitJSON code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	payload := decodeLifecycleJSONLine(t, stdout.String())
+	if payload["ok"] != true || payload["command"] != "supervisor stop" || payload["action"] != "stop" {
+		t.Errorf("payload = %v, want ok=true command=%q action=%q", payload, "supervisor stop", "stop")
+	}
+	if payload["message"] != "Supervisor stopped." {
+		t.Errorf("payload message = %v, want %q", payload["message"], "Supervisor stopped.")
+	}
+	if payload["wait"] != false {
+		t.Errorf("payload wait = %v, want false", payload["wait"])
+	}
+}
+
+// TestSupervisorStopDelegatedVerifiesSupervisorExit pins the managed
+// happy path: a supervisor that was alive before the delegated stop and
+// disappears once `systemctl stop` ran reports success.
+func TestSupervisorStopDelegatedVerifiesSupervisorExit(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int {
+		data, err := os.ReadFile(argsFile)
+		if err == nil && strings.Contains(string(data), "stop gascity-prod.service") {
+			return 0
+		}
+		return 4242
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := stopSupervisorWithWait(&stdout, &stderr, false, 0); code != 0 {
+		t.Fatalf("stopSupervisorWithWait code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Supervisor stopped.") {
+		t.Errorf("stdout = %q, want %q", stdout.String(), "Supervisor stopped.")
+	}
+}
+
+// TestSupervisorStopDelegatedUnmanagedSupervisorFails pins the false-success
+// fix: `systemctl stop` no-ops when the live supervisor is not managed by
+// the delegated unit, so the stop must fail naming the surviving PID
+// instead of printing "Supervisor stopped.".
+func TestSupervisorStopDelegatedUnmanagedSupervisorFails(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 4343 }
+	oldVerify := delegatedStopVerifyTimeout
+	delegatedStopVerifyTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { delegatedStopVerifyTimeout = oldVerify })
+
+	var stdout, stderr bytes.Buffer
+	if code := stopSupervisorWithWait(&stdout, &stderr, false, 0); code != 1 {
+		t.Fatalf("stopSupervisorWithWait code = %d, want 1; stdout=%q", code, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Supervisor stopped.") {
+		t.Errorf("stdout = %q, must not report success for an unmanaged supervisor", stdout.String())
+	}
+	for _, want := range []string{"still running (PID 4343)", "gascity-prod.service", supervisorSystemdUnitEnv} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+	lines := readRecordedSystemctlArgs(t, argsFile)
+	if len(lines) != 1 || lines[0] != "stop gascity-prod.service" {
+		t.Fatalf("systemctl invocations = %v, want exactly the stop (a live supervisor needs no is-active probe)", lines)
+	}
+}
+
+// TestSupervisorStopDelegatedNothingRunningKeepsExit1 pins the legacy
+// scriptable contract: stop with no live supervisor and an inactive unit
+// still exits 1 with "supervisor is not running" instead of a false
+// "Supervisor stopped.".
+func TestSupervisorStopDelegatedNothingRunningKeepsExit1(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctlWithUnitState(t, 0, "", 3)
+
+	var stdout, stderr bytes.Buffer
+	if code := stopSupervisorWithWait(&stdout, &stderr, false, 0); code != 1 {
+		t.Fatalf("stopSupervisorWithWait code = %d, want 1; stdout=%q", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "supervisor is not running") {
+		t.Errorf("stderr = %q, want legacy not-running message", stderr.String())
+	}
+	lines := readRecordedSystemctlArgs(t, argsFile)
+	if len(lines) != 1 || lines[0] != "is-active --quiet gascity-prod.service" {
+		t.Fatalf("systemctl invocations = %v, want only the is-active probe (no stop of an inactive unit)", lines)
+	}
+}
+
+// TestSupervisorStopDelegatedWaitTimeoutBoundsSystemctl pins the CLI
+// contract: --wait-timeout bounds the synchronous systemctl stop instead
+// of letting a wedged unit hold the command for systemd's own timeout.
+func TestSupervisorStopDelegatedWaitTimeoutBoundsSystemctl(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	installFakeDelegatedSystemctlHangingStop(t)
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	code := stopSupervisorWithWait(&stdout, &stderr, true, 300*time.Millisecond)
+	elapsed := time.Since(start)
+	if code != 1 {
+		t.Fatalf("stopSupervisorWithWait code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("delegated stop took %s; --wait-timeout=300ms did not bound the systemctl invocation", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "timed out after") {
+		t.Errorf("stderr = %q, want systemctl timeout named", stderr.String())
 	}
 }
 
@@ -299,10 +511,342 @@ func TestEnsureSupervisorRunningDelegatedAlreadyRunningSkipsSystemctl(t *testing
 	}
 }
 
+// TestEnsureSupervisorRunningDelegatedTimeoutPointsAtUnit pins the
+// readiness-timeout diagnostic in delegated mode: a delegated supervisor
+// logs to the journal, so the message must point at the unit's systemctl
+// status command, not gc's fork-mode log file.
+func TestEnsureSupervisorRunningDelegatedTimeoutPointsAtUnit(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	installFakeDelegatedSystemctl(t, 0, "")
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 0 }
+	oldTimeout := supervisorReadyTimeout
+	supervisorReadyTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { supervisorReadyTimeout = oldTimeout })
+
+	var stdout, stderr bytes.Buffer
+	if code := ensureSupervisorRunning(&stdout, &stderr); code != 1 {
+		t.Fatalf("ensureSupervisorRunning code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "check 'systemctl status gascity-prod.service'") {
+		t.Errorf("stderr = %q, want systemctl status guidance", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "supervisor.log") {
+		t.Errorf("stderr = %q, must not point at the fork-mode log file in delegated mode", stderr.String())
+	}
+}
+
+// TestSupervisorStatusDelegatedUnitFallback pins the control-socket
+// fallback under delegation: when the socket is unreachable (the common
+// case for a system-scope unit running under another uid), status must
+// probe the delegated unit at its configured scope, not gc's own user
+// unit.
+func TestSupervisorStatusDelegatedUnitFallback(t *testing.T) {
+	cases := []struct {
+		name         string
+		scope        string
+		isActiveExit int
+		wantProbe    string
+		wantRunning  bool
+	}{
+		{
+			name:        "system scope active unit reports running",
+			scope:       "",
+			wantProbe:   "is-active --quiet gascity-prod.service",
+			wantRunning: true,
+		},
+		{
+			name:        "user scope active unit reports running",
+			scope:       "user",
+			wantProbe:   "--user is-active --quiet gascity-prod.service",
+			wantRunning: true,
+		},
+		{
+			name:         "inactive unit reports not running",
+			scope:        "",
+			isActiveExit: 3,
+			wantProbe:    "is-active --quiet gascity-prod.service",
+			wantRunning:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GC_HOME", t.TempDir())
+			t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+			argsFile := installFakeDelegatedSystemctlWithUnitState(t, 0, "", tc.isActiveExit)
+
+			oldAPI := supervisorAPIReachable
+			supervisorAPIReachable = func() bool { return false }
+			t.Cleanup(func() { supervisorAPIReachable = oldAPI })
+
+			var stdout bytes.Buffer
+			code := supervisorStatusWithOptions(&stdout, io.Discard, false)
+			if tc.wantRunning {
+				if code != 0 {
+					t.Fatalf("supervisorStatusWithOptions code = %d, want 0; stdout=%q", code, stdout.String())
+				}
+				if !strings.Contains(stdout.String(), "service_manager") {
+					t.Errorf("stdout = %q, want liveness confirmed via service_manager", stdout.String())
+				}
+			} else {
+				if code != 1 {
+					t.Fatalf("supervisorStatusWithOptions code = %d, want 1; stdout=%q", code, stdout.String())
+				}
+				if !strings.Contains(stdout.String(), "Supervisor is not running") {
+					t.Errorf("stdout = %q, want not-running report", stdout.String())
+				}
+			}
+			lines := readRecordedSystemctlArgs(t, argsFile)
+			if len(lines) != 1 || lines[0] != tc.wantProbe {
+				t.Fatalf("systemctl invocations = %v, want exactly [%q]", lines, tc.wantProbe)
+			}
+		})
+	}
+}
+
+// TestSupervisorStatusInvalidDelegationScope pins that the one read-only
+// lifecycle command surfaces a broken delegation env instead of
+// swallowing it: with an invalid GC_SUPERVISOR_SYSTEMD_SCOPE, status must
+// name the configuration error in both output modes (a stderr line, plus
+// a config_error field in --json) rather than letting an unreachable
+// control socket read as a bare "Supervisor is not running". Every
+// mutating sibling hard-errors on the same typo; status is the command
+// operators and monitoring run first when debugging that migration. The
+// unit probe must not run — an unparseable scope leaves no trustworthy
+// unit to ask.
+func TestSupervisorStatusInvalidDelegationScope(t *testing.T) {
+	setup := func(t *testing.T, apiReachable bool) string {
+		t.Helper()
+		t.Setenv("GC_HOME", t.TempDir())
+		t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+		t.Setenv(supervisorSystemdScopeEnv, "systme")
+		argsFile := installFakeDelegatedSystemctl(t, 0, "")
+		oldAPI := supervisorAPIReachable
+		supervisorAPIReachable = func() bool { return apiReachable }
+		t.Cleanup(func() { supervisorAPIReachable = oldAPI })
+		return argsFile
+	}
+	const wantErrText = `invalid GC_SUPERVISOR_SYSTEMD_SCOPE="systme"`
+
+	t.Run("text mode names the config error and keeps the not-running exit", func(t *testing.T) {
+		argsFile := setup(t, false)
+		var stdout, stderr bytes.Buffer
+		code := supervisorStatusWithOptions(&stdout, &stderr, false)
+		if code != 1 {
+			t.Fatalf("supervisorStatusWithOptions code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "Supervisor is not running") {
+			t.Errorf("stdout = %q, want not-running report", stdout.String())
+		}
+		if !strings.Contains(stderr.String(), wantErrText) {
+			t.Errorf("stderr = %q, want config error naming %s", stderr.String(), wantErrText)
+		}
+		if _, err := os.Stat(argsFile); !os.IsNotExist(err) {
+			t.Errorf("systemctl probe ran despite unparseable scope: %v", readRecordedSystemctlArgs(t, argsFile))
+		}
+	})
+
+	t.Run("json mode embeds config_error", func(t *testing.T) {
+		setup(t, false)
+		var stdout, stderr bytes.Buffer
+		code := supervisorStatusWithOptions(&stdout, &stderr, true)
+		if code != 0 {
+			t.Fatalf("supervisorStatusWithOptions code = %d, want 0 (JSON encodes run-state in the payload); stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+		var payload struct {
+			Running     bool   `json:"running"`
+			ConfigError string `json:"config_error"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+			t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+		}
+		if payload.Running {
+			t.Errorf("running = true, want false; payload stdout=%q", stdout.String())
+		}
+		if !strings.Contains(payload.ConfigError, wantErrText) {
+			t.Errorf("config_error = %q, want it to name %s", payload.ConfigError, wantErrText)
+		}
+	})
+
+	t.Run("config error still surfaces when liveness comes from the api", func(t *testing.T) {
+		setup(t, true)
+		var stdout, stderr bytes.Buffer
+		code := supervisorStatusWithOptions(&stdout, &stderr, false)
+		if code != 0 {
+			t.Fatalf("supervisorStatusWithOptions code = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "liveness confirmed via api") {
+			t.Errorf("stdout = %q, want running-via-api report", stdout.String())
+		}
+		if !strings.Contains(stderr.String(), wantErrText) {
+			t.Errorf("stderr = %q, want config error naming %s", stderr.String(), wantErrText)
+		}
+	})
+}
+
+// TestSupervisorInstallRefusesDelegation pins the install guard: gc must
+// not write or load its own service files while the supervisor lifecycle
+// is delegated to an operator-managed unit.
+func TestSupervisorInstallRefusesDelegation(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorInstall(&stdout, &stderr); code != 1 {
+		t.Fatalf("doSupervisorInstall code = %d, want 1; stdout=%q", code, stdout.String())
+	}
+	for _, want := range []string{supervisorSystemdUnitEnv, "gascity-prod.service", "delegated"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestSupervisorInstallInvalidDelegationScopeFails(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	t.Setenv(supervisorSystemdScopeEnv, "remote")
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorInstall(&stdout, &stderr); code != 1 {
+		t.Fatalf("doSupervisorInstall code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), supervisorSystemdScopeEnv) {
+		t.Errorf("stderr = %q, want %s named", stderr.String(), supervisorSystemdScopeEnv)
+	}
+}
+
+// TestSupervisorUninstallWarnsAndSkipsDelegatedUnit pins the uninstall
+// guard: with delegation configured, uninstall warns, removes only
+// gc-owned service state, and never issues a systemctl command against
+// the delegated unit.
+func TestSupervisorUninstallWarnsAndSkipsDelegatedUnit(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	supervisorSystemctlActive = func(string) bool { return false }
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorUninstall(&stdout, &stderr); code != 0 {
+		t.Fatalf("doSupervisorUninstall code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "does not touch the delegated unit") {
+		t.Errorf("stderr = %q, want delegation warning", stderr.String())
+	}
+	for _, call := range calls {
+		if strings.Contains(call, "gascity-prod.service") {
+			t.Fatalf("systemctl call %q targets the delegated unit during uninstall", call)
+		}
+	}
+	if _, err := os.Stat(argsFile); !os.IsNotExist(err) {
+		t.Fatalf("uninstall invoked PATH systemctl against the delegated unit; recorded args: %v",
+			readRecordedSystemctlArgs(t, argsFile))
+	}
+}
+
+// TestUninstallSupervisorSystemdUnderDelegationStopsOwnUnitViaSocket pins
+// the blast-radius fix: uninstalling gc's own active unit while
+// delegation is configured must drive the graceful control-socket stop of
+// gc's own supervisor — not `systemctl stop <delegated-unit>`, which
+// would take down the operator's production supervisor as a side effect.
+func TestUninstallSupervisorSystemdUnderDelegationStopsOwnUnitViaSocket(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := shortTempDir(t, "gc-home-")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	currentPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", supervisorSystemdServiceName())
+	if err := os.MkdirAll(filepath.Dir(currentPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(currentPath), err)
+	}
+	if err := os.WriteFile(currentPath, []byte("current unit\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", currentPath, err)
+	}
+
+	var (
+		mu             sync.Mutex
+		socketStopSeen bool
+		stopped        bool
+	)
+	sockPath := supervisorSocketPath()
+	startTestSupervisorSocket(t, sockPath, func(cmd string) string {
+		mu.Lock()
+		defer mu.Unlock()
+		switch cmd {
+		case "ping":
+			if stopped {
+				return ""
+			}
+			return "4242\n"
+		case "stop":
+			socketStopSeen = true
+			stopped = true
+			return "ok\ndone:ok\n"
+		}
+		return ""
+	})
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	supervisorSystemctlRun = func(...string) error { return nil }
+	supervisorSystemctlActive = func(service string) bool {
+		return service == supervisorSystemdServiceName()
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorSystemd(&supervisorServiceData{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstallSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !socketStopSeen {
+		t.Fatal("uninstall did not stop gc's own supervisor through the control socket")
+	}
+	if _, err := os.Stat(argsFile); !os.IsNotExist(err) {
+		t.Fatalf("uninstall invoked PATH systemctl (delegated redirect leaked into uninstall); recorded args: %v",
+			readRecordedSystemctlArgs(t, argsFile))
+	}
+}
+
 // TestRunStartDriftCheck_DelegatedRestartUsesTryRestart pins the drift
 // auto-restart path under GC_SUPERVISOR_SYSTEMD_UNIT: the restart is a
 // single `systemctl try-restart <unit>` and none of gc's own restart
-// machinery (user-unit systemctl, launchctl, SIGTERM+respawn) fires.
+// machinery (user-unit systemctl, launchctl, SIGTERM+respawn) fires. The
+// fake systemctl restarts nothing and /health keeps serving the old
+// build, so the check must FAIL: declaring "ready" here would leave every
+// subsequent `gc start` in a detect → no-op → "ready" treadmill against a
+// supervisor the unit does not manage.
 func TestRunStartDriftCheck_DelegatedRestartUsesTryRestart(t *testing.T) {
 	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
 	setCommit("new-build-id")
@@ -340,11 +884,11 @@ func TestRunStartDriftCheck_DelegatedRestartUsesTryRestart(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
-	if exitCode != 0 {
-		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	if exitCode != 1 {
+		t.Fatalf("exitCode = %d, want 1 (supervisor was not replaced); stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
 	}
-	if !cont {
-		t.Fatalf("cont = false after delegated restart; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	if cont {
+		t.Fatalf("cont = true after a no-op delegated restart; drift is unresolved and must be terminal")
 	}
 	lines := readRecordedSystemctlArgs(t, argsFile)
 	if len(lines) != 1 || lines[0] != "try-restart gascity-prod.service" {
@@ -352,6 +896,156 @@ func TestRunStartDriftCheck_DelegatedRestartUsesTryRestart(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Restarting supervisor (systemd-delegated)") {
 		t.Errorf("stdout = %q, want systemd-delegated restart mode line", stdout.String())
+	}
+	for _, want := range []string{"was not replaced", "gascity-prod.service", "old-build-id"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+// TestRunStartDriftCheck_DelegatedRestartReplacementSucceeds pins the
+// delegated happy path: when try-restart actually replaces the
+// supervisor (served build identity flips), the drift check reports
+// ready and continues into normal registration.
+func TestRunStartDriftCheck_DelegatedRestartReplacementSucceeds(t *testing.T) {
+	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
+	setCommit("new-build-id")
+
+	oldDry, oldNoAR := dryRunMode, noAutoRestartMode
+	dryRunMode, noAutoRestartMode = false, false
+	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
+
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	// Serve the old build until the fake systemctl has run (argsFile
+	// exists), then the new build — modeling a unit restart that swaps
+	// the supervisor binary.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		build := "old-build-id"
+		if _, err := os.Stat(argsFile); err == nil {
+			build = "new-build-id"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"status":"ok","version":"v0","build_id":%q,"uptime_sec":1,"cities_total":0,"cities_running":0}`, build)
+	}))
+	t.Cleanup(srv.Close)
+	oldURL := supervisorAPIBaseURLHook
+	supervisorAPIBaseURLHook = func() (string, error) { return srv.URL, nil }
+	t.Cleanup(func() { supervisorAPIBaseURLHook = oldURL })
+
+	var stdout, stderr bytes.Buffer
+	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if !cont {
+		t.Fatalf("cont = false after a successful delegated restart; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	lines := readRecordedSystemctlArgs(t, argsFile)
+	if len(lines) != 1 || lines[0] != "try-restart gascity-prod.service" {
+		t.Fatalf("systemctl invocations = %v, want exactly [%q]", lines, "try-restart gascity-prod.service")
+	}
+	if !strings.Contains(stdout.String(), " ready (") {
+		t.Errorf("stdout = %q, want ready line after verified replacement", stdout.String())
+	}
+}
+
+// TestRunStartDriftCheck_DelegatedRestartNewPIDStillDriftedFails pins the
+// replaced-but-still-stale arm: the delegated unit genuinely restarts the
+// supervisor (new PID) but its ExecStart still launches the drifted
+// binary, so /health keeps serving the old build. Verification must fail
+// — a PID change is replacement evidence, not drift resolution — or
+// every later `gc start` re-detects the same drift and bounces the whole
+// supervisor again.
+func TestRunStartDriftCheck_DelegatedRestartNewPIDStillDriftedFails(t *testing.T) {
+	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
+	setCommit("new-build-id")
+
+	oldDry, oldNoAR := dryRunMode, noAutoRestartMode
+	dryRunMode, noAutoRestartMode = false, false
+	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
+
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	// Once the fake systemctl has run (argsFile exists), liveness reports
+	// a new PID while driftCheckEnv's /health keeps serving old-build-id —
+	// a real restart whose ExecStart points at a stale binary.
+	basePID := os.Getpid()
+	oldAlive := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = oldAlive })
+	supervisorAliveHook = func() int {
+		if _, err := os.Stat(argsFile); err == nil {
+			return basePID + 1
+		}
+		return basePID
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
+	if exitCode != 1 {
+		t.Fatalf("exitCode = %d, want 1 (drift unresolved after replacement); stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if cont {
+		t.Fatalf("cont = true after a still-drifted delegated restart; drift is unresolved and must be terminal")
+	}
+	lines := readRecordedSystemctlArgs(t, argsFile)
+	if len(lines) != 1 || lines[0] != "try-restart gascity-prod.service" {
+		t.Fatalf("systemctl invocations = %v, want exactly [%q]", lines, "try-restart gascity-prod.service")
+	}
+	for _, want := range []string{"still serves drifted build", "old-build-id", "new-build-id", "gascity-prod.service", "ExecStart"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+// TestRunStartDriftCheck_DelegatedRestartVerifyProbeFailureFails pins
+// fail-closed verification: when the post-restart /health response cannot
+// be decoded, the drift check must fail with a diagnostic instead of
+// skipping verification and declaring "ready" — the fail-open would
+// reproduce exactly the false success the verification exists to prevent.
+func TestRunStartDriftCheck_DelegatedRestartVerifyProbeFailureFails(t *testing.T) {
+	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
+	setCommit("new-build-id")
+
+	oldDry, oldNoAR := dryRunMode, noAutoRestartMode
+	dryRunMode, noAutoRestartMode = false, false
+	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
+
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	// Serve valid /health JSON until the fake systemctl has run, then a
+	// 200 with an undecodable body: PollReady's Ping (status-code only)
+	// still passes, while the verification Status decode fails.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := os.Stat(argsFile); err == nil {
+			_, _ = io.WriteString(w, "not json")
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"status":"ok","version":"v0","build_id":"old-build-id","uptime_sec":1,"cities_total":0,"cities_running":0}`)
+	}))
+	t.Cleanup(srv.Close)
+	oldURL := supervisorAPIBaseURLHook
+	supervisorAPIBaseURLHook = func() (string, error) { return srv.URL, nil }
+	t.Cleanup(func() { supervisorAPIBaseURLHook = oldURL })
+
+	var stdout, stderr bytes.Buffer
+	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
+	if exitCode != 1 {
+		t.Fatalf("exitCode = %d, want 1 (unverifiable restart); stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if cont {
+		t.Fatalf("cont = true after an unverifiable delegated restart; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"cannot verify supervisor", "try-restart gascity-prod.service"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr = %q, want %q", stderr.String(), want)
+		}
 	}
 }
 
@@ -411,6 +1105,39 @@ func TestRunStartDriftCheck_KillSwitchGuidance(t *testing.T) {
 				t.Errorf("stderr = %q, want guidance %q", stderr.String(), tc.want)
 			}
 		})
+	}
+}
+
+// TestRunStartDriftCheck_KillSwitchGuidanceNamesInvalidScope pins the
+// no-silent-fallback invariant on the kill-switch arm: a scope typo must
+// surface the bad env value in the guidance instead of silently naming
+// gc's default user unit.
+func TestRunStartDriftCheck_KillSwitchGuidanceNamesInvalidScope(t *testing.T) {
+	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
+	setCommit("new-build-id")
+
+	oldDry, oldNoAR := dryRunMode, noAutoRestartMode
+	dryRunMode, noAutoRestartMode = false, false
+	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
+
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	t.Setenv(supervisorSystemdScopeEnv, "systme")
+
+	cityToml := "[workspace]\nname = \"drift-guidance\"\n\n[daemon]\nauto_restart_on_drift = false\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("writing city.toml: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
+	if exitCode != 1 || cont {
+		t.Fatalf("(exitCode, cont) = (%d, %v), want (1, false); stderr=%q", exitCode, cont, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `invalid GC_SUPERVISOR_SYSTEMD_SCOPE="systme"`) {
+		t.Errorf("stderr = %q, want invalid scope value named in guidance", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "gascity-supervisor") {
+		t.Errorf("stderr = %q, must not silently fall back to the default unit text", stderr.String())
 	}
 }
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -378,6 +378,50 @@ Scope and caveats:
   defaults, so a hand-edited unit at gc's service path stays journal-only
   only on hosts where gc never manages the unit.
 
+## Delegating the Supervisor Lifecycle to an Operator-Managed systemd Unit
+
+By default `gc` owns the supervisor lifecycle: `gc start` installs and
+starts a per-user service (`gascity-supervisor`), and binary-drift
+detection restarts that service directly. Hosts that run the supervisor
+under an operator-managed systemd unit instead — for example a hardened
+system service with its own restart policy — can delegate the lifecycle:
+
+```bash
+GC_SUPERVISOR_SYSTEMD_UNIT=gascity-prod.service  # unit that owns the supervisor
+GC_SUPERVISOR_SYSTEMD_SCOPE=system               # "system" (default) or "user"
+```
+
+With the unit configured:
+
+- `gc supervisor start` and the `gc start` ensure path run
+  `systemctl [--user] start <unit>` and wait for the control socket to
+  answer. gc never writes, loads, or daemon-reloads its own service
+  files in delegated mode; `gc supervisor install` refuses to run, and
+  `gc supervisor uninstall` only removes gc's own legacy service.
+- `gc supervisor stop` runs `systemctl [--user] stop <unit>`
+  synchronously, bounded by `--wait-timeout` (default 30s) whether or
+  not `--wait` is set, then verifies a previously-running supervisor
+  actually exited. A live supervisor the unit does not manage (common
+  mid-migration) fails the stop with its PID instead of reporting a
+  false "Supervisor stopped.", and stop with nothing running keeps the
+  legacy exit-1 "supervisor is not running" contract.
+- The `gc start` drift auto-restart runs `systemctl try-restart <unit>`
+  (a unit the operator stopped stays stopped) and fails unless the
+  restart verifiably resolved the drift: a supervisor that was not
+  replaced, a replacement still serving the drifted build (the unit's
+  `ExecStart` launches a stale binary), or an unverifiable post-restart
+  probe each fail instead of declaring "ready" while a stale supervisor
+  keeps serving.
+- `gc supervisor status` probes the delegated unit
+  (`systemctl [--user] is-active <unit>`) when the control socket is
+  unreachable — the usual situation for a system-scope unit running
+  under a different user — and reports a broken delegation config (a
+  warning in text mode, a `config_error` field in `--json`) instead of
+  a bare "not running".
+
+An invalid `GC_SUPERVISOR_SYSTEMD_SCOPE` value is a hard error on every
+lifecycle path; gc never silently falls back to the default unit.
+
 ## JSONL Archive Push Failures
 
 The core pack runs `jsonl-export` every 15 minutes to dump each bead

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3781,6 +3781,13 @@ most callers that need deterministic cleanup want (e.g., integration
 tests that then expect to remove temp directories without racing
 against lingering supervisor / controller subprocesses).
 
+When GC_SUPERVISOR_SYSTEMD_UNIT is set, stop is delegated to
+'systemctl [--user] stop &lt;unit&gt;' instead of the control-socket stop.
+The systemctl invocation is synchronous and bounded by --wait-timeout
+whether or not --wait is set, gc then verifies a previously-running
+supervisor actually exited (failing with its PID when the unit does
+not manage it), and stop with nothing running still exits 1.
+
 ```
 gc supervisor stop [flags]
 ```
@@ -3789,7 +3796,7 @@ gc supervisor stop [flags]
 |------|------|---------|-------------|
 | `--json` | bool |  | emit JSONL summary |
 | `--wait` | bool |  | Wait for the supervisor to finish stopping all managed cities and release its socket before returning |
-| `--wait-timeout` | duration | `30s` | Maximum time to wait when --wait is set |
+| `--wait-timeout` | duration | `30s` | Maximum time to wait when --wait is set (in delegated mode, bounds the synchronous systemctl stop regardless of --wait) |
 
 ## gc supervisor uninstall
 

--- a/docs/troubleshooting/gc-start-walkthrough.mdx
+++ b/docs/troubleshooting/gc-start-walkthrough.mdx
@@ -117,6 +117,12 @@ systemctl --user restart gascity-supervisor
 gc start
 ```
 
+If the supervisor lifecycle is delegated to an operator-managed unit via
+`GC_SUPERVISOR_SYSTEMD_UNIT` (see "Delegating the Supervisor Lifecycle"
+in the troubleshooting guide), restart that unit instead:
+`systemctl restart <unit>`, with `--user` for user-scope units. The
+drift messages print the exact command for the configured unit.
+
 Verify after restart:
 
 ```bash


### PR DESCRIPTION
## Problem

Bead: ga-z2l4q4 (design §5 item 3, maintainer-city production).

When an operator-managed systemd unit owns the supervisor, gc's lifecycle paths fight it:

- `gc supervisor start` forks a detached `gc supervisor run` behind systemd's back (and `gc start` additionally installs/loads gc's own user service files).
- `gc supervisor stop` drives the destructive control-socket stop and unloads the platform service.
- The `gc start` drift auto-restart path SIGTERMs and respawns the binary directly, racing the unit's restart policy.
- The drift kill-switch guidance at `cmd/gc/cmd_start_drift.go:275` hardcodes `systemctl --user restart gascity-supervisor`, which is wrong for a system-scope production unit.

## Fix

New operator env vars (documented on the constants in `cmd/gc/supervisor_systemd_delegate.go`):

- `GC_SUPERVISOR_SYSTEMD_UNIT=<unit>` — delegate the supervisor lifecycle to that systemd unit.
- `GC_SUPERVISOR_SYSTEMD_SCOPE=system|user` (default `system`) — which manager the unit lives in. An invalid scope is a hard error, not a silent fallback.

When delegation is configured:

- `gc supervisor start` and the `gc start` ensure path exec `systemctl [--user] start <unit>` and wait for readiness; gc's own service-file install never runs.
- `gc supervisor stop` execs `systemctl [--user] stop <unit>` instead of the destructive socket stop + service unload.
- The drift auto-restart execs `systemctl [--user] try-restart <unit>` so a unit the operator stopped stays stopped.
- Drift remediation messages (`kill-switch`, `--no-auto-restart`, restart-timeout) render the configured unit/scope instead of the hardcoded user-unit text.

## Testing

TDD: failing-first was proven by (1) removing the implementation file — every new test fails to build — and (2) restoring the helper but reverting the wiring hunks in `cmd_start_drift.go` / `cmd_supervisor.go` / `cmd_supervisor_lifecycle.go` — the stop, drift try-restart, and guidance-text tests fail behaviorally (legacy socket-stop error, SIGTERM/respawn helpers firing, stale `gascity-supervisor` guidance).

- `go test ./cmd/gc/ -run 'TestSupervisorSystemdDelegation|TestSystemdDelegationCommandShapes|TestSupervisorStartDelegat|TestSupervisorStopDelegat|TestEnsureSupervisorRunningDelegat|TestRunStartDriftCheck_Delegated|TestRunStartDriftCheck_KillSwitchGuidance|TestRunStartDriftCheck_NoAutoRestartGuidance'` — pass. Tests inject a fake `systemctl` via PATH that records argv, so no real systemd is touched.
- `go vet ./...` and `go build ./...` clean.
- `make test` in the isolated sandbox — pass.

## Not included (follow-up)

`gc supervisor install --system` was scoped out: it needs a root-owned unit template, `/etc/systemd/system` paths, and privilege handling — not a small addition, and redundant when the operator already manages the unit being delegated to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
