### PR TITLE
feat(api): bearer-token auth on supervisor API mutation surface (ga-7otii0)

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1136,6 +1136,10 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	if len(supCfg.Supervisor.AllowedHosts) > 0 {
 		apiMux.WithAllowedHosts(supCfg.Supervisor.AllowedHosts)
 	}
+	if token := api.SupervisorAPITokenFromEnv(); token != "" {
+		apiMux.WithAPIToken(token)
+		fmt.Fprintf(stdout, "gc supervisor: api: bearer-token auth enabled on mutation endpoints (%s)\n", api.SupervisorAPITokenEnv) //nolint:errcheck
+	}
 
 	pprofSrv, pprofErr := api.StartPprof("")
 	if pprofErr != nil {

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -24,6 +24,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/processenv"
 	"github.com/gastownhall/gascity/internal/processgroup"
@@ -941,6 +942,7 @@ var supervisorServiceEnvKeys = map[string]bool{
 	"GC_DOLT_LOGLEVEL":                         true,
 	"GC_DOLT_PASSWORD":                         true,
 	"GC_DOLT_USER":                             true,
+	api.SupervisorAPITokenEnv:                  true,
 	"T3_HOME":                                  true,
 	"T3_WS_URL":                                true,
 	"T3CODE_HOME":                              true,

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -828,6 +828,25 @@ func TestBuildSupervisorServiceDataForwardsCuratedProviderCredentialEnvKeys(t *t
 	}
 }
 
+func TestBuildSupervisorServiceDataPersistsSupervisorAPIToken(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+	t.Setenv(api.SupervisorAPITokenEnv, "service-token-probe")
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	if got[api.SupervisorAPITokenEnv] != "service-token-probe" {
+		t.Errorf("ExtraEnv[%s] = %q, want %q — token must survive launchd/systemd service start",
+			api.SupervisorAPITokenEnv, got[api.SupervisorAPITokenEnv], "service-token-probe")
+	}
+}
+
 func TestBuildSupervisorServiceDataReadsAllowlistedDoltCredentialKeysFromLaunchctl(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -1335,6 +1335,10 @@ func runController(
 		// handler return 501 for create/unregister routes.
 		apiMux := api.NewSupervisorMux(&singleCityStateResolver{state: cs}, nil, readOnly, "controller", commit, time.Now())
 		apiMux.WithAnyHostAllowed()
+		if token := api.SupervisorAPITokenFromEnv(); token != "" {
+			apiMux.WithAPIToken(token)
+			fmt.Fprintf(stdout, "api: bearer-token auth enabled on mutation endpoints (%s)\n", api.SupervisorAPITokenEnv) //nolint:errcheck
+		}
 		addr := net.JoinHostPort(bind, strconv.Itoa(cfg.API.Port))
 		apiLis, apiErr := net.Listen("tcp", addr)
 		if apiErr != nil {

--- a/internal/api/auth_token.go
+++ b/internal/api/auth_token.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// SupervisorAPITokenEnv is the environment variable holding the shared
+// bearer token that gates supervisor API mutations. When the supervisor
+// process starts with this set, every mutating (POST/PUT/PATCH/DELETE)
+// request must carry "Authorization: Bearer <token>"; reads stay open.
+// The gc CLI client reads the same variable and attaches the header
+// automatically, so CLI-routed mutations keep working unchanged.
+const SupervisorAPITokenEnv = "GC_SUPERVISOR_API_TOKEN"
+
+// SupervisorAPITokenFromEnv returns the configured supervisor API bearer
+// token, trimmed of surrounding whitespace (so file-sourced exports with a
+// trailing newline behave). Empty means token auth is disabled.
+func SupervisorAPITokenFromEnv() string {
+	return strings.TrimSpace(os.Getenv(SupervisorAPITokenEnv))
+}
+
+// withBearerTokenAuth enforces a shared bearer token on mutating requests
+// when token is non-empty. Reads (GET/HEAD; OPTIONS is answered by the CORS
+// layer) pass through so loopback observability — dashboard reads, event
+// streams, status lines — keeps working without credential plumbing; the
+// destructive surface is the defense-in-depth target. Runs at the mux level
+// so it covers the /svc/* proxy as well as every Huma operation. Token
+// comparison is constant-time.
+func withBearerTokenAuth(token string, next http.Handler) http.Handler {
+	if token == "" {
+		return next
+	}
+	want := []byte(token)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isMutationMethod(r.Method) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		got, ok := bearerToken(r.Header.Get("Authorization"))
+		if !ok || subtle.ConstantTimeCompare([]byte(got), want) != 1 {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="gc-supervisor"`)
+			problemAPITokenRequired.writeTo(w)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// setSupervisorAPITokenHeader attaches the GC_SUPERVISOR_API_TOKEN bearer
+// token to req when one is configured in the client's environment. Sent on
+// every request (reads included) — the server only requires it on mutations,
+// and a stray Authorization header on open reads is harmless.
+func setSupervisorAPITokenHeader(req *http.Request) {
+	if token := SupervisorAPITokenFromEnv(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+}
+
+// bearerToken extracts the token from an Authorization header value.
+// Returns false when the header is absent, uses a non-Bearer scheme, or
+// carries an empty token.
+func bearerToken(header string) (string, bool) {
+	const prefix = "Bearer "
+	if len(header) < len(prefix) || !strings.EqualFold(header[:len(prefix)], prefix) {
+		return "", false
+	}
+	tok := strings.TrimSpace(header[len(prefix):])
+	return tok, tok != ""
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -308,6 +308,7 @@ func (c *Client) waitForEvent(ctx context.Context, requestID string, successType
 	}
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("X-GC-Request", "true")
+	setSupervisorAPITokenHeader(req)
 
 	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
@@ -429,6 +430,7 @@ func newClient(baseURL, cityName string) *Client {
 		genclient.WithHTTPClient(httpClient),
 		genclient.WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
 			req.Header.Set("X-GC-Request", "true")
+			setSupervisorAPITokenHeader(req)
 			return nil
 		}),
 	)

--- a/internal/api/client_token_auth_test.go
+++ b/internal/api/client_token_auth_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The CLI client reads GC_SUPERVISOR_API_TOKEN from its own environment and
+// sends it as Authorization: Bearer on every request, so a token-gated
+// supervisor (ga-7otii0) keeps accepting CLI-routed mutations.
+
+func TestClientSendsBearerTokenFromEnv(t *testing.T) {
+	t.Setenv(SupervisorAPITokenEnv, "tok-123\n")
+
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`)) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	if err := c.SuspendCity(); err != nil {
+		t.Fatalf("SuspendCity: %v", err)
+	}
+	if gotAuth != "Bearer tok-123" {
+		t.Fatalf("Authorization = %q, want %q (token trimmed of whitespace)", gotAuth, "Bearer tok-123")
+	}
+}
+
+func TestClientOmitsAuthorizationWhenTokenUnset(t *testing.T) {
+	t.Setenv(SupervisorAPITokenEnv, "")
+
+	var gotAuth string
+	var sawAuth bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, sawAuth = r.Header["Authorization"]
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`)) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	if err := c.SuspendCity(); err != nil {
+		t.Fatalf("SuspendCity: %v", err)
+	}
+	if sawAuth {
+		t.Fatalf("Authorization = %q, want header absent when no token configured", gotAuth)
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -61,6 +61,10 @@ var (
 		status: http.StatusMisdirectedRequest,
 		body:   []byte(`{"status":421,"title":"Misdirected Request","detail":"host_not_allowed: supervisor Host header is not allowed"}`),
 	}
+	problemAPITokenRequired = problemBody{
+		status: http.StatusUnauthorized,
+		body:   []byte(`{"status":401,"title":"Unauthorized","detail":"unauthorized: mutation endpoints require Authorization: Bearer <token> (GC_SUPERVISOR_API_TOKEN is configured on this supervisor)"}`),
+	}
 )
 
 type dataSourceKey struct{}

--- a/internal/api/supervisor.go
+++ b/internal/api/supervisor.go
@@ -113,6 +113,7 @@ type SupervisorMux struct {
 	allowedOrigins []string
 	allowedHosts   []string
 	allowAnyHost   bool
+	apiToken       string
 	server         *http.Server
 
 	// Single Huma API (Phase 3.5 — Topology 1). Owns every typed
@@ -199,13 +200,17 @@ func (sm *SupervisorMux) serveCitySvcProxy(w http.ResponseWriter, r *http.Reques
 //     Server's own middleware stack.
 //   - /svc/* paths bypass CSRF/read-only entirely (workspace services apply
 //     their own publication rules).
+//   - Bearer-token auth (withBearerTokenAuth, active only when an API token
+//     is configured) runs innermost at the mux level so it gates every
+//     mutating request uniformly — Huma operations and /svc/* alike — after
+//     Host validation (421 wins) and CORS preflight handling.
 func (sm *SupervisorMux) Handler() http.Handler {
 	root := http.HandlerFunc(sm.ServeHTTP)
 	audit := requestAuditConfig{
 		recorder:       sm.supervisorEventRecorder(),
 		allowedOrigins: sm.allowedOrigins,
 	}
-	return withLogging(withRecovery(withRequestID(withHostAllowing(sm.allowAnyHost, sm.allowedHosts, audit, withCORSAllowing(sm.allowedOrigins, root)))), audit)
+	return withLogging(withRecovery(withRequestID(withHostAllowing(sm.allowAnyHost, sm.allowedHosts, audit, withCORSAllowing(sm.allowedOrigins, withBearerTokenAuth(sm.apiToken, root))))), audit)
 }
 
 // WithAllowedOrigins sets extra CORS origins accepted beyond localhost and
@@ -221,6 +226,17 @@ func (sm *SupervisorMux) WithAllowedOrigins(origins []string) *SupervisorMux {
 // Serve.
 func (sm *SupervisorMux) WithAllowedHosts(hosts []string) *SupervisorMux {
 	sm.allowedHosts = hosts
+	sm.server = &http.Server{Handler: sm.Handler()}
+	return sm
+}
+
+// WithAPIToken sets a shared bearer token required on every mutating
+// (POST/PUT/PATCH/DELETE) request — Huma operations and the /svc/* proxy
+// alike — and rebuilds the internal http.Server handler. Reads stay open.
+// An empty token disables token auth (the default). Must be called before
+// Serve.
+func (sm *SupervisorMux) WithAPIToken(token string) *SupervisorMux {
+	sm.apiToken = token
 	sm.server = &http.Server{Handler: sm.Handler()}
 	return sm
 }

--- a/internal/api/supervisor_token_auth_test.go
+++ b/internal/api/supervisor_token_auth_test.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Bearer-token auth on the supervisor mutation surface (ga-7otii0).
+// When a token is configured, every mutating method (POST/PUT/PATCH/DELETE)
+// requires Authorization: Bearer <token>; reads stay open so loopback
+// observability (dashboard reads, event streams) keeps working.
+
+func TestSupervisorAPITokenMutationWithoutTokenUnauthorized(t *testing.T) {
+	sm := newTestSupervisorMux(t, map[string]*fakeState{})
+	sm.WithAPIToken("seekrit")
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8372/v0/city/ghost/unregister", nil)
+	req.Header.Set("X-GC-Request", "true")
+	rec := httptest.NewRecorder()
+
+	sm.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/problem+json") {
+		t.Fatalf("Content-Type = %q, want application/problem+json", got)
+	}
+	if !strings.Contains(rec.Body.String(), "unauthorized") {
+		t.Fatalf("body = %q, want unauthorized problem detail", rec.Body.String())
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); !strings.HasPrefix(got, "Bearer") {
+		t.Fatalf("WWW-Authenticate = %q, want Bearer challenge", got)
+	}
+}
+
+func TestSupervisorAPITokenMutationWithWrongTokenUnauthorized(t *testing.T) {
+	sm := newTestSupervisorMux(t, map[string]*fakeState{})
+	sm.WithAPIToken("seekrit")
+
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"wrong token", "Bearer not-the-token"},
+		{"empty bearer", "Bearer "},
+		{"wrong scheme", "Basic c2Vla3JpdA=="},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8372/v0/city/ghost/unregister", nil)
+			req.Header.Set("X-GC-Request", "true")
+			req.Header.Set("Authorization", tc.value)
+			rec := httptest.NewRecorder()
+
+			sm.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestSupervisorAPITokenMutationWithTokenReachesHandler(t *testing.T) {
+	sm := newTestSupervisorMux(t, map[string]*fakeState{})
+	sm.WithAPIToken("seekrit")
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8372/v0/city/ghost/unregister", nil)
+	req.Header.Set("X-GC-Request", "true")
+	req.Header.Set("Authorization", "Bearer seekrit")
+	rec := httptest.NewRecorder()
+
+	sm.Handler().ServeHTTP(rec, req)
+
+	// nil initializer → the handler itself answers 501. Anything but
+	// 401/403 proves the request cleared token auth and CSRF.
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d (handler reached); body=%s", rec.Code, http.StatusNotImplemented, rec.Body.String())
+	}
+}
+
+func TestSupervisorAPITokenReadsStayOpen(t *testing.T) {
+	sm := newTestSupervisorMux(t, map[string]*fakeState{})
+	sm.WithAPIToken("seekrit")
+
+	for _, path := range []string{"/v0/cities", "/health"} {
+		req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8372"+path, nil)
+		rec := httptest.NewRecorder()
+
+		sm.Handler().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want %d; body=%s", path, rec.Code, http.StatusOK, rec.Body.String())
+		}
+	}
+}
+
+func TestSupervisorAPITokenCoversSvcProxyMutations(t *testing.T) {
+	sm := newTestSupervisorMux(t, map[string]*fakeState{})
+	sm.WithAPIToken("seekrit")
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8372/v0/city/ghost/svc/myservice/run", strings.NewReader("{}"))
+	rec := httptest.NewRecorder()
+
+	sm.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestSupervisorAPITokenUnsetLeavesMutationsOpen(t *testing.T) {
+	sm := newTestSupervisorMux(t, map[string]*fakeState{})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8372/v0/city/ghost/unregister", nil)
+	req.Header.Set("X-GC-Request", "true")
+	rec := httptest.NewRecorder()
+
+	sm.Handler().ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatalf("status = %d; token auth must be disabled when no token is configured (body=%s)", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d (handler reached); body=%s", rec.Code, http.StatusNotImplemented, rec.Body.String())
+	}
+}
+
+func TestSupervisorAPITokenHostRejectionPrecedesTokenAuth(t *testing.T) {
+	sm := newTestSupervisorMux(t, map[string]*fakeState{})
+	sm.WithAPIToken("seekrit")
+
+	req := httptest.NewRequest(http.MethodPost, "http://evil.example:8372/v0/city/ghost/unregister", nil)
+	rec := httptest.NewRecorder()
+
+	sm.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusMisdirectedRequest, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "unauthorized") {
+		t.Fatalf("body = %q, host rejection must happen before token auth", rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Problem

The `:8372` supervisor API trusts loopback alone. Agents on this box share the host network namespace, and a sandboxed test reached the live API and **deregistered the production city** (bead `ga-7otii0`). Loopback is not a sufficient boundary; the design calls for bearer-token auth as defense in depth alongside `bwrap --unshare-net`.

## Fix

- **New mux-level middleware `withBearerTokenAuth`** (`internal/api/auth_token.go`): when `GC_SUPERVISOR_API_TOKEN` is set in the supervisor's environment, every mutating request (POST/PUT/PATCH/DELETE) requires `Authorization: Bearer <token>`. Missing/wrong tokens get a pre-serialized 401 `problem+json` (per the API control-plane error-body convention) plus a `WWW-Authenticate` challenge; comparison is constant-time.
- **Reads stay open** (GET/HEAD): loopback observability — dashboard reads, event streams, status — keeps working with zero credential plumbing. The destructive surface is the defense-in-depth target; gating reads would break the browser dashboard (which cannot carry the token) for no incident-relevant gain.
- **Uniform coverage**: the gate sits at the mux level, inside Host validation (421 wins) and CORS preflight handling, so it covers every Huma operation *and* the untyped `/svc/*` proxy identically.
- **`gc` CLI keeps working**: `internal/api/client.go` reads the same env var and attaches the header on every request (genclient request editor + the SSE wait-for-event path). All CLI mutation routing flows through this client (`cmd/gc/apiroute.go:apiClient()`).
- **Standalone controller** (`gc controller` / `gc serve`) gets the same opt-in gate.
- **Service persistence**: `GC_SUPERVISOR_API_TOKEN` is added to the supervisor service env allowlist so launchd/systemd-started supervisors keep the token across restarts.

**OpenAPI intentionally unchanged**: like the Host-allowlist gate (421), token auth is deployment-conditional perimeter middleware at the mux level — not part of the typed per-operation contract. Declaring optional bearer security on every operation would misdescribe both the open and the locked-down posture. `make dashboard-check` and `TestOpenAPISpecInSync` confirm no spec drift.

## Testing

TDD. Failing-first proven by reverting the implementation hunks (mux `Handler()` wiring reverted; `client.go` + `cmd_supervisor_lifecycle.go` hunks stashed) and watching the new tests fail meaningfully (501-instead-of-401, missing header, missing env key), then restoring and watching them pass:

- `internal/api`: `TestSupervisorAPITokenMutationWithoutTokenUnauthorized`, `...WithWrongTokenUnauthorized` (wrong token / empty bearer / wrong scheme), `...WithTokenReachesHandler`, `TestSupervisorAPITokenReadsStayOpen`, `...CoversSvcProxyMutations`, `...UnsetLeavesMutationsOpen`, `...HostRejectionPrecedesTokenAuth`, `TestClientSendsBearerTokenFromEnv` (token trimmed), `TestClientOmitsAuthorizationWhenTokenUnset`
- `cmd/gc`: `TestBuildSupervisorServiceDataPersistsSupervisorAPIToken`
- Full `go test ./internal/api/` pass; full sandboxed `make test` (bwrap, isolated /tmp) pass twice; `go vet ./...` clean; `make dashboard-check` pass.

## Follow-ups (out of scope)

- Sessions spawned by a token-bearing supervisor can inherit the env var. Production agents are `bwrap --unshare-net` sandboxed (the primary layer); scrubbing `GC_SUPERVISOR_API_TOKEN` from session-spawn environments is a candidate hardening follow-up across runtime providers.
- The browser dashboard cannot present the token, so dashboard *mutations* 401 when a token is configured (reads unaffected). Acceptable for the production posture this targets.

Refs: ga-7otii0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
