### PR TITLE
feat(testenv): refuse local prod Dolt port 3307 in test binaries (ga-4c2ss6)

### DIFF
--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -44,9 +44,21 @@
 // In that mode init() skips the scrub so env vars the testscript has
 // deliberately set (via its own `env FOO=bar` line) reach the subcommand.
 // Testscript owns the child env fully, so there is no leak risk.
+//
+// Production Dolt port guard: a Dolt port var (BEADS_DOLT_SERVER_PORT or
+// GC_DOLT_PORT) carrying ProdDoltPort that would survive into the process —
+// passthrough-preserved in go-test mode, or any value in testscript
+// subcommand mode — makes init() panic instead, unless the paired Dolt host
+// var survives with a non-local value (3307 is Dolt's default port, so
+// external-server fixtures like db.example.com:3307 are legitimate). Test
+// debris (testrig, tt, my_db databases) inside the production Dolt store
+// traced back to test clients reaching the local server on port 3307
+// (ga-4c2ss6). For the rare legitimate case, set ProdDoltPortOptOutVar
+// (GC_ALLOW_PROD_DOLT_PORT_IN_TESTS) to "1".
 package testenv
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,11 +120,74 @@ var LeakVectorVars = []string{
 	"GC_TMUX_SESSION",
 }
 
+// ProdDoltPort is the well-known port of the production Dolt server on
+// maintainer hosts. Nothing listens locally on 3307 in any gc-managed test
+// city, so a test binary about to talk to a local Dolt on it can only
+// corrupt the production store.
+const ProdDoltPort = "3307"
+
+// ProdDoltPortOptOutVar names the env var that disables the production
+// Dolt-port guard. Set it to "1" for the rare legitimate case where a test
+// process must deliberately target a local Dolt server on ProdDoltPort.
+const ProdDoltPortOptOutVar = "GC_ALLOW_PROD_DOLT_PORT_IN_TESTS"
+
+// doltPortVars maps each env var that selects a Dolt server port to the env
+// var that selects the matching Dolt server host.
+var doltPortVars = map[string]string{
+	"BEADS_DOLT_SERVER_PORT": "BEADS_DOLT_SERVER_HOST",
+	"GC_DOLT_PORT":           "GC_DOLT_HOST",
+}
+
+// isLocalDoltHost reports whether a Dolt host value targets the local
+// machine: empty (clients default to localhost), "localhost", a loopback
+// address, or an unspecified address.
+func isLocalDoltHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" || host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && (ip.IsLoopback() || ip.IsUnspecified())
+}
+
+// refuseProdDoltPort panics when a Dolt port var that will outlive init()
+// points at the local production Dolt server. survives reports whether the
+// named var survives the scrub: always in testscript subcommand mode,
+// passthrough-listed only in go-test mode. A paired host var that survives
+// with a non-local value disarms the guard for that pair — 3307 is Dolt's
+// default port, so external-server fixtures use it legitimately.
+// ProdDoltPortOptOutVar set to "1" disables the guard entirely.
+func refuseProdDoltPort(survives func(name string) bool) {
+	if os.Getenv(ProdDoltPortOptOutVar) == "1" {
+		return
+	}
+	for portVar, hostVar := range doltPortVars {
+		if !survives(portVar) {
+			continue
+		}
+		if strings.TrimSpace(os.Getenv(portVar)) != ProdDoltPort {
+			continue
+		}
+		host := ""
+		if survives(hostVar) {
+			host = os.Getenv(hostVar)
+		}
+		if !isLocalDoltHost(host) {
+			continue
+		}
+		panic("testenv: " + portVar + "=" + ProdDoltPort + " with a local Dolt host points at the production Dolt server; refusing to run tests against it (set " + ProdDoltPortOptOutVar + "=1 to deliberately allow it)")
+	}
+}
+
 func init() {
 	if !isGoTestBinary() {
 		// Testscript subcommand mode (e.g. this binary was copied to
 		// $PATH/bin/gc by testscript.Main). Testscript owns the child env
 		// exactly — skip the scrub so env vars it sets reach the subcommand.
+		// Every var survives here, so the prod-Dolt-port guard checks all of
+		// them: a testscript-driven gc/bd must never write to the production
+		// store either.
+		refuseProdDoltPort(func(string) bool { return true })
 		return
 	}
 	keep := map[string]bool{}
@@ -124,6 +199,7 @@ func init() {
 		}
 	}
 	_ = os.Unsetenv(PassthroughVar)
+	refuseProdDoltPort(func(name string) bool { return keep[name] })
 	for _, name := range LeakVectorVars {
 		if !keep[name] {
 			_ = os.Unsetenv(name)

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -150,6 +150,211 @@ func TestInitSkipsScrubInTestscriptSubcommandMode(t *testing.T) {
 	}
 }
 
+// TestInitRefusesProdDoltPort verifies init() refuses to let a Dolt port var
+// pointing at the production Dolt server (local host, port 3307) survive into
+// a test process. The guard fires only for values that would outlive the
+// scrub — passthrough-preserved vars in go-test mode, and all vars in
+// testscript subcommand mode (where the scrub is skipped) — and only when the
+// effective Dolt host is local (unset, scrubbed, localhost, or loopback).
+// External hosts on 3307 (Dolt's default port) are legitimate fixtures.
+// Setting GC_ALLOW_PROD_DOLT_PORT_IN_TESTS=1 opts out for the rare
+// legitimate case.
+func TestInitRefusesProdDoltPort(t *testing.T) {
+	if os.Getenv("GC_TESTENV_CHILD") == "1" {
+		// Child: report the Dolt host/port vars as the parent's env shaped them.
+		var lines []string
+		for _, name := range []string{"BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "GC_DOLT_HOST", "GC_DOLT_PORT"} {
+			lines = append(lines, name+"="+os.Getenv(name))
+		}
+		os.Stdout.WriteString(strings.Join(lines, "\n") + "\n") //nolint:errcheck
+		os.Exit(0)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("Executable: %v", err)
+	}
+	// Copy of the test binary under a non-`.test` name, simulating the
+	// testscript.Main subcommand re-invocation where the scrub is skipped.
+	fakeGC := filepath.Join(t.TempDir(), "gc")
+	if err := copyFile(exe, fakeGC); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		bin        string
+		env        []string
+		wantPanic  bool
+		wantOutput []string
+	}{
+		{
+			name: "passthrough BEADS_DOLT_SERVER_PORT prod port panics",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough GC_DOLT_PORT prod port panics",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=GC_DOLT_PORT",
+				"GC_DOLT_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough non-prod port survives",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_PORT=3308",
+			},
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=3308\n"},
+		},
+		{
+			name: "passthrough external host allows prod port",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_HOST,BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_HOST=city-db.example.com",
+				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantOutput: []string{
+				"BEADS_DOLT_SERVER_HOST=city-db.example.com\n",
+				"BEADS_DOLT_SERVER_PORT=3307\n",
+			},
+		},
+		{
+			name: "passthrough loopback host refuses prod port",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_HOST,BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_HOST=127.0.0.1",
+				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough port with scrubbed external host refuses prod port",
+			bin:  exe,
+			env: []string{
+				// Host is set but not passthrough-listed: it will be
+				// scrubbed, so the surviving client defaults to localhost.
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_HOST=city-db.example.com",
+				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough external GC_DOLT_HOST allows prod GC_DOLT_PORT",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=GC_DOLT_HOST,GC_DOLT_PORT",
+				"GC_DOLT_HOST=city-db.example.com",
+				"GC_DOLT_PORT=3307",
+			},
+			wantOutput: []string{
+				"GC_DOLT_HOST=city-db.example.com\n",
+				"GC_DOLT_PORT=3307\n",
+			},
+		},
+		{
+			name: "opt-out allows prod port through passthrough",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_PORT=3307",
+				"GC_ALLOW_PROD_DOLT_PORT_IN_TESTS=1",
+			},
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=3307\n"},
+		},
+		{
+			name: "scrubbed prod port without passthrough does not panic",
+			bin:  exe,
+			env: []string{
+				"BEADS_DOLT_SERVER_PORT=3307",
+				"GC_DOLT_PORT=3307",
+			},
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=\n", "GC_DOLT_PORT=\n"},
+		},
+		{
+			name:      "subcommand mode refuses prod port",
+			bin:       fakeGC,
+			env:       []string{"BEADS_DOLT_SERVER_PORT=3307"},
+			wantPanic: true,
+		},
+		{
+			name:       "subcommand mode keeps non-prod port",
+			bin:        fakeGC,
+			env:        []string{"BEADS_DOLT_SERVER_PORT=3309"},
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=3309\n"},
+		},
+		{
+			name: "subcommand mode external host keeps prod port",
+			bin:  fakeGC,
+			env: []string{
+				"BEADS_DOLT_SERVER_HOST=city-db.example.com",
+				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantOutput: []string{
+				"BEADS_DOLT_SERVER_HOST=city-db.example.com\n",
+				"BEADS_DOLT_SERVER_PORT=3307\n",
+			},
+		},
+		{
+			name: "subcommand mode localhost host refuses prod port",
+			bin:  fakeGC,
+			env: []string{
+				"BEADS_DOLT_SERVER_HOST=localhost",
+				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "subcommand mode opt-out allows prod port",
+			bin:  fakeGC,
+			env: []string{
+				"BEADS_DOLT_SERVER_PORT=3307",
+				"GC_ALLOW_PROD_DOLT_PORT_IN_TESTS=1",
+			},
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=3307\n"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(tc.bin, "-test.run=^TestInitRefusesProdDoltPort$", "-test.v")
+			cmd.Env = append([]string{"GC_TESTENV_CHILD=1"}, tc.env...)
+			out, err := cmd.Output()
+			if tc.wantPanic {
+				if err == nil {
+					t.Fatalf("child succeeded but should have refused the prod Dolt port; output:\n%s", out)
+				}
+				stderr := exitStderr(err)
+				for _, want := range []string{"production Dolt server", "GC_ALLOW_PROD_DOLT_PORT_IN_TESTS"} {
+					if !strings.Contains(stderr, want) {
+						t.Errorf("panic message missing %q; stderr:\n%s", want, stderr)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("re-exec: %v\nstderr: %s", err, exitStderr(err))
+			}
+			for _, want := range tc.wantOutput {
+				if !strings.Contains(string(out), want) {
+					t.Errorf("child output missing %q; got:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
 func copyFile(src, dst string) error {
 	data, err := os.ReadFile(src)
 	if err != nil {


### PR DESCRIPTION
## Problem

Test debris (`testrig`, `tt`, `my_db` databases) showed up inside the production Dolt store on the maintainer host (ga-4c2ss6). Test clients reached the prod server on `localhost:3307`. Nothing listens locally on 3307 in any gc-managed test city, so a test binary about to talk to a local Dolt on that port can only corrupt the production store.

## Fix

Add a guard to `internal/testenv`'s `init()` — the package every test directory must blank-import (enforced by `TestRequiresDedicatedTestenvImportFile`), so every test binary inherits it — analogous to the `GC_HOME` test panic in `supervisor.DefaultHome`.

The guard panics when `BEADS_DOLT_SERVER_PORT` or `GC_DOLT_PORT` carries `3307` AND the value would survive into the process (passthrough-preserved in go-test mode; any value in testscript subcommand mode, where the scrub is skipped) AND the paired Dolt host var (`BEADS_DOLT_SERVER_HOST` / `GC_DOLT_HOST`) is effectively local — unset, scrubbed, `localhost`, loopback, or unspecified.

Deliberate scope boundaries:

- External-host fixtures like `db.example.com:3307` stay legal — 3307 is Dolt's default port and existing cmd/gc external-endpoint tests use it (`TestInitAndHookDirExecGcBeadsBdProjectsInheritedExternalRigEnv` fired the first, port-only version of this guard).
- Values the scrub removes anyway stay non-fatal, so a maintainer-host shell exporting the prod port does not break ordinary `go test` runs.
- `GC_ALLOW_PROD_DOLT_PORT_IN_TESTS=1` opts out for the rare legitimate case, documented on `ProdDoltPortOptOutVar` and in the package doc.

## Testing

- TDD: `TestInitRefusesProdDoltPort` (14 subprocess cases: passthrough/scrub/subcommand modes x local/external hosts x opt-out) written first and verified failing against `origin/main`'s `testenv.go` (3 failures), then passing with the guard; the host-aware cases were verified failing against the intermediate port-only guard before implementing host awareness.
- `go test ./internal/testenv/...` pass; `go test ./cmd/gc/ -run TestInitAndHookDirExecGcBeadsBd` pass.
- `go build ./...` and `go vet ./...` clean.
- Full `make test` green in the isolated sandbox; pre-commit hook (lint + fast suite, all 8 jobs) green at commit time.

Bead: ga-4c2ss6

🤖 Generated with [Claude Code](https://claude.com/claude-code)