### PR TITLE
feat: add gc import status --json and packs.lock sha256 on /health (ga-qcnpu1)

### DIFF
--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -90,6 +90,7 @@ func newImportCmd(stdout, stderr io.Writer) *cobra.Command {
 		newImportInstallCmd(stdout, stderr),
 		newImportUpgradeCmd(stdout, stderr),
 		newImportListCmd(stdout, stderr),
+		newImportStatusCmd(stdout, stderr),
 		newImportWhyCmd(stdout, stderr),
 		newImportMigrateCmd(stdout, stderr),
 		newImportPruneCmd(stdout, stderr),

--- a/cmd/gc/cmd_import_status.go
+++ b/cmd/gc/cmd_import_status.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
+	"github.com/spf13/cobra"
+)
+
+// importStatusSchemaVersion identifies the JSON document emitted by
+// "gc import status --json".
+const importStatusSchemaVersion = "1"
+
+// ImportStatusJSON is the JSON output format for "gc import status --json".
+// It is the machine-readable drift surface for pack imports: every
+// declared import binding across scopes (root pack, default-rig, and
+// rig-scoped), the packs.lock pin closure, and the lockfile content hash.
+type ImportStatusJSON struct {
+	SchemaVersion string `json:"schema_version"`
+	// Root is the absolute city or pack root the status was computed from.
+	Root string `json:"root"`
+	// PacksLockPath is the absolute path of the packs.lock file (which
+	// may not exist; see PacksLockSHA256).
+	PacksLockPath string `json:"packs_lock_path"`
+	// PacksLockSHA256 is the hex-encoded SHA-256 digest of the raw
+	// packs.lock contents. Omitted when the file does not exist.
+	PacksLockSHA256 string `json:"packs_lock_sha256,omitempty"`
+	// Imports lists every declared import binding, sorted by name.
+	Imports []ImportStatusEntry `json:"imports"`
+	// LockedPacks mirrors the full packs.lock closure (direct and
+	// transitive pins), sorted by source.
+	LockedPacks []ImportStatusLockedPack `json:"locked_packs"`
+}
+
+// ImportStatusEntry is one declared import binding in the status output.
+type ImportStatusEntry struct {
+	// Name is the scoped binding key: "pack:<name>" for root-pack
+	// imports, "default-rig:<name>" for default rig imports, and
+	// "rig:<rig>:<name>" for rig-scoped imports.
+	Name string `json:"name"`
+	// Source is the declared source exactly as authored in TOML.
+	Source string `json:"source"`
+	// Constraint is the declared version constraint, when present.
+	Constraint string `json:"constraint,omitempty"`
+	// Kind is "remote" for git-backed sources and "path" for local
+	// directory sources.
+	Kind string `json:"kind"`
+	// Path is the resolved absolute path for kind "path" entries.
+	Path string `json:"path,omitempty"`
+	// Pin is the packs.lock resolution for kind "remote" entries.
+	// Omitted when the source has no lock entry (unlocked).
+	Pin *ImportStatusPin `json:"pin,omitempty"`
+}
+
+// ImportStatusPin is the packs.lock resolution pinned for a remote import.
+type ImportStatusPin struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Fetched string `json:"fetched,omitempty"`
+}
+
+// ImportStatusLockedPack is one packs.lock entry in the status output.
+type ImportStatusLockedPack struct {
+	Source  string `json:"source"`
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Fetched string `json:"fetched,omitempty"`
+}
+
+func newImportStatusCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Report declared imports and packs.lock pins",
+		Long: `Report declared imports and packs.lock pins.
+
+Covers every import scope (root pack [imports.*], [defaults.rig.imports.*],
+and rig-scoped [rigs.imports.*]) plus the full packs.lock closure and the
+lockfile content hash. With --json the output is a stable machine-readable
+document for drift checkers.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cityPath, err := resolveImportRoot()
+			if err != nil {
+				fmt.Fprintf(stderr, "gc import status: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			if doImportStatus(cityPath, jsonOut, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON result")
+	return cmd
+}
+
+// doImportStatus is the pure logic for "gc import status". It reads the
+// declared import set across all scopes plus packs.lock and renders
+// either the human-readable summary or the typed JSON document.
+func doImportStatus(cityPath string, jsonOut bool, stdout, stderr io.Writer) int {
+	status, err := buildImportStatus(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc import status: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	if jsonOut {
+		data, err := json.MarshalIndent(status, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "gc import status: encoding JSON: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		fmt.Fprintln(stdout, string(data)) //nolint:errcheck
+		return 0
+	}
+	writeImportStatusText(stdout, status)
+	return 0
+}
+
+// buildImportStatus assembles the import status document for cityPath.
+func buildImportStatus(cityPath string) (*ImportStatusJSON, error) {
+	fs := fsys.OSFS{}
+	allImports, err := collectAllImportsFS(fs, cityPath)
+	if err != nil {
+		return nil, err
+	}
+	lock, err := readImportLockfile(fs, cityPath)
+	if err != nil {
+		return nil, err
+	}
+
+	lockPath := filepath.Join(cityPath, packman.LockfileName)
+	status := &ImportStatusJSON{
+		SchemaVersion: importStatusSchemaVersion,
+		Root:          cityPath,
+		PacksLockPath: lockPath,
+		Imports:       make([]ImportStatusEntry, 0, len(allImports)),
+		LockedPacks:   make([]ImportStatusLockedPack, 0, len(lock.Packs)),
+	}
+	lockData, err := fs.ReadFile(lockPath)
+	switch {
+	case err == nil:
+		sum := sha256.Sum256(lockData)
+		status.PacksLockSHA256 = hex.EncodeToString(sum[:])
+	case !os.IsNotExist(err):
+		return nil, fmt.Errorf("reading %s: %w", packman.LockfileName, err)
+	}
+
+	names := make([]string, 0, len(allImports))
+	for name := range allImports {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		imp := allImports[name]
+		entry := ImportStatusEntry{
+			Name:       name,
+			Source:     imp.Source,
+			Constraint: imp.Version,
+		}
+		if isRemoteImportSource(imp.Source) {
+			entry.Kind = "remote"
+			if pack, ok := lock.Packs[imp.Source]; ok {
+				entry.Pin = &ImportStatusPin{
+					Version: pack.Version,
+					Commit:  pack.Commit,
+					Fetched: formatImportStatusTime(pack.Fetched),
+				}
+			}
+		} else {
+			entry.Kind = "path"
+			if abs, pathErr := resolveImportAddPath(cityPath, imp.Source); pathErr == nil {
+				entry.Path = abs
+			}
+		}
+		status.Imports = append(status.Imports, entry)
+	}
+
+	sources := make([]string, 0, len(lock.Packs))
+	for source := range lock.Packs {
+		sources = append(sources, source)
+	}
+	sort.Strings(sources)
+	for _, source := range sources {
+		pack := lock.Packs[source]
+		status.LockedPacks = append(status.LockedPacks, ImportStatusLockedPack{
+			Source:  source,
+			Version: pack.Version,
+			Commit:  pack.Commit,
+			Fetched: formatImportStatusTime(pack.Fetched),
+		})
+	}
+	return status, nil
+}
+
+// formatImportStatusTime renders a lock timestamp as RFC 3339 UTC, or
+// "" for the zero value so omitempty drops it from the JSON output.
+func formatImportStatusTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// writeImportStatusText renders the human-readable status: the lock
+// hash followed by one tab-separated line per declared import
+// (name, source, constraint, kind, pinned version, pinned commit).
+func writeImportStatusText(stdout io.Writer, status *ImportStatusJSON) {
+	if status.PacksLockSHA256 != "" {
+		fmt.Fprintf(stdout, "packs.lock sha256: %s\n", status.PacksLockSHA256) //nolint:errcheck
+	} else {
+		fmt.Fprintln(stdout, "packs.lock sha256: (missing)") //nolint:errcheck
+	}
+	for _, entry := range status.Imports {
+		pinnedVersion, pinnedCommit := "", ""
+		switch {
+		case entry.Pin != nil:
+			pinnedVersion = entry.Pin.Version
+			pinnedCommit = entry.Pin.Commit
+		case entry.Kind == "remote":
+			pinnedVersion = "(unlocked)"
+		}
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\n", //nolint:errcheck
+			entry.Name, entry.Source, entry.Constraint, entry.Kind, pinnedVersion, pinnedCommit)
+	}
+}

--- a/cmd/gc/cmd_import_status.go
+++ b/cmd/gc/cmd_import_status.go
@@ -26,6 +26,9 @@ const importStatusSchemaVersion = "1"
 // rig-scoped), the packs.lock pin closure, and the lockfile content hash.
 type ImportStatusJSON struct {
 	SchemaVersion string `json:"schema_version"`
+	// OK is the top-level success discriminator every gc --json result
+	// document must carry (see schemas/import/status/result.schema.json).
+	OK bool `json:"ok"`
 	// Root is the absolute city or pack root the status was computed from.
 	Root string `json:"root"`
 	// PacksLockPath is the absolute path of the packs.lock file (which
@@ -133,19 +136,18 @@ func buildImportStatus(cityPath string) (*ImportStatusJSON, error) {
 	if err != nil {
 		return nil, err
 	}
-	lock, err := readImportLockfile(fs, cityPath)
-	if err != nil {
-		return nil, err
-	}
 
 	lockPath := filepath.Join(cityPath, packman.LockfileName)
 	status := &ImportStatusJSON{
 		SchemaVersion: importStatusSchemaVersion,
+		OK:            true,
 		Root:          cityPath,
 		PacksLockPath: lockPath,
-		Imports:       make([]ImportStatusEntry, 0, len(allImports)),
-		LockedPacks:   make([]ImportStatusLockedPack, 0, len(lock.Packs)),
 	}
+	// Read packs.lock once and derive both the hash and the pins from
+	// the same bytes: a concurrent atomic lockfile rewrite between two
+	// reads could otherwise emit a document whose packs_lock_sha256
+	// does not match its own pin set.
 	lockData, err := fs.ReadFile(lockPath)
 	switch {
 	case err == nil:
@@ -154,6 +156,12 @@ func buildImportStatus(cityPath string) (*ImportStatusJSON, error) {
 	case !os.IsNotExist(err):
 		return nil, fmt.Errorf("reading %s: %w", packman.LockfileName, err)
 	}
+	lock, err := packman.ParseLockfile(lockData)
+	if err != nil {
+		return nil, err
+	}
+	status.Imports = make([]ImportStatusEntry, 0, len(allImports))
+	status.LockedPacks = make([]ImportStatusLockedPack, 0, len(lock.Packs))
 
 	names := make([]string, 0, len(allImports))
 	for name := range allImports {

--- a/cmd/gc/cmd_import_status_test.go
+++ b/cmd/gc/cmd_import_status_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
+)
+
+func importStatusLockFixture(t *testing.T, dir string) string {
+	t.Helper()
+	fetched := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	if err := packman.WriteLockfile(fsys.OSFS{}, dir, &packman.Lockfile{
+		Schema: packman.LockfileSchema,
+		Packs: map[string]packman.LockedPack{
+			"https://example.com/tools.git":  {Version: "1.4.2", Commit: "aaaa", Fetched: fetched},
+			"https://example.com/base.git":   {Version: "2.0.0", Commit: "bbbb", Fetched: fetched},
+			"https://example.com/worker.git": {Version: "3.1.0", Commit: "cccc", Fetched: fetched},
+		},
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, packman.LockfileName))
+	if err != nil {
+		t.Fatalf("ReadFile(packs.lock): %v", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// TestDoImportStatusJSONGolden pins the exact machine-readable document
+// emitted by "gc import status --json": the declared import set with
+// source paths and lock pins, plus the packs.lock closure and its
+// content hash (ga-qcnpu1). Drift checkers consume this instead of
+// parsing "gc import list" text.
+func TestDoImportStatusJSONGolden(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.4"
+
+[imports.local]
+source = "./packs/local"
+
+[defaults.rig.imports.worker]
+source = "https://example.com/worker.git"
+version = "^3.0"
+`)
+	lockSHA := importStatusLockFixture(t, dir)
+
+	var stdout, stderr bytes.Buffer
+	code := doImportStatus(dir, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+
+	want := fmt.Sprintf(`{
+  "schema_version": "1",
+  "root": %[1]q,
+  "packs_lock_path": %[2]q,
+  "packs_lock_sha256": %[3]q,
+  "imports": [
+    {
+      "name": "default-rig:worker",
+      "source": "https://example.com/worker.git",
+      "constraint": "^3.0",
+      "kind": "remote",
+      "pin": {
+        "version": "3.1.0",
+        "commit": "cccc",
+        "fetched": "2026-01-02T03:04:05Z"
+      }
+    },
+    {
+      "name": "pack:local",
+      "source": "./packs/local",
+      "kind": "path",
+      "path": %[4]q
+    },
+    {
+      "name": "pack:tools",
+      "source": "https://example.com/tools.git",
+      "constraint": "^1.4",
+      "kind": "remote",
+      "pin": {
+        "version": "1.4.2",
+        "commit": "aaaa",
+        "fetched": "2026-01-02T03:04:05Z"
+      }
+    }
+  ],
+  "locked_packs": [
+    {
+      "source": "https://example.com/base.git",
+      "version": "2.0.0",
+      "commit": "bbbb",
+      "fetched": "2026-01-02T03:04:05Z"
+    },
+    {
+      "source": "https://example.com/tools.git",
+      "version": "1.4.2",
+      "commit": "aaaa",
+      "fetched": "2026-01-02T03:04:05Z"
+    },
+    {
+      "source": "https://example.com/worker.git",
+      "version": "3.1.0",
+      "commit": "cccc",
+      "fetched": "2026-01-02T03:04:05Z"
+    }
+  ]
+}
+`, dir, filepath.Join(dir, packman.LockfileName), lockSHA, filepath.Join(dir, "packs", "local"))
+
+	if got := stdout.String(); got != want {
+		t.Fatalf("gc import status --json output mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestDoImportStatusJSONIncludesRigScopedImports asserts the status
+// document covers rig-scoped [rigs.imports.*] bindings — the drift
+// surface that "gc import list" only shows with an explicit --rig flag.
+func TestDoImportStatusJSONIncludesRigScopedImports(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, `
+[workspace]
+name = "demo"
+
+[[rigs]]
+name = "myrig"
+
+[rigs.imports.extra]
+source = "/opt/packs/extra"
+`)
+	writePackToml(t, dir, "[pack]\nname = \"demo\"\nschema = 1\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doImportStatus(dir, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `"name": "rig:myrig:extra"`) {
+		t.Fatalf("missing rig-scoped import entry:\n%s", out)
+	}
+	if !strings.Contains(out, `"source": "/opt/packs/extra"`) {
+		t.Fatalf("missing rig-scoped import source:\n%s", out)
+	}
+	if !strings.Contains(out, `"kind": "path"`) {
+		t.Fatalf("missing path kind for rig-scoped import:\n%s", out)
+	}
+}
+
+// TestDoImportStatusJSONOmitsLockHashWhenMissing confirms a city
+// without packs.lock emits no packs_lock_sha256 and an empty (not
+// null) locked_packs array.
+func TestDoImportStatusJSONOmitsLockHashWhenMissing(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, "[pack]\nname = \"demo\"\nschema = 1\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doImportStatus(dir, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "packs_lock_sha256") {
+		t.Fatalf("packs_lock_sha256 present despite missing packs.lock:\n%s", out)
+	}
+	if !strings.Contains(out, `"locked_packs": []`) {
+		t.Fatalf("locked_packs should be an empty array:\n%s", out)
+	}
+	if !strings.Contains(out, `"imports": []`) {
+		t.Fatalf("imports should be an empty array:\n%s", out)
+	}
+}
+
+// TestDoImportStatusTextShowsPins covers the human-readable default:
+// one line per import with its lock pin, prefixed by the lock hash.
+func TestDoImportStatusTextShowsPins(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.4"
+`)
+	lockSHA := importStatusLockFixture(t, dir)
+
+	var stdout, stderr bytes.Buffer
+	code := doImportStatus(dir, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "packs.lock sha256: "+lockSHA) {
+		t.Fatalf("missing lock hash line:\n%s", out)
+	}
+	if !strings.Contains(out, "pack:tools\thttps://example.com/tools.git\t^1.4\tremote\t1.4.2\taaaa") {
+		t.Fatalf("missing pinned import line:\n%s", out)
+	}
+}
+
+// TestImportStatusCommandRegistered asserts "gc import status" is wired
+// into the import command tree with a --json flag.
+func TestImportStatusCommandRegistered(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := newImportCmd(&stdout, &stderr)
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "status" {
+			if sub.Flags().Lookup("json") == nil {
+				t.Fatal("gc import status is missing the --json flag")
+			}
+			return
+		}
+	}
+	t.Fatal("gc import status subcommand not registered")
+}

--- a/cmd/gc/cmd_import_status_test.go
+++ b/cmd/gc/cmd_import_status_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,6 +71,7 @@ version = "^3.0"
 
 	want := fmt.Sprintf(`{
   "schema_version": "1",
+  "ok": true,
   "root": %[1]q,
   "packs_lock_path": %[2]q,
   "packs_lock_sha256": %[3]q,
@@ -219,6 +221,103 @@ version = "^1.4"
 	}
 	if !strings.Contains(out, "pack:tools\thttps://example.com/tools.git\t^1.4\tremote\t1.4.2\taaaa") {
 		t.Fatalf("missing pinned import line:\n%s", out)
+	}
+}
+
+// TestImportStatusJSONProductionRun exercises "gc import status --json"
+// through the full production CLI path — including the JSON contract
+// gate in run(), which rejects --json with json_unsupported unless the
+// command declares an embedded result schema — and validates the
+// emitted document against that schema. doImportStatus-level tests
+// bypass this gate, so only this test proves the machine-readable
+// drift surface is reachable in production. The fixture declares a
+// pinned remote, an unlocked remote, and a path import so the schema
+// validation covers every entry shape the command can emit.
+func TestImportStatusJSONProductionRun(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.4"
+
+[imports.local]
+source = "./packs/local"
+
+[imports.unlocked]
+source = "https://example.com/unlocked.git"
+version = "^9.9"
+`)
+	importStatusLockFixture(t, dir)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", dir, "import", "status", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(import status --json) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stdout.String(), "json_unsupported") {
+		t.Fatalf("production path rejected --json:\n%s", stdout.String())
+	}
+
+	var doc struct {
+		Imports []struct {
+			Kind string          `json:"kind"`
+			Pin  json.RawMessage `json:"pin"`
+		} `json:"imports"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("production document is not JSON: %v\n%s", err, stdout.String())
+	}
+	shapes := map[string]bool{}
+	for _, imp := range doc.Imports {
+		switch {
+		case imp.Kind == "path":
+			shapes["path"] = true
+		case len(imp.Pin) > 0:
+			shapes["pinned remote"] = true
+		default:
+			shapes["unlocked remote"] = true
+		}
+	}
+	for _, shape := range []string{"pinned remote", "unlocked remote", "path"} {
+		if !shapes[shape] {
+			t.Fatalf("fixture emitted no %s import entry, so the schema validation no longer covers that shape:\n%s", shape, stdout.String())
+		}
+	}
+
+	assertTopLevelOKTrue(t, stdout.Bytes())
+	validateJSONAgainstResultSchema(t, []string{"import", "status"}, stdout.Bytes())
+}
+
+// TestImportStatusJSONSchemaManifest asserts the --json-schema manifest
+// reports JSON support for "gc import status" with a valid embedded
+// result schema, so drift checkers can discover the contract.
+func TestImportStatusJSONSchemaManifest(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"import", "status", "--json-schema"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(import status --json-schema) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var manifest struct {
+		Command       []string                   `json:"command"`
+		JSONSupported bool                       `json:"json_supported"`
+		Schemas       map[string]json.RawMessage `json:"schemas"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got := strings.Join(manifest.Command, " "); got != "import status" {
+		t.Fatalf("manifest command = %q, want \"import status\"", got)
+	}
+	if !manifest.JSONSupported {
+		t.Fatalf("manifest json_supported = false, want true:\n%s", stdout.String())
+	}
+	if !json.Valid(manifest.Schemas["result"]) {
+		t.Fatalf("result schema missing or invalid: %s", manifest.Schemas["result"])
 	}
 }
 

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -4494,6 +4494,8 @@ export interface components {
              * @description Total managed cities.
              */
             cities_total: number;
+            /** @description SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock. */
+            packs_lock_sha256?: string;
             /** @description First-city startup info for single-city deployments. */
             startup?: components["schemas"]["SupervisorStartup"];
             /** @description Health status ("ok"). */

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -4494,7 +4494,7 @@ export interface components {
              * @description Total managed cities.
              */
             cities_total: number;
-            /** @description SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock. */
+            /** @description SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered, the city has no packs.lock, or the lockfile is unreadable (read error logged server-side) — treat absence as unknown, not as proof there is no lockfile. */
             packs_lock_sha256?: string;
             /** @description First-city startup info for single-city deployments. */
             startup?: components["schemas"]["SupervisorStartup"];

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -3300,7 +3300,7 @@ export type SupervisorHealthOutputBody = {
      */
     cities_total: number;
     /**
-     * SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.
+     * SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered, the city has no packs.lock, or the lockfile is unreadable (read error logged server-side) — treat absence as unknown, not as proof there is no lockfile.
      */
     packs_lock_sha256?: string;
     /**

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -3300,6 +3300,10 @@ export type SupervisorHealthOutputBody = {
      */
     cities_total: number;
     /**
+     * SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.
+     */
+    packs_lock_sha256?: string;
+    /**
      * First-city startup info for single-city deployments.
      */
     startup?: SupervisorStartup;

--- a/cmd/gc/json_runtime_schema_test.go
+++ b/cmd/gc/json_runtime_schema_test.go
@@ -146,6 +146,7 @@ func TestJSONResultStructsExposeExplicitOKField(t *testing.T) {
 		{name: "formula show", value: formulaShowJSON{}},
 		{name: "event emit", value: eventEmitJSONResult{}},
 		{name: "init", value: initJSONResult{}},
+		{name: "import status", value: ImportStatusJSON{}},
 	}
 
 	for _, tc := range tests {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1582,6 +1582,7 @@ gc import
 | [gc import list](#gc-import-list) | List imported packs |
 | [gc import prune](#gc-import-prune) | Remove unreferenced clones from the global pack cache |
 | [gc import remove](#gc-import-remove) | Remove a pack import |
+| [gc import status](#gc-import-status) | Report declared imports and packs.lock pins |
 | [gc import upgrade](#gc-import-upgrade) | Upgrade imported packs within their constraints |
 | [gc import why](#gc-import-why) | Explain why an import is present |
 
@@ -1685,6 +1686,23 @@ Remove a pack import
 ```
 gc import remove <name>
 ```
+
+## gc import status
+
+Report declared imports and packs.lock pins.
+
+Covers every import scope (root pack [imports.*], [defaults.rig.imports.*],
+and rig-scoped [rigs.imports.*]) plus the full packs.lock closure and the
+lockfile content hash. With --json the output is a stable machine-readable
+document for drift checkers.
+
+```
+gc import status [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | emit JSON result |
 
 ## gc import upgrade
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -7620,7 +7620,7 @@
             "type": "integer"
           },
           "packs_lock_sha256": {
-            "description": "SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.",
+            "description": "SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered, the city has no packs.lock, or the lockfile is unreadable (read error logged server-side) — treat absence as unknown, not as proof there is no lockfile.",
             "type": "string"
           },
           "startup": {

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -7619,6 +7619,10 @@
             "format": "int64",
             "type": "integer"
           },
+          "packs_lock_sha256": {
+            "description": "SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.",
+            "type": "string"
+          },
           "startup": {
             "$ref": "#/components/schemas/SupervisorStartup",
             "description": "First-city startup info for single-city deployments."

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -7620,7 +7620,7 @@
             "type": "integer"
           },
           "packs_lock_sha256": {
-            "description": "SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.",
+            "description": "SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered, the city has no packs.lock, or the lockfile is unreadable (read error logged server-side) — treat absence as unknown, not as proof there is no lockfile.",
             "type": "string"
           },
           "startup": {

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -7619,6 +7619,10 @@
             "format": "int64",
             "type": "integer"
           },
+          "packs_lock_sha256": {
+            "description": "SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.",
+            "type": "string"
+          },
           "startup": {
             "$ref": "#/components/schemas/SupervisorStartup",
             "description": "First-city startup info for single-city deployments."

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -3167,7 +3167,7 @@ type SupervisorHealthOutputBody struct {
 	// CitiesTotal Total managed cities.
 	CitiesTotal int64 `json:"cities_total"`
 
-	// PacksLockSha256 SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.
+	// PacksLockSha256 SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered, the city has no packs.lock, or the lockfile is unreadable (read error logged server-side) — treat absence as unknown, not as proof there is no lockfile.
 	PacksLockSha256 *string            `json:"packs_lock_sha256,omitempty"`
 	Startup         *SupervisorStartup `json:"startup,omitempty"`
 

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -3165,8 +3165,11 @@ type SupervisorHealthOutputBody struct {
 	CitiesRunning int64 `json:"cities_running"`
 
 	// CitiesTotal Total managed cities.
-	CitiesTotal int64              `json:"cities_total"`
-	Startup     *SupervisorStartup `json:"startup,omitempty"`
+	CitiesTotal int64 `json:"cities_total"`
+
+	// PacksLockSha256 SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.
+	PacksLockSha256 *string            `json:"packs_lock_sha256,omitempty"`
+	Startup         *SupervisorStartup `json:"startup,omitempty"`
 
 	// Status Health status ("ok").
 	Status string `json:"status"`

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
@@ -17,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/cityinit"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/packman"
 )
 
 // --- Supervisor Huma input/output types ---
@@ -32,13 +35,14 @@ type SupervisorCitiesOutput struct {
 // SupervisorHealthOutput is the response for GET /health (supervisor scope).
 type SupervisorHealthOutput struct {
 	Body struct {
-		Status        string             `json:"status" doc:"Health status (\"ok\")."`
-		Version       string             `json:"version" doc:"Supervisor version."`
-		BuildID       string             `json:"build_id,omitempty" doc:"Build identity (typically a short git commit hash, with \"-dirty\" suffix when built from an unclean tree). Empty when unavailable."`
-		UptimeSec     int                `json:"uptime_sec" doc:"Supervisor uptime in seconds."`
-		CitiesTotal   int                `json:"cities_total" doc:"Total managed cities."`
-		CitiesRunning int                `json:"cities_running" doc:"Cities currently running."`
-		Startup       *SupervisorStartup `json:"startup,omitempty" doc:"First-city startup info for single-city deployments."`
+		Status          string             `json:"status" doc:"Health status (\"ok\")."`
+		Version         string             `json:"version" doc:"Supervisor version."`
+		BuildID         string             `json:"build_id,omitempty" doc:"Build identity (typically a short git commit hash, with \"-dirty\" suffix when built from an unclean tree). Empty when unavailable."`
+		UptimeSec       int                `json:"uptime_sec" doc:"Supervisor uptime in seconds."`
+		CitiesTotal     int                `json:"cities_total" doc:"Total managed cities."`
+		CitiesRunning   int                `json:"cities_running" doc:"Cities currently running."`
+		PacksLockSHA256 string             `json:"packs_lock_sha256,omitempty" doc:"SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock."`
+		Startup         *SupervisorStartup `json:"startup,omitempty" doc:"First-city startup info for single-city deployments."`
 	}
 }
 
@@ -247,11 +251,13 @@ func (sm *SupervisorMux) humaHandleHealth(_ context.Context, _ *struct{}) (*Supe
 	cities := sm.resolver.ListCities()
 	var running int
 	var startup *SupervisorStartup
+	var packsLockSHA string
 	for _, c := range cities {
 		if c.Running {
 			running++
 		}
 		if startup == nil {
+			packsLockSHA = packsLockSHA256(c.Path)
 			if c.Running {
 				startup = &SupervisorStartup{
 					Ready:           true,
@@ -274,8 +280,28 @@ func (sm *SupervisorMux) humaHandleHealth(_ context.Context, _ *struct{}) (*Supe
 	out.Body.UptimeSec = int(time.Since(sm.startedAt).Seconds())
 	out.Body.CitiesTotal = len(cities)
 	out.Body.CitiesRunning = running
+	out.Body.PacksLockSHA256 = packsLockSHA
 	out.Body.Startup = startup
 	return out, nil
+}
+
+// packsLockSHA256 returns the hex-encoded SHA-256 digest of the
+// packs.lock file under cityPath, or "" when the file is missing.
+// Unexpected read errors are logged and reported as absent: /health
+// must stay available even when a city directory is unreadable.
+func packsLockSHA256(cityPath string) string {
+	if cityPath == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(cityPath, packman.LockfileName))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("health: reading %s for %s: %v", packman.LockfileName, cityPath, err)
+		}
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 func (sm *SupervisorMux) humaHandleReadiness(ctx context.Context, input *SupervisorReadinessInput) (*SupervisorReadinessOutput, error) {

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -41,7 +41,7 @@ type SupervisorHealthOutput struct {
 		UptimeSec       int                `json:"uptime_sec" doc:"Supervisor uptime in seconds."`
 		CitiesTotal     int                `json:"cities_total" doc:"Total managed cities."`
 		CitiesRunning   int                `json:"cities_running" doc:"Cities currently running."`
-		PacksLockSHA256 string             `json:"packs_lock_sha256,omitempty" doc:"SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock."`
+		PacksLockSHA256 string             `json:"packs_lock_sha256,omitempty" doc:"SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered, the city has no packs.lock, or the lockfile is unreadable (read error logged server-side) — treat absence as unknown, not as proof there is no lockfile."`
 		Startup         *SupervisorStartup `json:"startup,omitempty" doc:"First-city startup info for single-city deployments."`
 	}
 }

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -7620,7 +7620,7 @@
             "type": "integer"
           },
           "packs_lock_sha256": {
-            "description": "SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.",
+            "description": "SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered, the city has no packs.lock, or the lockfile is unreadable (read error logged server-side) — treat absence as unknown, not as proof there is no lockfile.",
             "type": "string"
           },
           "startup": {

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -7619,6 +7619,10 @@
             "format": "int64",
             "type": "integer"
           },
+          "packs_lock_sha256": {
+            "description": "SHA-256 hex digest of the first managed city's packs.lock contents, for single-city deployments (mirrors the startup field's first-city semantics). Drift checkers compare this against the committed lockfile copy. Omitted when no city is registered or the city has no packs.lock.",
+            "type": "string"
+          },
           "startup": {
             "$ref": "#/components/schemas/SupervisorStartup",
             "description": "First-city startup info for single-city deployments."

--- a/internal/api/supervisor_health_packslock_test.go
+++ b/internal/api/supervisor_health_packslock_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/packman"
+)
+
+// TestSupervisorHealthIncludesPacksLockSHA256 asserts /health surfaces
+// the SHA-256 digest of the first managed city's packs.lock contents.
+// Drift checkers compare this against the committed lockfile copy
+// instead of shelling into the city directory (ga-qcnpu1).
+func TestSupervisorHealthIncludesPacksLockSHA256(t *testing.T) {
+	s := newFakeState(t)
+	content := []byte("schema = 1\n\n[packs.\"https://example.com/tools.git\"]\nversion = \"1.4.2\"\ncommit = \"aaaa\"\nfetched = \"2026-01-02T03:04:05Z\"\n")
+	if err := os.WriteFile(filepath.Join(s.CityPath(), packman.LockfileName), content, 0o644); err != nil {
+		t.Fatalf("write packs.lock: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	want := hex.EncodeToString(sum[:])
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{"test-city": s})
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rec := httptest.NewRecorder()
+	sm.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, _ := resp["packs_lock_sha256"].(string); got != want {
+		t.Fatalf("packs_lock_sha256 = %q, want %q\nbody: %s", got, want, rec.Body.String())
+	}
+}
+
+// TestSupervisorHealthOmitsPacksLockSHA256WhenMissing confirms the
+// field is omitted (not emitted as an empty string) when the first
+// managed city has no packs.lock on disk, matching the omitempty
+// semantics used by build_id.
+func TestSupervisorHealthOmitsPacksLockSHA256WhenMissing(t *testing.T) {
+	s := newFakeState(t)
+	sm := newTestSupervisorMux(t, map[string]*fakeState{"test-city": s})
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rec := httptest.NewRecorder()
+	sm.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, present := resp["packs_lock_sha256"]; present {
+		t.Fatalf("packs_lock_sha256 present despite missing packs.lock; got: %v", resp["packs_lock_sha256"])
+	}
+}

--- a/internal/packman/lockfile.go
+++ b/internal/packman/lockfile.go
@@ -39,7 +39,14 @@ func ReadLockfile(fs fsys.FS, cityRoot string) (*Lockfile, error) {
 	if err != nil {
 		return emptyLockfileIfMissing(err)
 	}
+	return ParseLockfile(data)
+}
 
+// ParseLockfile decodes packs.lock contents. Empty data returns an
+// empty lock. Callers that need both the raw bytes and the pins (e.g.
+// to hash and parse one consistent snapshot) read the file once and
+// pass the same bytes here.
+func ParseLockfile(data []byte) (*Lockfile, error) {
 	var lock Lockfile
 	if _, err := toml.Decode(string(data), &lock); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", LockfileName, err)

--- a/internal/packman/lockfile_test.go
+++ b/internal/packman/lockfile_test.go
@@ -23,6 +23,53 @@ func TestReadLockfileMissingReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestParseLockfileDecodesPins(t *testing.T) {
+	lock, err := ParseLockfile([]byte(`schema = 1
+
+[packs."github.com/alpha/repo"]
+version = "1.0.0"
+commit = "aaaa"
+fetched = "2026-01-02T03:04:05Z"
+`))
+	if err != nil {
+		t.Fatalf("ParseLockfile: %v", err)
+	}
+	if lock.Schema != LockfileSchema {
+		t.Fatalf("Schema = %d, want %d", lock.Schema, LockfileSchema)
+	}
+	pack, ok := lock.Packs["github.com/alpha/repo"]
+	if !ok {
+		t.Fatalf("Packs missing github.com/alpha/repo: %#v", lock.Packs)
+	}
+	if pack.Version != "1.0.0" || pack.Commit != "aaaa" {
+		t.Fatalf("pack = %#v", pack)
+	}
+	if want := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC); !pack.Fetched.Equal(want) {
+		t.Fatalf("Fetched = %v, want %v", pack.Fetched, want)
+	}
+}
+
+func TestParseLockfileEmptyReturnsEmptyLock(t *testing.T) {
+	for _, data := range [][]byte{nil, {}} {
+		lock, err := ParseLockfile(data)
+		if err != nil {
+			t.Fatalf("ParseLockfile(%v): %v", data, err)
+		}
+		if lock.Schema != LockfileSchema {
+			t.Fatalf("Schema = %d, want %d", lock.Schema, LockfileSchema)
+		}
+		if len(lock.Packs) != 0 {
+			t.Fatalf("Packs len = %d, want 0", len(lock.Packs))
+		}
+	}
+}
+
+func TestParseLockfileInvalidTOMLErrors(t *testing.T) {
+	if _, err := ParseLockfile([]byte("not = [valid")); err == nil {
+		t.Fatal("ParseLockfile accepted invalid TOML")
+	}
+}
+
 func TestWriteLockfileSortsKeys(t *testing.T) {
 	dir := t.TempDir()
 	lock := &Lockfile{

--- a/schemas/import/status/result.schema.json
+++ b/schemas/import/status/result.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "gc import status --json result",
+  "description": "Machine-readable drift surface for pack imports: every declared import binding across scopes, the packs.lock pin closure, and the lockfile content hash.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "ok",
+    "root",
+    "packs_lock_path",
+    "imports",
+    "locked_packs"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Schema version for this command output."
+    },
+    "ok": {
+      "const": true
+    },
+    "root": {
+      "type": "string",
+      "description": "Absolute city or pack root the status was computed from."
+    },
+    "packs_lock_path": {
+      "type": "string",
+      "description": "Absolute path of the packs.lock file (which may not exist)."
+    },
+    "packs_lock_sha256": {
+      "type": "string",
+      "description": "Hex-encoded SHA-256 digest of the raw packs.lock contents. Omitted when the file does not exist."
+    },
+    "imports": {
+      "type": "array",
+      "description": "Every declared import binding, sorted by name.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "source",
+          "kind"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Scoped binding key: \"pack:<name>\" for root-pack imports, \"default-rig:<name>\" for default rig imports, and \"rig:<rig>:<name>\" for rig-scoped imports."
+          },
+          "source": {
+            "type": "string",
+            "description": "Declared source exactly as authored in TOML."
+          },
+          "constraint": {
+            "type": "string",
+            "description": "Declared version constraint, when present."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "remote",
+              "path"
+            ],
+            "description": "\"remote\" for git-backed sources and \"path\" for local directory sources."
+          },
+          "path": {
+            "type": "string",
+            "description": "Resolved absolute path for kind \"path\" entries."
+          },
+          "pin": {
+            "type": "object",
+            "description": "packs.lock resolution for kind \"remote\" entries. Omitted when the source has no lock entry (unlocked).",
+            "additionalProperties": false,
+            "required": [
+              "version",
+              "commit"
+            ],
+            "properties": {
+              "version": {
+                "type": "string",
+                "description": "Pinned version."
+              },
+              "commit": {
+                "type": "string",
+                "description": "Pinned commit."
+              },
+              "fetched": {
+                "type": "string",
+                "description": "RFC 3339 UTC fetch timestamp, when recorded."
+              }
+            }
+          }
+        }
+      }
+    },
+    "locked_packs": {
+      "type": "array",
+      "description": "Full packs.lock closure (direct and transitive pins), sorted by source.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "source",
+          "version",
+          "commit"
+        ],
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "Locked pack source."
+          },
+          "version": {
+            "type": "string",
+            "description": "Pinned version."
+          },
+          "commit": {
+            "type": "string",
+            "description": "Pinned commit."
+          },
+          "fetched": {
+            "type": "string",
+            "description": "RFC 3339 UTC fetch timestamp, when recorded."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The maintainer-city drift checker (design §5 item 10, maintainer-city-production) parses `gc import list` text output to detect pack drift. Text parsing is brittle, misses rig-scoped imports, and gives no cheap way to compare the deployed `packs.lock` against the committed copy. Bead: ga-qcnpu1.

## Fix

Two machine-readable drift inputs:

- **`gc import status [--json]`** — new subcommand reporting every declared import binding across all scopes (root pack `[imports.*]`, `[defaults.rig.imports.*]`, and rig-scoped `[rigs.imports.*]`) with source, constraint, kind (`remote`/`path`), resolved path or `packs.lock` pin, plus the full lock closure and the lockfile SHA-256 content hash. `--json` emits a schema-versioned typed document (`schema_version: "1"`) following the CLI's existing `--json` conventions; the default output is a human-readable tab-separated summary.
- **`GET /health` (supervisor scope)** — gains `packs_lock_sha256`: the SHA-256 hex digest of the first managed city's `packs.lock` contents (first-city semantics mirroring the existing `startup` field), `omitempty` when no city is registered or the city has no lockfile. The Huma-typed response struct is extended; OpenAPI spec, generated Go client, dashboard TS types, and the CLI reference are all regenerated.

## Testing

TDD: failing-first proven by removing the impl hunks — `TestDoImportStatusJSONGolden` fails to build without `cmd_import_status.go`, `TestImportStatusCommandRegistered` fails with "subcommand not registered" without the `cmd_import.go` hunk, and `TestSupervisorHealthIncludesPacksLockSHA256` fails with `packs_lock_sha256 = ""` without the handler hunk.

- `go test ./cmd/gc/ -run 'TestDoImportStatus|TestImportStatusCommandRegistered'` — pass (JSON golden, rig-scoped coverage, missing-lock omission, text output, registration)
- `go test ./internal/api/` — full package pass, including `TestSupervisorHealthIncludesPacksLockSHA256`, `TestSupervisorHealthOmitsPacksLockSHA256WhenMissing`, `TestOpenAPISpecInSync`
- `make test` — pass (isolated sandbox)
- `make dashboard-check` — pass (TS types regenerated, typecheck, SPA build)
- `go vet ./...` clean; `go run ./cmd/gc gen-doc` in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
