### PR TITLE
fix(dolt): managed sql-server binds 127.0.0.1 by default

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -9474,7 +9474,7 @@ func TestManagedDoltConfigGoWriterMatchesShellFallbackSemantics(t *testing.T) {
 		t.Fatal(err)
 	}
 	goConfigPath := filepath.Join(t.TempDir(), "go", "dolt-config.yaml")
-	if err := writeManagedDoltConfigFile(goConfigPath, "0.0.0.0", "3311", filepath.Join(cityPath, ".beads", "dolt"), "info", config.DoltConfig{}); err != nil {
+	if err := writeManagedDoltConfigFile(goConfigPath, "127.0.0.1", "3311", filepath.Join(cityPath, ".beads", "dolt"), "info", config.DoltConfig{}); err != nil {
 		t.Fatalf("writeManagedDoltConfigFile: %v", err)
 	}
 

--- a/cmd/gc/dolt_bind_localhost_test.go
+++ b/cmd/gc/dolt_bind_localhost_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNormalizeManagedDoltBindHost pins the managed-server bind default:
+// a blank host means "no explicit choice" and must resolve to loopback —
+// the production work ledger must never listen on a wildcard interface
+// unless the operator explicitly opts in. Explicit values (including the
+// 0.0.0.0 wildcard opt-out for multi-host deployments) pass through.
+func TestNormalizeManagedDoltBindHost(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+		want string
+	}{
+		{"blank defaults to loopback", "", "127.0.0.1"},
+		{"whitespace defaults to loopback", "   ", "127.0.0.1"},
+		{"explicit loopback preserved", "127.0.0.1", "127.0.0.1"},
+		{"explicit wildcard opt-out preserved", "0.0.0.0", "0.0.0.0"},
+		{"explicit interface preserved", "192.168.1.5", "192.168.1.5"},
+		{"surrounding whitespace trimmed", " 10.0.0.7 ", "10.0.0.7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeManagedDoltBindHost(tc.host); got != tc.want {
+				t.Fatalf("normalizeManagedDoltBindHost(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStartManagedDoltProcessWithOptions_BlankHostBindsLoopbackByDefault
+// drives the production start path with NO host configured and asserts the
+// rendered dolt-config.yaml binds the listener to 127.0.0.1 — not the
+// wildcard interface (the pre-P0.5 default left the work ledger
+// LAN-reachable with permissive auth).
+func TestStartManagedDoltProcessWithOptions_BlankHostBindsLoopbackByDefault(t *testing.T) {
+	cityPath := installStartManagedDoltLoopStubs(t, startManagedDoltLoopStubs{
+		startFn: func(cityPath, _, _ string, _ *os.File) (managedDoltStartedProcess, error) {
+			return managedDoltStartedProcess{CityPath: cityPath, PID: 0}, nil
+		},
+		waitReadyFn: func(_, _, _, _ string, _ int, _ time.Duration, _ bool) (managedDoltWaitReadyReport, error) {
+			return managedDoltWaitReadyReport{Ready: true, PIDAlive: true}, nil
+		},
+		logSuffixFn: func(_ string, _ int64) (string, error) {
+			return "", nil
+		},
+		portAvailableFn: func(_ string, _ int) bool { return true },
+		retryWindow:     time.Second,
+	})
+
+	report, err := startManagedDoltProcessWithOptions(cityPath, "", "17790", "root", "warning", -1, time.Second, false)
+	if err != nil {
+		t.Fatalf("startManagedDoltProcessWithOptions: %v", err)
+	}
+	if !report.Ready {
+		t.Fatalf("report.Ready = false, want true")
+	}
+
+	text := readManagedDoltConfigForBindTest(t, cityPath)
+	if !strings.Contains(text, "host: 127.0.0.1") {
+		t.Errorf("default bind must be loopback; dolt-config.yaml missing %q:\n%s", "host: 127.0.0.1", text)
+	}
+	if strings.Contains(text, "host: 0.0.0.0") {
+		t.Errorf("default bind leaked the wildcard interface:\n%s", text)
+	}
+}
+
+// TestStartManagedDoltProcessWithOptions_ExplicitWildcardBindPreserved pins
+// the multi-host opt-out: an operator who explicitly sets the wildcard host
+// keeps the old LAN-reachable bind.
+func TestStartManagedDoltProcessWithOptions_ExplicitWildcardBindPreserved(t *testing.T) {
+	cityPath := installStartManagedDoltLoopStubs(t, startManagedDoltLoopStubs{
+		startFn: func(cityPath, _, _ string, _ *os.File) (managedDoltStartedProcess, error) {
+			return managedDoltStartedProcess{CityPath: cityPath, PID: 0}, nil
+		},
+		waitReadyFn: func(_, _, _, _ string, _ int, _ time.Duration, _ bool) (managedDoltWaitReadyReport, error) {
+			return managedDoltWaitReadyReport{Ready: true, PIDAlive: true}, nil
+		},
+		logSuffixFn: func(_ string, _ int64) (string, error) {
+			return "", nil
+		},
+		portAvailableFn: func(_ string, _ int) bool { return true },
+		retryWindow:     time.Second,
+	})
+
+	report, err := startManagedDoltProcessWithOptions(cityPath, "0.0.0.0", "17791", "root", "warning", -1, time.Second, false)
+	if err != nil {
+		t.Fatalf("startManagedDoltProcessWithOptions: %v", err)
+	}
+	if !report.Ready {
+		t.Fatalf("report.Ready = false, want true")
+	}
+
+	text := readManagedDoltConfigForBindTest(t, cityPath)
+	if !strings.Contains(text, "host: 0.0.0.0") {
+		t.Errorf("explicit wildcard opt-out must be preserved; dolt-config.yaml missing %q:\n%s", "host: 0.0.0.0", text)
+	}
+}
+
+func readManagedDoltConfigForBindTest(t *testing.T, cityPath string) string {
+	t.Helper()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	data, err := os.ReadFile(layout.ConfigFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", layout.ConfigFile, err)
+	}
+	return string(data)
+}

--- a/cmd/gc/dolt_port_selection.go
+++ b/cmd/gc/dolt_port_selection.go
@@ -165,9 +165,9 @@ func nextAvailableManagedDoltPort(seed int) int {
 // port that probes free on 127.0.0.1 but is actually busy on the bind host
 // (e.g. another process holds 192.168.1.5:X while leaving 127.0.0.1:X free,
 // and dolt is binding 0.0.0.0:X, which would fail). Blank host normalizes
-// to "0.0.0.0" inside managedDoltPortAvailableFn (the indirection over
-// managedDoltPortAvailableForHost) to match the bind default in
-// startManagedDoltProcessWithOptions.
+// to the loopback bind default inside managedDoltPortAvailableFn (the
+// indirection over managedDoltPortAvailableForHost) to match the bind
+// default in startManagedDoltProcessWithOptions.
 func nextAvailableManagedDoltPortForHost(host string, seed int) int {
 	port := seed
 	for attempts := 0; attempts < 100; attempts++ {

--- a/cmd/gc/dolt_recover_managed.go
+++ b/cmd/gc/dolt_recover_managed.go
@@ -28,9 +28,7 @@ func recoverManagedDoltProcess(cityPath, host, port, user, logLevel string, time
 	if strings.TrimSpace(port) == "" {
 		return managedDoltRecoverReport{}, fmt.Errorf("missing port")
 	}
-	if strings.TrimSpace(host) == "" {
-		host = "0.0.0.0"
-	}
+	host = normalizeManagedDoltBindHost(host)
 	if strings.TrimSpace(user) == "" {
 		user = "root"
 	}

--- a/cmd/gc/dolt_start_address_in_use_retry_window_test.go
+++ b/cmd/gc/dolt_start_address_in_use_retry_window_test.go
@@ -278,7 +278,8 @@ func TestManagedDoltStartWaitForPortFree_FullChainBindsHostPortViaProductionProb
 }
 
 // TestManagedDoltPortAvailableForHost_NormalizesEmptyHost confirms the host
-// normalization shim ("" / "*" → "0.0.0.0") is wired and does not panic.
+// normalization shim ("" → loopback bind default, "*" → "0.0.0.0") is wired
+// and does not panic.
 // Picks a fresh unused random port via net.Listen("tcp", ":0") (Linux/macOS
 // will not put a never-bound port in TIME_WAIT), so the probe must report
 // available for at least the wildcard / unspecified forms. The interface-
@@ -291,12 +292,12 @@ func TestManagedDoltPortAvailableForHost_NormalizesEmptyHost(t *testing.T) {
 	port := listener.Addr().(*net.TCPAddr).Port
 	listener.Close() //nolint:errcheck
 
-	// The wildcard host forms ("" / "*" / "0.0.0.0") all normalize to
-	// 0.0.0.0; on Linux a 127.0.0.1 listener Close()'d immediately ago can
-	// leave a SYN_RECV / TIME_WAIT slot, but a fresh 0.0.0.0 bind should
-	// succeed since wildcard bind doesn't conflict with a closed 127.0.0.1
-	// listener that was never connected to. Assert at least one wildcard
-	// form reports available — otherwise the normalization is broken.
+	// "" normalizes to the loopback bind default; "*" and "0.0.0.0" are the
+	// explicit wildcard forms. On Linux a 127.0.0.1 listener Close()'d
+	// immediately ago can leave a SYN_RECV / TIME_WAIT slot, but a fresh
+	// bind on any of these forms should succeed since the listener was
+	// never connected to. Assert at least one form reports available —
+	// otherwise the normalization is broken.
 	wildcardAvailable := false
 	for _, host := range []string{"", "*", "0.0.0.0"} {
 		if managedDoltPortAvailableForHost(host, port) {

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -48,6 +48,26 @@ type managedDoltStartedProcess struct {
 	StartIdentity string
 }
 
+// defaultManagedDoltBindHost is the listener host a managed dolt sql-server
+// binds when no explicit host is configured. Loopback by default: the work
+// ledger must not listen on a wildcard (LAN-reachable) interface unless the
+// operator explicitly opts in with GC_DOLT_HOST=0.0.0.0. Distinct from
+// defaultManagedDoltHost (bd_env.go), which is the client-side connect
+// default.
+const defaultManagedDoltBindHost = "127.0.0.1"
+
+// normalizeManagedDoltBindHost resolves the listener host for a managed dolt
+// sql-server. Blank means "no explicit choice" and resolves to the loopback
+// default; any explicit value — including the 0.0.0.0 wildcard opt-out for
+// multi-host deployments — is preserved.
+func normalizeManagedDoltBindHost(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return defaultManagedDoltBindHost
+	}
+	return host
+}
+
 const (
 	managedDoltTestModeEnv      = "GC_MANAGED_DOLT_TEST_MODE"
 	managedDoltTestParentPIDEnv = "GC_MANAGED_DOLT_TEST_PARENT_PID"
@@ -130,9 +150,7 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 	if err != nil || portNum <= 0 {
 		return managedDoltStartReport{}, fmt.Errorf("invalid port %q", port)
 	}
-	if strings.TrimSpace(host) == "" {
-		host = "0.0.0.0"
-	}
+	host = normalizeManagedDoltBindHost(host)
 	if strings.TrimSpace(user) == "" {
 		user = "root"
 	}
@@ -322,8 +340,9 @@ func resolveManagedDoltStartAddressInUseRetryWindow(cityPath string) time.Durati
 // became free within the window. A non-positive retryWindow returns false
 // immediately (no wait).
 //
-// The host argument matches the host dolt will bind to (typically "0.0.0.0"
-// in production); using the same host for the probe and the bind avoids
+// The host argument matches the host dolt will bind to (typically
+// "127.0.0.1" in production); using the same host for the probe and the
+// bind avoids
 // false-positive availability reports caused by interface-specific bind
 // states. The poll interval is shrunk to the retry window when the window is
 // shorter than the default 2s, so a sub-2s window still gets one check
@@ -374,13 +393,15 @@ var managedDoltPortAvailableFn = managedDoltPortAvailableForHost
 // bound by a Go net.Listen call. Mirrors managedDoltPortAvailable's check but
 // uses the configured host instead of forcing 127.0.0.1, so the probe is
 // faithful to what dolt's bind will attempt (interface-specific TIME_WAIT
-// state on a wildcard bind is not seen by a localhost probe). A blank or "*"
-// host is normalized to "0.0.0.0".
+// state on a wildcard bind is not seen by a localhost probe). A "*" host is
+// an explicit wildcard spelling and normalizes to "0.0.0.0"; a blank host
+// normalizes to the loopback bind default, matching
+// startManagedDoltProcessWithOptions.
 func managedDoltPortAvailableForHost(host string, port int) bool {
-	host = strings.TrimSpace(host)
-	if host == "" || host == "*" {
+	if strings.TrimSpace(host) == "*" {
 		host = "0.0.0.0"
 	}
+	host = normalizeManagedDoltBindHost(host)
 	listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return false

--- a/cmd/gc/gc_beads_bd_bind_host_test.go
+++ b/cmd/gc/gc_beads_bd_bind_host_test.go
@@ -79,6 +79,8 @@ func TestGcBeadsBdIsRemoteHostClassification(t *testing.T) {
 		{"unset is local-managed", "", false},
 		{"loopback default is local-managed", "127.0.0.1", false},
 		{"wildcard opt-out is local-managed", "0.0.0.0", false},
+		{"localhost alias is local-managed", "localhost", false},
+		{"ipv6 loopback is local-managed", "::1", false},
 		{"hostname is remote", "db.example.com", true},
 		{"lan address is remote", "10.0.0.5", true},
 	}

--- a/cmd/gc/gc_beads_bd_bind_host_test.go
+++ b/cmd/gc/gc_beads_bd_bind_host_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -95,7 +96,8 @@ func TestGcBeadsBdIsRemoteHostClassification(t *testing.T) {
 			cmd.Stderr = &stderr
 			err := cmd.Run()
 			gotRemote := err == nil // is_remote returns 0 (sh success) when remote
-			if _, isExit := err.(*exec.ExitError); err != nil && !isExit {
+			var exitErr *exec.ExitError
+			if err != nil && !errors.As(err, &exitErr) {
 				t.Fatalf("sh -c failed: %v\nstderr:\n%s", err, stderr.String())
 			}
 			if gotRemote != tc.wantRemote {

--- a/cmd/gc/gc_beads_bd_bind_host_test.go
+++ b/cmd/gc/gc_beads_bd_bind_host_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestGcBeadsBdDefaultBindHostIsLoopback runs the DOLT_HOST default
+// assignment from gc-beads-bd.sh and asserts the managed bind default is
+// loopback, with GC_DOLT_HOST still honored as the explicit override.
+func TestGcBeadsBdDefaultBindHostIsLoopback(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available; skipping shell test")
+	}
+
+	line := extractGcBeadsBdDoltHostDefault(t)
+
+	cases := []struct {
+		name string
+		env  string // "" = unset
+		want string
+	}{
+		{"unset defaults to loopback", "", "127.0.0.1"},
+		{"explicit wildcard preserved", "0.0.0.0", "0.0.0.0"},
+		{"explicit remote preserved", "db.example.com", "db.example.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			script := line + "\nprintf '%s' \"$DOLT_HOST\"\n"
+			cmd := exec.Command("sh", "-c", script)
+			cmd.Env = environWithoutGCDoltHost()
+			if tc.env != "" {
+				cmd.Env = append(cmd.Env, "GC_DOLT_HOST="+tc.env)
+			}
+			out, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("sh -c failed: %v", err)
+			}
+			if got := string(out); got != tc.want {
+				t.Fatalf("DOLT_HOST = %q, want %q (default line: %s)", got, tc.want, line)
+			}
+		})
+	}
+}
+
+// TestGcBeadsBdIsRemoteHostClassification behaviorally pins is_remote from
+// gc-beads-bd.sh: local-managed means empty OR 127.0.0.1 (the bind default)
+// OR 0.0.0.0 (the explicit wildcard opt-out). Anything else names a remote
+// target GC must not manage. Without 127.0.0.1 in the local set, an operator
+// could not adopt the loopback default without breaking managed-server
+// detection.
+func TestGcBeadsBdIsRemoteHostClassification(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available; skipping shell-function test")
+	}
+
+	root := repoRootForLint(t)
+	scriptPath := filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	scriptBytes, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	fnSrc := extractShellFunction(t, string(scriptBytes), "is_remote")
+
+	cases := []struct {
+		name       string
+		host       string // "" = unset
+		wantRemote bool
+	}{
+		{"unset is local-managed", "", false},
+		{"loopback default is local-managed", "127.0.0.1", false},
+		{"wildcard opt-out is local-managed", "0.0.0.0", false},
+		{"hostname is remote", "db.example.com", true},
+		{"lan address is remote", "10.0.0.5", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command("sh", "-c", fnSrc+"\nis_remote\n")
+			cmd.Env = environWithoutGCDoltHost()
+			if tc.host != "" {
+				cmd.Env = append(cmd.Env, "GC_DOLT_HOST="+tc.host)
+			}
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+			gotRemote := err == nil // is_remote returns 0 (sh success) when remote
+			if _, isExit := err.(*exec.ExitError); err != nil && !isExit {
+				t.Fatalf("sh -c failed: %v\nstderr:\n%s", err, stderr.String())
+			}
+			if gotRemote != tc.wantRemote {
+				t.Fatalf("is_remote with GC_DOLT_HOST=%q: remote=%v, want %v\nfunction:\n%s",
+					tc.host, gotRemote, tc.wantRemote, fnSrc)
+			}
+		})
+	}
+}
+
+func extractGcBeadsBdDoltHostDefault(t *testing.T) string {
+	t.Helper()
+	root := repoRootForLint(t)
+	scriptPath := filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	pattern := regexp.MustCompile(`(?m)^DOLT_HOST=.*$`)
+	line := pattern.FindString(string(data))
+	if line == "" {
+		t.Fatal("could not find DOLT_HOST default assignment in gc-beads-bd.sh")
+	}
+	return line
+}
+
+func environWithoutGCDoltHost() []string {
+	env := os.Environ()
+	filtered := env[:0]
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GC_DOLT_HOST=") {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return filtered
+}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -103,7 +103,7 @@ resolve_gc_bin() {
 # managed server.
 is_remote() {
     case "${GC_DOLT_HOST:-}" in
-        ''|127.0.0.1|0.0.0.0) return 1 ;;
+        ''|127.0.0.1|0.0.0.0|localhost|"::1"|"[::1]") return 1 ;;
     esac
     return 0
 }
@@ -1291,6 +1291,11 @@ graceful_stop_owned_pid() {
 # accumulate and the server enters unrecoverable read-only mode.
 write_config_yaml() {
     local archive_level auto_gc_enabled auto_gc_sysvar gc_bin raw_wait_timeout wait_timeout_line max_connections read_timeout_millis write_timeout_millis
+    # Surface the resolved managed-server bind. Since the default flipped from
+    # 0.0.0.0 to loopback, an operator who relied on the old wildcard bind would
+    # otherwise see a bare connection-refused; this line names the bind host and
+    # the override knob.
+    printf 'gc-beads-bd: managed dolt server binding %s:%s (override bind with GC_DOLT_HOST=0.0.0.0)\n' "$DOLT_HOST" "$DOLT_PORT" >&2
     archive_level=${GC_DOLT_ARCHIVE_LEVEL:-0}
     case "$archive_level" in
         ''|*[!0-9]*)

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -13,7 +13,9 @@
 #   GC_PACK_STATE_DIR — canonical pack runtime root for dolt (optional)
 #   GC_DOLT       — set to "skip" to no-op all operations (exit 2)
 #   GC_BEADS_BACKEND — "dolt" (default) or "doltlite"
-#   GC_DOLT_HOST  — dolt server host (empty = local server)
+#   GC_DOLT_HOST  — dolt server host (empty = managed local server bound to
+#                   127.0.0.1; 0.0.0.0 = managed local server exposed on all
+#                   interfaces; anything else = remote server GC won't manage)
 #   GC_DOLT_PORT  — dolt server port (default: ephemeral, hashed from city path)
 #   GC_DOLT_USER  — dolt user (default: root)
 #   GC_DOLT_PASSWORD — dolt password (default: empty)
@@ -33,7 +35,7 @@ set -e
 # --- Configuration ---
 
 # DOLT_PORT is set after derived paths are resolved (see allocate_port below).
-DOLT_HOST="${GC_DOLT_HOST:-0.0.0.0}"
+DOLT_HOST="${GC_DOLT_HOST:-127.0.0.1}"
 DOLT_USER="${GC_DOLT_USER:-root}"
 DOLT_PASSWORD="${GC_DOLT_PASSWORD:-}"
 DOLT_LOGLEVEL="${GC_DOLT_LOGLEVEL:-warning}"
@@ -95,10 +97,15 @@ resolve_gc_bin() {
     command -v gc 2>/dev/null || true
 }
 
-# is_remote returns 0 (true) when GC_DOLT_HOST explicitly names a target.
-# Only the empty/default bind host means GC owns a local managed server.
+# is_remote returns 0 (true) when GC_DOLT_HOST explicitly names a remote
+# target. Empty, 127.0.0.1 (the default bind), and 0.0.0.0 (the explicit
+# wildcard opt-out for multi-host deployments) all mean GC owns a local
+# managed server.
 is_remote() {
-    [ -n "$GC_DOLT_HOST" ] && [ "$GC_DOLT_HOST" != "0.0.0.0" ]
+    case "${GC_DOLT_HOST:-}" in
+        ''|127.0.0.1|0.0.0.0) return 1 ;;
+    esac
+    return 0
 }
 
 # connect_host returns the host to connect to (loopback IPv4 for local servers).

--- a/examples/bd/dolt/commands/recover/run.sh
+++ b/examples/bd/dolt/commands/recover/run.sh
@@ -15,10 +15,12 @@ PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 
 beads_bd="$GC_BEADS_BD_SCRIPT"
 
-# Reject remote servers — can't manage remote dolt processes.
+# Reject remote servers — can't manage remote dolt processes. Local hosts
+# include 0.0.0.0, the explicit wildcard opt-out for the managed server's
+# bind (the default bind is 127.0.0.1).
 if [ -n "$GC_DOLT_HOST" ]; then
   case "$GC_DOLT_HOST" in
-    127.0.0.1|localhost|"::1"|"[::1]") ;; # local is fine
+    127.0.0.1|0.0.0.0|localhost|"::1"|"[::1]") ;; # local is fine
     *) echo "gc dolt recover: not supported for remote dolt servers" >&2; exit 1 ;;
   esac
 fi

--- a/examples/bd/dolt/commands/restart/run.sh
+++ b/examples/bd/dolt/commands/restart/run.sh
@@ -38,10 +38,16 @@ if [ "$#" -ne 0 ]; then
   exit 64
 fi
 
-if [ -n "${GC_DOLT_HOST:-}" ] && [ "$GC_DOLT_HOST" != "0.0.0.0" ]; then
-  echo "gc dolt restart: not supported for remote dolt servers (set GC_DOLT_HOST=0.0.0.0 or unset to manage a local server)" >&2
-  exit 1
-fi
+# Local-managed means GC_DOLT_HOST is empty, 127.0.0.1 (the default bind),
+# or 0.0.0.0 (the explicit wildcard opt-out). Anything else names a remote
+# server whose process GC cannot manage.
+case "${GC_DOLT_HOST:-}" in
+  ''|127.0.0.1|0.0.0.0) ;;
+  *)
+    echo "gc dolt restart: not supported for remote dolt servers (set GC_DOLT_HOST=127.0.0.1, GC_DOLT_HOST=0.0.0.0, or unset to manage a local server)" >&2
+    exit 1
+    ;;
+esac
 
 CITY_RUNTIME_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}"
 PACK_STATE_DIR="${GC_PACK_STATE_DIR:-$CITY_RUNTIME_DIR/packs/dolt}"

--- a/examples/bd/dolt/commands/restart/run.sh
+++ b/examples/bd/dolt/commands/restart/run.sh
@@ -42,7 +42,7 @@ fi
 # or 0.0.0.0 (the explicit wildcard opt-out). Anything else names a remote
 # server whose process GC cannot manage.
 case "${GC_DOLT_HOST:-}" in
-  ''|127.0.0.1|0.0.0.0) ;;
+  ''|127.0.0.1|0.0.0.0|localhost|"::1"|"[::1]") ;;
   *)
     echo "gc dolt restart: not supported for remote dolt servers (set GC_DOLT_HOST=127.0.0.1, GC_DOLT_HOST=0.0.0.0, or unset to manage a local server)" >&2
     exit 1

--- a/examples/bd/dolt/recover_host_test.go
+++ b/examples/bd/dolt/recover_host_test.go
@@ -50,13 +50,12 @@ func runRecoverWithHost(t *testing.T, host string) ([]byte, error) {
 }
 
 // TestRecoverTreatsLocalHostsAsManaged pins the recover script's host
-// classification to the P0.5 contract: empty, 127.0.0.1 (the bind
-// default), and 0.0.0.0 (the explicit wildcard opt-out) all mean a
-// GC-managed local server, so recovery must proceed past the remote-host
-// guard. Pre-fix, 0.0.0.0 was misclassified as remote even though it was
-// the managed bind default.
+// classification to the P0.5 contract: empty, 127.0.0.1 (the managed bind
+// default), 0.0.0.0 (the explicit wildcard opt-out), localhost, and ::1 all
+// mean a GC-managed local server, so recovery must proceed past the
+// remote-host guard. Matches contract.DoltHostIsLocal.
 func TestRecoverTreatsLocalHostsAsManaged(t *testing.T) {
-	for _, host := range []string{"", "127.0.0.1", "0.0.0.0", "localhost"} {
+	for _, host := range []string{"", "127.0.0.1", "0.0.0.0", "localhost", "::1"} {
 		name := host
 		if name == "" {
 			name = "unset"

--- a/examples/bd/dolt/recover_host_test.go
+++ b/examples/bd/dolt/recover_host_test.go
@@ -1,0 +1,84 @@
+package dolt_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const recoverScript = "commands/recover/run.sh"
+
+// writeFakeDoltForRecover writes a stub `dolt` binary that always succeeds
+// with empty output, so the recover script's read-only write probe reports
+// "writable" and the script exits 0 without invoking gc-beads-bd.
+func writeFakeDoltForRecover(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	body := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return binDir
+}
+
+func runRecoverWithHost(t *testing.T, host string) ([]byte, error) {
+	t.Helper()
+	root := repoRoot(t)
+	binDir := writeFakeDoltForRecover(t)
+	cityPath := t.TempDir()
+
+	cmd := exec.Command("sh", filepath.Join(root, recoverScript))
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_CITY_RUNTIME_DIR", "GC_PACK_STATE_DIR", "GC_DOLT_LOG_FILE",
+		"GC_BEADS_BD_SCRIPT",
+	),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_PORT=3311",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	if host != "" {
+		cmd.Env = append(cmd.Env, "GC_DOLT_HOST="+host)
+	}
+	return cmd.CombinedOutput()
+}
+
+// TestRecoverTreatsLocalHostsAsManaged pins the recover script's host
+// classification to the P0.5 contract: empty, 127.0.0.1 (the bind
+// default), and 0.0.0.0 (the explicit wildcard opt-out) all mean a
+// GC-managed local server, so recovery must proceed past the remote-host
+// guard. Pre-fix, 0.0.0.0 was misclassified as remote even though it was
+// the managed bind default.
+func TestRecoverTreatsLocalHostsAsManaged(t *testing.T) {
+	for _, host := range []string{"", "127.0.0.1", "0.0.0.0", "localhost"} {
+		name := host
+		if name == "" {
+			name = "unset"
+		}
+		t.Run(name, func(t *testing.T) {
+			out, err := runRecoverWithHost(t, host)
+			if err != nil {
+				t.Fatalf("gc dolt recover refused GC_DOLT_HOST=%q as if remote: %v\n%s", host, err, out)
+			}
+			if strings.Contains(string(out), "not supported for remote dolt servers") {
+				t.Fatalf("recover misclassified local host %q as remote:\n%s", host, out)
+			}
+		})
+	}
+}
+
+func TestRecoverRejectsRemoteHostWithDiagnostic(t *testing.T) {
+	out, err := runRecoverWithHost(t, "db.example.com")
+	if err == nil {
+		t.Fatalf("gc dolt recover unexpectedly proceeded for a remote host:\n%s", out)
+	}
+	if !strings.Contains(string(out), "not supported for remote dolt servers") {
+		t.Fatalf("recover did not explain remote-host refusal:\n%s", out)
+	}
+}

--- a/examples/bd/dolt/restart_test.go
+++ b/examples/bd/dolt/restart_test.go
@@ -233,6 +233,43 @@ func TestRestartRefusesRecentENOSPCUnlessForced(t *testing.T) {
 	}
 }
 
+// TestRestartTreatsLoopbackAndWildcardHostsAsLocalManaged pins the P0.5
+// host-classification contract: the managed-server bind default is
+// 127.0.0.1, and 0.0.0.0 remains the explicit wildcard opt-out — both must
+// be treated as a GC-managed local server (restart proceeds), exactly like
+// an unset GC_DOLT_HOST. Without 127.0.0.1 in the local set, adopting the
+// loopback bind default would break managed-server detection.
+func TestRestartTreatsLoopbackAndWildcardHostsAsLocalManaged(t *testing.T) {
+	root := repoRoot(t)
+
+	for _, host := range []string{"127.0.0.1", "0.0.0.0"} {
+		t.Run(host, func(t *testing.T) {
+			port, cleanup := startReachableTCPListener(t)
+			defer cleanup()
+
+			cityPath := t.TempDir()
+			bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 0})
+
+			out, err := runRestartWithEnv(t, cityPath, root, []string{
+				fmt.Sprintf("GC_DOLT_PORT=%d", port),
+				"GC_DOLT_HOST=" + host,
+			})
+			if err != nil {
+				t.Fatalf("gc dolt restart refused GC_DOLT_HOST=%s as if remote: %v\n%s", host, err, out)
+			}
+
+			data, err := os.ReadFile(bdLog)
+			if err != nil {
+				t.Fatalf("read fake bd log: %v", err)
+			}
+			got := strings.Join(strings.Fields(string(data)), " ")
+			if got != "stop start" {
+				t.Fatalf("expected ops in order 'stop start' for local host %s, got %q\noutput:\n%s", host, got, out)
+			}
+		})
+	}
+}
+
 func TestRestartRejectsRemoteHostWithDiagnostic(t *testing.T) {
 	root := repoRoot(t)
 	port, cleanup := startReachableTCPListener(t)

--- a/examples/bd/dolt/restart_test.go
+++ b/examples/bd/dolt/restart_test.go
@@ -242,7 +242,7 @@ func TestRestartRefusesRecentENOSPCUnlessForced(t *testing.T) {
 func TestRestartTreatsLoopbackAndWildcardHostsAsLocalManaged(t *testing.T) {
 	root := repoRoot(t)
 
-	for _, host := range []string{"127.0.0.1", "0.0.0.0"} {
+	for _, host := range []string{"127.0.0.1", "0.0.0.0", "localhost", "::1"} {
 		t.Run(host, func(t *testing.T) {
 			port, cleanup := startReachableTCPListener(t)
 			defer cleanup()


### PR DESCRIPTION
## Summary

The managed Dolt sql-server bound `0.0.0.0` by default, exposing the bead store to the local network with no auth beyond Dolt's own. This changes the default bind to `127.0.0.1` (loopback) for the managed server, the recover/restart pack scripts, and the bd pack script — with aligned local-host classification so health probes and endpoint resolution agree on what counts as local. Operators who need an external bind can still configure it explicitly.

Defaults-only change: cities that never set a bind address get loopback; explicit configuration is untouched.

## Testing

- [x] `go build ./...`; `go test ./cmd/gc/` bind tests pass (`dolt_bind_localhost_test.go`, `gc_beads_bd_bind_host_test.go`, recover/restart host tests)
- [ ] `make check` — CI

## Checklist

- [x] Added tests for the default + explicit-override paths
- [x] No API change; security-hardening default
- [ ] Breaking only for setups silently relying on the implicit 0.0.0.0 bind (called out here intentionally)