### PR TITLE
fix(test-isolation): resolve symlinks in discovery-path normalization + ceiling cmd/gc tests

### DIFF
--- a/cmd/gc/city_discovery.go
+++ b/cmd/gc/city_discovery.go
@@ -145,5 +145,27 @@ func normalizeDiscoveryPath(path string) string {
 	if err == nil {
 		path = abs
 	}
-	return filepath.Clean(path)
+	// Resolve symlinks so ceiling comparisons match regardless of how the
+	// path was obtained: on macOS, t.Chdir/os.Getwd can yield /tmp/... while
+	// the same directory resolves to /private/tmp/..., and comparing the two
+	// raw forms silently defeats the ceiling. Both the walked directory and
+	// the configured ceilings flow through here, so resolution stays
+	// symmetric. For paths that do not (fully) exist, resolve the longest
+	// existing ancestor and re-append the remainder, so a configured-but-
+	// not-yet-created ceiling still normalizes consistently instead of
+	// silently dropping out of the comparison.
+	path = filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved)
+	}
+	dir, rest := path, ""
+	for dir != string(filepath.Separator) && dir != "." {
+		parent := filepath.Dir(dir)
+		rest = filepath.Join(filepath.Base(dir), rest)
+		dir = parent
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Clean(filepath.Join(resolved, rest))
+		}
+	}
+	return path
 }

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -87,7 +87,12 @@ func clearGCEnv(t *testing.T) {
 	for _, k := range liveEnvKeysForTests() {
 		t.Setenv(k, "")
 	}
-	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "gc-home"))
+	td := t.TempDir()
+	t.Setenv("GC_HOME", filepath.Join(td, "gc-home"))
+	// Prevent city discovery from walking above the test temp dir and finding
+	// a .gc/ directory left by a running city or a prior test run in /tmp
+	// (e.g. a developer box hosting a live city contaminates no-city tests).
+	t.Setenv("GC_CEILING_DIRECTORIES", filepath.Dir(td))
 }
 
 func clearProcessLiveEnvForTests() {


### PR DESCRIPTION
## Summary

Split out of #3203 per the review there ("Confirmed correct — the /tmp vs /private/tmp mismatch is real and the fix is sound. Suggestion: split this into its own PR so it can merge immediately").

`GC_CEILING_DIRECTORIES` comparisons fail on macOS: `t.Chdir`/`os.Getwd` can yield `/tmp/...` while the directory resolves to `/private/tmp/...`, so raw-string ceiling comparison silently fails and no-city tests discover a live `/tmp/.gc` runtime root from the host. `normalizeDiscoveryPath` now resolves symlinks — symmetric for both the walked dir and the ceilings, which flow through the same function.

The review's one caveat ("a configured-but-nonexistent ceiling entry now silently stops bounding discovery — one-sided symlink resolution") is addressed: paths that don't fully exist resolve their longest existing ancestor and re-append the remainder, so nonexistent ceilings still normalize consistently.

`clearGCEnv` also pins `GC_CEILING_DIRECTORIES` to the test tempdir's parent so the cmd/gc suite never walks above its sandbox (this is the host-/tmp/.gc contamination the #3334 revert notes also hit).

## Testing
- [x] `go build ./...`; `go test ./cmd/gc/ -run 'TestFindCity|Discovery|Ceiling|TestDoPrime|NoCity'` pass
- [ ] `make check` — CI

## Checklist
- [x] Addresses the reviewer caveat from #3203 (nonexistent-ceiling resolution)
- [x] Test-infra + one pure normalization function; no behavior change for existing resolved paths