### PR TITLE
fix(beads): repair dependencies.id DEFAULT on native Dolt store open

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -451,16 +451,14 @@ func TestFindCity(t *testing.T) {
 	})
 
 	t.Run("not_found", func(t *testing.T) {
-		// Use an explicit /tmp-rooted dir so the upward walk cannot
-		// accidentally hit a real .gc/ directory on the host (e.g.
-		// a running city under $HOME).
-		dir, err := os.MkdirTemp("/tmp", "gc-test-notfound-*")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.RemoveAll(dir) }()
+		// Pin HOME to the test dir so the discovery ceiling is dir itself.
+		// The walk checks dir (no city/runtime found) then stops at the ceiling
+		// without climbing into /tmp or $HOME, which may have a live .gc/ on
+		// the host (e.g. a running city at /tmp/.gc or $HOME/.gc).
+		dir := t.TempDir()
+		t.Setenv("HOME", dir)
 
-		_, err = findCity(dir)
+		_, err := findCity(dir)
 		if err == nil {
 			t.Fatal("findCity() should fail without city.toml or .gc/")
 		}

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -2,6 +2,7 @@ package beads
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,41 @@ import (
 
 	beadslib "github.com/steveyegge/beads"
 )
+
+// rawDBGetter matches beadslib's internal storage.RawDBAccessor without
+// importing its internal package. DoltStore satisfies this interface.
+type rawDBGetter interface {
+	DB() *sql.DB
+}
+
+// repairDependenciesIDDefault ensures the dependencies.id column has DEFAULT
+// (uuid()). Migration 0043 adds it via PREPARE/EXECUTE, which Dolt silently
+// strips the expression default from on some versions. Without the default the
+// beadslib INSERT fails with "Field 'id' doesn't have a default value" because
+// the library never supplies id explicitly, relying on the expression default.
+// This repair is idempotent: it checks INFORMATION_SCHEMA before altering.
+func repairDependenciesIDDefault(db *sql.DB) error {
+	var hasDefault int
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'dependencies'
+		  AND COLUMN_NAME = 'id'
+		  AND COLUMN_DEFAULT IS NOT NULL
+	`).Scan(&hasDefault)
+	if err != nil {
+		return fmt.Errorf("checking dependencies.id default: %w", err)
+	}
+	if hasDefault > 0 {
+		return nil
+	}
+	_, err = db.Exec("ALTER TABLE `dependencies` MODIFY COLUMN `id` char(36) NOT NULL DEFAULT (uuid())")
+	if err != nil {
+		return fmt.Errorf("repairing dependencies.id default: %w", err)
+	}
+	return nil
+}
 
 const nativeDoltStoreActor = "gascity"
 
@@ -162,6 +198,12 @@ func newNativeDoltStoreAt(parent context.Context, scopeRoot string, env map[stri
 	if err != nil {
 		_ = storage.Close()
 		return nil, fmt.Errorf("reading native issue prefix: %w", err)
+	}
+	if accessor, ok := storage.(rawDBGetter); ok {
+		if repairErr := repairDependenciesIDDefault(accessor.DB()); repairErr != nil {
+			// Log but don't fail: the error will surface on the first DepAdd.
+			fmt.Fprintf(os.Stderr, "WARNING: gc beads: %v\n", repairErr)
+		}
 	}
 	return newNativeDoltStoreWithStorageAndPrefix(storage, nativeDoltStoreActor, prefix), nil
 }

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2899,6 +2899,49 @@ func TestFinalizeAutoConvoyTracksDepAddError(t *testing.T) {
 	}
 }
 
+// TestFinalizeAutoConvoyTracksDepCreated is a regression test for
+// "Field 'id' doesn't have a default value" on dependencies.id: Dolt strips
+// DEFAULT (uuid()) when migration 0043 runs via PREPARE/EXECUTE, causing
+// every DepAdd to fail silently via MetadataErrors. Verify that DoSling
+// creates the convoy→bead tracks dependency with no metadata errors.
+func TestFinalizeAutoConvoyTracksDepCreated(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+
+	b, err := deps.Store.Create(beads.Bead{Title: "work", Type: "task"})
+	if err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+
+	result, err := DoSling(SlingOpts{Target: a, BeadOrFormula: b.ID}, deps, deps.Store)
+	if err != nil {
+		t.Fatalf("DoSling: %v", err)
+	}
+	if result.ConvoyID == "" {
+		t.Fatal("expected auto-convoy creation")
+	}
+	if len(result.MetadataErrors) != 0 {
+		t.Errorf("unexpected MetadataErrors (dep link failure?): %v", result.MetadataErrors)
+	}
+
+	downDeps, err := deps.Store.DepList(result.ConvoyID, "down")
+	if err != nil {
+		t.Fatalf("DepList convoy: %v", err)
+	}
+	var tracks bool
+	for _, d := range downDeps {
+		if d.DependsOnID == b.ID && d.Type == "tracks" {
+			tracks = true
+			break
+		}
+	}
+	if !tracks {
+		t.Errorf("convoy %s missing tracks dep to bead %s; deps=%v", result.ConvoyID, b.ID, downDeps)
+	}
+}
+
 func TestFinalizeNoConvoyWhenSuppressed(t *testing.T) {
 	runner := newFakeRunner()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}

--- a/release-gates/ga-s6qc7f-dep-id-default-gate.md
+++ b/release-gates/ga-s6qc7f-dep-id-default-gate.md
@@ -1,0 +1,46 @@
+# Release gate: dependencies.id DEFAULT repair
+
+- Deploy bead: ga-s6qc7f
+- Source bug: ga-iwikr0
+- PR: https://github.com/gastownhall/gascity/pull/3365
+- Branch: fix/gc-sling-convoy-dep-id-default
+- Gate commit under review: cb03298cd3091ab2b04bde2c3aca222230ba4ca1
+- Gate run date: 2026-06-11
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead ga-z2f3h9 is closed with `REVIEW VERDICT: PASS`; deploy bead ga-s6qc7f records reviewer PASS. |
+| 2 | Acceptance criteria met | PASS | Sling regression test verifies auto-convoy `tracks` dependency creation with no `MetadataErrors`; native Dolt open repairs missing `dependencies.id DEFAULT (uuid())`; `TestFindCity/not_found` now pins `HOME` to the test dir. |
+| 3 | Tests pass | PASS | PR #3365 GitHub checks are green, including Check, Analyze, package/integration shards, cmd/gc process shards, dashboard, and worker gates. Local focused checks passed: `go test ./internal/sling -run TestFinalizeAutoConvoyTracksDepCreated -count=1`, `go test ./internal/beads -count=1`, `go test ./cmd/gc -run TestFindCity -count=1`, `go vet ./...`. Local `make test-fast-parallel` was attempted; failures were unrelated local baseline/environment failures from `/tmp/.gc` discovery and one supervisor temp cleanup flake. The cmd/gc failure set reproduced on `origin/main`, and `go test ./internal/supervisor -run TestRunSnapshot_Integration_RealDoltRoundTrip -count=1` passed on rerun. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list no blocking findings and no high-severity findings. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` shows `fix/gc-sling-convoy-dep-id-default...origin/main [ahead 1]` before gate-file commit, with no uncommitted changes. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reports merged results and no conflict markers; GitHub reports PR #3365 mergeable. |
+| 7 | Single feature theme | PASS | Commit set touches one feature theme: native beads/Dolt dependency ID repair plus the sling regression and a targeted test-environment cleanup. |
+
+## Acceptance Criteria
+
+| Source criterion | Result | Evidence |
+|------------------|--------|----------|
+| Reproducing `gc sling` no longer emits `Field 'id' doesn't have a default value` while linking convoy tracks dependencies. | PASS | `TestFinalizeAutoConvoyTracksDepCreated` exercises `DoSling` and requires no `MetadataErrors`. |
+| Sling-created convoy tracking rows receive stable IDs or the write path supplies the required ID explicitly. | PASS | `repairDependenciesIDDefault` restores `DEFAULT (uuid())` on `dependencies.id`, preserving the existing beadslib insert contract. |
+| Existing routing behavior is preserved: target hook receives the slung bead and metadata remains intact. | PASS | Regression is scoped to the existing `DoSling` path and verifies convoy dependency creation without changing routing metadata behavior. |
+| A regression test covers the convoy dependency-linking path for sling-created beads. | PASS | `internal/sling.TestFinalizeAutoConvoyTracksDepCreated`. |
+| If root cause is schema migration mismatch, record evidence and route correct follow-up before closing. | PASS | Root cause recorded in source review and PR body: Dolt strips the expression default from migration 0043 on some versions. Repair is in native Dolt store open. |
+
+## Local Test Notes
+
+Commands run on the release branch:
+
+- `go test ./internal/sling -run TestFinalizeAutoConvoyTracksDepCreated -count=1`: PASS
+- `go test ./internal/beads -count=1`: PASS
+- `go test ./cmd/gc -run TestFindCity -count=1`: PASS
+- `go vet ./...`: PASS
+- `git diff --check origin/main...HEAD`: PASS
+- `make test-fast-parallel`: local baseline red; not a PR regression.
+
+Baseline comparison:
+
+- The targeted cmd/gc failures from the local fast run also fail on `origin/main` with the same `/tmp/.gc`/`/tmp/city.toml` discovery behavior.
+- The single `internal/supervisor` cleanup failure passed on focused rerun.


### PR DESCRIPTION
## What this changes

Native Dolt-backed bead stores now repair a missing `dependencies.id` expression default when the store opens. This prevents `DepAdd` calls from failing with `Field 'id' doesn't have a default value`, which in turn lets `gc sling` create the convoy-to-work `tracks` dependency instead of reporting a metadata error after routing succeeds.

The branch also tightens `TestFindCity/not_found` so the discovery walk is bounded by the test directory. That keeps the test from accidentally discovering host-level city state such as `/tmp/.gc` or `$HOME/.gc`.

## Review notes

- The repair is scoped to `internal/beads/native_dolt_store.go` and runs only when the native Dolt storage exposes its raw `*sql.DB`.
- The SQL is hardcoded: it checks `INFORMATION_SCHEMA.COLUMNS` and runs one idempotent `ALTER TABLE` only when the default is absent.
- Store open logs a warning if the repair fails, but does not fail open; the real write failure still surfaces at the first dependency write.
- DoltLite, file-backed stores, and generic store contracts are unchanged.

## Test plan

- [x] `go test ./internal/sling -run TestFinalizeAutoConvoyTracksDepCreated -count=1`
- [x] `go test ./internal/beads -count=1`
- [x] `go test ./cmd/gc -run TestFindCity -count=1`
- [x] `go vet ./...`
- [x] GitHub CI passed on the code commit; the follow-up gate commit adds release evidence only.
- [x] Release gate: [`release-gates/ga-s6qc7f-dep-id-default-gate.md`](release-gates/ga-s6qc7f-dep-id-default-gate.md)
