### PR TITLE
fix(session): release configured named-session name on close by identity

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -958,7 +958,11 @@ func (m *Manager) clearWakeAndHoldOverrides(id string) error {
 }
 
 func (m *Manager) retireConfiguredNamedSessionIdentifiers(id string, b beads.Bead) error {
-	if strings.TrimSpace(b.Metadata["configured_named_session"]) != "true" {
+	// Recognize configured named sessions by flag OR identity so a
+	// partially-tagged bead (identity recorded, boolean flag absent) still
+	// releases its reserved runtime name on close instead of stranding the
+	// name and blocking respawn (ga-841).
+	if !wasConfiguredNamedSession(b) {
 		return nil
 	}
 	update := beads.UpdateOpts{

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1338,6 +1338,61 @@ func TestClose_ConfiguredNamedSessionRetiresIdentifiers(t *testing.T) {
 	}
 }
 
+// TestClose_NamedSessionByIdentityRetiresIdentifiers covers ga-841: a
+// configured named session recognized only by its configured_named_identity
+// (the boolean configured_named_session flag absent — e.g. a legacy or
+// partially-tagged bead) must still release its runtime name on close, and the
+// freed name must be reusable for a fresh same-named session. This is the
+// "create a named session, close it, assert its name is FREE" acceptance.
+func TestClose_NamedSessionByIdentityRetiresIdentifiers(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.CreateAliasedNamedWithTransportAndMetadata(
+		context.Background(),
+		"refinery",
+		"test-city--refinery",
+		"refinery",
+		"Refinery",
+		"claude",
+		"/tmp",
+		"claude",
+		"",
+		nil,
+		ProviderResume{},
+		runtime.Config{},
+		map[string]string{
+			// Identity only — the boolean flag is intentionally absent to
+			// model the ga-841 stale/legacy bead.
+			"configured_named_identity": "refinery",
+		},
+	)
+	if err != nil {
+		t.Fatalf("CreateAliasedNamedWithTransportAndMetadata: %v", err)
+	}
+
+	if err := mgr.Close(info.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := b.Metadata["session_name"]; got != "" {
+		t.Fatalf("session_name = %q, want empty after close", got)
+	}
+	if got := b.Metadata["alias"]; got != "" {
+		t.Fatalf("alias = %q, want empty after close", got)
+	}
+
+	// The freed runtime name must be available for a fresh session.
+	if err := ensureSessionNameAvailable(store, "test-city--refinery"); err != nil {
+		t.Fatalf("ensureSessionNameAvailable after close = %v, want nil", err)
+	}
+}
+
 func TestCreateInjectsUnifiedSessionRuntimeEnv(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -168,6 +168,20 @@ func NamedSessionIdentity(b beads.Bead) string {
 	return strings.TrimSpace(b.Metadata[NamedSessionIdentityMetadata])
 }
 
+// wasConfiguredNamedSession reports whether a bead was created for a configured
+// named session, recognized by either the configured-named-session boolean flag
+// or a recorded configured-named identity.
+//
+// The identity fallback is load-bearing on close/respawn (ga-841): a bead whose
+// boolean flag was never set or was later cleared — legacy beads predating the
+// flag, or beads closed by a path that only retained the identity — must still
+// be treated as a configured named session. Otherwise its reserved runtime
+// session name is never released and permanently blocks the on-demand respawn
+// of a same-named session (the refinery no-respawn class in ga-n2d).
+func wasConfiguredNamedSession(b beads.Bead) bool {
+	return IsNamedSessionBead(b) || NamedSessionIdentity(b) != ""
+}
+
 // NamedSessionMode returns the configured named session mode stored on a bead.
 func NamedSessionMode(b beads.Bead) string {
 	return strings.TrimSpace(b.Metadata[NamedSessionModeMetadata])

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -349,15 +349,20 @@ func ensureSessionNameAvailableForSelfAndOwner(store beads.Store, name, selfID, 
 		// session bead, including a closed one, they are never reused.
 		//
 		// Exception: closed beads that belong to a configured named session
-		// (configured_named_session=true) release their session_name so the
-		// reconciler can re-materialize a fresh canonical bead for the same
-		// identity. The design doc specifies: "Closed historical beads do not
-		// poison future canonical materialization of the reserved identity."
+		// release their session_name so the reconciler can re-materialize a
+		// fresh canonical bead for the same identity. The design doc specifies:
+		// "Closed historical beads do not poison future canonical
+		// materialization of the reserved identity." Recognition is by the
+		// boolean flag OR the recorded identity (wasConfiguredNamedSession) so a
+		// stale/legacy bead missing the flag still releases its name (ga-841) —
+		// independent of whether the caller passed a matching selfOwner, since
+		// the configured-named reservation is re-enforced by the cfg-aware check
+		// in ensureConfiguredSessionNameAvailable.
 		if strings.TrimSpace(b.Metadata["session_name"]) == name {
 			if continuityIneligibleConfiguredOwner(b, selfOwner) {
 				continue
 			}
-			if b.Status == "closed" && strings.TrimSpace(b.Metadata["configured_named_session"]) == "true" {
+			if b.Status == "closed" && wasConfiguredNamedSession(b) {
 				continue
 			}
 			return fmt.Errorf("%w: %q already belongs to %s", ErrSessionNameExists, name, b.ID)

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -308,6 +308,64 @@ func TestEnsureSessionNameAvailable_RejectsClosedAdHocSession(t *testing.T) {
 	}
 }
 
+// TestEnsureSessionNameAvailable_AllowsClosedNamedSessionByIdentity reproduces
+// ga-841: a closed configured named session bead that carries the
+// configured_named_identity but is MISSING the boolean configured_named_session
+// flag must not permanently reserve its runtime session name. Such stale beads
+// (closed by a path that only retained the identity, or predating the flag)
+// otherwise block on-demand respawn with ErrSessionNameExists ("already belongs
+// to <closed-id>"), which is exactly the refinery no-respawn class in ga-n2d.
+func TestEnsureSessionNameAvailable_AllowsClosedNamedSessionByIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+
+	bead, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name":              "gascity--gastown__refinery",
+			"configured_named_identity": "gastown.refinery",
+			// configured_named_session flag intentionally absent.
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Close(bead.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// A closed configured named session — recognized by its identity even
+	// without the boolean flag — releases its runtime name so the reconciler
+	// can materialize a fresh canonical bead.
+	if err := ensureSessionNameAvailable(store, "gascity--gastown__refinery"); err != nil {
+		t.Fatalf("ensureSessionNameAvailable(closed named-by-identity) = %v, want nil", err)
+	}
+}
+
+// TestEnsureSessionNameAvailable_RejectsLiveNamedSessionByIdentity guards the
+// no-regression requirement of ga-841: the release only applies to CLOSED
+// beads. A live (open) configured named session must still own its runtime
+// name so two live sessions cannot collide.
+func TestEnsureSessionNameAvailable_RejectsLiveNamedSessionByIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+
+	if _, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name":              "gascity--gastown__refinery",
+			"configured_named_identity": "gastown.refinery",
+			"configured_named_session":  "true",
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := ensureSessionNameAvailable(store, "gascity--gastown__refinery"); !errors.Is(err, ErrSessionNameExists) {
+		t.Fatalf("ensureSessionNameAvailable(live named) = %v, want %v", err, ErrSessionNameExists)
+	}
+}
+
 func TestEnsureAliasAvailableWithConfig_AllowsLiveAliasHistoryReuse(t *testing.T) {
 	store := beads.NewMemStore()
 	_, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Problem

A closed configured named session (e.g. a refinery whose runtime session name is `<rig>--<binding>__<template>`) could permanently reserve its session name when the closed bead carried `configured_named_identity` but was missing the boolean `configured_named_session` flag. This happens for legacy beads that predate the flag, or beads closed by a path that only retained the identity.

Both the name-availability scan (`ensureSessionNameAvailableForSelfAndOwner`) and the close-time identifier retirement (`retireConfiguredNamedSessionIdentifiers`) keyed solely on the boolean flag, so such a stale **closed** bead blocked on-demand respawn with:

```
session name already exists: "<name>" already belongs to <closed-id>
```

The reconciler's on-demand named-session spawn hit this silently, so the named session never respawned (observed as a refinery that idle-slept and then could not come back).

## Fix

Recognize a configured named session by flag **OR** recorded identity via a small shared helper `wasConfiguredNamedSession(bead)`:

- `ensureSessionNameAvailableForSelfAndOwner` now releases a **closed** identity-bearing bead's `session_name` independent of `selfOwner`. The configured-named reservation is still re-enforced by the cfg-aware check in `ensureConfiguredSessionNameAvailable`, so a different identity cannot steal the name.
- `retireConfiguredNamedSessionIdentifiers` clears the reserved name on close for identity-only beads too, so the name is freed promptly at close time.

This brings the configured-named `session_name` branch in line with how closed beads are treated everywhere else in the package (closed = non-blocking).

## Invariants preserved

- **Live sessions still own their names** — the release is gated on `status == "closed"`.
- **Ad-hoc explicit names stay permanent** — ad-hoc beads carry neither the flag nor an identity, so they are unaffected (the higher-level reopen path handles their restart).

## Tests

- `TestEnsureSessionNameAvailable_AllowsClosedNamedSessionByIdentity` — read path releases a closed identity-only bead (reproduces the bug).
- `TestEnsureSessionNameAvailable_RejectsLiveNamedSessionByIdentity` — live bead still reserved (no regression).
- `TestClose_NamedSessionByIdentityRetiresIdentifiers` — create → close → name is free and reusable (manager level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)