### PR TITLE
fix(import): honor city root import overrides

### DIFF
--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -276,6 +276,16 @@ func resolveImportRoot() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Explicit rig/dir signals carry user intent and outrank cwd inference:
+	// route them through the registered-city machinery first, exactly as
+	// --city does above. Only pure cwd inference may use the nearest-marker
+	// walk below.
+	if hasExplicitRigOrDirSignal() {
+		if cityPath, err := resolveCity(); err == nil {
+			return cityPath, nil
+		}
+		return findPackRoot(cwd)
+	}
 	if root, ok, err := findNearestImportRoot(cwd); ok || err != nil {
 		return root, err
 	}
@@ -283,6 +293,18 @@ func resolveImportRoot() (string, error) {
 		return cityPath, nil
 	}
 	return findPackRoot(cwd)
+}
+
+func hasExplicitRigOrDirSignal() bool {
+	if strings.TrimSpace(rigFlag) != "" {
+		return true
+	}
+	for _, key := range []string{"GC_RIG", "GC_DIR"} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveExplicitImportPathEnv() (string, bool) {
@@ -326,18 +348,24 @@ func findPackRoot(dir string) (string, error) {
 	return "", fmt.Errorf("could not find city or pack root from %s", dir)
 }
 
+// findNearestImportRoot walks dir upward to the nearest directory holding an
+// explicit config marker: pack.toml or city.toml. Bare .gc/ runtime
+// directories are deliberately not markers — stale rig worktrees and the
+// supervisor's global runtime root must fall through to resolveCity(), whose
+// registered-rig guards and legacy-runtime rules know how to resolve them.
+// The walk is bounded by the same ceilings as implicit city discovery.
 func findNearestImportRoot(dir string) (string, bool, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return "", false, err
 	}
+	ceilings := implicitCityDiscoveryCeilings()
 	for {
-		if packExists(abs) {
+		if packExists(abs) || citylayout.HasCityConfig(abs) {
 			return abs, true, nil
 		}
-		if citylayout.HasCityConfig(abs) || citylayout.HasRuntimeRoot(abs) {
-			cityPath, err := validateCityPath(abs)
-			return cityPath, true, err
+		if isCityDiscoveryCeiling(abs, ceilings) {
+			return "", false, nil
 		}
 		parent := filepath.Dir(abs)
 		if parent == abs {
@@ -479,20 +507,42 @@ func copyImports(imports map[string]config.Import) map[string]config.Import {
 }
 
 func applyCityRootImportOverridesFS(fs fsys.FS, cityPath string, imports map[string]config.Import) error {
-	if _, err := fs.Stat(filepath.Join(cityPath, "city.toml")); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	cfg, err := loadCityImportManifestFS(fs, cityPath)
+	overrides, err := loadCityRootImportsFS(fs, cityPath)
 	if err != nil {
 		return err
 	}
-	for name, imp := range cfg.Imports {
+	for name, imp := range overrides {
 		imports[name] = imp
 	}
 	return nil
+}
+
+// loadCityRootImportsFS returns the root-level [imports] entries from
+// city.toml, or nil when no city.toml exists.
+func loadCityRootImportsFS(fs fsys.FS, cityPath string) (map[string]config.Import, error) {
+	if _, err := fs.Stat(filepath.Join(cityPath, "city.toml")); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	cfg, err := loadCityImportManifestFS(fs, cityPath)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Imports, nil
+}
+
+// cityRootImportExistsFS reports whether city.toml's root [imports] table
+// defines name. City entries own the effective root import wholesale, so the
+// add/remove write paths must consult this before mutating pack.toml.
+func cityRootImportExistsFS(fs fsys.FS, cityPath, name string) (bool, error) {
+	overrides, err := loadCityRootImportsFS(fs, cityPath)
+	if err != nil {
+		return false, err
+	}
+	_, ok := overrides[name]
+	return ok, nil
 }
 
 func lookupInspectableImport(target string, imports map[string]config.Import) (config.Import, bool) {
@@ -573,6 +623,17 @@ func doImportAdd(fs fsys.FS, cityPath, source, nameOverride, versionFlag string,
 		fmt.Fprintf(stderr, "gc import add: import %q already exists\n", name) //nolint:errcheck
 		return 1
 	}
+	if scope.isRootPackScope() {
+		cityOwned, err := cityRootImportExistsFS(fs, cityPath, name)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc import add: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		if cityOwned {
+			fmt.Fprintf(stderr, "gc import add: import %q is defined by city.toml [imports], which overrides pack.toml; edit city.toml instead\n", name) //nolint:errcheck
+			return 1
+		}
+	}
 
 	version := versionFlag
 	if gitBacked {
@@ -627,16 +688,34 @@ func doImportRemove(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 		return 1
 	}
 	if _, exists := scope.imports[name]; !exists {
-		removed, err := removeRootDefaultRigImportFS(fs, cityPath, scope, name)
+		removed, err := removeCityRootImportFS(fs, cityPath, scope, name)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc import remove: %v\n", err) //nolint:errcheck
 			return 1
+		}
+		if !removed {
+			removed, err = removeRootDefaultRigImportFS(fs, cityPath, scope, name)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc import remove: %v\n", err) //nolint:errcheck
+				return 1
+			}
 		}
 		if !removed {
 			fmt.Fprintf(stderr, "gc import remove: import %q not found\n", name) //nolint:errcheck
 			return 1
 		}
 	} else {
+		if scope.isRootPackScope() {
+			cityOwned, err := cityRootImportExistsFS(fs, cityPath, name)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc import remove: %v\n", err) //nolint:errcheck
+				return 1
+			}
+			if cityOwned {
+				fmt.Fprintf(stderr, "gc import remove: import %q is overridden by city.toml [imports]; remove the city.toml entry first\n", name) //nolint:errcheck
+				return 1
+			}
+		}
 		delete(scope.imports, name)
 	}
 
@@ -662,6 +741,34 @@ func doImportRemove(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 	}
 	fmt.Fprintf(stdout, "Removed import %q\n", name) //nolint:errcheck
 	return 0
+}
+
+// removeCityRootImportFS removes a root import owned by city.toml [imports].
+// City-only root imports are visible in list/why output, so remove must be
+// able to delete them; they live in city.toml, so the save is redirected
+// there, mirroring removeRootDefaultRigImportFS.
+func removeCityRootImportFS(fs fsys.FS, cityPath string, scope *importScopeState, name string) (bool, error) {
+	if !scope.isRootPackScope() {
+		return false, nil
+	}
+	if _, err := fs.Stat(filepath.Join(cityPath, "city.toml")); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	cfg, err := loadCityImportManifestFS(fs, cityPath)
+	if err != nil {
+		return false, err
+	}
+	if _, ok := cfg.Imports[name]; !ok {
+		return false, nil
+	}
+	delete(cfg.Imports, name)
+	scope.save = func() error {
+		return writeCityImportManifestFS(fs, cityPath, cfg)
+	}
+	return true, nil
 }
 
 func removeRootDefaultRigImportFS(fs fsys.FS, cityPath string, scope *importScopeState, name string) (bool, error) {

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/packman"
@@ -271,12 +272,15 @@ func resolveImportRoot() (string, error) {
 	if raw, ok := resolveExplicitImportPathEnv(); ok {
 		return validateImportRootPath(raw)
 	}
-	if cityPath, err := resolveCity(); err == nil {
-		return cityPath, nil
-	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err
+	}
+	if root, ok, err := findNearestImportRoot(cwd); ok || err != nil {
+		return root, err
+	}
+	if cityPath, err := resolveCity(); err == nil {
+		return cityPath, nil
 	}
 	return findPackRoot(cwd)
 }
@@ -320,6 +324,27 @@ func findPackRoot(dir string) (string, error) {
 		abs = parent
 	}
 	return "", fmt.Errorf("could not find city or pack root from %s", dir)
+}
+
+func findNearestImportRoot(dir string) (string, bool, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", false, err
+	}
+	for {
+		if packExists(abs) {
+			return abs, true, nil
+		}
+		if citylayout.HasCityConfig(abs) || citylayout.HasRuntimeRoot(abs) {
+			cityPath, err := validateCityPath(abs)
+			return cityPath, true, err
+		}
+		parent := filepath.Dir(abs)
+		if parent == abs {
+			return "", false, nil
+		}
+		abs = parent
+	}
 }
 
 type importScopeState struct {
@@ -389,7 +414,11 @@ func collectAllImportsFS(fs fsys.FS, cityPath string) (map[string]config.Import,
 	if err != nil {
 		return nil, err
 	}
-	for name, imp := range packManifest.Imports {
+	rootImports := copyImports(packManifest.Imports)
+	if err := applyCityRootImportOverridesFS(fs, cityPath, rootImports); err != nil {
+		return nil, err
+	}
+	for name, imp := range rootImports {
 		all["pack:"+name] = imp
 	}
 	defaults, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
@@ -420,12 +449,12 @@ func collectAllImportsFS(fs fsys.FS, cityPath string) (map[string]config.Import,
 }
 
 func collectInspectableImportsFS(fs fsys.FS, cityPath string, scope *importScopeState) (map[string]config.Import, error) {
-	imports := make(map[string]config.Import, len(scope.imports))
-	for name, imp := range scope.imports {
-		imports[name] = imp
-	}
+	imports := copyImports(scope.imports)
 	if !scope.isRootPackScope() {
 		return imports, nil
+	}
+	if err := applyCityRootImportOverridesFS(fs, cityPath, imports); err != nil {
+		return nil, err
 	}
 	defaults, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
 	if err != nil {
@@ -439,6 +468,31 @@ func collectInspectableImportsFS(fs fsys.FS, cityPath string, scope *importScope
 		imports[key] = bound.Import
 	}
 	return imports, nil
+}
+
+func copyImports(imports map[string]config.Import) map[string]config.Import {
+	out := make(map[string]config.Import, len(imports))
+	for name, imp := range imports {
+		out[name] = imp
+	}
+	return out
+}
+
+func applyCityRootImportOverridesFS(fs fsys.FS, cityPath string, imports map[string]config.Import) error {
+	if _, err := fs.Stat(filepath.Join(cityPath, "city.toml")); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	cfg, err := loadCityImportManifestFS(fs, cityPath)
+	if err != nil {
+		return err
+	}
+	for name, imp := range cfg.Imports {
+		imports[name] = imp
+	}
+	return nil
 }
 
 func lookupInspectableImport(target string, imports map[string]config.Import) (config.Import, bool) {

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -656,6 +656,61 @@ version = "^1.4"
 	}
 }
 
+func TestDoImportInstallCityImportOverridesRootPackImport(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	localPack := filepath.Join(dir, "packs", "tools")
+	if err := os.MkdirAll(localPack, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writePackToml(t, localPack, "[pack]\nname = \"tools\"\nschema = 1\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.4"
+`)
+	writeCityToml(t, dir, `[workspace]
+name = "demo"
+
+[imports.tools]
+source = "packs/tools"
+`)
+
+	prevSync := syncImports
+	prevInstall := installLockedImports
+	t.Cleanup(func() {
+		syncImports = prevSync
+		installLockedImports = prevInstall
+	})
+	syncImports = func(_ string, imports map[string]config.Import, _ packman.InstallMode) (*packman.Lockfile, error) {
+		imp, ok := imports["pack:tools"]
+		if !ok {
+			t.Fatalf("imports = %#v, want pack:tools", imports)
+		}
+		if imp.Source != "packs/tools" {
+			t.Fatalf("pack:tools source = %q, want city.toml override", imp.Source)
+		}
+		for name, imp := range imports {
+			if imp.Source == "https://example.com/tools.git" {
+				t.Fatalf("imports[%s] still uses root pack remote source: %#v", name, imports)
+			}
+		}
+		return &packman.Lockfile{Schema: packman.LockfileSchema, Packs: map[string]packman.LockedPack{}}, nil
+	}
+	installLockedImports = func(_ string) (*packman.Lockfile, error) {
+		return &packman.Lockfile{Schema: packman.LockfileSchema, Packs: map[string]packman.LockedPack{}}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportInstall(dir, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+}
+
 func TestDoImportInstallRewritesLockToCurrentGraph(t *testing.T) {
 	clearGCEnv(t)
 	dir := t.TempDir()
@@ -1205,6 +1260,44 @@ source = "../packs/local"
 	}
 	if !strings.Contains(stdout.String(), "local\t../packs/local\t\t(path)") {
 		t.Fatalf("unexpected flat output:\n%s", stdout.String())
+	}
+}
+
+func TestDoImportListShowsCityImportOverrideForRootPackImport(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.4"
+`)
+	writeCityToml(t, dir, `[workspace]
+name = "demo"
+
+[imports.tools]
+source = "packs/tools"
+`)
+	if err := packman.WriteLockfile(fsys.OSFS{}, dir, &packman.Lockfile{
+		Schema: packman.LockfileSchema,
+		Packs:  map[string]packman.LockedPack{},
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportList(dir, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "tools\tpacks/tools\t\t(path)") {
+		t.Fatalf("missing city override path import:\n%s", out)
+	}
+	if strings.Contains(out, "https://example.com/tools.git") {
+		t.Fatalf("output still shows root pack remote source:\n%s", out)
 	}
 }
 

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -524,6 +524,135 @@ func TestDoImportRemoveRewritesConfig(t *testing.T) {
 	}
 }
 
+func TestDoImportAddRefusesCityOwnedRootImport(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writePackToml(t, dir, "[pack]\nname = \"demo\"\nschema = 1\n")
+	writeCityToml(t, dir, `[workspace]
+name = "demo"
+
+[imports.tools]
+source = "packs/tools"
+`)
+
+	prevSync := syncImports
+	t.Cleanup(func() { syncImports = prevSync })
+	syncImports = func(_ string, _ map[string]config.Import, _ packman.InstallMode) (*packman.Lockfile, error) {
+		t.Fatal("syncImports must not run for a refused add")
+		return nil, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportAdd(fsys.OSFS{}, dir, "https://example.com/tools.git", "tools", "^1.4", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "city.toml") {
+		t.Fatalf("stderr must point at city.toml ownership:\n%s", stderr.String())
+	}
+
+	manifest, err := loadCityPackManifestFS(fsys.OSFS{}, dir)
+	if err != nil {
+		t.Fatalf("loadCityPackManifestFS: %v", err)
+	}
+	if len(manifest.Imports) != 0 {
+		t.Fatalf("pack.toml imports = %#v, want untouched", manifest.Imports)
+	}
+}
+
+func TestDoImportRemoveRefusesCityOverriddenPackImport(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.4"
+`)
+	writeCityToml(t, dir, `[workspace]
+name = "demo"
+
+[imports.tools]
+source = "packs/tools"
+`)
+
+	prevSync := syncImports
+	t.Cleanup(func() { syncImports = prevSync })
+	syncImports = func(_ string, _ map[string]config.Import, _ packman.InstallMode) (*packman.Lockfile, error) {
+		t.Fatal("syncImports must not run for a refused remove")
+		return nil, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportRemove(fsys.OSFS{}, dir, "tools", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "city.toml") {
+		t.Fatalf("stderr must point at city.toml ownership:\n%s", stderr.String())
+	}
+
+	manifest, err := loadCityPackManifestFS(fsys.OSFS{}, dir)
+	if err != nil {
+		t.Fatalf("loadCityPackManifestFS: %v", err)
+	}
+	if _, ok := manifest.Imports["tools"]; !ok {
+		t.Fatal("pack.toml imports.tools must survive a refused remove")
+	}
+	cfg, err := loadCityImportManifestFS(fsys.OSFS{}, dir)
+	if err != nil {
+		t.Fatalf("loadCityImportManifestFS: %v", err)
+	}
+	if _, ok := cfg.Imports["tools"]; !ok {
+		t.Fatal("city.toml imports.tools must survive a refused remove")
+	}
+}
+
+func TestDoImportRemoveRemovesCityOnlyRootImport(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writePackToml(t, dir, "[pack]\nname = \"demo\"\nschema = 1\n")
+	writeCityToml(t, dir, `[workspace]
+name = "demo"
+
+[imports.tools]
+source = "packs/tools"
+`)
+
+	prevSync := syncImports
+	t.Cleanup(func() { syncImports = prevSync })
+	var synced map[string]config.Import
+	syncImports = func(_ string, imports map[string]config.Import, _ packman.InstallMode) (*packman.Lockfile, error) {
+		synced = imports
+		return &packman.Lockfile{Schema: packman.LockfileSchema, Packs: map[string]packman.LockedPack{}}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportRemove(fsys.OSFS{}, dir, "tools", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	if _, ok := synced["pack:tools"]; ok {
+		t.Fatalf("synced imports still contain removed city import: %#v", synced)
+	}
+	cfg, err := loadCityImportManifestFS(fsys.OSFS{}, dir)
+	if err != nil {
+		t.Fatalf("loadCityImportManifestFS: %v", err)
+	}
+	if _, ok := cfg.Imports["tools"]; ok {
+		t.Fatal("city.toml imports.tools must be removed")
+	}
+	manifest, err := loadCityPackManifestFS(fsys.OSFS{}, dir)
+	if err != nil {
+		t.Fatalf("loadCityPackManifestFS: %v", err)
+	}
+	if len(manifest.Imports) != 0 {
+		t.Fatalf("pack.toml imports = %#v, want untouched", manifest.Imports)
+	}
+}
+
 func TestDoImportRemovePreservesRootPackDefaultRigImports(t *testing.T) {
 	clearGCEnv(t)
 	dir := t.TempDir()
@@ -2263,6 +2392,170 @@ schema = 1
 	if got != want {
 		t.Fatalf("resolveImportRoot() = %q, want %q", got, want)
 	}
+}
+
+func TestFindNearestImportRootSkipsRuntimeOnlyDirs(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	rigDir := filepath.Join(cityDir, "rigs", "work")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(rigDir, "src", "deep")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	root, ok, err := findNearestImportRoot(nested)
+	if err != nil {
+		t.Fatalf("findNearestImportRoot: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected the walk to reach the city root")
+	}
+	if root != cityDir {
+		t.Fatalf("root = %q, want city %q (bare .gc/ dirs must not be import roots)", root, cityDir)
+	}
+}
+
+func TestFindNearestImportRootStopsAtCeiling(t *testing.T) {
+	clearGCEnv(t)
+	base := t.TempDir()
+	writePackToml(t, base, "[pack]\nname = \"demo\"\nschema = 1\n")
+	ceiling := filepath.Join(base, "ceiling")
+	nested := filepath.Join(ceiling, "deep")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CEILING_DIRECTORIES", ceiling)
+
+	root, ok, err := findNearestImportRoot(nested)
+	if err != nil {
+		t.Fatalf("findNearestImportRoot: %v", err)
+	}
+	if ok {
+		t.Fatalf("root = %q, want no match above the ceiling", root)
+	}
+}
+
+func TestResolveImportRootPrefersNearestPackUnderCity(t *testing.T) {
+	clearGCEnv(t)
+	resetFlags(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, "[pack]\nname = \"demo\"\nschema = 1\n")
+	packDir := filepath.Join(cityDir, "packs", "tools")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writePackToml(t, packDir, "[pack]\nname = \"tools\"\nschema = 1\n")
+	nested := filepath.Join(packDir, "prompts")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	setCwd(t, nested)
+
+	got, err := resolveImportRoot()
+	if err != nil {
+		t.Fatalf("resolveImportRoot: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(packDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", packDir, err)
+	}
+	if got != want {
+		t.Fatalf("resolveImportRoot() = %q, want nearest pack %q", got, want)
+	}
+}
+
+func TestResolveImportRootRuntimeOnlyAncestorResolvesRegisteredRigCity(t *testing.T) {
+	clearGCEnv(t)
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := setupCity(t, "import-city")
+	base := canonicalTestPath(t.TempDir())
+	rigDir := filepath.Join(base, "workrepo")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(rigDir, "internal")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Bound the marker walk inside the fixture so stray pack.toml/city.toml
+	// files in shared temp ancestors cannot hijack the test.
+	t.Setenv("GC_CEILING_DIRECTORIES", base)
+	registerRigBindingForResolution(t, gcHome, cityPath, "import-city", "workrepo", rigDir)
+	setCwd(t, nested)
+
+	got, err := resolveImportRoot()
+	if err != nil {
+		t.Fatalf("resolveImportRoot: %v", err)
+	}
+	assertSameTestPath(t, got, cityPath)
+}
+
+func TestResolveImportRootHonorsRigFlagOverNearestPack(t *testing.T) {
+	clearGCEnv(t)
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := setupCity(t, "rigflag-city")
+	rigDir := filepath.Join(canonicalTestPath(t.TempDir()), "workrepo")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	registerRigBindingForResolution(t, gcHome, cityPath, "rigflag-city", "workrepo", rigDir)
+
+	packDir := t.TempDir()
+	writePackToml(t, packDir, "[pack]\nname = \"bystander\"\nschema = 1\n")
+	setCwd(t, packDir)
+	rigFlag = "workrepo"
+
+	got, err := resolveImportRoot()
+	if err != nil {
+		t.Fatalf("resolveImportRoot: %v", err)
+	}
+	assertSameTestPath(t, got, cityPath)
+}
+
+func TestResolveImportRootHonorsGCDirOverNearestPack(t *testing.T) {
+	clearGCEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_HOME", t.TempDir())
+
+	cityPath := setupCity(t, "gcdir-city")
+	packDir := t.TempDir()
+	writePackToml(t, packDir, "[pack]\nname = \"bystander\"\nschema = 1\n")
+	setCwd(t, packDir)
+	t.Setenv("GC_DIR", cityPath)
+
+	got, err := resolveImportRoot()
+	if err != nil {
+		t.Fatalf("resolveImportRoot: %v", err)
+	}
+	assertSameTestPath(t, got, cityPath)
+}
+
+func TestResolveImportRootGCCityEnvWinsOverNearestPack(t *testing.T) {
+	clearGCEnv(t)
+	resetFlags(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	packDir := t.TempDir()
+	writePackToml(t, packDir, "[pack]\nname = \"bystander\"\nschema = 1\n")
+	setCwd(t, packDir)
+	t.Setenv("GC_CITY", cityDir)
+
+	got, err := resolveImportRoot()
+	if err != nil {
+		t.Fatalf("resolveImportRoot: %v", err)
+	}
+	assertSameTestPath(t, got, cityDir)
 }
 
 func TestImportAddCommandWorksInStandalonePackDir(t *testing.T) {


### PR DESCRIPTION
## Summary
- apply city-root import overrides over root pack imports during `gc import install` and `gc import list`
- prefer the nearest standalone `pack.toml` import root before falling back to an ancestor city root
- add regression coverage for city override install/list behavior

## Validation
- `go test ./cmd/gc -run 'TestResolveImportRootFallsBackToStandalonePackDir|TestImportAddCommandWorksInStandalonePackDir|TestImportAddCommandIgnoresInheritedLiveEnv|TestDoImport(InstallCityImportOverridesRootPackImport|ListShowsCityImportOverrideForRootPackImport|InstallUsesLockMode|ListShowsPathImportsInFlatOutput)'`\n- `go test ./cmd/gc -run TestDoImport`\n- `git diff --check`\n