### PR TITLE
fix(reconciler): wake assigned interactive sleepers

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -750,10 +750,10 @@ func wakeDemandOverridesSleepSuppression(
 	if hasExplicitSleepIntent {
 		return false
 	}
-	hasDemand := poolDesired[template] > 0 || eval.HasAssignedWork
 	if eval.HasAssignedWork {
 		return true
 	}
+	hasDemand := poolDesired[template] > 0
 	if hasDemand && policy.Class == config.SessionSleepNonInteractive {
 		return true
 	}
@@ -2277,14 +2277,16 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		name := target.session.Metadata["session_name"]
 		decision := awakeDecisions[name]
 		if decision.ShouldWake && !pendingInteractionReady(sp, name) && target.session.Metadata["pin_awake"] != "true" && configWakeSuppressed(*target.session, policy, sp, clk) {
-			// Active demand (poolDesired > 0 or direct assigned work)
-			// overrides sleep suppression for non-interactive sessions
+			// Direct assigned work overrides sleep suppression for every
+			// sleep class — the assignment is session-specific, so a pool
+			// sibling cannot serve it. Pool-scale demand (poolDesired > 0)
+			// overrides suppression only for non-interactive sessions
 			// (matching the old evaluateWakeReasons behavior). Min-active
 			// city-stop revival is also config demand: stale detach metadata
 			// from before gc stop must not cancel the post-start guarantee.
-			// Other interactive sessions honor their idle window regardless
-			// of demand — an idle chat session should still sleep to release
-			// resources.
+			// Interactive sessions honor their idle window against
+			// pool-scale demand — an idle chat session should still sleep
+			// to release resources.
 			// Explicit sleep_intent always wins — if the session has
 			// signaled it wants to sleep, honor that regardless of demand.
 			template := normalizedSessionTemplate(*target.session, cfg)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -751,6 +751,9 @@ func wakeDemandOverridesSleepSuppression(
 		return false
 	}
 	hasDemand := poolDesired[template] > 0 || eval.HasAssignedWork
+	if eval.HasAssignedWork {
+		return true
+	}
 	if hasDemand && policy.Class == config.SessionSleepNonInteractive {
 		return true
 	}

--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -374,6 +374,22 @@ func TestReconcilerWakeDemandOverridesSleepSuppressionForMinActive(t *testing.T)
 	}
 }
 
+func TestReconcilerWakeDemandOverridesSleepSuppressionForAssignedWork(t *testing.T) {
+	policy := resolvedSessionSleepPolicy{Class: config.SessionSleepInteractiveResume}
+	decision := AwakeDecision{ShouldWake: true, Reason: "assigned-work"}
+	eval := wakeEvaluation{
+		Reasons:         []WakeReason{WakeWork},
+		HasAssignedWork: true,
+	}
+
+	if !wakeDemandOverridesSleepSuppression(decision, eval, policy, nil, "worker", false) {
+		t.Fatal("assigned-work wake should override interactive sleep suppression")
+	}
+	if wakeDemandOverridesSleepSuppression(decision, eval, policy, nil, "worker", true) {
+		t.Fatal("explicit sleep intent should still override assigned-work demand")
+	}
+}
+
 func TestReconcileSessionBeads_MinActiveCityStopWakeBypassesInteractiveSleepSuppression(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
@@ -563,6 +579,55 @@ func TestReconcileSessionBeads_IdleLatchedSessionDoesNotWake(t *testing.T) {
 	}
 	if starts := startedSessionNames(env.sp); len(starts) != 0 {
 		t.Fatalf("unexpected starts: %v", starts)
+	}
+}
+
+func TestReconcileSessionBeads_AssignedWorkWakesIdleLatchedInteractiveSession(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		SessionSleep: config.SessionSleepConfig{
+			InteractiveResume: "60s",
+		},
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", false)
+	session := env.createSessionBead("worker", "worker")
+	policy := resolveSessionSleepPolicy(session, env.cfg, env.sp)
+	ts := env.clk.Time.Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		"sleep_reason":             "idle",
+		"sleep_policy_fingerprint": policy.Fingerprint,
+		"slept_at":                 ts,
+	})
+	work, err := env.store.Create(beads.Bead{
+		Title:    "assigned work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("create assigned work: %v", err)
+	}
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+
+	woken := reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, nil, []beads.Bead{work}, nil, env.dt, map[string]int{}, false, nil, "",
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
+	}
+	if !env.sp.IsRunning("worker") {
+		t.Fatal("assigned idle-latched worker should start")
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got.Metadata["config_wake_suppressed"] == "true" {
+		t.Fatal("assigned-work wake was suppressed by interactive sleep policy")
 	}
 }
 

--- a/internal/beads/factory_test.go
+++ b/internal/beads/factory_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestOpenStoreAtForCityEligibleNativeReturnsInjectedNativeStore(t *testing.T) {
+	t.Setenv(nativeForceFallbackEnv, "")
 	scope := "/city"
 	native := NewMemStore()
 
@@ -47,6 +48,7 @@ func TestOpenStoreAtForCityEligibleNativeReturnsInjectedNativeStore(t *testing.T
 }
 
 func TestOpenStoreAtForCityIneligibleProviderSkipsPreflight(t *testing.T) {
+	t.Setenv(nativeForceFallbackEnv, "")
 	result, err := OpenStoreAtForCity(context.Background(), StoreOpenOptions{
 		ScopeRoot: "/city",
 		Provider:  "unknown",
@@ -72,6 +74,7 @@ func TestOpenStoreAtForCityIneligibleProviderSkipsPreflight(t *testing.T) {
 }
 
 func TestOpenStoreAtForCityContextDriftFallsBackWithPreflightDiagnostic(t *testing.T) {
+	t.Setenv(nativeForceFallbackEnv, "")
 	scope := "/city"
 	var bdOpened bool
 
@@ -144,6 +147,7 @@ func TestOpenStoreAtForCityForceFallbackSkipsPreflightAndNativeOpen(t *testing.T
 }
 
 func TestOpenStoreAtForCityNativeOpenFailureFallsBackWithDiagnostic(t *testing.T) {
+	t.Setenv(nativeForceFallbackEnv, "")
 	scope := "/city"
 	fallback := NewMemStore()
 	var bdOpened bool
@@ -184,6 +188,7 @@ func TestOpenStoreAtForCityNativeOpenFailureFallsBackWithDiagnostic(t *testing.T
 }
 
 func TestOpenStoreAtForCityExecBdContractFallbackUsesExecStore(t *testing.T) {
+	t.Setenv(nativeForceFallbackEnv, "")
 	scope := "/city"
 	provider := "exec:/tmp/gc-beads-bd.sh"
 	execStore := NewMemStore()
@@ -220,6 +225,7 @@ func TestOpenStoreAtForCityExecBdContractFallbackUsesExecStore(t *testing.T) {
 }
 
 func TestOpenStoreAtForCityExecutableHooksBlockNativeStore(t *testing.T) {
+	t.Setenv(nativeForceFallbackEnv, "")
 	scope := t.TempDir()
 	hooksDir := filepath.Join(scope, ".beads", "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
@@ -260,6 +266,7 @@ func TestOpenStoreAtForCityExecutableHooksBlockNativeStore(t *testing.T) {
 }
 
 func TestOpenStoreAtForCityGCStampedHooksDoNotBlockNativeStore(t *testing.T) {
+	t.Setenv(nativeForceFallbackEnv, "")
 	scope := t.TempDir()
 	hooksDir := filepath.Join(scope, ".beads", "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
@@ -301,6 +308,7 @@ func TestOpenStoreAtForCityGCStampedHooksDoNotBlockNativeStore(t *testing.T) {
 }
 
 func TestOpenStoreAtForCityEmbeddedStampMarkerStillBlocksNativeStore(t *testing.T) {
+	t.Setenv(nativeForceFallbackEnv, "")
 	scope := t.TempDir()
 	hooksDir := filepath.Join(scope, ".beads", "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {


### PR DESCRIPTION
## Summary
- Treat concrete assigned work as wake demand even when an interactive session is latched idle.
- Keep generic pool demand wake behavior limited to non-interactive sleep policy.
- Add regressions for assigned-work wake behavior.

## Verification
- `go test ./cmd/gc -run 'TestReconcilerWakeDemandOverridesSleepSuppressionForAssignedWork|TestReconcileSessionBeads_AssignedWorkWakesIdleLatchedInteractiveSession|TestReconcilerWakeDemandOverridesSleepSuppressionForMinActive'`\n- Also included in phase1 verification branch `local/reconcile-live-verify-phase1-20260611` with focused regressions passing.