### PR TITLE
fix(session): restore a reaped handoff-orphan's pool route so completed work re-enters dispatch (ga-n2d.2)

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -2577,6 +2577,12 @@ func releaseWorkFromClosedSessionBead(store beads.Store, sessionBead beads.Bead,
 		stderr = io.Discard
 	}
 
+	// The owning pool/agent route, recovered from the closing session's own
+	// template metadata. ZFC-safe: derived from configuration carried on the
+	// session bead, never a hardcoded role name. Used below to re-route work
+	// that lost its routing mid-handoff so it stays discoverable.
+	fallbackRoute := retiredSessionFallbackRoute(sessionBead)
+
 	seenAssignees := make(map[string]struct{}, 3)
 	addAssignee := func(val string) {
 		val = strings.TrimSpace(val)
@@ -2611,9 +2617,20 @@ func releaseWorkFromClosedSessionBead(store beads.Store, sessionBead beads.Bead,
 				// release primitive clears the assignee (empty-string) and
 				// stale session-affinity metadata and resets in_progress to
 				// open — the same stale-affinity bug fixed on the retry,
-				// reopen, and orphan-pool release paths. No run_target
-				// fallback on the close-release path (passed "").
-				if err := wa.ReleaseWorkBead(item, ""); err != nil {
+				// reopen, and orphan-pool release paths.
+				//
+				// ga-n2d.2: pass the owning pool route (retiredSessionFallbackRoute,
+				// derived from the closing session's own template metadata) as the
+				// run_target fallback instead of "". A polecat that pushed its branch
+				// but died before completing the refinery handoff can leave work whose
+				// gc.routed_to was cleared; releasing it here with no route would
+				// strand it open+unassigned+unrouted — invisible to both the pool
+				// demand probe (keys on gc.routed_to) and releaseOrphanedPoolAssignments
+				// (skips empty-routed beads). ReleaseWorkBead applies the fallback only
+				// when BOTH routed_to and run_target are empty, and restoreCarriedWorkRoutes
+				// (#3421) then backfills gc.routed_to from that run_target so the work
+				// re-enters pool demand.
+				if err := wa.ReleaseWorkBead(item, fallbackRoute); err != nil {
 					fmt.Fprintf(stderr, "session beads: releasing work %s from closing session %s: %v\n", item.ID, sessionBead.ID, err) //nolint:errcheck
 				}
 			}

--- a/cmd/gc/session_beads_handoff_orphan_test.go
+++ b/cmd/gc/session_beads_handoff_orphan_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// A polecat that pushes its branch but dies before completing the refinery
+// handoff can leave its work bead with gc.routed_to cleared. When the
+// reconciler reaps the dead session bead, releaseWorkFromClosedSessionBead
+// clears the assignee and reopens the work — but if it does not also restore a
+// route, the bead is stranded open+unassigned+unrouted: invisible to BOTH the
+// pool demand probe (which keys on gc.routed_to) and releaseOrphanedPoolAssignments
+// (which skips empty-routed beads). The fix passes the owning pool route,
+// recovered from the closing session's own template metadata, as ReleaseWorkBead's
+// run_target fallback; restoreCarriedWorkRoutes (#3421) then backfills gc.routed_to
+// from that run_target so a fresh worker re-claims it.
+func TestReleaseWorkFromClosedSessionBeadRestoresPoolRouteForUnroutedWork(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "gastown__polecat-th-87n",
+			"template":     "gascity/gastown.polecat",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	// Completed-and-pushed work whose routing was lost mid-handoff: a branch
+	// on origin, no gc.routed_to, no gc.run_target, assigned to the dead session.
+	work, err := store.Create(beads.Bead{
+		Title:    "handoff-orphan work",
+		Status:   "open",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{"branch": "polecat/ga-n2d.2"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	releaseWorkFromClosedSessionBead(store, sessionBead, &stderr)
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Metadata[beadmeta.RunTargetMetadataKey] != "gascity/gastown.polecat" {
+		t.Fatalf("gc.run_target = %q, want gascity/gastown.polecat (restored pool route; restoreCarriedWorkRoutes re-stamps gc.routed_to from it so the pool demand probe re-discovers the work)", got.Metadata[beadmeta.RunTargetMetadataKey])
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "" {
+		t.Fatalf("gc.routed_to = %q, want empty immediately after release (restoreCarriedWorkRoutes backfills it from gc.run_target on the next tick)", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// Workflow-kind beads recover their route via the same ReleaseWorkBead
+// run_target fallback as plain work; they re-claim through the legacy
+// gc.run_target queue (see #2860), which restoreCarriedWorkRoutes (#3421)
+// recognizes for pre-eld2x workflow roots.
+func TestReleaseWorkFromClosedSessionBeadRestoresRunTargetForWorkflowKind(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"template":     "graph/worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:    "graph step",
+		Status:   "in_progress",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	releaseWorkFromClosedSessionBead(store, sessionBead, &stderr)
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RunTargetMetadataKey] != "graph/worker" {
+		t.Fatalf("gc.run_target = %q, want graph/worker (workflow-kind work routes via gc.run_target)", got.Metadata[beadmeta.RunTargetMetadataKey])
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "" {
+		t.Fatalf("gc.routed_to = %q, want empty for workflow-kind work", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// Work that still carries a route must be left untouched — only truly unrouted
+// orphans get a restored route. Guards against clobbering an in-flight route.
+func TestReleaseWorkFromClosedSessionBeadLeavesExistingRouteUntouched(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"template":     "gascity/gastown.polecat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:    "still-routed work",
+		Status:   "in_progress",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "gascity/other-pool"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	releaseWorkFromClosedSessionBead(store, sessionBead, &stderr)
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/other-pool" {
+		t.Fatalf("gc.routed_to = %q, want unchanged gascity/other-pool", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// When the closing session bead carries no template/agent_name, there is no
+// route to recover — the work is still released, just without a restored route.
+func TestReleaseWorkFromClosedSessionBeadWithoutTemplateStillReleases(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:    "worker",
+		Type:     sessionBeadType,
+		Labels:   []string{sessionBeadLabel},
+		Metadata: map[string]string{"session_name": "worker-1"},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:    "unrouted work, unknown pool",
+		Status:   "in_progress",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{"branch": "polecat/ga-n2d.2"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	releaseWorkFromClosedSessionBead(store, sessionBead, &stderr)
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "" {
+		t.Fatalf("gc.routed_to = %q, want empty (no template to recover a route from)", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}


### PR DESCRIPTION
## What

When a worker session is reaped (dead-runtime or stale-session close) with work still assigned, `releaseWorkFromClosedSessionBead` already clears the assignee and reopens in_progress work. This adds: it now also **restores the work bead's pool route** (`gc.routed_to`, or `gc.run_target` for workflow-kind beads) when that route is empty, recovering the value from the closing session bead's own `template` / `agent_name` metadata.

## Why

A polecat that finishes its bead and pushes its branch but **dies before completing the done-handoff** leaves the bead `open` with an **empty `gc.routed_to`** (a "handoff-orphan"). With no route, the pool demand probe (`bd ready --metadata-field gc.routed_to=<pool>`) never matches it, so no worker is dispatched — the completed work sits invisible and open indefinitely, and can block downstream beads. (Confirmed on a rig: two done-and-pushed beads stranded ~20h.) Existing `releaseOrphanedPoolAssignments` explicitly skips empty-routed beads — this closes exactly that gap.

## Behavior / safety

- Routes the orphan back to the **dead worker's own pool template** (e.g. `<rig>/<pack>.polecat`), so it re-enters pool demand and a **fresh worker** re-attempts the (idempotent) done/handoff. It does **not** route to a merge/refinery role and cannot merge incomplete work.
- Only fires on a **confirmed-dead / reaped** session (gated on `IsDeadRuntimeSession` + stop, or `!IsRunning` + startup-grace) — never touches a live worker's assigned work.
- Restores only when the route is empty (`gc.routed_to == "" && gc.run_target == ""`); beads still carrying a route are untouched. Per-key metadata merge preserves `branch`/`gc.kind`/etc. Idempotent.

## Scope

This is the Go **safety-net** half. The complementary **atomic done-handoff** (set the route on a clean done so the crash window shrinks) lives in the pack layer and is tracked separately.

## Tests

4 new table tests: restore-pool-route, restore-run-target-for-workflow, leave-existing-route-untouched, no-template-still-releases. Touched-scope tests green.

## Stacking

Cut from `main`; self-contained and independent. Touches only `cmd/gc/session_beads.go` (+ its new test). No dependency on #3373 or #3366.
