### PR TITLE
fix(reconciler): resolve persisted bound pool templates

### DIFF
--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -137,6 +137,42 @@ func TestFilterAssignedWorkBeadsForPoolDemandKeepsLegacyWorkflowRunTarget(t *tes
 	}
 }
 
+func TestFilterAssignedWorkBeadsForPoolDemandKeepsPersistedBoundRoute(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "gascity-packs")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "gascity-packs", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name: "implementation-worker",
+			Dir:  "gascity-packs",
+		}},
+	}
+	sessionName := "gc__implementation-worker-mc-xbvk5"
+	sessions := []beads.Bead{{
+		ID:     "mc-xbvk5",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"template":     "gascity-packs/gc.implementation-worker",
+			"session_name": sessionName,
+		},
+	}}
+	work := []beads.Bead{{
+		ID:       "gp-qx0o",
+		Status:   "in_progress",
+		Assignee: sessionName,
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity-packs/gc.implementation-worker",
+		},
+	}}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessions, work, []string{"gascity-packs"})
+
+	if len(got) != 1 || got[0].ID != "gp-qx0o" {
+		t.Fatalf("filtered work = %#v, want persisted bound route preserved", got)
+	}
+}
+
 func TestFilterAssignedWorkBeadsForPoolDemandDropsDirectAssigneeFromUnreachableStore(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "riga")

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -514,13 +514,17 @@ func buildDesiredStateWithSessionBeads(
 		runningSessions := 0
 		for _, sb := range allOpenSessionBeads {
 			if isPoolManagedSessionBead(sb) {
-				// Match the qualified template only. allOpenSessionBeads is
-				// aggregated across the city + every rig store, and pool session
-				// beads store the qualified name (agent.QualifiedName(), see
-				// session_sleep.go). Also matching the unqualified base name would
-				// let a same-base-name pool in another rig (e.g. rigB/planner)
-				// inflate this rig's count and wrongly suppress its cold-wake probe.
-				if sb.Metadata["template"] == template {
+				// Match the qualified template by identity equivalence.
+				// allOpenSessionBeads is aggregated across the city + every rig
+				// store, and pool session beads store the qualified name
+				// (agent.QualifiedName(), see session_sleep.go); adopted beads may
+				// still carry a legacy bound form of the same identity, which must
+				// count here or the cold-wake probe over-wakes a pool that already
+				// has a live session. Equivalence preserves the cross-rig guarantee:
+				// an unqualified base name never normalizes to a dir-scoped agent,
+				// and a same-base-name pool in another rig (e.g. rigB/planner)
+				// normalizes to itself, so neither inflates this rig's count.
+				if agentTemplateIdentitiesEquivalent(cfg, sb.Metadata["template"], template) {
 					runningSessions++
 				}
 			}
@@ -660,6 +664,20 @@ func buildDesiredStateWithSessionBeads(
 		// correct, and any bead missed by a partial query simply gets stamped
 		// on a later tick.
 		stampRunSessionIdentity(assignedWorkBeads, assignedWorkStores, sessionBeads, stderr)
+		// Re-home work pre-assigned to a legacy bound form of a now-unbound pool
+		// agent onto the canonical identity, so the canonical session the
+		// awake/scale accounting wakes for it can actually surface and claim it
+		// (the agent-side work_query/claim path matches identities by raw string).
+		canonicalizeLegacyBoundAssignedWork(cfg, assignedWorkBeads, assignedWorkStores, sessionBeads, stderr)
+		// Re-home open, unassigned work still routed to a legacy bound form of a
+		// now-unbound pool agent. This is the demand/claim half of the migration:
+		// empty-assignee open work never enters the assigned-work collection above,
+		// and the canonical pool-demand probe below (defaultScaleCheckCounts) plus
+		// the worker work_query/claim path match gc.routed_to canonically by raw
+		// string, so the route must be canonicalized before demand is counted or
+		// the cold pool never wakes for it.
+		unassignedRoutedBeads, unassignedRoutedStores := collectOpenUnassignedRoutedWork(cfg, store, rigStores, suspendedRigPaths, stderr)
+		canonicalizeLegacyBoundUnassignedRoutedWork(cfg, unassignedRoutedBeads, unassignedRoutedStores, stderr)
 		scaleCheckCounts, poolScaleCheckPartialTemplates = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 		if len(defaultScaleTargets) > 0 {
 			defaultCounts, partialTemplates, errs := defaultScaleCheckCounts(defaultScaleTargets)
@@ -1480,13 +1498,17 @@ func sortedBoolMapKeys(values map[string]bool) []string {
 	return out
 }
 
-func retainScaleCheckPartialPoolDesired(counts map[string]int, sessionBeads *sessionBeadSnapshot, partialTemplates map[string]bool) map[string]int {
+func retainScaleCheckPartialPoolDesired(cfg *config.City, counts map[string]int, sessionBeads *sessionBeadSnapshot, partialTemplates map[string]bool) map[string]int {
 	if len(partialTemplates) == 0 || sessionBeads == nil {
 		return counts
 	}
 	retained := make(map[string]int)
 	for _, b := range sessionBeads.Open() {
-		template := strings.TrimSpace(b.Metadata["template"])
+		// Adopted session beads can persist a legacy bound template identity;
+		// normalize to the current canonical name before the membership check,
+		// because partialTemplates is keyed canonically. Without this a transient
+		// scale_check partial failure would drop legacy-bound pool sessions.
+		template := normalizeAgentTemplateIdentity(cfg, strings.TrimSpace(b.Metadata["template"]))
 		if !partialTemplates[template] || !isPoolManagedSessionBead(b) || !scaleCheckPartialSessionRetainable(b) {
 			continue
 		}
@@ -3302,6 +3324,206 @@ func stampRunRootFromStep(store beads.Store, step beads.Bead, sessionName, workD
 	if err := store.SetMetadataBatch(rootID, patch); err != nil && stderr != nil {
 		fmt.Fprintf(stderr, "stampRunSessionIdentity root %s: %v\n", rootID, err) //nolint:errcheck
 	}
+}
+
+// canonicalizeLegacyBoundAssignedWork re-homes the Assignee and gc.routed_to of
+// actionable pool work that is pre-assigned to a legacy bound form of a
+// configured unbound pool agent (e.g. "dir/binding.name") to that agent's
+// current canonical identity ("dir/name").
+//
+// Why: after a bound→unbound agent migration, the awake/scale accounting wakes
+// a canonical pool session for work persisted under the legacy bound identity
+// (it normalizes template identities), but the woken session's work_query and
+// `gc hook --claim` path match assignees and routes by raw string. A canonical
+// session can derive neither the old binding name nor the legacy assignee, so
+// the triggering bead would surface to no one and stay unclaimed. Re-homing the
+// persisted identity to canonical makes the bead behave exactly like ordinary
+// canonical pool work, which the existing surface/claim machinery already
+// resumes — closing the agent-side half of the migration recovery loop.
+//
+// The live-session guard preserves the resume tier: work a still-running
+// session already owns under the legacy identity is left untouched so its own
+// work_query keeps resolving it; only orphaned work with no live owner (the
+// wake-known-identity case) is re-homed.
+//
+// Because a re-home moves an assignee away from its owner, it runs only on a
+// complete session snapshot. Unlike the benign stampRunSessionIdentity pass, a
+// nil or load-errored snapshot can omit a live legacy owner, and the
+// live-session guard would then misread that absence as "orphaned" and re-home
+// in-flight work out from under the running session. On a degraded snapshot the
+// whole pass is skipped and a later complete tick converges it (NDI), mirroring
+// releaseOrphanedPoolAssignmentsWhenSnapshotsComplete.
+//
+// Idempotent by design: it writes only when the canonical identity differs from
+// what is already on the bead, so steady-state reconciles perform no writes. A
+// write failure is logged and skipped — recovery is best-effort and must never
+// block reconciliation.
+func canonicalizeLegacyBoundAssignedWork(cfg *config.City, workBeads []beads.Bead, workStores []beads.Store, sessionBeads *sessionBeadSnapshot, stderr io.Writer) {
+	if cfg == nil || len(workBeads) != len(workStores) {
+		return
+	}
+	// A nil or load-errored snapshot is incomplete: the live-session guard below
+	// cannot prove a legacy owner is gone, so re-homing could strand a live
+	// session's in-flight work. Skip and let a later complete tick converge it.
+	if sessionBeads == nil || sessionBeads.LoadError() != nil {
+		return
+	}
+	sessionByAssignee := buildSessionAssigneeIndex(sessionBeads)
+	for i, wb := range workBeads {
+		if wb.Status != "in_progress" && wb.Status != "open" {
+			continue
+		}
+		store := workStores[i]
+		if store == nil {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		// Only template-assigned pool work qualifies: real per-session
+		// assignments (session names) and named-session work are not equivalent
+		// to a pool template's qualified name and are left untouched.
+		if assignee == "" || !isKnownPoolTemplate(assignee, cfg) {
+			continue
+		}
+		canonicalAssignee := normalizeAgentTemplateIdentity(cfg, assignee)
+		routedTo := strings.TrimSpace(wb.Metadata[beadmeta.RoutedToMetadataKey])
+		canonicalRouted := normalizeAgentTemplateIdentity(cfg, routedTo)
+		assigneeChanged := canonicalAssignee != "" && canonicalAssignee != assignee
+		routedChanged := routedTo != "" && canonicalRouted != routedTo
+		if !assigneeChanged && !routedChanged {
+			continue
+		}
+		// A live session still owns this assignment under the legacy identity —
+		// the resume tier handles it; re-homing would strand its work_query.
+		if _, served := sessionByAssignee[assignee]; served {
+			continue
+		}
+		opts := beads.UpdateOpts{}
+		if assigneeChanged {
+			opts.Assignee = &canonicalAssignee
+		}
+		if routedChanged {
+			opts.Metadata = map[string]string{beadmeta.RoutedToMetadataKey: canonicalRouted}
+		}
+		if err := store.Update(wb.ID, opts); err != nil && stderr != nil {
+			fmt.Fprintf(stderr, "canonicalizeLegacyBoundAssignedWork: %s: %v\n", wb.ID, err) //nolint:errcheck
+		}
+	}
+}
+
+// canonicalizeLegacyBoundUnassignedRoutedWork rewrites the gc.routed_to of open,
+// unassigned pool work that is still routed to the legacy bound form of a
+// now-unbound pool agent ("dir/binding.name") onto the agent's current canonical
+// identity ("dir/name").
+//
+// This closes the demand/claim half of the bound→unbound migration that the
+// assignee-keyed canonicalizeLegacyBoundAssignedWork cannot reach: open work with
+// an empty assignee never enters the assigned-work collection, and the canonical
+// pool-demand probe (EffectivePoolDemandQuery), the worker work_query
+// (EffectiveWorkQuery Tier 3), and the claim predicate (hookClaimMatchesRoute)
+// all match gc.routed_to against the canonical target by raw string. A bead still
+// routed to "dir/binding.name" is therefore invisible to the canonical "dir/name"
+// pool — it neither contributes scale demand nor can be claimed — so migration-era
+// ready work stays stuck until its route is canonicalized. Rewriting the route in
+// place lets every existing canonical-only path surface it, keeping the legacy
+// awareness confined to this migration pass instead of spread across the demand,
+// work_query, and claim predicates.
+//
+// Unlike the assignee re-home, this needs no session-snapshot guard: open
+// unassigned work has no live owner to strand, so rewriting its route can only
+// make it discoverable. Idempotent by design: it writes only when the canonical
+// identity differs from the persisted route, so steady-state reconciles perform
+// no writes, and a route that is already canonical, resolves to no configured
+// agent, or still matches a configured bound agent is left untouched. A write
+// failure is logged and skipped — recovery is best-effort and must never block
+// reconciliation.
+func canonicalizeLegacyBoundUnassignedRoutedWork(cfg *config.City, workBeads []beads.Bead, workStores []beads.Store, stderr io.Writer) {
+	if cfg == nil || len(workBeads) != len(workStores) {
+		return
+	}
+	for i, wb := range workBeads {
+		if wb.Status != "open" || strings.TrimSpace(wb.Assignee) != "" {
+			continue
+		}
+		store := workStores[i]
+		if store == nil {
+			continue
+		}
+		routedTo := strings.TrimSpace(wb.Metadata[beadmeta.RoutedToMetadataKey])
+		if routedTo == "" {
+			continue
+		}
+		// Cheap pre-filter: a legacy bound form is "dir/binding.name", so only a
+		// route whose local segment carries the binding-separator dot can be one.
+		// Canonical unbound routes ("dir/name") skip the per-bead agent scan in
+		// normalizeAgentTemplateIdentity, keeping the steady-state cost off the
+		// full open-routed backlog.
+		if _, local := config.ParseQualifiedName(routedTo); !strings.Contains(local, ".") {
+			continue
+		}
+		canonicalRouted := normalizeAgentTemplateIdentity(cfg, routedTo)
+		if canonicalRouted == "" || canonicalRouted == routedTo {
+			continue
+		}
+		opts := beads.UpdateOpts{Metadata: map[string]string{beadmeta.RoutedToMetadataKey: canonicalRouted}}
+		if err := store.Update(wb.ID, opts); err != nil && stderr != nil {
+			fmt.Fprintf(stderr, "canonicalizeLegacyBoundUnassignedRoutedWork: %s: %v\n", wb.ID, err) //nolint:errcheck
+		}
+	}
+}
+
+// collectOpenUnassignedRoutedWork gathers open, unassigned, pool-routed work from
+// the city store and every non-suspended rig store, index-aligned with the store
+// that owns each bead. It is the input collection for
+// canonicalizeLegacyBoundUnassignedRoutedWork: empty-assignee open work is dropped
+// by the assignee-keyed collectAssignedWorkBeadsWithStores passes, so the
+// migration re-home needs its own scan. Active-only List queries are served from
+// the CachingStore in steady state, so this adds no backing-store round trip.
+func collectOpenUnassignedRoutedWork(cfg *config.City, store beads.Store, rigStores map[string]beads.Store, suspendedRigPaths map[string]bool, stderr io.Writer) ([]beads.Bead, []beads.Store) {
+	if cfg == nil {
+		return nil, nil
+	}
+	type workStore struct {
+		store beads.Store
+		ref   string
+	}
+	stores := []workStore{{store: store, ref: "city"}}
+	for _, rig := range cfg.Rigs {
+		if suspendedRigPaths[filepath.Clean(rig.Path)] {
+			continue
+		}
+		if s, ok := rigStores[rig.Name]; ok {
+			stores = append(stores, workStore{store: s, ref: rig.Name})
+		}
+	}
+
+	var workBeads []beads.Bead
+	var workStores []beads.Store
+	seen := make(map[string]struct{})
+	for _, source := range stores {
+		if source.store == nil {
+			continue
+		}
+		open, err := listBothTiersForControllerDemand(source.store, beads.ListQuery{Status: "open"})
+		if err != nil && !beads.IsPartialResult(err) {
+			fmt.Fprintf(stderr, "collectOpenUnassignedRoutedWork: %s: List(open): %v\n", source.ref, err) //nolint:errcheck
+			continue
+		}
+		for _, b := range open {
+			if b.Type == sessionBeadType || strings.TrimSpace(b.Assignee) != "" {
+				continue
+			}
+			if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) == "" {
+				continue
+			}
+			if _, ok := seen[b.ID]; ok {
+				continue
+			}
+			seen[b.ID] = struct{}{}
+			workBeads = append(workBeads, b)
+			workStores = append(workStores, source.store)
+		}
+	}
+	return workBeads, workStores
 }
 
 func selectOrCreateDependencyPoolSessionBead(

--- a/cmd/gc/build_desired_state_legacy_bound_recovery_test.go
+++ b/cmd/gc/build_desired_state_legacy_bound_recovery_test.go
@@ -1,0 +1,420 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// updateCountingStore counts Update calls so a test can assert the legacy-bound
+// re-home is idempotent (no write once the bead already carries canonical
+// identity).
+type updateCountingStore struct {
+	beads.Store
+	updates int
+}
+
+func (u *updateCountingStore) Update(id string, opts beads.UpdateOpts) error {
+	u.updates++
+	return u.Store.Update(id, opts)
+}
+
+func legacyBoundRecoveryConfig() *config.City {
+	// Unbound pool agent "rig-A/planner"; its legacy bound form is
+	// "rig-A/gc.planner" (binding name "gc" was removed by the migration).
+	return &config.City{Agents: []config.Agent{poolAgent("planner", "rig-A", intPtr(5), 0)}}
+}
+
+// TestCanonicalizeLegacyBoundAssignedWorkRehomesToCanonical proves the
+// agent-side half of the migration recovery loop: work pre-assigned to the
+// legacy bound identity of a now-unbound pool agent has its Assignee and
+// gc.routed_to rewritten to the current canonical identity, so the canonical
+// session the awake/scale accounting wakes for it can surface and claim it.
+func TestCanonicalizeLegacyBoundAssignedWorkRehomesToCanonical(t *testing.T) {
+	cfg := legacyBoundRecoveryConfig()
+	const legacy = "rig-A/gc.planner"
+	const canonical = "rig-A/planner"
+
+	for _, status := range []string{"in_progress", "open"} {
+		t.Run(status, func(t *testing.T) {
+			wb := workBead("wb-1", legacy, legacy, status, 5)
+			mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
+			store := &updateCountingStore{Store: mem}
+
+			canonicalizeLegacyBoundAssignedWork(cfg, []beads.Bead{wb}, []beads.Store{store}, newSessionBeadSnapshot(nil), io.Discard)
+
+			got, err := mem.Get("wb-1")
+			if err != nil {
+				t.Fatalf("Get(wb-1): %v", err)
+			}
+			if got.Assignee != canonical {
+				t.Errorf("assignee = %q, want %q (re-homed to canonical)", got.Assignee, canonical)
+			}
+			if routed := got.Metadata["gc.routed_to"]; routed != canonical {
+				t.Errorf("gc.routed_to = %q, want %q (re-homed to canonical)", routed, canonical)
+			}
+
+			// Idempotent: a second pass over the now-canonical bead writes nothing.
+			rehomed, _ := mem.Get("wb-1")
+			store.updates = 0
+			canonicalizeLegacyBoundAssignedWork(cfg, []beads.Bead{rehomed}, []beads.Store{store}, newSessionBeadSnapshot(nil), io.Discard)
+			if store.updates != 0 {
+				t.Errorf("second pass wrote %d times, want 0 (re-home must be idempotent)", store.updates)
+			}
+		})
+	}
+}
+
+// TestCanonicalizeLegacyBoundAssignedWorkSkipsNonMigration covers the cases the
+// re-home must leave untouched: a live session still owns the legacy assignment
+// (resume tier), a real per-session assignee, already-canonical work, and work
+// that is neither in_progress nor open.
+func TestCanonicalizeLegacyBoundAssignedWorkSkipsNonMigration(t *testing.T) {
+	cfg := legacyBoundRecoveryConfig()
+	const legacy = "rig-A/gc.planner"
+
+	t.Run("live session owns legacy assignment", func(t *testing.T) {
+		wb := workBead("wb-live", legacy, legacy, "in_progress", 5)
+		mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
+		store := &updateCountingStore{Store: mem}
+		// A still-running session whose identity is the legacy assignee: the
+		// resume tier handles it, so re-homing would strand its work_query.
+		live := beads.Bead{
+			ID: "sess-legacy", Type: sessionBeadType, Status: "open",
+			Metadata: map[string]string{"session_name": legacy, "template": legacy, "state": "active"},
+		}
+		canonicalizeLegacyBoundAssignedWork(cfg, []beads.Bead{wb}, []beads.Store{store}, newSessionBeadSnapshot([]beads.Bead{live}), io.Discard)
+		if store.updates != 0 {
+			t.Fatalf("re-homed work owned by a live legacy session, got %d writes (want 0)", store.updates)
+		}
+		got, _ := mem.Get("wb-live")
+		if got.Assignee != legacy {
+			t.Errorf("assignee = %q, want %q (left for resume tier)", got.Assignee, legacy)
+		}
+	})
+
+	cases := map[string]beads.Bead{
+		// Real per-session assignment: a session name is not equivalent to any
+		// pool template, so it is not migration work.
+		"per-session assignee":  workBead("wb-sess", "rig-A/planner", "planner-gc-7", "in_progress", 5),
+		"already canonical":     workBead("wb-canon", "rig-A/planner", "rig-A/planner", "in_progress", 5),
+		"unconfigured assignee": workBead("wb-ext", "other/thing", "other/thing", "in_progress", 5),
+		"closed":                workBead("wb-closed", legacy, legacy, "closed", 5),
+	}
+	for name, wb := range cases {
+		t.Run(name, func(t *testing.T) {
+			mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
+			store := &updateCountingStore{Store: mem}
+			canonicalizeLegacyBoundAssignedWork(cfg, []beads.Bead{wb}, []beads.Store{store}, newSessionBeadSnapshot(nil), io.Discard)
+			if store.updates != 0 {
+				t.Errorf("%s: expected no re-home, got %d writes", name, store.updates)
+			}
+		})
+	}
+}
+
+// TestCanonicalizeLegacyBoundAssignedWorkSkipsDegradedSessionSnapshot proves the
+// major review finding is closed: re-homing must not run on an incomplete
+// session snapshot. A re-home moves an assignee away from its owner, so — unlike
+// the benign stampRunSessionIdentity pass — a nil or load-errored snapshot that
+// can omit a live legacy owner must skip the whole pass. Otherwise a transient
+// session-bead load failure rewrites in-flight work away from the running legacy
+// session that still owns it under the legacy identity.
+func TestCanonicalizeLegacyBoundAssignedWorkSkipsDegradedSessionSnapshot(t *testing.T) {
+	cfg := legacyBoundRecoveryConfig()
+	const legacy = "rig-A/gc.planner"
+
+	// In both cases a live legacy session still owns the work under its legacy
+	// identity, but it is absent from the snapshot the reconciler can see. A
+	// complete snapshot would carry that session and the live-session guard would
+	// protect the work; a degraded snapshot must not be trusted to prove the
+	// owner is gone.
+	cases := map[string]*sessionBeadSnapshot{
+		// loadSessionBeadSnapshot / loadSessionBeadSnapshotWithPartial both return
+		// a nil snapshot when the session-bead query fails.
+		"nil snapshot (session query failed)": nil,
+		// A fail-soft load keeps partial data but tags LoadError; the live owner
+		// may be one of the entries the degraded query dropped.
+		"load-errored snapshot": newSessionBeadSnapshotWithError(errors.New("session list timeout")),
+	}
+	for name, snapshot := range cases {
+		t.Run(name, func(t *testing.T) {
+			wb := workBead("wb-degraded", legacy, legacy, "in_progress", 5)
+			mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
+			store := &updateCountingStore{Store: mem}
+
+			canonicalizeLegacyBoundAssignedWork(cfg, []beads.Bead{wb}, []beads.Store{store}, snapshot, io.Discard)
+
+			if store.updates != 0 {
+				t.Fatalf("re-homed work on an incomplete session snapshot, got %d writes (want 0)", store.updates)
+			}
+			got, err := mem.Get("wb-degraded")
+			if err != nil {
+				t.Fatalf("Get(wb-degraded): %v", err)
+			}
+			if got.Assignee != legacy {
+				t.Errorf("assignee = %q, want %q (left untouched on degraded snapshot)", got.Assignee, legacy)
+			}
+			if routed := got.Metadata["gc.routed_to"]; routed != legacy {
+				t.Errorf("gc.routed_to = %q, want %q (left untouched on degraded snapshot)", routed, legacy)
+			}
+		})
+	}
+}
+
+// TestCanonicalizeLegacyBoundAssignedWorkWokenSessionClaimsRehomedWork is the
+// end-to-end proof requested by review: after the legacy-bound work is
+// re-homed, the canonical pool session the reconciler wakes for it actually
+// surfaces and claims the triggering bead through gc hook --claim (rather than
+// only emitting a wake request that lands on a session that cannot consume the
+// work).
+func TestCanonicalizeLegacyBoundAssignedWorkWokenSessionClaimsRehomedWork(t *testing.T) {
+	cfg := legacyBoundRecoveryConfig()
+	const legacy = "rig-A/gc.planner"
+	const canonical = "rig-A/planner"
+
+	// 1. In-progress work persisted under the legacy bound assignee, no live
+	//    session (the wake-known-identity case).
+	wb := workBead("wb-claim", legacy, legacy, "in_progress", 5)
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
+
+	// 2. The reconciler re-homes it to the canonical identity.
+	canonicalizeLegacyBoundAssignedWork(cfg, []beads.Bead{wb}, []beads.Store{mem}, newSessionBeadSnapshot(nil), io.Discard)
+	rehomed, err := mem.Get("wb-claim")
+	if err != nil {
+		t.Fatalf("Get(wb-claim): %v", err)
+	}
+	if rehomed.Assignee != canonical {
+		t.Fatalf("precondition: assignee = %q, want %q", rehomed.Assignee, canonical)
+	}
+
+	// 3. The woken canonical session runs gc hook --claim. Its work_query (tier
+	//    1: in_progress assigned to one of the session's identities) now
+	//    surfaces the bead because the assignee is the canonical template, which
+	//    the claim path always carries as resolvedAgentName.
+	workQueryOutput, err := json.Marshal([]beads.Bead{rehomed})
+	if err != nil {
+		t.Fatalf("marshal work query output: %v", err)
+	}
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(workQueryOutput), nil },
+		Claim: func(context.Context, string, []string, string, string) (beads.Bead, bool, error) {
+			t.Fatal("claim must not run: in-progress work already assigned to the canonical identity is an existing assignment")
+			return beads.Bead{}, false, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           "planner-gc-1",
+		IdentityCandidates: []string{"planner-gc-1", canonical},
+		RouteTargets:       []string{canonical},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("work-query", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.Action != "work" || result.BeadID != "wb-claim" {
+		t.Fatalf("woken canonical session did not claim the re-homed work: %+v", result)
+	}
+	if result.Reason != "existing_assignment" {
+		t.Errorf("claim reason = %q, want existing_assignment", result.Reason)
+	}
+}
+
+// TestCanonicalizeLegacyBoundUnassignedRoutedWorkRehomesRoute proves the
+// demand/claim half of the migration recovery loop (review finding BF-1): open,
+// unassigned work routed to the legacy bound identity of a now-unbound pool agent
+// has its gc.routed_to rewritten to the current canonical identity, so the
+// canonical pool-demand probe, worker work_query, and claim predicate — all of
+// which match gc.routed_to by raw string — can see and claim it.
+func TestCanonicalizeLegacyBoundUnassignedRoutedWorkRehomesRoute(t *testing.T) {
+	cfg := legacyBoundRecoveryConfig()
+	const legacy = "rig-A/gc.planner"
+	const canonical = "rig-A/planner"
+
+	wb := workBead("wb-1", legacy, "", "open", 5)
+	// An unrelated metadata key must survive the route rewrite (the Update must
+	// merge, not replace, the metadata map).
+	wb.Metadata["gc.root_bead_id"] = "root-7"
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
+	store := &updateCountingStore{Store: mem}
+
+	canonicalizeLegacyBoundUnassignedRoutedWork(cfg, []beads.Bead{wb}, []beads.Store{store}, io.Discard)
+
+	got, err := mem.Get("wb-1")
+	if err != nil {
+		t.Fatalf("Get(wb-1): %v", err)
+	}
+	if routed := got.Metadata["gc.routed_to"]; routed != canonical {
+		t.Errorf("gc.routed_to = %q, want %q (re-homed to canonical)", routed, canonical)
+	}
+	if got.Assignee != "" {
+		t.Errorf("assignee = %q, want empty (unassigned work stays unassigned)", got.Assignee)
+	}
+	if root := got.Metadata["gc.root_bead_id"]; root != "root-7" {
+		t.Errorf("gc.root_bead_id = %q, want root-7 (unrelated metadata must be preserved)", root)
+	}
+
+	// Idempotent: a second pass over the now-canonical bead writes nothing.
+	rehomed, _ := mem.Get("wb-1")
+	store.updates = 0
+	canonicalizeLegacyBoundUnassignedRoutedWork(cfg, []beads.Bead{rehomed}, []beads.Store{store}, io.Discard)
+	if store.updates != 0 {
+		t.Errorf("second pass wrote %d times, want 0 (re-home must be idempotent)", store.updates)
+	}
+}
+
+// TestCanonicalizeLegacyBoundUnassignedRoutedWorkSkipsNonMigration covers the
+// shapes the unassigned-route re-home must leave untouched: assigned work (the
+// assignee-keyed pass owns it), non-open status, an already-canonical route, an
+// empty route, and a dotted route that resolves to no configured agent.
+func TestCanonicalizeLegacyBoundUnassignedRoutedWorkSkipsNonMigration(t *testing.T) {
+	cfg := legacyBoundRecoveryConfig()
+	const legacy = "rig-A/gc.planner"
+	const canonical = "rig-A/planner"
+
+	cases := map[string]beads.Bead{
+		// Assigned work is re-homed by canonicalizeLegacyBoundAssignedWork, which
+		// carries the live-session guard; this pass must not touch it.
+		"assigned legacy route":      workBead("wb-assigned", legacy, "rig-A/gc.planner", "open", 5),
+		"in_progress unassigned":     workBead("wb-ip", legacy, "", "in_progress", 5),
+		"closed unassigned":          workBead("wb-closed", legacy, "", "closed", 5),
+		"already canonical":          workBead("wb-canon", canonical, "", "open", 5),
+		"empty route":                workBead("wb-noroute", "", "", "open", 5),
+		"dotted route, no agent":     workBead("wb-ext", "other/gc.thing", "", "open", 5),
+		"unqualified base no rehome": workBead("wb-bare", "planner", "", "open", 5),
+	}
+	for name, wb := range cases {
+		t.Run(name, func(t *testing.T) {
+			mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
+			store := &updateCountingStore{Store: mem}
+			canonicalizeLegacyBoundUnassignedRoutedWork(cfg, []beads.Bead{wb}, []beads.Store{store}, io.Discard)
+			if store.updates != 0 {
+				t.Errorf("%s: expected no re-home, got %d writes", name, store.updates)
+			}
+		})
+	}
+}
+
+// TestCanonicalizeLegacyBoundUnassignedRoutedWorkCanonicalWorkerClaims is the
+// claim-visibility proof requested by review: before the route is canonicalized
+// the canonical worker's claim predicate rejects the legacy-routed bead, and
+// after the re-home the woken canonical pool session claims it through
+// gc hook --claim as a fresh open claim.
+func TestCanonicalizeLegacyBoundUnassignedRoutedWorkCanonicalWorkerClaims(t *testing.T) {
+	cfg := legacyBoundRecoveryConfig()
+	const legacy = "rig-A/gc.planner"
+	const canonical = "rig-A/planner"
+
+	wb := workBead("wb-claim", legacy, "", "open", 5)
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
+
+	// Before the re-home: the canonical worker's claim predicate matches
+	// gc.routed_to by raw string, so the legacy route is invisible to it.
+	if hookClaimMatchesRoute(wb, []string{canonical}) {
+		t.Fatal("precondition: legacy-routed bead must not match the canonical route before re-home")
+	}
+
+	canonicalizeLegacyBoundUnassignedRoutedWork(cfg, []beads.Bead{wb}, []beads.Store{mem}, io.Discard)
+	rehomed, err := mem.Get("wb-claim")
+	if err != nil {
+		t.Fatalf("Get(wb-claim): %v", err)
+	}
+	if rehomed.Metadata["gc.routed_to"] != canonical {
+		t.Fatalf("precondition: route = %q, want %q", rehomed.Metadata["gc.routed_to"], canonical)
+	}
+	if !hookClaimMatchesRoute(rehomed, []string{canonical}) {
+		t.Fatal("re-homed bead must match the canonical route")
+	}
+
+	// The woken canonical session runs gc hook --claim. Its work_query surfaces
+	// the open, unassigned, canonically-routed bead, and the claim predicate now
+	// accepts it, so it is claimed as a fresh open claim.
+	workQueryOutput, err := json.Marshal([]beads.Bead{rehomed})
+	if err != nil {
+		t.Fatalf("marshal work query output: %v", err)
+	}
+	claimInvoked := false
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(workQueryOutput), nil },
+		Claim: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, bool, error) {
+			claimInvoked = true
+			claimed := rehomed
+			claimed.ID = id
+			claimed.Status = "in_progress"
+			claimed.Assignee = assignee
+			return claimed, true, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           "planner-gc-1",
+		IdentityCandidates: []string{"planner-gc-1", canonical},
+		RouteTargets:       []string{canonical},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("work-query", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !claimInvoked {
+		t.Fatal("claim must run: an open, unassigned, canonically-routed bead is a fresh claim")
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.Action != "work" || result.BeadID != "wb-claim" {
+		t.Fatalf("woken canonical session did not claim the re-homed work: %+v", result)
+	}
+	if result.Reason != "claimed" {
+		t.Errorf("claim reason = %q, want claimed", result.Reason)
+	}
+}
+
+// TestRetainScaleCheckPartialPoolDesiredNormalizesLegacyBoundTemplate proves a
+// transient scale_check partial failure still retains pool session beads
+// persisted under a legacy bound template. partialTemplates is keyed by the
+// current canonical name, so the retain pass must normalize each bead's stored
+// template before the membership check.
+func TestRetainScaleCheckPartialPoolDesiredNormalizesLegacyBoundTemplate(t *testing.T) {
+	cfg := legacyBoundRecoveryConfig()
+	const canonical = "rig-A/planner"
+
+	// Adopted pool session bead persisted under the removed binding.
+	legacySession := beads.Bead{
+		ID: "adopted-1", Type: sessionBeadType, Status: "open",
+		Metadata: map[string]string{
+			"template":             "rig-A/gc.planner",
+			"session_name":         "planner-legacy-1",
+			"state":                "active",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}
+	snapshot := newSessionBeadSnapshot([]beads.Bead{legacySession})
+	// The partial set is keyed canonically (as the scale_check paths produce it).
+	partial := map[string]bool{canonical: true}
+
+	got := retainScaleCheckPartialPoolDesired(cfg, nil, snapshot, partial)
+	if got[canonical] < 1 {
+		t.Fatalf("retained[%s] = %d, want >= 1 (legacy-bound session retained through partial scale_check)", canonical, got[canonical])
+	}
+
+	// Without normalization the raw legacy template would miss the canonical
+	// partial key: prove a nil cfg (no normalization possible) cannot retain it,
+	// which is exactly the pre-fix behavior the canonical path must avoid.
+	if raw := retainScaleCheckPartialPoolDesired(nil, nil, snapshot, partial); raw[canonical] != 0 {
+		t.Fatalf("retained[%s] = %d with nil cfg, want 0 (legacy template only matches after normalization)", canonical, raw[canonical])
+	}
+}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3392,6 +3392,68 @@ func TestRealizePoolDesiredSessionsDefersAliasWhenNormalizationCollides(t *testi
 	}
 }
 
+// TestRealizePoolDesiredSessionsResumePreservesLegacyBoundSessionName traces
+// the bound→unbound adoption through realize: a resume request for the
+// current canonical template that carries a session bead persisted under the
+// removed binding must keep that bead's persisted session_name, so the live
+// runtime session is reused instead of being renamed or recreated (which
+// would orphan the running agent holding in-progress work).
+func TestRealizePoolDesiredSessionsResumePreservesLegacyBoundSessionName(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	adopted, err := store.Create(beads.Bead{
+		Title:  "gascity-packs/gc.implementation-worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity-packs/gc.implementation-worker"},
+		Metadata: map[string]string{
+			"template":             "gascity-packs/gc.implementation-worker",
+			"agent_name":           "gascity-packs/gc.implementation-worker",
+			"session_name":         "gc__implementation-worker-mc-1",
+			"state":                "awake",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "implementation-worker",
+			Dir:               "gascity-packs",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(8),
+		}},
+	}
+	snapshot := &sessionBeadSnapshot{}
+	snapshot.add(adopted)
+	var stderr bytes.Buffer
+	bp := newAgentBuildParams("test-city", cityPath, cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+	bp.sessionBeads = snapshot
+	desired := map[string]TemplateParams{}
+
+	realizePoolDesiredSessions(bp, &cfg.Agents[0], PoolDesiredState{
+		Template: "gascity-packs/implementation-worker",
+		Requests: []SessionRequest{{
+			Template:      "gascity-packs/implementation-worker",
+			Tier:          "resume",
+			SessionBeadID: adopted.ID,
+		}},
+	}, desired, &stderr)
+
+	tp, ok := desired["gc__implementation-worker-mc-1"]
+	if !ok {
+		t.Fatalf("desired state missing adopted resume session under persisted session_name; keys=%v stderr=%q",
+			mapKeys(desired), stderr.String())
+	}
+	if tp.SessionName != "gc__implementation-worker-mc-1" {
+		t.Fatalf("TemplateParams.SessionName = %q, want persisted session_name preserved", tp.SessionName)
+	}
+	if got := len(desired); got != 1 {
+		t.Fatalf("desired sessions = %d, want 1 (no duplicate spawn for adopted bead)", got)
+	}
+}
+
 func TestRealizePoolDesiredSessionsLimitsFreshCreatesToWakeBudget(t *testing.T) {
 	maxWakes := 2
 	store := beads.NewMemStore()
@@ -6960,6 +7022,7 @@ func TestBuildDesiredState_ScaleCheckErrorPreservesDormantAffectedPoolSessionWit
 	}
 
 	poolDesired := retainScaleCheckPartialPoolDesired(
+		cfg,
 		PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.Open(), result.ScaleCheckCounts)),
 		snapshot,
 		result.PoolScaleCheckPartialTemplates,

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2081,6 +2081,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		phaseStart = time.Now()
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesired = retainScaleCheckPartialPoolDesired(
+			cr.cfg,
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
 				cr.cfg, poolWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace)),
 			sessionBeads,
@@ -2711,6 +2712,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 	open := filterSessionBeadsByName(updated, cfgNames)
 	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(filteredCfg, cr.cityPath, open, wfcResult.AssignedWorkBeads, wfcResult.AssignedWorkStoreRefs)
 	poolDesired := retainScaleCheckPartialPoolDesired(
+		filteredCfg,
 		PoolDesiredCounts(ComputePoolDesiredStates(
 			filteredCfg, poolWorkBeads, open, wfcResult.ScaleCheckCounts)),
 		newSessionBeadSnapshot(open),
@@ -2896,6 +2898,7 @@ func (cr *CityRuntime) loadDemandSnapshot(
 		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
 		result.PoolDesiredCounts = retainScaleCheckPartialPoolDesired(
+			cr.cfg,
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
 				cr.cfg, poolWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace)),
 			sessionBeads,

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -202,7 +202,7 @@ func TestCityStatusNamedSessionSurfacesLookupErrorWhenSnapshotDegraded(t *testin
 	}
 
 	store := beads.NewMemStore()
-	degraded := newSessionBeadSnapshotWithError(nil, errors.New("loading session snapshot timed out after 20ms"))
+	degraded := newSessionBeadSnapshotWithError(errors.New("loading session snapshot timed out after 20ms"))
 
 	status := namedSessionStatusForCity(
 		"/home/user/city", cfg, store, degraded,

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -404,7 +404,7 @@ func loadStatusSessionSnapshot(store beads.Store, stderr io.Writer) *sessionBead
 			if stderr != nil {
 				fmt.Fprintf(stderr, "gc status: loading session snapshot: %v\n", result.err) //nolint:errcheck // best-effort stderr
 			}
-			return newSessionBeadSnapshotWithError(nil, fmt.Errorf("loading session snapshot: %w", result.err))
+			return newSessionBeadSnapshotWithError(fmt.Errorf("loading session snapshot: %w", result.err))
 		}
 		if result.snapshot == nil {
 			return newSessionBeadSnapshot(nil)
@@ -414,7 +414,7 @@ func loadStatusSessionSnapshot(store beads.Store, stderr io.Writer) *sessionBead
 		if stderr != nil {
 			fmt.Fprintf(stderr, "gc status: loading session snapshot timed out after %s; continuing with runtime-only status\n", statusSessionSnapshotTimeout) //nolint:errcheck // best-effort stderr
 		}
-		return newSessionBeadSnapshotWithError(nil, fmt.Errorf("loading session snapshot timed out after %s", statusSessionSnapshotTimeout))
+		return newSessionBeadSnapshotWithError(fmt.Errorf("loading session snapshot timed out after %s", statusSessionSnapshotTimeout))
 	}
 }
 

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -225,7 +225,8 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach, json
 	}
 
 	// Store the canonical qualified name so the reconciler can match it
-	// via findAgentByTemplate (which compares against QualifiedName()).
+	// via findAgentByTemplate (which resolves canonical, V1 dir+name, and
+	// legacy bound identities).
 	canonicalTemplate := found.QualifiedName()
 	configuredOwner := sessionNewAliasOwner(cfg, &found)
 	reservationIDs := []string{alias, explicitName}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -896,6 +896,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	dt := newDrainTracker()
 	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, open, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
 	poolDesired := retainScaleCheckPartialPoolDesired(
+		cfg,
 		PoolDesiredCounts(ComputePoolDesiredStates(
 			cfg, poolWorkBeads, open, dsResult.ScaleCheckCounts)),
 		sessionBeads,

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -101,9 +101,12 @@ func buildAwakeInputFromReconciler(
 			Now:      clk,
 		})
 		bead := AwakeSessionBead{
-			ID:                     b.ID,
-			SessionName:            name,
-			Template:               b.Metadata["template"],
+			ID:          b.ID,
+			SessionName: name,
+			// Canonicalize so adopted beads persisted under a legacy identity
+			// (e.g. a removed binding) key the awake engine by the current
+			// agent template. Unresolvable templates pass through unchanged.
+			Template:               normalizeAgentTemplateIdentity(cfg, b.Metadata["template"]),
 			State:                  string(lifecycle.CompatState),
 			SleepReason:            b.Metadata["sleep_reason"],
 			ManualSession:          isManualSessionBead(*b),

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -43,6 +43,97 @@ func TestBuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilitySta
 	}
 }
 
+// TestBuildAwakeInputFromReconcilerCanonicalizesLegacyBoundTemplate pins the
+// bridge-side identity normalization for adopted legacy-bound session beads.
+// A bead persisted under a removed binding ("gascity-packs/gc.implementation-worker")
+// must enter the awake engine keyed by the current unbound agent's canonical
+// template, so explicit wake, suspension gates, and scale/min-active
+// accounting all see the adopted session. Without normalization the raw
+// stored template misses every agentsByName lookup and the explicit wake
+// request lingers unhonored.
+func TestBuildAwakeInputFromReconcilerCanonicalizesLegacyBoundTemplate(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "implementation-worker", Dir: "gascity-packs"}},
+	}
+	input := buildAwakeInputFromReconciler(
+		cfg,
+		"", // cityPath: empty exercises zero suspension state
+		[]beads.Bead{{
+			ID:     "mc-session-1",
+			Status: "open",
+			Type:   "session",
+			Metadata: map[string]string{
+				"state":        "stopped",
+				"session_name": "gc__implementation-worker-mc-1",
+				"template":     "gascity-packs/gc.implementation-worker",
+				"wake_request": "explicit",
+			},
+		}},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		now,
+	)
+
+	if len(input.SessionBeads) != 1 {
+		t.Fatalf("SessionBeads length = %d, want 1", len(input.SessionBeads))
+	}
+	if got := input.SessionBeads[0].Template; got != "gascity-packs/implementation-worker" {
+		t.Fatalf("Template = %q, want canonical current template", got)
+	}
+	if !input.SessionBeads[0].ExplicitWake {
+		t.Fatal("ExplicitWake = false, want true for wake_request=explicit")
+	}
+
+	decisions := ComputeAwakeSet(input)
+	got := decisions["gc__implementation-worker-mc-1"]
+	if !got.ShouldWake || got.Reason != "explicit-wake" {
+		t.Fatalf("decision = %+v, want explicit-wake for adopted legacy-bound bead", got)
+	}
+}
+
+// TestBuildAwakeInputFromReconcilerKeepsUnresolvableTemplateRaw guards the
+// conservative half of the bridge normalization: a stored template that does
+// not resolve to any configured agent must pass through unchanged rather
+// than being rewritten or dropped.
+func TestBuildAwakeInputFromReconcilerKeepsUnresolvableTemplateRaw(t *testing.T) {
+	now := time.Now().UTC()
+	input := buildAwakeInputFromReconciler(
+		&config.City{Agents: []config.Agent{{Name: "other", Dir: "rig"}}},
+		"", // cityPath: empty exercises zero suspension state
+		[]beads.Bead{{
+			ID:     "mc-session-1",
+			Status: "open",
+			Type:   "session",
+			Metadata: map[string]string{
+				"state":        "stopped",
+				"session_name": "s-orphan",
+				"template":     "removed-rig/gone-worker",
+			},
+		}},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		now,
+	)
+
+	if len(input.SessionBeads) != 1 {
+		t.Fatalf("SessionBeads length = %d, want 1", len(input.SessionBeads))
+	}
+	if got := input.SessionBeads[0].Template; got != "removed-rig/gone-worker" {
+		t.Fatalf("Template = %q, want raw stored template preserved", got)
+	}
+}
+
 func TestBuildAwakeInputFromReconcilerCarriesResetPendingMetadata(t *testing.T) {
 	now := time.Now().UTC()
 	input := buildAwakeInputFromReconciler(

--- a/cmd/gc/compute_awake_set_min_active_test.go
+++ b/cmd/gc/compute_awake_set_min_active_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
 
@@ -169,6 +170,39 @@ func TestBuildAwakeInputPropagatesMinActiveSessions(t *testing.T) {
 	if !found {
 		t.Fatalf("agent %q not present in AwakeInput.Agents", "pl")
 	}
+}
+
+// TestMinActive_LegacyBoundTemplateRevivedThroughBridge verifies an adopted
+// session bead persisted under a removed binding ("rig/gc.pl") still counts
+// for — and is revived by — the current unbound agent's min_active_sessions
+// guarantee. The bridge must canonicalize the stored template; with the raw
+// value the min-active pass would neither count nor wake the adopted bead and
+// the pool would stay cold after gc stop && gc start.
+func TestMinActive_LegacyBoundTemplateRevivedThroughBridge(t *testing.T) {
+	minSess := 1
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "pl", Dir: "rig", MinActiveSessions: &minSess}},
+	}
+	input := buildAwakeInputFromReconciler(
+		cfg,
+		"", // cityPath: empty exercises zero suspension state
+		[]beads.Bead{{
+			ID:     "s-1",
+			Status: "open",
+			Type:   "session",
+			Metadata: map[string]string{
+				"state":        "stopped",
+				"sleep_reason": "city-stop",
+				"session_name": "rig--pl-legacy",
+				"template":     "rig/gc.pl",
+			},
+		}},
+		nil, nil, nil, nil, nil, nil, nil,
+		time.Now().UTC(),
+	)
+	result := ComputeAwakeSet(input)
+	assertAwake(t, result, "rig--pl-legacy")
+	assertReason(t, result, "rig--pl-legacy", "min-active")
 }
 
 // TestMinActive_HeldBeadNotWoken verifies hold suppression still wins: a

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -178,9 +178,13 @@ func computePoolDesiredStates(
 				})
 				continue
 			}
-			if assignee != template || !isKnownPoolTemplate(assignee, cfg) {
+			if !agentTemplateIdentitiesEquivalent(cfg, assignee, template) || !isKnownPoolTemplate(assignee, cfg) {
 				// Assignee set but session closed/unknown and not a configured
-				// pool template — orphaned work, not our job to respawn.
+				// pool template — orphaned work, not our job to respawn. The
+				// identity-equivalence compare keeps work assigned under a
+				// legacy bound form of this template eligible for the
+				// wake-known-identity tier; the emitted request carries the
+				// canonical template.
 				continue
 			}
 			if _, ok := wakeRequestedTemplates[template]; ok {
@@ -573,7 +577,7 @@ func isKnownPoolTemplate(assignee string, cfg *config.City) bool {
 		if agent.Suspended || !agent.SupportsGenericEphemeralSessions() {
 			continue
 		}
-		if assignee == agent.QualifiedName() {
+		if agentTemplateIdentitiesEquivalent(cfg, assignee, agent.QualifiedName()) {
 			return true
 		}
 	}

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -149,9 +149,10 @@ func computePoolDesiredStates(
 					routedTo = cfg.Agents[0].QualifiedName()
 				}
 			}
+			routedTo = normalizeAgentTemplateIdentity(cfg, routedTo)
 			if sessionBeadID != "" {
 				sessionTemplate := strings.TrimSpace(sessionBeadTemplate[sessionBeadID])
-				if sessionTemplate != "" && routedTo != "" && routedTo != sessionTemplate {
+				if sessionTemplate != "" && routedTo != "" && !agentTemplateIdentitiesEquivalent(cfg, routedTo, sessionTemplate) {
 					continue
 				}
 			}

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -288,6 +288,36 @@ func TestComputePoolDesiredStates_ResumeResolvesPersistedBoundTemplate(t *testin
 	}
 }
 
+// TestComputePoolDesiredStates_WakeKnownIdentityResolvesPersistedBoundAssignee
+// covers the wake-known-identity tier one migration class over from the
+// resume tier: in-progress work assigned to the pool identity itself under
+// the legacy bound form, with no open session bead. The assignee/template
+// comparison must use identity equivalence so the work still produces a wake
+// request for the current canonical template instead of being treated as
+// orphaned.
+func TestComputePoolDesiredStates_WakeKnownIdentityResolvesPersistedBoundAssignee(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("implementation-worker", "gascity-packs", intPtr(8), 0)},
+	}
+	legacyIdentity := "gascity-packs/gc.implementation-worker"
+	work := []beads.Bead{
+		workBead("gp-qx1o", legacyIdentity, legacyIdentity, "in_progress", 5),
+	}
+
+	result := ComputePoolDesiredStates(cfg, work, nil, nil)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].Template != "gascity-packs/implementation-worker" {
+		t.Fatalf("result template = %q, want current canonical template", result[0].Template)
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 1 || reqs[0].Tier != "wake-known-identity" || reqs[0].WorkBeadID != "gp-qx1o" {
+		t.Fatalf("requests = %+v, want one wake-known-identity for gp-qx1o", reqs)
+	}
+}
+
 func TestComputePoolDesiredStates_MaxCapsTotal(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(2), 0)},

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -254,6 +254,40 @@ func TestComputePoolDesiredStates_ResumeResolvesAssigneeByAliasHistory(t *testin
 	}
 }
 
+func TestComputePoolDesiredStates_ResumeResolvesPersistedBoundTemplate(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("implementation-worker", "gascity-packs", intPtr(8), 0)},
+	}
+	sessionName := "gc__implementation-worker-mc-xbvk5"
+	work := []beads.Bead{
+		workBead("gp-qx0o", "gascity-packs/gc.implementation-worker", sessionName, "in_progress", 5),
+	}
+	sessions := []beads.Bead{{
+		ID:     "mc-xbvk5",
+		Status: "open",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":             "gascity-packs/gc.implementation-worker",
+			"session_name":         sessionName,
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}}
+
+	result := ComputePoolDesiredStates(cfg, work, sessions, nil)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].Template != "gascity-packs/implementation-worker" {
+		t.Fatalf("result template = %q, want current canonical template", result[0].Template)
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 1 || reqs[0].Tier != "resume" || reqs[0].SessionBeadID != "mc-xbvk5" {
+		t.Fatalf("requests = %+v, want one resume for mc-xbvk5", reqs)
+	}
+}
+
 func TestComputePoolDesiredStates_MaxCapsTotal(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(2), 0)},

--- a/cmd/gc/scale_from_zero_test.go
+++ b/cmd/gc/scale_from_zero_test.go
@@ -342,3 +342,179 @@ func TestBuildDesiredState_ScaleFromZero_UnqualifiedTemplateDoesNotSuppressCold(
 		t.Errorf("expected demand 1 (stray unqualified session must not suppress cold), got %d", demand)
 	}
 }
+
+// TestBuildDesiredState_ScaleFromZero_LegacyBoundTemplateSuppressesCold proves
+// the cold detection counts an adopted session bead persisted under a removed
+// binding ("rig-A/gc.planner") as a running session of the current unbound
+// rig-A/planner agent. The identities are equivalent after bound→unbound
+// migration, so the pool is NOT cold and the cold-wake probe must not fire —
+// otherwise every tick over-probes and transiently over-wakes a pool that
+// already has a live adopted session. The bare-name distinctness guarantee of
+// TestBuildDesiredState_ScaleFromZero_UnqualifiedTemplateDoesNotSuppressCold
+// must survive this widening.
+func TestBuildDesiredState_ScaleFromZero_LegacyBoundTemplateSuppressesCold(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigPath := tmpDir + "/rigs/rig-A"
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	maxSess := 5
+	minSess := 0
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:              "planner",
+				MaxActiveSessions: &maxSess,
+				MinActiveSessions: &minSess,
+				ScaleCheck:        "printf 0", // custom check returns 0
+				Dir:               "rig-A",
+				Provider:          "mock",
+			},
+		},
+		Rigs: []config.Rig{
+			{Name: "rig-A", Path: rigPath},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"mock": {
+				Command: "true",
+			},
+		},
+	}
+
+	cityStore := beads.NewMemStore()
+	rigAStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{
+		"rig-A": rigAStore,
+	}
+
+	qualifiedName := "rig-A/planner"
+
+	// Adopted pool session bead persisted under the removed binding. Its
+	// stored template is the legacy bound identity of the SAME agent, so it
+	// must count toward rig-A/planner's running sessions.
+	if _, err := rigAStore.Create(beads.Bead{
+		ID:     "adopted-session",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"template":     "rig-A/gc.planner",
+			"session_name": "planner-legacy-1",
+			"state":        "active",
+			"pool_slot":    "1",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Route demand to rig-A/planner in the city store.
+	if _, err := cityStore.Create(beads.Bead{
+		ID:     "bead-1",
+		Status: "open",
+		Type:   "task",
+		Metadata: map[string]string{
+			"gc.routed_to": qualifiedName,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionBeads := &sessionBeadSnapshot{} // Empty city store snapshot
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", tmpDir, time.Now(), cfg, &localMockProvider{},
+		cityStore, rigStores, sessionBeads, nil, os.Stderr,
+	)
+
+	// The adopted legacy-bound session counts as running → pool is not cold →
+	// the custom check's 0 stands and no cold-wake probe inflates demand.
+	if demand := result.ScaleCheckCounts[qualifiedName]; demand != 0 {
+		t.Errorf("expected demand 0 (adopted legacy-bound session suppresses cold probe), got %d", demand)
+	}
+}
+
+// TestBuildDesiredState_ScaleFromZero_LegacyBoundUnassignedRoutedWorkWakesCanonicalPool
+// proves the BF-1 review finding is closed: open, unassigned work routed to the
+// legacy bound form of a now-unbound pool agent ("rig-A/gc.planner") must wake
+// and be claimable by the canonical "rig-A/planner" pool. The canonical
+// pool-demand probe matches gc.routed_to against the canonical target by raw
+// string, so before the reconciler canonicalizes the route the cold pool never
+// sees the demand and migration-era ready work stays stuck at zero. After the
+// re-home the cold-wake probe counts it (clamped to 1) and the persisted route
+// is canonical so the canonical worker's work_query/claim path can surface it.
+func TestBuildDesiredState_ScaleFromZero_LegacyBoundUnassignedRoutedWorkWakesCanonicalPool(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigPath := tmpDir + "/rigs/rig-A"
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	maxSess := 5
+	minSess := 0
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:              "planner",
+				MaxActiveSessions: &maxSess,
+				MinActiveSessions: &minSess,
+				ScaleCheck:        "printf 0", // custom check returns 0
+				Dir:               "rig-A",
+				Provider:          "mock",
+			},
+		},
+		Rigs: []config.Rig{
+			{Name: "rig-A", Path: rigPath},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"mock": {
+				Command: "true",
+			},
+		},
+	}
+
+	cityStore := beads.NewMemStore()
+	rigAStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{
+		"rig-A": rigAStore,
+	}
+
+	const legacyRoute = "rig-A/gc.planner"
+	const canonical = "rig-A/planner"
+
+	// Open, unassigned demand still routed to the removed bound identity. No live
+	// session owns it (empty assignee, open status), so it is pure migration-era
+	// ready work that the canonical pool cannot see until its route is rewritten.
+	created, err := cityStore.Create(beads.Bead{
+		Status: "open",
+		Type:   "task",
+		Metadata: map[string]string{
+			"gc.routed_to": legacyRoute,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionBeads := &sessionBeadSnapshot{} // cold pool: no running sessions
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", tmpDir, time.Now(), cfg, &localMockProvider{},
+		cityStore, rigStores, sessionBeads, nil, os.Stderr,
+	)
+
+	// The legacy-routed demand is canonicalized to rig-A/planner, so the cold-wake
+	// probe now sees it and wakes the pool from zero (clamped to 1).
+	if demand := result.ScaleCheckCounts[canonical]; demand != 1 {
+		t.Errorf("expected demand 1 (legacy-routed work canonicalized wakes cold pool), got %d", demand)
+	}
+
+	// The persisted route is canonical, so the canonical worker's work_query and
+	// the claim predicate (raw-string gc.routed_to match) can surface and claim it.
+	got, err := cityStore.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", created.ID, err)
+	}
+	if routed := got.Metadata["gc.routed_to"]; routed != canonical {
+		t.Errorf("gc.routed_to = %q, want %q (re-homed to canonical)", routed, canonical)
+	}
+}

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -51,12 +51,12 @@ func (s *sessionBeadSnapshot) LoadError() error {
 	return s.loadErr
 }
 
-// newSessionBeadSnapshotWithError builds a snapshot from beadsIn and tags it
-// with a non-fatal load error. Callers that fail-soft on load (returning an
-// empty snapshot instead of nil) use this so downstream consumers can still
-// see the underlying failure via LoadError.
-func newSessionBeadSnapshotWithError(beadsIn []beads.Bead, err error) *sessionBeadSnapshot {
-	s := newSessionBeadSnapshot(beadsIn)
+// newSessionBeadSnapshotWithError builds an empty snapshot and tags it with a
+// non-fatal load error. Callers that fail-soft on load (returning an empty
+// snapshot instead of nil) use this so downstream consumers can still see the
+// underlying failure via LoadError.
+func newSessionBeadSnapshotWithError(err error) *sessionBeadSnapshot {
+	s := newSessionBeadSnapshot(nil)
 	// loadErr is set during construction, before s is published to any other
 	// goroutine, so no s.mu lock is needed here even though LoadError() reads
 	// it under RLock.

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -119,6 +119,9 @@ func resolvedTemplateForIdentity(identity string, cfg *config.City) string {
 func resolvedSessionTemplate(bead beads.Bead, cfg *config.City) string {
 	template := normalizedSessionTemplate(bead, cfg)
 	if template != "" && (cfg == nil || findAgentByTemplate(cfg, template) != nil) {
+		// normalizedSessionTemplate already returns the canonical qualified name
+		// when an agent resolves, so this re-normalization is a defensive no-op
+		// on that value (and still canonicalizes a non-canonical input).
 		return normalizeAgentTemplateIdentity(cfg, template)
 	}
 	storedTemplate := sessionBeadStoredTemplate(bead)

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -55,8 +55,8 @@ func resolveLegacyPoolTemplate(cfg *config.City, storedTemplate string) string {
 	if cfg == nil || storedTemplate == "" {
 		return ""
 	}
-	if findAgentByTemplate(cfg, storedTemplate) != nil {
-		return storedTemplate
+	if agent := findAgentByTemplate(cfg, storedTemplate); agent != nil {
+		return agent.QualifiedName()
 	}
 	match := ""
 	for i := range cfg.Agents {
@@ -89,8 +89,8 @@ func resolvedTemplateForIdentity(identity string, cfg *config.City) string {
 	if cfg == nil || identity == "" {
 		return ""
 	}
-	if findAgentByTemplate(cfg, identity) != nil {
-		return identity
+	if agent := findAgentByTemplate(cfg, identity); agent != nil {
+		return agent.QualifiedName()
 	}
 	if resolved := resolveLegacyPoolTemplate(cfg, identity); resolved != "" {
 		return resolved
@@ -119,7 +119,7 @@ func resolvedTemplateForIdentity(identity string, cfg *config.City) string {
 func resolvedSessionTemplate(bead beads.Bead, cfg *config.City) string {
 	template := normalizedSessionTemplate(bead, cfg)
 	if template != "" && (cfg == nil || findAgentByTemplate(cfg, template) != nil) {
-		return template
+		return normalizeAgentTemplateIdentity(cfg, template)
 	}
 	storedTemplate := sessionBeadStoredTemplate(bead)
 	if storedTemplate == "" {
@@ -137,7 +137,7 @@ func storedTemplateMatchesPoolTemplate(storedTemplate, template string, cfg *con
 	if storedTemplate == "" || template == "" {
 		return false
 	}
-	if storedTemplate == template {
+	if agentTemplateIdentitiesEquivalent(cfg, storedTemplate, template) {
 		return true
 	}
 	return resolveLegacyPoolTemplate(cfg, storedTemplate) == template
@@ -373,8 +373,10 @@ func normalizedSessionTemplate(bead beads.Bead, cfg *config.City) string {
 	if cfg == nil {
 		return template
 	}
-	if template != "" && findAgentByTemplate(cfg, template) != nil {
-		return template
+	if template != "" {
+		if agent := findAgentByTemplate(cfg, template); agent != nil {
+			return agent.QualifiedName()
+		}
 	}
 	agentName := sessionBeadAgentName(bead)
 	if agentName != "" {

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -489,15 +489,59 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 // findAgentByTemplate looks up a config agent by template name.
 // Returns nil if not found.
 func findAgentByTemplate(cfg *config.City, template string) *config.Agent {
+	template = strings.TrimSpace(template)
 	if cfg == nil || template == "" {
 		return nil
 	}
 	for i := range cfg.Agents {
-		if cfg.Agents[i].QualifiedName() == template {
+		if config.AgentMatchesIdentity(&cfg.Agents[i], template) {
+			return &cfg.Agents[i]
+		}
+	}
+	for i := range cfg.Agents {
+		if legacyBoundTemplateMatchesUnboundAgent(&cfg.Agents[i], template) {
 			return &cfg.Agents[i]
 		}
 	}
 	return nil
+}
+
+func legacyBoundTemplateMatchesUnboundAgent(agent *config.Agent, template string) bool {
+	if agent == nil || strings.TrimSpace(agent.BindingName) != "" {
+		return false
+	}
+	dir, local := config.ParseQualifiedName(strings.TrimSpace(template))
+	if strings.TrimSpace(dir) != strings.TrimSpace(agent.Dir) {
+		return false
+	}
+	binding, unbound, ok := strings.Cut(local, ".")
+	if !ok || strings.TrimSpace(binding) == "" {
+		return false
+	}
+	return strings.TrimSpace(unbound) == strings.TrimSpace(agent.Name)
+}
+
+func normalizeAgentTemplateIdentity(cfg *config.City, template string) string {
+	template = strings.TrimSpace(template)
+	if template == "" {
+		return ""
+	}
+	if agent := findAgentByTemplate(cfg, template); agent != nil {
+		return agent.QualifiedName()
+	}
+	return template
+}
+
+func agentTemplateIdentitiesEquivalent(cfg *config.City, a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return normalizeAgentTemplateIdentity(cfg, a) == normalizeAgentTemplateIdentity(cfg, b)
 }
 
 // healExpiredTimers clears expired held_until and quarantined_until.

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -486,7 +486,13 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 	return work
 }
 
-// findAgentByTemplate looks up a config agent by template name.
+// findAgentByTemplate looks up a config agent by template name. Exact
+// identity matches (canonical qualified name or V1 dir+name form, via
+// config.AgentMatchesIdentity) win over all fallbacks; when nothing matches
+// exactly, a legacy bound form ("dir/binding.name") resolves to the unbound
+// agent "dir/name" so sessions and work persisted before a bound→unbound
+// migration stay attributed. Callers that need strict exact-match lookup
+// (e.g. uniqueness validation) must not use this resolver.
 // Returns nil if not found.
 func findAgentByTemplate(cfg *config.City, template string) *config.Agent {
 	template = strings.TrimSpace(template)
@@ -521,6 +527,11 @@ func legacyBoundTemplateMatchesUnboundAgent(agent *config.Agent, template string
 	return strings.TrimSpace(unbound) == strings.TrimSpace(agent.Name)
 }
 
+// normalizeAgentTemplateIdentity maps a persisted template identity to the
+// matching agent's current canonical qualified name. It resolves through
+// findAgentByTemplate, so a legacy bound form ("dir/binding.name") left by a
+// bound→unbound migration normalizes to the unbound agent's canonical name.
+// Identities that resolve to no configured agent pass through unchanged.
 func normalizeAgentTemplateIdentity(cfg *config.City, template string) string {
 	template = strings.TrimSpace(template)
 	if template == "" {
@@ -532,6 +543,10 @@ func normalizeAgentTemplateIdentity(cfg *config.City, template string) string {
 	return template
 }
 
+// agentTemplateIdentitiesEquivalent reports whether two template identities
+// name the same configured agent after normalization. Distinct configured
+// agents stay distinct: each exact identity normalizes to itself, so a bound
+// agent and a same-named unbound agent never merge while both exist.
 func agentTemplateIdentitiesEquivalent(cfg *config.City, a, b string) bool {
 	a = strings.TrimSpace(a)
 	b = strings.TrimSpace(b)

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2421,6 +2421,44 @@ func TestFindAgentByTemplate(t *testing.T) {
 	}
 }
 
+// TestAgentTemplateIdentitiesEquivalent pins the load-bearing asymmetry of
+// the identity-equivalence helper: a legacy bound identity is equivalent to
+// the unbound agent only after the bound agent is gone. While both a bound
+// "rig/gc.worker" and an unbound "rig/worker" exist, each identity normalizes
+// to itself and the two must stay distinct — otherwise wake demand and
+// session accounting for two different roles would merge.
+func TestAgentTemplateIdentitiesEquivalent(t *testing.T) {
+	unboundOnly := &config.City{
+		Agents: []config.Agent{{Name: "worker", Dir: "rig"}},
+	}
+	if !agentTemplateIdentitiesEquivalent(unboundOnly, "rig/gc.worker", "rig/worker") {
+		t.Error("legacy bound identity should be equivalent to the remaining unbound agent")
+	}
+	if !agentTemplateIdentitiesEquivalent(unboundOnly, "rig/worker", "rig/gc.worker") {
+		t.Error("equivalence should be symmetric")
+	}
+
+	bothPresent := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "rig"},
+			{Name: "worker", Dir: "rig", BindingName: "gc"},
+		},
+	}
+	if agentTemplateIdentitiesEquivalent(bothPresent, "rig/gc.worker", "rig/worker") {
+		t.Error("bound and unbound identities must stay distinct while both agents exist")
+	}
+
+	if agentTemplateIdentitiesEquivalent(unboundOnly, "otherrig/gc.worker", "rig/worker") {
+		t.Error("legacy fallback must not cross rig/dir boundaries")
+	}
+	if agentTemplateIdentitiesEquivalent(unboundOnly, "", "rig/worker") {
+		t.Error("empty identity is never equivalent")
+	}
+	if !agentTemplateIdentitiesEquivalent(nil, "rig/worker", "rig/worker") {
+		t.Error("identical strings are equivalent even without config")
+	}
+}
+
 // --- isKnownState tests (Phase 0b: forward compatibility) ---
 
 func TestIsKnownState_KnownStates(t *testing.T) {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2393,6 +2393,23 @@ func TestFindAgentByTemplate(t *testing.T) {
 	if a := findAgentByTemplate(cfg, "worker"); a == nil || a.Name != "worker" {
 		t.Error("expected to find worker")
 	}
+	legacyCfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "implementation-worker", Dir: "gascity-packs"},
+		},
+	}
+	if a := findAgentByTemplate(legacyCfg, "gascity-packs/gc.implementation-worker"); a == nil || a.QualifiedName() != "gascity-packs/implementation-worker" {
+		t.Fatalf("expected persisted bound template to resolve to current unbound agent, got %#v", a)
+	}
+	boundCfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "rig"},
+			{Name: "worker", Dir: "rig", BindingName: "gc"},
+		},
+	}
+	if a := findAgentByTemplate(boundCfg, "rig/gc.worker"); a == nil || a.BindingName != "gc" {
+		t.Fatalf("expected exact bound agent to win over unbound legacy fallback, got %#v", a)
+	}
 	if a := findAgentByTemplate(cfg, "missing"); a != nil {
 		t.Error("expected nil for missing template")
 	}


### PR DESCRIPTION
## Summary
- Resolve persisted route/template identities like `dir/gc.worker` back to the current configured agent `dir/worker` when no exact bound agent exists.
- Normalize pool resume route/session-template comparisons through the canonical agent identity.
- Preserve explicit route mismatch behavior and exact bound-agent precedence.

## Verification
- `go test ./cmd/gc -run 'TestFindAgentByTemplate|TestFilterAssignedWorkBeadsForPoolDemandKeepsPersistedBoundRoute|TestComputePoolDesiredStates_ResumeResolvesPersistedBoundTemplate|TestComputePoolDesiredStates_DoesNotResume(Session|LegacySession)AcrossExplicitRouteMismatch|TestComputePoolDesiredStates|TestFilterAssignedWorkBeadsForPoolDemand'`\n- Phase1 verification branch `local/reconcile-live-verify-phase1-20260611` built successfully with `main.commit=e6bd80733`; focused combined regressions passed there.\n\n## Notes\n- The pre-commit hook reached `go vet ./...` and then broad `test-fast-parallel`, but unrelated existing `cmd/gc` shard failures prevented hook completion (`TestDoStartRequiresInitializedCity`, `TestFindCity/not_found`, `TestDoPrimeStrictNoCity`, plus builtin-pack/env warnings). The changed-code focused tests above passed.