### PR TITLE
fix(beads): exponential backoff + one-shot breaker signal for persistently-failing reconcile stores

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/contract"
@@ -1024,7 +1025,11 @@ func bdTransportErrorMatches(cityPath, scopeRoot string, env map[string]string, 
 const (
 	bdSilentFallbackMarkerImport  = "auto-importing"
 	bdSilentFallbackMarkerEmptyDB = "into empty database"
+
+	bdCommandRetryBaseDelay = 500 * time.Millisecond
 )
+
+var bdCommandRetrySleep = time.Sleep
 
 func bdTransportRetryableError(cityPath, scopeRoot string, env map[string]string, err error) bool {
 	return bdTransportErrorMatches(cityPath, scopeRoot, env, err, []string{
@@ -1120,6 +1125,7 @@ func bdCommandRunnerWithManagedRetryErr(cityPath string, envFn func(dir string) 
 				return out, err
 			}
 		}
+		bdCommandRetrySleep(bdCommandRetryBaseDelay)
 		retryEnv, retryEnvErr := envFn(dir)
 		if retryEnvErr != nil {
 			return nil, retryEnvErr

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -3920,6 +3920,49 @@ dolt.auto-start: false
 	}
 }
 
+// TestBDCommandRunnerManagedRetry_RetryDelayApplied guards that
+// bdCommandRunnerWithManagedRetryErr sleeps bdCommandRetryBaseDelay before the
+// single retry on the transport-retryable path.
+func TestBDCommandRunnerManagedRetry_RetryDelayApplied(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	origRunner := beadsExecCommandRunnerWithEnv
+	origRecover := recoverManagedBDCommand
+	origSleep := bdCommandRetrySleep
+	t.Cleanup(func() {
+		beadsExecCommandRunnerWithEnv = origRunner
+		recoverManagedBDCommand = origRecover
+		bdCommandRetrySleep = origSleep
+	})
+
+	var sleepCalled time.Duration
+	bdCommandRetrySleep = func(d time.Duration) { sleepCalled = d }
+
+	attempts := 0
+	beadsExecCommandRunnerWithEnv = func(env map[string]string) beads.CommandRunner {
+		return func(_ string, _ string, _ ...string) ([]byte, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, fmt.Errorf("server unreachable")
+			}
+			return []byte("ok"), nil
+		}
+	}
+	recoverManagedBDCommand = func(_ string) error { return nil }
+
+	cityPath := t.TempDir()
+	runner := bdCommandRunnerWithManagedRetry(cityPath, func(_ string) map[string]string {
+		return map[string]string{}
+	})
+
+	if _, err := runner(cityPath, "bd", "list", "--json"); err != nil {
+		t.Fatalf("runner error = %v, want nil", err)
+	}
+	if sleepCalled != bdCommandRetryBaseDelay {
+		t.Fatalf("bdCommandRetrySleep called with %v, want %v", sleepCalled, bdCommandRetryBaseDelay)
+	}
+}
+
 func TestBdRuntimeEnvDoesNotDefaultBeadsActorWhenUnset(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -3939,7 +3939,7 @@ func TestBDCommandRunnerManagedRetry_RetryDelayApplied(t *testing.T) {
 	bdCommandRetrySleep = func(d time.Duration) { sleepCalled = d }
 
 	attempts := 0
-	beadsExecCommandRunnerWithEnv = func(env map[string]string) beads.CommandRunner {
+	beadsExecCommandRunnerWithEnv = func(_ map[string]string) beads.CommandRunner {
 		return func(_ string, _ string, _ ...string) ([]byte, error) {
 			attempts++
 			if attempts == 1 {

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -149,6 +149,8 @@ const (
 	cacheReconcileIntervalLarge     = 120 * time.Second
 	cacheProblemLogWindow           = time.Minute
 	cacheReconcileFailureBackoff    = time.Minute
+	cacheReconcileBaseBackoff       = 2 * time.Second
+	cacheReconcileMaxBackoff        = 10 * time.Minute
 	// cacheReconcileSuccessLogWindow rate-limits the per-reconcile success
 	// log line. Reuses the one-minute pattern from cacheProblemLogWindow so
 	// the reconciler's footprint in the operator-visible log stays bounded

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -149,7 +149,6 @@ const (
 	cacheReconcileIntervalMedium    = 60 * time.Second
 	cacheReconcileIntervalLarge     = 120 * time.Second
 	cacheProblemLogWindow           = time.Minute
-	cacheReconcileFailureBackoff    = time.Minute
 	cacheReconcileBaseBackoff       = 2 * time.Second
 	cacheReconcileMaxBackoff        = 10 * time.Minute
 	// cacheReconcileSuccessLogWindow rate-limits the per-reconcile success

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -42,10 +42,11 @@ type CachingStore struct {
 	mutationSeq     uint64
 	primePartialErr error
 
-	reconciling  atomic.Bool
-	syncFailures int
-	stats        CacheStats
-	onChange     func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage)
+	reconciling    atomic.Bool
+	syncFailures   int
+	circuitTripped bool
+	stats          CacheStats
+	onChange       func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage)
 	problemf     func(string)
 	problemLog   map[string]cacheProblemLogState
 
@@ -591,6 +592,7 @@ func (c *CachingStore) prime(ctx context.Context) error {
 	}
 	c.state = cacheLive
 	c.syncFailures = 0
+	c.circuitTripped = false
 	c.stats.SyncFailures = 0
 	c.primePartialErr = partialErr
 	c.markFreshLocked(now)

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -47,8 +47,8 @@ type CachingStore struct {
 	circuitTripped bool
 	stats          CacheStats
 	onChange       func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage)
-	problemf     func(string)
-	problemLog   map[string]cacheProblemLogState
+	problemf       func(string)
+	problemLog     map[string]cacheProblemLogState
 
 	// lastReconcileLogAt rate-limits the per-reconcile success log line
 	// emitted by runReconciliation. Without this, a busy cache at SMALL

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1964,8 +1964,19 @@ func TestCachingStoreRunReconciliationSuppressesDuplicateProblemLogs(t *testing.
 	if stats.ProblemCount != int64(maxCacheSyncFailures) {
 		t.Fatalf("ProblemCount = %d, want %d", stats.ProblemCount, maxCacheSyncFailures)
 	}
-	if len(logs) != 1 {
-		t.Fatalf("logged %d problem lines, want 1: %#v", len(logs), logs)
+	// Expect 2 logs: the deduplicated reconcile-cache problem (run 1) and the
+	// one-shot circuit-breaker trip (emitted when syncFailures reaches maxCacheSyncFailures).
+	if len(logs) != 2 {
+		t.Fatalf("logged %d problem lines, want 2 (1 reconcile problem + 1 circuit-breaker trip): %#v", len(logs), logs)
+	}
+	hasTrip := false
+	for _, l := range logs {
+		if strings.Contains(l, "circuit-breaker tripped") {
+			hasTrip = true
+		}
+	}
+	if !hasTrip {
+		t.Fatalf("circuit-breaker trip not found in logs: %#v", logs)
 	}
 	if delay := cache.nextReconcileDelay(time.Now()); delay <= cacheReconcilePollInterval {
 		t.Fatalf("nextReconcileDelay = %v, want sustained-failure backoff above poll interval", delay)
@@ -1978,11 +1989,12 @@ func TestCachingStoreRunReconciliationSuppressesDuplicateProblemLogs(t *testing.
 	cache.mu.Unlock()
 
 	cache.runReconciliation()
-	if len(logs) != 2 {
-		t.Fatalf("logged %d problem lines after window expiry, want 2: %#v", len(logs), logs)
+	// After window expiry: 1 new reconcile-cache problem log (with suppressed count) → total 3.
+	if len(logs) != 3 {
+		t.Fatalf("logged %d problem lines after window expiry, want 3: %#v", len(logs), logs)
 	}
-	if !strings.Contains(logs[1], "suppressed 4 duplicate logs") {
-		t.Fatalf("second problem log = %q, want suppressed duplicate count", logs[1])
+	if !strings.Contains(logs[2], "suppressed 4 duplicate logs") {
+		t.Fatalf("third problem log = %q, want suppressed duplicate count", logs[2])
 	}
 }
 

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -256,8 +256,12 @@ func (c *CachingStore) nextReconcileDelay(now time.Time) time.Duration {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	if c.syncFailures >= maxCacheSyncFailures && !c.stats.LastProblemAt.IsZero() {
-		dueAt := c.stats.LastProblemAt.Add(cacheReconcileFailureBackoff)
+	if c.syncFailures > 0 && !c.stats.LastProblemAt.IsZero() {
+		backoff := cacheReconcileBaseBackoff << uint(c.syncFailures)
+		if backoff > cacheReconcileMaxBackoff || backoff <= 0 {
+			backoff = cacheReconcileMaxBackoff
+		}
+		dueAt := c.stats.LastProblemAt.Add(backoff)
 		if !now.Before(dueAt) {
 			return 0
 		}

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -569,6 +569,12 @@ func (c *CachingStore) runReconciliation() {
 // hold c.mu (write lock).
 func (c *CachingStore) promoteLiveLocked() {
 	c.state = cacheLive
+	// Re-arm the one-shot circuit-breaker signal. promoteLiveLocked is the single
+	// live-promotion point — both prime() and the reconcile success paths route
+	// through it — so resetting here ensures a store that recovers via reconcile
+	// (not just prime) will fire the trip log again on a subsequent re-degrade.
+	// Without this, a flapping store emits the breaker signal at most once.
+	c.circuitTripped = false
 }
 
 // reconcileSuccessLogLocked composes the per-reconcile success log line

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -302,6 +302,10 @@ func (c *CachingStore) runReconciliation() {
 		c.syncFailures++
 		if (IsPartialResult(err) || c.syncFailures >= maxCacheSyncFailures) && (c.state == cacheLive || c.state == cachePartial) {
 			c.state = cacheDegraded
+			if !c.circuitTripped {
+				c.circuitTripped = true
+				c.problemf(fmt.Sprintf("circuit-breaker tripped rig=%s syncFailures=%d", c.idPrefix, c.syncFailures))
+			}
 		}
 		c.recordProblemLocked("reconcile cache", err)
 		c.recordReconcileLatencyLocked(bdLatency)

--- a/internal/beads/caching_store_reconcile_internal_test.go
+++ b/internal/beads/caching_store_reconcile_internal_test.go
@@ -10,6 +10,60 @@ import (
 	"time"
 )
 
+// TestNextReconcileDelay verifies exponential backoff in nextReconcileDelay:
+// delay starts at failure 1 (not 5), doubles per increment, and caps at 10 min.
+func TestNextReconcileDelay(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(10000, 0)
+
+	makeCache := func(syncFails int, problemAt time.Time) *CachingStore {
+		c := NewCachingStoreForTest(NewMemStore(), nil)
+		c.state = cacheLive
+		c.lastFreshAt = time.Unix(1, 0) // stale — normal path returns 0
+		c.syncFailures = syncFails
+		c.stats.LastProblemAt = problemAt
+		return c
+	}
+
+	t.Run("backoff applies at failure 1", func(t *testing.T) {
+		t.Parallel()
+		// problemAt == now so delay == backoff exactly; normal cadence path returns 0 here.
+		c := makeCache(1, now)
+		if delay := c.nextReconcileDelay(now); delay <= 0 {
+			t.Fatalf("syncFailures=1: got delay %v, want > 0 (exponential backoff must apply from failure 1)", delay)
+		}
+	})
+
+	t.Run("delay doubles per failure", func(t *testing.T) {
+		t.Parallel()
+		// problemAt == now so delay == backoff; each step must be exactly 2× prior.
+		var prev time.Duration
+		for n := 1; n <= 6; n++ {
+			c := makeCache(n, now)
+			delay := c.nextReconcileDelay(now)
+			if delay <= 0 {
+				t.Fatalf("syncFailures=%d: got delay %v, want > 0", n, delay)
+			}
+			if n > 1 && delay != prev*2 {
+				t.Fatalf("syncFailures=%d: got %v, want %v (2× previous %v)", n, delay, prev*2, prev)
+			}
+			prev = delay
+		}
+	})
+
+	t.Run("caps at 10 minutes", func(t *testing.T) {
+		t.Parallel()
+		maxBackoff := 10 * time.Minute
+		// syncFailures=20 → 2s*2^20 far exceeds cap; delay must equal maxBackoff.
+		c := makeCache(20, now)
+		delay := c.nextReconcileDelay(now)
+		if delay != maxBackoff {
+			t.Fatalf("syncFailures=20: got %v, want %v (cap)", delay, maxBackoff)
+		}
+	})
+}
+
 type reconcileRaceStore struct {
 	Store
 	started chan struct{}

--- a/internal/beads/caching_store_reconcile_internal_test.go
+++ b/internal/beads/caching_store_reconcile_internal_test.go
@@ -548,6 +548,65 @@ func (s *failingScanStore) List(query ListQuery) ([]Bead, error) {
 	return s.Store.List(query)
 }
 
+// TestRunReconciliation_CircuitTripLogs_OnLiveToDegraded guards that the
+// first live→cacheDegraded transition emits exactly one "circuit-breaker
+// tripped" message, and that subsequent reconciliations in the degraded
+// window do not re-emit it.
+func TestRunReconciliation_CircuitTripLogs_OnLiveToDegraded(t *testing.T) {
+	backing := &failingScanStore{Store: NewMemStore()}
+	backing.setFailScan(true)
+	cs := NewCachingStoreForTest(backing, nil)
+	cs.state = cacheLive
+
+	var logMu sync.Mutex
+	var logLines []string
+	cs.problemf = func(msg string) {
+		logMu.Lock()
+		logLines = append(logLines, msg)
+		logMu.Unlock()
+	}
+
+	// Drive syncFailures to maxCacheSyncFailures to trigger the live→degraded transition.
+	for i := 0; i < maxCacheSyncFailures; i++ {
+		cs.runReconciliation()
+	}
+
+	if cs.state != cacheDegraded {
+		t.Fatalf("state = %v, want cacheDegraded after %d failures", cs.state, maxCacheSyncFailures)
+	}
+
+	logMu.Lock()
+	lines := append([]string(nil), logLines...)
+	logMu.Unlock()
+
+	tripCount := 0
+	for _, l := range lines {
+		if strings.Contains(l, "circuit-breaker tripped") {
+			tripCount++
+		}
+	}
+	if tripCount == 0 {
+		t.Fatal("expected 'circuit-breaker tripped' in log after live→degraded transition, got none")
+	}
+
+	// Subsequent reconciliations in the degraded window must NOT re-emit the trip.
+	logMu.Lock()
+	logLines = logLines[:0]
+	logMu.Unlock()
+
+	cs.runReconciliation()
+
+	logMu.Lock()
+	lines = append([]string(nil), logLines...)
+	logMu.Unlock()
+
+	for _, l := range lines {
+		if strings.Contains(l, "circuit-breaker tripped") {
+			t.Fatalf("circuit-breaker trip re-emitted on second degraded reconcile; want exactly once per live→degraded transition")
+		}
+	}
+}
+
 // TestRunReconciliationPromotesPartialCacheToLive asserts that a clean
 // full-scan reconciliation promotes a PrimeActive-only (cachePartial)
 // cache to live. A reconcile loads the same complete active snapshot a

--- a/internal/beads/caching_store_reconcile_internal_test.go
+++ b/internal/beads/caching_store_reconcile_internal_test.go
@@ -585,8 +585,8 @@ func TestRunReconciliation_CircuitTripLogs_OnLiveToDegraded(t *testing.T) {
 			tripCount++
 		}
 	}
-	if tripCount == 0 {
-		t.Fatal("expected 'circuit-breaker tripped' in log after live→degraded transition, got none")
+	if tripCount != 1 {
+		t.Fatalf("expected exactly one 'circuit-breaker tripped' log on the live→degraded transition, got %d", tripCount)
 	}
 
 	// Subsequent reconciliations in the degraded window must NOT re-emit the trip.
@@ -604,6 +604,69 @@ func TestRunReconciliation_CircuitTripLogs_OnLiveToDegraded(t *testing.T) {
 		if strings.Contains(l, "circuit-breaker tripped") {
 			t.Fatalf("circuit-breaker trip re-emitted on second degraded reconcile; want exactly once per live→degraded transition")
 		}
+	}
+}
+
+// TestRunReconciliation_CircuitTripReArmsAfterReconcileRecovery guards that the
+// one-shot breaker signal re-arms when a degraded store recovers via the
+// reconcile path (not just prime): trip → reconcile-recover → re-degrade must
+// fire the trip log a SECOND time. Without the circuitTripped reset in
+// promoteLiveLocked, a flapping store emits the signal at most once per process.
+func TestRunReconciliation_CircuitTripReArmsAfterReconcileRecovery(t *testing.T) {
+	backing := &failingScanStore{Store: NewMemStore()}
+	backing.setFailScan(true)
+	cs := NewCachingStoreForTest(backing, nil)
+	cs.state = cacheLive
+
+	var logMu sync.Mutex
+	var logLines []string
+	cs.problemf = func(msg string) {
+		logMu.Lock()
+		logLines = append(logLines, msg)
+		logMu.Unlock()
+	}
+	tripCount := func() int {
+		logMu.Lock()
+		defer logMu.Unlock()
+		n := 0
+		for _, l := range logLines {
+			if strings.Contains(l, "circuit-breaker tripped") {
+				n++
+			}
+		}
+		return n
+	}
+
+	// 1. Trip: drive live→degraded; the breaker fires once.
+	for i := 0; i < maxCacheSyncFailures; i++ {
+		cs.runReconciliation()
+	}
+	if cs.state != cacheDegraded {
+		t.Fatalf("state = %v, want cacheDegraded after the first failure run", cs.state)
+	}
+	if got := tripCount(); got != 1 {
+		t.Fatalf("trip count after first degrade = %d, want 1", got)
+	}
+
+	// 2. Recover via reconcile: a clean scan promotes degraded→live through
+	//    promoteLiveLocked, which must re-arm the breaker.
+	backing.setFailScan(false)
+	cs.runReconciliation()
+	if cs.state != cacheLive {
+		t.Fatalf("state = %v, want cacheLive after the recovery reconcile", cs.state)
+	}
+
+	// 3. Re-degrade: the breaker must fire AGAIN, proving it re-armed on the
+	//    reconcile recovery rather than staying latched from the first trip.
+	backing.setFailScan(true)
+	for i := 0; i < maxCacheSyncFailures; i++ {
+		cs.runReconciliation()
+	}
+	if cs.state != cacheDegraded {
+		t.Fatalf("state = %v, want cacheDegraded after the re-degrade run", cs.state)
+	}
+	if got := tripCount(); got != 2 {
+		t.Fatalf("trip count after recover→re-trip = %d, want 2 (breaker must re-arm on reconcile recovery)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes a persistently-failing reconcile store back off and signal, instead of spinning.

- **Unified exponential backoff** in `nextReconcileDelay`: backoff now starts from the **first** failure (not the fifth), doubling per failure from a 2 s base, capped at 10 min. Eliminates the CPU-spin observed when a store's backing connection wedges.
- **Retry pacing**: `bdCommandRunnerWithManagedRetryErr` now sleeps `bdCommandRetryBaseDelay` (500 ms) before its single retry on a transport-retryable error, so the retry doesn't immediately re-trigger the same failure.
- **One-shot breaker signal**: the first `cacheLive`→`cacheDegraded` transition emits a single `"circuit-breaker tripped"` log (guarded by a `circuitTripped` flag, reset on recovery). Gives a searchable signal when a store becomes persistently unavailable, without log-spamming every reconcile.

## Benefit
A flapping/wedged store degrades gracefully (bounded backoff + one clear signal) rather than burning CPU and flooding logs.

## Test plan

- [x] `TestNextReconcileDelay` — backoff at failure 1, doubles, caps at 10 min
- [x] `TestBDCommandRunnerManagedRetry_RetryDelayApplied` — retry delay applied on transport-retryable path
- [x] `TestRunReconciliation_CircuitTripLogs_OnLiveToDegraded` — trip emitted once on live→degraded, not re-emitted
- [x] dedup test updated; `go test ./internal/beads/ -race` (863 tests) + `go vet` clean
<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3364 — fits that store-resilience cluster: exponential backoff + one-shot breaker signal for a persistently-failing reconcile store, complementing the breaker / admission / health-patrol pieces.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
