### PR TITLE
fix(extmsg): bind conversations by session name so they survive respawn

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1156,6 +1156,11 @@ func (cr *CityRuntime) tick(
 	phaseStart = time.Now()
 	sessionBeads = cr.loadSessionBeadSnapshot()
 	recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.after_sync", phaseStart, traceSessionSnapshotFields(sessionBeads))
+	// Re-point external-message bindings at respawned sessions (and clear
+	// bindings whose session is gone) now that replacement beads are visible.
+	phaseStart = time.Now()
+	reapStaleExtmsgBindings(ctx, cr.cityBeadStore(), time.Now(), cr.stderr)
+	recordPhase(TraceSiteControllerTickPhase, "reap_stale_extmsg_bindings", phaseStart, nil)
 	phaseStart = time.Now()
 	result = refreshDesiredStateWithSessionBeads(
 		result,

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -3925,6 +3925,7 @@ export interface components {
             /** Format: int64 */
             SchemaVersion: number;
             SessionID: string;
+            SessionName: string;
             Status: components["schemas"]["BindingStatus"];
         };
         SessionCreateBody: {

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -2528,6 +2528,7 @@ export type SessionBindingRecord = {
     };
     SchemaVersion: number;
     SessionID: string;
+    SessionName: string;
     Status: BindingStatus;
 };
 

--- a/cmd/gc/extmsg_binding_reaper.go
+++ b/cmd/gc/extmsg_binding_reaper.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/extmsg"
+)
+
+// reapStaleExtmsgBindings reconciles external-message conversation bindings
+// against live session identity on each reconciler tick. A binding stores the
+// session bead ID it was created against; when that session crashes and
+// respawns under the same name it gets a fresh bead ID, leaving the binding
+// pointing at a dead session so inbound triage silently drops and a fresh bind
+// is rejected as a conflict. The reaper re-points bindings at the respawned
+// session and clears bindings whose session is gone.
+//
+// It runs after session beads have been synced for the tick so a respawned
+// session's replacement bead is already visible. Errors are logged and
+// swallowed so a binding-store hiccup never stalls the reconciler loop.
+func reapStaleExtmsgBindings(ctx context.Context, store beads.Store, now time.Time, stderr io.Writer) {
+	if store == nil {
+		return
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	stats, err := extmsg.ReapStaleBindings(ctx, store, now)
+	if err != nil {
+		fmt.Fprintf(stderr, "session reconciler: reaping stale extmsg bindings: %v\n", err) //nolint:errcheck
+		return
+	}
+	if stats.Reassigned > 0 || stats.Cleared > 0 {
+		fmt.Fprintf(stderr, "session reconciler: extmsg bindings reaped (reassigned=%d cleared=%d scanned=%d)\n", //nolint:errcheck
+			stats.Reassigned, stats.Cleared, stats.Scanned)
+	}
+}

--- a/cmd/gc/extmsg_binding_reaper_test.go
+++ b/cmd/gc/extmsg_binding_reaper_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/extmsg"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+func TestReapStaleExtmsgBindingsRepointsRespawnedSession(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Date(2026, time.March, 23, 9, 0, 0, 0, time.UTC)
+
+	oldSession, err := store.Create(beads.Bead{
+		Title:    "session gc-pl",
+		Type:     session.BeadType,
+		Labels:   []string{session.LabelSession},
+		Metadata: map[string]string{"session_name": "gc-pl"},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	ref := extmsg.ConversationRef{
+		ScopeID:        "city-1",
+		Provider:       "slack",
+		AccountID:      "acct-1",
+		ConversationID: "C0B25SS12CD",
+		Kind:           extmsg.ConversationRoom,
+	}
+	svc := extmsg.NewServices(store).Bindings
+	if _, err := svc.Bind(context.Background(), extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}, extmsg.BindInput{
+		Conversation: ref,
+		SessionID:    oldSession.ID,
+		Now:          now,
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+
+	// Respawn: close the old bead, mint a fresh one under the same name.
+	if err := store.Close(oldSession.ID); err != nil {
+		t.Fatalf("close old session: %v", err)
+	}
+	newSession, err := store.Create(beads.Bead{
+		Title:    "session gc-pl",
+		Type:     session.BeadType,
+		Labels:   []string{session.LabelSession},
+		Metadata: map[string]string{"session_name": "gc-pl"},
+	})
+	if err != nil {
+		t.Fatalf("recreate session bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	reapStaleExtmsgBindings(context.Background(), store, now, &stderr)
+
+	got, err := svc.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if got == nil || got.SessionID != newSession.ID {
+		t.Fatalf("binding not re-pointed at respawned session: got %+v want SessionID=%s", got, newSession.ID)
+	}
+}
+
+func TestReapStaleExtmsgBindingsNilStoreNoPanic(_ *testing.T) {
+	// Defensive: a tick before the bead store is wired must be a no-op.
+	reapStaleExtmsgBindings(context.Background(), nil, time.Now(), nil)
+}

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -6166,6 +6166,9 @@
           "SessionID": {
             "type": "string"
           },
+          "SessionName": {
+            "type": "string"
+          },
           "Status": {
             "$ref": "#/components/schemas/BindingStatus"
           }
@@ -6175,6 +6178,7 @@
           "SchemaVersion",
           "Conversation",
           "SessionID",
+          "SessionName",
           "Status",
           "BoundAt",
           "ExpiresAt",

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -6166,6 +6166,9 @@
           "SessionID": {
             "type": "string"
           },
+          "SessionName": {
+            "type": "string"
+          },
           "Status": {
             "$ref": "#/components/schemas/BindingStatus"
           }
@@ -6175,6 +6178,7 @@
           "SchemaVersion",
           "Conversation",
           "SessionID",
+          "SessionName",
           "Status",
           "BoundAt",
           "ExpiresAt",

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2523,6 +2523,7 @@ type SessionBindingRecord struct {
 	Metadata          map[string]string `json:"Metadata"`
 	SchemaVersion     int64             `json:"SchemaVersion"`
 	SessionID         string            `json:"SessionID"`
+	SessionName       string            `json:"SessionName"`
 
 	// Status Lifecycle state of a session binding.
 	Status BindingStatus `json:"Status"`

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -6166,6 +6166,9 @@
           "SessionID": {
             "type": "string"
           },
+          "SessionName": {
+            "type": "string"
+          },
           "Status": {
             "$ref": "#/components/schemas/BindingStatus"
           }
@@ -6175,6 +6178,7 @@
           "SchemaVersion",
           "Conversation",
           "SessionID",
+          "SessionName",
           "Status",
           "BoundAt",
           "ExpiresAt",

--- a/internal/extmsg/binding_reaper.go
+++ b/internal/extmsg/binding_reaper.go
@@ -65,7 +65,7 @@ func ReapStaleBindings(ctx context.Context, store beads.Store, now time.Time) (B
 	// reassigned tracks stale session IDs already processed so we don't call
 	// ReassignSessionBindings (which operates on all bindings for a session)
 	// more than once per session per sweep.
-	reassigned := make(map[string]bool)
+	reassigned := make(map[string]struct{})
 	for _, item := range items {
 		if err := checkContext(ctx); err != nil {
 			return stats, err
@@ -89,11 +89,14 @@ func ReapStaleBindings(ctx context.Context, store beads.Store, now time.Time) (B
 				return stats, fmt.Errorf("clear dead binding %s: %w", record.ID, err)
 			}
 			stats.Cleared++
-		case liveID != "" && liveID != record.SessionID && !reassigned[record.SessionID]:
+		case liveID != "" && liveID != record.SessionID:
+			if _, ok := reassigned[record.SessionID]; ok {
+				break
+			}
 			if err := ReassignSessionBindings(ctx, store, record.SessionID, liveID, now); err != nil {
 				return stats, fmt.Errorf("reassign session %s to live bead %s: %w", record.SessionID, liveID, err)
 			}
-			reassigned[record.SessionID] = true
+			reassigned[record.SessionID] = struct{}{}
 			stats.Reassigned++
 		}
 	}
@@ -121,6 +124,10 @@ func bindingLiveTarget(store beads.Store, record SessionBindingRecord) (liveID s
 	// Legacy binding with no recorded name: it can only ever point at the bead
 	// ID it stored, which never recovers across respawn (the replacement gets a
 	// fresh ID). Clear it once that bead is gone or closed; otherwise leave it.
+	// This path is self-eliminating: new bindings always record a SessionName,
+	// and re-binds opportunistically backfill it on existing entries. Legacy
+	// bindings that are never re-bound are eventually cleared here when their
+	// session is retired — no active migration is needed.
 	stored := record.SessionID
 	if stored == "" {
 		return "", false

--- a/internal/extmsg/binding_reaper.go
+++ b/internal/extmsg/binding_reaper.go
@@ -1,0 +1,139 @@
+package extmsg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// BindingReapStats summarizes a single ReapStaleBindings sweep.
+type BindingReapStats struct {
+	// Scanned counts active bindings examined.
+	Scanned int
+	// Reassigned counts sessions whose bindings were re-pointed at a new live
+	// bead after respawn. Each unique stale-session-ID is counted once even
+	// if that session has multiple active conversation bindings (ReassignSessionBindings
+	// updates all bindings for the session atomically).
+	Reassigned int
+	// Cleared counts bindings closed because their session has no live owner.
+	Cleared int
+}
+
+// ReapStaleBindings reconciles active conversation bindings against live
+// session identity. A binding stores the volatile session bead ID it was
+// created against; when that session crashes and respawns under the same name
+// it gets a fresh bead ID, leaving the binding pointing at a dead session.
+// Inbound routing then resolves to the dead bead and silently drops, and a
+// fresh bind is rejected with ErrBindingConflict because the conversation is
+// still bound.
+//
+// For each active binding the reaper:
+//   - re-points it at the session's current live bead when the binding's stable
+//     session name now resolves to a different (respawned) bead ID;
+//   - clears it (closing the binding and its delivery/membership state) when no
+//     live session owns the name, or — for legacy bindings with no recorded
+//     name — when the stored bead ID is no longer a live session.
+//
+// Bindings whose live target already matches the stored ID are left untouched.
+// Error tolerance: lookup errors inside bindingLiveTarget (transient store
+// reads) cause the individual binding to be skipped. Decode errors, Unbind
+// failures, and ReassignSessionBindings failures abort the sweep and are
+// returned to the caller (the reconciler wiring logs them).
+//
+// The sweep is idempotent and safe to run on every reconciler tick; it must run
+// after session beads have been synced for the tick so a respawned session's
+// replacement bead is already visible.
+func ReapStaleBindings(ctx context.Context, store beads.Store, now time.Time) (BindingReapStats, error) {
+	var stats BindingReapStats
+	if err := checkContext(ctx); err != nil {
+		return stats, err
+	}
+	if store == nil {
+		return stats, nil
+	}
+	items, err := store.List(beads.ListQuery{Label: labelBindingBase})
+	if err != nil {
+		return stats, fmt.Errorf("list active bindings: %w", err)
+	}
+	svc := NewServices(store)
+	caller := Caller{Kind: CallerController, ID: "binding-reaper"}
+	now = zeroNow(now)
+	// reassigned tracks stale session IDs already processed so we don't call
+	// ReassignSessionBindings (which operates on all bindings for a session)
+	// more than once per session per sweep.
+	reassigned := make(map[string]bool)
+	for _, item := range items {
+		if err := checkContext(ctx); err != nil {
+			return stats, err
+		}
+		record, err := decodeBindingBead(item)
+		if err != nil {
+			return stats, fmt.Errorf("decode binding %s: %w", item.ID, err)
+		}
+		if record.Status != BindingActive {
+			continue
+		}
+		stats.Scanned++
+
+		liveID, dead := bindingLiveTarget(store, record)
+		switch {
+		case dead:
+			if _, err := svc.Bindings.Unbind(ctx, caller, UnbindInput{
+				Conversation: &record.Conversation,
+				Now:          now,
+			}); err != nil {
+				return stats, fmt.Errorf("clear dead binding %s: %w", record.ID, err)
+			}
+			stats.Cleared++
+		case liveID != "" && liveID != record.SessionID && !reassigned[record.SessionID]:
+			if err := ReassignSessionBindings(ctx, store, record.SessionID, liveID, now); err != nil {
+				return stats, fmt.Errorf("reassign session %s to live bead %s: %w", record.SessionID, liveID, err)
+			}
+			reassigned[record.SessionID] = true
+			stats.Reassigned++
+		}
+	}
+	return stats, nil
+}
+
+// bindingLiveTarget resolves the current live session bead a binding should
+// point at. It returns (liveID, false) when a live target exists, ("", true)
+// when the binding's session is definitively gone (so the binding should be
+// cleared), and ("", false) when the state is indeterminate and the binding
+// should be left untouched (e.g. a transient store error or an ambiguous name).
+func bindingLiveTarget(store beads.Store, record SessionBindingRecord) (liveID string, dead bool) {
+	name := record.SessionName
+	if name != "" {
+		id, err := resolveLiveSessionID(store, name)
+		switch {
+		case errors.Is(err, session.ErrSessionNotFound):
+			return "", true
+		case err != nil:
+			return "", false
+		default:
+			return id, false
+		}
+	}
+	// Legacy binding with no recorded name: it can only ever point at the bead
+	// ID it stored, which never recovers across respawn (the replacement gets a
+	// fresh ID). Clear it once that bead is gone or closed; otherwise leave it.
+	stored := record.SessionID
+	if stored == "" {
+		return "", false
+	}
+	bead, err := store.Get(stored)
+	if errors.Is(err, beads.ErrNotFound) {
+		return "", true
+	}
+	if err != nil {
+		return "", false
+	}
+	if bead.Status == "closed" || !session.IsSessionBeadOrRepairable(bead) {
+		return "", true
+	}
+	return stored, false
+}

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -94,6 +94,9 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 	if sessionID == "" {
 		return SessionBindingRecord{}, fmt.Errorf("%w: session_id required", ErrInvalidInput)
 	}
+	// Capture the target's stable session name so the binding survives respawn.
+	// Best-effort: empty when the selector resolves to no session bead.
+	sessionName := sessionNameForSelector(s.store, sessionID)
 	now := zeroNow(input.Now)
 
 	var out SessionBindingRecord
@@ -112,6 +115,14 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 		if active != nil {
 			if active.SessionID != sessionID {
 				return fmt.Errorf("%w: conversation already bound to %s", ErrBindingConflict, active.SessionID)
+			}
+			if active.SessionName == "" && sessionName != "" {
+				if err := s.store.Update(active.ID, beads.UpdateOpts{
+					Labels:   []string{bindingSessionNameLabel(sessionName)},
+					Metadata: map[string]string{"session_name": sessionName},
+				}); err != nil {
+					return fmt.Errorf("backfill session name on binding %s: %w", active.ID, err)
+				}
 			}
 			if err := s.updateBindingMetadata(*active, input.Metadata, input.ExpiresAt, now); err != nil {
 				return err
@@ -136,10 +147,14 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 			return nil
 		}
 		nextGeneration := nextBindingGeneration(history)
+		labels := []string{"gc:extmsg-binding", labelBindingBase, bindingConversationLabel(ref), bindingSessionLabel(sessionID)}
+		if sessionName != "" {
+			labels = append(labels, bindingSessionNameLabel(sessionName))
+		}
 		b, err := s.store.Create(beads.Bead{
 			Title:  conversationTitle(ref),
 			Type:   "task",
-			Labels: []string{"gc:extmsg-binding", labelBindingBase, bindingConversationLabel(ref), bindingSessionLabel(sessionID)},
+			Labels: labels,
 			Metadata: encodeMetadataFields(input.Metadata, map[string]string{
 				"schema_version":         strconv.Itoa(schemaVersion),
 				"scope_id":               ref.ScopeID,
@@ -149,6 +164,7 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 				"parent_conversation_id": ref.ParentConversationID,
 				"conversation_kind":      string(ref.Kind),
 				"session_id":             sessionID,
+				"session_name":           sessionName,
 				"binding_generation":     strconv.FormatInt(nextGeneration, 10),
 				"bound_at":               formatTime(now),
 				"expires_at":             formatTimePtr(input.ExpiresAt),
@@ -192,7 +208,28 @@ func (s *bindingService) ResolveByConversation(ctx context.Context, ref Conversa
 	if err != nil {
 		return nil, err
 	}
-	return resolveActiveBinding(ctx, s.locks, s.store, s.delivery, s.transcript, ref, timeNow())
+	record, err := resolveActiveBinding(ctx, s.locks, s.store, s.delivery, s.transcript, ref, timeNow())
+	if err != nil || record == nil {
+		return record, err
+	}
+	overlayLiveSession(s.store, record)
+	return record, nil
+}
+
+// overlayLiveSession re-points a binding record at its session's current live
+// bead when the stored session_id has gone stale across a respawn. It mutates
+// only the in-memory copy — persistent healing is the binding reaper's job —
+// and is a no-op when the binding has no recorded session name or the name has
+// no live owner (a genuinely dead session, which the reaper clears).
+func overlayLiveSession(store beads.Store, record *SessionBindingRecord) {
+	if record.SessionName == "" {
+		return
+	}
+	liveID, err := resolveLiveSessionID(store, record.SessionName)
+	if err != nil || liveID == "" {
+		return
+	}
+	record.SessionID = liveID
 }
 
 func (s *bindingService) ListBySession(ctx context.Context, sessionID string) ([]SessionBindingRecord, error) {
@@ -752,6 +789,7 @@ func decodeBindingBead(b beads.Bead) (SessionBindingRecord, error) {
 		SchemaVersion:     parseInt(b.Metadata, "schema_version"),
 		Conversation:      ref,
 		SessionID:         strings.TrimSpace(b.Metadata["session_id"]),
+		SessionName:       strings.TrimSpace(b.Metadata["session_name"]),
 		Status:            recordStatus(b),
 		BoundAt:           boundAt,
 		ExpiresAt:         expiresAt,

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -218,9 +218,14 @@ func (s *bindingService) ResolveByConversation(ctx context.Context, ref Conversa
 
 // overlayLiveSession re-points a binding record at its session's current live
 // bead when the stored session_id has gone stale across a respawn. It mutates
-// only the in-memory copy — persistent healing is the binding reaper's job —
-// and is a no-op when the binding has no recorded session name or the name has
-// no live owner (a genuinely dead session, which the reaper clears).
+// only the in-memory copy — persistent healing is the binding reaper's job.
+//
+// Both layers are intentional: this overlay corrects routing immediately after
+// a respawn, before the next reconciler tick arrives. Without it, inbound
+// traffic would resolve to the dead bead ID for up to one full reconciler
+// interval. The reaper's persistent write is still needed to update the
+// labelBindingSessionPrefix label (indexed on the volatile ID) and keep
+// label-based lookups correct across ticks.
 func overlayLiveSession(store beads.Store, record *SessionBindingRecord) {
 	if record.SessionName == "" {
 		return

--- a/internal/extmsg/binding_survival_test.go
+++ b/internal/extmsg/binding_survival_test.go
@@ -1,0 +1,320 @@
+package extmsg
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// makeSessionBead creates an open session bead carrying the given stable
+// session name, mirroring how the session lifecycle records identity. It
+// returns the volatile bead ID, which changes across respawn.
+func makeSessionBead(t *testing.T, store beads.Store, name string) string {
+	t.Helper()
+	b, err := store.Create(beads.Bead{
+		Title:    "session " + name,
+		Type:     session.BeadType,
+		Labels:   []string{session.LabelSession},
+		Metadata: map[string]string{"session_name": name},
+	})
+	if err != nil {
+		t.Fatalf("create session bead %q: %v", name, err)
+	}
+	return b.ID
+}
+
+// respawn closes the session bead at oldID and mints a fresh one under the
+// same name, modeling a crash-and-restart that changes the bead ID.
+func respawn(t *testing.T, store beads.Store, oldID, name string) string {
+	t.Helper()
+	if err := store.Close(oldID); err != nil {
+		t.Fatalf("close session bead %s: %v", oldID, err)
+	}
+	return makeSessionBead(t, store, name)
+}
+
+func TestBindStoresStableSessionName(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	ref := testConversationRef()
+
+	sessionID := makeSessionBead(t, store, "gc-pl")
+	binding, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    sessionID,
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if binding.SessionName != "gc-pl" {
+		t.Fatalf("SessionName = %q, want %q", binding.SessionName, "gc-pl")
+	}
+	bead, err := store.Get(binding.ID)
+	if err != nil {
+		t.Fatalf("get binding bead: %v", err)
+	}
+	if bead.Metadata["session_name"] != "gc-pl" {
+		t.Fatalf("metadata session_name = %q, want %q", bead.Metadata["session_name"], "gc-pl")
+	}
+	if !slices.Contains(bead.Labels, bindingSessionNameLabel("gc-pl")) {
+		t.Fatalf("binding labels %v missing session-name label %q", bead.Labels, bindingSessionNameLabel("gc-pl"))
+	}
+}
+
+func TestResolveByConversationOverlaysLiveSessionAfterRespawn(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	ref := testConversationRef()
+
+	oldID := makeSessionBead(t, store, "gc-pl")
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    oldID,
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+
+	newID := respawn(t, store, oldID, "gc-pl")
+
+	got, err := svc.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ResolveByConversation returned nil after respawn")
+	}
+	if got.SessionID != newID {
+		t.Fatalf("SessionID = %q, want live respawned bead %q (overlay failed)", got.SessionID, newID)
+	}
+}
+
+func TestResolveByConversationLeavesStaleIDWhenSessionGone(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	ref := testConversationRef()
+
+	oldID := makeSessionBead(t, store, "gc-pl")
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    oldID,
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	// No respawn — the session is just gone.
+	if err := store.Close(oldID); err != nil {
+		t.Fatalf("close session: %v", err)
+	}
+
+	got, err := svc.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if got == nil || got.SessionID != oldID {
+		t.Fatalf("expected binding to retain stale id %q for the reaper to clear, got %+v", oldID, got)
+	}
+}
+
+func TestReapStaleBindingsReassignsToRespawnedSession(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	ref := testConversationRef()
+
+	oldID := makeSessionBead(t, store, "gc-pl")
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    oldID,
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	newID := respawn(t, store, oldID, "gc-pl")
+
+	stats, err := ReapStaleBindings(context.Background(), store, testNow())
+	if err != nil {
+		t.Fatalf("ReapStaleBindings: %v", err)
+	}
+	if stats.Scanned != 1 || stats.Reassigned != 1 || stats.Cleared != 0 {
+		t.Fatalf("stats = %+v, want Scanned=1 Reassigned=1 Cleared=0", stats)
+	}
+
+	// The persisted binding now points at the live bead even without the
+	// read-time overlay: re-resolving by the dead name resolver would fail,
+	// so prove the stored session_id was healed.
+	got, err := svc.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if got == nil || got.SessionID != newID {
+		t.Fatalf("after reap, SessionID = %v, want %q", got, newID)
+	}
+	bead, err := store.Get(got.ID)
+	if err != nil {
+		t.Fatalf("get binding bead: %v", err)
+	}
+	if bead.Metadata["session_id"] != newID {
+		t.Fatalf("stored session_id = %q, want healed %q", bead.Metadata["session_id"], newID)
+	}
+}
+
+func TestReapStaleBindingsClearsDeadNamedSession(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	ref := testConversationRef()
+
+	oldID := makeSessionBead(t, store, "gc-pl")
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    oldID,
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	// Session retired with no replacement: the name has no live owner.
+	if err := store.Close(oldID); err != nil {
+		t.Fatalf("close session: %v", err)
+	}
+
+	stats, err := ReapStaleBindings(context.Background(), store, testNow())
+	if err != nil {
+		t.Fatalf("ReapStaleBindings: %v", err)
+	}
+	if stats.Scanned != 1 || stats.Reassigned != 0 || stats.Cleared != 1 {
+		t.Fatalf("stats = %+v, want Scanned=1 Reassigned=0 Cleared=1", stats)
+	}
+	got, err := svc.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected binding cleared, got %+v", got)
+	}
+}
+
+func TestReapStaleBindingsClearsLegacyBindingWithClosedBead(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	ref := testConversationRef()
+
+	// Legacy binding: target session bead carries no stable session_name.
+	legacy, err := store.Create(beads.Bead{
+		Title:  "session legacy",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	})
+	if err != nil {
+		t.Fatalf("create legacy session bead: %v", err)
+	}
+	binding, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    legacy.ID,
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if binding.SessionName != "" {
+		t.Fatalf("legacy binding unexpectedly recorded a name: %q", binding.SessionName)
+	}
+
+	// While the bead is open the reaper must leave the legacy binding alone.
+	stats, err := ReapStaleBindings(context.Background(), store, testNow())
+	if err != nil {
+		t.Fatalf("ReapStaleBindings (open): %v", err)
+	}
+	if stats.Cleared != 0 {
+		t.Fatalf("reaper cleared a live legacy binding: %+v", stats)
+	}
+
+	if err := store.Close(legacy.ID); err != nil {
+		t.Fatalf("close legacy session: %v", err)
+	}
+	stats, err = ReapStaleBindings(context.Background(), store, testNow())
+	if err != nil {
+		t.Fatalf("ReapStaleBindings (closed): %v", err)
+	}
+	if stats.Cleared != 1 {
+		t.Fatalf("stats = %+v, want Cleared=1 after legacy session closed", stats)
+	}
+}
+
+// TestBindBackfillsSessionNameOnLegacyBinding verifies that calling Bind on a
+// conversation whose active binding has no session_name backfills the name from
+// the session bead, turning a legacy binding into a respawn-survivable one.
+// The scenario: binding was created before the session bead carried a stable
+// session_name; a later Bind call on the same conversation+session triggers the
+// backfill when the session bead has since been updated with a name.
+func TestBindBackfillsSessionNameOnLegacyBinding(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	ref := testConversationRef()
+
+	// Create a session bead without session_name (pre-fix format).
+	legacyBead, err := store.Create(beads.Bead{
+		Title:  "session gc-pl",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	})
+	if err != nil {
+		t.Fatalf("create legacy session bead: %v", err)
+	}
+
+	// Initial Bind: session bead has no session_name, so SessionName is empty.
+	binding, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    legacyBead.ID,
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("initial Bind: %v", err)
+	}
+	if binding.SessionName != "" {
+		t.Fatalf("legacy binding should have empty SessionName, got %q", binding.SessionName)
+	}
+
+	// Upgrade the session bead in-place to carry the stable session_name,
+	// simulating a system that back-patches existing session beads.
+	if err := store.Update(legacyBead.ID, beads.UpdateOpts{
+		Metadata: map[string]string{"session_name": "gc-pl"},
+	}); err != nil {
+		t.Fatalf("upgrade session bead: %v", err)
+	}
+
+	// Re-Bind: same conversation + same session bead (allowed — not a conflict).
+	// Now sessionNameForSelector finds "gc-pl" and the backfill path fires.
+	upgraded, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    legacyBead.ID,
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("rebind for backfill: %v", err)
+	}
+	if upgraded.SessionName != "gc-pl" {
+		t.Fatalf("backfilled SessionName = %q, want %q", upgraded.SessionName, "gc-pl")
+	}
+
+	// Verify the persisted binding bead now carries the session_name metadata.
+	bead, err := store.Get(binding.ID)
+	if err != nil {
+		t.Fatalf("get binding bead: %v", err)
+	}
+	if bead.Metadata["session_name"] != "gc-pl" {
+		t.Fatalf("stored session_name = %q, want %q", bead.Metadata["session_name"], "gc-pl")
+	}
+	if !slices.Contains(bead.Labels, bindingSessionNameLabel("gc-pl")) {
+		t.Fatalf("backfilled binding labels %v missing session-name label %q", bead.Labels, bindingSessionNameLabel("gc-pl"))
+	}
+}

--- a/internal/extmsg/labels.go
+++ b/internal/extmsg/labels.go
@@ -19,6 +19,7 @@ const (
 
 	labelBindingConversationPrefix = "extmsg:binding:conv:v1:"
 	labelBindingSessionPrefix      = "extmsg:binding:session:v1:"
+	labelBindingSessionNamePrefix  = "extmsg:binding:sessionname:v1:"
 	labelDeliveryRoutePrefix       = "extmsg:delivery:route:v1:"
 	labelDeliverySessionPrefix     = "extmsg:delivery:session:v1:"
 	labelGroupRootPrefix           = "extmsg:group:root:v1:"
@@ -47,6 +48,14 @@ func bindingConversationLabel(ref ConversationRef) string {
 
 func bindingSessionLabel(sessionID string) string {
 	return labelBindingSessionPrefix + strings.TrimSpace(sessionID)
+}
+
+// bindingSessionNameLabel labels a binding by the stable session name its
+// target session was created under. Unlike bindingSessionLabel (which keys on
+// the volatile session bead ID), this label survives respawn, so the reaper
+// can find every binding owned by a name even after the original bead closes.
+func bindingSessionNameLabel(sessionName string) string {
+	return labelBindingSessionNamePrefix + strings.TrimSpace(sessionName)
 }
 
 func deliveryRouteLabel(ref ConversationRef, sessionID string) string {

--- a/internal/extmsg/live_session.go
+++ b/internal/extmsg/live_session.go
@@ -1,0 +1,37 @@
+package extmsg
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// resolveLiveSessionID maps a stable session name to the current live session
+// bead ID, returning session.ErrSessionNotFound when no open session owns the
+// name. It is a package-level var so tests can substitute a deterministic
+// resolver without standing up real session beads (mirrors timeNow).
+var resolveLiveSessionID = session.ResolveSessionID
+
+// sessionNameForSelector resolves a bind selector (a session bead ID, alias,
+// or session name) to the stable session name recorded on the target bead.
+// Bindings store this name so they can follow the session across respawn.
+//
+// It is best-effort: on any lookup failure it returns the empty string and the
+// binding falls back to pure session-ID behavior. A non-empty result is always
+// the bead's recorded session_name, never the raw selector.
+func sessionNameForSelector(store beads.Store, selector string) string {
+	selector = strings.TrimSpace(selector)
+	if store == nil || selector == "" {
+		return ""
+	}
+	id, err := session.ResolveSessionIDAllowClosed(store, selector)
+	if err != nil {
+		return ""
+	}
+	bead, err := store.Get(id)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(bead.Metadata["session_name"])
+}

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -97,11 +97,18 @@ const (
 )
 
 // SessionBindingRecord links a conversation to a session.
+//
+// SessionID is the session bead ID this binding currently resolves to. It is
+// volatile: a session that crashes and respawns under the same name gets a
+// fresh bead ID. SessionName is the stable identity the binding was created
+// under; it survives respawn and lets ResolveByConversation and the binding
+// reaper re-point the binding at the session's current live bead.
 type SessionBindingRecord struct {
 	ID                string
 	SchemaVersion     int
 	Conversation      ConversationRef
 	SessionID         string
+	SessionName       string
 	Status            BindingStatus
 	BoundAt           time.Time
 	ExpiresAt         *time.Time


### PR DESCRIPTION
Fixes the SDK half of the extmsg respawn problem: external-message (Slack) conversation bindings were keyed in a way that did not survive a session respawn, so a respawned PL/adapter lost its bindings until manually re-bound.

**Fix:** bind conversations by **session name** so the binding survives respawn; plus a reconciler-tick reaper for the two-layer heal design.

- `fix(extmsg): bind conversations by session name so they survive respawn (gc-3mqde)` (c2e5b705f)
- `refactor(extmsg): use struct{} set for reassigned + clarify two-layer heal design` (8d5f7e3f2)

**Gates:** `make build` + `make check` PASS. The one flaky test (`TestReaperSplitSchemaQueriesUseSplitColumns`) is pre-existing, unrelated — passes in isolation and in `make check`.

Rebased onto current main.