### PR TITLE
fix(materialize-skills): extend --best-effort to resolveCity + loadCityConfig failures

### DIFF
--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -57,11 +57,19 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			cityPath, err := resolveCity()
 			if err != nil {
+				if bestEffort {
+					fmt.Fprintf(stderr, "gc internal materialize-skills: city not found: %v; skipping (best-effort)\n", err) //nolint:errcheck // best-effort stderr
+					return nil
+				}
 				fmt.Fprintf(stderr, "gc internal materialize-skills: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			cfg, err := loadCityConfig(cityPath, stderr)
 			if err != nil {
+				if bestEffort {
+					fmt.Fprintf(stderr, "gc internal materialize-skills: city config unavailable: %v; skipping (best-effort)\n", err) //nolint:errcheck // best-effort stderr
+					return nil
+				}
 				fmt.Fprintf(stderr, "gc internal materialize-skills: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
@@ -128,7 +136,7 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&workdir, "workdir", "", "agent working directory (skills materialize into workdir/.<vendor>/skills/)")
 	cmd.Flags().StringVar(&sharedCatalogSnapshot, "shared-catalog-snapshot", "", "base64-encoded shared catalog snapshot from the controller")
 	cmd.Flags().StringVar(&sharedCatalogSnapshotFile, "shared-catalog-snapshot-file", "", "path to a file containing the base64-encoded shared catalog snapshot (preferred over --shared-catalog-snapshot for large catalogs to avoid argv/env limits)")
-	cmd.Flags().BoolVar(&bestEffort, "best-effort", false, "warn and exit 0 instead of failing when the agent can't be resolved; used by pre_start so an unresolvable session identity (named/wisp expansion) doesn't make session start fatal")
+	cmd.Flags().BoolVar(&bestEffort, "best-effort", false, "warn and exit 0 instead of failing when city path, city config, or agent identity can't be resolved; used by pre_start so session startup is non-fatal when city state is transiently unavailable (dirty import cache, missing city.toml) or the session identity can't be matched to a config template")
 	return cmd
 }
 

--- a/cmd/gc/cmd_internal_materialize_skills_test.go
+++ b/cmd/gc/cmd_internal_materialize_skills_test.go
@@ -838,3 +838,73 @@ func TestInternalMaterializeSkillsBestEffortSkipsUnknownAgent(t *testing.T) {
 		t.Fatalf("expected a best-effort skip warning on stderr, got %q", se.String())
 	}
 }
+
+// TestInternalMaterializeSkillsBestEffortExitsZeroOnResolveCityError guards
+// the pre_start robustness fix: when the city itself can't be resolved (e.g.
+// GC_CITY unset, cwd outside any city, city directory missing), --best-effort
+// must warn and exit 0 so session start is not fatal.
+func TestInternalMaterializeSkillsBestEffortExitsZeroOnResolveCityError(t *testing.T) {
+	clearGCEnv(t)
+	// Change cwd to an isolated tempdir so all city-discovery steps fail:
+	// no GC_CITY, no GC_DIR, no registered cities (GC_HOME is also a fresh
+	// tempdir set by clearGCEnv), and the walk-up from cwd finds nothing.
+	t.Chdir(t.TempDir())
+
+	workdir := t.TempDir()
+	const agent = "some-agent"
+
+	// Direct call (no --best-effort): unresolvable city is fatal.
+	var so, se bytes.Buffer
+	if code := run([]string{"internal", "materialize-skills", "--agent", agent, "--workdir", workdir}, &so, &se); code == 0 {
+		t.Fatalf("city not found without --best-effort: got exit 0, want non-zero; stderr=%q", se.String())
+	}
+
+	// --best-effort: warn and exit 0 so pre_start is not fatal.
+	so.Reset()
+	se.Reset()
+	if code := run([]string{"internal", "materialize-skills", "--best-effort", "--agent", agent, "--workdir", workdir}, &so, &se); code != 0 {
+		t.Fatalf("city not found with --best-effort: exit %d, want 0; stderr=%q", code, se.String())
+	}
+	if !strings.Contains(se.String(), "best-effort") {
+		t.Fatalf("expected a best-effort skip warning on stderr, got %q", se.String())
+	}
+}
+
+// TestInternalMaterializeSkillsBestEffortExitsZeroOnLoadCityConfigError guards
+// the case where the city directory exists (has .gc/) but city.toml is absent
+// or unreadable. Under --best-effort this must warn and exit 0.
+func TestInternalMaterializeSkillsBestEffortExitsZeroOnLoadCityConfigError(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	// .gc/ present → passes validateCityPath; no city.toml → loadCityConfig fails.
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	workdir := t.TempDir()
+	var so, se bytes.Buffer
+	if code := run([]string{"internal", "materialize-skills", "--best-effort", "--agent", "some-agent", "--workdir", workdir}, &so, &se); code != 0 {
+		t.Fatalf("missing city.toml with --best-effort: exit %d, want 0; stderr=%q", code, se.String())
+	}
+	if !strings.Contains(se.String(), "best-effort") {
+		t.Fatalf("expected a best-effort skip warning on stderr, got %q", se.String())
+	}
+}
+
+// TestInternalMaterializeSkillsNonBestEffortFailsOnLoadCityConfigError guards
+// that the hard-fail path (no --best-effort) still returns non-zero when
+// city.toml is missing, so direct invocations get a clear error.
+func TestInternalMaterializeSkillsNonBestEffortFailsOnLoadCityConfigError(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	var so, se bytes.Buffer
+	if code := run([]string{"internal", "materialize-skills", "--agent", "some-agent", "--workdir", t.TempDir()}, &so, &se); code == 0 {
+		t.Fatalf("missing city.toml without --best-effort: got exit 0, want non-zero; stderr=%q", se.String())
+	}
+}


### PR DESCRIPTION
## What
`gc internal materialize-skills --best-effort` now skips cleanly (logs to stderr, returns nil) when `resolveCity()` or `loadCityConfig()` fail — i.e. the city is absent or its config can't be loaded — instead of erroring out. This matches the command's existing best-effort handling for the downstream materialization steps.

## Why
`--best-effort` is used in bootstrap/CI paths where the city may not yet exist or its config isn't loadable yet; those cases should be soft-skips, not hard failures. Two files (impl + test), 79 insertions.
