### PR TITLE
fix(cmd/gc): fix four pre-existing pre-commit test failures (env/CWD isolation)

### DIFF
--- a/cmd/gc/cmd_analyze_reliability_test.go
+++ b/cmd/gc/cmd_analyze_reliability_test.go
@@ -424,6 +424,7 @@ func TestResolveEventsPath_CityFlagComputesPath(t *testing.T) {
 }
 
 func TestResolveEventsPath_NoSourceReturnsError(t *testing.T) {
+	clearGCEnv(t)
 	t.Setenv("GC_CITY", "")
 	t.Setenv("GC_CITY_PATH", "")
 	t.Setenv("GC_CITY_ROOT", "")

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -315,15 +315,18 @@ func openEventsScope(apiURLOverride string, stderr io.Writer) (eventsAPIScope, i
 }
 
 func resolveEventsScope(apiURLOverride string) (eventsAPIScope, error) {
-	cityPath, cfg, err := resolveDashboardContext()
-	if err != nil {
-		return eventsAPIScope{}, err
-	}
-
-	cityName := resolvedEventsCityName(cityPath, cfg)
 	if override := strings.TrimSpace(apiURLOverride); override != "" {
 		localSupervisorAPI := matchesLocalSupervisorAPI(override)
-		cityName = resolvedExplicitEventsCityName(override, cityPath, cityName)
+		// Try local city context for display (soft fail — no-city and remote-
+		// only scenarios must both work when --api is explicit).
+		var cityPath, cityName string
+		if cp, cfg, cityErr := resolveDashboardContext(); cityErr == nil {
+			cityPath = cp
+			cityName = resolvedEventsCityName(cp, cfg)
+			if localSupervisorAPI {
+				cityName = resolvedManagedEventsCityName(cp, cityName)
+			}
+		}
 		return eventsAPIScope{
 			apiURL:             strings.TrimRight(override, "/"),
 			cityName:           cityName,
@@ -332,6 +335,13 @@ func resolveEventsScope(apiURLOverride string) (eventsAPIScope, error) {
 			localSupervisorAPI: localSupervisorAPI,
 		}, nil
 	}
+
+	cityPath, cfg, err := resolveDashboardContext()
+	if err != nil {
+		return eventsAPIScope{}, err
+	}
+
+	cityName := resolvedEventsCityName(cityPath, cfg)
 
 	if supervisorAliveHook() != 0 {
 		cityName = resolvedManagedEventsCityName(cityPath, cityName)
@@ -375,13 +385,6 @@ func resolveEventsScope(apiURLOverride string) (eventsAPIScope, error) {
 		cityPath,
 		"gc supervisor start",
 	)
-}
-
-func resolvedExplicitEventsCityName(apiURLOverride, cityPath, fallback string) string {
-	if !matchesLocalSupervisorAPI(apiURLOverride) {
-		return fallback
-	}
-	return resolvedManagedEventsCityName(cityPath, fallback)
 }
 
 func matchesLocalSupervisorAPI(apiURLOverride string) bool {

--- a/cmd/gc/cmd_events_test.go
+++ b/cmd/gc/cmd_events_test.go
@@ -80,6 +80,7 @@ func TestDoEventsSupervisorDefaultUsesTaggedJSONLItems(t *testing.T) {
 }
 
 func TestEventsJSONFlagIsSilentNoOp(t *testing.T) {
+	clearGCEnv(t)
 	t.Chdir(t.TempDir())
 
 	items := []cliWireTaggedEvent{

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -280,6 +280,9 @@ func resolveImportRoot() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if canonical, err2 := filepath.EvalSymlinks(cwd); err2 == nil {
+		cwd = canonical
+	}
 	// Explicit rig/dir signals carry user intent and outrank cwd inference:
 	// route them through the registered-city machinery first, exactly as
 	// --city does above. Only pure cwd inference may use the nearest-marker

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -2525,18 +2525,7 @@ name = "demo-pack"
 schema = 1
 `)
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Chdir(%q): %v", dir, err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Fatalf("restore cwd: %v", err)
-		}
-	})
+	t.Chdir(dir)
 
 	prevCityFlag := cityFlag
 	prevRigFlag := rigFlag
@@ -2732,18 +2721,7 @@ name = "demo-pack"
 schema = 1
 `)
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Chdir(%q): %v", dir, err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Fatalf("restore cwd: %v", err)
-		}
-	})
+	t.Chdir(dir)
 
 	prevCityFlag := cityFlag
 	prevRigFlag := rigFlag


### PR DESCRIPTION
## Summary

Fixes four pre-existing test failures that blocked `.githooks/pre-commit` via `make test-fast-parallel`. All four reproduced on a clean tree before this branch.

- **`TestEventsJSONFlagIsSilentNoOp`** / **`TestResolveEventsPath_NoSourceReturnsError`**: added `clearGCEnv(t)` env isolation; fixed `resolveEventsScope` to short-circuit before city discovery when `--api` is provided (avoiding the `city.toml` walk-to-`/tmp`).
- **`TestResolveImportRootFallsBackToStandalonePackDir`** / **`TestImportAddCommandWorksInStandalonePackDir`**: replaced `os.Chdir` + manual cleanup with `t.Chdir` to eliminate a CWD race with parallel tests.

## Test plan

- [x] All four target tests pass
- [x] Related reload/trace tests pass
- [x] `go test ./cmd/gc/ -race -count=1 -timeout 300s` (1276 tests) passes

**Out of scope:** a separate pre-existing data race in `TestCityRuntimeRun_RetriesConvergenceStartupUntilIndexPopulated` (`cr.convScopes` written without a mutex) reproduces on a clean tree and is fixed in a separate PR.
