### PR TITLE
refactor(cmd/gc): fold template_overrides parses onto session.ParseTemplateOverrides; declare opt_ prefix (ga-9s1a4a)

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -881,32 +881,26 @@ func buildPreparedStartWithWorkDirResolver(
 			agentCfg.Env[startupPromptDeliveredEnv] = "1"
 		}
 	}
-	// Initial message: append to prompt on first start only.
+	// Initial message: append to prompt on first start only, reusing the
+	// overrides parsed once by parseSessionTemplateOverridesForLaunch above.
 	// Schema overrides were already applied in the block above (before coreHash).
 	// resolveSessionCommand only adds --resume/--session-id which are not schema
 	// flags, so the overrides don't need to be re-applied.
-	if raw := session.Metadata["template_overrides"]; raw != "" {
-		var overrides map[string]string
-		if err := json.Unmarshal([]byte(raw), &overrides); err == nil {
-			firstStart := session.Metadata["started_config_hash"] == ""
-			forceFresh := session.Metadata["wake_mode"] == "fresh"
-			if msg, ok := overrides["initial_message"]; ok && msg != "" && (firstStart || forceFresh) {
-				if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "none" {
-					agentCfg.Nudge = appendInitialMessageToStartupNudge(agentCfg.Nudge, msg)
-				} else {
-					existing := ""
-					if agentCfg.PromptSuffix != "" {
-						parts := shellquote.Split(agentCfg.PromptSuffix)
-						if len(parts) > 0 {
-							existing = parts[0]
-						}
-					}
-					if existing != "" {
-						agentCfg.PromptSuffix = shellquote.Quote(existing + "\n\n---\n\nUser message:\n" + msg)
-					} else {
-						agentCfg.PromptSuffix = shellquote.Quote(msg)
-					}
+	if msg, ok := sessionOverrides["initial_message"]; ok && msg != "" && (firstStart || forceFresh) {
+		if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "none" {
+			agentCfg.Nudge = appendInitialMessageToStartupNudge(agentCfg.Nudge, msg)
+		} else {
+			existing := ""
+			if agentCfg.PromptSuffix != "" {
+				parts := shellquote.Split(agentCfg.PromptSuffix)
+				if len(parts) > 0 {
+					existing = parts[0]
 				}
+			}
+			if existing != "" {
+				agentCfg.PromptSuffix = shellquote.Quote(existing + "\n\n---\n\nUser message:\n" + msg)
+			} else {
+				agentCfg.PromptSuffix = shellquote.Quote(msg)
 			}
 		}
 	}
@@ -955,12 +949,8 @@ func parseSessionTemplateOverridesForLaunch(session *beads.Bead) map[string]stri
 	if session == nil {
 		return nil
 	}
-	rawOverrides := strings.TrimSpace(session.Metadata["template_overrides"])
-	if rawOverrides == "" {
-		return nil
-	}
-	var overrides map[string]string
-	if err := json.Unmarshal([]byte(rawOverrides), &overrides); err != nil {
+	overrides, err := sessionpkg.ParseTemplateOverrides(session.Metadata)
+	if err != nil {
 		log.Printf("session %s: invalid template_overrides JSON: %v", session.ID, err)
 		return nil
 	}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/api"
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
@@ -3438,12 +3439,11 @@ func applyTemplateOverridesToConfig(agentCfg *runtime.Config, session beads.Bead
 	if agentCfg == nil {
 		return
 	}
-	rawOvr := session.Metadata["template_overrides"]
-	if rawOvr == "" || tp.ResolvedProvider == nil || len(tp.ResolvedProvider.OptionsSchema) == 0 {
+	if tp.ResolvedProvider == nil || len(tp.ResolvedProvider.OptionsSchema) == 0 {
 		return
 	}
-	var ovr map[string]string
-	if err := json.Unmarshal([]byte(rawOvr), &ovr); err != nil || len(ovr) == 0 {
+	ovr, err := sessionpkg.ParseTemplateOverrides(session.Metadata)
+	if err != nil || len(ovr) == 0 {
 		return
 	}
 	fullOptions := make(map[string]string)
@@ -3748,10 +3748,10 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 	return ""
 }
 
-const dispatchOptionMetadataPrefix = "opt_"
-
+// dispatchOptionMetadataKey returns the bead-metadata key carrying a
+// per-dispatch provider option choice for the given OptionsSchema key.
 func dispatchOptionMetadataKey(key string) string {
-	return dispatchOptionMetadataPrefix + key
+	return beadmeta.OptionMetadataPrefix + key
 }
 
 // resolveTaskOptionOverrides returns provider option choices requested by the

--- a/cmd/gc/session_template_overrides_test.go
+++ b/cmd/gc/session_template_overrides_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/shellquote"
+)
+
+// Characterization tests for the template_overrides parse seams folded onto
+// session.ParseTemplateOverrides (ga-9s1a4a). Each case pins the observable
+// result for the same raw metadata value, including error inputs, so the fold
+// is provably behavior-preserving.
+
+func TestApplyTemplateOverridesToConfig_ParseSeam(t *testing.T) {
+	const baseCommand = "claude"
+	tests := []struct {
+		name        string
+		metadata    map[string]string
+		provider    *config.ResolvedProvider
+		wantCommand string
+	}{
+		{name: "nil metadata", metadata: nil, provider: optionSchemaProvider(), wantCommand: baseCommand},
+		{name: "empty value", metadata: map[string]string{"template_overrides": ""}, provider: optionSchemaProvider(), wantCommand: baseCommand},
+		{name: "whitespace only", metadata: map[string]string{"template_overrides": "   "}, provider: optionSchemaProvider(), wantCommand: baseCommand},
+		{name: "invalid json", metadata: map[string]string{"template_overrides": "{not json"}, provider: optionSchemaProvider(), wantCommand: baseCommand},
+		{name: "empty object", metadata: map[string]string{"template_overrides": "{}"}, provider: optionSchemaProvider(), wantCommand: baseCommand},
+		{name: "json null", metadata: map[string]string{"template_overrides": "null"}, provider: optionSchemaProvider(), wantCommand: baseCommand},
+		{name: "nil provider", metadata: map[string]string{"template_overrides": `{"model":"sonnet"}`}, provider: nil, wantCommand: baseCommand},
+		{
+			name:     "initial_message only resolves no schema flags",
+			metadata: map[string]string{"template_overrides": `{"initial_message":"hi"}`},
+			provider: optionSchemaProvider(),
+			// initial_message is excluded from option resolution and there are
+			// no effective defaults, so the command stays untouched.
+			wantCommand: baseCommand,
+		},
+		{
+			name:        "unknown option key is rejected whole",
+			metadata:    map[string]string{"template_overrides": `{"bogus":"x"}`},
+			provider:    optionSchemaProvider(),
+			wantCommand: baseCommand,
+		},
+		{
+			name:        "valid override replaces schema flags",
+			metadata:    map[string]string{"template_overrides": `{"model":"sonnet"}`},
+			provider:    optionSchemaProvider(),
+			wantCommand: "claude --model claude-sonnet-4-6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agentCfg := runtime.Config{Command: baseCommand}
+			session := beads.Bead{Metadata: tt.metadata}
+			tp := TemplateParams{Command: baseCommand, ResolvedProvider: tt.provider}
+			applyTemplateOverridesToConfig(&agentCfg, session, tp)
+			if agentCfg.Command != tt.wantCommand {
+				t.Fatalf("Command = %q, want %q", agentCfg.Command, tt.wantCommand)
+			}
+		})
+	}
+}
+
+func TestApplyTemplateOverridesToConfig_DefaultsPreservedAlongsideOverride(t *testing.T) {
+	provider := optionSchemaProvider()
+	provider.EffectiveDefaults = map[string]string{"effort": "low"}
+	agentCfg := runtime.Config{Command: "claude"}
+	session := beads.Bead{Metadata: map[string]string{"template_overrides": `{"model":"sonnet"}`}}
+	tp := TemplateParams{Command: "claude", ResolvedProvider: provider}
+	applyTemplateOverridesToConfig(&agentCfg, session, tp)
+	want := "claude --model claude-sonnet-4-6 --effort low"
+	if agentCfg.Command != want {
+		t.Fatalf("Command = %q, want %q", agentCfg.Command, want)
+	}
+}
+
+func TestParseSessionTemplateOverridesForLaunch_ParseSeam(t *testing.T) {
+	tests := []struct {
+		name     string
+		session  *beads.Bead
+		want     map[string]string
+		wantNone bool
+	}{
+		{name: "nil session", session: nil, wantNone: true},
+		{name: "nil metadata", session: &beads.Bead{ID: "gc-1"}, wantNone: true},
+		{name: "empty value", session: &beads.Bead{ID: "gc-1", Metadata: map[string]string{"template_overrides": ""}}, wantNone: true},
+		{name: "whitespace only", session: &beads.Bead{ID: "gc-1", Metadata: map[string]string{"template_overrides": " \t"}}, wantNone: true},
+		{name: "json null", session: &beads.Bead{ID: "gc-1", Metadata: map[string]string{"template_overrides": "null"}}, wantNone: true},
+		// Empty objects and parse failures are equivalent to "no overrides"
+		// for every caller (len checks, range loops, key lookups), so the
+		// pin is len==0, not nil-ness.
+		{name: "empty object", session: &beads.Bead{ID: "gc-1", Metadata: map[string]string{"template_overrides": "{}"}}, wantNone: true},
+		{name: "invalid json", session: &beads.Bead{ID: "gc-1", Metadata: map[string]string{"template_overrides": "{not json"}}, wantNone: true},
+		{name: "non-string value", session: &beads.Bead{ID: "gc-1", Metadata: map[string]string{"template_overrides": `{"model":1}`}}, wantNone: true},
+		{
+			name:    "valid object retains initial_message",
+			session: &beads.Bead{ID: "gc-1", Metadata: map[string]string{"template_overrides": `{"model":"sonnet","initial_message":"hi"}`}},
+			want:    map[string]string{"model": "sonnet", "initial_message": "hi"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSessionTemplateOverridesForLaunch(tt.session)
+			if tt.wantNone {
+				if len(got) != 0 {
+					t.Fatalf("parseSessionTemplateOverridesForLaunch() = %v, want no overrides", got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseSessionTemplateOverridesForLaunch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDispatchOptionMetadataKeyPinned locks the per-dispatch option metadata
+// key shape to the declared beadmeta prefix: work and session beads carry
+// provider option choices as opt_<OptionsSchema key>.
+func TestDispatchOptionMetadataKeyPinned(t *testing.T) {
+	if got := dispatchOptionMetadataKey("model"); got != "opt_model" {
+		t.Fatalf("dispatchOptionMetadataKey(model) = %q, want %q", got, "opt_model")
+	}
+	if got := dispatchOptionMetadataKey("effort"); got != "opt_effort" {
+		t.Fatalf("dispatchOptionMetadataKey(effort) = %q, want %q", got, "opt_effort")
+	}
+}
+
+// TestBuildPreparedStart_InitialMessageParseSeam pins the launch-path
+// initial_message behavior across the parse fold: a malformed payload is
+// ignored without failing the start, and a valid payload applies both the
+// schema override and the first-start prompt-suffix message from one parse.
+func TestBuildPreparedStart_InitialMessageParseSeam(t *testing.T) {
+	newCandidate := func(t *testing.T, store beads.Store, rawOverrides string) startCandidate {
+		t.Helper()
+		session, err := store.Create(beads.Bead{
+			Title:  "worker",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"session_name":       "worker",
+				"template":           "worker",
+				"state":              "creating",
+				"generation":         "1",
+				"instance_token":     "tok-worker",
+				"template_overrides": rawOverrides,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Create(session): %v", err)
+		}
+		return startCandidate{
+			session: &session,
+			tp: TemplateParams{
+				TemplateName:     "worker",
+				SessionName:      "worker",
+				Command:          "claude",
+				Prompt:           "startup prompt",
+				ResolvedProvider: optionSchemaProvider(),
+			},
+		}
+	}
+
+	t.Run("invalid json ignored without failing start", func(t *testing.T) {
+		store := beads.NewMemStore()
+		prepared, err := buildPreparedStart(newCandidate(t, store, "{not json"), &config.City{}, store)
+		if err != nil {
+			t.Fatalf("buildPreparedStart: %v", err)
+		}
+		if prepared.cfg.PromptSuffix != shellquote.Quote("startup prompt") {
+			t.Fatalf("PromptSuffix = %q, want base prompt only", prepared.cfg.PromptSuffix)
+		}
+		if strings.Contains(prepared.cfg.Command, "--model") {
+			t.Fatalf("Command = %q, want no schema flags from malformed overrides", prepared.cfg.Command)
+		}
+	})
+
+	t.Run("valid overrides apply schema flag and initial message", func(t *testing.T) {
+		store := beads.NewMemStore()
+		prepared, err := buildPreparedStart(newCandidate(t, store, `{"model":"sonnet","initial_message":"hello from the user"}`), &config.City{}, store)
+		if err != nil {
+			t.Fatalf("buildPreparedStart: %v", err)
+		}
+		if !strings.Contains(prepared.cfg.Command, "--model claude-sonnet-4-6") {
+			t.Fatalf("Command = %q, want --model claude-sonnet-4-6", prepared.cfg.Command)
+		}
+		want := shellquote.Quote("startup prompt\n\n---\n\nUser message:\nhello from the user")
+		if prepared.cfg.PromptSuffix != want {
+			t.Fatalf("PromptSuffix = %q, want %q", prepared.cfg.PromptSuffix, want)
+		}
+	})
+}

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -187,6 +187,15 @@ const (
 	LegacyWorkDirMetadataKey = "work_dir"
 )
 
+// OptionMetadataPrefix is the dynamic non-"gc."-prefixed key prefix under
+// which provider option choices are stored as opt_<OptionsSchema key> (e.g.
+// opt_model, opt_effort) on session and work beads. The suffix is open-world
+// (a pack-authored OptionsSchema key), so it is declared as a prefix, not
+// enumerated — the non-gc sibling of FormulaVarPrefix. Like the directory
+// keys above, it is not in KnownMetadataPrefixes because the drift guard's
+// key-shape rule only covers the gc. namespace.
+const OptionMetadataPrefix = "opt_"
+
 // KnownMetadataKeys lists every engine-owned bead-metadata key this package
 // declares. The guard test asserts every gc.* metadata literal used in non-test
 // Go resolves to a member of this slice (or a KnownMetadataPrefixes entry).

--- a/internal/beadmeta/keys_test.go
+++ b/internal/beadmeta/keys_test.go
@@ -62,6 +62,7 @@ func TestPinnedValues(t *testing.T) {
 		ExecutionRoutedToMetadataKey: "gc.execution_routed_to",
 		FormulaVarPrefix:             "gc.var.",
 		Namespace:                    "gc.",
+		OptionMetadataPrefix:         "opt_",
 	}
 	for got, want := range pinned {
 		if got != want {

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
@@ -88,7 +89,7 @@ func ResolveOptions(schema []ProviderOption, options map[string]string, effectiv
 		if value, ok := options[opt.Key]; ok {
 			choice := findChoice(opt.Choices, value)
 			extraArgs = append(extraArgs, choice.FlagArgs...)
-			metadata["opt_"+opt.Key] = value
+			metadata[beadmeta.OptionMetadataPrefix+opt.Key] = value
 		} else {
 			// Use effective default, falling back to schema default.
 			defValue := effectiveDefaults[opt.Key]

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/pathutil"
@@ -1220,7 +1221,7 @@ func (m *Manager) UpdateTemplateOverrides(id string, updates map[string]string) 
 			if key == "initial_message" {
 				continue
 			}
-			metadata["opt_"+key] = value
+			metadata[beadmeta.OptionMetadataPrefix+key] = value
 		}
 		if err := m.store.SetMetadataBatch(id, metadata); err != nil {
 			return err

--- a/internal/session/template_overrides_test.go
+++ b/internal/session/template_overrides_test.go
@@ -1,0 +1,58 @@
+package session
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestParseTemplateOverrides pins the shared template_overrides parse contract
+// every read site relies on (manager resume replay, API runtime projections,
+// cmd/gc launch and config-drift paths): absent, blank, JSON-null, and empty
+// objects normalize to nil with no error; malformed payloads surface an error
+// naming the metadata key; valid objects round-trip unchanged.
+func TestParseTemplateOverrides(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     map[string]string
+		wantErr  bool
+	}{
+		{name: "nil metadata", metadata: nil},
+		{name: "missing key", metadata: map[string]string{"state": "asleep"}},
+		{name: "empty value", metadata: map[string]string{"template_overrides": ""}},
+		{name: "whitespace only", metadata: map[string]string{"template_overrides": " \n\t "}},
+		{name: "json null", metadata: map[string]string{"template_overrides": "null"}},
+		{name: "empty object", metadata: map[string]string{"template_overrides": "{}"}},
+		{name: "invalid json", metadata: map[string]string{"template_overrides": "{not json"}, wantErr: true},
+		{name: "non-string value", metadata: map[string]string{"template_overrides": `{"model":1}`}, wantErr: true},
+		{
+			name:     "valid object",
+			metadata: map[string]string{"template_overrides": `{"model":"sonnet","initial_message":"hi"}`},
+			want:     map[string]string{"model": "sonnet", "initial_message": "hi"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTemplateOverrides(tt.metadata)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseTemplateOverrides() = %v, want error", got)
+				}
+				if !strings.Contains(err.Error(), "template_overrides") {
+					t.Fatalf("error %q does not name the metadata key", err)
+				}
+				if got != nil {
+					t.Fatalf("ParseTemplateOverrides() = %v on error, want nil", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTemplateOverrides(): %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ParseTemplateOverrides() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The two collision-free cmd/gc vocabulary slices deferred from PR #3382 (`ga-9s1a4a`), kept surgical because these files are the worker-boundary migration's hottest surface.

- **template_overrides parsing folds onto the existing canonical helper** `session.ParseTemplateOverrides` (already used by the API and worker-handle paths — no new helper minted): the reconciler's apply-to-config parse, the launch-path parse (keeping its caller-side log policy), and the initial_message block, which now reuses the single parse already done earlier in the same function (the no-mutation invariant between the two points was verified before removing the redundant re-parse).
- **The `opt_` option-metadata prefix is declared once** as `beadmeta.OptionMetadataPrefix` and wired at all four minting sites — including two undiscovered literal concatenations in `internal/config/options.go` and `internal/session/manager.go` beyond the enumerated pair.

Behavior deltas are cosmetic only (characterization-tested): the malformed-JSON log line gains the helper's error context, `"{}"` normalizes to nil, whitespace-only values treated as absent. No hash inputs change; identical bytes written and read.

Stacked on the dispatch-correctness batch. Deliberately NOT folded: the doctor migration's inline parse (it re-marshals — not a mechanical fold).

## Testing
Characterization tests pinned against pre-refactor behavior first; full session/config/cmd-gc suites green; lint 0 issues; full fast sharded suite green at this tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
