### PR TITLE
test: pin provider escape-skip and clone family mappings

### DIFF
--- a/internal/runtime/tmux/escape_skip_test.go
+++ b/internal/runtime/tmux/escape_skip_test.go
@@ -1,0 +1,53 @@
+package tmux
+
+import "testing"
+
+// TestProviderEnvSkipsEscapeBeforeEnter pins the per-provider escape-skip
+// behavior for nudge submission. Providers in
+// providersSkippingEscapeBeforeEnter treat Escape as a destructive input
+// (dismissing menus or clearing composer state), so submits must go straight
+// to Enter; dropping a family from the skip list silently reintroduces the
+// Escape keystroke for that provider's panes.
+func TestProviderEnvSkipsEscapeBeforeEnter(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     bool
+	}{
+		{provider: "claude", want: true},
+		{provider: "codex", want: true},
+		{provider: "copilot", want: true},
+		{provider: "gemini", want: true},
+		{provider: "grok", want: true},
+		{provider: "kimi", want: true},
+		{provider: "opencode", want: true},
+		{provider: "pi", want: true},
+		{provider: "antigravity", want: true},
+		// Derived names resolve through the session-log family mapping,
+		// which matches codex/gemini/kimi/opencode/antigravity by
+		// substring. GC_PROVIDER carries the builtin-ancestor family for
+		// aliased providers, so this is belt-and-suspenders for those
+		// families.
+		{provider: "antigravity-max", want: true},
+		{provider: "codex-mini", want: true},
+		// claude has no substring case in sessionlog.ProviderFamily, so a
+		// non-exact claude-derived value falls through to the default
+		// Escape-before-Enter submit. Aliased claude providers are
+		// unaffected in practice because GC_PROVIDER is already resolved
+		// to the ancestor family "claude".
+		{provider: "claude-mini", want: false},
+		// Unknown providers keep the default Escape-before-Enter submit.
+		{provider: "", want: false},
+		{provider: "some-unknown-provider", want: false},
+	}
+	for _, tt := range tests {
+		name := tt.provider
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			if got := providerEnvSkipsEscape(tt.provider); got != tt.want {
+				t.Fatalf("providerEnvSkipsEscape(%q) = %v, want %v", tt.provider, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/worker/handle_clone_test.go
+++ b/internal/worker/handle_clone_test.go
@@ -1,0 +1,30 @@
+package worker
+
+import "testing"
+
+// TestProfileFamily pins the profile-to-family mapping used by clone and
+// continuation handling. Losing a case here silently routes that profile's
+// clone behavior through the empty-family default.
+func TestProfileFamily(t *testing.T) {
+	tests := []struct {
+		profile Profile
+		want    string
+	}{
+		{profile: ProfileClaudeTmuxCLI, want: "claude"},
+		{profile: ProfileCodexTmuxCLI, want: "codex"},
+		{profile: ProfileGeminiTmuxCLI, want: "gemini"},
+		{profile: ProfileKimiTmuxCLI, want: "kimi"},
+		{profile: ProfileOpenCodeTmuxCLI, want: "opencode"},
+		{profile: ProfilePiTmuxCLI, want: "pi"},
+		{profile: ProfileAntigravityTmuxCLI, want: "antigravity"},
+		{profile: Profile("unknown/tmux-cli"), want: ""},
+	}
+	for _, tt := range tests {
+		name := string(tt.profile)
+		t.Run(name, func(t *testing.T) {
+			if got := profileFamily(tt.profile); got != tt.want {
+				t.Fatalf("profileFamily(%q) = %q, want %q", tt.profile, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two provider-special code paths carried per-provider cases (including antigravity) with no dedicated test, surfaced by the antigravity provider compatibility audit:

- `providerEnvSkipsEscape` (`internal/runtime/tmux`): table-test every family in `providersSkippingEscapeBeforeEnter`, substring-derived names, and unknown providers. Writing it surfaced — and the test now documents — the asymmetry that `sessionlog.ProviderFamily` has no claude substring case, so a non-exact claude-derived value falls through to the default Escape-before-Enter submit. Harmless in practice (GC_PROVIDER carries the builtin-ancestor family for aliased providers via `resolvedProviderLaunchFamily`), but worth pinning rather than leaving implicit.
- `profileFamily` (`internal/worker/handle_clone.go`): table-test the profile→family mapping used by clone/continuation handling, including the empty-family default for unknown profiles.

No behavior changes; tests only. `go test ./internal/runtime/tmux ./internal/worker` and the pre-push fast suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)