### PR TITLE
fix(gc): add convScopesMu to eliminate data race on convScopes map

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -110,6 +110,7 @@ type CityRuntime struct {
 	fsPressureEpisodeLogged    bool
 
 	convScopes          map[string]*convergenceScope // nil until bead store available; keyed by rig name ("" = city/HQ)
+	convScopesMu        sync.RWMutex                 // guards convScopes map pointer
 	convergenceReqCh    chan convergenceRequest      // receives CLI commands from controller.sock
 	reloadReqCh         chan reloadRequest           // receives structured reload requests from controller.sock
 	pokeCh              chan struct{}                // non-blocking signal to trigger immediate reconciler tick
@@ -870,6 +871,14 @@ func (d *tickDebouncer) cancelPending() {
 // fired returns the channel that emits when a debounced fire is due.
 func (d *tickDebouncer) fired() <-chan struct{} {
 	return d.fireCh
+}
+
+// convScope returns the convergence scope for the given rig name under a read
+// lock so callers outside the run() goroutine can safely read the map.
+func (cr *CityRuntime) convScope(rig string) *convergenceScope {
+	cr.convScopesMu.RLock()
+	defer cr.convScopesMu.RUnlock()
+	return cr.convScopes[rig]
 }
 
 func convergenceStartupComplete(cr *CityRuntime) bool {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -5339,7 +5339,7 @@ func TestCityRuntimeRun_RetriesConvergenceStartupUntilIndexPopulated(t *testing.
 
 	deadline := time.After(5 * time.Second)
 	for {
-		if scope := cr.convScopes[""]; scope != nil && scope.adapter.activeIndex != nil {
+		if scope := cr.convScope(""); scope != nil && scope.adapter.indexReady.Load() {
 			cancel()
 			break
 		}

--- a/cmd/gc/convergence_store.go
+++ b/cmd/gc/convergence_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
@@ -19,11 +20,13 @@ import (
 // It maintains an in-memory index of active convergence beads (bead ID →
 // target agent) to avoid O(n) scans on every tick. The index is populated
 // once at startup and maintained on state transitions via SetMetadata.
-// No mutex is needed — single-writer event loop.
+// No mutex is needed — single-writer event loop. indexReady is an atomic
+// flag for safe cross-goroutine reads of the ready state (e.g. test pollers).
 type convergenceStoreAdapter struct {
 	store              beads.Store
 	formulaSearchPaths []string          // search paths for formula compilation in PourWisp
 	activeIndex        map[string]string // bead ID → target agent; nil until populateIndex
+	indexReady         atomic.Bool       // true once populateIndex has completed
 }
 
 var _ convergence.Store = (*convergenceStoreAdapter)(nil)
@@ -50,6 +53,7 @@ func (a *convergenceStoreAdapter) populateIndex() error {
 		}
 	}
 	a.activeIndex = idx
+	a.indexReady.Store(true)
 	return nil
 }
 

--- a/cmd/gc/convergence_tick.go
+++ b/cmd/gc/convergence_tick.go
@@ -87,7 +87,9 @@ func (cr *CityRuntime) initConvergenceHandler() {
 		scopes[rigName] = cr.newConvergenceScope(
 			rigName, store, rigStorePaths[rigName], cr.cfg.FormulaLayers.SearchPaths(rigName))
 	}
+	cr.convScopesMu.Lock()
 	cr.convScopes = scopes
+	cr.convScopesMu.Unlock()
 }
 
 // newConvergenceScope wires a store adapter and convergence handler for a


### PR DESCRIPTION
## Summary

- Add `convScopesMu sync.RWMutex` to `CityRuntime` to protect the `convScopes` map pointer from concurrent reads and writes across goroutines
- Lock the write in `initConvergenceHandler` and expose a safe `convScope()` getter using `RLock`
- Add `indexReady atomic.Bool` to `convergenceStoreAdapter` so external goroutines can safely observe index readiness without touching the non-atomic `activeIndex` field directly
- Update the test poll loop to use both safe accessors

## Test plan

- [x] `go test -race -run TestCityRuntimeRun_RetriesConvergenceStartupUntilIndexPopulated ./cmd/gc/` — was the reported race, now green
- [x] `go test -race -run '.*Convergence.*' ./cmd/gc/` — 37 tests green
- [x] `go test -race -timeout=300s ./cmd/gc/` — all 1078 tests green, no data races detected
- [x] `go vet ./cmd/gc/` — clean
