### PR TITLE
fix(graphroute): stamp gc.continuation_group on pool-routed graph.v2 steps

### DIFF
--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -24,6 +24,11 @@ const (
 	GraphExecutionRigContextMetaKey = beadmeta.ExecutionRigContextMetadataKey
 )
 
+// poolWorkflowContinuationGroup is the continuation group value stamped on
+// pool-routed graph.v2 steps so preassignHookContinuationGroup keeps all steps
+// of a molecule on the same pool slot (fixes #2978).
+const poolWorkflowContinuationGroup = "pool-workflow"
+
 // AgentResolver resolves an agent name to a config.Agent.
 type AgentResolver interface {
 	ResolveAgent(cfg *config.City, name, rigContext string) (config.Agent, bool)
@@ -196,6 +201,11 @@ func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding)
 	}
 	step.Metadata[beadmeta.RoutedToMetadataKey] = binding.QualifiedName
 	if binding.MetadataOnly {
+		// Pool-routed step: stamp continuation group so preassignHookContinuationGroup
+		// pre-assigns all molecule steps to the claiming slot, preventing scatter
+		// across pool slots (fixes #2978).
+		step.Metadata[beadmeta.ContinuationGroupMetadataKey] = poolWorkflowContinuationGroup
+		step.Metadata[beadmeta.SessionAffinityMetadataKey] = "require"
 		step.Assignee = ""
 		return
 	}

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -1005,3 +1005,67 @@ func TestApplyGraphControlRouteBinding_ClearsStaleFallbackMetadata(t *testing.T)
 		t.Fatalf("gc.control_dispatcher_fallback = %q, want cleared on re-decoration", got)
 	}
 }
+
+func TestApplyGraphRouteBinding_PoolRouted_StampsContinuationGroup(t *testing.T) {
+	step := &formula.RecipeStep{
+		Metadata: map[string]string{},
+	}
+	binding := GraphRouteBinding{
+		QualifiedName: "gascity/polecat",
+		MetadataOnly:  true,
+	}
+	ApplyGraphRouteBinding(step, binding)
+
+	if got := step.Metadata["gc.continuation_group"]; got != "pool-workflow" {
+		t.Errorf("gc.continuation_group = %q, want pool-workflow", got)
+	}
+	if got := step.Metadata["gc.session_affinity"]; got != "require" {
+		t.Errorf("gc.session_affinity = %q, want require", got)
+	}
+	if got := step.Metadata["gc.routed_to"]; got != "gascity/polecat" {
+		t.Errorf("gc.routed_to = %q, want gascity/polecat", got)
+	}
+	if step.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty (pool slots claim at runtime)", step.Assignee)
+	}
+}
+
+func TestApplyGraphRouteBinding_SingleSession_NoAffinityKeys(t *testing.T) {
+	step := &formula.RecipeStep{
+		Metadata: map[string]string{},
+	}
+	binding := GraphRouteBinding{
+		QualifiedName: "gascity/architect",
+		SessionName:   "gascity--architect",
+		MetadataOnly:  false,
+	}
+	ApplyGraphRouteBinding(step, binding)
+
+	if got := step.Metadata["gc.continuation_group"]; got != "" {
+		t.Errorf("gc.continuation_group = %q, want empty for single-session step", got)
+	}
+	if got := step.Metadata["gc.session_affinity"]; got != "" {
+		t.Errorf("gc.session_affinity = %q, want empty for single-session step", got)
+	}
+}
+
+func TestApplyGraphRouteBinding_PoolRouted_DoesNotSetSessionName(t *testing.T) {
+	step := &formula.RecipeStep{
+		Metadata: map[string]string{
+			"gc.session_name": "stale-session",
+			"gc.session_id":   "stale-id",
+		},
+	}
+	binding := GraphRouteBinding{
+		QualifiedName: "gascity/polecat",
+		MetadataOnly:  true,
+	}
+	ApplyGraphRouteBinding(step, binding)
+
+	if got := step.Metadata["gc.session_name"]; got != "" {
+		t.Errorf("gc.session_name = %q, want cleared for pool step", got)
+	}
+	if got := step.Metadata["gc.session_id"]; got != "" {
+		t.Errorf("gc.session_id = %q, want cleared for pool step", got)
+	}
+}

--- a/release-gates/ga-39tsop-pool-step-slot-affinity-gate.md
+++ b/release-gates/ga-39tsop-pool-step-slot-affinity-gate.md
@@ -1,0 +1,92 @@
+# Release Gate: Pool-Step Slot Affinity
+
+- Deploy bead: `ga-39tsop`
+- Source bead: `ga-85rmnq`
+- Reviewed commit: `1e0dd4cce17bb02eaaf78a43061bd47739022b7c`
+- Clean deploy branch: `builder/ga-0ht5r6`
+- PR: https://github.com/gastownhall/gascity/pull/3405
+- Gate date: 2026-06-12
+
+## Scope Correction
+
+The deploy bead named `builder/ga-frmdxd.3` as the source branch, but that
+branch carried eight unrelated emergency, doctor, API, and dashboard commits in
+addition to the reviewed graphroute fix. The reviewed graphroute patch was
+re-cut as `builder/ga-0ht5r6` and opened as PR #3405. The patch in PR #3405 is
+byte-identical to the reviewed delta from `1e0dd4cce17bb02eaaf78a43061bd47739022b7c`
+for:
+
+- `internal/graphroute/graphroute.go`
+- `internal/graphroute/graphroute_test.go`
+- `test/docsync/docsync_test.go`
+
+The release gate therefore evaluates the clean branch `builder/ga-0ht5r6`
+instead of the contaminated hook branch.
+
+## Checklist
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | `ga-85rmnq` records reviewer PASS for `1e0dd4cce17bb02eaaf78a43061bd47739022b7c`; PR #3405 carries the same reviewed patch on a clean branch. |
+| 2 | Acceptance criteria met | PASS | `ApplyGraphRouteBinding` stamps `gc.continuation_group=pool-workflow` and `gc.session_affinity=require` only in the `MetadataOnly` pool-route path. Tests cover pool-routed metadata, single-session non-stamping, and absence of session-name assignment on pool steps. No formula changes or new metadata keys were introduced. |
+| 3 | Tests pass | PASS | Focused local checks passed: `go test ./internal/graphroute/... ./test/docsync/...` and `go vet ./internal/graphroute/...`. GitHub PR #3405 is mergeable with green `CI / required`, `CI / preflight`, `CI / integration`, process shards, integration shards, Dashboard SPA, and CodeQL on head `5def1f235410e1f885a7de9d621df56831019822`. Local `make test` was run and failed only in `cmd/gc` no-city/env-isolation tests because an active `/tmp/.gc` Dolt process makes `/tmp` resolve as a city without `/tmp/city.toml`; no graphroute or docsync tests failed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes on `ga-85rmnq` report no security concerns or blocking findings. No HIGH findings are recorded on the deploy bead. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean on `builder/ga-0ht5r6` before adding this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | PR #3405 reports `MERGEABLE` / `CLEAN`; `git merge-tree origin/main HEAD` completed without conflicts. |
+| 7 | Single feature theme | PASS | The clean branch contains one commit touching only graphroute route binding/tests plus a docsync ignore entry needed for the repository's worktree layout. The contaminated branch was not used for deploy. |
+
+## Local Test Details
+
+Passed:
+
+```text
+go test ./internal/graphroute/... ./test/docsync/...
+ok github.com/gastownhall/gascity/internal/graphroute 0.045s
+ok github.com/gastownhall/gascity/test/docsync 3.497s
+```
+
+Passed:
+
+```text
+go vet ./internal/graphroute/...
+```
+
+Broad local run:
+
+```text
+make test
+observable go test: FAIL status=1 log=/tmp/gascity-test.jsonl.uWrc4S
+FAIL github.com/gastownhall/gascity/cmd/gc
+```
+
+Failed tests were limited to `cmd/gc` cases that require no city to be
+discoverable from `/tmp`, including `TestFindCity/not_found`,
+`TestDoPrimeStrictNoCity`, `TestRunDashboardServeAllowsNoCityWithSupervisor`,
+`TestRunDashboardServeAllowsNoCityWithAPIOverride`, and related import/events
+no-city checks. `lsof +D /tmp/.gc` showed an active Dolt process holding
+`/tmp/.gc/runtime/packs/dolt/dolt.log`, so the deployer did not remove or move
+that temp city state.
+
+## CI Evidence
+
+PR #3405 head `5def1f235410e1f885a7de9d621df56831019822` had these completed
+green checks before the gate file was added:
+
+- `CI / required`
+- `CI / preflight`
+- `CI / integration`
+- `Preflight / static checks`
+- `Preflight / acceptance A`
+- `Dashboard SPA`
+- `cmd/gc process / shard 1 of 12` through `cmd/gc process / shard 12 of 12`
+- `Integration / packages-core-*`, `packages-cmd-gc-*`, `packages-runtime-tmux-*`
+- `Integration / bdstore`
+- `Integration / rest-smoke-*`
+- `Integration / rest-full-*`
+- `Integration / SQLite coordination store`
+- `CodeQL`
+
+## Gate Verdict
+
+PASS. The deployable branch is the clean PR #3405 branch, not the stale
+contaminated branch named in the original deploy bead.


### PR DESCRIPTION
## What this changes

Pool-routed graph.v2 work steps now stay on the same pool slot across a multi-step workflow. `ApplyGraphRouteBinding` stamps the existing `gc.continuation_group` and `gc.session_affinity` metadata on MetadataOnly pool-routed steps, which lets the hook claim path pre-assign sibling steps to the same pool slot.

Single-session route binding behavior is unchanged. Pool-routed steps still do not get a concrete session name at route-binding time.

## Review notes

- Uses existing metadata keys: `gc.continuation_group=pool-workflow` and `gc.session_affinity=require`.
- The implementation is limited to `internal/graphroute`; there are no formula, schema, or protocol changes.
- `test/docsync` now ignores the repository's git-excluded `worktrees` directory so local worktree markdown does not trip doc coverage.

## Test plan

- [x] `go test ./internal/graphroute/... ./test/docsync/...`
- [x] `go vet ./internal/graphroute/...`
- [x] GitHub `CI / required`, `CI / preflight`, `CI / integration`, process shards, integration shards, Dashboard SPA, and CodeQL are green on the PR branch
- [x] Release gate: [`release-gates/ga-39tsop-pool-step-slot-affinity-gate.md`](release-gates/ga-39tsop-pool-step-slot-affinity-gate.md)