### PR TITLE
agent: route all StartupHints materialization through one projection with a reflective conformance guard

### DIFF
--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -747,47 +747,35 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 		}
 		env[startupPromptDeliveredEnv] = "1"
 	}
-	cfg := runtime.Config{
-		Command:      tp.Command,
-		PromptSuffix: promptSuffix,
-		PromptFlag:   promptFlag,
-		Env:          env,
-		MCPServers: func() []runtime.MCPServerConfig {
-			if tp.IsACP {
-				return tp.MCPServers
-			}
-			return nil
-		}(),
-		WorkDir:                tp.WorkDir,
-		Lifecycle:              tp.Hints.Lifecycle,
-		ReadyPromptPrefix:      tp.Hints.ReadyPromptPrefix,
-		ReadyDelayMs:           tp.Hints.ReadyDelayMs,
-		ProcessNames:           tp.Hints.ProcessNames,
-		EmitsPermissionWarning: tp.Hints.EmitsPermissionWarning,
-		AcceptStartupDialogs:   tp.Hints.AcceptStartupDialogs,
-		// ga-c4w: interactive `gc session new` sessions (session_origin=manual)
-		// resolve mouse-on so the tmux wheel drives copy-mode scrollback, even
-		// when the agent config sets no mouse_mode. This is the managed,
-		// reconciler-deferred start seam the original API-only fix missed. Scoped
-		// to manual on purpose: MouseOn is a core-fingerprint field (locked by
-		// runtime.TestConfigFingerprintIncludesMouseOn), so auto-flipping it for
-		// long-lived config-declared/named sessions would force a one-time drift
-		// restart — they follow their resolved Hints.MouseOn (mouse_mode) instead.
-		// Ephemeral pool agents are likewise mouse-off (controller-poll safety).
-		MouseOn:             tp.Hints.MouseOn || templateParamsSessionOrigin(tp) == "manual",
-		Nudge:               nudge,
-		PreStart:            tp.Hints.PreStart,
-		SessionSetup:        tp.Hints.SessionSetup,
-		SessionSetupScript:  tp.Hints.SessionSetupScript,
-		SessionLive:         tp.Hints.SessionLive,
-		ProviderName:        tp.Hints.ProviderName,
-		ProviderOverlayName: tp.Hints.ProviderOverlayName,
-		InstallAgentHooks:   tp.Hints.InstallAgentHooks,
-		PackOverlayDirs:     tp.Hints.PackOverlayDirs,
-		OverlayDir:          tp.Hints.OverlayDir,
-		CopyFiles:           tp.Hints.CopyFiles,
-		FingerprintExtra:    tp.FPExtra,
+	// Startup-hint fields project through the single StartupHints →
+	// runtime.Config mapping (agent.StartupHints.ToRuntimeConfig) so a hint
+	// added to StartupHints reaches this path automatically instead of being
+	// threaded by hand here — the gc-wuofg / gc-0tna7 field-omission class.
+	// The reflective guard is agent.TestStartupHintsToRuntimeConfigPropagatesEveryField.
+	// Caller-owned, non-hint fields and the path-specific Nudge/MouseOn
+	// overrides below are layered on top.
+	cfg := tp.Hints.ToRuntimeConfig()
+	cfg.Command = tp.Command
+	cfg.PromptSuffix = promptSuffix
+	cfg.PromptFlag = promptFlag
+	cfg.Env = env
+	if tp.IsACP {
+		cfg.MCPServers = tp.MCPServers
 	}
+	cfg.WorkDir = tp.WorkDir
+	cfg.FingerprintExtra = tp.FPExtra
+	// Prompt delivery may prepend the startup prompt to the configured nudge.
+	cfg.Nudge = nudge
+	// ga-c4w: interactive `gc session new` sessions (session_origin=manual)
+	// resolve mouse-on so the tmux wheel drives copy-mode scrollback, even
+	// when the agent config sets no mouse_mode. This is the managed,
+	// reconciler-deferred start seam the original API-only fix missed. Scoped
+	// to manual on purpose: MouseOn is a core-fingerprint field (locked by
+	// runtime.TestConfigFingerprintIncludesMouseOn), so auto-flipping it for
+	// long-lived config-declared/named sessions would force a one-time drift
+	// restart — they follow their resolved Hints.MouseOn (mouse_mode) instead.
+	// Ephemeral pool agents are likewise mouse-off (controller-poll safety).
+	cfg.MouseOn = tp.Hints.MouseOn || templateParamsSessionOrigin(tp) == "manual"
 	applyT3BridgeRuntimeConfig(tp, env)
 	return cfg
 }

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/materialize"
@@ -98,7 +99,7 @@ func workerSessionCreateHints(resolved *config.ResolvedProvider) runtime.Config 
 	if resolved == nil {
 		return runtime.Config{}
 	}
-	return runtime.Config{
+	hints := agent.StartupHints{
 		Lifecycle:              runtime.Lifecycle(resolved.Lifecycle),
 		ReadyPromptPrefix:      resolved.ReadyPromptPrefix,
 		ReadyDelayMs:           resolved.ReadyDelayMs,
@@ -113,6 +114,12 @@ func workerSessionCreateHints(resolved *config.ResolvedProvider) runtime.Config 
 		// this does not weaken controller-poll safety.
 		MouseOn: true,
 	}
+	// Project through the single StartupHints → runtime.Config mapping so this
+	// CLI create path can never silently drop a hint field the reconciler
+	// threads (gc-0tna7). It still populates only the provider-resolvable subset
+	// above; closing the remaining create-vs-resume population gap is the
+	// internal/worker.Factory follow-up.
+	return hints.ToRuntimeConfig()
 }
 
 func resolvedRuntimeMCPServersWithConfig(
@@ -548,23 +555,29 @@ func resolvedWorkerRuntimeWithConfigAndMetadata(cityPath string, cfg *config.Cit
 		}
 		sessionLive = expandSessionSetup(agentCfg.SessionLive, setupCtx)
 	}
+	// Project the resolved hint subset through the single StartupHints →
+	// runtime.Config mapping (gc-0tna7), then layer the caller-owned
+	// WorkDir/Env/MCPServers. SessionLive is resolved above (ga-vtkhi) so
+	// resumed sessions re-theme; closing the remaining create-time field gap
+	// is the internal/worker.Factory population follow-up.
+	runtimeHints := agent.StartupHints{
+		Lifecycle:              runtime.Lifecycle(resolved.Lifecycle),
+		ReadyPromptPrefix:      resolved.ReadyPromptPrefix,
+		ReadyDelayMs:           resolved.ReadyDelayMs,
+		ProcessNames:           resolved.ProcessNames,
+		EmitsPermissionWarning: resolved.EmitsPermissionWarning,
+		AcceptStartupDialogs:   resolved.AcceptStartupDialogs,
+		SessionLive:            sessionLive,
+	}.ToRuntimeConfig()
+	runtimeHints.WorkDir = workDir
+	runtimeHints.Env = sessionEnv
+	runtimeHints.MCPServers = mcpServers
 	return &worker.ResolvedRuntime{
 		Command:    command,
 		WorkDir:    workDir,
 		Provider:   resolvedWorkerRuntimeProviderLabel(resolved, transport, info),
 		SessionEnv: sessionEnv,
-		Hints: runtime.Config{
-			WorkDir:                workDir,
-			Env:                    sessionEnv,
-			Lifecycle:              runtime.Lifecycle(resolved.Lifecycle),
-			ReadyPromptPrefix:      resolved.ReadyPromptPrefix,
-			ReadyDelayMs:           resolved.ReadyDelayMs,
-			ProcessNames:           resolved.ProcessNames,
-			EmitsPermissionWarning: resolved.EmitsPermissionWarning,
-			AcceptStartupDialogs:   resolved.AcceptStartupDialogs,
-			MCPServers:             mcpServers,
-			SessionLive:            sessionLive,
-		},
+		Hints:      runtimeHints,
 		Resume: session.ProviderResume{
 			ResumeFlag:    firstNonEmptyGCString(resolved.ResumeFlag, info.ResumeFlag),
 			ResumeStyle:   firstNonEmptyGCString(resolved.ResumeStyle, info.ResumeStyle),

--- a/internal/agent/hints.go
+++ b/internal/agent/hints.go
@@ -52,3 +52,34 @@ type StartupHints struct {
 	// directory before the agent command starts.
 	CopyFiles []runtime.CopyEntry
 }
+
+// ToRuntimeConfig projects the startup hints onto a runtime.Config. It is the
+// single source for the StartupHints → runtime.Config field mapping: every
+// consumer that builds a runtime.Config from agent-level hints (the reconciler
+// create path and the CLI worker-handle paths) routes through here, so a hint
+// field added above propagates everywhere instead of being threaded one call
+// site at a time. Caller-owned, non-hint fields (Command, Env, MCPServers,
+// WorkDir, PromptSuffix/PromptFlag, FingerprintExtra) are left zero for the
+// caller to populate.
+func (h StartupHints) ToRuntimeConfig() runtime.Config {
+	return runtime.Config{
+		Lifecycle:              h.Lifecycle,
+		ReadyPromptPrefix:      h.ReadyPromptPrefix,
+		ReadyDelayMs:           h.ReadyDelayMs,
+		ProcessNames:           h.ProcessNames,
+		EmitsPermissionWarning: h.EmitsPermissionWarning,
+		AcceptStartupDialogs:   h.AcceptStartupDialogs,
+		MouseOn:                h.MouseOn,
+		Nudge:                  h.Nudge,
+		PreStart:               h.PreStart,
+		SessionSetup:           h.SessionSetup,
+		SessionSetupScript:     h.SessionSetupScript,
+		SessionLive:            h.SessionLive,
+		ProviderName:           h.ProviderName,
+		ProviderOverlayName:    h.ProviderOverlayName,
+		InstallAgentHooks:      h.InstallAgentHooks,
+		PackOverlayDirs:        h.PackOverlayDirs,
+		OverlayDir:             h.OverlayDir,
+		CopyFiles:              h.CopyFiles,
+	}
+}

--- a/internal/agent/hints_test.go
+++ b/internal/agent/hints_test.go
@@ -1,0 +1,142 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestStartupHintsToRuntimeConfigPropagatesEveryField is the anti-omission
+// guard for gc-0tna7 / gc-wuofg. It reflectively sets every StartupHints field
+// to a non-zero value and asserts ToRuntimeConfig copies each one to the
+// same-named runtime.Config field. When StartupHints grows a field and the
+// projection is not updated, this fails — instead of the field silently
+// vanishing from every consumer (the SessionLive and MouseOn regressions that
+// motivated this work).
+func TestStartupHintsToRuntimeConfigPropagatesEveryField(t *testing.T) {
+	var hints StartupHints
+	hv := reflect.ValueOf(&hints).Elem()
+	for i := 0; i < hv.NumField(); i++ {
+		setNonZero(t, hv.Type().Field(i).Name, hv.Field(i))
+	}
+
+	cfg := hints.ToRuntimeConfig()
+	cv := reflect.ValueOf(cfg)
+
+	for i := 0; i < hv.NumField(); i++ {
+		name := hv.Type().Field(i).Name
+		field := cv.FieldByName(name)
+		if !field.IsValid() {
+			t.Errorf("runtime.Config has no field %q to receive StartupHints.%s", name, name)
+			continue
+		}
+		if field.IsZero() {
+			t.Errorf("ToRuntimeConfig did not propagate StartupHints.%s (runtime.Config.%s is zero)", name, name)
+		}
+	}
+}
+
+// setNonZero assigns a distinctive non-zero value to v based on its kind,
+// covering every field kind present in StartupHints (string/defined-string,
+// int, bool, *bool, and slices).
+func setNonZero(t *testing.T, name string, v reflect.Value) {
+	t.Helper()
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString("x")
+	case reflect.Int:
+		v.SetInt(1)
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Pointer:
+		v.Set(reflect.New(v.Type().Elem()))
+	case reflect.Slice:
+		v.Set(reflect.MakeSlice(v.Type(), 1, 1))
+	default:
+		t.Fatalf("setNonZero: unhandled kind %s for StartupHints.%s — extend this helper", v.Kind(), name)
+	}
+}
+
+// TestStartupHintsToRuntimeConfigCopiesValues documents the concrete mapping
+// with readable, explicit values (complementing the reflective totality guard).
+func TestStartupHintsToRuntimeConfigCopiesValues(t *testing.T) {
+	accept := true
+	hints := StartupHints{
+		Lifecycle:              "oneshot",
+		ReadyPromptPrefix:      "> ",
+		ReadyDelayMs:           250,
+		ProcessNames:           []string{"agent-cli"},
+		EmitsPermissionWarning: true,
+		AcceptStartupDialogs:   &accept,
+		MouseOn:                true,
+		Nudge:                  "go",
+		PreStart:               []string{"mkdir -p x"},
+		SessionSetup:           []string{"echo setup"},
+		SessionSetupScript:     "/tmp/setup.sh",
+		SessionLive:            []string{"tmux set -g status on"},
+		ProviderName:           "claude",
+		ProviderOverlayName:    "claude-custom",
+		InstallAgentHooks:      []string{"gemini"},
+		PackOverlayDirs:        []string{"/pack/overlay"},
+		OverlayDir:             "/agent/overlay",
+		CopyFiles:              make([]runtime.CopyEntry, 1),
+	}
+
+	cfg := hints.ToRuntimeConfig()
+
+	if string(cfg.Lifecycle) != "oneshot" {
+		t.Errorf("Lifecycle = %q, want oneshot", cfg.Lifecycle)
+	}
+	if cfg.ReadyPromptPrefix != "> " {
+		t.Errorf("ReadyPromptPrefix = %q", cfg.ReadyPromptPrefix)
+	}
+	if cfg.ReadyDelayMs != 250 {
+		t.Errorf("ReadyDelayMs = %d", cfg.ReadyDelayMs)
+	}
+	if len(cfg.ProcessNames) != 1 || cfg.ProcessNames[0] != "agent-cli" {
+		t.Errorf("ProcessNames = %v", cfg.ProcessNames)
+	}
+	if !cfg.EmitsPermissionWarning {
+		t.Error("EmitsPermissionWarning = false, want true")
+	}
+	if cfg.AcceptStartupDialogs == nil || !*cfg.AcceptStartupDialogs {
+		t.Errorf("AcceptStartupDialogs = %v, want ptr to true", cfg.AcceptStartupDialogs)
+	}
+	if !cfg.MouseOn {
+		t.Error("MouseOn = false, want true")
+	}
+	if cfg.Nudge != "go" {
+		t.Errorf("Nudge = %q", cfg.Nudge)
+	}
+	if len(cfg.PreStart) != 1 || cfg.PreStart[0] != "mkdir -p x" {
+		t.Errorf("PreStart = %v", cfg.PreStart)
+	}
+	if len(cfg.SessionSetup) != 1 || cfg.SessionSetup[0] != "echo setup" {
+		t.Errorf("SessionSetup = %v", cfg.SessionSetup)
+	}
+	if cfg.SessionSetupScript != "/tmp/setup.sh" {
+		t.Errorf("SessionSetupScript = %q", cfg.SessionSetupScript)
+	}
+	if len(cfg.SessionLive) != 1 || cfg.SessionLive[0] != "tmux set -g status on" {
+		t.Errorf("SessionLive = %v", cfg.SessionLive)
+	}
+	if cfg.ProviderName != "claude" {
+		t.Errorf("ProviderName = %q", cfg.ProviderName)
+	}
+	if cfg.ProviderOverlayName != "claude-custom" {
+		t.Errorf("ProviderOverlayName = %q", cfg.ProviderOverlayName)
+	}
+	if len(cfg.InstallAgentHooks) != 1 || cfg.InstallAgentHooks[0] != "gemini" {
+		t.Errorf("InstallAgentHooks = %v", cfg.InstallAgentHooks)
+	}
+	if len(cfg.PackOverlayDirs) != 1 || cfg.PackOverlayDirs[0] != "/pack/overlay" {
+		t.Errorf("PackOverlayDirs = %v", cfg.PackOverlayDirs)
+	}
+	if cfg.OverlayDir != "/agent/overlay" {
+		t.Errorf("OverlayDir = %q", cfg.OverlayDir)
+	}
+	if len(cfg.CopyFiles) != 1 {
+		t.Errorf("CopyFiles len = %d, want 1", len(cfg.CopyFiles))
+	}
+}


### PR DESCRIPTION
## What

- Adds `agent.StartupHints.ToRuntimeConfig()` — a single projection of all 18 hint fields onto `runtime.Config`.
- Adds a reflective conformance test (`TestStartupHintsToRuntimeConfigPropagatesEveryField`): any future `StartupHints` field that isn't wired into the projection fails the build instead of silently vanishing at session start.
- Migrates the 3 hand-built hint-materialization sites (session reconciler + both worker-handle paths) to the shared projection.

## Why

Hand-built hint mapping has already dropped fields in practice (`SessionLive`, `MouseOn` were silently omitted on one path, surfacing as lost theme/keybindings/mouse state on respawn). A single projection plus a reflection guard makes that class of omission a compile-/test-time failure rather than a runtime mystery.

Behavior-preserving: this PR unifies the mapping only. The under-population of hints on the worker-handle paths (the user-visible respawn symptom) is intentionally left for a follow-up, since the full factory migration touches the resolveTemplate pipeline and is too risky to bundle here.

## Verification

Local (CGO_ENABLED=0): build, vet, gofmt, golangci-lint (0 issues in changed files); go test on `internal/agent`, `internal/runtime/...`, and `cmd/gc` characterization suites (templateParamsToConfig / ResolveTemplate / ResolvedWorker / WorkerSessionCreateHints, fingerprint/drift/desired-state) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)