### PR TITLE
fix(config): gc rig add preserves city.toml comments via surgical append

### DIFF
--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -537,8 +537,17 @@ func doRigAddWithResult(fs fsys.FS, cityPath, rigPath string, includes []string,
 			return config.Rig{}, 1
 		}
 
-		if err := writeCityConfigForEditFS(fs, tomlPath, nextCfg); err != nil {
-			writeRigAddRollbackError(fs, stderr, snapshots, "writing config", err)
+		var writeErr error
+		if !reAdd {
+			// Surgical append: preserve existing comments by appending only the
+			// new [[rigs]] block instead of re-serializing the whole file.
+			newRig := nextCfg.Rigs[len(nextCfg.Rigs)-1]
+			writeErr = config.AppendRigAndWriteSiteBindingsForEdit(fs, tomlPath, nextCfg, newRig)
+		} else {
+			writeErr = writeCityConfigForEditFS(fs, tomlPath, nextCfg)
+		}
+		if writeErr != nil {
+			writeRigAddRollbackError(fs, stderr, snapshots, "writing config", writeErr)
 			return config.Rig{}, 1
 		}
 	}

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -108,6 +108,48 @@ func TestDoRigAdd_Basic(t *testing.T) {
 	}
 }
 
+func TestDoRigAdd_PreservesComments(t *testing.T) {
+	cityPath := t.TempDir()
+	cityToml := `# This is a city-level rationale comment.
+[workspace]
+name = "my-city"
+
+# Pack rationale: core tools are required.
+[packs.core]
+source = ".gc/system/packs/core"
+`
+	writeSchema2RigCity(t, cityPath, "my-city", cityToml, "")
+
+	rigPath := filepath.Join(t.TempDir(), "backend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		"# This is a city-level rationale comment.",
+		"# Pack rationale: core tools are required.",
+		"backend",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("city.toml missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestDoRigAddSqliteCityCreatesBdBackedRig(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(t.TempDir(), "tincan")

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -348,6 +348,57 @@ func WriteCityAndRigSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City) 
 	return writeCityAndRigSiteBindingsForEdit(fs, tomlPath, cfg, nil)
 }
 
+// AppendRigAndWriteSiteBindingsForEdit appends a new [[rigs]] block to
+// city.toml without re-serializing the whole file, preserving all existing
+// comments. cfg must include newRig (with its path) so that the site binding
+// (.gc/site.toml) is kept consistent. If the site binding write fails after
+// city.toml is changed, both files are restored before the error is returned.
+func AppendRigAndWriteSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City, newRig Rig) error {
+	cityRoot := filepath.Dir(tomlPath)
+
+	// Serialize only the new rig block, stripping path (it belongs in site.toml).
+	rigForCity := newRig
+	rigForCity.Path = ""
+	type rigBlock struct {
+		Rigs []Rig `toml:"rigs"`
+	}
+	var rigBuf bytes.Buffer
+	enc := toml.NewEncoder(&rigBuf)
+	enc.Indent = ""
+	if err := enc.Encode(rigBlock{Rigs: []Rig{rigForCity}}); err != nil {
+		return fmt.Errorf("serializing new rig block: %w", err)
+	}
+
+	existing, err := fs.ReadFile(tomlPath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", tomlPath, err)
+	}
+
+	snapshot, err := snapshotCityAndSiteFiles(fs, tomlPath, SiteBindingPath(cityRoot))
+	if err != nil {
+		return err
+	}
+
+	content := make([]byte, len(existing))
+	copy(content, existing)
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		content = append(content, '\n')
+	}
+	content = append(content, '\n')
+	content = append(content, rigBuf.Bytes()...)
+
+	if err := fsys.WriteFileIfChangedAtomic(fs, tomlPath, content, 0o644); err != nil {
+		return err
+	}
+	if err := persistRigSiteBindings(fs, cityRoot, cfg.Rigs, nil); err != nil {
+		if restoreErr := snapshot.restore(fs); restoreErr != nil {
+			return fmt.Errorf("writing .gc/site.toml failed and restoring city.toml/site binding failed: %w", errors.Join(err, restoreErr))
+		}
+		return fmt.Errorf("writing .gc/site.toml failed; restored city.toml and previous site binding, fix the site binding write error and retry: %w", err)
+	}
+	return nil
+}
+
 // WriteCityAndRigSiteBindingsForEditRemovingRigs writes city.toml and
 // .gc/site.toml while removing bindings for rig names that were intentionally
 // deleted from the city config.

--- a/release-gates/ga-q3gwx0-gc-rig-add-comment-preservation-gate.md
+++ b/release-gates/ga-q3gwx0-gc-rig-add-comment-preservation-gate.md
@@ -1,0 +1,65 @@
+# Release gate: ga-q3gwx0
+
+**Deploy bead:** ga-q3gwx0 - needs-deploy: gc rig add comment preservation (from:ga-48s4bw)  
+**Source review bead:** ga-48s4bw  
+**Implementation bead:** ga-un5mg3.1  
+**Branch:** `builder/ga-un5mg3.1`  
+**PR:** https://github.com/gastownhall/gascity/pull/3414  
+**Code HEAD before gate:** `e5f38b77878e5fb74b5ec264db5be16d53cbb323`  
+**Base:** `origin/main` at `331f5b23aed65a8c290817e6ec2545bbf919cde0`  
+**Verdict:** **PASS**
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-48s4bw` is closed with `VERDICT: PASS`; reviewer notes report the implementation is clean to deploy. |
+| 2 | Acceptance criteria met | PASS | The release branch is a clean one-commit PR for the rig-add comment-preservation fix, records PR #3414 / branch / commit in `ga-un5mg3.1`, limits the diff to the three approved files, includes `TestDoRigAdd_PreservesComments`, and does not reuse PR #3402. |
+| 3 | Tests pass | PASS | GitHub checks for PR #3414 are green, including required CI, CodeQL, preflight, cmd/gc process shards, integration shards, worker suites, and pack compatibility. Local focused regression, build, and vet passed; see Test Runs for the local fast-baseline environment note. |
+| 4 | No high-severity review findings open | PASS | Review notes list only LOW/INFO non-blocking findings; unresolved HIGH count is 0. GitHub PR reviews/comments are empty at gate time. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before adding this gate file. After this file is committed as the gate commit, the branch should be clean again. |
+| 6 | Branch diverges cleanly from main | PASS | `gh pr view 3414` reports `mergeStateStatus: CLEAN`; `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` exits 0. |
+| 7 | Single feature theme | PASS | Diff scope is limited to `cmd/gc/cmd_rig.go`, `cmd/gc/cmd_rig_test.go`, and `internal/config/site_binding.go`, all serving one behavior: preserving existing `city.toml` comments on new `gc rig add` writes while keeping site bindings consistent. |
+
+## Test Runs
+
+```
+$ go test ./cmd/gc -run '^TestDoRigAdd_PreservesComments$' -count=1
+ok  	github.com/gastownhall/gascity/cmd/gc	0.436s
+
+$ go build ./cmd/gc
+(clean)
+
+$ go vet ./...
+(clean)
+
+$ gh pr checks 3414 --watch=false
+All required GitHub checks pass, including CI / required, CodeQL, preflight,
+cmd/gc process shards, package integration shards, worker suites, and pack
+compatibility.
+```
+
+Local broad baseline note:
+
+```
+$ make test-fast-parallel
+FAIL in local cmd/gc shards due host test-environment contamination.
+```
+
+The local host has a live `/tmp/.gc` city marker owned by a Dolt sql-server
+process. `TestFindCity/not_found` is hard-coded to create under `/tmp`, so it
+fails on this host even with a clean `HOME` and short `TMPDIR`. The same
+focused no-city/supervisor set also fails on `origin/main`, so this is not
+introduced by the PR branch. With clean `HOME=/var/tmp/gchq3` and short
+`TMPDIR=/var/tmp/gctq3`, the three standalone-controller supervisor tests and
+`TestSupervisorCreatesControllerSocketForManagedCity` pass; only
+`TestFindCity/not_found` remains blocked by the live `/tmp/.gc`.
+
+## Diff Scope
+
+```
+cmd/gc/cmd_rig.go
+cmd/gc/cmd_rig_test.go
+internal/config/site_binding.go
+```
+


### PR DESCRIPTION
## What this changes

`gc rig add` now preserves existing comments in `city.toml` when adding a new rig. The command appends only the new `[[rigs]]` block instead of re-serializing the whole city config, so operator rationale comments and existing formatting survive the common new-rig path.

The `--re-add` path still uses the existing full write path because it updates an existing rig stanza rather than appending a new one.

## Review notes

- The behavior change is limited to new-rig additions in `cmd/gc/cmd_rig.go`.
- `internal/config/site_binding.go` adds a helper that appends the city config block while still writing `.gc/site.toml` for rig path bindings.
- The helper snapshots both files and restores them if site binding persistence fails after the city config is changed.
- No API, schema, dashboard, or migration behavior changes are included.

## Test plan

- [x] `go test ./cmd/gc -run '^TestDoRigAdd_PreservesComments$' -count=1`
- [x] `go build ./cmd/gc`
- [x] `go vet ./...`
- [x] GitHub PR checks green, including required CI, CodeQL, preflight, cmd/gc process shards, integration shards, worker suites, and pack compatibility
- [x] Release gate: [`release-gates/ga-q3gwx0-gc-rig-add-comment-preservation-gate.md`](release-gates/ga-q3gwx0-gc-rig-add-comment-preservation-gate.md)