### PR TITLE
fix(gastown): patrol formulas use invalid --type=wisp and wrong ledger

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -2123,35 +2123,15 @@ func TestNonDogStartupPromptsUseAssignedInProgressQuery(t *testing.T) {
 			rig:     "gastown",
 			binding: "gastown.",
 		},
-		{
-			rel:     "packs/gastown/agents/deacon/prompt.template.md",
-			start:   "## Startup Protocol",
-			end:     "**Hook ->",
-			want:    "{{ .AssignedInProgressQuery }}",
-			forbid:  []string{`gc bd list --assignee="$GC_ALIAS" --status=in_progress`},
-			render:  true,
-			agent:   "gastown/deacon",
-			tmpl:    "deacon",
-			rig:     "gastown",
-			binding: "gastown.",
-		},
-		// The witness Startup Protocol deliberately does NOT use the shared
+		// The deacon Startup Protocol deliberately does NOT use the shared
 		// AssignedInProgressQuery: its patrol wisps live on the town ledger
 		// and must be found with `gc bd`, not the bare-bd shared query that
-		// resolves to the rig ledger. Its startup/no-idle wisp reconciliation
-		// is covered by TestWitnessStartupAndNoIdleReconcileWisps.
-		{
-			rel:     "packs/gastown/agents/refinery/prompt.template.md",
-			start:   "# Step 1: Check for an in-progress patrol wisp",
-			end:     "Then follow the formula.",
-			want:    "{{ .AssignedInProgressQuery }}",
-			forbid:  []string{`gc bd list --assignee="$GC_AGENT" --status=in_progress`},
-			render:  true,
-			agent:   "gastown/refinery",
-			tmpl:    "refinery",
-			rig:     "gastown",
-			binding: "gastown.",
-		},
+		// resolves to the rig ledger. Its startup wisp reconciliation is
+		// covered by TestDeaconStartupReconcileWisps.
+		// The refinery Startup deliberately does NOT use the shared
+		// AssignedInProgressQuery for the same reason: its patrol wisps live
+		// on the town ledger. Its startup wisp reconciliation is covered by
+		// TestRefineryStartupReconcileWisps.
 	}
 	for _, check := range checks {
 		t.Run(check.rel+"/"+check.start, func(t *testing.T) {
@@ -2237,6 +2217,82 @@ func TestWitnessStartupAndNoIdleReconcileWisps(t *testing.T) {
 	} {
 		if !strings.Contains(noIdle, want) {
 			t.Errorf("witness no-idle guard missing %q", want)
+		}
+	}
+}
+
+// TestDeaconStartupReconcileWisps is the regression guard for ga-88s (same
+// bug class as ga-7c6). The deacon's patrol wisps are ephemeral molecules on
+// the town ledger, poured/assigned with `gc bd`. Its startup work-check must
+// therefore (1) look them up with `gc bd`, not the bare-bd shared query that
+// resolves to the rig ledger and never sees them; (2) filter `--type=molecule`,
+// never the invalid `--type=wisp`; and (3) reconcile duplicates to exactly one
+// by burning the surplus.
+func TestDeaconStartupReconcileWisps(t *testing.T) {
+	rendered := renderGastownPromptForPack(t,
+		"packs/gastown/agents/deacon/prompt.template.md",
+		"gastown/deacon", "deacon", "demo", "gastown", "gastown.")
+
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "gc bd") && strings.Contains(line, "--type=wisp") {
+			t.Errorf("deacon prompt runs a gc bd command with invalid --type=wisp (matches nothing -> duplicate wisps): %q", line)
+		}
+	}
+
+	startup := sectionBetween(t, rendered, "## Startup Protocol", "**Hook ->")
+	for _, bare := range []string{
+		`bd list --include-ephemeral --status in_progress --assignee="$GC_SESSION_ID"`,
+		"{{ .AssignedInProgressQuery }}",
+	} {
+		if strings.Contains(startup, bare) {
+			t.Errorf("deacon startup must not use the bare-bd shared query %q; patrol wisps live on the town ledger via gc bd", bare)
+		}
+	}
+	for _, want := range []string{
+		`gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule`,
+		`gc bd list --assignee="$GC_AGENT" --status=open --type=molecule`,
+		"gc bd mol burn",
+	} {
+		if !strings.Contains(startup, want) {
+			t.Errorf("deacon startup missing %q", want)
+		}
+	}
+}
+
+// TestRefineryStartupReconcileWisps is the regression guard for ga-88s (same
+// bug class as ga-7c6). The refinery's patrol wisps are ephemeral molecules on
+// the town ledger, poured/assigned with `gc bd`. Its startup work-check must
+// therefore (1) look them up with `gc bd`, not the bare-bd shared query that
+// resolves to the rig ledger and never sees them; (2) filter `--type=molecule`,
+// never the invalid `--type=wisp`; and (3) reconcile duplicates to exactly one
+// by burning the surplus.
+func TestRefineryStartupReconcileWisps(t *testing.T) {
+	rendered := renderGastownPromptForPack(t,
+		"packs/gastown/agents/refinery/prompt.template.md",
+		"gastown/refinery", "refinery", "demo", "gastown", "gastown.")
+
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "gc bd") && strings.Contains(line, "--type=wisp") {
+			t.Errorf("refinery prompt runs a gc bd command with invalid --type=wisp (matches nothing -> duplicate wisps): %q", line)
+		}
+	}
+
+	startup := sectionBetween(t, rendered, "## Startup", "Then follow the formula.")
+	for _, bare := range []string{
+		`bd list --include-ephemeral --status in_progress --assignee="$GC_SESSION_ID"`,
+		"{{ .AssignedInProgressQuery }}",
+	} {
+		if strings.Contains(startup, bare) {
+			t.Errorf("refinery startup must not use the bare-bd shared query %q; patrol wisps live on the town ledger via gc bd", bare)
+		}
+	}
+	for _, want := range []string{
+		`gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule`,
+		`gc bd list --assignee="$GC_AGENT" --status=open --type=molecule`,
+		"gc bd mol burn",
+	} {
+		if !strings.Contains(startup, want) {
+			t.Errorf("refinery startup missing %q", want)
 		}
 	}
 }
@@ -2745,8 +2801,8 @@ func TestGastownPatrolPromptFallbackPreservesLifecycle(t *testing.T) {
 				`run ` + "`gc hook`" + ` immediately`,
 				`CURRENT_WISP=${GC_BEAD_ID:-}`,
 				`if [ -z "$CURRENT_WISP" ]; then`,
-				`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')`,
-				`ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=wisp --limit=1 --json | jq -r '.[0].id // empty')`,
+				`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')`,
+				`ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=1 --json | jq -r '.[0].id // empty')`,
 				`if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then`,
 				`NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix=gastown. --json | jq -r '.new_epic_id // empty')`,
 				`if [ -z "$NEXT" ]; then`,
@@ -2837,7 +2893,7 @@ func TestRefineryPatrolRestartGuidanceAssignsSuccessor(t *testing.T) {
 			wantOrder: []string{
 				`CURRENT_WISP=${GC_BEAD_ID:-}`,
 				`if [ -z "$CURRENT_WISP" ]; then`,
-				`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')`,
+				`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')`,
 				`fi`,
 				`NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')`,
 				`if [ -z "$NEXT" ]; then`,
@@ -2863,7 +2919,7 @@ func TestRefineryPatrolRestartGuidanceAssignsSuccessor(t *testing.T) {
 			wantOrder: []string{
 				`CURRENT_WISP=${GC_BEAD_ID:-}`,
 				`if [ -z "$CURRENT_WISP" ]; then`,
-				`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')`,
+				`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')`,
 				`fi`,
 				`NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')`,
 				`if [ -z "$NEXT" ]; then`,
@@ -2903,7 +2959,7 @@ func TestRefineryPatrolRestartGuidanceAssignsSuccessor(t *testing.T) {
 	assertContainsInOrder(t, patrolLifecycle,
 		`CURRENT_WISP=${GC_BEAD_ID:-}`,
 		`if [ -z "$CURRENT_WISP" ]; then`,
-		`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')`,
+		`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')`,
 		`fi`,
 		`NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')`,
 		`if [ -z "$NEXT" ]; then`,
@@ -3838,7 +3894,7 @@ func TestDeaconPatrolNextIterationBurnsCurrentBeforeIdleExit(t *testing.T) {
 	assertContainsInOrder(t, section,
 		`CURRENT_WISP=${GC_BEAD_ID:-}`,
 		`if [ -z "$CURRENT_WISP" ]; then`,
-		`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')`,
+		`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')`,
 		`NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')`,
 		`if [ -z "$NEXT" ]; then`,
 		`if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then`,

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -53,23 +53,39 @@ Your formula: `mol-deacon-patrol`
 
 > **The Universal Propulsion Principle: If you find something on your hook, YOU RUN IT.**
 
+Your patrol wisps are ephemeral molecules on the **town ledger** (`th-wisp-*`),
+poured and assigned with `gc bd`. Find them the same way — with `gc bd`, never
+bare `bd`. Bare `bd` resolves to the rig ledger from your CWD and never sees
+your wisps, so every restart would pour a fresh one while the prior wisp leaks.
+Wisp roots are `issue_type=molecule`; never filter `--type=wisp` (not a valid
+bd type — the query errors and matches nothing).
+
 ```bash
-# Step 1: Check for assigned work
-{{ .AssignedInProgressQuery }}
+# Step 1: Reconcile your patrol wisps to exactly one (town ledger, via gc bd).
+WISP_IDS=$(
+  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=0 --json | jq -r '.[].id'
+  gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id'
+)
+WISP=$(printf '%s\n' $WISP_IDS | sed -n '1p')           # keep one (prefers in_progress)
+for extra in $(printf '%s\n' $WISP_IDS | sed '1d'); do  # burn any surplus
+  gc bd mol burn "$extra" --force
+done
 
-# Step 2: Nothing? Check mail for attached work
-gc mail inbox
+# Step 2: Existing wisp → resume it. None → check mail, then pour ONE.
+if [ -n "$WISP" ]; then
+  echo "Resuming patrol wisp $WISP"
+else
+  gc mail inbox
+  WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
+  gc bd update "$WISP" --assignee="$GC_AGENT"
+fi
 
-# Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
-
-# Step 4: Read the formula recipe — these are the steps to execute
+# Step 3: Read the formula recipe — these are the steps to execute
 # (Use 'gc bd formula show' for the recipe on disk; 'gc bd mol show' is
 #  for poured molecule instances, not formulas, and will say 'not found'.)
 gc bd formula show mol-deacon-patrol
 
-# Step 5: Execute — work through the steps in order
+# Step 4: Execute — work through the steps in order
 ```
 
 **Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration -> run `gc hook`.**
@@ -89,9 +105,9 @@ If `next-iteration` already ran, do not pour again; run `gc hook`.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
-ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
   NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
   if [ -z "$NEXT" ]; then

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -69,7 +69,7 @@ external observers (witness, mayor) only catch on a slow patrol cycle.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -114,7 +114,7 @@ assign the next wisp, burn the current wisp, THEN request restart**:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -158,6 +158,13 @@ name when no alias is configured. `$GC_ALIAS` can be empty or stale, which
 is how a refinery once self-polled for 13h42m with seven queued beads
 without catching the mismatch (upstream #1833).
 
+Your patrol wisps are ephemeral molecules on the **town ledger** (`th-wisp-*`),
+poured and assigned with `gc bd`. Find them the same way — with `gc bd`, never
+bare `bd`. Bare `bd` resolves to the rig ledger from your CWD and never sees
+your wisps, so every restart would pour a fresh one while the prior wisp leaks.
+Wisp roots are `issue_type=molecule`; never filter `--type=wisp` (not a valid
+bd type — the query errors and matches nothing).
+
 ```bash
 # Step 0: Orphan-merge scan (mail-loss fallback).
 # Polecats sometimes die between commit and MERGE_READY mail
@@ -173,12 +180,21 @@ for ORPHAN in $ORPHANS; do
   # surfaces beads the inbox missed.
 done
 
-# Step 1: Check for an in-progress patrol wisp
-{{ .AssignedInProgressQuery }}
+# Step 1: Reconcile your patrol wisps to exactly one (town ledger, via gc bd).
+WISP_IDS=$(
+  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=0 --json | jq -r '.[].id'
+  gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id'
+)
+WISP=$(printf '%s\n' $WISP_IDS | sed -n '1p')           # keep one (prefers in_progress)
+for extra in $(printf '%s\n' $WISP_IDS | sed '1d'); do  # burn any surplus
+  gc bd mol burn "$extra" --force
+done
 
-# If none found, pour one (root-only — no child step beads) and assign it
-WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$WISP" --assignee="$GC_AGENT"
+# Step 2: Existing wisp → resume it. None → pour one and assign it.
+if [ -z "$WISP" ]; then
+  WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
+  gc bd update "$WISP" --assignee="$GC_AGENT"
+fi
 ```
 
 Then follow the formula. The step descriptions below are your instructions —

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -427,7 +427,7 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
 
 NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -119,7 +119,7 @@ wisp, burn the current wisp, then request a restart:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -242,7 +242,7 @@ gc bd update $WORK \
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -343,7 +343,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```bash
      CURRENT_WISP=${GC_BEAD_ID:-}
      if [ -z "$CURRENT_WISP" ]; then
-       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
      fi
      NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
      if [ -z "$NEXT" ]; then
@@ -435,7 +435,7 @@ Branch: $BRANCH
 Target: $TARGET"
   CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -z "$CURRENT_WISP" ]; then
-    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
   fi
   if [ -z "$CURRENT_WISP" ]; then
     echo "Could not resolve current wisp; not burning."
@@ -1005,7 +1005,7 @@ If the cycle ended early (conflict rejection, no work found), note
 why and what state was left.
 
 This summary is not stored separately — it lives in the wisp's
-closing reason. The next session can find it via `gc bd list --type=wisp
+closing reason. The next session can find it via `gc bd list --type=molecule
 --status=closed --limit=5` if it needs predecessor context."""
 
 [[steps]]
@@ -1042,7 +1042,7 @@ If auto_land = "false": skip this entirely.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then


### PR DESCRIPTION
## Problem

The deacon and refinery patrol guards carry the same two-bug class already fixed for the witness:

1. **Invalid issue type in the patrol find-work query.** The guards resolve the current patrol wisp with `--type=wisp`, but `wisp` is not a valid `bd` issue type — wisp roots are `issue_type=molecule`. The query errors and matches nothing, so the guard never finds the agent's own in-flight patrol wisp. (Tracked upstream as #3384 for `mol-refinery-patrol`.)

2. **Startup ledger mismatch.** Both agents pour patrol wisps to the town ledger via `gc bd mol wisp`, but their startup work-checks used the shared bare-`bd` assigned-in-progress query, which reads the rig ledger and never sees town-ledger wisps. Every restart therefore poured a fresh wisp while the prior one leaked, accumulating orphaned open wisps over time.

## Fix

- Replace `--type=wisp` with `--type=molecule` in all four occurrences: `deacon/prompt.template.md`, `refinery/prompt.template.md`, `mol-deacon-patrol.toml`, and `mol-refinery-patrol.toml`.
- Switch the deacon and refinery startup checks to `gc bd list --type=molecule` against the town ledger (the ledger the wisp is actually poured to) and reconcile to exactly one wisp by burning any surplus — mirroring the prior witness fix so a restart no longer leaks a wisp.

This matches the already-merged witness change (same query and same reconcile-to-one pattern), so the three patrol agents are now consistent.

## Verification

- Cherry-picks cleanly onto `main`; `go build ./...` is clean.
- Two new regression guards added (`TestDeaconStartupReconcileWisps`, `TestRefineryStartupReconcileWisps`); deacon and refinery are removed from `TestNonDogStartupPromptsUseAssignedInProgressQuery` (the same exclusion the witness received), and the patrol-query tests now assert `--type=molecule`. `go vet ./examples/gastown/...` is clean.
