### PR TITLE
fix(test): make suspension tests hermetic against live-city ambient state

### DIFF
--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
 	"github.com/gastownhall/gascity/internal/worker"
 )
 
@@ -301,7 +302,7 @@ func collectCityStatusSnapshotFromStoreSnapshot(
 	for _, ns := range cfg.NamedSessions {
 		identity := ns.QualifiedName()
 		mode := ns.ModeOrDefault()
-		status := namedSessionStatusForCity(cityPath, cfg, store, statusSnapshot, snapshot.CityName, identity, mode, suspendedRigs)
+		status := namedSessionStatusForCity(cityPath, cfg, store, statusSnapshot, snapshot.CityName, identity, mode, suspState, suspendedRigs)
 		snapshot.NamedSessions = append(snapshot.NamedSessions, cityStatusNamedSession{
 			Identity: identity,
 			Status:   status,
@@ -320,11 +321,12 @@ func namedSessionStatusForCity(
 	cityName string,
 	identity string,
 	mode string,
+	suspState suspensionstate.State,
 	suspendedRigs map[string]bool,
 ) string {
 	status := "reserved-unmaterialized"
 	if spec, ok := findNamedSessionSpec(cfg, cityName, identity); ok {
-		if mode == "always" && namedSessionBlockedBySuspension(cfg, spec.Agent, suspendedRigs) {
+		if mode == "always" && namedSessionBlockedBySuspension(cfg, spec.Agent, suspState, suspendedRigs) {
 			status = "degraded blocked"
 		}
 	}

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
 	"github.com/gastownhall/gascity/internal/worker"
 )
 
@@ -206,7 +207,7 @@ func TestCityStatusNamedSessionSurfacesLookupErrorWhenSnapshotDegraded(t *testin
 
 	status := namedSessionStatusForCity(
 		"/home/user/city", cfg, store, degraded,
-		"city", "refinery", "on_demand", nil,
+		"city", "refinery", "on_demand", suspensionstate.State{}, nil,
 	)
 	if !strings.HasPrefix(status, "lookup error:") {
 		t.Fatalf("named session status = %q, want a 'lookup error: ...' prefix when snapshot is degraded", status)
@@ -239,7 +240,7 @@ func TestCityStatusNamedSessionsCleanSnapshotStillSilent(t *testing.T) {
 
 	status := namedSessionStatusForCity(
 		"/home/user/city", cfg, store, clean,
-		"city", "refinery", "on_demand", nil,
+		"city", "refinery", "on_demand", suspensionstate.State{}, nil,
 	)
 	if strings.HasPrefix(status, "lookup error:") {
 		t.Fatalf("named session status = %q, want cfg-derived status (no lookup error) when snapshot loaded cleanly", status)

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
 	"github.com/gastownhall/gascity/internal/worker"
 	"github.com/spf13/cobra"
 )
@@ -449,11 +450,11 @@ func statusObservationTargetForIdentity(
 	}
 }
 
-func namedSessionBlockedBySuspension(cfg *config.City, agentCfg *config.Agent, suspendedRigs map[string]bool) bool {
+func namedSessionBlockedBySuspension(cfg *config.City, agentCfg *config.Agent, suspState suspensionstate.State, suspendedRigs map[string]bool) bool {
 	if cfg == nil {
 		return false
 	}
-	if citySuspended(cfg) {
+	if citySuspendedWithState(cfg, suspState) {
 		return true
 	}
 	if agentCfg == nil {

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
 )
 
 var now = time.Date(2026, 3, 31, 12, 0, 0, 0, time.UTC)
@@ -2029,7 +2030,7 @@ func TestNamedAlways_SuspensionPropagation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &tt.cfg.Agents[0]
-			if !isAgentEffectivelySuspended(&tt.cfg, a) {
+			if !isAgentEffectivelySuspendedWith(&tt.cfg, a, suspensionstate.State{}) {
 				t.Fatalf("expected agent to be effectively suspended")
 			}
 			qn := a.QualifiedName()


### PR DESCRIPTION
## Problem

Two suspension tests fail when the suite runs inside a live, non-suspended city. Both call ambient-reading helpers that resolve the real city path and load its runtime suspension state, which overrides the `SuspendedOnStart: true` set in the hermetic test config:

- `TestNamedAlways_SuspensionPropagation/city_suspended` calls `isAgentEffectivelySuspended`, which resolves the ambient city path.
- `TestPhase0StatusText_DegradesAlwaysNamedIdentityBlockedByCitySuspend` calls `doCityStatus` → `namedSessionStatusForCity` → `namedSessionBlockedBySuspension` → `citySuspended`, which also resolves the ambient city path.

So the tests pass or fail depending on whether the machine running them happens to have a suspended city, rather than on the injected config.

## Fix

- Switch the `city_suspended` sub-test to `isAgentEffectivelySuspendedWith` with an empty `suspensionstate.State{}`, which falls back to config-only (`SuspendedOnStart`) with no runtime override. All three sub-tests in the table now use the injectable form, making the whole table hermetic.
- Thread the already-loaded suspension state (loaded from the injected `cityPath` in `collectCityStatusSnapshotFromStoreSnapshot`) through `namedSessionStatusForCity` and `namedSessionBlockedBySuspension`, so city-suspension is evaluated against the controlled state instead of being re-resolved from the ambient path. `namedSessionBlockedBySuspension` now accepts a `suspensionstate.State` and calls `citySuspendedWithState`.

No production behavior change: the callers already loaded the state from the controlled city path; they now pass it in rather than having the helper re-resolve it from disk.

## Verification

- Cherry-picks cleanly onto `main`; `go build ./...` is clean and `go vet ./cmd/gc/` is clean.
- The change is test-hermeticity plus a pure-function refactor (inject already-loaded state instead of re-reading it), so existing production callers are unaffected.
