### PR TITLE
fix(pool): exclude asleep/drained phantom beads from runningSessions count

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -513,7 +513,7 @@ func buildDesiredStateWithSessionBeads(
 		template := cfg.Agents[i].QualifiedName()
 		runningSessions := 0
 		for _, sb := range allOpenSessionBeads {
-			if isPoolManagedSessionBead(sb) {
+			if isPoolManagedSessionBead(sb) && poolSessionIsLive(sb) {
 				// Match the qualified template by identity equivalence.
 				// allOpenSessionBeads is aggregated across the city + every rig
 				// store, and pool session beads store the qualified name

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -18,6 +18,21 @@ func isDrainedSessionBead(session beads.Bead) bool {
 	return isDrainedSessionMetadata(session.Metadata)
 }
 
+// poolSessionIsLive reports whether a pool session bead represents an
+// actively running session for the runningSessions counter in
+// build_desired_state. An asleep or drained bead is not live — it holds
+// no active process and must not suppress the isCold cross-store wake
+// probe.
+func poolSessionIsLive(session beads.Bead) bool {
+	if strings.TrimSpace(session.Metadata["state"]) == "asleep" {
+		return false
+	}
+	if isDrainedSessionBead(session) {
+		return false
+	}
+	return true
+}
+
 // isPoolSessionSlotFreeable reports whether a session's bead is in a terminal
 // state where the pool slot it occupies can be freed — either explicitly
 // drained, or asleep from a normal idle transition. Sessions parked via

--- a/cmd/gc/session_state_helpers_test.go
+++ b/cmd/gc/session_state_helpers_test.go
@@ -6,6 +6,38 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
+// TestPoolSessionIsLive_Matrix exercises the liveness predicate used by the
+// runningSessions counter in buildDesiredState. An asleep or drained bead
+// must not count as live; everything else is treated as live so that the
+// isCold probe is never suppressed by an unknown/future state.
+func TestPoolSessionIsLive_Matrix(t *testing.T) {
+	cases := []struct {
+		name string
+		meta map[string]string
+		want bool
+	}{
+		{"awake", map[string]string{"state": "awake"}, true},
+		{"active", map[string]string{"state": "active"}, true},
+		{"creating", map[string]string{"state": "creating"}, true},
+		{"start-pending", map[string]string{"state": "start-pending"}, true},
+		{"no-metadata", nil, true},
+		{"empty-state", map[string]string{"state": ""}, true},
+		{"asleep-no-reason", map[string]string{"state": "asleep"}, false},
+		{"asleep-idle", map[string]string{"state": "asleep", "sleep_reason": "idle"}, false},
+		{"asleep-wait-hold", map[string]string{"state": "asleep", "sleep_reason": "wait-hold"}, false},
+		{"drained-state", map[string]string{"state": "drained"}, false},
+		{"asleep-drained-reason", map[string]string{"state": "asleep", "sleep_reason": "drained"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := poolSessionIsLive(beads.Bead{Metadata: tc.meta})
+			if got != tc.want {
+				t.Fatalf("poolSessionIsLive(%v) = %v, want %v", tc.meta, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestIsPoolSessionSlotFreeable_Matrix exercises the deny-by-default contract
 // of the freeable allowlist. The allowlist is tiny, so regressions that widen
 // it (e.g., adding `default: true`) or narrow it (e.g., removing `idle-timeout`)


### PR DESCRIPTION
## Problem

The pool autoscaler counts running sessions to decide whether a pool is cold (`isCold = runningSessions == 0 && minActiveSessions == 0`). When cold, it runs a cross-store wake probe to spawn the first worker on fresh demand.

The `runningSessions` counter included any pool session bead present in the store, including ones that are `asleep` or `drained`. A leftover phantom bead in one of those states inflates the count, flips `isCold` to false, and suppresses the cross-store wake probe — so genuinely-cold pools never get their first worker spawned and ready work stalls until manual intervention.

## Fix

- Add `poolSessionIsLive()` in `session_state_helpers.go`, which excludes `asleep`/`drained` session beads.
- Thread it into the `runningSessions` accumulation in `buildDesiredState`, so a phantom asleep/drained bead no longer counts as a live running session and can no longer keep `isCold` false.

A bead that does not represent a live session is exactly the case the cold check is meant to ignore, so the wake probe fires as intended.

## Verification

- Cherry-picks cleanly onto `main`; `go build ./...` is clean and `go vet ./cmd/gc/` is clean.
- A new test (`session_state_helpers_test.go`) covers `poolSessionIsLive` across the live and asleep/drained states.
