### PR TITLE
fix(controller): sweep fully-detached handoff orphans back to pool demand

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2387,6 +2387,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		emitDeadAssigneeReopenedEvents(cr.rec, assignedWorkBeads, released, time.Now())
 		assignedWorkBeads, assignedWorkStoreRefs = filterReleasedAssignedWorkSnapshot(assignedWorkBeads, assignedWorkStoreRefs, released)
 	}
+	phaseStart = time.Now()
+	detachedRestored := sweepDetachedHandoffOrphansAcrossStores(store, rigStores, cr.logPrefix, cr.stderr)
+	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.sweep_detached_handoff_orphans", phaseStart, map[string]any{
+		"restored_count": detachedRestored,
+	})
 	// Squatter guard (gastownhall/gascity#2930): a foreign Dolt that has bound
 	// this city's managed port returns zero demand, indistinguishable from a
 	// genuinely-idle fleet — and would drain every running pool. This runs on

--- a/cmd/gc/pool_detached_orphan_sweep.go
+++ b/cmd/gc/pool_detached_orphan_sweep.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// sweepDetachedHandoffOrphans restores gc.routed_to on work beads that were
+// fully detached by a failed done sequence. When a worker clears both the
+// assignee and gc.routed_to in a single atomic update (e.g. because
+// $REFINERY_TARGET resolved empty), the bead is left open+unassigned+unrouted
+// with a branch already on origin — invisible to both the pool demand probe
+// (which keys on gc.routed_to) and releaseOrphanedPoolAssignments (which only
+// processes assigned work). This sweep finds such beads via gc.session_name →
+// session bead → template and re-stamps gc.routed_to, returning each bead to
+// pool demand. Returns the count of restored beads.
+//
+// Recovery is judgment-free (ZFC): it reads the original pool route from the
+// session bead's own template metadata and re-stamps gc.routed_to. The bead
+// re-enters pool demand; the formula re-evaluates it from there. No role names
+// appear in this function.
+func sweepDetachedHandoffOrphans(store beads.Store) (int, error) {
+	if store == nil {
+		return 0, nil
+	}
+	// Scan open beads for detached handoff orphans. In steady state there are
+	// none, so the candidate slice is empty and the expensive session-index
+	// lookup is skipped entirely.
+	items, err := store.List(beads.ListQuery{Status: "open", AllowScan: true})
+	if err != nil {
+		return 0, fmt.Errorf("listing open beads: %w", err)
+	}
+
+	type candidate struct {
+		id, sessionName string
+	}
+	var candidates []candidate
+	for _, b := range items {
+		if !isDetachedHandoffOrphanCandidate(b) {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			id:          b.ID,
+			sessionName: strings.TrimSpace(b.Metadata[beadmeta.SessionNameMetadataKey]),
+		})
+	}
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	// Build a session_name → pool-route index once for all candidates.
+	routeIndex, indexErr := buildDetachedOrphanRouteIndex(store)
+	if indexErr != nil {
+		return 0, fmt.Errorf("building session route index: %w", indexErr)
+	}
+
+	var (
+		restored int
+		errs     []error
+	)
+	for _, c := range candidates {
+		route := routeIndex[c.sessionName]
+		if route == "" {
+			log.Printf("sweepDetachedHandoffOrphans: no recoverable route for bead %s (gc.session_name=%q not found in any session bead or session carries no template)", c.id, c.sessionName)
+			continue
+		}
+		if setErr := store.SetMetadata(c.id, beadmeta.RoutedToMetadataKey, route); setErr != nil {
+			errs = append(errs, fmt.Errorf("bead %s: restoring gc.routed_to=%q: %w", c.id, route, setErr))
+			continue
+		}
+		log.Printf("sweepDetachedHandoffOrphans: restored gc.routed_to=%q on detached handoff orphan %s", route, c.id)
+		restored++
+	}
+	return restored, errors.Join(errs...)
+}
+
+// isDetachedHandoffOrphanCandidate reports whether b has the signature of a
+// fully-detached handoff orphan: open, unassigned, no pool route, branch set
+// (indicating work was done and pushed), and a session reference from which the
+// pool route can be recovered.
+func isDetachedHandoffOrphanCandidate(b beads.Bead) bool {
+	if b.Status != "open" {
+		return false
+	}
+	if strings.TrimSpace(b.Assignee) != "" {
+		return false // still assigned — releaseOrphanedPoolAssignments covers this path
+	}
+	if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) != "" {
+		return false // already has a pool route
+	}
+	if strings.TrimSpace(b.Metadata[beadmeta.KindMetadataKey]) == beadmeta.KindWorkflow {
+		return false // workflow roots use gc.run_target; restoreCarriedWorkRoutes handles them
+	}
+	if strings.TrimSpace(b.Metadata["branch"]) == "" {
+		return false // no branch → not a completed-work handoff bead
+	}
+	return strings.TrimSpace(b.Metadata[beadmeta.SessionNameMetadataKey]) != ""
+}
+
+// buildDetachedOrphanRouteIndex returns a map from session_name to pool route
+// for every session bead (open or closed) that carries a template. Closed
+// session beads are included because the worker session is typically gone by
+// the time this sweep runs.
+func buildDetachedOrphanRouteIndex(store beads.Store) (map[string]string, error) {
+	all, listErr := session.ListAllSessionBeads(store, beads.ListQuery{IncludeClosed: true})
+	// Hard errors return nil rows; surface them to the caller.
+	// Partial results still yield rows we can use — don't propagate.
+	if listErr != nil && !beads.IsPartialResult(listErr) {
+		return nil, fmt.Errorf("listing session beads: %w", listErr)
+	}
+	index := make(map[string]string, len(all))
+	for _, sb := range all {
+		sn := strings.TrimSpace(sb.Metadata["session_name"])
+		if sn == "" {
+			continue
+		}
+		if _, exists := index[sn]; exists {
+			continue // keep first match; duplicate session names are rare edge cases
+		}
+		if route := retiredSessionFallbackRoute(sb); route != "" {
+			index[sn] = route
+		}
+	}
+	return index, nil
+}
+
+// sweepDetachedHandoffOrphansAcrossStores sweeps for fully-detached handoff
+// orphans across the city store and every active rig store. Errors are logged
+// to stderr; per-store failures do not abort remaining stores. Returns the
+// total count of beads whose gc.routed_to was restored.
+func sweepDetachedHandoffOrphansAcrossStores(cityStore beads.Store, rigStores map[string]beads.Store, logPrefix string, stderr io.Writer) int {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	type scope struct {
+		label string
+		store beads.Store
+	}
+	scopes := []scope{{label: "city", store: cityStore}}
+	for name, s := range rigStores {
+		scopes = append(scopes, scope{label: "rig " + name, store: s})
+	}
+	total := 0
+	for _, sc := range scopes {
+		if sc.store == nil {
+			continue
+		}
+		n, err := sweepDetachedHandoffOrphans(sc.store)
+		if err != nil {
+			fmt.Fprintf(stderr, "%s: detached handoff orphan sweep (%s): %v\n", logPrefix, sc.label, err) //nolint:errcheck
+		}
+		if n > 0 {
+			fmt.Fprintf(stderr, "%s: detached handoff orphan sweep (%s): restored gc.routed_to on %d bead(s)\n", logPrefix, sc.label, n) //nolint:errcheck
+		}
+		total += n
+	}
+	return total
+}

--- a/cmd/gc/pool_detached_orphan_sweep.go
+++ b/cmd/gc/pool_detached_orphan_sweep.go
@@ -27,6 +27,18 @@ import (
 // re-enters pool demand; the formula re-evaluates it from there. No role names
 // appear in this function.
 func sweepDetachedHandoffOrphans(store beads.Store) (int, error) {
+	return sweepDetachedHandoffOrphansWithRouteStore(store, nil)
+}
+
+// sweepDetachedHandoffOrphansWithRouteStore is sweepDetachedHandoffOrphans that
+// additionally resolves pool routes from routeStore. Session beads (which carry
+// the template/route) are city-stored, while a detached orphan can live in a rig
+// store — so when sweeping a rig store, routeStore is the city store, and a
+// rig-stored orphan whose closing session bead lives in the city store is
+// recovered (the cross-store case sweepDetachedHandoffOrphansAcrossStores exists
+// for). routeStore may be nil to resolve routes from store alone. Beads are only
+// re-stamped in store; routeStore is read-only.
+func sweepDetachedHandoffOrphansWithRouteStore(store, routeStore beads.Store) (int, error) {
 	if store == nil {
 		return 0, nil
 	}
@@ -55,10 +67,25 @@ func sweepDetachedHandoffOrphans(store beads.Store) (int, error) {
 		return 0, nil
 	}
 
-	// Build a session_name → pool-route index once for all candidates.
+	// Build a session_name → pool-route index once for all candidates, from this
+	// store and (for cross-store recovery) routeStore. A detached orphan in a rig
+	// store has its session bead in the city store, so without routeStore its
+	// route is never found and it is never recovered. store wins on conflict; the
+	// city store backfills session names absent here.
 	routeIndex, indexErr := buildDetachedOrphanRouteIndex(store)
 	if indexErr != nil {
 		return 0, fmt.Errorf("building session route index: %w", indexErr)
+	}
+	if routeStore != nil {
+		crossIndex, crossErr := buildDetachedOrphanRouteIndex(routeStore)
+		if crossErr != nil {
+			return 0, fmt.Errorf("building cross-store session route index: %w", crossErr)
+		}
+		for sn, route := range crossIndex {
+			if _, exists := routeIndex[sn]; !exists {
+				routeIndex[sn] = route
+			}
+		}
 	}
 
 	var (
@@ -152,7 +179,7 @@ func sweepDetachedHandoffOrphansAcrossStores(cityStore beads.Store, rigStores ma
 		if sc.store == nil {
 			continue
 		}
-		n, err := sweepDetachedHandoffOrphans(sc.store)
+		n, err := sweepDetachedHandoffOrphansWithRouteStore(sc.store, cityStore)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s: detached handoff orphan sweep (%s): %v\n", logPrefix, sc.label, err) //nolint:errcheck
 		}

--- a/cmd/gc/pool_detached_orphan_sweep.go
+++ b/cmd/gc/pool_detached_orphan_sweep.go
@@ -42,16 +42,24 @@ func sweepDetachedHandoffOrphansWithRouteStore(store, routeStore beads.Store) (i
 	if store == nil {
 		return 0, nil
 	}
-	// Scan open beads for detached handoff orphans. In steady state there are
-	// none, so the candidate slice is empty and the expensive session-index
-	// lookup is skipped entirely.
-	items, err := store.List(beads.ListQuery{Status: "open", AllowScan: true})
+	// Scan open beads for detached handoff orphans. Live is what makes
+	// Status:"open" mean open: mapBdStatus folds bd's blocked/deferred/review/
+	// testing into Gas City's three statuses, so such a bead decodes with Status
+	// "open", and a cached List (which filters the collapsed status via
+	// ListQuery.Matches) hands it back as if it were ready. Only the backing store
+	// filters on the raw status, so without Live a bead parked in bd review/
+	// testing with a pushed branch and a consumed gc.routed_to — an ordinary
+	// post-work state — is re-stamped every tick and respawns a worker that drains
+	// no-op (the sibling restoreCarriedWorkRoutes gates the same gc-4zb hazard with
+	// Live). In steady state there are no candidates, so the expensive session-
+	// index lookup is skipped entirely.
+	items, err := store.List(beads.ListQuery{Status: "open", AllowScan: true, Live: true})
 	if err != nil {
 		return 0, fmt.Errorf("listing open beads: %w", err)
 	}
 
 	type candidate struct {
-		id, sessionName string
+		id, sessionID, sessionName string
 	}
 	var candidates []candidate
 	for _, b := range items {
@@ -60,6 +68,7 @@ func sweepDetachedHandoffOrphansWithRouteStore(store, routeStore beads.Store) (i
 		}
 		candidates = append(candidates, candidate{
 			id:          b.ID,
+			sessionID:   strings.TrimSpace(b.Metadata[beadmeta.SessionIDMetadataKey]),
 			sessionName: strings.TrimSpace(b.Metadata[beadmeta.SessionNameMetadataKey]),
 		})
 	}
@@ -67,36 +76,63 @@ func sweepDetachedHandoffOrphansWithRouteStore(store, routeStore beads.Store) (i
 		return 0, nil
 	}
 
-	// Build a session_name → pool-route index once for all candidates, from this
-	// store and (for cross-store recovery) routeStore. A detached orphan in a rig
-	// store has its session bead in the city store, so without routeStore its
-	// route is never found and it is never recovered. store wins on conflict; the
-	// city store backfills session names absent here.
+	// Build the session route index once for all candidates, from this store and
+	// (for cross-store recovery) routeStore. A detached orphan in a rig store has
+	// its session bead in the city store, so without routeStore its route is never
+	// found and it is never recovered. store wins on conflict; the city store
+	// backfills gaps.
 	routeIndex, indexErr := buildDetachedOrphanRouteIndex(store)
 	if indexErr != nil {
 		return 0, fmt.Errorf("building session route index: %w", indexErr)
 	}
-	if routeStore != nil {
+	// Only union a distinct cross-store index. The city scope in
+	// sweepDetachedHandoffOrphansAcrossStores passes the city store as both store
+	// and routeStore; its routes are already in routeIndex, so rebuilding the same
+	// full ListAllSessionBeads scan and unioning it into itself is pure waste.
+	// Interface identity is the right test here — production stores are pointer-
+	// backed CachingStores.
+	if routeStore != nil && routeStore != store {
 		crossIndex, crossErr := buildDetachedOrphanRouteIndex(routeStore)
 		if crossErr != nil {
 			return 0, fmt.Errorf("building cross-store session route index: %w", crossErr)
 		}
-		for sn, route := range crossIndex {
-			if _, exists := routeIndex[sn]; !exists {
-				routeIndex[sn] = route
-			}
-		}
+		routeIndex.backfill(crossIndex)
 	}
 
+	// Resolve the authoritative, cache-bypassing read handle once. Production
+	// stores are CachingStore-wrapped, so a plain store.Get can return a bead that
+	// predates a cross-process claim/close; handles.Live reads the backing store
+	// directly. For a plain store this degrades to store.Get.
+	handles := beads.HandlesFor(store)
 	var (
 		restored int
 		errs     []error
 	)
 	for _, c := range candidates {
-		route := routeIndex[c.sessionName]
+		route := routeIndex.route(c.sessionID, c.sessionName)
 		if route == "" {
-			log.Printf("sweepDetachedHandoffOrphans: no recoverable route for bead %s (gc.session_name=%q not found in any session bead or session carries no template)", c.id, c.sessionName)
+			log.Printf("sweepDetachedHandoffOrphans: no recoverable route for bead %s (gc.session_id=%q / gc.session_name=%q not found in any session bead, the session carries no template, or the session name is ambiguous)", c.id, c.sessionID, c.sessionName)
 			continue
+		}
+		// Re-read the live bead immediately before writing, through the cache-
+		// bypassing handle. The open-bead List is a snapshot; a worker — often in
+		// another process — may have claimed, closed, or re-routed this bead in the
+		// window since. A claim atomically flips it open->in_progress and consumes
+		// gc.routed_to (ga-sa0), so a blind SetMetadata keyed on the stale snapshot
+		// would resurrect gc.routed_to on the now-claimed bead and hand the
+		// dispatcher a phantom pool-demand bead that flaps open<->in_progress
+		// (ga-bgu). Skip unless the live bead is still a detached-orphan candidate
+		// resolving to the same recovered route. (A block collapses to "open" on
+		// this Get too, so the Live candidate List above — not this re-read — is
+		// what excludes blocked/review/testing work; gc-4zb.)
+		live, getErr := handles.Live.Get(c.id)
+		if getErr != nil {
+			errs = append(errs, fmt.Errorf("bead %s: re-reading before route restore: %w", c.id, getErr))
+			continue
+		}
+		if !isDetachedHandoffOrphanCandidate(live) ||
+			routeIndex.route(strings.TrimSpace(live.Metadata[beadmeta.SessionIDMetadataKey]), strings.TrimSpace(live.Metadata[beadmeta.SessionNameMetadataKey])) != route {
+			continue // claimed, closed, or re-routed since the snapshot — don't clobber
 		}
 		if setErr := store.SetMetadata(c.id, beadmeta.RoutedToMetadataKey, route); setErr != nil {
 			errs = append(errs, fmt.Errorf("bead %s: restoring gc.routed_to=%q: %w", c.id, route, setErr))
@@ -109,9 +145,15 @@ func sweepDetachedHandoffOrphansWithRouteStore(store, routeStore beads.Store) (i
 }
 
 // isDetachedHandoffOrphanCandidate reports whether b has the signature of a
-// fully-detached handoff orphan: open, unassigned, no pool route, branch set
-// (indicating work was done and pushed), and a session reference from which the
-// pool route can be recovered.
+// fully-detached handoff orphan: open, unassigned, no pool route (neither
+// gc.routed_to nor a legacy gc.run_target), no gc.kind, branch set (indicating
+// work was done and pushed), and a session back-reference — gc.session_id or
+// gc.session_name — from which the pool route can be recovered. This sweep's
+// novel domain is exactly work that carries *no* self-declared route: a bead
+// that still has gc.run_target is recovered earlier in the same tick by
+// restoreCarriedWorkRoutes from its own declared route, and any non-empty
+// gc.kind is a workflow-root/control/topology bead that carriedPoolRoute
+// deliberately keeps out of pool demand.
 func isDetachedHandoffOrphanCandidate(b beads.Bead) bool {
 	if b.Status != "open" {
 		return false
@@ -122,40 +164,124 @@ func isDetachedHandoffOrphanCandidate(b beads.Bead) bool {
 	if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) != "" {
 		return false // already has a pool route
 	}
-	if strings.TrimSpace(b.Metadata[beadmeta.KindMetadataKey]) == beadmeta.KindWorkflow {
-		return false // workflow roots use gc.run_target; restoreCarriedWorkRoutes handles them
+	if strings.TrimSpace(b.Metadata[beadmeta.RunTargetMetadataKey]) != "" {
+		return false // carries its own legacy route — restoreCarriedWorkRoutes recovers it from gc.run_target
 	}
-	if strings.TrimSpace(b.Metadata["branch"]) == "" {
-		return false // no branch → not a completed-work handoff bead
+	if strings.TrimSpace(b.Metadata[beadmeta.KindMetadataKey]) != "" {
+		return false // any non-empty kind is workflow-root/control/topology work, not fully-detached pool work
+	}
+	if strings.TrimSpace(b.Metadata[beadmeta.WorkBranchMetadataKey]) == "" {
+		return false // no work branch → not a completed-work handoff bead
+	}
+	// Accept either session back-reference. The claim path stamps gc.session_id
+	// whenever GC_SESSION_ID is set and adds gc.session_name only when
+	// GC_SESSION_NAME is also present (hookClaimIdentityPatch), so a valid
+	// session-ID-only orphan exists. route() resolves either, preferring the
+	// unique gc.session_id, so requiring gc.session_name here would strand a
+	// session-ID-only orphan the exact-ID resolver could recover.
+	if strings.TrimSpace(b.Metadata[beadmeta.SessionIDMetadataKey]) != "" {
+		return true
 	}
 	return strings.TrimSpace(b.Metadata[beadmeta.SessionNameMetadataKey]) != ""
 }
 
-// buildDetachedOrphanRouteIndex returns a map from session_name to pool route
-// for every session bead (open or closed) that carries a template. Closed
-// session beads are included because the worker session is typically gone by
-// the time this sweep runs.
-func buildDetachedOrphanRouteIndex(store beads.Store) (map[string]string, error) {
+// detachedOrphanRouteIndex resolves a detached orphan's pool route from its
+// session back-reference. It prefers an exact session-bead ID match — gc.session_id
+// is the unique bead ID of the claiming session, stamped next to gc.session_name at
+// claim time — and only falls back to gc.session_name when that name resolves
+// unambiguously: every session bead carrying it that has a route agrees on one
+// route. This mirrors internal/session/resolve.go's refusal to act on an ambiguous
+// session_name match, so a duplicated session name never restores work to the wrong
+// pool.
+type detachedOrphanRouteIndex struct {
+	byID   map[string]string // session-bead ID → pool route
+	byName map[string]string // session_name → pool route, only when unambiguous
+}
+
+// route resolves the pool route for a detached orphan, preferring the exact
+// session-bead ID over the session_name fallback. It returns "" when neither
+// resolves — including when the session_name was dropped as ambiguous.
+func (idx detachedOrphanRouteIndex) route(sessionID, sessionName string) string {
+	if sessionID != "" {
+		if r := idx.byID[sessionID]; r != "" {
+			return r
+		}
+	}
+	if sessionName != "" {
+		if r := idx.byName[sessionName]; r != "" {
+			return r
+		}
+	}
+	return ""
+}
+
+// backfill copies entries from other for keys idx does not already own, so the
+// primary store wins on conflict and the cross store only fills gaps. Both the ID
+// and the (already ambiguity-pruned) name maps are unioned this way.
+func (idx detachedOrphanRouteIndex) backfill(other detachedOrphanRouteIndex) {
+	for id, route := range other.byID {
+		if _, exists := idx.byID[id]; !exists {
+			idx.byID[id] = route
+		}
+	}
+	for sn, route := range other.byName {
+		if _, exists := idx.byName[sn]; !exists {
+			idx.byName[sn] = route
+		}
+	}
+}
+
+// buildDetachedOrphanRouteIndex indexes every session bead (open or closed) that
+// carries a template, keyed both by the session bead's ID (matched against a work
+// bead's gc.session_id) and by session_name. Closed session beads are included
+// because the worker session is typically gone by the time this sweep runs. A
+// session_name shared by session beads with conflicting routes is dropped from the
+// name index so an ambiguous name never resolves to an arbitrary route; the unique
+// per-ID entry still resolves such an orphan exactly.
+func buildDetachedOrphanRouteIndex(store beads.Store) (detachedOrphanRouteIndex, error) {
+	idx := detachedOrphanRouteIndex{byID: map[string]string{}, byName: map[string]string{}}
 	all, listErr := session.ListAllSessionBeads(store, beads.ListQuery{IncludeClosed: true})
 	// Hard errors return nil rows; surface them to the caller.
-	// Partial results still yield rows we can use — don't propagate.
-	if listErr != nil && !beads.IsPartialResult(listErr) {
-		return nil, fmt.Errorf("listing session beads: %w", listErr)
+	partial := beads.IsPartialResult(listErr)
+	if listErr != nil && !partial {
+		return detachedOrphanRouteIndex{}, fmt.Errorf("listing session beads: %w", listErr)
 	}
-	index := make(map[string]string, len(all))
+	// A partial list still yields usable rows, but it may be MISSING rows — so it
+	// cannot prove a session_name is unambiguous: a conflicting same-name session
+	// bead could sit in the unlisted partition and make byName silently resolve to
+	// an arbitrary pool route. Session-bead IDs are unique, so a partial list can
+	// only omit a byID entry (the orphan is simply not recovered this tick and
+	// retries next tick), never make an existing one ambiguous. So byID stays safe
+	// on a partial list while byName does not: populate byID always and skip byName
+	// entirely when the list is partial, degrading to exact-gc.session_id recovery.
+	ambiguousNames := map[string]bool{}
 	for _, sb := range all {
+		route := retiredSessionFallbackRoute(sb)
+		if route == "" {
+			continue // no template/agent_name → carries no recoverable route
+		}
+		if id := strings.TrimSpace(sb.ID); id != "" {
+			idx.byID[id] = route // session-bead IDs are unique; exact gc.session_id match
+		}
+		if partial {
+			continue // partial list can't prove name uniqueness — exact-ID recovery only
+		}
 		sn := strings.TrimSpace(sb.Metadata["session_name"])
 		if sn == "" {
 			continue
 		}
-		if _, exists := index[sn]; exists {
-			continue // keep first match; duplicate session names are rare edge cases
+		if existing, seen := idx.byName[sn]; seen {
+			if existing != route {
+				ambiguousNames[sn] = true // duplicate name resolving to conflicting routes
+			}
+			continue // keep first route; a matching duplicate is not a conflict
 		}
-		if route := retiredSessionFallbackRoute(sb); route != "" {
-			index[sn] = route
-		}
+		idx.byName[sn] = route
 	}
-	return index, nil
+	for sn := range ambiguousNames {
+		delete(idx.byName, sn) // refuse to guess a route for an ambiguous name
+	}
+	return idx, nil
 }
 
 // sweepDetachedHandoffOrphansAcrossStores sweeps for fully-detached handoff

--- a/cmd/gc/pool_detached_orphan_sweep_test.go
+++ b/cmd/gc/pool_detached_orphan_sweep_test.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// A worker that cleared both gc.routed_to and assignee in a failed done
+// sequence (e.g. $REFINERY_TARGET was empty) leaves the work bead
+// open+unassigned+unrouted with a branch on origin. The pool demand probe
+// can't see it (keys on gc.routed_to) and releaseOrphanedPoolAssignments
+// can't recover it (only processes assigned work). sweepDetachedHandoffOrphans
+// finds it via gc.session_name → session bead → template.
+func TestSweepDetachedHandoffOrphans_RestoresRoute(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "polecat session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "gastown__polecat-th-abc",
+			"template":     "gascity/gastown.polecat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:  "orphaned work",
+		Status: "open",
+		Metadata: map[string]string{
+			"branch":                          "polecat/ga-abc",
+			beadmeta.SessionNameMetadataKey:   sessionBead.Metadata["session_name"],
+			// gc.routed_to and assignee left empty by failed done sequence
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("restored=%d, want 1", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat" {
+		t.Fatalf("gc.routed_to=%q, want gascity/gastown.polecat", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee=%q, want empty", got.Assignee)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status=%q, want open", got.Status)
+	}
+}
+
+// A bead that still has gc.routed_to set must not be touched.
+func TestSweepDetachedHandoffOrphans_SkipsAlreadyRouted(t *testing.T) {
+	store := beads.NewMemStore()
+
+	work, err := store.Create(beads.Bead{
+		Title:  "routed work",
+		Status: "open",
+		Metadata: map[string]string{
+			"branch":                          "polecat/ga-routed",
+			beadmeta.SessionNameMetadataKey:   "some-session",
+			beadmeta.RoutedToMetadataKey:      "gascity/gastown.polecat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat" {
+		t.Fatalf("gc.routed_to changed unexpectedly to %q", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// A bead that still has an assignee must not be touched (covered by
+// releaseOrphanedPoolAssignments when the session closes).
+func TestSweepDetachedHandoffOrphans_SkipsAssigned(t *testing.T) {
+	store := beads.NewMemStore()
+
+	_, err := store.Create(beads.Bead{
+		Title:    "assigned work",
+		Status:   "open",
+		Assignee: "some-session-id",
+		Metadata: map[string]string{
+			"branch":                        "polecat/ga-assigned",
+			beadmeta.SessionNameMetadataKey: "some-session-id",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0 (assigned beads are not detached orphans)", n)
+	}
+}
+
+// Workflow-kind beads route via gc.run_target and are handled by
+// restoreCarriedWorkRoutes — the detached-orphan sweep must leave them alone.
+func TestSweepDetachedHandoffOrphans_SkipsWorkflowKind(t *testing.T) {
+	store := beads.NewMemStore()
+
+	_, err := store.Create(beads.Bead{
+		Title:  "workflow root",
+		Status: "open",
+		Metadata: map[string]string{
+			"branch":                        "polecat/ga-wf",
+			beadmeta.SessionNameMetadataKey: "some-session",
+			beadmeta.KindMetadataKey:        beadmeta.KindWorkflow,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0 (workflow-kind beads are not detached handoff orphans)", n)
+	}
+}
+
+// A bead with no branch set is not a completed-work bead and must be skipped.
+func TestSweepDetachedHandoffOrphans_SkipsNoBranch(t *testing.T) {
+	store := beads.NewMemStore()
+
+	_, err := store.Create(beads.Bead{
+		Title:  "no-branch bead",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.SessionNameMetadataKey: "some-session",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0 (no branch → not a completed-work bead)", n)
+	}
+}
+
+// A bead with no gc.session_name cannot be routed back to the pool because
+// we have no session reference to recover the route from.
+func TestSweepDetachedHandoffOrphans_SkipsNoSessionName(t *testing.T) {
+	store := beads.NewMemStore()
+
+	_, err := store.Create(beads.Bead{
+		Title:  "no-session work",
+		Status: "open",
+		Metadata: map[string]string{
+			"branch": "polecat/ga-nosession",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0 (no gc.session_name → can't recover route)", n)
+	}
+}
+
+// When the session bead is not found (e.g. already GC'd), the bead is left
+// untouched — no route to recover.
+func TestSweepDetachedHandoffOrphans_SkipsWhenSessionNotFound(t *testing.T) {
+	store := beads.NewMemStore()
+
+	work, err := store.Create(beads.Bead{
+		Title:  "orphan with missing session",
+		Status: "open",
+		Metadata: map[string]string{
+			"branch":                        "polecat/ga-gone",
+			beadmeta.SessionNameMetadataKey: "gastown__polecat-gone",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0 (session bead not found)", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "" {
+		t.Fatalf("gc.routed_to=%q, want empty (no session bead to recover from)", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// When the session bead exists but has no template/agent_name, no route can be
+// recovered — the bead is left untouched but not an error.
+func TestSweepDetachedHandoffOrphans_SkipsWhenSessionHasNoTemplate(t *testing.T) {
+	store := beads.NewMemStore()
+
+	_, err := store.Create(beads.Bead{
+		Title:  "templateless session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "unknown-session",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:  "orphan with templateless session",
+		Status: "open",
+		Metadata: map[string]string{
+			"branch":                        "polecat/ga-notempl",
+			beadmeta.SessionNameMetadataKey: "unknown-session",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0 (session has no template)", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "" {
+		t.Fatalf("gc.routed_to=%q, want empty", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// A closed session bead still carries the template we need — route recovery
+// works even after the worker session has been closed and GC-swept.
+func TestSweepDetachedHandoffOrphans_RecoverFromClosedSessionBead(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "closed polecat session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "gastown__polecat-th-closed",
+			"template":     "gascity/gastown.polecat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	// Close the session bead to simulate the dead-worker scenario.
+	closed := "closed"
+	if err := store.Update(sessionBead.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:  "orphaned work (closed session)",
+		Status: "open",
+		Metadata: map[string]string{
+			"branch":                        "polecat/ga-closed",
+			beadmeta.SessionNameMetadataKey: sessionBead.Metadata["session_name"],
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("restored=%d, want 1 (closed session bead still carries template)", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat" {
+		t.Fatalf("gc.routed_to=%q, want gascity/gastown.polecat", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// Multiple detached orphans from the same session are all recovered in one sweep.
+func TestSweepDetachedHandoffOrphans_MultipleCandidates(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "polecat session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "gastown__polecat-th-multi",
+			"template":     "gascity/gastown.polecat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := store.Create(beads.Bead{
+			Status: "open",
+			Metadata: map[string]string{
+				"branch":                        "polecat/ga-multi",
+				beadmeta.SessionNameMetadataKey: sessionBead.Metadata["session_name"],
+			},
+		}); err != nil {
+			t.Fatalf("create work bead %d: %v", i, err)
+		}
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("restored=%d, want 3", n)
+	}
+}
+
+// Nil store is a no-op.
+func TestSweepDetachedHandoffOrphans_NilStore(t *testing.T) {
+	n, err := sweepDetachedHandoffOrphans(nil)
+	if err != nil {
+		t.Fatalf("sweep nil store: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0 for nil store", n)
+	}
+}

--- a/cmd/gc/pool_detached_orphan_sweep_test.go
+++ b/cmd/gc/pool_detached_orphan_sweep_test.go
@@ -33,8 +33,8 @@ func TestSweepDetachedHandoffOrphans_RestoresRoute(t *testing.T) {
 		Title:  "orphaned work",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch":                          "polecat/ga-abc",
-			beadmeta.SessionNameMetadataKey:   sessionBead.Metadata["session_name"],
+			"branch":                        "polecat/ga-abc",
+			beadmeta.SessionNameMetadataKey: sessionBead.Metadata["session_name"],
 			// gc.routed_to and assignee left empty by failed done sequence
 		},
 	})
@@ -73,9 +73,9 @@ func TestSweepDetachedHandoffOrphans_SkipsAlreadyRouted(t *testing.T) {
 		Title:  "routed work",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch":                          "polecat/ga-routed",
-			beadmeta.SessionNameMetadataKey:   "some-session",
-			beadmeta.RoutedToMetadataKey:      "gascity/gastown.polecat",
+			"branch":                        "polecat/ga-routed",
+			beadmeta.SessionNameMetadataKey: "some-session",
+			beadmeta.RoutedToMetadataKey:    "gascity/gastown.polecat",
 		},
 	})
 	if err != nil {

--- a/cmd/gc/pool_detached_orphan_sweep_test.go
+++ b/cmd/gc/pool_detached_orphan_sweep_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestSweepDetachedHandoffOrphans_RestoresRoute(t *testing.T) {
 		Title:  "orphaned work",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch":                        "polecat/ga-abc",
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-abc",
 			beadmeta.SessionNameMetadataKey: sessionBead.Metadata["session_name"],
 			// gc.routed_to and assignee left empty by failed done sequence
 		},
@@ -74,7 +75,7 @@ func TestSweepDetachedHandoffOrphans_SkipsAlreadyRouted(t *testing.T) {
 		Title:  "routed work",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch":                        "polecat/ga-routed",
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-routed",
 			beadmeta.SessionNameMetadataKey: "some-session",
 			beadmeta.RoutedToMetadataKey:    "gascity/gastown.polecat",
 		},
@@ -110,7 +111,7 @@ func TestSweepDetachedHandoffOrphans_SkipsAssigned(t *testing.T) {
 		Status:   "open",
 		Assignee: "some-session-id",
 		Metadata: map[string]string{
-			"branch":                        "polecat/ga-assigned",
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-assigned",
 			beadmeta.SessionNameMetadataKey: "some-session-id",
 		},
 	})
@@ -136,7 +137,7 @@ func TestSweepDetachedHandoffOrphans_SkipsWorkflowKind(t *testing.T) {
 		Title:  "workflow root",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch":                        "polecat/ga-wf",
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-wf",
 			beadmeta.SessionNameMetadataKey: "some-session",
 			beadmeta.KindMetadataKey:        beadmeta.KindWorkflow,
 		},
@@ -187,7 +188,7 @@ func TestSweepDetachedHandoffOrphans_SkipsNoSessionName(t *testing.T) {
 		Title:  "no-session work",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch": "polecat/ga-nosession",
+			beadmeta.WorkBranchMetadataKey: "polecat/ga-nosession",
 		},
 	})
 	if err != nil {
@@ -212,7 +213,7 @@ func TestSweepDetachedHandoffOrphans_SkipsWhenSessionNotFound(t *testing.T) {
 		Title:  "orphan with missing session",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch":                        "polecat/ga-gone",
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-gone",
 			beadmeta.SessionNameMetadataKey: "gastown__polecat-gone",
 		},
 	})
@@ -258,7 +259,7 @@ func TestSweepDetachedHandoffOrphans_SkipsWhenSessionHasNoTemplate(t *testing.T)
 		Title:  "orphan with templateless session",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch":                        "polecat/ga-notempl",
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-notempl",
 			beadmeta.SessionNameMetadataKey: "unknown-session",
 		},
 	})
@@ -310,7 +311,7 @@ func TestSweepDetachedHandoffOrphans_RecoverFromClosedSessionBead(t *testing.T) 
 		Title:  "orphaned work (closed session)",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch":                        "polecat/ga-closed",
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-closed",
 			beadmeta.SessionNameMetadataKey: sessionBead.Metadata["session_name"],
 		},
 	})
@@ -356,7 +357,7 @@ func TestSweepDetachedHandoffOrphans_MultipleCandidates(t *testing.T) {
 		if _, err := store.Create(beads.Bead{
 			Status: "open",
 			Metadata: map[string]string{
-				"branch":                        "polecat/ga-multi",
+				beadmeta.WorkBranchMetadataKey:  "polecat/ga-multi",
 				beadmeta.SessionNameMetadataKey: sessionBead.Metadata["session_name"],
 			},
 		}); err != nil {
@@ -411,7 +412,7 @@ func TestSweepDetachedHandoffOrphansAcrossStores_RigOrphanCityStoredSession(t *t
 		Title:  "orphaned rig work",
 		Status: "open",
 		Metadata: map[string]string{
-			"branch":                        "polecat/ga-xyz",
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-xyz",
 			beadmeta.SessionNameMetadataKey: "gastown__polecat-th-xyz",
 			// gc.routed_to and assignee left empty by the failed done sequence
 		},
@@ -428,6 +429,551 @@ func TestSweepDetachedHandoffOrphansAcrossStores_RigOrphanCityStoredSession(t *t
 	got, err := rigStore.Get(work.ID)
 	if err != nil {
 		t.Fatalf("get rig work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat" {
+		t.Fatalf("gc.routed_to=%q, want gascity/gastown.polecat", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// A candidate that is blocked in the backing store (bd blocked/review/testing,
+// which mapBdStatus collapses to "open" on every decoded read) must NOT be
+// re-stamped. The cached candidate List returns it as ready; only a Live query
+// reaches bd's raw-status filter and correctly omits it. This is the gc-4zb
+// class the sibling restoreCarriedWorkRoutes already guards — the MemStore-only
+// suite could not reproduce it because MemStore stores the literal status. The
+// closing session bead lives in a distinct plain routeStore so the route IS
+// recoverable and the only thing standing between the sweep and a re-stamp is
+// the Live candidate List. Fails against a non-Live candidate List (restored=1);
+// passes with Live (collapsedBlockedStatusStore serves nil to a Live query).
+func TestSweepDetachedHandoffOrphans_SkipsBlockedCollapsedCandidate(t *testing.T) {
+	const sessionName = "gastown__polecat-th-blk"
+	// Backing store: the candidate is blocked in bd but decodes as "open"
+	// (mapBdStatus), carrying the full detached-orphan signature with an
+	// already-consumed (empty) gc.routed_to.
+	live := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "EB-blk", Title: "finalize", Type: "task", Status: "open", Metadata: map[string]string{
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-blk",
+			beadmeta.SessionNameMetadataKey: sessionName,
+		}},
+	}, nil)
+	store := collapsedBlockedStatusStore{
+		Store: live,
+		cachedSnapshot: []beads.Bead{
+			{ID: "EB-blk", Title: "finalize", Type: "task", Status: "open", Metadata: map[string]string{
+				beadmeta.WorkBranchMetadataKey:  "polecat/ga-blk",
+				beadmeta.SessionNameMetadataKey: sessionName,
+			}},
+		},
+		// bd's --status=open filter sees raw status=blocked and excludes it.
+		liveSnapshot: nil,
+	}
+	routeStore := beads.NewMemStore()
+	if _, err := routeStore.Create(beads.Bead{
+		Title:  "polecat session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": sessionName,
+			"template":     "gascity/gastown.polecat",
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	restored, err := sweepDetachedHandoffOrphansWithRouteStore(store, routeStore)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if restored != 0 {
+		t.Fatalf("restored=%d, want 0 (a blocked/collapsed candidate must not be re-stamped)", restored)
+	}
+	if got := mustRoutedTo(t, live, "EB-blk"); got != "" {
+		t.Errorf("gc.routed_to=%q, want empty (a blocked bead must stay unrouted)", got)
+	}
+}
+
+// A candidate that a worker claims in the window between the open-bead List
+// snapshot and the per-candidate write must NOT be re-stamped. On production
+// CachingStores a plain Get can still return the pre-claim cached bead, so the
+// sweep must re-read through the authoritative cache-bypassing live handle. Here
+// the stale cache serves the open candidate to both List and plain Get, while
+// the live backing store already holds the claim (in_progress, assigned, route
+// consumed — ga-sa0/ga-bgu). Fails against a blind SetMetadata (restored=1);
+// passes with the handles.Live.Get re-read.
+func TestSweepDetachedHandoffOrphans_SkipsRaceClaimedCandidate(t *testing.T) {
+	const sessionName = "gastown__polecat-th-race"
+	// Backing/live store: the bead has ALREADY been claimed — open->in_progress,
+	// assignee set, gc.routed_to consumed.
+	live := beads.NewMemStoreFrom(0, []beads.Bead{
+		{
+			ID: "EB-race", Title: "work", Type: "task", Status: "in_progress",
+			Assignee: "gascity/gastown.polecat/th-race", Metadata: map[string]string{
+				beadmeta.WorkBranchMetadataKey:  "polecat/ga-race",
+				beadmeta.SessionNameMetadataKey: sessionName,
+			},
+		},
+	}, nil)
+	// Stale cache: List and plain Get still return the pre-claim candidate — open,
+	// unassigned, unrouted — so a blind re-stamp would clobber the claim. Only
+	// HandlesFor(store).Live.Get reaches the live claim.
+	store := staleCacheStore{
+		Store: live,
+		cached: beads.Bead{
+			ID: "EB-race", Title: "work", Type: "task", Status: "open", Metadata: map[string]string{
+				beadmeta.WorkBranchMetadataKey:  "polecat/ga-race",
+				beadmeta.SessionNameMetadataKey: sessionName,
+			},
+		},
+	}
+	routeStore := beads.NewMemStore()
+	if _, err := routeStore.Create(beads.Bead{
+		Title:  "polecat session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": sessionName,
+			"template":     "gascity/gastown.polecat",
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	restored, err := sweepDetachedHandoffOrphansWithRouteStore(store, routeStore)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if restored != 0 {
+		t.Fatalf("restored=%d, want 0 (a candidate claimed since the snapshot must not be re-stamped)", restored)
+	}
+	// The claim's route consumption must survive in the live store.
+	if got := mustRoutedTo(t, live, "EB-race"); got != "" {
+		t.Errorf("gc.routed_to=%q, want empty (claim consumed the route; sweep must not re-stamp)", got)
+	}
+	b, err := live.Get("EB-race")
+	if err != nil {
+		t.Fatalf("get EB-race: %v", err)
+	}
+	if b.Status != "in_progress" || b.Assignee == "" {
+		t.Errorf("EB-race status=%q assignee=%q, want in_progress + assigned (untouched)", b.Status, b.Assignee)
+	}
+}
+
+// A production claim stamps gc.work_branch, gc.session_id, AND gc.session_name
+// together in one hookClaimIdentityPatch — never a raw "branch" key. This is the
+// exact shape a detached orphan carries in production; before the branch gate read
+// gc.work_branch it was skipped and no route was ever restored. Route recovery
+// resolves through the exact gc.session_id → session-bead ID match. Pins F1.
+func TestSweepDetachedHandoffOrphans_ClaimShapedRoute(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "polecat session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "gastown__polecat-th-claim",
+			"template":     "gascity/gastown.polecat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:  "claim-shaped orphan",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-claim",
+			beadmeta.SessionIDMetadataKey:   sessionBead.ID,
+			beadmeta.SessionNameMetadataKey: sessionBead.Metadata["session_name"],
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	// The regression contract: production never stamps a raw "branch" key.
+	if _, ok := work.Metadata["branch"]; ok {
+		t.Fatalf("fixture must not carry a raw \"branch\" key — production stamps gc.work_branch")
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("restored=%d, want 1 (claim-shaped orphan must be recovered via gc.work_branch)", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat" {
+		t.Fatalf("gc.routed_to=%q, want gascity/gastown.polecat", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// Two historical session beads can share a session_name while resolving to
+// different pool routes. Claimed work also carries gc.session_id — the unique
+// session-bead ID — so route recovery must prefer that exact match and restore the
+// orphan to ITS session's route, not the first duplicate's. Mirrors
+// internal/session/resolve.go preferring an exact id over an ambiguous name.
+func TestSweepDetachedHandoffOrphans_DuplicateSessionNamePrefersSessionID(t *testing.T) {
+	store := beads.NewMemStore()
+
+	const sharedName = "gastown__polecat-dup"
+	// First session with this name routes to polecat-a.
+	if _, err := store.Create(beads.Bead{
+		Title:  "polecat session A",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": sharedName,
+			"template":     "gascity/gastown.polecat-a",
+		},
+	}); err != nil {
+		t.Fatalf("create session bead A: %v", err)
+	}
+	// Second session reuses the name but routes to polecat-b.
+	sessionB, err := store.Create(beads.Bead{
+		Title:  "polecat session B",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": sharedName,
+			"template":     "gascity/gastown.polecat-b",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead B: %v", err)
+	}
+
+	// The orphan belongs to session B by exact gc.session_id, though its name is shared.
+	work, err := store.Create(beads.Bead{
+		Title:  "orphan owned by session B",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-dup",
+			beadmeta.SessionIDMetadataKey:   sessionB.ID,
+			beadmeta.SessionNameMetadataKey: sharedName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("restored=%d, want 1 (exact gc.session_id must resolve even with a duplicated name)", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat-b" {
+		t.Fatalf("gc.routed_to=%q, want gascity/gastown.polecat-b (session B's route, chosen by gc.session_id)", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// When a session_name is shared by sessions resolving to conflicting routes and
+// the orphan carries NO gc.session_id to disambiguate, the sweep must refuse to
+// guess — restoring to an arbitrary one could hand the work to the wrong pool.
+// Mirrors internal/session/resolve.go treating an ambiguous match as an error.
+func TestSweepDetachedHandoffOrphans_AmbiguousSessionNameWithoutSessionID(t *testing.T) {
+	store := beads.NewMemStore()
+
+	const sharedName = "gastown__polecat-ambig"
+	for _, tmpl := range []string{"gascity/gastown.polecat-a", "gascity/gastown.polecat-b"} {
+		if _, err := store.Create(beads.Bead{
+			Title:  "polecat session " + tmpl,
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"session_name": sharedName,
+				"template":     tmpl,
+			},
+		}); err != nil {
+			t.Fatalf("create session bead %s: %v", tmpl, err)
+		}
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:  "orphan with only an ambiguous name",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-ambig",
+			beadmeta.SessionNameMetadataKey: sharedName,
+			// no gc.session_id — nothing to disambiguate the shared name
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0 (an ambiguous session_name with no gc.session_id must not be guessed)", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "" {
+		t.Fatalf("gc.routed_to=%q, want empty (ambiguous name must not resolve to an arbitrary route)", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// A session_name shared by sessions that all resolve to the SAME route is not
+// ambiguous — every match agrees — so an orphan carrying only that name (no
+// gc.session_id) is still recovered. Only conflicting routes force the refuse-to-
+// guess path; agreement resolves.
+func TestSweepDetachedHandoffOrphans_DuplicateSessionNameAgreeingRouteResolves(t *testing.T) {
+	store := beads.NewMemStore()
+
+	const sharedName = "gastown__polecat-agree"
+	for i := 0; i < 2; i++ {
+		if _, err := store.Create(beads.Bead{
+			Title:  "polecat session",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"session_name": sharedName,
+				"template":     "gascity/gastown.polecat",
+			},
+		}); err != nil {
+			t.Fatalf("create session bead %d: %v", i, err)
+		}
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:  "orphan with an agreeing duplicated name",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-agree",
+			beadmeta.SessionNameMetadataKey: sharedName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("restored=%d, want 1 (a duplicated name whose matches agree must still resolve)", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat" {
+		t.Fatalf("gc.routed_to=%q, want gascity/gastown.polecat", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// A production claim may stamp gc.session_id WITHOUT gc.session_name: the hook
+// path stamps gc.session_id whenever GC_SESSION_ID is set but adds
+// gc.session_name only when GC_SESSION_NAME is also present
+// (hookClaimIdentityPatch, cmd_hook_claim.go). Such a session-ID-only orphan is
+// a valid shape, and the exact gc.session_id → session-bead ID resolver can
+// recover it — so the candidate gate must accept it even though gc.session_name
+// is absent. Before the fix isDetachedHandoffOrphanCandidate required
+// gc.session_name and stranded this orphan invisibly, unreachable by the exact-ID
+// resolver. Pins the session-ID-only candidate fix.
+func TestSweepDetachedHandoffOrphans_SessionIDOnlyNoSessionName(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "polecat session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "gastown__polecat-th-idonly",
+			"template":     "gascity/gastown.polecat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:  "session-id-only orphan",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkBranchMetadataKey: "polecat/ga-idonly",
+			beadmeta.SessionIDMetadataKey:  sessionBead.ID,
+			// no gc.session_name — GC_SESSION_NAME was unset at claim time
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	// The regression contract: this orphan carries no gc.session_name at all.
+	if _, ok := work.Metadata[beadmeta.SessionNameMetadataKey]; ok {
+		t.Fatalf("fixture must not carry gc.session_name — it pins the session-ID-only shape")
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("restored=%d, want 1 (a gc.session_id-only orphan must recover via the exact ID match)", n)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat" {
+		t.Fatalf("gc.routed_to=%q, want gascity/gastown.polecat", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// partialUnionSessionStore models a bd session-bead List that returns a PARTIAL
+// result: some session rows failed to parse (or one tier was unavailable), so
+// ListAllSessionBeads folds the incomplete rows in and returns a
+// PartialResultError alongside them. Only the two session-bead union legs (by
+// Type=session and by Label=gc:session, matching ListAllSessionBeads) return the
+// partial subset; the candidate open-bead scan (Type/Label empty) delegates to
+// the backing store. A conflicting same-name session bead lives in the unlisted
+// partition, so the visible subset cannot detect the ambiguity.
+type partialUnionSessionStore struct {
+	beads.Store                  // backing store: holds the detached orphan
+	partialSessions []beads.Bead // the incomplete session-bead subset surfaced by List
+}
+
+func (s partialUnionSessionStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if q.Type == sessionBeadType || q.Label == sessionBeadLabel {
+		return append([]beads.Bead(nil), s.partialSessions...),
+			&beads.PartialResultError{Op: "bd list", Err: errors.New("a session row failed to parse")}
+	}
+	return s.Store.List(q)
+}
+
+// When ListAllSessionBeads returns a PartialResultError, the missing partition
+// can hide a conflicting same-name session bead, so an ambiguous gc.session_name
+// would silently resolve to whichever duplicate happened to be listed. The
+// route-index build must treat a partial list as unsafe for the byName fallback
+// and recover only by exact gc.session_id. Here two sessions share a name and
+// resolve to CONFLICTING routes, but only one is visible in the partial list and
+// the orphan carries no gc.session_id — so it must remain unrouted rather than be
+// guessed onto the visible route. Before the fix the visible duplicate populated
+// byName and the orphan was restored to an arbitrary pool. Pins the partial-list
+// name-fallback fix.
+func TestSweepDetachedHandoffOrphans_PartialSessionListSkipsNameFallback(t *testing.T) {
+	const sharedName = "gastown__polecat-partial"
+
+	// Backing store: just the detached orphan, carrying only the shared name.
+	backing := beads.NewMemStore()
+	work, err := backing.Create(beads.Bead{
+		Title:  "orphan with an ambiguous name under a partial session list",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-partial",
+			beadmeta.SessionNameMetadataKey: sharedName,
+			// no gc.session_id — nothing to disambiguate the shared name
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	// The partial session list surfaces only ONE of two conflicting same-name
+	// sessions (route polecat-a). The orphan's true owner (route polecat-b) is in
+	// the unlisted partition, invisible to the ambiguity check.
+	store := partialUnionSessionStore{
+		Store: backing,
+		partialSessions: []beads.Bead{{
+			ID:     "SB-partial-a",
+			Title:  "polecat session A",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Status: "open",
+			Metadata: map[string]string{
+				"session_name": sharedName,
+				"template":     "gascity/gastown.polecat-a",
+			},
+		}},
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("restored=%d, want 0 (a partial session list must not resolve an ambiguous name)", n)
+	}
+
+	got, err := backing.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "" {
+		t.Fatalf("gc.routed_to=%q, want empty (partial list must not guess a name-only route)", got.Metadata[beadmeta.RoutedToMetadataKey])
+	}
+}
+
+// A partial session list still recovers an orphan that carries an exact
+// gc.session_id: session-bead IDs are unique, so a partial list can only omit an
+// ID entry entirely (recovered on a later complete tick), never make one
+// ambiguous. The byID map therefore stays trustworthy even when byName is
+// suppressed. This guards the fix from over-correcting into "partial list → never
+// recover anything," which would strand an exactly-identified orphan.
+func TestSweepDetachedHandoffOrphans_PartialSessionListStillResolvesByID(t *testing.T) {
+	const sharedName = "gastown__polecat-partial-id"
+
+	backing := beads.NewMemStore()
+	work, err := backing.Create(beads.Bead{
+		Title:  "orphan recoverable by exact id under a partial list",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkBranchMetadataKey:  "polecat/ga-partial-id",
+			beadmeta.SessionIDMetadataKey:   "SB-partial-id",
+			beadmeta.SessionNameMetadataKey: sharedName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	store := partialUnionSessionStore{
+		Store: backing,
+		partialSessions: []beads.Bead{{
+			ID:     "SB-partial-id",
+			Title:  "polecat session",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Status: "open",
+			Metadata: map[string]string{
+				"session_name": sharedName,
+				"template":     "gascity/gastown.polecat",
+			},
+		}},
+	}
+
+	n, err := sweepDetachedHandoffOrphans(store)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("restored=%d, want 1 (exact gc.session_id must still resolve under a partial list)", n)
+	}
+
+	got, err := backing.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
 	}
 	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat" {
 		t.Fatalf("gc.routed_to=%q, want gascity/gastown.polecat", got.Metadata[beadmeta.RoutedToMetadataKey])

--- a/cmd/gc/pool_detached_orphan_sweep_test.go
+++ b/cmd/gc/pool_detached_orphan_sweep_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
@@ -380,5 +381,55 @@ func TestSweepDetachedHandoffOrphans_NilStore(t *testing.T) {
 	}
 	if n != 0 {
 		t.Fatalf("restored=%d, want 0 for nil store", n)
+	}
+}
+
+// A detached handoff orphan can live in a RIG store while its closing session
+// bead lives in the CITY store — the common case sweepDetachedHandoffOrphansAcross
+// Stores exists for. The route index must be built from the city store too, or
+// the rig-stored orphan's session bead is never found and it is never recovered.
+// Cross-store round-trip through the public entry point.
+func TestSweepDetachedHandoffOrphansAcrossStores_RigOrphanCityStoredSession(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	// Session bead lives in the CITY store (where session beads live).
+	if _, err := cityStore.Create(beads.Bead{
+		Title:  "polecat session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "gastown__polecat-th-xyz",
+			"template":     "gascity/gastown.polecat",
+		},
+	}); err != nil {
+		t.Fatalf("create city session bead: %v", err)
+	}
+
+	// Detached orphan lives in the RIG store, referencing the city-stored session.
+	work, err := rigStore.Create(beads.Bead{
+		Title:  "orphaned rig work",
+		Status: "open",
+		Metadata: map[string]string{
+			"branch":                        "polecat/ga-xyz",
+			beadmeta.SessionNameMetadataKey: "gastown__polecat-th-xyz",
+			// gc.routed_to and assignee left empty by the failed done sequence
+		},
+	})
+	if err != nil {
+		t.Fatalf("create rig work bead: %v", err)
+	}
+
+	n := sweepDetachedHandoffOrphansAcrossStores(cityStore, map[string]beads.Store{"ga": rigStore}, "test", io.Discard)
+	if n != 1 {
+		t.Fatalf("restored=%d, want 1 (rig orphan recovered via city-stored session bead)", n)
+	}
+
+	got, err := rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get rig work bead: %v", err)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "gascity/gastown.polecat" {
+		t.Fatalf("gc.routed_to=%q, want gascity/gastown.polecat", got.Metadata[beadmeta.RoutedToMetadataKey])
 	}
 }

--- a/cmd/gc/typedclass_edge_guard_test.go
+++ b/cmd/gc/typedclass_edge_guard_test.go
@@ -154,6 +154,12 @@ var typedClassCodecCensus = map[string]map[string]int{
 	// against a re-leaked / locally-redefined codec. internal/session's own white-box
 	// tests renamed WITH the codec and are not in any scan dir.
 	"ListAllSessionBeads(": {
+		// pool_detached_orphan_sweep's route-index build lists session beads
+		// (IncludeClosed) to read persisted route metadata (gc.session_id /
+		// gc.work_branch) raw when restoring gc.routed_to for fully-detached handoff
+		// orphans — the same still-raw floor as session_beads below, tracked here so the
+		// sanctioned fold-in is visible pending the W-sync typing wave.
+		"cmd/gc/pool_detached_orphan_sweep.go": 1,
 		// WI-7 W-delete zeroed session_bead_snapshot (1→0, the raw-half load edge flipped
 		// to ListAllForReconcile) and doctor_session_model (1→0, doctor issues its own two
 		// raw store.List legs inline rather than calling the policed helper — its §5


### PR DESCRIPTION
## Problem

When a worker's done-sequence clears both the assignee and the routing key (`gc.routed_to`) in a single atomic update — the pre-fix behavior that occurs when the refinery target resolves empty — the work bead is left `open`, unassigned, and unrouted, with a branch already pushed to origin.

That state is invisible to both recovery paths:

- the pool demand probe keys on `gc.routed_to`, which is now empty, and
- the assigned-work orphan release only processes *assigned* work.

So the bead stalls indefinitely until someone manually re-slings it, even though the work itself is finished and pushed.

## Fix

Add `sweepDetachedHandoffOrphans` / `sweepDetachedHandoffOrphansAcrossStores` in `pool_detached_orphan_sweep.go`. On every reconcile tick, after the assigned-work orphan sweep, it scans `open`+unassigned beads for the detached-orphan signature (no `gc.routed_to`, no run target, a branch set, and a session name set), looks up the original pool route from the session bead's template metadata, and re-stamps `gc.routed_to` so the bead re-enters pool demand.

- The route is sourced as a judgment-free copy of the route already recorded in the closing session's template — it never invents a route, so it cannot mis-route.
- It covers the city store and all active rig stores.
- Workflow-kind beads are skipped (those are handled by the carried-route recovery in the companion change).

## Verification

- Cherry-picks cleanly onto `main`; `go build ./...` is clean and `go vet ./cmd/gc/` is clean.
- A new test file (`pool_detached_orphan_sweep_test.go`) exercises the signature match, the route lookup from session-template metadata, the multi-store sweep, and the workflow-bead skip.

Companion to #3377 (handoff-orphan recovery); independent and builds standalone.
