### PR TITLE
fix(controller): backfill gc.routed_to from a bead's own gc.run_target so carried-route work re-enters pool demand

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -508,6 +508,20 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		return
 	}
 
+	// Recover ready work whose canonical pool route was lost or never written
+	// (gc.run_target set, gc.routed_to empty) before session reconciliation, so a
+	// post-restart rig re-enters pool demand without a manual `gc sling`
+	// (ga-n2d.4). Placed before the expensive reconcile for the same reason as
+	// startup-orders: routed demand should not wait behind cold-start drift work.
+	startupRouteRecoveryStart := time.Now()
+	cr.safeTick(func() {
+		cr.recoverUnroutedWorkRoutes()
+	}, "startup-route-recovery")
+	logPhaseElapsed("startup-route-recovery", startupRouteRecoveryStart)
+	if ctx.Err() != nil {
+		return
+	}
+
 	// Session bead sync BEFORE reconciliation: ensures beads exist for
 	// the reconciler to read/write hashes. Uses ListByLabel (indexed,
 	// fast even before CachingStore is primed).
@@ -1044,6 +1058,17 @@ func (cr *CityRuntime) tick(
 	phaseStart = time.Now()
 	cr.dispatchOrders(ctx, cityRoot)
 	recordPhase(TraceSiteOrderDispatch, "dispatch_orders", phaseStart, nil)
+	if ctx.Err() != nil {
+		return
+	}
+
+	// Re-route ready work whose canonical pool route was lost or never written
+	// (gc.run_target set, gc.routed_to empty), so the autoscaler — which keys on
+	// gc.routed_to — sees it as demand without a manual `gc sling` (ga-n2d.4).
+	// Runs in the cheap dispatch phase before the expensive session reconcile.
+	phaseStart = time.Now()
+	cr.recoverUnroutedWorkRoutes()
+	recordPhase(TraceSiteControllerTickPhase, "recover_unrouted_work_routes", phaseStart, nil)
 	if ctx.Err() != nil {
 		return
 	}

--- a/cmd/gc/route_recovery.go
+++ b/cmd/gc/route_recovery.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// carriedPoolRoute returns the pool route a bead already declares for itself and
+// that the controller may safely restore to gc.routed_to, or "" when the bead
+// carries no recoverable route. Two bead shapes carry a legacy gc.run_target
+// pool route: a plain (kind-less) standalone work bead — this fork's dominant
+// work shape — and a pre-ga-eld2x workflow root (recognized by
+// legacyWorkflowRunTarget).
+//
+// Control-dispatcher (retry, ralph, …) and other workflow-topology (scope, spec)
+// beads also carry a bare gc.run_target, but there it is a dispatch/structure
+// target an agent never claims from a pool; restoring gc.routed_to on one would
+// mis-route it into pool demand, so they yield "". The choice is judgment-free
+// (ZFC): it copies a route the bead already declares and never invents a target.
+// Idempotent: a bead that already carries gc.routed_to yields "".
+func carriedPoolRoute(b beads.Bead) string {
+	// Legacy pre-ga-eld2x workflow root: gc.run_target is the root's pool route
+	// only while gc.routed_to is empty — exactly legacyWorkflowRunTarget's rule.
+	if route := legacyWorkflowRunTarget(b); route != "" {
+		return route
+	}
+	// Broaden beyond workflow roots to plain standalone work beads. Any non-empty
+	// gc.kind reaching here is a control-dispatcher or workflow-topology construct
+	// (legacyWorkflowRunTarget already consumed the lone claimable kind,
+	// "workflow"), so its gc.run_target is not a recoverable pool route.
+	if strings.TrimSpace(b.Metadata[beadmeta.KindMetadataKey]) != "" {
+		return ""
+	}
+	if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) != "" {
+		return ""
+	}
+	return strings.TrimSpace(b.Metadata[beadmeta.RunTargetMetadataKey])
+}
+
+// restoreCarriedWorkRoutes re-stamps gc.routed_to from the route a bead already
+// carries (its legacy gc.run_target route, via carriedPoolRoute) for open,
+// unassigned work whose canonical pool route was lost or never written. It
+// returns the number of beads whose route it restored.
+//
+// The pool autoscaler keys exclusively on gc.routed_to, so an open work bead
+// that carries a gc.run_target hint but an empty gc.routed_to is invisible to
+// pool demand and never spawns a worker — the post-restart stall in ga-n2d.4
+// (ready beads, 0 routed, 0 workers, until a manual `gc sling`). The controller
+// runs this on startup and on every patrol tick so such work re-enters demand
+// on its own. It is the automatic, broader-scoped promotion of the manual
+// `gc doctor --fix` run-target-routed-to-backfill check.
+//
+// The recovery is judgment-free and cannot mis-route (ZFC): carriedPoolRoute
+// only copies a route the bead already declares and skips control-dispatcher and
+// topology beads. A bead with no carried route is left for its owner to sling —
+// which pool ad-hoc work belongs to is the owner's judgment, not the
+// controller's. Idempotent: an already-routed bead yields no route and is
+// skipped.
+func restoreCarriedWorkRoutes(store beads.Store) (int, error) {
+	if store == nil {
+		return 0, nil
+	}
+	// Open work is the only place a lost pool route can be recovered: closed or
+	// in-progress beads need no route restored. Scanning open beads (not the
+	// whole store) keeps the hot reconcile path cheap while still seeing both
+	// carriers of a legacy route — plain work beads and workflow roots — which a
+	// gc.kind=workflow query would miss. Mirrors sweepDetachedHandoffOrphans'
+	// open-bead scan (AllowScan acknowledges the intentional population read).
+	items, err := store.List(beads.ListQuery{Status: "open", AllowScan: true})
+	if err != nil {
+		return 0, fmt.Errorf("listing open work: %w", err)
+	}
+	var (
+		restored int
+		errs     []error
+	)
+	for _, b := range items {
+		route := carriedPoolRoute(b)
+		if route == "" {
+			continue
+		}
+		// Only re-route open, unassigned work: an assigned bead is already
+		// claimed. (Belt-and-braces with the Status:"open" query so the guarantee
+		// holds regardless of store-level filtering semantics.)
+		if b.Status != "open" || strings.TrimSpace(b.Assignee) != "" {
+			continue
+		}
+		if setErr := store.SetMetadata(b.ID, beadmeta.RoutedToMetadataKey, route); setErr != nil {
+			errs = append(errs, fmt.Errorf("bead %s: restoring gc.routed_to=%q: %w", b.ID, route, setErr))
+			continue
+		}
+		restored++
+	}
+	return restored, errors.Join(errs...)
+}
+
+// routeRecoveryScope pairs a bead store with a human label for logging.
+type routeRecoveryScope struct {
+	label string
+	store beads.Store
+}
+
+// recoverUnroutedWorkRoutes restores gc.routed_to from each bead's own carried
+// route across the city store and every active rig store, so ready work
+// re-enters pool demand after a controller restart without a manual `gc sling`
+// (ga-n2d.4). Best-effort: a per-store failure is logged and the remaining
+// stores still run.
+func (cr *CityRuntime) recoverUnroutedWorkRoutes() {
+	scopes := []routeRecoveryScope{{label: "city", store: cr.cityBeadStore()}}
+	for name, store := range cr.rigBeadStores() {
+		scopes = append(scopes, routeRecoveryScope{label: "rig " + name, store: store})
+	}
+	for _, sc := range scopes {
+		if sc.store == nil {
+			continue
+		}
+		restored, err := restoreCarriedWorkRoutes(sc.store)
+		if err != nil {
+			fmt.Fprintf(cr.stderr, "%s: route recovery (%s): %v\n", cr.logPrefix, sc.label, err) //nolint:errcheck // best-effort stderr
+		}
+		if restored > 0 {
+			fmt.Fprintf(cr.stderr, "%s: route recovery (%s): restored gc.routed_to on %d ready bead(s) from gc.run_target\n", cr.logPrefix, sc.label, restored) //nolint:errcheck // best-effort stderr
+		}
+	}
+}

--- a/cmd/gc/route_recovery_test.go
+++ b/cmd/gc/route_recovery_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"io"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestRestoreCarriedWorkRoutes covers ga-n2d.4: after a controller restart,
+// open+unassigned work that carries a gc.run_target pool route but no
+// gc.routed_to is invisible to the pool autoscaler (which keys on gc.routed_to)
+// and never spawns a worker. restoreCarriedWorkRoutes must re-stamp gc.routed_to
+// from the route the bead already declares, for both carriers of a legacy route
+// — a plain (kind-less) standalone work bead and a pre-ga-eld2x workflow root —
+// while leaving every bead for which gc.run_target is not a recoverable pool
+// route untouched: already-routed, assigned, closed, control-dispatcher, and
+// workflow-topology beads.
+func TestRestoreCarriedWorkRoutes(t *testing.T) {
+	const pool = "gascity/gastown.polecat"
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		// Recoverable: open workflow root, run_target set, routed_to empty.
+		{ID: "WR-1", Title: "root", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.kind": "workflow", "gc.run_target": pool,
+		}},
+		// Already routed — left alone (idempotent, no double-write).
+		{ID: "WR-2", Title: "root", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.kind": "workflow", "gc.run_target": pool, "gc.routed_to": "gascity/gastown.refinery",
+		}},
+		// Assigned workflow root — already claimed, no route restored.
+		{ID: "WR-3", Title: "root", Type: "task", Status: "open", Assignee: pool, Metadata: map[string]string{
+			"gc.kind": "workflow", "gc.run_target": pool,
+		}},
+		// Closed workflow root — done, no route restored.
+		{ID: "WR-4", Title: "root", Type: "task", Status: "closed", Metadata: map[string]string{
+			"gc.kind": "workflow", "gc.run_target": pool,
+		}},
+		// Recoverable broadening: a plain (kind-less) standalone work bead — this
+		// fork's dominant work shape — carries its pool route in gc.run_target
+		// too. The autoscaler is blind to it until gc.routed_to is restored.
+		{ID: "T-1", Title: "work", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.run_target": pool,
+		}},
+		// Assigned plain work bead — already claimed, no route restored.
+		{ID: "T-2", Title: "work", Type: "task", Status: "open", Assignee: pool, Metadata: map[string]string{
+			"gc.run_target": pool,
+		}},
+		// Already-routed plain work bead — idempotent, left untouched.
+		{ID: "T-3", Title: "work", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.run_target": pool, "gc.routed_to": pool,
+		}},
+		// Control-dispatcher and workflow-topology beads carry a bare
+		// gc.run_target, but there it is a dispatch/structure target an agent
+		// never claims from a pool — they must never be pool-routed.
+		{ID: "CTRL-1", Title: "retry", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.kind": "retry", "gc.run_target": pool,
+		}},
+		{ID: "TOPO-1", Title: "scope", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.kind": "scope", "gc.run_target": pool,
+		}},
+		{ID: "TOPO-2", Title: "spec", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.kind": "spec", "gc.run_target": pool,
+		}},
+	}, nil)
+
+	restored, err := restoreCarriedWorkRoutes(store)
+	if err != nil {
+		t.Fatalf("restoreCarriedWorkRoutes: %v", err)
+	}
+	if restored != 2 {
+		t.Fatalf("restored = %d, want 2 (WR-1 workflow root + T-1 plain work bead)", restored)
+	}
+
+	// Restored from the route each bead already carried.
+	for _, id := range []string{"WR-1", "T-1"} {
+		if got := mustRoutedTo(t, store, id); got != pool {
+			t.Errorf("%s gc.routed_to = %q, want %q (restored from gc.run_target)", id, got, pool)
+		}
+	}
+	// Already-routed beads keep their original route, not their run_target.
+	if got := mustRoutedTo(t, store, "WR-2"); got != "gascity/gastown.refinery" {
+		t.Errorf("WR-2 gc.routed_to = %q, want gascity/gastown.refinery (untouched)", got)
+	}
+	if got := mustRoutedTo(t, store, "T-3"); got != pool {
+		t.Errorf("T-3 gc.routed_to = %q, want %q (untouched)", got, pool)
+	}
+	// Assigned, closed, control, and topology beads must stay unrouted.
+	for _, id := range []string{"WR-3", "WR-4", "T-2", "CTRL-1", "TOPO-1", "TOPO-2"} {
+		if got := mustRoutedTo(t, store, id); got != "" {
+			t.Errorf("%s gc.routed_to = %q, want empty (must be left unrouted)", id, got)
+		}
+	}
+
+	// Idempotent: a second pass restores nothing because WR-1 and T-1 now carry
+	// gc.routed_to and yield no recoverable carried route.
+	restored2, err := restoreCarriedWorkRoutes(store)
+	if err != nil {
+		t.Fatalf("restoreCarriedWorkRoutes (second pass): %v", err)
+	}
+	if restored2 != 0 {
+		t.Errorf("second pass restored = %d, want 0 (idempotent)", restored2)
+	}
+}
+
+// TestRestoreCarriedWorkRoutesNilStore guards the nil-store path the controller
+// hits when a scope's bead store is unavailable.
+func TestRestoreCarriedWorkRoutesNilStore(t *testing.T) {
+	restored, err := restoreCarriedWorkRoutes(nil)
+	if err != nil {
+		t.Fatalf("restoreCarriedWorkRoutes(nil): %v", err)
+	}
+	if restored != 0 {
+		t.Errorf("restored = %d, want 0 for nil store", restored)
+	}
+}
+
+// TestCityRuntimeRecoverUnroutedWorkRoutes confirms the controller method
+// sweeps both the city store and every rig store, and recovers both carried-route
+// shapes (workflow root and plain work bead).
+func TestCityRuntimeRecoverUnroutedWorkRoutes(t *testing.T) {
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CW-1", Title: "root", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.kind": "workflow", "gc.run_target": "city/gastown.polecat",
+		}},
+	}, nil)
+	rigStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		// Plain work bead — the fork's standalone-issue shape.
+		{ID: "RW-1", Title: "work", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.run_target": "gascity/gastown.polecat",
+		}},
+	}, nil)
+	cr := &CityRuntime{
+		cityName:            "city",
+		standaloneCityStore: cityStore,
+		standaloneRigStores: map[string]beads.Store{"gascity": rigStore},
+		stderr:              io.Discard,
+	}
+
+	cr.recoverUnroutedWorkRoutes()
+
+	if got := mustRoutedTo(t, cityStore, "CW-1"); got != "city/gastown.polecat" {
+		t.Errorf("CW-1 gc.routed_to = %q, want city/gastown.polecat", got)
+	}
+	if got := mustRoutedTo(t, rigStore, "RW-1"); got != "gascity/gastown.polecat" {
+		t.Errorf("RW-1 gc.routed_to = %q, want gascity/gastown.polecat", got)
+	}
+}
+
+func mustRoutedTo(t *testing.T, store beads.Store, id string) string {
+	t.Helper()
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("get %s: %v", id, err)
+	}
+	return b.Metadata["gc.routed_to"]
+}


### PR DESCRIPTION
## Problem

The pool autoscaler keys exclusively on `gc.routed_to`. An `open`+unassigned work bead that already carries a legacy `gc.run_target` pool route but has an empty `gc.routed_to` is invisible to pool demand and never spawns a worker — it sits ready with zero workers until manually re-routed. This affects work routed via the older `gc.run_target` hint whose `gc.routed_to` was lost or never mirrored (e.g. carried across a controller restart, or a pre-`routed_to` workflow root).

Scope note: this recovers only beads that already declare a route for themselves via `gc.run_target`. Work that was never routed at all (no `gc.run_target` and no `gc.routed_to` — the control-dispatcher-stopped case) is out of scope; the controller cannot invent a route for it, and that is a separate dispatch concern, not a backfill.

## Fix

Add a controller-owned recovery step, `restoreCarriedWorkRoutes`, that restores `gc.routed_to` from the route a bead already declares for itself via its legacy run-target hint, for `open`+unassigned work. It runs in the cheap dispatch phase on startup and on every patrol tick, so ready work re-enters pool demand without a manual sling. It is the automatic, broader-scoped equivalent of the manual `gc doctor --fix` run-target-to-routed-to backfill.

Scope (`carriedPoolRoute`) recovers both shapes that carry a legacy pool route: a plain kind-less standalone work bead (the dominant work shape, which a workflow-only recovery would catch none of) and a pre-existing workflow root. Control-dispatcher beads (retry, ralph, …) and workflow-topology beads (scope, spec) also carry a bare run-target, but there it is a dispatch/structure target an agent never claims from a pool, so they are left untouched.

The recovery cannot mis-route: it only copies a route the bead already declares for itself, never invents one; hint-less ad-hoc beads are left for their owner to sling. It complements the two sibling handoff-orphan recoveries without overlap — those source the route from the closing session's template, whereas this one sources it from the bead's own run-target hint. First writer wins, idempotently.

## Verification

- Cherry-picks cleanly onto `main`; `go build ./...` is clean and `go vet ./cmd/gc/` is clean.
- A new test file (`route_recovery_test.go`) covers the standalone and workflow-root recovery shapes, the untouched dispatch/topology beads, and idempotency.

Companion to #3377 (handoff-orphan recovery); independent and builds standalone.

