### PR TITLE
fix(orders): add event-bus fallback to per-order cooldown last-run lookup

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -554,7 +554,8 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			continue
 		}
 
-		baseLastRunFn := trackingIndex.lastRunFunc(storesForGate, storeKeysForGate, orders.LastRunAcross(orderFrontDoorsForStores(storesForGate)))
+		baseLastRunFn := trackingIndex.lastRunFunc(storesForGate, storeKeysForGate,
+			orders.LastRunFuncWithEventFallback(orders.LastRunAcross(orderFrontDoorsForStores(storesForGate)), m.ep))
 		var lastRunErr error
 		var lastRunFromCache bool
 		lastRunFn := func(orderName string) (time.Time, error) {

--- a/internal/orders/runtime_helpers.go
+++ b/internal/orders/runtime_helpers.go
@@ -3,6 +3,8 @@ package orders
 import (
 	"log"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/events"
 )
 
 var runtimeHelpersLogf = log.Printf
@@ -25,6 +27,43 @@ func LastRunAcross(stores []*Store) LastRunFunc {
 			}
 			if last.After(latest) {
 				latest = last
+			}
+		}
+		return latest, nil
+	}
+}
+
+// LastRunFuncWithEventFallback wraps fn with an events.Provider fallback.
+// When fn returns a zero time (no tracking beads found — e.g. after a
+// wisp-compact prune), it queries the event bus for the most recent
+// order.fired event whose Subject matches the order's scoped name and
+// returns its timestamp. A nil ep disables the fallback and the wrapped
+// fn's result is returned unchanged. Event bus errors are non-fatal:
+// when the provider fails the zero time is returned so the order appears
+// unrun rather than permanently blocked.
+func LastRunFuncWithEventFallback(fn LastRunFunc, ep events.Provider) LastRunFunc {
+	if ep == nil {
+		return fn
+	}
+	return func(name string) (time.Time, error) {
+		last, err := fn(name)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if !last.IsZero() {
+			return last, nil
+		}
+		evts, listErr := ep.List(events.Filter{
+			Type:    events.OrderFired,
+			Subject: name,
+		})
+		if listErr != nil {
+			return time.Time{}, nil
+		}
+		var latest time.Time
+		for _, e := range evts {
+			if e.Ts.After(latest) {
+				latest = e.Ts
 			}
 		}
 		return latest, nil

--- a/internal/orders/runtime_helpers_test.go
+++ b/internal/orders/runtime_helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
 )
 
 type rowsErrorStore struct {
@@ -90,6 +91,129 @@ func TestLastRunUsesRowsFromPartialTierError(t *testing.T) {
 	}
 	if !got.Equal(want) {
 		t.Fatalf("LastRun() = %s, want %s from surviving rows", got, want)
+	}
+}
+
+func TestLastRunFuncWithEventFallback_UsesStoreResult(t *testing.T) {
+	want := time.Date(2026, 6, 9, 0, 23, 0, 0, time.UTC)
+	storeFn := func(string) (time.Time, error) { return want, nil }
+	ep := events.NewFake()
+	// Event with a later timestamp — must NOT be chosen when store succeeds.
+	ep.Record(events.Event{
+		Type:    events.OrderFired,
+		Subject: "digest-generate",
+		Ts:      want.Add(time.Hour),
+	})
+
+	got, err := LastRunFuncWithEventFallback(storeFn, ep)("digest-generate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("got %s, want store result %s", got, want)
+	}
+}
+
+func TestLastRunFuncWithEventFallback_FallsBackToEvents(t *testing.T) {
+	storeFn := func(string) (time.Time, error) { return time.Time{}, nil }
+	ep := events.NewFake()
+	want := time.Date(2026, 6, 9, 0, 23, 0, 0, time.UTC)
+	ep.Record(events.Event{
+		Type:    events.OrderFired,
+		Subject: "digest-generate",
+		Ts:      want,
+	})
+
+	got, err := LastRunFuncWithEventFallback(storeFn, ep)("digest-generate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("got %s, want event timestamp %s", got, want)
+	}
+}
+
+func TestLastRunFuncWithEventFallback_FallsBackToLatestEvent(t *testing.T) {
+	storeFn := func(string) (time.Time, error) { return time.Time{}, nil }
+	ep := events.NewFake()
+	older := time.Date(2026, 6, 8, 0, 23, 0, 0, time.UTC)
+	newer := time.Date(2026, 6, 9, 0, 23, 0, 0, time.UTC)
+	ep.Record(events.Event{Type: events.OrderFired, Subject: "digest-generate", Ts: older})
+	ep.Record(events.Event{Type: events.OrderFired, Subject: "digest-generate", Ts: newer})
+
+	got, err := LastRunFuncWithEventFallback(storeFn, ep)("digest-generate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equal(newer) {
+		t.Fatalf("got %s, want newest event %s", got, newer)
+	}
+}
+
+func TestLastRunFuncWithEventFallback_IgnoresOtherOrderEvents(t *testing.T) {
+	storeFn := func(string) (time.Time, error) { return time.Time{}, nil }
+	ep := events.NewFake()
+	ep.Record(events.Event{
+		Type:    events.OrderFired,
+		Subject: "other-order",
+		Ts:      time.Date(2026, 6, 9, 0, 23, 0, 0, time.UTC),
+	})
+
+	got, err := LastRunFuncWithEventFallback(storeFn, ep)("digest-generate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("got %s, want zero (event is for a different order)", got)
+	}
+}
+
+func TestLastRunFuncWithEventFallback_NilProviderReturnsStoreResult(t *testing.T) {
+	want := time.Date(2026, 6, 9, 0, 23, 0, 0, time.UTC)
+	storeFn := func(string) (time.Time, error) { return want, nil }
+
+	got, err := LastRunFuncWithEventFallback(storeFn, nil)("digest-generate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+func TestLastRunFuncWithEventFallback_NilProviderZeroStore(t *testing.T) {
+	storeFn := func(string) (time.Time, error) { return time.Time{}, nil }
+
+	got, err := LastRunFuncWithEventFallback(storeFn, nil)("digest-generate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("got %s, want zero (nil provider, no store result)", got)
+	}
+}
+
+func TestLastRunFuncWithEventFallback_StoreErrorPropagated(t *testing.T) {
+	wantErr := errors.New("store error")
+	storeFn := func(string) (time.Time, error) { return time.Time{}, wantErr }
+	ep := events.NewFake()
+
+	_, err := LastRunFuncWithEventFallback(storeFn, ep)("digest-generate")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got err %v, want %v", err, wantErr)
+	}
+}
+
+func TestLastRunFuncWithEventFallback_EventErrorFailsOpen(t *testing.T) {
+	storeFn := func(string) (time.Time, error) { return time.Time{}, nil }
+	ep := events.NewFailFake()
+
+	got, err := LastRunFuncWithEventFallback(storeFn, ep)("digest-generate")
+	if err != nil {
+		t.Fatalf("expected nil error (fail-open), got: %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("got %s, want zero time (fail-open on broken provider)", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

A periodic formula's per-order cooldown re-fires early once the order-run tracking bead it relies on is pruned by wisp-compaction. The cooldown's last-run lookup is bead-based: when every tracking bead for an order has been compacted away, the lookup returns a zero time, which reads as "never ran," and the order dispatches again well inside its intended (e.g. 24h) cooldown window.

## Fix

Add `LastRunFuncWithEventFallback`, which wraps the bead-based `LastRunFunc` with an `events.Provider` fallback: when the bead-based lookup yields a zero time (all tracking beads gone), it queries the event bus for the most recent `order.fired` event matching the order's scoped name. The event log is append-only and not subject to wisp-compact pruning, so the cooldown window is honoured even after the tracking bead is removed.

- Event-bus failures fail open (return zero time) so a broken provider can never permanently block order dispatch.
- Wired in the dispatcher at the `baseLastRunFn` construction point, wrapping `LastRunAcrossStores` with the events provider already available on the dispatcher.

## Verification

- Cherry-picks cleanly onto `main`; `go build ./...` is clean and `go vet ./internal/orders/ ./cmd/gc/` is clean.
- New tests (`runtime_helpers_test.go`) cover: fallback to the event bus when beads return zero time, bead time preferred when present, and fail-open on a provider error.

Adjacent to open #3205/#3321 (same order cooldown subsystem); happy to reconcile gate strategy.
