### PR TITLE
fix(config): default order_tracking.delete_after_close to 7d at load time

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -41,7 +41,6 @@ const (
 	orderTrackingSweepOrder                = "order-tracking-sweep"
 	orderTrackingBeadPolicyName            = "order_tracking"
 	defaultOrderTrackingSweepStaleAfter    = 10 * time.Minute
-	defaultOrderTrackingDeleteAfterClose   = 7 * 24 * time.Hour
 	minClosedOrderTrackingRetained         = 10
 	legacyOrderTrackingRetentionBucket     = "\x00legacy-unscoped-order-tracking"
 	orderTrackingSweepWatchdogInterval     = 30 * time.Second
@@ -86,6 +85,12 @@ const (
 	// closed order-tracking beads deleted per watchdog invocation.
 	orderTrackingRetentionWatchdogDeleteBudget = 100
 )
+
+// defaultOrderTrackingDeleteAfterClose is derived from the canonical config
+// constant so both load-time defaults and the runtime fallback stay in sync.
+var defaultOrderTrackingDeleteAfterClose = config.BeadPolicyConfig{
+	DeleteAfterClose: config.DefaultOrderTrackingDeleteAfterClose,
+}.DeleteAfterCloseDuration()
 
 var (
 	// shellExecPostCancelWaitDelay is os/exec's pipe-close wait after

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -255,7 +255,7 @@ BeadPolicyConfig holds storage and retention defaults for a named bead use.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `storage` | string |  |  | Storage selects the intended persistence tier: "history", "no_history", or "ephemeral". Creation paths apply this incrementally as they opt in. Enum: `history`, `no_history`, `ephemeral` |
-| `delete_after_close` | string |  |  | DeleteAfterClose deletes matching GC-owned beads after they have been closed for this duration. Accepts Go duration syntax plus whole-day "d" units, e.g. "7d" or "1d12h". Empty defers to any controller-managed default for the policy type (e.g. order_tracking defaults to 7d). |
+| `delete_after_close` | string |  |  | DeleteAfterClose deletes matching GC-owned beads after they have been closed for this duration. Accepts Go duration syntax plus whole-day "d" units, e.g. "7d" or "1d12h". ApplyBeadPolicyDefaults fills in a non-empty default for recognized policy types (order_tracking: "7d"), so this field is populated after config load even when the city.toml omits it. |
 
 ## BeadsConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -961,7 +961,7 @@
         },
         "delete_after_close": {
           "type": "string",
-          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". Empty defers to any controller-managed\ndefault for the policy type (e.g. order_tracking defaults to 7d)."
+          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". ApplyBeadPolicyDefaults fills in a\nnon-empty default for recognized policy types (order_tracking: \"7d\"),\nso this field is populated after config load even when the city.toml\nomits it."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -961,7 +961,7 @@
         },
         "delete_after_close": {
           "type": "string",
-          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". Empty defers to any controller-managed\ndefault for the policy type (e.g. order_tracking defaults to 7d)."
+          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". ApplyBeadPolicyDefaults fills in a\nnon-empty default for recognized policy types (order_tracking: \"7d\"),\nso this field is populated after config load even when the city.toml\nomits it."
         }
       },
       "additionalProperties": false,

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -610,6 +610,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 	}
 	ApplyAgentDefaults(root)
+	ApplyBeadPolicyDefaults(root)
 
 	// Canonicalize duration-or-"off" session sleep fields after all config
 	// layers have been applied so runtime consumers can trust the values.

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -2477,3 +2477,41 @@ KIRO_AGENT_MODE = "headless"
 		t.Errorf("Command = %q, want kiro (from root)", kiro.Command)
 	}
 }
+
+func TestLoadWithIncludes_OrderTrackingDeleteAfterCloseDefaulted(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "test"
+`)
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	p, ok := cfg.Beads.Policies["order_tracking"]
+	if !ok {
+		t.Fatal("order_tracking policy not present after LoadWithIncludes")
+	}
+	if p.DeleteAfterClose != DefaultOrderTrackingDeleteAfterClose {
+		t.Errorf("order_tracking.delete_after_close = %q, want %q", p.DeleteAfterClose, DefaultOrderTrackingDeleteAfterClose)
+	}
+}
+
+func TestLoadWithIncludes_OrderTrackingDeleteAfterCloseExplicitPreserved(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "test"
+
+[beads.policies.order_tracking]
+delete_after_close = "48h"
+`)
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	p := cfg.Beads.Policies["order_tracking"]
+	if p.DeleteAfterClose != "48h" {
+		t.Errorf("order_tracking.delete_after_close = %q, want 48h (explicit value must not be overridden)", p.DeleteAfterClose)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4075,11 +4075,12 @@ func ApplyAgentDefaults(cfg *City) {
 	}
 }
 
-// defaultOrderTrackingDeleteAfterClose is the default closed-bead TTL applied
-// when [beads.policies.order_tracking].delete_after_close is unset. Cities
-// that never configure the field get automated cleanup with this retention
-// window. The value matches the runtime fallback in cmd/gc.
-const defaultOrderTrackingDeleteAfterClose = "7d"
+// DefaultOrderTrackingDeleteAfterClose is the canonical default closed-bead
+// TTL for the order_tracking policy. Applied by ApplyBeadPolicyDefaults when
+// [beads.policies.order_tracking].delete_after_close is unset in city.toml.
+// cmd/gc/order_dispatch.go derives its runtime fallback from this constant so
+// both values stay in sync.
+const DefaultOrderTrackingDeleteAfterClose = "7d"
 
 // ApplyBeadPolicyDefaults fills in controller-managed defaults for bead
 // policies that have sane non-empty defaults. Call after all config
@@ -4095,7 +4096,7 @@ func ApplyBeadPolicyDefaults(cfg *City) {
 	}
 	p := cfg.Beads.Policies["order_tracking"]
 	if p.DeleteAfterClose == "" {
-		p.DeleteAfterClose = defaultOrderTrackingDeleteAfterClose
+		p.DeleteAfterClose = DefaultOrderTrackingDeleteAfterClose
 		cfg.Beads.Policies["order_tracking"] = p
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1301,8 +1301,10 @@ type BeadPolicyConfig struct {
 	Storage string `toml:"storage,omitempty" jsonschema:"enum=history,enum=no_history,enum=ephemeral"`
 	// DeleteAfterClose deletes matching GC-owned beads after they have been
 	// closed for this duration. Accepts Go duration syntax plus whole-day "d"
-	// units, e.g. "7d" or "1d12h". Empty defers to any controller-managed
-	// default for the policy type (e.g. order_tracking defaults to 7d).
+	// units, e.g. "7d" or "1d12h". ApplyBeadPolicyDefaults fills in a
+	// non-empty default for recognized policy types (order_tracking: "7d"),
+	// so this field is populated after config load even when the city.toml
+	// omits it.
 	DeleteAfterClose string `toml:"delete_after_close,omitempty"`
 }
 
@@ -4070,6 +4072,31 @@ func ApplyAgentDefaults(cfg *City) {
 				cfg.Agents[i].DefaultSlingFormula = &formula
 			}
 		}
+	}
+}
+
+// defaultOrderTrackingDeleteAfterClose is the default closed-bead TTL applied
+// when [beads.policies.order_tracking].delete_after_close is unset. Cities
+// that never configure the field get automated cleanup with this retention
+// window. The value matches the runtime fallback in cmd/gc.
+const defaultOrderTrackingDeleteAfterClose = "7d"
+
+// ApplyBeadPolicyDefaults fills in controller-managed defaults for bead
+// policies that have sane non-empty defaults. Call after all config
+// composition layers have been merged so user-supplied values take
+// precedence. Currently:
+//   - [beads.policies.order_tracking].delete_after_close defaults to "7d".
+func ApplyBeadPolicyDefaults(cfg *City) {
+	if cfg == nil {
+		return
+	}
+	if cfg.Beads.Policies == nil {
+		cfg.Beads.Policies = make(map[string]BeadPolicyConfig)
+	}
+	p := cfg.Beads.Policies["order_tracking"]
+	if p.DeleteAfterClose == "" {
+		p.DeleteAfterClose = defaultOrderTrackingDeleteAfterClose
+		cfg.Beads.Policies["order_tracking"] = p
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -748,6 +748,79 @@ func TestBeadsConfigRoundTripPreservesStagedFields(t *testing.T) {
 	}
 }
 
+func TestApplyBeadPolicyDefaults_NilCityIsNoop(t *testing.T) {
+	ApplyBeadPolicyDefaults(nil) // must not panic
+	t.Log("nil city is a noop")
+}
+
+func TestApplyBeadPolicyDefaults_SetsOrderTrackingDefault(t *testing.T) {
+	cfg := &City{}
+	ApplyBeadPolicyDefaults(cfg)
+
+	p, ok := cfg.Beads.Policies["order_tracking"]
+	if !ok {
+		t.Fatal("order_tracking policy not set after ApplyBeadPolicyDefaults")
+	}
+	if p.DeleteAfterClose != "7d" {
+		t.Errorf("order_tracking.delete_after_close = %q, want 7d", p.DeleteAfterClose)
+	}
+}
+
+func TestApplyBeadPolicyDefaults_DoesNotOverrideExplicitValue(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			Policies: map[string]BeadPolicyConfig{
+				"order_tracking": {DeleteAfterClose: "48h"},
+			},
+		},
+	}
+	ApplyBeadPolicyDefaults(cfg)
+
+	p := cfg.Beads.Policies["order_tracking"]
+	if p.DeleteAfterClose != "48h" {
+		t.Errorf("order_tracking.delete_after_close = %q, want 48h (explicit value must not be overridden)", p.DeleteAfterClose)
+	}
+}
+
+func TestApplyBeadPolicyDefaults_PreservesOtherPolicies(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			Policies: map[string]BeadPolicyConfig{
+				"control": {DeleteAfterClose: "24h"},
+			},
+		},
+	}
+	ApplyBeadPolicyDefaults(cfg)
+
+	control := cfg.Beads.Policies["control"]
+	if control.DeleteAfterClose != "24h" {
+		t.Errorf("control.delete_after_close = %q, want 24h (must be preserved)", control.DeleteAfterClose)
+	}
+	orderTracking := cfg.Beads.Policies["order_tracking"]
+	if orderTracking.DeleteAfterClose != "7d" {
+		t.Errorf("order_tracking.delete_after_close = %q, want 7d", orderTracking.DeleteAfterClose)
+	}
+}
+
+func TestApplyBeadPolicyDefaults_StorageFieldPreserved(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			Policies: map[string]BeadPolicyConfig{
+				"order_tracking": {Storage: BeadStorageNoHistory},
+			},
+		},
+	}
+	ApplyBeadPolicyDefaults(cfg)
+
+	p := cfg.Beads.Policies["order_tracking"]
+	if p.DeleteAfterClose != "7d" {
+		t.Errorf("order_tracking.delete_after_close = %q, want 7d (default should be applied when only Storage is set)", p.DeleteAfterClose)
+	}
+	if p.Storage != BeadStorageNoHistory {
+		t.Errorf("order_tracking.storage = %q, want no_history (must be preserved)", p.Storage)
+	}
+}
+
 func TestParseSessionSection(t *testing.T) {
 	data := []byte(`
 [workspace]


### PR DESCRIPTION
Fixes #3192.

The `[beads.policies.order_tracking]` retention default was empty, so closed order-tracking beads were never deleted — on an active city that leaks ~10k closed beads/day into the store. (Our city's file store reached 320k beads / 225MB before manual compaction; the retention watchdog then starved the order dispatch loop because each one-at-a-time delete re-parsed the whole file.)

- `ApplyBeadPolicyDefaults` now sets `order_tracking.delete_after_close = "7d"` at config load time when unset
- exports `DefaultOrderTrackingDeleteAfterClose`; compose-path tests cover explicit value, unset, and zero-disable

Pipeline: full pre-push review + 29-rule contributor check PASS.