### PR TITLE
fix(config): preserve city symlink when appending rigs

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1347,8 +1347,13 @@ func captureConfigMutationSnapshot(cityPath string) (*configMutationSnapshot, er
 		return nil
 	}
 
+	cityToml, err := cityTomlRollbackPath(fsys.OSFS{}, cityPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolving city.toml for rollback snapshot: %w", err)
+	}
+
 	for _, path := range []string{
-		filepath.Join(cityPath, "city.toml"),
+		cityToml,
 		filepath.Join(cityPath, ".gc", "site.toml"),
 	} {
 		if err := capture(path); err != nil {

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -1061,6 +1061,74 @@ func TestControllerStateMutationRestoresFullAgentScaffoldWhenRefreshFails(t *tes
 	}
 }
 
+// TestControllerStateMutationRestoresSymlinkedCityTomlWhenRefreshFails proves
+// the controller config-mutation rollback is symlink-aware, matching the CLI
+// rollback snapshots. When a forward mutation writes through a city.toml
+// symlink and the post-mutation config reload fails, restore must rewrite the
+// real target file and leave the live city.toml symlink intact. Before the fix,
+// captureConfigMutationSnapshot/restore operated on the unresolved link path,
+// so rollback replaced the symlink with a regular file and left the
+// forward-modified target un-reverted.
+func TestControllerStateMutationRestoresSymlinkedCityTomlWhenRefreshFails(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo")
+	cityDir := filepath.Join(dir, "city")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoCityPath := filepath.Join(repoDir, "city.toml")
+	liveCityPath := filepath.Join(cityDir, "city.toml")
+	original := []byte("[workspace]\nname = \"city1\"\n")
+	if err := os.WriteFile(repoCityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "repo", "city.toml"), liveCityPath); err != nil {
+		t.Fatal(err)
+	}
+
+	cs := &controllerState{
+		cityPath: cityDir,
+		cfg:      &config.City{Workspace: config.Workspace{Name: "city1"}},
+	}
+
+	mutErr := cs.mutateAndPoke(func() error {
+		// Forward mutation writes through the resolved symlink target, exactly
+		// like the config editor's ResolveCityRewritePath path. The broken TOML
+		// then makes refreshConfigSnapshot fail and triggers rollback -- the
+		// same post-mutation refresh failure the production path hits.
+		resolved, err := fsys.ResolveSymlinks(fsys.OSFS{}, liveCityPath)
+		if err != nil {
+			return err
+		}
+		return fsys.WriteFileAtomic(fsys.OSFS{}, resolved, []byte("["), 0o644)
+	})
+	if mutErr == nil {
+		t.Fatal("mutateAndPoke should fail when refreshing the post-mutation config fails")
+	}
+	if !strings.Contains(mutErr.Error(), "refreshing updated city config") {
+		t.Fatalf("mutateAndPoke error = %v, want refresh failure after mutation", mutErr)
+	}
+
+	info, err := os.Lstat(liveCityPath)
+	if err != nil {
+		t.Fatalf("Lstat(live city.toml): %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("rollback replaced the city.toml symlink with a regular file")
+	}
+	restored, readErr := os.ReadFile(repoCityPath)
+	if readErr != nil {
+		t.Fatalf("read repo city.toml: %v", readErr)
+	}
+	if string(restored) != string(original) {
+		t.Fatalf("repo city.toml = %q, want restored original %q", restored, original)
+	}
+}
+
 func TestControllerStateMutationAllowsSymlinkedAgentAssets(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 

--- a/cmd/gc/cmd_beads_city.go
+++ b/cmd/gc/cmd_beads_city.go
@@ -355,7 +355,7 @@ func validateCityExternalEndpointChange(cityPath string, targetState contract.Co
 
 func snapshotCityTopologyFiles(fs fsys.FS, cityPath string, plans []cityRigEndpointPlan) ([]fileSnapshot, error) {
 	snapshots := make([]fileSnapshot, 0, len(plans)+3)
-	cityToml, err := snapshotOptionalFile(fs, filepath.Join(cityPath, "city.toml"))
+	cityToml, err := snapshotCityTomlForRollback(fs, cityPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gc/cmd_beads_city_test.go
+++ b/cmd/gc/cmd_beads_city_test.go
@@ -878,3 +878,62 @@ func writeCityEndpointCityConfig(t *testing.T, cityDir string, rigs []config.Rig
 		t.Fatal(err)
 	}
 }
+
+// Regression for PR #3428 review: the gc beads city set-endpoint outer
+// rollback snapshots city.toml at its symlink-resolved path, so restoring
+// after a later step fails rewrites the real target and leaves the live
+// symlink intact instead of replacing it with a regular file. This is the same
+// latent bug fixed for gc rig add and gc rig set-endpoint.
+func TestSnapshotCityTopologyFilesRestoresSymlinkedCityToml(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo")
+	cityDir := filepath.Join(dir, "city")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoCityPath := filepath.Join(repoDir, "city.toml")
+	liveCityPath := filepath.Join(cityDir, "city.toml")
+	original := []byte("[workspace]\nname = \"test-city\"\n")
+	if err := os.WriteFile(repoCityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "repo", "city.toml"), liveCityPath); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := fsys.OSFS{}
+	snapshots, err := snapshotCityTopologyFiles(fs, cityDir, nil)
+	if err != nil {
+		t.Fatalf("snapshotCityTopologyFiles: %v", err)
+	}
+
+	// Simulate the city endpoint rewrite mutating the resolved target before a
+	// later step fails and triggers rollback.
+	mutated := []byte("[workspace]\nname = \"mutated\"\n")
+	if err := os.WriteFile(repoCityPath, mutated, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restoreSnapshots(fs, snapshots); err != nil {
+		t.Fatalf("restoreSnapshots: %v", err)
+	}
+
+	info, err := os.Lstat(liveCityPath)
+	if err != nil {
+		t.Fatalf("Lstat(live city.toml): %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("rollback replaced the live city.toml symlink with a regular file")
+	}
+	restored, err := os.ReadFile(repoCityPath)
+	if err != nil {
+		t.Fatalf("read repo city.toml: %v", err)
+	}
+	if !bytes.Equal(restored, original) {
+		t.Fatalf("repo city.toml = %q, want restored original %q", restored, original)
+	}
+}

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -789,7 +789,7 @@ func boundImportsMap(imports []config.BoundImport) map[string]config.Import {
 
 func snapshotRigAddTopologyFiles(fs fsys.FS, cityPath string, cfg *config.City) ([]fileSnapshot, error) {
 	snapshots := make([]fileSnapshot, 0, len(cfg.Rigs)*3+5)
-	cityToml, err := snapshotOptionalFile(fs, filepath.Join(cityPath, "city.toml"))
+	cityToml, err := snapshotCityTomlForRollback(fs, cityPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -684,13 +684,17 @@ func syncRigEndpointCompatConfig(fs fsys.FS, cityPath string, cfg *config.City, 
 }
 
 func snapshotRigEndpointFiles(fs fsys.FS, cityPath, scopeRoot string) ([]fileSnapshot, error) {
+	cityToml, err := snapshotCityTomlForRollback(fs, cityPath)
+	if err != nil {
+		return nil, err
+	}
 	paths := []string{
-		filepath.Join(cityPath, "city.toml"),
 		config.SiteBindingPath(cityPath),
 		filepath.Join(scopeRoot, ".beads", "metadata.json"),
 		filepath.Join(scopeRoot, ".beads", "config.yaml"),
 	}
-	snapshots := make([]fileSnapshot, 0, len(paths))
+	snapshots := make([]fileSnapshot, 0, len(paths)+1)
+	snapshots = append(snapshots, cityToml)
 	for _, path := range paths {
 		snap, err := snapshotOptionalFile(fs, path)
 		if err != nil {
@@ -711,6 +715,31 @@ func snapshotOptionalFile(fs fsys.FS, path string) (fileSnapshot, error) {
 	}
 	cp := append([]byte(nil), data...)
 	return fileSnapshot{path: path, data: cp, exists: true}, nil
+}
+
+// cityTomlRollbackPath returns the symlink-resolved city.toml path that a
+// rollback snapshot must read and later restore. Resolving first means an
+// atomic restore rewrites the real target file and leaves a live city.toml
+// symlink intact, instead of replacing the link with a regular file (the
+// failure ResolveCityRewritePath/ResolveCityAppendPath exist to prevent). When
+// city.toml is a plain file (or not yet created), resolution is a no-op and the
+// path is unchanged. Both the CLI rollback snapshots
+// (snapshotCityTomlForRollback) and the controller config-mutation snapshot
+// (captureConfigMutationSnapshot) route through this so the two rollback
+// surfaces stay symlink-aware together instead of drifting apart.
+func cityTomlRollbackPath(fs fsys.FS, cityPath string) (string, error) {
+	return fsys.ResolveSymlinks(fs, filepath.Join(cityPath, "city.toml"))
+}
+
+// snapshotCityTomlForRollback snapshots city.toml at its symlink-resolved path
+// (see cityTomlRollbackPath) so a later rollback restores the real target file
+// and leaves a live city.toml symlink intact.
+func snapshotCityTomlForRollback(fs fsys.FS, cityPath string) (fileSnapshot, error) {
+	resolved, err := cityTomlRollbackPath(fs, cityPath)
+	if err != nil {
+		return fileSnapshot{}, err
+	}
+	return snapshotOptionalFile(fs, resolved)
 }
 
 func writeRigEndpointRollbackError(fs fsys.FS, stderr io.Writer, snapshots []fileSnapshot, action string, cause error) {

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -1729,3 +1729,65 @@ func readRigEndpointConfigState(t *testing.T, dir string) contract.ConfigState {
 	}
 	return state
 }
+
+// Regression for PR #3428 review: the gc rig set-endpoint outer rollback
+// snapshots city.toml at its symlink-resolved path, so restoring after a later
+// step fails rewrites the real target and leaves the live symlink intact
+// instead of replacing it with a regular file.
+func TestSnapshotRigEndpointFilesRestoresSymlinkedCityToml(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo")
+	cityDir := filepath.Join(dir, "city")
+	scopeRoot := filepath.Join(dir, "rig")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(scopeRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoCityPath := filepath.Join(repoDir, "city.toml")
+	liveCityPath := filepath.Join(cityDir, "city.toml")
+	original := []byte("[workspace]\nname = \"test-city\"\n")
+	if err := os.WriteFile(repoCityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "repo", "city.toml"), liveCityPath); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := fsys.OSFS{}
+	snapshots, err := snapshotRigEndpointFiles(fs, cityDir, scopeRoot)
+	if err != nil {
+		t.Fatalf("snapshotRigEndpointFiles: %v", err)
+	}
+
+	// Simulate the endpoint config rewrite mutating the resolved target before
+	// a later step fails and triggers rollback.
+	mutated := []byte("[workspace]\nname = \"mutated\"\n")
+	if err := os.WriteFile(repoCityPath, mutated, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restoreSnapshots(fs, snapshots); err != nil {
+		t.Fatalf("restoreSnapshots: %v", err)
+	}
+
+	info, err := os.Lstat(liveCityPath)
+	if err != nil {
+		t.Fatalf("Lstat(live city.toml): %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("rollback replaced the live city.toml symlink with a regular file")
+	}
+	restored, err := os.ReadFile(repoCityPath)
+	if err != nil {
+		t.Fatalf("read repo city.toml: %v", err)
+	}
+	if !bytes.Equal(restored, original) {
+		t.Fatalf("repo city.toml = %q, want restored original %q", restored, original)
+	}
+}

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -3306,3 +3306,62 @@ func TestRouteRigList_StaleBannerOver30s(t *testing.T) {
 		t.Errorf("stale banner missing from human output:\n%s", stdout.String())
 	}
 }
+
+// Regression for PR #3428 review: the gc rig add outer rollback snapshots
+// city.toml at its symlink-resolved path, so restoring after a later step
+// fails rewrites the real target and leaves the live symlink intact instead of
+// replacing it with a regular file (and leaving the appended rig stranded in
+// the target).
+func TestSnapshotRigAddTopologyFilesRestoresSymlinkedCityToml(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo")
+	cityDir := filepath.Join(dir, "city")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoCityPath := filepath.Join(repoDir, "city.toml")
+	liveCityPath := filepath.Join(cityDir, "city.toml")
+	original := []byte("[workspace]\nname = \"test-city\"\n")
+	if err := os.WriteFile(repoCityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "repo", "city.toml"), liveCityPath); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := fsys.OSFS{}
+	snapshots, err := snapshotRigAddTopologyFiles(fs, cityDir, &config.City{Workspace: config.Workspace{Name: "test-city"}})
+	if err != nil {
+		t.Fatalf("snapshotRigAddTopologyFiles: %v", err)
+	}
+
+	// Simulate the surgical append mutating the resolved target before a later
+	// rig-add step fails and triggers rollback.
+	mutated := []byte("[workspace]\nname = \"test-city\"\n\n[[rigs]]\nname = \"frontend\"\n")
+	if err := os.WriteFile(repoCityPath, mutated, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restoreSnapshots(fs, snapshots); err != nil {
+		t.Fatalf("restoreSnapshots: %v", err)
+	}
+
+	info, err := os.Lstat(liveCityPath)
+	if err != nil {
+		t.Fatalf("Lstat(live city.toml): %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("rollback replaced the live city.toml symlink with a regular file")
+	}
+	restored, err := os.ReadFile(repoCityPath)
+	if err != nil {
+		t.Fatalf("read repo city.toml: %v", err)
+	}
+	if !bytes.Equal(restored, original) {
+		t.Fatalf("repo city.toml = %q, want restored original %q", restored, original)
+	}
+}

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -354,8 +354,11 @@ func WriteCityAndRigSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City) 
 // (.gc/site.toml) is kept consistent. If the site binding write fails after
 // city.toml is changed, both files are restored before the error is returned.
 func AppendRigAndWriteSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City, newRig Rig) error {
+	// cityRoot intentionally stays the symlink's directory even when city.toml
+	// links elsewhere: that is where the city's .gc/ state lives, so the site
+	// binding (.gc/site.toml) is kept next to the live city, not the target.
 	cityRoot := filepath.Dir(tomlPath)
-	writePath, err := ResolveCityRewritePath(fs, tomlPath)
+	writePath, err := ResolveCityAppendPath(fs, tomlPath)
 	if err != nil {
 		return err
 	}
@@ -456,6 +459,25 @@ func ResolveCityRewritePath(fs fsys.FS, tomlPath string) (string, error) {
 	return writePath, nil
 }
 
+// ResolveCityAppendPath returns the path a byte-preserving append to city.toml
+// must write to. Like ResolveCityRewritePath it follows symlinks so the append
+// targets the real file instead of replacing the link, and it refuses content
+// that no longer parses as City TOML (the caller loaded the config from this
+// same path, so unparsable content means it changed underneath us). Unlike the
+// full-rewrite path it does NOT refuse unknown keys: an append preserves the
+// existing bytes verbatim and cannot drop forward-compatible keys, so the
+// version-skew case (an older gc editing a newer gc's city.toml) stays lossless.
+func ResolveCityAppendPath(fs fsys.FS, tomlPath string) (string, error) {
+	writePath, err := fsys.ResolveSymlinks(fs, tomlPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s for append: %w", tomlPath, err)
+	}
+	if err := guardCityAppendCorruption(fs, writePath); err != nil {
+		return "", err
+	}
+	return writePath, nil
+}
+
 // guardCityRewriteKeyLoss refuses to rewrite a city.toml whose current
 // on-disk content contains keys this gc binary does not recognize: the
 // struct round-trip would silently drop them (ga-lurp5d dropped
@@ -465,17 +487,9 @@ func ResolveCityRewritePath(fs fsys.FS, tomlPath string) (string, error) {
 // mutating it, so unparsable content here means the file changed underneath
 // us and a rewrite would destroy whatever is there now.
 func guardCityRewriteKeyLoss(fs fsys.FS, path string) error {
-	data, err := fs.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("reading %s before rewrite: %w", path, err)
-	}
-	var cfg City
-	md, err := toml.Decode(string(data), &cfg)
-	if err != nil {
-		return fmt.Errorf("refusing to rewrite %s: current content does not parse, rewriting would destroy it: %w", path, err)
+	md, ok, err := decodeCityForGuard(fs, path)
+	if err != nil || !ok {
+		return err
 	}
 	undecoded := md.Undecoded()
 	if len(undecoded) == 0 {
@@ -487,6 +501,40 @@ func guardCityRewriteKeyLoss(fs fsys.FS, path string) error {
 	}
 	sort.Strings(keys)
 	return fmt.Errorf("refusing to rewrite %s: it contains keys this gc binary does not recognize and the rewrite would silently drop them: %s (upgrade gc or remove the keys, then retry)", path, strings.Join(keys, ", "))
+}
+
+// guardCityAppendCorruption refuses to append to a city.toml whose current
+// on-disk content no longer parses as City TOML. A missing file is fine — the
+// caller handles fresh writes. An unparsable file is refused for the same
+// reason as the rewrite guard: callers load the config from this same path
+// before mutating it, so unparsable content means the file changed underneath
+// us and appending would compound the corruption. Unlike guardCityRewriteKeyLoss
+// it does not refuse unknown keys: a byte-level append preserves the existing
+// content verbatim and cannot drop them.
+func guardCityAppendCorruption(fs fsys.FS, path string) error {
+	_, _, err := decodeCityForGuard(fs, path)
+	return err
+}
+
+// decodeCityForGuard reads and TOML-decodes the current on-disk city.toml for
+// the rewrite/append guards. ok is false when the file is missing (nothing to
+// lose). It returns an error when the file exists but no longer parses as City
+// TOML, because the caller loaded the config from this same path before
+// mutating it and any edit would destroy content that changed underneath us.
+func decodeCityForGuard(fs fsys.FS, path string) (md toml.MetaData, ok bool, err error) {
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return toml.MetaData{}, false, nil
+		}
+		return toml.MetaData{}, false, fmt.Errorf("reading %s before edit: %w", path, err)
+	}
+	var cfg City
+	md, err = toml.Decode(string(data), &cfg)
+	if err != nil {
+		return toml.MetaData{}, false, fmt.Errorf("refusing to edit %s: current content does not parse, the edit would destroy it: %w", path, err)
+	}
+	return md, true, nil
 }
 
 func rigNameSet(names []string) map[string]struct{} {

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -355,6 +355,10 @@ func WriteCityAndRigSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City) 
 // city.toml is changed, both files are restored before the error is returned.
 func AppendRigAndWriteSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City, newRig Rig) error {
 	cityRoot := filepath.Dir(tomlPath)
+	writePath, err := ResolveCityRewritePath(fs, tomlPath)
+	if err != nil {
+		return err
+	}
 
 	// Serialize only the new rig block, stripping path (it belongs in site.toml).
 	rigForCity := newRig
@@ -369,12 +373,12 @@ func AppendRigAndWriteSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City
 		return fmt.Errorf("serializing new rig block: %w", err)
 	}
 
-	existing, err := fs.ReadFile(tomlPath)
+	existing, err := fs.ReadFile(writePath)
 	if err != nil {
-		return fmt.Errorf("reading %s: %w", tomlPath, err)
+		return fmt.Errorf("reading %s: %w", writePath, err)
 	}
 
-	snapshot, err := snapshotCityAndSiteFiles(fs, tomlPath, SiteBindingPath(cityRoot))
+	snapshot, err := snapshotCityAndSiteFiles(fs, writePath, SiteBindingPath(cityRoot))
 	if err != nil {
 		return err
 	}
@@ -387,7 +391,7 @@ func AppendRigAndWriteSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City
 	content = append(content, '\n')
 	content = append(content, rigBuf.Bytes()...)
 
-	if err := fsys.WriteFileIfChangedAtomic(fs, tomlPath, content, 0o644); err != nil {
+	if err := fsys.WriteFileIfChangedAtomic(fs, writePath, content, 0o644); err != nil {
 		return err
 	}
 	if err := persistRigSiteBindings(fs, cityRoot, cfg.Rigs, nil); err != nil {

--- a/internal/config/site_binding_rewrite_test.go
+++ b/internal/config/site_binding_rewrite_test.go
@@ -119,6 +119,70 @@ func TestWriteCityAndRigSiteBindingsForEditRefusesToDropUnknownKeys(t *testing.T
 	}
 }
 
+// Regression for PR #3428 review: the byte-preserving append path must NOT
+// inherit the full-rewrite unknown-key refusal. Appending a [[rigs]] block
+// leaves the existing bytes untouched, so a city.toml carrying keys this gc
+// binary does not recognize (e.g. an older gc editing a newer gc's city) is
+// preserved verbatim instead of being rejected.
+func TestAppendRigAndWriteSiteBindingsForEditPreservesUnknownKeys(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte("[workspace]\nname = \"test-city\"\n\n[beads]\nfuture_unknown_knob = \"keep-me\"\n")
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	newRig := Rig{Name: "frontend", Path: "/srv/frontend"}
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Rigs:      []Rig{newRig},
+	}
+	if err := AppendRigAndWriteSiteBindingsForEdit(fsys.OSFS{}, cityPath, cfg, newRig); err != nil {
+		t.Fatalf("AppendRigAndWriteSiteBindingsForEdit: %v", err)
+	}
+
+	rewritten, err := os.ReadFile(cityPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(rewritten), `future_unknown_knob = "keep-me"`) {
+		t.Fatalf("append dropped the unknown key:\n%s", rewritten)
+	}
+	if !strings.Contains(string(rewritten), `name = "frontend"`) {
+		t.Fatalf("append did not add the rig block:\n%s", rewritten)
+	}
+}
+
+// The append path keeps the protective half of the rewrite guard: if the
+// on-disk city.toml no longer parses as TOML, appending would compound the
+// corruption, so it is refused and the file is left untouched. (The caller
+// loaded config from this same path before mutating it.)
+func TestAppendRigAndWriteSiteBindingsForEditRefusesUnparsableCity(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte("this is = = not valid toml [[[\n")
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	newRig := Rig{Name: "frontend", Path: "/srv/frontend"}
+	cfg := &City{Rigs: []Rig{newRig}}
+	err := AppendRigAndWriteSiteBindingsForEdit(fsys.OSFS{}, cityPath, cfg, newRig)
+	if err == nil {
+		t.Fatal("AppendRigAndWriteSiteBindingsForEdit succeeded, want refusal for unparsable city.toml")
+	}
+	if !strings.Contains(err.Error(), "does not parse") {
+		t.Fatalf("error = %v, want parse-refusal guidance", err)
+	}
+	current, readErr := os.ReadFile(cityPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile: %v", readErr)
+	}
+	if !bytes.Equal(current, original) {
+		t.Fatalf("city.toml was modified despite refusal:\n%s", current)
+	}
+}
+
 // A brand-new city.toml (no existing file) must still be writable: the
 // unknown-key guard only applies when there is existing content to lose.
 func TestWriteCityAndRigSiteBindingsForEditAllowsFreshWrite(t *testing.T) {

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -237,6 +238,65 @@ name = "test-city"
 	}
 	if len(binding.Rigs) != 1 || binding.Rigs[0].Name != "frontend" || binding.Rigs[0].Path != "/srv/frontend" {
 		t.Fatalf("site binding rigs = %+v, want frontend=/srv/frontend", binding.Rigs)
+	}
+}
+
+// Regression for PR #3428 review: when city.toml is a symlink and the site
+// binding write fails after the append, the rollback must restore the resolved
+// target's original bytes and leave the live symlink intact (it must not
+// replace the link with a regular file).
+func TestAppendRigAndWriteSiteBindingsForEditRestoresSymlinkedCityWhenSiteBindingFails(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo")
+	cityDir := filepath.Join(dir, "city")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoCityPath := filepath.Join(repoDir, "city.toml")
+	liveCityPath := filepath.Join(cityDir, "city.toml")
+	original := []byte("[workspace]\nname = \"test-city\"\n")
+	if err := os.WriteFile(repoCityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "repo", "city.toml"), liveCityPath); err != nil {
+		t.Fatal(err)
+	}
+
+	newRig := Rig{Name: "frontend", Path: "/srv/frontend"}
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Rigs:      []Rig{newRig},
+	}
+	fs := &failSiteRenameFS{target: SiteBindingPath(cityDir)}
+
+	err := AppendRigAndWriteSiteBindingsForEdit(fs, liveCityPath, cfg, newRig)
+	if err == nil {
+		t.Fatal("AppendRigAndWriteSiteBindingsForEdit succeeded, want injected site binding failure")
+	}
+	if !strings.Contains(err.Error(), "restored city.toml") {
+		t.Fatalf("error = %v, want rollback guidance", err)
+	}
+
+	info, err := os.Lstat(liveCityPath)
+	if err != nil {
+		t.Fatalf("Lstat(live city.toml): %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("live city.toml was replaced with a regular file during rollback")
+	}
+	restored, readErr := os.ReadFile(repoCityPath)
+	if readErr != nil {
+		t.Fatalf("read repo city.toml: %v", readErr)
+	}
+	if !bytes.Equal(restored, original) {
+		t.Fatalf("repo city.toml = %q, want restored original %q", restored, original)
+	}
+	if _, statErr := os.Stat(SiteBindingPath(cityDir)); !os.IsNotExist(statErr) {
+		t.Fatalf("site.toml stat err = %v, want not exist", statErr)
 	}
 }
 

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -180,6 +180,66 @@ path = "/srv/frontend"
 	}
 }
 
+func TestAppendRigAndWriteSiteBindingsForEditPreservesCityTomlSymlink(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo")
+	cityDir := filepath.Join(dir, "city")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoCityPath := filepath.Join(repoDir, "city.toml")
+	liveCityPath := filepath.Join(cityDir, "city.toml")
+	original := []byte(`[workspace]
+name = "test-city"
+`)
+	if err := os.WriteFile(repoCityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "repo", "city.toml"), liveCityPath); err != nil {
+		t.Fatal(err)
+	}
+
+	newRig := Rig{Name: "frontend", Path: "/srv/frontend"}
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Rigs:      []Rig{newRig},
+	}
+	if err := AppendRigAndWriteSiteBindingsForEdit(fsys.OSFS{}, liveCityPath, cfg, newRig); err != nil {
+		t.Fatalf("AppendRigAndWriteSiteBindingsForEdit: %v", err)
+	}
+
+	info, err := os.Lstat(liveCityPath)
+	if err != nil {
+		t.Fatalf("Lstat(live city.toml): %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("live city.toml was replaced with a regular file")
+	}
+
+	rewritten, err := os.ReadFile(repoCityPath)
+	if err != nil {
+		t.Fatalf("ReadFile(repo city.toml): %v", err)
+	}
+	if !strings.Contains(string(rewritten), `name = "frontend"`) {
+		t.Fatalf("repo city.toml did not receive appended rig:\n%s", rewritten)
+	}
+	if strings.Contains(string(rewritten), `path = "/srv/frontend"`) {
+		t.Fatalf("repo city.toml should not contain machine-local rig path:\n%s", rewritten)
+	}
+
+	binding, err := LoadSiteBinding(fsys.OSFS{}, cityDir)
+	if err != nil {
+		t.Fatalf("LoadSiteBinding: %v", err)
+	}
+	if len(binding.Rigs) != 1 || binding.Rigs[0].Name != "frontend" || binding.Rigs[0].Path != "/srv/frontend" {
+		t.Fatalf("site binding rigs = %+v, want frontend=/srv/frontend", binding.Rigs)
+	}
+}
+
 func TestApplySiteBindingsForEdit_KeepsLegacyPath(t *testing.T) {
 	fs := fsys.NewFake()
 	cfg := &City{


### PR DESCRIPTION
## Summary
- Resolve symlinked city.toml paths before the append-only rig writer reads, snapshots, and atomically writes the config.
- Keep .gc/site.toml writes rooted at the live city directory.
- Add a regression test proving append-rig updates the repo-backed target without replacing the live symlink.

## Tests
- go test ./internal/config -run 'Test(AppendRigAndWriteSiteBindingsForEditPreservesCityTomlSymlink|WriteCityAndRigSiteBindingsForEditRestoresCityWhenSiteBindingFails|WriteCityAndRigSiteBindingsForEditRemovingRigsDropsDeletedBinding)' -count=1
- go test ./internal/config -count=1