### PR TITLE
feat(workspacesvc): pass GC_SERVICE_SECRETS_DIR to proxy_process services (ga-bu5pcn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Proxy-process workspace services now receive `GC_SERVICE_SECRETS_DIR`
+  (`<GC_SERVICE_STATE_ROOT>/secrets`) in their environment, alongside the
+  existing `GC_SERVICE_*` variables. The directory is scaffolded at `0700`
+  by the service state-root setup and is the sanctioned home for
+  pack-managed credentials (bot tokens etc.), so pack services can rely on
+  the explicit contract instead of deriving the path from
+  `GC_SERVICE_STATE_ROOT`. See #3429.
 - `gc nudge drain --inject` now prepends a one-line current-time stamp
   (operator-local + UTC + epoch) to its `UserPromptSubmit` hook output, giving
   agents a live clock in context every turn. The local zone follows the host

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -1860,6 +1860,7 @@ func TestFindSupervisorWorkspaceServiceProcessesFiltersOwnershipAndRequiredEnv(t
 		"GC_CITY_PATH":              cityPath,
 		"GC_SERVICE_NAME":           "bridge",
 		"GC_SERVICE_STATE_ROOT":     serviceRoot,
+		"GC_SERVICE_SECRETS_DIR":    filepath.Join(serviceRoot, "secrets"),
 		"GC_SERVICE_SOCKET":         filepath.Join(t.TempDir(), "bridge.sock"),
 		"GC_CITY_RUNTIME_DIR":       filepath.Join(cityPath, ".gc", "runtime"),
 		"GC_SERVICE_RUN_ROOT":       filepath.Join(serviceRoot, "run"),

--- a/internal/workspacesvc/proxy_process.go
+++ b/internal/workspacesvc/proxy_process.go
@@ -208,6 +208,9 @@ func (p *proxyProcessInstance) start(now time.Time) error {
 	cmd.Env = append(cmd.Env,
 		"GC_SERVICE_NAME="+p.svc.Name,
 		"GC_SERVICE_STATE_ROOT="+p.absStateRoot,
+		// Scaffolded at 0700 by ensureStateRoot; the sanctioned home for
+		// pack-managed credentials (bot tokens etc.).
+		"GC_SERVICE_SECRETS_DIR="+filepath.Join(p.absStateRoot, "secrets"),
 		"GC_SERVICE_RUN_ROOT="+filepath.Join(p.absStateRoot, "run"),
 		"GC_SERVICE_SOCKET="+p.socketPath,
 		"GC_SERVICE_URL_PREFIX="+citylayout.PublicServiceMountPath(p.rt.CityName(), p.svc.Name),

--- a/internal/workspacesvc/proxy_process_test.go
+++ b/internal/workspacesvc/proxy_process_test.go
@@ -179,6 +179,7 @@ func TestProxyProcessHelper(t *testing.T) {
 			"GC_CONTROL_DISPATCHER_TRACE_DEFAULT": os.Getenv("GC_CONTROL_DISPATCHER_TRACE_DEFAULT"),
 			"GC_SERVICE_NAME":                     os.Getenv("GC_SERVICE_NAME"),
 			"GC_SERVICE_STATE_ROOT":               os.Getenv("GC_SERVICE_STATE_ROOT"),
+			"GC_SERVICE_SECRETS_DIR":              os.Getenv("GC_SERVICE_SECRETS_DIR"),
 			"GC_SERVICE_URL_PREFIX":               os.Getenv("GC_SERVICE_URL_PREFIX"),
 			"GC_SERVICE_PUBLIC_URL":               os.Getenv("GC_SERVICE_PUBLIC_URL"),
 			"GC_SERVICE_VISIBILITY":               os.Getenv("GC_SERVICE_VISIBILITY"),
@@ -278,6 +279,9 @@ func TestProxyProcessPublishesServiceEnv(t *testing.T) {
 	}
 	if env["GC_SERVICE_STATE_ROOT"] != filepath.Join(rt.cityPath, ".gc", "services", "bridge") {
 		t.Fatalf("GC_SERVICE_STATE_ROOT = %q, want %q", env["GC_SERVICE_STATE_ROOT"], filepath.Join(rt.cityPath, ".gc", "services", "bridge"))
+	}
+	if env["GC_SERVICE_SECRETS_DIR"] != filepath.Join(rt.cityPath, ".gc", "services", "bridge", "secrets") {
+		t.Fatalf("GC_SERVICE_SECRETS_DIR = %q, want %q", env["GC_SERVICE_SECRETS_DIR"], filepath.Join(rt.cityPath, ".gc", "services", "bridge", "secrets"))
 	}
 	if env["GC_SERVICE_PUBLIC_URL"] != "https://bridge--acme--deadbeef.apps.example.com" {
 		t.Fatalf("GC_SERVICE_PUBLIC_URL = %q, want authoritative route", env["GC_SERVICE_PUBLIC_URL"])


### PR DESCRIPTION
## Summary

Core already scaffolds `<state_root>/secrets` at 0700 for every service (`ensureStateRoot` in `internal/workspacesvc/manager.go`) and re-chmods it on each start — but the env block passed to `proxy_process` children never communicated the path. Pack services hand-derive it: the discord pack in gascity-packs reads `GC_SERVICE_SECRETS_DIR` as an optional override (`scripts/discord_intake_common.py`) and falls back to deriving `state_root/secrets` itself.

This makes the convention an explicit contract: `GC_SERVICE_SECRETS_DIR=<absStateRoot>/secrets` is now passed alongside `GC_SERVICE_STATE_ROOT`/`GC_SERVICE_RUN_ROOT`. The discord pack picks it up with zero changes; the upcoming telegram provider pack (ga-aiefhz) codes against it directly.

## Test

TDD: extended the `TestProxyProcessPublishesServiceEnv` env-echo helper and assertion (red), then added the env line (green). Full `internal/workspacesvc` package green, `go vet` clean.

Refs: ga-bu5pcn. Related follow-up: ga-77i7n3 (doctor lint for file perms inside secrets dirs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)