### PR TITLE
feat(doctor): flag group/other-accessible files under service secrets dirs (ga-77i7n3)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -223,6 +223,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewFormulaRequirementsCheck(cfg, cityPath))
 		register(doctor.NewNamedAlwaysMinConflictCheck(cfg))
 		register(doctor.NewInstructionsFileCheck(cfg, cityPath))
+		register(doctor.NewServiceSecretsPermsCheck(cfg, cityPath))
 		register(doctor.NewSkillCollisionCheck(cfg, cityPath))
 		register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath, doctor.WithOrderFiringCurrentLastRunFunc(doctorOrderFiringCurrentLastRunFunc(cityPath, cfg, opts.Stderr))))
 		register(newCodexHooksDriftCheck(codexHookWorkDirs(cityPath, cfg)))

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -29,6 +29,7 @@ provider-parity
 formula-requirements
 named-always-min-conflict
 instructions-file
+service-secrets-perms
 skill-collision
 order-firing-current
 codex-hooks-drift

--- a/internal/doctor/checks_service_secrets.go
+++ b/internal/doctor/checks_service_secrets.go
@@ -1,0 +1,167 @@
+package doctor
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// ServiceSecretsPermsCheck flags group/other-readable entries inside service
+// secrets directories. Core scaffolds `<state_root>/secrets` at 0700 for
+// every service (workspacesvc.ensureStateRoot) but only pack discipline
+// keeps the files inside at 0600 — a hand-copied token file or a sloppy
+// writer can land 0644 and quietly widen a credential to every same-group
+// process. The check is mechanical: regular files must have no group/other
+// bits, directories likewise (a 0755 subdirectory undermines the 0700
+// root). Symlinks are skipped — target permissions are what matter, and
+// symlink policy inside secrets dirs belongs to the pack loaders (which
+// reject them).
+type ServiceSecretsPermsCheck struct {
+	cfg      *config.City
+	cityPath string
+}
+
+// NewServiceSecretsPermsCheck creates a check that audits permissions under
+// each configured service's secrets directory.
+func NewServiceSecretsPermsCheck(cfg *config.City, cityPath string) *ServiceSecretsPermsCheck {
+	return &ServiceSecretsPermsCheck{cfg: cfg, cityPath: cityPath}
+}
+
+// Name returns the check identifier.
+func (c *ServiceSecretsPermsCheck) Name() string { return "service-secrets-perms" }
+
+// CanFix reports that loose permissions can be tightened automatically.
+func (c *ServiceSecretsPermsCheck) CanFix() bool { return true }
+
+// WarmupEligible keeps this check out of the `gc start` warm-up scan.
+func (c *ServiceSecretsPermsCheck) WarmupEligible() bool { return false }
+
+// secretsDirs returns the deduplicated, existing secrets directories for
+// all configured services. Services may share a state root (one pack, many
+// services), so each directory is audited once.
+func (c *ServiceSecretsPermsCheck) secretsDirs() []string {
+	if c.cfg == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var dirs []string
+	for _, svc := range c.cfg.Services {
+		root := svc.StateRootOrDefault()
+		if root == "" {
+			continue
+		}
+		if !filepath.IsAbs(root) {
+			root = filepath.Join(c.cityPath, root)
+		}
+		dir := filepath.Join(root, "secrets")
+		if seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		if st, err := os.Stat(dir); err != nil || !st.IsDir() {
+			continue
+		}
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	return dirs
+}
+
+// looseEntries walks one secrets directory and returns entries with
+// group/other permission bits set. The top directory itself is included:
+// core re-chmods it to 0700 on service start, but doctor may run against a
+// stopped city.
+func looseEntries(dir string) ([]string, error) {
+	var loose []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && !info.Mode().IsRegular() {
+			return nil
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			loose = append(loose, fmt.Sprintf("%s (mode %o)", path, info.Mode().Perm()))
+		}
+		return nil
+	})
+	return loose, err
+}
+
+// Run reports any group/other-accessible files or directories under the
+// configured services' secrets directories.
+func (c *ServiceSecretsPermsCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	var loose []string
+	for _, dir := range c.secretsDirs() {
+		entries, err := looseEntries(dir)
+		if err != nil {
+			r.Status = StatusError
+			r.Message = fmt.Sprintf("auditing %s: %v", dir, err)
+			return r
+		}
+		loose = append(loose, entries...)
+	}
+	if len(loose) == 0 {
+		r.Status = StatusOK
+		r.Message = "service secrets directories have tight permissions"
+		return r
+	}
+	r.Status = StatusWarning
+	r.Severity = SeverityAdvisory
+	r.Message = fmt.Sprintf("%d group/other-accessible entr%s under service secrets directories", len(loose), pluralYIES(len(loose)))
+	r.Details = loose
+	r.FixHint = "run `gc doctor --fix` (chmods files to 0600, directories to 0700)"
+	return r
+}
+
+// Fix tightens every loose entry: regular files to 0600, directories to
+// 0700.
+func (c *ServiceSecretsPermsCheck) Fix(_ *CheckContext) error {
+	for _, dir := range c.secretsDirs() {
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.Type()&fs.ModeSymlink != 0 {
+				return nil
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			if info.Mode().Perm()&0o077 == 0 {
+				return nil
+			}
+			switch {
+			case info.IsDir():
+				return os.Chmod(path, 0o700)
+			case info.Mode().IsRegular():
+				return os.Chmod(path, 0o600)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("tightening %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func pluralYIES(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}

--- a/internal/doctor/checks_service_secrets.go
+++ b/internal/doctor/checks_service_secrets.go
@@ -1,11 +1,13 @@
 package doctor
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -17,9 +19,16 @@ import (
 // writer can land 0644 and quietly widen a credential to every same-group
 // process. The check is mechanical: regular files must have no group/other
 // bits, directories likewise (a 0755 subdirectory undermines the 0700
-// root). Symlinks are skipped — target permissions are what matter, and
-// symlink policy inside secrets dirs belongs to the pack loaders (which
-// reject them).
+// root). Each secrets root is fully resolved (following any symlinked
+// ancestor or `secrets` dir and collapsing `..` segments) and then confined
+// to the city before it is walked, matching how core chmods through a
+// symlinked dir when it tightens it. Because `gc doctor --fix` recursively
+// chmods every entry it walks, a root that resolves outside the city —
+// through an absolute or `..` state_root, a symlinked ancestor, or a
+// symlinked `secrets` dir — or one that cannot be resolved is reported and
+// skipped, never walked or chmodded, so `--fix` can never rewrite file modes
+// outside the city boundary. Symlinked entries *inside* the tree are skipped
+// so the check never chmods through a link to a file it does not own.
 type ServiceSecretsPermsCheck struct {
 	cfg      *config.City
 	cityPath string
@@ -40,15 +49,59 @@ func (c *ServiceSecretsPermsCheck) CanFix() bool { return true }
 // WarmupEligible keeps this check out of the `gc start` warm-up scan.
 func (c *ServiceSecretsPermsCheck) WarmupEligible() bool { return false }
 
-// secretsDirs returns the deduplicated, existing secrets directories for
-// all configured services. Services may share a state root (one pack, many
-// services), so each directory is audited once.
-func (c *ServiceSecretsPermsCheck) secretsDirs() []string {
-	if c.cfg == nil {
-		return nil
+// serviceSecretsChmodHint is the remediation shown when loose entries exist.
+const serviceSecretsChmodHint = "run `gc doctor --fix` (chmods files to 0600, directories to 0700)"
+
+// secretsTarget is one confined service secrets directory to audit. walk is
+// the path the filesystem walk descends and the only path Fix chmods; it is
+// always inside the city boundary. configured is the operator-facing path
+// anchored to the service's configured state root, used when reporting
+// findings so they map back to service config even when the secrets root
+// resolved to a different real path.
+type secretsTarget struct {
+	configured string
+	walk       string
+}
+
+// report re-anchors a path walked under this target back onto the configured
+// secrets path, so a finding names the operator-configured location rather
+// than a resolved symlink target. When the resolved walk root already equals
+// the configured path nothing needs re-anchoring and the path is returned
+// unchanged.
+func (t secretsTarget) report(path string) string {
+	if t.walk == t.configured {
+		return path
 	}
-	seen := map[string]bool{}
-	var dirs []string
+	if rel, err := filepath.Rel(t.walk, path); err == nil {
+		return filepath.Join(t.configured, rel)
+	}
+	return path
+}
+
+// secretsDirs returns the confined secrets directories to audit for all
+// configured services, plus advisory notes for roots that were skipped because
+// they could not be audited safely.
+//
+// Every secrets root is fully resolved with filepath.EvalSymlinks so the walk
+// descends the real tree — matching how core's ensureStateRoot chmods through a
+// symlinked dir — and so the confinement check sees the true target no matter
+// how the configured path reaches it. Because Fix recursively chmods every
+// entry it walks, a resolved root is audited only when it stays inside the
+// city: a root that escapes — via an absolute or `..` state_root, a symlinked
+// ancestor, or a symlinked `secrets` dir — or one whose path cannot be resolved
+// is recorded in skipped and never walked or chmodded. state_root is not
+// validated at config load (only by the sibling config-valid check), so
+// confining the resolved walk root here is what keeps a stray symlink or a
+// mis-set state_root from turning `--fix` into a recursive chmod of an
+// arbitrary out-of-city tree. A secrets dir a service has not created yet is
+// simply absent and skipped silently. Services may share a state root, so each
+// resolved secrets directory is audited once.
+func (c *ServiceSecretsPermsCheck) secretsDirs() (targets []secretsTarget, skipped []string) {
+	if c.cfg == nil {
+		return nil, nil
+	}
+	seenConfigured := map[string]bool{}
+	seenWalk := map[string]bool{}
 	for _, svc := range c.cfg.Services {
 		root := svc.StateRootOrDefault()
 		if root == "" {
@@ -57,28 +110,96 @@ func (c *ServiceSecretsPermsCheck) secretsDirs() []string {
 		if !filepath.IsAbs(root) {
 			root = filepath.Join(c.cityPath, root)
 		}
-		dir := filepath.Join(root, "secrets")
-		if seen[dir] {
+		configured := filepath.Join(root, "secrets")
+		// Services may share a state root (one pack, many services); audit
+		// each configured secrets directory once. Deduping here also keeps a
+		// shared root from emitting duplicate skip notes.
+		if seenConfigured[configured] {
 			continue
 		}
-		seen[dir] = true
-		if st, err := os.Stat(dir); err != nil || !st.IsDir() {
+		seenConfigured[configured] = true
+
+		// A secrets dir a service has not created yet is not a finding; skip it
+		// silently. Lstat (not Stat) is used so a `secrets` symlink — even a
+		// dangling one — counts as present and is resolved below rather than
+		// read as absent. An unreadable ancestor also lands here and is skipped
+		// silently, exactly as before.
+		if _, err := os.Lstat(configured); err != nil {
 			continue
 		}
-		dirs = append(dirs, dir)
+
+		// Resolve the full walk root for every target, not only when the final
+		// `secrets` component is a symlink. An absolute or `..`-traversing
+		// state_root, or an in-city path whose ancestor is a symlink, can place
+		// the real walk root outside the city even though the configured path
+		// looks in-city — and Fix recursively chmods everything it walks.
+		// EvalSymlinks resolves every symlink and `..` segment against the real
+		// filesystem so the confinement check below sees the true target.
+		walk, err := filepath.EvalSymlinks(configured)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s: secrets path could not be resolved (%v); skipped (not audited or repaired)", configured, err))
+			continue
+		}
+		if !c.withinCity(walk) {
+			skipped = append(skipped, fmt.Sprintf("%s: secrets path resolves outside the city to %s; skipped (not audited or repaired)", configured, walk))
+			continue
+		}
+		// Two distinct configured paths can resolve to the same physical
+		// directory; audit the resolved target once.
+		if seenWalk[walk] {
+			continue
+		}
+		seenWalk[walk] = true
+		if st, err := os.Stat(walk); err != nil || !st.IsDir() {
+			continue
+		}
+		targets = append(targets, secretsTarget{configured: configured, walk: walk})
 	}
-	sort.Strings(dirs)
-	return dirs
+	sort.Slice(targets, func(i, j int) bool { return targets[i].configured < targets[j].configured })
+	sort.Strings(skipped)
+	return targets, skipped
 }
 
-// looseEntries walks one secrets directory and returns entries with
-// group/other permission bits set. The top directory itself is included:
-// core re-chmods it to 0700 on service start, but doctor may run against a
-// stopped city.
-func looseEntries(dir string) ([]string, error) {
+// withinCity reports whether an already-resolved path stays inside the city
+// boundary. Both sides are made absolute and symlink-resolved before the
+// comparison so a city root that itself contains symlinked components (a macOS
+// /var -> /private/var temp dir, for example) does not falsely read as an
+// escape. A resolved secrets target outside the city must never be walked or
+// chmodded by Fix.
+func (c *ServiceSecretsPermsCheck) withinCity(resolved string) bool {
+	city := c.cityPath
+	if abs, err := filepath.Abs(city); err == nil {
+		city = abs
+	}
+	if r, err := filepath.EvalSymlinks(city); err == nil {
+		city = r
+	}
+	city = filepath.Clean(city)
+	resolved = filepath.Clean(resolved)
+	if resolved == city {
+		return true
+	}
+	rel, err := filepath.Rel(city, resolved)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+// looseEntries walks one confined secrets directory and returns descriptions
+// of entries with group/other permission bits set, each anchored to the
+// target's configured path. The top directory itself is included: core
+// re-chmods it to 0700 on service start, but doctor may run against a stopped
+// city. Entries that vanish mid-walk are tolerated: services write secrets
+// with atomic temp-file→rename, so a self-healing race must not turn an
+// advisory hygiene check into a failure.
+func looseEntries(t secretsTarget) ([]string, error) {
 	var loose []string
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(t.walk, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
 			return err
 		}
 		if d.Type()&fs.ModeSymlink != 0 {
@@ -86,13 +207,16 @@ func looseEntries(dir string) ([]string, error) {
 		}
 		info, err := d.Info()
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
 			return err
 		}
 		if !info.IsDir() && !info.Mode().IsRegular() {
 			return nil
 		}
 		if info.Mode().Perm()&0o077 != 0 {
-			loose = append(loose, fmt.Sprintf("%s (mode %o)", path, info.Mode().Perm()))
+			loose = append(loose, fmt.Sprintf("%s (mode %o)", t.report(path), info.Mode().Perm()))
 		}
 		return nil
 	})
@@ -100,38 +224,69 @@ func looseEntries(dir string) ([]string, error) {
 }
 
 // Run reports any group/other-accessible files or directories under the
-// configured services' secrets directories.
+// configured services' secrets directories, plus any symlinked secrets roots
+// skipped because they escape the city or cannot be resolved. The result is
+// advisory: a finding is a hygiene warning, and even an infrastructure error
+// while auditing must not gate `gc doctor`, dispatch, or automation. Audit
+// errors are accumulated across directories — a single unreadable tree must
+// not hide loose entries in the others — mirroring Fix's aggregation.
 func (c *ServiceSecretsPermsCheck) Run(_ *CheckContext) *CheckResult {
-	r := &CheckResult{Name: c.Name()}
+	r := &CheckResult{Name: c.Name(), Severity: SeverityAdvisory}
+	targets, skipped := c.secretsDirs()
 	var loose []string
-	for _, dir := range c.secretsDirs() {
-		entries, err := looseEntries(dir)
+	var auditErrs []error
+	for _, t := range targets {
+		entries, err := looseEntries(t)
 		if err != nil {
-			r.Status = StatusError
-			r.Message = fmt.Sprintf("auditing %s: %v", dir, err)
-			return r
+			auditErrs = append(auditErrs, fmt.Errorf("auditing %s: %w", t.configured, err))
+			continue
 		}
 		loose = append(loose, entries...)
 	}
-	if len(loose) == 0 {
+	sort.Strings(loose)
+	r.Details = append(append([]string(nil), loose...), skipped...)
+
+	if len(auditErrs) > 0 {
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("auditing service secrets directories: %v", errors.Join(auditErrs...))
+		return r
+	}
+	if len(loose) == 0 && len(skipped) == 0 {
 		r.Status = StatusOK
 		r.Message = "service secrets directories have tight permissions"
 		return r
 	}
 	r.Status = StatusWarning
-	r.Severity = SeverityAdvisory
-	r.Message = fmt.Sprintf("%d group/other-accessible entr%s under service secrets directories", len(loose), pluralYIES(len(loose)))
-	r.Details = loose
-	r.FixHint = "run `gc doctor --fix` (chmods files to 0600, directories to 0700)"
+	switch {
+	case len(loose) > 0 && len(skipped) > 0:
+		r.Message = fmt.Sprintf("%d group/other-accessible %s under service secrets directories; %d secrets %s skipped (resolves outside the city or unresolved)",
+			len(loose), pluralEntry(len(loose)), len(skipped), pluralRoot(len(skipped)))
+		r.FixHint = serviceSecretsChmodHint
+	case len(loose) > 0:
+		r.Message = fmt.Sprintf("%d group/other-accessible %s under service secrets directories", len(loose), pluralEntry(len(loose)))
+		r.FixHint = serviceSecretsChmodHint
+	default:
+		r.Message = fmt.Sprintf("%d secrets %s skipped: resolves outside the city or unresolved", len(skipped), pluralRoot(len(skipped)))
+		r.FixHint = "keep each service `state_root`/`secrets` path inside the city (check for an out-of-city or `..` state_root, or a `secrets` symlink pointing outside)"
+	}
 	return r
 }
 
 // Fix tightens every loose entry: regular files to 0600, directories to
-// 0700.
+// 0700. It walks only the confined targets from secretsDirs, so a secrets
+// root resolving outside the city is never chmodded. Repair continues across
+// every secrets directory even when one fails — a single unreadable tree must
+// not strand otherwise-fixable directories — and per-directory errors are
+// aggregated with errors.Join. Entries that vanish mid-walk are tolerated.
 func (c *ServiceSecretsPermsCheck) Fix(_ *CheckContext) error {
-	for _, dir := range c.secretsDirs() {
-		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	var errs []error
+	targets, _ := c.secretsDirs()
+	for _, t := range targets {
+		err := filepath.WalkDir(t.walk, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
 				return err
 			}
 			if d.Type()&fs.ModeSymlink != 0 {
@@ -139,6 +294,9 @@ func (c *ServiceSecretsPermsCheck) Fix(_ *CheckContext) error {
 			}
 			info, err := d.Info()
 			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
 				return err
 			}
 			if info.Mode().Perm()&0o077 == 0 {
@@ -153,15 +311,16 @@ func (c *ServiceSecretsPermsCheck) Fix(_ *CheckContext) error {
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("tightening %s: %w", dir, err)
+			errs = append(errs, fmt.Errorf("tightening %s: %w", t.configured, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
-func pluralYIES(n int) string {
+// pluralRoot returns the singular or plural noun for a count of secrets roots.
+func pluralRoot(n int) string {
 	if n == 1 {
-		return "y"
+		return "root"
 	}
-	return "ies"
+	return "roots"
 }

--- a/internal/doctor/checks_service_secrets_test.go
+++ b/internal/doctor/checks_service_secrets_test.go
@@ -79,6 +79,15 @@ func TestServiceSecretsPermsCheckFlagsLooseFilesAndDirs(t *testing.T) {
 	if !strings.Contains(joined, nested) {
 		t.Fatalf("details missing loose dir %s:\n%s", nested, joined)
 	}
+	// bridge and bridge-admin share a state root: the shared secrets dir
+	// must be walked once, so exactly the two distinct loose entries (the
+	// bridge token and the intake nested dir) are reported, not three.
+	if len(r.Details) != 2 {
+		t.Fatalf("Details count = %d, want 2 (shared bridge/bridge-admin root must be audited once):\n%s", len(r.Details), joined)
+	}
+	if !strings.Contains(r.Message, "2 group/other-accessible entries") {
+		t.Fatalf("Message = %q, want it to report 2 entries", r.Message)
+	}
 }
 
 func TestServiceSecretsPermsCheckFixTightensPerms(t *testing.T) {
@@ -124,4 +133,268 @@ func TestServiceSecretsPermsCheckNilConfig(t *testing.T) {
 	if r := check.Run(&CheckContext{}); r.Status != StatusOK {
 		t.Fatalf("Status = %v, want OK", r.Status)
 	}
+}
+
+func TestServiceSecretsPermsCheckWalkErrorStaysAdvisory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0000 does not block reads")
+	}
+	cityPath := t.TempDir()
+	// An unreadable subdir surfaces a permission error (not fs.ErrNotExist)
+	// during the walk. The audit must report StatusError but keep advisory
+	// severity so an infrastructure error in a hygiene check never flips
+	// `gc doctor` to a blocking, non-zero exit.
+	locked := filepath.Join(cityPath, ".gc", "services", "bridge", "secrets", "locked")
+	if err := os.MkdirAll(locked, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", locked, err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatalf("chmod %s: %v", locked, err)
+	}
+	// Restore perms before t.TempDir cleanup so removal can recurse in.
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o700) })
+
+	check := NewServiceSecretsPermsCheck(serviceSecretsTestConfig(), cityPath)
+	r := check.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusError {
+		t.Fatalf("Status = %v, want Error (message %q)", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want advisory — an audit error must not block doctor", r.Severity)
+	}
+}
+
+func TestServiceSecretsPermsCheckFollowsSymlinkedSecretsDir(t *testing.T) {
+	cityPath := t.TempDir()
+	// A real directory holding a loose token, with the service's `secrets`
+	// path pointing at it through a symlink. Core follows such a link when
+	// it chmods the dir to 0700, so the audit must descend into the target
+	// rather than skip the symlinked root.
+	realDir := filepath.Join(cityPath, "real-bridge-secrets")
+	loose := filepath.Join(realDir, "bot-token.txt")
+	writeSecretFile(t, loose, 0o644)
+
+	link := filepath.Join(cityPath, ".gc", "services", "bridge", "secrets")
+	if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(link), err)
+	}
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", link, realDir, err)
+	}
+
+	check := NewServiceSecretsPermsCheck(serviceSecretsTestConfig(), cityPath)
+	r := check.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want Warning — symlinked secrets dir must be followed (message %q)", r.Status, r.Message)
+	}
+	// Findings are reported against the configured `<state_root>/secrets`
+	// path, not the resolved symlink target, so an operator can map them back
+	// to service config; the symlink resolution stays an implementation detail.
+	wantReport := filepath.Join(cityPath, ".gc", "services", "bridge", "secrets", "bot-token.txt")
+	joined := strings.Join(r.Details, "\n")
+	if !strings.Contains(joined, wantReport) {
+		t.Fatalf("details should report the configured secrets path %s:\n%s", wantReport, joined)
+	}
+	if strings.Contains(joined, "real-bridge-secrets") {
+		t.Fatalf("details should not leak the resolved symlink target path:\n%s", joined)
+	}
+
+	// --fix must also reach through the link and tighten the target file.
+	if err := check.Fix(&CheckContext{CityPath: cityPath}); err != nil {
+		t.Fatalf("Fix through symlinked secrets dir: %v", err)
+	}
+	st, err := os.Stat(loose)
+	if err != nil {
+		t.Fatalf("stat %s: %v", loose, err)
+	}
+	if st.Mode().Perm() != 0o600 {
+		t.Fatalf("post-fix %s mode = %o, want 600", loose, st.Mode().Perm())
+	}
+}
+
+func TestServiceSecretsPermsCheckSkipsOutOfCitySymlinkRoot(t *testing.T) {
+	cityPath := t.TempDir()
+	// A real secrets tree OUTSIDE the city holding a loose token, reachable
+	// only through a symlink at the service's in-city `secrets` path. Because
+	// `gc doctor --fix` recursively chmods everything it walks, following such
+	// a link would let a stray symlink turn --fix into a recursive chmod of an
+	// arbitrary out-of-city tree. The check must instead skip the escaping
+	// root: report it, but neither audit its entries nor repair them.
+	outside := t.TempDir()
+	loose := filepath.Join(outside, "bot-token.txt")
+	writeSecretFile(t, loose, 0o644)
+
+	link := filepath.Join(cityPath, ".gc", "services", "bridge", "secrets")
+	if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(link), err)
+	}
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", link, outside, err)
+	}
+
+	check := NewServiceSecretsPermsCheck(serviceSecretsTestConfig(), cityPath)
+	r := check.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want Warning — an escaping symlink root must be surfaced (message %q)", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want advisory", r.Severity)
+	}
+	joined := strings.Join(r.Details, "\n")
+	if !strings.Contains(joined, link) {
+		t.Fatalf("details should name the skipped symlinked secrets root %s:\n%s", link, joined)
+	}
+	// The out-of-city token must never be audited as an in-city loose entry.
+	if strings.Contains(joined, "bot-token.txt") {
+		t.Fatalf("out-of-city token must not be audited as a loose entry:\n%s", joined)
+	}
+
+	// The crux: --fix must leave the out-of-city target's mode untouched.
+	if err := check.Fix(&CheckContext{CityPath: cityPath}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	st, err := os.Stat(loose)
+	if err != nil {
+		t.Fatalf("stat %s: %v", loose, err)
+	}
+	if st.Mode().Perm() != 0o644 {
+		t.Fatalf("out-of-city %s mode = %o, want 644 unchanged — --fix must not chmod outside the city", loose, st.Mode().Perm())
+	}
+}
+
+func TestServiceSecretsPermsCheckSurfacesUnresolvableSymlinkRoot(t *testing.T) {
+	cityPath := t.TempDir()
+	// A dangling secrets symlink: the link exists but its target does not, so
+	// filepath.EvalSymlinks fails. The check must surface it rather than
+	// silently treat the secrets dir as clean, and must not walk or chmod
+	// through a link it cannot resolve.
+	link := filepath.Join(cityPath, ".gc", "services", "bridge", "secrets")
+	if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(link), err)
+	}
+	missing := filepath.Join(cityPath, "does-not-exist")
+	if err := os.Symlink(missing, link); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", link, missing, err)
+	}
+
+	check := NewServiceSecretsPermsCheck(serviceSecretsTestConfig(), cityPath)
+	r := check.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want Warning — an unresolvable secrets symlink must be surfaced, not read clean (message %q)", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want advisory", r.Severity)
+	}
+	if joined := strings.Join(r.Details, "\n"); !strings.Contains(joined, link) {
+		t.Fatalf("details should name the unresolved secrets symlink %s:\n%s", link, joined)
+	}
+
+	// Fix must be a no-op for an unresolvable root.
+	if err := check.Fix(&CheckContext{CityPath: cityPath}); err != nil {
+		t.Fatalf("Fix over unresolvable symlink root: %v", err)
+	}
+}
+
+// assertSkippedOutOfCityRoot runs the check against cfg and asserts the given
+// out-of-city secrets tree is surfaced as a skipped root, never audited, and —
+// the crux — never chmodded by Fix. configured is the operator-facing secrets
+// path the skip note must name; loose is the out-of-city token that must keep
+// its 0644 mode.
+func assertSkippedOutOfCityRoot(t *testing.T, cfg *config.City, cityPath, configured, loose string) {
+	t.Helper()
+	check := NewServiceSecretsPermsCheck(cfg, cityPath)
+	r := check.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want Warning — an out-of-city secrets root must be surfaced (message %q)", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want advisory", r.Severity)
+	}
+	joined := strings.Join(r.Details, "\n")
+	if !strings.Contains(joined, configured) {
+		t.Fatalf("details should name the skipped configured secrets root %s:\n%s", configured, joined)
+	}
+	// The out-of-city token must never be audited as an in-city loose entry.
+	if strings.Contains(joined, filepath.Base(loose)) {
+		t.Fatalf("out-of-city token %s must not be audited as a loose entry:\n%s", filepath.Base(loose), joined)
+	}
+	// The crux: --fix must leave the out-of-city target's mode untouched.
+	if err := check.Fix(&CheckContext{CityPath: cityPath}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	st, err := os.Stat(loose)
+	if err != nil {
+		t.Fatalf("stat %s: %v", loose, err)
+	}
+	if st.Mode().Perm() != 0o644 {
+		t.Fatalf("out-of-city %s mode = %o, want 644 unchanged — --fix must not chmod outside the city", loose, st.Mode().Perm())
+	}
+}
+
+func TestServiceSecretsPermsCheckSkipsAbsoluteOutOfCityStateRoot(t *testing.T) {
+	cityPath := t.TempDir()
+	// An absolute state_root pointing entirely outside the city, with a real
+	// secrets dir and a loose token out there. state_root is not validated at
+	// config load (only by the sibling config-valid check), so a city.toml with
+	// an absolute out-of-city state_root parses cleanly and reaches this check.
+	// The final `secrets` component is a plain directory, not a symlink, so a
+	// guard that only resolved symlinks would walk and chmod the out-of-city
+	// tree. The walk root itself must be city-confined.
+	outside := t.TempDir()
+	loose := filepath.Join(outside, "secrets", "bot-token.txt")
+	writeSecretFile(t, loose, 0o644)
+
+	cfg := &config.City{Services: []config.Service{
+		{Name: "bridge", Kind: "proxy_process", StateRoot: outside},
+	}}
+	assertSkippedOutOfCityRoot(t, cfg, cityPath, filepath.Join(outside, "secrets"), loose)
+}
+
+func TestServiceSecretsPermsCheckSkipsDotDotStateRootEscape(t *testing.T) {
+	parent := t.TempDir()
+	cityPath := filepath.Join(parent, "city")
+	if err := os.MkdirAll(cityPath, 0o700); err != nil {
+		t.Fatalf("mkdir city: %v", err)
+	}
+	// A relative state_root that climbs out of the city with `..`. Joined to the
+	// city path it lands in a sibling dir; like the absolute case it is a plain
+	// directory, not a symlink, so the walk root must be confined after `..`
+	// segments are collapsed against the real filesystem.
+	escape := filepath.Join(parent, "escape")
+	loose := filepath.Join(escape, "secrets", "bot-token.txt")
+	writeSecretFile(t, loose, 0o644)
+
+	cfg := &config.City{Services: []config.Service{
+		{Name: "bridge", Kind: "proxy_process", StateRoot: "../escape"},
+	}}
+	assertSkippedOutOfCityRoot(t, cfg, cityPath, filepath.Join(escape, "secrets"), loose)
+}
+
+func TestServiceSecretsPermsCheckSkipsAncestorSymlinkEscape(t *testing.T) {
+	cityPath := t.TempDir()
+	// The configured secrets path is lexically inside the city, but an ancestor
+	// directory (`.gc/services`) is a symlink pointing outside the city. The
+	// final `secrets` component is a real directory, not itself a symlink, so a
+	// guard that only resolves the final component (os.Lstat on `secrets`) sees
+	// a plain dir and misses the escape — letting --fix chmod the out-of-city
+	// tree through the ancestor link. Resolving the full walk root catches it.
+	outside := t.TempDir()
+	loose := filepath.Join(outside, "bridge", "secrets", "bot-token.txt")
+	writeSecretFile(t, loose, 0o644)
+
+	servicesLink := filepath.Join(cityPath, ".gc", "services")
+	if err := os.MkdirAll(filepath.Dir(servicesLink), 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(servicesLink), err)
+	}
+	if err := os.Symlink(outside, servicesLink); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", servicesLink, outside, err)
+	}
+
+	// .gc/services -> outside, so .gc/services/bridge/secrets resolves to
+	// outside/bridge/secrets even though the configured path looks in-city.
+	cfg := &config.City{Services: []config.Service{
+		{Name: "bridge", Kind: "proxy_process", StateRoot: ".gc/services/bridge"},
+	}}
+	configured := filepath.Join(cityPath, ".gc", "services", "bridge", "secrets")
+	assertSkippedOutOfCityRoot(t, cfg, cityPath, configured, loose)
 }

--- a/internal/doctor/checks_service_secrets_test.go
+++ b/internal/doctor/checks_service_secrets_test.go
@@ -1,0 +1,127 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func writeSecretFile(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("secret\n"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	// WriteFile mode is umask-filtered; chmod to the exact fixture mode.
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}
+
+func serviceSecretsTestConfig() *config.City {
+	return &config.City{
+		Services: []config.Service{
+			{Name: "bridge", Kind: "proxy_process", StateRoot: ".gc/services/bridge"},
+			// Same state root as bridge: the shared dir must be checked once.
+			{Name: "bridge-admin", Kind: "proxy_process", StateRoot: ".gc/services/bridge"},
+			{Name: "intake", Kind: "proxy_process", StateRoot: ".gc/services/intake"},
+		},
+	}
+}
+
+func TestServiceSecretsPermsCheckOKWhenTight(t *testing.T) {
+	cityPath := t.TempDir()
+	writeSecretFile(t, filepath.Join(cityPath, ".gc", "services", "bridge", "secrets", "bot-token.txt"), 0o600)
+
+	check := NewServiceSecretsPermsCheck(serviceSecretsTestConfig(), cityPath)
+	r := check.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want OK (message %q)", r.Status, r.Message)
+	}
+}
+
+func TestServiceSecretsPermsCheckOKWhenNoSecretsDir(t *testing.T) {
+	cityPath := t.TempDir()
+	check := NewServiceSecretsPermsCheck(serviceSecretsTestConfig(), cityPath)
+	r := check.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want OK (message %q)", r.Status, r.Message)
+	}
+}
+
+func TestServiceSecretsPermsCheckFlagsLooseFilesAndDirs(t *testing.T) {
+	cityPath := t.TempDir()
+	loose := filepath.Join(cityPath, ".gc", "services", "bridge", "secrets", "bot-token.txt")
+	writeSecretFile(t, loose, 0o644)
+	nested := filepath.Join(cityPath, ".gc", "services", "intake", "secrets", "nested")
+	writeSecretFile(t, filepath.Join(nested, "key.pem"), 0o600)
+	if err := os.Chmod(nested, 0o750); err != nil {
+		t.Fatalf("chmod nested: %v", err)
+	}
+
+	check := NewServiceSecretsPermsCheck(serviceSecretsTestConfig(), cityPath)
+	r := check.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want Warning (message %q)", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want advisory", r.Severity)
+	}
+	joined := strings.Join(r.Details, "\n")
+	if !strings.Contains(joined, loose) {
+		t.Fatalf("details missing loose file %s:\n%s", loose, joined)
+	}
+	if !strings.Contains(joined, nested) {
+		t.Fatalf("details missing loose dir %s:\n%s", nested, joined)
+	}
+}
+
+func TestServiceSecretsPermsCheckFixTightensPerms(t *testing.T) {
+	cityPath := t.TempDir()
+	loose := filepath.Join(cityPath, ".gc", "services", "bridge", "secrets", "bot-token.txt")
+	writeSecretFile(t, loose, 0o644)
+	nested := filepath.Join(cityPath, ".gc", "services", "bridge", "secrets", "nested")
+	writeSecretFile(t, filepath.Join(nested, "key.pem"), 0o640)
+	if err := os.Chmod(nested, 0o755); err != nil {
+		t.Fatalf("chmod nested: %v", err)
+	}
+
+	check := NewServiceSecretsPermsCheck(serviceSecretsTestConfig(), cityPath)
+	if !check.CanFix() {
+		t.Fatal("CanFix = false, want true")
+	}
+	if r := check.Run(&CheckContext{CityPath: cityPath}); r.Status != StatusWarning {
+		t.Fatalf("pre-fix Status = %v, want Warning", r.Status)
+	}
+	if err := check.Fix(&CheckContext{CityPath: cityPath}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	for path, want := range map[string]os.FileMode{
+		loose:                            0o600,
+		filepath.Join(nested, "key.pem"): 0o600,
+		nested:                           0o700,
+	} {
+		st, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if st.Mode().Perm() != want {
+			t.Fatalf("%s mode = %o, want %o", path, st.Mode().Perm(), want)
+		}
+	}
+	if r := check.Run(&CheckContext{CityPath: cityPath}); r.Status != StatusOK {
+		t.Fatalf("post-fix Status = %v, want OK (message %q)", r.Status, r.Message)
+	}
+}
+
+func TestServiceSecretsPermsCheckNilConfig(t *testing.T) {
+	check := NewServiceSecretsPermsCheck(nil, t.TempDir())
+	if r := check.Run(&CheckContext{}); r.Status != StatusOK {
+		t.Fatalf("Status = %v, want OK", r.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Core scaffolds `<state_root>/secrets` at 0700 for every `proxy_process` service (`workspacesvc.ensureStateRoot`, re-chmodded on each start), but nothing checks the **files inside** — only pack discipline keeps them 0600 (e.g. the discord pack's `save_bot_token` writes 0600 atomically). A hand-copied token file or a sloppy writer can land 0644 and quietly widen a credential.

New `service-secrets-perms` doctor check:
- Walks each configured service's `secrets/` dir (deduplicated across services sharing a `state_root`, like the discord pack's three services)
- Warns on regular files **or directories** with group/other permission bits (a 0755 subdirectory undermines the 0700 root); includes the top dir since doctor can run against a stopped city
- **Advisory severity** — never gates dispatch/start
- `gc doctor --fix` tightens files to 0600, directories to 0700
- Symlinks skipped: target perms are what matter, and symlink policy belongs to the pack loaders (which reject them)

Purely mechanical check, no judgment calls (ZFC-clean).

## Test

TDD: 5 new tests in `internal/doctor/checks_service_secrets_test.go` (tight-perms OK, missing-dir OK, flags loose files+dirs with advisory severity, fix tightens and re-run goes green, nil-config OK). `doctor_check_names.golden` updated. `internal/doctor` + `cmd/gc` doctor tests green, `go vet` and `gofmt` clean.

Refs: ga-77i7n3. Companion: #3429 (`GC_SERVICE_SECRETS_DIR` env contract). Surfaced during the telegram provider pack secrets review (ga-aiefhz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)