### PR TITLE
fix(dolt): scope compact flatten verification to the surfaces the flatten actually touches

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -627,6 +627,29 @@ user_tables() {
   rm -f "$out_tmp" "$err_tmp"
 }
 
+# committed_tables — emit one table name per line for the tables present in
+# the committed root at <at_head>. Tables visible in information_schema but
+# absent from the committed root (dolt_ignore'd working-set-only tables such
+# as bd's wisp tier, or not-yet-committed new tables) cannot be staged or
+# touched by the flatten's soft-reset+commit, and churn freely under
+# concurrent writers — so flatten integrity verification must be scoped to
+# this set, not to all user tables.
+committed_tables() {
+  db="$1"
+  at_head="$2"
+  out_tmp=$(mktemp)
+  err_tmp=$(mktemp)
+  if ! dolt_query "$db" "SHOW TABLES AS OF '$at_head'" \
+    > "$out_tmp" 2>"$err_tmp"; then
+    printf 'compact: db=%s committed table list probe failed at head=%s\n' "$db" "$at_head" >&2
+    emit_error_file "$db" "$err_tmp"
+    rm -f "$out_tmp" "$err_tmp"
+    return 1
+  fi
+  awk 'NR>=4 && /^\|/ {gsub(/^\| | \|$/, ""); gsub(/ /, ""); if ($0 != "") print}' "$out_tmp"
+  rm -f "$out_tmp" "$err_tmp"
+}
+
 # row_count — COUNT(*) for one table. Returns "" on error.
 row_count() {
   db="$1"
@@ -644,8 +667,13 @@ table_value_hash() {
 
 db_value_hash() {
   db="$1"
+  # Pinned to the committed root: the bare working-set hash also covers
+  # dolt_ignore'd tables, whose concurrent churn drifts it with no HEAD
+  # movement — a guaranteed false quarantine on a busy db. The flatten only
+  # rewrites committed history, so the committed root is the surface whose
+  # preservation this hash must prove.
   query_single_cell "$db" "database value hash probe failed" \
-    "SELECT DOLT_HASHOF_DB()"
+    "SELECT DOLT_HASHOF_DB('HEAD')"
 }
 
 remote_count() {
@@ -749,14 +777,30 @@ push_remote_refspec() {
     sql -r tabular -q "CALL DOLT_PUSH('--force', '--set-upstream', '$remote', '$refspec_arg')"
 }
 
-# preflight_counts — write "<table> <count> <value-hash>" lines for all user tables.
+# preflight_counts — write "<table> <count> <value-hash>" lines for the user
+# tables present in the committed root at <at_head>. Tables outside that root
+# (dolt_ignore'd working-set-only tables, not-yet-committed new tables) are
+# excluded: the flatten's soft-reset+commit cannot stage or touch them, their
+# concurrent churn is indistinguishable from the gain+drift corruption signal,
+# and the Option A DOLT_DIFF preservation probe structurally fails on a table
+# that exists in no commit — a guaranteed false quarantine on a busy db
+# (observed on hq with bd's wisp tier). The excluded names are recorded in the
+# preflight_excluded_tables global so verify_counts can skip them in the
+# post-flatten table-list comparison symmetrically.
 preflight_counts() {
   db="$1"
   out="$2"
+  at_head="$3"
   tables_tmp=$(mktemp)
   : > "$out"
+  preflight_excluded_tables=""
   if ! user_tables "$db" > "$tables_tmp"; then
     rm -f "$tables_tmp"
+    return 1
+  fi
+  committed_tmp=$(mktemp)
+  if ! committed_tables "$db" "$at_head" > "$committed_tmp"; then
+    rm -f "$tables_tmp" "$committed_tmp"
     return 1
   fi
   preflight_failed=0
@@ -767,6 +811,10 @@ preflight_counts() {
         "$db" "$t" >&2
       preflight_failed=1
       break
+    fi
+    if ! grep -Fxq "$t" "$committed_tmp"; then
+      preflight_excluded_tables="$preflight_excluded_tables $t"
+      continue
     fi
     if ! cnt=$(row_count "$db" "$t"); then
       printf 'compact: db=%s pre-flight row count failed for table=%s\n' "$db" "$t" >&2
@@ -792,7 +840,11 @@ preflight_counts() {
     fi
     printf '%s %s %s\n' "$t" "$cnt" "$table_hash" >> "$out"
   done < "$tables_tmp"
-  rm -f "$tables_tmp"
+  rm -f "$tables_tmp" "$committed_tmp"
+  if [ "$preflight_failed" -eq 0 ] && [ -n "$preflight_excluded_tables" ]; then
+    printf 'compact: db=%s excluding unversioned table(s) from flatten verification (absent from committed root at %s):%s\n' \
+      "$db" "$at_head" "$preflight_excluded_tables"
+  fi
   return "$preflight_failed"
 }
 
@@ -926,6 +978,13 @@ verify_counts() {
   fi
   while IFS= read -r post_table; do
     [ -n "$post_table" ] || continue
+    # Tables excluded from preflight verification (absent from the committed
+    # root at the stable preflight HEAD) stay outside the flatten's blast
+    # radius; skip them here too or every dolt_ignore'd table would read as
+    # "appeared after pre-flight snapshot".
+    case " $preflight_excluded_tables " in
+      *" $post_table "*) continue ;;
+    esac
     if ! valid_table_name "$post_table"; then
       printf 'compact: db=%s invalid table name after flatten table=%s — quarantine and investigate before GC\n' \
         "$db" "$post_table" >&2
@@ -1813,7 +1872,7 @@ flatten_database() {
     fi
 
     : > "$preflight_tmp"
-    if ! preflight_counts "$db" "$preflight_tmp"; then
+    if ! preflight_counts "$db" "$preflight_tmp" "$head"; then
       rm -f "$preflight_tmp"
       return 1
     fi

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1014,6 +1014,43 @@ verify_counts() {
   return "$fail"
 }
 
+# db_root_drift_within_verified_tables — prove a committed-root drift benign.
+# Reached only after per-table verification has PASSED: every verified table's
+# working-set value matches the pre-flight snapshot. The flatten's -Am commits
+# the working set by design, so standing uncommitted changes on a tracked
+# table (e.g. a writer's cursor cell) move the committed root across the
+# flatten with no HEAD movement — indistinguishable from corruption by the
+# aggregate hash alone. DOLT_DIFF_STAT between the pre-flight head and the
+# flatten head names exactly which tables differ; if every one is in the
+# verified set, their current values are already proven equal to the
+# pre-flight snapshot and the drift is absorbed working-set state. Any table
+# outside the verified set (system tables such as dolt_schemas), an empty
+# diff, or a probe failure fails closed.
+db_root_drift_within_verified_tables() {
+  db="$1"
+  from="$2"
+  to="$3"
+  preflight_file="$4"
+  [ -n "$from" ] && [ -n "$to" ] || return 1
+  stat_tmp=$(mktemp)
+  if ! dolt_query "$db" \
+    "SELECT table_name FROM DOLT_DIFF_STAT('$from', '$to')" \
+    > "$stat_tmp" 2>/dev/null; then
+    rm -f "$stat_tmp"
+    return 1
+  fi
+  drift_tables=$(awk 'NR>=4 && /^\|/ {gsub(/^\| | \|$/, ""); gsub(/ /, ""); if ($0 != "") print}' "$stat_tmp")
+  rm -f "$stat_tmp"
+  [ -n "$drift_tables" ] || return 1
+  for drift_t in $drift_tables; do
+    if ! awk -v t="$drift_t" '$1 == t {found=1} END {exit !found}' "$preflight_file"; then
+      return 1
+    fi
+  done
+  db_root_drift_proven_tables="$drift_tables"
+  return 0
+}
+
 oldgen_has_files() {
   db="$1"
   oldgen_dir="$DOLT_DATA_DIR/$db/.dolt/noms/oldgen"
@@ -2182,6 +2219,24 @@ flatten_database() {
       rm -f "$preflight_tmp"
       return 1
     else
+      # Per-table verification passed, no row gain, no HEAD movement — the
+      # remaining benign explanation is standing uncommitted working-set
+      # state on a tracked table that the flatten's -Am committed (observed
+      # on a production hq: one dirty cursor cell in `config`). Prove it by
+      # confining the root diff to the verified table set; defer exactly as
+      # the proven writer-race paths do. Anything else stays quarantined.
+      if db_root_drift_within_verified_tables "$db" "$head" "$flatten_head" "$preflight_tmp"; then
+        printf 'compact: db=%s committed-root drift confined to verified table(s) [%s] via DOLT_DIFF_STAT(%s..%s) with per-table verification passed — absorbed working-set state committed by the flatten, not corruption; deferring, will retry next run\n' \
+          "$db" "${db_root_drift_proven_tables:-}" "$head" "$flatten_head" >&2
+        if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+          "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+          "$compacted_from_head" "$local_branch" "$remote_branch"; then
+          rm -f "$preflight_tmp"
+          return 1
+        fi
+        rm -f "$preflight_tmp"
+        return 0
+      fi
       printf 'compact: db=%s value hash changed without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
         "$db" "$preflight_hash" "$postflight_hash" >&2
       write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed without row-count increase" || {

--- a/examples/bd/dolt/compact_real_dolt_test.go
+++ b/examples/bd/dolt/compact_real_dolt_test.go
@@ -100,6 +100,9 @@ func runDoltForCompactTest(t *testing.T, doltPath, dir string, args ...string) s
 	defer cancel()
 	cmd := exec.CommandContext(ctx, doltPath, args...)
 	cmd.Dir = dir
+	// Newer dolt CLIs colorize `dolt log` output even without a TTY; ANSI
+	// escapes would corrupt hash parsing in doltHeadForCompactTest.
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("dolt %s failed in %s: %v\n%s", strings.Join(args, " "), dir, err, out)

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -627,7 +627,32 @@ case "$query" in
     print_cell rootcommit
     exit 0
     ;;
-  *"DOLT_HASHOF_DB()"*)
+  *"DOLT_HASHOF_DB"*)
+    if [ "$mode" = "ignored_table_db_hash_drift" ]; then
+      case "$query" in
+        *"DOLT_HASHOF_DB('HEAD')"*)
+          # Committed root: stable across the flatten (no versioned change).
+          print_cell "$(current_hash)"
+          ;;
+        *)
+          # Bare working-set hash: drifts between preflight and postflight
+          # because the ignored table churns, with no commit and no HEAD move.
+          calls_file="$state_file.bare-db-hash-calls"
+          calls=0
+          if [ -f "$calls_file" ]; then
+            calls="$(cat "$calls_file")"
+          fi
+          calls=$((calls + 1))
+          printf '%%s\n' "$calls" > "$calls_file"
+          if [ "$calls" -gt 1 ]; then
+            print_cell hash-workingset-drift
+          else
+            print_cell hash-workingset-base
+          fi
+          ;;
+      esac
+      exit 0
+    fi
     if [ "$mode" = "db_hash_failure" ]; then
       printf 'db hash exploded\n' >&2
       exit 48
@@ -684,7 +709,29 @@ case "$query" in
     print_cell hash-blocked-issues
     exit 0
     ;;
-  *"information_schema.tables"*)
+  *"DOLT_HASHOF_TABLE('wisps')"*)
+    if [ "$mode" = "ignored_table_drift" ] && [ "$(current_head)" = "compactcommit" ]; then
+      print_cell hash-wisps-after-churn
+      exit 0
+    fi
+    print_cell hash-wisps-before
+    exit 0
+    ;;
+  *"SHOW TABLES AS OF"*|*"information_schema.tables"*)
+    # ignored_table_* modes model the production hq incident: "wisps" is a
+    # dolt_ignore'd working-set-only table — visible in information_schema
+    # but absent from every commit root, so SHOW TABLES AS OF omits it.
+    if [ "$mode" = "ignored_table_drift" ] || [ "$mode" = "ignored_table_db_hash_drift" ]; then
+      case "$query" in
+        *"SHOW TABLES AS OF"*)
+          print_cell beads
+          ;;
+        *)
+          print_cells beads wisps
+          ;;
+      esac
+      exit 0
+    fi
     if [ "$mode" = "table_discovery_failure" ]; then
       printf 'information_schema unavailable\n' >&2
       exit 43
@@ -733,6 +780,14 @@ case "$query" in
     exit 0
     ;;
   *"SELECT COUNT(*) FROM"*"notes"*)
+    print_cell 10
+    exit 0
+    ;;
+  *"SELECT COUNT(*) FROM"*"wisps"*)
+    if [ "$mode" = "ignored_table_drift" ] && [ "$(current_head)" = "compactcommit" ]; then
+      print_cell 11
+      exit 0
+    fi
     print_cell 10
     exit 0
     ;;
@@ -2275,6 +2330,67 @@ func TestCompactScriptStillQuarantinesGainAndHashDriftWithStableHead(t *testing.
 	}
 	if strings.Contains(string(data), "DOLT_GC") {
 		t.Fatalf("stable-HEAD gain+drift must block full GC:\n%s", string(data))
+	}
+}
+
+// Production incident (hq, 2026-06-12): bd marks its high-churn wisp tables
+// dolt_ignore'd, so they live only in the working set and exist in no commit
+// root. The flatten (soft reset + commit) cannot stage or touch them, yet they
+// were included in flatten integrity verification: concurrent wisp churn read
+// as gain+drift with a stable HEAD, and the Option A DOLT_DIFF preservation
+// probe structurally fails on a table that exists in no commit ("table not
+// found") — fail-closed permanent quarantine, GC starvation. Unversioned
+// tables must be excluded from flatten integrity verification: the
+// verification set is the tables committed at the stable pre-flight HEAD.
+func TestCompactScriptExcludesUnversionedTableChurnFromVerification(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "ignored_table_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("unversioned-table churn must not fail compaction: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "excluding unversioned table(s) from flatten verification") ||
+		!strings.Contains(out, "wisps") {
+		t.Fatalf("output missing unversioned-table exclusion notice:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("unversioned-table churn must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read fake dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_HASHOF_TABLE('wisps')") {
+		t.Fatalf("unversioned table must not be count/hash-verified:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("compact must reach full GC after excluding unversioned churn:\n%s", string(data))
+	}
+}
+
+// Companion to the unversioned-table exclusion: the whole-database value hash
+// must be pinned to the committed root (DOLT_HASHOF_DB('HEAD')), not the bare
+// working-set hash, or dolt_ignore'd-table churn drifts the database hash with
+// no HEAD movement and quarantines via the same-count db-hash path.
+func TestCompactScriptPinsDatabaseHashToCommittedRoot(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "ignored_table_db_hash_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("working-set db hash drift must not fail compaction: %v\n%s", err, out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("working-set db hash drift must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read fake dolt log: %v", readErr)
+	}
+	if !strings.Contains(string(data), "DOLT_HASHOF_DB('HEAD')") {
+		t.Fatalf("database value hash must be pinned to the committed root:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("compact must reach full GC when the committed root is stable:\n%s", string(data))
 	}
 }
 

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -628,6 +628,17 @@ case "$query" in
     exit 0
     ;;
   *"DOLT_HASHOF_DB"*)
+    if [ "$mode" = "absorbed_ws_db_hash_drift" ] || [ "$mode" = "absorbed_ws_db_hash_drift_system_table" ]; then
+      # Standing uncommitted working-set state absorbed by the flatten's -Am:
+      # the committed root legitimately differs across the flatten while HEAD
+      # never moves and every per-table working-set hash stays stable.
+      if [ "$(current_head)" = "compactcommit" ]; then
+        print_cell hash-root-after-absorb
+      else
+        print_cell hash-root-before
+      fi
+      exit 0
+    fi
     if [ "$mode" = "ignored_table_db_hash_drift" ]; then
       case "$query" in
         *"DOLT_HASHOF_DB('HEAD')"*)
@@ -816,6 +827,18 @@ case "$query" in
       print_cell 10
     fi
     exit 0
+    ;;
+  *"DOLT_DIFF_STAT"*)
+    if [ "$mode" = "absorbed_ws_db_hash_drift" ]; then
+      print_cell beads
+      exit 0
+    fi
+    if [ "$mode" = "absorbed_ws_db_hash_drift_system_table" ]; then
+      print_cell dolt_schemas
+      exit 0
+    fi
+    printf 'unexpected DOLT_DIFF_STAT query: %%s\n' "$query" >&2
+    exit 64
     ;;
   *"DOLT_RESET"*)
     if [[ "$query" == *"--hard"* ]]; then
@@ -2391,6 +2414,68 @@ func TestCompactScriptPinsDatabaseHashToCommittedRoot(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "DOLT_GC") {
 		t.Fatalf("compact must reach full GC when the committed root is stable:\n%s", string(data))
+	}
+}
+
+// Production incident (hq, 2026-06-12, second mode): a bd writer left one
+// uncommitted cell in a tracked table's working set before the compact ran.
+// Per-table verification compares working-set values, so it passed; but the
+// flatten's -Am committed that standing state, so the committed root at the
+// flatten head differs from the pre-flight HEAD root with no HEAD movement —
+// the database-hash check quarantined a by-design absorption. When per-table
+// verification passed and DOLT_DIFF_STAT(pre-flight head, flatten head) is
+// confined to verified tables, the drift is proven to be absorbed working-set
+// state: defer and retry, exactly like the proven writer-race paths.
+func TestCompactScriptDefersAbsorbedWorkingSetDbHashDrift(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "absorbed_ws_db_hash_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("absorbed working-set drift must defer, not fail: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "absorbed working-set state") ||
+		!strings.Contains(out, "deferring, will retry next run") {
+		t.Fatalf("output missing absorbed working-set defer message:\n%s", out)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(quarantine); !os.IsNotExist(statErr) {
+		t.Fatalf("absorbed working-set drift must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if reason := compactMarkerValue(t, pendingGC, "reason"); reason != "writer race during flatten deferred full GC" {
+		t.Fatalf("absorbed working-set defer should record pending-GC retry marker, got reason %q", reason)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read fake dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("absorbed working-set defer must skip GC this run:\n%s", string(data))
+	}
+}
+
+// The absorbed-working-set proof must stay narrow: a committed-root drift that
+// touches anything OUTSIDE the verified table set (system tables such as
+// dolt_schemas, or a table the preflight never verified) is unexplained and
+// keeps the fail-closed quarantine.
+func TestCompactScriptStillQuarantinesDbHashDriftBeyondVerifiedTables(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "absorbed_ws_db_hash_drift_system_table", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("root drift beyond verified tables must remain a blocking failure:\n%s", out)
+	}
+	if !strings.Contains(out, "value hash changed without row-count increase") {
+		t.Fatalf("output missing same-count db hash drift quarantine notice:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten value hash changed without row-count increase" {
+		t.Fatalf("quarantine reason should identify db hash drift, got %q", reason)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read fake dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("unexplained db root drift must block full GC:\n%s", string(data))
 	}
 }
 


### PR DESCRIPTION
## Summary

`gc dolt compact` permanently quarantines any busy database whose bd store uses dolt_ignore'd tables — which is every bd city: bd marks its high-churn wisp tier (`wisps`, `wisp_%`) plus `local_metadata` / `repo_mtimes` / `ignored_schema_migrations` as ignored. On a production hq this produced back-to-back quarantine markers (Jun 5, Jun 12), GC starvation, and a store that grew 898 MB → 7.2 GB in 12 days with 13.9k commits unreclaimable. This is the same failure class #2846 fixed for HEAD-proven races, surviving through two different doors.

## Root cause

Two instances of one mistake: flatten integrity is verified against surfaces the flatten cannot touch.

1. **Per-table verification includes unversioned tables.** `preflight_counts` builds its table list from `information_schema.tables`, which includes dolt_ignore'd working-set-only tables. The flatten (`DOLT_RESET('--soft')` + `DOLT_COMMIT('-Am')`) cannot stage them, but they are the busiest tables in the db, so concurrent churn reads as gain+drift (or same-count drift) with a stable HEAD. The #2855 Option A probe then *structurally* fails: `DOLT_DIFF` over commits returns `table not found` for a table that exists in no commit — fail-closed → quarantine, every run. (Diagnostic signature: `SELECT ... FROM wisps AS OF '<any commit>'` → error 1146 while live SELECT works, `dolt_status` empty, table listed in `dolt_ignore`.)

2. **The database-level hash covers the working set.** Bare `DOLT_HASHOF_DB()` includes ignored tables (verified live: bare ≠ `DOLT_HASHOF_DB('HEAD')` on an idle hq), so the same churn drifts the aggregate hash with no HEAD movement and quarantines via the same-count db-hash path.

Dogfooding the fix surfaced a third, adjacent mode: a writer had left one uncommitted cell in tracked table `config`. Per-table checks compare working-set values (stable → pass), but the flatten's `-Am` committed that standing state, so the committed root moved with no HEAD fingerprint — and the db-hash check quarantined a by-design absorption.

## Fix

One principle: verify the flatten against the committed root, and treat working-set state as outside its blast radius.

* `preflight_counts` intersects user tables with `SHOW TABLES AS OF '<stable preflight HEAD>'` (new `committed_tables` helper). Excluded tables are logged once and skipped symmetrically in the post-flatten table-list comparison, so they neither false-positive as drift nor as "appeared after pre-flight snapshot".
* `db_value_hash` pins to `DOLT_HASHOF_DB('HEAD')`.
* When per-table verification has passed and the committed-root still drifted with no HEAD movement, a new `db_root_drift_within_verified_tables` proof runs `DOLT_DIFF_STAT(preflight head, flatten head)`: if every named table is in the verified set — whose current values are already proven equal to the pre-flight snapshot — the drift is absorbed working-set state, and the run defers with the existing pending-GC retry marker, exactly like the HEAD-proven writer-race paths. Drift touching anything outside the verified set (e.g. `dolt_schemas`), an empty diff, or a probe failure still fails closed into quarantine.

All other quarantine semantics are unchanged (row decrease, table-list change, probe failures, gain+drift with stable HEAD on versioned tables).

## Tests

* `TestCompactScriptExcludesUnversionedTableChurnFromVerification` — new `ignored_table_drift` fake mode reproduces the production gain+drift quarantine deterministically; failing before, green after.
* `TestCompactScriptPinsDatabaseHashToCommittedRoot` — `ignored_table_db_hash_drift` mode reproduces the working-set db-hash false positive.
* `TestCompactScriptDefersAbsorbedWorkingSetDbHashDrift` — the absorbed dirty-cell mode defers with the pending-GC marker and skips GC that run.
* `TestCompactScriptStillQuarantinesDbHashDriftBeyondVerifiedTables` — drift naming `dolt_schemas` keeps the fail-closed quarantine.
* Full `TestCompactScript*` suite and the `dolt_integration` real-dolt test pass; `go vet` clean. The real-dolt test needed `NO_COLOR=1` (newer dolt CLIs colorize `dolt log` without a TTY, corrupting hash parsing in the helper) — included here as a one-line test fix.

## Validation (production dogfood)

On the affected hq (live writers, wisps churning):

* exclusion fired: `excluding unversioned table(s) from flatten verification ... wisps wisp_child_counters ...`
* first run flattened 13,934 → 2 commits; second run completed the full pipeline: flatten → verify → `DOLT_GC('--full')` through intact gates, no quarantine
* store: **6.8 GB → 104 MB**; bd fully healthy afterwards (552 live rows, 0.2 MB/row)

## Related

* #2846 / #2855 — this completes the same GC-starvation arc for unversioned-table churn, which the Option A probe cannot handle by construction.
* #3266 (`--gc-only`) — the stranded-oldgen state below threshold is how this bug presents after a partial run; that reclaim path remains complementary (recovery here used `GC_DOLT_COMPACT_THRESHOLD_COMMITS=1` to route through the full gated pipeline).
* #2817 — adjacent defer semantics for ambiguous writer races.
* Observation for a possible follow-up issue: builtin-pack materialization treats `dolt` as non-required unless the exec lifecycle is in use, so a stale `.gc/system/packs/dolt` (including this compactor) persists across binary upgrades under operator-edit preservation (#2429) — the production city was still running a Jun-5-era compact script after upgrading gc to today's head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)