### PR TITLE
fix(api): accept agent-shaped targets on graph.v2 formula detail (dashboard M3 follow-up)

### DIFF
--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -2903,7 +2903,7 @@ export interface components {
             scope_kind?: string;
             /** @description Scope reference. */
             scope_ref?: string;
-            /** @description Target agent for preview compilation. */
+            /** @description Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value). */
             target: string;
             /** @description Variable name-to-value overrides applied to the compiled preview. */
             vars?: {
@@ -9649,7 +9649,7 @@ export interface operations {
                 scope_kind?: string;
                 /** @description Scope reference. */
                 scope_ref?: string;
-                /** @description Target agent for preview compilation. */
+                /** @description Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value). */
                 target: string;
             };
             header?: never;
@@ -9772,7 +9772,7 @@ export interface operations {
                 scope_kind?: string;
                 /** @description Scope reference. */
                 scope_ref?: string;
-                /** @description Target agent for preview compilation. */
+                /** @description Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value). */
                 target: string;
             };
             header?: never;

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -1155,7 +1155,7 @@ export type FormulaPreviewBody = {
      */
     scope_ref?: string;
     /**
-     * Target agent for preview compilation.
+     * Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).
      */
     target: string;
     /**
@@ -8265,7 +8265,7 @@ export type GetV0CityByCityNameFormulaByNameData = {
          */
         scope_ref?: string;
         /**
-         * Target agent for preview compilation.
+         * Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).
          */
         target: string;
     };
@@ -8394,7 +8394,7 @@ export type GetV0CityByCityNameFormulasByNameData = {
          */
         scope_ref?: string;
         /**
-         * Target agent for preview compilation.
+         * Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).
          */
         target: string;
     };

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2947,7 +2947,7 @@
             "type": "string"
           },
           "target": {
-            "description": "Target agent for preview compilation.",
+            "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
             "minLength": 1,
             "type": "string"
           },
@@ -19965,13 +19965,13 @@
             }
           },
           {
-            "description": "Target agent for preview compilation.",
+            "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
             "explode": false,
             "in": "query",
             "name": "target",
             "required": true,
             "schema": {
-              "description": "Target agent for preview compilation.",
+              "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
               "type": "string"
             }
           }
@@ -20214,13 +20214,13 @@
             }
           },
           {
-            "description": "Target agent for preview compilation.",
+            "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
             "explode": false,
             "in": "query",
             "name": "target",
             "required": true,
             "schema": {
-              "description": "Target agent for preview compilation.",
+              "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
               "type": "string"
             }
           }

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -2947,7 +2947,7 @@
             "type": "string"
           },
           "target": {
-            "description": "Target agent for preview compilation.",
+            "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
             "minLength": 1,
             "type": "string"
           },
@@ -19965,13 +19965,13 @@
             }
           },
           {
-            "description": "Target agent for preview compilation.",
+            "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
             "explode": false,
             "in": "query",
             "name": "target",
             "required": true,
             "schema": {
-              "description": "Target agent for preview compilation.",
+              "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
               "type": "string"
             }
           }
@@ -20214,13 +20214,13 @@
             }
           },
           {
-            "description": "Target agent for preview compilation.",
+            "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
             "explode": false,
             "in": "query",
             "name": "target",
             "required": true,
             "schema": {
-              "description": "Target agent for preview compilation.",
+              "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
               "type": "string"
             }
           }

--- a/internal/api/agent_resolution.go
+++ b/internal/api/agent_resolution.go
@@ -48,7 +48,16 @@ func findUniqueAgentTemplateByBareName(cfg *config.City, input string) (config.A
 	return config.Agent{}, false
 }
 
+// findAgentByQualifiedTemplate returns the configured agent whose identity
+// matches identity, if any. The nil-config guard backstops a concurrent config
+// swap-to-nil between an earlier availability check and this lookup (for
+// example formulaDetail returns a typed 503 via formulaSearchPaths before
+// resolving routing identities here), so the helper stays panic-safe even when
+// called independently of that ordering.
 func findAgentByQualifiedTemplate(cfg *config.City, identity string) (config.Agent, bool) {
+	if cfg == nil {
+		return config.Agent{}, false
+	}
 	for _, a := range cfg.Agents {
 		if config.AgentMatchesIdentity(&a, identity) {
 			return a, true

--- a/internal/api/agent_resolution_test.go
+++ b/internal/api/agent_resolution_test.go
@@ -55,3 +55,16 @@ func TestResolveSessionTemplateAgentRejectsAmbiguousBareName(t *testing.T) {
 		t.Fatal("expected ambiguous bare name to fail")
 	}
 }
+
+func TestFindAgentByQualifiedTemplateNilConfig(t *testing.T) {
+	// The endpoint 503 path short-circuits before this helper, so the nil
+	// guard is only reachable on a concurrent config swap-to-nil. Assert it
+	// directly: a nil config must return no match without dereferencing.
+	a, ok := findAgentByQualifiedTemplate(nil, "x")
+	if ok {
+		t.Fatal("expected nil config to yield no match")
+	}
+	if got := a.QualifiedName(); got != "" {
+		t.Fatalf("QualifiedName = %q, want empty zero-value agent", got)
+	}
+}

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -1357,7 +1357,7 @@ type FormulaPreviewBody struct {
 	// ScopeRef Scope reference.
 	ScopeRef *string `json:"scope_ref,omitempty"`
 
-	// Target Target agent for preview compilation.
+	// Target Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).
 	Target string `json:"target"`
 
 	// Vars Variable name-to-value overrides applied to the compiled preview.
@@ -5496,7 +5496,7 @@ type GetV0CityByCityNameFormulaByNameParams struct {
 	// ScopeRef Scope reference.
 	ScopeRef *string `form:"scope_ref,omitempty" json:"scope_ref,omitempty"`
 
-	// Target Target agent for preview compilation.
+	// Target Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).
 	Target string `form:"target" json:"target"`
 }
 
@@ -5529,7 +5529,7 @@ type GetV0CityByCityNameFormulasByNameParams struct {
 	// ScopeRef Scope reference.
 	ScopeRef *string `form:"scope_ref,omitempty" json:"scope_ref,omitempty"`
 
-	// Target Target agent for preview compilation.
+	// Target Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).
 	Target string `form:"target" json:"target"`
 }
 

--- a/internal/api/handler_formulas.go
+++ b/internal/api/handler_formulas.go
@@ -171,7 +171,7 @@ func buildFormulaRuns(state State, formulaName, requestedScopeKind, requestedSco
 	}, nil
 }
 
-func buildFormulaDetail(ctx context.Context, store beads.Store, name string, paths []string, target string, vars map[string]string, validateRuntimeVars bool) (*formulaDetailResponse, error) {
+func buildFormulaDetail(ctx context.Context, store beads.Store, name string, paths []string, target string, targetIsRoutingIdentity bool, vars map[string]string, validateRuntimeVars bool) (*formulaDetailResponse, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("%w: %q not in search paths", errFormulaNotFound, name)
 	}
@@ -180,7 +180,7 @@ func buildFormulaDetail(ctx context.Context, store beads.Store, name string, pat
 	if err != nil {
 		return nil, err
 	}
-	compileVars, err := formulaDetailPreviewVars(ctx, store, name, paths, resolved, target, vars, validateRuntimeVars)
+	compileVars, err := formulaDetailPreviewVars(ctx, store, name, paths, resolved, target, targetIsRoutingIdentity, vars, validateRuntimeVars)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func buildFormulaDetail(ctx context.Context, store beads.Store, name string, pat
 	return resp, nil
 }
 
-func formulaDetailPreviewVars(ctx context.Context, store beads.Store, name string, paths []string, resolved *formula.Formula, target string, vars map[string]string, validateRuntimeVars bool) (map[string]string, error) {
+func formulaDetailPreviewVars(ctx context.Context, store beads.Store, name string, paths []string, resolved *formula.Formula, target string, targetIsRoutingIdentity bool, vars map[string]string, validateRuntimeVars bool) (map[string]string, error) {
 	if resolved == nil || !formula.UsesGraphCompiler(resolved) {
 		return vars, nil
 	}
@@ -303,9 +303,14 @@ func formulaDetailPreviewVars(ctx context.Context, store beads.Store, name strin
 		if err := formula.ValidateGraphV2RecipeReservedSymbols(recipe, true); err != nil {
 			return nil, err
 		}
-		inputConvoyID, err := graphv2.PreviewInputConvoyID(store, target)
-		if err != nil {
-			return nil, err
+		var inputConvoyID string
+		if targetIsRoutingIdentity {
+			inputConvoyID = graphv2.PreviewInputConvoyIDForRoutingIdentity(target)
+		} else {
+			inputConvoyID, err = graphv2.PreviewInputConvoyID(store, target)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if out == nil {
 			out = make(map[string]string, 1)
@@ -313,7 +318,7 @@ func formulaDetailPreviewVars(ctx context.Context, store beads.Store, name strin
 		out[graphv2.ConvoyIDVar] = inputConvoyID
 		return out, nil
 	}
-	inv, err := graphv2.PreparePreviewInvocation(ctx, store, name, paths, target, vars)
+	inv, err := graphv2.PreparePreviewInvocation(ctx, store, name, paths, target, targetIsRoutingIdentity, vars)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -830,6 +830,125 @@ title = "Inspect"
 	}
 }
 
+// graphAgentTargetFormulaTOML is a graph.v2 formula that references the
+// input convoy, so the preview compilation requires a target.
+const graphAgentTargetFormulaTOML = `
+description = "Preview {{convoy_id}}"
+formula = "graph-agent-target"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "inspect"
+title = "Inspect {{convoy_id}}"
+`
+
+// Workflow roots persist the routed agent identity as gc.routed_to
+// (ga-eld2x / #2763); run-detail clients echo that identity back as the
+// preview target. A configured agent identity has no bead-store entry, so
+// the detail endpoint must resolve it against config instead of failing the
+// graph.v2 bead lookup (dashboard audit finding M3 follow-up).
+func TestFormulaDetailGraphV2AcceptsConfiguredAgentTarget(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "graph-agent-target", graphAgentTargetFormulaTOML)
+
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/formulas/graph-agent-target?scope_kind=city&scope_ref=test-city&target=myrig/worker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET detail status = %d, want 200 for configured agent target: %s", rec.Code, rec.Body.String())
+	}
+	var detail formulaDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("Decode(detail): %v", err)
+	}
+	want := "preview-input-convoy:myrig/worker"
+	if detail.Description != "Preview "+want {
+		t.Fatalf("description = %q, want routing-identity preview input convoy", detail.Description)
+	}
+	if len(detail.Steps) != 1 || detail.Steps[0].Title != "Inspect "+want {
+		t.Fatalf("steps = %+v, want routing-identity graph.v2 detail step", detail.Steps)
+	}
+	matches, err := state.cityBeadStore.List(beads.ListQuery{Type: "convoy"})
+	if err != nil {
+		t.Fatalf("List input convoys: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("preview persisted input convoys = %+v, want none", matches)
+	}
+}
+
+func TestFormulaPreviewGraphV2AcceptsConfiguredAgentTarget(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "graph-agent-target", graphAgentTargetFormulaTOML)
+
+	body := bytes.NewBufferString(`{"scope_kind":"city","scope_ref":"test-city","target":"myrig/worker"}`)
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodPost, cityURL(state, "/formulas/graph-agent-target/preview"), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "true")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST preview status = %d, want 200 for configured agent target: %s", rec.Code, rec.Body.String())
+	}
+	var detail formulaDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("Decode(detail): %v", err)
+	}
+	want := "preview-input-convoy:myrig/worker"
+	if detail.Description != "Preview "+want {
+		t.Fatalf("description = %q, want routing-identity preview input convoy", detail.Description)
+	}
+	if len(detail.Steps) != 1 || detail.Steps[0].Title != "Inspect "+want {
+		t.Fatalf("steps = %+v, want routing-identity graph.v2 preview step", detail.Steps)
+	}
+}
+
+// A target that is neither a bead nor a configured agent identity must keep
+// failing with the existing not-found error: routing-identity acceptance is
+// config-resolved, not a blanket fallback that would mask mistyped bead IDs.
+func TestFormulaDetailGraphV2UnknownTargetStillRejected(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "graph-agent-target", graphAgentTargetFormulaTOML)
+
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/formulas/graph-agent-target?scope_kind=city&scope_ref=test-city&target=ga-nope"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("GET detail status = %d, want 400 for unknown target: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("body = %s, want graph.v2 target not-found error", rec.Body.String())
+	}
+}
+
 func TestFormulaPreviewRejectsMissingRequiredVars(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formulatest"
 )
 
@@ -922,9 +923,84 @@ func TestFormulaPreviewGraphV2AcceptsConfiguredAgentTarget(t *testing.T) {
 	}
 }
 
+// The live failure that motivated routing-identity acceptance used a V2
+// binding-qualified identity (dir/binding.name) under rig scope, while the
+// fixture agent above exercises only the V1 dir/name fallback branch of
+// AgentMatchesIdentity. Pin the binding-qualified shape at endpoint level so
+// a change to the V2 matching branch cannot silently drop it.
+func TestFormulaDetailGraphV2AcceptsBindingQualifiedAgentTarget(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.cfg.Daemon.FormulaV2 = true
+	state.cfg.Agents = append(state.cfg.Agents, config.Agent{
+		Name:              "operator",
+		Dir:               "myrig",
+		BindingName:       "mypack",
+		Provider:          "test-agent",
+		MaxActiveSessions: intPtr(1),
+	})
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "graph-agent-target", graphAgentTargetFormulaTOML)
+
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/formulas/graph-agent-target?scope_kind=rig&scope_ref=myrig&target=myrig/mypack.operator"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET detail status = %d, want 200 for binding-qualified agent target: %s", rec.Code, rec.Body.String())
+	}
+	var detail formulaDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("Decode(detail): %v", err)
+	}
+	want := "preview-input-convoy:myrig/mypack.operator"
+	if detail.Description != "Preview "+want {
+		t.Fatalf("description = %q, want binding-qualified routing-identity preview input convoy", detail.Description)
+	}
+	if len(detail.Steps) != 1 || detail.Steps[0].Title != "Inspect "+want {
+		t.Fatalf("steps = %+v, want binding-qualified routing-identity graph.v2 detail step", detail.Steps)
+	}
+	matches, err := state.stores["myrig"].List(beads.ListQuery{Type: "convoy"})
+	if err != nil {
+		t.Fatalf("List input convoys: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("preview persisted input convoys = %+v, want none", matches)
+	}
+}
+
+// The routing-identity lookup must not run before the endpoint's existing
+// config-availability guard: with a nil city config the detail and preview
+// endpoints keep returning the typed 503 instead of panicking on a nil
+// config dereference.
+func TestFormulaDetailNilConfigReturns503(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.cfg = nil
+
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/formulas/graph-agent-target?scope_kind=city&scope_ref=test-city&target=myrig/worker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET detail status = %d, want 503 when config is unavailable: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "config is unavailable") {
+		t.Fatalf("body = %s, want config-unavailable error", rec.Body.String())
+	}
+}
+
 // A target that is neither a bead nor a configured agent identity must keep
 // failing with the existing not-found error: routing-identity acceptance is
 // config-resolved, not a blanket fallback that would mask mistyped bead IDs.
+// The error must also say that config-identity resolution was attempted, so
+// a stale or mistyped agent identity is not misread as a bead-store problem.
 func TestFormulaDetailGraphV2UnknownTargetStillRejected(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 
@@ -946,6 +1022,9 @@ func TestFormulaDetailGraphV2UnknownTargetStillRejected(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "not found") {
 		t.Fatalf("body = %s, want graph.v2 target not-found error", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "matches neither a bead/convoy nor a configured agent identity") {
+		t.Fatalf("body = %s, want agent-identity resolution context in not-found error", rec.Body.String())
 	}
 }
 

--- a/internal/api/huma_handlers_formulas.go
+++ b/internal/api/huma_handlers_formulas.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/gastownhall/gascity/internal/beads"
 )
 
 // FormulaListBody is the response body for GET /v0/formulas.
@@ -140,14 +141,6 @@ func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawSc
 	if target == "" {
 		return nil, huma.Error400BadRequest("target is required")
 	}
-	// Workflow roots persist the routed agent identity as gc.routed_to
-	// (ga-eld2x / #2763), and run-detail clients echo that identity back as
-	// the preview target. A configured agent identity has no bead-store
-	// entry, so resolve it against the city config and let the graph.v2
-	// preview substitute a synthetic input convoy instead of failing the
-	// bead lookup. Targets that match neither a bead nor a configured agent
-	// keep the existing not-found error.
-	_, targetIsRoutingIdentity := findAgentByQualifiedTemplate(s.state.Config(), target)
 
 	paths, status, msg := s.formulaSearchPaths(scopeKind, scopeRef)
 	if status != 200 {
@@ -160,6 +153,17 @@ func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawSc
 		return nil, huma.Error400BadRequest(msg)
 	}
 
+	// Workflow roots persist the routed agent identity as gc.routed_to
+	// (ga-eld2x / #2763), and run-detail clients echo that identity back as
+	// the preview target. A configured agent identity has no bead-store
+	// entry, so resolve it against the city config and let the graph.v2
+	// preview substitute a synthetic input convoy instead of failing the
+	// bead lookup. Targets that match neither a bead nor a configured agent
+	// keep the existing not-found error. Resolved only after
+	// formulaSearchPaths succeeds so the config-unavailable state keeps
+	// returning the typed 503 above.
+	_, targetIsRoutingIdentity := findAgentByQualifiedTemplate(s.state.Config(), target)
+
 	store := s.state.CityBeadStore()
 	if scopeKind == "rig" {
 		store = s.state.BeadStore(scopeRef)
@@ -169,7 +173,14 @@ func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawSc
 		if errors.Is(err, errFormulaNotWorkflow) || errors.Is(err, errFormulaNotFound) {
 			return nil, huma.Error404NotFound(err.Error())
 		}
-		return nil, huma.Error400BadRequest(err.Error())
+		errMsg := err.Error()
+		// A not-found target already failed the configured-agent identity
+		// match above, so say so: without this context a stale or mistyped
+		// agent identity reads as a bead-store problem.
+		if !targetIsRoutingIdentity && errors.Is(err, beads.ErrNotFound) {
+			errMsg += "; target matches neither a bead/convoy nor a configured agent identity"
+		}
+		return nil, huma.Error400BadRequest(errMsg)
 	}
 
 	return &struct {

--- a/internal/api/huma_handlers_formulas.go
+++ b/internal/api/huma_handlers_formulas.go
@@ -140,6 +140,14 @@ func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawSc
 	if target == "" {
 		return nil, huma.Error400BadRequest("target is required")
 	}
+	// Workflow roots persist the routed agent identity as gc.routed_to
+	// (ga-eld2x / #2763), and run-detail clients echo that identity back as
+	// the preview target. A configured agent identity has no bead-store
+	// entry, so resolve it against the city config and let the graph.v2
+	// preview substitute a synthetic input convoy instead of failing the
+	// bead lookup. Targets that match neither a bead nor a configured agent
+	// keep the existing not-found error.
+	_, targetIsRoutingIdentity := findAgentByQualifiedTemplate(s.state.Config(), target)
 
 	paths, status, msg := s.formulaSearchPaths(scopeKind, scopeRef)
 	if status != 200 {
@@ -156,7 +164,7 @@ func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawSc
 	if scopeKind == "rig" {
 		store = s.state.BeadStore(scopeRef)
 	}
-	detail, err := buildFormulaDetail(ctx, store, name, paths, target, vars, validateRuntimeVars)
+	detail, err := buildFormulaDetail(ctx, store, name, paths, target, targetIsRoutingIdentity, vars, validateRuntimeVars)
 	if err != nil {
 		if errors.Is(err, errFormulaNotWorkflow) || errors.Is(err, errFormulaNotFound) {
 			return nil, huma.Error404NotFound(err.Error())

--- a/internal/api/huma_types_formulas.go
+++ b/internal/api/huma_types_formulas.go
@@ -142,7 +142,7 @@ type FormulaDetailInput struct {
 	Name      string `path:"name" doc:"Formula name."`
 	ScopeKind string `query:"scope_kind" required:"false" doc:"Scope kind (city or rig)."`
 	ScopeRef  string `query:"scope_ref" required:"false" doc:"Scope reference."`
-	Target    string `query:"target" required:"true" doc:"Target agent for preview compilation."`
+	Target    string `query:"target" required:"true" doc:"Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value)."`
 }
 
 // Resolve rejects legacy `var.<name>=<value>` query parameters with a
@@ -172,7 +172,7 @@ func (i *FormulaDetailInput) Resolve(ctx huma.Context, _ *huma.PathBuffer) []err
 type FormulaPreviewBody struct {
 	ScopeKind string            `json:"scope_kind,omitempty" doc:"Scope kind (city or rig)."`
 	ScopeRef  string            `json:"scope_ref,omitempty" doc:"Scope reference."`
-	Target    string            `json:"target" minLength:"1" doc:"Target agent for preview compilation."`
+	Target    string            `json:"target" minLength:"1" doc:"Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value)."`
 	Vars      map[string]string `json:"vars,omitempty" doc:"Variable name-to-value overrides applied to the compiled preview."`
 }
 

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -2947,7 +2947,7 @@
             "type": "string"
           },
           "target": {
-            "description": "Target agent for preview compilation.",
+            "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
             "minLength": 1,
             "type": "string"
           },
@@ -19965,13 +19965,13 @@
             }
           },
           {
-            "description": "Target agent for preview compilation.",
+            "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
             "explode": false,
             "in": "query",
             "name": "target",
             "required": true,
             "schema": {
-              "description": "Target agent for preview compilation.",
+              "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
               "type": "string"
             }
           }
@@ -20214,13 +20214,13 @@
             }
           },
           {
-            "description": "Target agent for preview compilation.",
+            "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
             "explode": false,
             "in": "query",
             "name": "target",
             "required": true,
             "schema": {
-              "description": "Target agent for preview compilation.",
+              "description": "Preview target: a bead or convoy ID, or a configured agent identity (for example a workflow root's gc.routed_to value).",
               "type": "string"
             }
           }

--- a/internal/graphv2/invocation.go
+++ b/internal/graphv2/invocation.go
@@ -408,8 +408,12 @@ func CreateSingleItemInputConvoy(store beads.Store, target beads.Bead) (beads.Be
 }
 
 // PreparePreviewInvocation validates graph.v2 preview inputs without creating
-// input convoys or workflow roots.
-func PreparePreviewInvocation(ctx context.Context, store beads.Store, formulaName string, searchPaths []string, targetID string, userVars map[string]string) (Invocation, error) {
+// input convoys or workflow roots. targetIsRoutingIdentity marks targetID as
+// a configured agent identity (for example a workflow root's gc.routed_to
+// value) rather than a bead or convoy ID; routing identities have no
+// bead-store entry, so the preview substitutes a synthetic input convoy
+// instead of resolving the target through the store.
+func PreparePreviewInvocation(ctx context.Context, store beads.Store, formulaName string, searchPaths []string, targetID string, targetIsRoutingIdentity bool, userVars map[string]string) (Invocation, error) {
 	resolved, parser, err := loadFormulaWithParser(formulaName, searchPaths)
 	if err != nil {
 		return Invocation{}, fmt.Errorf("loading formula %q: %w", formulaName, err)
@@ -458,9 +462,14 @@ func PreparePreviewInvocation(ctx context.Context, store beads.Store, formulaNam
 	if err := formula.ValidateGraphV2RecipeReservedSymbols(recipe, true); err != nil {
 		return Invocation{}, err
 	}
-	inputConvoyID, err := PreviewInputConvoyID(store, targetID)
-	if err != nil {
-		return Invocation{}, err
+	var inputConvoyID string
+	if targetIsRoutingIdentity {
+		inputConvoyID = PreviewInputConvoyIDForRoutingIdentity(targetID)
+	} else {
+		inputConvoyID, err = PreviewInputConvoyID(store, targetID)
+		if err != nil {
+			return Invocation{}, err
+		}
 	}
 	inv.Targeted = true
 	inv.InputConvoy = inputConvoyID
@@ -517,6 +526,17 @@ func PreviewInputConvoyID(store beads.Store, targetID string) (string, error) {
 		return target.ID, nil
 	}
 	return previewInputConvoyPrefix + target.ID, nil
+}
+
+// PreviewInputConvoyIDForRoutingIdentity returns the synthetic read-only
+// input convoy ID a graph.v2 preview should use when the preview target is a
+// routing identity (a configured agent identity, for example a workflow
+// root's gc.routed_to value) rather than a bead or convoy ID. Routing
+// identities have no bead-store entry, so the preview substitutes the same
+// synthetic preview-input-convoy value a non-convoy bead target receives,
+// without a store lookup.
+func PreviewInputConvoyIDForRoutingIdentity(targetID string) string {
+	return previewInputConvoyPrefix + strings.TrimSpace(targetID)
 }
 
 // LockKey serializes process-local graph.v2 materialization for a deterministic

--- a/internal/graphv2/invocation_test.go
+++ b/internal/graphv2/invocation_test.go
@@ -501,7 +501,7 @@ title = "Inspect {{convoy_id}}"
 		t.Fatalf("Create target: %v", err)
 	}
 
-	inv, err := PreparePreviewInvocation(context.Background(), store, "work", []string{dir}, target.ID, nil)
+	inv, err := PreparePreviewInvocation(context.Background(), store, "work", []string{dir}, target.ID, false, nil)
 	if err != nil {
 		t.Fatalf("PreparePreviewInvocation: %v", err)
 	}
@@ -518,6 +518,51 @@ title = "Inspect {{convoy_id}}"
 	}
 	if len(matches) != 0 {
 		t.Fatalf("preview created input convoys = %+v, want none", matches)
+	}
+}
+
+func TestPreparePreviewInvocationRoutingIdentityTargetSkipsBeadLookup(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeFormula(t, dir, "work.formula.toml", `
+formula = "work"
+version = 1
+contract = "graph.v2"
+type = "workflow"
+
+[[steps]]
+id = "inspect"
+title = "Inspect {{convoy_id}}"
+`)
+	store := beads.NewMemStore()
+
+	// A routing identity (e.g. a workflow root's gc.routed_to value) has no
+	// bead-store entry; the preview must not fail the bead lookup.
+	inv, err := PreparePreviewInvocation(context.Background(), store, "work", []string{dir}, "myrig/worker", true, nil)
+	if err != nil {
+		t.Fatalf("PreparePreviewInvocation: %v", err)
+	}
+	want := previewInputConvoyPrefix + "myrig/worker"
+	if inv.InputConvoy != want {
+		t.Fatalf("preview invocation = %+v, want routing-identity preview input convoy %q", inv, want)
+	}
+	if got := inv.Vars[ConvoyIDVar]; got != want {
+		t.Fatalf("vars[%s] = %q, want %q", ConvoyIDVar, got, want)
+	}
+	matches, err := store.List(beads.ListQuery{Type: "convoy"})
+	if err != nil {
+		t.Fatalf("List convoys: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("preview created input convoys = %+v, want none", matches)
+	}
+}
+
+func TestPreviewInputConvoyIDForRoutingIdentity(t *testing.T) {
+	got := PreviewInputConvoyIDForRoutingIdentity("  myrig/worker  ")
+	want := previewInputConvoyPrefix + "myrig/worker"
+	if got != want {
+		t.Fatalf("PreviewInputConvoyIDForRoutingIdentity = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Bug

Follow-up to dashboard audit finding **M3** (flagged in gastownhall/gascity-dashboard#125): the dashboard run-detail page resolves a run's formula identity from root-bead metadata and fetches formula details from the supervisor's graph.v2 formulas endpoint, passing the run's target taken from `gc.routed_to` — an **agent-shaped** identity like `gascity/gc.run-operator`. The supervisor's `GET /v0/city/{cityName}/formulas/{name}` (and `POST .../formulas/{name}/preview`) resolved `target` exclusively through the bead store (`graphv2.PreviewInputConvoyID` → `store.Get`), so every agent-shaped target failed with `400 graph.v2 target ... not found` and the formula preview/order overlay degraded.

This bites every current root: since ga-eld2x / #2763 retired `gc.run_target` as a root wire field, workflow roots persist only `gc.routed_to` (27 of 32 live workflow roots at the time of the audit).

## Evidence (live supervisor, maintainer-city, run `ga-wisp-x0tank`)

```
GET .../formulas/mol-adopt-pr-v2?scope_kind=rig&scope_ref=gascity&target=gascity/gc.run-operator
→ 400 {"detail":"graph.v2 target gascity/gc.run-operator not found: getting bead \"gascity/gc.run-operator\": bead not found"}

GET .../formulas/mol-adopt-pr-v2?scope_kind=rig&scope_ref=gascity&target=ga-hvg0gb   (the run's input convoy)
→ 200
```

The run's root carries `gc.routed_to=gascity/gc.run-operator` and the expanded city config contains that exact agent identity (`name=run-operator`, binding `gc`, dir `gascity`), so the supervisor can recognize it.

## Fix

`(*Server).formulaDetail` now resolves the target against the city config via the existing `findAgentByQualifiedTemplate` helper before the bead lookup. A target that matches a configured agent identity is treated as a **routing identity**: the graph.v2 preview substitutes the synthetic `preview-input-convoy:<identity>` value (the same family a non-convoy bead target already receives) via a new `graphv2.PreviewInputConvoyIDForRoutingIdentity`, with no store lookup. `graphv2.PreparePreviewInvocation` gains a `targetIsRoutingIdentity` flag so the POST preview path behaves identically.

- **Config-driven, zero hardcoded roles** — no role names in Go; resolution goes through `config.AgentMatchesIdentity`.
- **Not a blanket fallback** — targets that match neither a bead nor a configured agent keep the existing not-found 400, so mistyped bead IDs are not silently masked.
- **Bead/convoy-target callers unchanged** — existing preview semantics for convoy and non-convoy bead targets are untouched (pinned by existing tests).
- `Target` doc strings on `FormulaDetailInput`/`FormulaPreviewBody` updated to describe both accepted shapes; OpenAPI spec, `docs/schema` mirrors, generated Go client, and dashboard TS types regenerated (description-only diffs).

## Tests

TDD — new tests written first and observed failing with the exact live error:

- `internal/api/handler_formulas_test.go`
  - `TestFormulaDetailGraphV2AcceptsConfiguredAgentTarget` (GET, input-convoy-referencing graph.v2 formula, agent target → 200, synthetic convoy substitution, no convoys persisted)
  - `TestFormulaPreviewGraphV2AcceptsConfiguredAgentTarget` (POST preview equivalent)
  - `TestFormulaDetailGraphV2UnknownTargetStillRejected` (unknown target still 400 "not found")
- `internal/graphv2/invocation_test.go`
  - `TestPreparePreviewInvocationRoutingIdentityTargetSkipsBeadLookup`
  - `TestPreviewInputConvoyIDForRoutingIdentity`

Gates: `go vet ./...` clean; `make test` (full `go test ./...` baseline) green; `go test ./internal/api/... ./internal/graphv2/... ./internal/formula/... ./internal/sling/...` green (includes `TestOpenAPISpecInSync`); `make dashboard-check` green with regenerated artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
