### PR TITLE
feat(extmsg): agent-name conversation bindings with delivery-time cold-wake (ga-3tgxcq)

### DIFF
--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -2348,6 +2348,7 @@ export interface components {
          */
         BindingStatus: "active" | "ended";
         BoundEventPayload: {
+            agent_name?: string;
             conversation_id: string;
             provider: string;
             session_id: string;
@@ -2758,14 +2759,16 @@ export interface components {
             provider: string;
         };
         ExtMsgBindInputBody: {
+            /** @description Configured agent identity to bind; its live session is resolved at delivery time, cold-waking one when none is live (mutually exclusive with session_id). */
+            agent_name?: string;
             /** @description Conversation to bind. */
             conversation?: components["schemas"]["ConversationRef"];
             /** @description Optional binding metadata. */
             metadata?: {
                 [key: string]: string;
             };
-            /** @description Session ID to bind. */
-            session_id: string;
+            /** @description Session ID to bind (mutually exclusive with agent_name). */
+            session_id?: string;
         };
         ExtMsgGroupEnsureInputBody: {
             /** @description Default handle for the group. */
@@ -2837,10 +2840,12 @@ export interface components {
             unbound: components["schemas"]["SessionBindingRecord"][] | null;
         };
         ExtMsgUnbindInputBody: {
-            /** @description Conversation to unbind (nil = all). */
+            /** @description Configured agent identity to unbind. */
+            agent_name?: string;
+            /** @description Conversation to unbind (nil = filter by session_id/agent_name). */
             conversation?: components["schemas"]["ConversationRef"];
             /** @description Session ID to unbind. */
-            session_id: string;
+            session_id?: string;
         };
         ExternalActor: {
             display_name: string;
@@ -3018,12 +3023,14 @@ export interface components {
             actor: string;
             conversation_id: string;
             provider: string;
+            target_agent?: string;
             target_session: string;
         };
         InboundResult: {
             Binding: components["schemas"]["SessionBindingRecord"];
             GroupRoute: components["schemas"]["GroupRouteDecision"];
             Message: components["schemas"]["ExternalInboundMessage"];
+            TargetAgentName: string;
             TargetSessionID: string;
             TranscriptEntry: components["schemas"]["ConversationTranscriptRecord"];
         };
@@ -3939,6 +3946,7 @@ export interface components {
             agents: components["schemas"]["AgentMapping"][] | null;
         };
         SessionBindingRecord: {
+            AgentName: string;
             /** Format: int64 */
             BindingGeneration: number;
             /** Format: date-time */

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -423,6 +423,7 @@ export type BeadsDiagnostic = {
 export type BindingStatus = 'active' | 'ended';
 
 export type BoundEventPayload = {
+    agent_name?: string;
     conversation_id: string;
     provider: string;
     session_id: string;
@@ -929,6 +930,10 @@ export type ExtMsgAdapterUnregisterInputBody = {
 
 export type ExtMsgBindInputBody = {
     /**
+     * Configured agent identity to bind; its live session is resolved at delivery time, cold-waking one when none is live (mutually exclusive with session_id).
+     */
+    agent_name?: string;
+    /**
      * Conversation to bind.
      */
     conversation?: ConversationRef;
@@ -939,9 +944,9 @@ export type ExtMsgBindInputBody = {
         [key: string]: string;
     };
     /**
-     * Session ID to bind.
+     * Session ID to bind (mutually exclusive with agent_name).
      */
-    session_id: string;
+    session_id?: string;
 };
 
 export type ExtMsgGroupEnsureInputBody = {
@@ -1067,13 +1072,17 @@ export type ExtMsgUnbindBody = {
 
 export type ExtMsgUnbindInputBody = {
     /**
-     * Conversation to unbind (nil = all).
+     * Configured agent identity to unbind.
+     */
+    agent_name?: string;
+    /**
+     * Conversation to unbind (nil = filter by session_id/agent_name).
      */
     conversation?: ConversationRef;
     /**
      * Session ID to unbind.
      */
-    session_id: string;
+    session_id?: string;
 };
 
 export type ExternalActor = {
@@ -1287,6 +1296,7 @@ export type InboundEventPayload = {
     actor: string;
     conversation_id: string;
     provider: string;
+    target_agent?: string;
     target_session: string;
 };
 
@@ -1294,6 +1304,7 @@ export type InboundResult = {
     Binding: SessionBindingRecord;
     GroupRoute: GroupRouteDecision;
     Message: ExternalInboundMessage;
+    TargetAgentName: string;
     TargetSessionID: string;
     TranscriptEntry: ConversationTranscriptRecord;
 };
@@ -2547,6 +2558,7 @@ export type SessionAgentListResponse = {
 };
 
 export type SessionBindingRecord = {
+    AgentName: string;
     BindingGeneration: number;
     BoundAt: string;
     Conversation: ConversationRef;

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -1214,6 +1214,9 @@
       "BoundEventPayload": {
         "additionalProperties": false,
         "properties": {
+          "agent_name": {
+            "type": "string"
+          },
           "conversation_id": {
             "type": "string"
           },
@@ -2504,6 +2507,10 @@
       "ExtMsgBindInputBody": {
         "additionalProperties": false,
         "properties": {
+          "agent_name": {
+            "description": "Configured agent identity to bind; its live session is resolved at delivery time, cold-waking one when none is live (mutually exclusive with session_id).",
+            "type": "string"
+          },
           "conversation": {
             "$ref": "#/components/schemas/ConversationRef",
             "description": "Conversation to bind."
@@ -2516,14 +2523,10 @@
             "type": "object"
           },
           "session_id": {
-            "description": "Session ID to bind.",
-            "minLength": 1,
+            "description": "Session ID to bind (mutually exclusive with agent_name).",
             "type": "string"
           }
         },
-        "required": [
-          "session_id"
-        ],
         "type": "object"
       },
       "ExtMsgGroupEnsureInputBody": {
@@ -2706,19 +2709,19 @@
       "ExtMsgUnbindInputBody": {
         "additionalProperties": false,
         "properties": {
+          "agent_name": {
+            "description": "Configured agent identity to unbind.",
+            "type": "string"
+          },
           "conversation": {
             "$ref": "#/components/schemas/ConversationRef",
-            "description": "Conversation to unbind (nil = all)."
+            "description": "Conversation to unbind (nil = filter by session_id/agent_name)."
           },
           "session_id": {
             "description": "Session ID to unbind.",
-            "minLength": 1,
             "type": "string"
           }
         },
-        "required": [
-          "session_id"
-        ],
         "type": "object"
       },
       "ExternalActor": {
@@ -3378,6 +3381,9 @@
           "provider": {
             "type": "string"
           },
+          "target_agent": {
+            "type": "string"
+          },
           "target_session": {
             "type": "string"
           }
@@ -3402,6 +3408,9 @@
           "Message": {
             "$ref": "#/components/schemas/ExternalInboundMessage"
           },
+          "TargetAgentName": {
+            "type": "string"
+          },
           "TargetSessionID": {
             "type": "string"
           },
@@ -3414,7 +3423,8 @@
           "Binding",
           "GroupRoute",
           "TranscriptEntry",
-          "TargetSessionID"
+          "TargetSessionID",
+          "TargetAgentName"
         ],
         "type": "object"
       },
@@ -6240,6 +6250,9 @@
       "SessionBindingRecord": {
         "additionalProperties": false,
         "properties": {
+          "AgentName": {
+            "type": "string"
+          },
           "BindingGeneration": {
             "format": "int64",
             "type": "integer"
@@ -6287,6 +6300,7 @@
           "Conversation",
           "SessionID",
           "SessionName",
+          "AgentName",
           "Status",
           "BoundAt",
           "ExpiresAt",

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -1214,6 +1214,9 @@
       "BoundEventPayload": {
         "additionalProperties": false,
         "properties": {
+          "agent_name": {
+            "type": "string"
+          },
           "conversation_id": {
             "type": "string"
           },
@@ -2504,6 +2507,10 @@
       "ExtMsgBindInputBody": {
         "additionalProperties": false,
         "properties": {
+          "agent_name": {
+            "description": "Configured agent identity to bind; its live session is resolved at delivery time, cold-waking one when none is live (mutually exclusive with session_id).",
+            "type": "string"
+          },
           "conversation": {
             "$ref": "#/components/schemas/ConversationRef",
             "description": "Conversation to bind."
@@ -2516,14 +2523,10 @@
             "type": "object"
           },
           "session_id": {
-            "description": "Session ID to bind.",
-            "minLength": 1,
+            "description": "Session ID to bind (mutually exclusive with agent_name).",
             "type": "string"
           }
         },
-        "required": [
-          "session_id"
-        ],
         "type": "object"
       },
       "ExtMsgGroupEnsureInputBody": {
@@ -2706,19 +2709,19 @@
       "ExtMsgUnbindInputBody": {
         "additionalProperties": false,
         "properties": {
+          "agent_name": {
+            "description": "Configured agent identity to unbind.",
+            "type": "string"
+          },
           "conversation": {
             "$ref": "#/components/schemas/ConversationRef",
-            "description": "Conversation to unbind (nil = all)."
+            "description": "Conversation to unbind (nil = filter by session_id/agent_name)."
           },
           "session_id": {
             "description": "Session ID to unbind.",
-            "minLength": 1,
             "type": "string"
           }
         },
-        "required": [
-          "session_id"
-        ],
         "type": "object"
       },
       "ExternalActor": {
@@ -3378,6 +3381,9 @@
           "provider": {
             "type": "string"
           },
+          "target_agent": {
+            "type": "string"
+          },
           "target_session": {
             "type": "string"
           }
@@ -3402,6 +3408,9 @@
           "Message": {
             "$ref": "#/components/schemas/ExternalInboundMessage"
           },
+          "TargetAgentName": {
+            "type": "string"
+          },
           "TargetSessionID": {
             "type": "string"
           },
@@ -3414,7 +3423,8 @@
           "Binding",
           "GroupRoute",
           "TranscriptEntry",
-          "TargetSessionID"
+          "TargetSessionID",
+          "TargetAgentName"
         ],
         "type": "object"
       },
@@ -6240,6 +6250,9 @@
       "SessionBindingRecord": {
         "additionalProperties": false,
         "properties": {
+          "AgentName": {
+            "type": "string"
+          },
           "BindingGeneration": {
             "format": "int64",
             "type": "integer"
@@ -6287,6 +6300,7 @@
           "Conversation",
           "SessionID",
           "SessionName",
+          "AgentName",
           "Status",
           "BoundAt",
           "ExpiresAt",

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -730,9 +730,10 @@ type BindingStatus string
 
 // BoundEventPayload defines model for BoundEventPayload.
 type BoundEventPayload struct {
-	ConversationId string `json:"conversation_id"`
-	Provider       string `json:"provider"`
-	SessionId      string `json:"session_id"`
+	AgentName      *string `json:"agent_name,omitempty"`
+	ConversationId string  `json:"conversation_id"`
+	Provider       string  `json:"provider"`
+	SessionId      string  `json:"session_id"`
 }
 
 // CityCreateRequest defines model for CityCreateRequest.
@@ -1177,13 +1178,15 @@ type ExtMsgAdapterUnregisterInputBody struct {
 
 // ExtMsgBindInputBody defines model for ExtMsgBindInputBody.
 type ExtMsgBindInputBody struct {
+	// AgentName Configured agent identity to bind; its live session is resolved at delivery time, cold-waking one when none is live (mutually exclusive with session_id).
+	AgentName    *string          `json:"agent_name,omitempty"`
 	Conversation *ConversationRef `json:"conversation,omitempty"`
 
 	// Metadata Optional binding metadata.
 	Metadata *map[string]string `json:"metadata,omitempty"`
 
-	// SessionId Session ID to bind.
-	SessionId string `json:"session_id"`
+	// SessionId Session ID to bind (mutually exclusive with agent_name).
+	SessionId *string `json:"session_id,omitempty"`
 }
 
 // ExtMsgGroupEnsureInputBody defines model for ExtMsgGroupEnsureInputBody.
@@ -1275,10 +1278,12 @@ type ExtMsgUnbindBody struct {
 
 // ExtMsgUnbindInputBody defines model for ExtMsgUnbindInputBody.
 type ExtMsgUnbindInputBody struct {
+	// AgentName Configured agent identity to unbind.
+	AgentName    *string          `json:"agent_name,omitempty"`
 	Conversation *ConversationRef `json:"conversation,omitempty"`
 
 	// SessionId Session ID to unbind.
-	SessionId string `json:"session_id"`
+	SessionId *string `json:"session_id,omitempty"`
 }
 
 // ExternalActor defines model for ExternalActor.
@@ -1488,10 +1493,11 @@ type HeartbeatEvent struct {
 
 // InboundEventPayload defines model for InboundEventPayload.
 type InboundEventPayload struct {
-	Actor          string `json:"actor"`
-	ConversationId string `json:"conversation_id"`
-	Provider       string `json:"provider"`
-	TargetSession  string `json:"target_session"`
+	Actor          string  `json:"actor"`
+	ConversationId string  `json:"conversation_id"`
+	Provider       string  `json:"provider"`
+	TargetAgent    *string `json:"target_agent,omitempty"`
+	TargetSession  string  `json:"target_session"`
 }
 
 // InboundResult defines model for InboundResult.
@@ -1499,6 +1505,7 @@ type InboundResult struct {
 	Binding         SessionBindingRecord         `json:"Binding"`
 	GroupRoute      GroupRouteDecision           `json:"GroupRoute"`
 	Message         ExternalInboundMessage       `json:"Message"`
+	TargetAgentName string                       `json:"TargetAgentName"`
 	TargetSessionID string                       `json:"TargetSessionID"`
 	TranscriptEntry ConversationTranscriptRecord `json:"TranscriptEntry"`
 }
@@ -2566,6 +2573,7 @@ type SessionAgentListResponse struct {
 
 // SessionBindingRecord defines model for SessionBindingRecord.
 type SessionBindingRecord struct {
+	AgentName         string            `json:"AgentName"`
 	BindingGeneration int64             `json:"BindingGeneration"`
 	BoundAt           time.Time         `json:"BoundAt"`
 	Conversation      ConversationRef   `json:"Conversation"`

--- a/internal/api/handler_extmsg.go
+++ b/internal/api/handler_extmsg.go
@@ -41,6 +41,21 @@ func (s *Server) extmsgEmitEvent() func(string, string, events.Payload) {
 	}
 }
 
+// extmsgResolveSessionSelector builds the OutboundDeps session-selector
+// resolver: it maps a selector — a configured agent identity, session name,
+// alias, or concrete session bead ID — to the concrete ID of a live session,
+// without materializing one. HandleOutbound uses it to authorize publishes on
+// agent-bound conversations.
+func (s *Server) extmsgResolveSessionSelector() func(ctx context.Context, selector string) (string, error) {
+	store := s.state.CityBeadStore()
+	if store == nil {
+		return nil
+	}
+	return func(ctx context.Context, selector string) (string, error) {
+		return s.resolveSessionTargetIDWithContext(ctx, store, selector, apiSessionResolveOptions{})
+	}
+}
+
 func extmsgHandleLabel(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {

--- a/internal/api/handler_extmsg_agent_binding_test.go
+++ b/internal/api/handler_extmsg_agent_binding_test.go
@@ -1,0 +1,202 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/extmsg"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+func newExtMsgAgentBindingFixture(t *testing.T) (*fakeState, *Server, *extmsg.Services, extmsg.ConversationRef) {
+	t.Helper()
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	services := extmsg.NewServices(fs.cityBeadStore)
+	fs.extmsgSvc = &services
+	registry := extmsg.NewAdapterRegistry()
+	registry.Register(extmsg.AdapterKey{Provider: "discord", AccountID: "acct-1"}, &testExtMsgAdapter{})
+	fs.adapterReg = registry
+	ref := extmsg.ConversationRef{
+		ScopeID:        "guild-1",
+		Provider:       "discord",
+		AccountID:      "acct-1",
+		ConversationID: "thread-agent",
+		Kind:           extmsg.ConversationThread,
+	}
+	return fs, srv, &services, ref
+}
+
+func conversationBody(ref extmsg.ConversationRef) map[string]any {
+	return map[string]any{
+		"scope_id":        ref.ScopeID,
+		"provider":        ref.Provider,
+		"account_id":      ref.AccountID,
+		"conversation_id": ref.ConversationID,
+		"kind":            ref.Kind,
+	}
+}
+
+func postExtMsg(t *testing.T, fs *fakeState, srv *Server, path string, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal(body): %v", err)
+	}
+	req := newPostRequest(cityURL(fs, path), strings.NewReader(string(raw)))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandleExtMsgBindAgentNamePersistsConfiguredIdentity(t *testing.T) {
+	fs, srv, services, ref := newExtMsgAgentBindingFixture(t)
+
+	rec := postExtMsg(t, fs, srv, "/extmsg/bind", map[string]any{
+		"agent_name":   "myrig/worker",
+		"conversation": conversationBody(ref),
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	binding, err := services.Bindings.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if binding == nil || binding.AgentName != "myrig/worker" || binding.SessionID != "" {
+		t.Fatalf("binding = %#v, want agent binding myrig/worker", binding)
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	members, err := services.Transcript.ListMemberships(context.Background(), caller, ref)
+	if err != nil {
+		t.Fatalf("ListMemberships: %v", err)
+	}
+	if len(members) != 1 || members[0].SessionID != "myrig/worker" {
+		t.Fatalf("memberships = %#v, want one keyed myrig/worker", members)
+	}
+}
+
+func TestHandleExtMsgBindRejectsAmbiguousOrMissingTarget(t *testing.T) {
+	fs, srv, _, ref := newExtMsgAgentBindingFixture(t)
+
+	rec := postExtMsg(t, fs, srv, "/extmsg/bind", map[string]any{
+		"conversation": conversationBody(ref),
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status(neither) = %d, want %d; body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	rec = postExtMsg(t, fs, srv, "/extmsg/bind", map[string]any{
+		"session_id":   "sess-1",
+		"agent_name":   "myrig/worker",
+		"conversation": conversationBody(ref),
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status(both) = %d, want %d; body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestHandleExtMsgBindRejectsUnknownAgentName(t *testing.T) {
+	fs, srv, _, ref := newExtMsgAgentBindingFixture(t)
+
+	rec := postExtMsg(t, fs, srv, "/extmsg/bind", map[string]any{
+		"agent_name":   "myrig/ghost",
+		"conversation": conversationBody(ref),
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestHandleExtMsgInboundAgentBoundColdWakesNamedSession(t *testing.T) {
+	fs, srv, services, ref := newExtMsgAgentBindingFixture(t)
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	if _, err := services.Bindings.Bind(context.Background(), caller, extmsg.BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/worker",
+		Now:          time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+	if _, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil {
+		t.Fatal("named agent should not have a session before the inbound message")
+	}
+
+	rec := postExtMsg(t, fs, srv, "/extmsg/inbound", map[string]any{
+		"message": map[string]any{
+			"provider_message_id": "msg-1",
+			"conversation":        conversationBody(ref),
+			"actor":               map[string]any{"id": "user-1", "display_name": "User One", "is_bot": false},
+			"text":                "anyone there?",
+			"received_at":         time.Now().UTC().Format(time.RFC3339),
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var result extmsg.InboundResult
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode inbound result: %v", err)
+	}
+	if result.TargetAgentName != "myrig/worker" {
+		t.Fatalf("TargetAgentName = %q, want myrig/worker", result.TargetAgentName)
+	}
+
+	// The notify fan-out materializes the bound agent's named session —
+	// the cold-wake. It runs in a background goroutine, so poll briefly.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if id, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil && id != "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for agent-bound inbound to cold-wake myrig/worker")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestHandleExtMsgOutboundAgentBoundAuthorizesResolvedAgentSession(t *testing.T) {
+	fs, srv, services, ref := newExtMsgAgentBindingFixture(t)
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	if _, err := services.Bindings.Bind(context.Background(), caller, extmsg.BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/worker",
+		Now:          time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+
+	agentSessionID, err := srv.resolveSessionIDMaterializingNamed(fs.cityBeadStore, "myrig/worker")
+	if err != nil {
+		t.Fatalf("materialize myrig/worker: %v", err)
+	}
+	imposter := createTestSession(t, fs.cityBeadStore, fs.sp, "Imposter")
+
+	rec := postExtMsg(t, fs, srv, "/extmsg/outbound", map[string]any{
+		"session_id":   imposter.ID,
+		"conversation": conversationBody(ref),
+		"text":         "not my conversation",
+	})
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status(imposter) = %d, want %d; body: %s", rec.Code, http.StatusUnprocessableEntity, rec.Body.String())
+	}
+
+	rec = postExtMsg(t, fs, srv, "/extmsg/outbound", map[string]any{
+		"session_id":   agentSessionID,
+		"conversation": conversationBody(ref),
+		"text":         "reply from the bound agent",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status(agent) = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -3,7 +3,9 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -104,9 +106,10 @@ func (s *Server) humaHandleExtMsgOutbound(ctx context.Context, input *ExtMsgOutb
 
 	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
 	deps := extmsg.OutboundDeps{
-		Services:  *svc,
-		Registry:  reg,
-		EmitEvent: s.extmsgEmitEvent(),
+		Services:               *svc,
+		Registry:               reg,
+		EmitEvent:              s.extmsgEmitEvent(),
+		ResolveSessionSelector: s.extmsgResolveSessionSelector(),
 	}
 
 	result, err := extmsg.HandleOutbound(ctx, deps, caller, extmsg.OutboundRequest{
@@ -167,10 +170,37 @@ func (s *Server) humaHandleExtMsgBind(ctx context.Context, input *ExtMsgBindInpu
 		return nil, err
 	}
 
+	// Exactly one of session_id and agent_name — conditional requiredness
+	// the schema can't express, enforced here (see ExtMsgInboundInput).
+	sessionID := strings.TrimSpace(input.Body.SessionID)
+	agentName := strings.TrimSpace(input.Body.AgentName)
+	switch {
+	case sessionID == "" && agentName == "":
+		return nil, huma.Error400BadRequest("session_id or agent_name is required")
+	case sessionID != "" && agentName != "":
+		return nil, huma.Error400BadRequest("session_id and agent_name are mutually exclusive")
+	}
+	if agentName != "" {
+		// Agent bindings are resolved at delivery time, so the name must
+		// map to a configured named-session identity — the only identity
+		// the delivery layer can cold-wake a session for. Persist the
+		// configured identity so the binding stays unambiguous even when
+		// a later config change makes the bare name ambiguous.
+		spec, ok, err := s.findNamedSessionSpecForTarget(s.state.CityBeadStore(), agentName)
+		if err != nil {
+			return nil, huma.Error400BadRequest(fmt.Sprintf("resolving agent %q: %s", agentName, err))
+		}
+		if !ok {
+			return nil, huma.Error400BadRequest(fmt.Sprintf("agent %q does not resolve to a configured named session; agent bindings require a named-session-backed agent", agentName))
+		}
+		agentName = spec.Identity
+	}
+
 	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
 	binding, err := svc.Bindings.Bind(ctx, caller, extmsg.BindInput{
 		Conversation: input.Body.Conversation,
-		SessionID:    input.Body.SessionID,
+		SessionID:    sessionID,
+		AgentName:    agentName,
 		Metadata:     input.Body.Metadata,
 		Now:          time.Now(),
 	})
@@ -185,10 +215,15 @@ func (s *Server) humaHandleExtMsgBind(ctx context.Context, input *ExtMsgBindInpu
 		}
 	}
 
-	s.extmsgEmitEvent()(events.ExtMsgBound, input.Body.SessionID, extmsg.BoundEventPayload{
+	subject := sessionID
+	if subject == "" {
+		subject = agentName
+	}
+	s.extmsgEmitEvent()(events.ExtMsgBound, subject, extmsg.BoundEventPayload{
 		Provider:       input.Body.Conversation.Provider,
 		ConversationID: input.Body.Conversation.ConversationID,
-		SessionID:      input.Body.SessionID,
+		SessionID:      sessionID,
+		AgentName:      agentName,
 	})
 	out := &ExtMsgBindOutput{}
 	out.Body = binding
@@ -202,18 +237,29 @@ func (s *Server) humaHandleExtMsgUnbind(ctx context.Context, input *ExtMsgUnbind
 		return nil, err
 	}
 
+	sessionID := strings.TrimSpace(input.Body.SessionID)
+	agentName := strings.TrimSpace(input.Body.AgentName)
+	if input.Body.Conversation == nil && sessionID == "" && agentName == "" {
+		return nil, huma.Error400BadRequest("conversation, session_id, or agent_name is required")
+	}
+
 	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
 	unbound, err := svc.Bindings.Unbind(ctx, caller, extmsg.UnbindInput{
 		Conversation: input.Body.Conversation,
-		SessionID:    input.Body.SessionID,
+		SessionID:    sessionID,
+		AgentName:    agentName,
 		Now:          time.Now(),
 	})
 	if err != nil {
 		return nil, huma.Error422UnprocessableEntity(err.Error())
 	}
 
-	s.extmsgEmitEvent()(events.ExtMsgUnbound, input.Body.SessionID, extmsg.UnboundEventPayload{
-		SessionID: input.Body.SessionID,
+	subject := sessionID
+	if subject == "" {
+		subject = agentName
+	}
+	s.extmsgEmitEvent()(events.ExtMsgUnbound, subject, extmsg.UnboundEventPayload{
+		SessionID: sessionID,
 		Count:     len(unbound),
 	})
 	out := &ExtMsgUnbindOutput{}

--- a/internal/api/huma_types_extmsg.go
+++ b/internal/api/huma_types_extmsg.go
@@ -56,11 +56,16 @@ type ExtMsgBindingListInput struct {
 }
 
 // ExtMsgBindInput is the Huma input for POST /v0/city/{cityName}/extmsg/bind.
+//
+// Exactly one of SessionID and AgentName must be set. The schema cannot
+// express required-exactly-one-of-siblings, so both stay optional here and
+// the handler enforces the rule (same pattern as ExtMsgInboundInput).
 type ExtMsgBindInput struct {
 	CityScope
 	Body struct {
 		Conversation extmsg.ConversationRef `json:"conversation,omitempty" doc:"Conversation to bind."`
-		SessionID    string                 `json:"session_id" minLength:"1" doc:"Session ID to bind."`
+		SessionID    string                 `json:"session_id,omitempty" doc:"Session ID to bind (mutually exclusive with agent_name)."`
+		AgentName    string                 `json:"agent_name,omitempty" doc:"Configured agent identity to bind; its live session is resolved at delivery time, cold-waking one when none is live (mutually exclusive with session_id)."`
 		Metadata     map[string]string      `json:"metadata,omitempty" doc:"Optional binding metadata."`
 	}
 }
@@ -71,11 +76,15 @@ type ExtMsgBindOutput struct {
 }
 
 // ExtMsgUnbindInput is the Huma input for POST /v0/city/{cityName}/extmsg/unbind.
+//
+// At least one of Conversation, SessionID, and AgentName must be set; the
+// handler enforces the rule (the schema cannot).
 type ExtMsgUnbindInput struct {
 	CityScope
 	Body struct {
-		Conversation *extmsg.ConversationRef `json:"conversation,omitempty" doc:"Conversation to unbind (nil = all)."`
-		SessionID    string                  `json:"session_id" minLength:"1" doc:"Session ID to unbind."`
+		Conversation *extmsg.ConversationRef `json:"conversation,omitempty" doc:"Conversation to unbind (nil = filter by session_id/agent_name)."`
+		SessionID    string                  `json:"session_id,omitempty" doc:"Session ID to unbind."`
+		AgentName    string                  `json:"agent_name,omitempty" doc:"Configured agent identity to unbind."`
 	}
 }
 

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -1214,6 +1214,9 @@
       "BoundEventPayload": {
         "additionalProperties": false,
         "properties": {
+          "agent_name": {
+            "type": "string"
+          },
           "conversation_id": {
             "type": "string"
           },
@@ -2504,6 +2507,10 @@
       "ExtMsgBindInputBody": {
         "additionalProperties": false,
         "properties": {
+          "agent_name": {
+            "description": "Configured agent identity to bind; its live session is resolved at delivery time, cold-waking one when none is live (mutually exclusive with session_id).",
+            "type": "string"
+          },
           "conversation": {
             "$ref": "#/components/schemas/ConversationRef",
             "description": "Conversation to bind."
@@ -2516,14 +2523,10 @@
             "type": "object"
           },
           "session_id": {
-            "description": "Session ID to bind.",
-            "minLength": 1,
+            "description": "Session ID to bind (mutually exclusive with agent_name).",
             "type": "string"
           }
         },
-        "required": [
-          "session_id"
-        ],
         "type": "object"
       },
       "ExtMsgGroupEnsureInputBody": {
@@ -2706,19 +2709,19 @@
       "ExtMsgUnbindInputBody": {
         "additionalProperties": false,
         "properties": {
+          "agent_name": {
+            "description": "Configured agent identity to unbind.",
+            "type": "string"
+          },
           "conversation": {
             "$ref": "#/components/schemas/ConversationRef",
-            "description": "Conversation to unbind (nil = all)."
+            "description": "Conversation to unbind (nil = filter by session_id/agent_name)."
           },
           "session_id": {
             "description": "Session ID to unbind.",
-            "minLength": 1,
             "type": "string"
           }
         },
-        "required": [
-          "session_id"
-        ],
         "type": "object"
       },
       "ExternalActor": {
@@ -3378,6 +3381,9 @@
           "provider": {
             "type": "string"
           },
+          "target_agent": {
+            "type": "string"
+          },
           "target_session": {
             "type": "string"
           }
@@ -3402,6 +3408,9 @@
           "Message": {
             "$ref": "#/components/schemas/ExternalInboundMessage"
           },
+          "TargetAgentName": {
+            "type": "string"
+          },
           "TargetSessionID": {
             "type": "string"
           },
@@ -3414,7 +3423,8 @@
           "Binding",
           "GroupRoute",
           "TranscriptEntry",
-          "TargetSessionID"
+          "TargetSessionID",
+          "TargetAgentName"
         ],
         "type": "object"
       },
@@ -6240,6 +6250,9 @@
       "SessionBindingRecord": {
         "additionalProperties": false,
         "properties": {
+          "AgentName": {
+            "type": "string"
+          },
           "BindingGeneration": {
             "format": "int64",
             "type": "integer"
@@ -6287,6 +6300,7 @@
           "Conversation",
           "SessionID",
           "SessionName",
+          "AgentName",
           "Status",
           "BoundAt",
           "ExpiresAt",

--- a/internal/extmsg/agent_binding_test.go
+++ b/internal/extmsg/agent_binding_test.go
@@ -1,0 +1,437 @@
+package extmsg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+func TestBindingServiceBindAgentNameCreatesAgentBinding(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	svc := fabric.Bindings
+	ref := testConversationRef()
+
+	first, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+	if first.AgentName != "rig-a/helper" {
+		t.Fatalf("AgentName = %q, want rig-a/helper", first.AgentName)
+	}
+	if first.SessionID != "" {
+		t.Fatalf("SessionID = %q, want empty for agent binding", first.SessionID)
+	}
+	if first.BindingGeneration != 1 {
+		t.Fatalf("BindingGeneration = %d, want 1", first.BindingGeneration)
+	}
+
+	// Membership is keyed by the agent name so the notify path resolves it
+	// as a session selector (materializing a session when none is live).
+	members, err := fabric.Transcript.ListMemberships(context.Background(), testControllerCaller(), ref)
+	if err != nil {
+		t.Fatalf("ListMemberships: %v", err)
+	}
+	if len(members) != 1 || members[0].SessionID != "rig-a/helper" {
+		t.Fatalf("memberships = %#v, want one keyed rig-a/helper", members)
+	}
+
+	// Idempotent re-bind of the same agent keeps the record.
+	second, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "rig-a/helper",
+		Now:          testNow().Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Bind(idempotent agent): %v", err)
+	}
+	if second.ID != first.ID || second.BindingGeneration != first.BindingGeneration {
+		t.Fatalf("idempotent agent bind changed record: got %s/%d want %s/%d",
+			second.ID, second.BindingGeneration, first.ID, first.BindingGeneration)
+	}
+
+	// A different agent conflicts.
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "rig-a/other",
+		Now:          testNow(),
+	}); !errors.Is(err, ErrBindingConflict) {
+		t.Fatalf("Bind(other agent) error = %v, want ErrBindingConflict", err)
+	}
+
+	// A session bind conflicts with the active agent binding.
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-a",
+		Now:          testNow(),
+	}); !errors.Is(err, ErrBindingConflict) {
+		t.Fatalf("Bind(session over agent) error = %v, want ErrBindingConflict", err)
+	}
+
+	got, err := svc.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if got == nil || got.AgentName != "rig-a/helper" || got.SessionID != "" {
+		t.Fatalf("ResolveByConversation = %#v, want agent binding rig-a/helper", got)
+	}
+}
+
+func TestBindingServiceBindRequiresExactlyOneTarget(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	ref := testConversationRef()
+
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		Now:          testNow(),
+	}); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("Bind(neither) error = %v, want ErrInvalidInput", err)
+	}
+
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-a",
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	}); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("Bind(both) error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestBindingServiceAgentBindingSurvivesSessionRetirement(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	svc := fabric.Bindings
+	agentRef := testConversationRef()
+	sessionRef := testConversationRef()
+	sessionRef.ConversationID = "thread-2"
+
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: agentRef,
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: sessionRef,
+		SessionID:    "sess-live-1",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(session): %v", err)
+	}
+
+	// Retire the concrete session that has been serving the agent. The
+	// session-keyed binding dies with it; the agent binding and its
+	// membership survive — conversation continuity does not depend on
+	// session continuity.
+	if err := CloseSessionBindings(context.Background(), store, "sess-live-1", testNow().Add(time.Minute)); err != nil {
+		t.Fatalf("CloseSessionBindings: %v", err)
+	}
+
+	gone, err := svc.ResolveByConversation(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("ResolveByConversation(session): %v", err)
+	}
+	if gone != nil {
+		t.Fatalf("session binding survived retirement: %#v", gone)
+	}
+
+	kept, err := svc.ResolveByConversation(context.Background(), agentRef)
+	if err != nil {
+		t.Fatalf("ResolveByConversation(agent): %v", err)
+	}
+	if kept == nil || kept.AgentName != "rig-a/helper" {
+		t.Fatalf("agent binding = %#v, want active rig-a/helper", kept)
+	}
+	members, err := fabric.Transcript.ListMemberships(context.Background(), testControllerCaller(), agentRef)
+	if err != nil {
+		t.Fatalf("ListMemberships: %v", err)
+	}
+	if len(members) != 1 || members[0].SessionID != "rig-a/helper" {
+		t.Fatalf("agent membership = %#v, want one keyed rig-a/helper", members)
+	}
+}
+
+func TestBindingServiceUnbindAgentBindingByConversation(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	svc := fabric.Bindings
+	ref := testConversationRef()
+
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+
+	closed, err := svc.Unbind(context.Background(), testControllerCaller(), UnbindInput{
+		Conversation: &ref,
+		Now:          testNow().Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Unbind: %v", err)
+	}
+	if len(closed) != 1 || closed[0].AgentName != "rig-a/helper" || closed[0].Status != BindingEnded {
+		t.Fatalf("Unbind closed = %#v, want ended agent binding", closed)
+	}
+
+	members, err := fabric.Transcript.ListMemberships(context.Background(), testControllerCaller(), ref)
+	if err != nil {
+		t.Fatalf("ListMemberships: %v", err)
+	}
+	if len(members) != 0 {
+		t.Fatalf("memberships after unbind = %#v, want none", members)
+	}
+}
+
+func TestBindingServiceUnbindByAgentName(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	agentRef := testConversationRef()
+	otherRef := testConversationRef()
+	otherRef.ConversationID = "thread-2"
+
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: agentRef,
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: otherRef,
+		SessionID:    "sess-a",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(session): %v", err)
+	}
+
+	closed, err := svc.Unbind(context.Background(), testControllerCaller(), UnbindInput{
+		AgentName: "rig-a/helper",
+		Now:       testNow().Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Unbind(agent name): %v", err)
+	}
+	if len(closed) != 1 || closed[0].AgentName != "rig-a/helper" {
+		t.Fatalf("Unbind closed = %#v, want the agent binding only", closed)
+	}
+
+	still, err := svc.ResolveByConversation(context.Background(), otherRef)
+	if err != nil {
+		t.Fatalf("ResolveByConversation(other): %v", err)
+	}
+	if still == nil || still.SessionID != "sess-a" {
+		t.Fatalf("session binding = %#v, want untouched sess-a", still)
+	}
+}
+
+func TestHandleInboundNormalizedAgentBindingRoutesAgentTarget(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	ref := testConversationRef()
+
+	if _, err := fabric.Bindings.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+
+	var captured []capturedEvent
+	deps := InboundDeps{
+		Services: fabric,
+		EmitEvent: func(eventType, subject string, payload events.Payload) {
+			captured = append(captured, capturedEvent{Type: eventType, Subject: subject, Payload: payload})
+		},
+	}
+	result, err := HandleInboundNormalized(context.Background(), deps, ExternalInboundMessage{
+		Conversation: ref,
+		Actor:        ExternalActor{ID: "user-1", DisplayName: "User One"},
+		Text:         "hello",
+		ReceivedAt:   testNow(),
+	})
+	if err != nil {
+		t.Fatalf("HandleInboundNormalized: %v", err)
+	}
+	if result.TargetAgentName != "rig-a/helper" {
+		t.Fatalf("TargetAgentName = %q, want rig-a/helper", result.TargetAgentName)
+	}
+	if result.TargetSessionID != "" {
+		t.Fatalf("TargetSessionID = %q, want empty for agent binding", result.TargetSessionID)
+	}
+	if result.TranscriptEntry == nil {
+		t.Fatalf("TranscriptEntry = nil, want inbound appended for agent-bound conversation")
+	}
+	if len(captured) != 1 || captured[0].Subject != "rig-a/helper" {
+		t.Fatalf("events = %#v, want one inbound event with agent subject", captured)
+	}
+	payload, ok := captured[0].Payload.(InboundEventPayload)
+	if !ok || payload.TargetAgent != "rig-a/helper" {
+		t.Fatalf("payload = %#v, want TargetAgent rig-a/helper", captured[0].Payload)
+	}
+}
+
+// agentTestResolver maps session selectors (agent names or concrete IDs) to
+// concrete session IDs the way the API layer's session resolution does.
+func agentTestResolver(mapping map[string]string) func(context.Context, string) (string, error) {
+	return func(_ context.Context, selector string) (string, error) {
+		if id, ok := mapping[selector]; ok {
+			return id, nil
+		}
+		return "", fmt.Errorf("session not found: %q", selector)
+	}
+}
+
+func TestHandleOutboundAgentBoundResolverAuthorizesMatchingSession(t *testing.T) {
+	freezeTestClock(t)
+	fabric, adapter, captured, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	if _, err := fabric.Bindings.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+	deps.ResolveSessionSelector = agentTestResolver(map[string]string{
+		"rig-a/helper": "sess-live-1",
+		"sess-live-1":  "sess-live-1",
+	})
+
+	result, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-live-1",
+		Conversation: ref,
+		Text:         "reply from the woken session",
+	})
+	if err != nil {
+		t.Fatalf("HandleOutbound: %v", err)
+	}
+	if !result.Receipt.Delivered {
+		t.Fatalf("Receipt.Delivered = false, want true")
+	}
+	if len(adapter.publishs) != 1 {
+		t.Fatalf("publishes = %d, want 1", len(adapter.publishs))
+	}
+	// Delivery-context recording is skipped on the agent path (like the
+	// group-fallback path) — transcript remains the outbound record.
+	if result.DeliveryContext != nil {
+		t.Fatalf("DeliveryContext = %#v, want nil on agent path", result.DeliveryContext)
+	}
+	if result.TranscriptEntry == nil {
+		t.Fatalf("TranscriptEntry = nil, want outbound appended")
+	}
+	var outboundEvents []capturedEvent
+	for _, ev := range *captured {
+		if ev.Type == "extmsg.outbound" {
+			outboundEvents = append(outboundEvents, ev)
+		}
+	}
+	if len(outboundEvents) != 1 || outboundEvents[0].Subject != "sess-live-1" {
+		t.Fatalf("outbound events = %#v, want one with subject sess-live-1", outboundEvents)
+	}
+}
+
+func TestHandleOutboundAgentBoundRejectsMismatchedSession(t *testing.T) {
+	freezeTestClock(t)
+	fabric, adapter, _, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	if _, err := fabric.Bindings.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+	deps.ResolveSessionSelector = agentTestResolver(map[string]string{
+		"rig-a/helper": "sess-live-1",
+		"sess-other":   "sess-other",
+	})
+
+	if _, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-other",
+		Conversation: ref,
+		Text:         "imposter",
+	}); err == nil {
+		t.Fatalf("HandleOutbound(mismatch) = nil error, want rejection")
+	}
+	if len(adapter.publishs) != 0 {
+		t.Fatalf("publishes = %d, want 0 after rejection", len(adapter.publishs))
+	}
+}
+
+func TestHandleOutboundAgentBoundNoLiveSessionFails(t *testing.T) {
+	freezeTestClock(t)
+	fabric, adapter, _, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	if _, err := fabric.Bindings.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+	deps.ResolveSessionSelector = agentTestResolver(map[string]string{
+		"sess-other": "sess-other",
+	})
+
+	if _, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-other",
+		Conversation: ref,
+		Text:         "no live agent session",
+	}); err == nil {
+		t.Fatalf("HandleOutbound(no live agent session) = nil error, want failure")
+	}
+	if len(adapter.publishs) != 0 {
+		t.Fatalf("publishes = %d, want 0", len(adapter.publishs))
+	}
+}
+
+func TestHandleOutboundAgentBoundWithoutResolverFails(t *testing.T) {
+	freezeTestClock(t)
+	fabric, adapter, _, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	if _, err := fabric.Bindings.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "rig-a/helper",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(agent): %v", err)
+	}
+	deps.ResolveSessionSelector = nil
+
+	if _, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-live-1",
+		Conversation: ref,
+		Text:         "no resolver wired",
+	}); err == nil {
+		t.Fatalf("HandleOutbound(no resolver) = nil error, want failure")
+	}
+	if len(adapter.publishs) != 0 {
+		t.Fatalf("publishes = %d, want 0", len(adapter.publishs))
+	}
+}

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -91,8 +91,12 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 		return SessionBindingRecord{}, err
 	}
 	sessionID := strings.TrimSpace(input.SessionID)
-	if sessionID == "" {
-		return SessionBindingRecord{}, fmt.Errorf("%w: session_id required", ErrInvalidInput)
+	agentName := strings.TrimSpace(input.AgentName)
+	switch {
+	case sessionID == "" && agentName == "":
+		return SessionBindingRecord{}, fmt.Errorf("%w: session_id or agent_name required", ErrInvalidInput)
+	case sessionID != "" && agentName != "":
+		return SessionBindingRecord{}, fmt.Errorf("%w: session_id and agent_name are mutually exclusive", ErrInvalidInput)
 	}
 	// Capture the target's stable session name so the binding survives respawn.
 	// Best-effort: empty when the selector resolves to no session bead.
@@ -113,8 +117,8 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 			return err
 		}
 		if active != nil {
-			if active.SessionID != sessionID {
-				return fmt.Errorf("%w: conversation already bound to %s", ErrBindingConflict, active.SessionID)
+			if active.SessionID != sessionID || active.AgentName != agentName {
+				return fmt.Errorf("%w: conversation already bound to %s", ErrBindingConflict, bindingTarget(*active))
 			}
 			if active.SessionName == "" && sessionName != "" {
 				if err := s.store.Update(active.ID, beads.UpdateOpts{
@@ -136,7 +140,7 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 				if _, err := s.transcript.ensureMembershipLocked(EnsureMembershipInput{
 					Caller:         caller,
 					Conversation:   ref,
-					SessionID:      sessionID,
+					SessionID:      bindingMembershipKey(updated),
 					BackfillPolicy: MembershipBackfillSinceJoin,
 					Owner:          MembershipOwnerBinding,
 					Now:            now,
@@ -147,9 +151,18 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 			return nil
 		}
 		nextGeneration := nextBindingGeneration(history)
-		labels := []string{"gc:extmsg-binding", labelBindingBase, bindingConversationLabel(ref), bindingSessionLabel(sessionID)}
-		if sessionName != "" {
-			labels = append(labels, bindingSessionNameLabel(sessionName))
+		// A binding targets either a configured agent (delivery-time resolution)
+		// or a concrete session. Agent bindings get only the agent label; session
+		// bindings get the volatile session-id label plus the stable session-name
+		// label (which survives respawn) when a name is known.
+		labels := []string{"gc:extmsg-binding", labelBindingBase, bindingConversationLabel(ref)}
+		if agentName != "" {
+			labels = append(labels, bindingAgentLabel(agentName))
+		} else {
+			labels = append(labels, bindingSessionLabel(sessionID))
+			if sessionName != "" {
+				labels = append(labels, bindingSessionNameLabel(sessionName))
+			}
 		}
 		b, err := s.store.Create(beads.Bead{
 			Title:  conversationTitle(ref),
@@ -165,6 +178,7 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 				"conversation_kind":      string(ref.Kind),
 				"session_id":             sessionID,
 				"session_name":           sessionName,
+				"agent_name":             agentName,
 				"binding_generation":     strconv.FormatInt(nextGeneration, 10),
 				"bound_at":               formatTime(now),
 				"expires_at":             formatTimePtr(input.ExpiresAt),
@@ -184,7 +198,7 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 			if _, err := s.transcript.ensureMembershipLocked(EnsureMembershipInput{
 				Caller:         caller,
 				Conversation:   ref,
-				SessionID:      sessionID,
+				SessionID:      bindingMembershipKey(out),
 				BackfillPolicy: MembershipBackfillSinceJoin,
 				Owner:          MembershipOwnerBinding,
 				Now:            now,
@@ -313,8 +327,18 @@ func (s *bindingService) Unbind(ctx context.Context, caller Caller, input Unbind
 	}
 	now := zeroNow(input.Now)
 	sessionID := strings.TrimSpace(input.SessionID)
-	if input.Conversation == nil && sessionID == "" {
-		return nil, fmt.Errorf("%w: conversation or session_id required", ErrInvalidInput)
+	agentName := strings.TrimSpace(input.AgentName)
+	if input.Conversation == nil && sessionID == "" && agentName == "" {
+		return nil, fmt.Errorf("%w: conversation, session_id, or agent_name required", ErrInvalidInput)
+	}
+	matchesFilter := func(record SessionBindingRecord) bool {
+		if sessionID != "" && record.SessionID != sessionID {
+			return false
+		}
+		if agentName != "" && record.AgentName != agentName {
+			return false
+		}
+		return true
 	}
 
 	var seeds []SessionBindingRecord
@@ -334,15 +358,19 @@ func (s *bindingService) Unbind(ctx context.Context, caller Caller, input Unbind
 			if record.Status != BindingActive {
 				continue
 			}
-			if sessionID != "" && record.SessionID != sessionID {
+			if !matchesFilter(record) {
 				continue
 			}
 			seeds = append(seeds, record)
 		}
 	} else {
-		items, err := s.store.List(beads.ListQuery{Label: bindingSessionLabel(sessionID)})
+		label := bindingSessionLabel(sessionID)
+		if sessionID == "" {
+			label = bindingAgentLabel(agentName)
+		}
+		items, err := s.store.List(beads.ListQuery{Label: label})
 		if err != nil {
-			return nil, fmt.Errorf("list bindings by session label: %w", err)
+			return nil, fmt.Errorf("list bindings by target label: %w", err)
 		}
 		for _, item := range items {
 			if !hasLabel(item, "gc:extmsg-binding") {
@@ -352,7 +380,7 @@ func (s *bindingService) Unbind(ctx context.Context, caller Caller, input Unbind
 			if err != nil {
 				return nil, err
 			}
-			if record.Status != BindingActive || record.SessionID != sessionID {
+			if record.Status != BindingActive || !matchesFilter(record) {
 				continue
 			}
 			if err := authorizeMutation(caller, record.Conversation); err != nil {
@@ -383,7 +411,7 @@ func (s *bindingService) Unbind(ctx context.Context, caller Caller, input Unbind
 			if active == nil {
 				return nil
 			}
-			if sessionID != "" && active.SessionID != sessionID {
+			if !matchesFilter(*active) {
 				return nil
 			}
 			if err := s.store.SetMetadata(active.ID, "last_touched_at", formatTime(now)); err != nil {
@@ -393,7 +421,7 @@ func (s *bindingService) Unbind(ctx context.Context, caller Caller, input Unbind
 				if err := s.transcript.removeMembershipLocked(RemoveMembershipInput{
 					Caller:       caller,
 					Conversation: active.Conversation,
-					SessionID:    active.SessionID,
+					SessionID:    bindingMembershipKey(*active),
 					Owner:        MembershipOwnerBinding,
 					Now:          now,
 				}); err != nil {
@@ -405,7 +433,7 @@ func (s *bindingService) Unbind(ctx context.Context, caller Caller, input Unbind
 					_, _ = s.transcript.ensureMembershipLocked(EnsureMembershipInput{
 						Caller:         caller,
 						Conversation:   active.Conversation,
-						SessionID:      active.SessionID,
+						SessionID:      bindingMembershipKey(*active),
 						BackfillPolicy: MembershipBackfillSinceJoin,
 						Owner:          MembershipOwnerBinding,
 						Now:            now,
@@ -419,7 +447,7 @@ func (s *bindingService) Unbind(ctx context.Context, caller Caller, input Unbind
 			}
 			active.Metadata["last_touched_at"] = formatTime(now)
 			closed = append(closed, *active)
-			if s.delivery != nil {
+			if s.delivery != nil && active.SessionID != "" {
 				if err := s.delivery.ClearForConversation(ctx, active.SessionID, active.Conversation); err != nil {
 					return err
 				}
@@ -834,14 +862,14 @@ func (s *bindingService) activeBinding(ctx context.Context, history []SessionBin
 			if err := s.transcript.removeMembershipLocked(RemoveMembershipInput{
 				Caller:       Caller{Kind: CallerController, ID: "binding-expiry"},
 				Conversation: record.Conversation,
-				SessionID:    record.SessionID,
+				SessionID:    bindingMembershipKey(record),
 				Owner:        MembershipOwnerBinding,
 				Now:          now,
 			}); err != nil {
 				return wrapTranscriptSyncError("remove transcript membership after binding expiry", err)
 			}
 		}
-		if s.delivery != nil {
+		if s.delivery != nil && record.SessionID != "" {
 			if err := s.delivery.ClearForConversation(ctx, record.SessionID, record.Conversation); err != nil {
 				return err
 			}
@@ -851,7 +879,7 @@ func (s *bindingService) activeBinding(ctx context.Context, history []SessionBin
 				_, _ = s.transcript.ensureMembershipLocked(EnsureMembershipInput{
 					Caller:         Caller{Kind: CallerController, ID: "binding-expiry"},
 					Conversation:   record.Conversation,
-					SessionID:      record.SessionID,
+					SessionID:      bindingMembershipKey(record),
 					BackfillPolicy: MembershipBackfillSinceJoin,
 					Owner:          MembershipOwnerBinding,
 					Now:            now,
@@ -909,12 +937,33 @@ func decodeBindingBead(b beads.Bead) (SessionBindingRecord, error) {
 		Conversation:      ref,
 		SessionID:         strings.TrimSpace(b.Metadata["session_id"]),
 		SessionName:       strings.TrimSpace(b.Metadata["session_name"]),
+		AgentName:         strings.TrimSpace(b.Metadata["agent_name"]),
 		Status:            recordStatus(b),
 		BoundAt:           boundAt,
 		ExpiresAt:         expiresAt,
 		BindingGeneration: parseInt64(b.Metadata, "binding_generation"),
 		Metadata:          decodePrefixedMetadata(b.Metadata),
 	}, nil
+}
+
+// bindingTarget renders the bound endpoint for error messages: the agent
+// identity for agent bindings, the session ID otherwise.
+func bindingTarget(record SessionBindingRecord) string {
+	if record.AgentName != "" {
+		return "agent " + record.AgentName
+	}
+	return record.SessionID
+}
+
+// bindingMembershipKey is the transcript-membership key for a binding: the
+// agent identity for agent bindings (a session selector the delivery layer
+// resolves — materializing a session when none is live), the concrete
+// session ID otherwise.
+func bindingMembershipKey(record SessionBindingRecord) string {
+	if record.AgentName != "" {
+		return record.AgentName
+	}
+	return record.SessionID
 }
 
 func nextBindingGeneration(records []SessionBindingRecord) int64 {
@@ -977,14 +1026,14 @@ func resolveActiveBindingLocked(ctx context.Context, store beads.Store, delivery
 			if err := transcript.removeMembershipLocked(RemoveMembershipInput{
 				Caller:       Caller{Kind: CallerController, ID: "binding-expiry"},
 				Conversation: record.Conversation,
-				SessionID:    record.SessionID,
+				SessionID:    bindingMembershipKey(record),
 				Owner:        MembershipOwnerBinding,
 				Now:          now,
 			}); err != nil {
 				return wrapTranscriptSyncError("remove transcript membership after binding expiry", err)
 			}
 		}
-		if delivery != nil {
+		if delivery != nil && record.SessionID != "" {
 			if err := delivery.ClearForConversation(ctx, record.SessionID, record.Conversation); err != nil {
 				return err
 			}
@@ -994,7 +1043,7 @@ func resolveActiveBindingLocked(ctx context.Context, store beads.Store, delivery
 				_, _ = transcript.ensureMembershipLocked(EnsureMembershipInput{
 					Caller:         Caller{Kind: CallerController, ID: "binding-expiry"},
 					Conversation:   record.Conversation,
-					SessionID:      record.SessionID,
+					SessionID:      bindingMembershipKey(record),
 					BackfillPolicy: MembershipBackfillSinceJoin,
 					Owner:          MembershipOwnerBinding,
 					Now:            now,

--- a/internal/extmsg/events.go
+++ b/internal/extmsg/events.go
@@ -10,12 +10,14 @@ import "github.com/gastownhall/gascity/internal/events"
 
 // InboundEventPayload is emitted on events.ExtMsgInbound ("extmsg.inbound").
 // Actor is the inbound speaker's display name; TargetSession is the
-// resolved recipient session (empty if no routing match).
+// resolved recipient session and TargetAgent the bound agent identity for
+// agent-bound conversations (both empty if no routing match).
 type InboundEventPayload struct {
 	Provider       string `json:"provider"`
 	ConversationID string `json:"conversation_id"`
 	Actor          string `json:"actor"`
 	TargetSession  string `json:"target_session"`
+	TargetAgent    string `json:"target_agent,omitempty"`
 }
 
 // IsEventPayload marks InboundEventPayload as an events.Payload variant.
@@ -49,11 +51,12 @@ type OutboundChannelMismatchPayload struct {
 func (OutboundChannelMismatchPayload) IsEventPayload() {}
 
 // BoundEventPayload is emitted on events.ExtMsgBound (binding a
-// conversation to a session).
+// conversation to a session or to a configured agent identity).
 type BoundEventPayload struct {
 	Provider       string `json:"provider"`
 	ConversationID string `json:"conversation_id"`
 	SessionID      string `json:"session_id"`
+	AgentName      string `json:"agent_name,omitempty"`
 }
 
 // IsEventPayload marks BoundEventPayload as an events.Payload variant.

--- a/internal/extmsg/inbound.go
+++ b/internal/extmsg/inbound.go
@@ -10,12 +10,31 @@ import (
 )
 
 // InboundResult captures the outcome of processing an inbound message.
+// TargetSessionID is set when the conversation is bound to a concrete
+// session; TargetAgentName is set when it is bound to a configured agent
+// identity, whose live session the delivery layer resolves (cold-waking one
+// when none is live).
 type InboundResult struct {
 	Message         ExternalInboundMessage
 	Binding         *SessionBindingRecord
 	GroupRoute      *GroupRouteDecision
 	TranscriptEntry *ConversationTranscriptRecord
 	TargetSessionID string
+	TargetAgentName string
+}
+
+// targetSubject is the event subject for the routed target: the concrete
+// session when one is bound, the agent identity otherwise.
+func (r *InboundResult) targetSubject() string {
+	if r.TargetSessionID != "" {
+		return r.TargetSessionID
+	}
+	return r.TargetAgentName
+}
+
+// routed reports whether the message resolved to any delivery target.
+func (r *InboundResult) routed() bool {
+	return r.TargetSessionID != "" || r.TargetAgentName != ""
 }
 
 // InboundDeps bundles the dependencies for inbound processing.
@@ -66,10 +85,11 @@ func HandleInbound(ctx context.Context, deps InboundDeps, key AdapterKey, payloa
 	if binding != nil {
 		result.Binding = binding
 		result.TargetSessionID = binding.SessionID
+		result.TargetAgentName = binding.AgentName
 	}
 
 	// Step 4: If no binding, try group routing.
-	if result.TargetSessionID == "" {
+	if !result.routed() {
 		route, err := deps.Services.Groups.ResolveInbound(ctx, *msg)
 		if err != nil {
 			if !errors.Is(err, ErrGroupNotFound) && !errors.Is(err, ErrGroupRouteNotFound) {
@@ -83,7 +103,7 @@ func HandleInbound(ctx context.Context, deps InboundDeps, key AdapterKey, payloa
 	}
 
 	// Step 5: Append to transcript.
-	if result.TargetSessionID != "" {
+	if result.routed() {
 		caller := Caller{
 			Kind:      CallerAdapter,
 			ID:        adapter.Name(),
@@ -117,11 +137,12 @@ func HandleInbound(ctx context.Context, deps InboundDeps, key AdapterKey, payloa
 	// Wake is handled by the caller (HTTP handler calls state.Poke()).
 	// Sessions discover unread entries via gc transcript check --inject.
 	if deps.EmitEvent != nil {
-		deps.EmitEvent(events.ExtMsgInbound, result.TargetSessionID, InboundEventPayload{
+		deps.EmitEvent(events.ExtMsgInbound, result.targetSubject(), InboundEventPayload{
 			Provider:       msg.Conversation.Provider,
 			ConversationID: msg.Conversation.ConversationID,
 			Actor:          msg.Actor.DisplayName,
 			TargetSession:  result.TargetSessionID,
+			TargetAgent:    result.TargetAgentName,
 		})
 	}
 
@@ -148,10 +169,11 @@ func HandleInboundNormalized(ctx context.Context, deps InboundDeps, msg External
 	if binding != nil {
 		result.Binding = binding
 		result.TargetSessionID = binding.SessionID
+		result.TargetAgentName = binding.AgentName
 	}
 
 	// Step 2: If no binding, try group routing.
-	if result.TargetSessionID == "" {
+	if !result.routed() {
 		route, err := deps.Services.Groups.ResolveInbound(ctx, msg)
 		if err != nil {
 			if !errors.Is(err, ErrGroupNotFound) && !errors.Is(err, ErrGroupRouteNotFound) {
@@ -164,7 +186,7 @@ func HandleInboundNormalized(ctx context.Context, deps InboundDeps, msg External
 	}
 
 	// Step 3: Append to transcript.
-	if result.TargetSessionID != "" {
+	if result.routed() {
 		caller := Caller{Kind: CallerController, ID: "inbound-normalized"}
 		entry, err := deps.Services.Transcript.Append(ctx, AppendTranscriptInput{
 			Caller:            caller,
@@ -191,11 +213,12 @@ func HandleInboundNormalized(ctx context.Context, deps InboundDeps, msg External
 
 	// Step 4: Emit event.
 	if deps.EmitEvent != nil {
-		deps.EmitEvent(events.ExtMsgInbound, result.TargetSessionID, InboundEventPayload{
+		deps.EmitEvent(events.ExtMsgInbound, result.targetSubject(), InboundEventPayload{
 			Provider:       msg.Conversation.Provider,
 			ConversationID: msg.Conversation.ConversationID,
 			Actor:          msg.Actor.DisplayName,
 			TargetSession:  result.TargetSessionID,
+			TargetAgent:    result.TargetAgentName,
 		})
 	}
 

--- a/internal/extmsg/labels.go
+++ b/internal/extmsg/labels.go
@@ -22,6 +22,7 @@ const (
 	labelBindingConversationPrefix = "extmsg:binding:conv:v1:"
 	labelBindingSessionPrefix      = "extmsg:binding:session:v1:"
 	labelBindingSessionNamePrefix  = "extmsg:binding:sessionname:v1:"
+	labelBindingAgentPrefix        = "extmsg:binding:agent:v1:"
 	labelDeliveryRoutePrefix       = "extmsg:delivery:route:v1:"
 	labelDeliverySessionPrefix     = "extmsg:delivery:session:v1:"
 	labelGroupRootPrefix           = "extmsg:group:root:v1:"
@@ -58,6 +59,10 @@ func bindingSessionLabel(sessionID string) string {
 // can find every binding owned by a name even after the original bead closes.
 func bindingSessionNameLabel(sessionName string) string {
 	return labelBindingSessionNamePrefix + strings.TrimSpace(sessionName)
+}
+
+func bindingAgentLabel(agentName string) string {
+	return labelBindingAgentPrefix + strings.TrimSpace(agentName)
 }
 
 func deliveryRouteLabel(ref ConversationRef, sessionID string) string {

--- a/internal/extmsg/outbound.go
+++ b/internal/extmsg/outbound.go
@@ -36,10 +36,17 @@ type OutboundResult struct {
 }
 
 // OutboundDeps bundles the dependencies for outbound processing.
+//
+// ResolveSessionSelector resolves a session selector — a configured agent
+// identity, session name, alias, or concrete session bead ID — to the
+// concrete ID of a live session. The API layer supplies its session target
+// resolution; extmsg stays free of session-layer imports. It is required
+// only to publish on agent-bound conversations.
 type OutboundDeps struct {
-	Services  Services
-	Registry  *AdapterRegistry
-	EmitEvent func(eventType, subject string, payload events.Payload)
+	Services               Services
+	Registry               *AdapterRegistry
+	EmitEvent              func(eventType, subject string, payload events.Payload)
+	ResolveSessionSelector func(ctx context.Context, selector string) (string, error)
 }
 
 // HandleOutbound publishes a message from a session to an external conversation.
@@ -79,7 +86,32 @@ func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req O
 	// session. bindingGeneration is non-zero only on the binding path.
 	var publishingSession string
 	var bindingGeneration int64
+	agentBound := binding != nil && binding.AgentName != ""
 	switch {
+	case agentBound:
+		// Agent-bound conversations defer session identity to delivery
+		// time: the publish is authorized when the caller's session is
+		// the one the bound agent currently resolves to.
+		if deps.ResolveSessionSelector == nil {
+			return nil, fmt.Errorf("conversation %s/%s is bound to agent %s but no session selector resolution is available",
+				req.Conversation.Provider, req.Conversation.ConversationID, binding.AgentName)
+		}
+		agentSessionID, err := deps.ResolveSessionSelector(ctx, binding.AgentName)
+		if err != nil {
+			return nil, fmt.Errorf("resolving bound agent %q session: %w", binding.AgentName, err)
+		}
+		if req.SessionID != "" {
+			callerSessionID, err := deps.ResolveSessionSelector(ctx, req.SessionID)
+			if err != nil {
+				return nil, fmt.Errorf("resolving publishing session %q: %w", req.SessionID, err)
+			}
+			if callerSessionID != agentSessionID {
+				return nil, fmt.Errorf("session %q does not own binding for conversation %s/%s (bound to agent %s, currently session %s)",
+					req.SessionID, req.Conversation.Provider, req.Conversation.ConversationID, binding.AgentName, agentSessionID)
+			}
+		}
+		publishingSession = agentSessionID
+		bindingGeneration = binding.BindingGeneration
 	case binding != nil:
 		if req.SessionID != "" && binding.SessionID != req.SessionID {
 			// Cross-wire: the caller is trying to post into a channel owned
@@ -151,15 +183,19 @@ func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req O
 		return result, nil
 	}
 
-	// Step 5: Record delivery context (binding path only).
+	// Step 5: Record delivery context (session-binding path only).
 	//
 	// Delivery context tracks per-binding publish state and requires a
 	// non-zero BindingGeneration tied to an active binding — neither
 	// applies on the group fallback path. Recording is intentionally
 	// skipped there; transcript append below still runs and remains the
-	// authoritative outbound record for group flows.
+	// authoritative outbound record for group flows. The agent-binding
+	// path is skipped for the same reason: the delivery service
+	// revalidates ownership against the binding's session ID, which an
+	// agent binding does not pin, so the transcript is the authoritative
+	// outbound record there too.
 	now := time.Now()
-	if binding != nil {
+	if binding != nil && !agentBound {
 		dc := DeliveryContextRecord{
 			SessionID:         publishingSession,
 			Conversation:      req.Conversation,

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -96,19 +96,25 @@ const (
 	BindingEnded BindingStatus = "ended"
 )
 
-// SessionBindingRecord links a conversation to a session.
+// SessionBindingRecord links a conversation to a session or to a configured
+// agent identity. A binding is either a session binding (SessionID + SessionName)
+// or an agent binding (AgentName); exactly one target form is set.
 //
-// SessionID is the session bead ID this binding currently resolves to. It is
-// volatile: a session that crashes and respawns under the same name gets a
+// SessionID is the session bead ID a session binding currently resolves to. It
+// is volatile: a session that crashes and respawns under the same name gets a
 // fresh bead ID. SessionName is the stable identity the binding was created
 // under; it survives respawn and lets ResolveByConversation and the binding
 // reaper re-point the binding at the session's current live bead.
+//
+// AgentName defers session resolution to delivery time so the conversation
+// survives session retirement (delivery-time cold-wake).
 type SessionBindingRecord struct {
 	ID                string
 	SchemaVersion     int
 	Conversation      ConversationRef
 	SessionID         string
 	SessionName       string
+	AgentName         string
 	Status            BindingStatus
 	BoundAt           time.Time
 	ExpiresAt         *time.Time
@@ -398,19 +404,25 @@ type GroupOutboundDecision struct {
 	Participant ConversationGroupParticipant
 }
 
-// BindInput is the input for creating a session binding.
+// BindInput is the input for creating a session binding. Exactly one of
+// SessionID (bind to a concrete session) or AgentName (bind to a configured
+// agent identity whose live session is resolved at delivery time) must be set.
 type BindInput struct {
 	Conversation ConversationRef
 	SessionID    string
+	AgentName    string
 	ExpiresAt    *time.Time
 	Metadata     map[string]string
 	Now          time.Time
 }
 
-// UnbindInput is the input for removing a session binding.
+// UnbindInput is the input for removing a session binding. SessionID and
+// AgentName filter which active bindings are removed; with a nil
+// Conversation, at least one of them selects the bindings to close.
 type UnbindInput struct {
 	Conversation *ConversationRef
 	SessionID    string
+	AgentName    string
 	Now          time.Time
 }
 


### PR DESCRIPTION
## Summary

Routing ladder 1 (bead `ga-3tgxcq`) — the keystone of multi-agent external-messaging routing. Today `SessionBindingRecord` binds a conversation to a concrete session bead ID, so the binding dies with the session (the retirement cascade in `cmd/gc/session_beads.go` closes it) and the external conversation is orphaned whenever the bound session idles out or is reaped.

This adds **agent-name bindings**: bind a `ConversationRef` to a configured agent identity instead of a session. The live session is resolved at delivery time — cold-waking one when none is live — so conversation continuity no longer depends on session continuity (NDI).

## How it works

- `BindInput` / `SessionBindingRecord` gain `AgentName` (exactly one of `session_id` / `agent_name`; the schema can't express that, so the handler enforces it per the documented conditional-requiredness pattern).
- **Cold-wake rides existing machinery.** The binding's transcript membership is keyed by the configured named-session identity, which `extmsgNotifyMembers` already treats as a session selector and cold-materializes via `materializeNamedSessionWithContext` (the documented worker-boundary path) before nudging. An inbound to an agent-bound conversation with no live session wakes one and delivers, with since-join backfill via the existing shared-threads membership cursors. Zero new wake code; no new `session.Manager.Create*` call sites.
- **Survives retirement by construction.** `CloseSessionBindings` / `ReassignSessionBindings` list bindings by the concrete-session label; agent bindings live in their own label namespace. A regression test retires a session and proves the session-keyed binding dies while the agent binding and its membership survive.
- **Outbound authorization.** `HandleOutbound` gets an injected `OutboundDeps.ResolveSessionSelector` (API layer supplies `resolveSessionTargetIDWithContext`; extmsg keeps zero session-layer imports). A publish on an agent-bound conversation is authorized iff the caller's session resolves to the same live session as the bound agent. Delivery-context recording is skipped on the agent path for the same documented reason as the group-fallback path.
- **Bind-time validation.** The bind endpoint requires agent names to resolve to a configured `[[named_session]]` identity — the only identity the delivery layer can synchronously cold-wake (pool wake remains demand-driven per the 5710f89aa precedent) — and persists the qualified spec identity so bindings stay unambiguous under config drift. Unknown/pool-only names → 400.
- `InboundResult.TargetAgentName`, `InboundEventPayload.target_agent`, `BoundEventPayload.agent_name` added (additive wire changes); unbind accepts `agent_name` as a filter.

## Testing

- `internal/extmsg`: new agent-binding suite — XOR validation, idempotent re-bind, cross-kind conflicts, retirement survival, unbind by conversation/agent, inbound routing + event subject, outbound resolver authorize/mismatch/no-live-session/no-resolver. Full package green.
- `internal/api`: bind handler validation (missing/both/unknown agent → 400), qualified-identity persistence, **e2e cold-wake** (agent-bound inbound with no live session materializes the configured named session), outbound imposter rejected / resolved agent session authorized. Full package green (140s suite incl. `TestOpenAPISpecInSync`, `TestGeneratedClientInSync`).
- `go vet ./...`, `golangci-lint run` (changed packages), `gofmt` clean; `make dashboard-check` green; openapi/genclient/dashboard types regenerated.

Part of the extmsg routing-ladder program: ladder 2 (`ga-4uw8ee` default routes) and ladder 3 (`ga-fxi5zp` handoff/bind CLI verbs) build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)