### PR TITLE
perf(wisps): index defer_until — readiness probe full-scanned wisps on every dispatcher wake

### DIFF
--- a/schemas/wisps-composite-index/common.sh
+++ b/schemas/wisps-composite-index/common.sh
@@ -261,11 +261,7 @@ show_wisps_indexes() {
     dolt_sql_csv "USE \`$DOLT_DB\`; SHOW INDEX FROM wisps;"
 }
 
-index_rows() {
-    local output="$1"
-
-    printf '%s\n' "$output" | awk -F, -v idx="$INDEX_NAME" 'NR > 1 && $3 == idx { count++ } END { print count + 0 }'
-}
+index_rows() { index_rows_for "$1" "$INDEX_NAME"; }
 
 verify_index_definition() {
     local output="$1"

--- a/schemas/wisps-composite-index/common.sh
+++ b/schemas/wisps-composite-index/common.sh
@@ -286,42 +286,35 @@ verify_index_definition() {
     fi
 }
 
-status_index_rows() {
-    local output="$1"
+index_rows_for() {
+    local output="$1" name="$2"
 
-    printf '%s\n' "$output" | awk -F, -v idx="$STATUS_INDEX_NAME" 'NR > 1 && $3 == idx { count++ } END { print count + 0 }'
+    printf '%s\n' "$output" | awk -F, -v idx="$name" 'NR > 1 && $3 == idx { count++ } END { print count + 0 }'
 }
+
+verify_single_column_index() {
+    local output="$1" name="$2" col="$3"
+    local count
+
+    count=$(index_rows_for "$output" "$name")
+    if [ "$count" -ne 1 ]; then
+        die "index $name has $count column rows; expected exactly 1 for ($col)"
+    fi
+
+    printf '%s\n' "$output" | awk -F, -v idx="$name" -v c="$col" 'NR > 1 && $3 == idx && $4 == "1" && $5 == c { found = 1 } END { exit found ? 0 : 1 }' \
+        || die "index $name exists but does not match ($col)"
+}
+
+status_index_rows() { index_rows_for "$1" "$STATUS_INDEX_NAME"; }
 
 verify_status_index_definition() {
-    local output="$1"
-    local count
-
-    count=$(status_index_rows "$output")
-    if [ "$count" -ne 1 ]; then
-        die "index $STATUS_INDEX_NAME has $count column rows; expected exactly 1 for ($STATUS_INDEX_COLUMNS)"
-    fi
-
-    printf '%s\n' "$output" | awk -F, -v idx="$STATUS_INDEX_NAME" 'NR > 1 && $3 == idx && $4 == "1" && $5 == "status" { found = 1 } END { exit found ? 0 : 1 }' \
-        || die "index $STATUS_INDEX_NAME exists but does not match ($STATUS_INDEX_COLUMNS)"
+    verify_single_column_index "$1" "$STATUS_INDEX_NAME" "$STATUS_INDEX_COLUMNS"
 }
 
-defer_until_index_rows() {
-    local output="$1"
-
-    printf '%s\n' "$output" | awk -F, -v idx="$DEFER_UNTIL_INDEX_NAME" 'NR > 1 && $3 == idx { count++ } END { print count + 0 }'
-}
+defer_until_index_rows() { index_rows_for "$1" "$DEFER_UNTIL_INDEX_NAME"; }
 
 verify_defer_until_index_definition() {
-    local output="$1"
-    local count
-
-    count=$(defer_until_index_rows "$output")
-    if [ "$count" -ne 1 ]; then
-        die "index $DEFER_UNTIL_INDEX_NAME has $count column rows; expected exactly 1 for ($DEFER_UNTIL_INDEX_COLUMNS)"
-    fi
-
-    printf '%s\n' "$output" | awk -F, -v idx="$DEFER_UNTIL_INDEX_NAME" 'NR > 1 && $3 == idx && $4 == "1" && $5 == "defer_until" { found = 1 } END { exit found ? 0 : 1 }' \
-        || die "index $DEFER_UNTIL_INDEX_NAME exists but does not match ($DEFER_UNTIL_INDEX_COLUMNS)"
+    verify_single_column_index "$1" "$DEFER_UNTIL_INDEX_NAME" "$DEFER_UNTIL_INDEX_COLUMNS"
 }
 
 commit_schema_change() {

--- a/schemas/wisps-composite-index/common.sh
+++ b/schemas/wisps-composite-index/common.sh
@@ -4,6 +4,8 @@ INDEX_NAME="idx_wisps_type_status_assignee"
 INDEX_COLUMNS="issue_type, status, assignee"
 STATUS_INDEX_NAME="idx_wisps_status"
 STATUS_INDEX_COLUMNS="status"
+DEFER_UNTIL_INDEX_NAME="idx_wisps_defer_until"
+DEFER_UNTIL_INDEX_COLUMNS="defer_until"
 COMMIT_AUTHOR="gascity-builder <builder@gascity.local>"
 
 die() {
@@ -301,6 +303,25 @@ verify_status_index_definition() {
 
     printf '%s\n' "$output" | awk -F, -v idx="$STATUS_INDEX_NAME" 'NR > 1 && $3 == idx && $4 == "1" && $5 == "status" { found = 1 } END { exit found ? 0 : 1 }' \
         || die "index $STATUS_INDEX_NAME exists but does not match ($STATUS_INDEX_COLUMNS)"
+}
+
+defer_until_index_rows() {
+    local output="$1"
+
+    printf '%s\n' "$output" | awk -F, -v idx="$DEFER_UNTIL_INDEX_NAME" 'NR > 1 && $3 == idx { count++ } END { print count + 0 }'
+}
+
+verify_defer_until_index_definition() {
+    local output="$1"
+    local count
+
+    count=$(defer_until_index_rows "$output")
+    if [ "$count" -ne 1 ]; then
+        die "index $DEFER_UNTIL_INDEX_NAME has $count column rows; expected exactly 1 for ($DEFER_UNTIL_INDEX_COLUMNS)"
+    fi
+
+    printf '%s\n' "$output" | awk -F, -v idx="$DEFER_UNTIL_INDEX_NAME" 'NR > 1 && $3 == idx && $4 == "1" && $5 == "defer_until" { found = 1 } END { exit found ? 0 : 1 }' \
+        || die "index $DEFER_UNTIL_INDEX_NAME exists but does not match ($DEFER_UNTIL_INDEX_COLUMNS)"
 }
 
 commit_schema_change() {

--- a/schemas/wisps-composite-index/migrate.sh
+++ b/schemas/wisps-composite-index/migrate.sh
@@ -3,6 +3,7 @@
 # Adds the verified-needed wisps indexes to the Dolt-backed beads wisps table:
 #   - idx_wisps_type_status_assignee for mail-check lookups
 #   - idx_wisps_status for PrimeWisps status=open reconciliation
+#   - idx_wisps_defer_until for the control-dispatcher readiness probe
 #
 # Connection discovery order:
 #   database: GC_DOLT_DATABASE, BEADS_DOLT_DATABASE, then .beads/metadata.json dolt_database
@@ -56,6 +57,21 @@ fi
 
 indexes=$(show_wisps_indexes)
 verify_status_index_definition "$indexes"
+
+rows=$(defer_until_index_rows "$indexes")
+if [ "$rows" -gt 0 ]; then
+    verify_defer_until_index_definition "$indexes"
+    info "index $DEFER_UNTIL_INDEX_NAME already exists on wisps($DEFER_UNTIL_INDEX_COLUMNS)"
+else
+    dolt_sql -q "
+        USE \`$DOLT_DB\`;
+        CREATE INDEX $DEFER_UNTIL_INDEX_NAME ON wisps(defer_until);
+    " >/dev/null
+    changed=true
+fi
+
+indexes=$(show_wisps_indexes)
+verify_defer_until_index_definition "$indexes"
 
 if [ "$changed" = false ]; then
     info "all wisps indexes already exist; no changes needed"

--- a/schemas/wisps-composite-index/rollback.sh
+++ b/schemas/wisps-composite-index/rollback.sh
@@ -41,6 +41,19 @@ else
     info "index $STATUS_INDEX_NAME is absent"
 fi
 
+indexes=$(show_wisps_indexes)
+rows=$(defer_until_index_rows "$indexes")
+if [ "$rows" -gt 0 ]; then
+    verify_defer_until_index_definition "$indexes"
+    dolt_sql -q "
+        USE \`$DOLT_DB\`;
+        DROP INDEX $DEFER_UNTIL_INDEX_NAME ON wisps;
+    " >/dev/null
+    changed=true
+else
+    info "index $DEFER_UNTIL_INDEX_NAME is absent"
+fi
+
 if [ "$changed" = false ]; then
     info "no rollback changes needed"
     exit 0
@@ -55,6 +68,11 @@ fi
 rows=$(status_index_rows "$indexes")
 if [ "$rows" -ne 0 ]; then
     die "rollback failed; index $STATUS_INDEX_NAME is still present"
+fi
+
+rows=$(defer_until_index_rows "$indexes")
+if [ "$rows" -ne 0 ]; then
+    die "rollback failed; index $DEFER_UNTIL_INDEX_NAME is still present"
 fi
 
 commit_schema_change "schema: drop wisps planner indexes" >/dev/null


### PR DESCRIPTION
Fixes #3317.

The wisp `defer_until` readiness probe full-scans the wisps table on every dispatcher wake. This adds `idx_wisps_defer_until` to the wisps composite-index migration so the probe is index-served.

Pipeline: full pre-push review + 29-rule contributor check PASS.