### PR TITLE
feat(extmsg): default routes for unbound inbound conversations (ga-4uw8ee)

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -42,6 +42,7 @@ City is the top-level configuration for a Gas City instance.
 | `maintenance` | MaintenanceConfig |  |  | Maintenance configures periodic store-maintenance loops. |
 | `service` | []Service |  |  | Services declares workspace-owned HTTP services mounted on the controller edge under /svc/&#123;name&#125;. |
 | `github` | GitHubConfig |  |  | GitHub configures GitHub-facing repository monitors. |
+| `extmsg` | ExtMsgConfig |  |  | ExtMsg configures the external-messaging fabric (default routes for inbound conversations with no binding). |
 | `agent_defaults` | AgentDefaults |  |  | AgentDefaults provides root city defaults for agents that don't override them (canonical TOML key: agent_defaults). Pack-local defaults use the same table shape in pack.toml. The runtime currently applies provider, default_sling_formula, and append_fragments; the attachment-list fields remain tombstones, and the other fields are parsed/composed but not yet inherited automatically. |
 | `pricing` | []ModelPricing |  |  | Pricing holds per-model cost rate overrides keyed by (provider, model). City-level entries override pack-level entries which override the defaults shipped with the pricing package. See internal/pricing for the estimation seam introduced by issue #1255 (1d). |
 
@@ -384,6 +385,24 @@ EventsRotationConfig holds file-backed events rotation settings.
 | `check_interval_records` | integer |  | `1024` | CheckIntervalRecords is the number of records between size checks. Defaults to DefaultEventsRotationCheckIntervalRecords. |
 | `check_interval_seconds` | integer |  | `60` | CheckIntervalSeconds is the time backstop between size checks. Defaults to DefaultEventsRotationCheckIntervalSeconds. |
 | `archive_retain_age` | string |  |  | ArchiveRetainAge is an optional Go duration. Empty keeps all archives. |
+
+## ExtMsgConfig
+
+ExtMsgConfig configures the external-messaging fabric.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `default_route` | []ExtMsgDefaultRoute |  |  | DefaultRoutes map inbound conversations that have no binding and no group route to a configured agent, keyed by provider and optionally narrowed to one adapter account. The first matching inbound message binds the conversation to the agent (an agent-name binding), so the route is sticky until rebound or unbound. |
+
+## ExtMsgDefaultRoute
+
+ExtMsgDefaultRoute routes unbound inbound conversations from one external messaging provider (and optionally a single adapter account) to a configured agent.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `provider` | string | **yes** |  | Provider is the external messaging provider name as registered by the adapter (e.g. "telegram"). Required. |
+| `account_id` | string |  |  | AccountID narrows the route to one adapter account. Empty matches every account of the provider that has no account-specific route. |
+| `agent` | string | **yes** |  | Agent is the configured agent identity to route to. It must resolve to a configured named session so the delivery layer can cold-wake a session for it. |
 
 ## FormulasConfig
 

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1169,6 +1169,10 @@
           "$ref": "#/$defs/GitHubConfig",
           "description": "GitHub configures GitHub-facing repository monitors."
         },
+        "extmsg": {
+          "$ref": "#/$defs/ExtMsgConfig",
+          "description": "ExtMsg configures the external-messaging fabric (default routes\nfor inbound conversations with no binding)."
+        },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
           "description": "AgentDefaults provides root city defaults for agents that don't override\nthem (canonical TOML key: agent_defaults). Pack-local defaults use the\nsame table shape in pack.toml. The runtime currently applies provider,\ndefault_sling_formula, and append_fragments; the attachment-list fields\nremain tombstones, and the other fields are parsed/composed but not yet\ninherited automatically."
@@ -1478,6 +1482,43 @@
       "additionalProperties": false,
       "type": "object",
       "description": "EventsRotationConfig holds file-backed events rotation settings."
+    },
+    "ExtMsgConfig": {
+      "properties": {
+        "default_route": {
+          "items": {
+            "$ref": "#/$defs/ExtMsgDefaultRoute"
+          },
+          "type": "array",
+          "description": "DefaultRoutes map inbound conversations that have no binding and no\ngroup route to a configured agent, keyed by provider and optionally\nnarrowed to one adapter account. The first matching inbound message\nbinds the conversation to the agent (an agent-name binding), so the\nroute is sticky until rebound or unbound."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ExtMsgConfig configures the external-messaging fabric."
+    },
+    "ExtMsgDefaultRoute": {
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Provider is the external messaging provider name as registered by\nthe adapter (e.g. \"telegram\"). Required."
+        },
+        "account_id": {
+          "type": "string",
+          "description": "AccountID narrows the route to one adapter account. Empty matches\nevery account of the provider that has no account-specific route."
+        },
+        "agent": {
+          "type": "string",
+          "description": "Agent is the configured agent identity to route to. It must resolve\nto a configured named session so the delivery layer can cold-wake a\nsession for it."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "provider",
+        "agent"
+      ],
+      "description": "ExtMsgDefaultRoute routes unbound inbound conversations from one external messaging provider (and optionally a single adapter account) to a configured agent."
     },
     "FormulasConfig": {
       "properties": {},

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1169,6 +1169,10 @@
           "$ref": "#/$defs/GitHubConfig",
           "description": "GitHub configures GitHub-facing repository monitors."
         },
+        "extmsg": {
+          "$ref": "#/$defs/ExtMsgConfig",
+          "description": "ExtMsg configures the external-messaging fabric (default routes\nfor inbound conversations with no binding)."
+        },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
           "description": "AgentDefaults provides root city defaults for agents that don't override\nthem (canonical TOML key: agent_defaults). Pack-local defaults use the\nsame table shape in pack.toml. The runtime currently applies provider,\ndefault_sling_formula, and append_fragments; the attachment-list fields\nremain tombstones, and the other fields are parsed/composed but not yet\ninherited automatically."
@@ -1478,6 +1482,43 @@
       "additionalProperties": false,
       "type": "object",
       "description": "EventsRotationConfig holds file-backed events rotation settings."
+    },
+    "ExtMsgConfig": {
+      "properties": {
+        "default_route": {
+          "items": {
+            "$ref": "#/$defs/ExtMsgDefaultRoute"
+          },
+          "type": "array",
+          "description": "DefaultRoutes map inbound conversations that have no binding and no\ngroup route to a configured agent, keyed by provider and optionally\nnarrowed to one adapter account. The first matching inbound message\nbinds the conversation to the agent (an agent-name binding), so the\nroute is sticky until rebound or unbound."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ExtMsgConfig configures the external-messaging fabric."
+    },
+    "ExtMsgDefaultRoute": {
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Provider is the external messaging provider name as registered by\nthe adapter (e.g. \"telegram\"). Required."
+        },
+        "account_id": {
+          "type": "string",
+          "description": "AccountID narrows the route to one adapter account. Empty matches\nevery account of the provider that has no account-specific route."
+        },
+        "agent": {
+          "type": "string",
+          "description": "Agent is the configured agent identity to route to. It must resolve\nto a configured named session so the delivery layer can cold-wake a\nsession for it."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "provider",
+        "agent"
+      ],
+      "description": "ExtMsgDefaultRoute routes unbound inbound conversations from one external messaging provider (and optionally a single adapter account) to a configured agent."
     },
     "FormulasConfig": {
       "properties": {},

--- a/internal/api/handler_extmsg.go
+++ b/internal/api/handler_extmsg.go
@@ -41,6 +41,32 @@ func (s *Server) extmsgEmitEvent() func(string, string, events.Payload) {
 	}
 }
 
+// extmsgDefaultAgentForConversation builds the InboundDeps default-route
+// resolver from [[extmsg.default_route]] config: it maps an unrouted
+// inbound conversation to the qualified identity of the configured agent.
+// A route naming an agent that does not resolve to a configured named
+// session is logged and skipped — the message stays unrouted rather than
+// failing the inbound on a config error.
+func (s *Server) extmsgDefaultAgentForConversation() func(extmsg.ConversationRef) string {
+	cfg := s.state.Config()
+	if cfg == nil || len(cfg.ExtMsg.DefaultRoutes) == 0 {
+		return nil
+	}
+	store := s.state.CityBeadStore()
+	return func(ref extmsg.ConversationRef) string {
+		agent := cfg.ExtMsgDefaultRouteAgent(ref.Provider, ref.AccountID)
+		if agent == "" {
+			return ""
+		}
+		spec, ok, err := s.findNamedSessionSpecForTarget(store, agent)
+		if err != nil || !ok {
+			log.Printf("extmsg: default-route agent %q for %s/%s does not resolve to a configured named session (err=%v)", agent, ref.Provider, ref.AccountID, err)
+			return ""
+		}
+		return spec.Identity
+	}
+}
+
 // extmsgResolveSessionSelector builds the OutboundDeps session-selector
 // resolver: it maps a selector — a configured agent identity, session name,
 // alias, or concrete session bead ID — to the concrete ID of a live session,

--- a/internal/api/handler_extmsg_default_route_test.go
+++ b/internal/api/handler_extmsg_default_route_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/extmsg"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+func TestHandleExtMsgInboundDefaultRouteBindsAndColdWakes(t *testing.T) {
+	fs, srv, services, ref := newExtMsgAgentBindingFixture(t)
+	fs.cfg.ExtMsg = config.ExtMsgConfig{
+		DefaultRoutes: []config.ExtMsgDefaultRoute{
+			{Provider: "discord", Agent: "myrig/worker"},
+		},
+	}
+
+	if _, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil {
+		t.Fatal("named agent should not have a session before the inbound message")
+	}
+
+	rec := postExtMsg(t, fs, srv, "/extmsg/inbound", map[string]any{
+		"message": map[string]any{
+			"provider_message_id": "msg-default-1",
+			"conversation":        conversationBody(ref),
+			"actor":               map[string]any{"id": "user-1", "display_name": "User One", "is_bot": false},
+			"text":                "hello, is anyone responsible for this chat?",
+			"received_at":         time.Now().UTC().Format(time.RFC3339),
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var result extmsg.InboundResult
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode inbound result: %v", err)
+	}
+	if result.TargetAgentName != "myrig/worker" {
+		t.Fatalf("TargetAgentName = %q, want myrig/worker", result.TargetAgentName)
+	}
+
+	binding, err := services.Bindings.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if binding == nil || binding.AgentName != "myrig/worker" {
+		t.Fatalf("binding = %#v, want sticky agent binding myrig/worker", binding)
+	}
+
+	// The notify fan-out cold-wakes the routed agent's named session.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if id, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil && id != "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for default-routed inbound to cold-wake myrig/worker")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestHandleExtMsgInboundDefaultRouteUnknownAgentStaysUnbound(t *testing.T) {
+	fs, srv, services, ref := newExtMsgAgentBindingFixture(t)
+	fs.cfg.ExtMsg = config.ExtMsgConfig{
+		DefaultRoutes: []config.ExtMsgDefaultRoute{
+			{Provider: "discord", Agent: "myrig/ghost"},
+		},
+	}
+
+	rec := postExtMsg(t, fs, srv, "/extmsg/inbound", map[string]any{
+		"message": map[string]any{
+			"provider_message_id": "msg-default-2",
+			"conversation":        conversationBody(ref),
+			"actor":               map[string]any{"id": "user-1", "display_name": "User One", "is_bot": false},
+			"text":                "hello?",
+			"received_at":         time.Now().UTC().Format(time.RFC3339),
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var result extmsg.InboundResult
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode inbound result: %v", err)
+	}
+	if result.TargetSessionID != "" || result.TargetAgentName != "" {
+		t.Fatalf("result routed (%q/%q), want unrouted on unresolvable route agent", result.TargetSessionID, result.TargetAgentName)
+	}
+	binding, err := services.Bindings.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if binding != nil {
+		t.Fatalf("binding = %#v, want none for unresolvable route agent", binding)
+	}
+}

--- a/internal/api/handler_extmsg_default_route_test.go
+++ b/internal/api/handler_extmsg_default_route_test.go
@@ -65,6 +65,50 @@ func TestHandleExtMsgInboundDefaultRouteBindsAndColdWakes(t *testing.T) {
 	}
 }
 
+func TestHandleExtMsgInboundDefaultRouteMatchesMixedCaseProvider(t *testing.T) {
+	fs, srv, services, ref := newExtMsgAgentBindingFixture(t)
+	fs.cfg.ExtMsg = config.ExtMsgConfig{
+		DefaultRoutes: []config.ExtMsgDefaultRoute{
+			{Provider: "discord", Agent: "myrig/worker"},
+		},
+	}
+
+	// The inbound conversation carries a mixed-case provider ("Discord"),
+	// which extmsg canonicalizes to lowercase. The default-route lookup must
+	// match the lowercase configured route regardless of the incoming casing,
+	// otherwise the conversation stays unrouted.
+	mixedCase := ref
+	mixedCase.Provider = "Discord"
+
+	rec := postExtMsg(t, fs, srv, "/extmsg/inbound", map[string]any{
+		"message": map[string]any{
+			"provider_message_id": "msg-default-mixedcase-1",
+			"conversation":        conversationBody(mixedCase),
+			"actor":               map[string]any{"id": "user-1", "display_name": "User One", "is_bot": false},
+			"text":                "hello from a mixed-case provider",
+			"received_at":         time.Now().UTC().Format(time.RFC3339),
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var result extmsg.InboundResult
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode inbound result: %v", err)
+	}
+	if result.TargetAgentName != "myrig/worker" {
+		t.Fatalf("TargetAgentName = %q, want myrig/worker (mixed-case provider must match lowercase route)", result.TargetAgentName)
+	}
+
+	binding, err := services.Bindings.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if binding == nil || binding.AgentName != "myrig/worker" {
+		t.Fatalf("binding = %#v, want sticky agent binding myrig/worker", binding)
+	}
+}
+
 func TestHandleExtMsgInboundDefaultRouteUnknownAgentStaysUnbound(t *testing.T) {
 	fs, srv, services, ref := newExtMsgAgentBindingFixture(t)
 	fs.cfg.ExtMsg = config.ExtMsgConfig{

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -49,9 +49,10 @@ func (s *Server) humaHandleExtMsgInbound(ctx context.Context, input *ExtMsgInbou
 	}
 
 	deps := extmsg.InboundDeps{
-		Services:  *svc,
-		Registry:  reg,
-		EmitEvent: s.extmsgEmitEvent(),
+		Services:                    *svc,
+		Registry:                    reg,
+		EmitEvent:                   s.extmsgEmitEvent(),
+		DefaultAgentForConversation: s.extmsgDefaultAgentForConversation(),
 	}
 
 	// Pre-normalized path.

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -1031,8 +1031,8 @@ func mergeFragment(base, fragment *City, fragMeta toml.MetaData, fragPath string
 	if fragMeta.IsDefined("orders") {
 		base.Orders = fragment.Orders
 	}
-	if fragMeta.IsDefined("extmsg") {
-		base.ExtMsg = fragment.ExtMsg
+	if fragMeta.IsDefined("extmsg", "default_route") {
+		base.ExtMsg.DefaultRoutes = append(base.ExtMsg.DefaultRoutes, fragment.ExtMsg.DefaultRoutes...)
 	}
 	if fragMeta.IsDefined("api") {
 		base.API = fragment.API

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -1031,6 +1031,9 @@ func mergeFragment(base, fragment *City, fragMeta toml.MetaData, fragPath string
 	if fragMeta.IsDefined("orders") {
 		base.Orders = fragment.Orders
 	}
+	if fragMeta.IsDefined("extmsg") {
+		base.ExtMsg = fragment.ExtMsg
+	}
 	if fragMeta.IsDefined("api") {
 		base.API = fragment.API
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,6 +284,9 @@ type City struct {
 	Services []Service `toml:"service,omitempty"`
 	// GitHub configures GitHub-facing repository monitors.
 	GitHub GitHubConfig `toml:"github,omitempty"`
+	// ExtMsg configures the external-messaging fabric (default routes
+	// for inbound conversations with no binding).
+	ExtMsg ExtMsgConfig `toml:"extmsg,omitempty"`
 	// AgentDefaults provides root city defaults for agents that don't override
 	// them (canonical TOML key: agent_defaults). Pack-local defaults use the
 	// same table shape in pack.toml. The runtime currently applies provider,

--- a/internal/config/extmsg.go
+++ b/internal/config/extmsg.go
@@ -1,0 +1,56 @@
+package config
+
+import "strings"
+
+// ExtMsgConfig configures the external-messaging fabric.
+type ExtMsgConfig struct {
+	// DefaultRoutes map inbound conversations that have no binding and no
+	// group route to a configured agent, keyed by provider and optionally
+	// narrowed to one adapter account. The first matching inbound message
+	// binds the conversation to the agent (an agent-name binding), so the
+	// route is sticky until rebound or unbound.
+	DefaultRoutes []ExtMsgDefaultRoute `toml:"default_route,omitempty"`
+}
+
+// ExtMsgDefaultRoute routes unbound inbound conversations from one external
+// messaging provider (and optionally a single adapter account) to a
+// configured agent. The agent decides what to do with the conversation;
+// the route is pure transport.
+type ExtMsgDefaultRoute struct {
+	// Provider is the external messaging provider name as registered by
+	// the adapter (e.g. "telegram"). Required.
+	Provider string `toml:"provider"`
+	// AccountID narrows the route to one adapter account. Empty matches
+	// every account of the provider that has no account-specific route.
+	AccountID string `toml:"account_id,omitempty"`
+	// Agent is the configured agent identity to route to. It must resolve
+	// to a configured named session so the delivery layer can cold-wake a
+	// session for it.
+	Agent string `toml:"agent"`
+}
+
+// ExtMsgDefaultRouteAgent returns the configured default agent for inbound
+// conversations of (provider, accountID), or "" when no route matches. An
+// account-specific route takes precedence over the provider-wide route
+// (empty account_id); account-specific routes never match other accounts.
+func (c *City) ExtMsgDefaultRouteAgent(provider, accountID string) string {
+	provider = strings.TrimSpace(provider)
+	accountID = strings.TrimSpace(accountID)
+	if provider == "" {
+		return ""
+	}
+	providerWide := ""
+	for i := range c.ExtMsg.DefaultRoutes {
+		route := &c.ExtMsg.DefaultRoutes[i]
+		if strings.TrimSpace(route.Provider) != provider {
+			continue
+		}
+		switch strings.TrimSpace(route.AccountID) {
+		case accountID:
+			return strings.TrimSpace(route.Agent)
+		case "":
+			providerWide = strings.TrimSpace(route.Agent)
+		}
+	}
+	return providerWide
+}

--- a/internal/config/extmsg.go
+++ b/internal/config/extmsg.go
@@ -33,8 +33,15 @@ type ExtMsgDefaultRoute struct {
 // conversations of (provider, accountID), or "" when no route matches. An
 // account-specific route takes precedence over the provider-wide route
 // (empty account_id); account-specific routes never match other accounts.
+//
+// Provider names are matched case-insensitively (lowercased on both the
+// incoming and configured side) to mirror extmsg ConversationRef
+// canonicalization, so a normalized inbound posted as "Discord" still matches
+// a route configured as provider = "discord". Account IDs are matched
+// case-sensitively, also matching ConversationRef normalization, which trims
+// but does not lowercase the account ID.
 func (c *City) ExtMsgDefaultRouteAgent(provider, accountID string) string {
-	provider = strings.TrimSpace(provider)
+	provider = strings.ToLower(strings.TrimSpace(provider))
 	accountID = strings.TrimSpace(accountID)
 	if provider == "" {
 		return ""
@@ -42,7 +49,7 @@ func (c *City) ExtMsgDefaultRouteAgent(provider, accountID string) string {
 	providerWide := ""
 	for i := range c.ExtMsg.DefaultRoutes {
 		route := &c.ExtMsg.DefaultRoutes[i]
-		if strings.TrimSpace(route.Provider) != provider {
+		if strings.ToLower(strings.TrimSpace(route.Provider)) != provider {
 			continue
 		}
 		switch strings.TrimSpace(route.AccountID) {

--- a/internal/config/extmsg_config_test.go
+++ b/internal/config/extmsg_config_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestLoadParsesExtMsgDefaultRoutes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "city.toml")
+	content := `[workspace]
+name = "test"
+
+[[extmsg.default_route]]
+provider = "telegram"
+agent = "myrig/frontdesk"
+
+[[extmsg.default_route]]
+provider = "telegram"
+account_id = "ops"
+agent = "myrig/operator"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.ExtMsg.DefaultRoutes) != 2 {
+		t.Fatalf("len(DefaultRoutes) = %d, want 2", len(cfg.ExtMsg.DefaultRoutes))
+	}
+	if cfg.ExtMsg.DefaultRoutes[0].Provider != "telegram" || cfg.ExtMsg.DefaultRoutes[0].Agent != "myrig/frontdesk" {
+		t.Fatalf("DefaultRoutes[0] = %#v", cfg.ExtMsg.DefaultRoutes[0])
+	}
+	if cfg.ExtMsg.DefaultRoutes[1].AccountID != "ops" {
+		t.Fatalf("DefaultRoutes[1] = %#v", cfg.ExtMsg.DefaultRoutes[1])
+	}
+}
+
+func TestExtMsgDefaultRouteAgentPrecedence(t *testing.T) {
+	cfg := &City{
+		ExtMsg: ExtMsgConfig{
+			DefaultRoutes: []ExtMsgDefaultRoute{
+				{Provider: "telegram", Agent: "myrig/frontdesk"},
+				{Provider: "telegram", AccountID: "ops", Agent: "myrig/operator"},
+				{Provider: "discord", AccountID: "main", Agent: "myrig/helper"},
+			},
+		},
+	}
+
+	// Exact (provider, account) match wins over the provider-wide route.
+	if got := cfg.ExtMsgDefaultRouteAgent("telegram", "ops"); got != "myrig/operator" {
+		t.Fatalf("agent(telegram, ops) = %q, want myrig/operator", got)
+	}
+	// Other accounts fall back to the provider-wide route.
+	if got := cfg.ExtMsgDefaultRouteAgent("telegram", "default"); got != "myrig/frontdesk" {
+		t.Fatalf("agent(telegram, default) = %q, want myrig/frontdesk", got)
+	}
+	// Account-scoped routes do not match other accounts of the provider.
+	if got := cfg.ExtMsgDefaultRouteAgent("discord", "other"); got != "" {
+		t.Fatalf("agent(discord, other) = %q, want empty", got)
+	}
+	if got := cfg.ExtMsgDefaultRouteAgent("slack", "default"); got != "" {
+		t.Fatalf("agent(slack, default) = %q, want empty", got)
+	}
+
+	var empty City
+	if got := empty.ExtMsgDefaultRouteAgent("telegram", "default"); got != "" {
+		t.Fatalf("agent on empty config = %q, want empty", got)
+	}
+}

--- a/internal/config/extmsg_config_test.go
+++ b/internal/config/extmsg_config_test.go
@@ -73,3 +73,33 @@ func TestExtMsgDefaultRouteAgentPrecedence(t *testing.T) {
 		t.Fatalf("agent on empty config = %q, want empty", got)
 	}
 }
+
+func TestExtMsgDefaultRouteAgentNormalizesProviderCase(t *testing.T) {
+	cfg := &City{
+		ExtMsg: ExtMsgConfig{
+			DefaultRoutes: []ExtMsgDefaultRoute{
+				{Provider: "Discord", Agent: "myrig/helper"},
+				{Provider: "telegram", AccountID: "Ops", Agent: "myrig/operator"},
+			},
+		},
+	}
+
+	// Provider matching is case-insensitive on both sides, mirroring extmsg
+	// ConversationRef canonicalization: a normalized inbound posted as
+	// "discord"/"DISCORD" must match the route configured as "Discord".
+	if got := cfg.ExtMsgDefaultRouteAgent("discord", "any"); got != "myrig/helper" {
+		t.Fatalf("agent(discord, any) = %q, want myrig/helper", got)
+	}
+	if got := cfg.ExtMsgDefaultRouteAgent("DISCORD", "any"); got != "myrig/helper" {
+		t.Fatalf("agent(DISCORD, any) = %q, want myrig/helper", got)
+	}
+
+	// Account IDs stay case-sensitive (ConversationRef trims but does not
+	// lowercase account_id), so only the exact-case account matches its route.
+	if got := cfg.ExtMsgDefaultRouteAgent("Telegram", "Ops"); got != "myrig/operator" {
+		t.Fatalf("agent(Telegram, Ops) = %q, want myrig/operator", got)
+	}
+	if got := cfg.ExtMsgDefaultRouteAgent("telegram", "ops"); got != "" {
+		t.Fatalf("agent(telegram, ops) = %q, want empty (account_id is case-sensitive)", got)
+	}
+}

--- a/internal/config/loader_coverage_test.go
+++ b/internal/config/loader_coverage_test.go
@@ -54,6 +54,39 @@ mode = "on_demand"
 	}
 }
 
+func TestLoadWithIncludes_AppendExtMsgDefaultRoutes(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+include = ["extra.toml"]
+
+[workspace]
+name = "test"
+
+[[extmsg.default_route]]
+provider = "telegram"
+agent = "myrig/frontdesk"
+`)
+	fs.Files["/city/extra.toml"] = []byte(`
+[[extmsg.default_route]]
+provider = "telegram"
+account_id = "ops"
+agent = "myrig/operator"
+`)
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.ExtMsg.DefaultRoutes) != 2 {
+		t.Fatalf("len(DefaultRoutes) = %d, want 2", len(cfg.ExtMsg.DefaultRoutes))
+	}
+	if got := cfg.ExtMsgDefaultRouteAgent("telegram", "ops"); got != "myrig/operator" {
+		t.Fatalf("ExtMsgDefaultRouteAgent(telegram, ops) = %q, want myrig/operator", got)
+	}
+	if got := cfg.ExtMsgDefaultRouteAgent("telegram", "default"); got != "myrig/frontdesk" {
+		t.Fatalf("ExtMsgDefaultRouteAgent(telegram, default) = %q, want myrig/frontdesk", got)
+	}
+}
+
 func TestLoadWithIncludesLocalOnlyDoesNotRequireHome(t *testing.T) {
 	t.Setenv("HOME", "")
 	t.Setenv("USERPROFILE", "")

--- a/internal/extmsg/default_route_test.go
+++ b/internal/extmsg/default_route_test.go
@@ -1,0 +1,135 @@
+package extmsg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func defaultRouteTestMessage(ref ConversationRef) ExternalInboundMessage {
+	return ExternalInboundMessage{
+		Conversation: ref,
+		Actor:        ExternalActor{ID: "user-1", DisplayName: "User One"},
+		Text:         "anyone home?",
+		ReceivedAt:   testNow(),
+	}
+}
+
+func TestHandleInboundNormalizedDefaultRouteBindsConfiguredAgent(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	ref := testConversationRef()
+
+	deps := InboundDeps{
+		Services: fabric,
+		DefaultAgentForConversation: func(got ConversationRef) string {
+			if !sameConversationRef(got, ref) {
+				t.Fatalf("resolver called with %#v, want %#v", got, ref)
+			}
+			return "myrig/frontdesk"
+		},
+	}
+	result, err := HandleInboundNormalized(context.Background(), deps, defaultRouteTestMessage(ref))
+	if err != nil {
+		t.Fatalf("HandleInboundNormalized: %v", err)
+	}
+	if result.TargetAgentName != "myrig/frontdesk" {
+		t.Fatalf("TargetAgentName = %q, want myrig/frontdesk", result.TargetAgentName)
+	}
+	if result.Binding == nil || result.Binding.AgentName != "myrig/frontdesk" {
+		t.Fatalf("Binding = %#v, want agent binding myrig/frontdesk", result.Binding)
+	}
+	if result.TranscriptEntry == nil {
+		t.Fatalf("TranscriptEntry = nil, want inbound appended after default route")
+	}
+
+	// The default route is sticky: a durable agent binding now exists, so
+	// the next inbound routes through it without consulting the resolver.
+	binding, err := fabric.Bindings.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if binding == nil || binding.AgentName != "myrig/frontdesk" {
+		t.Fatalf("persisted binding = %#v, want agent binding", binding)
+	}
+	deps.DefaultAgentForConversation = func(ConversationRef) string {
+		t.Fatal("resolver consulted for an already-bound conversation")
+		return ""
+	}
+	again, err := HandleInboundNormalized(context.Background(), deps, defaultRouteTestMessage(ref))
+	if err != nil {
+		t.Fatalf("HandleInboundNormalized(second): %v", err)
+	}
+	if again.TargetAgentName != "myrig/frontdesk" {
+		t.Fatalf("second TargetAgentName = %q, want myrig/frontdesk", again.TargetAgentName)
+	}
+}
+
+func TestHandleInboundNormalizedDefaultRouteAbsentPreservesUnbound(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	ref := testConversationRef()
+
+	// No resolver wired (config absent) — unrouted, no binding created.
+	result, err := HandleInboundNormalized(context.Background(), InboundDeps{Services: fabric}, defaultRouteTestMessage(ref))
+	if err != nil {
+		t.Fatalf("HandleInboundNormalized: %v", err)
+	}
+	if result.TargetSessionID != "" || result.TargetAgentName != "" {
+		t.Fatalf("result routed (%q/%q), want unrouted", result.TargetSessionID, result.TargetAgentName)
+	}
+
+	// Resolver wired but no route for this conversation — same.
+	deps := InboundDeps{
+		Services:                    fabric,
+		DefaultAgentForConversation: func(ConversationRef) string { return "" },
+	}
+	result, err = HandleInboundNormalized(context.Background(), deps, defaultRouteTestMessage(ref))
+	if err != nil {
+		t.Fatalf("HandleInboundNormalized(empty route): %v", err)
+	}
+	if result.TargetSessionID != "" || result.TargetAgentName != "" {
+		t.Fatalf("result routed (%q/%q), want unrouted", result.TargetSessionID, result.TargetAgentName)
+	}
+	binding, err := fabric.Bindings.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if binding != nil {
+		t.Fatalf("binding = %#v, want none", binding)
+	}
+}
+
+func TestHandleInboundNormalizedDefaultRouteConflictAdoptsExistingBinding(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	ref := testConversationRef()
+
+	// The resolver simulates a concurrent racer: by the time the default
+	// route tries to bind, a session binding already exists. The pipeline
+	// must adopt the active binding instead of failing the inbound.
+	deps := InboundDeps{
+		Services: fabric,
+		DefaultAgentForConversation: func(ConversationRef) string {
+			if _, err := fabric.Bindings.Bind(context.Background(), testControllerCaller(), BindInput{
+				Conversation: ref,
+				SessionID:    "sess-racer",
+				Now:          testNow(),
+			}); err != nil {
+				t.Fatalf("racer Bind: %v", err)
+			}
+			return "myrig/frontdesk"
+		},
+	}
+	result, err := HandleInboundNormalized(context.Background(), deps, defaultRouteTestMessage(ref))
+	if err != nil {
+		t.Fatalf("HandleInboundNormalized: %v", err)
+	}
+	if result.TargetSessionID != "sess-racer" || result.TargetAgentName != "" {
+		t.Fatalf("result = %q/%q, want racer session binding adopted", result.TargetSessionID, result.TargetAgentName)
+	}
+}

--- a/internal/extmsg/default_route_test.go
+++ b/internal/extmsg/default_route_test.go
@@ -103,6 +103,137 @@ func TestHandleInboundNormalizedDefaultRouteAbsentPreservesUnbound(t *testing.T)
 	}
 }
 
+func TestHandleInboundNormalizedDefaultRouteSkipsGroupedConversation(t *testing.T) {
+	freezeTestClock(t)
+
+	cases := []struct {
+		// name describes the grouped routing miss being exercised.
+		name string
+		// defaultHandle seeds the group's default participant; empty means the
+		// group has no routable default at all.
+		defaultHandle string
+		// message builds the inbound that misses group routing.
+		message func(ref ConversationRef) ExternalInboundMessage
+	}{
+		{
+			// A group exists with a routable default, but the message explicitly
+			// targets a handle that is not a participant.
+			name:          "explicit target miss",
+			defaultHandle: "alpha",
+			message: func(ref ConversationRef) ExternalInboundMessage {
+				msg := defaultRouteTestMessage(ref)
+				msg.ExplicitTarget = "ghost"
+				return msg
+			},
+		},
+		{
+			// A group exists but has no default or last-addressed handle, so an
+			// untargeted message routes to no participant.
+			name:          "no routable default handle",
+			defaultHandle: "",
+			message:       defaultRouteTestMessage,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			fabric := NewServices(store)
+			ref := testConversationRef()
+
+			group, err := fabric.Groups.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+				RootConversation: ref,
+				Mode:             GroupModeLauncher,
+				DefaultHandle:    tc.defaultHandle,
+			})
+			if err != nil {
+				t.Fatalf("EnsureGroup: %v", err)
+			}
+			if _, err := fabric.Groups.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+				GroupID:   group.ID,
+				Handle:    "alpha",
+				SessionID: "sess-a",
+			}); err != nil {
+				t.Fatalf("UpsertParticipant(alpha): %v", err)
+			}
+
+			deps := InboundDeps{
+				Services: fabric,
+				DefaultAgentForConversation: func(ConversationRef) string {
+					return "myrig/frontdesk"
+				},
+			}
+			result, err := HandleInboundNormalized(context.Background(), deps, tc.message(ref))
+			if err != nil {
+				t.Fatalf("HandleInboundNormalized: %v", err)
+			}
+
+			// The conversation is grouped, so a routing miss leaves it unrouted
+			// rather than handing it to the default agent.
+			if result.TargetSessionID != "" || result.TargetAgentName != "" {
+				t.Fatalf("result routed (%q/%q), want unrouted grouped miss", result.TargetSessionID, result.TargetAgentName)
+			}
+			if result.GroupRoute == nil || result.GroupRoute.Match != GroupRouteNoMatch {
+				t.Fatalf("GroupRoute = %#v, want grouped no-match", result.GroupRoute)
+			}
+
+			// No sticky default-agent binding may exist: one would resolve before
+			// group routing on every later message and permanently bypass the room.
+			binding, err := fabric.Bindings.ResolveByConversation(context.Background(), ref)
+			if err != nil {
+				t.Fatalf("ResolveByConversation: %v", err)
+			}
+			if binding != nil {
+				t.Fatalf("binding = %#v, want none (grouped conversation must not be default-routed)", binding)
+			}
+		})
+	}
+}
+
+func TestGroupServiceResolveInboundDistinguishesNoGroupFromNoMatch(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+
+	// No group for the conversation: the distinct "no group" outcome that makes
+	// the conversation eligible for a default route.
+	noGroup, err := svc.ResolveInbound(context.Background(), ExternalInboundMessage{Conversation: ref})
+	if err != nil {
+		t.Fatalf("ResolveInbound(no group): %v", err)
+	}
+	if noGroup.Match != GroupRouteNoGroup {
+		t.Fatalf("ResolveInbound(no group).Match = %q, want %q", noGroup.Match, GroupRouteNoGroup)
+	}
+
+	// A group exists but yields no routable target: a grouped no-match, which
+	// stays distinct from "no group" so the default route cannot hijack the room.
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: "sess-a",
+	}); err != nil {
+		t.Fatalf("UpsertParticipant(alpha): %v", err)
+	}
+	noMatch, err := svc.ResolveInbound(context.Background(), ExternalInboundMessage{
+		Conversation:   ref,
+		ExplicitTarget: "ghost",
+	})
+	if err != nil {
+		t.Fatalf("ResolveInbound(grouped miss): %v", err)
+	}
+	if noMatch.Match != GroupRouteNoMatch {
+		t.Fatalf("ResolveInbound(grouped miss).Match = %q, want %q", noMatch.Match, GroupRouteNoMatch)
+	}
+}
+
 func TestHandleInboundNormalizedDefaultRouteConflictAdoptsExistingBinding(t *testing.T) {
 	freezeTestClock(t)
 	store := beads.NewMemStore()

--- a/internal/extmsg/group_service.go
+++ b/internal/extmsg/group_service.go
@@ -348,7 +348,7 @@ func (s *groupService) ResolveInbound(ctx context.Context, event ExternalInbound
 		return nil, err
 	}
 	if group == nil {
-		return &GroupRouteDecision{Match: GroupRouteNoMatch}, nil
+		return &GroupRouteDecision{Match: GroupRouteNoGroup}, nil
 	}
 	participants, err := s.listParticipants(group.ID)
 	if err != nil {

--- a/internal/extmsg/inbound.go
+++ b/internal/extmsg/inbound.go
@@ -40,17 +40,64 @@ func (r *InboundResult) routed() bool {
 // InboundDeps bundles the dependencies for inbound processing.
 // The caller (HTTP handler) assembles deps from api.State, keeping
 // the orchestrator independent of the State interface.
+//
+// DefaultAgentForConversation returns the configured default agent
+// identity for an inbound conversation that resolved to no binding and
+// no group route ("" = no route configured). The API layer supplies the
+// config lookup; extmsg stays config-free. When it names an agent, the
+// pipeline binds the conversation to that agent (a sticky agent-name
+// binding) and routes the message to it.
 type InboundDeps struct {
-	Services  Services
-	Registry  *AdapterRegistry
-	EmitEvent func(eventType, subject string, payload events.Payload)
+	Services                    Services
+	Registry                    *AdapterRegistry
+	EmitEvent                   func(eventType, subject string, payload events.Payload)
+	DefaultAgentForConversation func(ref ConversationRef) string
+}
+
+// applyDefaultRoute binds an unrouted conversation to its configured
+// default agent and marks the result as routed to it. A concurrent bind
+// races benignly: on conflict the freshly active binding wins, whatever
+// its kind.
+func applyDefaultRoute(ctx context.Context, deps InboundDeps, result *InboundResult, ref ConversationRef, now time.Time) error {
+	if deps.DefaultAgentForConversation == nil {
+		return nil
+	}
+	agentName := deps.DefaultAgentForConversation(ref)
+	if agentName == "" {
+		return nil
+	}
+	caller := Caller{Kind: CallerController, ID: "extmsg-default-route"}
+	binding, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: ref,
+		AgentName:    agentName,
+		Now:          now,
+	})
+	if err != nil {
+		if !errors.Is(err, ErrBindingConflict) {
+			return fmt.Errorf("binding default-route agent %q: %w", agentName, err)
+		}
+		active, rerr := deps.Services.Bindings.ResolveByConversation(ctx, ref)
+		if rerr != nil {
+			return fmt.Errorf("resolving binding after default-route conflict: %w", rerr)
+		}
+		if active == nil {
+			return nil
+		}
+		result.Binding = active
+		result.TargetSessionID = active.SessionID
+		result.TargetAgentName = active.AgentName
+		return nil
+	}
+	result.Binding = &binding
+	result.TargetAgentName = binding.AgentName
+	return nil
 }
 
 // HandleInbound processes a raw inbound payload through the full pipeline:
 //  1. Look up adapter by key.
 //  2. Verify and normalize the payload.
 //  3. Resolve binding for the conversation.
-//  4. If no binding, try group routing.
+//  4. If no binding, try group routing, then the configured default route.
 //  5. Append to transcript.
 //  6. Nudge all conversation members (not just the target).
 //  7. Emit event.
@@ -88,18 +135,26 @@ func HandleInbound(ctx context.Context, deps InboundDeps, key AdapterKey, payloa
 		result.TargetAgentName = binding.AgentName
 	}
 
-	// Step 4: If no binding, try group routing.
+	// Step 4: If no binding, try group routing, then the default route.
 	if !result.routed() {
 		route, err := deps.Services.Groups.ResolveInbound(ctx, *msg)
 		if err != nil {
 			if !errors.Is(err, ErrGroupNotFound) && !errors.Is(err, ErrGroupRouteNotFound) {
 				return nil, fmt.Errorf("resolving group route: %w", err)
 			}
-			// No binding and no group route — return result with empty target.
-			return result, nil
+		} else {
+			result.GroupRoute = route
+			result.TargetSessionID = route.TargetSessionID
 		}
-		result.GroupRoute = route
-		result.TargetSessionID = route.TargetSessionID
+	}
+	if !result.routed() {
+		if err := applyDefaultRoute(ctx, deps, result, msg.Conversation, msg.ReceivedAt); err != nil {
+			return nil, err
+		}
+	}
+	if !result.routed() {
+		// No binding, no group route, no default route — empty target.
+		return result, nil
 	}
 
 	// Step 5: Append to transcript.
@@ -172,17 +227,26 @@ func HandleInboundNormalized(ctx context.Context, deps InboundDeps, msg External
 		result.TargetAgentName = binding.AgentName
 	}
 
-	// Step 2: If no binding, try group routing.
+	// Step 2: If no binding, try group routing, then the default route.
 	if !result.routed() {
 		route, err := deps.Services.Groups.ResolveInbound(ctx, msg)
 		if err != nil {
 			if !errors.Is(err, ErrGroupNotFound) && !errors.Is(err, ErrGroupRouteNotFound) {
 				return nil, fmt.Errorf("resolving group route: %w", err)
 			}
-			return result, nil
+		} else {
+			result.GroupRoute = route
+			result.TargetSessionID = route.TargetSessionID
 		}
-		result.GroupRoute = route
-		result.TargetSessionID = route.TargetSessionID
+	}
+	if !result.routed() {
+		if err := applyDefaultRoute(ctx, deps, result, msg.Conversation, now); err != nil {
+			return nil, err
+		}
+	}
+	if !result.routed() {
+		// No binding, no group route, no default route — empty target.
+		return result, nil
 	}
 
 	// Step 3: Append to transcript.

--- a/internal/extmsg/inbound.go
+++ b/internal/extmsg/inbound.go
@@ -42,11 +42,13 @@ func (r *InboundResult) routed() bool {
 // the orchestrator independent of the State interface.
 //
 // DefaultAgentForConversation returns the configured default agent
-// identity for an inbound conversation that resolved to no binding and
-// no group route ("" = no route configured). The API layer supplies the
-// config lookup; extmsg stays config-free. When it names an agent, the
-// pipeline binds the conversation to that agent (a sticky agent-name
-// binding) and routes the message to it.
+// identity for an inbound conversation that has no binding and belongs to
+// no group ("" = no route configured). The API layer supplies the config
+// lookup; extmsg stays config-free. When it names an agent, the pipeline
+// binds the conversation to that agent (a sticky agent-name binding) and
+// routes the message to it. A grouped conversation is never default-routed,
+// even when its own routing finds no target, so the sticky binding cannot
+// shadow the room.
 type InboundDeps struct {
 	Services                    Services
 	Registry                    *AdapterRegistry
@@ -54,10 +56,11 @@ type InboundDeps struct {
 	DefaultAgentForConversation func(ref ConversationRef) string
 }
 
-// applyDefaultRoute binds an unrouted conversation to its configured
-// default agent and marks the result as routed to it. A concurrent bind
-// races benignly: on conflict the freshly active binding wins, whatever
-// its kind.
+// applyDefaultRoute binds an unrouted, ungrouped conversation to its
+// configured default agent and marks the result as routed to it. The caller
+// restricts this to conversations with no group so the sticky binding cannot
+// shadow a room's own routing. A concurrent bind races benignly: on conflict
+// the freshly active binding wins, whatever its kind.
 func applyDefaultRoute(ctx context.Context, deps InboundDeps, result *InboundResult, ref ConversationRef, now time.Time) error {
 	if deps.DefaultAgentForConversation == nil {
 		return nil
@@ -93,6 +96,54 @@ func applyDefaultRoute(ctx context.Context, deps InboundDeps, result *InboundRes
 	return nil
 }
 
+// resolveInboundTarget resolves the delivery target for an inbound message and
+// records it on result: an existing binding first, then a group route, then the
+// configured default route. result is left unrouted when nothing matches. Both
+// inbound entry points share this helper so the binding -> group -> default
+// precedence stays identical across the raw and pre-normalized paths.
+//
+// The default route applies only to conversations that belong to no group. A
+// grouped conversation whose message finds no routable participant stays
+// unrouted rather than being rebound to the default agent — a durable binding
+// there would resolve before group routing and shadow the room on every later
+// message.
+func resolveInboundTarget(ctx context.Context, deps InboundDeps, result *InboundResult, msg ExternalInboundMessage, now time.Time) error {
+	binding, err := deps.Services.Bindings.ResolveByConversation(ctx, msg.Conversation)
+	if err != nil {
+		return fmt.Errorf("resolving binding: %w", err)
+	}
+	if binding != nil {
+		result.Binding = binding
+		result.TargetSessionID = binding.SessionID
+		result.TargetAgentName = binding.AgentName
+	}
+
+	// No binding — try group routing.
+	grouped := false
+	if !result.routed() {
+		route, err := deps.Services.Groups.ResolveInbound(ctx, msg)
+		if err != nil {
+			if !errors.Is(err, ErrGroupNotFound) && !errors.Is(err, ErrGroupRouteNotFound) {
+				return fmt.Errorf("resolving group route: %w", err)
+			}
+		} else {
+			result.GroupRoute = route
+			result.TargetSessionID = route.TargetSessionID
+			grouped = route.Match != GroupRouteNoGroup
+		}
+	}
+
+	// Still no target — try the configured default route, but only for an
+	// ungrouped conversation. A grouped conversation that missed routing keeps
+	// the prior behavior of staying unrouted.
+	if !result.routed() && !grouped {
+		if err := applyDefaultRoute(ctx, deps, result, msg.Conversation, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // HandleInbound processes a raw inbound payload through the full pipeline:
 //  1. Look up adapter by key.
 //  2. Verify and normalize the payload.
@@ -123,34 +174,10 @@ func HandleInbound(ctx context.Context, deps InboundDeps, key AdapterKey, payloa
 
 	result := &InboundResult{Message: *msg}
 
-	// Step 3: Resolve binding.
-	binding, err := deps.Services.Bindings.ResolveByConversation(ctx, msg.Conversation)
-	if err != nil {
-		return nil, fmt.Errorf("resolving binding: %w", err)
-	}
-
-	if binding != nil {
-		result.Binding = binding
-		result.TargetSessionID = binding.SessionID
-		result.TargetAgentName = binding.AgentName
-	}
-
-	// Step 4: If no binding, try group routing, then the default route.
-	if !result.routed() {
-		route, err := deps.Services.Groups.ResolveInbound(ctx, *msg)
-		if err != nil {
-			if !errors.Is(err, ErrGroupNotFound) && !errors.Is(err, ErrGroupRouteNotFound) {
-				return nil, fmt.Errorf("resolving group route: %w", err)
-			}
-		} else {
-			result.GroupRoute = route
-			result.TargetSessionID = route.TargetSessionID
-		}
-	}
-	if !result.routed() {
-		if err := applyDefaultRoute(ctx, deps, result, msg.Conversation, msg.ReceivedAt); err != nil {
-			return nil, err
-		}
+	// Steps 3-4: Resolve the delivery target — existing binding, else group
+	// route, else the configured default route.
+	if err := resolveInboundTarget(ctx, deps, result, *msg, msg.ReceivedAt); err != nil {
+		return nil, err
 	}
 	if !result.routed() {
 		// No binding, no group route, no default route — empty target.
@@ -215,34 +242,10 @@ func HandleInboundNormalized(ctx context.Context, deps InboundDeps, msg External
 		now = time.Now()
 	}
 
-	// Step 1: Resolve binding.
-	binding, err := deps.Services.Bindings.ResolveByConversation(ctx, msg.Conversation)
-	if err != nil {
-		return nil, fmt.Errorf("resolving binding: %w", err)
-	}
-
-	if binding != nil {
-		result.Binding = binding
-		result.TargetSessionID = binding.SessionID
-		result.TargetAgentName = binding.AgentName
-	}
-
-	// Step 2: If no binding, try group routing, then the default route.
-	if !result.routed() {
-		route, err := deps.Services.Groups.ResolveInbound(ctx, msg)
-		if err != nil {
-			if !errors.Is(err, ErrGroupNotFound) && !errors.Is(err, ErrGroupRouteNotFound) {
-				return nil, fmt.Errorf("resolving group route: %w", err)
-			}
-		} else {
-			result.GroupRoute = route
-			result.TargetSessionID = route.TargetSessionID
-		}
-	}
-	if !result.routed() {
-		if err := applyDefaultRoute(ctx, deps, result, msg.Conversation, now); err != nil {
-			return nil, err
-		}
+	// Steps 1-2: Resolve the delivery target — existing binding, else group
+	// route, else the configured default route.
+	if err := resolveInboundTarget(ctx, deps, result, msg, now); err != nil {
+		return nil, err
 	}
 	if !result.routed() {
 		// No binding, no group route, no default route — empty target.

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -377,8 +377,15 @@ const (
 	GroupRouteLastAddressed GroupRouteMatch = "last_addressed"
 	// GroupRouteDefault means the message was routed to the default participant.
 	GroupRouteDefault GroupRouteMatch = "default"
-	// GroupRouteNoMatch means no routing match was found.
+	// GroupRouteNoMatch means a group exists for the conversation but the
+	// message matched no routable participant (an explicit target that is not a
+	// participant, or no default/last-addressed handle). The conversation is
+	// still grouped, so callers must not fall back to a non-group route.
 	GroupRouteNoMatch GroupRouteMatch = "no_match"
+	// GroupRouteNoGroup means no group exists for the conversation, so group
+	// routing did not apply. Unlike GroupRouteNoMatch, the conversation is
+	// ungrouped and is eligible for a configured default route.
+	GroupRouteNoGroup GroupRouteMatch = "no_group"
 	// GroupRouteParticipantMatch means an outbound publish was authorized
 	// because the publishing session is a participant of the group bound
 	// to the conversation.


### PR DESCRIPTION
## Summary

Routing ladder 2 (bead `ga-4uw8ee`). **Stacked on #3434** (agent-name bindings) — based on that branch so the diff shows only this slice; GitHub will retarget to `main` automatically when #3434 merges.

New `[[extmsg.default_route]]` city.toml section:

```toml
[[extmsg.default_route]]
provider = "telegram"          # required
account_id = "ops"             # optional; empty = provider-wide
agent = "myrig/frontdesk"      # configured agent identity
```

When an inbound message resolves to **no binding and no group route**, the pipeline binds the conversation to the configured agent (a sticky agent-name binding from ladder 1) and routes the message to it — the existing membership-notify path then cold-wakes a session and delivers. The agent's prompt decides what to do with the conversation (ZFC: pure config + mechanism, no role names in Go).

## Design notes

- Same layering as ladder 1: extmsg gains an injected `InboundDeps.DefaultAgentForConversation` resolver; the API layer supplies the config lookup and resolves the route agent to its **qualified named-session identity**. A route naming an unresolvable agent is logged and skipped — the message stays unrouted rather than the inbound failing on a config typo.
- Concurrent bind races benignly: on `ErrBindingConflict` the freshly active binding wins, whatever its kind (deterministic test simulates the race).
- Precedence: account-specific route beats provider-wide; account-scoped routes never match other accounts. Absent config preserves current unbound behavior exactly (tested).
- Fragment merge: `[extmsg]` is a simple last-writer-wins section like `[orders]`/`[beads]`.
- Config reference + city schema regenerated (`docs/reference/config.md`, `docs/schema/city-schema.*`). No OpenAPI/wire changes (`TestOpenAPISpecInSync` green).

## Testing

- `internal/config`: TOML parsing of the new section; precedence matrix incl. empty-config behavior.
- `internal/extmsg`: default route binds + routes + appends transcript; sticky on second message (resolver not consulted); absent/empty resolver preserves unbound with no binding created; conflict race adopts the existing binding.
- `internal/api`: e2e — unbound inbound with a configured route creates the agent binding and **cold-wakes the named session**; unresolvable route agent stays unbound with no binding.
- Full `internal/api` suite green (145s); `go vet ./...`, `golangci-lint`, `gofmt` clean.

Acceptance (ga-4uw8ee): unbound inbound routes to configured default agent ✔; absent config preserves current behavior ✔; config documented (generated reference) ✔; covered by tests ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)