### PR TITLE
feat(extmsg): handoff/bind/unbind CLI verbs + replace-bind handoff (ga-fxi5zp)

### DIFF
--- a/cmd/gc/cmd_extmsg.go
+++ b/cmd/gc/cmd_extmsg.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/api"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/extmsg"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/spf13/cobra"
+)
+
+// newExtMsgCmd groups the external-conversation binding verbs. These are
+// thin projections over the extmsg binding service via the city API —
+// there is deliberately no local fallback: conversation bindings are live
+// controller state, and mutating the bead store behind a running
+// controller's back would race its delivery pipeline.
+func newExtMsgCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "extmsg",
+		Short: "Manage external-conversation bindings",
+		Long: `Manage bindings between external conversations (telegram, discord, ...)
+and gc sessions or configured agents.
+
+A conversation bound to an agent name survives session restarts: inbound
+messages resolve a live session for the agent at delivery time, cold-waking
+one when none is live. "handoff" rebinds a conversation to another agent —
+the front-desk pattern: a default-routed agent inspects the conversation
+and hands it to the right specialist.
+
+These commands require the city API server; they have no local fallback.`,
+	}
+	cmd.AddCommand(newExtMsgBindCmd(stdout, stderr))
+	cmd.AddCommand(newExtMsgHandoffCmd(stdout, stderr))
+	cmd.AddCommand(newExtMsgUnbindCmd(stdout, stderr))
+	return cmd
+}
+
+// extMsgConversationFlags collects the flags identifying one conversation.
+type extMsgConversationFlags struct {
+	scopeID              string
+	provider             string
+	accountID            string
+	conversationID       string
+	parentConversationID string
+	kind                 string
+}
+
+func addExtMsgConversationFlags(cmd *cobra.Command, f *extMsgConversationFlags) {
+	cmd.Flags().StringVar(&f.provider, "provider", "", "External messaging provider (required)")
+	cmd.Flags().StringVar(&f.conversationID, "conversation-id", "", "Provider conversation ID (required)")
+	cmd.Flags().StringVar(&f.accountID, "account-id", "default", "Adapter account ID")
+	cmd.Flags().StringVar(&f.scopeID, "scope-id", "", "Conversation scope (default: the city name)")
+	cmd.Flags().StringVar(&f.parentConversationID, "parent-conversation-id", "", "Parent conversation ID for thread conversations")
+	cmd.Flags().StringVar(&f.kind, "kind", "dm", "Conversation kind: dm, room, or thread")
+}
+
+// conversationRef materializes the flags into a ConversationRef, defaulting
+// the scope to the city name (the convention bridges stamp on inbound).
+func (f *extMsgConversationFlags) conversationRef(cityPath string) (extmsg.ConversationRef, error) {
+	if strings.TrimSpace(f.provider) == "" {
+		return extmsg.ConversationRef{}, fmt.Errorf("--provider is required")
+	}
+	if strings.TrimSpace(f.conversationID) == "" {
+		return extmsg.ConversationRef{}, fmt.Errorf("--conversation-id is required")
+	}
+	scope := strings.TrimSpace(f.scopeID)
+	if scope == "" {
+		cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+		if err != nil {
+			return extmsg.ConversationRef{}, fmt.Errorf("resolving default scope from city config: %w", err)
+		}
+		scope = loadedCityName(cfg, cityPath)
+	}
+	return extmsg.ConversationRef{
+		ScopeID:              scope,
+		Provider:             f.provider,
+		AccountID:            f.accountID,
+		ConversationID:       f.conversationID,
+		ParentConversationID: f.parentConversationID,
+		Kind:                 extmsg.ConversationKind(f.kind),
+	}, nil
+}
+
+// conversationRefIfSet returns nil when no conversation flags were given,
+// letting unbind filter purely by session/agent.
+func (f *extMsgConversationFlags) conversationRefIfSet(cityPath string) (*extmsg.ConversationRef, error) {
+	if strings.TrimSpace(f.provider) == "" && strings.TrimSpace(f.conversationID) == "" {
+		return nil, nil
+	}
+	ref, err := f.conversationRef(cityPath)
+	if err != nil {
+		return nil, err
+	}
+	return &ref, nil
+}
+
+// extMsgClient resolves the city and returns its API client, failing with
+// a uniform message when the API is unavailable.
+func extMsgClient(verb string, stderr io.Writer) (*api.Client, string, bool) {
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc extmsg %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+		return nil, "", false
+	}
+	c := apiClient(cityPath)
+	if c == nil {
+		fmt.Fprintf(stderr, "gc extmsg %s: requires the city API server (no local fallback for conversation bindings)\n", verb) //nolint:errcheck // best-effort stderr
+		return nil, "", false
+	}
+	return c, cityPath, true
+}
+
+func extMsgReportBindError(verb string, err error, stderr io.Writer) int {
+	if api.ShouldFallback(err) {
+		fmt.Fprintf(stderr, "gc extmsg %s: city API unreachable (no local fallback for conversation bindings): %v\n", verb, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	fmt.Fprintf(stderr, "gc extmsg %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+	return 1
+}
+
+func printExtMsgBinding(stdout io.Writer, jsonOutput bool, record extmsg.SessionBindingRecord, action string) int {
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		if err := enc.Encode(record); err != nil {
+			return 1
+		}
+		return 0
+	}
+	target := record.SessionID
+	if record.AgentName != "" {
+		target = "agent " + record.AgentName
+	}
+	fmt.Fprintf(stdout, "%s %s/%s -> %s (binding %s, generation %d)\n", //nolint:errcheck // best-effort stdout
+		action, record.Conversation.Provider, record.Conversation.ConversationID, target, record.ID, record.BindingGeneration)
+	return 0
+}
+
+func newExtMsgBindCmd(stdout, stderr io.Writer) *cobra.Command {
+	var conv extMsgConversationFlags
+	var agentName, sessionID string
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "bind",
+		Short: "Bind a conversation to a session or configured agent",
+		Long: `Bind an external conversation to a concrete session (--session) or to a
+configured agent (--agent). Agent bindings survive session restarts:
+delivery resolves a live session for the agent each time, cold-waking one
+when none is live. Binding an actively-bound conversation conflicts; use
+"gc extmsg handoff" to rebind.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if cmdExtMsgBind(conv, agentName, sessionID, false, jsonOutput, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	addExtMsgConversationFlags(cmd, &conv)
+	cmd.Flags().StringVar(&agentName, "agent", "", "Configured agent identity to bind (mutually exclusive with --session)")
+	cmd.Flags().StringVar(&sessionID, "session", "", "Session ID to bind (mutually exclusive with --agent)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output the binding record as JSON")
+	return cmd
+}
+
+func newExtMsgHandoffCmd(stdout, stderr io.Writer) *cobra.Command {
+	var conv extMsgConversationFlags
+	var to string
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "handoff",
+		Short: "Rebind a conversation to another configured agent",
+		Long: `Rebind an external conversation to another configured agent, replacing
+the active binding. Run from inside an agent session to hand a
+conversation to the right specialist — the routing judgment lives in the
+agent's prompt, this verb is pure transport.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if strings.TrimSpace(to) == "" {
+				fmt.Fprintln(stderr, "gc extmsg handoff: --to is required") //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+			if cmdExtMsgBind(conv, to, "", true, jsonOutput, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	addExtMsgConversationFlags(cmd, &conv)
+	cmd.Flags().StringVar(&to, "to", "", "Configured agent identity to hand the conversation to (required)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output the binding record as JSON")
+	return cmd
+}
+
+// cmdExtMsgBind backs both bind (replace=false) and handoff (replace=true).
+func cmdExtMsgBind(conv extMsgConversationFlags, agentName, sessionID string, replace, jsonOutput bool, stdout, stderr io.Writer) int {
+	verb := "bind"
+	action := "bound"
+	if replace {
+		verb = "handoff"
+		action = "handed off"
+	}
+	agentName = strings.TrimSpace(agentName)
+	sessionID = strings.TrimSpace(sessionID)
+	switch {
+	case agentName == "" && sessionID == "":
+		fmt.Fprintf(stderr, "gc extmsg %s: --agent or --session is required\n", verb) //nolint:errcheck // best-effort stderr
+		return 1
+	case agentName != "" && sessionID != "":
+		fmt.Fprintf(stderr, "gc extmsg %s: --agent and --session are mutually exclusive\n", verb) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	c, cityPath, ok := extMsgClient(verb, stderr)
+	if !ok {
+		return 1
+	}
+	ref, err := conv.conversationRef(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc extmsg %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	record, err := c.BindExtMsgConversation(api.ExtMsgBindSpec{
+		Conversation: ref,
+		SessionID:    sessionID,
+		AgentName:    agentName,
+		Replace:      replace,
+	})
+	if err != nil {
+		return extMsgReportBindError(verb, err, stderr)
+	}
+	return printExtMsgBinding(stdout, jsonOutput, record, action)
+}
+
+func newExtMsgUnbindCmd(stdout, stderr io.Writer) *cobra.Command {
+	var conv extMsgConversationFlags
+	var agentName, sessionID string
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "unbind",
+		Short: "Remove active conversation bindings",
+		Long: `Remove active external-conversation bindings. Filter by conversation
+(--provider/--conversation-id), by --agent, by --session, or a
+combination. At least one filter is required.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if cmdExtMsgUnbind(conv, agentName, sessionID, jsonOutput, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	addExtMsgConversationFlags(cmd, &conv)
+	cmd.Flags().StringVar(&agentName, "agent", "", "Unbind conversations bound to this configured agent")
+	cmd.Flags().StringVar(&sessionID, "session", "", "Unbind conversations bound to this session ID")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output the removed binding records as JSON")
+	return cmd
+}
+
+func cmdExtMsgUnbind(conv extMsgConversationFlags, agentName, sessionID string, jsonOutput bool, stdout, stderr io.Writer) int {
+	agentName = strings.TrimSpace(agentName)
+	sessionID = strings.TrimSpace(sessionID)
+	c, cityPath, ok := extMsgClient("unbind", stderr)
+	if !ok {
+		return 1
+	}
+	ref, err := conv.conversationRefIfSet(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc extmsg unbind: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if ref == nil && agentName == "" && sessionID == "" {
+		fmt.Fprintln(stderr, "gc extmsg unbind: a conversation (--provider/--conversation-id), --agent, or --session is required") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	unbound, err := c.UnbindExtMsgConversation(ref, sessionID, agentName)
+	if err != nil {
+		return extMsgReportBindError("unbind", err, stderr)
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		if err := enc.Encode(unbound); err != nil {
+			return 1
+		}
+		return 0
+	}
+	if len(unbound) == 0 {
+		fmt.Fprintln(stdout, "No active bindings matched.") //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	for _, record := range unbound {
+		target := record.SessionID
+		if record.AgentName != "" {
+			target = "agent " + record.AgentName
+		}
+		fmt.Fprintf(stdout, "unbound %s/%s from %s (binding %s)\n", //nolint:errcheck // best-effort stdout
+			record.Conversation.Provider, record.Conversation.ConversationID, target, record.ID)
+	}
+	return 0
+}

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -2768,6 +2768,8 @@ export interface components {
             metadata?: {
                 [key: string]: string;
             };
+            /** @description Rebind (handoff) a conversation whose active binding targets someone else instead of returning a conflict. */
+            replace?: boolean;
             /** @description Session ID to bind (mutually exclusive with agent_name). */
             session_id?: string;
         };

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -945,6 +945,10 @@ export type ExtMsgBindInputBody = {
         [key: string]: string;
     };
     /**
+     * Rebind (handoff) a conversation whose active binding targets someone else instead of returning a conflict.
+     */
+    replace?: boolean;
+    /**
      * Session ID to bind (mutually exclusive with agent_name).
      */
     session_id?: string;

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -256,6 +256,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		newGitHubCmd(stdout, stderr),
 		newEventCmd(stdout, stderr),
 		newEventsCmd(stdout, stderr),
+		newExtMsgCmd(stdout, stderr),
 		newTraceCmd(stdout, stderr),
 		newOrderCmd(stdout, stderr),
 		newImportCmd(stdout, stderr),

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,6 +40,7 @@ gc [flags]
 | [gc dolt-cleanup](#gc-dolt-cleanup) | Find and remove orphaned Dolt databases (Go-side core) |
 | [gc event](#gc-event) | Event operations |
 | [gc events](#gc-events) | Show events from the GC API |
+| [gc extmsg](#gc-extmsg) | Manage external-conversation bindings |
 | [gc formula](#gc-formula) | Manage and inspect formulas |
 | [gc github](#gc-github) | GitHub integration commands |
 | [gc graph](#gc-graph) | Show dependency graph for beads |
@@ -1357,6 +1358,97 @@ gc --city /path/to/city events rotate --api http://127.0.0.1:8080
 |------|------|---------|-------------|
 | `--api` | string |  | GC API server URL override (auto-discovered by default) |
 | `--wait` | bool |  | Wait for archive compression to complete before returning |
+
+## gc extmsg
+
+Manage bindings between external conversations (telegram, discord, ...)
+and gc sessions or configured agents.
+
+A conversation bound to an agent name survives session restarts: inbound
+messages resolve a live session for the agent at delivery time, cold-waking
+one when none is live. "handoff" rebinds a conversation to another agent —
+the front-desk pattern: a default-routed agent inspects the conversation
+and hands it to the right specialist.
+
+These commands require the city API server; they have no local fallback.
+
+```
+gc extmsg
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc extmsg bind](#gc-extmsg-bind) | Bind a conversation to a session or configured agent |
+| [gc extmsg handoff](#gc-extmsg-handoff) | Rebind a conversation to another configured agent |
+| [gc extmsg unbind](#gc-extmsg-unbind) | Remove active conversation bindings |
+
+## gc extmsg bind
+
+Bind an external conversation to a concrete session (--session) or to a
+configured agent (--agent). Agent bindings survive session restarts:
+delivery resolves a live session for the agent each time, cold-waking one
+when none is live. Binding an actively-bound conversation conflicts; use
+"gc extmsg handoff" to rebind.
+
+```
+gc extmsg bind [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--account-id` | string | `default` | Adapter account ID |
+| `--agent` | string |  | Configured agent identity to bind (mutually exclusive with --session) |
+| `--conversation-id` | string |  | Provider conversation ID (required) |
+| `--json` | bool |  | Output the binding record as JSON |
+| `--kind` | string | `dm` | Conversation kind: dm, room, or thread |
+| `--parent-conversation-id` | string |  | Parent conversation ID for thread conversations |
+| `--provider` | string |  | External messaging provider (required) |
+| `--scope-id` | string |  | Conversation scope (default: the city name) |
+| `--session` | string |  | Session ID to bind (mutually exclusive with --agent) |
+
+## gc extmsg handoff
+
+Rebind an external conversation to another configured agent, replacing
+the active binding. Run from inside an agent session to hand a
+conversation to the right specialist — the routing judgment lives in the
+agent's prompt, this verb is pure transport.
+
+```
+gc extmsg handoff [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--account-id` | string | `default` | Adapter account ID |
+| `--conversation-id` | string |  | Provider conversation ID (required) |
+| `--json` | bool |  | Output the binding record as JSON |
+| `--kind` | string | `dm` | Conversation kind: dm, room, or thread |
+| `--parent-conversation-id` | string |  | Parent conversation ID for thread conversations |
+| `--provider` | string |  | External messaging provider (required) |
+| `--scope-id` | string |  | Conversation scope (default: the city name) |
+| `--to` | string |  | Configured agent identity to hand the conversation to (required) |
+
+## gc extmsg unbind
+
+Remove active external-conversation bindings. Filter by conversation
+(--provider/--conversation-id), by --agent, by --session, or a
+combination. At least one filter is required.
+
+```
+gc extmsg unbind [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--account-id` | string | `default` | Adapter account ID |
+| `--agent` | string |  | Unbind conversations bound to this configured agent |
+| `--conversation-id` | string |  | Provider conversation ID (required) |
+| `--json` | bool |  | Output the removed binding records as JSON |
+| `--kind` | string | `dm` | Conversation kind: dm, room, or thread |
+| `--parent-conversation-id` | string |  | Parent conversation ID for thread conversations |
+| `--provider` | string |  | External messaging provider (required) |
+| `--scope-id` | string |  | Conversation scope (default: the city name) |
+| `--session` | string |  | Unbind conversations bound to this session ID |
 
 ## gc formula
 

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -2532,6 +2532,10 @@
             "description": "Optional binding metadata.",
             "type": "object"
           },
+          "replace": {
+            "description": "Rebind (handoff) a conversation whose active binding targets someone else instead of returning a conflict.",
+            "type": "boolean"
+          },
           "session_id": {
             "description": "Session ID to bind (mutually exclusive with agent_name).",
             "type": "string"

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -2532,6 +2532,10 @@
             "description": "Optional binding metadata.",
             "type": "object"
           },
+          "replace": {
+            "description": "Rebind (handoff) a conversation whose active binding targets someone else instead of returning a conflict.",
+            "type": "boolean"
+          },
           "session_id": {
             "description": "Session ID to bind (mutually exclusive with agent_name).",
             "type": "string"

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gastownhall/gascity/internal/api/genclient"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
@@ -1396,4 +1397,123 @@ func derefBool(p *bool) bool {
 		return false
 	}
 	return *p
+}
+
+// ExtMsgBindSpec describes a bind or handoff request for an external
+// conversation. Exactly one of SessionID and AgentName must be set;
+// Replace rebinds a conversation whose active binding targets someone
+// else instead of conflicting.
+type ExtMsgBindSpec struct {
+	Conversation extmsg.ConversationRef
+	SessionID    string
+	AgentName    string
+	Replace      bool
+}
+
+// BindExtMsgConversation binds an external conversation to a session or a
+// configured agent via POST /v0/extmsg/bind and returns the resulting
+// binding record.
+func (c *Client) BindExtMsgConversation(spec ExtMsgBindSpec) (extmsg.SessionBindingRecord, error) {
+	if err := c.requireCityScope(); err != nil {
+		return extmsg.SessionBindingRecord{}, err
+	}
+	conv := genclientConversationRef(spec.Conversation)
+	body := genclient.PostV0CityByCityNameExtmsgBindJSONRequestBody{Conversation: &conv}
+	if spec.SessionID != "" {
+		body.SessionId = &spec.SessionID
+	}
+	if spec.AgentName != "" {
+		body.AgentName = &spec.AgentName
+	}
+	if spec.Replace {
+		body.Replace = &spec.Replace
+	}
+	resp, err := c.cw.PostV0CityByCityNameExtmsgBindWithResponse(context.Background(), c.cityName, nil, body)
+	if err != nil {
+		return extmsg.SessionBindingRecord{}, &connError{err: fmt.Errorf("request failed: %w", err)}
+	}
+	if resp == nil {
+		return extmsg.SessionBindingRecord{}, &connError{err: fmt.Errorf("nil response")}
+	}
+	if err := apiErrorFromResponse(resp.StatusCode(), resp.ApplicationproblemJSONDefault); err != nil {
+		return extmsg.SessionBindingRecord{}, err
+	}
+	if resp.JSON200 == nil {
+		return extmsg.SessionBindingRecord{}, fmt.Errorf("API returned %d with no body", resp.StatusCode())
+	}
+	return extmsgBindingRecordFromWire(*resp.JSON200), nil
+}
+
+// UnbindExtMsgConversation removes active external-conversation bindings
+// via POST /v0/extmsg/unbind, filtered by conversation and/or session ID
+// and agent name. It returns the bindings that were ended.
+func (c *Client) UnbindExtMsgConversation(conversation *extmsg.ConversationRef, sessionID, agentName string) ([]extmsg.SessionBindingRecord, error) {
+	if err := c.requireCityScope(); err != nil {
+		return nil, err
+	}
+	body := genclient.PostV0CityByCityNameExtmsgUnbindJSONRequestBody{}
+	if conversation != nil {
+		conv := genclientConversationRef(*conversation)
+		body.Conversation = &conv
+	}
+	if sessionID != "" {
+		body.SessionId = &sessionID
+	}
+	if agentName != "" {
+		body.AgentName = &agentName
+	}
+	resp, err := c.cw.PostV0CityByCityNameExtmsgUnbindWithResponse(context.Background(), c.cityName, nil, body)
+	if err != nil {
+		return nil, &connError{err: fmt.Errorf("request failed: %w", err)}
+	}
+	if resp == nil {
+		return nil, &connError{err: fmt.Errorf("nil response")}
+	}
+	if err := apiErrorFromResponse(resp.StatusCode(), resp.ApplicationproblemJSONDefault); err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil || resp.JSON200.Unbound == nil {
+		return nil, nil
+	}
+	out := make([]extmsg.SessionBindingRecord, 0, len(*resp.JSON200.Unbound))
+	for _, record := range *resp.JSON200.Unbound {
+		out = append(out, extmsgBindingRecordFromWire(record))
+	}
+	return out, nil
+}
+
+func genclientConversationRef(ref extmsg.ConversationRef) genclient.ConversationRef {
+	out := genclient.ConversationRef{
+		ScopeId:        ref.ScopeID,
+		Provider:       ref.Provider,
+		AccountId:      ref.AccountID,
+		ConversationId: ref.ConversationID,
+		Kind:           genclient.ConversationKind(ref.Kind),
+	}
+	if ref.ParentConversationID != "" {
+		out.ParentConversationId = &ref.ParentConversationID
+	}
+	return out
+}
+
+func extmsgBindingRecordFromWire(record genclient.SessionBindingRecord) extmsg.SessionBindingRecord {
+	return extmsg.SessionBindingRecord{
+		ID:            record.ID,
+		SchemaVersion: int(record.SchemaVersion),
+		Conversation: extmsg.ConversationRef{
+			ScopeID:              record.Conversation.ScopeId,
+			Provider:             record.Conversation.Provider,
+			AccountID:            record.Conversation.AccountId,
+			ConversationID:       record.Conversation.ConversationId,
+			ParentConversationID: derefStr(record.Conversation.ParentConversationId),
+			Kind:                 extmsg.ConversationKind(record.Conversation.Kind),
+		},
+		SessionID:         record.SessionID,
+		AgentName:         record.AgentName,
+		Status:            extmsg.BindingStatus(record.Status),
+		BoundAt:           record.BoundAt,
+		ExpiresAt:         record.ExpiresAt,
+		BindingGeneration: record.BindingGeneration,
+		Metadata:          record.Metadata,
+	}
 }

--- a/internal/api/client_extmsg_test.go
+++ b/internal/api/client_extmsg_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/extmsg"
+)
+
+func TestClientBindExtMsgConversationHandoff(t *testing.T) {
+	var gotBody struct {
+		Conversation extmsg.ConversationRef `json:"conversation"`
+		SessionID    string                 `json:"session_id"`
+		AgentName    string                 `json:"agent_name"`
+		Replace      bool                   `json:"replace"`
+	}
+	var gotHeader string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v0/city/alpha/extmsg/bind" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+		gotHeader = r.Header.Get("X-GC-Request")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode bind body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(extmsg.SessionBindingRecord{ //nolint:errcheck
+			ID:                "bind-1",
+			Conversation:      gotBody.Conversation,
+			AgentName:         gotBody.AgentName,
+			Status:            extmsg.BindingActive,
+			BoundAt:           time.Now().UTC(),
+			BindingGeneration: 2,
+		})
+	}))
+	defer ts.Close()
+
+	ref := extmsg.ConversationRef{
+		ScopeID:        "alpha",
+		Provider:       "telegram",
+		AccountID:      "default",
+		ConversationID: "7113355",
+		Kind:           extmsg.ConversationDM,
+	}
+	c := NewCityScopedClient(ts.URL, "alpha")
+	record, err := c.BindExtMsgConversation(ExtMsgBindSpec{
+		Conversation: ref,
+		AgentName:    "myrig/specialist",
+		Replace:      true,
+	})
+	if err != nil {
+		t.Fatalf("BindExtMsgConversation: %v", err)
+	}
+	if gotHeader != "true" {
+		t.Fatalf("X-GC-Request = %q, want true", gotHeader)
+	}
+	if gotBody.AgentName != "myrig/specialist" || !gotBody.Replace || gotBody.SessionID != "" {
+		t.Fatalf("bind body = %+v, want agent handoff", gotBody)
+	}
+	if gotBody.Conversation != ref {
+		t.Fatalf("conversation = %+v, want %+v", gotBody.Conversation, ref)
+	}
+	if record.ID != "bind-1" || record.AgentName != "myrig/specialist" || record.BindingGeneration != 2 {
+		t.Fatalf("record = %+v, want decoded binding", record)
+	}
+}
+
+func TestClientUnbindExtMsgConversationByAgent(t *testing.T) {
+	var gotBody struct {
+		Conversation *extmsg.ConversationRef `json:"conversation"`
+		SessionID    string                  `json:"session_id"`
+		AgentName    string                  `json:"agent_name"`
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v0/city/alpha/extmsg/unbind" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode unbind body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"unbound": []extmsg.SessionBindingRecord{{ID: "bind-9", AgentName: gotBody.AgentName, Status: extmsg.BindingEnded}},
+		})
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	unbound, err := c.UnbindExtMsgConversation(nil, "", "myrig/frontdesk")
+	if err != nil {
+		t.Fatalf("UnbindExtMsgConversation: %v", err)
+	}
+	if gotBody.Conversation != nil || gotBody.AgentName != "myrig/frontdesk" || gotBody.SessionID != "" {
+		t.Fatalf("unbind body = %+v, want agent-only filter", gotBody)
+	}
+	if len(unbound) != 1 || unbound[0].ID != "bind-9" || unbound[0].Status != extmsg.BindingEnded {
+		t.Fatalf("unbound = %+v, want one ended binding", unbound)
+	}
+}

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -1186,6 +1186,9 @@ type ExtMsgBindInputBody struct {
 	// Metadata Optional binding metadata.
 	Metadata *map[string]string `json:"metadata,omitempty"`
 
+	// Replace Rebind (handoff) a conversation whose active binding targets someone else instead of returning a conflict.
+	Replace *bool `json:"replace,omitempty"`
+
 	// SessionId Session ID to bind (mutually exclusive with agent_name).
 	SessionId *string `json:"session_id,omitempty"`
 }

--- a/internal/api/handler_extmsg_agent_binding_test.go
+++ b/internal/api/handler_extmsg_agent_binding_test.go
@@ -200,3 +200,42 @@ func TestHandleExtMsgOutboundAgentBoundAuthorizesResolvedAgentSession(t *testing
 		t.Fatalf("status(agent) = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 }
+
+func TestHandleExtMsgBindReplaceHandsOffActiveBinding(t *testing.T) {
+	fs, srv, services, ref := newExtMsgAgentBindingFixture(t)
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	if _, err := services.Bindings.Bind(context.Background(), caller, extmsg.BindInput{
+		Conversation: ref,
+		SessionID:    "sess-frontdesk",
+		Now:          time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Bind(session): %v", err)
+	}
+
+	// Without replace the rebind conflicts.
+	rec := postExtMsg(t, fs, srv, "/extmsg/bind", map[string]any{
+		"agent_name":   "myrig/worker",
+		"conversation": conversationBody(ref),
+	})
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status(no replace) = %d, want %d; body: %s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+
+	rec = postExtMsg(t, fs, srv, "/extmsg/bind", map[string]any{
+		"agent_name":   "myrig/worker",
+		"replace":      true,
+		"conversation": conversationBody(ref),
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status(replace) = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	binding, err := services.Bindings.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if binding == nil || binding.AgentName != "myrig/worker" || binding.SessionID != "" {
+		t.Fatalf("binding = %#v, want handed off to myrig/worker", binding)
+	}
+}

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -240,6 +240,7 @@ func (s *Server) humaHandleExtMsgBind(ctx context.Context, input *ExtMsgBindInpu
 		Conversation: input.Body.Conversation,
 		SessionID:    sessionID,
 		AgentName:    agentName,
+		Replace:      input.Body.Replace,
 		Metadata:     input.Body.Metadata,
 		Now:          time.Now(),
 	})

--- a/internal/api/huma_types_extmsg.go
+++ b/internal/api/huma_types_extmsg.go
@@ -66,6 +66,7 @@ type ExtMsgBindInput struct {
 		Conversation extmsg.ConversationRef `json:"conversation,omitempty" doc:"Conversation to bind."`
 		SessionID    string                 `json:"session_id,omitempty" doc:"Session ID to bind (mutually exclusive with agent_name)."`
 		AgentName    string                 `json:"agent_name,omitempty" doc:"Configured agent identity to bind; its live session is resolved at delivery time, cold-waking one when none is live (mutually exclusive with session_id)."`
+		Replace      bool                   `json:"replace,omitempty" doc:"Rebind (handoff) a conversation whose active binding targets someone else instead of returning a conflict."`
 		Metadata     map[string]string      `json:"metadata,omitempty" doc:"Optional binding metadata."`
 	}
 }

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -2532,6 +2532,10 @@
             "description": "Optional binding metadata.",
             "type": "object"
           },
+          "replace": {
+            "description": "Rebind (handoff) a conversation whose active binding targets someone else instead of returning a conflict.",
+            "type": "boolean"
+          },
           "session_id": {
             "description": "Session ID to bind (mutually exclusive with agent_name).",
             "type": "string"

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -117,10 +117,23 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 		if err != nil {
 			return err
 		}
-		if active != nil {
-			if active.SessionID != sessionID || active.AgentName != agentName {
+		if active != nil && (active.SessionID != sessionID || active.AgentName != agentName) {
+			if !input.Replace {
 				return fmt.Errorf("%w: conversation already bound to %s", ErrBindingConflict, bindingTarget(*active))
 			}
+			// Handoff: end the active binding and fall through to create
+			// the new one under the same conversation lock.
+			if err := s.endActiveBindingLocked(ctx, caller, *active, now); err != nil {
+				return err
+			}
+			if s.delivery != nil && active.SessionID != "" {
+				if err := s.delivery.ClearForConversation(ctx, active.SessionID, active.Conversation); err != nil {
+					return err
+				}
+			}
+			active = nil
+		}
+		if active != nil {
 			// Coalesce the rebind's writes — optional session-name backfill,
 			// binding metadata, and transcript membership — into one commit so a
 			// rebind costs a single DOLT_COMMIT instead of 2-4 (gastownhall/gascity#3735).
@@ -429,32 +442,8 @@ func (s *bindingService) Unbind(ctx context.Context, caller Caller, input Unbind
 			if !matchesFilter(*active) {
 				return nil
 			}
-			if err := s.store.SetMetadata(active.ID, "last_touched_at", formatTime(now)); err != nil {
-				return fmt.Errorf("update binding %s metadata: %w", active.ID, err)
-			}
-			if s.transcript != nil {
-				if err := s.transcript.removeMembershipLocked(RemoveMembershipInput{
-					Caller:       caller,
-					Conversation: active.Conversation,
-					SessionID:    bindingMembershipKey(*active),
-					Owner:        MembershipOwnerBinding,
-					Now:          now,
-				}); err != nil {
-					return wrapTranscriptSyncError("remove transcript membership after unbind", err)
-				}
-			}
-			if err := s.store.Close(active.ID); err != nil {
-				if s.transcript != nil {
-					_, _ = s.transcript.ensureMembershipLocked(EnsureMembershipInput{
-						Caller:         caller,
-						Conversation:   active.Conversation,
-						SessionID:      bindingMembershipKey(*active),
-						BackfillPolicy: MembershipBackfillSinceJoin,
-						Owner:          MembershipOwnerBinding,
-						Now:            now,
-					})
-				}
-				return fmt.Errorf("close binding %s: %w", active.ID, err)
+			if err := s.endActiveBindingLocked(ctx, caller, *active, now); err != nil {
+				return err
 			}
 			active.Status = BindingEnded
 			if active.Metadata == nil {
@@ -959,6 +948,43 @@ func decodeBindingBead(b beads.Bead) (SessionBindingRecord, error) {
 		BindingGeneration: parseInt64(b.Metadata, "binding_generation"),
 		Metadata:          decodePrefixedMetadata(b.Metadata),
 	}, nil
+}
+
+// endActiveBindingLocked terminates an active binding while the caller
+// holds the conversation's binding lock: it stamps last_touched_at,
+// removes the binding-owned transcript membership, and closes the binding
+// bead (re-ensuring the membership when the close fails). Clearing
+// delivery contexts stays with the callers — Unbind reports the ended
+// binding even when the subsequent clear fails.
+func (s *bindingService) endActiveBindingLocked(_ context.Context, caller Caller, active SessionBindingRecord, now time.Time) error {
+	if err := s.store.SetMetadata(active.ID, "last_touched_at", formatTime(now)); err != nil {
+		return fmt.Errorf("update binding %s metadata: %w", active.ID, err)
+	}
+	if s.transcript != nil {
+		if err := s.transcript.removeMembershipLocked(RemoveMembershipInput{
+			Caller:       caller,
+			Conversation: active.Conversation,
+			SessionID:    bindingMembershipKey(active),
+			Owner:        MembershipOwnerBinding,
+			Now:          now,
+		}); err != nil {
+			return wrapTranscriptSyncError("remove transcript membership after unbind", err)
+		}
+	}
+	if err := s.store.Close(active.ID); err != nil {
+		if s.transcript != nil {
+			_, _ = s.transcript.ensureMembershipLocked(EnsureMembershipInput{
+				Caller:         caller,
+				Conversation:   active.Conversation,
+				SessionID:      bindingMembershipKey(active),
+				BackfillPolicy: MembershipBackfillSinceJoin,
+				Owner:          MembershipOwnerBinding,
+				Now:            now,
+			})
+		}
+		return fmt.Errorf("close binding %s: %w", active.ID, err)
+	}
+	return nil
 }
 
 // bindingTarget renders the bound endpoint for error messages: the agent

--- a/internal/extmsg/rebind_test.go
+++ b/internal/extmsg/rebind_test.go
@@ -1,0 +1,133 @@
+package extmsg
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestBindingServiceReplaceRebindsActiveBinding(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	svc := fabric.Bindings
+	ref := testConversationRef()
+
+	first, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/frontdesk",
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("Bind(frontdesk): %v", err)
+	}
+
+	// Plain bind still conflicts — handoff is explicitly opt-in.
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/specialist",
+		Now:          testNow(),
+	}); !errors.Is(err, ErrBindingConflict) {
+		t.Fatalf("Bind(no replace) error = %v, want ErrBindingConflict", err)
+	}
+
+	second, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/specialist",
+		Replace:      true,
+		Now:          testNow().Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Bind(replace): %v", err)
+	}
+	if second.AgentName != "myrig/specialist" {
+		t.Fatalf("rebound AgentName = %q, want myrig/specialist", second.AgentName)
+	}
+	if second.BindingGeneration != first.BindingGeneration+1 {
+		t.Fatalf("BindingGeneration = %d, want %d", second.BindingGeneration, first.BindingGeneration+1)
+	}
+
+	active, err := svc.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if active == nil || active.ID != second.ID {
+		t.Fatalf("active = %#v, want the rebound binding", active)
+	}
+
+	// Membership followed the handoff: the old agent's membership is gone,
+	// the new agent's exists.
+	members, err := fabric.Transcript.ListMemberships(context.Background(), testControllerCaller(), ref)
+	if err != nil {
+		t.Fatalf("ListMemberships: %v", err)
+	}
+	if len(members) != 1 || members[0].SessionID != "myrig/specialist" {
+		t.Fatalf("memberships = %#v, want one keyed myrig/specialist", members)
+	}
+}
+
+func TestBindingServiceReplaceAcrossKindsAndIdempotence(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Bindings
+	ref := testConversationRef()
+
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-a",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(session): %v", err)
+	}
+
+	// Session binding -> agent binding via replace.
+	rebound, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/helper",
+		Replace:      true,
+		Now:          testNow().Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Bind(replace session->agent): %v", err)
+	}
+	if rebound.AgentName != "myrig/helper" || rebound.SessionID != "" {
+		t.Fatalf("rebound = %#v, want agent binding", rebound)
+	}
+
+	// Replace to the same target is idempotent — keeps the record.
+	same, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/helper",
+		Replace:      true,
+		Now:          testNow().Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Bind(replace same target): %v", err)
+	}
+	if same.ID != rebound.ID || same.BindingGeneration != rebound.BindingGeneration {
+		t.Fatalf("idempotent replace changed record: %#v vs %#v", same, rebound)
+	}
+
+	// Replace with no active binding behaves like a plain bind.
+	if _, err := svc.Unbind(context.Background(), testControllerCaller(), UnbindInput{
+		Conversation: &ref,
+		Now:          testNow().Add(3 * time.Minute),
+	}); err != nil {
+		t.Fatalf("Unbind: %v", err)
+	}
+	fresh, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-b",
+		Replace:      true,
+		Now:          testNow().Add(4 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Bind(replace on unbound): %v", err)
+	}
+	if fresh.SessionID != "sess-b" {
+		t.Fatalf("fresh = %#v, want sess-b session binding", fresh)
+	}
+}

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -413,11 +413,15 @@ type GroupOutboundDecision struct {
 
 // BindInput is the input for creating a session binding. Exactly one of
 // SessionID (bind to a concrete session) or AgentName (bind to a configured
-// agent identity whose live session is resolved at delivery time) must be set.
+// agent identity whose live session is resolved at delivery time) must be
+// set. Replace rebinds a conversation whose active binding targets someone
+// else (a handoff): the active binding is ended and the new one created
+// under the same conversation lock. Without Replace such a bind conflicts.
 type BindInput struct {
 	Conversation ConversationRef
 	SessionID    string
 	AgentName    string
+	Replace      bool
 	ExpiresAt    *time.Time
 	Metadata     map[string]string
 	Now          time.Time


### PR DESCRIPTION
## Summary

Routing ladder 3 (bead `ga-fxi5zp`). **Stacked on #3437** (default routes), which stacks on #3434 (agent-name bindings) — based so the diff shows only this slice; GitHub retargets as the train merges.

Completes the front-desk pattern: a default-routed agent inspects an unbound conversation and runs

```
gc extmsg handoff --provider telegram --conversation-id 7113355 --to myrig/specialist
```

Routing judgment lives in the agent's prompt; the verb is pure transport (ZFC).

## What's in the slice

- **Core — `BindInput.Replace`:** rebinding a conversation whose active binding targets someone else ends the active binding (membership removed, delivery contexts cleared for session bindings) and creates the new one **under the same conversation lock**, incrementing the binding generation. Plain bind still 409s — handoff is opt-in, preserving conflict semantics. The Unbind close path is factored into `endActiveBindingLocked` shared by both; Unbind's partial-result ordering (ended bindings reported even when a delivery clear fails) is pinned by the existing tests and preserved.
- **API:** bind body gains `replace`; handler passthrough; e2e test (no-replace → 409, replace → 200, binding handed off).
- **Client:** `BindExtMsgConversation` / `UnbindExtMsgConversation` — typed wire via genclient, converted to domain `extmsg.SessionBindingRecord` at the edge; httptest round-trip tests cover body shape, CSRF header, and decoding.
- **CLI:** new `gc extmsg` group (`bind`, `handoff`, `unbind`) routing all mutations through `apiClient()` per the control-plane rules, with an **explicit no-local-fallback decision**: conversation bindings are live controller state; mutating the bead store behind a running controller would race its delivery pipeline. Unreachable-API errors say exactly that. Conversation flags default `--scope-id` to the city name and `--account-id` to `default` (the convention bridges stamp on inbound); `--kind` defaults to `dm`.
- Wire artifacts (openapi, genclient, dashboard TS) and the generated CLI reference regenerated; `make dashboard-check` green.

## Testing

- `internal/extmsg`: replace rebinds agent→agent and session→agent with membership following the handoff; same-target replace is idempotent; replace on an unbound conversation acts as plain bind; plain-bind conflict preserved. Full suite green.
- `internal/api`: handler replace e2e; client httptest round-trips; full suite green (142s incl. spec/genclient sync guards).
- `cmd/gc`: builds; `TestGCNonTestFilesStayOnWorkerBoundary` green (no session-layer imports); `test/docsync` green.
- `go vet ./...`, `golangci-lint`, `gofmt` clean.

Acceptance (ga-fxi5zp): agent session can rebind a conversation to another agent by name ✔; binding conflict semantics preserved ✔; CLI routes through the API client per control-plane rules ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)