### PR TITLE
fix(telemetry): instrument supervisor API mail handlers (gc.mail.operations.total undercounts)

### DIFF
--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -10,6 +10,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/telemetry"
 )
 
 // mailReadDeadline is shorter than the API client's 10s timeout so typed
@@ -458,6 +459,7 @@ func (s *Server) humaHandleMailSend(ctx context.Context, input *MailSendInput) (
 	}
 
 	msg, err := mp.Send(input.Body.From, resolved, input.Body.Subject, input.Body.Body)
+	telemetry.RecordMailOp(ctx, "send", err)
 	if err != nil {
 		s.idem.unreserve(idemKey)
 		return nil, huma.Error500InternalServerError(err.Error())
@@ -603,8 +605,10 @@ func (s *Server) humaHandleMailRead(ctx context.Context, input *MailReadInput) (
 		return nil, huma.Error404NotFound("message " + id + " not found")
 	}
 	if err := mp.MarkRead(id); err != nil {
+		telemetry.RecordMailOp(ctx, "mark_read", err)
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
+	telemetry.RecordMailOp(ctx, "mark_read", nil)
 	if err := waitForMailReadState(ctx, mp, id, true); err != nil {
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
@@ -626,8 +630,10 @@ func (s *Server) humaHandleMailMarkUnread(ctx context.Context, input *MailMarkUn
 		return nil, huma.Error404NotFound("message " + id + " not found")
 	}
 	if err := mp.MarkUnread(id); err != nil {
+		telemetry.RecordMailOp(ctx, "mark_unread", err)
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
+	telemetry.RecordMailOp(ctx, "mark_unread", nil)
 	if err := waitForMailReadState(ctx, mp, id, false); err != nil {
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
@@ -662,7 +668,7 @@ func waitForMailReadState(ctx context.Context, mp mail.Provider, id string, want
 }
 
 // humaHandleMailArchive is the Huma-typed handler for POST /v0/mail/{id}/archive.
-func (s *Server) humaHandleMailArchive(_ context.Context, input *MailArchiveInput) (*OKResponse, error) {
+func (s *Server) humaHandleMailArchive(ctx context.Context, input *MailArchiveInput) (*OKResponse, error) {
 	id := input.ID
 	rig := input.Rig
 	mp, resolvedRig, err := s.findMailProviderForMessage(id, rig)
@@ -682,8 +688,10 @@ func (s *Server) humaHandleMailArchive(_ context.Context, input *MailArchiveInpu
 			resp.Body.Status = "archived"
 			return resp, nil
 		}
+		telemetry.RecordMailOp(ctx, "archive", err)
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
+	telemetry.RecordMailOp(ctx, "archive", nil)
 	s.recordMailEvent(events.MailArchived, "api", id, resolvedRig, nil)
 	resp := &OKResponse{}
 	resp.Body.Status = "archived"
@@ -691,7 +699,7 @@ func (s *Server) humaHandleMailArchive(_ context.Context, input *MailArchiveInpu
 }
 
 // humaHandleMailReply is the Huma-typed handler for POST /v0/mail/{id}/reply.
-func (s *Server) humaHandleMailReply(_ context.Context, input *MailReplyInput) (*IndexOutput[mail.Message], error) {
+func (s *Server) humaHandleMailReply(ctx context.Context, input *MailReplyInput) (*IndexOutput[mail.Message], error) {
 	id := input.ID
 	rig := input.Rig
 
@@ -704,6 +712,7 @@ func (s *Server) humaHandleMailReply(_ context.Context, input *MailReplyInput) (
 	}
 
 	msg, err := mp.Reply(id, input.Body.From, input.Body.Subject, input.Body.Body)
+	telemetry.RecordMailOp(ctx, "reply", err)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
@@ -717,7 +726,7 @@ func (s *Server) humaHandleMailReply(_ context.Context, input *MailReplyInput) (
 }
 
 // humaHandleMailDelete is the Huma-typed handler for DELETE /v0/mail/{id}.
-func (s *Server) humaHandleMailDelete(_ context.Context, input *MailDeleteInput) (*OKResponse, error) {
+func (s *Server) humaHandleMailDelete(ctx context.Context, input *MailDeleteInput) (*OKResponse, error) {
 	id := input.ID
 	rig := input.Rig
 	mp, resolvedRig, err := s.findMailProviderForMessage(id, rig)
@@ -737,8 +746,10 @@ func (s *Server) humaHandleMailDelete(_ context.Context, input *MailDeleteInput)
 			resp.Body.Status = "deleted"
 			return resp, nil
 		}
+		telemetry.RecordMailOp(ctx, "delete", err)
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
+	telemetry.RecordMailOp(ctx, "delete", nil)
 	s.recordMailEvent(events.MailDeleted, "api", id, resolvedRig, nil)
 	resp := &OKResponse{}
 	resp.Body.Status = "deleted"

--- a/internal/api/huma_handlers_mail_telemetry_test.go
+++ b/internal/api/huma_handlers_mail_telemetry_test.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/telemetry"
+)
+
+// installManualMeterReader swaps the global MeterProvider for one backed by a
+// manual reader and re-arms the telemetry recorder's lazy instrument binding
+// so Record* calls land in the reader. Cleanup restores the previous provider
+// and re-arms the binding again so later tests do not write to a dead reader.
+// Tests using this helper must NOT call t.Parallel() — the MeterProvider and
+// instrument binding are process-global.
+func installManualMeterReader(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	telemetry.ResetInstrumentsForTest()
+	reader := sdkmetric.NewManualReader()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		telemetry.ResetInstrumentsForTest()
+	})
+	return reader
+}
+
+// collectMailOpCounts collects from the manual reader and returns the
+// gc.mail.operations.total datapoints keyed by (operation, status). Other
+// metrics (e.g. middleware's gc.http.*) are ignored.
+func collectMailOpCounts(t *testing.T, reader *sdkmetric.ManualReader) map[[2]string]int64 {
+	t.Helper()
+	var out metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &out); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	counts := make(map[[2]string]int64)
+	for _, sm := range out.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "gc.mail.operations.total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("gc.mail.operations.total data = %T, want Sum[int64]", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				var op, status string
+				for _, kv := range dp.Attributes.ToSlice() {
+					switch kv.Key {
+					case "operation":
+						op = kv.Value.AsString()
+					case "status":
+						status = kv.Value.AsString()
+					}
+				}
+				counts[[2]string{op, status}] += dp.Value
+			}
+		}
+	}
+	return counts
+}
+
+// doMailRequest drives one HTTP request through the full Huma stack and
+// asserts the response status.
+func doMailRequest(t *testing.T, h http.Handler, req *http.Request, wantStatus int) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != wantStatus {
+		t.Fatalf("%s %s status = %d, want %d; body: %s",
+			req.Method, req.URL.Path, rec.Code, wantStatus, rec.Body.String())
+	}
+	return rec
+}
+
+// newDeleteRequest creates a DELETE httptest request with the X-GC-Request
+// CSRF header set, mirroring newPostRequest.
+func newDeleteRequest(url string) *http.Request {
+	req := httptest.NewRequest("DELETE", url, nil)
+	req.Header.Set("X-GC-Request", "true")
+	return req
+}
+
+// failingMutationMailProvider embeds a real provider (so Get works and
+// findMailProviderForMessage resolves) but fails every mutation operation.
+type failingMutationMailProvider struct {
+	mail.Provider
+	failErr error
+}
+
+func (p *failingMutationMailProvider) Send(string, string, string, string) (mail.Message, error) {
+	return mail.Message{}, p.failErr
+}
+
+func (p *failingMutationMailProvider) MarkRead(string) error { return p.failErr }
+
+func (p *failingMutationMailProvider) MarkUnread(string) error { return p.failErr }
+
+func (p *failingMutationMailProvider) Archive(string) error { return p.failErr }
+
+func (p *failingMutationMailProvider) Reply(string, string, string, string) (mail.Message, error) {
+	return mail.Message{}, p.failErr
+}
+
+func (p *failingMutationMailProvider) Delete(string) error { return p.failErr }
+
+// TestMailMutationHandlersRecordMailOpOnSuccess verifies that each of the six
+// supervisor API mail mutation handlers records exactly one
+// gc.mail.operations.total datapoint with status "ok" and the same operation
+// labels the CLI uses, so CLI and API traffic aggregate under one series.
+func TestMailMutationHandlersRecordMailOpOnSuccess(t *testing.T) {
+	reader := installManualMeterReader(t)
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+
+	rec := doMailRequest(t, h, newPostRequest(cityURL(state, "/mail"),
+		bytes.NewBufferString(`{"from":"mayor","to":"worker","subject":"s","body":"b"}`)),
+		http.StatusCreated)
+	var sent mail.Message
+	if err := json.NewDecoder(rec.Body).Decode(&sent); err != nil {
+		t.Fatalf("decode sent message: %v", err)
+	}
+
+	doMailRequest(t, h, newPostRequest(cityURL(state, "/mail/")+sent.ID+"/read", nil), http.StatusOK)
+	doMailRequest(t, h, newPostRequest(cityURL(state, "/mail/")+sent.ID+"/mark-unread", nil), http.StatusOK)
+
+	rec = doMailRequest(t, h, newPostRequest(cityURL(state, "/mail/")+sent.ID+"/reply",
+		bytes.NewBufferString(`{"from":"worker","subject":"re","body":"r"}`)),
+		http.StatusCreated)
+	var reply mail.Message
+	if err := json.NewDecoder(rec.Body).Decode(&reply); err != nil {
+		t.Fatalf("decode reply message: %v", err)
+	}
+
+	doMailRequest(t, h, newPostRequest(cityURL(state, "/mail/")+sent.ID+"/archive", nil), http.StatusOK)
+	doMailRequest(t, h, newDeleteRequest(cityURL(state, "/mail/")+reply.ID), http.StatusOK)
+
+	got := collectMailOpCounts(t, reader)
+	want := map[[2]string]int64{
+		{"send", "ok"}:        1,
+		{"mark_read", "ok"}:   1,
+		{"mark_unread", "ok"}: 1,
+		{"reply", "ok"}:       1,
+		{"archive", "ok"}:     1,
+		{"delete", "ok"}:      1,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mail op counts = %v, want %v", got, want)
+	}
+}
+
+// TestMailMutationHandlersRecordMailOpOnError verifies that provider failures
+// in each of the six mail mutation handlers record exactly one
+// gc.mail.operations.total datapoint with status "error".
+func TestMailMutationHandlersRecordMailOpOnError(t *testing.T) {
+	reader := installManualMeterReader(t)
+	state := newFakeState(t)
+
+	// Seed via the real provider so Get (and thus provider resolution for the
+	// per-message endpoints) succeeds; only the mutations fail.
+	msg, err := state.cityMailProv.Send("mayor", "worker", "s", "b")
+	if err != nil {
+		t.Fatalf("seed Send: %v", err)
+	}
+	state.cityMailProv = &failingMutationMailProvider{
+		Provider: state.cityMailProv,
+		failErr:  errors.New("provider down"),
+	}
+	h := newTestCityHandler(t, state)
+
+	doMailRequest(t, h, newPostRequest(cityURL(state, "/mail"),
+		bytes.NewBufferString(`{"from":"mayor","to":"worker","subject":"s","body":"b"}`)),
+		http.StatusInternalServerError)
+	doMailRequest(t, h, newPostRequest(cityURL(state, "/mail/")+msg.ID+"/read", nil), http.StatusInternalServerError)
+	doMailRequest(t, h, newPostRequest(cityURL(state, "/mail/")+msg.ID+"/mark-unread", nil), http.StatusInternalServerError)
+	doMailRequest(t, h, newPostRequest(cityURL(state, "/mail/")+msg.ID+"/reply",
+		bytes.NewBufferString(`{"from":"worker","subject":"re","body":"r"}`)),
+		http.StatusInternalServerError)
+	doMailRequest(t, h, newPostRequest(cityURL(state, "/mail/")+msg.ID+"/archive", nil), http.StatusInternalServerError)
+	doMailRequest(t, h, newDeleteRequest(cityURL(state, "/mail/")+msg.ID), http.StatusInternalServerError)
+
+	got := collectMailOpCounts(t, reader)
+	want := map[[2]string]int64{
+		{"send", "error"}:        1,
+		{"mark_read", "error"}:   1,
+		{"mark_unread", "error"}: 1,
+		{"reply", "error"}:       1,
+		{"archive", "error"}:     1,
+		{"delete", "error"}:      1,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mail op counts = %v, want %v", got, want)
+	}
+}
+
+// TestMailSendIdempotentReplayRecordsNoMailOp pins that an Idempotency-Key
+// replay of POST /mail serves the cached response without calling the
+// provider and records no additional gc.mail.operations.total datapoint, so
+// client retries cannot double-count sends.
+func TestMailSendIdempotentReplayRecordsNoMailOp(t *testing.T) {
+	reader := installManualMeterReader(t)
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+
+	body := `{"from":"mayor","to":"worker","subject":"s","body":"b"}`
+	for range 2 {
+		req := newPostRequest(cityURL(state, "/mail"), bytes.NewBufferString(body))
+		req.Header.Set("Idempotency-Key", "mail-telemetry-replay-1")
+		doMailRequest(t, h, req, http.StatusCreated)
+	}
+
+	got := collectMailOpCounts(t, reader)
+	want := map[[2]string]int64{
+		{"send", "ok"}: 1,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mail op counts = %v, want %v", got, want)
+	}
+}
+
+// TestMailArchiveDeleteIdempotentRepeatRecordsNoMailOp pins CLI-parity
+// semantics: an idempotent repeat archive/delete (message already gone)
+// returns 200 but records no mail-op datapoint, matching the CLI which skips
+// telemetry for already-archived messages.
+func TestMailArchiveDeleteIdempotentRepeatRecordsNoMailOp(t *testing.T) {
+	reader := installManualMeterReader(t)
+	state := newFakeState(t)
+
+	msgA, err := state.cityMailProv.Send("mayor", "worker", "a", "body-a")
+	if err != nil {
+		t.Fatalf("seed Send A: %v", err)
+	}
+	msgB, err := state.cityMailProv.Send("mayor", "worker", "b", "body-b")
+	if err != nil {
+		t.Fatalf("seed Send B: %v", err)
+	}
+	h := newTestCityHandler(t, state)
+
+	for range 2 {
+		doMailRequest(t, h, newPostRequest(cityURL(state, "/mail/")+msgA.ID+"/archive", nil), http.StatusOK)
+	}
+	for range 2 {
+		doMailRequest(t, h, newDeleteRequest(cityURL(state, "/mail/")+msgB.ID), http.StatusOK)
+	}
+
+	got := collectMailOpCounts(t, reader)
+	want := map[[2]string]int64{
+		{"archive", "ok"}: 1,
+		{"delete", "ok"}:  1,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mail op counts = %v, want %v", got, want)
+	}
+}

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -81,6 +81,17 @@ var (
 	inst     recorderInstruments
 )
 
+// ResetInstrumentsForTest re-arms the lazy instrument bindings (recorder and
+// invocation instruments) so the next Record* call re-registers them against
+// the current global MeterProvider. It exists so tests can swap in a
+// manual-reader SDK provider and observe emissions (mirroring ResetForTest).
+// Must be called only from tests, after swapping the global provider, and
+// again after restoring it.
+func ResetInstrumentsForTest() {
+	instOnce = sync.Once{}
+	invInstOnce = sync.Once{}
+}
+
 // initInstruments registers all recorder metric instruments against the current
 // global MeterProvider. Must be called after telemetry.Init so the real
 // provider is set. Also called lazily on first use as a safety net.


### PR DESCRIPTION
## Problem

All 21 `RecordMailOp` call sites live in `cmd/gc/cmd_mail.go`, so `gc.mail.operations.total` only counts agent-run `gc mail` CLI invocations (~6 datapoints/day in maintainer-city). The deployment's dominant mail flow — the supervisor's HTTP API mail mutation handlers used by the controller and dashboard — records nothing.

Tracked as bead **ga-oa00qh**.

## Fix

Add `telemetry.RecordMailOp` to the six mail mutation handlers in `internal/api/huma_handlers_mail.go` (Send, MarkRead, MarkUnread, Archive, Reply, Delete), reusing the exact CLI label vocabulary (`send`, `mark_read`, `mark_unread`, `archive`, `reply`, `delete`) so CLI and API traffic aggregate under one series.

CLI-parity semantics:
- recorded on provider success and provider failure (`err` is passed through);
- nothing recorded on idempotent no-ops (Send `Idempotency-Key` replay, archive/delete of an already-archived message) or on validation/pre-provider failures;
- `mark_read`/`mark_unread` success is recorded before `waitForMailReadState`, so read-visibility waiting cannot misreport the operation itself.

Telemetry-only: handler bodies only, zero OpenAPI/wire surface change (spec, genclient, and generated TS types untouched; `TestOpenAPISpecInSync` passes).

Supporting change: exported `telemetry.ResetInstrumentsForTest()` (mirrors the existing `ResetForTest()`) so consumer-package tests can rebind instruments to a manual-reader `MeterProvider`.

## Tests (TDD, red→green)

New `internal/api/huma_handlers_mail_telemetry_test.go` drives real HTTP through the full Huma+middleware stack against a `metric.NewManualReader` with exact-map `(operation, status)` assertions:

- success across all six handlers;
- provider-failure recording via a failing mail-provider double;
- idempotent archive/delete repeats record nothing;
- an `Idempotency-Key`-replayed POST /mail records no second `send` datapoint (kills both missing instrumentation and a hoisted-above-the-replay-return regression).

With the instrumentation stashed, all four tests fail with `mail op counts = map[]`. Tests also pass under `-race -shuffle=on -count=2`.

## Verification

- `go test -count=1 ./internal/api ./internal/api/genclient/... ./internal/telemetry` green
- `go vet ./...` clean, `gofmt` clean
- `make dashboard-check` clean (no regenerated artifacts)
- `.githooks/pre-commit` run against the staged change (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
