### PR TITLE
fix(hook): federate the city store for rig-scoped agents

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -214,6 +214,11 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 		if rigStores := appendOneRigHookStore(nil, cityPath, cfg, &a, rig, overrides); len(rigStores) > 0 {
 			stores = append(rigStores, stores...)
 		}
+		// A rig-backed agent's own env above is ALSO rig-scoped, so without
+		// this no entry reaches the CITY store and root-only beads assigned
+		// to the agent stay invisible. Best-effort tertiary; see
+		// appendCityHookStore.
+		stores = appendCityHookStore(stores, cityPath, cfg, &a, overrides)
 	}
 
 	runner := func(command, _ string) (string, error) {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -1182,6 +1182,74 @@ dir = "myrig"
 	}
 }
 
+// TestCmdHookRigScopedAgentFindsCityStoreWork guards the rig→city read
+// federation: a root-only (city-store) bead assigned to a rig-scoped agent
+// must surface through gc hook. The rig store is the agent's primary entry,
+// and a rig-backed agent's own work-query env is ALSO rig-scoped
+// (controllerWorkQueryEnv switches to rig coordinates when the agent has a
+// configured rig), so without a federated city entry the hook reports empty
+// while assigned city work sits invisible — e.g. singleton patrol wisps
+// created in the city store for a rig-scoped witness. Mirror of the #2877
+// city→rig federation in the opposite direction.
+func TestCmdHookRigScopedAgentFindsCityStoreWork(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
+	cityDir := t.TempDir()
+	fakeBin := t.TempDir()
+	rigDir := filepath.Join(cityDir, "myrig")
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "myrig"
+path = %q
+
+[[agent]]
+name = "worker"
+dir = "myrig"
+`, rigDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The fake bd answers with one ready row ONLY when queried against the
+	// CITY store; every rig-scoped query sees []. This simulates a root-only
+	// bead assigned to the rig-scoped agent.
+	cityBeads := filepath.Join(cityDir, ".beads")
+	fakeBD := filepath.Join(fakeBin, "bd")
+	script := fmt.Sprintf(`#!/bin/sh
+case "$BEADS_DIR" in
+  %s*) printf '[{"id":"td-city1","status":"open","assignee":"myrig/worker","title":"root-only city work"}]' ;;
+  *) printf '[]' ;;
+esac
+`, cityBeads)
+	if err := os.WriteFile(fakeBD, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_DIR", rigDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHook([]string{"worker"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHook() = %d, want 0 (city-store work must surface); stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "td-city1") {
+		t.Fatalf("stdout = %q, want the city-store bead td-city1", stdout.String())
+	}
+}
+
 // TestCmdHookResolvesRelativeRigPath guards the relative-rig-path handling:
 // when `[[rigs]].path` is relative (e.g. "myrig-repo"), cmdHook must
 // normalize it to an absolute path before building the rig env, or

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -81,6 +81,40 @@ func appendOneRigHookStore(stores []hookStore, cityPath string, cfg *config.City
 	})
 }
 
+// appendCityHookStore appends the CITY store as a best-effort federated entry
+// for a rig-scoped agent — the mirror of the #2877 city→rig read federation in
+// the opposite direction. Root-only (city-store) beads can be assigned to a
+// rig-scoped agent (e.g. singleton patrol wisps created at city scope for a
+// rig witness), and none of the agent's other entries reach them: the rig
+// store is its primary, and a rig-backed agent's own work-query env is ALSO
+// rig-scoped (controllerWorkQueryEnv switches to rig coordinates whenever the
+// agent has a configured rig). A city view of the agent (Dir cleared) keeps
+// controllerWorkQueryEnv at city coordinates; identity overrides are preserved
+// so the query still matches work routed/assigned to this agent. Best-effort:
+// returns stores unchanged when the city env cannot be built, and the city
+// entry is appended LAST so the rig store keeps firstStoreWithWork's
+// emit-on-timeout contract as the primary entry.
+func appendCityHookStore(stores []hookStore, cityPath string, cfg *config.City, a *config.Agent, identityOverrides map[string]string) []hookStore {
+	if cfg == nil || a == nil {
+		return stores
+	}
+	view := *a
+	view.Dir = ""
+	cityEnv, err := hookQueryEnv(cityPath, cfg, &view)
+	if err != nil || cityEnv == nil {
+		return stores
+	}
+	for _, k := range hookIdentityEnvKeys {
+		if v, ok := identityOverrides[k]; ok {
+			cityEnv[k] = v
+		}
+	}
+	return append(stores, hookStore{
+		dir: cityPath,
+		env: mergeRuntimeEnv(os.Environ(), cityEnv),
+	})
+}
+
 // rigScopedHookRig returns the rig whose store a rig-scoped agent must ALSO
 // query, or "" if none applies. A rig-scoped agent's identity is "<rig>/<name>"
 // (its GC_AGENT) and its routed work lives in the <rig> store, which the agent's


### PR DESCRIPTION
## Problem

`gc hook`'s store federation is asymmetric. City-scoped agents federate their work query across all rig stores (#2877, vp-kvp stage iii). A rig-scoped agent gets `[rig store (primary), own env]` — but a rig-backed agent's own env is **also rig-scoped** (`controllerWorkQueryEnv` switches to rig coordinates whenever the agent has a configured rig, #514). The city store is never queried.

Consequence: any root-only (city-store) bead assigned to a rig-scoped agent is invisible to its hook — the hook reports "no work" (exit 1, silent, per the documented empty contract) while assigned work sits open. In production this fires every patrol cycle for a rig witness whose singleton patrol wisps are created in the city store; the comment on `rigScopedHookRig` ("its city-scoped work-query env does not reach [rig work]") describes the inverse hole and masked this one.

Reproduced live: a plain open city bead assigned to `<rig>/gastown.witness`; the hook (both in-session env replay and positional form) returned empty; a direct city-store `bd ready --assignee=<same>` found it instantly. Identity forms and ephemeral semantics ruled out by measurement.

## Fix

`appendCityHookStore` in `hook_cross_store.go`: append the CITY store as a best-effort tertiary entry in the rig-scoped branch, mirroring #2877 in the opposite direction. A city view of the agent (`view.Dir = ""`) makes `controllerWorkQueryEnv` keep city coordinates; identity overrides are preserved the same way `appendOneRigHookStore` does. The rig store stays the primary entry, so `firstStoreWithWork`'s emit-on-timeout contract on the agent's own store is unchanged, and a broken city env degrades to today's behavior (best-effort, returns stores unchanged).

## Tests

- `TestCmdHookRigScopedAgentFindsCityStoreWork` — fake `bd` answers with one ready row only when `BEADS_DIR` is the city store: fails before the fix (hook exits 1, city work invisible), passes with it.
- Full `./cmd/gc` test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
