### PR TITLE
fix(testenv): follow-up prod Dolt port guard after #3357

### DIFF
--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -45,22 +45,29 @@
 // deliberately set (via its own `env FOO=bar` line) reach the subcommand.
 // Testscript owns the child env fully, so there is no leak risk.
 //
-// Production Dolt port guard: a Dolt port var (BEADS_DOLT_SERVER_PORT or
-// GC_DOLT_PORT) carrying ProdDoltPort that would survive into the process —
-// passthrough-preserved in go-test mode, or any value in testscript
-// subcommand mode — makes init() panic instead, unless the paired Dolt host
-// var survives with a non-local value (3307 is Dolt's default port, so
-// external-server fixtures like db.example.com:3307 are legitimate). Test
-// debris (testrig, tt, my_db databases) inside the production Dolt store
-// traced back to test clients reaching the local server on port 3307
+// Production Dolt port guard: a Dolt port var (BEADS_DOLT_SERVER_PORT,
+// GC_DOLT_PORT, or BEADS_DOLT_PORT) carrying ProdDoltPort that would survive
+// into the process — passthrough-preserved in go-test mode, or any value in
+// testscript subcommand mode — makes init() panic instead, unless the paired
+// Dolt host var survives with a non-local value (3307 is Dolt's default
+// port, so external-server fixtures like db.example.com:3307 are
+// legitimate). Port values are matched numerically the way consumers parse
+// them, so "03307" and "+3307" also refuse. BEADS_DOLT_PORT has no paired
+// host var — the beads library consumes it on multiple paths, as a legacy
+// server-port alias as well as for local/auto-started servers, so its
+// effective host cannot be proven from env pairing — and the guard fails
+// closed: it is treated as implicitly local and no host value disarms it.
+// Test debris (testrig, tt, my_db databases) inside the production Dolt
+// store traced back to test clients reaching the local server on port 3307
 // (ga-4c2ss6). For the rare legitimate case, set ProdDoltPortOptOutVar
 // (GC_ALLOW_PROD_DOLT_PORT_IN_TESTS) to "1".
 package testenv
 
 import (
-	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -88,12 +95,17 @@ const PassthroughVar = "GC_TESTENV_PASSTHROUGH"
 // package init except for names listed in PassthroughVar.
 //
 // Adding a new env var that names a city path, session identity, bead store,
-// or managed Dolt target? Add it here too. Test-gate vars (GC_FAST_UNIT,
-// GC_REAL_PROCESS_SIGNAL_TESTS, GC_DOLT_REAL_BINARY, ...) do NOT belong here;
-// they're how tests opt into expensive paths.
+// or managed Dolt target? Add it here too. Every key and non-empty value of
+// doltPortVars MUST appear here: refuseProdDoltPort models post-scrub
+// survival via the passthrough list, which is only exact for vars this scrub
+// actually unsets. TestDoltPortVarsAreLeakVectors enforces that pairing.
+// Test-gate vars (GC_FAST_UNIT, GC_REAL_PROCESS_SIGNAL_TESTS,
+// GC_DOLT_REAL_BINARY, ...) do NOT belong here; they're how tests opt into
+// expensive paths.
 var LeakVectorVars = []string{
 	"BEADS_DIR",
 	"BEADS_DOLT_PASSWORD",
+	"BEADS_DOLT_PORT",
 	"BEADS_DOLT_SERVER_HOST",
 	"BEADS_DOLT_SERVER_PORT",
 	"BEADS_DOLT_SERVER_USER",
@@ -132,31 +144,51 @@ const ProdDoltPort = "3307"
 const ProdDoltPortOptOutVar = "GC_ALLOW_PROD_DOLT_PORT_IN_TESTS"
 
 // doltPortVars maps each env var that selects a Dolt server port to the env
-// var that selects the matching Dolt server host.
+// var that selects the matching Dolt server host. An empty host var name
+// means the port var has no host pairing: BEADS_DOLT_PORT feeds multiple
+// beads code paths — a legacy server-port alias as well as local/auto-start
+// inputs — so its effective host cannot be proven from any env pairing. The
+// guard fails closed and treats it as implicitly local; no surviving host
+// value can disarm it. Every key and non-empty value here MUST also appear
+// in LeakVectorVars so the guard's survival model matches the scrub;
+// TestDoltPortVarsAreLeakVectors enforces that pairing.
 var doltPortVars = map[string]string{
+	"BEADS_DOLT_PORT":        "",
 	"BEADS_DOLT_SERVER_PORT": "BEADS_DOLT_SERVER_HOST",
 	"GC_DOLT_PORT":           "GC_DOLT_HOST",
 }
 
 // isLocalDoltHost reports whether a Dolt host value targets the local
 // machine: empty (clients default to localhost), "localhost", a loopback
-// address, or an unspecified address.
+// address, or an unspecified address, including bracketed IPv6 literals
+// like "[::1]". Mirrors the canonical contract.DoltHostIsLocal
+// (internal/beads/contract/connection.go) — kept as a stdlib-only copy so
+// this package, blank-imported by every test binary, links no domain
+// packages. TestIsLocalDoltHostMatchesCanonicalClassifier pins the two
+// classifiers together.
 func isLocalDoltHost(host string) bool {
-	host = strings.ToLower(strings.TrimSpace(host))
+	host = strings.Trim(strings.ToLower(strings.TrimSpace(host)), "[]")
 	if host == "" || host == "localhost" {
 		return true
 	}
-	ip := net.ParseIP(host)
-	return ip != nil && (ip.IsLoopback() || ip.IsUnspecified())
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	return addr.IsLoopback() || addr.IsUnspecified()
 }
 
 // refuseProdDoltPort panics when a Dolt port var that will outlive init()
 // points at the local production Dolt server. survives reports whether the
 // named var survives the scrub: always in testscript subcommand mode,
-// passthrough-listed only in go-test mode. A paired host var that survives
-// with a non-local value disarms the guard for that pair — 3307 is Dolt's
-// default port, so external-server fixtures use it legitimately.
-// ProdDoltPortOptOutVar set to "1" disables the guard entirely.
+// passthrough-listed only in go-test mode. Port values are parsed with
+// strconv.Atoi the way consumers do, so numeric equivalents of ProdDoltPort
+// like "03307" and "+3307" fire too; unparsable values never reach a server
+// and are skipped. A paired host var that survives with a non-local value
+// disarms the guard for that pair — 3307 is Dolt's default port, so
+// external-server fixtures use it legitimately. A port var with no paired
+// host var is implicitly local and is never disarmed. ProdDoltPortOptOutVar
+// set to "1" disables the guard entirely.
 func refuseProdDoltPort(survives func(name string) bool) {
 	if os.Getenv(ProdDoltPortOptOutVar) == "1" {
 		return
@@ -165,11 +197,12 @@ func refuseProdDoltPort(survives func(name string) bool) {
 		if !survives(portVar) {
 			continue
 		}
-		if strings.TrimSpace(os.Getenv(portVar)) != ProdDoltPort {
+		port, err := strconv.Atoi(strings.TrimSpace(os.Getenv(portVar)))
+		if err != nil || strconv.Itoa(port) != ProdDoltPort {
 			continue
 		}
 		host := ""
-		if survives(hostVar) {
+		if hostVar != "" && survives(hostVar) {
 			host = os.Getenv(hostVar)
 		}
 		if !isLocalDoltHost(host) {

--- a/internal/testenv/testenv_internal_test.go
+++ b/internal/testenv/testenv_internal_test.go
@@ -1,0 +1,79 @@
+package testenv
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+)
+
+// localDoltHostCases classifies every isLocalDoltHost branch: empty values,
+// localhost with case/whitespace noise, IPv4/IPv6 loopback, bracketed IPv6
+// literals, unspecified addresses, and external values that must not be
+// treated as local.
+var localDoltHostCases = []struct {
+	host string
+	want bool
+}{
+	{"", true},
+	{"   ", true},
+	{"localhost", true},
+	{" LOCALHOST ", true},
+	{"127.0.0.1", true},
+	{" 127.0.0.1 ", true},
+	{"::1", true},
+	{"[::1]", true},
+	{"0.0.0.0", true},
+	{"::", true},
+	{"[::]", true},
+	{"city-db.example.com", false},
+	{"192.0.2.10", false},
+	{"2001:db8::10", false},
+	{"[2001:db8::10]", false},
+}
+
+// TestIsLocalDoltHost exercises every isLocalDoltHost branch directly,
+// including the bracketed IPv6 forms that originally bypassed the
+// prod-Dolt-port guard.
+func TestIsLocalDoltHost(t *testing.T) {
+	for _, tc := range localDoltHostCases {
+		if got := isLocalDoltHost(tc.host); got != tc.want {
+			t.Errorf("isLocalDoltHost(%q) = %v, want %v", tc.host, got, tc.want)
+		}
+	}
+}
+
+// TestIsLocalDoltHostMatchesCanonicalClassifier pins isLocalDoltHost to the
+// canonical contract.DoltHostIsLocal semantics. isLocalDoltHost is a
+// stdlib-only copy — this package is blank-imported by every test binary and
+// must not link domain packages — and a host form the canonical classifier
+// calls local but the copy does not is exactly the divergence that let
+// "[::1]":3307 reach the production Dolt server.
+func TestIsLocalDoltHostMatchesCanonicalClassifier(t *testing.T) {
+	for _, tc := range localDoltHostCases {
+		if got, want := isLocalDoltHost(tc.host), contract.DoltHostIsLocal(tc.host); got != want {
+			t.Errorf("isLocalDoltHost(%q) = %v, but contract.DoltHostIsLocal(%q) = %v; keep the testenv copy aligned with the canonical classifier", tc.host, got, tc.host, want)
+		}
+	}
+}
+
+// TestDoltPortVarsAreLeakVectors enforces the load-bearing coupling between
+// the prod-Dolt-port guard and the scrub: refuseProdDoltPort models
+// post-scrub survival via the passthrough list, which is only exact when
+// every var it guards is also scrubbed. A doltPortVars entry missing from
+// LeakVectorVars fails silently in the dangerous direction — skipped by the
+// guard (not passthrough-listed, so survives reports false) yet kept by the
+// scrub.
+func TestDoltPortVarsAreLeakVectors(t *testing.T) {
+	leak := make(map[string]bool, len(LeakVectorVars))
+	for _, name := range LeakVectorVars {
+		leak[name] = true
+	}
+	for portVar, hostVar := range doltPortVars {
+		if !leak[portVar] {
+			t.Errorf("doltPortVars key %q is missing from LeakVectorVars; every guarded Dolt port var must also be scrubbed", portVar)
+		}
+		if hostVar != "" && !leak[hostVar] {
+			t.Errorf("doltPortVars[%q] host var %q is missing from LeakVectorVars; every guarded Dolt host var must also be scrubbed", portVar, hostVar)
+		}
+	}
+}

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -155,15 +155,21 @@ func TestInitSkipsScrubInTestscriptSubcommandMode(t *testing.T) {
 // a test process. The guard fires only for values that would outlive the
 // scrub — passthrough-preserved vars in go-test mode, and all vars in
 // testscript subcommand mode (where the scrub is skipped) — and only when the
-// effective Dolt host is local (unset, scrubbed, localhost, or loopback).
-// External hosts on 3307 (Dolt's default port) are legitimate fixtures.
-// Setting GC_ALLOW_PROD_DOLT_PORT_IN_TESTS=1 opts out for the rare
-// legitimate case.
+// effective Dolt host is local (unset, scrubbed, localhost, loopback, or
+// unspecified, including bracketed IPv6 forms like "[::1]"). Port values are
+// matched numerically the way consumers parse them, so "03307" and "+3307"
+// also refuse while unparsable values pass through. BEADS_DOLT_PORT feeds
+// multiple beads code paths — a legacy server-port alias as well as
+// local/auto-start inputs — so no env pairing proves its effective host; the
+// guard fails closed, treats it as implicitly local, and no surviving host
+// value disarms it. External hosts on 3307 (Dolt's default port) are
+// legitimate fixtures. Setting GC_ALLOW_PROD_DOLT_PORT_IN_TESTS=1 opts out
+// for the rare legitimate case.
 func TestInitRefusesProdDoltPort(t *testing.T) {
 	if os.Getenv("GC_TESTENV_CHILD") == "1" {
 		// Child: report the Dolt host/port vars as the parent's env shaped them.
 		var lines []string
-		for _, name := range []string{"BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "GC_DOLT_HOST", "GC_DOLT_PORT"} {
+		for _, name := range []string{"BEADS_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "GC_DOLT_HOST", "GC_DOLT_PORT"} {
 			lines = append(lines, name+"="+os.Getenv(name))
 		}
 		os.Stdout.WriteString(strings.Join(lines, "\n") + "\n") //nolint:errcheck
@@ -207,6 +213,26 @@ func TestInitRefusesProdDoltPort(t *testing.T) {
 			wantPanic: true,
 		},
 		{
+			name: "passthrough zero-padded prod port panics",
+			bin:  exe,
+			env: []string{
+				// Consumers parse the port with strconv.Atoi, so "03307"
+				// reaches the production server just like "3307".
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_PORT=03307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough plus-signed prod port panics",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=GC_DOLT_PORT",
+				"GC_DOLT_PORT=+3307",
+			},
+			wantPanic: true,
+		},
+		{
 			name: "passthrough non-prod port survives",
 			bin:  exe,
 			env: []string{
@@ -214,6 +240,17 @@ func TestInitRefusesProdDoltPort(t *testing.T) {
 				"BEADS_DOLT_SERVER_PORT=3308",
 			},
 			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=3308\n"},
+		},
+		{
+			name: "passthrough unparsable port value survives",
+			bin:  exe,
+			env: []string{
+				// strconv.Atoi rejects "3307x", so consumers never use it to
+				// reach a server and the guard must not refuse it.
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_PORT=3307x",
+			},
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=3307x\n"},
 		},
 		{
 			name: "passthrough external host allows prod port",
@@ -235,6 +272,46 @@ func TestInitRefusesProdDoltPort(t *testing.T) {
 				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_HOST,BEADS_DOLT_SERVER_PORT",
 				"BEADS_DOLT_SERVER_HOST=127.0.0.1",
 				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough bracketed IPv6 loopback host refuses prod port",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_HOST,BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_HOST=[::1]",
+				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough bracketed unspecified host refuses prod port",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_HOST,BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_HOST=[::]",
+				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough GC bracketed IPv6 loopback host refuses prod port",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=GC_DOLT_HOST,GC_DOLT_PORT",
+				"GC_DOLT_HOST=[::1]",
+				"GC_DOLT_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough GC bracketed unspecified host refuses prod port",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=GC_DOLT_HOST,GC_DOLT_PORT",
+				"GC_DOLT_HOST=[::]",
+				"GC_DOLT_PORT=3307",
 			},
 			wantPanic: true,
 		},
@@ -262,6 +339,38 @@ func TestInitRefusesProdDoltPort(t *testing.T) {
 				"GC_DOLT_HOST=city-db.example.com\n",
 				"GC_DOLT_PORT=3307\n",
 			},
+		},
+		{
+			name: "passthrough BEADS_DOLT_PORT prod port panics",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_PORT",
+				"BEADS_DOLT_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name: "passthrough BEADS_DOLT_PORT non-prod port survives",
+			bin:  exe,
+			env: []string{
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_PORT",
+				"BEADS_DOLT_PORT=3308",
+			},
+			wantOutput: []string{"BEADS_DOLT_PORT=3308\n"},
+		},
+		{
+			name: "passthrough external host does not disarm BEADS_DOLT_PORT",
+			bin:  exe,
+			env: []string{
+				// BEADS_DOLT_PORT feeds multiple beads code paths — a legacy
+				// server-port alias as well as local/auto-start inputs — so no
+				// env pairing proves its effective host; a surviving external
+				// server host must not disarm its guard.
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_HOST,BEADS_DOLT_PORT",
+				"BEADS_DOLT_SERVER_HOST=city-db.example.com",
+				"BEADS_DOLT_PORT=3307",
+			},
+			wantPanic: true,
 		},
 		{
 			name: "opt-out allows prod port through passthrough",
@@ -313,6 +422,27 @@ func TestInitRefusesProdDoltPort(t *testing.T) {
 				"BEADS_DOLT_SERVER_HOST=localhost",
 				"BEADS_DOLT_SERVER_PORT=3307",
 			},
+			wantPanic: true,
+		},
+		{
+			name: "subcommand mode bracketed IPv6 loopback host refuses prod port",
+			bin:  fakeGC,
+			env: []string{
+				"BEADS_DOLT_SERVER_HOST=[::1]",
+				"BEADS_DOLT_SERVER_PORT=3307",
+			},
+			wantPanic: true,
+		},
+		{
+			name:      "subcommand mode BEADS_DOLT_PORT refuses prod port",
+			bin:       fakeGC,
+			env:       []string{"BEADS_DOLT_PORT=3307"},
+			wantPanic: true,
+		},
+		{
+			name:      "subcommand mode zero-padded BEADS_DOLT_PORT refuses prod port",
+			bin:       fakeGC,
+			env:       []string{"BEADS_DOLT_PORT=03307"},
 			wantPanic: true,
 		},
 		{


### PR DESCRIPTION
Follow-up to #3357.

Original PR: https://github.com/gastownhall/gascity/pull/3357
Original title: feat(testenv): refuse local prod Dolt port 3307 in test binaries (ga-4c2ss6)
Original state: MERGED at 2026-06-12T15:11:24Z
Configured workflow base: main
Original GitHub base: main
Base mismatch: none

The original PR landed on main before the adopt workflow could push the reviewed maintainer fix. This follow-up contains only the maintainer-side fix commit from the approved adoption review; the contributor change set from #3357 is already on main.

Changes in this follow-up:
- Close the bracketed IPv6 local-host bypass for the testenv Dolt-port guard.
- Fence BEADS_DOLT_PORT alongside the existing Dolt port variables.
- Add regression coverage for the new guarded cases and the leak-vector coupling.

Review and validation:
- Adopt workflow root: ga-wisp-xis5bu
- Latest adoption review attempt: 2, decision approve
- git diff --check refs/adopt-pr/ga-ptwqh7/latest-base..HEAD
- go test ./internal/testenv
- go test ./cmd/gc/ -run TestInitAndHookDirExecGcBeadsBd