### PR TITLE
fix(supervisor): harden delegated systemd lifecycle

### DIFF
--- a/cmd/gc/cmd_start_drift.go
+++ b/cmd/gc/cmd_start_drift.go
@@ -340,7 +340,12 @@ func runStartDriftCheck(cityPath string, stdout, stderr io.Writer) (int, bool) {
 		} else {
 			restartErr = restartSupervisor(spec, restartHelpersHook())
 		}
-		if restartErr != nil {
+		// A bounded delegated try-restart timeout is not terminal: the
+		// restart job can still complete inside systemd after the CLI stops
+		// waiting, so fall through to PollReady and the post-restart drift
+		// verification below, which confirm whether the supervisor was
+		// actually replaced. Ordinary restart failures stay terminal.
+		if restartErr != nil && !isDelegatedSystemctlTimeout(restartErr) {
 			fmt.Fprintln(stdout)                                                      //nolint:errcheck // best-effort stdout
 			fmt.Fprintf(stderr, "error: supervisor restart failed: %v\n", restartErr) //nolint:errcheck // best-effort stderr
 			return 1, false

--- a/cmd/gc/cmd_start_drift.go
+++ b/cmd/gc/cmd_start_drift.go
@@ -174,8 +174,13 @@ func printDriftReport(w io.Writer, r driftReport) {
 
 // driftReadyTimeout caps how long PollReady waits after a restart for
 // the new supervisor to come up. Five seconds matches NFR-2 in the
-// architect's brief.
+// architect's brief. It also caps pollDelegatedRestartVerified's wait for
+// a delegated restart to land its replacement.
 var driftReadyTimeout = 5 * time.Second
+
+// driftVerifyProbeTimeout bounds each supervisor Status probe inside
+// pollDelegatedRestartVerified's post-restart verification poll.
+var driftVerifyProbeTimeout = 2 * time.Second
 
 // restartHelpersHook lets tests substitute a fake set of helpers for
 // the production kill+spawn (or systemctl) side effects.
@@ -350,38 +355,25 @@ func runStartDriftCheck(cityPath string, stdout, stderr io.Writer) (int, bool) {
 			fmt.Fprintf(stderr, "error: supervisor restart failed: %v\n", restartErr) //nolint:errcheck // best-effort stderr
 			return 1, false
 		}
-		// Wait for the new supervisor to come up.
-		if err := PollReady(newHTTPSupervisorClient(baseURL), driftReadyTimeout); err != nil {
-			fmt.Fprintln(stdout)                                                                                                                                                  //nolint:errcheck // best-effort stdout
-			fmt.Fprintf(stderr, "error: supervisor restart timed out after %s; check '%s' for details. Last known pid=%d.\n", driftReadyTimeout, supervisorStatusGuidance(), pid) //nolint:errcheck // best-effort stderr
-			return 1, false
-		}
 		if delegated {
-			// `try-restart` no-ops successfully when the unit is inactive,
-			// and PollReady answers from whatever process serves /health —
-			// the OLD supervisor when the unit never managed it. A unit can
-			// also genuinely replace the process while its ExecStart still
-			// launches the drifted binary. Require evidence that the drift
-			// actually cleared — not merely that the process changed — and
-			// treat an unverifiable post-restart probe as failure, instead
-			// of reporting "ready" while a stale supervisor keeps serving.
-			vctx, vcancel := context.WithTimeout(context.Background(), 2*time.Second)
-			verifyStatus, verifyErr := newHTTPSupervisorClient(baseURL).Status(vctx)
-			vcancel()
-			if verifyErr != nil {
-				fmt.Fprintln(stdout)                                                                                                                                              //nolint:errcheck // best-effort stdout
-				fmt.Fprintf(stderr, "error: cannot verify supervisor after '%s': %v; check '%s'\n", delegation.commandHint("try-restart"), verifyErr, supervisorStatusGuidance()) //nolint:errcheck // best-effort stderr
+			// A delegated try-restart can fall through a bounded CLI timeout
+			// (or restart the unit asynchronously) with systemd's restart job
+			// still in flight, so the OLD supervisor may keep answering
+			// /health for a moment. A single early probe — or PollReady, which
+			// answers from whatever serves /health — would then misreport "was
+			// not replaced" before the late replacement lands. Poll for genuine
+			// replacement *and* drift-clearance evidence until it is observed
+			// or driftReadyTimeout expires, then surface the last obstacle.
+			if msg := pollDelegatedRestartVerified(baseURL, pid, status.BuildID, commit, delegation, driftReadyTimeout); msg != "" {
+				fmt.Fprintln(stdout)             //nolint:errcheck // best-effort stdout
+				fmt.Fprintf(stderr, "%s\n", msg) //nolint:errcheck // best-effort stderr
 				return 1, false
 			}
-			verifyPID := supervisorAliveHook()
-			if verifyPID == pid && verifyStatus.BuildID == status.BuildID {
-				fmt.Fprintln(stdout)                                                                                                                                                                                                                                                                                                                    //nolint:errcheck // best-effort stdout
-				fmt.Fprintf(stderr, "error: supervisor was not replaced by '%s': PID %d still serving build %s; it is not managed by delegated unit %s — stop it with 'gc supervisor stop' (%s unset), or fix the delegation env\n", delegation.commandHint("try-restart"), verifyPID, verifyStatus.BuildID, delegation.Unit, supervisorSystemdUnitEnv) //nolint:errcheck // best-effort stderr
-				return 1, false
-			}
-			if DetectBinaryDrift(commit, verifyStatus) {
-				fmt.Fprintln(stdout)                                                                                                                                                                                                                                                                                                           //nolint:errcheck // best-effort stdout
-				fmt.Fprintf(stderr, "error: supervisor restarted by '%s' but still serves drifted build %s (local build %s); unit %s's ExecStart does not launch the updated gc binary — point the unit at the new binary, or fix the delegation env\n", delegation.commandHint("try-restart"), verifyStatus.BuildID, commit, delegation.Unit) //nolint:errcheck // best-effort stderr
+		} else {
+			// Wait for the new supervisor to come up.
+			if err := PollReady(newHTTPSupervisorClient(baseURL), driftReadyTimeout); err != nil {
+				fmt.Fprintln(stdout)                                                                                                                                                  //nolint:errcheck // best-effort stdout
+				fmt.Fprintf(stderr, "error: supervisor restart timed out after %s; check '%s' for details. Last known pid=%d.\n", driftReadyTimeout, supervisorStatusGuidance(), pid) //nolint:errcheck // best-effort stderr
 				return 1, false
 			}
 		}
@@ -418,6 +410,51 @@ func runStartDriftCheck(cityPath string, stdout, stderr io.Writer) (int, bool) {
 	}
 	// Unreachable; decideDriftAction always sets exactly one disposition.
 	return 0, true
+}
+
+// pollDelegatedRestartVerified polls the supervisor API after a delegated
+// `systemctl try-restart` until it observes that the supervisor was both
+// replaced (a new PID, or a new served build identity) and is no longer
+// drifted (the served build matches localBuildID), or readyTimeout
+// expires. It returns "" on success; otherwise it returns the
+// operator-facing diagnostic for the last obstacle observed.
+//
+// Polling — rather than a single probe — is load-bearing for the
+// bounded-timeout fall-through: a `systemctl try-restart` that exceeds
+// delegatedSystemctlJobTimeout leaves systemd's restart job running while
+// the OLD supervisor still answers /health, so verifying once would
+// misreport "was not replaced" before the late replacement lands. The
+// failure arms it can report — an unverifiable probe, a supervisor that was
+// never replaced, and a replacement whose ExecStart still serves the
+// drifted build — mirror the single-probe checks they replace.
+func pollDelegatedRestartVerified(baseURL string, oldPID int, oldBuildID, localBuildID string, d systemdDelegation, readyTimeout time.Duration) string {
+	client := newHTTPSupervisorClient(baseURL)
+	deadline := time.Now().Add(readyTimeout)
+	var lastMsg string
+	for {
+		vctx, vcancel := context.WithTimeout(context.Background(), driftVerifyProbeTimeout)
+		verifyStatus, verifyErr := client.Status(vctx)
+		vcancel()
+		switch {
+		case verifyErr != nil:
+			lastMsg = fmt.Sprintf("error: cannot verify supervisor after '%s': %v; check '%s'", d.commandHint("try-restart"), verifyErr, supervisorStatusGuidance())
+		default:
+			verifyPID := supervisorAliveHook()
+			switch {
+			case verifyPID == oldPID && verifyStatus.BuildID == oldBuildID:
+				lastMsg = fmt.Sprintf("error: supervisor was not replaced by '%s': PID %d still serving build %s; it is not managed by delegated unit %s — stop it with 'gc supervisor stop' (%s unset), or fix the delegation env", d.commandHint("try-restart"), verifyPID, verifyStatus.BuildID, d.Unit, supervisorSystemdUnitEnv)
+			case DetectBinaryDrift(localBuildID, verifyStatus):
+				lastMsg = fmt.Sprintf("error: supervisor restarted by '%s' but still serves drifted build %s (local build %s); unit %s's ExecStart does not launch the updated gc binary — point the unit at the new binary, or fix the delegation env", d.commandHint("try-restart"), verifyStatus.BuildID, localBuildID, d.Unit)
+			default:
+				// Replaced and drift cleared.
+				return ""
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return lastMsg
+		}
+		time.Sleep(supervisorReadyPollInterval)
+	}
 }
 
 func printUnreadableSupervisorRestartError(stderr io.Writer, pid int, exeErr error) {

--- a/cmd/gc/cmd_start_drift.go
+++ b/cmd/gc/cmd_start_drift.go
@@ -336,7 +336,7 @@ func runStartDriftCheck(cityPath string, stdout, stderr io.Writer) (int, bool) {
 			// try-restart: restart only if the unit is running. The drift
 			// path only fires when a supervisor is alive, and a stopped
 			// delegated unit must stay stopped — its operator owns starts.
-			restartErr = runDelegatedSystemctl(delegation, "try-restart")
+			restartErr = runDelegatedSystemctlTimeout(delegation, "try-restart", delegatedSystemctlJobTimeout)
 		} else {
 			restartErr = restartSupervisor(spec, restartHelpersHook())
 		}

--- a/cmd/gc/cmd_start_drift_test.go
+++ b/cmd/gc/cmd_start_drift_test.go
@@ -281,6 +281,18 @@ func driftCheckEnv(t *testing.T, supervisorBuildID string) (cityPath string, res
 	return cityPath, restoreCommit
 }
 
+// shrinkDriftReadyTimeout shortens the post-restart verification budget to
+// 300ms so delegated drift tests whose restart never lands (or whose probe
+// never verifies) fail fast instead of waiting the full production
+// driftReadyTimeout — pollDelegatedRestartVerified polls until that budget
+// expires before reporting the last obstacle.
+func shrinkDriftReadyTimeout(t *testing.T) {
+	t.Helper()
+	old := driftReadyTimeout
+	driftReadyTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { driftReadyTimeout = old })
+}
+
 // TestRunStartDriftCheck_RestartReturnsContinue pins the load-bearing
 // post-restart contract: when drift triggers a successful auto-restart,
 // runStartDriftCheck must return (0, true) so the caller continues into

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -561,11 +561,18 @@ func ensureSupervisorRunning(stdout, stderr io.Writer) int {
 		if supervisorAliveHook() != 0 {
 			return 0
 		}
-		if err := runDelegatedSystemctl(delegation, "start"); err != nil {
+		if err := runDelegatedSystemctlTimeout(delegation, "start", delegatedSystemctlJobTimeout); err != nil {
 			fmt.Fprintf(stderr, "gc: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if waitForSupervisorPID() != 0 {
+			return 0
+		}
+		// The socket never answered — the expected state for a
+		// system-scope unit under another uid. Trust the same fallback
+		// evidence status does (unit active, then API) before calling
+		// the start a failure.
+		if delegatedLivenessWithoutSocket(delegation) != "" {
 			return 0
 		}
 		// A delegated supervisor logs to the journal, not gc's fork-mode

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -561,7 +561,10 @@ func ensureSupervisorRunning(stdout, stderr io.Writer) int {
 		if supervisorAliveHook() != 0 {
 			return 0
 		}
-		if err := runDelegatedSystemctlTimeout(delegation, "start", delegatedSystemctlJobTimeout); err != nil {
+		// A bounded systemctl-start timeout is not terminal: fall through to
+		// the same socket-then-fallback liveness check that confirms a late
+		// start. Only an ordinary systemctl failure is terminal.
+		if err := runDelegatedSystemctlTimeout(delegation, "start", delegatedSystemctlJobTimeout); err != nil && !isDelegatedSystemctlTimeout(err) {
 			fmt.Fprintf(stderr, "gc: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}

--- a/cmd/gc/lifecycle_action_json.go
+++ b/cmd/gc/lifecycle_action_json.go
@@ -13,12 +13,17 @@ type lifecycleActionJSON struct {
 	CityName      string `json:"city_name,omitempty"`
 	CityPath      string `json:"city_path,omitempty"`
 	SupervisorPID int    `json:"supervisor_pid,omitempty"`
-	Wait          *bool  `json:"wait,omitempty"`
-	Force         *bool  `json:"force,omitempty"`
-	Async         *bool  `json:"async,omitempty"`
-	Soft          *bool  `json:"soft,omitempty"`
-	Outcome       string `json:"outcome,omitempty"`
-	Revision      string `json:"revision,omitempty"`
+	// PIDSource names the non-socket evidence a delegated start trusted
+	// when the control socket stayed unreachable ("service_manager" or
+	// "api"), mirroring `gc supervisor status --json`'s pid_source.
+	// Empty when SupervisorPID came from the socket.
+	PIDSource string `json:"pid_source,omitempty"`
+	Wait      *bool  `json:"wait,omitempty"`
+	Force     *bool  `json:"force,omitempty"`
+	Async     *bool  `json:"async,omitempty"`
+	Soft      *bool  `json:"soft,omitempty"`
+	Outcome   string `json:"outcome,omitempty"`
+	Revision  string `json:"revision,omitempty"`
 }
 
 func writeLifecycleActionJSON(stdout io.Writer, payload lifecycleActionJSON) error {

--- a/cmd/gc/supervisor_systemd_delegate.go
+++ b/cmd/gc/supervisor_systemd_delegate.go
@@ -176,19 +176,45 @@ func (d systemdDelegation) commandHint(verb string) string {
 	return "systemctl " + strings.Join(d.systemctlArgs(verb), " ")
 }
 
+// delegatedIsActiveTimeout bounds the delegated `systemctl is-active`
+// probe. is-active is a quick unit-state query, but the same wedged
+// manager or D-Bus connection that makes a delegated `systemctl
+// start`/`try-restart` block past delegatedSystemctlJobTimeout also blocks
+// is-active. The is-active fallback runs precisely after such a bounded
+// start/restart timeout — inside delegatedLivenessWithoutSocket and the
+// delegated `gc supervisor status` service-manager probe — so without a
+// CLI-side bound it would hang `gc supervisor start`, `gc start`, and `gc
+// supervisor status` forever, defeating the bound the mutating call just
+// enforced and starving the supervisor-API fallback that follows it.
+// Package var so tests can shrink the wait.
+var delegatedIsActiveTimeout = 10 * time.Second
+
 // delegatedUnitActive reports whether the delegated unit is currently
 // active, via `systemctl [--user] is-active --quiet <unit>` resolved on
-// PATH. A missing systemctl binary or unreachable manager reads as
-// inactive.
+// PATH and bounded by delegatedIsActiveTimeout. A missing systemctl
+// binary, an unreachable manager, or a probe that exceeds the bound reads
+// as inactive, so callers fall through to the next liveness signal (the
+// supervisor API) instead of blocking on a wedged manager.
 //
 // Decision: delegated paths exec PATH-resolved systemctl directly instead
 // of routing through the supervisorSystemctlRun hook, and the PATH-shim
 // fake systemctl (argv-recording) is the canonical test seam for them.
-// The bounded stop needs CommandContext+WaitDelay semantics the hook
-// cannot express, and the shim exercises the real exec path end to end.
-// delegatedSystemctlPath backstops the seam in test binaries.
+// The bounded stop and this bounded probe need CommandContext+WaitDelay
+// semantics the hook cannot express, and the shim exercises the real exec
+// path end to end. delegatedSystemctlPath backstops the seam in test
+// binaries.
 func delegatedUnitActive(d systemdDelegation) bool {
-	return exec.Command(delegatedSystemctlPath(), d.systemctlIsActiveArgs()...).Run() == nil
+	ctx := context.Background()
+	if delegatedIsActiveTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, delegatedIsActiveTimeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, delegatedSystemctlPath(), d.systemctlIsActiveArgs()...)
+	// Don't let an inherited pipe from a systemctl child stretch the wait
+	// past the kill the context deadline triggers.
+	cmd.WaitDelay = time.Second
+	return cmd.Run() == nil
 }
 
 // delegatedSystemctlTimeoutError reports that a delegated systemctl

--- a/cmd/gc/supervisor_systemd_delegate.go
+++ b/cmd/gc/supervisor_systemd_delegate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -61,8 +62,11 @@ var delegatedStopVerifyTimeout = 5 * time.Second
 // The budget sits above systemd's default 90s job timeout so a
 // default-configured unit surfaces systemd's own diagnostic first.
 // Killing systemctl at the bound does not cancel the job: it keeps
-// running inside systemd, and the readiness/verification polls that
-// follow pick up a late start on their own. Package var so tests can
+// running inside systemd. runDelegatedSystemctlTimeout reports that bound
+// as a delegatedSystemctlTimeoutError so the start, ensure, and drift
+// try-restart callers fall through into their own readiness or drift
+// verification — which observe a late start — instead of treating the
+// bounded wait as a terminal systemctl failure. Package var so tests can
 // shrink the wait.
 var delegatedSystemctlJobTimeout = 2 * time.Minute
 
@@ -187,13 +191,45 @@ func delegatedUnitActive(d systemdDelegation) bool {
 	return exec.Command(delegatedSystemctlPath(), d.systemctlIsActiveArgs()...).Run() == nil
 }
 
+// delegatedSystemctlTimeoutError reports that a delegated systemctl
+// invocation hit its CLI-side bound (delegatedSystemctlJobTimeout) before
+// systemctl returned. systemctl's unit job keeps running inside systemd
+// after the CLI stops waiting, so this is a bounded-wait outcome —
+// distinct from an ordinary systemctl failure — that callers with their
+// own readiness or drift verification should fall through into rather
+// than treat as terminal. Non-timeout systemctl errors stay terminal.
+type delegatedSystemctlTimeoutError struct {
+	args    string
+	timeout time.Duration
+}
+
+// Error implements error.
+func (e *delegatedSystemctlTimeoutError) Error() string {
+	return fmt.Sprintf("systemctl %s: timed out after %s", e.args, e.timeout)
+}
+
+// isDelegatedSystemctlTimeout reports whether err is a bounded-wait
+// timeout from runDelegatedSystemctlTimeout, as opposed to an ordinary
+// systemctl failure. Callers with their own post-start readiness or drift
+// verification use it to continue into that verification on timeout
+// instead of returning failure before a late systemd success can be
+// observed.
+func isDelegatedSystemctlTimeout(err error) bool {
+	var timeoutErr *delegatedSystemctlTimeoutError
+	return errors.As(err, &timeoutErr)
+}
+
 // runDelegatedSystemctlTimeout invokes systemctl (resolved via PATH) for
 // verb against the delegated unit, bounded by timeout (unbounded when
 // timeout <= 0), folding any output into the returned error so operators
 // see systemd's own diagnostic. systemctl runs unit jobs synchronously,
 // so the bound keeps a wedged unit from holding the CLI past its
 // advertised budget; the unit's own job keeps running inside systemd
-// after the CLI gives up waiting.
+// after the CLI gives up waiting. A timeout returns a
+// *delegatedSystemctlTimeoutError (see isDelegatedSystemctlTimeout) so
+// callers with their own readiness or drift verification can distinguish
+// the bounded wait from an ordinary systemctl failure; every other
+// failure is returned as an ordinary error.
 func runDelegatedSystemctlTimeout(d systemdDelegation, verb string, timeout time.Duration) error {
 	args := d.systemctlArgs(verb)
 	ctx := context.Background()
@@ -209,7 +245,7 @@ func runDelegatedSystemctlTimeout(d systemdDelegation, verb string, timeout time
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("systemctl %s: timed out after %s", strings.Join(args, " "), timeout)
+			return &delegatedSystemctlTimeoutError{args: strings.Join(args, " "), timeout: timeout}
 		}
 		if msg := strings.TrimSpace(string(out)); msg != "" {
 			return fmt.Errorf("systemctl %s: %w: %s", strings.Join(args, " "), err, msg)
@@ -266,7 +302,11 @@ func delegatedSupervisorStart(d systemdDelegation, stdout, stderr io.Writer, jso
 		fmt.Fprintf(stderr, "gc supervisor start: supervisor already running (PID %d)\n", pid) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if err := runDelegatedSystemctlTimeout(d, "start", delegatedSystemctlJobTimeout); err != nil {
+	// A bounded systemctl-start timeout is not terminal: the start job can
+	// still complete inside systemd after the CLI stops waiting, so fall
+	// through to the same readiness poll and is-active/API fallback that
+	// confirm a late start. Only an ordinary systemctl failure is terminal.
+	if err := runDelegatedSystemctlTimeout(d, "start", delegatedSystemctlJobTimeout); err != nil && !isDelegatedSystemctlTimeout(err) {
 		fmt.Fprintf(stderr, "gc supervisor start: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/supervisor_systemd_delegate.go
+++ b/cmd/gc/supervisor_systemd_delegate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -51,6 +52,69 @@ const (
 // managed. Package var so tests can shrink the wait.
 var delegatedStopVerifyTimeout = 5 * time.Second
 
+// delegatedSystemctlJobTimeout bounds the delegated `systemctl start`
+// and `systemctl try-restart` invocations. systemctl waits for the
+// unit's job synchronously, so without a CLI-side bound a unit with
+// TimeoutStartSec=infinity or a wedged manager/D-Bus connection holds
+// `gc supervisor start`, `gc start`, and drift remediation forever —
+// the failure mode the bounded delegated stop already defends against.
+// The budget sits above systemd's default 90s job timeout so a
+// default-configured unit surfaces systemd's own diagnostic first.
+// Killing systemctl at the bound does not cancel the job: it keeps
+// running inside systemd, and the readiness/verification polls that
+// follow pick up a late start on their own. Package var so tests can
+// shrink the wait.
+var delegatedSystemctlJobTimeout = 2 * time.Minute
+
+// hostSystemctlDirs lists the standard system binary directories a
+// PATH-resolved systemctl must not come from while running inside a
+// test binary. Tests that exercise delegated paths install an
+// argv-recording shim in a temp dir (installFakeDelegatedSystemctl);
+// resolving past it means the test is about to drive the host's real
+// systemd.
+var hostSystemctlDirs = []string{
+	"/bin/",
+	"/sbin/",
+	"/usr/bin/",
+	"/usr/sbin/",
+	"/usr/local/bin/",
+	"/usr/local/sbin/",
+}
+
+// delegatedSystemctlPath resolves the systemctl binary the delegated
+// paths exec. Delegated paths intentionally bypass the
+// supervisorSystemctlRun hook (see delegatedUnitActive), so the PATH
+// shim is the only test seam; this resolver backstops it by refusing —
+// in test binaries only — to return the host's real systemctl. Same
+// must-defend hazard class as guardSupervisorSocketDir: a test that
+// reaches a delegated exec without the shim installed would stop or
+// restart the operator's production supervisor unit. Production
+// behavior is unchanged (exec.Command performs the same PATH lookup).
+func delegatedSystemctlPath() string {
+	resolved, err := exec.LookPath("systemctl")
+	if err != nil {
+		// Let exec.Command surface its standard not-found error.
+		return "systemctl"
+	}
+	guardDelegatedSystemctlPath(resolved)
+	return resolved
+}
+
+// guardDelegatedSystemctlPath panics when a test binary resolved
+// systemctl into a host system directory instead of a test-installed
+// PATH shim. No-op outside test binaries.
+func guardDelegatedSystemctlPath(resolved string) {
+	if !isTestBinary() {
+		return
+	}
+	dir := filepath.Dir(resolved) + string(filepath.Separator)
+	for _, sys := range hostSystemctlDirs {
+		if dir == sys {
+			panic("delegated systemctl exec: refusing to run host systemctl (" + resolved + ") from a test binary; install a fake via installFakeDelegatedSystemctl or unset " + supervisorSystemdUnitEnv)
+		}
+	}
+}
+
 // systemdDelegation names the operator-managed systemd unit that owns the
 // supervisor lifecycle, plus the manager scope it lives in ("system" or
 // "user").
@@ -62,11 +126,16 @@ type systemdDelegation struct {
 // supervisorSystemdDelegation reads the delegation env vars. ok is false
 // when GC_SUPERVISOR_SYSTEMD_UNIT is unset or blank. An unrecognized
 // scope value is an error rather than a silent fallback so a typo cannot
-// quietly target the system manager.
+// quietly target the system manager, and a non-Linux platform is an
+// error rather than a low-level "systemctl: executable file not found"
+// once a lifecycle path execs — delegation is a systemd contract.
 func supervisorSystemdDelegation() (systemdDelegation, bool, error) {
 	unit := strings.TrimSpace(os.Getenv(supervisorSystemdUnitEnv))
 	if unit == "" {
 		return systemdDelegation{}, false, nil
+	}
+	if supervisorRuntimeGOOS != "linux" {
+		return systemdDelegation{}, false, fmt.Errorf("%s is set but systemd delegation requires linux (running on %s); unset it and use the platform service manager", supervisorSystemdUnitEnv, supervisorRuntimeGOOS)
 	}
 	scope := strings.TrimSpace(os.Getenv(supervisorSystemdScopeEnv))
 	switch scope {
@@ -113,22 +182,18 @@ func (d systemdDelegation) commandHint(verb string) string {
 // fake systemctl (argv-recording) is the canonical test seam for them.
 // The bounded stop needs CommandContext+WaitDelay semantics the hook
 // cannot express, and the shim exercises the real exec path end to end.
+// delegatedSystemctlPath backstops the seam in test binaries.
 func delegatedUnitActive(d systemdDelegation) bool {
-	return exec.Command("systemctl", d.systemctlIsActiveArgs()...).Run() == nil
+	return exec.Command(delegatedSystemctlPath(), d.systemctlIsActiveArgs()...).Run() == nil
 }
 
-// runDelegatedSystemctl invokes systemctl (resolved via PATH) for verb
-// against the delegated unit, folding any output into the returned error
-// so operators see systemd's own diagnostic.
-func runDelegatedSystemctl(d systemdDelegation, verb string) error {
-	return runDelegatedSystemctlTimeout(d, verb, 0)
-}
-
-// runDelegatedSystemctlTimeout is runDelegatedSystemctl bounded by
-// timeout (unbounded when timeout <= 0). systemctl runs unit jobs
-// synchronously, so the bound keeps a wedged unit from holding the CLI
-// past its advertised budget; the unit's own job keeps running inside
-// systemd after the CLI gives up waiting.
+// runDelegatedSystemctlTimeout invokes systemctl (resolved via PATH) for
+// verb against the delegated unit, bounded by timeout (unbounded when
+// timeout <= 0), folding any output into the returned error so operators
+// see systemd's own diagnostic. systemctl runs unit jobs synchronously,
+// so the bound keeps a wedged unit from holding the CLI past its
+// advertised budget; the unit's own job keeps running inside systemd
+// after the CLI gives up waiting.
 func runDelegatedSystemctlTimeout(d systemdDelegation, verb string, timeout time.Duration) error {
 	args := d.systemctlArgs(verb)
 	ctx := context.Background()
@@ -137,7 +202,7 @@ func runDelegatedSystemctlTimeout(d systemdDelegation, verb string, timeout time
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-	cmd := exec.CommandContext(ctx, "systemctl", args...)
+	cmd := exec.CommandContext(ctx, delegatedSystemctlPath(), args...)
 	// Don't let an inherited pipe from a systemctl child stretch the wait
 	// past the kill triggered by the context deadline.
 	cmd.WaitDelay = time.Second
@@ -157,9 +222,10 @@ func runDelegatedSystemctlTimeout(d systemdDelegation, verb string, timeout time
 // supervisorRestartGuidance returns the systemctl command operators
 // should run to restart the supervisor by hand: the delegated unit's
 // command when GC_SUPERVISOR_SYSTEMD_UNIT is configured, otherwise gc's
-// default user unit. An invalid delegation scope yields guidance naming
-// the bad value rather than silently pointing at the default unit. Used
-// by drift remediation messages.
+// own user unit via supervisorSystemdServiceName, which carries the
+// GC_HOME-isolation suffix when one applies. An invalid delegation
+// scope yields guidance naming the bad value rather than silently
+// pointing at the default unit. Used by drift remediation messages.
 func supervisorRestartGuidance() string {
 	d, ok, err := supervisorSystemdDelegation()
 	switch {
@@ -168,7 +234,7 @@ func supervisorRestartGuidance() string {
 	case ok:
 		return d.commandHint("restart")
 	}
-	return "systemctl --user restart gascity-supervisor"
+	return "systemctl --user restart " + supervisorSystemdServiceName()
 }
 
 // supervisorStatusGuidance is supervisorRestartGuidance for `systemctl
@@ -181,18 +247,26 @@ func supervisorStatusGuidance() string {
 	case ok:
 		return d.commandHint("status")
 	}
-	return "systemctl --user status gascity-supervisor"
+	return "systemctl --user status " + supervisorSystemdServiceName()
 }
 
 // delegatedSupervisorStart starts the supervisor by asking the
 // operator-managed systemd unit to start, then waits for the control
 // socket to answer — the same readiness contract as the fork path.
+//
+// A system-scope unit running under another uid (the documented default
+// topology) keeps its control socket unreachable from the operator's
+// shell, so a socket that never answers is not evidence the start
+// failed. After the socket poll times out, liveness falls back to the
+// same evidence chain `gc supervisor status` trusts (gascity#2984): the
+// delegated unit's is-active state, then the supervisor HTTP API. Only
+// when all three are silent does start report failure.
 func delegatedSupervisorStart(d systemdDelegation, stdout, stderr io.Writer, jsonOut bool) int {
 	if pid := supervisorAliveHook(); pid != 0 {
 		fmt.Fprintf(stderr, "gc supervisor start: supervisor already running (PID %d)\n", pid) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if err := runDelegatedSystemctl(d, "start"); err != nil {
+	if err := runDelegatedSystemctlTimeout(d, "start", delegatedSystemctlJobTimeout); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor start: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -212,8 +286,36 @@ func delegatedSupervisorStart(d systemdDelegation, stdout, stderr io.Writer, jso
 		}
 		time.Sleep(supervisorReadyPollInterval)
 	}
+	if pidSource := delegatedLivenessWithoutSocket(d); pidSource != "" {
+		if jsonOut {
+			return writeLifecycleActionJSONOrExit(stdout, stderr, "gc supervisor start", lifecycleActionJSON{
+				Command:   "supervisor start",
+				Action:    "start",
+				Message:   "Supervisor started.",
+				PIDSource: pidSource,
+			})
+		}
+		fmt.Fprintf(stdout, "Supervisor started (pid unavailable: control socket unreachable; liveness confirmed via %s)\n", pidSource) //nolint:errcheck // best-effort stdout
+		return 0
+	}
 	fmt.Fprintf(stderr, "gc supervisor start: supervisor did not become ready after '%s'; check '%s'\n", d.commandHint("start"), d.commandHint("status")) //nolint:errcheck // best-effort stderr
 	return 1
+}
+
+// delegatedLivenessWithoutSocket reports how a delegated supervisor
+// whose control socket is unreachable can still be confirmed live:
+// "service_manager" when the delegated unit is active, "api" when the
+// supervisor HTTP API answers, "" when neither does. The order and
+// naming mirror the supervisorStatusWithOptions fallback so start and
+// status agree about the same supervisor.
+func delegatedLivenessWithoutSocket(d systemdDelegation) string {
+	switch {
+	case delegatedUnitActive(d):
+		return "service_manager"
+	case supervisorAPIReachable():
+		return "api"
+	}
+	return ""
 }
 
 // delegatedSupervisorStop stops the supervisor by asking the

--- a/cmd/gc/supervisor_systemd_delegate_test.go
+++ b/cmd/gc/supervisor_systemd_delegate_test.go
@@ -13,6 +13,7 @@ import (
 	goruntime "runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -74,6 +75,22 @@ func installFakeDelegatedSystemctlHangingVerbWithUnitState(t *testing.T, verb st
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return argsFile
+}
+
+// installFakeDelegatedSystemctlHangingStartAndIsActive installs a shim
+// whose `start` AND `is-active` invocations both hang (exec sleep), while
+// other verbs succeed. It models a wedged manager / D-Bus path: the bounded
+// `systemctl start` times out, and the post-timeout is-active liveness
+// probe would also hang without a CLI-side bound.
+func installFakeDelegatedSystemctlHangingStartAndIsActive(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "systemctl-args")
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\ncase \" $* \" in *\" is-active \"*) exec sleep 5 ;; *\" start \"*) exec sleep 5 ;; esac\nexit 0\n", argsFile)
+	if err := os.WriteFile(filepath.Join(dir, "systemctl"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake systemctl: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 // setDelegationEnvForTest configures the systemd delegation env for the
@@ -599,6 +616,72 @@ func TestSupervisorStartDelegatedTimeoutThenLateStartSucceeds(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "liveness confirmed via service_manager") {
 		t.Errorf("stdout = %q, want service-manager liveness after a late start", stdout.String())
+	}
+}
+
+// TestDelegatedUnitActiveBoundsHangingProbe pins the is-active bound
+// directly: a `systemctl is-active` against a wedged manager must read as
+// inactive within delegatedIsActiveTimeout instead of blocking the caller.
+func TestDelegatedUnitActiveBoundsHangingProbe(t *testing.T) {
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	installFakeDelegatedSystemctlHangingStartAndIsActive(t)
+	oldIsActive := delegatedIsActiveTimeout
+	delegatedIsActiveTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { delegatedIsActiveTimeout = oldIsActive })
+
+	d := systemdDelegation{Unit: "gascity-prod.service", Scope: "system"}
+	start := time.Now()
+	active := delegatedUnitActive(d)
+	elapsed := time.Since(start)
+	if active {
+		t.Errorf("delegatedUnitActive = true, want false when the is-active probe hangs past its bound")
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("delegatedUnitActive took %s; the is-active probe was not bounded", elapsed)
+	}
+}
+
+// TestSupervisorStartDelegatedTimeoutThenHangingIsActiveStaysBounded pins
+// the is-active bound on the start fall-through: a wedged manager whose
+// `systemctl start` times out and whose `is-active` probe also hangs must
+// not hold `gc supervisor start` forever in delegatedLivenessWithoutSocket.
+// The bounded is-active probe reads inactive, so start falls through to the
+// reachable supervisor API and reports success via "api" — instead of
+// blocking on the unbounded is-active call and never reaching the API.
+func TestSupervisorStartDelegatedTimeoutThenHangingIsActiveStaysBounded(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	installFakeDelegatedSystemctlHangingStartAndIsActive(t)
+
+	oldJob := delegatedSystemctlJobTimeout
+	delegatedSystemctlJobTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
+	oldIsActive := delegatedIsActiveTimeout
+	delegatedIsActiveTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { delegatedIsActiveTimeout = oldIsActive })
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 0 }
+	oldTimeout := supervisorReadyTimeout
+	supervisorReadyTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { supervisorReadyTimeout = oldTimeout })
+	oldAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return true }
+	t.Cleanup(func() { supervisorAPIReachable = oldAPI })
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	code := doSupervisorStart(&stdout, &stderr)
+	elapsed := time.Since(start)
+	if code != 0 {
+		t.Fatalf("doSupervisorStart code = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("delegated start took %s; the is-active probe was not bounded after the start timeout", elapsed)
+	}
+	if !strings.Contains(stdout.String(), "liveness confirmed via api") {
+		t.Errorf("stdout = %q, want api liveness after the bounded is-active probe read inactive", stdout.String())
 	}
 }
 
@@ -1299,6 +1382,9 @@ func TestRunStartDriftCheck_DelegatedRestartUsesTryRestart(t *testing.T) {
 
 	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+	// The supervisor is never replaced, so the verification poll runs to
+	// driftReadyTimeout before reporting "was not replaced"; keep it short.
+	shrinkDriftReadyTimeout(t)
 
 	oldHelpers := restartHelpersHook
 	t.Cleanup(func() { restartHelpersHook = oldHelpers })
@@ -1411,6 +1497,9 @@ func TestRunStartDriftCheck_DelegatedRestartNewPIDStillDriftedFails(t *testing.T
 
 	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+	// The replaced supervisor stays drifted, so the verification poll runs to
+	// driftReadyTimeout before reporting the stale build; keep it short.
+	shrinkDriftReadyTimeout(t)
 
 	// Once the fake systemctl has run (argsFile exists), liveness reports
 	// a new PID while driftCheckEnv's /health keeps serving old-build-id —
@@ -1459,6 +1548,9 @@ func TestRunStartDriftCheck_DelegatedRestartVerifyProbeFailureFails(t *testing.T
 
 	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+	// The probe never decodes, so the verification poll runs to
+	// driftReadyTimeout before reporting "cannot verify"; keep it short.
+	shrinkDriftReadyTimeout(t)
 
 	// Serve valid /health JSON until the fake systemctl has run, then a
 	// 200 with an undecodable body: PollReady's Ping (status-code only)
@@ -1582,10 +1674,9 @@ func TestSupervisorGuidanceUsesServiceNameHelper(t *testing.T) {
 // CLI-side budget on delegated `systemctl try-restart`: a wedged unit must
 // not hold drift remediation (and with it `gc start`) past the job
 // timeout, matching the bounded delegated stop and start. The bounded
-// timeout is not terminal — it falls through to PollReady and the
-// post-restart drift verification — so a try-restart that never replaced
-// the supervisor still fails with the "was not replaced" diagnostic
-// instead of hanging.
+// timeout is not terminal — it falls through to the post-restart
+// verification poll — so a try-restart that never replaced the supervisor
+// still fails with the "was not replaced" diagnostic instead of hanging.
 func TestRunStartDriftCheck_DelegatedTryRestartBoundsSystemctl(t *testing.T) {
 	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
 	setCommit("new-build-id")
@@ -1599,6 +1690,10 @@ func TestRunStartDriftCheck_DelegatedTryRestartBoundsSystemctl(t *testing.T) {
 	oldJob := delegatedSystemctlJobTimeout
 	delegatedSystemctlJobTimeout = 300 * time.Millisecond
 	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
+	// The bounded try-restart never replaces the supervisor, so the
+	// verification poll runs to driftReadyTimeout before reporting "was not
+	// replaced"; shrink it so this stays well under the elapsed bound below.
+	shrinkDriftReadyTimeout(t)
 
 	var stdout, stderr bytes.Buffer
 	start := time.Now()
@@ -1617,10 +1712,14 @@ func TestRunStartDriftCheck_DelegatedTryRestartBoundsSystemctl(t *testing.T) {
 
 // TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds
 // pins the bounded-wait fix for drift remediation: a delegated
-// `systemctl try-restart` that exceeds the CLI budget but whose unit still
-// replaces the supervisor inside systemd must fall through to PollReady and
-// drift verification, observe the late replacement, and report ready —
-// instead of failing before the verification can run.
+// `systemctl try-restart` that exceeds the CLI budget but whose unit
+// replaces the supervisor only *after* the bounded wait must be observed by
+// the verification poll, not a single early probe. The fake keeps serving
+// the old build for several post-timeout probes before flipping to the new
+// build — the late replacement point — so a verify-once implementation
+// would sample an early old-build probe and misreport "was not replaced",
+// while the poll retries past them, observes the replacement, and reports
+// ready.
 func TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds(t *testing.T) {
 	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
 	setCommit("new-build-id")
@@ -1635,13 +1734,21 @@ func TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds(t 
 	delegatedSystemctlJobTimeout = 300 * time.Millisecond
 	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
 
-	// Serve the old build until the fake systemctl has recorded its argv
-	// (argsFile exists), then the new build — modeling a unit that replaces
-	// the supervisor binary only after the CLI's bounded wait has elapsed.
+	// Model a unit that replaces the supervisor binary only after the CLI's
+	// bounded try-restart wait has elapsed: once the fake systemctl has run
+	// (argsFile exists), keep serving the OLD build for the first few
+	// verification probes, then flip to the new build at the late
+	// replacement point. A verify-once implementation would sample an early
+	// old-build probe and misreport "was not replaced"; the poll must retry
+	// past them to the replacement.
+	const oldBuildProbesBeforeReplace = 3
+	var postTimeoutProbes atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		build := "old-build-id"
 		if _, err := os.Stat(argsFile); err == nil {
-			build = "new-build-id"
+			if postTimeoutProbes.Add(1) > oldBuildProbesBeforeReplace {
+				build = "new-build-id"
+			}
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprintf(w, `{"status":"ok","version":"v0","build_id":%q,"uptime_sec":1,"cities_total":0,"cities_running":0}`, build)
@@ -1660,6 +1767,9 @@ func TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds(t 
 	}
 	if !cont {
 		t.Fatalf("cont = false after a verified late replacement; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if postTimeoutProbes.Load() <= oldBuildProbesBeforeReplace {
+		t.Fatalf("verification made %d post-timeout probes; want > %d (the poll must retry past the early old-build probes to the late replacement)", postTimeoutProbes.Load(), oldBuildProbesBeforeReplace)
 	}
 	if elapsed > 3*time.Second {
 		t.Fatalf("delegated try-restart took %s; the job timeout did not bound the systemctl invocation", elapsed)

--- a/cmd/gc/supervisor_systemd_delegate_test.go
+++ b/cmd/gc/supervisor_systemd_delegate_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
@@ -49,19 +50,32 @@ func installFakeDelegatedSystemctlWithUnitState(t *testing.T, exitCode int, stde
 	return argsFile
 }
 
-// installFakeDelegatedSystemctlHangingStop installs a shim whose `stop`
-// invocation hangs (exec sleep) so tests can prove the CLI bounds the
-// systemctl wait. is-active probes report active; other verbs succeed.
-func installFakeDelegatedSystemctlHangingStop(t *testing.T) string {
+// installFakeDelegatedSystemctlHangingVerb installs a shim whose
+// invocation of verb hangs (exec sleep) so tests can prove the CLI
+// bounds the systemctl wait. is-active probes report active; other
+// verbs succeed.
+func installFakeDelegatedSystemctlHangingVerb(t *testing.T, verb string) {
 	t.Helper()
 	dir := t.TempDir()
 	argsFile := filepath.Join(dir, "systemctl-args")
-	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\ncase \" $* \" in *\" is-active \"*) exit 0 ;; *\" stop \"*) exec sleep 5 ;; esac\nexit 0\n", argsFile)
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\ncase \" $* \" in *\" is-active \"*) exit 0 ;; *\" %s \"*) exec sleep 5 ;; esac\nexit 0\n", argsFile, verb)
 	if err := os.WriteFile(filepath.Join(dir, "systemctl"), []byte(script), 0o755); err != nil {
 		t.Fatalf("writing fake systemctl: %v", err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return argsFile
+}
+
+// setDelegationEnvForTest configures the systemd delegation env for the
+// test and pins supervisorRuntimeGOOS to linux so delegation tests
+// exercise the linux/systemd contract on every development platform —
+// supervisorSystemdDelegation rejects the env elsewhere.
+func setDelegationEnvForTest(t *testing.T, unit, scope string) {
+	t.Helper()
+	old := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "linux"
+	t.Cleanup(func() { supervisorRuntimeGOOS = old })
+	t.Setenv(supervisorSystemdUnitEnv, unit)
+	t.Setenv(supervisorSystemdScopeEnv, scope)
 }
 
 // readRecordedSystemctlArgs returns the argv lines the fake systemctl
@@ -152,8 +166,7 @@ func TestSupervisorSystemdDelegationFromEnv(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(supervisorSystemdUnitEnv, tc.unit)
-			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+			setDelegationEnvForTest(t, tc.unit, tc.scope)
 			got, ok, err := supervisorSystemdDelegation()
 			if tc.wantErr {
 				if err == nil {
@@ -172,6 +185,97 @@ func TestSupervisorSystemdDelegationFromEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSupervisorSystemdDelegationRequiresLinux pins the platform
+// contract: delegation env on a non-systemd platform is an explicit
+// configuration error at parse time — surfaced by every lifecycle
+// command — instead of a low-level "systemctl: executable file not
+// found" once a delegated path execs.
+func TestSupervisorSystemdDelegationRequiresLinux(t *testing.T) {
+	old := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "darwin"
+	t.Cleanup(func() { supervisorRuntimeGOOS = old })
+	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	t.Setenv(supervisorSystemdScopeEnv, "")
+	t.Setenv("GC_HOME", t.TempDir())
+
+	_, ok, err := supervisorSystemdDelegation()
+	if ok || err == nil {
+		t.Fatalf("supervisorSystemdDelegation() = (ok=%v, err=%v), want platform error", ok, err)
+	}
+	for _, want := range []string{"requires linux", "darwin", supervisorSystemdUnitEnv} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want %q named", err, want)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorStart(&stdout, &stderr); code != 1 {
+		t.Fatalf("doSupervisorStart code = %d, want 1; stdout=%q", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "requires linux") {
+		t.Errorf("stderr = %q, want platform error surfaced", stderr.String())
+	}
+}
+
+// TestGuardDelegatedSystemctlPath pins the test-binary backstop on the
+// delegated exec seam: delegated paths bypass the supervisorSystemctlRun
+// hook, so a systemctl resolving into a host system directory inside a
+// test binary means a test is about to drive the operator's real
+// systemd unit and must panic instead.
+func TestGuardDelegatedSystemctlPath(t *testing.T) {
+	t.Run("host system dir panics in test binaries", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal(`guardDelegatedSystemctlPath("/usr/bin/systemctl") did not panic inside a test binary`)
+			}
+		}()
+		guardDelegatedSystemctlPath("/usr/bin/systemctl")
+	})
+	t.Run("temp shim path passes", func(t *testing.T) {
+		guardDelegatedSystemctlPath(filepath.Join(t.TempDir(), "systemctl"))
+	})
+}
+
+// TestDelegatedExecPathsRefuseHostSystemctl pins the guard wiring end to
+// end: with no PATH shim installed, both delegated exec helpers must
+// panic before spawning the host's real systemctl. Skips when the host
+// resolves systemctl outside the guarded system directories (the guard
+// is best-effort there); the unit name is deliberately one no host
+// should define so a guard regression stays harmless.
+func TestDelegatedExecPathsRefuseHostSystemctl(t *testing.T) {
+	resolved, err := exec.LookPath("systemctl")
+	if err != nil {
+		t.Skip("no systemctl on PATH")
+	}
+	dir := filepath.Dir(resolved) + string(filepath.Separator)
+	guarded := false
+	for _, sys := range hostSystemctlDirs {
+		if dir == sys {
+			guarded = true
+		}
+	}
+	if !guarded {
+		t.Skipf("host systemctl %q resolves outside the guarded system dirs", resolved)
+	}
+	d := systemdDelegation{Unit: "gc-test-guard-nonexistent.service", Scope: "system"}
+	t.Run("delegatedUnitActive", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("delegatedUnitActive reached host systemctl without panicking")
+			}
+		}()
+		delegatedUnitActive(d)
+	})
+	t.Run("runDelegatedSystemctlTimeout", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("runDelegatedSystemctlTimeout reached host systemctl without panicking")
+			}
+		}()
+		_ = runDelegatedSystemctlTimeout(d, "start", time.Second)
+	})
 }
 
 func TestSystemdDelegationCommandShapes(t *testing.T) {
@@ -209,8 +313,7 @@ func TestSupervisorStartDelegatesToSystemctl(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("GC_HOME", t.TempDir())
-			t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
-			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+			setDelegationEnvForTest(t, "gascity-prod.service", tc.scope)
 			argsFile := installFakeDelegatedSystemctl(t, 0, "")
 			stubSupervisorAliveAfterSystemctl(t, argsFile, 4242)
 
@@ -231,7 +334,7 @@ func TestSupervisorStartDelegatesToSystemctl(t *testing.T) {
 
 func TestSupervisorStartDelegatedJSON(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 	stubSupervisorAliveAfterSystemctl(t, argsFile, 4242)
 
@@ -250,7 +353,7 @@ func TestSupervisorStartDelegatedJSON(t *testing.T) {
 
 func TestSupervisorStartDelegatedSystemctlFailureSurfacesError(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	installFakeDelegatedSystemctl(t, 5, "Unit gascity-prod.service not found.")
 
 	old := supervisorAliveHook
@@ -269,10 +372,166 @@ func TestSupervisorStartDelegatedSystemctlFailureSurfacesError(t *testing.T) {
 	}
 }
 
+// delegatedStartFallbackEnv prepares a delegated start whose control
+// socket never answers: delegation env set, supervisor never alive via
+// the socket, the readiness poll shrunk, and the API hook pinned to
+// apiReachable so each test controls the full fallback evidence chain.
+func delegatedStartFallbackEnv(t *testing.T, isActiveExit int, apiReachable bool) string {
+	t.Helper()
+	t.Setenv("GC_HOME", t.TempDir())
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	argsFile := installFakeDelegatedSystemctlWithUnitState(t, 0, "", isActiveExit)
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 0 }
+	oldTimeout := supervisorReadyTimeout
+	supervisorReadyTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { supervisorReadyTimeout = oldTimeout })
+	oldAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return apiReachable }
+	t.Cleanup(func() { supervisorAPIReachable = oldAPI })
+	return argsFile
+}
+
+// TestSupervisorStartDelegatedSocketUnreachableTrustsServiceManager pins
+// the start half of the gascity#2984 fallback under delegation: in the
+// documented system-scope/other-uid topology the control socket is
+// unreachable from the operator's shell, so an active unit after the
+// readiness poll must report success the way status already does — not
+// a false "did not become ready".
+func TestSupervisorStartDelegatedSocketUnreachableTrustsServiceManager(t *testing.T) {
+	argsFile := delegatedStartFallbackEnv(t, 0, false)
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorStart(&stdout, &stderr); code != 0 {
+		t.Fatalf("doSupervisorStart code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "pid unavailable: control socket unreachable; liveness confirmed via service_manager") {
+		t.Errorf("stdout = %q, want service-manager liveness framing", stdout.String())
+	}
+	lines := readRecordedSystemctlArgs(t, argsFile)
+	want := []string{"start gascity-prod.service", "is-active --quiet gascity-prod.service"}
+	if len(lines) != 2 || lines[0] != want[0] || lines[1] != want[1] {
+		t.Fatalf("systemctl invocations = %v, want %v", lines, want)
+	}
+}
+
+// TestSupervisorStartDelegatedSocketUnreachableJSONNamesPIDSource pins
+// the --json contract for the fallback success: ok with pid_source
+// naming the evidence and no supervisor_pid (the socket never answered),
+// mirroring `gc supervisor status --json`.
+func TestSupervisorStartDelegatedSocketUnreachableJSONNamesPIDSource(t *testing.T) {
+	delegatedStartFallbackEnv(t, 0, false)
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorStartJSON(&stdout, &stderr, true); code != 0 {
+		t.Fatalf("doSupervisorStartJSON code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	payload := decodeLifecycleJSONLine(t, stdout.String())
+	if payload["ok"] != true || payload["pid_source"] != "service_manager" {
+		t.Errorf("payload = %v, want ok=true pid_source=%q", payload, "service_manager")
+	}
+	if pid, present := payload["supervisor_pid"]; present {
+		t.Errorf("payload supervisor_pid = %v, want omitted when the socket never answered", pid)
+	}
+}
+
+// TestSupervisorStartDelegatedSocketUnreachableFallsBackToAPI pins the
+// second link of the evidence chain: an inactive-reading unit with a
+// reachable supervisor API still reports success, attributed to the API.
+func TestSupervisorStartDelegatedSocketUnreachableFallsBackToAPI(t *testing.T) {
+	delegatedStartFallbackEnv(t, 3, true)
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorStart(&stdout, &stderr); code != 0 {
+		t.Fatalf("doSupervisorStart code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "liveness confirmed via api") {
+		t.Errorf("stdout = %q, want api liveness framing", stdout.String())
+	}
+}
+
+// TestSupervisorStartDelegatedNotReadyWithoutLivenessEvidenceFails pins
+// the genuine failure: socket silent, unit inactive, API unreachable —
+// only then is "did not become ready" the truth.
+func TestSupervisorStartDelegatedNotReadyWithoutLivenessEvidenceFails(t *testing.T) {
+	delegatedStartFallbackEnv(t, 3, false)
+
+	var stdout, stderr bytes.Buffer
+	if code := doSupervisorStart(&stdout, &stderr); code != 1 {
+		t.Fatalf("doSupervisorStart code = %d, want 1; stdout=%q", code, stdout.String())
+	}
+	for _, want := range []string{"did not become ready", "check 'systemctl status gascity-prod.service'"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+// TestSupervisorStartDelegatedBoundsSystemctl pins the CLI-side budget
+// on delegated `systemctl start`: a wedged manager or a unit with
+// TimeoutStartSec=infinity must not hold `gc supervisor start` past the
+// job timeout, matching the bounded delegated stop.
+func TestSupervisorStartDelegatedBoundsSystemctl(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	installFakeDelegatedSystemctlHangingVerb(t, "start")
+	oldJob := delegatedSystemctlJobTimeout
+	delegatedSystemctlJobTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 0 }
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	code := doSupervisorStart(&stdout, &stderr)
+	elapsed := time.Since(start)
+	if code != 1 {
+		t.Fatalf("doSupervisorStart code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("delegated start took %s; the job timeout did not bound the systemctl invocation", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "timed out after") {
+		t.Errorf("stderr = %q, want systemctl timeout named", stderr.String())
+	}
+}
+
+// TestEnsureSupervisorRunningDelegatedBoundsSystemctl is the gc-start
+// ensure twin of TestSupervisorStartDelegatedBoundsSystemctl.
+func TestEnsureSupervisorRunningDelegatedBoundsSystemctl(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	installFakeDelegatedSystemctlHangingVerb(t, "start")
+	oldJob := delegatedSystemctlJobTimeout
+	delegatedSystemctlJobTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 0 }
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	code := ensureSupervisorRunning(&stdout, &stderr)
+	elapsed := time.Since(start)
+	if code != 1 {
+		t.Fatalf("ensureSupervisorRunning code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("delegated ensure-start took %s; the job timeout did not bound the systemctl invocation", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "timed out after") {
+		t.Errorf("stderr = %q, want systemctl timeout named", stderr.String())
+	}
+}
+
 func TestSupervisorStartDelegationInvalidScopeFails(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
-	t.Setenv(supervisorSystemdScopeEnv, "remote")
+	setDelegationEnvForTest(t, "gascity-prod.service", "remote")
 
 	var stdout, stderr bytes.Buffer
 	if code := doSupervisorStart(&stdout, &stderr); code != 1 {
@@ -310,8 +569,7 @@ func TestSupervisorStopDelegatesToSystemctl(t *testing.T) {
 			// path trusts the active unit instead and never drives the
 			// destructive control-socket stop protocol.
 			t.Setenv("GC_HOME", t.TempDir())
-			t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
-			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+			setDelegationEnvForTest(t, "gascity-prod.service", tc.scope)
 			argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 			var stdout, stderr bytes.Buffer
@@ -331,7 +589,7 @@ func TestSupervisorStopDelegatesToSystemctl(t *testing.T) {
 
 func TestSupervisorStopDelegatedJSON(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	installFakeDelegatedSystemctl(t, 0, "")
 
 	var stdout, stderr bytes.Buffer
@@ -355,7 +613,7 @@ func TestSupervisorStopDelegatedJSON(t *testing.T) {
 // disappears once `systemctl stop` ran reports success.
 func TestSupervisorStopDelegatedVerifiesSupervisorExit(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 	old := supervisorAliveHook
@@ -383,7 +641,7 @@ func TestSupervisorStopDelegatedVerifiesSupervisorExit(t *testing.T) {
 // instead of printing "Supervisor stopped.".
 func TestSupervisorStopDelegatedUnmanagedSupervisorFails(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 	old := supervisorAliveHook
@@ -417,7 +675,7 @@ func TestSupervisorStopDelegatedUnmanagedSupervisorFails(t *testing.T) {
 // "Supervisor stopped.".
 func TestSupervisorStopDelegatedNothingRunningKeepsExit1(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctlWithUnitState(t, 0, "", 3)
 
 	var stdout, stderr bytes.Buffer
@@ -438,8 +696,8 @@ func TestSupervisorStopDelegatedNothingRunningKeepsExit1(t *testing.T) {
 // of letting a wedged unit hold the command for systemd's own timeout.
 func TestSupervisorStopDelegatedWaitTimeoutBoundsSystemctl(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
-	installFakeDelegatedSystemctlHangingStop(t)
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	installFakeDelegatedSystemctlHangingVerb(t, "stop")
 
 	var stdout, stderr bytes.Buffer
 	start := time.Now()
@@ -458,7 +716,7 @@ func TestSupervisorStopDelegatedWaitTimeoutBoundsSystemctl(t *testing.T) {
 
 func TestSupervisorStopDelegatedSystemctlFailureSurfacesError(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	installFakeDelegatedSystemctl(t, 4, "Interactive authentication required.")
 
 	var stdout, stderr bytes.Buffer
@@ -475,7 +733,7 @@ func TestSupervisorStopDelegatedSystemctlFailureSurfacesError(t *testing.T) {
 
 func TestEnsureSupervisorRunningDelegatesToSystemctl(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 	stubSupervisorAliveAfterSystemctl(t, argsFile, 4242)
 
@@ -494,7 +752,7 @@ func TestEnsureSupervisorRunningDelegatesToSystemctl(t *testing.T) {
 
 func TestEnsureSupervisorRunningDelegatedAlreadyRunningSkipsSystemctl(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 	old := supervisorAliveHook
@@ -514,11 +772,14 @@ func TestEnsureSupervisorRunningDelegatedAlreadyRunningSkipsSystemctl(t *testing
 // TestEnsureSupervisorRunningDelegatedTimeoutPointsAtUnit pins the
 // readiness-timeout diagnostic in delegated mode: a delegated supervisor
 // logs to the journal, so the message must point at the unit's systemctl
-// status command, not gc's fork-mode log file.
+// status command, not gc's fork-mode log file. The unit must read as
+// inactive and the API as unreachable — with liveness evidence the
+// silent socket is a success, not a timeout (see
+// TestEnsureSupervisorRunningDelegatedSocketUnreachableTrustsServiceManager).
 func TestEnsureSupervisorRunningDelegatedTimeoutPointsAtUnit(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
-	installFakeDelegatedSystemctl(t, 0, "")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	installFakeDelegatedSystemctlWithUnitState(t, 0, "", 3)
 
 	old := supervisorAliveHook
 	t.Cleanup(func() { supervisorAliveHook = old })
@@ -526,6 +787,9 @@ func TestEnsureSupervisorRunningDelegatedTimeoutPointsAtUnit(t *testing.T) {
 	oldTimeout := supervisorReadyTimeout
 	supervisorReadyTimeout = 50 * time.Millisecond
 	t.Cleanup(func() { supervisorReadyTimeout = oldTimeout })
+	oldAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = oldAPI })
 
 	var stdout, stderr bytes.Buffer
 	if code := ensureSupervisorRunning(&stdout, &stderr); code != 1 {
@@ -536,6 +800,38 @@ func TestEnsureSupervisorRunningDelegatedTimeoutPointsAtUnit(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "supervisor.log") {
 		t.Errorf("stderr = %q, must not point at the fork-mode log file in delegated mode", stderr.String())
+	}
+}
+
+// TestEnsureSupervisorRunningDelegatedSocketUnreachableTrustsServiceManager
+// pins the gc-start ensure path in the documented system-scope/other-uid
+// topology: `systemctl start` succeeds, the control socket never answers
+// from this shell, and the active unit must read as success — not the
+// false "did not become ready" that aborts `gc start` while status
+// reports the same supervisor as running.
+func TestEnsureSupervisorRunningDelegatedSocketUnreachableTrustsServiceManager(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	argsFile := installFakeDelegatedSystemctl(t, 0, "")
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 0 }
+	oldTimeout := supervisorReadyTimeout
+	supervisorReadyTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { supervisorReadyTimeout = oldTimeout })
+	oldAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = oldAPI })
+
+	var stdout, stderr bytes.Buffer
+	if code := ensureSupervisorRunning(&stdout, &stderr); code != 0 {
+		t.Fatalf("ensureSupervisorRunning code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	lines := readRecordedSystemctlArgs(t, argsFile)
+	want := []string{"start gascity-prod.service", "is-active --quiet gascity-prod.service"}
+	if len(lines) != 2 || lines[0] != want[0] || lines[1] != want[1] {
+		t.Fatalf("systemctl invocations = %v, want %v", lines, want)
 	}
 }
 
@@ -575,8 +871,7 @@ func TestSupervisorStatusDelegatedUnitFallback(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("GC_HOME", t.TempDir())
-			t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
-			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+			setDelegationEnvForTest(t, "gascity-prod.service", tc.scope)
 			argsFile := installFakeDelegatedSystemctlWithUnitState(t, 0, "", tc.isActiveExit)
 
 			oldAPI := supervisorAPIReachable
@@ -622,8 +917,7 @@ func TestSupervisorStatusInvalidDelegationScope(t *testing.T) {
 	setup := func(t *testing.T, apiReachable bool) string {
 		t.Helper()
 		t.Setenv("GC_HOME", t.TempDir())
-		t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
-		t.Setenv(supervisorSystemdScopeEnv, "systme")
+		setDelegationEnvForTest(t, "gascity-prod.service", "systme")
 		argsFile := installFakeDelegatedSystemctl(t, 0, "")
 		oldAPI := supervisorAPIReachable
 		supervisorAPIReachable = func() bool { return apiReachable }
@@ -693,7 +987,7 @@ func TestSupervisorStatusInvalidDelegationScope(t *testing.T) {
 // is delegated to an operator-managed unit.
 func TestSupervisorInstallRefusesDelegation(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 
 	var stdout, stderr bytes.Buffer
 	if code := doSupervisorInstall(&stdout, &stderr); code != 1 {
@@ -708,8 +1002,7 @@ func TestSupervisorInstallRefusesDelegation(t *testing.T) {
 
 func TestSupervisorInstallInvalidDelegationScopeFails(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
-	t.Setenv(supervisorSystemdScopeEnv, "remote")
+	setDelegationEnvForTest(t, "gascity-prod.service", "remote")
 
 	var stdout, stderr bytes.Buffer
 	if code := doSupervisorInstall(&stdout, &stderr); code != 1 {
@@ -731,7 +1024,7 @@ func TestSupervisorUninstallWarnsAndSkipsDelegatedUnit(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 	oldRun := supervisorSystemctlRun
@@ -779,7 +1072,7 @@ func TestUninstallSupervisorSystemdUnderDelegationStopsOwnUnitViaSocket(t *testi
 	t.Setenv("HOME", homeDir)
 	t.Setenv("GC_HOME", gcHome)
 	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 	currentPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", supervisorSystemdServiceName())
@@ -855,7 +1148,7 @@ func TestRunStartDriftCheck_DelegatedRestartUsesTryRestart(t *testing.T) {
 	dryRunMode, noAutoRestartMode = false, false
 	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
 
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 	oldHelpers := restartHelpersHook
@@ -916,7 +1209,7 @@ func TestRunStartDriftCheck_DelegatedRestartReplacementSucceeds(t *testing.T) {
 	dryRunMode, noAutoRestartMode = false, false
 	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
 
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 	// Serve the old build until the fake systemctl has run (argsFile
@@ -967,7 +1260,7 @@ func TestRunStartDriftCheck_DelegatedRestartNewPIDStillDriftedFails(t *testing.T
 	dryRunMode, noAutoRestartMode = false, false
 	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
 
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 	// Once the fake systemctl has run (argsFile exists), liveness reports
@@ -1015,7 +1308,7 @@ func TestRunStartDriftCheck_DelegatedRestartVerifyProbeFailureFails(t *testing.T
 	dryRunMode, noAutoRestartMode = false, false
 	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
 
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 	argsFile := installFakeDelegatedSystemctl(t, 0, "")
 
 	// Serve valid /health JSON until the fake systemctl has run, then a
@@ -1051,8 +1344,10 @@ func TestRunStartDriftCheck_DelegatedRestartVerifyProbeFailureFails(t *testing.T
 
 // TestRunStartDriftCheck_KillSwitchGuidance pins the operator remediation
 // text on the kill-switch arm: the default text references gc's own user
-// unit, and a configured GC_SUPERVISOR_SYSTEMD_UNIT/_SCOPE replaces it
-// with the delegated unit's systemctl command.
+// unit via supervisorSystemdServiceName (suffixed under an isolated
+// GC_HOME, as driftCheckEnv configures), and a configured
+// GC_SUPERVISOR_SYSTEMD_UNIT/_SCOPE replaces it with the delegated
+// unit's systemctl command.
 func TestRunStartDriftCheck_KillSwitchGuidance(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -1062,7 +1357,7 @@ func TestRunStartDriftCheck_KillSwitchGuidance(t *testing.T) {
 	}{
 		{
 			name: "default guidance names gc's user unit",
-			want: "Restart manually with 'systemctl --user restart gascity-supervisor'.",
+			// want computed after env setup: the unit name depends on GC_HOME.
 		},
 		{
 			name: "delegated system unit",
@@ -1085,8 +1380,12 @@ func TestRunStartDriftCheck_KillSwitchGuidance(t *testing.T) {
 			dryRunMode, noAutoRestartMode = false, false
 			t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
 
-			t.Setenv(supervisorSystemdUnitEnv, tc.unit)
-			t.Setenv(supervisorSystemdScopeEnv, tc.scope)
+			setDelegationEnvForTest(t, tc.unit, tc.scope)
+
+			want := tc.want
+			if want == "" {
+				want = fmt.Sprintf("Restart manually with 'systemctl --user restart %s'.", supervisorSystemdServiceName())
+			}
 
 			cityToml := "[workspace]\nname = \"drift-guidance\"\n\n[daemon]\nauto_restart_on_drift = false\n"
 			if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
@@ -1101,10 +1400,67 @@ func TestRunStartDriftCheck_KillSwitchGuidance(t *testing.T) {
 			if cont {
 				t.Fatalf("cont = true on kill-switch drift; should be terminal")
 			}
-			if !strings.Contains(stderr.String(), tc.want) {
-				t.Errorf("stderr = %q, want guidance %q", stderr.String(), tc.want)
+			if !strings.Contains(stderr.String(), want) {
+				t.Errorf("stderr = %q, want guidance %q", stderr.String(), want)
 			}
 		})
+	}
+}
+
+// TestSupervisorGuidanceUsesServiceNameHelper pins that the
+// non-delegated guidance fallback is built from
+// supervisorSystemdServiceName, so hosts running the GC_HOME-suffixed
+// gc-owned unit are pointed at their actual unit instead of the
+// hardcoded default name.
+func TestSupervisorGuidanceUsesServiceNameHelper(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(supervisorSystemdUnitEnv, "")
+	t.Setenv(supervisorSystemdScopeEnv, "")
+
+	service := supervisorSystemdServiceName()
+	if service == defaultSupervisorSystemdUnit {
+		t.Fatalf("isolated GC_HOME did not produce a suffixed unit name; got %q", service)
+	}
+	if got, want := supervisorRestartGuidance(), "systemctl --user restart "+service; got != want {
+		t.Errorf("supervisorRestartGuidance() = %q, want %q", got, want)
+	}
+	if got, want := supervisorStatusGuidance(), "systemctl --user status "+service; got != want {
+		t.Errorf("supervisorStatusGuidance() = %q, want %q", got, want)
+	}
+}
+
+// TestRunStartDriftCheck_DelegatedTryRestartBoundsSystemctl pins the
+// CLI-side budget on delegated `systemctl try-restart`: a wedged unit
+// must not hold drift remediation (and with it `gc start`) past the job
+// timeout, matching the bounded delegated stop and start.
+func TestRunStartDriftCheck_DelegatedTryRestartBoundsSystemctl(t *testing.T) {
+	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
+	setCommit("new-build-id")
+
+	oldDry, oldNoAR := dryRunMode, noAutoRestartMode
+	dryRunMode, noAutoRestartMode = false, false
+	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
+
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	installFakeDelegatedSystemctlHangingVerb(t, "try-restart")
+	oldJob := delegatedSystemctlJobTimeout
+	delegatedSystemctlJobTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
+	elapsed := time.Since(start)
+	if exitCode != 1 || cont {
+		t.Fatalf("(exitCode, cont) = (%d, %v), want (1, false); stderr=%q", exitCode, cont, stderr.String())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("delegated try-restart took %s; the job timeout did not bound the systemctl invocation", elapsed)
+	}
+	for _, want := range []string{"supervisor restart failed", "timed out after"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr = %q, want %q", stderr.String(), want)
+		}
 	}
 }
 
@@ -1120,8 +1476,7 @@ func TestRunStartDriftCheck_KillSwitchGuidanceNamesInvalidScope(t *testing.T) {
 	dryRunMode, noAutoRestartMode = false, false
 	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
 
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
-	t.Setenv(supervisorSystemdScopeEnv, "systme")
+	setDelegationEnvForTest(t, "gascity-prod.service", "systme")
 
 	cityToml := "[workspace]\nname = \"drift-guidance\"\n\n[daemon]\nauto_restart_on_drift = false\n"
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
@@ -1151,7 +1506,7 @@ func TestRunStartDriftCheck_NoAutoRestartGuidanceUsesDelegatedUnit(t *testing.T)
 	dryRunMode, noAutoRestartMode = false, true
 	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
 
-	t.Setenv(supervisorSystemdUnitEnv, "gascity-prod.service")
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
 
 	var stdout, stderr bytes.Buffer
 	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)

--- a/cmd/gc/supervisor_systemd_delegate_test.go
+++ b/cmd/gc/supervisor_systemd_delegate_test.go
@@ -53,16 +53,27 @@ func installFakeDelegatedSystemctlWithUnitState(t *testing.T, exitCode int, stde
 // installFakeDelegatedSystemctlHangingVerb installs a shim whose
 // invocation of verb hangs (exec sleep) so tests can prove the CLI
 // bounds the systemctl wait. is-active probes report active; other
-// verbs succeed.
-func installFakeDelegatedSystemctlHangingVerb(t *testing.T, verb string) {
+// verbs succeed. Returns the path the shim records its argv into.
+func installFakeDelegatedSystemctlHangingVerb(t *testing.T, verb string) string {
+	t.Helper()
+	return installFakeDelegatedSystemctlHangingVerbWithUnitState(t, verb, 0)
+}
+
+// installFakeDelegatedSystemctlHangingVerbWithUnitState is
+// installFakeDelegatedSystemctlHangingVerb with an explicit exit code for
+// `is-active` probes (0 = active, non-zero = inactive), so timeout tests
+// can model whether the post-timeout liveness fallback observes a late
+// start.
+func installFakeDelegatedSystemctlHangingVerbWithUnitState(t *testing.T, verb string, isActiveExit int) string {
 	t.Helper()
 	dir := t.TempDir()
 	argsFile := filepath.Join(dir, "systemctl-args")
-	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\ncase \" $* \" in *\" is-active \"*) exit 0 ;; *\" %s \"*) exec sleep 5 ;; esac\nexit 0\n", argsFile, verb)
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\ncase \" $* \" in *\" is-active \"*) exit %d ;; *\" %s \"*) exec sleep 5 ;; esac\nexit 0\n", argsFile, isActiveExit, verb)
 	if err := os.WriteFile(filepath.Join(dir, "systemctl"), []byte(script), 0o755); err != nil {
 		t.Fatalf("writing fake systemctl: %v", err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsFile
 }
 
 // setDelegationEnvForTest configures the systemd delegation env for the
@@ -469,14 +480,61 @@ func TestSupervisorStartDelegatedNotReadyWithoutLivenessEvidenceFails(t *testing
 	}
 }
 
-// TestSupervisorStartDelegatedBoundsSystemctl pins the CLI-side budget
-// on delegated `systemctl start`: a wedged manager or a unit with
+// TestRunDelegatedSystemctlTimeoutClassifiesTimeout pins the contract the
+// start/ensure/try-restart fall-through depends on: a bounded systemctl
+// invocation that exceeds its budget returns a delegatedSystemctlTimeoutError
+// (recognized by isDelegatedSystemctlTimeout), while an ordinary systemctl
+// failure does not — so only a true timeout is treated as a bounded wait.
+func TestRunDelegatedSystemctlTimeoutClassifiesTimeout(t *testing.T) {
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	d := systemdDelegation{Unit: "gascity-prod.service", Scope: "system"}
+
+	t.Run("timeout is classified and bounded", func(t *testing.T) {
+		installFakeDelegatedSystemctlHangingVerb(t, "start")
+		start := time.Now()
+		err := runDelegatedSystemctlTimeout(d, "start", 200*time.Millisecond)
+		elapsed := time.Since(start)
+		if err == nil {
+			t.Fatal("runDelegatedSystemctlTimeout err = nil, want timeout")
+		}
+		if !isDelegatedSystemctlTimeout(err) {
+			t.Errorf("isDelegatedSystemctlTimeout(%v) = false, want true", err)
+		}
+		if !strings.Contains(err.Error(), "timed out after") {
+			t.Errorf("err = %q, want 'timed out after'", err.Error())
+		}
+		if elapsed > 3*time.Second {
+			t.Fatalf("runDelegatedSystemctlTimeout took %s; the bound did not apply", elapsed)
+		}
+	})
+
+	t.Run("ordinary failure is not a timeout", func(t *testing.T) {
+		installFakeDelegatedSystemctl(t, 5, "Unit gascity-prod.service not found.")
+		err := runDelegatedSystemctlTimeout(d, "start", 2*time.Second)
+		if err == nil {
+			t.Fatal("runDelegatedSystemctlTimeout err = nil, want failure")
+		}
+		if isDelegatedSystemctlTimeout(err) {
+			t.Errorf("isDelegatedSystemctlTimeout(%v) = true, want false for an ordinary systemctl failure", err)
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("err = %q, want systemctl diagnostic folded in", err.Error())
+		}
+	})
+}
+
+// TestSupervisorStartDelegatedBoundsSystemctl pins the CLI-side budget on
+// delegated `systemctl start`: a wedged manager or a unit with
 // TimeoutStartSec=infinity must not hold `gc supervisor start` past the
-// job timeout, matching the bounded delegated stop.
+// job timeout, matching the bounded delegated stop. The bounded timeout is
+// not terminal — it falls through to the same readiness/is-active/API
+// fallback a normal start uses — so with the unit still inactive and the
+// API unreachable the command reports the standard "did not become ready"
+// failure instead of hanging or falsely succeeding.
 func TestSupervisorStartDelegatedBoundsSystemctl(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	setDelegationEnvForTest(t, "gascity-prod.service", "")
-	installFakeDelegatedSystemctlHangingVerb(t, "start")
+	installFakeDelegatedSystemctlHangingVerbWithUnitState(t, "start", 3)
 	oldJob := delegatedSystemctlJobTimeout
 	delegatedSystemctlJobTimeout = 300 * time.Millisecond
 	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
@@ -484,6 +542,12 @@ func TestSupervisorStartDelegatedBoundsSystemctl(t *testing.T) {
 	old := supervisorAliveHook
 	t.Cleanup(func() { supervisorAliveHook = old })
 	supervisorAliveHook = func() int { return 0 }
+	oldTimeout := supervisorReadyTimeout
+	supervisorReadyTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { supervisorReadyTimeout = oldTimeout })
+	oldAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = oldAPI })
 
 	var stdout, stderr bytes.Buffer
 	start := time.Now()
@@ -495,17 +559,20 @@ func TestSupervisorStartDelegatedBoundsSystemctl(t *testing.T) {
 	if elapsed > 3*time.Second {
 		t.Fatalf("delegated start took %s; the job timeout did not bound the systemctl invocation", elapsed)
 	}
-	if !strings.Contains(stderr.String(), "timed out after") {
-		t.Errorf("stderr = %q, want systemctl timeout named", stderr.String())
+	if !strings.Contains(stderr.String(), "did not become ready") {
+		t.Errorf("stderr = %q, want 'did not become ready' after the bounded timeout fell through to liveness verification", stderr.String())
 	}
 }
 
-// TestEnsureSupervisorRunningDelegatedBoundsSystemctl is the gc-start
-// ensure twin of TestSupervisorStartDelegatedBoundsSystemctl.
-func TestEnsureSupervisorRunningDelegatedBoundsSystemctl(t *testing.T) {
+// TestSupervisorStartDelegatedTimeoutThenLateStartSucceeds pins the
+// bounded-wait fix: a delegated `systemctl start` that exceeds the CLI
+// budget but whose unit still comes up inside systemd must report success
+// via the is-active fallback, not a false failure. The hanging shim leaves
+// the unit is-active, modeling a start that completes late.
+func TestSupervisorStartDelegatedTimeoutThenLateStartSucceeds(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	setDelegationEnvForTest(t, "gascity-prod.service", "")
-	installFakeDelegatedSystemctlHangingVerb(t, "start")
+	installFakeDelegatedSystemctlHangingVerbWithUnitState(t, "start", 0)
 	oldJob := delegatedSystemctlJobTimeout
 	delegatedSystemctlJobTimeout = 300 * time.Millisecond
 	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
@@ -513,6 +580,50 @@ func TestEnsureSupervisorRunningDelegatedBoundsSystemctl(t *testing.T) {
 	old := supervisorAliveHook
 	t.Cleanup(func() { supervisorAliveHook = old })
 	supervisorAliveHook = func() int { return 0 }
+	oldTimeout := supervisorReadyTimeout
+	supervisorReadyTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { supervisorReadyTimeout = oldTimeout })
+	oldAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = oldAPI })
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	code := doSupervisorStart(&stdout, &stderr)
+	elapsed := time.Since(start)
+	if code != 0 {
+		t.Fatalf("doSupervisorStart code = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("delegated start took %s; the job timeout did not bound the systemctl invocation", elapsed)
+	}
+	if !strings.Contains(stdout.String(), "liveness confirmed via service_manager") {
+		t.Errorf("stdout = %q, want service-manager liveness after a late start", stdout.String())
+	}
+}
+
+// TestEnsureSupervisorRunningDelegatedBoundsSystemctl is the gc-start
+// ensure twin of TestSupervisorStartDelegatedBoundsSystemctl: the bounded
+// timeout falls through to the socket-then-fallback liveness check and,
+// with the unit still inactive and the API unreachable, reports "did not
+// become ready" instead of hanging or falsely succeeding.
+func TestEnsureSupervisorRunningDelegatedBoundsSystemctl(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	installFakeDelegatedSystemctlHangingVerbWithUnitState(t, "start", 3)
+	oldJob := delegatedSystemctlJobTimeout
+	delegatedSystemctlJobTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 0 }
+	oldTimeout := supervisorReadyTimeout
+	supervisorReadyTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { supervisorReadyTimeout = oldTimeout })
+	oldAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = oldAPI })
 
 	var stdout, stderr bytes.Buffer
 	start := time.Now()
@@ -524,8 +635,46 @@ func TestEnsureSupervisorRunningDelegatedBoundsSystemctl(t *testing.T) {
 	if elapsed > 3*time.Second {
 		t.Fatalf("delegated ensure-start took %s; the job timeout did not bound the systemctl invocation", elapsed)
 	}
-	if !strings.Contains(stderr.String(), "timed out after") {
-		t.Errorf("stderr = %q, want systemctl timeout named", stderr.String())
+	if !strings.Contains(stderr.String(), "did not become ready") {
+		t.Errorf("stderr = %q, want 'did not become ready' after the bounded timeout fell through to liveness verification", stderr.String())
+	}
+}
+
+// TestEnsureSupervisorRunningDelegatedTimeoutThenLateStartSucceeds is the
+// gc-start ensure twin of
+// TestSupervisorStartDelegatedTimeoutThenLateStartSucceeds: a bounded
+// systemctl-start timeout whose unit still comes up late must succeed via
+// the is-active fallback rather than fail the whole `gc start`.
+func TestEnsureSupervisorRunningDelegatedTimeoutThenLateStartSucceeds(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	installFakeDelegatedSystemctlHangingVerbWithUnitState(t, "start", 0)
+	oldJob := delegatedSystemctlJobTimeout
+	delegatedSystemctlJobTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
+
+	old := supervisorAliveHook
+	t.Cleanup(func() { supervisorAliveHook = old })
+	supervisorAliveHook = func() int { return 0 }
+	oldTimeout := supervisorReadyTimeout
+	supervisorReadyTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { supervisorReadyTimeout = oldTimeout })
+	oldAPI := supervisorAPIReachable
+	supervisorAPIReachable = func() bool { return false }
+	t.Cleanup(func() { supervisorAPIReachable = oldAPI })
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	code := ensureSupervisorRunning(&stdout, &stderr)
+	elapsed := time.Since(start)
+	if code != 0 {
+		t.Fatalf("ensureSupervisorRunning code = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("delegated ensure-start took %s; the job timeout did not bound the systemctl invocation", elapsed)
+	}
+	if strings.Contains(stderr.String(), "did not become ready") {
+		t.Errorf("stderr = %q, want no readiness failure after a late start", stderr.String())
 	}
 }
 
@@ -1430,9 +1579,13 @@ func TestSupervisorGuidanceUsesServiceNameHelper(t *testing.T) {
 }
 
 // TestRunStartDriftCheck_DelegatedTryRestartBoundsSystemctl pins the
-// CLI-side budget on delegated `systemctl try-restart`: a wedged unit
-// must not hold drift remediation (and with it `gc start`) past the job
-// timeout, matching the bounded delegated stop and start.
+// CLI-side budget on delegated `systemctl try-restart`: a wedged unit must
+// not hold drift remediation (and with it `gc start`) past the job
+// timeout, matching the bounded delegated stop and start. The bounded
+// timeout is not terminal — it falls through to PollReady and the
+// post-restart drift verification — so a try-restart that never replaced
+// the supervisor still fails with the "was not replaced" diagnostic
+// instead of hanging.
 func TestRunStartDriftCheck_DelegatedTryRestartBoundsSystemctl(t *testing.T) {
 	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
 	setCommit("new-build-id")
@@ -1457,10 +1610,62 @@ func TestRunStartDriftCheck_DelegatedTryRestartBoundsSystemctl(t *testing.T) {
 	if elapsed > 3*time.Second {
 		t.Fatalf("delegated try-restart took %s; the job timeout did not bound the systemctl invocation", elapsed)
 	}
-	for _, want := range []string{"supervisor restart failed", "timed out after"} {
-		if !strings.Contains(stderr.String(), want) {
-			t.Errorf("stderr = %q, want %q", stderr.String(), want)
+	if !strings.Contains(stderr.String(), "was not replaced") {
+		t.Errorf("stderr = %q, want 'was not replaced' after the bounded timeout fell through to drift verification", stderr.String())
+	}
+}
+
+// TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds
+// pins the bounded-wait fix for drift remediation: a delegated
+// `systemctl try-restart` that exceeds the CLI budget but whose unit still
+// replaces the supervisor inside systemd must fall through to PollReady and
+// drift verification, observe the late replacement, and report ready —
+// instead of failing before the verification can run.
+func TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds(t *testing.T) {
+	cityPath, setCommit := driftCheckEnv(t, "old-build-id")
+	setCommit("new-build-id")
+
+	oldDry, oldNoAR := dryRunMode, noAutoRestartMode
+	dryRunMode, noAutoRestartMode = false, false
+	t.Cleanup(func() { dryRunMode, noAutoRestartMode = oldDry, oldNoAR })
+
+	setDelegationEnvForTest(t, "gascity-prod.service", "")
+	argsFile := installFakeDelegatedSystemctlHangingVerb(t, "try-restart")
+	oldJob := delegatedSystemctlJobTimeout
+	delegatedSystemctlJobTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { delegatedSystemctlJobTimeout = oldJob })
+
+	// Serve the old build until the fake systemctl has recorded its argv
+	// (argsFile exists), then the new build — modeling a unit that replaces
+	// the supervisor binary only after the CLI's bounded wait has elapsed.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		build := "old-build-id"
+		if _, err := os.Stat(argsFile); err == nil {
+			build = "new-build-id"
 		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"status":"ok","version":"v0","build_id":%q,"uptime_sec":1,"cities_total":0,"cities_running":0}`, build)
+	}))
+	t.Cleanup(srv.Close)
+	oldURL := supervisorAPIBaseURLHook
+	supervisorAPIBaseURLHook = func() (string, error) { return srv.URL, nil }
+	t.Cleanup(func() { supervisorAPIBaseURLHook = oldURL })
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	exitCode, cont := runStartDriftCheck(cityPath, &stdout, &stderr)
+	elapsed := time.Since(start)
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if !cont {
+		t.Fatalf("cont = false after a verified late replacement; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("delegated try-restart took %s; the job timeout did not bound the systemctl invocation", elapsed)
+	}
+	if !strings.Contains(stdout.String(), " ready (") {
+		t.Errorf("stdout = %q, want ready line after verified late replacement", stdout.String())
 	}
 }
 

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -52,6 +52,13 @@ var liveTestEnvVars = []string{
 	"GC_PROVIDER",
 	"GC_READY_PROMPT_PREFIX",
 	"GC_STARTUP_PROMPT_DELIVERED",
+	// Inherited systemd delegation env makes existing lifecycle tests
+	// take the delegated branch and exec PATH-resolved systemctl against
+	// the operator's real unit (including stop). The dynamic GC_* environ
+	// scan in liveEnvKeysForTests already catches these today; listing
+	// them pins the protection explicitly.
+	"GC_SUPERVISOR_SYSTEMD_SCOPE",
+	"GC_SUPERVISOR_SYSTEMD_UNIT",
 }
 
 // inheritedCityRoutingEnvVars lists GC_* variables that an outer gc-managed
@@ -101,6 +108,8 @@ func TestClearProcessLiveEnvForTestsUnsetsInheritedState(t *testing.T) {
 		"GC_RIG",
 		"GC_RIG_ROOT",
 		"GC_SESSION_NAME",
+		"GC_SUPERVISOR_SYSTEMD_SCOPE",
+		"GC_SUPERVISOR_SYSTEMD_UNIT",
 	}
 	preserved := []string{
 		"GC_FAST_UNIT",

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -394,10 +394,16 @@ GC_SUPERVISOR_SYSTEMD_SCOPE=system               # "system" (default) or "user"
 With the unit configured:
 
 - `gc supervisor start` and the `gc start` ensure path run
-  `systemctl [--user] start <unit>` and wait for the control socket to
-  answer. gc never writes, loads, or daemon-reloads its own service
-  files in delegated mode; `gc supervisor install` refuses to run, and
-  `gc supervisor uninstall` only removes gc's own legacy service.
+  `systemctl [--user] start <unit>` (bounded, so a wedged unit cannot
+  hold the CLI indefinitely) and wait for the control socket to answer.
+  When the socket stays unreachable — the usual situation for a
+  system-scope unit running under a different user — start falls back
+  to the same liveness evidence `gc supervisor status` trusts: an
+  active unit, then the supervisor HTTP API. Only when all three are
+  silent does start fail. gc never writes, loads, or daemon-reloads its
+  own service files in delegated mode; `gc supervisor install` refuses
+  to run, and `gc supervisor uninstall` only removes gc's own legacy
+  service.
 - `gc supervisor stop` runs `systemctl [--user] stop <unit>`
   synchronously, bounded by `--wait-timeout` (default 30s) whether or
   not `--wait` is set, then verifies a previously-running supervisor
@@ -421,6 +427,8 @@ With the unit configured:
 
 An invalid `GC_SUPERVISOR_SYSTEMD_SCOPE` value is a hard error on every
 lifecycle path; gc never silently falls back to the default unit.
+Setting `GC_SUPERVISOR_SYSTEMD_UNIT` on a non-Linux platform is the
+same kind of hard error — delegation is a systemd contract.
 
 ## JSONL Archive Push Failures
 


### PR DESCRIPTION
Follow-up for post-merge review of #3354.

Addresses required findings:
- scrub delegated supervisor systemd env from shared live test env
- treat delegated start/ensure as live when the control socket is unreachable but systemd/API liveness is present
- bound delegated systemctl start and try-restart calls so wedged jobs cannot hold gc indefinitely

Also includes non-gating review follow-ups for non-Linux delegation errors and GC_HOME-suffixed supervisor guidance.

Verification:
- go test ./cmd/gc -run 'Test(ClearProcessLiveEnvForTestsUnsetsInheritedState|SupervisorSystemdDelegation|SystemdDelegationCommandShapes|SupervisorStartDeleg|EnsureSupervisorRunningDeleg|SupervisorStatusDelegated|SupervisorInstall|SupervisorUninstall|UninstallSupervisorSystemdUnderDelegation|RunStartDriftCheck_)'\n- make test\n- go vet ./...\n- pre-commit hook: lint-changed, generated docs/schema check, go vet ./..., scripts/test-local-parallel fast, go test ./test/docsync\n\nReview range for source PR: 19a8a39c7a19bac453064f4603a870bfa8e91ac6..c6eb73c4c67c32a95106e6d8480b65b275a35b25