### PR TITLE
fix(doctor): bound each check with a per-check timeout

### DIFF
--- a/cmd/gc/builtin_include_doctor_check_test.go
+++ b/cmd/gc/builtin_include_doctor_check_test.go
@@ -1036,7 +1036,7 @@ schema = 2
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := doDoctor(true, false, false, false, &stdout, &stderr); code != 0 {
+	if code := doDoctor(true, false, false, false, 0, &stdout, &stderr); code != 0 {
 		t.Fatalf("gc doctor --fix = %d, want 0; stdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
 	}
 	output := stdout.String() + stderr.String()

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -30,6 +30,7 @@ var (
 
 func newDoctorCmd(stdout, stderr io.Writer) *cobra.Command {
 	var fix, verbose, jsonOut, explainPostgresAuth bool
+	var checkTimeout time.Duration
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Check workspace health",
@@ -51,7 +52,7 @@ legacy-to-current pack rewrites that are available on this branch.`,
   gc doctor --explain-postgres-auth`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if doDoctor(fix, verbose, jsonOut, explainPostgresAuth, stdout, stderr) != 0 {
+			if doDoctor(fix, verbose, jsonOut, explainPostgresAuth, checkTimeout, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -62,6 +63,8 @@ legacy-to-current pack rewrites that are available on this branch.`,
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit structured JSON instead of human-readable output")
 	cmd.Flags().BoolVar(&explainPostgresAuth, "explain-postgres-auth", false,
 		"after running checks, print per-scope Postgres credential resolution table (no values printed)")
+	cmd.Flags().DurationVar(&checkTimeout, "check-timeout", 60*time.Second,
+		"per-check time budget; a check exceeding it is abandoned and reported as a timed-out advisory error (0 disables)")
 	return cmd
 }
 
@@ -413,14 +416,14 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 	return checks
 }
 
-func doDoctor(fix, verbose, jsonOut, explainPostgresAuth bool, stdout, stderr io.Writer) int {
+func doDoctor(fix, verbose, jsonOut, explainPostgresAuth bool, checkTimeout time.Duration, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc doctor: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	d := &doctor.Doctor{}
+	d := &doctor.Doctor{CheckTimeout: checkTimeout}
 	ctx := &doctor.CheckContext{CityPath: cityPath, Verbose: verbose, ExplainPostgresAuth: explainPostgresAuth}
 	cfg, cfgErr := loadCityConfig(cityPath, stderr)
 	if cfgErr == nil {

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -64,7 +64,7 @@ legacy-to-current pack rewrites that are available on this branch.`,
 	cmd.Flags().BoolVar(&explainPostgresAuth, "explain-postgres-auth", false,
 		"after running checks, print per-scope Postgres credential resolution table (no values printed)")
 	cmd.Flags().DurationVar(&checkTimeout, "check-timeout", 60*time.Second,
-		"per-check time budget; a check exceeding it is abandoned and reported as a timed-out advisory error (0 disables)")
+		"per-check time budget; a check or its --fix remediation exceeding it is abandoned and reported as timed out (0 disables)")
 	return cmd
 }
 
@@ -582,6 +582,10 @@ type doctorJSONResult struct {
 	FixAttempted bool     `json:"fix_attempted,omitempty"`
 	FixError     string   `json:"fix_error,omitempty"`
 	Fixed        bool     `json:"fixed,omitempty"`
+	// TimedOut projects CheckResult.TimedOut so automation can structurally
+	// distinguish an abandoned check (outcome unknown, worth retrying) from a
+	// check that ran and returned an ordinary advisory error.
+	TimedOut bool `json:"timed_out,omitempty"`
 }
 
 type doctorJSONReport struct {
@@ -636,6 +640,7 @@ func writeDoctorJSON(w io.Writer, report *doctor.Report) error {
 			FixAttempted: r.FixAttempted,
 			FixError:     r.FixError,
 			Fixed:        r.Fixed,
+			TimedOut:     r.TimedOut,
 		})
 	}
 	return writeCLIJSONLine(w, out)

--- a/cmd/gc/cmd_doctor_dolt_local_only_test.go
+++ b/cmd/gc/cmd_doctor_dolt_local_only_test.go
@@ -107,7 +107,7 @@ func TestDoDoctorRegistersLocalOnlyRemoteCheckForActiveManagedRigs(t *testing.T)
 	})
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, false, false, false, &stdout, &stderr)
+	_ = doDoctor(false, false, false, false, 0, &stdout, &stderr)
 
 	if len(registered) != 1 {
 		t.Fatalf("registered dolt-local-only checks = %#v, want exactly the active managed rig", registered)
@@ -191,7 +191,7 @@ prefix = "ma"
 	})
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, false, false, false, &stdout, &stderr)
+	_ = doDoctor(false, false, false, false, 0, &stdout, &stderr)
 
 	if registered != 0 {
 		t.Fatalf("registered %d dolt-local-only checks, want 0 when GC_DOLT=skip", registered)

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -1051,3 +1051,39 @@ dolt_port = "3307"
 		t.Fatalf("status = %v, want ok; message = %q", res.Status, res.Message)
 	}
 }
+
+// TestWriteDoctorJSONProjectsTimedOut pins the machine-readable timeout
+// signal: a timed-out check projects timed_out=true so automation can tell an
+// abandoned check (outcome unknown) from an ordinary advisory failure, while
+// omitempty keeps output byte-identical for every non-timed-out result.
+func TestWriteDoctorJSONProjectsTimedOut(t *testing.T) {
+	report := &doctor.Report{
+		Failed: 2,
+		Results: []*doctor.CheckResult{
+			{Name: "wedged", Status: doctor.StatusError, Severity: doctor.SeverityAdvisory, Message: "timed out", TimedOut: true},
+			{Name: "advisory", Status: doctor.StatusError, Severity: doctor.SeverityAdvisory, Message: "ran and found an advisory issue"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := writeDoctorJSON(&buf, report); err != nil {
+		t.Fatalf("writeDoctorJSON: %v", err)
+	}
+	var decoded doctorJSONReport
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode doctor JSON: %v; out=%q", err, buf.String())
+	}
+	if len(decoded.Results) != 2 {
+		t.Fatalf("Results = %d, want 2", len(decoded.Results))
+	}
+	if !decoded.Results[0].TimedOut {
+		t.Fatalf("timed-out check projected TimedOut=false, want true")
+	}
+	if decoded.Results[1].TimedOut {
+		t.Fatalf("ordinary advisory check projected TimedOut=true, want false")
+	}
+	// omitempty: only the abandoned check carries the key, so existing --json
+	// consumers of non-timed-out results see unchanged output.
+	if n := strings.Count(buf.String(), "timed_out"); n != 1 {
+		t.Fatalf("timed_out appears %d times, want exactly 1 (only the abandoned check); out=%s", n, buf.String())
+	}
+}

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -230,7 +230,7 @@ prefix = "fe"
 	})
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, false, false, false, &stdout, &stderr)
+	_ = doDoctor(false, false, false, false, 0, &stdout, &stderr)
 
 	if citySkip == nil || *citySkip {
 		t.Fatalf("city dolt check skip = %v, want false when a bd-backed rig inherits the city endpoint", citySkip)
@@ -325,7 +325,7 @@ suspended = true
 	})
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, false, false, false, &stdout, &stderr)
+	_ = doDoctor(false, false, false, false, 0, &stdout, &stderr)
 
 	if len(registeredBackup) != 1 {
 		t.Fatalf("registered dolt-backup checks = %#v, want only active managed rig", registeredBackup)
@@ -422,7 +422,7 @@ prefix = "ma"
 	})
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, false, false, false, &stdout, &stderr)
+	_ = doDoctor(false, false, false, false, 0, &stdout, &stderr)
 
 	if registeredBackup != 0 {
 		t.Fatalf("registered %d dolt-backup checks, want 0 when GC_DOLT=skip", registeredBackup)
@@ -485,7 +485,7 @@ dolt_port = "3308"
 	})
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, false, false, false, &stdout, &stderr)
+	_ = doDoctor(false, false, false, false, 0, &stdout, &stderr)
 
 	if !strings.Contains(stdout.String(), "canonical/compat Dolt drift") {
 		t.Fatalf("doctor output missing Dolt topology drift:\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
@@ -517,7 +517,7 @@ source = "https://github.com/gastownhall/gc-actual-packs"
 	cleanupManagedDoltTestCity(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "stale-local-pack-dirs") {
 		t.Fatalf("doctor output missing stale-local-pack-dirs check:\n%s", out)
@@ -706,7 +706,7 @@ func runDoctorForStaleLocalPackDirTest(t *testing.T, cityDir string) string {
 	cleanupManagedDoltTestCity(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 	return stdout.String() + stderr.String()
 }
 
@@ -734,7 +734,7 @@ func TestDoDoctorReportsLegacyBDSplitStore(t *testing.T) {
 	t.Cleanup(func() { cityFlag = origCityFlag })
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, false, false, false, &stdout, &stderr)
+	_ = doDoctor(false, false, false, false, 0, &stdout, &stderr)
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "bd-split-store") {
 		t.Fatalf("doctor output missing bd-split-store check:\n%s", out)

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -106,7 +106,7 @@ schema = 2
 	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
 
 	var stdout, stderr bytes.Buffer
-	code := doDoctor(true, false, false, false, &stdout, &stderr)
+	code := doDoctor(true, false, false, false, 0, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("gc doctor --fix = %d, want 0; stdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
 	}
@@ -148,7 +148,7 @@ dir = "formulas"
 	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
 
 	var stdout, stderr bytes.Buffer
-	code := doDoctor(true, false, false, false, &stdout, &stderr)
+	code := doDoctor(true, false, false, false, 0, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("gc doctor --fix = %d, want 0; stdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
 	}
@@ -195,7 +195,7 @@ dir = "custom-formulas"
 	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
 
 	var stdout, stderr bytes.Buffer
-	code := doDoctor(true, false, false, false, &stdout, &stderr)
+	code := doDoctor(true, false, false, false, 0, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("gc doctor --fix unexpectedly passed with custom formulas dir; stdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
 	}
@@ -1149,7 +1149,7 @@ prompt_template = "prompts/helper.md"
 	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
 
 	var stdout, stderr bytes.Buffer
-	code := doDoctor(true, false, false, false, &stdout, &stderr)
+	code := doDoctor(true, false, false, false, 0, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("gc doctor --fix = %d, want 0; stdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
 	}

--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -556,7 +556,7 @@ version = "^1.0"
 	}
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "packv2-import-state") || !strings.Contains(out, `gc import install`) {
 		t.Fatalf("doctor output missing import state check:\n%s", out)
@@ -596,7 +596,7 @@ version = "^1.0"
 	}
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "packv2-import-state") || !strings.Contains(out, "missing-lockfile") {
 		t.Fatalf("doctor output missing import-state failure for broken install state:\n%s", out)
@@ -629,7 +629,7 @@ func TestDoDoctorSkipsImportStateCheckWhenCityConfigInvalid(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 	out := stdout.String() + stderr.String()
 	if strings.Contains(out, "packv2-import-state") {
 		t.Fatalf("doctor output included import state check for invalid config:\n%s", out)

--- a/cmd/gc/jsonl_archive_doctor_check_test.go
+++ b/cmd/gc/jsonl_archive_doctor_check_test.go
@@ -424,7 +424,7 @@ schema = 1
 	}
 
 	var stdout, stderr strings.Builder
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "jsonl-archive") {
 		t.Fatalf("doctor output missing jsonl-archive check:\n%s", out)
@@ -471,7 +471,7 @@ schema = 1
 	}
 
 	var stdout, stderr strings.Builder
-	_ = doDoctor(false, false, true, false, &stdout, &stderr)
+	_ = doDoctor(false, false, true, false, 0, &stdout, &stderr)
 
 	out := stdout.String()
 	if !strings.HasPrefix(strings.TrimSpace(out), "{") {

--- a/cmd/gc/session_model_phase0_doctor_spec_test.go
+++ b/cmd/gc/session_model_phase0_doctor_spec_test.go
@@ -47,7 +47,7 @@ func TestPhase0DoctorReportsClosedBeadOwner(t *testing.T) {
 
 	t.Setenv("GC_CITY", cityPath)
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "closed-bead-owner") {
@@ -71,7 +71,7 @@ func TestPhase0DoctorReportsStaleRoutedConfig(t *testing.T) {
 
 	t.Setenv("GC_CITY", cityPath)
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "stale-routed-config") {
@@ -93,7 +93,7 @@ func TestPhase0DoctorReportsMissingBeadOwner(t *testing.T) {
 
 	t.Setenv("GC_CITY", cityPath)
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "missing-bead-owner") {
@@ -129,7 +129,7 @@ func TestPhase0DoctorReportsRetiredBeadOwner(t *testing.T) {
 
 	t.Setenv("GC_CITY", cityPath)
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "retired-bead-owner") {
@@ -165,7 +165,7 @@ func TestPhase0DoctorDoesNotReportContinuityEligibleArchivedOwnerAsRetired(t *te
 
 	t.Setenv("GC_CITY", cityPath)
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 
 	out := stdout.String() + stderr.String()
 	if strings.Contains(out, "retired-bead-owner") {
@@ -200,7 +200,7 @@ func TestPhase0DoctorReportsAmbiguousLegacySessionToken(t *testing.T) {
 
 	t.Setenv("GC_CITY", cityPath)
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "ambiguous-legacy-session-token") {
@@ -231,7 +231,7 @@ start_command = "true"
 
 	t.Setenv("GC_CITY", cityPath)
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "legacy-token-matches-config-only") {
@@ -265,7 +265,7 @@ func TestPhase0DoctorReportsHistoricalAliasOwner(t *testing.T) {
 
 	t.Setenv("GC_CITY", cityPath)
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "historical-alias-owner") {
@@ -303,7 +303,7 @@ mode = "on_demand"
 
 	t.Setenv("GC_CITY", cityPath)
 	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, &stdout, &stderr)
+	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
 
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "configured-named-conflict") {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1321,6 +1321,7 @@ gc doctor --explain-postgres-auth
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--check-timeout` | duration | `1m0s` | per-check time budget; a check or its --fix remediation exceeding it is abandoned and reported as timed out (0 disables) |
 | `--explain-postgres-auth` | bool |  | after running checks, print per-scope Postgres credential resolution table (no values printed) |
 | `--fix` | bool |  | attempt automatic repairs and safe mechanical migrations |
 | `--json` | bool |  | emit structured JSON instead of human-readable output |

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,8 +1,10 @@
 package doctor
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"time"
 )
 
 // Report summarizes the results of a doctor run.
@@ -28,6 +30,13 @@ type Report struct {
 // Doctor runs registered health checks and reports results.
 type Doctor struct {
 	checks []Check
+	// CheckTimeout bounds each individual check's Run. Zero (the default)
+	// preserves the historical unbounded behavior. When a check exceeds
+	// the bound it is abandoned and reported as a timed-out advisory error
+	// so one wedged check (e.g. a store read stuck behind a saturated data
+	// plane) cannot stall the entire doctor run and hide every check
+	// registered after it.
+	CheckTimeout time.Duration
 }
 
 // Register adds a check to the doctor's check list.
@@ -67,10 +76,13 @@ func (d *Doctor) run(ctx *CheckContext, w io.Writer, fix, stream bool) *Report {
 
 	r := &Report{}
 	for _, c := range d.checks {
-		result := c.Run(ctx)
+		result := d.boundedRun(c, ctx)
 
-		// Attempt fix if requested and the check supports it.
-		if fix && result.Status != StatusOK && c.CanFix() {
+		// Attempt fix if requested and the check supports it. A timed-out
+		// check is skipped: its Run never completed, so its failure state
+		// is unknown and a fix (plus the verifying re-run) could wedge the
+		// loop the same way the check did.
+		if fix && result.Status != StatusOK && !result.TimedOut && c.CanFix() {
 			if err := c.Fix(ctx); err == nil {
 				// Re-run to verify the fix worked.
 				result = c.Run(ctx)
@@ -87,7 +99,9 @@ func (d *Doctor) run(ctx *CheckContext, w io.Writer, fix, stream bool) *Report {
 
 		if stream {
 			printResult(w, result, ctx.Verbose)
-			if r, ok := c.(Renderer); ok {
+			// Skip extras for a timed-out check: its Run goroutine may
+			// still be mutating internal state RenderExtras would read.
+			if r, ok := c.(Renderer); ok && !result.TimedOut {
 				r.RenderExtras(ctx, w)
 			}
 		}
@@ -109,6 +123,39 @@ func (d *Doctor) run(ctx *CheckContext, w io.Writer, fix, stream bool) *Report {
 		}
 	}
 	return r
+}
+
+// boundedRun executes one check under the doctor's per-check timeout.
+// Zero timeout runs the check inline (historical behavior). Otherwise the
+// check runs in a goroutine against a context whose Output is a private
+// buffer: on completion the buffer is flushed to the real writer (keeping a
+// check's incidental output grouped before its result line); on timeout the
+// goroutine is abandoned with its private buffer, so a still-running check
+// can never interleave writes with — or race against — the rest of the run.
+func (d *Doctor) boundedRun(c Check, ctx *CheckContext) *CheckResult {
+	if d.CheckTimeout <= 0 {
+		return c.Run(ctx)
+	}
+	var buf bytes.Buffer
+	checkCtx := *ctx
+	checkCtx.Output = &buf
+	done := make(chan *CheckResult, 1)
+	go func() { done <- c.Run(&checkCtx) }()
+	select {
+	case result := <-done:
+		if buf.Len() > 0 && ctx.Output != nil {
+			buf.WriteTo(ctx.Output) //nolint:errcheck // best-effort output
+		}
+		return result
+	case <-time.After(d.CheckTimeout):
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusError,
+			Severity: SeverityAdvisory,
+			TimedOut: true,
+			Message:  fmt.Sprintf("timed out after %s and was abandoned (outcome unknown); re-run alone or raise --check-timeout", d.CheckTimeout),
+		}
+	}
 }
 
 // printResult writes a single check result line to w.

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -2,10 +2,16 @@ package doctor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"time"
 )
+
+// errFixTimedOut is the internal sentinel boundedFix returns when a fix
+// exceeds the per-check timeout and is abandoned. It never reaches user
+// output — the runner substitutes a descriptive FixError message.
+var errFixTimedOut = errors.New("fix timed out and was abandoned")
 
 // Report summarizes the results of a doctor run.
 type Report struct {
@@ -30,12 +36,14 @@ type Report struct {
 // Doctor runs registered health checks and reports results.
 type Doctor struct {
 	checks []Check
-	// CheckTimeout bounds each individual check's Run. Zero (the default)
-	// preserves the historical unbounded behavior. When a check exceeds
-	// the bound it is abandoned and reported as a timed-out advisory error
-	// so one wedged check (e.g. a store read stuck behind a saturated data
-	// plane) cannot stall the entire doctor run and hide every check
-	// registered after it.
+	// CheckTimeout bounds each individual check's Run, its --fix remediation,
+	// and the post-fix verification re-run. Zero (the default) preserves the
+	// historical unbounded behavior. When one of those exceeds the bound it is
+	// abandoned so one wedged check (e.g. a store read stuck behind a saturated
+	// data plane, or a fix script blocked on I/O) cannot stall the entire
+	// doctor run and hide every check registered after it. A timed-out Run is
+	// reported as a timed-out advisory error; a timed-out fix is reported as an
+	// unconfirmed remediation.
 	CheckTimeout time.Duration
 }
 
@@ -78,51 +86,55 @@ func (d *Doctor) run(ctx *CheckContext, w io.Writer, fix, stream bool) *Report {
 	for _, c := range d.checks {
 		result := d.boundedRun(c, ctx)
 
+		// abandoned is true when a goroutine for this check may still be
+		// running — a timed-out Run, or a fix/verify abandoned below. Its
+		// internal state is not settled, so RenderExtras must be skipped to
+		// avoid reading half-mutated state.
+		abandoned := result.TimedOut
+
 		// Attempt fix if requested and the check supports it. A timed-out
 		// check is skipped: its Run never completed, so its failure state
 		// is unknown and a fix (plus the verifying re-run) could wedge the
 		// loop the same way the check did.
 		if fix && result.Status != StatusOK && !result.TimedOut && c.CanFix() {
-			if err := c.Fix(ctx); err == nil {
-				// Re-run to verify the fix worked.
-				result = c.Run(ctx)
-				if result.Status == StatusOK {
-					result.Fixed = true
-				} else {
-					result.FixAttempted = true
-				}
-			} else {
-				result.FixError = err.Error()
-				result.FixAttempted = true
-			}
+			var fixAbandoned bool
+			result, fixAbandoned = d.fixAndVerify(c, ctx, result)
+			abandoned = abandoned || fixAbandoned || result.TimedOut
 		}
 
 		if stream {
 			printResult(w, result, ctx.Verbose)
-			// Skip extras for a timed-out check: its Run goroutine may
-			// still be mutating internal state RenderExtras would read.
-			if r, ok := c.(Renderer); ok && !result.TimedOut {
+			// Skip extras for a check with a still-running abandoned
+			// goroutine (timed-out Run or fix): it may still be mutating
+			// internal state RenderExtras would read.
+			if r, ok := c.(Renderer); ok && !abandoned {
 				r.RenderExtras(ctx, w)
 			}
 		}
 		r.Results = append(r.Results, result)
-
-		switch {
-		case result.Fixed:
-			r.Fixed++
-			r.Passed++ // Fixed counts as passed.
-		case result.Status == StatusOK:
-			r.Passed++
-		case result.Status == StatusWarning:
-			r.Warned++
-		case result.Status == StatusError:
-			r.Failed++
-			if result.Severity == SeverityBlocking {
-				r.BlockingFailed++
-			}
-		}
+		r.tally(result)
 	}
 	return r
+}
+
+// tally folds one check result into the report's running counts. A fixed
+// check counts as passed; a failing check increments BlockingFailed only when
+// its severity gates.
+func (r *Report) tally(result *CheckResult) {
+	switch {
+	case result.Fixed:
+		r.Fixed++
+		r.Passed++ // Fixed counts as passed.
+	case result.Status == StatusOK:
+		r.Passed++
+	case result.Status == StatusWarning:
+		r.Warned++
+	case result.Status == StatusError:
+		r.Failed++
+		if result.Severity == SeverityBlocking {
+			r.BlockingFailed++
+		}
+	}
 }
 
 // boundedRun executes one check under the doctor's per-check timeout.
@@ -155,6 +167,68 @@ func (d *Doctor) boundedRun(c Check, ctx *CheckContext) *CheckResult {
 			TimedOut: true,
 			Message:  fmt.Sprintf("timed out after %s and was abandoned (outcome unknown); re-run alone or raise --check-timeout", d.CheckTimeout),
 		}
+	}
+}
+
+// fixAndVerify remediates a failing, fixable check and re-runs it to confirm,
+// bounding both the fix and the verifying re-run under the per-check timeout.
+// It returns the result to report (res mutated in place on fix failure, or the
+// fresh verification result on success) and whether the fix was abandoned at
+// the bound. A fix that exceeds the timeout is abandoned — not killed — so
+// gc doctor --fix cannot hang on a wedged remediation, while the fix still runs
+// to completion in the background rather than being interrupted mid-mutation.
+func (d *Doctor) fixAndVerify(c Check, ctx *CheckContext, res *CheckResult) (*CheckResult, bool) {
+	switch err := d.boundedFix(c, ctx); {
+	case errors.Is(err, errFixTimedOut):
+		res.FixAttempted = true
+		res.FixError = fmt.Sprintf("fix timed out after %s and was abandoned; remediation unconfirmed", d.CheckTimeout)
+		return res, true
+	case err != nil:
+		res.FixError = err.Error()
+		res.FixAttempted = true
+		return res, false
+	}
+	// Verify the fix worked, bounding the re-run exactly like the initial run.
+	// A check that fails fast, fixes fast, then wedges on this verification
+	// would otherwise hang gc doctor --fix — re-opening the very failure mode
+	// the per-check timeout closes.
+	verified := d.boundedRun(c, ctx)
+	if verified.Status == StatusOK {
+		verified.Fixed = true
+	} else {
+		verified.FixAttempted = true
+	}
+	return verified, false
+}
+
+// boundedFix runs a check's Fix under the doctor's per-check timeout using the
+// same abandon-on-timeout mechanism as boundedRun, including its output
+// isolation. Zero timeout runs Fix inline (historical behavior). Otherwise Fix
+// runs in a goroutine against a context whose Output is a private buffer: on
+// completion the buffer is flushed to the real writer (keeping a fix's
+// diagnostics grouped before the check's result line); on timeout the goroutine
+// is abandoned with its private buffer, so a still-running fix can never
+// interleave writes with — or race against — the rest of the run. The abandoned
+// goroutine keeps running until its own I/O returns or the process exits, so the
+// fix is not interrupted mid-mutation. errFixTimedOut is returned on timeout;
+// otherwise Fix's own error (or nil) is returned.
+func (d *Doctor) boundedFix(c Check, ctx *CheckContext) error {
+	if d.CheckTimeout <= 0 {
+		return c.Fix(ctx)
+	}
+	var buf bytes.Buffer
+	fixCtx := *ctx
+	fixCtx.Output = &buf
+	done := make(chan error, 1)
+	go func() { done <- c.Fix(&fixCtx) }()
+	select {
+	case err := <-done:
+		if buf.Len() > 0 && ctx.Output != nil {
+			buf.WriteTo(ctx.Output) //nolint:errcheck // best-effort output
+		}
+		return err
+	case <-time.After(d.CheckTimeout):
+		return errFixTimedOut
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 // mockCheck is a configurable Check for testing the runner.
@@ -15,11 +16,16 @@ type mockCheck struct {
 	msg      string
 	canFix   bool
 	fixErr   error
-	fixed    bool // set by Fix
+	fixed    bool          // set by Fix
+	delay    time.Duration // sleep inside Run, for timeout tests
+	fixCalls int           // incremented by Fix
 }
 
 func (m *mockCheck) Name() string { return m.name }
 func (m *mockCheck) Run(_ *CheckContext) *CheckResult {
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
 	st := m.status
 	if m.fixed {
 		st = StatusOK
@@ -33,6 +39,7 @@ func (m *mockCheck) Run(_ *CheckContext) *CheckResult {
 }
 func (m *mockCheck) CanFix() bool { return m.canFix }
 func (m *mockCheck) Fix(_ *CheckContext) error {
+	m.fixCalls++
 	if m.fixErr != nil {
 		return m.fixErr
 	}
@@ -537,4 +544,100 @@ func TestPrintSummary_AdvisoryRenderedSeparately(t *testing.T) {
 	if got := buf.String(); strings.Contains(got, "advisory") {
 		t.Errorf("summary = %q, must not include 'advisory' when all failures are blocking", got)
 	}
+}
+
+// TestRunCheckTimeoutAbandonsWedgedCheck guards the per-check timeout: one
+// wedged check must not stall the run — it reports as a timed-out advisory
+// error and every check registered after it still executes.
+func TestRunCheckTimeoutAbandonsWedgedCheck(t *testing.T) {
+	d := &Doctor{CheckTimeout: 25 * time.Millisecond}
+	wedged := &mockCheck{name: "wedged", status: StatusOK, delay: 5 * time.Second}
+	after := &mockCheck{name: "after", status: StatusOK, msg: "ran"}
+	d.Register(wedged)
+	d.Register(after)
+
+	var buf bytes.Buffer
+	start := time.Now()
+	report := d.Run(&CheckContext{}, &buf, false)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("run took %s; the wedged check was not abandoned", elapsed)
+	}
+
+	if len(report.Results) != 2 {
+		t.Fatalf("Results = %d, want 2 (check after the wedge must still run)", len(report.Results))
+	}
+	got := report.Results[0]
+	if !got.TimedOut || got.Status != StatusError || got.Severity != SeverityAdvisory {
+		t.Fatalf("wedged result = %+v, want TimedOut StatusError SeverityAdvisory", got)
+	}
+	if !strings.Contains(got.Message, "timed out") {
+		t.Fatalf("wedged message = %q, want a timeout explanation", got.Message)
+	}
+	if report.Results[1].Name != "after" || report.Results[1].Status != StatusOK {
+		t.Fatalf("after result = %+v, want it to have run normally", report.Results[1])
+	}
+	if report.Failed != 1 || report.BlockingFailed != 0 || report.Passed != 1 {
+		t.Fatalf("report = %+v, want 1 advisory failure + 1 pass", report)
+	}
+	if out := buf.String(); !strings.Contains(out, "wedged") || !strings.Contains(out, "after") {
+		t.Fatalf("output = %q, want both check lines", out)
+	}
+}
+
+// TestRunCheckTimeoutZeroIsUnbounded pins the default: CheckTimeout zero runs
+// checks inline with no bound, preserving historical behavior for embedders
+// that never set the field.
+func TestRunCheckTimeoutZeroIsUnbounded(t *testing.T) {
+	d := &Doctor{}
+	slow := &mockCheck{name: "slow", status: StatusOK, delay: 30 * time.Millisecond}
+	d.Register(slow)
+
+	var buf bytes.Buffer
+	report := d.Run(&CheckContext{}, &buf, false)
+	if report.Passed != 1 || len(report.Results) != 1 || report.Results[0].TimedOut {
+		t.Fatalf("report = %+v, want the slow check to complete unbounded", report)
+	}
+}
+
+// TestRunCheckTimeoutSkipsFixForTimedOutCheck: a timed-out check's failure
+// state is unknown, so --fix must not attempt remediation (whose verifying
+// re-run could wedge the loop the same way the check did).
+func TestRunCheckTimeoutSkipsFixForTimedOutCheck(t *testing.T) {
+	d := &Doctor{CheckTimeout: 25 * time.Millisecond}
+	wedged := &mockCheck{name: "wedged", status: StatusError, delay: 5 * time.Second, canFix: true}
+	d.Register(wedged)
+
+	var buf bytes.Buffer
+	report := d.Run(&CheckContext{}, &buf, true)
+	if wedged.fixCalls != 0 {
+		t.Fatalf("fixCalls = %d, want 0 (no fix for a timed-out check)", wedged.fixCalls)
+	}
+	if report.Fixed != 0 {
+		t.Fatalf("report.Fixed = %d, want 0", report.Fixed)
+	}
+}
+
+// TestRunCheckTimeoutFlushesCompletedCheckOutput: a check that completes
+// within the bound and wrote to ctx.Output must have that output reach the
+// real writer (the private abandonment buffer is an implementation detail).
+func TestRunCheckTimeoutFlushesCompletedCheckOutput(t *testing.T) {
+	d := &Doctor{CheckTimeout: time.Second}
+	d.Register(&outputWritingCheck{mockCheck{name: "writer", status: StatusOK}})
+
+	var buf bytes.Buffer
+	d.Run(&CheckContext{}, &buf, false)
+	if out := buf.String(); !strings.Contains(out, "incidental diagnostic") {
+		t.Fatalf("output = %q, want the check's incidental ctx.Output write flushed", out)
+	}
+}
+
+// outputWritingCheck writes to ctx.Output during Run, like checks that
+// surface fix-time diagnostics.
+type outputWritingCheck struct{ mockCheck }
+
+func (o *outputWritingCheck) Run(ctx *CheckContext) *CheckResult {
+	if ctx.Output != nil {
+		fmt.Fprintln(ctx.Output, "incidental diagnostic") //nolint:errcheck // test writer
+	}
+	return o.mockCheck.Run(ctx)
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -3,7 +3,9 @@ package doctor
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -17,14 +19,14 @@ type mockCheck struct {
 	canFix   bool
 	fixErr   error
 	fixed    bool          // set by Fix
-	delay    time.Duration // sleep inside Run, for timeout tests
+	block    chan struct{} // if non-nil, Run blocks on it until closed (models a wedge abandoned on timeout)
 	fixCalls int           // incremented by Fix
 }
 
 func (m *mockCheck) Name() string { return m.name }
 func (m *mockCheck) Run(_ *CheckContext) *CheckResult {
-	if m.delay > 0 {
-		time.Sleep(m.delay)
+	if m.block != nil {
+		<-m.block
 	}
 	st := m.status
 	if m.fixed {
@@ -551,7 +553,8 @@ func TestPrintSummary_AdvisoryRenderedSeparately(t *testing.T) {
 // error and every check registered after it still executes.
 func TestRunCheckTimeoutAbandonsWedgedCheck(t *testing.T) {
 	d := &Doctor{CheckTimeout: 25 * time.Millisecond}
-	wedged := &mockCheck{name: "wedged", status: StatusOK, delay: 5 * time.Second}
+	wedged := &mockCheck{name: "wedged", status: StatusOK, block: make(chan struct{})}
+	t.Cleanup(func() { close(wedged.block) }) // abandon the wedge once the run has returned
 	after := &mockCheck{name: "after", status: StatusOK, msg: "ran"}
 	d.Register(wedged)
 	d.Register(after)
@@ -589,13 +592,13 @@ func TestRunCheckTimeoutAbandonsWedgedCheck(t *testing.T) {
 // that never set the field.
 func TestRunCheckTimeoutZeroIsUnbounded(t *testing.T) {
 	d := &Doctor{}
-	slow := &mockCheck{name: "slow", status: StatusOK, delay: 30 * time.Millisecond}
-	d.Register(slow)
+	check := &mockCheck{name: "unbounded", status: StatusOK}
+	d.Register(check)
 
 	var buf bytes.Buffer
 	report := d.Run(&CheckContext{}, &buf, false)
 	if report.Passed != 1 || len(report.Results) != 1 || report.Results[0].TimedOut {
-		t.Fatalf("report = %+v, want the slow check to complete unbounded", report)
+		t.Fatalf("report = %+v, want the check to run inline and complete unbounded (never TimedOut)", report)
 	}
 }
 
@@ -604,7 +607,8 @@ func TestRunCheckTimeoutZeroIsUnbounded(t *testing.T) {
 // re-run could wedge the loop the same way the check did).
 func TestRunCheckTimeoutSkipsFixForTimedOutCheck(t *testing.T) {
 	d := &Doctor{CheckTimeout: 25 * time.Millisecond}
-	wedged := &mockCheck{name: "wedged", status: StatusError, delay: 5 * time.Second, canFix: true}
+	wedged := &mockCheck{name: "wedged", status: StatusError, block: make(chan struct{}), canFix: true}
+	t.Cleanup(func() { close(wedged.block) }) // abandon the wedge once the run has returned
 	d.Register(wedged)
 
 	var buf bytes.Buffer
@@ -641,3 +645,291 @@ func (o *outputWritingCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 	return o.mockCheck.Run(ctx)
 }
+
+// TestRunCheckTimeoutBoundsPostFixVerification guards the post-fix
+// verification rerun: a check that fails fast, fixes fast, then wedges on the
+// verifying re-run must not hang gc doctor --fix. Without bounding that rerun,
+// the per-check timeout only covers the initial Run and this exact interaction
+// re-opens the wedge the feature exists to close.
+func TestRunCheckTimeoutBoundsPostFixVerification(t *testing.T) {
+	d := &Doctor{CheckTimeout: 25 * time.Millisecond}
+	check := &wedgeOnVerifyCheck{name: "wedge-on-verify", release: make(chan struct{})}
+	t.Cleanup(func() { close(check.release) }) // release the abandoned verification goroutine
+	d.Register(check)
+
+	var buf bytes.Buffer
+	start := time.Now()
+	report := d.Run(&CheckContext{}, &buf, true)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("run took %s; the post-fix verification rerun was not bounded", elapsed)
+	}
+
+	// Fix ran once (the initial fast failure is fixable and not timed out),
+	// proving we exercised the post-fix path rather than skipping it.
+	if check.fixCalls != 1 {
+		t.Fatalf("fixCalls = %d, want 1 (fix runs once for the fast initial failure)", check.fixCalls)
+	}
+	if len(report.Results) != 1 {
+		t.Fatalf("Results = %d, want 1", len(report.Results))
+	}
+	got := report.Results[0]
+	// The only path to TimedOut here is the verification boundedRun timing
+	// out: the initial run failed fast, so it did not time out.
+	if !got.TimedOut || got.Status != StatusError || got.Severity != SeverityAdvisory {
+		t.Fatalf("verification result = %+v, want a timed-out advisory error", got)
+	}
+	if !got.FixAttempted {
+		t.Fatalf("result.FixAttempted = false, want true; the fix ran but verification never confirmed it")
+	}
+	if got.Fixed || report.Fixed != 0 {
+		t.Fatalf("result.Fixed=%v report.Fixed=%d, want the fix unconfirmed (0)", got.Fixed, report.Fixed)
+	}
+}
+
+// wedgeOnVerifyCheck fails fast on its first Run, its Fix succeeds, then its
+// post-fix verification Run wedges (blocks on release until the test abandons
+// it). fixCalls is written only by Fix on the main goroutine before the
+// verification goroutine is spawned, so the abandoned goroutine only ever reads
+// it — no data race.
+type wedgeOnVerifyCheck struct {
+	name     string
+	fixCalls int
+	release  chan struct{} // closed by the test to release the abandoned verification goroutine
+}
+
+func (c *wedgeOnVerifyCheck) Name() string { return c.name }
+func (c *wedgeOnVerifyCheck) Run(_ *CheckContext) *CheckResult {
+	if c.fixCalls > 0 {
+		<-c.release // verification wedges; abandoned on timeout, released at cleanup
+		return &CheckResult{Name: c.name, Status: StatusOK}
+	}
+	return &CheckResult{Name: c.name, Status: StatusError, Severity: SeverityBlocking, Message: "needs fix"}
+}
+func (c *wedgeOnVerifyCheck) CanFix() bool { return true }
+func (c *wedgeOnVerifyCheck) Fix(_ *CheckContext) error {
+	c.fixCalls++
+	return nil
+}
+func (c *wedgeOnVerifyCheck) WarmupEligible() bool { return false }
+
+// TestRunCheckTimeoutBoundsFix guards fix execution itself: a check that fails
+// fast then wedges inside Fix must not hang gc doctor --fix. The fix is
+// abandoned at the per-check bound (not killed — it finishes in the
+// background), the run returns promptly, and the result reports an unconfirmed
+// remediation while preserving the check's original failing status.
+func TestRunCheckTimeoutBoundsFix(t *testing.T) {
+	d := &Doctor{CheckTimeout: 25 * time.Millisecond}
+	check := &wedgeOnFixCheck{name: "wedge-on-fix", release: make(chan struct{})}
+	t.Cleanup(func() { close(check.release) }) // release the abandoned fix goroutine
+	d.Register(check)
+
+	var buf bytes.Buffer
+	start := time.Now()
+	report := d.Run(&CheckContext{}, &buf, true)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("run took %s; the wedged fix was not bounded", elapsed)
+	}
+
+	// Fix ran once (the initial fast failure is fixable and not timed out),
+	// proving we exercised the fix path rather than skipping it.
+	if got := check.fixCalls.Load(); got != 1 {
+		t.Fatalf("fixCalls = %d, want 1 (fix runs once for the fast initial failure)", got)
+	}
+	if len(report.Results) != 1 {
+		t.Fatalf("Results = %d, want 1", len(report.Results))
+	}
+	got := report.Results[0]
+	// The initial Run failed fast (not timed out); the FIX is what got
+	// abandoned, so the result is an unconfirmed remediation, never Fixed.
+	if got.Fixed || report.Fixed != 0 {
+		t.Fatalf("result.Fixed=%v report.Fixed=%d, want the fix unconfirmed (0)", got.Fixed, report.Fixed)
+	}
+	if !got.FixAttempted {
+		t.Fatalf("result.FixAttempted = false, want true; the fix ran but never confirmed")
+	}
+	if !strings.Contains(got.FixError, "timed out") {
+		t.Fatalf("result.FixError = %q, want a fix-timeout explanation", got.FixError)
+	}
+	// The check still fails at its original severity: a wedged fix leaves the
+	// problem unremediated, so it must still gate (unlike a timed-out Run,
+	// which is advisory because its outcome is unknown).
+	if got.Status != StatusError || got.Severity != SeverityBlocking {
+		t.Fatalf("result = %+v, want the original blocking failure preserved", got)
+	}
+	if report.Failed != 1 || report.BlockingFailed != 1 {
+		t.Fatalf("report = %+v, want the unfixed check counted as a blocking failure", report)
+	}
+}
+
+// wedgeOnFixCheck fails fast on Run, then wedges inside Fix (blocks on release
+// until the test abandons it) — modeling a remediation that hangs (e.g. a pack
+// fix script blocked on I/O). Fix runs in the abandoned goroutine, so fixCalls
+// is atomic: the goroutine writes it while the test reads it after the fix is
+// abandoned.
+type wedgeOnFixCheck struct {
+	name     string
+	fixCalls atomic.Int32
+	release  chan struct{} // closed by the test to release the abandoned fix goroutine
+}
+
+func (c *wedgeOnFixCheck) Name() string { return c.name }
+func (c *wedgeOnFixCheck) Run(_ *CheckContext) *CheckResult {
+	return &CheckResult{Name: c.name, Status: StatusError, Severity: SeverityBlocking, Message: "needs fix"}
+}
+func (c *wedgeOnFixCheck) CanFix() bool { return true }
+func (c *wedgeOnFixCheck) Fix(_ *CheckContext) error {
+	c.fixCalls.Add(1)
+	<-c.release // wedged remediation; abandoned on timeout, released at cleanup
+	return nil
+}
+func (c *wedgeOnFixCheck) WarmupEligible() bool { return false }
+
+// TestRunCheckTimeoutIsolatesLateOutputAndSkipsRenderExtras proves the two
+// safety guards the timeout path adds: an abandoned check's late writes land
+// in its private buffer (never the real writer), and RenderExtras is not
+// invoked for a timed-out check. Coordination is via channels so the
+// assertions are deterministic rather than timing-based.
+func TestRunCheckTimeoutIsolatesLateOutputAndSkipsRenderExtras(t *testing.T) {
+	d := &Doctor{CheckTimeout: 25 * time.Millisecond}
+	check := &lateWritingCheck{
+		name:      "late-writer",
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+		wroteLate: make(chan struct{}),
+	}
+	d.Register(check)
+
+	var buf bytes.Buffer
+	done := make(chan *Report, 1)
+	go func() { done <- d.Run(&CheckContext{}, &buf, false) }()
+
+	// Wait until the check is running, then let the 25ms bound fire and
+	// abandon it (the check stays blocked on release, so it cannot complete).
+	<-check.started
+	report := <-done
+
+	if len(report.Results) != 1 || !report.Results[0].TimedOut {
+		t.Fatalf("Results = %+v, want one timed-out result", report.Results)
+	}
+
+	// Release the abandoned check so it performs its late ctx.Output write,
+	// then wait for that write to finish before asserting.
+	outputBeforeLateWrite := buf.String()
+	close(check.release)
+	<-check.wroteLate
+
+	if got := buf.String(); got != outputBeforeLateWrite {
+		t.Fatalf("real writer received abandoned late output: before=%q after=%q", outputBeforeLateWrite, got)
+	}
+	if check.renderExtrasCalled.Load() {
+		t.Fatalf("RenderExtras was invoked for a timed-out check; it must be skipped")
+	}
+}
+
+// lateWritingCheck blocks inside Run until released, then writes to
+// ctx.Output — modeling an abandoned check whose goroutine keeps running and
+// emits output after the doctor timeout fired. It implements Renderer so the
+// test can prove RenderExtras is skipped for a timed-out check.
+type lateWritingCheck struct {
+	name               string
+	started            chan struct{}
+	release            chan struct{}
+	wroteLate          chan struct{}
+	renderExtrasCalled atomic.Bool
+}
+
+func (c *lateWritingCheck) Name() string { return c.name }
+func (c *lateWritingCheck) Run(ctx *CheckContext) *CheckResult {
+	close(c.started)
+	<-c.release
+	// The doctor timeout has fired by now; this write must land in the
+	// abandoned private buffer, never the real writer.
+	if ctx.Output != nil {
+		fmt.Fprintln(ctx.Output, "late abandoned output") //nolint:errcheck // test writer
+	}
+	close(c.wroteLate)
+	return &CheckResult{Name: c.name, Status: StatusOK}
+}
+func (c *lateWritingCheck) CanFix() bool              { return false }
+func (c *lateWritingCheck) Fix(_ *CheckContext) error { return nil }
+func (c *lateWritingCheck) WarmupEligible() bool      { return false }
+func (c *lateWritingCheck) RenderExtras(_ *CheckContext, _ io.Writer) {
+	c.renderExtrasCalled.Store(true)
+}
+
+// TestRunCheckTimeoutIsolatesLateFixOutput proves the fix path gets the same
+// output isolation as the Run path: when a wedged Fix is abandoned at the
+// per-check bound, its late writes to ctx.Output must land in the private
+// abandonment buffer, never the real writer. Without isolation the abandoned
+// fix goroutine races the main run's writer (garbled output on a stream, slice
+// corruption on a buffer-backed writer). Coordination is via channels so the
+// assertion is deterministic rather than timing-based and holds under -race.
+func TestRunCheckTimeoutIsolatesLateFixOutput(t *testing.T) {
+	d := &Doctor{CheckTimeout: 25 * time.Millisecond}
+	check := &lateWritingOnFixCheck{
+		name:      "late-fix-writer",
+		fixStart:  make(chan struct{}),
+		release:   make(chan struct{}),
+		wroteLate: make(chan struct{}),
+	}
+	d.Register(check)
+
+	var buf bytes.Buffer
+	done := make(chan *Report, 1)
+	go func() { done <- d.Run(&CheckContext{}, &buf, true) }()
+
+	// Wait until Fix is running, then let the 25ms bound fire and abandon it
+	// (Fix stays blocked on release, so it cannot complete within the bound).
+	<-check.fixStart
+	report := <-done
+
+	// The initial Run failed fast; the FIX was abandoned, so the result is an
+	// unconfirmed remediation — proving we exercised the fix-timeout path.
+	if len(report.Results) != 1 {
+		t.Fatalf("Results = %d, want 1", len(report.Results))
+	}
+	if got := report.Results[0]; got.Fixed || !got.FixAttempted || !strings.Contains(got.FixError, "timed out") {
+		t.Fatalf("result = %+v, want an unconfirmed fix-timeout", got)
+	}
+
+	// Release the abandoned fix so it performs its late ctx.Output write, then
+	// wait for that write to finish before asserting nothing reached the real
+	// writer.
+	outputBeforeLateWrite := buf.String()
+	close(check.release)
+	<-check.wroteLate
+
+	if got := buf.String(); got != outputBeforeLateWrite {
+		t.Fatalf("real writer received abandoned late fix output: before=%q after=%q", outputBeforeLateWrite, got)
+	}
+}
+
+// lateWritingOnFixCheck fails fast on Run, then blocks inside Fix until
+// released and writes to ctx.Output afterward — modeling an abandoned fix
+// goroutine (e.g. the dolt-drift or v2-migration fixes, which write ctx.Output)
+// that keeps running and emits diagnostics after the doctor timeout fired. The
+// late write must land in the fix path's private buffer, never the real writer.
+type lateWritingOnFixCheck struct {
+	name      string
+	fixStart  chan struct{}
+	release   chan struct{}
+	wroteLate chan struct{}
+}
+
+func (c *lateWritingOnFixCheck) Name() string { return c.name }
+func (c *lateWritingOnFixCheck) Run(_ *CheckContext) *CheckResult {
+	return &CheckResult{Name: c.name, Status: StatusError, Severity: SeverityBlocking, Message: "needs fix"}
+}
+func (c *lateWritingOnFixCheck) CanFix() bool { return true }
+func (c *lateWritingOnFixCheck) Fix(ctx *CheckContext) error {
+	close(c.fixStart)
+	<-c.release
+	// The doctor timeout has fired by now; this write must land in the
+	// abandoned private buffer, never the real writer.
+	if ctx.Output != nil {
+		fmt.Fprintln(ctx.Output, "late abandoned fix output") //nolint:errcheck // test writer
+	}
+	close(c.wroteLate)
+	return nil
+}
+func (c *lateWritingOnFixCheck) WarmupEligible() bool { return false }

--- a/internal/doctor/types.go
+++ b/internal/doctor/types.go
@@ -101,4 +101,9 @@ type CheckResult struct {
 	FixAttempted bool
 	// Fixed is true when --fix successfully remediated the issue.
 	Fixed bool
+	// TimedOut is true when the check exceeded the doctor's per-check
+	// timeout and was abandoned. The check's real outcome is unknown:
+	// the runner reports StatusError/SeverityAdvisory so the run keeps
+	// going without gating automation on an unfinished check.
+	TimedOut bool
 }


### PR DESCRIPTION
## Problem

`gc doctor` runs its checks sequentially with no per-check bound. One check that wedges — in production, `order-firing-current`, whose per-order `LastRunAcrossStores` store reads stall behind a saturated data plane — stalls the entire run indefinitely: no summary, no exit, and every check registered after the wedged one (import-state, jsonl-archive, MCP, rig coverage…) silently never runs. On a busy host this makes doctor unusable exactly when it's most needed, and the operator can't tell "doctor is slow" from "doctor is dead."

Observed in production: doctor produced zero results past 150s while the first ~34 (config-layer) checks complete in under a minute; line-buffered capture + the check registration order pinned the wedge to `order-firing-current` under load.

## Fix

- `Doctor.CheckTimeout` (zero = unbounded, preserving historical behavior for embedders): each check runs under a wall-clock bound. A check exceeding it is **abandoned** and reported as `StatusError` / `SeverityAdvisory` with `TimedOut: true` — advisory because the check's real outcome is unknown, so automation gates shouldn't fire on it; the run continues to the remaining checks.
- Abandonment is race-safe: each bounded check runs against a context whose `Output` is a private buffer, flushed to the real writer on completion — an abandoned goroutine can never interleave writes with the rest of the run. `--fix` and `RenderExtras` are skipped for timed-out checks (unknown state / possibly still mutating).
- `gc doctor --check-timeout` (default 60s, 0 disables). The `gc start` warm-up scan constructs its own Doctor and is unchanged.
- `CheckResult.TimedOut` is exported for `--json` consumers.

## Tests

- Wedged check (5s sleep, 25ms budget): abandoned in milliseconds, reported as timed-out advisory error, subsequent checks still run, report counts correct.
- Zero timeout: unbounded inline behavior pinned.
- Timed-out check: `--fix` not attempted.
- Completed check's incidental `ctx.Output` writes still reach the real writer through the buffering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
