### PR TITLE
fix(beads): include no-history wisps in DoltLite TierIssues reads + Count parity (#3444)

### DIFF
--- a/contrib/beads-scripts/gc-beads-br
+++ b/contrib/beads-scripts/gc-beads-br
@@ -86,6 +86,7 @@ br_object_to_gc() {
   local obj="$1"
   local parent_id="" key value rest key_hex value_hex
   local ephemeral=false
+  local no_history=false
   local -a kept_labels=()
   local -a needs=()
   local metadata='{}'
@@ -115,6 +116,9 @@ br_object_to_gc() {
       gc:ephemeral)
         ephemeral=true
         ;;
+      gc:no-history)
+        no_history=true
+        ;;
       *)
         kept_labels+=("$label")
         ;;
@@ -131,6 +135,7 @@ br_object_to_gc() {
     --argjson needs "$needs_json" \
     --argjson metadata "$metadata" \
     --argjson ephemeral "$ephemeral" \
+    --argjson no_history "$no_history" \
     '{
       id: .id,
       title: .title,
@@ -146,7 +151,8 @@ br_object_to_gc() {
       description: (.description // ""),
       labels: $labels,
       metadata: $metadata,
-      ephemeral: $ephemeral
+      ephemeral: $ephemeral,
+      no_history: $no_history
     }'
 }
 
@@ -209,6 +215,10 @@ case "$op" in
 
     if [ "$(echo "$input" | jq -r '.ephemeral // false')" = "true" ]; then
       all_labels+=("gc:ephemeral")
+    fi
+
+    if [ "$(echo "$input" | jq -r '.no_history // false')" = "true" ]; then
+      all_labels+=("gc:no-history")
     fi
 
     # Build create command.

--- a/docs/reference/exec-beads-provider.md
+++ b/docs/reference/exec-beads-provider.md
@@ -144,13 +144,17 @@ The script assigns `id`, `status`, `created_at`, and `updated_at` on `create`.
 On `create` the provider defaults a missing `type` to `task` before calling the
 script; on every read it normalizes a missing or empty `status` to `open`.
 `metadata` values may be any JSON type but are coerced to strings.
-Preserve `ephemeral` and `defer_until` on every read path so the provider can
-keep run beads out of normal work queries.
+Preserve `ephemeral`, `no_history`, and `defer_until` on every read path so the
+provider can keep run beads out of normal work queries. `no_history=true` marks
+durable work that carries no version-control history: unlike `ephemeral` beads
+it stays visible in issues-tier reads, and also appears in wisps-tier queries.
+Backends without native columns for these bits may store them internally (e.g.
+a private label) but must round-trip them as the matching JSON fields.
 
 The **create request** is a subset (`title`, `type`, `priority`, `labels`,
 `parent_id`, `ref`, `needs`, `description`, `assignee`, `from`, `metadata`,
-`ephemeral`, `defer_until`). The **update request** carries only the fields
-being changed (`title`, `status`, `type`, `priority`, `description`,
+`ephemeral`, `no_history`, `defer_until`). The **update request** carries only
+the fields being changed (`title`, `status`, `type`, `priority`, `description`,
 `parent_id`, `assignee`, plus `labels`/`remove_labels` and a `metadata`
 overlay); omitted fields are left unchanged, and `labels` appends rather than
 replaces. `dep-list` returns objects of `{ "issue_id", "depends_on_id", "type" }`.

--- a/internal/beads/beadstest/conformance.go
+++ b/internal/beads/beadstest/conformance.go
@@ -750,6 +750,49 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 			t.Fatal("Tx(nil) returned nil, want error")
 		}
 	})
+
+	// ListStorageTierContract pins query.go's TierMode row filter across
+	// every Store backend (#3045, #3444): TierIssues keeps history and
+	// no-history rows and drops only ephemeral ones; TierWisps keeps
+	// no-history and ephemeral rows; TierBoth unions all three. Backends
+	// must agree on these cardinalities or API list totals silently shift
+	// with backend selection.
+	t.Run("ListStorageTierContract", func(t *testing.T) {
+		s := newStore()
+		if _, err := s.Create(beads.Bead{Title: "tier-history", Labels: []string{"tier-contract"}}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.Create(beads.Bead{Title: "tier-no-history", Labels: []string{"tier-contract"}, NoHistory: true}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.Create(beads.Bead{Title: "tier-ephemeral", Labels: []string{"tier-contract"}, Ephemeral: true}); err != nil {
+			t.Fatal(err)
+		}
+
+		issues, err := s.List(beads.ListQuery{Label: "tier-contract"})
+		if err != nil {
+			t.Fatalf("List issues tier: %v", err)
+		}
+		if got := titlesOf(issues); !containsAll(got, "tier-history", "tier-no-history") {
+			t.Errorf("issues tier titles = %v, want [tier-history tier-no-history]", got)
+		}
+
+		wisps, err := s.List(beads.ListQuery{Label: "tier-contract", TierMode: beads.TierWisps})
+		if err != nil {
+			t.Fatalf("List wisps tier: %v", err)
+		}
+		if got := titlesOf(wisps); !containsAll(got, "tier-ephemeral", "tier-no-history") {
+			t.Errorf("wisps tier titles = %v, want [tier-ephemeral tier-no-history]", got)
+		}
+
+		both, err := s.List(beads.ListQuery{Label: "tier-contract", TierMode: beads.TierBoth})
+		if err != nil {
+			t.Fatalf("List both tiers: %v", err)
+		}
+		if got := titlesOf(both); !containsAll(got, "tier-ephemeral", "tier-history", "tier-no-history") {
+			t.Errorf("both tier titles = %v, want [tier-ephemeral tier-history tier-no-history]", got)
+		}
+	})
 }
 
 // RunMetadataTests runs conformance tests for metadata absent-vs-empty

--- a/internal/beads/beadstest/conformance.go
+++ b/internal/beads/beadstest/conformance.go
@@ -298,7 +298,7 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 			t.Fatalf("List() returned %d beads, want 2", len(got))
 		}
 		titles := titlesOf(got)
-		if !containsAll(titles, "first", "second") {
+		if !hasExactly(titles, "first", "second") {
 			t.Errorf("List() titles = %v, want [first second]", titles)
 		}
 	})
@@ -329,7 +329,7 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 			t.Fatalf("List() returned %d beads, want 3", len(got))
 		}
 		titles := titlesOf(got)
-		if !containsAll(titles, "alpha", "beta", "gamma") {
+		if !hasExactly(titles, "alpha", "beta", "gamma") {
 			t.Errorf("List() titles = %v, want [alpha beta gamma]", titles)
 		}
 	})
@@ -435,7 +435,7 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 			t.Fatalf("Ready() returned %d beads, want 2", len(got))
 		}
 		titles := titlesOf(got)
-		if !containsAll(titles, "first", "second") {
+		if !hasExactly(titles, "first", "second") {
 			t.Errorf("Ready() titles = %v, want [first second]", titles)
 		}
 	})
@@ -584,7 +584,7 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 			t.Fatalf("Ready() returned %d beads, want 3", len(got))
 		}
 		titles := titlesOf(got)
-		if !containsAll(titles, "alpha", "beta", "gamma") {
+		if !hasExactly(titles, "alpha", "beta", "gamma") {
 			t.Errorf("Ready() titles = %v, want [alpha beta gamma]", titles)
 		}
 	})
@@ -751,12 +751,22 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 		}
 	})
 
-	// ListStorageTierContract pins query.go's TierMode row filter across
-	// every Store backend (#3045, #3444): TierIssues keeps history and
-	// no-history rows and drops only ephemeral ones; TierWisps keeps
-	// no-history and ephemeral rows; TierBoth unions all three. Backends
-	// must agree on these cardinalities or API list totals silently shift
-	// with backend selection.
+	// ListStorageTierContract pins query.go's TierMode row filter (#3045,
+	// #3444): TierIssues keeps history and no-history rows and drops only
+	// ephemeral ones; TierWisps keeps no-history and ephemeral rows; TierBoth
+	// unions all three. Backends must agree on these cardinalities or API list
+	// totals silently shift with backend selection.
+	//
+	// This shared subtest seeds through Store.Create, so it runs only for the
+	// Create-seedable backends wired through RunStoreTests: MemStore,
+	// FileStore, ExecStore, the br exec bridge, and NativeDoltStore. Two
+	// full-Store backends seed differently and pin the same tier contract
+	// through their own tests instead: BdStore via
+	// TestBdStoreListStorageTierConformance, and the DoltLite read store via
+	// TestDoltliteReadStoreTierModesIncludeWisps (its Create routes to the
+	// external bd runner, so it cannot use this Create-based harness and seeds
+	// the snapshot tables directly). Keep those backend-specific tier tests in
+	// sync with this contract.
 	t.Run("ListStorageTierContract", func(t *testing.T) {
 		s := newStore()
 		if _, err := s.Create(beads.Bead{Title: "tier-history", Labels: []string{"tier-contract"}}); err != nil {
@@ -773,7 +783,7 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 		if err != nil {
 			t.Fatalf("List issues tier: %v", err)
 		}
-		if got := titlesOf(issues); !containsAll(got, "tier-history", "tier-no-history") {
+		if got := titlesOf(issues); !hasExactly(got, "tier-history", "tier-no-history") {
 			t.Errorf("issues tier titles = %v, want [tier-history tier-no-history]", got)
 		}
 
@@ -781,7 +791,7 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 		if err != nil {
 			t.Fatalf("List wisps tier: %v", err)
 		}
-		if got := titlesOf(wisps); !containsAll(got, "tier-ephemeral", "tier-no-history") {
+		if got := titlesOf(wisps); !hasExactly(got, "tier-ephemeral", "tier-no-history") {
 			t.Errorf("wisps tier titles = %v, want [tier-ephemeral tier-no-history]", got)
 		}
 
@@ -789,7 +799,7 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 		if err != nil {
 			t.Fatalf("List both tiers: %v", err)
 		}
-		if got := titlesOf(both); !containsAll(got, "tier-ephemeral", "tier-history", "tier-no-history") {
+		if got := titlesOf(both); !hasExactly(got, "tier-ephemeral", "tier-history", "tier-no-history") {
 			t.Errorf("both tier titles = %v, want [tier-ephemeral tier-history tier-no-history]", got)
 		}
 	})
@@ -1076,8 +1086,12 @@ func titlesOf(bs []beads.Bead) []string {
 	return titles
 }
 
-// containsAll checks that sorted has all the expected values.
-func containsAll(sorted []string, want ...string) bool {
+// hasExactly reports whether sorted holds exactly the want values and no
+// others — set equality (equal length plus an element-wise match after
+// sorting). The tier checks above rely on this to also catch over-inclusion,
+// such as an ephemeral row leaking into TierIssues. It is not a subset check:
+// do not use it where extra elements should be tolerated.
+func hasExactly(sorted []string, want ...string) bool {
 	expected := make([]string, len(want))
 	copy(expected, want)
 	sort.Strings(expected)

--- a/internal/beads/doltlite_count.go
+++ b/internal/beads/doltlite_count.go
@@ -17,20 +17,23 @@ import (
 // (gascity#3253), mirroring the hydration-free status counter from #3211.
 //
 // Count answers only the query shapes it can satisfy exactly with column and
-// EXISTS predicates. The read path narrows metadata queries with approximate
-// LIKE matching and applies the exact match in Go, so a metadata query cannot
-// be counted exactly in SQL and returns ErrCountUnsupported. The wisp and
-// both tiers also return ErrCountUnsupported because a union count would
-// double-count ids that List dedupes, and CreatedBefore/ParentID filters
-// return ErrCountUnsupported because List applies them with Go-side semantics a
-// single COUNT cannot reproduce. Limited queries are excluded because the
-// Counter contract is List cardinality parity, not full-result total
-// cardinality. UpdatedBefore is also excluded, but as an over-conservative
-// exclusion pending cleanup of the duplicate SQL/Go filter: queryIssueTable
-// already emits an exact COALESCE(updated_at, created_at) predicate for it, so
-// a COUNT could reproduce it — the redundant Go-side re-filter is what
-// currently keeps it out. Callers fall back to List for those shapes, exactly
-// as the Counter contract specifies.
+// EXISTS predicates. TierIssues counts span the durable issues table plus the
+// non-ephemeral (no_history) wisps rows the aligned List merges in (#3444),
+// deduped by id exactly as List dedupes. The read path narrows metadata
+// queries with approximate LIKE matching and applies the exact match in Go,
+// so a metadata query cannot be counted exactly in SQL and returns
+// ErrCountUnsupported. The wisp and both tiers also return
+// ErrCountUnsupported because their tier filters and unions are still applied
+// List-side, and CreatedBefore/ParentID filters return ErrCountUnsupported
+// because List applies them with Go-side semantics a single COUNT cannot
+// reproduce. Limited queries are excluded because the Counter contract is
+// List cardinality parity, not full-result total cardinality. UpdatedBefore
+// is also excluded, but as an over-conservative exclusion pending cleanup of
+// the duplicate SQL/Go filter: queryIssueTable already emits an exact
+// COALESCE(updated_at, created_at) predicate for it, so a COUNT could
+// reproduce it — the redundant Go-side re-filter is what currently keeps it
+// out. Callers fall back to List for those shapes, exactly as the Counter
+// contract specifies.
 func (s *DoltliteReadStore) Count(ctx context.Context, query ListQuery, excludeTypes ...string) (int, error) {
 	if err := query.Validate(); err != nil {
 		return 0, err
@@ -41,15 +44,66 @@ func (s *DoltliteReadStore) Count(ctx context.Context, query ListQuery, excludeT
 	if !doltliteCountSupported(query) {
 		return 0, fmt.Errorf("bd count: %w", ErrCountUnsupported)
 	}
+	total, issuesWhere, issuesArgs, err := s.countIssuesTier(ctx, query, excludeTypes)
+	if err != nil {
+		return 0, err
+	}
+	wisps, err := s.countDurableWisps(ctx, query, excludeTypes, issuesWhere, issuesArgs)
+	if err != nil {
+		return 0, err
+	}
+	return total + wisps, nil
+}
+
+// countIssuesTier counts the durable issues-table component of a TierIssues
+// query and returns the predicates it used so the wisps component can dedupe
+// against exactly the rows List's issues-table pass returns.
+func (s *DoltliteReadStore) countIssuesTier(ctx context.Context, query ListQuery, excludeTypes []string) (int, []string, []any, error) {
 	tables := doltliteIssueTables
 	where, args := doltliteCountWhere(query, tables, excludeTypes)
+	if flags := s.storageFlagExprsFor(tables); flags.ephemeral != "0" {
+		where = append(where, flags.ephemeral+" = 0")
+	}
 	sqlText := "SELECT COUNT(*) FROM " + tables.issues + " i"
 	if len(where) > 0 {
 		sqlText += " WHERE " + strings.Join(where, " AND ")
 	}
 	var n int
 	if err := s.db.QueryRowContext(ctx, sqlText, args...).Scan(&n); err != nil {
-		return 0, fmt.Errorf("bd count: %w", err)
+		return 0, nil, nil, fmt.Errorf("bd count: %w", err)
+	}
+	return n, where, args, nil
+}
+
+// countDurableWisps counts the non-ephemeral (no_history) wisps rows the
+// aligned TierIssues List merges in (#3444). Legacy snapshots without the
+// wisps storage-flag columns contribute nothing: every row there is
+// ephemeral. Rows whose id the issues-table pass already counted are
+// excluded, mirroring List's cross-table seen-map dedupe.
+func (s *DoltliteReadStore) countDurableWisps(ctx context.Context, query ListQuery, excludeTypes []string, issuesWhere []string, issuesArgs []any) (int, error) {
+	tables := doltliteWispTables
+	if !s.tableExists(tables.issues) {
+		return 0, nil
+	}
+	flags := s.storageFlagExprsFor(tables)
+	tierWhere, skipTable := doltliteTierPredicate(TierIssues, tables, flags)
+	if skipTable {
+		return 0, nil
+	}
+	where, args := doltliteCountWhere(query, tables, excludeTypes)
+	if tierWhere != "" {
+		where = append(where, tierWhere)
+	}
+	dedupe := "SELECT i.id FROM " + doltliteIssueTables.issues + " i"
+	if len(issuesWhere) > 0 {
+		dedupe += " WHERE " + strings.Join(issuesWhere, " AND ")
+	}
+	where = append(where, "i.id NOT IN ("+dedupe+")")
+	args = append(args, issuesArgs...)
+	sqlText := "SELECT COUNT(*) FROM " + tables.issues + " i WHERE " + strings.Join(where, " AND ")
+	var n int
+	if err := s.db.QueryRowContext(ctx, sqlText, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("bd count (wisps): %w", err)
 	}
 	return n, nil
 }

--- a/internal/beads/doltlite_count.go
+++ b/internal/beads/doltlite_count.go
@@ -44,11 +44,11 @@ func (s *DoltliteReadStore) Count(ctx context.Context, query ListQuery, excludeT
 	if !doltliteCountSupported(query) {
 		return 0, fmt.Errorf("bd count: %w", ErrCountUnsupported)
 	}
-	total, issuesWhere, issuesArgs, err := s.countIssuesTier(ctx, query, excludeTypes)
+	total, dedupeWhere, dedupeArgs, err := s.countIssuesTier(ctx, query, excludeTypes)
 	if err != nil {
 		return 0, err
 	}
-	wisps, err := s.countDurableWisps(ctx, query, excludeTypes, issuesWhere, issuesArgs)
+	wisps, err := s.countDurableWisps(ctx, query, excludeTypes, dedupeWhere, dedupeArgs)
 	if err != nil {
 		return 0, err
 	}
@@ -56,50 +56,76 @@ func (s *DoltliteReadStore) Count(ctx context.Context, query ListQuery, excludeT
 }
 
 // countIssuesTier counts the durable issues-table component of a TierIssues
-// query and returns the predicates it used so the wisps component can dedupe
-// against exactly the rows List's issues-table pass returns.
+// query and returns the dedupe predicates so the wisps component can suppress
+// exactly the rows List's issues-table pass returns. The returned predicates
+// omit excludeTypes: List builds its "issues win" cross-table dedupe set before
+// the post-List type exclusion runs, so a wisp whose durable twin is excluded
+// must still be deduped behind it, not counted (#3449 review).
 func (s *DoltliteReadStore) countIssuesTier(ctx context.Context, query ListQuery, excludeTypes []string) (int, []string, []any, error) {
 	tables := doltliteIssueTables
-	where, args := doltliteCountWhere(query, tables, excludeTypes)
-	if flags := s.storageFlagExprsFor(tables); flags.ephemeral != "0" {
-		where = append(where, flags.ephemeral+" = 0")
-	}
-	sqlText := "SELECT COUNT(*) FROM " + tables.issues + " i"
-	if len(where) > 0 {
-		sqlText += " WHERE " + strings.Join(where, " AND ")
-	}
-	var n int
-	if err := s.db.QueryRowContext(ctx, sqlText, args...).Scan(&n); err != nil {
+	dedupeWhere, dedupeArgs := doltliteCountWhere(query, tables)
+	// Apply the TierIssues row filter through the same shared helper List and
+	// countDurableWisps use, so the issues-table predicate has one source of
+	// truth and cannot drift from List's tier semantics (#3444). The issues
+	// table set never reports skipTable, so the durable count always runs.
+	flags, err := s.storageFlagExprsFor(tables)
+	if err != nil {
 		return 0, nil, nil, fmt.Errorf("bd count: %w", err)
 	}
-	return n, where, args, nil
+	if tierWhere, _ := doltliteTierPredicate(TierIssues, tables, flags); tierWhere != "" {
+		dedupeWhere = append(dedupeWhere, tierWhere)
+	}
+	// The durable count itself layers excludeTypes on top of the dedupe
+	// predicates, matching List(query) minus excludeTypes. The dedupe set the
+	// wisp anti-join reuses stays excludeTypes-free.
+	countWhere, countArgs := dedupeWhere, dedupeArgs
+	if exclWhere, exclArgs := doltliteExcludeTypesPredicate(excludeTypes); exclWhere != "" {
+		countWhere = append(append([]string{}, dedupeWhere...), exclWhere)
+		countArgs = append(append([]any{}, dedupeArgs...), exclArgs...)
+	}
+	sqlText := "SELECT COUNT(*) FROM " + tables.issues + " i"
+	if len(countWhere) > 0 {
+		sqlText += " WHERE " + strings.Join(countWhere, " AND ")
+	}
+	var n int
+	if err := s.db.QueryRowContext(ctx, sqlText, countArgs...).Scan(&n); err != nil {
+		return 0, nil, nil, fmt.Errorf("bd count: %w", err)
+	}
+	return n, dedupeWhere, dedupeArgs, nil
 }
 
 // countDurableWisps counts the non-ephemeral (no_history) wisps rows the
 // aligned TierIssues List merges in (#3444). Legacy snapshots without the
 // wisps storage-flag columns contribute nothing: every row there is
-// ephemeral. Rows whose id the issues-table pass already counted are
-// excluded, mirroring List's cross-table seen-map dedupe.
-func (s *DoltliteReadStore) countDurableWisps(ctx context.Context, query ListQuery, excludeTypes []string, issuesWhere []string, issuesArgs []any) (int, error) {
+// ephemeral. dedupeWhere/dedupeArgs are the issues-table pass predicates
+// before excludeTypes, so a wisp whose durable twin List already returned is
+// suppressed by the shared anti-join even when that twin's type is excluded;
+// excludeTypes filters only the wisp row's own type, matching the post-List
+// exclusion (#3449 review).
+func (s *DoltliteReadStore) countDurableWisps(ctx context.Context, query ListQuery, excludeTypes []string, dedupeWhere []string, dedupeArgs []any) (int, error) {
 	tables := doltliteWispTables
 	if !s.tableExists(tables.issues) {
 		return 0, nil
 	}
-	flags := s.storageFlagExprsFor(tables)
+	flags, err := s.storageFlagExprsFor(tables)
+	if err != nil {
+		return 0, fmt.Errorf("bd count (wisps): %w", err)
+	}
 	tierWhere, skipTable := doltliteTierPredicate(TierIssues, tables, flags)
 	if skipTable {
 		return 0, nil
 	}
-	where, args := doltliteCountWhere(query, tables, excludeTypes)
+	where, args := doltliteCountWhere(query, tables)
+	if exclWhere, exclArgs := doltliteExcludeTypesPredicate(excludeTypes); exclWhere != "" {
+		where = append(where, exclWhere)
+		args = append(args, exclArgs...)
+	}
 	if tierWhere != "" {
 		where = append(where, tierWhere)
 	}
-	dedupe := "SELECT i.id FROM " + doltliteIssueTables.issues + " i"
-	if len(issuesWhere) > 0 {
-		dedupe += " WHERE " + strings.Join(issuesWhere, " AND ")
-	}
-	where = append(where, "i.id NOT IN ("+dedupe+")")
-	args = append(args, issuesArgs...)
+	antiJoin, antiArgs := doltliteMatchingIssuesAntiJoin(dedupeWhere, dedupeArgs)
+	where = append(where, antiJoin)
+	args = append(args, antiArgs...)
 	sqlText := "SELECT COUNT(*) FROM " + tables.issues + " i WHERE " + strings.Join(where, " AND ")
 	var n int
 	if err := s.db.QueryRowContext(ctx, sqlText, args...).Scan(&n); err != nil {
@@ -128,11 +154,14 @@ func doltliteCountSupported(query ListQuery) bool {
 	return true
 }
 
-// doltliteCountWhere builds the SELECT COUNT(*) predicates for the supported
-// query shapes. It mirrors queryIssueTable's column predicates exactly for the
-// fields it covers; doltliteCountSupported gates out everything else, and
-// TestDoltliteCountMatchesList asserts the two paths agree across shapes.
-func doltliteCountWhere(query ListQuery, tables doltliteTableSet, excludeTypes []string) ([]string, []any) {
+// doltliteCountWhere builds the SELECT COUNT(*) base column predicates for the
+// supported query shapes. It mirrors queryIssueTable's column predicates exactly
+// for the fields it covers; excludeTypes is layered on separately by the callers
+// via doltliteExcludeTypesPredicate, because List dedupes cross-table twins
+// before the post-List type exclusion runs (#3449 review). doltliteCountSupported
+// gates out everything else, and TestDoltliteCountMatchesList asserts the two
+// paths agree across shapes.
+func doltliteCountWhere(query ListQuery, tables doltliteTableSet) ([]string, []any) {
 	where := make([]string, 0, 6)
 	args := make([]any, 0, 6)
 	if !query.IncludeClosed && query.Status != "closed" {
@@ -145,13 +174,6 @@ func doltliteCountWhere(query ListQuery, tables doltliteTableSet, excludeTypes [
 	if query.Type != "" {
 		where = append(where, "i.issue_type = ?")
 		args = append(args, query.Type)
-	}
-	if len(excludeTypes) > 0 {
-		placeholders := strings.TrimRight(strings.Repeat("?,", len(excludeTypes)), ",")
-		where = append(where, "COALESCE(i.issue_type, '') NOT IN ("+placeholders+")")
-		for _, t := range excludeTypes {
-			args = append(args, t)
-		}
 	}
 	if query.Assignee != "" {
 		where = append(where, "i.assignee = ?")
@@ -176,4 +198,22 @@ func doltliteCountWhere(query ListQuery, tables doltliteTableSet, excludeTypes [
 		args = append(args, query.Label)
 	}
 	return where, args
+}
+
+// doltliteExcludeTypesPredicate builds the "issue_type NOT IN (...)" filter that
+// drops excludeTypes from a count pass, matching the post-List type exclusion
+// the cache count fallback applies (caching_store_reads.go). It returns an empty
+// predicate when excludeTypes is empty. Callers apply it to the issues and wisps
+// count predicates themselves, never to the cross-table dedupe set, so an
+// excluded durable twin still suppresses its no-history wisp twin (#3449 review).
+func doltliteExcludeTypesPredicate(excludeTypes []string) (string, []any) {
+	if len(excludeTypes) == 0 {
+		return "", nil
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(excludeTypes)), ",")
+	args := make([]any, len(excludeTypes))
+	for i, t := range excludeTypes {
+		args[i] = t
+	}
+	return "COALESCE(i.issue_type, '') NOT IN (" + placeholders + ")", args
 }

--- a/internal/beads/doltlite_count_test.go
+++ b/internal/beads/doltlite_count_test.go
@@ -18,6 +18,14 @@ import (
 // suite.
 func newDoltliteStoreWithIssues(t testing.TB, issues []testDoltliteIssue) *DoltliteReadStore {
 	t.Helper()
+	return newDoltliteStoreWithRows(t, issues, nil)
+}
+
+// newDoltliteStoreWithRows builds a DoltLite read store seeded with rows in
+// both storage tables: issues land in the durable issues table and wisps in
+// the wisps table (set Ephemeral/NoHistory per row to pick the storage flag).
+func newDoltliteStoreWithRows(t testing.TB, issues, wisps []testDoltliteIssue) *DoltliteReadStore {
+	t.Helper()
 	dir := t.TempDir()
 	beadsDir := filepath.Join(dir, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
@@ -40,6 +48,9 @@ func newDoltliteStoreWithIssues(t testing.TB, issues []testDoltliteIssue) *Doltl
 	createTestDoltliteSchema(t, db)
 	for _, issue := range issues {
 		insertTestDoltliteIssue(t, db, "issues", "labels", "dependencies", issue)
+	}
+	for _, wisp := range wisps {
+		insertTestDoltliteIssue(t, db, "wisps", "wisp_labels", "wisp_dependencies", wisp)
 	}
 	backing := NewBdStore(dir, func(string, string, ...string) ([]byte, error) {
 		t.Fatal("backing bd runner should not be called by doltlite count tests")
@@ -72,6 +83,7 @@ func TestDoltliteCountMatchesList(t *testing.T) {
 		{name: "status closed", query: ListQuery{Status: "closed"}},
 		{name: "status in_progress", query: ListQuery{Status: "in_progress"}},
 		{name: "by assignee", query: ListQuery{Assignee: "rig/worker"}},
+		{name: "by no-history assignee", query: ListQuery{Assignee: "rig/nohistory-worker"}},
 		{name: "by label", query: ListQuery{Label: "tier-test"}},
 		{name: "exclude session", query: ListQuery{AllowScan: true, IncludeClosed: true}, exclude: []string{"session"}},
 		{name: "exclude session+task", query: ListQuery{AllowScan: true, IncludeClosed: true}, exclude: []string{"session", "task"}},
@@ -123,6 +135,74 @@ func TestDoltliteCountUnsupportedShapes(t *testing.T) {
 				t.Fatalf("Count err = %v, want ErrCountUnsupported", err)
 			}
 		})
+	}
+}
+
+// TestDoltliteCountTierIssuesIncludesNoHistoryWisps pins the #3444 contract on
+// the hydration-free counter: TierIssues counts durable issues plus
+// non-ephemeral (no_history) wisps rows — exactly what the aligned List
+// returns — while ephemeral wisps stay excluded. A cross-table duplicate id
+// must be counted once, mirroring List's seen-map dedupe.
+func TestDoltliteCountTierIssuesIncludesNoHistoryWisps(t *testing.T) {
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	issues := []testDoltliteIssue{
+		{ID: "gc-durable", Title: "durable", Status: "open", IssueType: "task", CreatedAt: base, Labels: []string{"count-tier"}},
+		{ID: "gc-dup", Title: "dup durable", Status: "open", IssueType: "task", CreatedAt: base.Add(time.Second), Labels: []string{"count-tier"}},
+		// The issues twin of gc-dup-unmatched does NOT match the query, so
+		// List returns the wisps twin and the count dedupe must not drop it.
+		{ID: "gc-dup-unmatched", Title: "dup durable other label", Status: "open", IssueType: "task", CreatedAt: base.Add(5 * time.Second), Labels: []string{"other"}},
+	}
+	wisps := []testDoltliteIssue{
+		{ID: "gc-nohistory", Title: "no-history", Status: "open", IssueType: "task", CreatedAt: base.Add(2 * time.Second), Labels: []string{"count-tier"}, NoHistory: true},
+		{ID: "gc-ephemeral", Title: "ephemeral", Status: "open", IssueType: "task", CreatedAt: base.Add(3 * time.Second), Labels: []string{"count-tier"}, Ephemeral: true},
+		// Defensive cross-table id collision: List dedupes it, Count must too.
+		{ID: "gc-dup", Title: "dup wisp", Status: "open", IssueType: "task", CreatedAt: base.Add(4 * time.Second), Labels: []string{"count-tier"}, NoHistory: true},
+		{ID: "gc-dup-unmatched", Title: "dup wisp matching", Status: "open", IssueType: "task", CreatedAt: base.Add(6 * time.Second), Labels: []string{"count-tier"}, NoHistory: true},
+	}
+	store := newDoltliteStoreWithRows(t, issues, wisps)
+
+	query := ListQuery{Label: "count-tier"}
+	list, err := store.List(query)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	wantIDs := map[string]bool{"gc-durable": true, "gc-dup": true, "gc-nohistory": true, "gc-dup-unmatched": true}
+	if len(list) != len(wantIDs) {
+		t.Fatalf("List rows = %v, want ids %v", testBeadIDs(list), wantIDs)
+	}
+	for _, b := range list {
+		if !wantIDs[b.ID] {
+			t.Fatalf("List rows = %v, want ids %v", testBeadIDs(list), wantIDs)
+		}
+	}
+
+	got, err := store.Count(context.Background(), query)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != len(list) {
+		t.Fatalf("Count = %d, want len(List) = %d", got, len(list))
+	}
+}
+
+// TestDoltliteCountLegacyWispsSchemaMatchesList pins Count==List parity for
+// pre-storage-flag snapshots: without the discriminator columns every wisps
+// row is ephemeral, so the TierIssues count stays issues-table only.
+func TestDoltliteCountLegacyWispsSchemaMatchesList(t *testing.T) {
+	store, closeStore := newLegacyTestDoltliteReadStore(t)
+	defer closeStore()
+
+	query := ListQuery{Label: "tier-test"}
+	list, err := store.List(query)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	got, err := store.Count(context.Background(), query)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != len(list) || got != 1 {
+		t.Fatalf("Count = %d, want len(List) = %d = 1", got, len(list))
 	}
 }
 

--- a/internal/beads/doltlite_count_test.go
+++ b/internal/beads/doltlite_count_test.go
@@ -185,6 +185,51 @@ func TestDoltliteCountTierIssuesIncludesNoHistoryWisps(t *testing.T) {
 	}
 }
 
+// TestDoltliteCountExcludedIssueTwinSuppressesWispTwin pins the #3449 review
+// fix: when a durable issue twin's type is in excludeTypes, List drops the issue
+// AND has already deduped its same-id no-history wisp twin behind it, so neither
+// survives the post-List exclusion. Count must match — the wisp dedupe anti-join
+// is built from the issues-table pass BEFORE excludeTypes, so the excluded issue
+// still suppresses its wisp twin instead of letting Count overcount it.
+func TestDoltliteCountExcludedIssueTwinSuppressesWispTwin(t *testing.T) {
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	issues := []testDoltliteIssue{
+		// Durable twin of gc-twin has an excluded type. List returns it, the
+		// excludeTypes filter then drops it, and its wisp twin is already deduped
+		// away — so the matching set contributes nothing for gc-twin.
+		{ID: "gc-twin", Title: "excluded durable twin", Status: "open", IssueType: "session", CreatedAt: base.Add(time.Second), Labels: []string{"excl-dedupe"}},
+		{ID: "gc-keep", Title: "kept task", Status: "open", IssueType: "task", CreatedAt: base.Add(2 * time.Second), Labels: []string{"excl-dedupe"}},
+	}
+	wisps := []testDoltliteIssue{
+		// Non-excluded no-history wisp sharing gc-twin's id. Before the fix the
+		// wisp dedupe subquery still carried excludeTypes, so the excluded issue
+		// fell out of the anti-join set and this wisp was wrongly counted.
+		{ID: "gc-twin", Title: "kept wisp twin", Status: "open", IssueType: "task", CreatedAt: base.Add(3 * time.Second), Labels: []string{"excl-dedupe"}, NoHistory: true},
+	}
+	store := newDoltliteStoreWithRows(t, issues, wisps)
+
+	query := ListQuery{Label: "excl-dedupe"}
+	exclude := []string{"session"}
+
+	list, err := store.List(query)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	want := 0
+	for _, b := range list {
+		if !containsTestString(exclude, b.Type) {
+			want++
+		}
+	}
+	got, err := store.Count(context.Background(), query, exclude...)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Count = %d, want len(List filtered by excludeTypes) = %d", got, want)
+	}
+}
+
 // TestDoltliteCountLegacyWispsSchemaMatchesList pins Count==List parity for
 // pre-storage-flag snapshots: without the discriminator columns every wisps
 // row is ephemeral, so the TierIssues count stays issues-table only.

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -43,25 +43,30 @@ type doltliteMetadata struct {
 }
 
 type doltliteTableSet struct {
-	issues    string
-	labels    string
-	deps      string
-	ephemeral bool
+	issues string
+	labels string
+	deps   string
+	// wisps marks the wisp-backed table set. Snapshots written before the
+	// storage-flag columns existed have no per-row discriminator there, in
+	// which case every row in the set is ephemeral.
+	wisps bool
 }
 
 var (
 	doltliteIssueTables = doltliteTableSet{issues: "issues", labels: "labels", deps: "dependencies"}
-	doltliteWispTables  = doltliteTableSet{issues: "wisps", labels: "wisp_labels", deps: "wisp_dependencies", ephemeral: true}
+	doltliteWispTables  = doltliteTableSet{issues: "wisps", labels: "wisp_labels", deps: "wisp_dependencies", wisps: true}
 )
 
+// doltliteTableSetsForMode maps a TierMode to the storage tables that can hold
+// matching rows. TierIssues spans both tables because non-ephemeral
+// (no_history) wisps rows belong to the durable tier (query.go TierMode
+// contract, #3444); queryIssueTable applies the per-row storage-flag filter.
 func doltliteTableSetsForMode(mode TierMode) []doltliteTableSet {
 	switch mode {
 	case TierWisps:
 		return []doltliteTableSet{doltliteWispTables}
-	case TierBoth:
+	default: // TierIssues, TierBoth
 		return []doltliteTableSet{doltliteIssueTables, doltliteWispTables}
-	default:
-		return []doltliteTableSet{doltliteIssueTables}
 	}
 }
 
@@ -309,7 +314,12 @@ func (s *DoltliteReadStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	readyWhere, readyArgs := s.doltliteReadyIssueWhere(doltliteIssueTables)
 	// The id tiebreaker keeps a LIMIT deterministic when rows share
 	// (priority, created_at) — same bug class as queryIssueTable (#3208).
-	out, err := s.queryIssuesOrdered(q, readyWhere, readyArgs, q.Limit, "ORDER BY COALESCE(i.priority, 2) ASC, i.created_at ASC, i.id ASC")
+	// Raw Ready stays on the durable issues table even though aligned
+	// TierIssues List reads span no-history wisps (#3444): claimable work
+	// remains history-backed per the compatibility policy documented on
+	// ReadyQuery.TierMode in query.go, and the ready blocker predicate is
+	// built for the issues-table dependency graph.
+	out, err := s.queryIssuesOrderedInTables(q, []doltliteTableSet{doltliteIssueTables}, readyWhere, readyArgs, q.Limit, "ORDER BY COALESCE(i.priority, 2) ASC, i.created_at ASC, i.id ASC")
 	if err != nil {
 		return nil, err
 	}
@@ -747,15 +757,21 @@ func (s *DoltliteReadStore) queryIssues(query ListQuery, extraWhere string, extr
 }
 
 func (s *DoltliteReadStore) queryIssuesOrdered(query ListQuery, extraWhere string, extraArgs []any, limit int, orderBy string) ([]Bead, error) {
+	return s.queryIssuesOrderedInTables(query, doltliteTableSetsForMode(query.TierMode), extraWhere, extraArgs, limit, orderBy)
+}
+
+// queryIssuesOrderedInTables runs the query against an explicit list of table
+// sets. Callers passing a custom orderBy must pass a single table set: the
+// merged path re-sorts only when orderBy is empty.
+func (s *DoltliteReadStore) queryIssuesOrderedInTables(query ListQuery, sets []doltliteTableSet, extraWhere string, extraArgs []any, limit int, orderBy string) ([]Bead, error) {
 	if err := query.Validate(); err != nil {
 		return nil, err
 	}
-	sets := doltliteTableSetsForMode(query.TierMode)
 	merged := make([]Bead, 0)
 	seen := make(map[string]struct{})
 	for _, tables := range sets {
 		tableLimit := limit
-		if len(sets) > 1 {
+		if len(sets) > 1 && !doltliteCanPushTableLimit(query) {
 			tableLimit = 0
 		}
 		rows, err := s.queryIssueTable(query, tables, extraWhere, extraArgs, tableLimit, orderBy)
@@ -866,12 +882,20 @@ func filterDoltliteMetadata(rows []Bead, filters map[string]string) []Bead {
 }
 
 func (s *DoltliteReadStore) queryIssueTable(query ListQuery, tables doltliteTableSet, extraWhere string, extraArgs []any, limit int, orderBy string) ([]Bead, error) {
-	if tables.ephemeral && !s.tableExists(tables.issues) {
+	if tables.wisps && !s.tableExists(tables.issues) {
 		return nil, nil
 	}
+	flags := s.storageFlagExprsFor(tables)
 	where := []string{}
 	args := []any{}
 	needParent := true
+	tierWhere, skipTable := doltliteTierPredicate(query.TierMode, tables, flags)
+	if skipTable {
+		return nil, nil
+	}
+	if tierWhere != "" {
+		where = append(where, tierWhere)
+	}
 	if !query.IncludeClosed && query.Status != "closed" {
 		where = append(where, "i.status != 'closed'")
 	}
@@ -931,7 +955,7 @@ func (s *DoltliteReadStore) queryIssueTable(query ListQuery, tables doltliteTabl
 	}
 	sqlText := `SELECT i.id, COALESCE(i.title, ''), COALESCE(i.status, ''), COALESCE(i.issue_type, ''), i.priority, i.created_at,
 		COALESCE(i.updated_at, ''), COALESCE(i.assignee, ''), COALESCE(i.description, ''), COALESCE(i.metadata, '{}'),
-		` + parentColumn + `
+		` + parentColumn + `, ` + flags.ephemeral + `, ` + flags.noHistory + `
 		FROM ` + tables.issues + ` i` + parentJoin
 	if len(where) > 0 {
 		sqlText += " WHERE " + strings.Join(where, " AND ")
@@ -956,7 +980,7 @@ func (s *DoltliteReadStore) queryIssueTable(query ListQuery, tables doltliteTabl
 	defer rows.Close()
 	var beads []Bead
 	for rows.Next() {
-		b, err := scanBead(rows, tables.ephemeral)
+		b, err := scanBead(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -971,6 +995,72 @@ func (s *DoltliteReadStore) queryIssueTable(query ListQuery, tables doltliteTabl
 		}
 	}
 	return beads, nil
+}
+
+// doltliteStorageFlagExprs holds SQL expressions yielding the per-row
+// ephemeral and no_history storage flags for one storage table, accounting
+// for snapshots whose schema predates those columns.
+type doltliteStorageFlagExprs struct {
+	ephemeral string
+	noHistory string
+	// hasColumns reports whether the table carries at least one storage-flag
+	// column, i.e. whether per-row tier classification is possible.
+	hasColumns bool
+}
+
+// storageFlagExprsFor resolves the storage-flag expressions for tables.
+// Legacy snapshots wrote wisps tables without the flag columns; every row
+// there is ephemeral, so the wisps fallback is the constant 1 while the
+// issues-table fallback is the constant 0 (durable history rows).
+func (s *DoltliteReadStore) storageFlagExprsFor(tables doltliteTableSet) doltliteStorageFlagExprs {
+	flags := doltliteStorageFlagExprs{ephemeral: "0", noHistory: "0"}
+	if tables.wisps {
+		flags.ephemeral = "1"
+	}
+	if s.tableHasColumn(tables.issues, "ephemeral") {
+		flags.ephemeral = "COALESCE(i.ephemeral, 0)"
+		flags.hasColumns = true
+	}
+	if s.tableHasColumn(tables.issues, "no_history") {
+		flags.noHistory = "COALESCE(i.no_history, 0)"
+		flags.hasColumns = true
+	}
+	return flags
+}
+
+// doltliteTierPredicate translates query.go's TierMode row filter (Matches)
+// into a SQL predicate for one storage table. It returns skipTable=true when
+// the table cannot hold rows for the tier at all (a legacy wisps table is
+// ephemeral-only, so the durable tier never reads it).
+func doltliteTierPredicate(mode TierMode, tables doltliteTableSet, flags doltliteStorageFlagExprs) (string, bool) {
+	switch mode {
+	case TierWisps:
+		if !flags.hasColumns {
+			// Legacy wisps rows are all ephemeral; issues-table rows never
+			// reach TierWisps because doltliteTableSetsForMode excludes them.
+			return "", false
+		}
+		return "(" + flags.ephemeral + " = 1 OR " + flags.noHistory + " = 1)", false
+	case TierBoth:
+		return "", false
+	default: // TierIssues keeps history and no-history rows, drops ephemeral.
+		if tables.wisps && !flags.hasColumns {
+			return "", true
+		}
+		if flags.ephemeral == "0" {
+			return "", false
+		}
+		return flags.ephemeral + " = 0", false
+	}
+}
+
+// doltliteCanPushTableLimit reports whether a per-table SQL LIMIT cuts an
+// exact prefix for a multi-table merge: each table returns its own
+// top-limit prefix in the shared (created_at, id) total order, so the merged
+// sort+limit is exact unless a Go-side filter (metadata LIKE refinement,
+// before-time re-checks) can still drop rows after the SQL cut.
+func doltliteCanPushTableLimit(query ListQuery) bool {
+	return len(query.Metadata) == 0 && query.CreatedBefore.IsZero() && query.UpdatedBefore.IsZero()
 }
 
 func doltliteSQLiteTime(t time.Time) string {
@@ -994,15 +1084,17 @@ func filterDoltliteBeforeTimes(rows []Bead, query ListQuery) []Bead {
 	return out
 }
 
-func scanBead(rows interface{ Scan(...any) error }, ephemeral bool) (Bead, error) {
+func scanBead(rows interface{ Scan(...any) error }) (Bead, error) {
 	var (
 		b           Bead
 		priority    sql.NullInt64
 		createdRaw  any
 		updatedRaw  any
 		metadataRaw string
+		ephemeral   int64
+		noHistory   int64
 	)
-	if err := rows.Scan(&b.ID, &b.Title, &b.Status, &b.Type, &priority, &createdRaw, &updatedRaw, &b.Assignee, &b.Description, &metadataRaw, &b.ParentID); err != nil {
+	if err := rows.Scan(&b.ID, &b.Title, &b.Status, &b.Type, &priority, &createdRaw, &updatedRaw, &b.Assignee, &b.Description, &metadataRaw, &b.ParentID, &ephemeral, &noHistory); err != nil {
 		return b, err
 	}
 	if priority.Valid {
@@ -1013,7 +1105,8 @@ func scanBead(rows interface{ Scan(...any) error }, ephemeral bool) (Bead, error
 	b.CreatedAt = parseDBTime(createdRaw).Truncate(time.Second)
 	b.UpdatedAt = parseDBTime(updatedRaw).Truncate(time.Second)
 	b.Metadata = parseMetadata(metadataRaw)
-	b.Ephemeral = ephemeral
+	b.Ephemeral = ephemeral != 0
+	b.NoHistory = noHistory != 0
 	if b.From == "" {
 		b.From = b.Metadata["from"]
 	}
@@ -1073,6 +1166,16 @@ func parseMetadata(raw string) map[string]string {
 func (s *DoltliteReadStore) tableExists(name string) bool {
 	var found string
 	err := s.db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`, name).Scan(&found)
+	return err == nil
+}
+
+// tableHasColumn reports whether the table's schema includes the named
+// column. Snapshot schemas vary by writer generation (the storage-flag
+// columns arrived with the upstream wisps/no-history migrations), so read
+// paths probe before referencing them.
+func (s *DoltliteReadStore) tableHasColumn(table, column string) bool {
+	var found string
+	err := s.db.QueryRow(`SELECT name FROM pragma_table_info(?) WHERE name = ?`, table, column).Scan(&found)
 	return err == nil
 }
 

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -314,11 +314,19 @@ func (s *DoltliteReadStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	readyWhere, readyArgs := s.doltliteReadyIssueWhere(doltliteIssueTables)
 	// The id tiebreaker keeps a LIMIT deterministic when rows share
 	// (priority, created_at) — same bug class as queryIssueTable (#3208).
-	// Raw Ready stays on the durable issues table even though aligned
-	// TierIssues List reads span no-history wisps (#3444): claimable work
-	// remains history-backed per the compatibility policy documented on
-	// ReadyQuery.TierMode in query.go, and the ready blocker predicate is
-	// built for the issues-table dependency graph.
+	//
+	// This read is issues-only and does NOT honor a policy-expanded
+	// rq.TierMode. A default (TierIssues) Ready is correctly history-backed per
+	// the ReadyQuery.TierMode policy in query.go. But policy-aware callers
+	// expand default Ready to TierBoth (bead_policy_store.go), and
+	// NativeDoltStore.Ready / BdStore.Ready surface ready no-history/ephemeral
+	// rows for that expansion while this path still returns issues-only — a
+	// known backend parity gap, not behavior the policy endorses. It is
+	// pre-existing (the internal Ready query was already issues-only before the
+	// TierIssues List span), and out of scope for the #3444/#3449 List+Count
+	// alignment because honoring rq.TierMode here also needs the wisp
+	// dependency graph modeled in the ready blocker predicate. Tracked as
+	// follow-up ga-4ax9bj.
 	out, err := s.queryIssuesOrderedInTables(q, []doltliteTableSet{doltliteIssueTables}, readyWhere, readyArgs, q.Limit, "ORDER BY COALESCE(i.priority, 2) ASC, i.created_at ASC, i.id ASC")
 	if err != nil {
 		return nil, err
@@ -767,11 +775,27 @@ func (s *DoltliteReadStore) queryIssuesOrderedInTables(query ListQuery, sets []d
 	if err := query.Validate(); err != nil {
 		return nil, err
 	}
+	// A bounded multi-table read can resolve its exact global top-N by
+	// selecting ids in one SQL statement and hydrating only those ids, instead
+	// of reading every matching row from both tables and cutting in Go. This
+	// keeps the default TierIssues bounded path O(limit) rather than spanning
+	// full matching history (#3449 review).
+	if doltliteCanSelectBoundedTopN(query, sets, extraWhere, limit, orderBy) {
+		return s.queryBoundedTopN(query, sets, limit)
+	}
 	merged := make([]Bead, 0)
 	seen := make(map[string]struct{})
 	for _, tables := range sets {
+		// A per-table SQL LIMIT is an exact prefix of the merged result only
+		// for a single table set. Across multiple tables the cross-table id
+		// dedupe below can drop a table's whole limited prefix (an id that
+		// also appears in an earlier set), so a later unique row that belongs
+		// in the global top-N may never be fetched. Read every matching row
+		// for multi-table merges and let the Go sort+limit cut the exact
+		// top-N (#3444); the bounded fast path above avoids this full read for
+		// the common limited case.
 		tableLimit := limit
-		if len(sets) > 1 && !doltliteCanPushTableLimit(query) {
+		if len(sets) > 1 {
 			tableLimit = 0
 		}
 		rows, err := s.queryIssueTable(query, tables, extraWhere, extraArgs, tableLimit, orderBy)
@@ -799,11 +823,188 @@ func (s *DoltliteReadStore) queryIssuesOrderedInTables(query ListQuery, sets []d
 	return merged, nil
 }
 
+// doltliteCanSelectBoundedTopN reports whether a bounded multi-table read can
+// resolve its exact global top-N by selecting ids in one SQL statement (then
+// hydrating only those ids). It is restricted to the shapes whose result is
+// fully determined by SQL-expressible predicates and the standard
+// (created_at, id) sort, so the SQL LIMIT is exact. A custom orderBy, caller
+// extraWhere, or a ParentID/metadata/before-time filter all need post-SQL Go
+// work that a bounded SQL selection could truncate incorrectly, so those fall
+// back to the full-read merge.
+func doltliteCanSelectBoundedTopN(query ListQuery, sets []doltliteTableSet, extraWhere string, limit int, orderBy string) bool {
+	return limit > 0 &&
+		len(sets) > 1 &&
+		orderBy == "" &&
+		extraWhere == "" &&
+		query.ParentID == "" &&
+		len(query.Metadata) == 0 &&
+		query.CreatedBefore.IsZero() &&
+		query.UpdatedBefore.IsZero()
+}
+
+// queryBoundedTopN resolves a bounded multi-table read by selecting the exact
+// global top-N ids in one SQL statement and hydrating only those ids.
+func (s *DoltliteReadStore) queryBoundedTopN(query ListQuery, sets []doltliteTableSet, limit int) ([]Bead, error) {
+	ids, err := s.selectBoundedTopNIDs(query, sets, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return []Bead{}, nil
+	}
+	merged, err := s.hydrateBeadsByID(query, sets, ids)
+	if err != nil {
+		return nil, err
+	}
+	sortBeadsForQuery(merged, doltliteSortOrder(query.Sort))
+	if limit > 0 && len(merged) > limit {
+		merged = merged[:limit]
+	}
+	return merged, nil
+}
+
+// selectBoundedTopNIDs returns the ids of the exact global top-N rows for a
+// bounded multi-table read, ordered by the query's (created_at, id) sort. It
+// selects ids from the issues table plus the non-duplicate non-ephemeral wisps
+// rows — anti-joined against the matching issues set exactly as List dedupes
+// and as countDurableWisps counts — under one global ORDER BY/LIMIT, so the
+// SQL bound stays O(limit) instead of hydrating full matching history (#3449).
+func (s *DoltliteReadStore) selectBoundedTopNIDs(query ListQuery, sets []doltliteTableSet, limit int) ([]string, error) {
+	// The issues-table predicates back both the issues union leg and the wisps
+	// dedupe anti-join, so the wisp leg excludes exactly the ids a matching
+	// issues row already contributes (List's "issues win" cross-table dedupe).
+	issuesTQ, err := s.buildDoltliteTableQuery(query, doltliteIssueTables, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	unionParts := make([]string, 0, len(sets))
+	args := make([]any, 0)
+	for _, tables := range sets {
+		if tables.wisps && !s.tableExists(tables.issues) {
+			continue
+		}
+		tq := issuesTQ
+		if tables.wisps {
+			tq, err = s.buildDoltliteTableQuery(query, tables, "", nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if tq.skipTable {
+			continue
+		}
+		legWhere := append([]string{}, tq.where...)
+		legArgs := append([]any{}, tq.args...)
+		if tables.wisps && !issuesTQ.skipTable {
+			antiJoin, antiArgs := doltliteMatchingIssuesAntiJoin(issuesTQ.where, issuesTQ.args)
+			legWhere = append(legWhere, antiJoin)
+			legArgs = append(legArgs, antiArgs...)
+		}
+		// Select created_at truncated to whole seconds, not the raw sub-second
+		// text: the outer LIMIT must cut on the same second-granular key the Go
+		// merge and post-hydration re-sort compare, or the bounded prefix can
+		// diverge from the unbounded merge for same-second rows (#3449 review).
+		leg := "SELECT i.id AS id, " + doltliteCreatedAtSortKey("i") + " AS created_at FROM " + tables.issues + " i"
+		if len(legWhere) > 0 {
+			leg += " WHERE " + strings.Join(legWhere, " AND ")
+		}
+		unionParts = append(unionParts, leg)
+		args = append(args, legArgs...)
+	}
+	if len(unionParts) == 0 {
+		return nil, nil
+	}
+	// The id tiebreaker matches sortBeadsForQuery's (created_at, id) total
+	// order so the LIMIT cuts the same deterministic prefix the Go merge would
+	// (#3208). created_at here is already the second-granular sort key.
+	order := "DESC"
+	if query.Sort == SortCreatedAsc {
+		order = "ASC"
+	}
+	sqlText := "SELECT id FROM (" + strings.Join(unionParts, " UNION ALL ") +
+		") ORDER BY created_at " + order + ", id " + order +
+		fmt.Sprintf(" LIMIT %d", limit)
+	rows, err := s.db.Query(sqlText, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ids := make([]string, 0, limit)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// hydrateBeadsByID fetches full bead rows for ids from each table set, applying
+// query's filters and deduping by id (issues-table rows win), exactly as the
+// full-read merge does.
+func (s *DoltliteReadStore) hydrateBeadsByID(query ListQuery, sets []doltliteTableSet, ids []string) ([]Bead, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	merged := make([]Bead, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, tables := range sets {
+		rows, err := s.queryIssueTable(query, tables, "i.id IN ("+placeholders+")", args, 0, "")
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range rows {
+			if _, ok := seen[row.ID]; ok {
+				continue
+			}
+			seen[row.ID] = struct{}{}
+			merged = append(merged, row)
+		}
+	}
+	return merged, nil
+}
+
 func doltliteSortOrder(order SortOrder) SortOrder {
 	if order == SortCreatedAsc {
 		return SortCreatedAsc
 	}
 	return SortCreatedDesc
+}
+
+// doltliteCreatedAtSortKey returns the SQL expression for a row's created_at
+// truncated to whole seconds for the given table alias, matching scanBead's
+// parseDBTime(...).Truncate(time.Second). SQL LIMIT cuts that feed a bounded
+// read must order by this key, not the raw sub-second created_at text: the Go
+// merge and post-hydration re-sort compare the truncated CreatedAt, so cutting
+// on raw sub-second precision could select a different same-second prefix than
+// the unbounded merge (#3449 review). The first 19 chars span
+// "YYYY-MM-DD?HH:MM:SS" for every layout parseTimeString accepts, so the prefix
+// sorts by second exactly as the truncated time does.
+func doltliteCreatedAtSortKey(alias string) string {
+	return "substr(" + alias + ".created_at, 1, 19)"
+}
+
+// doltliteMatchingIssuesAntiJoin returns the "i.id NOT IN (SELECT i.id FROM
+// issues i ...)" predicate and its args that drop every wisp whose durable
+// issue twin the issues-table pass already contributes, reproducing List's
+// "issues win" cross-table dedupe. The inner query re-aliases the issues table
+// as i so its predicates resolve against issues, shadowing the outer wisps i.
+// issuesWhere must be the issues-table pass before any post-List excludeTypes
+// filter, because List dedupes wisps against the merged issues set before
+// excludeTypes runs (#3449 review). Shared by the bounded List id selection and
+// countDurableWisps so the dedupe shape has one source of truth.
+func doltliteMatchingIssuesAntiJoin(issuesWhere []string, issuesArgs []any) (string, []any) {
+	dedupe := "SELECT i.id FROM " + doltliteIssueTables.issues + " i"
+	if len(issuesWhere) > 0 {
+		dedupe += " WHERE " + strings.Join(issuesWhere, " AND ")
+	}
+	return "i.id NOT IN (" + dedupe + ")", append([]any{}, issuesArgs...)
 }
 
 // doltliteMetadataFilterPredicates narrows metadata queries in SQL without
@@ -881,18 +1082,34 @@ func filterDoltliteMetadata(rows []Bead, filters map[string]string) []Bead {
 	return out
 }
 
-func (s *DoltliteReadStore) queryIssueTable(query ListQuery, tables doltliteTableSet, extraWhere string, extraArgs []any, limit int, orderBy string) ([]Bead, error) {
-	if tables.wisps && !s.tableExists(tables.issues) {
-		return nil, nil
+// doltliteTableQuery holds the resolved per-table-set SQL fragments shared by
+// full-row reads (queryIssueTable) and id-only top-N selection
+// (selectBoundedTopNIDs), so both apply identical filters from one source of
+// truth and cannot drift.
+type doltliteTableQuery struct {
+	flags      doltliteStorageFlagExprs
+	where      []string
+	args       []any
+	parentJoin string
+	// skipTable reports that this table set cannot hold any rows for the
+	// query's tier (e.g. a legacy ephemeral-only wisps table under TierIssues).
+	skipTable bool
+}
+
+// buildDoltliteTableQuery resolves the storage-flag expressions, WHERE
+// clauses, args, and parent join for one storage table set. It returns
+// skipTable=true when the tier predicate excludes the whole table.
+func (s *DoltliteReadStore) buildDoltliteTableQuery(query ListQuery, tables doltliteTableSet, extraWhere string, extraArgs []any) (doltliteTableQuery, error) {
+	flags, err := s.storageFlagExprsFor(tables)
+	if err != nil {
+		return doltliteTableQuery{}, err
 	}
-	flags := s.storageFlagExprsFor(tables)
-	where := []string{}
-	args := []any{}
-	needParent := true
 	tierWhere, skipTable := doltliteTierPredicate(query.TierMode, tables, flags)
 	if skipTable {
-		return nil, nil
+		return doltliteTableQuery{skipTable: true}, nil
 	}
+	where := []string{}
+	args := []any{}
 	if tierWhere != "" {
 		where = append(where, tierWhere)
 	}
@@ -914,7 +1131,7 @@ func (s *DoltliteReadStore) queryIssueTable(query ListQuery, tables doltliteTabl
 	if len(query.Assignees) > 0 {
 		assignees := compactStrings(query.Assignees)
 		if len(assignees) == 0 {
-			return nil, nil
+			return doltliteTableQuery{skipTable: true}, nil
 		}
 		placeholders := strings.TrimRight(strings.Repeat("?,", len(assignees)), ",")
 		where = append(where, "i.assignee IN ("+placeholders+")")
@@ -947,33 +1164,46 @@ func (s *DoltliteReadStore) queryIssueTable(query ListQuery, tables doltliteTabl
 		where = append(where, extraWhere)
 		args = append(args, extraArgs...)
 	}
-	parentColumn := "''"
-	parentJoin := ""
-	if needParent {
-		parentColumn = doltliteQualifiedDependsOnExpr("pc")
-		parentJoin = " LEFT JOIN " + tables.deps + " pc ON pc.issue_id = i.id AND pc.type = 'parent-child'"
+	parentJoin := " LEFT JOIN " + tables.deps + " pc ON pc.issue_id = i.id AND pc.type = 'parent-child'"
+	return doltliteTableQuery{flags: flags, where: where, args: args, parentJoin: parentJoin}, nil
+}
+
+func (s *DoltliteReadStore) queryIssueTable(query ListQuery, tables doltliteTableSet, extraWhere string, extraArgs []any, limit int, orderBy string) ([]Bead, error) {
+	if tables.wisps && !s.tableExists(tables.issues) {
+		return nil, nil
 	}
+	tq, err := s.buildDoltliteTableQuery(query, tables, extraWhere, extraArgs)
+	if err != nil {
+		return nil, err
+	}
+	if tq.skipTable {
+		return nil, nil
+	}
+	parentColumn := doltliteQualifiedDependsOnExpr("pc")
 	sqlText := `SELECT i.id, COALESCE(i.title, ''), COALESCE(i.status, ''), COALESCE(i.issue_type, ''), i.priority, i.created_at,
 		COALESCE(i.updated_at, ''), COALESCE(i.assignee, ''), COALESCE(i.description, ''), COALESCE(i.metadata, '{}'),
-		` + parentColumn + `, ` + flags.ephemeral + `, ` + flags.noHistory + `
-		FROM ` + tables.issues + ` i` + parentJoin
-	if len(where) > 0 {
-		sqlText += " WHERE " + strings.Join(where, " AND ")
+		` + parentColumn + `, ` + tq.flags.ephemeral + `, ` + tq.flags.noHistory + `
+		FROM ` + tables.issues + ` i` + tq.parentJoin
+	if len(tq.where) > 0 {
+		sqlText += " WHERE " + strings.Join(tq.where, " AND ")
 	}
 	// The id tiebreaker matches sortBeadsForQuery's (created_at, id) total
 	// order so a SQL LIMIT cuts a deterministic prefix even when rows share
-	// a created_at timestamp (#3208).
+	// a created_at timestamp (#3208). Order on the second-granular created_at
+	// key, not the raw sub-second text, so a single-table bounded read cuts the
+	// same prefix the Go re-sort over the truncated CreatedAt would (#3449
+	// review).
 	if orderBy != "" {
 		sqlText += " " + orderBy
 	} else if query.Sort == SortCreatedAsc {
-		sqlText += " ORDER BY i.created_at ASC, i.id ASC"
+		sqlText += " ORDER BY " + doltliteCreatedAtSortKey("i") + " ASC, i.id ASC"
 	} else {
-		sqlText += " ORDER BY i.created_at DESC, i.id DESC"
+		sqlText += " ORDER BY " + doltliteCreatedAtSortKey("i") + " DESC, i.id DESC"
 	}
 	if limit > 0 {
 		sqlText += fmt.Sprintf(" LIMIT %d", limit)
 	}
-	rows, err := s.db.Query(sqlText, args...)
+	rows, err := s.db.Query(sqlText, tq.args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1011,21 +1241,31 @@ type doltliteStorageFlagExprs struct {
 // storageFlagExprsFor resolves the storage-flag expressions for tables.
 // Legacy snapshots wrote wisps tables without the flag columns; every row
 // there is ephemeral, so the wisps fallback is the constant 1 while the
-// issues-table fallback is the constant 0 (durable history rows).
-func (s *DoltliteReadStore) storageFlagExprsFor(tables doltliteTableSet) doltliteStorageFlagExprs {
+// issues-table fallback is the constant 0 (durable history rows). A probe
+// failure is propagated rather than treated as an absent column, so a
+// transient DB error cannot silently downgrade tier classification.
+func (s *DoltliteReadStore) storageFlagExprsFor(tables doltliteTableSet) (doltliteStorageFlagExprs, error) {
 	flags := doltliteStorageFlagExprs{ephemeral: "0", noHistory: "0"}
 	if tables.wisps {
 		flags.ephemeral = "1"
 	}
-	if s.tableHasColumn(tables.issues, "ephemeral") {
+	hasEphemeral, err := s.tableHasColumn(tables.issues, "ephemeral")
+	if err != nil {
+		return doltliteStorageFlagExprs{}, err
+	}
+	if hasEphemeral {
 		flags.ephemeral = "COALESCE(i.ephemeral, 0)"
 		flags.hasColumns = true
 	}
-	if s.tableHasColumn(tables.issues, "no_history") {
+	hasNoHistory, err := s.tableHasColumn(tables.issues, "no_history")
+	if err != nil {
+		return doltliteStorageFlagExprs{}, err
+	}
+	if hasNoHistory {
 		flags.noHistory = "COALESCE(i.no_history, 0)"
 		flags.hasColumns = true
 	}
-	return flags
+	return flags, nil
 }
 
 // doltliteTierPredicate translates query.go's TierMode row filter (Matches)
@@ -1052,15 +1292,6 @@ func doltliteTierPredicate(mode TierMode, tables doltliteTableSet, flags doltlit
 		}
 		return flags.ephemeral + " = 0", false
 	}
-}
-
-// doltliteCanPushTableLimit reports whether a per-table SQL LIMIT cuts an
-// exact prefix for a multi-table merge: each table returns its own
-// top-limit prefix in the shared (created_at, id) total order, so the merged
-// sort+limit is exact unless a Go-side filter (metadata LIKE refinement,
-// before-time re-checks) can still drop rows after the SQL cut.
-func doltliteCanPushTableLimit(query ListQuery) bool {
-	return len(query.Metadata) == 0 && query.CreatedBefore.IsZero() && query.UpdatedBefore.IsZero()
 }
 
 func doltliteSQLiteTime(t time.Time) string {
@@ -1172,11 +1403,21 @@ func (s *DoltliteReadStore) tableExists(name string) bool {
 // tableHasColumn reports whether the table's schema includes the named
 // column. Snapshot schemas vary by writer generation (the storage-flag
 // columns arrived with the upstream wisps/no-history migrations), so read
-// paths probe before referencing them.
-func (s *DoltliteReadStore) tableHasColumn(table, column string) bool {
+// paths probe before referencing them. A genuinely absent column reports
+// (false, nil); an unexpected probe failure is returned so the caller fails
+// the read instead of silently downgrading tier classification to legacy
+// semantics, which would drop the whole wisps table from TierIssues and
+// misclassify no-history rows (#3449 review).
+func (s *DoltliteReadStore) tableHasColumn(table, column string) (bool, error) {
 	var found string
 	err := s.db.QueryRow(`SELECT name FROM pragma_table_info(?) WHERE name = ?`, table, column).Scan(&found)
-	return err == nil
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("doltlite probe %s.%s: %w", table, column, err)
+	}
+	return true, nil
 }
 
 func (s *DoltliteReadStore) hydrateLabels(beads []Bead, labelTable string) error {

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -775,6 +775,15 @@ func (s *DoltliteReadStore) queryIssuesOrderedInTables(query ListQuery, sets []d
 	if err := query.Validate(); err != nil {
 		return nil, err
 	}
+	// A custom orderBy is applied per table in SQL, and the cross-table Go
+	// re-sort below runs only for the empty-orderBy default order, so a custom
+	// orderBy across more than one table set would concatenate independently
+	// ordered tables. Reject that shape explicitly rather than silently
+	// returning cross-table-unsorted results; the only custom-orderBy caller
+	// (Ready) correctly passes a single issues-only table set (#3449 review).
+	if orderBy != "" && len(sets) > 1 {
+		return nil, fmt.Errorf("doltlite: custom orderBy requires a single table set, got %d", len(sets))
+	}
 	// A bounded multi-table read can resolve its exact global top-N by
 	// selecting ids in one SQL statement and hydrating only those ids, instead
 	// of reading every matching row from both tables and cutting in Go. This
@@ -940,31 +949,54 @@ func (s *DoltliteReadStore) selectBoundedTopNIDs(query ListQuery, sets []doltlit
 	return ids, rows.Err()
 }
 
+// doltliteMaxHydrateIDsPerChunk bounds how many id placeholders a single
+// hydrateBeadsByID query may bind. The native DoltLite driver
+// (modernc.org/sqlite) caps a statement at SQLITE_MAX_VARIABLE_NUMBER = 32766
+// bound parameters. A bounded read's id selection is limited only by the query
+// limit, and the API derives that limit from an uncapped cursor offset
+// (internal/api/pagination.go), so a deep page can select tens of thousands of
+// ids. Hydrate the IN (...) clause in chunks well under the driver cap, leaving
+// headroom for the query's own tier/status/label/assignee predicate parameters,
+// so a deep cursor walk over a large rig cannot overflow the statement variable
+// limit (#3449 review).
+const doltliteMaxHydrateIDsPerChunk = 16000
+
 // hydrateBeadsByID fetches full bead rows for ids from each table set, applying
 // query's filters and deduping by id (issues-table rows win), exactly as the
-// full-read merge does.
+// full-read merge does. The id set is hydrated in chunks bounded by
+// doltliteMaxHydrateIDsPerChunk so a large bounded selection cannot exceed the
+// SQLite bound-parameter limit. The dedupe spans every chunk and table set, so
+// an issues-table row still wins over its wisp twin regardless of where the
+// chunk boundaries fall.
 func (s *DoltliteReadStore) hydrateBeadsByID(query ListQuery, sets []doltliteTableSet, ids []string) ([]Bead, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
 	merged := make([]Bead, 0, len(ids))
 	seen := make(map[string]struct{}, len(ids))
 	for _, tables := range sets {
-		rows, err := s.queryIssueTable(query, tables, "i.id IN ("+placeholders+")", args, 0, "")
-		if err != nil {
-			return nil, err
-		}
-		for _, row := range rows {
-			if _, ok := seen[row.ID]; ok {
-				continue
+		for start := 0; start < len(ids); start += doltliteMaxHydrateIDsPerChunk {
+			end := start + doltliteMaxHydrateIDsPerChunk
+			if end > len(ids) {
+				end = len(ids)
 			}
-			seen[row.ID] = struct{}{}
-			merged = append(merged, row)
+			chunk := ids[start:end]
+			placeholders := strings.TrimRight(strings.Repeat("?,", len(chunk)), ",")
+			args := make([]any, len(chunk))
+			for i, id := range chunk {
+				args[i] = id
+			}
+			rows, err := s.queryIssueTable(query, tables, "i.id IN ("+placeholders+")", args, 0, "")
+			if err != nil {
+				return nil, err
+			}
+			for _, row := range rows {
+				if _, ok := seen[row.ID]; ok {
+					continue
+				}
+				seen[row.ID] = struct{}{}
+				merged = append(merged, row)
+			}
 		}
 	}
 	return merged, nil

--- a/internal/beads/doltlite_read_store_test.go
+++ b/internal/beads/doltlite_read_store_test.go
@@ -705,6 +705,11 @@ func TestDoltliteMetadataFilterPredicatesMatchStringValues(t *testing.T) {
 	}
 }
 
+// TestDoltliteReadStoreTierModesIncludeWisps pins the storage-tier contract
+// from query.go (TierMode) to the same shape TestBdStoreListStorageTierConformance
+// pins for BdStore (#3045, #3444): TierIssues keeps history and no-history
+// rows and drops only ephemeral ones; TierWisps keeps no-history and
+// ephemeral rows; TierBoth unions everything.
 func TestDoltliteReadStoreTierModesIncludeWisps(t *testing.T) {
 	store, closeStore := newTestDoltliteReadStore(t)
 	defer closeStore()
@@ -713,24 +718,70 @@ func TestDoltliteReadStoreTierModesIncludeWisps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List issues tier: %v", err)
 	}
-	if len(issues) != 1 || issues[0].ID != "gc-tier-issue" || issues[0].Ephemeral {
-		t.Fatalf("issues tier rows = %#v, want only non-ephemeral gc-tier-issue", issues)
+	if got := testBeadIDs(issues); !slices.Equal(got, []string{"gc-tier-issue", "gc-tier-nohistory"}) {
+		t.Fatalf("issues tier ids = %v, want [gc-tier-issue gc-tier-nohistory]; rows=%#v", got, issues)
+	}
+	noHistory := findTestBead(t, issues, "gc-tier-nohistory")
+	if noHistory.Ephemeral || !noHistory.NoHistory {
+		t.Fatalf("no-history row flags = %#v, want Ephemeral=false NoHistory=true", noHistory)
+	}
+	durable := findTestBead(t, issues, "gc-tier-issue")
+	if durable.Ephemeral || durable.NoHistory {
+		t.Fatalf("history row flags = %#v, want Ephemeral=false NoHistory=false", durable)
 	}
 
 	wisps, err := store.List(ListQuery{Label: "tier-test", TierMode: TierWisps, Sort: SortCreatedAsc})
 	if err != nil {
 		t.Fatalf("List wisps tier: %v", err)
 	}
-	if len(wisps) != 1 || wisps[0].ID != "gc-tier-wisp" || !wisps[0].Ephemeral {
-		t.Fatalf("wisps tier rows = %#v, want only ephemeral gc-tier-wisp", wisps)
+	if got := testBeadIDs(wisps); !slices.Equal(got, []string{"gc-tier-wisp", "gc-tier-nohistory"}) {
+		t.Fatalf("wisps tier ids = %v, want [gc-tier-wisp gc-tier-nohistory]; rows=%#v", got, wisps)
+	}
+	if ephemeral := findTestBead(t, wisps, "gc-tier-wisp"); !ephemeral.Ephemeral || ephemeral.NoHistory {
+		t.Fatalf("ephemeral row flags = %#v, want Ephemeral=true NoHistory=false", ephemeral)
 	}
 
 	both, err := store.List(ListQuery{Label: "tier-test", TierMode: TierBoth, Sort: SortCreatedAsc})
 	if err != nil {
 		t.Fatalf("List both tiers: %v", err)
 	}
-	if got := testBeadIDs(both); !slices.Equal(got, []string{"gc-tier-issue", "gc-tier-wisp"}) {
-		t.Fatalf("both tier ids = %v, want [gc-tier-issue gc-tier-wisp]; rows=%#v", got, both)
+	if got := testBeadIDs(both); !slices.Equal(got, []string{"gc-tier-issue", "gc-tier-wisp", "gc-tier-nohistory"}) {
+		t.Fatalf("both tier ids = %v, want [gc-tier-issue gc-tier-wisp gc-tier-nohistory]; rows=%#v", got, both)
+	}
+}
+
+// TestDoltliteReadStoreLegacyWispsSchemaStaysEphemeralOnly pins backward
+// compatibility for doltlite snapshots written before the wisps table carried
+// the ephemeral/no_history storage-flag columns (beads migrations 0020/0023):
+// without the discriminator every wisp row is ephemeral, so TierIssues must
+// keep excluding the whole wisps table and TierWisps must surface its rows
+// with Ephemeral=true.
+func TestDoltliteReadStoreLegacyWispsSchemaStaysEphemeralOnly(t *testing.T) {
+	store, closeStore := newLegacyTestDoltliteReadStore(t)
+	defer closeStore()
+
+	issues, err := store.List(ListQuery{Label: "tier-test", Sort: SortCreatedAsc})
+	if err != nil {
+		t.Fatalf("List issues tier: %v", err)
+	}
+	if got := testBeadIDs(issues); !slices.Equal(got, []string{"gc-legacy-issue"}) {
+		t.Fatalf("issues tier ids = %v, want [gc-legacy-issue]; rows=%#v", got, issues)
+	}
+
+	wisps, err := store.List(ListQuery{Label: "tier-test", TierMode: TierWisps, Sort: SortCreatedAsc})
+	if err != nil {
+		t.Fatalf("List wisps tier: %v", err)
+	}
+	if len(wisps) != 1 || wisps[0].ID != "gc-legacy-wisp" || !wisps[0].Ephemeral {
+		t.Fatalf("wisps tier rows = %#v, want only ephemeral gc-legacy-wisp", wisps)
+	}
+
+	both, err := store.List(ListQuery{Label: "tier-test", TierMode: TierBoth, Sort: SortCreatedAsc})
+	if err != nil {
+		t.Fatalf("List both tiers: %v", err)
+	}
+	if got := testBeadIDs(both); !slices.Equal(got, []string{"gc-legacy-issue", "gc-legacy-wisp"}) {
+		t.Fatalf("both tier ids = %v, want [gc-legacy-issue gc-legacy-wisp]; rows=%#v", got, both)
 	}
 }
 
@@ -1051,6 +1102,18 @@ func newTestDoltliteReadStore(t *testing.T) (*DoltliteReadStore, func()) {
 		Assignee:  "rig/wisp-worker",
 		Labels:    []string{"tier-test"},
 		Metadata:  map[string]string{"kind": "wisp"},
+		Ephemeral: true,
+	})
+	insertTestDoltliteIssue(t, db, "wisps", "wisp_labels", "wisp_dependencies", testDoltliteIssue{
+		ID:        "gc-tier-nohistory",
+		Title:     "tier no-history",
+		Status:    "open",
+		IssueType: "task",
+		CreatedAt: now.Add(5 * time.Second),
+		Assignee:  "rig/nohistory-worker",
+		Labels:    []string{"tier-test"},
+		Metadata:  map[string]string{"kind": "no-history"},
+		NoHistory: true,
 	})
 
 	backing := NewBdStore(dir, func(string, string, ...string) ([]byte, error) {
@@ -1085,9 +1148,30 @@ type testDoltliteIssue struct {
 	Labels       []string
 	Metadata     map[string]string
 	Dependencies []testDoltliteDependency
+	Ephemeral    bool
+	NoHistory    bool
 }
 
+// createTestDoltliteSchema mirrors the snapshot schema the current DoltLite
+// beads backend writes: the upstream wisps/no-history migrations (0020/0023)
+// give both row tables ephemeral and no_history storage-flag columns.
+// createLegacyTestDoltliteSchema covers snapshots from before those columns.
 func createTestDoltliteSchema(t testing.TB, db *sql.DB) {
+	t.Helper()
+	const storageFlagColumns = `,
+			ephemeral INTEGER DEFAULT 0,
+			no_history INTEGER DEFAULT 0`
+	createTestDoltliteSchemaWithRowColumns(t, db, storageFlagColumns)
+}
+
+// createLegacyTestDoltliteSchema mirrors doltlite snapshots written before
+// the wisps table carried storage-flag columns: every wisps row is ephemeral.
+func createLegacyTestDoltliteSchema(t testing.TB, db *sql.DB) {
+	t.Helper()
+	createTestDoltliteSchemaWithRowColumns(t, db, "")
+}
+
+func createTestDoltliteSchemaWithRowColumns(t testing.TB, db *sql.DB, extraRowColumns string) {
 	t.Helper()
 	for _, stmt := range []string{
 		`CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)`,
@@ -1104,7 +1188,7 @@ func createTestDoltliteSchema(t testing.TB, db *sql.DB) {
 			design TEXT,
 			acceptance_criteria TEXT,
 			notes TEXT,
-			metadata TEXT
+			metadata TEXT` + extraRowColumns + `
 		)`,
 		`CREATE TABLE wisps (
 			id TEXT PRIMARY KEY,
@@ -1119,7 +1203,7 @@ func createTestDoltliteSchema(t testing.TB, db *sql.DB) {
 			design TEXT,
 			acceptance_criteria TEXT,
 			notes TEXT,
-			metadata TEXT
+			metadata TEXT` + extraRowColumns + `
 		)`,
 		`CREATE TABLE labels (issue_id TEXT, label TEXT)`,
 		`CREATE TABLE wisp_labels (issue_id TEXT, label TEXT)`,
@@ -1172,8 +1256,9 @@ func insertTestDoltliteIssue(t testing.TB, db *sql.DB, issueTable, labelTable, d
 	}
 	_, err := db.Exec(`INSERT INTO `+issueTable+` (
 		id, title, status, issue_type, priority, created_at, updated_at,
-		assignee, description, design, acceptance_criteria, notes, metadata
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '', '', '', ?)`,
+		assignee, description, design, acceptance_criteria, notes, metadata,
+		ephemeral, no_history
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '', '', '', ?, ?, ?)`,
 		issue.ID,
 		issue.Title,
 		issue.Status,
@@ -1184,6 +1269,8 @@ func insertTestDoltliteIssue(t testing.TB, db *sql.DB, issueTable, labelTable, d
 		issue.Assignee,
 		issue.Description,
 		metadata,
+		boolToTestInt(issue.Ephemeral),
+		boolToTestInt(issue.NoHistory),
 	)
 	if err != nil {
 		t.Fatalf("insert %s into %s: %v", issue.ID, issueTable, err)
@@ -1204,6 +1291,77 @@ func insertTestDoltliteIssue(t testing.TB, db *sql.DB, issueTable, labelTable, d
 			t.Fatalf("insert dep %s -> %s: %v", issue.ID, dep.DependsOnID, err)
 		}
 	}
+}
+
+func boolToTestInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+// newLegacyTestDoltliteReadStore builds a read store over a pre-storage-flag
+// snapshot (no ephemeral/no_history columns) seeded with one durable issue
+// and one wisps row, both labeled tier-test.
+func newLegacyTestDoltliteReadStore(t *testing.T) (*DoltliteReadStore, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	meta := []byte(`{"backend":"doltlite","database":"doltlite","dolt_database":"hq"}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), meta, 0o600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	dbDir := filepath.Join(beadsDir, "doltlite")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatalf("mkdir doltlite dir: %v", err)
+	}
+	dbPath := filepath.Join(dbDir, "hq.db")
+	db, err := sql.Open("sqlite", dbPath+"?_busy_timeout=10000")
+	if err != nil {
+		t.Fatalf("open legacy doltlite fixture db: %v", err)
+	}
+	defer db.Close() //nolint:errcheck // test cleanup
+	createLegacyTestDoltliteSchema(t, db)
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	for _, stmt := range []struct {
+		sql  string
+		args []any
+	}{
+		{
+			`INSERT INTO issues (
+			id, title, status, issue_type, priority, created_at, updated_at,
+			assignee, description, design, acceptance_criteria, notes, metadata
+		) VALUES (?, ?, 'open', 'task', 2, ?, ?, '', '', '', '', '', '{}')`,
+			[]any{"gc-legacy-issue", "legacy issue", now, now},
+		},
+		{`INSERT INTO labels (issue_id, label) VALUES ('gc-legacy-issue', 'tier-test')`, nil},
+		{
+			`INSERT INTO wisps (
+			id, title, status, issue_type, priority, created_at, updated_at,
+			assignee, description, design, acceptance_criteria, notes, metadata
+		) VALUES (?, ?, 'open', 'task', 2, ?, ?, '', '', '', '', '', '{}')`,
+			[]any{"gc-legacy-wisp", "legacy wisp", now, now},
+		},
+		{`INSERT INTO wisp_labels (issue_id, label) VALUES ('gc-legacy-wisp', 'tier-test')`, nil},
+	} {
+		if _, err := db.Exec(stmt.sql, stmt.args...); err != nil {
+			t.Fatalf("seed legacy doltlite fixture: %v\nstmt: %s", err, stmt.sql)
+		}
+	}
+
+	backing := NewBdStore(dir, func(string, string, ...string) ([]byte, error) {
+		t.Fatal("backing bd runner should not be called by doltlite read tests")
+		return nil, nil
+	})
+	store, err := NewDoltliteReadStore(dir, backing)
+	if err != nil {
+		t.Fatalf("NewDoltliteReadStore: %v", err)
+	}
+	return store, func() { _ = store.CloseStore() }
 }
 
 func testBeadIDs(rows []Bead) []string {

--- a/internal/beads/doltlite_read_store_test.go
+++ b/internal/beads/doltlite_read_store_test.go
@@ -868,6 +868,200 @@ func TestDoltliteReadStoreLimitCutsDeterministicPrefixOnCreatedAtTies(t *testing
 	}
 }
 
+// TestDoltliteReadStoreBoundedMultiTableMergeKeepsGlobalTopN pins the
+// cross-table merge contract for bounded TierIssues reads (#3444). TierIssues
+// now spans both the issues and wisps tables, and the merge dedupes by id
+// before the global sort+limit. A per-table SQL LIMIT must therefore not be
+// pushed for multi-table reads: if it were, a table whose limited prefix is
+// entirely cross-table duplicates would never surface a later unique row that
+// belongs in the global top-N. Here gc-dup-a and gc-dup-b are durable issues
+// that outrank their no-history wisp twins, so a pushed per-table LIMIT 2
+// would fetch only the duplicated wisps prefix (a@99, b@98) and never see the
+// unique durable wisp gc-dup-c@97 that sorts into the true top-2.
+func TestDoltliteReadStoreBoundedMultiTableMergeKeepsGlobalTopN(t *testing.T) {
+	store, closeStore := newTestDoltliteReadStore(t)
+	defer closeStore()
+	writer := openTestDoltliteWriter(t, store.db)
+	defer writer.Close() //nolint:errcheck // test cleanup
+
+	base := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	for _, issue := range []testDoltliteIssue{
+		{ID: "gc-dup-a", Title: "dup a issue", CreatedAt: base.Add(100 * time.Second), Labels: []string{"dup-prefix"}},
+		{ID: "gc-dup-b", Title: "dup b issue", CreatedAt: base.Add(1 * time.Second), Labels: []string{"dup-prefix"}},
+	} {
+		insertTestDoltliteIssue(t, writer, "issues", "labels", "dependencies", issue)
+	}
+	for _, wisp := range []testDoltliteIssue{
+		{ID: "gc-dup-a", Title: "dup a wisp", CreatedAt: base.Add(99 * time.Second), Labels: []string{"dup-prefix"}, NoHistory: true},
+		{ID: "gc-dup-b", Title: "dup b wisp", CreatedAt: base.Add(98 * time.Second), Labels: []string{"dup-prefix"}, NoHistory: true},
+		{ID: "gc-dup-c", Title: "dup c wisp", CreatedAt: base.Add(97 * time.Second), Labels: []string{"dup-prefix"}, NoHistory: true},
+	} {
+		insertTestDoltliteIssue(t, writer, "wisps", "wisp_labels", "wisp_dependencies", wisp)
+	}
+
+	// Unbounded TierIssues read is the ground truth: the durable issue rows
+	// plus the deduped unique no-history wisp (the a/b wisp twins fold into
+	// their issue rows), sorted created-desc.
+	all, err := store.List(ListQuery{Label: "dup-prefix", Sort: SortCreatedDesc, SkipLabels: true})
+	if err != nil {
+		t.Fatalf("List unbounded: %v", err)
+	}
+	if got := testBeadIDs(all); !slices.Equal(got, []string{"gc-dup-a", "gc-dup-c", "gc-dup-b"}) {
+		t.Fatalf("unbounded ids = %v, want [gc-dup-a gc-dup-c gc-dup-b]", got)
+	}
+
+	// The bounded read must equal the unbounded top-2, not the per-table
+	// limited prefix [gc-dup-a gc-dup-b].
+	top2, err := store.List(ListQuery{Label: "dup-prefix", Sort: SortCreatedDesc, Limit: 2, SkipLabels: true})
+	if err != nil {
+		t.Fatalf("List limit 2: %v", err)
+	}
+	if got := testBeadIDs(top2); !slices.Equal(got, []string{"gc-dup-a", "gc-dup-c"}) {
+		t.Fatalf("bounded top-2 ids = %v, want [gc-dup-a gc-dup-c]", got)
+	}
+}
+
+// TestDoltliteReadStoreBoundedTopNAvoidsFullHistoryHydration pins the bounded
+// multi-table read fix (#3449 review). A limited default-tier read now selects
+// the exact global top-N ids in one SQL statement and hydrates only those ids,
+// instead of reading every matching row from both tables and cutting in Go.
+// The dataset's highest-sorted row is an ephemeral wisp that must stay out of
+// TierIssues, and a no-history wisp twin folds into its durable issue, so the
+// bounded result must equal the unbounded top-N across the issues/wisps
+// boundary while the id selection itself stays O(limit).
+func TestDoltliteReadStoreBoundedTopNAvoidsFullHistoryHydration(t *testing.T) {
+	store, closeStore := newTestDoltliteReadStore(t)
+	defer closeStore()
+	writer := openTestDoltliteWriter(t, store.db)
+	defer writer.Close() //nolint:errcheck // test cleanup
+
+	base := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	for _, issue := range []testDoltliteIssue{
+		{ID: "gc-bt-i1", Title: "i1", CreatedAt: base.Add(10 * time.Second), Labels: []string{"bt"}},
+		{ID: "gc-bt-i2", Title: "i2", CreatedAt: base.Add(8 * time.Second), Labels: []string{"bt"}},
+		{ID: "gc-bt-i3", Title: "i3", CreatedAt: base.Add(2 * time.Second), Labels: []string{"bt"}},
+	} {
+		insertTestDoltliteIssue(t, writer, "issues", "labels", "dependencies", issue)
+	}
+	for _, wisp := range []testDoltliteIssue{
+		{ID: "gc-bt-w1", Title: "w1", CreatedAt: base.Add(9 * time.Second), Labels: []string{"bt"}, NoHistory: true},
+		{ID: "gc-bt-i2", Title: "i2 wisp twin", CreatedAt: base.Add(7 * time.Second), Labels: []string{"bt"}, NoHistory: true},
+		{ID: "gc-bt-w2", Title: "w2", CreatedAt: base.Add(5 * time.Second), Labels: []string{"bt"}, NoHistory: true},
+		{ID: "gc-bt-eph", Title: "ephemeral", CreatedAt: base.Add(100 * time.Second), Labels: []string{"bt"}, Ephemeral: true},
+	} {
+		insertTestDoltliteIssue(t, writer, "wisps", "wisp_labels", "wisp_dependencies", wisp)
+	}
+
+	// Ground truth: the ephemeral wisp is excluded from TierIssues, the i2 wisp
+	// twin folds into its durable issue, sorted created-desc.
+	wantUnbounded := []string{"gc-bt-i1", "gc-bt-w1", "gc-bt-i2", "gc-bt-w2", "gc-bt-i3"}
+	all, err := store.List(ListQuery{Label: "bt", Sort: SortCreatedDesc})
+	if err != nil {
+		t.Fatalf("List unbounded: %v", err)
+	}
+	if got := testBeadIDs(all); !slices.Equal(got, wantUnbounded) {
+		t.Fatalf("unbounded ids = %v, want %v", got, wantUnbounded)
+	}
+
+	// The id selection is bounded and exact: it returns exactly the top-3 ids
+	// (not all five matches), proving the SQL LIMIT is applied during selection
+	// rather than after hydrating full matching history.
+	sets := doltliteTableSetsForMode(TierIssues)
+	ids, err := store.selectBoundedTopNIDs(ListQuery{Label: "bt", Sort: SortCreatedDesc}, sets, 3)
+	if err != nil {
+		t.Fatalf("selectBoundedTopNIDs: %v", err)
+	}
+	if !slices.Equal(ids, []string{"gc-bt-i1", "gc-bt-w1", "gc-bt-i2"}) {
+		t.Fatalf("selected top-3 ids = %v, want [gc-bt-i1 gc-bt-w1 gc-bt-i2]", ids)
+	}
+
+	// End to end the bounded List equals the unbounded top-3, and the hydrated
+	// rows carry their labels and storage flags across both tables.
+	top3, err := store.List(ListQuery{Label: "bt", Sort: SortCreatedDesc, Limit: 3})
+	if err != nil {
+		t.Fatalf("List limit 3: %v", err)
+	}
+	if got := testBeadIDs(top3); !slices.Equal(got, []string{"gc-bt-i1", "gc-bt-w1", "gc-bt-i2"}) {
+		t.Fatalf("bounded top-3 ids = %v, want [gc-bt-i1 gc-bt-w1 gc-bt-i2]", got)
+	}
+	w1 := findTestBead(t, top3, "gc-bt-w1")
+	if !slices.Contains(w1.Labels, "bt") {
+		t.Fatalf("hydrated wisp gc-bt-w1 missing label bt: %#v", w1.Labels)
+	}
+	if !w1.NoHistory {
+		t.Fatalf("hydrated wisp gc-bt-w1 should be NoHistory: %#v", w1)
+	}
+
+	// TierBoth takes the same bounded fast path but applies no tier filter, so
+	// the ephemeral wisp (highest created_at) is the bounded top-1 — the
+	// opposite of the TierIssues result above.
+	bothTop1, err := store.List(ListQuery{Label: "bt", Sort: SortCreatedDesc, Limit: 1, TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("List TierBoth limit 1: %v", err)
+	}
+	if got := testBeadIDs(bothTop1); !slices.Equal(got, []string{"gc-bt-eph"}) {
+		t.Fatalf("TierBoth bounded top-1 ids = %v, want [gc-bt-eph]", got)
+	}
+}
+
+// TestDoltliteReadStoreBoundedSameSecondPrefixMatchesUnbounded pins the #3449
+// review fix for sub-second precision: scanBead truncates CreatedAt to whole
+// seconds, so the Go merge orders same-second rows by id. A bounded read's SQL
+// LIMIT must cut on that same second-granular key, not the raw sub-second
+// created_at text, or it selects a different prefix than the unbounded merge.
+// The sub-second offsets below are the exact reverse of the id order, so a raw
+// ordering would invert the canonical prefix at every limit boundary. Covers
+// both the multi-table bounded path (selectBoundedTopNIDs) and the single-table
+// limited path (queryIssueTable).
+func TestDoltliteReadStoreBoundedSameSecondPrefixMatchesUnbounded(t *testing.T) {
+	base := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+
+	assertPrefixParity := func(t *testing.T, store *DoltliteReadStore, tier TierMode) {
+		t.Helper()
+		for _, sort := range []SortOrder{SortCreatedDesc, SortCreatedAsc} {
+			unbounded, err := store.List(ListQuery{Label: "ss", Sort: sort, TierMode: tier})
+			if err != nil {
+				t.Fatalf("List unbounded (tier=%v sort=%v): %v", tier, sort, err)
+			}
+			if len(unbounded) != 4 {
+				t.Fatalf("unbounded len = %d, want 4 (ids %v)", len(unbounded), testBeadIDs(unbounded))
+			}
+			for k := 1; k <= 4; k++ {
+				bounded, err := store.List(ListQuery{Label: "ss", Sort: sort, TierMode: tier, Limit: k})
+				if err != nil {
+					t.Fatalf("List(tier=%v sort=%v limit=%d): %v", tier, sort, k, err)
+				}
+				got, want := testBeadIDs(bounded), testBeadIDs(unbounded[:k])
+				if !slices.Equal(got, want) {
+					t.Fatalf("bounded prefix (tier=%v sort=%v limit=%d) = %v, want unbounded prefix %v", tier, sort, k, got, want)
+				}
+			}
+		}
+	}
+
+	t.Run("tier_issues_multi_table", func(t *testing.T) {
+		issues := []testDoltliteIssue{
+			{ID: "gc-ss-a", Title: "a", CreatedAt: base.Add(800 * time.Millisecond), Labels: []string{"ss"}},
+			{ID: "gc-ss-c", Title: "c", CreatedAt: base.Add(400 * time.Millisecond), Labels: []string{"ss"}},
+		}
+		wisps := []testDoltliteIssue{
+			{ID: "gc-ss-b", Title: "b", CreatedAt: base.Add(600 * time.Millisecond), Labels: []string{"ss"}, NoHistory: true},
+			{ID: "gc-ss-d", Title: "d", CreatedAt: base.Add(200 * time.Millisecond), Labels: []string{"ss"}, NoHistory: true},
+		}
+		assertPrefixParity(t, newDoltliteStoreWithRows(t, issues, wisps), TierIssues)
+	})
+
+	t.Run("tier_wisps_single_table", func(t *testing.T) {
+		wisps := []testDoltliteIssue{
+			{ID: "gc-ss-a", Title: "a", CreatedAt: base.Add(800 * time.Millisecond), Labels: []string{"ss"}, NoHistory: true},
+			{ID: "gc-ss-b", Title: "b", CreatedAt: base.Add(600 * time.Millisecond), Labels: []string{"ss"}, NoHistory: true},
+			{ID: "gc-ss-c", Title: "c", CreatedAt: base.Add(400 * time.Millisecond), Labels: []string{"ss"}, NoHistory: true},
+			{ID: "gc-ss-d", Title: "d", CreatedAt: base.Add(200 * time.Millisecond), Labels: []string{"ss"}, NoHistory: true},
+		}
+		assertPrefixParity(t, newDoltliteStoreWithRows(t, nil, wisps), TierWisps)
+	})
+}
+
 // TestDoltliteReadStoreReadyLimitCutsDeterministicPrefixOnTies pins the same
 // (#3208) tie-cut contract for the Ready path, whose custom ORDER BY
 // (priority, created_at) also needs the id tiebreaker for a deterministic

--- a/internal/beads/doltlite_read_store_test.go
+++ b/internal/beads/doltlite_read_store_test.go
@@ -1062,6 +1062,138 @@ func TestDoltliteReadStoreBoundedSameSecondPrefixMatchesUnbounded(t *testing.T) 
 	})
 }
 
+// TestDoltliteReadStoreBoundedHydrationChunksLargeIDSet pins the deep-pagination
+// fix for the bounded multi-table read (#3449 review). The bounded path selects
+// up to `limit` ids in one SQL statement and hydrates them with an
+// `i.id IN (?,...)` clause. The native DoltLite driver (modernc.org/sqlite) caps
+// a statement at SQLITE_MAX_VARIABLE_NUMBER = 32766 bound parameters, and the
+// API sets query.Limit to the cursor Offset+Limit with the offset uncapped
+// (internal/api/pagination.go), so a deep cursor walk over a large rig can select
+// more ids than the cap. An unchunked IN clause then overflows with
+// "too many SQL variables" and the read 500s on its last page(s) — a
+// success→error regression on exactly the large-rig hot path this PR optimizes,
+// invisible to first-page reads. Seed more than the cap worth of matching rows
+// and assert a large-limit List succeeds and returns the exact global order.
+func TestDoltliteReadStoreBoundedHydrationChunksLargeIDSet(t *testing.T) {
+	// 32766 is modernc.org/sqlite's SQLITE_MAX_VARIABLE_NUMBER; seed above it so
+	// an unchunked hydrate IN clause would overflow.
+	const rowCount = 33000
+	store := newDoltliteStoreWithBulkIssues(t, rowCount)
+
+	// limit > rowCount so the bounded selection returns every matching id: the
+	// hydrate clause therefore carries all rowCount ids, exceeding the variable
+	// cap unless hydrateBeadsByID chunks it.
+	got, err := store.List(ListQuery{AllowScan: true, Sort: SortCreatedAsc, Limit: rowCount + 1000})
+	if err != nil {
+		t.Fatalf("large-limit bounded List failed (deep-pagination IN overflow regression): %v", err)
+	}
+	if len(got) != rowCount {
+		t.Fatalf("List returned %d rows, want %d", len(got), rowCount)
+	}
+	// Chunked hydration must not change which ids survive the cut or their order:
+	// the rows are id-ordered with strictly increasing created_at, so the asc
+	// result is the seed order from first to last id.
+	if got[0].ID != "gc-bulk-000000" {
+		t.Fatalf("first row = %q, want gc-bulk-000000", got[0].ID)
+	}
+	if last, want := got[len(got)-1].ID, fmt.Sprintf("gc-bulk-%06d", rowCount-1); last != want {
+		t.Fatalf("last row = %q, want %q", last, want)
+	}
+}
+
+// newDoltliteStoreWithBulkIssues seeds a fresh DoltLite snapshot with n minimal
+// durable task issues inside one transaction (autocommit would fsync per row,
+// which is far too slow for the tens of thousands of rows the variable-cap
+// regression needs) and returns a read store over it. Rows are id-ordered
+// gc-bulk-NNNNNN with strictly increasing created_at so the bounded read order
+// is deterministic.
+func newDoltliteStoreWithBulkIssues(t testing.TB, n int) *DoltliteReadStore {
+	t.Helper()
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "doltlite"), 0o755); err != nil {
+		t.Fatalf("mkdir doltlite dir: %v", err)
+	}
+	meta := []byte(`{"backend":"doltlite","database":"doltlite","dolt_database":"hq"}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), meta, 0o600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	dbPath := filepath.Join(beadsDir, "doltlite", "hq.db")
+	db, err := sql.Open("sqlite", dbPath+"?_busy_timeout=10000")
+	if err != nil {
+		t.Fatalf("open doltlite fixture db: %v", err)
+	}
+	defer db.Close() //nolint:errcheck // test cleanup
+	createTestDoltliteSchema(t, db)
+
+	base := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin bulk insert: %v", err)
+	}
+	stmt, err := tx.Prepare(`INSERT INTO issues (
+		id, title, status, issue_type, priority, created_at, updated_at,
+		assignee, description, design, acceptance_criteria, notes, metadata,
+		ephemeral, no_history
+	) VALUES (?, ?, 'open', 'task', 2, ?, ?, '', '', '', '', '', '{}', 0, 0)`)
+	if err != nil {
+		t.Fatalf("prepare bulk insert: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		ts := base.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano)
+		id := fmt.Sprintf("gc-bulk-%06d", i)
+		if _, err := stmt.Exec(id, id, ts, ts); err != nil {
+			t.Fatalf("bulk insert row %d: %v", i, err)
+		}
+	}
+	if err := stmt.Close(); err != nil {
+		t.Fatalf("close bulk insert stmt: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit bulk insert: %v", err)
+	}
+
+	backing := NewBdStore(dir, func(string, string, ...string) ([]byte, error) {
+		t.Fatal("backing bd runner should not be called by doltlite read tests")
+		return nil, nil
+	})
+	store, err := NewDoltliteReadStore(dir, backing)
+	if err != nil {
+		t.Fatalf("NewDoltliteReadStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.CloseStore() })
+	return store
+}
+
+// TestDoltliteReadStoreCustomOrderByRejectsMultiTableSet pins the invariant that
+// a custom orderBy must target a single table set (#3449 review). The merged
+// read path applies a custom orderBy per table in SQL and skips the cross-table
+// Go re-sort, so a multi-table set would silently concatenate independently
+// ordered tables. The public List path always passes the default (empty)
+// orderBy and Ready passes a single issues-only set, so this guard never fires
+// in production; it converts a latent silent-misordering into an explicit error
+// for any future caller.
+func TestDoltliteReadStoreCustomOrderByRejectsMultiTableSet(t *testing.T) {
+	store, closeStore := newTestDoltliteReadStore(t)
+	defer closeStore()
+
+	sets := doltliteTableSetsForMode(TierIssues)
+	if len(sets) < 2 {
+		t.Fatalf("TierIssues table sets = %d, want >= 2 to exercise the guard", len(sets))
+	}
+	const customOrder = "ORDER BY i.created_at ASC, i.id ASC"
+	if _, err := store.queryIssuesOrderedInTables(ListQuery{AllowScan: true}, sets, "", nil, 0, customOrder); err == nil {
+		t.Fatal("custom orderBy with multiple table sets should error, got nil")
+	} else if !strings.Contains(err.Error(), "single table set") {
+		t.Fatalf("error = %q, want it to mention the single-table-set invariant", err)
+	}
+
+	// The same custom orderBy against a single table set is allowed.
+	if _, err := store.queryIssuesOrderedInTables(ListQuery{AllowScan: true}, []doltliteTableSet{doltliteIssueTables}, "", nil, 0, customOrder); err != nil {
+		t.Fatalf("custom orderBy with a single table set should succeed, got %v", err)
+	}
+}
+
 // TestDoltliteReadStoreReadyLimitCutsDeterministicPrefixOnTies pins the same
 // (#3208) tie-cut contract for the Ready path, whose custom ORDER BY
 // (priority, created_at) also needs the id tiebreaker for a deterministic

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -187,6 +187,7 @@ func (w *beadWire) toBead() beads.Bead {
 		Labels:      w.Labels,
 		Metadata:    coerceMetadata(w.Metadata),
 		Ephemeral:   w.Ephemeral,
+		NoHistory:   w.NoHistory,
 		DeferUntil:  cloneTimePtr(w.DeferUntil),
 	}
 }

--- a/internal/beads/exec/json.go
+++ b/internal/beads/exec/json.go
@@ -26,6 +26,7 @@ type createRequest struct {
 	From        string            `json:"from,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 	Ephemeral   bool              `json:"ephemeral,omitempty"`
+	NoHistory   bool              `json:"no_history,omitempty"`
 	DeferUntil  *time.Time        `json:"defer_until,omitempty"`
 }
 
@@ -67,6 +68,7 @@ type beadWire struct {
 	Labels      []string                   `json:"labels"`
 	Metadata    map[string]json.RawMessage `json:"metadata,omitempty"`
 	Ephemeral   bool                       `json:"ephemeral,omitempty"`
+	NoHistory   bool                       `json:"no_history,omitempty"`
 	DeferUntil  *time.Time                 `json:"defer_until,omitempty"`
 }
 
@@ -85,6 +87,7 @@ func marshalCreate(b beads.Bead) ([]byte, error) {
 		From:        b.From,
 		Metadata:    b.Metadata,
 		Ephemeral:   b.Ephemeral,
+		NoHistory:   b.NoHistory,
 		DeferUntil:  b.DeferUntil,
 	}
 	return json.Marshal(r)

--- a/internal/beads/exec/testdata/conformance.sh
+++ b/internal/beads/exec/testdata/conformance.sh
@@ -85,6 +85,7 @@ create)
 	ref=$(echo "$input" | jq -r '.ref // ""')
 	description=$(echo "$input" | jq -r '.description // ""')
 	ephemeral=$(echo "$input" | jq -r '.ephemeral // false')
+	no_history=$(echo "$input" | jq -r '.no_history // false')
 	defer_until=$(echo "$input" | jq -r '.defer_until // ""')
 	created_at=$(now)
 
@@ -114,6 +115,7 @@ create)
 		--arg description "$description" \
 		--argjson labels "$labels" \
 		--argjson ephemeral "$ephemeral" \
+		--argjson no_history "$no_history" \
 		--arg defer_until "$defer_until" \
 		'{
         id: $id,
@@ -128,7 +130,8 @@ create)
         needs: $needs,
         description: $description,
         labels: $labels,
-        ephemeral: $ephemeral
+        ephemeral: $ephemeral,
+        no_history: $no_history
       } + (if $defer_until == "" then {} else {defer_until: $defer_until} end)' >"$STATE_ROOT/$id.json"
 
 	# Output the created bead (normalized: meta: labels → .metadata map).


### PR DESCRIPTION
## Contract decision

**TierIssues = durable history rows + non-ephemeral (`no_history`) wisps rows; only `ephemeral` rows are excluded.** The DoltLite read store's issues-table-only behavior was drift, not a deliberate exclusion. Evidence:

- `internal/beads/query.go` (#3045, `ce32c6bf6`, Jun 3): *"NoHistory rows remain visible to list filters in TierIssues because they are durable work without Dolt history."* `Bead.NoHistory`'s doc says the same: *"visible in normal durable reads."*
- `TestBdStoreListStorageTierConformance` pins it for BdStore: *"issues tier keeps history and no-history rows."*
- `NativeDoltStore` matches via upstream `SearchIssues` (`Ephemeral=&false` includes no-history rows — upstream pins this in `TestPR4107SearchIssuesWithCountsEphemeralFalseIncludesNoHistoryOnly`), and `native_dolt_store_count_test.go` already documents that an issues-table-only count *"undercounts open work relative to List."*
- Upstream beads v1.0.5 `types.go`: no-history wisps are *"durable work items without Dolt history."*
- `DoltliteReadStore` landed in #2474 (Jun 1) **before** the contract was written in #3045 (Jun 3), and #3045 touched `bdstore.go`/`query.go` but not `doltlite_read_store.go`. No commit or doc anywhere argues for excluding no-history rows from the native durable read.

## Measured (gascity rig store, read-only, dolt server `ga`)

- 29,906 issues; 12,725 wisps — 12,722 `no_history`, 3 `ephemeral` (matches the issue's numbers)
- `type=task, all=true`: durable-only **23,777** vs aligned (issues + non-ephemeral wisps, id-deduped) **23,777 + 9,821 = 33,598** — the ~29% disagreement from the issue, eliminated by this change

## Fix

`internal/beads/doltlite_read_store.go`
- TierIssues `List` now reads both tables; the wisps table contributes rows with `COALESCE(ephemeral,0)=0`, merged and id-deduped exactly like the existing TierBoth path. TierWisps keeps `ephemeral=1 OR no_history=1`; TierBoth unchanged (union).
- Rows now carry per-row `Ephemeral`/`NoHistory` read from the storage-flag columns instead of a table-level ephemeral bit, so flags agree with BdStore's `bd list --json` output.
- **Legacy snapshots** (wisps table without the storage-flag columns, written before beads migrations 0020/0023 were translated to the DoltLite SQLite schema) keep their old semantics: every wisps row is ephemeral, TierIssues stays issues-only. Schema is probed via `pragma_table_info`.
- Bounded reads keep SQL `LIMIT` pushdown per table when no Go-side re-filter can drop rows (preserves the #3253/#3208 bounded-read shape).

`internal/beads/doltlite_count.go`
- `Count` (Counter contract: exact `len(List)` parity, gascity#3253) counts the same durable wisps component with the same cross-table id dedupe, including the asymmetric case where the issues twin of a duplicated id does not match the filter. Unsupported shapes still return `ErrCountUnsupported`.

## Conformance harness (the load-bearing test)

`beadstest.RunStoreTests` gains **`ListStorageTierContract`**, pinning the tier semantics for every Store backend (memstore, filestore, exec stores, NativeDoltStore fixture). It immediately caught a third out-of-contract backend: **ExecStore dropped `no_history` on its JSON wire**, so its wisps tier lost no-history rows. Fixed in `exec/json.go` + `exec.go` (wire field), the `conformance.sh` reference backend, and the `gc-beads-br` adapter (`gc:no-history` label emulation, mirroring `gc:ephemeral`); contract documented in `docs/reference/exec-beads-provider.md`. DoltliteReadStore cannot run the write-path harness (writes delegate to the bd CLI), so its pinning lives in `TestDoltliteReadStoreTierModesIncludeWisps` (mirrors the BdStore conformance case 1:1), plus legacy-schema and Count==List parity tests.

## Scoped out (with reasoning)

- **`Get`** already reads TierBoth — finds wisps rows; it now additionally reports correct per-row flags.
- **Session/metadata fallback reads** route through the aligned TierIssues path and now see no-history rows (matching BdStore's `--include-infra` behavior) — no separate change needed.
- **Raw `Ready`** intentionally stays on the durable issues table (commented at the call site): the compatibility policy documented on `ReadyQuery.TierMode` keeps default claimable work history-backed, and the ready blocker predicate is built for the issues-table dependency graph. Note BdStore-on-bd-1.0.5 and NativeDoltStore *do* surface no-history rows in raw Ready, and `DoltliteReadStore.Ready` ignores `ReadyQuery.TierMode` entirely — that pre-existing divergence deserves its own issue rather than a rider here (follow-up filed).
- **`LastOrderRun`/`HasOpenOrderRun`** read `issues`+`labels` only; they currently have no callers outside the store. Same follow-up.

## Gates

- `make test` (full fast suite) — pass
- pre-commit hook: format, `lint-changed`, genspec/genclient/genschema, `go vet ./...`, `make test-fast-parallel`, docsync — pass
- `go test [-tags gascity_native_beads] ./internal/beads/...`, `go test ./internal/api/...`, `go test ./internal/beads/exec/...` — pass
- No wire/API changes; diff is confined to `internal/beads/`, the exec-store wire structs + reference scripts, and one reference doc.

Fixes #3444

🤖 Generated with [Claude Code](https://claude.com/claude-code)