### PR TITLE
Clear session affinity when rerouting work

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1329,6 +1329,9 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		if err := target.storeView.store.SetMetadata(currentSource.ID, beadmeta.RoutedToMetadataKey, nextRoute); err != nil {
 			return err
 		}
+		if err := clearSessionAffinityMetadataOnBead(target.storeView.store, currentSource.ID); err != nil {
+			return err
+		}
 		if err := target.storeView.store.Update(currentSource.ID, beads.UpdateOpts{
 			Status:   &open,
 			Assignee: &unassigned,

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1121,6 +1121,12 @@ func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
 	if err := store.SetMetadata(source.ID, "gc.routed_to", "mayor"); err != nil {
 		t.Fatalf("SetMetadata(gc.routed_to): %v", err)
 	}
+	if err := store.SetMetadata(source.ID, "gc.session_affinity", "require"); err != nil {
+		t.Fatalf("SetMetadata(gc.session_affinity): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "gc.continuation_group", "main"); err != nil {
+		t.Fatalf("SetMetadata(gc.continuation_group): %v", err)
+	}
 
 	var stdout, stderr bytes.Buffer
 	if code := cmdWorkflowReopenSource(source.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 0 {
@@ -1143,6 +1149,12 @@ func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
 	}
 	if got := strings.TrimSpace(updated.Metadata["gc.routed_to"]); got != "" {
 		t.Fatalf("gc.routed_to = %q, want cleared (no gc.run_target → legacy blank)", got)
+	}
+	if got := strings.TrimSpace(updated.Metadata["gc.session_affinity"]); got != "" {
+		t.Fatalf("gc.session_affinity = %q, want cleared with unassigned reopen", got)
+	}
+	if got := strings.TrimSpace(updated.Metadata["gc.continuation_group"]); got != "" {
+		t.Fatalf("gc.continuation_group = %q, want cleared with unassigned reopen", got)
 	}
 	if updated.Status != "open" {
 		t.Fatalf("status = %q, want open", updated.Status)

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -334,9 +334,10 @@ func releaseOrphanedPoolAssignment(store beads.Store, id string, clearDetached b
 	opts := beads.UpdateOpts{
 		Assignee: stringPtr(""),
 		Status:   stringPtr("open"),
+		Metadata: withClearedSessionAffinityMetadata(nil),
 	}
 	if clearDetached {
-		opts.Metadata = map[string]string{detachedProbeMetadataKey: ""}
+		opts.Metadata[detachedProbeMetadataKey] = ""
 	}
 	if err := store.Update(id, opts); err != nil {
 		log.Printf("releaseOrphanedPoolAssignments: releasing orphaned pool assignment %s: %v", id, err)

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1468,6 +1468,62 @@ func TestReleaseOrphanedPoolAssignments_ReopensCrossStoreIDCollisions(t *testing
 	}
 }
 
+func TestReleaseOrphanedPoolAssignments_ClearsSessionAffinityOnRelease(t *testing.T) {
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "orphaned pool work",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{
+			"gc.continuation_group": "main",
+			"gc.routed_to":          "worker",
+			"gc.session_affinity":   "require",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{
+			Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
+		},
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("work = status %q assignee %q, want open/unassigned", got.Status, got.Assignee)
+	}
+	if got.Metadata["gc.session_affinity"] != "" {
+		t.Fatalf("gc.session_affinity still present after release: %#v", got.Metadata)
+	}
+	if got.Metadata["gc.continuation_group"] != "" {
+		t.Fatalf("gc.continuation_group still present after release: %#v", got.Metadata)
+	}
+	if got.Metadata["gc.routed_to"] != "worker" {
+		t.Fatalf("gc.routed_to = %q, want worker", got.Metadata["gc.routed_to"])
+	}
+}
+
 func TestReleaseOrphanedPoolAssignments_SkipsStoreAwareEntryWithoutOwnerStore(t *testing.T) {
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()

--- a/cmd/gc/session_affinity_metadata.go
+++ b/cmd/gc/session_affinity_metadata.go
@@ -1,10 +1,13 @@
 package main
 
-import "github.com/gastownhall/gascity/internal/beads"
+import (
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
 
 var routedWorkSessionAffinityMetadataKeys = []string{
-	"gc.session_affinity",
-	"gc.continuation_group",
+	beadmeta.SessionAffinityMetadataKey,
+	beadmeta.ContinuationGroupMetadataKey,
 }
 
 func withClearedSessionAffinityMetadata(metadata map[string]string) map[string]string {

--- a/cmd/gc/session_affinity_metadata.go
+++ b/cmd/gc/session_affinity_metadata.go
@@ -1,0 +1,27 @@
+package main
+
+import "github.com/gastownhall/gascity/internal/beads"
+
+var routedWorkSessionAffinityMetadataKeys = []string{
+	"gc.session_affinity",
+	"gc.continuation_group",
+}
+
+func withClearedSessionAffinityMetadata(metadata map[string]string) map[string]string {
+	if metadata == nil {
+		metadata = make(map[string]string, len(routedWorkSessionAffinityMetadataKeys))
+	}
+	for _, key := range routedWorkSessionAffinityMetadataKeys {
+		metadata[key] = ""
+	}
+	return metadata
+}
+
+func clearSessionAffinityMetadataOnBead(store beads.Store, beadID string) error {
+	for _, key := range routedWorkSessionAffinityMetadataKeys {
+		if err := store.SetMetadata(beadID, key, ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/gc/session_affinity_metadata.go
+++ b/cmd/gc/session_affinity_metadata.go
@@ -5,23 +5,28 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-var routedWorkSessionAffinityMetadataKeys = []string{
-	beadmeta.SessionAffinityMetadataKey,
-	beadmeta.ContinuationGroupMetadataKey,
-}
-
+// withClearedSessionAffinityMetadata returns metadata with every
+// beadmeta.SessionAffinityMetadataKeys entry set to the empty string,
+// allocating the map when nil. cmd/gc clears affinity by persisting an empty
+// value rather than deleting the key (as internal/dispatch does) because these
+// helpers feed beads.UpdateOpts.Metadata, whose merge only touches supplied
+// keys. Every consumer treats the keys as absent when strings.TrimSpace is
+// empty, so empty-value and deleted are equivalent.
 func withClearedSessionAffinityMetadata(metadata map[string]string) map[string]string {
 	if metadata == nil {
-		metadata = make(map[string]string, len(routedWorkSessionAffinityMetadataKeys))
+		metadata = make(map[string]string, len(beadmeta.SessionAffinityMetadataKeys))
 	}
-	for _, key := range routedWorkSessionAffinityMetadataKeys {
+	for _, key := range beadmeta.SessionAffinityMetadataKeys {
 		metadata[key] = ""
 	}
 	return metadata
 }
 
+// clearSessionAffinityMetadataOnBead persists an empty value for every
+// session-affinity key on beadID. See withClearedSessionAffinityMetadata for
+// why cmd/gc clears by empty value rather than key deletion.
 func clearSessionAffinityMetadataOnBead(store beads.Store, beadID string) error {
-	for _, key := range routedWorkSessionAffinityMetadataKeys {
+	for _, key := range beadmeta.SessionAffinityMetadataKeys {
 		if err := store.SetMetadata(beadID, key, ""); err != nil {
 			return err
 		}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -664,7 +664,16 @@ func unclaimWorkAssignedToRetiredSessionBead(
 						continue
 					}
 					seen[key] = struct{}{}
-					update := beads.UpdateOpts{Assignee: &empty}
+					// The session owning this work is retired, so the work is fully
+					// detached (not preserved to a new assignee). Clear the stale
+					// session-affinity metadata too, or the next claim re-pins the
+					// reopened work onto the dead session's continuation group — the
+					// same stale-affinity bug fixed on the retry, reopen, orphan-pool,
+					// and closed-session release paths.
+					update := beads.UpdateOpts{
+						Assignee: &empty,
+						Metadata: withClearedSessionAffinityMetadata(nil),
+					}
 					// Clearing assignee on an in_progress bead leaves it invisible to
 					// the work_query: Tier 1 needs an assignee match, Tiers 2/3 only
 					// match "ready" status. Reset to "open" so a fresh worker can
@@ -675,7 +684,7 @@ func unclaimWorkAssignedToRetiredSessionBead(
 					if fallbackRoute != "" &&
 						strings.TrimSpace(item.Metadata[beadmeta.RunTargetMetadataKey]) == "" &&
 						strings.TrimSpace(item.Metadata[beadmeta.RoutedToMetadataKey]) == "" {
-						update.Metadata = map[string]string{beadmeta.RunTargetMetadataKey: fallbackRoute}
+						update.Metadata[beadmeta.RunTargetMetadataKey] = fallbackRoute
 					}
 					if err := ownerStore.Update(item.ID, update); err != nil {
 						fmt.Fprintf(stderr, "session beads: unclaiming work %s assigned to retired session %s: %v\n", item.ID, sessionBead.ID, err) //nolint:errcheck
@@ -2359,7 +2368,16 @@ func releaseWorkFromClosedSessionBead(store beads.Store, sessionBead beads.Bead,
 					continue
 				}
 				seenWork[item.ID] = struct{}{}
-				update := beads.UpdateOpts{Assignee: &empty}
+				// The session owning this work is closing, so the work is
+				// fully detached (not preserved to a new assignee). Clear the
+				// stale session-affinity metadata too, or the next claim
+				// re-pins the reopened work onto the dead session's group —
+				// the same stale-affinity bug fixed on the retry, reopen, and
+				// orphan-pool release paths.
+				update := beads.UpdateOpts{
+					Assignee: &empty,
+					Metadata: withClearedSessionAffinityMetadata(nil),
+				}
 				if item.Status == "in_progress" {
 					update.Status = &openStatus
 				}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -4433,6 +4433,61 @@ func TestCloseBeadReleasesWorkAssignedBySessionName(t *testing.T) {
 	}
 }
 
+func TestCloseBeadClearsSessionAffinityOnRelease(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-gm-dead",
+			"template":     "worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:    "shared-drain work",
+		Assignee: "worker-gm-dead",
+		Metadata: map[string]string{
+			"gc.routed_to":          "worker",
+			"gc.continuation_group": "main",
+			"gc.session_affinity":   "require",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: strPtr("in_progress")}); err != nil {
+		t.Fatalf("set work in_progress: %v", err)
+	}
+
+	if !closeBead(store, sessionBead.ID, "orphaned", now, ioDiscard{}) {
+		t.Fatal("closeBead returned false, want true")
+	}
+
+	gotWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if gotWork.Assignee != "" || gotWork.Status != "open" {
+		t.Fatalf("work = assignee %q status %q, want unassigned/open", gotWork.Assignee, gotWork.Status)
+	}
+	if got := strings.TrimSpace(gotWork.Metadata["gc.session_affinity"]); got != "" {
+		t.Errorf("gc.session_affinity = %q, want cleared after closed-session release", got)
+	}
+	if got := strings.TrimSpace(gotWork.Metadata["gc.continuation_group"]); got != "" {
+		t.Errorf("gc.continuation_group = %q, want cleared after closed-session release", got)
+	}
+	if gotWork.Metadata["gc.routed_to"] != "worker" {
+		t.Errorf("gc.routed_to = %q, want preserved as worker for pool redispatch", gotWork.Metadata["gc.routed_to"])
+	}
+}
+
 func TestCloseBeadReleasesWorkAssignedByBeadID(t *testing.T) {
 	store := beads.NewMemStore()
 	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
@@ -7406,6 +7461,69 @@ func TestUnclaimWorkAssignedToRetiredSessionBeadPreservesRunTargetRoute(t *testi
 	}
 	if got.Metadata["gc.routed_to"] != "" {
 		t.Fatalf("gc.routed_to = %q, want empty to preserve gc.run_target as the canonical route", got.Metadata["gc.routed_to"])
+	}
+}
+
+func TestUnclaimWorkAssignedToRetiredSessionBeadClearsSessionAffinity(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	// In-progress work pinned to the retired session via continuation-group
+	// affinity, with no existing route so the fallback run_target applies. The
+	// detach must clear both affinity keys (or the next claim re-vacuums the
+	// reopened bead onto the dead session's group) while still seeding the
+	// fallback route: the affinity clears and the route merge must not clobber
+	// each other.
+	work, err := store.Create(beads.Bead{
+		Title:    "scoped step",
+		Status:   "in_progress",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{
+			"gc.continuation_group": "main",
+			"gc.session_affinity":   "require",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	unclaimWorkAssignedToRetiredSessionBead(store, nil, sessionBead, "fallback/worker", &stderr)
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Assignee != "" {
+		t.Errorf("assignee = %q, want empty", got.Assignee)
+	}
+	if got.Status != "open" {
+		t.Errorf("status = %q, want open", got.Status)
+	}
+	if v := strings.TrimSpace(got.Metadata["gc.session_affinity"]); v != "" {
+		t.Errorf("gc.session_affinity = %q, want cleared after retired-session unclaim", v)
+	}
+	if v := strings.TrimSpace(got.Metadata["gc.continuation_group"]); v != "" {
+		t.Errorf("gc.continuation_group = %q, want cleared after retired-session unclaim", v)
+	}
+	if got.Metadata["gc.run_target"] != "fallback/worker" {
+		t.Errorf("gc.run_target = %q, want fallback/worker applied alongside the affinity clear", got.Metadata["gc.run_target"])
 	}
 }
 

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -331,3 +331,23 @@ var KnownMetadataKeys = []string{
 var KnownMetadataPrefixes = []string{
 	FormulaVarPrefix,
 }
+
+// SessionAffinityMetadataKeys are the metadata keys that pin a work bead to a
+// particular live session through continuation-group routing. They must be
+// cleared together whenever work is rerouted off its original session without a
+// preserved assignee (retry-to-pool, reopen-source, orphan/closed/retired-session
+// release); otherwise a later claim re-vacuums the bead onto an unrelated
+// session via the stale group. Both cmd/gc and internal/dispatch consume this
+// single list so a new affinity key cannot silently fix one clear path while
+// leaving another stale.
+//
+// Of these keys, ContinuationGroupMetadataKey is the active routing vector: the
+// hook claim path reads it to vacuum open, unassigned sibling work onto the
+// claiming session. SessionAffinityMetadataKey is currently an advisory marker —
+// it is written (e.g. internal/dispatch/drain.go) but no Go routing path reads
+// it yet, so it is cleared alongside the group for hygiene and future-proofing
+// rather than because it gates routing today.
+var SessionAffinityMetadataKeys = []string{
+	SessionAffinityMetadataKey,
+	ContinuationGroupMetadataKey,
+}

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -1036,8 +1036,8 @@ func clearSessionAffinityMetadata(meta map[string]string) {
 		return
 	}
 	for _, key := range []string{
-		"gc.session_affinity",
-		"gc.continuation_group",
+		beadmeta.SessionAffinityMetadataKey,
+		beadmeta.ContinuationGroupMetadataKey,
 	} {
 		delete(meta, key)
 	}

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -423,6 +423,10 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 	if controlFor := strings.TrimSpace(subjectMeta[beadmeta.ControlForMetadataKey]); controlFor != "" {
 		subjectMeta[beadmeta.ControlForMetadataKey] = rewriteRetryControlFor(subjectMeta, controlFor, oldScopeRef, newScopeRef, oldAttempt, nextAttempt)
 	}
+	subjectAssignee := retryPreservedAssigneeWithConfig(prevSubject, cfg)
+	if subjectAssignee == "" {
+		clearSessionAffinityMetadata(subjectMeta)
+	}
 	newSubject, err := store.Create(beads.Bead{
 		Title:       prevSubject.Title,
 		Description: prevSubject.Description,
@@ -437,8 +441,8 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 		return nil, err
 	}
 	mapping[prevSubject.ID] = newSubject.ID
-	if preservedAssignee := retryPreservedAssigneeWithConfig(prevSubject, cfg); preservedAssignee != "" {
-		pendingAssignees[prevSubject.ID] = preservedAssignee
+	if subjectAssignee != "" {
+		pendingAssignees[prevSubject.ID] = subjectAssignee
 	}
 
 	for _, old := range ordered {
@@ -456,6 +460,10 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 		if controlFor := strings.TrimSpace(meta[beadmeta.ControlForMetadataKey]); controlFor != "" {
 			meta[beadmeta.ControlForMetadataKey] = rewriteRetryControlFor(meta, controlFor, oldScopeRef, newScopeRef, oldAttempt, nextAttempt)
 		}
+		preservedAssignee := retryPreservedAssigneeWithConfig(old, cfg)
+		if preservedAssignee == "" {
+			clearSessionAffinityMetadata(meta)
+		}
 		created, err := store.Create(beads.Bead{
 			Title:       old.Title,
 			Description: old.Description,
@@ -470,7 +478,7 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 			return nil, err
 		}
 		mapping[old.ID] = created.ID
-		if preservedAssignee := retryPreservedAssigneeWithConfig(old, cfg); preservedAssignee != "" {
+		if preservedAssignee != "" {
 			pendingAssignees[old.ID] = preservedAssignee
 		}
 	}
@@ -484,6 +492,10 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 	checkMeta[beadmeta.StepRefMetadataKey] = rewriteRetryStepRef(checkMeta, prevCheck.Ref, oldScopeRef, newScopeRef, oldAttempt, nextAttempt)
 	if controlFor := strings.TrimSpace(checkMeta[beadmeta.ControlForMetadataKey]); controlFor != "" {
 		checkMeta[beadmeta.ControlForMetadataKey] = rewriteRetryControlFor(checkMeta, controlFor, oldScopeRef, newScopeRef, oldAttempt, nextAttempt)
+	}
+	checkAssignee := retryPreservedAssigneeWithConfig(prevCheck, cfg)
+	if checkAssignee == "" {
+		clearSessionAffinityMetadata(checkMeta)
 	}
 	newCheck, err := store.Create(beads.Bead{
 		Title:       prevCheck.Title,
@@ -499,8 +511,8 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 		return nil, err
 	}
 	mapping[prevCheck.ID] = newCheck.ID
-	if preservedAssignee := retryPreservedAssigneeWithConfig(prevCheck, cfg); preservedAssignee != "" {
-		pendingAssignees[prevCheck.ID] = preservedAssignee
+	if checkAssignee != "" {
+		pendingAssignees[prevCheck.ID] = checkAssignee
 	}
 
 	for _, old := range ordered {
@@ -640,6 +652,9 @@ func buildRalphRetryGraphNode(old beads.Bead, logicalID, oldScopeRef, newScopeRe
 		parentID = ""
 	}
 	assignee := retryPreservedAssigneeWithConfig(old, cfg)
+	if assignee == "" {
+		clearSessionAffinityMetadata(meta)
+	}
 	return beads.GraphApplyNode{
 		Key:               old.ID,
 		Title:             old.Title,
@@ -1011,6 +1026,18 @@ func clearRetryEphemera(meta map[string]string) {
 		"review.verdict",
 		"design_review.verdict",
 		"code_review.verdict",
+	} {
+		delete(meta, key)
+	}
+}
+
+func clearSessionAffinityMetadata(meta map[string]string) {
+	if meta == nil {
+		return
+	}
+	for _, key := range []string{
+		"gc.session_affinity",
+		"gc.continuation_group",
 	} {
 		delete(meta, key)
 	}

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -1035,10 +1035,10 @@ func clearSessionAffinityMetadata(meta map[string]string) {
 	if meta == nil {
 		return
 	}
-	for _, key := range []string{
-		beadmeta.SessionAffinityMetadataKey,
-		beadmeta.ContinuationGroupMetadataKey,
-	} {
+	// Delete (rather than empty-string clear, as cmd/gc does) because this map
+	// is handed to store.Create on the cloned attempt, where an absent key is
+	// the natural representation of "no affinity".
+	for _, key := range beadmeta.SessionAffinityMetadataKeys {
 		delete(meta, key)
 	}
 }

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -542,6 +542,10 @@ func appendRetryAttempt(store beads.Store, logicalID string, prevRun, prevEval b
 func retryAttemptBead(prev beads.Bead, logicalID, stepRef string, attempt int, cityPath string) beads.Bead {
 	meta := cloneMetadata(prev.Metadata)
 	clearRetryEphemera(meta)
+	assignee := retryPreservedAssignee(prev, cityPath)
+	if assignee == "" {
+		clearSessionAffinityMetadata(meta)
+	}
 	meta[beadmeta.AttemptMetadataKey] = strconv.Itoa(attempt)
 	meta[beadmeta.RetryFromMetadataKey] = prev.ID
 	meta[beadmeta.StepRefMetadataKey] = stepRef
@@ -550,7 +554,7 @@ func retryAttemptBead(prev beads.Bead, logicalID, stepRef string, attempt int, c
 		Title:       prev.Title,
 		Description: prev.Description,
 		Type:        prev.Type,
-		Assignee:    retryPreservedAssignee(prev, cityPath),
+		Assignee:    assignee,
 		From:        prev.From,
 		ParentID:    prev.ParentID,
 		Ref:         stepRef,
@@ -562,6 +566,7 @@ func retryAttemptBead(prev beads.Bead, logicalID, stepRef string, attempt int, c
 func retryEvalBead(prev beads.Bead, logicalID, stepRef string, attempt int) beads.Bead {
 	meta := cloneMetadata(prev.Metadata)
 	clearRetryEphemera(meta)
+	clearSessionAffinityMetadata(meta)
 	meta[beadmeta.AttemptMetadataKey] = strconv.Itoa(attempt)
 	meta[beadmeta.RetryFromMetadataKey] = prev.ID
 	meta[beadmeta.StepRefMetadataKey] = stepRef

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -620,16 +620,19 @@ func TestProcessRetryEvalTransientAppendErrorStaysOpenForRetry(t *testing.T) {
 		Type:   "task",
 		Status: "closed",
 		Metadata: map[string]string{
-			"gc.kind":            "retry-run",
-			"gc.root_bead_id":    root.ID,
-			"gc.step_ref":        "demo.review.run.1",
-			"gc.logical_bead_id": logical.ID,
-			"gc.attempt":         "1",
-			"gc.max_attempts":    "3",
-			"gc.on_exhausted":    "hard_fail",
-			"gc.outcome":         "fail",
-			"gc.failure_class":   "transient",
-			"gc.failure_reason":  "rate_limited",
+			"gc.kind":               "retry-run",
+			"gc.root_bead_id":       root.ID,
+			"gc.step_ref":           "demo.review.run.1",
+			"gc.logical_bead_id":    logical.ID,
+			"gc.attempt":            "1",
+			"gc.max_attempts":       "3",
+			"gc.on_exhausted":       "hard_fail",
+			"gc.outcome":            "fail",
+			"gc.failure_class":      "transient",
+			"gc.failure_reason":     "rate_limited",
+			"gc.routed_to":          "polecat",
+			"gc.session_affinity":   "require",
+			"gc.continuation_group": "main",
 		},
 	})
 	eval1 := mustCreateWorkflowBead(t, base, beads.Bead{
@@ -1000,6 +1003,12 @@ func TestProcessRetryEvalTransientRetriesAndRecyclesPoolSession(t *testing.T) {
 	}
 	if run2.Assignee != "" {
 		t.Fatalf("run2 assignee = %q, want empty for pooled retry", run2.Assignee)
+	}
+	if run2.Metadata["gc.session_affinity"] != "" {
+		t.Fatalf("run2 gc.session_affinity = %q, want cleared with pooled retry assignee", run2.Metadata["gc.session_affinity"])
+	}
+	if run2.Metadata["gc.continuation_group"] != "" {
+		t.Fatalf("run2 gc.continuation_group = %q, want cleared with pooled retry assignee", run2.Metadata["gc.continuation_group"])
 	}
 	if got := run2.Metadata["gc.retry_from"]; got != run1.ID {
 		t.Fatalf("run2 gc.retry_from = %q, want %s", got, run1.ID)

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -1025,6 +1025,116 @@ func TestProcessRetryEvalTransientRetriesAndRecyclesPoolSession(t *testing.T) {
 	}
 }
 
+// TestProcessRetryEvalTransientPreservesPinnedSessionAffinity covers the
+// preserve half of the clear/preserve rule: a retry whose previous attempt has
+// a concrete non-pool (pinned) assignee must keep both the assignee and the
+// session-affinity metadata, so shared-drain co-location survives the retry.
+// The pooled counterpart that clears affinity is
+// TestProcessRetryEvalTransientRetriesAndRecyclesPoolSession.
+func TestProcessRetryEvalTransientPreservesPinnedSessionAffinity(t *testing.T) {
+	t.Parallel()
+
+	store := newStrictCloseStore()
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	logical := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "retry",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "demo.review",
+			"gc.max_attempts": "3",
+			"gc.on_exhausted": "hard_fail",
+		},
+	})
+	run1 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:    "review attempt 1",
+		Type:     "task",
+		Status:   "closed",
+		Assignee: "reviewer-mc-7",
+		Metadata: map[string]string{
+			"gc.kind":               "retry-run",
+			"gc.root_bead_id":       root.ID,
+			"gc.step_ref":           "demo.review.run.1",
+			"gc.logical_bead_id":    logical.ID,
+			"gc.attempt":            "1",
+			"gc.max_attempts":       "3",
+			"gc.on_exhausted":       "hard_fail",
+			"gc.outcome":            "fail",
+			"gc.failure_class":      "transient",
+			"gc.failure_reason":     "rate_limited",
+			"gc.continuation_group": "review-fixes",
+			"gc.session_affinity":   "require",
+		},
+	})
+	eval1 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review eval 1",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":            "retry-eval",
+			"gc.root_bead_id":    root.ID,
+			"gc.step_ref":        "demo.review.eval.1",
+			"gc.logical_bead_id": logical.ID,
+			"gc.attempt":         "1",
+			"gc.max_attempts":    "3",
+			"gc.on_exhausted":    "hard_fail",
+		},
+	})
+	mustDepAdd(t, store, logical.ID, eval1.ID, "blocks")
+	mustDepAdd(t, store, eval1.ID, run1.ID, "blocks")
+
+	var recycled []string
+	result, err := ProcessControl(store, eval1, ProcessOptions{
+		RecycleSession: func(subject beads.Bead) error {
+			recycled = append(recycled, subject.Assignee)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ProcessControl(retry-eval transient pinned): %v", err)
+	}
+	if !result.Processed || result.Action != "retry" {
+		t.Fatalf("result = %+v, want processed retry", result)
+	}
+	// A pinned (non-pool) retry stays on its named session, so no recycle fires.
+	if len(recycled) != 0 {
+		t.Fatalf("recycled = %v, want none for pinned retry", recycled)
+	}
+
+	var run2 beads.Bead
+	all, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen(): %v", err)
+	}
+	for _, bead := range all {
+		if bead.Metadata["gc.step_ref"] == "demo.review.run.2" {
+			run2 = bead
+		}
+	}
+	if run2.ID == "" {
+		t.Fatalf("missing retry attempt bead run2")
+	}
+	if run2.Assignee != "reviewer-mc-7" {
+		t.Fatalf("run2 assignee = %q, want preserved reviewer-mc-7", run2.Assignee)
+	}
+	if run2.Metadata["gc.session_affinity"] != "require" {
+		t.Fatalf("run2 gc.session_affinity = %q, want preserved require for pinned retry", run2.Metadata["gc.session_affinity"])
+	}
+	if run2.Metadata["gc.continuation_group"] != "review-fixes" {
+		t.Fatalf("run2 gc.continuation_group = %q, want preserved review-fixes for pinned retry", run2.Metadata["gc.continuation_group"])
+	}
+	if got := run2.Metadata["gc.retry_from"]; got != run1.ID {
+		t.Fatalf("run2 gc.retry_from = %q, want %s", got, run1.ID)
+	}
+}
+
 func TestProcessRetryEvalSoftFailOnExhaustedTransient(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -3967,7 +3967,11 @@ max = -1
 	poolSlot := "polecat-2"
 	if err := store.Update(run1.ID, beads.UpdateOpts{
 		Assignee: &poolSlot,
-		Metadata: map[string]string{"gc.routed_to": "polecat"},
+		Metadata: map[string]string{
+			"gc.continuation_group": "main",
+			"gc.routed_to":          "polecat",
+			"gc.session_affinity":   "require",
+		},
 	}); err != nil {
 		t.Fatalf("assign pooled run1: %v", err)
 	}
@@ -3982,6 +3986,12 @@ max = -1
 	run2 := mustGetBead(t, store, mapping[run1.ID])
 	if run2.Assignee != "" {
 		t.Fatalf("run2 assignee = %q, want empty for pooled retry task", run2.Assignee)
+	}
+	if run2.Metadata["gc.session_affinity"] != "" {
+		t.Fatalf("run2 gc.session_affinity = %q, want cleared with pooled retry assignee", run2.Metadata["gc.session_affinity"])
+	}
+	if run2.Metadata["gc.continuation_group"] != "" {
+		t.Fatalf("run2 gc.continuation_group = %q, want cleared with pooled retry assignee", run2.Metadata["gc.continuation_group"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- clear routed-work session affinity metadata when workflow source beads are reopened unassigned
- clear affinity metadata when orphaned pool work is released for recliaming
- clear affinity metadata from unassigned retry clones while preserving named-session assignment behavior

## Tests
- go test ./internal/dispatch -run 'TestProcessRetryEvalTransientRetriesAndRecyclesPoolSession|TestAppendRalphRetryClearsPoolAssignee'
- GC_FAST_UNIT=1 go test ./cmd/gc -run 'TestReleaseOrphanedPoolAssignments_ClearsSessionAffinityOnRelease|TestCmdWorkflowReopenSourceClearsRoutedToForResling'