### PR TITLE
Bound managed prompt hook commands

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -56,7 +57,83 @@ With --claim: runs the standard startup claim protocol for one work item.
 	if flag := cmd.Flags().Lookup("hook-format"); flag != nil {
 		flag.Hidden = true
 	}
+	cmd.AddCommand(newHookRunCmd(stdout, stderr))
 	return cmd
+}
+
+func newHookRunCmd(stdout, stderr io.Writer) *cobra.Command {
+	opts := hookRunOptions{
+		Timeout:         defaultHookRunTimeout,
+		TimeoutExitCode: 124,
+	}
+	cmd := &cobra.Command{
+		Use:   "run -- <gc args...>",
+		Short: "Run a managed hook command with a hard timeout",
+		Long: `Runs a managed gc hook command in a child process with a hard timeout.
+
+This protects provider hook callbacks from wedged data-plane commands. The
+child process is the current gc executable, and <gc args...> are passed to it
+verbatim.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				fmt.Fprintln(stderr, "gc hook run: missing gc command arguments after --") //nolint:errcheck
+				return errExit
+			}
+			return exitForCode(cmdHookRun(args, opts, stdout, stderr))
+		},
+	}
+	cmd.Flags().DurationVar(&opts.Timeout, "timeout", defaultHookRunTimeout, "hard timeout for the managed hook command")
+	cmd.Flags().IntVar(&opts.TimeoutExitCode, "timeout-exit-code", 124, "exit code to return when the managed hook command times out")
+	return cmd
+}
+
+const defaultHookRunTimeout = 15 * time.Second
+
+type hookRunOptions struct {
+	Timeout         time.Duration
+	TimeoutExitCode int
+}
+
+var hookRunExecutable = os.Executable
+
+func cmdHookRun(args []string, opts hookRunOptions, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "gc hook run: missing gc command arguments") //nolint:errcheck
+		return 1
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = defaultHookRunTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	exe, err := hookRunExecutable()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc hook run: resolving gc executable: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	cmd := exec.CommandContext(ctx, exe, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.WaitDelay = 2 * time.Second
+	prepareProviderOpCommand(cmd)
+
+	err = cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		fmt.Fprintf(stderr, "gc hook run: command timed out after %s\n", timeout) //nolint:errcheck
+		return opts.TimeoutExitCode
+	}
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	fmt.Fprintf(stderr, "gc hook run: %v\n", err) //nolint:errcheck
+	return 1
 }
 
 type hookCommandOptions struct {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -75,12 +75,12 @@ This protects provider hook callbacks from wedged data-plane commands. The
 child process is the current gc executable, and <gc args...> are passed to it
 verbatim.`,
 		Args: cobra.ArbitraryArgs,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				fmt.Fprintln(stderr, "gc hook run: missing gc command arguments after --") //nolint:errcheck
 				return errExit
 			}
-			return exitForCode(cmdHookRun(args, opts, stdout, stderr))
+			return exitForCode(cmdHookRun(args, opts, c.InOrStdin(), stdout, stderr))
 		},
 	}
 	cmd.Flags().DurationVar(&opts.Timeout, "timeout", defaultHookRunTimeout, "hard timeout for the managed hook command")
@@ -97,7 +97,7 @@ type hookRunOptions struct {
 
 var hookRunExecutable = os.Executable
 
-func cmdHookRun(args []string, opts hookRunOptions, stdout, stderr io.Writer) int {
+func cmdHookRun(args []string, opts hookRunOptions, stdin io.Reader, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "gc hook run: missing gc command arguments") //nolint:errcheck
 		return 1
@@ -115,19 +115,38 @@ func cmdHookRun(args []string, opts hookRunOptions, stdout, stderr io.Writer) in
 		return 1
 	}
 	cmd := exec.CommandContext(ctx, exe, args...)
-	cmd.Stdout = stdout
+	// Forward the provider hook stdin so wrapped commands like
+	// `nudge drain --inject` still receive the UserPromptSubmit JSON
+	// (carrying transcript_path) they need for context-pressure injection.
+	// readHookStdin already bounds the read with an io.LimitReader and the
+	// hard timeout below bounds any block, so forwarding is safe.
+	cmd.Stdin = stdin
+	// Buffer child stdout instead of streaming it straight to the provider so
+	// a wedged command cannot leak partial injectable output before the
+	// fail-open timeout path runs. The buffer is flushed only on a clean or
+	// self-determined exit, and discarded on timeout.
+	var childOut bytes.Buffer
+	cmd.Stdout = &childOut
 	cmd.Stderr = stderr
 	cmd.WaitDelay = 2 * time.Second
 	prepareProviderOpCommand(cmd)
 
 	err = cmd.Run()
+	// A clean exit wins even if the deadline fired in the same instant: the
+	// child finished and produced complete output, so report success and flush.
+	if err == nil {
+		_, _ = stdout.Write(childOut.Bytes()) //nolint:errcheck
+		return 0
+	}
 	if ctx.Err() == context.DeadlineExceeded {
+		// Timed out: the child was killed mid-flight, so any buffered output is
+		// partial. Discard it and return the configured fail-open code.
 		fmt.Fprintf(stderr, "gc hook run: command timed out after %s\n", timeout) //nolint:errcheck
 		return opts.TimeoutExitCode
 	}
-	if err == nil {
-		return 0
-	}
+	// The child exited on its own with a non-zero status: its output is
+	// complete, so preserve it and propagate the exit code.
+	_, _ = stdout.Write(childOut.Bytes()) //nolint:errcheck
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		return exitErr.ExitCode()

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -19,6 +19,15 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 )
 
+func setHookRunExecutableForTest(t *testing.T, path string) func() {
+	t.Helper()
+	previous := hookRunExecutable
+	hookRunExecutable = func() (string, error) { return path, nil }
+	restore := func() { hookRunExecutable = previous }
+	t.Cleanup(restore)
+	return restore
+}
+
 func TestNewHookCmdUsesRoutedWorkHelp(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	cmd := newHookCmd(&stdout, &stderr)
@@ -589,6 +598,53 @@ func TestHookInjectDoesNotRunWorkQuery(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Errorf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestHookRunTimesOutAndFailsOpenWhenConfigured(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	restore := setHookRunExecutableForTest(t, "sh")
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	code := cmdHookRun([]string{"-c", "sleep 10"}, hookRunOptions{
+		Timeout:         50 * time.Millisecond,
+		TimeoutExitCode: 0,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHookRun timeout code = %d, want fail-open 0; stderr=%s", code, stderr.String())
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("cmdHookRun timeout took %s, want bounded below provider hook timeout", elapsed)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "timed out after 50ms") {
+		t.Fatalf("stderr = %q, want timeout diagnostic", stderr.String())
+	}
+}
+
+func TestHookRunPreservesChildExitCodeAndOutput(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	restore := setHookRunExecutableForTest(t, "sh")
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHookRun([]string{"-c", "printf ok; exit 7"}, hookRunOptions{
+		Timeout:         time.Second,
+		TimeoutExitCode: 124,
+	}, &stdout, &stderr)
+	if code != 7 {
+		t.Fatalf("cmdHookRun code = %d, want child exit 7; stderr=%s", code, stderr.String())
+	}
+	if stdout.String() != "ok" {
+		t.Fatalf("stdout = %q, want ok", stdout.String())
 	}
 }
 

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -19,10 +19,13 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 )
 
-func setHookRunExecutableForTest(t *testing.T, path string) func() {
+// setHookRunExecutableForTest stubs the re-exec target of `gc hook run` to the
+// shell so tests can drive the wrapper with `sh -c` scripts instead of the real
+// gc binary. The stub is restored on cleanup.
+func setHookRunExecutableForTest(t *testing.T) func() {
 	t.Helper()
 	previous := hookRunExecutable
-	hookRunExecutable = func() (string, error) { return path, nil }
+	hookRunExecutable = func() (string, error) { return "sh", nil }
 	restore := func() { hookRunExecutable = previous }
 	t.Cleanup(restore)
 	return restore
@@ -605,7 +608,7 @@ func TestHookRunTimesOutAndFailsOpenWhenConfigured(t *testing.T) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh not available")
 	}
-	restore := setHookRunExecutableForTest(t, "sh")
+	restore := setHookRunExecutableForTest(t)
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
@@ -613,7 +616,7 @@ func TestHookRunTimesOutAndFailsOpenWhenConfigured(t *testing.T) {
 	code := cmdHookRun([]string{"-c", "sleep 10"}, hookRunOptions{
 		Timeout:         50 * time.Millisecond,
 		TimeoutExitCode: 0,
-	}, &stdout, &stderr)
+	}, nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHookRun timeout code = %d, want fail-open 0; stderr=%s", code, stderr.String())
 	}
@@ -632,19 +635,98 @@ func TestHookRunPreservesChildExitCodeAndOutput(t *testing.T) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh not available")
 	}
-	restore := setHookRunExecutableForTest(t, "sh")
+	restore := setHookRunExecutableForTest(t)
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := cmdHookRun([]string{"-c", "printf ok; exit 7"}, hookRunOptions{
 		Timeout:         time.Second,
 		TimeoutExitCode: 124,
-	}, &stdout, &stderr)
+	}, nil, &stdout, &stderr)
 	if code != 7 {
 		t.Fatalf("cmdHookRun code = %d, want child exit 7; stderr=%s", code, stderr.String())
 	}
 	if stdout.String() != "ok" {
 		t.Fatalf("stdout = %q, want ok", stdout.String())
+	}
+}
+
+// TestHookRunForwardsStdinToChild guards the regression where `gc hook run`
+// left cmd.Stdin nil, so wrapped commands such as `nudge drain --inject` saw
+// /dev/null instead of the provider UserPromptSubmit JSON and silently dropped
+// context-pressure injection. The child here echoes its stdin; the wrapper must
+// forward the piped input through to it.
+func TestHookRunForwardsStdinToChild(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	restore := setHookRunExecutableForTest(t)
+	defer restore()
+
+	const payload = `{"transcript_path":"/tmp/transcript.jsonl"}`
+	var stdout, stderr bytes.Buffer
+	code := cmdHookRun([]string{"-c", "cat"}, hookRunOptions{
+		Timeout:         time.Second,
+		TimeoutExitCode: 124,
+	}, strings.NewReader(payload), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHookRun code = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if stdout.String() != payload {
+		t.Fatalf("child stdin not forwarded: stdout = %q, want %q", stdout.String(), payload)
+	}
+}
+
+// TestHookRunDiscardsPartialStdoutOnTimeout guards the fail-open contract: a
+// child that prints partial injectable output and then wedges past the timeout
+// must not leak that partial output to the provider. The wrapper buffers child
+// stdout and discards it when the deadline fires.
+func TestHookRunDiscardsPartialStdoutOnTimeout(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	restore := setHookRunExecutableForTest(t)
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHookRun([]string{"-c", "printf partial; sleep 10"}, hookRunOptions{
+		Timeout:         50 * time.Millisecond,
+		TimeoutExitCode: 0,
+	}, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHookRun timeout code = %d, want fail-open 0; stderr=%s", code, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("partial stdout leaked on timeout: stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "timed out after 50ms") {
+		t.Fatalf("stderr = %q, want timeout diagnostic", stderr.String())
+	}
+}
+
+// TestHookRunCommandForwardsStdinAndArgsAfterDoubleDash exercises the full
+// production wiring through the real Cobra command: flags before `--` are
+// parsed by `gc hook run`, the args after `--` reach the wrapped child
+// verbatim, and the command's stdin (defaulting to os.Stdin in production,
+// injected here via SetIn) is forwarded to the child. The child echoes its
+// stdin, so a passthrough failure shows up as empty stdout.
+func TestHookRunCommandForwardsStdinAndArgsAfterDoubleDash(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	restore := setHookRunExecutableForTest(t)
+	defer restore()
+
+	const payload = `{"transcript_path":"/tmp/transcript.jsonl"}`
+	var stdout, stderr bytes.Buffer
+	cmd := newHookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"run", "--timeout", "5s", "--timeout-exit-code", "0", "--", "-c", "cat"})
+	cmd.SetIn(strings.NewReader(payload))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc hook run failed: %v; stderr=%s", err, stderr.String())
+	}
+	if stdout.String() != payload {
+		t.Fatalf("cobra hook run did not forward stdin through `--`: stdout = %q, want %q", stdout.String(), payload)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1566,6 +1566,27 @@ gc hook [agent] [flags]
 | `--inject` | bool |  | silent legacy Stop-hook compatibility; skip work query and exit 0 |
 | `--json` | bool |  | with --claim, emit a JSON protocol result |
 
+| Subcommand | Description |
+|------------|-------------|
+| [gc hook run](#gc-hook-run) | Run a managed hook command with a hard timeout |
+
+## gc hook run
+
+Runs a managed gc hook command in a child process with a hard timeout.
+
+This protects provider hook callbacks from wedged data-plane commands. The
+child process is the current gc executable, and &lt;gc args...&gt; are passed to it
+verbatim.
+
+```
+gc hook run -- <gc args...> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--timeout` | duration | `15s` | hard timeout for the managed hook command |
+| `--timeout-exit-code` | int | `124` | exit code to return when the managed hook command times out |
+
 ## gc import
 
 Manage pack imports

--- a/internal/bootstrap/packs/core/overlay/per-provider/antigravity/.agents/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/antigravity/.agents/hooks.json
@@ -12,7 +12,7 @@
     "PreInvocation": [
       {
         "type": "command",
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\" && gc nudge drain --inject --hook-format antigravity",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format antigravity",
         "timeout": 30
       }
     ]
@@ -21,7 +21,7 @@
     "PreInvocation": [
       {
         "type": "command",
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\" && gc mail check --inject --hook-format antigravity",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format antigravity",
         "timeout": 30
       }
     ]

--- a/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
@@ -28,11 +28,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc nudge drain --inject --hook-format codex"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format codex"
           },
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject --hook-format codex"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format codex"
           }
         ]
       }

--- a/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json
@@ -19,12 +19,12 @@
       {
         "type": "command",
         "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject",
-        "timeoutSec": 10
+        "timeoutSec": 30
       },
       {
         "type": "command",
         "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject",
-        "timeoutSec": 10
+        "timeoutSec": 30
       }
     ]
   }

--- a/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json
@@ -18,12 +18,12 @@
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc nudge drain --inject",
+        "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject",
         "timeoutSec": 10
       },
       {
         "type": "command",
-        "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject",
+        "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject",
         "timeoutSec": 10
       }
     ]

--- a/internal/bootstrap/packs/core/overlay/per-provider/cursor/.cursor/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/cursor/.cursor/hooks.json
@@ -13,10 +13,10 @@
     ],
     "beforeSubmitPrompt": [
       {
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc nudge drain --inject"
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject"
       },
       {
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject"
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject"
       }
     ]
   }

--- a/internal/bootstrap/packs/core/overlay/per-provider/gemini/.gemini/settings.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/gemini/.gemini/settings.json
@@ -33,11 +33,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "gc nudge drain --inject --hook-format gemini"
+            "command": "gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format gemini"
           },
           {
             "type": "command",
-            "command": "gc mail check --inject --hook-format gemini"
+            "command": "gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format gemini"
           }
         ]
       }

--- a/internal/bootstrap/packs/core/overlay/per-provider/kiro/.kiro/agents/gascity.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/kiro/.kiro/agents/gascity.json
@@ -11,10 +11,10 @@
     ],
     "userPromptSubmit": [
       {
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc nudge drain --inject"
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject"
       },
       {
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject"
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject"
       }
     ]
   }

--- a/internal/hooks/config/README.md
+++ b/internal/hooks/config/README.md
@@ -1,8 +1,9 @@
 # Hook Event Vocabulary
 
 Gas City wires per-provider hook configs into a small set of coordination
-commands (`gc prime --hook`, `gc handoff --auto`, `gc nudge drain --inject`,
-`gc mail check --inject`). Each provider names its hook events differently;
+commands (`gc prime --hook`, `gc handoff --auto`, and prompt-submit
+`gc hook run --timeout 15s --timeout-exit-code 0 -- ...` wrappers around
+`gc nudge drain --inject` / `gc mail check --inject`). Each provider names its hook events differently;
 this document maps Gas City's canonical events to the provider's native
 name for each, plus where the wiring lives on disk.
 
@@ -41,9 +42,10 @@ For each provider where a row above is ✓, the wired command is one of:
 - **session start** → `gc prime --hook` (loads context, drains hooks).
 - **pre-compaction** → `gc handoff --auto "context cycle"` (capture state
   before the provider compacts the conversation).
-- **user prompt submit** / **before agent run** → `gc nudge drain --inject`
-  and/or `gc mail check --inject` (inject pending agent-to-agent messages
-  into the upcoming prompt).
+- **user prompt submit** / **before agent run** → bounded `gc hook run`
+  wrappers around `gc nudge drain --inject` and/or `gc mail check --inject`
+  (inject pending agent-to-agent messages into the upcoming prompt without
+  letting a wedged data-plane command block the provider hook).
 
 Some providers fold both injection commands into a single hook entry;
 others split them. The exact wiring lives in the per-provider config —

--- a/internal/hooks/config/claude.json
+++ b/internal/hooks/config/claude.json
@@ -31,11 +31,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc nudge drain --inject"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject"
           },
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject"
           }
         ]
       }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -770,12 +770,36 @@ func upgradeCodexHookCommand(command string) (string, bool) {
 		prefix := strings.TrimSuffix(command, body)
 		return prefix + sessionStartCurrentFormBody, true
 	}
+	if upgraded, ok := upgradeManagedPromptHookCommand(command, "codex"); ok {
+		return upgraded, true
+	}
 	if strings.Contains(command, `--hook-format codex`) {
 		return "", false
 	}
 	for _, needle := range codexManagedHookCommandNeedles {
 		if strings.Contains(command, needle) {
 			return strings.Replace(command, needle, needle+` --hook-format codex`, 1), true
+		}
+	}
+	return "", false
+}
+
+const managedPromptHookRunPrefix = `gc hook run --timeout 15s --timeout-exit-code 0 -- `
+
+func upgradeManagedPromptHookCommand(command, hookFormat string) (string, bool) {
+	body := commandBodyAfterCanonicalPrefix(command)
+	for _, base := range []string{
+		`gc nudge drain --inject`,
+		`gc mail check --inject`,
+	} {
+		if equalsLegacyCommandBody(body, base) ||
+			(hookFormat != "" && equalsLegacyCommandBody(body, base+` --hook-format `+hookFormat)) {
+			target := strings.TrimPrefix(base, `gc `)
+			if hookFormat != "" {
+				target += ` --hook-format ` + hookFormat
+			}
+			prefix := strings.TrimSuffix(command, body)
+			return prefix + managedPromptHookRunPrefix + target, true
 		}
 	}
 	return "", false
@@ -1047,6 +1071,10 @@ func isLegacyGCManagedCommand(event, command string) bool {
 			equalsLegacyCommandBody(body, "gc prime --hook --hook-format codex") ||
 			equalsLegacyCommandBody(body, sessionStartPreviousManagedFormBody) ||
 			equalsLegacyCommandBody(body, sessionStartCurrentFormBody)
+	case "UserPromptSubmit":
+		return equalsLegacyCommandBody(body, `gc nudge drain --inject`) ||
+			equalsLegacyCommandBody(body, `gc mail check --inject`) ||
+			strings.HasPrefix(body, managedPromptHookRunPrefix)
 	}
 	return false
 }
@@ -1117,6 +1145,8 @@ func upgradeClaudeHookCommand(event, command string) (string, bool) {
 			prefix := strings.TrimSuffix(command, body)
 			return prefix + sessionStartCurrentFormBody, true
 		}
+	case "UserPromptSubmit":
+		return upgradeManagedPromptHookCommand(command, "")
 	}
 	return "", false
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -143,8 +143,11 @@ func TestInstallClaude(t *testing.T) {
 	if !strings.Contains(claudeHookCommand(t, runtimeData, "PreCompact"), `gc handoff --auto "context cycle"`) {
 		t.Error("claude PreCompact hook should use gc handoff --auto (not gc prime or restart handoff) on compaction")
 	}
-	if !strings.Contains(s, "gc nudge drain --inject") {
-		t.Error("claude settings should contain gc nudge drain --inject")
+	if !strings.Contains(s, "gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject") {
+		t.Error("claude settings should run nudge drain through gc hook run")
+	}
+	if !strings.Contains(s, "gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject") {
+		t.Error("claude settings should run mail check through gc hook run")
 	}
 	if strings.Contains(s, "gc hook --inject") {
 		t.Error("fresh claude settings should not install no-op gc hook --inject")
@@ -400,6 +403,9 @@ func TestInstallCodexUpgradesManagedFileMissingPreCompact(t *testing.T) {
 	}
 	if !strings.Contains(got, `gc handoff --auto --hook-format codex \"context cycle\"`) {
 		t.Errorf("upgraded codex PreCompact missing auto handoff command:\n%s", got)
+	}
+	if !strings.Contains(got, `gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format codex`) {
+		t.Errorf("upgraded codex UserPromptSubmit missing bounded mail check command:\n%s", got)
 	}
 }
 
@@ -1478,6 +1484,44 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	if !strings.Contains(codexHooksText, `gc handoff --auto --hook-format codex \"context cycle\"`) {
 		t.Error("codex PreCompact should use auto handoff with Codex hook output format")
 	}
+	for _, want := range []string{
+		`gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format codex`,
+		`gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format codex`,
+	} {
+		if !strings.Contains(codexHooksText, want) {
+			t.Errorf("codex prompt hooks missing bounded command %q:\n%s", want, codexHooksText)
+		}
+	}
+	geminiHooks := string(fs.Files["/work/.gemini/settings.json"])
+	for _, want := range []string{
+		`gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format gemini`,
+		`gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format gemini`,
+	} {
+		if !strings.Contains(geminiHooks, want) {
+			t.Errorf("gemini prompt hooks missing bounded command %q:\n%s", want, geminiHooks)
+		}
+	}
+	for path, wants := range map[string][]string{
+		"/work/.github/hooks/gascity.json": {
+			`gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject`,
+			`gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject`,
+		},
+		"/work/.cursor/hooks.json": {
+			`gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject`,
+			`gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject`,
+		},
+		"/work/.kiro/agents/gascity.json": {
+			`gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject`,
+			`gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject`,
+		},
+	} {
+		data := string(fs.Files[path])
+		for _, want := range wants {
+			if !strings.Contains(data, want) {
+				t.Errorf("%s prompt hooks missing bounded command %q:\n%s", path, want, data)
+			}
+		}
+	}
 	// Copilot CLI documents preCompact (camelCase). The hook fires before
 	// context compaction starts so handoff can capture state; without it,
 	// long Copilot sessions silently lose context at compact boundaries.
@@ -1492,8 +1536,8 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	antigravityHooks := string(fs.Files["/work/.agents/hooks.json"])
 	for hookName, wantCommand := range map[string]string{
 		"gascity-prime":       `GC_PROVIDER_SESSION_ID_REQUIRED=antigravity GC_PROVIDER_SESSION_ID=\"${ANTIGRAVITY_CONVERSATION_ID:-}\" GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format antigravity`,
-		"gascity-nudge-drain": "gc nudge drain --inject --hook-format antigravity",
-		"gascity-mail-check":  "gc mail check --inject --hook-format antigravity",
+		"gascity-nudge-drain": "gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format antigravity",
+		"gascity-mail-check":  "gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format antigravity",
 	} {
 		if !strings.Contains(antigravityHooks, `"`+hookName+`"`) {
 			t.Errorf("Antigravity hooks missing hook %q:\n%s", hookName, antigravityHooks)
@@ -1663,6 +1707,8 @@ func TestInstallAntigravityMergesExistingHooks(t *testing.T) {
 		`"command": "echo custom"`,
 		`"gascity-prime"`,
 		`gc prime --hook --hook-format antigravity`,
+		`gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format antigravity`,
+		`gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format antigravity`,
 	} {
 		if !strings.Contains(data, want) {
 			t.Errorf("merged Antigravity hooks missing %q:\n%s", want, data)

--- a/test/packlint/managed_prompt_hook_timeout_test.go
+++ b/test/packlint/managed_prompt_hook_timeout_test.go
@@ -1,0 +1,169 @@
+// TestManagedPromptHookTimeoutExceedsWrapper guards gastownhall/gascity#3457:
+// managed prompt hooks are wrapped in `gc hook run --timeout <d> --timeout-exit-code 0`
+// so a wedged data-plane command fails open before it can block prompt
+// submission. That only works if the provider's own per-hook timeout is long
+// enough for the wrapper to reach its fail-open path. Copilot shipped a 10s
+// provider timeout under a 15s wrapper, so the provider killed the hook 5s
+// before the bound ever fired — the exact behavior the wrapper exists to
+// prevent. This test fails if any shipped pack pairs a wrapper command with a
+// sibling provider timeout (`timeoutSec` or Antigravity's `timeout`) that does
+// not clear the wrapper timeout plus cleanup headroom.
+
+package packlint
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// managedHookWrapperWaitDelay mirrors cmd.WaitDelay in cmd/gc/cmd_hook.go: after
+// the wrapper's deadline fires it can take up to this long to SIGKILL the child
+// process group and drain its pipes before returning the fail-open exit code.
+// A provider timeout must clear the wrapper timeout by at least this margin or
+// the provider can abandon the hook before the fail-open code is returned.
+const managedHookWrapperWaitDelay = 2 * time.Second
+
+// managedWrapperMarker identifies a `gc hook run` wrapper command body within a
+// shipped hook config string.
+const managedWrapperMarker = "gc hook run --timeout"
+
+func TestManagedPromptHookTimeoutExceedsWrapper(t *testing.T) {
+	root := repoRoot()
+	packsDir := filepath.Join(root, "internal/bootstrap/packs")
+
+	var violations []string
+	checked := 0
+	checkedFiles := map[string]int{}
+	err := filepath.WalkDir(packsDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		if !strings.Contains(string(data), managedWrapperMarker) {
+			return nil
+		}
+		var doc any
+		if err := json.Unmarshal(data, &doc); err != nil {
+			// A pack JSON we cannot parse is a separate problem; skip it here so
+			// this invariant stays focused on the timeout relationship.
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		walkHookTimeoutNodes(doc, func(wrapperCmd string, providerTimeoutSec float64) {
+			checked++
+			checkedFiles[filepath.ToSlash(rel)]++
+			wrapperTimeout, ok := wrapperHookTimeout(wrapperCmd)
+			if !ok {
+				violations = append(violations, fmt.Sprintf(
+					"%s: could not parse wrapper --timeout from %q", filepath.ToSlash(rel), wrapperCmd))
+				return
+			}
+			providerTimeout := time.Duration(providerTimeoutSec * float64(time.Second))
+			minProvider := wrapperTimeout + managedHookWrapperWaitDelay
+			if providerTimeout < minProvider {
+				violations = append(violations, fmt.Sprintf(
+					"%s: provider hook timeout %v is below wrapper timeout %s + %s cleanup headroom (need >= %s)",
+					filepath.ToSlash(rel), providerTimeout, wrapperTimeout, managedHookWrapperWaitDelay, minProvider))
+			}
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", packsDir, err)
+	}
+	if checked == 0 {
+		t.Fatalf("no wrapper command with a sibling provider timeout found under %s; "+
+			"the invariant is no longer exercised — update the walker", packsDir)
+	}
+	// Antigravity ships the same wrapped prompt hooks as Copilot but pins the
+	// provider timeout under the key "timeout" rather than "timeoutSec". Guard
+	// against a regression where the walker stops matching that key and silently
+	// drops Antigravity from the invariant (gastownhall/gascity#3457).
+	const antigravityHooks = "internal/bootstrap/packs/core/overlay/per-provider/antigravity/.agents/hooks.json"
+	if checkedFiles[antigravityHooks] == 0 {
+		t.Errorf("timeout-headroom invariant did not check any wrapped prompt hook in %s; "+
+			"walkHookTimeoutNodes likely stopped matching the \"timeout\" sibling key", antigravityHooks)
+	}
+	if len(violations) > 0 {
+		t.Errorf("managed prompt hook provider timeout(s) below the wrapper fail-open budget"+
+			" (gastownhall/gascity#3457).\nRaise the provider timeoutSec above the `gc hook run"+
+			" --timeout` value plus cleanup headroom, or lower the wrapper timeout below the"+
+			" smallest provider timeout.\n\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+// walkHookTimeoutNodes invokes fn for every JSON object that contains both a
+// string field holding a `gc hook run` wrapper command and a sibling numeric
+// provider timeout. Providers spell that sibling differently: most use
+// `timeoutSec` (Copilot), while Antigravity uses `timeout`, so the walker
+// checks `timeoutSec` first and falls back to `timeout`. Known limit: a
+// provider that declares the timeout on a parent object rather than as a
+// sibling of the command is not matched; the shipped configs that pin a hook
+// timeout place it as a sibling.
+func walkHookTimeoutNodes(node any, fn func(wrapperCmd string, providerTimeoutSec float64)) {
+	switch v := node.(type) {
+	case map[string]any:
+		wrapperCmd := ""
+		for _, val := range v {
+			if s, ok := val.(string); ok && strings.Contains(s, managedWrapperMarker) {
+				wrapperCmd = s
+				break
+			}
+		}
+		if wrapperCmd != "" {
+			if sec, ok := numericField(v["timeoutSec"]); ok {
+				fn(wrapperCmd, sec)
+			} else if sec, ok := numericField(v["timeout"]); ok {
+				fn(wrapperCmd, sec)
+			}
+		}
+		for _, val := range v {
+			walkHookTimeoutNodes(val, fn)
+		}
+	case []any:
+		for _, item := range v {
+			walkHookTimeoutNodes(item, fn)
+		}
+	}
+}
+
+// numericField coerces a JSON-decoded value to a float64 second count.
+func numericField(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+// wrapperHookTimeout extracts the duration that follows the wrapper's
+// `--timeout` flag (not `--timeout-exit-code`) from a hook command string.
+func wrapperHookTimeout(command string) (time.Duration, bool) {
+	fields := strings.Fields(command)
+	for i, f := range fields {
+		if f == "--timeout" && i+1 < len(fields) {
+			d, err := time.ParseDuration(fields[i+1])
+			if err != nil {
+				return 0, false
+			}
+			return d, true
+		}
+	}
+	return 0, false
+}


### PR DESCRIPTION
## Summary
- add gc hook run wrapper with a hard timeout for managed hook child commands
- route managed prompt-submit nudge/mail hooks through the wrapper across provider templates
- upgrade stale managed Claude/Codex prompt-hook commands and update CLI docs

## Tests
- go test ./cmd/gc -run 'TestGeneratedCLIReferenceCoversCommandTree|TestGeneratedCLIReferenceHasNoStaleSections|TestHookRunTimesOutAndFailsOpenWhenConfigured|TestHookRunPreservesChildExitCodeAndOutput'
- go test ./internal/hooks -run 'TestInstallClaude|TestInstallCodexUpgradesGeneratedFileMissingHookFormat|TestInstallCodexUpgradesManagedFileMissingPreCompact|TestInstallOverlayManagedProviders|TestInstallAntigravityMergesExistingHooks'
- go test ./cmd/gc ./internal/hooks
- git diff --check