### PR TITLE
fix(supervisor): don't orphan-release a live pending pool claim

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2049,7 +2049,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	assignedWorkBeads := result.AssignedWorkBeads
 	assignedWorkStoreRefs := result.AssignedWorkStoreRefs
 	phaseStart := time.Now()
-	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, cr.cfg, cr.cityPath, sessionBeads.Open(), result, rigStores)
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, cr.cfg, cr.cityPath, sessionBeads.Open(), result, rigStores, cr.sp, clock.Real{})
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments", phaseStart, map[string]any{
 		"released_count": len(released),
 	})

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -877,7 +877,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	)
 
 	open := sessionBeads.Open()
-	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, cfg, cityPath, open, dsResult, rigStores); len(released) > 0 {
+	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, cfg, cityPath, open, dsResult, rigStores, sp, clock.Real{}); len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -635,6 +635,8 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 			StoreQueryPartial:  true,
 		},
 		nil,
+		nil,
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %d work bead(s) from a partial snapshot, want none", len(released))
@@ -658,6 +660,8 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 			SessionQueryPartial: true,
 		},
 		nil,
+		nil,
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %d work bead(s) from a partial session snapshot, want none", len(released))
@@ -679,6 +683,8 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 			AssignedWorkBeads:  []beads.Bead{work},
 			AssignedWorkStores: []beads.Store{store},
 		},
+		nil,
+		nil,
 		nil,
 	)
 	if len(released) != 1 {

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -9,10 +9,19 @@ import (
 
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sling"
 )
+
+// orphanReleasePendingBackstop bounds how long the pending-interactive guard
+// (#3453) defers orphan release. A holder parked on an interactive prompt keeps
+// its claim, but a pane stuck pending forever (a true zombie that never gets
+// input) is released once the hold is older than this, so abandoned work still
+// recovers.
+const orphanReleasePendingBackstop = 3 * time.Hour
 
 // sessionBeadAssigneeIdentities returns every identifier under which a work
 // bead could be assigned to this session: the session bead ID, session_name,
@@ -86,6 +95,8 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	openSessionBeads []beads.Bead,
 	result DesiredStateResult,
 	rigStores map[string]beads.Store,
+	sp runtime.Provider,
+	clk clock.Clock,
 ) []releasedPoolAssignment {
 	// Partial input snapshots can make active work look orphaned for this
 	// tick only: missing work affects drain decisions, and missing sessions
@@ -93,13 +104,18 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	if result.snapshotQueryPartial() {
 		return nil
 	}
-	return releaseOrphanedPoolAssignments(store, cfg, cityPath, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores)
+	return releaseOrphanedPoolAssignmentsWithProvider(store, cfg, cityPath, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores, sp, clk)
 }
 
 // releaseOrphanedPoolAssignments reopens active pool-routed work whose
 // assignee no longer maps to any open session bead. This also recovers
 // pool-routed work left in_progress with no assignee, which cannot be claimed
 // again until it is moved back to open.
+//
+// This nil-provider entry preserves the original behavior (the
+// pending-interactive backstop is disabled without a runtime provider). The
+// daemon path threads a real provider + clock via
+// releaseOrphanedPoolAssignmentsWithProvider.
 func releaseOrphanedPoolAssignments(
 	store beads.Store,
 	cfg *config.City,
@@ -109,6 +125,27 @@ func releaseOrphanedPoolAssignments(
 	assignedWorkStores []beads.Store,
 	assignedWorkStoreRefs []string,
 	rigStores map[string]beads.Store,
+) []releasedPoolAssignment {
+	return releaseOrphanedPoolAssignmentsWithProvider(store, cfg, cityPath, openSessionBeads, assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, rigStores, nil, nil)
+}
+
+// releaseOrphanedPoolAssignmentsWithProvider is releaseOrphanedPoolAssignments
+// with the pending-interactive backstop (#3453): when sp is non-nil it skips
+// release for a holder whose pane is still alive and parked on an interactive
+// prompt (within orphanReleasePendingBackstop), so a transiently-unowned claim
+// is not cleared out from under a live, intentionally-waiting session — which
+// would let demand reappear and spawn a duplicate worker on the same bead.
+func releaseOrphanedPoolAssignmentsWithProvider(
+	store beads.Store,
+	cfg *config.City,
+	cityPath string,
+	openSessionBeads []beads.Bead,
+	assignedWorkBeads []beads.Bead,
+	assignedWorkStores []beads.Store,
+	assignedWorkStoreRefs []string,
+	rigStores map[string]beads.Store,
+	sp runtime.Provider,
+	clk clock.Clock,
 ) []releasedPoolAssignment {
 	if store == nil || cfg == nil || len(assignedWorkBeads) == 0 {
 		return nil
@@ -124,12 +161,16 @@ func releaseOrphanedPoolAssignments(
 
 	openIdentifiers := makeOpenSessionStoreRefIndex(cityPath, cfg, openSessionBeads, storeRefAware)
 	legacyOpenIdentifiers := make(map[string]struct{}, len(openSessionBeads)*5)
+	openSessionByIdentity := make(map[string]beads.Bead, len(openSessionBeads)*5)
 	for _, sb := range openSessionBeads {
 		if sb.Status == "closed" {
 			continue
 		}
 		for _, id := range sessionBeadAssigneeIdentities(sb) {
 			legacyOpenIdentifiers[id] = struct{}{}
+			if _, exists := openSessionByIdentity[id]; !exists {
+				openSessionByIdentity[id] = sb
+			}
 		}
 	}
 
@@ -163,6 +204,16 @@ func releaseOrphanedPoolAssignments(
 				continue
 			}
 			if liveOpenSessionAssignmentExists(store, assignee) {
+				continue
+			}
+			// Pending-interactive backstop (#3453): the ownership/liveness
+			// checks above can transiently miss a holder whose pane is alive but
+			// parked on an interactive prompt (e.g. store-ref-scoped
+			// openSessionOwnsWork=false, or a label-lost session bead). Confirm
+			// with the runtime provider before clearing the claim — releasing a
+			// live, intentionally-waiting holder lets demand reappear and spawns
+			// a duplicate worker on the same bead.
+			if pendingInteractiveHolderBlocksRelease(openSessionByIdentity, assignee, sp, clk) {
 				continue
 			}
 		}
@@ -464,6 +515,50 @@ func assigneePreservesNamedSessionRoute(cfg *config.City, cityPath, template, as
 		return true
 	}
 	return assignedWorkStoreRefForAgent(cityPath, cfg, spec.Agent) == workStoreRef
+}
+
+// pendingInteractiveHolderBlocksRelease reports whether the open-session holder
+// of this assignee is alive and parked on an interactive prompt, within the
+// orphanReleasePendingBackstop window. A nil provider disables the backstop
+// (pendingInteractionKeepsAwake returns false), preserving the original release
+// behavior. The runtime probe is authoritative about liveness: a genuinely dead
+// pane reports not-pending and is released as before.
+func pendingInteractiveHolderBlocksRelease(openSessionByIdentity map[string]beads.Bead, assignee string, sp runtime.Provider, clk clock.Clock) bool {
+	holder, ok := openSessionByIdentity[strings.TrimSpace(assignee)]
+	if !ok {
+		return false
+	}
+	name := strings.TrimSpace(holder.Metadata["session_name"])
+	if !pendingInteractionKeepsAwake(holder, sp, name, clk) {
+		return false
+	}
+	if orphanReleasePendingBackstopExpired(holder, clk) {
+		return false
+	}
+	// Mirror the sibling detached-probe path, which logs every skip/release
+	// decision: make the duplicate-suppression observable.
+	log.Printf("releaseOrphanedPoolAssignments: skipping release: holder %s pending-interactive for assignee %q", name, assignee)
+	return true
+}
+
+// orphanReleasePendingBackstopExpired reports whether the holder's pending hold
+// is older than orphanReleasePendingBackstop. An unstamped or unparseable
+// pending_interaction_at is treated as a fresh hold (not expired): the holder is
+// provably pending now, and reconcilePendingInteractionAt stamps the bead so the
+// backstop can fire on a later tick.
+func orphanReleasePendingBackstopExpired(session beads.Bead, clk clock.Clock) bool {
+	if clk == nil {
+		return false
+	}
+	raw := strings.TrimSpace(session.Metadata["pending_interaction_at"])
+	if raw == "" {
+		return false
+	}
+	started, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return false
+	}
+	return clk.Now().Sub(started) >= orphanReleasePendingBackstop
 }
 
 func stringPtr(s string) *string { return &s }

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -6,9 +6,12 @@ import (
 	"log"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
 )
 
 const testDetachedPoolProbeSpec = "tmux:gascity:soak-loop"
@@ -1913,5 +1916,174 @@ func TestReleaseOrphanedPoolAssignments_PreservesNamedIdentityForSameStore(t *te
 	}
 	if got.Assignee != "reviewer" {
 		t.Fatalf("assignee = %q, want reviewer", got.Assignee)
+	}
+}
+
+// pendingHolderFixture builds the store + open-session snapshot for the #3453
+// pending-interactive backstop tests: a pool work bead claimed by "worker-mc-live"
+// whose holder session bead is present in the open snapshot but absent from the
+// store's live-session query (simulating the store-ref-scoped openSessionOwnsWork
+// miss / label-lost liveness query that lets the race reach the release path).
+func pendingHolderFixture(t *testing.T) (beads.Store, beads.Bead, beads.Bead) {
+	t.Helper()
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "claimed pool work",
+		Assignee: "worker-mc-live",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+	holder := beads.Bead{
+		ID:     "mc-live",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "worker-mc-live",
+			"template":             "worker",
+			"state":                "active",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}
+	return store, work, holder
+}
+
+func releasePendingTestCfg() *config.City {
+	return &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
+}
+
+func TestReleaseOrphanedPoolAssignments_SkipsPendingInteractiveHolder(t *testing.T) {
+	store, work, holder := pendingHolderFixture(t)
+	sp := &attachmentAwareProvider{
+		Fake:    runtime.NewFake(),
+		pending: &runtime.PendingInteraction{RequestID: "req-1", Kind: "approval"},
+	}
+	clk := &clock.Fake{Time: time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)}
+
+	released := releaseOrphanedPoolAssignmentsWithProvider(
+		store,
+		releasePendingTestCfg(),
+		"",
+		[]beads.Bead{holder},
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		[]string{"rig:other"}, // store-ref mismatch -> openSessionOwnsWork=false
+		nil,
+		sp,
+		clk,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none — live pending-interactive holder owns the work", released)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-mc-live" {
+		t.Fatalf("pending holder work was released: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_ReleasesWhenHolderNotPending(t *testing.T) {
+	store, work, holder := pendingHolderFixture(t)
+	// Provider reports no pending interaction: a genuinely dead/idle pane is
+	// released exactly as before the backstop existed.
+	sp := &attachmentAwareProvider{Fake: runtime.NewFake()}
+	clk := &clock.Fake{Time: time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)}
+
+	released := releaseOrphanedPoolAssignmentsWithProvider(
+		store,
+		releasePendingTestCfg(),
+		"",
+		[]beads.Bead{holder},
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		[]string{"rig:other"},
+		nil,
+		sp,
+		clk,
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s] — non-pending holder must release", released, work.ID)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("non-pending holder work not released: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_ReleasesPendingHolderPastBackstop(t *testing.T) {
+	store, work, holder := pendingHolderFixture(t)
+	clk := &clock.Fake{Time: time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)}
+	// Pane has been parked pending longer than orphanReleasePendingBackstop:
+	// a pane stuck pending forever is a zombie and must still be recovered.
+	holder.Metadata["pending_interaction_at"] = clk.Now().Add(-4 * time.Hour).UTC().Format(time.RFC3339)
+	sp := &attachmentAwareProvider{
+		Fake:    runtime.NewFake(),
+		pending: &runtime.PendingInteraction{RequestID: "req-1", Kind: "approval"},
+	}
+
+	released := releaseOrphanedPoolAssignmentsWithProvider(
+		store,
+		releasePendingTestCfg(),
+		"",
+		[]beads.Bead{holder},
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		[]string{"rig:other"},
+		nil,
+		sp,
+		clk,
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s] — pending hold past backstop must release", released, work.ID)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("stale pending holder work not released: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}
+
+func TestOrphanReleasePendingBackstopExpired(t *testing.T) {
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	mk := func(ts string) beads.Bead {
+		return beads.Bead{Metadata: map[string]string{"pending_interaction_at": ts}}
+	}
+	tests := []struct {
+		name    string
+		session beads.Bead
+		clk     clock.Clock
+		want    bool
+	}{
+		{"just under backstop holds", mk(now.Add(-(orphanReleasePendingBackstop - time.Minute)).Format(time.RFC3339)), clk, false},
+		{"just past backstop expires", mk(now.Add(-(orphanReleasePendingBackstop + time.Minute)).Format(time.RFC3339)), clk, true},
+		{"exactly at backstop expires", mk(now.Add(-orphanReleasePendingBackstop).Format(time.RFC3339)), clk, true},
+		{"unstamped treated as fresh", beads.Bead{}, clk, false},
+		{"unparseable treated as fresh", mk("not-a-timestamp"), clk, false},
+		{"nil clock fails closed", mk(now.Add(-4 * time.Hour).Format(time.RFC3339)), nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := orphanReleasePendingBackstopExpired(tt.session, tt.clk); got != tt.want {
+				t.Fatalf("orphanReleasePendingBackstopExpired = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1765,6 +1765,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			alive = false
 		}
 		reconcileDetachedAt(session, store, policy, alive, sp, clk)
+		reconcilePendingInteractionAt(session, store, sp, name, clk)
 
 		// Stability check: detect rapid crash after state healing. Rate-limit
 		// detection intentionally ran above before healState.

--- a/cmd/gc/session_sleep.go
+++ b/cmd/gc/session_sleep.go
@@ -140,6 +140,38 @@ func pendingInteractionKeepsAwake(session beads.Bead, sp runtime.Provider, name 
 	return !view.HasBlocker(sessionpkg.BlockerHeld) && !view.HasBlocker(sessionpkg.BlockerQuarantined)
 }
 
+// reconcilePendingInteractionAt stamps pending_interaction_at (RFC3339) on the
+// session bead the first time a pending-interactive hold is observed, and clears
+// it once the hold resolves. It writes only on the pending<->not-pending
+// transition (no steady-state churn). This is the cheap TTL input the
+// orphan-release backstop (releaseOrphanedPoolAssignmentsWithProvider) reads to
+// bound how long a live pending holder's claim is protected — see #3453.
+func reconcilePendingInteractionAt(session *beads.Bead, store beads.Store, sp runtime.Provider, name string, clk clock.Clock) {
+	if session == nil || store == nil {
+		return
+	}
+	pending := pendingInteractionReady(sp, name)
+	existing := strings.TrimSpace(session.Metadata["pending_interaction_at"])
+	switch {
+	case pending && existing == "":
+		ts := clk.Now().UTC().Format(time.RFC3339)
+		if err := store.SetMetadata(session.ID, "pending_interaction_at", ts); err != nil {
+			log.Printf("session sleep: stamping pending_interaction_at for %s: %v", session.ID, err)
+			return
+		}
+		if session.Metadata == nil {
+			session.Metadata = make(map[string]string, 1)
+		}
+		session.Metadata["pending_interaction_at"] = ts
+	case !pending && existing != "":
+		if err := store.SetMetadata(session.ID, "pending_interaction_at", ""); err != nil {
+			log.Printf("session sleep: clearing pending_interaction_at for %s: %v", session.ID, err)
+			return
+		}
+		session.Metadata["pending_interaction_at"] = ""
+	}
+}
+
 func reconcileDetachedAt(
 	session *beads.Bead,
 	store beads.Store,

--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -1250,3 +1250,51 @@ func waitForIdleProbeReady(t *testing.T, dt *drainTracker, beadID string) {
 	}
 	t.Fatalf("idle probe for %s not ready within 10s", beadID)
 }
+
+func TestReconcilePendingInteractionAt_StampsThenClears(t *testing.T) {
+	store := beads.NewMemStore()
+	sb, err := store.Create(beads.Bead{
+		Title:    "worker",
+		Type:     sessionBeadType,
+		Status:   "open",
+		Metadata: map[string]string{"session_name": "worker-mc-1"},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	clk := &clock.Fake{Time: time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)}
+
+	// First pending observation stamps the bead.
+	pending := &attachmentAwareProvider{
+		Fake:    runtime.NewFake(),
+		pending: &runtime.PendingInteraction{RequestID: "r1", Kind: "approval"},
+	}
+	reconcilePendingInteractionAt(&sb, store, pending, "worker-mc-1", clk)
+	want := clk.Now().UTC().Format(time.RFC3339)
+	got, err := store.Get(sb.ID)
+	if err != nil {
+		t.Fatalf("Get session bead: %v", err)
+	}
+	if got.Metadata["pending_interaction_at"] != want {
+		t.Fatalf("pending_interaction_at = %q, want %q", got.Metadata["pending_interaction_at"], want)
+	}
+	if sb.Metadata["pending_interaction_at"] != want {
+		t.Fatalf("in-memory bead not updated: %q", sb.Metadata["pending_interaction_at"])
+	}
+
+	// Re-observing pending later does not re-stamp (write only on transition).
+	clk.Time = clk.Time.Add(time.Hour)
+	reconcilePendingInteractionAt(&sb, store, pending, "worker-mc-1", clk)
+	got, _ = store.Get(sb.ID)
+	if got.Metadata["pending_interaction_at"] != want {
+		t.Fatalf("pending_interaction_at re-stamped: got %q, want stable %q", got.Metadata["pending_interaction_at"], want)
+	}
+
+	// Hold resolves: clear the stamp.
+	notPending := &attachmentAwareProvider{Fake: runtime.NewFake()}
+	reconcilePendingInteractionAt(&sb, store, notPending, "worker-mc-1", clk)
+	got, _ = store.Get(sb.ID)
+	if got.Metadata["pending_interaction_at"] != "" {
+		t.Fatalf("pending_interaction_at not cleared: %q", got.Metadata["pending_interaction_at"])
+	}
+}


### PR DESCRIPTION
## What

Stops the supervisor's `releaseOrphanedPoolAssignments` from clearing an
`in_progress` pool claim while the holder pane is alive and intentionally parked
on an interactive prompt. Previously that wrongful release let demand reappear
and spawned a backup session that ground the same bead in parallel — duplicate
token burn plus a double-write hazard on whatever the original holder produces.

## Why / root cause

The release gate chain (`openSessionOwnsWork`, named-route,
`liveOpenSessionAssignmentExists`, releasable, detached-probe) never consulted
the pending-interactive predicate the idle-reaper already honors
(`pendingInteractionKeepsAwake`, `cmd/gc/session_sleep.go`). A transient
`openSessionOwnsWork=false` (store-ref scoping) or a detached-dead probe then
reopened the bead while the holder was alive and deliberately waiting on input.

## Fix (no schema / store changes)

1. **Release-path gate (primary).** Thread a `runtime.Provider` + `clock.Clock`
   through `releaseOrphanedPoolAssignmentsWhenSnapshotsComplete` to both daemon
   callers (`city_runtime.go`, `cmd_start.go`) and skip release when the holder
   is in the open-session snapshot, `pendingInteractionKeepsAwake` reports it
   alive + pending, and the hold is younger than `orphanReleasePendingBackstop`
   (3h). A `nil` provider preserves the original behavior; the 3h backstop still
   releases a pane stuck pending forever.
2. **`pending_interaction_at` stamp.** `reconcilePendingInteractionAt` stamps /
   clears `pending_interaction_at` (RFC3339) on the session bead on the
   pending↔not-pending transition (write only on transition). It is the cheap
   TTL input bounding the backstop — no extra pane probe.

Preventing the wrongful release keeps the bead `in_progress` + assigned, so the
demand snapshot never counts it as new work and no duplicate worker is minted —
the race is closed at the release layer.

## Tests

- Unit (`pool_session_name_test.go`): skip-release when holder is pending+live;
  release when the holder pane is not pending; release once the hold passes the
  3h backstop; `orphanReleasePendingBackstopExpired` boundary + fail-closed
  cases. The existing `releaseOrphanedPoolAssignments` suite exercises the
  `nil`-provider path unchanged (behavior-preserving regression guard).
- Unit (`session_sleep_test.go`): `pending_interaction_at` stamped on first
  pending observation, not re-stamped, cleared on resolve.

Closes #3453.

---

Contrib-ops audit trail (internal workflow metadata):

Mayor-classified-baseline-noise: 2026-06-13T03:06Z — 3 failing tests classified as same gc-0ucc7 Dolt-init-timeout supervisor fragility (pre-reconcile, outside blast radius). SHIP GO verdict (bead gco-1e30).

Mayor-scope-reduced: 2026-06-13T03:37Z — fix #2 (demand decrement) dropped per source-level review verdict; scale_check counts UNASSIGNED only (build_desired_state.go:1325), so the decrement either steals a slot from a real pending unassigned bead or no-ops. Remaining fixes #1 (PRIMARY pending+live+TTL skip gate) + #3 (pending_interaction_at stamp) cover the race surface fully. Bead gco-1e30 mayor verdict.

Mayor-amend-token-granted: 2026-06-13T03:56Z — single-shot --no-verify granted for amend on 26dabcaf0 to reflect fix #2 drop. Re-run surfaced 1 ForStoppedManagedCity flake (same gc-0ucc7 supervisor-not-ready-60s-under-load class), scope smaller than prior 3, baseline-noise hypothesis preserved. Token covers 1 amend + force-push only; new class failure → re-escalate. Bead gco-1e30 mayor verdict.

Mayor-city-review-waiver: 2026-06-13T04:03Z — city-review structurally blocked by gco-yhbf [P1] (scrutineer sling yields non-pollable workflow-id gc-vx5h5; named scrutineer assignee-hook trap, gco-gk0 wake-gate class); 3-pass scrutineer-level review pass + ship gate green covers the diff; defense-in-depth waiver per documented per-PR workaround. Bead gco-1e30 mayor verdict.
