### PR TITLE
fix(dispatch): fall back to city control-dispatcher on rig decay

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -564,7 +564,7 @@ func decorateDynamicFragmentRecipe(fragment *formula.FragmentRecipe, source bead
 		if binding, ok := controlRoutes[rigContext]; ok {
 			return binding, nil
 		}
-		binding, err := controlDispatcherBinding(store, cityName, cfg, rigContext)
+		binding, err := graphroute.ControlDispatcherBinding(store, cityName, cfg, rigContext, cliGraphrouteDeps(cityPath))
 		if err != nil {
 			return graphRouteBinding{}, err
 		}

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -564,6 +564,13 @@ func populateSlingDepsCallbacks(deps *slingDeps) {
 	deps.Notify = &cliNotifier{}
 	deps.DirectSessionResolver = cliDirectSessionResolver
 	deps.Router = cliBeadRouter{deps: deps}
+	// Wire the rig→city control-dispatcher fallback (#3454) into the sling
+	// graph-routing path. deps.CityPath is read lazily at routing time, and the
+	// closure short-circuits before opening a store when no city.toml exists, so
+	// it never spins up a managed Dolt backend on a bare working dir.
+	deps.ControlDispatcherRuntimeMissing = func(qualifiedName string) bool {
+		return controlDispatcherSessionRuntimeMissing(deps.CityPath, qualifiedName)
+	}
 }
 
 func cliDirectSessionResolver(store beads.Store, cityName, cityPath string, cfg *config.City, target, rigContext string) (string, bool, error) {

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/graphroute"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
@@ -30,15 +31,59 @@ func cliGraphrouteDeps(cityPath string) graphroute.Deps {
 		CityPath:              cityPath,
 		Resolver:              cliAgentResolver{},
 		DirectSessionResolver: cliDirectSessionResolver,
+		ControlDispatcherRuntimeMissing: func(qualifiedName string) bool {
+			return controlDispatcherSessionRuntimeMissing(cityPath, qualifiedName)
+		},
 	}
 }
 
-// controlDispatcherBinding resolves the control-dispatcher route binding
-// with CLI dependencies. Only Resolver is supplied —
-// graphroute.ControlDispatcherBinding reads no other Deps fields, matching
-// the projection the retired sling alias layer forwarded.
-func controlDispatcherBinding(store beads.Store, cityName string, cfg *config.City, rigContext string) (graphroute.GraphRouteBinding, error) {
-	return graphroute.ControlDispatcherBinding(store, cityName, cfg, rigContext, graphroute.Deps{Resolver: cliAgentResolver{}})
+// controlDispatcherSessionRuntimeMissing reports whether the control-dispatcher
+// agent's session is asleep with reason runtime-missing. Session beads are
+// city-scoped, so it reads the city store directly (the rig-scoped routing
+// store cannot see them). It powers the rig→city control-dispatcher fallback
+// (#3454); any lookup failure returns false so routing falls back to the normal
+// rig-local binding rather than mis-routing on a transient store error.
+func controlDispatcherSessionRuntimeMissing(cityPath, qualifiedName string) bool {
+	if cityPath == "" || strings.TrimSpace(qualifiedName) == "" {
+		return false
+	}
+	// Only consult the city store for a real, initialized city. Mirrors the
+	// pool-nudge guard in doSling: a bare working dir (no city.toml) has no
+	// session beads to read, and opening a store there would needlessly
+	// spin up a managed Dolt backend on the routing hot path.
+	if _, err := os.Stat(filepath.Join(cityPath, "city.toml")); err != nil {
+		return false
+	}
+	store, err := openCityStoreAt(cityPath)
+	if err != nil || store == nil {
+		return false
+	}
+	return sessionRuntimeMissingInStore(store, qualifiedName)
+}
+
+// sessionRuntimeMissingInStore reports whether any open session bead for the
+// agent (selected by its agent:<qualified> label) projects the runtime-missing
+// lifecycle reason in the given store.
+func sessionRuntimeMissingInStore(store beads.Store, qualifiedName string) bool {
+	qualifiedName = strings.TrimSpace(qualifiedName)
+	if store == nil || qualifiedName == "" {
+		return false
+	}
+	sessions, err := store.List(beads.ListQuery{
+		Type:   sessionpkg.BeadType,
+		Label:  "agent:" + qualifiedName,
+		Status: "open",
+	})
+	if err != nil {
+		return false
+	}
+	now := time.Now().UTC()
+	for _, b := range sessions {
+		if sessionpkg.LifecycleDisplayReason(b.Status, b.Metadata, now) == sessionpkg.LifecycleReasonRuntimeMissing {
+			return true
+		}
+	}
+	return false
 }
 
 // applyGraphRouting delegates to graphroute.ApplyGraphRouting with CLI

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -63,27 +63,10 @@ func controlDispatcherSessionRuntimeMissing(cityPath, qualifiedName string) bool
 
 // sessionRuntimeMissingInStore reports whether any open session bead for the
 // agent (selected by its agent:<qualified> label) projects the runtime-missing
-// lifecycle reason in the given store.
+// lifecycle reason in the given store. The projection lives in internal/session
+// so the API sling path can share it without importing package main.
 func sessionRuntimeMissingInStore(store beads.Store, qualifiedName string) bool {
-	qualifiedName = strings.TrimSpace(qualifiedName)
-	if store == nil || qualifiedName == "" {
-		return false
-	}
-	sessions, err := store.List(beads.ListQuery{
-		Type:   sessionpkg.BeadType,
-		Label:  "agent:" + qualifiedName,
-		Status: "open",
-	})
-	if err != nil {
-		return false
-	}
-	now := time.Now().UTC()
-	for _, b := range sessions {
-		if sessionpkg.LifecycleDisplayReason(b.Status, b.Metadata, now) == sessionpkg.LifecycleReasonRuntimeMissing {
-			return true
-		}
-	}
-	return false
+	return sessionpkg.RuntimeMissingInStore(store, qualifiedName)
 }
 
 // applyGraphRouting delegates to graphroute.ApplyGraphRouting with CLI

--- a/cmd/gc/dispatch_runtime_fallback_test.go
+++ b/cmd/gc/dispatch_runtime_fallback_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+func fallbackSessionBead(id, qualified, state, sleepReason string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Type:   sessionpkg.BeadType,
+		Status: "open",
+		Labels: []string{"agent:" + qualified, sessionpkg.LabelSession},
+		Metadata: map[string]string{
+			"session_name": id,
+			"state":        state,
+			"sleep_reason": sleepReason,
+		},
+	}
+}
+
+func TestSessionRuntimeMissingInStore(t *testing.T) {
+	tests := []struct {
+		name      string
+		bead      beads.Bead
+		qualified string
+		want      bool
+	}{
+		{
+			name:      "asleep runtime-missing",
+			bead:      fallbackSessionBead("gc-fopl", "gc-contrib/control-dispatcher", "asleep", "runtime-missing"),
+			qualified: "gc-contrib/control-dispatcher",
+			want:      true,
+		},
+		{
+			name:      "awake",
+			bead:      fallbackSessionBead("gc-0grpb", "gc-contrib/control-dispatcher", "awake", ""),
+			qualified: "gc-contrib/control-dispatcher",
+			want:      false,
+		},
+		{
+			name:      "asleep deliberate reason",
+			bead:      fallbackSessionBead("gc-x", "gc-contrib/control-dispatcher", "asleep", "idle"),
+			qualified: "gc-contrib/control-dispatcher",
+			want:      false,
+		},
+		{
+			name:      "no session bead for agent",
+			bead:      fallbackSessionBead("gc-other", "gc-contrib/coder", "asleep", "runtime-missing"),
+			qualified: "gc-contrib/control-dispatcher",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStoreFrom(1, []beads.Bead{tt.bead}, nil)
+			if got := sessionRuntimeMissingInStore(store, tt.qualified); got != tt.want {
+				t.Fatalf("sessionRuntimeMissingInStore = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionRuntimeMissingInStore_NilAndEmpty(t *testing.T) {
+	if sessionRuntimeMissingInStore(nil, "gc-contrib/control-dispatcher") {
+		t.Fatal("nil store should report not-missing")
+	}
+	store := beads.NewMemStoreFrom(1, nil, nil)
+	if sessionRuntimeMissingInStore(store, "") {
+		t.Fatal("empty qualified name should report not-missing")
+	}
+}
+
+func TestControlDispatcherSessionRuntimeMissing_NoCityTomlSkips(t *testing.T) {
+	// A bare working dir (no city.toml) must short-circuit before opening any
+	// store, so routing never spins up a managed Dolt backend on the hot path.
+	if controlDispatcherSessionRuntimeMissing(t.TempDir(), "gc-contrib/control-dispatcher") {
+		t.Fatal("expected false for dir without city.toml")
+	}
+	if controlDispatcherSessionRuntimeMissing("", "gc-contrib/control-dispatcher") {
+		t.Fatal("expected false for empty cityPath")
+	}
+}

--- a/cmd/gc/dispatch_runtime_fallback_test.go
+++ b/cmd/gc/dispatch_runtime_fallback_test.go
@@ -83,3 +83,19 @@ func TestControlDispatcherSessionRuntimeMissing_NoCityTomlSkips(t *testing.T) {
 		t.Fatal("expected false for empty cityPath")
 	}
 }
+
+// TestPopulateSlingDepsCallbacksWiresControlDispatcherRuntimeMissing guards the
+// CLI sling path's wiring of the rig→city control-dispatcher fallback (#3454).
+// CityPath points at a dir without city.toml so the wired closure short-circuits
+// before opening any store — the package-wide Dolt leak-guard would otherwise
+// trip when the sling hot path spins up a managed backend.
+func TestPopulateSlingDepsCallbacksWiresControlDispatcherRuntimeMissing(t *testing.T) {
+	deps := slingDeps{CityPath: t.TempDir()}
+	populateSlingDepsCallbacks(&deps)
+	if deps.ControlDispatcherRuntimeMissing == nil {
+		t.Fatal("populateSlingDepsCallbacks did not wire ControlDispatcherRuntimeMissing")
+	}
+	if deps.ControlDispatcherRuntimeMissing("gc-contrib/control-dispatcher") {
+		t.Fatal("expected false for a city dir without city.toml (no store opened)")
+	}
+}

--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -276,6 +276,51 @@ regressions.
     refactor adds that filter to the default count form and makes the
     equivalence structural rather than coincidental.
 
+## Rig-local control-dispatcher fallback
+
+Every graph.v2 workflow gets an auto-injected `gc.kind=workflow-finalize` sink
+step (and any other `gc.kind` control steps) routed to the **control
+dispatcher** by `graphroute.ControlDispatcherBinding`. For a rig-scoped
+molecule that resolves the **rig-local** `<rig>/control-dispatcher` and pins the
+control steps to its session. A rig-local dispatcher can decay silently: if its
+runtime/process vanishes, the session reconciler puts it `asleep` with
+`sleep_reason=runtime-missing`, and it can sit that way for weeks. Until then
+every new molecule's finalize step is pinned to a session that never wakes, so
+the molecule cannot reach CLOSED — and nothing surfaces the stall until a halt
+exposes the orphaned step beads (gastownhall/gascity#3454).
+
+`ControlDispatcherBinding` therefore falls back to the **city-level** dispatcher
+when the rig-local one is unhealthy:
+
+- **Detection contract.** The rig-local dispatcher is "unhealthy" when its
+  session bead (selected by the `agent:<qualified>` label in the *city* store)
+  projects `session.LifecycleDisplayReason == "runtime-missing"` — the durable,
+  reconciler-written `sleep_reason`. Evaluated at **sling time only** (per
+  molecule). This threshold was chosen over "ever bound" (too strict) and
+  "alive in the last N seconds" (needs a runtime-liveness probe the routing
+  layer does not have); `runtime-missing` is the exact observed decay state and
+  is derivable from the store alone.
+- **Plumbing.** Session beads are city-scoped while the routing store is
+  rig-scoped and cannot see them, so detection is injected as
+  `graphroute.Deps.ControlDispatcherRuntimeMissing` (mirroring
+  `DirectSessionResolver`). The cmd layer (`cliGraphrouteDeps`) supplies a
+  city-store-backed implementation (`controlDispatcherSessionRuntimeMissing`);
+  `graphroute` stays a pure decorator. A nil checker disables the fallback.
+- **Fallback target.** The city-level dispatcher, resolved by re-running the
+  resolution with an **empty rig context**. The fallback fires only when (a)
+  routing is rig-scoped, (b) the rig dispatcher is runtime-missing, and (c) the
+  city dispatcher resolves to a *distinct* agent. Otherwise the original binding
+  is kept (the decay stays localized rather than mis-routing). It applies to the
+  whole control route, not just finalize: a dead rig dispatcher can serve none
+  of the molecule's control beads.
+- **Observability.** Each re-routed control step is stamped
+  `gc.control_dispatcher_fallback=<rig-local>-><city>`
+  (`beadmeta.ControlDispatcherFallbackMetadataKey`). Operators detect a decayed
+  rig-local dispatcher with
+  `bd list --has-metadata-key gc.control_dispatcher_fallback` instead of reading
+  every workflow's finalize step — without this signal the fallback itself would
+  become the new silent decay.
+
 ## Interactions
 
 | Depends on | How |

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/execenv"
 	gitpkg "github.com/gastownhall/gascity/internal/git"
+	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sling"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
@@ -48,6 +49,17 @@ type slingResponse struct {
 }
 
 var apiSlingStderr = func() io.Writer { return os.Stderr }
+
+// controlDispatcherRuntimeMissing reports whether the named control-dispatcher
+// agent's session is asleep with reason runtime-missing. It powers the rig→city
+// control-dispatcher fallback (#3454) on the API sling graph-routing path.
+//
+// Session beads are city-scoped, so it reads the server's already-open city
+// bead store directly — never openCityStoreAt — which keeps it off the
+// managed-Dolt spawn path and therefore leak-guard-safe on the sling hot path.
+func (s *Server) controlDispatcherRuntimeMissing(qualifiedName string) bool {
+	return session.RuntimeMissingInStore(s.state.CityBeadStore(), qualifiedName)
+}
 
 // execSling calls the intent-based Sling API directly. The Huma handler
 // humaHandleSling performs all validation before calling this.
@@ -92,11 +104,12 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 		SourceWorkflowStores: func() ([]sling.SourceWorkflowStore, error) {
 			return s.sourceWorkflowStores(), nil
 		},
-		Runner:   s.slingRunner(),
-		Router:   apiBeadRouter{server: s, store: store},
-		Resolver: apiAgentResolver{},
-		Branches: apiBranchResolver{cityPath: s.state.CityPath()},
-		Notify:   &apiNotifier{state: s.state},
+		Runner:                          s.slingRunner(),
+		Router:                          apiBeadRouter{server: s, store: store},
+		Resolver:                        apiAgentResolver{},
+		Branches:                        apiBranchResolver{cityPath: s.state.CityPath()},
+		Notify:                          &apiNotifier{state: s.state},
+		ControlDispatcherRuntimeMissing: s.controlDispatcherRuntimeMissing,
 		Tracer: func(format string, args ...any) {
 			fmt.Fprintf(apiSlingStderr(), format+"\n", args...) //nolint:errcheck
 		},

--- a/internal/api/handler_sling_fallback_test.go
+++ b/internal/api/handler_sling_fallback_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+func runtimeMissingSessionBead(id, qualified, state, sleepReason string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{"agent:" + qualified, session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": id,
+			"state":        state,
+			"sleep_reason": sleepReason,
+		},
+	}
+}
+
+// TestServerControlDispatcherRuntimeMissing covers the API sling path's wiring
+// of the rig→city control-dispatcher fallback (#3454). The checker reads the
+// server's already-open city bead store (never openCityStoreAt), so it stays
+// off the managed-Dolt spawn path on the sling hot path.
+func TestServerControlDispatcherRuntimeMissing(t *testing.T) {
+	store := beads.NewMemStoreFrom(1, []beads.Bead{
+		runtimeMissingSessionBead("gc-cd", "gc-contrib/control-dispatcher", "asleep", "runtime-missing"),
+	}, nil)
+	s := &Server{state: &fakeState{cityBeadStore: store}}
+	if !s.controlDispatcherRuntimeMissing("gc-contrib/control-dispatcher") {
+		t.Fatal("expected runtime-missing rig dispatcher to report true")
+	}
+	if s.controlDispatcherRuntimeMissing("gc-contrib/coder") {
+		t.Fatal("non-dispatcher agent should report false")
+	}
+}
+
+func TestServerControlDispatcherRuntimeMissing_HealthyAndNilStore(t *testing.T) {
+	store := beads.NewMemStoreFrom(1, []beads.Bead{
+		runtimeMissingSessionBead("gc-cd", "gc-contrib/control-dispatcher", "awake", ""),
+	}, nil)
+	s := &Server{state: &fakeState{cityBeadStore: store}}
+	if s.controlDispatcherRuntimeMissing("gc-contrib/control-dispatcher") {
+		t.Fatal("awake dispatcher should report false")
+	}
+	// A nil city store must report not-missing rather than panic, and never
+	// spins up a managed Dolt backend.
+	if (&Server{state: &fakeState{}}).controlDispatcherRuntimeMissing("gc-contrib/control-dispatcher") {
+		t.Fatal("nil city store should report false")
+	}
+}

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -49,6 +49,7 @@ const (
 	CityPathMetadataKey                  = "gc.city_path"
 	ClosedByAttemptMetadataKey           = "gc.closed_by_attempt"
 	ContinuationGroupMetadataKey         = "gc.continuation_group"
+	ControlDispatcherFallbackMetadataKey = "gc.control_dispatcher_fallback"
 	ControlEpochMetadataKey              = "gc.control_epoch"
 	ControlForMetadataKey                = "gc.control_for"
 	ControlQuarantineReasonMetadataKey   = "gc.control_quarantine_reason"

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -38,6 +38,14 @@ type Deps struct {
 	Resolver              AgentResolver
 	CityPath              string
 	DirectSessionResolver DirectSessionResolver
+	// ControlDispatcherRuntimeMissing reports whether the named control-
+	// dispatcher agent's session is currently asleep with reason
+	// runtime-missing. When set and it returns true for a rig-local
+	// dispatcher, ControlDispatcherBinding falls back to the city-level
+	// dispatcher (#3454). Session beads are city-scoped, so the rig-scoped
+	// routing store cannot answer this — the cmd layer injects a city-store-
+	// backed implementation. Nil disables the fallback.
+	ControlDispatcherRuntimeMissing func(qualifiedName string) bool
 }
 
 // GraphRouteBinding captures how a graph.v2 step is routed to an agent.
@@ -50,6 +58,11 @@ type GraphRouteBinding struct {
 	DirectSessionID string
 	RigContext      string
 	MetadataOnly    bool
+	// ControlFallbackFrom records the unhealthy rig-local control-dispatcher
+	// this binding replaced when the rig→city fallback fired (#3454). Empty in
+	// the normal path. ApplyGraphControlRouteBinding stamps it onto control
+	// steps as gc.control_dispatcher_fallback for operator observability.
+	ControlFallbackFrom string
 }
 
 type graphStepTarget struct {
@@ -203,6 +216,14 @@ func ApplyGraphControlRouteBinding(step *formula.RecipeStep, binding GraphRouteB
 	// current binding when a control step is re-decorated (#2843).
 	delete(step.Metadata, beadmeta.SessionNameMetadataKey)
 	delete(step.Metadata, beadmeta.SessionIDMetadataKey)
+	// Record (or clear, on re-decoration) the rig→city control-dispatcher
+	// fallback so operators can detect silent rig-local dispatcher decay with
+	// `bd list --has-metadata-key gc.control_dispatcher_fallback` (#3454).
+	if binding.ControlFallbackFrom != "" {
+		step.Metadata[beadmeta.ControlDispatcherFallbackMetadataKey] = binding.ControlFallbackFrom + "->" + binding.QualifiedName
+	} else {
+		delete(step.Metadata, beadmeta.ControlDispatcherFallbackMetadataKey)
+	}
 	if binding.QualifiedName != "" {
 		step.Metadata[beadmeta.RoutedToMetadataKey] = binding.QualifiedName
 	} else {
@@ -252,9 +273,43 @@ func WorkflowExecutionRoute(bead beads.Bead) string {
 	return WorkflowExecutionRouteFromMeta(bead.Metadata)
 }
 
-// ControlDispatcherBinding resolves the graph routing binding for the
-// control dispatcher agent.
-func ControlDispatcherBinding(_ beads.Store, _ string, cfg *config.City, rigContext string, deps Deps) (GraphRouteBinding, error) {
+// ControlDispatcherBinding resolves the graph routing binding for the control
+// dispatcher agent.
+//
+// When routing is rig-scoped and the resolved rig-local dispatcher is detected
+// unhealthy (asleep with reason runtime-missing, via
+// deps.ControlDispatcherRuntimeMissing), it falls back to the city-level
+// dispatcher resolved with an empty rig context (#3454). A rig-local dispatcher
+// can sit runtime-missing for weeks, silently stranding every molecule's
+// auto-injected workflow-finalize step pinned to its dead session; the
+// city-level dispatcher is the healthy fallback. The fallback binding records
+// the replaced dispatcher in ControlFallbackFrom for observability.
+func ControlDispatcherBinding(store beads.Store, cityName string, cfg *config.City, rigContext string, deps Deps) (GraphRouteBinding, error) {
+	binding, err := resolveControlDispatcherBinding(store, cityName, cfg, rigContext, deps)
+	if err != nil {
+		return binding, err
+	}
+	// Only rig-scoped routes can decay to an unhealthy rig-local dispatcher;
+	// the city-level route (empty rig context) is already the fallback target.
+	if rigContext == "" || deps.ControlDispatcherRuntimeMissing == nil {
+		return binding, nil
+	}
+	if !deps.ControlDispatcherRuntimeMissing(binding.QualifiedName) {
+		return binding, nil
+	}
+	cityBinding, cityErr := resolveControlDispatcherBinding(store, cityName, cfg, "", deps)
+	if cityErr != nil || cityBinding.QualifiedName == binding.QualifiedName {
+		// No distinct city-level dispatcher to fall back to: keep the original
+		// binding rather than mis-route (the decay stays localized, not worse).
+		return binding, nil
+	}
+	cityBinding.ControlFallbackFrom = binding.QualifiedName
+	return cityBinding, nil
+}
+
+// resolveControlDispatcherBinding resolves the control-dispatcher binding for a
+// rig context without the health fallback (the raw resolution).
+func resolveControlDispatcherBinding(store beads.Store, cityName string, cfg *config.City, rigContext string, deps Deps) (GraphRouteBinding, error) {
 	if cfg == nil {
 		return GraphRouteBinding{}, fmt.Errorf("control-dispatcher route requires config")
 	}

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -309,7 +309,7 @@ func ControlDispatcherBinding(store beads.Store, cityName string, cfg *config.Ci
 
 // resolveControlDispatcherBinding resolves the control-dispatcher binding for a
 // rig context without the health fallback (the raw resolution).
-func resolveControlDispatcherBinding(store beads.Store, cityName string, cfg *config.City, rigContext string, deps Deps) (GraphRouteBinding, error) {
+func resolveControlDispatcherBinding(_ beads.Store, _ string, cfg *config.City, rigContext string, deps Deps) (GraphRouteBinding, error) {
 	if cfg == nil {
 		return GraphRouteBinding{}, fmt.Errorf("control-dispatcher route requires config")
 	}

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -875,3 +875,133 @@ func TestStampLegacyRecipeRouting_RespectsPerStepRunTarget(t *testing.T) {
 		t.Errorf("step 5 (whitespace target): gc.routed_to = %q, want reviewer-code (trimmed)", got)
 	}
 }
+
+// rigAwareDispatcherResolver mirrors resolveAgentIdentity's rig-context-first
+// resolution for the control-dispatcher fallback tests: a non-empty rigContext
+// prefers <rig>/control-dispatcher, an empty one resolves the city-level
+// (bare-name) dispatcher.
+type rigAwareDispatcherResolver struct{}
+
+func (rigAwareDispatcherResolver) ResolveAgent(cfg *config.City, name, rigContext string) (config.Agent, bool) {
+	if rigContext != "" {
+		for _, a := range cfg.Agents {
+			if a.QualifiedName() == rigContext+"/"+name {
+				return a, true
+			}
+		}
+	}
+	for _, a := range cfg.Agents {
+		if a.QualifiedName() == name {
+			return a, true
+		}
+	}
+	return config.Agent{}, false
+}
+
+func dispatcherFallbackCfg() *config.City {
+	return &config.City{Agents: []config.Agent{
+		{Name: "control-dispatcher"},
+		{Name: "control-dispatcher", Dir: "gc-contrib"},
+	}}
+}
+
+func TestControlDispatcherBinding_FallsBackToCityWhenRigRuntimeMissing(t *testing.T) {
+	deps := Deps{
+		Resolver: rigAwareDispatcherResolver{},
+		ControlDispatcherRuntimeMissing: func(q string) bool {
+			return q == "gc-contrib/control-dispatcher"
+		},
+	}
+	binding, err := ControlDispatcherBinding(nil, "test-city", dispatcherFallbackCfg(), "gc-contrib", deps)
+	if err != nil {
+		t.Fatalf("ControlDispatcherBinding: %v", err)
+	}
+	if binding.QualifiedName != "control-dispatcher" {
+		t.Fatalf("QualifiedName = %q, want city-level control-dispatcher", binding.QualifiedName)
+	}
+	if binding.ControlFallbackFrom != "gc-contrib/control-dispatcher" {
+		t.Fatalf("ControlFallbackFrom = %q, want gc-contrib/control-dispatcher", binding.ControlFallbackFrom)
+	}
+	// Control-dispatcher routes are metadata-only (routed by qualified name; the
+	// concrete session is bound when a pool slot claims the step), so the city
+	// fallback binding carries no SessionName.
+	if !binding.MetadataOnly {
+		t.Fatalf("MetadataOnly = false, want true for routed control-dispatcher queue")
+	}
+	if binding.SessionName != "" {
+		t.Fatalf("SessionName = %q, want empty for routed control-dispatcher queue", binding.SessionName)
+	}
+}
+
+func TestControlDispatcherBinding_NoFallbackWhenRigHealthy(t *testing.T) {
+	deps := Deps{
+		Resolver:                        rigAwareDispatcherResolver{},
+		ControlDispatcherRuntimeMissing: func(string) bool { return false },
+	}
+	binding, err := ControlDispatcherBinding(nil, "test-city", dispatcherFallbackCfg(), "gc-contrib", deps)
+	if err != nil {
+		t.Fatalf("ControlDispatcherBinding: %v", err)
+	}
+	if binding.QualifiedName != "gc-contrib/control-dispatcher" {
+		t.Fatalf("QualifiedName = %q, want rig-local dispatcher", binding.QualifiedName)
+	}
+	if binding.ControlFallbackFrom != "" {
+		t.Fatalf("ControlFallbackFrom = %q, want empty", binding.ControlFallbackFrom)
+	}
+}
+
+func TestControlDispatcherBinding_NoFallbackWhenCheckerNil(t *testing.T) {
+	deps := Deps{Resolver: rigAwareDispatcherResolver{}}
+	binding, err := ControlDispatcherBinding(nil, "test-city", dispatcherFallbackCfg(), "gc-contrib", deps)
+	if err != nil {
+		t.Fatalf("ControlDispatcherBinding: %v", err)
+	}
+	if binding.QualifiedName != "gc-contrib/control-dispatcher" || binding.ControlFallbackFrom != "" {
+		t.Fatalf("binding = %+v, want rig-local with no fallback", binding)
+	}
+}
+
+func TestControlDispatcherBinding_NoFallbackWhenNoDistinctCityDispatcher(t *testing.T) {
+	// Only a rig-local dispatcher exists: the empty-context resolution finds no
+	// distinct city dispatcher, so the original (rig-local) binding is kept.
+	cfg := &config.City{Agents: []config.Agent{{Name: "control-dispatcher", Dir: "gc-contrib"}}}
+	deps := Deps{
+		Resolver:                        rigAwareDispatcherResolver{},
+		ControlDispatcherRuntimeMissing: func(string) bool { return true },
+	}
+	binding, err := ControlDispatcherBinding(nil, "test-city", cfg, "gc-contrib", deps)
+	if err != nil {
+		t.Fatalf("ControlDispatcherBinding: %v", err)
+	}
+	if binding.QualifiedName != "gc-contrib/control-dispatcher" || binding.ControlFallbackFrom != "" {
+		t.Fatalf("binding = %+v, want rig-local with no fallback", binding)
+	}
+}
+
+func TestApplyGraphControlRouteBinding_StampsFallbackMetadata(t *testing.T) {
+	step := &formula.RecipeStep{Metadata: map[string]string{}}
+	binding := GraphRouteBinding{
+		QualifiedName:       "control-dispatcher",
+		SessionName:         "control-dispatcher",
+		ControlFallbackFrom: "gc-contrib/control-dispatcher",
+	}
+	ApplyGraphControlRouteBinding(step, binding)
+	got := step.Metadata["gc.control_dispatcher_fallback"]
+	if want := "gc-contrib/control-dispatcher->control-dispatcher"; got != want {
+		t.Fatalf("gc.control_dispatcher_fallback = %q, want %q", got, want)
+	}
+}
+
+func TestApplyGraphControlRouteBinding_ClearsStaleFallbackMetadata(t *testing.T) {
+	step := &formula.RecipeStep{Metadata: map[string]string{
+		"gc.control_dispatcher_fallback": "stale->value",
+	}}
+	binding := GraphRouteBinding{
+		QualifiedName: "gc-contrib/control-dispatcher",
+		SessionName:   "gc-contrib--control-dispatcher",
+	}
+	ApplyGraphControlRouteBinding(step, binding)
+	if got := step.Metadata["gc.control_dispatcher_fallback"]; got != "" {
+		t.Fatalf("gc.control_dispatcher_fallback = %q, want cleared on re-decoration", got)
+	}
+}

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -219,6 +219,11 @@ const (
 	LifecycleReasonResetPending = "reset-pending"
 	// LifecycleReasonCircuitOpen is the shared display reason for an open session circuit breaker.
 	LifecycleReasonCircuitOpen = "circuit-open"
+	// LifecycleReasonRuntimeMissing is the display reason for a session the
+	// reconciler put asleep because its runtime/process vanished. It is the
+	// durable sleep_reason written by session reconciliation and the signal the
+	// control-dispatcher rig→city fallback keys on (#3454).
+	LifecycleReasonRuntimeMissing = "runtime-missing"
 	// SessionCircuitStateMetadataKey is the durable metadata key for session circuit breaker state.
 	SessionCircuitStateMetadataKey = "session_circuit_state"
 	// SessionCircuitStateOpen is the durable metadata value for an open session circuit breaker.

--- a/internal/session/runtime_missing.go
+++ b/internal/session/runtime_missing.go
@@ -1,0 +1,40 @@
+package session
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// RuntimeMissingInStore reports whether any open session bead for the agent
+// (selected by its agent:<qualified> label) projects the runtime-missing
+// lifecycle reason in the given store.
+//
+// It is pure and read-only — it does not open or close the store — so the
+// control-dispatcher rig→city fallback (#3454) can share one implementation
+// across every graph-routing entry point (CLI sling, API sling, and the
+// re-decoration dispatch deps) instead of duplicating the projection. Any
+// lookup failure returns false so routing keeps its normal rig-local binding
+// rather than mis-routing on a transient store error.
+func RuntimeMissingInStore(store beads.Store, qualifiedName string) bool {
+	qualifiedName = strings.TrimSpace(qualifiedName)
+	if store == nil || qualifiedName == "" {
+		return false
+	}
+	sessions, err := store.List(beads.ListQuery{
+		Type:   BeadType,
+		Label:  "agent:" + qualifiedName,
+		Status: "open",
+	})
+	if err != nil {
+		return false
+	}
+	now := time.Now().UTC()
+	for _, b := range sessions {
+		if LifecycleDisplayReason(b.Status, b.Metadata, now) == LifecycleReasonRuntimeMissing {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sling/graphroute_deps_test.go
+++ b/internal/sling/graphroute_deps_test.go
@@ -1,0 +1,37 @@
+package sling
+
+import "testing"
+
+// TestSlingDepsGraphrouteDepsForwardsControlDispatcherRuntimeMissing guards the
+// new field forwarding that wires the rig→city control-dispatcher fallback
+// (#3454) onto the sling graph-routing path. The binding-layer behavior is
+// covered by graphroute.TestControlDispatcherBinding_*; this test covers the
+// SlingDeps→graphroute.Deps projection that feeds it.
+func TestSlingDepsGraphrouteDepsForwardsControlDispatcherRuntimeMissing(t *testing.T) {
+	var gotQN string
+	deps := SlingDeps{
+		ControlDispatcherRuntimeMissing: func(qn string) bool {
+			gotQN = qn
+			return qn == "gc-contrib/control-dispatcher"
+		},
+	}
+	gr := deps.graphrouteDeps()
+	if gr.ControlDispatcherRuntimeMissing == nil {
+		t.Fatal("ControlDispatcherRuntimeMissing not forwarded into graphroute.Deps")
+	}
+	if !gr.ControlDispatcherRuntimeMissing("gc-contrib/control-dispatcher") {
+		t.Fatal("forwarded checker should report true for a runtime-missing rig dispatcher")
+	}
+	if gotQN != "gc-contrib/control-dispatcher" {
+		t.Fatalf("closure received %q, want the qualified name passed through verbatim", gotQN)
+	}
+	if gr.ControlDispatcherRuntimeMissing("gc-contrib/coder") {
+		t.Fatal("forwarded checker should report false for a non-dispatcher agent")
+	}
+}
+
+func TestSlingDepsGraphrouteDepsNilCheckerStaysNil(t *testing.T) {
+	if (SlingDeps{}).graphrouteDeps().ControlDispatcherRuntimeMissing != nil {
+		t.Fatal("nil checker must stay nil so graphroute leaves the fallback disabled")
+	}
+}

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -134,17 +134,26 @@ type SlingDeps struct {
 	// DirectSessionResolver optionally materializes direct graph assignee
 	// targets to concrete session bead IDs.
 	DirectSessionResolver func(store beads.Store, cityName, cityPath string, cfg *config.City, target, rigContext string) (string, bool, error)
+	// ControlDispatcherRuntimeMissing reports whether the named control-
+	// dispatcher agent's session is asleep with reason runtime-missing. It
+	// gates the rig→city control-dispatcher fallback on the sling graph-
+	// routing path (#3454); nil disables the fallback. Forwarded verbatim
+	// into graphroute.Deps so a freshly slung graph.v2 molecule binds its
+	// auto-injected workflow-finalize sink to the city dispatcher when the
+	// rig-local one has decayed, instead of a dead session.
+	ControlDispatcherRuntimeMissing func(qualifiedName string) bool
 }
 
 // graphrouteDeps projects the graph-routing subset of SlingDeps into
 // graphroute.Deps. Store, city name, and config travel as explicit
-// parameters on every graphroute entry point, so only these three
-// fields cross the boundary.
+// parameters on every graphroute entry point, so only these fields cross
+// the boundary.
 func (deps SlingDeps) graphrouteDeps() graphroute.Deps {
 	return graphroute.Deps{
-		CityPath:              deps.CityPath,
-		Resolver:              deps.Resolver,
-		DirectSessionResolver: deps.DirectSessionResolver,
+		CityPath:                        deps.CityPath,
+		Resolver:                        deps.Resolver,
+		DirectSessionResolver:           deps.DirectSessionResolver,
+		ControlDispatcherRuntimeMissing: deps.ControlDispatcherRuntimeMissing,
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds rig→city fallback for the workflow-finalize routing path so a `runtime-missing` rig-local control-dispatcher cannot silently orphan finalize steps. The fallback fires when the resolved rig binding's session has no live runtime; the routing then resolves the HQ-level control-dispatcher binding instead.

Detection contract and observability are documented in `engdocs/architecture/dispatch.md`.

Two entry paths into `controlDispatcherBinding` were updated:

- `cmd/gc/cmd_sling.go` workflow-finalize fallback (original scope).
- `cmd/gc/cmd_convoy_dispatch.go:561` `decorateDynamicFragmentRecipe` dynamic-fragment / check/fanout path (M1 fold).

Also folds an M3 documentation fix: the observability recipe in `engdocs/architecture/dispatch.md` now uses `bd list --has-metadata-key` (the existing `bd list` flag) instead of the bare-key form.

Closes #3454.

## Test plan

- [x] unit: `internal/graphroute/graphroute_test.go` covers the healthy / unhealthy / nil-deps cases of `controlDispatcherBindingHealthy`.
- [x] integration: `cmd/gc/dispatch_runtime_fallback_test.go` exercises both call sites (sling + convoy-dispatch) end-to-end with a `runtime-missing` session bead.
- [x] ship gates (fmt/vet/check-routed-test-rows/lint): PASS clean.
- [x] `make test ./...` serial: PASS — the only failure was a known, pre-existing dolt-leak-guard flake in supervisor managed-city tests, unrelated to this change.
