### PR TITLE
fix(session): re-register @handle alias on participant reassignment (lost-message fix)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1170,6 +1170,13 @@ func (cr *CityRuntime) tick(
 	phaseStart = time.Now()
 	reapStaleExtmsgBindings(ctx, cr.cityBeadStore(), time.Now(), cr.stderr)
 	recordPhase(TraceSiteControllerTickPhase, "reap_stale_extmsg_bindings", phaseStart, nil)
+	// Re-point group participants at respawned sessions and carry their
+	// group-owned transcript membership; the participant side has no read-time
+	// membership overlay, so this backstop is what converges binding-less
+	// participants the binding reaper never sees.
+	phaseStart = time.Now()
+	reapStaleExtmsgParticipants(ctx, cr.cityBeadStore(), cr.stderr)
+	recordPhase(TraceSiteControllerTickPhase, "reap_stale_extmsg_participants", phaseStart, nil)
 	phaseStart = time.Now()
 	result = refreshDesiredStateWithSessionBeads(
 		result,

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -2478,6 +2478,7 @@ export interface components {
             };
             Public: boolean;
             SessionID: string;
+            SessionName: string;
         };
         ConversationGroupRecord: {
             DefaultHandle: string;

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -590,6 +590,7 @@ export type ConversationGroupParticipant = {
     };
     Public: boolean;
     SessionID: string;
+    SessionName: string;
 };
 
 export type ConversationGroupRecord = {

--- a/cmd/gc/extmsg_binding_reaper.go
+++ b/cmd/gc/extmsg_binding_reaper.go
@@ -38,3 +38,30 @@ func reapStaleExtmsgBindings(ctx context.Context, store beads.Store, now time.Ti
 			stats.Reassigned, stats.Cleared, stats.Scanned)
 	}
 }
+
+// reapStaleExtmsgParticipants reconciles external-message group participants
+// against live session identity on each reconciler tick — the participant-side
+// companion to reapStaleExtmsgBindings. Group-participant routing self-heals at
+// read time, but the group-owned transcript membership (keyed by session ID)
+// does not, and a binding-less group participant whose session respawns is
+// reached by no other backstop, so without this sweep its membership would stay
+// stranded on the retired session bead. It runs on the same tick and after
+// session beads have been synced. Errors are logged and swallowed so a
+// participant-store hiccup never stalls the reconciler loop.
+func reapStaleExtmsgParticipants(ctx context.Context, store beads.Store, stderr io.Writer) {
+	if store == nil {
+		return
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	stats, err := extmsg.ReapStaleParticipants(ctx, store)
+	if err != nil {
+		fmt.Fprintf(stderr, "session reconciler: reaping stale extmsg participants: %v\n", err) //nolint:errcheck
+		return
+	}
+	if stats.Reassigned > 0 {
+		fmt.Fprintf(stderr, "session reconciler: extmsg participants reaped (reassigned=%d scanned=%d)\n", //nolint:errcheck
+			stats.Reassigned, stats.Scanned)
+	}
+}

--- a/cmd/gc/extmsg_binding_reaper_test.go
+++ b/cmd/gc/extmsg_binding_reaper_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -69,4 +70,94 @@ func TestReapStaleExtmsgBindingsRepointsRespawnedSession(t *testing.T) {
 func TestReapStaleExtmsgBindingsNilStoreNoPanic(_ *testing.T) {
 	// Defensive: a tick before the bead store is wired must be a no-op.
 	reapStaleExtmsgBindings(context.Background(), nil, time.Now(), nil)
+}
+
+func TestReapStaleExtmsgParticipantsMigratesMembershipToRespawn(t *testing.T) {
+	store := beads.NewMemStore()
+
+	oldSession, err := store.Create(beads.Bead{
+		Title:    "session gc-pl",
+		Type:     session.BeadType,
+		Labels:   []string{session.LabelSession},
+		Metadata: map[string]string{"session_name": "gc-pl"},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	ref := extmsg.ConversationRef{
+		ScopeID:        "city-1",
+		Provider:       "slack",
+		AccountID:      "acct-1",
+		ConversationID: "C0B25SS12CD",
+		Kind:           extmsg.ConversationRoom,
+	}
+	fabric := extmsg.NewServices(store)
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	group, err := fabric.Groups.EnsureGroup(context.Background(), caller, extmsg.EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             extmsg.GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	participant, err := fabric.Groups.UpsertParticipant(context.Background(), caller, extmsg.UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: oldSession.ID,
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	// Respawn: close the old bead, mint a fresh one under the same name. No
+	// binding exists, so the binding reaper never observes this session — only
+	// the participant reaper can converge it.
+	if err := store.Close(oldSession.ID); err != nil {
+		t.Fatalf("close old session: %v", err)
+	}
+	newSession, err := store.Create(beads.Bead{
+		Title:    "session gc-pl",
+		Type:     session.BeadType,
+		Labels:   []string{session.LabelSession},
+		Metadata: map[string]string{"session_name": "gc-pl"},
+	})
+	if err != nil {
+		t.Fatalf("recreate session bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	reapStaleExtmsgParticipants(context.Background(), store, &stderr)
+
+	// Persistent heal: the participant now points at the respawned bead.
+	bead, err := store.Get(participant.ID)
+	if err != nil {
+		t.Fatalf("get participant bead: %v", err)
+	}
+	if bead.Metadata["session_id"] != newSession.ID {
+		t.Fatalf("participant session_id = %q, want %q (respawned bead)", bead.Metadata["session_id"], newSession.ID)
+	}
+
+	// The group-owned transcript membership followed the respawn. Routing already
+	// self-heals at read time, so membership migration is the reaper's unique
+	// contribution and the thing finding-3 guards against stranding.
+	memberships, err := fabric.Transcript.ListMemberships(context.Background(), caller, ref)
+	if err != nil {
+		t.Fatalf("ListMemberships: %v", err)
+	}
+	var sessionIDs []string
+	for _, m := range memberships {
+		sessionIDs = append(sessionIDs, m.SessionID)
+	}
+	if slices.Contains(sessionIDs, oldSession.ID) {
+		t.Errorf("group membership still stranded on retired session %s: %v", oldSession.ID, sessionIDs)
+	}
+	if !slices.Contains(sessionIDs, newSession.ID) {
+		t.Errorf("group membership did not follow respawn to %s: %v", newSession.ID, sessionIDs)
+	}
+}
+
+func TestReapStaleExtmsgParticipantsNilStoreNoPanic(_ *testing.T) {
+	// Defensive: a tick before the bead store is wired must be a no-op.
+	reapStaleExtmsgParticipants(context.Background(), nil, nil)
 }

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -749,6 +749,9 @@ func reassignStateAssignedToRetiredSessionBead(store beads.Store, oldSessionID, 
 	if err := extmsg.ReassignSessionBindings(context.Background(), store, oldSessionID, newSessionID, now); err != nil {
 		fmt.Fprintf(stderr, "session beads: reassigning external message bindings from retired session %s to %s: %v\n", oldSessionID, newSessionID, err) //nolint:errcheck
 	}
+	if err := extmsg.ReassignSessionParticipants(context.Background(), store, oldSessionID, newSessionID); err != nil {
+		fmt.Fprintf(stderr, "session beads: reassigning external message participants from retired session %s to %s: %v\n", oldSessionID, newSessionID, err) //nolint:errcheck
+	}
 }
 
 func cancelStateAssignedToRetiredSessionBead(store beads.Store, sessionID string, now time.Time, stderr io.Writer) {

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -1646,6 +1646,9 @@
           },
           "SessionID": {
             "type": "string"
+          },
+          "SessionName": {
+            "type": "string"
           }
         },
         "required": [
@@ -1653,6 +1656,7 @@
           "GroupID",
           "Handle",
           "SessionID",
+          "SessionName",
           "Public",
           "Metadata"
         ],

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -1646,6 +1646,9 @@
           },
           "SessionID": {
             "type": "string"
+          },
+          "SessionName": {
+            "type": "string"
           }
         },
         "required": [
@@ -1653,6 +1656,7 @@
           "GroupID",
           "Handle",
           "SessionID",
+          "SessionName",
           "Public",
           "Metadata"
         ],

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -880,12 +880,13 @@ type ConfigValidateOutputBody struct {
 
 // ConversationGroupParticipant defines model for ConversationGroupParticipant.
 type ConversationGroupParticipant struct {
-	GroupID   string            `json:"GroupID"`
-	Handle    string            `json:"Handle"`
-	ID        string            `json:"ID"`
-	Metadata  map[string]string `json:"Metadata"`
-	Public    bool              `json:"Public"`
-	SessionID string            `json:"SessionID"`
+	GroupID     string            `json:"GroupID"`
+	Handle      string            `json:"Handle"`
+	ID          string            `json:"ID"`
+	Metadata    map[string]string `json:"Metadata"`
+	Public      bool              `json:"Public"`
+	SessionID   string            `json:"SessionID"`
+	SessionName string            `json:"SessionName"`
 }
 
 // ConversationGroupRecord defines model for ConversationGroupRecord.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -1646,6 +1646,9 @@
           },
           "SessionID": {
             "type": "string"
+          },
+          "SessionName": {
+            "type": "string"
           }
         },
         "required": [
@@ -1653,6 +1656,7 @@
           "GroupID",
           "Handle",
           "SessionID",
+          "SessionName",
           "Public",
           "Metadata"
         ],

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -193,6 +193,9 @@ func (s *Server) reassignContinuityIneligibleNamedSessionState(ctx context.Conte
 		if err := extmsg.ReassignSessionBindings(ctx, store, b.ID, replacementID, now); err != nil {
 			return fmt.Errorf("reassign external message bindings from retired session %s to %s: %w", b.ID, replacementID, err)
 		}
+		if err := extmsg.ReassignSessionParticipants(ctx, store, b.ID, replacementID); err != nil {
+			return fmt.Errorf("reassign external message participants from retired session %s to %s: %w", b.ID, replacementID, err)
+		}
 	}
 	return nil
 }

--- a/internal/extmsg/binding_reaper.go
+++ b/internal/extmsg/binding_reaper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -97,6 +98,124 @@ func ReapStaleBindings(ctx context.Context, store beads.Store, now time.Time) (B
 				return stats, fmt.Errorf("reassign session %s to live bead %s: %w", record.SessionID, liveID, err)
 			}
 			reassigned[record.SessionID] = struct{}{}
+			stats.Reassigned++
+		}
+	}
+	return stats, nil
+}
+
+// ParticipantReapStats summarizes a single ReapStaleParticipants sweep.
+type ParticipantReapStats struct {
+	// Scanned counts active group participants examined.
+	Scanned int
+	// Reassigned counts retired session IDs whose group participants were
+	// re-pointed at a new live bead after respawn. Each unique stale session ID
+	// is counted once even when several participants share it
+	// (ReassignSessionParticipants migrates all participants for the session).
+	Reassigned int
+}
+
+// ReapStaleParticipants reconciles active group participants against live
+// session identity — the participant-side analog of ReapStaleBindings. A group
+// participant stores the volatile session bead ID it was created against plus the
+// stable session name; when that session respawns under the same name it gets a
+// fresh bead ID, leaving the participant pointing at a retired bead.
+//
+// Routing self-heals at read time via overlayLiveParticipantSessionID, but the
+// group-owned transcript membership (keyed by session ID) has no read-time
+// overlay. The canonical respawn-handover paths (session-bead reconciliation and
+// API materialization repair) already call ReassignSessionParticipants, but a
+// respawn reconciled only by this backstop — e.g. a binding-less group
+// participant whose session the binding reaper never observes — would otherwise
+// strand its membership on the dead session. This sweep re-points such
+// participants at the live bead and carries their transcript membership on the
+// same NDI cadence as the binding reaper.
+//
+// It acts on two stale shapes. First, a participant whose stable session name
+// resolves to a different live bead is re-pointed at that bead. Second, a
+// participant whose session_id already names the live bead but whose
+// previous_session_id_pending_cleanup still lists a retired session — the
+// residue of a handover that committed the session_id swap and then failed
+// mid-migration — has that pending handover finished so its stranded
+// transcript membership is migrated to the live bead. Participants with no
+// recorded name, or whose name no longer resolves to a live session, are left
+// untouched: RemoveParticipant and CloseSessionBindings own participant
+// teardown, and a genuine respawn always re-resolves to a live bead.
+//
+// The sweep is idempotent and safe to run on every reconciler tick; it must run
+// after session beads have been synced for the tick so a respawned session's
+// replacement bead is already visible.
+func ReapStaleParticipants(ctx context.Context, store beads.Store) (ParticipantReapStats, error) {
+	var stats ParticipantReapStats
+	if err := checkContext(ctx); err != nil {
+		return stats, err
+	}
+	if store == nil {
+		return stats, nil
+	}
+	items, err := store.List(beads.ListQuery{Label: labelGroupParticipantBase})
+	if err != nil {
+		return stats, fmt.Errorf("list active group participants: %w", err)
+	}
+	// reassigned tracks retired session IDs already handed over so we don't call
+	// ReassignSessionParticipants (which migrates all participants for a session)
+	// more than once per session per sweep.
+	reassigned := make(map[string]struct{})
+	for _, item := range items {
+		if err := checkContext(ctx); err != nil {
+			return stats, err
+		}
+		if !hasLabel(item, "gc:extmsg-participant") || item.Status == "closed" {
+			continue
+		}
+		record, err := decodeParticipantBead(item)
+		if err != nil {
+			return stats, fmt.Errorf("decode participant %s: %w", item.ID, err)
+		}
+		stats.Scanned++
+		name := strings.TrimSpace(record.SessionName)
+		oldID := strings.TrimSpace(record.SessionID)
+		if name == "" || oldID == "" {
+			continue
+		}
+		liveID, err := resolveLiveSessionID(store, name)
+		if err != nil || liveID == "" {
+			continue
+		}
+		if liveID != oldID {
+			// session_id still names a retired bead: re-point the participant at
+			// the live replacement, carrying its transcript membership. This
+			// handover appends oldID to (and processes) any cleanup already
+			// pending on the bead, so it subsumes the pending-cleanup pass below.
+			if _, done := reassigned[oldID]; done {
+				continue
+			}
+			if err := ReassignSessionParticipants(ctx, store, oldID, liveID); err != nil {
+				return stats, fmt.Errorf("reassign participants for retired session %s to live bead %s: %w", oldID, liveID, err)
+			}
+			reassigned[oldID] = struct{}{}
+			stats.Reassigned++
+			continue
+		}
+		// session_id already names the live bead, but a prior handover may have
+		// committed the session_id swap and then failed mid-migration, leaving a
+		// retired session in previous_session_id_pending_cleanup with its
+		// transcript membership still stranded on the dead bead. The
+		// liveID == oldID fast path never retries those, so finish each pending
+		// handover by re-driving it to the live bead: participantReassignmentPending
+		// recognizes the already-swapped state and migrateParticipantGroupMembership
+		// completes the membership migration and clears the pending record.
+		for _, pendingOldID := range pendingCleanupSessionIDsFromMetadata(item.Metadata) {
+			if pendingOldID == "" || pendingOldID == oldID {
+				continue
+			}
+			if _, done := reassigned[pendingOldID]; done {
+				continue
+			}
+			if err := ReassignSessionParticipants(ctx, store, pendingOldID, oldID); err != nil {
+				return stats, fmt.Errorf("finish pending participant cleanup from retired session %s to live bead %s: %w", pendingOldID, oldID, err)
+			}
+			reassigned[pendingOldID] = struct{}{}
 			stats.Reassigned++
 		}
 	}

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -227,14 +227,7 @@ func (s *bindingService) ResolveByConversation(ctx context.Context, ref Conversa
 // labelBindingSessionPrefix label (indexed on the volatile ID) and keep
 // label-based lookups correct across ticks.
 func overlayLiveSession(store beads.Store, record *SessionBindingRecord) {
-	if record.SessionName == "" {
-		return
-	}
-	liveID, err := resolveLiveSessionID(store, record.SessionName)
-	if err != nil || liveID == "" {
-		return
-	}
-	record.SessionID = liveID
+	overlayLiveSessionID(store, record.SessionName, record.SessionID, &record.SessionID)
 }
 
 func (s *bindingService) ListBySession(ctx context.Context, sessionID string) ([]SessionBindingRecord, error) {
@@ -546,6 +539,73 @@ func ReassignSessionBindings(ctx context.Context, store beads.Store, oldSessionI
 			}
 			if err := delivery.ClearForConversation(ctx, oldSessionID, record.Conversation); err != nil {
 				return err
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReassignSessionParticipants moves active group participants from one session
+// bead ID to another during canonical session repair. It mirrors
+// ReassignSessionBindings: the volatile session_id metadata and the
+// groupParticipantSessionLabel are updated; the stable session_name and
+// groupParticipantSessionNameLabel are left untouched because the name is the
+// same before and after a respawn.
+func ReassignSessionParticipants(ctx context.Context, store beads.Store, oldSessionID, newSessionID string) error {
+	if err := checkContext(ctx); err != nil {
+		return err
+	}
+	if store == nil {
+		return nil
+	}
+	oldSessionID = strings.TrimSpace(oldSessionID)
+	newSessionID = strings.TrimSpace(newSessionID)
+	if oldSessionID == "" || newSessionID == "" || oldSessionID == newSessionID {
+		return nil
+	}
+	items, err := store.List(beads.ListQuery{Label: groupParticipantSessionLabel(oldSessionID)})
+	if err != nil {
+		return fmt.Errorf("list participants by retired session label: %w", err)
+	}
+	locks := sharedBindingLockPool(store)
+	for _, item := range items {
+		if err := checkContext(ctx); err != nil {
+			return err
+		}
+		if !hasLabel(item, "gc:extmsg-participant") || item.Status == "closed" {
+			continue
+		}
+		if strings.TrimSpace(item.Metadata["session_id"]) != oldSessionID {
+			continue
+		}
+		seedGroupID := strings.TrimSpace(item.Metadata["group_id"])
+		if err := withLockKey(locks, groupParticipantsMutationLock(seedGroupID), func() error {
+			latest, err := store.Get(item.ID)
+			if err != nil {
+				return fmt.Errorf("get participant %s: %w", item.ID, err)
+			}
+			if !hasLabel(latest, "gc:extmsg-participant") || latest.Status == "closed" {
+				return nil
+			}
+			record, err := decodeParticipantBead(latest)
+			if err != nil {
+				return fmt.Errorf("decode participant %s: %w", latest.ID, err)
+			}
+			if record.SessionID != oldSessionID {
+				return nil
+			}
+			labelsToAdd, labelsToRemove := recordLabels(latest.Labels,
+				[]string{groupParticipantSessionLabel(oldSessionID)},
+				[]string{groupParticipantSessionLabel(newSessionID)})
+			if err := store.Update(record.ID, beads.UpdateOpts{
+				Labels:       labelsToAdd,
+				RemoveLabels: labelsToRemove,
+				Metadata:     map[string]string{"session_id": newSessionID},
+			}); err != nil {
+				return fmt.Errorf("reassign participant %s from session %s to %s: %w", record.ID, oldSessionID, newSessionID, err)
 			}
 			return nil
 		}); err != nil {

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -548,12 +548,34 @@ func ReassignSessionBindings(ctx context.Context, store beads.Store, oldSessionI
 	return nil
 }
 
+// newReassignmentTranscript constructs the transcript syncer used by
+// ReassignSessionParticipants. It is a package-level var so tests can substitute
+// a flaky transcript and exercise retry idempotence after a membership-migration
+// failure (mirrors resolveLiveSessionID and timeNow).
+var newReassignmentTranscript = func(store beads.Store, locks *bindingLockPool) groupTranscriptSync {
+	return newTranscriptService(store, locks)
+}
+
 // ReassignSessionParticipants moves active group participants from one session
 // bead ID to another during canonical session repair. It mirrors
 // ReassignSessionBindings: the volatile session_id metadata and the
 // groupParticipantSessionLabel are updated; the stable session_name and
 // groupParticipantSessionNameLabel are left untouched because the name is the
-// same before and after a respawn.
+// same before and after a respawn. Like the participant upsert path, it also
+// carries the group-owned transcript membership (keyed by session ID) to the
+// replacement session and retires the old one, so transcript discovery follows
+// the respawn instead of stranding the conversation on the dead session bead.
+//
+// The handover is retry-idempotent across a partial transcript-migration
+// failure. The participant is discovered by the retired-session lookup label,
+// so that label is retained until migrateParticipantGroupMembership commits:
+// session_id is swapped to the replacement (and the new label added) first so
+// the membership count logic sees the post-handover state, but the retired-session
+// label is dropped only after migration succeeds. A failure therefore leaves the
+// participant rediscoverable by both the retired-session label and
+// participantReassignmentPending, so a later ReassignSessionParticipants call (or
+// the participant reaper) finishes the handover instead of stranding the
+// group-owned membership on the dead session.
 func ReassignSessionParticipants(ctx context.Context, store beads.Store, oldSessionID, newSessionID string) error {
 	if err := checkContext(ctx); err != nil {
 		return err
@@ -571,6 +593,7 @@ func ReassignSessionParticipants(ctx context.Context, store beads.Store, oldSess
 		return fmt.Errorf("list participants by retired session label: %w", err)
 	}
 	locks := sharedBindingLockPool(store)
+	svc := &groupService{store: store, locks: locks, transcript: newReassignmentTranscript(store, locks)}
 	for _, item := range items {
 		if err := checkContext(ctx); err != nil {
 			return err
@@ -578,7 +601,7 @@ func ReassignSessionParticipants(ctx context.Context, store beads.Store, oldSess
 		if !hasLabel(item, "gc:extmsg-participant") || item.Status == "closed" {
 			continue
 		}
-		if strings.TrimSpace(item.Metadata["session_id"]) != oldSessionID {
+		if !participantReassignmentPending(item.Metadata, oldSessionID, newSessionID) {
 			continue
 		}
 		seedGroupID := strings.TrimSpace(item.Metadata["group_id"])
@@ -594,18 +617,49 @@ func ReassignSessionParticipants(ctx context.Context, store beads.Store, oldSess
 			if err != nil {
 				return fmt.Errorf("decode participant %s: %w", latest.ID, err)
 			}
-			if record.SessionID != oldSessionID {
+			if !participantReassignmentPending(latest.Metadata, oldSessionID, newSessionID) {
 				return nil
 			}
-			labelsToAdd, labelsToRemove := recordLabels(latest.Labels,
-				[]string{groupParticipantSessionLabel(oldSessionID)},
-				[]string{groupParticipantSessionLabel(newSessionID)})
+			group, err := svc.getGroupByID(record.GroupID)
+			if err != nil {
+				return fmt.Errorf("resolve group %s for participant %s during session reassignment: %w", record.GroupID, record.ID, err)
+			}
+			// Queue the retired session for group-membership cleanup, mirroring
+			// the upsert reassignment path. Persist it in the same update as the
+			// session_id swap so an ensure-membership failure still leaves a
+			// durable cleanup record.
+			pendingCleanup := pendingCleanupSessionIDsFromMetadata(latest.Metadata)
+			pendingCleanup = append(pendingCleanup, oldSessionID)
+			pendingCleanup = removeSessionID(pendingCleanup, newSessionID)
+			// Point the participant at the replacement and add the new session
+			// label, but KEEP the retired-session label until membership migration
+			// commits. The retired-session label is this handover's only
+			// retry-discoverable handle, so dropping it before
+			// migrateParticipantGroupMembership succeeds would strand the
+			// participant on a transcript-sync failure.
+			labelsToAdd, _ := recordLabels(latest.Labels, nil, []string{groupParticipantSessionLabel(newSessionID)})
 			if err := store.Update(record.ID, beads.UpdateOpts{
-				Labels:       labelsToAdd,
-				RemoveLabels: labelsToRemove,
-				Metadata:     map[string]string{"session_id": newSessionID},
+				Labels: labelsToAdd,
+				Metadata: map[string]string{
+					"session_id":                          newSessionID,
+					"previous_session_id_pending_cleanup": encodePendingCleanupSessionIDs(pendingCleanup),
+				},
 			}); err != nil {
 				return fmt.Errorf("reassign participant %s from session %s to %s: %w", record.ID, oldSessionID, newSessionID, err)
+			}
+			if err := svc.migrateParticipantGroupMembership(ctx, group, record.ID, newSessionID, pendingCleanup); err != nil {
+				return err
+			}
+			// Membership migration committed: the retired-session label is now
+			// safe to drop, completing the handover.
+			_, labelsToRemove := recordLabels(latest.Labels,
+				[]string{groupParticipantSessionLabel(oldSessionID)},
+				[]string{groupParticipantSessionLabel(newSessionID)})
+			if len(labelsToRemove) == 0 {
+				return nil
+			}
+			if err := store.Update(record.ID, beads.UpdateOpts{RemoveLabels: labelsToRemove}); err != nil {
+				return fmt.Errorf("drop retired session label from participant %s after reassignment to %s: %w", record.ID, newSessionID, err)
 			}
 			return nil
 		}); err != nil {

--- a/internal/extmsg/binding_survival_test.go
+++ b/internal/extmsg/binding_survival_test.go
@@ -318,3 +318,60 @@ func TestBindBackfillsSessionNameOnLegacyBinding(t *testing.T) {
 		t.Fatalf("backfilled binding labels %v missing session-name label %q", bead.Labels, bindingSessionNameLabel("gc-pl"))
 	}
 }
+
+// TestGroupRoutingFollowsRetiredButOpenSession proves the live-session overlay
+// re-resolves a stable session name even when the stored bead is archived
+// in place rather than closed. Duplicate-named-session repair archives the loser
+// with session.RetireNamedSessionPatch — clearing its identifiers but leaving it
+// open — so a "not closed" fast path would keep routing the group participant at
+// the retired bead instead of its live replacement.
+func TestGroupRoutingFollowsRetiredButOpenSession(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	// Retire session A the way duplicate-named-session repair does: release its
+	// identifiers and archive it WITHOUT closing the bead. It stays open, so the
+	// overlay must not treat it as the live owner of "pl-alpha".
+	retire := session.RetireNamedSessionPatch(testNow(), "duplicate-repair", "")
+	if err := store.SetMetadataBatch(sessAID, map[string]string(retire)); err != nil {
+		t.Fatalf("retire session A in place: %v", err)
+	}
+	a, err := store.Get(sessAID)
+	if err != nil {
+		t.Fatalf("get retired session A: %v", err)
+	}
+	if a.Status == "closed" {
+		t.Fatalf("retired session A is closed; this test must exercise the open-but-retired path")
+	}
+	// The replacement bead now owns "pl-alpha"; the real resolver must find it
+	// (session A's name was cleared, so it no longer matches).
+	sessBID := makeSessionBead(t, store, "pl-alpha")
+
+	decision, err := svc.ResolveInbound(context.Background(), ExternalInboundMessage{Conversation: ref})
+	if err != nil {
+		t.Fatalf("ResolveInbound: %v", err)
+	}
+	if decision.TargetSessionID != sessBID {
+		t.Errorf("TargetSessionID = %q, want %q (live replacement); open-but-retired bead %q must not short-circuit the overlay",
+			decision.TargetSessionID, sessBID, sessAID)
+	}
+}

--- a/internal/extmsg/extmsg_test.go
+++ b/internal/extmsg/extmsg_test.go
@@ -2202,6 +2202,281 @@ func TestGroupServiceRemoveParticipantRetriesTranscriptCleanup(t *testing.T) {
 	}
 }
 
+// overrideResolveLiveSessionID substitutes resolveLiveSessionID for the
+// duration of the test, restoring the original in t.Cleanup (Theme 18).
+func overrideResolveLiveSessionID(t *testing.T, fn func(beads.Store, string) (string, error)) {
+	t.Helper()
+	prev := resolveLiveSessionID
+	resolveLiveSessionID = fn
+	t.Cleanup(func() { resolveLiveSessionID = prev })
+}
+
+func TestGroupServiceUpsertParticipantStoresSessionName(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessID := makeSessionBead(t, store, "pl-alpha")
+
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+
+	participant, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessID,
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+	if participant.SessionName != "pl-alpha" {
+		t.Errorf("SessionName = %q, want %q", participant.SessionName, "pl-alpha")
+	}
+
+	bead, err := store.Get(participant.ID)
+	if err != nil {
+		t.Fatalf("get participant bead: %v", err)
+	}
+	wantLabel := groupParticipantSessionNameLabel("pl-alpha")
+	if !hasLabel(bead, wantLabel) {
+		t.Errorf("participant bead missing label %q; labels: %v", wantLabel, bead.Labels)
+	}
+}
+
+func TestGroupServiceResolveInboundFollowsRespawnedSession(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	// Session A is the original (now dead) bead; session B is the live respawn.
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+	sessBID := makeSessionBead(t, store, "pl-alpha-v2") // different name, same slot
+
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	// Simulate respawn: close the old session bead (as happens in production on
+	// handover), then override the resolver to point "pl-alpha" at session B.
+	if err := store.Close(sessAID); err != nil {
+		t.Fatalf("close session A bead: %v", err)
+	}
+	overrideResolveLiveSessionID(t, func(_ beads.Store, name string) (string, error) {
+		if name == "pl-alpha" {
+			return sessBID, nil
+		}
+		return "", errors.New("not found")
+	})
+
+	decision, err := svc.ResolveInbound(context.Background(), ExternalInboundMessage{Conversation: ref})
+	if err != nil {
+		t.Fatalf("ResolveInbound: %v", err)
+	}
+	if decision.TargetSessionID != sessBID {
+		t.Errorf("TargetSessionID = %q, want %q (live session B)", decision.TargetSessionID, sessBID)
+	}
+}
+
+func TestGroupServiceResolveOutboundFollowsRespawnedSession(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+	sessBID := makeSessionBead(t, store, "pl-alpha-v2")
+
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	if err := store.Close(sessAID); err != nil {
+		t.Fatalf("close session A bead: %v", err)
+	}
+	overrideResolveLiveSessionID(t, func(_ beads.Store, name string) (string, error) {
+		if name == "pl-alpha" {
+			return sessBID, nil
+		}
+		return "", errors.New("not found")
+	})
+
+	// Session B should now be authorized to publish (participant overlay matched it).
+	decision, err := svc.ResolveOutbound(context.Background(), ref, sessBID)
+	if err != nil {
+		t.Fatalf("ResolveOutbound: %v", err)
+	}
+	if decision.Match != GroupRouteParticipantMatch {
+		t.Errorf("ResolveOutbound(sessB).Match = %q, want %q", decision.Match, GroupRouteParticipantMatch)
+	}
+
+	// Original dead session A should not be authorized after respawn.
+	deadDecision, err := svc.ResolveOutbound(context.Background(), ref, sessAID)
+	if err != nil {
+		t.Fatalf("ResolveOutbound(dead): %v", err)
+	}
+	if deadDecision.Match != GroupRouteNoMatch {
+		t.Errorf("ResolveOutbound(sessA).Match = %q, want GroupRouteNoMatch", deadDecision.Match)
+	}
+}
+
+func TestReassignSessionParticipants(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	participant, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	sessBID := makeSessionBead(t, store, "pl-alpha-v2")
+	// Reassignment runs on a retired (closed) old session in production
+	// (session_beads.go and session_resolution.go both call it after the old
+	// bead is superseded); close sessAID so the test reflects that invariant.
+	if err := store.Close(sessAID); err != nil {
+		t.Fatalf("close retired session A bead: %v", err)
+	}
+	if err := ReassignSessionParticipants(context.Background(), store, sessAID, sessBID); err != nil {
+		t.Fatalf("ReassignSessionParticipants: %v", err)
+	}
+
+	bead, err := store.Get(participant.ID)
+	if err != nil {
+		t.Fatalf("get participant bead: %v", err)
+	}
+	if bead.Metadata["session_id"] != sessBID {
+		t.Errorf("session_id = %q, want %q", bead.Metadata["session_id"], sessBID)
+	}
+	if hasLabel(bead, groupParticipantSessionLabel(sessAID)) {
+		t.Errorf("participant still has old session label %q", groupParticipantSessionLabel(sessAID))
+	}
+	if !hasLabel(bead, groupParticipantSessionLabel(sessBID)) {
+		t.Errorf("participant missing new session label %q; labels: %v", groupParticipantSessionLabel(sessBID), bead.Labels)
+	}
+	// session_name label must be preserved (stable across respawn).
+	if !hasLabel(bead, groupParticipantSessionNameLabel("pl-alpha")) {
+		t.Errorf("participant missing session-name label %q; labels: %v", groupParticipantSessionNameLabel("pl-alpha"), bead.Labels)
+	}
+}
+
+func TestGroupServiceUpsertParticipantSessionNameLegacyFallback(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	// "legacy-sess" is a raw ID with no backing session bead — sessionNameForSelector returns "".
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+
+	participant, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: "legacy-sess",
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipant with legacy session: %v", err)
+	}
+	if participant.SessionName != "" {
+		t.Errorf("SessionName = %q, want empty for legacy session", participant.SessionName)
+	}
+
+	// ResolveInbound should still route to legacy-sess without panic.
+	decision, err := svc.ResolveInbound(context.Background(), ExternalInboundMessage{Conversation: ref})
+	if err != nil {
+		t.Fatalf("ResolveInbound: %v", err)
+	}
+	if decision.TargetSessionID != "legacy-sess" {
+		t.Errorf("TargetSessionID = %q, want legacy-sess", decision.TargetSessionID)
+	}
+}
+
+func TestGroupServiceResolveInboundDeadSessionNameReturnsStaleID(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	// Simulate session gone: resolver returns error for any name.
+	overrideResolveLiveSessionID(t, func(_ beads.Store, _ string) (string, error) {
+		return "", errors.New("session not found")
+	})
+
+	// Overlay returns "" → routing falls back to stored (stale) session ID; no panic.
+	decision, err := svc.ResolveInbound(context.Background(), ExternalInboundMessage{Conversation: ref})
+	if err != nil {
+		t.Fatalf("ResolveInbound: %v", err)
+	}
+	if decision.TargetSessionID != sessAID {
+		t.Errorf("TargetSessionID = %q, want stale %q as fallback", decision.TargetSessionID, sessAID)
+	}
+}
+
 func testConversationRef() ConversationRef {
 	return ConversationRef{
 		ScopeID:        "city-1",

--- a/internal/extmsg/extmsg_test.go
+++ b/internal/extmsg/extmsg_test.go
@@ -2211,6 +2211,16 @@ func overrideResolveLiveSessionID(t *testing.T, fn func(beads.Store, string) (st
 	t.Cleanup(func() { resolveLiveSessionID = prev })
 }
 
+// overrideReassignmentTranscript substitutes the transcript syncer used by
+// ReassignSessionParticipants so tests can inject a flaky transcript and drive
+// the retry-idempotence paths after a membership-migration failure.
+func overrideReassignmentTranscript(t *testing.T, transcript groupTranscriptSync) {
+	t.Helper()
+	prev := newReassignmentTranscript
+	newReassignmentTranscript = func(beads.Store, *bindingLockPool) groupTranscriptSync { return transcript }
+	t.Cleanup(func() { newReassignmentTranscript = prev })
+}
+
 func TestGroupServiceUpsertParticipantStoresSessionName(t *testing.T) {
 	freezeTestClock(t)
 	store := beads.NewMemStore()
@@ -2353,7 +2363,9 @@ func TestReassignSessionParticipants(t *testing.T) {
 	store := beads.NewMemStore()
 	sessAID := makeSessionBead(t, store, "pl-alpha")
 
-	svc := NewGroupService(store)
+	fabric := NewServices(store)
+	svc := fabric.Groups
+	transcript := fabric.Transcript
 	ref := testConversationRef()
 	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
 		RootConversation: ref,
@@ -2370,6 +2382,10 @@ func TestReassignSessionParticipants(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("UpsertParticipant: %v", err)
+	}
+	// The participant upsert seeds a group-owned membership for session A.
+	if got := membershipSessionIDs(t, transcript, ref); !sameMembers(got, []string{sessAID}) {
+		t.Fatalf("memberships(after upsert) = %#v, want [%s]", got, sessAID)
 	}
 
 	sessBID := makeSessionBead(t, store, "pl-alpha-v2")
@@ -2399,6 +2415,383 @@ func TestReassignSessionParticipants(t *testing.T) {
 	// session_name label must be preserved (stable across respawn).
 	if !hasLabel(bead, groupParticipantSessionNameLabel("pl-alpha")) {
 		t.Errorf("participant missing session-name label %q; labels: %v", groupParticipantSessionNameLabel("pl-alpha"), bead.Labels)
+	}
+	// The group-owned transcript membership must follow the participant to the
+	// respawned session: session B gains it, retired session A loses it. Without
+	// this, transcript discovery (keyed by session ID) misses binding-less group
+	// participants and the retired session's membership leaks.
+	if got := membershipSessionIDs(t, transcript, ref); !sameMembers(got, []string{sessBID}) {
+		t.Fatalf("memberships(after reassign) = %#v, want [%s]", got, sessBID)
+	}
+	membership := membershipRecordBySession(t, transcript, ref, sessBID)
+	if !sameMembershipOwners(membership.Owners, []MembershipOwner{MembershipOwnerGroup}) {
+		t.Errorf("membership owners = %#v, want [group]", membership.Owners)
+	}
+}
+
+// TestReassignSessionParticipantsLeavesOtherSessionMembershipsIntact proves the
+// reassign only migrates the membership for the retired session and never
+// disturbs a co-resident participant bound to a different live session.
+func TestReassignSessionParticipantsLeavesOtherSessionMembershipsIntact(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+	sessZID := makeSessionBead(t, store, "pl-zeta")
+
+	fabric := NewServices(store)
+	svc := fabric.Groups
+	transcript := fabric.Transcript
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	}); err != nil {
+		t.Fatalf("UpsertParticipant(alpha): %v", err)
+	}
+	if _, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "zeta",
+		SessionID: sessZID,
+	}); err != nil {
+		t.Fatalf("UpsertParticipant(zeta): %v", err)
+	}
+	if got := membershipSessionIDs(t, transcript, ref); !sameMembers(got, []string{sessAID, sessZID}) {
+		t.Fatalf("memberships(after upserts) = %#v, want [%s %s]", got, sessAID, sessZID)
+	}
+
+	sessBID := makeSessionBead(t, store, "pl-alpha-v2")
+	if err := store.Close(sessAID); err != nil {
+		t.Fatalf("close retired session A bead: %v", err)
+	}
+	if err := ReassignSessionParticipants(context.Background(), store, sessAID, sessBID); err != nil {
+		t.Fatalf("ReassignSessionParticipants: %v", err)
+	}
+
+	// alpha's membership moved A->B; zeta's session-Z membership is untouched.
+	if got := membershipSessionIDs(t, transcript, ref); !sameMembers(got, []string{sessBID, sessZID}) {
+		t.Fatalf("memberships(after reassign) = %#v, want [%s %s]", got, sessBID, sessZID)
+	}
+}
+
+// TestReassignSessionParticipantsRetriesAfterEnsureFailure proves the handover
+// survives a transcript ensure failure: the retired-session lookup label must be
+// retained until membership migration commits, so a retry can rediscover the
+// partially migrated participant and finish the move instead of stranding it.
+func TestReassignSessionParticipantsRetriesAfterEnsureFailure(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+
+	svc := NewServices(store).Groups
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	participant, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	sessBID := makeSessionBead(t, store, "pl-alpha-v2")
+	if err := store.Close(sessAID); err != nil {
+		t.Fatalf("close retired session A bead: %v", err)
+	}
+
+	// First handover attempt: the replacement-session membership ensure fails.
+	flaky := &flakyTranscriptService{failEnsureCount: 1, err: errors.New("boom")}
+	overrideReassignmentTranscript(t, flaky)
+	if err := ReassignSessionParticipants(context.Background(), store, sessAID, sessBID); err == nil || !errors.Is(err, ErrTranscriptSyncFailed) {
+		t.Fatalf("ReassignSessionParticipants(first) error = %v, want ErrTranscriptSyncFailed", err)
+	}
+
+	// Regression: the partially migrated participant must still be discoverable by
+	// the retired-session label so a retry can finish the handover. Dropping that
+	// label before membership migration committed is the bug this guards.
+	stale, err := store.ListByLabel(groupParticipantSessionLabel(sessAID), 0)
+	if err != nil {
+		t.Fatalf("ListByLabel(retired session): %v", err)
+	}
+	if len(stale) != 1 || stale[0].ID != participant.ID {
+		t.Fatalf("retired-session label dropped before migration committed: %#v", stale)
+	}
+	if got := stale[0].Metadata["session_id"]; got != sessBID {
+		t.Errorf("session_id after failed handover = %q, want %q (already swapped to replacement)", got, sessBID)
+	}
+	if got := stale[0].Metadata["previous_session_id_pending_cleanup"]; got != sessAID {
+		t.Errorf("pending cleanup after failed handover = %q, want %q", got, sessAID)
+	}
+
+	// Retry: ensure now succeeds and the handover completes.
+	if err := ReassignSessionParticipants(context.Background(), store, sessAID, sessBID); err != nil {
+		t.Fatalf("ReassignSessionParticipants(retry): %v", err)
+	}
+	if flaky.ensureCalls != 2 {
+		t.Fatalf("EnsureMembership calls = %d, want 2 (initial failure + successful retry)", flaky.ensureCalls)
+	}
+	bead, err := store.Get(participant.ID)
+	if err != nil {
+		t.Fatalf("Get(participant): %v", err)
+	}
+	if hasLabel(bead, groupParticipantSessionLabel(sessAID)) {
+		t.Errorf("retired-session label %q not cleared after successful retry", groupParticipantSessionLabel(sessAID))
+	}
+	if !hasLabel(bead, groupParticipantSessionLabel(sessBID)) {
+		t.Errorf("replacement-session label %q missing; labels: %v", groupParticipantSessionLabel(sessBID), bead.Labels)
+	}
+	if got := bead.Metadata["previous_session_id_pending_cleanup"]; got != "" {
+		t.Errorf("pending cleanup after retry = %q, want empty", got)
+	}
+}
+
+// TestReassignSessionParticipantsRetriesAfterRemoveFailure proves the same
+// retry idempotence when the retired session's membership removal fails after a
+// successful ensure on the replacement.
+func TestReassignSessionParticipantsRetriesAfterRemoveFailure(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+
+	svc := NewServices(store).Groups
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	participant, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	sessBID := makeSessionBead(t, store, "pl-alpha-v2")
+	if err := store.Close(sessAID); err != nil {
+		t.Fatalf("close retired session A bead: %v", err)
+	}
+
+	// First attempt: ensure(replacement) succeeds, remove(retired) fails.
+	flaky := &flakyTranscriptService{failRemoveCount: 1, err: errors.New("boom")}
+	overrideReassignmentTranscript(t, flaky)
+	if err := ReassignSessionParticipants(context.Background(), store, sessAID, sessBID); err == nil || !errors.Is(err, ErrTranscriptSyncFailed) {
+		t.Fatalf("ReassignSessionParticipants(first) error = %v, want ErrTranscriptSyncFailed", err)
+	}
+	stale, err := store.ListByLabel(groupParticipantSessionLabel(sessAID), 0)
+	if err != nil {
+		t.Fatalf("ListByLabel(retired session): %v", err)
+	}
+	if len(stale) != 1 || stale[0].ID != participant.ID {
+		t.Fatalf("retired-session label dropped before cleanup committed: %#v", stale)
+	}
+	if got := stale[0].Metadata["previous_session_id_pending_cleanup"]; got != sessAID {
+		t.Errorf("pending cleanup after failed remove = %q, want %q", got, sessAID)
+	}
+
+	// Retry: removal now succeeds and the handover completes.
+	if err := ReassignSessionParticipants(context.Background(), store, sessAID, sessBID); err != nil {
+		t.Fatalf("ReassignSessionParticipants(retry): %v", err)
+	}
+	if flaky.removeCalls != 2 {
+		t.Fatalf("RemoveMembership calls = %d, want 2 (initial failure + successful retry)", flaky.removeCalls)
+	}
+	bead, err := store.Get(participant.ID)
+	if err != nil {
+		t.Fatalf("Get(participant): %v", err)
+	}
+	if hasLabel(bead, groupParticipantSessionLabel(sessAID)) {
+		t.Errorf("retired-session label %q not cleared after successful retry", groupParticipantSessionLabel(sessAID))
+	}
+	if got := bead.Metadata["previous_session_id_pending_cleanup"]; got != "" {
+		t.Errorf("pending cleanup after retry = %q, want empty", got)
+	}
+}
+
+// TestReapStaleParticipants proves the background participant reaper heals a
+// binding-less group participant whose session respawned: it follows the live
+// bead and carries the group-owned transcript membership, on the same NDI
+// cadence as the binding reaper, and is a no-op once converged.
+func TestReapStaleParticipants(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+
+	fabric := NewServices(store)
+	svc := fabric.Groups
+	transcript := fabric.Transcript
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	participant, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+	if got := membershipSessionIDs(t, transcript, ref); !sameMembers(got, []string{sessAID}) {
+		t.Fatalf("memberships(after upsert) = %#v, want [%s]", got, sessAID)
+	}
+
+	// Respawn: retire A and mint a fresh bead under the same name. No binding
+	// exists, so only the participant reaper can converge this session.
+	sessBID := respawn(t, store, sessAID, "pl-alpha")
+
+	stats, err := ReapStaleParticipants(context.Background(), store)
+	if err != nil {
+		t.Fatalf("ReapStaleParticipants: %v", err)
+	}
+	if stats.Reassigned != 1 || stats.Scanned != 1 {
+		t.Fatalf("stats = %+v, want Reassigned=1 Scanned=1", stats)
+	}
+	bead, err := store.Get(participant.ID)
+	if err != nil {
+		t.Fatalf("Get(participant): %v", err)
+	}
+	if bead.Metadata["session_id"] != sessBID {
+		t.Errorf("participant session_id = %q, want %q (respawned bead)", bead.Metadata["session_id"], sessBID)
+	}
+	if got := membershipSessionIDs(t, transcript, ref); !sameMembers(got, []string{sessBID}) {
+		t.Fatalf("memberships(after reap) = %#v, want [%s]; group-owned membership must follow the respawn", got, sessBID)
+	}
+
+	// Idempotent: a second sweep finds nothing stale now that the participant
+	// already points at the live bead.
+	stats, err = ReapStaleParticipants(context.Background(), store)
+	if err != nil {
+		t.Fatalf("ReapStaleParticipants(second): %v", err)
+	}
+	if stats.Reassigned != 0 {
+		t.Fatalf("second sweep Reassigned = %d, want 0 (already converged)", stats.Reassigned)
+	}
+}
+
+// TestReapStaleParticipantsFinishesPendingCleanupAfterPartialHandover proves the
+// participant reaper completes a handover that committed the session_id swap and
+// then failed mid-migration. Such a participant already names the live bead
+// (session_id == liveID), so the reaper's "live target already matches" fast
+// path would otherwise skip it forever while its retired-session transcript
+// membership stays stranded in previous_session_id_pending_cleanup. The reaper
+// must instead re-drive the pending handover to the live bead.
+func TestReapStaleParticipantsFinishesPendingCleanupAfterPartialHandover(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	sessAID := makeSessionBead(t, store, "pl-alpha")
+
+	svc := NewServices(store).Groups
+	ref := testConversationRef()
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "alpha",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	participant, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: sessAID,
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	// Respawn A -> B. No binding exists, so only the participant reaper can
+	// converge this session.
+	sessBID := respawn(t, store, sessAID, "pl-alpha")
+
+	// First handover attempt fails mid-migration: the replacement-session
+	// membership ensure fails after session_id was already swapped to B. This
+	// leaves session_id == B (the live bead) with A still pending cleanup and the
+	// retired-session label retained for retry discovery.
+	failing := &flakyTranscriptService{failEnsureCount: 1, err: errors.New("boom")}
+	overrideReassignmentTranscript(t, failing)
+	if err := ReassignSessionParticipants(context.Background(), store, sessAID, sessBID); err == nil || !errors.Is(err, ErrTranscriptSyncFailed) {
+		t.Fatalf("ReassignSessionParticipants(partial) error = %v, want ErrTranscriptSyncFailed", err)
+	}
+	stale, err := store.Get(participant.ID)
+	if err != nil {
+		t.Fatalf("Get(participant after partial handover): %v", err)
+	}
+	if got := stale.Metadata["session_id"]; got != sessBID {
+		t.Fatalf("session_id after partial handover = %q, want %q (already swapped to live bead)", got, sessBID)
+	}
+	if got := stale.Metadata["previous_session_id_pending_cleanup"]; got != sessAID {
+		t.Fatalf("pending cleanup after partial handover = %q, want %q", got, sessAID)
+	}
+	if !hasLabel(stale, groupParticipantSessionLabel(sessAID)) {
+		t.Fatalf("retired-session label %q dropped before migration committed", groupParticipantSessionLabel(sessAID))
+	}
+
+	// The reaper now sees session_id == liveID == B, so the old "live target
+	// already matches" skip would strand the pending cleanup forever. A healthy
+	// transcript lets the reaper finish the handover.
+	healthy := &flakyTranscriptService{}
+	overrideReassignmentTranscript(t, healthy)
+	stats, err := ReapStaleParticipants(context.Background(), store)
+	if err != nil {
+		t.Fatalf("ReapStaleParticipants: %v", err)
+	}
+	if stats.Reassigned != 1 || stats.Scanned != 1 {
+		t.Fatalf("stats = %+v, want Reassigned=1 Scanned=1 (reaper must finish the pending handover)", stats)
+	}
+	if healthy.ensureCalls == 0 || healthy.removeCalls == 0 {
+		t.Fatalf("reaper did not drive membership migration: ensureCalls=%d removeCalls=%d", healthy.ensureCalls, healthy.removeCalls)
+	}
+	bead, err := store.Get(participant.ID)
+	if err != nil {
+		t.Fatalf("Get(participant after reap): %v", err)
+	}
+	if got := bead.Metadata["session_id"]; got != sessBID {
+		t.Errorf("session_id after reap = %q, want %q", got, sessBID)
+	}
+	if got := bead.Metadata["previous_session_id_pending_cleanup"]; got != "" {
+		t.Errorf("pending cleanup after reap = %q, want empty (handover finished)", got)
+	}
+	if hasLabel(bead, groupParticipantSessionLabel(sessAID)) {
+		t.Errorf("retired-session label %q not dropped after reaper finished the handover", groupParticipantSessionLabel(sessAID))
+	}
+	if !hasLabel(bead, groupParticipantSessionLabel(sessBID)) {
+		t.Errorf("replacement-session label %q missing; labels: %v", groupParticipantSessionLabel(sessBID), bead.Labels)
+	}
+
+	// Idempotent: a second sweep finds nothing pending now.
+	stats, err = ReapStaleParticipants(context.Background(), store)
+	if err != nil {
+		t.Fatalf("ReapStaleParticipants(second): %v", err)
+	}
+	if stats.Reassigned != 0 {
+		t.Fatalf("second sweep Reassigned = %d, want 0 (already converged)", stats.Reassigned)
 	}
 }
 

--- a/internal/extmsg/group_service.go
+++ b/internal/extmsg/group_service.go
@@ -209,53 +209,7 @@ func (s *groupService) UpsertParticipant(ctx context.Context, caller Caller, inp
 			if err != nil {
 				return err
 			}
-			if s.transcript == nil {
-				return nil
-			}
-			_, err = s.transcript.EnsureMembership(ctx, EnsureMembershipInput{
-				Caller:         groupTranscriptCaller(),
-				Conversation:   group.RootConversation,
-				SessionID:      sessionID,
-				BackfillPolicy: MembershipBackfillAll,
-				Owner:          MembershipOwnerGroup,
-				Now:            timeNow(),
-			})
-			if err != nil {
-				return wrapTranscriptSyncError("ensure transcript membership after participant upsert", err)
-			}
-			if len(pendingCleanup) == 0 {
-				return nil
-			}
-			activeSessions, err := s.activeParticipantSessionCounts(ctx, groupID)
-			if err != nil {
-				return err
-			}
-			remainingCleanup := make([]string, 0, len(pendingCleanup))
-			var cleanupErr error
-			for _, cleanupSessionID := range pendingCleanup {
-				if activeSessions[cleanupSessionID] > 0 {
-					continue
-				}
-				err = s.transcript.RemoveMembership(ctx, RemoveMembershipInput{
-					Caller:       groupTranscriptCaller(),
-					Conversation: group.RootConversation,
-					SessionID:    cleanupSessionID,
-					Owner:        MembershipOwnerGroup,
-					Now:          timeNow(),
-				})
-				if err == nil || errors.Is(err, ErrMembershipNotFound) {
-					continue
-				}
-				cleanupErr = err
-				remainingCleanup = append(remainingCleanup, cleanupSessionID)
-			}
-			if err := s.setParticipantPendingCleanup(item.ID, remainingCleanup); err != nil {
-				return err
-			}
-			if len(remainingCleanup) > 0 {
-				return wrapTranscriptSyncError("remove transcript membership after participant reassignment", cleanupErr)
-			}
-			return nil
+			return s.migrateParticipantGroupMembership(ctx, group, item.ID, sessionID, pendingCleanup)
 		}
 		createLabels := []string{"gc:extmsg-participant", labelGroupParticipantBase, groupParticipantLabel(groupID), groupParticipantSessionLabel(sessionID)}
 		if sessionName != "" {
@@ -274,21 +228,7 @@ func (s *groupService) UpsertParticipant(ctx context.Context, caller Caller, inp
 		if err != nil {
 			return err
 		}
-		if s.transcript == nil {
-			return nil
-		}
-		_, err = s.transcript.EnsureMembership(ctx, EnsureMembershipInput{
-			Caller:         groupTranscriptCaller(),
-			Conversation:   group.RootConversation,
-			SessionID:      sessionID,
-			BackfillPolicy: MembershipBackfillAll,
-			Owner:          MembershipOwnerGroup,
-			Now:            timeNow(),
-		})
-		if err != nil {
-			return wrapTranscriptSyncError("ensure transcript membership after participant upsert", err)
-		}
-		return nil
+		return s.migrateParticipantGroupMembership(ctx, group, created.ID, sessionID, nil)
 	})
 	if err != nil {
 		return ConversationGroupParticipant{}, err
@@ -635,6 +575,78 @@ func (s *groupService) setParticipantPendingCleanup(participantID string, sessio
 	return nil
 }
 
+// migrateParticipantGroupMembership ensures newSessionID owns the group's
+// transcript membership on the root conversation, then retires the group-owned
+// membership for any session in retiredSessionIDs that no active participant in
+// the group still references. A retired session whose membership cannot be
+// removed yet — a live participant still uses it, or the remove failed — is
+// written back onto the participant bead's previous_session_id_pending_cleanup
+// metadata so a later mutation retries it.
+//
+// Both UpsertParticipant (when a handle's session changes) and
+// ReassignSessionParticipants (canonical respawn handover) move a group
+// participant to a new session, so both must carry the session-ID-keyed
+// membership with it; sharing this helper keeps those paths from drifting.
+// Callers must hold groupParticipantsMutationLock for the group and should have
+// already persisted retiredSessionIDs to that metadata so an ensure failure
+// still leaves a durable cleanup record.
+//
+// The ensure/remove writes timestamp with the package timeNow() clock rather
+// than a caller-threaded now (as the sibling ReassignSessionBindings uses):
+// this helper is shared with UpsertParticipant, which has no caller-supplied
+// now, and timeNow is the package-wide clock seam (frozen in tests), so a single
+// clock source keeps both callers consistent without plumbing a now through the
+// participant upsert API. The timestamp is a touched-at marker, so the
+// sub-operation instant difference is immaterial.
+func (s *groupService) migrateParticipantGroupMembership(ctx context.Context, group ConversationGroupRecord, participantID, newSessionID string, retiredSessionIDs []string) error {
+	if s.transcript == nil {
+		return nil
+	}
+	if _, err := s.transcript.EnsureMembership(ctx, EnsureMembershipInput{
+		Caller:         groupTranscriptCaller(),
+		Conversation:   group.RootConversation,
+		SessionID:      newSessionID,
+		BackfillPolicy: MembershipBackfillAll,
+		Owner:          MembershipOwnerGroup,
+		Now:            timeNow(),
+	}); err != nil {
+		return wrapTranscriptSyncError("ensure transcript membership after participant session migration", err)
+	}
+	if len(retiredSessionIDs) == 0 {
+		return nil
+	}
+	activeSessions, err := s.activeParticipantSessionCounts(ctx, group.ID)
+	if err != nil {
+		return err
+	}
+	remainingCleanup := make([]string, 0, len(retiredSessionIDs))
+	var cleanupErr error
+	for _, cleanupSessionID := range retiredSessionIDs {
+		if activeSessions[cleanupSessionID] > 0 {
+			continue
+		}
+		err = s.transcript.RemoveMembership(ctx, RemoveMembershipInput{
+			Caller:       groupTranscriptCaller(),
+			Conversation: group.RootConversation,
+			SessionID:    cleanupSessionID,
+			Owner:        MembershipOwnerGroup,
+			Now:          timeNow(),
+		})
+		if err == nil || errors.Is(err, ErrMembershipNotFound) {
+			continue
+		}
+		cleanupErr = err
+		remainingCleanup = append(remainingCleanup, cleanupSessionID)
+	}
+	if err := s.setParticipantPendingCleanup(participantID, remainingCleanup); err != nil {
+		return err
+	}
+	if len(remainingCleanup) > 0 {
+		return wrapTranscriptSyncError("remove transcript membership after participant session migration", cleanupErr)
+	}
+	return nil
+}
+
 func groupParticipantsMutationLock(groupID string) string {
 	return groupParticipantLabel(groupID) + ":mutation"
 }
@@ -708,6 +720,25 @@ func removeSessionID(sessionIDs []string, target string) []string {
 		out = append(out, sessionID)
 	}
 	return pendingCleanupSessionIDsFromMetadata(map[string]string{"previous_session_id_pending_cleanup": encodePendingCleanupSessionIDs(out)})
+}
+
+// participantReassignmentPending reports whether a group-participant bead still
+// needs its session reassigned from oldSessionID to newSessionID. It is true
+// when the bead still points at the retired session, or when a prior attempt
+// already swapped session_id to the replacement but left the retired session in
+// previous_session_id_pending_cleanup — meaning transcript membership migration
+// had not completed yet, so a retry must finish the handover. The retired-session
+// lookup label is retained until that point precisely so such a partially
+// migrated participant remains discoverable by ReassignSessionParticipants.
+func participantReassignmentPending(metadata map[string]string, oldSessionID, newSessionID string) bool {
+	switch strings.TrimSpace(metadata["session_id"]) {
+	case oldSessionID:
+		return true
+	case newSessionID:
+		return slices.Contains(pendingCleanupSessionIDsFromMetadata(metadata), oldSessionID)
+	default:
+		return false
+	}
 }
 
 func decodeGroupBead(b beads.Bead) (ConversationGroupRecord, error) {

--- a/internal/extmsg/group_service.go
+++ b/internal/extmsg/group_service.go
@@ -146,12 +146,16 @@ func (s *groupService) UpsertParticipant(ctx context.Context, caller Caller, inp
 	if err := authorizeMutation(caller, group.RootConversation); err != nil {
 		return ConversationGroupParticipant{}, err
 	}
+	// Capture the stable session name so the participant survives respawn.
+	// Best-effort: empty when the selector resolves to no session bead.
+	sessionName := sessionNameForSelector(s.store, sessionID)
 	title := groupID + "/" + handle
 	fields := encodeMetadataFields(input.Metadata, map[string]string{
 		"schema_version": strconv.Itoa(schemaVersion),
 		"group_id":       groupID,
 		"handle":         handle,
 		"session_id":     sessionID,
+		"session_name":   sessionName,
 		"public":         strconv.FormatBool(input.Public),
 	})
 	var out ConversationGroupParticipant
@@ -184,7 +188,9 @@ func (s *groupService) UpsertParticipant(ctx context.Context, caller Caller, inp
 			pendingCleanup = removeSessionID(pendingCleanup, sessionID)
 			updateFields := mapsClone(fields)
 			updateFields["previous_session_id_pending_cleanup"] = encodePendingCleanupSessionIDs(pendingCleanup)
-			labelsToAdd, labelsToRemove := recordLabels(item.Labels, []string{groupParticipantSessionLabel(record.SessionID)}, []string{groupParticipantSessionLabel(sessionID)})
+			labelsToAdd, labelsToRemove := recordLabels(item.Labels,
+				participantSessionLabels(record.SessionID, record.SessionName),
+				participantSessionLabels(sessionID, sessionName))
 			if err := s.store.Update(item.ID, beads.UpdateOpts{
 				Title:        &title,
 				Labels:       labelsToAdd,
@@ -251,10 +257,14 @@ func (s *groupService) UpsertParticipant(ctx context.Context, caller Caller, inp
 			}
 			return nil
 		}
+		createLabels := []string{"gc:extmsg-participant", labelGroupParticipantBase, groupParticipantLabel(groupID), groupParticipantSessionLabel(sessionID)}
+		if sessionName != "" {
+			createLabels = append(createLabels, groupParticipantSessionNameLabel(sessionName))
+		}
 		created, err := s.store.Create(beads.Bead{
 			Title:    title,
 			Type:     "task",
-			Labels:   []string{"gc:extmsg-participant", labelGroupParticipantBase, groupParticipantLabel(groupID), groupParticipantSessionLabel(sessionID)},
+			Labels:   createLabels,
 			Metadata: fields,
 		})
 		if err != nil {
@@ -406,6 +416,7 @@ func (s *groupService) ResolveInbound(ctx context.Context, event ExternalInbound
 	}
 	byHandle := make(map[string]ConversationGroupParticipant, len(participants))
 	for _, participant := range participants {
+		overlayLiveParticipantSessionID(s.store, &participant)
 		byHandle[participant.Handle] = participant
 	}
 	if explicit := normalizeHandle(event.ExplicitTarget); explicit != "" {
@@ -468,6 +479,7 @@ func (s *groupService) ResolveOutbound(ctx context.Context, ref ConversationRef,
 		return nil, err
 	}
 	for _, participant := range participants {
+		overlayLiveParticipantSessionID(s.store, &participant)
 		if participant.SessionID == sessionID {
 			return &GroupOutboundDecision{
 				Match:       GroupRouteParticipantMatch,
@@ -723,11 +735,31 @@ func decodeGroupBead(b beads.Bead) (ConversationGroupRecord, error) {
 //nolint:unparam // error return reserved for future decoding failures
 func decodeParticipantBead(b beads.Bead) (ConversationGroupParticipant, error) {
 	return ConversationGroupParticipant{
-		ID:        b.ID,
-		GroupID:   strings.TrimSpace(b.Metadata["group_id"]),
-		Handle:    normalizeHandle(b.Metadata["handle"]),
-		SessionID: strings.TrimSpace(b.Metadata["session_id"]),
-		Public:    parseBool(b.Metadata, "public"),
-		Metadata:  decodePrefixedMetadata(b.Metadata),
+		ID:          b.ID,
+		GroupID:     strings.TrimSpace(b.Metadata["group_id"]),
+		Handle:      normalizeHandle(b.Metadata["handle"]),
+		SessionID:   strings.TrimSpace(b.Metadata["session_id"]),
+		SessionName: strings.TrimSpace(b.Metadata["session_name"]),
+		Public:      parseBool(b.Metadata, "public"),
+		Metadata:    decodePrefixedMetadata(b.Metadata),
 	}, nil
+}
+
+// overlayLiveParticipantSessionID re-points a participant at its session's
+// current live bead when the stored session_id has gone stale across a
+// respawn. It mutates only the in-memory copy — persistent healing is
+// ReassignSessionParticipants' job (runs on session handover).
+func overlayLiveParticipantSessionID(store beads.Store, participant *ConversationGroupParticipant) {
+	overlayLiveSessionID(store, participant.SessionName, participant.SessionID, &participant.SessionID)
+}
+
+// participantSessionLabels returns the label set for a participant given its
+// session ID (volatile) and optional session name (stable). The session-name
+// label is omitted when name is empty (legacy participants without one).
+func participantSessionLabels(sessionID, sessionName string) []string {
+	labels := []string{groupParticipantSessionLabel(sessionID)}
+	if sessionName != "" {
+		labels = append(labels, groupParticipantSessionNameLabel(sessionName))
+	}
+	return labels
 }

--- a/internal/extmsg/labels.go
+++ b/internal/extmsg/labels.go
@@ -14,8 +14,10 @@ const (
 	labelGroupBase            = "gc:extmsg-group"
 	labelGroupParticipantBase = "gc:extmsg-group-participant"
 	labelTranscriptBase       = "gc:extmsg-transcript"
-	labelMembershipBase       = "gc:extmsg-membership"
-	labelTranscriptStateBase  = "gc:extmsg-transcript-state"
+
+	labelGroupParticipantSessionNamePrefix = "extmsg:group:participant:session-name:v1:"
+	labelMembershipBase                    = "gc:extmsg-membership"
+	labelTranscriptStateBase               = "gc:extmsg-transcript-state"
 
 	labelBindingConversationPrefix = "extmsg:binding:conv:v1:"
 	labelBindingSessionPrefix      = "extmsg:binding:session:v1:"
@@ -93,6 +95,15 @@ func groupParticipantLabel(groupID string) string {
 
 func groupParticipantSessionLabel(sessionID string) string {
 	return labelGroupParticipantSession + strings.TrimSpace(sessionID)
+}
+
+// groupParticipantSessionNameLabel labels a participant by the stable session
+// name its target session was created under. Unlike groupParticipantSessionLabel
+// (which keys on the volatile bead ID), this label survives respawn, so
+// ReassignSessionParticipants can find participants owned by a name even after
+// the original session bead closes.
+func groupParticipantSessionNameLabel(name string) string {
+	return labelGroupParticipantSessionNamePrefix + strings.TrimSpace(name)
 }
 
 func transcriptConversationLabel(ref ConversationRef) string {

--- a/internal/extmsg/live_session.go
+++ b/internal/extmsg/live_session.go
@@ -14,14 +14,23 @@ import (
 var resolveLiveSessionID = session.ResolveSessionID
 
 // overlayLiveSessionID re-points *target at the current live bead for the
-// given stable session name. It is a no-op when the stored bead is still
-// active (fast path avoiding name-resolution round-trips) or when name
-// resolution fails. It mutates *target in place.
+// given stable session name. It is a no-op when the stored bead is still the
+// active owner of the name (fast path avoiding name-resolution round-trips) or
+// when name resolution fails. It mutates *target in place.
+//
+// "Not closed" alone does not prove the stored bead still owns the name: a
+// retired named session is archived without being closed
+// (session.RetireNamedSessionPatch clears its identifiers but leaves the bead
+// open so historical references can be reassigned). An open-but-identity-released
+// bead no longer owns the name, so it must fall through to name resolution;
+// otherwise routing keeps targeting the retired bead instead of its respawned
+// replacement.
 func overlayLiveSessionID(store beads.Store, name, currentID string, target *string) {
 	if name == "" {
 		return
 	}
-	if b, err := store.Get(currentID); err == nil && b.Status != "closed" {
+	if b, err := store.Get(currentID); err == nil && b.Status != "closed" &&
+		!session.LifecycleIdentityReleased(b.Status, b.Metadata) {
 		return
 	}
 	liveID, err := resolveLiveSessionID(store, name)

--- a/internal/extmsg/live_session.go
+++ b/internal/extmsg/live_session.go
@@ -13,6 +13,24 @@ import (
 // resolver without standing up real session beads (mirrors timeNow).
 var resolveLiveSessionID = session.ResolveSessionID
 
+// overlayLiveSessionID re-points *target at the current live bead for the
+// given stable session name. It is a no-op when the stored bead is still
+// active (fast path avoiding name-resolution round-trips) or when name
+// resolution fails. It mutates *target in place.
+func overlayLiveSessionID(store beads.Store, name, currentID string, target *string) {
+	if name == "" {
+		return
+	}
+	if b, err := store.Get(currentID); err == nil && b.Status != "closed" {
+		return
+	}
+	liveID, err := resolveLiveSessionID(store, name)
+	if err != nil || liveID == "" {
+		return
+	}
+	*target = liveID
+}
+
 // sessionNameForSelector resolves a bind selector (a session bead ID, alias,
 // or session name) to the stable session name recorded on the target bead.
 // Bindings store this name so they can follow the session across respawn.

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -346,13 +346,19 @@ type ConversationGroupRecord struct {
 }
 
 // ConversationGroupParticipant represents a participant in a conversation group.
+//
+// SessionID is the volatile session bead ID this participant currently resolves
+// to. SessionName is the stable identity the participant was registered under;
+// it survives session respawn and lets ResolveInbound/ResolveOutbound re-point
+// at the current live bead via resolveLiveSessionID.
 type ConversationGroupParticipant struct {
-	ID        string
-	GroupID   string
-	Handle    string
-	SessionID string
-	Public    bool
-	Metadata  map[string]string
+	ID          string
+	GroupID     string
+	Handle      string
+	SessionID   string
+	SessionName string
+	Public      bool
+	Metadata    map[string]string
 }
 
 // GroupRouteMatch classifies how a message was routed within a group.


### PR DESCRIPTION
## Summary

Completes the lost-message fix class started in #3381 (bind-by-name). When a session participant is reassigned/respawned, the `@handle` alias was not re-registered, so address-by-handle messages could be dropped.

This adds a participant `SessionName` overlay and `ReassignSessionParticipants` so the handle alias is re-registered on reassignment, keeping address-by-handle delivery intact across respawns.

## Changes
- Participant `SessionName` overlay + `ReassignSessionParticipants`
- Tests covering re-registration on reassignment
- Regenerated artifacts

## Test plan
- All change-scoped gates green; new tests pass.
