### PR TITLE
fix(beads): exact-ID match for gc bd writes (split 1/N of #3332)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,32 @@ bd create "Create a script that prints hello world"
 gc session attach mayor
 ```
 
+### Nix/Flox machines (ICU not on the default CGO path)
+
+On NixOS / Flox-managed Linux toolchains, system include/lib dirs are not
+searched, so the build fails with `fatal error: unicode/uregex.h: No such file
+or directory`. Point CGO at the Nix-store ICU dev headers + matching runtime
+lib (pick the dev output whose propagated lib matches your `gc`/`dolt` link, to
+avoid ICU version skew), and disable the Makefile's `/usr/lib` fallback so the
+Nix and system toolchains don't get mixed:
+
+```bash
+# Re-resolve the dev header path if the store path changes:
+#   find /nix/store -maxdepth 3 -path '*icu4c*-dev/include/unicode/uregex.h'
+# Match the lib to what your installed binary links: ldd $(which gc) | grep icu
+ICU_DEV=/nix/store/dvhx24q4icrig4q1v1lp7kzi3izd5jmb-icu4c-76.1-dev
+ICU_LIB=/nix/store/i4lj3w4yd9x9jbi7a1xhjqsr7bg8jq7p-icu4c-76.1
+
+CGO_ENABLED=1 \
+CGO_CPPFLAGS="-I$ICU_DEV/include" \
+CGO_LDFLAGS="-L$ICU_LIB/lib" \
+SYS_USR_CGO_FALLBACK=0 \
+  make build      # or: go build -o bin/gc ./cmd/gc
+```
+
+CGO-backed tests (e.g. `go test ./internal/beads`) take the same three CGO_*
+vars — no `CGO_ENABLED=0` workaround needed once ICU is pointed at correctly.
+
 For the longer walkthrough, start with
 [Tutorial 01](docs/tutorials/01-cities-and-rigs.md).
 

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -241,6 +241,17 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	// Fail-closed: if the arg scanner reports ambiguity (unrecognised
 	// value-consuming flag), the command is rejected rather than forwarded
 	// unguarded.
+	//
+	// Tradeoff: only a genuine ErrIDCollision (bd returned a *different* bead
+	// than requested) blocks the write. ErrNotFound and store-unavailable are
+	// non-fatal — the write falls through to bd, which will produce its own
+	// error if the bead truly does not exist. This preserves correctness for
+	// legitimate flows (heartbeat metadata writes, silent-fallback paths,
+	// ephemeral/wisp rows, projection-lag writes) that proceed even when the
+	// bead isn't yet visible through the read seam.
+	//
+	// Note: gc bd show (read passthrough) does NOT have this guard and still
+	// substring-resolves. That is intentional — reads are non-destructive.
 	if writeIDs, writeOK, ambiguous := bdMutationWriteIDs(bdArgs); writeOK {
 		if ambiguous {
 			fmt.Fprintf(stderr, "gc bd: cannot safely verify bead IDs (unrecognised flag in args %v); aborting to prevent substring-resolution mutation of the wrong bead\n", bdArgs) //nolint:errcheck // best-effort stderr
@@ -248,12 +259,19 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		}
 		if len(writeIDs) > 0 {
 			store, storeErr := openStoreAtForCity(target.ScopeRoot, cityPath)
+			// Store-unavailable: we cannot verify, but we must not block
+			// legitimate writes. Fall through; bd will error on actual problems.
 			if storeErr == nil {
 				for _, id := range writeIDs {
-					if _, getErr := store.Get(id); getErr != nil {
-						fmt.Fprintf(stderr, "gc bd: bead %q not found (exact match required; bd's fuzzy resolver may have resolved a different bead)\n", id) //nolint:errcheck // best-effort stderr
+					_, getErr := store.Get(id)
+					if errors.Is(getErr, beads.ErrIDCollision) {
+						// bd resolved a different bead — block the write to prevent
+						// mutating the wrong bead via substring resolution.
+						fmt.Fprintf(stderr, "gc bd: bead %q resolved to a different bead ID (substring collision); aborting to prevent mutating the wrong bead\n", id) //nolint:errcheck // best-effort stderr
 						return 1
 					}
+					// ErrNotFound or any other error: bead may be absent, ephemeral,
+					// or the read seam differs from the write seam — fall through.
 				}
 			}
 		}

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -238,7 +238,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	// Verify via BdStore.Get — which already enforces an exact-ID match —
 	// before forwarding any mutation to the bd subprocess.
 	//
-	// Fail-closed: if the arg scanner reports ambiguity (unrecognised
+	// Fail-closed: if the arg scanner reports ambiguity (unrecognized
 	// value-consuming flag), the command is rejected rather than forwarded
 	// unguarded.
 	//
@@ -254,7 +254,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	// substring-resolves. That is intentional — reads are non-destructive.
 	if writeIDs, writeOK, ambiguous := bdMutationWriteIDs(bdArgs); writeOK {
 		if ambiguous {
-			fmt.Fprintf(stderr, "gc bd: cannot safely verify bead IDs (unrecognised flag in args %v); aborting to prevent substring-resolution mutation of the wrong bead\n", bdArgs) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc bd: cannot safely verify bead IDs (unrecognized flag in args %v); aborting to prevent substring-resolution mutation of the wrong bead\n", bdArgs) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if len(writeIDs) > 0 {
@@ -366,7 +366,7 @@ func invalidBdReleaseIfCurrentArg(value string) bool {
 // Returns:
 //   - ids: all positional (non-flag) tokens after the subcommand; may be empty.
 //   - ok: false if args is empty or the subcommand is not a write-mutation.
-//   - ambiguous: true if the scanner encountered an unrecognised flag that
+//   - ambiguous: true if the scanner encountered an unrecognized flag that
 //     might consume the next argument as its value. In that case the caller
 //     must fail-closed — forwarding the command unguarded risks the original
 //     substring-resolution bug (gcy-g4o).
@@ -441,7 +441,6 @@ func bdMutationWriteIDs(args []string) (ids []string, ok bool, ambiguous bool) {
 		}
 		// Unknown flag. It might consume a value argument that looks like a
 		// bead ID. Fail-closed: report ambiguity so the caller can reject.
-		ambiguous = true
 		return nil, true, true
 	}
 	return ids, true, false
@@ -456,55 +455,55 @@ func bdSubcmdValueFlags(sub string) map[string]bool {
 		"--actor": true, "--db": true, "--directory": true, "-C": true,
 		"--dolt-auto-commit": true,
 	}
-	var sub_ map[string]bool
+	var subFlags map[string]bool
 	switch sub {
 	case "update":
-		sub_ = map[string]bool{
+		subFlags = map[string]bool{
 			"--acceptance": true,
 			"--add-label":  true, "--append-notes": true,
 			"-a": true, "--assignee": true,
-			"--await-id":    true,
-			"--body-file":   true,
-			"--defer":       true,
-			"-d": true, "--description": true,
+			"--await-id":  true,
+			"--body-file": true,
+			"--defer":     true,
+			"-d":          true, "--description": true,
 			"--design": true, "--design-file": true,
-			"--due":          true,
-			"-e": true, "--estimate": true,
+			"--due": true,
+			"-e":    true, "--estimate": true,
 			"--external-ref": true,
 			"--metadata":     true,
 			"--notes":        true,
 			"--parent":       true,
-			"-p": true, "--priority": true,
-			"--remove-label":   true,
-			"--session":        true,
-			"--set-labels":     true,
-			"--set-metadata":   true,
-			"-s": true, "--status": true,
+			"-p":             true, "--priority": true,
+			"--remove-label": true,
+			"--session":      true,
+			"--set-labels":   true,
+			"--set-metadata": true,
+			"-s":             true, "--status": true,
 			"-t": true, "--type": true,
 			"--title":          true,
 			"--spec-id":        true,
 			"--unset-metadata": true,
 		}
 	case "close":
-		sub_ = map[string]bool{
+		subFlags = map[string]bool{
 			"-r": true, "--reason": true,
 			"--reason-file": true,
 			"--session":     true,
 		}
 	case "reopen":
-		sub_ = map[string]bool{
+		subFlags = map[string]bool{
 			"-r": true, "--reason": true,
 		}
 	case "delete":
-		sub_ = map[string]bool{
+		subFlags = map[string]bool{
 			"--from-file": true,
 		}
 	}
-	merged := make(map[string]bool, len(global)+len(sub_))
+	merged := make(map[string]bool, len(global)+len(subFlags))
 	for k := range global {
 		merged[k] = true
 	}
-	for k := range sub_ {
+	for k := range subFlags {
 		merged[k] = true
 	}
 	return merged
@@ -523,34 +522,34 @@ func bdSubcmdBoolFlags(sub string) map[string]bool {
 		"-v": true, "--verbose": true,
 		"-h": true, "--help": true,
 	}
-	var sub_ map[string]bool
+	var subFlags map[string]bool
 	switch sub {
 	case "update":
-		sub_ = map[string]bool{
+		subFlags = map[string]bool{
 			"--allow-empty-description": true,
-			"--claim": true, "--ephemeral": true,
+			"--claim":                   true, "--ephemeral": true,
 			"--history": true, "--no-history": true,
 			"--persistent": true, "--stdin": true,
 		}
 	case "close":
-		sub_ = map[string]bool{
+		subFlags = map[string]bool{
 			"--claim-next": true, "--continue": true,
 			"-f": true, "--force": true,
 			"--no-auto": true, "--suggest-next": true,
 		}
 	case "reopen":
-		sub_ = map[string]bool{}
+		subFlags = map[string]bool{}
 	case "delete":
-		sub_ = map[string]bool{
+		subFlags = map[string]bool{
 			"--cascade": true, "--dry-run": true,
 			"-f": true, "--force": true,
 		}
 	}
-	merged := make(map[string]bool, len(global)+len(sub_))
+	merged := make(map[string]bool, len(global)+len(subFlags))
 	for k := range global {
 		merged[k] = true
 	}
-	for k := range sub_ {
+	for k := range subFlags {
 		merged[k] = true
 	}
 	return merged

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -232,6 +232,33 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Pre-flight exact-ID guard for write-mutating subcommands (gcy-g4o).
+	// bd's fuzzy/substring resolver can silently match a longer ID that
+	// contains the supplied ID as a substring (e.g. "gcy-dv7" → "gcy-wisp-dv78").
+	// Verify via BdStore.Get — which already enforces an exact-ID match —
+	// before forwarding any mutation to the bd subprocess.
+	//
+	// Fail-closed: if the arg scanner reports ambiguity (unrecognised
+	// value-consuming flag), the command is rejected rather than forwarded
+	// unguarded.
+	if writeIDs, writeOK, ambiguous := bdMutationWriteIDs(bdArgs); writeOK {
+		if ambiguous {
+			fmt.Fprintf(stderr, "gc bd: cannot safely verify bead IDs (unrecognised flag in args %v); aborting to prevent substring-resolution mutation of the wrong bead\n", bdArgs) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if len(writeIDs) > 0 {
+			store, storeErr := openStoreAtForCity(target.ScopeRoot, cityPath)
+			if storeErr == nil {
+				for _, id := range writeIDs {
+					if _, getErr := store.Get(id); getErr != nil {
+						fmt.Fprintf(stderr, "gc bd: bead %q not found (exact match required; bd's fuzzy resolver may have resolved a different bead)\n", id) //nolint:errcheck // best-effort stderr
+						return 1
+					}
+				}
+			}
+		}
+	}
+
 	reapStaleBdExportJSONL(target.ScopeRoot)
 	warnExternalBdOverrideDrift(stderr, cityPath, target)
 
@@ -312,6 +339,213 @@ func parseBdReleaseIfCurrentArgs(args []string) (id, expectedAssignee string, ok
 
 func invalidBdReleaseIfCurrentArg(value string) bool {
 	return value == "" || strings.IndexFunc(value, unicode.IsSpace) >= 0
+}
+
+// bdMutationWriteIDs extracts all positional bead IDs from a bd write-mutation
+// command (update, close, reopen, delete) and reports whether the scan was
+// unambiguous.
+//
+// Returns:
+//   - ids: all positional (non-flag) tokens after the subcommand; may be empty.
+//   - ok: false if args is empty or the subcommand is not a write-mutation.
+//   - ambiguous: true if the scanner encountered an unrecognised flag that
+//     might consume the next argument as its value. In that case the caller
+//     must fail-closed — forwarding the command unguarded risks the original
+//     substring-resolution bug (gcy-g4o).
+//
+// The scanner has complete knowledge of every value-consuming flag for each
+// subcommand (sourced from `bd <sub> --help`). Unknown flags that start with
+// "-" and do not contain "=" are treated as potentially value-consuming, which
+// triggers ambiguous=true. Boolean flags (no value) are fine to ignore.
+// The "--" terminator is respected: everything after it is positional.
+//
+// All returned IDs must be verified via BdStore.Get (exact-ID guard) before
+// the mutation is forwarded to the bd subprocess.
+func bdMutationWriteIDs(args []string) (ids []string, ok bool, ambiguous bool) {
+	if len(args) == 0 {
+		return nil, false, false
+	}
+	sub := args[0]
+	switch sub {
+	case "update", "close", "reopen", "delete":
+	default:
+		return nil, false, false
+	}
+
+	// valueFlags is the complete set of flags that consume the next argument as
+	// their value for this subcommand, in both long and short form.
+	// Sourced from `bd <sub> --help` (2026-06-10).
+	valueFlags := bdSubcmdValueFlags(sub)
+
+	// boolFlags is the complete set of boolean (no-value) flags. Unknown flags
+	// not in either set trigger ambiguous=true.
+	boolFlags := bdSubcmdBoolFlags(sub)
+
+	positional := false // true after "--"
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		if positional {
+			if arg != "" {
+				ids = append(ids, arg)
+			}
+			continue
+		}
+		if arg == "--" {
+			positional = true
+			continue
+		}
+		if !strings.HasPrefix(arg, "-") {
+			// Positional token — a bead ID (or batch of IDs).
+			if arg != "" {
+				ids = append(ids, arg)
+			}
+			continue
+		}
+		// Flag token.
+		// --flag=value form: value is embedded, no next-arg consumed.
+		if strings.Contains(arg, "=") {
+			continue
+		}
+		// Strip leading dashes to get the flag name for lookup.
+		flagName := strings.TrimLeft(arg, "-")
+		// Reconstruct the canonical long or short form for set membership.
+		longForm := "--" + flagName
+		shortForm := "-" + flagName // only meaningful when flagName is 1 char
+
+		if valueFlags[longForm] || (len(flagName) == 1 && valueFlags[shortForm]) {
+			// Known value-consuming flag: skip its value argument.
+			i++
+			continue
+		}
+		if boolFlags[longForm] || (len(flagName) == 1 && boolFlags[shortForm]) {
+			// Known boolean flag: no value to skip.
+			continue
+		}
+		// Unknown flag. It might consume a value argument that looks like a
+		// bead ID. Fail-closed: report ambiguity so the caller can reject.
+		ambiguous = true
+		return nil, true, true
+	}
+	return ids, true, false
+}
+
+// bdSubcmdValueFlags returns the set of value-consuming flag names (in
+// "--long" / "-s" form) for the given bd write-mutation subcommand.
+// Sourced from `bd <sub> --help` output (2026-06-10).
+func bdSubcmdValueFlags(sub string) map[string]bool {
+	// Global flags shared by all bd subcommands that take a value.
+	global := map[string]bool{
+		"--actor": true, "--db": true, "--directory": true, "-C": true,
+		"--dolt-auto-commit": true,
+	}
+	var sub_ map[string]bool
+	switch sub {
+	case "update":
+		sub_ = map[string]bool{
+			"--acceptance": true,
+			"--add-label":  true, "--append-notes": true,
+			"-a": true, "--assignee": true,
+			"--await-id":    true,
+			"--body-file":   true,
+			"--defer":       true,
+			"-d": true, "--description": true,
+			"--design": true, "--design-file": true,
+			"--due":          true,
+			"-e": true, "--estimate": true,
+			"--external-ref": true,
+			"--metadata":     true,
+			"--notes":        true,
+			"--parent":       true,
+			"-p": true, "--priority": true,
+			"--remove-label":   true,
+			"--session":        true,
+			"--set-labels":     true,
+			"--set-metadata":   true,
+			"-s": true, "--status": true,
+			"-t": true, "--type": true,
+			"--title":          true,
+			"--spec-id":        true,
+			"--unset-metadata": true,
+		}
+	case "close":
+		sub_ = map[string]bool{
+			"-r": true, "--reason": true,
+			"--reason-file": true,
+			"--session":     true,
+		}
+	case "reopen":
+		sub_ = map[string]bool{
+			"-r": true, "--reason": true,
+		}
+	case "delete":
+		sub_ = map[string]bool{
+			"--from-file": true,
+		}
+	}
+	merged := make(map[string]bool, len(global)+len(sub_))
+	for k := range global {
+		merged[k] = true
+	}
+	for k := range sub_ {
+		merged[k] = true
+	}
+	return merged
+}
+
+// bdSubcmdBoolFlags returns the set of boolean (no-value) flag names for the
+// given bd write-mutation subcommand.
+// Sourced from `bd <sub> --help` output (2026-06-10).
+func bdSubcmdBoolFlags(sub string) map[string]bool {
+	// Global boolean flags shared by all bd subcommands.
+	global := map[string]bool{
+		"--global": true, "--ignore-schema-skew": true,
+		"--json": true, "--profile": true,
+		"-q": true, "--quiet": true,
+		"--readonly": true, "--sandbox": true,
+		"-v": true, "--verbose": true,
+		"-h": true, "--help": true,
+	}
+	var sub_ map[string]bool
+	switch sub {
+	case "update":
+		sub_ = map[string]bool{
+			"--allow-empty-description": true,
+			"--claim": true, "--ephemeral": true,
+			"--history": true, "--no-history": true,
+			"--persistent": true, "--stdin": true,
+		}
+	case "close":
+		sub_ = map[string]bool{
+			"--claim-next": true, "--continue": true,
+			"-f": true, "--force": true,
+			"--no-auto": true, "--suggest-next": true,
+		}
+	case "reopen":
+		sub_ = map[string]bool{}
+	case "delete":
+		sub_ = map[string]bool{
+			"--cascade": true, "--dry-run": true,
+			"-f": true, "--force": true,
+		}
+	}
+	merged := make(map[string]bool, len(global)+len(sub_))
+	for k := range global {
+		merged[k] = true
+	}
+	for k := range sub_ {
+		merged[k] = true
+	}
+	return merged
+}
+
+// bdMutationWriteID is a compatibility shim retained for callers that only
+// need the first ID. Prefer bdMutationWriteIDs for new code.
+func bdMutationWriteID(args []string) (string, bool) {
+	ids, ok, ambiguous := bdMutationWriteIDs(args)
+	if !ok || ambiguous || len(ids) == 0 {
+		return "", false
+	}
+	return ids[0], true
 }
 
 func doBdReleaseIfCurrent(cityPath string, target execStoreTarget, id, expectedAssignee string, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -2269,6 +2269,253 @@ func TestRewriteBdHeartbeatArgs(t *testing.T) {
 	})
 }
 
+// TestBdMutationWriteID covers the compatibility shim (first-ID extraction).
+func TestBdMutationWriteID(t *testing.T) {
+	t.Run("extracts id from write subcommands", func(t *testing.T) {
+		cases := []struct {
+			args []string
+			want string
+		}{
+			{[]string{"update", "gcy-dv7", "--title", "x"}, "gcy-dv7"},
+			{[]string{"update", "--title", "x", "gcy-dv7"}, "gcy-dv7"},
+			{[]string{"close", "gcy-dv7"}, "gcy-dv7"},
+			{[]string{"close", "--reason", "done", "gcy-dv7"}, "gcy-dv7"},
+			{[]string{"close", "--force", "--json", "gcy-dv7"}, "gcy-dv7"},
+			{[]string{"reopen", "gcy-dv7"}, "gcy-dv7"},
+			{[]string{"delete", "--force", "gcy-dv7"}, "gcy-dv7"},
+			{[]string{"delete", "--force", "--json", "gcy-dv7"}, "gcy-dv7"},
+			// double-dash separator
+			{[]string{"update", "--", "gcy-dv7"}, "gcy-dv7"},
+		}
+		for _, tc := range cases {
+			got, ok := bdMutationWriteID(tc.args)
+			if !ok || got != tc.want {
+				t.Errorf("bdMutationWriteID(%q) = (%q, %v), want (%q, true)", tc.args, got, ok, tc.want)
+			}
+		}
+	})
+	t.Run("returns false for read or unrecognised subcommands", func(t *testing.T) {
+		for _, args := range [][]string{
+			{"show", "gcy-dv7"},
+			{"list", "-s", "open"},
+			{"query", "gcy-dv7"},
+			{},
+			{"create", "new task"},
+		} {
+			if _, ok := bdMutationWriteID(args); ok {
+				t.Errorf("bdMutationWriteID(%q) returned ok=true, want false", args)
+			}
+		}
+	})
+	// Regression: short ID "gcy-dv7" must NOT be confused for "gcy-wisp-dv78"
+	// by the caller — the returned token is the exact string in args.
+	t.Run("returns the exact supplied token (gcy-g4o regression)", func(t *testing.T) {
+		got, ok := bdMutationWriteID([]string{"update", "gcy-dv7", "--status", "open"})
+		if !ok || got != "gcy-dv7" {
+			t.Errorf("bdMutationWriteID: got (%q, %v), want (\"gcy-dv7\", true)", got, ok)
+		}
+	})
+}
+
+// TestBdMutationWriteIDs covers the full scanner used by the pre-flight guard.
+func TestBdMutationWriteIDs(t *testing.T) {
+	type result struct {
+		ids       []string
+		ok        bool
+		ambiguous bool
+	}
+	cases := []struct {
+		name string
+		args []string
+		want result
+	}{
+		// --- Basic extraction ---
+		{
+			name: "single id, no flags",
+			args: []string{"close", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "id before flags",
+			args: []string{"update", "gcy-dv7", "--title", "x"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "id after long value flag",
+			args: []string{"update", "--title", "new title", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+
+		// --- Short flags (previously broken) ---
+		{
+			name: "short -s value flag before id",
+			args: []string{"update", "-s", "closed", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "short -a value flag before id",
+			args: []string{"update", "-a", "alice", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "short -t value flag before id",
+			args: []string{"update", "-t", "task", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "short -p value flag before id",
+			args: []string{"update", "-p", "P2", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "short -d value flag before id",
+			args: []string{"update", "-d", "description text", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "short -e value flag before id",
+			args: []string{"update", "-e", "60", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "short -r reason flag for close before id",
+			args: []string{"close", "-r", "done", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "short -C directory flag before id",
+			args: []string{"close", "-C", "/some/path", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+
+		// --- --flag=value form ---
+		{
+			name: "--flag=value does not consume next token",
+			args: []string{"update", "--status=closed", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "--title=value with id after",
+			args: []string{"update", "--title=new title", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+
+		// --- Message / notes flags whose values may contain bead tokens ---
+		{
+			name: "notes value contains bead token",
+			args: []string{"update", "--notes", "see gcy-dv7 for context", "gcy-real"},
+			want: result{ids: []string{"gcy-real"}, ok: true},
+		},
+		{
+			name: "append-notes value contains bead token",
+			args: []string{"update", "--append-notes", "related: gcy-dv7", "gcy-real"},
+			want: result{ids: []string{"gcy-real"}, ok: true},
+		},
+
+		// --- Batch IDs ---
+		{
+			name: "batch close multiple ids",
+			args: []string{"close", "id1", "id2", "id3"},
+			want: result{ids: []string{"id1", "id2", "id3"}, ok: true},
+		},
+		{
+			name: "batch delete multiple ids with --force",
+			args: []string{"delete", "--force", "id1", "id2", "id3"},
+			want: result{ids: []string{"id1", "id2", "id3"}, ok: true},
+		},
+		{
+			name: "batch update with flags interspersed",
+			args: []string{"update", "--status", "closed", "id1", "id2"},
+			want: result{ids: []string{"id1", "id2"}, ok: true},
+		},
+
+		// --- Double-dash terminator ---
+		{
+			name: "double-dash: everything after is positional",
+			args: []string{"update", "--", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "double-dash: multiple ids after",
+			args: []string{"close", "--force", "--", "id1", "id2"},
+			want: result{ids: []string{"id1", "id2"}, ok: true},
+		},
+
+		// --- Fail-closed: ambiguous unknown flags ---
+		// gcy-g4o demonstrated break: `close --session gcy-realbead gcy-dv7`
+		// Previously the hand-rolled scanner lacked --session → returned
+		// "gcy-realbead" as the ID, leaving gcy-dv7 unguarded. Now --session
+		// is in the known set so it is correctly handled, but an *unknown*
+		// value flag must trigger ambiguous.
+		{
+			name: "known --session flag handled correctly for close",
+			args: []string{"close", "--session", "sess-id-abc", "gcy-dv7"},
+			want: result{ids: []string{"gcy-dv7"}, ok: true},
+		},
+		{
+			name: "unknown value flag triggers fail-closed",
+			args: []string{"close", "--unknown-future-flag", "gcy-realbead", "gcy-dv7"},
+			want: result{ok: true, ambiguous: true},
+		},
+		{
+			name: "unknown short flag triggers fail-closed",
+			args: []string{"update", "-z", "something", "gcy-dv7"},
+			want: result{ok: true, ambiguous: true},
+		},
+
+		// --- Non-write subcommands ---
+		{
+			name: "show is not a write command",
+			args: []string{"show", "gcy-dv7"},
+			want: result{ok: false},
+		},
+		{
+			name: "list is not a write command",
+			args: []string{"list", "-s", "open"},
+			want: result{ok: false},
+		},
+		{
+			name: "empty args",
+			args: []string{},
+			want: result{ok: false},
+		},
+
+		// --- No IDs supplied (e.g. "last touched" fallback) ---
+		{
+			name: "update with no ids (last-touched fallback)",
+			args: []string{"update", "--status", "closed"},
+			want: result{ids: nil, ok: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ids, ok, ambiguous := bdMutationWriteIDs(tc.args)
+			if ok != tc.want.ok {
+				t.Errorf("ok = %v, want %v", ok, tc.want.ok)
+			}
+			if ambiguous != tc.want.ambiguous {
+				t.Errorf("ambiguous = %v, want %v", ambiguous, tc.want.ambiguous)
+			}
+			if !bdTestSlicesEqual(ids, tc.want.ids) {
+				t.Errorf("ids = %v, want %v", ids, tc.want.ids)
+			}
+		})
+	}
+}
+
+func bdTestSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestParseBdReleaseIfCurrentArgs(t *testing.T) {
 	id, assignee, ok, err := parseBdReleaseIfCurrentArgs([]string{"release-if-current", "gc-abc", "worker-1"})
 	if err != nil {

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -2294,7 +2294,7 @@ func TestBdMutationWriteID(t *testing.T) {
 			}
 		}
 	})
-	t.Run("returns false for read or unrecognised subcommands", func(t *testing.T) {
+	t.Run("returns false for read or unrecognized subcommands", func(t *testing.T) {
 		for _, args := range [][]string{
 			{"show", "gcy-dv7"},
 			{"list", "-s", "open"},

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -941,7 +941,16 @@ func (s *BdStore) Get(id string) (Bead, error) {
 	if len(issues) == 0 {
 		return Bead{}, fmt.Errorf("getting bead %q: %w", id, ErrNotFound)
 	}
-	return issues[0].toBead(), nil
+	bead := issues[0].toBead()
+	// Guard against bd's fuzzy/substring ID resolution silently returning a
+	// different bead than requested (gascity#gcy-g4o). bd may resolve a short
+	// ID like "gcy-dv7" to an unrelated bead whose ID contains "dv7" as a
+	// substring (e.g. "gcy-wisp-dv78"). Since gc always passes full bead IDs,
+	// a mismatch means the requested bead does not exist in this store.
+	if bead.ID != id {
+		return Bead{}, fmt.Errorf("getting bead %q: %w", id, ErrNotFound)
+	}
+	return bead, nil
 }
 
 // Update modifies fields of an existing bead via bd update.

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -958,23 +958,6 @@ func (s *BdStore) Get(id string) (Bead, error) {
 	return bead, nil
 }
 
-// guardExactID checks whether the given id would collide with a different bead
-// via bd's fuzzy/substring resolver. It calls Get and inspects the result:
-//   - ErrIDCollision → returns ErrIDCollision so the caller can abort the mutation.
-//   - ErrNotFound or any other error (store unavailable, projection lag) → returns nil
-//     so the mutation is allowed to proceed (bd will produce its own error if needed).
-//   - Success (bead.ID == id) → returns nil.
-//
-// This intentionally does NOT block on ErrNotFound so that callers handling
-// ephemeral/wisp beads, projection-lagged rows, or store-unavailable paths are
-// not regressed. Only a genuine substring collision is fatal.
-func (s *BdStore) guardExactID(id string) error {
-	if _, err := s.Get(id); errors.Is(err, ErrIDCollision) {
-		return err
-	}
-	return nil
-}
-
 // Update modifies fields of an existing bead via bd update.
 func (s *BdStore) Update(id string, opts UpdateOpts) error {
 	args := []string{"update", "--json", id}
@@ -1019,11 +1002,9 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 	if len(args) == 3 {
 		return nil
 	}
-	// Guard against bd's fuzzy/substring resolver mutating the wrong bead
-	// (gcy-g4o). Only runs when there are actual fields to write.
-	if err := s.guardExactID(id); err != nil {
-		return fmt.Errorf("updating bead %q: %w", id, err)
-	}
+	// Internal store callers supply canonical full IDs; the exact-ID collision
+	// guard lives at the CLI/API entry points (cmd_bd.go, huma_handlers_beads.go)
+	// where user-typed short IDs originate (gcy-g4o).
 	err := s.runBDTransientWrite(args...)
 	if err != nil {
 		if isBdNotFound(err) {
@@ -1964,11 +1945,8 @@ func bdCloseArgs(reason string, ids ...string) []string {
 }
 
 func (s *BdStore) close(id, reason string) error {
-	// Guard against bd's fuzzy/substring resolver mutating the wrong bead
-	// (gcy-g4o). A genuine ID collision aborts; ErrNotFound passes through.
-	if err := s.guardExactID(id); err != nil {
-		return fmt.Errorf("closing bead %q: %w", id, err)
-	}
+	// Internal callers supply canonical full IDs; exact-ID guard lives at the
+	// CLI/API entry points (gcy-g4o).
 	err := s.runBDTransientWrite(bdCloseArgs(reason, id)...)
 	if err != nil {
 		// Some bd error paths collapse to a bare exit status without a helpful
@@ -2007,11 +1985,8 @@ func (s *BdStore) Reopen(id string) error {
 
 // Delete permanently removes a bead from the store via bd delete.
 func (s *BdStore) Delete(id string) error {
-	// Guard against bd's fuzzy/substring resolver mutating the wrong bead
-	// (gcy-g4o). A genuine ID collision aborts; ErrNotFound passes through.
-	if err := s.guardExactID(id); err != nil {
-		return fmt.Errorf("deleting bead %q: %w", id, err)
-	}
+	// Internal callers supply canonical full IDs; exact-ID guard lives at the
+	// CLI/API entry points (gcy-g4o).
 	err := s.runBDTransientWrite("delete", "--force", "--json", id)
 	if err != nil {
 		if isBdNotFound(err) {

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -948,9 +948,31 @@ func (s *BdStore) Get(id string) (Bead, error) {
 	// substring (e.g. "gcy-wisp-dv78"). Since gc always passes full bead IDs,
 	// a mismatch means the requested bead does not exist in this store.
 	if bead.ID != id {
-		return Bead{}, fmt.Errorf("getting bead %q: %w", id, ErrNotFound)
+		// bd resolved a DIFFERENT bead (substring collision): the requested ID
+		// does not exist in this store but bd silently matched another one.
+		// Return ErrIDCollision so mutation guards can distinguish this from a
+		// plain absent bead. ErrIDCollision wraps ErrNotFound so existing
+		// errors.Is(err, ErrNotFound) callers remain unaffected.
+		return Bead{}, fmt.Errorf("getting bead %q (resolved to %q): %w", id, bead.ID, ErrIDCollision)
 	}
 	return bead, nil
+}
+
+// guardExactID checks whether the given id would collide with a different bead
+// via bd's fuzzy/substring resolver. It calls Get and inspects the result:
+//   - ErrIDCollision → returns ErrIDCollision so the caller can abort the mutation.
+//   - ErrNotFound or any other error (store unavailable, projection lag) → returns nil
+//     so the mutation is allowed to proceed (bd will produce its own error if needed).
+//   - Success (bead.ID == id) → returns nil.
+//
+// This intentionally does NOT block on ErrNotFound so that callers handling
+// ephemeral/wisp beads, projection-lagged rows, or store-unavailable paths are
+// not regressed. Only a genuine substring collision is fatal.
+func (s *BdStore) guardExactID(id string) error {
+	if _, err := s.Get(id); errors.Is(err, ErrIDCollision) {
+		return err
+	}
+	return nil
 }
 
 // Update modifies fields of an existing bead via bd update.
@@ -996,6 +1018,11 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 	// No fields to update — no-op (bd errors on empty update).
 	if len(args) == 3 {
 		return nil
+	}
+	// Guard against bd's fuzzy/substring resolver mutating the wrong bead
+	// (gcy-g4o). Only runs when there are actual fields to write.
+	if err := s.guardExactID(id); err != nil {
+		return fmt.Errorf("updating bead %q: %w", id, err)
 	}
 	err := s.runBDTransientWrite(args...)
 	if err != nil {
@@ -1937,6 +1964,11 @@ func bdCloseArgs(reason string, ids ...string) []string {
 }
 
 func (s *BdStore) close(id, reason string) error {
+	// Guard against bd's fuzzy/substring resolver mutating the wrong bead
+	// (gcy-g4o). A genuine ID collision aborts; ErrNotFound passes through.
+	if err := s.guardExactID(id); err != nil {
+		return fmt.Errorf("closing bead %q: %w", id, err)
+	}
 	err := s.runBDTransientWrite(bdCloseArgs(reason, id)...)
 	if err != nil {
 		// Some bd error paths collapse to a bare exit status without a helpful
@@ -1975,6 +2007,11 @@ func (s *BdStore) Reopen(id string) error {
 
 // Delete permanently removes a bead from the store via bd delete.
 func (s *BdStore) Delete(id string) error {
+	// Guard against bd's fuzzy/substring resolver mutating the wrong bead
+	// (gcy-g4o). A genuine ID collision aborts; ErrNotFound passes through.
+	if err := s.guardExactID(id); err != nil {
+		return fmt.Errorf("deleting bead %q: %w", id, err)
+	}
 	err := s.runBDTransientWrite("delete", "--force", "--json", id)
 	if err != nil {
 		if isBdNotFound(err) {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -500,82 +500,14 @@ func TestBdStoreGetExactIDGuard(t *testing.T) {
 	}
 }
 
-// TestBdStoreUpdateBlocksOnIDCollision verifies that Update refuses to mutate
-// when bd's resolver would return a different bead (gcy-g4o regression).
-func TestBdStoreUpdateBlocksOnIDCollision(t *testing.T) {
-	runner := fakeRunner(map[string]struct {
-		out []byte
-		err error
-	}{
-		// Get pre-check: bd resolves "gcy-dv7" to the wrong bead.
-		`bd show --json gcy-dv7`: {
-			out: []byte(`[{"id":"gcy-wisp-dv78","title":"Wrong bead","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
-		},
-	})
-	s := beads.NewBdStore("/city", runner)
-	title := "mutated"
-	err := s.Update("gcy-dv7", beads.UpdateOpts{Title: &title})
-	if err == nil {
-		t.Fatal("Update returned nil error, want ErrIDCollision")
-	}
-	if !errors.Is(err, beads.ErrIDCollision) {
-		t.Errorf("Update error = %v, want errors.Is(err, ErrIDCollision) true", err)
-	}
-}
-
-// TestBdStoreDeleteBlocksOnIDCollision verifies that Delete refuses to mutate
-// when bd's resolver would return a different bead (gcy-g4o regression).
-func TestBdStoreDeleteBlocksOnIDCollision(t *testing.T) {
-	runner := fakeRunner(map[string]struct {
-		out []byte
-		err error
-	}{
-		`bd show --json gcy-dv7`: {
-			out: []byte(`[{"id":"gcy-wisp-dv78","title":"Wrong bead","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
-		},
-	})
-	s := beads.NewBdStore("/city", runner)
-	err := s.Delete("gcy-dv7")
-	if err == nil {
-		t.Fatal("Delete returned nil error, want ErrIDCollision")
-	}
-	if !errors.Is(err, beads.ErrIDCollision) {
-		t.Errorf("Delete error = %v, want errors.Is(err, ErrIDCollision) true", err)
-	}
-}
-
-// TestBdStoreCloseBlocksOnIDCollision verifies that Close refuses to mutate
-// when bd's resolver would return a different bead (gcy-g4o regression).
-func TestBdStoreCloseBlocksOnIDCollision(t *testing.T) {
-	runner := fakeRunner(map[string]struct {
-		out []byte
-		err error
-	}{
-		`bd show --json gcy-dv7`: {
-			out: []byte(`[{"id":"gcy-wisp-dv78","title":"Wrong bead","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
-		},
-	})
-	s := beads.NewBdStore("/city", runner)
-	err := s.Close("gcy-dv7")
-	if err == nil {
-		t.Fatal("Close returned nil error, want ErrIDCollision")
-	}
-	if !errors.Is(err, beads.ErrIDCollision) {
-		t.Errorf("Close error = %v, want errors.Is(err, ErrIDCollision) true", err)
-	}
-}
-
 // TestBdStoreMutationsPassThroughOnNotFound verifies that Update/Delete/Close
-// do NOT block when the bead simply doesn't exist (ErrNotFound without
-// collision). The write should reach bd and let bd produce its own error.
+// always reach bd directly (internal hot-path callers supply canonical full IDs;
+// the exact-ID collision guard lives at the CLI/API entry points — gcy-g4o).
 func TestBdStoreMutationsPassThroughOnNotFound(t *testing.T) {
 	var updateCalled, deleteCalled, closeCalled bool
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		cmd := strings.Join(append([]string{name}, args...), " ")
 		switch {
-		case cmd == "bd show --json gcy-dv7":
-			// bd returns empty — bead simply absent, no collision.
-			return []byte("[]"), nil
 		case strings.HasPrefix(cmd, "bd update "):
 			updateCalled = true
 			return nil, fmt.Errorf("bd: issue not found")
@@ -1101,13 +1033,10 @@ func TestBdStoreTxCombinesWritesForSameBead(t *testing.T) {
 
 	want := []string{
 		"bd show --json bd-42", // Tx initial Get
-		"bd show --json bd-42", // guardExactID pre-check before update
 		"bd update --json bd-42 --title before --type task --priority 2 --description after --set-metadata close_reason=completed during transaction --set-metadata existing=kept --set-metadata tx=applied",
 		"bd show --json bd-42", // honesty re-read after update (close's honesty guard)
-		"bd show --json bd-42", // guardExactID pre-check before close
 		"bd close --force --json --reason completed during transaction bd-42",
 		"bd show --json bd-42", // honesty re-read after close (close's honesty guard)
-		"bd show --json bd-42", // guardExactID pre-check before fallback update
 		"bd update --json bd-42 --title before --status closed --type task --priority 2 --description after --set-metadata close_reason=completed during transaction --set-metadata existing=kept --set-metadata tx=applied",
 		"bd show --json bd-42", // Tx final Get
 		"bd show --json bd-42", // final Get after Tx
@@ -1146,7 +1075,6 @@ func TestBdStoreTxCloseOnlyUsesCloseCommand(t *testing.T) {
 
 	want := []string{
 		"bd show --json bd-42", // Tx initial Get
-		"bd show --json bd-42", // guardExactID pre-check before close
 		"bd close --force --json --reason completed during transaction bd-42",
 		"bd show --json bd-42", // honesty re-read after close
 	}
@@ -1210,7 +1138,6 @@ func TestBdStoreTxPreservesAddsAndRemovesLabels(t *testing.T) {
 
 	want := []string{
 		"bd show --json bd-42", // Tx initial Get
-		"bd show --json bd-42", // guardExactID pre-check before update
 		"bd update --json bd-42 --title before --status open --type task --add-label b --add-label c --remove-label a",
 	}
 	if !reflect.DeepEqual(commands, want) {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -471,6 +471,29 @@ func TestBdStoreGetEmptyArray(t *testing.T) {
 	}
 }
 
+// TestBdStoreGetExactIDGuard verifies that BdStore.Get returns ErrNotFound when
+// bd's fuzzy resolver returns a different bead than requested (gcy-g4o).
+// e.g. requesting "gcy-dv7" must NOT silently accept "gcy-wisp-dv78".
+func TestBdStoreGetExactIDGuard(t *testing.T) {
+	// bd returns a bead whose ID is a superset of the requested ID.
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd show --json gcy-dv7`: {
+			out: []byte(`[{"id":"gcy-wisp-dv78","title":"Wrong bead","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	_, err := s.Get("gcy-dv7")
+	if err == nil {
+		t.Fatal("Get returned nil error, want ErrNotFound")
+	}
+	if !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("Get error = %v, want ErrNotFound", err)
+	}
+}
+
 // --- Close ---
 
 func TestBdStoreClose(t *testing.T) {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -471,9 +471,12 @@ func TestBdStoreGetEmptyArray(t *testing.T) {
 	}
 }
 
-// TestBdStoreGetExactIDGuard verifies that BdStore.Get returns ErrNotFound when
-// bd's fuzzy resolver returns a different bead than requested (gcy-g4o).
-// e.g. requesting "gcy-dv7" must NOT silently accept "gcy-wisp-dv78".
+// TestBdStoreGetExactIDGuard verifies that BdStore.Get returns ErrIDCollision
+// (which wraps ErrNotFound) when bd's fuzzy resolver returns a different bead
+// than requested (gcy-g4o). e.g. requesting "gcy-dv7" must NOT silently accept
+// "gcy-wisp-dv78". Both errors.Is(err, ErrNotFound) and
+// errors.Is(err, ErrIDCollision) must hold so mutation guards can distinguish
+// a genuine collision from a plain absent bead.
 func TestBdStoreGetExactIDGuard(t *testing.T) {
 	// bd returns a bead whose ID is a superset of the requested ID.
 	runner := fakeRunner(map[string]struct {
@@ -487,10 +490,117 @@ func TestBdStoreGetExactIDGuard(t *testing.T) {
 	s := beads.NewBdStore("/city", runner)
 	_, err := s.Get("gcy-dv7")
 	if err == nil {
-		t.Fatal("Get returned nil error, want ErrNotFound")
+		t.Fatal("Get returned nil error, want ErrIDCollision")
 	}
 	if !errors.Is(err, beads.ErrNotFound) {
-		t.Errorf("Get error = %v, want ErrNotFound", err)
+		t.Errorf("Get error = %v, want errors.Is(err, ErrNotFound) true", err)
+	}
+	if !errors.Is(err, beads.ErrIDCollision) {
+		t.Errorf("Get error = %v, want errors.Is(err, ErrIDCollision) true", err)
+	}
+}
+
+// TestBdStoreUpdateBlocksOnIDCollision verifies that Update refuses to mutate
+// when bd's resolver would return a different bead (gcy-g4o regression).
+func TestBdStoreUpdateBlocksOnIDCollision(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		// Get pre-check: bd resolves "gcy-dv7" to the wrong bead.
+		`bd show --json gcy-dv7`: {
+			out: []byte(`[{"id":"gcy-wisp-dv78","title":"Wrong bead","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	title := "mutated"
+	err := s.Update("gcy-dv7", beads.UpdateOpts{Title: &title})
+	if err == nil {
+		t.Fatal("Update returned nil error, want ErrIDCollision")
+	}
+	if !errors.Is(err, beads.ErrIDCollision) {
+		t.Errorf("Update error = %v, want errors.Is(err, ErrIDCollision) true", err)
+	}
+}
+
+// TestBdStoreDeleteBlocksOnIDCollision verifies that Delete refuses to mutate
+// when bd's resolver would return a different bead (gcy-g4o regression).
+func TestBdStoreDeleteBlocksOnIDCollision(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd show --json gcy-dv7`: {
+			out: []byte(`[{"id":"gcy-wisp-dv78","title":"Wrong bead","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	err := s.Delete("gcy-dv7")
+	if err == nil {
+		t.Fatal("Delete returned nil error, want ErrIDCollision")
+	}
+	if !errors.Is(err, beads.ErrIDCollision) {
+		t.Errorf("Delete error = %v, want errors.Is(err, ErrIDCollision) true", err)
+	}
+}
+
+// TestBdStoreCloseBlocksOnIDCollision verifies that Close refuses to mutate
+// when bd's resolver would return a different bead (gcy-g4o regression).
+func TestBdStoreCloseBlocksOnIDCollision(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd show --json gcy-dv7`: {
+			out: []byte(`[{"id":"gcy-wisp-dv78","title":"Wrong bead","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	err := s.Close("gcy-dv7")
+	if err == nil {
+		t.Fatal("Close returned nil error, want ErrIDCollision")
+	}
+	if !errors.Is(err, beads.ErrIDCollision) {
+		t.Errorf("Close error = %v, want errors.Is(err, ErrIDCollision) true", err)
+	}
+}
+
+// TestBdStoreMutationsPassThroughOnNotFound verifies that Update/Delete/Close
+// do NOT block when the bead simply doesn't exist (ErrNotFound without
+// collision). The write should reach bd and let bd produce its own error.
+func TestBdStoreMutationsPassThroughOnNotFound(t *testing.T) {
+	var updateCalled, deleteCalled, closeCalled bool
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		cmd := strings.Join(append([]string{name}, args...), " ")
+		switch {
+		case cmd == "bd show --json gcy-dv7":
+			// bd returns empty — bead simply absent, no collision.
+			return []byte("[]"), nil
+		case strings.HasPrefix(cmd, "bd update "):
+			updateCalled = true
+			return nil, fmt.Errorf("bd: issue not found")
+		case strings.HasPrefix(cmd, "bd delete "):
+			deleteCalled = true
+			return nil, fmt.Errorf("bd: issue not found")
+		case strings.HasPrefix(cmd, "bd close "):
+			closeCalled = true
+			return nil, fmt.Errorf("bd: issue not found")
+		}
+		return nil, fmt.Errorf("unexpected: %s", cmd)
+	}
+	s := beads.NewBdStore("/city", runner)
+	title := "x"
+	_ = s.Update("gcy-dv7", beads.UpdateOpts{Title: &title})
+	_ = s.Delete("gcy-dv7")
+	_ = s.Close("gcy-dv7")
+	if !updateCalled {
+		t.Error("Update did not reach bd when bead was not-found (should pass through)")
+	}
+	if !deleteCalled {
+		t.Error("Delete did not reach bd when bead was not-found (should pass through)")
+	}
+	if !closeCalled {
+		t.Error("Close did not reach bd when bead was not-found (should pass through)")
 	}
 }
 
@@ -990,14 +1100,17 @@ func TestBdStoreTxCombinesWritesForSameBead(t *testing.T) {
 	}
 
 	want := []string{
-		"bd show --json bd-42",
+		"bd show --json bd-42", // Tx initial Get
+		"bd show --json bd-42", // guardExactID pre-check before update
 		"bd update --json bd-42 --title before --type task --priority 2 --description after --set-metadata close_reason=completed during transaction --set-metadata existing=kept --set-metadata tx=applied",
-		"bd show --json bd-42",
+		"bd show --json bd-42", // honesty re-read after update (close's honesty guard)
+		"bd show --json bd-42", // guardExactID pre-check before close
 		"bd close --force --json --reason completed during transaction bd-42",
-		"bd show --json bd-42",
+		"bd show --json bd-42", // honesty re-read after close (close's honesty guard)
+		"bd show --json bd-42", // guardExactID pre-check before fallback update
 		"bd update --json bd-42 --title before --status closed --type task --priority 2 --description after --set-metadata close_reason=completed during transaction --set-metadata existing=kept --set-metadata tx=applied",
-		"bd show --json bd-42",
-		"bd show --json bd-42",
+		"bd show --json bd-42", // Tx final Get
+		"bd show --json bd-42", // final Get after Tx
 	}
 	if !reflect.DeepEqual(commands, want) {
 		t.Fatalf("commands = %#v, want %#v", commands, want)
@@ -1032,9 +1145,10 @@ func TestBdStoreTxCloseOnlyUsesCloseCommand(t *testing.T) {
 	}
 
 	want := []string{
-		"bd show --json bd-42",
+		"bd show --json bd-42", // Tx initial Get
+		"bd show --json bd-42", // guardExactID pre-check before close
 		"bd close --force --json --reason completed during transaction bd-42",
-		"bd show --json bd-42",
+		"bd show --json bd-42", // honesty re-read after close
 	}
 	if !reflect.DeepEqual(commands, want) {
 		t.Fatalf("commands = %#v, want %#v", commands, want)
@@ -1095,7 +1209,8 @@ func TestBdStoreTxPreservesAddsAndRemovesLabels(t *testing.T) {
 	}
 
 	want := []string{
-		"bd show --json bd-42",
+		"bd show --json bd-42", // Tx initial Get
+		"bd show --json bd-42", // guardExactID pre-check before update
 		"bd update --json bd-42 --title before --status open --type task --add-label b --add-label c --remove-label a",
 	}
 	if !reflect.DeepEqual(commands, want) {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -5,11 +5,21 @@ package beads
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 )
 
 // ErrNotFound is returned when a bead ID does not exist in the store.
 var ErrNotFound = errors.New("bead not found")
+
+// ErrIDCollision is returned when bd's fuzzy/substring resolver returns a bead
+// whose ID differs from the requested ID (e.g. "gcy-dv7" resolves to
+// "gcy-wisp-dv78"). This is a distinct sub-case of not-found: the requested
+// bead is absent AND bd silently matched a different one. errors.Is(err,
+// ErrNotFound) remains true so existing not-found callers are unaffected;
+// mutation guards that need to distinguish a genuine collision from a plain
+// absent bead should check errors.Is(err, ErrIDCollision).
+var ErrIDCollision = fmt.Errorf("bd resolved a different bead ID (substring collision): %w", ErrNotFound)
 
 // ErrCacheUnavailable is returned by cache-only read handles when the cache
 // cannot answer without consulting the backing store.


### PR DESCRIPTION
## Summary

Single-scope split of #3332 (by @sarendipitee) for independent review + clean bisection, per the maintainer mixed-scope split policy.

This is the **fix(beads) exact-ID** scope: stop substring mis-resolution on `gc bd` writes by requiring exact-ID match, close the `ErrIDCollision`/over-reject gap, and scope the collision guard to CLI/API entry points.

## Commits (cherry-picked from #3332, authorship preserved)
- `fix(beads)`: exact-ID match for `gc bd` writes to stop substring mis-resolution (gcy-g4o)
- `fix(beads)`: close ErrIDCollision/over-reject gap in exact-ID guard (gcy-wck, gcy-g4o)
- `refactor(beads)`: scope exact-ID collision guard to CLI/API entry points

Kept together as one PR because the refactor is part of the same guard — splitting it would break bisection.

## Test plan
- `make build` clean; `go test ./internal/beads/... ./cmd/gc/` green.

Credit: @sarendipitee (#3332). Split by maintainer for review hygiene.
