### PR TITLE
fix(dolt): dedup mol-dog-doctor [MEDIUM] advisory storm (#3409)

### DIFF
--- a/examples/bd/dolt/assets/scripts/advisory_state.sh
+++ b/examples/bd/dolt/assets/scripts/advisory_state.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# advisory_state.sh — collapse a persistent dolt-health advisory into a single
+# rolling notification instead of one mayor bead per doctor tick (#3409).
+#
+# mol-dog-doctor runs as a cooldown order every 5 minutes. Any sustained warning
+# (latency at threshold, connections high, orphan DBs, stale backups) would
+# otherwise mail a fresh "Dolt health advisory [MEDIUM]" every tick, flooding the
+# mayor inbox with identical beads for one root cause. These helpers persist a
+# signature of the last-sent advisory and suppress re-sends until that signature
+# changes, clearing it when the server is healthy so the next occurrence
+# re-alerts.
+#
+# The caller builds the signature from the *set of active conditions*, not their
+# tick-volatile measurements (exact latency ms, connection count, backup age),
+# so a steady condition yields exactly one advisory while a changed condition set
+# re-alerts. The CRITICAL "server unreachable" escalation is intentionally NOT
+# routed through this dedup, so a true outage always alerts.
+#
+# Sourced by mol-dog-doctor.sh; unit-tested by test/dolt/advisory_dedup_test.sh.
+
+# advisory_changed SIGNATURE STATE_FILE — exit 0 when SIGNATURE differs from the
+# signature recorded in STATE_FILE (or none is recorded yet); exit 1 when they
+# are identical. Read-only: never writes. With no STATE_FILE it fails open
+# (treats the advisory as changed) so a misconfiguration degrades to the
+# pre-dedup behavior — a repeated alert — never to silence.
+advisory_changed() {
+  _adv_sig="${1:-}"
+  _adv_file="${2:-}"
+  [ -n "$_adv_file" ] || return 0
+  [ -f "$_adv_file" ] || return 0
+  IFS= read -r _adv_prev < "$_adv_file" 2>/dev/null || _adv_prev=""
+  if [ "$_adv_prev" = "$_adv_sig" ]; then
+    return 1
+  fi
+  return 0
+}
+
+# advisory_record SIGNATURE STATE_FILE — persist SIGNATURE as the last-sent
+# advisory. Call only after a successful send, so a failed escalation does not
+# suppress the retry on the next tick. Best-effort: a write failure is ignored
+# (fails open — the worst case is a duplicate alert, not a missed one).
+advisory_record() {
+  _adv_sig="${1:-}"
+  _adv_file="${2:-}"
+  [ -n "$_adv_file" ] || return 0
+  _adv_dir=$(dirname "$_adv_file")
+  [ -d "$_adv_dir" ] || mkdir -p "$_adv_dir" 2>/dev/null || true
+  ( umask 077; printf '%s\n' "$_adv_sig" > "$_adv_file" ) 2>/dev/null || true
+}
+
+# advisory_clear STATE_FILE — forget the last-sent signature so the next warning
+# re-alerts. Call when the server is healthy (no active warnings). Best-effort.
+advisory_clear() {
+  [ -n "${1:-}" ] || return 0
+  rm -f "$1" 2>/dev/null || true
+}

--- a/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 . "$PACK_DIR/assets/scripts/latency.sh"
+. "$PACK_DIR/assets/scripts/advisory_state.sh"
 . "$PACK_DIR/assets/scripts/_notify.sh"
 
 PORT="$GC_DOLT_PORT"
@@ -23,6 +24,10 @@ LATENCY_WARN_MS="${GC_DOCTOR_LATENCY_WARN_MS:-$(( ${GC_DOCTOR_LATENCY_WARN_S:-1}
 CONN_WARN_PCT="${GC_DOCTOR_CONN_WARN_PCT:-80}"
 BACKUP_STALE_S="${GC_DOCTOR_BACKUP_STALE_S:-43200}"  # 2x 6h backup interval
 BACKUP_ARTIFACT_DIR="${GC_BACKUP_ARTIFACT_DIR:-$GC_CITY_PATH/.dolt-backup}"
+# Advisory dedup state (#3409): records the signature of the last-sent [MEDIUM]
+# advisory so a persistent condition collapses into one rolling alert instead of
+# a fresh bead every 5-min tick. DOLT_STATE_DIR is set by runtime.sh.
+ADVISORY_STATE_FILE="${GC_DOCTOR_ADVISORY_STATE_FILE:-$DOLT_STATE_DIR/doctor-advisory-state}"
 
 dolt_sql() {
     DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" \
@@ -191,14 +196,29 @@ fi
 
 WARNINGS="${LATENCY_WARN}${CONN_WARN}${ORPHAN_WARN}${BACKUP_STALE}"
 if [ -n "$WARNINGS" ]; then
-    if ! send_escalation \
-        "Dolt health advisory [MEDIUM]" \
-        "Latency: ${LATENCY_MS}ms${LATENCY_WARN}
+    # Dedup (#3409): key on which conditions are active — not their tick-volatile
+    # values (exact latency ms, connection count, backup age) — and re-send only
+    # when that set changes. Record after a successful send so a failed
+    # escalation retries next tick. The CRITICAL "server unreachable" path above
+    # is never deduped, so a true outage always alerts.
+    ADVISORY_SIG=""
+    if [ -n "$LATENCY_WARN" ]; then ADVISORY_SIG="${ADVISORY_SIG}latency "; fi
+    if [ -n "$CONN_WARN" ]; then ADVISORY_SIG="${ADVISORY_SIG}conn "; fi
+    if [ -n "$ORPHAN_WARN" ]; then ADVISORY_SIG="${ADVISORY_SIG}orphan "; fi
+    if [ -n "$BACKUP_STALE" ]; then ADVISORY_SIG="${ADVISORY_SIG}backup "; fi
+    if advisory_changed "$ADVISORY_SIG" "$ADVISORY_STATE_FILE"; then
+        if send_escalation \
+            "Dolt health advisory [MEDIUM]" \
+            "Latency: ${LATENCY_MS}ms${LATENCY_WARN}
 Connections: ${CONN_COUNT}/${CONN_MAX}${CONN_WARN}
 Disk: ${DISK_USAGE}
 Orphan DBs: ${ORPHAN_COUNT}${ORPHAN_WARN}${BACKUP_STALE}"; then
-        :
+            advisory_record "$ADVISORY_SIG" "$ADVISORY_STATE_FILE"
+        fi
     fi
+else
+    # Healthy: forget the last advisory so a future condition re-alerts.
+    advisory_clear "$ADVISORY_STATE_FILE"
 fi
 
 SUMMARY="doctor — server: ok, latency: ${LATENCY_MS}ms, conns: ${CONN_COUNT}/${CONN_MAX}, disk: ${DISK_USAGE}, orphans: ${ORPHAN_COUNT}"

--- a/test/dolt/advisory_dedup_test.sh
+++ b/test/dolt/advisory_dedup_test.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Unit test for examples/bd/dolt/assets/scripts/advisory_state.sh.
+#
+# Proves the dedup fix for the dolt-health advisory storm in mol-dog-doctor.sh
+# (#3409): a persistent condition sends exactly one advisory (not one per tick),
+# a changed condition set re-alerts, and a healthy server clears the state so the
+# next occurrence alerts again.
+#
+# Run: sh test/dolt/advisory_dedup_test.sh
+set -u
+HERE=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+ADVISORY_LIB="${ADVISORY_LIB:-$HERE/../../examples/bd/dolt/assets/scripts/advisory_state.sh}"
+
+if [ ! -f "$ADVISORY_LIB" ]; then
+  echo "FAIL: advisory helper not found at $ADVISORY_LIB"
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$ADVISORY_LIB"
+
+fail=0
+pass() { echo "PASS: $1"; }
+bad()  { echo "FAIL: $1"; fail=1; }
+
+command -v advisory_changed >/dev/null 2>&1 || { echo "FAIL: advisory_changed not defined"; exit 1; }
+command -v advisory_record  >/dev/null 2>&1 || { echo "FAIL: advisory_record not defined"; exit 1; }
+command -v advisory_clear   >/dev/null 2>&1 || { echo "FAIL: advisory_clear not defined"; exit 1; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+STATE="$WORK/doctor-advisory-state"
+
+# No state recorded yet -> first advisory must send.
+if advisory_changed "latency " "$STATE"; then pass "first advisory (no state) -> send"; else bad "first advisory suppressed with no state on file"; fi
+
+# Recording persists the signature.
+advisory_record "latency " "$STATE"
+if [ -f "$STATE" ]; then pass "record creates the state file"; else bad "record did not create the state file"; fi
+
+# Same signature after a record -> suppressed (the storm fix).
+if advisory_changed "latency " "$STATE"; then bad "identical advisory re-sent (storm not deduped)"; else pass "identical advisory -> suppressed"; fi
+
+# A simulated 50-tick run with an unchanged condition sends nothing further.
+resends=0
+i=0
+while [ "$i" -lt 50 ]; do
+  if advisory_changed "latency " "$STATE"; then resends=$((resends + 1)); advisory_record "latency " "$STATE"; fi
+  i=$((i + 1))
+done
+if [ "$resends" -eq 0 ]; then pass "50 steady ticks -> 0 re-sends"; else bad "$resends/50 steady ticks re-sent"; fi
+
+# A changed condition set -> re-alert.
+if advisory_changed "latency conn " "$STATE"; then pass "changed condition set -> re-alert"; else bad "changed condition set did not re-alert"; fi
+advisory_record "latency conn " "$STATE"
+
+# Healthy server clears state; the next occurrence alerts again.
+advisory_clear "$STATE"
+if [ -f "$STATE" ]; then bad "clear did not remove the state file"; else pass "clear removes the state file"; fi
+if advisory_changed "latency " "$STATE"; then pass "post-clear recurrence -> re-alert"; else bad "post-clear recurrence suppressed"; fi
+
+# Fail-open: with no state-file path, never suppress (degrade to pre-fix alert,
+# never to silence).
+if advisory_changed "latency " ""; then pass "empty state path -> fail open (send)"; else bad "empty state path suppressed the advisory"; fi
+
+# record into a not-yet-existing directory creates the path (mkdir -p).
+NESTED="$WORK/runtime/packs/dolt/doctor-advisory-state"
+advisory_record "orphan " "$NESTED"
+if [ -f "$NESTED" ]; then pass "record creates missing parent directories"; else bad "record did not create nested state path"; fi
+
+# The recorded signature round-trips exactly.
+got=$(cat "$NESTED" 2>/dev/null || true)
+if [ "$got" = "orphan " ]; then pass "recorded signature round-trips"; else bad "recorded signature mismatch: got '$got'"; fi
+
+echo "----"
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "FAILURES PRESENT"; fi
+exit "$fail"


### PR DESCRIPTION
Fixes #3409 (the per-tick duplication half).

## Problem
A sustained dolt-health condition (latency at threshold, high connection count, orphan DBs, stale backups) made `mol-dog-doctor` mail a fresh **"Dolt health advisory [MEDIUM]"** bead every 5-min tick, flooding the mayor inbox with identical beads for one root cause.

## Fix
Collapse a persistent advisory into a single rolling alert. New `advisory_state.sh` records the signature of the last-sent advisory keyed on the **set of active conditions** (latency/conn/orphan/backup), *not* their tick-volatile values, and re-sends only when that set changes; a healthy tick clears the state so the next occurrence re-alerts.

Safety properties:
- **Fails open** — an unwritable/misconfigured state path degrades to the pre-fix repeated alert, never to silence.
- The CRITICAL **"server unreachable"** escalation is intentionally **not** routed through the dedup, so a true outage always alerts.

## Scope note
The latency-quantization half of #3409 (whole-second `date +%s` aliasing a sub-second probe to the 1s threshold) is **already fixed on main** (ms-resolution `LATENCY_MS` + `GC_DOCTOR_LATENCY_WARN_MS`); this change addresses only the remaining per-tick duplication.

## Tests
Adds `test/dolt/advisory_dedup_test.sh`: 50 steady ticks → 0 re-sends, changed-condition-set re-alerts, clear-on-healthy, fail-open, and nested state-dir creation. All pass locally.