### PR TITLE
fix(gc): symlink-safe config rewrites on all paths + key-loss guards (ga-lurp5d follow-up to #3349)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1334,6 +1334,15 @@ func captureConfigMutationSnapshot(cityPath string) (*configMutationSnapshot, er
 	}
 
 	capture := func(path string) error {
+		// Snapshot at the resolved symlink target: restore writes with a
+		// temp-file + rename, and renaming over the unresolved path would
+		// replace a symlinked config with a regular file (the ga-lurp5d
+		// failure mode). Resolve-only — restores write the original bytes
+		// back, so the key-loss rewrite guard does not apply.
+		path, err := fsys.ResolveSymlinks(fsys.OSFS{}, path)
+		if err != nil {
+			return err
+		}
 		data, err := os.ReadFile(path)
 		switch {
 		case err == nil:
@@ -1366,6 +1375,40 @@ func captureConfigMutationSnapshot(cityPath string) (*configMutationSnapshot, er
 		return nil, fmt.Errorf("snapshotting agent scaffolds: %w", err)
 	}
 	snapshot.agentTree = agentTree
+
+	// SnapshotTree preserves a symlinked agents/<name>/agent.toml as a link
+	// entry but never the bytes behind it, while the forward agent mutation
+	// path (WriteLocalDiscoveredAgentSuspended / removeAgentTomlConvention)
+	// writes or removes the *resolved target*. Capture the resolved-target
+	// bytes here — symmetric with city.toml/site.toml above — so restore()
+	// rewrites the operator's checked-out agent.toml content after the tree
+	// restore re-creates the link, closing the ga-lurp5d rollback gap.
+	agentsDir := filepath.Join(cityPath, "agents")
+	agentEntries, err := os.ReadDir(agentsDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("listing agents for symlinked agent.toml snapshot: %w", err)
+	}
+	for _, entry := range agentEntries {
+		if !entry.IsDir() {
+			continue
+		}
+		agentTomlPath := filepath.Join(agentsDir, entry.Name(), "agent.toml")
+		info, lstatErr := os.Lstat(agentTomlPath)
+		if lstatErr != nil {
+			if os.IsNotExist(lstatErr) {
+				continue
+			}
+			return nil, fmt.Errorf("inspecting agents/%s/agent.toml: %w", entry.Name(), lstatErr)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			// Regular-file agent.toml content is captured and restored by the
+			// tree snapshot; only symlinked targets need separate handling.
+			continue
+		}
+		if err := capture(agentTomlPath); err != nil {
+			return nil, err
+		}
+	}
 
 	return snapshot, nil
 }

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -3573,3 +3573,254 @@ func TestStoreMetadataSignatureChangesOnRigSuspensionFlip(t *testing.T) {
 		t.Fatalf("signature unchanged across rig suspension flip:\n%s", before)
 	}
 }
+
+func TestConfigMutationSnapshotRestoresThroughSymlinks(t *testing.T) {
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	links := make(map[string]string) // link path -> target path
+	for link, target := range map[string]string{
+		filepath.Join(cityDir, "city.toml"):        filepath.Join(checkoutDir, "city.toml"),
+		filepath.Join(cityDir, ".gc", "site.toml"): filepath.Join(checkoutDir, "site.toml"),
+	} {
+		if err := os.WriteFile(target, []byte("original = true\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		links[link] = target
+	}
+
+	snapshot, err := captureConfigMutationSnapshot(cityDir)
+	if err != nil {
+		t.Fatalf("captureConfigMutationSnapshot: %v", err)
+	}
+
+	for _, target := range links {
+		if err := os.WriteFile(target, []byte("mutated = true\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := snapshot.restore(); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	for link, target := range links {
+		info, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("Lstat %s: %v", link, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s symlink was replaced by a %v entry; restore must write through the link", link, info.Mode())
+		}
+		data, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatalf("ReadFile %s: %v", target, err)
+		}
+		if string(data) != "original = true\n" {
+			t.Fatalf("%s target content = %q, want original bytes restored", link, data)
+		}
+	}
+}
+
+func TestConfigMutationSnapshotRestoresSymlinkedAgentTomlTarget(t *testing.T) {
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(cityDir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// agents/worker/agent.toml is symlinked to an operator file checked out of
+	// the agents/ tree (the ga-lurp5d "linked into a repo" case). The forward
+	// agent mutation path writes/removes the resolved target, so a rollback must
+	// restore the target bytes — SnapshotTree only preserves the link entry.
+	target := filepath.Join(checkoutDir, "worker-agent.toml")
+	original := []byte("provider = \"claude\"\n")
+	if err := os.WriteFile(target, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(agentDir, "agent.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	snapshot, err := captureConfigMutationSnapshot(cityDir)
+	if err != nil {
+		t.Fatalf("captureConfigMutationSnapshot: %v", err)
+	}
+
+	// A suspend writes through the link, mutating the resolved target content.
+	if err := os.WriteFile(target, []byte("provider = \"claude\"\nsuspended = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := snapshot.restore(); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat %s: %v", link, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s symlink was replaced by a %v entry; restore must write through the link", link, info.Mode())
+	}
+	if got, err := os.Readlink(link); err != nil || got != target {
+		t.Fatalf("agent.toml symlink target = %q, %v; want %q", got, err, target)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", target, err)
+	}
+	if string(data) != string(original) {
+		t.Fatalf("agent.toml target content = %q, want original bytes %q restored", data, original)
+	}
+}
+
+func TestConfigMutationSnapshotRecreatesRemovedSymlinkedAgentTomlTarget(t *testing.T) {
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(cityDir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// An empty resume/delete removes the resolved target through the link. The
+	// rollback must recreate the operator's target bytes, not leave a dangling
+	// link with the durable config gone.
+	target := filepath.Join(checkoutDir, "worker-agent.toml")
+	original := []byte("provider = \"claude\"\n")
+	if err := os.WriteFile(target, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(agentDir, "agent.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	snapshot, err := captureConfigMutationSnapshot(cityDir)
+	if err != nil {
+		t.Fatalf("captureConfigMutationSnapshot: %v", err)
+	}
+
+	if err := os.Remove(target); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := snapshot.restore(); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat %s: %v", link, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s symlink was replaced by a %v entry; restore must keep the link", link, info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile restored %s: %v", target, err)
+	}
+	if string(data) != string(original) {
+		t.Fatalf("agent.toml target content = %q, want original bytes %q recreated", data, original)
+	}
+}
+
+func TestControllerStateSuspendRestoresSymlinkedAgentTomlTargetWhenRefreshFails(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city1\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("write pack.toml: %v", err)
+	}
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatalf("mkdir checkout: %v", err)
+	}
+	agentDir := filepath.Join(cityDir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatalf("write prompt.template.md: %v", err)
+	}
+
+	// agents/worker/agent.toml is symlinked to a checked-out operator file.
+	agentTarget := filepath.Join(checkoutDir, "worker-agent.toml")
+	originalAgent := []byte("provider = \"claude\"\n")
+	if err := os.WriteFile(agentTarget, originalAgent, 0o644); err != nil {
+		t.Fatalf("write agent target: %v", err)
+	}
+	agentLink := filepath.Join(agentDir, "agent.toml")
+	if err := os.Symlink(agentTarget, agentLink); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	resolvedAgentTarget, err := fsys.ResolveSymlinks(fsys.OSFS{}, agentLink)
+	if err != nil {
+		t.Fatalf("resolve agent symlink: %v", err)
+	}
+
+	original := []byte("[workspace]\nname = \"city1\"\n\n[providers.claude]\nbase = \"builtin:claude\"\n")
+	tomlPath := filepath.Join(cityDir, "city.toml")
+	if err := os.WriteFile(tomlPath, original, 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	cs := newControllerState(context.Background(), &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+		Providers: map[string]config.ProviderSpec{
+			"claude": config.BuiltinProviderAlias("claude"),
+		},
+	}, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+	// The suspend write renames a temp file onto the resolved agent.toml target;
+	// corrupt city.toml at that moment so the post-mutation refresh fails and
+	// the rollback path runs.
+	cs.editor = configedit.NewEditor(&corruptCityAfterRenameFS{
+		triggerPath: resolvedAgentTarget,
+		cityToml:    tomlPath,
+	}, tomlPath)
+	cs.pokeCh = make(chan struct{}, 1)
+	cs.configDirty = &atomic.Bool{}
+
+	err = cs.SuspendAgent("worker")
+	if err == nil {
+		t.Fatal("SuspendAgent should fail when refreshing the updated snapshot fails")
+	}
+	if !strings.Contains(err.Error(), "refreshing updated city config") {
+		t.Fatalf("SuspendAgent error = %v, want refresh failure after mutation", err)
+	}
+
+	info, err := os.Lstat(agentLink)
+	if err != nil {
+		t.Fatalf("Lstat agent symlink: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("agent.toml symlink was replaced by a %v entry after rollback", info.Mode())
+	}
+	gotAgent, err := os.ReadFile(agentTarget)
+	if err != nil {
+		t.Fatalf("read restored agent target: %v", err)
+	}
+	if string(gotAgent) != string(originalAgent) {
+		t.Fatalf("agent.toml target = %q, want rollback to %q", gotAgent, originalAgent)
+	}
+	if cs.configDirty.Load() {
+		t.Fatal("SuspendAgent should not mark config dirty after rollback")
+	}
+}

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -1376,17 +1376,24 @@ func writeDoltPortFile(dir, port, scopeLabel string, warn io.Writer) {
 		}
 		fmt.Fprintf(warn, "WARN: %s .beads/dolt-server.port rewrite %s → %s (managed city port)\n", label, existing, trimmedPort) //nolint:errcheck // best-effort stderr
 	}
-	if err := ensureBeadsDir(fsys.OSFS{}, filepath.Dir(portFile)); err != nil {
+	writePath, err := resolveDoltPortFileWritePath(fsys.OSFS{}, portFile)
+	if err != nil {
 		return
 	}
-	_ = fsys.WriteFileAtomic(fsys.OSFS{}, portFile, []byte(trimmedPort+"\n"), 0o644)
+	if err := ensureBeadsDir(fsys.OSFS{}, filepath.Dir(writePath)); err != nil {
+		return
+	}
+	_ = fsys.WriteFileAtomic(fsys.OSFS{}, writePath, []byte(trimmedPort+"\n"), 0o644)
 }
 
 func removeDoltPortFile(dir string) {
 	if dir == "" {
 		return
 	}
-	_ = os.Remove(filepath.Join(dir, ".beads", "dolt-server.port"))
+	// Resolve through any operator symlink so cleanup clears the target and
+	// preserves the link, mirroring writeDoltPortFile's symlink-preserving
+	// write path (ga-lurp5d). Best-effort: ignore the resolve/remove error.
+	_ = removeResolvedDoltPortFile(fsys.OSFS{}, dir)
 }
 
 func removeScopeLocalDoltServerArtifacts(dir string) error {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -1720,6 +1720,92 @@ func TestSyncConfiguredDoltPortFilesWarnsOnRigPortFileRewrite(t *testing.T) {
 	}
 }
 
+func TestWriteDoltPortFileWritesThroughSymlink(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetDir := filepath.Join(t.TempDir(), "ports")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetDir, "dolt-server.port")
+	if err := os.WriteFile(target, []byte("3307\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(beadsDir, "dolt-server.port")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	writeDoltPortFile(dir, "3311", "city", &warn)
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dolt-server.port symlink was replaced by a %v entry; rewrite must write through the link", info.Mode())
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, target))); got != "3311" {
+		t.Fatalf("target port = %q, want 3311", got)
+	}
+	if out := warn.String(); !strings.Contains(out, "3307") || !strings.Contains(out, "3311") {
+		t.Fatalf("warning = %q, want old and new ports", out)
+	}
+}
+
+func TestRemoveDoltPortFileClearsThroughSymlink(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetDir := filepath.Join(t.TempDir(), "ports")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetDir, "dolt-server.port")
+	if err := os.WriteFile(target, []byte("3311\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(beadsDir, "dolt-server.port")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	removeDoltPortFile(dir)
+
+	// The best-effort lifecycle mirror cleanup must preserve the operator's
+	// link and clear only the resolved target.
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dolt-server.port symlink was replaced by a %v entry; cleanup must clear through the link", info.Mode())
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("target stat err = %v, want resolved target removed", err)
+	}
+
+	// A later publication must write through the preserved link.
+	var warn bytes.Buffer
+	writeDoltPortFile(dir, "3320", "city", &warn)
+	info, err = os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link after re-publish: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("after re-publish, link mode = %v; want symlink preserved", info.Mode())
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, target))); got != "3320" {
+		t.Fatalf("re-published target port = %q, want 3320", got)
+	}
+}
+
 func TestSyncConfiguredDoltPortFilesSilentOnNoChange(t *testing.T) {
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(t.TempDir(), "quiet")

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -183,9 +183,16 @@ func loadCityPackConfigForEditFS(fs fsys.FS, packPath string) (*initPackConfig, 
 		return nil, err
 	}
 	cfg := initPackConfig{}
-	if _, err := toml.Decode(string(data), &cfg); err != nil {
+	md, err := toml.Decode(string(data), &cfg)
+	if err != nil {
 		return nil, fmt.Errorf("loading pack config %q: %w", packPath, err)
 	}
+	// Fold the legacy [agents] alias into [agent_defaults] before any rewrite:
+	// marshalInitPackConfig emits only [agent_defaults], so without this the
+	// suspend/resume rewrite would silently drop an [agents] table even though
+	// the key-loss guard recognizes it. Mirrors parse-time normalization.
+	config.FoldAgentDefaultsAlias(&cfg.AgentDefaults, cfg.AgentsDefaults, md)
+	cfg.AgentsDefaults = config.AgentDefaults{}
 	return &cfg, nil
 }
 
@@ -197,7 +204,19 @@ func writeCityPackConfigForEditFS(fs fsys.FS, packPath string, cfg *initPackConf
 	if err != nil {
 		return err
 	}
-	return fsys.WriteFileIfChangedAtomic(fs, packPath, content, 0o644)
+	// Resolve before the rename: a symlinked pack.toml must keep its
+	// link, with the write landing in the checked-in target.
+	writePath, err := fsys.ResolveSymlinks(fs, packPath)
+	if err != nil {
+		return err
+	}
+	// Refuse the rewrite when the on-disk pack.toml carries keys this binary
+	// does not recognize: marshalInitPackConfig round-trips a reduced struct
+	// and would silently drop newer or manual keys at the checked-in target.
+	if err := config.GuardRewriteKeyLoss[initPackConfig](fs, writePath); err != nil {
+		return err
+	}
+	return fsys.WriteFileIfChangedAtomic(fs, writePath, content, 0o644)
 }
 
 func updateRootPackAgentSuspended(fs fsys.FS, cityPath string, cityCfg *config.City, name string, suspended bool) (bool, error) {

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -570,6 +570,140 @@ name = "mayor"
 	}
 }
 
+func TestDoAgentSuspendRootPackPreservesPricing(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+`)
+	// Root pack.toml carries a [[pricing]] table, which compose.go parses and
+	// merges. Suspending a root-pack agent rewrites pack.toml through a reduced
+	// struct; the rewrite must preserve pricing rather than refusing the write
+	// (false key-loss positive) or silently dropping it.
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+
+[[pricing]]
+provider = "claude"
+model = "claude-opus-4-8"
+last_verified = "2026-06-01"
+
+[pricing.tier]
+prompt_usd_per_1m = 15.0
+completion_usd_per_1m = 75.0
+
+[[agent]]
+name = "mayor"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentSuspend(fs, "/city", "mayor", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packToml := string(fs.Files["/city/pack.toml"])
+	if !strings.Contains(packToml, `suspended = true`) {
+		t.Fatalf("pack.toml missing suspended = true:\n%s", packToml)
+	}
+	for _, want := range []string{
+		"[[pricing]]",
+		`provider = "claude"`,
+		`model = "claude-opus-4-8"`,
+		`last_verified = "2026-06-01"`,
+		"prompt_usd_per_1m",
+		"completion_usd_per_1m",
+	} {
+		if !strings.Contains(packToml, want) {
+			t.Fatalf("pack.toml dropped pricing field %q after suspend:\n%s", want, packToml)
+		}
+	}
+}
+
+func TestDoAgentSuspendRootPackCanonicalizesAgentsAlias(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+`)
+	// Root pack.toml carries the legacy [agents] alias for [agent_defaults].
+	// Suspending a root-pack agent rewrites pack.toml through a reduced struct;
+	// the rewrite must canonicalize the alias into [agent_defaults] rather than
+	// silently dropping it (the key-loss class this PR exists to prevent).
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+
+[agents]
+append_fragments = ["shared"]
+
+[[agent]]
+name = "mayor"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentSuspend(fs, "/city", "mayor", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packToml := string(fs.Files["/city/pack.toml"])
+	if !strings.Contains(packToml, `suspended = true`) {
+		t.Fatalf("pack.toml missing suspended = true:\n%s", packToml)
+	}
+	// The alias value survives, canonicalized under [agent_defaults].
+	if !strings.Contains(packToml, "[agent_defaults]") || !strings.Contains(packToml, `append_fragments = ["shared"]`) {
+		t.Fatalf("pack.toml dropped the [agents] alias value:\n%s", packToml)
+	}
+	// The legacy alias table name is not re-emitted.
+	if strings.Contains(packToml, "[agents]") {
+		t.Fatalf("pack.toml still contains the legacy [agents] table:\n%s", packToml)
+	}
+}
+
+func TestDoAgentSuspendRootPackMergesAgentsAliasPreferringCanonical(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+`)
+	// Both [agent_defaults] and the legacy [agents] alias are present. The
+	// rewrite must keep canonical values winning on overlapping keys while the
+	// alias only fills gaps, matching parse-time normalization.
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+
+[agent_defaults]
+provider = "canonical"
+
+[agents]
+provider = "alias"
+append_fragments = ["from-alias"]
+
+[[agent]]
+name = "mayor"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentSuspend(fs, "/city", "mayor", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packToml := string(fs.Files["/city/pack.toml"])
+	if !strings.Contains(packToml, `provider = "canonical"`) {
+		t.Fatalf("pack.toml lost canonical provider precedence:\n%s", packToml)
+	}
+	if strings.Contains(packToml, `provider = "alias"`) {
+		t.Fatalf("pack.toml let the alias provider override canonical:\n%s", packToml)
+	}
+	if !strings.Contains(packToml, `append_fragments = ["from-alias"]`) {
+		t.Fatalf("pack.toml dropped the gap-filling alias value:\n%s", packToml)
+	}
+	if strings.Contains(packToml, "[agents]") {
+		t.Fatalf("pack.toml still contains the legacy [agents] table:\n%s", packToml)
+	}
+}
+
 func TestStrictFatalLoadConfigWarningsKeepsMixedTableWarningsFatal(t *testing.T) {
 	warnings := []string{
 		`/city/pack.toml: [agents] is a deprecated compatibility alias for [agent_defaults]; rewrite the table name to [agent_defaults]`,
@@ -1232,5 +1366,124 @@ name = "test-city"
 	}
 	if !molecule.IsGraphApplyEnabled() {
 		t.Fatalf("molecule.IsGraphApplyEnabled() = false, want true")
+	}
+}
+
+// Regression for the ga-lurp5d follow-up review: the CLI fallback for
+// `gc agent suspend`/`gc agent resume` re-marshals pack.toml for
+// pack-declared agents; when pack.toml is a symlink (e.g., into a
+// checked-out repo) the rewrite must write through the link instead of
+// replacing it with a regular file and stranding the stale config in the
+// checked-in target.
+func TestDoAgentSuspendWritesThroughPackTomlSymlink(t *testing.T) {
+	t.Parallel()
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkoutDir, "pack.toml")
+	src := `[pack]
+name = "test-city"
+schema = 2
+
+[providers.claude]
+base = "builtin:claude"
+
+[[agent]]
+name = "worker"
+provider = "claude"
+`
+	if err := os.WriteFile(target, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(cityDir, "pack.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doAgentSuspend(fsys.OSFS{}, cityDir, "worker", &stdout, &stderr); code != 0 {
+		t.Fatalf("code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("pack.toml symlink was replaced by a %v entry; suspend must write through the link", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if !strings.Contains(string(data), "suspended = true") {
+		t.Fatalf("symlink target missing suspended = true:\n%s", data)
+	}
+}
+
+// Regression for the ga-lurp5d follow-up review: the CLI fallback for
+// `gc agent suspend` re-marshals pack.toml through the reduced initPackConfig
+// struct, which would silently drop keys this gc binary does not recognize. A
+// symlinked pack.toml carrying an unknown key must make the rewrite refuse
+// rather than strand a reduced manifest at the checked-in target.
+func TestDoAgentSuspendRefusesPackTomlUnknownKeys(t *testing.T) {
+	t.Parallel()
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkoutDir, "pack.toml")
+	src := `[pack]
+name = "test-city"
+schema = 2
+
+[providers.claude]
+base = "builtin:claude"
+
+[[agent]]
+name = "worker"
+provider = "claude"
+
+[future_unknown_section]
+knob = "keep-me"
+`
+	if err := os.WriteFile(target, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(cityDir, "pack.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doAgentSuspend(fsys.OSFS{}, cityDir, "worker", &stdout, &stderr); code == 0 {
+		t.Fatalf("code = 0, want non-zero refusal; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "future_unknown_section") {
+		t.Fatalf("stderr = %q, want mention of future_unknown_section", stderr.String())
+	}
+	// The symlink and its content must survive an aborted rewrite.
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("pack.toml symlink was replaced by a %v entry", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if string(data) != src {
+		t.Fatalf("pack.toml was rewritten despite refusal:\n%s", data)
 	}
 }

--- a/cmd/gc/cmd_beads_city.go
+++ b/cmd/gc/cmd_beads_city.go
@@ -355,12 +355,12 @@ func validateCityExternalEndpointChange(cityPath string, targetState contract.Co
 
 func snapshotCityTopologyFiles(fs fsys.FS, cityPath string, plans []cityRigEndpointPlan) ([]fileSnapshot, error) {
 	snapshots := make([]fileSnapshot, 0, len(plans)+3)
-	cityToml, err := snapshotCityTomlForRollback(fs, cityPath)
+	cityToml, err := snapshotResolvedFile(fs, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		return nil, err
 	}
 	snapshots = append(snapshots, cityToml)
-	siteToml, err := snapshotOptionalFile(fs, config.SiteBindingPath(cityPath))
+	siteToml, err := snapshotResolvedFile(fs, config.SiteBindingPath(cityPath))
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +400,7 @@ func snapshotCityManagedPortFiles(fs fsys.FS, cityPath string, plans []cityRigEn
 			continue
 		}
 		seen[path] = struct{}{}
-		snap, err := snapshotOptionalFile(fs, path)
+		snap, err := snapshotResolvedFile(fs, path)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/gc/cmd_beads_city_test.go
+++ b/cmd/gc/cmd_beads_city_test.go
@@ -879,61 +879,22 @@ func writeCityEndpointCityConfig(t *testing.T, cityDir string, rigs []config.Rig
 	}
 }
 
-// Regression for PR #3428 review: the gc beads city set-endpoint outer
-// rollback snapshots city.toml at its symlink-resolved path, so restoring
-// after a later step fails rewrites the real target and leaves the live
-// symlink intact instead of replacing it with a regular file. This is the same
-// latent bug fixed for gc rig add and gc rig set-endpoint.
-func TestSnapshotCityTopologyFilesRestoresSymlinkedCityToml(t *testing.T) {
-	dir := t.TempDir()
-	repoDir := filepath.Join(dir, "repo")
-	cityDir := filepath.Join(dir, "city")
-	if err := os.MkdirAll(repoDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	repoCityPath := filepath.Join(repoDir, "city.toml")
-	liveCityPath := filepath.Join(cityDir, "city.toml")
-	original := []byte("[workspace]\nname = \"test-city\"\n")
-	if err := os.WriteFile(repoCityPath, original, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink(filepath.Join("..", "repo", "city.toml"), liveCityPath); err != nil {
-		t.Fatal(err)
-	}
-
+// Regression test for the ga-lurp5d follow-up: a failed topology change must
+// roll back a symlinked city.toml by restoring the link target, not by
+// replacing the link with a regular file.
+func TestCityTopologyRollbackRestoresThroughCityTomlSymlink(t *testing.T) {
 	fs := fsys.OSFS{}
+	cityDir, link, target := setupSymlinkedCityToml(t)
+
 	snapshots, err := snapshotCityTopologyFiles(fs, cityDir, nil)
 	if err != nil {
 		t.Fatalf("snapshotCityTopologyFiles: %v", err)
 	}
-
-	// Simulate the city endpoint rewrite mutating the resolved target before a
-	// later step fails and triggers rollback.
-	mutated := []byte("[workspace]\nname = \"mutated\"\n")
-	if err := os.WriteFile(repoCityPath, mutated, 0o644); err != nil {
+	if err := os.WriteFile(target, []byte("[workspace]\nname = \"mutated\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-
 	if err := restoreSnapshots(fs, snapshots); err != nil {
 		t.Fatalf("restoreSnapshots: %v", err)
 	}
-
-	info, err := os.Lstat(liveCityPath)
-	if err != nil {
-		t.Fatalf("Lstat(live city.toml): %v", err)
-	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		t.Fatalf("rollback replaced the live city.toml symlink with a regular file")
-	}
-	restored, err := os.ReadFile(repoCityPath)
-	if err != nil {
-		t.Fatalf("read repo city.toml: %v", err)
-	}
-	if !bytes.Equal(restored, original) {
-		t.Fatalf("repo city.toml = %q, want restored original %q", restored, original)
-	}
+	assertCityTomlSymlinkRestored(t, link, target, symlinkedCityTomlOriginal)
 }

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/packman"
+	"github.com/gastownhall/gascity/internal/pricing"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +40,7 @@ type cityPackManifest struct {
 	Pack                  config.PackMeta                `toml:"pack"`
 	Imports               map[string]config.Import       `toml:"imports,omitempty"`
 	AgentDefaults         config.AgentDefaults           `toml:"agent_defaults,omitempty"`
+	AgentsDefaults        config.AgentDefaults           `toml:"agents,omitempty" jsonschema:"-"`
 	Defaults              cityPackDefaults               `toml:"defaults,omitempty"`
 	DefaultRigImportOrder []string                       `toml:"-"`
 	Agents                []config.Agent                 `toml:"agent,omitempty"`
@@ -50,6 +52,7 @@ type cityPackManifest struct {
 	Doctor                []config.PackDoctorEntry       `toml:"doctor,omitempty"`
 	Commands              []config.PackCommandEntry      `toml:"commands,omitempty"`
 	Global                config.PackGlobal              `toml:"global,omitempty"`
+	Pricing               []pricing.ModelPricing         `toml:"pricing,omitempty"`
 }
 
 type cityPackDefaults struct {
@@ -73,6 +76,7 @@ type cityPackManifestBody struct {
 	Doctor        []config.PackDoctorEntry       `toml:"doctor,omitempty"`
 	Commands      []config.PackCommandEntry      `toml:"commands,omitempty"`
 	Global        config.PackGlobal              `toml:"global,omitempty"`
+	Pricing       []pricing.ModelPricing         `toml:"pricing,omitempty"`
 }
 
 func newImportCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -1329,9 +1333,17 @@ func loadCityPackManifestFS(fs fsys.FS, cityPath string) (*cityPackManifest, err
 	}
 
 	var manifest cityPackManifest
-	if _, err := toml.Decode(string(data), &manifest); err != nil {
+	md, err := toml.Decode(string(data), &manifest)
+	if err != nil {
 		return nil, fmt.Errorf("parsing pack.toml: %w", err)
 	}
+	// Fold the legacy [agents] alias into [agent_defaults] before any rewrite:
+	// the manifest body emits only [agent_defaults], so without this the
+	// import-manifest rewrite would silently drop an [agents] table even though
+	// the key-loss guard recognizes it. Mirrors parse-time normalization and the
+	// gc agent suspend/resume edit path.
+	config.FoldAgentDefaultsAlias(&manifest.AgentDefaults, manifest.AgentsDefaults, md)
+	manifest.AgentsDefaults = config.AgentDefaults{}
 	if manifest.Pack.Name == "" {
 		manifest.Pack.Name = defaultCityPackName(fs, cityPath)
 	}
@@ -1382,6 +1394,7 @@ func writeCityPackManifest(fs fsys.FS, cityPath string, manifest *cityPackManife
 		Doctor:        manifest.Doctor,
 		Commands:      manifest.Commands,
 		Global:        manifest.Global,
+		Pricing:       manifest.Pricing,
 	}
 	if err := toml.NewEncoder(&buf).Encode(body); err != nil {
 		return fmt.Errorf("encoding pack.toml: %w", err)
@@ -1389,7 +1402,21 @@ func writeCityPackManifest(fs fsys.FS, cityPath string, manifest *cityPackManife
 	if err := writeOrderedDefaultRigImports(&buf, manifest); err != nil {
 		return err
 	}
-	return fsys.WriteFileAtomic(fs, filepath.Join(cityPath, "pack.toml"), buf.Bytes(), 0o644)
+	// Resolve before the rename: pack.toml may be a symlink into a
+	// checked-out repo, and renaming over the unresolved path would
+	// replace the link with a regular file and strand the stale manifest
+	// in the checked-in target.
+	writePath, err := fsys.ResolveSymlinks(fs, filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		return err
+	}
+	// Refuse the rewrite when the on-disk pack.toml carries keys this binary
+	// does not recognize: the manifest round-trip would silently drop newer
+	// or manual keys at the checked-in target.
+	if err := config.GuardRewriteKeyLoss[cityPackManifest](fs, writePath); err != nil {
+		return err
+	}
+	return fsys.WriteFileAtomic(fs, writePath, buf.Bytes(), 0o644)
 }
 
 func writeOrderedDefaultRigImports(buf *bytes.Buffer, manifest *cityPackManifest) error {

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -93,7 +93,7 @@ name = "mayor"
 scope = "city"
 
 [providers.default]
-type = "claude"
+base = "builtin:claude"
 
 [[commands]]
 name = "status"
@@ -145,6 +145,7 @@ session_live = ["echo hi"]
 		`append_fragments = ["pack-fragment"]`,
 		`name = "mayor"`,
 		`[providers.default]`,
+		`base = "builtin:claude"`,
 		`[[commands]]`,
 		`session_live = ["echo hi"]`,
 		`[imports.tools]`,
@@ -152,6 +153,58 @@ session_live = ["echo hi"]
 		if !strings.Contains(text, want) {
 			t.Fatalf("pack.toml missing %q:\n%s", want, text)
 		}
+	}
+}
+
+// Regression for the ga-lurp5d follow-up review: gc import add rewrites
+// pack.toml through the reduced cityPackManifest struct. When the on-disk
+// pack.toml carries a key this gc binary does not recognize, the rewrite must
+// refuse rather than silently drop it (the city.toml rewrite guard's contract,
+// now extended to pack.toml).
+func TestDoImportAddRefusesUnknownPackTomlKeys(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	original := `[pack]
+name = "demo"
+schema = 1
+
+[future_unknown_section]
+knob = "keep-me"
+`
+	writePackToml(t, dir, original)
+
+	prevResolve := resolveImportVersion
+	prevConstraint := defaultImportConstraint
+	prevSync := syncImports
+	t.Cleanup(func() {
+		resolveImportVersion = prevResolve
+		defaultImportConstraint = prevConstraint
+		syncImports = prevSync
+	})
+	resolveImportVersion = func(_, _ string) (packman.ResolvedVersion, error) {
+		return packman.ResolvedVersion{Version: "1.4.2", Commit: "abc123"}, nil
+	}
+	defaultImportConstraint = func(_ string) (string, error) { return "^1.4", nil }
+	syncImports = func(_ string, _ map[string]config.Import, _ packman.InstallMode) (*packman.Lockfile, error) {
+		return &packman.Lockfile{Schema: packman.LockfileSchema}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportAdd(fsys.OSFS{}, dir, "https://github.com/example/tools.git", "", "", &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("code = 0, want non-zero refusal; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "future_unknown_section") {
+		t.Fatalf("stderr = %q, want mention of future_unknown_section", stderr.String())
+	}
+	// The pack.toml must survive an aborted rewrite unchanged.
+	data, err := os.ReadFile(filepath.Join(dir, "pack.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(pack.toml): %v", err)
+	}
+	if string(data) != original {
+		t.Fatalf("pack.toml was rewritten despite refusal:\n%s", data)
 	}
 }
 
@@ -2256,6 +2309,119 @@ scope = "city"
 	}
 	if got, want := imp.Version, "^1.2"; got != want {
 		t.Fatalf("Version = %q, want %q", got, want)
+	}
+}
+
+// The pack rewrite key-loss guards must not refuse legitimate packs: every
+// section the gc binary recognizes has to decode cleanly into the structs the
+// writers round-trip (initPackConfig for gc agent suspend, cityPackManifest for
+// import-manifest rewrites). This pins zero false positives for the known pack
+// schema, so the guards fire only on genuinely unknown keys. The fixture must
+// include the sections where the reduced structs historically diverged from
+// config.PackConfig — the legacy [agents] alias and [[pricing]] — because those
+// are the keys the guards would otherwise flag as unrecognized.
+func TestGuardPackRewriteKeyLossAcceptsKnownPackSchema(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "pack.toml")
+	src := `[pack]
+name = "full-pack"
+schema = 1
+version = "1.0.0"
+description = "exercises known sections"
+
+[imports.gastown]
+source = "https://example/gastown.git"
+version = "^1.2"
+
+[agent_defaults]
+provider = "claude"
+
+[agents]
+append_fragments = ["legacy-alias"]
+
+[defaults.rig.imports.review]
+source = "https://example/review.git"
+
+[providers.claude]
+base = "builtin:claude"
+
+[[pricing]]
+provider = "claude"
+model = "claude-opus-4-8"
+last_verified = "2026-06-01"
+
+[pricing.tier]
+prompt_usd_per_1m = 15.0
+completion_usd_per_1m = 75.0
+
+[[agent]]
+name = "worker"
+provider = "claude"
+`
+	if err := os.WriteFile(packPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.GuardRewriteKeyLoss[initPackConfig](fsys.OSFS{}, packPath); err != nil {
+		t.Fatalf("GuardRewriteKeyLoss[initPackConfig] = %v, want nil for known schema", err)
+	}
+	if err := config.GuardRewriteKeyLoss[cityPackManifest](fsys.OSFS{}, packPath); err != nil {
+		t.Fatalf("GuardRewriteKeyLoss[cityPackManifest] = %v, want nil for known schema", err)
+	}
+}
+
+// An import-manifest rewrite must round-trip [[pricing]] (which compose.go
+// consumes) and canonicalize the legacy [agents] alias into [agent_defaults],
+// rather than refusing the rewrite or silently dropping recognized data. This
+// pins the cityPackManifest reduced struct as a faithful superset of the pack
+// schema it guards.
+func TestWriteCityPackManifestPreservesPricingAndFoldsAgentsAlias(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 1
+
+[agents]
+append_fragments = ["legacy-alias"]
+
+[[pricing]]
+provider = "claude"
+model = "claude-opus-4-8"
+last_verified = "2026-06-01"
+
+[pricing.tier]
+prompt_usd_per_1m = 15.0
+completion_usd_per_1m = 75.0
+`)
+
+	manifest, err := loadCityPackManifestFS(fs, "/city")
+	if err != nil {
+		t.Fatalf("loadCityPackManifestFS: %v", err)
+	}
+	if err := writeCityPackManifest(fs, "/city", manifest); err != nil {
+		t.Fatalf("writeCityPackManifest: %v", err)
+	}
+
+	out := string(fs.Files["/city/pack.toml"])
+	for _, want := range []string{
+		"[[pricing]]",
+		`provider = "claude"`,
+		`model = "claude-opus-4-8"`,
+		`last_verified = "2026-06-01"`,
+		"prompt_usd_per_1m",
+		"completion_usd_per_1m",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rewritten pack.toml dropped %q:\n%s", want, out)
+		}
+	}
+	// The alias value survives, canonicalized under [agent_defaults]; the legacy
+	// [agents] table name is not re-emitted.
+	if !strings.Contains(out, "[agent_defaults]") || !strings.Contains(out, `append_fragments = ["legacy-alias"]`) {
+		t.Fatalf("rewritten pack.toml dropped the [agents] alias value:\n%s", out)
+	}
+	if strings.Contains(out, "[agents]") {
+		t.Fatalf("rewritten pack.toml still contains the legacy [agents] table:\n%s", out)
 	}
 }
 

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/hooks"
 	"github.com/gastownhall/gascity/internal/overlay"
+	"github.com/gastownhall/gascity/internal/pricing"
 	"github.com/spf13/cobra"
 )
 
@@ -66,6 +67,7 @@ type initPackConfig struct {
 	Doctor         []config.PackDoctorEntry       `toml:"doctor,omitempty"`
 	Commands       []config.PackCommandEntry      `toml:"commands,omitempty"`
 	Global         config.PackGlobal              `toml:"global,omitempty"`
+	Pricing        []pricing.ModelPricing         `toml:"pricing,omitempty"`
 }
 
 var initConventionDirs = cityinit.InitConventionDirs()
@@ -802,6 +804,7 @@ func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
 		Doctor        []config.PackDoctorEntry       `toml:"doctor,omitempty"`
 		Commands      []config.PackCommandEntry      `toml:"commands,omitempty"`
 		Global        *config.PackGlobal             `toml:"global,omitempty"`
+		Pricing       []pricing.ModelPricing         `toml:"pricing,omitempty"`
 	}
 
 	encCfg := encodedInitPackConfig{
@@ -821,6 +824,7 @@ func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
 		Providers:     cfg.Providers,
 		Doctor:        cfg.Doctor,
 		Commands:      cfg.Commands,
+		Pricing:       cfg.Pricing,
 	}
 	if !isZeroValue(cfg.AgentDefaults) {
 		encCfg.AgentDefaults = &cfg.AgentDefaults

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -789,12 +789,12 @@ func boundImportsMap(imports []config.BoundImport) map[string]config.Import {
 
 func snapshotRigAddTopologyFiles(fs fsys.FS, cityPath string, cfg *config.City) ([]fileSnapshot, error) {
 	snapshots := make([]fileSnapshot, 0, len(cfg.Rigs)*3+5)
-	cityToml, err := snapshotCityTomlForRollback(fs, cityPath)
+	cityToml, err := snapshotResolvedFile(fs, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		return nil, err
 	}
 	snapshots = append(snapshots, cityToml)
-	siteToml, err := snapshotOptionalFile(fs, config.SiteBindingPath(cityPath))
+	siteToml, err := snapshotResolvedFile(fs, config.SiteBindingPath(cityPath))
 	if err != nil {
 		return nil, err
 	}
@@ -804,7 +804,7 @@ func snapshotRigAddTopologyFiles(fs fsys.FS, cityPath string, cfg *config.City) 
 		return nil, err
 	}
 	snapshots = append(snapshots, citySnapshots...)
-	cityPort, err := snapshotOptionalFile(fs, filepath.Join(cityPath, ".beads", "dolt-server.port"))
+	cityPort, err := snapshotResolvedFile(fs, filepath.Join(cityPath, ".beads", "dolt-server.port"))
 	if err != nil {
 		return nil, err
 	}
@@ -825,7 +825,7 @@ func snapshotRigAddTopologyFiles(fs fsys.FS, cityPath string, cfg *config.City) 
 			return nil, err
 		}
 		snapshots = append(snapshots, rigSnapshots...)
-		rigPort, err := snapshotOptionalFile(fs, filepath.Join(rigPath, ".beads", "dolt-server.port"))
+		rigPort, err := snapshotResolvedFile(fs, filepath.Join(rigPath, ".beads", "dolt-server.port"))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -438,14 +438,46 @@ func writeDoltPortFileStrict(fs fsys.FS, dir, port string) error {
 	if err := ensureBeadsDir(fs, filepath.Dir(portFile)); err != nil {
 		return err
 	}
-	return fsys.WriteFileAtomic(fs, portFile, []byte(strings.TrimSpace(port)+"\n"), 0o644)
+	writePath, err := resolveDoltPortFileWritePath(fs, portFile)
+	if err != nil {
+		return err
+	}
+	if err := ensureBeadsDir(fs, filepath.Dir(writePath)); err != nil {
+		return err
+	}
+	return fsys.WriteFileAtomic(fs, writePath, []byte(strings.TrimSpace(port)+"\n"), 0o644)
+}
+
+func resolveDoltPortFileWritePath(fs fsys.FS, portFile string) (string, error) {
+	writePath, err := fsys.ResolveSymlinks(fs, portFile)
+	if err != nil {
+		return "", fmt.Errorf("resolving managed dolt port file %q for rewrite: %w", portFile, err)
+	}
+	return writePath, nil
 }
 
 func removeDoltPortFileStrict(dir string) error {
 	if strings.TrimSpace(dir) == "" {
 		return nil
 	}
-	if err := os.Remove(filepath.Join(dir, ".beads", "dolt-server.port")); err != nil && !os.IsNotExist(err) {
+	return removeResolvedDoltPortFile(fsys.OSFS{}, dir)
+}
+
+// removeResolvedDoltPortFile clears the managed dolt port mirror under dir,
+// resolving an operator symlink to its target first so the link entry is
+// preserved and only the resolved target is removed. This mirrors the
+// symlink-preserving write path (resolveDoltPortFileWritePath); removing the
+// unresolved link instead would delete the operator's symlink and make the
+// next port publication recreate a regular file at the link path (the
+// ga-lurp5d clobber class). Missing files, including dangling links, are not
+// an error.
+func removeResolvedDoltPortFile(fs fsys.FS, dir string) error {
+	portFile := filepath.Join(dir, ".beads", "dolt-server.port")
+	target, err := fsys.ResolveSymlinks(fs, portFile)
+	if err != nil {
+		return fmt.Errorf("resolving managed dolt port file %q for cleanup: %w", portFile, err)
+	}
+	if err := fs.Remove(target); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil
@@ -662,7 +694,7 @@ func snapshotRigCanonicalFiles(fs fsys.FS, scopeRoot string) ([]fileSnapshot, er
 	}
 	snapshots := make([]fileSnapshot, 0, len(paths))
 	for _, path := range paths {
-		snap, err := snapshotOptionalFile(fs, path)
+		snap, err := snapshotResolvedFile(fs, path)
 		if err != nil {
 			return nil, err
 		}
@@ -684,7 +716,7 @@ func syncRigEndpointCompatConfig(fs fsys.FS, cityPath string, cfg *config.City, 
 }
 
 func snapshotRigEndpointFiles(fs fsys.FS, cityPath, scopeRoot string) ([]fileSnapshot, error) {
-	cityToml, err := snapshotCityTomlForRollback(fs, cityPath)
+	cityToml, err := snapshotResolvedFile(fs, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		return nil, err
 	}
@@ -696,13 +728,31 @@ func snapshotRigEndpointFiles(fs fsys.FS, cityPath, scopeRoot string) ([]fileSna
 	snapshots := make([]fileSnapshot, 0, len(paths)+1)
 	snapshots = append(snapshots, cityToml)
 	for _, path := range paths {
-		snap, err := snapshotOptionalFile(fs, path)
+		snap, err := snapshotResolvedFile(fs, path)
 		if err != nil {
 			return nil, err
 		}
 		snapshots = append(snapshots, snap)
 	}
 	return snapshots, nil
+}
+
+// snapshotResolvedFile snapshots path for rollback through any symlink
+// chain: restoring at the link path would replace the link with a regular
+// file (the ga-lurp5d failure mode), so the snapshot records the resolved
+// target and the restore writes there instead. Resolve-only by design — a
+// rollback writes the original bytes back, so the key-loss rewrite guard
+// does not apply. A path blocked by a regular-file intermediate cannot
+// exist; it snapshots as missing, matching snapshotOptionalFile.
+func snapshotResolvedFile(fs fsys.FS, path string) (fileSnapshot, error) {
+	resolved, err := fsys.ResolveSymlinks(fs, path)
+	if err != nil {
+		if errors.Is(err, syscall.ENOTDIR) {
+			return fileSnapshot{path: path}, nil
+		}
+		return fileSnapshot{}, err
+	}
+	return snapshotOptionalFile(fs, resolved)
 }
 
 func snapshotOptionalFile(fs fsys.FS, path string) (fileSnapshot, error) {
@@ -723,23 +773,11 @@ func snapshotOptionalFile(fs fsys.FS, path string) (fileSnapshot, error) {
 // symlink intact, instead of replacing the link with a regular file (the
 // failure ResolveCityRewritePath/ResolveCityAppendPath exist to prevent). When
 // city.toml is a plain file (or not yet created), resolution is a no-op and the
-// path is unchanged. Both the CLI rollback snapshots
-// (snapshotCityTomlForRollback) and the controller config-mutation snapshot
-// (captureConfigMutationSnapshot) route through this so the two rollback
-// surfaces stay symlink-aware together instead of drifting apart.
+// path is unchanged. The controller config-mutation snapshot
+// (captureConfigMutationSnapshot) routes through this so it stays symlink-aware,
+// matching the CLI rollback snapshots that resolve via snapshotResolvedFile.
 func cityTomlRollbackPath(fs fsys.FS, cityPath string) (string, error) {
 	return fsys.ResolveSymlinks(fs, filepath.Join(cityPath, "city.toml"))
-}
-
-// snapshotCityTomlForRollback snapshots city.toml at its symlink-resolved path
-// (see cityTomlRollbackPath) so a later rollback restores the real target file
-// and leaves a live city.toml symlink intact.
-func snapshotCityTomlForRollback(fs fsys.FS, cityPath string) (fileSnapshot, error) {
-	resolved, err := cityTomlRollbackPath(fs, cityPath)
-	if err != nil {
-		return fileSnapshot{}, err
-	}
-	return snapshotOptionalFile(fs, resolved)
 }
 
 func writeRigEndpointRollbackError(fs fsys.FS, stderr io.Writer, snapshots []fileSnapshot, action string, cause error) {

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -953,6 +953,93 @@ func TestWriteDoltPortFileStrictUsesAtomicWrite(t *testing.T) {
 	}
 }
 
+func TestWriteDoltPortFileStrictWritesThroughSymlink(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetDir := filepath.Join(t.TempDir(), "ports")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetDir, "dolt-server.port")
+	if err := os.WriteFile(target, []byte("3307\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(beadsDir, "dolt-server.port")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeDoltPortFileStrict(fsys.OSFS{}, dir, "3311"); err != nil {
+		t.Fatalf("writeDoltPortFileStrict: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dolt-server.port symlink was replaced by a %v entry; rewrite must write through the link", info.Mode())
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, target))); got != "3311" {
+		t.Fatalf("target port = %q, want 3311", got)
+	}
+}
+
+func TestRemoveDoltPortFileStrictClearsThroughSymlink(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetDir := filepath.Join(t.TempDir(), "ports")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetDir, "dolt-server.port")
+	if err := os.WriteFile(target, []byte("3311\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(beadsDir, "dolt-server.port")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeDoltPortFileStrict(dir); err != nil {
+		t.Fatalf("removeDoltPortFileStrict: %v", err)
+	}
+
+	// The operator's link must survive; only the resolved target is cleared.
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dolt-server.port symlink was replaced by a %v entry; cleanup must clear through the link", info.Mode())
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("target stat err = %v, want resolved target removed", err)
+	}
+
+	// A later publication must write through the preserved link to the
+	// operator's target instead of recreating a regular file at the link path.
+	if err := writeDoltPortFileStrict(fsys.OSFS{}, dir, "3320"); err != nil {
+		t.Fatalf("re-publish writeDoltPortFileStrict: %v", err)
+	}
+	info, err = os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link after re-publish: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("after re-publish, link mode = %v; want symlink preserved", info.Mode())
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, target))); got != "3320" {
+		t.Fatalf("re-published target port = %q, want 3320", got)
+	}
+}
+
 func TestSyncRigEndpointCompatConfigUsesAtomicWrite(t *testing.T) {
 	fs := fsys.NewFake()
 	cityDir := "/city"
@@ -993,6 +1080,183 @@ func TestRestoreSnapshotUsesAtomicWrite(t *testing.T) {
 	}
 	if got := string(fs.Files[snap.path]); got != "updated = true\n" {
 		t.Fatalf("restored file = %q", got)
+	}
+}
+
+// setupSymlinkedCityToml creates cityDir/city.toml as a symlink into a
+// checkout directory holding the original content, mirroring the ga-lurp5d
+// production layout where city.toml links into a checked-out repo.
+const symlinkedCityTomlOriginal = "[workspace]\nname = \"test-city\"\n"
+
+func setupSymlinkedCityToml(t *testing.T) (cityDir, link, target string) {
+	t.Helper()
+	dir := t.TempDir()
+	checkoutDir := filepath.Join(dir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target = filepath.Join(checkoutDir, "city.toml")
+	if err := os.WriteFile(target, []byte(symlinkedCityTomlOriginal), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cityDir = filepath.Join(dir, "city")
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link = filepath.Join(cityDir, "city.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	return cityDir, link, target
+}
+
+// assertCityTomlSymlinkRestored fails the test unless link is still a symlink
+// and target holds the original content after a rollback restore.
+func assertCityTomlSymlinkRestored(t *testing.T, link, target, original string) {
+	t.Helper()
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("city.toml symlink was replaced by a %v entry; rollback must restore through the link", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if string(data) != original {
+		t.Fatalf("target content = %q, want restored original %q", data, original)
+	}
+}
+
+// Regression test for the ga-lurp5d follow-up: a failed endpoint change must
+// roll back a symlinked city.toml by restoring the link target, not by
+// replacing the link with a regular file.
+func TestRigEndpointRollbackRestoresThroughCityTomlSymlink(t *testing.T) {
+	fs := fsys.OSFS{}
+	cityDir, link, target := setupSymlinkedCityToml(t)
+	scopeRoot := filepath.Join(cityDir, "rig")
+	if err := os.MkdirAll(scopeRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshots, err := snapshotRigEndpointFiles(fs, cityDir, scopeRoot)
+	if err != nil {
+		t.Fatalf("snapshotRigEndpointFiles: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("[workspace]\nname = \"mutated\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := restoreSnapshots(fs, snapshots); err != nil {
+		t.Fatalf("restoreSnapshots: %v", err)
+	}
+	assertCityTomlSymlinkRestored(t, link, target, symlinkedCityTomlOriginal)
+}
+
+// Regression for the attempt-3 review's consistency finding: cmd-side
+// rollback snapshots must resolve every captured file the way the API-side
+// capture does, not just city.toml — restoring a symlinked .gc/site.toml
+// must write the link target, not replace the link with a regular file.
+func TestRigEndpointRollbackRestoresThroughSiteTomlSymlink(t *testing.T) {
+	fs := fsys.OSFS{}
+	original := "name = \"bound-site\"\n"
+	cityDir, _, _ := setupSymlinkedCityToml(t)
+	checkout := filepath.Join(cityDir, "site-checkout")
+	if err := os.MkdirAll(checkout, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkout, "site.toml")
+	if err := os.WriteFile(target, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := config.SiteBindingPath(cityDir)
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	scopeRoot := filepath.Join(cityDir, "rig")
+	if err := os.MkdirAll(scopeRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshots, err := snapshotRigEndpointFiles(fs, cityDir, scopeRoot)
+	if err != nil {
+		t.Fatalf("snapshotRigEndpointFiles: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("name = \"mutated\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := restoreSnapshots(fs, snapshots); err != nil {
+		t.Fatalf("restoreSnapshots: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("site.toml symlink was replaced by a %v entry; rollback must restore through the link", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if string(data) != original {
+		t.Fatalf("target content = %q, want restored original %q", data, original)
+	}
+}
+
+func TestRigEndpointRollbackRestoresAfterSiteBindingForwardWriteThroughSymlink(t *testing.T) {
+	fs := fsys.OSFS{}
+	original := "workspace_name = \"bound-site\"\nworkspace_prefix = \"bs\"\n"
+	cityDir, _, _ := setupSymlinkedCityToml(t)
+	checkout := filepath.Join(cityDir, "site-checkout")
+	if err := os.MkdirAll(checkout, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkout, "site.toml")
+	if err := os.WriteFile(target, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := config.SiteBindingPath(cityDir)
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	scopeRoot := filepath.Join(cityDir, "rig")
+	if err := os.MkdirAll(scopeRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshots, err := snapshotRigEndpointFiles(fs, cityDir, scopeRoot)
+	if err != nil {
+		t.Fatalf("snapshotRigEndpointFiles: %v", err)
+	}
+	if err := config.PersistWorkspaceSiteBinding(fs, cityDir, "mutated-site", "ms"); err != nil {
+		t.Fatalf("PersistWorkspaceSiteBinding: %v", err)
+	}
+	if err := restoreSnapshots(fs, snapshots); err != nil {
+		t.Fatalf("restoreSnapshots: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("site.toml symlink was replaced by a %v entry; rollback must restore the effective linked state", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if string(data) != original {
+		t.Fatalf("target content = %q, want restored original %q", data, original)
 	}
 }
 

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -3307,61 +3307,22 @@ func TestRouteRigList_StaleBannerOver30s(t *testing.T) {
 	}
 }
 
-// Regression for PR #3428 review: the gc rig add outer rollback snapshots
-// city.toml at its symlink-resolved path, so restoring after a later step
-// fails rewrites the real target and leaves the live symlink intact instead of
-// replacing it with a regular file (and leaving the appended rig stranded in
-// the target).
-func TestSnapshotRigAddTopologyFilesRestoresSymlinkedCityToml(t *testing.T) {
-	dir := t.TempDir()
-	repoDir := filepath.Join(dir, "repo")
-	cityDir := filepath.Join(dir, "city")
-	if err := os.MkdirAll(repoDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	repoCityPath := filepath.Join(repoDir, "city.toml")
-	liveCityPath := filepath.Join(cityDir, "city.toml")
-	original := []byte("[workspace]\nname = \"test-city\"\n")
-	if err := os.WriteFile(repoCityPath, original, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink(filepath.Join("..", "repo", "city.toml"), liveCityPath); err != nil {
-		t.Fatal(err)
-	}
-
+// Regression test for the ga-lurp5d follow-up: a failed rig add must roll
+// back a symlinked city.toml by restoring the link target, not by replacing
+// the link with a regular file.
+func TestRigAddRollbackRestoresThroughCityTomlSymlink(t *testing.T) {
 	fs := fsys.OSFS{}
-	snapshots, err := snapshotRigAddTopologyFiles(fs, cityDir, &config.City{Workspace: config.Workspace{Name: "test-city"}})
+	cityDir, link, target := setupSymlinkedCityToml(t)
+
+	snapshots, err := snapshotRigAddTopologyFiles(fs, cityDir, &config.City{})
 	if err != nil {
 		t.Fatalf("snapshotRigAddTopologyFiles: %v", err)
 	}
-
-	// Simulate the surgical append mutating the resolved target before a later
-	// rig-add step fails and triggers rollback.
-	mutated := []byte("[workspace]\nname = \"test-city\"\n\n[[rigs]]\nname = \"frontend\"\n")
-	if err := os.WriteFile(repoCityPath, mutated, 0o644); err != nil {
+	if err := os.WriteFile(target, []byte("[workspace]\nname = \"mutated\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-
 	if err := restoreSnapshots(fs, snapshots); err != nil {
 		t.Fatalf("restoreSnapshots: %v", err)
 	}
-
-	info, err := os.Lstat(liveCityPath)
-	if err != nil {
-		t.Fatalf("Lstat(live city.toml): %v", err)
-	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		t.Fatalf("rollback replaced the live city.toml symlink with a regular file")
-	}
-	restored, err := os.ReadFile(repoCityPath)
-	if err != nil {
-		t.Fatalf("read repo city.toml: %v", err)
-	}
-	if !bytes.Equal(restored, original) {
-		t.Fatalf("repo city.toml = %q, want restored original %q", restored, original)
-	}
+	assertCityTomlSymlinkRestored(t, link, target, symlinkedCityTomlOriginal)
 }

--- a/cmd/gc/doctor_provider_catalog.go
+++ b/cmd/gc/doctor_provider_catalog.go
@@ -180,6 +180,10 @@ func missingBuiltinProviderRefs(refs []config.ProviderReference) []string {
 	return out
 }
 
+// appendBuiltinProviderAliases is exempt from config.ResolveCityRewritePath:
+// os.WriteFile truncates through a symlinked city.toml and the append keeps
+// every existing byte, so neither link identity nor unknown keys are at
+// risk. Switching this to a temp-file + rename write revokes the exemption.
 func appendBuiltinProviderAliases(cityPath string, providers []string) error {
 	if len(providers) == 0 {
 		return nil

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -283,7 +283,16 @@ func rewriteWithoutDefaultFormulasDir(path string) error {
 	if !changed {
 		return fmt.Errorf("could not locate [formulas].dir assignment")
 	}
-	return fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, path, []byte(rendered), 0o644)
+	// Resolve-only, like the rollback snapshots: the rewrite is a lossless
+	// textual strip of one declaration, so the key-loss guard in
+	// config.ResolveCityRewritePath would falsely refuse it whenever
+	// unrelated unknown keys are present. Writing at the unresolved path
+	// would replace a symlinked config with a regular file.
+	writePath, err := fsys.ResolveSymlinks(fsys.OSFS{}, path)
+	if err != nil {
+		return err
+	}
+	return fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, writePath, []byte(rendered), 0o644)
 }
 
 func stripDefaultFormulasDirDeclaration(source string) (string, bool) {

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -1491,6 +1491,44 @@ func TestV2WorkspaceNameFixWritesThroughCityTomlSymlink(t *testing.T) {
 	}
 }
 
+func TestV2FormulasDirFixWritesThroughCityTomlSymlink(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkoutDir, "city.toml")
+	if err := os.WriteFile(target, []byte("[formulas]\ndir = \"formulas\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(cityDir, "city.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	d := &doctor.Doctor{}
+	registerV2DeprecationChecks(d)
+	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, true)
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("city.toml symlink was replaced by a %v entry; fix must write through the link", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if strings.Contains(string(data), `dir = "formulas"`) {
+		t.Fatalf("default formulas dir declaration should be stripped from the symlink target:\n%s", data)
+	}
+}
+
 func TestV2DeprecationChecksWarnOnLegacyTemplateSuffix(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/packman"
 )
 
@@ -605,5 +606,126 @@ func TestDoDoctorSkipsImportStateCheckWhenCityConfigInvalid(t *testing.T) {
 	}
 	if !strings.Contains(out, "city-config") {
 		t.Fatalf("doctor output missing city config failure:\n%s", out)
+	}
+}
+
+// Regression for the ga-lurp5d follow-up review: the packv2 import-state
+// rewrite re-marshals pack.toml; when pack.toml is a symlink (e.g., into a
+// checked-out repo) the rewrite must write through the link instead of
+// replacing it with a regular file and stranding the stale manifest in the
+// checked-in target.
+func TestRewriteLegacyPublicPackImportsWritesThroughPackTomlSymlink(t *testing.T) {
+	t.Parallel()
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkoutDir, "pack.toml")
+	src := `[pack]
+name = "demo"
+schema = 1
+
+[imports.gastown]
+source = ".gc/system/packs/gastown"
+`
+	if err := os.WriteFile(target, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(cityDir, "pack.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := rewriteLegacyPublicPackImportsFS(fsys.OSFS{}, cityDir, map[string]wave1PublicPackImportTarget{
+		"gastown": {
+			Binding: "gastown",
+			Import:  config.Import{Source: "https://packages.example/gastown.git", Version: "^1.2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("rewriteLegacyPublicPackImportsFS: %v", err)
+	}
+	if !changed {
+		t.Fatal("rewriteLegacyPublicPackImportsFS reported no change, want pack.toml rewrite")
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("pack.toml symlink was replaced by a %v entry; rewrite must write through the link", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "https://packages.example/gastown.git") {
+		t.Fatalf("symlink target missing migrated import source:\n%s", text)
+	}
+	if strings.Contains(text, ".gc/system/packs/gastown") {
+		t.Fatalf("symlink target still contains legacy import source:\n%s", text)
+	}
+}
+
+// Regression for the ga-lurp5d follow-up review: the packv2 import-state
+// rewrite re-marshals pack.toml through the reduced cityPackManifest struct,
+// which would silently drop keys this gc binary does not recognize. A pack.toml
+// carrying an unknown key must make the rewrite refuse rather than strand a
+// reduced manifest at the checked-in target.
+func TestRewriteLegacyPublicPackImportsRefusesPackTomlUnknownKeys(t *testing.T) {
+	t.Parallel()
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkoutDir, "pack.toml")
+	src := `[pack]
+name = "demo"
+schema = 1
+
+[imports.gastown]
+source = ".gc/system/packs/gastown"
+
+[future_unknown_section]
+knob = "keep-me"
+`
+	if err := os.WriteFile(target, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(cityDir, "pack.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := rewriteLegacyPublicPackImportsFS(fsys.OSFS{}, cityDir, map[string]wave1PublicPackImportTarget{
+		"gastown": {
+			Binding: "gastown",
+			Import:  config.Import{Source: "https://packages.example/gastown.git", Version: "^1.2"},
+		},
+	})
+	if err == nil {
+		t.Fatal("rewriteLegacyPublicPackImportsFS succeeded, want refusal for unknown key")
+	}
+	if !strings.Contains(err.Error(), "future_unknown_section") {
+		t.Fatalf("error = %v, want mention of future_unknown_section", err)
+	}
+	// The symlink and its content must survive an aborted rewrite.
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("pack.toml symlink was replaced by a %v entry", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if string(data) != src {
+		t.Fatalf("pack.toml was rewritten despite refusal:\n%s", data)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2791,18 +2791,28 @@ func mergeAgentDefaultsAliasPreferCanonical(dst *AgentDefaults, src AgentDefault
 	}
 }
 
-func normalizeAgentDefaultsAlias(cfg *City, meta toml.MetaData) {
+// FoldAgentDefaultsAlias folds a legacy [agents] alias table into the canonical
+// [agent_defaults] target so a struct round-trip that emits only
+// [agent_defaults] does not silently drop the alias. When both tables are
+// present the canonical values win on overlapping keys and the alias only fills
+// gaps; when only the alias is present its values become the canonical defaults.
+// meta must be the toml.MetaData from decoding the same document. Callers are
+// responsible for clearing their own alias field afterward.
+func FoldAgentDefaultsAlias(canonical *AgentDefaults, alias AgentDefaults, meta toml.MetaData) {
 	if meta.IsDefined("agent_defaults") {
 		if meta.IsDefined("agents") {
-			mergeAgentDefaultsAliasPreferCanonical(&cfg.AgentDefaults, cfg.AgentsDefaults, meta)
+			mergeAgentDefaultsAliasPreferCanonical(canonical, alias, meta)
 		}
-		cfg.AgentsDefaults = AgentDefaults{}
 		return
 	}
 	if meta.IsDefined("agents") {
-		cfg.AgentDefaults = cfg.AgentsDefaults
-		cfg.AgentsDefaults = AgentDefaults{}
+		*canonical = alias
 	}
+}
+
+func normalizeAgentDefaultsAlias(cfg *City, meta toml.MetaData) {
+	FoldAgentDefaultsAlias(&cfg.AgentDefaults, cfg.AgentsDefaults, meta)
+	cfg.AgentsDefaults = AgentDefaults{}
 }
 
 const (

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1023,15 +1023,7 @@ func parsePackConfigWithMetadata(data []byte, source string) (PackConfig, toml.M
 }
 
 func normalizePackAgentDefaultsAlias(cfg *PackConfig, meta toml.MetaData) {
-	if !meta.IsDefined("agents") {
-		cfg.AgentsDefaults = AgentDefaults{}
-		return
-	}
-	if meta.IsDefined("agent_defaults") {
-		mergeAgentDefaultsAliasPreferCanonical(&cfg.AgentDefaults, cfg.AgentsDefaults, meta)
-	} else {
-		cfg.AgentDefaults = cfg.AgentsDefaults
-	}
+	FoldAgentDefaultsAlias(&cfg.AgentDefaults, cfg.AgentsDefaults, meta)
 	cfg.AgentsDefaults = AgentDefaults{}
 }
 

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -425,7 +425,17 @@ func writeCityAndRigSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City, 
 	if err != nil {
 		return err
 	}
-	snapshot, err := snapshotCityAndSiteFiles(fs, writePath, SiteBindingPath(cityRoot))
+	// Snapshot the .gc/site.toml target persistSiteBinding actually writes,
+	// not the link itself: resolve-only (no key-loss guard, the rollback
+	// rewrites snapshotted bytes), mirroring the resolved forward write so a
+	// post-city.toml binding failure restores the target instead of renaming
+	// over (or removing) a symlinked site binding.
+	sitePath := SiteBindingPath(cityRoot)
+	resolvedSitePath, err := fsys.ResolveSymlinks(fs, sitePath)
+	if err != nil {
+		return fmt.Errorf("resolving site binding %q for rewrite: %w", sitePath, err)
+	}
+	snapshot, err := snapshotCityAndSiteFiles(fs, writePath, resolvedSitePath)
 	if err != nil {
 		return err
 	}
@@ -446,14 +456,23 @@ func writeCityAndRigSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City, 
 // renaming a temp file over the link would replace the link itself, so the
 // rewrite must follow the chain and write at the final target instead. It
 // also refuses the rewrite when the current on-disk content would lose keys
-// in the round-trip (see guardCityRewriteKeyLoss). Every code path that
-// rewrites an existing city.toml must resolve through this helper.
+// in the round-trip (see GuardCityRewriteKeyLoss).
+//
+// Every code path that rewrites an existing city.toml from a re-marshaled
+// struct must resolve through this helper. Two classes are exempt because
+// only half the protection applies: lossless byte-preserving writers that
+// follow the link anyway (an os.WriteFile append or rewrite keeps existing
+// bytes and truncates through the link; switching one to a temp-file +
+// rename write revokes its exemption), and resolve-only restore or repair
+// paths that write previously-snapshotted or stripped bytes back (they
+// resolve via fsys.ResolveSymlinks but must skip the key-loss guard, which
+// would falsely refuse whenever unrelated unknown keys are present).
 func ResolveCityRewritePath(fs fsys.FS, tomlPath string) (string, error) {
 	writePath, err := fsys.ResolveSymlinks(fs, tomlPath)
 	if err != nil {
 		return "", fmt.Errorf("resolving %s for rewrite: %w", tomlPath, err)
 	}
-	if err := guardCityRewriteKeyLoss(fs, writePath); err != nil {
+	if err := GuardCityRewriteKeyLoss(fs, writePath); err != nil {
 		return "", err
 	}
 	return writePath, nil
@@ -478,7 +497,7 @@ func ResolveCityAppendPath(fs fsys.FS, tomlPath string) (string, error) {
 	return writePath, nil
 }
 
-// guardCityRewriteKeyLoss refuses to rewrite a city.toml whose current
+// GuardCityRewriteKeyLoss refuses to rewrite a city.toml whose current
 // on-disk content contains keys this gc binary does not recognize: the
 // struct round-trip would silently drop them (ga-lurp5d dropped
 // agent_defaults.provider and beads.bd_compatibility in production this
@@ -486,10 +505,33 @@ func ResolveCityAppendPath(fs fsys.FS, tomlPath string) (string, error) {
 // file is also refused: callers load the config from this same path before
 // mutating it, so unparsable content here means the file changed underneath
 // us and a rewrite would destroy whatever is there now.
-func guardCityRewriteKeyLoss(fs fsys.FS, path string) error {
-	md, ok, err := decodeCityForGuard(fs, path)
-	if err != nil || !ok {
-		return err
+func GuardCityRewriteKeyLoss(fs fsys.FS, path string) error {
+	return GuardRewriteKeyLoss[City](fs, path)
+}
+
+// GuardRewriteKeyLoss refuses to rewrite a TOML config whose current on-disk
+// content contains keys that struct T does not recognize. T must be the struct
+// the caller marshals back (or a faithful superset of it) so that every key T
+// fails to decode is genuinely one the rewrite would silently drop. It backs
+// GuardCityRewriteKeyLoss for city.toml and the equivalent pack.toml rewrite
+// guards (gc agent suspend, import-manifest rewrites), all of which round-trip
+// a config through a reduced struct and would otherwise drop newer or manual
+// keys at a checked-in target. A missing file is fine — there is nothing to
+// lose. An unparsable file is refused: callers load from this same path before
+// mutating it, so unparsable content means the file changed underneath us and
+// a rewrite would destroy whatever is there now.
+func GuardRewriteKeyLoss[T any](fs fsys.FS, path string) error {
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("reading %s before rewrite: %w", path, err)
+	}
+	var cfg T
+	md, err := toml.Decode(string(data), &cfg)
+	if err != nil {
+		return fmt.Errorf("refusing to rewrite %s: current content does not parse, rewriting would destroy it: %w", path, err)
 	}
 	undecoded := md.Undecoded()
 	if len(undecoded) == 0 {
@@ -633,9 +675,13 @@ func PersistWorkspaceSiteBinding(fs fsys.FS, cityRoot, name, prefix string) erro
 
 func persistSiteBinding(fs fsys.FS, cityRoot string, binding SiteBinding) error {
 	path := SiteBindingPath(cityRoot)
+	writePath, err := fsys.ResolveSymlinks(fs, path)
+	if err != nil {
+		return fmt.Errorf("resolving site binding %q for rewrite: %w", path, err)
+	}
 	if len(binding.Rigs) == 0 && binding.WorkspaceName == "" && binding.WorkspacePrefix == "" {
-		if err := fs.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("removing site binding %q: %w", path, err)
+		if err := fs.Remove(writePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing site binding %q: %w", writePath, err)
 		}
 		return nil
 	}
@@ -646,14 +692,14 @@ func persistSiteBinding(fs fsys.FS, cityRoot string, binding SiteBinding) error 
 	if err := enc.Encode(binding); err != nil {
 		return fmt.Errorf("marshaling site binding: %w", err)
 	}
-	if err := fs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("creating runtime dir %q: %w", filepath.Dir(path), err)
+	if err := fs.MkdirAll(filepath.Dir(writePath), 0o755); err != nil {
+		return fmt.Errorf("creating runtime dir %q: %w", filepath.Dir(writePath), err)
 	}
 	// Skip the write when on-disk content already matches. Keeps repeated
 	// rig/suspend/resume/agent commands idempotent instead of churning
 	// .gc/site.toml mtime (and breaking watcher debounce logic).
-	if err := fsys.WriteFileIfChangedAtomic(fs, path, buf.Bytes(), 0o644); err != nil {
-		return fmt.Errorf("writing site binding %q: %w", path, err)
+	if err := fsys.WriteFileIfChangedAtomic(fs, writePath, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("writing site binding %q: %w", writePath, err)
 	}
 	return nil
 }

--- a/internal/config/site_binding_rewrite_test.go
+++ b/internal/config/site_binding_rewrite_test.go
@@ -183,6 +183,229 @@ func TestAppendRigAndWriteSiteBindingsForEditRefusesUnparsableCity(t *testing.T)
 	}
 }
 
+// The funnel's rollback must also preserve a symlinked city.toml: when the
+// site-binding write fails after city.toml was rewritten, the snapshot
+// restore writes back through the resolved target instead of replacing the
+// link with a regular file.
+func TestWriteCityAndRigSiteBindingsForEditRestoresSymlinkOnBindingFailure(t *testing.T) {
+	dir := t.TempDir()
+	checkoutDir := filepath.Join(dir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkoutDir, "city.toml")
+	original := []byte("[workspace]\nname = \"test-city\"\n")
+	if err := os.WriteFile(target, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cityDir := filepath.Join(dir, "city")
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(cityDir, "city.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	// Force persistRigSiteBindings to fail after the city.toml write: .gc
+	// exists but is read-only, so the site-binding temp file cannot be
+	// created there.
+	gcDir := filepath.Join(cityDir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(gcDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(gcDir, 0o755) })
+
+	cfg := &City{
+		Workspace: Workspace{Name: "renamed-city"},
+		Rigs:      []Rig{{Name: "frontend", Path: filepath.Join(dir, "frontend")}},
+	}
+	err := WriteCityAndRigSiteBindingsForEdit(fsys.OSFS{}, link, cfg)
+	if err == nil {
+		t.Fatal("WriteCityAndRigSiteBindingsForEdit succeeded, want site-binding write failure")
+	}
+	if !strings.Contains(err.Error(), "restored city.toml") {
+		t.Fatalf("error = %v, want restore confirmation", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("city.toml symlink was replaced by a %v entry; rollback must restore through the link", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if !bytes.Equal(data, original) {
+		t.Fatalf("target content = %q, want restored original %q", data, original)
+	}
+}
+
+// The funnel's rollback must also preserve a symlinked .gc/site.toml: the
+// snapshot records the resolved target persistSiteBinding writes to, so a
+// site-binding failure after the city.toml rewrite restores the target's
+// contents instead of renaming over (or removing) the link itself.
+func TestWriteCityAndRigSiteBindingsForEditPreservesSiteTomlSymlinkOnBindingFailure(t *testing.T) {
+	originalCity := []byte("[workspace]\nname = \"test-city\"\n")
+
+	// setupCity creates a writable city dir with a regular city.toml and a
+	// writable .gc dir, and links .gc/site.toml to linkTarget.
+	setupCity := func(t *testing.T, dir, linkTarget string) (cityPath, link string) {
+		t.Helper()
+		cityDir := filepath.Join(dir, "city")
+		gcDir := filepath.Join(cityDir, ".gc")
+		if err := os.MkdirAll(gcDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cityPath = filepath.Join(cityDir, "city.toml")
+		if err := os.WriteFile(cityPath, originalCity, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		link = filepath.Join(gcDir, "site.toml")
+		if err := os.Symlink(linkTarget, link); err != nil {
+			t.Fatal(err)
+		}
+		return cityPath, link
+	}
+
+	editCfg := func(dir string) *City {
+		return &City{
+			Workspace: Workspace{Name: "renamed-city"},
+			Rigs:      []Rig{{Name: "frontend", Path: filepath.Join(dir, "frontend")}},
+		}
+	}
+
+	assertLinkAndCityRestored := func(t *testing.T, link, linkTarget, cityPath string) {
+		t.Helper()
+		info, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("Lstat link: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf(".gc/site.toml symlink was replaced by a %v entry; rollback must restore through the link", info.Mode())
+		}
+		gotTarget, err := os.Readlink(link)
+		if err != nil {
+			t.Fatalf("Readlink: %v", err)
+		}
+		if gotTarget != linkTarget {
+			t.Fatalf("link target = %q, want %q", gotTarget, linkTarget)
+		}
+		cityData, err := os.ReadFile(cityPath)
+		if err != nil {
+			t.Fatalf("ReadFile city.toml: %v", err)
+		}
+		if !bytes.Equal(cityData, originalCity) {
+			t.Fatalf("city.toml = %q, want restored original %q", cityData, originalCity)
+		}
+	}
+
+	t.Run("write fails at read-only link target", func(t *testing.T) {
+		dir := t.TempDir()
+		checkoutDir := filepath.Join(dir, "checkout")
+		if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(checkoutDir, "site.toml")
+		originalSite := []byte("[[rig]]\nname = \"backend\"\npath = \"/srv/backend\"\n")
+		if err := os.WriteFile(target, originalSite, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// The link target's directory is read-only, so the forward
+		// site-binding write fails there — while the link-side .gc stays
+		// writable, which is exactly where a rollback at the unresolved
+		// path would "succeed" by renaming over the link.
+		if err := os.Chmod(checkoutDir, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(checkoutDir, 0o755) })
+		cityPath, link := setupCity(t, dir, target)
+
+		err := WriteCityAndRigSiteBindingsForEdit(fsys.OSFS{}, cityPath, editCfg(dir))
+		if err == nil {
+			t.Fatal("WriteCityAndRigSiteBindingsForEdit succeeded, want site-binding write failure")
+		}
+
+		assertLinkAndCityRestored(t, link, target, cityPath)
+		data, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatalf("ReadFile target: %v", err)
+		}
+		if !bytes.Equal(data, originalSite) {
+			t.Fatalf("target content = %q, want untouched original %q", data, originalSite)
+		}
+	})
+
+	t.Run("load failure restores target through link", func(t *testing.T) {
+		dir := t.TempDir()
+		checkoutDir := filepath.Join(dir, "checkout")
+		if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(checkoutDir, "site.toml")
+		// Unparsable content makes persistRigSiteBindings fail after the
+		// city.toml rewrite, so rollback must rewrite these exact bytes at
+		// the resolved target, not rename over the link.
+		originalSite := []byte("not toml [\n")
+		if err := os.WriteFile(target, originalSite, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cityPath, link := setupCity(t, dir, target)
+
+		err := WriteCityAndRigSiteBindingsForEdit(fsys.OSFS{}, cityPath, editCfg(dir))
+		if err == nil {
+			t.Fatal("WriteCityAndRigSiteBindingsForEdit succeeded, want site-binding load failure")
+		}
+		if !strings.Contains(err.Error(), "restored city.toml") {
+			t.Fatalf("error = %v, want restore confirmation", err)
+		}
+
+		assertLinkAndCityRestored(t, link, target, cityPath)
+		data, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatalf("ReadFile target: %v", err)
+		}
+		if !bytes.Equal(data, originalSite) {
+			t.Fatalf("target content = %q, want restored original %q", data, originalSite)
+		}
+	})
+
+	t.Run("dangling link is not removed by rollback", func(t *testing.T) {
+		dir := t.TempDir()
+		checkoutDir := filepath.Join(dir, "checkout")
+		if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// The dangling target's parent cannot be created, so the forward
+		// write fails; the !existed rollback branch must remove the
+		// (missing) target, never the link itself.
+		if err := os.Chmod(checkoutDir, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(checkoutDir, 0o755) })
+		target := filepath.Join(checkoutDir, "sub", "site.toml")
+		cityPath, link := setupCity(t, dir, target)
+
+		err := WriteCityAndRigSiteBindingsForEdit(fsys.OSFS{}, cityPath, editCfg(dir))
+		if err == nil {
+			t.Fatal("WriteCityAndRigSiteBindingsForEdit succeeded, want site-binding write failure")
+		}
+		if !strings.Contains(err.Error(), "restored city.toml") {
+			t.Fatalf("error = %v, want restore confirmation", err)
+		}
+
+		assertLinkAndCityRestored(t, link, target, cityPath)
+		if _, err := os.Lstat(target); !os.IsNotExist(err) {
+			t.Fatalf("Lstat target = %v, want not-exist after rollback", err)
+		}
+	})
+}
+
 // A brand-new city.toml (no existing file) must still be writable: the
 // unknown-key guard only applies when there is existing content to lose.
 func TestWriteCityAndRigSiteBindingsForEditAllowsFreshWrite(t *testing.T) {

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -72,10 +72,7 @@ func TestPersistRigSiteBindings(t *testing.T) {
 
 func TestPersistRigSiteBindings_PreservesWorkspaceIdentity(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Files[SiteBindingPath("/city")] = []byte(`
-workspace_name = "site-city"
-workspace_prefix = "sc"
-`)
+	fs.Files[SiteBindingPath("/city")] = []byte("workspace_name = \"site-city\"\nworkspace_prefix = \"sc\"\n")
 	cfg := []Rig{{Name: "frontend", Path: "/tmp/frontend"}}
 
 	if err := PersistRigSiteBindings(fs, "/city", cfg); err != nil {
@@ -94,6 +91,80 @@ workspace_prefix = "sc"
 	}
 	if len(binding.Rigs) != 1 || binding.Rigs[0].Name != "frontend" {
 		t.Fatalf("binding.Rigs = %+v, want preserved workspace identity plus frontend rig", binding.Rigs)
+	}
+}
+
+func TestPersistWorkspaceSiteBindingWritesThroughSiteTomlSymlink(t *testing.T) {
+	dir := t.TempDir()
+	targetDir := filepath.Join(dir, "checkout")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetDir, "site.toml")
+	if err := os.WriteFile(target, []byte("workspace_name = \"old-site\"\nworkspace_prefix = \"os\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cityDir := filepath.Join(dir, "city")
+	link := SiteBindingPath(cityDir)
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := PersistWorkspaceSiteBinding(fsys.OSFS{}, cityDir, "new-site", "ns"); err != nil {
+		t.Fatalf("PersistWorkspaceSiteBinding: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("site.toml symlink was replaced by a %v entry; rewrite must write through the link", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	if got := string(data); !strings.Contains(got, `workspace_name = "new-site"`) || !strings.Contains(got, `workspace_prefix = "ns"`) {
+		t.Fatalf("target content = %q, want updated workspace binding", got)
+	}
+}
+
+func TestPersistWorkspaceSiteBindingRemovesSiteTomlSymlinkTarget(t *testing.T) {
+	dir := t.TempDir()
+	targetDir := filepath.Join(dir, "checkout")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetDir, "site.toml")
+	if err := os.WriteFile(target, []byte("workspace_name = \"old-site\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cityDir := filepath.Join(dir, "city")
+	link := SiteBindingPath(cityDir)
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := PersistWorkspaceSiteBinding(fsys.OSFS{}, cityDir, "", ""); err != nil {
+		t.Fatalf("PersistWorkspaceSiteBinding: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("site.toml symlink was replaced by a %v entry; empty binding removal must preserve the link", info.Mode())
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("target stat err = %v, want removed target", err)
 	}
 }
 

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -542,15 +542,48 @@ func isAgentPatchOnlyIdentity(p config.AgentPatch) bool {
 	return true
 }
 
+// resolveAgentTomlTarget resolves a convention agent.toml path through any
+// symlink so atomic rewrites land on the checked-in target instead of replacing
+// the link entry. A non-symlink path is returned cleaned; a missing or dangling
+// link resolves to its would-be target so a suspend can still create it.
+func resolveAgentTomlTarget(fs fsys.FS, agentTomlPath, name string) (string, error) {
+	target, err := fsys.ResolveSymlinks(fs, agentTomlPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving agents/%s/agent.toml: %w", name, err)
+	}
+	return target, nil
+}
+
+// removeAgentTomlConvention clears the durable agent.toml convention content.
+// When agent.toml is a symlink into a checked-in target, the resolved target is
+// removed so the durable content is cleared at its real location; the operator's
+// link is intentionally left in place (edits act on the target, not the link).
+// A now-dangling link is treated as "no durable config" by every reader and is
+// rewritten through on the next suspend. Missing files are not an error.
+func removeAgentTomlConvention(fs fsys.FS, agentTomlPath, name string) error {
+	target, err := resolveAgentTomlTarget(fs, agentTomlPath, name)
+	if err != nil {
+		return err
+	}
+	if err := fs.Remove(target); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing agents/%s/agent.toml: %w", name, err)
+	}
+	return nil
+}
+
 // WriteLocalDiscoveredAgentSuspended writes the suspended state to
 // agents/<name>/agent.toml using an atomic temp-file rename. When
 // suspended is false and the file would become empty (no other fields),
-// it is removed instead.
+// the durable content is cleared instead.
 //
 // Decoding into map[string]any (rather than a typed struct) preserves
 // any user-set fields the caller didn't ask about. TOML comments and
 // key ordering are not preserved — that is a limitation of the
 // underlying decode/encode round trip, not this helper.
+//
+// Writes and removals resolve a symlinked agent.toml to its checked-in target
+// first, so a linked config is updated/cleared at the target rather than having
+// the link replaced by a regular file (the ga-lurp5d symlink-clobber class).
 func WriteLocalDiscoveredAgentSuspended(fs fsys.FS, cityRoot string, agent config.Agent, suspended bool) error {
 	agentTomlPath := filepath.Join(cityRoot, "agents", agent.Name, "agent.toml")
 
@@ -576,17 +609,18 @@ func WriteLocalDiscoveredAgentSuspended(fs fsys.FS, cityRoot string, agent confi
 	}
 
 	if len(values) == 0 {
-		if err := fs.Remove(agentTomlPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("removing agents/%s/agent.toml: %w", agent.Name, err)
-		}
-		return nil
+		return removeAgentTomlConvention(fs, agentTomlPath, agent.Name)
 	}
 
 	var buf bytes.Buffer
 	if err := toml.NewEncoder(&buf).Encode(values); err != nil {
 		return fmt.Errorf("encoding agents/%s/agent.toml: %w", agent.Name, err)
 	}
-	if err := fsys.WriteFileAtomic(fs, agentTomlPath, buf.Bytes(), 0o644); err != nil {
+	writePath, err := resolveAgentTomlTarget(fs, agentTomlPath, agent.Name)
+	if err != nil {
+		return err
+	}
+	if err := fsys.WriteFileAtomic(fs, writePath, buf.Bytes(), 0o644); err != nil {
 		return fmt.Errorf("writing agents/%s/agent.toml: %w", agent.Name, err)
 	}
 	return nil
@@ -770,7 +804,11 @@ func WriteLocalDiscoveredAgentConfig(fs fsys.FS, cityRoot string, agent config.A
 	if err := toml.NewEncoder(&buf).Encode(values); err != nil {
 		return cleanupFreshScaffold(fmt.Errorf("encoding agents/%s/agent.toml: %w", agent.Name, err))
 	}
-	if err := fsys.WriteFileAtomic(fs, filepath.Join(agentDir, "agent.toml"), buf.Bytes(), 0o644); err != nil {
+	writePath, err := resolveAgentTomlTarget(fs, filepath.Join(agentDir, "agent.toml"), agent.Name)
+	if err != nil {
+		return cleanupFreshScaffold(err)
+	}
+	if err := fsys.WriteFileAtomic(fs, writePath, buf.Bytes(), 0o644); err != nil {
 		return cleanupFreshScaffold(fmt.Errorf("writing agents/%s/agent.toml: %w", agent.Name, err))
 	}
 	return nil
@@ -849,17 +887,18 @@ func writeLocalDiscoveredAgentUpdate(fs fsys.FS, cityRoot string, agent config.A
 	// An empty merged convention config means there is no durable agent.toml
 	// content to preserve; the prompt scaffold still defines the agent.
 	if len(values) == 0 {
-		if err := fs.Remove(agentTomlPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("removing agents/%s/agent.toml: %w", agent.Name, err)
-		}
-		return nil
+		return removeAgentTomlConvention(fs, agentTomlPath, agent.Name)
 	}
 
 	var buf bytes.Buffer
 	if err := toml.NewEncoder(&buf).Encode(values); err != nil {
 		return fmt.Errorf("encoding agents/%s/agent.toml: %w", agent.Name, err)
 	}
-	if err := fsys.WriteFileAtomic(fs, agentTomlPath, buf.Bytes(), 0o644); err != nil {
+	writePath, err := resolveAgentTomlTarget(fs, agentTomlPath, agent.Name)
+	if err != nil {
+		return err
+	}
+	if err := fsys.WriteFileAtomic(fs, writePath, buf.Bytes(), 0o644); err != nil {
 		return fmt.Errorf("writing agents/%s/agent.toml: %w", agent.Name, err)
 	}
 	return nil

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -545,6 +545,126 @@ schema = 2
 	}
 }
 
+// setupSymlinkedConventionAgent builds a schema-2 city with a convention
+// "worker" whose agents/worker/agent.toml is a symlink into a separate
+// checked-in location. It returns the city.toml path, the agent.toml link
+// path, and the resolved checked-in target path.
+func setupSymlinkedConventionAgent(t *testing.T, agentTomlBody string) (cityTOML, link, target string) {
+	t.Helper()
+	dir := t.TempDir()
+	cityTOML = writeTOML(t, dir, `[workspace]
+name = "test-city"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	checkedIn := filepath.Join(dir, "checked-in")
+	if err := os.MkdirAll(checkedIn, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target = filepath.Join(checkedIn, "worker.agent.toml")
+	if err := os.WriteFile(target, []byte(agentTomlBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link = filepath.Join(agentDir, "agent.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	return cityTOML, link, target
+}
+
+func assertStillSymlink(t *testing.T, link string) {
+	t.Helper()
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat %q: %v", link, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%q symlink was replaced by a regular file", link)
+	}
+}
+
+func TestSuspendAgent_LocalDiscovered_SymlinkedAgentTomlWritesThroughLink(t *testing.T) {
+	cityTOML, link, target := setupSymlinkedConventionAgent(t, "provider = \"codex\"\n")
+
+	ed := configedit.NewEditor(fsys.OSFS{}, cityTOML)
+	if err := ed.SuspendAgent("worker"); err != nil {
+		t.Fatalf("SuspendAgent: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+	got := string(mustReadFile(t, target))
+	if !strings.Contains(got, "suspended = true") {
+		t.Fatalf("checked-in target = %q, want suspended = true written through the link", got)
+	}
+	if !strings.Contains(got, `provider = "codex"`) {
+		t.Fatalf("checked-in target = %q, want provider preserved", got)
+	}
+}
+
+func TestResumeAgent_LocalDiscovered_SymlinkedAgentTomlEmptyClearsTarget(t *testing.T) {
+	// Only the suspended flag is durable, so resume empties the config and the
+	// resolved checked-in target is cleared. The operator's link is left in
+	// place (edits act on the target, not the link).
+	cityTOML, link, target := setupSymlinkedConventionAgent(t, "suspended = true\n")
+
+	ed := configedit.NewEditor(fsys.OSFS{}, cityTOML)
+	if err := ed.ResumeAgent("worker"); err != nil {
+		t.Fatalf("ResumeAgent: %v", err)
+	}
+
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("checked-in target should be cleared on empty resume, stat err = %v", err)
+	}
+	assertStillSymlink(t, link)
+	cfg := readExpandedTOML(t, cityTOML)
+	if findAgent(t, cfg, "worker").Suspended {
+		t.Fatal("worker should not be suspended after resume")
+	}
+}
+
+func TestUpdateAgent_LocalDiscovered_SymlinkedAgentTomlWritesThroughLink(t *testing.T) {
+	cityTOML, link, target := setupSymlinkedConventionAgent(t, "provider = \"codex\"\n")
+
+	ed := configedit.NewEditor(fsys.OSFS{}, cityTOML)
+	if err := ed.UpdateAgent("worker", configedit.AgentUpdate{Provider: "claude"}); err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+	got := string(mustReadFile(t, target))
+	if !strings.Contains(got, `provider = "claude"`) {
+		t.Fatalf("checked-in target = %q, want provider updated through the link", got)
+	}
+}
+
+func TestWriteLocalDiscoveredAgentConfig_SymlinkedAgentTomlWritesThroughLink(t *testing.T) {
+	cityTOML, link, target := setupSymlinkedConventionAgent(t, "provider = \"codex\"\n")
+	cityRoot := filepath.Dir(cityTOML)
+
+	agent := config.Agent{
+		Name:     "worker",
+		Provider: "claude",
+		Scope:    "city",
+	}
+	if err := configedit.WriteLocalDiscoveredAgentConfig(fsys.OSFS{}, cityRoot, agent); err != nil {
+		t.Fatalf("WriteLocalDiscoveredAgentConfig: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+	got := string(mustReadFile(t, target))
+	if !strings.Contains(got, `provider = "claude"`) {
+		t.Fatalf("checked-in target = %q, want provider written through the link", got)
+	}
+}
+
 // TestSuspendAgent_PackDeclaredAgentUsesPatch ensures that an [[agent]]
 // explicitly declared in the city's pack.toml is suspended via
 // [[patches.agent]] in city.toml — not via agents/<name>/agent.toml,

--- a/internal/doctor/autofix_skills.go
+++ b/internal/doctor/autofix_skills.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 // DeprecatedAttachmentFieldsCheck scans user-editable city TOML files
@@ -186,7 +188,9 @@ func findDeprecatedAttachmentFieldLines(source string) []deprecatedAttachmentLin
 // removing every assignment whose key is one of the tombstone names.
 // Multi-line arrays are removed in full. Surrounding lines, comments,
 // and section headers are preserved verbatim. Trailing-newline shape
-// is preserved when present.
+// is preserved when present. The write lands on the resolved symlink
+// target with the original file mode, so a symlinked config keeps its
+// link and its permissions.
 //
 // Mirrors findDeprecatedAttachmentFieldLines's multi-line string
 // state tracking: lines inside a `"""..."""` or `”'...”'` block
@@ -228,21 +232,22 @@ func rewriteWithoutDeprecatedAttachmentFields(path string) error {
 		rendered += "\n"
 	}
 
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-")
+	// Resolve-only, like the formulas-dir strip: the rewrite is a lossless
+	// textual removal, so the key-loss guard in config.ResolveCityRewritePath
+	// would falsely refuse it whenever unrelated unknown keys are present.
+	// Renaming over the unresolved path would replace a symlinked
+	// city.toml/pack.toml with a regular file and strand the stale content
+	// in the checked-in target. The write keeps the original file mode —
+	// a temp file's default 0600 must not survive the rename.
+	writePath, err := fsys.ResolveSymlinks(fsys.OSFS{}, path)
 	if err != nil {
 		return err
 	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath) //nolint:errcheck // best-effort cleanup
-	if _, err := tmp.WriteString(rendered); err != nil {
-		tmp.Close() //nolint:errcheck
+	info, err := os.Stat(writePath)
+	if err != nil {
 		return err
 	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmpPath, path)
+	return fsys.WriteFileAtomic(fsys.OSFS{}, writePath, []byte(rendered), info.Mode().Perm())
 }
 
 // tomlStringState tracks whether the scanner is currently inside an

--- a/internal/doctor/autofix_skills_test.go
+++ b/internal/doctor/autofix_skills_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -274,6 +275,95 @@ func TestDeprecatedAttachmentFieldsCheckEndToEnd(t *testing.T) {
 	want := "[[agent]]\nname = \"mayor\"\nprovider = \"claude\"\n"
 	if string(got) != want {
 		t.Fatalf("post-fix file:\n%s\nwant:\n%s", string(got), want)
+	}
+}
+
+// Regression for the ga-lurp5d follow-up review: the attachment-fields
+// autofix must rewrite through symlinked city.toml and pack.toml,
+// preserving each link and updating the checkout target instead of
+// replacing the link with a divorced regular file that strands the
+// stale deprecated content.
+func TestDeprecatedAttachmentFieldsFixWritesThroughSymlinks(t *testing.T) {
+	t.Parallel()
+	city := t.TempDir()
+	checkout := filepath.Join(city, "checkout")
+	if err := os.MkdirAll(checkout, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sources := map[string]string{
+		"city.toml": "[[agent]]\nname = \"mayor\"\nprovider = \"claude\"\nskills = [\"foo\"]\n",
+		"pack.toml": "[pack]\nname = \"demo\"\nmcp = []\n",
+	}
+	targets := map[string]string{}
+	for name, src := range sources {
+		target := filepath.Join(checkout, name)
+		if err := os.WriteFile(target, []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, filepath.Join(city, name)); err != nil {
+			t.Fatal(err)
+		}
+		targets[name] = target
+	}
+
+	check := &DeprecatedAttachmentFieldsCheck{}
+	if err := check.Fix(&CheckContext{CityPath: city}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	for name, target := range targets {
+		link := filepath.Join(city, name)
+		info, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("Lstat %s: %v", link, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s symlink was replaced by a %v entry; fix must write through the link", name, info.Mode())
+		}
+		data, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatalf("ReadFile %s: %v", target, err)
+		}
+		got := string(data)
+		if strings.Contains(got, "skills =") || strings.Contains(got, "mcp =") {
+			t.Fatalf("%s symlink target still carries deprecated fields:\n%s", name, got)
+		}
+	}
+}
+
+// Regression for the ga-lurp5d follow-up review: the rewrite's temp file
+// is created 0600 by os.CreateTemp, so an applied fix must not let that
+// mode survive the rename and silently narrow the config's permissions.
+// The rewrite preserves the original file mode.
+func TestDeprecatedAttachmentFieldsFixPreservesFileMode(t *testing.T) {
+	t.Parallel()
+	for _, perm := range []os.FileMode{0o644, 0o600} {
+		perm := perm
+		t.Run(fmt.Sprintf("%04o", perm), func(t *testing.T) {
+			t.Parallel()
+			city := t.TempDir()
+			path := filepath.Join(city, "city.toml")
+			src := "[[agent]]\nname = \"x\"\nprovider = \"claude\"\nskills = []\n"
+			if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, perm); err != nil {
+				t.Fatal(err)
+			}
+
+			check := &DeprecatedAttachmentFieldsCheck{}
+			if err := check.Fix(&CheckContext{CityPath: city}); err != nil {
+				t.Fatalf("Fix: %v", err)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != perm {
+				t.Fatalf("post-fix mode = %04o, want %04o", got, perm)
+			}
+		})
 	}
 }
 

--- a/internal/doctor/checks_legacy_suspended.go
+++ b/internal/doctor/checks_legacy_suspended.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 // LegacySuspendedFieldCheck warns when city.toml carries the
@@ -139,7 +140,24 @@ func renameLegacySuspendedInCityTOML(path string) (int, error) {
 	if changes == 0 {
 		return 0, nil
 	}
-	return changes, writeFileAtomic(path, []byte(out), 0o644)
+	// Resolve-only, like the formulas-dir strip: the rename is a lossless
+	// line edit, so the key-loss guard in config.ResolveCityRewritePath
+	// would falsely refuse it whenever unrelated unknown keys are present.
+	// Renaming over the unresolved path would replace a symlinked
+	// city.toml with a regular file and strand the stale content in the
+	// checked-in target. The write keeps the original file mode — a temp
+	// file's default 0600 must not survive the rename, and a restrictive
+	// 0600 city.toml must not be widened to 0644 — matching the sibling
+	// rewriteWithoutDeprecatedAttachmentFields fixer.
+	writePath, err := fsys.ResolveSymlinks(fsys.OSFS{}, path)
+	if err != nil {
+		return 0, err
+	}
+	info, err := os.Stat(writePath)
+	if err != nil {
+		return 0, err
+	}
+	return changes, fsys.WriteFileAtomic(fsys.OSFS{}, writePath, []byte(out), info.Mode().Perm())
 }
 
 // rewriteLegacySuspended is the pure-string form of
@@ -226,33 +244,4 @@ func classifySection(name string, isArrayOfTables bool) sectionKind {
 	default:
 		return sectionOther
 	}
-}
-
-// writeFileAtomic writes data to path via temp + rename so a crash
-// mid-write can't leave a half-rewritten city.toml. Sibling-file path
-// (no leading dot) so the write lands on the same filesystem as the
-// target and rename is atomic.
-func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	base := filepath.Base(path)
-	tmp, err := os.CreateTemp(dir, base+".doctorfix.*")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := tmp.Chmod(perm); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	return os.Rename(tmpName, path)
 }

--- a/internal/doctor/checks_legacy_suspended_test.go
+++ b/internal/doctor/checks_legacy_suspended_test.go
@@ -257,6 +257,102 @@ suspended = true
 	}
 }
 
+// Regression for the ga-lurp5d follow-up review: the rewrite's temp file is
+// created 0600 by os.CreateTemp, so an applied fix must preserve the original
+// file mode rather than narrowing 0644 or widening a restrictive 0600 to 0644 —
+// matching the sibling rewriteWithoutDeprecatedAttachmentFields fixer.
+func TestLegacySuspendedFieldCheck_Fix_PreservesFileMode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		perm os.FileMode
+	}{
+		{"0644", 0o644},
+		{"0600", 0o600},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "city.toml")
+			if err := os.WriteFile(path, []byte("[workspace]\nname = \"demo\"\nsuspended = true\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, tc.perm); err != nil {
+				t.Fatal(err)
+			}
+
+			c := NewLegacySuspendedFieldCheck(&config.City{
+				Workspace: config.Workspace{Suspended: true},
+			})
+			if err := c.Fix(&CheckContext{CityPath: dir}); err != nil {
+				t.Fatalf("Fix: %v", err)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != tc.perm {
+				t.Fatalf("post-fix mode = %04o, want %04o", got, tc.perm)
+			}
+			rewritten, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(rewritten), "suspended_on_start = true") {
+				t.Fatalf("fix did not rewrite legacy field; got:\n%s", rewritten)
+			}
+		})
+	}
+}
+
+// Regression for the ga-lurp5d follow-up review: `gc doctor --fix` must
+// rename the legacy field through a symlinked city.toml, preserving the
+// link and updating the checkout target instead of replacing the link
+// with a divorced regular file that strands the stale content.
+func TestLegacySuspendedFieldCheck_Fix_WritesThroughCityTomlSymlink(t *testing.T) {
+	t.Parallel()
+	cityDir := t.TempDir()
+	checkoutDir := filepath.Join(cityDir, "checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(checkoutDir, "city.toml")
+	original := "[workspace]\nname = \"demo\"\nsuspended = true\n"
+	if err := os.WriteFile(target, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(cityDir, "city.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewLegacySuspendedFieldCheck(&config.City{
+		Workspace: config.Workspace{Suspended: true},
+	})
+	if err := c.Fix(&CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("city.toml symlink was replaced by a %v entry; fix must write through the link", info.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile target: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "suspended_on_start = true") {
+		t.Fatalf("symlink target not rewritten:\n%s", got)
+	}
+	if strings.Contains(got, "suspended = true") {
+		t.Fatalf("symlink target still carries the legacy field:\n%s", got)
+	}
+}
+
 func TestLegacySuspendedFieldCheck_Fix_MissingFileIsNoOp(t *testing.T) {
 	dir := t.TempDir()
 	c := NewLegacySuspendedFieldCheck(&config.City{})

--- a/internal/fsys/resolve_symlinks.go
+++ b/internal/fsys/resolve_symlinks.go
@@ -5,44 +5,139 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // maxSymlinkDepth bounds symlink chain resolution, mirroring the kernel's
 // nested-link limit so cycles fail instead of looping forever.
 const maxSymlinkDepth = 40
 
-// ResolveSymlinks follows any chain of symlinks at path and returns the
-// final non-symlink path. Relative link targets are resolved against the
-// directory of the link that contains them. A path (or dangling link
-// target) that does not exist is returned as-is so callers can create it.
+// ResolveSymlinks resolves every symlink in path — intermediate directory
+// links as well as any chain at the final component — and returns the
+// physical path, matching kernel resolution semantics for the active FS.
+// Relative link targets are resolved against the physically-resolved
+// directory that contains the link, so a `..`-bearing target behind a
+// symlinked parent lands where the kernel would land instead of where a
+// lexical join would. Components that do not exist are kept as-is (nothing
+// below a missing component can be a link), so a missing path or dangling
+// link target resolves to the would-be target and callers can create it.
 //
 // Use this before an atomic temp-file + rename write: renaming over a
 // symlink replaces the link itself, so writers that must preserve links
 // resolve the target first and write there instead.
 func ResolveSymlinks(fs FS, path string) (string, error) {
-	for range maxSymlinkDepth {
-		info, err := fs.Lstat(path)
+	if path == "" {
+		return path, nil
+	}
+	orig := path
+	sep := string(os.PathSeparator)
+
+	// volLen is the length of the walk anchor that ".." may never climb
+	// above: the leading separator for absolute paths, nothing for
+	// relative ones.
+	volLen := 0
+	if os.IsPathSeparator(path[0]) {
+		volLen = 1
+	}
+	dest := path[:volLen]
+	linksWalked := 0
+	var end int
+	for start := volLen; start < len(path); start = end {
+		for start < len(path) && os.IsPathSeparator(path[start]) {
+			start++
+		}
+		end = start
+		for end < len(path) && !os.IsPathSeparator(path[end]) {
+			end++
+		}
+
+		// The next path component is in path[start:end].
+		if end == start {
+			break
+		}
+		switch path[start:end] {
+		case ".":
+			continue
+		case "..":
+			// dest is physical, so its lexical parent is its physical
+			// parent. Set r to the index of the last separator in dest;
+			// keep ".."s that would climb above the walk anchor.
+			var r int
+			for r = len(dest) - 1; r >= volLen; r-- {
+				if os.IsPathSeparator(dest[r]) {
+					break
+				}
+			}
+			if r < volLen || dest[r+1:] == ".." {
+				if len(dest) > volLen {
+					dest += sep
+				}
+				dest += ".."
+			} else {
+				dest = dest[:r]
+			}
+			continue
+		}
+
+		if len(dest) > volLen && !os.IsPathSeparator(dest[len(dest)-1]) {
+			dest += sep
+		}
+		dest += path[start:end]
+
+		info, err := fs.Lstat(dest)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				return path, nil
+				// A missing component cannot be a link and cannot hide
+				// one below it: keep it so callers can create the path.
+				continue
 			}
-			return "", fmt.Errorf("resolving symlinks for %s: %w", path, err)
+			return "", fmt.Errorf("resolving symlinks for %s: %w", dest, err)
 		}
 		if info.Mode()&os.ModeSymlink == 0 {
-			return path, nil
+			if !info.IsDir() && end < len(path) {
+				return "", fmt.Errorf("resolving symlinks for %s: %w", orig, syscall.ENOTDIR)
+			}
+			continue
+		}
+
+		linksWalked++
+		if linksWalked > maxSymlinkDepth {
+			return "", fmt.Errorf("resolving symlinks for %s: too many levels of symbolic links", orig)
 		}
 		rl, ok := fs.(readlinkFS)
 		if !ok {
-			return "", fmt.Errorf("resolving symlinks for %s: filesystem does not support Readlink", path)
+			return "", fmt.Errorf("resolving symlinks for %s: filesystem does not support Readlink", dest)
 		}
-		target, err := rl.Readlink(path)
+		target, err := rl.Readlink(dest)
 		if err != nil {
-			return "", fmt.Errorf("resolving symlinks for %s: %w", path, err)
+			return "", fmt.Errorf("resolving symlinks for %s: %w", dest, err)
 		}
-		if !filepath.IsAbs(target) {
-			target = filepath.Join(filepath.Dir(path), target)
+
+		path = target + path[end:]
+		if len(target) > 0 && os.IsPathSeparator(target[0]) {
+			// Absolute target: restart the walk from the root.
+			dest = target[:1]
+			volLen = 1
+			end = 1
+		} else {
+			// Relative target: drop the link's own component from dest
+			// and continue the walk from its physical parent.
+			var r int
+			for r = len(dest) - 1; r >= volLen; r-- {
+				if os.IsPathSeparator(dest[r]) {
+					break
+				}
+			}
+			if r < volLen {
+				dest = dest[:volLen]
+			} else {
+				dest = dest[:r]
+			}
+			end = 0
 		}
-		path = target
 	}
-	return "", fmt.Errorf("resolving symlinks for %s: too many levels of symbolic links", path)
+	if dest == "" {
+		return ".", nil
+	}
+	return filepath.Clean(dest), nil
 }

--- a/internal/fsys/resolve_symlinks_test.go
+++ b/internal/fsys/resolve_symlinks_test.go
@@ -1,9 +1,11 @@
 package fsys_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -90,6 +92,42 @@ func TestResolveSymlinks_DanglingLinkReturnsTarget(t *testing.T) {
 	}
 }
 
+func TestResolveSymlinks_RelativeLinkBehindSymlinkedParent(t *testing.T) {
+	// A `..`-bearing relative target behind a symlinked parent directory
+	// must resolve against the physical parent, not the lexical one:
+	// /base/linkcity -> /other/realcity and city.toml -> ../checkout/city.toml
+	// resolves to /other/checkout/city.toml, where a lexical join would
+	// cancel the symlinked component and yield /base/checkout/city.toml.
+	fs := fsys.NewFake()
+	fs.Dirs["/base"] = true
+	fs.Dirs["/other/realcity"] = true
+	fs.Dirs["/other/checkout"] = true
+	fs.Symlinks["/base/linkcity"] = "/other/realcity"
+	fs.Symlinks["/other/realcity/city.toml"] = "../checkout/city.toml"
+	fs.Files["/other/checkout/city.toml"] = []byte("data")
+
+	got, err := fsys.ResolveSymlinks(fs, "/base/linkcity/city.toml")
+	if err != nil {
+		t.Fatalf("ResolveSymlinks: %v", err)
+	}
+	if got != "/other/checkout/city.toml" {
+		t.Fatalf("got %q, want /other/checkout/city.toml", got)
+	}
+}
+
+func TestResolveSymlinks_NonDirIntermediateComponentErrors(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte("data")
+
+	_, err := fsys.ResolveSymlinks(fs, "/city/city.toml/nested")
+	if err == nil {
+		t.Fatal("ResolveSymlinks through a regular file succeeded, want error")
+	}
+	if !errors.Is(err, syscall.ENOTDIR) {
+		t.Fatalf("error = %v, want ENOTDIR", err)
+	}
+}
+
 func TestResolveSymlinks_CycleErrors(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Symlinks["/a"] = "/b"
@@ -139,7 +177,7 @@ func TestResolveSymlinks_ErrorsWhenFSCannotReadlink(t *testing.T) {
 }
 
 func TestResolveSymlinks_OSFS(t *testing.T) {
-	dir := t.TempDir()
+	dir := osTempDirPhysical(t)
 	target := filepath.Join(dir, "checkout", "city.toml")
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		t.Fatal(err)
@@ -159,4 +197,50 @@ func TestResolveSymlinks_OSFS(t *testing.T) {
 	if got != target {
 		t.Fatalf("got %q, want %q", got, target)
 	}
+}
+
+func TestResolveSymlinks_OSFSRelativeLinkBehindSymlinkedParent(t *testing.T) {
+	dir := osTempDirPhysical(t)
+	for _, sub := range []string{"other/realcity", "other/checkout"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := filepath.Join(dir, "other", "checkout", "city.toml")
+	if err := os.WriteFile(want, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "other", "realcity"), filepath.Join(dir, "linkcity")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "checkout", "city.toml"), filepath.Join(dir, "other", "realcity", "city.toml")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fsys.ResolveSymlinks(fsys.OSFS{}, filepath.Join(dir, "linkcity", "city.toml"))
+	if err != nil {
+		t.Fatalf("ResolveSymlinks: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	kernel, err := filepath.EvalSymlinks(filepath.Join(dir, "linkcity", "city.toml"))
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if got != kernel {
+		t.Fatalf("got %q, want kernel resolution %q", got, kernel)
+	}
+}
+
+// osTempDirPhysical returns a fresh temp dir with any symlinked prefix
+// (e.g. /tmp or /var on some platforms) resolved, so resolved-path
+// equality assertions compare physical paths to physical paths.
+func osTempDirPhysical(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -287,6 +287,14 @@ func packNameStillReferencedByRigIncludes(cityCfg *config.City, name string) boo
 	return false
 }
 
+// loadCityFile reads, parses, and key-loss-guards a city.toml for migration.
+// Migration deliberately uses the real OS filesystem (fsys.OSFS) rather than a
+// parameterized fsys.FS: it is a one-shot CLI step over a concrete city
+// directory the operator names, it already reads bytes via os.ReadFile, and its
+// sibling calls (GuardCityRewriteKeyLoss, ResolveWorkspaceIdentity, and the
+// byte-level city.toml rewrites) all run against that same on-disk tree. No
+// runtime caller migrates over a virtual filesystem, so threading an fsys.FS
+// through the migration path would add abstraction with no consumer.
 func loadCityFile(path string) (*config.City, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -294,6 +302,13 @@ func loadCityFile(path string) (*config.City, error) {
 	}
 	cfg, err := config.Parse(data)
 	if err != nil {
+		return nil, fmt.Errorf("migrate %q: %w", path, err)
+	}
+	// Apply rewrites city.toml from this re-marshaled struct, so keys the
+	// binary does not recognize would vanish silently (the ga-lurp5d
+	// incident class). Refuse before any mutation, mirroring what
+	// loadPackFile does for pack.toml via migrationFatalPackWarnings.
+	if err := config.GuardCityRewriteKeyLoss(fsys.OSFS{}, path); err != nil {
 		return nil, fmt.Errorf("migrate %q: %w", path, err)
 	}
 	if err := config.ResolveWorkspaceIdentity(fsys.OSFS{}, filepath.Dir(path), cfg); err != nil {

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -303,6 +303,36 @@ legacy_unknown = "silently dropped before strict migration validation"
 	}
 }
 
+func TestMigrateRejectsUnknownCityTomlKeys(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+includes = ["../packs/gastown"]
+
+[agent_defaults]
+future_unknown = "written by a newer gc, silently dropped by this rewrite"
+`)
+
+	beforeCity := readFile(t, filepath.Join(cityDir, "city.toml"))
+
+	_, err := Apply(cityDir, Options{})
+	if err == nil {
+		t.Fatal("expected Apply to refuse a city.toml with unknown keys")
+	}
+	if !strings.Contains(err.Error(), "agent_defaults.future_unknown") {
+		t.Fatalf("error = %v, want the unknown key named", err)
+	}
+	if !strings.Contains(err.Error(), "refusing to rewrite") {
+		t.Fatalf("error = %v, want key-loss refusal with remediation", err)
+	}
+	if got := readFile(t, filepath.Join(cityDir, "city.toml")); got != beforeCity {
+		t.Fatalf("city.toml changed after refusal:\n%s", got)
+	}
+}
+
 func TestMigrateMovesExistingRootDefaultRigImportsToCityToml(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Maintainer follow-up to #3349 (already merged)

This carries the maintainer-side review work for the `ga-lurp5d` config-rewrite
safety fix forward onto current `main`.

- **Original PR:** https://github.com/gastownhall/gascity/pull/3349
- **Title:** fix(config): write city.toml rewrites through symlinks, refuse key loss (ga-lurp5d)
- **State:** MERGED (merge commit `19a8a39c7`)
- **Configured base:** `main` · **Original GitHub base:** `main` (no base mismatch)

### Why this follow-up exists

PR #3349 fixed two concrete data-loss bugs in `gc`'s config rewriter: a symlinked
`city.toml` being replaced by a regular file on atomic rewrite, and silent loss
of unrecognized TOML keys during struct round-trips. While the adopt-pr
maintainer review/fix loop was hardening that change, the original PR was merged.
The review loop had already expanded the fix beyond the two paths in the original
PR, so that additional maintainer work needs its own merge surface. The original
contributor commit is preserved in `main`; this PR adds only the maintainer fixes
on top.

### What this adds on top of #3349

The original PR resolved symlinks and guarded key loss on the two rewrite paths it
touched. Review found the same latent failure on **every** other config-rewrite
path, and this follow-up closes them:

- **Symlink-safe rewrites on all paths** — `gc init`, `gc rig add`/`set-endpoint`,
  `gc beads city set-endpoint`, `gc agent suspend/resume`, `gc import add/rm`,
  the doctor v2 fixers, the legacy-suspended/attachment-field fixers, managed-dolt
  port-file cleanup, and the API controller config-mutation snapshot/rollback now
  resolve the symlink target before atomic writes, so a checked-in `city.toml` /
  `.gc/site.toml` / `pack.toml` / `agent.toml` symlink survives the write.
- **Rollback symmetry** — CLI and controller rollback snapshots record and restore
  the *resolved* target, so a failed mutation restores the real file instead of
  replacing the link with a regular file.
- **Key-loss guard generalized** — the city.toml unknown-key guard becomes a
  reusable `GuardRewriteKeyLoss[T]`, applied to `pack.toml` rewrites, with the
  reduced edit structs made faithful supersets (legacy `[agents]` alias and
  `[[pricing]]` preserved) so re-marshaling cannot silently drop them.
- **`migrate.Apply`** guards `city.toml` against unknown-key loss before writing.

### Review & validation

Reviewed across 11 iterations to `approve` (no blocking findings remaining).
Rebased onto current `main`; conflicts with `main`'s independent symlink work
(#3414, #3428, #3370) were resolved by standardizing on the shared
`snapshotResolvedFile` helper and preserving `main`'s comment-preserving append
path. Local gates on the rebased head — `go build ./...`, `go vet`,
changed-package `go test`, and `golangci-lint run` — are all clean.

---
_Maintainer follow-up via `/adopt-pr`. Original contributor commit preserved in #3349._
