### PR TITLE
ci: fold mac regression into RC Gate

### DIFF
--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -1,6 +1,34 @@
 name: Mac Regression
 
 on:
+  workflow_call:
+    inputs:
+      suite:
+        description: Which macOS suite to run
+        required: false
+        type: string
+        default: full
+      pr_number:
+        description: Pull request number for label-dispatched runs
+        required: false
+        type: string
+      head_repo:
+        description: Pull request head repository for label-dispatched runs
+        required: false
+        type: string
+      head_sha:
+        description: Pull request head SHA for label-dispatched runs
+        required: false
+        type: string
+      head_ref:
+        description: Pull request head ref for label-dispatched runs
+        required: false
+        type: string
+      force_blacksmith:
+        description: Force all jobs in the reusable mac regression graph onto Blacksmith runners.
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       suite:
@@ -60,7 +88,7 @@ env:
 jobs:
   runner-policy:
     name: Runner policy
-    runs-on: ${{ github.event_name == 'pull_request' && contains(fromJSON('["julianknutsen","csells","sjarmak","quad341"]'), github.event.pull_request.user.login) && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.force_blacksmith && 'blacksmith-2vcpu-ubuntu-2404' || (github.event_name == 'pull_request' && contains(fromJSON('["julianknutsen","csells","sjarmak","quad341"]'), github.event.pull_request.user.login) && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     outputs:
       use_blacksmith: ${{ steps.policy.outputs.use_blacksmith }}
       reason: ${{ steps.policy.outputs.reason }}
@@ -76,6 +104,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          FORCE_BLACKSMITH: ${{ inputs.force_blacksmith }}
         run: |
           python3 .github/workflows/scripts/runner_policy.py
 

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -385,51 +385,15 @@ jobs:
           path: dist/**
           if-no-files-found: error
 
-  macos_fast_tests:
-    name: macOS / fast tests / ${{ matrix.label }}
-    runs-on: blacksmith-12vcpu-macos-15
-    timeout-minutes: ${{ matrix.timeout_minutes }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - label: fsys-darwin-compile
-            timeout_minutes: 10
-            command: |
-              tmp="$(mktemp -d)"
-              trap 'rm -rf "$tmp"' EXIT
-              GOOS=darwin GOARCH=arm64 go test -c -o "$tmp/fsys.test" ./internal/fsys
-          - label: unit-core
-            timeout_minutes: 30
-            command: |
-              GC_FAST_UNIT=1 go test -timeout 20m $(go list ./... | grep -v '^github.com/gastownhall/gascity/cmd/gc$')
-          - label: cmd-gc-1-of-6
-            timeout_minutes: 30
-            command: GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc 1 6
-          - label: cmd-gc-2-of-6
-            timeout_minutes: 30
-            command: GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc 2 6
-          - label: cmd-gc-3-of-6
-            timeout_minutes: 30
-            command: GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc 3 6
-          - label: cmd-gc-4-of-6
-            timeout_minutes: 30
-            command: GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc 4 6
-          - label: cmd-gc-5-of-6
-            timeout_minutes: 30
-            command: GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc 5 6
-          - label: cmd-gc-6-of-6
-            timeout_minutes: 30
-            command: GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc 6 6
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/setup-gascity-macos
-        with:
-          dolt-version: ${{ env.DOLT_VERSION }}
-          bd-version: ${{ env.BD_VERSION }}
-          install-claude-cli: "false"
-      - name: Run macOS fast test shard
-        run: ${{ matrix.command }}
+  mac_regression:
+    name: Mac regression
+    permissions:
+      contents: read
+    uses: ./.github/workflows/mac-regression.yml
+    with:
+      suite: full
+      force_blacksmith: true
+    secrets: inherit
 
   rc_summary:
     name: RC summary
@@ -445,7 +409,7 @@ jobs:
       - ubuntu_integration_shards
       - ubuntu_tutorial
       - ubuntu_goreleaser_snapshot
-      - macos_fast_tests
+      - mac_regression
     env:
       NEEDS_JSON: ${{ toJSON(needs) }}
     steps:

--- a/.github/workflows/scripts/test_rc_gate_policy.py
+++ b/.github/workflows/scripts/test_rc_gate_policy.py
@@ -3,6 +3,7 @@ import unittest
 
 
 WORKFLOW = Path(__file__).resolve().parents[1] / "rc-gate.yml"
+MAC_WORKFLOW = Path(__file__).resolve().parents[1] / "mac-regression.yml"
 
 
 def _job_block(workflow: str, job_name: str) -> str:
@@ -36,6 +37,26 @@ class RCGatePolicyTests(unittest.TestCase):
         tutorial = _job_block(workflow, "ubuntu_tutorial")
         self.assertIn("needs: ubuntu_integration_shards", tutorial)
         self.assertIn("max-parallel: 1", tutorial)
+
+    def test_rc_gate_runs_full_mac_regression_workflow(self) -> None:
+        workflow = WORKFLOW.read_text()
+
+        self.assertNotIn("macos_fast_tests:", workflow)
+
+        mac_regression = _job_block(workflow, "mac_regression")
+        self.assertIn("uses: ./.github/workflows/mac-regression.yml", mac_regression)
+        self.assertIn("suite: full", mac_regression)
+        self.assertIn("force_blacksmith: true", mac_regression)
+
+        summary = _job_block(workflow, "rc_summary")
+        self.assertIn("- mac_regression", summary)
+
+    def test_mac_regression_is_reusable_by_rc_gate(self) -> None:
+        workflow = MAC_WORKFLOW.read_text()
+
+        self.assertIn("workflow_call:", workflow)
+        self.assertIn("force_blacksmith:", workflow)
+        self.assertIn("FORCE_BLACKSMITH: ${{ inputs.force_blacksmith }}", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make Mac Regression reusable via workflow_call
- have RC Gate run the full Mac Regression workflow with suite=full
- replace the smaller RC-only macOS fast matrix with the aggregate Mac regression job
- add policy tests to keep RC Gate wired to Mac Regression

## Validation

- python3 .github/workflows/scripts/test_rc_gate_policy.py
- python3 .github/workflows/scripts/test_runner_policy.py
- actionlint .github/workflows/rc-gate.yml .github/workflows/mac-regression.yml
- git diff --check
- .githooks/pre-commit
