### PR TITLE
docs: add Build Cache Conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,30 @@ Lesson test — it becomes LESS useful as models improve.
   `make test-cmd-gc-process-parallel`, `make test-integration-shards-parallel`,
   `make test-local-full-parallel`) over raw `go test`.
 
+## Build Cache Conventions
+
+**Hard ban: never run `go clean -cache`** in any script, hook, or agent session.
+
+Running `go clean -cache` against a shared `GOCACHE` (the default when
+`$GOCACHE` is not overridden) corrupts the fleet-wide build cache for every
+concurrent executor. Each executor that hits a missing cache entry then runs a
+full rebuild, and any that calls `go clean -cache` mid-flight invalidates all
+the others' in-progress caches. The incident (vp-g96b, 2026-06-13) produced
+~10 cascading cache-miss errors across the executor pool.
+
+**Safe alternative for cold builds:**
+
+```bash
+GOCACHE=$(mktemp -d) go build ./cmd/gc/
+```
+
+This isolates the cache to a throwaway directory without touching the shared
+pool. Clean up with `rm -rf` after if disk space matters.
+
+**Exception:** `go clean -testcache` is explicitly allowed. It clears only the
+test-result cache, not the compiled-object cache, and does not corrupt
+concurrent builds.
+
 ## Code quality gates
 
 Before considering any task complete:


### PR DESCRIPTION
## Summary

Adds `## Build Cache Conventions` to `AGENTS.md`, inserted immediately before `## Code quality gates`.

**Hard ban:** never run `go clean -cache` in any script, hook, or agent session.

The shared `GOCACHE` (default when `$GOCACHE` is not overridden) is used by all concurrent executors. Any `go clean -cache` call invalidates in-progress caches for every other concurrent build. Incident vp-g96b (2026-06-13) produced ~10 cascading cache-miss errors across the executor pool.

**Safe cold-build alternative:**
```bash
GOCACHE=$(mktemp -d) go build ./cmd/gc/
```

**Exception:** `go clean -testcache` is explicitly allowed (clears test-result cache only; does not touch compiled-object cache).

## Diff scope

- 1 file changed: `AGENTS.md`
- ~24 lines added
- No code changes

## Context

Companion to voxist-platform PR #241 (vp-ww87), which added a `CLAUDE.md` pointer to `gascity/AGENTS.md → Build Cache Conventions`. This PR fulfills that pointer.

Replaces #3471 (closed — accidentally pushed full WIP branch instead of docs-only delta).

Delivery bead: vp-vdhl