### PR TITLE
fix(beads): reject digit-led bd query values to unblock digit-prefixed assignees

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -2207,8 +2207,18 @@ func appendBdQueryClause(clauses []string, serverFilteredOnly bool, field, value
 }
 
 func isBareBdQueryValue(value string) bool {
+	if value == "" {
+		return false
+	}
 	upper := strings.ToUpper(value)
 	if upper == "AND" || upper == "OR" || upper == "NOT" {
+		return false
+	}
+	// The bd query lexer treats a digit-led token as a numeric literal and
+	// errors at the first non-digit byte. Values like "3-recurse" must fall
+	// back to the client-side filter path instead of being inlined into the
+	// query string.
+	if value[0] >= '0' && value[0] <= '9' {
 		return false
 	}
 	for _, r := range value {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -4430,6 +4430,11 @@ func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testi
 			query: beads.ListQuery{Type: "or", TierMode: beads.TierWisps},
 			want:  "bd-match-type",
 		},
+		{
+			name:  "digit-prefixed assignee",
+			query: beads.ListQuery{Assignee: "3-recurse", Type: "message", Status: "open", TierMode: beads.TierWisps},
+			want:  "bd-match-digit-assignee",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4441,6 +4446,7 @@ func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testi
 					{"id":"bd-match-assignee","title":"message","status":"open","issue_type":"message","assignee":"gascity/workflows.codex-max","created_at":"2026-05-01T00:00:00Z","ephemeral":true},
 					{"id":"bd-match-label","title":"label","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","ephemeral":true,"labels":["order tracking"]},
 					{"id":"bd-match-type","title":"reserved","status":"open","issue_type":"or","created_at":"2026-05-01T00:00:00Z","ephemeral":true},
+					{"id":"bd-match-digit-assignee","title":"digit-prefixed","status":"open","issue_type":"message","assignee":"3-recurse","created_at":"2026-05-01T00:00:00Z","ephemeral":true},
 					{"id":"bd-other","title":"other","status":"open","issue_type":"task","assignee":"someone-else","created_at":"2026-05-01T00:00:00Z","ephemeral":true}
 				]`), nil
 			}
@@ -4472,6 +4478,10 @@ func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testi
 			case "type reserved token":
 				if strings.Contains(queryCmd, "type=or") {
 					t.Fatalf("query cmd = %q, reserved type token must be client-filtered", queryCmd)
+				}
+			case "digit-prefixed assignee":
+				if strings.Contains(queryCmd, "assignee=3-recurse") {
+					t.Fatalf("query cmd = %q, digit-prefixed assignee trips bd query lexer and must be client-filtered", queryCmd)
 				}
 			}
 			if len(got) != 1 || got[0].ID != tc.want {


### PR DESCRIPTION
## Summary

`bd`'s query DSL lexer parses a digit-led token as a numeric literal and errors at the first non-digit byte. `isBareBdQueryValue` accepted any value composed of safe characters, so `listEphemeral` inlined assignees like `3-recurse` / `2-contact` / `0-city` directly into the wisps-tier query string and failed at the `bd` binary. That broke `gc mail inbox` for every digit-prefixed agent alias:

\`\`\`
gc mail inbox: beadmail: listing beads: listing by assignee "3-recurse":
bd list both tiers: wisps tier: bd query (wisps): exit status 1: {
  "error": "parsing query: expected digit at position 63",
  "schema_version": 1
}
\`\`\`

This routes digit-led values through the existing client-side filter fallback — the same path already used for slash assignees, spaced labels, and reserved tokens — and adds a defensive empty-string check.

## Repro (before the fix)

From an agent working dir whose alias has a digit prefix:

\`\`\`
$ gc mail inbox
gc mail inbox: beadmail: listing beads: listing by assignee "3-recurse":
bd list both tiers: wisps tier: bd query (wisps): exit status 1: ...
\`\`\`

Or hit `bd query` directly:

\`\`\`
$ bd query 'assignee=3-recurse'
Error: parsing query: expected digit at position 11
\`\`\`

After the fix, the alias is filtered client-side and `gc mail inbox` returns normally.

## Testing

- [x] `go test ./internal/beads/` passes locally (full package, 6.2s)
- [x] New \`digit-prefixed assignee\` case added to `TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues`
- [x] End-to-end: built `cmd/gc`, ran `gc mail inbox` for a digit-prefixed agent — returns `No unread messages for 3-recurse` instead of the parser error

## Checklist

- [x] Tests added (extends the existing client-side-filter contract test)
- [ ] No docs change needed (internal helper)
- [ ] No breaking changes