### PR TITLE
feat(registry): move publish commands under pack registry

### DIFF
--- a/cmd/gc/cmd_pack_registry.go
+++ b/cmd/gc/cmd_pack_registry.go
@@ -32,6 +32,9 @@ func newPackRegistryCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd.AddCommand(newPackRegistryRefreshCmd(stdout, stderr))
 	cmd.AddCommand(newPackRegistrySearchCmd(stdout, stderr))
 	cmd.AddCommand(newPackRegistryShowCmd(stdout, stderr))
+	cmd.AddCommand(newRegistryLoginCmd(stdout, stderr))
+	cmd.AddCommand(newRegistryPublishCmd(stdout, stderr))
+	cmd.AddCommand(newRegistryWhoamiCmd(stdout, stderr))
 	return cmd
 }
 

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -522,14 +522,27 @@ func TestPackRegistrySearchWarnsOnStaleCache(t *testing.T) {
 func TestPackCommandTreeKeepsRegistryAndLegacySurfacesSeparate(t *testing.T) {
 	cmd := newPackCmd(&bytes.Buffer{}, &bytes.Buffer{})
 	for _, args := range [][]string{{"registry", "list"}, {"fetch"}, {"list"}} {
-		if found, _, err := cmd.Find(args); err != nil || found == cmd {
+		found, remaining, err := cmd.Find(args)
+		if err != nil || found == cmd || len(remaining) != 0 || found.Name() != args[len(args)-1] {
 			t.Fatalf("gc pack %s not found: found=%v err=%v", strings.Join(args, " "), found, err)
 		}
 	}
 	for _, name := range []string{"add", "remove", "refresh", "search", "show"} {
-		if found, _, err := cmd.Find([]string{"registry", name}); err != nil || found == cmd {
+		found, remaining, err := cmd.Find([]string{"registry", name})
+		if err != nil || found == cmd || len(remaining) != 0 || found.Name() != name {
 			t.Fatalf("gc pack registry %s not found: found=%v err=%v", name, found, err)
 		}
+	}
+	for _, name := range []string{"login", "publish", "whoami"} {
+		found, remaining, err := cmd.Find([]string{"registry", name})
+		if err != nil || found == cmd || len(remaining) != 0 || found.Name() != name {
+			t.Fatalf("gc pack registry %s not found: found=%v err=%v", name, found, err)
+		}
+	}
+
+	root := newRootCmd(&bytes.Buffer{}, &bytes.Buffer{})
+	if found, _, err := root.Find([]string{"registry"}); err == nil && found != root {
+		t.Fatalf("gc registry should not be a root command; found=%s", found.CommandPath())
 	}
 }
 

--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -28,22 +28,6 @@ const (
 
 var registryPublishHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
-func newRegistryCmd(stdout, stderr io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "registry",
-		Short: "Publish packs to Gas City Registry",
-		Long:  "Publish packs to the hosted Gas City Registry.",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
-	cmd.AddCommand(newRegistryLoginCmd(stdout, stderr))
-	cmd.AddCommand(newRegistryPublishCmd(stdout, stderr))
-	cmd.AddCommand(newRegistryWhoamiCmd(stdout, stderr))
-	return cmd
-}
-
 type registryPublishOptions struct {
 	RegistryURL   string
 	Name          string
@@ -104,7 +88,7 @@ func doRegistryPublish(ctx context.Context, packRoot string, opts registryPublis
 
 	baseURL, err := resolveRegistryPublishBaseURL(opts.RegistryURL)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc pack registry publish: %v\n", err) //nolint:errcheck
 		return 1
 	}
 
@@ -125,7 +109,7 @@ func doRegistryPublish(ctx context.Context, packRoot string, opts registryPublis
 	if !auth.hasCredentials() && !opts.DevAuth {
 		configuredToken, err := readRegistryConfiguredToken(baseURL)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+			fmt.Fprintf(stderr, "gc pack registry publish: %v\n", err) //nolint:errcheck
 			return 1
 		}
 		auth.Token = strings.TrimSpace(configuredToken)
@@ -134,7 +118,7 @@ func doRegistryPublish(ctx context.Context, packRoot string, opts registryPublis
 
 	request, err := buildRegistryPublishRequest(ctx, packRoot, opts, useGitHubActionsOIDC)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc pack registry publish: %v\n", err) //nolint:errcheck
 		return 1
 	}
 
@@ -149,37 +133,37 @@ func doRegistryPublish(ctx context.Context, packRoot string, opts registryPublis
 		var err error
 		auth, err = registryPublishDevAuth(ctx, registryPublishHTTPClient, baseURL, opts.DevAuthHandle)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+			fmt.Fprintf(stderr, "gc pack registry publish: %v\n", err) //nolint:errcheck
 			return 1
 		}
 	}
 	if useGitHubActionsOIDC {
 		oidcToken, err := registryRequestGitHubActionsOIDCToken(ctx, registryPublishHTTPClient, registryGitHubActionsAudience)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+			fmt.Fprintf(stderr, "gc pack registry publish: %v\n", err) //nolint:errcheck
 			return 1
 		}
 		publishToken, err := registryMintGitHubActionsPublishToken(ctx, registryPublishHTTPClient, baseURL, request, oidcToken)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+			fmt.Fprintf(stderr, "gc pack registry publish: %v\n", err) //nolint:errcheck
 			return 1
 		}
 		auth.Token = publishToken
 	}
 	if !auth.hasCredentials() {
-		fmt.Fprintln(stderr, "gc registry publish: authentication required; run `gc registry login`, set GC_REGISTRY_TOKEN, pass --token, set GC_REGISTRY_SESSION and GC_REGISTRY_CSRF_TOKEN, or use --dev-auth against a local registry") //nolint:errcheck
+		fmt.Fprintln(stderr, "gc pack registry publish: authentication required; run `gc pack registry login`, set GC_REGISTRY_TOKEN, pass --token, set GC_REGISTRY_SESSION and GC_REGISTRY_CSRF_TOKEN, or use --dev-auth against a local registry") //nolint:errcheck
 		return 1
 	}
 
 	submitted, err := submitRegistryPublishRequest(ctx, registryPublishHTTPClient, baseURL, request, auth, opts.Validate)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc registry publish: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc pack registry publish: %v\n", err) //nolint:errcheck
 		return 1
 	}
 	writeRegistryPublishSubmitted(stdout, baseURL, submitted)
 	if opts.Validate {
 		if failure := registryPublishValidationFailure(submitted); failure != "" {
-			fmt.Fprintf(stderr, "gc registry publish: validation failed: %s\n", failure) //nolint:errcheck
+			fmt.Fprintf(stderr, "gc pack registry publish: validation failed: %s\n", failure) //nolint:errcheck
 			return 1
 		}
 	}
@@ -780,7 +764,7 @@ func writeRegistryPublishSubmitted(stdout io.Writer, baseURL string, result regi
 }
 
 // registryPublishValidationRejectedStatuses lists publish-request statuses that
-// represent a terminal validation rejection. A `gc registry publish --validate`
+// represent a terminal validation rejection. A `gc pack registry publish --validate`
 // run that lands in one of these states failed validation; statuses outside
 // this set (for example queued or pending-review states) are not treated as
 // failures, so a successfully queued request still exits zero.
@@ -795,7 +779,7 @@ var registryPublishValidationRejectedStatuses = map[string]bool{
 // registryPublishValidationFailure reports a human-readable reason when a
 // validated publish request did not pass registry validation, or "" when it
 // did. A populated ValidationError is always a failure; otherwise a terminal
-// rejected/invalid status is treated as a failure so `gc registry publish
+// rejected/invalid status is treated as a failure so `gc pack registry publish
 // --validate` exits non-zero instead of masking a pack the registry rejected
 // inside a 2xx response as a successful publish.
 func registryPublishValidationFailure(result registryPublishSubmitted) string {

--- a/cmd/gc/cmd_registry_auth.go
+++ b/cmd/gc/cmd_registry_auth.go
@@ -102,7 +102,7 @@ func newRegistryWhoamiCmd(stdout, stderr io.Writer) *cobra.Command {
 func doRegistryLogin(ctx context.Context, opts registryLoginOptions, stdout, stderr io.Writer) int {
 	baseURL, err := resolveRegistryPublishBaseURL(opts.RegistryURL)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc registry login: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc pack registry login: %v\n", err) //nolint:errcheck
 		return 1
 	}
 	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
@@ -118,18 +118,18 @@ func doRegistryLogin(ctx context.Context, opts registryLoginOptions, stdout, std
 			token, err = registryBrowserLogin(ctx, baseURL, opts.Label, stdout, !opts.NoBrowser)
 		}
 		if err != nil {
-			fmt.Fprintf(stderr, "gc registry login: %v\n", err) //nolint:errcheck
+			fmt.Fprintf(stderr, "gc pack registry login: %v\n", err) //nolint:errcheck
 			return 1
 		}
 	}
 
 	user, err := registryFetchCurrentUser(ctx, registryPublishHTTPClient, baseURL, token)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc registry login: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc pack registry login: %v\n", err) //nolint:errcheck
 		return 1
 	}
 	if err := writeRegistryConfiguredToken(baseURL, token); err != nil {
-		fmt.Fprintf(stderr, "gc registry login: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc pack registry login: %v\n", err) //nolint:errcheck
 		return 1
 	}
 	fmt.Fprintf(stdout, "Logged in to %s as @%s\n", baseURL, user.Handle) //nolint:errcheck
@@ -139,7 +139,7 @@ func doRegistryLogin(ctx context.Context, opts registryLoginOptions, stdout, std
 func doRegistryWhoami(ctx context.Context, opts registryLoginOptions, stdout, stderr io.Writer) int {
 	baseURL, err := resolveRegistryPublishBaseURL(opts.RegistryURL)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc registry whoami: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc pack registry whoami: %v\n", err) //nolint:errcheck
 		return 1
 	}
 	// Secrets resolve at execution time, never as flag defaults, so help
@@ -148,19 +148,19 @@ func doRegistryWhoami(ctx context.Context, opts registryLoginOptions, stdout, st
 	if token == "" {
 		token, err = readRegistryConfiguredToken(baseURL)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc registry whoami: %v\n", err) //nolint:errcheck
+			fmt.Fprintf(stderr, "gc pack registry whoami: %v\n", err) //nolint:errcheck
 			return 1
 		}
 	}
 	if token == "" {
-		fmt.Fprintln(stderr, "gc registry whoami: not logged in; run `gc registry login`") //nolint:errcheck
+		fmt.Fprintln(stderr, "gc pack registry whoami: not logged in; run `gc pack registry login`") //nolint:errcheck
 		return 1
 	}
 	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
 	user, err := registryFetchCurrentUser(ctx, registryPublishHTTPClient, baseURL, token)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc registry whoami: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc pack registry whoami: %v\n", err) //nolint:errcheck
 		return 1
 	}
 	fmt.Fprintf(stdout, "@%s (%s)\n", user.Handle, user.ID) //nolint:errcheck

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -119,7 +119,7 @@ schema = 2
 
 // TestBuildRegistryPublishRequestIgnoresPoisonedGitEnv proves the publish
 // request is derived from the pack repository even when git-locating
-// environment variables point elsewhere. Running `gc registry publish` inside a
+// environment variables point elsewhere. Running `gc pack registry publish` inside a
 // pre-commit hook or nested worktree tooling exports GIT_DIR/GIT_WORK_TREE/
 // GIT_INDEX_FILE for an unrelated repository; the publish git subprocesses must
 // strip those so status, HEAD, upstream, and remote URL are read from the pack
@@ -928,15 +928,15 @@ func TestRegistryHelpDoesNotLeakEnvironmentSecrets(t *testing.T) {
 
 	for _, sub := range []string{"publish", "login", "whoami"} {
 		var help bytes.Buffer
-		cmd := newRegistryCmd(io.Discard, io.Discard)
+		cmd := newPackRegistryCmd(io.Discard, io.Discard)
 		cmd.SetOut(&help)
 		cmd.SetErr(&help)
 		cmd.SetArgs([]string{sub, "--help"})
 		if err := cmd.Execute(); err != nil {
-			t.Fatalf("registry %s --help: %v", sub, err)
+			t.Fatalf("pack registry %s --help: %v", sub, err)
 		}
 		if strings.Contains(help.String(), "s3cr3t") {
-			t.Fatalf("registry %s --help leaks environment secrets:\n%s", sub, help.String())
+			t.Fatalf("pack registry %s --help leaks environment secrets:\n%s", sub, help.String())
 		}
 	}
 }
@@ -1386,7 +1386,7 @@ func TestRegistryPollDeviceToken(t *testing.T) {
 // TestRegistryDeviceLoginCompletesAfterPending drives the device-code login
 // orchestration end to end: it requests a device code, prints the verification
 // instructions, polls through an authorization_pending response, and returns the
-// access token once the registry approves. This covers gc registry login
+// access token once the registry approves. This covers gc pack registry login
 // --device above the registryPollDeviceToken helper unit test.
 func TestRegistryDeviceLoginCompletesAfterPending(t *testing.T) {
 	var mu sync.Mutex

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -261,7 +261,6 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		newImportCmd(stdout, stderr),
 		newConfigCmd(stdout, stderr),
 		newPackCmd(stdout, stderr),
-		newRegistryCmd(stdout, stderr),
 		newLintCmd(stdout, stderr),
 		newDoctorCmd(stdout, stderr),
 		newHookCmd(stdout, stderr),

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,7 +57,6 @@ gc [flags]
 | [gc prime](#gc-prime) | Output the behavioral prompt for an agent |
 | [gc prompt](#gc-prompt) | Author and inspect agent prompt templates |
 | [gc register](#gc-register) | Register a city with the machine-wide supervisor |
-| [gc registry](#gc-registry) | Publish packs to Gas City Registry |
 | [gc reload](#gc-reload) | Reload the current city's config without restarting the city/controller |
 | [gc restart](#gc-restart) | Restart all agent sessions in the city |
 | [gc resume](#gc-resume) | Resume a suspended city |
@@ -2392,10 +2391,13 @@ gc pack registry
 |------------|-------------|
 | [gc pack registry add](#gc-pack-registry-add) | Add a pack registry |
 | [gc pack registry list](#gc-pack-registry-list) | List configured pack registries |
+| [gc pack registry login](#gc-pack-registry-login) | Log in to Gas City Registry |
+| [gc pack registry publish](#gc-pack-registry-publish) | Submit a pack publish request |
 | [gc pack registry refresh](#gc-pack-registry-refresh) | Refresh cached pack registry catalogs |
 | [gc pack registry remove](#gc-pack-registry-remove) | Remove a pack registry |
 | [gc pack registry search](#gc-pack-registry-search) | Search cached pack registry catalogs |
 | [gc pack registry show](#gc-pack-registry-show) | Show one pack registry entry |
+| [gc pack registry whoami](#gc-pack-registry-whoami) | Show the authenticated registry account |
 
 ## gc pack registry add
 
@@ -2421,6 +2423,53 @@ gc pack registry list [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--json` | bool |  | emit JSONL result |
+
+## gc pack registry login
+
+Log in to Gas City Registry and store a local API token.
+
+By default this opens a browser for GitHub or Google Workspace sign-in. Use
+--device for headless shells, or --token to store an existing registry token.
+
+```
+gc pack registry login [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--device` | bool |  | use device-code login instead of browser callback login |
+| `--label` | string | `GC CLI login` | label for the registry API token |
+| `--no-browser` | bool |  | print the browser login URL instead of opening it |
+| `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
+| `--timeout` | duration | `15m0s` | maximum time to wait for interactive login |
+| `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN |
+
+## gc pack registry publish
+
+Submit a pack publish request to Gas City Registry.
+
+The command requires a clean Git checkout whose current HEAD matches its
+configured upstream branch, then submits the GitHub repository, commit, pack
+path, pack name, and version to the registry API.
+
+```
+gc pack registry publish <path-to-pack-root> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--csrf-token` | string |  | registry CSRF token; defaults to GC_REGISTRY_CSRF_TOKEN |
+| `--description` | string |  | release description; defaults to [pack].description |
+| `--dev-auth` | bool |  | create a local dev-auth session before submitting; localhost only |
+| `--dev-auth-handle` | string | `local-cli` | dev-auth handle when --dev-auth is used |
+| `--dry-run` | bool |  | print the publish request without submitting |
+| `--name` | string |  | registry pack name; defaults to [pack].name |
+| `--ref` | string |  | release ref label; defaults to the upstream branch name |
+| `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
+| `--session-cookie` | string |  | registry_session cookie value or Cookie header; defaults to GC_REGISTRY_SESSION |
+| `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN |
+| `--validate` | bool | `true` | ask the registry to validate the request immediately; a rejected validation exits non-zero |
+| `--version` | string |  | release version; defaults to [pack].version |
 
 ## gc pack registry refresh
 
@@ -2474,6 +2523,19 @@ gc pack registry show <pack-name> [flags]
 |------|------|---------|-------------|
 | `--json` | bool |  | emit JSONL result |
 | `--refresh` | bool |  | refresh catalogs before showing |
+
+## gc pack registry whoami
+
+Show the authenticated registry account
+
+```
+gc pack registry whoami [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
+| `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN or stored login |
 
 ## gc pack release
 
@@ -2699,80 +2761,6 @@ gc register [path] [flags]
 | `--json` | bool |  | emit JSONL summary |
 | `--name` | string |  | machine-local alias for this city registration |
 | `--yes` | bool |  | bypass the cross-city supervisor cycle confirmation prompt (warning is still printed for the audit trail) |
-
-## gc registry
-
-Publish packs to the hosted Gas City Registry.
-
-```
-gc registry
-```
-
-| Subcommand | Description |
-|------------|-------------|
-| [gc registry login](#gc-registry-login) | Log in to Gas City Registry |
-| [gc registry publish](#gc-registry-publish) | Submit a pack publish request |
-| [gc registry whoami](#gc-registry-whoami) | Show the authenticated registry account |
-
-## gc registry login
-
-Log in to Gas City Registry and store a local API token.
-
-By default this opens a browser for GitHub or Google Workspace sign-in. Use
---device for headless shells, or --token to store an existing registry token.
-
-```
-gc registry login [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--device` | bool |  | use device-code login instead of browser callback login |
-| `--label` | string | `GC CLI login` | label for the registry API token |
-| `--no-browser` | bool |  | print the browser login URL instead of opening it |
-| `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
-| `--timeout` | duration | `15m0s` | maximum time to wait for interactive login |
-| `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN |
-
-## gc registry publish
-
-Submit a pack publish request to Gas City Registry.
-
-The command requires a clean Git checkout whose current HEAD matches its
-configured upstream branch, then submits the GitHub repository, commit, pack
-path, pack name, and version to the registry API.
-
-```
-gc registry publish <path-to-pack-root> [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--csrf-token` | string |  | registry CSRF token; defaults to GC_REGISTRY_CSRF_TOKEN |
-| `--description` | string |  | release description; defaults to [pack].description |
-| `--dev-auth` | bool |  | create a local dev-auth session before submitting; localhost only |
-| `--dev-auth-handle` | string | `local-cli` | dev-auth handle when --dev-auth is used |
-| `--dry-run` | bool |  | print the publish request without submitting |
-| `--name` | string |  | registry pack name; defaults to [pack].name |
-| `--ref` | string |  | release ref label; defaults to the upstream branch name |
-| `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
-| `--session-cookie` | string |  | registry_session cookie value or Cookie header; defaults to GC_REGISTRY_SESSION |
-| `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN |
-| `--validate` | bool | `true` | ask the registry to validate the request immediately; a rejected validation exits non-zero |
-| `--version` | string |  | release version; defaults to [pack].version |
-
-## gc registry whoami
-
-Show the authenticated registry account
-
-```
-gc registry whoami [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
-| `--token` | string |  | registry API token; defaults to GC_REGISTRY_TOKEN or stored login |
 
 ## gc reload
 


### PR DESCRIPTION
## Summary
- move registry login/publish/whoami under `gc pack registry`
- remove the top-level `gc registry` command registration
- update CLI diagnostics, tests, and generated CLI reference docs

## Context
PR #3343 merged the registry publish/login flow at the top-level `gc registry` namespace. This follow-up applies the 1.3 namespace decision: publish/login/whoami belong under `gc pack registry` alongside registry search/show/add/remove.

Paired registry-site PR: https://github.com/gascity/registry/pull/7

## Tests
- `go test ./cmd/gc -run 'Test(PackCommandTreeKeepsRegistryAndLegacySurfacesSeparate|RegistryHelpDoesNotLeakEnvironmentSecrets|DoRegistryPublish|RegistryDeviceLogin|RegistryBrowserLogin|RegistryWhoami|RegistryLogin|CLIDocsFreshness)$'`
- `go vet ./...`
- `make test-fast-parallel`
- `.githooks/pre-commit`