### PR TITLE
fix(molecule): fallback on native graph apply timeouts

### DIFF
--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -406,7 +406,7 @@ func (s *NativeDoltStore) ApplyGraphPlanWithStorage(parent context.Context, plan
 
 		return nil
 	}); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("native graph apply: %w", err)
 	}
 
 	result := &GraphApplyResult{IDs: keyToID}

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -84,7 +84,7 @@ func isTransientGraphApplyError(err error) bool {
 		return false
 	}
 	text := strings.ToLower(err.Error())
-	if !strings.Contains(text, "bd create --graph") {
+	if !isGraphApplyErrorText(text) {
 		return false
 	}
 	return strings.Contains(text, "i/o timeout") ||
@@ -94,6 +94,14 @@ func isTransientGraphApplyError(err error) bool {
 		strings.Contains(text, "bad connection") ||
 		strings.Contains(text, "connection reset") ||
 		strings.Contains(text, "broken pipe")
+}
+
+func isGraphApplyErrorText(text string) bool {
+	return strings.Contains(text, "bd create --graph") ||
+		strings.Contains(text, "native graph apply") ||
+		strings.Contains(text, "failed to check for dependency cycle") ||
+		strings.Contains(text, "graph create: adding edge") ||
+		strings.Contains(text, "adding edge ")
 }
 
 func instantiateFragmentViaGraphApply(ctx context.Context, store beads.Store, applier beads.GraphApplyStore, recipe *formula.FragmentRecipe, opts FragmentOptions) (*FragmentResult, error) {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -695,6 +695,43 @@ func TestInstantiateFallsBackWhenGraphApplyDoltConnectionTimesOut(t *testing.T) 
 	}
 }
 
+func TestInstantiateFallsBackWhenNativeGraphApplyCycleCheckTimesOut(t *testing.T) {
+	store := &graphApplySpyStore{
+		MemStore: beads.NewMemStore(),
+		err:      fmt.Errorf("adding edge ga-wisp-f5tz43->ga-wisp-oog3my: failed to check for dependency cycle: context deadline exceeded"),
+	}
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{ID: "wf", Title: "Workflow", Type: "task", IsRoot: true, Metadata: map[string]string{"gc.kind": "workflow"}},
+			{ID: "wf.step", Title: "Work", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf.step", DependsOnID: "wf", Type: "parent-child"},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if store.calls != 2 {
+		t.Fatalf("ApplyGraphPlan calls = %d, want 2", store.calls)
+	}
+	if result.Created != 2 {
+		t.Fatalf("Created = %d, want 2", result.Created)
+	}
+	if result.RootID == "" || result.RootID == "bd-1" {
+		t.Fatalf("RootID = %q, want sequential store ID", result.RootID)
+	}
+	if _, err := store.Get(result.RootID); err != nil {
+		t.Fatalf("fallback root missing from store: %v", err)
+	}
+}
+
 func TestInstantiateDoesNotFallbackForNonTransientGraphApplyError(t *testing.T) {
 	store := &graphApplySpyStore{
 		MemStore: beads.NewMemStore(),


### PR DESCRIPTION
## Summary
- classify native graph-apply dependency-cycle deadline failures as transient
- fall back to sequential molecule instantiation after repeated native graph-apply timeouts
- wrap native graph-apply transaction errors with graph context for clearer diagnostics

## Release blocker
Fixes the PR-review launch failure tracked by `ga-igvbr0.12`, reproduced on PR-review sources for #3344 and #3476 as `adding edge ... failed to check for dependency cycle: context deadline exceeded`.

## Tests
- `go test ./internal/molecule -run 'TestInstantiate(FallsBackWhenNativeGraphApplyCycleCheckTimesOut|FallsBackWhenGraphApplyDoltConnectionTimesOut|RetriesTransientGraphApplyBeforeFallback|DoesNotFallbackForNonTransientGraphApplyError)|TestIsTransientGraphApplyErrorTreatsCommandTimeoutAsTransient' -count=1`
- `go test ./internal/beads -run 'TestNativeDoltStoreApplyGraphPlan|TestBdStore.*GraphApply|TestBdStoreSupportsEphemeralGraphApply' -count=1`
- `go vet ./...`
- `make test-fast-parallel`
- `.githooks/pre-commit`