### PR TITLE
fix(molecule): fence graph workflow fallback instantiation

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/dispatch"
@@ -2940,6 +2941,28 @@ case "$*" in
 esac
 `)
 	assertJSONEqual(t, out, `[{"id":"ga-pending","metadata":{"gc.kind":"retry"}},{"id":"ga-ready","metadata":{"gc.kind":"scope-check"}}]`)
+}
+
+func TestWorkflowServeControlReadyQuerySkipsInstantiatingBeads(t *testing.T) {
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
+	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
+		"GC_SESSION_NAME": "gascity--control-dispatcher",
+		"GC_ALIAS":        "gascity/control-dispatcher",
+	}, fmt.Sprintf(`#!/bin/sh
+set -eu
+case "$*" in
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+    printf '[{"id":"ga-instantiating-assigned","metadata":{"%s":"true"}},{"id":"ga-assigned","metadata":{"gc.kind":"retry"}}]'
+    ;;
+  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
+    printf '[{"id":"ga-instantiating-routed","metadata":{"%s":"true"}},{"id":"ga-routed","metadata":{"gc.kind":"scope-check"}}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`, beadmeta.InstantiatingMetadataKey, beadmeta.InstantiatingMetadataKey))
+	assertJSONEqual(t, out, `[{"id":"ga-assigned","metadata":{"gc.kind":"retry"}},{"id":"ga-routed","metadata":{"gc.kind":"scope-check"}}]`)
 }
 
 func TestWorkflowServeControlReadyQueryPreservesQueryPriorityWhenMerging(t *testing.T) {

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -656,6 +656,13 @@ func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg conf
 	if beadsCfg.UsesBD105ReadySemantics() {
 		includeEphemeral = " --include-ephemeral"
 	}
+	jqFilter := fmt.Sprintf(
+		`reduce add[] as $item ([]; if (($item.metadata // {})[%q] // "") != "" then . elif any(.[]; .id == $item.id) then . else . + [$item] end)`,
+		beadmeta.InstantiatingMetadataKey,
+	)
+	jqFilter = strings.ReplaceAll(jqFilter, `\`, `\\`)
+	jqFilter = strings.ReplaceAll(jqFilter, `"`, `\"`)
+	jqFilter = strings.ReplaceAll(jqFilter, `$`, `\$`)
 	queryPrefix := `BD_EXPORT_AUTO=false GC_CONTROL_TARGET=` + shellquote.Quote(target)
 	for _, name := range controlSessionNames {
 		name = strings.TrimSpace(name)
@@ -688,7 +695,7 @@ func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg conf
 		`done; ` +
 		`routed_ready "$GC_CONTROL_TARGET"; ` +
 		`routed_ready "${GC_CONTROL_LEGACY_TARGET:-}"; ` +
-		`if [ -s "$tmp" ]; then jq -s "reduce add[] as \$item ([]; if any(.[]; .id == \$item.id) then . else . + [\$item] end)" "$tmp"; else printf "[]"; fi` + `'`
+		`if [ -s "$tmp" ]; then jq -s "` + jqFilter + `" "$tmp"; else printf "[]"; fi` + `'`
 	return query
 }
 

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -100,6 +100,7 @@ const (
 	Graphv2RootKeyMetadataKey            = "gc.graphv2_root_key"
 	IdempotencyKeyMetadataKey            = "gc.idempotency_key"
 	InputConvoyIDMetadataKey             = "gc.input_convoy_id"
+	InstantiatingMetadataKey             = "gc.instantiating"
 	ItemRootKeyMetadataKey               = "gc.item_root_key"
 	KindMetadataKey                      = "gc.kind"
 	LastFailureClassMetadataKey          = "gc.last_failure_class"
@@ -258,6 +259,7 @@ var KnownMetadataKeys = []string{
 	Graphv2RootKeyMetadataKey,
 	IdempotencyKeyMetadataKey,
 	InputConvoyIDMetadataKey,
+	InstantiatingMetadataKey,
 	ItemRootKeyMetadataKey,
 	KindMetadataKey,
 	LastFailureClassMetadataKey,

--- a/internal/beadmeta/keys_test.go
+++ b/internal/beadmeta/keys_test.go
@@ -60,6 +60,7 @@ func TestPinnedValues(t *testing.T) {
 		ScopeRefMetadataKey:          "gc.scope_ref",
 		AttemptMetadataKey:           "gc.attempt",
 		ExecutionRoutedToMetadataKey: "gc.execution_routed_to",
+		InstantiatingMetadataKey:     "gc.instantiating",
 		PhaseMetadataKey:             "gc.phase",
 		FormulaVarPrefix:             "gc.var.",
 		Namespace:                    "gc.",

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -77,6 +77,10 @@ const (
 	// molecule creation. Speculative actionable work is created as a ready-
 	// excluded type and restored on activation.
 	DeferredTypeMetadataKey = beadmeta.DeferredTypeMetadataKey
+
+	// InstantiatingMetadataKey marks graph workflows that are visible in the
+	// store while sequential fallback is still wiring their dependency graph.
+	InstantiatingMetadataKey = beadmeta.InstantiatingMetadataKey
 )
 
 // FragmentOptions configures instantiation of a rootless recipe fragment into
@@ -509,6 +513,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 	embeddedDeps := make(map[string]bool)
 	pendingAssignees := make(map[string]string)
 	graphWorkflow := preservesGraphActionTypes(recipe)
+	fenceGraphWorkflow := graphWorkflow && !opts.DeferAssignees
 	externalDepsByStep, err := groupExternalDeps(opts.ExternalDeps)
 	if err != nil {
 		return nil, err
@@ -636,6 +641,9 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				b.Assignee = ""
 			}
 		}
+		if fenceGraphWorkflow {
+			fenceGraphWorkflowBead(&b)
+		}
 
 		// Catch unresolved {{...}} in the bead title — the field agents see
 		// first. Unresolved placeholders here cause agent churn (#618).
@@ -721,6 +729,19 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			if err := store.Update(beadID, beads.UpdateOpts{Assignee: &assignee}); err != nil {
 				markFailed(store, createdIDs)
 				return nil, fmt.Errorf("assigning graph step %q: %w", stepID, err)
+			}
+		}
+	}
+
+	if fenceGraphWorkflow {
+		for _, step := range recipe.Steps {
+			beadID := idMapping[step.ID]
+			if beadID == "" {
+				continue
+			}
+			if err := activateFencedGraphWorkflowBead(store, beadID); err != nil {
+				markFailed(store, createdIDs)
+				return nil, fmt.Errorf("activating graph step %q: %w", step.ID, err)
 			}
 		}
 	}
@@ -1070,6 +1091,60 @@ func deferBeadRouting(b *beads.Bead) {
 	deferBeadMetadataValue(b, beadmeta.ExecutionRoutedToMetadataKey, DeferredExecutionRoutedToMetadataKey)
 }
 
+func fenceGraphWorkflowBead(b *beads.Bead) {
+	ensureBeadMetadata(b)
+	b.Metadata[InstantiatingMetadataKey] = "true"
+	deferBeadRouting(b)
+}
+
+func activateFencedGraphWorkflowBead(store beads.Store, id string) error {
+	b, err := store.Get(id)
+	if err != nil {
+		return err
+	}
+	update := deferredRoutingActivationUpdate(b)
+	if update.Assignee == nil && update.Type == nil && len(update.Metadata) == 0 {
+		return nil
+	}
+	return store.Update(id, update)
+}
+
+func deferredRoutingActivationUpdate(b beads.Bead) beads.UpdateOpts {
+	update := beads.UpdateOpts{}
+	metadata := map[string]string{}
+	if assignee := b.Metadata[DeferredAssigneeMetadataKey]; assignee != "" {
+		if b.Assignee != assignee {
+			update.Assignee = &assignee
+		}
+		metadata[DeferredAssigneeMetadataKey] = ""
+	}
+	if routedTo := b.Metadata[DeferredRoutedToMetadataKey]; routedTo != "" {
+		if b.Metadata[beadmeta.RoutedToMetadataKey] != routedTo {
+			metadata[beadmeta.RoutedToMetadataKey] = routedTo
+		}
+		metadata[DeferredRoutedToMetadataKey] = ""
+	}
+	if executionRoutedTo := b.Metadata[DeferredExecutionRoutedToMetadataKey]; executionRoutedTo != "" {
+		if b.Metadata[beadmeta.ExecutionRoutedToMetadataKey] != executionRoutedTo {
+			metadata[beadmeta.ExecutionRoutedToMetadataKey] = executionRoutedTo
+		}
+		metadata[DeferredExecutionRoutedToMetadataKey] = ""
+	}
+	if typ := b.Metadata[DeferredTypeMetadataKey]; typ != "" {
+		if b.Type != typ {
+			update.Type = &typ
+		}
+		metadata[DeferredTypeMetadataKey] = ""
+	}
+	if b.Metadata[InstantiatingMetadataKey] != "" {
+		metadata[InstantiatingMetadataKey] = ""
+	}
+	if len(metadata) > 0 {
+		update.Metadata = metadata
+	}
+	return update
+}
+
 func deferBeadMetadataValue(b *beads.Bead, sourceKey, deferredKey string) {
 	if b.Metadata == nil {
 		return
@@ -1218,7 +1293,10 @@ func unresolvedTitleValidationErrorsWithVars(recipe *formula.Recipe, opts Option
 // error path.
 func markFailed(store beads.Store, ids []string) {
 	for _, id := range ids {
-		_ = store.SetMetadata(id, "molecule_failed", "true")
+		_ = store.SetMetadataBatch(id, map[string]string{
+			"molecule_failed":        "true",
+			InstantiatingMetadataKey: "",
+		})
 	}
 }
 

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -827,6 +827,198 @@ func TestBuildRecipeApplyPlan_GraphWorkflowOwnershipUsesTracks(t *testing.T) {
 	}
 }
 
+func TestInstantiateSequentialGraphWorkflowDefersRoutingUntilGraphWired(t *testing.T) {
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(false)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+	base := beads.NewMemStore()
+	store := &observingCreateStore{MemStore: base}
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{
+				ID:       "wf",
+				Title:    "Workflow",
+				Type:     "task",
+				IsRoot:   true,
+				Assignee: "controller",
+				Metadata: map[string]string{
+					"gc.kind":      "workflow",
+					"gc.routed_to": "gascity/control-dispatcher",
+				},
+			},
+			{
+				ID:       "wf.body",
+				Title:    "Body",
+				Type:     "task",
+				Assignee: "worker",
+				Metadata: map[string]string{
+					"gc.kind":      "scope",
+					"gc.routed_to": "gascity/worker",
+				},
+			},
+			{
+				ID:    "wf.workflow-finalize",
+				Title: "Finalize",
+				Type:  "task",
+				Metadata: map[string]string{
+					"gc.kind":                  "workflow-finalize",
+					"gc.execution_routed_to":   "gascity/control-dispatcher",
+					"gc.step_timeout":          "5m",
+					"gc.control_dispatch_kind": "finalize",
+				},
+			},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf.body", DependsOnID: "wf", Type: "parent-child"},
+			{StepID: "wf.workflow-finalize", DependsOnID: "wf", Type: "parent-child"},
+			{StepID: "wf.workflow-finalize", DependsOnID: "wf.body", Type: "blocks"},
+			{StepID: "wf", DependsOnID: "wf.workflow-finalize", Type: "blocks"},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if len(store.created) != 3 {
+		t.Fatalf("created %d beads, want 3", len(store.created))
+	}
+	for _, created := range store.created {
+		if got := created.Metadata[InstantiatingMetadataKey]; got != "true" {
+			t.Fatalf("created bead %s instantiating metadata = %q, want true", created.ID, got)
+		}
+		if created.Assignee != "" {
+			t.Fatalf("created bead %s assignee = %q, want deferred", created.ID, created.Assignee)
+		}
+		if created.Type != "gate" {
+			t.Fatalf("created bead %s type = %q, want gate", created.ID, created.Type)
+		}
+		if created.Metadata["gc.routed_to"] != "" || created.Metadata["gc.execution_routed_to"] != "" {
+			t.Fatalf("created bead %s exposed routing metadata during instantiation: %#v", created.ID, created.Metadata)
+		}
+	}
+
+	root, err := base.Get(result.IDMapping["wf"])
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if root.Metadata[InstantiatingMetadataKey] != "" {
+		t.Fatalf("root instantiating metadata after instantiate = %q, want cleared", root.Metadata[InstantiatingMetadataKey])
+	}
+	if root.Assignee != "controller" || root.Type != "task" || root.Metadata["gc.routed_to"] != "gascity/control-dispatcher" {
+		t.Fatalf("root routing not restored: type=%q assignee=%q metadata=%#v", root.Type, root.Assignee, root.Metadata)
+	}
+
+	body, err := base.Get(result.IDMapping["wf.body"])
+	if err != nil {
+		t.Fatalf("Get(body): %v", err)
+	}
+	if body.Metadata[InstantiatingMetadataKey] != "" {
+		t.Fatalf("body instantiating metadata after instantiate = %q, want cleared", body.Metadata[InstantiatingMetadataKey])
+	}
+	if body.Assignee != "worker" || body.Type != "task" || body.Metadata["gc.routed_to"] != "gascity/worker" {
+		t.Fatalf("body routing not restored: type=%q assignee=%q metadata=%#v", body.Type, body.Assignee, body.Metadata)
+	}
+
+	finalize, err := base.Get(result.IDMapping["wf.workflow-finalize"])
+	if err != nil {
+		t.Fatalf("Get(finalize): %v", err)
+	}
+	if finalize.Metadata[InstantiatingMetadataKey] != "" {
+		t.Fatalf("finalize instantiating metadata after instantiate = %q, want cleared", finalize.Metadata[InstantiatingMetadataKey])
+	}
+	if finalize.Type != "task" || finalize.Metadata["gc.execution_routed_to"] != "gascity/control-dispatcher" {
+		t.Fatalf("finalize routing not restored: type=%q metadata=%#v", finalize.Type, finalize.Metadata)
+	}
+}
+
+func TestInstantiateGraphWorkflowFailureClearsInstantiationFence(t *testing.T) {
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(false)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+	base := beads.NewMemStore()
+	store := &errDepStore{Store: base}
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{
+				ID:       "wf",
+				Title:    "Workflow",
+				Type:     "task",
+				IsRoot:   true,
+				Assignee: "controller",
+				Metadata: map[string]string{
+					"gc.kind":      "workflow",
+					"gc.routed_to": "gascity/control-dispatcher",
+				},
+			},
+			{
+				ID:       "wf.body",
+				Title:    "Body",
+				Type:     "task",
+				Assignee: "worker",
+				Metadata: map[string]string{
+					"gc.kind":      "scope",
+					"gc.routed_to": "gascity/worker",
+				},
+			},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf.body", DependsOnID: "wf", Type: "parent-child"},
+		},
+	}
+
+	_, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err == nil {
+		t.Fatal("expected error on dep failure")
+	}
+
+	all, err := base.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("open beads = %d, want 2", len(all))
+	}
+	for _, b := range all {
+		full, err := base.Get(b.ID)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", b.ID, err)
+		}
+		if full.Metadata["molecule_failed"] != "true" {
+			t.Errorf("bead %s molecule_failed = %q, want true", full.ID, full.Metadata["molecule_failed"])
+		}
+		if full.Metadata[InstantiatingMetadataKey] != "" {
+			t.Errorf("bead %s instantiating metadata = %q, want cleared", full.ID, full.Metadata[InstantiatingMetadataKey])
+		}
+		if full.Type != "gate" {
+			t.Errorf("bead %s type = %q, want gate", full.ID, full.Type)
+		}
+		if full.Assignee != "" {
+			t.Errorf("bead %s assignee = %q, want deferred", full.ID, full.Assignee)
+		}
+		if full.Metadata["gc.routed_to"] != "" {
+			t.Errorf("bead %s restored routing metadata after failed instantiation: %#v", full.ID, full.Metadata)
+		}
+	}
+}
+
+type observingCreateStore struct {
+	*beads.MemStore
+	created []beads.Bead
+}
+
+func (s *observingCreateStore) Create(b beads.Bead) (beads.Bead, error) {
+	created, err := s.MemStore.Create(b)
+	if err == nil {
+		s.created = append(s.created, created)
+	}
+	return created, err
+}
+
 func TestInstantiateGraphApplyPreservesStepMetadata(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
 	prev := IsGraphApplyEnabled()
@@ -1253,7 +1445,7 @@ func (r *recordingStore) Update(id string, opts beads.UpdateOpts) error {
 	return r.Store.Update(id, opts)
 }
 
-func TestInstantiateGraphWorkflowDefersAssignmentsOnlyForFutureBlockers(t *testing.T) {
+func TestInstantiateGraphWorkflowDefersAssignmentsUntilGraphWired(t *testing.T) {
 	base := beads.NewMemStore()
 	store := &recordingStore{Store: base}
 
@@ -1295,11 +1487,17 @@ func TestInstantiateGraphWorkflowDefersAssignmentsOnlyForFutureBlockers(t *testi
 	for _, created := range store.created {
 		createdByRef[created.Ref] = created
 	}
-	if got := createdByRef["graph-assign.setup"].Assignee; got != "worker" {
-		t.Fatalf("setup created assignee = %q, want worker", got)
+	if got := createdByRef["graph-assign.setup"].Assignee; got != "" {
+		t.Fatalf("setup created assignee = %q, want empty until graph wiring completes", got)
 	}
 	if got := createdByRef["graph-assign.run"].Assignee; got != "" {
-		t.Fatalf("run created assignee = %q, want empty until blocker wiring completes", got)
+		t.Fatalf("run created assignee = %q, want empty until graph wiring completes", got)
+	}
+	if got := createdByRef["graph-assign.setup"].Type; got != "gate" {
+		t.Fatalf("setup created type = %q, want gate until graph wiring completes", got)
+	}
+	if got := createdByRef["graph-assign.run"].Type; got != "gate" {
+		t.Fatalf("run created type = %q, want gate until graph wiring completes", got)
 	}
 
 	setup, err := base.Get(result.IDMapping["graph-assign.setup"])


### PR DESCRIPTION
## Summary
- add a shared gc.instantiating metadata key for graph workflow materialization
- fence sequential graph.v2 fallback beads as gate/unrouted/unassigned until all dependencies are wired
- filter fenced beads out of the control-dispatcher ready query before returning work

## Validation
- go test ./internal/beadmeta ./internal/molecule -count=1
- go test ./cmd/gc -run 'TestWorkflowServeControlReadyQuery|TestWorkflowServeControlReadyQuerySkipsInstantiatingBeads' -count=1
- go vet ./...
- make test-fast-parallel
- .githooks/pre-commit
- live retry: mc-zkzdj (#3344) launched via patched binary; native graph apply timed out twice, fenced fallback completed, source stamped workflow_root_id=ga-wisp-ebaexw, with 0 remaining gc.instantiating=true beads and 0 quarantine/failure markers under the new root