### PR TITLE
test: harden final RC gate regressions

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -4373,8 +4373,8 @@ func TestCityRuntimeReloadDrainShortCircuitsOnTickContextCancel(t *testing.T) {
 	lastProviderName := "fake"
 	start := time.Now()
 	cr.reloadConfig(ctx, &lastProviderName, cityPath)
-	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
-		t.Fatalf("reload drain took %s after tick context cancellation, want <200ms", elapsed)
+	if elapsed := time.Since(start); elapsed >= reloadOrderDrainTimeout {
+		t.Fatalf("reload drain took %s after tick context cancellation, want less than %s", elapsed, reloadOrderDrainTimeout)
 	}
 	errs := od.drainContextErrors()
 	if len(errs) == 0 || !errors.Is(errs[0], context.Canceled) {

--- a/test/acceptance/tier_c/fresh_install_spawn_test.go
+++ b/test/acceptance/tier_c/fresh_install_spawn_test.go
@@ -121,6 +121,7 @@ func runFreshInitSlingClaudeWork(t *testing.T, prompt, outputRel string) freshIn
 			return false
 		}
 		sessionBeads := parseBeadListJSON(t, sessionsOut)
+		sessionListOut, sessionListErr := runGCWithTimeout(10*time.Second, testEnvC, c.Dir, "session", "list")
 		for _, sessionBead := range sessionBeads {
 			if metaString(sessionBead.Metadata, "template") != "claude" {
 				continue
@@ -129,11 +130,18 @@ func runFreshInitSlingClaudeWork(t *testing.T, prompt, outputRel string) freshIn
 			if state != "creating" && state != "active" && state != "awake" {
 				continue
 			}
-			if metaString(sessionBead.Metadata, "session_name") == "" {
+			sessionName := metaString(sessionBead.Metadata, "session_name")
+			if sessionName == "" {
 				continue
 			}
 			spawnedSessionBead = sessionBead
-			return state == "active" || state == "awake"
+			if state == "active" || state == "awake" {
+				return true
+			}
+			if sessionListErr != nil {
+				return false
+			}
+			return sessionListShowsActive(sessionListOut, sessionBead.ID, sessionName)
 		}
 		return false
 	})
@@ -280,6 +288,54 @@ func parseCreatedBeadID(output string) string {
 		return ""
 	}
 	return strings.TrimSpace(match[1])
+}
+
+func TestSessionListShowsActiveAcceptsLiveStateDuringMetadataLag(t *testing.T) {
+	output := `2026/06/13 22:51:49 WARN native_store_unavailable
+ID           TEMPLATE  STATE   REASON          TARGET              TITLE   AGE  LAST ACTIVE  LAST NUDGE
+a9-wisp-0my  claude    active  session,config  claude-a9-wisp-0my  claude  19s  0s ago       -
+a9-wisp-q0w  claude    creating create,config  s-a9-wisp-q0w       claude  27s  -            -
+`
+
+	if !sessionListShowsActive(output, "a9-wisp-0my", "claude-a9-wisp-0my") {
+		t.Fatal("expected active live session row to satisfy spawned-worker check")
+	}
+	if sessionListShowsActive(output, "a9-wisp-q0w", "s-a9-wisp-q0w") {
+		t.Fatal("creating live session row must not satisfy spawned-worker check")
+	}
+	if sessionListShowsActive(output, "missing", "missing") {
+		t.Fatal("unrelated session must not satisfy spawned-worker check")
+	}
+}
+
+func sessionListShowsActive(output, beadID, sessionName string) bool {
+	beadID = strings.TrimSpace(beadID)
+	sessionName = strings.TrimSpace(sessionName)
+	if beadID == "" && sessionName == "" {
+		return false
+	}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		state := fields[2]
+		if state != "active" && state != "awake" {
+			continue
+		}
+		if beadID != "" && fields[0] == beadID {
+			return true
+		}
+		if sessionName == "" {
+			continue
+		}
+		for _, field := range fields[3:] {
+			if field == sessionName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func parseBeadListJSON(t *testing.T, out string) []beadJSON {

--- a/test/acceptance/tier_c/tierc_test.go
+++ b/test/acceptance/tier_c/tierc_test.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -35,7 +36,10 @@ import (
 	"github.com/gastownhall/gascity/test/tmuxtest"
 )
 
-var testEnvC *helpers.Env
+var (
+	testEnvC                *helpers.Env
+	attachedWorkflowPattern = regexp.MustCompile(`(?m)^Attached workflow (\S+)\b`)
+)
 
 const tierCStartupTimeout = "3m"
 
@@ -261,6 +265,7 @@ func TestGastown_PolecatImplementsRefineryMerges(t *testing.T) {
 		t.Fatalf("gc sling: %v\n%s", err, out)
 	}
 	t.Logf("Slung work to polecat: %s", strings.TrimSpace(out))
+	attachedWorkflowID := parseAttachedWorkflowID(out)
 
 	routeKey := gastownRigAgent(rigName, "polecat")
 	readyOut, err := bdCmd(testEnvC, rigDir, "ready", "--metadata-field", "gc.routed_to="+routeKey, "--unassigned", "--json", "--limit=20")
@@ -277,6 +282,9 @@ func TestGastown_PolecatImplementsRefineryMerges(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(outerOut), &outer), "unmarshal outer bead")
 	require.Len(t, outer, 1, "expected one outer bead")
 	moleculeID := attachedRootID(outer[0])
+	if moleculeID == "" {
+		moleculeID = attachedWorkflowID
+	}
 	require.NotEmpty(t, moleculeID, "routed bead should carry or be the attached workflow/molecule root")
 
 	rootOut, err := bdCmd(testEnvC, rigDir, "show", moleculeID, "--json")
@@ -402,14 +410,22 @@ func TestGastown_MayorDispatchPipeline(t *testing.T) {
 	c.RigAdd(rigDir, "packs/gastown")
 	seedGastownClaudeProjects(t, c, rigName)
 
-	// Limit pool sizes.
-	c.AppendToConfig("\n[[rigs.overrides]]\nagent = \"polecat\"\n[rigs.overrides.pool]\nmin = 1\nmax = 1\n")
+	// Keep polecat idle until the mayor creates routed work. A warm min=1
+	// polecat can see the fixture TODO and directly mutate the repo before the
+	// mayor dispatch path has anything to prove.
+	c.AppendToConfig("\n[[rigs.overrides]]\nagent = \"polecat\"\n[rigs.overrides.pool]\nmin = 0\nmax = 1\n")
 
 	c.StartWithSupervisor()
 	time.Sleep(15 * time.Second)
 
 	// Send durable mail, then notify the mayor so an idle session processes it.
-	out, err := c.GC("mail", "send", "--notify", "mayor", "Please add a greet() function to app.py that prints 'hello'")
+	dispatchTarget := gastownRigAgent(rigName, "polecat")
+	body := fmt.Sprintf(
+		"Create a rig work bead in rig %q for this task, then dispatch it with `gc sling %s <bead-id>`: add a greet() function to app.py that prints 'hello'. Do not edit the file directly as mayor.",
+		rigName,
+		dispatchTarget,
+	)
+	out, err := c.GC("mail", "send", "--notify", "mayor", "-s", "Dispatch app.py greet work to polecat", "-m", body)
 	if err != nil {
 		t.Fatalf("gc mail send: %v\n%s", err, out)
 	}
@@ -601,6 +617,14 @@ func attachedRootID(bead beadJSON) string {
 		return bead.ID
 	}
 	return ""
+}
+
+func parseAttachedWorkflowID(output string) string {
+	match := attachedWorkflowPattern.FindStringSubmatch(output)
+	if len(match) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(match[1])
 }
 
 func bdCmd(env *helpers.Env, dir string, args ...string) (string, error) {
@@ -963,6 +987,18 @@ func TestUniqueRigName(t *testing.T) {
 		if got := uniqueRigName(tc.testName); got != tc.want {
 			t.Errorf("uniqueRigName(%q) = %q, want %q", tc.testName, got, tc.want)
 		}
+	}
+}
+
+func TestParseAttachedWorkflowID(t *testing.T) {
+	output := `Created pir-pgi — "Create a file called feature.txt containing 'new feature'"
+Attached workflow pir-swc (formula "mol-polecat-work") to pir-swc
+`
+	if got := parseAttachedWorkflowID(output); got != "pir-swc" {
+		t.Fatalf("parseAttachedWorkflowID() = %q, want pir-swc", got)
+	}
+	if got := parseAttachedWorkflowID("Created pir-pgi\n"); got != "" {
+		t.Fatalf("parseAttachedWorkflowID() = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Relax the reload-drain cancellation test to assert the cancellation contract without a brittle 200ms macOS scheduler cutoff.
- Let the fresh-init Tier C test accept live `gc session list` state when session bead metadata still says `creating`.
- Harden Tier C Gastown assertions for attached workflow output and keep idle polecats from pre-empting the mayor dispatch test fixture.

## RC Gate failures addressed
- RC Gate run 27481127010: `Mac regression / Mac / make test` failed in `TestCityRuntimeReloadDrainShortCircuitsOnTickContextCancel` at 211ms vs a 200ms test cap.
- RC Gate run 27481127010: acceptance C shard 1 failed `TestFreshInit_SlingSpawnsDefaultPoolWorker` while `gc session list` showed the spawned worker active but bead metadata still said `creating`.
- RC Gate run 27481127010: acceptance C shard 1 failed `TestGastown_MayorDispatchPipeline` because an idle min=1 polecat directly handled the fixture TODO before the mayor dispatch path could create a bead.
- RC Gate run 27481127010: acceptance C shard 4 failed `TestGastown_PolecatImplementsRefineryMerges` when the routed queue entry did not carry root metadata but `gc sling` printed the attached workflow root.

## Verification
- `.githooks/pre-commit` (lint-changed, generated checks, `go vet ./...`, fast parallel suite)
- `go test ./cmd/gc -run '^TestCityRuntimeReloadDrain(BoundedByTimeout|ShortCircuitsOnTickContextCancel)$' -count=1`
- `go test ./cmd/gc -run '^TestCityRuntimeReloadDrainShortCircuitsOnTickContextCancel$' -count=20`
- `go test -tags acceptance_c ./test/acceptance/tier_c -run '^(TestSessionListShowsActiveAcceptsLiveStateDuringMetadataLag|TestParseAttachedWorkflowID|TestUniqueRigName)$' -count=1`
- `go test -c -tags acceptance_c ./test/acceptance/tier_c -o /tmp/tier_c_acceptance.test`
- `git diff --check`
