### PR TITLE
fix(telemetry): settle reconcile-cycle attrs and instrument gc session kill

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/shellquote"
+	"github.com/gastownhall/gascity/internal/telemetry"
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 	"github.com/gastownhall/gascity/internal/worker"
 	"github.com/spf13/cobra"
@@ -2233,6 +2234,7 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 		Message: "killed",
 		Payload: api.SessionLifecyclePayloadJSON(sessionID, "", "killed"),
 	})
+	recordSessionKillStop(bead, beadErr)
 	if asJSON {
 		if err := writeSessionActionJSON(stdout, sessionActionResult{
 			Action:    "kill",
@@ -2245,6 +2247,23 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 	}
 	fmt.Fprintf(stdout, "Session %s killed.\n", sessionID) //nolint:errcheck // best-effort stdout
 	return 0
+}
+
+// recordSessionKillStop records gc.agent.stops.total for a manual
+// "gc session kill", beside the SessionStopped emission. Skip-on-unknown:
+// when the session bead failed to load (or carries no bounded session name)
+// nothing is recorded — an unknown identity must not become a garbage metric
+// label. Purely observational: it never influences control flow or the exit
+// code.
+func recordSessionKillStop(bead beads.Bead, beadErr error) {
+	if beadErr != nil {
+		return
+	}
+	sessionName := strings.TrimSpace(bead.Metadata["session_name"])
+	if sessionName == "" {
+		return
+	}
+	telemetry.RecordAgentStop(context.Background(), sessionName, "stopped", nil)
 }
 
 func sessionKillRuntimeAlreadyInactive(bead beads.Bead, sp runtime.Provider) bool {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -951,13 +951,13 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	// counter means "cycles", not "cycles that ran to completion". started
 	// counts the planned wakes the tick actually executed. Stops are applied
 	// asynchronously (drain advance, drain-ack goroutines) and skips are
-	// per-session trace decisions; neither is aggregated at the tick
-	// boundary, so they are reported as 0 rather than invented (tracked for
-	// fidelity in ga-ebb62d). The ctx param may legitimately be nil here, so
-	// the metric uses context.Background().
+	// per-session trace decisions, so honest tick-boundary counts cannot
+	// exist for them and the metric deliberately omits them (settled in
+	// ga-ebb62d). The ctx param may legitimately be nil here, so the metric
+	// uses context.Background().
 	startedThisTick := 0
 	defer func() {
-		telemetry.RecordReconcileCycle(context.Background(), startedThisTick, 0, 0)
+		telemetry.RecordReconcileCycle(context.Background(), startedThisTick)
 	}()
 	if ctx != nil && ctx.Err() != nil {
 		return 0

--- a/cmd/gc/telemetry_lifecycle_metrics_test.go
+++ b/cmd/gc/telemetry_lifecycle_metrics_test.go
@@ -14,6 +14,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -433,18 +435,157 @@ func TestRecordChurn_QuarantineRecordsMetric(t *testing.T) {
 	}
 }
 
+// TestCmdSessionKill_RecordsAgentStopMetric verifies a successful
+// `gc session kill` increments gc.agent.stops.total exactly once with the
+// bounded runtime session name from the session bead, reason "stopped", and
+// status "ok" — beside its SessionStopped emission (ga-rjk4or).
+func TestCmdSessionKill_RecordsAgentStopMetric(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-kill-stop-metric-")
+	t.Setenv("GC_CITY", cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
+
+	fakeProvider := runtime.NewFake()
+	oldBuild := buildSessionProviderByName
+	buildSessionProviderByName = func(string, config.SessionConfig, string, string) (runtime.Provider, error) {
+		return fakeProvider, nil
+	}
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	const identity = "session-a"
+	const sessionName = "s-gc-kill-stop-metric"
+	bead, err := store.Create(beads.Bead{
+		Title:  "named session",
+		Type:   sessionpkg.BeadType,
+		Labels: []string{sessionpkg.LabelSession, "template:worker"},
+		Metadata: map[string]string{
+			"alias":                      identity,
+			"template":                   "worker",
+			"session_name":               sessionName,
+			"state":                      "awake",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+	if err := fakeProvider.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("fakeProvider.Start: %v", err)
+	}
+	if err := fakeProvider.SetMeta(sessionName, "GC_SESSION_ID", bead.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	lis, err := startControllerSocket(
+		cityDir,
+		func() {},
+		nil,
+		nil,
+		make(chan reloadRequest),
+		make(chan convergenceRequest, 1),
+		make(chan struct{}, 1),
+		make(chan struct{}, 1),
+	)
+	if err != nil {
+		t.Fatalf("startControllerSocket: %v", err)
+	}
+	defer lis.Close()                              //nolint:errcheck
+	defer os.Remove(controllerSocketPath(cityDir)) //nolint:errcheck
+
+	reader := installManualMetricReader(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionKill([]string{identity}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionKill = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	points := collectCounterDataPoints(t, reader, "gc.agent.stops.total")
+	want := map[string]string{"agent": sessionName, "reason": "stopped", "status": "ok"}
+	if !hasDataPointWithStringAttrs(points, want) {
+		t.Fatalf("gc.agent.stops.total has no datapoint with agent=%s reason=stopped status=ok: %+v", sessionName, points)
+	}
+	for _, dp := range points {
+		matched := true
+		for key, wantValue := range want {
+			val, ok := dp.Attributes.Value(attribute.Key(key))
+			if !ok || val.AsString() != wantValue {
+				matched = false
+				break
+			}
+		}
+		if matched && dp.Value != 1 {
+			t.Fatalf("gc.agent.stops.total datapoint value = %d, want exactly 1 per kill: %+v", dp.Value, dp.Attributes)
+		}
+	}
+}
+
+// TestRecordSessionKillStop_SkipOnUnknown pins the skip-on-unknown contract
+// of recordSessionKillStop: when the session bead failed to load, or carries
+// no bounded session name, nothing is recorded — an unknown identity must
+// not become a garbage metric label. The beadErr path is deterministically
+// unreachable through cmdSessionKill end-to-end (handle resolution on the
+// same store fails first), so this helper-level test is the only way to pin
+// it.
+func TestRecordSessionKillStop_SkipOnUnknown(t *testing.T) {
+	t.Run("bead load failure records nothing", func(t *testing.T) {
+		reader := installManualMetricReader(t)
+
+		recordSessionKillStop(beads.Bead{}, errors.New("store unavailable"))
+
+		if points := collectCounterDataPoints(t, reader, "gc.agent.stops.total"); len(points) != 0 {
+			t.Fatalf("gc.agent.stops.total datapoints = %+v, want none when the bead failed to load", points)
+		}
+	})
+
+	t.Run("empty session name records nothing", func(t *testing.T) {
+		reader := installManualMetricReader(t)
+
+		recordSessionKillStop(beads.Bead{Metadata: map[string]string{"session_name": "  "}}, nil)
+
+		if points := collectCounterDataPoints(t, reader, "gc.agent.stops.total"); len(points) != 0 {
+			t.Fatalf("gc.agent.stops.total datapoints = %+v, want none for a blank session name", points)
+		}
+	})
+
+	t.Run("loaded bead records the stop", func(t *testing.T) {
+		reader := installManualMetricReader(t)
+
+		recordSessionKillStop(beads.Bead{Metadata: map[string]string{"session_name": "worker-9"}}, nil)
+
+		points := collectCounterDataPoints(t, reader, "gc.agent.stops.total")
+		if !hasDataPointWithStringAttrs(points, map[string]string{"agent": "worker-9", "reason": "stopped", "status": "ok"}) {
+			t.Fatalf("gc.agent.stops.total has no datapoint with agent=worker-9 reason=stopped status=ok: %+v", points)
+		}
+	})
+}
+
 // TestReconcileSessionBeads_RecordsReconcileCycleMetric verifies every
 // reconciler tick increments gc.reconcile.cycles.total at the chokepoint all
 // reconcile wrappers funnel into — including ticks aborted by context
 // cancellation, so the counter means "cycles", not "cycles that ran to
 // completion". Stops and skips are not aggregated at the tick boundary, so
-// they are honestly reported as 0.
+// the metric intentionally carries only the started attribute.
 func TestReconcileSessionBeads_RecordsReconcileCycleMetric(t *testing.T) {
 	assertCycleRecorded := func(t *testing.T, reader *sdkmetric.ManualReader) {
 		t.Helper()
 		points := collectCounterDataPoints(t, reader, "gc.reconcile.cycles.total")
-		if !hasDataPointWithIntAttrs(points, map[string]int64{"started": 0, "stopped": 0, "skipped": 0}) {
-			t.Fatalf("gc.reconcile.cycles.total has no datapoint with started=0 stopped=0 skipped=0: %+v", points)
+		if !hasDataPointWithIntAttrs(points, map[string]int64{"started": 0}) {
+			t.Fatalf("gc.reconcile.cycles.total has no datapoint with started=0: %+v", points)
+		}
+		for _, dp := range points {
+			if _, ok := dp.Attributes.Value(attribute.Key("stopped")); ok {
+				t.Fatalf("gc.reconcile.cycles.total datapoint carries dropped attribute %q: %+v", "stopped", dp.Attributes)
+			}
+			if _, ok := dp.Attributes.Value(attribute.Key("skipped")); ok {
+				t.Fatalf("gc.reconcile.cycles.total datapoint carries dropped attribute %q: %+v", "skipped", dp.Attributes)
+			}
 		}
 	}
 

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -353,20 +353,19 @@ func RecordAgentMaxAgeKill(ctx context.Context, agentName string) {
 	)
 }
 
-// RecordReconcileCycle records a reconciliation cycle with counts (metrics + log event).
-func RecordReconcileCycle(ctx context.Context, started, stopped, skipped int) {
+// RecordReconcileCycle records a reconciliation cycle (metrics + log event).
+// The metric carries only the cycle count and the started attribute: stops
+// are applied asynchronously and skips are per-session decisions, so no
+// honest per-tick counts exist for them.
+func RecordReconcileCycle(ctx context.Context, started int) {
 	initInstruments()
 	inst.reconcileCycleTotal.Add(ctx, 1,
 		metric.WithAttributes(
 			attribute.Int("started", started),
-			attribute.Int("stopped", stopped),
-			attribute.Int("skipped", skipped),
 		),
 	)
 	emit(ctx, "reconcile.cycle", otellog.SeverityInfo,
 		otellog.Int("started", started),
-		otellog.Int("stopped", stopped),
-		otellog.Int("skipped", skipped),
 	)
 }
 

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -126,8 +126,8 @@ func TestRecordReconcileCycle(t *testing.T) {
 	resetInstruments(t)
 	ctx := context.Background()
 
-	RecordReconcileCycle(ctx, 3, 1, 2)
-	RecordReconcileCycle(ctx, 0, 0, 0)
+	RecordReconcileCycle(ctx, 3)
+	RecordReconcileCycle(ctx, 0)
 }
 
 func TestRecordNudge(t *testing.T) {


### PR DESCRIPTION
## Summary

Two telemetry follow-ups approved on the ga-vk4qzh (PR #3441) lifecycle-metrics work.

- **ga-ebb62d** — `RecordReconcileCycle` drops the permanently-false `stopped`/`skipped` attributes; the signature is now `(ctx, started)`. Stops are applied asynchronously and skips are per-session trace decisions, so no honest per-tick counts exist for them — per-stop truth lives in `gc.agent.stops.total`.
- **ga-rjk4or** — `gc session kill` records `gc.agent.stops.total` exactly once per kill (`reason="stopped"`), beside the `SessionStopped` emission. Skip-on-unknown: nothing is recorded when the session bead lookup fails or carries no bounded session name, so `agent=""` never becomes a garbage metric label. Purely observational — no control-flow or exit-code change.

## Stacking

Stacked on PR #3441 (`fix/agent-lifecycle-telemetry-ga-vk4qzh`); retargets to `main` when #3441 merges.

## Testing

TDD red→green for both follow-ups; full `cmd/gc` package + `internal/telemetry` green (`-count=1`), `go vet ./...` clean, `.githooks/pre-commit` fast gate green.

## Review

Adversarially reviewed (multi-agent workflow): one real finding fixed (redundant test `MkdirAll`); the blank-`session_name` skip extension was kept because literal compliance would emit `agent=""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
