### PR TITLE
docs: refresh public registry guidance

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -171,6 +171,7 @@
           "guides/understanding-packs",
           "guides/understanding-formulas",
           "guides/shareable-packs",
+          "guides/registry-showcase",
           "guides/gastown-config-recipes",
           "guides/using-json-from-gc",
           "guides/multi-agent-engineering-environment"

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -8,6 +8,7 @@ These guides are task-oriented and current.
 - [Capabilities for Coding Agent Users](/guides/capabilities-for-coding-agent-users)
 - [Understanding Packs](/guides/understanding-packs)
 - [Shareable Packs](/guides/shareable-packs)
+- [Public Registry Packs](/guides/registry-showcase)
 - [Using JSON from the Gas City CLI (`gc`)](/guides/using-json-from-gc)
 - [Using Gas City as a Multi-Agent Engineering Environment](/guides/multi-agent-engineering-environment)
 

--- a/docs/guides/registry-showcase.md
+++ b/docs/guides/registry-showcase.md
@@ -1,0 +1,86 @@
+---
+title: "Public Registry Packs"
+description: Find and import first-party packs from the public Gas City registry.
+---
+
+# Public Registry Packs
+
+Gas City publishes first-party reusable packs through the public
+`gascity-packs` registry. A registry is a discovery catalog: checked-in
+`pack.toml` files still record durable GitHub tree URLs plus an optional
+version constraint or pin.
+
+Add the public registry locally:
+
+```bash
+gc pack registry add main https://github.com/gastownhall/gascity-packs.git
+gc pack registry refresh main
+```
+
+Search and inspect entries:
+
+```bash
+gc pack registry search gascity
+gc pack registry show main:gascity
+```
+
+When you decide to use a pack, prefer the import command printed by
+`gc pack registry show`. It writes the durable `source` URL and selected
+`version`; it does not write the local registry handle into `pack.toml`.
+
+## First-Party Packs
+
+| Pack | Use it for | Registry source |
+|---|---|---|
+| `gascity` | Gas City planning and implementation workflow support. | `https://github.com/gastownhall/gascity-packs/tree/main/gascity` |
+| `gastown` | Default Gas Town coding workflow support. | `https://github.com/gastownhall/gascity-packs/tree/main/gastown` |
+| `cass` | Coding Agent Session Search prompt fragments and skill overlays. | `https://github.com/gastownhall/gascity-packs/tree/main/cass` |
+| `discord` | Discord services, commands, and prompt fragments. | `https://github.com/gastownhall/gascity-packs/tree/main/discord` |
+| `github` | GitHub webhook intake services and commands. | `https://github.com/gastownhall/gascity-packs/tree/main/github` |
+| `slack-full` | Slack services, commands, and adapter integration. | `https://github.com/gastownhall/gascity-packs/tree/main/slack-full` |
+| `slack-channel` | Shared Slack channel routing and session identity. | `https://github.com/gastownhall/gascity-packs/tree/main/slack-channel` |
+| `slack-mini` | Minimal Slack mention bridge and outbound messaging. | `https://github.com/gastownhall/gascity-packs/tree/main/slack-mini` |
+
+## Built-In Packs
+
+Gas City's built-in packs are explicit imports, not implicit loader magic.
+New cities created by `gc init` include pinned imports for the bundled packs
+they need. `gc doctor --fix` can repair missing or stale bundled-pack pins.
+See [System Packs](/reference/system-packs) for the built-in pack contract.
+
+## Freshness
+
+Registry records are cached locally. `gc pack registry search` and
+`gc pack registry show` warn when a cache is older than the freshness window.
+The default window is 24 hours.
+
+Use `--refresh` when you want the command to fetch the latest catalog before
+reading it:
+
+```bash
+gc pack registry search gascity --refresh
+gc pack registry show main:gascity --refresh
+```
+
+Set `GC_REGISTRY_FRESHNESS` to a positive Go duration string when you want a
+different warning window:
+
+```bash
+GC_REGISTRY_FRESHNESS=1h gc pack registry search gascity
+```
+
+Invalid, zero, or negative values warn and are ignored for freshness
+calculation.
+
+## Publishing
+
+Use the registry submission command for pack publish requests:
+
+```bash
+gc pack registry publish .
+```
+
+The command submits the pack rooted at the given path to the configured
+registry service. The hosted registry still reviews and lands catalog changes
+before other users see them; after a publish is accepted, refresh local caches
+before searching or showing the new entry.

--- a/docs/guides/shareable-packs.md
+++ b/docs/guides/shareable-packs.md
@@ -133,23 +133,43 @@ binding.
 ## Registry Discovery
 
 Registries help you find packs, but they do not change the authored import
-shape. The registry commands available in this release are discovery and cache
-management commands:
+shape. The registry commands available in this release cover discovery, cache
+management, authentication, and publish submission:
 
 ```text
 gc pack registry add main https://github.com/gastownhall/gascity-packs.git
 gc pack registry refresh main
 gc pack registry search gastown
-gc pack registry show gastown
+gc pack registry show main:gastown
+gc pack registry login
+gc pack registry publish .
+gc pack registry whoami
 gc pack registry list
 gc pack registry remove main
 ```
 
 When a registry entry is used to add or migrate a pack, the durable
 `pack.toml` entry stores the entry's resolved `source` and optional `version`,
-not the registry handle. Publishing registry content is still a registry-repo
-workflow in this wave: edit the registry catalog, review it, and refresh the
-local registry cache before searching or showing new entries.
+not the registry handle.
+
+The first public registry is the `gascity-packs` catalog:
+
+```text
+gc pack registry add main https://github.com/gastownhall/gascity-packs.git
+gc pack registry refresh main
+gc pack registry search gascity
+gc pack registry show main:gascity
+```
+
+Registry caches are local. Search and show warn when a registry cache is older
+than the freshness window. The default window is 24 hours. Set
+`GC_REGISTRY_FRESHNESS` to a positive Go duration string, such as `1h` or
+`30m`, to change that warning window. Invalid, zero, or negative values warn.
+Pass `--refresh` to `gc pack registry search` or `gc pack registry show` when
+you want that command to fetch the latest catalog before reading it.
+
+See [Public Registry Packs](/guides/registry-showcase) for the first-party
+packs currently advertised through the public registry.
 
 ## City Usage
 

--- a/docs/guides/understanding-packs.md
+++ b/docs/guides/understanding-packs.md
@@ -424,6 +424,7 @@ state.
 | Refresh cached catalog records | `gc pack registry refresh` |
 | Search for a reusable pack | `gc pack registry search` |
 | Inspect a registry record | `gc pack registry show` |
+| Submit a pack publish request | `gc pack registry publish <path>` |
 | Share a chosen dependency with the team | `[imports.<binding>]` in checked-in TOML |
 | Install or repair authored imports | `gc import install` |
 | Check installed import state without mutating | `gc import check` |
@@ -431,3 +432,30 @@ state.
 
 This separation keeps local discovery flexible without making shared config
 depend on the names or cache layout of one machine.
+
+### Registry Freshness
+
+Registry catalogs are cached locally. `gc pack registry search` and
+`gc pack registry show` read that cache unless you pass `--refresh`, and they
+warn when a configured registry cache is older than the freshness window.
+
+By default, a registry cache is considered fresh for 24 hours. Set
+`GC_REGISTRY_FRESHNESS` to a positive Go duration string when you need a
+different window:
+
+```bash
+GC_REGISTRY_FRESHNESS=1h gc pack registry search gascity
+```
+
+Invalid, zero, or negative values produce a warning and leave the command
+without a custom freshness window. Use `--refresh` when you want a command to
+fetch the latest catalog before reading it:
+
+```bash
+gc pack registry search gascity --refresh
+gc pack registry show main:gascity --refresh
+```
+
+Freshness affects discovery, not authored imports. A stale registry cache can
+hide a newly published pack record from search/show output, but shared
+`pack.toml` still stores durable import `source` and `version` values.

--- a/docs/reference/specs/pack-spec.md
+++ b/docs/reference/specs/pack-spec.md
@@ -68,7 +68,10 @@ constraints and lockfile resolution, not by a loader comparing `[pack].version`
 directly.
 
 The `requires_gc` field is optional metadata for the minimum compatible `gc`
-version. It is parsed as pack metadata.
+version. It is parsed and preserved as pack metadata. The current loader,
+importer, and doctor surfaces do not enforce the constraint during load,
+import, or validation; enforcement must be introduced by an explicit future
+implementation change before pack authors can rely on it as a hard gate.
 
 ### 0.3. Pack Contents
 
@@ -207,7 +210,7 @@ requires_gc = ">=0.13.0"
 | `name` | string | yes | Pack identifier and provenance label. Must not be empty. |
 | `schema` | integer | yes | Pack format version. Must be `2` for this specification. |
 | `version` | string | no | Pack version metadata. |
-| `requires_gc` | string | no | Minimum compatible `gc` version metadata. |
+| `requires_gc` | string | no | Minimum compatible `gc` version metadata. Parsed and preserved; not currently enforced during load/import/doctor. |
 | `description` | string | no | Human-readable pack summary. |
 | `requires` | array of tables | no | Agent requirements validated after expansion. |
 
@@ -775,9 +778,10 @@ version selection, cache population, and lockfile update occur before or around
 loading. They must produce a concrete pack root directory whose `pack.toml` can
 be loaded by this specification.
 
-The `gc pack` command surface is registry discovery and local registry
-configuration: `gc pack registry add`, `list`, `remove`, `refresh`, `search`,
-and `show`.
+The `gc pack` command surface is registry discovery, local registry
+configuration, authentication, and publish submission: `gc pack registry add`,
+`list`, `remove`, `refresh`, `search`, `show`, `login`, `whoami`, and
+`publish`.
 
 Registry handles are not durable dependency coordinates. The shipped registry
 commands may accept a handle such as `main:gascity` while searching or

--- a/engdocs/design/packv2/README.md
+++ b/engdocs/design/packv2/README.md
@@ -1,5 +1,11 @@
 # PackV2 Engineering Design Notes
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/reference/specs/pack-spec.md`, `docs/guides/understanding-packs.md`,
+> and `docs/guides/shareable-packs.md`. When this note disagrees with shipped
+> behavior, prefer the current docs, generated reference, code, and tests.
+
 This directory contains PackV2 engineering design notes, rollout ledgers, and
 historical reconciliation docs. These files are not user-facing product
 documentation and should not be used as the primary source for authoring a new

--- a/engdocs/design/packv2/doc-agent-v2.md
+++ b/engdocs/design/packv2/doc-agent-v2.md
@@ -1,5 +1,11 @@
 # Agent Definition v.next
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/reference/specs/pack-spec.md`, `docs/guides/understanding-packs.md`,
+> and `docs/guides/shareable-packs.md`. When this note disagrees with shipped
+> behavior, prefer the current docs, generated reference, code, and tests.
+
 **GitHub Issue:** [gastownhall/gascity#356](https://github.com/gastownhall/gascity/issues/356)
 
 Title: `feat: Agent Definition v.next — agents as directories`

--- a/engdocs/design/packv2/doc-conformance-matrix.md
+++ b/engdocs/design/packv2/doc-conformance-matrix.md
@@ -1,5 +1,11 @@
 # Pack/City v2 Conformance Matrix
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/reference/specs/pack-spec.md`, `docs/guides/understanding-packs.md`,
+> and `docs/guides/shareable-packs.md`. When this note disagrees with shipped
+> behavior, prefer the current docs, generated reference, code, and tests.
+
 This document turns the reconciled pack/city v.next docs into an
 executable conformance plan for the current Pack/City v2 rollout.
 

--- a/engdocs/design/packv2/doc-directory-conventions.md
+++ b/engdocs/design/packv2/doc-directory-conventions.md
@@ -1,5 +1,11 @@
 # Pack Structure v.next
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/reference/specs/pack-spec.md`, `docs/guides/understanding-packs.md`,
+> and `docs/guides/shareable-packs.md`. When this note disagrees with shipped
+> behavior, prefer the current docs, generated reference, code, and tests.
+
 **GitHub Issue:** TBD
 
 Title: `feat: Pack structure v.next — principles and standard directory layout for packs and cities`

--- a/engdocs/design/packv2/doc-pack-v2.md
+++ b/engdocs/design/packv2/doc-pack-v2.md
@@ -1,5 +1,11 @@
 # Pack/City Model v.next
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/reference/specs/pack-spec.md`, `docs/guides/understanding-packs.md`,
+> and `docs/guides/shareable-packs.md`. When this note disagrees with shipped
+> behavior, prefer the current docs, generated reference, code, and tests.
+
 **GitHub Issue:** [gastownhall/gascity#360](https://github.com/gastownhall/gascity/issues/360) (supersedes [#159](https://github.com/gastownhall/gascity/issues/159))
 
 Title: `feat: Pack/City Model v.next — cities as packs, import model, managed state`

--- a/engdocs/design/packv2/doc-packman.md
+++ b/engdocs/design/packv2/doc-packman.md
@@ -1,5 +1,11 @@
 # City/Pack Import Management
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/reference/specs/pack-spec.md`, `docs/guides/understanding-packs.md`,
+> and `docs/guides/shareable-packs.md`. When this note disagrees with shipped
+> behavior, prefer the current docs, generated reference, code, and tests.
+
 **GitHub Issue:** TBD
 
 Title: `feat: gc import — import management for schema-2 Gas City packs`

--- a/engdocs/design/packv2/doc-rig-binding-phases.md
+++ b/engdocs/design/packv2/doc-rig-binding-phases.md
@@ -1,5 +1,11 @@
 # Rig Binding Phases
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/reference/specs/pack-spec.md`, `docs/guides/understanding-packs.md`,
+> and `docs/guides/shareable-packs.md`. When this note disagrees with shipped
+> behavior, prefer the current docs, generated reference, code, and tests.
+
 Doc state: transition truth
 
 GitHub issues:

--- a/engdocs/design/packv2/skew-analysis.md
+++ b/engdocs/design/packv2/skew-analysis.md
@@ -1,5 +1,11 @@
 # Spec vs. Implementation Skew Analysis — Current Pack/City v2 Desired State
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/reference/specs/pack-spec.md`, `docs/guides/understanding-packs.md`,
+> and `docs/guides/shareable-packs.md`. When this note disagrees with shipped
+> behavior, prefer the current docs, generated reference, code, and tests.
+
 > Generated 2026-04-12 by comparing `docs/reference/config.md` (as-built
 > from the release branch Go structs) against the reconciled pack v2 specs.
 > Revised through field-by-field walkthrough to reflect the **current


### PR DESCRIPTION
## Summary\n\n- supersedes stale/conflicting #3033 with current registry docs\n- adds a Public Registry Packs guide for first-party gascity-packs entries\n- documents cache freshness, `GC_REGISTRY_FRESHNESS`, `--refresh`, and the shipped `gc pack registry publish` namespace\n- clarifies `requires_gc` is parsed/preserved metadata, not an enforced load/import/doctor gate\n- marks PackV2 design notes as historical when they differ from current docs/code\n\n## Verification\n\n- make check-docs\n- git diff --check