### PR TITLE
test: stabilize event flock contention check

### DIFF
--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -1346,11 +1346,18 @@ func TestFileRecorderFlockSucceedsAfterShortContention(t *testing.T) {
 	if elapsed < 40*time.Millisecond {
 		t.Errorf("elapsed = %v, want >= %v", elapsed, 40*time.Millisecond)
 	}
-	if elapsed >= recordFlockTimeout {
-		t.Errorf("elapsed = %v, want < %v", elapsed, recordFlockTimeout)
-	}
 	if stderr.Len() != 0 {
 		t.Errorf("stderr = %q, want empty", stderr.String())
+	}
+	got, err := rec.List(Filter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("List returned %d events, want 1", len(got))
+	}
+	if got[0].Type != "test" {
+		t.Errorf("recorded event type = %q, want %q", got[0].Type, "test")
 	}
 }
 


### PR DESCRIPTION
## Summary\n- Fixes the RC Gate unit-core failure in TestFileRecorderFlockSucceedsAfterShortContention.\n- Replaces the scheduler-sensitive upper wall-clock assertion with a direct assertion that the event was recorded and no timeout was reported.\n\n## RC Gate Failure\n- Run: https://github.com/gastownhall/gascity/actions/runs/27489502905\n- Job: ubuntu / fast tests / unit-core\n- Failure: elapsed 296.643594ms exceeded the 250ms flock timeout assertion even though the short-contention write succeeded.\n\n## Verification\n- go test ./internal/events -run '^TestFileRecorderFlockSucceedsAfterShortContention$' -count=1\n- go test ./internal/events -count=1\n- git diff --check\n- pre-commit hook: lint-changed, generated docs/schema, go vet ./..., scripts/test-local-parallel fast\n\nNote: the triggering RC Gate still had its final acceptance C shard running when this PR was opened; all completed jobs had only this unit-core failure.