### PR TITLE
test(integration): raise bdInitTimeout 15s→60s for slower hosted runners

### DIFF
--- a/test/integration/bdstore_test.go
+++ b/test/integration/bdstore_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	bdInitTimeout          = 15 * time.Second
+	bdInitTimeout          = 60 * time.Second
 	doltServerStartupLimit = 10 * time.Second
 )
 


### PR DESCRIPTION
## What

Raise `bdInitTimeout` in `test/integration/bdstore_test.go` from **15s → 60s** (one const, line 24).

## Why — a contributor-only CI flake from the runner policy

`TestBdStoreConformance` budgets `bd init --server` at 15s (`bdInitTimeout`, used at `bdstore_test.go:149`/`:157` in `runBDInit` and `:167`/`:175` in `configureCustomTypes`). That budget is comfortable on the fast runners maintainers get, but tight-to-failing on the slower runners contributor PRs get:

- The `integration-sqlite-coordstore` job (`Integration / SQLite coordination store`) requests `runner_32vcpu` (`.github/workflows/ci.yml:482`).
- `.github/workflows/scripts/runner_policy.py` resolves that label by author: allowlisted PRs → `blacksmith-32vcpu-ubuntu-2404` (32 vCPU), everyone else → `ubuntu-latest` (GitHub-hosted, 2 vCPU). See `BLACKSMITH_RUNNERS` vs `GITHUB_RUNNERS` and the allowlist gate in `select_runners`.
- So on a **non-allowlist contributor PR**, this integration test runs on a 2-vCPU `ubuntu-latest`, where `bd init --server` (dolt sql-server spin-up, CGO-heavy) routinely takes >15s under CI load. The `context.WithTimeout(15s)` then cancels an init that was actually about to succeed.

The failure is timing, not logic — the captured output already contains `✓ bd initialized successfully!` immediately before `bd init timed out after 15s`. It surfaced on a recent contributor PR (#3458) as the sole red check (`Integration / SQLite coordination store`) with 78 other checks green, and is invisible on maintainer PRs because those run on the 32-vCPU Blacksmith backend where 15s is plenty.

## Fix

Bump to 60s — 4x headroom, in line with the repo's existing "supervisor not ready 60s"-class budgets. Test-only; no production code path changes. The adjacent `doltServerStartupLimit` (10s) is a separate concern and left untouched.

Corroborating prior art on bd/dolt init weight and startup races: #753, #2093, #2201.
