### PR TITLE
docs: fix public registry setup commands (follow-up to #3490)

### DIFF
--- a/docs/guides/registry-showcase.md
+++ b/docs/guides/registry-showcase.md
@@ -10,10 +10,10 @@ Gas City publishes first-party reusable packs through the public
 `pack.toml` files still record durable GitHub tree URLs plus an optional
 version constraint or pin.
 
-Add the public registry locally:
+The public `main` registry is configured by default, so there is nothing to
+add. Refresh its catalog before browsing:
 
 ```bash
-gc pack registry add main https://github.com/gastownhall/gascity-packs.git
 gc pack registry refresh main
 ```
 

--- a/docs/guides/shareable-packs.md
+++ b/docs/guides/shareable-packs.md
@@ -137,7 +137,7 @@ shape. The registry commands available in this release cover discovery, cache
 management, authentication, and publish submission:
 
 ```text
-gc pack registry add main https://github.com/gastownhall/gascity-packs.git
+gc pack registry add example https://raw.githubusercontent.com/gastownhall/gascity-packs/main/registry.toml
 gc pack registry refresh main
 gc pack registry search gastown
 gc pack registry show main:gastown
@@ -145,17 +145,17 @@ gc pack registry login
 gc pack registry publish .
 gc pack registry whoami
 gc pack registry list
-gc pack registry remove main
+gc pack registry remove example
 ```
 
 When a registry entry is used to add or migrate a pack, the durable
 `pack.toml` entry stores the entry's resolved `source` and optional `version`,
 not the registry handle.
 
-The first public registry is the `gascity-packs` catalog:
+The first public registry is the `gascity-packs` catalog, configured by default
+as the built-in `main` registry, so there is nothing to add:
 
 ```text
-gc pack registry add main https://github.com/gastownhall/gascity-packs.git
 gc pack registry refresh main
 gc pack registry search gascity
 gc pack registry show main:gascity


### PR DESCRIPTION
## Summary

Follow-up to #3490 (`docs: refresh public registry guidance`), which is **MERGED** into `main`.

When #3490 merged it carried the contributor commit but **not** the approved maintainer
review fix, so the merged docs still tell users to run an **invalid** registry setup
command. This PR lands only that dropped fix.

## What this changes

Removes the invalid instruction
`gc pack registry add main https://github.com/gastownhall/gascity-packs.git` from the
public registry guides and documents that `main` is the **built-in default registry**
(nothing to add — just `gc pack registry refresh main`). Where an explicit `add`
example is still useful, it now uses a non-default name and the catalog `registry.toml`
URL.

- `docs/guides/registry-showcase.md`
- `docs/guides/shareable-packs.md`

The review/fix loop on #3490 flagged this as a major issue: the documented
`gc pack registry add main <git-url>` fails with
`HTTPS registry source path must end with registry.toml`, because `main` is the
built-in registry (`internal/packregistry/config.go`: `DefaultRegistryName = "main"`,
default source = the raw `registry.toml` URL).

## Original PR context

- Original PR: #3490 — `docs: refresh public registry guidance`
- State: MERGED
- Configured base: `main`
- Original GitHub base: `main` (no base mismatch)

## Verification

- `make check-docs` (`go test ./test/docsync`) — pass
- `git diff --check` — clean
