### PR TITLE
test(beads): add integration test for non-ephemeral SetMetadata event recording

### DIFF
--- a/cmd/gc/city_discovery.go
+++ b/cmd/gc/city_discovery.go
@@ -32,7 +32,7 @@ func findCityWithOptions(dir string, opts cityDiscoveryOptions) (string, error) 
 		if citylayout.HasCityConfig(dir) {
 			return dir, nil
 		}
-		if legacy == "" && citylayout.HasRuntimeRoot(dir) && !isIgnoredLegacyRuntimeRoot(dir, opts.ignoredLegacyRuntime) {
+		if legacy == "" && !isCityDiscoveryCeiling(dir, opts.ceilingDirs) && citylayout.HasRuntimeRoot(dir) && !isIgnoredLegacyRuntimeRoot(dir, opts.ignoredLegacyRuntime) {
 			legacy = dir
 		}
 		if isCityDiscoveryCeiling(dir, opts.ceilingDirs) {
@@ -58,14 +58,18 @@ func implicitCityDiscoveryOptions() cityDiscoveryOptions {
 }
 
 func implicitCityDiscoveryCeilings() []string {
+	var paths []string
 	if raw := strings.TrimSpace(os.Getenv("GC_CEILING_DIRECTORIES")); raw != "" {
-		return normalizeDiscoveryPaths(strings.Split(raw, string(os.PathListSeparator)))
+		paths = append(paths, strings.Split(raw, string(os.PathListSeparator))...)
 	}
 	home, err := os.UserHomeDir()
-	if err != nil || strings.TrimSpace(home) == "" {
-		return nil
+	if err == nil && strings.TrimSpace(home) != "" {
+		paths = append(paths, home)
 	}
-	return normalizeDiscoveryPaths([]string{home})
+	if tmp := strings.TrimSpace(os.TempDir()); tmp != "" {
+		paths = append(paths, tmp)
+	}
+	return normalizeDiscoveryPaths(paths)
 }
 
 func implicitIgnoredLegacyRuntimeRoots() []string {

--- a/internal/beads/native_dolt_store_integration_test.go
+++ b/internal/beads/native_dolt_store_integration_test.go
@@ -11,6 +11,45 @@ import (
 	beadslib "github.com/steveyegge/beads"
 )
 
+// TestNativeDoltStoreRegularUpdateEventRecording verifies that calling
+// SetMetadata on a non-ephemeral bead succeeds. This exercises
+// RecordEventInTable on the regular events table, which regresses when the
+// INSERT omits the id column and the live schema has no DEFAULT for it.
+func TestNativeDoltStoreRegularUpdateEventRecording(t *testing.T) {
+	ctx := context.Background()
+	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))
+	if err != nil {
+		t.Skipf("upstream native beads storage unavailable: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := storage.Close(); err != nil {
+			t.Fatalf("close upstream storage: %v", err)
+		}
+	})
+	if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+		t.Fatalf("set issue prefix: %v", err)
+	}
+	store := newNativeDoltStoreWithStorageAndPrefix(storage, "update-event-regression", "gc")
+
+	bead, err := store.Create(Bead{Title: "regular update event regression bead"})
+	if err != nil {
+		t.Fatalf("Create bead: %v", err)
+	}
+	if bead.Ephemeral {
+		t.Fatalf("Ephemeral = true on regular bead, want false")
+	}
+	if err := store.SetMetadata(bead.ID, "gc.routed_to", "gascity/builder"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get bead after SetMetadata: %v", err)
+	}
+	if got.Metadata["gc.routed_to"] != "gascity/builder" {
+		t.Fatalf("Metadata[gc.routed_to] = %q, want %q", got.Metadata["gc.routed_to"], "gascity/builder")
+	}
+}
+
 func TestNativeDoltStoreRealBackendRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))

--- a/release-gates/ga-jqvmde-3-setmetadata-clean-gate.md
+++ b/release-gates/ga-jqvmde-3-setmetadata-clean-gate.md
@@ -1,0 +1,61 @@
+# Release Gate: ga-jqvmde.3 SetMetadata Clean Branch
+
+Date: 2026-06-14
+Bead: ga-jqvmde.3
+PR: https://github.com/gastownhall/gascity/pull/3498
+Branch: origin/builder/ga-jqvmde-1-setmetadata-clean
+Gate worktree: /tmp/gascity-deploy-ga-jqvmde3.tcBhYa
+
+## Candidate
+
+- Base checked: origin/main @ 89002ab38bfd45cf3b26e9fc2869638b7aac0353
+- Candidate head: 5caa698a16a8faca194347125303586c1fc01d08
+- Merge base: cecb8eee45a07627adfde1b14d997ae4e78d1bc6
+- Candidate commits:
+  - 5caa698a1 fix(city_discovery): add TMPDIR ceiling and guard legacy root at ceiling dirs
+  - add4c8376 test(beads): add integration test for non-ephemeral SetMetadata event recording
+- Candidate diff:
+  - M cmd/gc/city_discovery.go
+  - M internal/beads/native_dolt_store_integration_test.go
+- Explicitly excluded pack-pin paths produced no diff:
+  - docs/guides/gastown-config-recipes.md
+  - examples/gastown/city.toml
+  - examples/gastown/pack.toml
+  - examples/gastown/packs.lock
+  - go.mod
+  - go.sum
+  - internal/config/public_packs.go
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-ytud6c is closed with verdict `pass` for PR #3498. Superseded high-scope review ga-3cue96 is closed; the scope issue was addressed by the clean PR branch. |
+| 2 | Acceptance criteria met | PASS | `TestNativeDoltStoreRegularUpdateEventRecording` exists in `internal/beads/native_dolt_store_integration_test.go`, creates a non-ephemeral bead, calls `SetMetadata(bead.ID, "gc.routed_to", "gascity/builder")`, reloads, and verifies persisted metadata. Diff scope contains only the SetMetadata integration test plus the approved `cmd/gc/city_discovery.go` gate-remediation change. |
+| 3 | Tests pass | PASS | `go build -o /tmp/gc-ga-jqvmde3-smoke ./cmd/gc` PASS; `/tmp/gc-ga-jqvmde3-smoke --help` PASS; `go vet ./...` PASS; `make test` PASS in 432s with `observable go test: PASS log=/tmp/gascity-test.jsonl.2sKIqd`; `go test -tags=integration ./internal/beads -run '^TestNativeDoltStoreRegularUpdateEventRecording$' -count=1 -v` PASS with package `ok github.com/gastownhall/gascity/internal/beads 0.610s`. Gate logs: `/tmp/gascity-jqvmde3-gate-logs.LQcXAc`. |
+| 4 | No high-severity review findings open | PASS | The known high/critical scope review ga-3cue96 is closed as superseded by PR #3498. No open review bead was found for the current clean branch; ga-ytud6c records no blocking findings. |
+| 5 | Final branch is clean | PASS | Before gate artifact: `git status --short --branch` showed no uncommitted files in the isolated worktree. |
+| 6 | Branch diverges cleanly from main | PASS | Current `origin/main` is one commit ahead of the branch base (`89002ab38` ahead of merge base `cecb8eee4`). Non-mutating conflict check `git merge-tree --write-tree HEAD origin/main` succeeded and returned tree `badc07ba7dba06f96f39db33d28dd65f7584aa20`. |
+| 7 | Single feature theme | PASS | Commit set is one release unit: SetMetadata event-recording regression coverage plus the contained city discovery hermetic-test remediation needed for the standard gate. Pack-pin changes and agent-home worktree cleanup are absent from the PR diff. |
+
+## Commands
+
+```bash
+git rev-parse HEAD origin/main
+git merge-base HEAD origin/main
+git log --oneline origin/main..HEAD
+git log --oneline HEAD..origin/main
+git diff --name-status origin/main...HEAD
+git diff --check origin/main...HEAD
+git diff --name-status origin/main...HEAD -- docs/guides/gastown-config-recipes.md examples/gastown/city.toml examples/gastown/pack.toml examples/gastown/packs.lock go.mod go.sum internal/config/public_packs.go
+git merge-tree --write-tree HEAD origin/main
+go build -o /tmp/gc-ga-jqvmde3-smoke ./cmd/gc
+/tmp/gc-ga-jqvmde3-smoke --help
+go vet ./...
+make test
+go test -tags=integration ./internal/beads -run '^TestNativeDoltStoreRegularUpdateEventRecording$' -count=1 -v
+```
+
+## Decision
+
+PASS. Open/update PR #3498 with SetMetadata-only scope, push this gate artifact to the PR branch, close ga-jqvmde.3 with the PR URL, and route the merge request to mayor/mpr.


### PR DESCRIPTION
## What this changes

This adds integration coverage for non-ephemeral native Dolt bead metadata updates. The new test creates a regular bead, calls `SetMetadata` for `gc.routed_to`, reloads the bead, and verifies the metadata is persisted. That exercises the regular `events` table path that regressed when event insertion omitted the `id` column against schemas without a database default.

The branch also includes a small `gc` city-discovery hardening used by the test gate: temp-dir based tests now stop discovery at the OS temp directory ceiling instead of escaping into an ambient `/tmp/.gc` runtime root.

## Review notes

- The bead change is test-only: `internal/beads/native_dolt_store_integration_test.go`.
- `cmd/gc/city_discovery.go` changes discovery boundaries for temp-dir tests; it does not add a new user-facing command or config knob.
- The earlier Gastown pack-pin update and agent-home worktree cleanup changes are not part of this PR.

Release tracking: `ga-jqvmde.3`.

## Test plan

- [x] `go build -o /tmp/gc-ga-jqvmde3-smoke ./cmd/gc`
- [x] `/tmp/gc-ga-jqvmde3-smoke --help`
- [x] `go vet ./...`
- [x] `make test`
- [x] `go test -tags=integration ./internal/beads -run '^TestNativeDoltStoreRegularUpdateEventRecording$' -count=1 -v`
- [x] Release gate: [`release-gates/ga-jqvmde-3-setmetadata-clean-gate.md`](release-gates/ga-jqvmde-3-setmetadata-clean-gate.md)
