### PR TITLE
fix(wisp-autoclose): preserve molecule parked at human-gate on owner-bead close (#3474)

### DIFF
--- a/cmd/gc/wisp_autoclose.go
+++ b/cmd/gc/wisp_autoclose.go
@@ -93,23 +93,29 @@ func doWispAutocloseWith(store beads.Store, beadID string, stdout io.Writer) {
 // deliberately parked at an open descendant — e.g. a human-gate step plus the
 // finalize step it blocks. Such a subtree is designed to outlive the owner
 // dispatch/loop bead whose close triggered this hook, so force-closing it here
-// would steamroll the human checkpoint before the maintainer acts (the PR #3474
+// would steamroll the human checkpoint before the maintainer acts (the #3474
 // finalize defect).
 //
 // The predicate mirrors the terminality guard the sibling `gc molecule
-// autoclose` path already applies (autocloseMoleculeIfComplete): a subtree with
-// open descendants is left open, so the two close-time auto-closers agree. We
-// additionally require the attached root itself to still be open, because a
-// parked molecule is always live. An already-terminal root with leftover open
-// steps is an orphan, not a parked checkpoint, and still reaps — preserving the
-// descendant-cleanup intent this hook was built for. A stepless/ephemeral wisp
-// has zero descendants -> (true, 0) -> not parked -> still reaped.
+// autoclose` path applies (autocloseMoleculeIfComplete leaves a non-terminal
+// subtree open), so the two close-time auto-closers agree. We additionally
+// require the attached root itself to still be open: an already-terminal root
+// with leftover open steps is an orphan, not a parked checkpoint, and still
+// reaps — preserving the descendant-cleanup intent this hook was built for.
+//
+// subtreeTerminalExcludingRoot returns (true, 0) for a stepless/ephemeral wisp
+// (terminal, so not parked -> still reaped) and (false, 0) on a subtree-walk
+// error. We deliberately treat that walk error as parked, matching the
+// sibling's fail-safe `if !terminal { return }`: force-closing a possibly
+// human-pending subtree because a transient store read failed is the very
+// destructive behavior #3474 removes, and a genuinely complete wisp left open
+// on a read error is still reaped by the redundant later close paths.
 func attachedMoleculeIsParked(store beads.Store, attached beads.Bead) bool {
 	if convoycore.IsTerminalStatus(attached.Status) {
 		return false
 	}
-	terminal, descendants := subtreeTerminalExcludingRoot(store, attached.ID)
-	return !terminal && descendants > 0
+	terminal, _ := subtreeTerminalExcludingRoot(store, attached.ID)
+	return !terminal
 }
 
 func closeAttachedWispSubtree(store beads.Store, attached beads.Bead) (int, error) {

--- a/cmd/gc/wisp_autoclose.go
+++ b/cmd/gc/wisp_autoclose.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/sling"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 	"github.com/spf13/cobra"
@@ -68,6 +69,9 @@ func doWispAutocloseWith(store beads.Store, beadID string, stdout io.Writer) {
 	attachments, err := collectAttachedBeads(parent, store, beads.HandlesFor(store).Live)
 	if err == nil || len(attachments) > 0 {
 		for _, attached := range attachments {
+			if attachedMoleculeIsParked(store, attached) {
+				continue
+			}
 			closed, err := closeAttachedWispSubtree(store, attached)
 			if err != nil || closed == 0 {
 				continue
@@ -83,6 +87,29 @@ func doWispAutocloseWith(store beads.Store, beadID string, stdout io.Writer) {
 		return
 	}
 	fmt.Fprintf(stdout, "Auto-closed %d generated spec bead(s) on %s\n", closed, beadID) //nolint:errcheck // best-effort stdout
+}
+
+// attachedMoleculeIsParked reports whether the attached root is a live molecule
+// deliberately parked at an open descendant — e.g. a human-gate step plus the
+// finalize step it blocks. Such a subtree is designed to outlive the owner
+// dispatch/loop bead whose close triggered this hook, so force-closing it here
+// would steamroll the human checkpoint before the maintainer acts (the PR #3474
+// finalize defect).
+//
+// The predicate mirrors the terminality guard the sibling `gc molecule
+// autoclose` path already applies (autocloseMoleculeIfComplete): a subtree with
+// open descendants is left open, so the two close-time auto-closers agree. We
+// additionally require the attached root itself to still be open, because a
+// parked molecule is always live. An already-terminal root with leftover open
+// steps is an orphan, not a parked checkpoint, and still reaps — preserving the
+// descendant-cleanup intent this hook was built for. A stepless/ephemeral wisp
+// has zero descendants -> (true, 0) -> not parked -> still reaped.
+func attachedMoleculeIsParked(store beads.Store, attached beads.Bead) bool {
+	if convoycore.IsTerminalStatus(attached.Status) {
+		return false
+	}
+	terminal, descendants := subtreeTerminalExcludingRoot(store, attached.ID)
+	return !terminal && descendants > 0
 }
 
 func closeAttachedWispSubtree(store beads.Store, attached beads.Bead) (int, error) {

--- a/cmd/gc/wisp_autoclose_test.go
+++ b/cmd/gc/wisp_autoclose_test.go
@@ -168,6 +168,84 @@ func TestAttachedMoleculeIsParkedPreservesOnWalkError(t *testing.T) {
 	}
 }
 
+// walkFailOnceStore fails the subtree-walk ListByMetadata lookup for one root
+// on its FIRST call, then succeeds. It models a *transient* store read failure
+// (the fail-safe's documented trigger), which a persistent walkFailingStore
+// cannot: with a persistent failure the close path's own ListSubtree walk also
+// errors, so the subtree is preserved whether or not the fail-safe fires — the
+// regression hides. Failing exactly once makes the owner-close reap's parked-
+// check walk error while a later close-path walk would succeed, so an
+// end-to-end test can tell the fail-safe preserve apart from a no-op close.
+type walkFailOnceStore struct {
+	beads.Store
+	failID string
+	failed bool
+}
+
+func (s *walkFailOnceStore) ListByMetadata(filters map[string]string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	if !s.failed && filters[beadmeta.RootBeadIDMetadataKey] == s.failID {
+		s.failed = true
+		return nil, fmt.Errorf("subtree walk transiently unavailable for %s", s.failID)
+	}
+	return s.Store.ListByMetadata(filters, limit, opts...)
+}
+
+func TestWispAutoclosePreservesParkedMoleculeSubtreeOnWalkError(t *testing.T) {
+	// End-to-end fail-safe arm of the #3474 fix, driven through the full
+	// on_close hook (doWispAutocloseWith) rather than the predicate alone.
+	// A molecule parked at an open human-gate plus the finalize step it blocks
+	// is attached to a dispatch/loop bead; when that owner bead closes and the
+	// parked-check subtree walk errors transiently, the whole parked subtree
+	// must be PRESERVED, never force-closed.
+	//
+	// The walk fails exactly once (walkFailOnceStore): the parked-check walk
+	// errors, but the reap's own close-path walk would succeed. So if the
+	// fail-safe regressed to `!terminal && descendants > 0`, the parked-check
+	// would misclassify the (false, 0) walk-error result as not-parked and the
+	// now-succeeding close walk would force-close gc-2..gc-4 — destroying the
+	// gate-close -> finalize handoff #3474 protects. With the fail-safe intact
+	// the close path is never reached and the subtree survives. This is the
+	// end-to-end coverage TestAttachedMoleculeIsParkedPreservesOnWalkError pins
+	// only at the predicate.
+	base := beads.NewMemStore()
+	_, _ = base.Create(beads.Bead{
+		Title:    "dispatch/loop bead",
+		Metadata: map[string]string{"molecule_id": "gc-2"},
+	}) // gc-1
+	_, _ = base.Create(beads.Bead{Title: "molecule root", Type: "molecule"}) // gc-2 (open, parked)
+	_, _ = base.Create(beads.Bead{
+		Title:    "human-gate",
+		Type:     "task",
+		ParentID: "gc-2",
+		Metadata: map[string]string{"gc.step_ref": "mol-adopt-pr.human-gate"},
+	}) // gc-3 (open, parked gate)
+	_, _ = base.Create(beads.Bead{
+		Title:    "finalize",
+		Type:     "task",
+		ParentID: "gc-2",
+		Metadata: map[string]string{"gc.step_ref": "mol-adopt-pr.finalize"},
+	}) // gc-4 (open, blocked by the gate)
+	_ = base.Close("gc-1")
+
+	store := &walkFailOnceStore{Store: base, failID: "gc-2"}
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, "gc-1", &stdout)
+
+	if stdout.String() != "" {
+		t.Fatalf("walk-error fail-safe must not auto-close parked molecule, got %q", stdout.String())
+	}
+	for _, id := range []string{"gc-2", "gc-3", "gc-4"} {
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if b.Status != "open" {
+			t.Fatalf("%s status = %q, want open (parked subtree preserved under walk error)", id, b.Status)
+		}
+	}
+}
+
 func TestWispAutocloseChecksDescendantsWhenAttachedRootAlreadyClosed(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{

--- a/cmd/gc/wisp_autoclose_test.go
+++ b/cmd/gc/wisp_autoclose_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -126,6 +128,43 @@ func TestWispAutocloseForceClosesTerminalMoleculeSubtree(t *testing.T) {
 	}
 	if root.Status != "closed" {
 		t.Fatalf("molecule root status = %q, want closed", root.Status)
+	}
+}
+
+// walkFailingStore makes the subtree walk in subtreeTerminalExcludingRoot ->
+// molecule.ListSubtree fail for one root, by erroring its logical-member
+// ListByMetadata lookup. It models a transient store read failure while the
+// root bead itself is still resolvable.
+type walkFailingStore struct {
+	beads.Store
+	failID string
+}
+
+func (s *walkFailingStore) ListByMetadata(filters map[string]string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	if filters[beadmeta.RootBeadIDMetadataKey] == s.failID {
+		return nil, fmt.Errorf("subtree walk unavailable for %s", s.failID)
+	}
+	return s.Store.ListByMetadata(filters, limit, opts...)
+}
+
+func TestAttachedMoleculeIsParkedPreservesOnWalkError(t *testing.T) {
+	// Fail-safe arm of the #3474 fix: when the subtree walk errors (a transient
+	// store read failure), the attached molecule must be classified as parked
+	// and preserved, not force-closed. subtreeTerminalExcludingRoot maps a walk
+	// error to (false, 0); the guard must treat that as parked, mirroring the
+	// sibling autocloseMoleculeIfComplete's `if !terminal { return }`. This is
+	// the only behavior that distinguishes the guard from the dropped
+	// `&& descendants > 0` clause — end-to-end the close path's own walk also
+	// fails on a persistent error, so it must be pinned at the predicate.
+	base := beads.NewMemStore()
+	root, err := base.Create(beads.Bead{Title: "molecule root", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	store := &walkFailingStore{Store: base, failID: root.ID}
+
+	if !attachedMoleculeIsParked(store, root) {
+		t.Fatal("attachedMoleculeIsParked = false on subtree walk error, want true (fail-safe preserve)")
 	}
 }
 

--- a/cmd/gc/wisp_autoclose_test.go
+++ b/cmd/gc/wisp_autoclose_test.go
@@ -56,31 +56,76 @@ func TestWispAutocloseClosesMetadataAttachedMolecule(t *testing.T) {
 	}
 }
 
-func TestWispAutocloseClosesAttachedMoleculeDescendants(t *testing.T) {
+func TestWispAutoclosePreservesParkedMoleculeSubtree(t *testing.T) {
+	// Regression for PR #3474: when a dispatch/loop bead closes, the
+	// on_close wisp-autoclose hook must NOT force-close an attached molecule that
+	// is parked at an open human-gate plus the finalize step it blocks. The
+	// molecule root is still open (live, awaiting the maintainer), so the whole
+	// subtree must survive — otherwise the gate-close -> finalize handoff is
+	// destroyed before the human ever acts.
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{
-		Title:    "work item",
+		Title:    "dispatch/loop bead",
 		Metadata: map[string]string{"molecule_id": "gc-2"},
 	}) // gc-1
-	_, _ = store.Create(beads.Bead{Title: "molecule root", Type: "molecule"})        // gc-2
-	_, _ = store.Create(beads.Bead{Title: "step", Type: "task", ParentID: "gc-2"})   // gc-3
-	_, _ = store.Create(beads.Bead{Title: "nested", Type: "task", ParentID: "gc-3"}) // gc-4
+	_, _ = store.Create(beads.Bead{Title: "molecule root", Type: "molecule"}) // gc-2 (open, parked)
+	_, _ = store.Create(beads.Bead{
+		Title:    "human-gate",
+		Type:     "task",
+		ParentID: "gc-2",
+		Metadata: map[string]string{"gc.step_ref": "mol-adopt-pr.human-gate"},
+	}) // gc-3 (open, parked gate)
+	_, _ = store.Create(beads.Bead{
+		Title:    "finalize",
+		Type:     "task",
+		ParentID: "gc-2",
+		Metadata: map[string]string{"gc.step_ref": "mol-adopt-pr.finalize"},
+	}) // gc-4 (open, blocked by the gate)
 	_ = store.Close("gc-1")
 
 	var stdout bytes.Buffer
 	doWispAutocloseWith(store, "gc-1", &stdout)
 
-	if !strings.Contains(stdout.String(), "Auto-closed molecule gc-2 on gc-1") {
-		t.Fatalf("stdout = %q, want metadata auto-close message", stdout.String())
+	if stdout.String() != "" {
+		t.Fatalf("parked molecule must not be auto-closed, got %q", stdout.String())
 	}
 	for _, id := range []string{"gc-2", "gc-3", "gc-4"} {
 		b, err := store.Get(id)
 		if err != nil {
 			t.Fatalf("Get(%s): %v", id, err)
 		}
-		if b.Status != "closed" {
-			t.Fatalf("%s status = %q, want closed", id, b.Status)
+		if b.Status != "open" {
+			t.Fatalf("%s status = %q, want open (parked subtree preserved)", id, b.Status)
 		}
+	}
+}
+
+func TestWispAutocloseForceClosesTerminalMoleculeSubtree(t *testing.T) {
+	// A molecule whose descendants are all terminal is genuinely complete — no
+	// parked checkpoint remains — so the owner-close reap still force-closes the
+	// open root. Preserves the original wisp-cleanup intent for finished work.
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{
+		Title:    "dispatch/loop bead",
+		Metadata: map[string]string{"molecule_id": "gc-2"},
+	}) // gc-1
+	_, _ = store.Create(beads.Bead{Title: "molecule root", Type: "molecule"})      // gc-2 (open)
+	_, _ = store.Create(beads.Bead{Title: "step", Type: "task", ParentID: "gc-2"}) // gc-3 (terminal)
+	_ = store.Close("gc-3")
+	_ = store.Close("gc-1")
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, "gc-1", &stdout)
+
+	if !strings.Contains(stdout.String(), "Auto-closed molecule gc-2 on gc-1") {
+		t.Fatalf("stdout = %q, want auto-close message for terminal subtree", stdout.String())
+	}
+	root, err := store.Get("gc-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root.Status != "closed" {
+		t.Fatalf("molecule root status = %q, want closed", root.Status)
 	}
 }
 


### PR DESCRIPTION
## Problem

The bd `on_close` hook runs `gc wisp autoclose <dispatch/loop-bead>`, which force-closes the whole subtree of any attached molecule via `molecule.CloseSubtree` with **no terminality guard**. When a dispatch/loop bead auto-closes (`loop_close: auto`) while its attached molecule is parked at an open human-gate plus the finalize step that gate blocks, the parked subtree is force-closed before the maintainer acts. That destroys the gate-close → finalize handoff (finalize is already closed, so closing the gate triggers nothing) and the auto-merge never fires.

Reported as #3474; reproduced live. The sibling auto-closer in the same hook chain (`gc molecule autoclose`) already guards with `subtreeTerminalExcludingRoot` and leaves a non-terminal molecule open — the two close-time paths disagreed.

## Fix

Before force-closing an attached molecule, skip it when it is a live (still-open) root whose subtree is non-terminal — reusing the existing `subtreeTerminalExcludingRoot` helper rather than adding a formula-side gate marker. `CloseSubtree` is untouched; this only makes the two close paths agree.

The guard predicate is `return !terminal`. `subtreeTerminalExcludingRoot` deliberately maps a subtree **walk error** to `(terminal=false)` so the caller fails safe and leaves the root open; the predicate honors that — a transient store error during the walk preserves the subtree rather than force-closing possibly human-pending work.

## Tests

- `TestWispAutoclosePreservesParkedMoleculeSubtree` — parked human-gate/finalize subtree is preserved on owner-bead close.
- `TestWispAutocloseForceClosesTerminalMoleculeSubtree` — a fully-terminal subtree still reaps.
- `TestAttachedMoleculeIsParkedPreservesOnWalkError` — fail-safe on subtree-walk error.

Existing `CloseSubtree` / descendant-cleanup tests unchanged and green.
