### PR TITLE
docs: align 1.3 pack import guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,23 +63,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a runtime/pack mismatch fails in gascity CI.
 
 - **The bundled maintenance pack was folded into the core pack, and builtin
-  packs are no longer implicitly included.** There is now one builtin pack —
-  core — carrying everything any city needs: the gc-* skills, default worker
-  prompts, core formulas, the mechanical housekeeping orders that used to
-  ship in the maintenance pack (gate-sweep, orphan-sweep, cross-rig-deps,
-  order-tracking-sweep, spawn-storm-detect, prune-branches, wisp-compact,
-  nudge-mail-sweep, nudge-on-route, cascade-nudge-on-blocker-close), the
-  check-binaries doctor check, and the per-provider hook overlays. Config
-  load no longer splices builtin packs into composition: `gc init` writes
-  explicit includes into city.toml (`[workspace] includes =
-  [".gc/system/packs/core", ".gc/system/packs/bd"]`; the bd entry only for
-  bd-provider cities), and the new fixable `builtin-pack-includes` doctor
-  check repairs missing includes and removes stale
-  `.gc/system/packs/maintenance` references. Config load still self-heals
-  the materialized `.gc/system/packs` content and warns once per city when a
-  required builtin include is missing. **Migration:** run
-  `gc doctor --fix` once per existing city; stale materialized maintenance
-  directories are pruned automatically.
+  packs compose only through explicit pinned imports.** The bundled `core`
+  pack carries the gc-* skills, default worker prompts, core formulas, the
+  mechanical housekeeping orders that used to ship in the maintenance pack
+  (gate-sweep, orphan-sweep, cross-rig-deps, order-tracking-sweep,
+  spawn-storm-detect, prune-branches, wisp-compact, nudge-mail-sweep,
+  nudge-on-route, cascade-nudge-on-blocker-close), the check-binaries doctor
+  check, and the per-provider hook overlays. Config load no longer splices
+  builtin packs into composition: `gc init` writes explicit `[imports.core]`
+  and, for default bd-provider cities, `[imports.bd]` entries into
+  `pack.toml`, plus a matching `packs.lock`. The fixable
+  `builtin-pack-imports` doctor check repairs missing imports and migrates
+  legacy `workspace.includes = [".gc/system/packs/..."]` cities by stripping
+  those includes, adding the pinned imports, and pruning stale
+  `.gc/system/packs` materialization. **Migration:** run `gc doctor --fix`
+  once per existing city.
 - **The implicit fallback dog is gone, and the `fallback` agent field was
   removed.** The gastown pack now owns its dog pool outright
   (`agents/dog/`, themed, with `mol-shutdown-dance`), and the dolt pack

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -58,9 +58,10 @@ $ gc init ~/my-city
 Welcome to Gas City SDK!
 
 Choose a config template:
-  1. minimal   — default coding agent (default)
-  2. gastown   — multi-agent orchestration pack
-  3. custom    — empty workspace, configure it yourself
+  1. gascity   — planning & implementation skills pack (default)
+  2. minimal   — default coding agent
+  3. gastown   — multi-agent orchestration pack
+  4. custom    — empty workspace, configure it yourself
 Template [1]:
 
 Choose your coding agent:
@@ -74,7 +75,7 @@ Agent: 1
 [3/8] Writing default prompts
 [4/8] Writing pack.toml
 [5/8] Writing city configuration
-Created minimal config (Level 1) in "my-city".
+Created gascity config (Level 1) in "my-city".
 [6/8] Checking provider readiness
 [7/8] Registering city with supervisor
 Registered city 'my-city' (/Users/csells/my-city)
@@ -118,10 +119,10 @@ At the top level of the city directory:
 - `pack.toml` — the portable pack definition layer
 - `city.toml` — city-local deployment and runtime settings
 
-This city comes with a built-in `mayor` agent. The mayor's prompt lives at
+This city comes with a city-local `mayor` agent. The mayor's prompt lives at
 `agents/mayor/prompt.template.md`, and `pack.toml` defines the always-on mayor
-session that uses it. Assuming you chose the default `minimal` config
-template and Claude Code, `city.toml` keeps the shared runtime settings:
+session that uses it. Assuming you chose the default `gascity` config template
+and Claude Code, `city.toml` keeps the shared runtime settings:
 
 ```shell
 ~/my-city
@@ -157,6 +158,10 @@ version = "sha:<pinned commit>"
 source = "https://github.com/gastownhall/gascity.git//examples/bd"
 version = "sha:<pinned commit>"
 
+[imports.gascity]
+source = "https://github.com/gastownhall/gascity-packs/tree/main/gascity"
+version = "sha:<pinned commit>"
+
 [[named_session]]
 template = "mayor"
 mode = "always"
@@ -167,27 +172,28 @@ the provider. The `[providers.claude]` table registers your chosen provider
 against the builtin `claude` preset, and `[daemon]`'s `formula_v2 = true`
 turns on the v2 formula compiler — the default for new cities (you'll meet
 formulas in [Tutorial 05](/tutorials/05-formulas)). The `[imports]` entries
-in `pack.toml` pin the builtin packs bundled with the `gc` binary: `core`
-(housekeeping orders, doctor checks, default prompts, and core formulas) and
-— for cities on the default `bd` beads provider — `bd`, which brings in its
-`dolt` helper pack. They resolve offline from the user-global pack cache,
-which the binary keeps hydrated with its own embedded content. If these
+in `pack.toml` are explicit pack composition, not hidden load-time behavior.
+`core` and, for cities on the default `bd` beads provider, `bd` are bundled
+system packs that resolve offline from the user-global pack cache. The
+`gascity` import is the public planning and implementation skills pack pinned
+to the registry release embedded with this `gc` binary. If required builtin
 imports go missing, `gc doctor --fix` restores them. The machine-local
 workspace identity lives in `.gc/site.toml` instead, which is how `gc
 cities`, `gc status`, and other commands still know this city is named
 `my-city`.
 
-The built-in `mayor` comes from the scaffolded `agents/mayor/` content, and
-`[[named_session]]` keeps a `mayor` session running so you can talk to it at
-any time. When you add more agents later, Gas City creates `agents/<name>/`,
-with `prompt.template.md` for the prompt and `agent.toml` for any per-agent
+The `mayor` session comes from the scaffolded `agents/mayor/` content and the
+explicit `[[named_session]]` entry, so you can talk to it at any time. When
+you add more agents later, Gas City creates `agents/<name>/`, with
+`prompt.template.md` for the prompt and `agent.toml` for any per-agent
 overrides.
 
-Gas City also gives you an implicit agent for each provider declared in
-`city.toml`'s `[providers]` table — so `claude` is available as an agent name
-(and, once you add a rig, `<rig>/claude`) even though it's not listed in
-`pack.toml`. Implicit agents use the core pack's stock pool-worker prompt and
-get `mol-do-work` as their default sling formula — more on that in a moment.
+Gas City also derives a worker template for each provider declared in
+`city.toml`'s `[providers]` table — so `claude` is available as a template
+name (and, once you add a rig, `<rig>/claude`) even though it is not a
+hardcoded role. Provider-derived workers use the core pack's stock
+pool-worker prompt and get `mol-do-work` as their default sling formula —
+more on that in a moment.
 
 To check on the status of your city, use `gc status`:
 
@@ -218,9 +224,9 @@ materializes it; once the mayor session is up, its state reads `awake` (or
 `active` — the two are equivalent).
 
 The `dolt.dog` pool is a background utility agent from the bundled `dolt` pack
-(pulled in through the `bd` include you saw in `city.toml` — the `dolt.`
-prefix is the import binding it arrived through). It handles Dolt database
-housekeeping for the beads backend. `control-dispatcher` is SDK
+(pulled in transitively through the explicit `bd` import you saw in
+`pack.toml` — the `dolt.` prefix is the import binding it arrived through).
+It handles Dolt database housekeeping for the beads backend. `control-dispatcher` is SDK
 infrastructure: the controller uses it to advance formula workflows. You don't
 need to interact with either — ignore them for now.
 

--- a/docs/tutorials/05-formulas.md
+++ b/docs/tutorials/05-formulas.md
@@ -108,11 +108,13 @@ mol-scoped-work
 pancakes
 ```
 
-Your fresh city carries several built-in `mol-*` formulas that ship with the
-bundled core and dolt packs (polecat worker scaffolds, review workflows, Dolt
-watchdog workflows, etc.).
-The list above shows those built-ins alongside the `pancakes` you just
-defined — the exact set may grow as new built-ins land, so expect your
+Your fresh city composes several `mol-*` formulas from the explicit imports
+that `gc init` wrote: bundled system packs such as `core` and `bd`/`dolt`,
+plus the default `gascity` methodology pack. Those imports provide the stock
+worker workflow, Dolt maintenance workflows, and planning or implementation
+workflows.
+The list above shows imported formulas alongside the `pancakes` you just
+defined — the exact set may grow as pack releases change, so expect your
 output to include additional `mol-*` entries.
 
 To see the compiled recipe for a specific formula:


### PR DESCRIPTION
## Summary
- update the 1.3 changelog wording for explicit pinned builtin imports
- refresh Tutorial 01 so default `gc init` shows the `gascity` template and `[imports.gascity]`
- reword Tutorial 05 formula discovery around explicit imports instead of implicit built-ins

## Verification
- `git diff --check`
- `make check-docs`
- `go test ./cmd/gc -run 'Test(DefaultWizardConfigUsesGascityTemplate|RunWizardBlankTemplateChoiceUsesGascity|DoInitDefaultTemplateImportsGascityPack|DoInitWithGascityTemplate|CityInitExactOutput_DefaultScaffold)$'`\n