### PR TITLE
feat(docs): add CI hardening to reject GitHub-friendly docs reformatting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,8 +17,5 @@
 /cmd/gc/dashboard/web/package.json @gastownhall/gascity-admin
 /cmd/gc/dashboard/web/package-lock.json @gastownhall/gascity-admin
 
-# Selected public docs areas are owned by csells.
-/docs/getting-started/ @csells
-/docs/guides/ @csells
-/docs/troubleshooting/ @csells
-/docs/tutorials/ @csells
+# All docs/ is owned by csells (auto-requests review on any docs-touching PR).
+/docs/ @csells

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 
 - [ ] `make check`
 - [ ] `make check-docs` if docs, navigation, or links changed
+  > **Note:** `docs/` is authored for [docs.gascityhall.com](https://docs.gascityhall.com) (Mintlify), not for direct GitHub viewing. Use extensionless page links (e.g. `/tutorials/01-beads`, not `/tutorials/01-beads.md`). If something looks broken on GitHub but works on the live site, that's intentional.
 - [ ] `make test-integration` if runtime, controller, or workflow behavior changed
 
 ## Checklist

--- a/.github/scripts/docs-render-check.sh
+++ b/.github/scripts/docs-render-check.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# docs-render-check.sh — baseline-aware Mintlify broken-link check for CI.
+#
+# Runs `mint broken-links` on the HEAD docs tree. When the HEAD has broken
+# page links, materializes the BASE docs tree (via git archive) and reports
+# only NET-NEW breakage — links that the PR introduced, not pre-existing ones.
+# Static-asset refs (.png/.svg/.jpg/.gif) are excluded: mint over-reports
+# in-tree images the published build serves fine.
+#
+# Usage:
+#   docs-render-check.sh [<base-ref>]
+#
+#   <base-ref>  The base branch/sha to compare against (default: origin/main).
+#               Enables baseline-aware net-new detection.
+#
+# Exit codes:
+#   0 — no net-new page-link regressions
+#   1 — net-new page-link regressions found; details on stdout
+#
+# Requires: git, npx (Node.js), jq
+#
+set -euo pipefail
+
+DOCS_DIR="docs"
+DOCS_CONFIG="$DOCS_DIR/docs.json"
+BASE_REF="${1:-origin/main}"
+MINT_CMD="${MINT_CMD:-npx --yes mint@latest}"
+
+WORK_TMP="$(mktemp -d)"
+trap 'rm -rf "$WORK_TMP"' EXIT
+
+# Verify we have a Mintlify docs tree.
+if [[ ! -f "$DOCS_CONFIG" ]]; then
+    echo "docs-render-check: no docs/docs.json found — skipping" >&2
+    exit 0
+fi
+
+# --- extract_page_links <mint-output-file> -----------------------------------
+# Parse `mint broken-links` output lines. Each broken link looks like:
+#   [broken-links]  tutorials/01-beads.md  ->  /tutorials/01-beads.md
+# or
+#   ✗  /tutorials/01-beads.md
+# We capture only page links (no static-asset extensions).
+ASSET_EXTS='\.png$|\.svg$|\.jpg$|\.jpeg$|\.gif$|\.ico$|\.webp$|\.woff2?$|\.ttf$|\.eot$'
+
+extract_page_links() {
+    local file="$1"
+    grep -oE '[^ ]+\.[a-z]+$|/[^ ]+' "$file" 2>/dev/null \
+        | grep -vE "$ASSET_EXTS" \
+        | sort -u || true
+}
+
+# Alternative simpler extraction: just lines with the broken-links marker.
+parse_mint_broken_links() {
+    local file="$1"
+    # mint outputs lines like: "  ✗  /path/to/page" or "  ✗  page-slug"
+    # or with indentation. Grab any token that looks like a link (starts with /).
+    grep -E '✗|broken|BROKEN|error|ERROR' "$file" 2>/dev/null \
+        | grep -oE '[/][^ )]+' \
+        | grep -vE "$ASSET_EXTS" \
+        | sort -u || true
+}
+
+# --- run_mint <docs-root> <output-file> → exit code -------------------------
+run_mint() {
+    local root="$1"
+    local out="$2"
+    cd "$root"
+    if $MINT_CMD broken-links >"$out" 2>&1; then
+        cd - >/dev/null
+        return 0
+    fi
+    cd - >/dev/null
+    return 1
+}
+
+HEAD_OUT="$WORK_TMP/head-mint.txt"
+BASE_OUT="$WORK_TMP/base-mint.txt"
+BASE_TREE="$WORK_TMP/base-docs"
+
+# --- HEAD check --------------------------------------------------------------
+HEAD_EXIT=0
+run_mint "." "$HEAD_OUT" || HEAD_EXIT=$?
+
+if [[ $HEAD_EXIT -eq 0 ]]; then
+    echo "docs-render-check: no broken links in HEAD — PASS" >&2
+    exit 0
+fi
+
+HEAD_LINKS="$WORK_TMP/head-links.txt"
+parse_mint_broken_links "$HEAD_OUT" | sort -u >"$HEAD_LINKS"
+
+if [[ ! -s "$HEAD_LINKS" ]]; then
+    # mint exited non-zero but no links we care about. Pass.
+    echo "docs-render-check: mint non-zero but no page-link regressions detected — PASS" >&2
+    exit 0
+fi
+
+# --- BASE check (baseline-aware) --------------------------------------------
+mkdir -p "$BASE_TREE"
+if git archive "$BASE_REF" -- "$DOCS_DIR" 2>/dev/null | tar -x -C "$BASE_TREE"; then
+    BASE_EXIT=0
+    run_mint "$BASE_TREE" "$BASE_OUT" || BASE_EXIT=$?
+    BASE_LINKS="$WORK_TMP/base-links.txt"
+    parse_mint_broken_links "$BASE_OUT" | sort -u >"$BASE_LINKS"
+    # Net-new = in HEAD but NOT in BASE.
+    NEW_LINKS="$WORK_TMP/new-links.txt"
+    comm -23 "$HEAD_LINKS" "$BASE_LINKS" >"$NEW_LINKS"
+else
+    echo "docs-render-check: could not materialize base tree from $BASE_REF — checking HEAD only" >&2
+    cp "$HEAD_LINKS" "$WORK_TMP/new-links.txt"
+    NEW_LINKS="$WORK_TMP/new-links.txt"
+fi
+
+if [[ ! -s "$NEW_LINKS" ]]; then
+    echo "docs-render-check: broken links exist but none are net-new — PASS (pre-existing baseline)" >&2
+    exit 0
+fi
+
+# --- NET-NEW regressions found — fail with csells's explanation --------------
+echo ""
+echo "::error::docs-render-check: net-new broken Mintlify page links detected"
+echo ""
+echo "The following page links are newly broken by this PR:"
+while IFS= read -r link; do
+    echo "  $link"
+done <"$NEW_LINKS"
+echo ""
+echo "──────────────────────────────────────────────────────────────────────────"
+echo "docs/ is authored for the Mintlify site (https://docs.gascityhall.com),"
+echo "not for direct GitHub viewing. These paths/links are intentional —"
+echo "please don't reformat them for GitHub. If something is genuinely broken"
+echo "on the live site, note it in the PR and we'll fix it Mintlify-side."
+echo "──────────────────────────────────────────────────────────────────────────"
+exit 1

--- a/.github/workflows/docs-render.yml
+++ b/.github/workflows/docs-render.yml
@@ -1,0 +1,33 @@
+name: Docs render check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-render-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  broken-links:
+    name: Mintlify broken-links (baseline-aware)
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
+        with:
+          node-version: '20'
+
+      - name: Run baseline-aware broken-link check
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: .github/scripts/docs-render-check.sh "$BASE_REF"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,37 @@ When updating docs:
 - Updating `GastownCity()`'s `Imports` or `DefaultRigImports` map requires
   updating the auto-import table in `engdocs/design/packv2/migration.mdx`
 
+### Docs link conventions
+
+`docs/` is published to **[docs.gascityhall.com](https://docs.gascityhall.com)**
+via Mintlify — it is **not** meant to be read directly on GitHub. The published
+site serves **route-based, extensionless URLs**, so internal page links must be
+written that way:
+
+| Context | Correct | Wrong |
+|---|---|---|
+| `docs/` page link (Mintlify) | `/tutorials/01-beads` | `/tutorials/01-beads.md` |
+| `engdocs/` and root `.md` (GitHub-only) | `engdocs/architecture/index.md` | `engdocs/architecture/index` |
+
+**Why this matters — and why you usually do _not_ want to "fix" a docs path:**
+a `.md`/`.mdx` suffix on a `docs/` page link breaks Mintlify navigation on the
+live site **even though the file exists on disk**. A link that looks "broken" on
+GitHub is very often correct for the deployed site, so reformatting `docs/` links
+to be GitHub-friendly is the most common way to *silently break the published
+docs*.
+
+Two checks enforce this, both failing **only on net-new** breakage your change
+introduces (pre-existing issues won't block you):
+
+- `make check-docs` (`test/docsync`) — on-disk check that `docs/` page links are
+  extensionless and that `engdocs/`/root links resolve.
+- The **Docs render check** CI Action (`.github/workflows/docs-render.yml`) —
+  runs Mintlify's own `broken-links` against your branch vs `main`.
+
+If a `docs/` link is **genuinely** broken on the live site, note it in your PR
+and a maintainer will fix it Mintlify-side — don't change the on-disk path to
+work around GitHub rendering.
+
 ## Make Targets
 
 Run `make help` for the full list. The most useful targets are:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Run `make help` for the full list. The most useful targets are:
 | `make build` | Build `gc` with version metadata |
 | `make install` | Install `gc` into `$(go env GOPATH)/bin` |
 | `make check` | Fast Go quality gates |
-| `make check-docs` | Docs sync tests plus Mintlify broken-link checks |
+| `make check-docs` | Docs sync tests (on-disk link checker; does not run `mint broken-links`) |
 | `make check-all` | Extended quality gates including integration tests |
 | `make test` | Unit and repo-level Go tests |
 | `make test-integration` | Integration tests |

--- a/release-gates/ga-jfva11-docs-ci-hardening-gate.md
+++ b/release-gates/ga-jfva11-docs-ci-hardening-gate.md
@@ -1,44 +1,48 @@
-# Release Gate: docs-CI hardening
+# Release Gate: docs CI hardening
 
-- Deploy bead: `ga-jfva11`
+- Deploy bead: `ga-bzzvst`
 - Source build bead: `ga-y7r05r`
-- Review bead: `ga-9r4k04`
+- Review bead: `ga-w8a0v2`
 - Source branch: `builder/ga-y7r05r`
 - PR: https://github.com/gastownhall/gascity/pull/3504
-- Base tip checked: `origin/main` at `e02391fe7f0b4281cd10afc4f9293412467f529d`
+- Gate run: `2026-06-15T11:19:55-07:00`
+- Base tip checked: `origin/main` at `1ff917a8913d69443392829c26a2b9f2e2196ab8`
 - Branch merge base: `a52bb3626da330c3ef2718a48a448751432753d1`
-- Source commit checked: `8b713e4f65ac90034b078c697cc54aa5f767f4be`
+- Reviewed source tip checked: `e3e24a21502464b1253654beac50b6b31c6b8538`
 - Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so the deployer release criteria from the handoff prompt were used.
+- File note: this path is retained because PR #3504 already links it; this content supersedes the earlier gate evidence on the branch.
 
 ## Gate Criteria
 
 | # | Criterion | Verdict | Evidence |
 |---|-----------|---------|----------|
-| 1 | Review PASS present | PASS | Review bead `ga-9r4k04` is closed and notes `Review verdict: PASS` for source commit `8b713e4f65ac90034b078c697cc54aa5f767f4be`. |
-| 2 | Acceptance criteria met | PASS | See acceptance evidence below. |
-| 3 | Tests pass | PASS | `make check-docs`, `go test ./test/docsync`, negative `TestLocalMarkdownLinks` smoke, `BASE_REF=origin/main .github/scripts/docs-render-check.sh origin/main`, `make test`, and `go vet ./...` all completed as expected. PR #3504 status checks were rechecked and all non-skipped checks were successful. |
-| 4 | No high-severity review findings open | PASS | Review notes list only low/info follow-ups; unresolved HIGH findings count is 0. |
-| 5 | Final branch is clean | PASS | Gate ran in a clean detached worktree; after the gate commit, deployer rechecked `git status --short --branch` before push. |
-| 6 | Branch diverges cleanly from main | PASS | PR #3504 reported `mergeStateStatus: CLEAN`, and `git merge-tree --write-tree origin/main HEAD` exited 0 against the current `origin/main` tip with no conflicts. The branch was not rebased from the deployer seat. |
-| 7 | Single feature theme | PASS | Commit set is one docs-safety theme: docsync link validation, rendered-docs CI, docs ownership, and contributor guidance. |
+| 1 | Review PASS present | PASS | Review bead `ga-w8a0v2` is closed with `Review verdict: PASS` for commit `e3e24a21502464b1253654beac50b6b31c6b8538`. |
+| 2 | Acceptance criteria met | PASS | Source bead `ga-y7r05r` is closed as implemented; deployer rechecked each acceptance surface below against code and tests. |
+| 3 | Tests pass | PASS | `make check-docs`, `go test ./test/docsync`, negative `TestLocalMarkdownLinks` smoke, `BASE_REF=origin/main .github/scripts/docs-render-check.sh origin/main`, `make test`, `go vet ./...`, and `git diff --check origin/main...HEAD` all completed as expected. PR #3504 status checks on the reviewed tip were rechecked and all non-skipped checks were successful. |
+| 4 | No high-severity review findings open | PASS | Review notes list one minor non-blocking dead-code cleanup item (`extract_page_links` unused); unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | Gate ran in a clean isolated worktree on `deploy/ga-bzzvst-docs-ci-gate` tracking `origin/builder/ga-y7r05r`; only this gate markdown was edited for the deploy commit. |
+| 6 | Branch diverges cleanly from main | PASS | PR #3504 reported `mergeStateStatus: CLEAN`, and `git merge-tree --write-tree origin/main HEAD` exited 0 against `origin/main` at `1ff917a8913d69443392829c26a2b9f2e2196ab8`. The branch was not rebased from the deployer seat. |
+| 7 | Single feature theme | PASS | Commit set is one docs-safety theme: docsync route validation, rendered-docs CI, docs ownership, contributor guidance, and docs-domain correction. |
 
 ## Acceptance Evidence
 
-- `test/docsync` now checks Mintlify-published docs pages for internal page links ending in `.md` or `.mdx` after stripping anchors and query strings.
+- `test/docsync` rejects internal Mintlify page links ending in `.md` or `.mdx` after stripping anchors and query strings.
 - A negative smoke edit changing `docs/tutorials/index.md` to link to `/tutorials/03-sessions.md` made `go test -run TestLocalMarkdownLinks ./test/docsync` fail with the expected broken-link report.
 - `.github/workflows/docs-render.yml` is scoped to docs PRs, skips drafts, uses read-only contents permission, cancels in-progress reruns for the same PR, and pins `actions/checkout` and `actions/setup-node` by SHA.
 - `.github/scripts/docs-render-check.sh` runs Mintlify broken-link checking against `origin/main`, ignores non-page static assets, and fails only on net-new page-link regressions versus the base branch.
 - `.github/CODEOWNERS` assigns `/docs/` to `@csells`.
-- `CONTRIBUTING.md` describes `make check-docs` as validating local links and Mintlify link hygiene.
+- `CONTRIBUTING.md` describes `make check-docs` as validating local links and the docs route convention, and it points rendered-link validation at the docs-render workflow.
 - `.github/pull_request_template.md` reminds contributors that docs links should use Mintlify routes, not GitHub markdown paths.
-- `grep -R "docs\\.gascity\\.com" -n .` returned no matches.
+- The follow-up source commit `e3e24a21502464b1253654beac50b6b31c6b8538` makes the docs-link convention discoverable in failure output and contributor docs.
+- `rg --hidden --glob '!.git' 'docs\\.gascity\\.com' .` returned no matches.
 
 ## Test Evidence
 
-- `make check-docs`: PASS (`ok github.com/gastownhall/gascity/test/docsync 1.765s`).
-- `go test ./test/docsync`: PASS (`ok github.com/gastownhall/gascity/test/docsync 1.760s`).
+- `make check-docs`: PASS (`ok github.com/gastownhall/gascity/test/docsync 1.914s`).
+- `go test ./test/docsync`: PASS (`ok github.com/gastownhall/gascity/test/docsync 2.286s`).
 - `go test -run TestLocalMarkdownLinks ./test/docsync` with an injected `/tutorials/03-sessions.md` link: failed as expected with `broken local markdown links`.
 - `BASE_REF=origin/main .github/scripts/docs-render-check.sh origin/main`: PASS; Mintlify returned non-zero, but the script found no page-link regressions and exited 0.
-- `make test`: PASS (`observable go test: PASS log=/tmp/gascity-test.jsonl.TPImbN`).
+- `make test`: PASS (`observable go test: PASS log=/tmp/gascity-test.jsonl.l41hQg`).
 - `go vet ./...`: PASS.
-- GitHub checks on PR #3504: all non-skipped checks successful, including CI required, pack compatibility gate, CodeQL, dashboard SPA, preflight, worker core, and integration shards.
+- `git diff --check origin/main...HEAD`: PASS.
+- GitHub checks on PR #3504 at `e3e24a21502464b1253654beac50b6b31c6b8538`: all non-skipped checks successful, including CI required, pack compatibility gate, CodeQL, dashboard SPA, preflight, worker core, and integration shards.

--- a/release-gates/ga-jfva11-docs-ci-hardening-gate.md
+++ b/release-gates/ga-jfva11-docs-ci-hardening-gate.md
@@ -1,0 +1,44 @@
+# Release Gate: docs-CI hardening
+
+- Deploy bead: `ga-jfva11`
+- Source build bead: `ga-y7r05r`
+- Review bead: `ga-9r4k04`
+- Source branch: `builder/ga-y7r05r`
+- PR: https://github.com/gastownhall/gascity/pull/3504
+- Base tip checked: `origin/main` at `e02391fe7f0b4281cd10afc4f9293412467f529d`
+- Branch merge base: `a52bb3626da330c3ef2718a48a448751432753d1`
+- Source commit checked: `8b713e4f65ac90034b078c697cc54aa5f767f4be`
+- Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so the deployer release criteria from the handoff prompt were used.
+
+## Gate Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-9r4k04` is closed and notes `Review verdict: PASS` for source commit `8b713e4f65ac90034b078c697cc54aa5f767f4be`. |
+| 2 | Acceptance criteria met | PASS | See acceptance evidence below. |
+| 3 | Tests pass | PASS | `make check-docs`, `go test ./test/docsync`, negative `TestLocalMarkdownLinks` smoke, `BASE_REF=origin/main .github/scripts/docs-render-check.sh origin/main`, `make test`, and `go vet ./...` all completed as expected. PR #3504 status checks were rechecked and all non-skipped checks were successful. |
+| 4 | No high-severity review findings open | PASS | Review notes list only low/info follow-ups; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | Gate ran in a clean detached worktree; after the gate commit, deployer rechecked `git status --short --branch` before push. |
+| 6 | Branch diverges cleanly from main | PASS | PR #3504 reported `mergeStateStatus: CLEAN`, and `git merge-tree --write-tree origin/main HEAD` exited 0 against the current `origin/main` tip with no conflicts. The branch was not rebased from the deployer seat. |
+| 7 | Single feature theme | PASS | Commit set is one docs-safety theme: docsync link validation, rendered-docs CI, docs ownership, and contributor guidance. |
+
+## Acceptance Evidence
+
+- `test/docsync` now checks Mintlify-published docs pages for internal page links ending in `.md` or `.mdx` after stripping anchors and query strings.
+- A negative smoke edit changing `docs/tutorials/index.md` to link to `/tutorials/03-sessions.md` made `go test -run TestLocalMarkdownLinks ./test/docsync` fail with the expected broken-link report.
+- `.github/workflows/docs-render.yml` is scoped to docs PRs, skips drafts, uses read-only contents permission, cancels in-progress reruns for the same PR, and pins `actions/checkout` and `actions/setup-node` by SHA.
+- `.github/scripts/docs-render-check.sh` runs Mintlify broken-link checking against `origin/main`, ignores non-page static assets, and fails only on net-new page-link regressions versus the base branch.
+- `.github/CODEOWNERS` assigns `/docs/` to `@csells`.
+- `CONTRIBUTING.md` describes `make check-docs` as validating local links and Mintlify link hygiene.
+- `.github/pull_request_template.md` reminds contributors that docs links should use Mintlify routes, not GitHub markdown paths.
+- `grep -R "docs\\.gascity\\.com" -n .` returned no matches.
+
+## Test Evidence
+
+- `make check-docs`: PASS (`ok github.com/gastownhall/gascity/test/docsync 1.765s`).
+- `go test ./test/docsync`: PASS (`ok github.com/gastownhall/gascity/test/docsync 1.760s`).
+- `go test -run TestLocalMarkdownLinks ./test/docsync` with an injected `/tutorials/03-sessions.md` link: failed as expected with `broken local markdown links`.
+- `BASE_REF=origin/main .github/scripts/docs-render-check.sh origin/main`: PASS; Mintlify returned non-zero, but the script found no page-link regressions and exited 0.
+- `make test`: PASS (`observable go test: PASS log=/tmp/gascity-test.jsonl.TPImbN`).
+- `go vet ./...`: PASS.
+- GitHub checks on PR #3504: all non-skipped checks successful, including CI required, pack compatibility gate, CodeQL, dashboard SPA, preflight, worker core, and integration shards.

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -478,6 +478,23 @@ func TestSchemaFreshness(t *testing.T) {
 	}
 }
 
+// hasMdSuffix reports whether the path portion of a link target (before any
+// anchor or query) has a .md or .mdx extension. Used to catch "GitHub-friendly"
+// edits that add .md suffixes to Mintlify page links — the deployed site serves
+// extensionless routes, so the suffix breaks navigation even though the file
+// exists on disk.
+func hasMdSuffix(target string) bool {
+	path := target
+	if idx := strings.Index(path, "#"); idx >= 0 {
+		path = path[:idx]
+	}
+	if idx := strings.Index(path, "?"); idx >= 0 {
+		path = path[:idx]
+	}
+	ext := filepath.Ext(path)
+	return ext == ".md" || ext == ".mdx"
+}
+
 // isMintlifySource returns true if path belongs to a doc tree that has a
 // Mintlify config (docs.json). In Mintlify trees, extensionless root-relative
 // links like /tutorials/01-beads are the expected convention. Other trees are
@@ -505,6 +522,10 @@ func TestLocalMarkdownLinks(t *testing.T) {
 			t.Fatalf("reading %s: %v", path, err)
 		}
 		mintlify := isMintlifySource(root, path)
+		docsRoot := filepath.Join(root, "docs")
+		relToDocsRoot, _ := filepath.Rel(docsRoot, path)
+		relToDocsRoot = filepath.ToSlash(relToDocsRoot)
+		publishedMintlifyPage := mintlify && !docsPublishExemptions[relToDocsRoot]
 		for _, target := range extractMarkdownLinks(string(data)) {
 			if isExternalLink(target) {
 				continue
@@ -514,9 +535,16 @@ func TestLocalMarkdownLinks(t *testing.T) {
 				continue
 			}
 			if mintlify {
-				// Mintlify docs: extensionless links are OK (deployed
-				// site uses route-based URLs without .md).
-				if !localLinkExists(resolved) {
+				// Mintlify docs: extensionless links are the correct convention
+				// (deployed site uses route-based URLs without extensions).
+				// A .md/.mdx suffix on an internal page link breaks Mintlify
+				// navigation even though the file exists on disk.
+				// Only enforce for published pages — workspace meta files
+				// (docsPublishExemptions) may legitimately reference raw filenames.
+				if publishedMintlifyPage && hasMdSuffix(target) {
+					relPath, _ := filepath.Rel(root, path)
+					broken = append(broken, relPath+" -> "+target)
+				} else if !localLinkExists(resolved) {
 					relPath, _ := filepath.Rel(root, path)
 					broken = append(broken, relPath+" -> "+target)
 				}

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -567,7 +567,18 @@ func TestLocalMarkdownLinks(t *testing.T) {
 		}
 	}
 	if len(unexpected) > 0 {
-		t.Errorf("broken local markdown links:")
+		t.Errorf(`broken local markdown links (%d):
+
+docs/ is authored for the Mintlify site (https://docs.gascityhall.com), NOT for
+direct GitHub viewing. Internal page links in docs/ are extensionless by
+convention — use /tutorials/01-beads, not /tutorials/01-beads.md. A .md/.mdx
+suffix breaks Mintlify navigation even though the file exists on disk, so please
+don't reformat docs/ links to be "GitHub-friendly". (engdocs/ and root .md files
+ARE GitHub-only and DO require explicit .md paths.) See CONTRIBUTING.md ->
+"Docs link conventions". If a link is genuinely broken on the live site, say so
+in the PR and we'll fix it Mintlify-side rather than changing the path here.
+
+Offending links:`, len(unexpected))
 		for _, item := range unexpected {
 			t.Errorf("  %s", item)
 		}


### PR DESCRIPTION
## What this changes

Docs changes now get two layers of protection against GitHub-style markdown paths leaking into Mintlify pages. The local docs check rejects internal page links ending in `.md` or `.mdx` for published docs pages, and a new `Docs render check` workflow runs Mintlify broken-link checking on docs-touching pull requests.

The change also routes docs edits to `@csells` through CODEOWNERS, corrects the `make check-docs` description in `CONTRIBUTING.md`, and adds a PR-template reminder that docs links should use rendered Mintlify routes such as `/tutorials/03-sessions`.

## Why this shape

The Go docsync check catches the common mistake quickly in local and preflight runs. The Mintlify workflow is baseline-aware so existing rendered-docs output does not block unrelated PRs, while net-new page-link regressions still fail before review.

## Review notes

- `.github/workflows/docs-render.yml` is scoped to docs PRs, skips drafts, uses read-only `contents` permission, cancels stale reruns, and pins GitHub Actions by SHA.
- `.github/scripts/docs-render-check.sh` excludes non-page static assets from Mintlify output and compares against `origin/main`.
- The `.md`/`.mdx` rejection is scoped to Mintlify-published docs pages, not every markdown-adjacent file in the repo.
- This does not change branch protection; an admin still has to mark the new docs-render workflow required.

## Test plan

- [x] `make check-docs`
- [x] `go test ./test/docsync`
- [x] `go test -run TestLocalMarkdownLinks ./test/docsync` fails on an injected `/tutorials/03-sessions.md` link
- [x] `BASE_REF=origin/main .github/scripts/docs-render-check.sh origin/main`
- [x] `grep -R "docs\\.gascity\\.com" -n .` returns no matches
- [x] `make test`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-jfva11-docs-ci-hardening-gate.md`](release-gates/ga-jfva11-docs-ci-hardening-gate.md)
