### PR TITLE
test(rig-anywhere): isolate ResolveRigToContext from ambient city

### DIFF
--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1189,6 +1189,20 @@ func TestRigAnywhere_WriteBeadsEnvGTRoot(t *testing.T) {
 // ===========================================================================
 
 func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
+	// Ambient-isolation for every subtest: these cases build their own
+	// temp cities/registries and assume no real city is in scope. A stray
+	// GC_CITY/GC_DIR in the environment, or a cwd nested inside a live city
+	// (e.g. a polecat worktree under <city>/.gc/worktrees), makes
+	// resolveRigToContext's local-city fallback load that ambient city —
+	// whose pack imports may be unfetched in the test's empty pack cache —
+	// and fail spuriously. Subtests that need a specific cwd override it via
+	// setCwd below.
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+	setCwd(t, t.TempDir())
+
 	t.Run("rig_not_registered_anywhere", func(t *testing.T) {
 		t.Setenv("GC_HOME", t.TempDir())
 


### PR DESCRIPTION
## Problem

`TestRigAnywhere_ResolveRigToContext`'s subtests construct their own temp
cities and registries and assume no real city is in scope, but they only
isolate `GC_HOME`. When `go test` runs with a cwd nested inside a live gas
city — the default for polecat/contrib worktrees, which live under
`<city>/.gc/worktrees/...` — `resolveRigToContext`'s local-city fallback
(`resolveLocalCityForRigFallback` → `findCity(cwd)`) walks up to that ambient
city and loads its rig bindings. With the test's empty per-subtest pack cache
a locked pack import cannot be resolved, so `rig_not_registered_anywhere` and
`legacy_city_toml_path_is_not_registered_binding` receive a pack-load error
instead of the expected "not registered" and fail deterministically:

```
rig_anywhere_test.go:1200: error = "loading local city rig bindings: <city>:
  city import \"gastown\": remote import ... is locked but not cached ...;
  pinned at superseded canonical sha:...; run \"gc doctor --fix\" ...",
  want 'not registered'
```

## Fix

Hoist the ambient isolation to the parent test: clear
`GC_CITY`/`GC_CITY_PATH`/`GC_CITY_ROOT`/`GC_DIR` and chdir to a temp dir
before any subtest runs. Subtests that need a specific cwd still override it
via `setCwd`. The later subtests already did this per-subtest; this extends
the same shielding to every subtest, so the suite no longer depends on where
it is invoked from.

## Validation

Reproduced from a cwd nested in a live city: `rig_not_registered_anywhere`
and `legacy_city_toml_path_is_not_registered_binding` FAIL before the change,
PASS after. Full `TestRigAnywhere_ResolveRigToContext` is green with the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
