### PR TITLE
perf(api): use root-only workflow projections in orders feed

### DIFF
--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -353,6 +353,131 @@ func TestHandleOrderDisableThenEnableResolvesFilteredOrder(t *testing.T) {
 	}
 }
 
+// TestHandleOrdersFeedSkipsPerRootChildHistoryQueries pins the root-only
+// projection switch: a feed rebuild must not issue per-root child-history
+// Lists (Metadata gc.root_bead_id + IncludeClosed), so a store that fails
+// exactly those queries still serves a complete, non-partial feed. Before
+// the switch this surfaced as partial_errors ("workflow history
+// incomplete") on every rebuild against such a store.
+func TestHandleOrdersFeedSkipsPerRootChildHistoryQueries(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	mem := beads.NewMemStore()
+	fs.stores = map[string]beads.Store{"myrig": &workflowProjectionStore{MemStore: mem}}
+
+	root, err := mem.Create(beads.Bead{
+		Title: "Deploy",
+		Type:  "workflow",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.workflow_id":      "wf-rootonly",
+			"gc.scope_kind":       "rig",
+			"gc.scope_ref":        "myrig",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	inProgress := "in_progress"
+	assignee := "myrig/claude"
+	if err := mem.Update(root.ID, beads.UpdateOpts{Status: &inProgress, Assignee: &assignee}); err != nil {
+		t.Fatalf("set workflow in_progress: %v", err)
+	}
+	child, err := mem.Create(beads.Bead{
+		Title:    "Run step",
+		Type:     "task",
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := mem.Close(child.ID); err != nil {
+		t.Fatalf("close child: %v", err)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/feed?scope_kind=rig&scope_ref=myrig"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp struct {
+		Items         []monitorFeedItemResponse `json:"items"`
+		Partial       bool                      `json:"partial"`
+		PartialErrors []string                  `json:"partial_errors"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Partial || len(resp.PartialErrors) != 0 {
+		t.Fatalf("feed partial = %v errors = %v, want complete feed without child-history queries", resp.Partial, resp.PartialErrors)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].WorkflowID != "wf-rootonly" {
+		t.Fatalf("items = %+v, want single wf-rootonly item", resp.Items)
+	}
+	if resp.Items[0].Status != "active" {
+		t.Fatalf("status = %q, want active from root+open children only", resp.Items[0].Status)
+	}
+}
+
+func TestHandleOrdersFeedRootOnlyUsesRootTerminalOutcome(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	mem := beads.NewMemStore()
+	fs.stores = map[string]beads.Store{"myrig": &workflowProjectionStore{MemStore: mem}}
+
+	root, err := mem.Create(beads.Bead{
+		Title: "Deploy",
+		Type:  "workflow",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.workflow_id":      "wf-failed-root",
+			"gc.scope_kind":       "rig",
+			"gc.scope_ref":        "myrig",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	closed := "closed"
+	if err := mem.Update(root.ID, beads.UpdateOpts{
+		Status:   &closed,
+		Metadata: map[string]string{"gc.outcome": "fail"},
+	}); err != nil {
+		t.Fatalf("close workflow root: %v", err)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/feed?scope_kind=rig&scope_ref=myrig"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp struct {
+		Items         []monitorFeedItemResponse `json:"items"`
+		Partial       bool                      `json:"partial"`
+		PartialErrors []string                  `json:"partial_errors"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Partial || len(resp.PartialErrors) != 0 {
+		t.Fatalf("feed partial = %v errors = %v, want complete feed from root summary", resp.Partial, resp.PartialErrors)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].WorkflowID != "wf-failed-root" {
+		t.Fatalf("items = %+v, want single wf-failed-root item", resp.Items)
+	}
+	if resp.Items[0].Status != "failed" {
+		t.Fatalf("status = %q, want failed from root gc.outcome", resp.Items[0].Status)
+	}
+}
+
 func TestHandleOrdersFeedReturnsWorkflowAndScheduledOrderRuns(t *testing.T) {
 	fs := newFakeState(t)
 	fs.cityBeadStore = beads.NewMemStore()

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -588,7 +588,13 @@ func (s *Server) humaHandleOrdersFeed(_ context.Context, input *OrdersFeedInput)
 		}{Body: body}, nil
 	}
 
-	workflowRuns, err := buildWorkflowRunProjections(s.state, scopeKind, scopeRef, "")
+	// Root-only projections skip the per-root closed-child List that the
+	// full path issues for every workflow root (one backing query per root
+	// per rebuild). The feed is a freshness-over-precision monitor view, the
+	// same trade /formulas/feed already made when it switched to the
+	// root-only builder; see buildWorkflowRunProjectionsRootOnly's contract
+	// note for what may lag.
+	workflowRuns, err := buildWorkflowRunProjectionsRootOnly(s.state, scopeKind, scopeRef)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("workflow feed failed")
 	}


### PR DESCRIPTION
## Summary

`GET /v0/orders/feed` builds list rows from order-tracking records and from
workflow/formula execution roots. A formula-backed order can produce both; this
change only affects the execution-root rows. The old path rebuilt each execution
row by loading every closed child step under that root, even though the list view
renders the execution summary plus any currently open steps. The feed now uses
the same summary-only projection shape as `/formulas/feed`.

## Changes

- Switches the formula/workflow execution rows in the orders feed to a
  summary-only projection: execution roots plus open children, without loading
  closed child step history for every row.
- Preserves terminal root outcomes from the root summary when serving the
  root-only projection.
- Preserves the monitor/feed freshness trade already used by `/formulas/feed`:
  status or updated time can lag when the newest activity is a closed child.
- Adds a regression test proving a store that cannot serve per-root child
  history can still return a complete, non-partial orders feed.

## Validation

- `go test ./internal/api -count=1`
- `go vet ./internal/api`

## Benchmark Evidence

Supplemental benchmark source lives on the same public fork:

`gr7n:public/bench/orders-feed-rootonly-projections`

Synthetic in-memory benchmark scope: compare the previous full projection path
with the new summary-only path for formula/workflow execution rows with two
closed child steps each. Environment: Linux/amd64, AMD Ryzen 7 7800X3D 8-Core
Processor.

| Formula/workflow execution rows | Full projection | Summary-only projection | Store lists | Child-history lists |
| --- | ---: | ---: | ---: | ---: |
| 10 | 39.425 us/op | 22.296 us/op | 12 -> 2 | 10 -> 0 |
| 100 | 2.404 ms/op | 0.117 ms/op | 102 -> 2 | 100 -> 0 |
| 500 | 51.756 ms/op | 1.704 ms/op | 502 -> 2 | 500 -> 0 |

The structural result is the main signal: feed rebuilds no longer issue one
closed-child step-history query per formula/workflow execution row.

## Related

- Issue #3253 is the public umbrella for feed views that should be cheap at
  cold-cache rebuild time; this PR applies that direction to the workflow/root
  half of `/orders/feed`.
- PR #3258 established the summary/bounded projection shape for feed and
  bead-list reads. This branch brings the orders feed's formula/workflow
  execution rows into that same shape.
- PR #3492 removes the per-order tracking lookup fan-out in the same endpoint.
  This branch removes the independent per-workflow-root closed-child fan-out, so
  the two PRs address separate query sources in `/orders/feed`.