### PR TITLE
fix(beads): self-heal events/wisp_events id DEFAULT (uuid()) at native-store open

### DIFF
--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -21,31 +21,39 @@ type rawDBGetter interface {
 	DB() *sql.DB
 }
 
-// repairDependenciesIDDefault ensures the dependencies.id column has DEFAULT
-// (uuid()). Migration 0043 adds it via PREPARE/EXECUTE, which Dolt silently
-// strips the expression default from on some versions. Without the default the
-// beadslib INSERT fails with "Field 'id' doesn't have a default value" because
-// the library never supplies id explicitly, relying on the expression default.
-// This repair is idempotent: it checks INFORMATION_SCHEMA before altering.
-func repairDependenciesIDDefault(db *sql.DB) error {
-	var hasDefault int
+// idDefaultRepairTables lists the char(36) id columns whose DEFAULT (uuid())
+// some Dolt versions silently strip from the expression default that beads
+// migrations add via PREPARE/EXECUTE. Without the default, beadslib INSERTs
+// that never supply id fail with "Field 'id' doesn't have a default value":
+//   - dependencies: DepAdd (migration 0043)
+//   - events / wisp_events: RecordEventInTable, reached when gc stamps
+//     metadata (e.g. gc.routed_to during sling) on a non-ephemeral bead.
+var idDefaultRepairTables = []string{"dependencies", "events", "wisp_events"}
+
+// repairIDDefault ensures table.id has DEFAULT (uuid()). It is idempotent and
+// tolerant of an absent table (e.g. wisp_events): it checks INFORMATION_SCHEMA
+// and only issues the ALTER when the id column exists without a default.
+//
+//nolint:gosec // G201: table is drawn from idDefaultRepairTables, hardcoded constants.
+func repairIDDefault(db *sql.DB, table string) error {
+	var idCols, withDefault int
 	err := db.QueryRow(`
-		SELECT COUNT(*)
+		SELECT COUNT(*), COUNT(COLUMN_DEFAULT)
 		FROM INFORMATION_SCHEMA.COLUMNS
 		WHERE TABLE_SCHEMA = DATABASE()
-		  AND TABLE_NAME = 'dependencies'
+		  AND TABLE_NAME = ?
 		  AND COLUMN_NAME = 'id'
-		  AND COLUMN_DEFAULT IS NOT NULL
-	`).Scan(&hasDefault)
+	`, table).Scan(&idCols, &withDefault)
 	if err != nil {
-		return fmt.Errorf("checking dependencies.id default: %w", err)
+		return fmt.Errorf("checking %s.id default: %w", table, err)
 	}
-	if hasDefault > 0 {
+	if idCols == 0 || withDefault > 0 {
+		// Table/column absent, or the default is already present.
 		return nil
 	}
-	_, err = db.Exec("ALTER TABLE `dependencies` MODIFY COLUMN `id` char(36) NOT NULL DEFAULT (uuid())")
+	_, err = db.Exec(fmt.Sprintf("ALTER TABLE `%s` MODIFY COLUMN `id` char(36) NOT NULL DEFAULT (uuid())", table))
 	if err != nil {
-		return fmt.Errorf("repairing dependencies.id default: %w", err)
+		return fmt.Errorf("repairing %s.id default: %w", table, err)
 	}
 	return nil
 }
@@ -200,9 +208,12 @@ func newNativeDoltStoreAt(parent context.Context, scopeRoot string, env map[stri
 		return nil, fmt.Errorf("reading native issue prefix: %w", err)
 	}
 	if accessor, ok := storage.(rawDBGetter); ok {
-		if repairErr := repairDependenciesIDDefault(accessor.DB()); repairErr != nil {
-			// Log but don't fail: the error will surface on the first DepAdd.
-			fmt.Fprintf(os.Stderr, "WARNING: gc beads: %v\n", repairErr)
+		for _, table := range idDefaultRepairTables {
+			if repairErr := repairIDDefault(accessor.DB(), table); repairErr != nil {
+				// Log but don't fail: the error will surface on the first
+				// DepAdd / event-recording write against the affected table.
+				fmt.Fprintf(os.Stderr, "WARNING: gc beads: %v\n", repairErr)
+			}
 		}
 	}
 	return newNativeDoltStoreWithStorageAndPrefix(storage, nativeDoltStoreActor, prefix), nil

--- a/internal/beads/native_dolt_store_integration_test.go
+++ b/internal/beads/native_dolt_store_integration_test.go
@@ -114,6 +114,62 @@ func TestNativeDoltStoreEphemeralMailSend(t *testing.T) {
 	}
 }
 
+// TestNativeDoltStoreEventsIDDefaultRepair reproduces the live-DB regression
+// where Dolt stripped DEFAULT (uuid()) from events.id: RecordEventInTable
+// (reached via SetMetadata on a non-ephemeral bead) then fails because the
+// upstream INSERT omits the id column. It proves repairIDDefault restores the
+// default so the write succeeds — the same self-heal gc applies at store open.
+func TestNativeDoltStoreEventsIDDefaultRepair(t *testing.T) {
+	ctx := context.Background()
+	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))
+	if err != nil {
+		t.Skipf("upstream native beads storage unavailable: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := storage.Close(); err != nil {
+			t.Fatalf("close upstream storage: %v", err)
+		}
+	})
+	if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+		t.Fatalf("set issue prefix: %v", err)
+	}
+	accessor, ok := storage.(rawDBGetter)
+	if !ok {
+		t.Skip("storage does not expose a raw DB")
+	}
+	db := accessor.DB()
+	store := newNativeDoltStoreWithStorageAndPrefix(storage, "events-default-repair", "gc")
+
+	// Create while the default is intact (Create itself records an event).
+	bead, err := store.Create(Bead{Title: "events id default repair bead"})
+	if err != nil {
+		t.Fatalf("Create bead: %v", err)
+	}
+
+	// Reproduce the regression: strip the DEFAULT from events.id.
+	if _, err := db.Exec("ALTER TABLE `events` MODIFY COLUMN `id` char(36) NOT NULL"); err != nil {
+		t.Fatalf("strip events.id default: %v", err)
+	}
+	if err := store.SetMetadata(bead.ID, "gc.routed_to", "gascity/builder"); err == nil {
+		t.Fatalf("SetMetadata succeeded with events.id default stripped, want failure")
+	}
+
+	// Repair restores the default; the same write then succeeds.
+	if err := repairIDDefault(db, "events"); err != nil {
+		t.Fatalf("repairIDDefault(events): %v", err)
+	}
+	if err := store.SetMetadata(bead.ID, "gc.routed_to", "gascity/builder"); err != nil {
+		t.Fatalf("SetMetadata after repair: %v", err)
+	}
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get after repair: %v", err)
+	}
+	if got.Metadata["gc.routed_to"] != "gascity/builder" {
+		t.Fatalf("Metadata[gc.routed_to] = %q, want %q", got.Metadata["gc.routed_to"], "gascity/builder")
+	}
+}
+
 func TestNativeDoltStoreRealBackendRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))


### PR DESCRIPTION
## Problem

Stamping metadata on a non-ephemeral bead (e.g. an orchestrator writing a routing marker) reaches beadslib `RecordEventInTable`, which runs:

```sql
INSERT INTO events (issue_id, event_type, actor, old_value, new_value) VALUES (?, ?, ?, ?, ?)
```

It **omits `id`** and relies on the column's `DEFAULT (uuid())`. When a migration recreated `events` and Dolt stripped that expression default, the insert fails with `Field 'id' doesn't have a default value`, breaking event recording.

This is the **same regression class** already handled for the `dependencies` table by `repairDependenciesIDDefault` (migration 0043). The `events`/`wisp_events` id defaults are added by the same `PREPARE/EXECUTE` migration mechanism (`0037_uuid_primary_keys`) that Dolt strips, so they are subject to the identical failure — reached via `RecordEventInTable` instead of `DepAdd`.

## Change

- Generalize `repairDependenciesIDDefault` → table-parameterized `repairIDDefault(db, table)`, made **absent-tolerant** (skips when the table/column is missing) and **idempotent** (`INFORMATION_SCHEMA` check; ALTERs only when the id column exists without a default).
- Run it for **`dependencies`, `events`, `wisp_events`** at native-store open (`newNativeDoltStoreAt`).
- Same `ALTER … DEFAULT (uuid())` already used for `dependencies`. Self-heals on every open; the expensive ALTER fires at most once per DB (subsequent opens see the default present and skip).

The INSERT lives in beadslib, so the fix belongs at the store-open boundary — mirroring the existing `dependencies` precedent rather than changing the library.

## Tests

Adds `TestNativeDoltStoreEventsIDDefaultRepair` (create → strip default → assert the metadata write fails → repair → assert it succeeds). Skips where `OpenBestAvailable` yields a non-Dolt backend, matching the file's existing skip-on-unavailable convention.

`go build ./internal/beads ./cmd/gc` and `go vet` clean on `main`.