### PR TITLE
fix(ci): [P0] deflake TestCleanInstallTutorialPath + TestGraphWorkflowSuccessPath blocking all integration runs

### DIFF
--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -60,7 +60,17 @@ var (
 	workflowServeIdlePollInterval  = 100 * time.Millisecond
 	workflowServeIdlePollAttempts  = 3
 	workflowServeWakeSweepInterval = 1 * time.Second
-	workflowServeMaxIdleSleep      = 30 * time.Second
+	// Cap the --follow idle backoff at 5s. A worker that closes a step bead
+	// with a raw bd write does not publish a city BeadClosed event, so the
+	// control-dispatcher only notices the next ready step on its idle re-poll.
+	// At the former 30s cap each graph hop could wait up to ~30s, so a
+	// multi-step workflow accumulated minutes of pure wake latency (the bulk of
+	// the TestGraphWorkflowSuccessPath flake). 5s keeps the loop responsive
+	// across hops while still backing off from the 1s base; the cost is one
+	// serve loop polling every 5s rather than 30s when a city is fully idle.
+	// (Complementary to the wake-debounce coalescing below, which only helps
+	// the event-arrival path; a raw-bd-write close publishes no event.)
+	workflowServeMaxIdleSleep = 5 * time.Second
 	// workflowServeWakeDebounce is the coalescing window opened once the first
 	// relevant event wakes the --follow loop. Additional buffered events that
 	// arrive during the window are drained and folded into the same wake so a
@@ -68,7 +78,7 @@ var (
 	// single work/ready re-scan instead of N heavy per-event Dolt scans. This is
 	// a fixed (max-wait) window, so a lone relevant wake also waits out the
 	// window before its drain; the delay is intentional and small relative to
-	// the 1–30s idle sleeps it replaces. Set it to 0 to disable coalescing and
+	// the 1–5s idle sleeps it replaces. Set it to 0 to disable coalescing and
 	// restore one-event-one-drain. Injectable so tests can shrink it. Fixes
 	// gastownhall/gascity#3206.
 	workflowServeWakeDebounce = 250 * time.Millisecond

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -408,6 +408,7 @@ func sweepSubprocessTestProcesses() {
 			_ = syscall.Kill(pid, syscall.SIGKILL)
 		}
 	}
+	waitForPIDsReaped(killSet)
 }
 
 func configureIntegrationSupervisorCommand(cmd *exec.Cmd) {
@@ -499,6 +500,32 @@ func terminateIntegrationPIDs(killSet map[int]bool) {
 		if err := syscall.Kill(pid, syscall.Signal(0)); err == nil {
 			_ = syscall.Kill(pid, syscall.SIGKILL)
 		}
+	}
+	waitForPIDsReaped(killSet)
+}
+
+// waitForPIDsReaped blocks until every PID in killSet is gone (signal-0 errors)
+// or a bounded deadline elapses. Without it, a SIGKILL returns before the
+// kernel has torn the process down and released its open files: a following
+// t.TempDir() RemoveAll then races a dying managed Dolt server under
+// cityDir/.beads/dolt ("directory not empty"), and a following test can
+// re-bind the just-freed managed Dolt port and adopt a half-dead server whose
+// DB still has prior tables ("alter pre-existing dirty tables"). The deadline
+// guarantees a wedged process can never hang the suite.
+func waitForPIDsReaped(killSet map[int]bool) {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		alive := false
+		for pid := range killSet {
+			if err := syscall.Kill(pid, syscall.Signal(0)); err == nil {
+				alive = true
+				break
+			}
+		}
+		if !alive {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## P0 — these two flakes block the green CI signal across the repo

`TestCleanInstallTutorialPath` (`Integration / rest-full-13-of-16`) and `TestGraphWorkflowSuccessPath` (`Integration / rest-smoke-1-of-2`) fail on **nearly every integration run**, reddening unrelated PRs repo-wide and denying maintainers the green signal needed to merge. Neither is a product bug — both are deterministic once understood. **Priority: P0 / blocking.**

## 1. TestCleanInstallTutorialPath — test-isolation teardown race
`terminateIntegrationPIDs` SIGKILLed the managed Dolt server but **returned before the kernel reaped it** and released its files under `cityDir/.beads/dolt`. Two signatures, same root:
- `TempDir RemoveAll: directory not empty` — the following `t.TempDir()` cleanup races the dying Dolt process.
- `alter pre-existing dirty tables: comments, issues, child_counters` — a following test re-binds the freed managed-Dolt port and adopts a half-dead server whose DB still has prior tables.

**Fix:** extract `waitForPIDsReaped` and block (bounded 5s) until every SIGKILLed PID is gone — wired into both `terminateIntegrationPIDs` and `sweepSubprocessTestProcesses`. Test-infra only.

## 2. TestGraphWorkflowSuccessPath — control-dispatcher wake latency
A worker closes step beads with a raw `bd` write, which emits **no city `BeadClosed` event**, so the control-dispatcher `--follow` loop only advances the molecule on its idle re-poll. At the **30s idle-backoff cap**, each of ~7 graph hops could wait up to 30s — minutes of pure wake latency that blew the 6m close deadline (observed 478s).

**Fix:** cap the `--follow` idle backoff at **5s** (`cmd/gc/dispatch_runtime.go`), bounding multi-hop latency while still backing off from the 1s base. Cost: one serve loop polls every 5s vs 30s when a city is fully idle. The 6m test deadline is **left unchanged** so it still guards regressions rather than masking them.

### Deferred follow-up (not in this PR)
The control-dispatcher default scale-check demand (`defaultScaleCheckCounts`) still reads **cached** Ready, which can briefly lag a worker-driven close and delay session re-spawn. Routing it through live Ready (as #2890 did for the assigned-work probe) would remove the residual term but touches the reconciler hot path, so it's split out.

## Validation
`go build ./cmd/gc`, `go vet -tags integration ./test/integration`, gofmt, and the `cmd/gc` dispatch unit tests pass on `main`.