### PR TITLE
chore(config): bump gastown pack pin to release 0.1.6

### DIFF
--- a/docs/guides/gastown-config-recipes.md
+++ b/docs/guides/gastown-config-recipes.md
@@ -24,7 +24,7 @@ schema = 2
 
 [imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"
 ```
 
 ```toml
@@ -34,7 +34,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"
 ```
 
 ```bash
@@ -52,7 +52,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"
 
 [[rigs.patches]]
 agent = "gastown.polecat"
@@ -70,7 +70,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"
 
 [[rigs.patches]]
 agent = "gastown.polecat"
@@ -124,7 +124,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"
 
 [[rigs.patches]]
 agent = "gastown.refinery"
@@ -253,7 +253,7 @@ base = "builtin:claude"
 
 [defaults.rig.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"
 
 [daemon]
 patrol_interval = "30s"
@@ -320,7 +320,7 @@ schema = 2
 # bundled copy. The gastown pack is no longer a local directory.
 [imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"
 ```
 
 ### The gastown pack — the reusable defaults

--- a/examples/gastown/city.toml
+++ b/examples/gastown/city.toml
@@ -31,7 +31,7 @@ base = "builtin:claude"
 
 [defaults.rig.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"
 
 [daemon]
 patrol_interval = "30s"

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -457,10 +457,10 @@ func TestRefineryFormulaChainsMergeMetadataWithClose(t *testing.T) {
 	// that gates gc bd close must appear after --unset-metadata.
 	assertContainsInOrder(t, body,
 		"--set-metadata merge_result=merged",
-		"--set-metadata merged_sha=$MERGED_SHA",
-		"--set-metadata merged_target=$TARGET",
+		`--set-metadata merged_sha="$MERGED_SHA"`,
+		`--set-metadata merged_target="$TARGET"`,
 		"--unset-metadata rejection_reason &&",
-		`gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"`,
+		`gc bd close "$WORK" --reason "Merged to $TARGET at $MERGED_SHORT"`,
 	)
 
 	// mr/pr handoff path: same chained shape, different metadata fields.
@@ -530,8 +530,8 @@ func TestRefineryFormulaRefusesZeroDiffMerge(t *testing.T) {
 	assertContainsInOrder(t, body,
 		`**If MERGE_STRATEGY = "direct" (default):**`,
 		`branch_has_real_change "origin/$TARGET" temp ||`,
-		"git merge --ff-only temp",
-		`gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"`,
+		`git -C "$MERGE_WT" merge --ff-only "$TEMP_SHA"`,
+		`gc bd close "$WORK" --reason "Merged to $TARGET at $MERGED_SHORT"`,
 	)
 
 	// mr/pr publication path: guard precedes the push and the close.

--- a/examples/gastown/pack.toml
+++ b/examples/gastown/pack.toml
@@ -30,4 +30,4 @@ version = "sha:f895c0ff47d6ee9334ed282a416387eb5b084d24"
 # pin in lockstep with the registry release and the module dependency.
 [imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"

--- a/examples/gastown/packs.lock
+++ b/examples/gastown/packs.lock
@@ -2,8 +2,8 @@ schema = 1
 
 [packs]
 [packs."https://github.com/gastownhall/gascity-packs/tree/main/gastown"]
-version = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
-commit = "817f85e155e2b0b0c375835b076103108f8a4724"
+version = "sha:4212acb7046c11f6f633df73307006493185233a"
+commit = "4212acb7046c11f6f633df73307006493185233a"
 
 [packs."https://github.com/gastownhall/gascity.git//internal/bootstrap/packs/core"]
 version = "sha:f895c0ff47d6ee9334ed282a416387eb5b084d24"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/danielgtaylor/huma/v2 v2.37.3
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/gastownhall/gascity-packs v0.3.1-0.20260614121227-817f85e155e2
+	github.com/gastownhall/gascity-packs v0.3.1-0.20260615021309-4212acb7046c
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674

--- a/go.sum
+++ b/go.sum
@@ -452,6 +452,8 @@ github.com/gastownhall/gascity-packs v0.3.1-0.20260614024906-af1640917a24 h1:x/m
 github.com/gastownhall/gascity-packs v0.3.1-0.20260614024906-af1640917a24/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
 github.com/gastownhall/gascity-packs v0.3.1-0.20260614121227-817f85e155e2 h1:NKNTxqHF3UP+QgLOUt+a4JBH3HI1i/AtF0x3MrK1xgo=
 github.com/gastownhall/gascity-packs v0.3.1-0.20260614121227-817f85e155e2/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
+github.com/gastownhall/gascity-packs v0.3.1-0.20260615021309-4212acb7046c h1:D5kqIyjXb21tcvEEVTDXv3cji6dHHR+O5r77U7X8Zo8=
+github.com/gastownhall/gascity-packs v0.3.1-0.20260615021309-4212acb7046c/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=

--- a/internal/config/public_packs.go
+++ b/internal/config/public_packs.go
@@ -8,7 +8,7 @@ const (
 
 	// PublicGastownPackVersion pins fresh init output to the registry release
 	// content commit from gastownhall/gascity-packs main.
-	PublicGastownPackVersion = "sha:817f85e155e2b0b0c375835b076103108f8a4724"
+	PublicGastownPackVersion = "sha:4212acb7046c11f6f633df73307006493185233a"
 
 	// PublicGascityPackSource is the concrete durable source for the
 	// gascity planning/implementation skills pack.
@@ -56,6 +56,7 @@ var SupersededBundledPackImportVersions = []string{
 // When bumping PublicGastownPackVersion, append the old value here
 // (scripts/update-bundled-gastown-pack does this).
 var SupersededPublicGastownPackVersions = []string{
+	"sha:817f85e155e2b0b0c375835b076103108f8a4724",
 	"sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b",
 	"sha:fa91a3b4f1fe5cc9d1ba9ffbdd2d26274680adf9",
 }


### PR DESCRIPTION
## Summary

- `scripts/update-bundled-gastown-pack --check` was failing because the live registry advanced to gastown pack release 0.1.6 (sha `4212acb7046c`) while the repo still pinned 0.1.5 (sha `817f85e155e2`).
- Update all 8 pinned files: `public_packs.go`, `go.mod`/`go.sum`, gastown example config/lock files, and the config recipe doc.
- Update `gastown_test.go` assertions to match v0.1.6 formula changes: worktree-based merge (`git -C "$MERGE_WT" merge --ff-only "$TEMP_SHA"`) and quoted shell variables in bd commands.

## Test plan

- [ ] Pre-commit hook passed: lint, go vet, fast unit suite, docsync — all green on commit
- [ ] `scripts/update-bundled-gastown-pack --check` will pass once merged (pinned SHA matches live registry)
- [ ] `TestRefineryFormulaChainsMergeMetadataWithClose` — assertions updated for v0.1.6 quoting changes
- [ ] `TestRefineryFormulaRefusesZeroDiffMerge` — assertion updated for v0.1.6 worktree-based merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)