### PR TITLE
test(cmd/gc): skip Dolt lifecycle tests under GC_FAST_UNIT=1

### DIFF
--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -445,6 +445,7 @@ func TestControllerStateRuntimeUpdateIgnoresEmptyRevisionDuringPendingMutation(t
 }
 
 func TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	configureTestDoltIdentityEnv(t)
 	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_BEADS", "")
@@ -484,6 +485,7 @@ func TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision(t *testing.T) {
 }
 
 func TestControllerStateMutationRefreshKeepsBuiltinOrdersAndClearsPending(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	configureTestDoltIdentityEnv(t)
 	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_BEADS", "")

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1852,6 +1852,7 @@ func TestRequireWorkflowServeFollowSessionEnvAllowsManagedSession(t *testing.T) 
 }
 
 func TestRunWorkflowServeReturnsControlErrorWithoutQuarantine(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	clearInheritedBeadsEnv(t)
 	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -493,6 +493,7 @@ dolt_port = "3308"
 }
 
 func TestDoDoctorRegistersStaleLocalPackDirCheck(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -612,6 +613,7 @@ source = "https://github.com/gastownhall/gc-actual-packs"
 }
 
 func TestDoDoctorRegistersStaleLocalPackDirCheckForDefaultRigRemoteImport(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	cityDir := t.TempDir()
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -620,6 +620,7 @@ func TestDoPrimeWithHookFormat_FormatsDefaultFallback(t *testing.T) {
 }
 
 func TestDoPrimeWithHook_DeliveredStartupPromptCodexJSONHookFormat(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	clearGCEnv(t)
 	clearInheritedBeadsEnv(t)
 	clearInheritedCityRoutingEnv(t)
@@ -685,6 +686,7 @@ prompt_template = "prompts/worker.md"
 }
 
 func TestDoPrimeWithHook_CodexJSONFormatInfersAgentFromWorkDir(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	for _, tt := range []struct {
 		name        string
 		identity    string

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -535,6 +535,7 @@ func TestReloadControlReadTimeoutWaitIncludesRequestedTimeout(t *testing.T) {
 }
 
 func TestSendReloadControlRequestNoChange(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	sp := runtime.NewFake()
 
 	var reconcileCount atomic.Int32
@@ -608,6 +609,7 @@ func TestSendReloadControlRequestNoChange(t *testing.T) {
 }
 
 func TestReloadConfigTracedRescansOrdersWhenConfigRevisionUnchanged(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	clearInheritedBeadsEnv(t)
 	t.Setenv("GC_BEADS", "")
 
@@ -735,6 +737,7 @@ func warningsWithoutV1Surfaces(in []string) []string {
 }
 
 func TestSendReloadControlRequestInvalidConfig(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	sp := runtime.NewFake()
 
 	var reconcileCount atomic.Int32

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -1801,6 +1801,7 @@ func readSessionCircuitResetSocketReply(t *testing.T, conn net.Conn) sessionCirc
 }
 
 func TestControllerReloadInvalidConfig(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	old := debounceDelay
 	debounceDelay = 5 * time.Millisecond
 	t.Cleanup(func() { debounceDelay = old })
@@ -1878,6 +1879,7 @@ func TestControllerReloadInvalidConfig(t *testing.T) {
 }
 
 func TestControllerReloadCityNameChange(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	old := debounceDelay
 	debounceDelay = 5 * time.Millisecond
 	t.Cleanup(func() { debounceDelay = old })

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -310,6 +310,7 @@ func TestPruneLegacyConfiguredScripts_FallbackPreservesTopLevelScriptsTargets(t 
 }
 
 func TestPrepareCityForSupervisorPrunesLegacyScripts(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts real Dolt lifecycle")
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "city")
 	cleanupManagedDoltTestCity(t, cityPath)

--- a/release-gates/ga-vmc5vi-unit-cover-guards-gate.md
+++ b/release-gates/ga-vmc5vi-unit-cover-guards-gate.md
@@ -1,0 +1,56 @@
+# Release Gate: GC_FAST_UNIT Dolt lifecycle test guards
+
+- Deploy bead: `ga-vmc5vi`
+- Source review bead: `ga-c1d2sc`
+- Source fix bead: `ga-j0uv9n`
+- PR: https://github.com/gastownhall/gascity/pull/3518
+- Branch: `builder/ga-j0uv9n-unit-cover-guards`
+- Evaluated source commit: `47474383aa45e58fced50d54a50c01829586400a`
+- Local `origin/main` at gate time: `1ff917a8913d69443392829c26a2b9f2e2196ab8`
+- Merge base with `origin/main`: `aafabd2a43f862535ac077ab49ce9e8d267eaf0c`
+- Manifest note: `docs/PROJECT_MANIFEST.md` is absent in this worktree; the release criteria from the deployer prompt were used.
+
+## Scope
+
+The change is test-only: 13 `cmd/gc` tests that start real Dolt lifecycle
+infrastructure now call `skipSlowCmdGCTest(t, "starts real Dolt lifecycle")`
+as their first line. Under `GC_FAST_UNIT=1` they are skipped from the unit-cover
+preflight; under normal process/integration runs they still execute.
+
+Changed files:
+
+- `cmd/gc/api_state_test.go`
+- `cmd/gc/cmd_convoy_dispatch_test.go`
+- `cmd/gc/cmd_doctor_test.go`
+- `cmd/gc/cmd_prime_test.go`
+- `cmd/gc/cmd_reload_test.go`
+- `cmd/gc/controller_test.go`
+- `cmd/gc/script_resolve_test.go`
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-c1d2sc` is closed and records `Review verdict: PASS` for commit `47474383aa45e58fced50d54a50c01829586400a`. |
+| 2 | Acceptance criteria met | PASS | The diff is limited to seven `cmd/gc` test files and adds 13 fast-unit skip guards for tests that start real Dolt lifecycle infrastructure. Targeted smoke under `GC_FAST_UNIT=1` confirmed all 13 named tests skip immediately with reason `starts real Dolt lifecycle`. |
+| 3 | Tests pass | PASS | `GC_FAST_UNIT=1 go test ./cmd/gc -run '<13 guarded tests>' -count=1 -timeout=2m -v` passed; `make test` passed with observable log `/tmp/gascity-test.jsonl.tO6VhV`; `go vet ./...` passed; `git diff --check origin/main...HEAD` passed. PR checks on the reviewed source tip were clean before adding this gate commit. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes for `ga-c1d2sc` record no open concerns and no high-severity findings. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed a clean `deploy/ga-vmc5vi-unit-cover-guards` worktree tracking `origin/builder/ga-j0uv9n-unit-cover-guards`; `.githooks` is active via `core.hooksPath`. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` completed successfully with tree `1d5b32ccf66ca1561214be1cd1d970b9c317756c`; GitHub reported PR #3518 `mergeStateStatus: CLEAN` on the reviewed source tip. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem and one behavior: `cmd/gc` fast-unit coverage excludes real Dolt lifecycle tests while leaving slower process/integration coverage intact. |
+
+## Guarded Tests
+
+- `TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision`
+- `TestControllerStateMutationRefreshKeepsBuiltinOrdersAndClearsPending`
+- `TestRunWorkflowServeReturnsControlErrorWithoutQuarantine`
+- `TestDoDoctorRegistersStaleLocalPackDirCheck`
+- `TestDoDoctorRegistersStaleLocalPackDirCheckForDefaultRigRemoteImport`
+- `TestDoPrimeWithHook_DeliveredStartupPromptCodexJSONHookFormat`
+- `TestDoPrimeWithHook_CodexJSONFormatInfersAgentFromWorkDir`
+- `TestSendReloadControlRequestNoChange`
+- `TestReloadConfigTracedRescansOrdersWhenConfigRevisionUnchanged`
+- `TestSendReloadControlRequestInvalidConfig`
+- `TestControllerReloadInvalidConfig`
+- `TestControllerReloadCityNameChange`
+- `TestPrepareCityForSupervisorPrunesLegacyScripts`


### PR DESCRIPTION
## What this changes

`GC_FAST_UNIT=1` fast unit coverage now skips 13 `cmd/gc` tests that start a real Dolt lifecycle. This keeps the `Preflight / unit cover` path focused on fast tests instead of spending its timeout budget starting real Dolt infrastructure.

The skipped tests still run when `GC_FAST_UNIT` is unset or `0`, so the slower process and integration suites continue to exercise the Dolt lifecycle behavior.

## Review notes

- Test-only change across seven `cmd/gc` test files.
- Uses the existing `skipSlowCmdGCTest` helper as the first line of each affected test.
- No production code, config, schema, generated artifact, or dashboard change.

## Test plan

- [x] `GC_FAST_UNIT=1 go test ./cmd/gc -run '<guarded Dolt lifecycle tests>' -count=1 -timeout=2m -v`
- [x] `make test`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-vmc5vi-unit-cover-guards-gate.md`](release-gates/ga-vmc5vi-unit-cover-guards-gate.md)
