### PR TITLE
test(integration): fix uniqueCityName prefix collision causing dirty-table failures

### DIFF
--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -31,12 +31,22 @@ func usingSubprocess() bool {
 }
 
 // uniqueCityName generates a random city name for test isolation.
+//
+// Names like "gctest-{hex}" all derive to Dolt DB prefix "gc" via
+// DeriveBeadsPrefix, causing dirty-table schema migration failures when
+// tests share a Dolt server and a prior run crashes. Instead, generate
+// a 6-letter random name: DeriveBeadsPrefix returns the first 2 chars,
+// giving 26² = 676 distinct prefixes across the test suite.
 func uniqueCityName() string {
-	b := make([]byte, 4)
+	b := make([]byte, 6)
 	if _, err := rand.Read(b); err != nil {
 		panic("generating random city name: " + err.Error())
 	}
-	return fmt.Sprintf("gctest-%x", b)
+	name := make([]byte, 6)
+	for i, c := range b {
+		name[i] = 'a' + c%26
+	}
+	return string(name)
 }
 
 // setupCity creates a city directory, initializes it, writes a city.toml

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -7,7 +7,9 @@
 // By default tests use tmux. Set GC_SESSION=subprocess to use the subprocess
 // provider instead (no tmux required).
 //
-// Session safety: all test cities use the "gctest-<8hex>" naming prefix.
+// Session safety: no-guard test cities use randomized 6-letter lowercase
+// names (see uniqueCityName) so they spread across distinct Dolt DB
+// prefixes instead of all collapsing to "gc".
 // Three layers of cleanup (pre-sweep, per-test t.Cleanup, post-sweep)
 // prevent orphan tmux sessions on developer boxes.
 package integration


### PR DESCRIPTION
## Summary

`uniqueCityName()` in `test/integration/helpers_test.go` was generating names like `gctest-{4 hex bytes}`. All of these derive to Dolt DB prefix **`"gc"`** via `DeriveBeadsPrefix` (split on `-` → first letter of each part: `"g"` + `"c"`).

When integration tests share a Dolt server, every test would reuse the same `gc` database name. If any prior test's supervisor or gc process crashed without committing the Dolt working set, the `gc_*` tables (`comments`, `events`, `issues`) would be left dirty. The next test calling `bd config get issue_prefix` would fail with:

```
failed to open Dolt store: failed to initialize schema: schema migration: pending schema migrations alter pre-existing dirty tables: comments, events, issues
```

**Fix**: generate 6-letter random all-lowercase names (e.g. `xqbmaz`). `DeriveBeadsPrefix` for a single word `>3` chars returns the first 2 chars → 26² = 676 distinct prefix values, matching the tier_c fix pattern ([`uniqueRigName`](https://github.com/gastownhall/gascity/blob/main/test/acceptance/tier_c/tierc_test.go#L487-L503)).

Fixes: ga-1bpec3

## Test plan
- [ ] `Integration / rest-full-13-of-16` (and other rest-full shards) should not see dirty-table schema migration failures

🤖 Generated with [Claude Code](https://claude.ai/claude-code)