### PR TITLE
fix(dispatch): coalesce control-dispatcher wake events to stop per-event Dolt re-scan

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -5974,6 +5974,52 @@ func TestWaitForRelevantWorkflowWakeTraceIncludesBackoffState(t *testing.T) {
 	}
 }
 
+func TestWaitForRelevantWorkflowWakeCoalescesBurst(t *testing.T) {
+	prevDebounce := workflowServeWakeDebounce
+	workflowServeWakeDebounce = 50 * time.Millisecond
+	defer func() { workflowServeWakeDebounce = prevDebounce }()
+
+	const burst = 8
+	eventCh := make(chan workflowWatchResult, burst)
+	for i := 0; i < burst; i++ {
+		eventCh <- workflowWatchResult{evt: events.Event{Type: events.BeadUpdated, Subject: fmt.Sprintf("mc-wisp-%d", i)}}
+	}
+
+	// A single wait call must drain the whole buffered burst and return exactly
+	// one wake, so runWorkflowServeFollow performs one re-scan for the burst
+	// rather than one per event.
+	eventWake, err := waitForRelevantWorkflowWake(eventCh, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !eventWake {
+		t.Fatal("eventWake = false, want true when a relevant burst arrives")
+	}
+	if leftover := len(eventCh); leftover != 0 {
+		t.Fatalf("eventCh still has %d buffered events after one wake; want 0 (burst not coalesced)", leftover)
+	}
+}
+
+func TestWaitForRelevantWorkflowWakeBurstSurfacesWatcherErr(t *testing.T) {
+	prevDebounce := workflowServeWakeDebounce
+	workflowServeWakeDebounce = 50 * time.Millisecond
+	defer func() { workflowServeWakeDebounce = prevDebounce }()
+
+	eventCh := make(chan workflowWatchResult, 2)
+	eventCh <- workflowWatchResult{evt: events.Event{Type: events.BeadUpdated, Subject: "gc-1"}}
+	eventCh <- workflowWatchResult{err: os.ErrDeadlineExceeded}
+
+	// A fatal stream error that arrives during the coalescing window must still
+	// terminate the serve loop, not be swallowed by the debounce drain.
+	eventWake, err := waitForRelevantWorkflowWake(eventCh, time.Second)
+	if err == nil {
+		t.Fatal("wait returned nil err, want watcher err surfaced from coalescing window")
+	}
+	if eventWake {
+		t.Fatal("eventWake = true on error path, want false")
+	}
+}
+
 func TestWorkflowTracefWarnsOnceWhenTracePathCannotBeOpened(t *testing.T) {
 	tracePath := filepath.Join(t.TempDir(), "missing", "workflow-trace.log")
 	t.Setenv("GC_WORKFLOW_TRACE", tracePath)

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -61,8 +61,15 @@ var (
 	workflowServeIdlePollAttempts  = 3
 	workflowServeWakeSweepInterval = 1 * time.Second
 	workflowServeMaxIdleSleep      = 30 * time.Second
-	workflowServeWaitForWake       = waitForRelevantWorkflowWakeWithTrace
-	workflowTraceNow               = time.Now
+	// workflowServeWakeDebounce is the coalescing window opened once the first
+	// relevant event wakes the --follow loop. Additional buffered events that
+	// arrive during the window are drained and folded into the same wake so a
+	// burst of N bead.* events (e.g. an mc-wisp-* event storm) collapses into a
+	// single work/ready re-scan instead of N heavy per-event Dolt scans.
+	// Injectable so tests can shrink it. Fixes gastownhall/gascity#3206.
+	workflowServeWakeDebounce = 250 * time.Millisecond
+	workflowServeWaitForWake  = waitForRelevantWorkflowWakeWithTrace
+	workflowTraceNow          = time.Now
 	// The trace helper is intentionally process-global because workflowTracef
 	// does not carry per-invocation context. Nested installs (serve ->
 	// runControlDispatcherWithStore) reuse the active dedup map so one bad trace
@@ -593,6 +600,16 @@ func waitForRelevantWorkflowWakeWithTrace(eventCh <-chan workflowWatchResult, sl
 				} else {
 					workflowTracef("serve wake-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
 				}
+				// Coalesce a burst: keep draining buffered events for a short
+				// debounce window so N relevant events collapse into one drain.
+				// runWorkflowServeFollow does exactly one drain per return=true,
+				// so the trailing events are already covered by that single
+				// re-scan — no event is dropped, only batched.
+				if coalesced, err := coalesceWorkflowWakeBurst(eventCh); err != nil {
+					return false, err
+				} else if coalesced > 0 {
+					workflowTracef("serve wake-coalesce extra=%d debounce=%s", coalesced, workflowServeWakeDebounce)
+				}
 				return true, nil
 			}
 			workflowTracef("serve ignore-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
@@ -603,6 +620,34 @@ func waitForRelevantWorkflowWakeWithTrace(eventCh <-chan workflowWatchResult, sl
 				workflowTracef("serve wake-sweep")
 			}
 			return false, nil
+		}
+	}
+}
+
+// coalesceWorkflowWakeBurst drains additional buffered events from eventCh for
+// the workflowServeWakeDebounce window after a relevant event has already
+// decided to wake the loop. It returns the number of extra events it folded
+// into this wake so the caller emits a single drain for the whole burst. A
+// watcher error encountered while draining is surfaced so the serve loop still
+// terminates on a fatal stream failure. Events are only batched here, never
+// dropped: the caller's single re-scan already reflects every drained event.
+func coalesceWorkflowWakeBurst(eventCh <-chan workflowWatchResult) (int, error) {
+	if workflowServeWakeDebounce <= 0 {
+		return 0, nil
+	}
+	debounce := time.NewTimer(workflowServeWakeDebounce)
+	defer debounce.Stop()
+
+	coalesced := 0
+	for {
+		select {
+		case res := <-eventCh:
+			if res.err != nil {
+				return coalesced, res.err
+			}
+			coalesced++
+		case <-debounce.C:
+			return coalesced, nil
 		}
 	}
 }


### PR DESCRIPTION
## Bug
The control-dispatcher serve loop (`cmd/gc/dispatch_runtime.go`) re-runs the full work/ready scan on **every** relevant `bead.*` event with no coalescing. Under an `mc-wisp-*` ephemeral event storm this drives a heavy federated Dolt ready-scan per event across every rig dispatcher — a primary contributor to runaway Dolt SELECT load (observed Com_select climbing from ~116/s to ~1,500/s, decoupled from the ~5-min reconcile cadence).

## Fix
Coalesce a burst of buffered relevant events into a single drain (one re-scan) via a debounce window in `waitForRelevantWorkflowWakeWithTrace` (injectable `workflowServeWakeDebounce`, default 250ms; `<=0` disables). No events are dropped — the single re-scan reflects every drained event; watcher errors still terminate the loop.

## Tests
Added a coalescing test in `cmd_convoy_dispatch_test.go`; existing serve tests pass. `go build ./cmd/gc` + targeted tests green.

## Follow-up
The window is fixed, so it adds ≤250ms latency to isolated wakes too; a trailing-edge/adaptive variant could avoid penalizing low-rate single events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
