### PR TITLE
fix(nudge): release nudge-poll bead store each tick to stop Dolt connection leak

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1459,6 +1459,7 @@ func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time
 
 func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(queuedNudge) bool) ([]queuedNudge, error) {
 	store := openNudgeBeadStore(cityPath)
+	defer closeBeadStoreHandle(store) //nolint:errcheck // best-effort
 	var claimed []queuedNudge
 	err := withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
 		if err := recoverExpiredInFlightNudges(state, store, now); err != nil {
@@ -1494,6 +1495,7 @@ func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(que
 
 func listQueuedNudges(cityPath, agentName string, now time.Time) ([]queuedNudge, []queuedNudge, []queuedNudge, error) {
 	store := openNudgeBeadStore(cityPath)
+	defer closeBeadStoreHandle(store) //nolint:errcheck // best-effort
 	var pending []queuedNudge
 	var inFlight []queuedNudge
 	var dead []queuedNudge
@@ -1529,6 +1531,7 @@ func listQueuedNudges(cityPath, agentName string, now time.Time) ([]queuedNudge,
 
 func listQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, []queuedNudge, []queuedNudge, error) {
 	store := openNudgeBeadStore(cityPath)
+	defer closeBeadStoreHandle(store) //nolint:errcheck // best-effort
 	var pending []queuedNudge
 	var inFlight []queuedNudge
 	var dead []queuedNudge
@@ -1614,8 +1617,13 @@ func takeQueuedNudgesByID(items []queuedNudge, id string, removed []queuedNudge)
 }
 
 func enqueueQueuedNudgeWithStore(cityPath string, store beads.Store, item queuedNudge) error {
+	ownStore := false
 	if store == nil {
 		store = openNudgeBeadStore(cityPath)
+		ownStore = true
+	}
+	if ownStore {
+		defer closeBeadStoreHandle(store) //nolint:errcheck // best-effort
 	}
 	beadID, created, err := ensureQueuedNudgeBead(store, item)
 	if err != nil {
@@ -1712,6 +1720,7 @@ func ackQueuedNudgesWithOutcome(cityPath string, ids []string, outcome, reason, 
 		return nil
 	}
 	store := openNudgeBeadStore(cityPath)
+	defer closeBeadStoreHandle(store) //nolint:errcheck // best-effort
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		want[id] = true
@@ -1760,6 +1769,7 @@ func releaseQueuedNudgeClaims(cityPath string, ids []string) error {
 		return nil
 	}
 	store := openNudgeBeadStore(cityPath)
+	defer closeBeadStoreHandle(store) //nolint:errcheck // best-effort
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		want[id] = true
@@ -1802,12 +1812,22 @@ func recordQueuedNudgeFailureWithStore(cityPath string, store beads.Store, ids [
 	return err
 }
 
+// The dead-lettered slice is part of the helper's API (tests assert on it and
+// the *Detailed name promises it), even though the only production caller today
+// is recordQueuedNudgeFailureWithStore, which discards it.
+//
+//nolint:unparam // first result is an intentional diagnostic API
 func recordQueuedNudgeFailureDetailed(cityPath string, store beads.Store, ids []string, cause error, now time.Time) ([]queuedNudge, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
+	ownStore := false
 	if store == nil {
 		store = openNudgeBeadStore(cityPath)
+		ownStore = true
+	}
+	if ownStore {
+		defer closeBeadStoreHandle(store) //nolint:errcheck // best-effort
 	}
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -4415,3 +4415,166 @@ func TestFormatNudgeInjectOutputStripsSystemReminderBreakoutSequence(t *testing.
 		t.Fatalf("Message-field tag breakout survived stripping:\n%s", got)
 	}
 }
+
+// countingNudgeStore wraps a shared MemStore and counts CloseStore calls so a
+// test can assert that per-tick poll helpers release every store they open.
+// closeBeadStoreHandle peels policy/Router/Caching wrappers and finally calls
+// CloseStore() on the unwrapped store; a leaking helper that never closes the
+// store it opened leaves opens > closes.
+type countingNudgeStore struct {
+	*beads.MemStore
+	closes *int
+}
+
+// CloseStore satisfies the interface{ CloseStore() error } that
+// closeBeadStoreHandle type-asserts against; the error return is required by
+// that contract even though this fake never fails.
+//
+//nolint:unparam // error return mandated by the CloseStore interface
+func (s *countingNudgeStore) CloseStore() error {
+	*s.closes++
+	return nil
+}
+
+// installCountingNudgeStoreSeam swaps openNudgeBeadStore for a fake that hands
+// out a fresh countingNudgeStore over a single shared MemStore on every call
+// (mirroring the deployed binary, where each per-tick open resolves to the same
+// backing native store). It returns pointers to the open and close counters and
+// restores the original seam via t.Cleanup. Tests using it must stay serial.
+func installCountingNudgeStoreSeam(t *testing.T) (opens, closes *int) {
+	t.Helper()
+	backing := beads.NewMemStore()
+	var openCount, closeCount int
+	prev := openNudgeBeadStore
+	openNudgeBeadStore = func(string) beads.Store {
+		openCount++
+		return &countingNudgeStore{MemStore: backing, closes: &closeCount}
+	}
+	t.Cleanup(func() { openNudgeBeadStore = prev })
+	return &openCount, &closeCount
+}
+
+// TestNudgePollHelpersCloseEveryStoreTheyOpen pins the connection-leak fix: the
+// per-tick poll helpers that unconditionally open a bead store
+// (claimDueQueuedNudgesMatching, listQueuedNudges, listQueuedNudgesForTarget,
+// ackQueuedNudgesWithOutcome, releaseQueuedNudgeClaims) must release it via
+// closeBeadStoreHandle so connections do not accumulate across poll iterations.
+func TestNudgePollHelpersCloseEveryStoreTheyOpen(t *testing.T) {
+	opens, closes := installCountingNudgeStoreSeam(t)
+	dir := t.TempDir()
+	now := time.Now()
+
+	item := newQueuedNudgeWithOptions("worker", "do work", "session", now, queuedNudgeOptions{ID: "n-leak"})
+	if err := enqueueQueuedNudge(dir, item); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	// Drive the unconditional per-tick helpers a few times, as a poll loop would.
+	for i := 0; i < 3; i++ {
+		if _, err := claimDueQueuedNudgesMatching(dir, now, func(queuedNudge) bool { return false }); err != nil {
+			t.Fatalf("claimDueQueuedNudgesMatching: %v", err)
+		}
+		if _, _, _, err := listQueuedNudges(dir, "worker", now); err != nil {
+			t.Fatalf("listQueuedNudges: %v", err)
+		}
+		target := nudgeTarget{cityPath: dir}
+		if _, _, _, err := listQueuedNudgesForTarget(dir, target, now); err != nil {
+			t.Fatalf("listQueuedNudgesForTarget: %v", err)
+		}
+		if err := releaseQueuedNudgeClaims(dir, []string{"n-leak"}); err != nil {
+			t.Fatalf("releaseQueuedNudgeClaims: %v", err)
+		}
+		if err := ackQueuedNudgesWithOutcome(dir, []string{"absent"}, "injected", "", "test"); err != nil {
+			t.Fatalf("ackQueuedNudgesWithOutcome: %v", err)
+		}
+	}
+
+	if *opens == 0 {
+		t.Fatalf("expected per-tick helpers to open the bead store, got 0 opens")
+	}
+	if *opens != *closes {
+		t.Fatalf("bead store leak: opens=%d closes=%d (every per-tick open must be released)", *opens, *closes)
+	}
+}
+
+// TestEnqueueQueuedNudgeWithStoreClosesOnlyOwnedStore pins the ownStore guard:
+// enqueueQueuedNudgeWithStore must close the store it opens itself (store==nil
+// path) but must NOT close a store passed in by the caller, since the caller
+// owns that handle's lifecycle.
+func TestEnqueueQueuedNudgeWithStoreClosesOnlyOwnedStore(t *testing.T) {
+	opens, closes := installCountingNudgeStoreSeam(t)
+
+	// store==nil: the helper opens and must close exactly that store.
+	dir := t.TempDir()
+	ownItem := newQueuedNudgeWithOptions("worker", "owned", "session", time.Now(), queuedNudgeOptions{ID: "n-own"})
+	if err := enqueueQueuedNudgeWithStore(dir, nil, ownItem); err != nil {
+		t.Fatalf("enqueueQueuedNudgeWithStore(nil store): %v", err)
+	}
+	if *opens != 1 {
+		t.Fatalf("opens=%d, want 1 (helper should open its own store when passed nil)", *opens)
+	}
+	if *closes != 1 {
+		t.Fatalf("closes=%d, want 1 (helper must release the store it opened)", *closes)
+	}
+
+	// store!=nil: the caller's store must not be opened or closed by the helper.
+	passedCloses := 0
+	passed := &countingNudgeStore{MemStore: beads.NewMemStore(), closes: &passedCloses}
+	dir2 := t.TempDir()
+	passedItem := newQueuedNudgeWithOptions("worker", "passed", "session", time.Now(), queuedNudgeOptions{ID: "n-passed"})
+	if err := enqueueQueuedNudgeWithStore(dir2, passed, passedItem); err != nil {
+		t.Fatalf("enqueueQueuedNudgeWithStore(passed store): %v", err)
+	}
+	if *opens != 1 {
+		t.Fatalf("opens=%d, want 1 (helper must not open when a store is passed in)", *opens)
+	}
+	if passedCloses != 0 {
+		t.Fatalf("caller-owned store closed %d times, want 0 (helper must not close a passed-in store)", passedCloses)
+	}
+}
+
+// TestRecordQueuedNudgeFailureDetailedClosesOnlyOwnedStore pins the same
+// ownStore guard for recordQueuedNudgeFailureDetailed.
+func TestRecordQueuedNudgeFailureDetailedClosesOnlyOwnedStore(t *testing.T) {
+	opens, closes := installCountingNudgeStoreSeam(t)
+	now := time.Now()
+
+	// store==nil: opened and closed by the helper.
+	dir := t.TempDir()
+	item := newQueuedNudgeWithOptions("worker", "fail", "session", now, queuedNudgeOptions{ID: "n-fail"})
+	if err := enqueueQueuedNudge(dir, item); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+	// enqueueQueuedNudge opened+closed its own store via the seam already, so
+	// measure the deltas around the recordQueuedNudgeFailureDetailed call.
+	opensBefore := *opens
+	closesBefore := *closes
+	if _, err := recordQueuedNudgeFailureDetailed(dir, nil, []string{"n-fail"}, context.DeadlineExceeded, now); err != nil {
+		t.Fatalf("recordQueuedNudgeFailureDetailed(nil store): %v", err)
+	}
+	if *opens != opensBefore+1 {
+		t.Fatalf("opens delta=%d, want 1 (helper should open its own store when passed nil)", *opens-opensBefore)
+	}
+	if *closes != closesBefore+1 {
+		t.Fatalf("closes delta=%d, want 1 (helper must release the store it opened)", *closes-closesBefore)
+	}
+
+	// store!=nil: caller's store must not be closed.
+	passedCloses := 0
+	passed := &countingNudgeStore{MemStore: beads.NewMemStore(), closes: &passedCloses}
+	dir2 := t.TempDir()
+	item2 := newQueuedNudgeWithOptions("worker", "fail2", "session", now, queuedNudgeOptions{ID: "n-fail2"})
+	if err := enqueueQueuedNudgeWithStore(dir2, passed, item2); err != nil {
+		t.Fatalf("enqueueQueuedNudgeWithStore(passed store): %v", err)
+	}
+	closesAfterEnqueue := *closes
+	if _, err := recordQueuedNudgeFailureDetailed(dir2, passed, []string{"n-fail2"}, context.DeadlineExceeded, now); err != nil {
+		t.Fatalf("recordQueuedNudgeFailureDetailed(passed store): %v", err)
+	}
+	if *closes != closesAfterEnqueue {
+		t.Fatalf("shared seam store closed during passed-store call (closes=%d, want %d)", *closes, closesAfterEnqueue)
+	}
+	if passedCloses != 0 {
+		t.Fatalf("caller-owned store closed %d times, want 0 (helper must not close a passed-in store)", passedCloses)
+	}
+}

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -30,7 +30,11 @@ const (
 
 type nudgeReference = nudgequeue.Reference
 
-func openNudgeBeadStore(cityPath string) beads.Store {
+// openNudgeBeadStore is a test seam (mirrors the injectable vars in
+// cmd_nudge.go) so tests can substitute a fake beads.Store and assert that
+// per-tick poll helpers close every store they open. Tests that replace this
+// package variable must stay serial; do not use t.Parallel in those tests.
+var openNudgeBeadStore = func(cityPath string) beads.Store {
 	store, err := openCityStoreAt(cityPath)
 	if err != nil {
 		return nil


### PR DESCRIPTION
## Bug
`gc nudge poll`'s 2s loop opens a beads store every tick via `openNudgeBeadStore` in several helpers but never releases it. In the deployed (in-process native-dolt) configuration each store holds a `*sql.DB` pool, so Dolt connections accumulate (observed live: pollers holding 80–106 connections, ~300 idle `Sleep` conns on db `mc`, `Threads_connected` climbing to ~450).

## Fix
Add `defer closeBeadStoreHandle(store)` (nil-safe; unwraps policy/Router/Caching wrappers, calls store-level `CloseStore()`) after each per-tick open in `claimDueQueuedNudgesMatching`, `listQueuedNudges`, `listQueuedNudgesForTarget`, `ackQueuedNudgesWithOutcome`, `releaseQueuedNudgeClaims`. Helpers that open only when their store arg is nil use an `ownStore` guard so caller-owned stores and the long-lived pre-loop store are never closed.

## Tests
`cmd_nudge_test.go`: injected fake store with open/CloseStore counters asserts opens==closes across poll iterations. Build + targeted tests green.

## Follow-up
A few non-loop one-shot `openNudgeBeadStore` sites (drain / mail-notify / resolve) also lack release but exit immediately; worth a separate cleanup bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
