### PR TITLE
fix(nudge): reap stale poller .pid files (janitor; leave lock inode stable)

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1166,6 +1166,14 @@ func maybeStartNudgePoller(target nudgeTarget) {
 	if target.sessionName == "" {
 		return
 	}
+	// Reap stale poller PID files before deciding whether to spawn. Owning
+	// processes only remove their PID file via the release closure, so any
+	// poller that is killed/crashes/os.Exit's leaves the .pid behind forever.
+	// This low-frequency hook keeps the pollers directory from growing without
+	// bound. The sibling .pid.lock is intentionally left in place (removing it
+	// races concurrent acquirers — see reapStaleNudgePoller). Best-effort:
+	// never block a spawn.
+	_ = reapStaleNudgePollers(target.cityPath)
 	// Supervisor-hosted dispatcher owns delivery in supervisor mode; the
 	// per-session poller would race with it and reintroduce the bd-shellout
 	// load it was designed to eliminate.
@@ -2037,6 +2045,70 @@ func withNudgeQueueState(cityPath string, fn func(*nudgeQueueState) error) error
 
 func nudgePollerPIDPath(cityPath, sessionName, agentName string) string {
 	return citylayout.RuntimePath(cityPath, "nudges", "pollers", nudgepoller.PollerFileStem(sessionName, agentName)+".pid")
+}
+
+// reapStaleNudgePollers removes orphaned nudge poller PID files left behind by
+// pollers that were killed, crashed, or os.Exit'd without running their release
+// closure. A *.pid file is stale when its contents are unparseable or its PID
+// is no longer alive. The sibling .pid.lock file is deliberately NOT removed —
+// it is the stable per-key flock mutex inode and removing it under the lock
+// would race concurrent acquirers (see reapStaleNudgePoller). The work is done
+// under the same per-file lock the lease path uses so a concurrently starting
+// poller is never raced. It is best-effort: a missing pollers directory is a
+// no-op and per-file errors are accumulated and returned without aborting the
+// sweep.
+func reapStaleNudgePollers(cityPath string) error {
+	pollersDir := citylayout.RuntimePath(cityPath, "nudges", "pollers")
+	entries, err := os.ReadDir(pollersDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading nudge pollers dir: %w", err)
+	}
+	var errs []error
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pid") {
+			continue
+		}
+		pidPath := filepath.Join(pollersDir, entry.Name())
+		if err := reapStaleNudgePoller(pidPath); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// reapStaleNudgePoller removes pidPath when the PID it names is unparseable or
+// no longer alive. It takes the per-file lock so the liveness check and removal
+// cannot race a poller acquiring the same lease, mirroring exactly what the
+// lease release closure does (which is safe).
+func reapStaleNudgePoller(pidPath string) error {
+	return withNudgePollerPIDLock(pidPath, func() error {
+		data, err := os.ReadFile(pidPath)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read nudge poller pid %q: %w", pidPath, err)
+		}
+		pidText := strings.TrimSpace(string(data))
+		var pid int
+		if n, parseErr := fmt.Sscanf(pidText, "%d", &pid); parseErr == nil && n == 1 && pidutil.Alive(pid) {
+			return nil
+		}
+		// Remove ONLY the stale .pid. The sibling .pid.lock is intentionally
+		// left in place: it is the stable per-key flock mutex inode. Calling
+		// os.Remove on it while we hold LOCK_EX would let a third concurrent
+		// acquirer create a brand-new lock inode and run its critical section
+		// alongside a blocked acquirer that inherited the now-orphaned inode,
+		// breaking mutual exclusion and double-spawning pollers — exactly what
+		// the lease exists to prevent. Leave the lock inode permanently stable.
+		if err := os.Remove(pidPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove stale nudge poller pid %q: %w", pidPath, err)
+		}
+		return nil
+	})
 }
 
 var errNudgePollerRunning = errors.New("nudge poller already running")

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -3517,6 +3517,117 @@ func TestExistingPollerPIDPreservesSameTargetAfterDifferentTarget(t *testing.T) 
 	}
 }
 
+// deadPID starts and reaps a short-lived process so its PID is guaranteed to
+// refer to no live process for the duration of the test.
+func deadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start(true): %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Wait(true): %v", err)
+	}
+	if pidutil.Alive(pid) {
+		t.Skipf("reaped PID %d still reported alive (PID reuse); skipping", pid)
+	}
+	return pid
+}
+
+func TestReapStaleNudgePollersRemovesDeadPID(t *testing.T) {
+	cityPath := t.TempDir()
+	pidPath := nudgePollerPIDPath(cityPath, "sess-worker", "session-id")
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", deadPID(t))), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := reapStaleNudgePollers(cityPath); err != nil {
+		t.Fatalf("reapStaleNudgePollers: %v", err)
+	}
+
+	if _, err := os.Stat(pidPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dead pid file still exists after reap: %v", err)
+	}
+}
+
+func TestReapStaleNudgePollersRemovesUnparseablePID(t *testing.T) {
+	cityPath := t.TempDir()
+	pidPath := nudgePollerPIDPath(cityPath, "sess-worker", "session-id")
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte("not-a-pid\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := reapStaleNudgePollers(cityPath); err != nil {
+		t.Fatalf("reapStaleNudgePollers: %v", err)
+	}
+
+	if _, err := os.Stat(pidPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unparseable pid file still exists after reap: %v", err)
+	}
+}
+
+func TestReapStaleNudgePollersKeepsLivePID(t *testing.T) {
+	cityPath := t.TempDir()
+	pidPath := nudgePollerPIDPath(cityPath, "sess-worker", "session-id")
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := reapStaleNudgePollers(cityPath); err != nil {
+		t.Fatalf("reapStaleNudgePollers: %v", err)
+	}
+
+	if _, err := os.Stat(pidPath); err != nil {
+		t.Fatalf("live pid file was removed by reap: %v", err)
+	}
+}
+
+func TestReapStaleNudgePollersLeavesLock(t *testing.T) {
+	cityPath := t.TempDir()
+	pidPath := nudgePollerPIDPath(cityPath, "sess-worker", "session-id")
+	lockPath := pidPath + ".lock"
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", deadPID(t))), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid): %v", err)
+	}
+	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile(lock): %v", err)
+	}
+
+	if err := reapStaleNudgePollers(cityPath); err != nil {
+		t.Fatalf("reapStaleNudgePollers: %v", err)
+	}
+
+	if _, err := os.Stat(pidPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dead pid file still exists after reap: %v", err)
+	}
+	// The .pid.lock is the stable per-key flock mutex inode. The reaper must
+	// leave it in place: removing it under flock races concurrent acquirers
+	// and can break mutual exclusion (double-spawn). Assert it survives.
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock file was removed by reap (must remain stable): %v", err)
+	}
+}
+
+func TestReapStaleNudgePollersMissingDirNoOp(t *testing.T) {
+	cityPath := t.TempDir() // no .gc/nudges/pollers dir created
+	if err := reapStaleNudgePollers(cityPath); err != nil {
+		t.Fatalf("reapStaleNudgePollers on missing dir: %v", err)
+	}
+}
+
 func startPollerLikeProcess(t *testing.T, cityPath, agentName string) *exec.Cmd {
 	t.Helper()
 	const sessionName = "sess-worker"


### PR DESCRIPTION
## Bug
Nudge-poller PID files in `<cityPath>/.gc/nudges/pollers/` are removed only by the owning process's release closure; any poller killed/crashed/exited abnormally leaves its `<stem>.pid` behind forever. Live: **12,656 stale `.pid` files** (only 5 alive), dominated by ephemeral `mc-wisp-*` session tuples — unbounded accumulation. (The PID guard key is already `(sessionName, pollerKey)`; duplicates come from this accumulation + restart-orphaning, not a keying bug.)

## Fix
Add `reapStaleNudgePollers(cityPath)`, called once at the top of `maybeStartNudgePoller`: read the pollers dir and, for each `<stem>.pid`, take the existing per-key lock, and if the pid is unparseable or `!pidutil.Alive(pid)`, remove the stale `.pid` (matching the release closure's safe semantics). Conservative liveness errs toward keeping files; missing-dir is a no-op; best-effort.

**Deliberately does NOT remove the `.pid.lock` inode** — that is the stable per-key flock mutex. Removing it while holding `LOCK_EX` would let a third concurrent acquirer create a fresh inode and run concurrently with a blocked acquirer holding the orphaned inode → broken mutual exclusion → double-spawn. Leaving it stable preserves correctness.

## Tests
`cmd_nudge_test.go`: removes-dead-pid, keeps-live-pid, removes-unparseable, leaves-`.pid.lock`, missing-dir no-op. Existing `TestExistingPollerPID*` pass; build + fast suite green.

## Follow-up
`.pid.lock` files for ephemeral session tuples are not reclaimed (the price of avoiding the race); safe reclamation needs a lock-mechanism redesign — separate bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
