### PR TITLE
Add gc mail wisp_events INSERT regression tripwire

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 endif
 endif
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
 
 ## build: compile gc binary with version metadata
 build:
@@ -599,6 +599,14 @@ install-buildx:
 	echo "$$expected_sha  $$tmp" | sha256sum -c -; \
 	install -m 0755 "$$tmp" $(HOME)/.docker/cli-plugins/docker-buildx
 	@echo "Installed docker-buildx v$(BUILDX_VERSION)"
+
+## test-mail-wisp-insert: run the beads version-skew regression tests for gc mail send (wisp_events INSERT path)
+## Tripwire for the 2026-06-11 P0: covers both NativeDoltStore and BdStore → Dolt paths.
+test-mail-wisp-insert:
+	@echo "=== NativeDoltStore ephemeral mail (go.mod beads library) ==="
+	$(TEST_ENV) go test -tags integration ./internal/beads/ -run TestNativeDoltStoreEphemeralMailSend -v -count=1
+	@echo "=== BdStore mail wisp INSERT (bd CLI → Dolt SQL) ==="
+	$(TEST_ENV) go test -tags integration ./test/integration/ -run TestBdStoreMailWispInsert -v -count=1
 
 ## test-mcp-mail: run mcp_agent_mail live conformance test (auto-starts server)
 test-mcp-mail:

--- a/internal/beads/native_dolt_store_integration_test.go
+++ b/internal/beads/native_dolt_store_integration_test.go
@@ -50,6 +50,70 @@ func TestNativeDoltStoreRegularUpdateEventRecording(t *testing.T) {
 	}
 }
 
+// TestNativeDoltStoreEphemeralMailSend verifies that creating an ephemeral message
+// bead (the gc mail send code path) succeeds through the upstream beads library.
+//
+// Regression tripwire for the 2026-06-11 P0 incident: a beads version-skew broke
+// gc mail send with "Field 'id' doesn't have a default value" because a newer
+// schema migration dropped DEFAULT (UUID()) from wisp_events.id while the linked
+// beads code still omitted id on INSERT. Released beads v1.0.5 is coherent, so
+// this test PASSES today. It FAILS if a future go.mod upgrade ships a version
+// where code and schema disagree on wisp_events.id.
+func TestNativeDoltStoreEphemeralMailSend(t *testing.T) {
+	ctx := context.Background()
+	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))
+	if err != nil {
+		t.Skipf("upstream native beads storage unavailable: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := storage.Close(); err != nil {
+			t.Fatalf("close upstream storage: %v", err)
+		}
+	})
+	if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+		t.Fatalf("set issue prefix: %v", err)
+	}
+	store := newNativeDoltStoreWithStorageAndPrefix(storage, "mail-wisp-regression", "gc")
+
+	// Create an ephemeral message bead — the beadmail.Send() path.
+	// Ephemeral=true routes the INSERT to wisps + wisp_events tables.
+	// A NOT NULL / missing-DEFAULT failure here reproduces the 2026-06-11 incident.
+	sent, err := store.Create(Bead{
+		Title:     "hello from mail regression",
+		Type:      "message",
+		Assignee:  "builder",
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create ephemeral message bead (wisp_events INSERT): %v", err)
+	}
+	if !sent.Ephemeral {
+		t.Fatalf("Ephemeral = false on returned bead %s, want true", sent.ID)
+	}
+	if sent.ID == "" {
+		t.Fatal("returned bead has empty ID")
+	}
+
+	// List with TierWisps to confirm the bead is retrievable after the INSERT.
+	results, err := store.List(ListQuery{
+		TierMode: TierWisps,
+		Assignee: "builder",
+	})
+	if err != nil {
+		t.Fatalf("List wisp beads: %v", err)
+	}
+	var found bool
+	for _, b := range results {
+		if b.ID == sent.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("created wisp bead %s not in List(TierWisps); got %d beads total", sent.ID, len(results))
+	}
+}
+
 func TestNativeDoltStoreRealBackendRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))

--- a/release-gates/ga-6sdnap-wisp-events-mail-insert-gate.md
+++ b/release-gates/ga-6sdnap-wisp-events-mail-insert-gate.md
@@ -1,0 +1,72 @@
+# Release Gate: ga-6sdnap wisp_events mail INSERT tripwire
+
+Date: 2026-06-15
+Deployer: gascity/deployer
+Bead: ga-6sdnap
+Source branch: builder/ga-v62dur-mail-integration-test
+Base checked: origin/main@85768eeba752bfe2d8e066a6110a29e04f2e6b61
+Candidate checked: d0e3d7562bf64732273e0e5ca1fe7861824c95e5
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. Release criteria were evaluated against the deployer prompt gate table and the repo testing guidance in `TESTING.md`.
+
+## Summary
+
+This is a single-bead deploy for a test-only regression tripwire around `gc mail` ephemeral-message creation. The candidate adds integration coverage for `wisp_events` INSERTs through both the native Dolt-backed store path and the bd CLI backed store path, then wires the focused check into the bdstore integration shard and a local `make test-mail-wisp-insert` target.
+
+Diff scope against `origin/main`:
+
+- `Makefile`
+- `internal/beads/native_dolt_store_integration_test.go`
+- `scripts/test-integration-shard`
+- `test/integration/bdstore_test.go`
+
+## Gate Checklist
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-4fvqpk` is closed with `REVIEW VERDICT: PASS` from `gascity/reviewer`. Deploy bead `ga-6sdnap` also records reviewed + PASSED evidence for commit `d0e3d7562bf64732273e0e5ca1fe7861824c95e5`. |
+| 2 | Acceptance criteria met | PASS | Source bead `ga-v62dur` requires a real beads-backed mail path that exercises `wisp_events` INSERT and fails on the prior `wisp_events.id` NOT NULL/version-skew regression. The candidate adds `TestNativeDoltStoreEphemeralMailSend`, `TestBdStoreMailWispInsert`, bdstore shard wiring, and `make test-mail-wisp-insert`. The reviewer noted one LOW non-blocking gap: no separate `Get(sent.ID)` content assertion; the release-blocking INSERT tripwire objective is covered. |
+| 3 | Tests pass | PASS | `make test` passed with observable log `/tmp/gascity-test.jsonl.JQYePa`; `go vet ./...` passed; `go build ./cmd/gc` passed; `make test-mail-wisp-insert` passed both `TestNativeDoltStoreEphemeralMailSend` and `TestBdStoreMailWispInsert`. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-4fvqpk` list no HIGH findings and no security findings. The only recorded gap is LOW/non-blocking. |
+| 5 | Final branch is clean | PASS | Before writing this checklist, `git status --short --branch` in the feature worktree showed a clean `builder/ga-v62dur-mail-integration-test...origin/builder/ga-v62dur-mail-integration-test` branch. This checklist is the only deployer-added file and is committed as the branch tip before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` exited 0 against `origin/main@85768eeba752bfe2d8e066a6110a29e04f2e6b61`. The branch is behind current main by `85768eeba chore(config): bump gastown pack pin to release 0.1.6 (#3516)`, but has no merge conflicts with main. |
+| 7 | Single feature theme | PASS | The branch contains one candidate commit and touches one subsystem theme: regression coverage for `wisp_events` mail INSERT behavior and the runner wiring for that coverage. No independent feature theme is bundled. |
+
+## Test Evidence
+
+Commands run on `builder/ga-v62dur-mail-integration-test`:
+
+```bash
+make test
+go vet ./...
+go build ./cmd/gc
+make test-mail-wisp-insert
+```
+
+Focused smoke output included:
+
+```text
+--- PASS: TestNativeDoltStoreEphemeralMailSend (0.59s)
+ok  	github.com/gastownhall/gascity/internal/beads	0.610s
+--- PASS: TestBdStoreMailWispInsert (1.22s)
+ok  	github.com/gastownhall/gascity/test/integration	11.908s
+```
+
+## Scope Evidence
+
+`git log --oneline --left-right --cherry-pick origin/main...HEAD` before the gate commit:
+
+```text
+< 85768eeba chore(config): bump gastown pack pin to release 0.1.6 (#3516)
+> d0e3d7562 test(beads): add wisp_events INSERT regression tripwire for gc mail
+```
+
+`git diff --stat origin/main...HEAD` before the gate commit:
+
+```text
+ Makefile                                           | 10 +++-
+ .../beads/native_dolt_store_integration_test.go    | 64 ++++++++++++++++++++
+ scripts/test-integration-shard                     |  4 +-
+ test/integration/bdstore_test.go                   | 70 ++++++++++++++++++++++
+ 4 files changed, 145 insertions(+), 3 deletions(-)
+```

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -280,7 +280,7 @@ run_rest_full_shard_modulo() {
   local excluded excluded_name test_name
 
   excluded=""
-  for excluded_name in "${formula_tests[@]}" "${rest_smoke_tests[@]}" TestBdStoreConformance; do
+  for excluded_name in "${formula_tests[@]}" "${rest_smoke_tests[@]}" TestBdStoreConformance TestBdStoreMailWispInsert; do
     excluded+="${excluded_name}"$'\n'
   done
 
@@ -356,7 +356,7 @@ case "$shard" in
     run_pkg_tests "$pkg" "${review_formulas_recovery_tests[@]}"
     ;;
   bdstore)
-    run_pkg_tests "$pkg" TestBdStoreConformance
+    run_pkg_tests "$pkg" TestBdStoreConformance TestBdStoreMailWispInsert
     ;;
   rest-smoke)
     run_rest_smoke_shard

--- a/test/integration/bdstore_test.go
+++ b/test/integration/bdstore_test.go
@@ -161,6 +161,76 @@ func runBDInit(t *testing.T, env []string, dir, prefix, port string) {
 	}
 }
 
+// TestBdStoreMailWispInsert verifies that creating an ephemeral mail message
+// bead via BdStore succeeds through the full bd CLI → Dolt SQL stack.
+//
+// Regression tripwire for the 2026-06-11 P0 incident: gc mail send broke in
+// production with "Field 'id' doesn't have a default value" because the bd CLI
+// code omitted id on INSERT INTO wisp_events while a newer schema migration had
+// dropped the DEFAULT (UUID()). The e2e mail tests use the file beads provider
+// and never touch Dolt SQL; this test closes that gap by exercising the
+// BdStore → bd create --ephemeral → Dolt → wisp_events INSERT path directly.
+func TestBdStoreMailWispInsert(t *testing.T) {
+	requireDoltIntegration(t)
+	env := newIsolatedToolEnv(t, true)
+
+	rootDir := t.TempDir()
+	doltDataDir := filepath.Join(rootDir, "dolt")
+	wsDir := filepath.Join(rootDir, "ws")
+	serverPort := startSharedDoltServer(t, env, doltDataDir)
+
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatalf("creating workspace: %v", err)
+	}
+	gitCmd := exec.Command("git", "init", "--quiet")
+	gitCmd.Dir = wsDir
+	if out, err := gitCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	runBDInit(t, env, wsDir, "mc", serverPort)
+	configureCustomTypes(t, env, wsDir, doctor.RequiredCustomTypes)
+
+	store := beads.NewBdStore(wsDir, beads.ExecCommandRunner())
+
+	// Create an ephemeral message bead — exercises bd create --ephemeral →
+	// Dolt SQL INSERT INTO wisps + INSERT INTO wisp_events.
+	// A NOT NULL / no-DEFAULT failure on wisp_events.id reproduces the incident.
+	sent, err := store.Create(beads.Bead{
+		Title:     "hello from bdstore mail regression",
+		Type:      "message",
+		Assignee:  "builder",
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("BdStore Create ephemeral message (wisp_events INSERT): %v", err)
+	}
+	if !sent.Ephemeral {
+		t.Fatalf("Ephemeral = false on returned bead %s, want true", sent.ID)
+	}
+	if sent.ID == "" {
+		t.Fatal("returned bead has empty ID")
+	}
+
+	// List with TierWisps to confirm the bead is readable after the INSERT.
+	results, err := store.List(beads.ListQuery{
+		TierMode: beads.TierWisps,
+		Assignee: "builder",
+	})
+	if err != nil {
+		t.Fatalf("BdStore List wisp beads: %v", err)
+	}
+	var found bool
+	for _, b := range results {
+		if b.ID == sent.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("sent bead %s not in BdStore List(TierWisps); got %d beads total", sent.ID, len(results))
+	}
+}
+
 func configureCustomTypes(t *testing.T, env []string, wsDir string, customTypes []string) {
 	t.Helper()
 


### PR DESCRIPTION
## What this changes

This adds regression coverage for ephemeral mail creation so a `wisp_events.id` schema/default mismatch trips tests before release. The new checks exercise the INSERT path through the native Dolt-backed store and through the bd CLI backed store used by `gc mail` flows.

The branch also wires the focused coverage into the bdstore integration shard and adds `make test-mail-wisp-insert` for local smoke verification.

## Review notes

- Test-only change; no production behavior changes.
- New integration coverage lives in `internal/beads/native_dolt_store_integration_test.go` and `test/integration/bdstore_test.go`.
- `scripts/test-integration-shard bdstore` now includes the bd-backed mail INSERT check, while `rest-full` excludes it to avoid duplicate coverage.
- Known limit: the tests assert create/list round-trip for wisp beads; they do not add a separate `Get(sent.ID)` content assertion.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] `go build ./cmd/gc`
- [x] `make test-mail-wisp-insert`
- [x] Release gate: [`release-gates/ga-6sdnap-wisp-events-mail-insert-gate.md`](release-gates/ga-6sdnap-wisp-events-mail-insert-gate.md)