### PR TITLE
Block unreleased go.mod replace targets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,8 @@ jobs:
           install-claude-cli: "false"
       - name: Install tools
         run: make install-tools
+      - name: go.mod replace guard
+        run: make check-gomod-replace
       - name: Native dependency surface guard
         run: make check-native-dependency-surface
       - name: Native DoltLite beads tests

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 endif
 endif
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-gomod-replace check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
 
 ## build: compile gc binary with version metadata
 build:
@@ -117,6 +117,13 @@ check: fmt-check lint vet check-routed-test-rows test
 ## api-404-error, controller-down, escape-hatch).
 check-routed-test-rows:
 	./scripts/check-routed-test-rows.sh
+
+## check-gomod-replace: block unreleased replace directives (pseudo-version, local path, git ref)
+## Tripwire for the 2026-06-11 incident where PR #3489 shipped a pseudo-version replace
+## (=> v1.0.5-0.20260611054652-dc0561af28e9) that violated the public-project release policy.
+## Policy: only released semver tags allowed; human-operator bypass required for exceptions.
+check-gomod-replace:
+	bash scripts/check-gomod-replace.sh go.mod
 
 ## check-native-dependency-surface: guard native beads dependency and binary growth
 check-native-dependency-surface:

--- a/release-gates/ga-jrsux8-gomod-replace-multiline-gate.md
+++ b/release-gates/ga-jrsux8-gomod-replace-multiline-gate.md
@@ -1,0 +1,43 @@
+# Release Gate: go.mod replace guard multi-line block detection
+
+Deploy bead: ga-jrsux8
+Feature branch: builder/ga-xttrv5-gomod-replace-multiline
+Tip under gate: 95b1634d3
+Base: origin/main 322dc987b
+
+Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the deployer release criteria and the repo testing guidance in `TESTING.md`.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Base guard review `ga-1rc90l` contains `REVIEW VERDICT: PASS`; follow-up parser review `ga-jwsz0i` contains `Reviewer verdict: PASS`. |
+| 2 | Acceptance criteria met | PASS | Base guard acceptance is covered: `scripts/check-gomod-replace.sh` rejects pseudo-version, local-path, git-ref, and prerelease replace targets while allowing released semver targets; `make check-gomod-replace` is wired through the Makefile and CI. Follow-up acceptance is covered: grouped `replace (...)` blocks now track `in_replace_block` state and apply the same RHS checks to inner lines; subtests cover pseudo-version failure, local-path failure, and released-version pass in block form. |
+| 3 | Tests pass | PASS | `go test ./scripts/ -v -run TestCheckGomodReplaceGuard` PASS; `make check-gomod-replace` PASS; `go vet ./...` PASS; `make test` PASS via observable runner; `git diff --check origin/main...HEAD` PASS. |
+| 4 | No high-severity review findings open | PASS | `ga-1rc90l` had one MEDIUM non-blocking parser gap, fixed by this branch and reviewed in `ga-jwsz0i`; `ga-jwsz0i` lists only minor non-blocking observations. Unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short` was clean before writing this gate artifact; the gate artifact is the only deployer-authored branch change and is committed as the final branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base origin/main builder/ga-xttrv5-gomod-replace-multiline` equals `origin/main` (`322dc987b`); `git merge-tree origin/main builder/ga-xttrv5-gomod-replace-multiline` exited 0 with no conflicts. |
+| 7 | Single feature theme | PASS | Diff is one CI/developer-tooling feature: a `go.mod` replace guard in `.github/workflows/ci.yml`, `Makefile`, `scripts/check-gomod-replace.sh`, and `scripts/gomod_replace_guard_test.go`. No independent subsystem or user-facing behavior is bundled. |
+
+## Review And Acceptance Evidence
+
+| Bead | Scope | Review verdict | Evidence |
+|---|---|---|---|
+| ga-z0fyli | Add required guard for unreleased `go.mod` replace targets | PASS via ga-1rc90l | Current branch includes the rebased base guard commits `0aa5582cd` and `fac44259f`; tests cover pseudo-version, local-path, git-ref, prerelease, clean go.mod, released semver, policy message, Makefile wiring, and CI wiring. |
+| ga-xttrv5 | Fix grouped multi-line `replace (...)` parser gap | PASS via ga-jwsz0i | Current branch includes follow-up commit `95b1634d3`; state-machine parsing checks inner block lines and adds block-form failure/pass coverage. |
+
+## Test Evidence
+
+- `go test ./scripts/ -v -run TestCheckGomodReplaceGuard`: PASS.
+- `make check-gomod-replace`: PASS.
+- `go vet ./...`: PASS.
+- `make test`: PASS (`observable go test: PASS`, log `/tmp/gascity-test.jsonl.wfrNtV`).
+- `git diff --check origin/main...HEAD`: PASS.
+
+## Branch Evidence
+
+- `git log --oneline origin/main..builder/ga-xttrv5-gomod-replace-multiline`:
+  - `95b1634d3 fix(check-gomod-replace): handle multi-line replace blocks`
+  - `fac44259f fix(check-gomod-replace): block git-ref and prerelease version tokens`
+  - `0aa5582cd ci(deps): block outbound PRs adding unreleased go.mod replace directives`
+- Changed files: `.github/workflows/ci.yml`, `Makefile`, `scripts/check-gomod-replace.sh`, `scripts/gomod_replace_guard_test.go`.

--- a/scripts/check-gomod-replace.sh
+++ b/scripts/check-gomod-replace.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# check-gomod-replace.sh [go.mod-path]
+#
+# Fails if go.mod contains any replace directive targeting an unreleased
+# version: pseudo-version, local filesystem path, or git branch/ref.
+#
+# Policy: gascity is a public project. It must only pin released semver tags.
+# The only override is an explicit human-operator decision (e.g. an emergency
+# security fix from an unreleased commit). That override is a manual admin
+# bypass of this required CI check — automated workers may NEVER self-authorize
+# an unreleased dependency.
+#
+# Released: v1.2.3 or vX.Y.Z with only digits (e.g. v0.0.0)
+# Unreleased: pseudo-version (vX.Y.Z-0.YYYYMMDDHHMMSS-<sha>), local path (./..  ../.. /...), git ref
+set -euo pipefail
+
+gomod="${1:-go.mod}"
+
+if [[ ! -f "$gomod" ]]; then
+	echo "check-gomod-replace: $gomod not found" >&2
+	exit 1
+fi
+
+# Extract replace targets (the part after "=>").
+# go.mod replace syntax: replace <old> [<version>] => <new> [<new-version>]
+# We only care about the replacement target, which follows "=>".
+failed=0
+while IFS= read -r line; do
+	# Strip leading whitespace and skip non-replace lines.
+	stripped="${line#"${line%%[! ]*}"}"
+	[[ "$stripped" == replace* ]] || continue
+
+	# Extract the replacement target: everything after "=>".
+	rhs="${stripped#*=>}"
+	rhs="${rhs#"${rhs%%[! ]*}"}"  # strip leading whitespace
+
+	# Split into path and optional version (the last space-separated token).
+	# If rhs is "github.com/foo/bar v1.0.0-pseudo", path=github.com/foo/bar version=v1.0.0-pseudo
+	# If rhs is "./local/path", path=./local/path version=""
+	version=""
+	path_part="$rhs"
+	if [[ "$rhs" =~ ^([^ ]+)[[:space:]]+([^ ]+)$ ]]; then
+		path_part="${BASH_REMATCH[1]}"
+		version="${BASH_REMATCH[2]}"
+	fi
+
+	# Local filesystem paths are always unreleased.
+	if [[ "$path_part" == ./* || "$path_part" == ../* || "$path_part" == /* ]]; then
+		echo "check-gomod-replace: BLOCKED — replace directive targets a local path:" >&2
+		echo "  $stripped" >&2
+		echo "" >&2
+		echo "  Policy: gascity is a public project that must only pin released semver deps." >&2
+		echo "  Local-path replaces (./  ../  /) may not appear in committed go.mod." >&2
+		echo "  Override: human operator must manually bypass this required CI check." >&2
+		failed=1
+		continue
+	fi
+
+	# If there's no version, the replace is a path-only redirect (unusual but valid if
+	# it resolves to a released tag). Nothing to check here without a version.
+	[[ -n "$version" ]] || continue
+
+	# Pseudo-version pattern: vX.Y.Z-0.YYYYMMDDHHMMSS-<12hexsha>
+	#                      or vX.Y.Z-<pre>.0.YYYYMMDDHHMMSS-<sha>
+	# Both contain a 14-digit timestamp and a hex sha separated by hyphens.
+	if [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?\.[0-9]{14}-[0-9a-f]+ ]]; then
+		echo "check-gomod-replace: BLOCKED — replace directive targets a pseudo-version (unreleased commit):" >&2
+		echo "  $stripped" >&2
+		echo "" >&2
+		echo "  Policy: gascity is a public project that must only pin released semver deps." >&2
+		echo "  Pseudo-versions pin to unreleased commits; only real vX.Y.Z tags are allowed." >&2
+		echo "  Override: human operator must manually bypass this required CI check." >&2
+		failed=1
+	fi
+done < "$gomod"
+
+if [[ $failed -ne 0 ]]; then
+	exit 1
+fi
+
+echo "check-gomod-replace: OK (no unreleased replace directives)"

--- a/scripts/check-gomod-replace.sh
+++ b/scripts/check-gomod-replace.sh
@@ -10,8 +10,15 @@
 # bypass of this required CI check — automated workers may NEVER self-authorize
 # an unreleased dependency.
 #
-# Released: v1.2.3 or vX.Y.Z with only digits (e.g. v0.0.0)
-# Unreleased: pseudo-version (vX.Y.Z-0.YYYYMMDDHHMMSS-<sha>), local path (./..  ../.. /...), git ref
+# Released: exactly vX.Y.Z where X, Y, Z are integers (e.g. v1.0.5, v0.0.1).
+# Blocked: pseudo-version, prerelease label, local path, git branch/ref, or
+#          any non-semver version token.
+#
+# Handles both single-line and grouped multi-line replace blocks:
+#   replace foo => bar v1.0.0-pseudo          (single-line)
+#   replace (                                 (grouped block)
+#       foo => bar v1.0.0-pseudo
+#   )
 set -euo pipefail
 
 gomod="${1:-go.mod}"
@@ -21,24 +28,11 @@ if [[ ! -f "$gomod" ]]; then
 	exit 1
 fi
 
-# Extract replace targets (the part after "=>").
-# go.mod replace syntax: replace <old> [<version>] => <new> [<new-version>]
-# We only care about the replacement target, which follows "=>".
-failed=0
-while IFS= read -r line; do
-	# Strip leading whitespace and skip non-replace lines.
-	stripped="${line#"${line%%[! ]*}"}"
-	[[ "$stripped" == replace* ]] || continue
+check_replace_rhs() {
+	local stripped="$1" rhs="$2"
+	local version="" path_part="$rhs"
 
-	# Extract the replacement target: everything after "=>".
-	rhs="${stripped#*=>}"
-	rhs="${rhs#"${rhs%%[! ]*}"}"  # strip leading whitespace
-
-	# Split into path and optional version (the last space-separated token).
-	# If rhs is "github.com/foo/bar v1.0.0-pseudo", path=github.com/foo/bar version=v1.0.0-pseudo
-	# If rhs is "./local/path", path=./local/path version=""
-	version=""
-	path_part="$rhs"
+	# Split into path and optional version (last space-separated token).
 	if [[ "$rhs" =~ ^([^ ]+)[[:space:]]+([^ ]+)$ ]]; then
 		path_part="${BASH_REMATCH[1]}"
 		version="${BASH_REMATCH[2]}"
@@ -52,26 +46,62 @@ while IFS= read -r line; do
 		echo "  Policy: gascity is a public project that must only pin released semver deps." >&2
 		echo "  Local-path replaces (./  ../  /) may not appear in committed go.mod." >&2
 		echo "  Override: human operator must manually bypass this required CI check." >&2
-		failed=1
-		continue
+		return 1
 	fi
 
-	# If there's no version, the replace is a path-only redirect (unusual but valid if
-	# it resolves to a released tag). Nothing to check here without a version.
-	[[ -n "$version" ]] || continue
+	# No version: path-only redirect with no version to check.
+	[[ -n "$version" ]] || return 0
 
-	# Pseudo-version pattern: vX.Y.Z-0.YYYYMMDDHHMMSS-<12hexsha>
-	#                      or vX.Y.Z-<pre>.0.YYYYMMDDHHMMSS-<sha>
-	# Both contain a 14-digit timestamp and a hex sha separated by hyphens.
-	if [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?\.[0-9]{14}-[0-9a-f]+ ]]; then
-		echo "check-gomod-replace: BLOCKED — replace directive targets a pseudo-version (unreleased commit):" >&2
+	# Only pure vX.Y.Z release tags are allowed. Everything else — pseudo-versions
+	# (timestamp+sha suffix), prerelease labels (-rc1, -beta), and non-semver
+	# tokens (branch names like "main", git refs) — is blocked.
+	if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		echo "check-gomod-replace: BLOCKED — replace directive targets an unreleased version:" >&2
 		echo "  $stripped" >&2
 		echo "" >&2
 		echo "  Policy: gascity is a public project that must only pin released semver deps." >&2
-		echo "  Pseudo-versions pin to unreleased commits; only real vX.Y.Z tags are allowed." >&2
+		echo "  Only exact vX.Y.Z release tags are allowed; pseudo-versions, prerelease" >&2
+		echo "  labels, and git branch/ref tokens are not. Version seen: $version" >&2
 		echo "  Override: human operator must manually bypass this required CI check." >&2
-		failed=1
+		return 1
 	fi
+
+	return 0
+}
+
+failed=0
+in_replace_block=0
+while IFS= read -r line; do
+	stripped="${line#"${line%%[! ]*}"}"
+
+	# Detect opening of a grouped block: replace (
+	if [[ "$stripped" == "replace (" ]]; then
+		in_replace_block=1
+		continue
+	fi
+
+	# Detect closing of a grouped block.
+	if [[ $in_replace_block -eq 1 && "$stripped" == ")" ]]; then
+		in_replace_block=0
+		continue
+	fi
+
+	if [[ $in_replace_block -eq 1 ]]; then
+		# Inner line of a block: "old [version] => new [version]"
+		[[ -z "$stripped" || "$stripped" == //* ]] && continue
+		[[ "$stripped" == *"=>"* ]] || continue
+		rhs="${stripped#*=>}"
+		rhs="${rhs#"${rhs%%[! ]*}"}"
+		check_replace_rhs "$stripped" "$rhs" || failed=1
+		continue
+	fi
+
+	# Single-line replace: starts with "replace " but is not "replace ("
+	[[ "$stripped" == replace\ * && "$stripped" != "replace (" ]] || continue
+	[[ "$stripped" == *"=>"* ]] || continue
+	rhs="${stripped#*=>}"
+	rhs="${rhs#"${rhs%%[! ]*}"}"
+	check_replace_rhs "$stripped" "$rhs" || failed=1
 done < "$gomod"
 
 if [[ $failed -ne 0 ]]; then

--- a/scripts/check-gomod-replace.sh
+++ b/scripts/check-gomod-replace.sh
@@ -32,6 +32,15 @@ check_replace_rhs() {
 	local stripped="$1" rhs="$2"
 	local version="" path_part="$rhs"
 
+	# Strip an inline `// comment` from the RHS before splitting; otherwise the
+	# trailing comment tokens defeat the two-token path/version match below and
+	# an unreleased version slips through (e.g. `=> mod v1.0.5-pseudo // why`).
+	if [[ "$rhs" == *"//"* ]]; then
+		rhs="${rhs%%//*}"
+	fi
+	rhs="${rhs%"${rhs##*[![:space:]]}"}"   # trim trailing whitespace
+	path_part="$rhs"
+
 	# Split into path and optional version (last space-separated token).
 	if [[ "$rhs" =~ ^([^ ]+)[[:space:]]+([^ ]+)$ ]]; then
 		path_part="${BASH_REMATCH[1]}"

--- a/scripts/gomod_replace_guard_test.go
+++ b/scripts/gomod_replace_guard_test.go
@@ -1,0 +1,175 @@
+package scripts_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCheckGomodReplaceGuard verifies the check-gomod-replace script:
+//   - FAILS on pseudo-version, local-path, and git-ref replace targets
+//   - PASSES when no replace directives are present
+//   - PASSES when all replaces point to released semver tags
+//
+// Regression guard for the 2026-06-11 incident where PR #3489 shipped a
+// pseudo-version replace (`=> v1.0.5-0.20260611054652-dc0561af28e9`) that
+// violated the public-project release policy. No automated check caught it.
+func TestCheckGomodReplaceGuard(t *testing.T) {
+	repoRoot := repoRoot(t)
+	script := filepath.Join(repoRoot, "scripts", "check-gomod-replace.sh")
+
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("check-gomod-replace.sh not found at %s: %v", script, err)
+	}
+
+	runScript := func(t *testing.T, content string) (output string, exitCode int) {
+		t.Helper()
+		dir := t.TempDir()
+		gomod := filepath.Join(dir, "go.mod")
+		if err := os.WriteFile(gomod, []byte(content), 0o644); err != nil {
+			t.Fatalf("write go.mod: %v", err)
+		}
+		cmd := exec.Command("bash", script, gomod)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			ex := &exec.ExitError{}
+			if errors.As(err, &ex) {
+				return string(out), ex.ExitCode()
+			}
+			t.Fatalf("exec error: %v", err)
+		}
+		return string(out), 0
+	}
+
+	t.Run("passes_no_replace", func(t *testing.T) {
+		gomod := "module github.com/example/mod\n\ngo 1.22\n"
+		out, code := runScript(t, gomod)
+		if code != 0 {
+			t.Fatalf("expected exit 0 for clean go.mod, got %d\n%s", code, out)
+		}
+	})
+
+	t.Run("passes_released_semver_replace", func(t *testing.T) {
+		gomod := fmt.Sprintf("module github.com/example/mod\n\ngo 1.22\n\nreplace %s\n",
+			"github.com/steveyegge/beads v1.0.4 => github.com/steveyegge/beads v1.0.5")
+		out, code := runScript(t, gomod)
+		if code != 0 {
+			t.Fatalf("expected exit 0 for released semver replace, got %d\n%s", code, out)
+		}
+	})
+
+	pseudoVersionCases := []struct {
+		name  string
+		block string
+	}{
+		{
+			"pseudo_version_no_source",
+			"replace github.com/steveyegge/beads => github.com/steveyegge/beads v1.0.5-0.20260611054652-dc0561af28e9",
+		},
+		{
+			"pseudo_version_with_source",
+			"replace github.com/steveyegge/beads v1.0.5 => github.com/steveyegge/beads v1.0.5-0.20260611054652-dc0561af28e9",
+		},
+		{
+			"pseudo_version_prerelease_form",
+			"replace github.com/steveyegge/beads v1.0.5 => github.com/steveyegge/beads v1.0.5-beta.0.20260611054652-abcdef012345",
+		},
+	}
+	for _, tc := range pseudoVersionCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gomod := "module github.com/example/mod\n\ngo 1.22\n\n" + tc.block + "\n"
+			out, code := runScript(t, gomod)
+			if code == 0 {
+				t.Fatalf("expected non-zero exit for pseudo-version replace %q, got 0\n%s", tc.block, out)
+			}
+			if out == "" {
+				t.Fatal("expected failure message, got empty output")
+			}
+		})
+	}
+
+	localPathCases := []struct {
+		name  string
+		block string
+	}{
+		{
+			"local_relative_path",
+			"replace github.com/steveyegge/beads => ./local/beads",
+		},
+		{
+			"local_parent_relative_path",
+			"replace github.com/steveyegge/beads => ../beads",
+		},
+		{
+			"local_absolute_path",
+			"replace github.com/steveyegge/beads => /usr/local/beads",
+		},
+	}
+	for _, tc := range localPathCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gomod := "module github.com/example/mod\n\ngo 1.22\n\n" + tc.block + "\n"
+			out, code := runScript(t, gomod)
+			if code == 0 {
+				t.Fatalf("expected non-zero exit for local-path replace %q, got 0\n%s", tc.block, out)
+			}
+			if out == "" {
+				t.Fatal("expected failure message, got empty output")
+			}
+		})
+	}
+
+	t.Run("failure_message_mentions_policy", func(t *testing.T) {
+		gomod := "module github.com/example/mod\n\ngo 1.22\n\nreplace github.com/steveyegge/beads => ./local/beads\n"
+		out, code := runScript(t, gomod)
+		if code == 0 {
+			t.Fatal("expected non-zero exit")
+		}
+		for _, want := range []string{"released", "human"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("failure message should mention %q:\n%s", want, out)
+			}
+		}
+	})
+}
+
+// TestCheckGomodReplaceGuardWiredIntoMakefile verifies that the guard
+// is a registered .PHONY target and is called from the preflight check
+// target so a CI run actually invokes it.
+func TestCheckGomodReplaceGuardWiredIntoMakefile(t *testing.T) {
+	repoRoot := repoRoot(t)
+
+	makefile, err := os.ReadFile(filepath.Join(repoRoot, "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	content := string(makefile)
+
+	for _, want := range []string{
+		"check-gomod-replace",
+		"scripts/check-gomod-replace.sh",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("Makefile missing %q", want)
+		}
+	}
+}
+
+// TestCheckGomodReplaceGuardWiredIntoCI verifies that the guard is wired
+// into the preflight-static CI job so every PR is checked.
+func TestCheckGomodReplaceGuardWiredIntoCI(t *testing.T) {
+	repoRoot := repoRoot(t)
+
+	workflow, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read ci.yml: %v", err)
+	}
+	if !strings.Contains(string(workflow), "check-gomod-replace") {
+		t.Error("ci.yml preflight-static job is missing the check-gomod-replace step")
+	}
+}

--- a/scripts/gomod_replace_guard_test.go
+++ b/scripts/gomod_replace_guard_test.go
@@ -93,6 +93,33 @@ func TestCheckGomodReplaceGuard(t *testing.T) {
 		})
 	}
 
+	gitRefCases := []struct {
+		name  string
+		block string
+	}{
+		{
+			"git_ref_branch_name",
+			"replace github.com/steveyegge/beads => github.com/steveyegge/beads main",
+		},
+		{
+			"prerelease_label",
+			"replace github.com/steveyegge/beads v1.0.4 => github.com/steveyegge/beads v1.0.5-rc1",
+		},
+	}
+	for _, tc := range gitRefCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gomod := "module github.com/example/mod\n\ngo 1.22\n\n" + tc.block + "\n"
+			out, code := runScript(t, gomod)
+			if code == 0 {
+				t.Fatalf("expected non-zero exit for git-ref/prerelease replace %q, got 0\n%s", tc.block, out)
+			}
+			if out == "" {
+				t.Fatal("expected failure message, got empty output")
+			}
+		})
+	}
+
 	localPathCases := []struct {
 		name  string
 		block string

--- a/scripts/gomod_replace_guard_test.go
+++ b/scripts/gomod_replace_guard_test.go
@@ -151,6 +151,37 @@ func TestCheckGomodReplaceGuard(t *testing.T) {
 		})
 	}
 
+	multiLineBlockCases := []struct {
+		name  string
+		gomod string
+	}{
+		{
+			"multi_line_block_pseudo_version",
+			"module github.com/example/mod\n\ngo 1.22\n\nreplace (\n\tgithub.com/steveyegge/beads v1.0.5 => github.com/steveyegge/beads v1.0.5-0.20260611054652-dc0561af28e9\n)\n",
+		},
+		{
+			"multi_line_block_local_path",
+			"module github.com/example/mod\n\ngo 1.22\n\nreplace (\n\tgithub.com/steveyegge/beads => ./local/beads\n)\n",
+		},
+		{
+			"multi_line_block_passes_released",
+			"module github.com/example/mod\n\ngo 1.22\n\nreplace (\n\tgithub.com/steveyegge/beads v1.0.4 => github.com/steveyegge/beads v1.0.5\n)\n",
+		},
+	}
+	for _, tc := range multiLineBlockCases {
+		tc := tc
+		wantFail := !strings.HasSuffix(tc.name, "_released")
+		t.Run(tc.name, func(t *testing.T) {
+			out, code := runScript(t, tc.gomod)
+			if wantFail && code == 0 {
+				t.Fatalf("expected non-zero exit for multi-line block case %q, got 0\n%s", tc.name, out)
+			}
+			if !wantFail && code != 0 {
+				t.Fatalf("expected exit 0 for multi-line block released case %q, got %d\n%s", tc.name, code, out)
+			}
+		})
+	}
+
 	t.Run("failure_message_mentions_policy", func(t *testing.T) {
 		gomod := "module github.com/example/mod\n\ngo 1.22\n\nreplace github.com/steveyegge/beads => ./local/beads\n"
 		out, code := runScript(t, gomod)

--- a/scripts/gomod_replace_guard_test.go
+++ b/scripts/gomod_replace_guard_test.go
@@ -182,6 +182,55 @@ func TestCheckGomodReplaceGuard(t *testing.T) {
 		})
 	}
 
+	inlineCommentCases := []struct {
+		name     string
+		gomod    string
+		wantFail bool
+	}{
+		{
+			"inline_comment_pseudo_version",
+			"module github.com/example/mod\n\ngo 1.22\n\nreplace github.com/steveyegge/beads v1.0.5 => github.com/steveyegge/beads v1.0.5-0.20260611054652-dc0561af28e9 // emergency fix\n",
+			true,
+		},
+		{
+			"inline_comment_git_ref",
+			"module github.com/example/mod\n\ngo 1.22\n\nreplace github.com/steveyegge/beads => github.com/steveyegge/beads main // pin branch\n",
+			true,
+		},
+		{
+			"inline_comment_local_path",
+			"module github.com/example/mod\n\ngo 1.22\n\nreplace github.com/steveyegge/beads => ./local/beads // dev\n",
+			true,
+		},
+		{
+			"inline_comment_released_semver",
+			"module github.com/example/mod\n\ngo 1.22\n\nreplace github.com/steveyegge/beads v1.0.4 => github.com/steveyegge/beads v1.0.5 // bump\n",
+			false,
+		},
+		{
+			"multi_line_block_inline_comment_pseudo_version",
+			"module github.com/example/mod\n\ngo 1.22\n\nreplace (\n\tgithub.com/steveyegge/beads v1.0.5 => github.com/steveyegge/beads v1.0.5-0.20260611054652-dc0561af28e9 // emergency fix\n)\n",
+			true,
+		},
+		{
+			"multi_line_block_inline_comment_released",
+			"module github.com/example/mod\n\ngo 1.22\n\nreplace (\n\tgithub.com/steveyegge/beads v1.0.4 => github.com/steveyegge/beads v1.0.5 // bump\n)\n",
+			false,
+		},
+	}
+	for _, tc := range inlineCommentCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			out, code := runScript(t, tc.gomod)
+			if tc.wantFail && code == 0 {
+				t.Fatalf("expected non-zero exit for inline-comment case %q, got 0\n%s", tc.name, out)
+			}
+			if !tc.wantFail && code != 0 {
+				t.Fatalf("expected exit 0 for inline-comment case %q, got %d\n%s", tc.name, code, out)
+			}
+		})
+	}
+
 	t.Run("failure_message_mentions_policy", func(t *testing.T) {
 		gomod := "module github.com/example/mod\n\ngo 1.22\n\nreplace github.com/steveyegge/beads => ./local/beads\n"
 		out, code := runScript(t, gomod)


### PR DESCRIPTION
## What this changes

Pull requests now run a `make check-gomod-replace` preflight that blocks `go.mod` replace directives pointing at local paths, pseudo-versions, branch names, or prerelease tags. The guard handles both single-line replacements and grouped multi-line `replace (...)` blocks, so the CI check covers the forms authors can write by hand.

The policy lives in `scripts/check-gomod-replace.sh` and is wired through `Makefile` and the preflight CI job. That gives local runs and GitHub Actions the same entry point and keeps the check focused on developer tooling rather than runtime behavior.

## Review notes

- Released semver replacement targets continue to pass; the guard is scoped to unreleased/local replacement targets.
- The parser tracks whether it is inside a grouped replace block and applies the same RHS checks used for single-line replace directives.
- The failure text names the released-dependency policy and the human-operator-only override path.
- No runtime behavior changes; this only affects CI and local developer checks.

## Test plan

- [x] `go test ./scripts/ -v -run TestCheckGomodReplaceGuard`
- [x] `make check-gomod-replace`
- [x] `make test`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-jrsux8-gomod-replace-multiline-gate.md`](release-gates/ga-jrsux8-gomod-replace-multiline-gate.md)
