### PR TITLE
fix(wisp-gc): reap orphaned closed wisp descendants past TTL (dry-run default, batch-capped)

### DIFF
--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -4,15 +4,42 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 const mailReadMetadataKey = "mail.read"
+
+// wispGCReapOrphanBatchCap bounds how many orphaned closed wisp descendants a
+// single sweep will reap. The orphaned-closure backlog (~8k rows) drains over
+// roughly cap-sized batches across successive sweeps so no single tick does an
+// unbounded amount of deletion work.
+var wispGCReapOrphanBatchCap = 500
+
+// reapOrphansEnforced reports whether orphaned-closed-wisp reaping should
+// actually delete rows. It defaults to dry-run (false) unless the
+// GC_WISP_GC_REAP_ORPHANS env var is set to a truthy value. Indirected through
+// a package var so tests can toggle enforcement without touching the
+// environment.
+var reapOrphansEnforced = func() bool { return parseWispGCBoolEnv(os.Getenv("GC_WISP_GC_REAP_ORPHANS")) }
+
+// parseWispGCBoolEnv interprets an environment value as a boolean. Unset, empty,
+// and unparseable values are treated as false so the dry-run default holds.
+func parseWispGCBoolEnv(raw string) bool {
+	v, err := strconv.ParseBool(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	return v
+}
 
 // wispGC performs mechanical garbage collection of closed molecules that
 // have exceeded their TTL. Follows the nil-guard tracker pattern used by
@@ -90,6 +117,10 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 		closurePurged, closureDeleteErr := purgeExpiredBeadClosures(store, entries, cutoff)
 		purged += closurePurged
 		deleteErr = errors.Join(deleteErr, closureDeleteErr)
+
+		orphanReaped, orphanErr := reapOrphanedClosedWisps(store, cutoff, wispGCReapOrphanBatchCap)
+		purged += orphanReaped
+		deleteErr = errors.Join(deleteErr, orphanErr)
 	}
 
 	if m.mailRetentionTTL > 0 {
@@ -135,6 +166,112 @@ func closedWispGCEntries(store beads.Store) ([]beads.Bead, error) {
 	}
 	appendUnique(wisps)
 	return entries, nil
+}
+
+// reapOrphanedClosedWisps reaps closed wisp-tier descendants whose owning root
+// is gone or already terminal but which the root-rooted closure purge never
+// enumerates (their root is absent from, or never appears in, the closed-root
+// list). Candidates are closed wisp-tier rows carrying a gc.root_bead_id
+// pointer and older than cutoff.
+//
+// Safety: a descendant is reaped only when its root is provably collectible —
+// the root Get returns ErrNotFound (root gone) or the root is terminal
+// (closed/tombstone). A live/open root, or any other (unreadable) Get error,
+// causes the descendant to be SKIPPED so an in-flight workflow is never
+// stripped of its closed steps.
+//
+// With GC_WISP_GC_REAP_ORPHANS unset the function mutates nothing: it counts
+// the would-be reaps and logs a dry-run notice. Per-bead delete errors are
+// joined and never abort the sweep. The batch cap bounds reaps per sweep so the
+// backlog drains over multiple ticks.
+func reapOrphanedClosedWisps(store beads.Store, cutoff time.Time, batchCap int) (int, error) {
+	if store == nil {
+		return 0, fmt.Errorf("reaping orphaned closed wisps: bead store unavailable")
+	}
+
+	candidates, err := store.List(beads.ListQuery{
+		Status:    "closed",
+		TierMode:  beads.TierWisps,
+		AllowScan: true,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("listing closed wisp-tier rows: %w", err)
+	}
+
+	enforce := reapOrphansEnforced()
+
+	// rootCollectible caches the per-root reap decision so many siblings
+	// sharing one dead root cost a single Get.
+	rootCollectible := make(map[string]bool)
+	var collectErr error
+
+	reaped := 0
+	var deleteErr error
+	for _, c := range candidates {
+		if batchCap > 0 && reaped >= batchCap {
+			break
+		}
+
+		rootID := c.Metadata[beadmeta.RootBeadIDMetadataKey]
+		if rootID == "" {
+			// No root pointer — out of scope for orphan reaping.
+			continue
+		}
+
+		// Reuse the closure purge's age semantics: skip zero/recent rows.
+		if c.CreatedAt.IsZero() || !c.CreatedAt.Before(cutoff) {
+			continue
+		}
+
+		decision, cached := rootCollectible[rootID]
+		if !cached {
+			root, getErr := store.Get(rootID)
+			switch {
+			case errors.Is(getErr, beads.ErrNotFound):
+				decision = true // root gone
+			case getErr == nil && convoycore.IsTerminalStatus(root.Status):
+				decision = true // root terminal
+			case getErr == nil:
+				decision = false // root live/open — never reap its descendants
+			default:
+				// Any other Get error: cannot prove safe — skip without caching
+				// as collectible. Surface so the sweep records the failure.
+				decision = false
+				collectErr = errors.Join(collectErr, fmt.Errorf("resolving root %q for orphan %q: %w", rootID, c.ID, getErr))
+			}
+			rootCollectible[rootID] = decision
+		}
+		if !decision {
+			continue
+		}
+
+		if !enforce {
+			reaped++
+			continue
+		}
+
+		if err := deleteWorkflowBead(store, c.ID); err != nil {
+			deleteErr = errors.Join(deleteErr, fmt.Errorf("reaping orphaned closed wisp %q: %w", c.ID, err))
+			continue
+		}
+		reaped++
+	}
+
+	if reaped > 0 {
+		if enforce {
+			log.Printf("wisp gc: reaped %d orphaned closed wisp(s)", reaped)
+		} else {
+			log.Printf("wisp gc: %d orphaned closed wisp(s) would be reaped (dry-run; set GC_WISP_GC_REAP_ORPHANS=1 to enforce)", reaped)
+		}
+	}
+
+	if !enforce {
+		// Dry-run never mutates: report would-be count via log only, return 0
+		// purged so callers don't over-count deletions that did not happen.
+		return 0, errors.Join(collectErr, deleteErr)
+	}
+
+	return reaped, errors.Join(collectErr, deleteErr)
 }
 
 func readMessageWispGCEntries(store beads.Store) ([]beads.Bead, error) {

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
@@ -685,6 +686,170 @@ func TestWispGC_ListErrorFailsRun(t *testing.T) {
 	}
 }
 
+func TestWispGC_ReapsClosedOrphanWhenRootAbsent(t *testing.T) {
+	withReapOrphansEnforced(t, true)
+	now := time.Now()
+	// Root "ghost-root" is never inserted: the orphan descendant's root is gone.
+	store := newGCStore([]beads.Bead{
+		makeGCOrphanWisp("orphan-1", now.Add(-2*time.Hour), "ghost-root"),
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "orphan-1")
+}
+
+func TestWispGC_ReapsClosedOrphanWhenRootClosed(t *testing.T) {
+	withReapOrphansEnforced(t, true)
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		// Closed task root (terminal) without gc.kind=wisp so the root-rooted
+		// closure purge does not enumerate it; the orphan path must still reap.
+		makeGCBead("term-root", now.Add(-2*time.Hour), "closed", "task"),
+		makeGCOrphanWisp("orphan-2", now.Add(-2*time.Hour), "term-root"),
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "orphan-2")
+	// The terminal root itself is out of scope for the orphan path.
+	if _, err := store.Get("term-root"); err != nil {
+		t.Fatalf("term-root should remain: %v", err)
+	}
+}
+
+func TestWispGC_DoesNotReapWhenRootOpen(t *testing.T) {
+	withReapOrphansEnforced(t, true)
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("live-root", now.Add(-2*time.Hour), "in_progress", "molecule"),
+		makeGCOrphanWisp("orphan-live", now.Add(-2*time.Hour), "live-root"),
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 0 {
+		t.Fatalf("purged = %d, want 0; descendant of a live root must never be reaped", purged)
+	}
+	if len(store.deletedIDs) != 0 {
+		t.Fatalf("deleted = %v, want none", store.deletedIDs)
+	}
+	if _, err := store.Get("orphan-live"); err != nil {
+		t.Fatalf("orphan-live must still be Get-able while root is open: %v", err)
+	}
+}
+
+func TestWispGC_DryRunDefaultReapsNothing(t *testing.T) {
+	withReapOrphansEnforced(t, false)
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCOrphanWisp("orphan-dry", now.Add(-2*time.Hour), "ghost-root"),
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	var purged int
+	var runErr error
+	logOutput := captureWispGCLog(t, func() {
+		purged, runErr = wg.runGC(store, now)
+	})
+	if runErr != nil {
+		t.Fatalf("runGC: %v", runErr)
+	}
+	if purged != 0 {
+		t.Fatalf("purged = %d, want 0 in dry-run", purged)
+	}
+	if len(store.deletedIDs) != 0 {
+		t.Fatalf("deleted = %v, want none in dry-run", store.deletedIDs)
+	}
+	if _, err := store.Get("orphan-dry"); err != nil {
+		t.Fatalf("orphan-dry must survive dry-run: %v", err)
+	}
+	if !strings.Contains(logOutput, "would be reaped") {
+		t.Fatalf("log = %q, want dry-run notice containing %q", logOutput, "would be reaped")
+	}
+}
+
+func TestWispGC_ReapHonorsBatchCap(t *testing.T) {
+	withReapOrphansEnforced(t, true)
+	withReapOrphanBatchCap(t, 1)
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCOrphanWisp("orphan-cap-1", now.Add(-2*time.Hour), "ghost-root"),
+		makeGCOrphanWisp("orphan-cap-2", now.Add(-2*time.Hour), "ghost-root"),
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (batch cap)", purged)
+	}
+	if len(store.deletedIDs) != 1 {
+		t.Fatalf("deleted = %v, want exactly 1 per sweep", store.deletedIDs)
+	}
+}
+
+func TestWispGC_ReapSkipsRowsWithoutRootPointer(t *testing.T) {
+	withReapOrphansEnforced(t, true)
+	now := time.Now()
+	// Closed wisp-tier row with no gc.root_bead_id pointer: out of scope.
+	noRoot := makeGCBeadWithMetadata("no-root", now.Add(-2*time.Hour), "closed", "task", map[string]string{})
+	noRoot.Ephemeral = true
+	store := newGCStore([]beads.Bead{noRoot})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 0 {
+		t.Fatalf("purged = %d, want 0; rows without a root pointer are out of scope", purged)
+	}
+	if _, err := store.Get("no-root"); err != nil {
+		t.Fatalf("no-root must be preserved: %v", err)
+	}
+}
+
+func TestWispGC_ReapDeleteErrorSurfacedAndContinues(t *testing.T) {
+	withReapOrphansEnforced(t, true)
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCOrphanWisp("orphan-err", now.Add(-2*time.Hour), "ghost-root"),
+		makeGCOrphanWisp("orphan-ok", now.Add(-2*time.Hour), "ghost-root"),
+	})
+	store.deleteErrors["orphan-err"] = fmt.Errorf("delete failed")
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err == nil {
+		t.Fatal("expected reap delete error to be surfaced")
+	}
+	if !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("err = %v, want delete failure to be included", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (other orphan still reaped)", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "orphan-ok")
+}
+
 type gcQueryKey struct {
 	Status   string
 	Type     string
@@ -765,6 +930,36 @@ func makeGCMessageWisp(id string, createdAt time.Time, metadata map[string]strin
 		Metadata:  metadata,
 		Ephemeral: true,
 	}
+}
+
+// makeGCOrphanWisp builds a closed wisp-tier descendant carrying a
+// gc.root_bead_id pointer. Ephemeral:true places it in the wisp tier so the
+// orphan reaper's TierWisps query sees it. It deliberately omits gc.kind=wisp so
+// the root-rooted closure purge does not enumerate it as a root.
+func makeGCOrphanWisp(id string, createdAt time.Time, rootID string) beads.Bead {
+	bead := makeGCBeadWithMetadata(id, createdAt, "closed", "task", map[string]string{
+		beadmeta.RootBeadIDMetadataKey: rootID,
+	})
+	bead.Ephemeral = true
+	return bead
+}
+
+// withReapOrphansEnforced toggles the enforcement indirection for the duration
+// of a test, restoring the prior value on cleanup.
+func withReapOrphansEnforced(t *testing.T, enforce bool) {
+	t.Helper()
+	prev := reapOrphansEnforced
+	reapOrphansEnforced = func() bool { return enforce }
+	t.Cleanup(func() { reapOrphansEnforced = prev })
+}
+
+// withReapOrphanBatchCap overrides the per-sweep reap cap for the duration of a
+// test, restoring the prior value on cleanup.
+func withReapOrphanBatchCap(t *testing.T, batchCap int) {
+	t.Helper()
+	prev := wispGCReapOrphanBatchCap
+	wispGCReapOrphanBatchCap = batchCap
+	t.Cleanup(func() { wispGCReapOrphanBatchCap = prev })
 }
 
 func captureWispGCLog(t *testing.T, fn func()) string {


### PR DESCRIPTION
## Bug
The periodic wisp GC purges closed *roots* + their subtrees (`closedWispGCEntries`), but closed STEP descendants whose root is gone — or that never appear in the closed-root list — are never enumerated, so they're never reaped. Live (maintainer-city): ~11k closed wisp rows, **8,233 >24h old** (orphaned task/chore steps), bloating `wisps`/`wisp_dependencies` and every `TierBoth` scan. The existing GC structurally can't reach them.

## Fix
Add `reapOrphanedClosedWisps` to `runGC` (after the existing closure purge). It enumerates closed wisp-tier rows carrying `gc.root_bead_id` and reaps one **only if its root is gone (`ErrNotFound`) or terminal** — **never** a descendant of an open/non-terminal root (the critical guard; an unreadable root → skip + surface the error, fail-safe). Reaping goes through `deleteWorkflowBead` (consistent `wisp_dependencies` edge + row removal — no raw SQL).

Guards / shippable defaults:
- **Dry-run default** — `GC_WISP_GC_REAP_ORPHANS` unset ⇒ counts + logs `"N orphaned closed wisp(s) would be reaped"`, mutates nothing. The existing closure purge is unchanged (always enforces).
- **Per-sweep batch cap** (`wispGCReapOrphanBatchCap = 500`) ⇒ ~17 sweeps to drain 8k, bounding transaction/IO pressure.
- Best-effort `errors.Join`; never aborts the GC tick.

## Tests (`wisp_gc_test.go`)
reaps-when-root-absent, reaps-when-root-closed, **does-not-reap-when-root-open** (mutation-verified load-bearing), **dry-run-default-reaps-nothing** (mutation-verified), batch-cap, skips-rows-without-root-pointer, delete-error-surfaced-and-continues. `go build` + `TestWispGC` green.

## Enabling (after merge/deploy)
Dry-run by default. To drain: review the dry-run `"would be reaped"` count in the supervisor log, then set `GC_WISP_GC_REAP_ORPHANS=1` and restart.

## Follow-ups (non-blocking, from review)
- Add a direct test for the unreadable-root fail-safe branch.
- Candidate `List` has no `Limit` (materializes all closed wisp-tier rows) — fine at ~8k; consider keyset pagination before it grows much larger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
