### PR TITLE
fix(doctor): gc doctor --fix re-pins stale managed Dolt port files

### DIFF
--- a/cmd/gc/cmd_doctor_drift.go
+++ b/cmd/gc/cmd_doctor_drift.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -132,7 +133,7 @@ func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 		}
 		r.Message = fmt.Sprintf("%d drift issue%s between rig-local Dolt state and managed city topology", len(errors), plural)
 		r.Details = append(append([]string{}, errors...), warnings...)
-		r.FixHint = "stop the rig-local Dolt server, or acknowledge explicit rig-local ownership with `gc rig set-endpoint <rig> --self --port <port> --force`; use --external for non-local servers; remove stale .dolt/sql-server.info files"
+		r.FixHint = "`gc doctor --fix` re-pins rig port-file drift; for a live rig-local Dolt, stop it or acknowledge explicit ownership with `gc rig set-endpoint <rig> --self --port <port> --force` (use --external for non-local servers); remove stale .dolt/sql-server.info files"
 		return r
 	}
 	plural := ""
@@ -161,11 +162,18 @@ func (c *doltDriftCheck) CanFix() bool {
 // path that `gc start` runs at startup, so a stale rig port file no longer
 // requires a full restart to correct. The doctor framework re-runs Run
 // afterward to verify (and to surface any remaining non-re-pinnable drift).
-func (c *doltDriftCheck) Fix(_ *doctor.CheckContext) error {
+func (c *doltDriftCheck) Fix(ctx *doctor.CheckContext) error {
 	if c.cfg == nil {
 		return fmt.Errorf("dolt-drift: no city config available to re-pin port files")
 	}
-	return syncConfiguredDoltPortFiles(c.cityPath, c.cfg.Dolt, config.EffectiveHQPrefix(c.cfg), c.cfg.Rigs, os.Stderr)
+	// Thread the framework's output writer so re-pin diagnostics are captured
+	// with the rest of doctor output (and discarded on the JSON-collect path);
+	// fall back to stderr for direct out-of-framework calls.
+	warn := io.Writer(os.Stderr)
+	if ctx != nil && ctx.Output != nil {
+		warn = ctx.Output
+	}
+	return syncConfiguredDoltPortFiles(c.cityPath, c.cfg.Dolt, config.EffectiveHQPrefix(c.cfg), c.cfg.Rigs, warn)
 }
 
 // rigLocalDoltPIDFromSQLServerInfo reads the colon-separated PID:PORT:UUID

--- a/cmd/gc/cmd_doctor_drift.go
+++ b/cmd/gc/cmd_doctor_drift.go
@@ -19,6 +19,16 @@ import (
 type doltDriftCheck struct {
 	cityPath string
 	cfg      *config.City
+
+	// repinnablePortDrift is set by Run when at least one rig's
+	// .beads/dolt-server.port disagrees with the managed city port (Case B) —
+	// drift that re-pinning the configured port files repairs.
+	repinnablePortDrift bool
+	// liveRigLocalBlocking is set by Run when a rig configured inherited_city
+	// still has a live rig-local Dolt (Case A). Re-pinning a port file while a
+	// rig-local server is listening would point the file at the wrong server,
+	// so it suppresses the auto-fix until the operator resolves ownership.
+	liveRigLocalBlocking bool
 }
 
 func newDoltDriftCheck(cityPath string, cfg *config.City) *doltDriftCheck {
@@ -29,6 +39,10 @@ func (c *doltDriftCheck) Name() string { return "dolt-drift" }
 
 func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 	r := &doctor.CheckResult{Name: c.Name()}
+	// Reset fix-eligibility state; Run may be invoked again (the doctor re-runs
+	// it after a successful Fix to verify), so stale flags must not persist.
+	c.repinnablePortDrift = false
+	c.liveRigLocalBlocking = false
 	if c.cfg == nil || !workspaceUsesManagedBdStoreContract(c.cityPath, c.cfg.Rigs) {
 		r.Status = doctor.StatusOK
 		r.Message = "not using bd-backed Dolt topology"
@@ -75,6 +89,7 @@ func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 
 		// Case A: rig is inherited_city but has a live rig-local Dolt.
 		if liveRigLocal {
+			c.liveRigLocalBlocking = true
 			errors = append(errors, fmt.Sprintf(
 				"rig %q endpoint_origin=inherited_city but rig-local Dolt pid %d is listening on port %d (.dolt/sql-server.info); stop the rig-local server or acknowledge it with `gc rig set-endpoint %s --self --port %d --force`",
 				rig.Name, livePID, livePort, rig.Name, livePort,
@@ -94,8 +109,9 @@ func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 			if data, err := os.ReadFile(rigPortFile); err == nil {
 				got := strings.TrimSpace(string(data))
 				if got != "" && got != managedPort {
+					c.repinnablePortDrift = true
 					errors = append(errors, fmt.Sprintf(
-						"rig %q .beads/dolt-server.port=%s disagrees with managed city port %s; next `gc start` will overwrite the rig port file",
+						"rig %q .beads/dolt-server.port=%s disagrees with managed city port %s; `gc doctor --fix` re-pins it (or next `gc start` overwrites it)",
 						rig.Name, got, managedPort,
 					))
 				}
@@ -130,9 +146,27 @@ func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 	return r
 }
 
-func (c *doltDriftCheck) CanFix() bool { return false }
+// CanFix reports whether the detected drift is the re-pinnable kind: at least
+// one rig port file disagrees with the managed city port (Case B), and no rig
+// has a conflicting live rig-local Dolt (Case A). Re-pinning while a rig-local
+// server is listening would point the file at the wrong server, so that case is
+// left for the operator (the FixHint covers it). Run populates these flags and
+// is always invoked before CanFix by the doctor framework.
+func (c *doltDriftCheck) CanFix() bool {
+	return c.repinnablePortDrift && !c.liveRigLocalBlocking
+}
 
-func (c *doltDriftCheck) Fix(_ *doctor.CheckContext) error { return nil }
+// Fix re-pins the configured .beads/dolt-server.port files to the managed city
+// port, repairing Case-B drift. It reuses the same syncConfiguredDoltPortFiles
+// path that `gc start` runs at startup, so a stale rig port file no longer
+// requires a full restart to correct. The doctor framework re-runs Run
+// afterward to verify (and to surface any remaining non-re-pinnable drift).
+func (c *doltDriftCheck) Fix(_ *doctor.CheckContext) error {
+	if c.cfg == nil {
+		return fmt.Errorf("dolt-drift: no city config available to re-pin port files")
+	}
+	return syncConfiguredDoltPortFiles(c.cityPath, c.cfg.Dolt, config.EffectiveHQPrefix(c.cfg), c.cfg.Rigs, os.Stderr)
+}
 
 // rigLocalDoltPIDFromSQLServerInfo reads the colon-separated PID:PORT:UUID
 // content of rigPath/.dolt/sql-server.info (written by dolt sql-server). It

--- a/cmd/gc/cmd_doctor_drift_test.go
+++ b/cmd/gc/cmd_doctor_drift_test.go
@@ -210,7 +210,8 @@ func TestDoltDriftCheckDetectsPortFileDrift(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := newDoltDriftCheck(cityDir, cfg).Run(&doctor.CheckContext{CityPath: cityDir})
+	check := newDoltDriftCheck(cityDir, cfg)
+	r := check.Run(&doctor.CheckContext{CityPath: cityDir})
 	if r.Status != doctor.StatusError {
 		t.Fatalf("Run() status = %v, want StatusError; message=%q details=%v", r.Status, r.Message, r.Details)
 	}
@@ -220,6 +221,29 @@ func TestDoltDriftCheckDetectsPortFileDrift(t *testing.T) {
 	}
 	if !strings.Contains(joined, stalePort) || !strings.Contains(joined, managedPort) {
 		t.Errorf("want both stale %s and managed %s ports in result, got:\n%s", stalePort, managedPort, joined)
+	}
+	// Pure port-file drift (no live rig-local server) is re-pinnable, so the
+	// doctor offers `--fix`.
+	if !check.CanFix() {
+		t.Errorf("CanFix() = false after pure port-file drift, want true (re-pin is safe)")
+	}
+}
+
+// TestDoltDriftCheckCanFixGating pins the fix-eligibility decision: re-pinning
+// is offered only for port-file drift (Case B) and is suppressed when a live
+// rig-local Dolt (Case A) would make re-pinning point at the wrong server.
+func TestDoltDriftCheckCanFixGating(t *testing.T) {
+	c := &doltDriftCheck{}
+	if c.CanFix() {
+		t.Error("CanFix() = true with no drift recorded, want false")
+	}
+	c.repinnablePortDrift = true
+	if !c.CanFix() {
+		t.Error("CanFix() = false with re-pinnable port drift and no live rig-local, want true")
+	}
+	c.liveRigLocalBlocking = true
+	if c.CanFix() {
+		t.Error("CanFix() = true with a live rig-local Dolt present, want false (re-pin unsafe)")
 	}
 }
 


### PR DESCRIPTION
## Problem
The `dolt-drift` check is **detect-only** (`CanFix()=false`). When a rig's `.beads/dolt-server.port` disagrees with the managed city port (Case B), the only remedy today is a full `gc start`.

## Fix
Wire `Fix()` to reuse the existing `syncConfiguredDoltPortFiles` re-pin path that `gc start` already runs at startup.

**Scoped fix-eligibility:** `CanFix()` returns true only when there is re-pinnable port-file drift (Case B) **and** no rig has a live rig-local Dolt (Case A) — where re-pinning would point the file at the wrong server. Case A (stop the rig-local server) and Case C (stale `sql-server.info`) remain operator actions. The doctor framework re-runs `Run` after `Fix` to verify and surface any remaining non-re-pinnable drift. `Fix` threads `CheckContext.Output` so re-pin diagnostics are captured with doctor output (and discarded on the JSON-collect path), matching the `v2MigrationWarnSink` idiom.

This is general managed-Dolt-topology drift healing — independent of `[beads]` proxy mode.

## Tests
`TestDoltDriftCheckCanFixGating` (the gating decision) + a `CanFix()` assertion on `TestDoltDriftCheckDetectsPortFileDrift`. `go build ./cmd/gc` and all `dolt-drift` tests pass.

Merged to our fork first (Voxist/gascity#52).