### PR TITLE
test(tmux): fix flaky deadline-after-ready test with deterministic sync

### DIFF
--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -1027,7 +1027,11 @@ func TestDoStartSession_TreatsDeadlineAfterReadyAsSuccessWhenSessionAlive(t *tes
 	ops := &fakeStartOps{
 		hasSessionResult: true,
 		waitReadyHook: func() {
-			time.Sleep(5 * time.Millisecond)
+			// Block until context expires so ctx.Err() is guaranteed non-nil when
+			// the hook returns. time.Sleep(N) races with the context timer under
+			// high parallel load: if the timer goroutine is delayed, ctx.Err() can
+			// return nil after the sleep, causing an extra acceptStartupDialogs call.
+			<-ctx.Done()
 		},
 	}
 

--- a/release-gates/ga-kw7i0z-flaky-tmux-gate.md
+++ b/release-gates/ga-kw7i0z-flaky-tmux-gate.md
@@ -1,0 +1,57 @@
+# Release gate - tmux startup deadline test flake (ga-kw7i0z)
+
+**Verdict:** PASS
+
+- Deploy bead: `ga-kw7i0z`
+- Source review bead: `ga-8hxfet` (closed PASS)
+- PR: https://github.com/gastownhall/gascity/pull/3530
+- Branch: `builder/ga-p3z19x-flaky-deadline-test`
+- Gate input HEAD: `6a7af8e174afd778feac0911eb35615a555329e6`
+- Current `origin/main`: `8c84dc3902149cff17137f0f994c31f2a2ea3733`
+- Merge-tree result against current main: `2608c8b5a228adb26859ff26865f18380c4bf329`
+- Gate run date: 2026-06-15
+- Project manifest note: `docs/PROJECT_MANIFEST.md` is not present in this checkout; this gate uses the deployer prompt's release criteria plus the bead acceptance context.
+
+## Scope note
+
+The branch history contains two test-stability commits:
+
+- `41114c1ff` - integration `uniqueCityName` prefix collision fix
+- `6a7af8e17` - tmux startup deadline-after-ready race fix
+
+Current `origin/main` already contains the integration prefix-collision fix as
+`e5bae16a7`, so the clean merge result against current main changes only:
+
+- `internal/runtime/tmux/startup_test.go`
+
+`git diff origin/main 2608c8b5a228adb26859ff26865f18380c4bf329` shows a
+single-file merge effect: 5 insertions and 1 deletion in the tmux startup test.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Reviewer PASS verdict in bead notes | PASS | Review bead `ga-8hxfet` is closed with `VERDICT: PASS` for commit `6a7af8e17`; deploy bead `ga-kw7i0z` records reviewed + passed status. |
+| 2 | Acceptance criteria met | PASS | The effective merge changes `TestDoStartSession_TreatsDeadlineAfterReadyAsSuccessWhenSessionAlive` to wait on `<-ctx.Done()` instead of sleeping 5ms, guaranteeing `ctx.Err()` is non-nil before the post-ready branch is evaluated. No production code changes. |
+| 3 | Tests pass on final branch | PASS | Local focused tmux test, focused integration smoke, `go vet ./...`, and `make test-fast-parallel` all passed. GitHub CI run `27573629348` completed `success`, including required preflight and integration summaries. |
+| 4 | No high-severity review findings open | PASS | Review notes contain only non-blocking INFO follow-ups; unresolved HIGH finding count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before this gate file was added. This gate file is the only deployer change. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` completed successfully with tree `2608c8b5a228adb26859ff26865f18380c4bf329`; PR #3530 reports `mergeStateStatus: CLEAN`. |
+| 7 | Single feature theme | PASS | The effective merge surface is a single tmux test flake fix. The branch's integration-helper commit is already present on main and has no additional merge effect. |
+
+## Validation
+
+- `go test ./internal/runtime/tmux -run 'TestDoStartSession_TreatsDeadlineAfterReadyAsSuccessWhenSessionAlive|TestDoStartSession_TreatsDeadlineAfterPostReadyAsSuccessWhenSessionAlive' -count=20` - PASS
+- `go test -tags integration ./test/integration -run 'TestHumaBinary|TestSupervisor' -count=1 -timeout=5m` - PASS (`77.378s`)
+- `go vet ./...` - PASS
+- `make test-fast-parallel` - PASS (`All fast jobs passed`)
+- `git diff --check origin/main...HEAD` - PASS
+- GitHub CI run `27573629348` - PASS (`conclusion: success`)
+
+## Non-gating local note
+
+An over-broad local package command, `go test -tags integration ./test/integration -run Test -count=1`, hit the default 10-minute package timeout in `TestE2E_Restart`. That command is not one of the documented sharded local runners and is broader than the deploy smoke requested for this test-only branch. The focused integration smoke and the PR's sharded CI integration suite both passed.
+
+## Push target
+
+PR #3530 is already open from `gastownhall/gascity:builder/ga-p3z19x-flaky-deadline-test` to `main`. Push target should remain `origin` if the deployer dry-run rule confirms write access.

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -31,12 +31,22 @@ func usingSubprocess() bool {
 }
 
 // uniqueCityName generates a random city name for test isolation.
+//
+// Names like "gctest-{hex}" all derive to Dolt DB prefix "gc" via
+// DeriveBeadsPrefix, causing dirty-table schema migration failures when
+// tests share a Dolt server and a prior run crashes. Instead, generate
+// a 6-letter random name: DeriveBeadsPrefix returns the first 2 chars,
+// giving 26² = 676 distinct prefixes across the test suite.
 func uniqueCityName() string {
-	b := make([]byte, 4)
+	b := make([]byte, 6)
 	if _, err := rand.Read(b); err != nil {
 		panic("generating random city name: " + err.Error())
 	}
-	return fmt.Sprintf("gctest-%x", b)
+	name := make([]byte, 6)
+	for i, c := range b {
+		name[i] = 'a' + c%26
+	}
+	return string(name)
 }
 
 // setupCity creates a city directory, initializes it, writes a city.toml


### PR DESCRIPTION
## What this changes

This removes a timing race from `TestDoStartSession_TreatsDeadlineAfterReadyAsSuccessWhenSessionAlive`. The test now waits for the context to actually finish with `<-ctx.Done()` instead of sleeping for 5ms and hoping the 1ms timer fired on schedule.

The behavior under test is unchanged: when tmux reports the session as ready, a deadline that expires immediately afterward should still be treated as success if the session is alive. This PR makes the assertion deterministic under parallel load.

## Review notes

- Test-only change; no production runtime behavior changes.
- The effective merge against current `main` changes only `internal/runtime/tmux/startup_test.go`.
- The branch history includes an integration helper commit that is already present on `main`; the release gate records the merge-tree check and actual merge effect.

## Test plan

- [x] `go test ./internal/runtime/tmux -run 'TestDoStartSession_TreatsDeadlineAfterReadyAsSuccessWhenSessionAlive|TestDoStartSession_TreatsDeadlineAfterPostReadyAsSuccessWhenSessionAlive' -count=20`
- [x] `go test -tags integration ./test/integration -run 'TestHumaBinary|TestSupervisor' -count=1 -timeout=5m`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] GitHub CI passed on the reviewed code commit; gate commit is documentation-only
- [x] Release gate: [`release-gates/ga-kw7i0z-flaky-tmux-gate.md`](release-gates/ga-kw7i0z-flaky-tmux-gate.md)