### PR TITLE
fix(dispatch): coalesce control-dispatcher wake events to stop per-event Dolt re-scan

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -5975,6 +5975,52 @@ func TestWaitForRelevantWorkflowWakeTraceIncludesBackoffState(t *testing.T) {
 	}
 }
 
+func TestWaitForRelevantWorkflowWakeCoalescesBurst(t *testing.T) {
+	prevDebounce := workflowServeWakeDebounce
+	workflowServeWakeDebounce = 50 * time.Millisecond
+	defer func() { workflowServeWakeDebounce = prevDebounce }()
+
+	const burst = 8
+	eventCh := make(chan workflowWatchResult, burst)
+	for i := 0; i < burst; i++ {
+		eventCh <- workflowWatchResult{evt: events.Event{Type: events.BeadUpdated, Subject: fmt.Sprintf("mc-wisp-%d", i)}}
+	}
+
+	// A single wait call must drain the whole buffered burst and return exactly
+	// one wake, so runWorkflowServeFollow performs one re-scan for the burst
+	// rather than one per event.
+	eventWake, err := waitForRelevantWorkflowWake(eventCh, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !eventWake {
+		t.Fatal("eventWake = false, want true when a relevant burst arrives")
+	}
+	if leftover := len(eventCh); leftover != 0 {
+		t.Fatalf("eventCh still has %d buffered events after one wake; want 0 (burst not coalesced)", leftover)
+	}
+}
+
+func TestWaitForRelevantWorkflowWakeBurstSurfacesWatcherErr(t *testing.T) {
+	prevDebounce := workflowServeWakeDebounce
+	workflowServeWakeDebounce = 50 * time.Millisecond
+	defer func() { workflowServeWakeDebounce = prevDebounce }()
+
+	eventCh := make(chan workflowWatchResult, 2)
+	eventCh <- workflowWatchResult{evt: events.Event{Type: events.BeadUpdated, Subject: "gc-1"}}
+	eventCh <- workflowWatchResult{err: os.ErrDeadlineExceeded}
+
+	// A fatal stream error that arrives during the coalescing window must still
+	// terminate the serve loop, not be swallowed by the debounce drain.
+	eventWake, err := waitForRelevantWorkflowWake(eventCh, time.Second)
+	if err == nil {
+		t.Fatal("wait returned nil err, want watcher err surfaced from coalescing window")
+	}
+	if eventWake {
+		t.Fatal("eventWake = true on error path, want false")
+	}
+}
+
 func TestWorkflowTracefWarnsOnceWhenTracePathCannotBeOpened(t *testing.T) {
 	tracePath := filepath.Join(t.TempDir(), "missing", "workflow-trace.log")
 	t.Setenv("GC_WORKFLOW_TRACE", tracePath)

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -4835,6 +4835,90 @@ func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testi
 	}
 }
 
+// TestRunWorkflowServeFollowDrainsObservedWakeBeforeSurfacingWatcherErr is the
+// regression guard for the coalescing bug where a relevant event observed just
+// before a fatal watcher error was consumed without its promised re-scan. When
+// the wait reports a relevant wake AND a pending fatal stream error (the error
+// arrived inside the same coalescing window), the loop must perform the one
+// drain that wake scheduled before surfacing the error, so newly-ready work is
+// serviced in-process rather than stranded until an external dispatcher
+// restart re-scans.
+func TestRunWorkflowServeFollowDrainsObservedWakeBeforeSurfacingWatcherErr(t *testing.T) {
+	eventsDir := t.TempDir()
+	ep := newTestProvider(t, eventsDir)
+
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevProvider := workflowServeOpenEventsProvider
+	prevWait := workflowServeWaitForWake
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	t.Cleanup(func() {
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeOpenEventsProvider = prevProvider
+		workflowServeWaitForWake = prevWait
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	workflowServeOpenEventsProvider = func(io.Writer) (events.Provider, error) { return ep, nil }
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+
+	watcherErr := errors.New("event stream closed")
+	waitCalls := 0
+	workflowServeWaitForWake = func(_ <-chan workflowWatchResult, _ time.Duration, _ int) (bool, error) {
+		waitCalls++
+		if waitCalls == 1 {
+			// A relevant event was observed, then a fatal watcher error arrived
+			// inside the coalescing window: report the wake AND the error.
+			return true, watcherErr
+		}
+		t.Fatalf("unexpected wait call %d: the loop must drain the observed wake and exit, not wait again", waitCalls)
+		return false, watcherErr
+	}
+
+	listCalls := 0
+	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+		listCalls++
+		switch listCalls {
+		case 1:
+			// Initial drain before the first wait: nothing ready yet.
+			return nil, nil
+		case 2:
+			// The re-scan the observed wake promised finds newly-ready work that
+			// must be processed before the loop surfaces the watcher error.
+			return []hookBead{{ID: "gc-woke", Metadata: map[string]string{"gc.kind": "scope-check"}}}, nil
+		case 3:
+			// Drain's internal exit poll after processing gc-woke.
+			return nil, nil
+		default:
+			t.Fatalf("unexpected list call %d: the loop must perform exactly one re-scan for the observed wake before exiting", listCalls)
+			return nil, nil
+		}
+	}
+	processedAfterWake := false
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
+		if beadID == "gc-woke" {
+			processedAfterWake = true
+		}
+		return nil
+	}
+
+	agent := config.Agent{Name: "control-dispatcher"}
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
+	if !errors.Is(err, watcherErr) {
+		t.Fatalf("runWorkflowServeFollow error = %v, want %v", err, watcherErr)
+	}
+	if waitCalls != 1 {
+		t.Fatalf("wait calls = %d, want 1 (loop must drain the observed wake then exit, not wait again)", waitCalls)
+	}
+	if !processedAfterWake {
+		t.Fatal("observed wake's newly-ready bead was not processed before the watcher error surfaced")
+	}
+}
+
 // TestRunWorkflowServeFollowSurvivesTransientWorkQueryTimeout is the
 // regression guard for the bug where a single transient work-query timeout
 // (the bead store briefly saturated) killed the entire control-dispatcher
@@ -5895,6 +5979,12 @@ func TestFollowSleepDurationBacksOffThenCaps(t *testing.T) {
 }
 
 func TestWaitForRelevantWorkflowWakeReturnsTrueOnRelevantEvent(t *testing.T) {
+	// Set the debounce explicitly so a lone relevant wake is fast and
+	// intentional rather than silently inheriting the package default.
+	prevDebounce := workflowServeWakeDebounce
+	workflowServeWakeDebounce = 5 * time.Millisecond
+	defer func() { workflowServeWakeDebounce = prevDebounce }()
+
 	eventCh := make(chan workflowWatchResult, 1)
 	eventCh <- workflowWatchResult{evt: events.Event{Type: events.BeadCreated, Subject: "gc-1"}}
 
@@ -6011,13 +6101,45 @@ func TestWaitForRelevantWorkflowWakeBurstSurfacesWatcherErr(t *testing.T) {
 	eventCh <- workflowWatchResult{err: os.ErrDeadlineExceeded}
 
 	// A fatal stream error that arrives during the coalescing window must still
-	// terminate the serve loop, not be swallowed by the debounce drain.
+	// terminate the serve loop, but the relevant event observed just before it
+	// must still report a wake so runWorkflowServeFollow performs the one
+	// promised re-scan for that wake before surfacing the error. Returning
+	// (false, err) here would strand the just-observed work until a dispatcher
+	// restart re-scans.
 	eventWake, err := waitForRelevantWorkflowWake(eventCh, time.Second)
 	if err == nil {
 		t.Fatal("wait returned nil err, want watcher err surfaced from coalescing window")
 	}
-	if eventWake {
-		t.Fatal("eventWake = true on error path, want false")
+	if !eventWake {
+		t.Fatal("eventWake = false, want true: the relevant event observed before the error must still wake the loop for its re-scan")
+	}
+}
+
+func TestWaitForRelevantWorkflowWakeDisabledDebounceDoesNotCoalesce(t *testing.T) {
+	prevDebounce := workflowServeWakeDebounce
+	workflowServeWakeDebounce = 0
+	defer func() { workflowServeWakeDebounce = prevDebounce }()
+
+	// With coalescing disabled (debounce <= 0) the escape hatch restores
+	// one-event-one-drain: a relevant event still wakes the loop, but the helper
+	// must not consume any trailing buffered events.
+	eventCh := make(chan workflowWatchResult, 2)
+	eventCh <- workflowWatchResult{evt: events.Event{Type: events.BeadCreated, Subject: "gc-1"}}
+	eventCh <- workflowWatchResult{evt: events.Event{Type: events.BeadCreated, Subject: "gc-2"}}
+
+	start := time.Now()
+	eventWake, err := waitForRelevantWorkflowWake(eventCh, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !eventWake {
+		t.Fatal("eventWake = false, want true for a relevant event with coalescing disabled")
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("returned after %v, want near-immediate when debounce is disabled", elapsed)
+	}
+	if leftover := len(eventCh); leftover != 1 {
+		t.Fatalf("eventCh has %d buffered events, want 1 (disabled debounce must not drain the trailing event)", leftover)
 	}
 }
 

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -61,8 +61,15 @@ var (
 	workflowServeIdlePollAttempts  = 3
 	workflowServeWakeSweepInterval = 1 * time.Second
 	workflowServeMaxIdleSleep      = 30 * time.Second
-	workflowServeWaitForWake       = waitForRelevantWorkflowWakeWithTrace
-	workflowTraceNow               = time.Now
+	// workflowServeWakeDebounce is the coalescing window opened once the first
+	// relevant event wakes the --follow loop. Additional buffered events that
+	// arrive during the window are drained and folded into the same wake so a
+	// burst of N bead.* events (e.g. an mc-wisp-* event storm) collapses into a
+	// single work/ready re-scan instead of N heavy per-event Dolt scans.
+	// Injectable so tests can shrink it. Fixes gastownhall/gascity#3206.
+	workflowServeWakeDebounce = 250 * time.Millisecond
+	workflowServeWaitForWake  = waitForRelevantWorkflowWakeWithTrace
+	workflowTraceNow          = time.Now
 	// The trace helper is intentionally process-global because workflowTracef
 	// does not carry per-invocation context. Nested installs (serve ->
 	// runControlDispatcherWithStore) reuse the active dedup map so one bad trace
@@ -593,6 +600,16 @@ func waitForRelevantWorkflowWakeWithTrace(eventCh <-chan workflowWatchResult, sl
 				} else {
 					workflowTracef("serve wake-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
 				}
+				// Coalesce a burst: keep draining buffered events for a short
+				// debounce window so N relevant events collapse into one drain.
+				// runWorkflowServeFollow does exactly one drain per return=true,
+				// so the trailing events are already covered by that single
+				// re-scan — no event is dropped, only batched.
+				if coalesced, err := coalesceWorkflowWakeBurst(eventCh); err != nil {
+					return false, err
+				} else if coalesced > 0 {
+					workflowTracef("serve wake-coalesce extra=%d debounce=%s", coalesced, workflowServeWakeDebounce)
+				}
 				return true, nil
 			}
 			workflowTracef("serve ignore-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
@@ -603,6 +620,34 @@ func waitForRelevantWorkflowWakeWithTrace(eventCh <-chan workflowWatchResult, sl
 				workflowTracef("serve wake-sweep")
 			}
 			return false, nil
+		}
+	}
+}
+
+// coalesceWorkflowWakeBurst drains additional buffered events from eventCh for
+// the workflowServeWakeDebounce window after a relevant event has already
+// decided to wake the loop. It returns the number of extra events it folded
+// into this wake so the caller emits a single drain for the whole burst. A
+// watcher error encountered while draining is surfaced so the serve loop still
+// terminates on a fatal stream failure. Events are only batched here, never
+// dropped: the caller's single re-scan already reflects every drained event.
+func coalesceWorkflowWakeBurst(eventCh <-chan workflowWatchResult) (int, error) {
+	if workflowServeWakeDebounce <= 0 {
+		return 0, nil
+	}
+	debounce := time.NewTimer(workflowServeWakeDebounce)
+	defer debounce.Stop()
+
+	coalesced := 0
+	for {
+		select {
+		case res := <-eventCh:
+			if res.err != nil {
+				return coalesced, res.err
+			}
+			coalesced++
+		case <-debounce.C:
+			return coalesced, nil
 		}
 	}
 }

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -65,8 +65,12 @@ var (
 	// relevant event wakes the --follow loop. Additional buffered events that
 	// arrive during the window are drained and folded into the same wake so a
 	// burst of N bead.* events (e.g. an mc-wisp-* event storm) collapses into a
-	// single work/ready re-scan instead of N heavy per-event Dolt scans.
-	// Injectable so tests can shrink it. Fixes gastownhall/gascity#3206.
+	// single work/ready re-scan instead of N heavy per-event Dolt scans. This is
+	// a fixed (max-wait) window, so a lone relevant wake also waits out the
+	// window before its drain; the delay is intentional and small relative to
+	// the 1–30s idle sleeps it replaces. Set it to 0 to disable coalescing and
+	// restore one-event-one-drain. Injectable so tests can shrink it. Fixes
+	// gastownhall/gascity#3206.
 	workflowServeWakeDebounce = 250 * time.Millisecond
 	workflowServeWaitForWake  = waitForRelevantWorkflowWakeWithTrace
 	workflowTraceNow          = time.Now
@@ -514,6 +518,7 @@ func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuer
 	go pumpWorkflowEvents(done, watcher, eventCh)
 
 	idleSweeps := 0
+	var pendingWakeErr error
 	for {
 		drainResult, err := drainWorkflowServeWork(agentCfg, cityPath, storePath, workQuery, workEnv, stderr)
 		if err != nil {
@@ -532,6 +537,13 @@ func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuer
 			workflowTracef("serve drain-transient-retry agent=%s err=%v", agentCfg.QualifiedName(), err)
 			drainResult = workflowServeDrainResult{}
 		}
+		if pendingWakeErr != nil {
+			// The previous wait observed a relevant event and then a fatal
+			// watcher error in the same coalescing window. The drain above is
+			// the one re-scan that wake promised, so the observed work is now
+			// serviced; surface the watcher error to end the loop.
+			return pendingWakeErr
+		}
 		if drainResult.processedAny || drainResult.pendingAny {
 			idleSweeps = 0
 		}
@@ -546,7 +558,17 @@ func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuer
 		)
 		eventWake, err := workflowServeWaitForWake(eventCh, sleepDur, idleSweeps)
 		if err != nil {
-			return err
+			if !eventWake {
+				// Fatal stream error with no relevant event observed: nothing to
+				// re-scan, so terminate immediately.
+				return err
+			}
+			// A relevant event was observed just before the fatal error. Loop
+			// once more so the next drain services that wake, then surface the
+			// error on the following iteration.
+			pendingWakeErr = err
+			idleSweeps = 0
+			continue
 		}
 		switch {
 		case eventWake, drainResult.pendingAny:
@@ -605,12 +627,18 @@ func waitForRelevantWorkflowWakeWithTrace(eventCh <-chan workflowWatchResult, sl
 				// runWorkflowServeFollow does exactly one drain per return=true,
 				// so the trailing events are already covered by that single
 				// re-scan — no event is dropped, only batched.
-				if coalesced, err := coalesceWorkflowWakeBurst(eventCh); err != nil {
-					return false, err
-				} else if coalesced > 0 {
+				coalesced, coalesceErr := coalesceWorkflowWakeBurst(eventCh)
+				if coalesced > 0 {
 					workflowTracef("serve wake-coalesce extra=%d debounce=%s", coalesced, workflowServeWakeDebounce)
 				}
-				return true, nil
+				// Report the wake even when a fatal stream error arrived during
+				// the coalescing window: a relevant event was already observed,
+				// so runWorkflowServeFollow must still perform the one re-scan it
+				// promised for that wake before terminating. Surfacing
+				// (true, err) lets the caller drain the observed wake and then
+				// exit on the error, instead of stranding newly-ready work until
+				// a dispatcher restart re-scans.
+				return true, coalesceErr
 			}
 			workflowTracef("serve ignore-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
 		case <-timer.C:
@@ -627,10 +655,12 @@ func waitForRelevantWorkflowWakeWithTrace(eventCh <-chan workflowWatchResult, sl
 // coalesceWorkflowWakeBurst drains additional buffered events from eventCh for
 // the workflowServeWakeDebounce window after a relevant event has already
 // decided to wake the loop. It returns the number of extra events it folded
-// into this wake so the caller emits a single drain for the whole burst. A
-// watcher error encountered while draining is surfaced so the serve loop still
-// terminates on a fatal stream failure. Events are only batched here, never
-// dropped: the caller's single re-scan already reflects every drained event.
+// into this wake so the caller emits a single drain for the whole burst, plus
+// any watcher error encountered while draining. The caller pairs that error
+// with the already-observed wake (returning true, err) so the serve loop still
+// performs the one promised re-scan before terminating on a fatal stream
+// failure. Events are only batched here, never dropped: the caller's single
+// re-scan already reflects every drained event.
 func coalesceWorkflowWakeBurst(eventCh <-chan workflowWatchResult) (int, error) {
 	if workflowServeWakeDebounce <= 0 {
 		return 0, nil


### PR DESCRIPTION
## Bug
The control-dispatcher serve loop re-runs the full work/ready scan on **every** relevant `bead.*` event with no coalescing. Under an `mc-wisp-*` event storm this drives a heavy federated Dolt ready-scan per event — a primary contributor to runaway Dolt SELECT load (observed `Com_select` ~112/s → ~1,500/s, decoupled from the ~5-min reconcile cadence).
## Fix
Coalesce a burst of buffered relevant events into a single drain (one re-scan) via a debounce window in `waitForRelevantWorkflowWakeWithTrace`. No events dropped; watcher errors still terminate the loop.
## Tests
`cmd_convoy_dispatch_test.go`: `TestWaitForRelevantWorkflowWakeCoalescesBurst`, `…BurstSurfacesWatcherErr`. Build + tests green. (Also shipped on `release/v1.3.0` as `77fb05672`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
