### PR TITLE
feat(beads-doltlite): add example pack

### DIFF
--- a/examples/beads-doltlite/DOCTOR-CHECKS-REVIEW.md
+++ b/examples/beads-doltlite/DOCTOR-CHECKS-REVIEW.md
@@ -1,0 +1,191 @@
+# Beads DoltLite Doctor Check Review
+
+This note anchors the doctor-check work for bead `gc-eyyi`. Any follow-up
+bead that references this work should link back to this file plus the source
+references below, so the implementer starts from the actual integration code
+instead of a generic pack checklist.
+
+## Required References
+
+- DoltLite README: [../../../doltlite/README.md](../../../doltlite/README.md)
+- Builtin Beads DoltLite pack manifest: [pack.toml](pack.toml)
+- Builtin Beads DoltLite pack commands: [commands/](commands/)
+- Existing pack-local doctor checks: [doctor/](doctor/)
+- Beads DoltLite source README: [../../../beads-doltlite/README.md](../../../beads-doltlite/README.md)
+- Beads DoltLite source doctor package: [../../../beads-doltlite/cmd/bd/doctor/](../../../beads-doltlite/cmd/bd/doctor/)
+- Beads DoltLite source health entrypoint: [../../../beads-doltlite/cmd/bd/doctor_health.go](../../../beads-doltlite/cmd/bd/doctor_health.go)
+- Beads DoltLite backend open path: [../../../beads-doltlite/beads_cgo.go](../../../beads-doltlite/beads_cgo.go)
+- Non-CGO DoltLite failure path: [../../../beads-doltlite/beads_nocgo.go](../../../beads-doltlite/beads_nocgo.go)
+- Gas City `gc bd` store bridge: [../../cmd/gc/cmd_bd_store_bridge.go](../../cmd/gc/cmd_bd_store_bridge.go)
+- Gas City built-in pack coverage for the build command: [../../cmd/gc/embed_builtin_packs_test.go](../../cmd/gc/embed_builtin_packs_test.go)
+- Gas City pack doctor script contract: [../../internal/doctor/pack_checks.go](../../internal/doctor/pack_checks.go)
+
+## What Was Reviewed
+
+- Gas City pack doctor checks are executable scripts loaded from pack doctor
+  declarations. The script protocol is exit `0` for OK, exit `1` for warning,
+  exit `2` or other non-zero for error. The first stdout line is the message;
+  later lines are details. Scripts receive `GC_CITY_PATH` and `GC_PACK_DIR`.
+- This builtin pack source currently has one pack-local doctor check under
+  `doctor/check-sqlite3`. A runtime/imported `gascity-packs` copy has more
+  DoltLite checks, but that tree is not the source of truth for this bead. Work
+  in this rig should update the builtin pack source here.
+- This builtin pack exposes operational commands under `commands/`: `build`,
+  `client`, `flatten`, `gc`, and `health`.
+- The pack `build` command is responsible for building DoltLite-linked `gc`,
+  `bd`, and the debug client with `CGO_ENABLED=1`, libsqlite3/libdoltlite
+  link flags, install targets, and build-detail JSON.
+- Gas City's `gc bd` store bridge switches to DoltLite by reading
+  `.beads/metadata.json` or `GC_BEADS_BACKEND` / `BEADS_BACKEND`, then sets
+  `GC_BEADS_BACKEND=doltlite` and `BEADS_BACKEND=doltlite` for bd operations.
+- The beads source opens DoltLite only in CGO builds. Non-CGO builds return a
+  clear `doltlite requires a CGO build` error.
+- The DoltLite README documents that libdoltlite installs a CLI, headers, a
+  static library, and shared libraries, and that Go integration uses
+  `mattn/go-sqlite3` with the `libsqlite3` build tag and CGO link flags.
+
+## Builtin-Pack Audit Question
+
+Before adding more checks, audit whether `beads-doltlite` still needs to be a
+builtin pack.
+
+Initial answer from the current code review: keep it builtin for now, but
+record exactly which responsibilities force that. The pack is part of the
+bootstrap story for DoltLite-backed Gas City installs because it carries the
+`build` command that produces DoltLite-linked `gc` and `bd` binaries, the
+maintenance commands used by DoltLite health/maintenance orders, and the
+pack-local doctor entrypoint that `gc doctor` can discover during builtin pack
+materialization. That is stronger than a normal optional workflow pack.
+
+The weak point in the current case for builtin status is that the source pack
+does not yet own much doctor coverage: it has only `check-sqlite3`, while the
+operationally interesting checks are either in the `bd` source doctor package,
+in Gas City's `gc bd` bridge, or in a runtime/imported pack copy. The audit
+should decide whether to move those checks into this builtin source pack,
+whether to rely on `bd doctor`, or whether the pack can later become a normal
+import once install/bootstrap no longer depends on embedded availability.
+
+Reasons it may need to stay builtin:
+
+- It participates in bootstrapping the active beads backend for a city.
+- It installs/builds `gc`, `bd`, and DoltLite-linked binaries that may be
+  needed before external pack import is reliable.
+- It provides doctor checks for runtime materialization and `gc bd` behavior.
+
+Reasons it may not need to stay builtin:
+
+- If the only remaining responsibilities are optional maintenance commands and
+  documentation, a normal imported pack may be sufficient.
+- If Gas City can reliably import and materialize this pack before any
+  DoltLite-backed bead operation, builtin status may be unnecessary.
+- If `gc bd` no longer depends on this pack's assets to operate, the pack can
+  potentially be externalized.
+
+The audit should identify which startup/install/doctor paths truly require
+builtin availability and which can move to normal pack import later.
+
+## How Gas City Doctor Checks Run
+
+Gas City discovers pack doctor checks from pack metadata and conventional
+`doctor/<name>/run.sh` files. Each discovered check becomes a `PackScriptCheck`.
+The check script runs with its working directory set to the pack directory and
+receives `GC_CITY_PATH` plus `GC_PACK_DIR`. A script can also declare a fix
+script through `doctor.toml`; `gc doctor --fix` runs that fix script with the
+same environment contract.
+
+Pack doctor output is intentionally simple:
+
+- exit `0`: OK
+- exit `1`: warning
+- exit `2` or any other non-zero: error
+- first stdout line: short result message
+- remaining non-empty stdout lines: verbose details
+
+This means new `beads-doltlite` checks should be small shell scripts under
+`doctor/<check-name>/run.sh` with optional `doctor.toml` metadata. They should
+not require changes to Gas City's core doctor implementation unless the pack
+doctor protocol itself is insufficient.
+
+## How The Beads DoltLite Pack Works
+
+The builtin pack is embedded from `examples/beads-doltlite/embed.go`. Its
+`PackFS` includes `pack.toml`, `doctor`, `commands`, `formulas`, `orders`, and
+`assets`. The pack imports and exports the `bd` pack, so regular beads
+operations still flow through the `bd` provider wrapper. The DoltLite pack adds
+DoltLite-specific operational surfaces:
+
+- `commands/build`: builds DoltLite-linked `gc`, `bd`, and debug client
+  binaries using `CGO_ENABLED=1`, `libsqlite3`, and `libdoltlite`.
+- `commands/health`: runs a bd-backed health/status probe with
+  `BEADS_BACKEND=doltlite` and `GC_BEADS_BACKEND=doltlite`.
+- `commands/flatten`: runs `bd flatten --force --json`.
+- `commands/gc`: runs `bd gc --force --json`.
+- `commands/client`: runs the DoltLite debug client built by the pack.
+
+Gas City's `gc bd` bridge detects DoltLite mode by checking
+`GC_BEADS_BACKEND`, `BEADS_BACKEND`, or `.beads/metadata.json` with
+`backend = "doltlite"` or `database = "doltlite"`. In DoltLite mode it sets
+`GC_BEADS_BACKEND=doltlite` and `BEADS_BACKEND=doltlite` for bd operations
+instead of configuring a managed Dolt SQL server.
+
+The beads source code has a separate backend open path: in CGO builds,
+`OpenBestAvailable` opens `internal/storage/doltlite` when config says
+DoltLite. In non-CGO builds, DoltLite returns a clear error because DoltLite
+requires CGO.
+
+## Doctor Check Inventory
+
+These checks should remain pack-local. If a check needs Gas City state, the
+pack script should inspect it through supported runtime environment or CLI
+output rather than moving logic into unrelated Gas City core doctor code.
+
+- Pack materialization: verify this builtin pack is active, `GC_PACK_DIR`
+  points at a readable pack checkout, and the active pack contains expected
+  command and doctor directories.
+- Backend metadata: verify the active `.beads/metadata.json` selects
+  `backend = "doltlite"` or `database = "doltlite"` when the city expects the
+  DoltLite backend.
+- `gc bd` bridge: verify `gc bd` operations run with
+  `GC_BEADS_BACKEND=doltlite` / `BEADS_BACKEND=doltlite` and do not fall back
+  to an unrelated global bd database.
+- Binary availability: verify `gc`, `bd`, `sqlite3`, and `doltlite` or
+  libdoltlite artifacts are discoverable using documented pack discovery rules.
+- Linked build details: verify the build command wrote usable build-detail JSON
+  for `gc` and `bd`, including tags, CGO state, libdoltlite path, binary path,
+  and checksum.
+- Linked binary sanity: verify linked `gc` and `bd` report `CGO_ENABLED=1` via
+  `go version -m` where available, and warn when the check cannot be performed
+  on the platform.
+- DoltLite library layout: verify libdoltlite shared/static library and headers
+  are present in the configured or discovered build/install location.
+- Safe read smoke: run a read-only bd status/list style check against the active
+  DoltLite store and report actionable errors.
+- Optional write smoke: provide an opt-in disposable-scope write/read/update
+  smoke check so routine doctor runs do not mutate production work.
+- Maintenance safety: warn before `flatten` or `VACUUM` style maintenance runs
+  while the city is not quiesced or active writers are present.
+- SQLite/DoltLite pragmas: report WAL/busy-timeout or equivalent state where it
+  is inspectable, and warn when the active build path cannot prove lock
+  behavior.
+- Direct-write contract: report whether direct table writes are expected to be
+  versioned and durable; point to the chosen single-writer path when raw writes
+  are unsafe.
+- Cross-platform behavior: guard Linux/macOS-specific probes and emit
+  unsupported warnings instead of failing mysteriously on other systems.
+- Remediation text: every warning/error should include a concrete command or
+  source reference suitable for a fresh Gas City install.
+
+## Bead Authoring Rule
+
+Any new bead created from this review should include links to:
+
+- this file,
+- [../../../doltlite/README.md](../../../doltlite/README.md),
+- [pack.toml](pack.toml),
+- [commands/](commands/),
+- [doctor/](doctor/), and
+- [../../../beads-doltlite/README.md](../../../beads-doltlite/README.md).
+
+Do not sling doctor-check work until the implementer has reviewed these
+references, the current pack-local doctor scripts, and the actual DoltLite
+integration code paths listed above.

--- a/examples/beads-doltlite/assets/scripts/runtime.sh
+++ b/examples/beads-doltlite/assets/scripts/runtime.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# doltlite runtime utilities — shared functions for doltlite maintenance ops.
+# The doltlite backend stores data via the bd CLI with BEADS_BACKEND=doltlite.
+# The actual database is at .beads/doltlite/<database>.db (SQLite with Dolt VC API).
+set -euo pipefail
+
+doltlite_scope_dir() {
+  local beads_dir="${1:-${BEADS_DIR:-${GC_CITY_PATH:-.}/.beads}}"
+  echo "${beads_dir%/.*}"
+}
+
+run_bd_doltlite() {
+  local dir="$1"
+  shift
+  cd "$dir" || die "cannot enter $dir"
+  export BEADS_BACKEND=doltlite GC_BEADS_BACKEND=doltlite BD_NON_INTERACTIVE=1
+  bd "$@"
+}

--- a/examples/beads-doltlite/commands/build/command.toml
+++ b/examples/beads-doltlite/commands/build/command.toml
@@ -1,0 +1,1 @@
+description = "Build gc, bd, or the DoltLite client against libdoltlite"

--- a/examples/beads-doltlite/commands/build/run.sh
+++ b/examples/beads-doltlite/commands/build/run.sh
@@ -1,0 +1,1154 @@
+#!/usr/bin/env bash
+# Build DoltLite-linked binaries with CGO/libsqlite3.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: gc beads-doltlite build [gc|bd|client|all] [options]
+
+Builds DoltLite-linked binaries from the Gas City and beads-doltlite source trees.
+The default target is gc.
+
+Options:
+  --source DIR       Source checkout for the selected single target.
+  --gc-source DIR    Gas City source checkout. Default: ./gascity, current dir, or script checkout.
+  --bd-source DIR    beads-doltlite source checkout. Default: ./beads-doltlite or adjacent checkout.
+  --doltlite-source DIR
+                     DoltLite source checkout. Default: ./doltlite or adjacent checkout.
+  --lib DIR          Directory containing libdoltlite.so. Default: ./doltlite-work/build or ./doltlite/build.
+  --bootstrap-dir DIR
+                     Source checkout cache for missing DoltLite/beads-doltlite deps.
+                     Default: <city>/.cache/beads-doltlite/sources.
+  --doltlite-repo URL
+                     DoltLite source repo. Default: https://github.com/dolthub/doltlite.git.
+  --bd-repo URL      beads-doltlite source repo. Default: https://github.com/duncan4123/beads-doltlite.git.
+  --no-bootstrap     Do not clone/build missing DoltLite or beads-doltlite deps.
+  --output FILE      Build output path for the selected single target.
+  --gc-output FILE   Build output path for gc. Default: <gc-source>/bin/gc.
+  --bd-output FILE   Build output path for bd. Default: <bd-source>/bin/bd.
+  --client-output FILE
+                     Build output path for doltlite-client.
+                     Default: <build-details-dir>/bin/doltlite-client.
+  --install          Install built binaries after link verification.
+  --install-dir DIR  Install directory for both binaries.
+                     Default: existing supervisor gc path, active binary under $HOME,
+                     else $HOME/.local/bin.
+  --gc-install FILE  Install path for gc.
+  --bd-install FILE  Install path for bd.
+  --build-details-dir DIR
+                     Directory for last-build-*.json.
+                     Default: runtime pack state dir.
+  --restart          Stop supervisor/city before building gc, then start after install. Default.
+  --no-restart       Do not restart supervisor/city after installing gc.
+  --version VALUE    Version string embedded in gc. Default: dev.
+  --bd-build VALUE   Build string embedded in bd. Default: dev.
+
+Environment overrides:
+  GASCITY_SRC, GC_GASCITY_SRC
+  BD_SRC, BEADS_DOLTLITE_SRC, GC_BEADS_DOLTLITE_SRC
+  DOLTLITE_LIB, GC_DOLTLITE_LIB
+  DOLTLITE_SRC, GC_DOLTLITE_SRC
+  GC_DOLTLITE_BOOTSTRAP_SOURCES, GC_DOLTLITE_BOOTSTRAP_DIR
+  GC_DOLTLITE_REPO, GC_BEADS_DOLTLITE_REPO
+  OUTPUT, GC_DOLTLITE_GC_OUTPUT, BD_OUTPUT, GC_DOLTLITE_BD_OUTPUT
+  GC_DOLTLITE_INSTALL, GC_DOLTLITE_INSTALL_DIR
+  GC_DOLTLITE_GC_INSTALL, GC_DOLTLITE_BD_INSTALL
+  GC_DOLTLITE_CLIENT_OUTPUT
+  GC_DOLTLITE_BUILD_DETAILS_DIR
+  GC_DOLTLITE_GO_CACHE_ROOT, GOCACHE, GOMODCACHE, GOTMPDIR
+  GC_DOLTLITE_RESTART_AFTER_INSTALL, GC_DOLTLITE_RESTART_WAIT_SECONDS
+  GC_VERSION, GC_COMMIT, GC_BUILD_DATE
+  BD_BUILD, BD_COMMIT, BD_BRANCH
+EOF
+}
+
+die() {
+  echo "$*" >&2
+  exit 1
+}
+
+usage_error() {
+  echo "$*" >&2
+  usage >&2
+  exit 2
+}
+
+require_value() {
+  if [ -z "${2:-}" ] || [[ "${2:-}" == --* ]]; then
+    usage_error "$1 requires a value"
+  fi
+}
+
+abs_dir() {
+  cd "$1" && pwd
+}
+
+has_gascity_source() {
+  [ -f "$1/go.mod" ] && [ -d "$1/cmd/gc" ]
+}
+
+has_bd_source() {
+  [ -f "$1/go.mod" ] && [ -d "$1/cmd/bd" ]
+}
+
+has_doltlite_lib() {
+  [ -r "$1/libdoltlite.so" ] || [ -r "$1/libdoltlite.so.0" ] || [ -r "$1/libdoltlite.dylib" ]
+}
+
+has_doltlite_source() {
+  [ -f "$1/main.mk" ] && [ -f "$1/Makefile" ]
+}
+
+find_gascity_source() {
+  for candidate in \
+    "$CITY_ROOT/gascity" \
+    "$CITY_ROOT/../gascity" \
+    "$(pwd)" \
+    "$SCRIPT_CHECKOUT"; do
+    if has_gascity_source "$candidate"; then
+      abs_dir "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+find_bd_source() {
+  for candidate in \
+    "$CITY_ROOT/beads-doltlite" \
+    "$CITY_ROOT/../beads-doltlite" \
+    "$SCRIPT_CHECKOUT/../beads-doltlite" \
+    "$(pwd)"; do
+    if has_bd_source "$candidate"; then
+      abs_dir "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+find_doltlite_source() {
+  for candidate in \
+    "$CITY_ROOT/doltlite" \
+    "$CITY_ROOT/doltlite-work" \
+    "$CITY_ROOT/../doltlite" \
+    "$CITY_ROOT/../doltlite-work" \
+    "$SCRIPT_CHECKOUT/../doltlite"; do
+    if has_doltlite_source "$candidate"; then
+      abs_dir "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+find_doltlite_lib() {
+  for candidate in \
+    "$CITY_ROOT/doltlite" \
+    "$CITY_ROOT/doltlite-work" \
+    "$CITY_ROOT/doltlite-work/build" \
+    "$CITY_ROOT/doltlite/build" \
+    "$CITY_ROOT/../doltlite" \
+    "$CITY_ROOT/../doltlite-work" \
+    "$CITY_ROOT/../doltlite-work/build" \
+    "$CITY_ROOT/../doltlite/build"; do
+    if has_doltlite_lib "$candidate"; then
+      abs_dir "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+target_includes_bd() {
+  [ "$TARGET" = "bd" ] || [ "$TARGET" = "all" ]
+}
+
+clone_source_if_missing() {
+  local repo="$1"
+  local dest="$2"
+  local label="$3"
+
+  if [ -d "$dest/.git" ]; then
+    echo "using existing $label source: $dest"
+    return 0
+  fi
+  if [ -e "$dest" ]; then
+    die "$label bootstrap path exists but is not a git checkout: $dest"
+  fi
+  command -v git >/dev/null 2>&1 || die "git is required to bootstrap missing $label source"
+  mkdir -p "$(dirname "$dest")"
+  echo "cloning $label source from $repo into $dest"
+  git clone "$repo" "$dest"
+}
+
+bootstrap_bd_source() {
+  if [ "$BOOTSTRAP_SOURCES" != "1" ] || ! target_includes_bd; then
+    return 0
+  fi
+  if [ -n "$BD_SRC" ] && has_bd_source "$BD_SRC"; then
+    return 0
+  fi
+  local found
+  found="$(find_bd_source || true)"
+  if [ -n "$found" ]; then
+    BD_SRC="$found"
+    return 0
+  fi
+
+  BD_SRC="$BOOTSTRAP_DIR/beads-doltlite"
+  clone_source_if_missing "$BD_REPO" "$BD_SRC" "beads-doltlite"
+  has_bd_source "$BD_SRC" || die "bootstrapped beads-doltlite source is missing cmd/bd: $BD_SRC"
+}
+
+bootstrap_doltlite_lib() {
+  if [ "$BOOTSTRAP_SOURCES" != "1" ]; then
+    return 0
+  fi
+  if [ -n "$DOLTLITE_LIB" ] && has_doltlite_lib "$DOLTLITE_LIB"; then
+    return 0
+  fi
+  local found
+  found="$(find_doltlite_lib || true)"
+  if [ -n "$found" ]; then
+    DOLTLITE_LIB="$found"
+    return 0
+  fi
+
+  if [ -z "$DOLTLITE_SRC" ]; then
+    DOLTLITE_SRC="$(find_doltlite_source || true)"
+  fi
+  if [ -z "$DOLTLITE_SRC" ]; then
+    DOLTLITE_SRC="$BOOTSTRAP_DIR/doltlite"
+    clone_source_if_missing "$DOLTLITE_REPO" "$DOLTLITE_SRC" "DoltLite"
+  fi
+  has_doltlite_source "$DOLTLITE_SRC" || die "bootstrapped DoltLite source is missing Makefile/main.mk: $DOLTLITE_SRC"
+
+  echo "building libdoltlite from $DOLTLITE_SRC"
+  make -C "$DOLTLITE_SRC" doltlite-lib
+
+  for candidate in "$DOLTLITE_SRC" "$DOLTLITE_SRC/build"; do
+    if has_doltlite_lib "$candidate"; then
+      DOLTLITE_LIB="$(abs_dir "$candidate")"
+      return 0
+    fi
+  done
+  die "DoltLite build completed but libdoltlite was not found under $DOLTLITE_SRC"
+}
+
+revision_for() {
+  local source_dir="$1"
+  if command -v jj >/dev/null 2>&1 && [ -d "$source_dir/.jj" ]; then
+    (cd "$source_dir" && jj log --no-graph -r @ -T 'commit_id.short()' 2>/dev/null | tr -d '\n' || true)
+    return 0
+  fi
+  if command -v git >/dev/null 2>&1; then
+    git -C "$source_dir" rev-parse --short HEAD 2>/dev/null || true
+  fi
+}
+
+branch_for() {
+  local source_dir="$1"
+  if command -v git >/dev/null 2>&1; then
+    git -C "$source_dir" symbolic-ref --short HEAD 2>/dev/null || true
+  fi
+}
+
+common_env_prefix() {
+  local tags="$1"
+  export CGO_ENABLED=1
+  export GOFLAGS="${BASE_GOFLAGS:+$BASE_GOFLAGS }-tags=${tags}"
+  export CGO_LDFLAGS="${BASE_CGO_LDFLAGS:+$BASE_CGO_LDFLAGS }-L${DOLTLITE_LIB} -Wl,-rpath,${DOLTLITE_LIB} -ldoltlite"
+  export LD_LIBRARY_PATH="${DOLTLITE_LIB}${BASE_LD_LIBRARY_PATH:+:${BASE_LD_LIBRARY_PATH}}"
+}
+
+verify_linked_binary() {
+  local output="$1"
+  local name="$2"
+  if ! go version -m "$output" 2>/dev/null | grep -q 'CGO_ENABLED=1'; then
+    die "built $name binary does not report CGO_ENABLED=1"
+  fi
+  if command -v ldd >/dev/null 2>&1; then
+    if ! ldd "$output" 2>/dev/null | grep -q 'libdoltlite'; then
+      die "built $name binary does not appear to link libdoltlite"
+    fi
+  fi
+}
+
+path_under_home() {
+  local path="$1"
+  [ -n "$path" ] && [ -n "${HOME:-}" ] && [[ "$path" == "$HOME"/* ]]
+}
+
+supervisor_gc_path() {
+  local unit="gascity-supervisor.service"
+  local value path candidate
+
+  for candidate in \
+    "${XDG_CONFIG_HOME:-${HOME:-}/.config}/systemd/user/$unit" \
+    "${HOME:-}/.local/share/systemd/user/$unit"; do
+    if [ -r "$candidate" ]; then
+      value="$(awk -F= '$1 == "ExecStart" { print substr($0, index($0, "=") + 1); exit }' "$candidate")"
+      if [ -n "$value" ]; then
+        case "$value" in
+          \"*) path="${value#\"}"; path="${path%%\"*}" ;;
+          *) path="${value%% *}" ;;
+        esac
+        if [ -n "$path" ]; then
+          echo "$path"
+          return 0
+        fi
+      fi
+    fi
+  done
+
+  if command -v systemctl >/dev/null 2>&1; then
+    value="$(systemctl --user show "$unit" -p ExecStart --value 2>/dev/null || true)"
+    if [ -n "$value" ]; then
+      path="${value#*path=}"
+      if [ "$path" != "$value" ]; then
+        path="${path%% ;*}"
+        path="${path%%;*}"
+        if [ -n "$path" ]; then
+          echo "$path"
+          return 0
+        fi
+      fi
+    fi
+  fi
+
+  return 1
+}
+
+default_install_path() {
+  local name="$1"
+  local current=""
+  if [ -n "$INSTALL_DIR" ]; then
+    echo "$INSTALL_DIR/$name"
+    return 0
+  fi
+  if [ "$name" = "gc" ]; then
+    current="$(supervisor_gc_path || true)"
+    if path_under_home "$current"; then
+      echo "$current"
+      return 0
+    fi
+  fi
+  current="$(command -v "$name" 2>/dev/null || true)"
+  if path_under_home "$current"; then
+    echo "$current"
+    return 0
+  fi
+  if [ -n "${HOME:-}" ]; then
+    echo "$HOME/.local/bin/$name"
+    return 0
+  fi
+  die "could not choose install path for $name; set --install-dir or --${name}-install"
+}
+
+install_binary() {
+  local source="$1"
+  local dest="$2"
+  local name="$3"
+  local dest_dir tmp current
+
+  dest_dir="$(dirname "$dest")"
+  mkdir -p "$dest_dir"
+  tmp="$dest_dir/.${name}.tmp.$$"
+  rm -f "$tmp"
+  if ! install -m 0755 "$source" "$tmp"; then
+    rm -f "$tmp"
+    die "installing $name to temporary path failed: $tmp"
+  fi
+  if ! mv -f "$tmp" "$dest"; then
+    rm -f "$tmp"
+    die "installing $name failed: $dest"
+  fi
+  echo "installed $name: $dest"
+
+  current="$(command -v "$name" 2>/dev/null || true)"
+  if [ -n "$current" ] && [ "$current" != "$dest" ]; then
+    echo "note: current $name resolves to $current; ensure $dest is earlier on PATH"
+  fi
+}
+
+artifact_path_for_source() {
+  local source_dir="$1"
+  local output="$2"
+  case "$output" in
+    /*) echo "$output" ;;
+    *) echo "$source_dir/$output" ;;
+  esac
+}
+
+sha256_for() {
+  local path="$1"
+  local sum rest
+  if command -v sha256sum >/dev/null 2>&1; then
+    read -r sum rest < <(sha256sum "$path")
+    echo "$sum"
+    return 0
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    read -r sum rest < <(shasum -a 256 "$path")
+    echo "$sum"
+    return 0
+  fi
+  die "sha256sum or shasum is required to write build details"
+}
+
+json_escape() {
+  local value="${1-}"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  printf '%s' "$value"
+}
+
+write_build_details() {
+  local name="$1"
+  local source_dir="$2"
+  local output="$3"
+  local installed_to="$4"
+  local commit="$5"
+  local version="$6"
+  local branch="$7"
+  local tags="$8"
+  local built_at="$9"
+  local output_path output_sha binary_path binary_sha install_sha stamp tmp go_version go_version_m
+
+  output_path="$(artifact_path_for_source "$source_dir" "$output")"
+  output_sha="$(sha256_for "$output_path")"
+  binary_path="$output_path"
+  binary_sha="$output_sha"
+  install_sha=""
+  if [ -n "$installed_to" ]; then
+    binary_path="$installed_to"
+    install_sha="$(sha256_for "$installed_to")"
+    binary_sha="$install_sha"
+  fi
+
+  go_version="$(go version 2>/dev/null || true)"
+  go_version_m="$(go version -m "$binary_path" 2>/dev/null || true)"
+  if [ -z "$go_version_m" ] && [ "$binary_path" != "$output_path" ]; then
+    go_version_m="$(go version -m "$output_path" 2>/dev/null || true)"
+  fi
+
+  mkdir -p "$BUILD_DETAILS_DIR"
+  stamp="$BUILD_DETAILS_DIR/last-build-${name}.json"
+  tmp="$stamp.tmp.$$"
+  rm -f "$tmp"
+  {
+    printf '{\n'
+    printf '  "schema_version": "1",\n'
+    printf '  "pack": "beads-doltlite",\n'
+    printf '  "target": "%s",\n' "$(json_escape "$name")"
+    printf '  "built_at": "%s",\n' "$(json_escape "$built_at")"
+    printf '  "source": "%s",\n' "$(json_escape "$source_dir")"
+    printf '  "output": "%s",\n' "$(json_escape "$output_path")"
+    printf '  "installed_to": "%s",\n' "$(json_escape "$installed_to")"
+    printf '  "binary_path": "%s",\n' "$(json_escape "$binary_path")"
+    printf '  "sha256": "%s",\n' "$(json_escape "$binary_sha")"
+    printf '  "output_sha256": "%s",\n' "$(json_escape "$output_sha")"
+    printf '  "install_sha256": "%s",\n' "$(json_escape "$install_sha")"
+    printf '  "commit": "%s",\n' "$(json_escape "$commit")"
+    printf '  "branch": "%s",\n' "$(json_escape "$branch")"
+    printf '  "version": "%s",\n' "$(json_escape "$version")"
+    printf '  "tags": "%s",\n' "$(json_escape "$tags")"
+    printf '  "doltlite_lib": "%s",\n' "$(json_escape "$DOLTLITE_LIB")"
+    printf '  "gocache": "%s",\n' "$(json_escape "${GOCACHE:-}")"
+    printf '  "gomodcache": "%s",\n' "$(json_escape "${GOMODCACHE:-}")"
+    printf '  "gotmpdir": "%s",\n' "$(json_escape "${GOTMPDIR:-}")"
+    printf '  "go_version": "%s",\n' "$(json_escape "$go_version")"
+    printf '  "goflags": "%s",\n' "$(json_escape "${GOFLAGS:-}")"
+    printf '  "cgo_ldflags": "%s",\n' "$(json_escape "${CGO_LDFLAGS:-}")"
+    printf '  "go_version_m": "%s"\n' "$(json_escape "$go_version_m")"
+    printf '}\n'
+  } >"$tmp"
+  mv -f "$tmp" "$stamp"
+  echo "wrote $name build details: $stamp"
+}
+
+controller_field_for_city() {
+  local gc_bin="$1"
+  local field="$2"
+  local status_file
+  status_file="$(mktemp "${TMPDIR:-/tmp}/gc-status.XXXXXX")"
+  if ! "$gc_bin" status --json "$CITY_ROOT" >"$status_file" 2>/dev/null && [ ! -s "$status_file" ]; then
+    rm -f "$status_file"
+    return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$field" "$status_file" <<'PY'
+import json
+import sys
+
+field, path = sys.argv[1], sys.argv[2]
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+value = (data.get("controller") or {}).get(field, "")
+if value is None:
+    value = ""
+print(value)
+PY
+    rm -f "$status_file"
+    return 0
+  fi
+  awk -v want="$field" '
+    /"controller"[[:space:]]*:/ { in_controller=1; next }
+    in_controller && /^[[:space:]]*}/ { exit }
+    in_controller && $0 ~ "\"" want "\"" {
+      value=$0
+      sub("^[^:]*:[[:space:]]*", "", value)
+      gsub("[,\"]", "", value)
+      gsub("^[[:space:]]+|[[:space:]]+$", "", value)
+      print value
+      exit
+    }
+  ' "$status_file"
+  rm -f "$status_file"
+}
+
+controller_mode_for_city() {
+  controller_field_for_city "$1" "mode"
+}
+
+controller_pid_for_city() {
+  controller_field_for_city "$1" "pid"
+}
+
+process_alive() {
+  local pid="$1"
+  [ -n "$pid" ] && kill -0 "$pid" >/dev/null 2>&1
+}
+
+wait_for_pid_exit() {
+  local pid="$1"
+  local remaining="$RESTART_WAIT_SECONDS"
+  while [ "$remaining" -gt 0 ]; do
+    if ! process_alive "$pid"; then
+      return 0
+    fi
+    sleep 1
+    remaining=$((remaining - 1))
+  done
+  ! process_alive "$pid"
+}
+
+terminate_controller_pid() {
+  local pid="$1"
+  if ! process_alive "$pid"; then
+    return 0
+  fi
+  echo "stopping leftover city controller PID $pid"
+  kill "$pid" >/dev/null 2>&1 || true
+  if wait_for_pid_exit "$pid"; then
+    return 0
+  fi
+  echo "force-stopping leftover city controller PID $pid"
+  kill -KILL "$pid" >/dev/null 2>&1 || true
+  wait_for_pid_exit "$pid" || die "city controller PID $pid did not stop"
+}
+
+stop_standalone_controller_if_running() {
+  local gc_bin="$1"
+  local mode pid
+  mode="$(controller_mode_for_city "$gc_bin" || true)"
+  if [ "$mode" != "standalone" ]; then
+    return 0
+  fi
+  pid="$(controller_pid_for_city "$gc_bin" || true)"
+  echo "stopping standalone city controller${pid:+ PID $pid}"
+  "$gc_bin" stop "$CITY_ROOT" --force --timeout "${RESTART_WAIT_SECONDS}s" || die "stopping standalone city controller failed"
+  if [ -n "$pid" ]; then
+    terminate_controller_pid "$pid"
+  fi
+}
+
+stop_supervisor_if_running() {
+  local gc_bin="$1"
+  if ! "$gc_bin" supervisor status >/dev/null 2>&1; then
+    echo "supervisor already stopped"
+    return 0
+  fi
+  echo "stopping supervisor"
+  "$gc_bin" supervisor stop --wait --wait-timeout "${RESTART_WAIT_SECONDS}s" || die "stopping supervisor failed"
+  if "$gc_bin" supervisor status >/dev/null 2>&1; then
+    die "supervisor still running after stop"
+  fi
+}
+
+stop_leftover_controller_if_running() {
+  local gc_bin="$1"
+  local pid
+  pid="$(controller_pid_for_city "$gc_bin" || true)"
+  if [ -z "$pid" ]; then
+    return 0
+  fi
+  terminate_controller_pid "$pid"
+}
+
+current_gc_for_stop() {
+  if [ -n "$GC_INSTALL" ] && [ -x "$GC_INSTALL" ]; then
+    echo "$GC_INSTALL"
+    return 0
+  fi
+  if command -v gc >/dev/null 2>&1; then
+    command -v gc
+    return 0
+  fi
+  return 1
+}
+
+target_includes_gc() {
+  [ "$TARGET" = "gc" ] || [ "$TARGET" = "all" ]
+}
+
+prepare_gc_install_path() {
+  if [ "$INSTALL_BUILT" != "1" ] || [ "$RESTART_AFTER_INSTALL" != "1" ] || ! target_includes_gc; then
+    return 0
+  fi
+  if [ -z "$GC_INSTALL" ]; then
+    GC_INSTALL="$(default_install_path gc)"
+  fi
+}
+
+stop_before_gc_build() {
+  if [ "$INSTALL_BUILT" != "1" ] || [ "$RESTART_AFTER_INSTALL" != "1" ] || ! target_includes_gc; then
+    return 0
+  fi
+  local gc_bin
+  gc_bin="$(current_gc_for_stop || true)"
+  if [ -z "$gc_bin" ]; then
+    die "restart requires an existing gc binary to stop current services; pass --no-restart to build without cycling services"
+  fi
+
+  echo "stopping gc services before build with $gc_bin"
+  stop_standalone_controller_if_running "$gc_bin"
+  stop_supervisor_if_running "$gc_bin"
+  stop_leftover_controller_if_running "$gc_bin"
+  GC_SERVICES_STOPPED_FOR_BUILD=1
+}
+
+start_after_gc_install() {
+  local gc_bin="$1"
+  if [ "$RESTART_AFTER_INSTALL" != "1" ]; then
+    echo "restart after gc install disabled"
+    return 0
+  fi
+  if [ ! -x "$gc_bin" ]; then
+    die "installed gc is not executable: $gc_bin"
+  fi
+
+  if [ "$GC_SERVICES_STOPPED_FOR_BUILD" != "1" ]; then
+    die "refusing to start gc services because they were not stopped before build"
+  fi
+
+  echo "starting city from $CITY_ROOT"
+  "$gc_bin" start "$CITY_ROOT" || die "starting city after gc install failed"
+}
+
+build_gc() {
+  if [ -z "$GASCITY_SRC" ]; then
+    GASCITY_SRC="$(find_gascity_source || true)"
+  fi
+  if [ -z "$GASCITY_SRC" ] || ! has_gascity_source "$GASCITY_SRC"; then
+    die "could not find Gas City source; set GASCITY_SRC=/path/to/gascity or pass --gc-source"
+  fi
+  GASCITY_SRC="$(abs_dir "$GASCITY_SRC")"
+
+  if [ -z "$GC_OUTPUT" ]; then
+    GC_OUTPUT="$GASCITY_SRC/bin/gc"
+  fi
+
+  local commit="${GC_COMMIT:-}"
+  if [ -z "$commit" ]; then
+    commit="$(revision_for "$GASCITY_SRC")"
+  fi
+  commit="${commit:-unknown}"
+  local date="${GC_BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+  mkdir -p "$(dirname "$GC_OUTPUT")"
+  common_env_prefix "gascity_doltlite_lib,libsqlite3"
+
+  echo "building gc from $GASCITY_SRC"
+  echo "linking libdoltlite from $DOLTLITE_LIB"
+  echo "writing $GC_OUTPUT"
+
+  (
+    cd "$GASCITY_SRC"
+    go build \
+      -ldflags "-X main.version=${VERSION} -X main.commit=${commit} -X main.date=${date}" \
+      -o "$GC_OUTPUT" \
+      ./cmd/gc
+  )
+
+  verify_linked_binary "$GC_OUTPUT" "gc"
+  echo "built libdoltlite-linked gc: $GC_OUTPUT"
+
+  local installed_to=""
+  if [ "$INSTALL_BUILT" = "1" ]; then
+    if [ -z "$GC_INSTALL" ]; then
+      GC_INSTALL="$(default_install_path gc)"
+    fi
+    install_binary "$GC_OUTPUT" "$GC_INSTALL" "gc"
+    installed_to="$GC_INSTALL"
+  fi
+  write_build_details "gc" "$GASCITY_SRC" "$GC_OUTPUT" "$installed_to" "$commit" "$VERSION" "" "gascity_doltlite_lib,libsqlite3" "$date"
+  if [ -n "$installed_to" ]; then
+    start_after_gc_install "$installed_to"
+    write_build_details "gc" "$GASCITY_SRC" "$GC_OUTPUT" "$installed_to" "$commit" "$VERSION" "" "gascity_doltlite_lib,libsqlite3" "$date"
+  fi
+}
+
+build_bd() {
+  if [ -z "$BD_SRC" ]; then
+    BD_SRC="$(find_bd_source || true)"
+  fi
+  if [ -z "$BD_SRC" ] || ! has_bd_source "$BD_SRC"; then
+    die "could not find beads-doltlite source; set BD_SRC=/path/to/beads-doltlite or pass --bd-source"
+  fi
+  BD_SRC="$(abs_dir "$BD_SRC")"
+
+  if [ -z "$BD_OUTPUT" ]; then
+    BD_OUTPUT="$BD_SRC/bin/bd"
+  fi
+
+  local commit="${BD_COMMIT:-}"
+  if [ -z "$commit" ]; then
+    commit="$(revision_for "$BD_SRC")"
+  fi
+  commit="${commit:-unknown}"
+  local branch="${BD_BRANCH:-}"
+  if [ -z "$branch" ]; then
+    branch="$(branch_for "$BD_SRC")"
+  fi
+  local date
+  date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local ldflags="-X main.Build=${BD_BUILD_VALUE} -X main.Commit=${commit}"
+  if [ -n "$branch" ]; then
+    ldflags="${ldflags} -X main.Branch=${branch}"
+  fi
+
+  mkdir -p "$(dirname "$BD_OUTPUT")"
+  common_env_prefix "libsqlite3"
+
+  echo "building bd from $BD_SRC"
+  echo "linking libdoltlite from $DOLTLITE_LIB"
+  echo "writing $BD_OUTPUT"
+
+  (
+    cd "$BD_SRC"
+    go build \
+      -ldflags "$ldflags" \
+      -o "$BD_OUTPUT" \
+      ./cmd/bd
+  )
+
+  verify_linked_binary "$BD_OUTPUT" "bd"
+  echo "built libdoltlite-linked bd: $BD_OUTPUT"
+
+  local installed_to=""
+  if [ "$INSTALL_BUILT" = "1" ]; then
+    if [ -z "$BD_INSTALL" ]; then
+      BD_INSTALL="$(default_install_path bd)"
+    fi
+    install_binary "$BD_OUTPUT" "$BD_INSTALL" "bd"
+    installed_to="$BD_INSTALL"
+  fi
+  write_build_details "bd" "$BD_SRC" "$BD_OUTPUT" "$installed_to" "$commit" "$BD_BUILD_VALUE" "$branch" "libsqlite3" "$date"
+}
+
+build_client() {
+  if [ -z "$GASCITY_SRC" ]; then
+    GASCITY_SRC="$(find_gascity_source || true)"
+  fi
+  if [ -z "$GASCITY_SRC" ] || ! has_gascity_source "$GASCITY_SRC"; then
+    die "could not find Gas City source; set GASCITY_SRC=/path/to/gascity or pass --gc-source"
+  fi
+  GASCITY_SRC="$(abs_dir "$GASCITY_SRC")"
+
+  if [ ! -f "$GASCITY_SRC/tools/doltlite-client/main.go" ]; then
+    die "could not find doltlite-client source under $GASCITY_SRC/tools/doltlite-client"
+  fi
+
+  if [ -z "$CLIENT_OUTPUT" ]; then
+    CLIENT_OUTPUT="$BUILD_DETAILS_DIR/bin/doltlite-client"
+  fi
+
+  local commit="${GC_COMMIT:-}"
+  if [ -z "$commit" ]; then
+    commit="$(revision_for "$GASCITY_SRC")"
+  fi
+  commit="${commit:-unknown}"
+  local date="${GC_BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+  mkdir -p "$(dirname "$CLIENT_OUTPUT")"
+  common_env_prefix "gascity_doltlite_lib,libsqlite3"
+
+  echo "building doltlite-client from $GASCITY_SRC"
+  echo "linking libdoltlite from $DOLTLITE_LIB"
+  echo "writing $CLIENT_OUTPUT"
+
+  (
+    cd "$GASCITY_SRC"
+    go build \
+      -o "$CLIENT_OUTPUT" \
+      ./tools/doltlite-client
+  )
+
+  verify_linked_binary "$CLIENT_OUTPUT" "doltlite-client"
+  echo "built libdoltlite-linked doltlite-client: $CLIENT_OUTPUT"
+  write_build_details "doltlite-client" "$GASCITY_SRC" "$CLIENT_OUTPUT" "$CLIENT_OUTPUT" "$commit" "dev" "" "gascity_doltlite_lib,libsqlite3" "$date"
+}
+
+CITY_ROOT="${GC_CITY_PATH:-$(pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_CHECKOUT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+BASE_GOFLAGS="${GOFLAGS:-}"
+BASE_CGO_LDFLAGS="${CGO_LDFLAGS:-}"
+BASE_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+
+TARGET="gc"
+COMMON_SOURCE=""
+COMMON_OUTPUT="${OUTPUT:-}"
+GASCITY_SRC="${GASCITY_SRC:-${GC_GASCITY_SRC:-}}"
+BD_SRC="${BD_SRC:-${BEADS_DOLTLITE_SRC:-${GC_BEADS_DOLTLITE_SRC:-}}}"
+DOLTLITE_LIB="${DOLTLITE_LIB:-${GC_DOLTLITE_LIB:-}}"
+DOLTLITE_SRC="${DOLTLITE_SRC:-${GC_DOLTLITE_SRC:-}}"
+DOLTLITE_REPO="${GC_DOLTLITE_REPO:-https://github.com/dolthub/doltlite.git}"
+BD_REPO="${GC_BEADS_DOLTLITE_REPO:-https://github.com/duncan4123/beads-doltlite.git}"
+BOOTSTRAP_SOURCES="${GC_DOLTLITE_BOOTSTRAP_SOURCES:-1}"
+BOOTSTRAP_DIR="${GC_DOLTLITE_BOOTSTRAP_DIR:-}"
+GC_OUTPUT="${GC_DOLTLITE_GC_OUTPUT:-}"
+BD_OUTPUT="${BD_OUTPUT:-${GC_DOLTLITE_BD_OUTPUT:-}}"
+CLIENT_OUTPUT="${GC_DOLTLITE_CLIENT_OUTPUT:-}"
+INSTALL_BUILT="${GC_DOLTLITE_INSTALL:-0}"
+INSTALL_DIR="${GC_DOLTLITE_INSTALL_DIR:-}"
+GC_INSTALL="${GC_DOLTLITE_GC_INSTALL:-}"
+BD_INSTALL="${GC_DOLTLITE_BD_INSTALL:-}"
+BUILD_DETAILS_DIR="${GC_DOLTLITE_BUILD_DETAILS_DIR:-}"
+GO_CACHE_ROOT="${GC_DOLTLITE_GO_CACHE_ROOT:-}"
+RESTART_AFTER_INSTALL="${GC_DOLTLITE_RESTART_AFTER_INSTALL:-1}"
+RESTART_WAIT_SECONDS="${GC_DOLTLITE_RESTART_WAIT_SECONDS:-180}"
+GC_SERVICES_STOPPED_FOR_BUILD=0
+VERSION="${GC_VERSION:-dev}"
+BD_BUILD_VALUE="${BD_BUILD:-dev}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    gc|bd|client|all)
+      TARGET="$1"
+      shift
+      ;;
+    --target)
+      require_value "$1" "${2:-}"
+      TARGET="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET="${1#*=}"
+      shift
+      ;;
+    --source)
+      require_value "$1" "${2:-}"
+      COMMON_SOURCE="$2"
+      shift 2
+      ;;
+    --source=*)
+      COMMON_SOURCE="${1#*=}"
+      shift
+      ;;
+    --gc-source)
+      require_value "$1" "${2:-}"
+      GASCITY_SRC="$2"
+      shift 2
+      ;;
+    --gc-source=*)
+      GASCITY_SRC="${1#*=}"
+      shift
+      ;;
+    --bd-source)
+      require_value "$1" "${2:-}"
+      BD_SRC="$2"
+      shift 2
+      ;;
+    --bd-source=*)
+      BD_SRC="${1#*=}"
+      shift
+      ;;
+    --lib)
+      require_value "$1" "${2:-}"
+      DOLTLITE_LIB="$2"
+      shift 2
+      ;;
+    --lib=*)
+      DOLTLITE_LIB="${1#*=}"
+      shift
+      ;;
+    --doltlite-source)
+      require_value "$1" "${2:-}"
+      DOLTLITE_SRC="$2"
+      shift 2
+      ;;
+    --doltlite-source=*)
+      DOLTLITE_SRC="${1#*=}"
+      shift
+      ;;
+    --doltlite-repo)
+      require_value "$1" "${2:-}"
+      DOLTLITE_REPO="$2"
+      shift 2
+      ;;
+    --doltlite-repo=*)
+      DOLTLITE_REPO="${1#*=}"
+      shift
+      ;;
+    --bd-repo)
+      require_value "$1" "${2:-}"
+      BD_REPO="$2"
+      shift 2
+      ;;
+    --bd-repo=*)
+      BD_REPO="${1#*=}"
+      shift
+      ;;
+    --bootstrap-dir)
+      require_value "$1" "${2:-}"
+      BOOTSTRAP_DIR="$2"
+      shift 2
+      ;;
+    --bootstrap-dir=*)
+      BOOTSTRAP_DIR="${1#*=}"
+      shift
+      ;;
+    --no-bootstrap)
+      BOOTSTRAP_SOURCES=0
+      shift
+      ;;
+    --output)
+      require_value "$1" "${2:-}"
+      COMMON_OUTPUT="$2"
+      shift 2
+      ;;
+    --output=*)
+      COMMON_OUTPUT="${1#*=}"
+      shift
+      ;;
+    --gc-output)
+      require_value "$1" "${2:-}"
+      GC_OUTPUT="$2"
+      shift 2
+      ;;
+    --gc-output=*)
+      GC_OUTPUT="${1#*=}"
+      shift
+      ;;
+    --bd-output)
+      require_value "$1" "${2:-}"
+      BD_OUTPUT="$2"
+      shift 2
+      ;;
+    --bd-output=*)
+      BD_OUTPUT="${1#*=}"
+      shift
+      ;;
+    --client-output)
+      require_value "$1" "${2:-}"
+      CLIENT_OUTPUT="$2"
+      shift 2
+      ;;
+    --client-output=*)
+      CLIENT_OUTPUT="${1#*=}"
+      shift
+      ;;
+    --install)
+      INSTALL_BUILT=1
+      shift
+      ;;
+    --install-dir)
+      require_value "$1" "${2:-}"
+      INSTALL_DIR="$2"
+      INSTALL_BUILT=1
+      shift 2
+      ;;
+    --install-dir=*)
+      INSTALL_DIR="${1#*=}"
+      INSTALL_BUILT=1
+      shift
+      ;;
+    --gc-install)
+      require_value "$1" "${2:-}"
+      GC_INSTALL="$2"
+      INSTALL_BUILT=1
+      shift 2
+      ;;
+    --gc-install=*)
+      GC_INSTALL="${1#*=}"
+      INSTALL_BUILT=1
+      shift
+      ;;
+    --bd-install)
+      require_value "$1" "${2:-}"
+      BD_INSTALL="$2"
+      INSTALL_BUILT=1
+      shift 2
+      ;;
+    --bd-install=*)
+      BD_INSTALL="${1#*=}"
+      INSTALL_BUILT=1
+      shift
+      ;;
+    --build-details-dir)
+      require_value "$1" "${2:-}"
+      BUILD_DETAILS_DIR="$2"
+      shift 2
+      ;;
+    --build-details-dir=*)
+      BUILD_DETAILS_DIR="${1#*=}"
+      shift
+      ;;
+    --restart)
+      RESTART_AFTER_INSTALL=1
+      shift
+      ;;
+    --no-restart)
+      RESTART_AFTER_INSTALL=0
+      shift
+      ;;
+    --version)
+      require_value "$1" "${2:-}"
+      VERSION="$2"
+      shift 2
+      ;;
+    --version=*)
+      VERSION="${1#*=}"
+      shift
+      ;;
+    --bd-build)
+      require_value "$1" "${2:-}"
+      BD_BUILD_VALUE="$2"
+      shift 2
+      ;;
+    --bd-build=*)
+      BD_BUILD_VALUE="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage_error "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$TARGET" in
+  gc|bd|client|all) ;;
+  *) usage_error "unknown target: $TARGET" ;;
+esac
+
+if [ -n "$COMMON_SOURCE" ]; then
+  case "$TARGET" in
+    gc) GASCITY_SRC="$COMMON_SOURCE" ;;
+    bd) BD_SRC="$COMMON_SOURCE" ;;
+    client) GASCITY_SRC="$COMMON_SOURCE" ;;
+    all) usage_error "--source is ambiguous with target all; use --gc-source and --bd-source" ;;
+  esac
+fi
+
+if [ -n "$COMMON_OUTPUT" ]; then
+  case "$TARGET" in
+    gc) GC_OUTPUT="$COMMON_OUTPUT" ;;
+    bd) BD_OUTPUT="$COMMON_OUTPUT" ;;
+    client) CLIENT_OUTPUT="$COMMON_OUTPUT" ;;
+    all) usage_error "--output is ambiguous with target all; use --gc-output, --bd-output, and --client-output" ;;
+  esac
+fi
+
+case "${INSTALL_BUILT,,}" in
+  1|true|yes|on) INSTALL_BUILT=1 ;;
+  ""|0|false|no|off) INSTALL_BUILT=0 ;;
+  *) usage_error "GC_DOLTLITE_INSTALL must be true or false" ;;
+esac
+
+case "${BOOTSTRAP_SOURCES,,}" in
+  1|true|yes|on) BOOTSTRAP_SOURCES=1 ;;
+  ""|0|false|no|off) BOOTSTRAP_SOURCES=0 ;;
+  *) usage_error "GC_DOLTLITE_BOOTSTRAP_SOURCES must be true or false" ;;
+esac
+
+case "${RESTART_AFTER_INSTALL,,}" in
+  1|true|yes|on) RESTART_AFTER_INSTALL=1 ;;
+  ""|0|false|no|off) RESTART_AFTER_INSTALL=0 ;;
+  *) usage_error "GC_DOLTLITE_RESTART_AFTER_INSTALL must be true or false" ;;
+esac
+
+case "$RESTART_WAIT_SECONDS" in
+  ''|*[!0-9]*) usage_error "GC_DOLTLITE_RESTART_WAIT_SECONDS must be a positive integer" ;;
+  0) usage_error "GC_DOLTLITE_RESTART_WAIT_SECONDS must be greater than zero" ;;
+esac
+
+if [ -z "$BOOTSTRAP_DIR" ]; then
+  BOOTSTRAP_DIR="$CITY_ROOT/.cache/beads-doltlite/sources"
+fi
+mkdir -p "$BOOTSTRAP_DIR"
+
+bootstrap_bd_source
+bootstrap_doltlite_lib
+
+if [ -z "$DOLTLITE_LIB" ]; then
+  DOLTLITE_LIB="$(find_doltlite_lib || true)"
+fi
+if [ -z "$DOLTLITE_LIB" ] || ! has_doltlite_lib "$DOLTLITE_LIB"; then
+  die "could not find libdoltlite; set DOLTLITE_LIB=/path/to/doltlite-work/build, pass --lib, or leave bootstrapping enabled"
+fi
+DOLTLITE_LIB="$(abs_dir "$DOLTLITE_LIB")"
+
+if [ -z "$BUILD_DETAILS_DIR" ]; then
+  BUILD_DETAILS_DIR="${GC_PACK_STATE_DIR:-$CITY_ROOT/.gc/runtime/packs/beads-doltlite}"
+fi
+if [ -z "$GO_CACHE_ROOT" ]; then
+  GO_CACHE_ROOT="$CITY_ROOT/.cache/go"
+fi
+if [ -z "${GOCACHE:-}" ]; then
+  export GOCACHE="$GO_CACHE_ROOT/build"
+fi
+if [ -z "${GOMODCACHE:-}" ]; then
+  export GOMODCACHE="$GO_CACHE_ROOT/mod"
+fi
+if [ -z "${GOTMPDIR:-}" ]; then
+  export GOTMPDIR="$GO_CACHE_ROOT/tmp"
+fi
+mkdir -p "$GOCACHE" "$GOMODCACHE" "$GOTMPDIR"
+
+if ! command -v go >/dev/null 2>&1; then
+  die "go is required to build DoltLite-linked binaries"
+fi
+
+prepare_gc_install_path
+stop_before_gc_build
+
+case "$TARGET" in
+  gc)
+    build_gc
+    ;;
+  bd)
+    build_bd
+    ;;
+  client)
+    build_client
+    ;;
+  all)
+    build_bd
+    build_client
+    build_gc
+    ;;
+esac

--- a/examples/beads-doltlite/commands/client/command.toml
+++ b/examples/beads-doltlite/commands/client/command.toml
@@ -1,0 +1,1 @@
+description = "Run the DoltLite debug client"

--- a/examples/beads-doltlite/commands/client/run.sh
+++ b/examples/beads-doltlite/commands/client/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Run the DoltLite debug client built by `gc beads-doltlite build client`.
+set -euo pipefail
+
+die() {
+  echo "$*" >&2
+  exit 1
+}
+
+has_doltlite_lib() {
+  [ -r "$1/libdoltlite.so" ] || [ -r "$1/libdoltlite.so.0" ] || [ -r "$1/libdoltlite.dylib" ]
+}
+
+find_doltlite_lib() {
+  for candidate in \
+    "$CITY_ROOT/doltlite-work/build" \
+    "$CITY_ROOT/doltlite/build" \
+    "$CITY_ROOT/../doltlite-work/build" \
+    "$CITY_ROOT/../doltlite/build"; do
+    if has_doltlite_lib "$candidate"; then
+      cd "$candidate" && pwd
+      return 0
+    fi
+  done
+  return 1
+}
+
+CITY_ROOT="${GC_CITY_PATH:-${GC_CITY:-$(pwd)}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SOURCE_CITY_ROOT="$(cd "$PACK_DIR/../../.." && pwd)"
+PACK_STATE_DIR="${GC_PACK_STATE_DIR:-$CITY_ROOT/.gc/runtime/packs/beads-doltlite}"
+CLIENT_BIN="${GC_DOLTLITE_CLIENT_BIN:-}"
+DOLTLITE_LIB="${DOLTLITE_LIB:-${GC_DOLTLITE_LIB:-}}"
+
+if [ -z "$CLIENT_BIN" ]; then
+  for candidate in \
+    "$PACK_STATE_DIR/bin/doltlite-client" \
+    "$CITY_ROOT/.gc/runtime/packs/beads-doltlite/bin/doltlite-client" \
+    "$PACK_DIR/bin/doltlite-client"; do
+    if [ -x "$candidate" ]; then
+      CLIENT_BIN="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ ! -x "$CLIENT_BIN" ]; then
+  die "doltlite-client is not built; run: gc beads-doltlite build client"
+fi
+
+if [ -z "$DOLTLITE_LIB" ]; then
+  DOLTLITE_LIB="$(find_doltlite_lib || true)"
+fi
+if [ -z "$DOLTLITE_LIB" ] || ! has_doltlite_lib "$DOLTLITE_LIB"; then
+  die "could not find libdoltlite; set DOLTLITE_LIB=/path/to/doltlite/build"
+fi
+
+export LD_LIBRARY_PATH="$DOLTLITE_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$CLIENT_BIN" -city "$CITY_ROOT" "$@"

--- a/examples/beads-doltlite/commands/flatten/command.toml
+++ b/examples/beads-doltlite/commands/flatten/command.toml
@@ -1,0 +1,1 @@
+description = "Compact the doltlite SQLite database (VACUUM and WAL checkpoint)"

--- a/examples/beads-doltlite/commands/flatten/run.sh
+++ b/examples/beads-doltlite/commands/flatten/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# doltlite flatten — compact the doltlite database via bd flatten.
+set -euo pipefail
+
+BEADS_DIR="${BEADS_DIR:-${GC_CITY_PATH:-.}/.beads}"
+SCOPE_DIR="${BEADS_DIR%/.*}"
+
+if command -v bd >/dev/null 2>&1; then
+  cd "$SCOPE_DIR" || exit 1
+  export BEADS_BACKEND=doltlite GC_BEADS_BACKEND=doltlite BD_NON_INTERACTIVE=1
+  bd flatten --force --json 2>&1 || echo '{"reclaimed_bytes":0,"error":"bd flatten failed"}'
+else
+  echo '{"reclaimed_bytes":0,"error":"bd CLI not found"}'
+fi

--- a/examples/beads-doltlite/commands/gc/command.toml
+++ b/examples/beads-doltlite/commands/gc/command.toml
@@ -1,0 +1,1 @@
+description = "Remove deleted beads from the doltlite database (compact deleted rows)"

--- a/examples/beads-doltlite/commands/gc/run.sh
+++ b/examples/beads-doltlite/commands/gc/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# doltlite gc — remove deleted beads via bd gc.
+set -euo pipefail
+
+BEADS_DIR="${BEADS_DIR:-${GC_CITY_PATH:-.}/.beads}"
+SCOPE_DIR="${BEADS_DIR%/.*}"
+
+if command -v bd >/dev/null 2>&1; then
+  cd "$SCOPE_DIR" || exit 1
+  export BEADS_BACKEND=doltlite GC_BEADS_BACKEND=doltlite BD_NON_INTERACTIVE=1
+  bd gc --skip-decay --force --json 2>&1 || echo '{"deleted_beads_removed":0,"error":"bd gc failed"}'
+else
+  echo '{"deleted_beads_removed":0,"error":"bd CLI not found"}'
+fi

--- a/examples/beads-doltlite/commands/health/command.toml
+++ b/examples/beads-doltlite/commands/health/command.toml
@@ -1,0 +1,1 @@
+description = "Check doltlite database health (schema integrity, storage stats)"

--- a/examples/beads-doltlite/commands/health/run.sh
+++ b/examples/beads-doltlite/commands/health/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# doltlite health — check doltlite database integrity and stats via bd.
+set -euo pipefail
+
+BEADS_DIR="${BEADS_DIR:-${GC_CITY_PATH:-.}/.beads}"
+SCOPE_DIR="${BEADS_DIR%/.*}"
+
+if command -v bd >/dev/null 2>&1; then
+  cd "$SCOPE_DIR" || exit 1
+  export BEADS_BACKEND=doltlite GC_BEADS_BACKEND=doltlite BD_NON_INTERACTIVE=1
+  bd status --json 2>&1 || echo '{"ok":false,"error":"bd status failed"}'
+else
+  echo '{"ok":false,"error":"bd CLI not found"}'
+fi

--- a/examples/beads-doltlite/doctor/check-doltlite-metadata/doctor.toml
+++ b/examples/beads-doltlite/doctor/check-doltlite-metadata/doctor.toml
@@ -1,0 +1,1 @@
+description = "Verify doltlite beads metadata matches the configured backend"

--- a/examples/beads-doltlite/doctor/check-doltlite-metadata/run.sh
+++ b/examples/beads-doltlite/doctor/check-doltlite-metadata/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+city_root="${GC_CITY:-${GC_CITY_PATH:-}}"
+if [[ -z "$city_root" ]]; then
+  city_root="$(pwd)"
+fi
+
+metadata="$city_root/.beads/metadata.json"
+city_config="$city_root/city.toml"
+
+if [[ ! -f "$city_config" ]]; then
+  echo "city.toml not found at $city_config"
+  exit 1
+fi
+
+if [[ ! -f "$metadata" ]]; then
+  echo "beads metadata not found at $metadata"
+  exit 1
+fi
+
+if ! grep -Eq '^[[:space:]]*backend[[:space:]]*=[[:space:]]*"doltlite"' "$city_config"; then
+  echo "doltlite backend is not configured in city.toml; skipping metadata backend check"
+  exit 0
+fi
+
+backend="$(sed -nE 's/^[[:space:]]*"backend"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$metadata" | head -1)"
+
+if [[ "$backend" != "doltlite" ]]; then
+  echo "configured [beads] backend is doltlite, but $metadata has backend=$backend"
+  echo "repair: set .beads/metadata.json backend to \"doltlite\" or run the doltlite bootstrap/migration for this city"
+  exit 1
+fi
+
+echo "doltlite metadata backend OK: $metadata"

--- a/examples/beads-doltlite/doctor/check-doltlite-read-fastpath/doctor.toml
+++ b/examples/beads-doltlite/doctor/check-doltlite-read-fastpath/doctor.toml
@@ -1,0 +1,1 @@
+description = "Verify doltlite read path is responsive with the native fast path enabled"

--- a/examples/beads-doltlite/doctor/check-doltlite-read-fastpath/run.sh
+++ b/examples/beads-doltlite/doctor/check-doltlite-read-fastpath/run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+city_root="${GC_CITY:-${GC_CITY_PATH:-}}"
+if [[ -z "$city_root" ]]; then
+  city_root="$(pwd)"
+fi
+
+if [[ ! -f "$city_root/city.toml" ]] || [[ ! -f "$city_root/.beads/metadata.json" ]]; then
+  echo "city root is missing city.toml or .beads/metadata.json: $city_root"
+  exit 1
+fi
+
+if ! grep -Eq '^[[:space:]]*backend[[:space:]]*=[[:space:]]*"doltlite"' "$city_root/city.toml"; then
+  echo "doltlite backend is not configured in city.toml; skipping fast-path check"
+  exit 0
+fi
+
+metadata_backend="$(sed -nE 's/^[[:space:]]*"backend"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$city_root/.beads/metadata.json" | head -1)"
+if [[ "$metadata_backend" != "doltlite" ]]; then
+  echo "cannot check fast path: .beads/metadata.json backend=$metadata_backend"
+  echo "repair: set .beads/metadata.json backend to \"doltlite\""
+  exit 1
+fi
+
+candidate="${GC_DOLTLITE_DOCTOR_BEAD_ID:-}"
+if [[ -z "$candidate" ]]; then
+  candidate="$(bd list --json 2>/dev/null | sed -nE 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -1 || true)"
+fi
+
+if [[ -z "$candidate" ]]; then
+  echo "no bead id available; skipping doltlite read-path responsiveness check"
+  exit 0
+fi
+
+out="$(mktemp)"
+err="$(mktemp)"
+trap 'rm -f "$out" "$err"' EXIT
+
+if ! (
+  cd "$city_root"
+  GC_NATIVE_DOLTLITE_BEADS=1 timeout 10s gc beads show "$candidate" >"$out" 2>"$err"
+); then
+  echo "doltlite read path failed for bead $candidate"
+  sed -n '1,10p' "$err"
+  exit 1
+fi
+
+echo "doltlite read path OK with GC_NATIVE_DOLTLITE_BEADS=1: gc beads show $candidate"

--- a/examples/beads-doltlite/doctor/check-gc-doltlite-link/doctor.toml
+++ b/examples/beads-doltlite/doctor/check-gc-doltlite-link/doctor.toml
@@ -1,0 +1,1 @@
+description = "Verify gc is linked against libdoltlite"

--- a/examples/beads-doltlite/doctor/check-gc-doltlite-link/run.sh
+++ b/examples/beads-doltlite/doctor/check-gc-doltlite-link/run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+city_root="${GC_CITY:-${GC_CITY_PATH:-}}"
+if [[ -z "$city_root" ]]; then
+  city_root="$(pwd)"
+fi
+
+gc_bin="$(command -v gc || true)"
+if [[ -z "$gc_bin" ]]; then
+  echo "gc binary not found in PATH"
+  exit 1
+fi
+
+status_file="$(mktemp)"
+trap 'rm -f "$status_file"' EXIT
+controller_bin=""
+if gc status --json "$city_root" >"$status_file" 2>/dev/null; then
+  controller_bin="$(sed -nE 's/^[[:space:]]*"binary"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$status_file" | head -1)"
+fi
+if [[ -n "$controller_bin" && -x "$controller_bin" ]]; then
+  gc_bin="$controller_bin"
+fi
+
+build_stamp="$city_root/.gc/runtime/packs/beads-doltlite/last-build-gc.json"
+if [[ -f "$build_stamp" ]]; then
+  stamped_bin="$(sed -nE 's/^[[:space:]]*"binary_path"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$build_stamp" | head -1)"
+  tags="$(sed -nE 's/^[[:space:]]*"tags"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$build_stamp" | head -1)"
+  if [[ -n "$controller_bin" && -n "$stamped_bin" && "$controller_bin" != "$stamped_bin" ]]; then
+    echo "running controller binary does not match doltlite build stamp"
+    echo "controller: $controller_bin"
+    echo "build stamp: $stamped_bin"
+    exit 1
+  fi
+  if [[ "$tags" != *gascity_doltlite_lib* ]]; then
+    echo "last-build-gc.json does not record gascity_doltlite_lib tag"
+    echo "build stamp: $build_stamp"
+    exit 1
+  fi
+fi
+
+if command -v ldd >/dev/null 2>&1; then
+  if ldd "$gc_bin" 2>/dev/null | grep -q 'libdoltlite'; then
+    echo "gc links libdoltlite: $gc_bin"
+    exit 0
+  fi
+fi
+
+if strings "$gc_bin" 2>/dev/null | grep -q 'libdoltlite'; then
+  echo "gc contains libdoltlite symbols: $gc_bin"
+  exit 0
+fi
+
+echo "gc does not appear to be built against libdoltlite: $gc_bin"
+echo "repair: rebuild gc with the beads-doltlite build command so ldd reports libdoltlite"
+exit 1

--- a/examples/beads-doltlite/doctor/check-sqlite3/doctor.toml
+++ b/examples/beads-doltlite/doctor/check-sqlite3/doctor.toml
@@ -1,0 +1,1 @@
+description = "Verify sqlite3 CLI is available for doltlite maintenance"

--- a/examples/beads-doltlite/doctor/check-sqlite3/run.sh
+++ b/examples/beads-doltlite/doctor/check-sqlite3/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 is required for doltlite bead store maintenance"
+  exit 1
+fi
+
+echo "sqlite3 available: $(sqlite3 --version 2>&1 | head -1)"
+exit 0

--- a/examples/beads-doltlite/embed.go
+++ b/examples/beads-doltlite/embed.go
@@ -1,0 +1,9 @@
+// Package beadsdoltlite embeds the built-in DoltLite beads provider pack.
+package beadsdoltlite
+
+import "embed"
+
+// PackFS contains the DoltLite beads provider pack files.
+//
+//go:embed pack.toml doctor commands formulas orders all:assets
+var PackFS embed.FS

--- a/examples/beads-doltlite/formulas/mol-doltlite-maintenance.toml
+++ b/examples/beads-doltlite/formulas/mol-doltlite-maintenance.toml
@@ -1,0 +1,61 @@
+description = """
+Run doltlite maintenance: flatten (VACUUM, WAL checkpoint) and gc (purge
+deleted beads) on the SQLite bead store.
+
+This is an infrastructure formula run by the dog pool. It performs:
+1. Health check (integrity, bead count, storage stats)
+2. Flatten (compact the SQLite database)
+3. GC (remove soft-deleted beads)
+4. Report findings
+
+## Dog Contract
+
+This is infrastructure work. You:
+1. Run `gc beads-doltlite health --json` to assess current state.
+2. Run `gc beads-doltlite flatten --json` to compact.
+3. Run `gc beads-doltlite gc --json` to purge deleted beads.
+4. Emit reporting events and return to kennel.
+"""
+formula = "mol-doltlite-maintenance"
+
+[[steps]]
+id = "maintenance"
+title = "Run doltlite health, flatten, and gc"
+description = """
+Run this as one shell script:
+
+```bash
+set -euo pipefail
+
+WORK_BEAD="${GC_BEAD_ID:?GC_BEAD_ID required; aborting}"
+
+run_or_warn() {
+  local label="$1"
+  shift
+  if ! "$@"; then
+    echo "${label} failed" >&2
+  fi
+}
+
+HEALTH=$(gc beads-doltlite health --json 2>&1 || echo '{"ok":false}')
+echo "$HEALTH"
+
+FLATTEN=$(gc beads-doltlite flatten --json 2>&1 || echo '{"reclaimed_bytes":0}')
+echo "$FLATTEN"
+
+GC=$(gc beads-doltlite gc --json 2>&1 || echo '{"deleted_beads_removed":0}')
+echo "$GC"
+
+RECLAIMED=$(echo "$FLATTEN" | jq -r '.reclaimed_bytes // 0')
+DELETED=$(echo "$GC" | jq -r '.deleted_beads_removed // 0')
+
+run_or_warn "emit maintenance event" gc event emit mol-doltlite-maintenance.done \
+  --message "reclaimed ${RECLAIMED} bytes, removed ${DELETED} deleted beads"
+
+bd close "$WORK_BEAD" --reason "DoltLite maintenance complete: reclaimed ${RECLAIMED} bytes, removed ${DELETED} deleted beads"
+gc runtime drain-ack
+exit
+```
+
+**Exit criteria:** Health report collected, flatten and gc applied, event
+emitted, work bead closed, dog returned to kennel."""

--- a/examples/beads-doltlite/orders/doltlite-health.toml
+++ b/examples/beads-doltlite/orders/doltlite-health.toml
@@ -1,0 +1,5 @@
+[order]
+description = "Check doltlite database health periodically"
+trigger = "cooldown"
+interval = "60s"
+exec = "gc beads-doltlite health --json"

--- a/examples/beads-doltlite/orders/doltlite-maintenance.toml
+++ b/examples/beads-doltlite/orders/doltlite-maintenance.toml
@@ -1,0 +1,5 @@
+[order]
+description = "Run doltlite maintenance (flatten + gc) periodically"
+trigger = "cooldown"
+interval = "1h"
+exec = "gc beads-doltlite flatten --json && gc beads-doltlite gc --json"

--- a/examples/beads-doltlite/pack.toml
+++ b/examples/beads-doltlite/pack.toml
@@ -1,0 +1,30 @@
+# Beads DoltLite — embedded DoltLite beads provider pack.
+#
+# Provides the DoltLite backend (embedded Dolt) as an alternative to the
+# managed Dolt SQL server. Cities select this pack by setting
+# [beads].backend = "doltlite" and bd_compatibility = "bd-1.0.5" in
+# city.toml, so beads use embedded DoltLite databases instead of a managed
+# Dolt server process.
+#
+# DoltLite stores each bead scope as a standalone embedded database under
+# .beads/doltlite/ — no server process, no port management, no TCP
+# health probes. Suitable for local dev, single-host deployments, and
+# environments where running a separate database server is undesirable.
+#
+# This pack is layered on top of the bd pack, not a replacement for it. The bd
+# pack supplies the gc-beads-bd.sh exec provider wrapper used for normal beads
+# operations and writes; this pack imports and exports bd and adds
+# doltlite-specific maintenance operations: flatten (compact the SQLite WAL),
+# gc (remove deleted beads), health (schema integrity check), and build
+# (rebuild gc or bd against libdoltlite).
+#
+# The doltlite backend in gc-beads-bd.sh uses sqlite3 CLI for schema
+# initialization and bd CLI for bead operations. Both must be in PATH.
+
+[pack]
+name = "beads-doltlite"
+schema = 2
+
+[imports.bd]
+source = "../bd"
+export = true

--- a/examples/beads-doltlite/template-fragments/city-understanding.template.md
+++ b/examples/beads-doltlite/template-fragments/city-understanding.template.md
@@ -1,0 +1,94 @@
+{{ define "city-understanding" }}
+## City: doltlite-gascity
+
+### Purpose
+
+This city exists to develop, test, and maintain the **doltlite backend** for Gas Town and beads. It runs Gas Town's full machinery (mayor, polecats, witnesses, refinery, dogs) on a doltlite storage backend — an embedded prolly-tree SQLite engine with zero server process.
+
+The city is the **primary development and testing ground** for running Gas Town cities without a Dolt MySQL-compatible server.
+
+### The Ship-It Principle
+
+A fix is only real when another user on another machine gets the same result by running the same commands — no manual steps, no ad-hoc edits, no "we already fixed that on this machine." Every change must be in code or config that ships:
+
+- **gascity source** — patches to `cmd/gc/`, `internal/`, or `examples/*/pack/` that compile into the `gc` binary.
+- **beads-doltlite source** — patches to `internal/storage/doltlite/` or `cmd/bd/` that compile into the `bd` binary.
+- **doltlite C source** — patches to the prolly-tree engine that produce `libdoltlite.so`.
+- **city.toml** — declarative config (`backend = "doltlite"`, pack includes, order overrides) that any `gc init` can reproduce.
+
+Manual edits to runtime files (`.gc/system/packs/`, wrapper scripts, installed binaries) are scaffolding. They prove the fix works but are not the fix. Before declaring done, port every manual edit into its upstream source and rebuild.
+
+### Codebases
+
+| Repo | Location | Purpose |
+|------|----------|---------|
+| `gastownhall/gascity` | `./gascity/` | Gas Town controller, CLI, packs, molecules |
+| `dolthub/doltlite` | `./doltlite/` | C library: prolly-tree SQLite fork (libdoltlite.so) |
+| `duncan4123/beads-doltlite` | `./beads-doltlite/` | `bd` CLI: beads issue tracker with doltlite storage backend |
+
+### Build Pipeline
+
+```
+doltlite C source              beads-doltlite Go source          gascity Go source
+  ../configure && make            gc beads-doltlite build bd        gc beads-doltlite build gc
+                                  GOFLAGS=-tags=libsqlite3
+  doltlite-lib                    CGO_LDFLAGS=-ldoltlite           CGO_ENABLED=1
+                                                                    GOFLAGS=-tags=gascity_doltlite_lib,libsqlite3
+  → libdoltlite.so ──────────→  bin/bd                             → bin/gc
+          └──────────────────────────────────────────────────────→  libdoltlite-linked binaries
+```
+
+1. Build `libdoltlite.so` from `dolthub/doltlite` with `make doltlite-lib`
+2. Build `bd` from `duncan4123/beads-doltlite` with `gc beads-doltlite build bd`
+3. Build `gc` from `gastownhall/gascity` with `gc beads-doltlite build gc` when direct libdoltlite-linked Gas City behavior is needed
+4. `bd` binary provides beads CLI; Gas Town's `gc bd` commands shell out to it
+5. Gas Town's `gc` binary embeds pack definitions (including the bd pack with `gc-beads-bd.sh` wrapper)
+
+The `gc beads-doltlite build` command is pack-managed. It still requires an existing `gc` binary to run the city and dispatch pack commands. If the user does not already have DoltLite or beads-doltlite sources, the build command bootstraps them into `.cache/beads-doltlite/sources/` from `https://github.com/dolthub/doltlite.git` and `https://github.com/duncan4123/beads-doltlite.git`, then runs `make doltlite-lib` before building `bd` or `gc`. Use `--no-bootstrap` for offline/reproducible builds that must fail instead of cloning, or override with `--bootstrap-dir`, `--doltlite-source`, `--doltlite-repo`, `--bd-source`, and `--bd-repo`.
+
+By default it builds libdoltlite-linked replacements to `<beads-doltlite>/bin/bd` and `<gascity>/bin/gc`. Use `gc beads-doltlite build all` for both binaries. Add `--install` to copy verified binaries to the existing supervisor unit's `gc` path when present, then to the active binary path when it is under `$HOME`, otherwise `$HOME/.local/bin`. Use `--install-dir`, `--bd-install`, and `--gc-install` to choose exact install paths.
+
+The pack is builtin for now because bootstrap has to work before remote pack registries, import pins, or provider-specific source checkouts are available. The goal is not to make DoltLite a permanent hardcoded role in Gas City; the pack keeps all DoltLite behavior in an example pack boundary while the backend and install story stabilize. Once DoltLite-backed beads can be installed as an ordinary remote pack with released binaries and stable source provenance, this can move out of the builtin/example distribution path.
+
+Installing a rebuilt `bd` affects new `gc bd` calls as soon as that `bd` path is first on `PATH`. Installing a rebuilt `gc` affects new `gc` invocations immediately, but a running controller still uses the old in-memory binary until it is reloaded or restarted.
+
+### Backend Architecture
+
+- **Storage**: `libdoltlite.so` — embedded prolly-tree engine. Single `.db` file per database, no server process.
+- **Pack layering**: `beads-doltlite` is not a replacement for the `bd` pack. It imports and exports `bd`, so normal beads provider operations still use the materialized `bd` pack's `gc-beads-bd.sh` wrapper.
+- **Beads CLI**: `gc beads-doltlite build bd` rebuilds `bd` with `CGO_ENABLED=1`, `GOFLAGS=-tags=libsqlite3`, and `CGO_LDFLAGS=-ldoltlite`.
+- **Gas City binary**: `gc beads-doltlite build gc` rebuilds `gc` with `CGO_ENABLED=1`, `GOFLAGS=-tags=gascity_doltlite_lib,libsqlite3`, and `CGO_LDFLAGS=-ldoltlite`. Do not use `gascity_native_beads` for this; upstream uses that tag for its pure-Go native beads path.
+- **Gas Town integration**: `gc bd` commands delegate to `bd` via `gc-beads-bd.sh` wrapper script. The wrapper detects `BEADS_BACKEND=doltlite` and routes init/operations through doltlite-specific code paths. Optional native `gc` reads can bypass the CLI for selected hot paths, but writes and general `gc bd` behavior still go through `bd`.
+- **No Dolt server**: No MySQL protocol, no port, no `dolt sql-server` process. The dolt pack is conditionally skipped when backend is doltlite (see `embed_builtin_packs.go`).
+
+### Key Differences from Dolt-Backed Cities
+
+| Aspect | Dolt (default) | Doltlite |
+|--------|---------------|----------|
+| Storage | Dolt SQL server (port 37282) | Embedded prolly-tree `.db` file |
+| Beads init | `DOLT_COMMIT()` via MySQL | `dolt_commit()` via SQLite built-in |
+| Pack auto-install | `dolt` pack included | `dolt` pack skipped |
+| Formulas | `mol-dolt-health`, `mol-dolt-remotes-patrol` | `mol-doltlite-maintenance` |
+| `--dolt-auto-commit` | Controls VCS commit timing | Same flag passed but doltlite ignores VCS semantics |
+
+### Database Layout
+
+```
+.beads/
+  metadata.json        → {"backend":"doltlite","database":"doltlite","dolt_database":"hq"}
+  doltlite/
+    hq.db              → Single-file prolly-tree database (city-level beads)
+    .lock              → flock() sentinel for exclusive write access
+  routes.jsonl         → Rig prefix routing
+
+gascity/.beads/        → Rig-level beads store (same layout, database: gc.db)
+beads-doltlite/.beads/ → Rig-level beads store
+```
+
+### Rig Status
+
+| Rig | Prefix | Repo | Role |
+|-----|--------|------|------|
+| gascity | `gc-` | `gastownhall/gascity` | Gas Town source, packs, CLI |
+| beads-doltlite | `bd-` | `duncan4123/beads-doltlite` | Beads CLI with doltlite backend |
+{{ end }}


### PR DESCRIPTION
## Summary

- Adds the builtin `examples/beads-doltlite` pack for local DoltLite-backed bead store operations.
- Clarifies the DoltLite layering: the merged DoltLite backend support already works through Gas City core config/lifecycle plus the existing `bd` pack wrapper. This pack does not make DoltLite possible; it packages the DoltLite-specific operator surface around that backend.
- Keeps this PR scoped to the pack only; no Gas Town JJ/LazyJJ pack material is included.

## What this pack does

The merged DoltLite path is:

```text
Gas City beads config/lifecycle
  -> builtin bd pack
    -> gc-beads-bd.sh
      -> BEADS_BACKEND=doltlite / GC_BEADS_BACKEND=doltlite
        -> bd CLI DoltLite backend
```

This new builtin pack layers on top of that existing path. It imports/exports `bd` and adds DoltLite-specific commands and docs:

- `gc beads-doltlite health` for schema/runtime health checks.
- `gc beads-doltlite flatten` and `gc beads-doltlite gc` for maintenance operations.
- `gc beads-doltlite build` for building `gc`, `bd`, and the debug client against `libdoltlite`.
- scheduled maintenance/health orders and a city-understanding fragment for DoltLite-backed cities.
- doctor checks for sqlite3, metadata, fast-path reads, and libdoltlite-linked `gc` binaries.

## Install/build story

The build command includes the bootstrap path we need for local operators:

- It searches for local `doltlite`, `doltlite-work`, and `beads-doltlite` checkouts first.
- If they are missing, bootstrapping is enabled by default and it clones source repos into `<city>/.cache/beads-doltlite/sources`.
- Defaults are `https://github.com/dolthub/doltlite.git` for DoltLite and `https://github.com/duncan4123/beads-doltlite.git` for beads-doltlite; both can be overridden with flags/env.
- It builds `libdoltlite` when needed, then builds linked `gc`, `bd`, or `doltlite-client` binaries.
- `--no-bootstrap` disables source cloning for environments that require pre-provisioned source trees.

This remains a builtin pack for now because the backend is still crossing core Gas City, the `bd` wrapper, and external DoltLite/beads-doltlite source builds. Keeping the pack builtin gives users one discoverable command namespace while the install and maintenance story stabilizes.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

Not run in this cleanup pass. Verified the PR diff contains 26 files, all under `examples/beads-doltlite/`.

## Checklist

- [ ] Linked an issue, or explained why one is not needed
- [ ] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No breaking changes expected; this adds a new example/builtin pack surface only.
