### PR TITLE
fix(dolt): exclude dolt_ignore'd tables force-inlined into HEAD from compact flatten verification (#3431 follow-up)

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -650,6 +650,31 @@ committed_tables() {
   rm -f "$out_tmp" "$err_tmp"
 }
 
+# ignored_tables — emit one table name per line for the user tables currently
+# matched by an active dolt_ignore pattern. The flatten's `-Am` commit never
+# stages a dolt_ignore'd table, so its working-set churn can diverge from the
+# committed root with no flatten involvement — and committed-root membership
+# alone does not catch this: a store recovered via the dolt#11131
+# schema-encoding heal force-inlines its wisp tier into HEAD (DOLT_ADD --force)
+# while leaving it dolt_ignore'd, so the table is present in committed_tables
+# yet still un-stageable. Excluding on dolt_ignore membership too keeps flatten
+# verification scoped to the surfaces -Am can actually touch.
+ignored_tables() {
+  db="$1"
+  out_tmp=$(mktemp)
+  err_tmp=$(mktemp)
+  if ! dolt_query "$db" \
+    "SELECT DISTINCT t.table_name FROM information_schema.tables t JOIN dolt_ignore i ON t.table_name LIKE i.pattern WHERE t.table_schema = '$db' AND t.table_type = 'BASE TABLE' AND i.ignored = true ORDER BY t.table_name" \
+    > "$out_tmp" 2>"$err_tmp"; then
+    printf 'compact: db=%s dolt_ignore table list probe failed\n' "$db" >&2
+    emit_error_file "$db" "$err_tmp"
+    rm -f "$out_tmp" "$err_tmp"
+    return 1
+  fi
+  awk 'NR>=4 && /^\|/ {gsub(/^\| | \|$/, ""); gsub(/ /, ""); if ($0 != "") print}' "$out_tmp"
+  rm -f "$out_tmp" "$err_tmp"
+}
+
 # row_count — COUNT(*) for one table. Returns "" on error.
 row_count() {
   db="$1"
@@ -778,15 +803,20 @@ push_remote_refspec() {
 }
 
 # preflight_counts — write "<table> <count> <value-hash>" lines for the user
-# tables present in the committed root at <at_head>. Tables outside that root
-# (dolt_ignore'd working-set-only tables, not-yet-committed new tables) are
-# excluded: the flatten's soft-reset+commit cannot stage or touch them, their
-# concurrent churn is indistinguishable from the gain+drift corruption signal,
-# and the Option A DOLT_DIFF preservation probe structurally fails on a table
-# that exists in no commit — a guaranteed false quarantine on a busy db
-# (observed on hq with bd's wisp tier). The excluded names are recorded in the
-# preflight_excluded_tables global so verify_counts can skip them in the
-# post-flatten table-list comparison symmetrically.
+# tables the flatten can actually touch: present in the committed root at
+# <at_head> AND not matched by an active dolt_ignore pattern. Tables failing
+# either test are excluded — the flatten's soft-reset+commit cannot stage or
+# touch them, their concurrent churn is indistinguishable from the gain+drift
+# corruption signal, and the Option A DOLT_DIFF preservation probe structurally
+# fails on a table that exists in no commit. Two shapes need exclusion:
+# (1) absent from the committed root — dolt_ignore'd working-set-only tables or
+# not-yet-committed new tables; (2) present in the committed root yet still
+# dolt_ignore'd — a force-inlined wisp tier on a dolt#11131-healed store, which
+# committed-root membership alone would wrongly keep in verification. Both are a
+# guaranteed false quarantine on a busy db (observed on hq with bd's wisp tier).
+# The excluded names are recorded in the preflight_excluded_tables global so
+# verify_counts can skip them in the post-flatten table-list comparison
+# symmetrically.
 preflight_counts() {
   db="$1"
   out="$2"
@@ -803,6 +833,11 @@ preflight_counts() {
     rm -f "$tables_tmp" "$committed_tmp"
     return 1
   fi
+  ignored_tmp=$(mktemp)
+  if ! ignored_tables "$db" > "$ignored_tmp"; then
+    rm -f "$tables_tmp" "$committed_tmp" "$ignored_tmp"
+    return 1
+  fi
   preflight_failed=0
   while IFS= read -r t; do
     [ -n "$t" ] || continue
@@ -812,7 +847,7 @@ preflight_counts() {
       preflight_failed=1
       break
     fi
-    if ! grep -Fxq "$t" "$committed_tmp"; then
+    if ! grep -Fxq "$t" "$committed_tmp" || grep -Fxq "$t" "$ignored_tmp"; then
       preflight_excluded_tables="$preflight_excluded_tables $t"
       continue
     fi
@@ -840,9 +875,9 @@ preflight_counts() {
     fi
     printf '%s %s %s\n' "$t" "$cnt" "$table_hash" >> "$out"
   done < "$tables_tmp"
-  rm -f "$tables_tmp" "$committed_tmp"
+  rm -f "$tables_tmp" "$committed_tmp" "$ignored_tmp"
   if [ "$preflight_failed" -eq 0 ] && [ -n "$preflight_excluded_tables" ]; then
-    printf 'compact: db=%s excluding unversioned table(s) from flatten verification (absent from committed root at %s):%s\n' \
+    printf 'compact: db=%s excluding table(s) from flatten verification (absent from committed root at %s, or matched by an active dolt_ignore pattern and unstageable by -Am):%s\n' \
       "$db" "$at_head" "$preflight_excluded_tables"
   fi
   return "$preflight_failed"

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -721,11 +721,24 @@ case "$query" in
     exit 0
     ;;
   *"DOLT_HASHOF_TABLE('wisps')"*)
-    if [ "$mode" = "ignored_table_drift" ] && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "ignored_table_drift" ] || [ "$mode" = "force_healed_ignored_table_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-wisps-after-churn
       exit 0
     fi
     print_cell hash-wisps-before
+    exit 0
+    ;;
+  *"JOIN dolt_ignore"*)
+    # ignored_tables(): the user tables matched by an active dolt_ignore
+    # pattern. Empty for a normal store. The ignored_table_* modes model bd's
+    # dolt_ignore'd wisp tier; force_healed_ignored_table_drift additionally
+    # has it force-inlined into HEAD (present in SHOW TABLES AS OF) yet still
+    # dolt_ignore'd — the dolt#11131-healed shape.
+    case "$mode" in
+      ignored_table_drift|ignored_table_db_hash_drift|force_healed_ignored_table_drift)
+        print_cell wisps
+        ;;
+    esac
     exit 0
     ;;
   *"SHOW TABLES AS OF"*|*"information_schema.tables"*)
@@ -741,6 +754,15 @@ case "$query" in
           print_cells beads wisps
           ;;
       esac
+      exit 0
+    fi
+    # force_healed_ignored_table_drift: the dolt#11131 heal force-inlined the
+    # still-dolt_ignore'd wisp tier into HEAD, so it is present in the committed
+    # root (SHOW TABLES AS OF) as well as information_schema. committed-root
+    # membership alone would keep it in verification; ignored_tables() excludes
+    # it because the flatten's -Am still cannot stage a dolt_ignore'd table.
+    if [ "$mode" = "force_healed_ignored_table_drift" ]; then
+      print_cells beads wisps
       exit 0
     fi
     if [ "$mode" = "table_discovery_failure" ]; then
@@ -795,7 +817,7 @@ case "$query" in
     exit 0
     ;;
   *"SELECT COUNT(*) FROM"*"wisps"*)
-    if [ "$mode" = "ignored_table_drift" ] && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "ignored_table_drift" ] || [ "$mode" = "force_healed_ignored_table_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell 11
       exit 0
     fi
@@ -2371,7 +2393,7 @@ func TestCompactScriptExcludesUnversionedTableChurnFromVerification(t *testing.T
 	if err != nil {
 		t.Fatalf("unversioned-table churn must not fail compaction: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "excluding unversioned table(s) from flatten verification") ||
+	if !strings.Contains(out, "excluding table(s) from flatten verification") ||
 		!strings.Contains(out, "wisps") {
 		t.Fatalf("output missing unversioned-table exclusion notice:\n%s", out)
 	}
@@ -2388,6 +2410,40 @@ func TestCompactScriptExcludesUnversionedTableChurnFromVerification(t *testing.T
 	}
 	if !strings.Contains(string(data), "DOLT_GC") {
 		t.Fatalf("compact must reach full GC after excluding unversioned churn:\n%s", string(data))
+	}
+}
+
+// Force-healed variant of the unversioned-table exclusion (gascity #3431
+// follow-up). A store recovered via the dolt#11131 schema-encoding heal
+// force-inlines its still-dolt_ignore'd wisp tier into HEAD (DOLT_ADD --force),
+// so the table IS present in the committed root (SHOW TABLES AS OF) — yet the
+// flatten's -Am still cannot stage a dolt_ignore'd table, so its concurrent
+// churn reads as gain+drift exactly like the working-set-only case. Excluding
+// on committed-root absence alone keeps it in verification and false-quarantines
+// it; excluding on dolt_ignore membership too is required.
+func TestCompactScriptExcludesForceHealedIgnoredTableChurnFromVerification(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "force_healed_ignored_table_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("force-healed dolt_ignore'd-table churn must not fail compaction: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "excluding table(s) from flatten verification") ||
+		!strings.Contains(out, "wisps") {
+		t.Fatalf("output missing dolt_ignore'd-table exclusion notice:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("force-healed dolt_ignore'd-table churn must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read fake dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_HASHOF_TABLE('wisps')") {
+		t.Fatalf("force-inlined-but-ignored table must not be count/hash-verified:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("compact must reach full GC after excluding force-healed ignored churn:\n%s", string(data))
 	}
 }
 


### PR DESCRIPTION
Closes #3541

This completes #3431 for the **force-healed-store** variant. #3431 scopes compact flatten verification to the committed root (`committed_tables` = `SHOW TABLES AS OF HEAD`), excluding `dolt_ignore`'d tables on the assumption they're working-set-only and absent from every commit. That holds for a normally-grown store.

A store recovered via the **dolt#11131 schema-encoding heal** force-inlines its `dolt_ignore`'d wisp tier **into HEAD** (`DOLT_ADD --force` + commit) to clear the dirty-working-set write-block — so the table is **present** in `SHOW TABLES AS OF HEAD` while **still** in `dolt_ignore`. `committed_tables` then includes it → it stays in per-table verification → its concurrent flatten-window churn reads as gain+drift → false quarantine. But a `-Am` flatten can never stage a `dolt_ignore`'d table regardless of committed-root presence, so its live count/hash was never the flatten's to preserve. (Flagged pre-merge in the review comment on this PR; confirmed it survived the merge.)

**Fix:** add the symmetric exclusion criterion — also exclude a user table matched by an active `dolt_ignore` pattern, regardless of committed-root presence — via a new `ignored_tables()` helper (symmetric to `committed_tables()`), one extra clause in `preflight_counts`, and the existing `verify_counts` skip already covers the excluded set.

**Preserved:** HEAD-movement corruption detection (`DOLT_HASHOF_DB('HEAD')`) and the benign-drift deferral (`db_root_drift_within_verified_tables`) are untouched. A force-inlined-but-ignored table's committed portion is no longer per-table verified — defensible, since `-Am` cannot move it and HEAD-movement detection still catches real committed corruption.

**Repro (dolt 2.1.6):** after `DOLT_ADD('--force','wisps')` + commit, `SHOW TABLES AS OF HEAD` lists `wisps`; flatten-window churn drives the live per-table count 3→5 + hash drift while committed HEAD stays 3 → #3431 as-merged quarantines. Observed on a live force-healed hq across three consecutive compactor fires.

**Tests (TDD):** new `TestCompactScriptExcludesForceHealedIgnoredTableChurnFromVerification` (fake-dolt mode `force_healed_ignored_table_drift`) is **red** on #3431 as-merged (`post-flatten INTEGRITY check failed`, exit 1) and **green** with the fix (no marker, `wisps` not count/hash-verified, reaches `DOLT_GC`). Existing `…ExcludesUnversionedTableChurnFromVerification` still green. Full `examples/bd/dolt` suite green; `go vet` clean.

Follow-up to #3431; refs #3341, #2348.
