### PR TITLE
fix(scripts): degrade shellcheck lint when the mise shim can't run

### DIFF
--- a/scripts/test-slice-enroll-test
+++ b/scripts/test-slice-enroll-test
@@ -27,11 +27,20 @@ if [[ ! -f "$lib" ]]; then
   exit 1
 fi
 
-# The wrapper must stay shellcheck-clean (and so must this suite).
-if command -v shellcheck >/dev/null 2>&1; then
+# The wrapper must stay shellcheck-clean (and so must this suite). But the
+# linter is often a mise shim that refuses to run when the mise config is
+# untrusted in this subprocess (`go test` invokes us with a scratch $HOME,
+# so the shim can't reach its trust store). Probe that the linter can
+# actually execute before treating a non-zero exit as a lint finding;
+# otherwise a tooling failure masquerades as a script defect and blocks
+# commits city-wide. Degrade to a logged warning when the linter is
+# present-but-unrunnable, just as when it is absent.
+if shellcheck --version >/dev/null 2>&1; then
   if ! shellcheck "$lib" "${BASH_SOURCE[0]}"; then
     fail "shellcheck reported issues"
   fi
+elif command -v shellcheck >/dev/null 2>&1; then
+  echo "warning: shellcheck on PATH but not runnable (untrusted mise shim?); skipping shell lint" >&2
 else
   echo "note: shellcheck not installed; skipping lint" >&2
 fi


### PR DESCRIPTION
## Problem

`scripts/test-slice-enroll-test` treats a non-zero `shellcheck` exit as a lint finding. But when `shellcheck` on `PATH` is a `mise` shim, it refuses to run if the mise config is untrusted in the calling subprocess — and `go test` invokes this wrapper with a scratch `$HOME`, so the shim can't reach its trust store. The result: a tooling failure (shim-can't-run) masquerades as a script defect, failing the suite and blocking commits.

## Fix

Probe that the linter can actually execute (`shellcheck --version`) before treating a non-zero exit as a finding. When `shellcheck` is present-but-unrunnable (untrusted mise shim), degrade to a logged warning and skip the shell lint — exactly as the script already does when `shellcheck` is absent.

```
if shellcheck --version >/dev/null 2>&1; then
  # run the lint
elif command -v shellcheck >/dev/null 2>&1; then
  echo "warning: shellcheck on PATH but not runnable (untrusted mise shim?); skipping shell lint" >&2
else
  echo "note: shellcheck not installed; skipping lint" >&2
fi
```

Single file, +11/-2. The wrapper itself stays shellcheck-clean.
