### PR TITLE
fix(compact): exclude dolt_ignore'd committed tables from flatten verification (#3541)

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -650,6 +650,25 @@ committed_tables() {
   rm -f "$out_tmp" "$err_tmp"
 }
 
+# dolt_ignore_patterns — emit one pattern per line from dolt_ignore WHERE ignored=1.
+# Fails open (returns 0 with empty output) when dolt_ignore does not exist or the
+# query fails: older stores and bare servers may lack this table. The ignored=1
+# filter matches only explicit ignore entries; negative entries (ignored=0) that
+# un-ignore sub-patterns of a broader glob are deliberately excluded.
+dolt_ignore_patterns() {
+  db="$1"
+  out_tmp=$(mktemp)
+  err_tmp=$(mktemp)
+  if ! dolt_query "$db" \
+    "SELECT pattern FROM dolt_ignore WHERE ignored = 1" \
+    > "$out_tmp" 2>"$err_tmp"; then
+    rm -f "$out_tmp" "$err_tmp"
+    return 0
+  fi
+  awk 'NR>=4 && /^\|/ {gsub(/^\| | \|$/, ""); gsub(/ /, ""); if ($0 != "") print}' "$out_tmp"
+  rm -f "$out_tmp" "$err_tmp"
+}
+
 # row_count — COUNT(*) for one table. Returns "" on error.
 row_count() {
   db="$1"
@@ -778,15 +797,24 @@ push_remote_refspec() {
 }
 
 # preflight_counts — write "<table> <count> <value-hash>" lines for the user
-# tables present in the committed root at <at_head>. Tables outside that root
-# (dolt_ignore'd working-set-only tables, not-yet-committed new tables) are
-# excluded: the flatten's soft-reset+commit cannot stage or touch them, their
-# concurrent churn is indistinguishable from the gain+drift corruption signal,
-# and the Option A DOLT_DIFF preservation probe structurally fails on a table
-# that exists in no commit — a guaranteed false quarantine on a busy db
-# (observed on hq with bd's wisp tier). The excluded names are recorded in the
-# preflight_excluded_tables global so verify_counts can skip them in the
-# post-flatten table-list comparison symmetrically.
+# tables present in the committed root at <at_head>. Two categories are excluded:
+#
+# 1. Tables absent from the committed root (dolt_ignore'd working-set-only tables,
+#    not-yet-committed new tables): the flatten's soft-reset+commit cannot stage or
+#    touch them, their concurrent churn is indistinguishable from the gain+drift
+#    corruption signal, and the Option A DOLT_DIFF preservation probe structurally
+#    fails on a table that exists in no commit — a guaranteed false quarantine.
+#
+# 2. Tables present in the committed root that are dolt_ignore'd (#3541): a
+#    force-healed store (dolt#11131) can inline a dolt_ignore'd table into HEAD
+#    via DOLT_ADD('--force',...)+commit, so SHOW TABLES AS OF HEAD returns it.
+#    But -Am still cannot stage dolt_ignore'd tables, so their live count/hash
+#    drifts freely under concurrent writers and would false-quarantine identically
+#    to category 1. Querying dolt_ignore and removing matching tables from the
+#    committed-root set catches this case before the per-table verification loop.
+#
+# Excluded names are recorded in preflight_excluded_tables so verify_counts can
+# skip them in the post-flatten table-list comparison symmetrically.
 preflight_counts() {
   db="$1"
   out="$2"
@@ -803,6 +831,36 @@ preflight_counts() {
     rm -f "$tables_tmp" "$committed_tmp"
     return 1
   fi
+  # Remove dolt_ignore'd tables from the committed-root set even if they appear
+  # in HEAD (see category 2 in the function comment above for why).
+  ignored_patterns_tmp=$(mktemp)
+  dolt_ignore_patterns "$db" > "$ignored_patterns_tmp" || true
+  if [ -s "$ignored_patterns_tmp" ]; then
+    filtered_committed_tmp=$(mktemp)
+    preflight_dolt_ignored_tables=""
+    while IFS= read -r ct; do
+      [ -n "$ct" ] || continue
+      ct_matched=0
+      while IFS= read -r pat; do
+        [ -n "$pat" ] || continue
+        case "$ct" in
+          $pat) ct_matched=1; break ;;
+        esac
+      done < "$ignored_patterns_tmp"
+      if [ "$ct_matched" = "1" ]; then
+        preflight_dolt_ignored_tables="$preflight_dolt_ignored_tables $ct"
+      else
+        printf '%s\n' "$ct" >> "$filtered_committed_tmp"
+      fi
+    done < "$committed_tmp"
+    rm -f "$committed_tmp"
+    committed_tmp="$filtered_committed_tmp"
+    if [ -n "$preflight_dolt_ignored_tables" ]; then
+      printf 'compact: db=%s excluding dolt_ignored committed table(s) from flatten verification (force-inlined into HEAD but -Am cannot stage them):%s\n' \
+        "$db" "$preflight_dolt_ignored_tables"
+    fi
+  fi
+  rm -f "$ignored_patterns_tmp"
   preflight_failed=0
   while IFS= read -r t; do
     [ -n "$t" ] || continue

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -721,11 +721,25 @@ case "$query" in
     exit 0
     ;;
   *"DOLT_HASHOF_TABLE('wisps')"*)
-    if [ "$mode" = "ignored_table_drift" ] && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "ignored_table_drift" ] || [ "$mode" = "ignored_committed_table_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-wisps-after-churn
       exit 0
     fi
     print_cell hash-wisps-before
+    exit 0
+    ;;
+  *"SELECT pattern FROM dolt_ignore WHERE ignored"*)
+    # ignored_committed_table_drift: wisps was force-inlined into HEAD by a
+    # dolt#11131 heal but is still dolt_ignore'd — the fix must detect this and
+    # exclude wisps from flatten verification (#3541).
+    case "$mode" in
+      ignored_committed_table_drift)
+        print_cell wisps
+        ;;
+      *)
+        print_cells
+        ;;
+    esac
     exit 0
     ;;
   *"SHOW TABLES AS OF"*|*"information_schema.tables"*)
@@ -741,6 +755,14 @@ case "$query" in
           print_cells beads wisps
           ;;
       esac
+      exit 0
+    fi
+    # ignored_committed_table_drift models a force-healed store (#3541): wisps
+    # was inlined into HEAD by DOLT_ADD('--force',...)+commit, so SHOW TABLES
+    # AS OF HEAD returns it — unlike the normal ignored_table_drift case where
+    # wisps is absent from every commit root. Both queries return wisps here.
+    if [ "$mode" = "ignored_committed_table_drift" ]; then
+      print_cells beads wisps
       exit 0
     fi
     if [ "$mode" = "table_discovery_failure" ]; then
@@ -795,7 +817,7 @@ case "$query" in
     exit 0
     ;;
   *"SELECT COUNT(*) FROM"*"wisps"*)
-    if [ "$mode" = "ignored_table_drift" ] && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "ignored_table_drift" ] || [ "$mode" = "ignored_committed_table_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell 11
       exit 0
     fi
@@ -2388,6 +2410,41 @@ func TestCompactScriptExcludesUnversionedTableChurnFromVerification(t *testing.T
 	}
 	if !strings.Contains(string(data), "DOLT_GC") {
 		t.Fatalf("compact must reach full GC after excluding unversioned churn:\n%s", string(data))
+	}
+}
+
+// Companion to the unversioned-table exclusion: when a force-healed store
+// (dolt#11131) inlines a dolt_ignore'd table into HEAD via DOLT_ADD('--force')
+// + commit, SHOW TABLES AS OF HEAD returns it. The -Am flatten still cannot
+// stage it, so its live count/hash drifts freely under concurrent writers.
+// The fix queries dolt_ignore and excludes any committed table matched by an
+// ignored=1 pattern from flatten integrity verification (#3541).
+func TestCompactScriptExcludesDoltIgnoredCommittedTableFromVerification(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "ignored_committed_table_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("dolt_ignored committed table churn must not fail compaction: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "excluding dolt_ignored committed table(s) from flatten verification") ||
+		!strings.Contains(out, "wisps") {
+		t.Fatalf("output missing dolt_ignored committed table exclusion notice:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("dolt_ignored committed table churn must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read fake dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_HASHOF_TABLE('wisps')") {
+		t.Fatalf("dolt_ignored committed table must not be hash-verified:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "SELECT pattern FROM dolt_ignore WHERE ignored") {
+		t.Fatalf("compact must query dolt_ignore to detect ignored committed tables:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("compact must reach full GC after excluding dolt_ignored committed table:\n%s", string(data))
 	}
 }
 


### PR DESCRIPTION
## Summary

- `preflight_counts` in `examples/bd/dolt/commands/compact/run.sh` now queries `dolt_ignore WHERE ignored=1` after `committed_tables` returns and removes any table matched by a `dolt_ignore` pattern from the per-table verification set.
- A force-healed store (dolt#11131) can inline a `dolt_ignore`'d table into HEAD via `DOLT_ADD('--force',...)+commit`. `SHOW TABLES AS OF HEAD` then returns it, but `-Am` still cannot stage it — so its live count/hash drifts freely under concurrent writers and false-quarantines via the same gain+drift signal as unversioned tables.
- Fails open: if `dolt_ignore` does not exist or the query fails (older store, bare server), `preflight_counts` proceeds with the full committed set. `DOLT_HASHOF_DB('HEAD')` integrity check is unaffected.

## Test plan

- [ ] New fake-dolt mode `ignored_committed_table_drift` simulates a force-healed store: `SHOW TABLES AS OF HEAD` returns `wisps`, `dolt_ignore` returns `wisps` as an ignored pattern, and the live hash drifts after the flatten window.
- [ ] `TestCompactScriptExcludesDoltIgnoredCommittedTableFromVerification` verifies: exclusion notice logged with table name, no quarantine marker written, `wisps` never hash-verified, `dolt_ignore` queried, `DOLT_GC` reached (compaction completes).
- [ ] All 85 compact tests pass (`go test ./examples/bd/dolt/...`).
- [ ] All pre-commit shards pass.

Closes #3541. Refs #3431, #3341, #2348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)