### PR TITLE
fix(gchome): use process-unique temp when home unresolved (#3506)

### DIFF
--- a/internal/gchome/gchome.go
+++ b/internal/gchome/gchome.go
@@ -2,6 +2,7 @@
 package gchome
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,16 +10,27 @@ import (
 
 // Default returns the Gas City machine-local state directory.
 //
-// Resolution order: GC_HOME, user home/.gc, temp fallback.
+// Resolution order: GC_HOME, user home/.gc, process-unique temp fallback.
 func Default() string {
 	if v := strings.TrimSpace(os.Getenv("GC_HOME")); v != "" {
 		return v
 	}
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return filepath.Join(os.TempDir(), ".gc")
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".gc")
 	}
-	return filepath.Join(home, ".gc")
+	// Home unresolved. Never fall back to a fixed os.TempDir()/.gc: that path
+	// is shared and world-writable, so concurrent processes clobber each
+	// other's state and unrelated city scans pick it up as a real city
+	// (#3506). Hand out a process-unique directory instead.
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	// MkdirTemp failed, so the temp directory itself is unusable. Return a
+	// process-unique path under it rather than "" (which callers would join
+	// into a CWD-relative path, silently writing state to the wrong place) or
+	// the shared os.TempDir()/.gc that #3506 is about. The caller then fails
+	// loudly when it cannot create or write this path.
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
 }
 
 // RegistriesPath returns the configured registry file path under home.

--- a/internal/gchome/gchome_test.go
+++ b/internal/gchome/gchome_test.go
@@ -1,6 +1,7 @@
 package gchome
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -11,6 +12,31 @@ func TestDefaultUsesGCHome(t *testing.T) {
 
 	if got := Default(); got != dir {
 		t.Fatalf("Default() = %q, want %q", got, dir)
+	}
+}
+
+// TestDefaultAvoidsSharedTempFallback guards #3506: when GC_HOME is unset and
+// the user home cannot be resolved, Default() must not hand back the shared
+// os.TempDir()/.gc path. That path is world-writable and shared across every
+// process and user on the host, so concurrent processes clobber each other's
+// state and unrelated city scans pick it up as a real city.
+func TestDefaultAvoidsSharedTempFallback(t *testing.T) {
+	t.Setenv("GC_HOME", "")
+	t.Setenv("HOME", "") // forces os.UserHomeDir() to fail on unix
+
+	got := Default()
+
+	if shared := filepath.Join(os.TempDir(), ".gc"); got == shared {
+		t.Fatalf("Default() = %q, want a process-isolated path, not the shared %q", got, shared)
+	}
+	// Must never be empty: callers join the result into a path (e.g.
+	// filepath.Join(home, "registries.toml")), so "" silently becomes a
+	// CWD-relative path and writes state to the wrong place instead of failing.
+	if got == "" {
+		t.Fatal("Default() returned an empty path; callers would write state to a CWD-relative path")
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("Default() = %q, want an absolute process-isolated path", got)
 	}
 }
 


### PR DESCRIPTION
## What

`gchome.Default()` resolved the machine-local state dir as
`GC_HOME` → `~/.gc` → and, when the user home could not be resolved,
a fixed `os.TempDir()/.gc` fallback. This replaces that last fallback
with a process-unique directory.

## Why

`os.TempDir()/.gc` is a single shared, world-writable path. When `HOME`
is unresolvable (minimal containers, stripped environments), every
process on the host lands on the *same* directory, so:

- concurrent processes clobber each other's state, and
- unrelated city scans pick that directory up as a real city.

This is the cross-process collision reported in #3506.

## Change

When home is unresolved, hand out a process-unique directory instead:

- `os.MkdirTemp("", "gc-home-*")` when it succeeds;
- otherwise `os.TempDir()/gc-home-<pid>`.

The fallback is never the shared path and never `""` — an empty string
would be joined by callers into a CWD-relative path and silently write
state to the wrong place. When the temp dir itself is unusable, callers
fail loudly on create/write rather than aliasing the working directory.

## Test

`TestDefaultAvoidsSharedTempFallback` forces `os.UserHomeDir()` to fail
and asserts the result is not the shared path, is non-empty, and is
absolute. `go test ./internal/gchome` and `go vet ./internal/gchome`
pass.

## Note / follow-up (out of scope)

The same shared-`/tmp` fallback pattern also lives in three sibling
resolvers — `defaultGCHome` (`internal/bootstrap/bootstrap.go`),
`builtinDefaultHome` (`internal/supervisor/config.go`), and
`ImplicitGCHome` (`internal/config/implicit.go`). This PR fixes only
`gchome.Default()`, the function named in #3506, to keep the change
surgical (one issue per PR). The siblings are left for a separate
follow-up.

Closes #3506.
