### PR TITLE
fix(cover): increase test-cover per-package timeout from 8m to 20m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,7 @@ UNIT_COVER_PKGS = $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.Imp
 ## The skipped cmd/gc process-backed scenarios remain covered by
 ## `make test-cmd-gc-process` locally and the CI `cmd/gc process suite` job.
 test-cover: test-fsys-darwin-compile
-	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 8m -coverprofile=coverage.txt $(UNIT_COVER_PKGS)
+	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 20m -coverprofile=coverage.txt $(UNIT_COVER_PKGS)
 
 ## cover: run tests and show coverage report
 cover: test-cover


### PR DESCRIPTION
## Summary

- `cmd/gc` takes **~450–480s under `GC_FAST_UNIT=1`**, which exactly hits the old 8-minute per-package timeout and kills the `Preflight / unit cover` CI job on every main push
- This has caused 4 consecutive `Preflight / unit cover` failures on main (SHAs b4ca71e1, 0ed81eb8, a94de58f, d72b52bd)
- The fix is a 1-line timeout increase: `8m` → `20m`, giving each package a comfortable budget

Root-cause evidence from CI job `81689417770`:
```
panic: test timed out after 8m0s
FAIL  github.com/gastownhall/gascity/cmd/gc  480.456s
```
Local measurement: 448s. The CI runner (~480s) hits the limit with near-zero margin.

Previous guards (PR #3518 skip Dolt lifecycle tests, PR #3544 skip forkRateCheck) reduced the sequenced-test time but `cmd/gc` still exceeds 8m on CI due to its 6700+ test functions even without the guarded slow tests.

## Test plan

- [x] Fast unit suite (`make test-fast-parallel`) passes
- [x] `go vet ./...` clean
- [ ] `Preflight / unit cover` CI job succeeds (main merge target)

Closes ga-uifq0l

🤖 Generated with [Claude Code](https://claude.com/claude-code)