### PR TITLE
fix(test): bump dolt-fixture spawn-visibility deadline 1s→10s to kill CI flake

### DIFF
--- a/cmd/gc/dolt_standalone_conflict_test.go
+++ b/cmd/gc/dolt_standalone_conflict_test.go
@@ -69,7 +69,9 @@ func startStandaloneBdDoltLikeProcess(t *testing.T, dataDir string) *exec.Cmd {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 	})
-	deadline := time.Now().Add(time.Second)
+	// 10s: must outlast a worst-case processArgsPSTimeout (1s) ps fallback plus
+	// process-exec/proc-reflection latency under heavy parallel CI load.
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		if cmd.Process.Signal(syscall.Signal(0)) == nil && processLooksLikeDoltSQLServer(cmd.Process.Pid, dataDir) {
 			return cmd

--- a/release-gates/ga-soumke-dolt-fixture-deadline-gate.md
+++ b/release-gates/ga-soumke-dolt-fixture-deadline-gate.md
@@ -1,0 +1,43 @@
+# Release Gate: ga-soumke
+
+Feature: bump dolt-fixture spawn-visibility deadline from 1s to 10s
+PR: https://github.com/gastownhall/gascity/pull/3551
+Branch: builder/ga-qtwo8j
+Reviewed commit: ee9490f252b48b83628285e4ba81729e7a0f246c
+Gate worktree: /tmp/gascity-deploy-ga-soumke-1781627665
+Gate date: 2026-06-16
+
+## Gate Inputs
+
+- Deploy bead: ga-soumke
+- Source review bead: ga-dpwzuz
+- Source implementation bead: ga-qtwo8j
+- Review verdict: PASS in ga-dpwzuz notes.
+- Manifest note: docs/PROJECT_MANIFEST.md is not present in this checkout, so this gate uses the deployer release criteria table from the agent instructions.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-dpwzuz is closed with close reason `pass`; notes contain `REVIEWER VERDICT: PASS` and `Findings: none`. |
+| 2 | Acceptance criteria met | PASS | Commit ee9490f252b48b83628285e4ba81729e7a0f246c changes only `cmd/gc/dolt_standalone_conflict_test.go`, increasing `startStandaloneBdDoltLikeProcess` inspection deadline from 1s to 10s with an explanatory comment. No production files changed. |
+| 3 | Tests pass | PASS | `go test -count=3 ./cmd/gc -run 'TestDetectStandaloneBdDoltLiveDoltForDifferentDataDirDoesNotConflict\|TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt\|TestInitDirIfReadyDetectsStandaloneBdDoltAtProviderConvergence'` passed. `go build ./cmd/gc` passed. `go vet ./...` passed. `make test-fast-parallel` passed: all fast jobs passed. |
+| 4 | No high-severity review findings open | PASS | ga-dpwzuz review notes report `Findings: none`; no HIGH findings are recorded in the deploy or review bead notes. |
+| 5 | Final branch is clean | PASS | Clean gate worktree before gate file; final cleanliness rechecked after committing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` reported clean. Current `origin/main` at 47afaf75a454d7577ff33b9210fe11bd8c172820; merge-base beba5c8bdff857da0da12248f50b9a4f6e3c064f. |
+| 7 | Single feature theme | PASS | Single test-only reliability fix in one `cmd/gc` test helper; no unrelated package or user-facing behavior changes. |
+
+## Diff Scope
+
+```text
+M	cmd/gc/dolt_standalone_conflict_test.go
+```
+
+## Test Commands
+
+```text
+go test -count=3 ./cmd/gc -run 'TestDetectStandaloneBdDoltLiveDoltForDifferentDataDirDoesNotConflict|TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt|TestInitDirIfReadyDetectsStandaloneBdDoltAtProviderConvergence'
+go build ./cmd/gc
+go vet ./...
+make test-fast-parallel
+```


### PR DESCRIPTION
## What this changes

This adjusts the test-only fake `dolt sql-server` fixture in `cmd/gc/dolt_standalone_conflict_test.go` so process inspection can take up to 10 seconds instead of failing after 1 second. The old deadline was equal to the helper's own `processArgsPSTimeout`, so one slow `ps` fallback under CI load could exhaust the entire budget even when the fake process was healthy.

No production behavior changes. This is only a reliability fix for the standalone Dolt conflict tests.

## Review notes

- The only code change is in `cmd/gc/dolt_standalone_conflict_test.go`.
- No config, API, schema, runtime behavior, or migration changes.
- The branch includes release-gate evidence in `release-gates/ga-soumke-dolt-fixture-deadline-gate.md`.

## Test plan

- [x] `go test -count=3 ./cmd/gc -run 'TestDetectStandaloneBdDoltLiveDoltForDifferentDataDirDoesNotConflict|TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt|TestInitDirIfReadyDetectsStandaloneBdDoltAtProviderConvergence'`
- [x] `go build ./cmd/gc`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-soumke-dolt-fixture-deadline-gate.md`](release-gates/ga-soumke-dolt-fixture-deadline-gate.md)