### PR TITLE
fix(beads): DEBUG the benign bd_context_agreement native-store fallback

### DIFF
--- a/internal/beads/factory.go
+++ b/internal/beads/factory.go
@@ -258,5 +258,16 @@ func logNativeUnavailable(logger *slog.Logger, scope, gate, reason string) {
 		logger.Error(nativeUnavailableMessage, args...)
 		return
 	}
+	if gate == string(contract.PreflightCheckBDContextAgreement) {
+		// Benign, expected fallback: the native store declines activation when it
+		// cannot cross-verify bd's backend (e.g. the bd context probe is briefly
+		// unreachable) and transparently falls back to the bd-backed store. In
+		// deployments where the native store is not eligible this fires on every
+		// store-open, spamming WARN on routine commands like `gc session attach`.
+		// Log at DEBUG instead (still visible with -v); genuine backend
+		// disagreements remain surfaced by `gc doctor`'s preflight diagnostic.
+		logger.Debug(nativeUnavailableMessage, args...)
+		return
+	}
 	logger.Warn(nativeUnavailableMessage, args...)
 }


### PR DESCRIPTION
## Problem

`gc session attach` (and any routine command that opens a beads store) emits repeated WARNs in deployments where the native store isn't eligible:

```
WARN native_store_unavailable gate=bd_context_agreement reason="bd context is unreachable; cannot cross-verify backend agreement" scope=...
```

The native-store preflight's `bd_context_agreement` gate fails when it can't cross-verify bd's backend, the store **correctly falls back to the bd-backed store**, and `logNativeUnavailable` logs at WARN. This is expected, benign degradation — but it fires on every store-open, so a single `gc session attach` prints it 3×, and it recurs on every command.

## Fix

In `internal/beads/factory.go`, drop the `bd_context_agreement` fallback to **DEBUG** (still visible with `-v`). `identity_match` stays **ERROR** (data integrity) and all other gates stay **WARN**. Genuine backend *disagreements* (metadata backend ≠ bd-reported backend) remain surfaced by `gc doctor`'s preflight diagnostic, so no real signal is lost.

## Test

`make build` (the project's CGO build) clean; the changed file is a single log-level adjustment with no behavioral change beyond severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
