### PR TITLE
fix(cover): shard cmd/gc in test-cover and restore tight 10m timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 CLAUDE.local.md
 coverage.txt
 coverage.integration-*.txt
+coverage.noncmdgc.txt
+coverage.cmdgc.*.txt
 cmd/gc/.runtime/
 /bin/
 /gc

--- a/Makefile
+++ b/Makefile
@@ -545,7 +545,6 @@ check-docs:
 # Packages for coverage — exclude noise:
 #   session/tmux: integration-test-only, not meaningful for unit coverage
 #   beadstest: conformance helper, runs under internal/beads coverage
-UNIT_COVER_PKGS = $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /session/tmux -e /beadstest)
 # cmd/gc excluded: it runs sharded below in test-cover to stay under per-package timeout
 UNIT_COVER_PKGS_NONCMDGC = $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /session/tmux -e /beadstest -e '/cmd/gc$$')
 

--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,7 @@ test-cmd-gc-process:
 
 CMD_GC_PROCESS_SHARD ?= 1
 CMD_GC_PROCESS_TOTAL ?= 6
+CMD_GC_COVER_TOTAL ?= 6
 test-cmd-gc-process-shard:
 	$(TEST_ENV) GC_FAST_UNIT=0 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc $(CMD_GC_PROCESS_SHARD) $(CMD_GC_PROCESS_TOTAL)
 
@@ -545,12 +546,23 @@ check-docs:
 #   session/tmux: integration-test-only, not meaningful for unit coverage
 #   beadstest: conformance helper, runs under internal/beads coverage
 UNIT_COVER_PKGS = $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /session/tmux -e /beadstest)
+# cmd/gc excluded: it runs sharded below in test-cover to stay under per-package timeout
+UNIT_COVER_PKGS_NONCMDGC = $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /session/tmux -e /beadstest -e '/cmd/gc$$')
 
-## test-cover: run fast unit-test coverage without the integration-tagged package sweep
+## test-cover: run fast unit-test coverage without the integration-tagged package sweep.
+## cmd/gc is sharded CMD_GC_COVER_TOTAL (default 6) ways via test-go-test-shard so each
+## shard lands well under the per-package timeout; profiles are merged via merge-coverprofiles.
 ## The skipped cmd/gc process-backed scenarios remain covered by
 ## `make test-cmd-gc-process` locally and the CI `cmd/gc process suite` job.
 test-cover: test-fsys-darwin-compile
-	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 20m -coverprofile=coverage.txt $(UNIT_COVER_PKGS)
+	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 10m -coverprofile=coverage.noncmdgc.txt $(UNIT_COVER_PKGS_NONCMDGC)
+	@rm -f coverage.cmdgc.*.txt
+	@for s in $$(seq 1 $(CMD_GC_COVER_TOTAL)); do \
+		$(TEST_ENV) GO_TEST_COVERPROFILE="coverage.cmdgc.$$s.txt" \
+		GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=10m \
+		./scripts/test-go-test-shard ./cmd/gc "$$s" $(CMD_GC_COVER_TOTAL) || exit 1; \
+	done
+	./scripts/merge-coverprofiles coverage.txt coverage.noncmdgc.txt coverage.cmdgc.*.txt
 
 ## cover: run tests and show coverage report
 cover: test-cover

--- a/release-gates/ga-7kav6u-test-cover-sharding-gate.md
+++ b/release-gates/ga-7kav6u-test-cover-sharding-gate.md
@@ -1,0 +1,44 @@
+# Release Gate: ga-7kav6u
+
+Feature: shard `cmd/gc` in `make test-cover` and restore 10m timeout
+PR: https://github.com/gastownhall/gascity/pull/3553
+Branch: builder/ga-92tpq3
+Reviewed commit: 0ee4951ebdb21a9dc5fad70be667f552e01913dc
+Gate worktree: /tmp/gascity-deploy-ga-7kav6u-1781628712
+Gate date: 2026-06-16
+
+## Gate Inputs
+
+- Deploy bead: ga-7kav6u
+- Source review bead: ga-qux1ih
+- Source implementation bead: ga-92tpq3
+- Review verdict: PASS in ga-qux1ih notes.
+- Manifest note: docs/PROJECT_MANIFEST.md is not present in this checkout, so this gate uses the deployer release criteria table from the agent instructions.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-qux1ih is closed with close reason `pass`; notes contain `REVIEWER VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | Commit 0ee4951ebdb21a9dc5fad70be667f552e01913dc changes only `Makefile`. It adds `CMD_GC_COVER_TOTAL ?= 6`, excludes `cmd/gc` from the non-sharded coverage package list, runs `cmd/gc` coverage through `scripts/test-go-test-shard`, restores a 10m coverage timeout, and merges profiles with `scripts/merge-coverprofiles`. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc` passed. `go vet ./...` passed. `make test-fast-parallel` passed: all fast jobs passed. `make test-cover` passed and merged `coverage.noncmdgc.txt` plus six `coverage.cmdgc.*.txt` profiles into `coverage.txt`; total coverage was 70.9%. `cmd/gc` coverage shard runtimes were 48.628s, 50.423s, 54.604s, 66.928s, 74.080s, and 70.909s. |
+| 4 | No high-severity review findings open | PASS | ga-qux1ih review notes contain one INFO finding (`UNIT_COVER_PKGS` is now a dead variable) and no HIGH findings. |
+| 5 | Final branch is clean | PASS | Clean gate worktree before gate file; generated coverage artifacts removed after `make test-cover`; final cleanliness rechecked after committing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` reported clean. Current `origin/main` at 47afaf75a454d7577ff33b9210fe11bd8c172820; merge-base 47afaf75a454d7577ff33b9210fe11bd8c172820. |
+| 7 | Single feature theme | PASS | Single Makefile-only test-infrastructure change for coverage execution; no production code, config, API, schema, or runtime behavior changes. |
+
+## Diff Scope
+
+```text
+M	Makefile
+```
+
+## Test Commands
+
+```text
+go build ./cmd/gc
+go vet ./...
+make test-fast-parallel
+make test-cover
+go tool cover -func=coverage.txt
+```

--- a/release-gates/ga-7kav6u-test-cover-sharding-gate.md
+++ b/release-gates/ga-7kav6u-test-cover-sharding-gate.md
@@ -24,7 +24,7 @@ Gate date: 2026-06-16
 | 3 | Tests pass | PASS | `go build ./cmd/gc` passed. `go vet ./...` passed. `make test-fast-parallel` passed: all fast jobs passed. `make test-cover` passed and merged `coverage.noncmdgc.txt` plus six `coverage.cmdgc.*.txt` profiles into `coverage.txt`; total coverage was 70.9%. `cmd/gc` coverage shard runtimes were 48.628s, 50.423s, 54.604s, 66.928s, 74.080s, and 70.909s. |
 | 4 | No high-severity review findings open | PASS | ga-qux1ih review notes contain one INFO finding (`UNIT_COVER_PKGS` is now a dead variable) and no HIGH findings. |
 | 5 | Final branch is clean | PASS | Clean gate worktree before gate file; generated coverage artifacts removed after `make test-cover`; final cleanliness rechecked after committing this gate file. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` reported clean. Current `origin/main` at 47afaf75a454d7577ff33b9210fe11bd8c172820; merge-base 47afaf75a454d7577ff33b9210fe11bd8c172820. |
+| 6 | Branch diverges cleanly from main | PASS | Rebased cleanly onto main (2026-06-16). Current `origin/main` at e6c2df1fa3f0a66ed9c09b4edc4b2aa8563c6ea7; merge-base e6c2df1fa3f0a66ed9c09b4edc4b2aa8563c6ea7. |
 | 7 | Single feature theme | PASS | Single Makefile-only test-infrastructure change for coverage execution; no production code, config, API, schema, or runtime behavior changes. |
 
 ## Diff Scope


### PR DESCRIPTION
## What this changes

`make test-cover` now runs the large `cmd/gc` package as six coverage shards instead of one monolithic package run. The non-`cmd/gc` packages still run in the normal coverage sweep, then the `cmd/gc` shard profiles are merged with the rest into `coverage.txt`.

This restores the per-package coverage timeout to 10 minutes while avoiding the previous `cmd/gc` timeout pressure. No Go source, production behavior, config, API, schema, or runtime path changes.

## Review notes

- The only code change is in `Makefile`.
- `CMD_GC_COVER_TOTAL` defaults to `6` and controls only the coverage target's `cmd/gc` sharding.
- The existing non-coverage fast and process test targets are not changed.
- Release-gate evidence is in `release-gates/ga-7kav6u-test-cover-sharding-gate.md`.

## Test plan

- [x] `go build ./cmd/gc`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] `make test-cover`
- [x] `go tool cover -func=coverage.txt`
- [x] Release gate: [`release-gates/ga-7kav6u-test-cover-sharding-gate.md`](release-gates/ga-7kav6u-test-cover-sharding-gate.md)