### PR TITLE
fix(beads): give rig bead-store init the long lifecycle timeout (config reload wedge)

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -2117,12 +2117,16 @@ func acquireProviderSemaphoreForOp(cityPath, op string) (func(), error) {
 }
 
 // providerOpTimeout returns the context timeout for a given lifecycle
-// operation. The "start" and "recover" operations get a longer timeout
-// because dolt server startup can take 30+ seconds for large data dirs.
-// All other operations use 30s.
+// operation. The "start", "recover", and "init" operations get a longer
+// timeout: dolt server startup can take 30+ seconds for large data dirs, and
+// initializing a rig's bead store can likewise exceed 30s when it creates or
+// migrates a database on a busy shared dolt server. Under the old 30s budget,
+// init of an existing-but-unmigrated rig DB during a config reload was
+// SIGKILLed, leaving the supervisor "keeping old config" so newly configured
+// rigs never came online. All other operations use 30s.
 var providerOpTimeout = func(op string) time.Duration {
 	switch op {
-	case "start", "recover":
+	case "start", "recover", "init":
 		return 120 * time.Second
 	default:
 		return 30 * time.Second

--- a/cmd/gc/beads_provider_op_timeout_test.go
+++ b/cmd/gc/beads_provider_op_timeout_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestProviderOpTimeoutInitGetsLongWindow guards the config-reload wedge fix:
+// "init" must get the long (start/recover-class) timeout, not 30s, so a rig
+// bead-store init that creates or migrates a database on a busy shared dolt
+// server is not SIGKILLed mid-reload — which previously left the supervisor
+// "keeping old config" so newly configured rigs never came online.
+func TestProviderOpTimeoutInitGetsLongWindow(t *testing.T) {
+	const long = 120 * time.Second
+	const short = 30 * time.Second
+	for _, op := range []string{"start", "recover", "init"} {
+		if got := providerOpTimeout(op); got != long {
+			t.Errorf("providerOpTimeout(%q) = %v, want %v", op, got, long)
+		}
+	}
+	for _, op := range []string{"health", "stop", "probe", ""} {
+		if got := providerOpTimeout(op); got != short {
+			t.Errorf("providerOpTimeout(%q) = %v, want %v", op, got, short)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`providerOpTimeout` returned 30s for the `init` operation, but initializing a
rig's bead store can exceed that when it creates or migrates a database on a
busy shared Dolt server. During a config reload that adds a rig whose DB is
present but unmigrated, `beads init` was SIGKILLed at the 30s
`exec.CommandContext` deadline — `exec beads init: signal: killed (keeping old
config)` — so the reload silently kept the old config and newly configured rigs
never came online. The reload order then retried every cycle and was killed
every time.

## Fix

Move `init` into the same 120s class as `start`/`recover`, which already get the
long window because Dolt startup/migration is slow. Adds
`TestProviderOpTimeoutInitGetsLongWindow`.

## Test plan

- `go build ./cmd/gc`, `go vet ./cmd/gc`, `gofmt` clean
- `go test ./cmd/gc -run TestProviderOpTimeoutInitGetsLongWindow` passes

## Note

This supersedes #3517, whose head branch was accidentally cut from our fork's
integration line and carried unrelated fork-only commits. This PR is the
narrow, two-file change (`beads_provider_lifecycle.go` + a focused test).