### PR TITLE
fix(reconciler): reclaim terminal-error and stale pool sessions before scaling (ga-6soapf5)

### DIFF
--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -126,6 +126,9 @@ func computePoolDesiredStates(
 		if sb.Status == "closed" {
 			continue
 		}
+		if sessionHasProviderTerminalError(sb) {
+			continue
+		}
 		template := strings.TrimSpace(normalizedSessionTemplate(sb, cfg))
 		if template != "" {
 			sessionBeadTemplate[sb.ID] = template
@@ -266,6 +269,7 @@ func computePoolDesiredStates(
 				continue
 			}
 			newCount := capNewDemandCount(limits, usage, agent, scaleCount)
+			recordNewDemandCapTrace(trace, template, agent, limits, usage, scaleCount, newCount)
 			inFlight := inFlightNewRequests[template]
 			inFlightCount := minInt(len(inFlight), newCount)
 			if scaleCount > 0 && len(inFlight) > 0 && trace != nil {
@@ -375,6 +379,9 @@ func poolInFlightNewRequests(cfg *config.City, sessionBeads []beads.Bead, resume
 		template := agent.QualifiedName()
 		for _, sb := range sortedSessionBeads {
 			if sb.ID == "" || sb.Status == "closed" {
+				continue
+			}
+			if sessionHasProviderTerminalError(sb) {
 				continue
 			}
 			if _, ok := resumeSessionBeadIDs[sb.ID]; ok {
@@ -515,6 +522,7 @@ type nestedCapUsage struct {
 	rigCount        map[string]int
 	workspaceCount  int
 	seenSessionBead map[string]bool
+	requests        []SessionRequest
 }
 
 func newNestedCapLimits(cfg *config.City) nestedCapLimits {
@@ -658,6 +666,86 @@ func (u *nestedCapUsage) accept(req SessionRequest, limits nestedCapLimits) {
 	if req.SessionBeadID != "" {
 		u.seenSessionBead[req.SessionBeadID] = true
 	}
+	u.requests = append(u.requests, req)
+}
+
+func recordNewDemandCapTrace(
+	trace *sessionReconcilerTraceCycle,
+	template string,
+	agent *config.Agent,
+	limits nestedCapLimits,
+	usage nestedCapUsage,
+	scaleCount int,
+	newCount int,
+) {
+	if trace == nil || scaleCount <= 0 || newCount >= scaleCount {
+		return
+	}
+	site, reason, capMax, current, blockers := newDemandBlockingScope(template, agent, limits, usage, newCount)
+	if site == "" {
+		return
+	}
+	blockingSessions := make([]string, 0, len(blockers))
+	blockingWork := make([]string, 0, len(blockers))
+	for _, req := range blockers {
+		if req.SessionBeadID != "" {
+			blockingSessions = append(blockingSessions, req.SessionBeadID)
+		}
+		if req.WorkBeadID != "" {
+			blockingWork = append(blockingWork, req.WorkBeadID)
+		}
+	}
+	trace.recordDecision(site, template, "", reason, "rejected", traceRecordPayload{
+		"scale_check":          scaleCount,
+		"accepted_new":         newCount,
+		"blocked_new":          scaleCount - newCount,
+		"current":              current,
+		"max":                  capMax,
+		"blocking_sessions":    blockingSessions,
+		"blocking_work_beads":  blockingWork,
+		"active_capacity_kind": reason,
+	}, nil, "")
+}
+
+func newDemandBlockingScope(
+	template string,
+	agent *config.Agent,
+	limits nestedCapLimits,
+	usage nestedCapUsage,
+	newCount int,
+) (string, string, int, int, []SessionRequest) {
+	if agentMax := limits.agentMax[template]; agentMax >= 0 && agentMax-usage.agentCount[template] <= newCount {
+		return string(TraceSitePoolNewDemandCap), string(TraceReasonAgentCap), agentMax, usage.agentCount[template], filterCapBlockers(usage.requests, func(req SessionRequest) bool {
+			return req.Template == template
+		})
+	}
+	if agent != nil {
+		if rig := limits.agentRig[template]; rig != "" {
+			rigMax, ok := limits.rigMax[rig]
+			if !ok {
+				rigMax = -1
+			}
+			if rigMax >= 0 && rigMax-usage.rigCount[rig] <= newCount {
+				return string(TraceSitePoolNewDemandCap), string(TraceReasonRigCap), rigMax, usage.rigCount[rig], filterCapBlockers(usage.requests, func(req SessionRequest) bool {
+					return limits.agentRig[req.Template] == rig
+				})
+			}
+		}
+	}
+	if limits.workspaceMax >= 0 && limits.workspaceMax-usage.workspaceCount <= newCount {
+		return string(TraceSitePoolNewDemandCap), string(TraceReasonWorkspaceCap), limits.workspaceMax, usage.workspaceCount, usage.requests
+	}
+	return "", "", 0, 0, nil
+}
+
+func filterCapBlockers(requests []SessionRequest, keep func(SessionRequest) bool) []SessionRequest {
+	out := make([]SessionRequest, 0, len(requests))
+	for _, req := range requests {
+		if keep(req) {
+			out = append(out, req)
+		}
+	}
+	return out
 }
 
 func minInt(a, b int) int {

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -73,6 +73,15 @@ func poolTraceFieldInt(t *testing.T, fields map[string]any, key string) int {
 	return got
 }
 
+func poolTraceFieldStrings(t *testing.T, fields map[string]any, key string) []string {
+	t.Helper()
+	got, ok := fields[key].([]string)
+	if !ok {
+		t.Fatalf("trace field %s = %#v, want []string", key, fields[key])
+	}
+	return got
+}
+
 func newPoolDesiredStateTestTrace(templates ...string) *sessionReconcilerTraceCycle {
 	detail := make(map[string]TraceSource, len(templates))
 	for _, template := range templates {
@@ -333,6 +342,74 @@ func TestComputePoolDesiredStates_MaxCapsTotal(t *testing.T) {
 	// Max=2: only 2 of the 3 requested sessions allowed.
 	if len(result[0].Requests) != 2 {
 		t.Errorf("len(requests) = %d, want 2 (capped by max)", len(result[0].Requests))
+	}
+}
+
+func TestComputePoolDesiredStates_TerminalProviderErrorSessionsDoNotBlockNewDemand(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(1), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w-stale", "claude", "sess-stale", "in_progress", 5),
+	}
+	stale := sessionBead("sess-stale", "open")
+	stale.Type = sessionBeadType
+	stale.Metadata = map[string]string{
+		"template":                              "claude",
+		"session_name":                          "claude-sess-stale",
+		sessionHealthStateMetadataKey:           "unhealthy",
+		sessionHealthReasonMetadataKey:          "model_not_found",
+		sessionDrainableMetadataKey:             boolMetadata(true),
+		sessionProviderTerminalErrorMetadataKey: "model_not_found",
+	}
+
+	result := ComputePoolDesiredStates(cfg, work, []beads.Bead{stale}, map[string]int{"claude": 1})
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 1 {
+		t.Fatalf("len(requests) = %d, want 1 new request; got %#v", len(reqs), reqs)
+	}
+	if reqs[0].Tier != "new" || reqs[0].SessionBeadID != "" {
+		t.Fatalf("request = %+v, want anonymous new demand replacing unhealthy stale owner", reqs[0])
+	}
+}
+
+func TestComputePoolDesiredStates_TraceListsActiveCapacityBlockers(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(1), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w-active", "claude", "sess-active", "in_progress", 5),
+	}
+	sessions := []beads.Bead{sessionBead("sess-active", "open")}
+	trace := newPoolDesiredStateTestTrace("claude")
+
+	result := computePoolDesiredStates(cfg, work, sessions, map[string]int{"claude": 1}, nil, trace)
+
+	if len(result) != 1 || len(result[0].Requests) != 1 || result[0].Requests[0].Tier != "resume" {
+		t.Fatalf("result = %#v, want only the active resume request under max_active_sessions=1", result)
+	}
+	if got := trace.decisionCounts[string(TraceSitePoolNewDemandCap)]; got != 1 {
+		t.Fatalf("new-demand cap trace decisions = %d, want 1; records=%#v", got, trace.records)
+	}
+	rec := poolTraceDecision(t, trace, TraceSitePoolNewDemandCap)
+	for key, want := range map[string]int{
+		"scale_check":  1,
+		"accepted_new": 0,
+		"blocked_new":  1,
+	} {
+		if got := poolTraceFieldInt(t, rec.Fields, key); got != want {
+			t.Fatalf("%s = %d, want %d", key, got, want)
+		}
+	}
+	if got := poolTraceFieldStrings(t, rec.Fields, "blocking_sessions"); len(got) != 1 || got[0] != "sess-active" {
+		t.Fatalf("blocking_sessions = %#v, want [sess-active]", got)
+	}
+	if got := poolTraceFieldStrings(t, rec.Fields, "blocking_work_beads"); len(got) != 1 || got[0] != "w-active" {
+		t.Fatalf("blocking_work_beads = %#v, want [w-active]", got)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1953,6 +1953,22 @@ func commitStartFailure(result startResult, store beads.Store, clk clock.Clock, 
 	name := result.prepared.candidate.name()
 	tp := result.prepared.candidate.tp
 	fmt.Fprintf(stderr, "session reconciler: starting %s: %s\n", name, formatLifecycleError(result.err)) //nolint:errcheck
+	if reason := runtime.ProviderTerminalErrorReason(result.err.Error()); reason != "" {
+		if err := markProviderTerminalError(session, store, clk, reason); err != nil {
+			fmt.Fprintf(stderr, "session reconciler: marking terminal provider error for %s: %v\n", name, err) //nolint:errcheck
+		}
+		if trace != nil {
+			trace.recordOperation("reconciler.start.terminal_provider_error", tp.TemplateName, name, "", "start", result.outcome, traceRecordPayload{
+				"error":  formatLifecycleError(result.err),
+				"reason": reason,
+			}, "")
+		}
+		if result.rollbackPending {
+			rollbackPendingCreate(session, store, clk.Now().UTC(), stderr)
+		}
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
+		return
+	}
 	if result.rateLimitScreen {
 		if err := recordRateLimitQuarantine(session, store, clk); err != nil {
 			fmt.Fprintf(stderr, "session reconciler: recording startup rate-limit hold for %s: %v\n", name, err) //nolint:errcheck

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -4895,6 +4895,45 @@ func TestCommitStartResult_SanitizesMultilineError(t *testing.T) {
 	}
 }
 
+func TestCommitStartResult_TerminalProviderErrorMarksUnhealthy(t *testing.T) {
+	store := newTestStore()
+	session := makeBead("b1", map[string]string{
+		"template":     "worker",
+		"session_name": "worker",
+		"state":        "active",
+		"last_woke_at": "2026-05-27T12:00:00Z",
+	})
+	session.Type = sessionBeadType
+	session.Labels = []string{sessionBeadLabel}
+	session.Title = "worker"
+	candidate := startCandidate{
+		session: &session,
+		tp:      TemplateParams{TemplateName: "worker", InstanceName: "worker"},
+	}
+	result := startResult{
+		prepared: preparedStart{candidate: candidate},
+		err:      fmt.Errorf("model_not_found: gpt-5.3-codex-spark"),
+		outcome:  "provider_error",
+	}
+
+	if commitStartResult(result, store, &clock.Fake{Time: time.Unix(3, 0)}, events.NewFake(), 0, ioDiscard{}, ioDiscard{}) {
+		t.Fatal("commitStartResult returned true for terminal provider error")
+	}
+	got := store.metadata[session.ID]
+	if got[sessionHealthStateMetadataKey] != "unhealthy" {
+		t.Fatalf("session health = %q, want unhealthy", got[sessionHealthStateMetadataKey])
+	}
+	if got[sessionHealthReasonMetadataKey] != "model_not_found" {
+		t.Fatalf("health reason = %q, want model_not_found", got[sessionHealthReasonMetadataKey])
+	}
+	if got[sessionDrainableMetadataKey] != boolMetadata(true) {
+		t.Fatalf("drainable = %q, want true", got[sessionDrainableMetadataKey])
+	}
+	if got["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared", got["last_woke_at"])
+	}
+}
+
 func TestInterruptTargetsBounded_LogsSuccessOutcome(t *testing.T) {
 	sp := runtime.NewFake()
 	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -41,6 +41,11 @@ type wakeEvaluation struct {
 
 const sleepReasonRuntimeMissing = "runtime-missing"
 
+// sleepReasonProviderTerminalError parks a session that hit a terminal
+// (non-retryable) provider error. markProviderTerminalError writes it; the
+// pool-slot freeable allowlist reads it to reap the dead bead + its worktree.
+const sleepReasonProviderTerminalError = "provider-terminal-error"
+
 const (
 	sessionHealthStateMetadataKey           = "session_health"
 	sessionHealthReasonMetadataKey          = "session_health_reason"
@@ -618,11 +623,23 @@ func checkStability(session *beads.Bead, cfg *config.City, alive bool, dt *drain
 	return true
 }
 
-// checkRateLimitStability runs the rate-limit lane of the exit-classification
-// decider: a dead crash candidate whose provider screen shows a rate-limit
-// message is quarantined without counting a crash. Returns handled=true when
-// the quarantine was recorded, or the write error when recording failed; the
-// caller skips further processing for the session in either case.
+// checkRateLimitStability runs the provider-screen lane of the
+// exit-classification decider for a dead crash candidate. It peeks the
+// session's provider screen and records, without counting an ordinary crash:
+//
+//   - a terminal (non-retryable) provider error → mark the session
+//     unhealthy + drainable so pool sizing excludes its slot. Terminal errors
+//     take precedence over the rate-limit screen: they are non-retryable.
+//   - otherwise a rate-limit screen → quarantine with a back-off and a
+//     distinct sleep_reason, so the session is retried rather than crashed.
+//
+// Returns handled=true when either was recorded, or the write error when
+// recording failed; the caller skips further processing for the session in
+// either case.
+//
+// This is the non-zombie counterpart to the reconciler's `running && !alive`
+// zombie screen capture: a session that died without satisfying that screen
+// but still exposes a terminal provider error via peek is classified here.
 func checkRateLimitStability(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, store beads.Store, clk clock.Clock, peek func(lines int) (string, error)) (bool, error) {
 	if session == nil {
 		return false, nil
@@ -632,8 +649,16 @@ func checkRateLimitStability(session *beads.Bead, cfg *config.City, alive bool, 
 	dec := sessionpkg.DecideSessionExit(facts)
 	for dec == sessionpkg.ExitGatherScreen {
 		facts.Screen = sessionpkg.ScreenOther
-		if content, err := peek(rateLimitPeekLines); err == nil && runtime.ContainsProviderRateLimitScreen(content) {
-			facts.Screen = sessionpkg.ScreenRateLimit
+		if content, err := peek(rateLimitPeekLines); err == nil {
+			if reason := runtime.ProviderTerminalErrorReason(content); reason != "" {
+				if markErr := markProviderTerminalError(session, store, clk, reason); markErr != nil {
+					return false, markErr
+				}
+				return true, nil
+			}
+			if runtime.ContainsProviderRateLimitScreen(content) {
+				facts.Screen = sessionpkg.ScreenRateLimit
+			}
 		}
 		dec = sessionpkg.DecideSessionExit(facts)
 	}
@@ -710,7 +735,7 @@ func markProviderTerminalError(session *beads.Bead, store beads.Store, clk clock
 	}
 	batch := map[string]string{
 		"state":                                 string(sessionpkg.StateAsleep),
-		"sleep_reason":                          "provider-terminal-error",
+		"sleep_reason":                          sleepReasonProviderTerminalError,
 		"last_woke_at":                          "",
 		"pending_create_claim":                  "",
 		"pending_create_started_at":             "",

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -41,6 +41,14 @@ type wakeEvaluation struct {
 
 const sleepReasonRuntimeMissing = "runtime-missing"
 
+const (
+	sessionHealthStateMetadataKey           = "session_health"
+	sessionHealthReasonMetadataKey          = "session_health_reason"
+	sessionDrainableMetadataKey             = "session_drainable"
+	sessionProviderTerminalErrorMetadataKey = "provider_terminal_error"
+	sessionProviderTerminalErrorAtKey       = "provider_terminal_error_at"
+)
+
 // Deprecated: evaluateWakeReasons and wakeReasons are legacy functions
 // superseded by ComputeAwakeSet (compute_awake_set.go). The production
 // reconciler at session_reconciler.go:438 uses ComputeAwakeSet →
@@ -683,6 +691,51 @@ func recordRateLimitQuarantine(session *beads.Bead, store beads.Store, clk clock
 		session.Metadata[k] = v
 	}
 	return nil
+}
+
+func markProviderTerminalError(session *beads.Bead, store beads.Store, clk clock.Clock, reason string) error {
+	if session == nil || store == nil {
+		return nil
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return nil
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string)
+	}
+	now := time.Now().UTC()
+	if clk != nil {
+		now = clk.Now().UTC()
+	}
+	batch := map[string]string{
+		"state":                                 string(sessionpkg.StateAsleep),
+		"sleep_reason":                          "provider-terminal-error",
+		"last_woke_at":                          "",
+		"pending_create_claim":                  "",
+		"pending_create_started_at":             "",
+		sessionHealthStateMetadataKey:           "unhealthy",
+		sessionHealthReasonMetadataKey:          reason,
+		sessionDrainableMetadataKey:             boolMetadata(true),
+		sessionProviderTerminalErrorMetadataKey: reason,
+		sessionProviderTerminalErrorAtKey:       now.Format(time.RFC3339),
+	}
+	if err := store.SetMetadataBatch(session.ID, batch); err != nil {
+		return err
+	}
+	for k, v := range batch {
+		session.Metadata[k] = v
+	}
+	return nil
+}
+
+func sessionHasProviderTerminalError(session beads.Bead) bool {
+	if strings.TrimSpace(session.Metadata[sessionProviderTerminalErrorMetadataKey]) != "" {
+		return true
+	}
+	return strings.TrimSpace(session.Metadata[sessionHealthStateMetadataKey]) == "unhealthy" &&
+		strings.TrimSpace(session.Metadata[sessionDrainableMetadataKey]) == boolMetadata(true) &&
+		strings.TrimSpace(session.Metadata[sessionHealthReasonMetadataKey]) != ""
 }
 
 // recordWakeFailure increments wake_attempts and quarantines if threshold exceeded.

--- a/cmd/gc/session_reconcile_ratelimit_test.go
+++ b/cmd/gc/session_reconcile_ratelimit_test.go
@@ -348,3 +348,52 @@ func TestCheckStability_RateLimitScreen_PeekErrorFallsBackToCrash(t *testing.T) 
 		t.Errorf("wake_attempts = %q, want 1", got)
 	}
 }
+
+// TestCheckStability_TerminalErrorScreen_MarksTerminalNotCrash pins fix-finding
+// #2: a non-zombie dead session (running==false, so the reconciler's
+// `running && !alive` zombie capture never fires) whose provider screen shows a
+// terminal, non-retryable error must be classified terminal here — marked
+// unhealthy + drainable so pool sizing excludes its slot — instead of being
+// counted as an ordinary crash and retried forever.
+func TestCheckStability_TerminalErrorScreen_MarksTerminalNotCrash(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+
+	session := makeBead("b1", map[string]string{
+		"last_woke_at":  now.Add(-10 * time.Second).Format(time.RFC3339),
+		"wake_attempts": "3", // a real crash would push us to 4
+	})
+
+	peek := func(_ int) (string, error) {
+		return "model_not_found: gpt-5.3-codex-spark", nil
+	}
+
+	if !checkStability(&session, nil, false, dt, store, clk, peek) {
+		t.Fatal("checkStability should return true when it records a terminal provider error")
+	}
+	if got := session.Metadata["wake_attempts"]; got != "3" {
+		t.Errorf("wake_attempts = %q, want 3; a terminal provider error must not count as a crash", got)
+	}
+	if got := session.Metadata["state"]; got != "asleep" {
+		t.Errorf("state = %q, want asleep", got)
+	}
+	if got := session.Metadata["sleep_reason"]; got != sleepReasonProviderTerminalError {
+		t.Errorf("sleep_reason = %q, want %q", got, sleepReasonProviderTerminalError)
+	}
+	if got := session.Metadata[sessionProviderTerminalErrorMetadataKey]; got != "model_not_found" {
+		t.Errorf("%s = %q, want model_not_found", sessionProviderTerminalErrorMetadataKey, got)
+	}
+	if got := session.Metadata[sessionHealthStateMetadataKey]; got != "unhealthy" {
+		t.Errorf("%s = %q, want unhealthy", sessionHealthStateMetadataKey, got)
+	}
+	if got := session.Metadata[sessionDrainableMetadataKey]; got != boolMetadata(true) {
+		t.Errorf("%s = %q, want %q", sessionDrainableMetadataKey, got, boolMetadata(true))
+	}
+	// Edge-triggered: last_woke_at cleared so the terminal classification isn't
+	// re-evaluated (and can't accrue a wake failure) on the next tick.
+	if got := session.Metadata["last_woke_at"]; got != "" {
+		t.Errorf("last_woke_at = %q, want cleared after terminal classification", got)
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1505,6 +1505,16 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// Zombie capture: session exists but process dead — grab scrollback for forensics.
 		if running && !alive {
 			if output, err := peek(rateLimitPeekLines); err == nil && output != "" {
+				if reason := runtime.ProviderTerminalErrorReason(output); reason != "" {
+					if markErr := markProviderTerminalError(session, store, clk, reason); markErr != nil {
+						fmt.Fprintf(stderr, "session reconciler: marking terminal provider error for %s: %v\n", name, markErr) //nolint:errcheck
+					}
+					if trace != nil {
+						trace.recordDecision("reconciler.session.terminal_provider_error", tp.TemplateName, name, reason, "unhealthy", traceRecordPayload{
+							"session_bead_id": session.ID,
+						}, nil, "")
+					}
+				}
 				if !runtime.ContainsProviderRateLimitScreen(output) {
 					rec.Record(events.Event{
 						Type:    events.SessionCrashed,

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -8784,7 +8784,7 @@ func TestReconcileSessionBeads_ZombieDetectedCrashRecordedAndSessionNotAlive(t *
 
 	// Simulate zombie: tmux session exists but process is dead.
 	env.sp.Zombies["worker"] = true
-	env.sp.SetPeekOutput("worker", "Error: quota exceeded")
+	env.sp.SetPeekOutput("worker", "panic: worker process exited unexpectedly")
 
 	env.reconcile([]beads.Bead{session})
 
@@ -8816,6 +8816,44 @@ func TestReconcileSessionBeads_ZombieDetectedCrashRecordedAndSessionNotAlive(t *
 	}
 	if got.Metadata["wake_attempts"] == "" || got.Metadata["wake_attempts"] == "0" {
 		t.Error("expected wake_attempts > 0 (rapid exit recorded for zombie)")
+	}
+}
+
+func TestReconcileSessionBeads_ZombieTerminalProviderErrorMarkedUnhealthy(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	tp := TemplateParams{
+		Command:      "test-cmd",
+		SessionName:  "worker",
+		TemplateName: "worker",
+		Hints:        agent.StartupHints{ProcessNames: []string{"test-cmd"}},
+	}
+	env.desiredState["worker"] = tp
+	_ = env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"})
+
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.sp.Zombies["worker"] = true
+	env.sp.SetPeekOutput("worker", "model_not_found: gpt-5.3-codex-spark")
+
+	env.reconcile([]beads.Bead{session})
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Metadata[sessionHealthStateMetadataKey] != "unhealthy" {
+		t.Fatalf("session health = %q, want unhealthy", got.Metadata[sessionHealthStateMetadataKey])
+	}
+	if got.Metadata[sessionHealthReasonMetadataKey] != "model_not_found" {
+		t.Fatalf("health reason = %q, want model_not_found", got.Metadata[sessionHealthReasonMetadataKey])
+	}
+	if got.Metadata[sessionDrainableMetadataKey] != boolMetadata(true) {
+		t.Fatalf("drainable = %q, want true", got.Metadata[sessionDrainableMetadataKey])
+	}
+	if got.Metadata[sessionProviderTerminalErrorMetadataKey] != "model_not_found" {
+		t.Fatalf("provider terminal error = %q, want model_not_found", got.Metadata[sessionProviderTerminalErrorMetadataKey])
 	}
 }
 

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -85,6 +85,7 @@ const (
 	TraceSitePoolMinFill                    TraceSiteCode = "reconciler.pool.min_fill"
 	TraceSitePoolInFlightReuse              TraceSiteCode = "reconciler.pool.inflight_reuse"
 	TraceSitePoolWakeKnownIdentity          TraceSiteCode = "reconciler.pool.wake_known_identity"
+	TraceSitePoolNewDemandCap               TraceSiteCode = "reconciler.pool.new_demand_cap"
 	TraceSiteReconcilerUnknownState         TraceSiteCode = "reconciler.session.skip_unknown_state"
 	TraceSiteReconcilerOrphaned             TraceSiteCode = "reconciler.session.orphan_or_suspended"
 	TraceSiteReconcilerCloseOrphan          TraceSiteCode = "reconciler.session.close_orphan"
@@ -580,6 +581,7 @@ func normalizeTraceSiteCode(raw string) (TraceSiteCode, string) {
 		TraceSitePoolMinFill,
 		TraceSitePoolInFlightReuse,
 		TraceSitePoolWakeKnownIdentity,
+		TraceSitePoolNewDemandCap,
 		TraceSiteReconcilerUnknownState,
 		TraceSiteReconcilerOrphaned,
 		TraceSiteReconcilerCloseOrphan,

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -30,6 +30,11 @@ func isDrainedSessionBead(session beads.Bead) bool {
 // pool beads lets the supervisor spawn a fresh worker for ready queue work
 // instead of stranding it on a ghost slot.
 //
+// A session parked with sleep_reason=provider-terminal-error is also freeable:
+// markProviderTerminalError has classified it as a dead, non-retryable provider
+// failure, so its slot must be reaped — otherwise the dead bead and its worktree
+// leak indefinitely while still excluded from pool capacity.
+//
 // An explicit sleep_reason is required: deny-by-default for unknown or
 // missing reasons so writes that land in state=asleep without a known
 // reason (legacy beads, regressions, write races) cannot silently free
@@ -43,7 +48,8 @@ func isPoolSessionSlotFreeable(session beads.Bead) bool {
 	}
 	reason := strings.TrimSpace(session.Metadata["sleep_reason"])
 	switch reason {
-	case "idle", "idle-timeout", sleepReasonCityStop, "failed-create", sleepReasonRuntimeMissing:
+	case "idle", "idle-timeout", sleepReasonCityStop, "failed-create", sleepReasonRuntimeMissing,
+		sleepReasonProviderTerminalError:
 		return true
 	}
 	return false

--- a/cmd/gc/session_state_helpers_test.go
+++ b/cmd/gc/session_state_helpers_test.go
@@ -23,6 +23,7 @@ func TestIsPoolSessionSlotFreeable_Matrix(t *testing.T) {
 		{"asleep+city-stop", map[string]string{"state": "asleep", "sleep_reason": sleepReasonCityStop}, true},
 		{"asleep+failed-create", map[string]string{"state": "asleep", "sleep_reason": "failed-create"}, true},
 		{"asleep+runtime-missing", map[string]string{"state": "asleep", "sleep_reason": sleepReasonRuntimeMissing}, true},
+		{"asleep+provider-terminal-error", map[string]string{"state": "asleep", "sleep_reason": sleepReasonProviderTerminalError}, true},
 		{"asleep+empty-reason", map[string]string{"state": "asleep", "sleep_reason": ""}, false},
 		{"asleep+missing-reason", map[string]string{"state": "asleep"}, false},
 		{"asleep+wait-hold", map[string]string{"state": "asleep", "sleep_reason": "wait-hold"}, false},

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -1021,6 +1021,26 @@ func ContainsProviderRateLimitScreen(content string) bool {
 		strings.Contains(content, "Stop")
 }
 
+// ProviderTerminalErrorReason classifies high-confidence provider errors that
+// require operator/config intervention rather than immediate retry.
+func ProviderTerminalErrorReason(content string) string {
+	lower := strings.ToLower(content)
+	switch {
+	case strings.Contains(lower, "model_not_found"):
+		return "model_not_found"
+	case strings.Contains(lower, "model") && strings.Contains(lower, "not found"):
+		return "model_not_found"
+	case strings.Contains(lower, "insufficient_quota"):
+		return "quota_exceeded"
+	case strings.Contains(lower, "quota_exceeded"):
+		return "quota_exceeded"
+	case strings.Contains(lower, "quota exceeded") && !strings.Contains(lower, "disk quota"):
+		return "quota_exceeded"
+	default:
+		return ""
+	}
+}
+
 // containsPromptIndicator checks whether any line in the content looks like a
 // common shell or agent prompt, indicating the session is ready and no dialog is
 // present. Full-screen agent UIs often render placeholder input after the prompt

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -1028,7 +1028,11 @@ func ProviderTerminalErrorReason(content string) string {
 	switch {
 	case strings.Contains(lower, "model_not_found"):
 		return "model_not_found"
-	case strings.Contains(lower, "model") && strings.Contains(lower, "not found"):
+	case lineContainsAll(lower, "model", "not found"):
+		// Require both tokens on the same line so the loose phrasing matches a
+		// real "model … not found" provider error, not "model" and "not found"
+		// landing on unrelated scrollback lines (which would permanently and
+		// wrongly mark the session terminal with no self-heal).
 		return "model_not_found"
 	case strings.Contains(lower, "insufficient_quota"):
 		return "quota_exceeded"
@@ -1039,6 +1043,25 @@ func ProviderTerminalErrorReason(content string) string {
 	default:
 		return ""
 	}
+}
+
+// lineContainsAll reports whether any single line of content contains every
+// substring in subs. It bounds loose multi-token matches to one line so the
+// tokens must co-occur in the same message rather than anywhere in scrollback.
+func lineContainsAll(content string, subs ...string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		all := true
+		for _, sub := range subs {
+			if !strings.Contains(line, sub) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
 }
 
 // containsPromptIndicator checks whether any line in the content looks like a

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -1041,6 +1041,29 @@ func TestContainsProviderRateLimitScreen(t *testing.T) {
 	}
 }
 
+func TestProviderTerminalErrorReason(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "codex model not found code", content: "model_not_found: gpt-5.3-codex-spark", want: "model_not_found"},
+		{name: "model not found text", content: "Error: model gpt-x was not found", want: "model_not_found"},
+		{name: "quota exceeded", content: "Error: quota exceeded", want: "quota_exceeded"},
+		{name: "insufficient quota", content: "insufficient_quota: billing required", want: "quota_exceeded"},
+		{name: "disk quota is not provider quota", content: "disk quota exceeded while writing log", want: ""},
+		{name: "generic rate limit remains transient", content: "Rate limit reached\n1. Keep trying\n2. Stop", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProviderTerminalErrorReason(tt.content); got != tt.want {
+				t.Errorf("ProviderTerminalErrorReason(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestContainsCustomAPIKeyDialog(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -1050,6 +1050,7 @@ func TestProviderTerminalErrorReason(t *testing.T) {
 	}{
 		{name: "codex model not found code", content: "model_not_found: gpt-5.3-codex-spark", want: "model_not_found"},
 		{name: "model not found text", content: "Error: model gpt-x was not found", want: "model_not_found"},
+		{name: "model and not-found on different lines is not terminal", content: "loading model weights\n... file path not found", want: ""},
 		{name: "quota exceeded", content: "Error: quota exceeded", want: "quota_exceeded"},
 		{name: "insufficient quota", content: "insufficient_quota: billing required", want: "quota_exceeded"},
 		{name: "disk quota is not provider quota", content: "disk quota exceeded while writing log", want: ""},

--- a/internal/session/lifecycle_exits.go
+++ b/internal/session/lifecycle_exits.go
@@ -132,6 +132,11 @@ func DecideSessionExit(f ExitFacts) ExitOutcome {
 // IsDeliberateSleepReason reports whether a sleep_reason records an
 // intentional stop rather than a crash, so the death must not accrue churn.
 // "city-stop" mirrors the CLI's stop sleep reason.
+// "provider-terminal-error" is a classified, non-retryable provider failure
+// (set by markProviderTerminalError); it is suppressed here so a session
+// already parked terminal cannot also accrue a spurious wake failure, making
+// the invariant explicit rather than relying on last_woke_at being cleared in
+// the same metadata batch.
 // The reason list deliberately diverges from shouldResetContinuation's
 // near-identical list (this one has "failed-create" and lacks
 // "runtime-missing"): that one decides continuation reset on wake, this one
@@ -139,7 +144,8 @@ func DecideSessionExit(f ExitFacts) ExitOutcome {
 func IsDeliberateSleepReason(reason string) bool {
 	switch strings.TrimSpace(reason) {
 	case "idle", "idle-timeout", "no-wake-reason", "config-drift", "drained",
-		"city-stop", "user-hold", "wait-hold", "rate_limit", "failed-create":
+		"city-stop", "user-hold", "wait-hold", "rate_limit", "failed-create",
+		"provider-terminal-error":
 		return true
 	default:
 		return false

--- a/internal/session/lifecycle_exits_test.go
+++ b/internal/session/lifecycle_exits_test.go
@@ -201,6 +201,7 @@ func TestIsDeliberateSleepReason(t *testing.T) {
 	deliberate := []string{
 		"idle", "idle-timeout", "no-wake-reason", "config-drift", "drained",
 		"city-stop", "user-hold", "wait-hold", "rate_limit", "failed-create",
+		"provider-terminal-error",
 		" idle ",
 	}
 	for _, reason := range deliberate {


### PR DESCRIPTION
## Problem

The pool scaler counted sessions stuck in a terminal provider-error state against capacity, so terminal-error/zombie polecat sessions blocked new demand from spawning fresh sessions.

## Fix

- Detect terminal provider errors (`internal/runtime/dialog.go`) and surface a reason.
- Mark zombie/terminal-error sessions unhealthy during reconcile so they no longer occupy a capacity slot (`cmd/gc/session_reconcile.go`, `session_reconciler.go`, `session_lifecycle_parallel.go`).
- Pool desired-state computation excludes terminal-error sessions from active capacity and traces the active capacity blockers (`cmd/gc/pool_desired_state.go`, new `TraceSitePoolNewDemandCap`).

## Verification

- gofmt + `go vet ./cmd/gc/ ./internal/runtime/` — clean
- `go test ./internal/runtime/ -run TestProviderTerminalErrorReason` — pass
- `go test ./cmd/gc/ -run 'TestCommitStartResult_TerminalProviderErrorMarksUnhealthy|TestComputePoolDesiredStates_TerminalProviderErrorSessionsDoNotBlockNewDemand|TestComputePoolDesiredStates_TraceListsActiveCapacityBlockers|TestReconcileSessionBeads_ZombieTerminalProviderErrorMarkedUnhealthy'` — pass

Rebased onto current `main` from the stranded `polecat/ga-6soapf5` branch (complete but unmerged due to a routing bug). One trivial conflict resolved in `session_reconciler_trace_types.go` (both main and this branch added a new trace-site constant; kept both). Beads: `ga-6soapf5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)