### PR TITLE
feat(doctor): add dolt-journal-size doctor check + golden file fix

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -307,6 +307,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 	// managed bd scope. The version check follows the same gate so file-backed
 	// and external Dolt workspaces do not get irrelevant local-binary warnings.
 	register(doctor.NewDoltNomsSizeCheckForConfig(cityPath, opts.SkipManagedDoltCheck, cfg, cfgErr))
+	register(doctor.NewDoltJournalSizeCheckForConfig(cityPath, opts.SkipManagedDoltCheck, cfg, cfgErr))
 	register(doctor.NewDoltConfigCheckForConfig(cityPath, opts.SkipManagedDoltCheck, cfg, cfgErr))
 	register(doctor.NewScopedDoltVersionCheckForConfig(cityPath, opts.SkipManagedDoltCheck, cfg, cfgErr))
 	register(&doctor.EventsLogCheck{})

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -61,6 +61,7 @@ session-model
 dolt-server
 fork-rate
 dolt-noms-size
+dolt-journal-size
 dolt-config
 dolt-version
 events-log

--- a/internal/doctor/checks_dolt_journal_size.go
+++ b/internal/doctor/checks_dolt_journal_size.go
@@ -1,0 +1,199 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+const (
+	doltJournalWarnBytesDefault  = int64(4) * 1024 * 1024 * 1024 // 4 GB
+	doltJournalErrorBytesDefault = int64(6) * 1024 * 1024 * 1024 // 6 GB
+)
+
+// DoltJournalSizeCheck warns when Dolt write-ahead journal files approach the
+// compaction threshold. Journal files grow unboundedly between compactions and
+// are the primary corruption vector documented in ga-pqfk8t.
+//
+// Registered once per city — the managed Dolt server is shared across all rigs.
+type DoltJournalSizeCheck struct {
+	cityPath        string
+	skip            bool
+	applicableKnown bool
+	applicable      bool
+	scopeRoots      []string
+}
+
+// NewDoltJournalSizeCheck creates a Dolt journal size check.
+func NewDoltJournalSizeCheck(cityPath string, skip bool) *DoltJournalSizeCheck {
+	return &DoltJournalSizeCheck{cityPath: cityPath, skip: skip}
+}
+
+// NewDoltJournalSizeCheckForConfig creates a Dolt journal size check using a
+// preloaded city config.
+func NewDoltJournalSizeCheckForConfig(cityPath string, skip bool, cfg *config.City, cfgErr error) *DoltJournalSizeCheck {
+	return &DoltJournalSizeCheck{
+		cityPath:        cityPath,
+		skip:            skip,
+		applicableKnown: true,
+		applicable:      ManagedLocalDoltChecksApplicableForConfig(cityPath, cfg, cfgErr),
+		scopeRoots:      managedDoltScopeRootsForConfig(cityPath, cfg, cfgErr),
+	}
+}
+
+func (c *DoltJournalSizeCheck) managedApplicable() bool {
+	if c.applicableKnown {
+		return c.applicable
+	}
+	return managedLocalDoltChecksApplicable(c.cityPath)
+}
+
+// Name returns the check identifier.
+func (c *DoltJournalSizeCheck) Name() string { return "dolt-journal-size" }
+
+// Run inspects *.journal files under each managed Dolt database's noms
+// directory and compares the largest single-database journal to
+// warning/error thresholds.
+func (c *DoltJournalSizeCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.skip || !c.managedApplicable() {
+		r.Status = StatusOK
+		r.Message = "skipped (file backend, external dolt endpoint, or GC_DOLT=skip)"
+		return r
+	}
+
+	warnBytes := doltJournalThreshold("GC_DOLT_JOURNAL_WARN_BYTES", doltJournalWarnBytesDefault)
+	errorBytes := doltJournalThreshold("GC_DOLT_JOURNAL_ERROR_BYTES", doltJournalErrorBytesDefault)
+
+	targets, unresolved := managedLocalDoltScanTargets(c.cityPath)
+	if c.applicableKnown {
+		targets, unresolved = managedLocalDoltScanTargetsForScopeRoots(c.cityPath, c.scopeRoots)
+	}
+	if len(targets) == 0 {
+		if unresolved {
+			r.Status = StatusOK
+			r.Message = "skipped (dolt target unresolved)"
+			return r
+		}
+		r.Status = StatusOK
+		r.Message = "skipped (file backend, external dolt endpoint, or GC_DOLT=skip)"
+		return r
+	}
+
+	dataDir := resolveManagedDoltDataDir(c.cityPath)
+
+	type dbResult struct {
+		db   string
+		size int64
+	}
+	var results []dbResult
+	for _, target := range targets {
+		journalDir := filepath.Join(target.ScanRoot, "noms")
+		size, err := sumJournalFiles(journalDir)
+		if err != nil {
+			r.Status = StatusWarning
+			r.Message = fmt.Sprintf("scan dolt journal dir: %v", err)
+			return r
+		}
+		results = append(results, dbResult{db: target.Database, size: size})
+	}
+
+	var worstDB string
+	var worstSize int64
+	for _, res := range results {
+		if res.size > worstSize {
+			worstSize = res.size
+			worstDB = res.db
+		}
+	}
+
+	dbLabel := strings.TrimSpace(worstDB)
+	if dbLabel == "" {
+		dbLabel = "managed dolt data"
+	}
+
+	details := []string{
+		fmt.Sprintf("scan path: %s", dataDir),
+	}
+	for _, res := range results {
+		name := strings.TrimSpace(res.db)
+		if name == "" {
+			name = "managed dolt data"
+		}
+		details = append(details, fmt.Sprintf("database %s: %s journal", name, formatGB(res.size)))
+	}
+	details = append(details,
+		fmt.Sprintf("warn threshold: GC_DOLT_JOURNAL_WARN_BYTES (default 4 GB, current %s)", formatGB(warnBytes)),
+		fmt.Sprintf("error threshold: GC_DOLT_JOURNAL_ERROR_BYTES (default 6 GB, current %s)", formatGB(errorBytes)),
+	)
+	r.Details = details
+
+	switch {
+	case worstSize >= errorBytes:
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("dolt journal for %s is %s — at corruption risk; compact immediately (see ga-pqfk8t for incident context)", dbLabel, formatGB(worstSize))
+		r.FixHint = "run: gc dolt compact"
+	case worstSize >= warnBytes:
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("dolt journal for %s is %s — approaching compaction threshold; run: gc dolt compact", dbLabel, formatGB(worstSize))
+		r.FixHint = "run: gc dolt compact"
+	default:
+		n := len(results)
+		if worstSize == 0 {
+			r.Status = StatusOK
+			r.Message = fmt.Sprintf("dolt-journal-size: no journal files found (%d database(s) scanned)", n)
+		} else {
+			r.Status = StatusOK
+			r.Message = fmt.Sprintf("dolt-journal-size: %s across %d database(s) (largest: %s)", formatGB(worstSize), n, dbLabel)
+		}
+	}
+	return r
+}
+
+// CanFix returns false — compaction must be triggered manually to avoid
+// racing the live server.
+func (c *DoltJournalSizeCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *DoltJournalSizeCheck) Fix(_ *CheckContext) error { return nil }
+
+// doltJournalThreshold reads an int64 byte threshold from env, falling back
+// to defaultVal on empty or invalid input.
+func doltJournalThreshold(envVar string, defaultVal int64) int64 {
+	v := strings.TrimSpace(os.Getenv(envVar))
+	if v == "" {
+		return defaultVal
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n <= 0 {
+		return defaultVal
+	}
+	return n
+}
+
+// sumJournalFiles returns the sum of sizes of all *.journal files in dir.
+// Returns 0, nil for non-existent or empty directories.
+func sumJournalFiles(dir string) (int64, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.journal"))
+	if err != nil {
+		return 0, fmt.Errorf("glob %s: %w", dir, err)
+	}
+	var total int64
+	for _, path := range matches {
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				continue
+			}
+			return 0, fmt.Errorf("stat %s: %w", path, statErr)
+		}
+		if info.Mode().IsRegular() {
+			total += info.Size()
+		}
+	}
+	return total, nil
+}

--- a/internal/doctor/checks_dolt_journal_size_test.go
+++ b/internal/doctor/checks_dolt_journal_size_test.go
@@ -1,0 +1,118 @@
+package doctor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoltJournalSizeCheck_Skipped(t *testing.T) {
+	c := NewDoltJournalSizeCheck(t.TempDir(), true)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "skipped") {
+		t.Errorf("message = %q, want skipped", r.Message)
+	}
+}
+
+func TestDoltJournalSizeCheck_NonManagedDolt(t *testing.T) {
+	dir := setupFreshManagedDoltCity(t)
+	c := NewDoltJournalSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "skipped") {
+		t.Errorf("message = %q, want skipped", r.Message)
+	}
+}
+
+func TestDoltJournalSizeCheck_NoJournalFiles(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	// Create the noms dir but only non-journal files — check must return OK.
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "manifest"), 1024)
+	c := NewDoltJournalSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltJournalSizeCheck_OKUnderThreshold(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "vvvv1.journal"), 1024*1024) // 1 MB
+	c := NewDoltJournalSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "dolt-journal-size") {
+		t.Errorf("message = %q, want dolt-journal-size prefix", r.Message)
+	}
+}
+
+func TestDoltJournalSizeCheck_WarnAtThreshold(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	// 5 GB — above warn (4 GB), below error (6 GB). Sparse file via Truncate.
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "vvvv1.journal"), 5*1024*1024*1024)
+	c := NewDoltJournalSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "approaching compaction threshold") {
+		t.Errorf("message = %q, want approaching-threshold text", r.Message)
+	}
+	if !strings.Contains(r.Message, "gc dolt compact") {
+		t.Errorf("message = %q, want gc dolt compact", r.Message)
+	}
+}
+
+func TestDoltJournalSizeCheck_ErrorAtThreshold(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	// 7 GB — above error (6 GB). Sparse file via Truncate.
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "vvvv1.journal"), 7*1024*1024*1024)
+	c := NewDoltJournalSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusError {
+		t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "corruption risk") {
+		t.Errorf("message = %q, want corruption-risk text", r.Message)
+	}
+	if !strings.Contains(r.Message, "ga-pqfk8t") {
+		t.Errorf("message = %q, want ga-pqfk8t incident reference", r.Message)
+	}
+}
+
+func TestDoltJournalSizeCheck_EnvThresholdOverride(t *testing.T) {
+	t.Setenv("GC_DOLT_JOURNAL_WARN_BYTES", "1048576")  // override to 1 MB
+	t.Setenv("GC_DOLT_JOURNAL_ERROR_BYTES", "2097152") // override to 2 MB
+	dir := setupManagedDoltCity(t)
+	// 1.5 MB — above overridden warn (1 MB), below overridden error (2 MB).
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "vvvv1.journal"), 1536*1024)
+	c := NewDoltJournalSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning with overridden thresholds; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltJournalSizeCheck_MultiDBLargestDrives(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	dataDir := filepath.Join(dir, ".beads", "dolt")
+	// hq: small journal (1 MB).
+	writeFakeFile(t, filepath.Join(dataDir, "hq", ".dolt", "noms", "vvvv1.journal"), 1024*1024)
+	// de: large journal (5 GB) — orphan directory, picked up from the data dir scan.
+	writeFakeFile(t, filepath.Join(dataDir, "de", ".dolt", "noms", "vvvv1.journal"), 5*1024*1024*1024)
+	c := NewDoltJournalSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning driven by largest DB; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "de") {
+		t.Errorf("message = %q, want largest database name 'de' in message", r.Message)
+	}
+}

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -70,6 +70,10 @@ func (c *DoltConfigCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *DoltJournalSizeCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *DoltNomsSizeCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the


### PR DESCRIPTION
## Summary

Adds the `dolt-journal-size` doctor check (`ga-ix5uly`) and fixes the missing golden-file entry that blocked the deploy gate (`ga-vgro3l`).

- `internal/doctor/checks_dolt_journal_size.go` — new `DoltJournalSizeCheck` (199 lines, follows `DoltNomsSizeCheck` pattern, `CanFix=false`)
- `cmd/gc/cmd_doctor.go` — registers `NewDoltJournalSizeCheckForConfig` after `NewDoltNomsSizeCheckForConfig`
- `cmd/gc/testdata/doctor_check_names.golden` — adds `dolt-journal-size` (was missing; deploy gate `ga-vgro3l` caught the gap)

## Test plan

- [x] `TestBuildDoctorChecks_NameSetUnchanged` — passes with golden file updated
- [x] All 8 `DoltJournalSizeCheck` unit tests pass (reviewed + PASSED by gascity/reviewer)
- [x] `go vet ./...` clean
- [x] Pre-commit passed on golden-file commit

Reviewer evidence: gascity/reviewer PASSED — deploy gate: ga-vgro3l

🤖 Generated with [Claude Code](https://claude.com/claude-code)