### PR TITLE
feat(compactor): reduce mol-dog-compactor interval 24h → 2h (ga-ox5oz8)

### DIFF
--- a/examples/bd/dolt/orders/mol-dog-compactor.toml
+++ b/examples/bd/dolt/orders/mol-dog-compactor.toml
@@ -1,6 +1,8 @@
 [order]
 description = "Flatten Dolt commit history to reduce storage"
 trigger = "cooldown"
-interval = "24h"
+# 2h: bounds journal to ~0.7 GB at observed write rates (incident ga-pqfk8t: 8.3 GB / 24h)
+# Operator-approved change — see bead ga-ox5oz8 for sign-off note.
+interval = "2h"
 exec = "gc dolt compact"
 timeout = "24h"


### PR DESCRIPTION
## Summary

- Reduces `mol-dog-compactor` interval from 24h to 2h in `examples/bd/dolt/orders/mol-dog-compactor.toml`
- Bounds Dolt commit journal to ~0.7 GB at observed write rates (incident ga-pqfk8t: 8.3 GB at 24h)
- Operator-approved via ga-ox5oz8.1; compact-duration alert implemented in ga-2ommpw.2 (#3563)

## Test plan

- [ ] `make test` passes (only a TOML config change, no Go code touched)
- [ ] mol-dog-compactor order TOML is valid
- [ ] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)