### PR TITLE
fix(deps): bump litellm>=1.84.0 to clear CRITICAL CVE-2026-49468

### DIFF
--- a/.github/requirements/mcp-agent-mail.in
+++ b/.github/requirements/mcp-agent-mail.in
@@ -20,6 +20,11 @@ urllib3>=2.7.0
 # carry the patched version themselves.
 idna>=3.15
 
+# Security floor: CVE-2026-49468 (CRITICAL, authentication bypass via Host
+# Header Injection) in litellm < 1.84.0. Drop once mcp-agent-mail's
+# transitive constraint carries the patched version itself.
+litellm>=1.84.0
+
 # Authlib and FastMCP security floors live in
 # .github/requirements/mcp-agent-mail.overrides.txt because mcp-agent-mail
 # v0.3.2 still caps Authlib below the fixed release.

--- a/.github/requirements/mcp-agent-mail.txt
+++ b/.github/requirements/mcp-agent-mail.txt
@@ -1238,10 +1238,12 @@ keyring==25.7.0 \
     --hash=sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f \
     --hash=sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b
     # via py-key-value-aio
-litellm==1.83.14 \
-    --hash=sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9 \
-    --hash=sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb
-    # via mcp-agent-mail
+litellm==1.89.1 \
+    --hash=sha256:a52a67625d89cb1787ef48c4b3c1ab9c2574ea304f56900bc631844297a13bd4 \
+    --hash=sha256:eb9292f90afe46dcce4bfef6bbeaa54494945813763e1c0917f4e9a1c584c1a4
+    # via
+    #   -r .github/requirements/mcp-agent-mail.in
+    #   mcp-agent-mail
 markdown-it-py==4.0.0 \
     --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147 \
     --hash=sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3

--- a/release-gates/ga-30prfb-litellm-cve-2026-49468-gate.md
+++ b/release-gates/ga-30prfb-litellm-cve-2026-49468-gate.md
@@ -1,0 +1,74 @@
+# Release Gate: litellm CVE-2026-49468
+
+Bead: `ga-30prfb`  
+Source review bead: `ga-v6631l`  
+PR: <https://github.com/gastownhall/gascity/pull/3565>  
+Branch: `fix/ga-w8s6xm-litellm-cve-2026-49468`  
+Reviewed commit: `80faa89daf748be5b547b4e56936778113574275`  
+Base checked: `origin/main` at `db9a8821d0a6`
+
+Result: PASS
+
+## Summary
+
+This release raises the `litellm` security floor for the `mcp-agent-mail`
+requirements set to remediate CVE-2026-49468. The compiled lock resolves
+`litellm` to `1.89.1`.
+
+The branch history contains a stale change to
+`examples/bd/dolt/orders/mol-dog-compactor.toml`, but merge-tree verification
+shows that file is not part of the effective merge result. The actual merge
+diff against `origin/main` is limited to:
+
+- `.github/requirements/mcp-agent-mail.in`
+- `.github/requirements/mcp-agent-mail.txt`
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead `ga-v6631l` is closed with `## Review verdict: PASS` for commit `80faa89daf748be5b547b4e56936778113574275`. |
+| 2 | Acceptance criteria met | PASS | `.github/requirements/mcp-agent-mail.in:26` contains `litellm>=1.84.0`; `.github/requirements/mcp-agent-mail.txt:1241` resolves `litellm==1.89.1`; reviewer verified PyPI wheel and sdist hashes. |
+| 3 | Tests pass | PASS | Local `make test` passed with `observable go test: PASS`; local `make vet` passed (`go vet ./...`). GitHub PR checks include `Image vulnerabilities` SUCCESS and `CI / required` SUCCESS on the reviewed head. |
+| 4 | No high-severity review findings open | PASS | Review notes list no unresolved HIGH findings. The only finding is an advisory stale branch-history artifact, and merge-tree confirms it is not in the effective merge. |
+| 5 | Final branch is clean | PASS | Clean deploy worktree used at `/tmp/gascity-deploy-ga-30prfb`; pre-gate `git status --short --branch` returned only `## HEAD (no branch)`. The gate commit is the sole release artifact on top of the reviewed source. |
+| 6 | Branch diverges cleanly from main | PASS | PR merge state is `CLEAN`; `git merge-tree --write-tree origin/main HEAD` succeeded and produced a merge result touching only the two requirements files. |
+| 7 | Single feature theme | PASS | Commit set is one dependency-security theme: raise the `litellm` floor and lock to remediate CVE-2026-49468 for the MCP agent mail image. |
+
+## Command Evidence
+
+```text
+$ rg -n '^litellm' .github/requirements/mcp-agent-mail.in .github/requirements/mcp-agent-mail.txt
+.github/requirements/mcp-agent-mail.in:26:litellm>=1.84.0
+.github/requirements/mcp-agent-mail.txt:1241:litellm==1.89.1 \
+```
+
+```text
+$ git merge-tree --write-tree origin/main HEAD
+cd61891fae0181d2e99b971084fe24127dd23a97
+
+$ git diff --name-status origin/main cd61891fae0181d2e99b971084fe24127dd23a97
+M       .github/requirements/mcp-agent-mail.in
+M       .github/requirements/mcp-agent-mail.txt
+
+$ git diff --stat origin/main cd61891fae0181d2e99b971084fe24127dd23a97
+ .github/requirements/mcp-agent-mail.in  |  5 +++++
+ .github/requirements/mcp-agent-mail.txt | 10 ++++++----
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+```
+
+```text
+$ make test
+observable go test: PASS log=/tmp/gascity-test.jsonl.FXJPqf
+
+$ make vet
+go vet ./...
+```
+
+```text
+$ gh pr view 3565 --json headRefOid,mergeStateStatus,statusCheckRollup
+headRefOid: 80faa89daf748be5b547b4e56936778113574275
+mergeStateStatus: CLEAN
+Image vulnerabilities: SUCCESS
+CI / required: SUCCESS
+```


### PR DESCRIPTION
## What this changes

Adds a security floor for `litellm` in `.github/requirements/mcp-agent-mail.in` so the `gc-mcp-mail` image no longer installs versions affected by CVE-2026-49468. The generated lock now resolves `litellm` to `1.89.1` with the matching hashes.

This is a dependency-only change for the MCP agent mail image. It does not change runtime code, commands, configuration, or user-facing behavior beyond removing the vulnerable dependency version from the build.

## Review notes

- The effective merge diff touches only `.github/requirements/mcp-agent-mail.in` and `.github/requirements/mcp-agent-mail.txt`.
- The branch history may show `examples/bd/dolt/orders/mol-dog-compactor.toml`, but merge-tree verification shows that file is not part of the merge result.
- The floor follows the existing security-floor pattern used by the other pinned vulnerability remediations in the requirements input.

## Test plan

- [x] `make test`
- [x] `make vet`
- [x] GitHub `Image vulnerabilities` check passes on the PR head
- [x] GitHub `CI / required` passes on the PR head
- [x] Release gate: [`release-gates/ga-30prfb-litellm-cve-2026-49468-gate.md`](release-gates/ga-30prfb-litellm-cve-2026-49468-gate.md)