### PR TITLE
Make bd probe timeout configurable for pool checks

### DIFF
--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -52,7 +52,28 @@ type ScaleCheckRunner func(command, dir string, env map[string]string) (string, 
 // bdProbeTimeout is the timeout for bd subprocess probes (scale_check,
 // work_query). Generous to accommodate bd calls that serialize through
 // a shared dolt sql-server when many pool probes run in parallel.
-const bdProbeTimeout = 180 * time.Second
+// Override via GC_BD_PROBE_TIMEOUT (e.g. "30s" for test cities); minimum 5s.
+var bdProbeTimeout = parseBdProbeTimeout()
+
+// parseBdProbeTimeout reads GC_BD_PROBE_TIMEOUT and returns the probe timeout
+// to use. Falls back to 180s when unset or unparseable; enforces a 5s floor so
+// a misconfigured production city cannot make the fleet unresponsive.
+func parseBdProbeTimeout() time.Duration {
+	const defaultTimeout = 180 * time.Second
+	const floor = 5 * time.Second
+	raw := os.Getenv("GC_BD_PROBE_TIMEOUT")
+	if raw == "" {
+		return defaultTimeout
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return defaultTimeout
+	}
+	if d < floor {
+		return floor
+	}
+	return d
+}
 
 // hookTimeout is the timeout for lifecycle hook commands (on_death,
 // on_boot). Kept shorter than probe timeout because hooks run
@@ -80,7 +101,8 @@ func shellCommand(command, dir string, timeout time.Duration, env map[string]str
 }
 
 // shellScaleCheck runs a scale_check command via sh -c and returns stdout.
-// dir sets the command's working directory. Uses bdProbeTimeout (180s).
+// dir sets the command's working directory. Uses bdProbeTimeout (default 180s,
+// overridable via GC_BD_PROBE_TIMEOUT env var).
 func shellScaleCheck(command, dir string, env map[string]string) (string, error) {
 	return shellCommand(command, dir, bdProbeTimeout, env)
 }

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
@@ -97,6 +98,46 @@ func TestEvaluatePoolNonInteger(t *testing.T) {
 	}
 	if got != 1 {
 		t.Errorf("got %d, want 1 (min on error)", got)
+	}
+}
+
+func TestParseBdProbeTimeoutDefault(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "")
+	got := parseBdProbeTimeout()
+	if got != 180*time.Second {
+		t.Errorf("parseBdProbeTimeout() = %v, want 180s", got)
+	}
+}
+
+func TestParseBdProbeTimeoutEnvVarOverride(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "30s")
+	got := parseBdProbeTimeout()
+	if got != 30*time.Second {
+		t.Errorf("parseBdProbeTimeout() = %v, want 30s", got)
+	}
+}
+
+func TestParseBdProbeTimeoutFloorEnforced(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "2s")
+	got := parseBdProbeTimeout()
+	if got != 5*time.Second {
+		t.Errorf("parseBdProbeTimeout() with 2s = %v, want 5s (floor)", got)
+	}
+}
+
+func TestParseBdProbeTimeoutZeroUsesFloor(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "0s")
+	got := parseBdProbeTimeout()
+	if got != 5*time.Second {
+		t.Errorf("parseBdProbeTimeout() with 0s = %v, want 5s (floor)", got)
+	}
+}
+
+func TestParseBdProbeTimeoutInvalidUsesDefault(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "notaduration")
+	got := parseBdProbeTimeout()
+	if got != 180*time.Second {
+		t.Errorf("parseBdProbeTimeout() with invalid = %v, want 180s (default)", got)
 	}
 }
 

--- a/release-gates/ga-00cjq1-gc-bd-probe-timeout-gate.md
+++ b/release-gates/ga-00cjq1-gc-bd-probe-timeout-gate.md
@@ -1,0 +1,64 @@
+# Release Gate: ga-00cjq1 GC_BD_PROBE_TIMEOUT
+
+Date: 2026-06-17
+Deployer branch: `release/ga-00cjq1-gc-bd-probe-timeout`
+Base: `origin/main` at `70519347fde7944f1aafb0e6792b64a6b24d34a8`
+Feature head before gate commit: `abbac2b912295f88695a4d1317a5c4f46a6c24ec`
+Source branch: `origin/builder/ga-x5ocw1`
+Deploy bead: `ga-00cjq1`
+Source review bead: `ga-ciqexy`
+
+## Scope
+
+Single-bead deploy. The branch contains one feature commit:
+
+- `abbac2b91 feat(pool): make bdProbeTimeout configurable via GC_BD_PROBE_TIMEOUT env var (ga-x5ocw1)`
+
+Changed files:
+
+- `cmd/gc/pool.go`
+- `cmd/gc/pool_test.go`
+- `test/integration/review_formula_test.go`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so no additional
+project-manifest release criteria were available. This gate uses the deployer
+release criteria from `gc prime` plus the bead acceptance/review evidence.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-ciqexy` contains `REVIEWER VERDICT: PASS`; reviewer mail `gm-wisp-5mb5ymf` says deploy bead `ga-00cjq1` is ready. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/pool.go` reads `GC_BD_PROBE_TIMEOUT`, defaults to `180s`, parses Go durations, and enforces a `5s` floor. `cmd/gc/pool_test.go` covers default, override, floor, zero, and invalid values. `test/integration/review_formula_test.go` injects `GC_BD_PROBE_TIMEOUT=30s` before isolated supervisor env construction. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc`; `go test ./cmd/gc -run TestParseBdProbeTimeout -count=1`; `make test-fast-parallel`; `go vet ./...`; `./scripts/test-integration-shard review-formulas-basic-1-of-2`; `git diff --check origin/main...HEAD`. |
+| 4 | No high-severity review findings open | PASS | Review notes report no findings to escalate and no security findings; no unresolved HIGH findings are present in the deploy/review bead notes. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before adding this gate file; deployer rechecks cleanliness after committing the gate before push. |
+| 6 | Branch diverges cleanly from main | PASS | `origin/main` is the merge base for `origin/builder/ga-x5ocw1`; `git merge-tree $(git merge-base origin/main origin/builder/ga-x5ocw1) origin/main origin/builder/ga-x5ocw1` reported a clean synthetic merge with no conflict markers. |
+| 7 | Single feature theme | PASS | Commit set touches only pool probe timeout configuration and the review-formula integration test that consumes the lower timeout. |
+
+## Test Evidence
+
+```text
+go build ./cmd/gc
+PASS
+
+go test ./cmd/gc -run TestParseBdProbeTimeout -count=1
+ok  	github.com/gastownhall/gascity/cmd/gc	0.453s
+
+make test-fast-parallel
+All fast jobs passed
+
+go vet ./...
+PASS
+
+./scripts/test-integration-shard review-formulas-basic-1-of-2
+ok  	github.com/gastownhall/gascity/test/integration	96.382s
+
+git diff --check origin/main...HEAD
+PASS
+```
+
+## Result
+
+PASS. Open a PR from `release/ga-00cjq1-gc-bd-probe-timeout` to `main`, then
+route merge authority to mayor/mpr. Deployer must not merge.

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -347,6 +347,10 @@ on_exhausted = "hard_fail"
 
 func setupReviewFormulaCity(t *testing.T, mode string, extraEnv map[string]string) string {
 	t.Helper()
+	// Reduce probe timeout so worst-case scale_check delay is ~2m on busy CI
+	// runners instead of 12m (4 × bdProbeTimeout). Root fix: ga-jtjaiy / WP-A.
+	// Set before newIsolatedCommandEnv so the isolated supervisor inherits it.
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "30s")
 	env := newIsolatedCommandEnv(t, true)
 
 	var cityName string


### PR DESCRIPTION
## What this changes

Pool `scale_check` and work-query probes now read `GC_BD_PROBE_TIMEOUT` to choose the timeout used for `bd` subprocess calls. The default remains `180s`, invalid values fall back to that default, and values below `5s` are floored so a bad operator override cannot make probe failures immediate.

The review-formula integration setup sets `GC_BD_PROBE_TIMEOUT=30s` before constructing the isolated supervisor environment. That keeps the long-running review-formulas CI path from spending up to four full default probe windows when the runner is busy, without changing production defaults.

## Review notes

- New operator knob: `GC_BD_PROBE_TIMEOUT`, parsed as a Go duration such as `30s`.
- Default behavior is unchanged when the environment variable is unset or invalid.
- The timeout is parsed once for the process lifetime and passed through the existing probe path.
- The integration test change is scoped to review-formula city setup so the child supervisor inherits the shorter timeout.

## Test plan

- [x] `go build ./cmd/gc`
- [x] `go test ./cmd/gc -run TestParseBdProbeTimeout -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `./scripts/test-integration-shard review-formulas-basic-1-of-2`
- [x] Release gate: [`release-gates/ga-00cjq1-gc-bd-probe-timeout-gate.md`](release-gates/ga-00cjq1-gc-bd-probe-timeout-gate.md)
