### PR TITLE
Make bd probe timeout configurable with GC_BD_PROBE_TIMEOUT

### DIFF
--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -53,12 +53,13 @@ type ScaleCheckRunner func(command, dir string, env map[string]string) (string, 
 // work_query). Generous to accommodate bd calls that serialize through
 // a shared dolt sql-server when many pool probes run in parallel.
 // Override via GC_BD_PROBE_TIMEOUT (e.g. "30s" for test cities); minimum 5s.
-var bdProbeTimeout = parseBdProbeTimeout()
+var bdProbeTimeout = parseBdProbeTimeout(os.Stderr)
 
 // parseBdProbeTimeout reads GC_BD_PROBE_TIMEOUT and returns the probe timeout
 // to use. Falls back to 180s when unset or unparseable; enforces a 5s floor so
 // a misconfigured production city cannot make the fleet unresponsive.
-func parseBdProbeTimeout() time.Duration {
+// Writes a warning to w when the floor is applied.
+func parseBdProbeTimeout(w io.Writer) time.Duration {
 	const defaultTimeout = 180 * time.Second
 	const floor = 5 * time.Second
 	raw := os.Getenv("GC_BD_PROBE_TIMEOUT")
@@ -70,6 +71,7 @@ func parseBdProbeTimeout() time.Duration {
 		return defaultTimeout
 	}
 	if d < floor {
+		fmt.Fprintf(w, "warning: GC_BD_PROBE_TIMEOUT %q is below the 5s floor; using 5s\n", raw) //nolint:errcheck // best-effort stderr
 		return floor
 	}
 	return d

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -52,7 +52,28 @@ type ScaleCheckRunner func(command, dir string, env map[string]string) (string, 
 // bdProbeTimeout is the timeout for bd subprocess probes (scale_check,
 // work_query). Generous to accommodate bd calls that serialize through
 // a shared dolt sql-server when many pool probes run in parallel.
-const bdProbeTimeout = 180 * time.Second
+// Override via GC_BD_PROBE_TIMEOUT (e.g. "30s" for test cities); minimum 5s.
+var bdProbeTimeout = parseBdProbeTimeout()
+
+// parseBdProbeTimeout reads GC_BD_PROBE_TIMEOUT and returns the probe timeout
+// to use. Falls back to 180s when unset or unparseable; enforces a 5s floor so
+// a misconfigured production city cannot make the fleet unresponsive.
+func parseBdProbeTimeout() time.Duration {
+	const defaultTimeout = 180 * time.Second
+	const floor = 5 * time.Second
+	raw := os.Getenv("GC_BD_PROBE_TIMEOUT")
+	if raw == "" {
+		return defaultTimeout
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return defaultTimeout
+	}
+	if d < floor {
+		return floor
+	}
+	return d
+}
 
 // hookTimeout is the timeout for lifecycle hook commands (on_death,
 // on_boot). Kept shorter than probe timeout because hooks run
@@ -80,7 +101,8 @@ func shellCommand(command, dir string, timeout time.Duration, env map[string]str
 }
 
 // shellScaleCheck runs a scale_check command via sh -c and returns stdout.
-// dir sets the command's working directory. Uses bdProbeTimeout (180s).
+// dir sets the command's working directory. Uses bdProbeTimeout (default 180s,
+// overridable via GC_BD_PROBE_TIMEOUT env var).
 func shellScaleCheck(command, dir string, env map[string]string) (string, error) {
 	return shellCommand(command, dir, bdProbeTimeout, env)
 }

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -103,7 +103,7 @@ func TestEvaluatePoolNonInteger(t *testing.T) {
 
 func TestParseBdProbeTimeoutDefault(t *testing.T) {
 	t.Setenv("GC_BD_PROBE_TIMEOUT", "")
-	got := parseBdProbeTimeout()
+	got := parseBdProbeTimeout(io.Discard)
 	if got != 180*time.Second {
 		t.Errorf("parseBdProbeTimeout() = %v, want 180s", got)
 	}
@@ -111,7 +111,7 @@ func TestParseBdProbeTimeoutDefault(t *testing.T) {
 
 func TestParseBdProbeTimeoutEnvVarOverride(t *testing.T) {
 	t.Setenv("GC_BD_PROBE_TIMEOUT", "30s")
-	got := parseBdProbeTimeout()
+	got := parseBdProbeTimeout(io.Discard)
 	if got != 30*time.Second {
 		t.Errorf("parseBdProbeTimeout() = %v, want 30s", got)
 	}
@@ -119,7 +119,7 @@ func TestParseBdProbeTimeoutEnvVarOverride(t *testing.T) {
 
 func TestParseBdProbeTimeoutFloorEnforced(t *testing.T) {
 	t.Setenv("GC_BD_PROBE_TIMEOUT", "2s")
-	got := parseBdProbeTimeout()
+	got := parseBdProbeTimeout(io.Discard)
 	if got != 5*time.Second {
 		t.Errorf("parseBdProbeTimeout() with 2s = %v, want 5s (floor)", got)
 	}
@@ -127,7 +127,7 @@ func TestParseBdProbeTimeoutFloorEnforced(t *testing.T) {
 
 func TestParseBdProbeTimeoutZeroUsesFloor(t *testing.T) {
 	t.Setenv("GC_BD_PROBE_TIMEOUT", "0s")
-	got := parseBdProbeTimeout()
+	got := parseBdProbeTimeout(io.Discard)
 	if got != 5*time.Second {
 		t.Errorf("parseBdProbeTimeout() with 0s = %v, want 5s (floor)", got)
 	}
@@ -135,9 +135,18 @@ func TestParseBdProbeTimeoutZeroUsesFloor(t *testing.T) {
 
 func TestParseBdProbeTimeoutInvalidUsesDefault(t *testing.T) {
 	t.Setenv("GC_BD_PROBE_TIMEOUT", "notaduration")
-	got := parseBdProbeTimeout()
+	got := parseBdProbeTimeout(io.Discard)
 	if got != 180*time.Second {
 		t.Errorf("parseBdProbeTimeout() with invalid = %v, want 180s (default)", got)
+	}
+}
+
+func TestParseBdProbeTimeoutFloorLogsWarning(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "2s")
+	var buf bytes.Buffer
+	parseBdProbeTimeout(&buf)
+	if !strings.Contains(buf.String(), "5s floor") {
+		t.Errorf("expected floor warning in stderr output, got: %q", buf.String())
 	}
 }
 

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
@@ -97,6 +98,46 @@ func TestEvaluatePoolNonInteger(t *testing.T) {
 	}
 	if got != 1 {
 		t.Errorf("got %d, want 1 (min on error)", got)
+	}
+}
+
+func TestParseBdProbeTimeoutDefault(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "")
+	got := parseBdProbeTimeout()
+	if got != 180*time.Second {
+		t.Errorf("parseBdProbeTimeout() = %v, want 180s", got)
+	}
+}
+
+func TestParseBdProbeTimeoutEnvVarOverride(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "30s")
+	got := parseBdProbeTimeout()
+	if got != 30*time.Second {
+		t.Errorf("parseBdProbeTimeout() = %v, want 30s", got)
+	}
+}
+
+func TestParseBdProbeTimeoutFloorEnforced(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "2s")
+	got := parseBdProbeTimeout()
+	if got != 5*time.Second {
+		t.Errorf("parseBdProbeTimeout() with 2s = %v, want 5s (floor)", got)
+	}
+}
+
+func TestParseBdProbeTimeoutZeroUsesFloor(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "0s")
+	got := parseBdProbeTimeout()
+	if got != 5*time.Second {
+		t.Errorf("parseBdProbeTimeout() with 0s = %v, want 5s (floor)", got)
+	}
+}
+
+func TestParseBdProbeTimeoutInvalidUsesDefault(t *testing.T) {
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "notaduration")
+	got := parseBdProbeTimeout()
+	if got != 180*time.Second {
+		t.Errorf("parseBdProbeTimeout() with invalid = %v, want 180s (default)", got)
 	}
 }
 

--- a/release-gates/ga-5gqdm4-bd-probe-timeout-gate.md
+++ b/release-gates/ga-5gqdm4-bd-probe-timeout-gate.md
@@ -1,0 +1,24 @@
+# Release Gate: GC_BD_PROBE_TIMEOUT bd probe timeout
+
+- Deploy bead: ga-5gqdm4
+- Source/review bead: ga-e295ze
+- Source branch: builder/ga-x5ocw1
+- Base: origin/main @ 70519347fde7944f1aafb0e6792b64a6b24d34a8
+- Reviewed candidate head: cb13cf1f9b6aa4bf3dc2d4d77bb43837fabf7ae9
+- Scope: cmd/gc pool probe timeout configuration and review-formula test timeout wiring
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-e295ze contains `RE-REVIEW VERDICT: PASS` for commit cb13cf1f9 after the blocker fix. |
+| 2 | Acceptance criteria met | PASS | `parseBdProbeTimeout(io.Writer)` reads `GC_BD_PROBE_TIMEOUT`, defaults to 180s, enforces a 5s floor, emits a warning when clamped, and keeps invalid values on the default. `setupReviewFormulaCity` sets `GC_BD_PROBE_TIMEOUT=30s` before creating the isolated supervisor environment. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run '^TestParseBdProbeTimeout' -count=1` PASS; `go test ./cmd/gc -run '^TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork$' -count=1` PASS; `make test-fast-parallel` PASS; `go vet ./...` PASS; `make test-integration-review-formulas` PASS (`review-formulas-basic` 205.362s, `review-formulas-retries` 287.682s, `review-formulas-recovery` 63.581s). |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list one blocker, resolved by cb13cf1f9, and one low/info item acknowledged as intentional. No unresolved HIGH findings remain. |
+| 5 | Final branch is clean | PASS | Gate worktree was clean before writing this artifact; final status is verified after committing the artifact. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main builder/ga-x5ocw1` exited 0; `git merge-tree` reported merged paths and no conflicts. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem/theme: configurable pool `bd` probe timeout and the review-formula test environment that consumes it. Diff is limited to `cmd/gc/pool.go`, `cmd/gc/pool_test.go`, and `test/integration/review_formula_test.go`. |
+
+## Notes
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate uses the deployer role release criteria and `TESTING.md` sharded test guidance.

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -347,6 +347,10 @@ on_exhausted = "hard_fail"
 
 func setupReviewFormulaCity(t *testing.T, mode string, extraEnv map[string]string) string {
 	t.Helper()
+	// Reduce probe timeout so worst-case scale_check delay is ~2m on busy CI
+	// runners instead of 12m (4 × bdProbeTimeout). Root fix: ga-jtjaiy / WP-A.
+	// Set before newIsolatedCommandEnv so the isolated supervisor inherits it.
+	t.Setenv("GC_BD_PROBE_TIMEOUT", "30s")
 	env := newIsolatedCommandEnv(t, true)
 
 	var cityName string


### PR DESCRIPTION
## What this changes

Pool `bd` probe commands no longer use only the fixed 180s timeout. Operators and test cities can set `GC_BD_PROBE_TIMEOUT` with a Go duration such as `30s`; unset or invalid values keep the existing 180s default.

Values below 5s are clamped to 5s and emit a warning, which avoids a misconfigured production city turning pool probes into near-immediate failures. The review-formula integration fixture now sets a 30s probe timeout before the isolated supervisor environment is created, reducing worst-case probe waits in that suite without changing production defaults.

## Review notes

- `cmd/gc/pool.go` parses the environment once at process startup into the package-level probe timeout.
- The new knob is environment-only; there is no TOML, API, dashboard, or schema surface.
- `--limit=0` in the review-formula `scale_check` remains intentional because it is a count query over all ready beads.

## Test plan

- [x] `go test ./cmd/gc -run '^TestParseBdProbeTimeout' -count=1`
- [x] `go test ./cmd/gc -run '^TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork$' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `make test-integration-review-formulas`
- [x] Release gate: [`release-gates/ga-5gqdm4-bd-probe-timeout-gate.md`](release-gates/ga-5gqdm4-bd-probe-timeout-gate.md)
