### PR TITLE
feat(devcontainer): add gascity development environment

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,73 @@
+# Devcontainer for gascity
+
+This devcontainer reproduces a development environment for [gastownhall/gascity](https://github.com/gastownhall/gascity) per the [official installation guide](https://github.com/gastownhall/gascity/blob/main/docs/getting-started/installation.md).
+
+## What it installs
+
+| Tool | Source | Version |
+|---|---|---|
+| Go 1.26 | `mcr.microsoft.com/devcontainers/go` base image | 1.26 (matches `go.mod`) |
+| `tmux` | apt | system |
+| `jq` | apt | system |
+| `flock` | apt | system (via `util-linux`) |
+| `git` | devcontainer feature | latest |
+| `gh` | devcontainer feature | latest |
+| `dolt` | GitHub release tarball | `DOLT_VERSION` from `deps.env` (currently 2.1.7) |
+| `bd` (Beads CLI) | GitHub release tarball | `BD_VERSION` from `deps.env` (currently v1.0.5) |
+| `gc` (Gas City) | `make install` from source | built from current commit |
+
+Versions come from `deps.env` so bumping is one file change.
+
+## Lifecycle
+
+| Hook | Runs | Notes |
+|---|---|---|
+| `onCreateCommand` | Once on container create | `apt install` of the system packages |
+| `postCreateCommand` | Once after `onCreate` | Installs `dolt`, `bd`, then builds and installs `gc` from source |
+| `postStartCommand` | Every time the container starts | Smoke check that all binaries are on PATH |
+
+## Why source build, not Homebrew
+
+The [installation guide](https://github.com/gastownhall/gascity/blob/main/docs/getting-started/installation.md) recommends Homebrew for daily use. The devcontainer uses the source-build path because:
+
+1. The devcontainer is for contributors and reviewers — `make install` from source is the path documented in "Build from source" and "Contributor setup"
+2. Homebrew is not available in the base `devcontainers/go` Ubuntu image
+3. Source build matches what CI does in `.github/actions/setup-gascity-ubuntu/`
+
+## Dolt data persistence
+
+`mounts` declares a named volume `gc-dolt-data` at `/home/vscode/.dolt-data` so Dolt databases created by `gc init` survive container rebuilds. Without this, every `postCreateCommand` would start from an empty Dolt state.
+
+## What this does NOT install
+
+- `claude` (Claude Code CLI) — not required for gascity itself, only for agent runtime providers. Install manually if you `gc sling claude`.
+- Other agent CLIs (codex, gemini, etc.) — same as above.
+- Homebrew — not present in Linux devcontainer base image.
+
+## Testing the devcontainer
+
+```bash
+# From repo root, with the devcontainer CLI installed:
+devcontainer up --workspace-folder .
+devcontainer exec --workspace-folder . bash -c 'gc version && gc init /tmp/test-city && cd /tmp/test-city && gc rig add /tmp/test-rig && gc sling claude "echo hello"'
+```
+
+Or in VS Code: `Ctrl+Shift+P` → "Dev Containers: Reopen in Container".
+
+## After `gc init`
+
+Follow the [Quickstart](https://github.com/gastownhall/gascity/blob/main/docs/getting-started/quickstart.md):
+
+```bash
+gc init ~/my-city
+cd ~/my-city
+mkdir ~/hello-world && cd ~/hello-world && git init && cd -
+gc rig add ~/hello-world
+cd ~/hello-world
+gc sling claude "Create a script that prints hello world"
+bd show <bead-id> --watch
+```
+
+## Note on `gc` and Oh My Zsh
+
+If your shell aliases `gc` to `git commit --verbose`, use `command gc ...` to bypass it. The base image here uses bash by default so this is not a problem, but if you opt into Oh My Zsh you'll need the workaround from the [troubleshooting guide](https://github.com/gastownhall/gascity/blob/main/docs/getting-started/troubleshooting.md#oh-my-zsh-git-plugin-hides-gc).

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -9,6 +9,7 @@ This devcontainer reproduces a development environment for [gastownhall/gascity]
 | Go 1.26 | `mcr.microsoft.com/devcontainers/go` base image | 1.26 (matches `go.mod`) |
 | `tmux` | apt | system |
 | `jq` | apt | system |
+| `libicu-dev` | apt | system |
 | `flock` | apt | system (via `util-linux`) |
 | `git` | devcontainer feature | latest |
 | `gh` | devcontainer feature | latest |
@@ -36,7 +37,7 @@ The [installation guide](https://github.com/gastownhall/gascity/blob/main/docs/g
 
 ## Dolt data persistence
 
-`mounts` declares a named volume `gc-dolt-data` at `/home/vscode/.dolt-data` so Dolt databases created by `gc init` survive container rebuilds. Without this, every `postCreateCommand` would start from an empty Dolt state.
+`mounts` declares a named volume `gc-cities` at `/home/vscode/gc-cities`. Gas City stores managed Dolt data under each city's `.beads/dolt`, so **initializing cities under `~/gc-cities/` is what makes them survive container rebuilds.** A city created at `~/gc-cities/my-city` writes its Dolt databases to `~/gc-cities/my-city/.beads/dolt`, which lives inside the persisted volume. Cities initialized elsewhere are not persisted.
 
 ## What this does NOT install
 
@@ -49,7 +50,8 @@ The [installation guide](https://github.com/gastownhall/gascity/blob/main/docs/g
 ```bash
 # From repo root, with the devcontainer CLI installed:
 devcontainer up --workspace-folder .
-devcontainer exec --workspace-folder . bash -c 'gc version && gc init /tmp/test-city && cd /tmp/test-city && gc rig add /tmp/test-rig && gc sling claude "echo hello"'
+devcontainer exec --workspace-folder . bash -c \
+  'gc version && gc init ~/gc-cities/test-city && cd ~/gc-cities/test-city && mkdir -p /tmp/test-rig && git -C /tmp/test-rig init && gc rig add /tmp/test-rig'
 ```
 
 Or in VS Code: `Ctrl+Shift+P` → "Dev Containers: Reopen in Container".
@@ -59,14 +61,16 @@ Or in VS Code: `Ctrl+Shift+P` → "Dev Containers: Reopen in Container".
 Follow the [Quickstart](https://github.com/gastownhall/gascity/blob/main/docs/getting-started/quickstart.md):
 
 ```bash
-gc init ~/my-city
-cd ~/my-city
+gc init ~/gc-cities/my-city
+cd ~/gc-cities/my-city
 mkdir ~/hello-world && cd ~/hello-world && git init && cd -
 gc rig add ~/hello-world
 cd ~/hello-world
 gc sling claude "Create a script that prints hello world"
 bd show <bead-id> --watch
 ```
+
+Initialize cities under `~/gc-cities/` so their managed Dolt data persists across rebuilds (see [Dolt data persistence](#dolt-data-persistence)).
 
 ## Note on `gc` and Oh My Zsh
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -12,8 +12,8 @@ This devcontainer reproduces a development environment for [gastownhall/gascity]
 | `flock` | apt | system (via `util-linux`) |
 | `git` | devcontainer feature | latest |
 | `gh` | devcontainer feature | latest |
-| `dolt` | GitHub release tarball | `DOLT_VERSION` from `deps.env` (currently 2.1.7) |
-| `bd` (Beads CLI) | GitHub release tarball | `BD_VERSION` from `deps.env` (currently v1.0.5) |
+| `dolt` | `.github/scripts/install-dolt-archive.sh` (SHA-256 verified) | `DOLT_VERSION` from `deps.env` (currently 2.1.7) |
+| `bd` (Beads CLI) | `.github/scripts/install-bd-archive.sh` (SHA-256 verified) | `BD_VERSION` from `deps.env` (currently v1.0.5) |
 | `gc` (Gas City) | `make install` from source | built from current commit |
 
 Versions come from `deps.env` so bumping is one file change.
@@ -23,7 +23,7 @@ Versions come from `deps.env` so bumping is one file change.
 | Hook | Runs | Notes |
 |---|---|---|
 | `onCreateCommand` | Once on container create | `apt install` of the system packages |
-| `postCreateCommand` | Once after `onCreate` | Installs `dolt`, `bd`, then builds and installs `gc` from source |
+| `postCreateCommand` | Once after `onCreate` | Installs `dolt` and `bd` via the canonical `.github/scripts/install-*-archive.sh` scripts (pinned, SHA-256 verified), then builds and installs `gc` from source |
 | `postStartCommand` | Every time the container starts | Smoke check that all binaries are on PATH |
 
 ## Why source build, not Homebrew

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,8 @@
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,
   "onCreateCommand": {
-    "deps-apt": "sudo apt-get update && sudo apt-get install -y tmux jq libicu-dev"
+    "deps-apt": "sudo apt-get update && sudo apt-get install -y tmux jq libicu-dev",
+    "fix-perms": "sudo mkdir -p /home/vscode/gc-cities && sudo chown vscode:vscode /home/vscode/gc-cities"
   },
   "postCreateCommand": {
     "dolt": "set -a && . ./deps.env && set +a && .github/scripts/install-dolt-archive.sh \"$DOLT_VERSION\" && dolt version",
@@ -45,7 +46,7 @@
     "GC_BEADS": "dolt"
   },
   "mounts": [
-    "source=gc-dolt-data,target=/home/vscode/.dolt-data,type=volume"
+    "source=gc-cities,target=/home/vscode/gc-cities,type=volume"
   ],
   "portsAttributes": {},
   "otherPortsAttributes": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,11 +16,11 @@
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,
   "onCreateCommand": {
-    "deps-apt": "sudo apt-get update && sudo apt-get install -y tmux jq libicu-dev flock"
+    "deps-apt": "sudo apt-get update && sudo apt-get install -y tmux jq libicu-dev"
   },
   "postCreateCommand": {
-    "dolt": "set -a && . ./deps.env && set +a && curl -fsSL https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-amd64.tar.gz | sudo tar -xz -C /usr/local/bin dolt && dolt --version",
-    "bd": "set -a && . ./deps.env && set +a && curl -fsSL \"https://github.com/${BD_REPO}/releases/download/${BD_VERSION}/bd_${BD_VERSION#v}_linux_amd64.tar.gz\" | sudo tar -xz -C /usr/local/bin bd && bd version",
+    "dolt": "set -a && . ./deps.env && set +a && .github/scripts/install-dolt-archive.sh \"$DOLT_VERSION\" && dolt version",
+    "bd": "set -a && . ./deps.env && set +a && .github/scripts/install-bd-archive.sh \"$BD_VERSION\" && bd version",
     "gascity": "export PATH=\"$(go env GOPATH)/bin:$PATH\" && make setup && make install && export PATH=\"$(go env GOPATH)/bin:$PATH\" && gc version"
   },
   "postStartCommand": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,55 @@
+{
+  "name": "Gas City",
+  "image": "mcr.microsoft.com/devcontainers/go:1.26-ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true,
+      "installOhMyZsh": false
+    },
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "runServices": [],
+  "overrideCommand": false,
+  "containerUser": "vscode",
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "onCreateCommand": {
+    "deps-apt": "sudo apt-get update && sudo apt-get install -y tmux jq libicu-dev flock"
+  },
+  "postCreateCommand": {
+    "dolt": "set -a && . ./deps.env && set +a && curl -fsSL https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-amd64.tar.gz | sudo tar -xz -C /usr/local/bin dolt && dolt --version",
+    "bd": "set -a && . ./deps.env && set +a && curl -fsSL \"https://github.com/${BD_REPO}/releases/download/${BD_VERSION}/bd_${BD_VERSION#v}_linux_amd64.tar.gz\" | sudo tar -xz -C /usr/local/bin bd && bd version",
+    "gascity": "export PATH=\"$(go env GOPATH)/bin:$PATH\" && make setup && make install && export PATH=\"$(go env GOPATH)/bin:$PATH\" && gc version"
+  },
+  "postStartCommand": {
+    "verify": "command -v gc && command -v dolt && command -v bd && command -v tmux && command -v jq && command -v flock && gc version"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "github.vscode-pull-request-github",
+        "EditorConfig.EditorConfig"
+      ],
+      "settings": {
+        "go.goroot": "/usr/local/go",
+        "go.gopath": "/home/vscode/go",
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/home/vscode/go/bin",
+    "GC_BEADS": "dolt"
+  },
+  "mounts": [
+    "source=gc-dolt-data,target=/home/vscode/.dolt-data,type=volume"
+  ],
+  "portsAttributes": {},
+  "otherPortsAttributes": {},
+  "containerEnv": {
+    "DEBIAN_FRONTEND": "noninteractive"
+  }
+}


### PR DESCRIPTION
Adds a [devcontainer](https://containers.dev/) configuration that reproduces the runtime setup documented in `docs/getting-started/installation.md`.

## What it installs

| Tool | Source | Version |
|---|---|---|
| Go 1.26 | `mcr.microsoft.com/devcontainers/go` base | matches `go.mod` |
| `tmux`, `jq`, `libicu-dev`, `flock` | apt | system |
| `git`, `gh` | devcontainer features | latest |
| `dolt` | GitHub release tarball | `DOLT_VERSION` from `deps.env` (currently 2.1.7) |
| `bd` (Beads CLI) | GitHub release tarball | `BD_VERSION` from `deps.env` (currently v1.0.5) |
| `gc` (Gas City) | `make install` from source | built from current commit |

## Why source build, not Homebrew

The installation guide recommends Homebrew for daily use. The devcontainer uses the source-build path because:
1. It targets contributors and reviewers (the path documented in "Build from source" / "Contributor setup")
2. Homebrew is not available in the `devcontainers/go` Ubuntu base image
3. The install path matches `.github/actions/setup-gascity-ubuntu` so behaviour matches CI

## Validation

- `devcontainer read-configuration` succeeds with the devcontainer CLI 0.87.0
- JSON schema validates
- All commands reference files that exist in the repo (`deps.env`, `Makefile` targets `setup` and `install`)
- A real `devcontainer up` was not run in this PR because the authoring environment lacks Docker. VS Code's "Reopen in Container" or `devcontainer up` on a Docker-enabled host should work out of the box.

## Dolt data persistence

A named volume `gc-dolt-data` is mounted at `/home/vscode/.dolt-data` so Dolt databases created by `gc init` survive container rebuilds.

## Quickstart after the container comes up

\`\`\`bash
gc init ~/my-city
cd ~/my-city
mkdir ~/hello-world && cd ~/hello-world && git init && cd -
gc rig add ~/hello-world
cd ~/hello-world
gc sling claude "Create a script that prints hello world"
bd show <bead-id> --watch
\`\`\`

## Files

- `.devcontainer/devcontainer.json` — the spec
- `.devcontainer/README.md` — what it does, how to use, what it doesn't install