### PR TITLE
fix(config): merge provider option choices by value

### DIFF
--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -411,7 +411,7 @@ func mergeOptionsSchemaByKey(base, city []ProviderOption) ([]ProviderOption, map
 			continue
 		}
 		if idx, ok := index[opt.Key]; ok && opt.Key != "" {
-			out[idx] = opt
+			out[idx] = mergeProviderOptionByKey(out[idx], opt)
 			continue
 		}
 		if opt.Key != "" {
@@ -420,6 +420,43 @@ func mergeOptionsSchemaByKey(base, city []ProviderOption) ([]ProviderOption, map
 		out = append(out, opt)
 	}
 	return out, pruned
+}
+
+func mergeProviderOptionByKey(base, overlay ProviderOption) ProviderOption {
+	out := overlay
+	if out.Label == "" {
+		out.Label = base.Label
+	}
+	if out.Type == "" {
+		out.Type = base.Type
+	}
+	if out.Default == "" {
+		out.Default = base.Default
+	}
+	out.Choices = mergeOptionChoicesByValue(base.Choices, overlay.Choices)
+	return out
+}
+
+func mergeOptionChoicesByValue(base, overlay []OptionChoice) []OptionChoice {
+	out := make([]OptionChoice, 0, len(base)+len(overlay))
+	index := make(map[string]int, len(base)+len(overlay))
+	for _, choice := range base {
+		if choice.Value != "" {
+			index[choice.Value] = len(out)
+		}
+		out = append(out, choice)
+	}
+	for _, choice := range overlay {
+		if idx, ok := index[choice.Value]; ok && choice.Value != "" {
+			out[idx] = choice
+			continue
+		}
+		if choice.Value != "" {
+			index[choice.Value] = len(out)
+		}
+		out = append(out, choice)
+	}
+	return out
 }
 
 func optionKeysRemovedByReplacement(base, replacement []ProviderOption) map[string]bool {

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -172,6 +172,59 @@ func TestResolveProviderWorkspaceProvider(t *testing.T) {
 	}
 }
 
+func TestResolveProviderOptionsSchemaByKeyMergesChoices(t *testing.T) {
+	base := BasePrefixBuiltin + "codex"
+	providers := map[string]ProviderSpec{
+		"codex": {
+			Base:               &base,
+			OptionsSchemaMerge: "by_key",
+			OptionDefaults: map[string]string{
+				"effort": "low",
+				"model":  "gpt-5.4-mini",
+			},
+			OptionsSchema: []ProviderOption{{
+				Key:     "model",
+				Label:   "Model",
+				Type:    "select",
+				Default: "",
+				Choices: []OptionChoice{{
+					Value:       "gpt-5.4-mini",
+					Label:       "GPT-5.4 Mini",
+					FlagArgs:    []string{"--model", "gpt-5.4-mini"},
+					FlagAliases: [][]string{{"-m", "gpt-5.4-mini"}},
+				}},
+			}},
+		},
+	}
+
+	defaultResolved, err := ResolveProvider(&Agent{Name: "worker"}, &Workspace{Provider: "codex"}, providers, lookPathOnly("codex"))
+	if err != nil {
+		t.Fatalf("ResolveProvider default agent: %v", err)
+	}
+	defaultArgs := strings.Join(defaultResolved.ResolveDefaultArgs(), " ")
+	if !strings.Contains(defaultArgs, "--model gpt-5.4-mini") {
+		t.Fatalf("ResolveDefaultArgs() = %v, missing city-added default model", defaultResolved.ResolveDefaultArgs())
+	}
+
+	optInAgent := &Agent{
+		Name: "polecat",
+		OptionDefaults: map[string]string{
+			"model": "gpt-5.5",
+		},
+	}
+	optInResolved, err := ResolveProvider(optInAgent, &Workspace{Provider: "codex"}, providers, lookPathOnly("codex"))
+	if err != nil {
+		t.Fatalf("ResolveProvider opt-in agent: %v", err)
+	}
+	optInArgs := strings.Join(optInResolved.ResolveDefaultArgs(), " ")
+	if !strings.Contains(optInArgs, "--model gpt-5.5") {
+		t.Fatalf("ResolveDefaultArgs() = %v, missing preserved built-in opt-in model", optInResolved.ResolveDefaultArgs())
+	}
+	if strings.Contains(optInArgs, "gpt-5.4-mini") {
+		t.Fatalf("ResolveDefaultArgs() = %v, default model survived agent override", optInResolved.ResolveDefaultArgs())
+	}
+}
+
 func TestResolveProviderRequiresExplicitBuiltinCatalogEntry(t *testing.T) {
 	agent := &Agent{Name: "worker", Provider: "claude"}
 	_, err := ResolveProvider(agent, nil, nil, lookPathOnly("claude"))
@@ -1481,6 +1534,54 @@ func TestMergeProviderOverBuiltinOptionsSchemaByKeyAndOmit(t *testing.T) {
 	}
 	if got := merged.OptionDefaults["effort"]; got != "high" {
 		t.Errorf("effort default = %q, want high", got)
+	}
+}
+
+func TestMergeProviderOverBuiltinOptionsSchemaByKeyMergesChoices(t *testing.T) {
+	base := ProviderSpec{
+		OptionsSchema: []ProviderOption{{
+			Key:     "model",
+			Label:   "Base Model",
+			Type:    "select",
+			Default: "opus",
+			Choices: []OptionChoice{
+				{Value: "opus", Label: "Old Opus", FlagArgs: []string{"--model", "old-opus"}},
+				{Value: "sonnet", Label: "Sonnet", FlagArgs: []string{"--model", "sonnet"}},
+			},
+		}},
+	}
+	city := ProviderSpec{
+		OptionsSchemaMerge: "by_key",
+		OptionsSchema: []ProviderOption{{
+			Key: "model",
+			Choices: []OptionChoice{
+				{Value: "opus", Label: "New Opus", FlagArgs: []string{"--model", "new-opus"}},
+				{Value: "haiku", Label: "Haiku", FlagArgs: []string{"--model", "haiku"}},
+			},
+		}},
+	}
+
+	merged := MergeProviderOverBuiltin(base, city)
+	if len(merged.OptionsSchema) != 1 {
+		t.Fatalf("option count = %d, want 1", len(merged.OptionsSchema))
+	}
+	model := merged.OptionsSchema[0]
+	if model.Label != "Base Model" {
+		t.Errorf("label = %q, want inherited Base Model", model.Label)
+	}
+	if model.Type != "select" {
+		t.Errorf("type = %q, want inherited select", model.Type)
+	}
+	if model.Default != "opus" {
+		t.Errorf("default = %q, want inherited opus", model.Default)
+	}
+	wantChoices := []OptionChoice{
+		{Value: "opus", Label: "New Opus", FlagArgs: []string{"--model", "new-opus"}},
+		{Value: "sonnet", Label: "Sonnet", FlagArgs: []string{"--model", "sonnet"}},
+		{Value: "haiku", Label: "Haiku", FlagArgs: []string{"--model", "haiku"}},
+	}
+	if !reflect.DeepEqual(model.Choices, wantChoices) {
+		t.Fatalf("choices = %#v, want %#v", model.Choices, wantChoices)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Merge provider `options_schema` choices by `value` when `options_schema_merge = \"by_key\"` overlays an existing option key.
- Preserve base option `label`, `type`, and `default` when an overlay omits those fields.
- Add regression coverage for city-added Codex model defaults plus agent-level opt-in model overrides.

## Why

A city can extend the built-in Codex `model` option with a local choice such as `gpt-5.4-mini` and set that as the provider default, while individual agent roles opt into higher-cost choices like `gpt-5.5` through `agent.option_defaults`.

Before this change, the by-key schema merge replaced the whole `model` option. That deleted built-in choices such as `gpt-5.5`, so `ResolveDefaultArgs` could not map the agent override to `--model gpt-5.5`; affected sessions launched without an explicit model flag and inherited whatever Codex last used.

## Validation

- `git diff --check upstream/main..HEAD`
- `CGO_ENABLED=1 CGO_CPPFLAGS='-I/nix/store/dvhx24q4icrig4q1v1lp7kzi3izd5jmb-icu4c-76.1-dev/include' CGO_LDFLAGS='-L/nix/store/i4lj3w4yd9x9jbi7a1xhjqsr7bg8jq7p-icu4c-76.1/lib' go test ./internal/config`
- Read-only adversarial validation found no blocking issues.