### PR TITLE
fix: harden doctor order dispatch recovery

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1319,6 +1319,7 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 	}
 
 	for key, group := range groups {
+		counted := make(map[string]struct{})
 		// Ready()/CachedReady() iteration surfaces actionable work
 		// matched against gc.routed_to/gc.run_target. Formula orders that
 		// should wake pools must create an actionable root, such as a
@@ -1340,10 +1341,77 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			if _, ok := group.templates[template]; !ok {
 				continue
 			}
+			if _, dup := counted[b.ID]; dup {
+				continue
+			}
+			counted[b.ID] = struct{}{}
+			counts[template]++
+		}
+
+		// Cron-fired pool orders can land as molecule roots, which Ready()
+		// intentionally hides. Count only the explicit gc.pool_demand path.
+		demand, demandErr := listPoolOrderDemand(group.store)
+		if demandErr != nil {
+			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: List(%s): %w", key, strings.Join(sortedStringSet(group.templates), ","), poolDemandMetadataKey, demandErr))
+			partialTemplates = markScaleCheckPartialSet(partialTemplates, group.templates)
+			if !beads.IsPartialResult(demandErr) {
+				demand = nil
+			}
+		}
+		now := time.Now().UTC()
+		for _, b := range demand {
+			if strings.TrimSpace(b.Assignee) != "" {
+				continue
+			}
+			if beads.IsDeferred(b, now) {
+				continue
+			}
+			template := controllerDemandRouteTarget(b, group.templates)
+			if _, ok := group.templates[template]; !ok {
+				continue
+			}
+			if _, dup := counted[b.ID]; dup {
+				continue
+			}
+			counted[b.ID] = struct{}{}
 			counts[template]++
 		}
 	}
 	return counts, partialTemplates, errs
+}
+
+func listPoolOrderDemand(store beads.Store) ([]beads.Bead, error) {
+	demand, err := store.List(beads.ListQuery{
+		Status:   "open",
+		Metadata: poolDemandMetadataPair(),
+		Live:     true,
+		TierMode: beads.TierBoth,
+	})
+	if err != nil || len(demand) > 0 {
+		return demand, err
+	}
+
+	// Some backends miss dotted metadata equality filters on live indexed
+	// queries. Fall back to a live scan and filter in-process so pool demand
+	// still wakes the pool.
+	demand, err = store.List(beads.ListQuery{
+		Status:    "open",
+		Type:      "molecule",
+		Live:      true,
+		TierMode:  beads.TierBoth,
+		AllowScan: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	filtered := demand[:0]
+	for _, b := range demand {
+		if b.Metadata[poolDemandMetadataKey] != poolDemandMetadataValue {
+			continue
+		}
+		filtered = append(filtered, b)
+	}
+	return filtered, nil
 }
 
 func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.City, cityName string) (map[string]bool, map[string]bool, []error) {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1320,6 +1320,7 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 
 	for key, group := range groups {
 		counted := make(map[string]struct{})
+		readyMatchedTemplates := make(map[string]struct{})
 		// Ready()/CachedReady() iteration surfaces actionable work
 		// matched against gc.routed_to/gc.run_target. Formula orders that
 		// should wake pools must create an actionable root, such as a
@@ -1345,11 +1346,20 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 				continue
 			}
 			counted[b.ID] = struct{}{}
+			readyMatchedTemplates[template] = struct{}{}
 			counts[template]++
 		}
 
 		// Cron-fired pool orders can land as molecule roots, which Ready()
-		// intentionally hides. Count only the explicit gc.pool_demand path.
+		// intentionally hides. Only pay the fallback cost when at least one
+		// template still has no Ready-visible demand; otherwise Ready already
+		// proved the store has actionable routed work for every template here.
+		needsHiddenDemandProbe := len(readyMatchedTemplates) < len(group.templates)
+		if !needsHiddenDemandProbe {
+			continue
+		}
+
+		// Count only the explicit gc.pool_demand path.
 		demand, demandErr := listPoolOrderDemand(group.store)
 		if demandErr != nil {
 			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: List(%s): %w", key, strings.Join(sortedStringSet(group.templates), ","), poolDemandMetadataKey, demandErr))

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -130,7 +130,10 @@ type demandListCountingStore struct {
 	liveInProgressIssueLists int
 	liveInProgressWispLists  int
 	liveOpenMolecules        int
+	livePoolDemand           int
+	livePoolDemandFallback   int
 	fullPrimeLists           int
+	hideIndexedPoolDemand    bool
 }
 
 func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
@@ -147,6 +150,15 @@ func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, err
 	}
 	if query.Live && query.Status == "open" && query.Type == "molecule" {
 		s.liveOpenMolecules++
+	}
+	if query.Live && query.Status == "open" && query.Metadata[poolDemandMetadataKey] == poolDemandMetadataValue {
+		s.livePoolDemand++
+		if s.hideIndexedPoolDemand {
+			return nil, nil
+		}
+	}
+	if query.Live && query.Status == "open" && query.AllowScan && len(query.Metadata) == 0 && query.TierMode == beads.TierBoth {
+		s.livePoolDemandFallback++
 	}
 	return s.Store.List(query)
 }
@@ -1182,9 +1194,154 @@ func TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers(t *testing.T) {
 	if got := counts["gascity/workflows.codex-min"]; got != 0 {
 		t.Fatalf("defaultScaleCheckCounts = %d, want molecule container ignored", got)
 	}
-	if backing.liveOpenMolecules != 0 {
-		t.Fatalf("live open molecule list calls = %d, want no molecule demand query", backing.liveOpenMolecules)
+	if backing.liveOpenMolecules == 0 {
+		t.Fatalf("live open molecule list calls = 0, want fallback scan to verify no gc.pool_demand roots")
 	}
+}
+
+func TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:     "pool-order root",
+		Type:      "molecule",
+		Status:    "open",
+		Metadata:  poolWispMetadata("dog"),
+		Ephemeral: true,
+	}); err != nil {
+		t.Fatalf("create pool-order root: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "dog",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["dog"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1", "dog", got)
+	}
+	if backing.livePoolDemand == 0 {
+		t.Fatalf("livePoolDemand list calls = 0, want >0")
+	}
+}
+
+func TestDefaultScaleCheckCountsFallsBackWhenIndexedPoolDemandMissesDottedMetadata(t *testing.T) {
+	backing := &demandListCountingStore{
+		Store:                 beads.NewMemStore(),
+		hideIndexedPoolDemand: true,
+	}
+	if _, err := backing.Create(beads.Bead{
+		Title:    "pool-order root",
+		Type:     "molecule",
+		Status:   "open",
+		Metadata: poolWispMetadata("gastown-override.dog"),
+	}); err != nil {
+		t.Fatalf("create pool-order root: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gastown-override.dog",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gastown-override.dog"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1", "gastown-override.dog", got)
+	}
+	if backing.livePoolDemand == 0 {
+		t.Fatalf("livePoolDemand list calls = 0, want indexed lookup attempted first")
+	}
+	if backing.livePoolDemandFallback == 0 {
+		t.Fatalf("livePoolDemandFallback list calls = 0, want fallback scan after empty indexed lookup")
+	}
+}
+
+func TestDefaultScaleCheckCountsPoolDemandUsesRoutedToBeforeRunTarget(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	metadata := map[string]string{
+		"gc.run_target": "dog",
+		"gc.routed_to":  "cat",
+	}
+	for k, v := range poolDemandMetadataPair() {
+		metadata[k] = v
+	}
+	if _, err := backing.Create(beads.Bead{
+		Title:     "pool demand with canonical route",
+		Type:      "molecule",
+		Status:    "open",
+		Metadata:  metadata,
+		Ephemeral: true,
+	}); err != nil {
+		t.Fatalf("create pool-order root: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{
+		{template: "dog", storeKey: "city", store: cache},
+		{template: "cat", storeKey: "city", store: cache},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["dog"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 0", "dog", got)
+	}
+	if got := counts["cat"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1", "cat", got)
+	}
+}
+
+func TestDefaultScaleCheckCountsIgnoresFutureDeferredCronPoolDemand(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	future := time.Now().UTC().Add(time.Hour)
+	if _, err := backing.Create(beads.Bead{
+		Title:      "deferred pool-order root",
+		Type:       "molecule",
+		Status:     "open",
+		Metadata:   poolWispMetadata("cat"),
+		DeferUntil: &future,
+	}); err != nil {
+		t.Fatalf("create deferred pool-order root: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "cat",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["cat"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 0", "cat", got)
+	}
+}
+
+func poolWispMetadata(pool string) map[string]string {
+	m := map[string]string{"gc.routed_to": pool}
+	for k, v := range poolDemandMetadataPair() {
+		m[k] = v
+	}
+	return m
 }
 
 // TestDefaultScaleCheckCountsIgnoresGraphV2StepRoutedToPool pins the

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -75,12 +75,14 @@ type CityRuntime struct {
 	it                      idleTracker
 	mat                     maxSessionAgeTracker
 	wg                      wispGC
+	orderDispatchMu         sync.Mutex
 	od                      orderDispatcher
 	retiredOrderDispatchers []orderDispatcher
 	orderSet                []orders.Order
 	orderSetSignature       string
 	orderRescanEnabled      bool
 	orderRescanLast         time.Time
+	orderDispatchLast       time.Time
 	trace                   *sessionReconcilerTraceManager
 
 	orderSweepWatchdogLast             time.Time
@@ -648,6 +650,8 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	interval := cr.cfg.Daemon.PatrolIntervalDuration()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	stopOrderDispatchLoop := cr.startOrderDispatchLoop(ctx, cityRoot, interval)
+	defer stopOrderDispatchLoop()
 
 	// Start the supervisor nudge dispatcher when configured. The wake-socket
 	// listener feeds nudgeWakeCh on every producer enqueue, giving sub-second
@@ -738,6 +742,37 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+func (cr *CityRuntime) startOrderDispatchLoop(ctx context.Context, cityRoot string, interval time.Duration) func() {
+	if interval <= 0 {
+		return func() {}
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				func() {
+					prev := beads.SetReconcilerTickTrigger("orders")
+					defer beads.RestoreReconcilerTickTrigger(prev)
+					cr.safeTick(func() {
+						cr.dispatchOrdersWithMinGap(loopCtx, cityRoot, interval/2)
+					}, "orders")
+				}()
+			case <-loopCtx.Done():
+				return
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done
 	}
 }
 
@@ -1258,15 +1293,32 @@ func (cr *CityRuntime) tick(
 }
 
 func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) {
+	cr.dispatchOrdersWithMinGap(ctx, cityRoot, 0)
+}
+
+func (cr *CityRuntime) dispatchOrdersWithMinGap(ctx context.Context, cityRoot string, minGap time.Duration) {
+	cr.orderDispatchMu.Lock()
+	defer cr.orderDispatchMu.Unlock()
 	if ctx.Err() != nil {
 		return
 	}
 	now := time.Now()
+	if minGap > 0 && !cr.orderDispatchLast.IsZero() && now.Sub(cr.orderDispatchLast) < minGap {
+		return
+	}
+	cr.orderDispatchLast = now
+	cr.dispatchOrdersLocked(ctx, cityRoot, now)
+}
+
+func (cr *CityRuntime) dispatchOrdersLocked(ctx context.Context, cityRoot string, now time.Time) {
+	if ctx.Err() != nil {
+		return
+	}
 	if !cr.wispIndexMigrationApplied {
 		cr.wispIndexMigrationApplied = true
 		cr.applyWispQueryIndexes(ctx)
 	}
-	cr.rescanOrderDispatcherIfDue(ctx, cityRoot, now)
+	cr.rescanOrderDispatcherIfDueLocked(ctx, cityRoot, now)
 	cr.runOrderTrackingSweepWatchdog(now)
 	cr.runOrderTrackingRetentionWatchdog(now)
 	cr.runNudgeMailSweepWatchdog(now)
@@ -1275,7 +1327,7 @@ func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) {
 	}
 }
 
-func (cr *CityRuntime) rescanOrderDispatcherIfDue(ctx context.Context, cityRoot string, now time.Time) {
+func (cr *CityRuntime) rescanOrderDispatcherIfDueLocked(ctx context.Context, cityRoot string, now time.Time) {
 	if !cr.orderRescanEnabled || cr.tomlPath == "" || strings.TrimSpace(cityRoot) == "" {
 		return
 	}
@@ -1302,6 +1354,12 @@ func (cr *CityRuntime) replaceOrderDispatcher(next orderDispatcher) {
 }
 
 func (cr *CityRuntime) rescanOrderDispatcher(ctx context.Context, cityRoot string, cfg *config.City, cmdName string, now time.Time) (bool, string, error) {
+	cr.orderDispatchMu.Lock()
+	defer cr.orderDispatchMu.Unlock()
+	return cr.rescanOrderDispatcherLocked(ctx, cityRoot, cfg, cmdName, now)
+}
+
+func (cr *CityRuntime) rescanOrderDispatcherLocked(ctx context.Context, cityRoot string, cfg *config.City, cmdName string, now time.Time) (bool, string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -1915,17 +1973,22 @@ func (cr *CityRuntime) reloadConfigTraced(
 	// and drained again during shutdown.
 	// Deriving from ctx (the tick ctx) lets a shutdown racing with reload
 	// short-circuit the drain instead of waiting the full 1s.
-	if cr.od != nil {
-		drainCtx, drainCancel := context.WithTimeout(ctx, reloadOrderDrainTimeout)
-		cr.drainOutgoingOrderDispatcher(drainCtx, cr.od)
-		drainCancel()
-	}
-	nextOD, orderSnapshot := buildOrderDispatcherWithSnapshot(cityRoot, nextCfg, cr.rec, cr.stderr, "gc reload: order scan")
-	orderSummary := orderSetChangeSummary(cr.orderSet, orderSnapshot.Orders)
-	cr.replaceOrderDispatcher(nextOD)
-	cr.orderSet = orderSnapshot.Orders
-	cr.orderSetSignature = orderSnapshot.Signature
-	cr.orderRescanLast = time.Now()
+	var orderSummary string
+	func() {
+		cr.orderDispatchMu.Lock()
+		defer cr.orderDispatchMu.Unlock()
+		if cr.od != nil {
+			drainCtx, drainCancel := context.WithTimeout(ctx, reloadOrderDrainTimeout)
+			cr.drainOutgoingOrderDispatcher(drainCtx, cr.od)
+			drainCancel()
+		}
+		nextOD, orderSnapshot := buildOrderDispatcherWithSnapshot(cityRoot, nextCfg, cr.rec, cr.stderr, "gc reload: order scan")
+		orderSummary = orderSetChangeSummary(cr.orderSet, orderSnapshot.Orders)
+		cr.replaceOrderDispatcher(nextOD)
+		cr.orderSet = orderSnapshot.Orders
+		cr.orderSetSignature = orderSnapshot.Signature
+		cr.orderRescanLast = time.Now()
+	}()
 	if orderSummary != "unchanged" {
 		fmt.Fprintf(cr.stderr, "%s: orders reloaded: %s\n", cr.logPrefix, orderSummary) //nolint:errcheck // best-effort stderr
 	}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1584,6 +1584,85 @@ func TestCityRuntimeRunStartupOrderDispatchPanicIsRecovered(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeRunDispatchesOrdersWhileReconcileTickIsBlocked(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.Daemon.PatrolInterval = "10ms"
+
+	sp := runtime.NewFake()
+	od := &recordingOrderDispatcher{}
+	blockedTickStarted := make(chan struct{})
+	releaseBlockedTick := make(chan struct{})
+	var buildCalls atomic.Int32
+	var blockedOnce sync.Once
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath: cityPath,
+		CityName: "test-city",
+		TomlPath: tomlPath,
+		Cfg:      cfg,
+		SP:       sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			if buildCalls.Add(1) >= 2 {
+				blockedOnce.Do(func() { close(blockedTickStarted) })
+				<-releaseBlockedTick
+			}
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	})
+	cr.od = od
+
+	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+	cs.cityBeadStore = beads.NewMemStore()
+	cr.setControllerState(cs)
+
+	done := make(chan struct{})
+	go func() {
+		cr.run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-blockedTickStarted:
+	case <-time.After(time.Second):
+		cancel()
+		close(releaseBlockedTick)
+		t.Fatal("steady-state reconcile tick did not block")
+	}
+
+	deadline := time.After(250 * time.Millisecond)
+	for od.calls.Load() < 3 {
+		select {
+		case <-deadline:
+			cancel()
+			close(releaseBlockedTick)
+			t.Fatalf("order dispatch calls = %d, want at least 3 while reconcile tick is blocked", od.calls.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	cancel()
+	close(releaseBlockedTick)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runtime did not stop after releasing blocked tick")
+	}
+}
+
 func TestOrderTrackingSweepWatchdogClosesAllStaleTracking(t *testing.T) {
 	// #2168: the watchdog must clear stale tracking beads for EVERY order, not
 	// just order-tracking-sweep's own. The old narrow scope only swept the

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -184,6 +184,20 @@ func doctorOrderFiringCurrentLastRunFunc(cityPath string, cfg *config.City, stde
 	}
 }
 
+func doctorOrderFiringCurrentOpenRunFunc(cityPath string, cfg *config.City, stderr io.Writer) doctor.OrderFiringCurrentOpenRunFunc {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	resolveStores := cachedOrderHistoryStoresResolver(cityPath, cfg, stderr)
+	return func(order orders.Order) (bool, error) {
+		stores, err := resolveStores(order)
+		if err != nil {
+			return false, err
+		}
+		return orders.HasOpenRunAcrossStores(stores...)(order.ScopedName())
+	}
+}
+
 func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts buildDoctorChecksOpts) []doctor.Check {
 	var checks []doctor.Check
 	register := func(c doctor.Check) {
@@ -229,7 +243,12 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewInstructionsFileCheck(cfg, cityPath))
 		register(doctor.NewServiceSecretsPermsCheck(cfg, cityPath))
 		register(doctor.NewSkillCollisionCheck(cfg, cityPath))
-		register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath, doctor.WithOrderFiringCurrentLastRunFunc(doctorOrderFiringCurrentLastRunFunc(cityPath, cfg, opts.Stderr))))
+		register(doctor.NewOrderFiringCurrentCheck(
+			cfg,
+			cityPath,
+			doctor.WithOrderFiringCurrentLastRunFunc(doctorOrderFiringCurrentLastRunFunc(cityPath, cfg, opts.Stderr)),
+			doctor.WithOrderFiringCurrentOpenRunFunc(doctorOrderFiringCurrentOpenRunFunc(cityPath, cfg, opts.Stderr)),
+		))
 		register(newCodexHooksDriftCheck(codexHookWorkDirs(cityPath, cfg)))
 		register(doctor.NewRigPackCoverageCheck(cfg, cityPath))
 		register(newMCPConfigDoctorCheck(cityPath, cfg, exec.LookPath))

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -722,6 +722,9 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 	}
 	if a.Pool != "" {
 		update.Metadata = map[string]string{beadmeta.RoutedToMetadataKey: pool}
+		for k, v := range poolDemandMetadataPair() {
+			update.Metadata[k] = v
+		}
 	}
 	if err := store.Update(rootID, update); err != nil {
 		fmt.Fprintf(stderr, "gc order run: labeling wisp: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -1751,7 +1751,7 @@ func TestOrderRunResolvesPackBindingForPool(t *testing.T) {
 	if got := results[0].Metadata["gc.routed_to"]; got != "maintenance.dog" {
 		t.Fatalf("gc.routed_to = %q, want maintenance.dog", got)
 	}
-	assertNoDeprecatedPoolDemandMetadata(t, results[0].Metadata)
+	assertPoolDemandMetadata(t, results[0].Metadata, "maintenance.dog")
 	if !strings.Contains(stdout.String(), "gc.routed_to=maintenance.dog") {
 		t.Fatalf("stdout = %q, want binding-qualified route", stdout.String())
 	}
@@ -1814,7 +1814,7 @@ description = "Do the cleanup."
 	if got := wisp.Metadata["gc.routed_to"]; got != "dog" {
 		t.Fatalf("gc.routed_to = %q, want dog", got)
 	}
-	assertNoDeprecatedPoolDemandMetadata(t, wisp.Metadata)
+	assertPoolDemandMetadata(t, wisp.Metadata, "dog")
 	if !strings.Contains(wisp.Description, "Dog cleanup recipe.") {
 		t.Fatalf("wisp description missing formula description:\n%s", wisp.Description)
 	}
@@ -1899,13 +1899,22 @@ func TestOrderRunNonPoolDoesNotSetRouteMetadata(t *testing.T) {
 	if got := results[0].Metadata["gc.routed_to"]; got != "" {
 		t.Fatalf("gc.routed_to = %q, want empty for unrouted order", got)
 	}
-	assertNoDeprecatedPoolDemandMetadata(t, results[0].Metadata)
+	assertPoolDemandMetadata(t, results[0].Metadata, "")
 }
 
-func assertNoDeprecatedPoolDemandMetadata(t *testing.T, metadata map[string]string) {
+func assertPoolDemandMetadata(t *testing.T, metadata map[string]string, routedTo string) {
 	t.Helper()
-	if got := metadata["gc.pool_demand"]; got != "" {
-		t.Fatalf("gc.pool_demand = %q, want empty", got)
+	if routedTo == "" {
+		if got := metadata["gc.pool_demand"]; got != "" {
+			t.Fatalf("gc.pool_demand = %q, want empty", got)
+		}
+		return
+	}
+	if got := metadata["gc.pool_demand"]; got != "order" {
+		t.Fatalf("gc.pool_demand = %q, want order", got)
+	}
+	if got := metadata["gc.routed_to"]; got != routedTo {
+		t.Fatalf("gc.routed_to = %q, want %q", got, routedTo)
 	}
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -74,7 +74,7 @@ const (
 	completedOrderTrackingCloseReason = "order dispatch completed: tracking bead lifecycle finished"
 
 	orderTrackingHistoryIndexLimit   = 2048
-	defaultMaxOrderDispatchesPerTick = 4
+	defaultMaxOrderDispatchesPerTick = 64
 	orderTrackingSweepCloseBudget    = 4
 
 	// orderTrackingRetentionWatchdogInterval is the minimum time between
@@ -1389,6 +1389,9 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	}
 	if a.Pool != "" {
 		update.Metadata = map[string]string{beadmeta.RoutedToMetadataKey: pool}
+		for k, v := range poolDemandMetadataPair() {
+			update.Metadata[k] = v
+		}
 	}
 	if err := store.Update(rootID, update); err != nil {
 		// Label failure is critical for duplicate-dispatch prevention.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -380,7 +380,7 @@ func TestOrderDispatchResolvesPackBindingForPool(t *testing.T) {
 	if got := work.Metadata["gc.routed_to"]; got != "maintenance.dog" {
 		t.Errorf("gc.routed_to = %q, want %q (pack binding must qualify pool target)", got, "maintenance.dog")
 	}
-	assertNoDeprecatedPoolDemandMetadata(t, work.Metadata)
+	assertPoolDemandMetadata(t, work.Metadata, "maintenance.dog")
 }
 
 func TestOrderDispatchPoolLegacyFormulaWarnsWhenRootIsNotReadyVisible(t *testing.T) {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1383,6 +1383,33 @@ func TestOrderDispatchRespectsMaxDispatchesPerTick(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchDefaultBudgetCoversMaintenanceBurst(t *testing.T) {
+	store := beads.NewMemStore()
+	var aa []orders.Order
+	for i := 0; i < 12; i++ {
+		aa = append(aa, orders.Order{
+			Name:     fmt.Sprintf("maintenance-%d", i),
+			Trigger:  "cooldown",
+			Interval: "1m",
+			Exec:     "true",
+		})
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, func(context.Context, string, string, []string) ([]byte, error) {
+		return []byte("ok\n"), nil
+	}, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	now := time.Date(2026, 5, 19, 2, 30, 0, 0, time.UTC)
+	ad.dispatch(context.Background(), t.TempDir(), now)
+	ad.drain(context.Background())
+
+	if got := countOrderTrackingRuns(t, store); got != len(aa) {
+		t.Fatalf("tracking runs after default-budget tick = %d, want %d", got, len(aa))
+	}
+}
+
 func TestOrderDispatchBudgetRotatesAcrossAlwaysDueOrders(t *testing.T) {
 	store := beads.NewMemStore()
 	var aa []orders.Order

--- a/cmd/gc/pool_demand_metadata.go
+++ b/cmd/gc/pool_demand_metadata.go
@@ -1,0 +1,12 @@
+package main
+
+const (
+	poolDemandMetadataKey   = "gc.pool_demand"
+	poolDemandMetadataValue = "order"
+)
+
+func poolDemandMetadataPair() map[string]string {
+	return map[string]string{
+		poolDemandMetadataKey: poolDemandMetadataValue,
+	}
+}

--- a/docs/guides/gastown-config-recipes.md
+++ b/docs/guides/gastown-config-recipes.md
@@ -27,7 +27,7 @@ schema = 2
 
 [imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 ```
 
 ```toml
@@ -37,7 +37,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 ```
 
 ```bash
@@ -55,7 +55,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [[rigs.patches]]
 agent = "gastown.polecat"
@@ -73,7 +73,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [[rigs.patches]]
 agent = "gastown.polecat"
@@ -127,7 +127,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [[rigs.patches]]
 agent = "gastown.refinery"
@@ -255,7 +255,7 @@ base = "builtin:claude"
 
 [defaults.rig.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [daemon]
 patrol_interval = "30s"
@@ -298,7 +298,7 @@ schema = 2
 # bundled copy. The gastown pack is no longer a local directory.
 [imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 ```
 
 ### The gastown pack — the reusable defaults

--- a/examples/gastown/city.toml
+++ b/examples/gastown/city.toml
@@ -31,7 +31,7 @@ base = "builtin:claude"
 
 [defaults.rig.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [daemon]
 patrol_interval = "30s"

--- a/examples/gastown/pack.toml
+++ b/examples/gastown/pack.toml
@@ -30,4 +30,4 @@ version = "sha:f895c0ff47d6ee9334ed282a416387eb5b084d24"
 # pin in lockstep with the registry release and the module dependency.
 [imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"

--- a/examples/gastown/packs.lock
+++ b/examples/gastown/packs.lock
@@ -2,8 +2,8 @@ schema = 1
 
 [packs]
 [packs."https://github.com/gastownhall/gascity-packs/tree/main/gastown"]
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
-commit = "4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
+commit = "33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [packs."https://github.com/gastownhall/gascity.git//internal/bootstrap/packs/core"]
 version = "sha:f895c0ff47d6ee9334ed282a416387eb5b084d24"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/danielgtaylor/huma/v2 v2.37.3
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/gastownhall/gascity-packs v0.3.1-0.20260615021309-4212acb7046c
+	github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ github.com/gastownhall/gascity-packs v0.3.1-0.20260614121227-817f85e155e2 h1:NKN
 github.com/gastownhall/gascity-packs v0.3.1-0.20260614121227-817f85e155e2/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
 github.com/gastownhall/gascity-packs v0.3.1-0.20260615021309-4212acb7046c h1:D5kqIyjXb21tcvEEVTDXv3cji6dHHR+O5r77U7X8Zo8=
 github.com/gastownhall/gascity-packs v0.3.1-0.20260615021309-4212acb7046c/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
+github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d h1:I20T52WM8FGFgEGDGfmzVds0ZS73M3tc8GYB/Cy25vk=
+github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3408,6 +3408,22 @@ func legacyEphemeralPoolDemandShell(limit int, includeEphemeralReady, quiet bool
 	return `{ ` + query + ` | jq --arg target "$target" ` + shellquote.Quote(filter) + jqStderr + `; } || printf "[]"`
 }
 
+func poolDemandRouteFilterJQ(limit int) string {
+	filter := `[.[] | select((.metadata["gc.routed_to"] // "") == $target)]`
+	if limit > 0 {
+		filter += ` | .[:` + strconv.Itoa(limit) + `]`
+	}
+	return `jq --arg target "$target" ` + shellquote.Join([]string{filter})
+}
+
+func poolDemandOrderMoleculeFilterJQ(limit int) string {
+	filter := `[.[] | select((.metadata["gc.routed_to"] // "") == $target and (.metadata["gc.pool_demand"] // "") == "order")]`
+	if limit > 0 {
+		filter += ` | .[:` + strconv.Itoa(limit) + `]`
+	}
+	return `jq --arg target "$target" ` + shellquote.Join([]string{filter})
+}
+
 // poolDemandFirstRowFunctionScript emits the work_query Tier 3 function: it
 // reads the first ready, unassigned, routed bead for the supplied target,
 // prints it, and exits 0. The caller appends a terminal fallthrough
@@ -3421,6 +3437,9 @@ func poolDemandFirstRowFunctionScript(includeEphemeralReady bool) string {
 		`legacy_candidates=$(` + bdReadyPoolDemandMigrationShell("--limit=20", includeEphemeralReady) + ` 2>/dev/null); ` +
 		`r=$(printf "%s" "$legacy_candidates" | ` + poolDemandMigrationFilterJQ(1) + ` 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`pool_order_candidates=$(bd list --status=open --type=molecule --no-assignee --json --limit=0 2>/dev/null); ` +
+		`r=$(printf "%s" "$pool_order_candidates" | ` + poolDemandOrderMoleculeFilterJQ(1) + ` 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`legacy_ephemeral_candidates=$(` + legacyEphemeralPoolDemandShell(20, includeEphemeralReady, true) + `); ` +
 		`r=$(printf "%s" "$legacy_ephemeral_candidates" | jq '.[0:1]' 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
@@ -3431,7 +3450,7 @@ func poolDemandFirstRowFunctionScript(includeEphemeralReady bool) string {
 func routedReadyTierCommand(includeEphemeralReady bool) string {
 	// The shared predicate stays order-free so the count-form does no wasted
 	// sorting; the worker first-row path asks bd for the oldest candidate.
-	return bdReadyPoolDemandShell("--sort oldest --limit=1", includeEphemeralReady) + ` 2>/dev/null`
+	return bdReadyPoolDemandShell("--sort oldest --limit=20", includeEphemeralReady) + ` 2>/dev/null | ` + poolDemandRouteFilterJQ(1)
 }
 
 // poolDemandCountShell emits the reconciler count-form for target: it counts
@@ -3568,8 +3587,9 @@ func routedPoolWorkQueryCommand(includeEphemeralReady bool, targets ...string) s
 // ready+assigned (pre-assigned) > ready+unassigned+routed_to (pool).
 // Executable formula roots can be epic-typed; the bead storage policy decides
 // whether those roots are history-backed, no-history, or ephemeral for the
-// configured bd compatibility mode. Molecule containers are not routable
-// demand.
+// configured bd compatibility mode. Order-created pool-demand molecule roots
+// are the narrow exception: they are routable only when marked with
+// gc.pool_demand=order and a matching gc.routed_to.
 //
 // Parent epics are excluded from the routed (pool) tier only
 // (--exclude-type=epic). An unassigned parent epic has no executable spec —

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -1798,8 +1800,11 @@ func TestEffectiveWorkQueryDefault(t *testing.T) {
 	if strings.Contains(got, `--include-ephemeral`) {
 		t.Errorf("EffectiveWorkQuery() default must be bd 1.0.4-compatible without --include-ephemeral: %q", got)
 	}
-	if !strings.Contains(got, `bd ready --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json --sort oldest --limit=1`) {
+	if !strings.Contains(got, `bd ready --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json --sort oldest --limit=20`) {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 pool-demand probe: %q", got)
+	}
+	if !strings.Contains(got, `jq --arg target "$target"`) {
+		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to safety filter: %q", got)
 	}
 	if !strings.Contains(got, "-- mayor") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 target argument: %q", got)
@@ -1812,6 +1817,12 @@ func TestEffectiveWorkQueryDefault(t *testing.T) {
 			t.Errorf("EffectiveWorkQuery() missing run_target migration filter fragment %q: %q", want, got)
 		}
 	}
+	if !strings.Contains(got, `bd list --status=open --type=molecule --no-assignee --json --limit=0`) {
+		t.Errorf("EffectiveWorkQuery() missing pool-order molecule root fallback: %q", got)
+	}
+	if !strings.Contains(got, `gc.pool_demand`) {
+		t.Errorf("EffectiveWorkQuery() missing pool-order molecule root filter: %q", got)
+	}
 	if !strings.Contains(got, `"$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"`) {
 		t.Errorf("EffectiveWorkQuery() missing multi-identifier resolution: %q", got)
 	}
@@ -1820,7 +1831,7 @@ func TestEffectiveWorkQueryDefault(t *testing.T) {
 func TestEffectiveWorkQueryBD105CompatibilityOptIn(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveWorkQueryForBeads(BeadsConfig{BDCompatibility: BeadsBDCompatibility105})
-	if !strings.Contains(got, `bd ready --include-ephemeral --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json --sort oldest --limit=1`) {
+	if !strings.Contains(got, `bd ready --include-ephemeral --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json --sort oldest --limit=20`) {
 		t.Errorf("EffectiveWorkQueryForBeads(bd-1.0.5) missing include-ephemeral routed probe: %q", got)
 	}
 	if !strings.Contains(got, `bd ready --include-ephemeral --assignee="$id" --json --limit=1`) {
@@ -2193,21 +2204,18 @@ func TestEffectiveWorkQueryControlDispatcherClaimsLegacyUnassignedRoute(t *testi
 	out := runEffectiveWorkQuery(t, a, nil, `#!/bin/sh
 set -eu
 case "$*" in
-  *"ready --include-ephemeral"*"--metadata-field gc.routed_to=gascity/control-dispatcher"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
+  *"ready --metadata-field gc.routed_to=gascity/control-dispatcher"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=20"*)
     printf '[]'
     ;;
-  *"ready --metadata-field gc.routed_to=gascity/control-dispatcher"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
-    printf '[]'
-    ;;
-  *"ready --metadata-field gc.routed_to=gascity/workflow-control"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
-    printf '[{"id":"ga-legacy-route"}]'
+  *"ready --metadata-field gc.routed_to=gascity/workflow-control"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=20"*)
+    printf '[{"id":"ga-legacy-route","metadata":{"gc.routed_to":"gascity/workflow-control"}}]'
     ;;
   *)
     printf '[]'
     ;;
 esac
 `)
-	if got, want := strings.TrimSpace(out), `[{"id":"ga-legacy-route"}]`; got != want {
+	if got, want := strings.TrimSpace(out), `[{"id":"ga-legacy-route","metadata":{"gc.routed_to":"gascity/workflow-control"}}]`; compactJSONForTest(t, got) != compactJSONForTest(t, want) {
 		t.Fatalf("legacy routed work query output = %q, want %q", got, want)
 	}
 }
@@ -2228,8 +2236,8 @@ func TestEffectiveWorkQueryRoutedQueueUsesNativeOldestSortAcrossReadyTiers(t *te
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "ready --metadata-field gc.routed_to=hello-world/worker --unassigned --exclude-type=epic --json --sort oldest --limit=1")
-    printf '[{"id":"older-no-history","priority":2,"created_at":"2026-05-20T06:09:30Z","no_history":true}]'
+  "ready --metadata-field gc.routed_to=hello-world/worker --unassigned --exclude-type=epic --json --sort oldest --limit=20")
+    printf '[{"id":"older-no-history","priority":2,"created_at":"2026-05-20T06:09:30Z","no_history":true,"metadata":{"gc.routed_to":"hello-world/worker"}}]'
     ;;
   *)
     printf '[]'
@@ -2273,8 +2281,8 @@ func TestEffectiveWorkQueryRoutedQueueUsesOldestBeforePriority(t *testing.T) {
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  *"ready --metadata-field gc.routed_to=hello-world/worker"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
-    printf '[{"id":"older-p2","priority":2,"created_at":"2026-05-20T06:09:30Z"}]'
+  *"ready --metadata-field gc.routed_to=hello-world/worker"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=20"*)
+    printf '[{"id":"older-p2","priority":2,"created_at":"2026-05-20T06:09:30Z","metadata":{"gc.routed_to":"hello-world/worker"}}]'
     ;;
   *)
     printf '[]'
@@ -2296,7 +2304,7 @@ func TestEffectiveWorkQueryRoutedFallbackUsesNativeOldestSort(t *testing.T) {
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  *"ready --metadata-field gc.routed_to=hello-world/worker"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
+  *"ready --metadata-field gc.routed_to=hello-world/worker"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=20"*)
     printf '[]'
     ;;
   *"ready --metadata-field gc.run_target=hello-world/worker"*"--metadata-field gc.kind=workflow"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=20"*)
@@ -2693,9 +2701,18 @@ func TestPoolDemandPredicateSharedWithWorkQuery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wq := tt.agent.EffectiveWorkQuery()
 			demand := tt.agent.EffectivePoolDemandQuery()
-			workPredicate := bdReadyPoolDemandShell("--sort oldest --limit=1", false)
+			workPredicate := bdReadyPoolDemandShell("--sort oldest --limit=20", false)
 			if !strings.Contains(wq, workPredicate) {
 				t.Errorf("EffectiveWorkQuery() missing shared predicate %q in %q", workPredicate, wq)
+			}
+			if !strings.Contains(wq, `jq --arg target "$target"`) ||
+				!strings.Contains(wq, `.metadata["gc.routed_to"]`) ||
+				!strings.Contains(wq, `.[:1]`) {
+				t.Errorf("EffectiveWorkQuery() missing routed_to safety filter in %q", wq)
+			}
+			if !strings.Contains(wq, `bd list --status=open --type=molecule --no-assignee --json --limit=0`) ||
+				!strings.Contains(wq, `gc.pool_demand`) {
+				t.Errorf("EffectiveWorkQuery() missing pool-order molecule fallback filter in %q", wq)
 			}
 			migrationWorkPredicate := bdReadyPoolDemandMigrationShell("--limit=20", false)
 			if !strings.Contains(wq, migrationWorkPredicate) {
@@ -2780,6 +2797,15 @@ func TestEffectivePoolDemandQueryRespectsOverride(t *testing.T) {
 	}
 }
 
+func compactJSONForTest(t *testing.T, raw string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, []byte(raw)); err != nil {
+		t.Fatalf("compact JSON %q: %v", raw, err)
+	}
+	return buf.String()
+}
+
 // TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics is the behavioral
 // counterpart to TestPoolDemandPredicateSharedWithWorkQuery. Given a
 // fake bd that returns the same routed-and-claimable signal to either
@@ -2839,10 +2865,17 @@ func TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			metadataSuffix := `,"metadata":{"gc.routed_to":"` + tc.target + `"}`
+			bdReadyOutput := strings.ReplaceAll(tc.bdReadyOutput, `}`, metadataSuffix+`}`)
+			wantWorkQuery := strings.ReplaceAll(tc.wantWorkQuery, `}`, metadataSuffix+`}`)
+			if tc.bdReadyOutput == `[]` {
+				bdReadyOutput = tc.bdReadyOutput
+				wantWorkQuery = tc.wantWorkQuery
+			}
 			bdScript := `#!/bin/sh
 case "$*" in
   *"ready --metadata-field gc.routed_to=` + tc.target + `"*"--unassigned"*"--exclude-type=epic"*)
-    printf '%s' '` + tc.bdReadyOutput + `'
+    printf '%s' '` + bdReadyOutput + `'
     ;;
   *)
     printf '[]'
@@ -2850,8 +2883,8 @@ case "$*" in
 esac
 `
 			wqOut := strings.TrimSpace(runEffectiveWorkQuery(t, tc.agent, nil, bdScript))
-			if wqOut != tc.wantWorkQuery {
-				t.Errorf("EffectiveWorkQuery output = %q, want %q", wqOut, tc.wantWorkQuery)
+			if compactJSONForTest(t, wqOut) != compactJSONForTest(t, wantWorkQuery) {
+				t.Errorf("EffectiveWorkQuery output = %q, want %q", wqOut, wantWorkQuery)
 			}
 			demandOut := strings.TrimSpace(runShellWithFakeBd(t, tc.agent.EffectivePoolDemandQuery(), nil, bdScript))
 			if tc.wantDemandZero {

--- a/internal/config/public_packs.go
+++ b/internal/config/public_packs.go
@@ -8,7 +8,7 @@ const (
 
 	// PublicGastownPackVersion pins fresh init output to the registry release
 	// content commit from gastownhall/gascity-packs main.
-	PublicGastownPackVersion = "sha:4212acb7046c11f6f633df73307006493185233a"
+	PublicGastownPackVersion = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 	// PublicGascityPackSource is the concrete durable source for the
 	// gascity planning/implementation skills pack.
@@ -17,7 +17,7 @@ const (
 	// PublicGascityPackVersion pins fresh init output to the registry
 	// release content commit from gastownhall/gascity-packs main
 	// (gascity 0.1.4).
-	PublicGascityPackVersion = "sha:99464ed9240b1f6e6b7ab1d351f67016e1a973ff"
+	PublicGascityPackVersion = "sha:3b3b89f2011e06d84459aa7bea1552382f13930a"
 
 	// BundledPackImportVersion pins the [imports.core]/[imports.bd] entries
 	// gc init writes for the gascity.git packs bundled with the binary.
@@ -56,6 +56,7 @@ var SupersededBundledPackImportVersions = []string{
 // When bumping PublicGastownPackVersion, append the old value here
 // (scripts/update-bundled-gastown-pack does this).
 var SupersededPublicGastownPackVersions = []string{
+	"sha:4212acb7046c11f6f633df73307006493185233a",
 	"sha:817f85e155e2b0b0c375835b076103108f8a4724",
 	"sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b",
 	"sha:fa91a3b4f1fe5cc9d1ba9ffbdd2d26274680adf9",
@@ -64,6 +65,7 @@ var SupersededPublicGastownPackVersions = []string{
 // SupersededPublicGascityPackVersions is the gascity-pack counterpart of
 // SupersededPublicGastownPackVersions.
 var SupersededPublicGascityPackVersions = []string{
+	"sha:99464ed9240b1f6e6b7ab1d351f67016e1a973ff",
 	"sha:788b6e8ec224a8951c728ef6da74dab8bc04d474",
 	"sha:5fc675b85d4ae0ebca2f17cb027a24b03f2832f8",
 	"sha:abf24a2a123da29563f0473e6771e3f4769de0ab",

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -23,6 +23,9 @@ const (
 // OrderFiringCurrentLastRunFunc reports the newest persisted run time for an order.
 type OrderFiringCurrentLastRunFunc func(order orders.Order) (time.Time, error)
 
+// OrderFiringCurrentOpenRunFunc reports whether an order currently has an open run.
+type OrderFiringCurrentOpenRunFunc func(order orders.Order) (bool, error)
+
 // OrderFiringCurrentOption configures the scheduled-order freshness check.
 type OrderFiringCurrentOption func(*OrderFiringCurrentCheck)
 
@@ -34,12 +37,21 @@ func WithOrderFiringCurrentLastRunFunc(fn OrderFiringCurrentLastRunFunc) OrderFi
 	}
 }
 
+// WithOrderFiringCurrentOpenRunFunc lets callers provide the same open
+// order-run source used by the dispatcher to suppress duplicate firings.
+func WithOrderFiringCurrentOpenRunFunc(fn OrderFiringCurrentOpenRunFunc) OrderFiringCurrentOption {
+	return func(c *OrderFiringCurrentCheck) {
+		c.openRun = fn
+	}
+}
+
 // OrderFiringCurrentCheck reports scheduled orders whose last firing is stale.
 type OrderFiringCurrentCheck struct {
 	cfg      *config.City
 	cityPath string
 	clock    func() time.Time
 	lastRun  OrderFiringCurrentLastRunFunc
+	openRun  OrderFiringCurrentOpenRunFunc
 }
 
 // NewOrderFiringCurrentCheck creates a check for cron and cooldown order freshness.
@@ -145,7 +157,17 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 			blockingErrors++
 			continue
 		}
-		status, severity, detail := classifyOrderFiring(order, now, expected, lastFired, startedAt)
+		openRun, err := c.hasOpenOrderRun(order)
+		if err != nil {
+			worst = worseStatus(worst, StatusError)
+			result.Details = append(result.Details, fmt.Sprintf("%s: cannot read open order-run state: %v", orderDisplayName(order), err))
+			if firstNonOK == "" {
+				firstNonOK = orderHistoryHintTarget(order)
+			}
+			blockingErrors++
+			continue
+		}
+		status, severity, detail := classifyOrderFiring(order, now, expected, lastFired, startedAt, openRun)
 		worst = worseStatus(worst, status)
 		result.Details = append(result.Details, detail)
 		if status != StatusOK {
@@ -548,6 +570,13 @@ func (c *OrderFiringCurrentCheck) latestOrderFiredAt(evts []events.Event, order 
 	return latest, nil
 }
 
+func (c *OrderFiringCurrentCheck) hasOpenOrderRun(order orders.Order) (bool, error) {
+	if c.openRun == nil {
+		return false, nil
+	}
+	return c.openRun(order)
+}
+
 func latestOrderFiredAt(evts []events.Event, subject string) time.Time {
 	var latest time.Time
 	for _, event := range evts {
@@ -561,8 +590,15 @@ func latestOrderFiredAt(evts []events.Event, subject string) time.Time {
 	return latest
 }
 
-func classifyOrderFiring(order orders.Order, now time.Time, expected time.Duration, lastFired, controllerStarted time.Time) (CheckStatus, CheckSeverity, string) {
+func classifyOrderFiring(order orders.Order, now time.Time, expected time.Duration, lastFired, controllerStarted time.Time, openRun bool) (CheckStatus, CheckSeverity, string) {
 	name := orderDisplayName(order)
+	if openRun {
+		if lastFired.IsZero() {
+			return StatusOK, SeverityBlocking, fmt.Sprintf("%s: order run in flight (run start unknown)", name)
+		}
+		age := nonNegativeDuration(now.Sub(lastFired))
+		return StatusOK, SeverityBlocking, fmt.Sprintf("%s: order run in flight for %s, expected every %s", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
+	}
 	if lastFired.IsZero() {
 		if controllerStarted.IsZero() {
 			return StatusOK, SeverityBlocking, fmt.Sprintf("%s: never fired (controller start unknown)", name)

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	orderFiringCurrentName    = "order-firing-current"
-	orderFiringInspectHintFmt = "Inspect with: gc order check && gc order history %s"
+	orderFiringCurrentName             = "order-firing-current"
+	orderFiringInspectHintFmt          = "Inspect with: gc order check && gc order history %s"
+	orderFiringCriticalStaleGraceFloor = 5 * time.Minute
 )
 
 // OrderFiringCurrentLastRunFunc reports the newest persisted run time for an order.
@@ -618,8 +619,12 @@ func classifyOrderFiring(order orders.Order, now time.Time, expected time.Durati
 	}
 
 	age := nonNegativeDuration(now.Sub(lastFired))
+	staleThreshold := expected * 3
+	if staleThreshold < orderFiringCriticalStaleGraceFloor {
+		staleThreshold = orderFiringCriticalStaleGraceFloor
+	}
 	switch {
-	case age >= expected*3:
+	case age >= staleThreshold:
 		return StatusError, SeverityBlocking, fmt.Sprintf("%s: last fired %s ago, expected every %s (CRITICAL: stale)", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
 	case age >= expected+expected/2:
 		return StatusWarning, SeverityBlocking, fmt.Sprintf("%s: last fired %s ago, expected every %s (overdue)", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -207,6 +207,39 @@ func TestOrderFiringCurrent_UsesNewestOrderRunHistory(t *testing.T) {
 	}
 }
 
+func TestOrderFiringCurrent_OpenOrderRunIsInFlight(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "mol-dog-doctor", "cooldown", "5m")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "mol-dog-doctor", Ts: now.Add(-45 * time.Minute)},
+	)
+
+	check := NewOrderFiringCurrentCheck(
+		cfg,
+		cityPath,
+		WithOrderFiringCurrentLastRunFunc(func(order orders.Order) (time.Time, error) {
+			if order.ScopedName() != "mol-dog-doctor" {
+				return time.Time{}, nil
+			}
+			return now.Add(-45 * time.Minute), nil
+		}),
+		WithOrderFiringCurrentOpenRunFunc(func(order orders.Order) (bool, error) {
+			return order.ScopedName() == "mol-dog-doctor", nil
+		}),
+	)
+	check.clock = func() time.Time { return now }
+	result := check.Run(&CheckContext{CityPath: cityPath})
+
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK while order run is in flight; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if !strings.Contains(strings.Join(result.Details, "\n"), "in flight") {
+		t.Fatalf("details = %v, want in-flight detail", result.Details)
+	}
+}
+
 func TestOrderFiringCurrent_SkipsSuspendedRigOrders(t *testing.T) {
 	// The dispatcher intentionally skips suspended rigs. Doctor should not turn
 	// their paused recurring orders into blocking stale-order failures.

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -412,6 +412,24 @@ func TestOrderFiringCurrent_Stale(t *testing.T) {
 	}
 }
 
+func TestOrderFiringCurrent_ShortIntervalStaleBeforeGraceFloorIsWarning(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "gate-sweep", "cooldown", "30s")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "gate-sweep", Ts: now.Add(-2 * time.Minute)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning for short-interval lag before grace floor; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if strings.Contains(strings.Join(result.Details, "\n"), "(CRITICAL: stale)") {
+		t.Fatalf("details = %v, short-interval lag before grace floor should not be critical", result.Details)
+	}
+}
+
 func TestOrderFiringCurrent_IgnoresManualAndEventTriggers(t *testing.T) {
 	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
 	cityPath, cfg := orderFiringTestCity(t)

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -104,6 +104,18 @@ func isGraphApplyErrorText(text string) bool {
 		strings.Contains(text, "adding edge ")
 }
 
+func isUnsupportedGraphApplyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	if !strings.Contains(text, "bd create --graph") {
+		return false
+	}
+	return strings.Contains(text, "unknown flag: --graph") ||
+		strings.Contains(text, "unknown shorthand flag")
+}
+
 func instantiateFragmentViaGraphApply(ctx context.Context, store beads.Store, applier beads.GraphApplyStore, recipe *formula.FragmentRecipe, opts FragmentOptions) (*FragmentResult, error) {
 	graphApplyTracef("graph-apply fragment-enter root=%s applier=%T", opts.RootID, applier)
 	plan, err := buildFragmentApplyPlan(store, recipe, opts)

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -478,25 +478,31 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			if err == nil {
 				return result, nil
 			}
-			if !isTransientGraphApplyError(err) {
+			if isUnsupportedGraphApplyError(err) {
+				graphApplyTracef("graph-apply unsupported fallback recipe=%s err=%v", recipe.Name, err)
+			} else if !isTransientGraphApplyError(err) {
 				return nil, err
+			} else {
+				graphApplyTracef("graph-apply transient-error retry recipe=%s err=%v", recipe.Name, err)
+				timer := time.NewTimer(graphApplyTransientRetryDelay)
+				defer timer.Stop()
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+					return nil, fmt.Errorf("retrying graph apply for recipe %q: %w", recipe.Name, ctx.Err())
+				}
+				result, retryErr := instantiateViaGraphApply(ctx, applier, recipe, opts)
+				if retryErr == nil {
+					return result, nil
+				}
+				if isUnsupportedGraphApplyError(retryErr) {
+					graphApplyTracef("graph-apply unsupported fallback recipe=%s first_err=%v retry_err=%v", recipe.Name, err, retryErr)
+				} else if !isTransientGraphApplyError(retryErr) {
+					return nil, retryErr
+				} else {
+					graphApplyTracef("graph-apply transient-error fallback recipe=%s first_err=%v retry_err=%v", recipe.Name, err, retryErr)
+				}
 			}
-			graphApplyTracef("graph-apply transient-error retry recipe=%s err=%v", recipe.Name, err)
-			timer := time.NewTimer(graphApplyTransientRetryDelay)
-			defer timer.Stop()
-			select {
-			case <-timer.C:
-			case <-ctx.Done():
-				return nil, fmt.Errorf("retrying graph apply for recipe %q: %w", recipe.Name, ctx.Err())
-			}
-			result, retryErr := instantiateViaGraphApply(ctx, applier, recipe, opts)
-			if retryErr == nil {
-				return result, nil
-			}
-			if !isTransientGraphApplyError(retryErr) {
-				return nil, retryErr
-			}
-			graphApplyTracef("graph-apply transient-error fallback recipe=%s first_err=%v retry_err=%v", recipe.Name, err, retryErr)
 		} else {
 			graphApplyTracef("graph-apply unavailable recipe=%s store=%T", recipe.Name, store)
 		}
@@ -784,7 +790,14 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 	if IsGraphApplyEnabled() {
 		if applier, ok := beads.GraphApplyFor(store); ok {
 			opts.PriorityOverride = priorityOverride
-			return instantiateFragmentViaGraphApply(ctx, store, applier, recipe, opts)
+			result, err := instantiateFragmentViaGraphApply(ctx, store, applier, recipe, opts)
+			if err == nil {
+				return result, nil
+			}
+			if !isUnsupportedGraphApplyError(err) {
+				return nil, err
+			}
+			graphApplyTracef("graph-apply fragment-unsupported fallback root=%s err=%v", opts.RootID, err)
 		}
 		graphApplyTracef("graph-apply fragment-unavailable root=%s store=%T", opts.RootID, store)
 	}

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -478,11 +478,12 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			if err == nil {
 				return result, nil
 			}
-			if isUnsupportedGraphApplyError(err) {
+			switch {
+			case isUnsupportedGraphApplyError(err):
 				graphApplyTracef("graph-apply unsupported fallback recipe=%s err=%v", recipe.Name, err)
-			} else if !isTransientGraphApplyError(err) {
+			case !isTransientGraphApplyError(err):
 				return nil, err
-			} else {
+			default:
 				graphApplyTracef("graph-apply transient-error retry recipe=%s err=%v", recipe.Name, err)
 				timer := time.NewTimer(graphApplyTransientRetryDelay)
 				defer timer.Stop()
@@ -495,11 +496,12 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				if retryErr == nil {
 					return result, nil
 				}
-				if isUnsupportedGraphApplyError(retryErr) {
+				switch {
+				case isUnsupportedGraphApplyError(retryErr):
 					graphApplyTracef("graph-apply unsupported fallback recipe=%s first_err=%v retry_err=%v", recipe.Name, err, retryErr)
-				} else if !isTransientGraphApplyError(retryErr) {
+				case !isTransientGraphApplyError(retryErr):
 					return nil, retryErr
-				} else {
+				default:
 					graphApplyTracef("graph-apply transient-error fallback recipe=%s first_err=%v retry_err=%v", recipe.Name, err, retryErr)
 				}
 			}

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -695,10 +695,10 @@ func TestInstantiateFallsBackWhenGraphApplyDoltConnectionTimesOut(t *testing.T) 
 	}
 }
 
-func TestInstantiateFallsBackWhenNativeGraphApplyCycleCheckTimesOut(t *testing.T) {
+func TestInstantiateFallsBackWhenGraphApplyUnsupported(t *testing.T) {
 	store := &graphApplySpyStore{
 		MemStore: beads.NewMemStore(),
-		err:      fmt.Errorf("adding edge ga-wisp-f5tz43->ga-wisp-oog3my: failed to check for dependency cycle: context deadline exceeded"),
+		err:      fmt.Errorf("bd create --graph: exit status 1: Error: unknown flag: --graph"),
 	}
 	prev := IsGraphApplyEnabled()
 	SetGraphApplyEnabled(true)
@@ -718,8 +718,8 @@ func TestInstantiateFallsBackWhenNativeGraphApplyCycleCheckTimesOut(t *testing.T
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}
-	if store.calls != 2 {
-		t.Fatalf("ApplyGraphPlan calls = %d, want 2", store.calls)
+	if store.calls != 1 {
+		t.Fatalf("ApplyGraphPlan calls = %d, want 1", store.calls)
 	}
 	if result.Created != 2 {
 		t.Fatalf("Created = %d, want 2", result.Created)
@@ -764,6 +764,50 @@ func TestInstantiateDoesNotFallbackForNonTransientGraphApplyError(t *testing.T) 
 	}
 	if len(beads) != 0 {
 		t.Fatalf("fallback created %d beads for non-transient graph apply error", len(beads))
+	}
+}
+
+func TestInstantiateFragmentFallsBackWhenGraphApplyUnsupported(t *testing.T) {
+	store := &graphApplySpyStore{
+		MemStore: beads.NewMemStore(),
+		err:      fmt.Errorf("bd create --graph: exit status 1: Error: unknown flag: --graph"),
+	}
+	root, err := store.Create(beads.Bead{
+		Title:    "Workflow root",
+		Type:     "task",
+		Priority: priorityPtr(1),
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			{ID: "frag.scope", Title: "Scope", Type: "task"},
+			{ID: "frag.work", Title: "Work", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "frag.work", DependsOnID: "frag.scope", Type: "parent-child"},
+		},
+	}
+
+	result, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{RootID: root.ID})
+	if err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+	if store.calls != 1 {
+		t.Fatalf("ApplyGraphPlan calls = %d, want 1", store.calls)
+	}
+	if result.Created != 2 {
+		t.Fatalf("Created = %d, want 2", result.Created)
+	}
+	if _, err := store.Get(result.IDMapping["frag.scope"]); err != nil {
+		t.Fatalf("fallback fragment scope missing from store: %v", err)
 	}
 }
 

--- a/internal/orders/runtime_helpers.go
+++ b/internal/orders/runtime_helpers.go
@@ -2,6 +2,7 @@ package orders
 
 import (
 	"log"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -57,6 +58,50 @@ func LastRunAcrossStores(stores ...beads.Store) LastRunFunc {
 			}
 		}
 		return latest, nil
+	}
+}
+
+type openOrderRunStore interface {
+	HasOpenOrderRun(name string) (bool, error)
+}
+
+// HasOpenRunFuncForStore returns true when a store has any non-closed
+// order-run bead for the named order.
+func HasOpenRunFuncForStore(store beads.Store) func(string) (bool, error) {
+	return func(name string) (bool, error) {
+		name = strings.TrimSpace(name)
+		if store == nil || name == "" {
+			return false, nil
+		}
+		if fastStore, ok := store.(openOrderRunStore); ok {
+			return fastStore.HasOpenOrderRun(name)
+		}
+		results, err := store.List(beads.ListQuery{
+			Label:    "order-run:" + name,
+			Limit:    1,
+			Live:     true,
+			TierMode: beads.TierBoth,
+		})
+		if err != nil {
+			return false, err
+		}
+		return len(results) > 0, nil
+	}
+}
+
+// HasOpenRunAcrossStores returns true if any store has a non-closed order run.
+func HasOpenRunAcrossStores(stores ...beads.Store) func(string) (bool, error) {
+	return func(name string) (bool, error) {
+		for _, store := range stores {
+			open, err := HasOpenRunFuncForStore(store)(name)
+			if err != nil {
+				return false, err
+			}
+			if open {
+				return true, nil
+			}
+		}
+		return false, nil
 	}
 }
 


### PR DESCRIPTION
## Summary
- restore pool-demand visibility for order-created molecule roots in scale checks and work queries
- keep order dispatch running independently of slow reconcile ticks and tighten graph-apply fallback behavior
- treat open order runs as in-flight in doctor and add a grace floor for short-interval staleness checks

## Testing
- env CGO_ENABLED=0 go test ./internal/config -run 'TestEffectiveWorkQueryDefault|TestEffectiveWorkQueryBD105CompatibilityOptIn|TestEffectiveWorkQueryControlDispatcherClaimsLegacyUnassignedRoute|TestEffectiveWorkQueryRoutedQueueUsesNativeOldestSortAcrossReadyTiers|TestEffectiveWorkQueryRoutedQueueUsesOldestBeforePriority|TestEffectiveWorkQueryRoutedFallbackUsesNativeOldestSort|TestPoolDemandPredicateSharedWithWorkQuery|TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics' -count=1
- env CGO_ENABLED=0 go test ./internal/molecule -run 'TestInstantiateFallsBackWhenGraphApplyUnsupported|TestInstantiateFragmentFallsBackWhenGraphApplyUnsupported|TestInstantiateDoesNotFallbackForNonTransientGraphApplyError' -count=1
- env CGO_ENABLED=0 go test ./cmd/gc -run 'TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers|TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag|TestDefaultScaleCheckCountsFallsBackWhenIndexedPoolDemandMissesDottedMetadata|TestDefaultScaleCheckCountsPoolDemandUsesRoutedToBeforeRunTarget|TestDefaultScaleCheckCountsIgnoresFutureDeferredCronPoolDemand|TestCityRuntimeRunDispatchesOrdersWhileReconcileTickIsBlocked' -count=1
- env CGO_ENABLED=0 go test ./internal/doctor -run 'Test.*' -count=1
- env CGO_ENABLED=0 go test ./cmd/gc -run 'TestBuildDoctorChecksOrderFiringCurrentUsesOrderRunHistory' -count=1

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3368 — moves order dispatch into a dedicated loop on its own ticker, independent of the reconcile tick, so orders keep dispatching when the tick is slow or skipped instead of going dark (the issue's fix-candidate-A direction; pressure-aware exec-timeout scaling is not included).
- Related to #2604 — decouples order dispatch from the single reconcile tick by running it in a separate loop, addressing the shared seam where in-tick synchronous dispatch and session reconciliation contend.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
