### PR TITLE
fix(dolt): emit compact quarantine operator alerts

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -223,6 +223,7 @@ compact_remote="${GC_DOLT_COMPACT_REMOTE:-}"
 dry_run="${GC_DOLT_COMPACT_DRY_RUN:-}"
 only_dbs="${GC_DOLT_COMPACT_ONLY_DBS:-}"
 bare_gc_input="${GC_DOLT_COMPACT_BARE_GC:-}"
+compact_alert_to="${GC_DOLT_COMPACT_ALERT_TO:-mayor}"
 case "$bare_gc_input" in
   ''|0|false|FALSE|no|NO)
     bare_gc=0
@@ -1181,7 +1182,21 @@ write_compact_marker() {
     printf 'compact: db=%s unable to install marker in %s\n' "$db" "$dir" >&2
     return 1
   fi
+  if [ "$dir" = "$quarantine_dir" ]; then
+    send_compact_quarantine_alert "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at" || true
+  fi
   return 0
+}
+
+send_compact_quarantine_alert() {
+  _ca_db="$1"
+  _ca_type="$2"
+  _ca_path="$3"
+  _ca_reason="$4"
+  _ca_created_at="${5:-<unknown>}"
+  _ca_msg="db=$_ca_db type=$_ca_type marker=$_ca_path reason=$_ca_reason created_at=$_ca_created_at recipient=$compact_alert_to"
+  gc event emit dolt.compact.quarantine --actor controller --message "$_ca_msg" || true
+  gc mail send "$compact_alert_to" --from controller -s "dolt compact quarantine: $_ca_db $_ca_type" -m "$_ca_msg" || true
 }
 
 ensure_compact_marker_writable() {
@@ -1306,6 +1321,7 @@ ensure_remote_push_retry_fresh() {
   if [ "$age_secs" -gt "$pending_push_max_age_secs" ]; then
     printf 'compact: db=%s %s marker is stale age=%ss max_age=%ss — manual review required before remote push retry\n' \
       "$db" "$marker_label" "$age_secs" "$pending_push_max_age_secs" >&2
+    send_compact_quarantine_alert "$db" "$(basename "$dir")" "$(compact_marker_path "$dir" "$db")" "$marker_label marker is stale" "$(compact_marker_value "$dir" "$db" created_at || true)" || true
     return 1
   fi
   return 0
@@ -1676,6 +1692,7 @@ flatten_database() {
     quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
     printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s — manual intervention required before compaction or GC\n' \
       "$db" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" >&2
+    send_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" || true
     return 1
   fi
 
@@ -2353,6 +2370,7 @@ bare_gc_database() {
     quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
     printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s — manual intervention required before compaction or GC\n' \
       "$db" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" >&2
+    send_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" || true
     return 1
   fi
 

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -108,6 +108,7 @@ type compactScriptFixture struct {
 	dataDir       string
 	binDir        string
 	doltLog       string
+	gcLog         string
 	stateFile     string
 	hashStateFile string
 	port          int
@@ -130,7 +131,7 @@ func newCompactScriptFixture(t *testing.T) compactScriptFixture {
 	writeManagedRuntimeStateForScriptWithPID(t, cityPath, port, os.Getpid())
 
 	binDir := t.TempDir()
-	writeCompactFakeGC(t, binDir)
+	gcLog := writeCompactFakeGC(t, binDir)
 	doltLog := writeCompactFakeDolt(t, binDir)
 	stateFile := filepath.Join(binDir, "head-state")
 	if err := os.WriteFile(stateFile, []byte("headcommit\n"), 0o644); err != nil {
@@ -146,6 +147,7 @@ func newCompactScriptFixture(t *testing.T) compactScriptFixture {
 		dataDir:       dataDir,
 		binDir:        binDir,
 		doltLog:       doltLog,
+		gcLog:         gcLog,
 		stateFile:     stateFile,
 		hashStateFile: hashStateFile,
 		port:          port,
@@ -173,6 +175,7 @@ func (f compactScriptFixture) run(t *testing.T, mode string, extraEnv ...string)
 		"GC_DOLT_COMPACT_REMOTE",
 		"GC_DOLT_COMPACT_BARE_GC",
 		"GC_DOLT_RIG_LIST_TIMEOUT_SECS",
+		"GC_DOLT_COMPACT_ALERT_TO",
 		"GC_FAKE_DOLT_COMPACT_MODE",
 		"GC_FAKE_DOLT_COUNT_FILE",
 		"GC_FAKE_DOLT_STATE_FILE",
@@ -282,15 +285,68 @@ func runCompactScriptCommand(t *testing.T, mode string) (string, string, error) 
 	return out, fixture.doltLog, err
 }
 
-func writeCompactFakeGC(t *testing.T, binDir string) {
+func writeCompactFakeGC(t *testing.T, binDir string) string {
 	t.Helper()
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	logPath := filepath.Join(binDir, "gc.log")
+	writeExecutable(t, filepath.Join(binDir, "gc"), fmt.Sprintf(`#!/bin/sh
+printf 'gc %%s\n' "$*" >> %s
 if [ "${1:-}" = "rig" ] && [ "${2:-}" = "list" ]; then
   printf '{"rigs":[]}\n'
   exit 0
 fi
 exit 0
-`)
+`, shellQuote(logPath)))
+	return logPath
+}
+
+func readCompactGCLog(t *testing.T, fixture compactScriptFixture) string {
+	t.Helper()
+	data, err := os.ReadFile(fixture.gcLog)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	return string(data)
+}
+
+func resetCompactGCLog(t *testing.T, fixture compactScriptFixture) {
+	t.Helper()
+	if err := os.WriteFile(fixture.gcLog, nil, 0o644); err != nil {
+		t.Fatalf("reset gc log: %v", err)
+	}
+}
+
+func compactGCLogLinesWithPrefix(log, prefix string) []string {
+	var matches []string
+	for _, line := range strings.Split(log, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			matches = append(matches, line)
+		}
+	}
+	return matches
+}
+
+func assertCompactBeadsQuarantineAlert(t *testing.T, fixture compactScriptFixture, recipient, markerPath, markerType, reason string) {
+	t.Helper()
+	log := readCompactGCLog(t, fixture)
+	mailLines := compactGCLogLinesWithPrefix(log, "gc mail send ")
+	if len(mailLines) != 1 {
+		t.Fatalf("compact quarantine should send exactly one operator mail, got %d\nlog:\n%s", len(mailLines), log)
+	}
+	eventLines := compactGCLogLinesWithPrefix(log, "gc event emit dolt.compact.quarantine")
+	if len(eventLines) != 1 {
+		t.Fatalf("compact quarantine should emit exactly one dolt.compact.quarantine event, got %d\nlog:\n%s", len(eventLines), log)
+	}
+
+	for _, want := range []string{recipient, "beads", markerPath, markerType, reason, "--from controller"} {
+		if !strings.Contains(mailLines[0], want) {
+			t.Fatalf("mail alert line missing %q\nline:\n%s\nlog:\n%s", want, mailLines[0], log)
+		}
+	}
+	for _, want := range []string{recipient, "beads", markerPath, markerType, reason, "--actor controller"} {
+		if !strings.Contains(eventLines[0], want) {
+			t.Fatalf("event alert line missing %q\nline:\n%s\nlog:\n%s", want, eventLines[0], log)
+		}
+	}
 }
 
 func writeCompactFakeDolt(t *testing.T, binDir string) string {
@@ -1718,6 +1774,27 @@ func TestCompactScriptBlocksStalePendingPushRetryBeforeForcePush(t *testing.T) {
 	if _, err := os.Stat(pendingPush); err != nil {
 		t.Fatalf("stale retry should keep pending-push marker: %v", err)
 	}
+}
+
+func TestCompactScriptStalePendingPushMarkerAlertsDefaultMayorBeforeManualReview(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("first compact should succeed locally despite remote push failure: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	replaceCompactMarkerCreatedAt(t, pendingPush, "1970-01-01T00:00:00Z")
+	resetCompactGCLog(t, fixture)
+
+	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stale pending-push retry succeeded without manual review:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_push marker is stale") ||
+		!strings.Contains(secondOut, "manual review required") {
+		t.Fatalf("retry missing stale-marker manual-review explanation:\n%s", secondOut)
+	}
+	assertCompactBeadsQuarantineAlert(t, fixture, "mayor", pendingPush, "compact-pending-push", "pending_push marker is stale")
 }
 
 func TestCompactScriptDryRunReportsStalePendingPushMarker(t *testing.T) {
@@ -3167,6 +3244,72 @@ func TestCompactScriptQuarantineBlocksSecondCycleAfterRowCountDecrease(t *testin
 	if strings.Contains(string(logData), "DOLT_GC") {
 		t.Fatalf("quarantined database must not run full GC:\n%s", logData)
 	}
+}
+
+func TestCompactScriptFreshQuarantineMarkerAlertsDefaultMayor(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite row-count decrease:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten row count decreased" {
+		t.Fatalf("fresh quarantine marker reason = %q, want row-count decrease", reason)
+	}
+	assertCompactBeadsQuarantineAlert(t, fixture, "mayor", marker, "compact-quarantine", "post-flatten row count decreased")
+}
+
+func TestCompactScriptExistingQuarantineMarkerAlertsDefaultMayorBeforeFlattenAndBareGC(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		extraEnv []string
+	}{
+		{name: "flatten_database"},
+		{name: "bare_gc_database", extraEnv: []string{"GC_DOLT_COMPACT_BARE_GC=1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newCompactScriptFixture(t)
+			marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+			if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+				t.Fatalf("mkdir quarantine dir: %v", err)
+			}
+			const reason = "manual repair pending"
+			if err := os.WriteFile(marker, []byte("db=beads\nreason="+reason+"\ncreated_at=2026-05-01T00:00:00Z\n"), 0o600); err != nil {
+				t.Fatalf("write quarantine marker: %v", err)
+			}
+
+			env := append([]string{"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500"}, tc.extraEnv...)
+			out, err := fixture.run(t, "success", env...)
+			if err == nil {
+				t.Fatalf("%s must fail when quarantine marker exists:\n%s", tc.name, out)
+			}
+			if !strings.Contains(out, marker) || !strings.Contains(out, "reason="+reason) {
+				t.Fatalf("%s output missing quarantine marker details:\n%s", tc.name, out)
+			}
+			assertCompactBeadsQuarantineAlert(t, fixture, "mayor", marker, "compact-quarantine", reason)
+		})
+	}
+}
+
+func TestCompactScriptQuarantineAlertRecipientCanBeOverridden(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		t.Fatalf("mkdir quarantine dir: %v", err)
+	}
+	const reason = "manual repair pending"
+	if err := os.WriteFile(marker, []byte("db=beads\nreason="+reason+"\ncreated_at=2026-05-01T00:00:00Z\n"), 0o600); err != nil {
+		t.Fatalf("write quarantine marker: %v", err)
+	}
+
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_ALERT_TO=gascity/operator",
+	)
+	if err == nil {
+		t.Fatalf("compact must fail when quarantine marker exists:\n%s", out)
+	}
+	assertCompactBeadsQuarantineAlert(t, fixture, "gascity/operator", marker, "compact-quarantine", reason)
 }
 
 func TestCompactScriptDryRunSkipsMutations(t *testing.T) {

--- a/release-gates/ga-uz6mr1-compact-quarantine-alerts-v2-gate.md
+++ b/release-gates/ga-uz6mr1-compact-quarantine-alerts-v2-gate.md
@@ -1,0 +1,52 @@
+# Release gate: compact quarantine operator alerts
+
+Primary deploy bead: `ga-uz6mr1`  
+Duplicate deploy bead for same release unit: `ga-e1wfde`  
+Source implementation bead: `ga-f342m1.2`  
+Review bead: `ga-6v9lg2`  
+Release branch: `deploy/ga-uz6mr1-compact-alerts-v2`  
+Reviewed head before gate: `29f847304baaf02497735833b77c12917cafce52`  
+Current `origin/main` checked for mergeability: `cdcf685f54e956737941a7ca4654a76b545c8c9d`
+
+## Release Criteria Source
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This checklist uses
+the deployer release criteria from the active role prompt plus the repository
+testing guidance in `TESTING.md`.
+
+## Scope
+
+The release branch contains one compact-script alerting slice:
+
+| Path | Change |
+| --- | --- |
+| `examples/bd/dolt/commands/compact/run.sh` | Adds fire-and-forget compact quarantine event/mail alerts. |
+| `examples/bd/dolt/dog_exec_scripts_test.go` | Adds validator coverage for alert delivery and recipient override. |
+
+The broader `builder/ga-84xwd5.1` branch was not used because it carries
+unrelated Dolt maintenance subsystem removal work. This gate uses the narrow
+reviewed branch `origin/builder/ga-f342m1.2`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+| --- | --- | --- | --- |
+| 1 | Review PASS present | PASS | `ga-6v9lg2` is closed `pass` and its notes record `VERDICT: PASS` for commit `29f847304baaf02497735833b77c12917cafce52` on `builder/ga-f342m1.2`. |
+| 2 | Acceptance criteria met | PASS | `run.sh` now parses `GC_DOLT_COMPACT_ALERT_TO`, calls `send_compact_quarantine_alert`, emits `gc event emit dolt.compact.quarantine`, sends `gc mail`, alerts on fresh quarantine markers, existing quarantine markers in flatten/bare-GC paths, and stale pending-push markers. Validator tests cover default mayor, flatten/bare-GC existing markers, recipient override, and stale pending-push. |
+| 3 | Tests pass | PASS | `go test ./examples/bd/dolt -run 'TestCompactScript(FreshQuarantineMarkerAlertsDefaultMayor\|ExistingQuarantineMarkerAlertsDefaultMayorBeforeFlattenAndBareGC\|QuarantineAlertRecipientCanBeOverridden\|StalePendingPushMarkerAlertsDefaultMayorBeforeManualReview)$' -count=1` passed in 1.377s. `go test ./examples/bd/dolt -run 'TestCompactScript' -count=1` passed in 43.422s. `make test-fast-parallel` passed all 8 fast shards. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-6v9lg2` list no findings and explicitly mark style, security, spec compliance, and coverage as passing. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before writing this gate file. This gate file is committed as the final release-gate evidence before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` succeeded and produced tree `f926f175b29b265cd9e76bb10c0fed03e381f4ff`; `git diff --check origin/main...HEAD` produced no output. |
+| 7 | Single feature theme | PASS | The commit set touches only the Dolt compact script and its compact-script tests. It adds operator notifications for quarantine/pending-marker states without bundling maintenance removal, doctor, dashboard, API, or unrelated test-helper changes. |
+
+## Test Commands
+
+```bash
+go test ./examples/bd/dolt -run 'TestCompactScript(FreshQuarantineMarkerAlertsDefaultMayor|ExistingQuarantineMarkerAlertsDefaultMayorBeforeFlattenAndBareGC|QuarantineAlertRecipientCanBeOverridden|StalePendingPushMarkerAlertsDefaultMayorBeforeManualReview)$' -count=1
+go test ./examples/bd/dolt -run 'TestCompactScript' -count=1
+make test-fast-parallel
+go vet ./...
+git diff --check origin/main...HEAD
+git merge-tree --write-tree HEAD origin/main
+```
+


### PR DESCRIPTION
## What this changes

The Dolt compact helper now alerts operators when compact quarantine or stale pending-push markers require manual attention. It emits a `dolt.compact.quarantine` event and sends `gc mail` to `mayor` by default, with `GC_DOLT_COMPACT_ALERT_TO` available for deployments that need a different recipient.

The compact control flow stays unchanged: alert delivery is fire-and-forget, and notification failures do not unblock, retry, or mask the underlying compact safety behavior.

## Review notes

- The behavior is default-on for quarantine and stale pending-push alert paths in `examples/bd/dolt/commands/compact/run.sh`.
- `GC_DOLT_COMPACT_ALERT_TO` is the only new knob; it only changes the mail recipient.
- The PR intentionally excludes the broader Dolt maintenance-removal branch that carried unrelated work.

## Test plan

- [x] `go test ./examples/bd/dolt -run 'TestCompactScript(FreshQuarantineMarkerAlertsDefaultMayor|ExistingQuarantineMarkerAlertsDefaultMayorBeforeFlattenAndBareGC|QuarantineAlertRecipientCanBeOverridden|StalePendingPushMarkerAlertsDefaultMayorBeforeManualReview)$' -count=1`
- [x] `go test ./examples/bd/dolt -run 'TestCompactScript' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-uz6mr1-compact-quarantine-alerts-v2-gate.md`](release-gates/ga-uz6mr1-compact-quarantine-alerts-v2-gate.md)
