### PR TITLE
fix(acp): ensure mcpServers serializes as [] for empty input

### DIFF
--- a/internal/runtime/acp/protocol.go
+++ b/internal/runtime/acp/protocol.go
@@ -77,6 +77,11 @@ type InitializeResult struct {
 }
 
 // SessionNewParams is the params for the "session/new" request.
+//
+// McpServers must always be present in the wire payload, even when empty:
+// ACP servers (e.g. Devin) reject session/new with -32602 "missing field
+// 'mcpServers'" if the field is omitted. The slice is therefore always
+// non-nil; see sessionNewMCPServers and TestSessionNewRequest_*.
 type SessionNewParams struct {
 	Cwd        string                `json:"cwd"`
 	McpServers []SessionNewMCPServer `json:"mcpServers"`

--- a/internal/runtime/acp/protocol_test.go
+++ b/internal/runtime/acp/protocol_test.go
@@ -305,6 +305,33 @@ func TestSessionNewRequest_IncludesCwdAndMcpServers(t *testing.T) {
 	}
 }
 
+func TestSessionNewRequest_EmptyMCPServersSliceYieldsEmptyArray(t *testing.T) {
+	msg, _ := newSessionNewRequest("/home/user/project", []runtime.MCPServerConfig{})
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var decoded JSONRPCMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	var params SessionNewParams
+	if err := json.Unmarshal(decoded.Params, &params); err != nil {
+		t.Fatalf("Unmarshal params: %v", err)
+	}
+	if params.McpServers == nil {
+		t.Fatal("mcpServers should be non-nil empty array for non-nil empty input")
+	}
+	if len(params.McpServers) != 0 {
+		t.Errorf("mcpServers len = %d, want 0", len(params.McpServers))
+	}
+	if !strings.Contains(string(data), `"mcpServers":[]`) {
+		t.Errorf("raw JSON should contain \"mcpServers\":[], got %s", data)
+	}
+}
+
 func TestSessionNewRequest_SerializesMCPServersByTransport(t *testing.T) {
 	msg, _ := newSessionNewRequest("/home/user/project", []runtime.MCPServerConfig{
 		{


### PR DESCRIPTION
Closes #3576

## Summary

ACP `session/new` requests against `v1.2.1` were reported to send only
`{"cwd": "..."}` to servers (e.g. Devin) that require the `mcpServers`
field, causing `-32602 "missing field 'mcpServers'"` and breaking
session creation.

## Root cause and investigation

Investigation at the `v1.2.1` commit (`eedcee360`) shows the fix is
**already present** in the release line:

- `internal/runtime/acp/protocol.go` — `SessionNewParams.McpServers` is
  declared as `[]SessionNewMCPServer` with `json:"mcpServers"` and no
  `omitempty`, so the field is always present in the marshaled wire
  payload.
- `sessionNewMCPServers` returns `[]SessionNewMCPServer{}` (a non-nil
  empty slice) for the empty-input case, so `encoding/json` serializes
  it as `"mcpServers":[]` rather than `"mcpServers":null` or omitting
  the field.
- `TestSessionNewRequest_IncludesCwdAndMcpServers` already asserts the
  raw JSON contains `"mcpServers":[]` for the `nil`-input case.

So `v1.2.1` at the tagged commit already produces the JSON shape Devin
expects. This backport therefore **hardens** the guarantee rather than
introducing a new fix.

## Changes

- `internal/runtime/acp/protocol.go`: add a doc comment on
  `SessionNewParams` noting that `McpServers` must always be present
  and non-nil, and pointing at the helpers and tests that enforce it.
- `internal/runtime/acp/protocol_test.go`: add
  `TestSessionNewRequest_EmptyMCPServersSliceYieldsEmptyArray`, which
  covers the non-nil empty slice input case (e.g. a config that
  declares an MCP list with no entries). This guards against any future
  regression that drops the field or omits it as `null`.

No behavior change: the wire format is unchanged for both empty and
populated inputs.

## Verification

- `go test ./internal/runtime/acp/...` — not run locally; the host has
  no `go` toolchain. The new and existing tests are pure JSON round-trip
  assertions and will be exercised by upstream CI on this PR.

## Secondary finding: `nudge-on-route.toml`

The issue also notes that `nudge-on-route.toml` is reportedly missing
from `.gc/system/packs/core/orders/` at `v1.2.1`. Confirmed against the
`eedcee360` tree:

- `internal/bootstrap/packs/core/orders/` contains only `beads-health.toml`.
- The `//go:embed orders` directive in
  `internal/bootstrap/packs/core/embed.go` faithfully embeds whatever is
  present, so `nudge-on-route.toml` is genuinely absent from the source
  tree at `v1.2.1`, not a packaging/install artifact.
- `upstream/main` does include `nudge-on-route.toml` (alongside other
  cascade/sweep orders that are likewise missing from `v1.2.1`, e.g.
  `cascade-nudge-on-blocker-close.toml`, `gate-sweep.toml`,
  `nudge-mail-sweep.toml`, `wisp-compact.toml`, `prune-branches.toml`,
  `reaper.toml`, `order-tracking-sweep.toml`, `orphan-sweep.toml`,
  `jsonl-export.toml`, `spawn-storm-detect.toml`,
  `cross-rig-deps.toml`).

This looks like a v1.2.x release-line gap rather than a packaging bug.
Per the issue's out-of-scope guidance, no change is proposed here; a
separate PR can decide whether the missing orders should be
cherry-picked into the `v1.2.x` line.

## Out of scope

- Restoring the missing core orders on the `v1.2.x` line.
- Refactoring the ACP provider.
- Bumping dependencies.