### PR TITLE
chore(packs): bump gastown pin to 0.1.10, gascity to 0.1.6

### DIFF
--- a/docs/guides/gastown-config-recipes.md
+++ b/docs/guides/gastown-config-recipes.md
@@ -27,7 +27,7 @@ schema = 2
 
 [imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 ```
 
 ```toml
@@ -37,7 +37,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 ```
 
 ```bash
@@ -55,7 +55,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [[rigs.patches]]
 agent = "gastown.polecat"
@@ -73,7 +73,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [[rigs.patches]]
 agent = "gastown.polecat"
@@ -127,7 +127,7 @@ name = "myproject"
 
 [rigs.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [[rigs.patches]]
 agent = "gastown.refinery"
@@ -255,7 +255,7 @@ base = "builtin:claude"
 
 [defaults.rig.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [daemon]
 patrol_interval = "30s"
@@ -298,7 +298,7 @@ schema = 2
 # bundled copy. The gastown pack is no longer a local directory.
 [imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 ```
 
 ### The gastown pack — the reusable defaults

--- a/examples/gastown/city.toml
+++ b/examples/gastown/city.toml
@@ -31,7 +31,7 @@ base = "builtin:claude"
 
 [defaults.rig.imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [daemon]
 patrol_interval = "30s"

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -2095,18 +2095,13 @@ func TestNonDogStartupPromptsUseAssignedInProgressQuery(t *testing.T) {
 			want:   "{{ .AssignedInProgressQuery }}",
 			forbid: []string{`gc bd list --assignee=$GC_AGENT --status=in_progress`},
 		},
-		{
-			rel:     "packs/gastown/agents/polecat/prompt.template.md",
-			start:   "## Startup Protocol",
-			end:     "## Context Exhaustion",
-			want:    "{{ .AssignedInProgressQuery }}",
-			forbid:  []string{`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`},
-			render:  true,
-			agent:   "gastown/polecat",
-			tmpl:    "polecat",
-			rig:     "gastown",
-			binding: "gastown.",
-		},
+		// The polecat Startup Protocol deliberately does NOT use the bare
+		// AssignedInProgressQuery template: since gastown 0.1.10 polecat
+		// uses `gc hook --claim --json`, which internally checks for existing
+		// in-progress assigned work via hookClaimExistingOrAssigned before
+		// falling through to unassigned pool work. The assigned-in-progress
+		// check is still present; it is now inside gc hook rather than a
+		// bare bd query rendered into the prompt.
 		{
 			rel:     "packs/gastown/agents/deacon/prompt.template.md",
 			start:   "## Startup Protocol",

--- a/examples/gastown/pack.toml
+++ b/examples/gastown/pack.toml
@@ -30,4 +30,4 @@ version = "sha:f895c0ff47d6ee9334ed282a416387eb5b084d24"
 # pin in lockstep with the registry release and the module dependency.
 [imports.gastown]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"

--- a/examples/gastown/packs.lock
+++ b/examples/gastown/packs.lock
@@ -2,8 +2,8 @@ schema = 1
 
 [packs]
 [packs."https://github.com/gastownhall/gascity-packs/tree/main/gastown"]
-version = "sha:4212acb7046c11f6f633df73307006493185233a"
-commit = "4212acb7046c11f6f633df73307006493185233a"
+version = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
+commit = "33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 [packs."https://github.com/gastownhall/gascity.git//internal/bootstrap/packs/core"]
 version = "sha:f895c0ff47d6ee9334ed282a416387eb5b084d24"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/danielgtaylor/huma/v2 v2.37.3
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/gastownhall/gascity-packs v0.3.1-0.20260615021309-4212acb7046c
+	github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ github.com/gastownhall/gascity-packs v0.3.1-0.20260614121227-817f85e155e2 h1:NKN
 github.com/gastownhall/gascity-packs v0.3.1-0.20260614121227-817f85e155e2/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
 github.com/gastownhall/gascity-packs v0.3.1-0.20260615021309-4212acb7046c h1:D5kqIyjXb21tcvEEVTDXv3cji6dHHR+O5r77U7X8Zo8=
 github.com/gastownhall/gascity-packs v0.3.1-0.20260615021309-4212acb7046c/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
+github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d h1:I20T52WM8FGFgEGDGfmzVds0ZS73M3tc8GYB/Cy25vk=
+github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=

--- a/internal/config/public_packs.go
+++ b/internal/config/public_packs.go
@@ -8,7 +8,7 @@ const (
 
 	// PublicGastownPackVersion pins fresh init output to the registry release
 	// content commit from gastownhall/gascity-packs main.
-	PublicGastownPackVersion = "sha:4212acb7046c11f6f633df73307006493185233a"
+	PublicGastownPackVersion = "sha:33d3a430a67d1782ad364556cb566bdb01d0afe3"
 
 	// PublicGascityPackSource is the concrete durable source for the
 	// gascity planning/implementation skills pack.
@@ -17,7 +17,7 @@ const (
 	// PublicGascityPackVersion pins fresh init output to the registry
 	// release content commit from gastownhall/gascity-packs main
 	// (gascity 0.1.4).
-	PublicGascityPackVersion = "sha:99464ed9240b1f6e6b7ab1d351f67016e1a973ff"
+	PublicGascityPackVersion = "sha:3b3b89f2011e06d84459aa7bea1552382f13930a"
 
 	// BundledPackImportVersion pins the [imports.core]/[imports.bd] entries
 	// gc init writes for the gascity.git packs bundled with the binary.
@@ -56,6 +56,7 @@ var SupersededBundledPackImportVersions = []string{
 // When bumping PublicGastownPackVersion, append the old value here
 // (scripts/update-bundled-gastown-pack does this).
 var SupersededPublicGastownPackVersions = []string{
+	"sha:4212acb7046c11f6f633df73307006493185233a",
 	"sha:817f85e155e2b0b0c375835b076103108f8a4724",
 	"sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b",
 	"sha:fa91a3b4f1fe5cc9d1ba9ffbdd2d26274680adf9",
@@ -64,6 +65,7 @@ var SupersededPublicGastownPackVersions = []string{
 // SupersededPublicGascityPackVersions is the gascity-pack counterpart of
 // SupersededPublicGastownPackVersions.
 var SupersededPublicGascityPackVersions = []string{
+	"sha:99464ed9240b1f6e6b7ab1d351f67016e1a973ff",
 	"sha:788b6e8ec224a8951c728ef6da74dab8bc04d474",
 	"sha:5fc675b85d4ae0ebca2f17cb027a24b03f2832f8",
 	"sha:abf24a2a123da29563f0473e6771e3f4769de0ab",


### PR DESCRIPTION
## Summary

- Runs `scripts/update-bundled-gastown-pack` to advance `PublicGastownPackVersion` → `sha:33d3a430a67d` (gastown 0.1.10) and `PublicGascityPackVersion` → `sha:3b3b89f2011e` (gascity 0.1.6)
- Old pins appended to superseded lists so the doctor fix can re-pin cities offline
- Exempts polecat from `TestNonDogStartupPromptsUseAssignedInProgressQuery`: since 0.1.10 polecat uses `gc hook --claim --json`, which checks assigned in-progress work internally via `hookClaimExistingOrAssigned`, so the explicit `{{ .AssignedInProgressQuery }}` template variable is no longer in the polecat startup prompt

Fixes: ga-smqzhf (Pack compatibility gate CI red), ga-yndfxn (Bundled gastown pack pin check CI red)

## Test plan

- [x] `python3 scripts/update-bundled-gastown-pack --check` passes
- [x] `go vet ./...` clean
- [x] `make test-fast-parallel` (all fast jobs) pass
- [x] Pre-commit hook passed (docsync, lint-changed, go vet, test-local-parallel fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)