### PR TITLE
feat(pool): make bdProbeTimeout configurable via GC_BD_PROBE_TIMEOUT

### DIFF
--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -52,7 +52,27 @@ type ScaleCheckRunner func(command, dir string, env map[string]string) (string, 
 // bdProbeTimeout is the timeout for bd subprocess probes (scale_check,
 // work_query). Generous to accommodate bd calls that serialize through
 // a shared dolt sql-server when many pool probes run in parallel.
-const bdProbeTimeout = 180 * time.Second
+// Override via GC_BD_PROBE_TIMEOUT (e.g. "30s"); floor is 5s.
+var bdProbeTimeout = parseBdProbeTimeout(os.Getenv("GC_BD_PROBE_TIMEOUT"))
+
+// parseBdProbeTimeout parses a duration string for bdProbeTimeout.
+// Empty string or invalid input returns the default (180s). Values below
+// the 5s floor are raised to the floor.
+func parseBdProbeTimeout(s string) time.Duration {
+	const defaultTimeout = 180 * time.Second
+	const minTimeout = 5 * time.Second
+	if s == "" {
+		return defaultTimeout
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return defaultTimeout
+	}
+	if d < minTimeout {
+		return minTimeout
+	}
+	return d
+}
 
 // hookTimeout is the timeout for lifecycle hook commands (on_death,
 // on_boot). Kept shorter than probe timeout because hooks run
@@ -80,7 +100,7 @@ func shellCommand(command, dir string, timeout time.Duration, env map[string]str
 }
 
 // shellScaleCheck runs a scale_check command via sh -c and returns stdout.
-// dir sets the command's working directory. Uses bdProbeTimeout (180s).
+// dir sets the command's working directory. Uses bdProbeTimeout.
 func shellScaleCheck(command, dir string, env map[string]string) (string, error) {
 	return shellCommand(command, dir, bdProbeTimeout, env)
 }

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
@@ -1321,6 +1322,28 @@ func TestShellScaleCheck_NoBEADS_DOLT_SERVER_PORT_Injection(t *testing.T) {
 	// level (PR #207), not in shellScaleCheck itself. See
 	// TestBuildDesiredState_PoolCheckInjectsDoltPortForRigScopedAgent
 	// for the integration test.
+}
+
+func TestParseBdProbeTimeout(t *testing.T) {
+	cases := []struct {
+		input string
+		want  time.Duration
+	}{
+		{"", 180 * time.Second},
+		{"30s", 30 * time.Second},
+		{"5m", 5 * time.Minute},
+		{"180s", 180 * time.Second},
+		{"1s", 5 * time.Second},  // below floor → raised to 5s
+		{"0s", 5 * time.Second},  // zero → floor
+		{"-1s", 5 * time.Second}, // negative → floor
+		{"not-a-duration", 180 * time.Second},
+	}
+	for _, c := range cases {
+		got := parseBdProbeTimeout(c.input)
+		if got != c.want {
+			t.Errorf("parseBdProbeTimeout(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
 }
 
 func runExternal(t *testing.T, dir, name string, args ...string) {

--- a/release-gates/ga-ab92m9-bd-probe-timeout-gate.md
+++ b/release-gates/ga-ab92m9-bd-probe-timeout-gate.md
@@ -1,0 +1,39 @@
+# Release Gate: ga-ab92m9 bd probe timeout
+
+Feature branch: `builder/ga-e4oku0-bd-probe-timeout`
+Reviewed head: `fe8c2b6dc104211f8e31673a58668d4a02c1c48f`
+Base: `origin/main` at `ca35aa9fb75931cbf3cf4b571f39e3643c057ae3`
+Deploy bead: `ga-ab92m9`
+Source bead: `ga-e4oku0`
+Review bead: `ga-7je8qa`
+
+## Summary
+
+This release makes the `cmd/gc` pool `bd` probe timeout configurable with
+`GC_BD_PROBE_TIMEOUT`. Production keeps the 180s default, invalid values fall
+back to 180s, and values below 5s are raised to a 5s floor. Review-formula
+integration cities set `GC_BD_PROBE_TIMEOUT=30s` so test subprocesses are less
+likely to stall for the full production timeout under CI load.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-7je8qa` is closed with `REVIEW PASS (gascity/reviewer, 2026-06-17)` and verdict `PASS`. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/pool.go` reads `GC_BD_PROBE_TIMEOUT`; empty/invalid input returns 180s; durations below 5s are floored to 5s; `test/integration/review_formula_test.go` injects `GC_BD_PROBE_TIMEOUT=30s`; `cmd/gc/pool_test.go` covers 8 parser cases. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed; `go vet ./...` passed; `go build ./cmd/gc/` passed; `go test ./cmd/gc -run TestParseBdProbeTimeout -count=1` passed; `make test-integration-review-formulas-basic` passed with `ok github.com/gastownhall/gascity/test/integration 286.255s`. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes report style clean, security no concerns, coverage complete, and no follow-up findings. No HIGH findings are listed in the deploy or review bead notes. |
+| 5 | Final branch is clean | PASS | Candidate checkout was clean before writing this gate file (`git status --short --branch` showed only detached HEAD state). This gate file is the only deployer change and is committed as the branch tip before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main fe8c2b6dc104211f8e31673a58668d4a02c1c48f` exited 0 and produced tree `0f62c46ec8077b13d5f3650e21669069800e91bd`. |
+| 7 | Single feature theme | PASS | Diff is limited to `cmd/gc/pool.go`, `cmd/gc/pool_test.go`, and review-formula test env injection for the same timeout knob. One commit: `fe8c2b6dc feat(pool): make bdProbeTimeout configurable via GC_BD_PROBE_TIMEOUT`. |
+
+## Diff Scope
+
+```text
+cmd/gc/pool.go                          | 24 ++++++++++++++++++++++--
+cmd/gc/pool_test.go                     | 23 +++++++++++++++++++++++
+test/integration/review_formula_test.go |  1 +
+3 files changed, 46 insertions(+), 2 deletions(-)
+```
+
+Gate verdict: PASS.

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -348,6 +348,7 @@ on_exhausted = "hard_fail"
 func setupReviewFormulaCity(t *testing.T, mode string, extraEnv map[string]string) string {
 	t.Helper()
 	env := newIsolatedCommandEnv(t, true)
+	env = append(env, "GC_BD_PROBE_TIMEOUT=30s")
 
 	var cityName string
 	if usingSubprocess() {


### PR DESCRIPTION
## What this changes

`gc` pool scale checks and `bd` work-query probes can now use `GC_BD_PROBE_TIMEOUT` instead of the hardcoded production timeout. Production behavior stays at 180s by default; invalid values fall back to that default, and values below 5s are raised to a 5s floor.

Review-formula integration cities set `GC_BD_PROBE_TIMEOUT=30s`, so CI runs that exercise pool respawn behavior fail faster under runner load instead of waiting through the full production probe timeout.

## Review notes

- The environment variable is parsed once at process startup in `cmd/gc/pool.go`.
- The lifecycle hook timeout is unchanged; this only affects `shellScaleCheck` and related `bd` probe calls.
- The new integration-test env value applies to scratch review-formula cities, not normal operator cities.

## Test plan

- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build ./cmd/gc/`
- [x] `go test ./cmd/gc -run TestParseBdProbeTimeout -count=1`
- [x] `make test-integration-review-formulas-basic`
- [x] Release gate: [`release-gates/ga-ab92m9-bd-probe-timeout-gate.md`](release-gates/ga-ab92m9-bd-probe-timeout-gate.md)