### PR TITLE
fix(wisp-autoclose): reap orphaned graph.v2 workflow root via input convoy

### DIFF
--- a/cmd/gc/wisp_autoclose.go
+++ b/cmd/gc/wisp_autoclose.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/sling"
@@ -67,6 +68,11 @@ func doWispAutocloseWith(store beads.Store, beadID string, stdout io.Writer) {
 		return
 	}
 	attachments, err := collectAttachedBeads(parent, store, beads.HandlesFor(store).Live)
+	seen := make(map[string]bool, len(attachments))
+	for _, attached := range attachments {
+		seen[attached.ID] = true
+	}
+	attachments = append(attachments, collectInputConvoyWorkflowRoots(store, parent, seen)...)
 	if err == nil || len(attachments) > 0 {
 		for _, attached := range attachments {
 			if attachedMoleculeIsParked(store, attached) {
@@ -116,6 +122,58 @@ func attachedMoleculeIsParked(store beads.Store, attached beads.Bead) bool {
 	}
 	terminal, _ := subtreeTerminalExcludingRoot(store, attached.ID)
 	return !terminal
+}
+
+// collectInputConvoyWorkflowRoots finds open graph.v2 workflow roots that were
+// dispatched over a synthetic input convoy tracking the just-closed bead. A
+// root-only in-session wisp -- mol-focus-review and peers routed to a pool --
+// runs every formula step in one worker session, so it materializes no step
+// beads and no workflow-finalize control bead to close its root. sling also
+// clears gc.source_bead_id for graph workflows (internal/sling/sling.go), so
+// such a wisp carries no source-bead attachment for collectAttachedBeads to
+// follow. Its only durable link back to the work issue is gc.input_convoy_id ->
+// the tracking convoy whose member is the issue. Without reaping the root here,
+// it outlives its closed issue, re-routes to the pool, and churns a fresh worker
+// (the gastownhall/gascity review-pool spawn-churn finalize-gap).
+//
+// This is discovery only: the caller runs each root through the shared
+// attachedMoleculeIsParked guard, so an orchestrated workflow whose step beads
+// are still in flight stays open and closes later via its workflow-finalize
+// control instead.
+func collectInputConvoyWorkflowRoots(store beads.Store, parent beads.Bead, seen map[string]bool) []beads.Bead {
+	convoys, err := convoycore.TrackingConvoysForItem(store, parent.ID)
+	if err != nil {
+		return nil
+	}
+	var roots []beads.Bead
+	for _, convoy := range convoys {
+		matches, err := store.ListByMetadata(
+			map[string]string{beadmeta.InputConvoyIDMetadataKey: convoy.ID},
+			0, beads.WithBothTiers,
+		)
+		if err != nil {
+			continue
+		}
+		for _, root := range matches {
+			if seen[root.ID] {
+				continue
+			}
+			if convoycore.IsTerminalStatus(root.Status) || !sourceworkflow.IsWorkflowRoot(root) {
+				continue
+			}
+			// Restrict to graph.v2 roots, matching the documented intent and
+			// formulaCookLiveInputConvoyGraphRoots: only graph workflows clear
+			// gc.source_bead_id and link back solely through gc.input_convoy_id,
+			// so a legacy gc.kind=workflow root is reaped via its source-bead
+			// attachment instead and must not be force-closed here.
+			if root.Metadata[beadmeta.FormulaContractMetadataKey] != "graph.v2" {
+				continue
+			}
+			seen[root.ID] = true
+			roots = append(roots, root)
+		}
+	}
+	return roots
 }
 
 func closeAttachedWispSubtree(store beads.Store, attached beads.Bead) (int, error) {

--- a/cmd/gc/wisp_autoclose_test.go
+++ b/cmd/gc/wisp_autoclose_test.go
@@ -556,6 +556,135 @@ func TestWispAutocloseMultipleMolecules(t *testing.T) {
 	}
 }
 
+func TestWispAutocloseClosesRootOnlyWispViaInputConvoy(t *testing.T) {
+	// Regression for the graph.v2 workflow-root finalize-gap (gastownhall/gascity
+	// review-pool spawn-churn): a root-only graph.v2 workflow wisp -- e.g.
+	// mol-focus-review routed to a pool -- runs every step in one worker session,
+	// so it materializes no step beads and no workflow-finalize control bead to
+	// close its root. sling clears gc.source_bead_id for graph workflows
+	// (sling.go), so the wisp carries NO source-bead attachment for
+	// collectAttachedBeads to follow. Its only durable link to the work issue is
+	// gc.input_convoy_id -> the synthetic tracking convoy whose member is the
+	// issue. When the formula's finalize step closes the issue, the on_close hook
+	// must reap the orphaned root via that input-convoy link; otherwise the open
+	// root re-routes to the pool and churns a fresh worker.
+	store := beads.NewMemStore()
+	issue, _ := store.Create(beads.Bead{Title: "work issue", Type: "task"}) // gc-1
+	convoy, _ := store.Create(beads.Bead{
+		Title:    "synthetic input convoy",
+		Type:     "convoy",
+		Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"},
+	}) // gc-2
+	if err := store.DepAdd(convoy.ID, issue.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+	root, _ := store.Create(beads.Bead{
+		Title: "mol-focus-review",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            "workflow",
+			beadmeta.FormulaContractMetadataKey: "graph.v2",
+			beadmeta.InputConvoyIDMetadataKey:   convoy.ID,
+			beadmeta.RoutedToMetadataKey:        "/home/ds/gascity/polecat",
+			"gc.var.issue":                      issue.ID,
+		},
+	}) // gc-3
+
+	_ = store.Close(issue.ID)
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, issue.ID, &stdout)
+
+	rootAfter, err := store.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if rootAfter.Status != "closed" {
+		t.Fatalf("root-only wisp status = %q, want closed (reaped via input convoy)", rootAfter.Status)
+	}
+	if !strings.Contains(stdout.String(), "Auto-closed workflow "+root.ID+" on "+issue.ID) {
+		t.Fatalf("stdout = %q, want workflow auto-close message", stdout.String())
+	}
+}
+
+func TestWispAutoclosePreservesOrchestratedWorkflowViaInputConvoyWhenStepsOpen(t *testing.T) {
+	// The input-convoy reap must not steamroll an orchestrated graph.v2 workflow
+	// whose step beads are still in flight: those roots close via their
+	// workflow-finalize control bead, not the on_close hook. The shared parked
+	// guard (subtreeTerminalExcludingRoot) keeps a root with a non-terminal
+	// descendant alive even when an input-convoy member closes early, so only the
+	// genuinely stepless root-only wisp reaps here.
+	store := beads.NewMemStore()
+	issue, _ := store.Create(beads.Bead{Title: "convoy member", Type: "task"})
+	convoy, _ := store.Create(beads.Bead{Title: "input convoy", Type: "convoy"})
+	if err := store.DepAdd(convoy.ID, issue.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+	root, _ := store.Create(beads.Bead{
+		Title: "orchestrated workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            "workflow",
+			beadmeta.FormulaContractMetadataKey: "graph.v2",
+			beadmeta.InputConvoyIDMetadataKey:   convoy.ID,
+		},
+	})
+	// An open step bead keeps the subtree non-terminal -> root stays parked.
+	_, _ = store.Create(beads.Bead{
+		Title:    "in-flight step",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+
+	_ = store.Close(issue.ID)
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, issue.ID, &stdout)
+
+	rootAfter, err := store.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if rootAfter.Status != "open" {
+		t.Fatalf("orchestrated workflow root status = %q, want open (left for workflow-finalize)", rootAfter.Status)
+	}
+}
+
+func TestWispAutocloseLeavesLegacyWorkflowRootViaInputConvoy(t *testing.T) {
+	// The input-convoy reap is graph.v2-only by contract: a legacy
+	// gc.kind=workflow root keeps its gc.source_bead_id attachment and is reaped
+	// via collectAttachedBeads, so it must not be force-closed through the
+	// input-convoy path. A root carrying only the legacy label (no
+	// gc.formula_contract=graph.v2) and an input-convoy link stays open here.
+	store := beads.NewMemStore()
+	issue, _ := store.Create(beads.Bead{Title: "work issue", Type: "task"})
+	convoy, _ := store.Create(beads.Bead{Title: "input convoy", Type: "convoy"})
+	if err := store.DepAdd(convoy.ID, issue.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+	root, _ := store.Create(beads.Bead{
+		Title: "legacy workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:          "workflow",
+			beadmeta.InputConvoyIDMetadataKey: convoy.ID,
+		},
+	})
+
+	_ = store.Close(issue.ID)
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, issue.ID, &stdout)
+
+	rootAfter, err := store.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if rootAfter.Status != "open" {
+		t.Fatalf("legacy workflow root status = %q, want open (not reaped via input convoy)", rootAfter.Status)
+	}
+}
+
 func TestWispAutocloseBeadNotFound(t *testing.T) {
 	store := beads.NewMemStore()
 


### PR DESCRIPTION

### Problem

A root-only graph.v2 workflow wisp — e.g. an in-session review formula routed
to a pool — runs every formula step in a single worker session. It therefore
materializes **no step beads** and **no `workflow-finalize` control bead**, so
nothing closes its workflow root. `sling` also clears `gc.source_bead_id` for
graph workflows, so the wisp carries no source-bead attachment for
`collectAttachedBeads` to follow. Its only durable link to the work issue is
`gc.input_convoy_id` → the synthetic tracking convoy whose member is the issue.

When the formula's finalize step closed the issue, the root stayed open,
re-routed to the pool hook, and churned a fresh worker — the review-pool
spawn-churn finalize-gap (PRs reviewed twice).

### Fix

`doWispAutocloseWith` now discovers open graph.v2 workflow roots via that
input-convoy link (`collectInputConvoyWorkflowRoots`) during the `on_close`
cascade and reaps them through the **existing** `attachedMoleculeIsParked`
guard. An orchestrated workflow whose step beads are still in flight stays open
and closes later via its `workflow-finalize` control, exactly as before.

Discovery is restricted to `gc.formula_contract=graph.v2`, mirroring the
sibling `formulaCookLiveInputConvoyGraphRoots`: a legacy `gc.kind=workflow`
root keeps its source-bead attachment and is reaped via `collectAttachedBeads`,
so it is deliberately **not** force-closed through the input-convoy path.

This extends the close-time finalize-defect lineage of #3474 / #3500 (which
preserve a molecule parked at a human-gate on owner-bead close) to the
root-only graph.v2 in-session shape those changes did not cover.

### Tests

- `TestWispAutocloseClosesRootOnlyWispViaInputConvoy` — fails before (root
  stays open) / passes after; asserts the root is closed and the auto-close
  message is emitted.
- `TestWispAutoclosePreservesOrchestratedWorkflowViaInputConvoyWhenStepsOpen` —
  an orchestrated root with an open step bead stays open (parked guard).
- `TestWispAutocloseLeavesLegacyWorkflowRootViaInputConvoy` — a legacy
  `gc.kind=workflow` root (no `graph.v2`) with an input-convoy link stays open
  (graph.v2-only contract).

### Verification

`make build`, `golangci-lint`, `go vet`, and the full `make check` suite
(`./...`, `-count=1`) all pass clean. `go test -race ./cmd/gc -run TestWispAutoclose`
passes. The only fast-parallel-shard flake observed
(`TestControllerReloadCommandReloadsConfigImmediately`, a timing test) passes
3/3 in isolation and is unrelated to this `cmd/gc` change.
