### PR TITLE
test(integration): increase reviewWorkflowTimeout 18→24 min (ga-8xg07a)

### DIFF
--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -17,12 +17,14 @@ import (
 
 // reviewWorkflowTimeout bounds waits for review-formula workflow beads to
 // close. Successful runs on CI average ~5 min per test, but runner variance
-// is high: the transient-retry test (soft-fail after 3 attempts) runs 3
-// full polecat cycles back-to-back, each ~3 min on a busy runner, plus
-// synthesis. The earlier 12-minute budget left no headroom and produced
-// intermittent timeout flakes; 18 min keeps a healthy margin for runner
-// contention without letting a genuinely stuck workflow loiter.
-const reviewWorkflowTimeout = 18 * time.Minute
+// is high: mol-personal-work-v2 has 18+ steps across two Ralph loops (6
+// polecat in design-review, 2 in code-review), taking ~20 min on busy
+// runners. The transient-retry tests add extra polecat cycles on top. The
+// earlier 12-minute budget produced intermittent flakes; 18 min still left
+// no headroom for personal-work and retry tests (~38 s from done at cutoff
+// in CI run 27788351365). 24 min leaves ~4 min margin while staying under
+// the 30-minute job ceiling.
+const reviewWorkflowTimeout = 24 * time.Minute
 
 // reviewWorkflowSlingTimeout only covers formula instantiation and convoy
 // routing. The personal-work graph is large enough that bd-backed graph apply


### PR DESCRIPTION
## Summary

- Raises `reviewWorkflowTimeout` from 18 to 24 minutes in `test/integration/review_formula_test.go`
- `mol-personal-work-v2` has 18+ steps across two Ralph loops (6 polecat in design-review, 2 in code-review); on busy CI runners this takes ~20 min wall-clock, leaving only ~38 s of margin at the cutoff
- The 6-min buffer gives headroom for busy runners while staying under the 30-min job ceiling

## Context

This fix was originally committed to `builder/ga-buw681` (PR #3584) but that PR is operator-gated on the compact-health env contracts. Splitting this out so the CI fix ships independently.

Fixes: ga-8xg07a, ga-jtjaiy, ga-0norj1

## Test plan

- [ ] CI passes on `test/integration/review_formula_test.go`
- [ ] No other changes — single-file, timeout constants only

🤖 Generated with [Claude Code](https://claude.com/claude-code)