### PR TITLE
fix(beads): exclude convoy beads from Ready() (#3591)

### DIFF
--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2326,7 +2326,7 @@ func TestBdStoreReadyDoesNotSpecialCaseSyntheticMetadata(t *testing.T) {
 	}{
 		`bd ready --json --limit 0`: {
 			out: []byte(`[
-				{"id":"bd-synthetic","title":"synthetic unit","status":"open","issue_type":"convoy","created_at":"2025-01-15T10:29:00Z","metadata":{"gc.synthetic":"true"}},
+				{"id":"bd-synthetic","title":"synthetic unit","status":"open","issue_type":"task","created_at":"2025-01-15T10:29:00Z","metadata":{"gc.synthetic":"true"}},
 				{"id":"bd-task","title":"ready one","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},
 				{"id":"bd-extra","title":"ready two","status":"open","issue_type":"task","created_at":"2025-01-15T10:31:00Z"}
 			]`),
@@ -2379,7 +2379,8 @@ func TestBdStoreReadyFiltersInfraTypes(t *testing.T) {
 		`bd ready --json --limit 0`: {
 			out: []byte(`[
 				{"id":"bd-task","title":"ready one","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},
-				{"id":"bd-session","title":"infra session","status":"open","issue_type":"session","created_at":"2025-01-15T10:31:00Z"}
+				{"id":"bd-session","title":"infra session","status":"open","issue_type":"session","created_at":"2025-01-15T10:31:00Z"},
+				{"id":"bd-convoy","title":"sling convoy","status":"open","issue_type":"convoy","created_at":"2025-01-15T10:32:00Z"}
 			]`),
 		},
 	})

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -179,6 +179,7 @@ var readyExcludeTypes = map[string]bool{
 	"gate":          true, // async wait conditions
 	"molecule":      true, // workflow containers
 	"step":          true, // non-root formula steps; parent molecule is the actionable unit (#1039)
+	"convoy":        true, // sling-minted container; groups child beads, never actionable Ready work (#3591)
 	"message":       true, // mail/communication items
 	"session":       true, // runtime/session continuity beads, never actionable work
 	"agent":         true, // identity/state tracking beads
@@ -235,9 +236,16 @@ func IsReadyCandidateForTier(b Bead, now time.Time, tier TierMode) bool {
 // IsReadyExcludedBead reports whether a bead is infrastructure rather than
 // actionable Ready work.
 func IsReadyExcludedBead(b Bead) bool {
-	if IsReadyExcludedType(b.Type) {
-		return true
-	}
+	return IsReadyExcludedType(b.Type) || HasReadyExcludedLabel(b)
+}
+
+// HasReadyExcludedLabel reports whether a bead carries a label that marks it
+// as infrastructure bookkeeping (session continuity, order tracking) rather
+// than actionable Ready work. Distinct from IsReadyExcludedType: a bead may be
+// label-excluded regardless of its type. Callers that have already constrained
+// the bead's type (e.g. iterating known-convoy beads) use this to test only
+// the label dimension.
+func HasReadyExcludedLabel(b Bead) bool {
 	for _, label := range b.Labels {
 		switch label {
 		case "gc:session", "gc:order-tracking", "order-tracking":

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -60,13 +60,13 @@ func TestIsReadyExcludedType(t *testing.T) {
 		{"gate", true},
 		{"molecule", true},
 		{"step", true},
+		{"convoy", true}, // container type; never actionable Ready work (#3591)
 		{"message", true},
 		{"session", true},
 		{"agent", true},
 		{"role", true},
 		{"rig", true},
 		{"task", false},
-		{"convoy", false},
 		{"wisp", false},
 		{"", false},
 		{"MOLECULE", false}, // case-sensitive

--- a/internal/beads/beadstest/conformance.go
+++ b/internal/beads/beadstest/conformance.go
@@ -596,7 +596,7 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 			t.Fatal(err)
 		}
 		// Create beads with types that bd ready excludes.
-		for _, typ := range []string{"molecule", "step", "message", "gate", "merge-request", "session", "agent", "role", "rig"} {
+		for _, typ := range []string{"molecule", "step", "convoy", "message", "gate", "merge-request", "session", "agent", "role", "rig"} {
 			if _, err := s.Create(beads.Bead{Title: typ, Type: typ}); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -364,7 +364,10 @@ func hasLiveTrackingConvoy(store beads.Store, itemID string) bool {
 		return false
 	}
 	for _, convoy := range convoys {
-		if beads.IsReadyExcludedBead(convoy) {
+		// These are convoys by construction, so the convoy type's Ready
+		// exclusion (#3591) does not apply here — only skip convoys excluded
+		// by infrastructure label (session/order-tracking bookkeeping).
+		if beads.HasReadyExcludedLabel(convoy) {
 			continue
 		}
 		if !convoycore.IsTerminalStatus(convoy.Status) {


### PR DESCRIPTION
## What

`gc sling <target> <bead>` mints a persistent `Type=convoy` bead (`sling-<beadid>`) per invocation. The bead type `convoy` was omitted from `readyExcludeTypes` (`internal/beads/beads.go`), so every open convoy flooded `bd ready` and pool-demand queries. Observed in production: 30 stray convoys flooded the Elder rig's `bd ready`.

Sibling container types `molecule` and `step` are already excluded; `convoy` was not, even though `IsContainerType("convoy")` returns true and a convoy is never itself actionable Ready work.

This adds `"convoy": true` to `readyExcludeTypes`.

## Single source of truth (verified)

`readyExcludeTypes` is the only gascity-owned exclusion list. All consumers derive from it, so the one-line map edit fixes every path:

- candidate path: `IsReadyCandidateForTier` → `IsReadyExcludedBead` → `IsReadyExcludedType` → `readyExcludeTypes`
- doltlite SQL store: `doltliteIssueTypeNotInPredicate` iterates `readyExcludeTypes` to build the `NOT IN (...)` predicate
- native dolt store: `Ready()` pre-filters with external `beadslib.GetReadyWork` (`github.com/steveyegge/beads`), then post-filters every result through `IsReadyCandidateForTier` — so convoy is excluded regardless of upstream `beadslib` behavior
- the `bd ready` CLI bridge (`cmd/gc/cmd_bd_store_bridge.go`) routes through `store.Ready()` and inherits the fix

No second hardcoded `["molecule","step",...]` exclusion list exists in the repo.

## Follow-on fix

`hasLiveTrackingConvoy` (sling idempotency, `internal/sling/sling_attachment.go`) skipped convoys via `IsReadyExcludedBead`. That call previously meant "label-excluded"; with convoy now a type-excluded type it would mean "always true," nullifying the idempotency guard and breaking re-sling detection. Extracted `HasReadyExcludedLabel` (label-only) and used it there, since those beads are convoys by construction and the type exclusion does not apply. This is behavior-preserving for the original intent (skip session/order-tracking label-excluded convoys).

## Tests

- `TestIsReadyExcludedType` (unit) now asserts `convoy` is excluded; `molecule`/`step` retained as positive controls.
- `beadstest` `ReadyExcludesInfraTypes` conformance case (runs against all store implementations) now includes a convoy bead and asserts it is excluded at the `Ready()` level.
- `TestBdStoreReadyFiltersInfraTypes` gains a convoy positive-control row.
- Both new assertions failed before the map edit and pass after.

`go test ./internal/beads/...` passes. sling / convoy / molecule / dispatch / api and the cmd/gc convoy-dispatch + ready tests all pass. `go vet` clean.

Closes #3591

🤖 Generated with [Claude Code](https://claude.com/claude-code)