### PR TITLE
fix(ci): raise review-formulas shard timeout

### DIFF
--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -146,7 +146,7 @@ jobs:
       - gate
     if: needs.gate.outputs.run_shard == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/release-gates/ga-hvt04d-review-formulas-timeout-gate.md
+++ b/release-gates/ga-hvt04d-review-formulas-timeout-gate.md
@@ -1,0 +1,52 @@
+# Release Gate: ga-hvt04d review-formulas timeout
+
+Bead: ga-hvt04d  
+Source review bead: ga-xx5xan  
+Reviewed commit: 40de01b5658fb1ce00056df3e16bbba6355c47ba  
+Feature branch: builder/ga-ftgzxd  
+Gate date: 2026-06-19
+
+## Scope
+
+Single-bead deploy for a CI workflow timeout fix. The reviewed change updates
+`.github/workflows/review-formulas.yml` so the `review-formulas-shard` job has
+`timeout-minutes: 45` instead of `30`.
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses
+the release criteria from the deployer prompt and the bead's explicit
+build/smoke instruction.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-xx5xan` reports `REVIEWER VERDICT: PASS (2026-06-19T11:15:12Z)` for commit `40de01b5658fb1ce00056df3e16bbba6355c47ba`. |
+| 2 | Acceptance criteria met | PASS | `git diff origin/main..HEAD -- .github/workflows/review-formulas.yml` shows exactly one behavior change: `timeout-minutes: 30` -> `timeout-minutes: 45` for `review-formulas-shard`. This restores headroom above the 24 minute internal shard timeout described in the bead. |
+| 3 | Tests pass | PASS | `make build` passed, producing `bin/gc` from commit `40de01b56`; `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/review-formulas.yml"))'` passed; `./scripts/test-integration-shard review-formulas-basic-2-of-2` passed with `ok github.com/gastownhall/gascity/test/integration 104.569s`. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-xx5xan` list no findings: style clean, security no impact, coverage not required for a CI config change, confidence HIGH. |
+| 5 | Final branch is clean | PASS | After committing the gate file, `git status --short --branch` reported `## HEAD (no branch)` with no modified or untracked files. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree --messages origin/main HEAD` returned merged tree `cf3899d332447c76432fe453101a863226c59d32` with no conflict messages. |
+| 7 | Single feature theme | PASS | Commit set touches only `.github/workflows/review-formulas.yml` and changes one CI job timeout for the review-formulas shard. |
+
+## Commands Run
+
+```text
+bd show ga-hvt04d
+bd show ga-xx5xan
+git fetch origin main
+git fetch fork builder/ga-ftgzxd
+git show --stat --oneline 40de01b5658fb1ce00056df3e16bbba6355c47ba
+git diff --name-status origin/main..40de01b5658fb1ce00056df3e16bbba6355c47ba
+git merge-tree --write-tree --messages origin/main 40de01b5658fb1ce00056df3e16bbba6355c47ba
+make build
+python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/review-formulas.yml")); print("workflow yaml parse ok")'
+./scripts/test-integration-shard review-formulas-basic-2-of-2
+git diff --check origin/main..HEAD
+git status --short --branch
+git merge-tree --write-tree --messages origin/main HEAD
+```
+
+## Result
+
+PASS. Proceed to push the feature branch, open a PR, record the PR URL on
+`ga-hvt04d`, close the deploy bead, and route a merge request to mayor.


### PR DESCRIPTION
## What this changes

The `review-formulas-shard` GitHub Actions job now has a 45-minute job timeout instead of 30 minutes. The shard internal test timeout is 24 minutes, so the job has enough wall-clock margin to report the test result instead of GitHub cancelling the job first.

This only changes the CI workflow cap. It does not change which shards run, runner selection, test commands, or product/runtime behavior.

## Review notes

- Look at `.github/workflows/review-formulas.yml`; the behavioral diff is the `timeout-minutes` value on `review-formulas-shard`.
- This is default-on for that workflow job, but scoped to the existing review-formulas shard job.
- No Go code, generated files, or dashboard/API schema changes.

## Test plan

- [x] `make build`
- [x] PyYAML parse of `.github/workflows/review-formulas.yml`
- [x] `./scripts/test-integration-shard review-formulas-basic-2-of-2`
- [x] Release gate: [`release-gates/ga-hvt04d-review-formulas-timeout-gate.md`](release-gates/ga-hvt04d-review-formulas-timeout-gate.md)