### PR TITLE
test(integration): raise review workflow timeout headroom

### DIFF
--- a/release-gates/ga-2t52hy-review-workflow-timeout-gate.md
+++ b/release-gates/ga-2t52hy-review-workflow-timeout-gate.md
@@ -1,0 +1,73 @@
+# Release Gate: Review Workflow Timeout Headroom
+
+Bead: `ga-2t52hy`
+
+Source review bead: `ga-j4l65h`
+
+Branch under review: `builder/ga-omnkls`
+
+Local deploy branch: `deploy/ga-2t52hy-review-workflow-timeout`
+
+Candidate head: `e8bff9069d40668345586c291c3e7bb99fb45f46`
+
+Current base checked: `origin/main` at `c1a5f331a396a9699bf9ef5db8d8bff4b751e34a`
+
+Merge base: `81579e6118e06506d1333e69366c0bc465bb3247`
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `ga-j4l65h` is closed with close reason `PASS: no findings`; notes contain `REVIEW VERDICT: PASS`, commit `e8bff9069`, and branch `builder/ga-omnkls`. |
+| 2 | Acceptance criteria met | PASS | `test/integration/review_formula_test.go` raises `reviewWorkflowTimeout` from 24 minutes to 35 minutes and documents the CI evidence and 45-minute shard ceiling headroom. The effective merge diff is limited to that timeout/comment change. |
+| 3 | Tests pass | PASS | `make build` passed. `go vet ./...` passed. `make test-integration-review-formulas` passed all three shards: basic `194.184s`, retries `298.716s`, recovery `54.438s`. `make test-fast-parallel` passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | Source review notes list no findings and explicitly state no blocking findings. No HIGH findings are recorded on `ga-j4l65h` or `ga-2t52hy`. |
+| 5 | Final branch is clean | PASS | Before writing this gate artifact, `git status --short --branch` showed a clean branch at `e8bff9069`. This artifact is the only deployer-authored file to be committed. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` exited 0 and produced tree `34fe62fbfcc8da922acd70eaf7e9d977a21b65f5`; no merge conflicts. `git diff --check origin/main..fork/builder/ga-omnkls` exited 0. |
+| 7 | Single feature theme | PASS | The effective merge diff is only `test/integration/review_formula_test.go`, and the change is one review-formulas integration timeout headroom adjustment. |
+
+## Scope Notes
+
+The branch is one commit ahead of its merge base:
+
+- `e8bff9069` raises `reviewWorkflowTimeout` from 24 minutes to 35 minutes.
+
+Current `origin/main` is ahead of the branch by newer work-record changes, so
+the two-dot tree diff includes unrelated files that are already on main. The
+actual PR merge surface was verified with both the merge tree and triple-dot
+diff:
+
+```bash
+MERGE_TREE=$(git merge-tree --write-tree HEAD origin/main)
+git diff --stat origin/main "$MERGE_TREE"
+git diff --name-only origin/main "$MERGE_TREE"
+git diff --stat origin/main...HEAD
+git diff --name-only origin/main...HEAD
+```
+
+Both views report only:
+
+```text
+test/integration/review_formula_test.go | 9 ++++++---
+1 file changed, 6 insertions(+), 3 deletions(-)
+```
+
+## Commands Run
+
+```bash
+gh auth status
+git fetch origin main
+git fetch fork builder/ga-omnkls:refs/remotes/fork/builder/ga-omnkls
+git diff --check origin/main..fork/builder/ga-omnkls
+git merge-tree --write-tree HEAD origin/main
+make build
+go vet ./...
+make test-integration-review-formulas
+make test-fast-parallel
+```
+
+## Decision
+
+Gate PASS. Push `builder/ga-omnkls`, open a PR to
+`gastownhall/gascity:main`, then route the merge-request to mayor/mpr. Do not
+merge from the deployer session.

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -22,9 +22,12 @@ import (
 // runners. The transient-retry tests add extra polecat cycles on top. The
 // earlier 12-minute budget produced intermittent flakes; 18 min still left
 // no headroom for personal-work and retry tests (~38 s from done at cutoff
-// in CI run 27788351365). 24 min leaves ~4 min margin while staying under
-// the 30-minute job ceiling.
-const reviewWorkflowTimeout = 24 * time.Minute
+// in CI run 27788351365). 24 min was insufficient on busy runners — both
+// personal-work and retry tests hit the ceiling with design-review-loop still
+// in progress (CI run 27823218494). 35 min gives ~15 min margin over the
+// ~20 min busy-runner baseline; the review-formulas shard job ceiling is 45
+// min (#3593), leaving ~10 min headroom above this constant.
+const reviewWorkflowTimeout = 35 * time.Minute
 
 // reviewWorkflowSlingTimeout only covers formula instantiation and convoy
 // routing. The personal-work graph is large enough that bd-backed graph apply


### PR DESCRIPTION
## What this changes

The review-formulas integration tests now allow a single review workflow up to 35 minutes instead of 24 minutes. This gives the long personal-work and retry cases enough room on busy runners while staying below the 45-minute shard ceiling.

## Review notes

- The change is limited to `test/integration/review_formula_test.go`.
- No production code, workflow dispatch logic, or CI routing changes are included.
- The comment above `reviewWorkflowTimeout` records the observed busy-runner baseline and the remaining shard headroom.

## Test plan

- [x] `make build`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] `make test-integration-review-formulas`
- [x] Release gate: [`release-gates/ga-2t52hy-review-workflow-timeout-gate.md`](release-gates/ga-2t52hy-review-workflow-timeout-gate.md)