### PR TITLE
fix(ci-mac): shard cmd/gc unit tests on Mac like Linux (ga-jfnpr8)

### DIFF
--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -186,8 +186,44 @@ jobs:
           dolt-version: ${{ env.DOLT_VERSION }}
           bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "false"
-      - name: Run make test
-        run: make test
+      - name: Run make test-mac
+        run: make test-mac
+
+  # cmd/gc unit/process tests — sharded 12-way so each shard comfortably fits
+  # the per-shard timeout even on slower Mac ARM runners. Mirrors the Linux
+  # cmd-gc-process matrix in ci.yml. cmd/gc is excluded from mac-unit's
+  # make test-mac sweep; coverage is preserved here across all 12 shards.
+  mac-cmd-gc-process:
+    name: Mac / cmd-gc process / shard ${{ matrix.shard }} of 12
+    needs: runner-policy
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !github.event.pull_request.draft &&
+        contains(github.event.pull_request.labels.*.name, 'needs-mac')
+      )
+    runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-gascity-macos
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "false"
+      - name: Run cmd/gc process shard
+        run: make test-cmd-gc-process-shard CMD_GC_PROCESS_SHARD=${{ matrix.shard }} CMD_GC_PROCESS_TOTAL=12
 
   # Tier A acceptance — smoke-level gate on every PR.
   mac-acceptance:
@@ -260,10 +296,10 @@ jobs:
           install-claude-cli: "true"
       - name: Install tools
         run: make install-tools
-      - name: Run test-cover
+      - name: Run test-cover-mac
         id: cover
         continue-on-error: true
-        run: make test-cover
+        run: make test-cover-mac
       - name: Upload coverage artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -542,6 +578,7 @@ jobs:
       - runner-policy
       - mac-quality
       - mac-unit
+      - mac-cmd-gc-process
       - mac-acceptance
       - mac-cover
       - mac-integration-packages
@@ -554,6 +591,7 @@ jobs:
         env:
           QUALITY: ${{ needs.mac-quality.result }}
           UNIT: ${{ needs.mac-unit.result }}
+          CMD_GC: ${{ needs.mac-cmd-gc-process.result }}
           ACCEPTANCE: ${{ needs.mac-acceptance.result }}
           # Best-effort jobs: use outputs.outcome (not needs.*.result).
           COVER: ${{ needs.mac-cover.outputs.outcome || needs.mac-cover.result }}
@@ -568,9 +606,10 @@ jobs:
           | Job | Result |
           | --- | --- |
           | Mac / quality | ${QUALITY} |
-          | Mac / make test | ${UNIT} |
+          | Mac / make test-mac | ${UNIT} |
+          | Mac / cmd-gc process | ${CMD_GC} |
           | Mac / acceptance (Tier A) | ${ACCEPTANCE} |
-          | Mac / test-cover (best-effort) | ${COVER} |
+          | Mac / test-cover-mac (best-effort) | ${COVER} |
           | Mac / integration packages | ${INT_PACKAGES} |
           | Mac / integration bdstore (best-effort) | ${INT_BDSTORE} |
           | Mac / integration rest | ${INT_REST} |
@@ -578,7 +617,7 @@ jobs:
           EOF
 
           fail=0
-          for result in "$QUALITY" "$UNIT" "$ACCEPTANCE" "$INT_PACKAGES" "$INT_REST"; do
+          for result in "$QUALITY" "$UNIT" "$CMD_GC" "$ACCEPTANCE" "$INT_PACKAGES" "$INT_REST"; do
             # Skipped is acceptable (e.g. when run outside the needs-mac trigger set)
             case "$result" in
               success|skipped|"") ;;

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 endif
 endif
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-gomod-replace check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-gomod-replace check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-docker test-k8s test-cover test-cover-mac cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
 
 ## build: compile gc binary with version metadata
 build:
@@ -308,6 +308,14 @@ TEST_ENV = env -i \
 ## Wrapped in $(TEST_ENV) — see comment above for why.
 test: test-fsys-darwin-compile
 	$(TEST_ENV) GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 -timeout 15m ./...
+
+# MAC_UNIT_PKGS excludes cmd/gc from the Mac unit sweep; cmd/gc runs
+# sharded via the mac-cmd-gc-process CI matrix job instead.
+MAC_UNIT_PKGS = $(shell go list ./... | grep -v '/cmd/gc$$')
+
+## test-mac: Mac unit sweep with cmd/gc excluded; cmd/gc covered by the Mac sharded job.
+test-mac: test-fsys-darwin-compile
+	$(TEST_ENV) GC_FAST_UNIT=1 scripts/go-test-observable test-mac -- -p=4 -count=1 -timeout 15m $(MAC_UNIT_PKGS)
 
 LOCAL_TEST_JOBS ?= $(shell nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)
 
@@ -562,6 +570,11 @@ test-cover: test-fsys-darwin-compile
 		./scripts/test-go-test-shard ./cmd/gc "$$s" $(CMD_GC_COVER_TOTAL) || exit 1; \
 	done
 	./scripts/merge-coverprofiles coverage.txt coverage.noncmdgc.txt coverage.cmdgc.*.txt
+
+## test-cover-mac: Mac coverage sweep with cmd/gc excluded; cmd/gc runs via the Mac sharded job.
+## Running the full test-cover cmd/gc shards sequentially on Mac would exceed the 25m job cap.
+test-cover-mac: test-fsys-darwin-compile
+	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 10m -coverprofile=coverage.txt $(UNIT_COVER_PKGS_NONCMDGC)
 
 ## cover: run tests and show coverage report
 cover: test-cover

--- a/release-gates/ga-us16ah-mac-shard-cmd-gc-gate.md
+++ b/release-gates/ga-us16ah-mac-shard-cmd-gc-gate.md
@@ -1,0 +1,63 @@
+# Release Gate: Mac cmd/gc Sharding
+
+Gate evaluated: 2026-06-19T17:43:14Z
+
+Bead: ga-us16ah
+Source review bead: ga-zeeq0j
+PR: https://github.com/gastownhall/gascity/pull/3598
+Branch: fix/mac-shard-cmd-gc-ga-jfnpr8
+Reviewed head: ca87dd1c81f07effe89dbd85a94d23003364e2ff
+Current origin/main: b9288b2abddc1c5368713692f740cd2142c203af
+Merge base: fea30636527f24ea515e28d831b2751630ac5448
+
+## Candidate Scope
+
+Three-dot diff from `origin/main...HEAD`:
+
+- `.github/workflows/mac-regression.yml`
+- `Makefile`
+
+Commit set:
+
+- `ca87dd1c8 fix(ci-mac): shard cmd/gc unit tests on Mac (ga-jfnpr8)`
+
+The candidate is a single CI feature theme: Mac unit/coverage workflow split
+and 12-way `cmd/gc` process sharding to mirror the Linux command-gc process
+coverage pattern.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-zeeq0j` is closed with close reason `pass`. Notes include `REVIEWER VERDICT: PASS`, reviewed by `gascity/reviewer`, commit `ca87dd1c81f07effe89dbd85a94d23003364e2ff`, and `Blockers: None`. |
+| 2 | Acceptance criteria met | PASS | `Makefile` adds `test-mac` and `test-cover-mac`; `test-mac` excludes `cmd/gc` via `MAC_UNIT_PKGS`; `.github/workflows/mac-regression.yml` runs `make test-mac`, adds the 12-way `mac-cmd-gc-process` matrix, runs `make test-cover-mac`, and gates the Mac regression summary on `CMD_GC`. |
+| 3 | Tests pass | PASS | Local: `make build`, `go vet ./...`, `make test-fast-parallel`, `make test-mac`, and `make test-cmd-gc-process-shard CMD_GC_PROCESS_SHARD=1 CMD_GC_PROCESS_TOTAL=12` all exited 0. GitHub checks for PR #3598 are green, including all 12 Mac cmd/gc process shards, Mac acceptance, Mac quality, Mac test-cover, and Mac regression summary. |
+| 4 | No high-severity review findings open | PASS | Review bead `ga-zeeq0j` records no blockers. `gh pr view 3598 --json comments,reviews,latestReviews` returned no comments and no reviews, so there is no unresolved HIGH finding or external contributor engagement. |
+| 5 | Final branch is clean | PASS | `git status --short` returned no output before writing this gate artifact. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and printed `clean`; GitHub reports `mergeStateStatus=CLEAN`. |
+| 7 | Single feature theme | PASS | Three-dot diff is limited to `.github/workflows/mac-regression.yml` and `Makefile`; the one commit only changes Mac CI sharding/test target wiring. |
+
+## Local Command Evidence
+
+```text
+make build
+PASS: exited 0
+
+go vet ./...
+PASS: exited 0
+
+make test-fast-parallel
+PASS: All fast jobs passed
+
+make test-mac
+PASS: observable go test: PASS log=/tmp/gascity-test-mac.jsonl.YOyvMf
+
+make test-cmd-gc-process-shard CMD_GC_PROCESS_SHARD=1 CMD_GC_PROCESS_TOTAL=12
+PASS: exited 0
+```
+
+## Decision
+
+PASS. Open/update the PR for `fix/mac-shard-cmd-gc-ga-jfnpr8`, push this gate
+artifact to the PR branch, and route the merge request to mayor/mpr. Deployer
+does not merge.


### PR DESCRIPTION
## What this changes

The Mac regression workflow no longer runs the full `cmd/gc` process suite inside the unsharded Mac unit job. Instead, Mac unit and coverage jobs use Mac-specific Make targets that exclude `cmd/gc`, and `cmd/gc` runs through a dedicated 12-way Mac shard matrix that mirrors the Linux process-test pattern.

This keeps the same `cmd/gc` coverage while avoiding the single-package 15 minute timeout that made Mac regression runs unreliable on slower Mac ARM runners.

## Review notes

- `.github/workflows/mac-regression.yml` adds the `mac-cmd-gc-process` matrix and includes its result in the Mac regression summary gate.
- `Makefile` adds `test-mac` and `test-cover-mac`; both keep `cmd/gc` out of the broad Mac sweep so that package is covered by the shard matrix instead.
- No Go source behavior changes are included. Linux CI targets and non-Mac test entrypoints are unchanged.

## Test plan

- [x] `make build`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] `make test-mac`
- [x] `make test-cmd-gc-process-shard CMD_GC_PROCESS_SHARD=1 CMD_GC_PROCESS_TOTAL=12`
- [x] GitHub PR checks: all Mac cmd/gc shards and Mac regression summary green
- [x] Release gate: [`release-gates/ga-us16ah-mac-shard-cmd-gc-gate.md`](release-gates/ga-us16ah-mac-shard-cmd-gc-gate.md)
