### PR TITLE
feat(init): managed-Dolt pre-flight readiness wait (ga-o1exvf.1)

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -136,11 +136,9 @@ var (
 var (
 	initDirIfReadyEnsureBeadsProvider = ensureBeadsProvider
 	initDirIfReadyInitAndHookDir      = initAndHookDir
-	initDirIfReadyRetryDelay          = time.Second
+	initDirIfReadyWaitForManagedDolt  = waitForManagedDoltInitReady
 	initAndHookDirWaitForScopeReady   = waitForBeadsScopeReadyAfterRecovery
 )
-
-const initDirIfReadyRetryLimit = 2
 
 func isRetryableManagedDoltLifecycleError(err error) bool {
 	if err == nil {
@@ -292,31 +290,14 @@ func initDirIfReady(cityPath, dir, prefix string) (deferred bool, err error) {
 	return false, nil
 }
 
-func initDirIfReadyManagedDolt(cityPath, dir, prefix, provider string) error {
-	var err error
-	for attempt := 1; attempt <= initDirIfReadyRetryLimit; attempt++ {
-		if err = initDirIfReadyEnsureBeadsProvider(cityPath); err != nil {
-			err = fmt.Errorf("bead store: %w", err)
-		} else if err = initDirIfReadyInitAndHookDir(cityPath, dir, prefix); err == nil {
-			return nil
-		}
-		if attempt == initDirIfReadyRetryLimit || !shouldRetryInitDirIfReady(cityPath, provider, err) {
-			return err
-		}
-		time.Sleep(initDirIfReadyRetryDelay)
+func initDirIfReadyManagedDolt(cityPath, dir, prefix, _ string) error {
+	if err := initDirIfReadyEnsureBeadsProvider(cityPath); err != nil {
+		return fmt.Errorf("bead store: %w", err)
 	}
-	return err
-}
-
-func shouldRetryInitDirIfReady(cityPath, provider string, err error) bool {
-	if !providerUsesBdStoreContract(provider) || !cityUsesManagedDoltBeadsLifecycle(cityPath) {
-		return false
+	if err := initDirIfReadyWaitForManagedDolt(cityPath, managedDoltInitReadyTimeout); err != nil {
+		return err
 	}
-	owned, ownershipErr := managedDoltLifecycleOwned(cityPath)
-	if ownershipErr != nil || !owned {
-		return false
-	}
-	return isRetryableManagedDoltLifecycleError(err)
+	return initDirIfReadyInitAndHookDir(cityPath, dir, prefix)
 }
 
 func desiredScopeDoltConfigStateForInit(cityPath, dir, prefix string) (contract.ConfigState, bool, error) {

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -2867,11 +2867,14 @@ func TestDoRigAdd_AdoptWithBdContractInvokesInitAndHook(t *testing.T) {
 	// init path was invoked with the adopted rig dir.
 	origEnsure := initDirIfReadyEnsureBeadsProvider
 	origInit := initDirIfReadyInitAndHookDir
+	origWait := initDirIfReadyWaitForManagedDolt
 	t.Cleanup(func() {
 		initDirIfReadyEnsureBeadsProvider = origEnsure
 		initDirIfReadyInitAndHookDir = origInit
+		initDirIfReadyWaitForManagedDolt = origWait
 	})
 	initDirIfReadyEnsureBeadsProvider = func(_ string) error { return nil }
+	initDirIfReadyWaitForManagedDolt = func(_ string, _ time.Duration) error { return nil }
 
 	var initCalls []string
 	initDirIfReadyInitAndHookDir = func(_, dir, _ string) error {
@@ -2927,11 +2930,14 @@ func TestDoRigAdd_AdoptWithBdContractProvider_NonAdoptControlInvokesInit(t *test
 
 	origEnsure := initDirIfReadyEnsureBeadsProvider
 	origInit := initDirIfReadyInitAndHookDir
+	origWait := initDirIfReadyWaitForManagedDolt
 	t.Cleanup(func() {
 		initDirIfReadyEnsureBeadsProvider = origEnsure
 		initDirIfReadyInitAndHookDir = origInit
+		initDirIfReadyWaitForManagedDolt = origWait
 	})
 	initDirIfReadyEnsureBeadsProvider = func(_ string) error { return nil }
+	initDirIfReadyWaitForManagedDolt = func(_ string, _ time.Duration) error { return nil }
 
 	var initCalls []string
 	initDirIfReadyInitAndHookDir = func(_, dir, _ string) error {

--- a/cmd/gc/dolt_init_wait.go
+++ b/cmd/gc/dolt_init_wait.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// managedDoltInitReadyTimeout is the maximum time waitForManagedDoltInitReady
+// will block waiting for a running managed Dolt process to become TCP-reachable.
+var managedDoltInitReadyTimeout = 60 * time.Second
+
+// managedDoltInitReadyPollInterval is how often waitForManagedDoltInitReady
+// polls for runtime-state publication and TCP reachability.
+var managedDoltInitReadyPollInterval = 200 * time.Millisecond
+
+// Injectable function vars for unit testing.
+var (
+	managedDoltInitWaitIsManaged = cityUsesManagedDoltBeadsLifecycle
+	managedDoltInitWaitReadState = readValidProviderManagedDoltState
+	managedDoltInitWaitReachable = managedDoltTCPReachable
+	managedDoltInitWaitPidAlive  = pidAlive
+)
+
+// waitForManagedDoltInitReady blocks until the managed Dolt process for
+// cityPath is TCP-reachable, or timeout expires, or the process exits.
+//
+// Returns nil immediately when cityPath is not a managed-Dolt city, so
+// callers can invoke it unconditionally.
+//
+// Callers should use the production default via the package-level timeout var:
+//
+//	err := waitForManagedDoltInitReady(cityPath, managedDoltInitReadyTimeout)
+func waitForManagedDoltInitReady(cityPath string, timeout time.Duration) error {
+	if !managedDoltInitWaitIsManaged(cityPath) {
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = managedDoltInitReadyTimeout
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		state, ok := managedDoltInitWaitReadState(cityPath)
+		if ok && state.Port > 0 {
+			if state.PID > 0 && !managedDoltInitWaitPidAlive(state.PID) {
+				return fmt.Errorf("managed Dolt process (pid %d) exited before becoming TCP-ready", state.PID)
+			}
+			host := managedDoltConnectHost("")
+			port := strconv.Itoa(state.Port)
+			if managedDoltInitWaitReachable(host, port) {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			if ok && state.Port > 0 {
+				return fmt.Errorf("timed out after %s waiting for managed Dolt on port %d to become TCP-ready", timeout, state.Port)
+			}
+			return fmt.Errorf("timed out after %s waiting for managed Dolt runtime state to be published", timeout)
+		}
+		time.Sleep(managedDoltInitReadyPollInterval)
+	}
+}

--- a/cmd/gc/dolt_init_wait_test.go
+++ b/cmd/gc/dolt_init_wait_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubManagedDoltInitWait replaces the injectable functions used by
+// waitForManagedDoltInitReady for the duration of a test.
+type stubManagedDoltInitWait struct {
+	isManaged bool
+	state     doltRuntimeState
+	stateOK   bool
+	reachable bool
+	pidAlive  bool
+}
+
+func (s *stubManagedDoltInitWait) install(t *testing.T) {
+	t.Helper()
+	prevIsManaged := managedDoltInitWaitIsManaged
+	prevReadState := managedDoltInitWaitReadState
+	prevReachable := managedDoltInitWaitReachable
+	prevPidAlive := managedDoltInitWaitPidAlive
+
+	managedDoltInitWaitIsManaged = func(_ string) bool { return s.isManaged }
+	managedDoltInitWaitReadState = func(_ string) (doltRuntimeState, bool) { return s.state, s.stateOK }
+	managedDoltInitWaitReachable = func(_, _ string) bool { return s.reachable }
+	managedDoltInitWaitPidAlive = func(_ int) bool { return s.pidAlive }
+
+	t.Cleanup(func() {
+		managedDoltInitWaitIsManaged = prevIsManaged
+		managedDoltInitWaitReadState = prevReadState
+		managedDoltInitWaitReachable = prevReachable
+		managedDoltInitWaitPidAlive = prevPidAlive
+	})
+}
+
+// --- waitForManagedDoltInitReady tests ---
+
+// Criterion: non-managed Dolt city — skip immediately, return nil.
+func TestWaitForManagedDoltInitReady_NonManaged(t *testing.T) {
+	stub := &stubManagedDoltInitWait{isManaged: false}
+	stub.install(t)
+	if err := waitForManagedDoltInitReady("any", 5*time.Second); err != nil {
+		t.Errorf("non-managed: want nil, got %v", err)
+	}
+}
+
+// Criterion: fast ready — TCP-reachable immediately, return nil.
+func TestWaitForManagedDoltInitReady_FastReady(t *testing.T) {
+	stub := &stubManagedDoltInitWait{
+		isManaged: true,
+		state:     doltRuntimeState{PID: 999, Port: 28231},
+		stateOK:   true,
+		reachable: true,
+		pidAlive:  true,
+	}
+	stub.install(t)
+	if err := waitForManagedDoltInitReady("any", 5*time.Second); err != nil {
+		t.Errorf("fast ready: want nil, got %v", err)
+	}
+}
+
+// Criterion: delayed ready — state/TCP not available at first, then appears.
+func TestWaitForManagedDoltInitReady_DelayedReady(t *testing.T) {
+	var calls atomic.Int32
+	prevIsManaged := managedDoltInitWaitIsManaged
+	prevReadState := managedDoltInitWaitReadState
+	prevReachable := managedDoltInitWaitReachable
+	prevPidAlive := managedDoltInitWaitPidAlive
+	t.Cleanup(func() {
+		managedDoltInitWaitIsManaged = prevIsManaged
+		managedDoltInitWaitReadState = prevReadState
+		managedDoltInitWaitReachable = prevReachable
+		managedDoltInitWaitPidAlive = prevPidAlive
+	})
+	managedDoltInitWaitIsManaged = func(_ string) bool { return true }
+	managedDoltInitWaitPidAlive = func(_ int) bool { return true }
+	managedDoltInitWaitReadState = func(_ string) (doltRuntimeState, bool) {
+		n := calls.Add(1)
+		if n < 3 {
+			return doltRuntimeState{}, false // state not ready yet
+		}
+		return doltRuntimeState{PID: 123, Port: 28231}, true
+	}
+	managedDoltInitWaitReachable = func(_, _ string) bool {
+		return calls.Load() >= 3
+	}
+
+	if err := waitForManagedDoltInitReady("any", 2*time.Second); err != nil {
+		t.Errorf("delayed ready: want nil, got %v", err)
+	}
+	if n := calls.Load(); n < 3 {
+		t.Errorf("expected at least 3 poll calls before ready, got %d", n)
+	}
+}
+
+// Criterion: missing port (state never published within timeout) — return error.
+func TestWaitForManagedDoltInitReady_MissingState_Timeout(t *testing.T) {
+	stub := &stubManagedDoltInitWait{
+		isManaged: true,
+		stateOK:   false, // port never published
+		reachable: false,
+		pidAlive:  true,
+	}
+	stub.install(t)
+
+	start := time.Now()
+	err := waitForManagedDoltInitReady("any", 80*time.Millisecond)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Error("expected error when state never published, got nil")
+	}
+	// Must have waited at least most of the timeout.
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("returned too fast: %v (want ≥50ms)", elapsed)
+	}
+}
+
+// Criterion: process exits before TCP-ready — return error quickly.
+func TestWaitForManagedDoltInitReady_ProcessExits(t *testing.T) {
+	stub := &stubManagedDoltInitWait{
+		isManaged: true,
+		state:     doltRuntimeState{PID: 9999999, Port: 28231},
+		stateOK:   true,
+		reachable: false, // TCP not ready
+		pidAlive:  false, // process exited
+	}
+	stub.install(t)
+
+	start := time.Now()
+	err := waitForManagedDoltInitReady("any", 5*time.Second)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Error("expected error when process exits, got nil")
+	}
+	// Should return quickly, not wait the full 5s.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("process-exit detection too slow: %v (want <500ms)", elapsed)
+	}
+}
+
+// Criterion: timeout cleanup — port published and process alive but TCP never ready.
+func TestWaitForManagedDoltInitReady_Timeout(t *testing.T) {
+	stub := &stubManagedDoltInitWait{
+		isManaged: true,
+		state:     doltRuntimeState{PID: 123, Port: 28231},
+		stateOK:   true,
+		reachable: false, // TCP never becomes ready
+		pidAlive:  true,
+	}
+	stub.install(t)
+
+	start := time.Now()
+	err := waitForManagedDoltInitReady("any", 80*time.Millisecond)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Error("expected timeout error, got nil")
+	}
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("returned too fast: %v (want ≥50ms block)", elapsed)
+	}
+}
+
+// Verify that managedDoltTCPReachable works correctly with a real socket.
+// This is an implementation sanity-check, not a wait test per se.
+func TestManagedDoltTCPReachable_RealSocket(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	addr := lis.Addr().String()
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if !managedDoltTCPReachable(host, port) {
+		t.Errorf("managedDoltTCPReachable(%q, %q) = false, want true", host, port)
+	}
+	if managedDoltTCPReachable(host, "1") {
+		t.Error("managedDoltTCPReachable on port 1 (no listener) = true, want false")
+	}
+}

--- a/cmd/gc/lifecycle_coordination_test.go
+++ b/cmd/gc/lifecycle_coordination_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -362,7 +363,7 @@ func TestLifecycleCoordination_InitDirIfReadySkipsProviderForPostgresCityAndRig(
 	}
 }
 
-func TestLifecycleCoordination_InitDirIfReady_RetriesTransientManagedDoltFailure(t *testing.T) {
+func TestLifecycleCoordination_InitDirIfReady_PropagatesManagedDoltInitFailure(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -372,14 +373,15 @@ func TestLifecycleCoordination_InitDirIfReady_RetriesTransientManagedDoltFailure
 
 	originalEnsure := initDirIfReadyEnsureBeadsProvider
 	originalInitAndHook := initDirIfReadyInitAndHookDir
-	originalDelay := initDirIfReadyRetryDelay
+	originalWait := initDirIfReadyWaitForManagedDolt
 	t.Cleanup(func() {
 		initDirIfReadyEnsureBeadsProvider = originalEnsure
 		initDirIfReadyInitAndHookDir = originalInitAndHook
-		initDirIfReadyRetryDelay = originalDelay
+		initDirIfReadyWaitForManagedDolt = originalWait
 	})
 
-	initDirIfReadyRetryDelay = 0
+	// Bypass the pre-flight wait; we're testing initAndHookDir error propagation.
+	initDirIfReadyWaitForManagedDolt = func(_ string, _ time.Duration) error { return nil }
 
 	var ensureCalls int
 	initDirIfReadyEnsureBeadsProvider = func(_ string) error {
@@ -390,28 +392,25 @@ func TestLifecycleCoordination_InitDirIfReady_RetriesTransientManagedDoltFailure
 	var initCalls int
 	initDirIfReadyInitAndHookDir = func(_, _, _ string) error {
 		initCalls++
-		if initCalls == 1 {
-			return fmt.Errorf("exec beads init: signal: terminated")
-		}
-		return nil
+		return fmt.Errorf("exec beads init: signal: terminated")
 	}
 
 	deferred, err := initDirIfReady(dir, dir, "gc")
-	if err != nil {
-		t.Fatalf("initDirIfReady() error = %v, want nil after retry", err)
+	if err == nil {
+		t.Fatal("initDirIfReady() error = nil, want propagated initAndHookDir failure")
 	}
 	if deferred {
 		t.Fatal("initDirIfReady() deferred = true, want false")
 	}
-	if ensureCalls != 2 {
-		t.Fatalf("ensureBeadsProvider calls = %d, want 2", ensureCalls)
+	if ensureCalls != 1 {
+		t.Fatalf("ensureBeadsProvider calls = %d, want 1", ensureCalls)
 	}
-	if initCalls != 2 {
-		t.Fatalf("initAndHookDir calls = %d, want 2", initCalls)
+	if initCalls != 1 {
+		t.Fatalf("initAndHookDir calls = %d, want 1 (no retry)", initCalls)
 	}
 }
 
-func TestLifecycleCoordination_InitDirIfReady_RetriesManagedDoltSchemaNotReady(t *testing.T) {
+func TestLifecycleCoordination_InitDirIfReady_PropagatesManagedDoltSchemaError(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -421,34 +420,32 @@ func TestLifecycleCoordination_InitDirIfReady_RetriesManagedDoltSchemaNotReady(t
 
 	originalEnsure := initDirIfReadyEnsureBeadsProvider
 	originalInitAndHook := initDirIfReadyInitAndHookDir
-	originalDelay := initDirIfReadyRetryDelay
+	originalWait := initDirIfReadyWaitForManagedDolt
 	t.Cleanup(func() {
 		initDirIfReadyEnsureBeadsProvider = originalEnsure
 		initDirIfReadyInitAndHookDir = originalInitAndHook
-		initDirIfReadyRetryDelay = originalDelay
+		initDirIfReadyWaitForManagedDolt = originalWait
 	})
 
-	initDirIfReadyRetryDelay = 0
+	// Bypass the pre-flight wait; we're testing initAndHookDir error propagation.
+	initDirIfReadyWaitForManagedDolt = func(_ string, _ time.Duration) error { return nil }
 	initDirIfReadyEnsureBeadsProvider = func(_ string) error { return nil }
 
 	var initCalls int
 	initDirIfReadyInitAndHookDir = func(_, _, _ string) error {
 		initCalls++
-		if initCalls == 1 {
-			return fmt.Errorf("bd list: exit status 1: table not found: issues")
-		}
-		return nil
+		return fmt.Errorf("bd list: exit status 1: table not found: issues")
 	}
 
 	deferred, err := initDirIfReady(dir, dir, "gc")
-	if err != nil {
-		t.Fatalf("initDirIfReady() error = %v, want nil after retry", err)
+	if err == nil {
+		t.Fatal("initDirIfReady() error = nil, want propagated schema error")
 	}
 	if deferred {
 		t.Fatal("initDirIfReady() deferred = true, want false")
 	}
-	if initCalls != 2 {
-		t.Fatalf("initAndHookDir calls = %d, want 2", initCalls)
+	if initCalls != 1 {
+		t.Fatalf("initAndHookDir calls = %d, want 1 (no retry)", initCalls)
 	}
 }
 
@@ -466,14 +463,10 @@ func TestLifecycleCoordination_InitDirIfReady_DoesNotRetryNonManagedProviderFail
 
 	originalEnsure := initDirIfReadyEnsureBeadsProvider
 	originalInitAndHook := initDirIfReadyInitAndHookDir
-	originalDelay := initDirIfReadyRetryDelay
 	t.Cleanup(func() {
 		initDirIfReadyEnsureBeadsProvider = originalEnsure
 		initDirIfReadyInitAndHookDir = originalInitAndHook
-		initDirIfReadyRetryDelay = originalDelay
 	})
-
-	initDirIfReadyRetryDelay = 0
 
 	var ensureCalls int
 	initDirIfReadyEnsureBeadsProvider = func(_ string) error {


### PR DESCRIPTION
## Summary

- Replaces the 2-attempt retry loop in `initDirIfReadyManagedDolt` with a true blocking wait (`waitForManagedDoltInitReady`) that polls for port publication then TCP reachability — eliminating the startup race without spurious retries
- Detects early process exit and returns a fast, actionable error instead of timing out the full 60s window
- All injectable: `initDirIfReadyWaitForManagedDolt`, `managedDoltInitWaitIsManaged/ReadState/Reachable/PidAlive` — unit tests mock freely; existing `cmd_rig_test.go` tests updated to inject the no-op bypass

## Test plan

- [ ] `TestWaitForManagedDoltInitReady_*` (7 cases): non-managed skip, fast-ready, delayed-ready, missing-state timeout, process-exit fast-return, TCP timeout, real-socket sanity
- [ ] `TestLifecycleCoordination_InitDirIfReady_Propagates*` (2 renamed tests): verify error propagation with no retry
- [ ] `TestDoRigAdd_AdoptWithBdContract*` (2 tests): confirmed no longer block 60s
- [ ] `make test-fast-parallel` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)