### PR TITLE
fix(dolt): reject 19-digit ns reading in latency now_ms guard

### DIFF
--- a/examples/bd/dolt/assets/scripts/latency.sh
+++ b/examples/bd/dolt/assets/scripts/latency.sh
@@ -8,13 +8,17 @@
 # producing false latency WARNs (and MEDIUM advisory mail) at a 1s threshold.
 
 # _now_ms_plausible VALUE — exit 0 when VALUE looks like an epoch-millisecond
-# reading: all digits, at least 13 of them (epoch-ms is 13 digits from
-# 2001-09-09 through 2286-11-20).
+# reading: all digits, 13 or 14 of them (epoch-ms is 13 digits from 2001-09-09
+# through 2286-11-20, 14 thereafter). The upper bound rejects a 19-digit
+# epoch-NANOSECOND reading, which a 'date +%s%3N' that ignores the %3 width
+# (some coreutils builds, e.g. WSL2) emits — otherwise it would pass as ms and
+# inflate latency ~1e6×, falsely tripping the advisory threshold. Over-long
+# readings fall through to the perl/python3 fallbacks, which return real ms.
 _now_ms_plausible() {
   case "${1:-}" in
     ''|*[!0-9]*) return 1 ;;
   esac
-  [ "${#1}" -ge 13 ]
+  [ "${#1}" -ge 13 ] && [ "${#1}" -le 14 ]
 }
 
 # now_ms — echo the current time in epoch milliseconds.

--- a/test/dolt/latency_test.sh
+++ b/test/dolt/latency_test.sh
@@ -87,6 +87,36 @@ else
   echo "SKIP: neither perl nor python3 on PATH; cannot exercise sub-second fallbacks"
 fi
 
+# A PATH shim emulates a coreutils 'date' that ignores the %3 width in
+# '+%s%3N' (observed: WSL2): %N emits all 9 nanosecond digits, yielding a
+# 19-digit all-digit value. The lower-bound-only plausibility guard accepted
+# it as epoch-ms (~1e6x inflated latency); the upper bound now rejects it, so
+# the perl/python3 fallback must still produce a sub-second reading.
+mkdir -p "$SHIM_DIR/wsl"
+cat > "$SHIM_DIR/wsl/date" <<EOF
+#!/bin/sh
+if [ "\${1:-}" = "+%s%3N" ]; then
+  printf '%s%09d\n' "\$("$REAL_DATE" +%s)" 0
+else
+  exec "$REAL_DATE" "\$@"
+fi
+EOF
+chmod +x "$SHIM_DIR/wsl/date"
+
+if command -v perl >/dev/null 2>&1 || command -v python3 >/dev/null 2>&1; then
+  d=$( (
+    PATH="$SHIM_DIR/wsl:$PATH"; export PATH
+    s=$(now_ms); sleep 0.05; e=$(now_ms); echo $((e - s))
+  ) )
+  if [ "$d" -ge 5 ] && [ "$d" -le 800 ]; then
+    pass "WSL-date shim: 19-digit ns rejected, perl/python3 fallback keeps sub-second resolution (${d}ms)"
+  else
+    bad "WSL-date shim: got ${d}ms for a 50ms sleep, want 5..800 (19-digit ns accepted as ms)"
+  fi
+else
+  echo "SKIP: neither perl nor python3 on PATH; cannot exercise sub-second fallbacks"
+fi
+
 # With GNU date, perl, and python3 all unavailable, now_ms must degrade to
 # whole seconds (a plausible epoch reading ending in 000) rather than emit
 # garbage or crash.


### PR DESCRIPTION
## What

`examples/bd/dolt/assets/scripts/latency.sh` measures Dolt probe latency in
epoch-milliseconds. Its `_now_ms_plausible()` guard only checked a *lower*
length bound (`>= 13` digits), so on coreutils builds where `date +%s%3N`
ignores the `%3` field-width modifier (observed on WSL2) `%N` emits the full
9 nanosecond digits — a 19-digit value that passed the guard as if it were
epoch-milliseconds. `now_ms` then returned epoch-**nanoseconds** labeled "ms",
inflating measured latency ~1e6x and tripping a false `Dolt health advisory
[MEDIUM]` on every probe while the data plane was healthy.

This adds an upper length bound (`<= 14`; epoch-ms is 13 digits now, 14 after
2286 per the file's own comment) so over-long nanosecond readings fall through
to the existing perl/python3 fallbacks, which return correct 13-digit
epoch-milliseconds.

## Why

Pure false positive — the same advisory-storm class `latency.sh` was written to
suppress, resurfacing through a different `date` quirk. The lower-bound-only
guard accepted any all-digit value of length >= 13, including the 19-digit
nanosecond form, so `LATENCY_MS` was computed in nanoseconds but compared
against a millisecond threshold.

## Test

Adds a WSL-style `date`-shim regression case to `test/dolt/latency_test.sh`,
mirroring the existing BSD-shim block: it emits a 19-digit all-digit value for
`+%s%3N` and asserts `now_ms` still measures a ~50ms sleep within the 5..800ms
band (i.e. the nanosecond reading is rejected and the perl/python3 fallback
wins). The case fails on the old guard and passes with the upper bound; the
existing cases stay green since the bound is a no-op for every value that
passes today.

Closes #3569.
