### PR TITLE
fix(ci): pin golangci-lint version in cache key — prevents SA5011 cache-version-mismatch (ga-kikn9h)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,13 +177,18 @@ jobs:
         run: make check-native-dependency-surface
       - name: Native DoltLite beads tests
         run: make test-native-doltlite-beads
+      - name: Get golangci-lint version for cache key
+        id: glint-version
+        run: |
+          version=$(grep -m1 '^GOLANGCI_LINT_VERSION := ' Makefile | awk '{print $3}')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Restore golangci-lint cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/golangci-lint
-          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          key: ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ hashFiles('go.sum', '.golangci.yml') }}
           restore-keys: |
-            ${{ runner.os }}-golangci-lint-
+            ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-
       - name: Lint
         env:
           GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -137,13 +137,18 @@ jobs:
           install-claude-cli: "false"
       - name: Install tools
         run: make install-tools
+      - name: Get golangci-lint version for cache key
+        id: glint-version
+        run: |
+          version=$(grep -m1 '^GOLANGCI_LINT_VERSION := ' Makefile | awk '{print $3}')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Restore golangci-lint cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/golangci-lint
-          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml', 'Makefile') }}
+          key: ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ hashFiles('go.sum', '.golangci.yml') }}
           restore-keys: |
-            ${{ runner.os }}-golangci-lint-
+            ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-
       - name: Lint
         env:
           GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint


### PR DESCRIPTION
## Summary

- Adds `GOLANGCI_LINT_VERSION` (read from Makefile at CI runtime) to the golangci-lint cache key in both `ci.yml` (Linux static checks) and `mac-regression.yml` (Mac quality)
- Updates `restore-keys` prefix to also include the version, preventing cross-version cache fallback
- Drops `Makefile` from `mac-regression.yml`'s golangci-lint cache hash (same fix #3596 applied to `ci.yml`)

## Why

The golangci-lint internal cache is keyed only on `go.sum` + `.golangci.yml`. When golangci-lint or its bundled staticcheck is upgraded, old cached analysis results from a different linter version can be restored, causing phantom SA5011 "possible nil pointer dereference" on 150 test patterns. Fresh runs produce no SA5011 (verified locally); the errors come only from the poisoned `4943fedd6` cache.

Including the binary version in the key ensures:
1. Upgrading golangci-lint in the Makefile automatically invalidates the cache
2. The current poisoned key (`Linux-golangci-lint-4943fedd6…`) is bypassed immediately — new key doesn't exist → cache miss → fresh correct analysis

## Test plan

- [ ] `Preflight / static checks` goes green on this PR (cache miss → clean fresh analysis)
- [ ] `Mac / quality` goes green (same fix)
- [ ] Verify new cache key format: `Linux-golangci-lint-2.9.0-<hash>` in run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)