### PR TITLE
fix(beads): retry transient BdStore read failures

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -248,7 +248,10 @@ type BdStore struct {
 	readyProjectionEnabled bool
 }
 
-const bdTransientWriteAttempts = 3
+const (
+	bdTransientWriteAttempts = 3
+	bdTransientReadAttempts  = 3
+)
 
 var _ ConditionalAssignmentReleaser = (*BdStore)(nil)
 
@@ -1728,6 +1731,25 @@ func (s *BdStore) runBDTransientWriteOutputWhen(shouldRetry func(error) bool, ar
 	return out, err
 }
 
+// runBDTransientRead runs a read-only bd command, retrying on transient Dolt
+// connection errors (invalid connection, broken pipe, etc.). Reads are
+// idempotent so retry is unconditional on isBdAmbiguousWriteError, with no
+// stable-ID guard needed.
+func (s *BdStore) runBDTransientRead(args ...string) ([]byte, error) {
+	var (
+		out []byte
+		err error
+	)
+	for attempt := 1; attempt <= bdTransientReadAttempts; attempt++ {
+		out, err = s.runner(s.dir, "bd", args...)
+		if err == nil || !isBdAmbiguousWriteError(err) || attempt == bdTransientReadAttempts {
+			return out, err
+		}
+		time.Sleep(time.Duration(attempt) * 50 * time.Millisecond)
+	}
+	return out, err
+}
+
 func (s *BdStore) bdTransientWriteArgs(args []string) []string {
 	if !s.isDoltliteBackend() {
 		return args
@@ -2059,7 +2081,7 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 		args = append(args, "--skip-labels")
 	}
 
-	out, err := s.runner(s.dir, "bd", args...)
+	out, err := s.runBDTransientRead(args...)
 	if err != nil {
 		return nil, fmt.Errorf("bd list: %w", err)
 	}
@@ -2342,7 +2364,7 @@ func (s *BdStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	q := readyQueryFromArgs(query)
 	includeEphemeral := q.TierMode == TierBoth || q.TierMode == TierWisps
 	args := bdReadyArgs(q, includeEphemeral)
-	out, err := s.runner(s.dir, "bd", args...)
+	out, err := s.runBDTransientRead(args...)
 	if err != nil {
 		return nil, fmt.Errorf("bd ready: %w", err)
 	}

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2215,6 +2215,45 @@ func TestBdStoreListIncludesInfra(t *testing.T) {
 	}
 }
 
+func TestBdStoreListRetriesOnInvalidConnection(t *testing.T) {
+	calls := 0
+	goodJSON := []byte(`[{"id":"bd-x","title":"t","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`)
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("begin read tx: invalid connection")
+		}
+		return goodJSON, nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen() error = %v, want nil after retry recovered", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListOpen() returned %d beads, want 1", len(got))
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2 (1 transient + 1 success)", calls)
+	}
+}
+
+func TestBdStoreListRetryBoundedReturnsErrorAfterExhaustion(t *testing.T) {
+	calls := 0
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		calls++
+		return nil, fmt.Errorf("begin read tx: invalid connection")
+	}
+	s := beads.NewBdStore("/city", runner)
+	_, err := s.ListOpen()
+	if err == nil {
+		t.Fatal("ListOpen() error = nil, want error after retries exhausted")
+	}
+	if calls < 2 {
+		t.Fatalf("calls = %d, want >= 2 (retry must be attempted)", calls)
+	}
+}
+
 // --- Ready ---
 
 func TestBdStoreReady(t *testing.T) {
@@ -4478,5 +4517,46 @@ func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testi
 				t.Fatalf("List() = %+v, want only %s after client filtering", got, tc.want)
 			}
 		})
+	}
+}
+
+// --- Read retry ---
+
+func TestBdStoreReadyRetriesOnInvalidConnection(t *testing.T) {
+	calls := 0
+	goodJSON := []byte(`[{"id":"bd-x","title":"t","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`)
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("begin read tx: invalid connection")
+		}
+		return goodJSON, nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.Ready()
+	if err != nil {
+		t.Fatalf("Ready() error = %v, want nil after retry recovered", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Ready() returned %d beads, want 1", len(got))
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2 (1 transient + 1 success)", calls)
+	}
+}
+
+func TestBdStoreReadyRetryBoundedReturnsErrorAfterExhaustion(t *testing.T) {
+	calls := 0
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		calls++
+		return nil, fmt.Errorf("begin read tx: invalid connection")
+	}
+	s := beads.NewBdStore("/city", runner)
+	_, err := s.Ready()
+	if err == nil {
+		t.Fatal("Ready() error = nil, want error after retries exhausted")
+	}
+	if calls < 2 {
+		t.Fatalf("calls = %d, want >= 2 (retry must be attempted)", calls)
 	}
 }

--- a/release-gates/ga-2f7a9j-bdstore-read-retry-gate.md
+++ b/release-gates/ga-2f7a9j-bdstore-read-retry-gate.md
@@ -1,0 +1,77 @@
+# Release Gate: BdStore Transient Read Retry
+
+Deploy bead: `ga-2f7a9j`
+
+Source implementation bead: `ga-53dcz7`
+
+Source review bead: `ga-8n54c3`
+
+Branch under review: `fix/bdstore-read-retry-ga-53dcz7`
+
+Candidate head: `1d3193a394db4e22dfedbc7955b079e68992f506`
+
+Current base checked: `origin/main` at `66c985638a94d1465190ae79518abc22c5b5a704`
+
+Merge base: `66c985638a94d1465190ae79518abc22c5b5a704`
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | Review bead `ga-8n54c3` is closed with close reason `pass`. Its notes contain `Review verdict: PASS`, identify branch `fix/bdstore-read-retry-ga-53dcz7`, and record reviewed commit `1d3193a394db4e22dfedbc7955b079e68992f506`. |
+| 2 | Acceptance criteria met | PASS | The diff adds bounded read retry via `runBDTransientRead`, uses the existing `isBdAmbiguousWriteError` transient classifier, wraps `listViaBDList()` and `Ready()`, and leaves `build_desired_state.go` untouched. `List*` callers are covered through `listViaBDList()`. Four dedicated tests cover List/Ready recovery and bounded exhaustion. |
+| 3 | Tests pass | PASS | `go test ./internal/beads -count=1` passed. The four new retry tests passed with `-count=5`. `go vet ./...` passed. Final `make test-fast-parallel` passed all 8 fast jobs. An earlier `make test-fast-parallel` attempt hit one isolated `TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand` timing failure; that test then passed `-count=20` on both this branch and current `origin/main`. |
+| 4 | No high-severity review findings open | PASS | Review notes list STYLE, SECURITY, SPEC COMPLIANCE, and COVERAGE as PASS. The only observations are non-blocking minor test-strength comments; no HIGH or blocking findings are open. |
+| 5 | Final branch is clean | PASS | Before writing this gate artifact, `git status --short --branch` showed a clean detached HEAD at `1d3193a394db4e22dfedbc7955b079e68992f506`. This artifact is the only deployer-authored file to be committed. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base origin/main HEAD` returned `66c985638a94d1465190ae79518abc22c5b5a704`, matching current `origin/main`. `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `d54dc42ab678bff9938a262d0efe561afe80efdd`. `git diff --check origin/main...HEAD` exited 0. |
+| 7 | Single feature theme | PASS | The effective code diff is scoped to `internal/beads/bdstore.go` and `internal/beads/bdstore_test.go`; it implements one BdStore reliability fix for transient Dolt read failures. |
+
+## Scope Notes
+
+The branch is one implementation commit on top of current `origin/main`:
+
+```text
+HEAD        1d3193a394db4e22dfedbc7955b079e68992f506
+origin/main 66c985638a94d1465190ae79518abc22c5b5a704
+merge-base  66c985638a94d1465190ae79518abc22c5b5a704
+```
+
+The effective diff is:
+
+```text
+internal/beads/bdstore.go      | 28 +++++++++++++--
+internal/beads/bdstore_test.go | 80 ++++++++++++++++++++++++++++++++++++++++++
+2 files changed, 105 insertions(+), 3 deletions(-)
+```
+
+`git diff --name-only origin/main...HEAD` reports only:
+
+```text
+internal/beads/bdstore.go
+internal/beads/bdstore_test.go
+```
+
+## Commands Run
+
+```bash
+gc hook
+gh auth status
+bd show ga-2f7a9j
+bd show ga-8n54c3
+bd show ga-53dcz7
+git fetch origin main fix/bdstore-read-retry-ga-53dcz7
+git diff --check origin/main...fix/bdstore-read-retry-ga-53dcz7
+git merge-tree --write-tree origin/main HEAD
+make test-fast-parallel
+go test ./internal/beads -run TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand -count=20
+go test ./internal/beads -run 'TestBdStore(ListRetriesOnInvalidConnection|ListRetryBoundedReturnsErrorAfterExhaustion|ReadyRetriesOnInvalidConnection|ReadyRetryBoundedReturnsErrorAfterExhaustion)$' -count=5
+go test ./internal/beads -count=1
+go vet ./...
+make test-fast-parallel
+```
+
+## Decision
+
+Gate PASS. Push `fix/bdstore-read-retry-ga-53dcz7`, open a scoped PR to
+`gastownhall/gascity:main`, then route the merge-request to mayor/mpr. Do not
+merge from the deployer session.


### PR DESCRIPTION
## What this changes

BdStore-backed read paths now retry transient Dolt connection failures before failing closed. This covers the `bd list` and `bd ready` calls used by controller demand and assigned-work probes, so a single `invalid connection` response no longer makes routed work look absent for that tick.

The retry is bounded and applies only to read commands, where the operation is idempotent. Persistent failures still return an error after the retry budget, preserving the existing fail-closed behavior.

## Review notes

- `runBDTransientRead` reuses the existing transient-error classifier rather than adding a new Dolt-specific path.
- `listViaBDList()` covers the List/ListByMetadata/ListByAssignee/ListByLabel family through the shared list implementation.
- `Ready()` wraps its bd command directly.
- No desired-state or wake logic changes are included.

## Test plan

- [x] `make test-fast-parallel`
- [x] `go test ./internal/beads -count=1`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-2f7a9j-bdstore-read-retry-gate.md`](release-gates/ga-2f7a9j-bdstore-read-retry-gate.md)

Internal tracking: ga-2f7a9j.