### PR TITLE
fix(ci): rename Review Formulas workflow display + deflake mail partial-success tests

### DIFF
--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -1,6 +1,4 @@
-name: CI
-# Keep the historical check name `CI / Integration / review-formulas` even
-# though the shard now lives in a dedicated workflow.
+name: Review Formulas
 
 on:
   push:

--- a/internal/api/handler_mail_test.go
+++ b/internal/api/handler_mail_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+// mailPartialReadTestDeadline is load-tolerant (2s vs 5ms); 5ms fails under CI CPU saturation (ga-97aayp).
+const mailPartialReadTestDeadline = 2 * time.Second
+
 type exactRecipientMailProvider struct {
 	messages map[string][]mail.Message
 }
@@ -556,7 +559,7 @@ func TestMailListAllRigsStoreSlowReturnsPartial(t *testing.T) {
 		},
 	}
 	oldDeadline := mailReadDeadline
-	mailReadDeadline = 5 * time.Millisecond
+	mailReadDeadline = mailPartialReadTestDeadline
 	t.Cleanup(func() {
 		mailReadDeadline = oldDeadline
 		close(release)
@@ -582,7 +585,7 @@ func TestMailListAllStatusStoreSlowReturnsPartial(t *testing.T) {
 		},
 	}
 	oldDeadline := mailReadDeadline
-	mailReadDeadline = 5 * time.Millisecond
+	mailReadDeadline = mailPartialReadTestDeadline
 	t.Cleanup(func() {
 		mailReadDeadline = oldDeadline
 		close(release)
@@ -608,7 +611,7 @@ func TestMailCountAllRigsStoreSlowReturnsPartial(t *testing.T) {
 		},
 	}
 	oldDeadline := mailReadDeadline
-	mailReadDeadline = 5 * time.Millisecond
+	mailReadDeadline = mailPartialReadTestDeadline
 	t.Cleanup(func() {
 		mailReadDeadline = oldDeadline
 		close(release)
@@ -744,7 +747,7 @@ func TestMailThreadAllRigsStoreSlowReturnsPartial(t *testing.T) {
 		},
 	}
 	oldDeadline := mailReadDeadline
-	mailReadDeadline = 5 * time.Millisecond
+	mailReadDeadline = mailPartialReadTestDeadline
 	t.Cleanup(func() {
 		mailReadDeadline = oldDeadline
 		close(release)


### PR DESCRIPTION
Two small CI/test reliability fixes surfaced by the recent CI audit:

1. **Rename the `review-formulas.yml` workflow display name** from "CI" to "Review Formulas". The duplicate "CI" display name (shared with `ci.yml`) was masking which workflow was actually red in the checks list.

2. **Deflake the mail partial-success tests.** `mailReadDeadline` was 5ms in 4 partial-success tests — too tight under CI CPU load, causing intermittent failures. Raised to 2s (well under the 8s production default), fixing the flake without masking real latency.

Both are isolated; no production behavior changes.
