### PR TITLE
fix(ci): parallelize preflight-unit-cover — split serial cmd/gc loop into 6 shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,13 +200,15 @@ jobs:
       - name: Docs
         run: make check-docs
 
-  preflight-unit-cover:
-    name: Preflight / unit cover
+  # Coverage reporting only matters on the main branch — codecov regression
+  # info doesn't need to gate every PR, and the full ./... unit suite is
+  # already covered by integration-shards, cmd-gc-process, and acceptance A.
+  # Split into two parallel push-only jobs to take the serial cmd/gc loop off
+  # the critical path (ga-29jlpr); Codecov merges uploads server-side.
+  preflight-unit-cover-noncmdgc:
+    name: Preflight / unit cover (noncmdgc)
     needs:
       - runner-policy
-    # Coverage reporting only matters on the main branch — codecov regression
-    # info doesn't need to gate every PR, and the full ./... unit suite is
-    # already covered by integration-shards, cmd-gc-process, and acceptance A.
     if: github.event_name == 'push'
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
@@ -221,12 +223,47 @@ jobs:
           install-claude-cli: "false"
       - name: Install tools
         run: make install-tools
-      - name: Test
-        run: make test-cover
+      - name: Unit cover (non-cmd/gc)
+        run: make test-cover-noncmdgc
       - name: Upload coverage to Codecov
+        if: hashFiles('coverage.noncmdgc.txt') != ''
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
-          files: coverage.txt
+          files: coverage.noncmdgc.txt
+          flags: unit-cover-noncmdgc
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+  preflight-unit-cover-cmdgc:
+    name: Preflight / unit cover (cmd/gc ${{ matrix.shard }} of 6)
+    needs:
+      - runner-policy
+    if: github.event_name == 'push'
+    runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
+    env:
+      DOLT_VERSION: "2.1.7"
+      BD_VERSION: "v1.0.5"
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "false"
+      - name: Install tools
+        run: make install-tools
+      - name: Unit cover (cmd/gc shard ${{ matrix.shard }} of 6)
+        run: make test-cover-cmdgc-shard CMD_GC_COVER_SHARD=${{ matrix.shard }} CMD_GC_COVER_TOTAL=6
+      - name: Upload coverage to Codecov
+        if: hashFiles(format('coverage.cmdgc.{0}.txt', matrix.shard)) != ''
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          files: coverage.cmdgc.${{ matrix.shard }}.txt
+          flags: unit-cover-cmdgc
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 endif
 endif
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-gomod-replace check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-docker test-k8s test-cover test-cover-mac cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-gomod-replace check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-docker test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
 
 ## build: compile gc binary with version metadata
 build:
@@ -358,6 +358,7 @@ test-cmd-gc-process:
 CMD_GC_PROCESS_SHARD ?= 1
 CMD_GC_PROCESS_TOTAL ?= 6
 CMD_GC_COVER_TOTAL ?= 6
+CMD_GC_COVER_SHARD ?= 1
 test-cmd-gc-process-shard:
 	$(TEST_ENV) GC_FAST_UNIT=0 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc $(CMD_GC_PROCESS_SHARD) $(CMD_GC_PROCESS_TOTAL)
 
@@ -575,6 +576,14 @@ test-cover: test-fsys-darwin-compile
 ## Running the full test-cover cmd/gc shards sequentially on Mac would exceed the 25m job cap.
 test-cover-mac: test-fsys-darwin-compile
 	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 10m -coverprofile=coverage.txt $(UNIT_COVER_PKGS_NONCMDGC)
+
+## test-cover-noncmdgc: run unit coverage for all packages except cmd/gc (CI parallel half).
+test-cover-noncmdgc:
+	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 10m -coverprofile=coverage.noncmdgc.txt $(UNIT_COVER_PKGS_NONCMDGC)
+
+## test-cover-cmdgc-shard: run unit coverage for one cmd/gc shard (CMD_GC_COVER_SHARD of CMD_GC_COVER_TOTAL).
+test-cover-cmdgc-shard:
+	$(TEST_ENV) GO_TEST_COVERPROFILE=coverage.cmdgc.$(CMD_GC_COVER_SHARD).txt GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=10m ./scripts/test-go-test-shard ./cmd/gc $(CMD_GC_COVER_SHARD) $(CMD_GC_COVER_TOTAL)
 
 ## cover: run tests and show coverage report
 cover: test-cover

--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ test-cover-mac: test-fsys-darwin-compile
 	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 10m -coverprofile=coverage.txt $(UNIT_COVER_PKGS_NONCMDGC)
 
 ## test-cover-noncmdgc: run unit coverage for all packages except cmd/gc (CI parallel half).
-test-cover-noncmdgc:
+test-cover-noncmdgc: test-fsys-darwin-compile
 	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 10m -coverprofile=coverage.noncmdgc.txt $(UNIT_COVER_PKGS_NONCMDGC)
 
 ## test-cover-cmdgc-shard: run unit coverage for one cmd/gc shard (CMD_GC_COVER_SHARD of CMD_GC_COVER_TOTAL).


### PR DESCRIPTION
## Summary

- Replaces the single `preflight-unit-cover` job (serial 6-shard cmd/gc loop, ~18 min pole) with two parallel push-only jobs:
  - `preflight-unit-cover-noncmdgc`: runs `test-cover-noncmdgc` (non-cmd/gc packages, ~7.5 min)
  - `preflight-unit-cover-cmdgc`: 6-way matrix, each shard runs `test-cover-cmdgc-shard` (~2-3 min/shard)
- Adds `CMD_GC_COVER_SHARD ?= 1`, `test-cover-noncmdgc`, and `test-cover-cmdgc-shard` Makefile targets
- Preserves `test-cover-mac` (landed in #3598) and the original `test-cover` local target unchanged
- Codecov receives one upload per shard; merges server-side (same pattern as review-formulas.yml shards)
- Neither new CI job is in the `check` or `ci-required` gate — no merge-blocking impact

## Test plan

- [ ] `go vet ./...` clean (no Go source changes)
- [ ] `make test-cover-noncmdgc` runs the non-cmd/gc package sweep locally
- [ ] `make test-cover-cmdgc-shard CMD_GC_COVER_SHARD=1 CMD_GC_COVER_TOTAL=6` runs shard 1
- [ ] CI: both new jobs appear in the push run; no existing jobs break
- [ ] Codecov receives uploads from both new jobs after merge to main

Closes: ga-29jlpr

🤖 Generated with [Claude Code](https://claude.com/claude-code)