### PR TITLE
docs(extmsg): add connected-client API guide and reference

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -187,6 +187,7 @@
               "guides/registry-showcase",
               "guides/gastown-config-recipes",
               "guides/using-json-from-gc",
+              "guides/connected-clients",
               "guides/multi-agent-engineering-environment"
             ]
           }

--- a/docs/guides/connected-clients.md
+++ b/docs/guides/connected-clients.md
@@ -1,0 +1,279 @@
+---
+title: Connect an external LLM client
+description: Register an external LLM client, open a reply stream, and send turns to a Gas City session over HTTP and SSE.
+---
+
+Gas City's external messaging API lets any HTTP client act as a participant in
+a city session — registering itself, opening a durable SSE reply stream, and
+sending turns that the session agent receives as inbound messages. This guide
+walks the full protocol: register → subscribe → send, plus reconnection and
+error handling.
+
+## Overview
+
+Three HTTP calls form the entire protocol:
+
+1. **Register** — `POST /v0/extmsg/clients` — obtain a bearer token that
+   identifies your client to the city.
+2. **Subscribe** — `GET /v0/extmsg/{provider}/{account_id}/{conversation_id}/subscribe`
+   — open a long-lived SSE stream to receive the session's replies.
+3. **Send** — `POST /v0/extmsg/inbound` (with `provider: "llm-client"`) —
+   deliver a turn from your client to the session.
+
+The subscribe stream stays open between turns. You send a turn via the inbound
+endpoint, and the session's reply arrives as an SSE `message` event on the
+already-open stream.
+
+## Prerequisites
+
+- A running city with external messaging enabled in `city.toml`:
+  ```toml
+  [extmsg]
+  enabled = true
+  ```
+- The session you want to connect must exist in the city's active config.
+- The `gc` supervisor must be reachable at its HTTP address (default: `http://localhost:7375`).
+
+## Step 1 — Register and get a client token
+
+```http
+POST /v0/extmsg/clients
+Content-Type: application/json
+X-GC-Request: 1
+
+{
+  "provider": "llm-client",
+  "display_name": "my-bot"
+}
+```
+
+**Response (201 Created):**
+
+```json
+{
+  "client_id": "lcl-a1b2c3d4",
+  "token": "eyJ..."
+}
+```
+
+Store the `client_id` and `token`. The `token` is a bearer credential used on
+the subscribe endpoint. The `client_id` appears as the `account_id` path segment
+in subscribe and inbound requests.
+
+Tokens do not expire automatically. An operator can revoke a token via the API
+or `city.toml` allowlist changes; your client receives a `token_revoked` SSE
+error event if this happens while a stream is open.
+
+## Step 2 — Subscribe to the reply stream
+
+Open the SSE stream before sending any turns, so you do not miss the reply:
+
+```http
+GET /v0/extmsg/llm-client/{account_id}/{conversation_id}/subscribe
+Authorization: Bearer {token}
+Accept: text/event-stream
+```
+
+Replace `{account_id}` with your `client_id` and `{conversation_id}` with any
+stable string identifying this conversation (e.g., a UUID you generate).
+
+**On success** the server responds `200 Content-Type: text/event-stream` and
+holds the connection open, emitting events as the session agent produces replies.
+
+Message events arrive as:
+
+```
+id: 42
+event: message
+data: {"version":"1","seq":42,"role":"assistant","content":"Hello from the session."}
+
+```
+
+The `id:` field is the sequence number of the last successfully delivered message.
+Pass it as `Last-Event-ID` on reconnect to resume from that point.
+
+## Step 3 — Send a turn
+
+Once the stream is open, deliver your turn:
+
+```http
+POST /v0/extmsg/inbound
+Content-Type: application/json
+X-GC-Request: 1
+
+{
+  "provider": "llm-client",
+  "account_id": "{account_id}",
+  "conversation_id": "{conversation_id}",
+  "content": "What is the status of the city?"
+}
+```
+
+The first inbound turn for a `(account_id, conversation_id)` pair implicitly
+creates the conversation binding. Subsequent turns reuse it.
+
+**Response (202 Accepted):** the turn has been queued. The session agent's
+reply will arrive on the SSE stream opened in Step 2.
+
+## Reconnecting after a drop
+
+If your SSE connection drops, reconnect by including `Last-Event-ID` with the
+sequence number of the last `message` event you received:
+
+```http
+GET /v0/extmsg/llm-client/{account_id}/{conversation_id}/subscribe
+Authorization: Bearer {token}
+Accept: text/event-stream
+Last-Event-ID: 42
+```
+
+The server replays all messages after sequence 42 before resuming live delivery.
+Error and heartbeat events do not advance the replay cursor and are not replayed.
+
+## Error catalog
+
+### HTTP errors — before the stream is established
+
+These are standard HTTP responses returned before the server commits
+`Content-Type: text/event-stream`.
+
+| Status | Code | Condition |
+|--------|------|-----------|
+| `401 Unauthorized` | `unauthorized` | Bearer token missing or unrecognized. |
+| `403 Forbidden` | `session_forbidden` | Token valid but not permitted to bind to the requested session. |
+| `404 Not Found` | `session_not_found` | Session name does not exist in the city's active config. |
+| `404 Not Found` | `binding_not_found` | ConversationRef presented but no binding exists; send a first inbound turn to create it. |
+| `503 Service Unavailable` | `extmsg_unavailable` | External messaging is not enabled, or the controller is not ready. |
+
+Error body shape:
+
+```json
+{
+  "code": "session_forbidden",
+  "message": "Token not authorized to bind to session 'mayor'."
+}
+```
+
+### SSE error events — after the stream is established
+
+Once the stream is open, errors arrive as SSE events:
+
+```
+id: error
+event: error
+data: {"version":"1","code":"session_stopped","message":"...","retryable":true,"retry_after_ms":5000}
+
+```
+
+`id: error` is a literal sentinel — it does not advance your replay cursor.
+
+| Code | Retryable | Retry hint | Trigger |
+|------|-----------|------------|---------|
+| `session_stopped` | yes | 5 000 ms | Session stopped cleanly; may restart. |
+| `session_not_found` | yes | 10 000 ms | Session removed from config while stream was open. |
+| `server_shutdown` | yes | 3 000 ms | Controller process shutting down; honor the SSE `retry:` field too. |
+| `idle_timeout` | yes | 0 ms | Idle stream closed (reserved; not active in v1). |
+| `token_revoked` | no | — | Operator revoked the token; re-register with `POST /v0/extmsg/clients`. |
+| `binding_removed` | no | — | Conversation binding removed; send a new inbound turn to recreate. |
+| `account_mismatch` | no | — | `account_id` in the URL does not match the token's `client_id`; programming error. |
+
+After emitting an error event the server closes the connection. For retryable
+codes, reconnect after the `retry_after_ms` hint (with exponential backoff).
+
+## Heartbeat
+
+The server emits a heartbeat every 30 s when no message or error has been sent:
+
+```
+event: heartbeat
+data: {"version":"1","ts":"2026-06-19T19:45:00Z"}
+
+```
+
+Heartbeats carry no `id:` field and do not advance the replay cursor. Use them
+to distinguish a quiet-but-alive connection from a truly dead one.
+
+## Configuration
+
+The `[extmsg]` section in `city.toml` controls the connected-client surface:
+
+```toml
+[extmsg]
+enabled = true
+
+# Optional: restrict which sessions connected clients may bind to.
+# If omitted, any session in the city is bindable.
+allowed_sessions = ["mayor", "deacon"]
+```
+
+Tokens issued before `allowed_sessions` is narrowed retain access until the
+controller reloads config; the next subscribe attempt will fail with
+`session_forbidden`.
+
+## Go example
+
+A minimal end-to-end example using `net/http`:
+
+```go
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const base = "http://localhost:7375"
+
+func main() {
+	// 1. Register.
+	regBody, _ := json.Marshal(map[string]string{
+		"provider":     "llm-client",
+		"display_name": "example-bot",
+	})
+	resp, _ := http.Post(base+"/v0/extmsg/clients", "application/json", bytes.NewReader(regBody))
+	var reg struct {
+		ClientID string `json:"client_id"`
+		Token    string `json:"token"`
+	}
+	json.NewDecoder(resp.Body).Decode(&reg)
+	resp.Body.Close()
+
+	accountID := reg.ClientID
+	convID := "conv-001"
+
+	// 2. Subscribe.
+	req, _ := http.NewRequest("GET",
+		fmt.Sprintf("%s/v0/extmsg/llm-client/%s/%s/subscribe", base, accountID, convID), nil)
+	req.Header.Set("Authorization", "Bearer "+reg.Token)
+	req.Header.Set("Accept", "text/event-stream")
+	stream, _ := http.DefaultClient.Do(req)
+
+	// 3. Send a turn.
+	inbound, _ := json.Marshal(map[string]string{
+		"provider":        "llm-client",
+		"account_id":      accountID,
+		"conversation_id": convID,
+		"content":         "Hello from the external client!",
+	})
+	sendReq, _ := http.NewRequest("POST", base+"/v0/extmsg/inbound",
+		bytes.NewReader(inbound))
+	sendReq.Header.Set("Content-Type", "application/json")
+	sendReq.Header.Set("X-GC-Request", "1")
+	http.DefaultClient.Do(sendReq)
+
+	// Read one reply event.
+	scanner := bufio.NewScanner(stream.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data:") {
+			fmt.Println("Reply:", strings.TrimPrefix(line, "data:"))
+			break
+		}
+	}
+	stream.Body.Close()
+}
+```

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -36,6 +36,14 @@ The spec is the full reference. A brief summary of the surfaces:
   query + hook operations, dependencies, labels.
 - **Sessions.** CRUD under `/v0/city/{cityName}/sessions`, submit,
   prompt, resume, interaction response, transcript, SSE stream.
+- **Connected-client external messaging.** `POST /v0/extmsg/clients`
+  registers an external LLM client and returns a bearer token.
+  `POST /v0/extmsg/inbound` (with `provider: "llm-client"`) delivers an
+  inbound turn from the registered client to a city session.
+  `GET /v0/extmsg/{provider}/{account_id}/{conversation_id}/subscribe`
+  opens a long-lived SSE reply stream for that conversation.
+  See [Connect an external LLM client](/guides/connected-clients) for
+  the full integration guide including the SSE error catalog.
 - **Mail, convoys, orders, formulas, participants,
   transcripts, adapters.** External messaging and orchestration
   surfaces; see the spec for per-operation shapes.

--- a/release-gates/ga-zy0p7n-connected-client-docs-gate.md
+++ b/release-gates/ga-zy0p7n-connected-client-docs-gate.md
@@ -1,0 +1,69 @@
+# Release Gate: ga-zy0p7n connected-client docs
+
+Result: PASS
+
+Date: 2026-06-19
+
+## Candidate
+
+- Bead: `ga-zy0p7n`
+- Title: `needs-deploy: connected-client API guide and reference docs`
+- Clean deploy branch: `deploy/ga-zy0p7n-connected-client-docs`
+- Base: `origin/main` at `ee9239f4311d9dbf4428db399e46377d680a9eaa`
+- Source branch: `builder/ga-omnkls`
+- Source commits evaluated:
+  - `a6c0c013c` - `docs(extmsg): add connected-client API guide and reference docs (ga-lyikvt.3)`
+  - `d8837b590` - `test: add connected-client docsync coverage`
+- Final branch commits before this gate file:
+  - `16087043d` - `docs(extmsg): add connected-client API guide and reference docs (ga-lyikvt.3)`
+  - `f9aae5157` - `test: add connected-client docsync coverage`
+
+## Changed Paths
+
+- `docs/docs.json`
+- `docs/guides/connected-clients.md`
+- `docs/reference/api.md`
+- `test/docsync/connected_clients_test.go`
+
+## Release Criteria Source
+
+`docs/PROJECT_MANIFEST.md` is not present in this repository. This gate applies
+the deployer release criteria, the Gas City docs verification guidance, and the
+repository testing guidance in `TESTING.md`.
+
+## Operational Hold Note
+
+These docs are spec-first. They document `POST /v0/extmsg/clients` and
+`GET /v0/extmsg/{provider}/{account_id}/{conversation_id}/subscribe` before the
+implementation for those endpoints is merged. The search surface for those
+paths is limited to the new docs and docsync coverage. Treat the PR as ready for
+review, but hold merge or docs publication until the connected-client transport
+implementation ships unless the operator intentionally wants docs ahead of code.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-90vojc` is closed and includes `## VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | Adds the connected-client guide, links it from `docs/docs.json`, extends the API reference, and adds docsync coverage for the guide, navigation entry, anchors, and API-reference links. The known implementation gap is explicitly recorded above. |
+| 3 | Tests pass | PASS | After rebasing onto `origin/main`: `make check-docs` PASS; `go test ./test/docsync -run 'TestConnectedClients'` PASS; `go vet ./...` PASS; `make test` PASS (`observable go test: PASS log=/tmp/gascity-test.jsonl.WiUgeg`). |
+| 4 | No high-severity review findings open | PASS | Review notes include only a low-severity example error-handling follow-up; no HIGH findings are open. |
+| 5 | Final branch is clean | PASS | `git config core.hooksPath` reports `.githooks`; `git status --short --branch` on the candidate branch was clean before adding this gate file. This gate file is committed as release evidence before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git fetch origin main` completed, then `git merge-tree --write-tree origin/main HEAD` returned tree `3a505e88b432cad533587b550b1f7bc8ef1c38e8` with exit 0. |
+| 7 | Single feature theme | PASS | The final branch touches only connected-client external messaging docs and their docsync coverage; the unrelated commits present on `builder/ga-omnkls` were excluded. |
+
+## Review Evidence
+
+- `ga-90vojc`: PASS review for the connected-client docs.
+- No external contributor interaction was observed on this deploy branch.
+- `gh auth status` passed for the authenticated deploy account before PR work.
+
+## Acceptance Notes
+
+- The guide covers registration, subscription, inbound message posting, callback
+  delivery, connection lifecycle, security notes, configuration, and a minimal
+  Go example.
+- The API reference covers the connected-client registration and subscribe
+  endpoints along with the existing inbound endpoint.
+- Docsync coverage locks the navigation and anchor surface so the public docs do
+  not drift from the reference links.

--- a/test/docsync/connected_clients_test.go
+++ b/test/docsync/connected_clients_test.go
@@ -1,0 +1,137 @@
+package docsync
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const connectedClientsGuidePage = "guides/connected-clients"
+
+func TestConnectedClientsGuideIsInGuidesNavigation(t *testing.T) {
+	root := repoRoot()
+	configPath := filepath.Join(root, "docs", "docs.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading docs.json: %v", err)
+	}
+
+	var decoded struct {
+		Navigation struct {
+			Groups []struct {
+				Group string `json:"group"`
+				Pages []any  `json:"pages"`
+			} `json:"groups"`
+		} `json:"navigation"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("parsing docs.json: %v", err)
+	}
+
+	for _, group := range decoded.Navigation.Groups {
+		if group.Group != "Guides" {
+			continue
+		}
+		if !containsMintPage(group.Pages, connectedClientsGuidePage) {
+			t.Fatalf("docs.json Guides navigation must include %q", connectedClientsGuidePage)
+		}
+		return
+	}
+
+	t.Fatalf("docs.json navigation is missing the Guides group")
+}
+
+func TestConnectedClientsAPIReferenceDocumentsEndpointFamily(t *testing.T) {
+	root := repoRoot()
+	path := filepath.Join(root, "docs", "reference", "api.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading docs/reference/api.md: %v", err)
+	}
+	text := string(data)
+
+	for _, endpoint := range []string{
+		"POST /v0/extmsg/clients",
+		"POST /v0/extmsg/inbound",
+		"GET /v0/extmsg/{provider}/{account_id}/{conversation_id}/subscribe",
+	} {
+		if !strings.Contains(text, endpoint) {
+			t.Errorf("docs/reference/api.md must document %s", endpoint)
+		}
+	}
+
+	if !providerLLMClientRE.MatchString(text) {
+		t.Errorf("docs/reference/api.md must state that POST /v0/extmsg/inbound uses provider llm-client")
+	}
+}
+
+func TestConnectedClientsGuideDocumentsRequiredSections(t *testing.T) {
+	root := repoRoot()
+	path := filepath.Join(root, "docs", connectedClientsGuidePage+".md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", filepath.ToSlash(filepath.Join("docs", connectedClientsGuidePage+".md")), err)
+	}
+
+	headings := markdownHeadings(string(data))
+	for _, section := range []struct {
+		name    string
+		pattern string
+	}{
+		{name: "register", pattern: "register"},
+		{name: "subscribe", pattern: "subscribe"},
+		{name: "send", pattern: "send"},
+		{name: "reconnect", pattern: "reconnect"},
+		{name: "error catalog", pattern: "error catalog"},
+		{name: "heartbeat", pattern: "heartbeat"},
+		{name: "configuration", pattern: "configuration"},
+	} {
+		if !hasHeadingContaining(headings, section.pattern) {
+			t.Errorf("%s must include a %q section heading", connectedClientsGuidePage+".md", section.name)
+		}
+	}
+}
+
+var (
+	headingRE           = regexp.MustCompile(`(?m)^#{1,6}\s+(.+)$`)
+	providerLLMClientRE = regexp.MustCompile(`(?is)provider\s*[:=]?\s*["']?llm-client`)
+)
+
+func containsMintPage(pages []any, want string) bool {
+	for _, page := range pages {
+		switch x := page.(type) {
+		case string:
+			if x == want {
+				return true
+			}
+		case map[string]any:
+			if nested, ok := x["pages"].([]any); ok && containsMintPage(nested, want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func markdownHeadings(content string) []string {
+	matches := headingRE.FindAllStringSubmatch(content, -1)
+	headings := make([]string, 0, len(matches))
+	for _, match := range matches {
+		heading := strings.TrimSpace(match[1])
+		heading = strings.Trim(heading, "`*_ ")
+		headings = append(headings, strings.ToLower(heading))
+	}
+	return headings
+}
+
+func hasHeadingContaining(headings []string, pattern string) bool {
+	for _, heading := range headings {
+		if strings.Contains(heading, pattern) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What this changes

Adds the connected-client external messaging guide and API reference surface for registering connected clients, receiving callback delivery, publishing inbound messages, and subscribing to outbound events. The docs navigation now exposes the guide under Guides > How-to, and docsync coverage keeps the page, anchors, and reference links in sync.

## Review notes

- Spec-first docs: `POST /v0/extmsg/clients` and the SSE subscribe endpoint are documented before their implementation is merged. `POST /v0/extmsg/inbound` already exists.
- This PR changes docs and docsync tests only; it does not change API handlers, OpenAPI schema, or generated clients.
- Hold merge or docs publication until the connected-client transport implementation lands unless the operator explicitly wants the docs published ahead of code.

## Test plan

- [x] `make check-docs`
- [x] `go test ./test/docsync -run 'TestConnectedClients'`
- [x] `go vet ./...`
- [x] `make test`
- [x] Release gate: [`release-gates/ga-zy0p7n-connected-client-docs-gate.md`](release-gates/ga-zy0p7n-connected-client-docs-gate.md)
