### PR TITLE
fix(ci): move integration-sqlite-coordstore from ci.yml to nightly.yml (ga-oa8173)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,33 +518,6 @@ jobs:
       - name: Run integration shard
         run: ${{ matrix.command }}
 
-  integration-sqlite-coordstore:
-    name: Integration / SQLite coordination store
-    needs:
-      - runner-policy
-      - changes
-    if: needs.changes.outputs.integration == 'true'
-    runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
-    timeout-minutes: 30
-    env:
-      DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.5"
-      GC_BEADS: sqlite
-      GC_ACCEPTANCE_BEADS_PROVIDER: sqlite
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/setup-gascity-ubuntu
-        with:
-          dolt-version: ${{ env.DOLT_VERSION }}
-          bd-version: ${{ env.BD_VERSION }}
-          install-claude-cli: "true"
-      - name: Install tools
-        run: make install-tools
-      - name: Integration tests (SQLite coordination store)
-        run: make test-integration-bdstore
-      - name: Acceptance tests (SQLite coordination store, Tier A)
-        run: make test-acceptance
-
   worker-core-claude:
     name: Worker core (Claude)
     needs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,6 +79,29 @@ jobs:
           go test -tags acceptance_c -timeout 45m -v ./test/acceptance/tier_c/...
           -run 'Test(BdCmdSeparatesStdoutAndStderrOnError|BdCmdReturnsPureStdoutOnSuccessfulJSONCommand|Swarm_SlingWorkCoderCommits|Gastown_PolecatLifecycle|Gastown_MayorDispatchPipeline|TierCEnvAuthDoesNotMirrorAuthTokenIntoAPIKey)$'
 
+  integration-sqlite-coordstore:
+    name: Integration / SQLite coordination store
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DOLT_VERSION: "2.1.7"
+      BD_VERSION: "v1.0.5"
+      GC_BEADS: sqlite
+      GC_ACCEPTANCE_BEADS_PROVIDER: sqlite
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Integration tests (SQLite coordination store)
+        run: make test-integration-bdstore
+      - name: Acceptance tests (SQLite coordination store, Tier A)
+        run: make test-acceptance
+
   # Catches registry-side drift: a new gastown release published to
   # gascity-packs makes the local pins stale without any PR to trigger
   # the pack-gate pin check in ci.yml.


### PR DESCRIPTION
## Summary

- `integration-sqlite-coordstore` job was orphaned in ci.yml (no `needs:` references, no fan-in) and was the #1 CI pole at 13.5min per push
- Move to nightly.yml keeps SQLite coordstore coverage without blocking every PR
- nightly.yml uses ubuntu-latest matching the existing nightly job pattern

Bead: ga-oa8173

## Test plan
- [ ] ci.yml no longer contains `integration-sqlite-coordstore`
- [ ] nightly.yml contains the moved job
- [ ] No timeout-bump commits included (branch is clean off origin/main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)