### PR TITLE
fix(testutil): add load-tolerant deadline constants + raise processArgsPSTimeout (ga-nzt59t)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -404,6 +404,17 @@ test coverage. This table is the checklist for new provider implementations.
    sequencing), add a coordination test using the `exec:<spy>` pattern
 3. Update this table
 
+## Test deadline rule
+
+Any test timer that races a goroutine, exec, or socket start must be ≥ 10s.
+Use `testutil.GoroutineRaceTimeout` or `testutil.ExecRaceTimeout` from
+`internal/testutil/timeout.go`.
+
+A sub-second constant for such a timer is a CI reliability defect: the
+operation completes in < 1s on an idle machine but fails under CI CPU
+saturation. The only exception is a timer that is itself the subject under
+test (e.g., testing that a function honours a 100ms deadline).
+
 ## Decision guide
 
 | Question you're testing | Tier |

--- a/cmd/gc/dolt_process_inspection.go
+++ b/cmd/gc/dolt_process_inspection.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	processArgsPSTimeout = time.Second
+	processArgsPSTimeout = 10 * time.Second
 	lsofCommandTimeout   = 2 * time.Second
 )
 

--- a/cmd/gc/dolt_standalone_conflict_test.go
+++ b/cmd/gc/dolt_standalone_conflict_test.go
@@ -69,9 +69,9 @@ func startStandaloneBdDoltLikeProcess(t *testing.T, dataDir string) *exec.Cmd {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 	})
-	// 10s: must outlast a worst-case processArgsPSTimeout (1s) ps fallback plus
+	// 30s: must outlast a worst-case processArgsPSTimeout (10s) ps fallback plus
 	// process-exec/proc-reflection latency under heavy parallel CI load.
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		if cmd.Process.Signal(syscall.Signal(0)) == nil && processLooksLikeDoltSQLServer(cmd.Process.Pid, dataDir) {
 			return cmd

--- a/internal/testutil/timeout.go
+++ b/internal/testutil/timeout.go
@@ -1,0 +1,12 @@
+package testutil
+
+import "time"
+
+// GoroutineRaceTimeout is the minimum safe deadline for a test timer that races
+// a goroutine under CI CPU saturation. A sub-second value for such a timer is a
+// CI reliability defect. See TESTING.md "Test deadline rule."
+const GoroutineRaceTimeout = 10 * time.Second
+
+// ExecRaceTimeout is the minimum safe deadline for a test timer that races a
+// subprocess start (exec, ps, dolt, bd) under CI CPU saturation.
+const ExecRaceTimeout = 10 * time.Second


### PR DESCRIPTION
## Summary

- Add `GoroutineRaceTimeout` and `ExecRaceTimeout` constants to `internal/testutil/timeout.go` for tests that race goroutines or execs under CI CPU saturation
- Raise `processArgsPSTimeout` from 1s → 10s so ps calls succeed under CI load
- Update TESTING.md with the test deadline rule
- Sub-second timer sweep: other values are deliberate input-under-test or per-attempt probes in retry loops, not goroutine/exec race deadlines

Bead: ga-nzt59t

## Test plan
- [ ] `go test ./cmd/gc/ -run TestDoltStandalone` passes
- [ ] `internal/testutil/timeout.go` exists with the two new constants
- [ ] No timeout-bump commits included (branch is clean off origin/main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)