### PR TITLE
fix(reconciler): wake asleep named session on direct open handoff (ga-3p5)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1138,6 +1138,13 @@ func collectAssignedWorkBeadsWithStores(
 	// iterates (identity).
 	stores := coordClassStoreCandidates(cfg, cityStore, rigStores, suspendedRigPaths, "")
 
+	// Configured named-session identities (read-only; shared across the
+	// per-store goroutines). An open bead assigned directly to one of these is
+	// a coordination-session handoff — the canonical-target assignment IS the
+	// wake demand, independent of gc.routed_to and of the per-assignee Ready()
+	// probe. See appendOpenRoutedWorkUnique and ga-3p5.
+	namedIdentities := configuredNamedSessionIdentities(cfg)
+
 	type storeAssignedWorkResult struct {
 		ref       string // store ref these beads came from (empty = city store)
 		beads     []beads.Bead
@@ -1183,12 +1190,12 @@ func collectAssignedWorkBeadsWithStores(
 			// live-session step beads in the same range are skipped untouched.
 			if openRouted, err := listBothTiersForControllerDemand(source.store, beads.ListQuery{Status: "open"}); err == nil {
 				appendOpenAssignedMoleculeWorkUnique(&result, &resultStores, &resultStoreRefs, readyIDs, openRouted, seen, source.store, source.ref)
-				appendOpenRoutedWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref)
+				appendOpenRoutedWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref, namedIdentities)
 			} else {
 				errs = append(errs, fmt.Errorf("List(open): %w", err))
 				if beads.IsPartialResult(err) && len(openRouted) > 0 {
 					appendOpenAssignedMoleculeWorkUnique(&result, &resultStores, &resultStoreRefs, readyIDs, openRouted, seen, source.store, source.ref)
-					appendOpenRoutedWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref)
+					appendOpenRoutedWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref, namedIdentities)
 				}
 			}
 			results[idx] = storeAssignedWorkResult{ref: source.ref, beads: result, stores: resultStores, storeRefs: resultStoreRefs, readyIDs: readyIDs, errs: errs}
@@ -1962,22 +1969,73 @@ func isOpenAssignedMoleculeWork(b beads.Bead) bool {
 	return b.Ephemeral || b.NoHistory || strings.TrimSpace(b.Metadata[beadmeta.KindMetadataKey]) == "workflow"
 }
 
-// appendOpenRoutedWorkUnique includes open beads that are still releasably
-// pool-routed AND still carry an assignee. This is the narrow input
-// releaseOrphanedPoolAssignments needs to clear step beads abandoned by a
-// dead session (graph.v2 wisps where the root depends on the finalize
-// step, so the root never enters ready and the step assignee remains a
-// long-form dead-session identity invisible to readyAssignedWorkAssignees).
-func appendOpenRoutedWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
+// appendOpenRoutedWorkUnique includes open beads that still carry an assignee
+// AND are either (a) releasably pool-routed or (b) a direct handoff to a
+// configured named-session identity.
+//
+// Case (a) is the narrow input releaseOrphanedPoolAssignments needs to clear
+// step beads abandoned by a dead session (graph.v2 wisps where the root depends
+// on the finalize step, so the root never enters ready and the step assignee
+// remains a long-form dead-session identity invisible to
+// readyAssignedWorkAssignees).
+//
+// Case (b) closes the wake-on-demand gap behind ga-3p5: a polecat's done
+// sequence reassigns the work bead to the refinery's canonical identity and
+// CLEARS gc.routed_to ("direct assignment IS the handoff"). Such a bead is
+// invisible to the routed filter, and the per-assignee Ready() probe only
+// enumerates on_demand named sessions plus live session beads — so an
+// always-mode or asleep/drained coordination session's handoff is never probed
+// and the merge strands. Collecting it here from the plain open list makes the
+// canonical-target assignment itself the wake demand, independent of routed
+// metadata and of the store's readiness model (deferred/ready-excluded handoffs
+// included). The named-identity scope keeps pool-release semantics untouched.
+//
+// Case (b) is restricted to non-ephemeral, non-molecule beads: it targets
+// durable coordination-session handoffs (a real work bead reassigned to the
+// named session's canonical identity), not ephemeral wisp work and not molecule
+// containers. Ephemeral routed work still flows through case (a) unchanged;
+// assigned molecule roots/wisps remain the sole concern of
+// appendOpenAssignedMoleculeWorkUnique, which deliberately ignores non-wisp
+// molecule containers (TestCollectAssignedWorkBeadsIgnoresOpenAssignedMoleculeContainer).
+func appendOpenRoutedWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string, namedIdentities map[string]struct{}) {
 	for _, b := range beadList {
-		if strings.TrimSpace(b.Assignee) == "" {
+		assignee := strings.TrimSpace(b.Assignee)
+		if assignee == "" {
 			continue
 		}
-		if routedToOrLegacyWorkflowTarget(b) == "" {
+		routed := routedToOrLegacyWorkflowTarget(b) != ""
+		namedHandoff := !b.Ephemeral && !beads.IsMoleculeType(b.Type) && isConfiguredNamedSessionAssignee(assignee, namedIdentities)
+		if !routed && !namedHandoff {
 			continue
 		}
 		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)
 	}
+}
+
+// configuredNamedSessionIdentities returns the set of qualified named-session
+// identities declared in cfg (all modes). A bead assigned directly to one of
+// these is a coordination-session handoff to that session's canonical target.
+func configuredNamedSessionIdentities(cfg *config.City) map[string]struct{} {
+	if cfg == nil || len(cfg.NamedSessions) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(cfg.NamedSessions))
+	for i := range cfg.NamedSessions {
+		if id := strings.TrimSpace(cfg.NamedSessions[i].QualifiedName()); id != "" {
+			set[id] = struct{}{}
+		}
+	}
+	return set
+}
+
+// isConfiguredNamedSessionAssignee reports whether assignee names a configured
+// named-session identity.
+func isConfiguredNamedSessionAssignee(assignee string, namedIdentities map[string]struct{}) bool {
+	if assignee == "" || len(namedIdentities) == 0 {
+		return false
+	}
+	_, ok := namedIdentities[assignee]
+	return ok
 }
 
 // appendWorkUnique appends b to the aligned dst/stores/storeRefs slices unless

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -11662,3 +11662,77 @@ func TestBuildDesiredState_AsleepNamedAliasHolderStaysSingle(t *testing.T) {
 		t.Fatalf("retained entry is not the named alias-holder: %+v", mayorEntries[0])
 	}
 }
+
+// TestCollectAssignedWorkBeads_IncludesOpenHandoffToConfiguredNamedSession
+// reproduces the wake-on-demand gap behind ga-3p5. A polecat's done-sequence
+// reassigns the work bead directly to the refinery's canonical identity AND
+// clears gc.routed_to ("direct assignment IS the handoff"). In a populated city
+// the assignee enumeration is non-empty, so the unfiltered Ready() fallback
+// never runs; and readyAssignedWorkAssignees only enumerates on_demand named
+// sessions plus live session beads, so an always-mode coordination session with
+// no live bead is never probed. Without collecting open beads directly assigned
+// to a configured named identity, the handoff never becomes wake demand and the
+// merge strands — the controller leaves the refinery asleep until a human does
+// close+re-assign. The direct named-assignee collection closes that gap.
+func TestCollectAssignedWorkBeads_IncludesOpenHandoffToConfiguredNamedSession(t *testing.T) {
+	store := beads.NewMemStore()
+	handoff, err := store.Create(beads.Bead{
+		Title:    "merge me",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("create handoff bead: %v", err)
+	}
+
+	cfg := &config.City{NamedSessions: []config.NamedSession{
+		{Name: "refinery", Dir: "repo", Mode: "always"},
+		// A second on_demand named session keeps readyAssignedWorkAssignees
+		// non-empty so the unfiltered Ready() fallback does not run — mirroring a
+		// populated city where this bug actually manifests.
+		{Name: "witness", Dir: "repo", Mode: "on_demand"},
+	}}
+
+	got, partial := collectAssignedWorkBeads(cfg, store)
+	if partial {
+		t.Fatal("collectAssignedWorkBeads reported partial results")
+	}
+	if len(got) != 1 || got[0].ID != handoff.ID {
+		t.Fatalf("collectAssignedWorkBeads = %#v, want open handoff %s assigned to repo/refinery", got, handoff.ID)
+	}
+	if got[0].Assignee != "repo/refinery" || got[0].Status != "open" {
+		t.Fatalf("assigned handoff bead = assignee %q status %q, want repo/refinery open", got[0].Assignee, got[0].Status)
+	}
+}
+
+// TestCollectAssignedWorkBeads_IgnoresOpenUnroutedWorkForUnconfiguredAssignee
+// guards the blast radius of the ga-3p5 fix: an open bead with a cleared
+// gc.routed_to whose assignee is NOT a configured named session must stay
+// invisible to assigned-work demand (the original appendOpenRoutedWorkUnique
+// contract — only routed pool work and named-session handoffs qualify). Here the
+// only enumerated assignee is an unrelated on_demand session, so the per-assignee
+// Ready() probe runs (not the unfiltered fallback) and the stray bead is dropped.
+func TestCollectAssignedWorkBeads_IgnoresOpenUnroutedWorkForUnconfiguredAssignee(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:    "stray open assignment",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/some-dead-session",
+	}); err != nil {
+		t.Fatalf("create stray bead: %v", err)
+	}
+
+	cfg := &config.City{NamedSessions: []config.NamedSession{
+		{Name: "witness", Dir: "repo", Mode: "on_demand"},
+	}}
+
+	got, partial := collectAssignedWorkBeads(cfg, store)
+	if partial {
+		t.Fatal("collectAssignedWorkBeads reported partial results")
+	}
+	if len(got) != 0 {
+		t.Fatalf("collectAssignedWorkBeads = %#v, want no demand for unconfigured assignee", got)
+	}
+}

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -921,6 +921,40 @@ func TestDrained_PinnedStaysAsleepUntilUndrained(t *testing.T) {
 	assertAsleep(t, result, "polecat-mc-1")
 }
 
+// TestNamedOnDemand_DrainedPinnedWakesOnOpenAssignedMerge locks the wake-on-
+// demand decision for ga-3p5: a pinned, drained on_demand refinery (state
+// asleep) must wake when a fresh OPEN ready merge bead is assigned to its
+// canonical identity — no manual close+re-assign. The pin keeps it exempt from
+// idle-sleep churn while warm; the durable assigned-work demand is what re-wakes
+// it once drained. Complements TestDrained_WithAssignedWork_Wakes (in_progress)
+// and TestDrained_PinnedStaysAsleepUntilUndrained (no work → stays asleep): the
+// fix that makes the open handoff reach AwakeWorkBead lives in the collection
+// layer (collectAssignedWorkBeads), but this guards the decision contract.
+func TestNamedOnDemand_DrainedPinnedWakesOnOpenAssignedMerge(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "repo/refinery"}},
+		NamedSessions: []AwakeNamedSession{{
+			Identity:    "repo/refinery",
+			Template:    "repo/refinery",
+			Mode:        "on_demand",
+			RuntimeName: "repo--refinery",
+		}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:            "mc-1",
+			SessionName:   "repo--refinery",
+			Template:      "repo/refinery",
+			State:         "asleep",
+			Drained:       true,
+			Pinned:        true,
+			NamedIdentity: "repo/refinery",
+		}},
+		WorkBeads: []AwakeWorkBead{{ID: "rb-1", Assignee: "repo/refinery", Status: "open", Ready: true}},
+		Now:       now,
+	})
+	assertAwake(t, result, "repo--refinery")
+	assertReason(t, result, "repo--refinery", "assigned-work")
+}
+
 // ---------------------------------------------------------------------------
 // Hold
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A pinned/keep-warm coordination session (e.g. a refinery) that **drained after
merging** stays asleep when a fresh `open` work bead is assigned **directly to
its canonical identity**. The merge strands until an operator does a manual
`close + re-assign` — on our deployment that meant ~23h idle cycles before the
session was probed again.

## Root cause — collection gap, not the wake decision

The wake **decision** is already correct: `ComputeAwakeSet` wakes a drained
session given assigned-work demand. The demand simply never reaches it.

A done-sequence handoff reassigns the work bead to the session's canonical
identity (`status=open`) and **clears `gc.routed_to`** ("direct assignment IS
the handoff"). Such a bead is:

- dropped by `appendOpenRoutedWorkUnique` (it required a non-empty `routed_to`), and
- only otherwise recoverable via the per-assignee `Ready()` probe, which
  enumerates `on_demand` named sessions plus live session beads and is subject
  to the store's readiness model — so an `always`-mode or asleep/drained
  coordination session's handoff is never probed and never becomes wake demand.

## Fix

`collectAssignedWorkBeadsWithStores` now also collects **non-ephemeral** open
beads assigned directly to a **configured named-session identity**, from the
plain open list — independent of `gc.routed_to` and of the store's readiness
model. Two small helpers (`configuredNamedSessionIdentities`,
`isConfiguredNamedSessionAssignee`) keep the scope tight:

- **Named identities only** → pool-release semantics
  (`releaseOrphanedPoolAssignments`, which skips empty-`routed_to` beads) are untouched.
- **Non-ephemeral only** → targets durable coordination-session handoffs, not
  ephemeral wisp work. Ephemeral routed work still flows through the existing
  releasable-pool path unchanged.

## Tests

- `TestCollectAssignedWorkBeads_IncludesOpenHandoffToConfiguredNamedSession` —
  reproduces the gap (fails before, passes after).
- `TestCollectAssignedWorkBeads_IgnoresOpenUnroutedWorkForUnconfiguredAssignee` —
  blast-radius guard: a cleared-`routed_to` open bead for an *unconfigured*
  assignee stays invisible to demand.
- `TestNamedOnDemand_DrainedPinnedWakesOnOpenAssignedMerge` — decision-layer
  lock: confirms `ComputeAwakeSet` already wakes a drained/pinned/asleep named
  session with reason `assigned-work` on an open assigned merge. **This test
  passes on `main` unchanged**, demonstrating the decision layer needed no
  change — only the collection gap did.

`go build`, `go vet`, and the affected `cmd/gc` tests are green.

## Notes

- Deployed and battle-tested on our gascity fork. Ported as the minimal,
  idiomatic slice: our fork wraps the open-list call sites in an
  `excludePatrolWakeWisps(...)` helper from in-flight patrol-wisp work that is
  not yet on `main`; this PR omits that wrapper and threads the new
  `namedIdentities` set into the existing call shape, so it applies cleanly here.
- Complementary to (not overlapping with) #3610 (dispatch-wake file, per-step
  idle latency) and #2675 (bounding patrol-wisp wake probes) — those touch
  different mechanisms; this closes the direct-named-handoff collection gap and
  explicitly leaves patrol-wisp handling alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)