### PR TITLE
fix(dispatch): consume pool route on claim to stop double-claim re-pool

### DIFF
--- a/cmd/gc/build_desired_state_legacy_bound_recovery_test.go
+++ b/cmd/gc/build_desired_state_legacy_bound_recovery_test.go
@@ -204,7 +204,7 @@ func TestCanonicalizeLegacyBoundAssignedWorkWokenSessionClaimsRehomedWork(t *tes
 	}
 	ops := hookClaimOps{
 		Runner: func(string, string) (string, error) { return string(workQueryOutput), nil },
-		Claim: func(context.Context, string, []string, string, string) (beads.Bead, bool, error) {
+		Claim: func(context.Context, string, []string, string, string, string) (beads.Bead, bool, error) {
 			t.Fatal("claim must not run: in-progress work already assigned to the canonical identity is an existing assignment")
 			return beads.Bead{}, false, nil
 		},
@@ -348,7 +348,7 @@ func TestCanonicalizeLegacyBoundUnassignedRoutedWorkCanonicalWorkerClaims(t *tes
 	claimInvoked := false
 	ops := hookClaimOps{
 		Runner: func(string, string) (string, error) { return string(workQueryOutput), nil },
-		Claim: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, bool, error) {
+		Claim: func(_ context.Context, _ string, _ []string, id, assignee, _ string) (beads.Bead, bool, error) {
 			claimInvoked = true
 			claimed := rehomed
 			claimed.ID = id

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -47,7 +47,7 @@ type hookClaimOps struct {
 }
 
 type (
-	hookClaimFunc              func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
+	hookClaimFunc              func(context.Context, string, []string, string, string, string) (beads.Bead, bool, error)
 	hookListContinuationFunc   func(context.Context, string, []string, string, string) ([]beads.Bead, error)
 	hookAssignContinuationFunc func(context.Context, string, []string, string, string) error
 	hookDrainAckFunc           func(io.Writer) error
@@ -139,7 +139,7 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 			!hookClaimMatchesRoute(candidate, opts.RouteTargets) {
 			continue
 		}
-		claimed, ok, err := ops.Claim(ctx, dir, opts.Env, candidate.ID, opts.Assignee)
+		claimed, ok, err := ops.Claim(ctx, dir, opts.Env, candidate.ID, opts.Assignee, strings.TrimSpace(candidate.Metadata[beadmeta.RoutedToMetadataKey]))
 		if err != nil {
 			fmt.Fprintf(stderr, "gc hook --claim: claiming %s: %v\n", candidate.ID, err) //nolint:errcheck
 			return 1
@@ -293,9 +293,29 @@ func preassignHookContinuationGroup(bead beads.Bead, opts hookClaimOptions, ops 
 	return assigned, nil
 }
 
-func hookClaimWithBdStore(_ context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {
+// claimConsumingRoute claims a bead and, when consumeRoute is non-empty,
+// consumes the pool route in the same atomic bd update: it clears gc.routed_to
+// so a live-owned, in-progress bead is no longer pool demand and cannot be
+// re-pooled by the reconciler/claim hook (ga-sa0), and records the route as
+// gc.run_target so a dead owner's in-progress work is still recoverable into the
+// pool (releaseOrphanedPoolAssignments recovers it via consumedPoolRouteAnchor
+// and re-stamps gc.routed_to once the bead is reopened). When consumeRoute is
+// empty (e.g. a workflow root claimed via gc.run_target, which carries no
+// gc.routed_to to consume) it is a plain claim that leaves routing metadata
+// untouched.
+func claimConsumingRoute(store *beads.BdStore, beadID, consumeRoute string) (beads.Bead, bool, error) {
+	consumeRoute = strings.TrimSpace(consumeRoute)
+	if consumeRoute == "" {
+		return store.Claim(beadID)
+	}
+	return store.ClaimWithMetadata(beadID,
+		map[string]string{beadmeta.RunTargetMetadataKey: consumeRoute},
+		[]string{beadmeta.RoutedToMetadataKey})
+}
+
+func hookClaimWithBdStore(_ context.Context, dir string, env []string, beadID, assignee, consumeRoute string) (beads.Bead, bool, error) {
 	store := hookClaimBdStore(dir, env, assignee)
-	claimed, ok, err := store.Claim(beadID)
+	claimed, ok, err := claimConsumingRoute(store, beadID, consumeRoute)
 	if err != nil {
 		return beads.Bead{}, false, err
 	}

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -293,7 +293,7 @@ func TestDoHookClaimReturnsExistingAssignment(t *testing.T) {
 	}
 	ops := hookClaimOps{
 		Runner: runner,
-		Claim: func(context.Context, string, []string, string, string) (beads.Bead, bool, error) {
+		Claim: func(context.Context, string, []string, string, string, string) (beads.Bead, bool, error) {
 			t.Fatal("claim must not run for existing assigned in-progress work")
 			return beads.Bead{}, false, nil
 		},
@@ -326,7 +326,7 @@ func TestDoHookClaimClaimsRoutedUnassignedWork(t *testing.T) {
 	}
 	ops := hookClaimOps{
 		Runner: runner,
-		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee, _ string) (beads.Bead, bool, error) {
 			claimedID = beadID
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
 		},
@@ -355,6 +355,71 @@ func TestDoHookClaimClaimsRoutedUnassignedWork(t *testing.T) {
 	}
 }
 
+func TestDoHookClaimPassesRoutedToAsConsumeRoute(t *testing.T) {
+	var gotConsumeRoute string
+	runner := func(string, string) (string, error) {
+		return `[{"id":"hw-5","status":"open","metadata":{"gc.routed_to":"rig/pool"}}]`, nil
+	}
+	ops := hookClaimOps{
+		Runner: runner,
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee, consumeRoute string) (beads.Bead, bool, error) {
+			gotConsumeRoute = consumeRoute
+			// Mirror the production claim: the route is consumed (gc.routed_to
+			// cleared) and retained as the gc.run_target recovery anchor.
+			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.run_target": "rig/pool"}}, true, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"rig/pool"},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if gotConsumeRoute != "rig/pool" {
+		t.Fatalf("consumeRoute passed to claim = %q, want the candidate's gc.routed_to %q", gotConsumeRoute, "rig/pool")
+	}
+}
+
+// TestDoHookClaim_DoesNotClaimConsumedRouteWork is the claim-hook half of the
+// double-claim fix (ga-sa0). Once a polecat claims a routed bead the route is
+// consumed — gc.routed_to is cleared and the route is retained only as the
+// gc.run_target recovery anchor. A SECOND polecat's claim hook must NOT treat
+// that bead as pool demand: with gc.routed_to gone, hookClaimMatchesRoute no
+// longer matches it, so it is never handed out a second time. Contrast with
+// TestDoHookClaimClaimsRoutedUnassignedWork, where gc.routed_to is still set and
+// the bead IS claimed.
+func TestDoHookClaim_DoesNotClaimConsumedRouteWork(t *testing.T) {
+	runner := func(string, string) (string, error) {
+		// Post-consumption shape: route retained only as gc.run_target, no
+		// gc.routed_to. (A plain, kind-less work bead — not a workflow root.)
+		return `[{"id":"hw-consumed","status":"open","metadata":{"gc.run_target":"rig/pool"}}]`, nil
+	}
+	ops := hookClaimOps{
+		Runner: runner,
+		Claim: func(_ context.Context, _ string, _ []string, beadID, _, _ string) (beads.Bead, bool, error) {
+			t.Fatalf("claim attempted on consumed-route bead %q; want it skipped as non-demand", beadID)
+			return beads.Bead{}, false, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-2",
+		IdentityCandidates: []string{"worker-2"},
+		RouteTargets:       []string{"rig/pool"},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doHookClaim = %d, want 1 (no claimable work); stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+}
+
 func TestDoHookClaimRetriesAfterClaimConflict(t *testing.T) {
 	var attempts []string
 	runner := func(string, string) (string, error) {
@@ -365,7 +430,7 @@ func TestDoHookClaimRetriesAfterClaimConflict(t *testing.T) {
 	}
 	ops := hookClaimOps{
 		Runner: runner,
-		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee, _ string) (beads.Bead, bool, error) {
 			attempts = append(attempts, beadID)
 			if beadID == "hw-raced" {
 				return beads.Bead{}, false, nil
@@ -411,7 +476,7 @@ func TestDoHookClaimEmitsRejectedOnLostClaim(t *testing.T) {
 	}
 	ops := hookClaimOps{
 		Runner: runner,
-		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee, _ string) (beads.Bead, bool, error) {
 			if beadID == "hw-lost" {
 				// Lost the race: the re-read shows the bead owned by worker-2.
 				return beads.Bead{ID: beadID, Status: "in_progress", Assignee: "worker-2", Metadata: map[string]string{"gc.routed_to": "worker"}}, false, nil
@@ -459,7 +524,7 @@ func TestDoHookClaimStampsWorkBranch(t *testing.T) {
 	}
 	ops := hookClaimOps{
 		Runner: runner,
-		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee, _ string) (beads.Bead, bool, error) {
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
 		},
 		ResolveWorkBranch: func(string) string { return "bd-hw-stamp" },
@@ -494,7 +559,7 @@ func TestDoHookClaimSkipsStampWhenBranchUnchanged(t *testing.T) {
 	}
 	ops := hookClaimOps{
 		Runner: runner,
-		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee, _ string) (beads.Bead, bool, error) {
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker", "gc.work_branch": "bd-hw-idem"}}, true, nil
 		},
 		ResolveWorkBranch: func(string) string { return "bd-hw-idem" },
@@ -526,7 +591,7 @@ func TestDoHookClaimClaimsLegacyRunTargetWorkflowRoot(t *testing.T) {
 	}
 	ops := hookClaimOps{
 		Runner: runner,
-		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee, _ string) (beads.Bead, bool, error) {
 			claimedID = beadID
 			return beads.Bead{
 				ID:       beadID,
@@ -650,7 +715,7 @@ func TestDoHookClaimPreassignsContinuationGroupSiblings(t *testing.T) {
 	}
 	ops := hookClaimOps{
 		Runner: runner,
-		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee, _ string) (beads.Bead, bool, error) {
 			return beads.Bead{
 				ID:       beadID,
 				Status:   "in_progress",
@@ -1078,8 +1143,8 @@ name = "worker"
 	script := fmt.Sprintf(`#!/bin/sh
 printf 'actor=%%s args=%%s\n' "${BEADS_ACTOR:-}" "$*" >> %q
 case "$*" in
-  *"update hw-claim --claim --json"*)
-    printf '[{"id":"hw-claim","status":"in_progress","assignee":"%%s","metadata":{"gc.routed_to":"worker","gc.root_bead_id":"root-1","gc.continuation_group":"body"}}]' "${BEADS_ACTOR:-}"
+  *"update hw-claim --claim --set-metadata gc.run_target=worker --unset-metadata gc.routed_to --json"*)
+    printf '[{"id":"hw-claim","status":"in_progress","assignee":"%%s","metadata":{"gc.run_target":"worker","gc.root_bead_id":"root-1","gc.continuation_group":"body"}}]' "${BEADS_ACTOR:-}"
     ;;
   *"list --json --status=open"*"gc.continuation_group=body"*"gc.root_bead_id=root-1"*)
     printf '[{"id":"hw-claim","status":"open","metadata":{"gc.routed_to":"worker","gc.root_bead_id":"root-1","gc.continuation_group":"body"}},{"id":"hw-next","status":"open","metadata":{"gc.routed_to":"worker","gc.root_bead_id":"root-1","gc.continuation_group":"body"}},{"id":"hw-other","status":"open","metadata":{"gc.routed_to":"other","gc.root_bead_id":"root-1","gc.continuation_group":"body"}}]'
@@ -1130,8 +1195,8 @@ esac
 		t.Fatalf("ReadFile(%s): %v", logPath, err)
 	}
 	logText := string(logData)
-	if !strings.Contains(logText, "actor=worker-1 args=update hw-claim --claim --json") {
-		t.Fatalf("bd claim did not use session BEADS_ACTOR=worker-1; log:\n%s", logText)
+	if !strings.Contains(logText, "actor=worker-1 args=update hw-claim --claim --set-metadata gc.run_target=worker --unset-metadata gc.routed_to --json") {
+		t.Fatalf("bd claim did not consume the route under session BEADS_ACTOR=worker-1; log:\n%s", logText)
 	}
 	if !strings.Contains(logText, "args=update --json hw-next --assignee worker-1") {
 		t.Fatalf("continuation sibling was not preassigned through bd; log:\n%s", logText)

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
@@ -140,6 +141,19 @@ func releaseOrphanedPoolAssignments(
 		}
 		assignee := strings.TrimSpace(wb.Assignee)
 		template := routedToOrLegacyWorkflowTarget(wb)
+		restampRoute := ""
+		if template == "" {
+			// A pool route consumed on claim leaves gc.routed_to cleared but
+			// retains the route as the gc.run_target anchor (see
+			// claimConsumingRoute), so a dead owner's in-progress work is
+			// recovered via that anchor rather than stranded. Re-stamp
+			// gc.routed_to on reopen (restampRoute) so the recovered work
+			// re-enters pool demand, which keys on gc.routed_to.
+			if anchor := consumedPoolRouteAnchor(wb); anchor != "" {
+				template = anchor
+				restampRoute = anchor
+			}
+		}
 		if template == "" {
 			continue
 		}
@@ -187,7 +201,7 @@ func releaseOrphanedPoolAssignments(
 		if !allowsRelease {
 			continue
 		}
-		if !releaseOrphanedPoolAssignment(ownerStore, wb.ID, clearDetached) {
+		if !releaseOrphanedPoolAssignment(ownerStore, wb.ID, clearDetached, restampRoute) {
 			continue
 		}
 		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
@@ -327,7 +341,7 @@ func isRecoverableUnassignedInProgressPoolWork(cfg *config.City, wb beads.Bead) 
 	return agentCfg != nil && agentCfg.SupportsGenericEphemeralSessions()
 }
 
-func releaseOrphanedPoolAssignment(store beads.Store, id string, clearDetached bool) bool {
+func releaseOrphanedPoolAssignment(store beads.Store, id string, clearDetached bool, restampRoute string) bool {
 	if store == nil || id == "" {
 		return false
 	}
@@ -338,6 +352,14 @@ func releaseOrphanedPoolAssignment(store beads.Store, id string, clearDetached b
 	}
 	if clearDetached {
 		opts.Metadata[detachedProbeMetadataKey] = ""
+	}
+	if restampRoute != "" {
+		// ga-sa0: this bead's gc.routed_to was consumed on claim and recovered
+		// from the gc.run_target anchor (consumedPoolRouteAnchor). Re-stamp
+		// gc.routed_to on reopen so the recovered work re-enters pool demand —
+		// the autoscaler keys on gc.routed_to, so without this the reopened bead
+		// would be invisible to demand and never re-dispatched.
+		opts.Metadata[beadmeta.RoutedToMetadataKey] = restampRoute
 	}
 	if err := store.Update(id, opts); err != nil {
 		log.Printf("releaseOrphanedPoolAssignments: releasing orphaned pool assignment %s: %v", id, err)

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1917,6 +1917,127 @@ func TestReleaseOrphanedPoolAssignments_ReleasesNamedIdentityForUnreachableStore
 	}
 }
 
+// TestReleaseOrphanedPoolAssignments_ConsumedRouteKeepsLiveOwnership asserts
+// single ownership after the dispatch double-claim fix (ga-sa0). A claimed pool
+// bead has its route consumed: gc.routed_to is cleared and the route survives
+// only as the gc.run_target anchor. The reconciler must still recognize the live
+// owner and NOT re-pool the bead — the bead stays with its single owner, and the
+// route is not re-advertised (gc.routed_to stays empty) so no second polecat can
+// be handed the same work.
+func TestReleaseOrphanedPoolAssignments_ConsumedRouteKeepsLiveOwnership(t *testing.T) {
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   "session",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name":         "worker-live",
+			"template":             "worker",
+			"agent_name":           "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	// Post-consumption shape: gc.run_target anchor retained, gc.routed_to gone.
+	work, err := store.Create(beads.Bead{
+		Title:    "claimed pool work",
+		Assignee: "worker-live",
+		Metadata: map[string]string{"gc.run_target": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		[]beads.Bead{session},
+		[]beads.Bead{work},
+		nil,
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none (live owner must keep the work)", released)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-live" {
+		t.Fatalf("work = (status %q, assignee %q), want single ownership (in_progress, worker-live)", got.Status, got.Assignee)
+	}
+	if rt := strings.TrimSpace(got.Metadata["gc.routed_to"]); rt != "" {
+		t.Fatalf("gc.routed_to = %q, want empty (claimed work must not re-advertise as pool demand)", rt)
+	}
+}
+
+// TestReleaseOrphanedPoolAssignments_ConsumedRouteRecoversDeadOwner asserts the
+// dispatch double-claim fix (ga-sa0) does not regress crash recovery. After the
+// route is consumed on claim (gc.routed_to cleared, gc.run_target anchor kept), a
+// DEAD owner's in-progress work must still be reopened via that anchor
+// (consumedPoolRouteAnchor) — otherwise clearing gc.routed_to would strand it.
+// Recovery is self-contained: the reopen re-stamps gc.routed_to from the anchor
+// so the work re-enters pool demand (which keys on gc.routed_to) in the same
+// transition, without a separate restore pass.
+func TestReleaseOrphanedPoolAssignments_ConsumedRouteRecoversDeadOwner(t *testing.T) {
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "claimed pool work, owner died",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{"gc.run_target": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		nil,
+		[]beads.Bead{work},
+		nil,
+		nil,
+		nil,
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s] (dead owner's consumed-route work must be recoverable)", released, work.ID)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("work = (status %q, assignee %q), want reopened (open, unassigned)", got.Status, got.Assignee)
+	}
+	if rt := strings.TrimSpace(got.Metadata["gc.routed_to"]); rt != "worker" {
+		t.Fatalf("gc.routed_to = %q, want \"worker\" re-stamped on reopen so recovered work re-enters pool demand", rt)
+	}
+	if rt := strings.TrimSpace(got.Metadata["gc.run_target"]); rt != "worker" {
+		t.Fatalf("gc.run_target = %q, want \"worker\" anchor left intact on reopen", rt)
+	}
+}
+
 func TestReleaseOrphanedPoolAssignments_PreservesNamedIdentityForSameStore(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/work_routing_metadata.go
+++ b/cmd/gc/work_routing_metadata.go
@@ -24,6 +24,31 @@ func routedToOrLegacyWorkflowTarget(b beads.Bead) string {
 	return legacyWorkflowRunTarget(b)
 }
 
+// consumedPoolRouteAnchor returns the pool route retained as the gc.run_target
+// anchor after gc.routed_to was consumed on claim (ga-sa0), or "" when the bead
+// carries no recoverable anchor. It is the orphan-recovery counterpart to
+// claimConsumingRoute: clearing gc.routed_to on claim would otherwise strand a
+// dead owner's in-progress pool work, so releaseOrphanedPoolAssignments falls
+// back to this anchor to reopen that work (and re-stamp gc.routed_to from it).
+//
+// It deliberately recovers only a plain (kind-less) pool work bead. A bead that
+// still carries gc.routed_to is already routed and yields ""; any non-empty
+// gc.kind is a control-dispatcher or workflow-topology construct whose
+// gc.run_target is a dispatch/structure target an agent never claims from a
+// pool, so restoring gc.routed_to on one would mis-route it into pool demand.
+// The lone claimable kind, "workflow", is already handled upstream of this
+// fallback by routedToOrLegacyWorkflowTarget/legacyWorkflowRunTarget. The choice
+// is judgment-free: it only copies a route the bead already declares.
+func consumedPoolRouteAnchor(b beads.Bead) string {
+	if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) != "" {
+		return ""
+	}
+	if strings.TrimSpace(b.Metadata[beadmeta.KindMetadataKey]) != "" {
+		return ""
+	}
+	return strings.TrimSpace(b.Metadata[beadmeta.RunTargetMetadataKey])
+}
+
 func routedToAndLegacyWorkflowCandidates(b beads.Bead) []string {
 	routedTo := strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey])
 	legacy := legacyWorkflowRunTarget(b)

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1198,7 +1198,39 @@ func bdSQLStringLiteral(value string) string {
 // The caller controls the claim actor through the store's CommandRunner
 // environment, typically BEADS_ACTOR.
 func (s *BdStore) Claim(id string) (Bead, bool, error) {
-	out, err := s.runBDTransientWriteOutput("update", id, "--claim", "--json")
+	return s.ClaimWithMetadata(id, nil, nil)
+}
+
+// ClaimWithMetadata atomically claims a bead (open->in_progress, assignee set to
+// the store actor) while setting and/or unsetting the given metadata keys in the
+// SAME bd update. Folding the metadata mutation into the claim keeps both
+// observable as a single transition: a caller that consumes a routing key on
+// claim cannot be interrupted between claiming the bead and clearing the key.
+// The set and unset mutations are applied in addition to the claim; pass nil for
+// either to skip it. set keys are emitted in sorted order for deterministic
+// command construction. Like Claim, it returns ok=false with a nil error on a
+// claim conflict (the bead was already claimed by another actor), in which case
+// no metadata mutation is applied.
+func (s *BdStore) ClaimWithMetadata(id string, set map[string]string, unset []string) (Bead, bool, error) {
+	args := []string{"update", id, "--claim"}
+	if len(set) > 0 {
+		keys := make([]string, 0, len(set))
+		for k := range set {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			args = append(args, "--set-metadata", k+"="+set[k])
+		}
+	}
+	for _, k := range unset {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		args = append(args, "--unset-metadata", k)
+	}
+	args = append(args, "--json")
+	out, err := s.runBDTransientWriteOutput(args...)
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
 		if isBdClaimConflictMessage(msg) || isBdClaimConflictMessage(err.Error()) {

--- a/internal/beads/bdstore_claim_route_test.go
+++ b/internal/beads/bdstore_claim_route_test.go
@@ -1,0 +1,91 @@
+package beads_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestBdStoreClaimWithMetadataConsumesRouteAtomically verifies that claiming a
+// bead while consuming its pool route folds the claim and the metadata mutation
+// into a SINGLE bd update invocation: --claim, the --set-metadata for the
+// retained anchor, and the --unset-metadata for the consumed route all ride on
+// one command so they cannot be observed (or interrupted) separately. This is
+// the atomic primitive behind the dispatch double-claim fix (ga-sa0): the route
+// is consumed in the same transition that claims the bead.
+func TestBdStoreClaimWithMetadataConsumesRouteAtomically(t *testing.T) {
+	var calls int
+	var gotArgs []string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("name = %q, want bd", name)
+		}
+		calls++
+		gotArgs = append([]string(nil), args...)
+		return []byte(`[{"id":"bd-7","title":"pool work","status":"in_progress","assignee":"worker-1","issue_type":"task","created_at":"2026-06-01T00:00:00Z","metadata":{"gc.run_target":"rig/pool"}}]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+
+	claimed, ok, err := s.ClaimWithMetadata("bd-7",
+		map[string]string{"gc.run_target": "rig/pool"},
+		[]string{"gc.routed_to"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ClaimWithMetadata ok = false, want true")
+	}
+	if calls != 1 {
+		t.Fatalf("bd invocations = %d, want 1 (claim + metadata must be atomic)", calls)
+	}
+	if claimed.ID != "bd-7" || claimed.Status != "in_progress" || claimed.Assignee != "worker-1" {
+		t.Fatalf("claimed bead = %+v, want claimed bd-7 assigned to worker-1", claimed)
+	}
+	if got := strings.Join(gotArgs, " "); got != "update bd-7 --claim --set-metadata gc.run_target=rig/pool --unset-metadata gc.routed_to --json" {
+		t.Fatalf("args = %q, want atomic claim+route-consume args", got)
+	}
+}
+
+// TestBdStoreClaimWithMetadataMultipleSetKeysSorted verifies set keys are
+// emitted in a deterministic (sorted) order so the constructed command is
+// stable regardless of map iteration order.
+func TestBdStoreClaimWithMetadataMultipleSetKeysSorted(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = append([]string(nil), args...)
+		return []byte(`[{"id":"bd-8","status":"in_progress","assignee":"w","issue_type":"task","created_at":"2026-06-01T00:00:00Z"}]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+
+	if _, ok, err := s.ClaimWithMetadata("bd-8",
+		map[string]string{"gc.run_target": "p", "z.last": "1", "a.first": "2"},
+		nil); err != nil || !ok {
+		t.Fatalf("ClaimWithMetadata ok=%v err=%v, want ok=true err=nil", ok, err)
+	}
+	if got := strings.Join(gotArgs, " "); got != "update bd-8 --claim --set-metadata a.first=2 --set-metadata gc.run_target=p --set-metadata z.last=1 --json" {
+		t.Fatalf("args = %q, want sorted --set-metadata flags", got)
+	}
+}
+
+// TestBdStoreClaimWithMetadataConflictReturnsFalse verifies a claim conflict
+// (the bead was already claimed by another actor) yields ok=false with a nil
+// error and applies no metadata mutation — mirroring Claim's contract so the
+// route is only consumed on a claim this caller actually won.
+func TestBdStoreClaimWithMetadataConflictReturnsFalse(t *testing.T) {
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		return []byte(`{"error":"issue is already claimed by worker-2"}`), fmt.Errorf("exit status 1")
+	}
+	s := beads.NewBdStore("/city", runner)
+
+	claimed, ok, err := s.ClaimWithMetadata("bd-9",
+		map[string]string{"gc.run_target": "rig/pool"},
+		[]string{"gc.routed_to"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("ClaimWithMetadata ok = true, want false on conflict; claimed=%+v", claimed)
+	}
+}


### PR DESCRIPTION
## What

A polecat that claimed a routed pool bead left `gc.routed_to` set on the
`in_progress`, live-owned bead. That stale route kept the bead in pool
demand/claim space, so the reconciler/claim hook could re-pool it and hand the
same work to a second polecat — a double-claim (two workers grinding the same
bead, duplicate token burn, double-write hazard on the output).

This consumes the route at claim time, splitting the overloaded `gc.routed_to`
into its two meanings:

- **`gc.routed_to` = ephemeral "claimable pool demand"** — cleared on claim, so a
  claimed bead is no longer demand, is not returned by the pool work query, and
  is not handed to a second polecat.
- **`gc.run_target` = durable "belongs to pool X" anchor** — recorded on claim so a
  dead owner's in-progress work can still be recovered into the pool.

## How

- **`internal/beads`** — `BdStore.ClaimWithMetadata` claims and mutates metadata in
  one atomic `bd update` (claim + clear `gc.routed_to` + set `gc.run_target`
  cannot be observed or interrupted separately). `Claim` delegates to it with no
  mutations, so its existing command shape is unchanged.
- **`cmd/gc` hook claim** — `claimConsumingRoute` consumes the claimed bead's
  `gc.routed_to` into `gc.run_target`; the route is threaded through
  `hookClaimFunc`. A workflow root claimed via `gc.run_target` (no `gc.routed_to`
  to consume) takes the plain-claim path and is left untouched.
- **`cmd/gc` reconciler** — `releaseOrphanedPoolAssignments` recovers a dead
  owner's consumed-route work via the `gc.run_target` anchor
  (`consumedPoolRouteAnchor`) instead of stranding it, and **re-stamps
  `gc.routed_to` on reopen** so the recovered work re-enters pool demand (the
  autoscaler keys on `gc.routed_to`). Recovery is self-contained in the release
  path — no separate restore pass required.

`consumedPoolRouteAnchor` deliberately recovers only a plain (kind-less) pool
work bead: a still-routed bead is already demand, and any non-empty `gc.kind` is
a control/topology construct whose `gc.run_target` is a dispatch target an agent
never claims from a pool (re-routing one would mis-route it). The lone claimable
kind, `workflow`, is already handled by `routedToOrLegacyWorkflowTarget`.

## Relationship to in-flight pool-claim PRs (complementary, not a dup)

This is the **claim-layer** half of the double-claim surface and is orthogonal
to the in-flight release/reconciler work:

- **#3458** (`fix(supervisor): don't orphan-release a live pending pool claim`) is
  a **release-layer** guard: it skips releasing a claim while the holder pane is
  alive and parked on an interactive prompt. It does not touch the claim path and
  leaves `gc.routed_to` set on the claimed bead. This PR removes that bead from
  demand at claim time regardless of holder pane state, closing the vector where
  a non-pending holder's claimed bead is re-pooled.
- **#3558** (`fix(reconciler): reclaim terminal-error and stale pool sessions
  before scaling`) operates on pool **sessions** before scaling and does not
  consume the claim route. Orthogonal.

The distinct live-owner release guard is its own concern; this PR is scoped to
the claim-consume change.

## Tests

- `internal/beads`: `ClaimWithMetadata` folds claim + set + unset into a single
  `bd update` with sorted, deterministic flags; a claim conflict yields
  `ok=false` and applies no metadata mutation.
- `cmd/gc`: the claim hook passes the candidate's `gc.routed_to` as the
  consume-route; a second polecat's claim hook skips a consumed-route bead
  (no `gc.routed_to` → not demand); a live owner keeps single ownership with no
  re-advertised route; a dead owner's consumed-route work is still reopened and
  re-enters demand (re-stamped `gc.routed_to`).

`go build ./...`, `go vet ./...`, and the `internal/beads` + `cmd/gc`
pool/hook/desired-state suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
