### PR TITLE
fix(wisp-gc): bound per-tick deletion work in periodic reapers (post-merge #3535)

### DIFF
--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -61,6 +61,14 @@ var closeAbandonedEnforced = func() bool {
 // unbounded amount of deletion work. Package var so tests can shrink it.
 var wispGCReapOrphanBatchCap = 500
 
+// wispGCClosurePurgeBatchCap bounds how many closed-root ownership closures a
+// single sweep will purge. Like wispGCReapOrphanBatchCap it caps DELETE
+// ATTEMPTS per tick — counting failures, not just successful purges — so the
+// first-deploy backlog of newly-collectible closed graph.v2/workflow roots, and
+// a failing delete backend, drain across successive ticks instead of one
+// unbounded pass. Package var so tests can shrink it.
+var wispGCClosurePurgeBatchCap = 500
+
 // reapOrphansEnforced reports whether orphaned-closed-wisp reaping should
 // actually delete rows (true) or run dry (false). It is a package var so tests
 // can flip it without touching the process environment. By default it reads
@@ -167,7 +175,7 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 		}
 
 		cutoff := now.Add(-m.ttl)
-		closurePurged, closureDeleteErr := purgeExpiredBeadClosures(store, entries, cutoff)
+		closurePurged, closureDeleteErr := purgeExpiredBeadClosures(store, entries, cutoff, wispGCClosurePurgeBatchCap)
 		purged += closurePurged
 		deleteErr = errors.Join(deleteErr, closureDeleteErr)
 
@@ -307,13 +315,16 @@ func reapOrphanedClosedWisps(store beads.Store, cutoff time.Time, batchCap int) 
 	var collectErr error
 
 	reaped := 0
+	attempted := 0
 	var deleteErr error
 	for _, c := range candidates {
-		// The batch cap bounds DELETION work per sweep. In dry-run keep counting
-		// past the cap so the logged estimate reflects the true eligible backlog
-		// an operator needs before enabling enforcement, not just the cap-sized
-		// prefix the enforced sweep would reap this tick.
-		if enforce && batchCap > 0 && reaped >= batchCap {
+		// The batch cap bounds DELETION ATTEMPTS per sweep — counting failed
+		// deletes, not just successful reaps — so a failing delete backend can't
+		// attempt the whole backlog in one tick. In dry-run attempted stays 0 and
+		// reaped keeps counting past the cap so the logged estimate reflects the
+		// true eligible backlog an operator needs before enabling enforcement, not
+		// just the cap-sized prefix the enforced sweep would reap this tick.
+		if enforce && batchCap > 0 && attempted >= batchCap {
 			break
 		}
 
@@ -355,6 +366,7 @@ func reapOrphanedClosedWisps(store beads.Store, cutoff time.Time, batchCap int) 
 			continue
 		}
 
+		attempted++
 		if err := deleteWorkflowBead(store, c.ID); err != nil {
 			deleteErr = errors.Join(deleteErr, fmt.Errorf("reaping orphaned closed wisp %q: %w", c.ID, err))
 			continue
@@ -538,21 +550,40 @@ func readMessageWispGCEntries(store beads.Store) ([]beads.Bead, error) {
 	return entries, nil
 }
 
-func purgeExpiredBeadClosures(store beads.Store, entries []beads.Bead, cutoff time.Time) (int, error) {
-	return purgeExpiredBeads(store, entries, cutoff, deleteExpiredBeadClosure)
+// purgeExpiredBeadClosures purges aged closed roots, deleting each root's full
+// ownership closure. batchCap bounds how many root closures one sweep attempts
+// (see wispGCClosurePurgeBatchCap) so a first-deploy backlog of newly-collectible
+// roots drains across ticks instead of in one unbounded pass.
+func purgeExpiredBeadClosures(store beads.Store, entries []beads.Bead, cutoff time.Time, batchCap int) (int, error) {
+	return purgeExpiredBeads(store, entries, cutoff, batchCap, deleteExpiredBeadClosure)
 }
 
+// purgeExpiredBeadRoots purges aged single-row roots (the read-message mail
+// retention sweep). It is intentionally unbounded (batchCap=0): it predates the
+// wisp-GC reaper caps and its candidate set is not the first-deploy backlog the
+// closure-purge cap guards against.
 func purgeExpiredBeadRoots(store beads.Store, entries []beads.Bead, cutoff time.Time) (int, error) {
-	return purgeExpiredBeads(store, entries, cutoff, deleteWorkflowBead)
+	return purgeExpiredBeads(store, entries, cutoff, 0, deleteWorkflowBead)
 }
 
-func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time, deleteFn func(beads.Store, string) error) (int, error) {
+// purgeExpiredBeads deletes each entry older than cutoff via deleteFn and
+// returns the count successfully purged. When batchCap > 0 it bounds the number
+// of DELETE ATTEMPTS per call — counting failures, not just successes — so a
+// large backlog or a failing delete backend cannot make one sweep attempt an
+// unbounded amount of deletion work; the remainder drains on later ticks.
+// batchCap <= 0 disables the bound. Entries skipped for age never consume the cap.
+func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time, batchCap int, deleteFn func(beads.Store, string) error) (int, error) {
 	purged := 0
+	attempted := 0
 	var deleteErr error
 	for _, entry := range entries {
+		if batchCap > 0 && attempted >= batchCap {
+			break
+		}
 		if entry.CreatedAt.IsZero() || !entry.CreatedAt.Before(cutoff) {
 			continue
 		}
+		attempted++
 		if err := deleteFn(store, entry.ID); err != nil {
 			deleteErr = errors.Join(deleteErr, fmt.Errorf("deleting expired bead %q: %w", entry.ID, err))
 			continue

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -806,6 +806,45 @@ func TestWispGC_ReapHonorsBatchCap(t *testing.T) {
 	}
 }
 
+// TestWispGC_ReapBatchCapBoundsAttemptsNotJustSuccesses is the post-merge
+// regression for the finding that the orphan reaper's batch cap advanced only on
+// SUCCESSFUL deletes: a failing delete backend could attempt every eligible
+// orphan in a single tick even though the cap is the safety bound for sweep
+// work. With the cap at 1 and EVERY eligible orphan's delete failing, a sweep
+// must stop after a single delete ATTEMPT — leaving the rest for a later tick —
+// rather than walking the whole backlog because no success ever advanced the
+// counter. Both candidates fail so the assertion is independent of which one the
+// store lists first.
+func TestWispGC_ReapBatchCapBoundsAttemptsNotJustSuccesses(t *testing.T) {
+	withReapOrphansEnforced(t, true)
+	withReapOrphanBatchCap(t, 1)
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCOrphanWisp("orphan-fail-1", now.Add(-2*time.Hour), "ghost-root"),
+		makeGCOrphanWisp("orphan-fail-2", now.Add(-2*time.Hour), "ghost-root"),
+	})
+	store.deleteErrors["orphan-fail-1"] = fmt.Errorf("delete failed")
+	store.deleteErrors["orphan-fail-2"] = fmt.Errorf("delete failed")
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err == nil {
+		t.Fatal("expected reap delete error to be surfaced")
+	}
+	if !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("err = %v, want delete failure to be included", err)
+	}
+	if purged != 0 {
+		t.Fatalf("purged = %d, want 0 (every delete failed)", purged)
+	}
+	if len(store.deletedIDs) != 0 {
+		t.Fatalf("deletedIDs = %v, want none (every delete failed)", store.deletedIDs)
+	}
+	if len(store.deleteAttempts) != 1 {
+		t.Fatalf("delete attempts = %v (n=%d), want exactly 1; the batch cap must bound delete ATTEMPTS, not just successful reaps", store.deleteAttempts, len(store.deleteAttempts))
+	}
+}
+
 func TestWispGC_ReapSkipsRowsWithoutRootPointer(t *testing.T) {
 	withReapOrphansEnforced(t, true)
 	now := time.Now()
@@ -1124,6 +1163,47 @@ func TestWispGC_CollectsClosedGraphWorkflowRoot(t *testing.T) {
 	}
 }
 
+// TestWispGC_ClosurePurgeHonorsBatchCap is the post-merge regression for the
+// finding that the closed-root closure purge had no per-tick bound. The selector
+// expansion (adding graph.v2/workflow roots) made a never-before-collected class
+// of closed roots eligible, so the first GC tick after deploy could delete the
+// whole accumulated backlog's ownership closures in one uncapped pass. With the
+// cap shrunk to 1 a single sweep purges at most one root closure and the rest
+// drain on later ticks; a second sweep collects the next root, proving the
+// backlog clears across ticks rather than being dropped.
+func TestWispGC_ClosurePurgeHonorsBatchCap(t *testing.T) {
+	withClosurePurgeBatchCap(t, 1)
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-a", now.Add(-2*time.Hour), "closed", "molecule"),
+		makeGCBead("mol-b", now.Add(-2*time.Hour), "closed", "molecule"),
+		makeGCBead("mol-c", now.Add(-2*time.Hour), "closed", "molecule"),
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (closure purge batch cap bounds roots per tick)", purged)
+	}
+	if len(store.deletedIDs) != 1 {
+		t.Fatalf("deleted = %v, want exactly 1 root closure per capped sweep", store.deletedIDs)
+	}
+
+	purged2, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC second sweep: %v", err)
+	}
+	if purged2 != 1 {
+		t.Fatalf("second sweep purged = %d, want 1 (backlog drains across ticks)", purged2)
+	}
+	if len(store.deletedIDs) != 2 {
+		t.Fatalf("after two sweeps deleted = %v, want 2 distinct root closures", store.deletedIDs)
+	}
+}
+
 func TestWispGC_LeavesOpenRootWithLiveDescendant(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
@@ -1321,6 +1401,10 @@ type gcTestStore struct {
 	deleteErrors map[string]error
 	getErrors    map[string]error
 	deletedIDs   []string
+	// deleteAttempts records every Delete call, success or failure, so tests can
+	// assert that a batch cap bounds delete ATTEMPTS and not merely successful
+	// deletes (a failed delete leaves no trace in deletedIDs).
+	deleteAttempts []string
 }
 
 func newGCStore(existing []beads.Bead) *gcTestStore {
@@ -1347,6 +1431,7 @@ func (s *gcTestStore) Get(id string) (beads.Bead, error) {
 }
 
 func (s *gcTestStore) Delete(id string) error {
+	s.deleteAttempts = append(s.deleteAttempts, id)
 	if err := s.deleteErrors[id]; err != nil {
 		return err
 	}
@@ -1427,6 +1512,15 @@ func withReapOrphanBatchCap(t *testing.T, batchCap int) {
 	prev := wispGCReapOrphanBatchCap
 	wispGCReapOrphanBatchCap = batchCap
 	t.Cleanup(func() { wispGCReapOrphanBatchCap = prev })
+}
+
+// withClosurePurgeBatchCap overrides the per-sweep closed-root closure purge cap
+// for the duration of a test, restoring the prior value on cleanup.
+func withClosurePurgeBatchCap(t *testing.T, batchCap int) {
+	t.Helper()
+	prev := wispGCClosurePurgeBatchCap
+	wispGCClosurePurgeBatchCap = batchCap
+	t.Cleanup(func() { wispGCClosurePurgeBatchCap = prev })
 }
 
 func captureWispGCLog(t *testing.T, fn func()) string {


### PR DESCRIPTION
## Post-merge remediation for #3535

A post-merge review of #3535 (wisp-GC periodic reapers) found that the new
periodic deletion paths could attempt an unbounded amount of work on a single
GC tick. This PR bounds that work. It does not change the reapers' dry-run
defaults or their safety guards.

### Findings addressed

1. **Orphan reaper cap counted only successful deletes.** The
   `wispGCReapOrphanBatchCap` guard advanced only when a delete succeeded, so a
   failing delete backend could attempt every eligible orphan on each tick even
   though the cap is the safety bound. The cap now counts delete *attempts*
   (including failures), so a failed delete still consumes the cap.

2. **Closed-root closure purge had no per-tick cap.** The selector expansion in
   #3535 made closed graph.v2/workflow roots newly collectible, so the first GC
   tick after deploy could delete the entire accumulated backlog's ownership
   closures in one uncapped pass. A new `wispGCClosurePurgeBatchCap` (default
   500) bounds how many root closures one sweep attempts. The read-message mail
   retention purge stays unbounded — it predates these caps and is not the
   first-deploy backlog the cap guards against.

Both caps now bound *attempts*, so a backlog or a failing delete backend drains
across successive ticks instead of one pass.

### Tests

- Orphan reaper stops after a single delete *attempt* when the first eligible
  delete fails with the cap at 1 (regression for finding 1).
- Closure purge collects one root closure per capped sweep and drains the
  backlog across ticks (regression for finding 2).
- Full `TestWispGC` suite, `go vet ./...`, and the fast test shards pass; the
  diff is limited to `cmd/gc/wisp_gc.go` and `cmd/gc/wisp_gc_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)