### PR TITLE
fix(supervisor): orphan-release strands live city-scoped pool holders (cross-store ownership)

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -24,6 +24,48 @@ func agentIsCrossStoreEligible(agentCfg *config.Agent) bool {
 	return agentutil.AgentIsCrossStoreEligible(agentCfg)
 }
 
+// sessionAgentConfig resolves the agent config backing a session bead from its
+// template metadata, or nil when neither the template nor a backing agent can be
+// resolved.
+func sessionAgentConfig(cfg *config.City, session beads.Bead) *config.Agent {
+	if cfg == nil {
+		return nil
+	}
+	template := normalizedSessionTemplate(session, cfg)
+	if template == "" {
+		template = strings.TrimSpace(session.Metadata["template"])
+	}
+	if template == "" {
+		template = strings.TrimSpace(session.Metadata["common_name"])
+	}
+	if template == "" {
+		return nil
+	}
+	return findAgentByTemplate(cfg, template)
+}
+
+// openSessionReachableStoreRef returns the store-ref under which an open session
+// bead owns assigned work, for makeOpenSessionStoreRefIndex. A cross-store
+// eligible (city-scoped) session federates across every store (vp-kvp), so it is
+// indexed under crossStoreOpenSessionStoreRef — a wildcard openSessionOwnsWork
+// matches against any work store-ref. This mirrors the cross-store ownership the
+// demand and session-wake filters already grant (filterAssignedWorkBeadsForSessionWake);
+// without it the release path strands a live city-scoped holder's rig-routed
+// work and a backup worker is minted on the same bead (#3453). A session whose
+// template/agent cannot be resolved falls back to unresolvedOpenSessionStoreRef
+// (also a wildcard), preserving the legacy keep-on-match fail-safe; every other
+// session stays scoped to its configured rig's store-ref.
+func openSessionReachableStoreRef(cityPath string, cfg *config.City, session beads.Bead) string {
+	agentCfg := sessionAgentConfig(cfg, session)
+	if agentCfg == nil {
+		return unresolvedOpenSessionStoreRef
+	}
+	if agentIsCrossStoreEligible(agentCfg) {
+		return crossStoreOpenSessionStoreRef
+	}
+	return assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
+}
+
 func assignedWorkIndexReachableFromAgent(cityPath string, cfg *config.City, agentCfg *config.Agent, storeRefs []string, index int) bool {
 	if len(storeRefs) == 0 {
 		return true

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -243,6 +243,12 @@ func clearDetachedProbeMetadata(store beads.Store, id string) {
 
 const unresolvedOpenSessionStoreRef = "\x00unresolved"
 
+// crossStoreOpenSessionStoreRef marks an open session whose backing agent is
+// cross-store eligible (city-scoped). Such a session federates across every
+// store (vp-kvp), so openSessionOwnsWork matches it against any work store-ref.
+// The \x00 prefix cannot collide with a real rig name.
+const crossStoreOpenSessionStoreRef = "\x00crossstore"
+
 func makeOpenSessionStoreRefIndex(cityPath string, cfg *config.City, openSessionBeads []beads.Bead, storeRefAware bool) map[string]map[string]struct{} {
 	index := make(map[string]map[string]struct{}, len(openSessionBeads)*5)
 	if !storeRefAware {
@@ -252,10 +258,7 @@ func makeOpenSessionStoreRefIndex(cityPath string, cfg *config.City, openSession
 		if sb.Status == "closed" {
 			continue
 		}
-		storeRef, ok := assignedWorkStoreRefForSession(cityPath, cfg, sb)
-		if !ok {
-			storeRef = unresolvedOpenSessionStoreRef
-		}
+		storeRef := openSessionReachableStoreRef(cityPath, cfg, sb)
 		for _, id := range sessionBeadAssigneeIdentities(sb) {
 			addOpenSessionStoreRef(index, id, storeRef)
 		}
@@ -286,6 +289,9 @@ func openSessionOwnsWork(legacyIdentifiers map[string]struct{}, scopedIdentifier
 		return false
 	}
 	if _, ok := refs[unresolvedOpenSessionStoreRef]; ok {
+		return true
+	}
+	if _, ok := refs[crossStoreOpenSessionStoreRef]; ok {
 		return true
 	}
 	_, ok := refs[workStoreRef]

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1693,6 +1693,82 @@ func TestReleaseOrphanedPoolAssignments_ReleasesRigWorkAssignedToUnreachableOpen
 	}
 }
 
+// A live, cross-store-eligible (city-scoped, Scope="city") open session
+// legitimately owns rig-routed work whose bead lives in a rig store — city
+// agents federate across every store (vp-kvp). The release path must recognize
+// that ownership and NOT reopen the bead. This is the exact inverse of
+// ReleasesRigWorkAssignedToUnreachableOpenSession, where the holder is
+// rig-scoped and genuinely cannot reach the work; here the holder can. Reopening
+// a live city holder's claim is the #3453 root cause: openSessionOwnsWork
+// returns false on a store-ref mismatch, demand reappears, and a backup worker
+// is minted on the same in_progress bead (duplicate token burn + double-write).
+func TestReleaseOrphanedPoolAssignments_KeepsCrossStoreEligibleHolderRigWork(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	session, err := cityStore.Create(beads.Bead{
+		Title:  "city worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name":         "worker-live",
+			"template":             "worker",
+			"agent_name":           "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create city session bead: %v", err)
+	}
+	work, err := rigStore.Create(beads.Bead{
+		Title:    "rig pool work owned by a live city session",
+		Assignee: "worker-live",
+		Metadata: map[string]string{"gc.routed_to": "repo/worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+	if err := rigStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set rig work status: %v", err)
+	}
+	work, err = rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload rig work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		cityStore,
+		&config.City{
+			Rigs: []config.Rig{{Name: "repo", Path: t.TempDir()}},
+			Agents: []config.Agent{
+				// The session's "worker" template resolves to this city-scoped
+				// agent (cross-store eligible). The rig agent below exists only so
+				// the work's routed "repo/worker" template resolves and the bead
+				// reaches the ownership gate instead of being skipped earlier.
+				{Name: "worker", Scope: "city", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)},
+				{Name: "worker", Dir: "repo", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)},
+			},
+		},
+		cityPath,
+		[]beads.Bead{session},
+		[]beads.Bead{work},
+		[]beads.Store{rigStore},
+		[]string{"repo"}, // work store-ref "repo" != city agent ref "" — the mismatch the fix must federate over
+		map[string]beads.Store{"repo": rigStore},
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none — a live city-scoped session owns rig-routed work across stores (vp-kvp)", released)
+	}
+
+	got, err := rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get rig work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-live" {
+		t.Fatalf("rig work = status %q assignee %q, want in_progress/worker-live (claim preserved)", got.Status, got.Assignee)
+	}
+}
+
 func TestStoreForPoolAssignment_UsesConfiguredHyphenatedIDPrefix(t *testing.T) {
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2701,20 +2701,7 @@ func sessionHasAwakeAssignedWorkForReachableStore(
 }
 
 func assignedWorkStoreRefForSession(cityPath string, cfg *config.City, session beads.Bead) (string, bool) {
-	if cfg == nil {
-		return "", false
-	}
-	template := normalizedSessionTemplate(session, cfg)
-	if template == "" {
-		template = strings.TrimSpace(session.Metadata["template"])
-	}
-	if template == "" {
-		template = strings.TrimSpace(session.Metadata["common_name"])
-	}
-	if template == "" {
-		return "", false
-	}
-	agentCfg := findAgentByTemplate(cfg, template)
+	agentCfg := sessionAgentConfig(cfg, session)
 	if agentCfg == nil {
 		return "", false
 	}


### PR DESCRIPTION
## What

`releaseOrphanedPoolAssignments` (the supervisor's orphan sweeper) reopened a
**live** city-scoped session's `in_progress` pool claim whenever the work bead
lived in a different store than the holder's resolved store-ref. The reopened
bead became unassigned-open, demand re-counted it as new work, and a backup
worker was minted on the same bead — two agents grinding the same work
(duplicate token burn + a double-write hazard on the output). This is the
release-layer root cause behind #3453.

## Root cause

The release path decides "has this holder abandoned its work?" through a chain
of gates. For a bead with an assignee, the first gate is `openSessionOwnsWork`,
and it is **not** an ownership check — it is an exact-equality *join* of two
store-refs derived from completely different places:

- **work side** — the ref is *where the bead physically lives*
  (`collectAssignedWorkBeadsWithStores`: city store → `""`, rig store → `rig.Name`).
- **session side** — the ref is *where the holder's agent is configured to read
  from* (`assignedWorkStoreRefForSession` → `configuredRigName`).

```go
// pool_session_name.go — openSessionOwnsWork (before)
refs := scopedIdentifiers[assignee]
if refs == nil { return false }
if _, ok := refs[unresolvedOpenSessionStoreRef]; ok { return true }
_, ok := refs[workStoreRef]   // strict equality — no cross-store federation
return ok
```

The two refs coincide in the common single-store case, so the gate usually
works. They **diverge** for a city-scoped (`Scope = "city"`) holder serving
rig-routed work: the work's physical ref is `"repo"`, but the city agent's
configured ref is `""`, so `openSessionOwnsWork` returns `false` and the chain
falls through to clear the claim — even though the holder demonstrably *can*
reach the bead (it claimed it and is working it).

The decisive part: the rest of the system **already knows** city-scoped agents
federate across every store. `assigned_work_scope.go` encodes exactly this for
the demand and session-wake filters:

```go
// agentIsCrossStoreEligible: Scope == "city"
// "crossStore identities ... are reachable from ANY store (vp-kvp).
//  They bypass the per-ref match."
```

The **release path never adopted that rule.** So its notion of "owner" is
strictly narrower than the demand path's, and a live city-scoped holder that the
demand path considers reachable gets its claim released anyway — a cross-store
dead-drop in the release direction.

## The fix

Teach the release path the same cross-store federation the demand and wake
filters already have. Cross-store-eligible open sessions are indexed under a
wildcard store-ref (`crossStoreOpenSessionStoreRef`) that `openSessionOwnsWork`
matches against any work store-ref:

- `openSessionReachableStoreRef` (new) resolves a session → agent and returns the
  wildcard for `Scope = "city"` agents, the unresolved sentinel when the agent
  can't be resolved (legacy fail-safe, unchanged), and the configured rig ref
  otherwise.
- `makeOpenSessionStoreRefIndex` uses it; `openSessionOwnsWork` treats the new
  wildcard like the existing unresolved sentinel.
- `sessionAgentConfig` extracts the session → agent resolution so
  `assignedWorkStoreRefForSession` and the new helper share one path (no
  behavior change to the former).

No schema/store changes. The change is scoped strictly to `Scope = "city"`
holders — **rig-scoped behavior is identical**, so genuinely unreachable work is
still released (see tests), preserving the #1544 / #564 phantom-bead respawn-loop
fix.

## Why this is the root cause, not another per-trigger guard

The investigation in #3453 found the release path is a *bundle of liveness
predicates*, and each prior fix bolted another predicate onto a specific symptom
(pending-interactive, idle-sleep, completed-and-draining). Those guards
compensate **after** ownership has already been mis-judged. Fixing the ownership
predicate itself closes the live-holder triggers at the source: any live holder
leaves an open session bead with the matching assignee, so once
`openSessionOwnsWork` recognizes it, the bead is never released and no backup is
minted — no pending-detection, TTL, or metadata stamp required.

## Tests (TDD)

- **`TestReleaseOrphanedPoolAssignments_KeepsCrossStoreEligibleHolderRigWork`**
  (new, written first / red→green): a live `Scope="city"` session holding
  rig-routed work (store-ref `"repo"`) must **not** be released. Fails on `main`
  (`released = [gc-1]`), passes with the fix.
- **`...ReleasesRigWorkAssignedToUnreachableOpenSession`** (existing, stays
  green): a **rig-scoped** holder that genuinely can't reach the work is still
  released — proves the fix doesn't over-retain and doesn't regress #1544/#564.
- Full `releaseOrphanedPoolAssignments` suite + the cross-store /
  store-ref / reconciler / desired-state / session-wake suites pass; `go build`,
  `go vet`, `gofmt` clean. (The monolithic `go test ./cmd/gc/` exceeds the 10m
  default — verified via the documented targeted suites per `TESTING.md`.)

## Relationship to #3458 and #3616 — thank you 🙏

Both of these PRs attacked the same duplicate-worker symptom from adjacent
layers, and their investigations are what surfaced the shared root cause:

- **#3458** (`don't orphan-release a live pending pool claim`) added a
  release-layer guard that skips release while the holder is alive and parked on
  an interactive prompt. That work pinpointed `openSessionOwnsWork` returning a
  transient `false` as the trigger — the thread that led directly here. With the
  ownership check fixed, the pending-interactive case (and the idle-sleep and
  completed-and-draining siblings) is recognized as owned at gate 1, so the
  dedicated pending predicate + 3h backstop + `pending_interaction_at` stamp are
  no longer needed.
- **#3616** (`consume pool route on claim`) hardened the claim/demand layer so a
  claimed bead leaves pool demand. Complementary framing of the same
  double-claim surface; its analysis helped delineate claim-layer vs
  release-layer.

Huge thanks to the authors and reviewers of both — this fix stands on that
analysis. Superseding both in favor of the single root-cause fix.

## Follow-ups (intentionally not bundled)

- `assigneePreservesNamedSessionRoute` (gate 2) has the same latent store-ref
  asymmetry for **named** cross-store sessions; the wake filter already
  special-cases them. Worth a symmetric follow-up with its own test.
- The structural end-state remains the work-claim lease (#3566): store-ref is a
  per-tick inference, and a holder-renewed lease would collapse the whole
  predicate bundle. This PR is the correct next commit; the lease is the
  architecture.

Closes #3453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
