### PR TITLE
fix(cli): gc unregister fails loudly on unknown name/path instead of false success (ga-m3ev9r)

### DIFF
--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -153,7 +153,24 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 		fmt.Fprintf(stderr, "gc unregister: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	entry, registered, _ := registeredCityEntry(cityPath)
+	entry, registered, lookupErr := registeredCityEntry(cityPath)
+	if lookupErr != nil {
+		fmt.Fprintf(stderr, "gc unregister: %v\n", lookupErr) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !registered {
+		// gc unregister takes a city directory path, not a name. The common
+		// footgun is passing the NAME shown by `gc cities`, or a wrong path:
+		// the target resolves to a path that was never registered. Fail loudly
+		// rather than exit 0 silently (non-JSON) or fabricate a success record
+		// (JSON), which would leave the city registered and mislead the caller.
+		rawArg := ""
+		if len(args) > 0 {
+			rawArg = args[0]
+		}
+		writeUnregisterNotRegistered(stderr, rawArg, cityPath)
+		return 1
+	}
 	unregisterStdout := stdout
 	var unregisterProgress bytes.Buffer
 	if jsonOut {
@@ -167,17 +184,25 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 	if !jsonOut {
 		return code
 	}
-	cityName := ""
-	if registered {
-		cityName = entry.EffectiveName()
-	}
 	return writeLifecycleActionJSONOrExit(stdout, stderr, "gc unregister", lifecycleActionJSON{
 		Command:  "unregister",
 		Action:   "unregister",
 		Message:  "City unregistered.",
-		CityName: cityName,
+		CityName: entry.EffectiveName(),
 		CityPath: cityPath,
 	})
+}
+
+// writeUnregisterNotRegistered emits an actionable diagnostic when the
+// unregister target does not resolve to a registered city. rawArg is the
+// original CLI argument (empty when the city was discovered from cwd) and
+// cityPath is the resolved absolute path that failed to match.
+func writeUnregisterNotRegistered(stderr io.Writer, rawArg, cityPath string) {
+	fmt.Fprintf(stderr, "gc unregister: no registered city at %s\n", cityPath) //nolint:errcheck // best-effort stderr
+	if trimmed := strings.TrimSpace(rawArg); trimmed != "" && trimmed != cityPath {
+		fmt.Fprintf(stderr, "gc unregister: %q was treated as a path — gc unregister takes a city directory path, not a name\n", trimmed) //nolint:errcheck // best-effort stderr
+	}
+	fmt.Fprintf(stderr, "gc unregister: run 'gc cities' to see registered cities, then 'gc unregister <path>'\n") //nolint:errcheck // best-effort stderr
 }
 
 func replayJSONModeProgress(stderr io.Writer, progress *bytes.Buffer) {

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -121,7 +121,10 @@ func newUnregisterCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Remove a city from the machine-wide supervisor registry.
 
 If no path is given, unregisters the current city (discovered from cwd).
-If the supervisor is running, it immediately stops managing the city.`,
+If the supervisor is running, it immediately stops managing the city.
+Takes a city directory path, not the name shown by 'gc cities'. Unlike
+'gc register' (which is idempotent), this errors when the resolved path is not
+a registered city, so it is not a silent no-op on an unknown target.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if doUnregisterJSON(args, jsonOut, stdout, stderr) != 0 {
@@ -158,16 +161,16 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 		fmt.Fprintf(stderr, "gc unregister: %v\n", lookupErr) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	rawArg := ""
+	if len(args) > 0 {
+		rawArg = args[0]
+	}
 	if !registered {
 		// gc unregister takes a city directory path, not a name. The common
 		// footgun is passing the NAME shown by `gc cities`, or a wrong path:
 		// the target resolves to a path that was never registered. Fail loudly
 		// rather than exit 0 silently (non-JSON) or fabricate a success record
 		// (JSON), which would leave the city registered and mislead the caller.
-		rawArg := ""
-		if len(args) > 0 {
-			rawArg = args[0]
-		}
 		writeUnregisterNotRegistered(stderr, rawArg, cityPath)
 		return 1
 	}
@@ -176,10 +179,21 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 	if jsonOut {
 		unregisterStdout = &unregisterProgress
 	}
-	_, code := unregisterCityFromSupervisor(cityPath, unregisterStdout, stderr)
+	handled, code := unregisterCityFromSupervisor(cityPath, unregisterStdout, stderr)
 	if code != 0 {
 		replayJSONModeProgress(stderr, &unregisterProgress)
 		return code
+	}
+	if !handled {
+		// The registration disappeared between the pre-check above and the
+		// helper's own registry read — a concurrent `gc stop` / `gc unregister`
+		// from another process. The helper reports (handled=false, code=0) for
+		// that not-registered state and writes nothing to stdout, so treat it as
+		// the loud not-registered failure instead of emitting a fabricated
+		// success record. The helper's handled bool, not the earlier pre-check,
+		// is the authority on whether anything was actually unregistered.
+		writeUnregisterNotRegistered(stderr, rawArg, cityPath)
+		return 1
 	}
 	if !jsonOut {
 		return code
@@ -199,8 +213,13 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 // cityPath is the resolved absolute path that failed to match.
 func writeUnregisterNotRegistered(stderr io.Writer, rawArg, cityPath string) {
 	fmt.Fprintf(stderr, "gc unregister: no registered city at %s\n", cityPath) //nolint:errcheck // best-effort stderr
-	if trimmed := strings.TrimSpace(rawArg); trimmed != "" && trimmed != cityPath {
-		fmt.Fprintf(stderr, "gc unregister: %q was treated as a path — gc unregister takes a city directory path, not a name\n", trimmed) //nolint:errcheck // best-effort stderr
+	// Only the bare-NAME footgun warrants the name-vs-path hint. A path-shaped
+	// argument (relative like ./city, a trailing slash, or a symlink) is a
+	// genuine path that simply was not registered; comparing the raw token to
+	// the fully normalized cityPath would misfire and contradict the diagnostic,
+	// so gate on "no path separator" instead of raw-string inequality.
+	if trimmed := strings.TrimSpace(rawArg); trimmed != "" && !strings.ContainsRune(trimmed, filepath.Separator) {
+		fmt.Fprintf(stderr, "gc unregister: %q looks like a name — gc unregister takes a city directory path, not a name\n", trimmed) //nolint:errcheck // best-effort stderr
 	}
 	fmt.Fprintf(stderr, "gc unregister: run 'gc cities' to see registered cities, then 'gc unregister <path>'\n") //nolint:errcheck // best-effort stderr
 }

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -486,6 +486,136 @@ func TestDoUnregister(t *testing.T) {
 	}
 }
 
+// gc unregister takes a city directory path, not a name. When the argument
+// does not resolve to a registered city — the common footgun is passing the
+// NAME shown by `gc cities`, or a wrong path — unregister must fail loudly
+// instead of silently exiting 0 (non-JSON) or reporting a false success
+// (JSON). Regression for ga-m3ev9r.
+func TestDoUnregisterUnknownTargetFailsLoudly(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GC_HOME", dir)
+
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "my-city"); err != nil {
+		t.Fatal(err)
+	}
+
+	// An absolute path that is not registered — the same not-registered code
+	// path a bare name like "my-city" hits once it is resolved relative to cwd.
+	ghostPath := filepath.Join(dir, "ghost-city")
+
+	var stdout, stderr bytes.Buffer
+	code := doUnregister([]string{ghostPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no registered city") {
+		t.Fatalf("stderr = %q, want a 'no registered city' diagnostic", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "gc cities") {
+		t.Fatalf("stderr = %q, want a pointer to 'gc cities'", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Unregistered city") {
+		t.Fatalf("stdout = %q, want no false success message", stdout.String())
+	}
+
+	// The real registration must be left untouched.
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("registry entries = %v, want the original city left registered", entries)
+	}
+}
+
+func TestDoUnregisterJSONUnknownTargetDoesNotReportFalseSuccess(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GC_HOME", dir)
+
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "my-city"); err != nil {
+		t.Fatal(err)
+	}
+
+	ghostPath := filepath.Join(dir, "ghost-city")
+
+	var stdout, stderr bytes.Buffer
+	code := doUnregisterJSON([]string{ghostPath}, true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	// doUnregisterJSON must not emit a success record; the central JSON
+	// failure envelope is written by run() when RunE returns errExit.
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty JSON stdout on failure", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "no registered city") {
+		t.Fatalf("stderr = %q, want a 'no registered city' diagnostic", stderr.String())
+	}
+
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("registry entries = %v, want the original city left registered", entries)
+	}
+}
+
+// End-to-end through run(): the --json failure envelope must report ok:false,
+// not the previous fabricated {"ok":true,"message":"City unregistered."}.
+func TestUnregisterUnknownTargetJSONEnvelopeReportsNotOK(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GC_HOME", dir)
+
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "my-city"); err != nil {
+		t.Fatal(err)
+	}
+
+	ghostPath := filepath.Join(dir, "ghost-city")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"unregister", ghostPath, "--json"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "City unregistered") {
+		t.Fatalf("stdout = %q, want no false success message", stdout.String())
+	}
+	var env struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout is not a JSON envelope: %v\n%s", err, stdout.String())
+	}
+	if env.OK {
+		t.Fatalf("stdout ok = true, want false: %s", stdout.String())
+	}
+}
+
 func TestDoCities(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GC_HOME", dir)

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -616,6 +616,45 @@ func TestUnregisterUnknownTargetJSONEnvelopeReportsNotOK(t *testing.T) {
 	}
 }
 
+// The name-vs-path hint must fire for a bare NAME (the common footgun of
+// passing the name shown by `gc cities`). Regression for ga-m3ev9r.
+func TestWriteUnregisterNotRegisteredNameHint(t *testing.T) {
+	var stderr bytes.Buffer
+	writeUnregisterNotRegistered(&stderr, "my-city", "/abs/my-city")
+	out := stderr.String()
+	if !strings.Contains(out, "no registered city at /abs/my-city") {
+		t.Fatalf("stderr = %q, want a 'no registered city' line", out)
+	}
+	if !strings.Contains(out, "not a name") {
+		t.Fatalf("stderr = %q, want the name-vs-path hint for a bare name", out)
+	}
+	if !strings.Contains(out, "gc cities") {
+		t.Fatalf("stderr = %q, want the 'gc cities' guidance", out)
+	}
+}
+
+// The name-vs-path hint must NOT fire for a path-shaped argument (relative
+// path, trailing slash, or nested path). Those are genuine paths that simply
+// were not registered, so claiming they "look like a name" contradicts the
+// diagnostic. Comparing the raw token to the fully normalized cityPath used to
+// misfire here. Regression for ga-m3ev9r finding #2.
+func TestWriteUnregisterNotRegisteredPathShapedNoNameHint(t *testing.T) {
+	for _, rawArg := range []string{"./my-city", "/abs/my-city/", "sub/my-city"} {
+		var stderr bytes.Buffer
+		writeUnregisterNotRegistered(&stderr, rawArg, "/abs/my-city")
+		out := stderr.String()
+		if !strings.Contains(out, "no registered city at /abs/my-city") {
+			t.Fatalf("rawArg=%q stderr = %q, want a 'no registered city' line", rawArg, out)
+		}
+		if strings.Contains(out, "not a name") {
+			t.Fatalf("rawArg=%q stderr = %q, name-vs-path hint must not fire for a path-shaped arg", rawArg, out)
+		}
+		if !strings.Contains(out, "gc cities") {
+			t.Fatalf("rawArg=%q stderr = %q, want the 'gc cities' guidance", rawArg, out)
+		}
+	}
+}
+
 func TestDoCities(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GC_HOME", dir)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4106,6 +4106,9 @@ Remove a city from the machine-wide supervisor registry.
 
 If no path is given, unregisters the current city (discovered from cwd).
 If the supervisor is running, it immediately stops managing the city.
+Takes a city directory path, not the name shown by 'gc cities'. Unlike
+'gc register' (which is idempotent), this errors when the resolved path is not
+a registered city, so it is not a silent no-op on an unknown target.
 
 ```
 gc unregister [path] [flags]

--- a/test/acceptance/helpers/city.go
+++ b/test/acceptance/helpers/city.go
@@ -18,13 +18,12 @@ import (
 // isolated environment, providing high-level methods that shell out to
 // the real gc binary.
 type City struct {
-	t              *testing.T
-	Dir            string
-	Env            *Env
-	started        bool
-	usedSupervisor bool
-	cmd            *exec.Cmd
-	logFile        *os.File
+	t       *testing.T
+	Dir     string
+	Env     *Env
+	started bool
+	cmd     *exec.Cmd
+	logFile *os.File
 }
 
 // NewCity creates a temp directory for a city and returns the DSL handle.
@@ -229,12 +228,10 @@ func (c *City) Stop() {
 		return
 	}
 	c.started = false
-	// Best-effort stop — don't fail the test on cleanup errors.
+	// Best-effort stop — don't fail the test on cleanup errors. gc stop also
+	// unregisters a supervisor-registered city, so no explicit unregister is
+	// needed here.
 	RunGC(c.Env, c.Dir, "stop", c.Dir) //nolint:errcheck
-	if c.usedSupervisor {
-		RunGC(c.Env, c.Dir, "unregister", c.Dir) //nolint:errcheck
-		c.usedSupervisor = false
-	}
 	if c.cmd != nil {
 		done := make(chan struct{})
 		go func() {
@@ -259,11 +256,10 @@ func (c *City) Stop() {
 
 func (c *City) cleanupRuntime() {
 	c.t.Helper()
+	// gc stop unregisters a supervisor-registered city, so a follow-up gc
+	// unregister would now fail loudly on the already-cleared registry.
 	if out, err := RunGC(c.Env, c.Dir, "stop", c.Dir); err != nil {
 		c.t.Logf("cleanup: gc stop %s: %v\n%s", c.Dir, err, out)
-	}
-	if out, err := RunGC(c.Env, c.Dir, "unregister", c.Dir); err != nil {
-		c.t.Logf("cleanup: gc unregister %s: %v\n%s", c.Dir, err, out)
 	}
 	if out, err := RunGC(c.Env, "", "supervisor", "stop", "--wait"); err != nil {
 		c.t.Logf("cleanup: gc supervisor stop --wait: %v\n%s", err, out)
@@ -272,11 +268,11 @@ func (c *City) cleanupRuntime() {
 
 func (c *City) cleanupScaffoldOnly() {
 	c.t.Helper()
+	// gc stop unregisters the city when it is registered, so an explicit gc
+	// unregister is unnecessary and would now fail loudly on an unregistered
+	// scaffold-only city.
 	if out, err := RunGC(c.Env, c.Dir, "stop", c.Dir); err != nil {
 		c.t.Logf("cleanup: gc stop %s: %v\n%s", c.Dir, err, out)
-	}
-	if out, err := RunGC(c.Env, c.Dir, "unregister", c.Dir); err != nil {
-		c.t.Logf("cleanup: gc unregister %s: %v\n%s", c.Dir, err, out)
 	}
 }
 

--- a/test/acceptance/helpers/lifecycle.go
+++ b/test/acceptance/helpers/lifecycle.go
@@ -27,7 +27,6 @@ func (c *City) StartWithSupervisor() {
 		c.t.Fatalf("gc start failed: %v\n%s", err, out)
 	}
 	c.started = true
-	c.usedSupervisor = true
 	c.t.Cleanup(func() {
 		c.Stop()
 		RunGC(c.Env, "", "supervisor", "stop", "--wait") //nolint:errcheck

--- a/test/acceptance/supervisor_registry_test.go
+++ b/test/acceptance/supervisor_registry_test.go
@@ -33,9 +33,17 @@ func TestRegisterUnregister(t *testing.T) {
 	c := helpers.NewCity(t, testEnv)
 	c.Init("claude")
 
-	// gc init starts a standalone controller. Stop it first so register
-	// can hand management to the supervisor.
+	// gc init registers the city and starts its controller; gc stop both
+	// stops that controller and unregisters the city. Stop here so the
+	// register/unregister lifecycle below starts from an empty registry.
 	c.GC("stop", c.Dir) //nolint:errcheck
+
+	t.Run("Register", func(t *testing.T) {
+		out, err := c.GC("register", c.Dir)
+		if err != nil {
+			t.Fatalf("gc register failed: %v\n%s", err, out)
+		}
+	})
 
 	t.Run("Unregister", func(t *testing.T) {
 		out, err := c.GC("unregister", c.Dir)
@@ -44,10 +52,18 @@ func TestRegisterUnregister(t *testing.T) {
 		}
 	})
 
-	t.Run("RegisterAfterUnregister", func(t *testing.T) {
-		out, err := c.GC("register", c.Dir)
-		if err != nil {
-			t.Fatalf("gc register after unregister failed: %v\n%s", err, out)
+	t.Run("UnregisterNotRegisteredFailsLoudly", func(t *testing.T) {
+		// The previous subtest unregistered the city, so the path no longer
+		// resolves to a registered city. gc unregister must fail loudly
+		// instead of reporting a false success (ga-m3ev9r) — otherwise a
+		// mistyped path, or a name passed where a path belongs, looks like it
+		// worked while the city stays registered.
+		out, err := c.GC("unregister", c.Dir)
+		if err == nil {
+			t.Fatalf("gc unregister on a not-registered city succeeded; want failure\n%s", out)
+		}
+		if !strings.Contains(out, "no registered city") {
+			t.Fatalf("gc unregister output = %q, want a 'no registered city' diagnostic", out)
 		}
 	})
 

--- a/test/acceptance/tier_b/idle_bead_stability_test.go
+++ b/test/acceptance/tier_b/idle_bead_stability_test.go
@@ -28,12 +28,10 @@ func TestGastownIdleOpenBeadCountsStayBounded(t *testing.T) {
 	c.InitFrom(filepath.Join(helpers.ExamplesDir(), "gastown"))
 
 	// gc init --from starts a controller for the copied city. Restart under the
-	// isolated supervisor after installing the fast idle orders below.
+	// isolated supervisor after installing the fast idle orders below. gc stop
+	// also unregisters the city, so no explicit unregister is needed.
 	if out, err := c.GC("stop", c.Dir); err != nil {
 		t.Logf("gc stop after init-from: %v\n%s", err, out)
-	}
-	if out, err := c.GC("unregister", c.Dir); err != nil {
-		t.Logf("gc unregister after init-from: %v\n%s", err, out)
 	}
 
 	rewriteGastownPatrolInterval(t, c.Dir, "1s")

--- a/test/acceptance/tier_b/lifecycle_b_test.go
+++ b/test/acceptance/tier_b/lifecycle_b_test.go
@@ -429,13 +429,11 @@ func TestLifecycle_PackCacheSelfHealsOnStart(t *testing.T) {
 	c := helpers.NewCity(t, testEnvB)
 	c.InitFrom(filepath.Join(helpers.ExamplesDir(), "gastown"))
 
-	// gc init --from now completes startup registration, so stop and
-	// unregister before exercising the explicit gc start path below.
+	// gc init --from completes startup registration and starts a controller.
+	// gc stop both stops that controller and unregisters the city, leaving an
+	// empty registry before the explicit gc start path is exercised below.
 	if out, err := c.GC("stop", c.Dir); err != nil {
 		t.Fatalf("gc stop after init-from failed: %v\n%s", err, out)
-	}
-	if out, err := c.GC("unregister", c.Dir); err != nil {
-		t.Fatalf("gc unregister after init-from failed: %v\n%s", err, out)
 	}
 
 	cacheRoot := filepath.Join(testEnvB.Get("GC_HOME"), "cache", "repos")

--- a/test/acceptance/worker_inference/worker_handle_city_helpers_test.go
+++ b/test/acceptance/worker_inference/worker_handle_city_helpers_test.go
@@ -131,8 +131,9 @@ func restoreRealHomeDuring(env *helpers.Env) func() {
 func teardownLiveHandleCityRuntime(env *helpers.Env, cityDir string) {
 	restoreHome := restoreRealHomeDuring(env)
 	defer restoreHome()
+	// gc stop also unregisters the city, so a follow-up gc unregister would now
+	// fail loudly on the already-cleared registry.
 	_, _ = runGCWithTimeout(liveShutdownTimeout, env, cityDir, "stop", cityDir)
-	_, _ = runGCWithTimeout(liveShutdownTimeout, env, cityDir, "unregister", cityDir)
 	_, _ = runGCWithTimeout(liveShutdownTimeout, env, "", "supervisor", "stop", "--wait")
 }
 


### PR DESCRIPTION
## Problem

A user reported `gc unregister` "not working" after installing 1.3.1. Reproduced from a supplied city: running `gc unregister <name>` (the **name** shown by `gc cities`) — or any non-matching path — leaves the city registered while reporting success.

- **non-JSON:** silently exits `0`, prints nothing.
- **`--json`:** emits a fabricated success — `{"ok":true,"message":"City unregistered.","city_path":"..."}` — for a city that was never registered.

## Root cause

`gc unregister <arg>` resolves `<arg>` strictly as a path (`filepath.Abs`) and matches the supervisor registry by normalized path. `register`/`start`/`stop`/`unregister` all take a **path**, never a name, so passing the name resolves to `$cwd/<name>`, which matches nothing.

On no-match, `unregisterCityFromSupervisor` returns `(false, 0)`. `doUnregisterJSON` only checked that exit code, so:
- non-JSON returned `0`;
- `--json` fell through to `writeLifecycleActionJSONOrExit`, which **hardcodes `OK=true`** (`lifecycle_action_json.go`), fabricating success.

The registry lookup error was also swallowed (`entry, registered, _ := registeredCityEntry(...)`).

## Fix

In `doUnregisterJSON` (the single entrypoint for both modes): when the target isn't a registered city, write an actionable stderr diagnostic and return non-zero **without** emitting a success record. The central `--json` failure handler in `run()` then emits `{"ok":false,...}`. The previously swallowed lookup error is now surfaced.

```
$ gc unregister chris-city
gc unregister: no registered city at /Users/chris/work/chris-city
gc unregister: "chris-city" was treated as a path — gc unregister takes a city directory path, not a name
gc unregister: run 'gc cities' to see registered cities, then 'gc unregister <path>'
$ echo $?   # 1
```

The shared `unregisterCityFromSupervisor*` helper is **unchanged**, so `gc stop`'s intentional "not supervisor-managed → fall through to standalone stop" routing is preserved.

## Scope

This is the "fail loudly" fix only. Accepting a bare **name** across `register`/`start`/`stop`/`unregister` is a deliberate follow-up (tracked under ga-m3ev9r).

## Sibling audit

Audited the related command groups (`stop`, `start`, `restart`, `reload`, `suspend`, `status`, `events`, `supervisor *`, `rig`, `register`/`init`, and id-based mutators) for the same "resolve-target-then-falsely-report-success" class. **No other instances found** — siblings either fail loudly (rig commands use `writeJSONError`), intentionally fall through to standalone paths (`stop`/`restart` on unmanaged cities), or use `registeredCityEntry` only as a probe/name-resolver.

## Test plan

New regression tests in `cmd_register_test.go`:
- `TestDoUnregisterUnknownTargetFailsLoudly` — non-JSON: exit 1, actionable stderr, registry untouched.
- `TestDoUnregisterJSONUnknownTargetDoesNotReportFalseSuccess` — JSON: exit 1, no success record on stdout.
- `TestUnregisterUnknownTargetJSONEnvelopeReportsNotOK` — e2e via `run()`: `--json` envelope reports `ok:false`.

Existing `TestDoUnregister` (correct path) and `TestDoUnregisterJSONFailureReplaysHelperProgressToStderr` still pass. Full local pre-commit gate green: `lint-changed` (0 issues), `go vet ./...`, all fast test shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)