### PR TITLE
fix(supervisor): orphan-release strands live city-scoped NAMED holders (cross-store ownership)

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -467,7 +467,7 @@ func assigneePreservesNamedSessionRoute(cfg *config.City, cityPath, template, as
 	// City-scoped named sessions federate across every store (vp-kvp), exactly
 	// as filterAssignedWorkBeadsForSessionWake already treats them. Without this
 	// a live city-scoped named holder's rig-routed claim is released and a backup
-	// worker is minted on the same bead — the named-route analogue of the
+	// worker is minted on the same bead — the named-route analog of the
 	// pool-worker openSessionOwnsWork cross-store fix (#3453).
 	if agentIsCrossStoreEligible(spec.Agent) {
 		return true

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -464,6 +464,14 @@ func assigneePreservesNamedSessionRoute(cfg *config.City, cityPath, template, as
 	if !storeRefAware {
 		return true
 	}
+	// City-scoped named sessions federate across every store (vp-kvp), exactly
+	// as filterAssignedWorkBeadsForSessionWake already treats them. Without this
+	// a live city-scoped named holder's rig-routed claim is released and a backup
+	// worker is minted on the same bead — the named-route analogue of the
+	// pool-worker openSessionOwnsWork cross-store fix (#3453).
+	if agentIsCrossStoreEligible(spec.Agent) {
+		return true
+	}
 	return assignedWorkStoreRefForAgent(cityPath, cfg, spec.Agent) == workStoreRef
 }
 

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1917,6 +1917,68 @@ func TestReleaseOrphanedPoolAssignments_ReleasesNamedIdentityForUnreachableStore
 	}
 }
 
+// A live, cross-store-eligible (city-scoped, Scope="city") NAMED session
+// legitimately owns rig-routed work whose bead lives in a rig store (vp-kvp).
+// assigneePreservesNamedSessionRoute must preserve that claim instead of letting
+// the bead be released — the named-route analogue of the pool-worker
+// openSessionOwnsWork cross-store fix (#3453). Without it a backup worker is
+// minted on the same in_progress bead. Contrast
+// ReleasesNamedIdentityForUnreachableStore, where the named agent is rig-scoped
+// and genuinely cannot reach the work, so release is still correct.
+func TestReleaseOrphanedPoolAssignments_PreservesCrossStoreEligibleNamedIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	work, err := rigStore.Create(beads.Bead{
+		Title:    "rig work owned by a city-scoped named session",
+		Assignee: "reviewer",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+	if err := rigStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set rig work status: %v", err)
+	}
+	work, err = rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload rig work bead: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs:   []config.Rig{{Name: "repo", Path: t.TempDir()}},
+		Agents: []config.Agent{{Name: "worker", Scope: "city", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "reviewer",
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+		ResolvedWorkspaceName: "test-city",
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		cityStore,
+		cfg,
+		cityPath,
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{rigStore},
+		[]string{"repo"}, // rig store-ref != city named agent ref "" — the mismatch the fix must federate over
+		map[string]beads.Store{"repo": rigStore},
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none — a live city-scoped named session owns rig-routed work across stores (vp-kvp)", released)
+	}
+
+	got, err := rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get rig work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "reviewer" {
+		t.Fatalf("rig work = status %q assignee %q, want in_progress/reviewer (claim preserved)", got.Status, got.Assignee)
+	}
+}
+
 func TestReleaseOrphanedPoolAssignments_PreservesNamedIdentityForSameStore(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1920,7 +1920,7 @@ func TestReleaseOrphanedPoolAssignments_ReleasesNamedIdentityForUnreachableStore
 // A live, cross-store-eligible (city-scoped, Scope="city") NAMED session
 // legitimately owns rig-routed work whose bead lives in a rig store (vp-kvp).
 // assigneePreservesNamedSessionRoute must preserve that claim instead of letting
-// the bead be released — the named-route analogue of the pool-worker
+// the bead be released — the named-route analog of the pool-worker
 // openSessionOwnsWork cross-store fix (#3453). Without it a backup worker is
 // minted on the same in_progress bead. Contrast
 // ReleasesNamedIdentityForUnreachableStore, where the named agent is rig-scoped


### PR DESCRIPTION
## What

`assigneePreservesNamedSessionRoute` — gate 2 of `releaseOrphanedPoolAssignments`
— released a **live** city-scoped **named** session's `in_progress` rig-routed
claim, because it did a strict store-ref-equality check and ignored that
city-scoped agents federate across every store. The reopened bead re-entered
pool demand and a backup worker was minted on the same bead (duplicate token
burn + double-write hazard).

This is the **named-route analogue** of #3621, which fixed the same defect in the
pool-worker ownership gate (`openSessionOwnsWork`).

## Root cause

For a bead routed to a named session, gate 2 preserves the claim only when the
named session's configured rig ref equals the work's store-ref:

```go
// before
if !storeRefAware { return true }
return assignedWorkStoreRefForAgent(cityPath, cfg, spec.Agent) == workStoreRef
```

A city-scoped (`Scope = "city"`) named session resolves to ref `""` but
legitimately serves rig-routed work whose bead lives in a rig store (`"repo"`),
so the equality fails and the live holder's claim is released. The rest of the
system already knows city agents are cross-store reachable —
`filterAssignedWorkBeadsForSessionWake` special-cases exactly this
(`assigned_work_scope.go`):

```go
if agentIsCrossStoreEligible(spec.Agent) {
    crossStore[...] = struct{}{}   // reachable from ANY store (vp-kvp)
    continue
}
```

The release path's named-route gate never adopted that rule.

## The fix

Honor cross-store eligibility in gate 2, mirroring the wake filter:

```go
if agentIsCrossStoreEligible(spec.Agent) {
    return true
}
return assignedWorkStoreRefForAgent(cityPath, cfg, spec.Agent) == workStoreRef
```

Scoped strictly to `Scope = "city"` named agents — **rig-scoped named sessions
are unchanged**, so genuinely unreachable named work is still released.

## Tests (TDD)

- **`TestReleaseOrphanedPoolAssignments_PreservesCrossStoreEligibleNamedIdentity`**
  (new, red→green): a live `Scope="city"` named session holding rig-routed work
  must **not** be released. Fails on `main` (`released = [gc-1]`), passes with the
  fix.
- **`...ReleasesNamedIdentityForUnreachableStore`** (existing, stays green): a
  rig-scoped named agent that genuinely can't reach the work is still released —
  proves no over-retention.
- Full `releaseOrphanedPoolAssignments` + named-route + cross-store suites pass;
  `go build`, `go vet`, `gofmt`, and `make test-fast-parallel` clean.

## Relationship

- **Follow-up to #3621** (pool-worker `openSessionOwnsWork` cross-store fix). Same
  root cause — the release path's ownership gates apply strict store-ref equality
  where the demand/wake paths federate city-scoped agents across stores. #3621
  covers the generic pool-worker gate; this covers the named-route gate. Both are
  independent (different functions), so this stacks cleanly even before #3621
  merges.
- Related: #3453 (the umbrella double-worker bug, closed by #3621).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
