### PR TITLE
feat(cli): accept a bare city name across city-targeting commands (ga-m3ev9r)

### DIFF
--- a/cmd/gc/city_arg_resolve.go
+++ b/cmd/gc/city_arg_resolve.go
@@ -67,11 +67,35 @@ func resolveCityRef(ref string, opts cityRefOpts, pathResolve func(string) (stri
 	if classifyCityRef(ref) != cityRefName || !opts.allowNameFallback {
 		return pathResolve(ref)
 	}
-	name := strings.TrimSpace(ref)
-
-	cwd, err := os.Getwd()
+	registeredPath, useLocal, err := resolveCityNameRef(strings.TrimSpace(ref))
 	if err != nil {
-		return "", fmt.Errorf("resolving working directory: %w", err)
+		return "", err
+	}
+	if useLocal {
+		// The local city wins. Route through the command's path resolver so the
+		// path branch behaves exactly as if a path were supplied; because
+		// cwd/<name> is a real city, findCity returns it without walking up.
+		return pathResolve(strings.TrimSpace(ref))
+	}
+	return registeredPath, nil
+}
+
+// resolveCityNameRef resolves a name-shaped city reference (the caller
+// guarantees classifyCityRef(name) == cityRefName) against the cwd and the
+// supervisor registry:
+//
+//   - useLocal == true: cwd/<name> is itself a city; the caller should resolve
+//     it as a local path.
+//   - registeredPath != "": the name resolves to a registered city.
+//   - err != nil: ambiguous (a local city AND a different registration) or not
+//     found (neither a local city nor a registered name).
+//
+// It never feeds the name to a path resolver, so findCity's upward walk can
+// never silently resolve a bare name to an ambient ancestor city.
+func resolveCityNameRef(name string) (registeredPath string, useLocal bool, err error) {
+	cwd, werr := os.Getwd()
+	if werr != nil {
+		return "", false, fmt.Errorf("resolving working directory: %w", werr)
 	}
 	localDir := filepath.Join(cwd, name)
 	localIsCity := citylayout.HasCityConfig(localDir)
@@ -80,19 +104,31 @@ func resolveCityRef(ref string, opts cityRefOpts, pathResolve func(string) (stri
 
 	switch {
 	case localIsCity && registered && !samePath(localDir, entry.Path):
-		return "", fmt.Errorf(
-			"%q is ambiguous: it is both a local city directory (%s) and a registered city at %s; pass ./%s for the local one, or cd elsewhere to use the registered city",
-			name, localDir, entry.Path, name)
+		return "", false, cityRefAmbiguousErr(name, localDir, entry.Path)
 	case localIsCity:
-		// The local city wins. Route through the command's path resolver so the
-		// path branch behaves exactly as if a path were supplied; because
-		// cwd/<name> is a real city, findCity returns it without walking up.
-		return pathResolve(name)
+		return "", true, nil
 	case registered:
-		return entry.Path, nil
+		return entry.Path, false, nil
 	default:
-		return "", fmt.Errorf(
-			"%q is not a registered city name, and %s is not a city directory (run 'gc cities' to list registered cities)",
-			name, localDir)
+		return "", false, cityRefNotFoundErr(name, localDir)
 	}
+}
+
+func cityRefAmbiguousErr(name, localDir, registeredPath string) error {
+	return fmt.Errorf(
+		"%q is ambiguous: it is both a local city directory (%s) and a registered city at %s; pass ./%s for the local one, or cd elsewhere to use the registered city",
+		name, localDir, registeredPath, name)
+}
+
+func cityRefNotFoundErr(name, localDir string) error {
+	return fmt.Errorf(
+		"%q is not a registered city name, and %s is not a city directory (run 'gc cities' to list registered cities)",
+		name, localDir)
+}
+
+// resolveCityFlagValue resolves the --city flag value, accepting either a
+// directory path or a registered city name (parallel to the positional
+// argument). validateCityPath provides the path branch.
+func resolveCityFlagValue(city string) (string, error) {
+	return resolveCityRef(city, cityRefOpts{cmd: "gc", allowNameFallback: true}, validateCityPath)
 }

--- a/cmd/gc/city_arg_resolve.go
+++ b/cmd/gc/city_arg_resolve.go
@@ -78,6 +78,61 @@ func resolveCityRef(ref string, opts cityRefOpts, pathResolve func(string) (stri
 	return registeredPath, nil
 }
 
+// cityNameFacts captures what a name-shaped city reference resolves to against
+// the cwd and the supervisor registry, before any command-specific path or rig
+// resolution. It is the single source of truth for the local-city vs
+// registered-name routing decision, shared by every command that accepts a bare
+// name so the trimming and fallback semantics cannot drift between call sites.
+type cityNameFacts struct {
+	name        string // the trimmed reference
+	localDir    string // cwd/<name>
+	localIsCity bool   // localDir is itself a city (city.toml or .gc/ runtime root)
+	registered  bool   // <name> matches a registered city
+	regPath     string // the registered city's path (meaningful when registered)
+	loadErr     error  // registry read failure, deferred until a genuine miss
+}
+
+// lookupCityNameFacts gathers the local-city and registered-name facts for a
+// name-shaped reference. It trims the reference once here so callers never pass
+// a raw, space-padded arg on to a path resolver. The registry read error is
+// returned as a deferred fact (not an immediate failure) because a corrupt
+// registry only changes the outcome when the name does not otherwise resolve to
+// a local city.
+func lookupCityNameFacts(name string) (cityNameFacts, error) {
+	trimmed := strings.TrimSpace(name)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return cityNameFacts{}, fmt.Errorf("resolving working directory: %w", err)
+	}
+	localDir := filepath.Join(cwd, trimmed)
+	entry, registered, loadErr := supervisor.NewRegistry(supervisor.RegistryPath()).LookupCityByNameE(trimmed)
+	return cityNameFacts{
+		name:        trimmed,
+		localDir:    localDir,
+		localIsCity: citylayout.HasCityConfig(localDir) || citylayout.HasRuntimeRoot(localDir),
+		registered:  registered,
+		regPath:     entry.Path,
+		loadErr:     loadErr,
+	}, nil
+}
+
+// ambiguous reports whether the name denotes both a distinct local city and a
+// registered city, which callers must reject loudly so neither is targeted by
+// accident.
+func (f cityNameFacts) ambiguous() bool {
+	return f.localIsCity && f.registered && !samePath(f.localDir, f.regPath)
+}
+
+// notFoundErr is the terminal error for a name that resolved to nothing. It
+// surfaces a deferred registry read failure rather than masquerading a corrupt
+// registry as a clean "not registered" miss.
+func (f cityNameFacts) notFoundErr() error {
+	if f.loadErr != nil {
+		return fmt.Errorf("looking up registered city %q: %w", f.name, f.loadErr)
+	}
+	return cityRefNotFoundErr(f.name, f.localDir)
+}
+
 // resolveCityNameRef resolves a name-shaped city reference (the caller
 // guarantees classifyCityRef(name) == cityRefName) against the cwd and the
 // supervisor registry:
@@ -91,25 +146,77 @@ func resolveCityRef(ref string, opts cityRefOpts, pathResolve func(string) (stri
 // It never feeds the name to a path resolver, so findCity's upward walk can
 // never silently resolve a bare name to an ambient ancestor city.
 func resolveCityNameRef(name string) (registeredPath string, useLocal bool, err error) {
-	cwd, werr := os.Getwd()
-	if werr != nil {
-		return "", false, fmt.Errorf("resolving working directory: %w", werr)
+	f, err := lookupCityNameFacts(name)
+	if err != nil {
+		return "", false, err
 	}
-	localDir := filepath.Join(cwd, name)
-	localIsCity := citylayout.HasCityConfig(localDir)
-
-	entry, registered := supervisor.NewRegistry(supervisor.RegistryPath()).LookupCityByName(name)
-
 	switch {
-	case localIsCity && registered && !samePath(localDir, entry.Path):
-		return "", false, cityRefAmbiguousErr(name, localDir, entry.Path)
-	case localIsCity:
+	case f.ambiguous():
+		return "", false, cityRefAmbiguousErr(f.name, f.localDir, f.regPath)
+	case f.localIsCity:
 		return "", true, nil
-	case registered:
-		return entry.Path, false, nil
+	case f.registered:
+		return f.regPath, false, nil
 	default:
-		return "", false, cityRefNotFoundErr(name, localDir)
+		return "", false, f.notFoundErr()
 	}
+}
+
+// resolveCityNameContext resolves a name-shaped positional argument to a full
+// city+rig context for commands whose positional contract also accepts a local
+// rig directory (status/reload/suspend/resume and stop). Resolution order:
+//
+//   - ambiguous (local city AND a different registration)    -> loud error
+//   - cwd/<name> is itself a city                            -> localPathResolve
+//   - cwd/<name> is a real local rig dir AND <name> is a
+//     different registered city                              -> loud error
+//   - cwd/<name> is a real local rig directory               -> the rig's context
+//   - <name> is a registered city                            -> that city
+//   - cwd/<name> only matches an ancestor rig scope          -> that rig's context
+//   - otherwise                                              -> loud not-found
+//
+// It never feeds the name to an upward city walk, so a bare name can never
+// silently target an ambient ancestor city. The rig-path probe preserves the
+// pre-name-resolution behavior where a slashless rig directory such as
+// "frontend" (no city.toml, no .gc/) resolved to its owning city. A real local
+// rig directory (cwd/<name> on disk) is resolved before the registry name so a
+// same-name registered city cannot silently shadow it; when the two resolve to
+// different cities the collision is rejected loudly, mirroring the
+// local-city-vs-registration guard. Requiring the directory to exist keeps a
+// bare registered name typed from inside an unrelated ancestor rig scope on the
+// registry branch (and avoids the rig probe entirely on that common path).
+func resolveCityNameContext(name string, localPathResolve func(string) (resolvedContext, error)) (resolvedContext, error) {
+	f, err := lookupCityNameFacts(name)
+	if err != nil {
+		return resolvedContext{}, err
+	}
+	switch {
+	case f.ambiguous():
+		return resolvedContext{}, cityRefAmbiguousErr(f.name, f.localDir, f.regPath)
+	case f.localIsCity:
+		return localPathResolve(f.name)
+	}
+	// Probe cwd/<name> as a rig path when it is a real local directory, or when
+	// the name is unregistered (the ancestor-scope parity fallback). When the
+	// name is registered and cwd/<name> is not a real dir, skip the probe so the
+	// registered city wins without an extra registry scan, exactly as before.
+	localRigDir := isExistingDir(f.localDir)
+	if localRigDir || !f.registered {
+		ctx, isRig, rigErr := resolveRigPathToContext(f.localDir)
+		if rigErr != nil {
+			return resolvedContext{}, rigErr
+		}
+		if isRig {
+			if localRigDir && f.registered && !samePath(ctx.CityPath, f.regPath) {
+				return resolvedContext{}, cityRefRigVsRegisteredErr(f.name, f.localDir, f.regPath)
+			}
+			return ctx, nil
+		}
+	}
+	if f.registered {
+		return resolvedContext{CityPath: f.regPath}, nil
+	}
+	return resolvedContext{}, f.notFoundErr()
 }
 
 func cityRefAmbiguousErr(name, localDir, registeredPath string) error {
@@ -122,6 +229,24 @@ func cityRefNotFoundErr(name, localDir string) error {
 	return fmt.Errorf(
 		"%q is not a registered city name, and %s is not a city directory (run 'gc cities' to list registered cities, or pass a directory path to act on an unregistered city)",
 		name, localDir)
+}
+
+// cityRefRigVsRegisteredErr is the loud rejection when cwd/<name> is a real
+// local rig directory whose owning city differs from a same-name registered
+// city. Like cityRefAmbiguousErr it refuses to silently pick either target so a
+// command such as `gc stop frontend` can never act on the wrong city.
+func cityRefRigVsRegisteredErr(name, localRigDir, registeredPath string) error {
+	return fmt.Errorf(
+		"%q is ambiguous: it is both a local rig directory (%s) and a registered city at %s; pass ./%s for the local rig, or cd elsewhere to use the registered city",
+		name, localRigDir, registeredPath, name)
+}
+
+// isExistingDir reports whether p exists and is a directory. It distinguishes a
+// real local rig directory (cwd/<name> on disk) from a bare registered name
+// that only matches an ancestor rig scope lexically.
+func isExistingDir(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && info.IsDir()
 }
 
 // resolveCityFlagValue resolves the --city flag value, accepting either a

--- a/cmd/gc/city_arg_resolve.go
+++ b/cmd/gc/city_arg_resolve.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/supervisor"
+)
+
+// cityRefKind classifies an explicit city reference (a positional argument, a
+// --city value, or GC_CITY) by shape. A registered city name can never contain
+// a path separator (see supervisor.IsValidCityName), so shape alone decides
+// whether a reference could be a name.
+type cityRefKind int
+
+const (
+	cityRefEmpty cityRefKind = iota
+	cityRefName
+	cityRefPath
+)
+
+func classifyCityRef(ref string) cityRefKind {
+	s := strings.TrimSpace(ref)
+	switch {
+	case s == "":
+		return cityRefEmpty
+	case supervisor.IsValidCityName(s):
+		return cityRefName
+	default:
+		return cityRefPath
+	}
+}
+
+// cityRefOpts configures resolveCityRef.
+type cityRefOpts struct {
+	// cmd is the command label used in diagnostics, e.g. "gc unregister".
+	cmd string
+	// allowNameFallback enables resolving a bare registered city NAME. Commands
+	// that create a registration from a path (gc register) set this false, so a
+	// name-shaped argument is always treated as a path.
+	allowNameFallback bool
+}
+
+// resolveCityRef resolves an explicit, non-empty city reference to a city path,
+// accepting either a directory PATH or a registered city NAME. Callers handle
+// the no-argument (cwd) case themselves; ref must be non-empty.
+//
+// pathResolve is the command's existing path resolver. It is invoked ONLY for
+// path-shaped references and for name-shaped references that name an actual
+// local city directory — NEVER for a bare name with no local city. This is
+// deliberate: the path resolvers end in findCity(), which walks UP the
+// directory tree, so feeding a bare name to them would silently resolve to an
+// ambient ancestor city. A name-shaped reference with no local city is instead
+// resolved against the supervisor registry.
+//
+// Resolution when name fallback is enabled:
+//   - path-shaped              -> pathResolve(ref)            (behavior unchanged)
+//   - name + local city only   -> pathResolve(name)          (the local city wins)
+//   - name + registered only   -> the registered path        (no path resolver)
+//   - name + both, same path   -> pathResolve(name)
+//   - name + both, diff paths  -> ambiguous: loud error, caller disambiguates
+//   - name + neither           -> not found: loud error
+func resolveCityRef(ref string, opts cityRefOpts, pathResolve func(string) (string, error)) (string, error) {
+	if classifyCityRef(ref) != cityRefName || !opts.allowNameFallback {
+		return pathResolve(ref)
+	}
+	name := strings.TrimSpace(ref)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolving working directory: %w", err)
+	}
+	localDir := filepath.Join(cwd, name)
+	localIsCity := citylayout.HasCityConfig(localDir)
+
+	entry, registered := supervisor.NewRegistry(supervisor.RegistryPath()).LookupCityByName(name)
+
+	switch {
+	case localIsCity && registered && !samePath(localDir, entry.Path):
+		return "", fmt.Errorf(
+			"%q is ambiguous: it is both a local city directory (%s) and a registered city at %s; pass ./%s for the local one, or cd elsewhere to use the registered city",
+			name, localDir, entry.Path, name)
+	case localIsCity:
+		// The local city wins. Route through the command's path resolver so the
+		// path branch behaves exactly as if a path were supplied; because
+		// cwd/<name> is a real city, findCity returns it without walking up.
+		return pathResolve(name)
+	case registered:
+		return entry.Path, nil
+	default:
+		return "", fmt.Errorf(
+			"%q is not a registered city name, and %s is not a city directory (run 'gc cities' to list registered cities)",
+			name, localDir)
+	}
+}

--- a/cmd/gc/city_arg_resolve.go
+++ b/cmd/gc/city_arg_resolve.go
@@ -36,8 +36,6 @@ func classifyCityRef(ref string) cityRefKind {
 
 // cityRefOpts configures resolveCityRef.
 type cityRefOpts struct {
-	// cmd is the command label used in diagnostics, e.g. "gc unregister".
-	cmd string
 	// allowNameFallback enables resolving a bare registered city NAME. Commands
 	// that create a registration from a path (gc register) set this false, so a
 	// name-shaped argument is always treated as a path.
@@ -130,5 +128,5 @@ func cityRefNotFoundErr(name, localDir string) error {
 // directory path or a registered city name (parallel to the positional
 // argument). validateCityPath provides the path branch.
 func resolveCityFlagValue(city string) (string, error) {
-	return resolveCityRef(city, cityRefOpts{cmd: "gc", allowNameFallback: true}, validateCityPath)
+	return resolveCityRef(city, cityRefOpts{allowNameFallback: true}, validateCityPath)
 }

--- a/cmd/gc/city_arg_resolve.go
+++ b/cmd/gc/city_arg_resolve.go
@@ -122,7 +122,7 @@ func cityRefAmbiguousErr(name, localDir, registeredPath string) error {
 
 func cityRefNotFoundErr(name, localDir string) error {
 	return fmt.Errorf(
-		"%q is not a registered city name, and %s is not a city directory (run 'gc cities' to list registered cities)",
+		"%q is not a registered city name, and %s is not a city directory (run 'gc cities' to list registered cities, or pass a directory path to act on an unregistered city)",
 		name, localDir)
 }
 

--- a/cmd/gc/city_arg_resolve_test.go
+++ b/cmd/gc/city_arg_resolve_test.go
@@ -59,7 +59,7 @@ func TestResolveCityRefPathShapedSkipsRegistry(t *testing.T) {
 		called = true
 		return "/resolved/" + ref, nil
 	}
-	got, err := resolveCityRef("foo/bar", cityRefOpts{cmd: "gc test", allowNameFallback: true}, pathResolve)
+	got, err := resolveCityRef("foo/bar", cityRefOpts{allowNameFallback: true}, pathResolve)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestResolveCityRefNameNoLocalDirHitsRegistry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := resolveCityRef("alpha", cityRefOpts{cmd: "gc test", allowNameFallback: true}, failingPathResolve(t))
+	got, err := resolveCityRef("alpha", cityRefOpts{allowNameFallback: true}, failingPathResolve(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestResolveCityRefNameNoMatchLoudError(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Chdir(t.TempDir())
 
-	_, err := resolveCityRef("ghost", cityRefOpts{cmd: "gc test", allowNameFallback: true}, failingPathResolve(t))
+	_, err := resolveCityRef("ghost", cityRefOpts{allowNameFallback: true}, failingPathResolve(t))
 	if err == nil {
 		t.Fatal("expected a loud error for an unknown name with no local city")
 	}
@@ -111,7 +111,7 @@ func TestResolveCityRefLocalCityWins(t *testing.T) {
 
 	called := ""
 	pathResolve := func(ref string) (string, error) { called = ref; return local, nil }
-	got, err := resolveCityRef("mycity", cityRefOpts{cmd: "gc test", allowNameFallback: true}, pathResolve)
+	got, err := resolveCityRef("mycity", cityRefOpts{allowNameFallback: true}, pathResolve)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestResolveCityRefAmbiguousLoudError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := resolveCityRef("dup", cityRefOpts{cmd: "gc test", allowNameFallback: true}, failingPathResolve(t))
+	_, err := resolveCityRef("dup", cityRefOpts{allowNameFallback: true}, failingPathResolve(t))
 	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
 		t.Fatalf("expected ambiguity error, got %v", err)
 	}
@@ -153,7 +153,7 @@ func TestResolveCityRefLocalAndRegisteredSamePathNotAmbiguous(t *testing.T) {
 
 	called := false
 	pathResolve := func(string) (string, error) { called = true; return local, nil }
-	got, err := resolveCityRef("same", cityRefOpts{cmd: "gc test", allowNameFallback: true}, pathResolve)
+	got, err := resolveCityRef("same", cityRefOpts{allowNameFallback: true}, pathResolve)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestResolveCityRefRegisterNoNameFallback(t *testing.T) {
 
 	called := false
 	pathResolve := func(ref string) (string, error) { called = true; return "/p/" + ref, nil }
-	got, err := resolveCityRef("alpha", cityRefOpts{cmd: "gc register", allowNameFallback: false}, pathResolve)
+	got, err := resolveCityRef("alpha", cityRefOpts{allowNameFallback: false}, pathResolve)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestResolveCityRefFromInsideCityDoesNotWalkUp(t *testing.T) {
 	// walkUp simulates findCity: it returns the ambient city. If resolveCityRef
 	// ever feeds the bare name to it, the assertion below catches the mis-target.
 	walkUp := func(string) (string, error) { return ambient, nil }
-	got, err := resolveCityRef("other", cityRefOpts{cmd: "gc stop", allowNameFallback: true}, walkUp)
+	got, err := resolveCityRef("other", cityRefOpts{allowNameFallback: true}, walkUp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/city_arg_resolve_test.go
+++ b/cmd/gc/city_arg_resolve_test.go
@@ -30,6 +30,17 @@ func mkTestCity(t *testing.T, path string) {
 	}
 }
 
+// mkRuntimeRootOnlyCity creates a legacy runtime-root-only city: a directory
+// with a .gc/ runtime root but no city.toml. validateCityPath accepts this
+// shape via HasRuntimeRoot, so bare-name resolution must recognize it as a
+// local city too.
+func mkRuntimeRootOnlyCity(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(path, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestClassifyCityRef(t *testing.T) {
 	tests := []struct {
 		in   string
@@ -138,6 +149,50 @@ func TestResolveCityRefAmbiguousLoudError(t *testing.T) {
 	_, err := resolveCityRef("dup", cityRefOpts{allowNameFallback: true}, failingPathResolve(t))
 	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
 		t.Fatalf("expected ambiguity error, got %v", err)
+	}
+}
+
+// A legacy runtime-root-only (.gc/-only, no city.toml) local city must win for a
+// bare name, matching validateCityPath's HasRuntimeRoot acceptance, instead of
+// falling through to the registry and failing as "not registered".
+func TestResolveCityRefRuntimeRootOnlyLocalCityWins(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	local := filepath.Join(cwd, "rtcity")
+	mkRuntimeRootOnlyCity(t, local) // ./rtcity has only .gc/, not registered
+
+	called := ""
+	pathResolve := func(ref string) (string, error) { called = ref; return local, nil }
+	got, err := resolveCityRef("rtcity", cityRefOpts{allowNameFallback: true}, pathResolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if called != "rtcity" {
+		t.Fatalf("a .gc/-only local city must route through pathResolve; called=%q", called)
+	}
+	if !samePath(got, local) {
+		t.Fatalf("got %q, want local city %q", got, local)
+	}
+}
+
+// A runtime-root-only local city whose name conflicts with a different
+// registered city is ambiguous, exactly like the city.toml case.
+func TestResolveCityRefRuntimeRootOnlyLocalCityAmbiguousWithRegistered(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	mkRuntimeRootOnlyCity(t, filepath.Join(cwd, "dup")) // local ./dup with only .gc/
+
+	elsewhere := filepath.Join(t.TempDir(), "dup")
+	mkTestCity(t, elsewhere)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(elsewhere, "dup"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := resolveCityRef("dup", cityRefOpts{allowNameFallback: true}, failingPathResolve(t))
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguity error for a .gc/-only local city conflicting with a registration, got %v", err)
 	}
 }
 
@@ -357,6 +412,158 @@ func TestResolveStopCityPathByNameFromInsideAnotherCity(t *testing.T) {
 	}
 }
 
+// Regression (PR #3625 review, Contract & Interface Fidelity): a slashless
+// local rig directory with no city.toml and no .gc/ must still resolve to its
+// owning city+rig through the positional-arg seam. The name-first branch must
+// probe the rig-path resolver before failing, instead of rejecting "frontend"
+// as an unknown city name.
+func TestResolveCommandContextSlashlessRigDirResolvesToCity(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+
+	cityPath := setupCity(t, "demo-city")
+	parent := t.TempDir()
+	rigDir := filepath.Join(parent, "frontend") // plain dir: no city.toml, no .gc/
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[workspace]\nname = \"demo-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"" + rigDir + "\"\n"
+	writeRigAnywhereCityToml(t, cityPath, toml)
+	registerCityForRigResolution(t, os.Getenv("GC_HOME"), cityPath, "demo-city")
+
+	setCwd(t, parent) // cwd/frontend == rigDir, but "frontend" classifies as a name
+
+	ctx, err := resolveCommandContext([]string{"frontend"})
+	if err != nil {
+		t.Fatalf("resolveCommandContext(frontend) error: %v", err)
+	}
+	assertSameTestPath(t, ctx.CityPath, cityPath)
+	if ctx.RigName != "frontend" {
+		t.Fatalf("RigName = %q, want frontend", ctx.RigName)
+	}
+}
+
+// Regression companion for the stop seam: resolveStopCityPath must resolve a
+// slashless local rig directory to its owning city, not reject it as an unknown
+// city name.
+func TestResolveStopCityPathSlashlessRigDirResolvesToCity(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+
+	cityPath := setupCity(t, "stop-demo-city")
+	parent := t.TempDir()
+	rigDir := filepath.Join(parent, "frontend") // plain dir: no city.toml, no .gc/
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[workspace]\nname = \"stop-demo-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"" + rigDir + "\"\n"
+	writeRigAnywhereCityToml(t, cityPath, toml)
+	registerCityForRigResolution(t, os.Getenv("GC_HOME"), cityPath, "stop-demo-city")
+
+	setCwd(t, parent)
+
+	got, err := resolveStopCityPath([]string{"frontend"})
+	if err != nil {
+		t.Fatalf("resolveStopCityPath(frontend) error: %v", err)
+	}
+	assertSameTestPath(t, got, cityPath)
+}
+
+// Regression companion for the start seam (PR #3625 review F1): resolveStartDir
+// must resolve a slashless local rig directory to its owning city, not reject it
+// as an unknown city name. Without the rig-path probe, gc start <rig-name>
+// regressed to a hard error where the sibling stop/command-context seams resolve.
+func TestResolveStartDirSlashlessRigDirResolvesToCity(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+
+	cityPath := setupCity(t, "start-demo-city")
+	parent := t.TempDir()
+	rigDir := filepath.Join(parent, "frontend") // plain dir: no city.toml, no .gc/
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[workspace]\nname = \"start-demo-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"" + rigDir + "\"\n"
+	writeRigAnywhereCityToml(t, cityPath, toml)
+	registerCityForRigResolution(t, os.Getenv("GC_HOME"), cityPath, "start-demo-city")
+
+	setCwd(t, parent)
+
+	got, err := resolveStartDir([]string{"frontend"})
+	if err != nil {
+		t.Fatalf("resolveStartDir(frontend) error: %v", err)
+	}
+	assertSameTestPath(t, got, cityPath)
+}
+
+// Regression companion for the restart seam (PR #3625 review F1): restartTarget
+// delegates to resolveStartDir, so gc restart <rig-name> must resolve a slashless
+// local rig directory to its owning city just like gc stop <rig-name>. The
+// documented "stop then start" contract breaks if restart rejects a rig name the
+// stop leg accepts.
+func TestRestartTargetSlashlessRigDirResolvesToCity(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+
+	cityPath := setupCity(t, "restart-demo-city")
+	parent := t.TempDir()
+	rigDir := filepath.Join(parent, "frontend") // plain dir: no city.toml, no .gc/
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[workspace]\nname = \"restart-demo-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"" + rigDir + "\"\n"
+	writeRigAnywhereCityToml(t, cityPath, toml)
+	registerCityForRigResolution(t, os.Getenv("GC_HOME"), cityPath, "restart-demo-city")
+
+	setCwd(t, parent)
+
+	gotPath, _, err := restartTarget([]string{"frontend"})
+	if err != nil {
+		t.Fatalf("restartTarget(frontend) error: %v", err)
+	}
+	assertSameTestPath(t, gotPath, cityPath)
+}
+
+// Guard: the rig-path probe must NOT reopen the walk-up footgun. A slashless
+// name that is neither a registered city, a local city, nor a local rig must
+// still fail loudly from inside an ambient city instead of silently targeting
+// it.
+func TestResolveCommandContextSlashlessUnknownFromInsideCityFailsLoud(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+
+	ambient := setupCity(t, "ambient-city")
+	setCwd(t, ambient) // inside a city; the old footgun would walk up to here
+
+	_, err := resolveCommandContext([]string{"ghost-rig"})
+	if err == nil {
+		t.Fatal("expected a loud error for an unknown slashless name from inside a city")
+	}
+	if !strings.Contains(err.Error(), "not a registered city name") {
+		t.Fatalf("err = %v, want a name-aware not-found error", err)
+	}
+}
+
 func TestResolveStartDirByName(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Chdir(t.TempDir())
@@ -421,5 +628,162 @@ func TestCityNameCandidatesFiltersByPrefix(t *testing.T) {
 		if !strings.Contains(c, "\t") {
 			t.Fatalf("candidate %q missing tab-separated path description", c)
 		}
+	}
+}
+
+// setupSlashlessRigDirCollision builds the "cwd/<name> is a local rig dir AND
+// <name> is a registered city" scenario shared by the ambiguity regressions:
+// city "demo-city" owns a slashless rig directory cwd/frontend, and a DIFFERENT
+// city is registered under the bare name "frontend". Returns the parent dir the
+// caller should cd into so that cwd/frontend is the rig directory.
+func setupSlashlessRigDirCollision(t *testing.T) string {
+	t.Helper()
+	gcHome := os.Getenv("GC_HOME")
+
+	cityA := setupCity(t, "demo-city")
+	parent := t.TempDir()
+	rigDir := filepath.Join(parent, "frontend") // plain dir: no city.toml, no .gc/
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[workspace]\nname = \"demo-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"" + rigDir + "\"\n"
+	writeRigAnywhereCityToml(t, cityA, toml)
+	registerCityForRigResolution(t, gcHome, cityA, "demo-city")
+
+	cityB := setupCity(t, "frontend") // a different city, registered under the same bare name
+	registerCityForRigResolution(t, gcHome, cityB, "frontend")
+	return parent
+}
+
+// Regression (PR #3625 review, Behavioral Correctness, major): when cwd/<name>
+// is a real local rig directory AND <name> is ALSO a registered city pointing
+// to a different city, the positional seam must reject the collision loudly
+// instead of silently preferring the registered city over the local rig dir.
+// The old path behavior targeted the rig's owning city; the new name resolution
+// must not silently shadow it. Mirrors the local-city-vs-registration guard.
+func TestResolveCommandContextSlashlessRigDirVsRegisteredCityIsAmbiguous(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+
+	parent := setupSlashlessRigDirCollision(t)
+	setCwd(t, parent) // cwd/frontend == rig dir, and "frontend" is also registered
+
+	_, err := resolveCommandContext([]string{"frontend"})
+	if err == nil {
+		t.Fatal("expected a loud ambiguity error: cwd/frontend is a local rig dir AND frontend is a registered city")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") || !strings.Contains(err.Error(), "rig") {
+		t.Fatalf("err = %v, want an ambiguity error naming the local rig directory", err)
+	}
+}
+
+// Regression companion for the stop seam: resolveStopCityPath must reject the
+// same rig-dir/registered-city collision loudly, not silently stop a different
+// city than the local rig the operator pointed at.
+func TestResolveStopCityPathSlashlessRigDirVsRegisteredCityIsAmbiguous(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+
+	parent := setupSlashlessRigDirCollision(t)
+	setCwd(t, parent)
+
+	_, err := resolveStopCityPath([]string{"frontend"})
+	if err == nil {
+		t.Fatal("expected a loud ambiguity error from the stop seam for a rig-dir/registered-city collision")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") || !strings.Contains(err.Error(), "rig") {
+		t.Fatalf("err = %v, want an ambiguity error naming the local rig directory", err)
+	}
+}
+
+// Guard: when cwd/<name> is a local rig dir whose OWNING city is the very same
+// city registered under <name>, the two interpretations agree, so resolution
+// must succeed instead of raising a false-positive ambiguity error.
+func TestResolveCommandContextSlashlessRigDirSameRegisteredCityResolves(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+
+	gcHome := os.Getenv("GC_HOME")
+	city := setupCity(t, "frontend")
+	parent := t.TempDir()
+	rigDir := filepath.Join(parent, "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[workspace]\nname = \"frontend\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"" + rigDir + "\"\n"
+	writeRigAnywhereCityToml(t, city, toml)
+	registerCityForRigResolution(t, gcHome, city, "frontend")
+
+	setCwd(t, parent)
+
+	ctx, err := resolveCommandContext([]string{"frontend"})
+	if err != nil {
+		t.Fatalf("resolveCommandContext(frontend) where the rig's owning city IS the registered city: %v", err)
+	}
+	assertSameTestPath(t, ctx.CityPath, city)
+}
+
+// Regression (PR #3625 review, Test Evidence Quality): an unknown slashless name
+// run from INSIDE a registered rig directory resolves to that rig's owning city
+// — parity with the historical path-arg behavior — rather than failing loud.
+// Pins the documented outcome for the ancestor-rig-scope match; the fail-loud
+// guard above only covers a city root with no rigs in scope.
+func TestResolveCommandContextSlashlessUnknownFromInsideRigResolvesToOwningCity(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+
+	gcHome := os.Getenv("GC_HOME")
+	cityPath := setupCity(t, "demo-city")
+	rigDir := t.TempDir()
+	toml := "[workspace]\nname = \"demo-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"" + rigDir + "\"\n"
+	writeRigAnywhereCityToml(t, cityPath, toml)
+	registerCityForRigResolution(t, gcHome, cityPath, "demo-city")
+
+	setCwd(t, rigDir) // cwd lies INSIDE the registered rig's scope
+
+	ctx, err := resolveCommandContext([]string{"ghost"}) // unknown name; rigDir/ghost does not exist
+	if err != nil {
+		t.Fatalf("resolveCommandContext(ghost) from inside a registered rig: %v", err)
+	}
+	assertSameTestPath(t, ctx.CityPath, cityPath)
+	if ctx.RigName != "frontend" {
+		t.Fatalf("RigName = %q, want frontend", ctx.RigName)
+	}
+}
+
+// Regression (PR #3625 review, Error Handling & Resilience): the GC_CITY=<name>
+// env lookup is intentionally best-effort. A corrupt/unreadable registry must
+// NOT hard-error the ambient env path; it falls through (ok=false) so later
+// GC_DIR/cwd discovery still runs. This deliberately differs from the loud
+// corrupt-registry behavior of the positional arg and --city flag.
+func TestResolveExplicitCityPathEnvNameBestEffortOnCorruptRegistry(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	// Corrupt registry: malformed TOML so the registry load fails to parse.
+	if err := os.WriteFile(supervisor.RegistryPath(), []byte("[[city]\nname = \"broken\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", "broken")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+
+	if got, ok := resolveExplicitCityPathEnv(); ok {
+		t.Fatalf("resolveExplicitCityPathEnv() = (%q, true) on a corrupt registry; want (\"\", false) best-effort fall-through", got)
 	}
 }

--- a/cmd/gc/city_arg_resolve_test.go
+++ b/cmd/gc/city_arg_resolve_test.go
@@ -212,3 +212,145 @@ func TestResolveCityRefFromInsideCityDoesNotWalkUp(t *testing.T) {
 		t.Fatalf("got %q, want registered other-city %q", got, otherPath)
 	}
 }
+
+// resolveCommandCity is the central seam reload/suspend/resume/status use; a
+// name passed to it must resolve via the registry.
+func TestResolveCommandCityByName(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	cityPath := filepath.Join(t.TempDir(), "alpha")
+	mkTestCity(t, cityPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveCommandCity([]string{"alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !samePath(got, cityPath) {
+		t.Fatalf("resolveCommandCity(alpha) = %q, want %q", got, cityPath)
+	}
+}
+
+// The central seam must also resist the walk-up footgun: a bare name from
+// inside city A targets the registered city, not A.
+func TestResolveCommandCityByNameFromInsideAnotherCity(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	ambient := t.TempDir()
+	mkTestCity(t, ambient)
+	t.Chdir(ambient)
+	otherPath := filepath.Join(t.TempDir(), "other")
+	mkTestCity(t, otherPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(otherPath, "other"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveCommandCity([]string{"other"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if samePath(got, ambient) {
+		t.Fatalf("resolveCommandCity targeted the ambient city %q (walk-up footgun)", ambient)
+	}
+	if !samePath(got, otherPath) {
+		t.Fatalf("resolveCommandCity(other) = %q, want %q", got, otherPath)
+	}
+}
+
+func TestResolveCommandCityUnknownNameFailsLoudly(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	_, err := resolveCommandCity([]string{"ghost-name"})
+	if err == nil || !strings.Contains(err.Error(), "not a registered city name") {
+		t.Fatalf("err = %v, want a name-aware not-found error", err)
+	}
+}
+
+func TestResolveCityFlagValueByName(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	cityPath := filepath.Join(t.TempDir(), "alpha")
+	mkTestCity(t, cityPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveCityFlagValue("alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !samePath(got, cityPath) {
+		t.Fatalf("resolveCityFlagValue(alpha) = %q, want %q", got, cityPath)
+	}
+}
+
+func TestResolveExplicitCityPathEnvByName(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	cityPath := filepath.Join(t.TempDir(), "alpha")
+	mkTestCity(t, cityPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+
+	// GC_CITY accepts a registered name.
+	t.Setenv("GC_CITY", "alpha")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	got, ok := resolveExplicitCityPathEnv()
+	if !ok || !samePath(got, cityPath) {
+		t.Fatalf("resolveExplicitCityPathEnv() = (%q,%v), want (%q,true)", got, ok, cityPath)
+	}
+
+	// GC_CITY_PATH is path-only: a bare name must NOT resolve via the registry.
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "alpha")
+	if _, ok := resolveExplicitCityPathEnv(); ok {
+		t.Fatal("GC_CITY_PATH must not resolve a bare registered name")
+	}
+}
+
+func TestRestartTargetResolvesByNameOnce(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	cityPath := filepath.Join(t.TempDir(), "alpha")
+	mkTestCity(t, cityPath)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil { // bootstrapped runtime root
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	gotPath, gotName, err := restartTarget([]string{"alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !samePath(gotPath, cityPath) {
+		t.Fatalf("restartTarget path = %q, want %q", gotPath, cityPath)
+	}
+	if gotName != "alpha" {
+		t.Fatalf("restartTarget name = %q, want alpha", gotName)
+	}
+}
+
+func TestCityNameCandidatesFiltersByPrefix(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	for _, n := range []string{"alpha", "alpine", "beta"} {
+		p := filepath.Join(t.TempDir(), n)
+		mkTestCity(t, p)
+		if err := reg.Register(p, n); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := cityNameCandidates("alp")
+	if len(got) != 2 {
+		t.Fatalf("cityNameCandidates(\"alp\") = %v, want 2 (alpha, alpine)", got)
+	}
+	for _, c := range got {
+		if !strings.HasPrefix(c, "alp") {
+			t.Fatalf("candidate %q does not match prefix", c)
+		}
+		if !strings.Contains(c, "\t") {
+			t.Fatalf("candidate %q missing tab-separated path description", c)
+		}
+	}
+}

--- a/cmd/gc/city_arg_resolve_test.go
+++ b/cmd/gc/city_arg_resolve_test.go
@@ -331,6 +331,75 @@ func TestRestartTargetResolvesByNameOnce(t *testing.T) {
 	}
 }
 
+// The bespoke per-command resolvers (resolveStopCityPath, resolveStartDir)
+// must also accept a name and resist the walk-up footgun; the central
+// resolveCommandCity tests cover reload/suspend/resume/status, which share
+// that seam.
+func TestResolveStopCityPathByNameFromInsideAnotherCity(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	ambient := t.TempDir()
+	mkTestCity(t, ambient)
+	t.Chdir(ambient)
+	otherPath := filepath.Join(t.TempDir(), "other")
+	mkTestCity(t, otherPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(otherPath, "other"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveStopCityPath([]string{"other"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if samePath(got, ambient) {
+		t.Fatalf("resolveStopCityPath targeted the ambient city %q (walk-up footgun)", ambient)
+	}
+	if !samePath(got, otherPath) {
+		t.Fatalf("resolveStopCityPath(other) = %q, want %q", got, otherPath)
+	}
+}
+
+func TestResolveStartDirByName(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	cityPath := filepath.Join(t.TempDir(), "alpha")
+	mkTestCity(t, cityPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveStartDir([]string{"alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !samePath(got, cityPath) {
+		t.Fatalf("resolveStartDir(alpha) = %q, want %q", got, cityPath)
+	}
+}
+
+// GC_CITY uses path-first / local-wins precedence (a documented deviation from
+// the loud-ambiguity policy of the positional arg and --city flag): a local
+// city dir of the same name wins over a different registration, silently.
+func TestResolveExplicitCityPathEnvLocalWinsOverRegistration(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	local := filepath.Join(cwd, "alpha")
+	mkTestCity(t, local) // local ./alpha city
+	registeredElsewhere := filepath.Join(t.TempDir(), "alpha")
+	mkTestCity(t, registeredElsewhere)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(registeredElsewhere, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", "alpha")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	got, ok := resolveExplicitCityPathEnv()
+	if !ok {
+		t.Fatal("GC_CITY=alpha should resolve")
+	}
+	if !samePath(got, local) {
+		t.Fatalf("GC_CITY=alpha resolved to %q, want the local city %q (path-first/local-wins)", got, local)
+	}
+}
+
 func TestCityNameCandidatesFiltersByPrefix(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())

--- a/cmd/gc/city_arg_resolve_test.go
+++ b/cmd/gc/city_arg_resolve_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/supervisor"
+)
+
+// failingPathResolve returns a pathResolve closure that fails the test if it is
+// ever invoked — used to prove a bare name resolves via the registry and is
+// never fed to the (walk-up) path resolver.
+func failingPathResolve(t *testing.T) func(string) (string, error) {
+	t.Helper()
+	return func(ref string) (string, error) {
+		t.Fatalf("pathResolve must not be called for ref %q", ref)
+		return "", nil
+	}
+}
+
+func mkTestCity(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClassifyCityRef(t *testing.T) {
+	tests := []struct {
+		in   string
+		want cityRefKind
+	}{
+		{"", cityRefEmpty},
+		{"   ", cityRefEmpty},
+		{"chris-city", cityRefName},
+		{"a.b_c-1", cityRefName},
+		{"a/b", cityRefPath},
+		{"./x", cityRefPath},
+		{"../x", cityRefPath},
+		{"/abs/path", cityRefPath},
+		{"~/x", cityRefPath},
+	}
+	for _, tt := range tests {
+		if got := classifyCityRef(tt.in); got != tt.want {
+			t.Errorf("classifyCityRef(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestResolveCityRefPathShapedSkipsRegistry(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir()) // empty registry; must not be consulted
+	called := false
+	pathResolve := func(ref string) (string, error) {
+		called = true
+		return "/resolved/" + ref, nil
+	}
+	got, err := resolveCityRef("foo/bar", cityRefOpts{cmd: "gc test", allowNameFallback: true}, pathResolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called || got != "/resolved/foo/bar" {
+		t.Fatalf("path-shaped ref must go straight to pathResolve; called=%v got=%q", called, got)
+	}
+}
+
+func TestResolveCityRefNameNoLocalDirHitsRegistry(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir()) // cwd has no ./alpha
+
+	cityPath := filepath.Join(t.TempDir(), "alpha")
+	mkTestCity(t, cityPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveCityRef("alpha", cityRefOpts{cmd: "gc test", allowNameFallback: true}, failingPathResolve(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !samePath(got, cityPath) {
+		t.Fatalf("got %q, want registered path %q", got, cityPath)
+	}
+}
+
+func TestResolveCityRefNameNoMatchLoudError(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+
+	_, err := resolveCityRef("ghost", cityRefOpts{cmd: "gc test", allowNameFallback: true}, failingPathResolve(t))
+	if err == nil {
+		t.Fatal("expected a loud error for an unknown name with no local city")
+	}
+	for _, want := range []string{"not a registered city name", "not a city directory"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestResolveCityRefLocalCityWins(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	local := filepath.Join(cwd, "mycity")
+	mkTestCity(t, local) // ./mycity is a city, not registered
+
+	called := ""
+	pathResolve := func(ref string) (string, error) { called = ref; return local, nil }
+	got, err := resolveCityRef("mycity", cityRefOpts{cmd: "gc test", allowNameFallback: true}, pathResolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if called != "mycity" {
+		t.Fatalf("a local city must route through pathResolve; called=%q", called)
+	}
+	if !samePath(got, local) {
+		t.Fatalf("got %q, want local city %q", got, local)
+	}
+}
+
+func TestResolveCityRefAmbiguousLoudError(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	mkTestCity(t, filepath.Join(cwd, "dup")) // local ./dup city
+
+	elsewhere := filepath.Join(t.TempDir(), "dup")
+	mkTestCity(t, elsewhere)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(elsewhere, "dup"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := resolveCityRef("dup", cityRefOpts{cmd: "gc test", allowNameFallback: true}, failingPathResolve(t))
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguity error, got %v", err)
+	}
+}
+
+func TestResolveCityRefLocalAndRegisteredSamePathNotAmbiguous(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	local := filepath.Join(cwd, "same")
+	mkTestCity(t, local)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(local, "same"); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	pathResolve := func(string) (string, error) { called = true; return local, nil }
+	got, err := resolveCityRef("same", cityRefOpts{cmd: "gc test", allowNameFallback: true}, pathResolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called || !samePath(got, local) {
+		t.Fatalf("same-path local+registered must resolve to the local city via pathResolve; called=%v got=%q", called, got)
+	}
+}
+
+func TestResolveCityRefRegisterNoNameFallback(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	cityPath := filepath.Join(t.TempDir(), "alpha")
+	mkTestCity(t, cityPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	pathResolve := func(ref string) (string, error) { called = true; return "/p/" + ref, nil }
+	got, err := resolveCityRef("alpha", cityRefOpts{cmd: "gc register", allowNameFallback: false}, pathResolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called || got != "/p/alpha" {
+		t.Fatalf("register (no name fallback) must treat a name-shaped ref as a path; called=%v got=%q", called, got)
+	}
+}
+
+// Core regression guard: a bare name run from INSIDE another city must resolve
+// via the registry, never via the path resolver's upward walk to the ambient
+// city (the footgun the design exists to prevent).
+func TestResolveCityRefFromInsideCityDoesNotWalkUp(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	ambient := t.TempDir()
+	mkTestCity(t, ambient)
+	t.Chdir(ambient) // cwd is itself a city
+
+	otherPath := filepath.Join(t.TempDir(), "other")
+	mkTestCity(t, otherPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(otherPath, "other"); err != nil {
+		t.Fatal(err)
+	}
+
+	// walkUp simulates findCity: it returns the ambient city. If resolveCityRef
+	// ever feeds the bare name to it, the assertion below catches the mis-target.
+	walkUp := func(string) (string, error) { return ambient, nil }
+	got, err := resolveCityRef("other", cityRefOpts{cmd: "gc stop", allowNameFallback: true}, walkUp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if samePath(got, ambient) {
+		t.Fatalf("bare name resolved to the AMBIENT city %q (walk-up footgun)", ambient)
+	}
+	if !samePath(got, otherPath) {
+		t.Fatalf("got %q, want registered other-city %q", got, otherPath)
+	}
+}

--- a/cmd/gc/city_context.go
+++ b/cmd/gc/city_context.go
@@ -3,13 +3,24 @@ package main
 import (
 	"os"
 	"strings"
+
+	"github.com/gastownhall/gascity/internal/supervisor"
 )
 
 func resolveExplicitCityPathEnv() (string, bool) {
 	for _, key := range []string{"GC_CITY", "GC_CITY_PATH", "GC_CITY_ROOT"} {
-		if raw := strings.TrimSpace(os.Getenv(key)); raw != "" {
-			if cityPath, err := validateCityPath(raw); err == nil {
-				return cityPath, true
+		raw := strings.TrimSpace(os.Getenv(key))
+		if raw == "" {
+			continue
+		}
+		if cityPath, err := validateCityPath(raw); err == nil {
+			return cityPath, true
+		}
+		// GC_CITY (the generic key) additionally accepts a registered city
+		// NAME; GC_CITY_PATH / GC_CITY_ROOT are path-only by their names.
+		if key == "GC_CITY" && supervisor.IsValidCityName(raw) {
+			if entry, ok := supervisor.NewRegistry(supervisor.RegistryPath()).LookupCityByName(raw); ok {
+				return entry.Path, true
 			}
 		}
 	}

--- a/cmd/gc/city_context.go
+++ b/cmd/gc/city_context.go
@@ -26,6 +26,15 @@ func resolveExplicitCityPathEnv() (string, bool) {
 		// reaches the registry lookup here. The interactive positional and
 		// --city forms instead raise a loud ambiguity error when a local city
 		// and a different registration collide (see resolveCityNameRef).
+		//
+		// Registry-error note (intentional): this uses the lenient bool
+		// LookupCityByName, not LookupCityByNameE, so a corrupt/unreadable
+		// registry collapses to a miss and this ambient env path falls through
+		// to GC_DIR/cwd discovery rather than hard-erroring. The interactive
+		// positional/--city paths use LookupCityByNameE to surface that error
+		// because the user named a city explicitly there; the env path is
+		// best-effort by design (pinned by
+		// TestResolveExplicitCityPathEnvNameBestEffortOnCorruptRegistry).
 		if key == "GC_CITY" && supervisor.IsValidCityName(raw) {
 			if entry, ok := supervisor.NewRegistry(supervisor.RegistryPath()).LookupCityByName(raw); ok {
 				return entry.Path, true

--- a/cmd/gc/city_context.go
+++ b/cmd/gc/city_context.go
@@ -18,6 +18,14 @@ func resolveExplicitCityPathEnv() (string, bool) {
 		}
 		// GC_CITY (the generic key) additionally accepts a registered city
 		// NAME; GC_CITY_PATH / GC_CITY_ROOT are path-only by their names.
+		//
+		// Precedence note (intentional, differs from the positional arg and
+		// --city flag): an env var is set deliberately and is ambient, so it
+		// uses path-first / local-wins — validateCityPath above already returned
+		// a same-named local city dir if one exists, and only an unshadowed name
+		// reaches the registry lookup here. The interactive positional and
+		// --city forms instead raise a loud ambiguity error when a local city
+		// and a different registration collide (see resolveCityNameRef).
 		if key == "GC_CITY" && supervisor.IsValidCityName(raw) {
 			if entry, ok := supervisor.NewRegistry(supervisor.RegistryPath()).LookupCityByName(raw); ok {
 				return entry.Path, true

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -116,11 +116,12 @@ func newStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 	var jsonFlag bool
 	var formatFlag string
 	cmd := &cobra.Command{
-		Use:   "status [path]",
+		Use:   "status [path|name]",
 		Short: "Show city-wide status overview",
 		Long: `Shows a city-wide overview: controller state, suspension,
 all agents with running status, rigs, and a summary count.`,
-		Args: cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeCityNames,
 		RunE: func(_ *cobra.Command, args []string) error {
 			format := strings.ToLower(strings.TrimSpace(formatFlag))
 			switch format {

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -124,12 +124,12 @@ func newUnregisterCmd(stdout, stderr io.Writer) *cobra.Command {
 The argument may be a path to a city directory or a registered city name (as
 shown by 'gc cities'); a name is resolved against the supervisor registry. An
 existing local city directory of the same name takes precedence over a
-registration; a local city plus a different registration is reported as
-ambiguous. If no argument is given, unregisters the current city (discovered
-from cwd). If the supervisor is running, it immediately stops managing the
-city. Unlike 'gc register' (which is idempotent), this errors when the resolved
-path is not a registered city, so it is not a silent no-op on an unknown
-target.`,
+registration; if a local city directory and a different registration both
+exist, the name is reported as ambiguous.
+If no argument is given, unregisters the current city (discovered from cwd).
+If the supervisor is running, it immediately stops managing the city. Unlike
+'gc register' (which is idempotent), this errors when the resolved path is not
+a registered city, so it is not a silent no-op on an unknown target.`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completeCityNames,
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -151,7 +151,7 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 	var cityPath string
 	var err error
 	if len(args) > 0 {
-		cityPath, err = resolveCityRef(args[0], cityRefOpts{cmd: "gc unregister", allowNameFallback: true}, func(ref string) (string, error) {
+		cityPath, err = resolveCityRef(args[0], cityRefOpts{allowNameFallback: true}, func(ref string) (string, error) {
 			abs, aerr := filepath.Abs(ref)
 			if aerr != nil {
 				return "", aerr

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -31,7 +31,8 @@ When --name is omitted, the current effective city identity is used
 otherwise the directory basename) — in every case city.toml is not modified.
 Registration is idempotent — registering the same city twice is a no-op.
 The supervisor is started if needed and immediately reconciles the city.`,
-		Args: cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeCityNames,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if doRegisterWithOptionsJSON(args, nameFlag, jsonOut, stdout, stderr) != 0 {
 				return errExit
@@ -116,16 +117,21 @@ func resolveRegistrationName(cityPath, nameOverride string) (string, error) {
 func newUnregisterCmd(stdout, stderr io.Writer) *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "unregister [path]",
+		Use:   "unregister [path|name]",
 		Short: "Remove a city from the machine-wide supervisor",
 		Long: `Remove a city from the machine-wide supervisor registry.
 
-If no path is given, unregisters the current city (discovered from cwd).
-If the supervisor is running, it immediately stops managing the city.
-Takes a city directory path, not the name shown by 'gc cities'. Unlike
-'gc register' (which is idempotent), this errors when the resolved path is not
-a registered city, so it is not a silent no-op on an unknown target.`,
-		Args: cobra.MaximumNArgs(1),
+The argument may be a path to a city directory or a registered city name (as
+shown by 'gc cities'); a name is resolved against the supervisor registry. An
+existing local city directory of the same name takes precedence over a
+registration; a local city plus a different registration is reported as
+ambiguous. If no argument is given, unregisters the current city (discovered
+from cwd). If the supervisor is running, it immediately stops managing the
+city. Unlike 'gc register' (which is idempotent), this errors when the resolved
+path is not a registered city, so it is not a silent no-op on an unknown
+target.`,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeCityNames,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if doUnregisterJSON(args, jsonOut, stdout, stderr) != 0 {
 				return errExit
@@ -145,10 +151,13 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 	var cityPath string
 	var err error
 	if len(args) > 0 {
-		cityPath, err = filepath.Abs(args[0])
-		if err == nil {
-			cityPath = normalizePathForCompare(cityPath)
-		}
+		cityPath, err = resolveCityRef(args[0], cityRefOpts{cmd: "gc unregister", allowNameFallback: true}, func(ref string) (string, error) {
+			abs, aerr := filepath.Abs(ref)
+			if aerr != nil {
+				return "", aerr
+			}
+			return normalizePathForCompare(abs), nil
+		})
 	} else {
 		cityPath, err = resolveCommandCity(nil)
 	}
@@ -161,17 +170,13 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 		fmt.Fprintf(stderr, "gc unregister: %v\n", lookupErr) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	rawArg := ""
-	if len(args) > 0 {
-		rawArg = args[0]
-	}
 	if !registered {
-		// gc unregister takes a city directory path, not a name. The common
-		// footgun is passing the NAME shown by `gc cities`, or a wrong path:
-		// the target resolves to a path that was never registered. Fail loudly
-		// rather than exit 0 silently (non-JSON) or fabricate a success record
-		// (JSON), which would leave the city registered and mislead the caller.
-		writeUnregisterNotRegistered(stderr, rawArg, cityPath)
+		// The reference resolved to a path (an explicit path, a local city, or
+		// the cwd city) that is not registered. A bare unregistered NAME is
+		// already rejected by resolveCityRef. Fail loudly rather than exit 0
+		// silently (non-JSON) or fabricate a success record (JSON), which would
+		// leave the city registered and mislead the caller.
+		writeUnregisterNotRegistered(stderr, cityPath)
 		return 1
 	}
 	unregisterStdout := stdout
@@ -192,7 +197,7 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 		// the loud not-registered failure instead of emitting a fabricated
 		// success record. The helper's handled bool, not the earlier pre-check,
 		// is the authority on whether anything was actually unregistered.
-		writeUnregisterNotRegistered(stderr, rawArg, cityPath)
+		writeUnregisterNotRegistered(stderr, cityPath)
 		return 1
 	}
 	if !jsonOut {
@@ -208,20 +213,12 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 }
 
 // writeUnregisterNotRegistered emits an actionable diagnostic when the
-// unregister target does not resolve to a registered city. rawArg is the
-// original CLI argument (empty when the city was discovered from cwd) and
-// cityPath is the resolved absolute path that failed to match.
-func writeUnregisterNotRegistered(stderr io.Writer, rawArg, cityPath string) {
-	fmt.Fprintf(stderr, "gc unregister: no registered city at %s\n", cityPath) //nolint:errcheck // best-effort stderr
-	// Only the bare-NAME footgun warrants the name-vs-path hint. A path-shaped
-	// argument (relative like ./city, a trailing slash, or a symlink) is a
-	// genuine path that simply was not registered; comparing the raw token to
-	// the fully normalized cityPath would misfire and contradict the diagnostic,
-	// so gate on "no path separator" instead of raw-string inequality.
-	if trimmed := strings.TrimSpace(rawArg); trimmed != "" && !strings.ContainsRune(trimmed, filepath.Separator) {
-		fmt.Fprintf(stderr, "gc unregister: %q looks like a name — gc unregister takes a city directory path, not a name\n", trimmed) //nolint:errcheck // best-effort stderr
-	}
-	fmt.Fprintf(stderr, "gc unregister: run 'gc cities' to see registered cities, then 'gc unregister <path>'\n") //nolint:errcheck // best-effort stderr
+// unregister target — an explicit path, a resolved local city, or the cwd
+// city — is not registered. (A bare unregistered NAME is rejected earlier by
+// resolveCityRef with its own name-aware message.)
+func writeUnregisterNotRegistered(stderr io.Writer, cityPath string) {
+	fmt.Fprintf(stderr, "gc unregister: no registered city at %s\n", cityPath)       //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "gc unregister: run 'gc cities' to see registered cities\n") //nolint:errcheck // best-effort stderr
 }
 
 func replayJSONModeProgress(stderr io.Writer, progress *bytes.Buffer) {

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -214,7 +214,7 @@ func TestRegisteredCityNamePreservesExistingRegistryAlias(t *testing.T) {
 	}
 }
 
-func TestRestartRegistrationNameCapturesExistingRegistryAlias(t *testing.T) {
+func TestRestartTargetCapturesExistingRegistryAlias(t *testing.T) {
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "my-city")
 	if err := ensureCityScaffold(cityPath); err != nil {
@@ -233,12 +233,15 @@ func TestRestartRegistrationNameCapturesExistingRegistryAlias(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := restartRegistrationName([]string{cityPath})
+	gotPath, gotName, err := restartTarget([]string{cityPath})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "machine-alias" {
-		t.Fatalf("restartRegistrationName = %q, want existing machine-local alias", got)
+	if gotName != "machine-alias" {
+		t.Fatalf("restartTarget name = %q, want existing machine-local alias", gotName)
+	}
+	if gotPath == "" {
+		t.Fatal("restartTarget returned empty city path")
 	}
 }
 

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -486,11 +486,10 @@ func TestDoUnregister(t *testing.T) {
 	}
 }
 
-// gc unregister takes a city directory path, not a name. When the argument
-// does not resolve to a registered city — the common footgun is passing the
-// NAME shown by `gc cities`, or a wrong path — unregister must fail loudly
-// instead of silently exiting 0 (non-JSON) or reporting a false success
-// (JSON). Regression for ga-m3ev9r.
+// gc unregister fails loudly when the target resolves to a path that is not
+// registered (rather than exiting 0 silently / fabricating JSON success).
+// A bare unregistered NAME is handled separately by resolveCityRef; this
+// covers an explicit unregistered path. Regression for ga-m3ev9r.
 func TestDoUnregisterUnknownTargetFailsLoudly(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GC_HOME", dir)
@@ -616,42 +615,51 @@ func TestUnregisterUnknownTargetJSONEnvelopeReportsNotOK(t *testing.T) {
 	}
 }
 
-// The name-vs-path hint must fire for a bare NAME (the common footgun of
-// passing the name shown by `gc cities`). Regression for ga-m3ev9r.
-func TestWriteUnregisterNotRegisteredNameHint(t *testing.T) {
-	var stderr bytes.Buffer
-	writeUnregisterNotRegistered(&stderr, "my-city", "/abs/my-city")
-	out := stderr.String()
-	if !strings.Contains(out, "no registered city at /abs/my-city") {
-		t.Fatalf("stderr = %q, want a 'no registered city' line", out)
+// gc unregister accepts a registered city NAME (as shown by gc cities), not
+// just a path (ga-m3ev9r).
+func TestDoUnregisterByName(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GC_HOME", dir)
+	t.Chdir(t.TempDir()) // cwd has no ./my-city, so the name resolves via the registry
+
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(out, "not a name") {
-		t.Fatalf("stderr = %q, want the name-vs-path hint for a bare name", out)
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(out, "gc cities") {
-		t.Fatalf("stderr = %q, want the 'gc cities' guidance", out)
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "my-city"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doUnregister([]string{"my-city"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("registry entries = %v, want empty after unregister-by-name", entries)
 	}
 }
 
-// The name-vs-path hint must NOT fire for a path-shaped argument (relative
-// path, trailing slash, or nested path). Those are genuine paths that simply
-// were not registered, so claiming they "look like a name" contradicts the
-// diagnostic. Comparing the raw token to the fully normalized cityPath used to
-// misfire here. Regression for ga-m3ev9r finding #2.
-func TestWriteUnregisterNotRegisteredPathShapedNoNameHint(t *testing.T) {
-	for _, rawArg := range []string{"./my-city", "/abs/my-city/", "sub/my-city"} {
-		var stderr bytes.Buffer
-		writeUnregisterNotRegistered(&stderr, rawArg, "/abs/my-city")
-		out := stderr.String()
-		if !strings.Contains(out, "no registered city at /abs/my-city") {
-			t.Fatalf("rawArg=%q stderr = %q, want a 'no registered city' line", rawArg, out)
-		}
-		if strings.Contains(out, "not a name") {
-			t.Fatalf("rawArg=%q stderr = %q, name-vs-path hint must not fire for a path-shaped arg", rawArg, out)
-		}
-		if !strings.Contains(out, "gc cities") {
-			t.Fatalf("rawArg=%q stderr = %q, want the 'gc cities' guidance", rawArg, out)
-		}
+func TestDoUnregisterByUnknownNameFailsLoudly(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GC_HOME", dir)
+	t.Chdir(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := doUnregister([]string{"ghost-name"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not a registered city name") {
+		t.Fatalf("stderr = %q, want a name-aware 'not a registered city name' diagnostic", stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -88,7 +88,7 @@ func newReloadCmd(stdout, stderr io.Writer) *cobra.Command {
 	var jsonOut bool
 	var timeoutValue string
 	cmd := &cobra.Command{
-		Use:   "reload [path]",
+		Use:   "reload [path|name]",
 		Short: "Reload the current city's config without restarting the city/controller",
 		Long: `Force the current city controller to re-read effective config and
 process one reload tick without restarting the city/controller.
@@ -107,7 +107,8 @@ drains fire. Useful when editing a running city's .gc/settings.json
 without disrupting in-flight work. Sessions whose template no longer
 maps to a configured agent are NOT updated; normal orphan/suspended
 drain handles them on the next tick.`,
-		Args: cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeCityNames,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			timeoutChanged := cmd.Flags().Changed("timeout")
 			if cmdReload(args, async, soft, jsonOut, timeoutValue, timeoutChanged, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -88,11 +88,6 @@ func restartTarget(args []string) (cityPath, nameOverride string, err error) {
 	return cityPath, nameOverride, nil
 }
 
-func restartRegistrationName(args []string) (string, error) {
-	_, nameOverride, err := restartTarget(args)
-	return nameOverride, err
-}
-
 // newRigRestartCmd creates the "gc rig restart <name>" subcommand.
 func newRigRestartCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -15,14 +15,15 @@ import (
 func newRestartCmd(stdout, stderr io.Writer) *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "restart [path]",
+		Use:   "restart [path|name]",
 		Short: "Restart all agent sessions in the city",
 		Long: `Restart the city by stopping it then starting it again.
 
 Equivalent to running "gc stop" followed by "gc start". Under supervisor
 mode this unregisters the city, then re-registers it and triggers an
 immediate reconcile.`,
-		Args: cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeCityNames,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdRestartJSON(args, stdout, stderr, jsonOut) != 0 {
 				return errExit
@@ -35,27 +36,26 @@ immediate reconcile.`,
 }
 
 func cmdRestartJSON(args []string, stdout, stderr io.Writer, jsonOut bool) int {
-	nameOverride, err := restartRegistrationName(args)
+	// Resolve the city reference ONCE up front (accepting a path or a
+	// registered name) and thread the resolved PATH into both the stop and
+	// start legs, so a bare name can never re-resolve to different targets
+	// across legs.
+	cityPath, nameOverride, err := restartTarget(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc restart: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	resolvedArgs := []string{cityPath}
 	restartStdout := stdout
 	if jsonOut {
 		restartStdout = io.Discard
 	}
-	if code := cmdStop(args, restartStdout, stderr, 0, false); code != 0 {
+	if code := cmdStop(resolvedArgs, restartStdout, stderr, 0, false); code != 0 {
 		return code
 	}
-	code := doStartWithNameOverride(args, false /*controllerMode*/, restartStdout, stderr, nameOverride)
+	code := doStartWithNameOverride(resolvedArgs, false /*controllerMode*/, restartStdout, stderr, nameOverride)
 	if code != 0 || !jsonOut {
 		return code
-	}
-	cityPath := ""
-	if dir, err := resolveStartDir(args); err == nil {
-		if resolved, err := requireBootstrappedCity(dir); err == nil {
-			cityPath = resolved
-		}
 	}
 	return writeLifecycleActionJSONOrExit(stdout, stderr, "gc restart", lifecycleActionJSON{
 		Command:  "restart",
@@ -66,20 +66,31 @@ func cmdRestartJSON(args []string, stdout, stderr io.Writer, jsonOut bool) int {
 	})
 }
 
-func restartRegistrationName(args []string) (string, error) {
+// restartTarget resolves the restart argument once to the city path and its
+// registered name (empty when the city is not registered), so both the stop
+// and start legs operate on the same resolved path.
+func restartTarget(args []string) (cityPath, nameOverride string, err error) {
 	dir, err := resolveStartDir(args)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	cityPath, err := requireBootstrappedCity(dir)
+	cityPath, err = requireBootstrappedCity(dir)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	entry, registered, err := registeredCityEntry(cityPath)
-	if err != nil || !registered {
-		return "", err
+	entry, registered, lookupErr := registeredCityEntry(cityPath)
+	if lookupErr != nil {
+		return "", "", lookupErr
 	}
-	return entry.EffectiveName(), nil
+	if registered {
+		nameOverride = entry.EffectiveName()
+	}
+	return cityPath, nameOverride, nil
+}
+
+func restartRegistrationName(args []string) (string, error) {
+	_, nameOverride, err := restartTarget(args)
+	return nameOverride, err
 }
 
 // newRigRestartCmd creates the "gc rig restart <name>" subcommand.

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -567,12 +567,31 @@ func doStartWithNameOverrideJSON(args []string, controllerMode bool, stdout, std
 func resolveStartDir(args []string) (string, error) {
 	switch {
 	case len(args) > 0:
-		return resolveCityRef(args[0], cityRefOpts{allowNameFallback: true}, filepath.Abs)
+		return resolveStartDirRef(args[0])
 	case cityFlag != "":
-		return resolveCityRef(cityFlag, cityRefOpts{allowNameFallback: true}, filepath.Abs)
+		return resolveStartDirRef(cityFlag)
 	default:
 		return os.Getwd()
 	}
+}
+
+// resolveStartDirRef resolves a name-or-path start/restart reference to a
+// directory that requireBootstrappedCity can turn into a bootstrapped city. A
+// name-shaped reference is routed through the shared name resolver (the same
+// rig-aware path used by resolveCommandContext and resolveStopCityPath) so a
+// slashless local rig directory such as "frontend" resolves to its owning city
+// instead of failing as an unknown city name. Path-shaped references keep the
+// original filepath.Abs behavior, leaving city validation to
+// requireBootstrappedCity.
+func resolveStartDirRef(ref string) (string, error) {
+	if classifyCityRef(ref) == cityRefName {
+		ctx, err := resolveCityNameContext(ref, resolveContextFromPath)
+		if err != nil {
+			return "", err
+		}
+		return ctx.CityPath, nil
+	}
+	return filepath.Abs(ref)
 }
 
 func requireBootstrappedCity(dir string) (string, error) {

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -567,9 +567,9 @@ func doStartWithNameOverrideJSON(args []string, controllerMode bool, stdout, std
 func resolveStartDir(args []string) (string, error) {
 	switch {
 	case len(args) > 0:
-		return resolveCityRef(args[0], cityRefOpts{cmd: "gc start", allowNameFallback: true}, filepath.Abs)
+		return resolveCityRef(args[0], cityRefOpts{allowNameFallback: true}, filepath.Abs)
 	case cityFlag != "":
-		return resolveCityRef(cityFlag, cityRefOpts{cmd: "gc start", allowNameFallback: true}, filepath.Abs)
+		return resolveCityRef(cityFlag, cityRefOpts{allowNameFallback: true}, filepath.Abs)
 	default:
 		return os.Getwd()
 	}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -367,7 +367,7 @@ func newStartCmd(stdout, stderr io.Writer) *cobra.Command {
 	var foregroundMode bool
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "start [path]",
+		Use:   "start [path|name]",
 		Short: "Start the city under the machine-wide supervisor",
 		Long: `Start the city under the machine-wide supervisor.
 
@@ -379,7 +379,8 @@ Use "gc supervisor run" for foreground operation.`,
   gc start ~/my-city
   gc start --dry-run
   gc supervisor run`,
-		Args: cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeCityNames,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOut && (foregroundMode || dryRunMode) {
 				fmt.Fprintln(stderr, "gc start: --json is only supported for supervisor-managed start") //nolint:errcheck // best-effort stderr
@@ -566,9 +567,9 @@ func doStartWithNameOverrideJSON(args []string, controllerMode bool, stdout, std
 func resolveStartDir(args []string) (string, error) {
 	switch {
 	case len(args) > 0:
-		return filepath.Abs(args[0])
+		return resolveCityRef(args[0], cityRefOpts{cmd: "gc start", allowNameFallback: true}, filepath.Abs)
 	case cityFlag != "":
-		return filepath.Abs(cityFlag)
+		return resolveCityRef(cityFlag, cityRefOpts{cmd: "gc start", allowNameFallback: true}, filepath.Abs)
 	default:
 		return os.Getwd()
 	}

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -156,7 +156,7 @@ func resolveStopCityPath(args []string) (string, error) {
 	if len(args) == 0 {
 		return resolveCommandCity(nil)
 	}
-	return resolveCityRef(args[0], cityRefOpts{cmd: "gc stop", allowNameFallback: true}, stopCityPathFromArg)
+	return resolveCityRef(args[0], cityRefOpts{allowNameFallback: true}, stopCityPathFromArg)
 }
 
 // stopCityPathFromArg resolves a path-shaped stop argument (or a local city) to

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -22,7 +22,7 @@ func newStopCmd(stdout, stderr io.Writer) *cobra.Command {
 	var force bool
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "stop [path]",
+		Use:   "stop [path|name]",
 		Short: "Stop all agent sessions in the city",
 		Long: `Stop all agent sessions in the city with graceful shutdown.
 
@@ -36,7 +36,8 @@ before giving up; the default budgets configured session interrupt and
 stop waves, the configured shutdown grace wait, and a second orphan
 cleanup pass. Use --force to skip the interrupt grace period and go
 straight to kill.`,
-		Args: cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeCityNames,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdStopJSON(args, stdout, stderr, wallClockTimeout, force, jsonOut) != 0 {
 				return errExit
@@ -155,7 +156,15 @@ func resolveStopCityPath(args []string) (string, error) {
 	if len(args) == 0 {
 		return resolveCommandCity(nil)
 	}
-	abs, err := filepath.Abs(args[0])
+	return resolveCityRef(args[0], cityRefOpts{cmd: "gc stop", allowNameFallback: true}, stopCityPathFromArg)
+}
+
+// stopCityPathFromArg resolves a path-shaped stop argument (or a local city) to
+// a city path, trying an exact city path, then a rig path, then an upward city
+// walk — the original path-only behavior, now invoked as resolveCityRef's path
+// resolver.
+func stopCityPathFromArg(ref string) (string, error) {
+	abs, err := filepath.Abs(ref)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -156,7 +156,21 @@ func resolveStopCityPath(args []string) (string, error) {
 	if len(args) == 0 {
 		return resolveCommandCity(nil)
 	}
-	return resolveCityRef(args[0], cityRefOpts{allowNameFallback: true}, stopCityPathFromArg)
+	// A name-shaped positional may be a registered city name or a local rig
+	// directory; route it through the shared name resolver so a slashless rig
+	// dir still resolves to its owning city without reopening the bare-name
+	// walk-up footgun. Path-shaped args keep the exact stop path resolver.
+	if classifyCityRef(args[0]) == cityRefName {
+		ctx, err := resolveCityNameContext(args[0], func(name string) (resolvedContext, error) {
+			cp, perr := stopCityPathFromArg(name)
+			return resolvedContext{CityPath: cp}, perr
+		})
+		if err != nil {
+			return "", err
+		}
+		return ctx.CityPath, nil
+	}
+	return stopCityPathFromArg(args[0])
 }
 
 // stopCityPathFromArg resolves a path-shaped stop argument (or a local city) to

--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -18,7 +18,7 @@ import (
 func newSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "suspend [path]",
+		Use:   "suspend [path|name]",
 		Short: "Suspend the city (all agents effectively suspended)",
 		Long: `Suspends the city by recording an explicit "suspended" preference
 in .gc/runtime/suspension-state.json (per-clone runtime state, not
@@ -29,7 +29,8 @@ effectively suspended regardless of their individual suspended fields.
 The reconciler won't spawn agents, gc hook/prime return empty.
 
 Use "gc resume" to restore.`,
-		Args: cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeCityNames,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdSuspend(args, jsonOut, stdout, stderr) != 0 {
 				return errExit
@@ -45,7 +46,7 @@ Use "gc resume" to restore.`,
 func newResumeCmd(stdout, stderr io.Writer) *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "resume [path]",
+		Use:   "resume [path|name]",
 		Short: "Resume a suspended city",
 		Long: `Resume a suspended city by recording an explicit "resumed" preference
 in .gc/runtime/suspension-state.json. The override sticks across city
@@ -54,7 +55,8 @@ restarts even when [workspace] declares suspended_on_start = true.
 Restores normal operation: the reconciler will spawn agents again and
 gc hook/prime will return work. Use "gc agent resume" to resume
 individual agents, or "gc rig resume" for rigs.`,
-		Args: cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeCityNames,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdResume(args, jsonOut, stdout, stderr) != 0 {
 				return errExit

--- a/cmd/gc/completion.go
+++ b/cmd/gc/completion.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/suspensionstate"
 	"github.com/spf13/cobra"
 )
@@ -73,6 +74,39 @@ func completeOrderNames(_ *cobra.Command, args []string, toComplete string) ([]s
 		candidates = append(candidates, o.Name+"\t"+orderCompletionDescription(o))
 	}
 	return candidates, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeCityNames completes registered city names for commands whose first
+// positional is a city path-or-name. It uses ShellCompDirectiveDefault (not
+// NoFileComp) because these commands also accept a directory path, so the
+// shell should still offer filesystem paths alongside the registered names.
+func completeCityNames(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	return cityNameCandidates(toComplete), cobra.ShellCompDirectiveDefault
+}
+
+// cityNameCandidates returns registered city names (with their paths as
+// descriptions) as cobra completion entries, filtered by the prefix being
+// typed. Reads only the supervisor registry, so it works from any cwd.
+func cityNameCandidates(toComplete string) []string {
+	var candidates []string
+	quietDefaultLogger(func() {
+		entries, err := supervisor.NewRegistry(supervisor.RegistryPath()).List()
+		if err != nil {
+			return
+		}
+		candidates = make([]string, 0, len(entries))
+		for _, e := range entries {
+			name := e.EffectiveName()
+			if name == "" || !strings.HasPrefix(name, toComplete) {
+				continue
+			}
+			candidates = append(candidates, name+"\t"+e.Path)
+		}
+	})
+	return candidates
 }
 
 // quietDefaultLogger runs fn with the default log.Logger's output redirected

--- a/cmd/gc/completion.go
+++ b/cmd/gc/completion.go
@@ -82,7 +82,7 @@ func completeOrderNames(_ *cobra.Command, args []string, toComplete string) ([]s
 // shell should still offer filesystem paths alongside the registered names.
 func completeCityNames(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveDefault
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	return cityNameCandidates(toComplete), cobra.ShellCompDirectiveDefault
 }

--- a/cmd/gc/completion.go
+++ b/cmd/gc/completion.go
@@ -159,7 +159,7 @@ func resolveCityForCompletion() (string, error) {
 
 func resolveCityForCompletionContext(honorRigFlag bool) (string, error) {
 	if city := strings.TrimSpace(cityFlag); city != "" {
-		return validateCityPath(city)
+		return resolveCityFlagValue(city)
 	}
 	if honorRigFlag {
 		if rig := strings.TrimSpace(rigFlag); rig != "" {

--- a/cmd/gc/completion_test.go
+++ b/cmd/gc/completion_test.go
@@ -179,6 +179,35 @@ func TestRigNameCandidates_LoadsAndFilters(t *testing.T) {
 	}
 }
 
+// Regression (PR #3625 review F2): a registered city NAME supplied via --city
+// must drive rig-name completion the same way a city PATH does. Before the fix
+// the completion resolver validated --city as a filesystem path only, so
+// `gc --city <name> --rig <TAB>` returned no candidates even though
+// `gc --city <name> --rig <rig> ...` is a supported invocation.
+func TestRigNameCandidates_ResolvesRegisteredCityNameFlag(t *testing.T) {
+	gcHome := t.TempDir()
+	cityPath := t.TempDir()
+	rigDir := filepath.Join(cityPath, "rigs", "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HOME", gcHome)
+	registerRigBindingForResolution(t, gcHome, cityPath, "completion-city", "frontend", rigDir)
+
+	isolateCompletionContext(t, "") // no GC_CITY; resets cityFlag to ""
+	cityFlag = "completion-city"    // a registered NAME, not a path
+	t.Chdir(t.TempDir())            // outside the city: only the name can resolve it
+
+	got := rigNameCandidates("")
+	names := make([]string, len(got))
+	for i, c := range got {
+		names[i] = strings.SplitN(c, "\t", 2)[0]
+	}
+	if !slicesContains(names, "frontend") {
+		t.Fatalf("rigNameCandidates(--city=registered name) = %v, want it to include the city's rig %q", names, "frontend")
+	}
+}
+
 func TestCompleteRigFlagNames_IgnoresPositionalArgs(t *testing.T) {
 	cityPath := t.TempDir()
 	writeCompletionCity(t, cityPath, "[workspace]\nname = \"my-city\"\n\n[[rigs]]\nname = \"alpha\"\npath = \"/tmp/alpha\"\n\n[[rigs]]\nname = \"beta\"\npath = \"/tmp/beta\"\n")

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -433,6 +433,21 @@ func resolveCommandContext(args []string) (resolvedContext, error) {
 	if len(args) == 0 {
 		return resolveContext()
 	}
+	// A name-shaped positional may be a registered city name. Resolve it
+	// against the registry before falling back to path resolution, so a bare
+	// name is never fed to resolveContextFromPath's upward city walk (which
+	// would silently target an ambient ancestor city).
+	if classifyCityRef(args[0]) == cityRefName {
+		registeredPath, useLocal, err := resolveCityNameRef(strings.TrimSpace(args[0]))
+		if err != nil {
+			return resolvedContext{}, err
+		}
+		if !useLocal {
+			return resolvedContext{CityPath: registeredPath}, nil
+		}
+		// useLocal: cwd/<name> is a real city — fall through to path resolution
+		// so the rig-from-cwd behavior is identical to passing the path.
+	}
 	return resolveContextFromPath(args[0])
 }
 
@@ -464,7 +479,7 @@ func resolveContext() (resolvedContext, error) {
 
 	// Step 1: --city + --rig
 	if city != "" && rig != "" {
-		cp, err := validateCityPath(city)
+		cp, err := resolveCityFlagValue(city)
 		if err != nil {
 			return resolvedContext{}, err
 		}
@@ -473,7 +488,7 @@ func resolveContext() (resolvedContext, error) {
 
 	// Step 2: --city only
 	if city != "" {
-		cp, err := validateCityPath(city)
+		cp, err := resolveCityFlagValue(city)
 		if err != nil {
 			return resolvedContext{}, err
 		}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -433,20 +433,13 @@ func resolveCommandContext(args []string) (resolvedContext, error) {
 	if len(args) == 0 {
 		return resolveContext()
 	}
-	// A name-shaped positional may be a registered city name. Resolve it
-	// against the registry before falling back to path resolution, so a bare
-	// name is never fed to resolveContextFromPath's upward city walk (which
-	// would silently target an ambient ancestor city).
+	// A name-shaped positional may be a registered city name or a local rig
+	// directory. Route it through the shared name resolver, which consults the
+	// registry and the rig-path resolver before failing and never feeds a bare
+	// name to resolveContextFromPath's upward city walk (which would silently
+	// target an ambient ancestor city).
 	if classifyCityRef(args[0]) == cityRefName {
-		registeredPath, useLocal, err := resolveCityNameRef(strings.TrimSpace(args[0]))
-		if err != nil {
-			return resolvedContext{}, err
-		}
-		if !useLocal {
-			return resolvedContext{CityPath: registeredPath}, nil
-		}
-		// useLocal: cwd/<name> is a real city — fall through to path resolution
-		// so the rig-from-cwd behavior is identical to passing the path.
+		return resolveCityNameContext(args[0], resolveContextFromPath)
 	}
 	return resolveContextFromPath(args[0])
 }
@@ -459,72 +452,73 @@ func resolveCommandCity(args []string) (string, error) {
 	return ctx.CityPath, nil
 }
 
-// resolveContext resolves the city and optional rig context using the
-// following priority chain:
-//  1. --city + --rig flags (explicit both, validated)
-//  2. --city only (explicit city, rig from cwd if applicable)
-//  3. --rig only (rig from registered city site bindings)
-//  4. Explicit city env (GC_CITY / GC_CITY_PATH / GC_CITY_ROOT) + GC_RIG
-//  5. Explicit city env only (city set, rig from GC_DIR/cwd if applicable)
-//  6. GC_RIG only (rig from registered city site bindings)
-//  7. Registered rig binding lookup using GC_DIR (rig with leftover .gc/)
-//  8. GC_DIR-derived city path (walk-up)
-//  9. Registered rig binding lookup (cwd prefix match)
-//  10. Walk up from cwd looking for city.toml
-//  11. Fail
+// resolveContext resolves the city and optional rig context using a fixed
+// priority chain, each stage delegated to a helper that reports whether it
+// handled the request so the chain stops at the first match:
+//  1. --city / --rig flags                  (resolveContextFromFlags)
+//  2. explicit city env + GC_RIG            (resolveContextFromCityEnv)
+//  3. GC_DIR / cwd discovery and walk-up    (resolveContextFromDir)
 func resolveContext() (resolvedContext, error) {
+	if ctx, handled, err := resolveContextFromFlags(); handled {
+		return ctx, err
+	}
+	if ctx, handled, err := resolveContextFromCityEnv(); handled {
+		return ctx, err
+	}
+	return resolveContextFromDir()
+}
+
+// resolveContextFromFlags resolves context from the explicit --city and --rig
+// flags (priority steps 1-3). handled is false with a nil error when neither
+// flag is set, so the caller falls through to env/cwd resolution.
+func resolveContextFromFlags() (resolvedContext, bool, error) {
 	city := cityFlag
 	rig := rigFlag
-	gcRig := os.Getenv("GC_RIG")
-
-	// Step 1: --city + --rig
-	if city != "" && rig != "" {
+	switch {
+	case city != "" && rig != "": // Step 1: --city + --rig
 		cp, err := resolveCityFlagValue(city)
 		if err != nil {
-			return resolvedContext{}, err
+			return resolvedContext{}, true, err
 		}
-		return resolvedContext{CityPath: cp, RigName: rig}, nil
-	}
-
-	// Step 2: --city only
-	if city != "" {
+		return resolvedContext{CityPath: cp, RigName: rig}, true, nil
+	case city != "": // Step 2: --city only
 		cp, err := resolveCityFlagValue(city)
 		if err != nil {
-			return resolvedContext{}, err
+			return resolvedContext{}, true, err
 		}
-		rn := rigFromCwd(cp)
-		return resolvedContext{CityPath: cp, RigName: rn}, nil
-	}
-
-	// Step 3: --rig only
-	if rig != "" {
+		return resolvedContext{CityPath: cp, RigName: rigFromCwd(cp)}, true, nil
+	case rig != "": // Step 3: --rig only
 		ctx, err := resolveRigToContext(rig)
-		if err != nil {
-			return resolvedContext{}, err
-		}
-		return ctx, nil
+		return ctx, true, err
+	default:
+		return resolvedContext{}, false, nil
 	}
+}
 
-	// Step 4: explicit city env + GC_RIG
-	if gcCity, ok := resolveExplicitCityPathEnv(); ok && gcRig != "" {
-		return resolvedContext{CityPath: gcCity, RigName: gcRig}, nil
-	}
-
-	// Step 5: explicit city env only
-	if gcCity, ok := resolveExplicitCityPathEnv(); ok {
-		rn := rigFromGCDirOrCwd(gcCity)
-		return resolvedContext{CityPath: gcCity, RigName: rn}, nil
-	}
-
-	// Step 6: GC_RIG only
-	if gcRig != "" {
+// resolveContextFromCityEnv resolves context from the explicit city env
+// (GC_CITY / GC_CITY_PATH / GC_CITY_ROOT) and GC_RIG (priority steps 4-6).
+// handled is false with a nil error when neither resolves.
+func resolveContextFromCityEnv() (resolvedContext, bool, error) {
+	gcRig := os.Getenv("GC_RIG")
+	gcCity, ok := resolveExplicitCityPathEnv()
+	switch {
+	case ok && gcRig != "": // Step 4: explicit city env + GC_RIG
+		return resolvedContext{CityPath: gcCity, RigName: gcRig}, true, nil
+	case ok: // Step 5: explicit city env only
+		return resolvedContext{CityPath: gcCity, RigName: rigFromGCDirOrCwd(gcCity)}, true, nil
+	case gcRig != "": // Step 6: GC_RIG only
 		ctx, err := resolveRigToContext(gcRig)
-		if err != nil {
-			return resolvedContext{}, err
-		}
-		return ctx, nil
+		return ctx, true, err
+	default:
+		return resolvedContext{}, false, nil
 	}
+}
 
+// resolveContextFromDir resolves context from GC_DIR and the cwd (priority
+// steps 7-11): a GC_DIR rig binding, a GC_DIR-derived city, a cwd rig binding,
+// and finally a walk up from cwd for city.toml. This is the terminal stage, so
+// it always returns a result or an error.
+func resolveContextFromDir() (resolvedContext, error) {
 	// Step 7: Registered rig binding lookup using GC_DIR. Must run before
 	// the GC_DIR walkup (step 8) so that a rig dir with a leftover ".gc/"
 	// runtime artifact does not get mistaken for a legacy city via
@@ -540,11 +534,10 @@ func resolveContext() (resolvedContext, error) {
 	// the walkup at step 8 finds the right city in O(1) and we don't pay
 	// for a full registry scan. When GC_DIR has neither, step 9 (cwd-based
 	// rig lookup) covers it.
-	if gcDir := strings.TrimSpace(os.Getenv("GC_DIR")); gcDir != "" {
-		if citylayout.HasRuntimeRoot(gcDir) && !citylayout.HasCityConfig(gcDir) {
-			if ctx, ok := lookupRigFromCwd(gcDir); ok {
-				return ctx, nil
-			}
+	if gcDir := strings.TrimSpace(os.Getenv("GC_DIR")); gcDir != "" &&
+		citylayout.HasRuntimeRoot(gcDir) && !citylayout.HasCityConfig(gcDir) {
+		if ctx, ok := lookupRigFromCwd(gcDir); ok {
+			return ctx, nil
 		}
 	}
 
@@ -568,8 +561,7 @@ func resolveContext() (resolvedContext, error) {
 	if err != nil {
 		return resolvedContext{}, err
 	}
-	rn := rigFromCwdDir(cityPath, cwd)
-	return resolvedContext{CityPath: cityPath, RigName: rn}, nil
+	return resolvedContext{CityPath: cityPath, RigName: rigFromCwdDir(cityPath, cwd)}, nil
 }
 
 // resolveCity returns the city root path. Thin wrapper over resolveContext
@@ -672,7 +664,7 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 
 func resolveLocalCityForRigFallback() (string, error) {
 	if cityFlag != "" {
-		return validateCityPath(cityFlag)
+		return resolveCityFlagValue(cityFlag)
 	}
 	if gcCity, ok := resolveExplicitCityPathEnv(); ok {
 		return gcCity, nil

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2812,7 +2812,7 @@ maps to a configured agent are NOT updated; normal orphan/suspended
 drain handles them on the next tick.
 
 ```
-gc reload [path] [flags]
+gc reload [path|name] [flags]
 ```
 
 | Flag | Type | Default | Description |
@@ -2831,7 +2831,7 @@ mode this unregisters the city, then re-registers it and triggers an
 immediate reconcile.
 
 ```
-gc restart [path] [flags]
+gc restart [path|name] [flags]
 ```
 
 | Flag | Type | Default | Description |
@@ -2849,7 +2849,7 @@ gc hook/prime will return work. Use "gc agent resume" to resume
 individual agents, or "gc rig resume" for rigs.
 
 ```
-gc resume [path] [flags]
+gc resume [path|name] [flags]
 ```
 
 | Flag | Type | Default | Description |
@@ -3750,7 +3750,7 @@ ensures the supervisor is running, and triggers immediate reconciliation.
 Use "gc supervisor run" for foreground operation.
 
 ```
-gc start [path] [flags]
+gc start [path|name] [flags]
 ```
 
 **Example:**
@@ -3775,7 +3775,7 @@ Shows a city-wide overview: controller state, suspension,
 all agents with running status, rigs, and a summary count.
 
 ```
-gc status [path] [flags]
+gc status [path|name] [flags]
 ```
 
 | Flag | Type | Default | Description |
@@ -3799,7 +3799,7 @@ cleanup pass. Use --force to skip the interrupt grace period and go
 straight to kill.
 
 ```
-gc stop [path] [flags]
+gc stop [path|name] [flags]
 ```
 
 | Flag | Type | Default | Description |
@@ -3976,7 +3976,7 @@ The reconciler won't spawn agents, gc hook/prime return empty.
 Use "gc resume" to restore.
 
 ```
-gc suspend [path] [flags]
+gc suspend [path|name] [flags]
 ```
 
 | Flag | Type | Default | Description |
@@ -4104,14 +4104,17 @@ gc trace tail [flags]
 
 Remove a city from the machine-wide supervisor registry.
 
-If no path is given, unregisters the current city (discovered from cwd).
+The argument may be a path to a city directory or a registered city name (as
+shown by 'gc cities'); a name is resolved against the supervisor registry. An
+existing local directory of the same name takes precedence over a registration.
+If no argument is given, unregisters the current city (discovered from cwd).
 If the supervisor is running, it immediately stops managing the city.
 Takes a city directory path, not the name shown by 'gc cities'. Unlike
 'gc register' (which is idempotent), this errors when the resolved path is not
 a registered city, so it is not a silent no-op on an unknown target.
 
 ```
-gc unregister [path] [flags]
+gc unregister [path|name] [flags]
 ```
 
 | Flag | Type | Default | Description |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4106,10 +4106,11 @@ Remove a city from the machine-wide supervisor registry.
 
 The argument may be a path to a city directory or a registered city name (as
 shown by 'gc cities'); a name is resolved against the supervisor registry. An
-existing local directory of the same name takes precedence over a registration.
+existing local city directory of the same name takes precedence over a
+registration; if a local city directory and a different registration both
+exist, the name is reported as ambiguous.
 If no argument is given, unregisters the current city (discovered from cwd).
-If the supervisor is running, it immediately stops managing the city.
-Takes a city directory path, not the name shown by 'gc cities'. Unlike
+If the supervisor is running, it immediately stops managing the city. Unlike
 'gc register' (which is idempotent), this errors when the resolved path is not
 a registered city, so it is not a silent no-op on an unknown target.
 

--- a/engdocs/contributors/design-gc-city-name-resolution.md
+++ b/engdocs/contributors/design-gc-city-name-resolution.md
@@ -1,0 +1,166 @@
+# Design: accept a bare city NAME (not just a path) across gc city-targeting commands
+
+- **Status:** Draft (proposal for review — not yet implemented)
+- **Issue:** ga-m3ev9r
+- **Follows:** PR #3623 (gc unregister fails loudly on unknown name/path)
+- **Produced by:** multi-agent design workflow (explore → 3 proposals → adversarial review → synthesis)
+
+> **Critical insight from adversarial review (do not skip):**
+> All three proposals share a fatal flaw the break-testers exposed: they frame name resolution as run-the-path-resolver-first then fall-back-to-registry-on-error. But every existing path resolver ends in findCity(cwd/token), which WALKS UP the directory tree (verified in city_discovery.go:19-49: from inside any city, findCity returns the ambient ancestor city with err=nil). So a bare name run from inside a city resolves to the AMBIENT city, the path resolver succeeds, the name fallback never fires, and stop/suspend/reload/restart silently mis-target; under --json this reports ok:true for the wrong city. The fix is to classify by arg SHAPE up front and ROUTE accordingly: a name-shaped token that is NOT an existing directory in cwd must skip the path resolver entirely and go straight to Registry.LookupCityByName. This is the only synthesis that resolves every blocking issue. I drop proposal 3's --as-name/--as-path escape-hatch flags (YAGNI; the single ambiguous case is handled deterministically with a stderr breadcrumb).
+
+**Chosen approach:** 
+Hybrid: shape-classify-then-route (proposal 3 shape gate) plus per-command class awareness so register opts out of name fallback (proposal 2), MINUS the escape-hatch flags. The decisive correction over all three: a name-shaped token that does not name an existing *city* directory is routed directly to the registry and NEVER passed to the walk-up path resolver, eliminating the silent ambient-city mis-target. A single shared resolver plus Registry.LookupCityByName and IsValidCityName; each command injects its existing path resolver as a closure used only for the path-shaped and city-dir-exists branches.
+
+---
+
+## Decisions (resolved 2026-06-20 by maintainer)
+
+These answers to the open questions are authoritative and **supersede** the
+conflicting notes in §3, §5, and Appendix A below.
+
+1. **No escape-hatch flags; ambiguity is a loud failure.** v1 ships no
+   `--as-name`/`--as-path`. The only genuine ambiguity — a name-shaped token
+   that is BOTH an existing local **city** directory AND a registered name
+   pointing at a **different** path — is a **loud failure** (exit 1): the
+   command refuses and tells the user to disambiguate (`./<dir>` for the local
+   path, or `cd` elsewhere to use the registered name). This replaces the
+   workflow's "path-wins + breadcrumb" (old RULE 2/RULE 4). **Refinement that
+   closes a walk-up sub-hole:** a name-shaped token only takes the PATH branch
+   when `cwd/<token>` is an actual city (`citylayout.HasCityConfig`), not
+   merely an existing directory — a non-city dir of the same name must NOT be
+   fed to `findCity`'s upward walk. Non-ambiguous cases are unchanged: a
+   path-shaped arg always means path; a registered name with no local city dir
+   resolves via the registry; a genuine miss fails loudly (preserves PR #3623).
+
+2. **`--city <name>` and `GC_CITY` are IN SCOPE from the start** (was deferred
+   in §5). The shared resolver is reframed as a single "city reference"
+   resolver applied to (a) the positional arg, (b) the `--city` persistent
+   flag, and (c) the `GC_CITY` env var. `GC_CITY_PATH` / `GC_CITY_ROOT` stay
+   path-only (their names denote paths). This brings the central resolution
+   sites into wiring scope: `resolveContext` steps 1–2 (main.go ~466,475),
+   `resolveExplicitCityPathEnv` (city_context.go), and `resolveStartDir`'s
+   direct `filepath.Abs(cityFlag)` (cmd_start.go ~571). Because these feed
+   nearly every command, this is the highest-risk wiring and gets its own
+   phase with dedicated precedence/regression tests.
+
+3. **`gc restart` resolves the reference once at the top** and threads the
+   resolved **path** (never the raw name) into both the stop and start legs
+   (as already specified in §5).
+
+4. **`gc register` completion shows registered city names as hints** (with
+   file completion still enabled), to help users avoid double-registering.
+
+---
+
+## 1. Context and goal
+
+gc city-targeting commands (register, unregister, start, stop, restart, reload, suspend, resume, status) today treat their optional positional argument strictly as a path. Passing the name shown by `gc cities` (e.g. `gc unregister chris-city`) silently resolves to cwd/chris-city, which usually is not a city, and the command fails or, far worse, walks up to the ambient city and acts on the wrong target. PR #3623 added a fail-loudly-on-no-match guard to unregister (writeUnregisterNotRegistered, cmd_register.go:196-206). This design is the follow-up that makes the intuitive name form work, while preserving PR #3623 fail-loudly for genuine misses. Goal: every city-targeting command accepts either a directory PATH (today behavior, byte-for-byte unchanged) or a bare registered city NAME resolved against the supervisor registry, with deterministic disambiguation and zero regression for path callers.
+
+The load-bearing constraint the naive design gets wrong: validateCityPath (main.go:594-603), resolveContextFromPath (main.go:565-591), and resolveStopCityPath (cmd_stop.go:154-177) all end in findCity(abs) (city_discovery.go:19-49), which walks upward looking for an ancestor city.toml/.gc (bounded only by HOME and TMPDIR ceilings). From cwd /x/mycity/sub, findCity(/x/mycity/sub/chris-city) returns /x/mycity with err nil. Therefore try-path-first-then-registry-on-error is unsafe: from inside any city a bare name never errors, it walks up to the ambient city, and under --json the command reports ok:true for it. This design classifies by shape before any resolution and only invokes the walk-up path resolver for tokens that actually denote a path or an existing directory.
+
+## 2. Resolution algorithm
+
+A registered city name can never contain a slash: validCityName requires a leading alphanumeric and allows only alphanumerics, dots, underscores, hyphens (registry.go:24). name-shaped means supervisor.IsValidCityName(TrimSpace(arg)); path-shaped means not name-shaped (contains a separator, leading dot or tilde, is absolute, empty, or has any out-of-class character).
+
+RULE 0 no arg (unchanged): keep each command current no-arg behavior (resolveCommandCity(nil) / resolveContext / cwd). Name resolution applies only to an explicitly supplied positional.
+
+RULE 1 path-shaped means PATH, no registry IO: run the command existing path resolver verbatim and return its result including its error. Byte-for-byte unchanged for ., ./x, ../x, ~/x, /abs, rel/dir.
+
+RULE 2 name-shaped AND an existing directory in cwd means PATH wins: if cwd/token exists as a directory, run the existing path resolver against it. Path wins the single genuine collision (RULE 4 adds a breadcrumb when that directory shadows a same-named registration elsewhere). Existence is a single os.Stat on filepath.Join(cwd, token); it does NOT walk up.
+
+RULE 3 name-shaped AND NOT an existing directory means REGISTRY ONLY: the fix for the walk-up footgun. The token is NOT fed to the path resolver. Instead call Registry.LookupCityByName(token): hit returns entry.Path (absolute; flows through normal downstream validation such as requireBootstrappedCity and registeredCityEntry); miss returns a combined error (RULE 5). The os.Stat in RULE 2/3 replaces the implicit cwd/token walk-up with an exact non-ascending existence check, so a name-shaped token never resolves to an ancestor city.
+
+RULE 4 collision breadcrumb (non-fatal, stderr only): when RULE 2 fired AND LookupCityByName(token) also hits AND the resolved local dir abs path differs from entry.Path, print to stderr a note that token is also a registered city at entry.Path, using local directory absDir, cd elsewhere or pass an absolute path to target the registered city. Suppressed under --json (stderr only; stdout JSONL untouched). Same path means no note. Cost: one extra LookupCityByName only on the rare name-shaped plus dir-exists branch.
+
+RULE 5 combined miss (fail loudly, preserves PR #3623): if neither a path nor a registered name resolves, return a structured error naming both attempts; exit 1 with empty stdout so run() central handler (main.go:173-186) emits ok:false under --json. No fabricated success.
+
+RULE 6 register opts out of name fallback: register creates a new registration for a path, so a name match is meaningless. It skips RULE 3 registry lookup; a name-shaped non-directory yields the existing not-a-city-directory error plus a clarifying note if the token already names a registration.
+
+## 3. Ambiguity policy and escape hatches
+
+The shape gate collapses ambiguity to one case: a bare name-shaped token that is simultaneously an existing relative directory under cwd and a registered city name pointing at a different absolute path. Policy: PATH WINS, with a visible breadcrumb (RULE 4). Name-first would silently retarget gc stop chris-city away from a real ./chris-city in cwd, the more dangerous surprise and a regression of today path semantics. Path-wins guarantees zero regression for existing path callers; the breadcrumb keeps it non-silent. No escape-hatch flags in v1: an earlier proposal added --as-name/--as-path; rejected as YAGNI since the single collision is rare, deterministic and breadcrumbed, and threading two mutually-exclusive flags through nine commands plus the fixed-signature resolveContextFromPath roughly doubles the surface. The escape hatch that already exists is trivial: pass an absolute or ./-prefixed path to force PATH, or cd out of the colliding directory to force NAME. Name comparison is exact and case-sensitive on the stored EffectiveName() snapshot, matching Register dedup (registry.go:144) and LookupRigByName (registry.go:509-524). The registry is the source of registration identity: a post-registration rename in city.toml/site.toml does not change the registered-name lookup; this matches what gc cities shows (gascity#602) and is documented in help text.
+
+## 4. Shared helper API
+
+Registry layer, internal/supervisor/registry.go, mirroring LookupRigByName exactly: func (r *Registry) LookupCityByName(name string) (CityEntry, bool) takes RLock, loads entries, returns the first entry whose EffectiveName() equals name with true, else zero plus false (and false on load error). Also func IsValidCityName(s string) bool returns validCityName.MatchString(TrimSpace(s)) so the CLI can classify without importing the regexp. No new locking or load paths.
+
+CLI layer, new file cmd/gc/city_arg_resolve.go. A cityArgKind enum (cityArgEmpty, cityArgPath, cityArgName) and classifyCityArg(raw) string-only: empty if TrimSpace is empty; cityArgName if supervisor.IsValidCityName(raw); else cityArgPath. A cityArgOpts struct carries cmd (diagnostic name), allowNameFallback (false for register), and warn io.Writer (breadcrumb sink, nil to suppress). The core resolver func resolveCityArg(raw string, opts cityArgOpts, pathResolve func(string) (string, error)) (string, error) where pathResolve is the command EXISTING path resolver injected as a closure. Behavior: cityArgEmpty and cityArgPath return pathResolve(raw) directly (RULE 0/1). For cityArgName: compute dir as filepath.Join(cwd, raw); if isExistingDir(dir) call pathResolve(raw) and on success call maybeWarnCityNameCollision (RULE 2/4); otherwise if opts.allowNameFallback do reg.LookupCityByName(raw) and return entry.Path on hit (RULE 3); else return cityArgNotFoundErr (RULE 5/6). CRITICAL: pathResolve is invoked ONLY for path-shaped or directory-exists tokens, so the findCity walk-up cannot silently resolve a bare name to an ambient ancestor city. Helpers isExistingDir, maybeWarnCityNameCollision (does the extra LookupCityByName plus samePath compare, prints RULE 4 to opts.warn), and cityArgNotFoundErr live in the same file. A second wrapper func resolveCityContextArg(args []string, opts cityArgOpts) (resolvedContext, error) returns a resolvedContext for family-A commands that need RigName; on a name hit it builds a city-only context (no rig). Where it hooks in: resolveCityArg and resolveCityContextArg are the single shared seam; each command keeps its own pathResolve closure so the path branch is identical to today. It is intentionally NOT wired into resolveContextFromPath (main.go:565) because that has a fixed (path string) signature, is also called by requireBootstrappedCity and resolveContext, and embeds the walk-up; wrapping it would either change its signature everywhere (merge-hostile) or re-introduce the walk-up footgun.
+
+## 5. Per-command scope
+
+unregister [path|name] (registry-required): PRIMARY. Replace the filepath.Abs plus normalize branch (cmd_register.go:144-148) with resolveCityArg(args[0], opts allowNameFallback true warn stderr, pathFn) where pathFn is filepath.Abs then normalizePathForCompare. Keep registeredCityEntry fail-loud (:156-173); rewrite writeUnregisterNotRegistered. Headline fix.
+
+stop [path|name] (create-capable): wrap the len(args)>0 body of resolveStopCityPath (cmd_stop.go:154-177) as pathFn; call resolveCityArg with allowNameFallback true. Standalone/unregistered-dir stops preserved.
+
+start [path|name] (create-capable): in resolveStartDir (cmd_start.go:566-575), route the len(args)>0 case through resolveCityArg BEFORE filepath.Abs(args[0]). Name fallback fires only when cwd/token is not a dir; requireBootstrappedCity still validates .gc and errors clearly for a stale registration. New/standalone path dirs never regress.
+
+restart [path|name] (create-capable): resolve NAME to PATH ONCE at the top of cmdRestartJSON and thread the resolved PATH (not the raw name) into both cmdStop and doStartWithNameOverride so the three legs cannot re-resolve a bare name to different targets. restartRegistrationName uses resolveCityArg for the JSON city_name.
+
+reload [path|name] (registry-friendly): cmdReload calls resolveCityContextArg(args, opts) instead of resolveCommandCity(args) (cmd_reload.go:127). Name selects which controller socket.
+
+suspend / resume [path|name] (registry-friendly): resolveSuspendDir (cmd_suspend.go:112-114) calls resolveCityContextArg. Standalone cities still work via the dir-exists branch.
+
+status [path|name] top-level newStatusCmd (cmd_citystatus.go): cmdCityStatus (cmd_citystatus.go:147) calls resolveCityContextArg. This is TOP-LEVEL city status, distinct from gc rig status. Existing --json resolve-failure path (:149-151) carries the combined error.
+
+register [path] (create-only): path-first, NO name fallback (allowNameFallback false). Keep validateCityPath(args[0]). A name-shaped non-dir yields not-a-city-directory plus a takes-a-path-not-a-name note, plus a note if the token already names a registration.
+
+supervisor start/stop/status/reload/run/logs/install/uninstall: OUT OF SCOPE, all cobra.NoArgs (cmd_supervisor.go:74,108,127,927), operate on the machine-wide supervisor, take no city positional.
+
+--city <path> flag and GC_CITY/GC_CITY_PATH/GC_CITY_ROOT env: OUT OF SCOPE for v1; they flow through validateCityPath (main.go:466,475,659) and resolveStartDir direct filepath.Abs(cityFlag) (cmd_start.go:571). Deferred; positional name support covers the headline cases.
+
+gc rig status/suspend/resume/restart [name]: OUT OF SCOPE; they resolve a RIG name against cfg.Rigs, a different mechanism (config, not registry).
+
+Prior-art correction: the brief cited gc status [name] and gc rig suspend/resume [name] as reusable name-to-target resolvers. Verified false: top-level gc status resolves via resolveCommandCity then resolveContextFromPath with NO registry name lookup; gc rig commands resolve a rig name from cfg.Rigs. The only genuine precedent is LookupRigByName; LookupCityByName is built fresh.
+
+## 6. UX: success, error, help text
+
+Success (unchanged shape): gc unregister chris-city prints City unregistered.; --json success stays ok:true via writeLifecycleActionJSONOrExit with CityName equal to entry.EffectiveName(). Errors: combined miss (gc stop bogus) prints that bogus is not a city directory (no city.toml or .gc at cwd/bogus) and is not a registered city name, run gc cities to see registered cities. unregister genuine miss rewrites writeUnregisterNotRegistered dropping the now-false treated-as-a-path-not-a-name line, to a message that chris-city is not a registered city name and cwd/chris-city is not a registered city, run gc cities then gc unregister name-or-path. register name-shaped non-dir prints not a city directory cwd/chris-city no city.toml found, gc register takes a path to a city directory not a registration name, plus note chris-city is already a registered city when applicable. start name resolves but .gc missing uses the existing message via the resolved path: city runtime not bootstrapped at path, run gc init path first. Breadcrumb (stderr, action proceeds, suppressed under --json): note that chris-city is also a registered city at /srv/chris-city, using local directory cwd/chris-city, cd elsewhere or pass an absolute path to target the registered city. Help text: for register, unregister, start, stop, restart, reload, suspend, resume, status change Use from <cmd> [path] to <cmd> [path|name] and add to Long that it accepts either a path to a city directory or a registered city name (as shown by gc cities), a name is resolved against the supervisor registry, and an existing local directory of the same name takes precedence. For register, Long states it takes a path only.
+
+## 7. Shell completion
+
+Add completeCityNames and cityNameCandidates to cmd/gc/completion.go mirroring completeRigNames/rigNameCandidates (completion.go:47-120). completeCityNames early-exits (nil, ShellCompDirectiveDefault) when len(args)>0; otherwise returns cityNameCandidates(toComplete) with ShellCompDirectiveDefault. cityNameCandidates wraps work in quietDefaultLogger (mandatory, keeps log noise off the completion line), constructs supervisor.NewRegistry(supervisor.RegistryPath()), calls reg.List(), and for each entry whose EffectiveName has the toComplete prefix appends EffectiveName tab Path. Directive is ShellCompDirectiveDefault (NOT NoFileComp) because city args accept name-or-path, so the shell should offer registered names AND directories; reg.List needs no resolution context so completion works from any cwd. Wire as ValidArgsFunction on the constructors that have none today: newUnregisterCmd, newStopCmd, newStartCmd, newRestartCmd (city), newReloadCmd, newSuspendCmd, newResumeCmd, newStatusCmd (top-level), and newRegisterCmd (names as hints; file completion stays on). newCitiesCmd is NoArgs, skip. --city flag completion is deferred with the flag name support.
+
+## 8. Backward compatibility and migration
+
+Do existing absolute/relative PATH invocations behave identically? YES. Path-shaped args (., ./x, ../x, ~/x, /abs, rel/dir, anything with a separator) are classified cityArgPath and routed straight to the existing pathResolve with no registry IO: identical code path and error text. Preserves TestResolveCommandContextPathValidatesExactCityRootAtHomeBoundary and the unregister ghost-absolute-path tests (cmd_register_test.go:494-578). A name-shaped token that names an existing dir is cityArgName plus dir-exists, routed to pathResolve (path wins): preserves TestRigAnywhere_ResolveCommandContext arg-inside/arg-outside cases and standalone-dir start/stop. A name-shaped token with no local dir that is registered now resolves instead of failing (or, critically, instead of silently walking up to the ambient city): strictly additive. Walk-up safety: RULE 3 routes name-shaped non-dir tokens to the registry and never to findCity, so gc stop other-name from inside city A no longer silently stops A; behavior changes ONLY for previously-broken cases. JSON contract unchanged: success ok:true; miss exits 1 with empty stdout so run() emits ok:false (main.go:173-186). No registry write-path change. No --city/GC_CITY change. The one deliberate string change: writeUnregisterNotRegistered treated-as-a-path-not-a-name line is removed (now false); its comments at cmd_register_test.go:489-493,510-511 become false and must be updated. Audit confirms no test asserts that exact substring; tests assert no-registered-city and gc-cities which remain present.
+
+## 9. Test plan
+
+Registry, internal/supervisor/registry_test.go: TestLookupCityByName registers two cities, each name returns the right entry plus true, unknown returns zero plus false (mirrors TestRigLookupByName registry_test.go:559-583); TestIsValidCityName table accepts chris-city, a.b, a_b, 1city and rejects a/b, ./x, ../x, ~/x, /abs, empty, has-space.
+
+Classifier/resolver, new cmd/gc/city_arg_resolve_test.go: TestClassifyCityArg table; TestResolveCityArg_PathShapedSkipsRegistry (foo/bar miss returns pathFn error verbatim; registry NOT consulted via a spy that fails the test if called); TestResolveCityArg_NameNoDirHitsRegistry (name-shaped, no cwd/token dir, registered returns entry.Path; pathFn NOT called, proving no walk-up); TestResolveCityArg_NameNoDirMissCombinedError (both not-a-city-directory and registered-city-name substrings); TestResolveCityArg_DirExistsPathWins (create cwd/token as a city dir AND register a same-name city elsewhere returns local dir, breadcrumb written to warn); TestResolveCityArg_DirExistsSamePathNoBreadcrumb; TestResolveCityArg_RegisterNoNameFallback (allowNameFallback false means registry never consulted on name-shaped non-dir); and the core-bug guard TestResolveCityArg_FromInsideCityDoesNotWalkUp (cwd is a real city subdir, register a DIFFERENT city by name, resolveCityArg(other-name) returns the registered other-city path, NOT the ambient city).
+
+Per-command (each *_test.go, isolated GC_HOME via t.Setenv plus supervisor.NewRegistry(RegistryPath()).Register, cf. cmd_register_test.go:505-508): cmd_register_test.go gets TestDoUnregisterByName (success plus ok:true), TestDoUnregisterByName_PathWinsOverName (local ./name registered elsewhere means local dir unregistered plus breadcrumb), updates the false comments at :489-493,510-511, keeps ghost-absolute-path tests behaviorally green, and adds a bare-unknown-NAME miss producing loud failure plus ok:false; cmd_stop_test.go gets TestStopByRegisteredName, TestStopStandalonePathStillWorks, TestStopByNameFromInsideAnotherCity (inside A, gc stop B-name targets B); cmd_start_test.go gets TestStartByRegisteredName, TestStartNewUnregisteredPathStillWorks; cmd_restart_test.go gets TestRestartByRegisteredName, TestRestartByName_SingleTargetAcrossLegs; cmd_reload_test.go, cmd_suspend_test.go (suspend plus resume), cmd_citystatus_test.go get by-name resolves plus one path-arg case re-asserted. Regression guard: keep TestRigAnywhere_ResolveCommandContext and TestResolveCommandContextPathValidatesExactCityRootAtHomeBoundary (command_context_test.go:83-146) green unchanged. Completion: TestCompleteCityNames_EarlyExitOnExtraArgs and TestCityNameCandidates_LoadsAndFilters (name-tab-path shape, prefix filter), seeding via Register under isolated GC_HOME.
+
+## 10. Risks and open questions
+
+Two resolver families (family A reload/suspend/resume/status via resolveCommandCity vs bespoke stop/start/restart/unregister): mitigated by the single shared seam every entrypoint adopts; a grep checklist of all nine entrypoints is in the test plan. restart fan-out: cmdRestartJSON threads raw args into three legs; resolve once at the top and thread the PATH down (covered by TestRestartByName_SingleTargetAcrossLegs). Stale registry: LookupCityByName may return a path whose city.toml/.gc was deleted; name resolution returns only the path and downstream validation errors clearly referencing the resolved path so the user can gc unregister it (no worse than today). Symlink normalization: returned registry paths must flow through the same normalization the path branch uses; for unregister the resolved value re-enters registeredCityEntry then normalizeRegisteredCityPath (EvalSymlinks), verify in tests. EffectiveName snapshot vs live name: lookup matches the registered name not a post-registration rename (correct, gascity#602, documented). --city/GC_CITY gap: deferred; gc --city name stop still misses in v1, documented. Open questions: should register completion show names at all or files only (proposed hints); is --city name worth scheduling now or on demand.
+
+## 11. Phased implementation plan (each phase 5 files or fewer)
+
+Phase 1 primitives (2 files): add Registry.LookupCityByName plus IsValidCityName to internal/supervisor/registry.go; add TestLookupCityByName plus TestIsValidCityName to internal/supervisor/registry_test.go; run package tests. Phase 2 shared CLI resolver (2 files): new cmd/gc/city_arg_resolve.go (classifyCityArg, resolveCityArg, resolveCityContextArg, breadcrumb plus error helpers); new cmd/gc/city_arg_resolve_test.go (full matrix incl. the walk-up regression guard); run. Phase 3 primary command plus diagnostic rewrite (2 files): wire unregister in cmd/gc/cmd_register.go incl. the writeUnregisterNotRegistered rewrite; update cmd/gc/cmd_register_test.go; run. Phase 4 create-capable commands (3 files): wire stop (cmd/gc/cmd_stop.go), start (cmd/gc/cmd_start.go), restart (cmd/gc/cmd_restart.go, single-resolution threading); verify standalone-path regression and from-inside-another-city tests. Phase 5 registry-friendly commands plus completion plus help (5 files): wire reload (cmd/gc/cmd_reload.go), suspend/resume (cmd/gc/cmd_suspend.go), status (cmd/gc/cmd_citystatus.go) through resolveCityContextArg; add completeCityNames plus ValidArgsFunction wiring plus Use/Long help-text edits (cmd/gc/completion.go plus constructors); add completion tests (cmd/gc/completion_test.go); run full cmd/gc suite plus go vet.
+
+## Appendix A — Open questions
+
+- Should gc register tab-completion offer registered city names as hints (to help users avoid double-registering) or stay file-only? Proposed: show names as informational hints with file completion still on (ShellCompDirectiveDefault).
+- Is --city name (persistent flag) name support worth scheduling now, or deferred until a real user asks? It touches several validateCityPath call sites (main.go:466,475,659) plus resolveStartDir direct filepath.Abs(cityFlag) at cmd_start.go:571. Proposed: defer to a clearly-scoped follow-up.
+- For the collision breadcrumb wording, is cd-elsewhere-or-pass-an-absolute-path the right guidance given there are no escape-hatch flags in v1, or should v1 ship a minimal --as-name on stop/unregister only?
+- restart threads raw args into three legs; preferred mechanism to pass the single resolved PATH down: rewrite the args slice to one resolved path, or add path-accepting internal entrypoints for cmdStop/doStartWithNameOverride? The slice-rewrite is smaller but relies on every leg treating an absolute path identically.
+
+## Appendix B — Phased implementation plan
+
+1. Phase 1 - Registry primitives (2 files): add Registry.LookupCityByName plus IsValidCityName to internal/supervisor/registry.go (mirroring LookupRigByName, exact case-sensitive match on EffectiveName); add TestLookupCityByName plus TestIsValidCityName to internal/supervisor/registry_test.go. Verify package tests pass.
+2. Phase 2 - Shared CLI resolver (2 files): create cmd/gc/city_arg_resolve.go with classifyCityArg, resolveCityArg (shape-classify-then-route: path-shaped and dir-exists go to injected pathResolve; name-shaped-no-dir goes straight to registry, never to the findCity walk-up), resolveCityContextArg, plus breadcrumb (RULE 4) and combined-error (RULE 5) helpers; create cmd/gc/city_arg_resolve_test.go covering the full matrix including TestResolveCityArg_FromInsideCityDoesNotWalkUp. Verify.
+3. Phase 3 - Primary command plus diagnostic rewrite (2 files): wire gc unregister through resolveCityArg in cmd/gc/cmd_register.go and rewrite writeUnregisterNotRegistered to drop the now-false not-a-name line; update cmd/gc/cmd_register_test.go (add TestDoUnregisterByName, path-wins-over-name, bare-unknown-name miss; fix the false comments at :489-493,510-511). Verify.
+4. Phase 4 - Create-capable commands (3 files): wire gc stop (cmd/gc/cmd_stop.go via resolveStopCityPath body as pathFn), gc start (cmd/gc/cmd_start.go: route resolveStartDir arg case through resolveCityArg before filepath.Abs), gc restart (cmd/gc/cmd_restart.go: resolve name-to-path once, thread the PATH into both stop and start legs). Verify, including standalone-path regression and from-inside-another-city tests.
+5. Phase 5 - Registry-friendly commands plus completion plus help (5 files): wire gc reload (cmd/gc/cmd_reload.go), suspend/resume (cmd/gc/cmd_suspend.go), status (cmd/gc/cmd_citystatus.go) through resolveCityContextArg; add completeCityNames plus cityNameCandidates and ValidArgsFunction wiring plus Use/Long help-text edits in cmd/gc/completion.go and the command constructors; add completion tests in cmd/gc/completion_test.go. Run full cmd/gc suite plus go vet.
+
+## Appendix C — Alternatives considered (review digest)
+
+Three proposals were generated and each was scored by a maintainer reviewer and an adversarial break-tester:
+
+- path-first-name-fallback
+- class-aware-name-or-path
+- shape-classified city name-or-path resolution with escape hatches
+
+The break-tester rejected/down-scored the path-first approaches for the walk-up footgun above; the synthesis adopts the shape-classify-then-route gate that eliminates it.

--- a/engdocs/contributors/design-gc-city-name-resolution.md
+++ b/engdocs/contributors/design-gc-city-name-resolution.md
@@ -8,7 +8,7 @@
 > **Critical insight from adversarial review (do not skip):**
 > All three proposals share a fatal flaw the break-testers exposed: they frame name resolution as run-the-path-resolver-first then fall-back-to-registry-on-error. But every existing path resolver ends in findCity(cwd/token), which WALKS UP the directory tree (verified in city_discovery.go:19-49: from inside any city, findCity returns the ambient ancestor city with err=nil). So a bare name run from inside a city resolves to the AMBIENT city, the path resolver succeeds, the name fallback never fires, and stop/suspend/reload/restart silently mis-target; under --json this reports ok:true for the wrong city. The fix is to classify by arg SHAPE up front and ROUTE accordingly: a name-shaped token that is NOT an existing directory in cwd must skip the path resolver entirely and go straight to Registry.LookupCityByName. This is the only synthesis that resolves every blocking issue. I drop proposal 3's --as-name/--as-path escape-hatch flags (YAGNI; the single ambiguous case is handled deterministically with a stderr breadcrumb).
 
-**Chosen approach:** 
+**Chosen approach:**
 Hybrid: shape-classify-then-route (proposal 3 shape gate) plus per-command class awareness so register opts out of name fallback (proposal 2), MINUS the escape-hatch flags. The decisive correction over all three: a name-shaped token that does not name an existing *city* directory is routed directly to the registry and NEVER passed to the walk-up path resolver, eliminating the silent ambient-city mis-target. A single shared resolver plus Registry.LookupCityByName and IsValidCityName; each command injects its existing path resolver as a closure used only for the path-shaped and city-dir-exists branches.
 
 ---

--- a/engdocs/contributors/design-gc-city-name-resolution.md
+++ b/engdocs/contributors/design-gc-city-name-resolution.md
@@ -1,9 +1,28 @@
 # Design: accept a bare city NAME (not just a path) across gc city-targeting commands
 
-- **Status:** Draft (proposal for review — not yet implemented)
+- **Status:** Implemented (shipped in PR #3625; the code and tests cited below are canonical where the draft prose disagrees)
 - **Issue:** ga-m3ev9r
 - **Follows:** PR #3623 (gc unregister fails loudly on unknown name/path)
 - **Produced by:** multi-agent design workflow (explore → 3 proposals → adversarial review → synthesis)
+
+> **Implementation note (shipped via PR #3625):** This design is implemented;
+> the shipped helper names differ from the draft prose below, and the code in
+> `cmd/gc/city_arg_resolve.go`, its tests in `cmd/gc/city_arg_resolve_test.go`,
+> and `internal/supervisor/registry.go` are canonical when they disagree with
+> this document. Draft → shipped renames: `classifyCityArg` →
+> `classifyCityRef`; `cityArgKind`/`cityArgEmpty`/`cityArgPath`/`cityArgName` →
+> `cityRefKind`/`cityRefEmpty`/`cityRefPath`/`cityRefName`; `cityArgOpts` →
+> `cityRefOpts`; `resolveCityArg` → `resolveCityRef`; `resolveCityContextArg` →
+> `resolveCityNameContext` (plus the path-returning `resolveCityNameRef` and the
+> shared fact-gatherer `lookupCityNameFacts`); `cityArgNotFoundErr` →
+> `cityRefNotFoundErr`. Per Decision 1, the single genuine ambiguity is a **loud
+> failure** (`cityRefAmbiguousErr`, and `cityRefRigVsRegisteredErr` when a local
+> rig directory shadows a different registered city), not the draft §3
+> "path-wins + breadcrumb". `resolveCityNameContext` also runs a rig-path probe
+> so a slashless local rig directory (e.g. `frontend`) resolves to its owning
+> city across the positional `stop`/`start`/`restart`/`reload`/`suspend`/
+> `resume`/`status` seams; the `--city <name>` flag is resolved by
+> `resolveCityFlagValue`.
 
 > **Critical insight from adversarial review (do not skip):**
 > All three proposals share a fatal flaw the break-testers exposed: they frame name resolution as run-the-path-resolver-first then fall-back-to-registry-on-error. But every existing path resolver ends in findCity(cwd/token), which WALKS UP the directory tree (verified in city_discovery.go:19-49: from inside any city, findCity returns the ambient ancestor city with err=nil). So a bare name run from inside a city resolves to the AMBIENT city, the path resolver succeeds, the name fallback never fires, and stop/suspend/reload/restart silently mis-target; under --json this reports ok:true for the wrong city. The fix is to classify by arg SHAPE up front and ROUTE accordingly: a name-shaped token that is NOT an existing directory in cwd must skip the path resolver entirely and go straight to Registry.LookupCityByName. This is the only synthesis that resolves every blocking issue. I drop proposal 3's --as-name/--as-path escape-hatch flags (YAGNI; the single ambiguous case is handled deterministically with a stderr breadcrumb).

--- a/engdocs/contributors/design-gc-city-name-resolution.md
+++ b/engdocs/contributors/design-gc-city-name-resolution.md
@@ -42,6 +42,14 @@ conflicting notes in §3, §5, and Appendix A below.
    direct `filepath.Abs(cityFlag)` (cmd_start.go ~571). Because these feed
    nearly every command, this is the highest-risk wiring and gets its own
    phase with dedicated precedence/regression tests.
+   **Refinement (precedence for GC_CITY):** the positional arg and `--city`
+   flag are explicit user input and use the loud-ambiguity policy of
+   decision 1. `GC_CITY` is ambient and deliberately set, so it uses
+   **path-first / local-wins**: a same-named local city directory wins over a
+   different registration silently (no loud ambiguity), matching the env's
+   "this is my working city" intent. Per-command `--city` flags that bypass
+   the central chain (e.g. `gc bd --city`) remain path-only and are tracked as
+   a separate follow-up.
 
 3. **`gc restart` resolves the reference once at the top** and threads the
    resolved **path** (never the raw name) into both the stop and start legs
@@ -134,7 +142,7 @@ Per-command (each *_test.go, isolated GC_HOME via t.Setenv plus supervisor.NewRe
 
 ## 10. Risks and open questions
 
-Two resolver families (family A reload/suspend/resume/status via resolveCommandCity vs bespoke stop/start/restart/unregister): mitigated by the single shared seam every entrypoint adopts; a grep checklist of all nine entrypoints is in the test plan. restart fan-out: cmdRestartJSON threads raw args into three legs; resolve once at the top and thread the PATH down (covered by TestRestartByName_SingleTargetAcrossLegs). Stale registry: LookupCityByName may return a path whose city.toml/.gc was deleted; name resolution returns only the path and downstream validation errors clearly referencing the resolved path so the user can gc unregister it (no worse than today). Symlink normalization: returned registry paths must flow through the same normalization the path branch uses; for unregister the resolved value re-enters registeredCityEntry then normalizeRegisteredCityPath (EvalSymlinks), verify in tests. EffectiveName snapshot vs live name: lookup matches the registered name not a post-registration rename (correct, gascity#602, documented). --city/GC_CITY gap: deferred; gc --city name stop still misses in v1, documented. Open questions: should register completion show names at all or files only (proposed hints); is --city name worth scheduling now or on demand.
+Two resolver families (family A reload/suspend/resume/status via resolveCommandCity vs bespoke stop/start/restart/unregister): mitigated by the single shared seam every entrypoint adopts; a grep checklist of all nine entrypoints is in the test plan. restart fan-out: cmdRestartJSON threads raw args into three legs; resolve once at the top and thread the PATH down (covered by TestRestartByName_SingleTargetAcrossLegs). Stale registry: LookupCityByName may return a path whose city.toml/.gc was deleted; name resolution returns only the path and downstream validation errors clearly referencing the resolved path so the user can gc unregister it (no worse than today). Symlink normalization: returned registry paths must flow through the same normalization the path branch uses; for unregister the resolved value re-enters registeredCityEntry then normalizeRegisteredCityPath (EvalSymlinks), verify in tests. EffectiveName snapshot vs live name: lookup matches the registered name not a post-registration rename (correct, gascity#602, documented). --city/GC_CITY: name support SHIPPED (the persistent --city flag and GC_CITY both accept a name; GC_CITY uses local-wins precedence per decision 2). Per-command --city flags that bypass the central chain (gc bd/import/analyze) remain path-only — tracked as a separate follow-up. Open questions: should register completion show names at all or files only (resolved: hints).
 
 ## 11. Phased implementation plan (each phase 5 files or fewer)
 

--- a/internal/supervisor/registry.go
+++ b/internal/supervisor/registry.go
@@ -190,6 +190,38 @@ func (r *Registry) Unregister(cityPath string) error {
 	return r.saveLocked(filtered)
 }
 
+// LookupCityByName finds a registered city by its effective name. Returns the
+// matching entry and true, or a zero entry and false if no registered city has
+// that name (or on a registry read error). The match is exact and
+// case-sensitive, mirroring the uniqueness Register enforces on names and the
+// LookupRigByName behavior; because Register rejects duplicate names, at most
+// one entry can match.
+func (r *Registry) LookupCityByName(name string) (CityEntry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entries, err := r.loadLocked()
+	if err != nil {
+		return CityEntry{}, false
+	}
+	for _, e := range entries {
+		if e.EffectiveName() == name {
+			return e, true
+		}
+	}
+	return CityEntry{}, false
+}
+
+// IsValidCityName reports whether s is shaped like a registered city name and
+// therefore can never denote a filesystem path: city names match validCityName
+// (a leading alphanumeric followed by alphanumerics, dots, underscores, and
+// hyphens), so they contain no path separators, leading dot, or tilde. CLI
+// callers use this to classify a city reference as a name vs a path before
+// resolving it. Surrounding whitespace is ignored.
+func IsValidCityName(s string) bool {
+	return validCityName.MatchString(strings.TrimSpace(s))
+}
+
 // StorePendingCityRequestID records a request_id for later supervisor
 // reconciliation. The entry is persisted in the supervisor registry so a
 // restarted supervisor can still emit the terminal async result event.

--- a/internal/supervisor/registry.go
+++ b/internal/supervisor/registry.go
@@ -195,21 +195,32 @@ func (r *Registry) Unregister(cityPath string) error {
 // that name (or on a registry read error). The match is exact and
 // case-sensitive, mirroring the uniqueness Register enforces on names and the
 // LookupRigByName behavior; because Register rejects duplicate names, at most
-// one entry can match.
+// one entry can match. Callers that must distinguish an unreadable registry
+// from a genuine miss should use LookupCityByNameE.
 func (r *Registry) LookupCityByName(name string) (CityEntry, bool) {
+	entry, ok, _ := r.LookupCityByNameE(name)
+	return entry, ok
+}
+
+// LookupCityByNameE is like LookupCityByName but also returns any registry read
+// error, so callers can surface a corrupt or unreadable registry instead of
+// silently collapsing it into a "not registered" miss. The bool is true only on
+// an exact, case-sensitive name match; on a read error it is false and the
+// error is non-nil.
+func (r *Registry) LookupCityByNameE(name string) (CityEntry, bool, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	entries, err := r.loadLocked()
 	if err != nil {
-		return CityEntry{}, false
+		return CityEntry{}, false, err
 	}
 	for _, e := range entries {
 		if e.EffectiveName() == name {
-			return e, true
+			return e, true, nil
 		}
 	}
-	return CityEntry{}, false
+	return CityEntry{}, false, nil
 }
 
 // IsValidCityName reports whether s is shaped like a registered city name and

--- a/internal/supervisor/registry_test.go
+++ b/internal/supervisor/registry_test.go
@@ -764,3 +764,80 @@ func TestPathHasPrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestLookupCityByName(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRegistry(filepath.Join(dir, "cities.toml"))
+
+	cityA := filepath.Join(dir, "alpha")
+	cityB := filepath.Join(dir, "beta")
+	for _, p := range []string{cityA, cityB} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := r.Register(cityA, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Register(cityB, "beta"); err != nil {
+		t.Fatal(err)
+	}
+
+	entry, ok := r.LookupCityByName("alpha")
+	if !ok {
+		t.Fatal("expected to find city by name 'alpha'")
+	}
+	testutil.AssertSamePath(t, entry.Path, cityA)
+	if entry.EffectiveName() != "alpha" {
+		t.Fatalf("entry name = %q, want alpha", entry.EffectiveName())
+	}
+
+	entry, ok = r.LookupCityByName("beta")
+	if !ok {
+		t.Fatal("expected to find city by name 'beta'")
+	}
+	testutil.AssertSamePath(t, entry.Path, cityB)
+
+	if _, ok := r.LookupCityByName("nonexistent"); ok {
+		t.Fatal("expected no match for nonexistent name")
+	}
+	// Match is exact and case-sensitive (mirrors Register dedup).
+	if _, ok := r.LookupCityByName("Alpha"); ok {
+		t.Fatal("expected case-sensitive lookup to miss 'Alpha'")
+	}
+}
+
+func TestLookupCityByNameEmptyRegistry(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRegistry(filepath.Join(dir, "cities.toml"))
+	if _, ok := r.LookupCityByName("anything"); ok {
+		t.Fatal("expected no match against an empty/missing registry")
+	}
+}
+
+func TestIsValidCityName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"chris-city", true},
+		{"a.b", true},
+		{"a_b", true},
+		{"1city", true},
+		{"  chris-city  ", true}, // surrounding whitespace ignored
+		{"a/b", false},           // names cannot contain a separator -> it's a path
+		{"./x", false},
+		{"../x", false},
+		{"~/x", false},
+		{"/abs", false},
+		{"", false},
+		{"has space", false},
+		{"-leading-dash", false}, // must start alphanumeric
+		{".leading-dot", false},
+	}
+	for _, tt := range tests {
+		if got := IsValidCityName(tt.in); got != tt.want {
+			t.Errorf("IsValidCityName(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/supervisor/registry_test.go
+++ b/internal/supervisor/registry_test.go
@@ -815,6 +815,26 @@ func TestLookupCityByNameEmptyRegistry(t *testing.T) {
 	}
 }
 
+func TestLookupCityByNameESurfacesLoadError(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "cities.toml")
+	// Corrupt registry: malformed TOML so loadLocked fails to parse it.
+	if err := os.WriteFile(regPath, []byte("[[city]\nname = \"broken\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := NewRegistry(regPath)
+
+	// The bool API collapses the read error into a plain miss.
+	if _, ok := r.LookupCityByName("broken"); ok {
+		t.Fatal("expected no match from a corrupt registry")
+	}
+	// The error-returning variant surfaces the underlying load failure so the
+	// caller can distinguish a corrupt registry from a genuine miss.
+	if _, ok, err := r.LookupCityByNameE("broken"); ok || err == nil {
+		t.Fatalf("LookupCityByNameE on corrupt registry = (ok=%v, err=%v), want (false, non-nil)", ok, err)
+	}
+}
+
 func TestIsValidCityName(t *testing.T) {
 	tests := []struct {
 		in   string


### PR DESCRIPTION
## What

`gc` city-targeting commands now accept a **registered city name** (as shown by `gc cities`) in addition to a path. `gc unregister chris-city`, `gc stop chris-city`, `gc reload prod`, `gc start --city prod`, `GC_CITY=prod gc status`, etc. all work — no more "I typed the name and nothing happened."

Applies to the **positional arg** of `unregister`, `stop`, `start`, `restart`, `reload`, `suspend`, `resume`, `status`, plus the persistent `--city` flag and `GC_CITY`. `register` stays path-only (you can't register *by* a name that doesn't exist yet) but gains name *hints* in completion. Shell completion (`completeCityNames`) is wired on all of them.

This is the follow-up to **#3623** (which made `gc unregister` *fail loudly* on an unknown name/path instead of silently reporting success). Design doc: `engdocs/contributors/design-gc-city-name-resolution.md`.

> **Note on base:** this branch is stacked on #3623, so until that merges this PR's diff includes its one commit (`de3735111`). Merge #3623 first and this reduces to the feature commits.

## How — shape-classify-then-route

The load-bearing constraint (verified against `findCity`): the existing path resolvers **walk *up*** the directory tree. So a naive "try path first, fall back to name" is unsafe — a bare name run from inside any city silently resolves to the **ambient ancestor city** (and `--json` reports `ok:true` for the wrong city). The adversarial design review caught this.

So the arg is classified by **shape** before any resolution (a registered name can't contain `/`, per `validCityName`):
- **path-shaped** (`/abs`, `./x`, `../x`, `~/x`, separator) → existing path resolver, byte-for-byte unchanged.
- **name-shaped + a local `cwd/<name>` city** → that local city (path wins); if it also matches a *different* registration → **loud ambiguity error**.
- **name-shaped + no local city** → `Registry.LookupCityByName` only — **never** the walk-up resolver.
- **neither** → loud not-found error (preserves #3623).

`restart` resolves the reference **once** and threads the resolved path into both the stop and start legs. `GC_CITY` uses path-first/local-wins precedence (documented — an ambient env var differs from explicit arg/flag input).

## Key files

- `internal/supervisor/registry.go`: `LookupCityByName` + `IsValidCityName` (mirror `LookupRigByName`).
- `cmd/gc/city_arg_resolve.go`: `classifyCityRef`, `resolveCityNameRef`, `resolveCityRef`, `resolveCityFlagValue` — the single shared seam; each command injects its own path resolver as a closure.
- `cmd/gc/main.go` (`resolveCommandContext`, `resolveContext`), `cmd/gc/city_context.go` (`GC_CITY`): central wiring covering reload/suspend/resume/status + `--city`.
- `cmd/gc/cmd_{register,stop,start,restart}.go`, `cmd/gc/completion.go`.

## Process

Built phase-by-phase (primitives → resolver → wiring), then ran a **30-agent adversarial review** (5 dimensions × verify): 8 confirmed of 25 findings (3 medium, 2 low, 3 nit; 17 refuted as intentional/pre-existing), all addressed in the final commit. The #1 review target — any path where a bare name still reaches a walk-up resolver — found none.

## Test plan

- Resolver matrix incl. the **from-inside-a-city walk-up guard** (`resolveCityRef`, `resolveCommandCity`, `resolveStopCityPath`).
- Central seams: `resolveCommandCity` by name (+ walk-up guard + unknown-name loud failure), `resolveCityFlagValue`, `GC_CITY` by name + local-wins + `GC_CITY_PATH` path-only.
- `restartTarget` single-resolution; `resolveStartDir` by name; `unregister` by name; completion prefix filtering.
- Backward-compat: path-shaped args unchanged (existing resolution/`RigAnywhere` tests stay green).
- Full local gate green per commit: `lint-changed` (0), `go vet ./...`, all fast shards (`test-local-parallel fast`), `check-docs`.

## Deferred

ga-xgfs92: per-command `--city` flags that bypass the central chain (`gc bd/import/analyze`) accepting a name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)