### PR TITLE
fix(reconciler): defer named-session drain on transient spec collapse

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1142,6 +1142,12 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		if _, _, pending := resetPendingCommittedAt(*session); !pending && dt != nil {
 			dt.clearResetStall(session.ID)
 		}
+		// #3630: the session is in the desired set this tick, so its spec is
+		// present — reset any suspend-drain confirmation window accrued during a
+		// transient spec-enumeration collapse.
+		if desired {
+			dt.clearSuspendDeferral(session.ID)
+		}
 
 		if reconcileDrainAckStopPending(cityPath, cfg, sp, store, rigStores, session, tp, desired, dops, dt, asyncStopTracker, clk, rec, stderr) {
 			continue
@@ -1193,6 +1199,12 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				}
 			}
 			preserveNamed := preserveConfiguredNamedSessionBead(*session, cfg, cityName)
+			// #3630: the configured spec is present this tick — reset any
+			// suspend-drain confirmation window so a later genuine removal still
+			// gets the full confirmation buffer.
+			if preserveNamed {
+				dt.clearSuspendDeferral(session.ID)
+			}
 			var (
 				preservedTP  TemplateParams
 				preserveErr  error
@@ -1390,6 +1402,34 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						}
 						fmt.Fprintf(stdout, "Skipping drain for '%s': live assigned work found\n", name) //nolint:errcheck
 						continue
+					}
+					// #3630: a LIVE named session reaches this drain only because
+					// its configured spec is absent this tick (preserve did not fire
+					// above) and it has no live assigned work. A namedSessionSpecs
+					// enumeration collapse during boot can drop a spec for a single
+					// tick and restore it on the next; draining the live runtime
+					// respawns it fresh and loses in-session context. Suspend-class
+					// drains are revertible, so require namedSuspendConfirmTicks
+					// consecutive confirming ticks before draining. The counter is
+					// cleared above once the spec reappears. Scoped to live sessions:
+					// a dead bead with no spec still releases its alias immediately
+					// (ga-ue1r).
+					if isNamedSessionBead(*session) {
+						if n := dt.bumpSuspendDeferral(session.ID); n < namedSuspendConfirmTicks {
+							if trace != nil {
+								template := normalizedSessionTemplate(*session, cfg)
+								if template == "" {
+									template = session.Metadata["template"]
+								}
+								trace.recordDecision("reconciler.session.orphan_or_suspended", template, name, reason, "deferred_confirm", traceRecordPayload{
+									"confirm_ticks":    n,
+									"confirm_required": namedSuspendConfirmTicks,
+									"provider_alive":   providerAlive,
+								}, nil, "")
+							}
+							fmt.Fprintf(stdout, "Deferring drain for named session '%s': awaiting spec-absence confirmation (%d/%d) — transient enumeration-collapse guard (#3630)\n", name, n, namedSuspendConfirmTicks) //nolint:errcheck
+							continue
+						}
 					}
 					if beginSessionDrain(*session, sp, dt, reason, clk, defaultDrainTimeout) {
 						if trace != nil {

--- a/cmd/gc/session_reconciler_named_collapse_test.go
+++ b/cmd/gc/session_reconciler_named_collapse_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestReconcileSessionBeads_NamedSessionTransientSpecCollapseDeferred covers
+// issue #3630: a namedSessionSpecs enumeration collapse during boot can drop a
+// configured named session's spec for a single reconciler tick, after which it
+// reappears. A running named session whose spec is merely transiently absent
+// must NOT be suspend-drained on that first tick (the drain causes a fresh
+// respawn that loses in-session context). The drain is deferred until
+// namedSuspendConfirmTicks consecutive ticks confirm the spec is genuinely
+// gone; suspend-class drains are revertible, so a 1-tick confirmation buffer is
+// safe and cheap.
+func TestReconcileSessionBeads_NamedSessionTransientSpecCollapseDeferred(t *testing.T) {
+	env := newReconcilerTestEnv()
+	// cfg has the agent template but NO [[named_session]] entry this tick —
+	// modeling the transient collapse where the named spec briefly vanishes.
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{{Name: "warlord", StartCommand: "true"}},
+	}
+	sessionName := "warlord"
+	_ = env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true"})
+	session := env.createSessionBead(sessionName, "warlord")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "warlord",
+		namedSessionModeMetadata:     "always",
+		"state":                      "active",
+		"last_woke_at":               env.clk.Now().UTC().Format(time.RFC3339),
+	})
+
+	// Tick 1 (collapse tick): spec absent for the first time → defer, do not drain.
+	env.reconcile([]beads.Bead{session})
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("named session must not be drained on the first spec-absent tick (transient collapse #3630), got drain reason=%q", ds.reason)
+	}
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatalf("named session %q must stay running through a single-tick spec collapse", sessionName)
+	}
+
+	// Tick 2 (still absent): now confirmed across N consecutive ticks → drain proceeds.
+	env.reconcile([]beads.Bead{session})
+	if ds := env.dt.get(session.ID); ds == nil {
+		t.Fatal("named session should be drained after namedSuspendConfirmTicks consecutive spec-absent ticks")
+	}
+}
+
+// TestReconcileSessionBeads_NamedSessionSpecReappearsClearsDeferral covers the
+// recovery half of issue #3630: when the spec reappears after a collapse tick,
+// the confirmation counter resets so a LATER genuine removal still gets a full
+// confirmation window rather than draining on its first tick.
+func TestReconcileSessionBeads_NamedSessionSpecReappearsClearsDeferral(t *testing.T) {
+	env := newReconcilerTestEnv()
+	sessionName := config.NamedSessionRuntimeName("test-city", config.Workspace{Name: "test-city"}, "warlord")
+	withSpec := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "warlord", StartCommand: "true"}},
+		NamedSessions: []config.NamedSession{{Template: "warlord", Mode: "always"}},
+	}
+	withoutSpec := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{{Name: "warlord", StartCommand: "true"}},
+	}
+
+	_ = env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true"})
+	session := env.createSessionBead(sessionName, "warlord")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "warlord",
+		namedSessionModeMetadata:     "always",
+		"state":                      "active",
+		"last_woke_at":               env.clk.Now().UTC().Format(time.RFC3339),
+	})
+
+	// Tick 1: collapse — spec absent → defer (counter = 1).
+	env.cfg = withoutSpec
+	env.reconcile([]beads.Bead{session})
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("must defer on first spec-absent tick, got drain reason=%q", ds.reason)
+	}
+
+	// Tick 2: spec reappears → preserved, counter must reset.
+	env.cfg = withSpec
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "warlord",
+		ConfiguredNamedIdentity: "warlord",
+		ConfiguredNamedMode:     "always",
+	}
+	env.reconcile([]beads.Bead{session})
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("named session with present spec must not drain, got reason=%q", ds.reason)
+	}
+
+	// Tick 3: collapse again — because the counter reset, this is the first
+	// confirming tick of a fresh window, so it must defer (not drain).
+	env.cfg = withoutSpec
+	delete(env.desiredState, sessionName)
+	env.reconcile([]beads.Bead{session})
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("confirmation window must reset after the spec reappears, got drain reason=%q on the first absent tick of a new collapse", ds.reason)
+	}
+}

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -72,18 +72,20 @@ type idleProbeState struct {
 
 // drainTracker manages in-memory drain states for all sessions.
 type drainTracker struct {
-	mu              sync.Mutex
-	drains          map[string]*drainState     // session bead ID -> drain state
-	idleProbes      map[string]*idleProbeState // session bead ID -> async idle probe
-	resetStalls     map[string]bool            // session bead ID -> reset stall event emitted
-	idleProbeCursor int
+	mu               sync.Mutex
+	drains           map[string]*drainState     // session bead ID -> drain state
+	idleProbes       map[string]*idleProbeState // session bead ID -> async idle probe
+	resetStalls      map[string]bool            // session bead ID -> reset stall event emitted
+	suspendDeferrals map[string]int             // session bead ID -> consecutive ticks a named session has been suspend-drain-eligible with its spec absent (#3630)
+	idleProbeCursor  int
 }
 
 func newDrainTracker() *drainTracker {
 	return &drainTracker{
-		drains:      make(map[string]*drainState),
-		idleProbes:  make(map[string]*idleProbeState),
-		resetStalls: make(map[string]bool),
+		drains:           make(map[string]*drainState),
+		idleProbes:       make(map[string]*idleProbeState),
+		resetStalls:      make(map[string]bool),
+		suspendDeferrals: make(map[string]int),
 	}
 }
 
@@ -103,6 +105,38 @@ func (dt *drainTracker) remove(beadID string) {
 	dt.mu.Lock()
 	defer dt.mu.Unlock()
 	delete(dt.drains, beadID)
+	delete(dt.suspendDeferrals, beadID)
+}
+
+// bumpSuspendDeferral increments and returns the consecutive-tick count for a
+// named session that is suspend-drain-eligible because its configured spec is
+// absent this tick. The reconciler requires namedSuspendConfirmTicks confirming
+// ticks before actually draining, so a transient namedSessionSpecs enumeration
+// collapse during boot (the spec vanishes for one tick and reappears) does not
+// spuriously drain a named session and lose its in-session context (#3630).
+func (dt *drainTracker) bumpSuspendDeferral(beadID string) int {
+	if dt == nil {
+		return 0
+	}
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	if dt.suspendDeferrals == nil {
+		dt.suspendDeferrals = make(map[string]int)
+	}
+	dt.suspendDeferrals[beadID]++
+	return dt.suspendDeferrals[beadID]
+}
+
+// clearSuspendDeferral resets the deferral counter once a named session's spec
+// is present again (preserved or desired), so a later genuine removal starts a
+// fresh confirmation window rather than draining on its first absent tick.
+func (dt *drainTracker) clearSuspendDeferral(beadID string) {
+	if dt == nil {
+		return
+	}
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	delete(dt.suspendDeferrals, beadID)
 }
 
 func (dt *drainTracker) all() map[string]*drainState {
@@ -226,6 +260,15 @@ const (
 	// survives before being killed. Prevents killing sessions that are
 	// slow to register their beads.
 	orphanGraceTicks = 3
+
+	// namedSuspendConfirmTicks is how many consecutive reconciler ticks a
+	// named session must be observed as suspend-drain-eligible (its configured
+	// spec absent from the desired set) before it is actually drained. A
+	// namedSessionSpecs enumeration collapse during boot can drop a spec for a
+	// single tick and restore it on the next; suspend-class drains are
+	// revertible, so a 1-tick confirmation buffer is safe and cheap and
+	// prevents spurious context-losing respawns (#3630).
+	namedSuspendConfirmTicks = 2
 
 	// defaultDrainTimeout is the default time allowed for graceful drain
 	// before force-stopping a session.


### PR DESCRIPTION
A namedSessionSpecs enumeration collapse during boot can drop a
configured named session's spec for a single reconciler tick (e.g.
11 specs -> 3, recovering on the next tick). The reconciler treated
the shrunk set as authoritative and suspend-drained any live named
session whose spec vanished, respawning it fresh and losing
in-session context.

Suspend-class drains are revertible (the spec reappears next tick),
so require two consecutive confirming ticks before draining a live
named session whose spec is absent. The confirmation counter lives
on drainTracker and resets the moment the spec reappears (preserved
or desired), so a later genuine config removal still drains. Scoped
to live sessions: a dead bead with no spec still releases its alias
immediately.

Closes #3630.
