### PR TITLE
chore(hooks): run heavy go test at push, not on every commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -33,7 +33,11 @@ if [ -n "$staged_go_files" ]; then
   git add docs/reference/schema/city-schema.json docs/reference/schema/city-schema.txt docs/reference/config.md docs/reference/cli.md
 
   make vet
-  make test-fast-parallel
+  # Heavy `go test` fan-out runs in .githooks/pre-push, not here (#3628).
+  # Invoking `make test-fast-parallel` on every commit fired an
+  # `xargs -P<nproc>` storm of ~2.8 GB test-binary compiles (~17 GB pressure,
+  # load >100 on constrained hosts such as WSL). Format, lint, vet, and codegen
+  # stay in pre-commit; the test suite gates at push time instead.
 fi
 
 if [ -n "$staged_docs" ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Heavy `go test` fan-out runs here, at push time, instead of on every commit
+# (#3628). pre-commit was invoking `make test-fast-parallel`, whose
+# `xargs -P<nproc>` runner compiles ~2.8 GB test binaries per shard — on an
+# N-core host that is N concurrent compiles (~17 GB pressure, load >100,
+# I/O/compile storms and occasional livelocks on WSL) on EVERY commit.
+# GOFLAGS=-p=2 bounds build parallelism within one `go test` but not the outer
+# fan-out. Running the suite at push time fires it far less often, and only when
+# Go sources actually change.
+#
+# git feeds "<local ref> <local sha> <remote ref> <remote sha>" per pushed ref
+# on stdin (see githooks(5)).
+
+zero="0000000000000000000000000000000000000000"
+
+go_changed=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  # Branch deletion — nothing to test.
+  if [ "$local_sha" = "$zero" ]; then
+    continue
+  fi
+  # New remote branch: no cheap base to diff against — run the suite.
+  if [ "$remote_sha" = "$zero" ]; then
+    go_changed=1
+    continue
+  fi
+  if git diff --name-only "$remote_sha" "$local_sha" -- '*.go' 2>/dev/null | grep -q .; then
+    go_changed=1
+  fi
+done
+
+if [ "$go_changed" -eq 0 ]; then
+  exit 0
+fi
+
+# Bound the local fan-out by default so the suite stays friendly on developer
+# machines; an explicit LOCAL_TEST_JOBS (and CI's Makefile default) still wins.
+export LOCAL_TEST_JOBS="${LOCAL_TEST_JOBS:-3}"
+exec make test-fast-parallel

--- a/scripts/test-local-parallel
+++ b/scripts/test-local-parallel
@@ -161,6 +161,20 @@ export TEST_LOCAL_GOMODCACHE="$gomodcache_val"
 export TEST_LOCAL_GOTMPDIR="$gotmpdir_val"
 export TEST_LOCAL_GOROOT="${GOROOT:-$goroot_val}"
 
+# Lower each shard's CPU and I/O priority (best-effort) so the parallel fan-out
+# yields to interactive work and does not livelock constrained hosts during the
+# heavy test-binary compiles (#3628). Both tools are optional: ionice is
+# Linux-only and nice may be absent in minimal images, so each is added only
+# when present and the runner works unchanged without them.
+nice_prefix=""
+if command -v nice >/dev/null 2>&1; then
+  nice_prefix="nice -n 10"
+fi
+if command -v ionice >/dev/null 2>&1; then
+  nice_prefix="ionice -c 3 ${nice_prefix}"
+fi
+export TEST_LOCAL_NICE="$nice_prefix"
+
 echo "Running ${#jobspecs[@]} ${mode} job(s) with LOCAL_TEST_JOBS=${local_jobs}"
 
 set +e
@@ -173,7 +187,7 @@ printf '%s\0' "${jobspecs[@]}" | xargs -0 -n1 -P "$local_jobs" bash -c '
   log="$LOCAL_TEST_LOG_DIR/${safe_label}.log"
 
   echo "[$label] start"
-  if env -i \
+  if ${TEST_LOCAL_NICE:-} env -i \
     PATH="${PATH}" \
     HOME="${HOME:-}" \
     USER="${USER:-}" \


### PR DESCRIPTION
`.githooks/pre-commit` invoked `make test-fast-parallel` on every commit,
whose `scripts/test-local-parallel` runner fans out heavy `go test` shards
with `xargs -P<nproc>`. Each shard compiles a ~2.8 GB test binary, so on an
N-core host that is N concurrent compiles — ~17 GB memory pressure and load
well above 100 on constrained hosts (notably WSL), producing I/O / compile
storms and occasional livelocks on every commit. `GOFLAGS=-p=2` bounds build
parallelism within a single `go test` but not the outer fan-out.

- Move the heavy suite out of pre-commit into a new `.githooks/pre-push`,
  gated on Go-file changes in the push range. pre-commit keeps the fast
  format / lint / vet / codegen gates; the test suite runs at push time.
- Default `LOCAL_TEST_JOBS` to 3 in the pre-push hook to bound the local
  fan-out (an explicit value and CI's Makefile default still win).
- `nice`/`ionice` each shard (best-effort, both optional) so the fan-out
  yields CPU/I/O priority to interactive work.

Closes #3628.
