### PR TITLE
fix(session): sync bead to asleep on gc session kill (#3629)

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -2224,6 +2224,20 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 		fmt.Fprintf(stderr, "gc session kill: warning: session %s runtime was already inactive; cleared named-session circuit breaker\n", sessionID) //nolint:errcheck // best-effort stderr
 	}
 
+	// Sync the bead to asleep so a later `gc session wake` / reconcile starts
+	// a fresh runtime instead of short-circuiting on the stale live state the
+	// kill leaves behind (#3629). Written here at the CLI layer rather than in
+	// Manager.Kill so the drain-ack async-stop path (verifiedStop ->
+	// handle.Kill -> Manager.Kill) keeps owning its own lifecycle state.
+	if beadErr == nil {
+		now := time.Now().UTC()
+		patch := session.SleepPatch(now, "killed")
+		patch["synced_at"] = now.Format(time.RFC3339)
+		if err := store.SetMetadataBatch(sessionID, patch); err != nil {
+			fmt.Fprintf(stderr, "gc session kill: warning: syncing session %s to asleep: %v\n", sessionID, err) //nolint:errcheck // best-effort stderr
+		}
+	}
+
 	// Use the resolved session ID as the canonical Subject for event
 	// consumers. This ensures a stable key regardless of how the user
 	// specified the target (session ID or alias).

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -219,6 +219,92 @@ func TestCmdSessionKill_ClearsCircuitBreaker(t *testing.T) {
 	}
 }
 
+// TestCmdSessionKill_SyncsBeadToAsleep is the regression guard for #3629:
+// `gc session kill` must sync the bead to asleep + refresh synced_at at the
+// CLI layer (cmdSessionKill), otherwise the bead retains its prior live state
+// ("awake") and a later `gc session wake` short-circuits on the stale
+// metadata and never starts a fresh runtime. The write lives in cmdSessionKill
+// (not Manager.Kill) so the drain-ack async-stop path is unaffected.
+func TestCmdSessionKill_SyncsBeadToAsleep(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-session-kill-asleep-")
+	t.Setenv("GC_CITY", cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	fakeProvider := runtime.NewFake()
+	oldBuild := buildSessionProviderByName
+	buildSessionProviderByName = func(string, config.SessionConfig, string, string) (runtime.Provider, error) {
+		return fakeProvider, nil
+	}
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	const identity = "session-a"
+	const sessionName = "s-gc-kill-asleep-test"
+	bead, err := store.Create(beads.Bead{
+		Title:  "named session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "template:worker"},
+		Metadata: map[string]string{
+			"alias":                      identity,
+			"template":                   "worker",
+			"session_name":               sessionName,
+			"state":                      "awake",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+	if err := fakeProvider.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("fakeProvider.Start: %v", err)
+	}
+	if err := fakeProvider.SetMeta(sessionName, "GC_SESSION_ID", bead.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	lis, err := startControllerSocket(
+		cityDir,
+		func() {},
+		nil,
+		nil,
+		make(chan reloadRequest),
+		make(chan convergenceRequest, 1),
+		make(chan struct{}, 1),
+		make(chan struct{}, 1),
+	)
+	if err != nil {
+		t.Fatalf("startControllerSocket: %v", err)
+	}
+	defer lis.Close()                              //nolint:errcheck
+	defer os.Remove(controllerSocketPath(cityDir)) //nolint:errcheck
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionKill([]string{identity}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionKill = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	updated, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(session bead): %v", err)
+	}
+	if got := updated.Metadata["state"]; got != string(session.StateAsleep) {
+		t.Errorf("post-kill state = %q, want %q", got, session.StateAsleep)
+	}
+	if got := updated.Metadata["synced_at"]; got == "" {
+		t.Error("post-kill synced_at is empty, want a refreshed timestamp")
+	}
+}
+
 func TestCmdSessionKill_ClearsCircuitBreakerForAsleepNamedSession(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")


### PR DESCRIPTION
`gc session kill` terminated the runtime but left the session bead's
metadata.state at its prior live value (e.g. "awake") and never stamped
synced_at, so a later `gc session wake` short-circuited on the stale
state and started no fresh runtime.

Sync the bead to asleep + refresh synced_at in cmdSessionKill, after
handle.Kill succeeds. The write lives at the CLI layer rather than in
Manager.Kill: Manager.Kill is also reached by the drain-ack async-stop
path (verifiedStop -> handle.Kill -> Manager.Kill), which owns its own
lifecycle state; writing there would re-wake sessions after an
agent-acknowledged drain.

Closes #3629.
