### PR TITLE
docs(contributing): warn make install writes shared GOPATH/bin (#3636)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,17 @@ Run `make help` for the full list. The most useful targets are:
 | `make dashboard-check` | Typecheck + build + test the dashboard |
 | `make cover` | Coverage run |
 
+> **`make install` writes to the shared `$(go env GOPATH)/bin`.** It (and
+> `go install ./cmd/gc`) install `gc` there, and `make install` also re-points
+> an existing `~/.local/bin/gc` at the result — so when that path is the binary
+> a running deployment uses (commonly `~/.local/bin/gc` → `~/go/bin/gc`),
+> installing from any checkout silently replaces the live `gc`, and every later
+> `gc` exec runs the just-installed build. To redirect when that isn't
+> intended, run `make install INSTALL_DIR=<dir>` (the `install` target writes
+> `$(go env GOPATH)/bin` and ignores `GOBIN`), or for a plain
+> `go install ./cmd/gc` set `GOBIN=<dir>`. `make build` (→ `./bin/gc`) is
+> unaffected.
+
 ## macOS Local Development
 
 On macOS, `make build` signs `gc` with a stable local codesigning identity


### PR DESCRIPTION
`make install` and `go install ./cmd/gc` write to the shared
`$(go env GOPATH)/bin`, and `make install` re-points `~/.local/bin/gc`
at the result. When that path is the binary a running deployment uses,
installing from any checkout silently replaces the live `gc`, and every
later exec runs the just-installed build. Document the footgun and the
`GOBIN=<dir>` redirect next to the Make Targets table.

The opt-in install-target guard suggested in the issue (warn/refuse when
INSTALL_DIR/gc resolves to the running binary) is left as a follow-up.

Closes #3636.
