### PR TITLE
fix(nudge): queue wait-idle nudge to busy session, not 30s block

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -40,8 +40,7 @@ const (
 	defaultNudgePollQuiescence      = 3 * time.Second
 	// A controller wake can legitimately take a couple of minutes when the
 	// session has to rematerialize a worktree and complete startup dialog.
-	defaultNudgePollStartGrace  = 5 * time.Minute
-	defaultNudgeWaitIdleTimeout = 30 * time.Second
+	defaultNudgePollStartGrace = 5 * time.Minute
 )
 
 var errNudgeSessionFenceMismatch = errors.New("queued nudge session fence mismatch")
@@ -615,6 +614,28 @@ func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp run
 	if queueManagedWake {
 		return queueManagedSessionNudgeWake(target, store, message, mode, jsonOutput, stdout, stderr)
 	}
+	// A wait-idle nudge to a RUNNING-but-busy target must not block the caller in
+	// the worker's synchronous WaitForIdle (runtimeHandleWaitIdleTimeout, 30s):
+	// the session never reports idle for the whole window, so the caller stalls
+	// ~30s while the city store's Dolt connection sits idle in scope and gets
+	// reaped server-side ("[mysql] unexpected EOF"). Detect "busy" without
+	// blocking (LastActivity, the same quiescence signal the nudge poller uses)
+	// and queue immediately instead — the supervisor dispatcher (or the
+	// per-session poller in legacy mode) delivers at the next idle boundary, off
+	// the caller's critical path. An idle target still delivers live below (its
+	// WaitForIdle returns promptly); an unknown LastActivity is treated as
+	// not-busy so untracked sessions keep the existing behavior.
+	//
+	// Restrict this to the claude, non-ACP transport — the ONLY case
+	// RuntimeHandle.nudgeWaitIdle actually blocks on WaitForIdle. ACP delivers
+	// live in-process and non-claude returns immediately (see
+	// internal/worker/runtime_handle.go nudgeWaitIdle), so short-circuiting
+	// those would needlessly downgrade live delivery to queued. (gco-90ui)
+	if mode == nudgeDeliveryWaitIdle && target.sessionTransport() != "acp" && target.providerName() == "claude" {
+		if obs, obsErr := nudgeObserveTarget(target, store, sp); obsErr == nil && obs.Running && nudgeObservationBusy(obs) {
+			return queueSessionNudgeWithWorker(target, store, sp, message, mode, jsonOutput, stdout, stderr)
+		}
+	}
 	delivery, ok := workerNudgeDeliveryForMode(mode)
 	if !ok {
 		fmt.Fprintf(stderr, "gc session nudge: unknown delivery mode %q\n", mode) //nolint:errcheck
@@ -671,6 +692,25 @@ func shouldQueueManagedNudgeWake(target nudgeTarget, store beads.Store, sp runti
 		return false, fmt.Errorf("observing managed session before wake routing: %w", err)
 	}
 	return !obs.Running, nil
+}
+
+// nudgeObservationBusy reports, WITHOUT blocking, whether the observed session
+// is actively busy right now. It uses the LastActivity timestamp — the same
+// quiescence signal the nudge poller relies on (defaultNudgePollQuiescence). An
+// unknown (nil/zero) LastActivity returns false (treat as not-busy) so callers
+// fall back to the existing wait-idle path rather than queue a session whose
+// activity cannot be observed.
+//
+// This is the near-inverse of pollerSessionIdleEnough's LastActivity branch
+// (idle when time-since >= quiescence); they intentionally differ on the
+// unknown-LastActivity case — the poller falls back to a blocking WaitForIdle,
+// whereas this non-blocking caller-side check must not, so it defaults to
+// not-busy.
+func nudgeObservationBusy(obs worker.LiveObservation) bool {
+	if obs.LastActivity == nil || obs.LastActivity.IsZero() {
+		return false
+	}
+	return time.Since(*obs.LastActivity) < defaultNudgePollQuiescence
 }
 
 func canRequestManagedNudgeWake(target nudgeTarget, store beads.Store) bool {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -4689,3 +4689,96 @@ func TestRecordQueuedNudgeFailureDetailedClosesOnlyOwnedStore(t *testing.T) {
 		t.Fatalf("caller-owned store closed %d times, want 0 (helper must not close a passed-in store)", passedCloses)
 	}
 }
+
+func TestNudgeObservationBusy(t *testing.T) {
+	now := time.Now()
+	recent := now.Add(-1 * time.Second)
+	stale := now.Add(-1 * time.Hour)
+	var zero time.Time
+
+	tests := []struct {
+		name string
+		obs  worker.LiveObservation
+		want bool
+	}{
+		{"nil LastActivity is not busy", worker.LiveObservation{Running: true}, false},
+		{"zero LastActivity is not busy", worker.LiveObservation{Running: true, LastActivity: &zero}, false},
+		{"activity within quiescence is busy", worker.LiveObservation{Running: true, LastActivity: &recent}, true},
+		{"activity past quiescence is not busy", worker.LiveObservation{Running: true, LastActivity: &stale}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nudgeObservationBusy(tc.obs); got != tc.want {
+				t.Fatalf("nudgeObservationBusy(%+v) = %v, want %v", tc.obs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeliverSessionNudgeWaitIdleBusyTargetQueuesWithoutBlocking(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "sess-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	fake.SetActivity("sess-worker", time.Now()) // busy: activity within quiescence
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "worker"},
+		resolved:    &config.ResolvedProvider{Name: "claude"},
+		sessionName: "sess-worker",
+	}
+
+	prev := startNudgePoller
+	startNudgePoller = func(string, string, string) error { return nil }
+	t.Cleanup(func() { startNudgePoller = prev })
+
+	var stdout, stderr bytes.Buffer
+	code := deliverSessionNudgeWithProvider(target, fake, nudgeDeliveryWaitIdle, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("deliver = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Queued nudge for worker") {
+		t.Fatalf("stdout = %q, want queued (busy claude target short-circuits)", stdout.String())
+	}
+	for _, call := range fake.Calls {
+		if call.Method == "WaitForIdle" {
+			t.Fatalf("busy target must not block in WaitForIdle; calls = %#v", fake.Calls)
+		}
+	}
+}
+
+func TestDeliverSessionNudgeWaitIdleIdleTargetNotShortCircuited(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "sess-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	fake.SetActivity("sess-worker", time.Now().Add(-time.Hour)) // idle: activity past quiescence
+	fake.WaitForIdleErrors["sess-worker"] = nil
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "worker"},
+		resolved:    &config.ResolvedProvider{Name: "claude"},
+		sessionName: "sess-worker",
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := deliverSessionNudgeWithProvider(target, fake, nudgeDeliveryWaitIdle, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("deliver = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	sawWait := false
+	for _, call := range fake.Calls {
+		if call.Method == "WaitForIdle" {
+			sawWait = true
+		}
+	}
+	if !sawWait {
+		t.Fatalf("idle target should consult WaitForIdle (not short-circuited); calls = %#v", fake.Calls)
+	}
+}


### PR DESCRIPTION
gc session nudge defaults to wait-idle. For a running but busy target,
deliverSessionNudgeWithWorker called handle.Nudge, which blocks the caller
in the worker's synchronous WaitForIdle (30s, runtimeHandleWaitIdleTimeout)
until the session next goes idle. A session that stays busy the whole
window made the caller stall ~35s, and the city store's Dolt connection,
held idle in scope across the wait, was reaped server-side ("[mysql]
unexpected EOF").

Detect a busy target without blocking, from the LiveObservation
LastActivity timestamp (the same quiescence signal the nudge poller uses),
and queue the nudge immediately instead. The supervisor dispatcher (or the
per-session poller in legacy mode) delivers it at the next idle boundary,
off the caller's critical path. Idle and asleep targets are unchanged; an
unknown LastActivity falls back to the existing wait-idle path.

Removes the unused defaultNudgeWaitIdleTimeout constant (the live timeout
is runtimeHandleWaitIdleTimeout in internal/worker).

Closes #3637.
