### PR TITLE
Deflake session and clean-install tutorial tests

### DIFF
--- a/release-gates/ga-q32h2b-test-deflakes-gate.md
+++ b/release-gates/ga-q32h2b-test-deflakes-gate.md
@@ -1,0 +1,44 @@
+# Release Gate: ga-q32h2b test deflakes
+
+Outcome: PASS
+
+- Deploy bead: ga-q32h2b
+- Source review bead: ga-r4jmdq
+- Branch under evaluation: builder/ga-q32h2b-test-deflakes-clean
+- Local deploy branch: deploy/ga-q32h2b-test-deflakes-clean
+- Base: origin/main @ 2d90faf433c5ad1b28edc51f2ba80aa066d9027a
+- Reviewed source commit: ed544a1f7
+- Clean branch commit: 16d3453bdc00cc5c5b0565d6044875955bc7abc2
+- Release criteria source: deployer gate instructions. `docs/PROJECT_MANIFEST.md` was not present in this checkout.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead ga-r4jmdq is closed with close reason `pass` and notes contain `REVIEWER VERDICT: PASS`. Deploy bead ga-q32h2b notes record the clean rebuilt branch as ready for deploy gate. |
+| 2 | Acceptance criteria met | PASS | C2 changes `TestCleanInstallTutorialPath` to use `tutorial-rig-alpha`, whose derived prefix is `tra`, avoiding the prior 2-character random-city prefix collision. C3 adds a 30s `WaitForCondition` before `TestSessionDefaultNamedSession` subtests so the asynchronously created default `mayor` session is visible before assertions run. Diff is limited to `test/acceptance/session_test.go` and `test/integration/tutorial_path_test.go`. |
+| 3 | Tests pass | PASS | See verification commands below. Focused acceptance, focused integration, fast unit shards, vet, build, and diff whitespace checks all passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for ga-r4jmdq report PASS, test-only scope, no production code, no security concerns, and no unresolved HIGH findings. Deploy bead notes contain no HIGH/CRITICAL open finding. |
+| 5 | Final branch is clean | PASS | `git status --porcelain=v1` was empty before writing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` passed before the gate commit; the clean branch is a direct descendant of `origin/main` with no merge conflict state. |
+| 7 | Single feature theme | PASS | The commit set has one test-reliability theme: deflaking two existing tests identified by the same investigator pass. It touches only test files and no unrelated subsystem or user-facing behavior. |
+
+## Verification Commands
+
+| Command | Result |
+|---------|--------|
+| `go test -tags acceptance_a -run TestSessionDefaultNamedSession -count=1 -v ./test/acceptance` | PASS: `ok github.com/gastownhall/gascity/test/acceptance 14.504s` |
+| `go test -tags integration -run TestCleanInstallTutorialPath -count=1 -v ./test/integration` | PASS: `ok github.com/gastownhall/gascity/test/integration 34.126s`; cleanup noted supervisor was already stopped. |
+| `make test-fast-parallel` | PASS: all fast jobs passed. |
+| `go vet ./...` | PASS |
+| `go build ./cmd/gc/` | PASS |
+| `git diff --check origin/main...HEAD` | PASS |
+
+## Scope Check
+
+`git diff --name-only origin/main...HEAD`:
+
+```text
+test/acceptance/session_test.go
+test/integration/tutorial_path_test.go
+```

--- a/test/acceptance/session_test.go
+++ b/test/acceptance/session_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
@@ -96,6 +97,17 @@ func TestSessionErrors(t *testing.T) {
 func TestSessionDefaultNamedSession(t *testing.T) {
 	c := helpers.NewCity(t, testEnv)
 	c.Init("claude")
+
+	// The default named session (mayor) is created asynchronously by the
+	// reconciler. Poll until it appears before running subtests to avoid a
+	// race on slow or CPU-saturated runners.
+	if !c.WaitForCondition(func() bool {
+		out, err := c.GC("session", "list")
+		return err == nil && strings.Contains(out, "mayor")
+	}, 30*time.Second) {
+		out, _ := c.GC("session", "list")
+		t.Fatalf("timed out waiting for default named session (mayor) to appear:\n%s", out)
+	}
 
 	t.Run("List_DefaultNamedSession", func(t *testing.T) {
 		out, err := c.GC("session", "list")

--- a/test/integration/tutorial_path_test.go
+++ b/test/integration/tutorial_path_test.go
@@ -58,8 +58,10 @@ func TestCleanInstallTutorialPath(t *testing.T) {
 		runGCDoltWithEnv(env, "", "supervisor", "stop", "--wait") //nolint:errcheck // best-effort cleanup
 	})
 
-	// --- Step 2: gc rig add (simulate `gc rig add ~/my-project`) ---
-	rigName := "my-project"
+	// --- Step 2: gc rig add (simulate `gc rig add ~/tutorial-rig-alpha`) ---
+	// Three-part name so DeriveBeadsPrefix produces a 3-char prefix ("tra") that
+	// can never equal the 2-char prefix derived from the random city name.
+	rigName := "tutorial-rig-alpha"
 	rigDir := filepath.Join(t.TempDir(), rigName)
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatalf("creating rig dir: %v", err)
@@ -69,7 +71,7 @@ func TestCleanInstallTutorialPath(t *testing.T) {
 		t.Fatalf("gc rig add failed: %v\noutput: %s", err, out)
 	}
 
-	wantPrefix := config.DeriveBeadsPrefix(rigName) // "mp"
+	wantPrefix := config.DeriveBeadsPrefix(rigName) // "tra"
 
 	// --- Assertion 1: bd config get issue_prefix returns the derived prefix ---
 	// Regression: rig Dolt DB was never seeded so this returned "" before the fix.


### PR DESCRIPTION
## What this changes

This makes two existing flaky tests deterministic without changing production behavior. `TestCleanInstallTutorialPath` now uses `tutorial-rig-alpha`, whose derived beads prefix is `tra`, so it cannot collide with the two-character prefix from the random city name. `TestSessionDefaultNamedSession` now waits for the asynchronously created default `mayor` session before asserting session list output.

## Review notes

- Test-only change in `test/acceptance/session_test.go` and `test/integration/tutorial_path_test.go`.
- The session wait uses the existing `WaitForCondition` helper with a 30-second timeout and prints `gc session list` output on timeout.
- The clean-install tutorial test still exercises `gc init`, `gc rig add`, `bd config get issue_prefix`, and rig-scoped bead creation through the Dolt integration path.

## Test plan

- [x] `go test -tags acceptance_a -run TestSessionDefaultNamedSession -count=1 -v ./test/acceptance`
- [x] `go test -tags integration -run TestCleanInstallTutorialPath -count=1 -v ./test/integration`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build ./cmd/gc/`
- [x] Release gate: [`release-gates/ga-q32h2b-test-deflakes-gate.md`](release-gates/ga-q32h2b-test-deflakes-gate.md)
