### PR TITLE
fix(init): generate resolvable tree-URL sources for bundled imports (#3644)

### DIFF
--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -178,7 +178,11 @@ func builtinImportsForNames(names []string) (map[string]config.Import, []string)
 	imports := make(map[string]config.Import, len(names))
 	ordered := make([]string, 0, len(names))
 	for _, name := range names {
-		source, ok := builtinpacks.Source(name)
+		// CanonicalImportSource authors the dereferenceable tree-URL form
+		// that gc init and the builtin-pack-imports doctor fix write into
+		// pack.toml; the version pin still derives from the normalized
+		// source, which both spellings share.
+		source, ok := builtinpacks.CanonicalImportSource(name)
 		if !ok {
 			continue
 		}

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -460,9 +460,11 @@ func TestRequiredBuiltinPackNames(t *testing.T) {
 			t.Fatalf("requiredBuiltinImports order = %v, want [core bd]", ordered)
 		}
 		for _, name := range ordered {
-			source, ok := builtinpacks.Source(name)
+			// requiredBuiltinImports authors the dereferenceable tree-URL
+			// form (issue #3644), not the internal //subpath form.
+			source, ok := builtinpacks.CanonicalImportSource(name)
 			if !ok {
-				t.Fatalf("builtinpacks.Source(%q) not registered", name)
+				t.Fatalf("builtinpacks.CanonicalImportSource(%q) not registered", name)
 			}
 			imp, ok := imports[name]
 			if !ok {
@@ -470,6 +472,9 @@ func TestRequiredBuiltinPackNames(t *testing.T) {
 			}
 			if imp.Source != source {
 				t.Errorf("imports[%q].Source = %q, want %q", name, imp.Source, source)
+			}
+			if !strings.Contains(imp.Source, "/tree/") || strings.Contains(imp.Source, ".git//") {
+				t.Errorf("imports[%q].Source = %q, want a resolvable tree URL, not the .git//subpath form", name, imp.Source)
 			}
 			if imp.Version != config.BundledPackImportVersion {
 				t.Errorf("imports[%q].Version = %q, want %q", name, imp.Version, config.BundledPackImportVersion)
@@ -534,13 +539,21 @@ func TestBuiltinImportsForNames(t *testing.T) {
 		t.Fatalf("builtinImportsForNames imports = %#v, want 3 entries", imports)
 	}
 	for _, name := range ordered {
-		source, ok := builtinpacks.Source(name)
+		// gc init authors the dereferenceable tree-URL form, not the
+		// internal //subpath recognition form returned by Source.
+		source, ok := builtinpacks.CanonicalImportSource(name)
 		if !ok {
-			t.Fatalf("builtinpacks.Source(%q) not registered", name)
+			t.Fatalf("builtinpacks.CanonicalImportSource(%q) not registered", name)
 		}
 		imp := imports[name]
 		if imp.Source != source {
 			t.Errorf("imports[%q].Source = %q, want %q", name, imp.Source, source)
+		}
+		if !strings.Contains(imp.Source, "/tree/") {
+			t.Errorf("imports[%q].Source = %q, want a dereferenceable GitHub tree URL", name, imp.Source)
+		}
+		if strings.Contains(imp.Source, ".git//") {
+			t.Errorf("imports[%q].Source = %q, must not author the legacy .git//subpath form", name, imp.Source)
 		}
 		if imp.Version != config.BundledPackImportVersion {
 			t.Errorf("imports[%q].Version = %q, want %q", name, imp.Version, config.BundledPackImportVersion)
@@ -576,6 +589,53 @@ func TestBuiltinImportsForInit(t *testing.T) {
 			t.Errorf("builtinImportsForInit with GC_BEADS=file = %v, want core only", ordered)
 		}
 	})
+}
+
+// TestCanonicalImportSourcePublicPacksMatchConstants asserts the public-pack
+// branch of CanonicalImportSource produces exactly the durable source
+// constants gc init and the wave-1 doctor migration write for the public
+// gascity-packs packs, so the bundled generator and the init/doctor paths
+// never diverge on spelling.
+func TestCanonicalImportSourcePublicPacksMatchConstants(t *testing.T) {
+	cases := map[string]string{
+		"gastown": config.PublicGastownPackSource,
+		"gascity": config.PublicGascityPackSource,
+	}
+	for name, want := range cases {
+		got, ok := builtinpacks.CanonicalImportSource(name)
+		if !ok {
+			t.Fatalf("CanonicalImportSource(%q) ok = false, want true", name)
+		}
+		if got != want {
+			t.Errorf("CanonicalImportSource(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestCanonicalImportSourceCacheKeyParity is the safety property the whole
+// "change generation, leave recognition unchanged" strategy rests on: the
+// authored tree-URL spelling and the internal //subpath spelling must resolve
+// to the same repo cache slot at the canonical pin. If this ever diverges, a
+// freshly-initialized city and an old-form city would fight over (or miss)
+// the same bundled synthetic cache.
+func TestCanonicalImportSourceCacheKeyParity(t *testing.T) {
+	commit := strings.TrimPrefix(config.BundledPackImportVersion, "sha:")
+	for _, name := range []string{"core", "bd", "dolt"} {
+		legacy, ok := builtinpacks.Source(name)
+		if !ok {
+			t.Fatalf("Source(%q) not registered", name)
+		}
+		canonical, ok := builtinpacks.CanonicalImportSource(name)
+		if !ok {
+			t.Fatalf("CanonicalImportSource(%q) not registered", name)
+		}
+		if legacy == canonical {
+			t.Fatalf("Source(%q) and CanonicalImportSource(%q) are the same spelling %q; parity test is vacuous", name, name, legacy)
+		}
+		if packman.RepoCacheKey(legacy, commit) != packman.RepoCacheKey(canonical, commit) {
+			t.Errorf("RepoCacheKey diverges for %q: legacy %q vs canonical %q", name, legacy, canonical)
+		}
+	}
 }
 
 func TestNoMaintenanceBuiltinPack(t *testing.T) {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -2806,10 +2806,10 @@ schema = 2
 
 [imports]
 [imports.bd]
-source = "https://github.com/gastownhall/gascity.git//examples/bd"
+source = "https://github.com/gastownhall/gascity/tree/main/examples/bd"
 version = "` + config.BundledPackImportVersion + `"
 [imports.core]
-source = "https://github.com/gastownhall/gascity.git//internal/bootstrap/packs/core"
+source = "https://github.com/gastownhall/gascity/tree/main/internal/bootstrap/packs/core"
 version = "` + config.BundledPackImportVersion + `"
 [imports.gascity]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gascity"

--- a/internal/builtinpacks/registry.go
+++ b/internal/builtinpacks/registry.go
@@ -37,6 +37,12 @@ const (
 	// ordinary git checkouts that point at the same repository and commit.
 	SyntheticCacheNamespace = "bundled-synthetic-v1"
 
+	// canonicalBrowseRef is the branch ref embedded in the dereferenceable
+	// GitHub tree URLs CanonicalImportSource authors. It is the browse ref
+	// only — the exact pinned commit travels in the import's version field —
+	// and matches the ref the public gascity-packs tree sources use.
+	canonicalBrowseRef = "main"
+
 	syntheticMarkerFile = ".gc-bundled-pack-cache.toml"
 )
 
@@ -87,12 +93,39 @@ func Source(name string) (string, bool) {
 }
 
 // CanonicalImportSource returns the source spelling gc writes for NEW
-// imports of a bundled pack: the public registry source when the pack is
-// published there (matching what gc init templates and the wave-1 doctor
-// migration write), else the gascity.git source.
+// imports of a bundled pack: a dereferenceable GitHub tree URL pinned to the
+// canonical browse ref, matching the authored form documented for
+// Import.Source and the form "gc import add" expects. Packs published in the
+// public gascity-packs repository resolve to its tree URL (identical to the
+// config.PublicGastownPackSource / config.PublicGascityPackSource
+// constants); the remaining bundled packs resolve to the gascity.git tree
+// URL. The //subpath spelling returned by Source stays the internal
+// recognition/cache form; only the authored text changes.
+//
+// Resolution treats both spellings identically (remotesource.Parse and
+// IsSource normalize tree URLs and //subpath forms to the same clone URL +
+// subpath), so this only affects how the source reads in pack.toml. The
+// FormatGitHubTreeSource fallback to Source keeps a non-GitHub bundled
+// repository (should one ever be added) authorable.
 func CanonicalImportSource(name string) (string, bool) {
-	if publicSubpath, ok := publicSubpathForPack(name); ok {
+	// Resolve registry identity first: generation must stay tied to an
+	// actually-bundled pack, so an unregistered name returns ok=false even
+	// if it happens to match publicSubpathForPack (which keys off the name
+	// string, not the registry).
+	pack, ok := ByName(name)
+	if !ok {
+		return "", false
+	}
+	if publicSubpath, ok := publicSubpathForPack(pack.Name); ok {
+		if tree, ok := remotesource.FormatGitHubTreeSource(PublicRepository, canonicalBrowseRef, publicSubpath); ok {
+			return tree, true
+		}
 		return PublicRepository + "//" + publicSubpath, true
+	}
+	if pack.Subpath != "" {
+		if tree, ok := remotesource.FormatGitHubTreeSource(Repository, canonicalBrowseRef, pack.Subpath); ok {
+			return tree, true
+		}
 	}
 	return Source(name)
 }

--- a/internal/builtinpacks/registry_test.go
+++ b/internal/builtinpacks/registry_test.go
@@ -46,6 +46,61 @@ func TestAllAndSourceAreDeterministic(t *testing.T) {
 	}
 }
 
+// TestCanonicalImportSourceAuthorsResolvableTreeURLs locks in the rule from
+// issue #3644: the source spelling gc generates into pack.toml must be a
+// dereferenceable GitHub tree URL (the form imports.gascity already uses),
+// never the legacy .git//subpath form that does not resolve in a browser.
+// Recognition still accepts both spellings (TestSourceRecognitionVariants);
+// only generation is constrained here.
+func TestCanonicalImportSourceAuthorsResolvableTreeURLs(t *testing.T) {
+	for _, pack := range All() {
+		source, ok := CanonicalImportSource(pack.Name)
+		if !ok {
+			t.Fatalf("CanonicalImportSource(%q) ok = false, want true", pack.Name)
+		}
+		if !strings.Contains(source, "/tree/") {
+			t.Errorf("CanonicalImportSource(%q) = %q, want a dereferenceable GitHub tree URL", pack.Name, source)
+		}
+		if strings.Contains(source, ".git//") || strings.Contains(source, ".git/tree/") {
+			t.Errorf("CanonicalImportSource(%q) = %q, must not author the legacy non-resolvable .git//subpath form", pack.Name, source)
+		}
+		// The generated spelling must round-trip through recognition so
+		// resolution, cache keying, and the doctor checks still see it as a
+		// bundled source.
+		if !IsSource(source) {
+			t.Errorf("IsSource(%q) = false, generated source must be recognized as bundled", source)
+		}
+	}
+}
+
+// TestGascityBundledSubpathsExistInWorkingTree guards the browse ref choice
+// for issue #3644: CanonicalImportSource authors gascity.git tree URLs at the
+// "main" browse ref while the real pin lives in the version field. That URL is
+// only dereferenceable if the pack subpath still exists at main. This test
+// fails fast if a gascity.git-hosted bundled pack is moved or renamed without
+// updating All(), which would otherwise ship a 404 browse URL into pack.toml.
+// (Public packs live in gascity-packs, not this repo, so they are excluded.)
+func TestGascityBundledSubpathsExistInWorkingTree(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate repo root")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	for _, pack := range All() {
+		if pack.Subpath == "" {
+			continue
+		}
+		if _, public := publicSubpathForPack(pack.Name); public {
+			continue
+		}
+		packToml := filepath.Join(repoRoot, filepath.FromSlash(pack.Subpath), "pack.toml")
+		if _, err := os.Stat(packToml); err != nil {
+			t.Errorf("bundled pack %q subpath %q has no pack.toml at %s (%v); the generated /tree/main/%s URL would 404 — update builtinpacks.All() or move the pack back",
+				pack.Name, pack.Subpath, packToml, err, pack.Subpath)
+		}
+	}
+}
+
 func TestSourceRecognitionVariants(t *testing.T) {
 	coreSource := MustSource("core")
 	cases := []struct {


### PR DESCRIPTION
Fixes #3644.

## Problem

`gc init` generated two different URL formats for pack imports:

```toml
[imports.bd]
source = "https://github.com/gastownhall/gascity.git//examples/bd"                 # not browser-resolvable
[imports.core]
source = "https://github.com/gastownhall/gascity.git//internal/bootstrap/packs/core" # not browser-resolvable
[imports.gascity]
source = "https://github.com/gastownhall/gascity-packs/tree/main/gascity"           # resolvable
```

The `.git//<subpath>` spelling does not resolve in a browser. The two forms diverged because `gc init` resolved bundled sources through `builtinpacks.Source`, which returns the internal `//subpath` recognition spelling, while the public packs used the `/tree/` constants.

## Approach — conservative writer, liberal reader

- **Liberal reader:** the loader still parses **both** formats. `Source()` and all recognition / cache-key machinery are intentionally unchanged, so existing cities and deliberately-authored third-party `//subpath` imports keep resolving.
- **Conservative writer:** generation is now constrained to the resolvable `/tree/` form for references into **our** (gastownhall) repos.

## Changes

- `CanonicalImportSource` now emits dereferenceable GitHub tree URLs via `remotesource.FormatGitHubTreeSource` at the `main` browse ref (the exact pinned commit still travels in the import's `version` field). It resolves `ByName` first so generation stays tied to an actually-registered pack.
- `builtinImportsForNames` (used by `gc init`) authors via `CanonicalImportSource` instead of `Source`.

Scope is deliberately limited to the **generator**. No doctor migration of existing cities: the old form still works, and a city may legitimately prefer `//subpath` for third-party repos.

## After

```toml
[imports.bd]
source = "https://github.com/gastownhall/gascity/tree/main/examples/bd"
[imports.core]
source = "https://github.com/gastownhall/gascity/tree/main/internal/bootstrap/packs/core"
[imports.gascity]
source = "https://github.com/gastownhall/gascity-packs/tree/main/gascity"
```

## Tests

- init/builtin sources are resolvable tree URLs, never the `.git//subpath` form
- the public-pack branch equals `config.PublicGastownPackSource` / `PublicGascityPackSource`
- old (`//subpath`) and new (`/tree/`) spellings share a `RepoCacheKey` at the canonical pin (the safety property behind "leave recognition unchanged")
- working-tree guard that the bundled subpaths exist at `main`, so a moved/renamed pack can't ship a 404 browse URL

Verified end-to-end: a fresh `gc init` now emits all three imports in `/tree/main/` form. Full `cmd/gc` suite plus `builtinpacks` / `remotesource` / `packregistry` / `config` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)