### PR TITLE
fix(skills): codex skills sink is .agents/skills, not .codex/skills (#3643)

### DIFF
--- a/cmd/gc/skill_install_dir_test.go
+++ b/cmd/gc/skill_install_dir_test.go
@@ -90,6 +90,7 @@ func TestSkillInstallDirsPerProviderAcrossScopes(t *testing.T) {
 		{"out-of-tree-rig", outOfTreeRig},
 	}
 
+	wantSource := filepath.Join(cityPath, "skills", "mayor")
 	for _, sc := range scopes {
 		for provider, sink := range canonicalSink {
 			link := filepath.Join(sc.root, filepath.FromSlash(sink), "mayor")
@@ -101,6 +102,18 @@ func TestSkillInstallDirsPerProviderAcrossScopes(t *testing.T) {
 			}
 			if info.Mode()&os.ModeSymlink == 0 {
 				t.Errorf("%s / %s: %s is not a symlink", sc.label, provider, link)
+				continue
+			}
+			// The provider CLI follows the symlink target, so a dangling
+			// or mis-targeted link delivers zero skills even though the
+			// link exists. Assert it resolves to the shared mayor source.
+			tgt, err := os.Readlink(link)
+			if err != nil {
+				t.Errorf("%s / %s: readlink %s: %v", sc.label, provider, link, err)
+				continue
+			}
+			if tgt != wantSource {
+				t.Errorf("%s / %s: symlink target = %q, want %q", sc.label, provider, tgt, wantSource)
 			}
 		}
 	}

--- a/cmd/gc/skill_install_dir_test.go
+++ b/cmd/gc/skill_install_dir_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestSkillInstallDirsPerProviderAcrossScopes is the issue #3643 regression
+// guard. The requirement: in a fresh install the pack skill must be
+// installed into the directory each provider's CLI actually reads, at the
+// city scope AND at every rig scope — whether the rig lives under the city
+// tree (a subdir rig) or out of tree.
+//
+// It drives the real production path (InjectImplicitAgents → stage-1
+// materialization) rather than hand-authored [[agent]] entries, because the
+// implicit per-provider agents are what a default `gc init` city relies on,
+// and that path is what the bug report exercised.
+//
+// canonicalSink is the project-scoped skills directory each provider's own
+// CLI scans, verified against vendor docs (2026-06):
+//
+//	claude   → .claude/skills   (code.claude.com/docs/en/skills)
+//	codex    → .agents/skills   (developers.openai.com/codex/skills — Codex
+//	                             does NOT read a project-scoped .codex/skills)
+//	gemini   → .gemini/skills   (github.com/google-gemini/gemini-cli)
+//	opencode → .opencode/skills (opencode.ai/docs/skills)
+//	mimocode → .mimocode/skills (mimo.xiaomi.com/mimocode/skills)
+func TestSkillInstallDirsPerProviderAcrossScopes(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+
+	// The pack ships a shared "mayor" skill (as the gascity pack does).
+	writeSkillSource(t, filepath.Join(cityPath, "skills", "mayor"))
+
+	// A rig under the city tree.
+	subdirRig := filepath.Join(cityPath, "rigs", "inside")
+	if err := os.MkdirAll(subdirRig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A rig out of the city tree: a sibling temp dir not under cityPath.
+	outOfTreeRig := filepath.Join(t.TempDir(), "temp-rig")
+	if err := os.MkdirAll(outOfTreeRig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalSink := map[string]string{
+		"claude":   ".claude/skills",
+		"codex":    ".agents/skills",
+		"gemini":   ".gemini/skills",
+		"opencode": ".opencode/skills",
+		"mimocode": ".mimocode/skills",
+	}
+
+	providers := map[string]config.ProviderSpec{}
+	for name := range canonicalSink {
+		providers[name] = config.ProviderSpec{}
+	}
+
+	cfg := &config.City{
+		PackSkillsDir: filepath.Join(cityPath, "skills"),
+		Session:       config.SessionConfig{Provider: "tmux"},
+		Providers:     providers,
+		Rigs: []config.Rig{
+			{Name: "inside", Path: subdirRig},
+			{Name: "temp-rig", Path: outOfTreeRig},
+		},
+	}
+
+	// Fresh-install production path: implicit per-provider agents at city
+	// scope and at each rig scope.
+	config.InjectImplicitAgents(cfg)
+	config.ApplyAgentDefaults(cfg)
+
+	var stderr bytes.Buffer
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("runStage1SkillMaterialization: %v", err)
+	}
+
+	scopes := []struct {
+		label string
+		root  string
+	}{
+		{"city", cityPath},
+		{"subdir-rig", subdirRig},
+		{"out-of-tree-rig", outOfTreeRig},
+	}
+
+	for _, sc := range scopes {
+		for provider, sink := range canonicalSink {
+			link := filepath.Join(sc.root, filepath.FromSlash(sink), "mayor")
+			info, err := os.Lstat(link)
+			if err != nil {
+				t.Errorf("%s / %s: skill not installed where the CLI reads it: %v (want symlink at %s)",
+					sc.label, provider, err, link)
+				continue
+			}
+			if info.Mode()&os.ModeSymlink == 0 {
+				t.Errorf("%s / %s: %s is not a symlink", sc.label, provider, link)
+			}
+		}
+	}
+
+	if stderr.Len() > 0 {
+		t.Logf("stderr:\n%s", stderr.String())
+	}
+}

--- a/cmd/gc/skill_supervisor_test.go
+++ b/cmd/gc/skill_supervisor_test.go
@@ -201,8 +201,9 @@ func TestRunStage1SkipsUnsupportedProvider(t *testing.T) {
 
 // TestRunStage1MixedProvidersCreateSiblingSinks verifies the spec's
 // mixed-provider scenario: a claude agent and a codex agent at the
-// same scope root produce sibling .claude/skills/ and .codex/skills/
-// sinks with the same city-pack skill.
+// same scope root produce sibling .claude/skills/ and .agents/skills/
+// sinks (the codex CLI reads .agents/skills, not .codex/skills) with the
+// same city-pack skill.
 func TestRunStage1MixedProvidersCreateSiblingSinks(t *testing.T) {
 	clearGCEnv(t)
 	cityPath := t.TempDir()
@@ -223,7 +224,7 @@ func TestRunStage1MixedProvidersCreateSiblingSinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, vendor := range []string{".claude", ".codex"} {
+	for _, vendor := range []string{".claude", ".agents"} {
 		sink := filepath.Join(cityPath, vendor, "skills", "plan")
 		info, err := os.Lstat(sink)
 		if err != nil {
@@ -553,8 +554,8 @@ func TestRunStage1AgentLocalOnlyInItsOwnSink(t *testing.T) {
 	if _, err := os.Lstat(filepath.Join(cityPath, ".claude", "skills", "mayor-only")); err != nil {
 		t.Errorf("mayor-only missing from claude sink: %v", err)
 	}
-	// deputy's codex sink does NOT get mayor's private skill.
-	if _, err := os.Lstat(filepath.Join(cityPath, ".codex", "skills", "mayor-only")); !os.IsNotExist(err) {
+	// deputy's codex sink (.agents/skills) does NOT get mayor's private skill.
+	if _, err := os.Lstat(filepath.Join(cityPath, ".agents", "skills", "mayor-only")); !os.IsNotExist(err) {
 		t.Errorf("mayor-only leaked into codex sink; err=%v", err)
 	}
 }

--- a/docs/guides/capabilities-for-coding-agent-users.md
+++ b/docs/guides/capabilities-for-coding-agent-users.md
@@ -74,7 +74,7 @@ The rest of this page is one short answer per capability.
     skill wins.
 - At startup Gas City **symlinks** the pack level and role level skill directories into
   each agent's provider-specific skill sink — `.claude/skills/`,
-  `.codex/skills/`, `.gemini/skills/`, `.opencode/skills/`. List with
+  `.agents/skills/` (codex), `.gemini/skills/`, `.opencode/skills/`. List with
   `gc skill list`.
 - It *places* the files into each provider's own convention; it doesn't
   translate them. Providers whose convention isn't confirmed (copilot, cursor,

--- a/engdocs/proposals/skill-materialization.md
+++ b/engdocs/proposals/skill-materialization.md
@@ -199,7 +199,7 @@ workdir, or a sidecar init step).
 | Provider   | Skill sink           | v0.15.1 status    |
 |------------|----------------------|-------------------|
 | `claude`   | `.claude/skills/`    | materialize       |
-| `codex`    | `.codex/skills/`     | materialize       |
+| `codex`    | `.agents/skills/`    | materialize       |
 | `gemini`   | `.gemini/skills/`    | materialize       |
 | `opencode` | `.opencode/skills/`  | materialize       |
 | `copilot`  | —                    | skip (no sink)    |
@@ -463,7 +463,7 @@ scope root:
   .claude/skills/           # materialized for claude agents
     gc-work/ -> ...
     plan/ -> ...
-  .codex/skills/            # materialized for codex agents
+  .agents/skills/           # materialized for codex agents
     gc-work/ -> ...
     plan/ -> ...
 ```

--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -50,13 +50,25 @@ import (
 // vendorSinks maps an agent provider to the relative directory under the
 // agent's scope-root or session WorkDir where skills are materialized.
 //
-// Only the providers with verified skill-reading behavior are included.
+// Each path is the project-scoped skills directory that the provider's own
+// CLI actually scans (a directory of <name>/SKILL.md), verified against
+// vendor docs (2026-06):
+//
+//	claude   → .claude/skills   (code.claude.com/docs/en/skills)
+//	codex    → .agents/skills   (developers.openai.com/codex/skills — Codex
+//	                             scans .agents/skills from cwd up to the repo
+//	                             root; it does NOT read a project-scoped
+//	                             .codex/skills, only ~/.codex for user state)
+//	gemini   → .gemini/skills   (github.com/google-gemini/gemini-cli docs/cli/skills.md)
+//	opencode → .opencode/skills (opencode.ai/docs/skills)
+//	mimocode → .mimocode/skills (mimo.xiaomi.com/mimocode/skills)
+//
 // The other providers recognized by hooks.go (copilot, cursor, pi, omp)
 // intentionally have no entry — VendorSink returns ok=false so the caller
 // can log a single skip line per session.
 var vendorSinks = map[string]string{
 	"claude":   ".claude/skills",
-	"codex":    ".codex/skills",
+	"codex":    ".agents/skills",
 	"gemini":   ".gemini/skills",
 	"opencode": ".opencode/skills",
 	"mimocode": ".mimocode/skills",

--- a/internal/materialize/skills_test.go
+++ b/internal/materialize/skills_test.go
@@ -97,7 +97,7 @@ func TestVendorSink(t *testing.T) {
 		wantOK   bool
 	}{
 		{"claude", ".claude/skills", true},
-		{"codex", ".codex/skills", true},
+		{"codex", ".agents/skills", true},
 		{"gemini", ".gemini/skills", true},
 		{"opencode", ".opencode/skills", true},
 		{"mimocode", ".mimocode/skills", true},


### PR DESCRIPTION
## Summary

Fixes the **codex** slice of #3643: in a fresh city the gascity `mayor` skill
(and every pack skill) resolved for `claude` but never for `codex`. Root cause —
gc materialized codex skills into `.codex/skills`, but the Codex CLI only scans
**`.agents/skills`** (walked from cwd up to the repo root) for project skills; it
never reads a project-scoped `.codex/skills`. So `$mayor` was the right invocation
pointed at a directory Codex never looks in.

One-line behavioral fix: `vendorSinks["codex"] = ".agents/skills"`.

The other four sinks were re-verified against current vendor docs and are
**already correct**, so they're unchanged:

| provider | sink | reads it? |
|---|---|---|
| claude | `.claude/skills` | ✅ |
| **codex** | `.codex/skills` → **`.agents/skills`** | ✅ after fix |
| gemini | `.gemini/skills` | ✅ |
| opencode | `.opencode/skills` | ✅ |
| mimocode | `.mimocode/skills` | ✅ |

## Test (TDD)

New `TestSkillInstallDirsPerProviderAcrossScopes` drives the real
`InjectImplicitAgents` → stage-1 materialization path (the path the bug report
hit, not hand-authored `[[agent]]` entries) and asserts each provider's skill
lands in the directory **its own CLI reads**, at three scopes:

- the **city** dir (fresh install),
- a **subdir rig** (under the city tree),
- an **out-of-tree rig** (sibling of the city).

It fails on `codex` at all three scopes before the fix and passes after. This
also confirms materialization is **location-symmetric** — out-of-tree rigs get
sinks identically to in-tree rigs.

## Scope / not in this PR

This PR is the verified, high-confidence codex path fix. Two other #3643
observations are **separate** and intentionally not bundled:

- **gemini** doesn't resolve `/mayor` or `$mayor` because Gemini has no slash/`$`
  skill invocation — skills auto-activate by `description` (and the sink path is
  already correct). That's a docs/UX item, not a path bug.
- **claude in an out-of-tree rig** depends on the supervisor having materialized
  the per-rig sink; the in-tree case is rescued by Claude's upward `.claude/skills`
  tree-walk to the city sink, which out-of-tree rigs can't reach. Lifecycle item,
  tracked separately.

## Migration note

Existing installs may keep stale `.codex/skills/*` symlinks; they're harmless
(Codex never read them) and will simply stop being refreshed. No cleanup logic
added for the hotfix.

## Target

Hotfix for the 1.3 line → **v1.3.2** (branch cut from `release/v1.3.0`, currently
at the `v1.3.1` tag).

Verification: `lint-changed` clean, `go vet ./...` clean, full `test-local-parallel fast`
+ `test/docsync` green (via pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)