### PR TITLE
fix(api): drop extmsg inbound invariant violations as permanent 4xx (post-merge #3435)

### DIFF
--- a/internal/api/handler_extmsg_test.go
+++ b/internal/api/handler_extmsg_test.go
@@ -487,6 +487,33 @@ func TestHandleExtMsgInboundNormalizedInvalidConversationReturns400(t *testing.T
 	}
 }
 
+// TestHandleExtMsgInboundNormalizedInvariantViolationReturns400 pins the third
+// arm of the contract: an invariant violation (e.g. duplicate active bindings
+// surfaced by ResolveByConversation, or duplicate groups/participants/transcript
+// state surfaced by the group-route and transcript steps) is permanent — the
+// same inbound message re-resolves the same corrupt state and fails identically
+// until it is repaired out-of-band. It must stay 4xx so adapters drop the poison
+// message instead of retrying a 5xx forever and wedging the account's ordered
+// inbound stream behind it.
+func TestHandleExtMsgInboundNormalizedInvariantViolationReturns400(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+
+	services := extmsg.NewServices(fs.cityBeadStore)
+	services.Bindings = faultBindingService{err: fmt.Errorf("%w: multiple active bindings for telegram/acct-1/chat-1", extmsg.ErrInvariantViolation)}
+	fs.extmsgSvc = &services
+	fs.adapterReg = extmsg.NewAdapterRegistry()
+
+	req := newPostRequest(cityURL(fs, "/extmsg/inbound"), strings.NewReader(inboundNormalizedBody(t)))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invariant violation: status = %d, want %d; body: %s",
+			rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
 func TestTitleCaseProvider(t *testing.T) {
 	cases := []struct {
 		in, want string

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -58,23 +58,31 @@ func (s *Server) humaHandleExtMsgInbound(ctx context.Context, input *ExtMsgInbou
 	if input.Body.Message != nil {
 		result, handleErr := extmsg.HandleInboundNormalized(ctx, deps, *input.Body.Message)
 		if handleErr != nil {
-			// HandleInboundNormalized fails either on a deterministic input
-			// rejection (malformed/unroutable conversation — permanent, so a
-			// 4xx the adapter should drop) or on a transient binding/route/
-			// transcript store fault (retryable, so a 5xx the adapter should
-			// hold and redeliver). Out-of-process adapters treat 4xx as a
-			// permanent drop and 5xx as retryable, so a transient storage fault
-			// must not be reported as a permanent-looking 422. Mirrors the
-			// bind handler's error split.
+			// HandleInboundNormalized fails in one of two classes. Permanent
+			// rejections (a malformed/unroutable conversation, or an invariant
+			// violation such as duplicate active bindings) are a 4xx the adapter
+			// should drop: retrying re-resolves the same corrupt state and fails
+			// identically, so reporting 5xx would pin the adapter's ordered poll
+			// offset behind one poison message and wedge the whole account stream.
+			// Transient binding/route/transcript store faults are retryable, so a
+			// 5xx the adapter should hold and redeliver. Out-of-process adapters
+			// treat 4xx as a permanent drop and 5xx as retryable, so a transient
+			// fault must never surface as a permanent 4xx and a permanent fault
+			// must never surface as a retryable 5xx. This is a subset of the bind
+			// handler's split below: no ErrBindingConflict (409) arm, because the
+			// inbound path resolves existing bindings rather than creating them.
 			switch {
-			// ErrInvalidConversation is the only permanent error
-			// HandleInboundNormalized can actually surface today (a
-			// malformed/unroutable conversation). The ErrInvalidInput arm mirrors
-			// the bind handler's switch below for symmetry and future-proofing —
-			// the normalized path hard-codes Kind/Provenance so it has no live
-			// ErrInvalidInput source — and keeps the two switches identical if a
-			// later validation starts returning it.
-			case errors.Is(handleErr, extmsg.ErrInvalidInput), errors.Is(handleErr, extmsg.ErrInvalidConversation):
+			// Permanent conditions the normalized path can surface: an
+			// unroutable/malformed conversation (ErrInvalidConversation), and an
+			// invariant violation (ErrInvariantViolation) from binding, group-route,
+			// or transcript resolution — corrupt state that retrying cannot repair,
+			// so it is dropped rather than allowed to wedge the stream. The
+			// ErrInvalidInput arm is the bind switch's input-validation arm carried
+			// over for symmetry; the normalized path hard-codes Kind/Provenance so
+			// it has no live ErrInvalidInput source today.
+			case errors.Is(handleErr, extmsg.ErrInvalidInput),
+				errors.Is(handleErr, extmsg.ErrInvalidConversation),
+				errors.Is(handleErr, extmsg.ErrInvariantViolation):
 				return nil, huma.Error400BadRequest(handleErr.Error())
 			default:
 				return nil, huma.Error500InternalServerError(handleErr.Error())


### PR DESCRIPTION
## Post-merge remediation for #3435

A post-merge review of the landed range `478aa31..0387903` (openclaw-bridge)
found one actionable correctness issue in the normalized `/extmsg/inbound`
status-code contract introduced by #3435.

### Problem

`#3435` split normalized inbound handler errors into `400` (permanent, adapter
drops) vs `500` (transient, adapter retries). But `extmsg.ErrInvariantViolation`
— returned when binding, group-route, or transcript resolution finds corrupt
duplicate state (e.g. two active bindings for one conversation) — fell through
to the `default → 500` arm.

That misclassifies a **permanent** poison-message condition as **retryable**.
Out-of-process adapters retry 5xx, so:

- iMessage retries with `maxAttempts: Infinity` — forever;
- Telegram exhausts its retries and `drainBatch` stops without advancing the
  poll offset, so the next poll re-fetches the same update first.

Because the poll offset / watch stream is per-account and ordered, one
conversation with corrupt bindings would wedge the **entire account's inbound
stream** behind a single poison update. The pre-`#3435` behavior dropped exactly
one message; the regression converted that into an account-wide stall.

### Fix

- Map `ErrInvariantViolation` to the permanent `4xx` arm so adapters drop the
  poison message instead of retrying it. The mapping lives at the handler, so it
  uniformly covers invariant violations from **all three** inbound resolution
  steps (binding, group-route, transcript), not just one call site.
- Correct the handler comment, which falsely claimed `ErrInvalidConversation`
  was the only permanent error and that the inbound and bind switches were
  identical. The inbound switch is a **subset** of the bind split — no `409`
  arm, because it resolves existing bindings rather than creating them.
- Add a regression test (`TestHandleExtMsgInboundNormalizedInvariantViolationReturns400`)
  that injects a wrapped `ErrInvariantViolation` and asserts `400`.

Persistent repair of duplicate bindings remains the binding reaper's
responsibility (per the existing `overlayLiveSession` contract); this change
only ensures a corrupt conversation cannot wedge the whole stream while it
exists.

### Tests

- `go build ./internal/api/... ./internal/extmsg/...` — clean
- `go vet ./internal/api/...` — clean
- `go test ./internal/api ./internal/extmsg ./test/docsync` — pass (the three
  packages the original PR touched), including the new regression test and the
  existing transient-`500` / invalid-conversation-`400` contract tests.

### Self-review

Reviewed the final diff with fresh eyes: the change is additive (one error type
moves from the `5xx` default arm to the existing `4xx` permanent arm); no other
error mapping changes; `errors.Is` correctly unwraps the `%w`-wrapped errors the
inbound steps return; the transient-fault path still returns `500` (pinned by an
existing test). Scope is two files.
