### PR TITLE
fix(gastown): make digest-generate a single townwide order (co-ktkqt)

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
@@ -324,6 +325,64 @@ func TestCityPackTomlParses(t *testing.T) {
 	}
 	if gastownDefault.Source != "packs/gastown" {
 		t.Errorf("city.toml defaults.rig.imports[\"gastown\"].Source = %q, want %q", gastownDefault.Source, "packs/gastown")
+	}
+}
+
+// TestDigestGenerateOrderIsCityScoped locks the fix for the townwide digest
+// re-pour storm (gastownhall/gascity#co-ktkqt). digest-generate is imported by
+// every rig (it lives in packs/gastown/orders and the gastown pack is stamped
+// per-rig). Without scope="city" it instantiates once PER RIG, so a single
+// daily pour fans out to one digest molecule per rig, and each rig instance
+// keeps its own independent 24h cooldown clock in its own bead store — which is
+// how the same UTC window got re-digested ~16.5h after the first run. It must
+// be city-scoped so orderdiscovery.ScanAll registers it exactly once townwide
+// (one instance, one cooldown series). The generic scope mechanism is covered
+// by orderdiscovery.TestScanAllCityScopedOrderRegistersOnceAcrossRigs; this
+// asserts the gastown pack order actually opts in.
+func TestDigestGenerateOrderIsCityScoped(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "orders", "digest-generate.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	order, err := orders.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing digest-generate order: %v", err)
+	}
+	if !order.IsCityScoped() {
+		t.Fatalf("digest-generate order Scope = %q, want \"city\" — without it the order fans out per-rig (re-pour storm, co-ktkqt)", order.Scope)
+	}
+	if err := orders.Validate(orders.Order{
+		Name:     "digest-generate",
+		Formula:  order.Formula,
+		Trigger:  order.Trigger,
+		Interval: order.Interval,
+		Pool:     order.Pool,
+		Scope:    order.Scope,
+	}); err != nil {
+		t.Fatalf("digest-generate order does not validate: %v", err)
+	}
+}
+
+// TestDigestFormulaDocsDropStalePeriodicFormulasPath guards against the stale
+// documentation that described digest dispatch via a deacon "periodic-formulas"
+// step configured under city.toml [[formulas.periodic]]. No such config path or
+// deacon step exists in the codebase: the live dispatch path is the controller
+// order dispatcher driven by [order] trigger="cooldown". Keeping the stale prose
+// misleads operators debugging the cooldown (co-ktkqt).
+func TestDigestFormulaDocsDropStalePeriodicFormulasPath(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-digest-generate.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	body := string(data)
+	for _, stale := range []string{"formulas.periodic", "periodic-formulas"} {
+		if strings.Contains(body, stale) {
+			t.Errorf("mol-digest-generate.toml still references %q — no such dispatch path exists (co-ktkqt); document the [order] trigger=\"cooldown\" controller path instead", stale)
+		}
 	}
 }
 

--- a/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
@@ -15,21 +15,24 @@ gc runtime drain-ack
 
 The drain-ack tells the controller this session is done.
 
-This is a **periodic formula** — dispatched by the deacon's
-`periodic-formulas` step when the cooldown trigger elapses. Configured
-in `city.toml` under `[formulas]`:
+This formula is dispatched by the `digest-generate` order
+(`orders/digest-generate.toml`), a city-scoped cooldown order:
 
 ```toml
-[[formulas.periodic]]
+[order]
 formula = "mol-digest-generate"
+scope = "city"      # exactly one townwide run/day, never one per rig
 trigger = "cooldown"
 interval = "24h"
 pool = "dog"
 ```
 
-The deacon checks if enough time has passed since the last run
-(tracked via `type:order-run` beads), pours a wisp, and labels it
-for the dog pool. A dog picks it up and runs this formula.
+When the 24h cooldown elapses, the controller's order dispatcher records
+the run via a `type:order-run` bead (the same bead the cooldown check
+reads), pours a wisp, and labels it for the dog pool. A dog picks it up
+and runs this formula. There is exactly ONE townwide digest per day — the
+order is `scope = "city"`, so it is not instantiated per rig, and the
+single cooldown clock prevents re-pours of the same window (co-ktkqt).
 
 ## What it produces
 
@@ -79,7 +82,15 @@ UNTIL=$(date -u -d 'today 00:00' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
         date -u -j -f '%H:%M' '00:00' +%Y-%m-%dT%H:%M:%SZ)
 ```
 
-Note the timestamps for the digest header.
+**3. Derive a stable window key** — the start date of the window, used to
+label the digest bead and to detect a duplicate run of the same window:
+
+```bash
+# daily: the SINCE date, e.g. 2026-06-20 -> window:2026-06-20
+WINDOW=${SINCE%%T*}
+```
+
+Note the timestamps and $WINDOW for the digest header and dedup check.
 
 Continue to data collection when the time range is established."""
 
@@ -137,6 +148,20 @@ title = "Generate digest, send to mayor, archive"
 description = """
 Transform data into a formatted digest and deliver it.
 
+**0. Dedup guard — never mail two digests for the same window.**
+The city-scoped order + 24h cooldown make a same-window re-pour unlikely,
+but a manual `gc order run`, a cross-midnight retry, or clock skew can
+still produce one. Before generating, check for an existing digest bead
+for this $WINDOW:
+
+```bash
+gc bd list --label=digest,window:$WINDOW --json --limit=1
+```
+
+If one already exists, this window is already delivered. Do NOT mail or
+create a second digest bead — skip to step 4 (close the work bead, augment
+the existing digest bead if you have new data, drain-ack, exit).
+
 **1. Generate digest markdown:**
 
 ```markdown
@@ -171,10 +196,12 @@ gc mail send mayor/ -s "Gas Town Digest: $DATE" -m "$DIGEST"
 ```
 
 **3. Archive as bead:**
+The `window:$WINDOW` label is what the step-0 dedup guard matches on, so it
+MUST be present and MUST be the start date of the window (not today's date):
 ```bash
 gc bd create --type=task \
   --title="Digest: $DATE" \
-  --label=digest,{{period}}
+  --label=digest,{{period}},window:$WINDOW
 ```
 
 **4. Close work bead, signal reconciler, and exit:**
@@ -184,5 +211,5 @@ gc runtime drain-ack
 exit
 ```
 
-The deacon records this run via a `type:order-run` bead for cooldown
-tracking on the next patrol cycle."""
+The controller's order dispatcher records this run via a `type:order-run`
+bead for cooldown tracking; the next tick honors the 24h interval."""

--- a/examples/gastown/packs/gastown/orders/digest-generate.toml
+++ b/examples/gastown/packs/gastown/orders/digest-generate.toml
@@ -1,6 +1,14 @@
 [order]
 description = "Generate daily code digest across all rigs"
 formula = "mol-digest-generate"
+# scope="city" registers this order exactly once for the whole town, no matter
+# how many rigs import the gastown pack. Without it the order is rig-scoped (the
+# default) and instantiates once PER RIG: a single daily pour fans out to one
+# digest molecule per rig, and each rig instance keeps its own independent 24h
+# cooldown clock in its own bead store — so the same UTC window gets re-digested
+# (co-ktkqt). The digest formula already iterates every rig (`gc rig list`), so
+# one townwide run covers the whole town.
+scope = "city"
 trigger = "cooldown"
 interval = "24h"
 pool = "dog"


### PR DESCRIPTION
## Problem (bead co-ktkqt)

The `digest-generate` order (formula `mol-digest-generate`, `trigger="cooldown"`, `interval="24h"`, pool `dog`) had two compounding defects in the live Gas Town city:

1. **24h cooldown not honored** — a duplicate digest for the `2026-06-20` UTC window poured ~16.5h after the first run.
2. **Per-rig fanout** — a single daily pour produced **one digest molecule per rig** (`app`/`arnotts`/`detmold`/`flinders`, atop the real run), instead of exactly one townwide run/day.

## Root cause

`digest-generate.toml` lives in `packs/gastown/orders/`, and the gastown pack is stamped **per rig**. With no explicit scope, the order defaults to **rig-scoped**, so `orderdiscovery.ScanAll` instantiates it once per importing rig. Each rig instance:
- has its own `ScopedName()` (`digest-generate:rig:<rig>`),
- resolves to its **own bead store** (the rig's `.beads`),
- and therefore keeps an **independent 24h cooldown clock** via its own `order-run:<scoped>` bead.

So the order-run bead *is* written and the cooldown *is* honored — but **per scope**. N rigs ⇒ N independent cooldown clocks that don't share state. The `sb` instance ran at 04:47Z (→ canonical digest); the `app`/`arnotts`/`detmold`/`flinders` instances each later read `last.IsZero()` ("never run") in *their* stores and re-poured the same window at ~21:31–21:39Z. The defect is **scoping**, not cooldown persistence.

`gc order list` / `gc order history digest-generate` confirm the fanout: 6 instances (one per rig + one city-level `gas-city`), each with its own RIG column and cooldown.

The per-rig-fanout infrastructure already exists upstream (`Order.Scope` / `IsCityScoped()` / `orderdiscovery.ScanAll` city-scope dedup, covered by `TestScanAllCityScopedOrderRegistersOnceAcrossRigs`). The gastown digest order simply never opted in.

## Fix

- **`orders/digest-generate.toml`**: add `scope = "city"`. The order now registers exactly once townwide → one instance, one bead store, **one cooldown series**. This fixes both defects at the root (the formula already iterates every rig via `gc rig list`, so one run covers the whole town).
- **`formulas/mol-digest-generate.toml`**:
  - Drop the **stale doc header** describing a non-existent deacon `periodic-formulas` step / `[[formulas.periodic]]` config path (no such code path exists; it misleads operators debugging the cooldown). Document the real `[order] trigger="cooldown"` controller dispatch path.
  - Add a **defense-in-depth dedup guard**: derive a stable `window:<start-date>` key, label the archived digest bead with it, and skip mail/create if a digest for that window already exists. Covers manual `gc order run`, cross-midnight retries, and clock skew — codifying the manual self-suppression the dog pool performed during the incident.
- **`gastown_test.go`**: regression tests asserting (a) the pack order is city-scoped (`IsCityScoped()`), and (b) the formula docs no longer reference the non-existent `periodic-formulas` path.

## Testing

- `go test ./examples/gastown/ ./internal/orders/... ./internal/orderdiscovery/...` — green.
- `go test -run 'Order|Dispatch|Cooldown|Scope' ./cmd/gc/` — green.
- New tests fail before the pack change and pass after (TDD).

No production Go code changes — this is a pack-config + formula-doc + test change on top of the already-shipped `Scope` mechanism.

Refs bead co-ktkqt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgVYbdy6d7ASgxcirJQRRw
