### PR TITLE
fix(rig): `gc rig add` materializes skills immediately, incl. out-of-tree rigs (#3643)

### DIFF
--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -122,6 +122,12 @@ check remains informational.`,
 				if code != 0 {
 					return errExit
 				}
+				// Same immediate materialization as the human path (see
+				// cmdRigAdd) so `gc rig add --json` — the programmatic entry
+				// point most likely to drive out-of-tree codex rigs — also
+				// delivers skill sinks now, not on the next supervisor tick.
+				// Logs go to stderr so the JSONL on stdout stays clean.
+				materializeSkillsForCity(cityPath, stderr)
 				return writeManagementActionJSON(stdout, rigAddJSONSummary(rigPath, rig))
 			}
 			if cmdRigAdd(args, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, stdout, stderr) != 0 {
@@ -206,6 +212,15 @@ func materializeSkillsForCity(cityPath string, stderr io.Writer) {
 	cfg, _, err := loadCityConfigWithBuiltinPacks(cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig add: skipping immediate skill materialization (rig added; the supervisor will materialize on its next tick): %v\n", err) //nolint:errcheck // best-effort stderr
+		return
+	}
+	// Honor the same collision gate gc start and the supervisor run before
+	// materializing: a (scope-root, vendor) collision would otherwise let this
+	// pass write conflicting symlinks. On collision, skip — the supervisor
+	// surfaces the error on its next tick — rather than materialize a
+	// half-resolved sink.
+	if cerr := checkSkillCollisions(cfg, cityPath); cerr != nil {
+		fmt.Fprintf(stderr, "gc rig add: skipping immediate skill materialization due to a skill collision (the supervisor reports this on its next tick):\n%v\n", cerr) //nolint:errcheck // best-effort stderr
 		return
 	}
 	_ = runStage1SkillMaterialization(cityPath, cfg, stderr)

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -180,7 +180,35 @@ func cmdRigAdd(args []string, includes []string, nameOverride, prefixOverride, d
 		fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	return doRigAdd(fsys.OSFS{}, cityPath, rigPath, includes, nameOverride, prefixOverride, defaultBranchOverride, startSuspended, adopt, stdout, stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, includes, nameOverride, prefixOverride, defaultBranchOverride, startSuspended, adopt, stdout, stderr)
+	if code == 0 {
+		// Materialize skills now so the new rig's provider skill sinks
+		// (codex's .agents/skills, claude's .claude/skills, …) exist as soon
+		// as `gc rig add` returns — without waiting for the next supervisor
+		// tick, even for an out-of-tree rig, and even when no supervisor is
+		// running. Best-effort; never undoes a successful add.
+		materializeSkillsForCity(cityPath, stderr)
+	}
+	return code
+}
+
+// materializeSkillsForCity runs one best-effort stage-1 skill materialization
+// pass for the whole city, using the same compose+materialize path the
+// supervisor runs each tick. It exists so `gc rig add` delivers a rig's skill
+// sinks immediately rather than leaving a window until the next reconcile —
+// the difference that makes skills available in a freshly added rig's
+// directory, including an out-of-tree rig.
+//
+// Idempotent: a converged city creates nothing new. Non-fatal by design: a
+// config-load error here must not fail an already-persisted rig add, and
+// runStage1SkillMaterialization logs per-agent issues inline and returns nil.
+func materializeSkillsForCity(cityPath string, stderr io.Writer) {
+	cfg, _, err := loadCityConfigWithBuiltinPacks(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc rig add: skipping immediate skill materialization (rig added; the supervisor will materialize on its next tick): %v\n", err) //nolint:errcheck // best-effort stderr
+		return
+	}
+	_ = runStage1SkillMaterialization(cityPath, cfg, stderr)
 }
 
 func resolveRigAddPath(cityPath, rigArg string) (string, error) {

--- a/cmd/gc/skill_install_dir_test.go
+++ b/cmd/gc/skill_install_dir_test.go
@@ -124,15 +124,15 @@ func TestSkillInstallDirsPerProviderAcrossScopes(t *testing.T) {
 	}
 }
 
-// TestRigAddMaterializesSkillsIntoOutOfTreeRig is the issue #3643 lifecycle
-// guard. `gc rig add` must make pack skills available in the new rig's own
-// directory immediately — not only after the next supervisor tick — including
-// for an out-of-tree rig, so a coding CLI started there resolves the skill
-// right away (codex reads `.agents/skills` from cwd up to the repo root, so
-// the co-located rig sink is what carries it). This exercises the real
-// load+compose+materialize path that `gc rig add` now invokes via
-// materializeSkillsForCity, with a rig whose path is outside the city tree.
-func TestRigAddMaterializesSkillsIntoOutOfTreeRig(t *testing.T) {
+// TestMaterializeSkillsForCityCoversOutOfTreeRig is a focused unit test of the
+// materializeSkillsForCity helper (the pass `gc rig add` runs). It feeds the
+// real on-disk state a successful add leaves behind — a city-as-pack plus an
+// out-of-tree rig bound via .gc/site.toml — through the real
+// load+compose+materialize path and asserts the rig's own co-located sinks are
+// written (codex's .agents/skills, claude's .claude/skills). The end-to-end
+// wiring from the `gc rig add` command (both output modes) is guarded
+// separately by TestRigAddCommandMaterializesSkills.
+func TestMaterializeSkillsForCityCoversOutOfTreeRig(t *testing.T) {
 	clearGCEnv(t)
 	cityPath := t.TempDir()
 	t.Setenv("GC_CITY", cityPath)
@@ -176,5 +176,66 @@ func TestRigAddMaterializesSkillsIntoOutOfTreeRig(t *testing.T) {
 	}
 	if t.Failed() {
 		t.Logf("stderr:\n%s", stderr.String())
+	}
+}
+
+// TestRigAddCommandMaterializesSkills is the end-to-end wiring guard for issue
+// #3643: it drives the real `gc rig add` command (via run) for an out-of-tree
+// rig and asserts the codex sink (.agents/skills) lands immediately — for BOTH
+// the human and --json output modes. The --json path is a distinct code branch
+// in newRigAddCmd that bypasses cmdRigAdd, so without its own materialize call
+// `gc rig add <out-of-tree> --json` silently reproduces the #3643 symptom; this
+// test fails if either branch loses the materialization step.
+func TestRigAddCommandMaterializesSkills(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_CITY", cityPath)
+	t.Setenv("GC_HOME", t.TempDir())
+	// doRigAdd beads init: file-backed, no dolt — matches TestDoRigAdd_Basic.
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	// City-as-pack with claude+codex providers and a shared "mayor" skill.
+	cityTOML := "[workspace]\nname = \"test-city\"\n\n" +
+		"[session]\nprovider = \"tmux\"\n\n" +
+		"[providers.claude]\ncommand = \"claude\"\n\n" +
+		"[providers.codex]\ncommand = \"codex\"\n"
+	writeMaterializeTestCityFile(t, cityPath, "city.toml", cityTOML)
+	writeMaterializeTestCityFile(t, cityPath, "pack.toml", "[pack]\nname = \"test-city\"\nschema = 2\n")
+	writeBuiltinImportsFixture(t, cityPath, "core")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMaterializeTestCityFile(t, filepath.Join(cityPath, ".gc"), "site.toml", "workspace_name = \"test-city\"\n")
+	writeSkillSource(t, filepath.Join(cityPath, "skills", "mayor"))
+
+	for _, tc := range []struct {
+		name string
+		json bool
+	}{
+		{"human", false},
+		{"json", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Out-of-tree rig: a sibling temp dir, not under cityPath.
+			outRig := filepath.Join(t.TempDir(), "rig-"+tc.name)
+			if err := os.MkdirAll(outRig, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			args := []string{"rig", "add", outRig, "--name", "rig-" + tc.name}
+			if tc.json {
+				args = append(args, "--json")
+			}
+			var stdout, stderr bytes.Buffer
+			if code := run(args, &stdout, &stderr); code != 0 {
+				t.Fatalf("run %v = %d\nstderr:\n%s", args, code, stderr.String())
+			}
+			// codex's sink must exist in the rig's own dir right after add.
+			link := filepath.Join(outRig, ".agents", "skills", "mayor")
+			if _, err := os.Lstat(link); err != nil {
+				t.Errorf("%s mode: codex skill not materialized at %s: %v\nstderr:\n%s",
+					tc.name, link, err, stderr.String())
+			}
+		})
 	}
 }

--- a/cmd/gc/skill_install_dir_test.go
+++ b/cmd/gc/skill_install_dir_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -119,6 +120,61 @@ func TestSkillInstallDirsPerProviderAcrossScopes(t *testing.T) {
 	}
 
 	if stderr.Len() > 0 {
+		t.Logf("stderr:\n%s", stderr.String())
+	}
+}
+
+// TestRigAddMaterializesSkillsIntoOutOfTreeRig is the issue #3643 lifecycle
+// guard. `gc rig add` must make pack skills available in the new rig's own
+// directory immediately — not only after the next supervisor tick — including
+// for an out-of-tree rig, so a coding CLI started there resolves the skill
+// right away (codex reads `.agents/skills` from cwd up to the repo root, so
+// the co-located rig sink is what carries it). This exercises the real
+// load+compose+materialize path that `gc rig add` now invokes via
+// materializeSkillsForCity, with a rig whose path is outside the city tree.
+func TestRigAddMaterializesSkillsIntoOutOfTreeRig(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_CITY", cityPath)
+	t.Setenv("GC_HOME", t.TempDir())
+
+	// Out-of-tree rig: a sibling temp dir, not under cityPath.
+	outOfTreeRig := filepath.Join(t.TempDir(), "temp-rig")
+	if err := os.MkdirAll(outOfTreeRig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Minimal city-as-pack: a shared "mayor" skill, claude+codex providers
+	// (so InjectImplicitAgents creates per-rig agents), and the out-of-tree
+	// rig registered — the on-disk state `gc rig add` leaves behind (the rig
+	// path is a .gc/site.toml binding, not a city.toml rig.path).
+	cityTOML := "[workspace]\nname = \"test-city\"\n\n" +
+		"[beads]\nprovider = \"file\"\n\n" +
+		"[session]\nprovider = \"tmux\"\n\n" +
+		"[providers.claude]\ncommand = \"claude\"\n\n" +
+		"[providers.codex]\ncommand = \"codex\"\n\n" +
+		"[[rigs]]\nname = \"temp-rig\"\n"
+	writeMaterializeTestCityFile(t, cityPath, "city.toml", cityTOML)
+	writeMaterializeTestCityFile(t, cityPath, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
+	writeBuiltinImportsFixture(t, cityPath, "core")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMaterializeTestCityFile(t, filepath.Join(cityPath, ".gc"), "site.toml",
+		fmt.Sprintf("[[rig]]\nname = \"temp-rig\"\npath = %q\n", outOfTreeRig))
+	writeSkillSource(t, filepath.Join(cityPath, "skills", "mayor"))
+
+	// The behavior under test: gc rig add materializes synchronously.
+	var stderr bytes.Buffer
+	materializeSkillsForCity(cityPath, &stderr)
+
+	for _, sink := range []string{".agents/skills", ".claude/skills"} {
+		link := filepath.Join(outOfTreeRig, filepath.FromSlash(sink), "mayor")
+		if _, err := os.Lstat(link); err != nil {
+			t.Errorf("out-of-tree rig missing skill right after add: %s (%v)", link, err)
+		}
+	}
+	if t.Failed() {
 		t.Logf("stderr:\n%s", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #3647 (codex sink path fix, now merged). That PR made the steady
state correct; this one closes the **lifecycle gap** so out-of-tree rigs work
reliably, per the requirement: *"when a rig is added, the skill is available in
that directory — subdir rig or out-of-tree rig."*

`gc rig add` wrote `city.toml` and relied on the **next supervisor tick** to
materialize skill sinks. That leaves a window (and a no-supervisor-running gap)
where a freshly added rig has no skills. It bites **out-of-tree rigs hardest**:
a subdir rig can fall back to Claude's upward `.claude/skills` walk to the city
sink, but an out-of-tree rig has no gc-managed ancestor — its **own** sink is the
only thing that can carry skills, and Codex/Gemini never had the ancestor
fallback at all.

Fix: after a successful add, run one **best-effort synchronous** stage-1
materialization pass — the same `loadCityConfigWithBuiltinPacks` + 
`runStage1SkillMaterialization` path the supervisor runs each tick — so the new
rig's provider sinks (`.agents/skills` for codex, `.claude/skills` for claude, …)
exist in the rig's own directory the moment `gc rig add` returns, even with no
supervisor running. Idempotent; a config-load error never undoes the add.

## Why this makes out-of-tree codex work end-to-end

1. **Path** (from #3647): codex skills go to `.agents/skills` — the dir Codex reads.
2. **Read**: Codex scans `.agents/skills` from cwd up to the repo root, so the
   co-located rig sink resolves with no city-ancestry dependency.
3. **Lifecycle** (this PR): the sink is now present immediately on add, not only
   after the next tick.

## Test

`TestRigAddMaterializesSkillsIntoOutOfTreeRig` drives the real
load+compose+materialize path with an out-of-tree rig registered via a
`.gc/site.toml` binding (the on-disk shape `gc rig add` produces) and asserts the
codex (`.agents/skills`) and claude (`.claude/skills`) sinks land in the rig's own
directory immediately. The existing `TestSkillInstallDirsPerProviderAcrossScopes`
already covers the per-provider path correctness across city / subdir-rig /
out-of-tree-rig.

## Target

v1.3.2 hotfix line (`release/v1.3.0`), stacked on #3647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)