### PR TITLE
fix(home): sibling resolvers must not fall back to shared /tmp/.gc

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -160,11 +160,22 @@ func defaultGCHome() string {
 	if strings.HasSuffix(os.Args[0], ".test") {
 		return ""
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(os.TempDir(), ".gc")
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".gc")
 	}
-	return filepath.Join(home, ".gc")
+	// Home unresolved. Never fall back to a fixed os.TempDir()/.gc: that path
+	// is shared and world-writable, so concurrent processes clobber each
+	// other's state and unrelated city scans pick it up as a real city
+	// (#3506). Hand out a process-unique directory instead.
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	// MkdirTemp failed, so the temp directory itself is unusable. Return a
+	// process-unique path under it rather than "" (which callers would join
+	// into a CWD-relative path, silently writing state to the wrong place) or
+	// the shared os.TempDir()/.gc that #3506 is about. The caller then fails
+	// loudly when it cannot create or write this path.
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
 }
 
 func bootstrapPackRevision(entry Entry) (string, error) {

--- a/internal/bootstrap/home_fallback_test.go
+++ b/internal/bootstrap/home_fallback_test.go
@@ -1,0 +1,38 @@
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDefaultGCHomeAvoidsSharedTempFallback guards #3650 (sibling of #3506):
+// when GC_HOME is unset and the user home cannot be resolved, defaultGCHome()
+// must not hand back the shared os.TempDir()/.gc path. That path is
+// world-writable and shared across every process and user on the host, so
+// concurrent processes clobber each other's state and unrelated city scans
+// pick it up as a real city.
+func TestDefaultGCHomeAvoidsSharedTempFallback(t *testing.T) {
+	// defaultGCHome() short-circuits to "" under a *.test binary to stay
+	// hermetic. Temporarily mask that guard so the fallback path is reached.
+	orig := os.Args[0]
+	os.Args[0] = "gc"
+	defer func() { os.Args[0] = orig }()
+
+	t.Setenv("GC_HOME", "")
+	t.Setenv("HOME", "") // forces os.UserHomeDir() to fail on unix
+
+	got := defaultGCHome()
+
+	if shared := filepath.Join(os.TempDir(), ".gc"); got == shared {
+		t.Fatalf("defaultGCHome() = %q, want a process-isolated path, not the shared %q", got, shared)
+	}
+	// Must never be empty: callers join the result into a path, so "" silently
+	// becomes a CWD-relative path and writes state to the wrong place.
+	if got == "" {
+		t.Fatal("defaultGCHome() returned an empty path; callers would write state to a CWD-relative path")
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("defaultGCHome() = %q, want an absolute process-isolated path", got)
+	}
+}

--- a/internal/config/home_fallback_test.go
+++ b/internal/config/home_fallback_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestImplicitGCHomeAvoidsSharedTempFallback guards #3650 (sibling of #3506):
+// when GC_HOME is unset and the user home cannot be resolved, ImplicitGCHome()
+// must not hand back the shared os.TempDir()/.gc path. That path is
+// world-writable and shared across every process and user on the host, so
+// concurrent processes clobber each other's state and unrelated city scans
+// pick it up as a real city.
+func TestImplicitGCHomeAvoidsSharedTempFallback(t *testing.T) {
+	// ImplicitGCHome() short-circuits to "" under a *.test binary to stay
+	// hermetic. Temporarily mask that guard so the fallback path is reached.
+	orig := os.Args[0]
+	os.Args[0] = "gc"
+	defer func() { os.Args[0] = orig }()
+
+	t.Setenv("GC_HOME", "")
+	t.Setenv("HOME", "") // forces os.UserHomeDir() to fail on unix
+
+	got := ImplicitGCHome()
+
+	if shared := filepath.Join(os.TempDir(), ".gc"); got == shared {
+		t.Fatalf("ImplicitGCHome() = %q, want a process-isolated path, not the shared %q", got, shared)
+	}
+	// Must never be empty: callers join the result into a path, so "" silently
+	// becomes a CWD-relative path and writes state to the wrong place.
+	if got == "" {
+		t.Fatal("ImplicitGCHome() returned an empty path; callers would write state to a CWD-relative path")
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("ImplicitGCHome() = %q, want an absolute process-isolated path", got)
+	}
+}

--- a/internal/config/implicit.go
+++ b/internal/config/implicit.go
@@ -80,11 +80,22 @@ func ImplicitGCHome() string {
 	if strings.HasSuffix(os.Args[0], ".test") {
 		return ""
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(os.TempDir(), ".gc")
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".gc")
 	}
-	return filepath.Join(home, ".gc")
+	// Home unresolved. Never fall back to a fixed os.TempDir()/.gc: that path
+	// is shared and world-writable, so concurrent processes clobber each
+	// other's state and unrelated city scans pick it up as a real city
+	// (#3506). Hand out a process-unique directory instead.
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	// MkdirTemp failed, so the temp directory itself is unusable. Return a
+	// process-unique path under it rather than "" (which callers would join
+	// into a CWD-relative path, silently writing state to the wrong place) or
+	// the shared os.TempDir()/.gc that #3506 is about. The caller then fails
+	// loudly when it cannot create or write this path.
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
 }
 
 // GlobalRepoCacheRoot returns the user-global repo cache root

--- a/internal/supervisor/config.go
+++ b/internal/supervisor/config.go
@@ -158,11 +158,22 @@ func DefaultHome() string {
 }
 
 func builtinDefaultHome() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(os.TempDir(), ".gc")
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".gc")
 	}
-	return filepath.Join(home, ".gc")
+	// Home unresolved. Never fall back to a fixed os.TempDir()/.gc: that path
+	// is shared and world-writable, so concurrent processes clobber each
+	// other's state and unrelated city scans pick it up as a real city
+	// (#3506). Hand out a process-unique directory instead.
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	// MkdirTemp failed, so the temp directory itself is unusable. Return a
+	// process-unique path under it rather than "" (which callers would join
+	// into a CWD-relative path, silently writing state to the wrong place) or
+	// the shared os.TempDir()/.gc that #3506 is about. The caller then fails
+	// loudly when it cannot create or write this path.
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
 }
 
 // UsesIsolatedGCHomeOverride reports whether GC_HOME points away from the builtin ~/.gc default.

--- a/internal/supervisor/home_fallback_test.go
+++ b/internal/supervisor/home_fallback_test.go
@@ -1,0 +1,31 @@
+package supervisor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBuiltinDefaultHomeAvoidsSharedTempFallback guards #3650 (sibling of
+// #3506): when the user home cannot be resolved, builtinDefaultHome() must not
+// hand back the shared os.TempDir()/.gc path. That path is world-writable and
+// shared across every process and user on the host, so concurrent processes
+// clobber each other's state and unrelated city scans pick it up as a real
+// city. builtinDefaultHome() carries no *.test guard, so it is called directly.
+func TestBuiltinDefaultHomeAvoidsSharedTempFallback(t *testing.T) {
+	t.Setenv("HOME", "") // forces os.UserHomeDir() to fail on unix
+
+	got := builtinDefaultHome()
+
+	if shared := filepath.Join(os.TempDir(), ".gc"); got == shared {
+		t.Fatalf("builtinDefaultHome() = %q, want a process-isolated path, not the shared %q", got, shared)
+	}
+	// Must never be empty: callers join the result into a path, so "" silently
+	// becomes a CWD-relative path and writes state to the wrong place.
+	if got == "" {
+		t.Fatal("builtinDefaultHome() returned an empty path; callers would write state to a CWD-relative path")
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("builtinDefaultHome() = %q, want an absolute process-isolated path", got)
+	}
+}


### PR DESCRIPTION
## Summary

`#3548` (closed `#3506`) fixed `gchome.Default()` to hand out a process-unique
directory when the user home cannot be resolved, instead of the shared,
world-writable `os.TempDir()/.gc`. Three sibling home resolvers still carried
the original shared-fallback bug:

| Function | Location |
| --- | --- |
| `defaultGCHome()` | `internal/bootstrap/bootstrap.go` |
| `builtinDefaultHome()` | `internal/supervisor/config.go` |
| `ImplicitGCHome()` | `internal/config/implicit.go` |

Each returned the fixed `os.TempDir()/.gc` when `os.UserHomeDir()` failed. That
path is world-writable and shared across every process and user on the host, so
concurrent `gc` processes clobber each other's state and unrelated city scans
pick it up as a real city — the same failure mode as `#3506`.

## Fix

Mirror the `#3548` shape in each resolver: on home-resolution failure, hand out
a process-unique `os.MkdirTemp("", "gc-home-*")` directory, falling back to a
PID-stamped path under `TempDir` only if `MkdirTemp` itself fails. The existing
`GC_HOME` and `*.test` hermetic guards are preserved.

## Tests

One regression test per package (mirroring
`internal/gchome/gchome_test.go::TestDefaultAvoidsSharedTempFallback`): with
`GC_HOME`/`HOME` unset, each resolver must not return the shared
`os.TempDir()/.gc`, must not return `""`, and must return an absolute path.

Closes #3650.