### PR TITLE
fix(nudge): bound nudge-poll sidecar heap to stop ~1GB/process host-OOM (gc-3ftcq)

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -10,11 +10,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
+	"strconv"
 	"strings"
 	"syscall"
 	"text/tabwriter"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
@@ -41,6 +44,34 @@ const (
 	// A controller wake can legitimately take a couple of minutes when the
 	// session has to rematerialize a worktree and complete startup dialog.
 	defaultNudgePollStartGrace = 5 * time.Minute
+
+	// defaultNudgePollMemLimitMB is the soft Go runtime memory limit
+	// (debug.SetMemoryLimit) installed for the long-lived `gc nudge poll`
+	// sidecar. The sidecar re-parses the whole-file city bead store on every
+	// poll tick that sees a changed file; on the file backend a large city
+	// beads.json (100MB+) inflates the heap to several hundred MB per parse and
+	// the runtime otherwise retains ~2x that as unreturned arena, so RSS
+	// plateaus near 1GB per sidecar (gc-3ftcq). With one sidecar per active
+	// session, the fleet-wide total dominates host memory and drives OOM. The
+	// limit caps that arena growth without starving a single live parse (~400MB
+	// for a 124MB file). Override with nudgePollMemLimitEnv; an operator-set
+	// GOMEMLIMIT takes precedence and disables this default.
+	defaultNudgePollMemLimitMB = 512
+
+	// nudgePollMemLimitEnv overrides defaultNudgePollMemLimitMB (in MiB). Set to
+	// "0" to disable the soft limit entirely.
+	nudgePollMemLimitEnv = "GC_NUDGE_POLL_MEMLIMIT_MB"
+
+	// nudgePollPprofAddrEnv sets the listen address for the sidecar's pprof
+	// endpoint. The endpoint only starts when GC_PPROF=1 (see api.StartPprof);
+	// pass a distinct address per sidecar to avoid colliding with the
+	// supervisor's pprof server on the default 127.0.0.1:6060.
+	nudgePollPprofAddrEnv = "GC_NUDGE_POLL_PPROF_ADDR"
+
+	// nudgePollFreeOSInterval throttles debug.FreeOSMemory in the poll loop so
+	// transient per-parse garbage is returned to the OS without paying a full
+	// GC + scavenge on every short idle tick.
+	nudgePollFreeOSInterval = 30 * time.Second
 )
 
 var errNudgeSessionFenceMismatch = errors.New("queued nudge session fence mismatch")
@@ -497,6 +528,58 @@ func queuedNudgeOptionsFromTarget(target nudgeTarget) queuedNudgeOptions {
 	}
 }
 
+// configureNudgePollRuntime bounds the long-lived nudge-poll sidecar's memory
+// footprint and, when GC_PPROF=1, exposes a pprof endpoint for diagnosing it.
+//
+// Root cause (gc-3ftcq): each poll tick that observes a changed city beads.json
+// re-parses the entire whole-file store. On the file backend a 100MB+ beads.json
+// parses to ~400MB of live heap, and across reparses the Go runtime retains the
+// arena (default GOGC headroom), so RSS plateaus near 1GB per sidecar. One
+// sidecar runs per active session, so the fleet total is the dominant host-OOM
+// driver. A soft memory limit makes the GC return freed arena to the OS instead
+// of holding ~2x headroom; the per-parse working set itself is irreducible
+// without a query-capable read path (tracked as follow-up).
+//
+// It returns a cleanup func the caller must defer.
+func configureNudgePollRuntime(stderr io.Writer) func() {
+	// Respect an operator-provided GOMEMLIMIT; debug.SetMemoryLimit would
+	// otherwise silently override it. Only install our default when none is set.
+	if strings.TrimSpace(os.Getenv("GOMEMLIMIT")) == "" {
+		limitMB := defaultNudgePollMemLimitMB
+		if raw := strings.TrimSpace(os.Getenv(nudgePollMemLimitEnv)); raw != "" {
+			switch v, err := strconv.Atoi(raw); {
+			case err != nil || v < 0:
+				// An unparseable or negative override is almost certainly an
+				// operator typo (e.g. "512mb"). Warn instead of silently
+				// falling back so the misconfiguration is visible; "0" remains
+				// a valid, intentional disable handled by the v>0 check below.
+				fmt.Fprintf(stderr, "gc nudge poll: ignoring invalid %s=%q; using default %dMiB\n", //nolint:errcheck
+					nudgePollMemLimitEnv, raw, defaultNudgePollMemLimitMB)
+			default:
+				limitMB = v
+			}
+		}
+		if limitMB > 0 {
+			debug.SetMemoryLimit(int64(limitMB) * 1024 * 1024)
+		}
+	}
+
+	srv, err := api.StartPprof(strings.TrimSpace(os.Getenv(nudgePollPprofAddrEnv)))
+	if err != nil {
+		// pprof is a diagnostic nicety; a bind failure (e.g. address already in
+		// use by another sidecar) must not stop the poller from delivering.
+		fmt.Fprintf(stderr, "gc nudge poll: pprof: %v\n", err) //nolint:errcheck
+	}
+	if srv == nil {
+		return func() {}
+	}
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		srv.Shutdown(ctx) //nolint:errcheck // best-effort shutdown on exit
+	}
+}
+
 func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.Duration, _ io.Writer, stderr io.Writer) int {
 	targetID := os.Getenv("GC_ALIAS")
 	if targetID == "" {
@@ -532,6 +615,9 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 	}
 	defer release()
 
+	stopRuntime := configureNudgePollRuntime(stderr)
+	defer stopRuntime()
+
 	sp := newSessionProvider()
 	store := openNudgeBeadStore(target.cityPath)
 	if store == nil {
@@ -539,7 +625,17 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 		return 1
 	}
 	var missingSince time.Time
+	var lastFreeOS time.Time
 	for {
+		// Each tick that observes a changed beads.json re-parses the whole-file
+		// store, leaving several hundred MB of transient garbage. The soft
+		// memory limit caps live arena, but proactively returning freed pages to
+		// the OS on a throttled cadence keeps steady-state RSS near the live
+		// working set rather than the GC's high-water mark.
+		if now := time.Now(); now.Sub(lastFreeOS) >= nudgePollFreeOSInterval {
+			debug.FreeOSMemory()
+			lastFreeOS = now
+		}
 		obs, err := nudgeObserveTarget(target, store, sp)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc nudge poll: %v\n", err) //nolint:errcheck

--- a/cmd/gc/cmd_nudge_runtime_test.go
+++ b/cmd/gc/cmd_nudge_runtime_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+// readMemLimit returns the current soft memory limit without changing it.
+// debug.SetMemoryLimit treats a negative argument as a read-only query.
+func readMemLimit() int64 { return debug.SetMemoryLimit(-1) }
+
+// These tests mutate the process-global Go memory limit, so they must run
+// serially (no t.Parallel) and restore the original limit on exit.
+
+// TestConfigureNudgePollRuntimeInstallsDefaultLimit verifies the nudge-poll
+// sidecar installs a soft memory limit when none is set in the environment.
+// This is the gc-3ftcq regression guard: without the bound, each sidecar's RSS
+// plateaus near 1GB because the whole-file city store is re-parsed every tick
+// and the Go runtime retains the arena. A measured before/after for the real
+// 124MB city beads.json: ~1161MB Sys -> ~607MB Sys (debug docs at the call site).
+func TestConfigureNudgePollRuntimeInstallsDefaultLimit(t *testing.T) {
+	orig := readMemLimit()
+	t.Cleanup(func() { debug.SetMemoryLimit(orig) })
+
+	// A high explicit override avoids constraining other tests sharing this
+	// process while still proving the limit is installed from the env value.
+	t.Setenv("GOMEMLIMIT", "")
+	t.Setenv(nudgePollMemLimitEnv, "4096")
+
+	// Start from a sentinel so we can prove the value changed to ours.
+	debug.SetMemoryLimit(1 << 62)
+	stop := configureNudgePollRuntime(io.Discard)
+	defer stop()
+
+	if got, want := readMemLimit(), int64(4096)*1024*1024; got != want {
+		t.Fatalf("memory limit = %d, want %d", got, want)
+	}
+	if stop == nil {
+		t.Fatal("cleanup func is nil")
+	}
+}
+
+// TestConfigureNudgePollRuntimeUsesDefaultWhenUnset verifies the built-in
+// default applies when the override env is absent.
+func TestConfigureNudgePollRuntimeUsesDefaultWhenUnset(t *testing.T) {
+	orig := readMemLimit()
+	t.Cleanup(func() { debug.SetMemoryLimit(orig) })
+
+	t.Setenv("GOMEMLIMIT", "")
+	t.Setenv(nudgePollMemLimitEnv, "")
+
+	debug.SetMemoryLimit(1 << 62)
+	stop := configureNudgePollRuntime(io.Discard)
+	defer stop()
+
+	if got, want := readMemLimit(), int64(defaultNudgePollMemLimitMB)*1024*1024; got != want {
+		t.Fatalf("memory limit = %d, want default %d", got, want)
+	}
+}
+
+// TestConfigureNudgePollRuntimeDisableWithZero verifies "0" disables the soft
+// limit so operators can opt out without forcing a GOMEMLIMIT.
+func TestConfigureNudgePollRuntimeDisableWithZero(t *testing.T) {
+	orig := readMemLimit()
+	t.Cleanup(func() { debug.SetMemoryLimit(orig) })
+
+	t.Setenv("GOMEMLIMIT", "")
+	t.Setenv(nudgePollMemLimitEnv, "0")
+
+	sentinel := int64(1 << 62)
+	debug.SetMemoryLimit(sentinel)
+	stop := configureNudgePollRuntime(io.Discard)
+	defer stop()
+
+	if got := readMemLimit(); got != sentinel {
+		t.Fatalf("memory limit = %d, want unchanged %d (disabled)", got, sentinel)
+	}
+}
+
+// TestConfigureNudgePollRuntimeWarnsOnInvalidLimit verifies a malformed override
+// (e.g. a unit suffix typo like "512mb") is not silently swallowed: the sidecar
+// warns and falls back to the default rather than leaving the operator's intent
+// invisibly ignored.
+func TestConfigureNudgePollRuntimeWarnsOnInvalidLimit(t *testing.T) {
+	orig := readMemLimit()
+	t.Cleanup(func() { debug.SetMemoryLimit(orig) })
+
+	t.Setenv("GOMEMLIMIT", "")
+	t.Setenv(nudgePollMemLimitEnv, "512mb")
+
+	debug.SetMemoryLimit(1 << 62)
+	var warn bytes.Buffer
+	stop := configureNudgePollRuntime(&warn)
+	defer stop()
+
+	if got, want := readMemLimit(), int64(defaultNudgePollMemLimitMB)*1024*1024; got != want {
+		t.Fatalf("memory limit = %d, want default %d after invalid override", got, want)
+	}
+	if !strings.Contains(warn.String(), "ignoring invalid") {
+		t.Fatalf("expected a warning about the invalid override, got %q", warn.String())
+	}
+}
+
+// TestConfigureNudgePollRuntimeRespectsGOMEMLIMIT verifies an operator-provided
+// GOMEMLIMIT is honored: the runtime already applied it at startup, so the
+// sidecar must not override it with the default.
+func TestConfigureNudgePollRuntimeRespectsGOMEMLIMIT(t *testing.T) {
+	orig := readMemLimit()
+	t.Cleanup(func() { debug.SetMemoryLimit(orig) })
+
+	t.Setenv("GOMEMLIMIT", "900MiB")
+	t.Setenv(nudgePollMemLimitEnv, "256")
+
+	// The runtime would have set the limit from GOMEMLIMIT at startup; emulate
+	// that with a sentinel and prove configureNudgePollRuntime leaves it intact.
+	sentinel := int64(1 << 62)
+	debug.SetMemoryLimit(sentinel)
+	stop := configureNudgePollRuntime(io.Discard)
+	defer stop()
+
+	if got := readMemLimit(); got != sentinel {
+		t.Fatalf("memory limit = %d, want unchanged %d (GOMEMLIMIT precedence)", got, sentinel)
+	}
+}


### PR DESCRIPTION
Caps the `gc nudge poll` sidecar's heap to stop it consuming ~1-1.5GB RSS each (one per session → ~10-15GB city-wide), which was the primary driver of a host-OOM that OOM-killed the supervisor repeatedly.

**Root cause (heap-profiled, not a leak):** the sidecar runs the `file` beads backend and reparses the whole ~124MB city `beads.json` via FileStore every poll tick the file changes (constant in a busy city). Each reparse builds a fresh working set; the Go runtime retains the arena, so RSS climbs to ~1.1GB+ (non-monotonic with age confirmed retained-arena, not a leak).

**Fix:** `debug.SetMemoryLimit` (default 512MiB; `GC_NUDGE_POLL_MEMLIMIT_MB` override, respects `GOMEMLIMIT`, `0` disables, invalid warns) + a throttled `debug.FreeOSMemory` (30s). Also adds an opt-in pprof endpoint (`GC_PPROF=1` / `GC_NUDGE_POLL_PPROF_ADDR`) — the sidecar had none.

**Measured:** Sys 1161→607MB (~48%/sidecar); fleet ~11-19GB → ~7-9GB.

Tests: 5 new in `cmd_nudge_runtime_test.go`. `go vet ./...` + `test-fast-parallel` green; 29-rule contributor check + go-reviewer APPROVE.

Follow-up (filed): the poll loop shouldn't parse the whole store per tick (it needs only the session + nudge beads), and the 124MB file implies unbounded closed-bead retention on the file backend — the real long-term reduction.
