### PR TITLE
fix(gchome): isolate fallback temp directories

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -153,6 +153,13 @@ func EnsureBootstrapForCity(gcHome string, userImports map[string]config.Import)
 	return nil
 }
 
+func defaultGCHomeFallback() string {
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
+}
+
 func defaultGCHome() string {
 	if v := strings.TrimSpace(os.Getenv("GC_HOME")); v != "" {
 		return v
@@ -162,7 +169,7 @@ func defaultGCHome() string {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".gc")
+		return defaultGCHomeFallback()
 	}
 	return filepath.Join(home, ".gc")
 }

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -7,6 +7,19 @@ import (
 	"testing"
 )
 
+func TestDefaultGCHomeAvoidsSharedTempFallback(t *testing.T) {
+	got := defaultGCHomeFallback()
+	if got == "" {
+		t.Fatal("defaultGCHomeFallback: got empty string")
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("defaultGCHomeFallback: got non-absolute path %q", got)
+	}
+	if got == filepath.Join(os.TempDir(), ".gc") {
+		t.Fatalf("defaultGCHomeFallback: got shared temp fallback %q", got)
+	}
+}
+
 func TestEnsureBootstrapLeavesFreshHomesAlone(t *testing.T) {
 	gcHome := t.TempDir()
 	if err := EnsureBootstrap(gcHome); err != nil {

--- a/internal/config/implicit.go
+++ b/internal/config/implicit.go
@@ -66,6 +66,13 @@ func implicitImportPath() string {
 	return filepath.Join(home, "implicit-import.toml")
 }
 
+func implicitGCHomeFallback() string {
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
+}
+
 // ImplicitGCHome returns the user-global GC_HOME directory used to
 // resolve implicit-import bookkeeping and bootstrap pack caches.
 //
@@ -82,7 +89,7 @@ func ImplicitGCHome() string {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".gc")
+		return implicitGCHomeFallback()
 	}
 	return filepath.Join(home, ".gc")
 }

--- a/internal/config/implicit_test.go
+++ b/internal/config/implicit_test.go
@@ -8,6 +8,19 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
+func TestImplicitGCHomeAvoidsSharedTempFallback(t *testing.T) {
+	got := implicitGCHomeFallback()
+	if got == "" {
+		t.Fatal("implicitGCHomeFallback: got empty string")
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("implicitGCHomeFallback: got non-absolute path %q", got)
+	}
+	if got == filepath.Join(os.TempDir(), ".gc") {
+		t.Fatalf("implicitGCHomeFallback: got shared temp fallback %q", got)
+	}
+}
+
 func TestReadImplicitImports_MissingFile(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 

--- a/internal/supervisor/config.go
+++ b/internal/supervisor/config.go
@@ -157,10 +157,17 @@ func DefaultHome() string {
 	return builtinDefaultHome()
 }
 
+func builtinDefaultHomeFallback() string {
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
+}
+
 func builtinDefaultHome() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".gc")
+		return builtinDefaultHomeFallback()
 	}
 	return filepath.Join(home, ".gc")
 }

--- a/internal/supervisor/config_test.go
+++ b/internal/supervisor/config_test.go
@@ -8,6 +8,19 @@ import (
 	"time"
 )
 
+func TestBuiltinDefaultHomeAvoidsSharedTempFallback(t *testing.T) {
+	got := builtinDefaultHomeFallback()
+	if got == "" {
+		t.Fatal("builtinDefaultHomeFallback: got empty string")
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("builtinDefaultHomeFallback: got non-absolute path %q", got)
+	}
+	if got == filepath.Join(os.TempDir(), ".gc") {
+		t.Fatalf("builtinDefaultHomeFallback: got shared temp fallback %q", got)
+	}
+}
+
 func TestLoadConfigMissing(t *testing.T) {
 	cfg, err := LoadConfig("/nonexistent/supervisor.toml")
 	if err != nil {

--- a/release-gates/ga-x5xmd1-gchome-fallback-gate.md
+++ b/release-gates/ga-x5xmd1-gchome-fallback-gate.md
@@ -1,0 +1,54 @@
+# Release Gate: ga-x5xmd1 GCHome fallback isolation
+
+Gate run: 2026-06-22
+
+## Scope
+
+- Deploy bead: `ga-x5xmd1`
+- Review bead: `ga-mxx6wy`
+- Source commit reviewed: `48ac0ae9e`
+- Final PR branch: `release/ga-x5xmd1-gchome-fallback`
+- Final branch base: `origin/main`
+- Applied commit on final branch: `57a935f24`
+
+The reviewed commit was originally on `builder/ga-mjkqhb-extmsg-subscribe-clean`.
+That source branch also contained unrelated extmsg/dashboard commits. The release
+branch was cut cleanly from `origin/main` and contains only the reviewed GCHome
+fallback patch plus this gate file.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-mxx6wy` is closed with review verdict PASS for commit `48ac0ae9e`. |
+| 2 | Acceptance criteria met | PASS | `ga-hw9hfd`, `ga-6vrlw0`, and `ga-c7s52e` are closed. The final diff updates `defaultGCHomeFallback`, `implicitGCHomeFallback`, and `builtinDefaultHomeFallback` to use process-unique `gc-home-*` temp dirs with PID fallback, and adds the three requested tests. |
+| 3 | Tests pass | PASS | `go test ./internal/bootstrap ./internal/config ./internal/supervisor`; `go vet ./internal/bootstrap ./internal/config ./internal/supervisor`; `make test-fast-parallel`; `go vet ./...`. |
+| 4 | No high-severity review findings open | PASS | Review notes list only LOW informational findings: duplicate small helper bodies and temp-dir cleanup in fallback path. No HIGH findings. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed only `## release/ga-x5xmd1-gchome-fallback...origin/main [ahead 1]`. The gate file is committed as the final branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | Branch was created from `origin/main`; `git cherry-pick 48ac0ae9e` completed without conflicts; `git merge-tree origin/main HEAD` reported no conflict records. |
+| 7 | Single feature theme | PASS | Final branch touches only GCHome fallback path selection and adjacent tests in `internal/bootstrap`, `internal/config`, and `internal/supervisor`. The unrelated extmsg stack from the source branch is not included. |
+
+## Test Output Summary
+
+```text
+go test ./internal/bootstrap ./internal/config ./internal/supervisor
+ok  	github.com/gastownhall/gascity/internal/bootstrap	0.062s
+ok  	github.com/gastownhall/gascity/internal/config	1.761s
+ok  	github.com/gastownhall/gascity/internal/supervisor	0.468s
+
+go vet ./internal/bootstrap ./internal/config ./internal/supervisor
+PASS
+
+make test-fast-parallel
+[unit-cmd-gc-3-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-6-of-6] ok
+[unit-cmd-gc-1-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-core] ok
+All fast jobs passed
+
+go vet ./...
+PASS
+```


### PR DESCRIPTION
## What this changes

When Gas City cannot resolve the user's home directory, the bootstrap, implicit-import, and supervisor GC_HOME fallbacks no longer point every process at the shared `os.TempDir()/.gc` path. Each fallback now creates a process-unique `gc-home-*` temporary directory, with a PID-suffixed fallback only if temporary directory creation itself fails.

Normal `GC_HOME` and `~/.gc` behavior is unchanged. This only affects the error path where the OS cannot report a home directory, which previously allowed concurrent processes to collide in the same shared temp GC home.

## Review notes

- The PR branch is cut cleanly from `origin/main` and contains only the GCHome fallback patch plus the release gate.
- The changed surfaces are `internal/bootstrap`, `internal/config`, and `internal/supervisor`.
- The implementation keeps the fallback helpers package-local to avoid adding a new dependency path between these packages.

## Test plan

- [x] `go test ./internal/bootstrap ./internal/config ./internal/supervisor`
- [x] `go vet ./internal/bootstrap ./internal/config ./internal/supervisor`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-x5xmd1-gchome-fallback-gate.md`](release-gates/ga-x5xmd1-gchome-fallback-gate.md)
