### PR TITLE
feat(hook): record current run_id on the session bead at claim

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -43,7 +43,9 @@ type hookClaimOps struct {
 	ResolveWorkBranch hookResolveWorkBranchFunc
 	// StampWorkBranch writes gc.work_branch onto the claimed bead. Best-effort.
 	StampWorkBranch hookStampWorkBranchFunc
-	Now             func() time.Time
+	// RecordRunID writes gc.current_run_id onto the session bead. Best-effort.
+	RecordRunID hookRecordRunIDFunc
+	Now         func() time.Time
 }
 
 type (
@@ -54,6 +56,7 @@ type (
 	hookEmitClaimRejectedFunc  func(beadID, existingClaimant, attemptedClaimant string)
 	hookResolveWorkBranchFunc  func(dir string) string
 	hookStampWorkBranchFunc    func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
+	hookRecordRunIDFunc        func(ctx context.Context, dir string, env []string, sessionBeadID, runID string) error
 )
 
 type hookClaimJSONResult struct {
@@ -101,6 +104,9 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 	}
 	if ops.StampWorkBranch == nil {
 		ops.StampWorkBranch = hookStampWorkBranchWithBdStore
+	}
+	if ops.RecordRunID == nil {
+		ops.RecordRunID = hookRecordRunIDWithBdStore
 	}
 	now := time.Now
 	if ops.Now != nil {
@@ -220,6 +226,7 @@ func hookClaimExistingOrAssigned(candidates []beads.Bead, opts hookClaimOptions)
 
 func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stdout, stderr io.Writer) int {
 	stampHookWorkBranch(bead, opts, ops, dir, stderr)
+	recordHookClaimRunID(bead, opts, ops, dir, stderr)
 	assigned, err := preassignHookContinuationGroup(bead, opts, ops, dir)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc hook --claim: preassigning continuation group for %s: %v\n", bead.ID, err) //nolint:errcheck
@@ -341,6 +348,45 @@ func stampHookWorkBranch(bead beads.Bead, opts hookClaimOptions, ops hookClaimOp
 func hookStampWorkBranchWithBdStore(_ context.Context, dir string, env []string, beadID, assignee, branch string) error {
 	store := hookClaimBdStore(dir, env, assignee)
 	return store.Update(beadID, beads.UpdateOpts{Metadata: map[string]string{beadmeta.WorkBranchMetadataKey: branch}})
+}
+
+// recordHookClaimRunID records, on the session bead named by GC_SESSION_ID, the
+// run this session is now working: beadmeta.ResolveRunID of the just-claimed
+// bead, the same resolver the usage-fact emitters use (internal/worker), so a
+// per-request reader of the session bead resolves the same run id its model and
+// compute facts carry. A bead with no run chain resolves to its own id, so a
+// standalone unit is its own run and is never misattributed to a previous run on
+// this reused session bead. Best-effort:
+// a non-session run (no GC_SESSION_ID) or a write error never blocks the claim.
+func recordHookClaimRunID(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) {
+	sessionBeadID := hookClaimSessionID(opts.Env)
+	if sessionBeadID == "" {
+		return
+	}
+	runID := beadmeta.ResolveRunID(bead.Metadata, bead.ID, sessionBeadID)
+	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
+	defer cancel()
+	if err := ops.RecordRunID(ctx, dir, opts.Env, sessionBeadID, runID); err != nil {
+		fmt.Fprintf(stderr, "gc hook --claim: recording run_id on session bead %s: %v\n", sessionBeadID, err) //nolint:errcheck
+	}
+}
+
+func hookRecordRunIDWithBdStore(_ context.Context, dir string, env []string, sessionBeadID, runID string) error {
+	store := hookClaimBdStore(dir, env, "")
+	return store.Update(sessionBeadID, beads.UpdateOpts{Metadata: map[string]string{beadmeta.CurrentRunIDMetadataKey: runID}})
+}
+
+// hookClaimSessionID returns the session bead id (GC_SESSION_ID) from the claim
+// env, the override-sanitized value the rest of the claim path uses; it is empty
+// for a non-session run (cmd_hook.go blanks GC_SESSION_ID outside a session).
+func hookClaimSessionID(env []string) string {
+	sessionID := ""
+	for _, entry := range env {
+		if k, v, ok := strings.Cut(entry, "="); ok && k == "GC_SESSION_ID" {
+			sessionID = v
+		}
+	}
+	return strings.TrimSpace(sessionID)
 }
 
 // hookResolveWorkBranch returns the current git branch of dir, or "" when dir

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -56,7 +56,7 @@ type (
 	hookEmitClaimRejectedFunc  func(beadID, existingClaimant, attemptedClaimant string)
 	hookResolveWorkBranchFunc  func(dir string) string
 	hookStampWorkBranchFunc    func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
-	hookRecordRunIDFunc        func(ctx context.Context, dir string, env []string, sessionBeadID, runID string) error
+	hookRecordRunIDFunc        func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID string) error
 )
 
 type hookClaimJSONResult struct {
@@ -84,30 +84,7 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 		fmt.Fprintln(stderr, "gc hook --claim: missing work query runner") //nolint:errcheck
 		return 1
 	}
-	if ops.Claim == nil {
-		ops.Claim = hookClaimWithBdStore
-	}
-	if ops.ListContinuation == nil {
-		ops.ListContinuation = hookListContinuationWithBdStore
-	}
-	if ops.AssignContinuation == nil {
-		ops.AssignContinuation = hookAssignContinuationWithBdStore
-	}
-	if ops.DrainAck == nil {
-		ops.DrainAck = hookRuntimeDrainAck
-	}
-	if ops.EmitClaimRejected == nil {
-		ops.EmitClaimRejected = hookEmitClaimRejected
-	}
-	if ops.ResolveWorkBranch == nil {
-		ops.ResolveWorkBranch = hookResolveWorkBranch
-	}
-	if ops.StampWorkBranch == nil {
-		ops.StampWorkBranch = hookStampWorkBranchWithBdStore
-	}
-	if ops.RecordRunID == nil {
-		ops.RecordRunID = hookRecordRunIDWithBdStore
-	}
+	ops.applyDefaults()
 	now := time.Now
 	if ops.Now != nil {
 		now = ops.Now
@@ -137,12 +114,48 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 		return writeHookClaimWorkResultForBead(result, bead, opts, ops, dir, stdout, stderr)
 	}
 
+	return claimFirstEligibleHookCandidate(candidates, opts, ops, dir, stdout, stderr)
+}
+
+// applyDefaults fills any unset op seam with its production implementation, so
+// callers (and tests) only override the seams they care about. Runner has no
+// default — a missing work-query runner is a caller error handled in doHookClaim.
+func (ops *hookClaimOps) applyDefaults() {
+	if ops.Claim == nil {
+		ops.Claim = hookClaimWithBdStore
+	}
+	if ops.ListContinuation == nil {
+		ops.ListContinuation = hookListContinuationWithBdStore
+	}
+	if ops.AssignContinuation == nil {
+		ops.AssignContinuation = hookAssignContinuationWithBdStore
+	}
+	if ops.DrainAck == nil {
+		ops.DrainAck = hookRuntimeDrainAck
+	}
+	if ops.EmitClaimRejected == nil {
+		ops.EmitClaimRejected = hookEmitClaimRejected
+	}
+	if ops.ResolveWorkBranch == nil {
+		ops.ResolveWorkBranch = hookResolveWorkBranch
+	}
+	if ops.StampWorkBranch == nil {
+		ops.StampWorkBranch = hookStampWorkBranchWithBdStore
+	}
+	if ops.RecordRunID == nil {
+		ops.RecordRunID = hookRecordRunIDWithBdStore
+	}
+}
+
+// claimFirstEligibleHookCandidate claims the first unassigned, route-matched
+// candidate and returns the exit code of the resulting work-result write, or the
+// terminal no-work result when none can be claimed. A claim lost to a different
+// live claimant is surfaced as a bead.claim_rejected event before moving on.
+func claimFirstEligibleHookCandidate(candidates []beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stdout, stderr io.Writer) int {
 	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
 	defer cancel()
 	for _, candidate := range candidates {
-		if strings.TrimSpace(candidate.ID) == "" ||
-			strings.TrimSpace(candidate.Assignee) != "" ||
-			!hookClaimMatchesRoute(candidate, opts.RouteTargets) {
+		if !hookCandidateClaimable(candidate, opts.RouteTargets) {
 			continue
 		}
 		claimed, ok, err := ops.Claim(ctx, dir, opts.Env, candidate.ID, opts.Assignee)
@@ -151,16 +164,7 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 			return 1
 		}
 		if !ok {
-			// Lost the claim to a concurrent worker. When the conflicting
-			// claimant is known (Claim re-read the bead and it is owned by
-			// someone other than us), surface the race as an observable
-			// bead.claim_rejected event rather than silently re-trying the next
-			// candidate (ADR-0009). An empty/own assignee means the winner is
-			// unknown or it is us — no rejection to report.
-			if existing := strings.TrimSpace(claimed.Assignee); existing != "" &&
-				!hookClaimHasIdentity(claimed.Assignee, opts.IdentityCandidates) {
-				ops.EmitClaimRejected(candidate.ID, existing, opts.Assignee)
-			}
+			reportHookClaimRejected(candidate, claimed, opts, ops)
 			continue
 		}
 		if claimed.Metadata == nil {
@@ -186,6 +190,26 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 	}
 
 	return writeHookClaimNoWork(opts, ops, stdout, stderr)
+}
+
+// hookCandidateClaimable reports whether a work-query candidate is eligible for a
+// fresh claim: it has an id, is currently unassigned, and matches one of this
+// session's route targets.
+func hookCandidateClaimable(candidate beads.Bead, routeTargets []string) bool {
+	return strings.TrimSpace(candidate.ID) != "" &&
+		strings.TrimSpace(candidate.Assignee) == "" &&
+		hookClaimMatchesRoute(candidate, routeTargets)
+}
+
+// reportHookClaimRejected publishes a bead.claim_rejected event (ADR-0009) when a
+// claim was lost to a *different* live claimant. An empty or own-identity assignee
+// means the winner is unknown or is us, so there is no rejection to report.
+func reportHookClaimRejected(candidate, claimed beads.Bead, opts hookClaimOptions, ops hookClaimOps) {
+	existing := strings.TrimSpace(claimed.Assignee)
+	if existing == "" || hookClaimHasIdentity(claimed.Assignee, opts.IdentityCandidates) {
+		return
+	}
+	ops.EmitClaimRejected(candidate.ID, existing, opts.Assignee)
 }
 
 func hookClaimExistingOrAssigned(candidates []beads.Bead, opts hookClaimOptions) (hookClaimJSONResult, beads.Bead, bool) {
@@ -352,12 +376,27 @@ func hookStampWorkBranchWithBdStore(_ context.Context, dir string, env []string,
 
 // recordHookClaimRunID records, on the session bead named by GC_SESSION_ID, the
 // run this session is now working: beadmeta.ResolveRunID of the just-claimed
-// bead, the same resolver the usage-fact emitters use (internal/worker), so a
-// per-request reader of the session bead resolves the same run id its model and
-// compute facts carry. A bead with no run chain resolves to its own id, so a
+// bead, the same resolver the usage-fact emitters use (internal/worker). Those
+// emitters still resolve the run id from the session bead's own chain today;
+// once the deferred reader (ga-2m8abf) consumes gc.current_run_id, a per-request
+// reader of the session bead will yield the same run id the model and compute
+// facts carry. A bead with no run chain resolves to its own id, so a
 // standalone unit is its own run and is never misattributed to a previous run on
-// this reused session bead. Best-effort:
-// a non-session run (no GC_SESSION_ID) or a write error never blocks the claim.
+// this reused session bead. The write is unconditional on every claim by design:
+// the run id is a current-pointer that must follow a reused pool session onto its
+// new run, and the prior value isn't in hand here to guard against (only the work
+// bead and session id are). The only in-process idempotence guard available to
+// this subprocess is a pre-write read of the session bead — the controller's
+// CachingStore value-match guard is unreachable from here — so on a reused
+// session that re-stamps the same run id the cost is one redundant bd update and
+// its bead.updated event per claim. That is an accepted cost: claims are far less
+// frequent than the per-second no-op writes the CachingStore guard targets, and a
+// guard here would only trade the write for an equally unconditional read. The
+// write reuses the claiming assignee as the bd actor for parity with the
+// work_branch stamp, so both claim-time stamps attribute identically. Best-effort:
+// the bd write is bound to ctx, so a slow or stuck update cannot outlast
+// hookClaimMutationTimeout, and a non-session run (no GC_SESSION_ID), a timeout,
+// or a write error never blocks the claim.
 func recordHookClaimRunID(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) {
 	sessionBeadID := hookClaimSessionID(opts.Env)
 	if sessionBeadID == "" {
@@ -366,13 +405,13 @@ func recordHookClaimRunID(bead beads.Bead, opts hookClaimOptions, ops hookClaimO
 	runID := beadmeta.ResolveRunID(bead.Metadata, bead.ID, sessionBeadID)
 	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
 	defer cancel()
-	if err := ops.RecordRunID(ctx, dir, opts.Env, sessionBeadID, runID); err != nil {
+	if err := ops.RecordRunID(ctx, dir, opts.Env, opts.Assignee, sessionBeadID, runID); err != nil {
 		fmt.Fprintf(stderr, "gc hook --claim: recording run_id on session bead %s: %v\n", sessionBeadID, err) //nolint:errcheck
 	}
 }
 
-func hookRecordRunIDWithBdStore(_ context.Context, dir string, env []string, sessionBeadID, runID string) error {
-	store := hookClaimBdStore(dir, env, "")
+func hookRecordRunIDWithBdStore(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID string) error {
+	store := hookClaimBdStoreContext(ctx, dir, env, assignee)
 	return store.Update(sessionBeadID, beads.UpdateOpts{Metadata: map[string]string{beadmeta.CurrentRunIDMetadataKey: runID}})
 }
 
@@ -454,7 +493,14 @@ func hookRuntimeDrainAck(stderr io.Writer) error {
 }
 
 func hookClaimBdStore(dir string, env []string, actor string) *beads.BdStore {
-	return beads.NewBdStore(dir, beads.ExecCommandRunnerWithEnv(hookClaimEnvMap(env, dir, actor)))
+	return hookClaimBdStoreContext(context.Background(), dir, env, actor)
+}
+
+// hookClaimBdStoreContext is hookClaimBdStore with its bd commands bound to ctx,
+// so a best-effort claim-time write cannot outlast the caller's deadline even if
+// the underlying bd update stalls.
+func hookClaimBdStoreContext(ctx context.Context, dir string, env []string, actor string) *beads.BdStore {
+	return beads.NewBdStore(dir, beads.ExecCommandRunnerWithEnvContext(ctx, hookClaimEnvMap(env, dir, actor)))
 }
 
 func hookClaimEnvMap(env []string, dir string, actor string) map[string]string {

--- a/cmd/gc/cmd_hook_claim_runid_test.go
+++ b/cmd/gc/cmd_hook_claim_runid_test.go
@@ -11,18 +11,20 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// recordRunIDSpy captures the (sessionBeadID, runID) a claim records, and lets a
-// test inject a write error to prove the decoration never fails the claim.
+// recordRunIDSpy captures the (assignee, sessionBeadID, runID) a claim records,
+// and lets a test inject a write error to prove the decoration never fails the
+// claim. assignee is captured to pin actor parity with the work_branch stamp.
 type recordRunIDSpy struct {
-	calls   int
-	session string
-	runID   string
-	err     error
+	calls    int
+	assignee string
+	session  string
+	runID    string
+	err      error
 }
 
-func (s *recordRunIDSpy) fn(_ context.Context, _ string, _ []string, sessionBeadID, runID string) error {
+func (s *recordRunIDSpy) fn(_ context.Context, _ string, _ []string, assignee, sessionBeadID, runID string) error {
 	s.calls++
-	s.session, s.runID = sessionBeadID, runID
+	s.assignee, s.session, s.runID = assignee, sessionBeadID, runID
 	return s.err
 }
 
@@ -65,6 +67,9 @@ func TestDoHookClaimRecordsRunIDFromRunChain(t *testing.T) {
 	}
 	if spy.calls != 1 || spy.session != "sess-1" || spy.runID != "root-R1" {
 		t.Fatalf("record = {calls:%d session:%q runID:%q}, want {1 sess-1 root-R1}", spy.calls, spy.session, spy.runID)
+	}
+	if spy.assignee != "worker-1" {
+		t.Fatalf("record assignee = %q, want worker-1 (actor parity with the work_branch stamp)", spy.assignee)
 	}
 }
 
@@ -129,5 +134,44 @@ func TestDoHookClaimRunIDRecordFailureDoesNotFailClaim(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "recording run_id on session bead sess-1") {
 		t.Fatalf("stderr missing best-effort log line; got: %s", stderr.String())
+	}
+}
+
+// TestDoHookClaimRecordsRunIDOnExistingAssignment pins the run-chain projection
+// for the existing-assignment path: when gc hook --claim resumes a bead already
+// in_progress and owned by this session (no fresh Claim call), the run id is still
+// resolved from the candidate's metadata chain (gc.root_bead_id), not the bead's
+// own id. This guards against a future work-query projection that thins candidate
+// metadata silently switching the recorded value.
+func TestDoHookClaimRecordsRunIDOnExistingAssignment(t *testing.T) {
+	spy := &recordRunIDSpy{}
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) {
+			return `[{"id":"hw-existing","status":"in_progress","assignee":"worker-1","metadata":{"gc.routed_to":"worker","gc.root_bead_id":"root-R2"}}]`, nil
+		},
+		Claim: func(context.Context, string, []string, string, string) (beads.Bead, bool, error) {
+			t.Error("Claim must not be called on the existing-assignment path")
+			return beads.Bead{}, false, nil
+		},
+		ResolveWorkBranch: func(string) string { return "" }, // suppress work_branch stamp
+		RecordRunID:       spy.fn,
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		Env:                []string{"GC_SESSION_ID=sess-1"},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if spy.calls != 1 || spy.session != "sess-1" || spy.runID != "root-R2" {
+		t.Fatalf("record = {calls:%d session:%q runID:%q}, want {1 sess-1 root-R2}", spy.calls, spy.session, spy.runID)
+	}
+	if spy.assignee != "worker-1" {
+		t.Fatalf("record assignee = %q, want worker-1 (actor parity with the work_branch stamp)", spy.assignee)
 	}
 }

--- a/cmd/gc/cmd_hook_claim_runid_test.go
+++ b/cmd/gc/cmd_hook_claim_runid_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// recordRunIDSpy captures the (sessionBeadID, runID) a claim records, and lets a
+// test inject a write error to prove the decoration never fails the claim.
+type recordRunIDSpy struct {
+	calls   int
+	session string
+	runID   string
+	err     error
+}
+
+func (s *recordRunIDSpy) fn(_ context.Context, _ string, _ []string, sessionBeadID, runID string) error {
+	s.calls++
+	s.session, s.runID = sessionBeadID, runID
+	return s.err
+}
+
+// claimOpsForRunID builds the minimal seam for driving a successful fresh claim:
+// a routed/open candidate, a Claim that returns it owned by us, the work-branch
+// stamp suppressed, and the RecordRunID spy wired in.
+func claimOpsForRunID(beadID string, claimedMeta map[string]string, spy *recordRunIDSpy) (hookClaimOps, hookClaimOptions) {
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) {
+			return `[{"id":"` + beadID + `","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
+		},
+		Claim: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, bool, error) {
+			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Metadata: claimedMeta}, true, nil
+		},
+		ResolveWorkBranch: func(string) string { return "" }, // suppress work_branch stamp
+		RecordRunID:       spy.fn,
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		Env:                []string{"GC_SESSION_ID=sess-1"},
+		JSON:               true,
+	}
+	return ops, opts
+}
+
+// TestDoHookClaimRecordsRunIDFromRunChain: a claimed run bead stamps the session
+// bead with the run root resolved from its metadata chain (gc.root_bead_id here).
+func TestDoHookClaimRecordsRunIDFromRunChain(t *testing.T) {
+	spy := &recordRunIDSpy{}
+	ops, opts := claimOpsForRunID("hw-run", map[string]string{
+		"gc.routed_to":    "worker",
+		"gc.root_bead_id": "root-R1",
+	}, spy)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if spy.calls != 1 || spy.session != "sess-1" || spy.runID != "root-R1" {
+		t.Fatalf("record = {calls:%d session:%q runID:%q}, want {1 sess-1 root-R1}", spy.calls, spy.session, spy.runID)
+	}
+}
+
+// TestDoHookClaimRecordsRunIDFromOwnIDWhenNoRunChain is the no-run-id edge: a
+// worker grabbing work outside any run (no chain) resolves to the bead's OWN id
+// — a standalone unit is its own run, never misattributed to a prior run on the
+// reused session bead.
+func TestDoHookClaimRecordsRunIDFromOwnIDWhenNoRunChain(t *testing.T) {
+	spy := &recordRunIDSpy{}
+	ops, opts := claimOpsForRunID("hw-standalone", map[string]string{
+		"gc.routed_to": "worker",
+	}, spy)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if spy.calls != 1 || spy.session != "sess-1" || spy.runID != "hw-standalone" {
+		t.Fatalf("record = {calls:%d session:%q runID:%q}, want {1 sess-1 hw-standalone}", spy.calls, spy.session, spy.runID)
+	}
+}
+
+// TestDoHookClaimSkipsRunIDWhenNoSessionID: a non-session run (no GC_SESSION_ID)
+// has no session bead to stamp, so the record is skipped entirely.
+func TestDoHookClaimSkipsRunIDWhenNoSessionID(t *testing.T) {
+	spy := &recordRunIDSpy{}
+	ops, opts := claimOpsForRunID("hw-nosess", map[string]string{
+		"gc.routed_to":    "worker",
+		"gc.root_bead_id": "root-R1",
+	}, spy)
+	opts.Env = []string{"GC_ALIAS=worker-1"} // GC_SESSION_ID absent
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if spy.calls != 0 {
+		t.Fatalf("record calls = %d, want 0 (no session bead to stamp)", spy.calls)
+	}
+}
+
+// TestDoHookClaimRunIDRecordFailureDoesNotFailClaim: a failing run_id write is
+// best-effort decoration — it logs to stderr but the claim still succeeds and the
+// claimed bead id is still reported on stdout.
+func TestDoHookClaimRunIDRecordFailureDoesNotFailClaim(t *testing.T) {
+	spy := &recordRunIDSpy{err: errors.New("dolt boom")}
+	ops, opts := claimOpsForRunID("hw-err", map[string]string{
+		"gc.routed_to":    "worker",
+		"gc.root_bead_id": "root-R1",
+	}, spy)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0 (record error must not fail the claim); stderr=%s", code, stderr.String())
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.BeadID != "hw-err" || result.Reason != "claimed" {
+		t.Fatalf("claim result = %+v, want bead hw-err reason claimed", result)
+	}
+	if !strings.Contains(stderr.String(), "recording run_id on session bead sess-1") {
+		t.Fatalf("stderr missing best-effort log line; got: %s", stderr.String())
+	}
+}

--- a/engdocs/design/usage-facts-v0.md
+++ b/engdocs/design/usage-facts-v0.md
@@ -64,10 +64,16 @@ the session bead misattributes every later run to the first. Resolve
 4. plain work bead → its own id
 5. manual chat (no work bead) → `session.Info.ID`
 
-The worker learns the acting work bead via a **mutable** `gc.active_work_bead`
-pointer written on the session bead at dispatch (updated on every claim) plus
-`operationEventPayload.BeadID`; resolve at `operation_events.go:136` via the
-existing `GetWithBead` (`manager.go:1356`) or the dispatch-set `BeadID`. The
+v0 ships a **resolved-value** form of this. `gc hook --claim` resolves the run id
+from the just-claimed work bead (the order above) and writes it onto the session
+bead as `gc.current_run_id`, updated on **every** claim so a reused pool session
+follows its current run instead of staying frozen on its first. A per-operation
+reader then reads `gc.current_run_id` straight off the already-loaded session bead
+— no extra `GetWithBead`. The tradeoff: a resolved id, unlike a `gc.active_work_bead`
+*pointer*, cannot be re-resolved back to the acting work bead, so per-work-bead
+`step_id` attribution (`UsageFact.StepID`) is **not** preserved by this form; the
+pointer (resolve at `operation_events.go:136` via `GetWithBead`, `manager.go:1356`)
+stays the future option if `step_id` segmentation is wanted (open question 1). The
 session bead is a *current-pointer*, never a frozen id.
 
 ## Emission seams
@@ -155,8 +161,10 @@ rollup, else cost sums silently omit unpriced models.
 ## Decisions
 
 - `run_id` is **layered, resolved per-operation** from the acting work bead
-  (graph → poured → nested → self → session-id for manual chat), via a **mutable
-  `gc.active_work_bead` pointer** — never frozen on the session bead.
+  (graph → poured → nested → self → session-id for manual chat). v0 records the
+  resolved id on the session bead as `gc.current_run_id` at claim time (updated on
+  every claim, never frozen); a `gc.active_work_bead` pointer that would also keep
+  `step_id` stays a future option (run-identity section; open question 1).
 - Usage attaches to the **event-log** path (`WorkerOperation` payload) + the
   `Sink`, **not** OTel metric labels (which are cardinality-bounded by design).
 - Sink injection is the proven **`exec:<script>`** seam; the `usage.Sink`
@@ -179,14 +187,18 @@ above. Each keeps cost insight as decision-support (lossy by construction, per
 *Honest limits*) while avoiding larger changes the open questions below have not
 yet settled.
 
-- **Run identity is per-session for pooled sessions.** The mutable
-  `gc.active_work_bead` pointer is not yet written by any dispatch/claim path, so
-  per-work-bead (`step_id`) attribution is deferred and that metadata key is not
-  declared until a writer exists. RunID resolves per-operation off the session
-  bead's own run chain (`workflow_id || molecule_id || gc.root_bead_id-or-self ||
-  bead id || session id`), so a reused pool session rolls its facts up
-  per-session rather than per-run. Wiring the pointer at dispatch/claim is
-  tracked as follow-up (ga-2m8abf); see open question 1.
+- **Run identity is recorded per-run at claim; the reader is the remaining gap.**
+  `gc hook --claim` writes the resolved run id onto the session bead as
+  `gc.current_run_id` on every claim (`cmd/gc/cmd_hook_claim.go`), so a reused pool
+  session is stamped with its current run, not its first, and the key is declared
+  in `KnownMetadataKeys`. This value form intentionally drops per-work-bead
+  (`step_id`) attribution; a `gc.active_work_bead` pointer remains the future option
+  for it. The consumer side is staged behind the writer: `ResolveRunID` still
+  resolves per-operation off the session bead's own run chain (`workflow_id ||
+  molecule_id || gc.root_bead_id-or-self || bead id || session id`) and does **not**
+  yet read `gc.current_run_id`, so cost facts still roll up per-session until a
+  reader that consumes the recorded value lands (tracked as follow-up ga-2m8abf;
+  see open question 1).
 - **Compute facts emit from a reconcile scan, not a transactional outbox.** The
   reconcile tick scans the open session-bead snapshot it already loaded, emits a
   fact for any bead in a terminal state lacking its

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -57,6 +57,7 @@ const (
 	ControllerErrorClassMetadataKey      = "gc.controller_error_class"
 	ControllerErrorMetadataKey           = "gc.controller_error"
 	ControllerRetryableMetadataKey       = "gc.controller_retryable"
+	CurrentRunIDMetadataKey              = "gc.current_run_id"
 	DeferredAssigneeMetadataKey          = "gc.deferred_assignee"
 	DeferredExecutionRoutedToMetadataKey = "gc.deferred_execution_routed_to"
 	DeferredRoutedToMetadataKey          = "gc.deferred_routed_to"
@@ -243,6 +244,7 @@ var KnownMetadataKeys = []string{
 	ControllerErrorClassMetadataKey,
 	ControllerErrorMetadataKey,
 	ControllerRetryableMetadataKey,
+	CurrentRunIDMetadataKey,
 	DeferredAssigneeMetadataKey,
 	DeferredExecutionRoutedToMetadataKey,
 	DeferredRoutedToMetadataKey,

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -62,46 +62,37 @@ func ExecCommandRunner() CommandRunner {
 // applies the provided environment overrides. Explicit keys replace any
 // inherited values from the parent process.
 func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
+	return execCommandRunnerWithEnv(context.Background(), env)
+}
+
+// ExecCommandRunnerWithEnvContext is like ExecCommandRunnerWithEnv but binds
+// every command it runs to ctx, so each command exits at the sooner of ctx's
+// deadline and the per-command bd timeout. Callers with a short best-effort
+// budget (for example the claim-time gc.current_run_id decoration) use this so a
+// slow or stuck bd child cannot outlast that budget.
+func ExecCommandRunnerWithEnvContext(ctx context.Context, env map[string]string) CommandRunner {
+	return execCommandRunnerWithEnv(ctx, env)
+}
+
+func execCommandRunnerWithEnv(parent context.Context, env map[string]string) CommandRunner {
 	return func(dir, name string, args ...string) ([]byte, error) {
 		start := time.Now()
-		trace := func(status string, err error) {
-			// GC_BD_TRACE_JSON wins: when the structured JSONL trace
-			// (via TraceBDCall in bdtrace.go) is enabled, suppress the
-			// legacy line-format trace so the two don't interleave
-			// incompatible records in the same file when an operator
-			// points both env vars at the same path.
-			if strings.TrimSpace(os.Getenv("GC_BD_TRACE_JSON")) != "" {
-				return
-			}
-			path := strings.TrimSpace(os.Getenv("GC_BD_TRACE"))
-			if path == "" {
-				return
-			}
-			f, openErr := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-			if openErr != nil {
-				return
-			}
-			defer f.Close() //nolint:errcheck // best-effort trace log
-			msg := ""
-			if err != nil {
-				msg = err.Error()
-			}
-			fmt.Fprintf(f, "%s status=%s dur=%s dir=%s cmd=%s args=%q err=%q\n", //nolint:errcheck // best-effort trace log
-				time.Now().UTC().Format(time.RFC3339Nano), status, time.Since(start), dir, name, args, msg)
-		}
+		trace := newBDExecTrace(start, dir, name, args)
 		trace("start", nil)
+
 		timeout := bdCommandTimeoutFor(name, args)
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(parent, timeout)
 		defer cancel()
-		var slowTimer *time.Timer
+
 		if name == "bd" {
 			bdArgs := append([]string(nil), args...)
 			agentID := bdTelemetryAgentID(env)
-			slowTimer = time.AfterFunc(bdSlowTelemetryThreshold, func() {
+			slowTimer := time.AfterFunc(bdSlowTelemetryThreshold, func() {
 				telemetry.RecordBDSlow(ctx, bdArgs, dir, agentID)
 			})
 			defer slowTimer.Stop()
 		}
+
 		cmd := exec.CommandContext(ctx, name, args...)
 		cmd.WaitDelay = 2 * time.Second
 		prepareCommandForTimeout(cmd)
@@ -113,53 +104,118 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
 		out, err := cmd.Output()
-		if name == "bd" {
-			// Structured JSONL trace — independent of the legacy line-format
-			// trace above (gated by GC_BD_TRACE_JSON, not GC_BD_TRACE).
-			traceExit := 0
-			if err != nil {
-				var exitErr *exec.ExitError
-				if errors.As(err, &exitErr) {
-					traceExit = exitErr.ExitCode()
-				} else {
-					traceExit = -1
-				}
-			}
-			TraceBDCall("go:bdstore.runner", dir, args, start, traceExit, err)
-			telemetry.RecordBDCall(context.Background(),
-				args, float64(time.Since(start).Milliseconds()),
-				err, out, stderr.String())
-		}
-		if err == nil && name == "bd" && bdOutputIndicatesSilentFallback(stderr.String()) {
-			fallbackErr := fmt.Errorf("%w: %s", ErrBDSilentFallback, strings.TrimSpace(stderr.String()))
-			trace("error", fallbackErr)
-			return out, fallbackErr
-		}
-		if ctx.Err() == context.DeadlineExceeded {
-			timeoutErr := fmt.Errorf("timed out after %s", timeout)
-			trace("timeout", timeoutErr)
-			if stderr.Len() > 0 {
-				return out, fmt.Errorf("%w: %s", timeoutErr, stderr.String())
-			}
-			return out, timeoutErr
-		}
-		if err != nil {
-			// bd writes structured errors to stdout (JSON envelope) when
-			// invoked with --json, while stderr is often empty. Surface
-			// whichever stream has content so supervisor logs become
-			// actionable instead of bare "exit status 1".
-			detail := strings.TrimSpace(stderr.String())
-			if detail == "" && name == "bd" {
-				detail = bdStdoutErrorDetail(out)
-			}
-			if detail != "" {
-				trace("error", err)
-				return out, fmt.Errorf("%w: %s", err, detail)
-			}
-		}
-		trace("done", err)
-		return out, err
+
+		recordBDExecTelemetry(name, dir, args, start, out, stderr.String(), err)
+
+		status, traceErr, resultErr := classifyBDExecResult(
+			parent, ctx, name, timeout, start, out, stderr.String(), err)
+		trace(status, traceErr)
+		return out, resultErr
 	}
+}
+
+// newBDExecTrace returns the legacy line-format trace callback for one command
+// invocation. It is a no-op when GC_BD_TRACE is unset, or when GC_BD_TRACE_JSON
+// has claimed tracing (the structured JSONL trace in bdtrace.go) so the two
+// formats never interleave incompatible records when an operator points both
+// env vars at the same file. The returned callback appends one
+// "status=… dur=… cmd=… err=…" line per call.
+func newBDExecTrace(start time.Time, dir, name string, args []string) func(status string, err error) {
+	if strings.TrimSpace(os.Getenv("GC_BD_TRACE_JSON")) != "" {
+		return func(string, error) {}
+	}
+	path := strings.TrimSpace(os.Getenv("GC_BD_TRACE"))
+	if path == "" {
+		return func(string, error) {}
+	}
+	return func(status string, err error) {
+		f, openErr := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if openErr != nil {
+			return
+		}
+		defer f.Close() //nolint:errcheck // best-effort trace log
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		fmt.Fprintf(f, "%s status=%s dur=%s dir=%s cmd=%s args=%q err=%q\n", //nolint:errcheck // best-effort trace log
+			time.Now().UTC().Format(time.RFC3339Nano), status, time.Since(start), dir, name, args, msg)
+	}
+}
+
+// recordBDExecTelemetry emits the structured JSONL trace (bdtrace.go) and the
+// telemetry RecordBDCall for a completed "bd" invocation; it is a no-op for any
+// other command. The trace exit code is the child's exit status, or -1 when the
+// failure was not an *exec.ExitError (for example a context kill or a spawn
+// failure). It is independent of the legacy line-format trace (gated by
+// GC_BD_TRACE_JSON, not GC_BD_TRACE).
+func recordBDExecTelemetry(name, dir string, args []string, start time.Time, out []byte, stderr string, err error) {
+	if name != "bd" {
+		return
+	}
+	traceExit := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			traceExit = exitErr.ExitCode()
+		} else {
+			traceExit = -1
+		}
+	}
+	TraceBDCall("go:bdstore.runner", dir, args, start, traceExit, err)
+	telemetry.RecordBDCall(context.Background(),
+		args, float64(time.Since(start).Milliseconds()),
+		err, out, stderr)
+}
+
+// classifyBDExecResult maps a finished invocation to its legacy trace status,
+// the error to trace, and the error to return to the caller. The trace error
+// and the returned error differ only where the returned error is enriched with
+// stderr/stdout detail that the historical status-level trace line omits, so
+// the line-format trace stays compatible with prior releases. bd writes
+// structured errors to stdout (JSON envelope) under --json while stderr is
+// often empty, so the generic-error path surfaces whichever stream has content
+// rather than a bare "exit status 1".
+func classifyBDExecResult(parent, ctx context.Context, name string, timeout time.Duration, start time.Time, out []byte, stderr string, runErr error) (status string, traceErr, resultErr error) {
+	if runErr == nil && name == "bd" && bdOutputIndicatesSilentFallback(stderr) {
+		fallbackErr := fmt.Errorf("%w: %s", ErrBDSilentFallback, strings.TrimSpace(stderr))
+		return "error", fallbackErr, fallbackErr
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		timeoutErr := bdExecTimeoutError(parent, timeout, start)
+		if stderr != "" {
+			return "timeout", timeoutErr, fmt.Errorf("%w: %s", timeoutErr, stderr)
+		}
+		return "timeout", timeoutErr, timeoutErr
+	}
+	if runErr != nil {
+		detail := strings.TrimSpace(stderr)
+		if detail == "" && name == "bd" {
+			detail = bdStdoutErrorDetail(out)
+		}
+		if detail != "" {
+			return "error", runErr, fmt.Errorf("%w: %s", runErr, detail)
+		}
+	}
+	return "done", runErr, runErr
+}
+
+// bdExecTimeoutError formats the deadline error after the per-command context
+// expired, attributed to whichever budget actually won the race. ctx's
+// effective deadline is min(parent deadline, start+timeout): when the caller's
+// parent deadline is the binding one (for example the short claim-time
+// gc.current_run_id write budget), it reports that effective budget so the
+// failure is not misreported as the much larger per-command bd timeout; when
+// the per-command timer wins, it reports that timeout unchanged.
+func bdExecTimeoutError(parent context.Context, timeout time.Duration, start time.Time) error {
+	if deadline, ok := parent.Deadline(); ok && deadline.Before(start.Add(timeout)) {
+		budget := deadline.Sub(start)
+		if budget < 0 {
+			budget = 0
+		}
+		return fmt.Errorf("timed out after %s (caller deadline)", budget.Round(time.Millisecond))
+	}
+	return fmt.Errorf("timed out after %s", timeout)
 }
 
 func bdTelemetryAgentID(env map[string]string) string {

--- a/internal/beads/bdstore_exec_internal_test.go
+++ b/internal/beads/bdstore_exec_internal_test.go
@@ -41,6 +41,62 @@ func TestExecCommandRunnerTimesOut(t *testing.T) {
 	}
 }
 
+// TestExecCommandRunnerWithEnvContextHonorsParentDeadline proves the
+// context-aware runner binds each command to the caller's context: a parent
+// deadline well below bdCommandTimeout kills a long-running child promptly
+// instead of letting it run to the per-command budget. This is the seam the
+// best-effort claim-time gc.current_run_id write uses so a slow or stuck bd
+// update cannot outlast the claim's short mutation budget.
+func TestExecCommandRunnerWithEnvContextHonorsParentDeadline(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep unavailable")
+	}
+
+	// Leave bdCommandTimeout at its default so the only thing that can return
+	// the child quickly is the parent context, not the per-command timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := ExecCommandRunnerWithEnvContext(ctx, nil)(t.TempDir(), "sleep", "30")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("context-bound runner unexpectedly succeeded")
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("runner blocked %s; the 200ms parent deadline was ignored", elapsed)
+	}
+}
+
+// TestExecCommandRunnerWithEnvContextTimeoutReportsCallerDeadline proves the
+// timeout error is attributed to the caller's parent deadline when that budget
+// wins the race, not to the much larger per-command bd timeout. The claim-time
+// gc.current_run_id writer relies on this so a short claim-budget failure is not
+// misreported as "timed out after 2m0s".
+func TestExecCommandRunnerWithEnvContextTimeoutReportsCallerDeadline(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep unavailable")
+	}
+
+	// Leave the per-command timeout at its (large) default so only the short
+	// parent deadline can fire; the message must then report the parent budget.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err := ExecCommandRunnerWithEnvContext(ctx, nil)(t.TempDir(), "sleep", "30")
+	if err == nil {
+		t.Fatal("context-bound runner unexpectedly succeeded")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "caller deadline") {
+		t.Fatalf("timeout error = %q, want it attributed to the caller deadline", msg)
+	}
+	if perCommand := bdCommandTimeout.String(); strings.Contains(msg, perCommand) {
+		t.Fatalf("timeout error = %q, must not report the %s per-command timeout when the caller deadline won", msg, perCommand)
+	}
+}
+
 func TestBDCommandTimeoutForReadCommands(t *testing.T) {
 	if got := bdCommandTimeoutFor("bd", []string{"list", "--json"}); got != bdReadCommandTimeout {
 		t.Fatalf("bd list timeout = %s, want %s", got, bdReadCommandTimeout)


### PR DESCRIPTION
## What
`gc hook --claim` now records `gc.current_run_id` on the **session bead** (`GC_SESSION_ID`) at claim time, using `beadmeta.ResolveRunID` of the just-claimed bead — the same resolver `internal/worker` uses for usage facts. This puts a stable, per-request-readable handle to "the run this session is currently working" directly on the session bead.

## Why
Session-scoped telemetry needs to know, per request, which run a session is on. Resolving it through `beadmeta.ResolveRunID` keeps it identical to the run id a run's model facts and compute facts already carry, so a session's per-request reads and its usage facts group under one run id (no drift, no split rows).

## Behavior
- **Run work** → the resolved run root (`workflow_id` / `molecule_id` / `gc.root_bead_id`).
- **Work outside a run** (no run chain) → the bead's own id. A standalone unit is its own run, so it is never misattributed to a prior run on the long-lived, reused session bead.
- **Non-session run** (no `GC_SESSION_ID`) → skipped; there is no session bead to stamp.
- **Best-effort**: mirrors the existing `stampHookWorkBranch` (ADR-0009) pattern — its own timeout, swallow + log; a write error never fails or delays the claim, and the claim result is emitted regardless.

## Notes
- New key `beadmeta.CurrentRunIDMetadataKey`, declared and registered in `KnownMetadataKeys` and referenced via the constant (drift guard clean).
- `gc.current_run_id` is decoration on the session bead, never an authorization input.
- A per-request **reader** of `gc.current_run_id` is intentionally out of scope for this change (write side only).

## Tests
Seam-level tests via an injected `RecordRunID` (mirroring `TestDoHookClaimStampsWorkBranch`): resolves from the run chain, resolves to the bead's own id when there is no chain, skips when `GC_SESSION_ID` is absent, and a failing write does not fail the claim.

## Verification
`gofmt` clean · `golangci-lint` v2 — 0 issues · `go vet` clean · `go build ./...` · `go test ./internal/beadmeta/ ./cmd/gc/` green.
