### PR TITLE
fix(gchome): avoid shared temp fallback paths

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -153,6 +153,13 @@ func EnsureBootstrapForCity(gcHome string, userImports map[string]config.Import)
 	return nil
 }
 
+func defaultGCHomeFallback() string {
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
+}
+
 func defaultGCHome() string {
 	if v := strings.TrimSpace(os.Getenv("GC_HOME")); v != "" {
 		return v
@@ -162,7 +169,7 @@ func defaultGCHome() string {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".gc")
+		return defaultGCHomeFallback()
 	}
 	return filepath.Join(home, ".gc")
 }

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -7,6 +7,19 @@ import (
 	"testing"
 )
 
+func TestDefaultGCHomeAvoidsSharedTempFallback(t *testing.T) {
+	got := defaultGCHomeFallback()
+	if got == "" {
+		t.Fatal("defaultGCHomeFallback: got empty string")
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("defaultGCHomeFallback: got non-absolute path %q", got)
+	}
+	if got == filepath.Join(os.TempDir(), ".gc") {
+		t.Fatalf("defaultGCHomeFallback: got shared temp fallback %q", got)
+	}
+}
+
 func TestEnsureBootstrapLeavesFreshHomesAlone(t *testing.T) {
 	gcHome := t.TempDir()
 	if err := EnsureBootstrap(gcHome); err != nil {

--- a/internal/config/implicit.go
+++ b/internal/config/implicit.go
@@ -66,6 +66,13 @@ func implicitImportPath() string {
 	return filepath.Join(home, "implicit-import.toml")
 }
 
+func implicitGCHomeFallback() string {
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
+}
+
 // ImplicitGCHome returns the user-global GC_HOME directory used to
 // resolve implicit-import bookkeeping and bootstrap pack caches.
 //
@@ -82,7 +89,7 @@ func ImplicitGCHome() string {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".gc")
+		return implicitGCHomeFallback()
 	}
 	return filepath.Join(home, ".gc")
 }

--- a/internal/config/implicit_test.go
+++ b/internal/config/implicit_test.go
@@ -8,6 +8,19 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
+func TestImplicitGCHomeAvoidsSharedTempFallback(t *testing.T) {
+	got := implicitGCHomeFallback()
+	if got == "" {
+		t.Fatal("implicitGCHomeFallback: got empty string")
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("implicitGCHomeFallback: got non-absolute path %q", got)
+	}
+	if got == filepath.Join(os.TempDir(), ".gc") {
+		t.Fatalf("implicitGCHomeFallback: got shared temp fallback %q", got)
+	}
+}
+
 func TestReadImplicitImports_MissingFile(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 

--- a/internal/supervisor/config.go
+++ b/internal/supervisor/config.go
@@ -157,10 +157,17 @@ func DefaultHome() string {
 	return builtinDefaultHome()
 }
 
+func builtinDefaultHomeFallback() string {
+	if dir, err := os.MkdirTemp("", "gc-home-*"); err == nil {
+		return dir
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gc-home-%d", os.Getpid()))
+}
+
 func builtinDefaultHome() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".gc")
+		return builtinDefaultHomeFallback()
 	}
 	return filepath.Join(home, ".gc")
 }

--- a/internal/supervisor/config_test.go
+++ b/internal/supervisor/config_test.go
@@ -8,6 +8,19 @@ import (
 	"time"
 )
 
+func TestBuiltinDefaultHomeAvoidsSharedTempFallback(t *testing.T) {
+	got := builtinDefaultHomeFallback()
+	if got == "" {
+		t.Fatal("builtinDefaultHomeFallback: got empty string")
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("builtinDefaultHomeFallback: got non-absolute path %q", got)
+	}
+	if got == filepath.Join(os.TempDir(), ".gc") {
+		t.Fatalf("builtinDefaultHomeFallback: got shared temp fallback %q", got)
+	}
+}
+
 func TestLoadConfigMissing(t *testing.T) {
 	cfg, err := LoadConfig("/nonexistent/supervisor.toml")
 	if err != nil {

--- a/release-gates/ga-xq0c8s-gchome-dashboard-sync-gate.md
+++ b/release-gates/ga-xq0c8s-gchome-dashboard-sync-gate.md
@@ -1,0 +1,54 @@
+# Release Gate: ga-xq0c8s gchome shared-tmp + dashboard TS sync
+
+Date: 2026-06-23
+Branch: deploy/ga-xq0c8s-gchome-dashboard-sync
+Base: origin/main @ 632d24f7e
+Head before gate commit: e4135523a
+Source branch: builder/ga-mjkqhb-extmsg-subscribe-clean
+
+## Scope
+
+Deploy bead: ga-xq0c8s
+Reviewed source bead: ga-p5te24
+
+Requested source commits:
+
+| Source commit | Result on release branch | Evidence |
+| --- | --- | --- |
+| 48ac0ae9e fix(gchome): replace shared-tmp fallback with process-unique paths | Cherry-picked as e4135523a | Final diff touches `internal/bootstrap`, `internal/config`, and `internal/supervisor` fallback helpers plus tests. |
+| 5c20380ab chore(dashboard): sync generated TS types with openapi maintenance endpoints | Already satisfied by current `origin/main`; not replayed | `origin/main` already exports `triggerMaintenanceDoltGc` and `getV0CityByCityNameMaintenanceStatus` in generated dashboard TS. Replaying the source commit conflicts because its source context also carries unrelated extmsg generated-client exports, which the deploy bead explicitly excludes. |
+
+Final branch diff:
+
+```text
+internal/bootstrap/bootstrap.go
+internal/bootstrap/bootstrap_test.go
+internal/config/implicit.go
+internal/config/implicit_test.go
+internal/supervisor/config.go
+internal/supervisor/config_test.go
+```
+
+`docs/PROJECT_MANIFEST.md` is not present on `origin/main`; this gate uses the release criteria from the deployer prompt.
+
+## Gate Checklist
+
+| # | Criterion | Verdict | Evidence |
+| --- | --- | --- | --- |
+| 1 | Review PASS present | PASS | `bd show ga-p5te24` contains `REVIEW VERDICT: PASS` from gascity/reviewer and lists both requested source commits. |
+| 2 | Acceptance criteria met | PASS | gchome fallbacks now create process-unique `gc-home-*` temp directories with PID fallback only if `MkdirTemp` fails; tests cover bootstrap, config implicit imports, and supervisor default home. Dashboard maintenance generated TS functions are already present on base, so no extmsg generated-client context was imported. |
+| 3 | Tests pass | PASS | `make test` passed with `observable go test: PASS`; `go vet ./...` passed; `make dashboard-check` passed; isolated-cache build `GOCACHE=$(mktemp -d) go build ./cmd/gc/` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for ga-p5te24 list two INFO findings only: temp dir leak and duplicate fallback helpers. No HIGH findings are open. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` before gate file showed `## deploy/ga-xq0c8s-gchome-dashboard-sync...origin/main [ahead 1]` with no uncommitted changes. |
+| 6 | Branch diverges cleanly from main | PASS | Branch was cut from `origin/main`; `git merge-base --is-ancestor origin/main HEAD` returned success. |
+| 7 | Single feature theme | PASS | Final PR diff is limited to user-global GC home fallback behavior in gchome-related bootstrap/config/supervisor code. The dashboard generated-type item is already on base and introduces no second branch diff. |
+
+## Reviewer Notes
+
+- The release branch intentionally omits dashboard generated files because current `origin/main` already has the maintenance client exports.
+- The release branch intentionally omits extmsg WP-3 generated-client exports from the source branch; those belong to the separate extmsg PR called out in the deploy bead.
+- The original deployer worktree was mid-rebase on unrelated work, so this gate was evaluated in a fresh release worktree at `/home/jaword/projects/gascity-deploy-ga-xq0c8s`.
+
+## Gate Result
+
+PASS


### PR DESCRIPTION
## What this changes

When Gas City cannot resolve a user home directory, the gchome fallback now creates a process-unique temporary `gc-home-*` directory instead of using a shared path under the OS temp directory. That keeps bootstrap implicit imports, implicit config reads, and supervisor defaults from sharing fallback state across unrelated processes.

The dashboard maintenance TypeScript client sync requested with this release is already present on current `main`, so this PR deliberately does not include generated dashboard files or unrelated extmsg generated-client changes from the source branch.

## Review notes

- Fallback behavior changed in `internal/bootstrap`, `internal/config`, and `internal/supervisor` only.
- The new fallback first uses `os.MkdirTemp("", "gc-home-*")`; the PID-derived path remains only as a last-resort return value if temp directory creation itself fails.
- No dashboard files are changed in this PR because `triggerMaintenanceDoltGc` and `getV0CityByCityNameMaintenanceStatus` are already exported on the base branch.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] `make dashboard-check`
- [x] `GOCACHE=$(mktemp -d) go build ./cmd/gc/`
- [x] Release gate: [`release-gates/ga-xq0c8s-gchome-dashboard-sync-gate.md`](release-gates/ga-xq0c8s-gchome-dashboard-sync-gate.md)