### PR TITLE
fix(rig): drop dangling rig-targeted config on rig remove

### DIFF
--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -1666,8 +1666,20 @@ func cmdRigRemove(rigName string, stdout, stderr io.Writer) int {
 		func(p config.NamedSessionPatch) bool { return p.Dir == rigName })
 	cfg.Patches.Rigs = slices.DeleteFunc(cfg.Patches.Rigs,
 		func(p config.RigPatch) bool { return p.Name == rigName })
+	// Capture rig-scoped PR monitor names before deleting them so we can also
+	// drop any [[patches.github_pr_monitor]] that targets them by name —
+	// otherwise the patch dangles and ApplyPatches fails ("github pr monitor
+	// %q not found in merged config") on the next compose, the same #3666 class.
+	removedMonitors := map[string]bool{}
+	for _, m := range cfg.GitHub.PRMonitors {
+		if m.Rig == rigName {
+			removedMonitors[m.Name] = true
+		}
+	}
 	cfg.GitHub.PRMonitors = slices.DeleteFunc(cfg.GitHub.PRMonitors,
 		func(m config.GitHubPRMonitor) bool { return m.Rig == rigName })
+	cfg.Patches.GitHubPRMonitors = slices.DeleteFunc(cfg.Patches.GitHubPRMonitors,
+		func(p config.GitHubPRMonitorPatch) bool { return removedMonitors[p.Name] })
 	cfg.Orders.Overrides = slices.DeleteFunc(cfg.Orders.Overrides,
 		func(o config.OrderOverride) bool { return o.Rig == rigName })
 

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -1652,6 +1652,25 @@ func cmdRigRemove(rigName string, stdout, stderr io.Writer) int {
 	}
 	cfg.Rigs = filtered
 
+	// Drop config blocks that reference the removed rig; left dangling they
+	// break a later load of the city (#3666). The three [[patches.*]] kinds and
+	// a [[github.pr_monitor]] hard-fail config.LoadWithIncludes once their
+	// now-absent rig can no longer be resolved (ApplyPatches "not found in
+	// merged config" / ValidateGitHubPRMonitors "rig is not declared"); an
+	// [[orders.overrides]] instead dangles at order-scan time. The issue named
+	// [[patches.agent]] and [[orders.overrides]]; the rest fail the same way on
+	// rig removal, so sweep them all.
+	cfg.Patches.Agents = slices.DeleteFunc(cfg.Patches.Agents,
+		func(p config.AgentPatch) bool { return p.Dir == rigName })
+	cfg.Patches.NamedSessions = slices.DeleteFunc(cfg.Patches.NamedSessions,
+		func(p config.NamedSessionPatch) bool { return p.Dir == rigName })
+	cfg.Patches.Rigs = slices.DeleteFunc(cfg.Patches.Rigs,
+		func(p config.RigPatch) bool { return p.Name == rigName })
+	cfg.GitHub.PRMonitors = slices.DeleteFunc(cfg.GitHub.PRMonitors,
+		func(m config.GitHubPRMonitor) bool { return m.Rig == rigName })
+	cfg.Orders.Overrides = slices.DeleteFunc(cfg.Orders.Overrides,
+		func(o config.OrderOverride) bool { return o.Rig == rigName })
+
 	// Write updated config.
 	if err := config.WriteCityAndRigSiteBindingsForEditRemovingRigs(fsys.OSFS{}, tomlPath, cfg, rigName); err != nil {
 		fmt.Fprintf(stderr, "gc rig remove: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1001,6 +1001,129 @@ path = "packs/missing"
 		assertSameTestPath(t, bindingB.Rigs[0].Path, rigDir)
 		assertNoGlobalRigEntries(t, gcHome)
 	})
+
+	t.Run("drops_dangling_patches_and_order_overrides_for_removed_rig", func(t *testing.T) {
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+		resetFlags(t)
+
+		cityPath := setupCity(t, "patch-city")
+		rigDir := filepath.Join(t.TempDir(), "patch-rig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Every config block that references the rig goes stale when it is
+		// removed. The rig-scoped [[patches.agent]] (targeting the implicit
+		// claude agent), [[patches.named_session]], [[patches.rigs]], and the
+		// [[github.pr_monitor]] all hard-fail a later LoadWithIncludes (#3666);
+		// the [[orders.overrides]] rig="patch-rig" dangles at order-scan time.
+		// City-scoped siblings (dir/rig empty) must survive untouched.
+		toml := `[workspace]
+name = "patch-city"
+
+[[agent]]
+name = "mayor"
+
+[providers.claude]
+base = "builtin:claude"
+
+[[rigs]]
+name = "patch-rig"
+path = "` + rigDir + `"
+
+[[patches.agent]]
+dir = "patch-rig"
+name = "claude"
+suspended = true
+
+[[patches.named_session]]
+dir = "patch-rig"
+name = "patch-rig/worker"
+mode = "always"
+
+[[patches.rigs]]
+name = "patch-rig"
+suspended_on_start = true
+
+[[github.pr_monitor]]
+name = "patch-rig-monitor"
+owner = "acme"
+repo = "widget"
+base_branches = ["main"]
+rig = "patch-rig"
+repair_route = "patch-rig/coder"
+
+[[patches.agent]]
+name = "claude"
+suspended = true
+
+[[orders.overrides]]
+name = "rig-order"
+rig = "patch-rig"
+enabled = false
+
+[[orders.overrides]]
+name = "city-order"
+enabled = false
+`
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		registerCityForRigResolution(t, gcHome, cityPath, "patch-city")
+
+		cityFlag = cityPath
+		var stdout, stderr bytes.Buffer
+		code := cmdRigRemove("patch-rig", &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("cmdRigRemove = %d, stderr: %s", code, stderr.String())
+		}
+
+		// The city must stay loadable: gc reload / gc rig list compose via
+		// LoadWithIncludes, which applies [[patches.agent]]. A patch left
+		// targeting the removed rig's agent hard-fails there with
+		// "not found in merged config" (#3666).
+		if _, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); err != nil {
+			t.Fatalf("LoadWithIncludes after rig remove failed (#3666): %v", err)
+		}
+
+		// The rig-scoped patch + override must be gone; the city-scoped ones
+		// must remain.
+		raw, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		parsed, err := config.Parse(raw)
+		if err != nil {
+			t.Fatalf("Parse(rewritten city.toml): %v", err)
+		}
+		for _, p := range parsed.Patches.Agents {
+			if p.Dir == "patch-rig" {
+				t.Errorf("patches.agent for removed rig survived: %+v", p)
+			}
+		}
+		if len(parsed.Patches.Agents) != 1 || parsed.Patches.Agents[0].Dir != "" {
+			t.Errorf("city-scoped patches.agent not preserved: %#v", parsed.Patches.Agents)
+		}
+		// named_session / rigs / pr_monitor had only the one rig-targeting entry
+		// each, so the removal must leave each list empty — nothing survives and
+		// nothing spurious is introduced.
+		if len(parsed.Patches.NamedSessions) != 0 {
+			t.Errorf("patches.named_session for removed rig survived: %#v", parsed.Patches.NamedSessions)
+		}
+		if len(parsed.Patches.Rigs) != 0 {
+			t.Errorf("patches.rigs for removed rig survived: %#v", parsed.Patches.Rigs)
+		}
+		if len(parsed.GitHub.PRMonitors) != 0 {
+			t.Errorf("github.pr_monitor for removed rig survived: %#v", parsed.GitHub.PRMonitors)
+		}
+		for _, o := range parsed.Orders.Overrides {
+			if o.Rig == "patch-rig" {
+				t.Errorf("orders.overrides for removed rig survived: %+v", o)
+			}
+		}
+		if len(parsed.Orders.Overrides) != 1 || parsed.Orders.Overrides[0].Rig != "" {
+			t.Errorf("city-scoped orders.overrides not preserved: %#v", parsed.Orders.Overrides)
+		}
+	})
 }
 
 // ===========================================================================

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1054,6 +1054,10 @@ base_branches = ["main"]
 rig = "patch-rig"
 repair_route = "patch-rig/coder"
 
+[[patches.github_pr_monitor]]
+name = "patch-rig-monitor"
+poll_interval = "5m"
+
 [[patches.agent]]
 name = "claude"
 suspended = true
@@ -1114,6 +1118,9 @@ enabled = false
 		}
 		if len(parsed.GitHub.PRMonitors) != 0 {
 			t.Errorf("github.pr_monitor for removed rig survived: %#v", parsed.GitHub.PRMonitors)
+		}
+		if len(parsed.Patches.GitHubPRMonitors) != 0 {
+			t.Errorf("patches.github_pr_monitor for removed rig's monitor survived: %#v", parsed.Patches.GitHubPRMonitors)
 		}
 		for _, o := range parsed.Orders.Overrides {
 			if o.Rig == "patch-rig" {


### PR DESCRIPTION
## What

`gc rig remove <rig>` removed the rig from `[[rigs]]` and rewrote bindings/routes
but never scanned the config blocks that *reference* the rig. A left-behind
`[[patches.agent]] dir="<rig>"` then hard-fails `config.LoadWithIncludes`
(`applying patches: patches.agent[0]: agent "<rig>/..." not found in merged
config`) on the next compose, so `gc reload` and `gc rig list` both break until
the block is hand-deleted.

## Fix

`cmdRigRemove` now drops every rig-referencing config block before writing
`city.toml`. Four break a later compose/load once their now-absent rig can no
longer be resolved; one dangles at order-scan time:

| Block | Match key | Failure path |
|-------|-----------|--------------|
| `[[patches.agent]]` | `dir` | `ApplyPatches` → "not found in merged config" |
| `[[patches.named_session]]` | `dir` | `ApplyPatches` |
| `[[patches.rigs]]` | `name` | `ApplyPatches` |
| `[[github.pr_monitor]]` | `rig` | `ValidateGitHubPRMonitors` → "rig is not declared" (fires in `config.Load` itself) |
| `[[orders.overrides]]` | `rig` | order scan (`gc order` / controller) |

The issue reported `[[patches.agent]]` and `[[orders.overrides]]`; the other
three fail identically on rig removal, so the sweep covers all five.
`[[patches.providers]]` and `[[patches.github_pr_monitor]]` are keyed by their
own city-level identity (not a rig) and are intentionally left untouched.

## Test

`TestRigAnywhere_RigRemove/drops_dangling_patches_and_order_overrides_for_removed_rig`
builds a city with a rig + provider (which yields a rig-scoped implicit agent),
all five rig-targeting blocks, and city-scoped controls; runs `cmdRigRemove`;
then asserts `LoadWithIncludes` succeeds and each rig-targeting block is gone
while the city-scoped siblings survive. It fails on `main` with the exact
reported error and passes with the fix.

Closes #3666.

---

### CI note — pre-commit test flakes

The pre-commit hook's full parallel suite (`scripts/test-local-parallel fast`)
failed on a different unrelated supervisor/dolt integration test on each run,
while every change-relevant gate (lint-changed, `go vet`, `go build`, and the
new `TestRigAnywhere_RigRemove` cases) stayed green throughout:

| Run | Jobs | Failing test | Reason |
|-----|------|--------------|--------|
| 1 | `LOCAL_TEST_JOBS=2` | `TestResetSessionCircuitBreakerOnControllerMalformedReply` | `listen unix /tmp/gascity-controller/*.sock: bind: no such file or directory` (socket-dir race) |
| 2 | `LOCAL_TEST_JOBS=2` | `TestRegisterCityWithSupervisorRejectsStandaloneController` | `bd schema for 'hq' not visible after init`; leaked dolt sql-server |
| 3 | `LOCAL_TEST_JOBS=1` | `TestRegisterCityWithSupervisorRejectsStandaloneControllerDuringSupervisorStartupPhase` | city not ready under supervisor within `1m0s` start_ready_timeout |
| 4 | `LOCAL_TEST_JOBS=2` | `TestRegisterCityWithSupervisorRejectsStandaloneController` + `…DuringSupervisorStartupPhase` | bd schema not visible / `1m0s` timeout |

These appear to be pre-existing load-induced integration flakes in the
supervisor/dolt startup tests, presumed unrelated to this two-file change.
`make fmt-check vet check-routed-test-rows lint` is clean on the final commit.
