### PR TITLE
fix(reaper): exclude message wisps from stale count

### DIFF
--- a/internal/bootstrap/packs/core/assets/scripts/reaper.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/reaper.sh
@@ -773,6 +773,7 @@ while IFS= read -r DB; do
     get_sql_count "$DB" "stale non-closed wisp" "
         SELECT COUNT(*) FROM \`$DB\`.wisps
         WHERE status IN ('open', 'hooked', 'in_progress')
+        AND issue_type NOT IN ('message')
         AND created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
     "
     STALE_WISP_COUNT=$SQL_COUNT_RESULT


### PR DESCRIPTION
## What

The reaper's stale-wisp count query (`reaper.sh` Step 1) counted all wisps by age+status with no `issue_type` filter. Mail messages (`issue_type='message'`) satisfy the age+status filter and are counted as stale wisps, inflating `stale_wisps:N`. The close-candidate query (Step 1 subquery) already implicitly excludes messages via a parent-child join, so messages are never closed. The result is a chronic `stale_wisps:N closed_wisps:0` discrepancy that fires spurious reaper-failure escalations on every cycle where unarchived mail is present.

## Change

Add `AND issue_type NOT IN ('message')` to the Step 1 count query, matching the existing Step 6a anomaly-alert query which already uses the same filter. The close logic needs no change — the issue confirms messages are already excluded by the parent-child join.

### Why `NOT IN ('message')` instead of `= 'molecule'`

The issue proposes `issue_type = 'molecule'`, but research against the current codebase shows that would be a regression. Wisp roots compiled by the formula compiler can carry `issue_type = 'task'` (graph.v2 workflow roots and vapor/root-only wisps carry `gc.kind=workflow` or `gc.kind=wisp` metadata with `issue_type='task'`). Using `= 'molecule'` would make the reaper blind to those wisp shapes. `NOT IN ('message')` is the broader, safer filter that resolves the reported symptom, is consistent with the existing Step 6a alerting query, does not regress graph.v2 workflow / vapor wisp detection, and satisfies the existing `maintenance_scripts_test.go` regression test that enforces the script contains `issue_type NOT IN ('message')`.

## Test

The existing test in `examples/gastown/maintenance_scripts_test.go` enforces the reaper script contains `issue_type NOT IN ('message')` — the fix adds this fragment to the Step 1 query where it was missing.

Closes #1809.

## Summary

- Explain the change and why it is needed.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [ ] Linked an issue, or explained why one is not needed
- [ ] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes
