### PR TITLE
fix(ci): add fork-verify workflow with BD_VERSION v1.0.4

### DIFF
--- a/.github/workflows/fork-verify.yml
+++ b/.github/workflows/fork-verify.yml
@@ -1,7 +1,7 @@
 name: fork-verify
 
-# Minimal fork-only CI for bourgois/gascity. Verifies WIP feature branches
-# (e.g. cross-store work delivery, vp-kvp) WITHOUT upstream's Blacksmith
+# Minimal fork-only CI for gascity forks. Verifies WIP feature branches
+# WITHOUT upstream's Blacksmith
 # self-hosted runners, runner-policy gating, or secrets — none of which a fork
 # has. ubuntu-latest compiles the Dolt go-icu-regex CGO dependency cleanly; the
 # `unicode/regex.h` build failure is macOS-only (icu4c@78 header layout), so a
@@ -35,7 +35,7 @@ jobs:
         run: go build ./...
       - name: Vet changed package
         run: go vet ./cmd/gc/...
-      - name: Unit tests — cross-store work delivery (vp-kvp stages i/ii/iii)
+      - name: Unit tests — cross-store work delivery
         run: go test ./cmd/gc/ -run 'TestFilterAssignedWorkBeads|TestAssignedWork|TestFirstStoreWithWork|TestCrossStoreClaimDir|TestRunBDForBead|TestGateOpenWorkBounded|TestCrossStorePipeline' -count=1 -v
       - name: Unit tests — cross-store reachability predicate + fail-loud guard (vp-kvp stage i)
         run: |

--- a/.github/workflows/fork-verify.yml
+++ b/.github/workflows/fork-verify.yml
@@ -37,7 +37,7 @@ jobs:
         run: go vet ./cmd/gc/...
       - name: Unit tests — cross-store work delivery
         run: go test ./cmd/gc/ -run 'TestFilterAssignedWorkBeads|TestAssignedWork|TestFirstStoreWithWork|TestCrossStoreClaimDir|TestRunBDForBead|TestGateOpenWorkBounded|TestCrossStorePipeline' -count=1 -v
-      - name: Unit tests — cross-store reachability predicate + fail-loud guard (vp-kvp stage i)
+      - name: Unit tests — cross-store reachability predicate + fail-loud guard
         run: |
           go test ./internal/agentutil/ -run 'TestAgentReachesWorkflowStore|TestAgentIsCrossStoreEligible' -count=1 -v
           go test ./internal/sling/ -run 'TestValidateBuiltInRouteStoreReachableAllowsCityScopedTarget|TestDoSlingRefusesCrossStore' -count=1 -v

--- a/.github/workflows/fork-verify.yml
+++ b/.github/workflows/fork-verify.yml
@@ -1,0 +1,47 @@
+name: fork-verify
+
+# Minimal fork-only CI for bourgois/gascity. Verifies WIP feature branches
+# (e.g. cross-store work delivery, vp-kvp) WITHOUT upstream's Blacksmith
+# self-hosted runners, runner-policy gating, or secrets — none of which a fork
+# has. ubuntu-latest compiles the Dolt go-icu-regex CGO dependency cleanly; the
+# `unicode/regex.h` build failure is macOS-only (icu4c@78 header layout), so a
+# Linux runner is exactly what's needed to get a real green/red signal.
+#
+# Reuses the upstream composite action .github/actions/setup-gascity-ubuntu so
+# the Go + Dolt + native-dependency setup is not re-solved here.
+
+on:
+  push:
+    branches: ["feat/**", "fix/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      DOLT_VERSION: "2.1.7"
+      BD_VERSION: "v1.0.4"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "false"
+      - name: Build (compiles the whole tree — catches compile errors the macOS ICU break hides)
+        run: go build ./...
+      - name: Vet changed package
+        run: go vet ./cmd/gc/...
+      - name: Unit tests — cross-store work delivery (vp-kvp stages i/ii/iii)
+        run: go test ./cmd/gc/ -run 'TestFilterAssignedWorkBeads|TestAssignedWork|TestFirstStoreWithWork|TestCrossStoreClaimDir|TestRunBDForBead|TestGateOpenWorkBounded|TestCrossStorePipeline' -count=1 -v
+      - name: Unit tests — cross-store reachability predicate + fail-loud guard (vp-kvp stage i)
+        run: |
+          go test ./internal/agentutil/ -run 'TestAgentReachesWorkflowStore|TestAgentIsCrossStoreEligible' -count=1 -v
+          go test ./internal/sling/ -run 'TestValidateBuiltInRouteStoreReachableAllowsCityScopedTarget|TestDoSlingRefusesCrossStore' -count=1 -v
+      - name: Unit tests — order scope (#2830)
+        run: go test ./internal/orders/ -run 'TestParseScope|TestValidateRejectsUnknownScope|TestValidateAcceptsCityAndRigScope|TestParseEnv' -count=1 -v
+      - name: Unit tests — scale from zero (#2819)
+        run: go test ./cmd/gc/ -run 'TestBuildDesiredState_ScaleFromZero' -count=1 -v


### PR DESCRIPTION
## Why

`BD_VERSION=v1.0.5` was referenced in the Voxist fork's fork-verify workflow, but
v1.0.5 does not exist as a downloadable release in `gastownhall/beads` (latest is
v1.0.4, 2026-05-09). Cold runners 404 during `bd` binary setup, causing CI
failures on fork branches.

This is a re-submission of PR #3673 (closed), which was rejected because the branch
was created from the Voxist fork HEAD and inadvertently carried ~3 weeks of
Voxist-internal commits. This PR is branched directly from `gastownhall/gascity main`.

## What changed

- `.github/workflows/fork-verify.yml` (new file, 47 lines)

Adds a minimal fork-only CI workflow for contributors who fork this repo.
Runs on `ubuntu-latest` — no Blacksmith runners, no org secrets required —
giving forks a real green/red build signal on `feat/**` and `fix/**` branches.
`BD_VERSION` is pinned to the stable `v1.0.4` release.

## Diff size

1 file, 47 insertions, 0 deletions. No logic changes to existing files.

## Test plan

- [ ] CI passes on this PR (single workflow file addition; no compilation changes)
- [ ] Confirm `gastownhall/beads` has no v1.0.5 release (expected: latest is v1.0.4)
- [ ] Fork contributors can push to `feat/**` / `fix/**` and get a build result without org secrets

Fixes vp-by7n.