### PR TITLE
fix(eventexport): redact city_id, surface cursor errors, reject empty token (post-merge #3654)

### DIFF
--- a/cmd/gc/event_export.go
+++ b/cmd/gc/event_export.go
@@ -68,27 +68,45 @@ func startEventExport(ctx context.Context, ec supervisor.ExportConfig, providers
 	})
 
 	cursorPath := filepath.Join(homeDir, "events-export-cursor.json")
-	exp.SetCursors(eventexport.LoadCursors(cursorPath))
+	cursors, err := eventexport.LoadCursors(cursorPath)
+	if err != nil {
+		// Fail closed: a corrupt or unreadable cursor file would otherwise floor
+		// each city at its current head and silently skip every event accumulated
+		// since the last durable cursor. Refuse to start and surface it so an
+		// operator can repair the file (or remove it to deliberately start fresh)
+		// rather than lose exports.
+		logf("ERROR: cannot read durable export cursor %s (refusing to start; remove it to start fresh): %v", cursorPath, err)
+		return
+	}
+	exp.SetCursors(cursors)
 
 	src := eventfeed.NewMuxSource(providers, exp.Cursors, muxRebuildInterval, logf)
 	go func() { _ = exp.Run(ctx, src) }()
-	go persistExportCursors(ctx, exp, cursorPath)
+	go persistExportCursors(ctx, exp, cursorPath, logf)
 
 	logf("enabled -> %s (envelope-only metadata; no payloads leave the box)", ec.Endpoint)
 }
 
 // persistExportCursors snapshots the exporter cursor to disk periodically and on
-// shutdown so a restart resumes without re-reading the whole history.
-func persistExportCursors(ctx context.Context, exp *eventexport.Exporter, path string) {
+// shutdown so a restart resumes without re-reading the whole history. A save
+// failure is logged rather than swallowed: a full disk or bad permissions means
+// a restart would resume from a stale cursor (re-exporting or skipping events),
+// which an operator needs to see.
+func persistExportCursors(ctx context.Context, exp *eventexport.Exporter, path string, logf func(string, ...any)) {
 	t := time.NewTicker(10 * time.Second)
 	defer t.Stop()
+	save := func() {
+		if err := eventexport.SaveCursors(path, exp.Cursors()); err != nil {
+			logf("WARNING: failed to persist export cursor %s (a restart may re-export or skip events): %v", path, err)
+		}
+	}
 	for {
 		select {
 		case <-ctx.Done():
-			_ = eventexport.SaveCursors(path, exp.Cursors()) //nolint:errcheck
+			save()
 			return
 		case <-t.C:
-			_ = eventexport.SaveCursors(path, exp.Cursors()) //nolint:errcheck
+			save()
 		}
 	}
 }
@@ -110,7 +128,16 @@ func resolveExportCredentials(ec supervisor.ExportConfig, homeDir string, stderr
 			if err != nil {
 				return "", err
 			}
-			return strings.TrimSpace(string(b)), nil
+			tok := strings.TrimSpace(string(b))
+			if tok == "" {
+				// A configured token source that resolves empty is a config/auth
+				// error, not the deliberately-anonymous opt-out (which is the nil
+				// provider). Fail closed so the cursor holds and the empty
+				// credential surfaces, rather than silently downgrading to an
+				// unauthenticated POST.
+				return "", fmt.Errorf("token_file %s resolved to an empty token", tokenFile)
+			}
+			return tok, nil
 		}
 	case ec.Token != "":
 		token := ec.Token

--- a/cmd/gc/event_export_test.go
+++ b/cmd/gc/event_export_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/supervisor"
+)
+
+// TestResolveExportCredentials_EmptyTokenFileErrors proves a configured but
+// empty (or whitespace-only) token_file fails closed: the provider returns an
+// error so the cursor holds and the empty credential surfaces, instead of
+// silently downgrading to an unauthenticated POST.
+func TestResolveExportCredentials_EmptyTokenFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	for _, content := range []string{"", "   \n\t  "} {
+		if err := os.WriteFile(tokenPath, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		ec := supervisor.ExportConfig{TokenFile: tokenPath, ActorSalt: "test-salt"}
+		provider, _ := resolveExportCredentials(ec, dir, io.Discard)
+		if provider == nil {
+			t.Fatalf("configured token_file must yield a provider (content %q)", content)
+		}
+		tok, err := provider()
+		if err == nil {
+			t.Fatalf("empty token_file must error, got token %q (content %q)", tok, content)
+		}
+		if tok != "" {
+			t.Fatalf("empty token_file must return an empty token with the error, got %q", tok)
+		}
+	}
+}
+
+// TestResolveExportCredentials_ValidTokenFile proves a non-empty token_file is
+// read and trimmed.
+func TestResolveExportCredentials_ValidTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenPath, []byte("  s3cr3t\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ec := supervisor.ExportConfig{TokenFile: tokenPath, ActorSalt: "test-salt"}
+	provider, _ := resolveExportCredentials(ec, dir, io.Discard)
+	if provider == nil {
+		t.Fatal("configured token_file must yield a provider")
+	}
+	tok, err := provider()
+	if err != nil {
+		t.Fatalf("valid token_file must not error: %v", err)
+	}
+	if tok != "s3cr3t" {
+		t.Fatalf("token = %q, want trimmed %q", tok, "s3cr3t")
+	}
+}
+
+// TestResolveExportCredentials_NoSourceIsAnonymous proves the deliberately-
+// anonymous opt-out (no token and no token_file) still yields a nil provider,
+// distinct from the now-error empty-token-file case.
+func TestResolveExportCredentials_NoSourceIsAnonymous(t *testing.T) {
+	dir := t.TempDir()
+	ec := supervisor.ExportConfig{ActorSalt: "test-salt"}
+	provider, salt := resolveExportCredentials(ec, dir, io.Discard)
+	if provider != nil {
+		t.Fatal("no token source must yield a nil provider (the anonymous opt-out)")
+	}
+	if string(salt) != "test-salt" {
+		t.Fatalf("salt = %q, want inline ActorSalt", salt)
+	}
+}
+
+// TestResolveExportCredentials_InlineToken proves an inline token is returned
+// verbatim.
+func TestResolveExportCredentials_InlineToken(t *testing.T) {
+	dir := t.TempDir()
+	ec := supervisor.ExportConfig{Token: "inline-tok", ActorSalt: "test-salt"}
+	provider, _ := resolveExportCredentials(ec, dir, io.Discard)
+	if provider == nil {
+		t.Fatal("inline token must yield a provider")
+	}
+	tok, err := provider()
+	if err != nil || tok != "inline-tok" {
+		t.Fatalf("inline token provider = (%q, %v), want (inline-tok, nil)", tok, err)
+	}
+}

--- a/internal/eventfeed/muxsource_test.go
+++ b/internal/eventfeed/muxsource_test.go
@@ -126,7 +126,7 @@ func TestAdapter_NoLeakFromPayload(t *testing.T) {
 		{Seq: 7, Type: "convoy.closed", Ts: ts, Actor: "human", Subject: "gcg-4216"},
 	}
 	var batch eventexport.Batch
-	batch.CityID = "c"
+	batch.CityHash = eventexport.CityHash([]byte("salt"), "c")
 	batch.SchemaVersion = eventexport.SchemaVersion
 	for _, e := range corpus {
 		te := events.TaggedEvent{Event: e, City: "c"}

--- a/pkg/eventexport/cursors.go
+++ b/pkg/eventexport/cursors.go
@@ -2,19 +2,31 @@ package eventexport
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 )
 
-// LoadCursors reads persisted per-city resume cursors. A missing or unreadable
-// file yields an empty map (a fresh exporter floors each city at its head).
-func LoadCursors(path string) map[string]uint64 {
+// LoadCursors reads persisted per-city resume cursors. A missing file is the
+// expected first-run case and yields an empty map with no error (a fresh
+// exporter then floors each city at its head). An existing-but-unreadable or
+// corrupt file is reported as an error instead of being silently reset: doing
+// so would floor every tracked city at its current head and skip every event
+// accumulated since the last durable cursor, so the caller must decide (it
+// fails closed) rather than lose exports.
+func LoadCursors(path string) (map[string]uint64, error) {
 	out := map[string]uint64{}
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return out
+		if errors.Is(err, os.ErrNotExist) {
+			return out, nil // first run: no durable cursor yet
+		}
+		return nil, fmt.Errorf("eventexport: read cursor file %s: %w", path, err)
 	}
-	_ = json.Unmarshal(b, &out) //nolint:errcheck // a corrupt cursor file resets to empty
-	return out
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, fmt.Errorf("eventexport: parse cursor file %s: %w", path, err)
+	}
+	return out, nil
 }
 
 // SaveCursors atomically persists per-city resume cursors.

--- a/pkg/eventexport/cursors.go
+++ b/pkg/eventexport/cursors.go
@@ -26,6 +26,14 @@ func LoadCursors(path string) (map[string]uint64, error) {
 	if err := json.Unmarshal(b, &out); err != nil {
 		return nil, fmt.Errorf("eventexport: parse cursor file %s: %w", path, err)
 	}
+	if out == nil {
+		// A cursor file containing JSON null unmarshals to a nil map without an
+		// error. Treat it as corrupt and fail closed: a nil map reaching
+		// MuxSource reads as no durable cursors and floors every tracked city at
+		// head, skipping events accumulated since the last durable save. A
+		// legitimate empty object ("{}") stays a non-nil empty map and is kept.
+		return nil, fmt.Errorf("eventexport: cursor file %s contains null instead of a cursor object", path)
+	}
 	return out, nil
 }
 

--- a/pkg/eventexport/cursors_test.go
+++ b/pkg/eventexport/cursors_test.go
@@ -54,6 +54,26 @@ func TestLoadCursors_CorruptFileErrors(t *testing.T) {
 	}
 }
 
+// TestLoadCursors_NullFileErrors proves a cursor file containing JSON null fails
+// closed. json.Unmarshal accepts null for a map[string]uint64 and sets it to nil
+// without an error, which would otherwise reach MuxSource as no durable cursors
+// and floor every tracked city at head, skipping events accumulated since the
+// last durable save.
+func TestLoadCursors_NullFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "null.json")
+	if err := os.WriteFile(path, []byte("null"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadCursors(path)
+	if err == nil {
+		t.Fatalf("null cursor file must error, got map %v", got)
+	}
+	if got != nil {
+		t.Fatalf("null cursor file must return a nil map with the error, got %v", got)
+	}
+}
+
 // TestLoadCursors_UnreadableFileErrors proves an existing-but-unreadable cursor
 // file errors (permission), rather than being treated as a fresh start.
 func TestLoadCursors_UnreadableFileErrors(t *testing.T) {

--- a/pkg/eventexport/cursors_test.go
+++ b/pkg/eventexport/cursors_test.go
@@ -14,22 +14,73 @@ func TestCursorsRoundTrip(t *testing.T) {
 	if err := SaveCursors(path, want); err != nil {
 		t.Fatalf("SaveCursors: %v", err)
 	}
-	got := LoadCursors(path)
+	got, err := LoadCursors(path)
+	if err != nil {
+		t.Fatalf("LoadCursors: %v", err)
+	}
 	if len(got) != len(want) || got["c1"] != 42 || got["c2"] != 1000 {
 		t.Fatalf("round-trip mismatch: got %v want %v", got, want)
 	}
+}
 
-	// Missing file -> empty, non-nil map.
-	if m := LoadCursors(filepath.Join(dir, "nope.json")); m == nil || len(m) != 0 {
-		t.Fatalf("missing file: got %v, want empty non-nil", m)
+// TestLoadCursors_MissingFileIsFreshStart pins the one non-error empty case: a
+// first run with no cursor file yet floors each city at head, by design.
+func TestLoadCursors_MissingFileIsFreshStart(t *testing.T) {
+	dir := t.TempDir()
+	got, err := LoadCursors(filepath.Join(dir, "nope.json"))
+	if err != nil {
+		t.Fatalf("missing file must not error (fresh start), got %v", err)
 	}
+	if got == nil || len(got) != 0 {
+		t.Fatalf("missing file: got %v, want empty non-nil", got)
+	}
+}
 
-	// Corrupt file -> empty, non-nil map (resets rather than crashing).
+// TestLoadCursors_CorruptFileErrors proves a corrupt cursor file surfaces an
+// error instead of silently resetting to empty — resetting would floor every
+// tracked city at head and skip events accumulated since the last durable save.
+func TestLoadCursors_CorruptFileErrors(t *testing.T) {
+	dir := t.TempDir()
 	corrupt := filepath.Join(dir, "corrupt.json")
 	if err := os.WriteFile(corrupt, []byte("{not json"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if m := LoadCursors(corrupt); m == nil || len(m) != 0 {
-		t.Fatalf("corrupt file: got %v, want empty non-nil", m)
+	got, err := LoadCursors(corrupt)
+	if err == nil {
+		t.Fatalf("corrupt file must error, got map %v", got)
+	}
+	if got != nil {
+		t.Fatalf("corrupt file must return a nil map with the error, got %v", got)
+	}
+}
+
+// TestLoadCursors_UnreadableFileErrors proves an existing-but-unreadable cursor
+// file errors (permission), rather than being treated as a fresh start.
+func TestLoadCursors_UnreadableFileErrors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses file permission checks")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cursor.json")
+	if err := os.WriteFile(path, []byte(`{"c1":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	if _, err := LoadCursors(path); err == nil {
+		t.Fatal("unreadable file must error, got nil")
+	}
+}
+
+// TestSaveCursors_UnwritablePathErrors proves a save failure (here, a missing
+// parent directory) propagates so the caller can log it rather than lose the
+// cursor silently.
+func TestSaveCursors_UnwritablePathErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing-subdir", "cursor.json")
+	if err := SaveCursors(path, map[string]uint64{"c1": 1}); err == nil {
+		t.Fatal("SaveCursors to an unwritable path must error, got nil")
 	}
 }

--- a/pkg/eventexport/exporter.go
+++ b/pkg/eventexport/exporter.go
@@ -252,7 +252,7 @@ func (e *Exporter) flushCity(ctx context.Context, city string) {
 }
 
 func (e *Exporter) post(ctx context.Context, city string, batch []Envelope) error {
-	body, err := json.Marshal(Batch{CityID: city, SchemaVersion: SchemaVersion, Events: batch})
+	body, err := json.Marshal(Batch{CityHash: CityHash(e.cfg.Salt, city), SchemaVersion: SchemaVersion, Events: batch})
 	if err != nil {
 		return err
 	}

--- a/pkg/eventexport/exporter_test.go
+++ b/pkg/eventexport/exporter_test.go
@@ -106,8 +106,9 @@ func TestExporter_BatchesRedactsAdvancesCursor(t *testing.T) {
 
 	var types []string
 	var blob strings.Builder
+	wantCity := CityHash(testSalt, "c1")
 	for _, b := range cp.all() {
-		if b.CityID != "c1" || b.SchemaVersion != SchemaVersion {
+		if b.CityHash != wantCity || b.SchemaVersion != SchemaVersion {
 			t.Fatalf("bad batch envelope: %+v", b)
 		}
 		for _, e := range b.Events {
@@ -125,6 +126,45 @@ func TestExporter_BatchesRedactsAdvancesCursor(t *testing.T) {
 	for _, f := range []string{"nightly-sweep", "payload"} {
 		if strings.Contains(blob.String(), f) {
 			t.Fatalf("LEAK: %q in exported batches", f)
+		}
+	}
+}
+
+// TestExporter_HashesCityName proves the cleartext city name never reaches the
+// wire: the batch carries only a salted, opaque city_hash partition key.
+func TestExporter_HashesCityName(t *testing.T) {
+	cp := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(cp.handler))
+	defer srv.Close()
+
+	const city = "acme-prod" // operator-chosen, customer-identifying
+	src := &chanSource{ch: make(chan TaggedEvent, 4)}
+	exp := New(Config{
+		Endpoint: srv.URL, Salt: testSalt, ExportRef: true,
+		BatchMax: 100, BatchInterval: 10 * time.Millisecond, MaxPendingPerCity: 1000,
+		Client: srv.Client(),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = exp.Run(ctx, src); close(done) }()
+
+	src.ch <- tev(city, 1, "bead.closed", "controller", "mc-1")
+	waitFor(t, 2*time.Second, func() bool { return exp.Cursors()[city] == 1 })
+	cancel()
+	<-done
+
+	batches := cp.all()
+	if len(batches) == 0 {
+		t.Fatal("no batch captured")
+	}
+	want := CityHash(testSalt, city)
+	for _, b := range batches {
+		if b.CityHash != want {
+			t.Fatalf("city_hash = %q, want %q (salted hash of %q)", b.CityHash, want, city)
+		}
+		j, _ := json.Marshal(b)
+		if strings.Contains(string(j), city) {
+			t.Fatalf("LEAK: cleartext city %q on the wire: %s", city, j)
 		}
 	}
 }

--- a/pkg/eventexport/golden_test.go
+++ b/pkg/eventexport/golden_test.go
@@ -10,8 +10,8 @@ import (
 // TestGoldenWireBytes pins the exact JSON for representative envelopes so any
 // change that alters the wire bytes is caught — and, per the SchemaVersion
 // contract, must bump SchemaVersion. Crucially it proves that empty
-// run_id/session_id are OMITTED (byte-identical to the pre-spine wire), which is
-// what lets this restructure stay at SchemaVersion 1.
+// run_id/session_id are OMITTED (byte-identical to the pre-spine wire), so
+// adding that correlation spine did not by itself change the envelope bytes.
 func TestGoldenWireBytes(t *testing.T) {
 	cases := []struct {
 		name string
@@ -50,16 +50,17 @@ func TestGoldenWireBytes(t *testing.T) {
 	}
 }
 
-// TestBatchGoldenBytes pins the batch envelope shape.
+// TestBatchGoldenBytes pins the batch envelope shape: an opaque city_hash (never
+// a cleartext city name) and schema_version 2.
 func TestBatchGoldenBytes(t *testing.T) {
-	b := Batch{CityID: "maintainer-city", SchemaVersion: SchemaVersion, Events: []Envelope{
+	b := Batch{CityHash: "7f3a9c1e5b2d4068", SchemaVersion: SchemaVersion, Events: []Envelope{
 		{Seq: 1, Type: "convoy.closed", TS: "2026-06-21T10:03:27Z", ActorHash: "0123456789abcdef", Ref: "gcg-4216"},
 	}}
 	out, err := json.Marshal(b)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `{"city_id":"maintainer-city","schema_version":1,"events":[{"seq":1,"type":"convoy.closed","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","ref":"gcg-4216"}]}`
+	want := `{"city_hash":"7f3a9c1e5b2d4068","schema_version":2,"events":[{"seq":1,"type":"convoy.closed","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","ref":"gcg-4216"}]}`
 	if string(out) != want {
 		t.Fatalf("batch golden:\n got %s\nwant %s", out, want)
 	}

--- a/pkg/eventexport/project.go
+++ b/pkg/eventexport/project.go
@@ -36,7 +36,11 @@ import (
 // golden test), so a downstream consumer pinned to an older version rejects the
 // batch loudly (ValidateBatch -> ErrSchemaMismatch) instead of mis-handling it.
 // A pure refactor that leaves bytes and policy identical does NOT bump.
-const SchemaVersion = 1
+//
+// v2 replaced the cleartext city_id with a salted, non-reversible city_hash so
+// an operator-chosen city name (which can itself embed a customer/org
+// identifier) no longer leaves the box.
+const SchemaVersion = 2
 
 // Profile selects the redaction profile. There is exactly one today; it is part
 // of the public API so Validate can stay profile-aware as profiles are added
@@ -129,9 +133,11 @@ type Envelope struct {
 	SessionID string `json:"session_id,omitempty"` // opaque session correlation id (safeRef-gated)
 }
 
-// Batch is one POST body: the events for a single city.
+// Batch is one POST body: the events for a single city. CityHash is a salted,
+// non-reversible partition key (see CityHash); the cleartext city name never
+// crosses the wire.
 type Batch struct {
-	CityID        string     `json:"city_id"`
+	CityHash      string     `json:"city_hash"`
 	SchemaVersion int        `json:"schema_version"`
 	Events        []Envelope `json:"events"`
 }
@@ -157,6 +163,22 @@ func ActorHash(salt []byte, actor string) string {
 	h.Write(salt)
 	h.Write([]byte(":"))
 	h.Write([]byte(actor))
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// CityHash returns a salted, non-reversible, 16-hex partition key for a city
+// name. Like ActorHash, it lets the receiver group batches per city without the
+// cleartext city name — operator-chosen, and able to embed a customer/org
+// identifier — ever leaving the box. It is domain-separated from ActorHash so a
+// city and an actor that share a name do not hash alike.
+func CityHash(salt []byte, city string) string {
+	if city == "" {
+		return ""
+	}
+	h := sha256.New()
+	h.Write(salt)
+	h.Write([]byte(":city:"))
+	h.Write([]byte(city))
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }
 

--- a/pkg/eventexport/project.go
+++ b/pkg/eventexport/project.go
@@ -290,12 +290,18 @@ func Validate(env Envelope, opt Options) error {
 var ErrSchemaMismatch = errors.New("eventexport: batch schema_version mismatch")
 
 // ValidateBatch checks a received batch end to end: its schema_version must equal
-// SchemaVersion (else it returns an error wrapping ErrSchemaMismatch), then every
+// SchemaVersion (else it returns an error wrapping ErrSchemaMismatch), its
+// city_hash must be the opaque 16-hex partition-key shape that schema v2 promises
+// (rejecting empty, cleartext, or otherwise malformed values at the receiver trust
+// boundary, the same shape gate ValidateEnvelope applies to actor_hash), then every
 // envelope must pass ValidateEnvelope. Validation is fail-fast: it returns the
 // FIRST failure with its row index, not an aggregate of all failures.
 func ValidateBatch(b Batch) error {
 	if b.SchemaVersion != SchemaVersion {
 		return fmt.Errorf("eventexport: batch schema_version %d != %d: %w", b.SchemaVersion, SchemaVersion, ErrSchemaMismatch)
+	}
+	if !isHex16(b.CityHash) {
+		return fmt.Errorf("eventexport: city_hash %q must be 16 hex chars", b.CityHash)
 	}
 	for i, env := range b.Events {
 		if err := ValidateEnvelope(env); err != nil {
@@ -336,7 +342,7 @@ func safeRef(s string) string {
 }
 
 // isHex16 reports whether s is exactly 16 lowercase hex characters (the
-// ActorHash shape).
+// ActorHash and CityHash shape).
 func isHex16(s string) bool {
 	if len(s) != 16 {
 		return false

--- a/pkg/eventexport/project_test.go
+++ b/pkg/eventexport/project_test.go
@@ -147,7 +147,10 @@ func TestProject_NoLeak(t *testing.T) {
 		{9, "order.completed", "controller", "deploy-to-clientco-prod", "", ""}, // author slug
 	}
 	var batch Batch
-	batch.CityID = "maintainer-city"
+	// A customer-identifying city name (claude's "acme-prod" example) must be
+	// reduced to an opaque hash; the cleartext must never reach the wire.
+	const cityName = "acme-prod"
+	batch.CityHash = CityHash(opt.Salt, cityName)
 	batch.SchemaVersion = SchemaVersion
 	for _, e := range corpus {
 		if env, ok := proj(e.seq, e.typ, e.actor, e.subject, e.run, e.sess, opt); ok {
@@ -163,6 +166,7 @@ func TestProject_NoLeak(t *testing.T) {
 		"/data/projects", "gascity/", "gascity-packs/",
 		"acme-client-repo", "clientco", "deploy-to-clientco-prod",
 		"orphan-sweep", "@", "payload", "message",
+		cityName, // the cleartext city name must never appear; only its hash ships
 	}
 	for _, f := range forbidden {
 		if strings.Contains(blob, f) {
@@ -194,6 +198,26 @@ func TestActorHash(t *testing.T) {
 	}
 	if ActorHash([]byte("s"), "") != "" {
 		t.Fatal("empty actor -> empty hash")
+	}
+}
+
+func TestCityHash(t *testing.T) {
+	c := CityHash([]byte("s1"), "acme-prod")
+	if c != CityHash([]byte("s1"), "acme-prod") {
+		t.Fatal("same salt+city must be deterministic")
+	}
+	if c == CityHash([]byte("s2"), "acme-prod") {
+		t.Fatal("different salt must change the hash")
+	}
+	if !isHex16(c) {
+		t.Fatalf("hash %q not 16-hex", c)
+	}
+	if CityHash([]byte("s"), "") != "" {
+		t.Fatal("empty city -> empty hash")
+	}
+	// Domain separation: a city and an actor that share a name must not collide.
+	if CityHash([]byte("s"), "shared-name") == ActorHash([]byte("s"), "shared-name") {
+		t.Fatal("CityHash must be domain-separated from ActorHash")
 	}
 }
 

--- a/pkg/eventexport/validate_test.go
+++ b/pkg/eventexport/validate_test.go
@@ -74,20 +74,44 @@ func TestValidate_ProducerPolicy(t *testing.T) {
 }
 
 func TestValidateBatch(t *testing.T) {
-	good := Batch{CityHash: "c", SchemaVersion: SchemaVersion, Events: []Envelope{refEnv(t)}}
+	const cityHash = "0123456789abcdef" // a valid opaque 16-hex partition key
+
+	good := Batch{CityHash: cityHash, SchemaVersion: SchemaVersion, Events: []Envelope{refEnv(t)}}
 	if err := ValidateBatch(good); err != nil {
 		t.Fatalf("valid batch rejected: %v", err)
 	}
 
 	// schema skew -> typed ErrSchemaMismatch (so ingest can errors.Is it).
-	skew := Batch{CityHash: "c", SchemaVersion: SchemaVersion + 1, Events: nil}
+	skew := Batch{CityHash: cityHash, SchemaVersion: SchemaVersion + 1, Events: nil}
 	err := ValidateBatch(skew)
 	if err == nil || !errors.Is(err, ErrSchemaMismatch) {
 		t.Fatalf("schema skew must wrap ErrSchemaMismatch, got %v", err)
 	}
 
+	// Receiver trust boundary: city_hash must be the opaque 16-hex partition-key
+	// shape schema v2 promises. An empty, too-short, cleartext-shaped, uppercase,
+	// or over-length value is rejected before any row is processed — the receiver
+	// cannot assume the producer redacted the operator-chosen city name.
+	for name, ch := range map[string]string{
+		"empty":          "",
+		"too short":      "c",
+		"cleartext city": "acme-prod",
+		"uppercase hex":  "0123456789ABCDEF",
+		"too long":       "0123456789abcdef0",
+	} {
+		b := Batch{CityHash: ch, SchemaVersion: SchemaVersion, Events: []Envelope{refEnv(t)}}
+		if err := ValidateBatch(b); err == nil {
+			t.Errorf("%s city_hash %q must be rejected", name, ch)
+		}
+	}
+
+	// a producer-computed city_hash is accepted (the positive end of the gate).
+	if err := ValidateBatch(Batch{CityHash: CityHash(testSalt, "acme-prod"), SchemaVersion: SchemaVersion, Events: []Envelope{refEnv(t)}}); err != nil {
+		t.Fatalf("producer-computed city_hash rejected: %v", err)
+	}
+
 	// a bad row fails with its index.
-	bad := Batch{CityHash: "c", SchemaVersion: SchemaVersion, Events: []Envelope{
+	bad := Batch{CityHash: cityHash, SchemaVersion: SchemaVersion, Events: []Envelope{
 		refEnv(t),
 		{Seq: 0, Type: "bead.closed", TS: rfc(t)}, // row 1: seq 0
 	}}

--- a/pkg/eventexport/validate_test.go
+++ b/pkg/eventexport/validate_test.go
@@ -74,20 +74,20 @@ func TestValidate_ProducerPolicy(t *testing.T) {
 }
 
 func TestValidateBatch(t *testing.T) {
-	good := Batch{CityID: "c", SchemaVersion: SchemaVersion, Events: []Envelope{refEnv(t)}}
+	good := Batch{CityHash: "c", SchemaVersion: SchemaVersion, Events: []Envelope{refEnv(t)}}
 	if err := ValidateBatch(good); err != nil {
 		t.Fatalf("valid batch rejected: %v", err)
 	}
 
 	// schema skew -> typed ErrSchemaMismatch (so ingest can errors.Is it).
-	skew := Batch{CityID: "c", SchemaVersion: SchemaVersion + 1, Events: nil}
+	skew := Batch{CityHash: "c", SchemaVersion: SchemaVersion + 1, Events: nil}
 	err := ValidateBatch(skew)
 	if err == nil || !errors.Is(err, ErrSchemaMismatch) {
 		t.Fatalf("schema skew must wrap ErrSchemaMismatch, got %v", err)
 	}
 
 	// a bad row fails with its index.
-	bad := Batch{CityID: "c", SchemaVersion: SchemaVersion, Events: []Envelope{
+	bad := Batch{CityHash: "c", SchemaVersion: SchemaVersion, Events: []Envelope{
 		refEnv(t),
 		{Seq: 0, Type: "bead.closed", TS: rfc(t)}, // row 1: seq 0
 	}}

--- a/scripts/check-eventexport-isolation.sh
+++ b/scripts/check-eventexport-isolation.sh
@@ -45,7 +45,7 @@ fi
 
 # 2. One source of truth: each projection primitive defined exactly once in
 # non-test code across the surface.
-for sym in 'allowedTypes = map' 'func ActorHash' 'func safeRef'; do
+for sym in 'allowedTypes = map' 'func ActorHash' 'func CityHash' 'func safeRef'; do
   files=$(grep -rl "$sym" pkg/eventexport internal/eventfeed cmd/gc/event_export.go 2>/dev/null || true)
   n=$(printf '%s\n' "$files" | grep -v '_test.go' | grep -c . || true)
   [ "$n" = "1" ] || fail "expected exactly one definition of '$sym' in the surface, found $n"


### PR DESCRIPTION
## What & why

Post-merge review remediation for the redacted event-export subsystem that
landed in #3654. An independent post-merge review of the landed range
`3ab9d9c8..fa9e80ea` surfaced three actionable issues. The mutable-allowlist
finding from the same review was already resolved by #3677, so this PR is the
remaining three fixes, rebased onto current `main`.

## Fixes

### Security — `city_id` egress
`Batch.city_id` shipped the raw, operator-chosen city name in every POST. A city
name can itself embed a customer/org identifier (e.g. `acme-prod`), which is
asymmetric with the projection's own redaction (it hashes every actor and drops
order slugs / scope-root names). Replaced with a salted, non-reversible
`city_hash` — a stable partition key the receiver can group on without the
cleartext leaving the box, domain-separated from `ActorHash`. **Wire change:**
`SchemaVersion` bumped to `2` so a pinned receiver rejects the change loudly
(`ValidateBatch` → `ErrSchemaMismatch`).

### Correctness — cursor durability
`LoadCursors` silently reset to an empty map on an unreadable/corrupt cursor
file. On restart that floors every tracked city at its current head and
**silently skips** every event accumulated since the last durable cursor. A
missing file (legitimate fresh start) is now distinguished from a read/parse
error; on error the exporter **fails closed** at startup with a clear log
instead of losing exports, and periodic/shutdown cursor-save failures are logged
instead of swallowed.

### Security — empty `token_file`
A configured but empty (or whitespace-only) `token_file` resolved to a silent
unauthenticated POST with no startup signal. An empty resolved token from a
configured source is now an error that holds the cursor and surfaces at startup,
while the deliberately-anonymous (no token configured) opt-out is preserved.

## Tests
- `city_hash` redaction: batch golden bytes + an exporter wire test asserting a
  customer-like city name never appears on the wire; `CityHash` determinism and
  domain separation from `ActorHash`.
- Cursor errors: unreadable, corrupt, and unwritable cursor paths; missing-file
  fresh-start stays non-error.
- Token resolution: empty/whitespace `token_file` errors; valid/inline tokens
  resolve; no-source stays anonymous.

`go build ./...`, `go vet`, the `pkg/eventexport` / `internal/eventfeed` /
`internal/supervisor` suites, the `cmd/gc` credential tests, and
`make check-eventexport-isolation` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
