### PR TITLE
feat(eventexport): stamp typed run_id/session_id at the record site (v1-compatible)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -173,13 +173,15 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 	if ep != nil {
 		recorder = ep
 	}
-	onChange := func(eventType, beadID string, payload json.RawMessage) {
+	onChange := func(eventType, beadID, runID, sessionID string, payload json.RawMessage) {
 		if recorder != nil {
 			recorder.Record(events.Event{
-				Type:    eventType,
-				Actor:   "cache-reconcile",
-				Subject: beadID,
-				Payload: payload,
+				Type:      eventType,
+				Actor:     "cache-reconcile",
+				Subject:   beadID,
+				RunID:     runID,
+				SessionID: sessionID,
+				Payload:   payload,
 			})
 		}
 	}

--- a/cmd/gc/event_export.go
+++ b/cmd/gc/event_export.go
@@ -62,9 +62,14 @@ func startEventExport(ctx context.Context, ec supervisor.ExportConfig, providers
 		TokenProvider: tokenProvider,
 		Salt:          salt,
 		ExportRef:     ec.ExportRefEnabled(),
-		BatchMax:      ec.BatchMaxEvents,
-		BatchInterval: ec.BatchIntervalDuration(),
-		Logf:          logf,
+		// Events now carry typed run_id/session_id stamped at the record site, so
+		// emit the opaque correlation ids. They are safeRef-gated and remain
+		// within the v1 wire schema (the envelope already defines both as optional
+		// omitempty fields), so this does not bump SchemaVersion.
+		EmitCorrelation: true,
+		BatchMax:        ec.BatchMaxEvents,
+		BatchInterval:   ec.BatchIntervalDuration(),
+		Logf:            logf,
 	})
 
 	cursorPath := filepath.Join(homeDir, "events-export-cursor.json")

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -455,6 +455,11 @@ type stopTarget struct {
 // metadata.session_name. Returning the empty string here would violate
 // the SessionLifecyclePayload.SessionID "always present" contract — see
 // internal/api/event_payloads.go's docstring.
+// NOTE: when used as an event's SessionID (session.stopped), the t.name
+// fallback can be a non-opaque session NAME (uppercase allowed). That is
+// intentional and safe: the export's safeRef gate DROPS a non-opaque value
+// rather than emit it — do not "fix" the gate assuming this is always an
+// opaque id.
 func (t stopTarget) lifecycleCorrelationID() string {
 	if t.sessionID != "" {
 		return t.sessionID
@@ -1831,9 +1836,10 @@ func commitStartResultTraced(
 	// failure paths above report the start as failed and retry (ga-kmoj9c).
 	fmt.Fprintf(stdout, "Woke session '%s'\n", tp.DisplayName()) //nolint:errcheck
 	rec.Record(events.Event{
-		Type:    events.SessionWoke,
-		Actor:   "gc",
-		Subject: tp.DisplayName(),
+		Type:      events.SessionWoke,
+		Actor:     "gc",
+		Subject:   tp.DisplayName(),
+		SessionID: session.ID,
 	})
 	telemetry.RecordAgentStart(context.Background(), name, tp.DisplayName(), nil)
 	if trace != nil {
@@ -2883,7 +2889,8 @@ func stopTargetsBounded(
 					stopped++
 					rec.Record(events.Event{
 						Type: events.SessionStopped, Actor: actor, Subject: result.target.subject,
-						Payload: api.SessionLifecyclePayloadJSON(result.target.lifecycleCorrelationID(), result.target.template, "stopped"),
+						SessionID: result.target.lifecycleCorrelationID(),
+						Payload:   api.SessionLifecyclePayloadJSON(result.target.lifecycleCorrelationID(), result.target.template, "stopped"),
 					})
 					telemetry.RecordAgentStop(context.Background(), result.target.name, firstNonEmptyGCString(result.target.agentName, result.target.template), "stopped", nil)
 				}
@@ -2927,7 +2934,8 @@ func stopTargetsBounded(
 			stopped++
 			rec.Record(events.Event{
 				Type: events.SessionStopped, Actor: actor, Subject: result.target.subject,
-				Payload: api.SessionLifecyclePayloadJSON(result.target.lifecycleCorrelationID(), result.target.template, "stopped"),
+				SessionID: result.target.lifecycleCorrelationID(),
+				Payload:   api.SessionLifecyclePayloadJSON(result.target.lifecycleCorrelationID(), result.target.template, "stopped"),
 			})
 			telemetry.RecordAgentStop(context.Background(), result.target.name, firstNonEmptyGCString(result.target.agentName, result.target.template), "stopped", nil)
 		}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -155,11 +155,12 @@ func recordResetStallIfDue(
 
 	if rec != nil {
 		rec.Record(events.Event{
-			Type:    events.SessionResetStalled,
-			Actor:   "gc",
-			Subject: name,
-			Message: msg,
-			Payload: events.SessionResetStalledPayloadJSON(name, template, resetCommittedAt, elapsedSeconds),
+			Type:      events.SessionResetStalled,
+			Actor:     "gc",
+			Subject:   name,
+			Message:   msg,
+			SessionID: session.ID,
+			Payload:   events.SessionResetStalledPayloadJSON(name, template, resetCommittedAt, elapsedSeconds),
 		})
 	}
 	if trace != nil {
@@ -251,10 +252,11 @@ func recordDrainAckAssignedWorkEvent(
 		return
 	}
 	rec.Record(events.Event{
-		Type:    events.SessionDrainAckedWithAssignedWork,
-		Actor:   "gc",
-		Subject: subject,
-		Message: "session drain-acked while still assigned to work bead",
+		Type:      events.SessionDrainAckedWithAssignedWork,
+		Actor:     "gc",
+		Subject:   subject,
+		Message:   "session drain-acked while still assigned to work bead",
+		SessionID: session.ID,
 		Payload: api.SessionDrainAckedWithAssignedWorkPayloadJSON(
 			session.ID,
 			strandedBead.ID,
@@ -304,11 +306,12 @@ func finalizeDrainAckStoppedSession(
 			return
 		}
 		rec.Record(events.Event{
-			Type:    events.SessionStopped,
-			Actor:   "gc",
-			Subject: template,
-			Message: "drain acknowledged by agent",
-			Payload: api.SessionLifecyclePayloadJSON(session.ID, template, "drain acknowledged"),
+			Type:      events.SessionStopped,
+			Actor:     "gc",
+			Subject:   template,
+			Message:   "drain acknowledged by agent",
+			SessionID: session.ID,
+			Payload:   api.SessionLifecyclePayloadJSON(session.ID, template, "drain acknowledged"),
 		})
 	}
 	hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
@@ -1952,10 +1955,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "restart_in_place", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
 							}
 							rec.Record(events.Event{
-								Type:    events.SessionDraining,
-								Actor:   "gc",
-								Subject: tp.DisplayName(),
-								Message: "config drift detected",
+								Type:      events.SessionDraining,
+								Actor:     "gc",
+								Subject:   tp.DisplayName(),
+								Message:   "config drift detected",
+								SessionID: session.ID,
 							})
 							alive = false
 							restartedInPlace = true
@@ -2016,10 +2020,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "drain", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
 								}
 								rec.Record(events.Event{
-									Type:    events.SessionDraining,
-									Actor:   "gc",
-									Subject: tp.DisplayName(),
-									Message: "config drift detected",
+									Type:      events.SessionDraining,
+									Actor:     "gc",
+									Subject:   tp.DisplayName(),
+									Message:   "config drift detected",
+									SessionID: session.ID,
 								})
 							}
 							continue
@@ -2889,12 +2894,13 @@ func emitSessionStrandedDiagnostic(
 	ids := strandedAssignedWorkIDs(diagnosticWork)
 	now := clk.Now().UTC()
 	rec.Record(events.Event{
-		Type:    events.SessionStranded,
-		Ts:      now,
-		Actor:   "gc",
-		Subject: session.ID,
-		Message: formatStrandedMessage(template, session.Metadata["session_name"], ids),
-		Payload: api.SessionStrandedPayloadJSON(session.ID, session.Metadata["session_name"], template, ids),
+		Type:      events.SessionStranded,
+		Ts:        now,
+		Actor:     "gc",
+		Subject:   session.ID,
+		Message:   formatStrandedMessage(template, session.Metadata["session_name"], ids),
+		SessionID: session.ID,
+		Payload:   api.SessionStrandedPayloadJSON(session.ID, session.Metadata["session_name"], template, ids),
 	})
 	// Set the in-memory marker first so a SetMetadata failure below
 	// can't cause the next tick (still seeing this same *Bead value or

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -45,7 +45,7 @@ type CachingStore struct {
 	reconciling  atomic.Bool
 	syncFailures int
 	stats        CacheStats
-	onChange     func(eventType, beadID string, payload json.RawMessage)
+	onChange     func(eventType, beadID, runID, sessionID string, payload json.RawMessage)
 	problemf     func(string)
 	problemLog   map[string]cacheProblemLogState
 
@@ -223,7 +223,12 @@ func computeAutoStagger(agentID string) time.Duration {
 //
 // BdStore-backed caches filter hook events by issue prefix. Other Store
 // implementations are valid backings, but run without foreign-event filtering.
-func NewCachingStore(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
+//
+// onChange receives the opaque run/session correlation ids resolved from the
+// changed bead's metadata at the record site (see notifyChange); the wiring
+// stamps them onto the recorded event so the redacted export can forward them
+// as typed primitives without ever decoding the payload.
+func NewCachingStore(backing Store, onChange func(eventType, beadID, runID, sessionID string, payload json.RawMessage)) *CachingStore {
 	prefix := ""
 	bdBacking := false
 	nilBdBacking := false
@@ -250,15 +255,28 @@ func NewCachingStore(backing Store, onChange func(eventType, beadID string, payl
 }
 
 // NewCachingStoreForTest wraps any Store for testing without production prefix
-// validation.
+// validation. It keeps the legacy 3-param onChange (tests do not exercise the
+// run/session ids); adaptLegacyOnChange bridges it to the production 5-param form.
 func NewCachingStoreForTest(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
-	return newCachingStore(backing, "", onChange)
+	return newCachingStore(backing, "", adaptLegacyOnChange(onChange))
 }
 
 // NewCachingStoreForTestWithPrefix wraps any Store for tests that need
 // production-style bead ID ownership filtering.
 func NewCachingStoreForTestWithPrefix(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
-	return newCachingStore(backing, idPrefix, onChange)
+	return newCachingStore(backing, idPrefix, adaptLegacyOnChange(onChange))
+}
+
+// adaptLegacyOnChange bridges the legacy 3-param onChange used by the test
+// constructors to the production 5-param form, dropping the run/session ids the
+// tests do not exercise. Nil-safe.
+func adaptLegacyOnChange(fn func(eventType, beadID string, payload json.RawMessage)) func(eventType, beadID, runID, sessionID string, payload json.RawMessage) {
+	if fn == nil {
+		return nil
+	}
+	return func(eventType, beadID string, _, _ string, payload json.RawMessage) {
+		fn(eventType, beadID, payload)
+	}
 }
 
 // SetPrimeRetryDelayForTest overrides the inter-attempt backoff Prime
@@ -268,7 +286,7 @@ func (c *CachingStore) SetPrimeRetryDelayForTest(fn func(attempt int) time.Durat
 	c.primeRetryDelay = fn
 }
 
-func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
+func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID, runID, sessionID string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
 		backing:     backing,
 		idPrefix:    normalizeIDPrefix(idPrefix),

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -7,6 +7,8 @@ import (
 	"maps"
 	"slices"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
 )
 
 // ApplyEvent updates the cache from a bd hook event. Call this when the
@@ -660,7 +662,15 @@ func (c *CachingStore) notifyChange(eventType string, b Bead) {
 		c.recordProblem(fmt.Sprintf("marshal %s notification", eventType), err)
 		return
 	}
-	c.onChange(eventType, b.ID, payload)
+	// Resolve the opaque run/session correlation ids from the bead's metadata at
+	// the record site and pass ONLY those two ids to onChange — never the
+	// free-form metadata map. The run-chain (workflow_id || molecule_id ||
+	// gc.root_bead_id || bead.ID) always resolves to a non-empty id since b.ID is
+	// non-empty; session id is a direct, optional metadata read. Both are
+	// safeRef-gated again at the export boundary.
+	runID := beadmeta.ResolveRunID(b.Metadata, b.ID, "")
+	sessionID := b.Metadata[beadmeta.SessionIDMetadataKey]
+	c.onChange(eventType, b.ID, runID, sessionID, payload)
 }
 
 type cacheNotification struct {

--- a/internal/beads/caching_store_runid_test.go
+++ b/internal/beads/caching_store_runid_test.go
@@ -1,0 +1,55 @@
+package beads
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestNotifyChangeResolvesRunSession proves notifyChange resolves the opaque
+// run/session correlation ids from the bead's metadata AT the record site and
+// passes only those two ids to onChange (never the metadata map). This is the
+// typed-at-record-site resolution that lets the redacted export carry run_id
+// without ever decoding the payload.
+func TestNotifyChangeResolvesRunSession(t *testing.T) {
+	var gotType, gotID, gotRun, gotSession string
+	cs := NewCachingStore(NewMemStore(), func(eventType, beadID, runID, sessionID string, _ json.RawMessage) {
+		gotType, gotID, gotRun, gotSession = eventType, beadID, runID, sessionID
+	})
+
+	// gc.root_bead_id resolves the run root; gc.session_id is a direct read.
+	cs.notifyChange("bead.closed", Bead{ID: "mc-1", Metadata: map[string]string{
+		"gc.root_bead_id": "wf-root-x",
+		"gc.session_id":   "sess-y",
+	}})
+	if gotType != "bead.closed" || gotID != "mc-1" {
+		t.Fatalf("event meta: type=%q id=%q, want bead.closed/mc-1", gotType, gotID)
+	}
+	if gotRun != "wf-root-x" {
+		t.Fatalf("runID = %q, want wf-root-x (gc.root_bead_id)", gotRun)
+	}
+	if gotSession != "sess-y" {
+		t.Fatalf("sessionID = %q, want sess-y (gc.session_id)", gotSession)
+	}
+
+	// workflow_id wins the run-chain precedence over gc.root_bead_id.
+	var run2 string
+	cs2 := NewCachingStore(NewMemStore(), func(_, _, runID, _ string, _ json.RawMessage) { run2 = runID })
+	cs2.notifyChange("bead.created", Bead{ID: "mc-2", Metadata: map[string]string{
+		"workflow_id":     "wf-graph-root",
+		"gc.root_bead_id": "wf-root-x",
+	}})
+	if run2 != "wf-graph-root" {
+		t.Fatalf("runID = %q, want wf-graph-root (workflow_id precedence)", run2)
+	}
+
+	// No run-chain metadata: run falls back to the bead's own id; session empty.
+	var run3, sess3 string
+	cs3 := NewCachingStore(NewMemStore(), func(_, _, runID, sessionID string, _ json.RawMessage) { run3, sess3 = runID, sessionID })
+	cs3.notifyChange("bead.created", Bead{ID: "mc-3"})
+	if run3 != "mc-3" {
+		t.Fatalf("runID fallback = %q, want mc-3 (bead's own id)", run3)
+	}
+	if sess3 != "" {
+		t.Fatalf("sessionID = %q, want empty (no gc.session_id)", sess3)
+	}
+}

--- a/internal/eventfeed/muxsource.go
+++ b/internal/eventfeed/muxsource.go
@@ -48,19 +48,21 @@ func NewMuxSource(providers func() map[string]events.Provider, cursors func() ma
 }
 
 // toExport projects a tagged event down to the exporter's closed primitive set.
-// It forwards only envelope-safe fields (seq/type/time/actor/subject); it never
-// reads Payload or Message. RunID/SessionID are left empty here: the event has
-// no typed run/session field yet, and decoding the payload to recover one would
-// reintroduce the free-form content this boundary exists to keep out. Populating
-// them is a separate, typed-at-the-record-site change.
+// It forwards only envelope-safe fields (seq/type/time/actor/subject) plus the
+// two opaque correlation ids (run_id/session_id) the record site stamped onto
+// the typed Event fields; it never reads Payload or Message, so a payload-decode
+// can never reintroduce free-form content. The ids are safeRef-gated again in
+// ProjectEvent before egress.
 func toExport(te events.TaggedEvent) eventexport.TaggedEvent {
 	return eventexport.TaggedEvent{
-		City:    te.City,
-		Seq:     te.Seq,
-		Type:    te.Type,
-		Ts:      te.Ts,
-		Actor:   te.Actor,
-		Subject: te.Subject,
+		City:      te.City,
+		Seq:       te.Seq,
+		Type:      te.Type,
+		Ts:        te.Ts,
+		Actor:     te.Actor,
+		Subject:   te.Subject,
+		RunID:     te.RunID,
+		SessionID: te.SessionID,
 	}
 }
 

--- a/internal/eventfeed/muxsource_test.go
+++ b/internal/eventfeed/muxsource_test.go
@@ -108,7 +108,10 @@ func TestMuxSource_YieldsAndPicksUpNewCity(t *testing.T) {
 // never sees an events.Event). It also confirms #3654 does NOT resolve run_id by
 // decoding the payload: the run-root id buried in metadata must NOT appear.
 func TestAdapter_NoLeakFromPayload(t *testing.T) {
-	opt := eventexport.Options{Salt: []byte("sixteen-byte-salt-xx"), ExportRef: true}
+	// EmitCorrelation:true so emission is ON — proving the gc.root_bead_id buried
+	// in Payload metadata is STILL not promoted to run_id (toExport reads only the
+	// typed Event fields, which this corpus leaves empty).
+	opt := eventexport.Options{Salt: []byte("sixteen-byte-salt-xx"), ExportRef: true, EmitCorrelation: true}
 	ts := time.Date(2026, 6, 21, 10, 3, 27, 0, time.UTC)
 	corpus := []events.Event{
 		{
@@ -150,13 +153,36 @@ func TestAdapter_NoLeakFromPayload(t *testing.T) {
 			t.Fatalf("LEAK: adapter batch contains %q\n%s", f, blob)
 		}
 	}
-	// run_id/session_id must be ABSENT (the adapter does not resolve them in #3654).
+	// run_id/session_id must be ABSENT: the corpus carries them only inside Payload
+	// metadata, and toExport never decodes Payload — it forwards only the typed
+	// Event fields, which are empty here.
 	for _, en := range batch.Events {
 		if en.RunID != "" || en.SessionID != "" {
-			t.Fatalf("adapter must not populate run/session yet, got %+v", en)
+			t.Fatalf("adapter must not extract run/session from payload, got %+v", en)
 		}
 	}
 	if len(batch.Events) < 3 {
 		t.Fatalf("expected allowlisted events to survive, got %d", len(batch.Events))
+	}
+}
+
+// TestToExport_ForwardsTypedRunSession proves the adapter forwards the typed
+// Event.RunID/SessionID (stamped at the record site) through to the projected
+// envelope when EmitCorrelation is on.
+func TestToExport_ForwardsTypedRunSession(t *testing.T) {
+	te := events.TaggedEvent{
+		Event: events.Event{
+			Seq: 1, Type: "bead.closed", Ts: time.Date(2026, 6, 21, 10, 3, 27, 0, time.UTC),
+			Actor: "cache-reconcile", Subject: "mc-1", RunID: "wf-root-abc", SessionID: "sess-9f2a",
+		},
+		City: "c",
+	}
+	ex := toExport(te)
+	if ex.RunID != "wf-root-abc" || ex.SessionID != "sess-9f2a" {
+		t.Fatalf("toExport must forward typed run/session, got run=%q session=%q", ex.RunID, ex.SessionID)
+	}
+	env, ok := eventexport.ProjectEvent(ex, eventexport.Options{Salt: []byte("sixteen-byte-salt-xx"), ExportRef: true, EmitCorrelation: true})
+	if !ok || env.RunID != "wf-root-abc" || env.SessionID != "sess-9f2a" {
+		t.Fatalf("projected envelope must carry forwarded run/session, got %+v", env)
 	}
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -229,14 +229,23 @@ var KnownEventTypes = []string{
 }
 
 // Event is a single recorded occurrence in the system.
+//
+// RunID/SessionID are opaque correlation ids stamped at the record site (run
+// root via the bead metadata run-chain; session bead id), used by downstream
+// consumers to join an event to its run/session. They are additive and
+// omitempty: old records lack them and unmarshal as "". They are NOT derived
+// from Payload — the redacted export forwards them as typed primitives, never by
+// decoding the free-form payload.
 type Event struct {
-	Seq     uint64          `json:"seq"`
-	Type    string          `json:"type"`
-	Ts      time.Time       `json:"ts"`
-	Actor   string          `json:"actor"`
-	Subject string          `json:"subject,omitempty"`
-	Message string          `json:"message,omitempty"`
-	Payload json.RawMessage `json:"payload,omitempty"`
+	Seq       uint64          `json:"seq"`
+	Type      string          `json:"type"`
+	Ts        time.Time       `json:"ts"`
+	Actor     string          `json:"actor"`
+	Subject   string          `json:"subject,omitempty"`
+	Message   string          `json:"message,omitempty"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+	RunID     string          `json:"run_id,omitempty"`
+	SessionID string          `json:"session_id,omitempty"`
 }
 
 // Recorder records events. Safe for concurrent use. Best-effort.

--- a/pkg/eventexport/exporter.go
+++ b/pkg/eventexport/exporter.go
@@ -47,6 +47,7 @@ type Config struct {
 	Salt              []byte
 	ExportRef         bool
 	Profile           Profile
+	EmitCorrelation   bool          // emit opaque run_id/session_id (default false)
 	BatchMax          int           // max events per POST (default 1000)
 	BatchInterval     time.Duration // max time between POSTs (default 5s)
 	MaxPendingPerCity int           // backpressure threshold (default 50000)
@@ -175,9 +176,7 @@ func (e *Exporter) ingest(te TaggedEvent) {
 		return // already processed (resume overlap)
 	}
 	e.high[te.City] = te.Seq
-	// EmitCorrelation stays false in v0: run_id/session_id ship empty until the
-	// typed-at-record-site follow-up lands (then Config gains the toggle).
-	opt := Options{Salt: e.cfg.Salt, ExportRef: e.cfg.ExportRef, Profile: e.cfg.Profile}
+	opt := Options{Salt: e.cfg.Salt, ExportRef: e.cfg.ExportRef, Profile: e.cfg.Profile, EmitCorrelation: e.cfg.EmitCorrelation}
 	env, ok := ProjectEvent(te, opt)
 	if !ok {
 		return

--- a/pkg/eventexport/exporter_test.go
+++ b/pkg/eventexport/exporter_test.go
@@ -201,6 +201,54 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
+// TestExporter_EmitCorrelation proves the end-to-end exported batch carries
+// run_id/session_id only when Config.EmitCorrelation is true (the v1-compatible
+// opt-in; SchemaVersion stays 1 since the envelope already defines the fields).
+func TestExporter_EmitCorrelation(t *testing.T) {
+	run := func(emit bool) Batch {
+		cp := &capture{}
+		srv := httptest.NewServer(http.HandlerFunc(cp.handler))
+		defer srv.Close()
+		src := &chanSource{ch: make(chan TaggedEvent, 4)}
+		exp := New(Config{
+			Endpoint: srv.URL, Salt: testSalt, ExportRef: true, EmitCorrelation: emit,
+			BatchMax: 100, BatchInterval: 10 * time.Millisecond, MaxPendingPerCity: 1000,
+			Client: srv.Client(),
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() { _ = exp.Run(ctx, src); close(done) }()
+		src.ch <- TaggedEvent{City: "c1", Seq: 1, Type: "bead.closed", Ts: fixedTS, Actor: "ctl", Subject: "mc-1", RunID: "wf-root-abc", SessionID: "sess-9f2a"}
+		waitFor(t, 2*time.Second, func() bool { return exp.Cursors()["c1"] == 1 })
+		cancel()
+		<-done
+		all := cp.all()
+		if len(all) == 0 || len(all[0].Events) == 0 {
+			t.Fatalf("expected at least one exported event")
+		}
+		// schema_version must stay 1 regardless of correlation emission.
+		if all[0].SchemaVersion != 1 {
+			t.Fatalf("schema_version = %d, want 1 (emitting run/session is v1-compatible)", all[0].SchemaVersion)
+		}
+		return all[0]
+	}
+
+	on := run(true)
+	if on.Events[0].RunID != "wf-root-abc" || on.Events[0].SessionID != "sess-9f2a" {
+		t.Fatalf("EmitCorrelation=true must carry run/session, got %+v", on.Events[0])
+	}
+	// Headline invariant: a v1-pinned receiver accepts the populated batch with no
+	// schema mismatch — emitting run/session is v1-compatible (no flag day).
+	if err := ValidateBatch(on); err != nil {
+		t.Fatalf("v1 receiver must accept a populated batch: %v", err)
+	}
+
+	off := run(false)
+	if off.Events[0].RunID != "" || off.Events[0].SessionID != "" {
+		t.Fatalf("EmitCorrelation=false must drop run/session, got %+v", off.Events[0])
+	}
+}
+
 // TestExporter_NoTokenProviderNoAuthHeader proves a nil TokenProvider sends no
 // Authorization header (the unauthenticated opt-out), mirroring the old empty-
 // token behavior.

--- a/pkg/eventexport/project.go
+++ b/pkg/eventexport/project.go
@@ -141,7 +141,7 @@ type Options struct {
 	Salt            []byte  // actor-hash salt; must be >= 16 bytes (ProjectEvent fails closed otherwise)
 	ExportRef       bool    // include the id-gated ref (opaque ids/slugs only)
 	Profile         Profile // redaction profile (default ProfileRedactedEnvelope)
-	EmitCorrelation bool    // emit opaque run_id/session_id; default false (they ship empty in v0)
+	EmitCorrelation bool    // emit opaque run_id/session_id; default false (the production export sets it true)
 }
 
 // ActorHash returns a salted, non-reversible, 16-hex fingerprint of an actor.
@@ -167,8 +167,8 @@ func ActorHash(salt []byte, actor string) string {
 //
 // It fails closed (ok=false) for a non-allowlisted type, seq==0, a zero
 // timestamp, or a salt shorter than 16 bytes. run_id/session_id are emitted only
-// when opt.EmitCorrelation is set (they ship empty in v0) and only if opaque;
-// like ref, an opaque id over 64 bytes is DROPPED, not truncated.
+// when opt.EmitCorrelation is set and only if opaque; like ref, an opaque id over
+// 64 bytes is DROPPED, not truncated.
 func ProjectEvent(te TaggedEvent, opt Options) (Envelope, bool) {
 	if !allowedTypes[te.Type] {
 		return Envelope{}, false

--- a/pkg/eventexport/project_test.go
+++ b/pkg/eventexport/project_test.go
@@ -95,7 +95,7 @@ func TestProjectEvent_RejectsShortSalt(t *testing.T) {
 
 func TestProjectEvent_RunSessionGating(t *testing.T) {
 	// EmitCorrelation must be set for run_id/session_id to appear at all (the
-	// fail-closed M1 default: they ship empty in v0).
+	// fail-closed default; the production export sets it true).
 	off := Options{Salt: testSalt, ExportRef: true}
 	got, _ := proj(1, "bead.closed", "gc", "mc-1", "wf-root-abc", "sess-9f2a", off)
 	if got.RunID != "" || got.SessionID != "" {


### PR DESCRIPTION
## What & why

Lights up the `run_id` trace spine end-to-end: events now carry **typed, opaque `run_id`/`session_id`** stamped **at the record site** (never by decoding the free-form payload), so a downstream consumer can join an event to its run/session — and, with `manifold.spend` already keyed on `run_id`, join events to spend.

**This stays at `SchemaVersion = 1` — no flag day.** The merged hardening deliberately made `run_id`/`session_id` optional `omitempty` fields of the v1 envelope (`ValidateEnvelope` accepts them; the populated golden is pinned at v1). Emitting them is *using* the v1 schema, not changing it: a v1-pinned consumer (`ValidateBatch` checks `schema_version==1`; `ValidateEnvelope` accepts opaque run/session) accepts populated batches with **no `ErrSchemaMismatch` and no mis-parse**. So this is a producer-only change, consumer-transparent.

## How

- **`events.Event`** gains `RunID`/`SessionID` (omitempty) — additive, backward-compatible (old `events.jsonl` lines unmarshal them as `""`; SSE `WireEvent` and rotation are untouched; the export reads them via the multiplexer's `TaggedEvent`, which embeds `Event`).
- **bead.created/closed** (one record path): `internal/beads.notifyChange` resolves at the record site — `RunID = beadmeta.ResolveRunID(b.Metadata, b.ID, "")` (run-chain `workflow_id || molecule_id || gc.root_bead_id || bead.ID`), `SessionID = b.Metadata["gc.session_id"]` — and threads **only the two opaque ids** to `onChange` (the metadata map never leaves `internal/beads`). The export trust boundary remains `toExport`, which forwards only typed primitives and never reads `Payload`.
- **onChange signature** widened to 5-param on `NewCachingStore` (sole non-nil caller `api_state.go`); `NewCachingStoreForTest*` keep the legacy 3-param via an internal `adaptLegacyOnChange` shim — **zero test-file churn** across ~280 call sites.
- **session.* events**: `SessionID` = the in-scope session id; `RunID` empty (sessions have no run linkage — `gc.current_run_id` is crucible-proxy-written and absent at these Go sites). Non-opaque values are safeRef-dropped downstream (fail-safe).
- **order/infra events**: no run/session context → both empty.
- **emission**: `Config.EmitCorrelation` threaded into `Options` in `ingest`; `cmd/gc` sets it `true` now that events carry the typed fields. `ProjectEvent` safeRef-gates run/session before egress.

## Per-type matrix
| type | RunID | SessionID |
|---|---|---|
| bead.created, bead.closed | `ResolveRunID(meta, id, "")` | `meta["gc.session_id"]` |
| session.* (6) | "" | session id (opaque) |
| order.*, convoy.closed, controller.started, events.rotated, project.identity.stamped, gc.store.maintenance.done | "" | "" |

## Verification
`go build ./...`, `go vet`, golangci-lint (0 issues), `go test -race` (events/beads/eventfeed/eventexport incl. new `TestNotifyChangeResolvesRunSession`, `TestToExport_ForwardsTypedRunSession`, `TestExporter_EmitCorrelation`, strengthened `TestAdapter_NoLeakFromPayload`), `make check-eventexport-isolation`, and `TestRequiresDedicatedTestenvImportFile` all green. `SchemaVersion` and the batch golden unchanged (proven v1-compatible).

Per window 11's AC1. Resolution is typed-at-record-site (never payload-decode), reviewed for the leak boundary. Consumers (already pinned to `…@7f39639d1`) need no schema change — they begin seeing populated run/session once the AC1 `gc` producer ships via the normal release cadence.
