### PR TITLE
Fail closed on partial pool demand reads

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -55,6 +55,12 @@ type agentBuildParams struct {
 	// may still be reused, and dependency-floor prerequisites are exempt.
 	poolSessionCreateBudget *poolSessionCreateBudget
 
+	// poolScaleCheckPartialTemplates is the set of pool templates whose demand
+	// read failed (partial) in this build cycle. Creates for these templates are
+	// blocked; only existing beads may be reused or resumed. Symmetric with the
+	// drain gates already applied for partial reads.
+	poolScaleCheckPartialTemplates map[string]bool
+
 	// beadNames caches qualifiedName → session_name mappings resolved
 	// during this build cycle. Populated lazily by resolveSessionName.
 	beadNames map[string]string

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -87,7 +87,10 @@ type defaultScaleCheckTarget struct {
 	err      error
 }
 
-var errPoolSessionCreateBudgetExhausted = errors.New("pool session create budget exhausted")
+var (
+	errPoolSessionCreateBudgetExhausted = errors.New("pool session create budget exhausted")
+	errPoolScaleCheckPartialCreate      = errors.New("pool session create blocked: scale_check partial for this template")
+)
 
 // poolSessionCreateFairShareCounter rotates scarce create tokens across
 // contending pools so stable template sort order does not always win.
@@ -737,6 +740,7 @@ func buildDesiredStateWithSessionBeads(
 		bp.assignedWorkBeads = poolWorkBeads
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
 		bp.configurePoolSessionCreateFairShare(poolDesiredStates)
+		bp.poolScaleCheckPartialTemplates = poolScaleCheckPartialTemplates
 		for _, poolState := range poolDesiredStates {
 			cfgAgent := findAgentByTemplate(cfg, poolState.Template)
 			if cfgAgent == nil {
@@ -1561,10 +1565,10 @@ func scaleCheckPartialSessionPreservable(b beads.Bead) bool {
 
 func scaleCheckPartialSessionRetainable(b beads.Bead) bool {
 	switch strings.TrimSpace(b.Metadata["state"]) {
-	case "active", "awake", "start-pending", "creating":
+	case "active", "awake":
 		return true
 	default:
-		return isPendingPoolCreate(b)
+		return false
 	}
 }
 
@@ -2184,9 +2188,13 @@ func realizePoolDesiredSessions(
 			}
 			sessionBead, slot, plan, err := selectOrPlanPoolSessionBead(bp, cfgAgent, qualifiedName, prefer, used, usedSlots)
 			if err != nil {
-				if errors.Is(err, errPoolSessionCreateBudgetExhausted) {
+				switch {
+				case errors.Is(err, errPoolScaleCheckPartialCreate):
+					// debug-level: fires every tick during store contention; not operator noise
+					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
+				case errors.Is(err, errPoolSessionCreateBudgetExhausted):
 					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (fresh create deferred)\n", qualifiedName, err) //nolint:errcheck
-				} else {
+				default:
 					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
 				}
 				item.skip = true
@@ -2940,6 +2948,15 @@ func selectOrPlanPoolSessionBead(
 	}
 	slot := claimDesiredPoolSlot(bp.city, cfgAgent, beads.Bead{}, usedSlots)
 	_, qualifiedInstance, poolSlot := poolDesiredRequestIdentity(cfgAgent, slot)
+
+	// Partial demand read: refuse new creates for this template this tick.
+	// Only existing beads (reuse/resume paths above) may be selected.
+	// Symmetric with the drain gates in discoverSessionBeadsWithRoots and
+	// the reconciler's !storeQueryPartial rollback guard.
+	if bp.poolScaleCheckPartialTemplates[template] {
+		delete(usedSlots, slot)
+		return beads.Bead{}, 0, nil, errPoolScaleCheckPartialCreate
+	}
 
 	if !bp.tryClaimPoolSessionCreate(template) {
 		delete(usedSlots, slot)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1554,9 +1554,11 @@ func retainScaleCheckPartialPoolDesired(cfg *config.City, counts map[string]int,
 
 // Preserve dormant affected-template beads during transient scale_check
 // failures, but do not count them as awake demand.
+// draining/drained/archived beads are NOT preserved: they should continue their
+// lifecycle regardless of whether the template's demand read succeeded or failed.
 func scaleCheckPartialSessionPreservable(b beads.Bead) bool {
 	switch strings.TrimSpace(b.Metadata["state"]) {
-	case "", "active", "awake", "start-pending", "creating", "asleep", "stopped", "suspended", "quarantined", "draining", "drained", "archived":
+	case "", "active", "awake", "start-pending", "creating", "asleep", "stopped", "suspended", "quarantined":
 		return true
 	default:
 		return isPendingPoolCreate(b)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -10453,3 +10453,125 @@ func TestOpenControlDispatcherDemandHonorsBareLegacyRoute(t *testing.T) {
 		t.Fatalf("openControlDispatcherDemand = %v, want demand keyed by qualified name from bare route", demand)
 	}
 }
+
+// TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates verifies that
+// when a pool template's scale_check read is partial, the supervisor blocks
+// new session creates for that template (Change 1) while retaining existing
+// confirmed-alive sessions. Also tests that scaleCheckPartialSessionRetainable
+// counts only active/awake sessions, not creating/start-pending (Change 2).
+func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
+	cityPath := t.TempDir()
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "echo",
+			MinActiveSessions: intPtr(1),
+			MaxActiveSessions: intPtr(3),
+		}},
+	}
+
+	t.Run("NoExistingSessions_NoCreates", func(t *testing.T) {
+		store := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
+		var stderr strings.Builder
+		result := buildDesiredStateWithSessionBeads(
+			"test-city",
+			cityPath,
+			time.Now().UTC(),
+			cfg,
+			runtime.NewFake(),
+			store,
+			nil,
+			newSessionBeadSnapshot(nil),
+			nil,
+			&stderr,
+		)
+		if !result.PoolScaleCheckPartialTemplates["worker"] {
+			t.Fatalf("PoolScaleCheckPartialTemplates[worker] = false, want true; stderr=%s", stderr.String())
+		}
+		for k, tp := range result.State {
+			if tp.TemplateName == "worker" {
+				t.Fatalf("partial guard failed: desired state got worker session %q; stderr=%s", k, stderr.String())
+			}
+		}
+	})
+
+	t.Run("OneActiveSession_Retained_NoNew", func(t *testing.T) {
+		activeSession := beads.Bead{
+			ID:     "session-worker-active-1",
+			Title:  "worker",
+			Type:   sessionBeadType,
+			Status: "open",
+			Labels: []string{sessionBeadLabel, "template:worker"},
+			Metadata: map[string]string{
+				"session_name":         "worker-active-bd-1",
+				"template":             "worker",
+				"agent_name":           "worker",
+				"pool_slot":            "1",
+				poolManagedMetadataKey: boolMetadata(true),
+				"state":                "active",
+			},
+		}
+		store := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
+		var stderr strings.Builder
+		result := buildDesiredStateWithSessionBeads(
+			"test-city",
+			cityPath,
+			time.Now().UTC(),
+			cfg,
+			runtime.NewFake(),
+			store,
+			nil,
+			newSessionBeadSnapshot([]beads.Bead{activeSession}),
+			nil,
+			&stderr,
+		)
+		if !result.PoolScaleCheckPartialTemplates["worker"] {
+			t.Fatalf("PoolScaleCheckPartialTemplates[worker] = false, want true; stderr=%s", stderr.String())
+		}
+		if _, ok := result.State["worker-active-bd-1"]; !ok {
+			t.Fatalf("existing active session not retained; state keys=%v stderr=%s", mapKeys(result.State), stderr.String())
+		}
+		// Confirm no second session was created beyond the retained active one.
+		workerCount := 0
+		for _, tp := range result.State {
+			if tp.TemplateName == "worker" {
+				workerCount++
+			}
+		}
+		if workerCount != 1 {
+			t.Fatalf("want exactly 1 worker session (retained), got %d; state=%v stderr=%s", workerCount, mapKeys(result.State), stderr.String())
+		}
+	})
+
+	t.Run("RetainableCountsOnlyActiveAwake", func(t *testing.T) {
+		partial := map[string]bool{"worker": true}
+		snapshot := newSessionBeadSnapshot([]beads.Bead{
+			{
+				ID: "s-active", Type: sessionBeadType, Status: "open",
+				Labels:   []string{sessionBeadLabel, "template:worker"},
+				Metadata: map[string]string{"template": "worker", "state": "active", poolManagedMetadataKey: boolMetadata(true)},
+			},
+			{
+				ID: "s-awake", Type: sessionBeadType, Status: "open",
+				Labels:   []string{sessionBeadLabel, "template:worker"},
+				Metadata: map[string]string{"template": "worker", "state": "awake", poolManagedMetadataKey: boolMetadata(true)},
+			},
+			{
+				ID: "s-creating", Type: sessionBeadType, Status: "open",
+				Labels:   []string{sessionBeadLabel, "template:worker"},
+				Metadata: map[string]string{"template": "worker", "state": "creating", poolManagedMetadataKey: boolMetadata(true)},
+			},
+			{
+				ID: "s-start-pending", Type: sessionBeadType, Status: "open",
+				Labels:   []string{sessionBeadLabel, "template:worker"},
+				Metadata: map[string]string{"template": "worker", "state": "start-pending", poolManagedMetadataKey: boolMetadata(true)},
+			},
+		})
+		got := retainScaleCheckPartialPoolDesired(cfg, nil, snapshot, partial)
+		if got["worker"] != 2 {
+			t.Fatalf("retainScaleCheckPartialPoolDesired[worker] = %d, want 2 (active+awake only, not creating/start-pending)", got["worker"])
+		}
+	})
+}

--- a/release-gates/ga-zu2rsu-partial-demand-runaway-fix-gate.md
+++ b/release-gates/ga-zu2rsu-partial-demand-runaway-fix-gate.md
@@ -1,0 +1,33 @@
+# Release Gate: partial-demand runaway fix
+
+Bead: `ga-zu2rsu`  
+Source fix: `ga-01yukx` Changes 1-3  
+Branch: `builder/ga-01yukx-partial-demand-fix`  
+Reviewed commit: `8f032557bb04cacf2b1d56033adb569107faa1c8`  
+Base: `origin/main` at `32ca47acd639b80eee37f4623d0277018b674c06`
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate uses the deployer role's release criteria and the repo's `TESTING.md`/Makefile gates.
+
+## Gate Result
+
+PASS.
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-5h3l4j` is closed with `Reviewer verdict: PASS` for commits `73f15a956` and `8f032557b`. Reviewer recorded no blockers and no security findings. |
+| 2 | Acceptance criteria met | PASS | FR-01: `selectOrPlanPoolSessionBead` blocks fresh creates when `poolScaleCheckPartialTemplates[template]` is true, after reuse/resume paths. FR-02: active/awake pool sessions are retained. FR-03: creating/start-pending sessions are preserved by the desired overlay but no longer counted as wake demand. FR-04/Change 3: partial overlay uses `scaleCheckPartialSessionPreservable`, so draining/drained/archived sessions are not revived. NFR-01/NFR-03: behavior is centralized in desired-state build logic and applies to every pool template without config. NFR-02: resume requests with `SessionBeadID` follow the reuse path before the create guard. |
+| 3 | Tests pass | PASS | Focused regression: `go test ./cmd/gc -run 'TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates|TestCityRuntimeBeadReconcileTick_ScaleCheckPartialKeepsOnlyAffectedPoolSession|TestCityRuntimeBeadReconcileTick_ScaleCheckPartialPreservesDormantAffectedPoolSessionWithoutDrain|TestBuildDesiredState_NamedBackedPoolPartialRetainsGenericPoolSession|TestRetainScaleCheckPartialPoolDesiredNormalizesLegacyBoundTemplate'` passed. First `make test-fast-parallel` run failed in unrelated tests (`examples/gastown`, `internal/beads`, `internal/eventfeed`); each exact failing test passed on isolated rerun. Second full `make test-fast-parallel` passed all shards. `go vet ./...` passed. `go build ./cmd/gc` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-5h3l4j` report no blockers, no security findings, and only one non-blocking INFO comment wording observation. |
+| 5 | Final branch is clean | PASS | Gate worktree was clean before this file was added; generated `gc` build artifact was removed. Deployer verifies `git status --short --branch` is clean after the gate commit and before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base origin/main fork/builder/ga-01yukx-partial-demand-fix` returned `32ca47acd639b80eee37f4623d0277018b674c06`; `git merge-tree $(git merge-base 8f032557b origin/main) 8f032557b origin/main` produced no conflicts. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem and one behavior: `cmd/gc` supervisor desired-state handling for pool partial demand reads. Changed files are `cmd/gc/agent_build_params.go`, `cmd/gc/build_desired_state.go`, and `cmd/gc/build_desired_state_test.go`. |
+
+## Test Log Notes
+
+- Initial fast-suite log directory: `/tmp/gc-local-tests.ggMhCv`
+- Initial transient failures:
+  - `go test ./examples/gastown -run TestReaperClosesGraphWorkflowWispTrackedToClosedRoot`
+  - `go test ./internal/beads -run TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand`
+  - `go test ./internal/eventfeed -run TestMuxSource_YieldsAndPicksUpNewCity`
+- Immediate isolated reruns of all three tests passed.
+- Full `make test-fast-parallel` rerun passed.


### PR DESCRIPTION
## What this changes

Pool supervisors now fail closed when a pool template's demand read is partial. During that tick, the desired-state builder can still reuse or resume existing session beads, but it refuses to create fresh pool sessions for the affected template. That prevents a transient beads/store failure from ratcheting pool size upward.

Confirmed live sessions continue to be retained. Creating and start-pending sessions are preserved so they are not drained prematurely, but they no longer inflate wake demand. Draining, drained, and archived session beads are not revived by a partial read.

The create guard is intentionally placed in the pool session selection path after all reuse and resume paths. That keeps legitimate assigned-work resumes moving while blocking only the fresh-create branch that caused the runaway behavior.

## Review notes

- `cmd/gc/agent_build_params.go` carries the pool-specific partial-template set into pool realization.
- `cmd/gc/build_desired_state.go` adds the fresh-create guard, narrows partial retain counts to active/awake sessions, and uses the preservable-state predicate for partial desired-state overlay.
- `cmd/gc/build_desired_state_test.go` adds regression coverage for zero-existing sessions, active-session retention, and confirmed-alive-only retain counts.
- No config, API, schema, or dashboard behavior changes.

## Test plan

- [x] `go test ./cmd/gc -run 'TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates|TestCityRuntimeBeadReconcileTick_ScaleCheckPartialKeepsOnlyAffectedPoolSession|TestCityRuntimeBeadReconcileTick_ScaleCheckPartialPreservesDormantAffectedPoolSessionWithoutDrain|TestBuildDesiredState_NamedBackedPoolPartialRetainsGenericPoolSession|TestRetainScaleCheckPartialPoolDesiredNormalizesLegacyBoundTemplate'`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build ./cmd/gc`
- [x] Release gate: [`release-gates/ga-zu2rsu-partial-demand-runaway-fix-gate.md`](release-gates/ga-zu2rsu-partial-demand-runaway-fix-gate.md)
