### PR TITLE
fix(dolt-cleanup): skip non-dolt-backed rigs instead of force-blocking (az-374)

### DIFF
--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -948,6 +948,12 @@ func rigProtections(rigs []resolverRig, fs fsys.FS) ([]CleanupRigProtection, []r
 	var errs []rigProtectionError
 	for _, r := range orderRigsHQFirst(rigs) {
 		resolution := resolveRigDoltDatabase(r, fs)
+		if resolution.skip {
+			// Non-dolt-backed rig (e.g. mysql): not a dolt-cleanup target, so
+			// omit it from rig protections. It is then neither counted as a
+			// force_blocker nor selected for forced drop/purge (az-374).
+			continue
+		}
 		out = append(out, CleanupRigProtection{Rig: r.Name, DB: resolution.name})
 		if resolution.err != nil {
 			errs = append(errs, rigProtectionError{rig: r.Name, err: resolution.err})
@@ -1006,6 +1012,11 @@ func rigDoltDatabaseName(r resolverRig, fs fsys.FS) string {
 type rigDoltDatabaseResolution struct {
 	name string
 	err  error
+	// skip is set when the rig declares a non-dolt backend (e.g. mysql) and
+	// therefore has no dolt database for dolt-cleanup to verify, drop, or
+	// purge. Such rigs are excluded from rig protections rather than being
+	// treated as a force_blocker for a missing dolt_database (az-374).
+	skip bool
 }
 
 func resolveRigDoltDatabase(r resolverRig, fs fsys.FS) rigDoltDatabaseResolution {
@@ -1034,6 +1045,14 @@ func resolveRigDoltDatabase(r resolverRig, fs fsys.FS) rigDoltDatabaseResolution
 		return rigDoltDatabaseResolution{
 			name: r.Name,
 			err:  fmt.Errorf("parse rig metadata %s: %w", metadataPath, err),
+		}
+	}
+	// A rig that declares a non-dolt backend (e.g. mysql) has no dolt database
+	// for dolt-cleanup to act on. Skip it instead of reporting the absent
+	// dolt_database as a rig-protection force_blocker (az-374).
+	if backend, ok := meta["backend"].(string); ok {
+		if b := strings.TrimSpace(strings.ToLower(backend)); b != "" && b != "dolt" {
+			return rigDoltDatabaseResolution{name: r.Name, skip: true}
 		}
 	}
 	if db, ok := meta["dolt_database"]; ok {

--- a/cmd/gc/cmd_dolt_cleanup_test.go
+++ b/cmd/gc/cmd_dolt_cleanup_test.go
@@ -1248,6 +1248,65 @@ func TestRunDoltCleanup_RigsProtectedReadsDoltDatabaseFromMetadata(t *testing.T)
 	}
 }
 
+func TestRunDoltCleanup_SkipsNonDoltBackedRig(t *testing.T) {
+	// az-374: a rig whose metadata.json declares a non-dolt backend (e.g.
+	// mysql) has no dolt database for dolt-cleanup to verify, drop, or purge.
+	// It MUST be skipped — excluded from rigs_protected and never counted as a
+	// rig-protection force_blocker — rather than being treated as one for
+	// lacking dolt_database. A dolt-backed rig in the same city is unaffected.
+	fs := fsys.NewFake()
+	fs.Files["/city/.beads/metadata.json"] = []byte(`{"backend":"mysql","database":"anthony_beads"}`)
+	fs.Files["/rigs/doltrig/.beads/metadata.json"] = []byte(`{"dolt_database":"doltrig_db"}`)
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs: []resolverRig{
+			{Name: "city", Path: "/city", HQ: true},
+			{Name: "doltrig", Path: "/rigs/doltrig"},
+		},
+		FS:                fs,
+		JSON:              true,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%s", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+
+	// The mysql-backed rig must not trip rig-protection.
+	if len(r.ForceBlockers) != 0 {
+		t.Fatalf("ForceBlockers = %+v, want none (mysql-backed rig must be skipped)", r.ForceBlockers)
+	}
+	if hasRigProtectionError(&r) {
+		t.Fatalf("unexpected rig-protection error; mysql-backed rig must be skipped: %+v", r.Errors)
+	}
+	if r.Summary.ErrorsTotal != 0 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+
+	// The mysql-backed rig is skipped (absent from rigs_protected); the
+	// dolt-backed rig is still protected with its metadata dolt_database.
+	for _, rp := range r.RigsProtected {
+		if rp.Rig == "city" {
+			t.Errorf("mysql-backed rig 'city' must be skipped, but found in RigsProtected: %+v", rp)
+		}
+	}
+	want := CleanupRigProtection{Rig: "doltrig", DB: "doltrig_db"}
+	found := false
+	for _, rp := range r.RigsProtected {
+		if rp == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("dolt-backed rig %+v missing from RigsProtected; got %+v", want, r.RigsProtected)
+	}
+}
+
 func TestRunDoltCleanup_DryRunReportsUnsafeRigDatabaseName(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/rigs/foo/.beads/metadata.json"] = []byte(`{"dolt_database":"foo db"}`)


### PR DESCRIPTION
## Problem (az-374, P1)

`gc dolt-cleanup` reads every rig's `.beads/metadata.json` for a `dolt_database` name and, when absent, records a rig-protection **force_blocker**. A **mysql-backed rig** (`backend=mysql`, no `dolt_database`) therefore trips rig-protection on every probe — e.g. the `anthony` HQ rig and the `kit` rig — producing spurious force_blockers (`az-wisp-fnxyi2`) and keeping the `dolt.dog` formula re-probing ~30× since 2026-06-15, even though cleanup correctly **fails SAFE** (dropped 0 / reaped 0).

Same mysql-not-topology-aware root family as az-of4.

## Fix

A rig that declares a **non-dolt backend** has no dolt database for dolt-cleanup to verify, drop, or purge. `resolveRigDoltDatabase` now flags such rigs (`skip=true`) and `rigProtections` omits them, so they are **neither counted as force_blockers nor selected for forced drop/purge**.

- Keyed on the `backend` metadata field (`backend != "" && backend != "dolt"`), so:
  - dolt-backed rigs are unchanged;
  - rigs that merely lack `dolt_database` **without** declaring a non-dolt backend still fall back to `rig.Name` exactly as before (existing `{"database":"sqlite"}` behavior preserved).

## Test

`TestRunDoltCleanup_SkipsNonDoltBackedRig`: a city with a mysql-backed rig + a dolt-backed rig asserts **0 force_blockers**, the mysql rig **skipped** (absent from `rigs_protected`), and the dolt rig still protected by its `dolt_database`. Verified **PASS with the fix, FAIL without it**. `gofmt` + `go vet` clean; full `DoltCleanup` suite green.

## Notes

- Confined to `cmd/gc/cmd_dolt_cleanup.go` (+ test) — no overlap with the in-flight az-of4 branch.
- Should stop the recurring `kit/.beads/metadata.json` mysql-clobber churn driven by the repeated probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)