### PR TITLE
fix(supervisor): harden pool demand and create gates

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -62,6 +62,14 @@ type agentBuildParams struct {
 	// evaluatePendingPoolsMap runs; newAgentBuildParams does not set it.
 	poolScaleCheckPartialTemplates map[string]bool
 
+	// providerHealthSnapshot is the per-build provider-health registry view.
+	// Loaded once at the start of buildDesiredState; nil when the registry
+	// file is absent, unreadable, or stale. A nil snapshot means fail-open
+	// (same semantics as the reconciler's gate at session_reconciler.go:2424).
+	// This field is assigned in buildDesiredState before the pool realization
+	// loop; newAgentBuildParams does not set it.
+	providerHealthSnapshot *providerHealthSnapshot
+
 	// beadNames caches qualifiedName → session_name mappings resolved
 	// during this build cycle. Populated lazily by resolveSessionName.
 	beadNames map[string]string

--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -58,7 +58,8 @@ type agentBuildParams struct {
 	// poolScaleCheckPartialTemplates holds pool templates whose scale_check
 	// returned a partial result this build cycle. selectOrPlanPoolSessionBead
 	// refuses new creates for these templates; existing-session reuse is
-	// unaffected.
+	// unaffected. This field is assigned in buildDesiredState after
+	// evaluatePendingPoolsMap runs; newAgentBuildParams does not set it.
 	poolScaleCheckPartialTemplates map[string]bool
 
 	// beadNames caches qualifiedName → session_name mappings resolved

--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -63,11 +63,12 @@ type agentBuildParams struct {
 	poolScaleCheckPartialTemplates map[string]bool
 
 	// providerHealthSnapshot is the per-build provider-health registry view.
-	// Loaded once at the start of buildDesiredState; nil when the registry
-	// file is absent, unreadable, or stale. A nil snapshot means fail-open
-	// (same semantics as the reconciler's gate at session_reconciler.go:2424).
-	// This field is assigned in buildDesiredState before the pool realization
-	// loop; newAgentBuildParams does not set it.
+	// Loaded once at the start of buildDesiredState via loadProviderHealthSnapshot,
+	// which always returns a non-nil snapshot. When the registry file is absent,
+	// unreadable, or empty the snapshot has present=false and check() fails-open
+	// (healthy=true, registryPresent=false). This field is assigned in
+	// buildDesiredState before the pool realization loop; newAgentBuildParams
+	// does not set it.
 	providerHealthSnapshot *providerHealthSnapshot
 
 	// beadNames caches qualifiedName → session_name mappings resolved

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -90,6 +90,7 @@ type defaultScaleCheckTarget struct {
 var (
 	errPoolSessionCreateBudgetExhausted = errors.New("pool session create budget exhausted")
 	errPoolSessionCreatePartial         = errors.New("pool session create skipped: demand read partial")
+	errPoolSessionCreateProviderRed     = errors.New("pool session create skipped: provider red")
 )
 
 // poolSessionCreateFairShareCounter rotates scarce create tokens across
@@ -739,6 +740,7 @@ func buildDesiredStateWithSessionBeads(
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		bp.assignedWorkBeads = poolWorkBeads
 		bp.poolScaleCheckPartialTemplates = poolScaleCheckPartialTemplates
+		bp.providerHealthSnapshot = loadProviderHealthSnapshot(cityPath)
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
 		bp.configurePoolSessionCreateFairShare(poolDesiredStates)
 		for _, poolState := range poolDesiredStates {
@@ -755,6 +757,7 @@ func buildDesiredStateWithSessionBeads(
 	} else {
 		// No store — use scale_check counts directly.
 		scaleCheckCounts, _ = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
+		bp.providerHealthSnapshot = loadProviderHealthSnapshot(cityPath)
 		for _, pw := range pendingPools {
 			cfgAgent := &cfg.Agents[pw.agentIdx]
 			desiredCount := scaleCheckCounts[cfgAgent.QualifiedName()]
@@ -2205,6 +2208,9 @@ func realizePoolDesiredSessions(
 					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (fresh create deferred)\n", qualifiedName, err) //nolint:errcheck
 				case errors.Is(err, errPoolSessionCreatePartial):
 					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (partial demand read, fresh create blocked)\n", qualifiedName, err) //nolint:errcheck
+				case errors.Is(err, errPoolSessionCreateProviderRed):
+					// debug-level: fires every tick during a red episode; not operator noise
+					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (provider red, fresh create blocked)\n", qualifiedName, err) //nolint:errcheck
 				default:
 					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
 				}
@@ -2963,6 +2969,24 @@ func selectOrPlanPoolSessionBead(
 	if bp.poolScaleCheckPartialTemplates[template] {
 		delete(usedSlots, slot)
 		return beads.Bead{}, 0, nil, errPoolSessionCreatePartial
+	}
+
+	// Provider-health gate: refuse new creates when the registry reports this
+	// agent's provider as red. Reuse paths above are unaffected (they return
+	// before reaching this point). Fail-open when providerHealthSnapshot is nil.
+	// Symmetric with the respawn gate in session_reconciler.go:2424.
+	if bp.providerHealthSnapshot != nil {
+		provName := strings.TrimSpace(cfgAgent.Provider)
+		if provName == "" {
+			provName = strings.TrimSpace(cfgAgent.InheritedProvider)
+		}
+		if provName == "" && bp.workspace != nil {
+			provName = strings.TrimSpace(bp.workspace.Provider)
+		}
+		if healthy, present := bp.providerHealthSnapshot.check(provName); present && !healthy {
+			delete(usedSlots, slot)
+			return beads.Bead{}, 0, nil, errPoolSessionCreateProviderRed
+		}
 	}
 
 	if !bp.tryClaimPoolSessionCreate(template) {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1553,10 +1553,12 @@ func retainScaleCheckPartialPoolDesired(cfg *config.City, counts map[string]int,
 }
 
 // Preserve dormant affected-template beads during transient scale_check
-// failures, but do not count them as awake demand.
+// failures, but do not count them as awake demand. Sessions that are already
+// mid-drain or past-drain (draining/drained/archived) are not preserved so a
+// partial read cannot interrupt an in-progress drain lifecycle.
 func scaleCheckPartialSessionPreservable(b beads.Bead) bool {
 	switch strings.TrimSpace(b.Metadata["state"]) {
-	case "", "active", "awake", "start-pending", "creating", "asleep", "stopped", "suspended", "quarantined", "draining", "drained", "archived":
+	case "", "active", "awake", "start-pending", "creating", "asleep", "stopped", "suspended", "quarantined":
 		return true
 	default:
 		return isPendingPoolCreate(b)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1900,8 +1900,15 @@ func discoverSessionBeadsWithRoots(
 				desiredHasCanonicalNonExpandingPoolSession(desired, template, cfgAgent) {
 				continue
 			}
+			// Use a narrower partial-alive guard than scaleCheckPartial here: for
+			// creating/start-pending beads, only protect in-flight creates with an
+			// active pending_create_claim lease; stale creates (lease cleared/expired)
+			// roll back even during a partial tick. For all other states (active, awake,
+			// asleep, stopped, …) the broad preservable rule applies unchanged.
+			poolPartialAlive := (poolScaleCheckPartial || namedScaleCheckPartial) &&
+				(isPendingPoolCreate(b) || (!creating && scaleCheckPartialSessionPreservable(b)))
 			if controllerManagedPool && !manualSession && !isNamedSessionBead(b) &&
-				!sessionAlreadyDesired && !templateDesired && !scaleCheckPartial {
+				!sessionAlreadyDesired && !templateDesired && !poolPartialAlive {
 				continue
 			}
 			if !manualSession && (!creating || isStaleCreating(b)) && !templateDesired && !pendingCreate && !scaleCheckPartial {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1568,7 +1568,10 @@ func scaleCheckPartialSessionRetainable(b beads.Bead) bool {
 	case "active", "awake":
 		return true
 	default:
-		return false
+		// A fresh in-flight create that still holds an active pending_create_claim
+		// lease counts as retained capacity. Stale creates (lease expired/cleared)
+		// return false so they stop inflating the desired count.
+		return isPendingPoolCreate(b)
 	}
 }
 

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -474,6 +474,11 @@ func buildDesiredStateWithSessionBeads(
 	// below so the probe wakes a cold pool from zero without overriding the
 	// pool's custom scale_check count.
 	coldWakeTemplates := map[string]bool{}
+	// namedOnDemandTemplates marks templates where namedSessionMode != "always"
+	// and a defaultScaleTargets entry was appended (on_demand named-backing).
+	// Their pool demand is clamped to 1 at the merge so one pool slot wakes the
+	// session without over-spawning {name}-N phantoms when N routed beads arrive.
+	namedOnDemandTemplates := map[string]bool{}
 	// activeStores is the set of stores a cold custom-scale_check pool is probed
 	// against (city + every non-suspended rig store), so routed demand a sleeping
 	// rig pool can't see locally — e.g. work queued in the city store — still
@@ -496,13 +501,14 @@ func buildDesiredStateWithSessionBeads(
 		if cfg.Agents[i].Suspended {
 			continue
 		}
-		backsNamedSession := false
+		namedSessionMode := ""
 		for j := range cfg.NamedSessions {
 			if cfg.NamedSessions[j].TemplateQualifiedName() == cfg.Agents[i].QualifiedName() {
-				backsNamedSession = true
+				namedSessionMode = cfg.NamedSessions[j].ModeOrDefault()
 				break
 			}
 		}
+		backsNamedSession := namedSessionMode != ""
 
 		sp := scaleParamsForBeads(&cfg.Agents[i], cfg.Beads)
 		// Expand {{.Rig}}/{{.AgentBase}} before the scale_check enters the
@@ -559,7 +565,16 @@ func buildDesiredStateWithSessionBeads(
 			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
 			if store != nil && !hasCustomScaleCheck {
 				ownTarget := defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores)
-				defaultScaleTargets = append(defaultScaleTargets, ownTarget)
+				// mode='always': named session is unconditionally desired by the named
+				// pass; pool demand is redundant and creates {name}-N phantoms when N
+				// routed beads arrive. mode='on_demand': pool demand wakes the sleeping
+				// singleton (namedWorkReady covers only direct Assignee beads, not
+				// gc.routed_to). Leave defaultNamedScaleTargets unchanged for both modes
+				// (partial-query retention).
+				if namedSessionMode != "always" {
+					defaultScaleTargets = append(defaultScaleTargets, ownTarget)
+					namedOnDemandTemplates[template] = true
+				}
 				defaultNamedScaleTargets = append(defaultNamedScaleTargets, ownTarget)
 				// Cross-store cold-wake for named-backing pools (vp-cl4): mirror the
 				// generic-pool guard (vp-s37 / #3078 line ~598). A cold rig pool that
@@ -570,7 +585,9 @@ func buildDesiredStateWithSessionBeads(
 				// mirrors these probes only for partial-query retention bookkeeping.
 				if isCold && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
 					cityTarget := defaultScaleCheckTarget{template: template, store: store, storeKey: "city"}
-					defaultScaleTargets = append(defaultScaleTargets, cityTarget)
+					if namedSessionMode != "always" {
+						defaultScaleTargets = append(defaultScaleTargets, cityTarget)
+					}
 					defaultNamedScaleTargets = append(defaultNamedScaleTargets, cityTarget)
 				}
 				continue
@@ -706,6 +723,12 @@ func buildDesiredStateWithSessionBeads(
 				// contribution to 1 so it never overrides a custom scale_check's
 				// authoritative count for the same template.
 				if coldWakeTemplates[template] && count > 1 {
+					count = 1
+				}
+				// An on_demand named-session backing template is a singleton: one pool
+				// slot is enough to drain N queued routed tasks sequentially. Clamp to
+				// 1 so N unassigned gc.routed_to beads do not spawn {name}-N phantoms.
+				if namedOnDemandTemplates[template] && count > 1 {
 					count = 1
 				}
 				if count > scaleCheckCounts[template] {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2973,20 +2973,19 @@ func selectOrPlanPoolSessionBead(
 
 	// Provider-health gate: refuse new creates when the registry reports this
 	// agent's provider as red. Reuse paths above are unaffected (they return
-	// before reaching this point). Fail-open when providerHealthSnapshot is nil.
+	// before reaching this point). loadProviderHealthSnapshot always returns a
+	// non-nil snapshot; check() fails-open when the registry is absent or stale.
 	// Symmetric with the respawn gate in session_reconciler.go:2424.
-	if bp.providerHealthSnapshot != nil {
-		provName := strings.TrimSpace(cfgAgent.Provider)
-		if provName == "" {
-			provName = strings.TrimSpace(cfgAgent.InheritedProvider)
-		}
-		if provName == "" && bp.workspace != nil {
-			provName = strings.TrimSpace(bp.workspace.Provider)
-		}
-		if healthy, present := bp.providerHealthSnapshot.check(provName); present && !healthy {
-			delete(usedSlots, slot)
-			return beads.Bead{}, 0, nil, errPoolSessionCreateProviderRed
-		}
+	provName := strings.TrimSpace(cfgAgent.Provider)
+	if provName == "" {
+		provName = strings.TrimSpace(cfgAgent.InheritedProvider)
+	}
+	if provName == "" && bp.workspace != nil {
+		provName = strings.TrimSpace(bp.workspace.Provider)
+	}
+	if healthy, present := bp.providerHealthSnapshot.check(provName); present && !healthy {
+		delete(usedSlots, slot)
+		return beads.Bead{}, 0, nil, errPoolSessionCreateProviderRed
 	}
 
 	if !bp.tryClaimPoolSessionCreate(template) {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1568,10 +1568,7 @@ func scaleCheckPartialSessionRetainable(b beads.Bead) bool {
 	case "active", "awake":
 		return true
 	default:
-		// A fresh in-flight create that still holds an active pending_create_claim
-		// lease counts as retained capacity. Stale creates (lease expired/cleared)
-		// return false so they stop inflating the desired count.
-		return isPendingPoolCreate(b)
+		return false
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -10532,6 +10532,88 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		}
 	})
 
+	// Criterion #3 (ga-4qbgqf.1): awake sessions are also retained, not just active.
+	t.Run("one awake bead retained, no new creates", func(t *testing.T) {
+		store := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
+		awakeSession := makeSessionBead("session-worker-awake", "worker-awake-1", "awake", "1")
+
+		var stderr strings.Builder
+		result := buildDesiredStateWithSessionBeads(
+			"test-city", cityPath, time.Now().UTC(),
+			cfg, runtime.NewFake(), store, nil,
+			newSessionBeadSnapshot([]beads.Bead{awakeSession}),
+			nil, &stderr,
+		)
+
+		if !result.PoolScaleCheckPartialTemplates["worker"] {
+			t.Fatalf("PoolScaleCheckPartialTemplates[worker] = false, want true; stderr=%s", stderr.String())
+		}
+		if _, ok := result.State["worker-awake-1"]; !ok {
+			t.Fatalf("awake session not retained in desired state: keys=%v stderr=%s", mapKeys(result.State), stderr.String())
+		}
+		workerEntries := 0
+		for _, tp := range result.State {
+			if tp.TemplateName == "worker" {
+				workerEntries++
+			}
+		}
+		if workerEntries != 1 {
+			t.Fatalf("desired state has %d worker entries, want exactly 1; keys=%v", workerEntries, mapKeys(result.State))
+		}
+
+		snapshot := newSessionBeadSnapshot([]beads.Bead{awakeSession})
+		poolDesired := retainScaleCheckPartialPoolDesired(
+			cfg,
+			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.Open(), result.ScaleCheckCounts)),
+			snapshot,
+			result.PoolScaleCheckPartialTemplates,
+		)
+		if got := poolDesired["worker"]; got != 1 {
+			t.Fatalf("poolDesired[worker] = %d, want 1 (confirmed-alive awake bead)", got)
+		}
+	})
+
+	// Criterion #3 (ga-4qbgqf.1): awake sessions are also retained, not just active.
+	t.Run("one awake bead retained, no new creates", func(t *testing.T) {
+		store := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
+		awakeSession := makeSessionBead("session-worker-awake", "worker-awake-1", "awake", "1")
+
+		var stderr strings.Builder
+		result := buildDesiredStateWithSessionBeads(
+			"test-city", cityPath, time.Now().UTC(),
+			cfg, runtime.NewFake(), store, nil,
+			newSessionBeadSnapshot([]beads.Bead{awakeSession}),
+			nil, &stderr,
+		)
+
+		if !result.PoolScaleCheckPartialTemplates["worker"] {
+			t.Fatalf("PoolScaleCheckPartialTemplates[worker] = false, want true; stderr=%s", stderr.String())
+		}
+		if _, ok := result.State["worker-awake-1"]; !ok {
+			t.Fatalf("awake session not retained in desired state: keys=%v stderr=%s", mapKeys(result.State), stderr.String())
+		}
+		workerEntries := 0
+		for _, tp := range result.State {
+			if tp.TemplateName == "worker" {
+				workerEntries++
+			}
+		}
+		if workerEntries != 1 {
+			t.Fatalf("desired state has %d worker entries, want exactly 1; keys=%v", workerEntries, mapKeys(result.State))
+		}
+
+		snapshot := newSessionBeadSnapshot([]beads.Bead{awakeSession})
+		poolDesired := retainScaleCheckPartialPoolDesired(
+			cfg,
+			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.Open(), result.ScaleCheckCounts)),
+			snapshot,
+			result.PoolScaleCheckPartialTemplates,
+		)
+		if got := poolDesired["worker"]; got != 1 {
+			t.Fatalf("poolDesired[worker] = %d, want 1 (confirmed-alive awake bead)", got)
+		}
+	})
+
 	t.Run("zero existing beads yields zero creates", func(t *testing.T) {
 		store := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
 
@@ -10602,15 +10684,17 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		}
 	})
 
-	// Criterion #5 (ga-4qbgqf.1): stale creating beads are shielded from drain
-	// during a partial tick by scaleCheckPartial, but roll back within one
-	// reconciler tick once the partial resolves.
-	t.Run("stale creating bead rolls back on next non-partial tick", func(t *testing.T) {
+	// Criterion #5 (ga-4qbgqf.1): the narrow alive-on-partial guard for pool creates
+	// allows stale creating beads to roll back within the partial tick itself.
+	// Only in-flight creates holding an active pending_create_claim lease are
+	// shielded; expired/cleared creates (no lease) drain immediately.
+	t.Run("stale creating bead rolls back during partial tick", func(t *testing.T) {
 		partialStore := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
 		staleSession := makeSessionBead("session-worker-stale", "worker-stale-4", "creating", "4")
 		snapshot := newSessionBeadSnapshot([]beads.Bead{staleSession})
 
-		// Partial tick: scaleCheckPartial shields the pool-managed creating bead from drain.
+		// Partial tick: the narrow pool-create guard (poolPartialCreate) does NOT
+		// shield a stale creating bead (no pending_create_claim), so it rolls back now.
 		var pStderr strings.Builder
 		partialResult := buildDesiredStateWithSessionBeads(
 			"test-city", cityPath, time.Now().UTC(),
@@ -10620,20 +10704,8 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		if !partialResult.PoolScaleCheckPartialTemplates["worker"] {
 			t.Fatalf("partial tick: PoolScaleCheckPartialTemplates[worker] = false; stderr=%s", pStderr.String())
 		}
-		if _, ok := partialResult.State["worker-stale-4"]; !ok {
-			t.Fatalf("partial tick: stale creating bead absent from State (scaleCheckPartialSessionPreservable must retain it); keys=%v stderr=%s", mapKeys(partialResult.State), pStderr.String())
-		}
-
-		// Normal tick: partial resolves; scaleCheckPartial is false.
-		// The pool bead is not desired (poolDesired=0 with no demand), so
-		// the controllerManagedPool guard at build_desired_state.go:1903 drains it.
-		normalResult := buildDesiredStateWithSessionBeads(
-			"test-city", cityPath, time.Now().UTC(),
-			cfg, runtime.NewFake(), beads.NewMemStore(), nil,
-			snapshot, nil, io.Discard,
-		)
-		if _, ok := normalResult.State["worker-stale-4"]; ok {
-			t.Fatalf("normal tick: stale creating bead still in State after partial resolved; keys=%v", mapKeys(normalResult.State))
+		if _, ok := partialResult.State["worker-stale-4"]; ok {
+			t.Fatalf("partial tick: stale creating bead unexpectedly retained in State; narrow guard must allow rollback; keys=%v stderr=%s", mapKeys(partialResult.State), pStderr.String())
 		}
 	})
 }

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -10667,4 +10667,50 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 			t.Fatalf("partial tick: stale creating bead unexpectedly retained in State; narrow guard must allow rollback; keys=%v stderr=%s", mapKeys(partialResult.State), pStderr.String())
 		}
 	})
+
+	// Criterion #6 (ga-4qbgqf.3): fresh in-flight creates (pending_create_claim=true)
+	// are retained in desired state and in the retained count during a partial tick.
+	// poolPartialAlive is true via isPendingPoolCreate, so the narrow guard keeps them.
+	t.Run("fresh pending_create_claim creating bead retained during partial tick", func(t *testing.T) {
+		partialStore := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
+		freshCreate := beads.Bead{
+			ID:     "session-worker-fresh",
+			Title:  "worker",
+			Type:   sessionBeadType,
+			Status: "open",
+			Labels: []string{sessionBeadLabel, "template:worker"},
+			Metadata: map[string]string{
+				"session_name":         "worker-fresh-3",
+				"template":             "worker",
+				"agent_name":           "worker",
+				"pool_slot":            "3",
+				poolManagedMetadataKey: boolMetadata(true),
+				"state":                "creating",
+				"pending_create_claim": boolMetadata(true),
+			},
+		}
+		snapshot := newSessionBeadSnapshot([]beads.Bead{freshCreate})
+
+		var pStderr strings.Builder
+		partialResult := buildDesiredStateWithSessionBeads(
+			"test-city", cityPath, time.Now().UTC(),
+			cfg, runtime.NewFake(), partialStore, nil,
+			snapshot, nil, &pStderr,
+		)
+		if !partialResult.PoolScaleCheckPartialTemplates["worker"] {
+			t.Fatalf("partial tick: PoolScaleCheckPartialTemplates[worker] = false; stderr=%s", pStderr.String())
+		}
+		if _, ok := partialResult.State["worker-fresh-3"]; !ok {
+			t.Fatalf("partial tick: fresh pending_create_claim=true bead absent from State; poolPartialAlive must retain it; keys=%v stderr=%s", mapKeys(partialResult.State), pStderr.String())
+		}
+		poolDesired := retainScaleCheckPartialPoolDesired(
+			cfg,
+			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.Open(), partialResult.ScaleCheckCounts)),
+			snapshot,
+			partialResult.PoolScaleCheckPartialTemplates,
+		)
+		if got := poolDesired["worker"]; got != 1 {
+			t.Fatalf("poolDesired[worker] = %d, want 1 (fresh pending_create_claim=true create counts as retained capacity)", got)
+		}
+	})
 }

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -10573,47 +10573,6 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		}
 	})
 
-	// Criterion #3 (ga-4qbgqf.1): awake sessions are also retained, not just active.
-	t.Run("one awake bead retained, no new creates", func(t *testing.T) {
-		store := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
-		awakeSession := makeSessionBead("session-worker-awake", "worker-awake-1", "awake", "1")
-
-		var stderr strings.Builder
-		result := buildDesiredStateWithSessionBeads(
-			"test-city", cityPath, time.Now().UTC(),
-			cfg, runtime.NewFake(), store, nil,
-			newSessionBeadSnapshot([]beads.Bead{awakeSession}),
-			nil, &stderr,
-		)
-
-		if !result.PoolScaleCheckPartialTemplates["worker"] {
-			t.Fatalf("PoolScaleCheckPartialTemplates[worker] = false, want true; stderr=%s", stderr.String())
-		}
-		if _, ok := result.State["worker-awake-1"]; !ok {
-			t.Fatalf("awake session not retained in desired state: keys=%v stderr=%s", mapKeys(result.State), stderr.String())
-		}
-		workerEntries := 0
-		for _, tp := range result.State {
-			if tp.TemplateName == "worker" {
-				workerEntries++
-			}
-		}
-		if workerEntries != 1 {
-			t.Fatalf("desired state has %d worker entries, want exactly 1; keys=%v", workerEntries, mapKeys(result.State))
-		}
-
-		snapshot := newSessionBeadSnapshot([]beads.Bead{awakeSession})
-		poolDesired := retainScaleCheckPartialPoolDesired(
-			cfg,
-			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.Open(), result.ScaleCheckCounts)),
-			snapshot,
-			result.PoolScaleCheckPartialTemplates,
-		)
-		if got := poolDesired["worker"]; got != 1 {
-			t.Fatalf("poolDesired[worker] = %d, want 1 (confirmed-alive awake bead)", got)
-		}
-	})
-
 	t.Run("zero existing beads yields zero creates", func(t *testing.T) {
 		store := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5627,6 +5627,91 @@ func TestBuildDesiredState_OnDemandNamedSession_DirectAssigneeMaterializes(t *te
 	}
 }
 
+// TestBuildDesiredState_NamedBackingPoolNoCap_RoutedDemandDoesNotSpawnPhantoms
+// is the ga-xq1fsv regression repro (molecule-patrol demand ratchet, healthy
+// reads). A [[named_session]] backed by a pool-capable agent template that has
+// NO custom scale_check and NO max_active_sessions cap must resolve unassigned
+// gc.routed_to=<template> patrol demand to its single canonical named identity
+// — never to generic "{name}-N" pool phantoms.
+//
+// Root cause (bda368b0e "keep template-routed graph work unassigned"): the
+// backsNamedSession branch in buildDesiredStateWithSessionBeads now appends the
+// template's default probe to defaultScaleTargets (build_desired_state.go:561),
+// so the unassigned routed patrol roots are counted as generic pool demand by
+// defaultScaleCheckCounts. ComputePoolDesiredStates then emits N "new" requests,
+// and because the template has no max=1 cap (UsesCanonicalSingletonPoolIdentity
+// is false) realizePoolDesiredSessions materializes them as witness-1..N
+// alongside the canonical "witness" named session. Before bda368b0e the same
+// probe fed only defaultNamedScaleTargets, so routed demand resolved to the
+// single named identity.
+//
+// This facet engages on fully healthy (non-partial) reads, so the ga-01yukx /
+// #3686 partial-read fail-closed guards never trigger. MemStore reads are
+// non-partial, asserted below. MUST fail on e22049f86 (1 named + N phantoms)
+// and pass after the fix.
+func TestBuildDesiredState_NamedBackingPoolNoCap_RoutedDemandDoesNotSpawnPhantoms(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	const template = "witness"
+	const routedDemand = 3
+	for i := 0; i < routedDemand; i++ {
+		if _, err := store.Create(beads.Bead{
+			Title:  "witness patrol root",
+			Type:   "task", // actionable root (wisp/task); molecule/step roots are Ready()-excluded
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.routed_to": template,
+			},
+		}); err != nil {
+			t.Fatalf("create routed patrol demand %d: %v", i, err)
+		}
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         template,
+			StartCommand: "true",
+			WorkQuery:    "printf ''",
+			// no ScaleCheck        -> default routed-work probe drives demand
+			// no MaxActiveSessions -> UsesCanonicalSingletonPoolIdentity()==false,
+			//                         so pool path synthesizes {name}-N identities
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: template,
+			Mode:     "always",
+		}},
+	}
+	identity := cfg.NamedSessions[0].QualifiedName()
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	// This facet must engage on healthy reads, distinguishing it from the
+	// ga-01yukx partial-read facet whose guards fail closed.
+	if len(dsResult.ScaleCheckPartialTemplates) != 0 ||
+		len(dsResult.PoolScaleCheckPartialTemplates) != 0 ||
+		len(dsResult.NamedScaleCheckPartialTemplates) != 0 {
+		t.Fatalf("repro must exercise healthy (non-partial) reads, but reads were partial: scale=%v pool=%v named=%v",
+			dsResult.ScaleCheckPartialTemplates, dsResult.PoolScaleCheckPartialTemplates, dsResult.NamedScaleCheckPartialTemplates)
+	}
+
+	var named, phantom []string
+	for key, tp := range dsResult.State {
+		if tp.ConfiguredNamedIdentity == identity {
+			named = append(named, key)
+			continue
+		}
+		phantom = append(phantom, key)
+	}
+	if len(named) != 1 {
+		t.Fatalf("expected exactly 1 canonical named session %q, got %d: %v (state=%+v)", identity, len(named), named, dsResult.State)
+	}
+	if len(phantom) != 0 {
+		t.Fatalf("named-backing pool template %q spawned %d phantom pool session(s) %v alongside the canonical named session; "+
+			"unassigned gc.routed_to patrol demand must resolve to the single named identity (<=1), not generic {name}-N pool workers "+
+			"(scale_check_counts=%v)", template, len(phantom), phantom, dsResult.ScaleCheckCounts)
+	}
+}
+
 func TestBuildDesiredState_OnDemandNamedSession_RuntimeAssigneeDoesNotMaterialize(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "fixture")

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -10738,3 +10738,151 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildDesiredState_ProviderRedBlocksNewPoolSessionCreate(t *testing.T) {
+	writeHealthFile := func(t *testing.T, cityPath, status string) {
+		t.Helper()
+		dir := filepath.Join(cityPath, ".gc", "cache")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		probedAt := float64(time.Now().UnixNano()) / 1e9
+		content := fmt.Sprintf(`{"providers":[{"provider":"claude","status":%q,"probed_at":%f}]}`, status, probedAt)
+		if err := os.WriteFile(filepath.Join(dir, "provider-health.json"), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	makeCfg := func() *config.City {
+		return &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Agents: []config.Agent{{
+				Name:              "worker",
+				Provider:          "claude",
+				StartCommand:      "echo",
+				ScaleCheck:        "printf 3",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(5),
+			}},
+		}
+	}
+
+	makeSessionBead := func(id, sessionName, state, slot string) beads.Bead {
+		return beads.Bead{
+			ID:     id,
+			Title:  "worker",
+			Type:   sessionBeadType,
+			Status: "open",
+			Labels: []string{sessionBeadLabel, "template:worker"},
+			Metadata: map[string]string{
+				"session_name":         sessionName,
+				"template":             "worker",
+				"agent_name":           "worker",
+				"pool_slot":            slot,
+				poolManagedMetadataKey: boolMetadata(true),
+				"state":                state,
+			},
+		}
+	}
+
+	// Scenario A: registry red — no new creates for pool agent.
+	t.Run("registry red blocks new creates", func(t *testing.T) {
+		cityPath := t.TempDir()
+		writeHealthFile(t, cityPath, "unhealthy")
+		cfg := makeCfg()
+		store := beads.NewMemStore()
+		var stderr strings.Builder
+		result := buildDesiredStateWithSessionBeads(
+			"test-city", cityPath, time.Now().UTC(),
+			cfg, runtime.NewFake(), store, nil,
+			newSessionBeadSnapshot(nil),
+			nil, &stderr,
+		)
+		for _, tp := range result.State {
+			if tp.TemplateName == "worker" {
+				t.Fatalf("expected no worker creates when provider is red; got entry %q; stderr=%s", tp.SessionName, stderr.String())
+			}
+		}
+		if !strings.Contains(stderr.String(), "provider red, fresh create blocked") {
+			t.Fatalf("expected 'provider red, fresh create blocked' in stderr; stderr=%s", stderr.String())
+		}
+	})
+
+	// Scenario B: registry absent — fail-open, creates proceed normally.
+	t.Run("registry absent fails open", func(t *testing.T) {
+		cityPath := t.TempDir()
+		// no provider-health.json written
+		cfg := makeCfg()
+		store := beads.NewMemStore()
+		var stderr strings.Builder
+		result := buildDesiredStateWithSessionBeads(
+			"test-city", cityPath, time.Now().UTC(),
+			cfg, runtime.NewFake(), store, nil,
+			newSessionBeadSnapshot(nil),
+			nil, &stderr,
+		)
+		workerCreates := 0
+		for _, tp := range result.State {
+			if tp.TemplateName == "worker" {
+				workerCreates++
+			}
+		}
+		if workerCreates == 0 {
+			t.Fatalf("expected worker creates when registry absent (fail-open); stderr=%s", stderr.String())
+		}
+	})
+
+	// Scenario C: registry healthy — creates proceed normally.
+	t.Run("registry healthy allows create", func(t *testing.T) {
+		cityPath := t.TempDir()
+		writeHealthFile(t, cityPath, "healthy")
+		cfg := makeCfg()
+		store := beads.NewMemStore()
+		var stderr strings.Builder
+		result := buildDesiredStateWithSessionBeads(
+			"test-city", cityPath, time.Now().UTC(),
+			cfg, runtime.NewFake(), store, nil,
+			newSessionBeadSnapshot(nil),
+			nil, &stderr,
+		)
+		workerCreates := 0
+		for _, tp := range result.State {
+			if tp.TemplateName == "worker" {
+				workerCreates++
+			}
+		}
+		if workerCreates == 0 {
+			t.Fatalf("expected worker creates when provider is healthy; stderr=%s", stderr.String())
+		}
+	})
+
+	// Scenario D: red gate does not block reuse of an existing active session;
+	// no additional new creates are planned.
+	t.Run("red gate does not block reuse of active session", func(t *testing.T) {
+		cityPath := t.TempDir()
+		writeHealthFile(t, cityPath, "unhealthy")
+		cfg := makeCfg()
+		active := makeSessionBead("session-worker-1", "worker-1", "active", "1")
+		store := beads.NewMemStore()
+		var stderr strings.Builder
+		result := buildDesiredStateWithSessionBeads(
+			"test-city", cityPath, time.Now().UTC(),
+			cfg, runtime.NewFake(), store, nil,
+			newSessionBeadSnapshot([]beads.Bead{active}),
+			nil, &stderr,
+		)
+		if _, ok := result.State["worker-1"]; !ok {
+			t.Fatalf("active session must be reused even when provider is red; keys=%v stderr=%s", mapKeys(result.State), stderr.String())
+		}
+		workerEntries := 0
+		for _, tp := range result.State {
+			if tp.TemplateName == "worker" {
+				workerEntries++
+			}
+		}
+		// The active session is reused; the red gate blocks any additional creates.
+		if workerEntries != 1 {
+			t.Fatalf("expected exactly 1 worker entry (reused active); got %d; keys=%v stderr=%s", workerEntries, mapKeys(result.State), stderr.String())
+		}
+	})
+}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -10713,4 +10713,28 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 			t.Fatalf("poolDesired[worker] = %d, want 1 (fresh pending_create_claim=true create counts as retained capacity)", got)
 		}
 	})
+
+	// Change 3 (ga-btv7tm): draining/drained/archived sessions must NOT be
+	// preserved in desired state during a partial tick. Preserving them would
+	// interrupt an in-progress drain lifecycle.
+	t.Run("draining/drained/archived NOT preserved during partial tick", func(t *testing.T) {
+		for _, state := range []string{"draining", "drained", "archived"} {
+			state := state
+			t.Run(state, func(t *testing.T) {
+				store := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
+				b := makeSessionBead("session-worker-"+state, "worker-"+state+"-1", state, "1")
+				var pStderr strings.Builder
+				result := buildDesiredStateWithSessionBeads(
+					"test-city", cityPath, time.Now().UTC(),
+					cfg, runtime.NewFake(), store, nil,
+					newSessionBeadSnapshot([]beads.Bead{b}),
+					nil, &pStderr,
+				)
+				if _, ok := result.State["worker-"+state+"-1"]; ok {
+					t.Fatalf("state=%s bead must NOT be preserved in desired during partial tick (would interrupt drain); keys=%v stderr=%s",
+						state, mapKeys(result.State), pStderr.String())
+				}
+			})
+		}
+	})
 }

--- a/release-gates/ga-5nf5lm-partial-demand-pool-create-gate.md
+++ b/release-gates/ga-5nf5lm-partial-demand-pool-create-gate.md
@@ -1,4 +1,4 @@
-# Release Gate: ga-5nf5lm partial-demand pool create gate
+# Release Gate: fail-closed pool session creates
 
 Result: PASS
 
@@ -6,19 +6,14 @@ Date: 2026-06-23
 
 ## Candidate
 
-- Bead: `ga-5nf5lm`
-- Title: `needs-deploy: fail-closed partial demand pool create gate + retention narrowing`
+- Deploy bead: `ga-dfybgu`
+- Review bead: `ga-hs4fqf`
+- Title: `needs-deploy: fail-closed pool creates on partial demand reads`
+- Pull request: https://github.com/gastownhall/gascity/pull/3687
 - Source branch: `builder/ga-4qbgqf.2-partial-demand-create-gate`
-- Candidate commit: `60b7d027926919f0cf8675fd7940cd65f3512502`
+- Candidate commit: `d4c0fa80b8572609e4124504e0c8aafcae8a6f57`
 - Base: `origin/main` at `32ca47acd639b80eee37f4623d0277018b674c06`
 - Merge base: `32ca47acd639b80eee37f4623d0277018b674c06`
-
-## Changed Paths
-
-- `cmd/gc/agent_build_params.go`
-- `cmd/gc/build_desired_state.go`
-- `cmd/gc/build_desired_state_legacy_bound_recovery_test.go`
-- `cmd/gc/build_desired_state_test.go`
 
 ## Release Criteria Source
 
@@ -26,35 +21,49 @@ Date: 2026-06-23
 the deployer release criteria and the repository testing guidance in
 `TESTING.md`.
 
+## Changed Paths
+
+- `cmd/gc/agent_build_params.go`
+- `cmd/gc/build_desired_state.go`
+- `cmd/gc/build_desired_state_legacy_bound_recovery_test.go`
+- `cmd/gc/build_desired_state_test.go`
+- `release-gates/ga-5nf5lm-partial-demand-pool-create-gate.md`
+
 ## Gate Criteria
 
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
-| 1 | Review PASS present | PASS | Deploy bead `ga-5nf5lm` records "Reviewed + PASSED" by `reviewer-gm-wisp-fgacy95` for commit `60b7d027926919f0cf8675fd7940cd65f3512502`. |
-| 2 | Acceptance criteria met | PASS | `agentBuildParams.poolScaleCheckPartialTemplates` is package-private and assigned after `evaluatePendingPoolsMap`; `selectOrPlanPoolSessionBead` gates only fresh creates after reuse/resume tiers; the reserved slot is deleted before returning the partial sentinel; sentinel/log text match the accepted wording; `selectOrCreatePoolSessionBead` propagates the sentinel; retainable capacity counts active/awake and fresh `pending_create_claim=true` creates only; stale creating beads can roll back during a partial tick; draining/drained/archived sessions are not preserved by the partial path. |
-| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates|TestRetainScaleCheckPartialPoolDesired_InFlightCreatingBeadRetained|TestRetainScaleCheckPartialPoolDesiredNormalizesLegacyBoundTemplate' -count=1` PASS; `make test-fast-parallel` PASS; `go vet ./...` PASS. |
-| 4 | No high-severity review findings open | PASS | `ga-5nf5lm` has a PASS deploy handoff and no open HIGH findings in its notes. The earlier request-changes on the subset branch is superseded by this reviewed combined branch. |
-| 5 | Final branch is clean | PASS | Candidate worktree `deploy-ga-5nf5lm` was clean before adding this gate file; `git config core.hooksPath` reports `.githooks`. This gate file is committed as release evidence before push. |
-| 6 | Branch diverges cleanly from main | PASS | `git fetch origin main` completed, then `git merge-tree --write-tree origin/main HEAD` returned tree `c0a73bfc57617fc559e5a030667978c59ede03f6` with exit 0. |
-| 7 | Single feature theme | PASS | The branch touches only `cmd/gc` pool session planning and regression tests for fail-closed handling of partial pool demand reads. |
+| 1 | Review PASS present | PASS | `ga-hs4fqf` is closed with PASS by `reviewer-gm-wisp-3krxjnn` for commit `d4c0fa80b8572609e4124504e0c8aafcae8a6f57`; deploy bead `ga-dfybgu` records reviewed + passed status. |
+| 2 | Acceptance criteria met | PASS | Shipped scope covers `ga-4qbgqf.1`, `.2`, `.3`, and `.5`; `ga-4qbgqf.4` is explicitly deferred until post-merge fleet validation and is not part of this release. Acceptance evidence: partial scale-check reads mark the affected template partial and block only fresh pool creates; existing active/awake and resumable pool sessions remain eligible; reserved slots are released before the partial-demand sentinel returns; stale creating beads can roll back once no active `pending_create_claim` remains; provider-health red entries block only the fresh-create path and fail open for absent/stale registry data. |
+| 3 | Tests pass | PASS | Focused acceptance test PASS; `make test-fast-parallel` PASS (`All fast jobs passed`); `go vet ./...` PASS. |
+| 4 | No high-severity review findings open | PASS | Review notes list two non-blocking findings only: LOW stale gate evidence and INFO comment wording. This gate refreshes the stale evidence. No HIGH findings remain open. |
+| 5 | Final branch is clean | PASS | Clean detached deploy worktree was used for gate evaluation. `git status --short --branch` was clean before editing this gate file. After this gate file is committed, the PR branch tip contains only committed changes. `git config core.hooksPath` reports `.githooks`. |
+| 6 | Branch diverges cleanly from main | PASS | `git fetch origin main builder/ga-4qbgqf.2-partial-demand-create-gate` completed; `git merge-tree --write-tree HEAD origin/main` returned tree `fe065046538cd35e7bc7caf2fb9d3d085e3140a7` with exit 0. |
+| 7 | Single feature theme | PASS | The commit set touches one supervisor desired-state subsystem: fail-closed handling for fresh pool session creates when the planner cannot trust create eligibility. Partial-demand and provider-health gates share the same `selectOrPlanPoolSessionBead` fresh-create boundary and regression surface. |
 
 ## Acceptance Notes
 
-- `errPoolSessionCreatePartial` message is exactly `pool session create skipped: demand read partial`.
-- `realizePoolDesiredSessions` reports the distinct suffix `(partial demand read, fresh create blocked)`.
-- The fresh-create gate sits after preferred/resume, canonical non-expanding reuse, and reusable pool-session selection, and before `tryClaimPoolSessionCreate`.
-- `scaleCheckPartialSessionRetainable` counts only `active`, `awake`, and active `pending_create_claim=true` creates.
-- `discoverSessionBeadsWithRoots` uses `poolPartialAlive` so stale creating/start-pending pool beads are not kept alive by a partial tick.
+- `agentBuildParams.poolScaleCheckPartialTemplates` remains package-private and is assigned after `evaluatePendingPoolsMap`.
+- `selectOrPlanPoolSessionBead` evaluates preferred/resume and reuse paths before either fresh-create gate.
+- The partial-demand sentinel message is `pool session create skipped: demand read partial`.
+- The partial-demand debug suffix is `(partial demand read, fresh create blocked)`.
+- `scaleCheckPartialSessionRetainable` counts confirmed alive sessions plus fresh `pending_create_claim=true` creates, not stale creating/start-pending states.
+- `discoverSessionBeadsWithRoots` uses the narrower `poolPartialAlive` check so stale creating beads can clear.
+- `agentBuildParams.providerHealthSnapshot` is loaded once per desired-state build and shared through pool realization.
+- The provider-health create gate uses the configured agent/provider fallback order and blocks only `(present=true, healthy=false)` registry entries.
+- The provider-health sentinel message is `pool session create skipped: provider red`.
+- The provider-health debug suffix is `(provider red, fresh create blocked)`.
+- There is no new config, API, schema, or wire shape.
 
 ## Test Evidence
 
 - `git diff --check origin/main...HEAD`: PASS.
-- `go test ./cmd/gc -run 'TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates|TestRetainScaleCheckPartialPoolDesired_InFlightCreatingBeadRetained|TestRetainScaleCheckPartialPoolDesiredNormalizesLegacyBoundTemplate' -count=1`: PASS (`cmd/gc` in 0.503s).
+- `go test ./cmd/gc -run 'TestBuildDesiredState_(ScaleCheckPartialPoolBlocksNewCreates|ProviderRedBlocksNewPoolSessionCreate)|TestRetainScaleCheckPartialPoolDesired_InFlightCreatingBeadRetained'`: PASS (`cmd/gc` in 0.242s).
 - `make test-fast-parallel`: PASS (`All fast jobs passed`).
 - `go vet ./...`: PASS.
 
 ## Deploy Notes
 
 - `gh auth status` passed for account `quad341`.
-- No open PR was found for head branch `builder/ga-4qbgqf.2-partial-demand-create-gate` before creating this deploy PR.
-- The standing deployer worktree has an unrelated interrupted rebase on `deploy/ga-q32h2b-test-deflakes-clean`; this gate was evaluated in the clean `deploy-ga-5nf5lm` worktree at the candidate commit.
+- PR #3687 is open, in-repository, and authored by `quad341`.
+- The normal deployer worktree is in an unrelated interrupted rebase over an external contributor commit. This gate was evaluated in `/tmp/gascity-deploy-ga-dfybgu.hZMjbm` to avoid touching that state.

--- a/release-gates/ga-5nf5lm-partial-demand-pool-create-gate.md
+++ b/release-gates/ga-5nf5lm-partial-demand-pool-create-gate.md
@@ -1,0 +1,60 @@
+# Release Gate: ga-5nf5lm partial-demand pool create gate
+
+Result: PASS
+
+Date: 2026-06-23
+
+## Candidate
+
+- Bead: `ga-5nf5lm`
+- Title: `needs-deploy: fail-closed partial demand pool create gate + retention narrowing`
+- Source branch: `builder/ga-4qbgqf.2-partial-demand-create-gate`
+- Candidate commit: `60b7d027926919f0cf8675fd7940cd65f3512502`
+- Base: `origin/main` at `32ca47acd639b80eee37f4623d0277018b674c06`
+- Merge base: `32ca47acd639b80eee37f4623d0277018b674c06`
+
+## Changed Paths
+
+- `cmd/gc/agent_build_params.go`
+- `cmd/gc/build_desired_state.go`
+- `cmd/gc/build_desired_state_legacy_bound_recovery_test.go`
+- `cmd/gc/build_desired_state_test.go`
+
+## Release Criteria Source
+
+`docs/PROJECT_MANIFEST.md` is not present in this repository. This gate applies
+the deployer release criteria and the repository testing guidance in
+`TESTING.md`.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Deploy bead `ga-5nf5lm` records "Reviewed + PASSED" by `reviewer-gm-wisp-fgacy95` for commit `60b7d027926919f0cf8675fd7940cd65f3512502`. |
+| 2 | Acceptance criteria met | PASS | `agentBuildParams.poolScaleCheckPartialTemplates` is package-private and assigned after `evaluatePendingPoolsMap`; `selectOrPlanPoolSessionBead` gates only fresh creates after reuse/resume tiers; the reserved slot is deleted before returning the partial sentinel; sentinel/log text match the accepted wording; `selectOrCreatePoolSessionBead` propagates the sentinel; retainable capacity counts active/awake and fresh `pending_create_claim=true` creates only; stale creating beads can roll back during a partial tick; draining/drained/archived sessions are not preserved by the partial path. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates|TestRetainScaleCheckPartialPoolDesired_InFlightCreatingBeadRetained|TestRetainScaleCheckPartialPoolDesiredNormalizesLegacyBoundTemplate' -count=1` PASS; `make test-fast-parallel` PASS; `go vet ./...` PASS. |
+| 4 | No high-severity review findings open | PASS | `ga-5nf5lm` has a PASS deploy handoff and no open HIGH findings in its notes. The earlier request-changes on the subset branch is superseded by this reviewed combined branch. |
+| 5 | Final branch is clean | PASS | Candidate worktree `deploy-ga-5nf5lm` was clean before adding this gate file; `git config core.hooksPath` reports `.githooks`. This gate file is committed as release evidence before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git fetch origin main` completed, then `git merge-tree --write-tree origin/main HEAD` returned tree `c0a73bfc57617fc559e5a030667978c59ede03f6` with exit 0. |
+| 7 | Single feature theme | PASS | The branch touches only `cmd/gc` pool session planning and regression tests for fail-closed handling of partial pool demand reads. |
+
+## Acceptance Notes
+
+- `errPoolSessionCreatePartial` message is exactly `pool session create skipped: demand read partial`.
+- `realizePoolDesiredSessions` reports the distinct suffix `(partial demand read, fresh create blocked)`.
+- The fresh-create gate sits after preferred/resume, canonical non-expanding reuse, and reusable pool-session selection, and before `tryClaimPoolSessionCreate`.
+- `scaleCheckPartialSessionRetainable` counts only `active`, `awake`, and active `pending_create_claim=true` creates.
+- `discoverSessionBeadsWithRoots` uses `poolPartialAlive` so stale creating/start-pending pool beads are not kept alive by a partial tick.
+
+## Test Evidence
+
+- `git diff --check origin/main...HEAD`: PASS.
+- `go test ./cmd/gc -run 'TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates|TestRetainScaleCheckPartialPoolDesired_InFlightCreatingBeadRetained|TestRetainScaleCheckPartialPoolDesiredNormalizesLegacyBoundTemplate' -count=1`: PASS (`cmd/gc` in 0.503s).
+- `make test-fast-parallel`: PASS (`All fast jobs passed`).
+- `go vet ./...`: PASS.
+
+## Deploy Notes
+
+- `gh auth status` passed for account `quad341`.
+- No open PR was found for head branch `builder/ga-4qbgqf.2-partial-demand-create-gate` before creating this deploy PR.
+- The standing deployer worktree has an unrelated interrupted rebase on `deploy/ga-q32h2b-test-deflakes-clean`; this gate was evaluated in the clean `deploy-ga-5nf5lm` worktree at the candidate commit.

--- a/release-gates/ga-efg8i6-mode-aware-pool-demand-gate.md
+++ b/release-gates/ga-efg8i6-mode-aware-pool-demand-gate.md
@@ -1,0 +1,43 @@
+# Release Gate: Mode-Aware Pool Demand Gate
+
+Date: 2026-06-24
+
+Deploy bead: `ga-efg8i6`
+Source review bead: `ga-xl9qx7`
+Reviewed commit: `4c42a6f09a9354539e5a688fd6e4b6c970e9492a`
+Branch: `builder/ga-4qbgqf.2-partial-demand-create-gate`
+PR handling: branch already has open PR `#3687`, authored by `quad341`, with no comments or reviews at gate time. This deploy updates that PR instead of creating a duplicate PR for the same head branch.
+
+## Release Criteria Source
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate applies the deployer release criteria from the active role instructions plus the repository testing guidance in `TESTING.md`.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-xl9qx7` records `REVIEW VERDICT: PASS`; reviewer sections Style, Spec compliance, and Coverage are PASS; Blockers: NONE. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/build_desired_state.go` now tracks `namedSessionMode`, gates default pool-demand targets for `mode="always"`, leaves named partial-retention probes intact, and clamps `mode="on_demand"` named-backed pool demand to one. Focused acceptance tests passed. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'Test(DefaultNamedSessionDemandRecordsPartialWithoutRoutedDemand\|DefaultNamedSessionDemandIgnoresNamedIdentityRunTargetOnlyWorkflow\|BuildDesiredState_OnDemandNamedSession_DefaultRoutedWorkUsesTemplatePoolDemand\|BuildDesiredState_OnDemandNamedSession_DefaultRoutedTaskWispUsesTemplatePoolDemand\|BuildDesiredState_OnDemandNamedSession_DefaultRoutedTemplateUsesGenericPoolDemand\|BuildDesiredState_NamedBackedPoolPartialRetainsGenericPoolSession\|BuildDesiredState_NamedBackingPoolNoCap_RoutedDemandDoesNotSpawnPhantoms)$'` passed. `make test-fast-parallel` passed all 8 fast jobs. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list no findings requiring action and `Blockers: NONE`; no HIGH findings are present in the review bead notes. |
+| 5 | Final branch is clean | PASS | Clean deploy worktree used for gate evaluation. Before writing this checklist, `git status --short --branch` returned only the branch header. The gate commit contains only this checklist file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` passed. `git merge-tree --write-tree origin/main HEAD` produced clean tree `67a6ef2a1ade7969efd28fd361075808534d79de`. |
+| 7 | Single feature theme | PASS | The product diff is confined to `cmd/gc` pool/session desired-state behavior and its tests. The reviewed change is one pool-demand theme: prevent named-backed pool templates from spawning generic `{name}-N` sessions while preserving `on_demand` wake behavior. |
+
+## Acceptance Evidence
+
+- `mode="always"` named-backed templates no longer append default generic pool-demand probes, preventing routed work from spawning phantom pool sessions alongside the canonical named session.
+- `mode="on_demand"` named-backed templates still append default pool-demand probes so routed template work wakes the singleton.
+- Default named scale targets remain unchanged for partial-read retention bookkeeping.
+- Demand counts for `mode="on_demand"` named-backed templates are clamped to one during the default-count merge, mirroring the existing cold-wake clamp.
+- Repro test `TestBuildDesiredState_NamedBackingPoolNoCap_RoutedDemandDoesNotSpawnPhantoms` passed on healthy non-partial reads.
+
+## Commands Run
+
+```text
+go test ./cmd/gc -run 'Test(DefaultNamedSessionDemandRecordsPartialWithoutRoutedDemand\|DefaultNamedSessionDemandIgnoresNamedIdentityRunTargetOnlyWorkflow\|BuildDesiredState_OnDemandNamedSession_DefaultRoutedWorkUsesTemplatePoolDemand\|BuildDesiredState_OnDemandNamedSession_DefaultRoutedTaskWispUsesTemplatePoolDemand\|BuildDesiredState_OnDemandNamedSession_DefaultRoutedTemplateUsesGenericPoolDemand\|BuildDesiredState_NamedBackedPoolPartialRetainsGenericPoolSession\|BuildDesiredState_NamedBackingPoolNoCap_RoutedDemandDoesNotSpawnPhantoms)$'
+make test-fast-parallel
+go vet ./...
+git merge-base --is-ancestor origin/main HEAD
+git merge-tree --write-tree origin/main HEAD
+```

--- a/release-gates/ga-wujrgt-provider-health-snapshot-cleanup-gate.md
+++ b/release-gates/ga-wujrgt-provider-health-snapshot-cleanup-gate.md
@@ -1,0 +1,51 @@
+# Release Gate: provider-health snapshot nil-state cleanup
+
+- Bead: `ga-wujrgt`
+- Source review bead: `ga-vwj3q3`
+- Branch: `builder/ga-4qbgqf.2-partial-demand-create-gate`
+- Reviewed commit: `56b01ea0fc46e59e8c4226738b679f2adbefd71f`
+- PR: https://github.com/gastownhall/gascity/pull/3687
+- Gate worktree: clean detached checkout of `origin/builder/ga-4qbgqf.2-partial-demand-create-gate`
+- Manifest note: `docs/PROJECT_MANIFEST.md` and `PROJECT_MANIFEST.md` are not present in this checkout, so this gate uses the deployer release criteria plus `TESTING.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-vwj3q3` is closed with `Reviewer Verdict: PASS`. Reviewer found no severity findings and verified provider-health fail-open semantics. |
+| 2 | Acceptance criteria met | PASS | Cleanup removes the dead `bp.providerHealthSnapshot != nil` guard and updates the stale `agentBuildParams` comment. `loadProviderHealthSnapshot` always returns a non-nil snapshot; `check()` preserves fail-open behavior through `present=false`. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'Test(SnapshotCheck_|SnapshotHealthyProviders|Gate_|BuildDesiredState_ProviderRedBlocksNewPoolSessionCreate)' -count=1`; `make test-fast-parallel`; `go vet ./...`. All passed locally. PR #3687 checks were green before this gate commit. |
+| 4 | No high-severity review findings open | PASS | Review notes record no findings beyond informational observations. PR #3687 had no comments or reviews at gate time. |
+| 5 | Final branch is clean | PASS | Gate worktree was clean before writing this file. Only this gate checklist is staged for the gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` produced no conflict output before this gate commit. |
+| 7 | Single feature theme | PASS | The commit set remains one pool/provider-health subsystem theme on `cmd/gc` desired-state creation behavior and its release-gate evidence. The reviewed cleanup is a two-file maintenance commit on the provider-health gate introduced by the same PR. |
+
+## Reviewed Cleanup
+
+The reviewed cleanup touches:
+
+- `cmd/gc/agent_build_params.go`
+- `cmd/gc/build_desired_state.go`
+
+The change removes a dead nil guard from `selectOrPlanPoolSessionBead` and aligns the field comment with the actual contract: `loadProviderHealthSnapshot` returns a non-nil snapshot, using `present=false` when the registry is absent, unreadable, or empty.
+
+## Test Log
+
+```text
+go test ./cmd/gc -run 'Test(SnapshotCheck_|SnapshotHealthyProviders|Gate_|BuildDesiredState_ProviderRedBlocksNewPoolSessionCreate)' -count=1
+ok  	github.com/gastownhall/gascity/cmd/gc	0.153s
+
+make test-fast-parallel
+[fsys-darwin-compile] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-cmd-gc-1-of-6] ok
+[unit-cmd-gc-3-of-6] ok
+[unit-core] ok
+[unit-cmd-gc-6-of-6] ok
+All fast jobs passed
+
+go vet ./...
+PASS
+```


### PR DESCRIPTION
## What this changes

Supervisor pool reconciliation now fails closed before creating new pool sessions when demand reads are partial or provider health marks a runtime provider red. Existing usable pool sessions can still be retained or reused, but the supervisor no longer expands a pool from stale or unsafe demand signals.

Named-session-backed pool templates are now mode-aware. A `mode="always"` named session is satisfied by its canonical named identity and no longer also creates generic `{name}-N` pool workers for queued `gc.routed_to=<template>` work. A `mode="on_demand"` named session still wakes from routed template work, but its default pool demand is clamped to one slot so the singleton drains the queue without spawning phantoms.

## Root cause

This fixes a supervisor regression: named-session-backed pool templates (per-rig `witness` sessions, and the `mayor`) over-spawned unbounded phantom `{name}-N` pool workers on **fully healthy** demand reads.

`bda368b0e` ("keep template-routed graph work unassigned") intentionally surfaces `gc.routed_to=<template>` graph/molecule roots as generic pool demand so ordinary pool workers can claim them. But for a template that *also* backs a named session and has no custom `scale_check` and no `max_active_sessions`, that routed demand was counted as new-session demand and materialized as `{name}-N` instances *alongside* the canonical named singleton. Because the singleton cannot drain those routed roots (molecule/step roots are `Ready()`-excluded), the desired count only ratcheted upward — an unbounded spawn loop (observed live as a `witness-1..N` / duplicate-`mayor` swarm).

This is distinct from the **partial-read** fail-closed work in #3686: the over-spawn reproduces on healthy, **non-partial** reads, so those guards never engage. The added regression test asserts the reads are non-partial, isolating this facet. The mode-aware gate is the actual fix, and it removes the need for the `max_active_sessions=1` band-aid previously used to contain the `mayor`.

## Why this shape

The change stays inside the existing desired-state calculation: demand probes collect per-template gate signals, and session creation enforces them at the pool boundary. That keeps the behavior role-agnostic and avoids adding a new orchestration primitive or provider-specific path. `bda368b0e`'s intended behavior is preserved (its guard tests stay green); only the named-backing over-count is corrected.

## Review notes

- Main review surface: `cmd/gc/build_desired_state.go` and `cmd/gc/agent_build_params.go`.
- The tests in `cmd/gc/build_desired_state_test.go` cover partial reads, provider-red creates, pending creates, named-backed pool demand, and the phantom `{name}-N` regression.
- No config, API, schema, dashboard, or migration surface changes.
- Behavior is default-on for supervisor reconciliation; there is no operator knob.

## Test plan

- [x] `go test ./cmd/gc -run 'Test(DefaultNamedSessionDemandRecordsPartialWithoutRoutedDemand|DefaultNamedSessionDemandIgnoresNamedIdentityRunTargetOnlyWorkflow|BuildDesiredState_OnDemandNamedSession_DefaultRoutedWorkUsesTemplatePoolDemand|BuildDesiredState_OnDemandNamedSession_DefaultRoutedTaskWispUsesTemplatePoolDemand|BuildDesiredState_OnDemandNamedSession_DefaultRoutedTemplateUsesGenericPoolDemand|BuildDesiredState_NamedBackedPoolPartialRetainsGenericPoolSession|BuildDesiredState_NamedBackingPoolNoCap_RoutedDemandDoesNotSpawnPhantoms)$'`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-efg8i6-mode-aware-pool-demand-gate.md`](release-gates/ga-efg8i6-mode-aware-pool-demand-gate.md)
