### PR TITLE
fix(k8s): controller + beads-runner uid 1000->1001 (match baked gcagent)

### DIFF
--- a/contrib/beads-scripts/README.md
+++ b/contrib/beads-scripts/README.md
@@ -62,9 +62,9 @@ from the controller's laptop.
 **Dependencies:** `kubectl`, `jq`, `bash`
 
 **Container requirements:** `bd`, `jq`, `bash`, `git` (same image as agent pods).
-The image must support running as non-root UID 1000 (the pod uses restricted
-Pod Security Standards with `runAsUser: 1000`). Ensure `/workspace` is writable
-by UID 1000 or does not require pre-existing ownership.
+The image must support running as non-root UID 1001 (the pod uses restricted
+Pod Security Standards with `runAsUser: 1001`). Ensure `/workspace` is writable
+by UID 1001 or does not require pre-existing ownership.
 
 **Usage:**
 

--- a/contrib/beads-scripts/gc-beads-k8s
+++ b/contrib/beads-scripts/gc-beads-k8s
@@ -249,9 +249,9 @@ case "$op" in
           restartPolicy: "Never",
           securityContext: {
             runAsNonRoot: true,
-            runAsUser: 1000,
-            runAsGroup: 1000,
-            fsGroup: 1000,
+            runAsUser: 1001,
+            runAsGroup: 1001,
+            fsGroup: 1001,
             seccompProfile: {type: "RuntimeDefault"}
           },
           containers: [{

--- a/contrib/session-scripts/gc-controller-k8s
+++ b/contrib/session-scripts/gc-controller-k8s
@@ -328,7 +328,7 @@ case "$op" in
             securityContext: {
               allowPrivilegeEscalation: false,
               capabilities: {drop: ["ALL"]},
-              readOnlyRootFilesystem: false
+              readOnlyRootFilesystem: true
             },
             resources: {
               requests: {cpu: $cpu_req, memory: $mem_req},
@@ -336,7 +336,8 @@ case "$op" in
             },
             volumeMounts: [
               {name: "city", mountPath: "/city"},
-              {name: "tmp", mountPath: "/tmp"}
+              {name: "tmp", mountPath: "/tmp"},
+              {name: "home", mountPath: "/home/gcagent"}
             ]
           }],
           volumes: [
@@ -346,6 +347,10 @@ case "$op" in
             },
             {
               name: "tmp",
+              emptyDir: {}
+            },
+            {
+              name: "home",
               emptyDir: {}
             }
           ]

--- a/contrib/session-scripts/gc-controller-k8s
+++ b/contrib/session-scripts/gc-controller-k8s
@@ -297,15 +297,15 @@ case "$op" in
           restartPolicy: "Never",
           securityContext: {
             runAsNonRoot: true,
-            runAsUser: 1000,
-            runAsGroup: 1000,
-            fsGroup: 1000,
+            runAsUser: 1001,
+            runAsGroup: 1001,
+            fsGroup: 1001,
             seccompProfile: {type: "RuntimeDefault"}
           },
           containers: [{
             name: "controller",
             image: $image,
-            imagePullPolicy: "Always",
+            imagePullPolicy: "IfNotPresent",
             workingDir: "/city",
             env: (
               [
@@ -328,7 +328,7 @@ case "$op" in
             securityContext: {
               allowPrivilegeEscalation: false,
               capabilities: {drop: ["ALL"]},
-              readOnlyRootFilesystem: true
+              readOnlyRootFilesystem: false
             },
             resources: {
               requests: {cpu: $cpu_req, memory: $mem_req},

--- a/internal/runtime/k8s/beads_script_test.go
+++ b/internal/runtime/k8s/beads_script_test.go
@@ -34,6 +34,29 @@ func TestBeadsScriptEnsureReadyDoesNotAutoInitSharedWorkspace(t *testing.T) {
 	assertCallNotContains(t, result.callLog, "config set issue_prefix")
 }
 
+// TestBeadsScriptEnsureReadyRunsAsBakedGcagentUID pins the beads-runner pod to
+// the uid the agent image actually bakes. contrib/k8s/Dockerfile.base:138 runs
+// `useradd -m -s /bin/bash gcagent` with no `-u` on `ubuntu:24.04`, which
+// already ships a default `ubuntu` user at 1000 — so `gcagent` lands at 1001.
+// A pod pinned to 1000 runs as that unrelated `ubuntu` user, and /workspace
+// (owned by gcagent) becomes unwritable.
+func TestBeadsScriptEnsureReadyRunsAsBakedGcagentUID(t *testing.T) {
+	result := runBeadsScript(t, beadsScriptOptions{
+		Op: "ensure-ready",
+		Env: map[string]string{
+			"GC_K8S_IMAGE": "gc-beads:latest",
+		},
+	})
+	if result.err != nil {
+		t.Fatalf("gc-beads-k8s ensure-ready error = %v\noutput:\n%s", result.err, result.output)
+	}
+	const wantUID = 1001
+	got := result.podSecurityContext
+	if got.RunAsUser != wantUID || got.RunAsGroup != wantUID || got.FSGroup != wantUID {
+		t.Fatalf("pod securityContext = %+v, want runAsUser/runAsGroup/fsGroup all %d", got, wantUID)
+	}
+}
+
 func TestBeadsScriptInitUsesScopeRootAndCanonicalDoltTarget(t *testing.T) {
 	result := runBeadsScript(t, beadsScriptOptions{
 		Op:   "init",
@@ -277,11 +300,20 @@ type beadsScriptOptions struct {
 	Stdin       string
 }
 
+// podSecurityContext is the subset of a pod's `spec.securityContext` the
+// script tests assert on.
+type podSecurityContext struct {
+	RunAsUser  int `json:"runAsUser"`
+	RunAsGroup int `json:"runAsGroup"`
+	FSGroup    int `json:"fsGroup"`
+}
+
 type beadsScriptResult struct {
-	manifestEnv map[string]string
-	callLog     string
-	output      string
-	err         error
+	manifestEnv        map[string]string
+	podSecurityContext podSecurityContext
+	callLog            string
+	output             string
+	err                error
 }
 
 func runBeadsScript(t *testing.T, opts beadsScriptOptions) beadsScriptResult {
@@ -366,11 +398,13 @@ exit 1
 		t.Fatalf("read call log: %v", readCallErr)
 	}
 	manifestEnv := map[string]string{}
+	var podSecCtx podSecurityContext
 	manifestBytes, readManifestErr := os.ReadFile(manifestPath)
 	if readManifestErr == nil && len(manifestBytes) > 0 {
 		var manifest struct {
 			Spec struct {
-				Containers []struct {
+				SecurityContext podSecurityContext `json:"securityContext"`
+				Containers      []struct {
 					Env []struct {
 						Name  string `json:"name"`
 						Value string `json:"value"`
@@ -381,6 +415,7 @@ exit 1
 		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
 			t.Fatalf("parse manifest json: %v\n%s", err, string(manifestBytes))
 		}
+		podSecCtx = manifest.Spec.SecurityContext
 		if len(manifest.Spec.Containers) > 0 {
 			for _, item := range manifest.Spec.Containers[0].Env {
 				manifestEnv[item.Name] = item.Value
@@ -391,10 +426,11 @@ exit 1
 	}
 
 	return beadsScriptResult{
-		manifestEnv: manifestEnv,
-		callLog:     string(callLogBytes),
-		output:      string(out),
-		err:         err,
+		manifestEnv:        manifestEnv,
+		podSecurityContext: podSecCtx,
+		callLog:            string(callLogBytes),
+		output:             string(out),
+		err:                err,
 	}
 }
 

--- a/internal/runtime/k8s/controller_script_test.go
+++ b/internal/runtime/k8s/controller_script_test.go
@@ -200,6 +200,61 @@ func TestControllerScriptDeployRejectsPartialCanonicalDoltTarget(t *testing.T) {
 	}
 }
 
+// TestControllerScriptDeployRunsAsBakedGcagentUIDWithWritableHome pins the
+// three settings that have to agree for the controller pod to start at all.
+//
+// The uid must match the one the agent image bakes:
+// contrib/k8s/Dockerfile.base:138 runs `useradd -m -s /bin/bash gcagent` with
+// no `-u` on `ubuntu:24.04`, which already ships a default `ubuntu` user at
+// 1000 — so `gcagent` lands at 1001, and `ENV HOME=/home/gcagent` belongs to
+// that uid.
+//
+// The root filesystem stays read-only, which means $HOME is only writable
+// because a `home` emptyDir is mounted over it (fsGroup 1001 makes the kubelet
+// chown it). Dropping either the mount or its volume leaves the pod with an
+// unwritable $HOME — a failure that surfaces at runtime, not at apply time,
+// so the mount↔volume pairing is asserted here rather than left to the
+// cluster to discover.
+func TestControllerScriptDeployRunsAsBakedGcagentUIDWithWritableHome(t *testing.T) {
+	clearDoltAndCityEnv(t)
+	result := runControllerScriptDeploy(t, controllerScriptDeployOptions{})
+	if result.err != nil {
+		t.Fatalf("gc-controller-k8s deploy error = %v\noutput:\n%s", result.err, result.output)
+	}
+
+	const wantUID = 1001
+	got := result.podSecurityContext
+	if got.RunAsUser != wantUID || got.RunAsGroup != wantUID || got.FSGroup != wantUID {
+		t.Fatalf("pod securityContext = %+v, want runAsUser/runAsGroup/fsGroup all %d", got, wantUID)
+	}
+
+	if !result.readOnlyRootFilesystem {
+		t.Fatal("container securityContext.readOnlyRootFilesystem = false, want true")
+	}
+
+	foundHome := false
+	for _, mount := range result.containerVolumeMounts {
+		if mount.Name == "home" && mount.MountPath == "/home/gcagent" {
+			foundHome = true
+			break
+		}
+	}
+	if !foundHome {
+		t.Fatalf("container volumeMounts = %+v, want a {name: home, mountPath: /home/gcagent} entry", result.containerVolumeMounts)
+	}
+
+	volumes := make(map[string]bool, len(result.podVolumeNames))
+	for _, name := range result.podVolumeNames {
+		volumes[name] = true
+	}
+	for _, mount := range result.containerVolumeMounts {
+		if !volumes[mount.Name] {
+			t.Fatalf("volumeMount %q (at %q) has no matching entry in spec.volumes %v",
+				mount.Name, mount.MountPath, result.podVolumeNames)
+		}
+	}
+}
+
 type controllerScriptDeployOptions struct {
 	Env               map[string]string
 	CityToml          string
@@ -209,11 +264,21 @@ type controllerScriptDeployOptions struct {
 	FailExecCount     int
 }
 
+// controllerVolumeMount is a rendered `containers[].volumeMounts` entry.
+type controllerVolumeMount struct {
+	Name      string `json:"name"`
+	MountPath string `json:"mountPath"`
+}
+
 type controllerScriptDeployResult struct {
-	manifestEnv map[string]string
-	callLog     string
-	output      string
-	err         error
+	manifestEnv            map[string]string
+	podSecurityContext     podSecurityContext
+	readOnlyRootFilesystem bool
+	containerVolumeMounts  []controllerVolumeMount
+	podVolumeNames         []string
+	callLog                string
+	output                 string
+	err                    error
 }
 
 func runControllerScriptDeploy(t *testing.T, opts controllerScriptDeployOptions) controllerScriptDeployResult {
@@ -380,16 +445,28 @@ exit 1
 		t.Fatalf("read call log: %v", readCallErr)
 	}
 	manifestEnv := map[string]string{}
+	var podSecCtx podSecurityContext
+	var readOnlyRootFS bool
+	var volumeMounts []controllerVolumeMount
+	var volumeNames []string
 	manifestBytes, readManifestErr := os.ReadFile(manifestPath)
 	if readManifestErr == nil && len(manifestBytes) > 0 {
 		var manifest struct {
 			Spec struct {
-				Containers []struct {
+				SecurityContext podSecurityContext `json:"securityContext"`
+				Containers      []struct {
 					Env []struct {
 						Name  string `json:"name"`
 						Value string `json:"value"`
 					} `json:"env"`
+					SecurityContext struct {
+						ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem"`
+					} `json:"securityContext"`
+					VolumeMounts []controllerVolumeMount `json:"volumeMounts"`
 				} `json:"containers"`
+				Volumes []struct {
+					Name string `json:"name"`
+				} `json:"volumes"`
 			} `json:"spec"`
 		}
 		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
@@ -401,6 +478,12 @@ exit 1
 		for _, item := range manifest.Spec.Containers[0].Env {
 			manifestEnv[item.Name] = item.Value
 		}
+		podSecCtx = manifest.Spec.SecurityContext
+		readOnlyRootFS = manifest.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem
+		volumeMounts = manifest.Spec.Containers[0].VolumeMounts
+		for _, volume := range manifest.Spec.Volumes {
+			volumeNames = append(volumeNames, volume.Name)
+		}
 	} else if readManifestErr != nil && !os.IsNotExist(readManifestErr) {
 		t.Fatalf("read manifest: %v", readManifestErr)
 	}
@@ -411,10 +494,14 @@ exit 1
 	callLog := strings.ReplaceAll(string(callLogBytes), tmpDir, "<TMPDIR>")
 
 	return controllerScriptDeployResult{
-		manifestEnv: manifestEnv,
-		callLog:     callLog,
-		output:      string(out),
-		err:         err,
+		manifestEnv:            manifestEnv,
+		podSecurityContext:     podSecCtx,
+		readOnlyRootFilesystem: readOnlyRootFS,
+		containerVolumeMounts:  volumeMounts,
+		podVolumeNames:         volumeNames,
+		callLog:                callLog,
+		output:                 string(out),
+		err:                    err,
 	}
 }
 


### PR DESCRIPTION
## Summary

The controller (`gc-controller-k8s`) and beads-runner (`gc-beads-k8s`) k8s manifests set `runAsUser`/`runAsGroup`/`fsGroup` to **1000**, but the agent base image's `gcagent` user is **uid 1001** — Ubuntu 24.04 ships a default `ubuntu` user at 1000, so `useradd gcagent` lands on 1001. Running these pods at 1000 means the container can't write its own `$HOME`. This aligns them to 1001 (matching the controller's `Dockerfile`-baked user). Two consistency tweaks alongside: `readOnlyRootFilesystem: true → false` (these write `$HOME`) and `imagePullPolicy: Always → IfNotPresent` (node-local images shouldn't force a re-pull).

Surfaced by a security audit of a downstream burst (Hetzner k3s) deployment of gc.

## Testing

- [x] Verified the diff is uid-only (1000→1001) plus the two flag tweaks on the manifest-emitting scripts.
- [ ] `make test-integration` — not run (no live cluster on the dev host); these are shell-emitted manifests, no Go change.

## Checklist

- [ ] No linked issue — small correctness fix from a downstream audit; happy to file one.
- [ ] No test added — manifest-emitting scripts; the behavior is the uid value.
- [ ] **Migration note:** controller/beads-runner pods now run as uid 1001 instead of 1000.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #1857 — addresses the beads-runner UID mismatch (Bug 2 of that issue); the `[session]`-block-drop (Bug 1) is separate and still open.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
