### PR TITLE
fix(eventexport): assert correlation guard against SchemaVersion const, not literal 1

### DIFF
--- a/pkg/eventexport/exporter_test.go
+++ b/pkg/eventexport/exporter_test.go
@@ -266,9 +266,12 @@ func TestExporter_EmitCorrelation(t *testing.T) {
 		if len(all) == 0 || len(all[0].Events) == 0 {
 			t.Fatalf("expected at least one exported event")
 		}
-		// schema_version must stay 1 regardless of correlation emission.
-		if all[0].SchemaVersion != 1 {
-			t.Fatalf("schema_version = %d, want 1 (emitting run/session is v1-compatible)", all[0].SchemaVersion)
+		// Emitting run/session correlation is version-neutral: it must not change
+		// the batch schema_version away from the package's current SchemaVersion.
+		// Assert the const, not a literal, so a legitimate wire bump (e.g. the v2
+		// city_id->city_hash change in #3678) doesn't falsely fail this guard.
+		if all[0].SchemaVersion != SchemaVersion {
+			t.Fatalf("schema_version = %d, want %d (emitting run/session is version-neutral)", all[0].SchemaVersion, SchemaVersion)
 		}
 		return all[0]
 	}


### PR DESCRIPTION
## Fix the stale eventexport correlation guard reddening `main`

`TestExporter_EmitCorrelation` pins the batch `schema_version` to a literal `1` to prove that emitting `run_id`/`session_id` correlation is **version-neutral** (it shouldn't bump the schema).

PR #3678 ("redact city_id…") then legitimately bumped `SchemaVersion 1 → 2` — it replaced cleartext `city_id` with a salted `city_hash`, a real wire-format change — but did **not** update this guard test. So it has failed on `main` ever since:

```
--- FAIL: TestExporter_EmitCorrelation
    exporter_test.go:271: schema_version = 2, want 1 (emitting run/session is v1-compatible)
```

This reddens the `packages-core` integration shard on **every** open PR.

### Fix
The code/const is correct; only the assertion was stale. Assert against the `SchemaVersion` const instead of a literal `1`, preserving the test's real intent (correlation emission doesn't change the schema version from the package default) and surviving future legitimate wire bumps:

```go
if all[0].SchemaVersion != SchemaVersion {
    t.Fatalf("schema_version = %d, want %d (emitting run/session is version-neutral)", all[0].SchemaVersion, SchemaVersion)
}
```

Test-only change. `go test ./pkg/eventexport/` (and `-tags integration`) green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
