### PR TITLE
feat(eventexport): carry step_id (the acting work bead) on exported events

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -173,7 +173,7 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 	if ep != nil {
 		recorder = ep
 	}
-	onChange := func(eventType, beadID, runID, sessionID string, payload json.RawMessage) {
+	onChange := func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage) {
 		if recorder != nil {
 			recorder.Record(events.Event{
 				Type:      eventType,
@@ -181,6 +181,7 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 				Subject:   beadID,
 				RunID:     runID,
 				SessionID: sessionID,
+				StepID:    stepID,
 				Payload:   payload,
 			})
 		}

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -45,7 +45,7 @@ type CachingStore struct {
 	reconciling  atomic.Bool
 	syncFailures int
 	stats        CacheStats
-	onChange     func(eventType, beadID, runID, sessionID string, payload json.RawMessage)
+	onChange     func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage)
 	problemf     func(string)
 	problemLog   map[string]cacheProblemLogState
 
@@ -228,7 +228,7 @@ func computeAutoStagger(agentID string) time.Duration {
 // changed bead's metadata at the record site (see notifyChange); the wiring
 // stamps them onto the recorded event so the redacted export can forward them
 // as typed primitives without ever decoding the payload.
-func NewCachingStore(backing Store, onChange func(eventType, beadID, runID, sessionID string, payload json.RawMessage)) *CachingStore {
+func NewCachingStore(backing Store, onChange func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage)) *CachingStore {
 	prefix := ""
 	bdBacking := false
 	nilBdBacking := false
@@ -270,11 +270,11 @@ func NewCachingStoreForTestWithPrefix(backing Store, idPrefix string, onChange f
 // adaptLegacyOnChange bridges the legacy 3-param onChange used by the test
 // constructors to the production 5-param form, dropping the run/session ids the
 // tests do not exercise. Nil-safe.
-func adaptLegacyOnChange(fn func(eventType, beadID string, payload json.RawMessage)) func(eventType, beadID, runID, sessionID string, payload json.RawMessage) {
+func adaptLegacyOnChange(fn func(eventType, beadID string, payload json.RawMessage)) func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage) {
 	if fn == nil {
 		return nil
 	}
-	return func(eventType, beadID string, _, _ string, payload json.RawMessage) {
+	return func(eventType, beadID string, _, _, _ string, payload json.RawMessage) {
 		fn(eventType, beadID, payload)
 	}
 }
@@ -286,7 +286,7 @@ func (c *CachingStore) SetPrimeRetryDelayForTest(fn func(attempt int) time.Durat
 	c.primeRetryDelay = fn
 }
 
-func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID, runID, sessionID string, payload json.RawMessage)) *CachingStore {
+func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
 		backing:     backing,
 		idPrefix:    normalizeIDPrefix(idPrefix),

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -670,7 +670,11 @@ func (c *CachingStore) notifyChange(eventType string, b Bead) {
 	// safeRef-gated again at the export boundary.
 	runID := beadmeta.ResolveRunID(b.Metadata, b.ID, "")
 	sessionID := b.Metadata[beadmeta.SessionIDMetadataKey]
-	c.onChange(eventType, b.ID, runID, sessionID, payload)
+	// step_id is the acting work bead the lifecycle event is about: a work/dispatch
+	// bead carries its own gc.step_id, so a bead.created/closed on one stamps that
+	// step. Non-work beads (sessions, mail, …) carry none → empty, omitted at export.
+	stepID := b.Metadata[beadmeta.StepIDMetadataKey]
+	c.onChange(eventType, b.ID, runID, sessionID, stepID, payload)
 }
 
 type cacheNotification struct {

--- a/internal/beads/caching_store_runid_test.go
+++ b/internal/beads/caching_store_runid_test.go
@@ -11,15 +11,17 @@ import (
 // typed-at-record-site resolution that lets the redacted export carry run_id
 // without ever decoding the payload.
 func TestNotifyChangeResolvesRunSession(t *testing.T) {
-	var gotType, gotID, gotRun, gotSession string
-	cs := NewCachingStore(NewMemStore(), func(eventType, beadID, runID, sessionID string, _ json.RawMessage) {
-		gotType, gotID, gotRun, gotSession = eventType, beadID, runID, sessionID
+	var gotType, gotID, gotRun, gotSession, gotStep string
+	cs := NewCachingStore(NewMemStore(), func(eventType, beadID, runID, sessionID, stepID string, _ json.RawMessage) {
+		gotType, gotID, gotRun, gotSession, gotStep = eventType, beadID, runID, sessionID, stepID
 	})
 
-	// gc.root_bead_id resolves the run root; gc.session_id is a direct read.
+	// gc.root_bead_id resolves the run root; gc.session_id and gc.step_id are direct
+	// reads of the SUBJECT bead's own metadata (a work bead carries its own step).
 	cs.notifyChange("bead.closed", Bead{ID: "mc-1", Metadata: map[string]string{
 		"gc.root_bead_id": "wf-root-x",
 		"gc.session_id":   "sess-y",
+		"gc.step_id":      "mc-step-z",
 	}})
 	if gotType != "bead.closed" || gotID != "mc-1" {
 		t.Fatalf("event meta: type=%q id=%q, want bead.closed/mc-1", gotType, gotID)
@@ -30,10 +32,13 @@ func TestNotifyChangeResolvesRunSession(t *testing.T) {
 	if gotSession != "sess-y" {
 		t.Fatalf("sessionID = %q, want sess-y (gc.session_id)", gotSession)
 	}
+	if gotStep != "mc-step-z" {
+		t.Fatalf("stepID = %q, want mc-step-z (gc.step_id)", gotStep)
+	}
 
 	// workflow_id wins the run-chain precedence over gc.root_bead_id.
 	var run2 string
-	cs2 := NewCachingStore(NewMemStore(), func(_, _, runID, _ string, _ json.RawMessage) { run2 = runID })
+	cs2 := NewCachingStore(NewMemStore(), func(_, _, runID, _, _ string, _ json.RawMessage) { run2 = runID })
 	cs2.notifyChange("bead.created", Bead{ID: "mc-2", Metadata: map[string]string{
 		"workflow_id":     "wf-graph-root",
 		"gc.root_bead_id": "wf-root-x",
@@ -42,14 +47,17 @@ func TestNotifyChangeResolvesRunSession(t *testing.T) {
 		t.Fatalf("runID = %q, want wf-graph-root (workflow_id precedence)", run2)
 	}
 
-	// No run-chain metadata: run falls back to the bead's own id; session empty.
-	var run3, sess3 string
-	cs3 := NewCachingStore(NewMemStore(), func(_, _, runID, sessionID string, _ json.RawMessage) { run3, sess3 = runID, sessionID })
+	// No run-chain metadata: run falls back to the bead's own id; session + step empty
+	// (a non-work bead carries no gc.step_id).
+	var run3, sess3, step3 string
+	cs3 := NewCachingStore(NewMemStore(), func(_, _, runID, sessionID, stepID string, _ json.RawMessage) {
+		run3, sess3, step3 = runID, sessionID, stepID
+	})
 	cs3.notifyChange("bead.created", Bead{ID: "mc-3"})
 	if run3 != "mc-3" {
 		t.Fatalf("runID fallback = %q, want mc-3 (bead's own id)", run3)
 	}
-	if sess3 != "" {
-		t.Fatalf("sessionID = %q, want empty (no gc.session_id)", sess3)
+	if sess3 != "" || step3 != "" {
+		t.Fatalf("sessionID/stepID = %q/%q, want both empty (no gc.session_id/step_id)", sess3, step3)
 	}
 }

--- a/internal/eventfeed/muxsource.go
+++ b/internal/eventfeed/muxsource.go
@@ -63,6 +63,7 @@ func toExport(te events.TaggedEvent) eventexport.TaggedEvent {
 		Subject:   te.Subject,
 		RunID:     te.RunID,
 		SessionID: te.SessionID,
+		StepID:    te.StepID,
 	}
 }
 

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -246,6 +246,7 @@ type Event struct {
 	Payload   json.RawMessage `json:"payload,omitempty"`
 	RunID     string          `json:"run_id,omitempty"`
 	SessionID string          `json:"session_id,omitempty"`
+	StepID    string          `json:"step_id,omitempty"`
 }
 
 // Recorder records events. Safe for concurrent use. Best-effort.

--- a/pkg/eventexport/exporter.go
+++ b/pkg/eventexport/exporter.go
@@ -27,6 +27,7 @@ type TaggedEvent struct {
 	Subject   string
 	RunID     string
 	SessionID string
+	StepID    string
 	_         struct{} // force keyed literals; blocks positional field transposition
 }
 

--- a/pkg/eventexport/exporter_test.go
+++ b/pkg/eventexport/exporter_test.go
@@ -258,7 +258,7 @@ func TestExporter_EmitCorrelation(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		done := make(chan struct{})
 		go func() { _ = exp.Run(ctx, src); close(done) }()
-		src.ch <- TaggedEvent{City: "c1", Seq: 1, Type: "bead.closed", Ts: fixedTS, Actor: "ctl", Subject: "mc-1", RunID: "wf-root-abc", SessionID: "sess-9f2a"}
+		src.ch <- TaggedEvent{City: "c1", Seq: 1, Type: "bead.closed", Ts: fixedTS, Actor: "ctl", Subject: "mc-1", RunID: "wf-root-abc", SessionID: "sess-9f2a", StepID: "mc-step-7"}
 		waitFor(t, 2*time.Second, func() bool { return exp.Cursors()["c1"] == 1 })
 		cancel()
 		<-done
@@ -277,8 +277,8 @@ func TestExporter_EmitCorrelation(t *testing.T) {
 	}
 
 	on := run(true)
-	if on.Events[0].RunID != "wf-root-abc" || on.Events[0].SessionID != "sess-9f2a" {
-		t.Fatalf("EmitCorrelation=true must carry run/session, got %+v", on.Events[0])
+	if on.Events[0].RunID != "wf-root-abc" || on.Events[0].SessionID != "sess-9f2a" || on.Events[0].StepID != "mc-step-7" {
+		t.Fatalf("EmitCorrelation=true must carry run/session/step, got %+v", on.Events[0])
 	}
 	// Headline invariant: a v1-pinned receiver accepts the populated batch with no
 	// schema mismatch — emitting run/session is v1-compatible (no flag day).
@@ -287,8 +287,8 @@ func TestExporter_EmitCorrelation(t *testing.T) {
 	}
 
 	off := run(false)
-	if off.Events[0].RunID != "" || off.Events[0].SessionID != "" {
-		t.Fatalf("EmitCorrelation=false must drop run/session, got %+v", off.Events[0])
+	if off.Events[0].RunID != "" || off.Events[0].SessionID != "" || off.Events[0].StepID != "" {
+		t.Fatalf("EmitCorrelation=false must drop run/session/step, got %+v", off.Events[0])
 	}
 }
 

--- a/pkg/eventexport/golden_test.go
+++ b/pkg/eventexport/golden_test.go
@@ -34,9 +34,9 @@ func TestGoldenWireBytes(t *testing.T) {
 			want: `{"seq":60,"type":"mail.sent","ts":"2026-06-21T10:03:27Z"}`,
 		},
 		{
-			name: "populated run_id/session_id appear after actor_hash/ref",
-			env:  Envelope{Seq: 2, Type: "bead.created", TS: "2026-06-21T10:03:27Z", ActorHash: "0123456789abcdef", Ref: "mc-2", RunID: "wf-root-abc", SessionID: "sess-9f2a"},
-			want: `{"seq":2,"type":"bead.created","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","ref":"mc-2","run_id":"wf-root-abc","session_id":"sess-9f2a"}`,
+			name: "populated run_id/session_id/step_id appear after actor_hash/ref",
+			env:  Envelope{Seq: 2, Type: "bead.created", TS: "2026-06-21T10:03:27Z", ActorHash: "0123456789abcdef", Ref: "mc-2", RunID: "wf-root-abc", SessionID: "sess-9f2a", StepID: "mc-step-7"},
+			want: `{"seq":2,"type":"bead.created","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","ref":"mc-2","run_id":"wf-root-abc","session_id":"sess-9f2a","step_id":"mc-step-7"}`,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/eventexport/project.go
+++ b/pkg/eventexport/project.go
@@ -131,6 +131,7 @@ type Envelope struct {
 	Ref       string `json:"ref,omitempty"`        // id-regex-gated reference (opaque id/slug only)
 	RunID     string `json:"run_id,omitempty"`     // opaque run-root correlation id (safeRef-gated)
 	SessionID string `json:"session_id,omitempty"` // opaque session correlation id (safeRef-gated)
+	StepID    string `json:"step_id,omitempty"`    // opaque acting-work-bead (run step) id (safeRef-gated)
 }
 
 // Batch is one POST body: the events for a single city. CityHash is a salted,
@@ -220,6 +221,9 @@ func ProjectEvent(te TaggedEvent, opt Options) (Envelope, bool) {
 		if s := safeRef(te.SessionID); s != "" {
 			env.SessionID = s
 		}
+		if st := safeRef(te.StepID); st != "" {
+			env.StepID = st
+		}
 	}
 	return env, true
 }
@@ -241,7 +245,7 @@ func ValidateEnvelope(env Envelope) error {
 		return fmt.Errorf("eventexport: invalid ts %q", env.TS)
 	}
 	if mailReduced[env.Type] {
-		if env.ActorHash != "" || env.Ref != "" || env.RunID != "" || env.SessionID != "" {
+		if env.ActorHash != "" || env.Ref != "" || env.RunID != "" || env.SessionID != "" || env.StepID != "" {
 			return fmt.Errorf("eventexport: %q must carry only {seq,type,ts}", env.Type)
 		}
 		return nil
@@ -262,6 +266,9 @@ func ValidateEnvelope(env Envelope) error {
 	}
 	if env.SessionID != "" && !IsOpaqueRef(env.SessionID) {
 		return fmt.Errorf("eventexport: session_id %q is not an opaque id", env.SessionID)
+	}
+	if env.StepID != "" && !IsOpaqueRef(env.StepID) {
+		return fmt.Errorf("eventexport: step_id %q is not an opaque id", env.StepID)
 	}
 	return nil
 }

--- a/pkg/eventexport/project_test.go
+++ b/pkg/eventexport/project_test.go
@@ -124,6 +124,37 @@ func TestProjectEvent_RunSessionGating(t *testing.T) {
 	}
 }
 
+// step_id (the acting work bead) is gated exactly like run/session: EmitCorrelation
+// fail-closed, safeRef-opaque-only, never on mail-reduced types, empty when the
+// subject bead carries no gc.step_id.
+func TestProjectEvent_StepIDGating(t *testing.T) {
+	te := func(step string) TaggedEvent {
+		return TaggedEvent{Seq: 1, Type: "bead.closed", Ts: fixedTS, Actor: "gc", Subject: "mc-1", RunID: "wf-root-abc", SessionID: "sess-9f2a", StepID: step}
+	}
+	off := Options{Salt: testSalt, ExportRef: true}
+	if g, _ := ProjectEvent(te("mc-step-7"), off); g.StepID != "" {
+		t.Fatalf("EmitCorrelation=false must drop step_id, got %q", g.StepID)
+	}
+	on := Options{Salt: testSalt, ExportRef: true, EmitCorrelation: true}
+	if g, ok := ProjectEvent(te("mc-step-7"), on); !ok || g.StepID != "mc-step-7" {
+		t.Fatalf("opaque step_id must round-trip when emitted, got %q ok=%v", g.StepID, ok)
+	}
+	for _, bad := range []string{"gascity/codex", "user@host", "Up Per", "a b"} {
+		if g, _ := ProjectEvent(te(bad), on); g.StepID != "" {
+			t.Fatalf("non-opaque step_id %q must drop to empty, got %q", bad, g.StepID)
+		}
+	}
+	mail := te("mc-step-7")
+	mail.Type = "mail.sent"
+	if g, _ := ProjectEvent(mail, on); g.StepID != "" {
+		t.Fatalf("mail.sent must not carry step_id, got %q", g.StepID)
+	}
+	// A non-work bead carries no gc.step_id → empty, omitted cleanly (no error).
+	if g, ok := ProjectEvent(te(""), on); !ok || g.StepID != "" {
+		t.Fatalf("empty step_id must be omitted cleanly, got %q ok=%v", g.StepID, ok)
+	}
+}
+
 // TestProject_NoLeak feeds the projection a corpus carrying the sensitive markers
 // the raw stream holds — in the primitive fields the projection actually receives
 // — and proves none survive into the marshaled batch. The adapter-level

--- a/pkg/eventexport/validate_test.go
+++ b/pkg/eventexport/validate_test.go
@@ -47,7 +47,9 @@ func TestValidateEnvelope_Rejects(t *testing.T) {
 		"non-opaque ref":      {Seq: 1, Type: "bead.closed", TS: rfc(t), Ref: "a/b"},
 		"non-opaque run_id":   {Seq: 1, Type: "bead.closed", TS: rfc(t), RunID: "a/b"},
 		"non-opaque session":  {Seq: 1, Type: "bead.closed", TS: rfc(t), SessionID: "A@b"},
+		"non-opaque step_id":  {Seq: 1, Type: "bead.closed", TS: rfc(t), StepID: "a/b"},
 		"mail with extras":    {Seq: 1, Type: "mail.sent", TS: rfc(t), ActorHash: "0123456789abcdef"},
+		"mail with step_id":   {Seq: 1, Type: "mail.sent", TS: rfc(t), StepID: "mc-step-1"},
 	}
 	for name, env := range cases {
 		if err := ValidateEnvelope(env); err == nil {
@@ -151,7 +153,10 @@ func TestProfileZeroValue(t *testing.T) {
 // author to gate it in ProjectEvent + ValidateEnvelope (and bump SchemaVersion if
 // the wire changes) rather than letting it ship ungated.
 func TestEnvelopeFieldCount(t *testing.T) {
-	if n := reflect.TypeOf(Envelope{}).NumField(); n != 7 {
+	// 8 = the original 7 + step_id, added as a version-NEUTRAL optional correlation
+	// field (gated in ProjectEvent + ValidateEnvelope exactly like run_id/session_id),
+	// so SchemaVersion is unchanged — a pinned receiver still accepts a populated batch.
+	if n := reflect.TypeOf(Envelope{}).NumField(); n != 8 {
 		t.Fatalf("Envelope has %d fields; a field changed — gate it in ProjectEvent and ValidateEnvelope, then update this guard (and bump SchemaVersion if the wire changes)", n)
 	}
 }


### PR DESCRIPTION
## Phase 5 — carry `step_id` (the acting work bead) on exported events

Closes the `{run_id, session_id, step_id}` correlation tuple on the events plane, mirroring how `run_id`/`session_id` were added (#3680).

### How `step_id` is sourced (no `gc.active_work_bead` needed)
The exported lifecycle events (`bead.created` / `bead.closed`) are **about a specific bead**. At the record site (`internal/beads/caching_store_events.go` `notifyChange`), the **subject bead's own** `gc.step_id` (`StepIDMetadataKey`) is read alongside run/session and threaded through `onChange` → `events.Event.StepID` → `events.TaggedEvent` (embeds Event) → `eventexport.TaggedEvent` → `ProjectEvent`.

- A **work/dispatch bead** carries its own `gc.step_id` → its lifecycle event stamps that step.
- A **non-work bead** (session, mail) carries none → `step_id` empty → omitted.

This is the key distinction from the usage/spend planes (whose record site is the *session*, with no work bead in scope, hence those planes' `step_id` is deferred): the events record site **is** the subject bead.

### Redaction + compat (identical to run/session)
- `step_id` is `safeRef`-gated + `EmitCorrelation`-gated in `ProjectEvent`; `ValidateEnvelope` re-checks it is opaque (`IsOpaqueRef`) and that mail-reduced types never carry it. Opaque ids only — never free-form content.
- **Version-neutral**: `step_id` is an `omitempty` optional field (the `EnvelopeFieldCount` guard moves 7→8, **no `SchemaVersion` bump**) — a pinned receiver still accepts a populated batch.

### Consumer follow-on
This is the **producer** side (forward-compatible — an old `events-ingest` ignores the new field). The hosted `events-ingest` accepting `step_id` + a `city_events.step_id` column is the companion change in `gasworks-pack`/infra.

### Verification
`go test ./pkg/eventexport/ ./internal/beads/ ./internal/events/ ./internal/eventfeed/` green (incl. new StepID gating, validate-rejects, the extended golden wire-bytes pin, and the record-site `gc.step_id` wiring test) · targeted `cmd/gc` green · `vet` + `gofmt` clean. Adversarially red-teamed (2 lenses + verify): **0 must-fixes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
