### PR TITLE
fix(pool): suppress redundant canonical-singleton pool standby when named alias-holder is live

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -11213,3 +11213,124 @@ func TestBuildDesiredState_ProviderRedBlocksNewPoolSessionCreate(t *testing.T) {
 		}
 	})
 }
+
+// TestBuildDesiredState_NamedAliasHolderSuppressesPoolStandby is the FAITHFUL
+// gc-7e40y dual-mayor repro at the buildDesiredState level, mirroring the exact
+// live gastown.mayor bead shapes.
+//
+// The mayor shape: a bound agent (gastown.mayor) that is BOTH a configured
+// [[named_session]] (mode=always) AND trips UsesCanonicalSingletonPoolIdentity
+// (max_active_sessions=1, no min, no scale_check, no namepool). A live named
+// session holds the canonical alias "gastown.mayor". A pool-managed standby
+// session already exists, alias-deferred (pool_alias_conflict=gastown.mayor).
+//
+// EMPIRICAL ROOT (bisected against the live controller, commit dbc702304):
+// the dual is DEMANDED by ready, unassigned, routed work (live: gc-78iq with
+// gc.routed_to=gastown.mayor). defaultScaleCheckCounts counts that work →
+// scaleCheckCounts[gastown.mayor]=1 → computePoolDesiredStates emits one
+// tier="new" pool request → realizePoolDesiredSessions reuses the standby bead,
+// which then DEFERS on the held canonical alias (recordDeferredNonExpandingPool
+// AliasConflict). That standby is added to desired state alongside the named
+// alias-holder: two desired sessions for a max=1 agent. The standby can never
+// acquire the alias (held by the named session), so it defers forever and,
+// with effective_sleep_after_idle=off, never reaps.
+//
+// The fix must credit the live canonical-alias holder as occupying the
+// singleton's one slot, suppressing the redundant pool new-demand. Keyed on
+// CANONICAL-ALIAS OWNERSHIP, not isNamedSessionBead — a manual session holding
+// NO alias must still let the pool want its instance (see
+// TestComputePoolDesiredStates_ManualSessionDoesNotConsumeSingletonNewDemand).
+//
+// RED before the fix: produces 2 desired entries for gastown.mayor (the named
+// holder + the alias-deferred pool standby).
+func TestBuildDesiredState_NamedAliasHolderSuppressesPoolStandby(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+
+	// Ready, unassigned, routed work — mirrors live gc-78iq.
+	if _, err := store.Create(beads.Bead{
+		Title:    "routed mayor work",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "gastown.mayor"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Named-session alias holder for "gastown.mayor" — mirrors live gc-wisp-ak5aoga.
+	if _, err := store.Create(beads.Bead{
+		Title:  "gastown.mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:gastown.mayor"},
+		Metadata: map[string]string{
+			"agent_name":                 "gastown.mayor",
+			"alias":                      "gastown.mayor",
+			"session_name":               "gastown__mayor",
+			"session_name_explicit":      "true",
+			"state":                      "awake",
+			"session_origin":             "named",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "gastown.mayor",
+			namedSessionModeMetadata:     "always",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pool-managed standby, alias-deferred — mirrors live gc-wisp-tig9h8s.
+	if _, err := store.Create(beads.Bead{
+		Title:  "gastown.mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gastown.mayor"},
+		Metadata: map[string]string{
+			"agent_name":                      "gastown.mayor",
+			"alias":                           "",
+			"session_name":                    "gastown__mayor-gc-wisp-tig9h8s",
+			"state":                           "awake",
+			"session_origin":                  "ephemeral",
+			poolManagedMetadataKey:            boolMetadata(true),
+			poolAliasConflictMetadataKey:      "gastown.mayor",
+			poolAliasConflictCountMetadataKey: "249",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gchq"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			BindingName:       "gastown",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template:    "mayor",
+			BindingName: "gastown",
+			Scope:       "city",
+			Mode:        "always",
+		}},
+	}
+
+	dsResult := buildDesiredState("gchq", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	var mayorEntries []TemplateParams
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "gastown.mayor" {
+			mayorEntries = append(mayorEntries, tp)
+		}
+	}
+	if len(mayorEntries) != 1 {
+		var names []string
+		for _, tp := range mayorEntries {
+			names = append(names, fmt.Sprintf("%s(alias=%q,named=%q)", tp.SessionName, tp.Alias, tp.ConfiguredNamedIdentity))
+		}
+		t.Fatalf("gastown.mayor desired entries = %d, want 1 — a live session already holds the canonical alias, so the pool must not demand a redundant standby (gc-7e40y dual). Got: %v", len(mayorEntries), names)
+	}
+	// The single retained entry must be the named alias-holder, not a deferred
+	// pool standby (alias empty because it lost the alias-acquisition race).
+	if mayorEntries[0].ConfiguredNamedIdentity != "gastown.mayor" {
+		t.Fatalf("retained entry is not the named alias-holder: %+v", mayorEntries[0])
+	}
+}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -11334,3 +11334,99 @@ func TestBuildDesiredState_NamedAliasHolderSuppressesPoolStandby(t *testing.T) {
 		t.Fatalf("retained entry is not the named alias-holder: %+v", mayorEntries[0])
 	}
 }
+
+// TestBuildDesiredState_AsleepNamedAliasHolderStaysSingle documents the
+// gc-7e40y review ruling (mayor): an asleep canonical-singleton holder is NOT
+// a live alias holder, so pool demand SHOULD flow and WAKE the existing asleep
+// holder — net desired stays exactly 1, no redundant standby spawns.
+func TestBuildDesiredState_AsleepNamedAliasHolderStaysSingle(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+
+	// Ready, unassigned, routed work — mirrors live gc-78iq.
+	if _, err := store.Create(beads.Bead{
+		Title:    "routed mayor work",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "gastown.mayor"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Named-session alias holder for "gastown.mayor" — mirrors live gc-wisp-ak5aoga.
+	if _, err := store.Create(beads.Bead{
+		Title:  "gastown.mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:gastown.mayor"},
+		Metadata: map[string]string{
+			"agent_name":                 "gastown.mayor",
+			"alias":                      "gastown.mayor",
+			"session_name":               "gastown__mayor",
+			"session_name_explicit":      "true",
+			"state":                      "asleep",
+			"session_origin":             "named",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "gastown.mayor",
+			namedSessionModeMetadata:     "always",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pool-managed standby, alias-deferred — mirrors live gc-wisp-tig9h8s.
+	if _, err := store.Create(beads.Bead{
+		Title:  "gastown.mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gastown.mayor"},
+		Metadata: map[string]string{
+			"agent_name":                      "gastown.mayor",
+			"alias":                           "",
+			"session_name":                    "gastown__mayor-gc-wisp-tig9h8s",
+			"state":                           "awake",
+			"session_origin":                  "ephemeral",
+			poolManagedMetadataKey:            boolMetadata(true),
+			poolAliasConflictMetadataKey:      "gastown.mayor",
+			poolAliasConflictCountMetadataKey: "249",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gchq"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			BindingName:       "gastown",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template:    "mayor",
+			BindingName: "gastown",
+			Scope:       "city",
+			Mode:        "always",
+		}},
+	}
+
+	dsResult := buildDesiredState("gchq", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	var mayorEntries []TemplateParams
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "gastown.mayor" {
+			mayorEntries = append(mayorEntries, tp)
+		}
+	}
+	if len(mayorEntries) != 1 {
+		var names []string
+		for _, tp := range mayorEntries {
+			names = append(names, fmt.Sprintf("%s(alias=%q,named=%q)", tp.SessionName, tp.Alias, tp.ConfiguredNamedIdentity))
+		}
+		t.Fatalf("gastown.mayor desired entries = %d, want 1 — a live session already holds the canonical alias, so the pool must not demand a redundant standby (gc-7e40y dual). Got: %v", len(mayorEntries), names)
+	}
+	// The single retained entry must be the named alias-holder, not a deferred
+	// pool standby (alias empty because it lost the alias-acquisition race).
+	if mayorEntries[0].ConfiguredNamedIdentity != "gastown.mayor" {
+		t.Fatalf("retained entry is not the named alias-holder: %+v", mayorEntries[0])
+	}
+}

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -135,6 +135,8 @@ func computePoolDesiredStates(
 		}
 	}
 
+	aliasHeldTemplates := canonicalSingletonAliasHeldTemplates(cfg, sessionBeads)
+
 	var resumeRequests []SessionRequest
 	wakeRequestedTemplates := make(map[string]struct{})
 
@@ -255,6 +257,9 @@ func computePoolDesiredStates(
 			if !ok {
 				continue
 			}
+			if aliasHeldTemplates[template] {
+				continue
+			}
 			newCount := capNewDemandCount(limits, usage, agent, scaleCount)
 			inFlight := inFlightNewRequests[template]
 			inFlightCount := minInt(len(inFlight), newCount)
@@ -307,7 +312,37 @@ func computePoolDesiredStates(
 		}
 	}
 
-	return applyNestedCaps(cfg, allRequests, trace)
+	return applyNestedCaps(cfg, allRequests, aliasHeldTemplates, trace)
+}
+
+func canonicalSingletonAliasHeldTemplates(cfg *config.City, sessionBeads []beads.Bead) map[string]bool {
+	held := make(map[string]bool)
+	if cfg == nil {
+		return held
+	}
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		if agent.Suspended || !agent.UsesCanonicalSingletonPoolIdentity() {
+			continue
+		}
+		template := agent.QualifiedName()
+		for _, sb := range sessionBeads {
+			// failed-create beads release their alias (failedCreateIdentityReleased,
+			// names.go), so they are NOT live holders — counting one would suppress
+			// demand while the alias is actually free, hanging routed work.
+			if sb.Status == "closed" || isPoolManagedSessionBead(sb) || isDrainedSessionBead(sb) || isFailedCreateSessionBead(sb) {
+				continue
+			}
+			if strings.TrimSpace(sb.Metadata["state"]) == "asleep" {
+				continue
+			}
+			if strings.TrimSpace(sb.Metadata["alias"]) == template {
+				held[template] = true
+				break
+			}
+		}
+	}
+	return held
 }
 
 func poolInFlightNewRequests(cfg *config.City, sessionBeads []beads.Bead, resumeSessionBeadIDs map[string]struct{}) map[string][]SessionRequest {
@@ -366,7 +401,7 @@ func poolSessionConsumesNewDemand(session beads.Bead) bool {
 
 // applyNestedCaps enforces workspace, rig, and agent max_active_sessions caps.
 // Accepts requests in priority order, rejecting any that would exceed a cap.
-func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *sessionReconcilerTraceCycle) []PoolDesiredState {
+func applyNestedCaps(cfg *config.City, requests []SessionRequest, aliasHeldTemplates map[string]bool, trace *sessionReconcilerTraceCycle) []PoolDesiredState {
 	// Sort by priority DESC, resume tier first within same priority.
 	sort.SliceStable(requests, func(i, j int) bool {
 		if requests[i].BeadPriority != requests[j].BeadPriority {
@@ -415,6 +450,9 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *session
 		}
 		template := agent.QualifiedName()
 		minSess := agent.EffectiveMinActiveSessions()
+		if aliasHeldTemplates[template] {
+			continue
+		}
 		for usage.agentCount[template] < minSess {
 			req := SessionRequest{
 				Template:       template,

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -257,7 +257,7 @@ func computePoolDesiredStates(
 			if !ok {
 				continue
 			}
-			if aliasHeldTemplates[template] {
+			if _, ok := aliasHeldTemplates[template]; ok {
 				continue
 			}
 			newCount := capNewDemandCount(limits, usage, agent, scaleCount)
@@ -315,8 +315,8 @@ func computePoolDesiredStates(
 	return applyNestedCaps(cfg, allRequests, aliasHeldTemplates, trace)
 }
 
-func canonicalSingletonAliasHeldTemplates(cfg *config.City, sessionBeads []beads.Bead) map[string]bool {
-	held := make(map[string]bool)
+func canonicalSingletonAliasHeldTemplates(cfg *config.City, sessionBeads []beads.Bead) map[string]struct{} {
+	held := make(map[string]struct{})
 	if cfg == nil {
 		return held
 	}
@@ -327,9 +327,12 @@ func canonicalSingletonAliasHeldTemplates(cfg *config.City, sessionBeads []beads
 		}
 		template := agent.QualifiedName()
 		for _, sb := range sessionBeads {
-			// failed-create beads release their alias (failedCreateIdentityReleased,
-			// names.go), so they are NOT live holders — counting one would suppress
-			// demand while the alias is actually free, hanging routed work.
+			// None of these own the canonical alias: a closed or drained named
+			// session released it at close via the retire path, a pool-managed bead
+			// never held it, and a failed-create bead released it via
+			// failedCreateIdentityReleased (names.go). Counting any as a live holder
+			// would suppress demand while the alias is actually free, hanging routed
+			// work.
 			if sb.Status == "closed" || isPoolManagedSessionBead(sb) || isDrainedSessionBead(sb) || isFailedCreateSessionBead(sb) {
 				continue
 			}
@@ -337,7 +340,7 @@ func canonicalSingletonAliasHeldTemplates(cfg *config.City, sessionBeads []beads
 				continue
 			}
 			if strings.TrimSpace(sb.Metadata["alias"]) == template {
-				held[template] = true
+				held[template] = struct{}{}
 				break
 			}
 		}
@@ -401,7 +404,7 @@ func poolSessionConsumesNewDemand(session beads.Bead) bool {
 
 // applyNestedCaps enforces workspace, rig, and agent max_active_sessions caps.
 // Accepts requests in priority order, rejecting any that would exceed a cap.
-func applyNestedCaps(cfg *config.City, requests []SessionRequest, aliasHeldTemplates map[string]bool, trace *sessionReconcilerTraceCycle) []PoolDesiredState {
+func applyNestedCaps(cfg *config.City, requests []SessionRequest, aliasHeldTemplates map[string]struct{}, trace *sessionReconcilerTraceCycle) []PoolDesiredState {
 	// Sort by priority DESC, resume tier first within same priority.
 	sort.SliceStable(requests, func(i, j int) bool {
 		if requests[i].BeadPriority != requests[j].BeadPriority {
@@ -450,7 +453,7 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, aliasHeldTempl
 		}
 		template := agent.QualifiedName()
 		minSess := agent.EffectiveMinActiveSessions()
-		if aliasHeldTemplates[template] {
+		if _, ok := aliasHeldTemplates[template]; ok {
 			continue
 		}
 		for usage.agentCount[template] < minSess {

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -1448,12 +1448,31 @@ func TestCanonicalSingletonAliasHeldTemplates_ExcludesFailedCreateHolder(t *test
 	}
 
 	// A live named holder occupies the singleton's slot.
-	if live := canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{holder("active")}); !live["mayor"] {
-		t.Fatalf("live named alias-holder should mark mayor held; got %v", live)
+	if _, ok := canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{holder("active")})["mayor"]; !ok {
+		t.Fatalf("live named alias-holder should mark mayor held; got %v", canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{holder("active")}))
 	}
 
 	// A failed-create holder released the alias -> must NOT be treated as held.
-	if failed := canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{holder("failed-create")}); failed["mayor"] {
-		t.Fatalf("failed-create holder released its alias and must NOT mark mayor held (over-suppression hang); got %v", failed)
+	if _, ok := canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{holder("failed-create")})["mayor"]; ok {
+		t.Fatalf("failed-create holder released its alias and must NOT mark mayor held (over-suppression hang); got %v", canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{holder("failed-create")}))
+	}
+
+	// A closed holder no longer owns the alias.
+	closed := holder("active")
+	closed.Status = "closed"
+	if _, ok := canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{closed})["mayor"]; ok {
+		t.Fatalf("closed holder released its alias and must NOT mark mayor held; got held")
+	}
+
+	// A pool-managed bead is the pool's own instance, not the named alias holder.
+	poolManaged := holder("active")
+	poolManaged.Metadata[poolManagedMetadataKey] = boolMetadata(true)
+	if _, ok := canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{poolManaged})["mayor"]; ok {
+		t.Fatalf("pool-managed bead is not the named alias holder and must NOT mark mayor held; got held")
+	}
+
+	// A drained holder released its alias.
+	if _, ok := canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{holder("drained")})["mayor"]; ok {
+		t.Fatalf("drained holder released its alias and must NOT mark mayor held; got held")
 	}
 }

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -1421,3 +1421,39 @@ func TestComputePoolDesiredStates_RoutedRigScopedDoesNotSpawnNew(t *testing.T) {
 		t.Fatalf("total requests = %d, want 0", total)
 	}
 }
+
+// TestCanonicalSingletonAliasHeldTemplates_ExcludesFailedCreateHolder is the
+// regression guard for the failed-create over-suppression hang found during the
+// gc-7e40y fix review (opencode+Fugu Ultra). A failed-create bead RELEASES its
+// alias (failedCreateIdentityReleased, names.go), so it must NOT count as a live
+// holder -- otherwise pool demand is suppressed while the canonical alias is
+// actually free, hanging routed work for the template.
+func TestCanonicalSingletonAliasHeldTemplates_ExcludesFailedCreateHolder(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("mayor", "", intPtr(1), 0)}, // canonical singleton
+	}
+	holder := func(state string) beads.Bead {
+		return beads.Bead{
+			ID:     "sess-" + state,
+			Status: "open",
+			Type:   sessionBeadType,
+			Metadata: map[string]string{
+				"session_name":   "mayor",
+				"template":       "mayor",
+				"alias":          "mayor",
+				"session_origin": "named",
+				"state":          state,
+			},
+		}
+	}
+
+	// A live named holder occupies the singleton's slot.
+	if live := canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{holder("active")}); !live["mayor"] {
+		t.Fatalf("live named alias-holder should mark mayor held; got %v", live)
+	}
+
+	// A failed-create holder released the alias -> must NOT be treated as held.
+	if failed := canonicalSingletonAliasHeldTemplates(cfg, []beads.Bead{holder("failed-create")}); failed["mayor"] {
+		t.Fatalf("failed-create holder released its alias and must NOT mark mayor held (over-suppression hang); got %v", failed)
+	}
+}

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -1285,7 +1285,7 @@ func TestApplyNestedCaps_DedupsConcreteSessionRequestsAcrossTiers(t *testing.T) 
 		{Template: "claude", Tier: "new", SessionBeadID: "sess-2"},
 	}
 
-	result := applyNestedCaps(cfg, requests, nil)
+	result := applyNestedCaps(cfg, requests, nil, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))

--- a/cmd/gc/pool_desired_state_wake_test.go
+++ b/cmd/gc/pool_desired_state_wake_test.go
@@ -149,7 +149,7 @@ func TestApplyNestedCaps_WakeKnownIdentityRanksBeforeNew(t *testing.T) {
 		{Template: "claude", Tier: "wake-known-identity", SessionBeadID: "sess-closed", BeadPriority: 5},
 	}
 
-	result := applyNestedCaps(cfg, requests, nil)
+	result := applyNestedCaps(cfg, requests, nil, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))


### PR DESCRIPTION
Closes #3698

## Problem

A `max_active_sessions = 1` agent can run as **two live sessions** whenever
routed work exists for it. The trigger is a **config shape**, independent of
pack or agent identity — all three must hold:

1. configured as `[[named_session]]` → the named session owns the canonical alias (`Metadata["alias"] == QualifiedName()`);
2. canonical-singleton pool — `max_active_sessions = 1`, no namepool → `UsesCanonicalSingletonPoolIdentity() == true`;
3. routed work targets its template (`gc.routed_to = <template>`), which the default routed-work scale probe counts as pool demand.

Given (1)+(2)+(3), `computePoolDesiredStates` emits a `tier="new"` pool request
(`poolDesired[template] = 1`). The named session already holds the alias, so the
demanded standby can never acquire it — it parks via
`recordDeferredNonExpandingPoolAliasConflict` every reconcile tick. With
`effective_sleep_after_idle = off` the standby **never reaps**; with a finite
`sleep_after_idle` it would be shed on idle, so the *permanence* of the
duplicate is specific to `sleep=off`.

### Named-session inventory in the reporting deployment (anonymized)

6 named sessions, all `max=1` with no namepool (all satisfy the singleton
predicate). All use `wake_mode = fresh` (conversation reset each wake) with the
runtime's default `--resume` launch flag.

| agent | scope | mode | idle_timeout | sleep_after_idle | observed dual |
| --- | --- | --- | --- | --- | --- |
| cityAgent-A | city | always | 1h | off | **yes** (carried routed work) |
| cityAgent-B | city | always | 1h | off | no (no routed work) |
| cityAgent-C | city | always | — | off | no |
| cityAgent-D | city | always | — | off | no |
| rigAgent-E  | rig  | always | 1h | off | no |
| rigAgent-F  | rig  | on_demand | 2h | 300s | no (finite sleep would reap) |

From imported custom packs, two more `max=1` singletons are relevant:

- one **city-scope `[[named_session]]`** of the same shape as cityAgent-A — **also dualed permanently** (it carried routed work);
- one **rig-scope `min=0`/`max=1` *pool* singleton** (no `[[named_session]]`). It logs the identical alias-deferral very frequently, but **transiently**: the alias holder is its *own pool instance*, released on completion, so no permanent dual. This is the non-pathological case the fix deliberately leaves untouched (`!isPoolManagedSessionBead`) — real-world confirmation that the suppression scope is correct.

### Observed vs. untested combinations

- **Observed permanent dual:** `city` · `[[named_session]]` · `mode=always` · `max=1` · `sleep_after_idle=off` · routed work present — **2 templates** (cityAgent-A + one same-shape custom-pack named singleton).
- **Observed non-pathological (correctly not suppressed):** a `rig` · `min=0`/`max=1` *pool* singleton — same deferral log, but the holder is the pool's own instance, so it self-resolves; no permanent dual.
- **Untested (predicted vulnerable, unconfirmed):** `rig`-scope *named* singletons, `mode=on_demand`, finite `sleep_after_idle`, and any named singleton *without* routed work. The predicate implies these dual identically (finite `sleep_after_idle` self-reaps the standby), but this deployment did not exercise them.

### Environment

gastown pack `gastownhall/gascity-packs//gastown` `sha:33d3a430`; gc on upstream
`main` (PR base `55d4481f0`, fork point `dbc7023`); WSL2 single-host.

## Fix

`canonicalSingletonAliasHeldTemplates` returns the set of canonical-singleton templates whose alias is held by a **live, non-pool-managed, non-failed-create** session. `computePoolDesiredStates` (scale-check new-demand) and `applyNestedCaps` (min-floor fill) skip demand for held templates — the existing named session already is the singleton, so no redundant pool standby is demanded.

Three load-bearing guards, each tested:
- Keyed on **canonical-alias ownership** (`Metadata["alias"] == QualifiedName()`), not `isNamedSessionBead` — a manual session holds no alias, so the pool still wants its instance.
- `!isPoolManagedSessionBead` — when the live holder IS the pool's own canonical instance, the pool reuses it and demand must stand.
- Live only (not closed / drained / asleep / **failed-create**) — an asleep or failed-create holder has released the alias, so routed work must still be able to wake a session.

## Tests

- `TestBuildDesiredState_NamedAliasHolderSuppressesPoolStandby` — end-to-end repro at `buildDesiredState`: named alias-holder + routed work + deferred standby → exactly one desired entry (the named holder). Red before the fix.
- `TestCanonicalSingletonAliasHeldTemplates_ExcludesFailedCreateHolder` — guards the failed-create over-suppression (alias-released) case.
- Existing `…_ManualSessionDoesNotConsumeSingletonNewDemand`, `…_OnDemandNamedSessionWakesFromPoolDemandWithoutNamedDemand`, `…_MaxOneCanonicalBeadIsIdempotent`, `…_PrefersCanonicalWhenStaleDuplicateExists` stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

