### PR TITLE
feat(mcp): recognize pi as MCP-capable provider family (#3679)

### DIFF
--- a/cmd/gc/mcp_integration.go
+++ b/cmd/gc/mcp_integration.go
@@ -48,7 +48,8 @@ func supportsMCPProviderKind(kind string) bool {
 		materialize.MCPProviderGemini,
 		materialize.MCPProviderOpenCode,
 		materialize.MCPProviderMimoCode,
-		materialize.MCPProviderCursor:
+		materialize.MCPProviderCursor,
+		materialize.MCPProviderPi:
 		return true
 	default:
 		return false

--- a/cmd/gc/mcp_integration_test.go
+++ b/cmd/gc/mcp_integration_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/materialize"
+)
+
+func TestSupportsMCPProviderKindPi(t *testing.T) {
+	if !supportsMCPProviderKind(materialize.MCPProviderPi) {
+		t.Fatalf("supportsMCPProviderKind(%q) = false, want true", materialize.MCPProviderPi)
+	}
+}

--- a/internal/materialize/mcp_project.go
+++ b/internal/materialize/mcp_project.go
@@ -33,6 +33,11 @@ const (
 	MCPProviderMimoCode = "mimocode"
 	// MCPProviderCursor projects to Cursor Agent's project-native MCP file.
 	MCPProviderCursor = "cursor"
+	// MCPProviderPi projects to the Claude-native .mcp.json file. The de-facto
+	// pi MCP client (the community pi-mcp-adapter) reads .mcp.json using the
+	// Claude-compatible mcpServers schema, so pi reuses the Claude projection
+	// target and format verbatim.
+	MCPProviderPi = "pi"
 )
 
 // MCPProjection is one provider-native MCP payload for a single target file.
@@ -55,6 +60,7 @@ func BuildMCPProjection(providerKind, workdir string, servers []MCPServer) (MCPP
 	case MCPProviderOpenCode:
 	case MCPProviderMimoCode:
 	case MCPProviderCursor:
+	case MCPProviderPi:
 	default:
 		return MCPProjection{}, fmt.Errorf("unsupported MCP provider %q", providerKind)
 	}
@@ -67,7 +73,7 @@ func BuildMCPProjection(providerKind, workdir string, servers []MCPServer) (MCPP
 	sort.Slice(out.Servers, func(i, j int) bool { return out.Servers[i].Name < out.Servers[j].Name })
 
 	switch providerKind {
-	case MCPProviderClaude:
+	case MCPProviderClaude, MCPProviderPi:
 		out.Target = filepath.Join(workdir, ".mcp.json")
 	case MCPProviderCodex:
 		out.Target = filepath.Join(workdir, ".codex", "config.toml")
@@ -163,6 +169,10 @@ func (p MCPProjection) applyWithStderr(fs fsys.FS, stderr io.Writer) error {
 			return p.applyOpenCode(fs)
 		case MCPProviderCursor:
 			return p.applyCursor(fs)
+		case MCPProviderPi:
+			// pi reuses Claude's .mcp.json target + mcpServers schema
+			// (read by the pi-mcp-adapter), so it shares applyClaude.
+			return p.applyClaude(fs)
 		default:
 			return fmt.Errorf("unsupported MCP provider %q", p.Provider)
 		}

--- a/internal/materialize/mcp_project_test.go
+++ b/internal/materialize/mcp_project_test.go
@@ -98,6 +98,14 @@ func TestBuildMCPProjectionTargetsAndStableHash(t *testing.T) {
 	if got, want := cursor.Target, filepath.Join("/work", ".cursor", "mcp.json"); got != want {
 		t.Fatalf("cursor target = %q, want %q", got, want)
 	}
+
+	pi, err := BuildMCPProjection(MCPProviderPi, "/work", nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(pi): %v", err)
+	}
+	if got, want := pi.Target, filepath.Join("/work", ".mcp.json"); got != want {
+		t.Fatalf("pi target = %q, want %q", got, want)
+	}
 }
 
 func TestBuildMCPProjectionRejectsUnsupportedProvider(t *testing.T) {
@@ -169,6 +177,68 @@ func TestApplyMCPProjectionClaudeWritesManagedFile(t *testing.T) {
 		t.Fatalf(".mcp.json should be removed, stat err = %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".gc", "mcp-managed", "claude.json")); !os.IsNotExist(err) {
+		t.Fatalf("managed marker should be removed, stat err = %v", err)
+	}
+}
+
+func TestApplyMCPProjectionPiWritesManagedFile(t *testing.T) {
+	dir := t.TempDir()
+	proj, err := BuildMCPProjection(MCPProviderPi, dir, []MCPServer{
+		{
+			Name:      "alpha",
+			Transport: MCPTransportStdio,
+			Command:   "uvx",
+			Args:      []string{"pkg"},
+			Env:       map[string]string{"TOKEN": "secret"},
+		},
+		{
+			Name:      "remote",
+			Transport: MCPTransportHTTP,
+			URL:       "https://mcp.example.com",
+			Headers:   map[string]string{"Authorization": "Bearer token"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// pi reuses the Claude `.mcp.json` target + `mcpServers` schema, so the
+	// pi-mcp-adapter reads it like Claude Code.
+	data, err := os.ReadFile(filepath.Join(dir, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc struct {
+		MCPServers map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal .mcp.json: %v", err)
+	}
+	if _, ok := doc.MCPServers["alpha"]["command"]; !ok {
+		t.Fatalf("stdio server missing command: %+v", doc.MCPServers["alpha"])
+	}
+	if got := doc.MCPServers["remote"]["type"]; got != "http" {
+		t.Fatalf("remote type = %v, want http", got)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".gc", "mcp-managed", "pi.json")); err != nil {
+		t.Fatalf("managed marker missing: %v", err)
+	}
+
+	empty, err := BuildMCPProjection(MCPProviderPi, dir, nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(empty): %v", err)
+	}
+	if err := empty.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(empty): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf(".mcp.json should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gc", "mcp-managed", "pi.json")); !os.IsNotExist(err) {
 		t.Fatalf("managed marker should be removed, stat err = %v", err)
 	}
 }


### PR DESCRIPTION
Declaring [providers.pi] auto-creates a <rig>/pi agent. When that rig's
effective MCP catalog is non-empty, provider family "pi" was not in
supportsMCPProviderKind, so resolveAgentMCPProjection returned a hard
error and whole-city init fatalled into a 10s supervisor retry loop.

The de-facto pi MCP client (the community pi-mcp-adapter) reads
.mcp.json using the Claude-compatible mcpServers schema, so pi reuses
the existing Claude projection target and format verbatim: a new
MCPProviderPi constant, a BuildMCPProjection validation + target case
(shared with Claude -> .mcp.json), an Apply case routing to applyClaude,
and pi added to supportsMCPProviderKind. validateProviderContract stays
cursor-only; .mcp.json is already in managedMCPGitignoreEntries.

This is fix (1) of the two complementary fixes proposed in the issue;
the graceful-skip hardening (2) is left to a separate change.

Closes #3679.

