### PR TITLE
fix(gastown): pass WheelUp through to alternate-screen apps (Claude Code scroll)

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -387,6 +387,29 @@ func TestTmuxKeybindingsScrollWheel(t *testing.T) {
 	}
 }
 
+// TestTmuxKeybindingsAlternateScreenPassthrough locks the fix for the ga-c4w
+// alternate-screen regression: WheelUpPane must pass the wheel through to
+// full-screen apps (Claude Code, pagers) rather than forcing copy-mode over an
+// empty scrollback buffer (alternate-screen content never lands in the tmux
+// scrollback). Depends on gastownhall/gascity-packs#136; skips until go.mod is
+// bumped to a version that includes that change.
+func TestTmuxKeybindingsAlternateScreenPassthrough(t *testing.T) {
+	path := filepath.Join(packRoot(), "packs", "gastown", "assets", "scripts", "tmux-keybindings.sh")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading tmux-keybindings.sh: %v", err)
+	}
+	script := string(data)
+	if !strings.Contains(script, "alternate_on") {
+		t.Skip("embedded gascity-packs does not yet include #{alternate_on} in WheelUpPane " +
+			"(gastownhall/gascity-packs#136); test activates once go.mod is bumped to that release")
+	}
+	if !strings.Contains(script, "#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}") {
+		t.Error("WheelUpPane binding has #{alternate_on} but not the full passthrough condition " +
+			"#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}")
+	}
+}
+
 func TestOverlayDirsExist(t *testing.T) {
 	dir := exampleDir()
 	cfg := loadExpanded(t)


### PR DESCRIPTION
## Problem

ga-c4w (PR #3103) fixed the \`mouse on\` clobbering regression by setting \`MouseOn: true\` only for interactive session paths. The companion pack change in \`tmux-keybindings.sh\` added:

\`\`\`sh
gcmux bind-key -T root WheelUpPane   if-shell -F -t= "#{pane_in_mode}" "send-keys -M" "copy-mode -e"
\`\`\`

This was intended to keep tmux scrollback accessible. However, it unconditionally forces copy-mode on every upward scroll — even when Claude Code (or any full-screen TUI) is the focused pane. The problem: **tmux's scrollback buffer contains no content from alternate-screen apps**. Their output lives only in the alternate screen. Entering copy-mode while Claude Code is focused shows an empty buffer, silently discarding the scroll the user intended.

This is reproducible via \`gc attach session <name>\` after upgrading to 1.3.x: you can see live output but can no longer scroll through conversation history.

## Fix (in gascity-packs)

gastownhall/gascity-packs#136 adds \`#{alternate_on}\` (and belt-and-suspenders \`#{mouse_any_flag}\`) to the \`WheelUpPane\` passthrough condition:

| Before | \`#{pane_in_mode}\` |
|---|---|
| After | \`#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}\` |

Resulting behaviour:

| Pane state | WheelUp |
|---|---|
| Plain shell / bare prompt | enters copy-mode (tmux scrollback) — **unchanged** |
| Already in copy-mode | passes through (scroll within copy-mode) — **unchanged** |
| Alternate-screen app (Claude Code, pager, etc.) | passes through to app |
| App with mouse tracking active | passes through to app |

## This PR

Adds a regression test in gascity that locks the alternate-screen passthrough behaviour:

- **\`TestTmuxKeybindingsScrollWheel\`** — restored to its original assertions (WheelUp/WheelDown presence, no client-attached stopgap)
- **\`TestTmuxKeybindingsAlternateScreenPassthrough\`** (new) — asserts \`#{alternate_on}\` is present in the \`WheelUpPane\` binding. **Skips** against the current embedded gascity-packs version (which predates the fix); activates automatically once this repo's \`go.mod\` is bumped to the release that includes gastownhall/gascity-packs#136.

No \`go.mod\` or \`go.sum\` changes in this PR — those land in the follow-up bump once the packs PR merges.

## Safety

The ga-c4w ESC-injection safety is entirely in the gc runtime (\`disableMouseAndActivity\`). \`MouseOn\` is still \`true\` only for interactive session paths; headless controller-polled sessions have mouse off and never reach this binding. The \`cancelCopyModeIfParked\` guard (also from ga-c4w) is unaffected: copy-mode and alternate-screen are mutually exclusive, so \`pane_in_mode\` cannot be 1 when \`alternate_on\` is 1.

## References

- Fixes regression introduced by: #3103 (ga-c4w)
- gascity-packs change: https://github.com/gastownhall/gascity-packs/pull/136