### PR TITLE
feat(config): add [agent_defaults] mouse_mode — city-wide tmux mouse default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2854,6 +2854,12 @@ type AgentDefaults struct {
 	// WakeMode is the parsed/composed default wake mode ("resume" or
 	// "fresh"), but it is not yet auto-applied at runtime.
 	WakeMode string `toml:"wake_mode,omitempty" jsonschema:"enum=resume,enum=fresh"`
+	// MouseMode is the default tmux mouse_mode ("on" or "off") for agents that
+	// do not set their own. Applied to agents with an empty MouseMode by
+	// ApplyAgentDefaults. "on" keeps the session's mouse setting (so a human
+	// who attaches gets wheel scrollback); empty/"off" preserves the headless
+	// mouse-off startup. The control-dispatcher poll agent is always excluded.
+	MouseMode string `toml:"mouse_mode,omitempty" jsonschema:"enum=on,enum=off"`
 	// DefaultSlingFormula is the default formula used for agents that inherit
 	// [agent_defaults]. Explicit agents only receive this value when
 	// agent_defaults.default_sling_formula is set; implicit multi-session
@@ -2896,6 +2902,9 @@ func mergeAgentDefaultsAliasPreferCanonical(dst *AgentDefaults, src AgentDefault
 	}
 	if !meta.IsDefined("agent_defaults", "wake_mode") {
 		dst.WakeMode = src.WakeMode
+	}
+	if !meta.IsDefined("agent_defaults", "mouse_mode") {
+		dst.MouseMode = src.MouseMode
 	}
 	if !meta.IsDefined("agent_defaults", "default_sling_formula") {
 		dst.DefaultSlingFormula = src.DefaultSlingFormula
@@ -4263,6 +4272,22 @@ func ApplyAgentDefaults(cfg *City) {
 			}
 		}
 	}
+
+	// MouseMode: agents with no explicit mouse_mode inherit the city-level
+	// default so tmux wheel-scrollback can be enabled once city-wide for every
+	// human-attached agent (without a per-rig override per agent). The
+	// control-dispatcher poll agent is excluded — it stays mouse-off so
+	// controller-poll escape sequences never reach its stdin.
+	if mouseMode := cfg.AgentDefaults.MouseMode; mouseMode != "" {
+		for i := range cfg.Agents {
+			if cfg.Agents[i].Name == ControlDispatcherAgentName {
+				continue
+			}
+			if cfg.Agents[i].MouseMode == "" {
+				cfg.Agents[i].MouseMode = mouseMode
+			}
+		}
+	}
 }
 
 // DefaultOrderTrackingDeleteAfterClose is the canonical default closed-bead
@@ -4388,6 +4413,12 @@ func mergeAgentDefaults(dst *AgentDefaults, src AgentDefaults, label string, pro
 			prov.Warnings = append(prov.Warnings, fmt.Sprintf("agent_defaults.wake_mode redefined by %q", label))
 		}
 		dst.WakeMode = src.WakeMode
+	}
+	if src.MouseMode != "" {
+		if prov != nil && dst.MouseMode != "" && dst.MouseMode != src.MouseMode {
+			prov.Warnings = append(prov.Warnings, fmt.Sprintf("agent_defaults.mouse_mode redefined by %q", label))
+		}
+		dst.MouseMode = src.MouseMode
 	}
 	if src.DefaultSlingFormula != "" {
 		if prov != nil && dst.DefaultSlingFormula != "" && dst.DefaultSlingFormula != src.DefaultSlingFormula {


### PR DESCRIPTION
## Problem

Pool/reconciler-spawned agent sessions start **mouse-off** (`template_resolve.go`: `cfg.MouseOn = tp.Hints.MouseOn || origin=="manual"` → false for non-manual origin with no `mouse_mode` hint). The runtime then runs `disableMouseAndActivity` → session-local `mouse off`, which overrides the socket's global `mouse on`. Result: the wheel sends arrow keys instead of tmux scrollback for every agent a human attaches to (executor, planner, librarian, reviewers, …). The on-attach hooks (`client-attached` → `set mouse on`) race against the startup disable / miss respawns-under-attached-client.

The only existing knob is **per-agent** `mouse_mode`. With per-rig agent instantiation that means an override per (rig × agent) — unmanageable for a city-wide policy.

## Change

Add `MouseMode` to `AgentDefaults` so a single line — `[agent_defaults] mouse_mode = "on"` — flips it city-wide. Mirrors the existing `WakeMode`/`Upstream` default plumbing:
- struct field with `enum=on,enum=off` schema tag
- alias-merge + layer-merge precedence (with redefine warning)
- seeding in `ApplyAgentDefaults` for agents with empty `MouseMode`

The **control-dispatcher** poll agent is excluded (stays mouse-off / poll-safe), consistent with the other `ApplyAgentDefaults` blocks.

## Safety

**No behavior change unless `[agent_defaults] mouse_mode` is set** — empty default preserves today's headless mouse-off startup. Note: `MouseOn` is a core-fingerprint field, so setting the default triggers a one-time per-session drift restart when operators opt in.

## Test

- `go vet ./internal/config/` clean.
- `go test -run 'AgentDefaults|ApplyAgentDefaults|MouseMode' ./internal/config/` → ok.

Motivation: recurring tmux wheel-scroll regression on HQ portharbour pool sessions (po-zkfvh).