### PR TITLE
feat(usage): gc.active_work_bead — per-step attribution for usage facts

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -43,20 +43,22 @@ type hookClaimOps struct {
 	ResolveWorkBranch hookResolveWorkBranchFunc
 	// StampWorkBranch writes gc.work_branch onto the claimed bead. Best-effort.
 	StampWorkBranch hookStampWorkBranchFunc
-	// RecordRunID writes gc.current_run_id onto the session bead. Best-effort.
-	RecordRunID hookRecordRunIDFunc
-	Now         func() time.Time
+	// RecordSessionPointers writes the session bead's current-pointers — gc.current_run_id
+	// AND gc.active_work_bead (the claimed work bead's gc.step_id) — in ONE update, so
+	// the (run, step) tuple stays atomically consistent. Best-effort.
+	RecordSessionPointers hookRecordSessionPointersFunc
+	Now                   func() time.Time
 }
 
 type (
-	hookClaimFunc              func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
-	hookListContinuationFunc   func(context.Context, string, []string, string, string) ([]beads.Bead, error)
-	hookAssignContinuationFunc func(context.Context, string, []string, string, string) error
-	hookDrainAckFunc           func(io.Writer) error
-	hookEmitClaimRejectedFunc  func(beadID, existingClaimant, attemptedClaimant string)
-	hookResolveWorkBranchFunc  func(dir string) string
-	hookStampWorkBranchFunc    func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
-	hookRecordRunIDFunc        func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID string) error
+	hookClaimFunc                 func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
+	hookListContinuationFunc      func(context.Context, string, []string, string, string) ([]beads.Bead, error)
+	hookAssignContinuationFunc    func(context.Context, string, []string, string, string) error
+	hookDrainAckFunc              func(io.Writer) error
+	hookEmitClaimRejectedFunc     func(beadID, existingClaimant, attemptedClaimant string)
+	hookResolveWorkBranchFunc     func(dir string) string
+	hookStampWorkBranchFunc       func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
+	hookRecordSessionPointersFunc func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
 )
 
 type hookClaimJSONResult struct {
@@ -142,8 +144,8 @@ func (ops *hookClaimOps) applyDefaults() {
 	if ops.StampWorkBranch == nil {
 		ops.StampWorkBranch = hookStampWorkBranchWithBdStore
 	}
-	if ops.RecordRunID == nil {
-		ops.RecordRunID = hookRecordRunIDWithBdStore
+	if ops.RecordSessionPointers == nil {
+		ops.RecordSessionPointers = hookRecordSessionPointersWithBdStore
 	}
 }
 
@@ -250,7 +252,7 @@ func hookClaimExistingOrAssigned(candidates []beads.Bead, opts hookClaimOptions)
 
 func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stdout, stderr io.Writer) int {
 	stampHookWorkBranch(bead, opts, ops, dir, stderr)
-	recordHookClaimRunID(bead, opts, ops, dir, stderr)
+	recordHookClaimSessionPointers(bead, opts, ops, dir, stderr)
 	assigned, err := preassignHookContinuationGroup(bead, opts, ops, dir)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc hook --claim: preassigning continuation group for %s: %v\n", bead.ID, err) //nolint:errcheck
@@ -397,22 +399,30 @@ func hookStampWorkBranchWithBdStore(_ context.Context, dir string, env []string,
 // the bd write is bound to ctx, so a slow or stuck update cannot outlast
 // hookClaimMutationTimeout, and a non-session run (no GC_SESSION_ID), a timeout,
 // or a write error never blocks the claim.
-func recordHookClaimRunID(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) {
+func recordHookClaimSessionPointers(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) {
 	sessionBeadID := hookClaimSessionID(opts.Env)
 	if sessionBeadID == "" {
 		return
 	}
+	// Both pointers are derived from the SAME just-claimed work bead so the (run, step)
+	// tuple is consistent: run_id is the bead's resolved run root; step_id is its bare
+	// gc.step_id (the cross-plane join key the events plane also uses), empty when the
+	// work has no formula step (ad-hoc/manual) — which clears any prior step.
 	runID := beadmeta.ResolveRunID(bead.Metadata, bead.ID, sessionBeadID)
+	stepID := strings.TrimSpace(bead.Metadata[beadmeta.StepIDMetadataKey])
 	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
 	defer cancel()
-	if err := ops.RecordRunID(ctx, dir, opts.Env, opts.Assignee, sessionBeadID, runID); err != nil {
-		fmt.Fprintf(stderr, "gc hook --claim: recording run_id on session bead %s: %v\n", sessionBeadID, err) //nolint:errcheck
+	if err := ops.RecordSessionPointers(ctx, dir, opts.Env, opts.Assignee, sessionBeadID, runID, stepID); err != nil {
+		fmt.Fprintf(stderr, "gc hook --claim: recording session pointers on session bead %s: %v\n", sessionBeadID, err) //nolint:errcheck
 	}
 }
 
-func hookRecordRunIDWithBdStore(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID string) error {
+func hookRecordSessionPointersWithBdStore(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error {
 	store := hookClaimBdStoreContext(ctx, dir, env, assignee)
-	return store.Update(sessionBeadID, beads.UpdateOpts{Metadata: map[string]string{beadmeta.CurrentRunIDMetadataKey: runID}})
+	return store.Update(sessionBeadID, beads.UpdateOpts{Metadata: map[string]string{
+		beadmeta.CurrentRunIDMetadataKey:   runID,
+		beadmeta.ActiveWorkBeadMetadataKey: stepID,
+	}})
 }
 
 // hookClaimSessionID returns the session bead id (GC_SESSION_ID) from the claim

--- a/cmd/gc/cmd_hook_claim_runid_test.go
+++ b/cmd/gc/cmd_hook_claim_runid_test.go
@@ -11,20 +11,22 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// recordRunIDSpy captures the (assignee, sessionBeadID, runID) a claim records,
-// and lets a test inject a write error to prove the decoration never fails the
-// claim. assignee is captured to pin actor parity with the work_branch stamp.
+// recordRunIDSpy captures the (assignee, sessionBeadID, runID, stepID) a claim
+// records in one update, and lets a test inject a write error to prove the
+// decoration never fails the claim. assignee is captured to pin actor parity with
+// the work_branch stamp.
 type recordRunIDSpy struct {
 	calls    int
 	assignee string
 	session  string
 	runID    string
+	stepID   string
 	err      error
 }
 
-func (s *recordRunIDSpy) fn(_ context.Context, _ string, _ []string, assignee, sessionBeadID, runID string) error {
+func (s *recordRunIDSpy) fn(_ context.Context, _ string, _ []string, assignee, sessionBeadID, runID, stepID string) error {
 	s.calls++
-	s.assignee, s.session, s.runID = assignee, sessionBeadID, runID
+	s.assignee, s.session, s.runID, s.stepID = assignee, sessionBeadID, runID, stepID
 	return s.err
 }
 
@@ -39,8 +41,8 @@ func claimOpsForRunID(beadID string, claimedMeta map[string]string, spy *recordR
 		Claim: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, bool, error) {
 			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Metadata: claimedMeta}, true, nil
 		},
-		ResolveWorkBranch: func(string) string { return "" }, // suppress work_branch stamp
-		RecordRunID:       spy.fn,
+		ResolveWorkBranch:     func(string) string { return "" }, // suppress work_branch stamp
+		RecordSessionPointers: spy.fn,
 	}
 	opts := hookClaimOptions{
 		Assignee:           "worker-1",
@@ -132,7 +134,7 @@ func TestDoHookClaimRunIDRecordFailureDoesNotFailClaim(t *testing.T) {
 	if result.BeadID != "hw-err" || result.Reason != "claimed" {
 		t.Fatalf("claim result = %+v, want bead hw-err reason claimed", result)
 	}
-	if !strings.Contains(stderr.String(), "recording run_id on session bead sess-1") {
+	if !strings.Contains(stderr.String(), "recording session pointers on session bead sess-1") {
 		t.Fatalf("stderr missing best-effort log line; got: %s", stderr.String())
 	}
 }
@@ -153,8 +155,8 @@ func TestDoHookClaimRecordsRunIDOnExistingAssignment(t *testing.T) {
 			t.Error("Claim must not be called on the existing-assignment path")
 			return beads.Bead{}, false, nil
 		},
-		ResolveWorkBranch: func(string) string { return "" }, // suppress work_branch stamp
-		RecordRunID:       spy.fn,
+		ResolveWorkBranch:     func(string) string { return "" }, // suppress work_branch stamp
+		RecordSessionPointers: spy.fn,
 	}
 	opts := hookClaimOptions{
 		Assignee:           "worker-1",
@@ -173,5 +175,54 @@ func TestDoHookClaimRecordsRunIDOnExistingAssignment(t *testing.T) {
 	}
 	if spy.assignee != "worker-1" {
 		t.Fatalf("record assignee = %q, want worker-1 (actor parity with the work_branch stamp)", spy.assignee)
+	}
+}
+
+// TestDoHookClaimRecordsActiveWorkBeadAsStepID: the active-work-bead pointer is the
+// work bead's BARE gc.step_id, NOT its namespaced bead id — the cross-plane join key
+// the events plane also uses. The fixture makes them differ (bead id
+// "mol.finalize.attempt.1" vs gc.step_id "mol.finalize") so a bead.ID regression
+// can't pass. The (run, step) tuple is recorded in one consistent call.
+func TestDoHookClaimRecordsActiveWorkBeadAsStepID(t *testing.T) {
+	spy := &recordRunIDSpy{}
+	ops, opts := claimOpsForRunID("mol.finalize.attempt.1", map[string]string{
+		"gc.routed_to":    "worker",
+		"gc.root_bead_id": "root-R",
+		"gc.step_id":      "mol.finalize", // the bare logical step, != the bead id
+	}, spy)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if spy.calls != 1 {
+		t.Fatalf("record calls = %d, want 1 (run+step in ONE update)", spy.calls)
+	}
+	if spy.stepID != "mol.finalize" {
+		t.Fatalf("stepID = %q, want the bare gc.step_id mol.finalize (NOT the bead id)", spy.stepID)
+	}
+	if spy.stepID == "mol.finalize.attempt.1" {
+		t.Fatalf("stepID must NOT be the namespaced bead id — that never joins with events")
+	}
+	if spy.runID != "root-R" {
+		t.Fatalf("runID = %q, want root-R — the step must be recorded under its own run (tuple consistency)", spy.runID)
+	}
+}
+
+// TestDoHookClaimActiveWorkBeadEmptyForNonFormulaWork: a non-formula work bead has no
+// gc.step_id, so the pointer is written EMPTY — clearing any prior step on a reused
+// session so an ad-hoc unit attributes at run level, matching the events plane.
+func TestDoHookClaimActiveWorkBeadEmptyForNonFormulaWork(t *testing.T) {
+	spy := &recordRunIDSpy{}
+	ops, opts := claimOpsForRunID("hw-adhoc", map[string]string{
+		"gc.routed_to": "worker", // no gc.step_id
+	}, spy)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if spy.calls != 1 || spy.stepID != "" {
+		t.Fatalf("record = {calls:%d stepID:%q}, want {1 \"\"} (non-formula clears the step)", spy.calls, spy.stepID)
 	}
 }

--- a/cmd/gc/usage_compute.go
+++ b/cmd/gc/usage_compute.go
@@ -110,6 +110,15 @@ func emitComputeFactForBead(ctx context.Context, sink usage.Sink, store beads.St
 			logf("usage: marking compute fact emitted for session %s failed; may re-emit (deduped by idempotency key): %v", bead.ID, err)
 		}
 	}
+	// Clear the session's active-work-bead pointer at this terminal/sleep transition,
+	// so a model invocation made while idle (between this work and the next claim) is
+	// attributed at run level (StepID="") rather than to the step that just ended.
+	// Best-effort: a stale pointer is overwritten by the next claim regardless.
+	if err := store.SetMetadata(bead.ID, beadmeta.ActiveWorkBeadMetadataKey, ""); err != nil {
+		if logf != nil {
+			logf("usage: clearing active_work_bead for session %s failed (overwritten by next claim): %v", bead.ID, err)
+		}
+	}
 	return true
 }
 

--- a/cmd/gc/usage_compute_test.go
+++ b/cmd/gc/usage_compute_test.go
@@ -34,11 +34,12 @@ func TestEmitComputeFactForBead(t *testing.T) {
 	b, err := store.Create(beads.Bead{
 		Title: "session",
 		Metadata: map[string]string{
-			"state":            "asleep",
-			"session_name":     "s-x",
-			"awake_started_at": start.Format(time.RFC3339),
-			"slept_at":         slept.Format(time.RFC3339),
-			"molecule_id":      "mol-7",
+			"state":               "asleep",
+			"session_name":        "s-x",
+			"awake_started_at":    start.Format(time.RFC3339),
+			"slept_at":            slept.Format(time.RFC3339),
+			"molecule_id":         "mol-7",
+			"gc.active_work_bead": "mol.finalize", // the step the session was on; cleared at this terminal pass
 		},
 	})
 	if err != nil {
@@ -74,6 +75,11 @@ func TestEmitComputeFactForBead(t *testing.T) {
 	refreshed, err := store.Get(b.ID)
 	if err != nil {
 		t.Fatal(err)
+	}
+	// The terminal pass also CLEARS the active-work-bead pointer, so an idle
+	// invocation after this work attributes at run level (StepID="") not the old step.
+	if got := refreshed.Metadata["gc.active_work_bead"]; got != "" {
+		t.Fatalf("gc.active_work_bead = %q, want cleared (\"\") at the terminal pass", got)
 	}
 	if emitComputeFactForBead(context.Background(), sink, store, refreshed, "fake", "demo", now, nil) {
 		t.Fatal("second emit on same interval must no-op (marker set)")

--- a/engdocs/design/active-work-bead-v0.md
+++ b/engdocs/design/active-work-bead-v0.md
@@ -1,0 +1,110 @@
+# gc.active_work_bead — per-step attribution for usage facts (v0)
+
+> Council-reviewed (2026-06-24). Decision 1 = store the work bead's bare `gc.step_id`
+> (unanimous). Decision 2 = clear-on-terminal (majority). The compute read site is cut.
+
+## Problem
+
+Usage facts (`internal/usage`) and the spend rows derived from them carry `RunID`
+and `SessionID`, but **`StepID` is always empty**. The usage record sites only have
+the **session bead** in scope, not the **work bead** the session is executing. So a
+run's cost cannot be broken down per step.
+
+The events plane already carries `step_id`: a `bead.created`/`bead.closed` event reads
+its **subject bead's own `gc.step_id`**. That works because the events record site
+*is* the work bead. The usage record site is the session, so it needs a pointer FROM
+the session TO the work it is running.
+
+## The step identity (corrected; load-bearing)
+
+`gc.step_id` (`beadmeta.StepIDMetadataKey`) is the **bare logical formula step id**
+(e.g. `mol.finalize`), written by the control plane onto a work bead. It is
+**distinct from the bead's runtime `bead.ID`**, which is namespaced per attempt/scope
+(e.g. `mol.finalize.attempt.1`): `control.go:602-605/686-690` set `gc.step_id` to the
+bare `child.ID`/`control.ID` onto a bead whose ID is `attemptPrefix + "." + child.ID`;
+`ralph.go` sets `gc.step_id = step.ID` while the iteration bead id is
+`step.ID + ".iteration.N"`; `molecule.go:1380` builds `index[stepID] = bead.ID`,
+proving the two differ. Non-formula beads (ad-hoc, orders, manual) carry **no**
+`gc.step_id`.
+
+So the step_id that JOINS cross-plane is the **bare `gc.step_id`** — the events plane
+already uses it, and the cost plane must use the same value. Storing `bead.ID` would
+never join with events. **Decision 1 (locked, unanimous): the pointer holds the work
+bead's `gc.step_id`** (empty when the bead has none).
+
+## Goal
+
+Introduce `gc.active_work_bead` on the **session bead**: write the current work bead's
+`gc.step_id` at the claim transition, read it at the model-usage record site to
+populate `usage.Fact.StepID`. Mirrors `gc.current_run_id` (`cmd/gc/cmd_hook_claim.go`).
+Unblocks per-step cost for **formula/molecule runs** (the dominant attributed path);
+ad-hoc/manual work correctly rolls up at run level with empty StepID, matching events.
+
+## Mechanism
+
+### Key
+`internal/beadmeta/keys.go`: `ActiveWorkBeadMetadataKey = "gc.active_work_bead"` +
+add to `KnownMetadataKeys`.
+
+### Write — FOLDED into the run-id write (one atomic Update, same bead)
+`cmd/gc/cmd_hook_claim.go` `recordHookClaimRunID` already writes `gc.current_run_id`
+on the session bead at claim. **Fold** the step write into the SAME `store.Update`:
+derive `stepID = bead.Metadata[StepIDMetadataKey]` from the SAME just-claimed `bead`
+that yields `runID`, and write `{gc.current_run_id: runID, gc.active_work_bead: stepID}`
+in one update. This (a) halves the bd calls + `bead.updated` events per claim, and
+(b) locks the (run, step) tuple — the step is guaranteed to belong to the run stamped
+in the same claim. **Unconditional per claim** (a current-pointer must follow a reused
+pool session), including writing an EMPTY step (clearing a prior step when the new
+work is non-formula).
+
+### Read — model facts only (compute read CUT)
+`internal/worker/invocation_telemetry.go modelUsageFact`: read
+`bead.Metadata[ActiveWorkBeadMetadataKey]` → `Fact.StepID`, from the SAME session-bead
+snapshot `b` already used for `ResolveRunID`, so StepID and RunID never come from two
+reads. Nil-map read returns `""` (Go semantics) — safe, like the existing
+`b.Metadata["provider_kind"]` read.
+
+The compute emitter does **not** read it: `emitComputeFactForBead` fires at the
+session's terminal/sleep transition where the pointer is definitionally stale, and v0
+compute facts are omitted from spend anyway.
+
+### Clear — at the terminal/sleep transition (Decision 2, locked majority)
+`cmd/gc/usage_compute.go` already does `store.SetMetadata` on the session bead at every
+terminal pass. Clear `gc.active_work_bead` there (write `""`), so an idle / manual-chat
+invocation after work ends and before the next claim resolves `StepID=""` (run/session
+level) rather than the last step's id.
+
+## Honest limits (NOT a "rare race")
+- **Stale-on-idle is routine, not rare** — the model read fires on EVERY prompt op
+  (incl. idle/manual-chat), and reused pool/canonical sessions are the norm. The
+  terminal clear (above) is what bounds it; it is REQUIRED before the per-step
+  consumer (#51) ships, not deferred.
+- **Read-record non-atomicity** (genuinely narrow, accepted, matches
+  `gc.current_run_id`): a second claim between the transcript-tail read and the fact
+  record can stamp the new step. Bounded; both pointers read from one snapshot keep
+  StepID under the matching RunID.
+
+## Seam coverage (gc hook --claim is NOT universal)
+Work-starts the claim hook does NOT cover, where `gc.active_work_bead` is empty/stale:
+manual chat / no work bead (→ empty StepID); API-server fresh-handle turns;
+`RuntimeHandle` prompt ops (out of scope per `recordInvocationTelemetry`). **Empty
+StepID for these is CORRECT** — non-attribution, identical to the events plane's empty
+step_id for the same work. The only mis-attribution case is the pooled-session idle
+window, which the terminal clear addresses.
+
+## Test plan (TDD)
+- `beadmeta`: the new key is in `KnownMetadataKeys`.
+- claim hook: one `store.Update` writes BOTH `gc.current_run_id` AND
+  `gc.active_work_bead` on the session bead; the step value = the work bead's
+  `gc.step_id` — with a fixture where **`gc.step_id != bead.ID`** so a `bead.ID`
+  regression can't pass; `ResolveRunID(workbead)` equals the stamped run id (tuple
+  consistency); empty `GC_SESSION_ID` → skip; store error → best-effort (no panic);
+  a non-formula bead (no `gc.step_id`) writes an empty step (clears any prior).
+- `modelUsageFact`: reads the session bead's `gc.active_work_bead` → `Fact.StepID`,
+  distinct from RunID/SessionID; empty when absent.
+- compute terminal: clears `gc.active_work_bead` on the session bead.
+
+## Scope
+gc-side: the key; the folded write at claim; the model read; the terminal clear. OUT
+of scope (separate tasks): the metered-path proxy `X-Gc-Step-Id` stamp; the dashboard
+per-step rollup; the events-ingest `city_events.step_id` consumer.

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -59,6 +59,12 @@ const (
 	ControllerErrorMetadataKey           = "gc.controller_error"
 	ControllerRetryableMetadataKey       = "gc.controller_retryable"
 	CurrentRunIDMetadataKey              = "gc.current_run_id"
+	// ActiveWorkBeadMetadataKey is the session bead's current-pointer to the STEP it
+	// is executing — the work bead's bare gc.step_id (NOT its namespaced bead id),
+	// stamped at the claim hook and read at the usage record site to populate
+	// usage.Fact.StepID. Empty when the current work has no formula step (ad-hoc /
+	// manual), matching the events plane. See engdocs/design/active-work-bead-v0.md.
+	ActiveWorkBeadMetadataKey            = "gc.active_work_bead"
 	DeferredAssigneeMetadataKey          = "gc.deferred_assignee"
 	DeferredExecutionRoutedToMetadataKey = "gc.deferred_execution_routed_to"
 	DeferredRoutedToMetadataKey          = "gc.deferred_routed_to"
@@ -251,6 +257,7 @@ var KnownMetadataKeys = []string{
 	ControllerErrorMetadataKey,
 	ControllerRetryableMetadataKey,
 	CurrentRunIDMetadataKey,
+	ActiveWorkBeadMetadataKey,
 	DeferredAssigneeMetadataKey,
 	DeferredExecutionRoutedToMetadataKey,
 	DeferredRoutedToMetadataKey,

--- a/internal/worker/invocation_telemetry.go
+++ b/internal/worker/invocation_telemetry.go
@@ -193,12 +193,18 @@ func (h *SessionHandle) recordInvocationTelemetry(ctx context.Context) {
 // read as "not measured", never as a free invocation.
 func modelUsageFact(u sessionlog.TailUsage, bead beads.Bead, sessionID, worker, providerFamily string, cost float64, priced bool, now time.Time) usage.Fact {
 	runID := beadmeta.ResolveRunID(bead.Metadata, bead.ID, sessionID)
+	// The run STEP: the session's current work bead's gc.step_id, stamped at the claim
+	// hook (gc.active_work_bead). Read from the SAME session-bead snapshot as runID so
+	// StepID always names a step under this RunID. Empty when the session isn't on a
+	// formula work bead (ad-hoc/manual/idle) — run-level attribution, matching events.
+	stepID := strings.TrimSpace(bead.Metadata[beadmeta.ActiveWorkBeadMetadataKey])
 	reqID := usageIdentity(u)
 	if !priced {
 		cost = 0
 	}
 	return usage.Fact{
 		RunID:               runID,
+		StepID:              stepID,
 		Worker:              strings.TrimSpace(worker),
 		Kind:                usage.KindModel,
 		Model:               strings.TrimSpace(u.Model),

--- a/internal/worker/invocation_telemetry_usagefact_test.go
+++ b/internal/worker/invocation_telemetry_usagefact_test.go
@@ -184,7 +184,9 @@ func TestModelUsageFact(t *testing.T) {
 		CacheReadTokens:     10,
 		CacheCreationTokens: 5,
 	}
-	bead := beads.Bead{ID: "b1", Metadata: map[string]string{"molecule_id": "mol-7"}}
+	// The session bead carries gc.active_work_bead (the step it is currently on),
+	// stamped by the claim hook; modelUsageFact reads it into Fact.StepID.
+	bead := beads.Bead{ID: "b1", Metadata: map[string]string{"molecule_id": "mol-7", "gc.active_work_bead": "mol.finalize"}}
 
 	priced := modelUsageFact(u, bead, "session-1", "myrig/polecat-1", "claude", 0.02, true, now)
 	if priced.Kind != usage.KindModel {
@@ -192,6 +194,9 @@ func TestModelUsageFact(t *testing.T) {
 	}
 	if priced.RunID != "mol-7" {
 		t.Fatalf("RunID = %q, want mol-7 (resolved through the shared run-id chain)", priced.RunID)
+	}
+	if priced.StepID != "mol.finalize" {
+		t.Fatalf("StepID = %q, want mol.finalize (the session's gc.active_work_bead), distinct from RunID", priced.StepID)
 	}
 	if priced.Worker != "myrig/polecat-1" || priced.Model != "claude-opus-4-7" || priced.Provider != "claude" {
 		t.Fatalf("identity wrong: %+v", priced)


### PR DESCRIPTION
## `gc.active_work_bead` — per-step attribution for usage facts

Closes the deferred prerequisite for per-step **cost**. Usage facts carried `RunID` and `SessionID` but never `StepID`, because the usage record sites only see the **session** bead, not the **work** bead it's executing. The events plane already carries `step_id` (from a subject bead's `gc.step_id`); this gives the usage/spend plane the **same join key** via a session→work pointer, mirroring `gc.current_run_id`.

### Design decisions (council-reviewed — `engdocs/design/active-work-bead-v0.md`)
- **The value is the work bead's bare `gc.step_id`, not its `bead.ID`.** `gc.step_id` is the bare logical step (`mol.finalize`); the runtime `bead.ID` is namespaced per attempt (`mol.finalize.attempt.1`) — verified at `control.go:690,804`. Only `gc.step_id` joins with the events plane's step_id.
- **Clear-on-terminal** so an idle / manual-chat invocation after work attributes at run level (`StepID=""`), not the step that just ended.

### Changes
- `internal/beadmeta`: `ActiveWorkBeadMetadataKey = "gc.active_work_bead"`.
- `cmd/gc/cmd_hook_claim.go`: **fold** the step pointer into the SAME `store.Update` as `gc.current_run_id` — one write, the (run, step) tuple atomically consistent, both derived from the same just-claimed bead (`RecordRunID` → `RecordSessionPointers`).
- `internal/worker/invocation_telemetry.go`: `modelUsageFact` reads `gc.active_work_bead` from the **same** session-bead snapshot it uses for `ResolveRunID` → `Fact.StepID`.
- `cmd/gc/usage_compute.go`: clear the pointer at the terminal/sleep pass.

### Scope & honesty
Per-step cost lights up for **formula/molecule runs**; ad-hoc/manual/idle work correctly rolls up at run level with empty `StepID`, matching events — so empty is non-attribution, not a bug. Out of scope (separate follow-ons): the metered-path proxy `X-Gc-Step-Id` stamp, the dashboard per-step rollup, the `events-ingest` `city_events.step_id` consumer.

### Process & verification
Spec → 4-perspective design **council** (caught a load-bearing false premise — `gc.step_id == bead.ID` — and locked both open decisions) → TDD → **red-team** (3 lenses + verify: **0 findings**). New tests cover: the key guard; the claim hook writing both pointers from the same bead with a fixture where `gc.step_id != bead.ID`; tuple consistency; non-formula → empty; the model read; the terminal clear. `go test ./cmd/gc/... ./internal/worker/ ./internal/beadmeta/` green; `vet`/`gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
