### PR TITLE
fix(worker): stage per-provider overlay for rig-scoped agents (gc-6bw8o)

### DIFF
--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -124,6 +124,39 @@ func workerSessionCreateHints(resolved *config.ResolvedProvider) runtime.Config 
 	return hints.ToRuntimeConfig()
 }
 
+// applyWorkerOverlayHints populates the provider-overlay staging fields
+// (ProviderName/ProviderOverlayName/InstallAgentHooks/PackOverlayDirs) on a
+// worker create/resume runtime.Config, mirroring the canonical create-time
+// sourcing in cmd/gc/template_resolve.go (resolveTemplate). The worker.Factory
+// create and resume paths build runtime.Config directly and never route through
+// resolveTemplate, so without this they leave these fields empty:
+// OverlayProviderNames then falls back to ProviderName="" and the per-provider
+// overlay (e.g. core/overlay/per-provider/pi/.pi/extensions/gc-hooks.js for a
+// custom base="builtin:pi" provider) is never staged, the harness never signals
+// ready, and the controller churns into a fall-back-to-claude loop (gc-6bw8o).
+// Best-effort: a missing cfg/resolved (CLI direct-start fallback) leaves the
+// config untouched rather than failing the start.
+func applyWorkerOverlayHints(hints *runtime.Config, cfg *config.City, cityPath, template string, resolved *config.ResolvedProvider) {
+	if hints == nil || cfg == nil || resolved == nil {
+		return
+	}
+	// ProviderName is the launch family (BuiltinAncestor, e.g. "pi" for a
+	// base="builtin:pi" provider); ProviderOverlayName is the concrete provider
+	// name — identical to resolveTemplate's hint assignment.
+	hints.ProviderName = resolvedProviderLaunchFamily(resolved)
+	hints.ProviderOverlayName = strings.TrimSpace(resolved.Name)
+	agentCfg := findAgentByTemplate(cfg, template)
+	if agentCfg == nil {
+		// No agent config to resolve install-hooks/rig overlay scope against
+		// (e.g. a synthetic session). Still stage city pack overlays.
+		hints.PackOverlayDirs = effectiveOverlayDirs(cfg.PackOverlayDirs, cfg.RigOverlayDirs, "")
+		return
+	}
+	hints.InstallAgentHooks = config.ResolveInstallHooks(agentCfg, &cfg.Workspace)
+	rigName := sessionSetupContextForAgent(cityPath, cfg.EffectiveCityName(), firstNonEmptyGCString(agentCfg.QualifiedName(), template), agentCfg, cfg.Rigs).Rig
+	hints.PackOverlayDirs = effectiveOverlayDirs(cfg.PackOverlayDirs, cfg.RigOverlayDirs, rigName)
+}
+
 func resolvedRuntimeMCPServersWithConfig(
 	cityPath string,
 	cfg *config.City,
@@ -245,6 +278,11 @@ func newWorkerSessionHandleForResolvedRuntimeWithConfig(
 	if err != nil {
 		return nil, err
 	}
+	// Stage provider-overlay hooks on the CLI create path the same way the
+	// reconciler create path does; resolvedWorkerSessionConfigWithConfig builds
+	// runtime.Config directly and never routes through resolveTemplate
+	// (gc-6bw8o).
+	applyWorkerOverlayHints(&sessionCfg.Runtime.Hints, cfg, cityPath, template, resolved)
 	return factory.SessionForResolvedRuntime(sessionCfg)
 }
 
@@ -574,6 +612,10 @@ func resolvedWorkerRuntimeWithConfigAndMetadata(cityPath string, cfg *config.Cit
 	runtimeHints.WorkDir = workDir
 	runtimeHints.Env = sessionEnv
 	runtimeHints.MCPServers = mcpServers
+	// Stage provider-overlay hooks on resume the same way the reconciler create
+	// path does; this resume resolver builds runtime.Config directly and never
+	// routes through resolveTemplate (gc-6bw8o).
+	applyWorkerOverlayHints(&runtimeHints, cfg, cityPath, info.Template, resolved)
 	return &worker.ResolvedRuntime{
 		Command:    command,
 		WorkDir:    workDir,

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -2381,10 +2381,11 @@ func piVllmRigCity(t *testing.T) (cityDir, overlayDir string, cfg *config.City) 
 	cfg = &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Agents: []config.Agent{{
-			Name:     "polecat",
-			Provider: "pi-vllm",
-			Scope:    "rig",
-			Dir:      "myrig",
+			Name:              "polecat",
+			Provider:          "pi-vllm",
+			Scope:             "rig",
+			Dir:               "myrig",
+			InstallAgentHooks: []string{"pi"}, // declares the per-provider/pi/ overlay slot
 		}},
 		Providers: map[string]config.ProviderSpec{
 			// Explicit command so resolution does not depend on a real `pi`
@@ -2447,6 +2448,19 @@ func TestResolvedWorkerRuntimeStagesProviderOverlayForRigBasePiProvider(t *testi
 	slots := runtime.OverlayProviderNames(runtimeCfg.Hints)
 	if len(slots) == 0 {
 		t.Fatal("runtime.OverlayProviderNames(resume Hints) is empty; per-provider overlay would never stage")
+	}
+
+	// End-to-end proof of the gc-6bw8o regression: actually stage the workdir
+	// and confirm the per-provider/pi/ hook lands. Stage into a fresh temp
+	// workdir rather than the city dir so the assertion is unambiguous.
+	stageCfg := runtimeCfg.Hints
+	stageCfg.WorkDir = t.TempDir()
+	if err := runtime.StageSessionWorkDir(stageCfg); err != nil {
+		t.Fatalf("StageSessionWorkDir: %v", err)
+	}
+	hookPath := filepath.Join(stageCfg.WorkDir, ".pi", "extensions", "gc-hooks.js")
+	if _, err := os.Stat(hookPath); err != nil {
+		t.Fatalf("per-provider/pi hook not staged at %s: %v", hookPath, err)
 	}
 }
 

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -2352,3 +2352,157 @@ func TestWorkerSessionCreateHintsEnablesMouse(t *testing.T) {
 		t.Error("workerSessionCreateHints().MouseOn = false, want true (gc session new unmanaged-direct wheel→scrollback, ga-c4w)")
 	}
 }
+
+// piVllmRigCity builds an in-memory city with a single rig-scoped agent
+// "myrig/polecat" running a custom provider whose base = "builtin:pi", plus a
+// rig overlay dir carrying the per-provider/pi/ hooks. It mirrors the real
+// pi-vllm hybrid shape used in gc-6bw8o. The qualified template name
+// ("myrig/polecat") is the identity the resume path persists for a rig agent.
+func piVllmRigCity(t *testing.T) (cityDir, overlayDir string, cfg *config.City) {
+	t.Helper()
+	cityDir = t.TempDir()
+	gcDir := filepath.Join(cityDir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gcDir, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	overlayDir = filepath.Join(cityDir, "packs", "myrig", "overlay")
+	// per-provider/pi/.pi/extensions/gc-hooks.js is the slot OverlayProviderNames
+	// must resolve to for the harness to stage its ready-signal hook.
+	if err := os.MkdirAll(filepath.Join(overlayDir, "per-provider", "pi", ".pi", "extensions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "per-provider", "pi", ".pi", "extensions", "gc-hooks.js"), []byte("// hook"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := "builtin:pi"
+	cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:     "polecat",
+			Provider: "pi-vllm",
+			Scope:    "rig",
+			Dir:      "myrig",
+		}},
+		Providers: map[string]config.ProviderSpec{
+			// Explicit command so resolution does not depend on a real `pi`
+			// binary in the test host PATH; base still yields BuiltinAncestor=pi.
+			"pi-vllm": {Base: &base, Command: "/bin/echo"},
+		},
+		Rigs:           []config.Rig{{Name: "myrig", Path: filepath.Join(cityDir, "myrig")}},
+		RigOverlayDirs: map[string][]string{"myrig": {overlayDir}},
+	}
+	return cityDir, overlayDir, cfg
+}
+
+// TestResolvedWorkerRuntimeStagesProviderOverlayForRigBasePiProvider is the
+// regression test for gc-6bw8o. The worker resume resolver
+// (resolvedWorkerRuntimeWithConfigAndMetadata) builds runtime.Config directly
+// and never routes through resolveTemplate, so before the fix it left
+// ProviderOverlayName/PackOverlayDirs empty. OverlayProviderNames then fell back
+// to ProviderName="" and the per-provider/pi/ hooks (gc-hooks.js) never staged,
+// the harness never signaled ready, and the controller churned into a
+// fall-back-to-claude loop. The fix populates these via applyWorkerOverlayHints,
+// mirroring the reconciler create path's sourcing in template_resolve.go.
+func TestResolvedWorkerRuntimeStagesProviderOverlayForRigBasePiProvider(t *testing.T) {
+	cityDir, overlayDir, cfg := piVllmRigCity(t)
+
+	runtimeCfg, err := resolvedWorkerRuntimeWithConfig(cityDir, cfg, session.Info{
+		Template: "myrig/polecat",
+		Command:  "pi-vllm",
+		WorkDir:  cityDir,
+	}, "")
+	if err != nil {
+		t.Fatalf("resolvedWorkerRuntimeWithConfig: %v", err)
+	}
+	if runtimeCfg == nil {
+		t.Fatal("resolvedWorkerRuntimeWithConfig() = nil")
+	}
+
+	// Concrete provider name drives the per-provider overlay slot.
+	if got := strings.TrimSpace(runtimeCfg.Hints.ProviderOverlayName); got != "pi-vllm" {
+		t.Fatalf("resume Hints.ProviderOverlayName = %q, want %q (concrete provider name)", got, "pi-vllm")
+	}
+	// Launch family is the base (pi), mirroring the reconciler create path.
+	if got := strings.TrimSpace(runtimeCfg.Hints.ProviderName); got != "pi" {
+		t.Fatalf("resume Hints.ProviderName = %q, want %q (launch family)", got, "pi")
+	}
+	// Rig overlay dir must be staged so per-provider/pi/ hooks reach the workdir.
+	if len(runtimeCfg.Hints.PackOverlayDirs) == 0 {
+		t.Fatalf("resume Hints.PackOverlayDirs is empty, want the rig overlay dir %q", overlayDir)
+	}
+	foundOverlay := false
+	for _, od := range runtimeCfg.Hints.PackOverlayDirs {
+		if od == overlayDir {
+			foundOverlay = true
+		}
+	}
+	if !foundOverlay {
+		t.Fatalf("resume Hints.PackOverlayDirs = %v, want to include rig overlay dir %q", runtimeCfg.Hints.PackOverlayDirs, overlayDir)
+	}
+	// Sanity: the effective overlay slot list must be non-empty, otherwise
+	// StageProviderOverlayDir would copy no per-provider/<slot>/ content.
+	slots := runtime.OverlayProviderNames(runtimeCfg.Hints)
+	if len(slots) == 0 {
+		t.Fatal("runtime.OverlayProviderNames(resume Hints) is empty; per-provider overlay would never stage")
+	}
+}
+
+// TestResolvedWorkerSessionConfigStagesProviderOverlayForRigBasePiProvider
+// covers the CLI create path for the same gc-6bw8o rig pi-vllm agent. It first
+// documents the gap (resolvedWorkerSessionConfigWithConfig, which only sees
+// `resolved`, leaves the overlay fields empty), then asserts that
+// applyWorkerOverlayHints — the exact call
+// newWorkerSessionHandleForResolvedRuntimeWithConfig makes onto
+// sessionCfg.Runtime.Hints before handing the spec to the worker factory —
+// populates them so the per-provider/pi/ hooks would stage. The end-to-end
+// create wiring is hard to assert (the resulting worker.Handle does not expose
+// its Hints); the resume-path test above is the integration regression proof.
+func TestResolvedWorkerSessionConfigStagesProviderOverlayForRigBasePiProvider(t *testing.T) {
+	cityDir, overlayDir, cfg := piVllmRigCity(t)
+
+	resolved, _ := resolveWorkerRuntimeProviderWithConfigAndMetadata(cfg, session.Info{Template: "myrig/polecat"}, "", nil)
+	if resolved == nil {
+		t.Fatal("resolveWorkerRuntimeProviderWithConfigAndMetadata() = nil")
+	}
+
+	sessionCfg, err := resolvedWorkerSessionConfigWithConfig(
+		cityDir,
+		resolved.CommandString(),
+		"pi-vllm",
+		cityDir,
+		"myrig/polecat",
+		"",
+		"myrig/polecat",
+		"polecat",
+		"",
+		resolved,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("resolvedWorkerSessionConfigWithConfig: %v", err)
+	}
+	// The bare builder must NOT set overlay fields — that is the gap the create
+	// call site closes. If this ever starts populating them on its own, the
+	// create-path applyWorkerOverlayHints call is redundant and this guard flags it.
+	if got := strings.TrimSpace(sessionCfg.Runtime.Hints.ProviderOverlayName); got != "" {
+		t.Fatalf("resolvedWorkerSessionConfigWithConfig set ProviderOverlayName = %q on its own, expected empty (overlay is caller-applied)", got)
+	}
+
+	// Apply the overlay hints exactly as
+	// newWorkerSessionHandleForResolvedRuntimeWithConfig does before the factory call.
+	applyWorkerOverlayHints(&sessionCfg.Runtime.Hints, cfg, cityDir, "myrig/polecat", resolved)
+
+	if got := strings.TrimSpace(sessionCfg.Runtime.Hints.ProviderOverlayName); got != "pi-vllm" {
+		t.Fatalf("create Hints.ProviderOverlayName = %q, want %q", got, "pi-vllm")
+	}
+	if len(sessionCfg.Runtime.Hints.PackOverlayDirs) == 0 {
+		t.Fatalf("create Hints.PackOverlayDirs is empty, want rig overlay dir %q", overlayDir)
+	}
+	if slots := runtime.OverlayProviderNames(sessionCfg.Runtime.Hints); len(slots) == 0 {
+		t.Fatal("runtime.OverlayProviderNames(create Hints) is empty; per-provider overlay would never stage")
+	}
+}


### PR DESCRIPTION
## Problem

Rig-scoped agents (polecat / witness / refinery) configured for a non-default provider — e.g. a custom provider with `base = "builtin:pi"` (Pi) or `base = "builtin:opencode"` (OpenCode) — never get their per-provider overlay staged into the session work dir.

The overlay (`core/overlay/per-provider/<provider>/`, e.g. `.pi/extensions/gc-hooks.js`, `.opencode/plugins/gascity.js`) carries the lifecycle hooks the harness needs to signal "ready". Without it:

- the harness never signals ready,
- the controller SIGTERMs and retries → infinite `creating` churn,
- the controller then **silently falls back to the default provider (`claude`)** — so rig agents run on the wrong/expensive model instead of the configured local one (and silently burn Claude credits).

City-scoped agents (deacon, dog, …) are unaffected — they stage the overlay correctly.

## Root cause

The `worker.Factory` **create** and **resume** paths build `runtime.Config` directly and never route through `resolveTemplate` (the canonical create-time sourcing the reconciler/city path uses). So they leave `ProviderOverlayName`, `PackOverlayDirs`, and `InstallAgentHooks` empty. `runtime.OverlayProviderNames` then falls back to `ProviderName=""` and `StageProviderOverlayDir` stages nothing. The **resume** path is the one that churns live rig agents into the claude fallback.

## Fix

Add `applyWorkerOverlayHints` (`cmd/gc/worker_handle.go`), called at both worker sites, which populates the overlay-staging fields by mirroring `resolveTemplate`'s sourcing **line-for-line**, reusing existing helpers (`resolvedProviderLaunchFamily`, `config.ResolveInstallHooks`, `effectiveOverlayDirs`, `sessionSetupContextForAgent`) — no duplicated overlay logic, no signature changes. This brings the worker paths to parity with the already-correct city path.

Includes a regression test (`cmd/gc/worker_handle_test.go`) asserting the worker resume/create path now sets `ProviderOverlayName` / `ProviderName` / `PackOverlayDirs` for a rig agent on a `base="builtin:pi"` provider — it **fails without the fix** (`ProviderOverlayName = "", want "pi-vllm"`) and passes with it.

## Verification

- `go build ./...` and `go vet ./internal/worker/... ./internal/runtime/... ./cmd/gc/` — clean.
- `go test ./internal/runtime/... ./internal/worker/... ./cmd/gc/` (targeted) — green.
- New regression test fails without the fix, passes with it.

## Secondary issue (not addressed here — flagged for follow-up)

When an agent configured for provider X fails its readiness handshake, the controller silently relaunches it on the default provider (`claude`) rather than surfacing the failure. That silent provider swap masks exactly this class of bug (and silently spends Claude credits). Worth a separate change to fail loudly / quarantine with an attributed reason when a configured provider can't start on its configured provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
