### PR TITLE
fix(beads): clarify native-store Dolt mode fallback

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -248,6 +248,40 @@ rig `.beads/hooks/` directory to allow native store adoption. Keep
 `GC_BEADS_FORCE_FALLBACK=1` set when a deployment still depends on those hook
 scripts directly.
 
+## Native Store Falls Back Because Dolt Is in Embedded Mode
+
+**Symptom:** `gc status` or `gc session list` is slower than expected, or
+`gc doctor` reports `native_store_unavailable gate=dolt_mode_safe`.
+
+Gas City's native in-process beads store requires that `bd context` reports
+`dolt_mode=server`. When `bd` is configured with an embedded Dolt instance (the
+default for a freshly installed `bd`), the `dolt_mode_safe` gate fails and Gas
+City falls back to invoking the `bd` CLI as a subprocess for every store
+operation. Each subprocess call adds tens to hundreds of milliseconds of
+overhead, which accumulates noticeably during `gc status` and `gc session list`.
+
+**Remedy:** Run `bd` against a Dolt SQL server so that `bd context` reports
+`dolt_mode=server`:
+
+```bash
+# Start a local Dolt SQL server (one-time setup)
+dolt sql-server --port 28231
+
+# Confirm bd resolves server mode
+bd context --json | grep dolt_mode
+# expected: "dolt_mode": "server"
+```
+
+Once `bd context` reports `dolt_mode=server`, `gc doctor` will clear the
+`dolt_mode_safe` gate and Gas City will use the native store automatically
+on the next start.
+
+<Note>
+The `gascity_native_beads` build tag visible in some source files is a
+test-only mechanism — it requires `GC_NATIVE_DOLTLITE_BEADS=true` and is
+not a supported operator path. Use Dolt server mode instead.
+</Note>
+
 ## flock Not Found (macOS)
 
 macOS does not ship `flock`. Install it via Homebrew:

--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -183,7 +183,7 @@ func (c PreflightChecker) checkDoltModeSafe(metadata preflightMetadata, ctx Pref
 	case "server":
 		return NewPreflightCheckResult(PreflightCheckDoltModeSafe, PreflightCheckPass, "bd context reports dolt server mode", details)
 	case "embedded":
-		return NewPreflightCheckResult(PreflightCheckDoltModeSafe, PreflightCheckFail, "dolt_mode=embedded requires server mode or native_embedded build tag", details)
+		return NewPreflightCheckResult(PreflightCheckDoltModeSafe, PreflightCheckFail, "dolt_mode=embedded; native store requires Dolt server mode (bd context must report dolt_mode=server) — falling back to per-call bd. See troubleshooting.", details)
 	default:
 		return NewPreflightCheckResult(PreflightCheckDoltModeSafe, PreflightCheckFail, "bd context reports unsupported dolt mode", details)
 	}

--- a/release-gates/ga-i9brye-native-store-preflight-gate.md
+++ b/release-gates/ga-i9brye-native-store-preflight-gate.md
@@ -1,0 +1,39 @@
+# Release Gate: native-store preflight diagnostic docs
+
+Bead: `ga-i9brye`
+Source review bead: `ga-k2iovc`
+Source branch: `builder/ga-7v7qej-native-embedded-diag`
+Release branch: `release/ga-i9brye-native-store-preflight`
+Reviewed commit: `f7a16b332b92209ec1fb481f9e5b74243d79a3f3`
+Base: `origin/main` at `4c3b612b7fc0cbfff01ae527a9dcd4a1e9ee5741`
+
+The prompted `docs/PROJECT_MANIFEST.md` path is not present in this Gas City
+checkout. No Gas City `PROJECT_MANIFEST.md` or `SOFTWARE_FACTORY_MANIFEST.md`
+was found under the repository or management tree, so this gate uses the
+deployer release criteria from the role prompt.
+
+## Diff Scope
+
+`git diff --name-status origin/main..HEAD`:
+
+```text
+M	docs/getting-started/troubleshooting.md
+M	internal/beads/contract/preflight_checker.go
+```
+
+This is one release unit: the preflight error message and the matching
+troubleshooting documentation for the same `dolt_mode_safe` fallback.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-k2iovc` reports `REVIEW VERDICT: PASS`, reviewer `gascity/reviewer`, commit `f7a16b332b92209ec1fb481f9e5b74243d79a3f3`. |
+| 2 | Acceptance criteria met | PASS | `rg -n "native_embedded" internal/beads/contract/preflight_checker.go docs/getting-started/troubleshooting.md` returned no matches. `rg -n "dolt_mode=server\|Dolt server mode\|dolt_mode_safe\|per-call bd" ...` shows the new failure message in `preflight_checker.go:186` and the troubleshooting remedy in `docs/getting-started/troubleshooting.md:254-282`. The diff changes only the diagnostic string plus the matching docs page. |
+| 3 | Tests pass | PASS | `go test ./internal/beads/contract` passed. `make check-docs` passed. `go test ./test/docsync` passed. `go build -o /tmp/gc-ga-i9brye ./cmd/gc` passed. `go vet ./...` passed. `make test-fast-parallel` passed with all fast shards green. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-k2iovc` contain only `[PASS]` and `[INFO]` findings, with `SECURITY: Pure string + docs change. No injection surface, no auth/access change. No OWASP concerns.` |
+| 5 | Final branch is clean | PASS | Before this gate file, `git status --short --branch` returned only `## release/ga-i9brye-native-store-preflight`. After committing this gate file, the same command again returned only `## release/ga-i9brye-native-store-preflight`. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` passed and printed `origin/main is ancestor of HEAD`; the reviewed commit is directly based on `origin/main`. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem and one docs page for the same user-visible behavior: explaining and documenting native-store fallback when `bd context` reports embedded Dolt mode. |
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

Gas City no longer tells operators to use the nonexistent `native_embedded` build tag when native beads storage sees `dolt_mode=embedded`. The preflight diagnostic now says native storage requires Dolt server mode, names the exact `bd context` value operators should see, and makes clear that Gas City falls back to per-call `bd` while the gate is not satisfied.

The troubleshooting guide now has a matching section for `native_store_unavailable gate=dolt_mode_safe`, including the symptom, why the fallback is slower, and the server-mode setup check operators can run.

## Review notes

- Runtime behavior is unchanged; this is a diagnostic string plus public troubleshooting docs.
- `gascity_native_beads` remains documented as test-only, not as an operator remedy.
- No API, generated schema, dashboard, or config shape changes are included.

## Test plan

- [x] `go test ./internal/beads/contract`
- [x] `make check-docs`
- [x] `go test ./test/docsync`
- [x] `go build -o /tmp/gc-ga-i9brye ./cmd/gc`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Pre-push hook fast suite during `git push -u origin release/ga-i9brye-native-store-preflight`
- [x] Release gate: [`release-gates/ga-i9brye-native-store-preflight-gate.md`](release-gates/ga-i9brye-native-store-preflight-gate.md)