### PR TITLE
Fix formula lookup for names passed with extensions

### DIFF
--- a/internal/formula/resolve.go
+++ b/internal/formula/resolve.go
@@ -3,6 +3,7 @@ package formula
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // extOrder is the within-layer extension precedence used by Resolve:
@@ -32,6 +33,13 @@ func Resolve(layers []string, name string) (string, bool) {
 func ResolveWithSource(src Source, layers []string, name string) (string, bool) {
 	if src == nil {
 		src = FSSource{}
+	}
+	// Strip any known extension the caller may have passed (e.g. "loop-flow.toml"
+	// → "loop-flow") so name+ext never doubles it (GitHub #3704).
+	if trimmed, ok := TrimTOMLFilename(name); ok {
+		name = trimmed
+	} else {
+		name = strings.TrimSuffix(name, FormulaExtJSON)
 	}
 	for i := len(layers) - 1; i >= 0; i-- {
 		for _, ext := range extOrder {

--- a/internal/formula/resolve_test.go
+++ b/internal/formula/resolve_test.go
@@ -211,6 +211,60 @@ func TestResolveAndResolveAll_AgreeOnPath(t *testing.T) {
 	}
 }
 
+// TestResolve_ExtensionPassThrough guards that Resolve accepts formula names
+// supplied with their file extension already attached (e.g. "mol-a.toml",
+// "mol-a.formula.toml", "mol-a.formula.json"). All three must resolve to the
+// same path as the bare name "mol-a". This covers the CLI pattern
+// `gc formula show loop-flow.toml` (GitHub #3704).
+func TestResolve_ExtensionPassThrough(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("canonical_toml", func(t *testing.T) {
+		want := writeLayerFile(t, dir, "mol-a.toml", "")
+		bare, okBare := Resolve([]string{dir}, "mol-a")
+		withExt, okExt := Resolve([]string{dir}, "mol-a.toml")
+		if !okBare {
+			t.Fatal("Resolve(mol-a): not found")
+		}
+		if !okExt {
+			t.Fatal("Resolve(mol-a.toml): not found")
+		}
+		if bare != want || withExt != want {
+			t.Errorf("Resolve(bare)=%q Resolve(.toml)=%q want %q", bare, withExt, want)
+		}
+	})
+
+	t.Run("legacy_toml", func(t *testing.T) {
+		want := writeLayerFile(t, dir, "mol-b.formula.toml", "")
+		bare, okBare := Resolve([]string{dir}, "mol-b")
+		withExt, okExt := Resolve([]string{dir}, "mol-b.formula.toml")
+		if !okBare {
+			t.Fatal("Resolve(mol-b): not found")
+		}
+		if !okExt {
+			t.Fatal("Resolve(mol-b.formula.toml): not found")
+		}
+		if bare != want || withExt != want {
+			t.Errorf("Resolve(bare)=%q Resolve(.formula.toml)=%q want %q", bare, withExt, want)
+		}
+	})
+
+	t.Run("formula_json", func(t *testing.T) {
+		want := writeLayerFile(t, dir, "mol-c.formula.json", "")
+		bare, okBare := Resolve([]string{dir}, "mol-c")
+		withExt, okExt := Resolve([]string{dir}, "mol-c.formula.json")
+		if !okBare {
+			t.Fatal("Resolve(mol-c): not found")
+		}
+		if !okExt {
+			t.Fatal("Resolve(mol-c.formula.json): not found")
+		}
+		if bare != want || withExt != want {
+			t.Errorf("Resolve(bare)=%q Resolve(.formula.json)=%q want %q", bare, withExt, want)
+		}
+	})
+}
+
 // TestLoadByName_LastWinsAcrossLayers is the parser-level regression test
 // for the bug Resolve fixes: parser.loadFormula previously iterated layers
 // first-wins, inverting the lowest→highest priority contract that the

--- a/release-gates/ga-cch93d-formula-ext-gate.md
+++ b/release-gates/ga-cch93d-formula-ext-gate.md
@@ -1,0 +1,47 @@
+# Release Gate: Formula Extension Pass-Through
+
+Decision: PASS
+
+## Scope
+
+- Deploy bead: ga-cch93d
+- Source review bead: ga-negyxm
+- Branch: builder/ga-8ymdco-formula-ext-fix
+- Candidate commit: 4417eb5edc68066d79f173cd79044ed5ec81e2ec
+- Base: origin/main 4c3b612b7fc0cbfff01ae527a9dcd4a1e9ee5741
+- Shape: single-bead PR
+
+This release fixes formula name resolution when callers pass a formula file
+name with an existing known extension, such as `loop-flow.toml`,
+`loop-flow.formula.toml`, or `loop-flow.formula.json`. The change strips the
+known extension before the resolver probes the configured extension order, so
+callers no longer end up probing doubled names like `loop-flow.toml.toml`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead ga-negyxm is closed with `REVIEW VERDICT: PASS` for commit 4417eb5edc68066d79f173cd79044ed5ec81e2ec. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `internal/formula/resolve.go` and `internal/formula/resolve_test.go`. `ResolveWithSource` now strips known caller-supplied formula extensions before probing. `TestResolve_ExtensionPassThrough` covers `.toml`, `.formula.toml`, and `.formula.json`. CLI smoke verified `gc formula show loop-flow` and `gc formula show loop-flow.toml` render identical output in a scratch city. |
+| 3 | Tests pass | PASS | `go test ./internal/formula` passed. `make test-fast-parallel` passed all fast shards. `go vet ./...` passed. `go build -o /tmp/gc-ga-cch93d ./cmd/gc` passed. |
+| 4 | No high-severity review findings open | PASS | Review bead findings are all `[PASS]`; no unresolved HIGH or CRITICAL findings appear in the deploy or review bead notes. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before adding this gate file. The only deployer-authored change is this release gate checklist. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` passed on the candidate branch; the feature commit is directly on current `origin/main`. |
+| 7 | Single feature theme | PASS | Commit set is one formula resolver fix plus focused tests in `internal/formula`; no unrelated packages or user-facing themes are included. |
+
+## Commands Run
+
+```text
+go test ./internal/formula
+make test-fast-parallel
+go vet ./...
+go build -o /tmp/gc-ga-cch93d ./cmd/gc
+timeout 20 /tmp/gc-ga-cch93d --city <scratch-city> formula show loop-flow
+timeout 20 /tmp/gc-ga-cch93d --city <scratch-city> formula show loop-flow.toml
+```
+
+The scratch `formula cook loop-flow.toml` runtime smoke was attempted but not
+used as release evidence because the scratch city lacked a fully initialized
+native bead-store identity for cooking. That setup failure is outside the
+candidate diff; the resolver path used by show and cook is covered by
+`TestResolve_ExtensionPassThrough` and the passing fast suite.


### PR DESCRIPTION
## What this changes

Formula lookup now accepts names that already include a supported formula file extension. Commands and code paths that pass `loop-flow.toml`, `loop-flow.formula.toml`, or `loop-flow.formula.json` resolve the same formula they would have resolved from `loop-flow`, instead of probing doubled filenames such as `loop-flow.toml.toml`.

The normalization is placed inside `internal/formula.ResolveWithSource`, so CLI display paths and cook/compile paths share the same behavior while preserving the existing extension precedence order: `.toml`, then `.formula.toml`, then `.formula.json`.

## Review notes

- The behavior change is limited to formula name normalization in `internal/formula`.
- Extension precedence and layer precedence are unchanged.
- There are no config, API, schema, or migration changes.

## Test plan

- [x] `go test ./internal/formula`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build -o /tmp/gc-ga-cch93d ./cmd/gc`
- [x] Scratch-city smoke: `gc formula show loop-flow` and `gc formula show loop-flow.toml` render identical output.
- [x] Release gate: [`release-gates/ga-cch93d-formula-ext-gate.md`](release-gates/ga-cch93d-formula-ext-gate.md)