### PR TITLE
Improve formula loop.count error guidance

### DIFF
--- a/docs/tutorials/05-formulas.md
+++ b/docs/tutorials/05-formulas.md
@@ -513,6 +513,12 @@ one of `count`, `until`, or `range`; `range = "1..3"` with `var = "n"` is a
 compile-time cousin of `count` that exposes `{n}` for substitution in the body.
 When you mean "keep trying until it works," use **Check** below.
 
+<Note>
+`count` accepts an integer literal only — template variables such as `{{var}}` are
+not supported in `count`. For a variable-driven iteration count, use
+`range = "1..{n}"` with `var = "n"` instead.
+</Note>
+
 <Accordion title="The `until` loop and its caveat">
 An `until` loop expands one iteration at compile time and stamps the condition
 (plus a required `max` budget) on it:

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -2343,3 +2343,40 @@ type = "task"
 		t.Fatalf("metadata.gc.methodology.review_modes = %+v, want %+v", got.GC.Methodology.ReviewModes, want)
 	}
 }
+
+func TestCompile_LoopCountStringParseError(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "loop-count-string"
+version = 1
+
+[vars.cups]
+description = "Cup count"
+required = true
+
+[[steps]]
+id = "brew"
+title = "Brew"
+
+[steps.brew.loop]
+count = "{{cups}}"
+
+[[steps.brew.loop.body]]
+id = "pour"
+title = "Pour"
+`
+	if err := os.WriteFile(filepath.Join(dir, "loop-count-string.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Compile(context.Background(), "loop-count-string", []string{dir}, nil)
+	if err == nil {
+		t.Fatal("Compile should reject string-valued loop.count")
+	}
+	if !strings.Contains(err.Error(), "integer") {
+		t.Errorf("error = %q, want to mention 'integer'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "range") {
+		t.Errorf("error = %q, want to mention 'range'", err.Error())
+	}
+}

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -2358,10 +2358,10 @@ required = true
 id = "brew"
 title = "Brew"
 
-[steps.brew.loop]
+[steps.loop]
 count = "{{cups}}"
 
-[[steps.brew.loop.body]]
+[[steps.loop.body]]
 id = "pour"
 title = "Pour"
 `

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -398,6 +398,12 @@ func (s *Step) UnmarshalTOML(data interface{}) error {
 		return fmt.Errorf("type mismatch for formula.Step: expected table but found %T", data)
 	}
 
+	if loopRaw, ok := raw["loop"].(map[string]interface{}); ok {
+		if _, isStr := loopRaw["count"].(string); isStr {
+			return fmt.Errorf("loop.count must be an integer literal (e.g. count = 3); template variables are not supported — use range = \"1..{n}\" with var = \"n\" for variable-driven counts")
+		}
+	}
+
 	encoded, err := json.Marshal(raw)
 	if err != nil {
 		return fmt.Errorf("encode formula.Step: %w", err)

--- a/release-gates/ga-j40p4l-loop-count-friendly-error-gate.md
+++ b/release-gates/ga-j40p4l-loop-count-friendly-error-gate.md
@@ -1,59 +1,42 @@
-# Release Gate: ga-j40p4l loop.count friendly error UX
+# Release Gate: Loop Count Friendly Error
 
-Date: 2026-06-24
+Decision: PASS
 
-Branch: `release/ga-j40p4l-loop-count-friendly-error`
-Head before gate commit: `0a2b1e7edac3c1c9bf8d716652965d5d10266bfb`
-Base: `origin/main`
-Deploy bead: `ga-j40p4l`
-Source review bead: `ga-acfcqc`
+## Scope
 
-Note: this repo does not contain `docs/PROJECT_MANIFEST.md`; no Gas City
-project manifest was found with `rg --files -g PROJECT_MANIFEST.md` or `find`.
-This gate uses the deployer prompt release criteria and the repo gates in
-`TESTING.md` plus `gascity-docs` verification rules for the tutorial change.
+- Deploy bead: ga-j40p4l
+- Source review bead: ga-acfcqc
+- Reviewed commit: 0a2b1e7edac3c1c9bf8d716652965d5d10266bfb
+- Actual source branch: builder/ga-sdv68f-loop-count-friendly-error
+- Release branch: release/ga-j40p4l-loop-count-friendly-error
+- Base: origin/main 4c3b612b7fc0cbfff01ae527a9dcd4a1e9ee5741
+- Shape: single-bead PR
 
-## Summary
-
-PASS. The branch is a single feature theme: make string-valued
-`loop.count` fail with an actionable formula compile error and document the
-integer-literal requirement in the formulas tutorial.
+The deploy bead listed the branch as `main`, but the reviewed commit is present
+on `origin/builder/ga-sdv68f-loop-count-friendly-error` and not on
+`origin/main`. This gate uses a clean release branch cut from the reviewed
+commit so the PR has a valid feature head and does not depend on a dirty local
+builder worktree.
 
 ## Criteria
 
 | # | Criterion | Result | Evidence |
-|---|---|---|---|
-| 1 | Review PASS present | PASS | `ga-acfcqc` is closed with reason `pass`; notes contain `Review Verdict: PASS` from `reviewer-gm-wisp-22n14q2` dated 2026-06-24. |
-| 2 | Acceptance criteria met | PASS | `internal/formula/types.go` rejects string-valued `loop.count` before JSON decoding; `internal/formula/compile_test.go` adds `TestCompile_LoopCountStringParseError`; `docs/tutorials/05-formulas.md` notes integer-only `count` and points variable-driven counts to `range = "1..{n}"` with `var = "n"`. |
-| 3 | Tests pass | PASS | Focused test, formula package, full fast baseline, vet, and docs sync all passed. Details below. |
-| 4 | No high-severity review findings open | PASS | Review notes list one LOW style/wording finding; no HIGH findings. |
-| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before writing this gate file; the gate file is committed as the final branch tip. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` exited 0; `git merge-tree origin/main HEAD` returned a tree id with no conflict output. |
-| 7 | Single feature theme | PASS | Diff is limited to `internal/formula` parser behavior/tests and the matching formulas tutorial note. |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead ga-acfcqc is closed with `Review Verdict: PASS` for commit 0a2b1e7edac3c1c9bf8d716652965d5d10266bfb. |
+| 2 | Acceptance criteria met | PASS | Branch delta adds a pre-check in `internal/formula/types.go` so string-valued `loop.count` fails with a friendly message that points users to `range = "1..{n}"` plus `var = "n"`. `TestCompile_LoopCountStringParseError` covers the parse error. `docs/tutorials/05-formulas.md` documents that `count` accepts only integer literals and points variable-driven loops to `range`. |
+| 3 | Tests pass | PASS | `make check-docs`, `go test ./internal/formula -run TestCompile_LoopCountStringParseError`, `go test ./internal/formula`, `make test-fast-parallel`, `go vet ./...`, and `go build -o /tmp/gc-ga-j40p4l ./cmd/gc` all passed. |
+| 4 | No high-severity review findings open | PASS | Review findings are PASS/LOW only; no unresolved HIGH or CRITICAL findings appear in the deploy or review bead notes. |
+| 5 | Final branch is clean | PASS | The gate ran in a dedicated clean worktree on `release/ga-j40p4l-loop-count-friendly-error`; `git status --short --branch` was clean before adding this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` passed on the reviewed commit; the release branch is a straight descendant of current `origin/main`. |
+| 7 | Single feature theme | PASS | Commit set is one formula parser UX fix, one focused regression test, and one tutorial note for the same `loop.count` behavior. |
 
-## Test Evidence
+## Commands Run
 
-- PASS: `git diff --check origin/main..HEAD`
-- PASS: `go test ./internal/formula/ -run TestCompile_LoopCountStringParseError -count=1`
-  - `ok github.com/gastownhall/gascity/internal/formula 0.003s`
-- PASS: `go test ./internal/formula/...`
-  - `ok github.com/gastownhall/gascity/internal/formula 0.263s`
-- PASS: `go vet ./internal/formula/...`
-- PASS: `make check-docs`
-  - `ok github.com/gastownhall/gascity/test/docsync (cached)`
-- PASS: `go vet ./...`
-- PASS: `make test-fast-parallel`
-  - `All fast jobs passed`
-
-## Commit Set
-
-- `50bc876a4` - `test(formula): regression coverage for loop.count string parse errors (ga-sdv68f.1)`
-- `2703d79d1` - `fix(formula): friendly error when loop.count is a string or template value (ga-sdv68f.3)`
-- `0a2b1e7ed` - `docs(formula): note that loop.count is integer-only; point to range for variable counts (ga-sdv68f.2)`
-
-## Changed Paths
-
-- `internal/formula/types.go`
-- `internal/formula/compile_test.go`
-- `docs/tutorials/05-formulas.md`
-
+```text
+make check-docs
+go test ./internal/formula -run TestCompile_LoopCountStringParseError
+go test ./internal/formula
+make test-fast-parallel
+go vet ./...
+go build -o /tmp/gc-ga-j40p4l ./cmd/gc
+```

--- a/release-gates/ga-j40p4l-loop-count-friendly-error-gate.md
+++ b/release-gates/ga-j40p4l-loop-count-friendly-error-gate.md
@@ -1,0 +1,59 @@
+# Release Gate: ga-j40p4l loop.count friendly error UX
+
+Date: 2026-06-24
+
+Branch: `release/ga-j40p4l-loop-count-friendly-error`
+Head before gate commit: `0a2b1e7edac3c1c9bf8d716652965d5d10266bfb`
+Base: `origin/main`
+Deploy bead: `ga-j40p4l`
+Source review bead: `ga-acfcqc`
+
+Note: this repo does not contain `docs/PROJECT_MANIFEST.md`; no Gas City
+project manifest was found with `rg --files -g PROJECT_MANIFEST.md` or `find`.
+This gate uses the deployer prompt release criteria and the repo gates in
+`TESTING.md` plus `gascity-docs` verification rules for the tutorial change.
+
+## Summary
+
+PASS. The branch is a single feature theme: make string-valued
+`loop.count` fail with an actionable formula compile error and document the
+integer-literal requirement in the formulas tutorial.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `ga-acfcqc` is closed with reason `pass`; notes contain `Review Verdict: PASS` from `reviewer-gm-wisp-22n14q2` dated 2026-06-24. |
+| 2 | Acceptance criteria met | PASS | `internal/formula/types.go` rejects string-valued `loop.count` before JSON decoding; `internal/formula/compile_test.go` adds `TestCompile_LoopCountStringParseError`; `docs/tutorials/05-formulas.md` notes integer-only `count` and points variable-driven counts to `range = "1..{n}"` with `var = "n"`. |
+| 3 | Tests pass | PASS | Focused test, formula package, full fast baseline, vet, and docs sync all passed. Details below. |
+| 4 | No high-severity review findings open | PASS | Review notes list one LOW style/wording finding; no HIGH findings. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before writing this gate file; the gate file is committed as the final branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` exited 0; `git merge-tree origin/main HEAD` returned a tree id with no conflict output. |
+| 7 | Single feature theme | PASS | Diff is limited to `internal/formula` parser behavior/tests and the matching formulas tutorial note. |
+
+## Test Evidence
+
+- PASS: `git diff --check origin/main..HEAD`
+- PASS: `go test ./internal/formula/ -run TestCompile_LoopCountStringParseError -count=1`
+  - `ok github.com/gastownhall/gascity/internal/formula 0.003s`
+- PASS: `go test ./internal/formula/...`
+  - `ok github.com/gastownhall/gascity/internal/formula 0.263s`
+- PASS: `go vet ./internal/formula/...`
+- PASS: `make check-docs`
+  - `ok github.com/gastownhall/gascity/test/docsync (cached)`
+- PASS: `go vet ./...`
+- PASS: `make test-fast-parallel`
+  - `All fast jobs passed`
+
+## Commit Set
+
+- `50bc876a4` - `test(formula): regression coverage for loop.count string parse errors (ga-sdv68f.1)`
+- `2703d79d1` - `fix(formula): friendly error when loop.count is a string or template value (ga-sdv68f.3)`
+- `0a2b1e7ed` - `docs(formula): note that loop.count is integer-only; point to range for variable counts (ga-sdv68f.2)`
+
+## Changed Paths
+
+- `internal/formula/types.go`
+- `internal/formula/compile_test.go`
+- `docs/tutorials/05-formulas.md`
+


### PR DESCRIPTION
## What this changes

Formula compilation now catches string-valued `loop.count` before the generic
TOML decoding path. If a user writes `count = "{{cups}}"`, Gas City returns a
clear error that `count` must be an integer literal and points variable-driven
loops to `range = "1..{n}"` with `var = "n"`.

The formulas tutorial now calls out the same rule next to the `count`, `range`,
and `until` loop explanation, so users see the supported pattern before they hit
the compiler error.

## Review notes

- `LoopSpec.Count` and the internal TOML alias remain `int`; this does not widen
  the schema or accept templated counts.
- The new error message is static and does not echo user-supplied formula text.
- The docs change is limited to `docs/tutorials/05-formulas.md`; no generated
  docs, OpenAPI, or dashboard files are involved.

## Test plan

- [x] `go test ./internal/formula -run TestCompile_LoopCountStringParseError`
- [x] `go test ./internal/formula`
- [x] `make check-docs`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] `go build -o /tmp/gc-ga-j40p4l ./cmd/gc`
- [x] Release gate: [`release-gates/ga-j40p4l-loop-count-friendly-error-gate.md`](release-gates/ga-j40p4l-loop-count-friendly-error-gate.md)
