### PR TITLE
Improve loop.count error for variable counts

### DIFF
--- a/docs/tutorials/05-formulas.md
+++ b/docs/tutorials/05-formulas.md
@@ -513,6 +513,12 @@ one of `count`, `until`, or `range`; `range = "1..3"` with `var = "n"` is a
 compile-time cousin of `count` that exposes `{n}` for substitution in the body.
 When you mean "keep trying until it works," use **Check** below.
 
+<Note>
+`count` accepts an integer literal only — template variables such as `{{var}}` are
+not supported in `count`. For a variable-driven iteration count, use
+`range = "1..{n}"` with `var = "n"` instead.
+</Note>
+
 <Accordion title="The `until` loop and its caveat">
 An `until` loop expands one iteration at compile time and stamps the condition
 (plus a required `max` budget) on it:

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -2343,3 +2343,40 @@ type = "task"
 		t.Fatalf("metadata.gc.methodology.review_modes = %+v, want %+v", got.GC.Methodology.ReviewModes, want)
 	}
 }
+
+func TestCompile_LoopCountStringParseError(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "loop-count-string"
+version = 1
+
+[vars.cups]
+description = "Cup count"
+required = true
+
+[[steps]]
+id = "brew"
+title = "Brew"
+
+[steps.brew.loop]
+count = "{{cups}}"
+
+[[steps.brew.loop.body]]
+id = "pour"
+title = "Pour"
+`
+	if err := os.WriteFile(filepath.Join(dir, "loop-count-string.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Compile(context.Background(), "loop-count-string", []string{dir}, nil)
+	if err == nil {
+		t.Fatal("Compile should reject string-valued loop.count")
+	}
+	if !strings.Contains(err.Error(), "integer") {
+		t.Errorf("error = %q, want to mention 'integer'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "range") {
+		t.Errorf("error = %q, want to mention 'range'", err.Error())
+	}
+}

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -2358,10 +2358,10 @@ required = true
 id = "brew"
 title = "Brew"
 
-[steps.brew.loop]
+[steps.loop]
 count = "{{cups}}"
 
-[[steps.brew.loop.body]]
+[[steps.loop.body]]
 id = "pour"
 title = "Pour"
 `

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -398,6 +398,12 @@ func (s *Step) UnmarshalTOML(data interface{}) error {
 		return fmt.Errorf("type mismatch for formula.Step: expected table but found %T", data)
 	}
 
+	if loopRaw, ok := raw["loop"].(map[string]interface{}); ok {
+		if _, isStr := loopRaw["count"].(string); isStr {
+			return fmt.Errorf("loop.count must be an integer literal (e.g. count = 3); template variables are not supported — use range = \"1..{n}\" with var = \"n\" for variable-driven counts")
+		}
+	}
+
 	encoded, err := json.Marshal(raw)
 	if err != nil {
 		return fmt.Errorf("encode formula.Step: %w", err)

--- a/release-gates/ga-j40p4l-loop-count-friendly-error-gate.md
+++ b/release-gates/ga-j40p4l-loop-count-friendly-error-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: Loop Count Friendly Error
+
+Decision: PASS
+
+## Scope
+
+- Deploy bead: ga-j40p4l
+- Source review bead: ga-acfcqc
+- Reviewed commit: 0a2b1e7edac3c1c9bf8d716652965d5d10266bfb
+- Actual source branch: builder/ga-sdv68f-loop-count-friendly-error
+- Release branch: release/ga-j40p4l-loop-count-friendly-error-clean
+- Base: origin/main 4c3b612b7fc0cbfff01ae527a9dcd4a1e9ee5741
+- Shape: single-bead PR
+
+The deploy bead listed the branch as `main`, but the reviewed commit is present
+on `origin/builder/ga-sdv68f-loop-count-friendly-error` and not on
+`origin/main`. This gate uses a clean release branch cut from the reviewed
+commit so the PR has a valid feature head and does not depend on a dirty local
+builder worktree.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead ga-acfcqc is closed with `Review Verdict: PASS` for commit 0a2b1e7edac3c1c9bf8d716652965d5d10266bfb. |
+| 2 | Acceptance criteria met | PASS | Branch delta adds a pre-check in `internal/formula/types.go` so string-valued `loop.count` fails with a friendly message that points users to `range = "1..{n}"` plus `var = "n"`. `TestCompile_LoopCountStringParseError` covers the parse error. `docs/tutorials/05-formulas.md` documents that `count` accepts only integer literals and points variable-driven loops to `range`. |
+| 3 | Tests pass | PASS | `make check-docs`, `go test ./internal/formula -run TestCompile_LoopCountStringParseError`, `go test ./internal/formula`, `make test-fast-parallel`, `go vet ./...`, and `go build -o /tmp/gc-ga-j40p4l ./cmd/gc` all passed. |
+| 4 | No high-severity review findings open | PASS | Review findings are PASS/LOW only; no unresolved HIGH or CRITICAL findings appear in the deploy or review bead notes. |
+| 5 | Final branch is clean | PASS | The gate ran in a dedicated clean worktree on `release/ga-j40p4l-loop-count-friendly-error-clean`; `git status --short --branch` was clean before adding this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` passed on the reviewed commit; the release branch is a straight descendant of current `origin/main`. |
+| 7 | Single feature theme | PASS | Commit set is one formula parser UX fix, one focused regression test, and one tutorial note for the same `loop.count` behavior. |
+
+## Commands Run
+
+```text
+make check-docs
+go test ./internal/formula -run TestCompile_LoopCountStringParseError
+go test ./internal/formula
+make test-fast-parallel
+go vet ./...
+go build -o /tmp/gc-ga-j40p4l ./cmd/gc
+```


### PR DESCRIPTION
## What this changes

Formula parsing now catches `loop.count` values written as strings, including template-looking values such as `"{{cups}}"`, before the generic TOML decode path reports a low-level type mismatch. The error tells the user that `count` must be an integer literal and points variable-driven loops to `range = "1..{n}"` with `var = "n"`.

The formulas tutorial now carries the same guidance next to the loop examples, so users see the supported pattern before they hit the parser error.

## Review notes

- The code change is a pre-check in `internal/formula.Step.UnmarshalTOML`; it keeps `loop.count` typed as `int` and does not change formula schema shape.
- The regression coverage is in `internal/formula/compile_test.go` at the compile level.
- The docs change is limited to `docs/tutorials/05-formulas.md`; there are no generated docs, API, dashboard, or config changes.

## Test plan

- [x] `make check-docs`
- [x] `go test ./internal/formula -run TestCompile_LoopCountStringParseError`
- [x] `go test ./internal/formula`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build -o /tmp/gc-ga-j40p4l ./cmd/gc`
- [x] Release gate: [`release-gates/ga-j40p4l-loop-count-friendly-error-gate.md`](release-gates/ga-j40p4l-loop-count-friendly-error-gate.md)