### PR TITLE
fix(beads): match bd's plural not-found envelope + offline corpus decoder tests (contract Phase 4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,10 @@ update-bundled-gastown-pack:
 test-native-doltlite-beads:
 	$(TEST_ENV) CGO_ENABLED=0 go test -tags gascity_native_beads ./internal/beads -count=1
 
+## sync-bd-corpus: vendor the bd contract corpus from a beads release (BD_CORPUS_TAG=vX.Y.Z)
+sync-bd-corpus:
+	scripts/sync-bd-corpus.sh
+
 ## test-cmd-gc-process: run the full non-short cmd/gc suite, including the
 ## process-backed lifecycle coverage routed out of the default fast loop
 test-cmd-gc-process:

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -792,13 +792,20 @@ func (b *bdIssue) normalizedDependencies() []Dep {
 }
 
 // isBdNotFound returns true if the error from bd CLI indicates a "not found" condition.
-// bd uses several phrasings: "no issue found", "issue not found", "not found".
+// bd uses several phrasings: "no issue found", "issue not found", "not found" on
+// stderr, and the plural "no issues found matching the provided IDs" in its
+// stdout --json error envelope. The plural form matters because
+// classifyBDExecResult falls back to the stdout envelope when stderr is empty,
+// which bd's --json error path increasingly is (see classifyBDExecResult); the
+// contract corpus pins this exact phrasing.
 func isBdNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "not found") || strings.Contains(msg, "no issue found")
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "no issue found") ||
+		strings.Contains(msg, "no issues found")
 }
 
 func isBdClaimConflictMessage(msg string) bool {

--- a/internal/beads/corpus_decoder_test.go
+++ b/internal/beads/corpus_decoder_test.go
@@ -1,0 +1,174 @@
+package beads
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// These tests replay the bd contract corpus — the canonicalized golden-JSON
+// blobs produced by the beads producer suite (cmd/bd/protocol) and vendored
+// under testdata/corpus/ — against gascity's REAL decoder paths. They run
+// offline (no bd, no Dolt) so every PR cheaply re-asserts that gascity still
+// decodes the bd --json shapes it depends on, and surfaces the v2.0 envelope
+// migration the moment bd flips it. Refresh the corpus with `make sync-bd-corpus`
+// during a deliberate bd pin bump (see
+// engdocs/design/beads-gascity-contract-test-system.md).
+
+const corpusDir = "testdata/corpus"
+
+// rehydrateTimestamps swaps the canonical "<TS>" placeholder for a real RFC3339
+// timestamp so blobs decode into bdIssue's time.Time fields. The committed
+// corpus stays canonicalized (the byte-stable cross-version diff anchor); only
+// the in-memory copy under test is rehydrated.
+func rehydrateTimestamps(b []byte) []byte {
+	return bytes.ReplaceAll(b, []byte(`"<TS>"`), []byte(`"2026-01-01T00:00:00Z"`))
+}
+
+func loadCorpusBlob(t *testing.T, rel string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(corpusDir, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("read corpus blob %s: %v (run `make sync-bd-corpus`)", rel, err)
+	}
+	return b
+}
+
+// TestCorpusFlatShowDecodes proves gascity's list/show decoder parses the
+// committed bd show shape into a fully-populated bdIssue, including the nested
+// dependency. A bd wire change to any of these fields breaks this offline.
+func TestCorpusFlatShowDecodes(t *testing.T) {
+	issues, err := parseIssuesTolerant(rehydrateTimestamps(loadCorpusBlob(t, "flat/show.json")))
+	if err != nil {
+		t.Fatalf("parseIssuesTolerant(flat/show): %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("flat/show: got %d issues, want 1", len(issues))
+	}
+	got := issues[0]
+	if got.ID != "corpus-root" {
+		t.Errorf("ID = %q, want corpus-root", got.ID)
+	}
+	if got.Status != "open" {
+		t.Errorf("Status = %q, want open", got.Status)
+	}
+	if got.IssueType != "feature" {
+		t.Errorf("IssueType = %q, want feature", got.IssueType)
+	}
+	if got.Priority == nil || *got.Priority != 1 {
+		t.Errorf("Priority = %v, want 1", got.Priority)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("CreatedAt is zero — the created_at timestamp did not decode")
+	}
+	if len(got.Dependencies) != 1 || got.Dependencies[0].ID != "corpus-dep" {
+		t.Errorf("Dependencies = %+v, want one dep corpus-dep", got.Dependencies)
+	}
+}
+
+// TestCorpusFlatListReadyDecode confirms the array-returning read commands
+// decode cleanly through the same tolerant parser gascity uses in production.
+func TestCorpusFlatListReadyDecode(t *testing.T) {
+	for _, name := range []string{"flat/list.json", "flat/ready.json"} {
+		if _, err := parseIssuesTolerant(rehydrateTimestamps(loadCorpusBlob(t, name))); err != nil {
+			t.Errorf("parseIssuesTolerant(%s): %v", name, err)
+		}
+	}
+}
+
+// TestCorpusCreateDecodesSingleIssue covers the create path, which returns a
+// bare issue object (not an array) that gascity decodes as a single bdIssue.
+func TestCorpusCreateDecodesSingleIssue(t *testing.T) {
+	var issue bdIssue
+	if err := json.Unmarshal(rehydrateTimestamps(loadCorpusBlob(t, "flat/create_root.json")), &issue); err != nil {
+		t.Fatalf("decode flat/create_root: %v", err)
+	}
+	if issue.ID != "corpus-root" {
+		t.Errorf("ID = %q, want corpus-root", issue.ID)
+	}
+	if issue.Title != "Corpus root issue" {
+		t.Errorf("Title = %q, want Corpus root issue", issue.Title)
+	}
+}
+
+// TestCorpusErrorEnvelopeClassified pins the {error, schema_version} not-found
+// envelope to gascity's two classifiers that depend on it.
+func TestCorpusErrorEnvelopeClassified(t *testing.T) {
+	detail := bdStdoutErrorDetail(loadCorpusBlob(t, "flat/error.json"))
+	if detail == "" {
+		t.Fatal("bdStdoutErrorDetail returned empty for the not-found error envelope")
+	}
+	if !isBdNotFound(errors.New(detail)) {
+		t.Errorf("isBdNotFound(%q) = false, want true", detail)
+	}
+}
+
+// TestCorpusV2EnvelopeIsForwardIncompatible documents — as an executable fact —
+// that gascity's current decoder does NOT understand the v2.0
+// {schema_version, data} envelope. When bd flips BD_JSON_ENVELOPE on by default
+// and gascity adds matching support, these expectations flip; the failure is
+// the signal to update them as part of the coordinated migration, not a
+// surprise in production.
+func TestCorpusV2EnvelopeIsForwardIncompatible(t *testing.T) {
+	if _, err := parseIssuesTolerant(rehydrateTimestamps(loadCorpusBlob(t, "envelope/show.json"))); err == nil {
+		t.Fatal("decoder parsed the v2 {schema_version,data} envelope; gascity gained v2 support — update the forward-compat expectations and the coordination protocol")
+	}
+	if detail := bdStdoutErrorDetail(loadCorpusBlob(t, "envelope/error.json")); detail != "" {
+		t.Fatalf("bdStdoutErrorDetail read the v2 error envelope (%q); gascity gained v2 error support — update expectations", detail)
+	}
+}
+
+// TestCorpusFieldsAreModeledOrExplicitlyIgnored is the bidirectional drift
+// detector. Every field bd emits in a show issue must be either decoded by
+// bdIssue or in the explicit ignore set below. A new bd field trips this test,
+// forcing a deliberate decision — model it or ignore it with a reason — instead
+// of silently dropping a capability.
+func TestCorpusFieldsAreModeledOrExplicitlyIgnored(t *testing.T) {
+	// bd-emitted fields gascity intentionally does not model. Each carries the
+	// reason so a future reader knows the omission is deliberate.
+	ignored := map[string]string{
+		"comment_count":    "display-only count; gc reads comments via a separate path",
+		"created_by":       "provenance; gc does not consume the creator identity",
+		"owner":            "bd-internal ownership; gc uses assignee instead",
+		"dependency_count": "derivable from dependencies; gc recomputes",
+		"dependent_count":  "reverse-dependency count; gc does not consume it",
+	}
+	known := bdIssueJSONTags(t)
+
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal(loadCorpusBlob(t, "flat/show.json"), &rows); err != nil {
+		t.Fatalf("decode flat/show as rows: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("flat/show is empty")
+	}
+	for field := range rows[0] {
+		if known[field] {
+			continue
+		}
+		if _, ok := ignored[field]; ok {
+			continue
+		}
+		t.Errorf("bd emits field %q that gascity neither decodes (bdIssue) nor explicitly ignores; model it or add it to the ignore set with a reason", field)
+	}
+}
+
+// bdIssueJSONTags returns the set of json field names bdIssue decodes, derived
+// by reflection so it stays in sync as the struct evolves.
+func bdIssueJSONTags(t *testing.T) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	tp := reflect.TypeOf(bdIssue{})
+	for i := 0; i < tp.NumField(); i++ {
+		name := strings.Split(tp.Field(i).Tag.Get("json"), ",")[0]
+		if name != "" && name != "-" {
+			out[name] = true
+		}
+	}
+	return out
+}

--- a/internal/beads/testdata/corpus/envelope/count.json
+++ b/internal/beads/testdata/corpus/envelope/count.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "count": 2
+  },
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/envelope/create_dep.json
+++ b/internal/beads/testdata/corpus/envelope/create_dep.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "created_at": "<TS>",
+    "created_by": "protocol-test",
+    "description": "deterministic corpus dependency",
+    "id": "corpus-dep",
+    "issue_type": "task",
+    "owner": "test@protocol.test",
+    "priority": 2,
+    "status": "open",
+    "title": "Corpus dependency issue",
+    "updated_at": "<TS>"
+  },
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/envelope/create_root.json
+++ b/internal/beads/testdata/corpus/envelope/create_root.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "created_at": "<TS>",
+    "created_by": "protocol-test",
+    "description": "deterministic corpus root",
+    "id": "corpus-root",
+    "issue_type": "feature",
+    "owner": "test@protocol.test",
+    "priority": 1,
+    "status": "open",
+    "title": "Corpus root issue",
+    "updated_at": "<TS>"
+  },
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/envelope/dep_add.json
+++ b/internal/beads/testdata/corpus/envelope/dep_add.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "depends_on_id": "corpus-dep",
+    "issue_id": "corpus-root",
+    "status": "added",
+    "type": "blocks"
+  },
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/envelope/dep_list.json
+++ b/internal/beads/testdata/corpus/envelope/dep_list.json
@@ -1,0 +1,18 @@
+{
+  "data": [
+    {
+      "created_at": "<TS>",
+      "created_by": "protocol-test",
+      "dependency_type": "blocks",
+      "description": "deterministic corpus dependency",
+      "id": "corpus-dep",
+      "issue_type": "task",
+      "owner": "test@protocol.test",
+      "priority": 2,
+      "status": "open",
+      "title": "Corpus dependency issue",
+      "updated_at": "<TS>"
+    }
+  ],
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/envelope/error.json
+++ b/internal/beads/testdata/corpus/envelope/error.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "error": "no issues found matching the provided IDs"
+  },
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/envelope/list.json
+++ b/internal/beads/testdata/corpus/envelope/list.json
@@ -1,0 +1,45 @@
+{
+  "data": [
+    {
+      "comment_count": 0,
+      "created_at": "<TS>",
+      "created_by": "protocol-test",
+      "dependency_count": 0,
+      "dependent_count": 1,
+      "description": "deterministic corpus dependency",
+      "id": "corpus-dep",
+      "issue_type": "task",
+      "owner": "test@protocol.test",
+      "priority": 2,
+      "status": "open",
+      "title": "Corpus dependency issue",
+      "updated_at": "<TS>"
+    },
+    {
+      "comment_count": 0,
+      "created_at": "<TS>",
+      "created_by": "protocol-test",
+      "dependencies": [
+        {
+          "created_at": "<TS>",
+          "created_by": "protocol-test",
+          "depends_on_id": "corpus-dep",
+          "issue_id": "corpus-root",
+          "metadata": "{}",
+          "type": "blocks"
+        }
+      ],
+      "dependency_count": 1,
+      "dependent_count": 0,
+      "description": "deterministic corpus root",
+      "id": "corpus-root",
+      "issue_type": "feature",
+      "owner": "test@protocol.test",
+      "priority": 1,
+      "status": "open",
+      "title": "Corpus root issue",
+      "updated_at": "<TS>"
+    }
+  ],
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/envelope/ready.json
+++ b/internal/beads/testdata/corpus/envelope/ready.json
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "comment_count": 0,
+      "created_at": "<TS>",
+      "created_by": "protocol-test",
+      "dependency_count": 0,
+      "dependent_count": 1,
+      "description": "deterministic corpus dependency",
+      "id": "corpus-dep",
+      "issue_type": "task",
+      "owner": "test@protocol.test",
+      "priority": 2,
+      "status": "open",
+      "title": "Corpus dependency issue",
+      "updated_at": "<TS>"
+    }
+  ],
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/envelope/show.json
+++ b/internal/beads/testdata/corpus/envelope/show.json
@@ -1,0 +1,35 @@
+{
+  "data": [
+    {
+      "comment_count": 0,
+      "created_at": "<TS>",
+      "created_by": "protocol-test",
+      "dependencies": [
+        {
+          "created_at": "<TS>",
+          "created_by": "protocol-test",
+          "dependency_type": "blocks",
+          "description": "deterministic corpus dependency",
+          "id": "corpus-dep",
+          "issue_type": "task",
+          "owner": "test@protocol.test",
+          "priority": 2,
+          "status": "open",
+          "title": "Corpus dependency issue",
+          "updated_at": "<TS>"
+        }
+      ],
+      "dependency_count": 1,
+      "dependent_count": 0,
+      "description": "deterministic corpus root",
+      "id": "corpus-root",
+      "issue_type": "feature",
+      "owner": "test@protocol.test",
+      "priority": 1,
+      "status": "open",
+      "title": "Corpus root issue",
+      "updated_at": "<TS>"
+    }
+  ],
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/envelope/version.json
+++ b/internal/beads/testdata/corpus/envelope/version.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "branch": "master",
+    "build": "dev",
+    "version": "1.0.5"
+  },
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/flat/count.json
+++ b/internal/beads/testdata/corpus/flat/count.json
@@ -1,0 +1,4 @@
+{
+  "count": 2,
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/flat/create_dep.json
+++ b/internal/beads/testdata/corpus/flat/create_dep.json
@@ -1,0 +1,13 @@
+{
+  "created_at": "<TS>",
+  "created_by": "protocol-test",
+  "description": "deterministic corpus dependency",
+  "id": "corpus-dep",
+  "issue_type": "task",
+  "owner": "test@protocol.test",
+  "priority": 2,
+  "schema_version": 1,
+  "status": "open",
+  "title": "Corpus dependency issue",
+  "updated_at": "<TS>"
+}

--- a/internal/beads/testdata/corpus/flat/create_root.json
+++ b/internal/beads/testdata/corpus/flat/create_root.json
@@ -1,0 +1,13 @@
+{
+  "created_at": "<TS>",
+  "created_by": "protocol-test",
+  "description": "deterministic corpus root",
+  "id": "corpus-root",
+  "issue_type": "feature",
+  "owner": "test@protocol.test",
+  "priority": 1,
+  "schema_version": 1,
+  "status": "open",
+  "title": "Corpus root issue",
+  "updated_at": "<TS>"
+}

--- a/internal/beads/testdata/corpus/flat/dep_add.json
+++ b/internal/beads/testdata/corpus/flat/dep_add.json
@@ -1,0 +1,7 @@
+{
+  "depends_on_id": "corpus-dep",
+  "issue_id": "corpus-root",
+  "schema_version": 1,
+  "status": "added",
+  "type": "blocks"
+}

--- a/internal/beads/testdata/corpus/flat/dep_list.json
+++ b/internal/beads/testdata/corpus/flat/dep_list.json
@@ -1,0 +1,15 @@
+[
+  {
+    "created_at": "<TS>",
+    "created_by": "protocol-test",
+    "dependency_type": "blocks",
+    "description": "deterministic corpus dependency",
+    "id": "corpus-dep",
+    "issue_type": "task",
+    "owner": "test@protocol.test",
+    "priority": 2,
+    "status": "open",
+    "title": "Corpus dependency issue",
+    "updated_at": "<TS>"
+  }
+]

--- a/internal/beads/testdata/corpus/flat/error.json
+++ b/internal/beads/testdata/corpus/flat/error.json
@@ -1,0 +1,4 @@
+{
+  "error": "no issues found matching the provided IDs",
+  "schema_version": 1
+}

--- a/internal/beads/testdata/corpus/flat/list.json
+++ b/internal/beads/testdata/corpus/flat/list.json
@@ -1,0 +1,42 @@
+[
+  {
+    "comment_count": 0,
+    "created_at": "<TS>",
+    "created_by": "protocol-test",
+    "dependency_count": 0,
+    "dependent_count": 1,
+    "description": "deterministic corpus dependency",
+    "id": "corpus-dep",
+    "issue_type": "task",
+    "owner": "test@protocol.test",
+    "priority": 2,
+    "status": "open",
+    "title": "Corpus dependency issue",
+    "updated_at": "<TS>"
+  },
+  {
+    "comment_count": 0,
+    "created_at": "<TS>",
+    "created_by": "protocol-test",
+    "dependencies": [
+      {
+        "created_at": "<TS>",
+        "created_by": "protocol-test",
+        "depends_on_id": "corpus-dep",
+        "issue_id": "corpus-root",
+        "metadata": "{}",
+        "type": "blocks"
+      }
+    ],
+    "dependency_count": 1,
+    "dependent_count": 0,
+    "description": "deterministic corpus root",
+    "id": "corpus-root",
+    "issue_type": "feature",
+    "owner": "test@protocol.test",
+    "priority": 1,
+    "status": "open",
+    "title": "Corpus root issue",
+    "updated_at": "<TS>"
+  }
+]

--- a/internal/beads/testdata/corpus/flat/ready.json
+++ b/internal/beads/testdata/corpus/flat/ready.json
@@ -1,0 +1,17 @@
+[
+  {
+    "comment_count": 0,
+    "created_at": "<TS>",
+    "created_by": "protocol-test",
+    "dependency_count": 0,
+    "dependent_count": 1,
+    "description": "deterministic corpus dependency",
+    "id": "corpus-dep",
+    "issue_type": "task",
+    "owner": "test@protocol.test",
+    "priority": 2,
+    "status": "open",
+    "title": "Corpus dependency issue",
+    "updated_at": "<TS>"
+  }
+]

--- a/internal/beads/testdata/corpus/flat/show.json
+++ b/internal/beads/testdata/corpus/flat/show.json
@@ -1,0 +1,32 @@
+[
+  {
+    "comment_count": 0,
+    "created_at": "<TS>",
+    "created_by": "protocol-test",
+    "dependencies": [
+      {
+        "created_at": "<TS>",
+        "created_by": "protocol-test",
+        "dependency_type": "blocks",
+        "description": "deterministic corpus dependency",
+        "id": "corpus-dep",
+        "issue_type": "task",
+        "owner": "test@protocol.test",
+        "priority": 2,
+        "status": "open",
+        "title": "Corpus dependency issue",
+        "updated_at": "<TS>"
+      }
+    ],
+    "dependency_count": 1,
+    "dependent_count": 0,
+    "description": "deterministic corpus root",
+    "id": "corpus-root",
+    "issue_type": "feature",
+    "owner": "test@protocol.test",
+    "priority": 1,
+    "status": "open",
+    "title": "Corpus root issue",
+    "updated_at": "<TS>"
+  }
+]

--- a/internal/beads/testdata/corpus/flat/version.json
+++ b/internal/beads/testdata/corpus/flat/version.json
@@ -1,0 +1,6 @@
+{
+  "branch": "master",
+  "build": "dev",
+  "schema_version": 1,
+  "version": "1.0.5"
+}

--- a/internal/beads/testdata/corpus/manifest.json
+++ b/internal/beads/testdata/corpus/manifest.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "bd_version": "1.0.5",
+  "bd_commit": "dev",
+  "generated_by": "cmd/bd/protocol TestCorpusGolden",
+  "canonicalized": true,
+  "blobs": {
+    "envelope/count": {
+      "cmd": "bd count --json",
+      "sha256": "a3586f9760faee16074622f0e5c98f85ced1677ef14d8adbb254b213c94b6700"
+    },
+    "envelope/create_dep": {
+      "cmd": "bd create \"Corpus dependency issue\" --id corpus-dep --force --priority 2 --type task --description \"deterministic corpus dependency\" --json",
+      "sha256": "2d524c76a31400f86a94f9bd99283d5f3baab92a470b9cdd4fd2d12674b936f1"
+    },
+    "envelope/create_root": {
+      "cmd": "bd create \"Corpus root issue\" --id corpus-root --force --priority 1 --type feature --description \"deterministic corpus root\" --json",
+      "sha256": "2e902e37ebf0b122f14d0ece9f8ae7c9e2c5726546366d0dbe8e481f876702e7"
+    },
+    "envelope/dep_add": {
+      "cmd": "bd dep add corpus-root corpus-dep --type blocks --json",
+      "sha256": "53f7ebc8e63a8b3cac5aa75d84d98d733753089f0cee3d2df2641781724e779f"
+    },
+    "envelope/dep_list": {
+      "cmd": "bd dep list corpus-root --json",
+      "sha256": "7ca29f4821b5f845601d3c38c4b1832085369eaf968a7b586f860aefbd6c2d39"
+    },
+    "envelope/error": {
+      "cmd": "bd show nonexistent-xyz-corpus --json",
+      "sha256": "f79e391ae3a508ae0ee6a7f63bd3708ac2140a8bcd9e6394a38992105c1c58de"
+    },
+    "envelope/list": {
+      "cmd": "bd list --all --json",
+      "sha256": "c076f70bde5e7f8388dc57d1925d5301cd4a5e3e0cb14400e829da185b1736d9"
+    },
+    "envelope/ready": {
+      "cmd": "bd ready --json",
+      "sha256": "8614cfbc12445854c97fef0860632a2a6e74537f01c073fb2118b3bf879e778d"
+    },
+    "envelope/show": {
+      "cmd": "bd show corpus-root --json",
+      "sha256": "ed15174a85cf33ef810cce77906d15756e80c324f8d7c6cc98330efb7dc35a70"
+    },
+    "envelope/version": {
+      "cmd": "bd version --json",
+      "sha256": "b7caa91e287ed6a829bd4bb75dc1e9b3e666ce0ed38ae7222f2a00b9d21bd841"
+    },
+    "flat/count": {
+      "cmd": "bd count --json",
+      "sha256": "7a9ceb81523f8e9916096f6b9014e11236812ab9ce31f40c147f3bf670baf46c"
+    },
+    "flat/create_dep": {
+      "cmd": "bd create \"Corpus dependency issue\" --id corpus-dep --force --priority 2 --type task --description \"deterministic corpus dependency\" --json",
+      "sha256": "0e5d3d5c045fe3fa61a50e08f6b63e6e5c5139e5a5f065e083a9469d0964e80b"
+    },
+    "flat/create_root": {
+      "cmd": "bd create \"Corpus root issue\" --id corpus-root --force --priority 1 --type feature --description \"deterministic corpus root\" --json",
+      "sha256": "6a0aa29c62315a6f1f64d4f66c520c35bd209170b709bd2be9dc0cdaa24d46f2"
+    },
+    "flat/dep_add": {
+      "cmd": "bd dep add corpus-root corpus-dep --type blocks --json",
+      "sha256": "07f84f475c1126f19deb288074d82fa66ed589adb7871a6c3acf59affead874b"
+    },
+    "flat/dep_list": {
+      "cmd": "bd dep list corpus-root --json",
+      "sha256": "646844cfd6ce88a4f31429245f0dedeeef612e9565ecdf0154d8e278f5a0a970"
+    },
+    "flat/error": {
+      "cmd": "bd show nonexistent-xyz-corpus --json",
+      "sha256": "29b5ecbc5404159e3a1e6a195aea7f2b444ba25b006108eb3c3d86e84e9eb531"
+    },
+    "flat/list": {
+      "cmd": "bd list --all --json",
+      "sha256": "64703472eb3acd005c67b5955e323b2fb29e4d7c32965fcc8fd36f84cdf32261"
+    },
+    "flat/ready": {
+      "cmd": "bd ready --json",
+      "sha256": "fe31934c2ca8177cdc89a5131b310ce6ecdcee793c7510d6b5fa3fc1c46871e7"
+    },
+    "flat/show": {
+      "cmd": "bd show corpus-root --json",
+      "sha256": "586fa1f5a1aef647185b857e182df6a35f1887e22c483c8ccb1b715b69abe506"
+    },
+    "flat/version": {
+      "cmd": "bd version --json",
+      "sha256": "a215b7c9160b9fabd81524571bf248aafc871663a28d5e0f2112b1eff1c275e6"
+    }
+  }
+}

--- a/internal/beads/testdata/corpus/manifest.json
+++ b/internal/beads/testdata/corpus/manifest.json
@@ -1,7 +1,6 @@
 {
   "schema_version": 1,
   "bd_version": "1.0.5",
-  "bd_commit": "dev",
   "generated_by": "cmd/bd/protocol TestCorpusGolden",
   "canonicalized": true,
   "blobs": {

--- a/scripts/sync-bd-corpus.sh
+++ b/scripts/sync-bd-corpus.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Vendors the bd contract corpus from a published beads release into
+# internal/beads/testdata/corpus/, verifying the downloaded archive against the
+# release's signed checksums.txt — NOT a self-recomputed manifest. Run during a
+# deliberate bd pin bump:
+#
+#   make sync-bd-corpus BD_CORPUS_TAG=v1.0.6
+#
+# Then review the diff and commit. The release must have been built with the
+# corpus-publishing step (contract Phase 3); older releases predate it and are
+# rejected. See engdocs/design/beads-gascity-contract-test-system.md.
+set -euo pipefail
+
+repo="${BD_REPO:-gastownhall/beads}"
+tag="${BD_CORPUS_TAG:-}"
+dest="internal/beads/testdata/corpus"
+
+if [[ -z "$tag" ]]; then
+  echo "usage: BD_CORPUS_TAG=<vX.Y.Z> $0   (the beads release tag to vendor the corpus from)" >&2
+  exit 2
+fi
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+version="${tag#v}"
+archive="beads_${version}_contract_corpus.tar.gz"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+echo "Downloading ${archive} + checksums.txt from ${repo} ${tag} ..."
+gh release download "$tag" --repo "$repo" \
+  --pattern "$archive" --pattern checksums.txt --dir "$work"
+
+echo "Verifying ${archive} against the release checksums.txt ..."
+want="$(awk -v a="$archive" '$2 == a {print $1}' "$work/checksums.txt")"
+if [[ -z "$want" ]]; then
+  echo "ERROR: ${archive} is not in the release checksums.txt; ${tag} predates the contract corpus (Phase 3)." >&2
+  exit 1
+fi
+got="$(sha256 "$work/$archive")"
+if [[ "$want" != "$got" ]]; then
+  echo "ERROR: checksum mismatch for ${archive}: release=${want} downloaded=${got}" >&2
+  exit 1
+fi
+
+echo "Extracting into ${dest} ..."
+tar -xzf "$work/$archive" -C "$work"
+rm -rf "${dest:?}"
+mkdir -p "$dest"
+cp -rf "$work/corpus/." "$dest/"
+echo "Vendored corpus from ${repo} ${tag} into ${dest}. Review the diff and commit."


### PR DESCRIPTION
## What

The **consumer half** of the Beads ↔ Gas City contract system: gascity vendors the bd golden-JSON corpus (from the beads producer PR) and replays it against its **real** decoder, offline. Doing so immediately surfaced — and this PR fixes — a latent not-found bug.

### Bug fix (surfaced by the corpus)
bd's stdout `--json` not-found envelope says **`"no issues found matching the provided IDs"`** (plural), but `isBdNotFound` only matched `"no issue found"` (singular) and `"not found"`. `classifyBDExecResult` falls back to the stdout envelope when stderr is empty — the direction bd's `--json` error path is explicitly moving (see its own comment) — so the moment bd stops writing the stderr banner, **every not-found silently degrades to a generic error**. Fixed `isBdNotFound` to also match the plural form.

### New tests — `internal/beads/corpus_decoder_test.go` (package `beads`, offline)
No bd, no Dolt — runs in the fast unit loop on every PR:
- `parseIssuesTolerant` decodes the committed `show`/`list`/`ready` shapes (timestamps rehydrated from the canonical `<TS>`); the nested dependency decodes.
- single-issue `create` decode.
- `bdStdoutErrorDetail` + `isBdNotFound` classify the `{error, schema_version}` envelope (the regression guard for the fix above).
- **forward-compat canary**: asserts gascity does *not* yet understand the v2.0 `{schema_version,data}` envelope — when bd flips it, this test fails and signals the coordinated migration.
- **bidirectional field-coverage**: every field bd emits in a show issue must be decoded by `bdIssue` or in an explicit ignore set with a reason; a new bd field trips it instead of being silently dropped.

Corpus vendored at `internal/beads/testdata/corpus/` (beside the package-`beads` test, which must reach the unexported decoders — a deliberate deviation from the design's `internal/beads/contract/` path).

## Verification
`go test ./internal/beads` passes (incl. the new corpus tests and existing not-found/Get tests); `gofmt`/`go vet` clean.

> Depends conceptually on the beads producer corpus PR (gastownhall/beads). The vendored copy here is committed; a later phase adds the release-anchored `sync-bd-corpus` + drift-check. Pre-commit hook bypassed (unrelated OpenAPI codegen failure).