### PR TITLE
Persist Dolt server mode in canonical beads config

### DIFF
--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -43,7 +43,11 @@ type ConfigState struct {
 	DoltHost       string
 	DoltPort       string
 	DoltUser       string
-	Dolt           DoltConfig
+	// DoltMode is the beads dolt.mode value to write to config.yaml.
+	// When non-empty, EnsureCanonicalConfig writes dolt.mode to the canonical config.
+	// When empty, the existing dolt.mode value is preserved.
+	DoltMode string
+	Dolt     DoltConfig
 }
 
 // DoltConfig is the Dolt-specific subset of .beads/config.yaml that GC owns.
@@ -517,6 +521,10 @@ func EnsureCanonicalConfig(fs fsys.FS, path string, state ConfigState) (bool, er
 		changed = deleteKeys(root, "dolt.user") || changed
 	}
 
+	if mode := strings.TrimSpace(state.DoltMode); mode != "" {
+		changed = setString(root, "dolt.mode", mode) || changed
+	}
+
 	changed = deleteKeys(root, deprecatedConfigKeys...) || changed
 	if !changed {
 		return false, nil
@@ -654,6 +662,9 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 	} else {
 		deletions["dolt.user"] = struct{}{}
 	}
+	if mode := strings.TrimSpace(state.DoltMode); mode != "" {
+		replacements["dolt.mode"] = "dolt.mode: " + mode
+	}
 	disableEventFlush := doltDisableEventFlushFallbackValue(data, state)
 
 	lines := strings.Split(string(data), "\n")
@@ -708,6 +719,7 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		"dolt.host",
 		"dolt.port",
 		"dolt.user",
+		"dolt.mode",
 	}
 	for _, key := range orderedKeys {
 		want, ok := replacements[key]

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -1867,6 +1867,98 @@ func TestEnsureCanonicalMetadataScrubsDoltKeysOnPostgresCanonicalise(t *testing.
 	}
 }
 
+// TestEnsureCanonicalConfigWritesDoltModeOnAbsentConfig verifies that
+// EnsureCanonicalConfig writes dolt.mode: server to a new config when
+// ConfigState.DoltMode is "server".
+func TestEnsureCanonicalConfigWritesDoltModeOnAbsentConfig(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	changed, err := EnsureCanonicalConfig(fs, path, ConfigState{DoltMode: "server"})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("EnsureCanonicalConfig() changed = false, want true for new file with DoltMode")
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "dolt.mode: server") {
+		t.Fatalf("config missing dolt.mode: server:\n%s", data)
+	}
+}
+
+// TestEnsureCanonicalConfigDoltModeIdempotent verifies that a second call with
+// the same DoltMode:"server" on an already-canonical config returns changed=false.
+func TestEnsureCanonicalConfigDoltModeIdempotent(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	state := ConfigState{DoltMode: "server"}
+	if _, err := EnsureCanonicalConfig(fs, path, state); err != nil {
+		t.Fatalf("first EnsureCanonicalConfig() error = %v", err)
+	}
+
+	changed, err := EnsureCanonicalConfig(fs, path, state)
+	if err != nil {
+		t.Fatalf("second EnsureCanonicalConfig() error = %v", err)
+	}
+	if changed {
+		data, _ := fs.ReadFile(path)
+		t.Fatalf("second EnsureCanonicalConfig() changed = true, want false (idempotent):\n%s", data)
+	}
+}
+
+// TestEnsureCanonicalConfigPreservesExistingDoltModeWhenStateOmitsIt verifies
+// that a pre-existing dolt.mode: server in config is not removed or changed
+// when ConfigState.DoltMode is empty ("caller doesn't know the mode").
+func TestEnsureCanonicalConfigPreservesExistingDoltModeWhenStateOmitsIt(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Pre-write a config that already has dolt.mode: server.
+	if _, err := EnsureCanonicalConfig(fs, path, ConfigState{DoltMode: "server"}); err != nil {
+		t.Fatalf("setup EnsureCanonicalConfig() error = %v", err)
+	}
+
+	// Now call with DoltMode:"" — existing dolt.mode must be preserved unchanged.
+	changed, err := EnsureCanonicalConfig(fs, path, ConfigState{DoltMode: ""})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalConfig(DoltMode empty) error = %v", err)
+	}
+	if changed {
+		data, _ := fs.ReadFile(path)
+		t.Fatalf("EnsureCanonicalConfig(DoltMode empty) changed = true, want false:\n%s", data)
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "dolt.mode: server") {
+		t.Fatalf("config should preserve existing dolt.mode: server when DoltMode is empty:\n%s", data)
+	}
+}
+
+// TestCrossBackendKeysToScrubDoesNotIncludeConfigDotModeKey guards that the
+// config key "dolt.mode" (dot-separated, used in config.yaml) is never added
+// to the metadata scrub list for the dolt backend. The metadata key "dolt_mode"
+// (underscore) is expected and correct; only the config key would be wrong.
+func TestCrossBackendKeysToScrubDoesNotIncludeConfigDotModeKey(t *testing.T) {
+	scrub := crossBackendKeysToScrub("dolt")
+	for _, k := range scrub {
+		if k == "dolt.mode" {
+			t.Fatalf("crossBackendKeysToScrub(dolt) must not include config key %q (only metadata key %q is expected)", "dolt.mode", "dolt_mode")
+		}
+	}
+}
+
 func TestEnsureCanonicalMetadataPreservesAllKeysOnEmptyBackend(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()

--- a/release-gates/ga-m3up75-configstate-doltmode-gate.md
+++ b/release-gates/ga-m3up75-configstate-doltmode-gate.md
@@ -1,0 +1,55 @@
+# Release Gate: ConfigState.DoltMode canonical config write
+
+- Bead: ga-m3up75.3
+- Branch: deploy/ga-m3up75-configstate-doltmode
+- Tested implementation head: 288d54dfbe2ac8fef6ca48bc3fa285ebe67e5571
+- Base: 4f1dc179df0de97a28cab7393249a321e459d942
+- Scope: ConfigState.DoltMode and EnsureCanonicalConfig support for writing `dolt.mode`
+
+## Gate Summary
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-m3up75.2 records `VERDICT: PASS` for head `288d54dfbe2ac8fef6ca48bc3fa285ebe67e5571`. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `internal/beads/contract/files.go` and `internal/beads/contract/files_test.go`; it preserves the clean candidate from ga-m3up75.1 and the reviewer-confirmed behavior from ga-m3up75.2. |
+| 3 | Tests pass | PASS | `go test ./internal/beads/contract` passed; `go build ./cmd/gc` passed; `make test-fast-parallel` passed all fast jobs; `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | ga-m3up75.2 lists no blockers and no HIGH findings; reviewer recorded "Blockers: none". |
+| 5 | Final branch is clean | PASS | Branch was clean before the gate artifact was added; gate artifact is intended to be committed as the final branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded and returned tree `aa31a2da567aea1e9eac3fab5e58cccb5c69c21f`. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem, `internal/beads/contract`, and one behavior: persisting configured Dolt server mode to canonical beads config. |
+
+## Diff Scope
+
+```text
+M	internal/beads/contract/files.go
+M	internal/beads/contract/files_test.go
+```
+
+```text
+internal/beads/contract/files.go      | 14 +++++-
+internal/beads/contract/files_test.go | 92 +++++++++++++++++++++++++++++++++++
+2 files changed, 105 insertions(+), 1 deletion(-)
+```
+
+## Acceptance Evidence
+
+- `ConfigState` now carries `DoltMode`.
+- `EnsureCanonicalConfig` writes `dolt.mode` when `ConfigState.DoltMode` is non-empty.
+- Existing `dolt.mode` is preserved when `ConfigState.DoltMode` is empty.
+- `crossBackendKeysToScrub("dolt")` does not include the YAML config key `dolt.mode`; it remains separate from the metadata key `dolt_mode`.
+- The candidate excludes the unrelated `cmd/gc` pool/session desired-state changes and old release-gate artifacts from the prior failed gate.
+
+## Commands Run
+
+```text
+git diff --name-status origin/main...HEAD
+git merge-tree --write-tree origin/main HEAD
+go test ./internal/beads/contract
+go build ./cmd/gc
+make test-fast-parallel
+go vet ./...
+```
+
+## Result
+
+PASS. Open a PR for `deploy/ga-m3up75-configstate-doltmode` and route the merge request to mayor/mpr. Do not merge from the deployer seat.


### PR DESCRIPTION
## What this changes

Gas City's beads config canonicalizer can now carry `ConfigState.DoltMode` through to `.beads/config.yaml`. When the runtime knows the Dolt mode, canonical config writes include `dolt.mode: server`, keeping a regenerated beads config pinned to server mode instead of letting later commands fall back to direct/embedded mode.

If the caller does not provide a mode, the canonicalizer preserves any existing `dolt.mode` value. This keeps repair/idempotency behavior conservative for older or partially populated state.

## Review notes

- Scope is limited to `internal/beads/contract`.
- `dolt.mode` remains a config-file key; it is intentionally kept separate from the metadata key `dolt_mode`.
- No CLI, API, dashboard, or migration surface changes.

## Test plan

- [x] `go test ./internal/beads/contract`
- [x] `go build ./cmd/gc`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-m3up75-configstate-doltmode-gate.md`](release-gates/ga-m3up75-configstate-doltmode-gate.md)
