### PR TITLE
fix(orders): exclude order-tracking bead events from event-trigger eval

### DIFF
--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -2,6 +2,7 @@ package orders
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +15,10 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/execenv"
 )
+
+// labelOrderTracking is applied to order bookkeeping beads by the dispatcher.
+// Event orders must not self-fire on lifecycle events emitted by these beads.
+const labelOrderTracking = "order-tracking"
 
 // TriggerResult holds the outcome of a trigger check.
 type TriggerResult struct {
@@ -235,6 +240,8 @@ func mergeConditionEnv(environ, extra []string) []string {
 }
 
 // checkEvent checks if matching events exist after the last cursor position.
+// Events emitted by order-tracking beads (controller bookkeeping) are excluded
+// to prevent event orders from self-firing on their own tracking-bead lifecycle.
 func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc) TriggerResult {
 	if ep == nil {
 		return TriggerResult{Due: false, Reason: "event: no events provider"}
@@ -251,10 +258,35 @@ func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc) TriggerResult 
 	if err != nil {
 		return TriggerResult{Due: false, Reason: fmt.Sprintf("event: read error: %v", err)}
 	}
-	if len(matched) == 0 {
+	var count int
+	for _, e := range matched {
+		if !payloadHasLabel(e.Payload, labelOrderTracking) {
+			count++
+		}
+	}
+	if count == 0 {
 		return TriggerResult{Due: false, Reason: "event: no matching events"}
 	}
-	return TriggerResult{Due: true, Reason: fmt.Sprintf("event: %d %s event(s)", len(matched), a.On)}
+	return TriggerResult{Due: true, Reason: fmt.Sprintf("event: %d %s event(s)", count, a.On)}
+}
+
+// payloadHasLabel reports whether a JSON bead payload contains the given label.
+func payloadHasLabel(payload json.RawMessage, label string) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	var p struct {
+		Labels []string `json:"labels"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return false
+	}
+	for _, l := range p.Labels {
+		if l == label {
+			return true
+		}
+	}
+	return false
 }
 
 // MaxSeqFromLabels extracts the highest seq:<N> value from bead labels.

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -2,6 +2,7 @@ package orders
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -376,6 +377,68 @@ func TestCheckTriggerCronRigScoped(t *testing.T) {
 	if queriedName != "cleanup:rig:my-rig" {
 		t.Errorf("cron query = %q, want %q", queriedName, "cleanup:rig:my-rig")
 	}
+}
+
+func TestCheckTriggerEventOrderTrackingBeadsFiltered(t *testing.T) {
+	// Regression: event orders must not self-fire on bead lifecycle events emitted
+	// by order-tracking beads (controller bookkeeping). This was the root cause of
+	// the ~80 events/min feedback loop after ce32c6bf6 switched tracking beads from
+	// Ephemeral to NoHistory, making their lifecycle events visible to the cache.
+	trackingPayload := mustMarshalLabels(t, []string{"order-run:nudge-on-route", "order-tracking"})
+	regularPayload := mustMarshalLabels(t, []string{"work:some-bead"})
+
+	ep := newEventsProvider(t, []events.Event{
+		{Type: "bead.updated", Payload: trackingPayload}, // order-tracking — excluded
+		{Type: "bead.updated", Payload: regularPayload},  // real work bead — counted
+		{Type: "bead.updated", Payload: trackingPayload}, // order-tracking — excluded
+	})
+	a := Order{Name: "nudge-on-route", Trigger: "event", On: "bead.updated"}
+	result := CheckTrigger(a, time.Time{}, neverRan, ep, nil)
+	if !result.Due {
+		t.Errorf("Due = false, want true (one non-tracking bead.updated exists); reason: %s", result.Reason)
+	}
+	if result.Reason != "event: 1 bead.updated event(s)" {
+		t.Errorf("Reason = %q, want %q", result.Reason, "event: 1 bead.updated event(s)")
+	}
+}
+
+func TestCheckTriggerEventAllOrderTrackingFiltered(t *testing.T) {
+	// When ALL matched events come from order-tracking beads the order is not due.
+	trackingPayload := mustMarshalLabels(t, []string{"order-run:nudge-on-route", "order-tracking"})
+
+	ep := newEventsProvider(t, []events.Event{
+		{Type: "bead.updated", Payload: trackingPayload},
+		{Type: "bead.closed", Payload: trackingPayload},
+	})
+	a := Order{Name: "nudge-on-route", Trigger: "event", On: "bead.updated"}
+	result := CheckTrigger(a, time.Time{}, neverRan, ep, nil)
+	if result.Due {
+		t.Errorf("Due = true, want false (all events from order-tracking beads); reason: %s", result.Reason)
+	}
+}
+
+func TestCheckTriggerEventNoPayloadNotFiltered(t *testing.T) {
+	// Events with no payload (legacy or non-bead events) must pass through —
+	// absence of a label is not the same as having the order-tracking label.
+	ep := newEventsProvider(t, []events.Event{
+		{Type: "bead.closed"}, // no payload
+	})
+	a := Order{Name: "convoy-check", Trigger: "event", On: "bead.closed"}
+	result := CheckTrigger(a, time.Time{}, neverRan, ep, nil)
+	if !result.Due {
+		t.Errorf("Due = false, want true (no-payload events must not be filtered); reason: %s", result.Reason)
+	}
+}
+
+func mustMarshalLabels(t *testing.T, labels []string) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(struct {
+		Labels []string `json:"labels"`
+	}{Labels: labels})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
 }
 
 func TestCheckTriggerEventRigScoped(t *testing.T) {


### PR DESCRIPTION
## Problem

Event-triggered orders self-fire on the `bead.created/updated/closed` events emitted by their **own** order-tracking bookkeeping beads, creating an unbounded dispatch feedback loop (~80 events/min of order-tracking churn with zero real work).

Every dispatched order materializes an order-tracking bead labelled `order-tracking`. The controller's caching store emits a `bead.*` event for each tracking-bead lifecycle change. `checkEvent` then matches purely on event `Type` + cursor, with no exclusion of the order's own tracking-bead events — so `nudge-on-route` (on `bead.updated`) and `cascade-nudge-on-blocker-close` (on `bead.closed`) re-fire on their own tracking bead's lifecycle, and each fire creates another tracking bead. Timer/cooldown orders also create tracking beads but fire on long timers, so they don't self-trigger.

This was a latent design gap exposed by `ce32c6bf6` (#3045), which switched tracking-bead creation from `Ephemeral` to `NoHistory`: ephemeral rows are invisible to the cache (no lifecycle events emitted), whereas `NoHistory` rows are cache-visible, so their lifecycle events began flowing into the event recorder.

## Fix

`checkEvent` now counts only matched events whose bead payload does **not** carry the `order-tracking` label (new `payloadHasLabel` helper). When every matched event originates from a tracking bead, the order is not due. An event order must not fire on the bead events its own bookkeeping emits.

The fix is tier-independent (works regardless of `Ephemeral`/`NoHistory`) and preserves #3045's `NoHistory` choice (the open-work gate / history queries still observe in-flight tracking beads). Events with no payload (legacy/non-bead) pass through unchanged — absence of a label is not the order-tracking label.

## Tests

Three regression tests in `triggers_test.go`:
- `TestCheckTriggerEventOrderTrackingBeadsFiltered` — mixed events; only the non-tracking event is counted (due).
- `TestCheckTriggerEventAllOrderTrackingFiltered` — all events from tracking beads ⇒ **not** due (the self-fire case).
- `TestCheckTriggerEventNoPayloadNotFiltered` — no-payload events are not filtered.

`go vet ./internal/orders/` clean; `go test ./internal/orders/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)