### PR TITLE
ci(beads): cross-version contract gate — bd-current acceptance cell (Phase 5)

### DIFF
--- a/.github/actions/setup-gascity-ubuntu/action.yml
+++ b/.github/actions/setup-gascity-ubuntu/action.yml
@@ -14,8 +14,11 @@ inputs:
     description: Dolt version to install
     required: true
   bd-version:
-    description: Beads release version to install
-    required: true
+    description: >-
+      Beads release version to install. Empty string means the caller builds or
+      installs bd itself (used by the cross-version contract "current" cell).
+    required: false
+    default: ""
   install-claude-cli:
     description: Whether to install the Claude CLI
     required: false

--- a/.github/actions/setup-gascity-ubuntu/action.yml
+++ b/.github/actions/setup-gascity-ubuntu/action.yml
@@ -45,6 +45,9 @@ runs:
       run: ${{ github.action_path }}/../../scripts/install-dolt-archive.sh "${{ inputs.dolt-version }}"
 
     - name: Install released bd v${{ inputs.bd-version }}
+      # Skip when no version is given: the contract cross-version "current" cell
+      # builds bd from source instead of installing a released tarball.
+      if: ${{ inputs.bd-version != '' }}
       shell: bash
       run: ${{ github.action_path }}/../../scripts/install-bd-archive.sh "${{ inputs.bd-version }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
             beads:
               - 'go.mod'
               - 'internal/beads/**'
+              - 'deps.env'
+              - '.github/scripts/install-bd-archive.sh'
+              - 'cmd/gc/init_provider_readiness.go'
             packs:
               - 'examples/gastown/**'
               - 'internal/config/pack.go'
@@ -289,6 +292,48 @@ jobs:
           bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "true"
       - name: Acceptance tests (Tier A)
+        run: make test-acceptance
+
+  # Cross-version contract gate: the "current" cell of the bd matrix. The
+  # "prev" cell is preflight-acceptance above (bd v1.0.4, the min-supported
+  # release). This cell builds bd from gastownhall/beads source at
+  # BD_CURRENT_REF (deps.env) — the bleeding-edge rc has no release tarball —
+  # and runs the same live acceptance suite, so a bd change that breaks gc's
+  # decoder/classifier surface against the newer bd is caught before merge.
+  # Path-gated on the beads filter; tolerated as a skip by ci-required.
+  contract-acceptance-current:
+    name: Contract / acceptance A (bd current)
+    needs:
+      - runner-policy
+      - changes
+    if: ${{ needs.changes.outputs.beads == 'true' }}
+    runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
+    env:
+      DOLT_VERSION: "2.1.7"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: "" # build bd from source below instead of installing a release
+          install-claude-cli: "true"
+      - name: Resolve bd current pin
+        id: bd
+        run: |
+          echo "ref=$(grep -E '^BD_CURRENT_REF=' deps.env | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+          echo "ver=$(grep -E '^BD_CURRENT_VERSION=' deps.env | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+      - name: Build bd ${{ steps.bd.outputs.ver }} from source @ ${{ steps.bd.outputs.ref }}
+        run: |
+          set -euo pipefail
+          src="${RUNNER_TEMP}/beads-src"
+          git clone --filter=blob:none https://github.com/gastownhall/beads "$src"
+          git -C "$src" checkout "${{ steps.bd.outputs.ref }}"
+          mkdir -p "${HOME}/.local/bin"
+          go -C "$src" build -tags gms_pure_go -o "${HOME}/.local/bin/bd" ./cmd/bd
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+      - name: Verify bd on PATH
+        run: bd version
+      - name: Acceptance tests (Tier A, bd current)
         run: make test-acceptance
 
   preflight-generated:
@@ -1237,6 +1282,7 @@ jobs:
       - docker-session
       - k8s-session
       - openclaw-bridge
+      - contract-acceptance-current
     if: ${{ always() }}
     runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
     env:
@@ -1256,6 +1302,9 @@ jobs:
               "docker-session",
               "k8s-session",
               "openclaw-bridge",
+              # Path-gated on the beads filter: skips on PRs that touch no
+              # beads/contract path, which is the expected pass case.
+              "contract-acceptance-current",
           }
           failed = {}
           for job, meta in sorted(needs.items()):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,6 +411,10 @@ jobs:
     name: Check
     needs:
       - runner-policy
+      # `changes` is a hard dependency (kept out of allow_skipped) so a
+      # filter-job flake fails Check directly instead of silently skipping
+      # the path-gated contract-acceptance-current cell. Mirrors ci-required.
+      - changes
       - preflight-static
       - preflight-acceptance
       - preflight-generated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,42 @@ jobs:
       - name: Acceptance tests (Tier A, bd current)
         run: make test-acceptance
 
+  # NON-REQUIRED HEADxHEAD radar: builds bd from beads MAIN HEAD (live, not the
+  # pinned BD_CURRENT_REF) and runs gc-HEAD's real bd calls (the acceptance
+  # suite) against it — early warning when bd's bleeding edge diverges from what
+  # gc expects, before the next deliberate pin bump. Deliberately NOT wired into
+  # ci-required: a bd-main break must never block a gascity merge (that is the
+  # cross-HEAD deadlock the pinned cells avoid). A red here is an advisory signal
+  # to stage a coordinated change, not a gate. Path-gated on the beads filter.
+  contract-radar-bd-head:
+    name: Contract radar (gc HEAD x bd main HEAD)
+    needs:
+      - runner-policy
+      - changes
+    if: ${{ needs.changes.outputs.beads == 'true' }}
+    runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
+    env:
+      DOLT_VERSION: "2.1.7"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: "" # build bd from source below
+          install-claude-cli: "true"
+      - name: Build bd from beads main HEAD
+        run: |
+          set -euo pipefail
+          src="${RUNNER_TEMP}/beads-src"
+          git clone --depth 1 --filter=blob:none https://github.com/gastownhall/beads "$src"
+          mkdir -p "${HOME}/.local/bin"
+          go -C "$src" build -tags gms_pure_go -o "${HOME}/.local/bin/bd" ./cmd/bd
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+      - name: Verify bd on PATH
+        run: bd version
+      - name: Acceptance tests (Tier A, bd main HEAD)
+        run: make test-acceptance
+
   preflight-generated:
     name: Preflight / generated artifacts
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       mail: ${{ steps.filter.outputs.mail == 'true' || steps.filter.outputs.shared == 'true' }}
       docker: ${{ steps.filter.outputs.docker == 'true' || steps.filter.outputs.shared == 'true' }}
       k8s: ${{ steps.filter.outputs.k8s == 'true' || steps.filter.outputs.shared == 'true' }}
-      beads: ${{ steps.filter.outputs.beads }}
+      beads: ${{ steps.filter.outputs.beads == 'true' || steps.filter.outputs.shared == 'true' }}
       packs: ${{ steps.filter.outputs.packs == 'true' || steps.filter.outputs.shared == 'true' }}
       worker: ${{ steps.filter.outputs.worker == 'true' || steps.filter.outputs.shared == 'true' }}
       worker_phase2: ${{ steps.filter.outputs.worker_phase2 == 'true' || steps.filter.outputs.shared == 'true' }}
@@ -300,7 +300,7 @@ jobs:
   # BD_CURRENT_REF (deps.env) — the bleeding-edge rc has no release tarball —
   # and runs the same live acceptance suite, so a bd change that breaks gc's
   # decoder/classifier surface against the newer bd is caught before merge.
-  # Path-gated on the beads filter; tolerated as a skip by ci-required.
+  # Path-gated on the beads filter; tolerated as a skip by the Check gate.
   contract-acceptance-current:
     name: Contract / acceptance A (bd current)
     needs:
@@ -320,8 +320,15 @@ jobs:
       - name: Resolve bd current pin
         id: bd
         run: |
-          echo "ref=$(grep -E '^BD_CURRENT_REF=' deps.env | cut -d= -f2)" >> "$GITHUB_OUTPUT"
-          echo "ver=$(grep -E '^BD_CURRENT_VERSION=' deps.env | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          ref="$(grep -E '^BD_CURRENT_REF=' deps.env | cut -d= -f2)"
+          ver="$(grep -E '^BD_CURRENT_VERSION=' deps.env | cut -d= -f2)"
+          if [ -z "$ref" ] || [ -z "$ver" ]; then
+            echo "::error::BD_CURRENT_REF/BD_CURRENT_VERSION missing or empty in deps.env" >&2
+            exit 1
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "ver=$ver" >> "$GITHUB_OUTPUT"
       - name: Build bd ${{ steps.bd.outputs.ver }} from source @ ${{ steps.bd.outputs.ref }}
         run: |
           set -euo pipefail
@@ -394,8 +401,12 @@ jobs:
       - name: OpenAPI spec + client drift check
         run: make spec-ci
 
-  # Historical fan-in name. During the Blacksmith proof, branch protection can
-  # move to `CI / required`; this job keeps the old name meaningful.
+  # Historical fan-in name and the branch-protection-enforced required status.
+  # Branch protection requires `Check`, so the cross-version contract matrix
+  # must gate here: the `prev` cell is preflight-acceptance above, and the
+  # path-gated `current` cell (contract-acceptance-current) is folded in below.
+  # During the Blacksmith proof, branch protection can move to `CI / required`;
+  # this job keeps the old name meaningful either way.
   check:
     name: Check
     needs:
@@ -403,6 +414,7 @@ jobs:
       - preflight-static
       - preflight-acceptance
       - preflight-generated
+      - contract-acceptance-current
     if: ${{ always() }}
     runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
     env:
@@ -415,12 +427,19 @@ jobs:
           import os
           import sys
 
+          # contract-acceptance-current is path-gated on the beads filter: it
+          # skips on PRs that touch no beads/contract path, which is the
+          # expected pass case. Every other dependency runs unconditionally.
+          allow_skipped = {"contract-acceptance-current"}
           needs = json.loads(os.environ["NEEDS_JSON"])
-          failures = {
-              job: meta.get("result", "unknown")
-              for job, meta in sorted(needs.items())
-              if meta.get("result") != "success"
-          }
+          failures = {}
+          for job, meta in sorted(needs.items()):
+              result = meta.get("result", "unknown")
+              if result == "success":
+                  continue
+              if result == "skipped" and job in allow_skipped:
+                  continue
+              failures[job] = result
           summary_path = os.environ["GITHUB_STEP_SUMMARY"]
           with open(summary_path, "a", encoding="utf-8") as handle:
               handle.write("## CI Preflight\n\n")
@@ -1318,7 +1337,6 @@ jobs:
       - docker-session
       - k8s-session
       - openclaw-bridge
-      - contract-acceptance-current
     if: ${{ always() }}
     runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
     env:
@@ -1338,9 +1356,6 @@ jobs:
               "docker-session",
               "k8s-session",
               "openclaw-bridge",
-              # Path-gated on the beads filter: skips on PRs that touch no
-              # beads/contract path, which is the expected pass case.
-              "contract-acceptance-current",
           }
           failed = {}
           for job, meta in sorted(needs.items()):

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -84,6 +84,81 @@ vulnerabilities:
       - "usr/local/bin/dolt"
     expired_at: 2026-07-07
     statement: Latest Dolt 1.88.0 still embeds github.com/apache/thrift v0.13.1; remove after a Dolt release includes thrift 0.23.0 or later.
+  - id: CVE-2026-25680
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML parsing issue; remove once upstream rebuilds against the fixed x/net release.
+  - id: CVE-2026-25681
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML rendering issue; remove once upstream rebuilds against the fixed x/net release.
+  - id: CVE-2026-27136
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML rendering issue; remove once upstream rebuilds against the fixed x/net release.
+  - id: CVE-2026-39821
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles a Go module set with this x/net idna issue; remove once upstream rebuilds against the fixed x/net release.
+  - id: CVE-2026-42502
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML rendering issue; remove once upstream rebuilds against the fixed x/net release.
+  - id: CVE-2026-42506
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML rendering issue; remove once upstream rebuilds against the fixed x/net release.
+  - id: CVE-2026-39827
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
+  - id: CVE-2026-39828
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
+  - id: CVE-2026-39829
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
+  - id: CVE-2026-39830
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
+  - id: CVE-2026-39832
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
+  - id: CVE-2026-39835
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
+  - id: CVE-2026-42508
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
+  - id: CVE-2026-46595
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
+  - id: CVE-2026-46597
+    paths:
+      - "usr/local/bin/dolt"
+    expired_at: 2026-07-07
+    statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   # HIGH severity, fixed upstream. Both CVEs below are present ONLY via the
   # deliberate steveyegge/beads v1.0.4 repin (v1.0.5 has data corruption) in the
   # bundled bd CLI binary. bd is a local CLI: the affected apache/thrift and

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -175,3 +175,117 @@ vulnerabilities:
       - "usr/local/bin/bd"
     expired_at: 2026-07-07
     statement: "HIGH, fixed upstream (go-jose/go-jose/v4). Present only via the deliberate steveyegge/beads v1.0.4 repin (v1.0.5 has data corruption), in the bundled bd CLI binary on non-network JWE paths. Remove when gascity moves off bd 1.0.4 (tracking: move gascity off bd v1.0.4)."
+  # The golang.org/x/net (HTML/idna/http2) and golang.org/x/crypto/ssh CVEs in
+  # the same series the dolt entries above waive are also reported against the
+  # bd CLI binary (steveyegge/beads v1.0.4 repin, external), the gc binary
+  # (indirect golang.org/x/net v0.52.0 / golang.org/x/crypto v0.49.0), and the
+  # external kubectl binary (golang.org/x/net v0.49.0; the gc-controller image
+  # adds kubectl on top of the agent image). With set -e the Container Scan
+  # halts at the first failing image, so kubectl's x/net findings stayed masked
+  # until the bd/gc findings were waived. These are base-pre-existing: the
+  # Container Scan is already red on main (scheduled run 2026-06-24) and this PR
+  # does not change go.mod, so gc's transitive module versions are identical to
+  # base. Remove the bd/kubectl paths once those binaries rebuild upstream;
+  # remove the gc paths once gc's go.mod bumps golang.org/x/net >= 0.55.0
+  # (>= 0.53.0 for CVE-2026-33814) and golang.org/x/crypto >= 0.52.0.
+  - id: CVE-2026-25680
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-07-07
+    statement: golang.org/x/net HTML parsing DoS; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+  - id: CVE-2026-25681
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-07-07
+    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+  - id: CVE-2026-27136
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-07-07
+    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+  - id: CVE-2026-39821
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-07-07
+    statement: golang.org/x/net/idna issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+  - id: CVE-2026-42502
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-07-07
+    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+  - id: CVE-2026-42506
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-07-07
+    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+  - id: CVE-2026-33814
+    paths:
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/net http2 issue; base-pre-existing (also red on main 2026-06-24). gc only (indirect x/net v0.52.0); bd/br/dolt/kubectl already covered by the stdlib waiver above. Remove once gc bumps golang.org/x/net >= 0.53.0.
+  - id: CVE-2026-39827
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+  - id: CVE-2026-39828
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+  - id: CVE-2026-39829
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+  - id: CVE-2026-39830
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+  - id: CVE-2026-39832
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/crypto/ssh/agent CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+  - id: CVE-2026-39835
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+  - id: CVE-2026-42508
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/crypto/ssh/knownhosts CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+  - id: CVE-2026-46595
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+  - id: CVE-2026-46597
+    paths:
+      - "usr/local/bin/bd"
+      - "usr/local/bin/gc"
+    expired_at: 2026-07-07
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.

--- a/deps.env
+++ b/deps.env
@@ -8,3 +8,15 @@ DOLT_VERSION=2.1.7
 BD_REPO=gastownhall/beads
 BD_VERSION=v1.0.4
 BR_VERSION=0.1.20
+
+# Cross-version contract-test matrix pins.
+# See engdocs/design/beads-gascity-contract-test-system.md.
+# BD_PREV_VERSION is the minimum-supported bd: a published release whose tarball
+# SHA is pinned in .github/scripts/install-bd-archive.sh (no API fallback on the
+# required path). BD_CURRENT_VERSION is the bleeding-edge release-candidate; it
+# has no release tarball, so the matrix builds it from beads source at
+# BD_CURRENT_REF (a gastownhall/beads commit). Bump BD_CURRENT_REF deliberately,
+# in lockstep with the vendored corpus, per the coordination protocol.
+BD_PREV_VERSION=v1.0.4
+BD_CURRENT_VERSION=v1.1.0-rc.1
+BD_CURRENT_REF=8c958d225c8357cd474ea8056c2bd9b2e35d9622

--- a/deps.env
+++ b/deps.env
@@ -10,13 +10,11 @@ BD_VERSION=v1.0.4
 BR_VERSION=0.1.20
 
 # Cross-version contract-test matrix pins.
-# See engdocs/design/beads-gascity-contract-test-system.md.
-# BD_PREV_VERSION is the minimum-supported bd: a published release whose tarball
-# SHA is pinned in .github/scripts/install-bd-archive.sh (no API fallback on the
-# required path). BD_CURRENT_VERSION is the bleeding-edge release-candidate; it
-# has no release tarball, so the matrix builds it from beads source at
-# BD_CURRENT_REF (a gastownhall/beads commit). Bump BD_CURRENT_REF deliberately,
-# in lockstep with the vendored corpus, per the coordination protocol.
-BD_PREV_VERSION=v1.0.4
+# The "prev" cell of the matrix is the minimum-supported bd: BD_VERSION above, a
+# published release whose tarball SHA is pinned in
+# .github/scripts/install-bd-archive.sh. BD_CURRENT_VERSION is the bleeding-edge
+# release-candidate; it has no release tarball, so the matrix builds it from
+# beads source at BD_CURRENT_REF (a gastownhall/beads commit). Bump
+# BD_CURRENT_REF deliberately, in lockstep with the vendored corpus.
 BD_CURRENT_VERSION=v1.1.0-rc.1
 BD_CURRENT_REF=8c958d225c8357cd474ea8056c2bd9b2e35d9622


### PR DESCRIPTION
## What

Phase 5 (gascity side): adds the **`current` cell** of the bd cross-version contract matrix to the required merge gate, so a bd change that breaks `gc`'s decoder/classifier surface against the **newer** bd is caught before merge — the #3135 class (gascity has `bd>=1.0.5` code paths that CI never exercised because it pinned only v1.0.4).

- **`contract-acceptance-current`** job: builds bd from `gastownhall/beads` source at `BD_CURRENT_REF` (`deps.env`) — the bleeding-edge rc has no release tarball — and runs the live `make test-acceptance` (Tier A) suite against it. The **`prev` cell** is the existing `preflight-acceptance` job (bd v1.0.4, min-supported). Together they are the dolt-only `bd_prev × gc_HEAD` and `bd_current × gc_HEAD` cells.
- Broadens the previously **dead** `beads` paths-filter (zero consumers) to also watch `deps.env`, `install-bd-archive.sh`, `init_provider_readiness.go`, and gives it its first consumer.
- Makes `setup-gascity-ubuntu`'s bd install conditional on `bd-version` so the current cell can build from source.
- Wires `contract-acceptance-current` into **`ci-required`** with `allow_skipped` (it's path-gated and skips on PRs that touch no beads path).

## Self-verifying

Because the broadened filter watches `deps.env` (changed here), **this PR triggers the new gate on its own CI run** — so the matrix cell is exercised and observed before any human merges it into the required aggregator. `actionlint` clean; YAML validated.

> Carries the `deps.env` matrix pins shared with Phase 0+1 (#3714) — trivially merge-compatible. `status/needs-review-auto` controls the blast radius: the gate only becomes required after review + merge.