### PR TITLE
Propagate Dolt server mode through ConfigState

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -1655,6 +1655,7 @@ func desiredCityDoltConfigState(cityPath string, cityDolt config.DoltConfig, cit
 			EndpointOrigin: contract.EndpointOriginCityCanonical,
 			DoltHost:       cityHost,
 			DoltPort:       cityPort,
+			DoltMode:       "server",
 		}
 		state.DoltUser = preservedDoltUser(cityPath, state)
 		state.EndpointStatus = preservedEndpointStatus(cityPath, state, contract.EndpointStatusUnverified)
@@ -1665,6 +1666,7 @@ func desiredCityDoltConfigState(cityPath string, cityDolt config.DoltConfig, cit
 		IssuePrefix:    cityPrefix,
 		EndpointOrigin: contract.EndpointOriginManagedCity,
 		EndpointStatus: contract.EndpointStatusVerified,
+		DoltMode:       "server",
 	}
 }
 
@@ -1674,6 +1676,7 @@ func desiredRigDoltConfigState(cityPath string, rig config.Rig, cityState contra
 		state := contract.ConfigState{
 			IssuePrefix:    rig.EffectivePrefix(),
 			EndpointOrigin: contract.EndpointOriginExplicit,
+			DoltMode:       "server",
 		}
 		state.DoltHost, state.DoltPort = configuredExternalDoltTargetForRig(rig)
 		state.DoltUser = preservedDoltUser(rig.Path, state)
@@ -1688,6 +1691,7 @@ func inheritedRigDoltConfigState(rigPath, prefix string, cityState contract.Conf
 	state := contract.ConfigState{
 		IssuePrefix:    prefix,
 		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		DoltMode:       cityState.DoltMode,
 	}
 	if cityState.EndpointOrigin == contract.EndpointOriginCityCanonical {
 		state.DoltHost = cityState.DoltHost

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -694,6 +694,190 @@ func TestNormalizeCanonicalBdScopeFilesPreservesExistingPostgresMetadata(t *test
 	if state.DoltDatabase != "" || state.DoltMode != "" {
 		t.Fatalf("metadata state = %+v, want dolt fields absent on postgres metadata", state)
 	}
+	configState, ok, err := contract.ReadConfigState(fsys.OSFS{}, filepath.Join(cityPath, ".beads", "config.yaml"))
+	if err != nil {
+		t.Fatalf("ReadConfigState: %v", err)
+	}
+	if !ok {
+		t.Fatal("config.yaml missing after normalization")
+	}
+	if configState.DoltMode != "" {
+		t.Fatalf("config DoltMode = %q, want absent for postgres-backed scope", configState.DoltMode)
+	}
+}
+
+func TestDesiredDoltConfigStateMarksKnownServerModes(t *testing.T) {
+	t.Run("managed city without endpoint coordinates", func(t *testing.T) {
+		cityPath := t.TempDir()
+		state, err := syncDesiredCityDoltConfigState(cityPath, config.DoltConfig{}, "gc")
+		if err != nil {
+			t.Fatalf("syncDesiredCityDoltConfigState: %v", err)
+		}
+		if state.EndpointOrigin != contract.EndpointOriginManagedCity {
+			t.Fatalf("EndpointOrigin = %q, want %q", state.EndpointOrigin, contract.EndpointOriginManagedCity)
+		}
+		if state.DoltHost != "" || state.DoltPort != "" {
+			t.Fatalf("managed city host/port = %q/%q, want empty managed runtime coordinates", state.DoltHost, state.DoltPort)
+		}
+		if state.DoltMode != "server" {
+			t.Fatalf("DoltMode = %q, want server for managed city runtime", state.DoltMode)
+		}
+	})
+
+	t.Run("city canonical external endpoint", func(t *testing.T) {
+		cityPath := t.TempDir()
+		state, err := syncDesiredCityDoltConfigState(cityPath, config.DoltConfig{Host: "db.example.test", Port: 4406}, "gc")
+		if err != nil {
+			t.Fatalf("syncDesiredCityDoltConfigState: %v", err)
+		}
+		if state.EndpointOrigin != contract.EndpointOriginCityCanonical {
+			t.Fatalf("EndpointOrigin = %q, want %q", state.EndpointOrigin, contract.EndpointOriginCityCanonical)
+		}
+		if state.DoltHost != "db.example.test" || state.DoltPort != "4406" {
+			t.Fatalf("city canonical host/port = %q/%q, want db.example.test/4406", state.DoltHost, state.DoltPort)
+		}
+		if state.DoltMode != "server" {
+			t.Fatalf("DoltMode = %q, want server for resolved city Dolt endpoint", state.DoltMode)
+		}
+	})
+
+	t.Run("explicit rig endpoint", func(t *testing.T) {
+		cityPath := t.TempDir()
+		rigPath := filepath.Join(cityPath, "frontend")
+		if err := os.MkdirAll(rigPath, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		cityState := contract.ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: contract.EndpointOriginManagedCity,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltMode:       "server",
+		}
+		state, err := syncDesiredRigDoltConfigState(cityPath, config.Rig{
+			Name:     "frontend",
+			Path:     rigPath,
+			Prefix:   "fe",
+			DoltHost: "rig-db.example.test",
+			DoltPort: "4407",
+		}, cityState)
+		if err != nil {
+			t.Fatalf("syncDesiredRigDoltConfigState: %v", err)
+		}
+		if state.EndpointOrigin != contract.EndpointOriginExplicit {
+			t.Fatalf("EndpointOrigin = %q, want %q", state.EndpointOrigin, contract.EndpointOriginExplicit)
+		}
+		if state.DoltHost != "rig-db.example.test" || state.DoltPort != "4407" {
+			t.Fatalf("explicit rig host/port = %q/%q, want rig-db.example.test/4407", state.DoltHost, state.DoltPort)
+		}
+		if state.DoltMode != "server" {
+			t.Fatalf("DoltMode = %q, want server for explicit rig Dolt endpoint", state.DoltMode)
+		}
+	})
+
+	t.Run("inherited city canonical endpoint", func(t *testing.T) {
+		cityPath := t.TempDir()
+		rigPath := filepath.Join(cityPath, "frontend")
+		if err := os.MkdirAll(rigPath, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		cityState := contract.ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: contract.EndpointOriginCityCanonical,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltHost:       "db.example.test",
+			DoltPort:       "4406",
+			DoltMode:       "server",
+		}
+		state, err := syncDesiredRigDoltConfigState(cityPath, config.Rig{
+			Name:   "frontend",
+			Path:   rigPath,
+			Prefix: "fe",
+		}, cityState)
+		if err != nil {
+			t.Fatalf("syncDesiredRigDoltConfigState: %v", err)
+		}
+		if state.EndpointOrigin != contract.EndpointOriginInheritedCity {
+			t.Fatalf("EndpointOrigin = %q, want %q", state.EndpointOrigin, contract.EndpointOriginInheritedCity)
+		}
+		if state.DoltHost != "db.example.test" || state.DoltPort != "4406" {
+			t.Fatalf("inherited rig host/port = %q/%q, want db.example.test/4406", state.DoltHost, state.DoltPort)
+		}
+		if state.DoltMode != "server" {
+			t.Fatalf("DoltMode = %q, want server inherited from city Dolt endpoint", state.DoltMode)
+		}
+	})
+}
+
+func TestManagedCityDoltModeReachesBdContextAndPreflight(t *testing.T) {
+	cityPath := t.TempDir()
+	beadsDir := filepath.Join(cityPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq","project_id":"gc-local"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := syncDesiredCityDoltConfigState(cityPath, config.DoltConfig{}, "gc")
+	if err != nil {
+		t.Fatalf("syncDesiredCityDoltConfigState: %v", err)
+	}
+	if state.EndpointOrigin != contract.EndpointOriginManagedCity {
+		t.Fatalf("EndpointOrigin = %q, want %q", state.EndpointOrigin, contract.EndpointOriginManagedCity)
+	}
+	if state.DoltHost != "" || state.DoltPort != "" {
+		t.Fatalf("managed city host/port = %q/%q, want empty managed runtime coordinates", state.DoltHost, state.DoltPort)
+	}
+	if state.DoltMode != "server" {
+		t.Fatalf("DoltMode = %q, want server before canonical config write", state.DoltMode)
+	}
+	if err := normalizeScopeDoltConfig(cityPath, state); err != nil {
+		t.Fatalf("normalizeScopeDoltConfig: %v", err)
+	}
+
+	configState, ok, err := contract.ReadConfigState(fsys.OSFS{}, filepath.Join(beadsDir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("ReadConfigState: %v", err)
+	}
+	if !ok {
+		t.Fatal("config.yaml missing after normalization")
+	}
+	if configState.DoltMode != "server" {
+		t.Fatalf("config DoltMode = %q, want server", configState.DoltMode)
+	}
+
+	installConfigBackedBdContextForTest(t)
+	reader := preflightBDContextReader(cityPath)
+	ctx, err := reader(cityPath)
+	if err != nil {
+		t.Fatalf("preflightBDContextReader: %v", err)
+	}
+	if ctx.Backend != "dolt" || ctx.DoltMode != "server" {
+		t.Fatalf("bd context = %+v, want backend=dolt dolt_mode=server", ctx)
+	}
+
+	checker := contract.PreflightChecker{
+		FS:                  fsys.OSFS{},
+		Provider:            "bd",
+		BeadsLibraryVersion: "1.0.4",
+		BDContext:           reader,
+		DatabaseProjectID: func(scope string) (string, bool, error) {
+			if !samePath(scope, cityPath) {
+				return "", false, fmt.Errorf("unexpected scope %s", scope)
+			}
+			return "gc-local", true, nil
+		},
+	}
+	result, err := checker.Check(cityPath)
+	if err != nil {
+		t.Fatalf("PreflightChecker.Check: %v", err)
+	}
+	if !result.NativeStoreEligible {
+		t.Fatalf("NativeStoreEligible = false, want true; checks=%+v", result.Checks)
+	}
+	if got := preflightCheckStateForTest(t, result, contract.PreflightCheckDoltModeSafe); got != contract.PreflightCheckPass {
+		t.Fatalf("dolt_mode_safe state = %q, want %q; checks=%+v", got, contract.PreflightCheckPass, result.Checks)
+	}
 }
 
 func TestNormalizeCanonicalBdScopeFilesRejectsExistingManagedSystemDatabase(t *testing.T) {
@@ -11588,6 +11772,37 @@ func TestVerifyManagedDoltDatabaseExistsAfterInitCatalogMiss(t *testing.T) {
 	}
 }
 
+func installConfigBackedBdContextForTest(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+set -eu
+if [ "$#" -ne 2 ] || [ "$1" != "context" ] || [ "$2" != "--json" ]; then
+  exit 2
+fi
+mode=""
+if [ -f "${BEADS_DIR}/config.yaml" ]; then
+  mode="$(sed -n 's/^[[:space:]]*mode:[[:space:]]*//p' "${BEADS_DIR}/config.yaml" | head -n 1)"
+fi
+printf '{"backend":"dolt","dolt_mode":"%s","bd_version":"1.0.4","schema_version":1}' "$mode"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func preflightCheckStateForTest(t *testing.T, result contract.PreflightResult, id contract.PreflightCheckID) contract.PreflightCheckState {
+	t.Helper()
+	for _, check := range result.Checks {
+		if check.ID == id {
+			return check.State
+		}
+	}
+	t.Fatalf("missing preflight check %s in %+v", id, result.Checks)
+	return ""
+}
+
 func setupFileProviderCityForTest(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
@@ -11846,4 +12061,190 @@ func publishRejectingManagedDoltRuntimeForTest(t *testing.T, cityPath string) fu
 		_ = ln.Close()
 		<-done
 	}
+}
+
+// ga-yqn5py.2.2: managed-Dolt server-mode write chain end-to-end tests.
+
+func TestDesiredCityDoltConfigStateSetsServerModeForManagedCity(t *testing.T) {
+	cityPath := t.TempDir()
+	state := desiredCityDoltConfigState(cityPath, config.DoltConfig{}, "hq")
+	if state.DoltMode != "server" {
+		t.Fatalf("DoltMode = %q, want server for managed city", state.DoltMode)
+	}
+}
+
+func TestDesiredCityDoltConfigStateSetsServerModeForExternalCity(t *testing.T) {
+	cityPath := t.TempDir()
+	state := desiredCityDoltConfigState(cityPath, config.DoltConfig{Host: "db.example.com", Port: 3307}, "hq")
+	if state.DoltMode != "server" {
+		t.Fatalf("DoltMode = %q, want server for external city", state.DoltMode)
+	}
+}
+
+func TestDesiredRigDoltConfigStateSetsServerModeForExplicitRig(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := t.TempDir()
+	rig := config.Rig{
+		Name:     "fe",
+		Path:     rigPath,
+		DoltHost: "127.0.0.1",
+		DoltPort: "4406",
+	}
+	cityState := contract.ConfigState{EndpointOrigin: contract.EndpointOriginManagedCity, DoltMode: "server"}
+	state := desiredRigDoltConfigState(cityPath, rig, cityState)
+	if state.DoltMode != "server" {
+		t.Fatalf("DoltMode = %q, want server for explicit rig", state.DoltMode)
+	}
+}
+
+func TestInheritedRigDoltConfigStatePropagatesDoltMode(t *testing.T) {
+	rigPath := t.TempDir()
+	cases := []struct {
+		name         string
+		cityDoltMode string
+		wantDoltMode string
+	}{
+		{"managed city with server mode", "server", "server"},
+		{"canonical city with server mode", "server", "server"},
+		{"city with no dolt mode", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cityState := contract.ConfigState{
+				EndpointOrigin: contract.EndpointOriginManagedCity,
+				DoltMode:       tc.cityDoltMode,
+			}
+			state := inheritedRigDoltConfigState(rigPath, "fe", cityState)
+			if state.DoltMode != tc.wantDoltMode {
+				t.Fatalf("DoltMode = %q, want %q", state.DoltMode, tc.wantDoltMode)
+			}
+		})
+	}
+}
+
+func TestManagedCityDoltEnsuresServerModeInConfig(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cityPath, ".beads", "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("issue_prefix: hq\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state := desiredCityDoltConfigState(cityPath, config.DoltConfig{}, "hq")
+	if _, err := contract.EnsureCanonicalConfig(fsys.OSFS{}, cfgPath, state); err != nil {
+		t.Fatalf("EnsureCanonicalConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	got := doltModeFromLifecycleTestYAML(t, data)
+	if got != "server" {
+		t.Fatalf("dolt.mode = %q after EnsureCanonicalConfig for managed city, want server; config:\n%s", got, data)
+	}
+}
+
+func TestPreflightCheckerReportsEligibleForManagedDoltServerMode(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq","project_id":"gc-local"}`
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := contract.PreflightChecker{
+		FS:                  fsys.OSFS{},
+		Provider:            "bd",
+		BeadsLibraryVersion: "1.0.4",
+		BDContext: func(string) (contract.PreflightBDContext, error) {
+			return contract.PreflightBDContext{
+				Backend:       "dolt",
+				DoltMode:      "server",
+				BDVersion:     "1.0.4",
+				SchemaVersion: 1,
+			}, nil
+		},
+		DatabaseProjectID: func(string) (string, bool, error) {
+			return "gc-local", true, nil
+		},
+	}
+
+	result, err := checker.Check(cityPath)
+	if err != nil {
+		t.Fatalf("PreflightChecker.Check: %v", err)
+	}
+	if !result.NativeStoreEligible {
+		t.Fatalf("NativeStoreEligible = false for managed Dolt server mode; checks=%+v", result.Checks)
+	}
+}
+
+func TestScopeWithNoDoltModeKeepsDoltModeAbsent(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(rigPath, ".beads", "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("issue_prefix: fe\nbackup.enabled: false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityState := contract.ConfigState{EndpointOrigin: contract.EndpointOriginManagedCity, DoltMode: ""}
+	rigState := inheritedRigDoltConfigState(rigPath, "fe", cityState)
+	if rigState.DoltMode != "" {
+		t.Fatalf("DoltMode = %q from empty city, want empty", rigState.DoltMode)
+	}
+
+	rigState.IssuePrefix = "fe"
+	rigState.EndpointStatus = contract.EndpointStatusVerified
+	if _, err := contract.EnsureCanonicalConfig(fsys.OSFS{}, cfgPath, rigState); err != nil {
+		t.Fatalf("EnsureCanonicalConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if mode := doltModeFromLifecycleTestYAMLOrEmpty(data); mode != "" {
+		t.Fatalf("dolt.mode = %q after EnsureCanonicalConfig with empty DoltMode, want absent; config:\n%s", mode, data)
+	}
+
+	_ = cityPath
+}
+
+// doltModeFromLifecycleTestYAML reads the nested dolt.mode key from a YAML
+// config. It fails the test if the key is absent or the YAML is invalid.
+func doltModeFromLifecycleTestYAML(t *testing.T, data []byte) string {
+	t.Helper()
+	mode := doltModeFromLifecycleTestYAMLOrEmpty(data)
+	if mode == "" {
+		t.Fatalf("dolt.mode missing from config:\n%s", data)
+	}
+	return mode
+}
+
+// doltModeFromLifecycleTestYAMLOrEmpty reads the nested dolt.mode key from YAML,
+// returning "" when the key is absent.
+func doltModeFromLifecycleTestYAMLOrEmpty(data []byte) string {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil || doc.Kind == 0 || len(doc.Content) == 0 {
+		return ""
+	}
+	root := doc.Content[0]
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value == "dolt" && root.Content[i+1].Kind == yaml.MappingNode {
+			doltNode := root.Content[i+1]
+			for j := 0; j+1 < len(doltNode.Content); j += 2 {
+				if doltNode.Content[j].Value == "mode" {
+					return doltNode.Content[j+1].Value
+				}
+			}
+		}
+	}
+	return ""
 }

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -307,6 +307,7 @@ func requestedRigEndpointState(rig config.Rig, currentState, cityState contract.
 			EndpointStatus: contract.EndpointStatusVerified,
 			DoltHost:       "127.0.0.1",
 			DoltPort:       strings.TrimSpace(opts.Port),
+			DoltMode:       "server",
 		}
 		if opts.AdoptUnverified {
 			state.EndpointStatus = contract.EndpointStatusUnverified
@@ -326,6 +327,7 @@ func requestedRigEndpointState(rig config.Rig, currentState, cityState contract.
 		DoltHost:       strings.TrimSpace(opts.Host),
 		DoltPort:       strings.TrimSpace(opts.Port),
 		DoltUser:       user,
+		DoltMode:       "server",
 	}
 	if opts.AdoptUnverified {
 		state.EndpointStatus = contract.EndpointStatusUnverified

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -522,7 +522,8 @@ func EnsureCanonicalConfig(fs fsys.FS, path string, state ConfigState) (bool, er
 	}
 
 	if mode := strings.TrimSpace(state.DoltMode); mode != "" {
-		changed = setString(root, "dolt.mode", mode) || changed
+		changed = setNestedString(root, "dolt", "mode", mode) || changed
+		changed = deleteKeys(root, "dolt.mode") || changed
 	}
 
 	changed = deleteKeys(root, deprecatedConfigKeys...) || changed
@@ -912,6 +913,7 @@ func readConfigStateFromData(data []byte) ConfigState {
 }
 
 func readConfigStateFromRoot(root *yaml.Node) ConfigState {
+	doltMode, _ := nestedConfigStringValue(root, "dolt", "mode")
 	return ConfigState{
 		IssuePrefix:    configValue(root, "issue_prefix", "issue-prefix"),
 		EndpointOrigin: endpointOriginValue(configValue(root, "gc.endpoint_origin")),
@@ -919,8 +921,17 @@ func readConfigStateFromRoot(root *yaml.Node) ConfigState {
 		DoltHost:       configValue(root, "dolt.host"),
 		DoltPort:       configValue(root, "dolt.port"),
 		DoltUser:       configValue(root, "dolt.user"),
+		DoltMode:       doltMode,
 		Dolt:           readDoltConfigFromRoot(root),
 	}
+}
+
+func nestedConfigStringValue(root *yaml.Node, section string, keys ...string) (string, bool) {
+	sectionNode := findValue(root, section)
+	if sectionNode == nil || sectionNode.Kind != yaml.MappingNode {
+		return "", false
+	}
+	return configStringValue(sectionNode, keys...)
 }
 
 func readDoltConfigFromRoot(root *yaml.Node) DoltConfig {
@@ -1105,6 +1116,16 @@ func setNestedBool(root *yaml.Node, section, key string, value bool) bool {
 		changed = setMapping(root, section, sectionNode) || changed
 	}
 	return setBool(sectionNode, key, value) || changed
+}
+
+func setNestedString(root *yaml.Node, section, key, value string) bool {
+	sectionNode := findValue(root, section)
+	changed := false
+	if sectionNode == nil || sectionNode.Kind != yaml.MappingNode {
+		sectionNode = &yaml.Node{Kind: yaml.MappingNode}
+		changed = setMapping(root, section, sectionNode) || changed
+	}
+	return setString(sectionNode, key, value) || changed
 }
 
 func setMapping(root *yaml.Node, key string, value *yaml.Node) bool {

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -438,6 +438,93 @@ func TestEnsureCanonicalConfigPreservesDoltDisableEventFlushOptOut(t *testing.T)
 	}
 }
 
+func TestEnsureCanonicalConfigWritesDoltModeWhenSupplied(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue_prefix: gc",
+		"issue-prefix: gc",
+		"dolt.auto-start: false",
+		"export.auto: false",
+		"dolt:",
+		"  disable-event-flush: true",
+		"gc.endpoint_origin: managed_city",
+		"gc.endpoint_status: verified",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state := ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: EndpointOriginManagedCity,
+		EndpointStatus: EndpointStatusVerified,
+		DoltMode:       "server",
+	}
+	changed, err := EnsureCanonicalConfig(fs, path, state)
+	if err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("EnsureCanonicalConfig() should report changes when adding dolt.mode")
+	}
+	if got := doltModeFromConfig(t, path); got != "server" {
+		t.Fatalf("dolt.mode = %q, want %q", got, "server")
+	}
+
+	changed, err = EnsureCanonicalConfig(fs, path, state)
+	if err != nil {
+		t.Fatalf("second EnsureCanonicalConfig() error = %v", err)
+	}
+	if changed {
+		t.Fatal("second EnsureCanonicalConfig() should be idempotent with existing dolt.mode")
+	}
+	if got := doltModeFromConfig(t, path); got != "server" {
+		t.Fatalf("dolt.mode after idempotent run = %q, want %q", got, "server")
+	}
+}
+
+func TestEnsureCanonicalConfigPreservesExistingDoltModeWhenStateOmitsIt(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue_prefix: gc",
+		"issue-prefix: gc",
+		"dolt.auto-start: false",
+		"export.auto: false",
+		"backup.enabled: false",
+		"dolt:",
+		"  disable-event-flush: true",
+		"  mode: server",
+		"gc.endpoint_origin: managed_city",
+		"gc.endpoint_status: verified",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: EndpointOriginManagedCity,
+		EndpointStatus: EndpointStatusVerified,
+		DoltMode:       "",
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+	if changed {
+		data, _ := fs.ReadFile(path)
+		t.Fatalf("EnsureCanonicalConfig() should preserve existing dolt.mode when state omits it:\n%s", data)
+	}
+	if got := doltModeFromConfig(t, path); got != "server" {
+		t.Fatalf("dolt.mode = %q, want preserved %q", got, "server")
+	}
+}
+
 func TestEnsureCanonicalConfigCanonicalizesFlatDoltDisableEventFlush(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()
@@ -1883,12 +1970,8 @@ func TestEnsureCanonicalConfigWritesDoltModeOnAbsentConfig(t *testing.T) {
 		t.Fatal("EnsureCanonicalConfig() changed = false, want true for new file with DoltMode")
 	}
 
-	data, err := fs.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(data), "dolt.mode: server") {
-		t.Fatalf("config missing dolt.mode: server:\n%s", data)
+	if got := doltModeFromConfig(t, path); got != "server" {
+		t.Fatalf("dolt.mode = %q, want %q", got, "server")
 	}
 }
 
@@ -1914,10 +1997,10 @@ func TestEnsureCanonicalConfigDoltModeIdempotent(t *testing.T) {
 	}
 }
 
-// TestEnsureCanonicalConfigPreservesExistingDoltModeWhenStateOmitsIt verifies
-// that a pre-existing dolt.mode: server in config is not removed or changed
-// when ConfigState.DoltMode is empty ("caller doesn't know the mode").
-func TestEnsureCanonicalConfigPreservesExistingDoltModeWhenStateOmitsIt(t *testing.T) {
+// TestEnsureCanonicalConfigPreservesExistingDoltModeSimpleRoundTrip verifies
+// that a nested dolt.mode: server written by EnsureCanonicalConfig is preserved
+// when called again with DoltMode:"" (caller doesn't know the mode).
+func TestEnsureCanonicalConfigPreservesExistingDoltModeSimpleRoundTrip(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
@@ -1937,12 +2020,8 @@ func TestEnsureCanonicalConfigPreservesExistingDoltModeWhenStateOmitsIt(t *testi
 		t.Fatalf("EnsureCanonicalConfig(DoltMode empty) changed = true, want false:\n%s", data)
 	}
 
-	data, err := fs.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(data), "dolt.mode: server") {
-		t.Fatalf("config should preserve existing dolt.mode: server when DoltMode is empty:\n%s", data)
+	if got := doltModeFromConfig(t, path); got != "server" {
+		t.Fatalf("dolt.mode = %q, want preserved %q", got, "server")
 	}
 }
 
@@ -1991,4 +2070,43 @@ func TestEnsureCanonicalMetadataPreservesAllKeysOnEmptyBackend(t *testing.T) {
 			t.Fatalf("metadata should preserve %q when backend is empty: %s", key, data)
 		}
 	}
+}
+
+func TestCrossBackendKeysToScrubUsesMetadataDoltModeKey(t *testing.T) {
+	if containsString(crossBackendKeysToScrub("dolt"), "dolt.mode") {
+		t.Fatal(`crossBackendKeysToScrub("dolt") should not include config key "dolt.mode"`)
+	}
+	if !containsString(crossBackendKeysToScrub("postgres"), "dolt_mode") {
+		t.Fatal(`crossBackendKeysToScrub("postgres") should still include metadata key "dolt_mode"`)
+	}
+	if containsString(crossBackendKeysToScrub("postgres"), "dolt.mode") {
+		t.Fatal(`crossBackendKeysToScrub("postgres") should not replace metadata key "dolt_mode" with config key "dolt.mode"`)
+	}
+}
+
+func doltModeFromConfig(t *testing.T, path string) string {
+	t.Helper()
+	fs := fsys.OSFS{}
+	doc, err := readConfigDoc(fs, path)
+	if err != nil {
+		t.Fatalf("read config doc: %v", err)
+	}
+	value, ok := configStringValue(findValue(mappingRoot(doc), "dolt"), "mode")
+	if !ok {
+		data, readErr := fs.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("read config after missing dolt.mode: %v", readErr)
+		}
+		t.Fatalf("config missing dolt.mode:\n%s", data)
+	}
+	return value
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/release-gates/ga-t2x8dv-configstate-doltmode-gate.md
+++ b/release-gates/ga-t2x8dv-configstate-doltmode-gate.md
@@ -1,0 +1,71 @@
+# Release Gate: ConfigState DoltMode Server Propagation
+
+Date: 2026-06-25
+
+Primary deploy bead: `ga-t2x8dv.3`
+Duplicate deploy notification covered by this gate: `ga-59hpx3`
+Root/source bead: `ga-t2x8dv`
+Implementation source bead: `ga-yqn5py.2.1`
+Original review bead: `ga-94h3qv`
+Clean repackage review bead: `ga-t2x8dv.2`
+
+Branch: `builder/ga-t2x8dv.1-configstate-doltmode-clean`
+Reviewed implementation commit: `5bc45410676412e772b8a4e49688b2be254ce9e7`
+Base: `origin/main` at `3b1391cf9cfbe249ad6d25617d0c391982ee2890`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses
+the deployer release criteria supplied by the active Gas City deployer prompt.
+
+## Change Under Gate
+
+The branch carries Dolt server-mode through the existing `ConfigState` and
+canonical beads config paths. It writes or preserves `dolt.mode: server` for
+managed and explicit Dolt-backed city/rig scopes so preflight checks and bd/gc
+runtime context see server mode consistently.
+
+Touched implementation paths:
+
+- `cmd/gc/beads_provider_lifecycle.go`
+- `cmd/gc/beads_provider_lifecycle_test.go`
+- `cmd/gc/cmd_rig_endpoint.go`
+- `internal/beads/contract/files.go`
+- `internal/beads/contract/files_test.go`
+
+## Acceptance Criteria
+
+| Criterion | Result | Evidence |
+| --- | --- | --- |
+| Clean reviewed branch recorded | PASS | `ga-t2x8dv.2` records branch `builder/ga-t2x8dv.1-configstate-doltmode-clean`, commit `5bc45410676412e772b8a4e49688b2be254ce9e7`, and base `3b1391cf9cfbe249ad6d25617d0c391982ee2890`. |
+| Reviewer PASS present | PASS | `ga-t2x8dv.2` is closed with `Reviewer Verdict: PASS`; original review bead `ga-94h3qv` is also closed with `Review Verdict: PASS`. |
+| All four ConfigState constructor paths set or propagate server mode | PASS | Review evidence confirms `desiredCityDoltConfigState`, `desiredRigDoltConfigState`, `inheritedRigDoltConfigState`, and `requestedRigEndpointState` cover managed city, external city, explicit rig, inherited rig, and rig endpoint flows. Local code scan confirms `DoltMode: "server"` or inherited propagation at those call sites. |
+| Canonical config writes and preserves `dolt.mode` | PASS | `internal/beads/contract/files.go` adds `ConfigState.DoltMode`, writes non-empty mode into canonical config, preserves existing mode when omitted, and excludes only the metadata key `dolt_mode` from cross-backend scrub lists. |
+| Focused coverage present | PASS | New/updated tests cover server-mode constructors, inherited empty/server behavior, canonical config write/idempotency/preservation, preflight context, and scrub-key behavior. |
+| Standard deploy gate run | PASS | `make test` completed successfully on the final feature branch. Observable log: `/tmp/gascity-test.jsonl.qSpgE3`. |
+| Branch clean, mergeable, single theme | PASS | `git status --short --branch` was clean before writing this gate artifact; `git merge-tree --write-tree origin/main HEAD` exited 0; `origin/main...HEAD` contains one implementation commit and touches only the ConfigState/beads config subsystem. |
+
+## Release Gate Criteria
+
+| # | Criterion | Result | Evidence |
+| --- | --- | --- | --- |
+| 1 | Review PASS present | PASS | Clean review bead `ga-t2x8dv.2` is closed with `Reviewer Verdict: PASS`. Original review bead `ga-94h3qv` is closed with `Review Verdict: PASS`. |
+| 2 | Acceptance criteria met | PASS | All deploy bead acceptance criteria are satisfied: clean repackage evidence exists, review PASS exists, deployer gate ran on `5bc45410676412e772b8a4e49688b2be254ce9e7`, tests passed, merge-tree is clean, and the diff is one ConfigState DoltMode feature theme. |
+| 3 | Tests pass | PASS | `make test` returned exit 0 with `observable go test: PASS log=/tmp/gascity-test.jsonl.qSpgE3`. `go vet ./...` returned exit 0. |
+| 4 | No high-severity review findings open | PASS | `ga-t2x8dv.2` records PASS for scope hygiene, behavior fidelity, API scope, tests, and security. The earlier `ga-94h3qv` LOW coverage note is resolved by the clean branch's direct tests. No unresolved HIGH findings are recorded. |
+| 5 | Final branch is clean | PASS | Before gate artifact creation, `git status --short --branch` returned only `## builder/ga-t2x8dv.1-configstate-doltmode-clean...origin/builder/ga-t2x8dv.1-configstate-doltmode-clean`. This gate file is the only deployer-added file and is committed as the release-gate commit before push/PR. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` returned tree `2a6aa28b286ec1fecb0377701461f993a127acfa` with exit 0. |
+| 7 | Single feature theme | PASS | `git log --oneline --no-merges origin/main..HEAD` contains one implementation commit: `5bc454106 feat(beads): propagate DoltMode server-mode through ConfigState (#3702, ga-yqn5py)`. `git diff --name-status origin/main...HEAD` touches only the ConfigState/beads config lifecycle files listed above. |
+
+## Command Evidence
+
+- `git cat-file -e 5bc45410676412e772b8a4e49688b2be254ce9e7^{commit}`: PASS
+- `git fetch origin main`: PASS
+- `git status --short --branch`: clean before gate artifact creation
+- `git merge-tree --write-tree origin/main HEAD`: PASS, tree `2a6aa28b286ec1fecb0377701461f993a127acfa`
+- `make test`: PASS, observable log `/tmp/gascity-test.jsonl.qSpgE3`
+- `go vet ./...`: PASS
+
+## Decision
+
+PASS. Open a PR from `builder/ga-t2x8dv.1-configstate-doltmode-clean` to
+`main`, record the PR URL on `ga-t2x8dv.3` and `ga-59hpx3`, close both deploy
+beads, and route the merge-request to `mayor`. The deployer must not merge.


### PR DESCRIPTION
## What this changes

Gas City now carries Dolt server mode through the `ConfigState` used by beads config setup. Managed city, external city endpoint, explicit rig endpoint, inherited rig, and `gc rig endpoint` flows write or preserve `dolt.mode: server` before preflight and runtime-context checks run.

The config contract now includes `ConfigState.DoltMode`, and the canonical beads config writer records that mode when it is supplied while preserving an existing `dolt.mode` when the caller does not know it. That keeps `bd` and `gc` from losing server-mode intent during config canonicalization.

## Why this shape

The mode flows through the existing `ConfigState` / `EnsureCanonicalConfig` path instead of special-casing preflight or provider startup. That keeps all city and rig endpoint constructors feeding the same canonical config contract, and it keeps omitted state non-destructive for existing configs.

## Review notes

- New exported field: `internal/beads/contract.ConfigState.DoltMode`.
- Config writer behavior: non-empty mode writes `dolt.mode`; empty mode preserves an existing value.
- Constructor surfaces: `cmd/gc/beads_provider_lifecycle.go` and `cmd/gc/cmd_rig_endpoint.go`.
- No migration, flag, endpoint, or dashboard changes are included.
- Internal refs: `ga-t2x8dv`, `ga-yqn5py.2.1`, `ga-94h3qv`.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-t2x8dv-configstate-doltmode-gate.md`](release-gates/ga-t2x8dv-configstate-doltmode-gate.md)
