### PR TITLE
fix(beads): skip message beads in cache ready-projection to stop reconcile flood

### DIFF
--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -21,7 +21,13 @@ func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 	ids := make([]string, 0, len(items))
 	seen := make(map[string]struct{}, len(items))
 	for _, item := range items {
-		if item.ID == "" || item.Status == "closed" || item.IsBlocked != nil {
+		// Message (mail) beads are never dependency-blocked ready work, and
+		// bd's denormalized is_blocked column flaps NULL<->false for ephemeral
+		// mail wisps. Enriching them makes the CachingStore reconciler re-emit
+		// bead.updated for every open mail bead on every cycle (an event flood
+		// that starves gc-hook work queries). Leave their IsBlocked at bd's nil
+		// fallback so the reconcile diff converges.
+		if item.ID == "" || item.Status == "closed" || item.IsBlocked != nil || item.Type == "message" {
 			continue
 		}
 		if _, ok := seen[item.ID]; ok {
@@ -48,7 +54,7 @@ func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 	enriched := make([]Bead, len(items))
 	copy(enriched, items)
 	for i := range enriched {
-		if enriched[i].ID == "" || enriched[i].Status == "closed" || enriched[i].IsBlocked != nil {
+		if enriched[i].ID == "" || enriched[i].Status == "closed" || enriched[i].IsBlocked != nil || enriched[i].Type == "message" {
 			continue
 		}
 		blocked, ok := projection[enriched[i].ID]

--- a/internal/beads/bdstore_ready_projection_internal_test.go
+++ b/internal/beads/bdstore_ready_projection_internal_test.go
@@ -1,0 +1,50 @@
+package beads
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestEnrichReadyProjectionForCacheSkipsMessageBeads guards the cache-reconcile
+// convergence fix: message (mail) beads are never dependency-blocked ready work,
+// and bd's denormalized is_blocked column flaps NULL<->false for ephemeral mail
+// wisps. Feeding them through the ready projection makes the CachingStore
+// reconciler re-emit bead.updated for them every cycle (an event flood that
+// starved gc-hook work queries). The enrichment must leave their IsBlocked nil
+// so the reconcile diff converges, while still enriching real work beads.
+func TestEnrichReadyProjectionForCacheSkipsMessageBeads(t *testing.T) {
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		joined := name + " " + strings.Join(args, " ")
+		switch {
+		case joined == "bd version":
+			return []byte("bd version 1.1.0\n"), nil
+		case len(args) > 0 && args[0] == "sql":
+			// bd reports both ids as not-blocked; a buggy enrichment would
+			// stamp IsBlocked=&false on the message bead too.
+			return []byte(`[{"id":"mc-wisp-mail","is_blocked":false},{"id":"gcg-task","is_blocked":false}]`), nil
+		}
+		return nil, fmt.Errorf("unexpected command: %s", joined)
+	}
+	s := NewBdStore("/city", runner)
+
+	items := []Bead{
+		{ID: "mc-wisp-mail", Type: "message", Status: "open"}, // ephemeral mail, IsBlocked nil
+		{ID: "gcg-task", Type: "task", Status: "open"},        // real work, IsBlocked nil
+	}
+	out, err := s.enrichReadyProjectionForCache(items)
+	if err != nil {
+		t.Fatalf("enrichReadyProjectionForCache: %v", err)
+	}
+
+	byID := make(map[string]Bead, len(out))
+	for _, b := range out {
+		byID[b.ID] = b
+	}
+	if got := byID["mc-wisp-mail"].IsBlocked; got != nil {
+		t.Errorf("message bead IsBlocked = &%v, want nil (must be skipped so the reconcile diff converges)", *got)
+	}
+	if got := byID["gcg-task"].IsBlocked; got == nil || *got {
+		t.Errorf("task bead IsBlocked = %v, want &false (real work must still be enriched)", got)
+	}
+}


### PR DESCRIPTION
## Problem

On maintainer-city the PR-review pipeline stalled: PRs sat in `status/reviewing` indefinitely. Root cause was an event flood from the `CachingStore` reconciler.

**RCA:** The city store's background reconcile loop full-scans the active universe each cycle and emits `bead.updated` wherever `beadChanged()` differs from its cache snapshot. ~347 open `type=message` ephemeral **mail** beads accumulated (weeks old), and the reconciler re-emitted `bead.updated` for all of them **every cycle** — proven: one bead had 402 consecutive byte-identical emits; the supervisor heartbeat showed `rig=mc … updates=347` every cycle. That's ~138K `bead.updated`/day (~800/min bursts), which saturated the event bus and pushed run-operator `gc hook` work queries past their 15s hard timeout (`session.work_query_failed: work query timed out`) → operators got no work → molecules never advanced.

The flap isn't in bd's row output (byte-stable across reads) or in deps (these beads have none). It's in the cache's **ready-projection enrichment**: `bd list` returns these beads with `is_blocked` unset (nil); `enrichReadyProjectionForCache` fills it from `fetchReadyProjection`, whose SQL reads `is_blocked` from the `issues`/`wisps` tables. For ephemeral mail wisps that column flaps `NULL ↔ false` at the DB level, so the enriched `IsBlocked` flips `nil ↔ &false` each cycle and `beadChanged` (which compares `IsBlocked`) fires forever.

## Fix

Message (mail) beads are never dependency-blocked ready work, so exclude `Type == "message"` from the ready-projection enrichment (both the candidate-collection and apply loops). Their `IsBlocked` stays at bd's nil fallback, so the reconcile diff converges. Real work beads are enriched exactly as before. Only `BdStore` needs the change; the DoltLite enrichment is already a no-op.

## Testing

- New `TestEnrichReadyProjectionForCacheSkipsMessageBeads` (TDD: fails before, passes after) — a `message` bead stays `IsBlocked=nil` while a `task` bead is still enriched to `&false`.
- `go test ./internal/beads/` (full package, incl. all reconcile tests), `go vet ./...`, and `go build ./internal/... ./cmd/...` all pass.

## Follow-ups (not in this PR)

- **Reaper:** open ephemeral mail accumulates unbounded — nothing reaps undelivered/aged ephemeral messages (they're in the templates/wisp tier, invisible to `bd list --label … --status open`). An age-based expiry would prevent re-accumulation. (Live incident was mitigated by `bd close` + `bd purge --force` of the stale mail.)
- **General convergence:** the reconcile diff could carry forward a cached `IsBlocked` when the projection omits a bead, fixing the non-convergence for any bead type rather than just `message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)