### PR TITLE
fix(order): record cooldown tracking bead for manual exec order runs (#3570)

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -576,19 +576,29 @@ func cmdOrderRun(name, rig string, jsonOutput bool, stdout, stderr io.Writer) in
 			fmt.Fprintln(stderr, "gc order run: --json is not supported for exec orders because the exec body may write arbitrary stdout") //nolint:errcheck // best-effort stderr
 			return 1
 		}
+		// Manual/condition triggers have no cooldown clock to advance, so they run
+		// directly without opening a store. Event/cooldown/cron orders record a
+		// scoped tracking bead so `gc order check` sees the run and the order does
+		// not re-fire every tick (#3570).
+		if a.Trigger != "event" && !orderTriggerUsesLastRun(a) {
+			return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
+		}
+		store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
+		if store == nil {
+			return storeCode
+		}
+		// Only event-triggered orders need the event cursor; cooldown/cron
+		// orders just need the run recorded.
+		var ep events.Provider
 		if a.Trigger == "event" {
-			store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
-			if store == nil {
-				return storeCode
-			}
-			ep, epCode := openCityEventsProvider(stderr, "gc order run")
+			var epCode int
+			ep, epCode = openCityEventsProvider(stderr, "gc order run")
 			if ep == nil {
 				return epCode
 			}
 			defer ep.Close() //nolint:errcheck // best-effort
-			return doOrderRunExecTracked(a, cityPath, cfg, store, ep, stdout, stderr)
 		}
-		return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
+		return doOrderRunExecTracked(a, cityPath, cfg, store, ep, stdout, stderr)
 	}
 	store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
 	if store == nil {
@@ -771,16 +781,27 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 }
 
 func doOrderRunExecTracked(a orders.Order, cityPath string, cfg *config.City, store beads.Store, ep events.Provider, stdout, stderr io.Writer) int {
-	if a.Trigger != "event" || ep == nil {
-		return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
+	scoped := a.ScopedName()
+
+	// Event-triggered orders capture the event cursor before the side effect so
+	// the controller cursor isn't left stale; cooldown/cron orders only need the
+	// run record. Reading the cursor up front keeps a cursor failure from leaving
+	// an orphaned tracking bead.
+	var cursorLabels []string
+	if a.Trigger == "event" && ep != nil {
+		headSeq, err := ep.LatestSeq()
+		if err != nil {
+			fmt.Fprintf(stderr, "gc order run: reading event cursor for %s: %v\n", scoped, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		cursorLabels = eventCursorLabels(scoped, headSeq)
 	}
 
-	scoped := a.ScopedName()
-	headSeq, err := ep.LatestSeq()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc order run: reading event cursor for %s: %v\n", scoped, err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
+	// Record the run with a scoped tracking bead so `gc order check` advances the
+	// cooldown clock, matching dispatcher-driven runs (order_dispatch.go) and the
+	// formula path. Without this, a manual `gc order run --rig` is invisible to
+	// the labelOrderTracking history index and the order re-fires every tick
+	// (#3570).
 	tracking, err := store.Create(beads.Bead{
 		Title:     "order:" + scoped,
 		Labels:    []string{"order-run:" + scoped, labelOrderTracking},
@@ -792,11 +813,11 @@ func doOrderRunExecTracked(a orders.Order, cityPath string, cfg *config.City, st
 	}
 	defer store.Close(tracking.ID) //nolint:errcheck // best-effort close
 
-	// Persist the event cursor before running the command so manual event execs
-	// do not leave the controller cursor stale after the side effect.
-	if err := store.Update(tracking.ID, beads.UpdateOpts{Labels: eventCursorLabels(scoped, headSeq)}); err != nil {
-		fmt.Fprintf(stderr, "gc order run: labeling exec event cursor for %s: %v\n", scoped, err) //nolint:errcheck // best-effort stderr
-		return 1
+	if len(cursorLabels) > 0 {
+		if err := store.Update(tracking.ID, beads.UpdateOpts{Labels: cursorLabels}); err != nil {
+			fmt.Fprintf(stderr, "gc order run: labeling exec event cursor for %s: %v\n", scoped, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	result := doOrderRunExecResult(a, cityPath, cfg, stdout, stderr)

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -2681,6 +2681,59 @@ dolt.auto-start: false
 	}
 }
 
+func TestOrderRunExecTrackedRecordsCooldownForNonEventRigOrder(t *testing.T) {
+	// Regression for #3570: a manual `gc order run <name> --rig <rig>` of a
+	// cooldown-triggered exec order must record a rig-scoped cooldown tracking
+	// bead. Without it, `gc order check --rig` always reports "never run" and
+	// the order re-fires every tick (process exhaustion).
+	disableManagedDoltRecoveryForTest(t)
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`)
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	a := orders.Order{
+		Name:     "poll",
+		Rig:      "frontend",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "true",
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRunExecTracked(a, cityDir, cfg, store, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRunExecTracked = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	all := trackingBeads(t, store, "order-run:poll:rig:frontend")
+	if len(all) != 1 {
+		t.Fatalf("rig-scoped tracking bead count = %d, want 1 (labels must be scoped so gc order check finds the run)", len(all))
+	}
+	if all[0].Title != "order:poll:rig:frontend" {
+		t.Fatalf("tracking bead title = %q, want order:poll:rig:frontend", all[0].Title)
+	}
+	if !slicesContain(all[0].Labels, "exec") {
+		t.Fatalf("tracking bead labels = %v, want exec", all[0].Labels)
+	}
+}
+
 func TestOrderRunExecEnvBuildFailureRedactsProcessSecrets(t *testing.T) {
 	clearAmbientPostgresEnv(t)
 	t.Setenv("GC_BEADS", "bd")


### PR DESCRIPTION
Fixes #3570.

## Problem
Manual `gc order run --rig` for cooldown/cron/event-triggered orders did **not** record a scoped tracking bead, so `gc order check` never saw the manual run and the cooldown clock did not advance — the order stayed perpetually "due" and re-fired every tick (invisible to `labelOrderTracking`).

## Fix
`gc order run --rig` now records a scoped tracking bead for cooldown/cron/event orders, matching the behavior of dispatcher-driven and formula runs, so the cooldown clock advances correctly.

## Changes
- `cmd/gc/cmd_order.go` (+41/-20): record scoped tracking bead on manual exec runs.
- `cmd/gc/cmd_order_test.go` (+53, new): regression test `TestOrderRunExecTrackedRecordsCooldownForNonEventRigOrder`.

## Test plan
- `go build ./cmd/gc` — OK
- `go vet ./cmd/gc` — OK
- `go test ./cmd/gc -run Order` — OK (incl. the new regression test)
- Merges cleanly onto current `main` (no conflicts with merge-base).
