### PR TITLE
fix(k8s): make pod beads init POSIX sh compatible

### DIFF
--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -797,10 +797,10 @@ func initBeadsInPod(ctx context.Context, ops k8sOps, podName string, cfg runtime
 			`m=json.load(open('.beads/metadata.json')); `+
 			`p=json.loads(sys.argv[1]); m.update(p); m.pop('project_id', None); `+
 			`json.dump(m,open('.beads/metadata.json','w'),indent=2)" "$PATCH" 2>/dev/null || `+
-			`python3 -c "import json,sys; `+
+			`printf '%%s' "$PATCH" | python3 -c "import json,sys; `+
 			`m=json.load(open('.beads/metadata.json')); `+
 			`p=json.loads(sys.stdin.read()); m.update(p); m.pop('project_id', None); `+
-			`json.dump(m,open('.beads/metadata.json','w'),indent=2)" <<< "$PATCH"; `+
+			`json.dump(m,open('.beads/metadata.json','w'),indent=2)"; `+
 			`else PREFIX=$(echo '%s' | base64 -d) && `+
 			`DOLT_HOST=$(echo '%s' | base64 -d) && `+
 			`DOLT_PORT=$(echo '%s' | base64 -d) && `+

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -1643,6 +1643,12 @@ func TestInitBeadsInPodStripsProjectIDFromMetadata(t *testing.T) {
 	if count < 2 {
 		t.Errorf("expected %q to appear in both python3 patch invocations (>=2 times), got %d\nscript:\n%s", want, count, script)
 	}
+	if strings.Contains(script, "<<<") {
+		t.Errorf("metadata patch script must be POSIX sh compatible; found bash here-string in:\n%s", script)
+	}
+	if !strings.Contains(script, `printf '%s' "$PATCH" | python3 -c`) {
+		t.Errorf("metadata patch fallback should pipe PATCH into python3 stdin for POSIX sh compatibility:\n%s", script)
+	}
 }
 
 func TestStartSkipsStagingWhenPrebaked(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace the k8s provider's pod-side metadata patch here-string with a POSIX `printf | python3` pipeline
- add a regression assertion that generated `initBeadsInPod` scripts do not contain bash here-strings

## Root Cause
`initBeadsInPod` execs the metadata patch with `sh -c` inside agent pods. On the zilly-rig image used by gc-sentry witness/polecat, `/bin/sh` is dash, not bash. The fallback path used:

```sh
python3 -c "... sys.stdin.read() ..." <<< "$PATCH"
```

dash rejects `<<<` and emits the live failure seen in gc-sentry:

```text
sh: 1: Syntax error: redirection unexpected
```

That failure happens before the session command reaches a stable tmux server, so witness/polecat pods die with `no server running on /tmp/tmux-0/default`.

## Verification
- `go test ./internal/runtime/k8s -run 'TestInitBeadsInPod|TestStartUsesPodBeadsRepairScript|TestStartWarnsWhenInitBeadsInPodFails' -count=1`
- `go test ./internal/runtime/k8s -count=1`
- Standalone gc-sentry zilly-rig debug pod (`kubectl run`, not gc reconciler):
  - old `<<< "$PATCH"` form under `/bin/sh` reproduced `Syntax error: redirection unexpected`
  - patched `printf '%s' "$PATCH" | python3 ...` script passed `sh -n`, updated `.beads/metadata.json`, removed stale `project_id`, and left `tmux main` reachable
