### PR TITLE
feat(doctor): bd-backup-freshness check for stale backup syncs

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -322,6 +322,10 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 	// reclaimed and dolt-backup.json registrations pointing at deleted
 	// paths (ga-yfbs28).
 	register(doctor.NewBdBackupStateCheckForConfig(cityPath, cfg, cfgErr))
+	// Backup freshness: a configured bd backup that silently stopped syncing
+	// looks healthy to every other backup check while its recovery point ages
+	// out — the only surviving backup can be weeks stale before anyone notices.
+	register(doctor.NewBdBackupFreshnessCheckForConfig(cityPath, cfg, cfgErr))
 	// Worktree checks deliberately run even when cfgErr != nil — they
 	// only need the city path, and a broken city.toml is exactly when
 	// silent disk-fill is most likely. The zero-value DoctorConfig

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -69,6 +69,7 @@ events-log
 events-log-size
 bd-backup-size
 bd-backup-state
+bd-backup-freshness
 worktree-disk-size
 nested-worktree-prune
 custom-types:city

--- a/internal/doctor/checks_bd_backup_freshness.go
+++ b/internal/doctor/checks_bd_backup_freshness.go
@@ -1,0 +1,175 @@
+package doctor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// defaultBackupFreshnessMaxAge is how stale a rig's last bd backup sync may be
+// before BdBackupFreshnessCheck warns. bd's auto-backup interval is minutes, so
+// a day-old (or older) last sync means the backup pipeline is disabled, broken,
+// or the rig is unattended — the silent gap that turns a recoverable store loss
+// into a near-permanent one when the only surviving backup is weeks stale.
+const defaultBackupFreshnessMaxAge = 24 * time.Hour
+
+// BdBackupFreshnessCheck warns when a rig that HAS a local bd backup
+// (.beads/backup/backup_state.json) has not synced within maxAge. It is the
+// freshness complement to the existing backup checks: DoltBackupCheck verifies
+// a backup is registered, BdBackupSizeCheck guards the backup footprint, and
+// BdBackupStateCheck flags quarantines and stale registrations — none notice
+// that a configured backup has simply stopped running. Reading only the
+// on-disk backup_state.json keeps the check DB-free.
+//
+// A backup that exists but stopped syncing is invisible to every other signal:
+// the registration still looks healthy and the artifact dir is still present,
+// so the rig appears protected while its recovery point silently ages out.
+type BdBackupFreshnessCheck struct {
+	cityPath   string
+	scopeRoots []string
+	maxAge     time.Duration
+	now        func() time.Time
+}
+
+// NewBdBackupFreshnessCheckForConfig creates a freshness check across the city
+// and all managed rig scope roots, using preloaded city config to avoid
+// reparsing city.toml during doctor registration.
+func NewBdBackupFreshnessCheckForConfig(cityPath string, cfg *config.City, cfgErr error) *BdBackupFreshnessCheck {
+	return &BdBackupFreshnessCheck{
+		cityPath:   cityPath,
+		scopeRoots: managedDoltScopeRootsForConfig(cityPath, cfg, cfgErr),
+		maxAge:     defaultBackupFreshnessMaxAge,
+		now:        time.Now,
+	}
+}
+
+// NewBdBackupFreshnessCheckForScopeRoots creates a freshness check over an
+// explicit scope-root list with an injectable max age and clock. Used by tests.
+func NewBdBackupFreshnessCheckForScopeRoots(cityPath string, scopeRoots []string, maxAge time.Duration, now func() time.Time) *BdBackupFreshnessCheck {
+	if maxAge <= 0 {
+		maxAge = defaultBackupFreshnessMaxAge
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &BdBackupFreshnessCheck{cityPath: cityPath, scopeRoots: scopeRoots, maxAge: maxAge, now: now}
+}
+
+// Name returns the check identifier.
+func (c *BdBackupFreshnessCheck) Name() string { return "bd-backup-freshness" }
+
+// WarmupEligible returns false: backup freshness is a steady-state hygiene
+// signal, not a fail-fast gate that should block `gc start`.
+func (c *BdBackupFreshnessCheck) WarmupEligible() bool { return false }
+
+// CanFix returns false: re-enabling or repairing a backup pipeline is operator
+// policy, not a mechanical fix.
+func (c *BdBackupFreshnessCheck) CanFix() bool { return false }
+
+// Fix is a no-op; the check is report-only.
+func (c *BdBackupFreshnessCheck) Fix(_ *CheckContext) error { return nil }
+
+// Run reads each scope's .beads/backup/backup_state.json and warns on any whose
+// last sync is older than maxAge (or whose timestamp is missing or
+// unparseable). Scopes with no backup_state.json are skipped — "no backup at
+// all" is reported by DoltBackupCheck / BdBackupSizeCheck, not here.
+func (c *BdBackupFreshnessCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	now := c.now()
+
+	var findings []string
+	for _, target := range c.freshnessScanTargets() {
+		if finding, ok := scanBackupFreshness(target.Label, target.BeadsDir, now, c.maxAge); ok {
+			findings = append(findings, finding)
+		}
+	}
+
+	if len(findings) == 0 {
+		r.Status = StatusOK
+		r.Message = "all configured bd backups synced within " + c.maxAge.String()
+		return r
+	}
+	sort.Strings(findings)
+	r.Status = StatusWarning
+	r.Severity = SeverityAdvisory
+	r.Message = strings.Join(findings, "; ")
+	r.FixHint = "re-enable or repair the bd backup pipeline for the listed scopes " +
+		"(bd backup sync; verify backup.enabled and BD_BACKUP_ENABLED), then confirm " +
+		"bd backup status shows a recent sync"
+	return r
+}
+
+type bdBackupFreshnessTarget struct {
+	Label    string
+	BeadsDir string
+}
+
+func (c *BdBackupFreshnessCheck) freshnessScanTargets() []bdBackupFreshnessTarget {
+	scopeRoots := c.scopeRoots
+	if len(scopeRoots) == 0 {
+		scopeRoots = managedDoltScopeRoots(c.cityPath)
+	}
+	if len(scopeRoots) == 0 {
+		scopeRoots = []string{c.cityPath}
+	}
+
+	seen := make(map[string]struct{}, len(scopeRoots))
+	targets := make([]bdBackupFreshnessTarget, 0, len(scopeRoots))
+	for _, scopeRoot := range scopeRoots {
+		scopeRoot = strings.TrimSpace(scopeRoot)
+		if scopeRoot == "" {
+			continue
+		}
+		scopeRoot = filepath.Clean(scopeRoot)
+		if _, ok := seen[scopeRoot]; ok {
+			continue
+		}
+		seen[scopeRoot] = struct{}{}
+		targets = append(targets, bdBackupFreshnessTarget{
+			Label:    bdBackupScopeLabel(c.cityPath, scopeRoot),
+			BeadsDir: filepath.Join(scopeRoot, ".beads"),
+		})
+	}
+	return targets
+}
+
+// scanBackupFreshness reads <beadsDir>/backup/backup_state.json and returns a
+// finding when the last sync is older than maxAge or the timestamp cannot be
+// read. A missing backup_state.json returns ("", false) — not this check's job.
+func scanBackupFreshness(label, beadsDir string, now time.Time, maxAge time.Duration) (string, bool) {
+	path := filepath.Join(beadsDir, "backup", "backup_state.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false
+		}
+		return fmt.Sprintf("%s: read backup_state.json: %v", label, err), true
+	}
+	var state struct {
+		Timestamp string `json:"timestamp"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Sprintf("%s: backup_state.json is unparseable: %v", label, err), true
+	}
+	ts := strings.TrimSpace(state.Timestamp)
+	if ts == "" {
+		return fmt.Sprintf("%s: backup_state.json has no timestamp", label), true
+	}
+	synced, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return fmt.Sprintf("%s: backup_state.json timestamp %q is unparseable: %v", label, ts, err), true
+	}
+	if age := now.Sub(synced); age > maxAge {
+		return fmt.Sprintf("%s: last bd backup sync was %s ago (> %s) — backup pipeline may be disabled or broken",
+			label, age.Round(time.Minute), maxAge), true
+	}
+	return "", false
+}

--- a/internal/doctor/checks_bd_backup_freshness_test.go
+++ b/internal/doctor/checks_bd_backup_freshness_test.go
@@ -1,0 +1,104 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeBackupStateForFreshness(t *testing.T, scopeRoot, timestamp string) {
+	t.Helper()
+	dir := filepath.Join(scopeRoot, ".beads", "backup")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir backup dir: %v", err)
+	}
+	body := `{"last_dolt_commit":"abc123","timestamp":"` + timestamp + `"}`
+	if err := os.WriteFile(filepath.Join(dir, "backup_state.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write backup_state.json: %v", err)
+	}
+}
+
+func TestBdBackupFreshnessCheck(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	maxAge := 24 * time.Hour
+
+	t.Run("fresh sync is OK", func(t *testing.T) {
+		scope := t.TempDir()
+		writeBackupStateForFreshness(t, scope, now.Add(-1*time.Hour).Format(time.RFC3339Nano))
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{scope}, maxAge, clock).Run(nil)
+		if r.Status != StatusOK {
+			t.Fatalf("fresh backup: want StatusOK, got %v (%s)", r.Status, r.Message)
+		}
+	})
+
+	t.Run("stale sync warns and reports the age", func(t *testing.T) {
+		scope := t.TempDir()
+		writeBackupStateForFreshness(t, scope, now.Add(-72*time.Hour).Format(time.RFC3339Nano))
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{scope}, maxAge, clock).Run(nil)
+		if r.Status != StatusWarning {
+			t.Fatalf("stale backup: want StatusWarning, got %v (%s)", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "ago") {
+			t.Fatalf("stale message should describe the age, got %q", r.Message)
+		}
+		if r.FixHint == "" {
+			t.Fatalf("stale finding should carry a FixHint")
+		}
+	})
+
+	t.Run("missing backup_state.json is skipped (OK, not this check's job)", func(t *testing.T) {
+		scope := t.TempDir() // no .beads/backup at all
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{scope}, maxAge, clock).Run(nil)
+		if r.Status != StatusOK {
+			t.Fatalf("no backup: want StatusOK, got %v (%s)", r.Status, r.Message)
+		}
+	})
+
+	t.Run("missing timestamp warns", func(t *testing.T) {
+		scope := t.TempDir()
+		dir := filepath.Join(scope, ".beads", "backup")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "backup_state.json"), []byte(`{"last_dolt_commit":"x"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{scope}, maxAge, clock).Run(nil)
+		if r.Status != StatusWarning {
+			t.Fatalf("missing timestamp: want StatusWarning, got %v (%s)", r.Status, r.Message)
+		}
+	})
+
+	t.Run("unparseable timestamp warns", func(t *testing.T) {
+		scope := t.TempDir()
+		writeBackupStateForFreshness(t, scope, "not-a-timestamp")
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{scope}, maxAge, clock).Run(nil)
+		if r.Status != StatusWarning {
+			t.Fatalf("bad timestamp: want StatusWarning, got %v (%s)", r.Status, r.Message)
+		}
+	})
+
+	t.Run("one stale scope among fresh ones still warns", func(t *testing.T) {
+		fresh := t.TempDir()
+		stale := t.TempDir()
+		writeBackupStateForFreshness(t, fresh, now.Add(-2*time.Hour).Format(time.RFC3339Nano))
+		writeBackupStateForFreshness(t, stale, now.Add(-100*time.Hour).Format(time.RFC3339Nano))
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{fresh, stale}, maxAge, clock).Run(nil)
+		if r.Status != StatusWarning {
+			t.Fatalf("mixed: want StatusWarning, got %v (%s)", r.Status, r.Message)
+		}
+	})
+
+	t.Run("Name and CanFix are stable", func(t *testing.T) {
+		c := NewBdBackupFreshnessCheckForScopeRoots("", nil, maxAge, clock)
+		if c.Name() != "bd-backup-freshness" {
+			t.Fatalf("unexpected name %q", c.Name())
+		}
+		if c.CanFix() {
+			t.Fatalf("CanFix should be false (report-only)")
+		}
+	})
+}


### PR DESCRIPTION
Adds a report-only doctor check, `bd-backup-freshness`, that warns when a managed scope's `.beads/backup/backup_state.json` recovery point is >24h stale (or the file is missing/unparseable).

## Why
A configured `bd backup` that silently stops syncing looks healthy to every other backup check (`bd-backup-size`, `bd-backup-state`) while its recovery point ages out — the only surviving off-box backup can be weeks stale before anyone notices. This check surfaces that gap directly.

## Behavior
- DB-free, on-disk only; `WarmupEligible=false`, `CanFix=false`, report-only.
- Scopes with no `backup_state.json` are skipped ("no backup at all" is already reported by the other backup checks).
- Registered right after `bd-backup-state` in `buildDoctorChecks`.

## Tests
`internal/doctor/checks_bd_backup_freshness_test.go` (fresh OK / stale warns / missing-skipped / missing-timestamp / unparseable / mixed / metadata-stable) and the `doctor_check_names` golden are updated. Builds + tests green locally.