### PR TITLE
feat(k8s): per-rig container image selection via GC_K8S_RIG_IMAGES

### DIFF
--- a/internal/runtime/k8s/pod.go
+++ b/internal/runtime/k8s/pod.go
@@ -210,6 +210,19 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 	podWorkDir := projectedPodWorkDir(cfg)
 	ctrlCity := controllerCityPath(cfg.Env)
 
+	// Select the container image. Defaults to the single GC_K8S_IMAGE; when a
+	// per-rig override map is configured (GC_K8S_RIG_IMAGES), a session whose
+	// GC_RIG matches an entry runs on that rig's image instead. Unknown/empty
+	// rig falls back to the default — fully backward compatible when unset.
+	image := p.image
+	if len(p.rigImages) > 0 {
+		if rig := cfg.Env["GC_RIG"]; rig != "" {
+			if img := p.rigImages[rig]; img != "" {
+				image = img
+			}
+		}
+	}
+
 	// Build the agent command (base64-encoded to avoid quoting issues) — shared
 	// with the relaunch path so the entrypoint and a respawn launch identically.
 	cmdB64 := agentCommandB64(cfg)
@@ -333,7 +346,7 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 			RestartPolicy:      corev1.RestartPolicyNever,
 			Containers: []corev1.Container{{
 				Name:            "agent",
-				Image:           p.image,
+				Image:           image,
 				ImagePullPolicy: corev1.PullAlways,
 				WorkingDir:      podWorkDir,
 				Command:         []string{"/bin/sh", "-c"},
@@ -369,7 +382,7 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 		}
 		pod.Spec.InitContainers = []corev1.Container{{
 			Name:            "stage",
-			Image:           p.image,
+			Image:           image,
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{"sh", "-c", "while [ ! -f /workspace/.gc-ready ]; do sleep 0.5; done"},
 			VolumeMounts:    initVolMounts,

--- a/internal/runtime/k8s/pod_test.go
+++ b/internal/runtime/k8s/pod_test.go
@@ -99,6 +99,69 @@ func TestBuildPod_NoSchedulingFields_NoBehaviorChange(t *testing.T) {
 	}
 }
 
+func TestBuildPod_RigImageOverride(t *testing.T) {
+	// A session whose GC_RIG matches the rig-image map runs on the rig image,
+	// for both the main container and the staging init container.
+	p := newProviderWithOps(newFakeK8sOps())
+	p.image = "generic:mvp"
+	p.rigImages = map[string]string{"backend": "zilly-rig:bash"}
+	pod, err := buildPod("test-session", runtime.Config{
+		Command: "/bin/bash",
+		WorkDir: "/workspace/backend", // != ctrlCity ("") → forces a staging init container
+		Env:     map[string]string{"GC_RIG": "backend"},
+	}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+	if got := pod.Spec.Containers[0].Image; got != "zilly-rig:bash" {
+		t.Errorf("main container image = %q, want %q", got, "zilly-rig:bash")
+	}
+	if len(pod.Spec.InitContainers) != 1 {
+		t.Fatalf("len(InitContainers) = %d, want 1", len(pod.Spec.InitContainers))
+	}
+	if got := pod.Spec.InitContainers[0].Image; got != "zilly-rig:bash" {
+		t.Errorf("init container image = %q, want %q", got, "zilly-rig:bash")
+	}
+}
+
+func TestBuildPod_RigImageFallback(t *testing.T) {
+	// Rig not in the map, or no GC_RIG at all → falls back to GC_K8S_IMAGE.
+	p := newProviderWithOps(newFakeK8sOps())
+	p.image = "generic:mvp"
+	p.rigImages = map[string]string{"backend": "zilly-rig:bash"}
+
+	cases := map[string]map[string]string{
+		"unknown rig": {"GC_RIG": "ios"},
+		"empty rig":   {"GC_RIG": ""},
+		"no rig env":  {},
+	}
+	for name, env := range cases {
+		pod, err := buildPod("test-session", runtime.Config{Command: "/bin/bash", Env: env}, p)
+		if err != nil {
+			t.Fatalf("[%s] buildPod: %v", name, err)
+		}
+		if got := pod.Spec.Containers[0].Image; got != "generic:mvp" {
+			t.Errorf("[%s] image = %q, want %q", name, got, "generic:mvp")
+		}
+	}
+}
+
+func TestBuildPod_NoRigImages_UsesDefault(t *testing.T) {
+	// No rig-image map → every pod uses GC_K8S_IMAGE, unchanged from before.
+	p := newProviderWithOps(newFakeK8sOps())
+	p.image = "generic:mvp"
+	pod, err := buildPod("test-session", runtime.Config{
+		Command: "/bin/bash",
+		Env:     map[string]string{"GC_RIG": "backend"},
+	}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+	if got := pod.Spec.Containers[0].Image; got != "generic:mvp" {
+		t.Errorf("image = %q, want %q", got, "generic:mvp")
+	}
+}
+
 func TestBuildPod_ClonesSchedulingFields(t *testing.T) {
 	seconds := int64(30)
 	p := newProviderWithOps(newFakeK8sOps())

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -36,6 +36,7 @@ type Provider struct {
 	ops                k8sOps
 	namespace          string
 	image              string
+	rigImages          map[string]string // GC_K8S_RIG_IMAGES (JSON {"<rig>":"<image>"}); nil = single-image
 	k8sContext         string
 	managedServiceHost string
 	managedServicePort string
@@ -63,7 +64,8 @@ type schedulingFields struct {
 // NewProvider creates a K8s session provider.
 // Configuration is read from environment variables (matching gc-session-k8s):
 //   - GC_K8S_NAMESPACE — namespace (default: "gc")
-//   - GC_K8S_IMAGE — container image (required for Start)
+//   - GC_K8S_IMAGE — container image (required for Start; default/fallback)
+//   - GC_K8S_RIG_IMAGES — optional JSON {"<rig>":"<image>"} for per-rig images
 //   - GC_K8S_CONTEXT — kubectl context (default: current)
 //   - GC_K8S_SERVICE_ACCOUNT — pod service account name (default: namespace default)
 //   - GC_K8S_CPU_REQUEST, GC_K8S_MEM_REQUEST — resource requests
@@ -101,6 +103,11 @@ func NewProvider() (*Provider, error) {
 		return nil, err
 	}
 
+	rigImages, err := parseRigImagesEnv()
+	if err != nil {
+		return nil, err
+	}
+
 	return &Provider{
 		ops: &realK8sOps{
 			clientset:  clientset,
@@ -109,6 +116,7 @@ func NewProvider() (*Provider, error) {
 		},
 		namespace:          namespace,
 		image:              image,
+		rigImages:          rigImages,
 		k8sContext:         k8sContext,
 		managedServiceHost: managedServiceHost,
 		managedServicePort: managedServicePort,
@@ -146,6 +154,24 @@ func parseSchedulingEnv() (schedulingFields, error) {
 	}
 	scheduling.priorityClassName = os.Getenv("GC_K8S_PRIORITY_CLASS_NAME")
 	return scheduling, nil
+}
+
+// parseRigImagesEnv parses GC_K8S_RIG_IMAGES (a JSON object mapping rig name to
+// container image) into a map. Returns nil when unset/empty so callers fall back
+// to the single GC_K8S_IMAGE for every pod (backward compatible).
+func parseRigImagesEnv() (map[string]string, error) {
+	v := strings.TrimSpace(os.Getenv("GC_K8S_RIG_IMAGES"))
+	if v == "" {
+		return nil, nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(v), &m); err != nil {
+		return nil, fmt.Errorf("parsing GC_K8S_RIG_IMAGES: %w", err)
+	}
+	if len(m) == 0 {
+		return nil, nil
+	}
+	return m, nil
 }
 
 // newProviderWithOps creates a provider with a custom k8sOps (for testing).

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -20,6 +20,45 @@ func TestProviderImplementsInterface(_ *testing.T) {
 	var _ runtime.Provider = (*Provider)(nil)
 }
 
+func TestParseRigImagesEnv(t *testing.T) {
+	t.Run("unset returns nil", func(t *testing.T) {
+		t.Setenv("GC_K8S_RIG_IMAGES", "")
+		m, err := parseRigImagesEnv()
+		if err != nil {
+			t.Fatalf("parseRigImagesEnv: %v", err)
+		}
+		if m != nil {
+			t.Errorf("got %v, want nil", m)
+		}
+	})
+	t.Run("empty object returns nil", func(t *testing.T) {
+		t.Setenv("GC_K8S_RIG_IMAGES", "{}")
+		m, err := parseRigImagesEnv()
+		if err != nil {
+			t.Fatalf("parseRigImagesEnv: %v", err)
+		}
+		if m != nil {
+			t.Errorf("got %v, want nil", m)
+		}
+	})
+	t.Run("valid map parses", func(t *testing.T) {
+		t.Setenv("GC_K8S_RIG_IMAGES", `{"backend":"zilly-rig:bash","ios":"ios:img"}`)
+		m, err := parseRigImagesEnv()
+		if err != nil {
+			t.Fatalf("parseRigImagesEnv: %v", err)
+		}
+		if m["backend"] != "zilly-rig:bash" || m["ios"] != "ios:img" {
+			t.Errorf("got %v, want backend+ios entries", m)
+		}
+	})
+	t.Run("invalid JSON errors", func(t *testing.T) {
+		t.Setenv("GC_K8S_RIG_IMAGES", "{not json")
+		if _, err := parseRigImagesEnv(); err == nil {
+			t.Error("expected error for invalid JSON, got nil")
+		}
+	})
+}
+
 func TestManagedServiceAliasDefaults(t *testing.T) {
 	t.Setenv("GC_DOLT_HOST", "canonical-dolt.example.com")
 	t.Setenv("GC_DOLT_PORT", "4407")


### PR DESCRIPTION
## Problem

The k8s session provider uses a single `GC_K8S_IMAGE` for **every** pod. A multi-rig city therefore can't give each rig's sessions a rig-specific image — e.g. a heavy image with the rig's repo + deps baked in for that rig's polecat, while the mayor and other city-scope agents stay on a light generic image. Today the whole city must share one image (too heavy for the light agents, or too light — no repo — for the rig workers).

## Change

Add an optional `GC_K8S_RIG_IMAGES` env: a JSON object mapping rig name to container image (`{"<rig>":"<image>"}`).

`buildPod` selects the image by the session's `GC_RIG`:
- a matching entry wins → that rig's image,
- anything else (unknown rig, empty `GC_RIG`, or no map at all) → falls back to `GC_K8S_IMAGE`.

The selected image is used for **both** the main agent container and the staging init container.

## Backward compatibility

Fully backward compatible: when `GC_K8S_RIG_IMAGES` is unset or empty (`{}`), `parseRigImagesEnv` returns nil and every pod uses `GC_K8S_IMAGE` exactly as before. No behavior change for single-image cities.

## Tests

`internal/runtime/k8s` — added:
- `TestParseRigImagesEnv` — unset/empty→nil, valid map parses, invalid JSON errors.
- `TestBuildPod_RigImageOverride` — matching `GC_RIG` → rig image on main **and** init container.
- `TestBuildPod_RigImageFallback` — unknown rig / empty `GC_RIG` / no rig env → `GC_K8S_IMAGE`.
- `TestBuildPod_NoRigImages_UsesDefault` — no map → default for all.

`go test ./internal/runtime/k8s/... -count=1` green.