### PR TITLE
test: Isolate tests from host GC_* / DOLT_* environment leakage

### DIFF
--- a/examples/bd/dolt/health_test.go
+++ b/examples/bd/dolt/health_test.go
@@ -34,6 +34,14 @@ func repoRoot(t *testing.T) string {
 	return filepath.Dir(filename)
 }
 
+// filteredEnv returns os.Environ() with the supplied keys removed and
+// every GC_* / DOLT_* entry stripped unconditionally. The blanket
+// scrub keeps shell-script tests hermetic when invoked from an agent
+// worktree, where the host shell carries managed-runtime
+// state (GC_DOLT_STATE_FILE, GC_CITY_RUNTIME_DIR, GC_DOLT_PORT, etc.)
+// that would otherwise override the test fixture's temp paths and
+// route runtime.sh at the production state file. The explicit keys
+// argument remains for non-GC_/DOLT_ scrubbing such as PATH.
 func filteredEnv(keys ...string) []string {
 	blocked := make(map[string]struct{}, len(keys))
 	for _, key := range keys {
@@ -46,10 +54,47 @@ func filteredEnv(keys ...string) []string {
 			if _, skip := blocked[key]; skip {
 				continue
 			}
+			if strings.HasPrefix(key, "GC_") || strings.HasPrefix(key, "DOLT_") {
+				continue
+			}
 		}
 		env = append(env, entry)
 	}
 	return env
+}
+
+// TestFilteredEnvStripsGCAndDOLTPrefixes is the unit-level regression
+// guard for the env scrub. The TestRuntimeScriptPortPrecedence* tests
+// only fail when the host shell happens to carry leaking GC_* values,
+// so a revert of the prefix scrub goes undetected on clean machines.
+// This test injects the leak explicitly and asserts it never reaches
+// the returned slice.
+func TestFilteredEnvStripsGCAndDOLTPrefixes(t *testing.T) {
+	t.Setenv("GC_DOLT_STATE_FILE", "/host/leak/dolt-state.json")
+	t.Setenv("GC_DOLT_PORT", "38676")
+	t.Setenv("GC_CITY_RUNTIME_DIR", "/host/leak/runtime")
+	t.Setenv("DOLT_CLI_PASSWORD", "host-leak")
+	t.Setenv("FILTERED_ENV_TEST_KEEP", "kept")
+
+	got := filteredEnv()
+
+	for _, entry := range got {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "GC_") || strings.HasPrefix(key, "DOLT_") {
+			t.Errorf("filteredEnv leaked %q; GC_*/DOLT_* must be stripped", entry)
+		}
+	}
+
+	var sawKept bool
+	for _, entry := range got {
+		if entry == "FILTERED_ENV_TEST_KEEP=kept" {
+			sawKept = true
+			break
+		}
+	}
+	if !sawKept {
+		t.Errorf("filteredEnv dropped non-GC_/DOLT_ entry FILTERED_ENV_TEST_KEEP")
+	}
 }
 
 // startDeadTCPListener accepts connections but never writes or reads —

--- a/internal/runtime/k8s/beads_script_test.go
+++ b/internal/runtime/k8s/beads_script_test.go
@@ -129,6 +129,11 @@ func TestBeadsScriptInitRejectsPartialCanonicalDoltTarget(t *testing.T) {
 }
 
 func TestBeadsScriptInitFallsBackToDirWhenStoreRootUnset(t *testing.T) {
+	// This test deliberately omits GC_STORE_ROOT from opts.Env to exercise the
+	// init fall-back to the dir argument. Neutralize any ambient GC_STORE_ROOT
+	// (set whenever the suite runs inside a gc city) so it cannot leak in via
+	// os.Environ() and defeat the fall-back the test is asserting.
+	clearDoltAndCityEnv(t)
 	result := runBeadsScript(t, beadsScriptOptions{
 		Op:   "init",
 		Args: []string{"/city/services/api", "ap"},

--- a/internal/runtime/k8s/testenv_helpers_test.go
+++ b/internal/runtime/k8s/testenv_helpers_test.go
@@ -5,13 +5,27 @@ import (
 )
 
 // clearDoltAndCityEnv empties the GC_DOLT_* / GC_K8S_DOLT_* / GC_CITY_PATH /
-// GC_BIN env vars for the duration of the test so the child scripts spawned
-// via runControllerScriptDeploy and runBeadsScript (which inherit the test
-// process's env through `os.Environ()`) do not observe leaks from the
-// developer's shell. GC_BIN is included because the test constructs its own
-// cmd.Env with a fake GC_BIN entry appended after os.Environ(); on Linux,
-// getenv() returns the first occurrence, so an inherited real GC_BIN would
-// shadow the test's fake binary if not cleared here first.
+// GC_BIN / GC_STORE_ROOT env vars for the duration of the test so the child
+// scripts spawned via runControllerScriptDeploy and runBeadsScript (which
+// inherit the test process's env through `os.Environ()`) do not observe leaks
+// from the developer's shell or an enclosing gc city. Each test's opts.Env
+// continues to declare its own desired state, which overrides the emptied
+// values when cmd.Env is flattened.
+//
+// GC_BIN is included because the test constructs its own cmd.Env with a fake
+// GC_BIN entry appended after os.Environ(); on Linux, getenv() returns the
+// first occurrence, so an inherited real GC_BIN would shadow the test's fake
+// binary if not cleared here first.
+//
+// GC_STORE_ROOT in particular leaks whenever the suite runs inside a gc city
+// (CI, agent worktrees), where it points at the enclosing city root. Tests
+// that exercise the "store root unset" fall-back must neutralize it here, since
+// they deliberately leave GC_STORE_ROOT out of their own opts.Env and so have
+// nothing to override the leaked value.
+//
+// Shell scripts read these vars via `${VAR:-…}` / `[ -n "$VAR" ]` patterns, so
+// an empty string is treated the same as unset — good enough to make the tests
+// deterministic without needing a raw os.Unsetenv + manual cleanup.
 func clearDoltAndCityEnv(t *testing.T) {
 	t.Helper()
 	for _, name := range []string{
@@ -21,6 +35,7 @@ func clearDoltAndCityEnv(t *testing.T) {
 		"GC_K8S_DOLT_PORT",
 		"GC_CITY_PATH",
 		"GC_BIN",
+		"GC_STORE_ROOT",
 	} {
 		t.Setenv(name, "")
 	}


### PR DESCRIPTION
## Summary

Two test-harness fixes that make the affected suites hermetic. Both pass on a
clean dev shell but fail when the suite runs inside a gc city, in CI, or from an
agent worktree, because they inherit `GC_*` / `DOLT_*` environment variables from
the host instead of exercising their own hermetic fixtures. The changes are
confined to test code — no production behavior changes.

**fix(dolt-tests): isolate filteredEnv from host GC_\*/DOLT_\*** — `filteredEnv`
now strips every `GC_*` and `DOLT_*` entry unconditionally (in addition to the
explicit keys callers pass for PATH and other non-prefixed overrides), so
`runtime.sh` resolves the test's hermetic temp state file and random port instead
of the host's real state file / port 3307. Adds
`TestFilteredEnvStripsGCAndDOLTPrefixes` as a unit-level regression guard that
fails on clean machines if the prefix scrub is ever reverted.

**test(k8s): neutralize ambient GC_STORE_ROOT leak in beads init fall-back test**
— adds `GC_STORE_ROOT` to the vars `clearDoltAndCityEnv` neutralizes and calls
that helper from `TestBeadsScriptInitFallsBackToDirWhenStoreRootUnset`, so an
inherited `GC_STORE_ROOT` can't defeat the unset fall-back assertion. The
`gc-beads-k8s` script itself is unchanged; `gc-controller-k8s` callers of the
helper are unaffected.

Without these, both suites are the "passes locally, fails in the harness" flake
that is painful to debug — green on a clean shell, red anywhere `GC_*` / `DOLT_*`
are set.

## Testing

Test-harness-only change; verified directly:

- `go test ./examples/bd/dolt/... ./internal/runtime/k8s/... -count=1` — pass,
  both with `GC_*` / `DOLT_*` leaked into the environment and with them unset.
- New guard `TestFilteredEnvStripsGCAndDOLTPrefixes` goes red if the prefix scrub
  is reverted.
- `go vet` and `gofmt` clean.

- [ ] `make check`
- [x] `make check-docs` — n/a, no docs, navigation, or link changes
- [x] `make test-integration` — n/a, test code only; no runtime, controller, or
  workflow behavior changes

## Checklist

- [x] Linked an issue, or explained why one is not needed — no issue: isolated
  test-harness bug fixes; root cause and validation are captured above.
- [x] Added or updated tests for behavior changes — added
  `TestFilteredEnvStripsGCAndDOLTPrefixes`; updated the k8s fall-back test to
  neutralize the leak.
- [x] Updated docs for user-facing changes — n/a, no user-facing change.
- [x] Called out breaking changes or migration notes — `filteredEnv` now strips
  `GC_*` / `DOLT_*` unconditionally, so any test that intentionally relies on
  inheriting one of those variables must now pass it explicitly via the `keys`
  argument. No production code is affected.