### PR TITLE
perf(extmsg): coalesce bind writes into one transaction (#3735)

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1521,6 +1521,14 @@ func (tx *bdStoreTx) item(id string) (*bdStoreTxItem, error) {
 	return item, nil
 }
 
+// Create persists a bead immediately. The bd CLI has no multi-statement
+// transaction, so a create cannot be staged: subsequent staged writes in the
+// same Tx may reference the new bead's ID, which only exists after creation.
+// This matches the Store.Tx contract for stores without native transactions.
+func (tx *bdStoreTx) Create(b Bead) (Bead, error) {
+	return tx.store.Create(b)
+}
+
 func (tx *bdStoreTx) Update(id string, opts UpdateOpts) error {
 	if !hasUpdateOpts(opts) {
 		return nil

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -109,6 +109,7 @@ type ConditionalAssignmentReleaser interface {
 // Keep this interface limited to methods needed by current transactional
 // write pairs; do not add Store methods speculatively.
 type Tx interface {
+	Create(b Bead) (Bead, error)
 	Update(id string, opts UpdateOpts) error
 	SetMetadataBatch(id string, kvs map[string]string) error
 	Close(id string) error

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -490,6 +490,15 @@ func newCachingStoreTx() *cachingStoreTx {
 	}
 }
 
+func (tx *cachingStoreTx) Create(b Bead) (Bead, error) {
+	created, err := tx.backing.Create(b)
+	if err != nil {
+		return Bead{}, err
+	}
+	tx.touch(created.ID)
+	return created, nil
+}
+
 func (tx *cachingStoreTx) Update(id string, opts UpdateOpts) error {
 	if err := tx.backing.Update(id, opts); err != nil {
 		return err

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -501,41 +501,125 @@ func (s *NativeDoltStore) Update(id string, opts UpdateOpts) error {
 	ctx, cancel := nativeDoltOperationContext(context.TODO())
 	defer cancel()
 	err = storage.RunInTransaction(ctx, fmt.Sprintf("gc: update bead %s", id), func(tx beadslib.Transaction) error {
-		if opts.ParentID != nil {
-			if err := s.validateUpdateParent(ctx, tx, *opts.ParentID); err != nil {
-				return err
-			}
-		}
-		updates, err := s.nativeUpdates(ctx, tx, id, opts)
-		if err != nil {
-			return err
-		}
-		if len(updates) > 0 {
-			if err := tx.UpdateIssue(ctx, id, updates, s.actor); err != nil {
-				return nativeStoreError(id, err)
-			}
-		}
-		for _, label := range opts.Labels {
-			if err := tx.AddLabel(ctx, id, label, s.actor); err != nil {
-				return nativeStoreError(id, err)
-			}
-		}
-		for _, label := range opts.RemoveLabels {
-			if err := tx.RemoveLabel(ctx, id, label, s.actor); err != nil {
-				return nativeStoreError(id, err)
-			}
-		}
-		if opts.ParentID != nil {
-			if err := s.updateParentInTransaction(ctx, tx, id, *opts.ParentID); err != nil {
-				return err
-			}
-		}
-		return nil
+		return s.applyUpdateInTx(ctx, tx, id, opts)
 	})
 	if err != nil {
 		return nativeStoreError(id, err)
 	}
 	return nil
+}
+
+// applyUpdateInTx applies an Update against an open beadslib transaction. It is
+// shared by the standalone Update (one op, one commit) and the multi-write
+// Store.Tx path (many ops, one commit) so both routes have identical semantics.
+func (s *NativeDoltStore) applyUpdateInTx(ctx context.Context, tx beadslib.Transaction, id string, opts UpdateOpts) error {
+	if opts.ParentID != nil {
+		if err := s.validateUpdateParent(ctx, tx, *opts.ParentID); err != nil {
+			return err
+		}
+	}
+	updates, err := s.nativeUpdates(ctx, tx, id, opts)
+	if err != nil {
+		return err
+	}
+	if len(updates) > 0 {
+		if err := tx.UpdateIssue(ctx, id, updates, s.actor); err != nil {
+			return nativeStoreError(id, err)
+		}
+	}
+	for _, label := range opts.Labels {
+		if err := tx.AddLabel(ctx, id, label, s.actor); err != nil {
+			return nativeStoreError(id, err)
+		}
+	}
+	for _, label := range opts.RemoveLabels {
+		if err := tx.RemoveLabel(ctx, id, label, s.actor); err != nil {
+			return nativeStoreError(id, err)
+		}
+	}
+	if opts.ParentID != nil {
+		if err := s.updateParentInTransaction(ctx, tx, id, *opts.ParentID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applySetMetadataBatchInTx merges metadata onto a bead within an open
+// transaction. Mirrors SetMetadataBatch, sharing the read-modify-write path so
+// the Store.Tx route coalesces with sibling writes into a single commit.
+func (s *NativeDoltStore) applySetMetadataBatchInTx(ctx context.Context, tx beadslib.Transaction, id string, kvs map[string]string) error {
+	if len(kvs) == 0 {
+		return nil
+	}
+	issue, err := tx.GetIssue(ctx, id)
+	if err != nil {
+		return nativeStoreError(id, err)
+	}
+	if issue == nil {
+		return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+	}
+	metadata, err := metadataMapFromNative(issue.Metadata)
+	if err != nil {
+		return fmt.Errorf("parsing metadata for bead %q: %w", id, err)
+	}
+	if metadata == nil {
+		metadata = make(map[string]string, len(kvs))
+	}
+	for k, v := range kvs {
+		metadata[k] = v
+	}
+	raw, err := metadataRawFromMap(metadata)
+	if err != nil {
+		return err
+	}
+	return nativeStoreError(id, tx.UpdateIssue(ctx, id, map[string]interface{}{"metadata": raw}, s.actor))
+}
+
+// applyCloseInTx closes a bead within an open transaction, mirroring Close.
+// Closing an already-closed bead is a no-op; a missing bead is ErrNotFound.
+func (s *NativeDoltStore) applyCloseInTx(ctx context.Context, tx beadslib.Transaction, id string) error {
+	current, err := tx.GetIssue(ctx, id)
+	if err != nil {
+		return nativeStoreError(id, err)
+	}
+	if current == nil {
+		return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+	}
+	if current.Status == beadslib.StatusClosed {
+		return nil
+	}
+	reason := nativeCloseReasonFromIssue(current)
+	return nativeStoreError(id, tx.CloseIssue(ctx, id, reason, s.actor, ""))
+}
+
+// applyCreateInTx creates a bead and its dependencies within an open
+// transaction. Unlike the standalone Create, no compensation is needed: a
+// mid-create failure rolls the whole transaction back.
+func (s *NativeDoltStore) applyCreateInTx(ctx context.Context, tx beadslib.Transaction, b Bead) (Bead, error) {
+	issue, err := nativeIssueFromBead(b)
+	if err != nil {
+		return Bead{}, err
+	}
+	deps := cloneNativeDependencies(issue.Dependencies)
+	issue.Dependencies = nil
+	if err := tx.CreateIssue(ctx, issue, s.actor); err != nil {
+		return Bead{}, err
+	}
+	for _, dep := range deps {
+		if dep == nil {
+			continue
+		}
+		persisted := *dep
+		if strings.TrimSpace(persisted.IssueID) == "" {
+			persisted.IssueID = issue.ID
+		}
+		if err := tx.AddDependency(ctx, &persisted, s.actor); err != nil {
+			return Bead{}, fmt.Errorf("persisting native create dependency %q -> %q: %w", persisted.IssueID, persisted.DependsOnID, nativeStoreError(persisted.IssueID, err))
+		}
+	}
+	issue.Dependencies = deps
+	return beadFromNativeIssue(issue)
 }
 
 // ReleaseIfCurrent clears an in-progress assignment only when the bead still
@@ -865,14 +949,55 @@ func (s *NativeDoltStore) SetMetadataBatch(id string, kvs map[string]string) err
 	return nativeStoreError(id, storage.UpdateIssue(ctx, id, map[string]interface{}{"metadata": raw}, s.actor))
 }
 
-// Tx executes fn sequentially against the native Dolt store.
-func (s *NativeDoltStore) Tx(_ string, fn func(Tx) error) error {
-	_, release, err := s.acquireStorage()
+// Tx executes fn inside a single native Dolt transaction so every write in the
+// callback shares one DOLT_COMMIT. This is the coalescing path that lets a
+// caller (e.g. an extmsg bind) issue several bead writes at the cost of one
+// commit instead of one per write.
+func (s *NativeDoltStore) Tx(commitMsg string, fn func(Tx) error) error {
+	if fn == nil {
+		return errors.New("beads tx: nil callback")
+	}
+	storage, release, err := s.acquireStorage()
 	if err != nil {
 		return err
 	}
-	release()
-	return runSequentialTx(s, fn)
+	defer release()
+	ctx, cancel := nativeDoltOperationContext(context.TODO())
+	defer cancel()
+	if strings.TrimSpace(commitMsg) == "" {
+		commitMsg = "gc: tx"
+	}
+	return storage.RunInTransaction(ctx, commitMsg, func(tx beadslib.Transaction) error {
+		return fn(&nativeDoltTx{store: s, ctx: ctx, tx: tx})
+	})
+}
+
+// nativeDoltTx adapts the Store.Tx write surface onto an open beadslib
+// transaction. Every method routes through the store's applyXInTx helpers so
+// transactional and standalone writes share one implementation.
+type nativeDoltTx struct {
+	store *NativeDoltStore
+	ctx   context.Context
+	tx    beadslib.Transaction
+}
+
+func (t *nativeDoltTx) Create(b Bead) (Bead, error) {
+	return t.store.applyCreateInTx(t.ctx, t.tx, b)
+}
+
+func (t *nativeDoltTx) Update(id string, opts UpdateOpts) error {
+	if err := t.store.applyUpdateInTx(t.ctx, t.tx, id, opts); err != nil {
+		return nativeStoreError(id, err)
+	}
+	return nil
+}
+
+func (t *nativeDoltTx) SetMetadataBatch(id string, kvs map[string]string) error {
+	return t.store.applySetMetadataBatchInTx(t.ctx, t.tx, id, kvs)
+}
+
+func (t *nativeDoltTx) Close(id string) error {
+	return t.store.applyCloseInTx(t.ctx, t.tx, id)
 }
 
 // Delete permanently removes a bead from the upstream beads storage layer.

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -953,6 +953,97 @@ func TestNativeDoltStoreTxAppliesCallbackWrites(t *testing.T) {
 	}
 }
 
+// commitCountingMemStorage counts how many RunInTransaction (i.e. DOLT_COMMIT)
+// boundaries a sequence of store writes crosses.
+type commitCountingMemStorage struct {
+	*nativeDoltMemStorage
+	commits int
+}
+
+func (s *commitCountingMemStorage) RunInTransaction(ctx context.Context, msg string, fn func(beadslib.Transaction) error) error {
+	s.commits++
+	return s.nativeDoltMemStorage.RunInTransaction(ctx, msg, fn)
+}
+
+func TestNativeDoltStoreTxCoalescesWritesIntoSingleCommit(t *testing.T) {
+	counting := &commitCountingMemStorage{nativeDoltMemStorage: newNativeDoltMemStorage()}
+	store := newNativeDoltStoreForTest(counting)
+
+	seed, err := store.Create(Bead{Title: "seed", Metadata: map[string]string{"k": "v"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	commitsBeforeTx := counting.commits
+	var membershipID string
+	if err := store.Tx("coalesced bind", func(tx Tx) error {
+		created, err := tx.Create(Bead{Title: "membership", Metadata: map[string]string{"role": "member"}})
+		if err != nil {
+			return err
+		}
+		membershipID = created.ID
+		if err := tx.SetMetadataBatch(seed.ID, map[string]string{"touched": "yes"}); err != nil {
+			return err
+		}
+		if err := tx.Update(seed.ID, UpdateOpts{Metadata: map[string]string{"phase": "bound"}}); err != nil {
+			return err
+		}
+		return tx.Close(membershipID)
+	}); err != nil {
+		t.Fatalf("Tx: %v", err)
+	}
+
+	if got := counting.commits - commitsBeforeTx; got != 1 {
+		t.Fatalf("Tx with 4 writes issued %d commits, want exactly 1", got)
+	}
+
+	gotSeed, err := store.Get(seed.ID)
+	if err != nil {
+		t.Fatalf("Get seed: %v", err)
+	}
+	if gotSeed.Metadata["touched"] != "yes" || gotSeed.Metadata["phase"] != "bound" || gotSeed.Metadata["k"] != "v" {
+		t.Fatalf("seed metadata = %#v, want merged tx writes", gotSeed.Metadata)
+	}
+	gotMembership, err := store.Get(membershipID)
+	if err != nil {
+		t.Fatalf("Get membership: %v", err)
+	}
+	if gotMembership.Status != "closed" {
+		t.Fatalf("membership status = %q, want closed", gotMembership.Status)
+	}
+	if gotMembership.Metadata["role"] != "member" {
+		t.Fatalf("membership metadata = %#v, want created-in-tx fields", gotMembership.Metadata)
+	}
+}
+
+// TestNativeDoltStoreTxRollsBackOnError verifies the coalesced transaction is
+// atomic: a failure mid-callback leaves none of the writes committed.
+func TestNativeDoltStoreTxRollsBackOnError(t *testing.T) {
+	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	seed, err := store.Create(Bead{Title: "seed", Metadata: map[string]string{"phase": "initial"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	sentinel := errors.New("boom")
+	if err := store.Tx("rollback", func(tx Tx) error {
+		if err := tx.SetMetadataBatch(seed.ID, map[string]string{"phase": "mutated"}); err != nil {
+			return err
+		}
+		return sentinel
+	}); !errors.Is(err, sentinel) {
+		t.Fatalf("Tx error = %v, want sentinel", err)
+	}
+
+	got, err := store.Get(seed.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["phase"] != "initial" {
+		t.Fatalf("phase = %q, want initial (rolled back)", got.Metadata["phase"])
+	}
+}
+
 func TestNativeDoltStoreDependencyRoundTrip(t *testing.T) {
 	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
 	parent, err := store.Create(Bead{Title: "dependency parent"})
@@ -1583,9 +1674,11 @@ func assertNativeDependency(t *testing.T, deps []Dep, issueID, dependsOnID, depT
 }
 
 type nativeDoltTransactionTestStorage interface {
+	CreateIssue(context.Context, *beadslib.Issue, string) error
 	CreateIssues(context.Context, []*beadslib.Issue, string) error
 	GetIssue(context.Context, string) (*beadslib.Issue, error)
 	UpdateIssue(context.Context, string, map[string]interface{}, string) error
+	CloseIssue(context.Context, string, string, string, string) error
 	AddLabel(context.Context, string, string, string) error
 	RemoveLabel(context.Context, string, string, string) error
 	AddDependency(context.Context, *beadslib.Dependency, string) error
@@ -1598,8 +1691,16 @@ type nativeDoltTransactionForTest struct {
 	storage nativeDoltTransactionTestStorage
 }
 
+func (tx nativeDoltTransactionForTest) CreateIssue(ctx context.Context, issue *beadslib.Issue, actor string) error {
+	return tx.storage.CreateIssue(ctx, issue, actor)
+}
+
 func (tx nativeDoltTransactionForTest) CreateIssues(ctx context.Context, issues []*beadslib.Issue, actor string) error {
 	return tx.storage.CreateIssues(ctx, issues, actor)
+}
+
+func (tx nativeDoltTransactionForTest) CloseIssue(ctx context.Context, id, reason, actor, session string) error {
+	return tx.storage.CloseIssue(ctx, id, reason, actor, session)
 }
 
 func (tx nativeDoltTransactionForTest) GetIssue(ctx context.Context, id string) (*beadslib.Issue, error) {

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -36,6 +36,7 @@ type bindingMembershipEnsurer interface {
 	EnsureMembership(ctx context.Context, input EnsureMembershipInput) (ConversationMembershipRecord, error)
 	RemoveMembership(ctx context.Context, input RemoveMembershipInput) error
 	ensureMembershipLocked(input EnsureMembershipInput) (ConversationMembershipRecord, error)
+	ensureMembershipLockedWriter(w membershipWriter, input EnsureMembershipInput) (ConversationMembershipRecord, error)
 	removeMembershipLocked(input RemoveMembershipInput) error
 }
 
@@ -120,15 +121,35 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 			if active.SessionID != sessionID || active.AgentName != agentName {
 				return fmt.Errorf("%w: conversation already bound to %s", ErrBindingConflict, bindingTarget(*active))
 			}
-			if active.SessionName == "" && sessionName != "" {
-				if err := s.store.Update(active.ID, beads.UpdateOpts{
-					Labels:   []string{bindingSessionNameLabel(sessionName)},
-					Metadata: map[string]string{"session_name": sessionName},
-				}); err != nil {
-					return fmt.Errorf("backfill session name on binding %s: %w", active.ID, err)
+			// Coalesce the rebind's writes — optional session-name backfill,
+			// binding metadata, and transcript membership — into one commit so a
+			// rebind costs a single DOLT_COMMIT instead of 2-4 (gastownhall/gascity#3735).
+			if err := s.store.Tx("gc: extmsg rebind "+conversationLockKey(ref), func(tx beads.Tx) error {
+				if active.SessionName == "" && sessionName != "" {
+					if err := tx.Update(active.ID, beads.UpdateOpts{
+						Labels:   []string{bindingSessionNameLabel(sessionName)},
+						Metadata: map[string]string{"session_name": sessionName},
+					}); err != nil {
+						return fmt.Errorf("backfill session name on binding %s: %w", active.ID, err)
+					}
 				}
-			}
-			if err := s.updateBindingMetadata(*active, input.Metadata, input.ExpiresAt, now); err != nil {
+				if err := s.updateBindingMetadata(tx, *active, input.Metadata, input.ExpiresAt, now); err != nil {
+					return err
+				}
+				if s.transcript != nil {
+					if _, err := s.transcript.ensureMembershipLockedWriter(tx, EnsureMembershipInput{
+						Caller:         caller,
+						Conversation:   ref,
+						SessionID:      bindingMembershipKey(*active),
+						BackfillPolicy: MembershipBackfillSinceJoin,
+						Owner:          MembershipOwnerBinding,
+						Now:            now,
+					}); err != nil {
+						return wrapTranscriptSyncError("ensure transcript membership after bind", err)
+					}
+				}
+				return nil
+			}); err != nil {
 				return err
 			}
 			updated, err := s.getBinding(active.ID)
@@ -136,18 +157,6 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 				return err
 			}
 			out = updated
-			if s.transcript != nil {
-				if _, err := s.transcript.ensureMembershipLocked(EnsureMembershipInput{
-					Caller:         caller,
-					Conversation:   ref,
-					SessionID:      bindingMembershipKey(updated),
-					BackfillPolicy: MembershipBackfillSinceJoin,
-					Owner:          MembershipOwnerBinding,
-					Now:            now,
-				}); err != nil {
-					return wrapTranscriptSyncError("ensure transcript membership after bind", err)
-				}
-			}
 			return nil
 		}
 		nextGeneration := nextBindingGeneration(history)
@@ -164,49 +173,55 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 				labels = append(labels, bindingSessionNameLabel(sessionName))
 			}
 		}
-		b, err := s.store.Create(beads.Bead{
-			Title:  conversationTitle(ref),
-			Type:   "task",
-			Labels: labels,
-			Metadata: encodeMetadataFields(input.Metadata, map[string]string{
-				"schema_version":         strconv.Itoa(schemaVersion),
-				"scope_id":               ref.ScopeID,
-				"provider":               ref.Provider,
-				"account_id":             ref.AccountID,
-				"conversation_id":        ref.ConversationID,
-				"parent_conversation_id": ref.ParentConversationID,
-				"conversation_kind":      string(ref.Kind),
-				"session_id":             sessionID,
-				"session_name":           sessionName,
-				"agent_name":             agentName,
-				"binding_generation":     strconv.FormatInt(nextGeneration, 10),
-				"bound_at":               formatTime(now),
-				"expires_at":             formatTimePtr(input.ExpiresAt),
-				"last_touched_at":        formatTime(now),
-				"created_by_kind":        string(normalizeCaller(caller).Kind),
-				"created_by_id":          normalizeCaller(caller).ID,
-			}),
-		})
-		if err != nil {
-			return fmt.Errorf("create external binding: %w", err)
-		}
-		out, err = decodeBindingBead(b)
-		if err != nil {
-			return err
-		}
-		if s.transcript != nil {
-			if _, err := s.transcript.ensureMembershipLocked(EnsureMembershipInput{
-				Caller:         caller,
-				Conversation:   ref,
-				SessionID:      bindingMembershipKey(out),
-				BackfillPolicy: MembershipBackfillSinceJoin,
-				Owner:          MembershipOwnerBinding,
-				Now:            now,
-			}); err != nil {
-				return wrapTranscriptSyncError("ensure transcript membership after bind", err)
+		// Coalesce the new binding's create and its transcript membership (plus
+		// any first-touch transcript-state create) into one commit so a fresh
+		// bind costs a single DOLT_COMMIT (gastownhall/gascity#3735).
+		return s.store.Tx("gc: extmsg bind "+conversationLockKey(ref), func(tx beads.Tx) error {
+			b, err := tx.Create(beads.Bead{
+				Title:  conversationTitle(ref),
+				Type:   "task",
+				Labels: labels,
+				Metadata: encodeMetadataFields(input.Metadata, map[string]string{
+					"schema_version":         strconv.Itoa(schemaVersion),
+					"scope_id":               ref.ScopeID,
+					"provider":               ref.Provider,
+					"account_id":             ref.AccountID,
+					"conversation_id":        ref.ConversationID,
+					"parent_conversation_id": ref.ParentConversationID,
+					"conversation_kind":      string(ref.Kind),
+					"session_id":             sessionID,
+					"session_name":           sessionName,
+					"agent_name":             agentName,
+					"binding_generation":     strconv.FormatInt(nextGeneration, 10),
+					"bound_at":               formatTime(now),
+					"expires_at":             formatTimePtr(input.ExpiresAt),
+					"last_touched_at":        formatTime(now),
+					"created_by_kind":        string(normalizeCaller(caller).Kind),
+					"created_by_id":          normalizeCaller(caller).ID,
+				}),
+			})
+			if err != nil {
+				return fmt.Errorf("create external binding: %w", err)
 			}
-		}
-		return nil
+			decoded, err := decodeBindingBead(b)
+			if err != nil {
+				return err
+			}
+			out = decoded
+			if s.transcript != nil {
+				if _, err := s.transcript.ensureMembershipLockedWriter(tx, EnsureMembershipInput{
+					Caller:         caller,
+					Conversation:   ref,
+					SessionID:      bindingMembershipKey(decoded),
+					BackfillPolicy: MembershipBackfillSinceJoin,
+					Owner:          MembershipOwnerBinding,
+					Now:            now,
+				}); err != nil {
+					return wrapTranscriptSyncError("ensure transcript membership after bind", err)
+				}
+			}
+			return nil
+		})
 	})
 	if err != nil {
 		return SessionBindingRecord{}, err
@@ -891,7 +906,7 @@ func (s *bindingService) activeBinding(ctx context.Context, history []SessionBin
 	})
 }
 
-func (s *bindingService) updateBindingMetadata(record SessionBindingRecord, meta map[string]string, expiresAt *time.Time, now time.Time) error {
+func (s *bindingService) updateBindingMetadata(w beads.Tx, record SessionBindingRecord, meta map[string]string, expiresAt *time.Time, now time.Time) error {
 	fields := map[string]string{
 		"expires_at":      formatTimePtr(expiresAt),
 		"last_touched_at": formatTime(now),
@@ -903,7 +918,7 @@ func (s *bindingService) updateBindingMetadata(record SessionBindingRecord, meta
 	if len(kvs) == 0 {
 		return nil
 	}
-	return s.store.SetMetadataBatch(record.ID, kvs)
+	return w.SetMetadataBatch(record.ID, kvs)
 }
 
 func (s *bindingService) getBinding(id string) (SessionBindingRecord, error) {

--- a/internal/extmsg/extmsg_test.go
+++ b/internal/extmsg/extmsg_test.go
@@ -121,6 +121,81 @@ func TestBindingServiceExpiredBindingIsMissAndRebinds(t *testing.T) {
 	}
 }
 
+// commitCountingExtmsgStore counts standalone writes vs Tx batches so a test
+// can assert that a bind coalesces its writes into a single commit.
+type commitCountingExtmsgStore struct {
+	beads.Store
+	txCalls          int
+	standaloneWrites int
+}
+
+func (c *commitCountingExtmsgStore) Tx(commitMsg string, fn func(beads.Tx) error) error {
+	c.txCalls++
+	return c.Store.Tx(commitMsg, fn)
+}
+
+func (c *commitCountingExtmsgStore) Create(b beads.Bead) (beads.Bead, error) {
+	c.standaloneWrites++
+	return c.Store.Create(b)
+}
+
+func (c *commitCountingExtmsgStore) Update(id string, opts beads.UpdateOpts) error {
+	c.standaloneWrites++
+	return c.Store.Update(id, opts)
+}
+
+func (c *commitCountingExtmsgStore) SetMetadata(id, key, value string) error {
+	c.standaloneWrites++
+	return c.Store.SetMetadata(id, key, value)
+}
+
+func (c *commitCountingExtmsgStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	c.standaloneWrites++
+	return c.Store.SetMetadataBatch(id, kvs)
+}
+
+func TestBindingServiceBindCoalescesWritesIntoSingleCommit(t *testing.T) {
+	freezeTestClock(t)
+	counting := &commitCountingExtmsgStore{Store: beads.NewMemStore()}
+	svc := NewServices(counting).Bindings
+	ref := testConversationRef()
+
+	// A fresh bind creates three beads (binding + transcript-state +
+	// membership). All must land in one Tx with no standalone write —
+	// gastownhall/gascity#3735 turns 2-4 DOLT_COMMITs into one.
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-a",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind(fresh): %v", err)
+	}
+	if counting.txCalls != 1 {
+		t.Fatalf("fresh bind used %d Tx batches, want 1", counting.txCalls)
+	}
+	if counting.standaloneWrites != 0 {
+		t.Fatalf("fresh bind issued %d standalone writes, want 0 (all coalesced)", counting.standaloneWrites)
+	}
+
+	// A rebind of the same session coalesces its binding-metadata and
+	// transcript writes into a single Tx as well.
+	counting.txCalls = 0
+	counting.standaloneWrites = 0
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-a",
+		Now:          testNow().Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("Bind(rebind): %v", err)
+	}
+	if counting.txCalls != 1 {
+		t.Fatalf("rebind used %d Tx batches, want 1", counting.txCalls)
+	}
+	if counting.standaloneWrites != 0 {
+		t.Fatalf("rebind issued %d standalone writes, want 0 (all coalesced)", counting.standaloneWrites)
+	}
+}
+
 func TestBindingServiceBindSeparatesConversationVariants(t *testing.T) {
 	freezeTestClock(t)
 	store := beads.NewMemStore()
@@ -3022,6 +3097,10 @@ func (f *flakyTranscriptService) UpdateMembership(context.Context, UpdateMembers
 }
 
 func (f *flakyTranscriptService) ensureMembershipLocked(input EnsureMembershipInput) (ConversationMembershipRecord, error) {
+	return f.EnsureMembership(context.Background(), input)
+}
+
+func (f *flakyTranscriptService) ensureMembershipLockedWriter(_ membershipWriter, input EnsureMembershipInput) (ConversationMembershipRecord, error) {
 	return f.EnsureMembership(context.Background(), input)
 }
 

--- a/internal/extmsg/transcript_service.go
+++ b/internal/extmsg/transcript_service.go
@@ -294,7 +294,25 @@ func (s *transcriptService) RemoveMembership(ctx context.Context, input RemoveMe
 	})
 }
 
+// membershipWriter is the write surface ensureMembershipLockedWriter needs.
+// Both beads.Store and beads.Tx satisfy it, so a caller can route the
+// membership writes through a coalescing transaction (one commit) or commit
+// them standalone.
+type membershipWriter interface {
+	Create(b beads.Bead) (beads.Bead, error)
+	SetMetadataBatch(id string, kvs map[string]string) error
+}
+
 func (s *transcriptService) ensureMembershipLocked(input EnsureMembershipInput) (ConversationMembershipRecord, error) {
+	return s.ensureMembershipLockedWriter(s.store, input)
+}
+
+// ensureMembershipLockedWriter is ensureMembershipLocked with its writes routed
+// through w. Reads stay on s.store. When w is a transaction, the post-write
+// re-fetch of an existing membership reads pre-commit state; callers that pass a
+// transaction must not depend on the returned record (the bind path discards
+// it). The committed writes are correct in either case.
+func (s *transcriptService) ensureMembershipLockedWriter(w membershipWriter, input EnsureMembershipInput) (ConversationMembershipRecord, error) {
 	ref, err := validateConversationRef(input.Conversation)
 	if err != nil {
 		return ConversationMembershipRecord{}, err
@@ -312,7 +330,7 @@ func (s *transcriptService) ensureMembershipLocked(input EnsureMembershipInput) 
 		return ConversationMembershipRecord{}, err
 	}
 	now := zeroNow(input.Now)
-	state, err := s.ensureStateLocked(ref)
+	state, err := s.ensureStateLockedWriter(w, ref)
 	if err != nil {
 		return ConversationMembershipRecord{}, err
 	}
@@ -340,7 +358,7 @@ func (s *transcriptService) ensureMembershipLocked(input EnsureMembershipInput) 
 		if effectivePolicy != existing.BackfillPolicy {
 			fields["membership_backfill_policy"] = string(effectivePolicy)
 		}
-		if err := s.store.SetMetadataBatch(existing.ID, fields); err != nil {
+		if err := w.SetMetadataBatch(existing.ID, fields); err != nil {
 			return ConversationMembershipRecord{}, fmt.Errorf("update membership owners: %w", err)
 		}
 		updated, err := s.store.Get(existing.ID)
@@ -369,7 +387,7 @@ func (s *transcriptService) ensureMembershipLocked(input EnsureMembershipInput) 
 		"manual_backfill_policy":     manualBackfillMetadataValue(owner, policy),
 		"membership_owner_kinds":     encodeMembershipOwners([]MembershipOwner{owner}),
 	})
-	created, err := s.store.Create(beads.Bead{
+	created, err := w.Create(beads.Bead{
 		Title:    sessionID + " -> " + conversationTitle(ref),
 		Type:     "task",
 		Labels:   []string{"gc:extmsg-membership", labelMembershipBase, membershipConversationLabel(ref), membershipExactLabel(ref, sessionID), membershipSessionLabel(sessionID)},
@@ -711,6 +729,13 @@ func (s *transcriptService) updateHydrationState(ctx context.Context, caller Cal
 }
 
 func (s *transcriptService) ensureStateLocked(ref ConversationRef) (ConversationTranscriptStateRecord, error) {
+	return s.ensureStateLockedWriter(s.store, ref)
+}
+
+// ensureStateLockedWriter is ensureStateLocked with its create routed through w,
+// so a first-touch transcript-state bead can be created inside the same
+// transaction as the membership and binding writes it accompanies.
+func (s *transcriptService) ensureStateLockedWriter(w membershipWriter, ref ConversationRef) (ConversationTranscriptStateRecord, error) {
 	state, err := s.findStateLocked(ref)
 	if err != nil {
 		return ConversationTranscriptStateRecord{}, err
@@ -731,7 +756,7 @@ func (s *transcriptService) ensureStateLocked(ref ConversationRef) (Conversation
 		"hydration_status":            string(HydrationLiveOnly),
 		"max_retained_entries":        "0",
 	}
-	created, err := s.store.Create(beads.Bead{
+	created, err := w.Create(beads.Bead{
 		Title:    conversationTitle(ref) + "/state",
 		Type:     "task",
 		Labels:   []string{"gc:extmsg-transcript-state", labelTranscriptStateBase, transcriptStateLabel(ref)},


### PR DESCRIPTION
Fixes #3735.

## Problem
A single `extmsg/bind` issued **2–4 independent `DOLT_COMMIT`s** on the order-dispatch hot path (binding create/backfill, binding-metadata `SetMetadataBatch`, first-touch transcript-state create, transcript-membership create/update — each committed separately). Under concurrent reconciler commits through the 10-connection dolt pool, binds queued **4–16s** behind reconcile commits, stretching order cadence from ~2m to ~11m and **timing out Slack binds**.

## Fix — make the bind path commit once
- `NativeDoltStore.Tx` now runs the callback inside a single `storage.RunInTransaction` so every write in the batch shares **one** `DOLT_COMMIT` (was a sequential no-op grouping that committed per write). `Update`/`SetMetadataBatch`/`Close`/`Create` route through shared `applyXInTx` helpers so transactional and standalone writes have identical semantics.
- Add `Create` to the `beads.Tx` surface (needed by the membership + transcript-state creates); implemented on the native, caching, and bd transaction adapters.
- `bindingService.Bind` wraps both the new-binding and rebind paths in `store.Tx`; `transcriptService.ensureMembership`/`ensureState` route through the transaction so a bind costs one commit.

## Test plan
- New `internal/beads/native_dolt_store_test.go` (single-commit assertions) + `internal/extmsg/extmsg_test.go`.
- `go build ./...`, `go vet ./...`, `go test` for touched packages — green (per authoring gates).

## Impact
Observed live: `extmsg/bind` p99 ~16–22s under load; this is the keystone behind today's Slack-post timeouts (morning status, PL replies). Follow-ups deferred: reaper-commit serialization off the bind hot path, and correcting the `[memory]` log-source tag.

Rebased onto current main; diff is exactly the 8 fix files (+461/−98).