### PR TITLE
feat(formula): stamp gc.formula_name on the run-root for canonical event sourcing

### DIFF
--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -346,6 +346,17 @@ func toRecipeWithGraph(f *Formula, graphWorkflow bool) (*Recipe, error) {
 	} else if rootOnly {
 		rootStep.Metadata = map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWisp}
 	}
+	// Stamp the canonical run-recipe identity on the run-root so it rides the
+	// root bead.created payload (city_events.formula -> Forge "Run of <formula>").
+	// This is workflowFormulaName's gc.formula_name source, made exact and
+	// run-rooted instead of derived heuristically from a step's gc.step_ref
+	// "mol-<formula>.<step>" prefix downstream.
+	if f.Formula != "" {
+		if rootStep.Metadata == nil {
+			rootStep.Metadata = map[string]string{}
+		}
+		rootStep.Metadata[beadmeta.FormulaNameMetadataKey] = f.Formula
+	}
 	defPriority := 2
 	rootStep.Priority = &defPriority
 	r.Steps = append(r.Steps, rootStep)

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -764,6 +764,9 @@ timeout = "30s"
 	if got := root.Metadata["gc.formula_contract"]; got != "graph.v2" {
 		t.Fatalf("root gc.formula_contract = %q, want graph.v2", got)
 	}
+	if got := root.Metadata["gc.formula_name"]; got != "ralph-demo" {
+		t.Fatalf("root gc.formula_name = %q, want ralph-demo (canonical run-recipe identity for city_events.formula / \"Run of <formula>\")", got)
+	}
 	if root.Type != "task" {
 		t.Fatalf("root type = %q, want task", root.Type)
 	}


### PR DESCRIPTION
Stamps `gc.formula_name` = the formula name on the run-root bead at compile time (alongside `gc.kind=workflow`), so the canonical run-recipe identity rides the root `bead.created` payload. The hosted `city_events.events` contract carries a run-level `formula` field for the Forge run-detail header ("Run of <formula>"); the on-box gasworks-forwarder previously had to derive it heuristically from a step bead's `gc.step_ref` (`mol-<formula>.<step>`) prefix because the run-root carried no canonical name.

This is the exact value `workflowFormulaName` already reads (`root.Ref || gc.formula_name || root.ID`) — now populated instead of falling through to the heuristic. The key const + reader are already on main; this is the missing **write** site.

Context: this is the last orphan of the maintainer-city event-attribution stack (the others — Fact.SessionID #3694, events step_id #3696, active_work_bead #3708, envelope #3746 — already have open PRs). It currently lives only on the hand-deployed `deploy/sqlite-b36-probe-attribution` probe branch; landing it on main keeps the attribution set complete and surviving a from-main redeploy.

internal/formula/compile.go (+11) · compile_test.go (+3). Builds + `go test ./internal/formula/` green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>