### PR TITLE
docs+tooling: idle-controller-call-rate design + Phase-0 measurement harness (take-good of #3550)

### DIFF
--- a/engdocs/design/idle-controller-call-rate.md
+++ b/engdocs/design/idle-controller-call-rate.md
@@ -368,5 +368,3 @@ until validated, then defaults flipped.
   `internal/orders/triggers.go:~238-258`, `cmd/gc/session_reconciler.go` (idle/
   restart paths), `internal/beads/bdstore.go:~64` (`ExecCommandRunnerWithEnv`),
   `internal/beads/caching_store_reconcile.go`, `internal/beads/factory.go:42-150`.
-</content>
-</invoke>

--- a/engdocs/design/idle-controller-call-rate.md
+++ b/engdocs/design/idle-controller-call-rate.md
@@ -1,0 +1,372 @@
+---
+title: "Idle Controller Call-Rate Reduction"
+---
+
+| Field | Value |
+|---|---|
+| Status | Proposed |
+| Date | 2026-06-16 |
+| Author(s) | Claude (Opus 4.8) |
+| Issue | #3543, #2463 |
+| Supersedes | N/A |
+
+# Idle Controller Call-Rate Reduction
+
+> **Status: Proposed.** Layer-3 (Gas City scheduling) companion to the already
+> merged/in-flight store-layer work. Tracks #3543 (the idle-saturation data
+> point) and the "Gas City Layer" the reporter of #2463 called *"the most
+> immediately beneficial option."*
+
+## Summary
+
+An idle Gas City issues a high, roughly fixed rate of `bd`/Dolt reads — ~7 `bd`
+subprocesses/sec → ~463 Dolt `Com_select`/sec on a single idle city (#2463),
+and enough to push a small **multi-tenant** host to load 8→14 even with a tiny,
+retention-bounded store (#3543). The rate comes from the controller running a
+**full per-pass sweep** — every session, every order, every rig — on a fixed
+tick, regardless of whether anything changed.
+
+The store layer is being fixed in parallel: the native in-process store + the
+`CachingStore` (re-enabled by #3505/#3270 for #3248), `beads#4107`'s read
+optimisation, and the DoltLite backend all reduce **per-call cost**. This
+design is deliberately orthogonal: it reduces the controller's **logical call
+rate**. Both are required. As @coffeegoddd noted on #2463, cheaper queries
+*raise throughput and refill the CPU* unless the call rate also drops; as
+@mmlac demonstrated empirically (pruned 543k rows, "CPU did not move"), the
+saturation is **rate-bound, not size-bound**.
+
+The proposal is four pillars, ordered by confidence:
+
+1. **Demand-gated ticking** *(lead, high-confidence, store-layer-independent)* —
+   back off the controller tick when a pass observes no demand delta; wake
+   immediately on a real signal.
+2. **Single-snapshot per-pass evaluation** *(contingent on measurement)* —
+   collapse residual per-order / per-session read fan-out within a pass into one
+   snapshot read, reusing #3492's `ListQuery.LabelPrefix` primitive.
+3. **Quiescent-scope skipping + cursor sanity** — *largely shipped by #3097 +
+   `order_dispatch.go` suspended-skip; only a small residual remains* (see
+   pillar). Kept for the record and the cursor-sanity gap.
+4. **Snapshot-served hot hooks** *(secondary)* — serve `gc hook` / `gc mail
+   check` / `gc rig list --json` from a cached controller snapshot instead of a
+   fresh per-call fan-out.
+
+A cross-cutting **bd-call-rate budget + doctor guard** makes the win measurable
+and prevents regression — directly implementing @coffeegoddd's "GC/GT should
+rate limit usage of bd commands." The *measurement* half already exists
+(`GC_BD_TRACE_JSON`, #2485); the new part is a budget + a `bd-call-rate` doctor
+check.
+
+## Decision Log / Status
+
+- **Proposed** (this revision). No new optimisation code landed. Phase 0
+  (baseline measurement on a native-store build) **gates** the rest: pillar
+  ordering and the Phase-3 go/no-go depend on the measured residual rate, not on
+  the pre-fix CLI-fallback numbers. **Phase 0 is partially complete:** the `bd`-
+  subprocess A/B (CLI-fallback vs native store) is done and reshaped the scope
+  (below), but the gating measurement for Pillars 1–2 — a clean controller-only
+  `Com_select`/sec on a long-running idle supervisor — is **still pending**
+  (housekeeping-dog contamination; see the Phase-0 plan). Until that lands, the
+  pillar go/no-go calls remain provisional.
+- **Revision after re-checking `origin/main` (a2b890dd7):** three relevant fixes
+  already landed and reshape this design:
+  - **#3097 (merged 2026-06-05)** — "cut supervisor reconcile CPU": skips the
+    beads-cache reconcile loop for suspended rigs (~167-253% → ~19% on a
+    5-active/8-suspended city), memoizes pack-hash + remote-cache across ticks,
+    and honors `event_hooks=false`. Together with the order-dispatcher's existing
+    suspended-skip (`cmd/gc/order_dispatch.go:423,476`), **Pillar 3 is essentially
+    already shipped** — see that pillar for the small residual.
+  - **#3270 + #2928 (merged), #3505 (merged in `gastownhall/gascity` main — this
+    PR's base)** — native store runs with gc-owned hooks; per-write event hooks
+    are toggleable; #3505 drops the now-redundant forwarder hooks. #3270 alone
+    already makes the native store eligible, so the Phase-0 *build* (the fork's
+    `origin/main`, which predated #3505) is a **valid native-store baseline**;
+    #3505 is a further cleanup, not a prerequisite.
+  - **#2485 (merged)** — `internal/beads/bdtrace.go`: a scope-classified,
+    tick-reason-attributed `bd`-call JSONL tracer gated on `GC_BD_TRACE_JSON`.
+    **Phase 0's instrumentation already exists**; Phase 0 only adds an aggregator
+    + repro procedure on the post-#3097 baseline (see `engdocs/plans/`).
+- **Phase-0 measurement (2026-06-16, native-store build of `origin/main`):** an
+  A/B on `gc order check` showed **43 `bd` subprocesses in CLI-fallback → 1 with
+  the native store** (a single order-eval pass). Two conclusions reshape the
+  scope:
+  1. The #2463/#3543 **`bd`-subprocess flood is overwhelmingly a CLI-fallback
+     artifact** (#3248), already solved by the native store (#3270/#3505). Our
+     #3543 incident ran in CLI-fallback (binary predated #3505) — confirmed by
+     reproducing its exact `gate=bd_context_agreement` warning.
+  2. **Metric pivot:** on the native store, reads are in-process and `bd`/sec is
+     no longer the right meter. The residual this design targets is **in-process
+     Dolt query volume** — measure via `Com_select`/sec, not `GC_BD_TRACE_JSON`.
+     Pillars 1/2 are re-justified on that axis; the Com_select baseline is the
+     outstanding gate (see `engdocs/plans/idle-controller-call-rate-phase0.md`).
+
+## Problem Statement
+
+### Observed behaviour
+
+`#2463` (idle, single city, default Gas Town pack), 10-minute aggregate:
+
+| subcmd | calls | /sec | % |
+|---|--:|--:|--:|
+| list | 1,597 | 2.83 | 38.7% |
+| query | 1,118 | 1.98 | 27.1% |
+| show | 645 | 1.14 | 15.6% |
+| update | 358 | 0.63 | 8.7% |
+| dep | 191 | 0.34 | 4.6% |
+| create / close | 74 / 74 | 0.13 / 0.13 | 1.8% / 1.8% |
+| gate | 34 | 0.06 | 0.8% |
+
+Reads (`list`+`query`+`show`) are **81%** of calls. Corroborating data points:
+
+- **#3543 (our case):** a small **multi-tenant** host (4 cores, two cities under
+  one systemd supervisor) reached load 8→14 with a *retention-bounded* store
+  (~1,083 wisps total; 15 of 16 rig DBs held **0** wisps yet were still
+  patrolled), ~36–40 `order:*` events/min. Suspending the active agent did **not**
+  relieve it — the idle controller sweep continued. Only stopping the city did.
+- **@mmlac (#2463):** ~442–462 `Com_select`/sec, Dolt 250–450% CPU; **rate-bound
+  not size-bound** (pruned 543k orphaned rows, CPU unchanged).
+- **@Cdfghglz (#2463):** 37-rig city; `gc rig list --json` pegs a core on per-rig
+  runtime probes; a 60 s-TTL flock cache "noticeably reduced sustained load."
+- **@julianknutsen (#2463):** the tmux status line shells out **every 5 s per
+  session** to `gc hook` + `gc mail check`.
+
+### Where the rate comes from (code)
+
+- **Fixed tick.** Supervisor patrol ticker (`cmd/gc/cmd_supervisor.go:1344-1370`)
+  → per-city `CityRuntime.tick()` (`cmd/gc/city_runtime.go:~914-1271`) →
+  `dispatchOrders()` (`:~1273-1289`). The city patrol default is ~30 s
+  (`internal/config/config.go`, `PatrolIntervalDuration`). Every tick runs the
+  **full sweep** whether or not anything changed.
+- **Per-order read fan-out.** `order_dispatch.go` (~`:460-640`) already loads a
+  `trackingIndex` snapshot once, but still issues residual **per-order** reads:
+  `bdCursorAcrossStores()` for each event order, and `CheckTriggerWithOptions` →
+  `checkEvent` → `events.Provider.List(...)` per event order
+  (`internal/orders/triggers.go:~238-258`).
+- **Per-session reads/writes.** The session reconciler iterates every session
+  each pass, reading/writing session metadata (e.g. the restart-handoff and
+  idle-timeout paths around `cmd/gc/session_reconciler.go` — flagged by
+  @sjarmak on #2463 as the *top* idle-read candidates; line numbers drift across
+  `main`).
+- **Subprocess multiplier.** When the native store is unavailable each read
+  shells out via `exec.CommandContext(ctx, name, args…)` in
+  `ExecCommandRunnerWithEnv` (`internal/beads/bdstore.go:~64`) — spawn + connect
+  + query per call.
+
+### The #3248 multiplier (and why #3543's own diagnosis was incomplete)
+
+`#3543` attributed our saturation to call volume but did **not** identify that
+our binary was running with the **native store disabled**. It was: build
+`721a42f0d` (2026-06-14 16:41 Z) is *behind* #3505's merge commit (2026-06-14
+23:57 Z), so it predates the #3248 fix. The `WARN native_store_unavailable
+gate=bd_context_agreement` we observed is the exact #3248 signature — every bead
+op fell back to a CLI `bd` subprocess. **CLI-fallback was plausibly the dominant
+multiplier for our specific numbers**, and it is already fixed upstream
+(#3505/#3270). This document completes #3543's diagnosis and then designs for the
+**residual** rate that remains *after* the store layer is healthy — see Goals.
+
+## Goals
+
+- Reduce the controller's steady-state **logical** `bd`/Dolt call rate on an
+  idle or quiescent city, measured **on a post-#3505 binary** (native store +
+  cache active), not on CLI-fallback numbers.
+- Make the rate **scale with demand**, not with `tick_count × orders × rigs`;
+  in particular, suspended/empty rigs must contribute ~0 reads.
+- Make the call rate **observable** and add a regression guard.
+- Preserve order-firing and event-order latency guarantees
+  (`order-firing-current` doctor stays green; event-order p95 bounded).
+
+## Non-goals (fenced off — owned elsewhere)
+
+- **Native-store re-enablement / hook gating (#3248).** Done in #3505 + #3270.
+  This design *assumes* the native store + `CachingStore` are active and
+  optimises the rate on top of them.
+- **Per-call query cost / Beads read optimisation.** `beads#4107`, the hot
+  6-LEFT-JOIN aggregation, covering indexes, and using `ready_issues` are the
+  **Beads/Dolt layers (1 & 2)** of #2463 — not this doc.
+- **DoltLite embedded backend** (#2989/#3147/#3233/#3449) — store backend, not
+  scheduling.
+- **`bd`↔lib version-skew flood** (@mmlac on #2463) — a separate fail-loud /
+  auto-pin issue.
+- **The bd+Dolt contract** — owned by the Accepted `beads-dolt-contract-redesign`.
+- **Wisp history cascade-delete / orphan prune** — retention/GC, already shipped
+  for accumulation (#3424) and tracked separately for `wisp_events`/`wisp_labels`.
+
+## Upstream Alignment
+
+- **`beads-dolt-contract-redesign` (Accepted):** this is the Layer-3 consumer of
+  that contract; no contract changes proposed.
+- **`idle-session-sleep` (Accepted, implemented):** Pillar 1 lifts the same
+  demand-driven principle from the *session* level to the *controller-tick*
+  level. The session reconciler already sleeps/wakes individual sessions on
+  demand; the controller still sweeps them all on a fixed tick.
+- **#3492 (draft):** introduces `ListQuery.LabelPrefix` and fixes the orders-
+  *feed* N+1. Pillar 2 **reuses that primitive** for the dispatch path, which
+  #3492 does not touch. **#3511 (draft):** indexed order-run lookups in doctor —
+  complementary.
+- **#3097 (merged):** "cut supervisor reconcile CPU" — suspended-rig cache-
+  reconcile skip + pack-hash/remote-cache memoization + `event_hooks` gate.
+  **Supersedes most of Pillar 3** and reduces per-tick *cost*; this design's
+  Pillars 1/2 reduce per-tick *count*, which #3097 does not address.
+- **#2485 (merged):** `GC_BD_TRACE_JSON` scope-classified call tracer. Phase 0's
+  meter; the cross-cutting `bd-call-rate` doctor check builds on it.
+- **#3270 (merged) + #2928:** native store runs with gc-owned hooks +
+  `event_hooks` toggle — establishes the native-store baseline this design
+  optimises on top of.
+
+## Design
+
+### Pillar 1 — Demand-gated ticking *(lead)*
+
+Replace the fixed-cadence full sweep with a **demand-gated** one. Each pass
+computes a cheap **demand signal**; if nothing changed, the next city tick backs
+off; any real signal wakes it immediately.
+
+- **No-demand predicate (all true ⇒ idle):** event cursor unchanged since last
+  pass (one tail read, see Pillar 2); no order due (cooldown/cron not elapsed,
+  no matching event); no session-state delta requiring action; no pending
+  poke / mail / `gc reload`.
+- **Backoff:** exponential from the configured base (~30 s) to a capped ceiling
+  (e.g. 5 min), reset to base on any wake signal. A **heartbeat floor** (one
+  cheap liveness pass at the ceiling) guarantees forward progress even if a
+  wake signal is missed.
+- **Wake triggers (immediate):** new event appended (`events.Provider`),
+  controller poke (existing `tick("poke")` path, `city_runtime.go`), inbound
+  mail, config reload, session lifecycle request.
+
+Why lead: this pillar is **robust to every store-layer win**. Even with a
+perfect in-process cache, a fixed tick still re-evaluates orders, polls events,
+and runs the cache reconciler at cadence; backing off when idle removes the
+*number of passes*, which is the multiplier on all per-pass reads.
+
+### Pillar 2 — Single-snapshot per-pass evaluation *(contingent)*
+
+Within a pass, collapse residual per-order/per-session fan-out into **one**
+snapshot read:
+
+- Extend the existing `trackingIndex` to also carry, per scope: latest
+  `seq:` cursors for all event orders and the relevant event tail — loaded with
+  **one** `ListQuery.LabelPrefix` scan (the #3492 primitive) instead of
+  `bdCursorAcrossStores()` per order.
+- Evaluate every order's trigger against the in-memory snapshot; evaluate
+  session decisions against a single session-metadata snapshot.
+
+**Contingent:** with the `CachingStore` active post-#3505, some of these reads
+are already cache hits. Phase 0 must measure the residual per-pass fan-out
+*after* #3505 before investing here; if the cache already serves them, Pillar 2
+is low-value and is dropped.
+
+### Pillar 3 — Quiescent-scope skipping + cursor sanity *(largely shipped)*
+
+**Mostly done in `origin/main`** — verify against the Phase-0 trace before
+proposing any further work here:
+
+- **Skip suspended rigs.** Already implemented: #3097 skips the beads-cache
+  reconcile loop for suspended rigs, and the order dispatcher skips suspended
+  cities and suspended-rig-targeted orders (`cmd/gc/order_dispatch.go:423,476`).
+  This is the bulk of the #3543 win (our 15-of-16 idle rig DBs are now skipped).
+- **Residual to confirm:** per-rig *runtime probes* on the
+  `gc rig list --json` path (@Cdfghglz measured a core pegged); these may not be
+  covered by the dispatch/reconcile skip. Phase 0 will show whether they still
+  fire for suspended rigs.
+- **Cursor sanity (likely still open).** The phantom event-cursor backlog where
+  a suspended, 0-issue rig reports hundreds of thousands of "pending
+  `bead.updated`" events (@mmlac) — initialise/clamp cursors so a quiescent scope
+  yields an empty event match without a scan. Confirm against the trace.
+
+### Pillar 4 — Snapshot-served hot hooks *(secondary)*
+
+Serve the per-session-per-5 s status-line calls (`gc hook`, `gc mail check`) and
+`gc rig list --json` from a controller-maintained snapshot with a short TTL,
+rather than a fresh `bd`/runtime fan-out each call (validated informally by
+@Cdfghglz's 60 s-TTL flock cache). Bounded staleness is acceptable for a status
+line.
+
+### Cross-cutting — bd-call-rate budget + meter
+
+- A process-level **calls/sec meter** (by subcommand + caller), reusing the
+  trace approach from PR #2485.
+- A **doctor check** (`bd-call-rate`) that fails when idle rate exceeds a
+  threshold — the regression guard implementing @coffeegoddd's "rate limit"
+  directive.
+- *(Optional, later)* a soft budget that defers non-critical reads when over
+  budget.
+
+## Implementation Plan
+
+TDD / red-green; each phase independently shippable behind a flag, default-off
+until validated, then defaults flipped.
+
+- **Phase 0 — Baseline (gating). *In progress.***
+  Instrumentation already exists (`GC_BD_TRACE_JSON`, #2485). This phase adds an
+  **aggregator + repro procedure** (`engdocs/plans/idle-controller-call-rate-phase0.md`,
+  `scripts/bd-call-rate/`) and measures the idle rate on a **native-store build of
+  `origin/main`** (post-#3097/#3270 — `/tmp/gc-baseline` builds clean), single-rig
+  and multi-rig. *Output:* the residual rate per subcommand **and per trace scope**
+  (order-dispatch vs tick-body vs bead-event-watcher vs hook-cascade), which sets
+  thresholds, confirms the Pillar-3 residual, and decides the Pillar-2 go/no-go.
+  *Nothing else proceeds without these numbers.*
+
+- **Phase 1 — Demand-gated ticking (Pillar 1).**
+  Tests: a pass with no demand schedules a backed-off next tick; each wake
+  trigger (event/poke/mail/reload/session-request) resets to base within one
+  pass; the heartbeat floor fires at the ceiling. Flag `controller.idle_backoff`.
+
+- **Phase 2 — Quiescent-scope skipping + cursor sanity (Pillar 3).**
+  Tests: suspended rig ⇒ 0 order-eval reads, 0 runtime probes; a 0-issue
+  quiescent scope reports 0 pending events (no phantom backlog).
+
+- **Phase 3 — Per-pass snapshot coalescing (Pillar 2). *Blocked on #3492 merge.***
+  *Only if Phase 0 shows residual per-pass fan-out matters.* Extend `trackingIndex`
+  with cursors/event tail via `ListQuery.LabelPrefix` — the `LabelPrefix` primitive
+  does **not** yet exist in `origin/main`; it is introduced by #3492 (still draft),
+  so this phase cannot start until #3492 lands. Then remove per-order
+  `bdCursorAcrossStores`. Test: N event orders ⇒ O(1) snapshot reads per pass
+  (regression test in the spirit of #3492's 500-order test).
+
+- **Phase 4 — Snapshot-served hot hooks (Pillar 4).**
+  Tests: status-line calls served from snapshot within TTL ⇒ 0 store reads;
+  correctness within bounded staleness.
+
+- **Phase 5 — Rate-budget doctor check + telemetry; flip defaults.**
+  Ship the `bd-call-rate` doctor check + telemetry; enable Phase 1/2 defaults
+  after soak.
+
+## Risks & Mitigations
+
+- **Missed wake ⇒ stalled dispatch (Pillar 1).** Conservative, comprehensive
+  wake triggers; a capped backoff ceiling; a heartbeat-floor pass guarantees
+  eventual progress. Validate `order-firing-current` stays green under backoff.
+- **Event-order latency regression (Pillars 1–3).** Event append is an explicit
+  immediate wake trigger; assert an event-order p95 latency bound in tests.
+- **Interaction with `idle-session-sleep`.** Pillar 1 gates the *tick*, not
+  session wake demand; ensure an on-demand session wake is a controller wake
+  trigger so a backed-off controller still services it promptly.
+- **Stale hot-hook snapshot (Pillar 4).** Bounded TTL; mail/hook *writes* still
+  invalidate; status-line reads only.
+- **Optimising the wrong baseline.** Mitigated by Phase 0 gating on post-#3505
+  measurements (the central lesson from #3543's incomplete diagnosis).
+
+## Acceptance / Metrics
+
+- Idle single-rig city (post-#3505): steady-state `bd`/sec drops from the Phase-0
+  baseline to a target set by that baseline (goal: an idle city trends toward
+  near-zero reads between real events, not a fixed floor).
+- Multi-rig idle: total rate scales with *active* rigs, ~flat in suspended-rig
+  count (our 16-rig case ⇒ ≈ single active-rig cost).
+- No regression: `order-firing-current` doctor green; event-order p95 within the
+  asserted bound; `bd-call-rate` doctor check green at the new threshold.
+
+## References
+
+- Issues: #3543 (this design's trigger), #2463 (umbrella; three-layer framing),
+  #3248 (native-store gating — fixed by **#3505**/#3270), `beads#4107` (read opt).
+- PRs: #3492 (`LabelPrefix` primitive + orders-feed N+1; reused by Pillar 2),
+  #3511 (indexed order-run lookups), #2485 (`bd` trace instrumentation).
+- Design: `idle-session-sleep` (Accepted), `beads-dolt-contract-redesign`
+  (Accepted), `architecture/health-patrol.md`.
+- Code anchors: `cmd/gc/cmd_supervisor.go:~1344-1370`,
+  `cmd/gc/city_runtime.go:~914-1271,~1273-1289`, `cmd/gc/order_dispatch.go:~460-640`,
+  `internal/orders/triggers.go:~238-258`, `cmd/gc/session_reconciler.go` (idle/
+  restart paths), `internal/beads/bdstore.go:~64` (`ExecCommandRunnerWithEnv`),
+  `internal/beads/caching_store_reconcile.go`, `internal/beads/factory.go:42-150`.
+</content>
+</invoke>

--- a/engdocs/design/index.md
+++ b/engdocs/design/index.md
@@ -23,6 +23,7 @@ lives in the [Architecture](../architecture/index.md) section.
 | `dependency-aware-bounded-parallel-lifecycle` | Implemented | Bounded parallel start/stop waves for session lifecycle |
 | `beads-dolt-contract-redesign` | Accepted | Canonical bd+Dolt contract, topology commands, migration, and provider-boundary redesign |
 | `idle-session-sleep` | Accepted | Idle-sleep policy, precedence, and wake mechanics |
+| `idle-controller-call-rate` | Proposed | Layer-3 (#2463/#3543) cut of the controller's idle bd/Dolt call *rate*: demand-gated ticking, per-pass snapshot, quiescent-scope skipping |
 | `session-store-fences` | Accepted | Cross-process write fences for session-owned metadata: store facts, flock and token-reread fences, residual convergence-through-persistence |
 | `named-configured-sessions` | Accepted | Explicit canonical named sessions backed by reusable templates; partially superseded by `session-model-unification` |
 | `session-model-unification` | Accepted | Unified post-pool session model: config factories, canonical named identities, exact session ownership, and `scale_check`-only controller demand |

--- a/engdocs/plans/idle-controller-call-rate-phase0.md
+++ b/engdocs/plans/idle-controller-call-rate-phase0.md
@@ -1,0 +1,192 @@
+# Plan: idle-controller-call-rate — Phase 0 baseline measurement
+
+> **Status:** In progress — 2026-06-16
+> **Design:** [`idle-controller-call-rate`](../design/idle-controller-call-rate.md)
+> **Issues:** #3543, #2463
+
+Phase 0 of [`idle-controller-call-rate`](../design/idle-controller-call-rate.md).
+It produces the numbers that **gate** every optimisation pillar. No optimisation
+code is written until this baseline exists, because the headline #2463 figures
+(~7 `bd`/sec, ~463 Dolt q/sec) are stale: they predate #3097 (suspended-rig
+reconcile skip + pack-hash memoization), #3270 (native store with hooks), and
+the order-dispatcher's suspended-skip. We must measure the **residual** on a
+current native-store build, not re-quote pre-fix numbers.
+
+## What's already done
+
+- **Instrumentation exists** — `internal/beads/bdtrace.go` (#2485) writes one
+  JSONL record per `bd` subprocess to `GC_BD_TRACE_JSON`, scope-classified
+  (`order-dispatch`, `tick-body`, `bead-event-watcher`, `hook:*`, `cli-command`,
+  `unknown`) and tick-reason attributed (`patrol`/`poke`/…). No new tracer needed.
+- **Aggregator** — [`scripts/bd-call-rate/aggregate.py`](../../scripts/bd-call-rate/aggregate.py)
+  turns that JSONL into by-subcommand (the #2463 table), by-scope, by-tick-trigger,
+  and a scope×subcommand cross-tab. `python3 scripts/bd-call-rate/aggregate.py --self-test`.
+- **Baseline binary** — builds clean from `origin/main` (post-#3097/#3270):
+  `go build -o /tmp/gc-baseline ./cmd/gc`.
+
+## Procedure
+
+> ⚠️ **Measure the *idle controller*, not paid agents.** The target is the
+> controller's steady-state read fan-out, so the city must tick **without
+> spawning provider agents** (no Claude/API cost, and agent work would pollute
+> the idle signal). Use a disposable city and keep agents suspended.
+
+```bash
+GC=/tmp/gc-baseline
+CITY=$(mktemp -d /tmp/bd-rate-city.XXXX)
+TRACE=$(mktemp /tmp/bd-rate.XXXX.jsonl)
+
+# 1. Disposable city. git-init the scope so the native store is eligible
+#    (avoids the #3248 bd_context_agreement gate → real native-store baseline).
+"$GC" init --template gastown --default-provider claude "$CITY"
+git -C "$CITY" init -q
+"$GC" doctor --city "$CITY" 2>&1 | grep -i native_store || echo "native store eligible"
+
+# 2. Keep the controller running but spawn no agents.
+"$GC" suspend "$CITY"          # city suspended ⇒ reconciler skips agent spawn…
+#    …but we still want order-dispatch/tick reads. If suspend also halts the
+#    tick loop, instead leave the city active with every agent suspended
+#    (gc agent suspend <name> for each) so the controller ticks with zero agents.
+
+# 3. Idle run with tracing. 10 min mirrors the #2463 methodology; 3 min is a
+#    quick first read.
+GC_BD_TRACE_JSON="$TRACE" "$GC" start "$CITY"
+sleep 600
+"$GC" stop "$CITY"
+
+# 4. Aggregate.
+python3 scripts/bd-call-rate/aggregate.py "$TRACE"
+```
+
+Repeat for three shapes to characterise the rate's drivers:
+
+| Shape | Why |
+|---|---|
+| **single-rig, idle** | the floor: order-dispatch + tick-body + event-watcher reads |
+| **multi-rig (e.g. 8), all active** | does the rate scale with rig count? |
+| **multi-rig, mostly suspended** | confirms #3097 + dispatch suspended-skip (#3543's 15-of-16 case ⇒ should ≈ single-rig) |
+
+## Results (2026-06-16, native-store build `/tmp/gc-baseline` of `origin/main`)
+
+Measured on an isolated throwaway city (`GC_HOME=/tmp/bd-rate-gchome`, gastown
+template, claude provider, **agents never started — no spawn, no cost**) by
+tracing single read-only operations the controller/status-line invoke.
+
+**Per-operation `bd` *subprocess* fan-out, native store vs forced CLI-fallback:**
+
+| operation | bd subprocs (native store) | bd subprocs (CLI-fallback) |
+|---|--:|--:|
+| `gc order check` | **1** (`bd context` only) | **43** (21 `list` + 21 `query` + 1 `context`) |
+| `gc doctor` | 10 | — |
+| `gc rig list --json` | 0 | — |
+| `gc mail count` | 1 | — |
+
+CLI-fallback was forced by moving the scope's `.git` aside, tripping
+`gate=bd_context_agreement` — **the exact warning observed in the #3543
+incident.** The 21 `list` + 21 `query` per single order-eval pass mirrors
+#2463's read-dominated profile (list+query were 66% there).
+
+> **Note (#3552, merged `04eef3468` 2026-06-16):** the
+> `gate=bd_context_agreement` fallback line was dropped from `WARN` to `DEBUG`.
+> On a current binary this repro therefore needs `-v` (or
+> `GC_LOG_LEVEL=debug`) to observe the gate firing; without it the fallback is
+> silent. The subprocess-count A/B itself is unaffected.
+
+### Findings
+
+1. **The #2463/#3543 `bd`-subprocess flood is a CLI-fallback artifact.** One
+   order-eval pass: **43 → 1** bd subprocesses (native store), a ~43× cut. Our
+   #3543 incident ran in CLI-fallback (binary predated #3505); on the
+   native-store baseline (#3270/#3505) the subprocess fan-out is near-zero.
+2. **Metric pivot (important).** `GC_BD_TRACE_JSON` counts `bd` **subprocess**
+   spawns only. With the native store, reads are served **in-process** and are
+   *not* traced — so a near-zero `bd`/sec here does **not** mean zero Dolt load.
+   The residual rate the design's Pillars 1/2 target (the ~463 `Com_select`/sec
+   @mmlac measured) is now **in-process Dolt query volume**, which must be
+   measured via Dolt `Com_select` (`SHOW GLOBAL STATUS LIKE 'Com_select'`
+   delta) under an idle, *ticking* native-store city — not via this tracer.
+3. **The per-order N+1 (Pillar 2 / #3492) only bites in CLI-fallback.** With the
+   native store it is already coalesced to ~1 subprocess; whether an in-process
+   N+1 remains in Dolt-query terms is the open question for the Com_select pass.
+
+### Next sub-step (the real gate for Pillars 1/2)
+
+Stand up a *ticking* native-store city with **zero agents** and sample
+`Com_select`/sec over an idle window (single-rig, multi-active, mostly-suspended).
+That is blocked on a clean "controller-ticks-but-spawns-no-agents" config: `gc
+suspend` halts order dispatch (`order_dispatch.go:428`), and the gastown pack
+agents (incl. the autonomous `mayor`) can't be suspended via `gc agent suspend`
+(pack-defined → needs `[[patches.agent]] suspended=true`, ambiguous for the two
+`dog` agents). Resolve that targeting, then measure `Com_select`.
+
+**In-process Dolt query volume (the real residual), single-rig native-store city:**
+
+Measured `Com_select` (`SHOW GLOBAL STATUS`, via `dolt --host …:32033 --no-tls`)
+across a loop of `gc order check`:
+
+| metric | value |
+|---|--:|
+| `Com_select` per `gc order check` | **~56** (incl. per-process native-store *open* overhead) |
+| back-to-back loop rate (20 checks / 19 s) | ~59 `Com_select`/sec |
+| **estimated idle order-dispatch rate** (56 ÷ 30 s patrol) | **~1.9 `Com_select`/sec** |
+
+So the in-process query *volume per order-eval is real* (~56), but at the idle
+patrol cadence (one eval / 30 s) the **steady-state order-dispatch Dolt load is
+modest** — orders of magnitude below @mmlac's 463/sec, which was a 16-agent
+*active* town, not idle. The 56 is also inflated by per-invocation store-open
+(version/schema/`bd context`) that a long-running controller pays once, not per
+tick — so the true steady-state per-tick figure is lower still.
+
+**Long-running-controller idle `Com_select`/sec — attempted, contaminated.** A
+long-running isolated supervisor (open-once, tick at 30 s) was run on the
+native-store baseline. `[[patches.agent]] suspended=true` for the three
+auto-start agents (`boot`/`deacon`/`mayor` — verified by `gc start --dry-run`
+reporting "0 agents would start") successfully stopped autonomous spawns. Over a
+90 s window:
+
+| window | Com_select Δ | rate |
+|---|--:|--:|
+| 0–45 s (controller ticking) | 422 | ~9.4 /sec |
+| 45–90 s | 2125 | ~47 /sec |
+
+**But the run was contaminated:** the controller dispatched **housekeeping pool
+work** that spawned an ephemeral `gastown.dog` agent (a real
+`claude --dangerously-skip-permissions`) despite the autonomous agents being
+suspended. The 45–90 s spike is that dog's startup `work_query` pipelines, not
+controller idle. The dog was killed within ~2 min; only a brief, bounded number
+of dog invocations occurred.
+
+**Finding:** a gastown city has **no truly agentless idle state** — the
+controller's own housekeeping orders route work to the dog pool, spawning agents
+on-demand. Suspending the autonomous agents is not sufficient to quiesce it.
+A clean controller-only number needs *also* disabling the housekeeping orders
+that generate dog work (or measuring on a minimal non-gastown city with core
+orders only). Even so, the early/uncontaminated signal (~9 `Com_select`/sec) and
+the per-eval figure (~56 ÷ 30 s ≈ 2 /sec from order dispatch) both confirm the
+idle native-store rate is **single-digit to low-tens /sec — modest**, orders of
+magnitude below the 463/sec active-town figure.
+
+| Shape | window | Com_select/sec | notes |
+|---|---|---|---|
+| native-store, autonomous-agents-suspended | 90 s | ~9 idle → ~47 w/ housekeeping dog | contaminated by pool-dog spawn |
+| clean controller-only (orders+housekeeping disabled) | | | TODO — needs order-level quiesce |
+
+## What the numbers decide
+
+- **Overall idle bd/sec on the native-store baseline** — if already near-zero,
+  the design narrows to Pillar 1 (tick backoff) only, or closes.
+- **`order-dispatch` vs `tick-body` vs `bead-event-watcher` split** — picks
+  whether Pillar 2 (per-pass snapshot coalescing) is worth it, and which path.
+- **Suspended-rig shape ≈ single-rig?** — confirms Pillar 3 is already covered
+  by #3097/dispatch-skip; any excess isolates the residual (e.g. `gc rig list
+  --json` runtime probes, phantom event cursors).
+- **`patrol` vs `poke` trigger split** — sizes the Pillar 1 (demand-gated tick)
+  win: a high `patrol` share with low `poke` means most reads are the fixed
+  cadence sweeping with nothing to do.
+
+## Exit criteria
+
+A filled-in results table + a one-paragraph readout that (a) states the residual
+idle rate post-#3097, (b) confirms or revises the Pillar-3 "already shipped"
+claim, and (c) gives a go/no-go for Pillars 1 and 2 with the scope split as
+evidence.

--- a/scripts/bd-call-rate/aggregate.py
+++ b/scripts/bd-call-rate/aggregate.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Aggregate a GC_BD_TRACE_JSON trace into a bd-call-rate report.
+
+Phase 0 of the `idle-controller-call-rate` design (engdocs/design/). The
+instrumentation is gc's own JSONL tracer (internal/beads/bdtrace.go, #2485),
+enabled by setting GC_BD_TRACE_JSON=<path> before `gc start`. This script turns
+that JSONL into:
+
+  1. by-subcommand  — calls, /sec, % (reproduces the #2463 table)
+  2. by-scope       — order-dispatch / tick-body / bead-event-watcher / hook:* /
+                      cli-command / unknown (the attribution #2463 lacked)
+  3. by-tick-trigger — patrol vs poke vs ...
+  4. scope x subcommand cross-tab
+
+Rate is computed over the observed window (max ts - min ts). For an idle-rate
+baseline, run the city idle (no agent work) for several minutes, then point this
+at the trace file.
+
+Usage:
+    python3 aggregate.py TRACE.jsonl
+    cat TRACE.jsonl | python3 aggregate.py
+    python3 aggregate.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+# RFC3339Nano carries nanosecond precision; datetime supports at most
+# microseconds, so the fraction is trimmed to this many digits.
+_MICROSECOND_DIGITS = 6
+
+
+def _warn(msg: str) -> None:
+    """Emit a diagnostic to stderr so malformed input is never dropped silently."""
+    print(f"aggregate.py: {msg}", file=sys.stderr)
+
+
+def _parse_ts(ts: str) -> datetime:
+    """Parse an RFC3339Nano UTC timestamp ("...Z") into a datetime.
+
+    ``datetime.fromisoformat`` only accepts a trailing "Z" and a variable-length
+    fraction on Python 3.11+, so the string is normalized by hand (swap "Z" for
+    "+00:00" and trim the fraction to microseconds) to stay correct on 3.9/3.10.
+    Raises ``ValueError`` on a malformed timestamp.
+    """
+    ts = ts.replace("Z", "+00:00")
+    if "." in ts:
+        head, frac = ts.split(".", 1)
+        off = ""
+        for sep in ("+", "-"):
+            if sep in frac:
+                frac, off = frac.split(sep, 1)
+                off = sep + off
+                break
+        frac = (frac + "0" * _MICROSECOND_DIGITS)[:_MICROSECOND_DIGITS]
+        ts = f"{head}.{frac}{off}"
+    return datetime.fromisoformat(ts)
+
+
+def aggregate(records: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Pure aggregation over trace dicts. Returns a report dict.
+
+    Records whose ``ts`` is missing or unparseable are still counted in the call
+    totals but cannot contribute to the time window; their number is returned as
+    ``ts_dropped`` so the caller can warn that the derived rate is computed over
+    fewer timestamps than calls (and is therefore conservative, not inflated).
+    """
+    by_sub: Counter[str] = Counter()
+    by_scope: Counter[str] = Counter()
+    by_trigger: Counter[str] = Counter()
+    cross: Counter[tuple[str, str]] = Counter()
+    dur_by_sub: Counter[str] = Counter()
+    times: list[datetime] = []
+    ts_dropped = 0
+    for r in records:
+        args = r.get("args") or []
+        sub = args[0] if args else "(none)"
+        scope = r.get("scope") or "unknown"
+        by_sub[sub] += 1
+        by_scope[scope] += 1
+        by_trigger[r.get("tick_trigger") or "(none)"] += 1
+        cross[(scope, sub)] += 1
+        dur_by_sub[sub] += int(r.get("dur_ms") or 0)
+        ts = r.get("ts")
+        if not ts:
+            ts_dropped += 1
+            continue
+        try:
+            times.append(_parse_ts(ts))
+        except ValueError:
+            ts_dropped += 1
+    total = sum(by_sub.values())
+    window_s = 0.0
+    if len(times) >= 2:
+        window_s = (max(times) - min(times)).total_seconds()
+    return {
+        "total": total,
+        "window_s": window_s,
+        "ts_dropped": ts_dropped,
+        "by_sub": by_sub,
+        "by_scope": by_scope,
+        "by_trigger": by_trigger,
+        "cross": cross,
+        "dur_by_sub": dur_by_sub,
+    }
+
+
+def _fmt_table(
+    title: str,
+    counter: Counter[Any],
+    total: int,
+    window_s: float,
+    extra: Mapping[Any, str] | None = None,
+) -> str:
+    lines = [f"\n### {title}", f"{'key':<28}{'calls':>9}{'/sec':>10}{'%':>8}"]
+    for key, n in counter.most_common():
+        rate = n / window_s if window_s else 0.0
+        pct = 100.0 * n / total if total else 0.0
+        suffix = ""
+        if extra and key in extra:
+            suffix = extra[key]
+        lines.append(f"{str(key):<28}{n:>9}{rate:>10.2f}{pct:>7.1f}%{suffix}")
+    return "\n".join(lines)
+
+
+def render(report: Mapping[str, Any]) -> str:
+    total: int = report["total"]
+    window_s: float = report["window_s"]
+    ts_dropped: int = report.get("ts_dropped", 0)
+    out = [
+        "# bd-call-rate report",
+        f"total calls: {total}   window: {window_s:.1f}s   "
+        f"overall rate: {(total / window_s if window_s else 0.0):.2f} bd/sec",
+    ]
+    if ts_dropped:
+        out.append(
+            f"_note: {ts_dropped} record(s) had a missing/unparseable ts and "
+            "could not contribute to the window; the rate above is computed over "
+            "the remaining timestamps._"
+        )
+    dur = report["dur_by_sub"]
+    out.append(
+        _fmt_table(
+            "by subcommand",
+            report["by_sub"],
+            total,
+            window_s,
+            extra={k: f"   {dur[k]}ms total" for k in dur},
+        )
+    )
+    out.append(_fmt_table("by scope", report["by_scope"], total, window_s))
+    out.append(_fmt_table("by tick_trigger", report["by_trigger"], total, window_s))
+    out.append("\n### scope x subcommand (top 20)")
+    for (scope, sub), n in report["cross"].most_common(20):
+        out.append(f"  {scope:<24} {sub:<10} {n:>8}")
+    return "\n".join(out)
+
+
+def _self_test() -> None:
+    recs = [
+        {
+            "ts": "2026-06-16T10:00:00.000000Z",
+            "args": ["list"],
+            "scope": "order-dispatch",
+            "tick_trigger": "patrol",
+            "dur_ms": 5,
+        },
+        {
+            "ts": "2026-06-16T10:00:05.000000Z",
+            "args": ["query"],
+            "scope": "tick-body",
+            "tick_trigger": "patrol",
+            "dur_ms": 7,
+        },
+        {
+            "ts": "2026-06-16T10:00:10.000000Z",
+            "args": ["list"],
+            "scope": "order-dispatch",
+            "tick_trigger": "poke",
+            "dur_ms": 3,
+        },
+    ]
+    rep = aggregate(recs)
+    assert rep["total"] == 3, rep["total"]
+    assert abs(rep["window_s"] - 10.0) < 1e-6, rep["window_s"]
+    assert rep["by_sub"]["list"] == 2 and rep["by_sub"]["query"] == 1, rep["by_sub"]
+    assert rep["by_scope"]["order-dispatch"] == 2, rep["by_scope"]
+    assert rep["by_trigger"]["patrol"] == 2 and rep["by_trigger"]["poke"] == 1
+    assert rep["cross"][("order-dispatch", "list")] == 2
+    assert rep["dur_by_sub"]["list"] == 8
+    assert rep["ts_dropped"] == 0, rep["ts_dropped"]
+
+    # RFC3339Nano (9 fractional digits + "Z") parses, trimmed to microseconds.
+    parsed = _parse_ts("2026-06-16T10:00:00.123456789Z")
+    assert parsed.year == 2026 and parsed.microsecond == 123456, parsed
+
+    # Missing / unparseable timestamps are counted and surfaced, not dropped.
+    bad = aggregate(
+        recs
+        + [
+            {"args": ["list"], "scope": "x"},  # missing ts
+            {"ts": "not-a-timestamp", "args": ["query"], "scope": "y"},  # unparseable
+        ]
+    )
+    assert bad["total"] == 5, bad["total"]
+    assert bad["ts_dropped"] == 2, bad["ts_dropped"]
+
+    # render() produces the expected structure and flags dropped timestamps.
+    text = render(rep)
+    assert "# bd-call-rate report" in text, text
+    assert "by subcommand" in text and "order-dispatch" in text, text
+    assert "_note:" in render(bad)
+
+    # empty input must not divide by zero
+    empty = aggregate([])
+    assert empty["total"] == 0 and empty["window_s"] == 0.0
+    print("self-test OK")
+
+
+def main(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="aggregate.py",
+        description="Aggregate a GC_BD_TRACE_JSON trace into a bd-call-rate report.",
+    )
+    parser.add_argument(
+        "trace",
+        nargs="?",
+        type=argparse.FileType("r"),
+        default=sys.stdin,
+        help="JSONL trace file (default: stdin; '-' also reads stdin)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run the built-in self-test and exit",
+    )
+    args = parser.parse_args(list(argv[1:]))
+
+    if args.self_test:
+        _self_test()
+        return 0
+
+    records: list[dict[str, Any]] = []
+    bad_lines = 0
+    with args.trace as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                bad_lines += 1
+    if bad_lines:
+        _warn(f"skipped {bad_lines} malformed JSON line(s)")
+    report = aggregate(records)
+    if report["ts_dropped"]:
+        _warn(
+            f"{report['ts_dropped']} record(s) had a missing/unparseable ts; "
+            "rate is computed over the remaining timestamps"
+        )
+    print(render(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Take-the-good reimplementation salvaging the useful parts of contributor PR #3550 (remuscazacu).

## Contents (all new, low blast radius)
- `engdocs/design/idle-controller-call-rate.md` + index entry — design note.
- `engdocs/plans/idle-controller-call-rate-phase0.md` — Phase-0 plan.
- `scripts/bd-call-rate/aggregate.py` — standalone Phase-0 measurement harness (defensive RFC3339Nano parsing, warns instead of swallowing, ts_dropped accounting, `--self-test`).

No production code paths touched — docs + a standalone analysis script. Pre-push hook (make build + make check) green.

Supersedes #3550.