### PR TITLE
fix(sling): hint when a vapor formula without `pour = true` materializes only the root step

### DIFF
--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -271,7 +271,24 @@ func slingFormula(opts SlingOpts, deps SlingDeps) (SlingResult, error) {
 		return wfResult, wfErr
 	}
 	result := SlingResult{Target: a.QualifiedName(), FormulaName: opts.BeadOrFormula, Deprecations: inv.Deprecations}
+	if hint := rootOnlyVaporPourHint(opts.BeadOrFormula, recipe); hint != "" {
+		result.BeadWarnings = append(result.BeadWarnings, hint)
+	}
 	return finalize(opts, deps, mResult.RootID, method, result)
+}
+
+// rootOnlyVaporPourHint returns a sling-time diagnostic when a formula compiled
+// to a root-only wisp specifically because it is a vapor formula without
+// pour = true (cause (a) of the compile.go rootOnly rule). It deliberately stays
+// silent for the genuinely step-less formula (cause (b), len(steps) == 0): there
+// is no pour override to suggest there, so conflating the two would mislead. The
+// hint surfaces via SlingResult.BeadWarnings; it changes neither routing nor the
+// materialized wisp.
+func rootOnlyVaporPourHint(formulaName string, recipe *formula.Recipe) string {
+	if recipe == nil || !recipe.RootOnly || recipe.Pour || recipe.Phase != "vapor" {
+		return ""
+	}
+	return fmt.Sprintf("note: %q is a vapor formula without `pour = true`; only the root step was materialized. Add `pour = true` for eager child-step expansion (see internal/formula/compile.go rootOnly rule).", formulaName)
 }
 
 // slingOnFormula handles the --on formula attachment path.

--- a/internal/sling/sling_rootonly_hint_test.go
+++ b/internal/sling/sling_rootonly_hint_test.go
@@ -1,0 +1,119 @@
+package sling
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func compileHintFixture(t *testing.T, name, content string) *formula.Recipe {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	recipe, err := formula.Compile(context.Background(), name, []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile(%s): %v", name, err)
+	}
+	return recipe
+}
+
+// TestRootOnlyVaporPourHint pins the cause (a) vs cause (b) distinction: only a
+// vapor formula without pour = true (a) gets the hint; a genuinely step-less
+// formula (b), a poured vapor formula, and a normal multi-step formula do not.
+func TestRootOnlyVaporPourHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		formula  string
+		content  string
+		wantHint bool
+	}{
+		{
+			name:     "vapor without pour (cause a)",
+			formula:  "patrol",
+			content:  "formula = \"patrol\"\nversion = 1\nphase = \"vapor\"\n\n[[steps]]\nid = \"scan\"\ntitle = \"Scan\"\n",
+			wantHint: true,
+		},
+		{
+			name:     "step-less formula (cause b)",
+			formula:  "router",
+			content:  "formula = \"router\"\nversion = 1\n",
+			wantHint: false,
+		},
+		{
+			name:     "vapor with pour",
+			formula:  "eager",
+			content:  "formula = \"eager\"\nversion = 1\nphase = \"vapor\"\npour = true\n\n[[steps]]\nid = \"scan\"\ntitle = \"Scan\"\n",
+			wantHint: false,
+		},
+		{
+			name:     "normal multi-step liquid",
+			formula:  "build",
+			content:  "formula = \"build\"\nversion = 1\n\n[[steps]]\nid = \"a\"\ntitle = \"A\"\n\n[[steps]]\nid = \"b\"\ntitle = \"B\"\n",
+			wantHint: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recipe := compileHintFixture(t, tc.formula, tc.content)
+			got := rootOnlyVaporPourHint(tc.formula, recipe)
+			if tc.wantHint {
+				if got == "" {
+					t.Fatalf("want hint, got empty (RootOnly=%v Phase=%q Pour=%v)", recipe.RootOnly, recipe.Phase, recipe.Pour)
+				}
+				if !strings.Contains(got, "pour = true") || !strings.Contains(got, tc.formula) {
+					t.Errorf("hint missing key content: %q", got)
+				}
+				return
+			}
+			if got != "" {
+				t.Errorf("want no hint, got %q (RootOnly=%v Phase=%q Pour=%v)", got, recipe.RootOnly, recipe.Phase, recipe.Pour)
+			}
+		})
+	}
+}
+
+func TestRootOnlyVaporPourHintNilRecipe(t *testing.T) {
+	if got := rootOnlyVaporPourHint("x", nil); got != "" {
+		t.Errorf("nil recipe: want empty, got %q", got)
+	}
+}
+
+// TestDoSlingFormulaVaporNoPourEmitsHint locks the wiring: a vapor-without-pour
+// formula slung via the --formula path surfaces the hint through
+// SlingResult.BeadWarnings (which the CLI prints to stderr).
+func TestDoSlingFormulaVaporNoPourEmitsHint(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "root-only.toml"), []byte(
+		"formula = \"root-only\"\nversion = 1\nphase = \"vapor\"\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		FormulaLayers: config.FormulaLayers{City: []string{dir}},
+	}
+	a := config.Agent{Name: "agent-a", MaxActiveSessions: intPtr(3)}
+	deps := testDeps(cfg, sp, runner.run)
+	result, err := DoSling(SlingOpts{Target: a, BeadOrFormula: "root-only", IsFormula: true}, deps, nil)
+	if err != nil {
+		t.Fatalf("DoSling: %v", err)
+	}
+	var found bool
+	for _, w := range result.BeadWarnings {
+		if strings.Contains(w, "pour = true") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("vapor-no-pour sling: want pour hint in BeadWarnings, got %v", result.BeadWarnings)
+	}
+}


### PR DESCRIPTION
Closes #3752

## Problem

`gc sling --formula <F>` where `F` is a `phase = vapor` formula lacking `pour = true` compiles to a root-only wisp — only the root step is materialized and the worker correctly parks on the otherwise-empty wisp. **No hint is emitted at sling time**, so diagnosing "why did only one step appear?" takes multiple rounds.

Source rule (unchanged by this PR), `internal/formula/compile.go`:

```go
rootOnly := (!f.Pour && f.Phase == "vapor") || len(f.Steps) == 0
```

## Fix

A surgical, non-invasive sling-time hint. No change to the `rootOnly` compile logic.

- New pure helper `rootOnlyVaporPourHint` + one call site in `slingFormula` (`internal/sling/sling_core.go`). This is the real `gc sling --formula` path; `cmd/gc/cmd_formula.go`'s `RootOnly` is the formula-show/JSON path, not sling.
- The hint is appended to `result.BeadWarnings`, which `cmd/gc/cmd_sling.go` already prints to the user — so the message actually surfaces.
- **Cause-distinguished:** the hint fires **only** for the vapor-without-pour case (`f.Phase == "vapor" && !f.Pour`). The genuinely-empty case (`len(Steps) == 0`) stays silent — `pour = true` would not help there.
- The hint cites `pour = true`, the `compile.go` rootOnly rule, and names the formula.

## Test

`internal/sling/sling_rootonly_hint_test.go`: table-driven over the four cause cases (vapor+!pour → hint; vapor+pour → none; empty-steps → none; normal → none), a nil-recipe guard, and a `DoSling` wiring integration check.

## Verification

`go build ./internal/sling ./cmd/gc` OK · `go vet` OK · full `internal/sling` test package PASS.