### PR TITLE
fix(session): widen STATE cache-age banner to the wake-lag window

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -828,29 +828,33 @@ func renderSessionListFromAPI(cr api.CachedRead[[]SessionView], jsonOutput bool,
 	_ = w.Flush() //nolint:errcheck // best-effort stdout
 
 	if cr.AgeSeconds > sessionStateCacheAgeBannerThresholdSeconds {
-		fmt.Fprintln(stdout, sessionStateCacheAgeBanner(cr.AgeSeconds)) //nolint:errcheck
+		fmt.Fprintln(stdout, sessionCacheAgeBanner(cr.AgeSeconds, "STATE")) //nolint:errcheck
 	}
 	return 0
 }
 
 // sessionStateCacheAgeBannerThresholdSeconds is the cache-age cutoff for the
-// session list and peek STATE-column banner. It is session-scoped (NOT the
+// session list and peek cache-age banner. It is session-scoped (NOT the
 // shared cacheAgeBannerThresholdSeconds) and intentionally lower — 15s vs 30s —
-// because the STATE value most often lags inside the post-wake reconciler poll
-// window (#3755). Scoping the lower cutoff to just these two views keeps the
-// generic "reconciler may be lagging" footer on every other command at 30s.
+// because the session values it flags (the STATE column, the cached pane
+// output) most often lag inside the post-wake reconciler poll window (#3755).
+// Scoping the lower cutoff to just these two views keeps the generic
+// "reconciler may be lagging" footer on every other command at 30s.
 const sessionStateCacheAgeBannerThresholdSeconds = 15.0
 
-// sessionStateCacheAgeBanner is the human-output footer for the session list and
-// peek views when the supervisor read-cache age exceeds
+// sessionCacheAgeBanner is the human-output footer for the session list and peek
+// views when the supervisor read-cache age exceeds
 // sessionStateCacheAgeBannerThresholdSeconds. Unlike the generic cache-age
-// banner, it names the STATE column — the value most likely to lag a just-woken
-// session within the reconciler poll window — and points operators at
-// out-of-band ground truth. cr.AgeSeconds is a single whole-list value, so this
-// stays a low-noise footer rather than a per-row marker (true per-row freshness
-// needs a SessionView state_updated_at field — out of scope, follow-up gco-cyt3).
-func sessionStateCacheAgeBanner(ageSeconds float64) string {
-	return fmt.Sprintf("(cache age: %.0fs — STATE may lag the runtime; verify a just-woken session via transcript / bead state)", ageSeconds)
+// banner, it names the specific cached value most likely to lag a just-woken
+// session within the reconciler poll window and points operators at out-of-band
+// ground truth. subject identifies that value per view — the STATE column on the
+// session list, the cached pane output on peek — so the footer never names a
+// STATE column peek does not render. cr.AgeSeconds is a single whole-read value,
+// so this stays a low-noise footer rather than a per-row marker (true per-row
+// freshness needs a SessionView state_updated_at field — out of scope, follow-up
+// gco-cyt3).
+func sessionCacheAgeBanner(ageSeconds float64, subject string) string {
+	return fmt.Sprintf("(cache age: %.0fs — %s may lag the runtime; verify a just-woken session via transcript / bead state)", ageSeconds, subject)
 }
 
 // sessionViewTarget mirrors sessionListTarget's fallback behavior, but
@@ -2237,7 +2241,7 @@ func renderSessionPeekFromAPI(cr api.CachedRead[api.SessionView], target string,
 		fmt.Fprintln(stdout) //nolint:errcheck // best-effort stdout
 	}
 	if cr.AgeSeconds > sessionStateCacheAgeBannerThresholdSeconds {
-		fmt.Fprintln(stdout, sessionStateCacheAgeBanner(cr.AgeSeconds)) //nolint:errcheck
+		fmt.Fprintln(stdout, sessionCacheAgeBanner(cr.AgeSeconds, "cached pane output")) //nolint:errcheck
 	}
 	return 0
 }

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -827,10 +827,30 @@ func renderSessionListFromAPI(cr api.CachedRead[[]SessionView], jsonOutput bool,
 	}
 	_ = w.Flush() //nolint:errcheck // best-effort stdout
 
-	if cr.AgeSeconds > cacheAgeBannerThresholdSeconds {
-		fmt.Fprintf(stdout, "(cache age: %.0fs — reconciler may be lagging)\n", cr.AgeSeconds) //nolint:errcheck
+	if cr.AgeSeconds > sessionStateCacheAgeBannerThresholdSeconds {
+		fmt.Fprintln(stdout, sessionStateCacheAgeBanner(cr.AgeSeconds)) //nolint:errcheck
 	}
 	return 0
+}
+
+// sessionStateCacheAgeBannerThresholdSeconds is the cache-age cutoff for the
+// session list and peek STATE-column banner. It is session-scoped (NOT the
+// shared cacheAgeBannerThresholdSeconds) and intentionally lower — 15s vs 30s —
+// because the STATE value most often lags inside the post-wake reconciler poll
+// window (#3755). Scoping the lower cutoff to just these two views keeps the
+// generic "reconciler may be lagging" footer on every other command at 30s.
+const sessionStateCacheAgeBannerThresholdSeconds = 15.0
+
+// sessionStateCacheAgeBanner is the human-output footer for the session list and
+// peek views when the supervisor read-cache age exceeds
+// sessionStateCacheAgeBannerThresholdSeconds. Unlike the generic cache-age
+// banner, it names the STATE column — the value most likely to lag a just-woken
+// session within the reconciler poll window — and points operators at
+// out-of-band ground truth. cr.AgeSeconds is a single whole-list value, so this
+// stays a low-noise footer rather than a per-row marker (true per-row freshness
+// needs a SessionView state_updated_at field — out of scope, follow-up gco-cyt3).
+func sessionStateCacheAgeBanner(ageSeconds float64) string {
+	return fmt.Sprintf("(cache age: %.0fs — STATE may lag the runtime; verify a just-woken session via transcript / bead state)", ageSeconds)
 }
 
 // sessionViewTarget mirrors sessionListTarget's fallback behavior, but
@@ -2216,8 +2236,8 @@ func renderSessionPeekFromAPI(cr api.CachedRead[api.SessionView], target string,
 	if !strings.HasSuffix(output, "\n") {
 		fmt.Fprintln(stdout) //nolint:errcheck // best-effort stdout
 	}
-	if cr.AgeSeconds > cacheAgeBannerThresholdSeconds {
-		fmt.Fprintf(stdout, "(cache age: %.0fs — reconciler may be lagging)\n", cr.AgeSeconds) //nolint:errcheck
+	if cr.AgeSeconds > sessionStateCacheAgeBannerThresholdSeconds {
+		fmt.Fprintln(stdout, sessionStateCacheAgeBanner(cr.AgeSeconds)) //nolint:errcheck
 	}
 	return 0
 }

--- a/cmd/gc/cmd_session_state_banner_test.go
+++ b/cmd/gc/cmd_session_state_banner_test.go
@@ -8,15 +8,28 @@ import (
 	"github.com/gastownhall/gascity/internal/api"
 )
 
-func TestSessionStateCacheAgeBanner(t *testing.T) {
-	got := sessionStateCacheAgeBanner(20)
-	for _, want := range []string{"cache age: 20s", "STATE", "verify", "transcript", "bead state"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("banner %q missing %q", got, want)
+func TestSessionCacheAgeBanner(t *testing.T) {
+	// The session list view names the STATE column it renders.
+	stateBanner := sessionCacheAgeBanner(20, "STATE")
+	for _, want := range []string{"cache age: 20s", "STATE may lag", "verify", "transcript", "bead state"} {
+		if !strings.Contains(stateBanner, want) {
+			t.Errorf("list banner %q missing %q", stateBanner, want)
 		}
 	}
-	if strings.Contains(got, "reconciler may be lagging") {
-		t.Errorf("STATE banner should not reuse the generic text: %q", got)
+	if strings.Contains(stateBanner, "reconciler may be lagging") {
+		t.Errorf("session banner should not reuse the generic text: %q", stateBanner)
+	}
+
+	// The peek view names the cached pane output it renders, not a STATE column
+	// it does not show, so the footer never points operators at an absent column.
+	peekBanner := sessionCacheAgeBanner(20, "cached pane output")
+	for _, want := range []string{"cache age: 20s", "cached pane output may lag", "verify", "transcript", "bead state"} {
+		if !strings.Contains(peekBanner, want) {
+			t.Errorf("peek banner %q missing %q", peekBanner, want)
+		}
+	}
+	if strings.Contains(peekBanner, "STATE") {
+		t.Errorf("peek banner must not name a STATE column peek does not render: %q", peekBanner)
 	}
 }
 
@@ -73,19 +86,66 @@ func sessionPeekBannerOutput(t *testing.T, ageSeconds float64) string {
 }
 
 // TestRenderSessionPeekStateBannerWakeWindow mirrors the list-path assertion for
-// the peek view. peek reuses sessionStateCacheAgeBanner under the same
-// session-scoped sessionStateCacheAgeBannerThresholdSeconds, so the STATE banner
-// must fire in the 15-30s wake-lag window and name STATE, and stay silent for a
+// the peek view. peek shares the session-scoped
+// sessionStateCacheAgeBannerThresholdSeconds but names the cached pane output it
+// renders rather than a STATE column it does not show, so the banner must fire in
+// the 15-30s wake-lag window naming the cached pane output, and stay silent for a
 // fresh cache.
 func TestRenderSessionPeekStateBannerWakeWindow(t *testing.T) {
-	// 20s: inside the session-scoped window — banner fires and names STATE.
+	// 20s: inside the session-scoped window — banner fires and names the cached view.
 	out := sessionPeekBannerOutput(t, 20)
-	if !strings.Contains(out, "STATE may lag the runtime") {
-		t.Errorf("age=20s: want STATE banner on peek path, got:\n%s", out)
+	if !strings.Contains(out, "cached pane output may lag the runtime") {
+		t.Errorf("age=20s: want cached-pane banner on peek path, got:\n%s", out)
+	}
+	if strings.Contains(out, "STATE") {
+		t.Errorf("age=20s: peek banner must not name a STATE column, got:\n%s", out)
 	}
 	// 10s: below threshold, no banner.
 	quiet := sessionPeekBannerOutput(t, 10)
 	if strings.Contains(quiet, "cache age:") {
 		t.Errorf("age=10s: want no banner on peek path, got:\n%s", quiet)
+	}
+}
+
+// TestRenderSessionListFromAPIJSONHasNoBanner pins the wire-clean invariant for
+// the list --json path: it returns before footer emission, so even at a cache
+// age well past the banner threshold the JSON output must never carry the human
+// "cache age:" footer (the _cache_age_s field is the only JSON age signal). This
+// guards against a later refactor moving the footer above the early return.
+func TestRenderSessionListFromAPIJSONHasNoBanner(t *testing.T) {
+	var stdout bytes.Buffer
+	code := renderSessionListFromAPI(api.CachedRead[[]SessionView]{
+		AgeSeconds: 20,
+		Body: []SessionView{{
+			ID:       "gc-abc",
+			Template: "worker",
+			State:    "asleep",
+		}},
+	}, true, &stdout)
+	if code != 0 {
+		t.Fatalf("renderSessionListFromAPI = %d, want 0", code)
+	}
+	if strings.Contains(stdout.String(), "cache age:") {
+		t.Errorf("json list output must not contain the human cache-age footer, got:\n%s", stdout.String())
+	}
+}
+
+// TestRenderSessionPeekFromAPIJSONHasNoBanner mirrors the list assertion for the
+// peek --json path: it returns before footer emission, so no "cache age:" footer
+// may leak into JSON even when the cache age is past the banner threshold.
+func TestRenderSessionPeekFromAPIJSONHasNoBanner(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := renderSessionPeekFromAPI(api.CachedRead[api.SessionView]{
+		AgeSeconds: 20,
+		Body: api.SessionView{
+			ID:         "gc-abc",
+			LastOutput: "recent pane output\n",
+		},
+	}, "gc-abc", 50, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("renderSessionPeekFromAPI = %d, want 0", code)
+	}
+	if strings.Contains(stdout.String(), "cache age:") {
+		t.Errorf("json peek output must not contain the human cache-age footer, got:\n%s", stdout.String())
 	}
 }

--- a/cmd/gc/cmd_session_state_banner_test.go
+++ b/cmd/gc/cmd_session_state_banner_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/api"
+)
+
+func TestSessionStateCacheAgeBanner(t *testing.T) {
+	got := sessionStateCacheAgeBanner(20)
+	for _, want := range []string{"cache age: 20s", "STATE", "verify", "transcript", "bead state"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("banner %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "reconciler may be lagging") {
+		t.Errorf("STATE banner should not reuse the generic text: %q", got)
+	}
+}
+
+func sessionListBannerOutput(t *testing.T, ageSeconds float64) string {
+	t.Helper()
+	var stdout bytes.Buffer
+	code := renderSessionListFromAPI(api.CachedRead[[]SessionView]{
+		AgeSeconds: ageSeconds,
+		Body: []SessionView{{
+			ID:         "gc-abc",
+			Template:   "worker",
+			State:      "asleep",
+			CreatedAt:  "2026-04-23T10:00:00Z",
+			LastActive: "2026-04-23T12:00:00Z",
+		}},
+	}, false, &stdout)
+	if code != 0 {
+		t.Fatalf("renderSessionListFromAPI = %d, want 0", code)
+	}
+	return stdout.String()
+}
+
+// TestRenderSessionListStateBannerWakeWindow pins the lowered threshold (30 -> 15)
+// together with the STATE-specific reword: the banner now fires in the 15-30s
+// wake-lag window (previously silent) and names the STATE column, while staying
+// quiet for a fresh cache.
+func TestRenderSessionListStateBannerWakeWindow(t *testing.T) {
+	// 20s: inside the newly covered window (silent under the old 30s cutoff).
+	out := sessionListBannerOutput(t, 20)
+	if !strings.Contains(out, "STATE may lag the runtime") {
+		t.Errorf("age=20s: want STATE banner, got:\n%s", out)
+	}
+	// 10s: below threshold, still no banner (low-noise).
+	quiet := sessionListBannerOutput(t, 10)
+	if strings.Contains(quiet, "cache age:") {
+		t.Errorf("age=10s: want no banner, got:\n%s", quiet)
+	}
+}
+
+func sessionPeekBannerOutput(t *testing.T, ageSeconds float64) string {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := renderSessionPeekFromAPI(api.CachedRead[api.SessionView]{
+		AgeSeconds: ageSeconds,
+		Body: api.SessionView{
+			ID:         "gc-abc",
+			LastOutput: "recent pane output\n",
+		},
+	}, "gc-abc", 50, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("renderSessionPeekFromAPI = %d, want 0", code)
+	}
+	return stdout.String()
+}
+
+// TestRenderSessionPeekStateBannerWakeWindow mirrors the list-path assertion for
+// the peek view. peek reuses sessionStateCacheAgeBanner under the same
+// session-scoped sessionStateCacheAgeBannerThresholdSeconds, so the STATE banner
+// must fire in the 15-30s wake-lag window and name STATE, and stay silent for a
+// fresh cache.
+func TestRenderSessionPeekStateBannerWakeWindow(t *testing.T) {
+	// 20s: inside the session-scoped window — banner fires and names STATE.
+	out := sessionPeekBannerOutput(t, 20)
+	if !strings.Contains(out, "STATE may lag the runtime") {
+		t.Errorf("age=20s: want STATE banner on peek path, got:\n%s", out)
+	}
+	// 10s: below threshold, no banner.
+	quiet := sessionPeekBannerOutput(t, 10)
+	if strings.Contains(quiet, "cache age:") {
+		t.Errorf("age=10s: want no banner on peek path, got:\n%s", quiet)
+	}
+}


### PR DESCRIPTION
Closes #3755

## Problem

After `gc session wake`, the STATE column in `gc session list` / `gc session peek` keeps showing the stale cached value (`asleep` / `stopped`) for 30–60s+ while the session is already running. The existing cache-age banner under-covers this:

- It fires only when `cr.AgeSeconds > cacheAgeBannerThresholdSeconds`, and that threshold was `30.0` (`cmd/gc/cmd_rig.go`) — so a just-woken session in the **0–30s** window got no warning.
- The banner text (`"(cache age: Ns — reconciler may be lagging)"`) is a generic footer that never names the **STATE** column, so an operator does not connect it to the `asleep` row they are reading.

## Fix (render-layer only — no API / reconciler change)

- Add a **session-scoped** `sessionStateCacheAgeBannerThresholdSeconds = 15.0` (`cmd/gc/cmd_session.go`, doc-commented with the #3755 rationale) and gate **only** the session list + peek STATE banner on it. The shared `cacheAgeBannerThresholdSeconds` **stays at 30.0** — the wake-lag is a session-STATE symptom, so the ~17 other consumers (convoy / beads / citystatus / order / maintenance / mail / rig / status / wait …) keep their generic `"reconciler may be lagging"` footer at the original 30s. **Not a global lowering.**
- New `sessionStateCacheAgeBanner()` that explicitly names the **STATE** column and adds a verify hint (check transcript / bead state), applied to **both** `renderSessionListFromAPI` and `renderSessionPeekFromAPI`.
- `gc rig status` / `rig list` render no per-session STATE column (confirmed by grep), so they correctly keep the generic banner at 30s — not reworded.

## Scope

Render-layer only, and deliberately narrow: the new 15s cutoff only widens the STATE banner's coverage to the **0–15s** wake-lag window on two views — it is **not** the full freshness fix. A true per-row marker — `asleep (last-poll Ns ago)` — needs a per-session `state_updated_at` on `SessionView` (reconciler stamp + API field), which is the larger follow-up tracked as gco-cyt3 (to be filed upstream when picked up).

## Test

`cmd/gc/cmd_session_state_banner_test.go`: asserts the banner names the STATE column (not the generic wording) and that it fires at 20s but is silent at 10s (the session-scoped threshold window), on **both** the list path and the peek path.

## Note on the diff

The three-dot diff shows a 1-line addition to `docs/reference/cli.md` (a `gc session new --wait-timeout` row). This is a **pre-existing generated-doc sync**, not part of this change: the flag already exists in source (`cmd/gc/cmd_session.go`, untouched here) and **current `upstream/main`'s `cli.md` already contains this exact row**. The branch base is several commits stale, so the row surfaces in the PR diff, but it is **identical to current main and a no-op at merge**. The pre-commit doc generator re-emits it on every commit on this branch.

## Verification

`go build ./cmd/gc` OK · `go vet ./cmd/gc` OK · `golangci-lint --new-from-rev=upstream/main ./cmd/gc/...` → 0 issues · `go test ./cmd/gc/` PASS (banner list+peek tests + broad threshold-consumer regression — the shared const is unchanged, so no existing consumer is affected).
