### PR TITLE
fix(runtime): ignore blocked assigned work for demand

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -82,6 +82,13 @@ func assignedWorkIndexReachableFromAgent(cityPath string, cfg *config.City, agen
 	return storeRefs[index] == assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
 }
 
+func assignedWorkKnownBlocked(wb beads.Bead) bool {
+	if wb.IsBlocked != nil {
+		return *wb.IsBlocked
+	}
+	return wb.DependencyCount > 0
+}
+
 // filterAssignedWorkBeadsForPoolDemand resolves work through the routed
 // backing template because pool scale decisions are per agent template.
 func filterAssignedWorkBeadsForPoolDemand(
@@ -116,6 +123,9 @@ func filterAssignedWorkBeadsForPoolDemand(
 	}
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
 	for i, wb := range assignedWorkBeads {
+		if assignedWorkKnownBlocked(wb) {
+			continue
+		}
 		template := routedToOrLegacyWorkflowTarget(wb)
 		if template == "" {
 			if sessionBeadID := assigneeToSessionBeadID[strings.TrimSpace(wb.Assignee)]; sessionBeadID != "" {
@@ -212,6 +222,9 @@ func filterAssignedWorkBeadsForSessionWake(
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
 	for i, wb := range assignedWorkBeads {
 		if i >= len(assignedWorkStoreRefs) {
+			continue
+		}
+		if assignedWorkKnownBlocked(wb) {
 			continue
 		}
 		assignee := strings.TrimSpace(wb.Assignee)

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -114,6 +114,49 @@ func TestFilterAssignedWorkBeadsForPoolDemandKeepsDirectAssigneeAfterTemplateFal
 	}
 }
 
+func TestFilterAssignedWorkBeadsForPoolDemandSkipsKnownBlockedRoutedWork(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name: "worker",
+		}},
+	}
+	blockedProjection := true
+	work := []beads.Bead{
+		{
+			ID:       "blocked-by-count",
+			Status:   "open",
+			Assignee: "worker-session",
+			Metadata: map[string]string{
+				"gc.routed_to": "worker",
+			},
+			DependencyCount: 1,
+		},
+		{
+			ID:       "blocked-by-projection",
+			Status:   "open",
+			Assignee: "worker-session",
+			Metadata: map[string]string{
+				"gc.routed_to": "worker",
+			},
+			IsBlocked: &blockedProjection,
+		},
+		{
+			ID:       "ready-assigned",
+			Status:   "open",
+			Assignee: "worker-session",
+			Metadata: map[string]string{
+				"gc.routed_to": "worker",
+			},
+		},
+	}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{"", "", ""})
+
+	if len(got) != 1 || got[0].ID != "ready-assigned" {
+		t.Fatalf("filtered work = %#v, want only ready-assigned", got)
+	}
+}
+
 func TestFilterAssignedWorkBeadsForPoolDemandKeepsLegacyWorkflowRunTarget(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{{
@@ -134,6 +177,31 @@ func TestFilterAssignedWorkBeadsForPoolDemandKeepsLegacyWorkflowRunTarget(t *tes
 
 	if len(got) != 1 || got[0].ID != "legacy-workflow-root" {
 		t.Fatalf("filtered work = %#v, want legacy workflow root preserved through run_target fallback", got)
+	}
+}
+
+func TestFilterAssignedWorkBeadsForSessionWakeSkipsKnownBlockedAssignedWork(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name: "worker",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+	}
+	identity := cfg.NamedSessions[0].QualifiedName()
+	blockedProjection := true
+	work := []beads.Bead{
+		{ID: "blocked-by-count", Status: "open", Assignee: identity, DependencyCount: 1},
+		{ID: "blocked-by-projection", Status: "open", Assignee: identity, IsBlocked: &blockedProjection},
+		{ID: "ready-assigned", Status: "open", Assignee: identity},
+	}
+
+	got := filterAssignedWorkBeadsForSessionWake(cfg, "", nil, work, []string{"", "", ""})
+
+	if len(got) != 1 || got[0].ID != "ready-assigned" {
+		t.Fatalf("filtered work = %#v, want only ready-assigned", got)
 	}
 }
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -599,10 +599,13 @@ type bdIssue struct {
 	Labels       []string     `json:"labels"`
 	Metadata     StringMap    `json:"metadata,omitempty"`
 	Dependencies []bdIssueDep `json:"dependencies,omitempty"`
-	Ephemeral    bool         `json:"ephemeral,omitempty"`
-	NoHistory    bool         `json:"no_history,omitempty"`
-	DeferUntil   *time.Time   `json:"defer_until,omitempty"`
-	IsBlocked    optionalBool `json:"is_blocked,omitempty"`
+	// dependency_count is bd's active-blocker count, not simply
+	// len(dependencies). It excludes non-blocking relationships such as tracks.
+	DependencyCount int          `json:"dependency_count,omitempty"`
+	Ephemeral       bool         `json:"ephemeral,omitempty"`
+	NoHistory       bool         `json:"no_history,omitempty"`
+	DeferUntil      *time.Time   `json:"defer_until,omitempty"`
+	IsBlocked       optionalBool `json:"is_blocked,omitempty"`
 }
 
 type bdIssueDep struct {
@@ -735,26 +738,27 @@ func (b *bdIssue) toBead() Bead {
 		}
 	}
 	return Bead{
-		ID:           b.ID,
-		Title:        b.Title,
-		Status:       mapBdStatus(b.Status),
-		Type:         b.IssueType,
-		Priority:     cloneIntPtr(b.Priority),
-		CreatedAt:    b.CreatedAt.Truncate(time.Second),
-		UpdatedAt:    b.UpdatedAt.Truncate(time.Second),
-		Assignee:     b.Assignee,
-		From:         from,
-		ParentID:     parentID,
-		Ref:          b.Ref,
-		Needs:        b.Needs,
-		Description:  b.Description,
-		Labels:       b.Labels,
-		Metadata:     b.Metadata,
-		Dependencies: deps,
-		Ephemeral:    b.Ephemeral,
-		NoHistory:    b.NoHistory,
-		DeferUntil:   cloneTimePtr(b.DeferUntil),
-		IsBlocked:    b.IsBlocked.ptr(),
+		ID:              b.ID,
+		Title:           b.Title,
+		Status:          mapBdStatus(b.Status),
+		Type:            b.IssueType,
+		Priority:        cloneIntPtr(b.Priority),
+		CreatedAt:       b.CreatedAt.Truncate(time.Second),
+		UpdatedAt:       b.UpdatedAt.Truncate(time.Second),
+		Assignee:        b.Assignee,
+		From:            from,
+		ParentID:        parentID,
+		Ref:             b.Ref,
+		Needs:           b.Needs,
+		Description:     b.Description,
+		Labels:          b.Labels,
+		Metadata:        b.Metadata,
+		Dependencies:    deps,
+		DependencyCount: b.DependencyCount,
+		Ephemeral:       b.Ephemeral,
+		NoHistory:       b.NoHistory,
+		DeferUntil:      cloneTimePtr(b.DeferUntil),
+		IsBlocked:       b.IsBlocked.ptr(),
 	}
 }
 

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1841,7 +1841,7 @@ func TestBdStoreListDecodesIsBlockedProjection(t *testing.T) {
 	}{
 		`bd list --json --include-infra --include-gates --limit 0`: {
 			out: []byte(`[
-				{"id":"bd-blocked","title":"blocked","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","is_blocked":1},
+				{"id":"bd-blocked","title":"blocked","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","is_blocked":1,"dependency_count":2},
 				{"id":"bd-ready","title":"ready","status":"open","issue_type":"task","created_at":"2025-01-15T10:31:00Z","is_blocked":false}
 			]`),
 		},
@@ -1856,6 +1856,9 @@ func TestBdStoreListDecodesIsBlockedProjection(t *testing.T) {
 	}
 	if got[0].IsBlocked == nil || !*got[0].IsBlocked {
 		t.Fatalf("got[0].IsBlocked = %v, want true", got[0].IsBlocked)
+	}
+	if got[0].DependencyCount != 2 {
+		t.Fatalf("got[0].DependencyCount = %d, want 2", got[0].DependencyCount)
 	}
 	if got[1].IsBlocked == nil || *got[1].IsBlocked {
 		t.Fatalf("got[1].IsBlocked = %v, want false", got[1].IsBlocked)

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -65,6 +65,11 @@ type Bead struct {
 	Labels       []string          `json:"labels,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
 	Dependencies []Dep             `json:"dependencies,omitempty"`
+	// DependencyCount carries bd's count of active blocking dependencies when
+	// available from list-style output. It is not a count of all relationship
+	// edges; non-blocking links such as tracks/parent-child may still appear in
+	// Dependencies without making this value non-zero.
+	DependencyCount int `json:"dependency_count,omitempty"`
 	// Ephemeral routes the bead to the wisps tier on Create. Wisps live in
 	// a separate Dolt table, are not git-synced, and are eligible for TTL
 	// garbage collection. Reads must opt in via ListQuery.TierMode (or the


### PR DESCRIPTION
## Summary
- keep blocked assigned routed work visible for orphan-release collection
- stop known-blocked assigned work from counting as pool demand or session wake demand
- decode bd `dependency_count` so bd list rows can carry active-blocker state into controller filters

## Tests
- go test ./cmd/gc -run 'TestFilterAssignedWorkBeadsFor(PoolDemandSkipsKnownBlockedRoutedWork|SessionWakeSkipsKnownBlockedAssignedWork)'\n- go test ./internal/beads -run 'TestBdStoreListDecodesIsBlockedProjection'