### PR TITLE
test: deflake three CI-saturation timing races blocking main

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1300,7 +1300,10 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	// Redacted event export (opt-in via [events.export]). No-op unless an
 	// endpoint is configured.
 	if supCfg.Events.Export.Enabled() {
-		startEventExport(ctx, supCfg.Events.Export, apiMux.EventProviders, supervisor.DefaultHome(), stderr)
+		// The returned drain handle is intentionally discarded: the supervisor's
+		// home dir outlives the process, so there is nothing to wait for before
+		// teardown. Tests that own a transient home (t.TempDir) Wait on it.
+		_ = startEventExport(ctx, supCfg.Events.Export, apiMux.EventProviders, supervisor.DefaultHome(), stderr)
 	}
 
 	// Control socket — uses supervisor-specific path, not the per-city controller socket.

--- a/cmd/gc/event_export.go
+++ b/cmd/gc/event_export.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/eventfeed"
@@ -45,7 +46,15 @@ const minActorSaltLen = 16
 // batches to the configured endpoint. It runs in its own goroutine, holds its
 // cursor on sink failure, and applies backpressure rather than blocking event
 // recording.
-func startEventExport(ctx context.Context, ec supervisor.ExportConfig, providers func() map[string]events.Provider, homeDir string, stderr io.Writer) {
+//
+// The returned WaitGroup tracks the background goroutines (the exporter loop and
+// the cursor-persist loop, both of which write under homeDir). It is nil when no
+// goroutine was launched — the fail-closed cursor return. Callers that own
+// homeDir's lifetime — e.g. a test using t.TempDir, or a future supervisor that
+// wants its final cursor flush to complete before exit — cancel ctx and Wait on
+// it so the homeDir writes drain before teardown. The long-lived supervisor
+// process ignores it today: its homeDir outlives the process.
+func startEventExport(ctx context.Context, ec supervisor.ExportConfig, providers func() map[string]events.Provider, homeDir string, stderr io.Writer) *sync.WaitGroup {
 	logf := func(format string, args ...any) {
 		fmt.Fprintf(stderr, "gc events-export: "+format+"\n", args...) //nolint:errcheck
 	}
@@ -92,7 +101,7 @@ func startEventExport(ctx context.Context, ec supervisor.ExportConfig, providers
 		// operator can repair the file (or remove it to deliberately start fresh)
 		// rather than lose exports.
 		logf("ERROR: cannot read durable export cursor %s (refusing to start; remove it to start fresh): %v", cursorPath, err)
-		return
+		return nil
 	}
 	exp.SetCursors(cursors)
 
@@ -103,10 +112,13 @@ func startEventExport(ctx context.Context, ec supervisor.ExportConfig, providers
 	transcriptmeta.SetEnabled(true)
 
 	src := eventfeed.NewMuxSource(providers, exp.Cursors, muxRebuildInterval, logf)
-	go func() { _ = exp.Run(ctx, src) }()
-	go persistExportCursors(ctx, exp, cursorPath, logf)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); _ = exp.Run(ctx, src) }()
+	go func() { defer wg.Done(); persistExportCursors(ctx, exp, cursorPath, logf) }()
 
 	logf("enabled -> %s (envelope-only metadata; no payloads leave the box)", ec.Endpoint)
+	return &wg
 }
 
 // persistExportCursors snapshots the exporter cursor to disk periodically and on

--- a/cmd/gc/event_export_test.go
+++ b/cmd/gc/event_export_test.go
@@ -136,7 +136,15 @@ func TestStartEventExport_SuccessfulStartupArmsSidecar(t *testing.T) {
 	ec := supervisor.ExportConfig{Endpoint: "https://example.invalid/ingest", ActorSalt: "test-actor-salt-ok"}
 	providers := func() map[string]events.Provider { return map[string]events.Provider{} }
 
-	startEventExport(ctx, ec, providers, home, io.Discard)
+	wg := startEventExport(ctx, ec, providers, home, io.Discard)
+	// The exporter and cursor-persist goroutines write under home (e.g. the
+	// shutdown cursor flush in persistExportCursors). Drain them before the test
+	// returns so t.TempDir cleanup does not race those writes ("directory not
+	// empty"). On this happy path the goroutines were launched, so wg is non-nil.
+	if wg == nil {
+		t.Fatal("happy-path startEventExport must return a drain handle")
+	}
+	wg.Wait()
 
 	if !transcriptmeta.Enabled() {
 		t.Fatal("sidecar gate must be armed once the exporter clears its fail-closed startup")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3466,6 +3466,7 @@ gc session new helper --no-attach
 | `--no-attach` | bool |  | create session without attaching |
 | `--title` | string |  | human-readable session title |
 | `--title-hint` | string |  | text to auto-generate a session title from |
+| `--wait-timeout` | duration | `2m0s` | max time to wait for the reconciler to start the session before attaching |
 
 ## gc session nudge
 

--- a/internal/eventfeed/muxsource_test.go
+++ b/internal/eventfeed/muxsource_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/testutil"
 	"github.com/gastownhall/gascity/pkg/eventexport"
 )
 
@@ -89,7 +90,11 @@ func TestMuxSource_YieldsAndPicksUpNewCity(t *testing.T) {
 		}
 		return false
 	}
-	waitFor(t, 2*time.Second, func() bool { return has("c1", 1) && has("c1", 2) })
+	// The deadline races the consumer goroutine and the 15ms MuxSource rebuild
+	// loop; under the parallel fast-test CPU storm a 2s constant flakes
+	// ("condition not met within 2s"). See TESTING.md "Test deadline rule": use
+	// the shared goroutine-race floor since this timer is not the subject here.
+	waitFor(t, testutil.GoroutineRaceTimeout, func() bool { return has("c1", 1) && has("c1", 2) })
 
 	// add a second city after launch; it must be picked up on a rebuild.
 	f2 := events.NewFake()
@@ -98,7 +103,7 @@ func TestMuxSource_YieldsAndPicksUpNewCity(t *testing.T) {
 	pmu.Unlock()
 	time.Sleep(40 * time.Millisecond) // let a rebuild floor c2 at 0
 	f2.Record(events.Event{Seq: 1, Type: "bead.created", Ts: time.Now(), Actor: "b", Subject: "mc-9"})
-	waitFor(t, 2*time.Second, func() bool { return has("c2", 1) })
+	waitFor(t, testutil.GoroutineRaceTimeout, func() bool { return has("c2", 1) })
 }
 
 // TestAdapter_NoLeakFromPayload proves the events.Event -> primitive conversion

--- a/internal/runtime/subprocess/seams_test.go
+++ b/internal/runtime/subprocess/seams_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 // TestSeamsLifecycle drives the subprocess provider through the de-conflated
@@ -119,7 +120,13 @@ func TestSeamsInterrupt(t *testing.T) {
 		t.Fatalf("Interrupt: %v", err)
 	}
 
-	deadline := time.Now().Add(3 * time.Second)
+	// The deadline races a real subprocess death (SIGINT delivery to the process
+	// group, the kernel reaping `sleep`, and cmd.Wait closing sc.done). Under CI
+	// CPU saturation a sub-second/few-second constant flakes — see TESTING.md
+	// "Test deadline rule." This timer is not the subject under test (we prove
+	// Interrupt delegates, not that it lands within N seconds), so use the shared
+	// exec-race floor.
+	deadline := time.Now().Add(testutil.ExecRaceTimeout)
 	for {
 		alive, _ := place.IsRunning(ctx)
 		if !alive {


### PR DESCRIPTION
## Problem

`main` has been failing ~60% of recent CI runs (12 fail / 7 success of the
last 20), blocking the adopt-PR pipeline on a red base. The failing jobs
(`Preflight / unit cover (cmd/gc 2 of 6)`, `Integration /
packages-core-3-of-4`, and the `cmd/gc process` shards that fan into
`CI / integration` and `CI / required`) were all timing flakes — not real
regressions — surfacing only under CI CPU saturation on the 32-vcpu
many-shard runners.

All three are the exact class the `TESTING.md` "Test deadline rule"
targets: a short timer that races a goroutine/exec under load.

## Root cause + fix, per test

### 1. `TestStartEventExport_SuccessfulStartupArmsSidecar` (`cmd/gc`)
**Symptom:** `TempDir RemoveAll cleanup: ... directory not empty`.

`startEventExport` launches two goroutines (the exporter loop and
`persistExportCursors`) that write under `homeDir`. The test passes a
**pre-canceled** ctx and `t.TempDir()` as home; on `ctx.Done` the persist
loop runs a final `SaveCursors`, writing `events-export-cursor.json` into
the temp dir **after the test body returned**. That async write races
`t.TempDir()` cleanup. Reproduced ~10/50 on an idle machine.

**Fix:** `startEventExport` now returns a `*sync.WaitGroup` tracking its
background goroutines (`nil` on the fail-closed corrupt-cursor return,
where none launch). The test cancels ctx and `Wait`s on it so the homeDir
writes drain before cleanup. **The assertion is unchanged.** The handle is
also a genuine lifecycle seam — a future supervisor could flush its final
cursor before exit — but the long-lived supervisor discards it today since
its home outlives the process. Verified 100x + `-race` clean.

### 2. `TestSeamsInterrupt` (`internal/runtime/subprocess`)
**Symptom:** `session still alive after Interrupt (verb did not delegate)`.

The test SIGINTs a `sleep 3600` process group, then polls `IsRunning`
against a **3s** deadline that races a real subprocess death (signal
delivery + kernel reaping + `cmd.Wait` closing `sc.done`). Under CI CPU
saturation it intermittently exceeded 3s.

**Fix:** use the shared `testutil.ExecRaceTimeout` (10s) floor. The timer
is not the subject under test (we prove `Interrupt` *delegates*, not that
it lands within N seconds). Verified 30x clean.

### 3. `TestMuxSource_YieldsAndPicksUpNewCity` (`internal/eventfeed`)
**Symptom:** `condition not met within 2s`.

`waitFor` polls a consumer goroutine fed by the 15ms `MuxSource` rebuild
loop against a **2s** deadline; under the parallel fast-test CPU storm 2s
flakes. (Surfaced by this PR's own pre-push `make test-fast-parallel`
gate — same flake class, also contributing to main's red rate.)

**Fix:** use the shared `testutil.GoroutineRaceTimeout` (10s) floor at both
`waitFor` call sites. Verified 10x clean.

## Verification

- Each previously-failing test re-run many times (100x / 30x / 10x) — green.
- `cmd/gc` shard 2-of-6 (the failing CI shard) passes via
  `./scripts/test-go-test-shard ./cmd/gc 2 6`.
- Full `internal/runtime/...` tree passes; full `make test-fast-parallel`
  passes (also the pre-push gate).
- `go vet ./...` clean.
- `docs/reference/cli.md` is a 1-line generated-doc sync the pre-commit
  hook regenerated (a pre-existing `--wait-timeout` drift), not a behavior
  change.

No production behavior changes: the only non-test edit returns a drain
handle the supervisor explicitly discards.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)