### PR TITLE
fix(control-dispatcher): namespace-aware resolution + singleton-consistent routing

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1497,8 +1497,11 @@ func TestDecorateDynamicFragmentRecipePreservesPoolFallbackAndScopeMetadata(t *t
 	if control.Assignee != "" {
 		t.Fatalf("control assignee = %q, want empty routed control-dispatcher queue", control.Assignee)
 	}
-	if got := control.Metadata["gc.routed_to"]; got != "frontend/control-dispatcher" {
-		t.Fatalf("control gc.routed_to = %q, want frontend/control-dispatcher", got)
+	// The control step routes to the city-level singleton control-dispatcher
+	// (the one whose session actually runs, given max_active_sessions=1), not
+	// the rig-scoped frontend/control-dispatcher copy that no session claims.
+	if got := control.Metadata["gc.routed_to"]; got != "control-dispatcher" {
+		t.Fatalf("control gc.routed_to = %q, want city-level control-dispatcher", got)
 	}
 	if control.Metadata[graphroute.GraphExecutionRouteMetaKey] != "frontend/reviewer" {
 		t.Fatalf("control execution route = %q, want frontend/reviewer", control.Metadata[graphroute.GraphExecutionRouteMetaKey])
@@ -1578,8 +1581,10 @@ func TestDecorateDynamicFragmentRecipeUsesDirectExecutionRoute(t *testing.T) {
 	if check.Assignee != "" {
 		t.Fatalf("check assignee = %q, want empty routed control-dispatcher queue", check.Assignee)
 	}
-	if got := check.Metadata["gc.routed_to"]; got != "frontend/control-dispatcher" {
-		t.Fatalf("check gc.routed_to = %q, want frontend/control-dispatcher", got)
+	// Control routes to the city-level singleton control-dispatcher, not the
+	// rig-scoped frontend/control-dispatcher copy (which no session claims).
+	if got := check.Metadata["gc.routed_to"]; got != "control-dispatcher" {
+		t.Fatalf("check gc.routed_to = %q, want city-level control-dispatcher", got)
 	}
 	if got := check.Metadata[graphroute.GraphExecutionRouteMetaKey]; got != direct.ID {
 		t.Fatalf("check execution route = %q, want direct session %s", got, direct.ID)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,41 @@ func IsDeterministicControlDispatcher(agent *Agent) bool {
 		strings.Contains(agent.StartCommand, "convoy control --serve")
 }
 
+// PreferredDeterministicControlDispatcher returns the deterministic control-
+// dispatcher to route a scope's control beads to, binding-agnostic. The
+// city-level singleton (Dir == "") is preferred for every scope — given
+// max_active_sessions=1, it is the one whose session actually runs and claims
+// the control queue — and a rig-scoped instance (Dir == rigContext) is used only
+// when no city-level deterministic dispatcher is configured. Routing to a
+// rig-scoped copy when a city singleton exists strands the control bead, since
+// the singleton session never claims a <rig>/... route. This is the canonical
+// selection shared by the graph.v2 decoration path (internal/graphroute) and the
+// attempt-time control re-route path (internal/dispatch); keep them in lockstep.
+func PreferredDeterministicControlDispatcher(cfg *City, rigContext string) (Agent, bool) {
+	if cfg == nil {
+		return Agent{}, false
+	}
+	rigContext = strings.TrimSpace(rigContext)
+	var rigScoped Agent
+	haveRigScoped := false
+	for _, a := range cfg.Agents {
+		if !IsDeterministicControlDispatcher(&a) {
+			continue
+		}
+		if strings.TrimSpace(a.Dir) == "" {
+			return a, true
+		}
+		if !haveRigScoped && strings.TrimSpace(a.Dir) == rigContext {
+			rigScoped = a
+			haveRigScoped = true
+		}
+	}
+	if haveRigScoped {
+		return rigScoped, true
+	}
+	return Agent{}, false
+}
+
 // BindingQualifiedName returns the binding-qualified agent identity without a
 // rig prefix. Examples: "polecat", "gastown.polecat", or "gastown.mayor".
 func (a *Agent) BindingQualifiedName() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7704,6 +7704,84 @@ printf 'TRACE=%%s\nARGS=%%s\n' "$GC_WORKFLOW_TRACE" "$*" > %q
 	return tracePath, args
 }
 
+// TestPreferredDeterministicControlDispatcher locks the singleton-first
+// selection both graphroute and dispatch route control beads with. The city-
+// level singleton (Dir == "") must win for every scope; a rig-scoped instance is
+// used only when no city-level deterministic dispatcher exists. Non-deterministic
+// control-dispatcher agents (no convoy-control StartCommand) are ignored.
+func TestPreferredDeterministicControlDispatcher(t *testing.T) {
+	deterministic := func(dir string) Agent {
+		return Agent{
+			Name:         ControlDispatcherAgentName,
+			BindingName:  "core",
+			Dir:          dir,
+			StartCommand: ControlDispatcherStartCommandFor("{{.Agent}}"),
+		}
+	}
+
+	citySingleton := deterministic("")
+	rigCopy := deterministic("fixture")
+	plain := Agent{Name: ControlDispatcherAgentName, Dir: "fixture"} // no StartCommand
+
+	tests := []struct {
+		name       string
+		agents     []Agent
+		rigContext string
+		wantQN     string
+		wantOK     bool
+	}{
+		{
+			name:       "singleton preferred over rig copy for rig scope",
+			agents:     []Agent{rigCopy, citySingleton},
+			rigContext: "fixture",
+			wantQN:     "core.control-dispatcher",
+			wantOK:     true,
+		},
+		{
+			name:       "singleton preferred for empty scope",
+			agents:     []Agent{rigCopy, citySingleton},
+			rigContext: "",
+			wantQN:     "core.control-dispatcher",
+			wantOK:     true,
+		},
+		{
+			name:       "rig-scoped fallback when no singleton",
+			agents:     []Agent{rigCopy},
+			rigContext: "fixture",
+			wantQN:     "fixture/core.control-dispatcher",
+			wantOK:     true,
+		},
+		{
+			name:       "no match when only a non-deterministic dispatcher exists",
+			agents:     []Agent{plain},
+			rigContext: "fixture",
+			wantOK:     false,
+		},
+		{
+			name:       "no match when rig scope has no matching rig-scoped dispatcher",
+			agents:     []Agent{rigCopy},
+			rigContext: "other",
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := PreferredDeterministicControlDispatcher(&City{Agents: tt.agents}, tt.rigContext)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got.QualifiedName() != tt.wantQN {
+				t.Fatalf("QualifiedName = %q, want %q", got.QualifiedName(), tt.wantQN)
+			}
+		})
+	}
+
+	if _, ok := PreferredDeterministicControlDispatcher(nil, ""); ok {
+		t.Fatal("nil cfg should return ok=false")
+	}
+}
+
 // TestAllPackDirs covers (*City).AllPackDirs() — the union of PackDirs and
 // RigPackDirs that the prompt renderer relies on. Regression: rig-imported
 // pack template fragments were silently dropped before gascity#2676.

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -1037,16 +1037,16 @@ func controlDispatcherTargetForExecutionTarget(executionTarget, rigContext strin
 			rigContext = executionTarget[:slash]
 		}
 	}
-	if cfg != nil {
-		for _, agentCfg := range cfg.Agents {
-			if !config.IsDeterministicControlDispatcher(&agentCfg) {
-				continue
-			}
-			if strings.TrimSpace(agentCfg.Dir) == rigContext {
-				return agentCfg.QualifiedName()
-			}
-		}
+	// Prefer the city-level singleton deterministic dispatcher for every scope
+	// (the one whose session actually runs given max_active_sessions=1), falling
+	// back to a rig-scoped instance only when no city-level dispatcher exists.
+	// This keeps attempt-time control re-routing in lockstep with the graph.v2
+	// decoration path; without it an attempt-kind control bead would re-stamp a
+	// <rig>/control-dispatcher route the lone singleton session never claims.
+	if agentCfg, ok := config.PreferredDeterministicControlDispatcher(cfg, rigContext); ok {
+		return agentCfg.QualifiedName()
 	}
+	// String fallbacks for configs with no deterministic dispatcher at all.
 	if rigContext != "" {
 		return rigContext + "/" + config.ControlDispatcherAgentName
 	}

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -1127,7 +1127,14 @@ func TestApplyAttemptControlStepRoute_UsesExecutionRigContextForDirectSessionTar
 	}
 }
 
-func TestApplyAttemptControlStepRoute_ImportQualifiedControlDispatcherUsesScope(t *testing.T) {
+// TestApplyAttemptControlStepRoute_PrefersCitySingletonOverRigScoped covers the
+// attempt-time analog of the graph.v2 decoration fix: with a bound city-level
+// singleton (core.control-dispatcher, Dir="", max_active_sessions=1) plus a
+// per-rig copy (fixture/core.control-dispatcher), an attempt-kind control bead
+// whose execution target lives in the rig must still route to the city singleton
+// — the session that actually runs — not the rig-scoped copy that no session
+// claims (which would re-strand the control bead at attempt time).
+func TestApplyAttemptControlStepRoute_PrefersCitySingletonOverRigScoped(t *testing.T) {
 	t.Parallel()
 
 	maxActive := 1
@@ -1167,8 +1174,8 @@ func TestApplyAttemptControlStepRoute_ImportQualifiedControlDispatcherUsesScope(
 	if step.Assignee != "" {
 		t.Fatalf("assignee = %q, want empty routed control-dispatcher queue", step.Assignee)
 	}
-	if got := step.Metadata["gc.routed_to"]; got != "fixture/core.control-dispatcher" {
-		t.Fatalf("gc.routed_to = %q, want fixture/core.control-dispatcher", got)
+	if got := step.Metadata["gc.routed_to"]; got != "core.control-dispatcher" {
+		t.Fatalf("gc.routed_to = %q, want city-level singleton core.control-dispatcher", got)
 	}
 	if got := step.Metadata["gc.execution_routed_to"]; got != "fixture/superpowers.brainstorming" {
 		t.Fatalf("gc.execution_routed_to = %q, want fixture/superpowers.brainstorming", got)

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -326,25 +326,50 @@ func resolveControlDispatcherBinding(_ beads.Store, _ string, cfg *config.City, 
 	if deps.Resolver == nil {
 		return GraphRouteBinding{}, fmt.Errorf("ResolveAgent not configured")
 	}
-	agentCfg, ok := deps.Resolver.ResolveAgent(cfg, config.ControlDispatcherAgentName, rigContext)
-	if !ok {
-		agentCfg, ok = configuredControlDispatcherForScope(cfg, rigContext)
+	// Primary lookup: find the deterministic control-dispatcher directly, by
+	// behavior (IsDeterministicControlDispatcher) rather than bare-name string
+	// match. Since 9fa6b7fec the dispatcher ships bound (core.control-dispatcher),
+	// so AgentMatchesIdentity rejects the bare-name fallback for it and the
+	// per-rig fleet makes the bare-name scan ambiguous — both break a
+	// Resolver-based lookup. Preferring the city-level singleton (Dir == "")
+	// across every scope also keeps the stamped route on the one session that
+	// actually runs (max_active_sessions=1), curing the stranded-control-bead.
+	if agentCfg, ok := configuredControlDispatcherForScope(cfg, rigContext); ok {
+		return GraphRouteBinding{QualifiedName: agentCfg.QualifiedName(), MetadataOnly: true}, nil
 	}
+	// Fallback for configs without a deterministic dispatcher (e.g. a plain
+	// control-dispatcher agent carrying no convoy-control StartCommand): defer
+	// to the name-based resolver path, preserving the rig-context preference.
+	agentCfg, ok := deps.Resolver.ResolveAgent(cfg, config.ControlDispatcherAgentName, rigContext)
 	if !ok {
 		return GraphRouteBinding{}, fmt.Errorf("control-dispatcher agent %q not found", config.ControlDispatcherAgentName)
 	}
 	return GraphRouteBinding{QualifiedName: agentCfg.QualifiedName(), MetadataOnly: true}, nil
 }
 
+// configuredControlDispatcherForScope returns the deterministic control-
+// dispatcher for a scope, binding-agnostic. The city-level singleton (Dir == "")
+// is preferred for every scope — it is the one whose session actually runs given
+// max_active_sessions=1 — and a rig-scoped instance (Dir == rigContext) is used
+// only when no city-level deterministic dispatcher is configured.
 func configuredControlDispatcherForScope(cfg *config.City, rigContext string) (config.Agent, bool) {
 	rigContext = strings.TrimSpace(rigContext)
+	var rigScoped config.Agent
+	haveRigScoped := false
 	for _, a := range cfg.Agents {
 		if !config.IsDeterministicControlDispatcher(&a) {
 			continue
 		}
-		if strings.TrimSpace(a.Dir) == rigContext {
+		if strings.TrimSpace(a.Dir) == "" {
 			return a, true
 		}
+		if !haveRigScoped && strings.TrimSpace(a.Dir) == rigContext {
+			rigScoped = a
+			haveRigScoped = true
+		}
+	}
+	if haveRigScoped {
+		return rigScoped, true
 	}
 	return config.Agent{}, false
 }

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -331,10 +331,11 @@ func resolveControlDispatcherBinding(_ beads.Store, _ string, cfg *config.City, 
 	// match. Since 9fa6b7fec the dispatcher ships bound (core.control-dispatcher),
 	// so AgentMatchesIdentity rejects the bare-name fallback for it and the
 	// per-rig fleet makes the bare-name scan ambiguous — both break a
-	// Resolver-based lookup. Preferring the city-level singleton (Dir == "")
-	// across every scope also keeps the stamped route on the one session that
-	// actually runs (max_active_sessions=1), curing the stranded-control-bead.
-	if agentCfg, ok := configuredControlDispatcherForScope(cfg, rigContext); ok {
+	// Resolver-based lookup. PreferredDeterministicControlDispatcher prefers the
+	// city-level singleton (Dir == "") across every scope, keeping the stamped
+	// route on the one session that actually runs (max_active_sessions=1) and
+	// curing the stranded-control-bead.
+	if agentCfg, ok := config.PreferredDeterministicControlDispatcher(cfg, rigContext); ok {
 		return GraphRouteBinding{QualifiedName: agentCfg.QualifiedName(), MetadataOnly: true}, nil
 	}
 	// Fallback for configs without a deterministic dispatcher (e.g. a plain
@@ -345,33 +346,6 @@ func resolveControlDispatcherBinding(_ beads.Store, _ string, cfg *config.City, 
 		return GraphRouteBinding{}, fmt.Errorf("control-dispatcher agent %q not found", config.ControlDispatcherAgentName)
 	}
 	return GraphRouteBinding{QualifiedName: agentCfg.QualifiedName(), MetadataOnly: true}, nil
-}
-
-// configuredControlDispatcherForScope returns the deterministic control-
-// dispatcher for a scope, binding-agnostic. The city-level singleton (Dir == "")
-// is preferred for every scope — it is the one whose session actually runs given
-// max_active_sessions=1 — and a rig-scoped instance (Dir == rigContext) is used
-// only when no city-level deterministic dispatcher is configured.
-func configuredControlDispatcherForScope(cfg *config.City, rigContext string) (config.Agent, bool) {
-	rigContext = strings.TrimSpace(rigContext)
-	var rigScoped config.Agent
-	haveRigScoped := false
-	for _, a := range cfg.Agents {
-		if !config.IsDeterministicControlDispatcher(&a) {
-			continue
-		}
-		if strings.TrimSpace(a.Dir) == "" {
-			return a, true
-		}
-		if !haveRigScoped && strings.TrimSpace(a.Dir) == rigContext {
-			rigScoped = a
-			haveRigScoped = true
-		}
-	}
-	if haveRigScoped {
-		return rigScoped, true
-	}
-	return config.Agent{}, false
 }
 
 // ResolveGraphStepBinding resolves the routing binding for a graph step

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -727,7 +727,15 @@ func TestControlDispatcherBinding_ConfiguredDispatcherUsesCanonicalQueue(t *test
 	}
 }
 
-func TestControlDispatcherBinding_ConfiguredImportQualifiedDispatcherUsesScope(t *testing.T) {
+// TestControlDispatcherBinding_PrefersCitySingletonOverRigScoped covers the
+// production shape after 9fa6b7fec: a bound city-level singleton
+// (core.control-dispatcher, Dir="", max_active_sessions=1) plus a per-rig
+// materialized copy (fixture/core.control-dispatcher). For every scope the
+// binding must resolve to the city-level singleton — the one whose session
+// actually runs — not the rig-scoped copy (which would strand the control bead).
+// The resolver returns no match, exercising the binding-agnostic deterministic
+// lookup directly.
+func TestControlDispatcherBinding_PrefersCitySingletonOverRigScoped(t *testing.T) {
 	maxActive := 1
 	cfg := &config.City{Agents: []config.Agent{
 		{
@@ -745,15 +753,82 @@ func TestControlDispatcherBinding_ConfiguredImportQualifiedDispatcherUsesScope(t
 		},
 	}}
 
+	for _, rigContext := range []string{"", "fixture"} {
+		t.Run("rigContext="+rigContext, func(t *testing.T) {
+			binding, err := ControlDispatcherBinding(nil, "test-city", cfg, rigContext, Deps{Resolver: noMatchAgentResolver{}})
+			if err != nil {
+				t.Fatalf("ControlDispatcherBinding: %v", err)
+			}
+			if binding.QualifiedName != "core.control-dispatcher" {
+				t.Fatalf("QualifiedName = %q, want city-level singleton core.control-dispatcher", binding.QualifiedName)
+			}
+			if binding.SessionName != "" {
+				t.Fatalf("SessionName = %q, want empty for routed control-dispatcher queue", binding.SessionName)
+			}
+			if !binding.MetadataOnly {
+				t.Fatalf("MetadataOnly = false, want true")
+			}
+		})
+	}
+}
+
+// TestControlDispatcherBinding_CityOnlyBoundDispatcher covers a city with only
+// the bound city-level singleton (no per-rig copies). It must resolve for both
+// the empty and a non-empty rig context, and must NOT depend on bare-name
+// matching: AgentMatchesIdentity rejects the bare "control-dispatcher" for a
+// bound agent, so a resolver that only does qualified-name matching returns no
+// match — the binding-agnostic deterministic lookup must still succeed.
+func TestControlDispatcherBinding_CityOnlyBoundDispatcher(t *testing.T) {
+	maxActive := 1
+	dispatcher := config.Agent{
+		Name:              config.ControlDispatcherAgentName,
+		BindingName:       "core",
+		StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+		MaxActiveSessions: &maxActive,
+	}
+	cfg := &config.City{Agents: []config.Agent{dispatcher}}
+
+	// Regression guard: the bound agent is NOT addressable by the bare name the
+	// old Resolver path used, so resolution must not rely on it.
+	if config.AgentMatchesIdentity(&dispatcher, config.ControlDispatcherAgentName) {
+		t.Fatalf("precondition: bound core.control-dispatcher should NOT match bare %q", config.ControlDispatcherAgentName)
+	}
+
+	for _, rigContext := range []string{"", "fixture"} {
+		t.Run("rigContext="+rigContext, func(t *testing.T) {
+			binding, err := ControlDispatcherBinding(nil, "test-city", cfg, rigContext, Deps{Resolver: noMatchAgentResolver{}})
+			if err != nil {
+				t.Fatalf("ControlDispatcherBinding: %v", err)
+			}
+			if binding.QualifiedName != "core.control-dispatcher" {
+				t.Fatalf("QualifiedName = %q, want core.control-dispatcher", binding.QualifiedName)
+			}
+			if !binding.MetadataOnly {
+				t.Fatalf("MetadataOnly = false, want true")
+			}
+		})
+	}
+}
+
+// TestControlDispatcherBinding_RigScopedDeterministicFallback covers a city with
+// ONLY a rig-scoped deterministic dispatcher (no city-level singleton). The
+// rig-scoped instance is used as the fallback when its Dir matches the scope.
+func TestControlDispatcherBinding_RigScopedDeterministicFallback(t *testing.T) {
+	maxActive := 1
+	cfg := &config.City{Agents: []config.Agent{{
+		Name:              config.ControlDispatcherAgentName,
+		BindingName:       "core",
+		Dir:               "fixture",
+		StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+		MaxActiveSessions: &maxActive,
+	}}}
+
 	binding, err := ControlDispatcherBinding(nil, "test-city", cfg, "fixture", Deps{Resolver: noMatchAgentResolver{}})
 	if err != nil {
 		t.Fatalf("ControlDispatcherBinding: %v", err)
 	}
 	if binding.QualifiedName != "fixture/core.control-dispatcher" {
 		t.Fatalf("QualifiedName = %q, want fixture/core.control-dispatcher", binding.QualifiedName)
-	}
-	if binding.SessionName != "" {
-		t.Fatalf("SessionName = %q, want empty for routed control-dispatcher queue", binding.SessionName)
 	}
 	if !binding.MetadataOnly {
 		t.Fatalf("MetadataOnly = false, want true")


### PR DESCRIPTION
### Problem

After `9fa6b7fec` the control-dispatcher is a bound core-pack agent (`core.control-dispatcher`). Bare-name resolution in `graphroute.ControlDispatcherBinding` no longer matches it, and where the `Dir==rigContext` scope fallback resolves it returns a **rig-scoped** dispatcher whose qualified name is stamped onto control beads — but only the city-level singleton session runs and never claims `<rig>/core.control-dispatcher` routes. So v2-formula cooks either error `control-dispatcher agent "control-dispatcher" not found`, or succeed but strand their control beads (dispatcher active-but-idle). Full root cause: #3764.

### Fix (as implemented)

- New `config.PreferredDeterministicControlDispatcher(cfg, rigContext)` — selects the dispatcher **binding-agnostically** via `IsDeterministicControlDispatcher` (not the bare-name match the bound `core.control-dispatcher` defeats) and **prefers the city-level singleton** (`Dir==""`, the session that actually runs given `max_active_sessions=1`), falling back to a rig-scoped instance only when no city-level deterministic dispatcher exists.
- Both route-stamping paths delegate to the helper: `graphroute.ControlDispatcherBinding` (instantiation) **and** `internal/dispatch/control.go` `controlDispatcherTargetForExecutionTarget` (the attempt-time path: Check/Retry/Fanout/ScopeCheck/WorkflowFinalize/Ralph). This cures **both** the "not found" instantiation failure and the stranded-control-bead — both paths now stamp the singleton `core.control-dispatcher` route the running session claims. String fallbacks preserved for configs with no deterministic dispatcher.
- The maintainer call (singleton vs per-rig lanes) resolves to **singleton**, matching the shipped pack's `max_active_sessions = 1`; the draft's claim-query-completeness item was not needed.

### Test plan

- `TestPreferredDeterministicControlDispatcher` (table-driven, 5 cases); graphroute binding tests (city-singleton-preference / city-only-bound / rig-scoped fallback, `rigContext=""` and non-empty, asserting the singleton qualified name + a regression guard that `AgentMatchesIdentity` rejects the bare name for the bound agent); attempt-time integration test asserting `gc.routed_to == "core.control-dispatcher"` (was the strand); 2 updated convoy-dispatch tests.
- Verified: `make build` PASS; `go test ./internal/config/... ./internal/graphroute/... ./internal/dispatch/...` PASS; full `cmd/gc` suite PASS; gofmt / `go vet` / `golangci-lint fmt` clean.

### Notes

Separate follow-up: migrate `mol-focus-review` off removed `vars.issue` / `steps[].description: issue` (#2941).

Closes #3764.
