### PR TITLE
fix(reconciler): wake idle asleep on_demand named session with routed demand (#3413)

### DIFF
--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -453,10 +453,22 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// in_progress ownership or open work with Ready=true; blocked open
 		// assignments do not prevent idle sleep. Manual sessions within their
 		// grace period are also exempt.
+		//
+		// On_demand named sessions woken by routed/named demand
+		// ("named-demand", "work-query") are also exempt: that demand means
+		// there is pending work for this specific session, so an idle window
+		// must not put it back to sleep. Without this, an asleep on_demand
+		// named session (e.g. a refinery) with routed work that already exists
+		// (open_count==desired_count==1) is re-slept every tick and the work
+		// is wedged forever — the reconciler reports reason_code=retained
+		// indefinitely. A fresh cold-create wakes only because it has no
+		// idle reference. The "work done, no demand" drain still fires via the
+		// "on-demand:running" reason, which is NOT exempt. See #3413.
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
 			!isAlwaysNamedSession(input.NamedSessions, bead) &&
 			desired[name] != "assigned-work" && desired[name] != "min-active" &&
 			desired[name] != "reset-pending" &&
+			desired[name] != "named-demand" && desired[name] != "work-query" &&
 			!inManualGracePeriod(bead, input.ManualGracePeriod, input.Now) {
 			agent, hasAgent := lookupAgent(bead.Template)
 			var idleTimeout time.Duration

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -424,6 +424,44 @@ func TestNamedOnDemand_NamedSessionDemandWakesSingletonTemplateResolvedIdentity(
 	assertReason(t, result, "primary", "named-demand")
 }
 
+// TestNamedOnDemand_NamedSessionDemandWakesIdleAsleepSession is the #3413
+// regression: an asleep on_demand named session (sleep_reason=idle) with
+// routed/assigned demand must wake even when it has been idle past its
+// timeout. Before the fix, the idle-sleep suppression below only exempted
+// "assigned-work"/"min-active"/"reset-pending", so a session woken by
+// "named-demand" that was idle got re-slept every tick — leaving the work
+// wedged forever (reconciler emits reason_code=retained indefinitely).
+// Being idle while routed work is pending is the stuck state, not a drain
+// trigger.
+func TestNamedOnDemand_NamedSessionDemandWakesIdleAsleepSession(t *testing.T) {
+	idleSince := now.Add(-(defaultOnDemandIdleTimeout + time.Minute))
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:             []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions:      []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
+		SessionBeads:       []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", SleepReason: "idle", NamedIdentity: "hello-world/refinery", IdleSince: idleSince}},
+		NamedSessionDemand: map[string]bool{"hello-world/refinery": true},
+		Now:                now,
+	})
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "named-demand")
+}
+
+// TestNamedOnDemand_WorkQueryWakesIdleAsleepSession is the work-query variant
+// of #3413: a named session whose backing template's work-query found pending
+// work (NamedSessionWorkQ) must also wake despite being idle past timeout.
+func TestNamedOnDemand_WorkQueryWakesIdleAsleepSession(t *testing.T) {
+	idleSince := now.Add(-(defaultOnDemandIdleTimeout + time.Minute))
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:            []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions:     []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
+		SessionBeads:      []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", SleepReason: "idle", NamedIdentity: "hello-world/refinery", IdleSince: idleSince}},
+		NamedSessionWorkQ: map[string]bool{"hello-world/refinery": true},
+		Now:               now,
+	})
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "work-query")
+}
+
 func TestNamedOnDemand_PendingCreateWakesWithoutDemand(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},


### PR DESCRIPTION
## Summary

Fixes #3413 — an asleep `on_demand` named session never auto-wakes when it has routed demand. `ComputeAwakeSet`'s idle-sleep suppression exempted only assigned-work / min-active / reset-pending; an `on_demand` named session woken by named-demand/work-query, idle past its timeout, with its bead already present (`open_count == desired_count == 1`), was re-slept every tick → `reason_code=retained` forever. Cold-create only works because a fresh bead has zero `IdleSince`.

## Fix

Exempt named-demand / work-query from idle-sleep suppression. The `on-demand:running` drain path is unchanged. Isolated pure-function change in `cmd/gc/compute_awake_set.go` (+12).

## Test plan

- 2 new RED→GREEN regression tests in `cmd/gc/compute_awake_set_test.go` (+38): they **fail** without the fix (reproducing #3413's idle-sleep stuck state) and **pass** with it.
- `make build`, gofmt, `go vet ./...`, `golangci-lint` (cmd/gc, 0 issues), `go test ./cmd/gc` full suite (324s) — all pass.

Closes #3413.
