### PR TITLE
fix(controller): reap abandoned order molecule subtrees via watchdog (#3407)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -84,6 +84,7 @@ type CityRuntime struct {
 	trace                   *sessionReconcilerTraceManager
 
 	orderSweepWatchdogLast             time.Time
+	orderWispSweepWatchdogLast         time.Time
 	orderTrackingRetentionWatchdogLast time.Time
 	nudgeMailSweepWatchdogLast         time.Time
 	wispIndexMigrationApplied          bool
@@ -1281,6 +1282,7 @@ func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) {
 	}
 	cr.rescanOrderDispatcherIfDue(ctx, cityRoot, now)
 	cr.runOrderTrackingSweepWatchdog(now)
+	cr.runOrderWispSubtreeSweepWatchdog(now)
 	cr.runOrderTrackingRetentionWatchdog(now)
 	cr.runNudgeMailSweepWatchdog(now)
 	if cr.od != nil {
@@ -1423,6 +1425,77 @@ func (cr *CityRuntime) runOrderTrackingSweepWatchdog(now time.Time) {
 	if n > 0 && cr.stderr != nil {
 		fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog closed %d stale tracking bead(s)\n", cr.logPrefix, n) //nolint:errcheck // best-effort stderr
 	}
+}
+
+// runOrderWispSubtreeSweepWatchdog reaps abandoned order molecule/wisp subtrees
+// whose open descendants have been stale beyond
+// orderWispSubtreeSweepWatchdogStaleAfter. Without it a formula/pool order whose
+// instantiated molecule was left with an open descendant (e.g. the pool agent
+// never executed the step) wedges permanently: the single-flight guard counts
+// the open root as in-flight and skips every dispatch, while
+// runOrderTrackingSweepWatchdog is blind to molecule roots — they carry
+// order-run: but never order-tracking, so they fall outside its label filter.
+// Recovery previously required a manual
+// `gc order sweep-tracking <order> --include-wisps` (#3407).
+//
+// The reaper requires a non-empty order-name set — a deliberate safety gate
+// against closing genuine pool work — so the watchdog passes every configured
+// order's ScopedName. That set, combined with the generous stale-after and the
+// reaper's own whole-subtree age check, keeps in-flight pool work safe while
+// still self-clearing abandoned subtrees.
+func (cr *CityRuntime) runOrderWispSubtreeSweepWatchdog(now time.Time) {
+	if !cr.orderWispSweepWatchdogLast.IsZero() && now.Sub(cr.orderWispSweepWatchdogLast) < orderWispSubtreeSweepWatchdogInterval {
+		return
+	}
+	cr.orderWispSweepWatchdogLast = now
+
+	onlyOrders := scopedOrderNameSet(cr.orderSet)
+	if len(onlyOrders) == 0 {
+		// No configured orders to scope the reaper to; the order-name safety
+		// gate is unsatisfiable, so there is nothing to sweep.
+		return
+	}
+
+	stores, _, closeOpened, storeErr := cr.orderTrackingSweepStores()
+	defer closeOpened()
+	if len(stores) == 0 {
+		if storeErr != nil && cr.stderr != nil {
+			fmt.Fprintf(cr.stderr, "%s: order wisp subtree sweep watchdog: %v\n", cr.logPrefix, storeErr) //nolint:errcheck // best-effort stderr
+		}
+		return
+	}
+
+	result, sweepErr := sweepStaleOrderTrackingAcrossStoresLimit(stores, now, orderWispSubtreeSweepWatchdogStaleAfter, onlyOrders, orderTrackingWatchdogMetadataInitiator, true, orderTrackingSweepCloseBudget)
+	if err := errors.Join(storeErr, sweepErr); err != nil {
+		if cr.stderr != nil {
+			fmt.Fprintf(cr.stderr, "%s: order wisp subtree sweep watchdog: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
+		}
+	}
+	if result.wispClosed > 0 && cr.stderr != nil {
+		fmt.Fprintf(cr.stderr, "%s: order wisp subtree sweep watchdog closed %d abandoned order subtree bead(s)\n", cr.logPrefix, result.wispClosed) //nolint:errcheck // best-effort stderr
+	}
+}
+
+// scopedOrderNameSet returns the set of ScopedName keys for the configured
+// orders, the form used in order-run:<name> labels. It is the all-orders filter
+// the wisp-subtree reaper requires (its include-wisps path rejects an empty
+// order set). Returns nil when no orders are configured.
+func scopedOrderNameSet(orderSet []orders.Order) map[string]struct{} {
+	if len(orderSet) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(orderSet))
+	for i := range orderSet {
+		name := orderSet[i].ScopedName()
+		if name == "" {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // runOrderTrackingRetentionWatchdog deletes closed order-tracking beads that

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1633,6 +1633,129 @@ func TestOrderTrackingSweepWatchdogClosesAllStaleTracking(t *testing.T) {
 	}
 }
 
+// newWispWatchdogRuntime builds a minimal CityRuntime backed by store with the
+// given configured orders, matching the harness used by the tracking-sweep
+// watchdog tests.
+func newWispWatchdogRuntime(store beads.Store, orderSet []orders.Order) *CityRuntime {
+	return &CityRuntime{
+		cityName:            "test-city",
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		standaloneCityStore: store,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+		logPrefix:           "gc test",
+		orderSet:            orderSet,
+	}
+}
+
+// abandonedMoleculeSubtree creates a formula-order molecule root (carrying
+// order-run:<order> but never order-tracking) with a single open child step —
+// the abandoned-subtree shape from #3407 that wedges the order's single-flight
+// guard forever and is invisible to the order-tracking-label sweep.
+func abandonedMoleculeSubtree(t *testing.T, store beads.Store) (root, child beads.Bead) {
+	t.Helper()
+	const order = "mol-dog-stale-db"
+	root, err := store.Create(beads.Bead{
+		Title:  "mol-" + order,
+		Type:   "molecule",
+		Labels: []string{"order-run:" + order},
+	})
+	if err != nil {
+		t.Fatalf("Create(molecule root): %v", err)
+	}
+	child, err = store.Create(beads.Bead{
+		Title:    "abandoned-step",
+		ParentID: root.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(open child step): %v", err)
+	}
+	return root, child
+}
+
+func TestOrderWispSubtreeSweepWatchdogReapsAbandonedMoleculeSubtree(t *testing.T) {
+	store := beads.NewMemStore()
+	root, child := abandonedMoleculeSubtree(t, store)
+
+	cr := newWispWatchdogRuntime(store, []orders.Order{{Name: "mol-dog-stale-db"}})
+	cr.runOrderWispSubtreeSweepWatchdog(time.Now().Add(orderWispSubtreeSweepWatchdogStaleAfter + time.Second))
+
+	for _, id := range []string{root.ID, child.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed (abandoned subtree should be reaped)", id, got.Status)
+		}
+		if got.Metadata["close_reason"] != staleOrderWispCloseReason {
+			t.Fatalf("%s close_reason = %q, want %q", id, got.Metadata["close_reason"], staleOrderWispCloseReason)
+		}
+	}
+}
+
+func TestOrderWispSubtreeSweepWatchdogLeavesFreshSubtree(t *testing.T) {
+	store := beads.NewMemStore()
+	root, child := abandonedMoleculeSubtree(t, store)
+
+	cr := newWispWatchdogRuntime(store, []orders.Order{{Name: "mol-dog-stale-db"}})
+	// now is only one minute past creation — far inside the generous stale-after
+	// window, so a still-young (possibly genuinely in-flight) pool subtree must
+	// survive.
+	cr.runOrderWispSubtreeSweepWatchdog(root.CreatedAt.Add(time.Minute))
+
+	for _, id := range []string{root.ID, child.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status = %q, want open (fresh subtree must not be reaped)", id, got.Status)
+		}
+	}
+}
+
+func TestOrderWispSubtreeSweepWatchdogSkipsWhenIntervalNotElapsed(t *testing.T) {
+	store := beads.NewMemStore()
+	root, child := abandonedMoleculeSubtree(t, store)
+
+	cr := newWispWatchdogRuntime(store, []orders.Order{{Name: "mol-dog-stale-db"}})
+	now := time.Now().Add(orderWispSubtreeSweepWatchdogStaleAfter + time.Second)
+	cr.orderWispSweepWatchdogLast = now
+	// Second call well within the interval must early-return before sweeping.
+	cr.runOrderWispSubtreeSweepWatchdog(now.Add(orderWispSubtreeSweepWatchdogInterval / 2))
+
+	for _, id := range []string{root.ID, child.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status = %q, want open (watchdog must skip inside interval)", id, got.Status)
+		}
+	}
+}
+
+func TestOrderWispSubtreeSweepWatchdogNoConfiguredOrdersIsNoop(t *testing.T) {
+	store := beads.NewMemStore()
+	root, child := abandonedMoleculeSubtree(t, store)
+
+	cr := newWispWatchdogRuntime(store, nil)
+	// No configured orders → the reaper's order-name safety gate is unsatisfiable,
+	// so the watchdog must no-op rather than error or close anything.
+	cr.runOrderWispSubtreeSweepWatchdog(time.Now().Add(orderWispSubtreeSweepWatchdogStaleAfter + time.Second))
+
+	for _, id := range []string{root.ID, child.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status = %q, want open (no-op without configured orders)", id, got.Status)
+		}
+	}
+}
+
 func TestOrderTrackingSweepWatchdogUsesCloseBudget(t *testing.T) {
 	store := beads.NewMemStore()
 	ids := make([]string, 0, orderTrackingSweepCloseBudget+1)

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -51,6 +51,19 @@ const (
 	orderTrackingCloseVerifyAttempts       = 3
 	orderTrackingCloseVerifyRetryDelay     = 25 * time.Millisecond
 
+	// orderWispSubtreeSweepWatchdogInterval bounds how often the controller
+	// reaps abandoned order molecule/wisp subtrees. It runs far less often than
+	// the tracking-bead watchdog because the wisp reaper is more aggressive (it
+	// closes whole subtrees), so it stays conservative (#3407).
+	orderWispSubtreeSweepWatchdogInterval = 5 * time.Minute
+	// orderWispSubtreeSweepWatchdogStaleAfter is the generous staleness window
+	// before the controller reaps an abandoned order molecule subtree. It is
+	// deliberately far larger than orderTrackingSweepWatchdogStaleAfter so a
+	// genuinely in-flight pool subtree (whose step a pool agent can legitimately
+	// take many minutes to execute) is never reaped; only subtrees whose open
+	// descendants have been stale beyond this window are closed (#3407).
+	orderWispSubtreeSweepWatchdogStaleAfter = 1 * time.Hour
+
 	// orphanedOrderTrackingCloseReason is the canonical close_reason
 	// stamped on orphan-sweep closes. It satisfies bd's
 	// validation.on-close=error validator (which rejects closes without


### PR DESCRIPTION
## Summary
Order-dispatched molecule/wisp subtrees could be abandoned mid-flight (worker dies, dispatch never converges) with nothing to reclaim them — the formula/pool order then stays wedged forever behind the stranded subtree. This adds a watchdog that sweeps and reaps abandoned order molecule/wisp subtrees stale >1h, implementing suggested-fix #1 from the issue.

## Changes
- `cmd/gc/city_runtime.go` (+73): add `runOrderWispSubtreeSweepWatchdog` — a periodic sweep that finds order-rooted molecule/wisp subtrees with no live actor and last-update >1h, and reaps them.
- `cmd/gc/order_dispatch.go` (+13): wire the watchdog into the order-dispatch lifecycle.
- `cmd/gc/city_runtime_test.go` (+123): 4 watchdog tests (reaps stale abandoned subtree; leaves fresh/active subtrees; respects the >1h threshold; no-op when none abandoned).
- Additive only (+209, no deletions). No behavior change to live/fresh subtrees.

## Test plan
- [x] `go build ./...` OK
- [x] `go vet ./...` clean
- [x] 4 new watchdog tests pass
- [ ] CI green on push

Fixes #3407
