### PR TITLE
fix(sling): reopen in_progress beads on --reassign so pool handoff is claimable (#3231)

### DIFF
--- a/cmd/gc/cmd_sling_reassign_reopen_test.go
+++ b/cmd/gc/cmd_sling_reassign_reopen_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestOnFormulaReassignReopensOrderClaimedBead is the end-to-end regression for
+// gastownhall/gascity#3231, mirroring the exact failing command from the
+// issue: `gc sling <pool> <bead> --on mol-polecat-work --no-convoy --reassign`.
+//
+// An order claims the bead first (status=in_progress, assignee=order:<name>);
+// without the reopen, --reassign clears the assignee but leaves the status
+// in_progress, so the routed bead never becomes a Ready candidate and no pool
+// worker can claim it. After the fix the source bead is routed to the pool AND
+// open + unassigned, i.e. claimable.
+func TestOnFormulaReassignReopensOrderClaimedBead(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "polecat", MaxActiveSessions: intPtr(2)}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = beads.NewMemStoreFrom(1, []beads.Bead{
+		{ID: "BL-42", Title: "hotspot work", Type: "task", Status: "in_progress", Assignee: "order:mol-dog-jsonl"},
+	}, nil)
+
+	opts := testOpts(a, "BL-42")
+	opts.OnFormula = "mol-polecat-work"
+	opts.NoConvoy = true
+	opts.Reassign = true
+
+	code := doSling(opts, deps, deps.Store, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	source, err := deps.Store.Get("BL-42")
+	if err != nil {
+		t.Fatalf("store.Get(BL-42): %v", err)
+	}
+	if got := source.Metadata["gc.routed_to"]; got != "polecat" {
+		t.Errorf("gc.routed_to = %q, want polecat", got)
+	}
+	if source.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty after --reassign (order actor must not retain pool work)", source.Assignee)
+	}
+	if source.Status != "open" {
+		t.Errorf("Status = %q, want open after --reassign so the pool can claim it (#3231)", source.Status)
+	}
+}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -136,13 +136,16 @@ func preflight(opts SlingOpts, deps SlingDeps, querier BeadQuerier) (SlingResult
 		}
 	}
 
-	// Reassign: clear any existing human assignee before routing so the
-	// target pool/agent can claim the bead. Without this, beads claimed
-	// by `bd update --claim` stay invisible to the pool's claim filter
-	// even after sling sets gc.routed_to. See gastownhall/gascity#1007.
+	// Reassign: make the bead claimable by the target pool/agent before
+	// routing — clear any existing assignee and reopen it if a prior actor
+	// left it in_progress. Without this, a bead claimed by `bd update --claim`
+	// (status=in_progress, assignee=<actor>) stays invisible to the pool's
+	// claim filter even after sling sets gc.routed_to: clearing the assignee
+	// alone is not enough because IsReadyCandidate requires status=open. See
+	// gastownhall/gascity#1007 (assignee) and #3231 (status).
 	if opts.Reassign && !opts.DryRun {
-		if err := clearHumanAssignee(opts.BeadOrFormula, deps); err != nil {
-			return result, fmt.Errorf("clearing assignee for %s: %w", opts.BeadOrFormula, err)
+		if err := reopenForReassign(opts.BeadOrFormula, deps); err != nil {
+			return result, fmt.Errorf("reopening %s for reassign: %w", opts.BeadOrFormula, err)
 		}
 	}
 
@@ -1499,28 +1502,30 @@ func selectedStoreContainer(opts SlingOpts, deps SlingDeps) (beads.Bead, bool) {
 	return b, b.Type == "epic" || beads.IsContainerType(b.Type)
 }
 
-// clearHumanAssignee unsets the bead's assignee if non-empty. It checks the
-// city primary store (deps.Store) first; if the bead is not there it sweeps
-// the source-workflow stores (deps.SourceWorkflowStores) so rig-prefixed beads
-// — whose record lives in a rig store, not deps.Store — still get cleared.
-// No-op when the assignee is already empty, no store is available, or the bead
-// is absent from every store. Errors on a real primary-store read failure, a
-// store-Update failure, or a SourceWorkflowStores listing/read failure. See
-// SlingOpts.Reassign, #1007, and #3408.
-func clearHumanAssignee(beadID string, deps SlingDeps) error {
+// reopenForReassign makes a bead claimable by a target pool before routing:
+// it clears any assignee and reopens the bead if a prior actor left it
+// in_progress. It checks the city primary store (deps.Store) first; if the
+// bead is not there it sweeps the source-workflow stores
+// (deps.SourceWorkflowStores) so rig-prefixed beads — whose record lives in a
+// rig store, not deps.Store — are still reopened. No-op when the bead is
+// already open and unassigned, no store is available, or the bead is absent
+// from every store. Errors on a real primary-store read failure, a store-Update
+// failure, or a SourceWorkflowStores listing/read failure. See
+// SlingOpts.Reassign, #1007, #3408 (assignee), and #3231 (status).
+func reopenForReassign(beadID string, deps SlingDeps) error {
 	if deps.Store != nil {
 		b, err := deps.Store.Get(beadID)
 		if err == nil {
-			return clearAssigneeInStore(deps.Store, beadID, b)
+			return reopenForReassignInStore(deps.Store, beadID, b)
 		}
 		if !errors.Is(err, beads.ErrNotFound) {
-			return fmt.Errorf("reading %s from primary store to clear assignee: %w", beadID, err)
+			return fmt.Errorf("reading %s from primary store to reopen for reassign: %w", beadID, err)
 		}
 		// ErrNotFound: the record is not in the city primary store. For
 		// rig-prefixed beads it lives in a rig store, so fall through to the
 		// source-workflow sweep below.
 	}
-	// Sweep the source-workflow stores and clear the bead in whichever one
+	// Sweep the source-workflow stores and reopen the bead in whichever one
 	// holds it. Mirrors the multi-store pattern in sourceWorkflowRootByID,
 	// which likewise consults the workflow stores when deps.Store lacks (or
 	// omits) the bead.
@@ -1529,7 +1534,7 @@ func clearHumanAssignee(beadID string, deps SlingDeps) error {
 	}
 	stores, err := deps.SourceWorkflowStores()
 	if err != nil {
-		return fmt.Errorf("listing source-workflow stores to clear assignee for %s: %w", beadID, err)
+		return fmt.Errorf("listing source-workflow stores to reopen %s for reassign: %w", beadID, err)
 	}
 	for _, info := range stores {
 		if info.Store == nil {
@@ -1540,19 +1545,32 @@ func clearHumanAssignee(beadID string, deps SlingDeps) error {
 			if errors.Is(err, beads.ErrNotFound) {
 				continue
 			}
-			return fmt.Errorf("reading %s from store %q to clear assignee: %w", beadID, strings.TrimSpace(info.StoreRef), err)
+			return fmt.Errorf("reading %s from store %q to reopen for reassign: %w", beadID, strings.TrimSpace(info.StoreRef), err)
 		}
-		return clearAssigneeInStore(info.Store, beadID, b)
+		return reopenForReassignInStore(info.Store, beadID, b)
 	}
 	return nil
 }
 
-// clearAssigneeInStore unsets the assignee on b in store, returning nil when
-// the assignee is already empty so no spurious store write occurs.
-func clearAssigneeInStore(store beads.Store, beadID string, b beads.Bead) error {
-	if strings.TrimSpace(b.Assignee) == "" {
+// reopenForReassignInStore clears b's assignee and resets an in_progress
+// status back to open in a single update, returning nil without writing when
+// the bead is already open and unassigned so no spurious store write occurs.
+// The status reset is what makes a bead that an order or human previously
+// claimed (status=in_progress) claimable again — IsReadyCandidate requires
+// status=open, so clearing the assignee alone leaves it routed-but-unclaimable
+// (gastownhall/gascity#3231).
+func reopenForReassignInStore(store beads.Store, beadID string, b beads.Bead) error {
+	var update beads.UpdateOpts
+	if strings.TrimSpace(b.Assignee) != "" {
+		empty := ""
+		update.Assignee = &empty
+	}
+	if b.Status == "in_progress" {
+		open := "open"
+		update.Status = &open
+	}
+	if update.Assignee == nil && update.Status == nil {
 		return nil
 	}
-	empty := ""
-	return store.Update(beadID, beads.UpdateOpts{Assignee: &empty})
+	return store.Update(beadID, update)
 }

--- a/internal/sling/sling_reassign_reopen_test.go
+++ b/internal/sling/sling_reassign_reopen_test.go
@@ -1,0 +1,98 @@
+package sling
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// orderClaimedPoolHandoffSetup builds a sling against a worker pool for a bead
+// an order has already claimed (status=in_progress, assignee=order:<name>),
+// reproducing the gastownhall/gascity#3231 starting state. The agent is a
+// multi-session pool in a rig so the bead is routed to the pool's claim queue
+// rather than a single named session. MemStore.Create forces status=open, so
+// the in_progress/assignee state is applied via a follow-up Update.
+func orderClaimedPoolHandoffSetup(t *testing.T) (SlingOpts, SlingDeps, beads.Bead) {
+	t.Helper()
+	runner := newFakeRunner()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "myrig", Path: "/myrig", Prefix: "gc"},
+		},
+	}
+	a := config.Agent{Name: "polecat", Dir: "myrig", MaxActiveSessions: intPtr(2)}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	bead, err := deps.Store.Create(beads.Bead{Title: "hotspot work", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	inProgress, orderActor := "in_progress", "order:mol-dog-jsonl"
+	if err := deps.Store.Update(bead.ID, beads.UpdateOpts{Status: &inProgress, Assignee: &orderActor}); err != nil {
+		t.Fatalf("Update to order-claimed state: %v", err)
+	}
+	opts := SlingOpts{Target: a, BeadOrFormula: bead.ID, NoFormula: true, Reassign: true}
+	return opts, deps, bead
+}
+
+// TestDoSling_Reassign_ReopensOrderClaimedBead is the regression test for
+// gastownhall/gascity#3231. An order runs `bd update --claim` on a bead
+// (status=in_progress, assignee=order:<name>) and then slings it to a worker
+// pool with --reassign. Clearing the assignee alone is not enough: the bead
+// stays in_progress, and IsReadyCandidate (which requires status=open) filters
+// it out, so no pool worker ever claims it — "work looks in progress, but no
+// polecat actually owns it." --reassign must reopen the bead so the target
+// pool can claim it.
+func TestDoSling_Reassign_ReopensOrderClaimedBead(t *testing.T) {
+	opts, deps, bead := orderClaimedPoolHandoffSetup(t)
+	if _, err := DoSling(opts, deps, nil); err != nil {
+		t.Fatalf("DoSling --reassign: %v", err)
+	}
+	got, err := deps.Store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", bead.ID, err)
+	}
+	if got.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty after --reassign (order actor must not retain pool work)", got.Assignee)
+	}
+	if got.Status != "open" {
+		t.Errorf("Status = %q, want open after --reassign (an in_progress bead handed to a pool must be reopened so it is claimable)", got.Status)
+	}
+}
+
+// TestDoSling_Reassign_PreservesNonInProgressStatus guards the reopen from
+// over-reaching: --reassign only reopens in_progress beads. A bead in another
+// status (here, blocked) keeps its status; only the assignee is cleared.
+func TestDoSling_Reassign_PreservesNonInProgressStatus(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs:      []config.Rig{{Name: "myrig", Path: "/myrig", Prefix: "gc"}},
+	}
+	a := config.Agent{Name: "polecat", Dir: "myrig", MaxActiveSessions: intPtr(2)}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	bead, err := deps.Store.Create(beads.Bead{Title: "blocked work", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	blocked, orderActor := "blocked", "order:mol-dog-jsonl"
+	if err := deps.Store.Update(bead.ID, beads.UpdateOpts{Status: &blocked, Assignee: &orderActor}); err != nil {
+		t.Fatalf("Update to blocked state: %v", err)
+	}
+	opts := SlingOpts{Target: a, BeadOrFormula: bead.ID, NoFormula: true, Reassign: true}
+	if _, err := DoSling(opts, deps, nil); err != nil {
+		t.Fatalf("DoSling --reassign: %v", err)
+	}
+	got, err := deps.Store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", bead.ID, err)
+	}
+	if got.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty after --reassign", got.Assignee)
+	}
+	if got.Status != "blocked" {
+		t.Errorf("Status = %q, want blocked (reopen must only apply to in_progress beads)", got.Status)
+	}
+}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -3348,11 +3348,11 @@ func TestDoSling_Reassign_DryRunSkipsClear(t *testing.T) {
 	}
 }
 
-// TestClearHumanAssignee_RigStore: clearHumanAssignee clears the assignee on
+// TestReopenForReassign_RigStore: reopenForReassign clears the assignee on
 // a rig-prefixed bead whose record lives in a source-workflow (rig) store
 // rather than the city primary store. Direct unit test of the multi-store
 // fallback added for gastownhall/gascity#3408.
-func TestClearHumanAssignee_RigStore(t *testing.T) {
+func TestReopenForReassign_RigStore(t *testing.T) {
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()
 	bead, err := rigStore.Create(beads.Bead{Title: "task", Type: "task", Assignee: "human"})
@@ -3365,8 +3365,8 @@ func TestClearHumanAssignee_RigStore(t *testing.T) {
 			return []SourceWorkflowStore{{Store: rigStore, StoreRef: "rig:myrig"}}, nil
 		},
 	}
-	if err := clearHumanAssignee(bead.ID, deps); err != nil {
-		t.Fatalf("clearHumanAssignee: %v", err)
+	if err := reopenForReassign(bead.ID, deps); err != nil {
+		t.Fatalf("reopenForReassign: %v", err)
 	}
 	got, err := rigStore.Get(bead.ID)
 	if err != nil {
@@ -3377,13 +3377,13 @@ func TestClearHumanAssignee_RigStore(t *testing.T) {
 	}
 }
 
-// TestClearHumanAssignee_PrimaryStoreReadError: a non-ErrNotFound failure from
+// TestReopenForReassign_PrimaryStoreReadError: a non-ErrNotFound failure from
 // the city primary store must abort the clear with a contextual error rather
 // than falling through to the source-workflow sweep. A real read failure under
 // --force --reassign would otherwise be treated like a miss, so routing could
 // proceed with the human assignee uncleared (or a same-ID bead cleared in a
 // different store). Regression for the gastownhall/gascity#3408 review.
-func TestClearHumanAssignee_PrimaryStoreReadError(t *testing.T) {
+func TestReopenForReassign_PrimaryStoreReadError(t *testing.T) {
 	rigStore := beads.NewMemStore()
 	bead, err := rigStore.Create(beads.Bead{Title: "task", Type: "task", Assignee: "human"})
 	if err != nil {
@@ -3397,9 +3397,9 @@ func TestClearHumanAssignee_PrimaryStoreReadError(t *testing.T) {
 			return []SourceWorkflowStore{{Store: rigStore, StoreRef: "rig:myrig"}}, nil
 		},
 	}
-	err = clearHumanAssignee(bead.ID, deps)
+	err = reopenForReassign(bead.ID, deps)
 	if err == nil {
-		t.Fatal("clearHumanAssignee error = nil, want primary read failure")
+		t.Fatal("reopenForReassign error = nil, want primary read failure")
 	}
 	if !strings.Contains(err.Error(), "backend unavailable") {
 		t.Fatalf("error = %q, want wrapped primary read failure", err)
@@ -3419,12 +3419,12 @@ func TestClearHumanAssignee_PrimaryStoreReadError(t *testing.T) {
 	}
 }
 
-// TestClearHumanAssignee_SourceStoreReadError: a non-ErrNotFound failure while
+// TestReopenForReassign_SourceStoreReadError: a non-ErrNotFound failure while
 // reading a source-workflow store during the rig-store sweep aborts the clear
 // with a store-ref-qualified error instead of silently skipping the store,
 // which would leave the bead human-assigned and pool-invisible (the #3408
 // symptom) under partial store failure.
-func TestClearHumanAssignee_SourceStoreReadError(t *testing.T) {
+func TestReopenForReassign_SourceStoreReadError(t *testing.T) {
 	deps := SlingDeps{
 		Store: beads.NewMemStore(), // bead is absent here, so the sweep runs
 		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
@@ -3433,9 +3433,9 @@ func TestClearHumanAssignee_SourceStoreReadError(t *testing.T) {
 			}, nil
 		},
 	}
-	err := clearHumanAssignee("gc-123", deps)
+	err := reopenForReassign("gc-123", deps)
 	if err == nil {
-		t.Fatal("clearHumanAssignee error = nil, want source-store read failure")
+		t.Fatal("reopenForReassign error = nil, want source-store read failure")
 	}
 	if !strings.Contains(err.Error(), "rig store unreadable") {
 		t.Fatalf("error = %q, want wrapped source-store read failure", err)
@@ -3445,23 +3445,23 @@ func TestClearHumanAssignee_SourceStoreReadError(t *testing.T) {
 	}
 }
 
-// TestClearHumanAssignee_SourceStoreListError: a failure from the
+// TestReopenForReassign_SourceStoreListError: a failure from the
 // SourceWorkflowStores lister itself — the callback returning an error before
 // any store can be scanned, distinct from a per-store Get failure — aborts the
 // clear with a bead-qualified error instead of silently no-op'ing. This is the
 // fail-loud guard for the #3408 --reassign contract: if the source-workflow
 // stores cannot even be listed after a primary-store miss, routing must not
 // proceed as though the bead were absent everywhere and leave it human-assigned.
-func TestClearHumanAssignee_SourceStoreListError(t *testing.T) {
+func TestReopenForReassign_SourceStoreListError(t *testing.T) {
 	deps := SlingDeps{
 		Store: beads.NewMemStore(), // bead is absent here (ErrNotFound), so the sweep runs
 		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
 			return nil, fmt.Errorf("stores unavailable")
 		},
 	}
-	err := clearHumanAssignee("gc-456", deps)
+	err := reopenForReassign("gc-456", deps)
 	if err == nil {
-		t.Fatal("clearHumanAssignee error = nil, want source-workflow store listing failure")
+		t.Fatal("reopenForReassign error = nil, want source-workflow store listing failure")
 	}
 	if !strings.Contains(err.Error(), "listing source-workflow stores") {
 		t.Fatalf("error = %q, want wrapped source-workflow store listing failure", err)
@@ -3474,11 +3474,11 @@ func TestClearHumanAssignee_SourceStoreListError(t *testing.T) {
 	}
 }
 
-// TestClearHumanAssignee_NilPrimaryStore: with no city primary store, the clear
+// TestReopenForReassign_NilPrimaryStore: with no city primary store, the clear
 // still sweeps the source-workflow stores and clears the assignee where the
 // bead lives, matching the multi-store behavior of sourceWorkflowRootByID. A
 // nil deps.Store must not skip available rig stores.
-func TestClearHumanAssignee_NilPrimaryStore(t *testing.T) {
+func TestReopenForReassign_NilPrimaryStore(t *testing.T) {
 	rigStore := beads.NewMemStore()
 	bead, err := rigStore.Create(beads.Bead{Title: "task", Type: "task", Assignee: "human"})
 	if err != nil {
@@ -3490,8 +3490,8 @@ func TestClearHumanAssignee_NilPrimaryStore(t *testing.T) {
 			return []SourceWorkflowStore{{Store: rigStore, StoreRef: "rig:myrig"}}, nil
 		},
 	}
-	if err := clearHumanAssignee(bead.ID, deps); err != nil {
-		t.Fatalf("clearHumanAssignee: %v", err)
+	if err := reopenForReassign(bead.ID, deps); err != nil {
+		t.Fatalf("reopenForReassign: %v", err)
 	}
 	got, err := rigStore.Get(bead.ID)
 	if err != nil {
@@ -3505,7 +3505,7 @@ func TestClearHumanAssignee_NilPrimaryStore(t *testing.T) {
 // TestDoSling_Reassign_ClearsHumanAssignee_RigStore: --reassign clears a human
 // assignee on a rig-prefixed bead whose record lives in the rig store, not the
 // city primary store. Regression for gastownhall/gascity#3408 — the clear
-// previously no-op'd because clearHumanAssignee only consulted deps.Store, so
+// previously no-op'd because reopenForReassign only consulted deps.Store, so
 // the bead stayed routed+human-assigned and invisible to the pool scaler.
 func TestDoSling_Reassign_ClearsHumanAssignee_RigStore(t *testing.T) {
 	runner := newFakeRunner()


### PR DESCRIPTION
## Summary
An order claims a bead before handing it to a worker pool (`bd update --claim` → `status=in_progress`, `assignee=order:<name>`), then slings it with `--reassign`. Clearing the assignee alone left the bead `in_progress`, but `IsReadyCandidate` requires `status=open` — so the routed bead never became a Ready candidate and no pool worker could claim it. Work looked in-progress but nothing owned it.

Revived from a proven fix on a lost local branch `fix/sling-reassign-reopen-3231` @`322fcebbe` (never pushed; bug still on `origin/main`), cleanly cherry-picked onto current `origin/main`.

## Changes
- `internal/sling/sling_core.go`: extend the `--reassign` preflight to also reopen an `in_progress` bead in the same store update, so the handed-off bead ends **open + unassigned + routed-to-pool** (claimable). The reset is gated on `in_progress` only — `blocked`/`closed` statuses are left intact. Rename `clearHumanAssignee` → `reopenForReassign` to reflect the broadened, cohesive purpose. The reopen is actor-agnostic (no role names in production code).
- `internal/sling/sling_reassign_reopen_test.go` (+98), `cmd/gc/cmd_sling_reassign_reopen_test.go` (+54), `internal/sling/sling_test.go`: regression coverage for the reopen-on-reassign path.

## Test plan
- [x] `go build ./...` OK, `go vet ./...` clean
- [x] `internal/sling` + `cmd-gc-sling` reassign/reopen tests green
- [x] go-reviewer APPROVE (1 LOW rig-store coverage gap, 1 NIT; no CRIT/HIGH)
- [ ] CI green on push

Fixes #3231
