### PR TITLE
fix(molecule): preserve parked gate+finalize on subtree force-close (gc-yfn01)

### DIFF
--- a/internal/molecule/cleanup.go
+++ b/internal/molecule/cleanup.go
@@ -18,6 +18,45 @@ import (
 // incomplete.
 const SubtreeClosedReason = "molecule cleanup: subtree force-closed by CloseSubtree"
 
+// gateBeadType is the bead Type stamped on async gate beads (human gates and
+// other wait conditions; see deferBeadRouting and the formula compiler). An
+// open gate paired with an open workflow-finalize in the same subtree is a
+// parked resumption handle that CloseSubtree must not force-close.
+const gateBeadType = "gate"
+
+// isGateBead reports whether the bead is an async gate bead.
+func isGateBead(b beads.Bead) bool {
+	return b.Type == gateBeadType
+}
+
+// isWorkflowFinalizeBead reports whether the bead is a graph workflow's
+// finalize control bead.
+func isWorkflowFinalizeBead(b beads.Bead) bool {
+	return b.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflowFinalize
+}
+
+// subtreeHasParkedGate reports whether the matched subtree holds the live
+// gate→finalize park handle: at least one open gate AND at least one open
+// workflow-finalize. The finalize is what proves the park is still live; an
+// open gate without a pending finalize is an ordinary sibling and closes
+// normally, preserving the pre-existing teardown behavior for non-gate
+// molecules.
+func subtreeHasParkedGate(matched []beads.Bead) bool {
+	var openGate, openFinalize bool
+	for _, bead := range matched {
+		if bead.Status == "closed" {
+			continue
+		}
+		if isGateBead(bead) {
+			openGate = true
+		}
+		if isWorkflowFinalizeBead(bead) {
+			openFinalize = true
+		}
+	}
+	return openGate && openFinalize
+}
+
 // ListSubtree returns the root bead and all transitive parent-child
 // descendants, including already-closed beads so nested open descendants are
 // still reachable through a closed intermediate node.
@@ -127,9 +166,22 @@ func CloseSubtree(store beads.Store, rootID string) (int, error) {
 		return cmp.Compare(a.ID, b.ID)
 	})
 
+	// A parked human-gate molecule keeps an open gate bead paired with an open
+	// workflow-finalize: the gate is the resumption handle and the finalize is
+	// the gate-driven work (merge, etc.) that must run once the human releases
+	// the gate. When the dispatch/loop bead closes, the autoclose hook reaches
+	// here via sling.CloseAttachedSubtree; force-closing the gate or the
+	// finalize would destroy that handle, so the finalize could never run.
+	// Detect the pair and preserve exactly those two structural beads while
+	// still force-closing every unrelated open sibling.
+	preservePark := subtreeHasParkedGate(matched)
+
 	ids := make([]string, 0, len(matched))
 	for _, bead := range matched {
 		if bead.ID == "" || bead.Status == "closed" {
+			continue
+		}
+		if preservePark && (isGateBead(bead) || isWorkflowFinalizeBead(bead)) {
 			continue
 		}
 		ids = append(ids, bead.ID)

--- a/internal/molecule/cleanup_test.go
+++ b/internal/molecule/cleanup_test.go
@@ -293,6 +293,141 @@ func TestCloseSubtreeReturnsDepListError(t *testing.T) {
 	}
 }
 
+// TestCloseSubtreePreservesParkedGateAndFinalize models the adopt-pr
+// human-gate park: a molecule whose dispatch/loop bead has closed but whose
+// open gate (Type=gate) + open workflow-finalize form the resumption handle
+// that lets the gate-driven finalize run after the human releases the gate.
+// CloseSubtree must leave that pair open while still force-closing every
+// unrelated open sibling — otherwise the finalize is closed before it can
+// run and the park is unrecoverable.
+func TestCloseSubtreePreservesParkedGateAndFinalize(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "root", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	member := func(title, typ string, meta map[string]string) beads.Bead {
+		m := map[string]string{"gc.root_bead_id": root.ID}
+		for k, v := range meta {
+			m[k] = v
+		}
+		b, err := store.Create(beads.Bead{Title: title, Type: typ, ParentID: root.ID, Metadata: m})
+		if err != nil {
+			t.Fatalf("create %q: %v", title, err)
+		}
+		return b
+	}
+
+	sibling := member("review step", "task", nil)
+	gate := member("Gate: human", "gate", nil)
+	finalize := member("Finalize workflow", "task", map[string]string{"gc.kind": "workflow-finalize"})
+
+	closed, err := CloseSubtree(store, root.ID)
+	if err != nil {
+		t.Fatalf("CloseSubtree: %v", err)
+	}
+	// Root + sibling close; gate + finalize are preserved.
+	if closed != 2 {
+		t.Fatalf("CloseSubtree closed %d beads, want 2 (root + sibling)", closed)
+	}
+
+	for _, id := range []string{root.ID, sibling.ID} {
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if b.Status != "closed" {
+			t.Errorf("%s status = %q, want closed", id, b.Status)
+		}
+	}
+	for _, id := range []string{gate.ID, finalize.ID} {
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if b.Status == "closed" {
+			t.Errorf("%s was force-closed, want preserved (open park handle)", id)
+		}
+	}
+}
+
+// TestCloseSubtreeClosesGateWithoutOpenFinalize verifies that an open gate
+// with no open workflow-finalize in the subtree is NOT a park handle: it must
+// close like any other sibling. Only the gate+finalize pair is preserved.
+func TestCloseSubtreeClosesGateWithoutOpenFinalize(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "root", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	gate, err := store.Create(beads.Bead{
+		Title:    "Gate: human",
+		Type:     "gate",
+		ParentID: root.ID,
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	if err != nil {
+		t.Fatalf("create gate: %v", err)
+	}
+
+	closed, err := CloseSubtree(store, root.ID)
+	if err != nil {
+		t.Fatalf("CloseSubtree: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("CloseSubtree closed %d beads, want 2 (root + gate)", closed)
+	}
+	for _, id := range []string{root.ID, gate.ID} {
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if b.Status != "closed" {
+			t.Errorf("%s status = %q, want closed (no finalize → not a park)", id, b.Status)
+		}
+	}
+}
+
+// TestCloseSubtreeClosesFinalizeWithoutOpenGate verifies that a molecule with
+// NO open gate behaves exactly as before — every open bead, including an open
+// workflow-finalize, is force-closed. Guards against regressing the ordinary
+// teardown path.
+func TestCloseSubtreeClosesFinalizeWithoutOpenGate(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "root", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	finalize, err := store.Create(beads.Bead{
+		Title:    "Finalize workflow",
+		ParentID: root.ID,
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+			"gc.kind":         "workflow-finalize",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create finalize: %v", err)
+	}
+
+	closed, err := CloseSubtree(store, root.ID)
+	if err != nil {
+		t.Fatalf("CloseSubtree: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("CloseSubtree closed %d beads, want 2 (root + finalize)", closed)
+	}
+	for _, id := range []string{root.ID, finalize.ID} {
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if b.Status != "closed" {
+			t.Errorf("%s status = %q, want closed (no open gate → close as before)", id, b.Status)
+		}
+	}
+}
+
 func idsOf(bs []beads.Bead) []string {
 	out := make([]string, len(bs))
 	for i, b := range bs {


### PR DESCRIPTION
## Summary
`internal/molecule/cleanup.go`'s `CloseSubtree` force-closes the open human-gate (`Type=gate`, `Title="Gate: human"`) and finalize (`gc.kind=workflow-finalize`) beads when an adopt-pr dispatch/loop bead closes. The human-gate park pattern is therefore incompatible with subtree-cleanup-on-close: the gate-driven finalize/merge can never run because the gate + finalize beads are already CLOSED before the human closes the gate.

This preserves the park — `CloseSubtree` now skips closing **only** the open-gate + open-finalize resumption handle (an open gate bead whose subtree still has an open `workflow-finalize`), while still force-closing all unrelated siblings. The predicate keys on the gate/finalize **primitives** (`Type=gate` + `gc.kind=workflow-finalize`), with no formula or role names — ZFC-clean and forward-correct for graph.v2.

## Changes
- `internal/molecule/cleanup.go` (+52): in `CloseSubtree`, detect an open gate whose subtree has an open `workflow-finalize` and leave those two open; everything else still closes.
- `internal/molecule/cleanup_test.go` (+135): 3 regression tests — (a) gate+finalize preserved on dispatch close, (b) unrelated open siblings still force-closed, (c) molecule with no open gate behaves exactly as before (no regression).

## Scope note
This is the durable **SDK primitive** fix. It recognizes graph.v2 gate/finalize primitives; the current live `mol-adopt-pr` beads are recipe-style `Type=step` (`gc.step_ref=mol-adopt-pr.*`), so a **separate gascity-packs companion** is required to migrate `mol-adopt-pr` to emit real `Type=gate` + `workflow-finalize` primitives before the in-flight adopt-pr parks benefit. Keying this predicate off `step_ref`/formula names was deliberately rejected (zero-hardcoded-roles).

## Test plan
- [x] `go vet ./...` clean; `golangci-lint internal/molecule` 0 issues
- [x] `internal/molecule` + `internal/sling` tests green; `gofmt` clean
- [ ] CI green on push
