### PR TITLE
fix(orders): back off non-idempotent gate timeouts

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -513,6 +513,9 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		})
 		if err != nil {
 			if m.gateFailClosed(ctx, a, scoped, err) {
+				if errors.Is(err, errGateTimeout) {
+					m.rememberLastRun(scoped, storeKeysForGate, now)
+				}
 				continue
 			}
 		}
@@ -606,6 +609,9 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		})
 		if err != nil {
 			if m.gateFailClosed(ctx, a, scoped, err) {
+				if errors.Is(err, errGateTimeout) {
+					m.rememberLastRun(scoped, storeKeysForGate, now)
+				}
 				continue
 			}
 		}

--- a/cmd/gc/order_dispatch_gate_policy_test.go
+++ b/cmd/gc/order_dispatch_gate_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -128,5 +129,80 @@ func TestStoreHasOpenDescendantsSkipsTransientNotifications(t *testing.T) {
 		t.Fatal(err)
 	} else if !has {
 		t.Error("a real open work descendant must still count as open work")
+	}
+}
+
+// countingGateTimeoutStore wraps a Store and counts how many times the
+// hasOpenWorkStrict query shape (order-run: prefix, not IncludeClosed, no
+// Limit) is issued, while also introducing a configurable delay to force gate
+// timeouts in tests.
+type countingGateTimeoutStore struct {
+	beads.Store
+	delay     time.Duration
+	gateCount atomic.Int32
+}
+
+func (s *countingGateTimeoutStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if strings.HasPrefix(query.Label, "order-run:") && !query.IncludeClosed && query.Limit == 0 {
+		s.gateCount.Add(1)
+		time.Sleep(s.delay)
+	}
+	return s.Store.List(query)
+}
+
+// TestOrderDispatchNonIdempotentBackoffOnGateTimeout is the #3688 regression
+// test: when a non-idempotent order's open-work gate times out, the dispatcher
+// must apply a temporary backoff (via rememberLastRun) so the same gate is not
+// retried on the very next tick. Without the fix the order is still "due" on
+// tick 2 and the 8-second gate runs again, thrashing dolt sql-server CPU.
+func TestOrderDispatchNonIdempotentBackoffOnGateTimeout(t *testing.T) {
+	prev := orderGateTimeout
+	orderGateTimeout = 20 * time.Millisecond
+	defer func() { orderGateTimeout = prev }()
+
+	// Gate goroutine sleeps 50ms > 20ms timeout, so gateOpenWorkBounded times
+	// out and leaves the goroutine behind. The goroutine finishes ~50ms later.
+	store := &countingGateTimeoutStore{Store: beads.NewMemStore(), delay: 50 * time.Millisecond}
+	now := time.Date(2026, 6, 23, 17, 0, 0, 0, time.UTC)
+
+	aa := []orders.Order{
+		// 5-minute cooldown, non-idempotent — the reported order shape from #3688.
+		{Name: "cascade-nudge-on-blocker-close", Trigger: "cooldown", Interval: "5m", Exec: "true", Idempotent: false},
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	// cityPath must be the same for both ticks: the rememberLastRun cache key
+	// includes storeKey which is derived from cityPath, so different temp dirs
+	// would produce different keys and the backoff wouldn't transfer.
+	cityPath := t.TempDir()
+
+	// Tick 1: gate times out → order skipped (fail-closed); backoff must be applied.
+	ad.dispatch(context.Background(), cityPath, now)
+	ad.drain(context.Background())
+	if got := trackingBeads(t, store.Store, "order-run:cascade-nudge-on-blocker-close"); len(got) != 0 {
+		t.Fatalf("tick 1: non-idempotent order must be skipped on gate timeout; got %d tracking beads", len(got))
+	}
+
+	// Wait for the orphaned gate goroutine from tick 1 to finish (it sleeps
+	// 50ms; we wait 3× to be safe), then snapshot the gate-call count.
+	time.Sleep(150 * time.Millisecond)
+	countAfterTick1 := store.gateCount.Load()
+
+	// Tick 2: dispatched immediately after (well within the 5m cooldown).
+	// Without the fix the order is still "due" and the gate fires again.
+	// With the fix the backoff keeps the order out of the due-check.
+	ad.dispatch(context.Background(), cityPath, now.Add(time.Millisecond))
+	ad.drain(context.Background())
+	time.Sleep(150 * time.Millisecond) // let any tick-2 gate goroutine finish
+
+	if got := store.gateCount.Load(); got != countAfterTick1 {
+		t.Errorf("gate called again on tick 2 (backoff not applied): after tick 1 count=%d, after tick 2 count=%d; want no change",
+			countAfterTick1, got)
+	}
+	if got := trackingBeads(t, store.Store, "order-run:cascade-nudge-on-blocker-close"); len(got) != 0 {
+		t.Fatalf("tick 2: no tracking bead expected when order is backed off; got %d", len(got))
 	}
 }

--- a/release-gates/ga-5d03kz-order-gate-backoff-gate.md
+++ b/release-gates/ga-5d03kz-order-gate-backoff-gate.md
@@ -1,0 +1,45 @@
+# Release Gate: order gate-timeout backoff
+
+- Deploy bead: `ga-5d03kz`
+- Source review bead: `ga-rncogf`
+- Source issue: <https://github.com/gastownhall/gascity/issues/3688>
+- Candidate branch: `fix/ga-qnnz12-order-gate-backoff`
+- Reviewed commit: `cb4c26cf9435ee46e43dfe0bf538cd9508a06372`
+- Base checked: `origin/main` at `329d3e16c5b2e8c14449f986fdf13187211767d8`
+- Merge base: `41c54dcddc241e5f7bdea6f9475efd194bdb6e93`
+- Gate date: 2026-06-27
+
+## Manifest
+
+`docs/PROJECT_MANIFEST.md` was not present in this checkout, and `rg --files`
+found no `PROJECT_MANIFEST.md` or `SOFTWARE_FACTORY_MANIFEST.md`. This gate
+uses the deployer prompt criteria and the repo's `TESTING.md` guidance for
+test command selection.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-rncogf` is closed with close reason `pass`; notes contain `REVIEWER VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | The fix records `rememberLastRun(scoped, storeKeysForGate, now)` when `gateFailClosed` is caused by `errGateTimeout` at both open-work gate sites. `TestOrderDispatchNonIdempotentBackoffOnGateTimeout` verifies the non-idempotent order is skipped on timeout and is not immediately re-gated on the next tick. Existing idempotent timeout behavior remains covered by `TestOrderDispatchIdempotentFailsOpenOnGateTimeout`. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run TestOrderDispatchNonIdempotentBackoffOnGateTimeout -count=1` passed (`ok github.com/gastownhall/gascity/cmd/gc 0.538s`). `go build ./cmd/gc/` passed. `make test-fast-parallel` passed all 8 fast jobs. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list no blockers or HIGH findings. One non-blocking test reliability note was filed for the sleep-based goroutine drain in the regression test. Unresolved HIGH count: 0. |
+| 5 | Final branch is clean | PASS | Candidate worktree was clean before writing this gate file. The gate commit will contain only this release-gate artifact on top of the reviewed code. |
+| 6 | Branch diverges cleanly from main | PASS | After `git fetch origin main`, `git merge-tree --write-tree HEAD origin/main` exited 0 and produced tree `c057b979f15c8f75eadad41943adeef54246a35d`. The candidate is 44 commits behind `origin/main`; no deployer rebase was performed. |
+| 7 | Single feature theme | PASS | Diff scope is one subsystem: `cmd/gc/order_dispatch.go` and `cmd/gc/order_dispatch_gate_policy_test.go`. The change is limited to order-dispatch gate-timeout backoff behavior and its regression coverage. |
+
+## Diff Scope
+
+```text
+cmd/gc/order_dispatch.go
+cmd/gc/order_dispatch_gate_policy_test.go
+```
+
+## Test Commands
+
+```bash
+go test ./cmd/gc -run TestOrderDispatchNonIdempotentBackoffOnGateTimeout -count=1
+go build ./cmd/gc/
+make test-fast-parallel
+go vet ./...
+```


### PR DESCRIPTION
## What this changes

Non-idempotent orders that fail closed when their gate check times out now record that timeout as the order's last run. That makes the existing order cooldown act as backoff, so the dispatcher does not immediately re-query a slow gate on every controller tick.

Idempotent orders keep their existing fail-open behavior and dispatch normally on gate timeout.

## Review notes

- The behavior change is in `cmd/gc/order_dispatch.go` at both open-work gate paths.
- The regression coverage is in `cmd/gc/order_dispatch_gate_policy_test.go` and checks that a non-idempotent order is not re-gated immediately after a timeout.
- No config, API, schema, or migration surface changes.

## Test plan

- [x] `go test ./cmd/gc -run TestOrderDispatchNonIdempotentBackoffOnGateTimeout -count=1`
- [x] `go build ./cmd/gc/`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-5d03kz-order-gate-backoff-gate.md`](release-gates/ga-5d03kz-order-gate-backoff-gate.md)