### PR TITLE
fix(retention): archive-then-delete tail for nudge/mail + incremental jsonl archiver + bounded wisp scan (#3342)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1522,6 +1522,20 @@ func (cr *CityRuntime) runNudgeMailSweepWatchdog(now time.Time) {
 	if total > 0 && cr.stderr != nil {
 		fmt.Fprintf(cr.stderr, "%s: nudge-mail-sweep watchdog closed %d nudge bead(s), %d mail bead(s)\n", cr.logPrefix, result.NudgeClosed, result.MailClosed) //nolint:errcheck // best-effort stderr
 	}
+
+	// Archive-then-delete tail: prune closed nudge/mail beads past their
+	// delete-after-close TTL so the live issues table stops growing unbounded.
+	// Runs after the close phase; the jsonl export (5m cadence) has long since
+	// captured these rows — the delete TTLs (nudge 24h, mail 72h) dwarf that
+	// cadence — so the jsonl remains the system of record before deletion.
+	retentionPolicy := nudgeMailRetentionPolicyForConfig(cr.cfg)
+	retention, retentionErr := sweepClosedNudgeMailRetention(store, statePtr, now, retentionPolicy, nudgeMailRetentionDeleteBudget)
+	if retentionErr != nil && cr.stderr != nil {
+		fmt.Fprintf(cr.stderr, "%s: nudge-mail-sweep watchdog retention: %v\n", cr.logPrefix, retentionErr) //nolint:errcheck // best-effort stderr
+	}
+	if retention.NudgeDeleted+retention.MailDeleted > 0 && cr.stderr != nil {
+		fmt.Fprintf(cr.stderr, "%s: nudge-mail-sweep watchdog deleted %d closed nudge bead(s), %d closed mail bead(s)\n", cr.logPrefix, retention.NudgeDeleted, retention.MailDeleted) //nolint:errcheck // best-effort stderr
+	}
 }
 
 func (cr *CityRuntime) orderTrackingSweepStores() ([]beads.Store, []orderTrackingSweepTarget, func(), error) { //nolint:unparam // targets slice returned for callers that need sweep scope metadata; current call sites discard it

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -1729,15 +1729,24 @@ func newOrderSweepNudgeMailCmd(stdout, stderr io.Writer) *cobra.Command {
 	quiet := false
 	cmd := &cobra.Command{
 		Use:   "sweep-nudge-mail",
-		Short: "Close stale delivered nudge beads and read mail beads",
-		Long: `Close stale delivered nudge beads and read mail beads.
+		Short: "Close stale nudge/mail beads, then delete long-closed ones",
+		Long: `Close stale delivered nudge beads and read mail beads, then delete the
+long-closed ones so the live issues table stops growing unbounded.
 
 Nudge beads that are past --nudge-ttl and not in the live nudge queue are
 closed. Read mail beads past --mail-ttl are closed. A budget cap of ` + fmt.Sprintf("%d", nudgeMailSweepCloseBudget) + ` closes
 per invocation prevents runaway sweeps under load.
 
-Use --dry-run to log what would be closed without making any changes.
-The controller watchdog also runs this sweep automatically every 5 minutes.`,
+After closing, an archive-then-delete tail deletes closed nudge/mail beads
+older than their configured delete-after-close TTL
+([beads.policies.nudge] default 24h, [beads.policies.mail] default 72h),
+cascading their events/labels rows. Deletion is bounded to ` + fmt.Sprintf("%d", nudgeMailRetentionDeleteBudget) + ` beads per
+invocation and never touches open work, live nudges, or beads another bead
+still depends on.
+
+Use --dry-run to log what would be closed and deleted without making any
+changes. The controller watchdog also runs this sweep automatically every 5
+minutes.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if cmdOrderSweepNudgeMail(nudgeTTL, mailTTL, dryRun, quiet, stdout, stderr) != 0 {
@@ -1767,6 +1776,12 @@ func cmdOrderSweepNudgeMail(nudgeTTL, mailTTL time.Duration, dryRun, quiet bool,
 		fmt.Fprintf(stderr, "gc order sweep-nudge-mail: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	cfg, err := loadCityConfig(cityPath, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc order sweep-nudge-mail: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	retentionPolicy := nudgeMailRetentionPolicyForConfig(cfg)
 	store, err := openStoreAtForCity(cityPath, cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-nudge-mail: %v\n", err)     //nolint:errcheck // best-effort stderr
@@ -1788,62 +1803,84 @@ func cmdOrderSweepNudgeMail(nudgeTTL, mailTTL time.Duration, dryRun, quiet bool,
 
 	now := time.Now()
 	if dryRun {
-		return cmdOrderSweepNudgeMailDryRun(store, statePtr, now, nudgeTTL, mailTTL, quiet, stdout, stderr)
+		return cmdOrderSweepNudgeMailDryRun(store, statePtr, now, nudgeTTL, mailTTL, retentionPolicy, quiet, stdout, stderr)
 	}
-	return cmdOrderSweepNudgeMailRun(store, statePtr, now, nudgeTTL, mailTTL, quiet, stdout, stderr)
+	return cmdOrderSweepNudgeMailRun(store, statePtr, now, nudgeTTL, mailTTL, retentionPolicy, quiet, stdout, stderr)
 }
 
-func cmdOrderSweepNudgeMailDryRun(store beads.Store, nudgeState *nudgequeue.State, now time.Time, nudgeTTL, mailTTL time.Duration, quiet bool, stdout, stderr io.Writer) int {
+func cmdOrderSweepNudgeMailDryRun(store beads.Store, nudgeState *nudgequeue.State, now time.Time, nudgeTTL, mailTTL time.Duration, retentionPolicy nudgeMailRetentionPolicy, quiet bool, stdout, stderr io.Writer) int {
 	counts, err := countStaleNudgeMail(store, nudgeState, now, nudgeTTL, mailTTL, nudgeMailSweepCloseBudget)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-nudge-mail: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	retention, retentionErr := countClosedNudgeMailRetention(store, nudgeState, now, retentionPolicy, nudgeMailRetentionDeleteBudget)
+	if retentionErr != nil {
+		fmt.Fprintf(stderr, "gc order sweep-nudge-mail: %v\n", retentionErr) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	if quiet {
 		return 0
 	}
-	if counts.NudgeClosed == 0 && counts.MailClosed == 0 {
-		fmt.Fprintln(stdout, "nudge-mail-sweep: nothing to close (0 stale nudge beads, 0 stale mail beads)") //nolint:errcheck // best-effort stdout
+	if counts.NudgeClosed == 0 && counts.MailClosed == 0 && retention.NudgeDeleted == 0 && retention.MailDeleted == 0 {
+		fmt.Fprintln(stdout, "nudge-mail-sweep: nothing to close or delete (0 stale nudge beads, 0 stale mail beads)") //nolint:errcheck // best-effort stdout
 		return 0
 	}
-	fmt.Fprintf(stdout, "[DRY RUN] nudge-mail-sweep: would close %d nudge bead(s), %d mail bead(s)  (no changes made)\n", //nolint:errcheck
-		counts.NudgeClosed, counts.MailClosed)
+	fmt.Fprintf(stdout, "[DRY RUN] nudge-mail-sweep: would close %d nudge bead(s), %d mail bead(s); would delete %d closed nudge bead(s), %d closed mail bead(s)  (no changes made)\n", //nolint:errcheck
+		counts.NudgeClosed, counts.MailClosed, retention.NudgeDeleted, retention.MailDeleted)
 	return 0
 }
 
-func cmdOrderSweepNudgeMailRun(store beads.Store, nudgeState *nudgequeue.State, now time.Time, nudgeTTL, mailTTL time.Duration, quiet bool, stdout, stderr io.Writer) int {
-	result, sweepErr := sweepStaleNudgeMail(store, nudgeState, now, nudgeTTL, mailTTL, nudgeMailSweepCloseBudget)
-
-	if sweepErr != nil {
-		// Per-bead errors are joined via errors.Join (Unwrap() []error): print each
-		// to stderr and continue; the overall sweep is not fatal. A fatal list error
-		// is a single wrapped error that does not implement that interface: surface
-		// it and fail so an unreadable store does not silently "succeed".
-		type unwrapper interface{ Unwrap() []error }
-		if u, ok := sweepErr.(unwrapper); ok {
-			for _, e := range u.Unwrap() {
-				fmt.Fprintf(stderr, "nudge-mail-sweep: ERROR %v — skipping\n", e) //nolint:errcheck // best-effort stderr
-			}
-		} else {
-			fmt.Fprintf(stderr, "gc order sweep-nudge-mail: %v\n", sweepErr) //nolint:errcheck // best-effort stderr
-			return 1
+// reportNudgeMailSweepError prints a sweep error to stderr and reports whether
+// it was fatal. Joined per-bead errors (errors.Join exposes Unwrap() []error)
+// are non-fatal: each is logged and skipped so one bad bead does not abort the
+// sweep. Any other error means the sweep could not run at all (e.g. an
+// unreadable store) and is fatal, so the caller fails rather than silently
+// "succeeding".
+func reportNudgeMailSweepError(err error, stderr io.Writer) (fatal bool) {
+	if err == nil {
+		return false
+	}
+	if u, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, e := range u.Unwrap() {
+			fmt.Fprintf(stderr, "nudge-mail-sweep: ERROR %v — skipping\n", e) //nolint:errcheck // best-effort stderr
 		}
+		return false
+	}
+	fmt.Fprintf(stderr, "gc order sweep-nudge-mail: %v\n", err) //nolint:errcheck // best-effort stderr
+	return true
+}
+
+func cmdOrderSweepNudgeMailRun(store beads.Store, nudgeState *nudgequeue.State, now time.Time, nudgeTTL, mailTTL time.Duration, retentionPolicy nudgeMailRetentionPolicy, quiet bool, stdout, stderr io.Writer) int {
+	result, sweepErr := sweepStaleNudgeMail(store, nudgeState, now, nudgeTTL, mailTTL, nudgeMailSweepCloseBudget)
+	if reportNudgeMailSweepError(sweepErr, stderr) {
+		return 1
+	}
+
+	// Archive-then-delete tail: prune closed nudge/mail beads past their
+	// delete-after-close TTL. Runs after the close phase so the jsonl export has
+	// long since captured the rows (the delete TTLs dwarf the 5-minute export
+	// cadence), keeping the jsonl as the system of record before deletion.
+	retention, retentionErr := sweepClosedNudgeMailRetention(store, nudgeState, now, retentionPolicy, nudgeMailRetentionDeleteBudget)
+	if reportNudgeMailSweepError(retentionErr, stderr) {
+		return 1
 	}
 
 	if quiet {
 		return 0
 	}
 
-	total := result.NudgeClosed + result.MailClosed
-	if total == 0 {
-		fmt.Fprintln(stdout, "nudge-mail-sweep: nothing to close (0 stale nudge beads, 0 stale mail beads)") //nolint:errcheck // best-effort stdout
+	closed := result.NudgeClosed + result.MailClosed
+	deleted := retention.NudgeDeleted + retention.MailDeleted
+	if closed == 0 && deleted == 0 {
+		fmt.Fprintln(stdout, "nudge-mail-sweep: nothing to close or delete (0 stale nudge beads, 0 stale mail beads)") //nolint:errcheck // best-effort stdout
 		return 0
 	}
-	budgetLine := fmt.Sprintf("[budget: %d/%d used]", total, nudgeMailSweepCloseBudget)
-	if total >= nudgeMailSweepCloseBudget {
-		budgetLine = fmt.Sprintf("[budget: %d/%d — cap reached, re-run to continue]", total, nudgeMailSweepCloseBudget)
+	budgetLine := fmt.Sprintf("[budget: %d/%d used]", closed, nudgeMailSweepCloseBudget)
+	if closed >= nudgeMailSweepCloseBudget {
+		budgetLine = fmt.Sprintf("[budget: %d/%d — cap reached, re-run to continue]", closed, nudgeMailSweepCloseBudget)
 	}
-	fmt.Fprintf(stdout, "nudge-mail-sweep: closed %d nudge bead(s), %d mail bead(s)  %s\n", //nolint:errcheck // best-effort stdout
-		result.NudgeClosed, result.MailClosed, budgetLine)
+	fmt.Fprintf(stdout, "nudge-mail-sweep: closed %d nudge bead(s), %d mail bead(s); deleted %d closed nudge bead(s), %d closed mail bead(s)  %s\n", //nolint:errcheck // best-effort stdout
+		result.NudgeClosed, result.MailClosed, retention.NudgeDeleted, retention.MailDeleted, budgetLine)
 	return 0
 }

--- a/cmd/gc/nudge_mail_sweep.go
+++ b/cmd/gc/nudge_mail_sweep.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 )
 
@@ -203,6 +204,227 @@ func countStaleNudgeMail(store beads.Store, nudgeState *nudgequeue.State, now ti
 		}
 	}
 	return result, nil
+}
+
+// nudgeMailRetentionDeleteBudget caps closed nudge + mail bead deletions per
+// retention sweep invocation. It mirrors the order-tracking deletion budget
+// precedent: a bounded batch keeps each run's contention proportional while the
+// recurring sweep drains any backlog over successive ticks (report #3342 section
+// 5 gate #5).
+const nudgeMailRetentionDeleteBudget = 500
+
+// defaultNudgeDeleteAfterClose and defaultMailDeleteAfterClose are the runtime
+// fallbacks for the nudge/mail retention TTLs, derived from the canonical config
+// constants so load-time defaults and the runtime fallback stay in sync.
+var (
+	defaultNudgeDeleteAfterClose = config.BeadPolicyConfig{
+		DeleteAfterClose: config.DefaultNudgeDeleteAfterClose,
+	}.DeleteAfterCloseDuration()
+	defaultMailDeleteAfterClose = config.BeadPolicyConfig{
+		DeleteAfterClose: config.DefaultMailDeleteAfterClose,
+	}.DeleteAfterCloseDuration()
+)
+
+// nudgeMailRetentionResult holds per-category delete counts from
+// sweepClosedNudgeMailRetention.
+type nudgeMailRetentionResult struct {
+	NudgeDeleted int
+	MailDeleted  int
+}
+
+// nudgeMailRetentionPolicy holds the resolved delete-after-close TTLs for the
+// nudge and mail bead families. A non-positive duration disables deletion for
+// that family.
+type nudgeMailRetentionPolicy struct {
+	nudgeDeleteAfterClose time.Duration
+	mailDeleteAfterClose  time.Duration
+}
+
+// nudgeMailRetentionPolicyForConfig resolves delete-after-close TTLs from the
+// [beads.policies.nudge] and [beads.policies.mail] config sections. Unset or
+// non-positive durations fall back to the controller defaults (nudge 24h, mail
+// 72h) so retention is on by default, matching the order-tracking policy
+// precedent.
+func nudgeMailRetentionPolicyForConfig(cfg *config.City) nudgeMailRetentionPolicy {
+	policy := nudgeMailRetentionPolicy{
+		nudgeDeleteAfterClose: defaultNudgeDeleteAfterClose,
+		mailDeleteAfterClose:  defaultMailDeleteAfterClose,
+	}
+	if cfg == nil {
+		return policy
+	}
+	if configured, ok := cfg.Beads.Policies[config.BeadPolicyNudge]; ok {
+		if d := configured.DeleteAfterCloseDuration(); d > 0 {
+			policy.nudgeDeleteAfterClose = d
+		}
+	}
+	if configured, ok := cfg.Beads.Policies[config.BeadPolicyMail]; ok {
+		if d := configured.DeleteAfterCloseDuration(); d > 0 {
+			policy.mailDeleteAfterClose = d
+		}
+	}
+	return policy
+}
+
+// sweepClosedNudgeMailRetention deletes closed nudge and read mail beads whose
+// close time is older than the configured delete-after-close TTL. It is the
+// archive-then-delete tail that runs after the close phase (sweepStaleNudgeMail):
+// the periodic jsonl export captures every closed row on a 5-minute cadence,
+// and the delete TTLs (nudge 24h, mail 72h) dwarf that cadence, so the jsonl is
+// the system of record before any row is deleted here. Deleting a bead cascades
+// its events and labels rows at the storage layer, so the per-bead row
+// multipliers do not survive their parents.
+//
+// NDI safety gates (report #3342 section 5):
+//   - closed-only + close-time cutoff — open/in_progress work is never touched;
+//   - live-nudge protection — a nudge whose ID is still pending or in-flight is
+//     never deleted, even past its TTL, so a consumed-signal/cooldown window is
+//     respected;
+//   - ownership-edge skip — a bead another bead still depends on is left for a
+//     graph-aware reaper rather than severed here.
+//
+// limit caps total deletions (nudge + mail combined); pass 0 for no cap.
+// Per-bead errors do not abort the sweep; they are joined and returned so the
+// caller can report them without treating the sweep as fatal.
+func sweepClosedNudgeMailRetention(store beads.Store, nudgeState *nudgequeue.State, now time.Time, policy nudgeMailRetentionPolicy, limit int) (nudgeMailRetentionResult, error) {
+	return nudgeMailRetentionSweep(store, nudgeState, now, policy, limit, false)
+}
+
+// countClosedNudgeMailRetention returns what sweepClosedNudgeMailRetention would
+// delete without making any changes. Used by --dry-run to report the candidate
+// count, including the ownership-edge and live-nudge skips, without side effects.
+func countClosedNudgeMailRetention(store beads.Store, nudgeState *nudgequeue.State, now time.Time, policy nudgeMailRetentionPolicy, limit int) (nudgeMailRetentionResult, error) {
+	return nudgeMailRetentionSweep(store, nudgeState, now, policy, limit, true)
+}
+
+func nudgeMailRetentionSweep(store beads.Store, nudgeState *nudgequeue.State, now time.Time, policy nudgeMailRetentionPolicy, limit int, dryRun bool) (nudgeMailRetentionResult, error) {
+	var result nudgeMailRetentionResult
+	if store == nil {
+		return result, fmt.Errorf("nudge-mail-retention: bead store unavailable")
+	}
+	var beadErrs []error
+	liveIDs := liveNudgeIDSet(nudgeState)
+	// Read via the Live handle: close time (UpdatedAt) is a mutated timestamp, so
+	// purge callers must bypass any cache to avoid acting on stale values.
+	live := beads.HandlesFor(store).Live
+
+	// Phase 1: delete closed nudge beads past their delete TTL.
+	if policy.nudgeDeleteAfterClose > 0 {
+		cutoff := now.Add(-policy.nudgeDeleteAfterClose)
+		queryLimit := limit
+		if queryLimit < 0 {
+			queryLimit = 0
+		}
+		candidates, err := live.List(beads.ListQuery{
+			Status:        "closed",
+			Label:         nudgeBeadLabel,
+			UpdatedBefore: cutoff,
+			Limit:         queryLimit,
+			Sort:          beads.SortCreatedAsc,
+			TierMode:      beads.TierBoth,
+		})
+		if err != nil {
+			return result, fmt.Errorf("nudge-mail-retention: listing closed nudge beads: %w", err)
+		}
+		for _, b := range candidates {
+			if limit > 0 && result.NudgeDeleted+result.MailDeleted >= limit {
+				break
+			}
+			if b.Status != "closed" {
+				continue
+			}
+			nudgeID := strings.TrimSpace(b.Metadata["nudge_id"])
+			if nudgeID != "" && liveIDs[nudgeID] {
+				continue
+			}
+			deleted, err := deleteRetiredCoordinationBead(store, b.ID, dryRun)
+			if err != nil {
+				beadErrs = append(beadErrs, fmt.Errorf("nudge %s: %w", b.ID, err))
+				continue
+			}
+			if deleted {
+				result.NudgeDeleted++
+			}
+		}
+	}
+
+	// Phase 2: delete closed read mail beads past their delete TTL.
+	remaining := limit - result.NudgeDeleted - result.MailDeleted
+	if policy.mailDeleteAfterClose > 0 && (limit == 0 || remaining > 0) {
+		cutoff := now.Add(-policy.mailDeleteAfterClose)
+		queryLimit := remaining
+		if limit == 0 {
+			queryLimit = 0
+		}
+		candidates, err := live.List(beads.ListQuery{
+			Status:        "closed",
+			Type:          "message",
+			Label:         "read",
+			UpdatedBefore: cutoff,
+			Limit:         queryLimit,
+			Sort:          beads.SortCreatedAsc,
+			TierMode:      beads.TierBoth,
+		})
+		if err != nil {
+			return result, fmt.Errorf("nudge-mail-retention: listing closed mail beads: %w", err)
+		}
+		for _, b := range candidates {
+			if limit > 0 && result.NudgeDeleted+result.MailDeleted >= limit {
+				break
+			}
+			if b.Status != "closed" {
+				continue
+			}
+			deleted, err := deleteRetiredCoordinationBead(store, b.ID, dryRun)
+			if err != nil {
+				beadErrs = append(beadErrs, fmt.Errorf("mail %s: %w", b.ID, err))
+				continue
+			}
+			if deleted {
+				result.MailDeleted++
+			}
+		}
+	}
+
+	return result, errors.Join(beadErrs...)
+}
+
+// deleteRetiredCoordinationBead deletes a single closed coordination bead after
+// the NDI ownership-edge gate. A bead another bead still depends on (a non-empty
+// inbound/"up" dependency set) is left in place for a graph-aware reaper rather
+// than severed here, so deleting it can never orphan a surviving dependent.
+//
+// Beads with no inbound edge are deleted directly via store.Delete. In
+// production (BdStore → `bd delete --force` → DoltLite) that cascades the bead's
+// events, labels, comments and its own dependency rows at the storage layer —
+// the events/labels tables declare FOREIGN KEY (issue_id) ... ON DELETE CASCADE,
+// and the single-delete path additionally clears both dependency directions
+// (steveyegge/beads internal/storage/issueops/delete.go DeleteIssueInTx) — so
+// the ~2.5x events / ~3x labels row multipliers do not survive their parents.
+//
+// It returns (false, nil) — not an error — when the bead is skipped by the gate.
+// In dryRun mode it still performs the gate check so the reported count matches
+// a real sweep, but makes no deletion.
+//
+// Note: this deliberately uses an edge *skip* rather than deleteWorkflowBead's
+// edge *removal*. deleteWorkflowBead is built for workflow roots whose whole
+// ownership tree is being collected; for a stray coordination bead, severing a
+// surviving dependent's edge would violate the NDI gate, so the gate skips it.
+func deleteRetiredCoordinationBead(store beads.Store, id string, dryRun bool) (bool, error) {
+	dependents, err := store.DepList(id, "up")
+	if err != nil {
+		return false, fmt.Errorf("list dependents: %w", err)
+	}
+	if len(dependents) > 0 {
+		return false, nil
+	}
+	if dryRun {
+		return true, nil
+	}
+	if err := store.Delete(id); err != nil {
+		return false, fmt.Errorf("delete: %w", err)
+	}
+	return true, nil
 }
 
 // liveNudgeIDSet returns the set of nudge IDs currently in pending or in-flight state.

--- a/cmd/gc/nudge_mail_sweep_test.go
+++ b/cmd/gc/nudge_mail_sweep_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 )
 
@@ -453,7 +455,7 @@ func TestCmdOrderSweepNudgeMailRun_NothingToClose(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, nil, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, false, &stdout, &stderr)
 	if !strings.Contains(stdout.String(), "nothing to close") {
 		t.Errorf("expected 'nothing to close' message, got: %q", stdout.String())
 	}
@@ -468,7 +470,7 @@ func TestCmdOrderSweepNudgeMailRun_NormalOutput(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, false, &stdout, &stderr)
 	out := stdout.String()
 	if !strings.Contains(out, "nudge-mail-sweep: closed") {
 		t.Errorf("expected 'nudge-mail-sweep: closed' in output, got: %q", out)
@@ -491,7 +493,7 @@ func TestCmdOrderSweepNudgeMailRun_CapReachedMessage(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, false, &stdout, &stderr)
 	if !strings.Contains(stdout.String(), "cap reached") {
 		t.Errorf("expected 'cap reached' in output when budget is full, got: %q", stdout.String())
 	}
@@ -508,7 +510,7 @@ func TestCmdOrderSweepNudgeMailRun_PerBeadErrorPrintedToStderr(t *testing.T) {
 	store := &nudgeSweepFailingClose{MemStore: mem, failIDs: map[string]bool{failID: true}}
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, false, &stdout, &stderr)
 	if !strings.Contains(stderr.String(), "ERROR") {
 		t.Errorf("expected ERROR line on stderr for failing bead, got: %q", stderr.String())
 	}
@@ -523,7 +525,7 @@ func TestCmdOrderSweepNudgeMailRun_QuietSuppressesOutput(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, nil, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, true, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, true, &stdout, &stderr)
 	if stdout.String() != "" {
 		t.Errorf("expected empty stdout with --quiet, got: %q", stdout.String())
 	}
@@ -534,7 +536,7 @@ func TestCmdOrderSweepNudgeMailDryRun_NothingToClose(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, nil, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, false, &stdout, &stderr)
 	if !strings.Contains(stdout.String(), "nothing to close") {
 		t.Errorf("expected 'nothing to close' for empty store dry-run, got: %q", stdout.String())
 	}
@@ -549,7 +551,7 @@ func TestCmdOrderSweepNudgeMailDryRun_ShowsWouldClose(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, false, &stdout, &stderr)
 	out := stdout.String()
 	if !strings.HasPrefix(out, "[DRY RUN]") {
 		t.Errorf("expected '[DRY RUN]' prefix, got: %q", out)
@@ -571,7 +573,7 @@ func TestCmdOrderSweepNudgeMailDryRun_NoBeadsClosed(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, false, &stdout, &stderr)
 
 	// The bead should remain open.
 	open, _ := store.ListOpen()
@@ -597,7 +599,7 @@ func TestCmdOrderSweepNudgeMailDryRun_ListErrorReturnsNonZero(t *testing.T) {
 	store := &nudgeSweepFailingList{MemStore: beads.NewMemStoreFrom(100, nil, nil)}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	code := cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, false, &stdout, &stderr)
 	if code == 0 {
 		t.Errorf("expected non-zero exit code on list error, got %d", code)
 	}
@@ -617,7 +619,7 @@ func TestCmdOrderSweepNudgeMailRun_ListErrorReturnsNonZero(t *testing.T) {
 	store := &nudgeSweepFailingList{MemStore: beads.NewMemStoreFrom(100, nil, nil)}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	code := cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, nudgeMailRetentionPolicy{}, false, &stdout, &stderr)
 	if code == 0 {
 		t.Errorf("expected non-zero exit code on list error, got %d", code)
 	}
@@ -708,5 +710,395 @@ func TestCountStaleNudgeMail_MatchesSweepCounts(t *testing.T) {
 	}
 	if counts.MailClosed != 1 {
 		t.Errorf("count: MailClosed = %d, want 1", counts.MailClosed)
+	}
+}
+
+// --- gc order sweep-nudge-mail: archive-then-delete retention (#3342 Option A) ---
+
+// closedNudgeSeed builds a closed nudge bead whose close time (UpdatedAt) is
+// closedAt. CreatedAt is set slightly earlier so created-time and close-time
+// filters are distinguishable.
+func closedNudgeSeed(id, nudgeID string, closedAt time.Time) beads.Bead {
+	b := nudgeSeed(id, nudgeID, closedAt.Add(-time.Minute))
+	b.Status = "closed"
+	b.UpdatedAt = closedAt
+	return b
+}
+
+// closedMailSeed builds a closed read mail bead whose close time (UpdatedAt) is
+// closedAt.
+func closedMailSeed(id string, closedAt time.Time) beads.Bead {
+	b := mailSeed(id, closedAt.Add(-time.Minute))
+	b.Status = "closed"
+	b.UpdatedAt = closedAt
+	return b
+}
+
+func retentionBeadPresent(t *testing.T, store beads.Store, id string) bool {
+	t.Helper()
+	_, err := store.Get(id)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, beads.ErrNotFound) {
+		return false
+	}
+	t.Fatalf("unexpected error getting %s: %v", id, err)
+	return false
+}
+
+func testNudgeMailRetentionPolicy() nudgeMailRetentionPolicy {
+	return nudgeMailRetentionPolicy{
+		nudgeDeleteAfterClose: 24 * time.Hour,
+		mailDeleteAfterClose:  72 * time.Hour,
+	}
+}
+
+func TestSweepClosedNudgeMailRetention_TTLBoundaries(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	seed := []beads.Bead{
+		closedNudgeSeed("n-old", "n-old", now.Add(-policy.nudgeDeleteAfterClose-time.Second)),     // delete
+		closedNudgeSeed("n-fresh", "n-fresh", now.Add(-policy.nudgeDeleteAfterClose+time.Second)), // keep
+		closedMailSeed("m-old", now.Add(-policy.mailDeleteAfterClose-time.Second)),                // delete
+		closedMailSeed("m-fresh", now.Add(-policy.mailDeleteAfterClose+time.Second)),              // keep
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepClosedNudgeMailRetention(store, nil, now, policy, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeDeleted != 1 {
+		t.Errorf("NudgeDeleted = %d, want 1", result.NudgeDeleted)
+	}
+	if result.MailDeleted != 1 {
+		t.Errorf("MailDeleted = %d, want 1", result.MailDeleted)
+	}
+	if retentionBeadPresent(t, store, "n-old") {
+		t.Error("n-old should have been deleted")
+	}
+	if !retentionBeadPresent(t, store, "n-fresh") {
+		t.Error("n-fresh should have been kept (within TTL)")
+	}
+	if retentionBeadPresent(t, store, "m-old") {
+		t.Error("m-old should have been deleted")
+	}
+	if !retentionBeadPresent(t, store, "m-fresh") {
+		t.Error("m-fresh should have been kept (within TTL)")
+	}
+}
+
+func TestSweepClosedNudgeMailRetention_OpenWorkNeverDeleted(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	// Open + in_progress nudge/mail, all far past the delete TTL by age. The
+	// closed-only status filter must keep them: deleting open/in_progress work
+	// would lose the work queue (NDI gate "never touch open/in_progress").
+	openNudge := nudgeSeed("n-open", "n-open", now.Add(-policy.nudgeDeleteAfterClose-time.Hour))
+	openNudge.UpdatedAt = now.Add(-policy.nudgeDeleteAfterClose - time.Hour)
+	inProgressNudge := nudgeSeed("n-inprog", "n-inprog", now.Add(-policy.nudgeDeleteAfterClose-time.Hour))
+	inProgressNudge.Status = "in_progress"
+	inProgressNudge.UpdatedAt = now.Add(-policy.nudgeDeleteAfterClose - time.Hour)
+	openMail := mailSeed("m-open", now.Add(-policy.mailDeleteAfterClose-time.Hour))
+	openMail.UpdatedAt = now.Add(-policy.mailDeleteAfterClose - time.Hour)
+	inProgressMail := mailSeed("m-inprog", now.Add(-policy.mailDeleteAfterClose-time.Hour))
+	inProgressMail.Status = "in_progress"
+	inProgressMail.UpdatedAt = now.Add(-policy.mailDeleteAfterClose - time.Hour)
+	store := beads.NewMemStoreFrom(100, []beads.Bead{openNudge, inProgressNudge, openMail, inProgressMail}, nil)
+
+	result, err := sweepClosedNudgeMailRetention(store, nil, now, policy, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeDeleted != 0 || result.MailDeleted != 0 {
+		t.Errorf("deleted = %+v, want zero (open/in_progress work must never be deleted)", result)
+	}
+	for _, id := range []string{"n-open", "n-inprog", "m-open", "m-inprog"} {
+		if !retentionBeadPresent(t, store, id) {
+			t.Errorf("non-closed bead %q must not be deleted", id)
+		}
+	}
+}
+
+func TestSweepClosedNudgeMailRetention_LiveNudgeProtected(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	const liveID = "live-nudge"
+	seed := []beads.Bead{
+		closedNudgeSeed("n-live", liveID, now.Add(-policy.nudgeDeleteAfterClose-time.Hour)),
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+	state := &nudgequeue.State{Pending: []nudgequeue.Item{{ID: liveID}}}
+
+	result, err := sweepClosedNudgeMailRetention(store, state, now, policy, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeDeleted != 0 {
+		t.Errorf("NudgeDeleted = %d, want 0 (live nudge ID must be protected)", result.NudgeDeleted)
+	}
+	if !retentionBeadPresent(t, store, "n-live") {
+		t.Error("closed nudge whose ID is still live must not be deleted")
+	}
+}
+
+func TestSweepClosedNudgeMailRetention_InFlightNudgeProtected(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	const inFlightID = "inflight-nudge"
+	seed := []beads.Bead{
+		closedNudgeSeed("n-inflight", inFlightID, now.Add(-policy.nudgeDeleteAfterClose-time.Hour)),
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+	state := &nudgequeue.State{InFlight: []nudgequeue.Item{{ID: inFlightID}}}
+
+	result, err := sweepClosedNudgeMailRetention(store, state, now, policy, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeDeleted != 0 {
+		t.Errorf("NudgeDeleted = %d, want 0 (in-flight nudge ID must be protected)", result.NudgeDeleted)
+	}
+	if !retentionBeadPresent(t, store, "n-inflight") {
+		t.Error("closed nudge whose ID is still in-flight must not be deleted")
+	}
+}
+
+// TestSweepClosedNudgeMailRetention_BudgetTopsUpAcrossPhases verifies the
+// combined budget is computed from beads actually deleted, not from candidates
+// scanned: when phase 1 (nudge) under-delivers because a candidate is skipped by
+// a gate, phase 2 (mail) gets the unused budget rather than losing it.
+func TestSweepClosedNudgeMailRetention_BudgetTopsUpAcrossPhases(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	const liveID = "live-nudge"
+	seed := []beads.Bead{
+		// Two nudge candidates: one live-protected (skipped), one deletable.
+		closedNudgeSeed("n-live", liveID, now.Add(-policy.nudgeDeleteAfterClose-2*time.Minute)),
+		closedNudgeSeed("n-del", "n-del", now.Add(-policy.nudgeDeleteAfterClose-time.Minute)),
+		// Three mail candidates, all deletable.
+		closedMailSeed("m-0", now.Add(-policy.mailDeleteAfterClose-3*time.Minute)),
+		closedMailSeed("m-1", now.Add(-policy.mailDeleteAfterClose-2*time.Minute)),
+		closedMailSeed("m-2", now.Add(-policy.mailDeleteAfterClose-time.Minute)),
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+	state := &nudgequeue.State{Pending: []nudgequeue.Item{{ID: liveID}}}
+
+	// Budget 3: 1 nudge deleted (n-del; n-live skipped) + 2 mail deleted = 3 total.
+	result, err := sweepClosedNudgeMailRetention(store, state, now, policy, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeDeleted != 1 {
+		t.Errorf("NudgeDeleted = %d, want 1 (n-del; n-live is live-protected)", result.NudgeDeleted)
+	}
+	if result.MailDeleted != 2 {
+		t.Errorf("MailDeleted = %d, want 2 (phase 2 receives the unused budget)", result.MailDeleted)
+	}
+	if total := result.NudgeDeleted + result.MailDeleted; total != 3 {
+		t.Errorf("total deleted = %d, want 3 (budget cap)", total)
+	}
+}
+
+func TestSweepClosedNudgeMailRetention_OwnershipEdgeSkip(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	seed := []beads.Bead{
+		closedNudgeSeed("n-owned", "n-owned", now.Add(-policy.nudgeDeleteAfterClose-time.Hour)),
+	}
+	// Another bead depends on n-owned: DepList(id, "up") returns this edge, so
+	// the bead is left for a graph-aware reaper rather than severed here.
+	deps := []beads.Dep{{IssueID: "dependent", DependsOnID: "n-owned", Type: "blocks"}}
+	store := beads.NewMemStoreFrom(100, seed, deps)
+
+	result, err := sweepClosedNudgeMailRetention(store, nil, now, policy, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeDeleted != 0 {
+		t.Errorf("NudgeDeleted = %d, want 0 (bead with an inbound dependency must be skipped)", result.NudgeDeleted)
+	}
+	if !retentionBeadPresent(t, store, "n-owned") {
+		t.Error("bead with an inbound dependency must not be deleted")
+	}
+}
+
+func TestSweepClosedNudgeMailRetention_BudgetCap(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	const total = 5
+	seed := make([]beads.Bead, total)
+	for i := range seed {
+		id := fmt.Sprintf("n-%d", i)
+		seed[i] = closedNudgeSeed(id, id, now.Add(-policy.nudgeDeleteAfterClose-time.Duration(i+1)*time.Minute))
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepClosedNudgeMailRetention(store, nil, now, policy, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeDeleted != 3 {
+		t.Errorf("NudgeDeleted = %d, want 3 (budget cap)", result.NudgeDeleted)
+	}
+	remaining := 0
+	for i := 0; i < total; i++ {
+		if retentionBeadPresent(t, store, fmt.Sprintf("n-%d", i)) {
+			remaining++
+		}
+	}
+	if remaining != total-3 {
+		t.Errorf("remaining closed nudge beads = %d, want %d", remaining, total-3)
+	}
+}
+
+func TestSweepClosedNudgeMailRetention_BudgetZeroIsUnlimited(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	const total = 5
+	seed := make([]beads.Bead, total)
+	for i := range seed {
+		id := fmt.Sprintf("n-%d", i)
+		seed[i] = closedNudgeSeed(id, id, now.Add(-policy.nudgeDeleteAfterClose-time.Duration(i+1)*time.Minute))
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepClosedNudgeMailRetention(store, nil, now, policy, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeDeleted != total {
+		t.Errorf("NudgeDeleted = %d, want %d (budget 0 = unlimited)", result.NudgeDeleted, total)
+	}
+}
+
+func TestSweepClosedNudgeMailRetention_DisabledPolicyDeletesNothing(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	// Zero-valued policy: both TTLs non-positive => deletion disabled.
+	seed := []beads.Bead{
+		closedNudgeSeed("n-old", "n-old", now.Add(-100*time.Hour)),
+		closedMailSeed("m-old", now.Add(-100*time.Hour)),
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	result, err := sweepClosedNudgeMailRetention(store, nil, now, nudgeMailRetentionPolicy{}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NudgeDeleted != 0 || result.MailDeleted != 0 {
+		t.Errorf("deleted = %+v, want zero (disabled policy must delete nothing)", result)
+	}
+	if !retentionBeadPresent(t, store, "n-old") || !retentionBeadPresent(t, store, "m-old") {
+		t.Error("disabled policy must not delete any bead")
+	}
+}
+
+func TestCountClosedNudgeMailRetention_DryRunMakesNoChanges(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	seed := []beads.Bead{
+		closedNudgeSeed("n-old", "n-old", now.Add(-policy.nudgeDeleteAfterClose-time.Hour)),
+		closedMailSeed("m-old", now.Add(-policy.mailDeleteAfterClose-time.Hour)),
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	counts, err := countClosedNudgeMailRetention(store, nil, now, policy, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if counts.NudgeDeleted != 1 || counts.MailDeleted != 1 {
+		t.Errorf("counts = %+v, want NudgeDeleted=1 MailDeleted=1", counts)
+	}
+	if !retentionBeadPresent(t, store, "n-old") || !retentionBeadPresent(t, store, "m-old") {
+		t.Error("dry-run must not delete any bead")
+	}
+}
+
+func TestSweepClosedNudgeMailRetention_NilStoreErrors(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	_, err := sweepClosedNudgeMailRetention(nil, nil, now, testNudgeMailRetentionPolicy(), 0)
+	if err == nil {
+		t.Fatal("expected error for nil store, got nil")
+	}
+}
+
+// nudgeRetentionFailingDelete wraps MemStore and forces Delete to fail for
+// specific bead IDs, exercising the per-bead-error continuation path.
+type nudgeRetentionFailingDelete struct {
+	*beads.MemStore
+	failIDs map[string]bool
+}
+
+func (s *nudgeRetentionFailingDelete) Delete(id string) error {
+	if s.failIDs[id] {
+		return fmt.Errorf("forced delete failure for %s", id)
+	}
+	return s.MemStore.Delete(id)
+}
+
+func TestSweepClosedNudgeMailRetention_PerBeadDeleteFailureContinues(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	policy := testNudgeMailRetentionPolicy()
+
+	seed := []beads.Bead{
+		closedNudgeSeed("n-fail", "n-fail", now.Add(-policy.nudgeDeleteAfterClose-2*time.Minute)),
+		closedNudgeSeed("n-ok", "n-ok", now.Add(-policy.nudgeDeleteAfterClose-time.Minute)),
+	}
+	mem := beads.NewMemStoreFrom(100, seed, nil)
+	store := &nudgeRetentionFailingDelete{MemStore: mem, failIDs: map[string]bool{"n-fail": true}}
+
+	result, err := sweepClosedNudgeMailRetention(store, nil, now, policy, 0)
+	if err == nil {
+		t.Fatal("expected a joined per-bead error, got nil")
+	}
+	if !strings.Contains(err.Error(), "n-fail") {
+		t.Errorf("error should mention the failing bead, got: %v", err)
+	}
+	if result.NudgeDeleted != 1 {
+		t.Errorf("NudgeDeleted = %d, want 1 (the non-failing bead)", result.NudgeDeleted)
+	}
+	if retentionBeadPresent(t, store, "n-ok") {
+		t.Error("n-ok should have been deleted")
+	}
+	if !retentionBeadPresent(t, store, "n-fail") {
+		t.Error("n-fail should remain (delete failed)")
+	}
+}
+
+func TestNudgeMailRetentionPolicyForConfig(t *testing.T) {
+	// Nil config falls back to the controller defaults (24h / 72h).
+	def := nudgeMailRetentionPolicyForConfig(nil)
+	if def.nudgeDeleteAfterClose != 24*time.Hour {
+		t.Errorf("nil cfg nudge TTL = %v, want 24h", def.nudgeDeleteAfterClose)
+	}
+	if def.mailDeleteAfterClose != 72*time.Hour {
+		t.Errorf("nil cfg mail TTL = %v, want 72h", def.mailDeleteAfterClose)
+	}
+
+	// Explicit config values override the defaults.
+	cfg := &config.City{
+		Beads: config.BeadsConfig{
+			Policies: map[string]config.BeadPolicyConfig{
+				config.BeadPolicyNudge: {DeleteAfterClose: "1h"},
+				config.BeadPolicyMail:  {DeleteAfterClose: "2h"},
+			},
+		},
+	}
+	got := nudgeMailRetentionPolicyForConfig(cfg)
+	if got.nudgeDeleteAfterClose != time.Hour {
+		t.Errorf("configured nudge TTL = %v, want 1h", got.nudgeDeleteAfterClose)
+	}
+	if got.mailDeleteAfterClose != 2*time.Hour {
+		t.Errorf("configured mail TTL = %v, want 2h", got.mailDeleteAfterClose)
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2236,7 +2236,7 @@ gc order
 | [gc order list](#gc-order-list) | List available orders |
 | [gc order run](#gc-order-run) | Execute an order manually |
 | [gc order show](#gc-order-show) | Show details of an order |
-| [gc order sweep-nudge-mail](#gc-order-sweep-nudge-mail) | Close stale delivered nudge beads and read mail beads |
+| [gc order sweep-nudge-mail](#gc-order-sweep-nudge-mail) | Close stale nudge/mail beads, then delete long-closed ones |
 | [gc order sweep-tracking](#gc-order-sweep-tracking) | Close stale and prune closed order-tracking beads |
 
 ## gc order check
@@ -2324,14 +2324,23 @@ gc order show <name> [flags]
 
 ## gc order sweep-nudge-mail
 
-Close stale delivered nudge beads and read mail beads.
+Close stale delivered nudge beads and read mail beads, then delete the
+long-closed ones so the live issues table stops growing unbounded.
 
 Nudge beads that are past --nudge-ttl and not in the live nudge queue are
 closed. Read mail beads past --mail-ttl are closed. A budget cap of 50 closes
 per invocation prevents runaway sweeps under load.
 
-Use --dry-run to log what would be closed without making any changes.
-The controller watchdog also runs this sweep automatically every 5 minutes.
+After closing, an archive-then-delete tail deletes closed nudge/mail beads
+older than their configured delete-after-close TTL
+([beads.policies.nudge] default 24h, [beads.policies.mail] default 72h),
+cascading their events/labels rows. Deletion is bounded to 500 beads per
+invocation and never touches open work, live nudges, or beads another bead
+still depends on.
+
+Use --dry-run to log what would be closed and deleted without making any
+changes. The controller watchdog also runs this sweep automatically every 5
+minutes.
 
 ```
 gc order sweep-nudge-mail [flags]

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -9721,6 +9721,361 @@ func TestJsonlExportPushFailureEscalatesOncePerUnresolvedFailure(t *testing.T) {
 	}
 }
 
+// writeWatermarkDoltStub emits a `dolt` shim that distinguishes the full issues
+// dump from a since-watermark delta query (#3342): any query containing
+// `updated_at >=` returns deltaPayload, a bare issues SELECT returns
+// fullPayload, and supplemental tables return empty. Every invocation is
+// appended to DOLT_ARGS_LOG when set so tests can assert the query shape and
+// supplemental-skip behavior.
+func writeWatermarkDoltStub(t *testing.T, binDir, fullPayload, deltaPayload string) {
+	t.Helper()
+	body := "#!/bin/sh\n" +
+		"if [ -n \"${DOLT_ARGS_LOG:-}\" ]; then\n" +
+		"  printf '%s\\n' \"$*\" >> \"$DOLT_ARGS_LOG\"\n" +
+		"fi\n" +
+		"case \"$*\" in\n" +
+		"  *\"SHOW TABLES FROM\"*\"LIKE 'wisps'\"*)\n" +
+		"    printf 'Tables_in_db\\nwisps\\n'\n" +
+		"    ;;\n" +
+		"  *\"SHOW DATABASES\"*)\n" +
+		"    printf 'Database\\nbeads\\n'\n" +
+		"    ;;\n" +
+		"  *\"updated_at >=\"*)\n" +
+		"    printf '%s\\n' '" + deltaPayload + "'\n" +
+		"    ;;\n" +
+		"  *\"FROM \\`beads\\`.issues\"*)\n" +
+		"    printf '%s\\n' '" + fullPayload + "'\n" +
+		"    ;;\n" +
+		"  *\"SELECT *\"*)\n" +
+		"    printf '{\"rows\":[]}\\n'\n" +
+		"    ;;\n" +
+		"esac\n" +
+		"exit 0\n"
+	writeExecutable(t, filepath.Join(binDir, "dolt"), body)
+}
+
+// seedArchiveWithIssuesPayload initializes a git archive repo with one committed
+// beads/issues.jsonl holding the given `{"rows":[...]}` payload, so a later
+// delta run has a prior snapshot to merge into. Default branch is `main`.
+func seedArchiveWithIssuesPayload(t *testing.T, archiveRepo, payload string) {
+	t.Helper()
+	dbDir := filepath.Join(archiveRepo, "beads")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, "issues.jsonl"), []byte(payload+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	steps := [][]string{
+		{"-c", "init.defaultBranch=main", "init", "-q"},
+		{"config", "user.email", "test@example.invalid"},
+		{"config", "user.name", "test"},
+		{"add", "-A"},
+		{"commit", "-q", "-m", "seed"},
+	}
+	for _, args := range steps {
+		full := append([]string{"-C", archiveRepo}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+}
+
+// writeWatermarkState pre-seeds the export state with an issues watermark and
+// full-snapshot epoch for the test DB ("beads") so a run takes the delta (or
+// forced-full) path.
+func writeWatermarkState(t *testing.T, stateFile, watermark string, fullAt int64) {
+	t.Helper()
+	state := map[string]any{
+		"export_watermarks": map[string]any{
+			"beads": map[string]any{
+				"issues": map[string]any{
+					"updated_at_watermark": watermark,
+					"full_at":              fullAt,
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stateFile, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// readWatermarkState returns the stored issues watermark and full_at epoch for
+// the test DB ("beads").
+func readWatermarkState(t *testing.T, stateFile string) (string, int64) {
+	t.Helper()
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state struct {
+		ExportWatermarks map[string]struct {
+			Issues struct {
+				Watermark string  `json:"updated_at_watermark"`
+				FullAt    float64 `json:"full_at"`
+			} `json:"issues"`
+		} `json:"export_watermarks"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, data)
+	}
+	e := state.ExportWatermarks["beads"]
+	return e.Issues.Watermark, int64(e.Issues.FullAt)
+}
+
+// TestJsonlExportFullSnapshotRecordsWatermark verifies the first export for a DB
+// is a full snapshot (no since-watermark filter, supplemental tables refreshed)
+// and records the high-water updated_at plus a full_at epoch for the next pass.
+func TestJsonlExportFullSnapshotRecordsWatermark(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+
+	scriptBody, err := os.ReadFile(coreScriptPath("jsonl-export.sh"))
+	if err != nil {
+		t.Fatalf("ReadFile(jsonl-export.sh): %v", err)
+	}
+	if got := extractShellDefault(t, string(scriptBody), "GC_JSONL_FULL_SNAPSHOT_INTERVAL"); got != "3600" {
+		t.Fatalf("GC_JSONL_FULL_SNAPSHOT_INTERVAL default = %q, want 3600", got)
+	}
+
+	full := `{"rows":[{"id":"a","updated_at":"2026-06-14T08:00:00Z"},{"id":"b","updated_at":"2026-06-14T12:00:00Z"}]}`
+	writeWatermarkDoltStub(t, binDir, full, `{"rows":[]}`)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	env["DOLT_ARGS_LOG"] = doltLog
+
+	runScript(t, coreScriptPath("jsonl-export.sh"), env)
+
+	doltData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt args log): %v", err)
+	}
+	dolt := string(doltData)
+	if strings.Contains(dolt, "updated_at >=") {
+		t.Fatalf("first export must be a full snapshot, not a delta:\n%s", dolt)
+	}
+	if !strings.Contains(dolt, "FROM `beads`.`comments`") {
+		t.Fatalf("full snapshot must refresh supplemental tables:\n%s", dolt)
+	}
+
+	wm, fullAt := readWatermarkState(t, stateFile)
+	if wm != "2026-06-14T12:00:00Z" {
+		t.Fatalf("watermark = %q, want 2026-06-14T12:00:00Z (max updated_at)", wm)
+	}
+	if fullAt <= 0 {
+		t.Fatalf("full_at = %d, want a recorded epoch > 0", fullAt)
+	}
+}
+
+// TestJsonlExportDeltaMergesSinceWatermark verifies a delta cycle exports only
+// rows updated at/after the stored watermark, merges them into the prior
+// snapshot (delta wins on id collision, prior-only rows retained), skips the
+// supplemental tables, and advances the watermark to the delta high-water mark.
+func TestJsonlExportDeltaMergesSinceWatermark(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+
+	prior := `{"rows":[{"id":"p1","title":"one","updated_at":"2026-06-14T09:00:00Z"},{"id":"p2","title":"two-old","updated_at":"2026-06-14T10:00:00Z"}]}`
+	seedArchiveWithIssuesPayload(t, archiveRepo, prior)
+	// A recent full snapshot keeps this pass on the delta path.
+	writeWatermarkState(t, stateFile, "2026-06-14T10:00:00Z", time.Now().Unix())
+
+	delta := `{"rows":[{"id":"p2","title":"two-new","updated_at":"2026-06-14T11:00:00Z"},{"id":"p3","title":"three","updated_at":"2026-06-14T11:30:00Z"}]}`
+	// A wrong full-path would surface this sentinel row instead of the merge.
+	full := `{"rows":[{"id":"FULL","title":"wrong","updated_at":"2026-06-14T23:00:00Z"}]}`
+	writeWatermarkDoltStub(t, binDir, full, delta)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	env["DOLT_ARGS_LOG"] = doltLog
+
+	runScript(t, coreScriptPath("jsonl-export.sh"), env)
+
+	doltData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt args log): %v", err)
+	}
+	dolt := string(doltData)
+	if !strings.Contains(dolt, "updated_at >= '2026-06-14T10:00:00Z'") {
+		t.Fatalf("delta export must query since the stored watermark:\n%s", dolt)
+	}
+	for _, banned := range []string{"FROM `beads`.`comments`", "FROM `beads`.`labels`", "FROM `beads`.`metadata`"} {
+		if strings.Contains(dolt, banned) {
+			t.Fatalf("delta cycle must skip supplemental re-export; saw %q:\n%s", banned, dolt)
+		}
+	}
+
+	merged, err := os.ReadFile(filepath.Join(archiveRepo, "beads", "issues.jsonl"))
+	if err != nil {
+		t.Fatalf("ReadFile(merged issues.jsonl): %v", err)
+	}
+	var payload struct {
+		Rows []struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(merged, &payload); err != nil {
+		t.Fatalf("Unmarshal(merged): %v\n%s", err, merged)
+	}
+	got := map[string]string{}
+	for _, r := range payload.Rows {
+		got[r.ID] = r.Title
+	}
+	want := map[string]string{"p1": "one", "p2": "two-new", "p3": "three"}
+	if len(payload.Rows) != len(want) {
+		t.Fatalf("merged row count = %d, want %d\nrows: %s", len(payload.Rows), len(want), merged)
+	}
+	for id, title := range want {
+		if got[id] != title {
+			t.Fatalf("merged row %q title = %q, want %q\nrows: %s", id, got[id], title, merged)
+		}
+	}
+
+	wm, _ := readWatermarkState(t, stateFile)
+	if wm != "2026-06-14T11:30:00Z" {
+		t.Fatalf("watermark = %q, want 2026-06-14T11:30:00Z (delta high-water)", wm)
+	}
+}
+
+// TestJsonlExportMigrationFromPreWatermarkState verifies the upgrade path: an
+// archive that already has a committed issues.jsonl but a state file lacking any
+// export_watermarks key must take a full snapshot (not a delta), refresh
+// supplemental tables, and record a valid watermark + full_at without corrupting
+// state. Regression guard for the @tsv leading-tab parse that mis-read an empty
+// watermark as "0" and skipped the full cycle.
+func TestJsonlExportMigrationFromPreWatermarkState(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+
+	prior := `{"rows":[{"id":"p1","title":"one","updated_at":"2026-06-14T09:00:00Z"}]}`
+	seedArchiveWithIssuesPayload(t, archiveRepo, prior)
+	// Pre-watermark state: a populated state object with no export_watermarks key.
+	if err := os.WriteFile(stateFile, []byte(`{"last_logged_mode":"local-only"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	full := `{"rows":[{"id":"p1","title":"one","updated_at":"2026-06-14T09:00:00Z"},{"id":"p9","title":"nine","updated_at":"2026-06-14T13:00:00Z"}]}`
+	delta := `{"rows":[{"id":"SHOULD_NOT_APPEAR","updated_at":"2026-06-14T20:00:00Z"}]}`
+	writeWatermarkDoltStub(t, binDir, full, delta)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	env["DOLT_ARGS_LOG"] = doltLog
+
+	runScript(t, coreScriptPath("jsonl-export.sh"), env)
+
+	doltData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt args log): %v", err)
+	}
+	dolt := string(doltData)
+	if strings.Contains(dolt, "updated_at >=") {
+		t.Fatalf("migration with no watermark must be a full snapshot, not a delta:\n%s", dolt)
+	}
+	if !strings.Contains(dolt, "FROM `beads`.`metadata`") {
+		t.Fatalf("migration full snapshot must refresh supplemental tables:\n%s", dolt)
+	}
+
+	wm, fullAt := readWatermarkState(t, stateFile)
+	if wm != "2026-06-14T13:00:00Z" {
+		t.Fatalf("watermark = %q, want 2026-06-14T13:00:00Z (recorded on migration full cycle)", wm)
+	}
+	if fullAt <= 0 {
+		t.Fatalf("full_at = %d, want a recorded epoch > 0 (state must not be corrupted)", fullAt)
+	}
+	// Pre-existing state keys must survive the watermark write.
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("state file is not valid JSON after migration (corruption?): %v\n%s", err, stateData)
+	}
+}
+
+// TestJsonlExportForcesFullSnapshotAfterInterval verifies an ancient full_at
+// forces a full snapshot (no delta filter, supplemental tables refreshed) even
+// when a watermark exists, and that full_at is refreshed to a recent epoch.
+func TestJsonlExportForcesFullSnapshotAfterInterval(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+
+	prior := `{"rows":[{"id":"p1","title":"one","updated_at":"2026-06-14T09:00:00Z"}]}`
+	seedArchiveWithIssuesPayload(t, archiveRepo, prior)
+	// full_at far in the past → interval elapsed → forced full snapshot.
+	writeWatermarkState(t, stateFile, "2026-06-14T09:00:00Z", 1000)
+
+	full := `{"rows":[{"id":"p1","title":"one","updated_at":"2026-06-14T09:00:00Z"},{"id":"p9","title":"nine","updated_at":"2026-06-14T14:00:00Z"}]}`
+	delta := `{"rows":[{"id":"SHOULD_NOT_APPEAR","updated_at":"2026-06-14T20:00:00Z"}]}`
+	writeWatermarkDoltStub(t, binDir, full, delta)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	env["DOLT_ARGS_LOG"] = doltLog
+
+	runScript(t, coreScriptPath("jsonl-export.sh"), env)
+
+	doltData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt args log): %v", err)
+	}
+	dolt := string(doltData)
+	if strings.Contains(dolt, "updated_at >=") {
+		t.Fatalf("interval-elapsed export must be a full snapshot, not a delta:\n%s", dolt)
+	}
+	if !strings.Contains(dolt, "FROM `beads`.`labels`") {
+		t.Fatalf("forced full snapshot must refresh supplemental tables:\n%s", dolt)
+	}
+
+	merged, err := os.ReadFile(filepath.Join(archiveRepo, "beads", "issues.jsonl"))
+	if err != nil {
+		t.Fatalf("ReadFile(issues.jsonl): %v", err)
+	}
+	if strings.Contains(string(merged), "SHOULD_NOT_APPEAR") {
+		t.Fatalf("forced full snapshot must not merge a delta:\n%s", merged)
+	}
+
+	wm, fullAt := readWatermarkState(t, stateFile)
+	if wm != "2026-06-14T14:00:00Z" {
+		t.Fatalf("watermark = %q, want 2026-06-14T14:00:00Z", wm)
+	}
+	if fullAt <= 1000 {
+		t.Fatalf("full_at = %d, want refreshed to a recent epoch", fullAt)
+	}
+}
+
 // gateSweepEnv constructs the env for a gate-sweep.sh invocation with a
 // PATH-shimmed bd stub that logs every call to BD_LOG.
 func gateSweepEnv(t *testing.T) (binDir, bdLog string, env map[string]string) {
@@ -10061,7 +10416,8 @@ func TestPruneBranchesNoOpWhenNoGcBranches(t *testing.T) {
 const wispTimestampLayout = "2006-01-02T15:04:05"
 
 // wispCompactEnv installs a `bd` stub that returns the supplied beadsJSON on
-// `bd list --json --all -n 0` and logs all other bd subcommands to BD_LOG.
+// the bounded `bd list --json --all --sort updated --reverse -n <limit>` scan
+// and logs all other bd subcommands to BD_LOG.
 // BD_LOG is pre-created empty so skip-path tests can still assert on its
 // (empty) contents. TZ=UTC is pinned for cross-platform date parsing — see
 // wispTimestampLayout. jq is whatever is on PATH.
@@ -10076,13 +10432,15 @@ func wispCompactEnv(t *testing.T, beadsJSON string) (bdLog string, env map[strin
 	stubPath := filepath.Join(binDir, "bd")
 	// Stub fails fast on any subcommand or flag shape the script doesn't
 	// currently use. This pins the script's bd contract — a regression that
-	// dropped `--json` or `--all` from `bd list` would otherwise silently
-	// pass because cat would still emit valid JSON.
+	// dropped `--json`/`--all`, or reverted the bounded oldest-first scan
+	// (`--sort updated --reverse -n <limit>`) back to the unbounded `-n 0`
+	// form, would otherwise silently pass because cat would still emit valid
+	// JSON. See gastownhall/gascity#3342.
 	writeExecutable(t, stubPath, fmt.Sprintf(`#!/bin/sh
 case "$1" in
   list)
     case "$*" in
-      *"--json"*"--all"*"-n 0"*)
+      *"--json"*"--all"*"--sort updated"*"--reverse"*"-n "*)
         cat <<'EOF'
 %s
 EOF
@@ -10268,6 +10626,29 @@ func TestWispCompactSkipsNonEphemeralBeads(t *testing.T) {
 		if strings.Contains(s, banned) {
 			t.Fatalf("non-ephemeral bead must be ignored; saw %q in bd log:\n%s", banned, s)
 		}
+	}
+}
+
+// TestWispCompactBoundsScanOldestFirst pins the #3342 contention fix: the
+// candidate scan must be bounded (`-n "$WISP_COMPACT_LIMIT"`, default 5000) and
+// ordered oldest-updated-first (`--sort updated --reverse`) so each run drains
+// the stale backlog instead of walking the whole table. The unbounded `-n 0`
+// form must not reappear.
+func TestWispCompactBoundsScanOldestFirst(t *testing.T) {
+	body, err := os.ReadFile(coreScriptPath("wisp-compact.sh"))
+	if err != nil {
+		t.Fatalf("ReadFile(wisp-compact.sh): %v", err)
+	}
+	script := string(body)
+
+	if got := extractShellDefault(t, script, "GC_WISP_COMPACT_LIMIT"); got != "5000" {
+		t.Fatalf("GC_WISP_COMPACT_LIMIT default = %q, want 5000", got)
+	}
+	if !strings.Contains(script, `bd list --json --all --sort updated --reverse -n "$WISP_COMPACT_LIMIT"`) {
+		t.Fatalf("wisp-compact must scan oldest-first with a bounded limit; script:\n%s", script)
+	}
+	if strings.Contains(script, "bd list --json --all -n 0") {
+		t.Fatalf("wisp-compact must not reintroduce the unbounded `-n 0` scan; script:\n%s", script)
 	}
 }
 
@@ -10473,7 +10854,7 @@ exit 0
 	if err != nil {
 		t.Fatalf("ReadFile(bd log): %v", err)
 	}
-	if !strings.Contains(string(logData), "list --json --all -n 0") {
+	if !strings.Contains(string(logData), "list --json --all --sort updated --reverse -n 5000") {
 		t.Fatalf("bd list call not observed:\n%s", logData)
 	}
 

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -10076,6 +10076,125 @@ func TestJsonlExportForcesFullSnapshotAfterInterval(t *testing.T) {
 	}
 }
 
+// TestJsonlExportCommitFailureRollsBackWatermark verifies the per-DB issues
+// watermark advanced inside the export loop is rolled back when the post-loop
+// archive commit fails. Without the rollback the next delta cycle would query
+// `updated_at >= <advanced-watermark>` and skip the rows in the discarded
+// snapshot's window — and if Option A retention deletes those closed rows before
+// the next full snapshot they are unrecoverable, breaking the archive-before-
+// delete ordering #3342 retention relies on.
+func TestJsonlExportCommitFailureRollsBackWatermark(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+
+	const priorWatermark = "2026-06-14T09:00:00Z"
+	prior := `{"rows":[{"id":"p1","title":"one","updated_at":"` + priorWatermark + `"}]}`
+	seedArchiveWithIssuesPayload(t, archiveRepo, prior)
+	// A recent full snapshot keeps this pass on the delta path, so the loop
+	// advances the watermark before the commit is attempted.
+	writeWatermarkState(t, stateFile, priorWatermark, time.Now().Unix())
+
+	// A committed delta would advance the watermark to this newer updated_at; a
+	// sentinel full payload would surface only on a wrong (full-snapshot) path.
+	delta := `{"rows":[{"id":"p2","title":"two","updated_at":"2026-06-14T12:00:00Z"}]}`
+	full := `{"rows":[{"id":"FULL","title":"wrong","updated_at":"2026-06-14T23:00:00Z"}]}`
+	writeWatermarkDoltStub(t, binDir, full, delta)
+	writeJsonlExportGCStub(t, binDir)
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath(git): %v", err)
+	}
+	writeGitSubcommandFailureStub(t, binDir, realGit, "commit")
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+
+	out, runErr := runScriptResult(t, coreScriptPath("jsonl-export.sh"), env)
+	if runErr == nil {
+		t.Fatalf("expected script to fail when git commit fails on the delta path; output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "archive snapshot commit failed") {
+		t.Fatalf("expected archive-snapshot commit failure diagnostic, got:\n%s", out)
+	}
+
+	wm, _ := readWatermarkState(t, stateFile)
+	if wm != priorWatermark {
+		t.Fatalf("commit failure must roll the watermark back to %q, got %q (advanced past an uncommitted snapshot)", priorWatermark, wm)
+	}
+}
+
+// TestJsonlExportDeltaMergePreservesAnomalousNullIDRows verifies the delta merge
+// keys rows on a non-empty id only: an anomalous null/empty-id row (forbidden by
+// the issues PRIMARY KEY but possible in a corrupt export) is preserved rather
+// than collapsed onto a single object key — and a null id no longer aborts the
+// whole merge with a jq "Cannot index object with null" error.
+func TestJsonlExportDeltaMergePreservesAnomalousNullIDRows(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+
+	// Prior snapshot: one keyed row plus an anomalous empty-id row.
+	prior := `{"rows":[{"id":"p1","title":"one","updated_at":"2026-06-14T09:00:00Z"},{"id":"","title":"anon-prior","updated_at":"2026-06-14T08:00:00Z"}]}`
+	seedArchiveWithIssuesPayload(t, archiveRepo, prior)
+	writeWatermarkState(t, stateFile, "2026-06-14T08:00:00Z", time.Now().Unix())
+
+	// Delta updates the keyed row and carries a second anomalous row, this one
+	// with a null id — the case that aborts the buggy merge entirely.
+	delta := `{"rows":[{"id":"p1","title":"one-new","updated_at":"2026-06-14T11:00:00Z"},{"id":null,"title":"anon-delta","updated_at":"2026-06-14T11:30:00Z"}]}`
+	full := `{"rows":[{"id":"FULL","title":"wrong","updated_at":"2026-06-14T23:00:00Z"}]}`
+	writeWatermarkDoltStub(t, binDir, full, delta)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+
+	runScript(t, coreScriptPath("jsonl-export.sh"), env)
+
+	merged, err := os.ReadFile(filepath.Join(archiveRepo, "beads", "issues.jsonl"))
+	if err != nil {
+		t.Fatalf("ReadFile(merged issues.jsonl): %v", err)
+	}
+	var payload struct {
+		Rows []struct {
+			ID    *string `json:"id"`
+			Title string  `json:"title"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(merged, &payload); err != nil {
+		t.Fatalf("Unmarshal(merged): %v\n%s", err, merged)
+	}
+	if len(payload.Rows) != 3 {
+		t.Fatalf("merged row count = %d, want 3 (keyed p1 + both anomalous rows); rows: %s", len(payload.Rows), merged)
+	}
+
+	var keyedTitle string
+	anomalousTitles := map[string]bool{}
+	for _, r := range payload.Rows {
+		if r.ID != nil && *r.ID == "p1" {
+			keyedTitle = r.Title
+			continue
+		}
+		// id is null or empty → anomalous; it must survive the merge.
+		anomalousTitles[r.Title] = true
+	}
+	if keyedTitle != "one-new" {
+		t.Fatalf("keyed row p1 title = %q, want one-new (delta wins); rows: %s", keyedTitle, merged)
+	}
+	for _, want := range []string{"anon-prior", "anon-delta"} {
+		if !anomalousTitles[want] {
+			t.Fatalf("anomalous row %q was dropped by the merge; rows: %s", want, merged)
+		}
+	}
+}
+
 // gateSweepEnv constructs the env for a gate-sweep.sh invocation with a
 // PATH-shimmed bd stub that logs every call to BD_LOG.
 func gateSweepEnv(t *testing.T) (binDir, bdLog string, env map[string]string) {

--- a/internal/bootstrap/packs/core/assets/scripts/jsonl-export.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/jsonl-export.sh
@@ -42,6 +42,14 @@ ARCHIVE_REPO="${GC_JSONL_ARCHIVE_REPO:-$PACK_STATE_DIR/jsonl-archive}"
 # transition, so operators who missed the first line still see the current
 # configuration. Default one week.
 MODE_RELOG_INTERVAL_SECONDS="${GC_JSONL_MODE_RELOG_INTERVAL:-604800}"
+# How often (seconds) to force a full issues-table snapshot instead of a
+# since-watermark delta. Between full snapshots the issues export pulls only rows
+# updated at/after the stored high-water mark and merges them into the prior
+# snapshot, so the 5-minute pass stops re-dumping the whole table and fighting
+# live writers (gastownhall/gascity#3342). The periodic full snapshot is the
+# authoritative backstop: delta is best-effort (updated_at formats are mixed), so
+# a full cycle re-syncs every row and keeps compaction effective. Default 1h.
+FULL_SNAPSHOT_INTERVAL_SECONDS="${GC_JSONL_FULL_SNAPSHOT_INTERVAL:-3600}"
 
 # Cached archive mode ("push" or "local-only"). Resolved once on the first
 # get_archive_mode call and reused thereafter so every push checkpoint in a
@@ -132,6 +140,34 @@ validate_exported_issues() {
             error("issues export must be a JSON object with a rows array")
         end
     '
+}
+
+# Merge a since-watermark delta export into the prior full snapshot, keyed by
+# issue id (delta wins). Both inputs are `dolt sql -r json` payloads
+# (`{"rows":[...]}`); the output is the same shape holding the union of rows with
+# prior ordering preserved and updated rows replaced in place. Rows present only
+# in the prior snapshot are retained — a delta never drops a row, which preserves
+# the archive-before-delete guarantee #3342 retention depends on.
+merge_issue_delta() {
+    local prior="$1"
+    local delta="$2"
+
+    jq -n -c \
+        --slurpfile prior "$prior" \
+        --slurpfile delta "$delta" \
+        '{rows: (
+            (($prior[0].rows // []) + ($delta[0].rows // []))
+            | reduce .[] as $r ({}; .[$r.id] = $r)
+            | [ .[] ]
+        )}'
+}
+
+# Highest updated_at across an issues payload, or empty when no row carries one.
+# Feeds the next delta's since-watermark. Lexicographic max matches RFC3339
+# chronological order; mixed CURRENT_TIMESTAMP space-formats are tolerated
+# because the periodic full snapshot re-syncs anything a delta misses.
+issue_payload_watermark() {
+    jq -r '[.rows[]? | .updated_at // empty] | max // ""'
 }
 
 normalize_pending_spike_alert_state() {
@@ -286,6 +322,33 @@ clear_pending_archive_push() {
 
 has_pending_archive_push() {
     [ "$(read_state_json | jq -r '.pending_archive_push // false')" = "true" ]
+}
+
+# Per-database issues-export watermark accessors. State shape:
+#   .export_watermarks[<db>].issues = {updated_at_watermark, full_at}
+# full_at is the unix epoch of the last full snapshot; updated_at_watermark is the
+# high-water mark feeding the next delta export. Emits two lines — the watermark
+# (possibly empty) then full_at (0 when none recorded) — read separately so an
+# empty watermark stays in the first field rather than shifting under leading-tab
+# whitespace stripping in `read`.
+read_db_export_watermark() {
+    local db="$1"
+    read_state_json | jq -r --arg db "$db" '
+        (.export_watermarks[$db].issues // {})
+        | (.updated_at_watermark // ""), (.full_at // 0 | tostring)'
+}
+
+write_db_export_watermark() {
+    local db="$1"
+    local watermark="$2"
+    local full_at="$3"
+    write_state_json "$(
+        read_state_json | jq -c \
+            --arg db "$db" \
+            --arg wm "$watermark" \
+            --argjson full "$full_at" \
+            '.export_watermarks[$db].issues = {updated_at_watermark: $wm, full_at: $full}'
+    )"
 }
 
 refresh_archive_remote_main() {
@@ -909,15 +972,50 @@ while IFS= read -r DB; do
     DB_DIR="$ARCHIVE_REPO/$DB"
     mkdir -p "$DB_DIR"
 
-    # Step 1: Export issues table.
+    # Decide between a full snapshot and a since-watermark delta. A full
+    # snapshot is required on the first export for this DB, when the prior
+    # snapshot file is missing, when no watermark has been recorded yet, or once
+    # the full-snapshot interval has elapsed. Otherwise export only the rows
+    # updated at/after the watermark and merge them into the prior snapshot, so
+    # the 5-minute pass stops re-dumping the whole table (gastownhall/gascity#3342).
+    { IFS= read -r DB_WATERMARK; IFS= read -r DB_FULL_AT; } < <(read_db_export_watermark "$DB")
+    NOW_TS=$(date -u +%s)
+    NEED_FULL=0
+    if [ -z "$DB_WATERMARK" ] || [ ! -f "$DB_DIR/issues.jsonl" ]; then
+        NEED_FULL=1
+    elif [ "$DB_FULL_AT" -le 0 ] || [ "$((NOW_TS - DB_FULL_AT))" -ge "$FULL_SNAPSHOT_INTERVAL_SECONDS" ]; then
+        NEED_FULL=1
+    fi
+
+    # Step 1: Export issues table (full snapshot or merged delta).
     ISSUE_EXPORT_TMP=$(mktemp "$DB_DIR/issues.jsonl.tmp.XXXXXX")
-    if ! dolt_sql -r json -q "SELECT * FROM \`$DB\`.issues $SCRUB_FILTER" > "$ISSUE_EXPORT_TMP" 2>/dev/null; then
-        rm -f "$ISSUE_EXPORT_TMP"
-        discard_failed_db_outputs "$DB"
-        FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
-        FAILED_DBS="${FAILED_DBS}$DB
+    if [ "$NEED_FULL" -eq 1 ]; then
+        if ! dolt_sql -r json -q "SELECT * FROM \`$DB\`.issues $SCRUB_FILTER" > "$ISSUE_EXPORT_TMP" 2>/dev/null; then
+            rm -f "$ISSUE_EXPORT_TMP"
+            discard_failed_db_outputs "$DB"
+            FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+            FAILED_DBS="${FAILED_DBS}$DB
 "
-        continue
+            continue
+        fi
+        DB_FULL_AT="$NOW_TS"
+    else
+        if [ -n "$SCRUB_FILTER" ]; then
+            DELTA_FILTER="$SCRUB_FILTER AND updated_at >= '$DB_WATERMARK'"
+        else
+            DELTA_FILTER="WHERE updated_at >= '$DB_WATERMARK'"
+        fi
+        DELTA_TMP=$(mktemp "$DB_DIR/issues.jsonl.delta.XXXXXX")
+        if ! dolt_sql -r json -q "SELECT * FROM \`$DB\`.issues $DELTA_FILTER" > "$DELTA_TMP" 2>/dev/null \
+            || ! merge_issue_delta "$DB_DIR/issues.jsonl" "$DELTA_TMP" > "$ISSUE_EXPORT_TMP" 2>/dev/null; then
+            rm -f "$ISSUE_EXPORT_TMP" "$DELTA_TMP"
+            discard_failed_db_outputs "$DB"
+            FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+            FAILED_DBS="${FAILED_DBS}$DB
+"
+            continue
+        fi
+        rm -f "$DELTA_TMP"
     fi
     if ! mv -f "$ISSUE_EXPORT_TMP" "$DB_DIR/issues.jsonl"; then
         rm -f "$ISSUE_EXPORT_TMP"
@@ -928,10 +1026,14 @@ while IFS= read -r DB; do
         continue
     fi
 
-    # Export supplemental tables (best-effort).
-    for TABLE in comments config dependencies labels metadata; do
-        dolt_sql -r json -q "SELECT * FROM \`$DB\`.\`$TABLE\`" > "$DB_DIR/$TABLE.jsonl" 2>/dev/null || true
-    done
+    # Export supplemental tables (best-effort). These tables have no watermark
+    # column, so they are refreshed only on a full snapshot; delta cycles keep
+    # the prior copies rather than re-dumping them every pass.
+    if [ "$NEED_FULL" -eq 1 ]; then
+        for TABLE in comments config dependencies labels metadata; do
+            dolt_sql -r json -q "SELECT * FROM \`$DB\`.\`$TABLE\`" > "$DB_DIR/$TABLE.jsonl" 2>/dev/null || true
+        done
+    fi
 
     # Step 2: Validate the exported JSON payload and optionally scrub it. Even
     # when SCRUB=false we still fail the DB on malformed JSON so corrupt live
@@ -990,6 +1092,15 @@ while IFS= read -r DB; do
     TOTAL_EXPORTED=$((TOTAL_EXPORTED + CURRENT_COUNT))
 
     STAGE_PATHS+=("$DB" "$DB.jsonl")
+
+    # Record the high-water mark and snapshot time so the next pass can run a
+    # delta. Derived from the persisted (post-scrub) payload; an empty result —
+    # rows without an updated_at column — keeps the prior watermark so we stay on
+    # full cycles rather than advancing past rows we never observed. Merging only
+    # grows the snapshot, so the watermark is monotonic and never regresses.
+    NEW_WATERMARK=$(issue_payload_watermark < "$DB_DIR/issues.jsonl")
+    [ -n "$NEW_WATERMARK" ] || NEW_WATERMARK="$DB_WATERMARK"
+    write_db_export_watermark "$DB" "$NEW_WATERMARK" "$DB_FULL_AT"
 
     # Step 3: Spike detection — compare record counts against previous commit.
     PREV_COUNT=0

--- a/internal/bootstrap/packs/core/assets/scripts/jsonl-export.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/jsonl-export.sh
@@ -148,6 +148,13 @@ validate_exported_issues() {
 # prior ordering preserved and updated rows replaced in place. Rows present only
 # in the prior snapshot are retained — a delta never drops a row, which preserves
 # the archive-before-delete guarantee #3342 retention depends on.
+#
+# Rows are keyed only on a non-empty string id. Rows with a null/missing/empty id
+# (forbidden by the issues PRIMARY KEY, but possible in a corrupt export) are not
+# valid object keys: keying them would collapse every anomalous row onto one
+# entry and a null id aborts the whole merge with "Cannot index object with
+# null". Such rows are instead carried through verbatim so a corrupt export
+# surfaces in the archive rather than silently losing rows.
 merge_issue_delta() {
     local prior="$1"
     local delta="$2"
@@ -155,10 +162,17 @@ merge_issue_delta() {
     jq -n -c \
         --slurpfile prior "$prior" \
         --slurpfile delta "$delta" \
-        '{rows: (
-            (($prior[0].rows // []) + ($delta[0].rows // []))
-            | reduce .[] as $r ({}; .[$r.id] = $r)
-            | [ .[] ]
+        '
+        def keyed: (.id // "") | (type == "string" and . != "");
+        ($prior[0].rows // []) as $p
+        | ($delta[0].rows // []) as $d
+        | {rows: (
+            (
+                reduce ($p + $d | .[]) as $r ({};
+                    if ($r | keyed) then .[$r.id] = $r else . end)
+                | [ .[] ]
+            )
+            + (($p + $d) | map(select(keyed | not)))
         )}'
 }
 
@@ -348,6 +362,30 @@ write_db_export_watermark() {
             --arg wm "$watermark" \
             --argjson full "$full_at" \
             '.export_watermarks[$db].issues = {updated_at_watermark: $wm, full_at: $full}'
+    )"
+}
+
+# Snapshot the whole .export_watermarks sub-state before the export loop so a
+# post-loop failure can roll it back. The loop advances each DB's watermark in
+# lockstep with writing its snapshot file, but the archive is git-committed once
+# after the loop. If staging or the commit fails the snapshot is discarded back
+# to HEAD (discard_staged_archive_outputs); the watermark must roll back with it,
+# or the next delta cycle queries `updated_at >= <advanced-watermark>` and skips
+# the rows in the lost window — which Option A retention can then delete before
+# the next full snapshot, breaking the archive-before-delete ordering #3342
+# relies on. Emits the current value (or `null` when no watermarks are recorded).
+snapshot_export_watermarks() {
+    read_state_json | jq -c '.export_watermarks // null'
+}
+
+# Restore .export_watermarks to a value captured by snapshot_export_watermarks,
+# leaving every other state field untouched. A null snapshot (no watermarks
+# before the loop) deletes the key so the state matches its pre-loop shape.
+restore_export_watermarks() {
+    local snapshot="$1"
+    write_state_json "$(
+        read_state_json | jq -c --argjson wm "$snapshot" \
+            'if $wm == null then del(.export_watermarks) else .export_watermarks = $wm end'
     )"
 }
 
@@ -951,6 +989,10 @@ should_halt_for_jsonl_spike() {
     return 0
 }
 
+# Capture the pre-loop watermark state so a post-loop staging/commit failure can
+# restore it. Must run before the loop advances any per-DB watermark.
+EXPORT_WATERMARKS_SNAPSHOT=$(snapshot_export_watermarks)
+
 while IFS= read -r DB; do
     [ -z "$DB" ] && continue
     TOTAL_DBS=$((TOTAL_DBS + 1))
@@ -1137,6 +1179,7 @@ cd "$ARCHIVE_REPO"
 if [ "${#STAGE_PATHS[@]}" -gt 0 ]; then
     if ! git add -A -- "${STAGE_PATHS[@]}"; then
         discard_staged_archive_outputs
+        restore_export_watermarks "$EXPORT_WATERMARKS_SNAPSHOT"
         echo "jsonl-export: staging archive outputs failed" >&2
         exit 1
     fi
@@ -1153,6 +1196,7 @@ if [ "$HALTED" -eq 1 ]; then
             "[HALT] backup $(date -u +%Y-%m-%dT%H:%M:%SZ): exported=$EXPORTED_DBS/$TOTAL_DBS records=$TOTAL_EXPORTED (spike detected; push skipped)" \
             "HALT baseline" || {
             discard_staged_archive_outputs
+            restore_export_watermarks "$EXPORT_WATERMARKS_SNAPSHOT"
             exit 1
         }
         set_pending_archive_push
@@ -1204,6 +1248,7 @@ commit_archive_snapshot \
     "backup $(date -u +%Y-%m-%dT%H:%M:%SZ): exported=$EXPORTED_DBS/$TOTAL_DBS records=$TOTAL_EXPORTED" \
     "archive snapshot" || {
     discard_staged_archive_outputs
+    restore_export_watermarks "$EXPORT_WATERMARKS_SNAPSHOT"
     exit 1
 }
 set_pending_archive_push

--- a/internal/bootstrap/packs/core/assets/scripts/wisp-compact.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/wisp-compact.sh
@@ -23,8 +23,16 @@ __SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 CITY="${GC_CITY:-.}"
 
-# Get all ephemeral beads.
-ALL=$(bd list --json --all -n 0 2>/dev/null) || exit 0
+# Bound the candidate scan so the 5-minute maintenance pass stops fighting live
+# writers (gastownhall/gascity#3342). An unbounded `bd list --all -n 0` walks the
+# whole table every cycle; instead pull the oldest-updated beads — the ones most
+# likely past TTL — up to a configurable cap, and let later runs chip away at the
+# rest (NDI: deletion converges across cycles). `bd list --sort updated` defaults
+# to newest-first, so `--reverse` is required to surface the stale backlog first.
+WISP_COMPACT_LIMIT="${GC_WISP_COMPACT_LIMIT:-5000}"
+
+# Get ephemeral beads (oldest-updated first, bounded).
+ALL=$(bd list --json --all --sort updated --reverse -n "$WISP_COMPACT_LIMIT" 2>/dev/null) || exit 0
 EPHEMERALS=$(echo "$ALL" | jq '[.[] | select(.ephemeral == true)]' 2>/dev/null) || exit 0
 
 if [ -z "$EPHEMERALS" ] || [ "$EPHEMERALS" = "[]" ]; then

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4319,11 +4319,39 @@ func ApplyAgentDefaults(cfg *City) {
 // both values stay in sync.
 const DefaultOrderTrackingDeleteAfterClose = "7d"
 
+// DefaultNudgeDeleteAfterClose is the canonical default closed-bead TTL for the
+// nudge policy. Applied by ApplyBeadPolicyDefaults when
+// [beads.policies.nudge].delete_after_close is unset. The 24h window is far
+// longer than the 10-minute nudge close TTL, leaving ample room for incident
+// inspection and for the periodic jsonl archiver to capture the row before it
+// becomes eligible for deletion. cmd/gc/nudge_mail_sweep.go derives its runtime
+// fallback from this constant so both values stay in sync.
+const DefaultNudgeDeleteAfterClose = "24h"
+
+// DefaultMailDeleteAfterClose is the canonical default closed-bead TTL for the
+// mail policy. Applied by ApplyBeadPolicyDefaults when
+// [beads.policies.mail].delete_after_close is unset. The 72h window is far
+// longer than the 60-minute mail close TTL for the same reasons as the nudge
+// default. cmd/gc/nudge_mail_sweep.go derives its runtime fallback from this
+// constant so both values stay in sync.
+const DefaultMailDeleteAfterClose = "72h"
+
+const (
+	// BeadPolicyNudge names the [beads.policies.nudge] policy that governs
+	// delete-after-close retention for delivered nudge beads.
+	BeadPolicyNudge = "nudge"
+	// BeadPolicyMail names the [beads.policies.mail] policy that governs
+	// delete-after-close retention for read mail beads.
+	BeadPolicyMail = "mail"
+)
+
 // ApplyBeadPolicyDefaults fills in controller-managed defaults for bead
 // policies that have sane non-empty defaults. Call after all config
 // composition layers have been merged so user-supplied values take
 // precedence. Currently:
 //   - [beads.policies.order_tracking].delete_after_close defaults to "7d".
+//   - [beads.policies.nudge].delete_after_close defaults to "24h".
+//   - [beads.policies.mail].delete_after_close defaults to "72h".
 func ApplyBeadPolicyDefaults(cfg *City) {
 	if cfg == nil {
 		return
@@ -4331,10 +4359,19 @@ func ApplyBeadPolicyDefaults(cfg *City) {
 	if cfg.Beads.Policies == nil {
 		cfg.Beads.Policies = make(map[string]BeadPolicyConfig)
 	}
-	p := cfg.Beads.Policies["order_tracking"]
+	setBeadPolicyDeleteAfterCloseDefault(cfg, "order_tracking", DefaultOrderTrackingDeleteAfterClose)
+	setBeadPolicyDeleteAfterCloseDefault(cfg, BeadPolicyNudge, DefaultNudgeDeleteAfterClose)
+	setBeadPolicyDeleteAfterCloseDefault(cfg, BeadPolicyMail, DefaultMailDeleteAfterClose)
+}
+
+// setBeadPolicyDeleteAfterCloseDefault sets delete_after_close for the named
+// policy only when the loaded config left it empty, preserving any
+// user-supplied value and any other fields already present on the policy.
+func setBeadPolicyDeleteAfterCloseDefault(cfg *City, name, def string) {
+	p := cfg.Beads.Policies[name]
 	if p.DeleteAfterClose == "" {
-		p.DeleteAfterClose = DefaultOrderTrackingDeleteAfterClose
-		cfg.Beads.Policies["order_tracking"] = p
+		p.DeleteAfterClose = def
+		cfg.Beads.Policies[name] = p
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -802,6 +802,45 @@ func TestApplyBeadPolicyDefaults_PreservesOtherPolicies(t *testing.T) {
 	}
 }
 
+func TestApplyBeadPolicyDefaults_SetsNudgeAndMailDefaults(t *testing.T) {
+	cfg := &City{}
+	ApplyBeadPolicyDefaults(cfg)
+
+	nudge, ok := cfg.Beads.Policies[BeadPolicyNudge]
+	if !ok {
+		t.Fatal("nudge policy not set after ApplyBeadPolicyDefaults")
+	}
+	if nudge.DeleteAfterClose != "24h" {
+		t.Errorf("nudge.delete_after_close = %q, want 24h", nudge.DeleteAfterClose)
+	}
+	mail, ok := cfg.Beads.Policies[BeadPolicyMail]
+	if !ok {
+		t.Fatal("mail policy not set after ApplyBeadPolicyDefaults")
+	}
+	if mail.DeleteAfterClose != "72h" {
+		t.Errorf("mail.delete_after_close = %q, want 72h", mail.DeleteAfterClose)
+	}
+}
+
+func TestApplyBeadPolicyDefaults_DoesNotOverrideExplicitNudgeOrMail(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			Policies: map[string]BeadPolicyConfig{
+				BeadPolicyNudge: {DeleteAfterClose: "1h"},
+				BeadPolicyMail:  {DeleteAfterClose: "2h"},
+			},
+		},
+	}
+	ApplyBeadPolicyDefaults(cfg)
+
+	if got := cfg.Beads.Policies[BeadPolicyNudge].DeleteAfterClose; got != "1h" {
+		t.Errorf("nudge.delete_after_close = %q, want 1h (explicit value must not be overridden)", got)
+	}
+	if got := cfg.Beads.Policies[BeadPolicyMail].DeleteAfterClose; got != "2h" {
+		t.Errorf("mail.delete_after_close = %q, want 2h (explicit value must not be overridden)", got)
+	}
+}
+
 func TestApplyBeadPolicyDefaults_StorageFieldPreserved(t *testing.T) {
 	cfg := &City{
 		Beads: BeadsConfig{


### PR DESCRIPTION
## Summary
nudge/mail sweeps only *close* stale beads on main — there's no retention tail, so closed wisp/order/session/mail beads accumulate. The live beads DB grew 11k→98.7k in ~36h, seizing session/mail resolution city-wide (#3342). This adds the archive-then-delete retention path for nudge/mail plus an incremental (watermark) jsonl archiver and a bounded wisp scan.

Revived from a proven local branch and rebased clean onto current `origin/main` (3 commits replayed, no conflicts — the merge preserves both this branch's archive-then-delete retention tail and main's close-stale + #3535 dry-run wisp GC; `jsonl-export.sh` keeps the since-watermark incremental archiver).

## Changes
- nudge/mail: archive-then-delete retention tail + `delete_after_close` config defaults
- incremental (watermark) jsonl archiver (`jsonl-export.sh`)
- bounded wisp scan
- +1483/−69 across 10 files, with tests

## Scope
Covers nudge/mail (+ archiver + wisp scan). `order-tracking` already had retention; wisp GC reapers landed via #3535 (dry-run). `mol-/session/patrol` closed-bead retention is **not** covered here — tracked as a follow-up.

## Test plan
- [x] `make build` PASS
- [x] `make check` PASS
- [x] `make check-docs` PASS
- [ ] CI green on push

Fixes #3342
