### PR TITLE
fix: de-correlate reconciler 429 respawns with jitter + THROTTLED gate

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -3308,11 +3308,14 @@ func selectOrPlanPoolSessionBead(
 		return beads.Bead{}, 0, nil, errPoolSessionCreatePartial
 	}
 
-	// Provider-health gate: refuse new creates when the registry reports this
-	// agent's provider as red. Reuse paths above are unaffected (they return
-	// before reaching this point). loadProviderHealthSnapshot always returns a
-	// non-nil snapshot; check() fails-open when the registry is absent or stale.
-	// Symmetric with the respawn gate in session_reconciler.go:2424.
+	// Provider-health gate: refuse new creates only when the registry reports
+	// this agent's provider as RED. THROTTLED does not block creates — a create
+	// is not the storm amplifier the respawn path is (the synchronized herd is
+	// re-quarantined respawns, not fresh creates), so pacing creates would only
+	// add latency without de-correlating anything (#3279). Reuse paths above are
+	// unaffected (they return before reaching this point). loadProviderHealthSnapshot
+	// always returns a non-nil snapshot; check() fails-open when the registry is
+	// absent or stale. Symmetric with the respawn gate in session_reconciler.go.
 	provName := strings.TrimSpace(cfgAgent.Provider)
 	if provName == "" {
 		provName = strings.TrimSpace(cfgAgent.InheritedProvider)
@@ -3320,7 +3323,7 @@ func selectOrPlanPoolSessionBead(
 	if provName == "" && bp.workspace != nil {
 		provName = strings.TrimSpace(bp.workspace.Provider)
 	}
-	if healthy, present := bp.providerHealthSnapshot.check(provName); present && !healthy {
+	if status, present := bp.providerHealthSnapshot.check(provName); present && status == providerStatusRed {
 		delete(usedSlots, slot)
 		return beads.Bead{}, 0, nil, errPoolSessionCreateProviderRed
 	}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -11271,6 +11271,31 @@ func TestBuildDesiredState_ProviderRedBlocksNewPoolSessionCreate(t *testing.T) {
 			t.Fatalf("expected exactly 1 worker entry (reused active); got %d; keys=%v stderr=%s", workerEntries, mapKeys(result.State), stderr.String())
 		}
 	})
+
+	// Scenario E: registry throttled — creates proceed (throttled is treated as
+	// green on the create path; only the respawn path paces, #3279).
+	t.Run("registry throttled allows create", func(t *testing.T) {
+		cityPath := t.TempDir()
+		writeHealthFile(t, cityPath, "throttled")
+		cfg := makeCfg()
+		store := beads.NewMemStore()
+		var stderr strings.Builder
+		result := buildDesiredStateWithSessionBeads(
+			"test-city", cityPath, time.Now().UTC(),
+			cfg, runtime.NewFake(), store, nil,
+			newSessionBeadSnapshot(nil),
+			nil, &stderr,
+		)
+		workerCreates := 0
+		for _, tp := range result.State {
+			if tp.TemplateName == "worker" {
+				workerCreates++
+			}
+		}
+		if workerCreates == 0 {
+			t.Fatalf("expected worker creates when provider is throttled (create is not the storm amplifier); stderr=%s", stderr.String())
+		}
+	})
 }
 
 // TestBuildDesiredState_NamedAliasHolderSuppressesPoolStandby is the FAITHFUL

--- a/cmd/gc/provider_health_gate.go
+++ b/cmd/gc/provider_health_gate.go
@@ -41,7 +41,7 @@ const (
 // providerHealthRecord mirrors one entry in provider-health.json.
 type providerHealthRecord struct {
 	Provider string  `json:"provider"`
-	Status   string  `json:"status"`    // "healthy" | "unhealthy"
+	Status   string  `json:"status"`    // "healthy" | "throttled" | "unhealthy" (unknown → red)
 	ProbedAt float64 `json:"probed_at"` // Unix epoch seconds (float)
 }
 
@@ -57,10 +57,11 @@ type providerHealthSnapshot struct {
 	// present is false when the file is absent, unreadable, or empty.
 	// A false present means the registry is unavailable — callers fail-open.
 	present bool
-	// entries maps provider name → healthy. Only entries that exist in the
-	// file and are within TTL are stored; stale or missing entries are omitted
-	// so check() returns (true, false) for them (fail-open).
-	entries map[string]bool
+	// entries maps provider name → tri-state status (green/throttled/red).
+	// Only entries that exist in the file and are within TTL are stored; stale
+	// or missing entries are omitted so check() reports them as not-present
+	// (fail-open).
+	entries map[string]providerStatus
 }
 
 // loadProviderHealthSnapshot reads cityPath/.gc/cache/provider-health.json and
@@ -78,7 +79,7 @@ func loadProviderHealthSnapshot(cityPath string) *providerHealthSnapshot {
 	}
 	snap := &providerHealthSnapshot{
 		present: len(f.Providers) > 0,
-		entries: make(map[string]bool, len(f.Providers)),
+		entries: make(map[string]providerStatus, len(f.Providers)),
 	}
 	nowSecs := float64(time.Now().UnixNano()) / 1e9
 	for _, rec := range f.Providers {
@@ -87,36 +88,55 @@ func loadProviderHealthSnapshot(cityPath string) *providerHealthSnapshot {
 			// Stale — omit so check() fails-open for this provider.
 			continue
 		}
-		snap.entries[rec.Provider] = rec.Status == "healthy"
+		snap.entries[rec.Provider] = providerStatusFromString(rec.Status)
 	}
 	return snap
 }
 
-// check returns (healthy, registryPresent).
+// providerStatusFromString maps a provider-health.json status string to the
+// tri-state enum. "healthy"→green, "throttled"→throttled (rate-limited but
+// usable), "unhealthy"→red. Any unrecognized value (including future-writer
+// strings older readers don't know, or malformed entries) maps to red — the
+// most conservative real state — so an unknown status never silently respawns
+// into a degraded provider. The mapping is additive: pre-throttled writers
+// that only emit healthy/unhealthy keep working unchanged.
+func providerStatusFromString(status string) providerStatus {
+	switch status {
+	case "healthy":
+		return providerStatusGreen
+	case "throttled":
+		return providerStatusThrottled
+	default:
+		return providerStatusRed
+	}
+}
+
+// check returns (status, registryPresent).
 //   - registryPresent=false: file absent, unreadable, or no fresh entry for
-//     providerName. Callers MUST treat this as healthy=true (fail-open).
-//   - registryPresent=true, healthy=false: provider is red; gate respawn.
-//   - registryPresent=true, healthy=true: provider is green; allow respawn.
-func (s *providerHealthSnapshot) check(providerName string) (healthy, registryPresent bool) {
+//     providerName. Callers MUST treat this as green (fail-open).
+//   - registryPresent=true: status is the provider's fresh tri-state — green
+//     (respawn freely), throttled (respawn but paced), or red (gate respawn).
+func (s *providerHealthSnapshot) check(providerName string) (status providerStatus, registryPresent bool) {
 	if s == nil || !s.present {
-		return true, false
+		return providerStatusGreen, false
 	}
 	v, ok := s.entries[providerName]
 	if !ok {
-		return true, false // no fresh entry → fail-open
+		return providerStatusGreen, false // no fresh entry → fail-open
 	}
 	return v, true
 }
 
-// healthyProviders returns all provider names that are confirmed healthy in
-// this snapshot. Used to flush green ticks after the Phase-2 loop.
+// healthyProviders returns all provider names that are confirmed green in this
+// snapshot. Used to flush green ticks after the Phase-2 loop so a recovered
+// provider's red/throttled episode state is cleared.
 func (s *providerHealthSnapshot) healthyProviders() []string {
 	if s == nil {
 		return nil
 	}
 	out := make([]string, 0, len(s.entries))
-	for p, healthy := range s.entries {
-		if healthy {
+	for p, status := range s.entries {
+		if status == providerStatusGreen {
 			out = append(out, p)
 		}
 	}
@@ -129,17 +149,24 @@ type providerStatus int
 
 const (
 	providerStatusGreen providerStatus = iota
+	// providerStatusThrottled — provider is rate-limited but credentials are
+	// valid: respawns are allowed but paced (staggered) rather than skipped.
+	providerStatusThrottled
+	// providerStatusRed — provider is unhealthy/unreachable: respawns are
+	// skipped entirely until it recovers. Highest (most conservative) value so
+	// unknown statuses map here.
 	providerStatusRed
 )
 
-// providerEpisodeState tracks one provider's red/green episode.
-// A new episode begins on each green→red transition; AlertSent resets
-// on green so the next red episode fires a fresh alert.
+// providerEpisodeState tracks one provider's non-green (red or throttled)
+// episode. A new episode begins on each transition into a different status;
+// AlertSent resets on green so the next episode fires a fresh alert.
 type providerEpisodeState struct {
-	Status       providerStatus
-	EpisodeID    string
-	AlertSent    bool
-	RedSince     time.Time
+	Status    providerStatus
+	EpisodeID string
+	AlertSent bool
+	// Since is the start of the current non-green episode (red or throttled).
+	Since        time.Time
 	SessionCount int
 }
 
@@ -161,28 +188,53 @@ func newProviderHealthGate() *providerHealthGate {
 func (g *providerHealthGate) recordRedSkip(
 	providerName string,
 	now time.Time,
-	emitAlert func(provider, episodeID string, redSince time.Time, sessionCount int),
+	emitAlert func(provider, episodeID string, since time.Time, sessionCount int),
+) {
+	g.recordNonGreenEpisode(providerName, providerStatusRed, now, emitAlert)
+}
+
+// recordThrottledTick notes that providerName is throttled this tick and a
+// session respawn was paced (staggered, not skipped). Like recordRedSkip it
+// fires emitAlert exactly once per episode. Safe to call concurrently.
+func (g *providerHealthGate) recordThrottledTick(
+	providerName string,
+	now time.Time,
+	emitAlert func(provider, episodeID string, since time.Time, sessionCount int),
+) {
+	g.recordNonGreenEpisode(providerName, providerStatusThrottled, now, emitAlert)
+}
+
+// recordNonGreenEpisode tracks a red or throttled episode for providerName.
+// Entering a status different from the current one opens a fresh episode (new
+// ID, reset alert, Since=now, count=1); staying in the same status increments
+// the parked/paced session count. emitAlert fires exactly once per episode.
+func (g *providerHealthGate) recordNonGreenEpisode(
+	providerName string,
+	status providerStatus,
+	now time.Time,
+	emitAlert func(provider, episodeID string, since time.Time, sessionCount int),
 ) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	s := g.episodeFor(providerName)
-	if s.Status == providerStatusGreen {
-		s.Status = providerStatusRed
+	if s.Status != status {
+		s.Status = status
 		s.EpisodeID = uuid.New().String()
 		s.AlertSent = false
-		s.RedSince = now
+		s.Since = now
 		s.SessionCount = 1
 	} else {
 		s.SessionCount++
 	}
 	if !s.AlertSent {
-		emitAlert(providerName, s.EpisodeID, s.RedSince, s.SessionCount)
+		emitAlert(providerName, s.EpisodeID, s.Since, s.SessionCount)
 		s.AlertSent = true
 	}
 }
 
-// recordGreenTick clears red state so the next red transition opens a fresh
-// episode and fires a new alert. Called once per tick per healthy provider.
+// recordGreenTick clears non-green state so the next red/throttled transition
+// opens a fresh episode and fires a new alert. Called once per tick per green
+// provider.
 func (g *providerHealthGate) recordGreenTick(providerName string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -205,21 +257,32 @@ func (g *providerHealthGate) episodeFor(providerName string) *providerEpisodeSta
 // --- alert emission ---
 
 // emitProviderHealthGateAlert writes the ADR-0013 escalation alert to stdout
-// and records a ProviderHealthGateAlert event. Called once per episode.
+// and records a ProviderHealthGateAlert event. Called once per episode. status
+// selects the wording: RED parks respawns ("paused"); THROTTLED keeps respawning
+// but staggers them ("paced"). Any other status falls back to the RED wording.
 func emitProviderHealthGateAlert(
 	rec events.Recorder,
 	stdout io.Writer,
+	status providerStatus,
 	provider, episodeID string,
-	redSince time.Time,
+	since time.Time,
 	sessionCount int,
 ) {
+	action := fmt.Sprintf("Respawn for %s sessions paused", provider)
+	statusLabel := "red"
+	countLabel := "sessions_parked"
+	if status == providerStatusThrottled {
+		action = fmt.Sprintf("Respawn for %s sessions paced (staggered to avoid a synchronized retry storm)", provider)
+		statusLabel = "throttled"
+		countLabel = "sessions_paced"
+	}
 	msg := fmt.Sprintf(
-		"Provider health gate OPEN: provider=%s episode=%s since=%s sessions_parked=%d. "+
-			"Respawn for %s sessions paused. "+
+		"Provider health gate OPEN: provider=%s status=%s episode=%s since=%s %s=%d. "+
+			"%s. "+
 			"Resume is automatic when provider returns green. "+
 			"Verify token with: gc provider status %s",
-		provider, episodeID, redSince.UTC().Format(time.RFC3339), sessionCount,
-		provider, provider,
+		provider, statusLabel, episodeID, since.UTC().Format(time.RFC3339), countLabel, sessionCount,
+		action, provider,
 	)
 	fmt.Fprintln(stdout, msg) //nolint:errcheck
 	if rec == nil {
@@ -227,8 +290,9 @@ func emitProviderHealthGateAlert(
 	}
 	payload, _ := json.Marshal(map[string]any{
 		"provider":      provider,
+		"status":        statusLabel,
 		"episode_id":    episodeID,
-		"red_since":     redSince.UTC().Format(time.RFC3339),
+		"since":         since.UTC().Format(time.RFC3339),
 		"session_count": sessionCount,
 	})
 	rec.Record(events.Event{

--- a/cmd/gc/provider_health_gate_test.go
+++ b/cmd/gc/provider_health_gate_test.go
@@ -32,12 +32,12 @@ func TestSnapshotCheck_HealthyProvider(t *testing.T) {
 	dir := t.TempDir()
 	writeHealthCache(t, dir, "zai", "healthy", nowSecs())
 	snap := loadProviderHealthSnapshot(dir)
-	healthy, present := snap.check("zai")
+	status, present := snap.check("zai")
 	if !present {
 		t.Fatal("expected registryPresent=true")
 	}
-	if !healthy {
-		t.Fatal("expected healthy=true")
+	if status != providerStatusGreen {
+		t.Fatalf("expected green, got %v", status)
 	}
 }
 
@@ -45,25 +45,25 @@ func TestSnapshotCheck_UnhealthyProvider(t *testing.T) {
 	dir := t.TempDir()
 	writeHealthCache(t, dir, "zai", "unhealthy", nowSecs())
 	snap := loadProviderHealthSnapshot(dir)
-	healthy, present := snap.check("zai")
+	status, present := snap.check("zai")
 	if !present {
 		t.Fatal("expected registryPresent=true")
 	}
-	if healthy {
-		t.Fatal("expected healthy=false")
+	if status != providerStatusRed {
+		t.Fatalf("expected red, got %v", status)
 	}
 }
 
 func TestSnapshotCheck_RegistryAbsent(t *testing.T) {
 	dir := t.TempDir() // no file
 	snap := loadProviderHealthSnapshot(dir)
-	healthy, present := snap.check("zai")
+	status, present := snap.check("zai")
 	if present {
 		t.Fatal("expected registryPresent=false when file absent")
 	}
-	if !healthy {
+	if status != providerStatusGreen {
 		// fail-open: missing registry → treat as green
-		t.Fatal("expected healthy=true (fail-open) when registry absent")
+		t.Fatal("expected green (fail-open) when registry absent")
 	}
 }
 
@@ -72,12 +72,12 @@ func TestSnapshotCheck_StaleEntry(t *testing.T) {
 	staleAt := nowSecs() - (providerHealthTTL.Seconds() + 10)
 	writeHealthCache(t, dir, "zai", "unhealthy", staleAt)
 	snap := loadProviderHealthSnapshot(dir)
-	healthy, present := snap.check("zai")
+	status, present := snap.check("zai")
 	if present {
 		t.Fatal("expected registryPresent=false for stale entry")
 	}
-	if !healthy {
-		t.Fatal("expected healthy=true (fail-open) for stale entry")
+	if status != providerStatusGreen {
+		t.Fatal("expected green (fail-open) for stale entry")
 	}
 }
 
@@ -85,12 +85,12 @@ func TestSnapshotCheck_UnknownProvider(t *testing.T) {
 	dir := t.TempDir()
 	writeHealthCache(t, dir, "anthropic", "healthy", nowSecs())
 	snap := loadProviderHealthSnapshot(dir)
-	healthy, present := snap.check("zai") // different provider
+	status, present := snap.check("zai") // different provider
 	if present {
 		t.Fatal("expected registryPresent=false for unknown provider")
 	}
-	if !healthy {
-		t.Fatal("expected healthy=true (fail-open) for unknown provider")
+	if status != providerStatusGreen {
+		t.Fatal("expected green (fail-open) for unknown provider")
 	}
 }
 
@@ -115,7 +115,130 @@ func TestSnapshotHealthyProviders(t *testing.T) {
 	}
 }
 
+func TestSnapshotCheck_ThrottledProvider(t *testing.T) {
+	dir := t.TempDir()
+	writeHealthCache(t, dir, "zai", "throttled", nowSecs())
+	snap := loadProviderHealthSnapshot(dir)
+	status, present := snap.check("zai")
+	if !present {
+		t.Fatal("expected registryPresent=true")
+	}
+	if status != providerStatusThrottled {
+		t.Fatalf("expected throttled, got %v", status)
+	}
+	// Throttled is not green, so it is not flushed as a healthy provider.
+	if got := snap.healthyProviders(); len(got) != 0 {
+		t.Fatalf("healthyProviders = %v, want none (throttled is not green)", got)
+	}
+}
+
+func TestSnapshotCheck_UnknownStatusFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	// A future/garbage status string an older reader doesn't understand must
+	// map to the most conservative real state (red), never silently green.
+	writeHealthCache(t, dir, "zai", "quux-not-a-real-status", nowSecs())
+	snap := loadProviderHealthSnapshot(dir)
+	status, present := snap.check("zai")
+	if !present {
+		t.Fatal("expected registryPresent=true for a fresh (if unknown) entry")
+	}
+	if status != providerStatusRed {
+		t.Fatalf("unknown status mapped to %v, want red (fail-closed-safe)", status)
+	}
+}
+
+func TestProviderStatusFromString_Mapping(t *testing.T) {
+	cases := map[string]providerStatus{
+		"healthy":   providerStatusGreen,
+		"throttled": providerStatusThrottled,
+		"unhealthy": providerStatusRed,
+		"":          providerStatusRed,
+		"weird":     providerStatusRed,
+	}
+	for in, want := range cases {
+		if got := providerStatusFromString(in); got != want {
+			t.Errorf("providerStatusFromString(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestSnapshot_ThrottledJSONRoundTripIsAdditive confirms a file mixing the new
+// throttled status with the legacy healthy/unhealthy ones decodes correctly —
+// the schema extension is additive and pre-throttled writers keep working.
+func TestSnapshot_ThrottledJSONRoundTripIsAdditive(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, ".gc", "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdirAll: %v", err)
+	}
+	data, _ := json.Marshal(map[string]any{"providers": []any{
+		map[string]any{"provider": "green-prov", "status": "healthy", "probed_at": nowSecs()},
+		map[string]any{"provider": "throttled-prov", "status": "throttled", "probed_at": nowSecs()},
+		map[string]any{"provider": "red-prov", "status": "unhealthy", "probed_at": nowSecs()},
+	}})
+	if err := os.WriteFile(filepath.Join(cacheDir, "provider-health.json"), data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	snap := loadProviderHealthSnapshot(dir)
+	for prov, want := range map[string]providerStatus{
+		"green-prov":     providerStatusGreen,
+		"throttled-prov": providerStatusThrottled,
+		"red-prov":       providerStatusRed,
+	} {
+		got, present := snap.check(prov)
+		if !present || got != want {
+			t.Errorf("check(%q) = (%v, present=%v), want (%v, true)", prov, got, present, want)
+		}
+	}
+}
+
 // --- providerHealthGate episode-state tests ---
+
+func TestGate_ThrottledTickAlertsOncePerEpisode(t *testing.T) {
+	gate := newProviderHealthGate()
+	now := time.Now()
+	alerts := 0
+	emit := func(_, _ string, _ time.Time, _ int) { alerts++ }
+
+	for i := 0; i < 5; i++ {
+		gate.recordThrottledTick("zai", now, emit)
+	}
+	if alerts != 1 {
+		t.Fatalf("throttled episode: expected 1 alert, got %d", alerts)
+	}
+
+	gate.mu.Lock()
+	s := gate.episodes["zai"]
+	gate.mu.Unlock()
+	if s.Status != providerStatusThrottled {
+		t.Fatalf("episode status = %v, want throttled", s.Status)
+	}
+	if s.SessionCount != 5 {
+		t.Fatalf("SessionCount = %d, want 5 (one per pace)", s.SessionCount)
+	}
+
+	// Recovery clears the episode; a later red opens a NEW episode → new alert.
+	gate.recordGreenTick("zai")
+	gate.recordRedSkip("zai", now, emit)
+	if alerts != 2 {
+		t.Fatalf("after green→red: expected 2 total alerts, got %d", alerts)
+	}
+}
+
+// TestGate_ThrottledToRedOpensNewEpisode pins that a status change between two
+// non-green states still opens a fresh episode (new alert), not a silent merge.
+func TestGate_ThrottledToRedOpensNewEpisode(t *testing.T) {
+	gate := newProviderHealthGate()
+	now := time.Now()
+	alerts := 0
+	emit := func(_, _ string, _ time.Time, _ int) { alerts++ }
+
+	gate.recordThrottledTick("zai", now, emit) // episode 1 (throttled)
+	gate.recordRedSkip("zai", now, emit)       // episode 2 (red)
+	if alerts != 2 {
+		t.Fatalf("throttled→red expected 2 alerts (distinct episodes), got %d", alerts)
+	}
+}
 
 func TestGate_NoRespawnWhileRed(t *testing.T) {
 	dir := t.TempDir()
@@ -123,9 +246,9 @@ func TestGate_NoRespawnWhileRed(t *testing.T) {
 	gate := newProviderHealthGate()
 
 	snap := loadProviderHealthSnapshot(dir)
-	healthy, present := snap.check("zai")
-	if !present || healthy {
-		t.Fatalf("precondition: expected red present, got healthy=%v present=%v", healthy, present)
+	status, present := snap.check("zai")
+	if !present || status != providerStatusRed {
+		t.Fatalf("precondition: expected red present, got status=%v present=%v", status, present)
 	}
 
 	alerts := 0
@@ -213,13 +336,13 @@ func TestGate_WakeBudgetNotConsumedOnRedSkip(t *testing.T) {
 func TestGate_FailOpenRegistryUnavailable(t *testing.T) {
 	dir := t.TempDir() // no file
 	snap := loadProviderHealthSnapshot(dir)
-	healthy, present := snap.check("zai")
+	status, present := snap.check("zai")
 	if present {
 		t.Fatal("expected registryPresent=false")
 	}
 	// Caller should proceed as green (fail-open); no gate interaction needed.
-	if !healthy {
-		t.Fatal("expected healthy=true (fail-open) when registry absent")
+	if status != providerStatusGreen {
+		t.Fatal("expected green (fail-open) when registry absent")
 	}
 }
 
@@ -229,9 +352,9 @@ func TestGate_NoChangeBehaviorForGreenProvider(t *testing.T) {
 	gate := newProviderHealthGate()
 	snap := loadProviderHealthSnapshot(dir)
 
-	healthy, present := snap.check("zai")
-	if !present || !healthy {
-		t.Fatalf("precondition: expected healthy present, got healthy=%v present=%v", healthy, present)
+	status, present := snap.check("zai")
+	if !present || status != providerStatusGreen {
+		t.Fatalf("precondition: expected green present, got status=%v present=%v", status, present)
 	}
 	// A green provider records a green tick; no alert.
 	gate.recordGreenTick("zai")
@@ -273,14 +396,31 @@ func TestGate_Concurrent(t *testing.T) {
 func TestEmitProviderHealthGateAlert_Format(t *testing.T) {
 	var captured string
 	w := &capWriter{fn: func(b []byte) { captured += string(b) }}
-	redSince := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	since := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
 
-	emitProviderHealthGateAlert(nil, w, "zai", "ep-123", redSince, 3)
+	emitProviderHealthGateAlert(nil, w, providerStatusRed, "zai", "ep-123", since, 3)
 
-	for _, want := range []string{"zai", "ep-123", "2026-06-02T12:00:00Z", "sessions_parked=3"} {
+	for _, want := range []string{"zai", "ep-123", "2026-06-02T12:00:00Z", "sessions_parked=3", "status=red", "paused"} {
 		if !strings.Contains(captured, want) {
 			t.Errorf("alert message missing %q\ngot: %s", want, captured)
 		}
+	}
+}
+
+func TestEmitProviderHealthGateAlert_ThrottledFormat(t *testing.T) {
+	var captured string
+	w := &capWriter{fn: func(b []byte) { captured += string(b) }}
+	since := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	emitProviderHealthGateAlert(nil, w, providerStatusThrottled, "zai", "ep-9", since, 2)
+
+	for _, want := range []string{"zai", "ep-9", "status=throttled", "sessions_paced=2", "paced"} {
+		if !strings.Contains(captured, want) {
+			t.Errorf("throttled alert message missing %q\ngot: %s", want, captured)
+		}
+	}
+	if strings.Contains(captured, "paused") {
+		t.Errorf("throttled alert should not say 'paused'\ngot: %s", captured)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -6022,8 +6022,13 @@ func TestExecutePreparedStartWave_RateLimitStartupDeathQuarantinesWithoutWakeFai
 	if err != nil {
 		t.Fatalf("quarantined_until parse: %v", err)
 	}
-	if want := clk.Now().Add(defaultRateLimitQuarantineDuration); !qUntil.Equal(want) {
-		t.Fatalf("quarantined_until = %s, want %s", qUntil.Format(time.RFC3339), want.Format(time.RFC3339))
+	// #3279: jittered per-session hold (floor + deterministic full jitter).
+	if want := rateLimitQuarantineUntil(got.ID, clk.Now()).Truncate(time.Second); !qUntil.Equal(want) {
+		t.Fatalf("quarantined_until = %s, want %s (deterministic per-session jitter)", qUntil.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+	floor := clk.Now().Add(defaultRateLimitQuarantineDuration)
+	if qUntil.Before(floor) || !qUntil.Before(floor.Add(rateLimitQuarantineJitter)) {
+		t.Fatalf("quarantined_until = %s, want in [%s, %s)", qUntil.Format(time.RFC3339), floor.Format(time.RFC3339), floor.Add(rateLimitQuarantineJitter).Format(time.RFC3339))
 	}
 }
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -13,6 +13,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"strconv"
@@ -669,20 +670,65 @@ func clearLastWokeAt(session *beads.Bead, store beads.Store) {
 
 // recordRateLimitQuarantine backs off a session that exited into a provider
 // rate-limit screen without treating the exit as a crash or resetting its
-// conversation metadata.
+// conversation metadata. The hold is jittered per session so a herd that hit
+// the same provider limit on one tick does not wake in lockstep (#3279).
 func recordRateLimitQuarantine(session *beads.Bead, store beads.Store, clk clock.Clock) error {
+	return writeRateLimitHold(session, store, rateLimitQuarantineUntil(session.ID, clk.Now()))
+}
+
+// recordProviderThrottlePace staggers a respawn when the provider-health
+// registry reports the provider as THROTTLED: the session is held for a short,
+// per-session jittered window (no rate-limit floor) so parked pool sessions
+// spread their respawns instead of flooding back on a single tick (#3279).
+func recordProviderThrottlePace(session *beads.Bead, store beads.Store, clk clock.Clock) error {
+	now := clk.Now()
+	return writeRateLimitHold(session, store, now.Add(deterministicFullJitter(session.ID, now, providerThrottlePaceSpread)))
+}
+
+// writeRateLimitHold persists a rate-limit hold (StateAsleep,
+// sleep_reason="rate_limit", quarantined_until=until) and mirrors the patch
+// onto the in-memory bead. Shared by the hard rate-limit and throttled-pace
+// paths; both keep the pool slot (rate_limit is not a freeable sleep reason).
+func writeRateLimitHold(session *beads.Bead, store beads.Store, until time.Time) error {
 	if session.Metadata == nil {
 		session.Metadata = make(map[string]string)
 	}
-	batch := sessionpkg.RateLimitQuarantinePatch(clk.Now().Add(defaultRateLimitQuarantineDuration))
+	batch := sessionpkg.RateLimitQuarantinePatch(until)
 	if err := store.SetMetadataBatch(session.ID, batch); err != nil {
-		fmt.Fprintf(os.Stderr, "recordRateLimitQuarantine: SetMetadataBatch %s: %v\n", session.ID, err) //nolint:errcheck
+		fmt.Fprintf(os.Stderr, "writeRateLimitHold: SetMetadataBatch %s: %v\n", session.ID, err) //nolint:errcheck
 		return err
 	}
 	for k, v := range batch {
 		session.Metadata[k] = v
 	}
 	return nil
+}
+
+// rateLimitQuarantineUntil computes a rate-limited session's wake instant:
+// the defaultRateLimitQuarantineDuration floor plus a deterministic
+// per-session full-jitter offset in [0, rateLimitQuarantineJitter). Two
+// sessions quarantined on the same tick get distinct wake instants because the
+// offset is keyed on session ID, de-correlating the herd (#3279).
+func rateLimitQuarantineUntil(sessionID string, now time.Time) time.Time {
+	return now.Add(defaultRateLimitQuarantineDuration + deterministicFullJitter(sessionID, now, rateLimitQuarantineJitter))
+}
+
+// deterministicFullJitter returns a full-jitter duration uniformly in
+// [0, spread), derived from (key, now) via FNV-1a so the result is stable for
+// a given (session, tick) yet varies across sessions and across ticks — no
+// shared RNG, so it is free of the data races a process-wide math/rand would
+// invite (#3279 themes #16/#18). spread <= 0 disables jitter (returns 0),
+// preserving deterministic back-compat. Follows the same FNV+modulo idiom as
+// deterministicMaxSessionAgeOffset (which hashes its own template/session keys).
+func deterministicFullJitter(key string, now time.Time, spread time.Duration) time.Duration {
+	if spread <= 0 {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(now.UTC().Format(time.RFC3339Nano)))
+	return time.Duration(h.Sum64() % uint64(spread))
 }
 
 // recordWakeFailure increments wake_attempts and quarantines if threshold exceeded.

--- a/cmd/gc/session_reconcile_jitter_test.go
+++ b/cmd/gc/session_reconcile_jitter_test.go
@@ -1,0 +1,133 @@
+// Tests for the #3279 fix: de-correlated (full-jitter) rate-limit quarantine
+// and THROTTLED-provider respawn pacing. The regression was a synchronized
+// retry storm — sessions re-quarantined in lockstep and respawned together on
+// the single tick a provider cleared. These tests pin the de-correlation at the
+// level of the building blocks the reconciler wires together (the gate switch
+// in session_reconciler.go composes recordProviderThrottlePace with the
+// snapshot tri-state and the anonymous-pool guard, each covered here).
+
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/clock"
+)
+
+func TestDeterministicFullJitter_DisabledAndBounds(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+
+	if got := deterministicFullJitter("s1", now, 0); got != 0 {
+		t.Fatalf("spread=0 should disable jitter, got %s", got)
+	}
+	if got := deterministicFullJitter("s1", now, -time.Minute); got != 0 {
+		t.Fatalf("negative spread should disable jitter, got %s", got)
+	}
+
+	spread := 30 * time.Minute
+	for _, id := range []string{"a", "b", "c", "d", "e"} {
+		got := deterministicFullJitter(id, now, spread)
+		if got < 0 || got >= spread {
+			t.Fatalf("jitter(%q) = %s, want in [0, %s)", id, got, spread)
+		}
+	}
+
+	// Stable for the same (key, now): a given session/tick re-derives the same
+	// offset (no hidden RNG state).
+	if a, b := deterministicFullJitter("s1", now, spread), deterministicFullJitter("s1", now, spread); a != b {
+		t.Fatalf("offset not stable for same key+now: %s vs %s", a, b)
+	}
+}
+
+func TestRateLimitQuarantineUntil_DeCorrelatesHerd(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	floor := now.Add(defaultRateLimitQuarantineDuration)
+	ceil := floor.Add(rateLimitQuarantineJitter)
+
+	// Discriminating assertion: two sessions quarantined on the SAME tick must
+	// get DISTINCT wake instants. This fails iff the durations are equal — the
+	// old flat-30m lockstep behavior the regression describes.
+	a := rateLimitQuarantineUntil("session-a", now)
+	b := rateLimitQuarantineUntil("session-b", now)
+	if a.Equal(b) {
+		t.Fatalf("two sessions on the same tick got identical wake instant %s — herd not de-correlated", a)
+	}
+	for _, u := range []time.Time{a, b} {
+		if u.Before(floor) || !u.Before(ceil) {
+			t.Fatalf("wake instant %s outside [%s, %s)", u, floor, ceil)
+		}
+	}
+}
+
+// TestRecordProviderThrottlePace_StaggersWithinWindow is the respawn-gate's
+// THROTTLED pacing assertion at the building-block level: N sessions paced on
+// the same tick get wake instants spread across [now, now+spread) rather than
+// all on this tick — the de-correlation the gate relies on.
+func TestRecordProviderThrottlePace_StaggersWithinWindow(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	untils := make([]time.Time, 0, 3)
+	for _, id := range []string{"p1", "p2", "p3"} {
+		store := newTestStore()
+		session := makeBead(id, map[string]string{"state": "active"})
+		if err := recordProviderThrottlePace(&session, store, clk); err != nil {
+			t.Fatalf("recordProviderThrottlePace(%s): %v", id, err)
+		}
+		if got := session.Metadata["sleep_reason"]; got != "rate_limit" {
+			t.Fatalf("sleep_reason = %q, want rate_limit", got)
+		}
+		if got := session.Metadata["state"]; got != "asleep" {
+			t.Fatalf("state = %q, want asleep", got)
+		}
+		u, err := time.Parse(time.RFC3339, session.Metadata["quarantined_until"])
+		if err != nil {
+			t.Fatalf("quarantined_until parse: %v", err)
+		}
+		if u.Before(now) || !u.Before(now.Add(providerThrottlePaceSpread)) {
+			t.Fatalf("paced until %s outside [%s, %s)", u, now, now.Add(providerThrottlePaceSpread))
+		}
+		untils = append(untils, u)
+	}
+	// At least two of the three differ — the pace staggers the herd rather than
+	// holding everyone to one instant.
+	if untils[0].Equal(untils[1]) && untils[1].Equal(untils[2]) {
+		t.Fatalf("throttle pace produced identical holds %v — not staggered", untils)
+	}
+}
+
+// TestRecordProviderThrottlePace_PropagatesWriteError pins theme #1: the pace
+// path must surface a metadata-write failure, never swallow it.
+func TestRecordProviderThrottlePace_PropagatesWriteError(t *testing.T) {
+	clk := &clock.Fake{Time: time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)}
+	store := newTestStore()
+	store.metadataBatchErr = errors.New("batch failed")
+	session := makeBead("p1", map[string]string{"state": "active"})
+	if err := recordProviderThrottlePace(&session, store, clk); err == nil {
+		t.Fatal("expected the write error to propagate")
+	}
+}
+
+// TestProviderThrottlePace_OnlyAnonymousPoolSessions documents the theme #4
+// guard the gate applies: the reconciler paces only anonymous pool sessions
+// (namedSessionIdentity()==""), never named / infrastructure ones.
+func TestProviderThrottlePace_OnlyAnonymousPoolSessions(t *testing.T) {
+	pool := makeBead("pool-1", map[string]string{
+		"session_name": PoolSessionName("repo/worker", "pool-1"),
+		"template":     "repo/worker",
+	})
+	if id := namedSessionIdentity(pool); id != "" {
+		t.Fatalf("pool session identity = %q, want empty (anonymous → paceable)", id)
+	}
+
+	named := makeBead("ctrl-1", map[string]string{
+		"session_name":               "trace-town-dispatcher",
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "dispatcher",
+	})
+	if id := namedSessionIdentity(named); id == "" {
+		t.Fatal("named/infrastructure session identity is empty; it would be paced under throttle (theme #4 violation)")
+	}
+}

--- a/cmd/gc/session_reconcile_ratelimit_test.go
+++ b/cmd/gc/session_reconcile_ratelimit_test.go
@@ -66,8 +66,16 @@ func TestCheckStability_RateLimitScreen_DoesNotCountAsCrash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("quarantined_until parse: %v", err)
 	}
-	if want := now.Add(defaultRateLimitQuarantineDuration); !qUntil.Equal(want) {
-		t.Errorf("quarantined_until = %s, want %s", qUntil.Format(time.RFC3339), want.Format(time.RFC3339))
+	// #3279: the hold is the 30m floor plus a deterministic per-session
+	// full-jitter offset, so it must equal rateLimitQuarantineUntil and fall
+	// within [floor, floor+jitter).
+	if want := rateLimitQuarantineUntil(session.ID, now).Truncate(time.Second); !qUntil.Equal(want) {
+		t.Errorf("quarantined_until = %s, want %s (deterministic per-session jitter)", qUntil.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+	floor := now.Add(defaultRateLimitQuarantineDuration)
+	ceil := floor.Add(rateLimitQuarantineJitter)
+	if qUntil.Before(floor) || !qUntil.Before(ceil) {
+		t.Errorf("quarantined_until = %s, want in [%s, %s)", qUntil.Format(time.RFC3339), floor.Format(time.RFC3339), ceil.Format(time.RFC3339))
 	}
 
 	if gotLines != rateLimitPeekLines {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1750,11 +1750,13 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				}
 				providerHealthy := true
 				if !exempt && !holdsClaim && tp.ResolvedProvider != nil {
-					// Reuse the per-tick provider-health snapshot (#2962). Gate 1
-					// (provider RED) takes precedence: never recycle a session whose
-					// provider is red. Fail-open — absent/stale registry → healthy.
-					if h, present := phSnap.check(tp.ResolvedProvider.Name); present {
-						providerHealthy = h
+					// Reuse the per-tick provider-health snapshot (#2962). A
+					// non-green provider (RED or THROTTLED) takes precedence: never
+					// recycle a session whose provider is rate-limited or down —
+					// recycling cannot make progress and only adds churn. Fail-open —
+					// absent/stale registry → healthy.
+					if status, present := phSnap.check(tp.ResolvedProvider.Name); present {
+						providerHealthy = status == providerStatusGreen
 					}
 				}
 				if sessionProgressStalled(threshold, holdsClaim, providerHealthy, exempt, lastActivity, clk.Now()) {
@@ -2497,19 +2499,23 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					}
 				}
 			}
-			// Provider-health gate (ADR-0013 A1 M3a): skip respawn when the
-			// provider is red. Does NOT consume the wake budget (no append to
+			// Provider-health gate (ADR-0013 A1 M3a): RED skips respawn until the
+			// provider recovers; THROTTLED still respawns but paces (staggers)
+			// anonymous pool sessions so the herd does not re-saturate the next
+			// provider bucket in lockstep (#3279); GREEN respawns freely. The
+			// gate never consumes the wake budget on a skip/pace (no append to
 			// startCandidates). Episode tracking fires exactly one alert per
-			// red episode via emitProviderHealthGateAlert.
+			// red/throttled episode via emitProviderHealthGateAlert.
 			if gate != nil && target.tp.ResolvedProvider != nil {
 				phProvider := target.tp.ResolvedProvider.Name
-				phHealthy, phPresent := phSnap.check(phProvider)
-				if !phPresent {
+				phStatus, phPresent := phSnap.check(phProvider)
+				switch {
+				case !phPresent:
 					// Registry absent or no fresh entry — fail-open, log once per provider per tick.
 					fmt.Fprintf(stderr, "session reconciler: provider-health registry unavailable for %q; treating as green\n", phProvider) //nolint:errcheck
-				} else if !phHealthy {
+				case phStatus == providerStatusRed:
 					gate.recordRedSkip(phProvider, clk.Now().UTC(), func(p, epID string, since time.Time, count int) {
-						emitProviderHealthGateAlert(rec, stdout, p, epID, since, count)
+						emitProviderHealthGateAlert(rec, stdout, providerStatusRed, p, epID, since, count)
 					})
 					if trace != nil {
 						trace.recordDecision("reconciler.session.provider_health_gate", target.tp.TemplateName, name, "provider_red", "respawn_skipped", traceRecordPayload{
@@ -2517,6 +2523,33 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						}, nil, "")
 					}
 					continue // skip startCandidates; wake budget is NOT consumed
+				case phStatus == providerStatusThrottled && namedSessionIdentity(*target.session) == "":
+					// Throttled + anonymous pool session: pace the respawn with a
+					// short per-session jittered hold so parked pool siblings spread
+					// across ticks instead of flooding back together. Infrastructure
+					// and other named sessions are NOT paced (#3279 theme #4) — they
+					// hit the default case and respawn freely.
+					if err := recordProviderThrottlePace(target.session, store, clk); err != nil {
+						// Hold not written — do not record the episode/alert (it
+						// would claim a session was paced when none was); the
+						// continue still defers this tick and the write retries next.
+						fmt.Fprintf(stderr, "session reconciler: pacing throttled respawn for %s: %v\n", name, err) //nolint:errcheck
+					} else {
+						gate.recordThrottledTick(phProvider, clk.Now().UTC(), func(p, epID string, since time.Time, count int) {
+							emitProviderHealthGateAlert(rec, stdout, providerStatusThrottled, p, epID, since, count)
+						})
+						if trace != nil {
+							trace.recordDecision("reconciler.session.provider_health_gate", target.tp.TemplateName, name, "provider_throttled", "respawn_paced", traceRecordPayload{
+								"provider": phProvider,
+							}, nil, "")
+						}
+					}
+					continue // skip startCandidates this tick; the jittered hold reschedules it
+				default:
+					// GREEN, or THROTTLED for a named/infrastructure session:
+					// respawn freely. No-op here so the wake proceeds to
+					// startCandidates below; this default makes the fallthrough
+					// intentional (a future case must not silently swallow it).
 				}
 			}
 

--- a/cmd/gc/session_reconciler_progress_test.go
+++ b/cmd/gc/session_reconciler_progress_test.go
@@ -235,6 +235,17 @@ func TestReconcileSessionBeads_ProgressStallDoesNotRecycleExemptOrSafeSessions(t
 			},
 		},
 		{
+			name: "provider health throttled",
+			cityPath: func(t *testing.T) string {
+				dir := t.TempDir()
+				// A throttled provider is also non-green: a stalled session must
+				// not be recycled, since the stall is the provider's rate limit,
+				// not the session's fault (#3279).
+				writeHealthCache(t, dir, "zai", "throttled", nowSecs())
+				return dir
+			},
+		},
+		{
 			name: "recent provider activity",
 			configure: func(_ *testing.T, env *restartRequestTestEnv, _ *beads.Bead, sessionName string) {
 				env.sp.SetActivity(sessionName, env.clk.Now().Add(-time.Minute))

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -4046,8 +4046,13 @@ func TestReconcileSessionBeads_RateLimitScreenQuarantinesBeforeHeal(t *testing.T
 	if err != nil {
 		t.Fatalf("quarantined_until parse: %v", err)
 	}
-	if want := env.clk.Now().Add(defaultRateLimitQuarantineDuration); !qUntil.Equal(want) {
-		t.Fatalf("quarantined_until = %s, want %s", qUntil.Format(time.RFC3339), want.Format(time.RFC3339))
+	// #3279: jittered per-session hold (floor + deterministic full jitter).
+	if want := rateLimitQuarantineUntil(got.ID, env.clk.Now()).Truncate(time.Second); !qUntil.Equal(want) {
+		t.Fatalf("quarantined_until = %s, want %s (deterministic per-session jitter)", qUntil.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+	floor := env.clk.Now().Add(defaultRateLimitQuarantineDuration)
+	if qUntil.Before(floor) || !qUntil.Before(floor.Add(rateLimitQuarantineJitter)) {
+		t.Fatalf("quarantined_until = %s, want in [%s, %s)", qUntil.Format(time.RFC3339), floor.Format(time.RFC3339), floor.Add(rateLimitQuarantineJitter).Format(time.RFC3339))
 	}
 	if got.Metadata["session_key"] != "keep-session" {
 		t.Fatalf("session_key = %q, want preserved", got.Metadata["session_key"])

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -278,12 +278,33 @@ const (
 	// after exceeding max wake failures.
 	defaultQuarantineDuration = 5 * time.Minute
 
-	// defaultRateLimitQuarantineDuration is how long to hold a session when
-	// the pane shows a provider rate-limit screen. This is intentionally
-	// longer than crash-loop quarantine because immediate retries cannot help;
-	// 30m limits noisy respawn cycles for common minute-scale provider limits
-	// while still re-detecting and re-quarantining during longer windows.
+	// defaultRateLimitQuarantineDuration is the floor of the hold applied to a
+	// session when the pane shows a provider rate-limit screen. This is
+	// intentionally longer than crash-loop quarantine because immediate retries
+	// cannot help; 30m limits noisy respawn cycles for common minute-scale
+	// provider limits while still re-detecting and re-quarantining during
+	// longer windows. The effective hold is this floor plus a per-session
+	// full-jitter offset (rateLimitQuarantineJitter) so a herd of sessions
+	// quarantined in the same tick does not wake in lockstep (#3279).
 	defaultRateLimitQuarantineDuration = 30 * time.Minute
+
+	// rateLimitQuarantineJitter is the full-jitter spread added on top of
+	// defaultRateLimitQuarantineDuration. Each rate-limited session's wake
+	// instant is randomized uniformly in [floor, floor+jitter) via a
+	// deterministic per-session offset (deterministicFullJitter), so a herd
+	// that hit the same provider limit on one tick de-correlates its respawns
+	// instead of re-saturating the next provider bucket in lockstep (#3279).
+	// The 30m spread is far wider than any per-minute/per-few-minute provider
+	// bucket while never retrying sooner than the established 30m floor.
+	rateLimitQuarantineJitter = 30 * time.Minute
+
+	// providerThrottlePaceSpread is the full-jitter window used to stagger
+	// respawns when the provider-health registry reports a provider as
+	// THROTTLED (rate-limited but usable). Unlike the rate-limit floor above,
+	// throttled respawns ARE allowed — they are merely spread uniformly across
+	// [0, spread) so parked pool sessions do not all respawn on the single
+	// tick the provider clears, which is the exact synchronization #3279 fixes.
+	providerThrottlePaceSpread = 10 * time.Minute
 
 	// defaultMaxWakeAttempts is how many consecutive wake failures before
 	// quarantine.


### PR DESCRIPTION
Fixes #3279

## Summary
De-correlates reconciler 429 (rate-limit) respawns with jitter and adds a `THROTTLED` tristate to the provider-health gate, so a rate-limit storm no longer respawns the whole pool in lockstep.

- **Jittered per-session quarantine** — replaces the flat 30m lockstep quarantine with `FNV(sessionID, now)` full-jitter: 30m floor + `[0,30m)` spread, no shared RNG.
- **THROTTLED provider-health tristate** — respawn-but-paced for anonymous pool sessions (10m stagger); `RED` = skip, `GREEN` = free; named/infra sessions are never paced; the create-path blocks only on `RED`; progress-stall treats non-green as no-recycle.

## Out of scope (plan-confirmed)
- "Honor `Retry-After`" — 429 is pane-scraped, not an HTTP response at the reconciler layer, so there is no `Retry-After` header to read.
- Multi-field session-id extraction — the detector isn't in the tree.

## Production note
The `THROTTLED` path only fires once the failover-watcher pack emits `status="throttled"` in `provider-health.json`. The decoder + consumer are live and tested here; the external producer is a separate follow-up.

## Coordination
Extends the existing main create-path gate in place (no parallel gate). Interacts with open PR #3690 (binary create-time gate) — if #3690 merges first, reconcile its binary create gate with this tristate.

## Test plan
- `make build` / fmt-check / vet / lint (0 issues): pass
- `go test ./cmd/gc` (full package): pass
- New tests: jitter de-correlation + THROTTLED transitions (`session_reconcile_jitter_test.go`, `provider_health_gate_test.go`, `build_desired_state_test.go`)
