### PR TITLE
ci(beads): trigger contract jobs on setup-gascity-ubuntu changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,15 @@ jobs:
             # gated output above, forcing a full union run. Beads is the
             # universal persistence substrate, events the universal observation
             # substrate, config the universal activation mechanism; build,
-            # dependency, and CI-config files affect every job.
+            # dependency, and CI workflow/composite-action files affect every
+            # job. The setup-gascity-ubuntu composite action is shared by nearly
+            # every job, so a change to it must re-run all path-gated suites.
             shared:
               - 'go.mod'
               - 'go.sum'
               - 'Makefile'
               - '.github/workflows/**'
+              - '.github/actions/setup-gascity-ubuntu/**'
               - 'internal/beads/**'
               - 'internal/events/**'
               - 'internal/config/**'

--- a/.github/workflows/scripts/test_ci_suite_coverage.py
+++ b/.github/workflows/scripts/test_ci_suite_coverage.py
@@ -17,6 +17,7 @@ EXPECTED_SHARED_PATHS = {
     "go.sum",
     "Makefile",
     ".github/workflows/**",
+    ".github/actions/setup-gascity-ubuntu/**",
     "internal/beads/**",
     "internal/events/**",
     "internal/config/**",


### PR DESCRIPTION
## Post-merge remediation for #3721

Post-merge review of the landed change in #3721 (the cross-version
`bd-current` contract acceptance gate) found one actionable correctness
issue in the new CI path-filtering. This PR fixes it.

## Finding fixed (correctness)

The new bd-current contract jobs — `contract-acceptance-current` and
`contract-radar-bd-head` — run `./.github/actions/setup-gascity-ubuntu`
with `bd-version: ""` (build bd from source) and are path-gated on the
`beads` changes-output. But `.github/actions/setup-gascity-ubuntu/**`
matched **no** path filter, so a change to that composite action alone
would skip the very jobs meant to exercise its `bd-version: ""` path. The
action is used by ~9 jobs, so this was a general coverage gap.

## Fix

- Add `.github/actions/setup-gascity-ubuntu/**` to the `shared` filter in
  `ci.yml`. Every gated output folds in `shared`, so a change to the
  composite action now forces a full union run — including the beads-gated
  `contract-acceptance-current` / `contract-radar-bd-head` cells. `shared`
  is the right home: the action is cross-cutting CI infrastructure, the
  same category as `.github/workflows/**`. This mirrors how
  `review-formulas.yml` already path-triggers on the action.
- Guard the entry in `test_ci_suite_coverage.py` (`EXPECTED_SHARED_PATHS`)
  so the composite action cannot be silently dropped from `shared` again.

## Validation

- `actionlint .github/workflows/ci.yml` — clean.
- Focused `test_ci_suite_coverage.py` wiring tests pass
  (`test_shared_filter_covers_core_substrates`,
  `test_gated_outputs_fold_in_shared`). Confirmed the new guard fails if the
  filter entry is removed.

## Non-gating follow-ups (intentionally not in this PR)

Lower-severity items from the same review, kept out to scope this
remediation tightly (tracked separately):
- Add bounded retry/backoff or caching around the bd-current
  `git clone`/checkout/`go build` step.
- Make the prev bd pin source-of-truth consistent with the current pin
  (resolve from `deps.env`, or make the workflow literals canonical).
- File an owning tracking issue for the gc `golang.org/x/net` /
  `golang.org/x/crypto` Trivy waiver removal.

Reviewed landed range: `4c17b27c..b2b5944a`.