### PR TITLE
feat(beads): support external/hosted beads-gateway for city ledgers

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1508,6 +1508,7 @@ func overlayEnvEntries(environ []string, overrides map[string]string) []string {
 		out = removeEnvKey(out, key)
 		out = append(out, key+"="+overrides[key])
 	}
+	out = preserveHostedBeadsCredentialEnv(out, environ, overrides)
 	return out
 }
 
@@ -1570,6 +1571,45 @@ func mergeRuntimeEnv(environ []string, overrides map[string]string) []string {
 	sort.Strings(overrideKeys)
 	for _, key := range overrideKeys {
 		out = append(out, key+"="+overrides[key])
+	}
+	out = preserveHostedBeadsCredentialEnv(out, environ, overrides)
+	return out
+}
+
+// hostedBeadsCredentialPassthroughKeys are env vars the bd provider needs to
+// authenticate to a hosted beads-gateway: the credential command and the inputs
+// its helper (e.g. eia-helper) reads. Several contain execenv.IsSensitiveKey
+// markers (CREDENTIAL / TOKEN) and would otherwise be stripped by
+// FilterInherited, but they carry command/URL/path references — not secret
+// values (the orchestrator key itself stays in a file mount) — so they are
+// preserved explicitly for gc-spawned bd subprocesses.
+var hostedBeadsCredentialPassthroughKeys = []string{
+	"BEADS_DOLT_CREDENTIAL_COMMAND",
+	"BEADS_DOLT_SERVER_TLS",
+	"ORCHESTRATOR_KEY_FILE",
+	"EIA_AUDIENCE",
+	"EIA_SCOPES",
+	"STS_MACHINE_URL",
+	"STS_TOKEN_URL",
+}
+
+// preserveHostedBeadsCredentialEnv re-adds the hosted-gateway credential env
+// from the original (pre-filter) environ, unless an override already set the
+// key. Without this, FilterInherited drops the credential command (and the
+// STS token URL) and gc-spawned bd cannot reach a hosted beads-gateway.
+func preserveHostedBeadsCredentialEnv(out, environ []string, overrides map[string]string) []string {
+	for _, key := range hostedBeadsCredentialPassthroughKeys {
+		if _, ok := overrides[key]; ok {
+			continue
+		}
+		prefix := key + "="
+		for _, entry := range environ {
+			if strings.HasPrefix(entry, prefix) {
+				out = removeEnvKey(out, key)
+				out = append(out, entry)
+				break
+			}
+		}
 	}
 	return out
 }

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -599,6 +599,14 @@ var verifyManagedDoltDatabaseExistsAfterInit = func(cityPath, dir, dbName string
 	if !cityUsesBdStoreContract(cityPath) {
 		return nil
 	}
+	if isExternalDolt(cityPath) {
+		// External/hosted dolt endpoint (e.g. a per-tenant beads-gateway): the
+		// managed-local catalog is irrelevant, and the gateway denies the
+		// SHOW DATABASES catalog listing this guard relies on (it scopes each
+		// connection to its own provisioner-created project DB). Reachability of
+		// that DB is already proven by bd init's own connection.
+		return nil
+	}
 	port := currentResolvableManagedDoltPort(cityPath)
 	if port == "" {
 		return nil

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -188,13 +188,19 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, stderr io.Writer)
 		clearCityDoltConfig(cityPath)
 	}
 	skipLocalDolt := false
-	if cityUsesManagedDoltBeadsLifecycle(cityPath) {
+	switch {
+	case isExternalDolt(cityPath):
+		// An externally-pinned dolt endpoint (city_canonical / explicit, e.g. a
+		// hosted beads-gateway) is not a gc-managed local lifecycle: connect to
+		// the external server, never spawn or adopt a local managed Dolt for it.
+		skipLocalDolt = true
+	case cityUsesManagedDoltBeadsLifecycle(cityPath):
 		owned, err := managedDoltLifecycleOwned(cityPath)
 		if err != nil {
 			return err
 		}
 		skipLocalDolt = !owned
-	} else if cityUsesDoltliteBeadsBackend(cityPath) {
+	case cityUsesDoltliteBeadsBackend(cityPath):
 		skipLocalDolt = true
 	}
 	if !skipLocalDolt {

--- a/cmd/gc/hosted_beads_gateway_test.go
+++ b/cmd/gc/hosted_beads_gateway_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/execenv"
+)
+
+// hostedEnvEntriesToMap collapses KEY=VALUE entries into a map for assertions
+// (last write wins, mirroring process-env semantics).
+func hostedEnvEntriesToMap(entries []string) map[string]string {
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// TestPreserveHostedBeadsCredentialEnv pins the re-add logic in isolation:
+// passthrough keys present in the original environ are restored, keys carried by
+// an override are left to the caller, and unrelated keys are never injected.
+func TestPreserveHostedBeadsCredentialEnv(t *testing.T) {
+	const (
+		credCmd   = "eia-helper --audience beads"
+		serverTLS = "/etc/gc/ca.crt"
+		keyFile   = "/var/run/secrets/orchestrator.key"
+		audience  = "beads"
+		stsToken  = "https://id.example/sts/v0/token"
+		stsMach   = "https://id.example/sts/v0/machine"
+	)
+	// EIA_SCOPES is intentionally absent from environ; STS_MACHINE_URL is carried
+	// by an override; RANDOM_TOKEN is a non-passthrough sensitive key.
+	environ := []string{
+		"BEADS_DOLT_CREDENTIAL_COMMAND=" + credCmd,
+		"BEADS_DOLT_SERVER_TLS=" + serverTLS,
+		"ORCHESTRATOR_KEY_FILE=" + keyFile,
+		"EIA_AUDIENCE=" + audience,
+		"STS_TOKEN_URL=" + stsToken,
+		"STS_MACHINE_URL=" + stsMach,
+		"RANDOM_TOKEN=should-not-pass",
+		"PATH=/usr/bin",
+	}
+	// `out` starts as if FilterInherited already stripped the sensitive keys, plus
+	// a caller-supplied override that must win.
+	out := []string{"PATH=/usr/bin", "GC_DOLT_HOST=gw.beads.example"}
+	overrides := map[string]string{"STS_MACHINE_URL": "https://override.example/sts"}
+
+	got := hostedEnvEntriesToMap(preserveHostedBeadsCredentialEnv(out, environ, overrides))
+
+	for key, want := range map[string]string{
+		"BEADS_DOLT_CREDENTIAL_COMMAND": credCmd,
+		"BEADS_DOLT_SERVER_TLS":         serverTLS,
+		"ORCHESTRATOR_KEY_FILE":         keyFile,
+		"EIA_AUDIENCE":                  audience,
+		"STS_TOKEN_URL":                 stsToken,
+	} {
+		if got[key] != want {
+			t.Errorf("preserveHostedBeadsCredentialEnv() %s = %q, want %q", key, got[key], want)
+		}
+	}
+	// Overridden key: preserve must NOT re-add the inherited value (the caller
+	// already owns it via the override).
+	if v, ok := got["STS_MACHINE_URL"]; ok && v == stsMach {
+		t.Errorf("STS_MACHINE_URL was restored from environ %q, but an override is present; override must win", stsMach)
+	}
+	// Absent-from-environ passthrough key stays absent.
+	if _, ok := got["EIA_SCOPES"]; ok {
+		t.Errorf("EIA_SCOPES is absent from environ; it must not be synthesized")
+	}
+	// Non-passthrough sensitive key is never preserved.
+	if _, ok := got["RANDOM_TOKEN"]; ok {
+		t.Errorf("RANDOM_TOKEN is not a passthrough key; it must not be preserved")
+	}
+}
+
+// TestMergeRuntimeEnvPreservesHostedBeadsCredentialEnv proves the passthrough is
+// load-bearing end-to-end: FilterInherited strips the credential command (it
+// carries a CREDENTIAL marker), yet mergeRuntimeEnv restores it so a gc-spawned
+// bd can authenticate to a hosted beads-gateway — while genuinely unrelated
+// sensitive env stays stripped.
+func TestMergeRuntimeEnvPreservesHostedBeadsCredentialEnv(t *testing.T) {
+	environ := []string{
+		"PATH=/usr/bin",
+		"BEADS_DOLT_CREDENTIAL_COMMAND=eia-helper --audience beads",
+		"STS_TOKEN_URL=https://id.example/sts/v0/token",
+		"BEADS_DOLT_SERVER_TLS=/etc/gc/ca.crt",
+		"EIA_AUDIENCE=beads",
+		"SOME_OTHER_TOKEN=secret-should-be-dropped",
+	}
+
+	// Precondition: without the passthrough this test would be vacuous — confirm
+	// the generic inherited-env filter really drops the credential command.
+	for _, e := range execenv.FilterInherited(environ) {
+		if strings.HasPrefix(e, "BEADS_DOLT_CREDENTIAL_COMMAND=") {
+			t.Fatalf("precondition failed: FilterInherited kept BEADS_DOLT_CREDENTIAL_COMMAND; passthrough no longer needed?")
+		}
+	}
+
+	out := hostedEnvEntriesToMap(mergeRuntimeEnv(environ, map[string]string{"GC_DOLT_HOST": "gw.beads.example"}))
+
+	for key, want := range map[string]string{
+		"BEADS_DOLT_CREDENTIAL_COMMAND": "eia-helper --audience beads",
+		"STS_TOKEN_URL":                 "https://id.example/sts/v0/token",
+		"BEADS_DOLT_SERVER_TLS":         "/etc/gc/ca.crt",
+		"EIA_AUDIENCE":                  "beads",
+		"GC_DOLT_HOST":                  "gw.beads.example",
+	} {
+		if out[key] != want {
+			t.Errorf("mergeRuntimeEnv() %s = %q, want %q", key, out[key], want)
+		}
+	}
+	if _, ok := out["SOME_OTHER_TOKEN"]; ok {
+		t.Errorf("SOME_OTHER_TOKEN is not a passthrough key; FilterInherited must strip it")
+	}
+}
+
+// TestOverlayEnvEntriesPreservesHostedBeadsCredentialEnv covers the second call
+// site (overlayEnvEntries also filters inherited env before re-adding overrides).
+func TestOverlayEnvEntriesPreservesHostedBeadsCredentialEnv(t *testing.T) {
+	environ := []string{
+		"BEADS_DOLT_CREDENTIAL_COMMAND=eia-helper",
+		"PATH=/usr/bin",
+	}
+	out := hostedEnvEntriesToMap(overlayEnvEntries(environ, map[string]string{"GC_DOLT_HOST": "gw"}))
+	if got := out["BEADS_DOLT_CREDENTIAL_COMMAND"]; got != "eia-helper" {
+		t.Fatalf("overlayEnvEntries() BEADS_DOLT_CREDENTIAL_COMMAND = %q, want preserved", got)
+	}
+}
+
+// TestVerifyManagedDoltDatabaseExistsAfterInitSkipsExternalDolt verifies the
+// post-init catalog check short-circuits for an external/hosted dolt endpoint.
+// A per-tenant beads-gateway scopes each connection to its own project DB and
+// denies the SHOW DATABASES listing this guard relies on, so the managed-catalog
+// lister must never run. The test plants a resolvable managed port so that,
+// without the external short-circuit, verify would reach (and fail at) the
+// lister — making the assertion bite if the guard regresses.
+func TestVerifyManagedDoltDatabaseExistsAfterInitSkipsExternalDolt(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	for _, k := range []string{"GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER", "GC_DOLT_PASSWORD"} {
+		t.Setenv(k, "")
+		_ = os.Unsetenv(k)
+	}
+
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: e2e
+gc.endpoint_origin: city_canonical
+gc.endpoint_status: verified
+dolt.auto-start: false
+dolt.host: gw.beads.example.com
+dolt.port: 3306
+dolt.user: orchestrator
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make currentResolvableManagedDoltPort resolve a real port via the provider
+	// managed-dolt state fallback.
+	writeReachableProviderManagedDoltState(t, cityPath)
+
+	if !isExternalDolt(cityPath) {
+		t.Fatalf("precondition: expected isExternalDolt(cityPath)=true for a canonical external config")
+	}
+	if !cityUsesBdStoreContract(cityPath) {
+		t.Fatalf("precondition: expected cityUsesBdStoreContract(cityPath)=true for the default bd provider")
+	}
+	if port := currentResolvableManagedDoltPort(cityPath); port == "" {
+		t.Fatalf("precondition: expected a resolvable managed port so the guard regression would be observable")
+	}
+
+	orig := managedDoltListUserDatabasesAfterInit
+	t.Cleanup(func() { managedDoltListUserDatabasesAfterInit = orig })
+	called := false
+	managedDoltListUserDatabasesAfterInit = func(string) ([]string, error) {
+		called = true
+		return nil, fmt.Errorf("managed-catalog lister must not run for an external dolt endpoint")
+	}
+
+	if err := verifyManagedDoltDatabaseExistsAfterInit(cityPath, cityPath, "bd_prj_47890a40d5bee1d9"); err != nil {
+		t.Fatalf("verifyManagedDoltDatabaseExistsAfterInit() for external dolt = %v, want nil", err)
+	}
+	if called {
+		t.Fatalf("managed-catalog lister was called for an external dolt endpoint; the SHOW DATABASES guard must be skipped")
+	}
+}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -2716,6 +2716,25 @@ op_init() {
     # beads (#1039). Must match doctor.RequiredCustomTypes.
     local custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step}"
 
+    # Hosted beads-gateway: when a credential command is configured, bd
+    # authenticates to the gateway via that command (EIA-as-username over TLS) and
+    # the gateway owns database routing. The managed-local-dolt path below (raw
+    # `dolt --no-tls` reachability probes, server lifecycle, CREATE DATABASE)
+    # cannot reach a TLS+EIA gateway, so defer to bd: it connects over the gateway
+    # and inits/adopts the (provisioner-created) project database itself. Only
+    # engages for hosted scopes; managed cities have no credential command and
+    # fall through to the unchanged path.
+    if [ -n "${BEADS_DOLT_CREDENTIAL_COMMAND:-}" ]; then
+        local hosted_host
+        hosted_host=$(connect_host)
+        if ! run_bd_pinned "$dir" ready >/dev/null 2>&1; then
+            run_bd_init_pinned "$dir" "$prefix" "$dolt_database" "$hosted_host" ""
+        fi
+        ensure_beads_dir_permissions "$dir"
+        ensure_types_custom_in_yaml "$dir" "$custom_types"
+        exit 0
+    fi
+
     if is_doltlite_backend; then
         local database already_ready
         database="$dolt_database"


### PR DESCRIPTION
## Summary

Lets a city's beads ledger live on an **external, hosted, per-tenant beads-gateway** (a Dolt-wire endpoint fronted by TLS + a credential command, e.g. a hosted beads app) instead of a gc-managed local Dolt server. Today the beads lifecycle assumes it owns a local Dolt: it spawns/adopts a server, probes it with raw `dolt --no-tls`, and verifies the database via a `SHOW DATABASES` catalog listing. None of that works against a hosted gateway, which authenticates per-connection and scopes each connection to its own provisioner-created project database (and denies catalog listing). These four small, additive fixes teach gc to *connect to* such an endpoint rather than *manage* it.

Every change is gated on the scope already being external (`isExternalDolt`) or on a hosted credential command being configured, so the managed-local path is **byte-for-byte unchanged**. There are no behavior changes for existing managed or doltlite cities.

### Changes

1. **`startBeadsLifecycle` — skip local-Dolt management for external endpoints** (`cmd/gc/beads_provider_lifecycle.go`). An externally-pinned dolt target (`city_canonical` / `explicit`) is not a gc-managed lifecycle: connect, never spawn or adopt a local server. Rewrites the `if/else` into a `switch` with an `isExternalDolt` case ahead of the managed/doltlite cases.

2. **`gc-beads-bd` op_init — defer to `bd` for hosted scopes** (`examples/bd/assets/scripts/gc-beads-bd.sh`). When a credential command is configured, `bd` authenticates to the gateway (over TLS) and owns database routing, so the managed-local path (raw `dolt --no-tls` reachability probes, server lifecycle, `CREATE DATABASE`) is skipped — `bd` connects through the gateway and inits/adopts the project database itself. Only engages when a credential command is present; managed cities fall through unchanged.

3. **Preserve hosted-gateway credential env past the sensitive-key filter** (`cmd/gc/bd_env.go`). The credential command and its STS/EIA inputs carry `CREDENTIAL`/`TOKEN` substrings, so `execenv.FilterInherited` strips them — which would leave a gc-spawned `bd` unable to reach the gateway. `preserveHostedBeadsCredentialEnv` re-adds a small, explicit allowlist (the *command* and *URL/path references*, not secret values — the orchestrator key stays a file mount) after filtering, in both `mergeRuntimeEnv` and `overlayEnvEntries`. Overrides still win.

4. **Skip the managed-catalog post-init verify for external endpoints** (`cmd/gc/beads_provider_lifecycle.go`). The `SHOW DATABASES` guard that confirms `CREATE DATABASE` wasn't swallowed is meaningless against a per-tenant gateway (it denies the listing and scopes the connection to one DB). Reachability of that DB is already proven by `bd init`'s own connection, so `verifyManagedDoltDatabaseExistsAfterInit` returns early for external scopes.

5. **Tests** (`cmd/gc/hosted_beads_gateway_test.go`). Pure + integration coverage for the credential passthrough (the merge test asserts `FilterInherited` *would* drop the credential command, so the passthrough is provably load-bearing), and a verify-skip test that plants a resolvable managed port so the assertion **bites** if the guard regresses (confirmed by mutation: removing the guard fails the test).

## Why

This is the gc-side gap that blocked a controller from coming up on a hosted ledger. With these fixes a controller starts end-to-end against a hosted beads-gateway and runs its reconcile loop (reading and writing the hosted project DB) — verified end-to-end against a live hosted-gateway deployment. The fixes were extracted onto a clean branch from `main` (the original work sat on a long-lived integration branch).

## Runtime dependency

At runtime a hosted city needs a `bd` build with hosted beads-gateway support (the credential-command store path). These gc changes are **safe to merge independently** of that rollout: they are inert for every managed-local / doltlite city and only activate when a city is explicitly pinned external with a credential command.

## Follow-ups (not in this PR)

- Make the `dolt-health` order external-aware (probe the gateway or skip) — it currently logs a benign managed-port error for external endpoints.
- Have the controller entrypoint write the full external config recipe (it currently sets only host/database, which the resolver masks).

## Testing

- [x] `CGO_ENABLED=0 go build ./cmd/gc/`
- [x] `go vet ./cmd/gc/`
- [x] New tests pass; verify-skip test mutation-checked (fails when the guard is removed)
- [x] Broad `cmd/gc` env/lifecycle/provider suites green
- [x] `examples/bd/dolt`, `internal/runtime/k8s`, and the `gc-beads-bd` lint/identity/reachability tests green
- [ ] `make check` / `make test-integration` (CI)

## Checklist

- [x] Added tests for behavior changes
- [x] No user-facing doc changes required (no new config surface; external-dolt config already exists)
- [x] No breaking changes — additive, gated on external scope

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3754 — both explore non-local/alternative beads backends: this PR adds an external hosted beads-gateway, while that investigation weighs the Store/exec-provider as an extension point for non-beads stores.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
