### PR TITLE
feat(config): packs can declare [upstreams.<name>], inherited by importing cities

### DIFF
--- a/docs/guides/configuring-an-agent.md
+++ b/docs/guides/configuring-an-agent.md
@@ -275,8 +275,13 @@ $ gc doctor                          # validates your city / agent config
 - **Packs:** ship harness presets — a provider and its `upstream_env`
   serving-env binding — as reusable, shareable bundles —
   [Understanding Packs](/guides/understanding-packs),
-  [Shareable Packs](/guides/shareable-packs). (Named `[upstreams.<name>]`
-  endpoint presets stay city-level: declare them in `city.toml` or a city
-  fragment, not in a pack.)
+  [Shareable Packs](/guides/shareable-packs). (A pack may also declare named
+  `[upstreams.<name>]` endpoint presets as a base that the importing city
+  inherits — import the pack, get the upstream for free. A city's own
+  `[upstreams.<name>]` in `city.toml` or a city fragment overrides a
+  pack-provided one of the same name. A pack-carried `[upstreams.<name>]`
+  (its `base_url`, credential env-refs, and raw `[env]` block) is TRUSTED
+  configuration — the same trust level as a pack's `provider.command` — so
+  only import packs you trust.)
 - **Tutorial:** the guided walkthrough that introduces agents —
   [Tutorial 02 — Agents](/tutorials/02-agents).

--- a/docs/guides/harness-recipes.md
+++ b/docs/guides/harness-recipes.md
@@ -280,7 +280,9 @@ above.
 - **Other agent knobs** (prompt, model permission modes, transport, runtime,
   pools, lifecycle): [Configuring an Agent](/guides/configuring-an-agent).
 - **Ship a harness as a reusable preset** — a provider and its `upstream_env`
-  binding (named `[upstreams]` endpoint presets stay city-level):
+  binding (a pack may also declare named `[upstreams]` endpoint presets as a
+  base the importing city inherits; a city's or fragment's own `[upstreams]`
+  override the pack-provided ones):
   [Understanding Packs](/guides/understanding-packs) ·
   [Shareable Packs](/guides/shareable-packs).
 - **Exact fields and types:** [Config Reference](/reference/config).

--- a/docs/reference/schema/pack-schema.json
+++ b/docs/reference/schema/pack-schema.json
@@ -832,6 +832,12 @@
           },
           "type": "object"
         },
+        "upstreams": {
+          "additionalProperties": {
+            "$ref": "#/$defs/UpstreamSpec"
+          },
+          "type": "object"
+        },
         "runtimes": {
           "additionalProperties": {
             "$ref": "#/$defs/PackRuntimeEntry"
@@ -1399,6 +1405,48 @@
       "additionalProperties": false,
       "type": "object",
       "description": "UpstreamEnvBinding is a harness's serving-env contract: the env-var NAMES this CLI reads for the model-serving endpoint and credential."
+    },
+    "UpstreamSpec": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description is a human-readable summary shown in tooling."
+        },
+        "base_url": {
+          "type": "string",
+          "description": "BaseURL is the abstract serving endpoint, rendered onto the harness's\nbase_url env var name (UpstreamEnvBinding.BaseURL)."
+        },
+        "api_key": {
+          "type": "string",
+          "description": "APIKey is the abstract credential, rendered onto the harness's api_key env\nvar name. May be a $VAR ref so the secret stays out of config."
+        },
+        "auth_token": {
+          "type": "string",
+          "description": "AuthToken is an abstract bearer-token credential (an alternative to APIKey\nfor harnesses/upstreams that use a token), rendered onto the harness's\nauth_token env var name."
+        },
+        "base_url_env": {
+          "type": "string",
+          "description": "BaseURLEnv/APIKeyEnv/AuthTokenEnv override the HARNESS binding's env-var\nname for the corresponding abstract field. Needed for GATEWAY harnesses —\none CLI (e.g. opencode) fronting many upstreams where the credential env\nvar is upstream-dependent (GROQ_API_KEY, CEREBRAS_API_KEY, …), so the\nHARNESS has no single binding and the UPSTREAM names its own target.\nPrecedence per field: this override \u003e the harness binding \u003e error."
+        },
+        "api_key_env": {
+          "type": "string",
+          "description": "APIKeyEnv overrides the harness binding's api_key env-var name for this\nupstream (see BaseURLEnv for when this is needed)."
+        },
+        "auth_token_env": {
+          "type": "string",
+          "description": "AuthTokenEnv overrides the harness binding's auth_token env-var name for this\nupstream (see BaseURLEnv)."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env is a harness-specific escape hatch: raw env keys merged AFTER the\nabstract fields render. Values may use $VAR refs."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "UpstreamSpec is a named model-serving endpoint preset (Phase C — the Upstream axis: WHO serves+resolves the model)."
     }
   },
   "title": "Gas City Pack Manifest",

--- a/docs/reference/schema/pack-schema.txt
+++ b/docs/reference/schema/pack-schema.txt
@@ -832,6 +832,12 @@
           },
           "type": "object"
         },
+        "upstreams": {
+          "additionalProperties": {
+            "$ref": "#/$defs/UpstreamSpec"
+          },
+          "type": "object"
+        },
         "runtimes": {
           "additionalProperties": {
             "$ref": "#/$defs/PackRuntimeEntry"
@@ -1399,6 +1405,48 @@
       "additionalProperties": false,
       "type": "object",
       "description": "UpstreamEnvBinding is a harness's serving-env contract: the env-var NAMES this CLI reads for the model-serving endpoint and credential."
+    },
+    "UpstreamSpec": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description is a human-readable summary shown in tooling."
+        },
+        "base_url": {
+          "type": "string",
+          "description": "BaseURL is the abstract serving endpoint, rendered onto the harness's\nbase_url env var name (UpstreamEnvBinding.BaseURL)."
+        },
+        "api_key": {
+          "type": "string",
+          "description": "APIKey is the abstract credential, rendered onto the harness's api_key env\nvar name. May be a $VAR ref so the secret stays out of config."
+        },
+        "auth_token": {
+          "type": "string",
+          "description": "AuthToken is an abstract bearer-token credential (an alternative to APIKey\nfor harnesses/upstreams that use a token), rendered onto the harness's\nauth_token env var name."
+        },
+        "base_url_env": {
+          "type": "string",
+          "description": "BaseURLEnv/APIKeyEnv/AuthTokenEnv override the HARNESS binding's env-var\nname for the corresponding abstract field. Needed for GATEWAY harnesses —\none CLI (e.g. opencode) fronting many upstreams where the credential env\nvar is upstream-dependent (GROQ_API_KEY, CEREBRAS_API_KEY, …), so the\nHARNESS has no single binding and the UPSTREAM names its own target.\nPrecedence per field: this override \u003e the harness binding \u003e error."
+        },
+        "api_key_env": {
+          "type": "string",
+          "description": "APIKeyEnv overrides the harness binding's api_key env-var name for this\nupstream (see BaseURLEnv for when this is needed)."
+        },
+        "auth_token_env": {
+          "type": "string",
+          "description": "AuthTokenEnv overrides the harness binding's auth_token env-var name for this\nupstream (see BaseURLEnv)."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env is a harness-specific escape hatch: raw env keys merged AFTER the\nabstract fields render. Values may use $VAR refs."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "UpstreamSpec is a named model-serving endpoint preset (Phase C — the Upstream axis: WHO serves+resolves the model)."
     }
   },
   "title": "Gas City Pack Manifest",

--- a/internal/config/agent_layout_test.go
+++ b/internal/config/agent_layout_test.go
@@ -67,7 +67,7 @@ scope = "city"
 		t.Fatal(err)
 	}
 
-	agents, _, _, _, _, _, _, err := loadPack(
+	agents, _, _, _, _, _, _, _, err := loadPack(
 		fsys.OSFS{},
 		filepath.Join(packDir, "pack.toml"),
 		packDir,
@@ -115,7 +115,7 @@ scope = "city"
 		t.Fatal(err)
 	}
 
-	agents, _, _, _, _, _, _, err := loadPack(
+	agents, _, _, _, _, _, _, _, err := loadPack(
 		fsys.OSFS{},
 		filepath.Join(packDir, "pack.toml"),
 		packDir,

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -248,6 +248,17 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 				}
 			}
 		}
+		// Merge pack.toml upstreams (pack is base, city wins).
+		if len(pc.Upstreams) > 0 {
+			if root.Upstreams == nil {
+				root.Upstreams = make(map[string]UpstreamSpec)
+			}
+			for name, spec := range pc.Upstreams {
+				if _, exists := root.Upstreams[name]; !exists {
+					root.Upstreams[name] = spec
+				}
+			}
+		}
 		// Merge pack.toml pricing (pack is base, city wins by (provider, model) key).
 		if len(pc.Pricing) > 0 {
 			root.PackPricing = mergePricingByKey(root.PackPricing, pc.Pricing)
@@ -1572,7 +1583,7 @@ func loadImportPackGraphDirsForDoctor(fs fsys.FS, imp Import, declDir, cityRoot 
 		return nil, err
 	}
 	topoPath := filepath.Join(impDir, packFile)
-	_, _, _, _, topoDirs, _, _, err := loadPackWithCacheOptions(
+	_, _, _, _, _, topoDirs, _, _, err := loadPackWithCacheOptions(
 		fs, topoPath, impDir, cityRoot, "", nil, cache, LoadOptions{allowLegacyOrderLayouts: true})
 	if err != nil {
 		return nil, err

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -2415,7 +2415,7 @@ session_live = ["echo global"]
 	cache := &packLoadCache{results: map[string]*packLoadResult{}}
 	topoPath := filepath.Join(packDir, "pack.toml")
 
-	agents, namedSessions, providers, services, topoDirs, requires, globals, err := loadPackWithCache(
+	agents, namedSessions, providers, _, services, topoDirs, requires, globals, err := loadPackWithCache(
 		fsys.OSFS{}, topoPath, packDir, cityRoot, "", nil, cache)
 	if err != nil {
 		t.Fatalf("loadPackWithCache first pass: %v", err)
@@ -2435,7 +2435,7 @@ session_live = ["echo global"]
 	services[0].Process.Command[0] = "mutated"
 	globals[0].SessionLive[0] = "mutated"
 
-	agents2, namedSessions2, providers2, services2, topoDirs2, requires2, globals2, err := loadPackWithCache(
+	agents2, namedSessions2, providers2, _, services2, topoDirs2, requires2, globals2, err := loadPackWithCache(
 		fsys.OSFS{}, topoPath, packDir, cityRoot, "", nil, cache)
 	if err != nil {
 		t.Fatalf("loadPackWithCache second pass: %v", err)

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -51,6 +51,7 @@ type PackConfig struct {
 	NamedSessions []NamedSession              `toml:"named_session,omitempty"`
 	Services      []Service                   `toml:"service,omitempty"`
 	Providers     map[string]ProviderSpec     `toml:"providers,omitempty"`
+	Upstreams     map[string]UpstreamSpec     `toml:"upstreams,omitempty"`
 	Runtimes      map[string]PackRuntimeEntry `toml:"runtimes,omitempty"`
 	Formulas      FormulasConfig              `toml:"formulas,omitempty" jsonschema:"-"`
 	Patches       PackPatches                 `toml:"patches,omitempty"`
@@ -157,7 +158,7 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				}
 			}
 
-			agents, namedSessions, providers, services, topoDirs, reqs, globals, err := loadPackWithCacheOptions(fs, topoPath, topoDir, cityRoot, rig.Name, nil, cache, opts)
+			agents, namedSessions, providers, upstreams, services, topoDirs, reqs, globals, err := loadPackWithCacheOptions(fs, topoPath, topoDir, cityRoot, rig.Name, nil, cache, opts)
 			if err != nil {
 				return fmt.Errorf("rig %q pack %q: %w", rig.Name, ref, err)
 			}
@@ -241,6 +242,18 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 					}
 				}
 			}
+
+			// Merge pack upstreams into city (additive, no overwrite).
+			if len(upstreams) > 0 {
+				if cfg.Upstreams == nil {
+					cfg.Upstreams = make(map[string]UpstreamSpec)
+				}
+				for name, spec := range upstreams {
+					if _, exists := cfg.Upstreams[name]; !exists {
+						cfg.Upstreams[name] = spec
+					}
+				}
+			}
 		}
 
 		// Process rig-level [imports.X] entries (V2).
@@ -263,7 +276,7 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				}
 
 				impPath := filepath.Join(impDir, packFile)
-				agents, namedSessions, providers, services, topoDirs, reqs, globals, err := loadPackWithCacheOptions(
+				agents, namedSessions, providers, upstreams, services, topoDirs, reqs, globals, err := loadPackWithCacheOptions(
 					fs, impPath, impDir, cityRoot, rig.Name, nil, cache, opts)
 				if err != nil {
 					return fmt.Errorf("rig %q import %q: %w", rig.Name, bindingName, err)
@@ -290,6 +303,7 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 					doctors = filterDoctorsByPackDir(doctors, impDir)
 					runtimes = filterRuntimesByPackDir(runtimes, impDir)
 					providers = cachedPackLocalProviders(cache, impDir)
+					upstreams = cachedPackLocalUpstreams(cache, impDir)
 					topoDirs = cachedPackLocalTopoDirs(cache, impDir)
 					reqs = cachedPackLocalRequires(cache, impDir)
 					globals = cachedPackLocalGlobals(cache, impDir)
@@ -434,6 +448,17 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 					for name, spec := range providers {
 						if _, exists := cfg.Providers[name]; !exists {
 							cfg.Providers[name] = spec
+						}
+					}
+				}
+
+				if len(upstreams) > 0 {
+					if cfg.Upstreams == nil {
+						cfg.Upstreams = make(map[string]UpstreamSpec)
+					}
+					for name, spec := range upstreams {
+						if _, exists := cfg.Upstreams[name]; !exists {
+							cfg.Upstreams[name] = spec
 						}
 					}
 				}
@@ -585,7 +610,7 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 			}
 		}
 
-		agents, namedSessions, providers, services, topoDirs, reqs, globals, err := loadPackWithCacheOptions(fs, topoPath, topoDir, cityRoot, "", nil, cache, opts)
+		agents, namedSessions, providers, upstreams, services, topoDirs, reqs, globals, err := loadPackWithCacheOptions(fs, topoPath, topoDir, cityRoot, "", nil, cache, opts)
 		if err != nil {
 			// pack.toml may be missing if the pack was removed upstream after
 			// the repo was fetched. Skip gracefully.
@@ -650,6 +675,18 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 				}
 			}
 		}
+
+		// Merge pack upstreams (additive, first wins; city.toml upstreams win).
+		if len(upstreams) > 0 {
+			if cfg.Upstreams == nil {
+				cfg.Upstreams = make(map[string]UpstreamSpec)
+			}
+			for name, spec := range upstreams {
+				if _, exists := cfg.Upstreams[name]; !exists {
+					cfg.Upstreams[name] = spec
+				}
+			}
+		}
 	}
 
 	// Process city-level [imports.X] entries (V2). These produce agents
@@ -683,7 +720,7 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 			}
 
 			impPath := filepath.Join(impDir, packFile)
-			agents, namedSessions, providers, services, topoDirs, reqs, globals, err := loadPackWithCacheOptions(
+			agents, namedSessions, providers, upstreams, services, topoDirs, reqs, globals, err := loadPackWithCacheOptions(
 				fs, impPath, impDir, cityRoot, "", nil, cache, opts)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("city import %q: %w", bindingName, err)
@@ -718,6 +755,7 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 				doctors = filterDoctorsByPackDir(doctors, impDir)
 				runtimes = filterRuntimesByPackDir(runtimes, impDir)
 				providers = cachedPackLocalProviders(cache, impDir)
+				upstreams = cachedPackLocalUpstreams(cache, impDir)
 				topoDirs = cachedPackLocalTopoDirs(cache, impDir)
 				reqs = cachedPackLocalRequires(cache, impDir)
 				globals = cachedPackLocalGlobals(cache, impDir)
@@ -850,6 +888,18 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 				for name, spec := range providers {
 					if _, exists := cfg.Providers[name]; !exists {
 						cfg.Providers[name] = spec
+					}
+				}
+			}
+
+			// Merge upstreams (additive, first wins; city.toml upstreams win).
+			if len(upstreams) > 0 {
+				if cfg.Upstreams == nil {
+					cfg.Upstreams = make(map[string]UpstreamSpec)
+				}
+				for name, spec := range upstreams {
+					if _, exists := cfg.Upstreams[name]; !exists {
+						cfg.Upstreams[name] = spec
 					}
 				}
 			}
@@ -1047,6 +1097,8 @@ type packLoadResult struct {
 	namedSessions  []NamedSession
 	providers      map[string]ProviderSpec
 	localProviders map[string]ProviderSpec
+	upstreams      map[string]UpstreamSpec
+	localUpstreams map[string]UpstreamSpec
 	services       []Service
 	topoDirs       []string
 	localTopoDirs  []string
@@ -1085,11 +1137,11 @@ func normalizePackAgentDefaultsAlias(cfg *PackConfig, meta toml.MetaData) {
 }
 
 //nolint:unparam // compatibility wrapper keeps the recursion-set argument at the public helper boundary.
-func loadPack(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool) ([]Agent, []NamedSession, map[string]ProviderSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
+func loadPack(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool) ([]Agent, []NamedSession, map[string]ProviderSpec, map[string]UpstreamSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
 	return loadPackWithCache(fs, topoPath, topoDir, cityRoot, rigName, seen, nil)
 }
 
-func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool, cache *packLoadCache) ([]Agent, []NamedSession, map[string]ProviderSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
+func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool, cache *packLoadCache) ([]Agent, []NamedSession, map[string]ProviderSpec, map[string]UpstreamSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
 	return loadPackWithCacheOptions(fs, topoPath, topoDir, cityRoot, rigName, seen, cache, LoadOptions{})
 }
 
@@ -1116,7 +1168,7 @@ func LoadPackForLint(fs fsys.FS, packDir string) (*LintPackLoad, error) {
 	}
 	topoPath := filepath.Join(absDir, packFile)
 	cache := &packLoadCache{results: make(map[string]*packLoadResult)}
-	agents, namedSessions, providers, _, topoDirs, _, _, err := loadPackWithCacheOptions(
+	agents, namedSessions, providers, _, _, topoDirs, _, _, err := loadPackWithCacheOptions(
 		fs, topoPath, absDir, absDir, "", nil, cache, LoadOptions{})
 	if err != nil {
 		return nil, err
@@ -1140,24 +1192,25 @@ func LoadPackForLint(fs fsys.FS, packDir string) (*LintPackLoad, error) {
 	}, nil
 }
 
-func loadPackWithCacheOptions(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool, cache *packLoadCache, opts LoadOptions) ([]Agent, []NamedSession, map[string]ProviderSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
+func loadPackWithCacheOptions(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool, cache *packLoadCache, opts LoadOptions) ([]Agent, []NamedSession, map[string]ProviderSpec, map[string]UpstreamSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
 	var agents []Agent
 	var namedSessions []NamedSession
 	var providers map[string]ProviderSpec
+	var upstreams map[string]UpstreamSpec
 	var services []Service
 	var topoDirs []string
 	var requirements []PackRequirement
 	var globals []ResolvedPackGlobal
 	err := withRepoCacheReadLockForPath(topoDir, func() error {
 		var loadErr error
-		agents, namedSessions, providers, services, topoDirs, requirements, globals, loadErr = loadPackWithCacheOptionsLocked(
+		agents, namedSessions, providers, upstreams, services, topoDirs, requirements, globals, loadErr = loadPackWithCacheOptionsLocked(
 			fs, topoPath, topoDir, cityRoot, rigName, seen, cache, opts)
 		return loadErr
 	})
-	return agents, namedSessions, providers, services, topoDirs, requirements, globals, err
+	return agents, namedSessions, providers, upstreams, services, topoDirs, requirements, globals, err
 }
 
-func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool, cache *packLoadCache, opts LoadOptions) ([]Agent, []NamedSession, map[string]ProviderSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
+func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool, cache *packLoadCache, opts LoadOptions) ([]Agent, []NamedSession, map[string]ProviderSpec, map[string]UpstreamSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
 	// Initialize seen set on first call.
 	if seen == nil {
 		seen = make(map[string]bool)
@@ -1175,7 +1228,7 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 		absTopoDir = topoDir
 	}
 	if seen[absTopoDir] {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("cycle detected: pack %q already visited", topoDir)
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("cycle detected: pack %q already visited", topoDir)
 	}
 
 	// Dedup: if we've already loaded this exact directory, return a copy
@@ -1186,7 +1239,7 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	// and "bar").
 	if cached, ok := cache.results[absTopoDir]; ok {
 		cloned := clonePackLoadResult(cached)
-		return cloned.agents, cloned.namedSessions, cloned.providers, cloned.services, cloned.topoDirs, cloned.requires, cloned.globals, nil
+		return cloned.agents, cloned.namedSessions, cloned.providers, cloned.upstreams, cloned.services, cloned.topoDirs, cloned.requires, cloned.globals, nil
 	}
 
 	seen[absTopoDir] = true
@@ -1194,22 +1247,22 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 
 	data, err := fs.ReadFile(topoPath)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("loading %s: %w", packFile, err)
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("loading %s: %w", packFile, err)
 	}
 
 	tc, md, packWarnings, err := parsePackConfigWithMetadata(data, topoPath)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
 	}
 	if err := validatePackAuthoringSurface(md, topoPath); err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
 	}
 	if fatalWarnings := fatalUndecodedWarnings(md, topoPath); len(fatalWarnings) > 0 {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %s", packFile, strings.Join(fatalWarnings, "; "))
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %s", packFile, strings.Join(fatalWarnings, "; "))
 	}
 
 	if err := validatePackMeta(&tc.Pack); err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Process includes: accumulate base-layer agents, providers,
@@ -1226,18 +1279,19 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	var includedSkills []DiscoveredSkillCatalog
 	var inheritedWarnings []string
 	includedProviders := make(map[string]ProviderSpec)
+	includedUpstreams := make(map[string]UpstreamSpec)
 
 	for _, inc := range tc.Pack.Includes {
 		incTopoDir, err := resolvePackRef(inc, topoDir, cityRoot)
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("include %q: %w", inc, err)
+			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("include %q: %w", inc, err)
 		}
 
 		incTopoPath := filepath.Join(incTopoDir, packFile)
-		incAgents, incNamedSessions, incProviders, incServices, incTopoDirs, incReqs, incGlobals, err := loadPackWithCacheOptions(
+		incAgents, incNamedSessions, incProviders, incUpstreams, incServices, incTopoDirs, incReqs, incGlobals, err := loadPackWithCacheOptions(
 			fs, incTopoPath, incTopoDir, cityRoot, rigName, seen, cache, opts)
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("include %q: %w", inc, err)
+			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("include %q: %w", inc, err)
 		}
 		inheritedWarnings = appendUnique(inheritedWarnings, cachedPackWarnings(cache, incTopoDir)...)
 
@@ -1256,6 +1310,12 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 		for name, spec := range incProviders {
 			if _, exists := includedProviders[name]; !exists {
 				includedProviders[name] = spec
+			}
+		}
+		// Merge upstreams: included first, no overwrite (mirrors providers).
+		for name, spec := range incUpstreams {
+			if _, exists := includedUpstreams[name]; !exists {
+				includedUpstreams[name] = spec
 			}
 		}
 	}
@@ -1281,14 +1341,14 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 		// absent or lacks the entry — matching city- and rig-scope imports.
 		impDir, err := resolveImportPackRef(imp.Source, imp.Version, topoDir, cityRoot)
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("import %q: %w", bindingName, err)
+			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("import %q: %w", bindingName, err)
 		}
 
 		impPath := filepath.Join(impDir, packFile)
-		impAgents, impNamedSessions, impProviders, impServices, impTopoDirs, impReqs, impGlobals, err := loadPackWithCacheOptions(
+		impAgents, impNamedSessions, impProviders, impUpstreams, impServices, impTopoDirs, impReqs, impGlobals, err := loadPackWithCacheOptions(
 			fs, impPath, impDir, cityRoot, rigName, seen, cache, opts)
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("import %q: %w", bindingName, err)
+			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("import %q: %w", bindingName, err)
 		}
 		warnings := cachedPackWarnings(cache, impDir)
 		if !imp.ImportIsTransitive() {
@@ -1320,6 +1380,7 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 			impDoctors = filterDoctorsByPackDir(impDoctors, impDir)
 			impRuntimes = filterRuntimesByPackDir(impRuntimes, impDir)
 			impProviders = cachedPackLocalProviders(cache, impDir)
+			impUpstreams = cachedPackLocalUpstreams(cache, impDir)
 			impTopoDirs = cachedPackLocalTopoDirs(cache, impDir)
 			impReqs = cachedPackLocalRequires(cache, impDir)
 			impGlobals = cachedPackLocalGlobals(cache, impDir)
@@ -1360,11 +1421,11 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 		// Read the imported pack name for provenance tracking.
 		impData, readErr := fs.ReadFile(impPath)
 		if readErr != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("import %q: reading %s: %w", bindingName, impPath, readErr)
+			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("import %q: reading %s: %w", bindingName, impPath, readErr)
 		}
 		packName, err := decodePackName(impData)
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("import %q: parsing %s: %w", bindingName, impPath, err)
+			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("import %q: parsing %s: %w", bindingName, impPath, err)
 		}
 		for i := range impAgents {
 			if impAgents[i].PackName == "" {
@@ -1403,6 +1464,11 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 				includedProviders[name] = spec
 			}
 		}
+		for name, spec := range impUpstreams {
+			if _, exists := includedUpstreams[name]; !exists {
+				includedUpstreams[name] = spec
+			}
+		}
 	}
 
 	// Collect this pack's own requirements.
@@ -1420,32 +1486,32 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	// so [[agent]] tables take precedence when both exist.
 	discovered, dErr := DiscoverPackAgents(fs, topoDir, tc.Pack.Name, agentNameSet(tc.Agents))
 	if dErr != nil {
-		return nil, nil, nil, nil, nil, nil, nil, dErr
+		return nil, nil, nil, nil, nil, nil, nil, nil, dErr
 	}
 	tc.Agents = append(tc.Agents, discovered...)
 	applyInheritedPackAgentDefaults(tc.Agents, tc.AgentDefaults)
 
 	commands, err := DiscoverPackCommands(fs, topoDir, tc.Pack.Name)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 	commands = append(commands, legacyPackCommands(tc.Commands, topoDir, tc.Pack.Name)...)
 	doctors, err := DiscoverPackDoctors(fs, topoDir, tc.Pack.Name)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 	legacyDoctors, err := legacyPackDoctors(fs, tc.Doctor, topoDir, tc.Pack.Name)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 	doctors = append(doctors, legacyDoctors...)
 	localRuntimes, err := packLocalRuntimes(&tc, topoDir)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 	skills, err := DiscoverPackSkills(fs, topoDir, tc.Pack.Name)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	// V2 convention-based order discovery: top-level orders/ flat files are the
@@ -1457,7 +1523,7 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 			Dir:          filepath.Join(topoDir, "orders"),
 			FormulaLayer: filepath.Join(topoDir, "formulas"),
 		}}, nil); err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, nil, nil, nil, err
 		}
 	}
 
@@ -1502,7 +1568,7 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	for i := range services {
 		services[i].SourceDir = topoDir
 		if services[i].PublishMode == "direct" {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("service %q: packs may not set publish_mode=direct", services[i].Name)
+			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("service %q: packs may not set publish_mode=direct", services[i].Name)
 		}
 	}
 
@@ -1519,7 +1585,7 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	if !tc.Patches.IsEmpty() {
 		adjustPackPatchPaths(&tc.Patches, topoDir, cityRoot)
 		if err := applyPackAgentPatches(includedAgents, tc.Patches.Agents); err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, nil, nil, nil, err
 		}
 	}
 
@@ -1560,6 +1626,12 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 		mergedProviders[name] = spec
 	}
 
+	// Merge upstreams: parent wins over included (mirrors providers).
+	mergedUpstreams := includedUpstreams
+	for name, spec := range tc.Upstreams {
+		mergedUpstreams[name] = spec
+	}
+
 	// Build pack dirs: included pack dirs first (lower priority),
 	// then this pack's dir (higher priority).
 	var topoDirs []string
@@ -1584,6 +1656,8 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 		namedSessions:  includedNamedSessions,
 		providers:      mergedProviders,
 		localProviders: tc.Providers,
+		upstreams:      mergedUpstreams,
+		localUpstreams: tc.Upstreams,
 		services:       includedServices,
 		topoDirs:       topoDirs,
 		localTopoDirs:  []string{topoDir},
@@ -1599,7 +1673,7 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 		warnings:       appendUnique(append([]string(nil), inheritedWarnings...), packWarnings...),
 	})
 
-	return includedAgents, includedNamedSessions, mergedProviders, includedServices, topoDirs, allRequires, allGlobals, nil
+	return includedAgents, includedNamedSessions, mergedProviders, mergedUpstreams, includedServices, topoDirs, allRequires, allGlobals, nil
 }
 
 func clonePackLoadResult(in *packLoadResult) *packLoadResult {
@@ -1611,6 +1685,8 @@ func clonePackLoadResult(in *packLoadResult) *packLoadResult {
 		namedSessions:  deepCopyNamedSessions(in.namedSessions),
 		providers:      deepCopyProviderSpecs(in.providers),
 		localProviders: deepCopyProviderSpecs(in.localProviders),
+		upstreams:      deepCopyUpstreamSpecs(in.upstreams),
+		localUpstreams: deepCopyUpstreamSpecs(in.localUpstreams),
 		services:       deepCopyServices(in.services),
 		topoDirs:       append([]string(nil), in.topoDirs...),
 		localTopoDirs:  append([]string(nil), in.localTopoDirs...),
@@ -1679,6 +1755,18 @@ func deepCopyProviderSpecs(in map[string]ProviderSpec) map[string]ProviderSpec {
 	out := make(map[string]ProviderSpec, len(in))
 	for name, spec := range in {
 		out[name] = deepCopyProviderSpec(spec)
+	}
+	return out
+}
+
+func deepCopyUpstreamSpecs(in map[string]UpstreamSpec) map[string]UpstreamSpec {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]UpstreamSpec, len(in))
+	for name, spec := range in {
+		spec.Env = deepCopyStringMap(spec.Env)
+		out[name] = spec
 	}
 	return out
 }
@@ -1845,6 +1933,21 @@ func cachedPackLocalProviders(cache *packLoadCache, topoDir string) map[string]P
 		return nil
 	}
 	return deepCopyProviderSpecs(result.localProviders)
+}
+
+func cachedPackLocalUpstreams(cache *packLoadCache, topoDir string) map[string]UpstreamSpec {
+	if cache == nil {
+		return nil
+	}
+	absDir, err := filepath.Abs(topoDir)
+	if err != nil {
+		absDir = topoDir
+	}
+	result, ok := cache.results[absDir]
+	if !ok {
+		return nil
+	}
+	return deepCopyUpstreamSpecs(result.localUpstreams)
 }
 
 func cachedPackLocalTopoDirs(cache *packLoadCache, topoDir string) []string {
@@ -3035,7 +3138,7 @@ func PackDefinesAgent(fs fsys.FS, packRef, cityRoot, agentName string) bool {
 	}
 	topoPath := filepath.Join(topoDir, packFile)
 
-	agents, _, _, _, _, _, _, err := loadPack(fs, topoPath, topoDir, cityRoot, "", nil)
+	agents, _, _, _, _, _, _, _, err := loadPack(fs, topoPath, topoDir, cityRoot, "", nil)
 	if err != nil {
 		return false
 	}

--- a/internal/config/pack_fetch_test.go
+++ b/internal/config/pack_fetch_test.go
@@ -646,7 +646,7 @@ name = "boss"
 		t.Fatal(err)
 	}
 
-	agents, _, _, _, _, _, _, err := loadPack(
+	agents, _, _, _, _, _, _, _, err := loadPack(
 		fsys.OSFS{},
 		filepath.Join(topoDir, "pack.toml"),
 		topoDir,

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -2468,7 +2468,7 @@ includes = ["../maintenance"]
 name = "mayor"
 `)
 
-	agents, _, _, _, _, _, _, err := loadPack(
+	agents, _, _, _, _, _, _, _, err := loadPack(
 		fsys.OSFS{},
 		filepath.Join(dir, "packs/gastown/pack.toml"),
 		filepath.Join(dir, "packs/gastown"),
@@ -2515,7 +2515,7 @@ name = "mayor"
 scope = "city"
 `)
 
-	agents, _, _, _, _, _, _, err := loadPack(
+	agents, _, _, _, _, _, _, _, err := loadPack(
 		fsys.OSFS{},
 		filepath.Join(dir, "packs/gastown/pack.toml"),
 		filepath.Join(dir, "packs/gastown"),
@@ -2663,7 +2663,7 @@ name = "mayor"
 `)
 	writeFile(t, dir, "packs/gastown/formulas/.keep", "")
 
-	_, _, _, _, topoDirs, _, _, err := loadPack(
+	_, _, _, _, _, topoDirs, _, _, err := loadPack(
 		fsys.OSFS{},
 		filepath.Join(dir, "packs/gastown/pack.toml"),
 		filepath.Join(dir, "packs/gastown"),
@@ -2707,7 +2707,7 @@ includes = ["../a"]
 name = "beta"
 `)
 
-	_, _, _, _, _, _, _, err := loadPack(
+	_, _, _, _, _, _, _, _, err := loadPack(
 		fsys.OSFS{},
 		filepath.Join(dir, "packs/a/pack.toml"),
 		filepath.Join(dir, "packs/a"),
@@ -2733,7 +2733,7 @@ includes = ["../nonexistent"]
 name = "alpha"
 `)
 
-	_, _, _, _, _, _, _, err := loadPack(
+	_, _, _, _, _, _, _, _, err := loadPack(
 		fsys.OSFS{},
 		filepath.Join(dir, "packs/main/pack.toml"),
 		filepath.Join(dir, "packs/main"),
@@ -2776,7 +2776,7 @@ command = "main-claude"
 name = "boss"
 `)
 
-	_, _, providers, _, _, _, _, err := loadPack(
+	_, _, providers, _, _, _, _, _, err := loadPack(
 		fsys.OSFS{},
 		filepath.Join(dir, "packs/main/pack.toml"),
 		filepath.Join(dir, "packs/main"),
@@ -2919,7 +2919,7 @@ name = "polecat"
 scope = "rig"
 `)
 
-	agents, _, _, _, _, _, _, err := loadPack(
+	agents, _, _, _, _, _, _, _, err := loadPack(
 		fsys.OSFS{}, filepath.Join(dir, "packs/test/pack.toml"),
 		filepath.Join(dir, "packs/test"), dir, "myrig", nil)
 	if err != nil {

--- a/internal/config/pack_upstreams_test.go
+++ b/internal/config/pack_upstreams_test.go
@@ -1,0 +1,327 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// A city that imports a pack whose pack.toml declares [upstreams.gasworks]
+// inherits that upstream preset — "import the pack, get the upstream for free".
+func TestLoadWithIncludes_PackUpstreamInheritedByCity(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "c"
+
+[imports.local]
+source = "packs/local"
+`)
+	fs.Files["/city/packs/local/pack.toml"] = []byte(`
+[pack]
+name = "local"
+schema = 2
+
+[upstreams.gasworks]
+description = "Gasworks managed gateway"
+base_url = "https://gasworks.example/anthropic"
+api_key  = "$GASWORKS_API_KEY"
+
+[upstreams.gasworks.env]
+GASWORKS_TRACE = "$GASWORKS_TRACE"
+`)
+
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	u, ok := cfg.Upstreams["gasworks"]
+	if !ok {
+		t.Fatalf("pack upstream missing from composed config: %v", cfg.Upstreams)
+	}
+	if u.BaseURL != "https://gasworks.example/anthropic" {
+		t.Errorf("base_url = %q, want https://gasworks.example/anthropic", u.BaseURL)
+	}
+	if u.APIKey != "$GASWORKS_API_KEY" {
+		t.Errorf("api_key = %q, want $GASWORKS_API_KEY (env-ref)", u.APIKey)
+	}
+	if got := u.Env["GASWORKS_TRACE"]; got != "$GASWORKS_TRACE" {
+		t.Errorf("env GASWORKS_TRACE = %q, want $GASWORKS_TRACE", got)
+	}
+}
+
+// Precedence: when the city ALSO declares [upstreams.gasworks], the CITY's
+// definition wins — the pack is the base layer and is NOT overwritten over the
+// existing city entry (mirrors the providers "additive, no overwrite" rule).
+func TestLoadWithIncludes_CityUpstreamOverridesPack(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "c"
+
+[imports.local]
+source = "packs/local"
+
+[upstreams.gasworks]
+base_url = "https://city.example/anthropic"
+api_key  = "$CITY_API_KEY"
+`)
+	fs.Files["/city/packs/local/pack.toml"] = []byte(`
+[pack]
+name = "local"
+schema = 2
+
+[upstreams.gasworks]
+base_url = "https://pack.example/anthropic"
+api_key  = "$PACK_API_KEY"
+`)
+
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	u, ok := cfg.Upstreams["gasworks"]
+	if !ok {
+		t.Fatalf("upstream missing from composed config: %v", cfg.Upstreams)
+	}
+	if u.BaseURL != "https://city.example/anthropic" {
+		t.Errorf("base_url = %q, want city definition to win (https://city.example/anthropic)", u.BaseURL)
+	}
+	if u.APIKey != "$CITY_API_KEY" {
+		t.Errorf("api_key = %q, want $CITY_API_KEY (city wins)", u.APIKey)
+	}
+}
+
+// A root pack.toml (the city's own pack) that declares [upstreams.*] merges as
+// a base, and an [upstreams.<name>] in a pack.toml no longer produces a fatal
+// undecoded-key error: it loads cleanly.
+func TestLoadWithIncludes_RootPackUpstreamLoadsCleanly(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "c"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "test"
+schema = 2
+
+[upstreams.gasworks]
+base_url = "https://gasworks.example/anthropic"
+api_key  = "$GASWORKS_API_KEY"
+`)
+
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	u, ok := cfg.Upstreams["gasworks"]
+	if !ok {
+		t.Fatalf("root pack upstream missing from composed config: %v", cfg.Upstreams)
+	}
+	if u.BaseURL != "https://gasworks.example/anthropic" {
+		t.Errorf("base_url = %q, want https://gasworks.example/anthropic", u.BaseURL)
+	}
+}
+
+// Nested pack-imports-a-pack: pack B includes pack A. A declares
+// [upstreams.fromA]; B declares [upstreams.fromB] and a colliding
+// [upstreams.shared]. A city imports B. The composed city inherits fromA AND
+// fromB (the recursive merge), and for the collision B (the importing/parent
+// pack) wins over A (the included pack) — mirrors the provider merge where
+// tc.Upstreams overwrites includedUpstreams. This winner is deterministic:
+// includes are processed in declaration order and the parent pack's own
+// upstreams overwrite inherited ones.
+func TestLoadWithIncludes_NestedPackUpstreamsMerged(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "c"
+
+[imports.b]
+source = "packs/b"
+`)
+	fs.Files["/city/packs/b/pack.toml"] = []byte(`
+[pack]
+name = "b"
+schema = 2
+includes = ["../a"]
+
+[upstreams.fromB]
+base_url = "https://b.example/anthropic"
+
+[upstreams.shared]
+base_url = "https://shared-from-b.example/anthropic"
+`)
+	fs.Files["/city/packs/a/pack.toml"] = []byte(`
+[pack]
+name = "a"
+schema = 2
+
+[upstreams.fromA]
+base_url = "https://a.example/anthropic"
+
+[upstreams.shared]
+base_url = "https://shared-from-a.example/anthropic"
+`)
+
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if got := cfg.Upstreams["fromA"].BaseURL; got != "https://a.example/anthropic" {
+		t.Errorf("fromA base_url = %q, want https://a.example/anthropic (inherited from included pack A)", got)
+	}
+	if got := cfg.Upstreams["fromB"].BaseURL; got != "https://b.example/anthropic" {
+		t.Errorf("fromB base_url = %q, want https://b.example/anthropic (from importing pack B)", got)
+	}
+	// Collision: the importing pack (B) wins over the included pack (A).
+	if got := cfg.Upstreams["shared"].BaseURL; got != "https://shared-from-b.example/anthropic" {
+		t.Errorf("shared base_url = %q, want https://shared-from-b.example/anthropic (importing pack B wins over included pack A)", got)
+	}
+}
+
+// Two packs declaring the same upstream → deterministic first-wins. A city
+// imports two packs that both declare [upstreams.gasworks] with distinct
+// base_urls. Import binding names are processed in sorted order with "no
+// overwrite", so the lexically-first binding ("one") wins — mirrors the
+// provider determinism in TestExpandCityPacks_ProvidersMerged.
+func TestLoadWithIncludes_TwoPacksSameUpstreamFirstWins(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "c"
+
+[imports.one]
+source = "packs/one"
+
+[imports.two]
+source = "packs/two"
+`)
+	fs.Files["/city/packs/one/pack.toml"] = []byte(`
+[pack]
+name = "one"
+schema = 2
+
+[upstreams.gasworks]
+base_url = "https://one.example/anthropic"
+`)
+	fs.Files["/city/packs/two/pack.toml"] = []byte(`
+[pack]
+name = "two"
+schema = 2
+
+[upstreams.gasworks]
+base_url = "https://two.example/anthropic"
+`)
+
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	// Binding "one" sorts before "two" → first wins, no overwrite.
+	if got := cfg.Upstreams["gasworks"].BaseURL; got != "https://one.example/anthropic" {
+		t.Errorf("gasworks base_url = %q, want https://one.example/anthropic (first import 'one' wins)", got)
+	}
+}
+
+// Clone/cache isolation: the cached pack-load result must hand out detached
+// copies so a caller mutating the returned upstreams map (or a nested Env
+// value) cannot corrupt the cache for the next load. Proves
+// deepCopyUpstreamSpecs isolates both the map and each spec's Env.
+func TestLoadPackWithCache_DetachesUpstreams(t *testing.T) {
+	dir := t.TempDir()
+	cityRoot := filepath.Join(dir, "city")
+	packDir := filepath.Join(dir, "shared")
+	for _, d := range []string{cityRoot, packDir} {
+		mustMkdirAll(t, d, 0o755)
+	}
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "shared"
+schema = 1
+
+[upstreams.helper]
+base_url = "https://helper.example/anthropic"
+api_key  = "$HELPER_API_KEY"
+
+[upstreams.helper.env]
+HELPER_TRACE = "base"
+`)
+
+	cache := &packLoadCache{results: map[string]*packLoadResult{}}
+	topoPath := filepath.Join(packDir, "pack.toml")
+
+	_, _, _, upstreams, _, _, _, _, err := loadPackWithCache(
+		fsys.OSFS{}, topoPath, packDir, cityRoot, "", nil, cache)
+	if err != nil {
+		t.Fatalf("loadPackWithCache first pass: %v", err)
+	}
+	if len(upstreams) != 1 {
+		t.Fatalf("unexpected first-pass upstreams: %v", upstreams)
+	}
+
+	// Mutate the returned map AND a nested Env value, then drop the entry.
+	upstreams["helper"].Env["HELPER_TRACE"] = "mutated"
+	delete(upstreams, "helper")
+
+	_, _, _, upstreams2, _, _, _, _, err := loadPackWithCache(
+		fsys.OSFS{}, topoPath, packDir, cityRoot, "", nil, cache)
+	if err != nil {
+		t.Fatalf("loadPackWithCache second pass: %v", err)
+	}
+	helper2, ok := upstreams2["helper"]
+	if !ok {
+		t.Fatalf("cached upstream entry leaked deletion: %v", upstreams2)
+	}
+	if helper2.BaseURL != "https://helper.example/anthropic" {
+		t.Errorf("cached upstream base_url leaked mutation: got %q, want %q", helper2.BaseURL, "https://helper.example/anthropic")
+	}
+	if got := helper2.Env["HELPER_TRACE"]; got != "base" {
+		t.Errorf("cached upstream env leaked mutation: got %q, want %q", got, "base")
+	}
+}
+
+// Rig-scope pack expansion merges pack upstreams into the city (additive,
+// first-wins, no overwrite of an existing city entry) — the rig path threads
+// upstreams through a separate merge-into-cfg block from the city path, so it
+// gets its own coverage mirroring TestExpandPacks_ProvidersMerged.
+func TestExpandPacks_UpstreamsMerged(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "packs/gt/pack.toml", `
+[pack]
+name = "gastown"
+version = "1.0.0"
+schema = 1
+
+[upstreams.gasworks]
+base_url = "https://pack.example/anthropic"
+
+[[agent]]
+name = "witness"
+`)
+
+	cfg := &City{
+		Upstreams: map[string]UpstreamSpec{
+			"existing": {BaseURL: "https://city.example/anthropic"},
+		},
+		Rigs: []Rig{
+			{Name: "hw", Path: "/hw", Includes: []string{"packs/gt"}},
+		},
+	}
+
+	if err := ExpandPacks(cfg, fsys.OSFS{}, dir, nil); err != nil {
+		t.Fatalf("ExpandPacks: %v", err)
+	}
+
+	// gasworks upstream should be added from the pack.
+	if got := cfg.Upstreams["gasworks"].BaseURL; got != "https://pack.example/anthropic" {
+		t.Errorf("gasworks base_url = %q, want https://pack.example/anthropic (merged from pack)", got)
+	}
+	// existing city upstream should still exist, untouched.
+	if got := cfg.Upstreams["existing"].BaseURL; got != "https://city.example/anthropic" {
+		t.Errorf("existing base_url = %q, want https://city.example/anthropic (city entry preserved)", got)
+	}
+}


### PR DESCRIPTION
## What
A `pack.toml` can now declare `[upstreams.<name>]`, and a city that `gc import`s the pack **inherits** those upstream endpoint presets — "import the pack, get the upstream for free." Previously upstreams merged only from `city.toml` and `[[include]]` fragments.

`PackConfig` gains an `Upstreams` field, threaded through the recursive pack loader exactly like `providers`, merged into the importing city as a **base that the city/fragments override** (additive, no-overwrite, deterministic first-wins). A pack can never override a city's own `[upstreams.x]`.

## Why
The maintainer-city run_id proxy (the `gasworks` upstream) currently has to be hand-wired in each city's `city.toml`. With this, `gasworks-pack` can ship `[upstreams.gasworks]` once and every importing city inherits it. The merge is **additive and inert** until a pack actually declares `[upstreams.*]`.

## Tests (TDD)
pack→city inheritance · city-overrides-pack · nested pack-imports-pack · two-packs determinism (first-wins) · clone/cache isolation (mutation-tested) · rig path · clean load (no fatal undecoded key). `go build ./...`, `go test ./...`, `gofmt`, and the schema generator (idempotent) all green; the pre-push `test-fast-parallel` hook passed.

## Review
Adversarial 5-dimension workflow review (correctness clean, precedence consistent). Confirmed findings fixed: regenerated the pack reference schema; added the missing coverage; trust-model doc note (a pack-carried `[upstreams.<name>]` is **trusted config**, same level as a pack's `provider.command` — only import packs you trust).

## Deploy note
Pure config-layer change — needs gc rebuilt + deployed for cities to consume pack-carried upstreams. Safe/additive; nothing changes for existing cities. Once it lands + gc ships, `gasworks-pack` can carry `[upstreams.gasworks]` so any importing city gets the run_id proxy upstream for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)