### PR TITLE
ci: require PR→issue linkage (Closes #N or no-issue label)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 
 ## Checklist
 
-- [ ] Linked an issue, or explained why one is not needed
+- [ ] Linked an issue with a closing keyword (e.g. `Closes #123`), or applied the `no-issue` label if this PR closes none — enforced by the **PR issue linkage** check
 - [ ] Added or updated tests for behavior changes
 - [ ] Updated docs for user-facing changes
 - [ ] Called out breaking changes or migration notes

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -39,16 +39,21 @@ jobs:
               return;
             }
 
-            // GitHub closing keywords + an issue ref (same-repo #N or owner/repo#N).
-            // Mirrors what GitHub itself treats as an auto-closing link.
-            const linkRe = /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b\s*:?\s+(?:[\w.-]+\/[\w.-]+)?#\d+/i;
-            if (linkRe.test(body)) {
-              core.info("Linked issue via closing keyword found.");
-              return;
+            // Closing keyword + issue ref. Fully-qualified refs (owner/repo#N) only
+            // count when they point at THIS repo — a cross-repo ref closes nothing here.
+            const linkRe = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s+([\w.-]+\/[\w.-]+)?#\d+/gi;
+            const repoSlug = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
+            for (const m of body.matchAll(linkRe)) {
+              const qualified = m[1]; // "owner/repo" or undefined for a plain #N
+              if (!qualified || qualified.toLowerCase() === repoSlug) {
+                core.info("Linked issue via closing keyword found.");
+                return;
+              }
             }
 
             core.setFailed(
               "No linked issue found. Add a closing keyword + issue number to the PR " +
               "body (e.g. 'Closes #123'), or apply the 'no-issue' label if this PR " +
-              "intentionally closes no issue. See the PR template checklist."
+              "intentionally closes no issue. See the PR template checklist." +
+              " Fully qualified refs must point at this repository."
             );

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -1,0 +1,54 @@
+name: PR issue linkage
+
+# Enforce that every PR either links an issue with a GitHub closing keyword
+# (Closes/Fixes/Resolves #N — same-repo or owner/repo#N) OR is explicitly opted
+# out with the `no-issue` label. This is the gate that prevents the recurrence of
+# "fix merged, issue stayed open" (17 such issues in the 2026-06 hygiene triage).
+#
+# Deterministic + structural only (ZFC): it pattern-matches the body and reads
+# labels — no semantic judgement. The `no-issue` label is the maintainer opt-out
+# for PRs that genuinely close nothing (chores, docs, infra).
+#
+# pull_request_target is safe here: this job never checks out or runs PR code; it
+# only reads the PR body + labels and sets its own pass/fail conclusion. Re-runs on
+# edit/label changes so a contributor can fix the linkage and the check goes green.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions: {}
+
+jobs:
+  linkage:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Require a linked issue or the no-issue opt-out
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const labels = (pr.labels || []).map(l => l.name);
+
+            // Maintainer opt-out: PRs that legitimately close no issue.
+            if (labels.includes("no-issue")) {
+              core.info("no-issue label present — linkage requirement waived.");
+              return;
+            }
+
+            // GitHub closing keywords + an issue ref (same-repo #N or owner/repo#N).
+            // Mirrors what GitHub itself treats as an auto-closing link.
+            const linkRe = /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b\s*:?\s+(?:[\w.-]+\/[\w.-]+)?#\d+/i;
+            if (linkRe.test(body)) {
+              core.info("Linked issue via closing keyword found.");
+              return;
+            }
+
+            core.setFailed(
+              "No linked issue found. Add a closing keyword + issue number to the PR " +
+              "body (e.g. 'Closes #123'), or apply the 'no-issue' label if this PR " +
+              "intentionally closes no issue. See the PR template checklist."
+            );


### PR DESCRIPTION
## What

Adds a **PR issue linkage** check: every PR must either link an issue with a GitHub closing keyword (`Closes`/`Fixes`/`Resolves #N`, same-repo or `owner/repo#N`) **or** carry the `no-issue` label (maintainer opt-out for chores/docs/infra that close nothing). Otherwise the check fails red.

This closes the "fix merged, issue stayed open" recurrence — the 2026-06 issue-hygiene triage found **17** issues that stayed open only because their fixing PR never linked them.

## How

- New Action `.github/workflows/pr-issue-linkage.yml` — deterministic + structural only (ZFC-clean): it pattern-matches the PR body and reads labels, no semantic judgement, no auto-close.
- Uses `pull_request_target` so it works on fork PRs, but the job **never checks out or runs PR code** — it only reads body + labels and sets its own pass/fail (same safety model as the existing remove-needs-triage Action). `permissions: {}` at top level, `pull-requests: read` on the job.
- PR template line strengthened to state the enforced format.

## ⚠️ To make it BLOCKING (separate admin action)

Opening this PR makes the check **run** on every PR. To make it **block** merge, a repo admin must add **"PR issue linkage / linkage"** to the branch-protection required status checks. The PR alone does not change branch protection.

## Files

2 changed (+55 / −1): new Action + one PR-template line.
