### PR TITLE
fix(dispatch): resolve pack-relative ralph check_path against pack/city root when work_dir lacks it

### DIFF
--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -2,7 +2,9 @@ package dispatch
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -196,6 +198,20 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 		return convergence.GateResult{}, fmt.Errorf("%s: absolute gc.check_path %q escapes trusted roots", bead.ID, checkPath)
 	}
 	scriptPath, err := convergence.ResolveConditionPath(cityPath, scriptBase, checkPath)
+	if err != nil && scriptBase != storePath && !filepath.IsAbs(checkPath) && errors.Is(err, fs.ErrNotExist) {
+		// Pack-shipped check scripts live in the pack/city tree, not the
+		// per-task gc.work_dir worktree, so a relative gc.check_path joined
+		// against a work_dir worktree that lacks the pack tree resolves to a
+		// nonexistent path (gastownhall/gascity#3008). Fall back to the
+		// store/city root — exactly the base used when work_dir is empty, so
+		// it introduces no new trusted root and stays subject to
+		// ResolveConditionPath's containment checks. Only on a not-exist miss,
+		// so a check that does exist under the worktree keeps precedence; the
+		// original work_dir error is preserved when the fallback also misses.
+		if fallbackPath, fallbackErr := convergence.ResolveConditionPath(cityPath, storePath, checkPath); fallbackErr == nil {
+			scriptPath, err = fallbackPath, nil
+		}
+	}
 	if err != nil {
 		return convergence.GateResult{}, fmt.Errorf("%s: resolving check path: %w", bead.ID, err)
 	}

--- a/internal/dispatch/ralph_test.go
+++ b/internal/dispatch/ralph_test.go
@@ -149,6 +149,105 @@ func TestResolveRalphCheckMoleculePaths_UnsafeRootID(t *testing.T) {
 	}
 }
 
+// TestRunRalphCheckPackRelativeCheckPathWorkDirFallback covers
+// gastownhall/gascity#3008: a pack-relative gc.check_path
+// (e.g. assets/<pack>/scripts/check.sh) names a pack-shipped script that lives
+// under the store/city root, not the per-task gc.work_dir worktree. When the
+// control bead carries a work_dir pointing at a worktree that lacks the pack
+// tree, the relative join <work_dir>/assets/... does not exist and the check
+// was control-quarantined. The fallback resolves the relative path against the
+// store root instead, so the gate is evaluated.
+func TestRunRalphCheckPackRelativeCheckPathWorkDirFallback(t *testing.T) {
+	cityPath := t.TempDir()
+	// Pack-shipped check script lives under the city/store root.
+	checkRel := filepath.Join("assets", "demo-pack", "scripts", "check.sh")
+	storeScript := filepath.Join(cityPath, checkRel)
+	if err := os.MkdirAll(filepath.Dir(storeScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(storeScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Per-task worktree under the city root that does NOT contain the pack tree.
+	workDir := filepath.Join(cityPath, "worktrees", "task1")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{"gc.kind": "workflow"}})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.check_path":   filepath.ToSlash(checkRel),
+			"gc.work_dir":     workDir,
+			"gc.max_attempts": "3",
+		},
+	})
+	subject := mustCreate(t, store, beads.Bead{
+		Title:    "review loop iteration 1",
+		Metadata: map[string]string{"gc.kind": "scope", "gc.root_bead_id": root.ID},
+	})
+
+	result, err := runRalphCheck(store, control, subject, 1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("runRalphCheck: %v (the pack-relative check_path should fall back to the store root)", err)
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("Outcome = %q (stderr=%q), want pass via store-root fallback", result.Outcome, result.Stderr)
+	}
+}
+
+// TestRunRalphCheckWorkDirRelativeCheckPathKeepsPrecedence guards that the
+// #3008 fallback only fires when the work_dir join is missing: a check_path
+// that DOES exist under the worktree must still resolve against the worktree,
+// not the store root.
+func TestRunRalphCheckWorkDirRelativeCheckPathKeepsPrecedence(t *testing.T) {
+	cityPath := t.TempDir()
+	checkRel := "check.sh"
+	// Same relative name exists in both the store root and the worktree; the
+	// worktree copy must win. Distinguish them by exit code.
+	if err := os.WriteFile(filepath.Join(cityPath, checkRel), []byte("#!/bin/sh\nexit 7\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workDir := filepath.Join(cityPath, "worktrees", "task1")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, checkRel), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{"gc.kind": "workflow"}})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.check_path":   checkRel,
+			"gc.work_dir":     workDir,
+			"gc.max_attempts": "3",
+		},
+	})
+	subject := mustCreate(t, store, beads.Bead{
+		Title:    "review loop iteration 1",
+		Metadata: map[string]string{"gc.kind": "scope", "gc.root_bead_id": root.ID},
+	})
+
+	result, err := runRalphCheck(store, control, subject, 1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("runRalphCheck: %v", err)
+	}
+	// The worktree copy exits 0 (pass); the store copy exits 7 (fail). A pass
+	// proves the worktree script ran, i.e. the fallback did not shadow it.
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("Outcome = %q (stderr=%q), want pass from the worktree-relative script", result.Outcome, result.Stderr)
+	}
+}
+
 // TestRunRalphCheckEnvTracksSubject pins gastownhall/gascity#2558 review
 // feedback: GC_BEAD_ID and the molecule/artifact dirs must describe the SAME
 // bead. The per-attempt agent runs on the subject (attempt) bead and writes


### PR DESCRIPTION
Closes #3008

## Problem

A pack-relative `gc.check_path` (e.g. `assets/<pack>/scripts/check.sh`) names a pack-shipped script that lives under the store/city root, **not** the per-task `gc.work_dir` worktree. When the control bead carries a `work_dir` pointing at a worktree that does not contain the pack tree, `runRalphCheck` set `scriptBase=work_dir`; the relative join `<work_dir>/assets/...` did not exist, `ResolveConditionPath` returned a not-exist error, and the control-dispatcher **quarantined the gate while letting the step advance unevaluated**.

## Fix

Fall back to the store/city root for a relative `check_path` when the worktree join misses with `fs.ErrNotExist` — exactly the base used when `work_dir` is empty, so **no new trusted root is introduced** and `ResolveConditionPath`'s containment checks still apply.

- The fallback fires only on a not-exist miss, so a check that *does* exist under the worktree keeps precedence.
- The original `work_dir` error is preserved when the fallback also misses.
- Absolute paths keep their existing behavior.

This is issue option 3 (least-surprising, no new config surface) — no `$PACK_DIR` expansion / anchor syntax added.

## Tests

`internal/dispatch/ralph_test.go` (+99): reproduces a pack-relative check path with `gc.work_dir` pointing at a worktree lacking the pack tree, asserts the gate resolves (not control_quarantined), plus worktree-precedence and fallback-also-misses cases.

`go build` + `go vet` + `internal/dispatch` suite green.
