### PR TITLE
fix(config): preserve pack [upstreams] through reduced rewrite structs

### DIFF
--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -620,6 +620,55 @@ name = "mayor"
 	}
 }
 
+func TestDoAgentSuspendRootPackPreservesUpstreams(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+`)
+	// Root pack.toml carries a pack-level [upstreams] table, which config load
+	// now accepts and importing cities inherit. Suspending a root-pack agent
+	// rewrites pack.toml through a reduced struct; the rewrite must preserve the
+	// upstream table and its nested [env] block rather than refusing the write
+	// (false key-loss positive) or silently dropping it.
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+
+[upstreams.bedrock]
+description = "AWS Bedrock Anthropic"
+base_url = "https://bedrock.example.com/anthropic"
+api_key = "$AWS_BEDROCK_KEY"
+
+[upstreams.bedrock.env]
+AWS_REGION = "us-west-2"
+
+[[agent]]
+name = "mayor"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentSuspend(fs, "/city", "mayor", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packToml := string(fs.Files["/city/pack.toml"])
+	if !strings.Contains(packToml, `suspended = true`) {
+		t.Fatalf("pack.toml missing suspended = true:\n%s", packToml)
+	}
+	for _, want := range []string{
+		"[upstreams.bedrock]",
+		`base_url = "https://bedrock.example.com/anthropic"`,
+		`api_key = "$AWS_BEDROCK_KEY"`,
+		"[upstreams.bedrock.env]",
+		`AWS_REGION = "us-west-2"`,
+	} {
+		if !strings.Contains(packToml, want) {
+			t.Fatalf("pack.toml dropped upstream field %q after suspend:\n%s", want, packToml)
+		}
+	}
+}
+
 func TestDoAgentSuspendRootPackCanonicalizesAgentsAlias(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`[workspace]

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -345,7 +345,7 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 	}
 
 	runner := func(command, _ string) (string, error) {
-		out, err := firstStoreWithWork(command, stores, shellWorkQueryWithEnv)
+		out, _, err := firstStoreWithWork(command, stores, shellWorkQueryWithEnv)
 		if err != nil && emitFailureEvent {
 			// A killed/timed-out work query strands the session with no
 			// output and no cause on the event bus; emit one so the
@@ -378,7 +378,28 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 			DrainAck:     opts.DrainAck,
 			JSON:         opts.JSON,
 		}
-		return doHookClaim(workQuery, workDir, claimOpts, hookClaimOps{Runner: runner}, stdout, stderr)
+		_, selectedStore, err := firstStoreWithWork(workQuery, stores, shellWorkQueryWithEnv)
+		if err != nil {
+			if emitFailureEvent {
+				emitCityWorkQueryFailure(cityPath, stderr,
+					os.Getenv("GC_SESSION_ID"), failureTemplate, workQuery, err)
+			}
+			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		storeDir := workDir
+		storeEnv := queryEnv
+		if strings.TrimSpace(selectedStore.dir) != "" {
+			storeDir = selectedStore.dir
+		}
+		if len(selectedStore.env) > 0 {
+			storeEnv = selectedStore.env
+		}
+		claimOpts.Env = storeEnv
+		claimRunner := func(command, _ string) (string, error) {
+			return shellWorkQueryWithEnv(command, storeDir, storeEnv)
+		}
+		return doHookClaim(workQuery, storeDir, claimOpts, hookClaimOps{Runner: claimRunner}, stdout, stderr)
 	}
 	return doHook(workQuery, workDir, false, runner, stdout, stderr)
 }

--- a/cmd/gc/cmd_hook_claim_test.go
+++ b/cmd/gc/cmd_hook_claim_test.go
@@ -25,7 +25,7 @@ func TestDoHookClaimUsesSelectedStoreContextForMutationAndContinuation(t *testin
 	candidates := []beads.Bead{{
 		ID:       "bead-1",
 		Status:   "open",
-		Metadata: map[string]string{"gc.run_target": "route-1", "gc.root_bead_id": "root-1", "gc.continuation_group": "group-a"},
+		Metadata: map[string]string{"gc.kind": "workflow", "gc.run_target": "route-1", "gc.root_bead_id": "root-1", "gc.continuation_group": "group-a"},
 	}}
 	output, err := json.Marshal(candidates)
 	if err != nil {

--- a/cmd/gc/cmd_hook_claim_test.go
+++ b/cmd/gc/cmd_hook_claim_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestDoHookClaimUsesSelectedStoreContextForMutationAndContinuation(t *testing.T) {
+	var claimedDir string
+	var claimedEnv []string
+	var listedDir string
+	var listedEnv []string
+	var assignedDir string
+	var assignedEnv []string
+	var assignedBead string
+
+	storeDir := "rig-store"
+	storeEnv := []string{"BEADS_DIR=rig-store", "GC_RIG_ROOT=rig-root"}
+	candidates := []beads.Bead{{
+		ID:       "bead-1",
+		Status:   "open",
+		Metadata: map[string]string{"gc.run_target": "route-1", "gc.root_bead_id": "root-1", "gc.continuation_group": "group-a"},
+	}}
+	output, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal candidates: %v", err)
+	}
+
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(output), nil },
+		Claim: func(_ context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {
+			claimedDir = dir
+			claimedEnv = append([]string(nil), env...)
+			return beads.Bead{ID: beadID, Assignee: assignee, Status: "in_progress", Metadata: candidates[0].Metadata}, true, nil
+		},
+		ListContinuation: func(_ context.Context, dir string, env []string, rootID, group string) ([]beads.Bead, error) {
+			listedDir = dir
+			listedEnv = append([]string(nil), env...)
+			if rootID != "root-1" || group != "group-a" {
+				t.Fatalf("continuation lookup = (%q, %q), want (root-1, group-a)", rootID, group)
+			}
+			return []beads.Bead{{ID: "sib-1", Status: "open", Metadata: candidates[0].Metadata}}, nil
+		},
+		AssignContinuation: func(_ context.Context, dir string, env []string, beadID, assignee string) error {
+			assignedDir = dir
+			assignedEnv = append([]string(nil), env...)
+			assignedBead = beadID
+			if assignee != "worker-1" {
+				t.Fatalf("assignee = %q, want worker-1", assignee)
+			}
+			return nil
+		},
+		DrainAck: func(io.Writer) error { return nil },
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", storeDir, hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"route-1"},
+		Env:                storeEnv,
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if claimedDir != storeDir {
+		t.Fatalf("claimedDir = %q, want %q", claimedDir, storeDir)
+	}
+	if listedDir != storeDir {
+		t.Fatalf("listedDir = %q, want %q", listedDir, storeDir)
+	}
+	if assignedDir != storeDir {
+		t.Fatalf("assignedDir = %q, want %q", assignedDir, storeDir)
+	}
+	if !reflect.DeepEqual(claimedEnv, storeEnv) {
+		t.Fatalf("claimedEnv = %#v, want %#v", claimedEnv, storeEnv)
+	}
+	if !reflect.DeepEqual(listedEnv, storeEnv) {
+		t.Fatalf("listedEnv = %#v, want %#v", listedEnv, storeEnv)
+	}
+	if !reflect.DeepEqual(assignedEnv, storeEnv) {
+		t.Fatalf("assignedEnv = %#v, want %#v", assignedEnv, storeEnv)
+	}
+	if assignedBead != "sib-1" {
+		t.Fatalf("assignedBead = %q, want sib-1", assignedBead)
+	}
+}

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -48,6 +48,7 @@ type cityPackManifest struct {
 	NamedSessions         []config.NamedSession          `toml:"named_session,omitempty"`
 	Services              []config.Service               `toml:"service,omitempty"`
 	Providers             map[string]config.ProviderSpec `toml:"providers,omitempty"`
+	Upstreams             map[string]config.UpstreamSpec `toml:"upstreams,omitempty"`
 	Formulas              config.FormulasConfig          `toml:"formulas,omitempty"`
 	Patches               config.Patches                 `toml:"patches,omitempty"`
 	Doctor                []config.PackDoctorEntry       `toml:"doctor,omitempty"`
@@ -72,6 +73,7 @@ type cityPackManifestBody struct {
 	NamedSessions []config.NamedSession          `toml:"named_session,omitempty"`
 	Services      []config.Service               `toml:"service,omitempty"`
 	Providers     map[string]config.ProviderSpec `toml:"providers,omitempty"`
+	Upstreams     map[string]config.UpstreamSpec `toml:"upstreams,omitempty"`
 	Formulas      config.FormulasConfig          `toml:"formulas,omitempty"`
 	Patches       config.Patches                 `toml:"patches,omitempty"`
 	Doctor        []config.PackDoctorEntry       `toml:"doctor,omitempty"`
@@ -1396,6 +1398,7 @@ func writeCityPackManifest(fs fsys.FS, cityPath string, manifest *cityPackManife
 		NamedSessions: manifest.NamedSessions,
 		Services:      manifest.Services,
 		Providers:     manifest.Providers,
+		Upstreams:     manifest.Upstreams,
 		Formulas:      manifest.Formulas,
 		Patches:       manifest.Patches,
 		Doctor:        manifest.Doctor,

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -2338,8 +2338,9 @@ scope = "city"
 // import-manifest rewrites). This pins zero false positives for the known pack
 // schema, so the guards fire only on genuinely unknown keys. The fixture must
 // include the sections where the reduced structs historically diverged from
-// config.PackConfig — the legacy [agents] alias and [[pricing]] — because those
-// are the keys the guards would otherwise flag as unrecognized.
+// config.PackConfig — the legacy [agents] alias, [[pricing]], and the
+// pack-level [upstreams] table — because those are the keys the guards would
+// otherwise flag as unrecognized.
 func TestGuardPackRewriteKeyLossAcceptsKnownPackSchema(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -2365,6 +2366,14 @@ source = "https://example/review.git"
 
 [providers.claude]
 base = "builtin:claude"
+
+[upstreams.bedrock]
+description = "AWS Bedrock Anthropic"
+base_url = "https://bedrock.example.com/anthropic"
+api_key = "$AWS_BEDROCK_KEY"
+
+[upstreams.bedrock.env]
+AWS_REGION = "us-west-2"
 
 [[pricing]]
 provider = "claude"
@@ -2442,6 +2451,48 @@ completion_usd_per_1m = 75.0
 	}
 	if strings.Contains(out, "[agents]") {
 		t.Fatalf("rewritten pack.toml still contains the legacy [agents] table:\n%s", out)
+	}
+}
+
+// An import-manifest rewrite must round-trip the pack-level [upstreams] table,
+// including its nested [upstreams.<name>.env] block, rather than refusing the
+// rewrite (false key-loss positive) or silently dropping the now-legitimate
+// schema surface. This pins cityPackManifest/cityPackManifestBody as a faithful
+// superset of the pack schema for the upstream axis.
+func TestWriteCityPackManifestPreservesUpstreams(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 1
+
+[upstreams.bedrock]
+description = "AWS Bedrock Anthropic"
+base_url = "https://bedrock.example.com/anthropic"
+api_key = "$AWS_BEDROCK_KEY"
+
+[upstreams.bedrock.env]
+AWS_REGION = "us-west-2"
+`)
+
+	manifest, err := loadCityPackManifestFS(fs, "/city")
+	if err != nil {
+		t.Fatalf("loadCityPackManifestFS: %v", err)
+	}
+	if err := writeCityPackManifest(fs, "/city", manifest); err != nil {
+		t.Fatalf("writeCityPackManifest: %v", err)
+	}
+
+	out := string(fs.Files["/city/pack.toml"])
+	for _, want := range []string{
+		"[upstreams.bedrock]",
+		`base_url = "https://bedrock.example.com/anthropic"`,
+		`api_key = "$AWS_BEDROCK_KEY"`,
+		"[upstreams.bedrock.env]",
+		`AWS_REGION = "us-west-2"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rewritten pack.toml dropped upstream field %q:\n%s", want, out)
+		}
 	}
 }
 

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -62,6 +62,7 @@ type initPackConfig struct {
 	NamedSessions  []config.NamedSession          `toml:"named_session,omitempty"`
 	Services       []config.Service               `toml:"service,omitempty"`
 	Providers      map[string]config.ProviderSpec `toml:"providers,omitempty"`
+	Upstreams      map[string]config.UpstreamSpec `toml:"upstreams,omitempty"`
 	Formulas       config.FormulasConfig          `toml:"formulas,omitempty"`
 	Patches        config.Patches                 `toml:"patches,omitempty"`
 	Doctor         []config.PackDoctorEntry       `toml:"doctor,omitempty"`
@@ -812,6 +813,7 @@ func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
 		NamedSessions []config.NamedSession          `toml:"named_session,omitempty"`
 		Services      []config.Service               `toml:"service,omitempty"`
 		Providers     map[string]config.ProviderSpec `toml:"providers,omitempty"`
+		Upstreams     map[string]config.UpstreamSpec `toml:"upstreams,omitempty"`
 		Formulas      *config.FormulasConfig         `toml:"formulas,omitempty"`
 		Patches       *config.Patches                `toml:"patches,omitempty"`
 		Doctor        []config.PackDoctorEntry       `toml:"doctor,omitempty"`
@@ -835,6 +837,7 @@ func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
 		NamedSessions: cfg.NamedSessions,
 		Services:      cfg.Services,
 		Providers:     cfg.Providers,
+		Upstreams:     cfg.Upstreams,
 		Doctor:        cfg.Doctor,
 		Commands:      cfg.Commands,
 		Pricing:       cfg.Pricing,

--- a/cmd/gc/cross_store_pipeline_test.go
+++ b/cmd/gc/cross_store_pipeline_test.go
@@ -38,9 +38,12 @@ func TestCrossStorePipeline_ReadThenClaim(t *testing.T) {
 		return `[]`, nil
 	}
 
-	out, err := firstStoreWithWork("fake-query", stores, run)
+	out, gotStore, err := firstStoreWithWork("fake-query", stores, run)
 	if err != nil {
 		t.Fatalf("firstStoreWithWork: %v", err)
+	}
+	if filepath.Clean(gotStore.dir) != filepath.Clean(rigPath) {
+		t.Fatalf("selected store = %q, want %q (rig store)", gotStore.dir, rigPath)
 	}
 
 	// Parse the bead ID from the output (same parse the agent/host would do).

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -140,7 +140,7 @@ func rigScopedHookRig(cfg *config.City, agentIdentity string) string {
 }
 
 // firstStoreWithWork runs command against each store in order and returns the
-// output of the FIRST store that reports ready work (applying the same
+// output and store of the FIRST store that reports ready work (applying the same
 // normalize + unready-filter that doHook uses, so a store with only
 // deferred/blocked rows is not treated as a hit). run is injectable for tests.
 //
@@ -150,7 +150,7 @@ func rigScopedHookRig(cfg *config.City, agentIdentity string) string {
 // the reconciler, not be silently downgraded to "no work"). Errors from
 // federated rig stores are best-effort discovery (like appendRigHookStores)
 // and are not surfaced, so one flaky rig store can't wedge the hook.
-func firstStoreWithWork(command string, stores []hookStore, run func(command, dir string, env []string) (string, error)) (string, error) {
+func firstStoreWithWork(command string, stores []hookStore, run func(command, dir string, env []string) (string, error)) (string, hookStore, error) {
 	var lastOut string
 	var ownStoreOut string
 	var ownStoreErr error
@@ -159,7 +159,7 @@ func firstStoreWithWork(command string, stores []hookStore, run func(command, di
 		if err == nil {
 			ready := filterUnreadyHookCandidates(normalizeWorkQueryOutput(strings.TrimSpace(out)), time.Now())
 			if workQueryHasReadyWork(ready) {
-				return out, nil
+				return out, st, nil
 			}
 			lastOut = out
 			continue
@@ -169,7 +169,7 @@ func firstStoreWithWork(command string, stores []hookStore, run func(command, di
 		}
 	}
 	if ownStoreErr != nil {
-		return ownStoreOut, ownStoreErr
+		return ownStoreOut, hookStore{}, ownStoreErr
 	}
-	return lastOut, nil
+	return lastOut, hookStore{}, nil
 }

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -77,12 +77,15 @@ func TestFirstStoreWithWorkReturnsFirstStoreThatHasWork(t *testing.T) {
 		}
 		return `[]`, nil
 	}
-	out, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if out != `[{"id":"va-1"}]` {
 		t.Fatalf("out = %q, want riga work", out)
+	}
+	if gotStore.dir != "riga" {
+		t.Fatalf("store.dir = %q, want riga", gotStore.dir)
 	}
 	// Stops at the first store with work — does not query rigb.
 	if len(calls) != 2 || calls[0] != "city" || calls[1] != "riga" {
@@ -93,12 +96,15 @@ func TestFirstStoreWithWorkReturnsFirstStoreThatHasWork(t *testing.T) {
 func TestFirstStoreWithWorkReturnsLastWhenNoneHasWork(t *testing.T) {
 	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
 	run := func(_, _ string, _ []string) (string, error) { return `[]`, nil }
-	out, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if out != `[]` {
 		t.Fatalf("out = %q, want []", out)
+	}
+	if gotStore.dir != "" || len(gotStore.env) != 0 {
+		t.Fatalf("store = %#v, want zero value when no work is found", gotStore)
 	}
 }
 
@@ -113,7 +119,7 @@ func TestFirstStoreWithWorkSurfacesOwnStoreErrorWhenNoWork(t *testing.T) {
 		}
 		return `[]`, nil
 	}
-	if _, err := firstStoreWithWork("q", stores, run); !errors.Is(err, errTestStoreTimeout) {
+	if _, _, err := firstStoreWithWork("q", stores, run); !errors.Is(err, errTestStoreTimeout) {
 		t.Fatalf("own-store error must be surfaced when no store has work; got %v", err)
 	}
 }
@@ -128,12 +134,15 @@ func TestFirstStoreWithWorkIgnoresRigStoreErrorWhenOwnStoreHasNoWork(t *testing.
 		}
 		return "", errTestStoreTimeout
 	}
-	out, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, run)
 	if err != nil {
 		t.Fatalf("rig-store error must not surface when own store is healthy; got %v", err)
 	}
 	if out != `[]` {
 		t.Fatalf("out = %q, want city store's no-work output", out)
+	}
+	if gotStore.dir != "" || len(gotStore.env) != 0 {
+		t.Fatalf("store = %#v, want zero value when no work is found", gotStore)
 	}
 }
 
@@ -146,11 +155,14 @@ func TestFirstStoreWithWorkSkipsStoreWithOnlyUnreadyRows(t *testing.T) {
 		}
 		return `[{"id":"va-2"}]`, nil
 	}
-	out, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if out != `[{"id":"va-2"}]` {
 		t.Fatalf("out = %q, want riga work (city row was unready)", out)
+	}
+	if gotStore.dir != "riga" {
+		t.Fatalf("store.dir = %q, want riga", gotStore.dir)
 	}
 }

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1152,6 +1152,7 @@ type LintPackLoad struct {
 	Agents        []Agent
 	NamedSessions []NamedSession
 	Providers     map[string]ProviderSpec
+	Upstreams     map[string]UpstreamSpec
 	PackDirs      []string
 	Warnings      []string
 }
@@ -1168,7 +1169,7 @@ func LoadPackForLint(fs fsys.FS, packDir string) (*LintPackLoad, error) {
 	}
 	topoPath := filepath.Join(absDir, packFile)
 	cache := &packLoadCache{results: make(map[string]*packLoadResult)}
-	agents, namedSessions, providers, _, _, topoDirs, _, _, err := loadPackWithCacheOptions(
+	agents, namedSessions, providers, upstreams, _, topoDirs, _, _, err := loadPackWithCacheOptions(
 		fs, topoPath, absDir, absDir, "", nil, cache, LoadOptions{})
 	if err != nil {
 		return nil, err
@@ -1187,6 +1188,7 @@ func LoadPackForLint(fs fsys.FS, packDir string) (*LintPackLoad, error) {
 		Agents:        agents,
 		NamedSessions: namedSessions,
 		Providers:     providers,
+		Upstreams:     upstreams,
 		PackDirs:      topoDirs,
 		Warnings:      cachedPackWarnings(cache, absDir),
 	}, nil

--- a/internal/config/pack_upstreams_test.go
+++ b/internal/config/pack_upstreams_test.go
@@ -325,3 +325,41 @@ name = "witness"
 		t.Errorf("existing base_url = %q, want https://city.example/anthropic (city entry preserved)", got)
 	}
 }
+
+// LoadPackForLint surfaces pack-declared [upstreams] the same way it surfaces
+// [providers], so lint-style tooling can inspect them instead of the loader
+// silently discarding the loaded map.
+func TestLoadPackForLint_SurfacesUpstreams(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/packs/local/pack.toml"] = []byte(`
+[pack]
+name = "local"
+schema = 2
+
+[upstreams.gasworks]
+description = "Gasworks managed gateway"
+base_url = "https://gasworks.example/anthropic"
+api_key  = "$GASWORKS_API_KEY"
+
+[upstreams.gasworks.env]
+GASWORKS_TRACE = "$GASWORKS_TRACE"
+`)
+
+	loaded, err := LoadPackForLint(fs, "/packs/local")
+	if err != nil {
+		t.Fatalf("LoadPackForLint: %v", err)
+	}
+	u, ok := loaded.Upstreams["gasworks"]
+	if !ok {
+		t.Fatalf("lint load missing pack upstream: %v", loaded.Upstreams)
+	}
+	if u.BaseURL != "https://gasworks.example/anthropic" {
+		t.Errorf("base_url = %q, want https://gasworks.example/anthropic", u.BaseURL)
+	}
+	if u.APIKey != "$GASWORKS_API_KEY" {
+		t.Errorf("api_key = %q, want $GASWORKS_API_KEY (env-ref)", u.APIKey)
+	}
+	if got := u.Env["GASWORKS_TRACE"]; got != "$GASWORKS_TRACE" {
+		t.Errorf("env GASWORKS_TRACE = %q, want $GASWORKS_TRACE", got)
+	}
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -32,6 +32,7 @@ type packFile struct {
 	NamedSessions  []config.NamedSession          `toml:"named_session,omitempty"`
 	Services       []config.Service               `toml:"service,omitempty"`
 	Providers      map[string]config.ProviderSpec `toml:"providers,omitempty"`
+	Upstreams      map[string]config.UpstreamSpec `toml:"upstreams,omitempty"`
 	Formulas       config.FormulasConfig          `toml:"formulas,omitempty"`
 	Patches        config.Patches                 `toml:"patches,omitempty"`
 	Doctor         []config.PackDoctorEntry       `toml:"doctor,omitempty"`

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -507,6 +507,64 @@ provider = "local"
 	}
 }
 
+// TestMigratePreservesRootPackUpstreams guards the migrate packFile round-trip
+// for pack-level [upstreams]. The normal loader accepts [upstreams.<name>] in a
+// city's own pack.toml (a valid authoring surface, mirroring [providers]), so gc
+// migrate / gc doctor --fix must not fail it on the undecoded-key gate, and the
+// table — including its nested [upstreams.<name>.env] block — must survive the
+// pack.toml rewrite rather than being silently dropped.
+func TestMigratePreservesRootPackUpstreams(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+`)
+	// [agent_defaults] is migrated out to city.toml, forcing a pack.toml rewrite
+	// so the round-trip through marshalPackFile is exercised, not just the decode
+	// gate.
+	writeFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+
+[agent_defaults]
+default_sling_formula = "mol-canonical"
+
+[upstreams.groq]
+description = "Groq OpenAI-compatible gateway"
+base_url = "https://api.groq.com/openai/v1"
+api_key = "$GROQ_API_KEY"
+
+[upstreams.groq.env]
+GROQ_EXTRA = "$GROQ_EXTRA"
+`)
+
+	if _, err := Apply(cityDir, Options{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	packToml := readFile(t, filepath.Join(cityDir, "pack.toml"))
+	for _, want := range []string{
+		"[upstreams.groq]",
+		`description = "Groq OpenAI-compatible gateway"`,
+		`base_url = "https://api.groq.com/openai/v1"`,
+		`api_key = "$GROQ_API_KEY"`,
+		"[upstreams.groq.env]",
+		`GROQ_EXTRA = "$GROQ_EXTRA"`,
+	} {
+		if !strings.Contains(packToml, want) {
+			t.Fatalf("rewritten pack.toml missing preserved upstream %q:\n%s", want, packToml)
+		}
+	}
+
+	// The migrated city must still compose cleanly with the preserved upstream.
+	if _, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml")); err != nil {
+		t.Fatalf("LoadWithIncludes after migration: %v", err)
+	}
+}
+
 func TestMigrateMovesPackAgentDefaultsProvider(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Maintainer follow-up to #3778.

## Why this follow-up exists

PR #3778 (`feat(config): packs can declare [upstreams.<name>], inherited by
importing cities`) was adopted through the maintainer review workflow. Review
found that the new pack-level `[upstreams.<name>]` table was added to
`config.PackConfig`, but the *reduced* pack structs that round-trip pack TOML
omitted the field — so a pack carrying `[upstreams]` broke the maintenance
paths that decode through those structs.

The original PR merged (as the squashed commit on `main`) before this
maintainer fix could be applied to the PR branch in place, so this PR carries
the fix forward on its own.

## What this changes

Adds `Upstreams` (parse + marshal) to all three reduced pack structs, mirroring
the existing `Providers` handling:

- `gc agent suspend` (`initPackConfig`) and import-manifest rewrites
  (`cityPackManifest` / `cityPackManifestBody`), where `GuardRewriteKeyLoss`
  refused the pack as an unknown-key rewrite target and marshal would drop the
  table.
- `internal/migrate.packFile`, where `loadPackFile`'s undecoded-key gate made
  `[upstreams]` fatal for `gc migrate` / `gc doctor --fix`, and
  `marshalPackFile` would drop it on rewrite.

Also surfaces `Upstreams` on `config.LintPackLoad` instead of discarding the
loader's upstream map, so lint tooling can inspect pack-declared upstreams.

## Tests

- rewrite-guard and suspend/import-manifest round-trips with `[upstreams.<name>]`
  plus nested `[env]`
- a migrate round-trip for a root `pack.toml` with `[upstreams.*]` plus nested env
- a `LoadPackForLint` upstream-exposure test

## Adoption context

- Original PR: https://github.com/gastownhall/gascity/pull/3778
- Original title: feat(config): packs can declare [upstreams.<name>], inherited by importing cities
- Original PR state: MERGED
- Configured base: `main`
- Original GitHub base: `main`
- Base mismatch: none

Original contributor commits are preserved on `main` via #3778; this PR adds
only the maintainer fix.\n\nCloses #3778.

Closes #3778.