### PR TITLE
fix(test-isolation): resolve symlinks in discovery (adopts #3362)

### DIFF
--- a/cmd/gc/city_discovery.go
+++ b/cmd/gc/city_discovery.go
@@ -145,5 +145,27 @@ func normalizeDiscoveryPath(path string) string {
 	if err == nil {
 		path = abs
 	}
-	return filepath.Clean(path)
+	// Resolve symlinks so ceiling comparisons match regardless of how the
+	// path was obtained: on macOS, t.Chdir/os.Getwd can yield /tmp/... while
+	// the same directory resolves to /private/tmp/..., and comparing the two
+	// raw forms silently defeats the ceiling. Both the walked directory and
+	// the configured ceilings flow through here, so resolution stays
+	// symmetric. For paths that do not (fully) exist, resolve the longest
+	// existing ancestor and re-append the remainder, so a configured-but-
+	// not-yet-created ceiling still normalizes consistently instead of
+	// silently dropping out of the comparison.
+	path = filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved)
+	}
+	dir, rest := path, ""
+	for dir != string(filepath.Separator) && dir != "." {
+		parent := filepath.Dir(dir)
+		rest = filepath.Join(filepath.Base(dir), rest)
+		dir = parent
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Clean(filepath.Join(resolved, rest))
+		}
+	}
+	return path
 }

--- a/cmd/gc/city_discovery_symlink_test.go
+++ b/cmd/gc/city_discovery_symlink_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests pin the symlink-resolution behavior added to
+// normalizeDiscoveryPath and its effect on findCity's ceiling comparison. They
+// reproduce on Linux the macOS failure mode where os.Getwd()/t.Chdir yields
+// /tmp/... while the same directory resolves to /private/tmp/..., which
+// silently defeated GC_CEILING_DIRECTORIES before discovery paths were run
+// through filepath.EvalSymlinks. Linux CI never exercised the symlink/fallback
+// branches otherwise, so the fix shipped without executable coverage.
+
+func TestNormalizeDiscoveryPathResolvesExistingSymlink(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Clean(resolved)
+
+	if got := normalizeDiscoveryPath(link); got != want {
+		t.Errorf("normalizeDiscoveryPath(%q) = %q, want resolved real path %q", link, got, want)
+	}
+	// The symlink and the real directory must normalize identically, or ceiling
+	// comparisons would not be symmetric.
+	if got, viaReal := normalizeDiscoveryPath(link), normalizeDiscoveryPath(realDir); got != viaReal {
+		t.Errorf("symlink and real path normalize differently: %q vs %q", got, viaReal)
+	}
+}
+
+func TestNormalizeDiscoveryPathFallsBackToLongestExistingAncestor(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	// A configured-but-not-yet-created ceiling under the symlink. The existing
+	// ancestor (link -> realDir) must resolve while the missing remainder is
+	// re-appended verbatim, instead of the whole path dropping out of the
+	// comparison because EvalSymlinks failed on the leaf.
+	missing := filepath.Join(link, "not", "yet", "created")
+
+	resolved, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(filepath.Clean(resolved), "not", "yet", "created")
+
+	if got := normalizeDiscoveryPath(missing); got != want {
+		t.Errorf("normalizeDiscoveryPath(%q) = %q, want %q", missing, got, want)
+	}
+	// The same not-yet-created path expressed through the real directory must
+	// normalize identically, keeping discovery comparisons symmetric.
+	viaReal := normalizeDiscoveryPath(filepath.Join(realDir, "not", "yet", "created"))
+	if got := normalizeDiscoveryPath(missing); got != viaReal {
+		t.Errorf("symlinked vs real missing path normalize differently: %q vs %q", got, viaReal)
+	}
+}
+
+func TestFindCitySymlinkedCeilingBoundsDiscovery(t *testing.T) {
+	root := t.TempDir()
+	realCeiling := filepath.Join(root, "ceiling")
+	if err := os.MkdirAll(realCeiling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkCeiling := filepath.Join(root, "ceiling-link")
+	if err := os.Symlink(realCeiling, linkCeiling); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	// A stray city above the ceiling that discovery must NOT escape up to.
+	if err := os.WriteFile(filepath.Join(root, "city.toml"), []byte("[workspace]\nname = \"stray\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	start := filepath.Join(realCeiling, "child", "deep")
+	if err := os.MkdirAll(start, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure the ceiling via its symlinked form while discovery walks the
+	// real form. Before discovery paths were symlink-resolved, the raw strings
+	// differed, the ceiling never fired, and findCity escaped to the stray city
+	// above. With resolution both sides collapse to the same real path and the
+	// ceiling bounds the walk.
+	t.Setenv("GC_CEILING_DIRECTORIES", linkCeiling)
+
+	_, err := findCity(start)
+	if err == nil {
+		t.Fatal("findCity() escaped a symlinked ceiling and found the stray city above")
+	}
+	if !strings.Contains(err.Error(), "not in a city directory") {
+		t.Errorf("error = %q, want 'not in a city directory'", err)
+	}
+}

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -87,7 +87,12 @@ func clearGCEnv(t *testing.T) {
 	for _, k := range liveEnvKeysForTests() {
 		t.Setenv(k, "")
 	}
-	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "gc-home"))
+	td := t.TempDir()
+	t.Setenv("GC_HOME", filepath.Join(td, "gc-home"))
+	// Prevent city discovery from walking above the test temp dir and finding
+	// a .gc/ directory left by a running city or a prior test run in /tmp
+	// (e.g. a developer box hosting a live city contaminates no-city tests).
+	t.Setenv("GC_CEILING_DIRECTORIES", filepath.Dir(td))
 }
 
 func clearProcessLiveEnvForTests() {


### PR DESCRIPTION
Adopts and supersedes #3362 by @bourgois (from `Voxist/gascity`). Re-homed to a maintainer fork branch because a maintainer push to the contributor fork was blocked (403), so the original PR couldn't be updated in place.

## Contents
- **@bourgois's fix preserved** (commit `ed48e402e`): resolve symlinks in discovery-path normalization + ceiling `cmd/gc` tests.
- **Maintainer regression test added** (`39a92dba4`): cover symlink discovery ceiling + longest-existing-ancestor fallback — RED pre-fix, GREEN post-fix.

## Review
Three-model adopt-pr review (Claude go + Claude code + Codex): verdict take-the-good — fix is correct, no blast radius (`findCity` return shape unchanged, symmetry intact); the only gap was test evidence, now closed.

Gates: gofmt clean, `go vet ./cmd/gc` clean, new symlink suite RED→GREEN, `TestFindCity` all pass.

Credit to @bourgois. no-issue: adopted contributor fix, no separate tracking issue.
