### PR TITLE
fix(hook): fall back across stores when claim-time store empties

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -386,40 +386,69 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 }
 
 // claimHookWork claims routed work for gc hook --claim from the federated store
-// set. It selects the first store reporting ready work, then re-validates that
-// store and falls back to federated re-selection when it emptied between
-// discovery and claim (see claimStoreWithFallback), so routed work in a later
-// store is not stranded behind a stale single-store rerun. The captured
-// work-query output is handed to doHookClaim so the claim acts on the same rows
-// the selection observed, against that store's dir/env. emitFailure surfaces a
-// work-query timeout on the event bus when eligible.
+// set, binding the production shell work-query runner and real claim ops. See
+// claimHookWorkWithRunner for the federation and lost-claim-race semantics.
 func claimHookWork(workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
-	claimOutput, selectedStore, err := firstStoreWithWork(workQuery, stores, shellWorkQueryWithEnv)
-	claimStore := selectedStore
-	// firstStoreWithWork returns a zero store only when no store has ready work;
-	// re-validating then would query an unrelated default dir, so fall straight
-	// through to the no-work drain on the discovery output. When a store WAS
-	// selected, re-validate it for claim-time freshness and fall back to a later
-	// store if it has emptied since discovery.
-	if err == nil && (selectedStore.dir != "" || len(selectedStore.env) > 0) {
-		claimOutput, claimStore, err = claimStoreWithFallback(workQuery, stores, selectedStore, shellWorkQueryWithEnv)
+	return claimHookWorkWithRunner(workQuery, workDir, queryEnv, stores, claimOpts, hookClaimOps{}, shellWorkQueryWithEnv, emitFailure, stdout, stderr)
+}
+
+// claimHookWorkWithRunner is claimHookWork with the work-query runner and claim
+// ops injected for tests. It selects the first store reporting ready work,
+// re-validates it for claim-time freshness and falls back to a later store if it
+// emptied since discovery (claimStoreWithFallback), then attempts the claim
+// against that store's captured rows, against that store's dir/env.
+//
+// When a selected store still reports ready work but every claimable row is lost
+// to another claimant before the mutation, the single-store claim drains as
+// "no work". That would strand routed work waiting in a LATER federated store
+// behind the lost race, so this loop drops the exhausted store and reselects
+// across the remaining stores. It writes the no-work drain exactly once, after
+// every store has been exhausted. emitFailure surfaces a work-query timeout on
+// the event bus when eligible.
+func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, ops hookClaimOps, run hookStoreRunner, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
+	ops.applyDefaults()
+	remaining := stores
+	for len(remaining) > 0 {
+		_, selected, err := firstStoreWithWork(workQuery, remaining, run)
+		if err != nil {
+			emitFailure(workQuery, err)
+			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if isZeroHookStore(selected) {
+			break // no remaining store has ready work
+		}
+		claimOutput, claimStore, err := claimStoreWithFallback(workQuery, remaining, selected, run)
+		if err != nil {
+			emitFailure(workQuery, err)
+			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if isZeroHookStore(claimStore) {
+			break // selected store emptied and no later store has ready work
+		}
+		storeOpts := claimOpts
+		storeOpts.Env = queryEnv
+		if len(claimStore.env) > 0 {
+			storeOpts.Env = claimStore.env
+		}
+		storeDir := workDir
+		if dir := strings.TrimSpace(claimStore.dir); dir != "" {
+			storeDir = dir
+		}
+		storeOps := ops
+		storeOps.Runner = func(string, string) (string, error) { return claimOutput, nil }
+		res := tryHookClaim(workQuery, storeDir, &storeOpts, &storeOps, stdout, stderr)
+		if res.terminal {
+			return res.code
+		}
+		// This store reported ready work but the claim acquired nothing (every
+		// claimable row was lost to another claimant, or none matched this
+		// session). Drop it and reselect from the remaining stores so routed work
+		// in a later federated store is not stranded behind it.
+		remaining = removeHookStore(remaining, claimStore)
 	}
-	if err != nil {
-		emitFailure(workQuery, err)
-		fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	storeDir := workDir
-	if dir := strings.TrimSpace(claimStore.dir); dir != "" {
-		storeDir = dir
-	}
-	storeEnv := queryEnv
-	if len(claimStore.env) > 0 {
-		storeEnv = claimStore.env
-	}
-	claimOpts.Env = storeEnv
-	claimRunner := func(string, string) (string, error) { return claimOutput, nil }
-	return doHookClaim(workQuery, storeDir, claimOpts, hookClaimOps{Runner: claimRunner}, stdout, stderr)
+	return writeHookClaimNoWork(claimOpts, ops, stdout, stderr)
 }
 
 func hookClaimPrimaryRouteTarget(a *config.Agent) string {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -356,7 +356,7 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 			os.Getenv("GC_SESSION_ID"), failureTemplate, command, err)
 	}
 	runner := func(command, _ string) (string, error) {
-		out, _, err := firstStoreWithWork(command, stores, shellWorkQueryWithEnv)
+		out, _, err := firstStoreWithWork(command, stores, stores[0], shellWorkQueryWithEnv)
 		emitQueryFailure(command, err)
 		return out, err
 	}
@@ -407,9 +407,18 @@ func claimHookWork(workQuery, workDir string, queryEnv []string, stores []hookSt
 // the event bus when eligible.
 func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, ops hookClaimOps, run hookStoreRunner, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
 	ops.applyDefaults()
+	// primary is the agent's own store (the first entry). It is captured once
+	// here, before the loop shrinks remaining: only the primary may surface a
+	// work-query error as a fatal claim failure. Once the primary loses its
+	// claim race and is dropped, a later federated store must never inherit that
+	// emit-on-timeout semantics, so it is matched by identity, not slice index.
+	var primary hookStore
+	if len(stores) > 0 {
+		primary = stores[0]
+	}
 	remaining := stores
 	for len(remaining) > 0 {
-		_, selected, err := firstStoreWithWork(workQuery, remaining, run)
+		_, selected, err := firstStoreWithWork(workQuery, remaining, primary, run)
 		if err != nil {
 			emitFailure(workQuery, err)
 			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -418,7 +427,7 @@ func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, store
 		if isZeroHookStore(selected) {
 			break // no remaining store has ready work
 		}
-		claimOutput, claimStore, err := claimStoreWithFallback(workQuery, remaining, selected, run)
+		claimOutput, claimStore, err := claimStoreWithFallback(workQuery, remaining, selected, primary, run)
 		if err != nil {
 			emitFailure(workQuery, err)
 			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -344,17 +344,20 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 		stores = appendCityHookStore(stores, cityPath, cfg, &a, overrides)
 	}
 
+	// emitQueryFailure surfaces a killed/timed-out work query on the event bus
+	// so the reconciler can escalate instead of silently treating the strand as
+	// "no work" (issues #1496/#1497). Ordinary command errors are ignored by
+	// emitCityWorkQueryFailure and stay on the caller's stderr path.
+	emitQueryFailure := func(command string, err error) {
+		if err == nil || !emitFailureEvent {
+			return
+		}
+		emitCityWorkQueryFailure(cityPath, stderr,
+			os.Getenv("GC_SESSION_ID"), failureTemplate, command, err)
+	}
 	runner := func(command, _ string) (string, error) {
 		out, _, err := firstStoreWithWork(command, stores, shellWorkQueryWithEnv)
-		if err != nil && emitFailureEvent {
-			// A killed/timed-out work query strands the session with no
-			// output and no cause on the event bus; emit one so the
-			// reconciler can escalate instead of skipping it forever
-			// (issues #1496/#1497). Ordinary command errors are ignored
-			// by emitWorkQueryFailure and stay on the stderr path below.
-			emitCityWorkQueryFailure(cityPath, stderr,
-				os.Getenv("GC_SESSION_ID"), failureTemplate, command, err)
-		}
+		emitQueryFailure(command, err)
 		return out, err
 	}
 	if opts.Claim {
@@ -362,7 +365,6 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 		sessionName := strings.TrimSpace(sessionForQuery)
 		alias := strings.TrimSpace(overrides["GC_ALIAS"])
 		assignee := firstNonEmptyHookValue(sessionName, sessionID, alias, agentForQuery, resolvedAgentName)
-		routeTarget := hookClaimPrimaryRouteTarget(&a)
 		claimOpts := hookClaimOptions{
 			Assignee: assignee,
 			IdentityCandidates: hookClaimIdentityCandidates(
@@ -373,35 +375,51 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 				agentForQuery,
 				resolvedAgentName,
 			),
-			RouteTargets: hookClaimRouteTargets(routeTarget, resolvedAgentName, strings.TrimSpace(overrides["GC_TEMPLATE"])),
+			RouteTargets: hookClaimRouteTargets(hookClaimPrimaryRouteTarget(&a), resolvedAgentName, strings.TrimSpace(overrides["GC_TEMPLATE"])),
 			Env:          queryEnv,
 			DrainAck:     opts.DrainAck,
 			JSON:         opts.JSON,
 		}
-		_, selectedStore, err := firstStoreWithWork(workQuery, stores, shellWorkQueryWithEnv)
-		if err != nil {
-			if emitFailureEvent {
-				emitCityWorkQueryFailure(cityPath, stderr,
-					os.Getenv("GC_SESSION_ID"), failureTemplate, workQuery, err)
-			}
-			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		storeDir := workDir
-		storeEnv := queryEnv
-		if strings.TrimSpace(selectedStore.dir) != "" {
-			storeDir = selectedStore.dir
-		}
-		if len(selectedStore.env) > 0 {
-			storeEnv = selectedStore.env
-		}
-		claimOpts.Env = storeEnv
-		claimRunner := func(command, _ string) (string, error) {
-			return shellWorkQueryWithEnv(command, storeDir, storeEnv)
-		}
-		return doHookClaim(workQuery, storeDir, claimOpts, hookClaimOps{Runner: claimRunner}, stdout, stderr)
+		return claimHookWork(workQuery, workDir, queryEnv, stores, claimOpts, emitQueryFailure, stdout, stderr)
 	}
 	return doHook(workQuery, workDir, false, runner, stdout, stderr)
+}
+
+// claimHookWork claims routed work for gc hook --claim from the federated store
+// set. It selects the first store reporting ready work, then re-validates that
+// store and falls back to federated re-selection when it emptied between
+// discovery and claim (see claimStoreWithFallback), so routed work in a later
+// store is not stranded behind a stale single-store rerun. The captured
+// work-query output is handed to doHookClaim so the claim acts on the same rows
+// the selection observed, against that store's dir/env. emitFailure surfaces a
+// work-query timeout on the event bus when eligible.
+func claimHookWork(workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
+	claimOutput, selectedStore, err := firstStoreWithWork(workQuery, stores, shellWorkQueryWithEnv)
+	claimStore := selectedStore
+	// firstStoreWithWork returns a zero store only when no store has ready work;
+	// re-validating then would query an unrelated default dir, so fall straight
+	// through to the no-work drain on the discovery output. When a store WAS
+	// selected, re-validate it for claim-time freshness and fall back to a later
+	// store if it has emptied since discovery.
+	if err == nil && (selectedStore.dir != "" || len(selectedStore.env) > 0) {
+		claimOutput, claimStore, err = claimStoreWithFallback(workQuery, stores, selectedStore, shellWorkQueryWithEnv)
+	}
+	if err != nil {
+		emitFailure(workQuery, err)
+		fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	storeDir := workDir
+	if dir := strings.TrimSpace(claimStore.dir); dir != "" {
+		storeDir = dir
+	}
+	storeEnv := queryEnv
+	if len(claimStore.env) > 0 {
+		storeEnv = claimStore.env
+	}
+	claimOpts.Env = storeEnv
+	claimRunner := func(string, string) (string, error) { return claimOutput, nil }
+	return doHookClaim(workQuery, storeDir, claimOpts, hookClaimOps{Runner: claimRunner}, stdout, stderr)
 }
 
 func hookClaimPrimaryRouteTarget(a *config.Agent) string {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -74,17 +74,44 @@ type hookClaimJSONResult struct {
 	DrainAcknowledged    bool     `json:"drain_acknowledged,omitempty"`
 }
 
+// hookClaimResult is the outcome of attempting a claim against one store's
+// captured work-query output. A terminal result has already written its final
+// output — a claim, an existing assignment, or a hard error — and the caller
+// must return code as-is. A non-terminal result means the store yielded no
+// claimable work (it was empty/unready, or every claimable candidate was lost to
+// another claimant) and NO terminal output was written, so a federated caller
+// may try a later store before writing the single no-work drain.
+type hookClaimResult struct {
+	terminal bool
+	code     int
+}
+
 func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps, stdout, stderr io.Writer) int {
+	res := tryHookClaim(workQuery, dir, &opts, &ops, stdout, stderr)
+	if res.terminal {
+		return res.code
+	}
+	return writeHookClaimNoWork(opts, ops, stdout, stderr)
+}
+
+// tryHookClaim runs the work query for one store (dir, via ops.Runner) and
+// attempts to claim a ready candidate. It returns a terminal result once a
+// claim, existing assignment, or hard error has been written, or a non-terminal
+// result — with NO output written — when the store yielded no claimable work, so
+// a federated caller can try a later store before draining. opts and ops are
+// normalized in place so a non-terminal caller can reuse the normalized ops
+// (defaults applied) for the shared drain.
+func tryHookClaim(workQuery, dir string, opts *hookClaimOptions, ops *hookClaimOps, stdout, stderr io.Writer) hookClaimResult {
 	opts.Assignee = strings.TrimSpace(opts.Assignee)
 	opts.IdentityCandidates = hookClaimIdentityCandidates(append([]string{opts.Assignee}, opts.IdentityCandidates...)...)
 	opts.RouteTargets = hookClaimRouteTargets(opts.RouteTargets...)
 	if opts.Assignee == "" {
 		fmt.Fprintln(stderr, "gc hook --claim: assignee not specified (set $GC_SESSION_NAME or $GC_SESSION_ID)") //nolint:errcheck
-		return 1
+		return hookClaimResult{terminal: true, code: 1}
 	}
 	if ops.Runner == nil {
 		fmt.Fprintln(stderr, "gc hook --claim: missing work query runner") //nolint:errcheck
-		return 1
+		return hookClaimResult{terminal: true, code: 1}
 	}
 	ops.applyDefaults()
 	now := time.Now
@@ -95,28 +122,28 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 	output, err := ops.Runner(workQuery, dir)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck
-		return 1
+		return hookClaimResult{terminal: true, code: 1}
 	}
 
 	normalized := normalizeWorkQueryOutput(strings.TrimSpace(output))
 	normalized = filterUnreadyHookCandidates(normalized, now())
 	if !workQueryHasReadyWork(normalized) {
-		return writeHookClaimNoWork(opts, ops, stdout, stderr)
+		return hookClaimResult{}
 	}
 	candidates, err := decodeHookClaimBeads(normalized)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc hook --claim: requires JSON work_query output to identify claim candidates: %v\n", err) //nolint:errcheck
-		return 1
+		return hookClaimResult{terminal: true, code: 1}
 	}
 	if len(candidates) == 0 {
-		return writeHookClaimNoWork(opts, ops, stdout, stderr)
+		return hookClaimResult{}
 	}
 
-	if result, bead, ok := hookClaimExistingOrAssigned(candidates, opts); ok {
-		return writeHookClaimWorkResultForBead(result, bead, opts, ops, dir, stdout, stderr)
+	if result, bead, ok := hookClaimExistingOrAssigned(candidates, *opts); ok {
+		return hookClaimResult{terminal: true, code: writeHookClaimWorkResultForBead(result, bead, *opts, *ops, dir, stdout, stderr)}
 	}
 
-	return claimFirstEligibleHookCandidate(candidates, opts, ops, dir, stdout, stderr)
+	return claimFirstEligibleHookCandidate(candidates, *opts, *ops, dir, stdout, stderr)
 }
 
 // applyDefaults fills any unset op seam with its production implementation, so
@@ -150,10 +177,13 @@ func (ops *hookClaimOps) applyDefaults() {
 }
 
 // claimFirstEligibleHookCandidate claims the first unassigned, route-matched
-// candidate and returns the exit code of the resulting work-result write, or the
-// terminal no-work result when none can be claimed. A claim lost to a different
-// live claimant is surfaced as a bead.claim_rejected event before moving on.
-func claimFirstEligibleHookCandidate(candidates []beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stdout, stderr io.Writer) int {
+// candidate and returns a terminal result carrying the exit code of the
+// work-result write. A claim lost to a different live claimant is surfaced as a
+// bead.claim_rejected event before moving on. When no candidate can be claimed —
+// none match this session, or every claimable one was lost to another claimant —
+// it returns a non-terminal result (no output written) so a federated caller can
+// try a later store before the shared no-work drain.
+func claimFirstEligibleHookCandidate(candidates []beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stdout, stderr io.Writer) hookClaimResult {
 	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
 	defer cancel()
 	for _, candidate := range candidates {
@@ -163,7 +193,7 @@ func claimFirstEligibleHookCandidate(candidates []beads.Bead, opts hookClaimOpti
 		claimed, ok, err := ops.Claim(ctx, dir, opts.Env, candidate.ID, opts.Assignee)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc hook --claim: claiming %s: %v\n", candidate.ID, err) //nolint:errcheck
-			return 1
+			return hookClaimResult{terminal: true, code: 1}
 		}
 		if !ok {
 			reportHookClaimRejected(candidate, claimed, opts, ops)
@@ -188,10 +218,10 @@ func claimFirstEligibleHookCandidate(candidates []beads.Bead, opts hookClaimOpti
 		if result.Assignee == "" {
 			result.Assignee = opts.Assignee
 		}
-		return writeHookClaimWorkResultForBead(result, claimed, opts, ops, dir, stdout, stderr)
+		return hookClaimResult{terminal: true, code: writeHookClaimWorkResultForBead(result, claimed, opts, ops, dir, stdout, stderr)}
 	}
 
-	return writeHookClaimNoWork(opts, ops, stdout, stderr)
+	return hookClaimResult{}
 }
 
 // hookCandidateClaimable reports whether a work-query candidate is eligible for a

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -753,6 +753,67 @@ func TestClaimHookWorkRetriesLaterStoreWhenSelectedStoreLosesClaimRace(t *testin
 	}
 }
 
+// TestClaimHookWorkDrainsWhenPrimaryLosesRaceThenFederatedStoreErrors is the
+// post-merge regression for the primary-store error contract: once the agent's
+// own (primary) store loses its claim race and is dropped from the working set,
+// a later federated store that errors must stay a best-effort skip. The claim
+// must drain as "no work" rather than surface that federated store's error as a
+// fatal claim failure (the bug: firstStoreWithWork keyed "own store" on slice
+// position, so the federated store became index 0 after the primary was removed
+// and wedged the hook).
+func TestClaimHookWorkDrainsWhenPrimaryLosesRaceThenFederatedStoreErrors(t *testing.T) {
+	stores := []hookStore{
+		{dir: "city", env: []string{"GC_STORE=city"}}, // primary (own) store
+		{dir: "riga", env: []string{"GC_STORE=riga"}}, // best-effort federated store
+	}
+	// The primary store always reports ready work, so discovery and claim-time
+	// re-validation both select it; the federated store errors whenever queried.
+	run := func(_, dir string, _ []string) (string, error) {
+		switch dir {
+		case "city":
+			return `[{"id":"hw-city","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
+		case "riga":
+			return "", errTestStoreTimeout
+		default:
+			t.Fatalf("unexpected store dir %q", dir)
+			return "", nil
+		}
+	}
+	ops := hookClaimOps{
+		Claim: func(_ context.Context, _ string, _ []string, beadID, _ string) (beads.Bead, bool, error) {
+			// Lost the race: a different worker already owns the only city row.
+			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: "worker-2", Metadata: map[string]string{"gc.routed_to": "worker"}}, false, nil
+		},
+		EmitClaimRejected: func(string, string, string) {},
+		ResolveWorkBranch: func(string) string { return "" },
+		DrainAck:          func(io.Writer) error { return nil },
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		DrainAck:           true,
+		JSON:               true,
+	}
+
+	emitted := false
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("bd ready --json", "city", stores[0].env, stores, opts, ops, run, func(string, error) { emitted = true }, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("claimHookWorkWithRunner = %d, want 0 (clean drain); stderr=%s", code, stderr.String())
+	}
+	if emitted {
+		t.Fatal("a federated-store error after the primary lost its race must not emit a work-query failure")
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.Action != "drain" || result.Reason != "no_work" {
+		t.Fatalf("claim result = %+v, want drain/no_work", result)
+	}
+}
+
 // TestClaimHookWorkUsesFallbackStoreDirEnvAndOutput covers the load-bearing
 // fallback-store handoff directly at the claim entrypoint: when the discovery-
 // selected store has emptied by claim-time re-validation, the claim mutation

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -691,6 +691,132 @@ func TestDoHookClaimDrainAckOnNoWork(t *testing.T) {
 	}
 }
 
+// TestClaimHookWorkRetriesLaterStoreWhenSelectedStoreLosesClaimRace is the
+// post-merge regression for the federated claim race: when the discovery-
+// selected store still reports ready work at claim-time re-validation but every
+// claimable row is lost to another claimant before the mutation, the claim must
+// drop that store and reselect across the remaining federated stores instead of
+// draining as "no work" while a later store still has claimable routed work.
+func TestClaimHookWorkRetriesLaterStoreWhenSelectedStoreLosesClaimRace(t *testing.T) {
+	stores := []hookStore{
+		{dir: "city", env: []string{"GC_STORE=city"}},
+		{dir: "riga", env: []string{"GC_STORE=riga"}},
+	}
+	// Both stores report ready routed work on every query, so the selected
+	// store's claim-time re-validation succeeds; the only reason the city claim
+	// fails is the lost race below, not an emptied store.
+	run := func(_, dir string, _ []string) (string, error) {
+		switch dir {
+		case "city":
+			return `[{"id":"hw-city","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
+		case "riga":
+			return `[{"id":"hw-riga","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
+		default:
+			t.Fatalf("unexpected store dir %q", dir)
+			return "", nil
+		}
+	}
+	var claimDir string
+	ops := hookClaimOps{
+		Claim: func(_ context.Context, dir string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+			if beadID == "hw-city" {
+				// Lost the race: a different worker already owns the city row.
+				return beads.Bead{ID: beadID, Status: "in_progress", Assignee: "worker-2", Metadata: map[string]string{"gc.routed_to": "worker"}}, false, nil
+			}
+			claimDir = dir
+			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
+		},
+		EmitClaimRejected: func(string, string, string) {},   // suppress event side effect
+		ResolveWorkBranch: func(string) string { return "" }, // suppress stamp noise
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("bd ready --json", "city", stores[0].env, stores, opts, ops, run, func(string, error) {}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("claimHookWorkWithRunner = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.BeadID != "hw-riga" || result.Reason != "claimed" {
+		t.Fatalf("claim result = %+v, want hw-riga claimed (later store after lost city race)", result)
+	}
+	if claimDir != "riga" {
+		t.Fatalf("winning claim ran against dir %q, want riga", claimDir)
+	}
+}
+
+// TestClaimHookWorkUsesFallbackStoreDirEnvAndOutput covers the load-bearing
+// fallback-store handoff directly at the claim entrypoint: when the discovery-
+// selected store has emptied by claim-time re-validation, the claim mutation
+// must run against the LATER federated store's dir, env, and captured rows — not
+// the original selected store's coordinates.
+func TestClaimHookWorkUsesFallbackStoreDirEnvAndOutput(t *testing.T) {
+	stores := []hookStore{
+		{dir: "city", env: []string{"GC_STORE=city"}},
+		{dir: "riga", env: []string{"GC_STORE=riga"}},
+	}
+	cityCalls := 0
+	run := func(_, dir string, _ []string) (string, error) {
+		switch dir {
+		case "city":
+			cityCalls++
+			if cityCalls == 1 {
+				// Discovery sees ready work in the city store...
+				return `[{"id":"hw-city","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
+			}
+			// ...but it has emptied by claim-time re-validation (and stays empty).
+			return `[]`, nil
+		case "riga":
+			return `[{"id":"hw-riga","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
+		default:
+			t.Fatalf("unexpected store dir %q", dir)
+			return "", nil
+		}
+	}
+	var claimDir string
+	var claimEnv []string
+	ops := hookClaimOps{
+		Claim: func(_ context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {
+			claimDir, claimEnv = dir, env
+			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
+		},
+		ResolveWorkBranch: func(string) string { return "" },
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("bd ready --json", "city", stores[0].env, stores, opts, ops, run, func(string, error) {}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("claimHookWorkWithRunner = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.BeadID != "hw-riga" {
+		t.Fatalf("claim result = %+v, want hw-riga (fallback store's captured row)", result)
+	}
+	if claimDir != "riga" {
+		t.Fatalf("claim ran against dir %q, want riga (fallback store dir)", claimDir)
+	}
+	if len(claimEnv) != 1 || claimEnv[0] != "GC_STORE=riga" {
+		t.Fatalf("claim ran with env %v, want [GC_STORE=riga] (fallback store env)", claimEnv)
+	}
+}
+
 func TestDoHookClaimPreassignsContinuationGroupSiblings(t *testing.T) {
 	var assigned []string
 	runner := func(string, string) (string, error) {

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -238,7 +238,7 @@ func TestCmdSessionKill_SyncsBeadToAsleep(t *testing.T) {
 
 	fakeProvider := runtime.NewFake()
 	oldBuild := buildSessionProviderByName
-	buildSessionProviderByName = func(string, config.SessionConfig, string, string) (runtime.Provider, error) {
+	buildSessionProviderByName = func(*config.City, string, config.SessionConfig, string, string) (runtime.Provider, error) {
 		return fakeProvider, nil
 	}
 	t.Cleanup(func() { buildSessionProviderByName = oldBuild })

--- a/cmd/gc/cross_store_pipeline_test.go
+++ b/cmd/gc/cross_store_pipeline_test.go
@@ -38,7 +38,7 @@ func TestCrossStorePipeline_ReadThenClaim(t *testing.T) {
 		return `[]`, nil
 	}
 
-	out, gotStore, err := firstStoreWithWork("fake-query", stores, run)
+	out, gotStore, err := firstStoreWithWork("fake-query", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("firstStoreWithWork: %v", err)
 	}

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -15,6 +15,11 @@ type hookStore struct {
 	env []string
 }
 
+// hookStoreRunner runs a work query against one federated store's dir and env.
+// Injectable so the cross-store selection and claim paths can be tested without
+// a real bd subprocess.
+type hookStoreRunner func(command, dir string, env []string) (string, error)
+
 // hookIdentityEnvKeys are the identity overrides that must stay constant across
 // every federated store attempt — the query always matches the agent's OWN
 // identity (gc.routed_to / assignee == this identity) regardless of which store
@@ -150,7 +155,7 @@ func rigScopedHookRig(cfg *config.City, agentIdentity string) string {
 // the reconciler, not be silently downgraded to "no work"). Errors from
 // federated rig stores are best-effort discovery (like appendRigHookStores)
 // and are not surfaced, so one flaky rig store can't wedge the hook.
-func firstStoreWithWork(command string, stores []hookStore, run func(command, dir string, env []string) (string, error)) (string, hookStore, error) {
+func firstStoreWithWork(command string, stores []hookStore, run hookStoreRunner) (string, hookStore, error) {
 	var lastOut string
 	var ownStoreOut string
 	var ownStoreErr error
@@ -185,7 +190,7 @@ func firstStoreWithWork(command string, stores []hookStore, run func(command, di
 // the store it came from so the mutation runs against that store's bd context.
 // (The narrow window between this re-validation and the bd update --claim is
 // still handled by the claim itself skipping rows it cannot take.)
-func claimStoreWithFallback(command string, stores []hookStore, selected hookStore, run func(command, dir string, env []string) (string, error)) (string, hookStore, error) {
+func claimStoreWithFallback(command string, stores []hookStore, selected hookStore, run hookStoreRunner) (string, hookStore, error) {
 	selectedOut, err := run(command, selected.dir, selected.env)
 	if err != nil {
 		return "", hookStore{}, err
@@ -195,4 +200,41 @@ func claimStoreWithFallback(command string, stores []hookStore, selected hookSto
 		return selectedOut, selected, nil
 	}
 	return firstStoreWithWork(command, stores, run)
+}
+
+// isZeroHookStore reports whether s is the zero hookStore that firstStoreWithWork
+// returns when no store has ready work (no dir and no env).
+func isZeroHookStore(s hookStore) bool {
+	return strings.TrimSpace(s.dir) == "" && len(s.env) == 0
+}
+
+// removeHookStore returns stores with the first entry equal to target removed.
+// The federated claim loop uses it to drop a store whose ready work was lost to
+// another claimant before reselecting across the remaining stores, which also
+// guarantees the loop makes progress (the working set strictly shrinks).
+func removeHookStore(stores []hookStore, target hookStore) []hookStore {
+	out := make([]hookStore, 0, len(stores))
+	removed := false
+	for _, s := range stores {
+		if !removed && sameHookStore(s, target) {
+			removed = true
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// sameHookStore reports whether two stores address the same dir and env, so the
+// federated claim loop can drop the exact store it just exhausted.
+func sameHookStore(a, b hookStore) bool {
+	if a.dir != b.dir || len(a.env) != len(b.env) {
+		return false
+	}
+	for i := range a.env {
+		if a.env[i] != b.env[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -149,17 +149,21 @@ func rigScopedHookRig(cfg *config.City, agentIdentity string) string {
 // normalize + unready-filter that doHook uses, so a store with only
 // deferred/blocked rows is not treated as a hit). run is injectable for tests.
 //
-// When no store has ready work, an error on the agent's OWN store (the first
-// entry) is surfaced so emitCityWorkQueryFailure can classify it — preserving
-// the single-store emit-on-timeout contract (a work-query timeout must reach
-// the reconciler, not be silently downgraded to "no work"). Errors from
-// federated rig stores are best-effort discovery (like appendRigHookStores)
-// and are not surfaced, so one flaky rig store can't wedge the hook.
-func firstStoreWithWork(command string, stores []hookStore, run hookStoreRunner) (string, hookStore, error) {
+// When no store has ready work, an error on the agent's OWN store (identified by
+// primary, not by slice position) is surfaced so emitCityWorkQueryFailure can
+// classify it — preserving the single-store emit-on-timeout contract (a
+// work-query timeout must reach the reconciler, not be silently downgraded to
+// "no work"). Errors from federated rig stores are best-effort discovery (like
+// appendRigHookStores) and are not surfaced, so one flaky rig store can't wedge
+// the hook. primary is matched by identity rather than position because the
+// federated claim loop reselects over a shrinking store set: once the primary
+// store has been dropped it is no longer in stores, so no later federated store
+// may inherit its emit-on-timeout semantics.
+func firstStoreWithWork(command string, stores []hookStore, primary hookStore, run hookStoreRunner) (string, hookStore, error) {
 	var lastOut string
 	var ownStoreOut string
 	var ownStoreErr error
-	for i, st := range stores {
+	for _, st := range stores {
 		out, err := run(command, st.dir, st.env)
 		if err == nil {
 			ready := filterUnreadyHookCandidates(normalizeWorkQueryOutput(strings.TrimSpace(out)), time.Now())
@@ -169,7 +173,7 @@ func firstStoreWithWork(command string, stores []hookStore, run hookStoreRunner)
 			lastOut = out
 			continue
 		}
-		if i == 0 {
+		if sameHookStore(st, primary) {
 			ownStoreOut, ownStoreErr = out, err
 		}
 	}
@@ -190,16 +194,24 @@ func firstStoreWithWork(command string, stores []hookStore, run hookStoreRunner)
 // the store it came from so the mutation runs against that store's bd context.
 // (The narrow window between this re-validation and the bd update --claim is
 // still handled by the claim itself skipping rows it cannot take.)
-func claimStoreWithFallback(command string, stores []hookStore, selected hookStore, run hookStoreRunner) (string, hookStore, error) {
+//
+// A re-validation error on the selected store is surfaced only when that store
+// is the primary (own) store; a federated store erroring at claim time is
+// best-effort and falls through to re-selection, mirroring firstStoreWithWork's
+// emit-on-timeout contract so a flaky rig store can't wedge the claim.
+func claimStoreWithFallback(command string, stores []hookStore, selected, primary hookStore, run hookStoreRunner) (string, hookStore, error) {
 	selectedOut, err := run(command, selected.dir, selected.env)
 	if err != nil {
-		return "", hookStore{}, err
+		if sameHookStore(selected, primary) {
+			return "", hookStore{}, err
+		}
+		return firstStoreWithWork(command, stores, primary, run)
 	}
 	ready := filterUnreadyHookCandidates(normalizeWorkQueryOutput(strings.TrimSpace(selectedOut)), time.Now())
 	if workQueryHasReadyWork(ready) {
 		return selectedOut, selected, nil
 	}
-	return firstStoreWithWork(command, stores, run)
+	return firstStoreWithWork(command, stores, primary, run)
 }
 
 // isZeroHookStore reports whether s is the zero hookStore that firstStoreWithWork

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -173,3 +173,26 @@ func firstStoreWithWork(command string, stores []hookStore, run func(command, di
 	}
 	return lastOut, hookStore{}, nil
 }
+
+// claimStoreWithFallback re-validates the discovery-selected store for
+// claim-time freshness, then falls back to federated re-selection across all
+// stores when that store has emptied since discovery. It exists because
+// gc hook --claim selects the first store with ready work, then must commit to
+// one store for the claim mutation. Re-running only the selected store would
+// drain as "no work" whenever its claimable row was taken between discovery and
+// claim — even though a later federated store still has ready routed work. The
+// returned output is the work-query result the claim should act on, paired with
+// the store it came from so the mutation runs against that store's bd context.
+// (The narrow window between this re-validation and the bd update --claim is
+// still handled by the claim itself skipping rows it cannot take.)
+func claimStoreWithFallback(command string, stores []hookStore, selected hookStore, run func(command, dir string, env []string) (string, error)) (string, hookStore, error) {
+	selectedOut, err := run(command, selected.dir, selected.env)
+	if err != nil {
+		return "", hookStore{}, err
+	}
+	ready := filterUnreadyHookCandidates(normalizeWorkQueryOutput(strings.TrimSpace(selectedOut)), time.Now())
+	if workQueryHasReadyWork(ready) {
+		return selectedOut, selected, nil
+	}
+	return firstStoreWithWork(command, stores, run)
+}

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -166,3 +166,69 @@ func TestFirstStoreWithWorkSkipsStoreWithOnlyUnreadyRows(t *testing.T) {
 		t.Fatalf("store.dir = %q, want riga", gotStore.dir)
 	}
 }
+
+// TestClaimStoreWithFallbackFallsBackWhenSelectedStoreRerunsEmpty pins the
+// post-merge fix for the bundled gc hook --claim change: when the
+// discovery-selected store loses its claimable row before the claim, the claim
+// must re-select across the federated stores instead of draining as "no work"
+// while a later store still has ready routed work.
+func TestClaimStoreWithFallbackFallsBackWhenSelectedStoreRerunsEmpty(t *testing.T) {
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
+	selected := stores[0]
+	var calls []string
+	run := func(_, dir string, _ []string) (string, error) {
+		calls = append(calls, dir)
+		switch len(calls) {
+		case 1: // claim-time re-validation of the selected store: now empty.
+			return `[]`, nil
+		case 2: // federated re-selection: own store still empty.
+			return `[]`, nil
+		case 3: // later store still has ready routed work.
+			return `[{"id":"va-3"}]`, nil
+		default:
+			t.Fatalf("unexpected call %d to %q", len(calls), dir)
+			return "", nil
+		}
+	}
+
+	out, gotStore, err := claimStoreWithFallback("q", stores, selected, run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != `[{"id":"va-3"}]` {
+		t.Fatalf("out = %q, want later-store work", out)
+	}
+	if gotStore.dir != "riga" {
+		t.Fatalf("store.dir = %q, want riga", gotStore.dir)
+	}
+	if len(calls) != 3 || calls[0] != "city" || calls[1] != "city" || calls[2] != "riga" {
+		t.Fatalf("calls = %v, want [city city riga]", calls)
+	}
+}
+
+// TestClaimStoreWithFallbackUsesSelectedStoreWhenStillReady covers the common
+// path: when the selected store still reports ready work at claim time, the
+// claim acts on that store's fresh output without a redundant federated rescan.
+func TestClaimStoreWithFallbackUsesSelectedStoreWhenStillReady(t *testing.T) {
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
+	selected := stores[0]
+	var calls []string
+	run := func(_, dir string, _ []string) (string, error) {
+		calls = append(calls, dir)
+		return `[{"id":"va-1"}]`, nil
+	}
+
+	out, gotStore, err := claimStoreWithFallback("q", stores, selected, run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != `[{"id":"va-1"}]` {
+		t.Fatalf("out = %q, want selected-store work", out)
+	}
+	if gotStore.dir != "city" {
+		t.Fatalf("store.dir = %q, want city", gotStore.dir)
+	}
+	if len(calls) != 1 || calls[0] != "city" {
+		t.Fatalf("calls = %v, want a single [city] re-validation", calls)
+	}
+}

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -77,7 +77,7 @@ func TestFirstStoreWithWorkReturnsFirstStoreThatHasWork(t *testing.T) {
 		}
 		return `[]`, nil
 	}
-	out, gotStore, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestFirstStoreWithWorkReturnsFirstStoreThatHasWork(t *testing.T) {
 func TestFirstStoreWithWorkReturnsLastWhenNoneHasWork(t *testing.T) {
 	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
 	run := func(_, _ string, _ []string) (string, error) { return `[]`, nil }
-	out, gotStore, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestFirstStoreWithWorkSurfacesOwnStoreErrorWhenNoWork(t *testing.T) {
 		}
 		return `[]`, nil
 	}
-	if _, _, err := firstStoreWithWork("q", stores, run); !errors.Is(err, errTestStoreTimeout) {
+	if _, _, err := firstStoreWithWork("q", stores, stores[0], run); !errors.Is(err, errTestStoreTimeout) {
 		t.Fatalf("own-store error must be surfaced when no store has work; got %v", err)
 	}
 }
@@ -134,7 +134,7 @@ func TestFirstStoreWithWorkIgnoresRigStoreErrorWhenOwnStoreHasNoWork(t *testing.
 		}
 		return "", errTestStoreTimeout
 	}
-	out, gotStore, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("rig-store error must not surface when own store is healthy; got %v", err)
 	}
@@ -155,7 +155,7 @@ func TestFirstStoreWithWorkSkipsStoreWithOnlyUnreadyRows(t *testing.T) {
 		}
 		return `[{"id":"va-2"}]`, nil
 	}
-	out, gotStore, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestClaimStoreWithFallbackFallsBackWhenSelectedStoreRerunsEmpty(t *testing.
 		}
 	}
 
-	out, gotStore, err := claimStoreWithFallback("q", stores, selected, run)
+	out, gotStore, err := claimStoreWithFallback("q", stores, selected, stores[0], run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestClaimStoreWithFallbackUsesSelectedStoreWhenStillReady(t *testing.T) {
 		return `[{"id":"va-1"}]`, nil
 	}
 
-	out, gotStore, err := claimStoreWithFallback("q", stores, selected, run)
+	out, gotStore, err := claimStoreWithFallback("q", stores, selected, stores[0], run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
Post-merge remediation for #3783, which bundled a `gc hook --claim`
cross-store change together with the pack `[upstreams]` config fix.
Reviewed landed range: `d326a5f1..a1351179` on `main`.

## Finding fixed

`gc hook --claim` selected the first federated store reporting ready
work, then re-ran **only** that store for the claim. If that store's
claimable row was taken between discovery and the claim, the command
drained as "no work" even when a later federated store still had ready
routed work — stranding that work until the next hook.

## Change

- `claimStoreWithFallback` re-validates the selected store at claim
  time and falls back to federated re-selection when it has emptied
  since discovery, handing the captured rows to `doHookClaim` so the
  claim acts on the same store the selection observed.
- The claim orchestration is extracted into `claimHookWork`, which
  returns `cmdHookWithOptions` to its pre-#3783 complexity rather than
  growing it further, and routes claim-time work-query failures back
  through the same event-bus emit path the shared work-query runner
  uses.
- The no-work case is guarded so re-validation never queries an
  unrelated default store.

This carries the same fix shape (helper + regression test) as the
in-progress maintainer hook-claim work so the two converge rather than
landing divergently; the `[upstreams]` config portion of #3783 is
unaffected.

## Tests

- `go build ./cmd/gc/...`, `go vet ./cmd/gc/...`, `gofmt` clean.
- `go test ./cmd/gc -run 'ClaimStoreWithFallback|FirstStoreWithWork|DoHookClaim|CmdHookClaims'` — pass.
- New regression tests: stale-selected-store fallback to a later store,
  and the still-ready fast path.

## Self-review

Reviewed the final diff with fresh eyes for correctness, scope,
regression risk, and test evidence: scope is limited to the three hook
files; behavior on the single-store and no-work paths is preserved; the
fix is covered by direct regression tests.
