### PR TITLE
fix(test): unbreak main — 5-arg buildSessionProviderByName override (#3635/#3704 skew)

### DIFF
--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -238,7 +238,7 @@ func TestCmdSessionKill_SyncsBeadToAsleep(t *testing.T) {
 
 	fakeProvider := runtime.NewFake()
 	oldBuild := buildSessionProviderByName
-	buildSessionProviderByName = func(string, config.SessionConfig, string, string) (runtime.Provider, error) {
+	buildSessionProviderByName = func(*config.City, string, config.SessionConfig, string, string) (runtime.Provider, error) {
 		return fakeProvider, nil
 	}
 	t.Cleanup(func() { buildSessionProviderByName = oldBuild })


### PR DESCRIPTION
## Unbreaks `main`

`go test ./cmd/gc` currently fails to compile on `main` (HEAD ba627efc):

```
cmd/gc/cmd_session_reset_test.go:241: cannot use func(string, config.SessionConfig, string, string) ... as func(*config.City, string, config.SessionConfig, string, string) value in assignment
```

**Root cause:** a semantic merge conflict. #3704 changed `buildSessionProviderByName` to take a leading `*config.City` (5 args) and updated all then-existing overrides; #3635 added this override on a stale base (4 args). Per-PR CI never tested the merged combination (PRs aren't rebased-before-merge and there's no merge queue), so each passed green while their combination broke `main`.

**Fix:** align line 241 with the package's other overrides (130, 409) — add the leading `*config.City`. One line.

Verified: `go vet ./cmd/gc` clean.

_(Surfaced by the 2026-06-28 codebase audit as the #1 ship-now item.)_
