### PR TITLE
fix(dolt): add --skip-fetch opt-out to gc dolt compact (#2361)

### DIFF
--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -101,6 +101,42 @@ reclaiming. Unlike the full `dolt gc --archive-level=1` procedure above,
 the city — though quiescing writers still makes the GC faster and more
 thorough.
 
+## Compacting a city whose Dolt remote is uncredentialed
+
+Before flattening (and again before pushing) the compactor runs
+`CALL DOLT_FETCH('<remote>')` to reconcile against the remote. Against an
+**uncredentialed git+https remote**, that call does not merely return an error —
+it **crashes the managed Dolt sql-server process**. The shell tolerates a
+non-zero return code ("proceeding from local source of truth") but cannot catch
+a server-process death across the process boundary: the supervisor restarts the
+server seconds later, but by then every remaining database's probe hits
+`connection refused`, so one misconfigured remote takes down compaction for the
+whole city.
+
+If a city's remote is not (yet) credentialed, opt out of the fetch so
+compaction runs entirely from the local source of truth. The post-compaction
+remote push is deferred via a pending-push marker and resumes automatically on a
+later run once the fetch path is healthy:
+
+```bash
+# Skip the fetch for every database this run.
+gc dolt compact --skip-fetch
+
+# Equivalent environment opt-out (e.g. set in a wrapper or on the city).
+GC_DOLT_COMPACT_SKIP_FETCH=1 gc dolt compact
+
+# Skip the fetch only for specific, known-uncredentialed databases (CSV);
+# credentialed databases in the same city still fetch and push normally.
+GC_DOLT_COMPACT_SKIP_FETCH_DBS=<database>[,<database>...] gc dolt compact
+```
+
+Prefer the per-database `GC_DOLT_COMPACT_SKIP_FETCH_DBS` form over the global
+opt-out when only some databases are uncredentialed — the global form disables
+remote sync for every database, including ones whose push would otherwise
+succeed. Do **not** set the global opt-out in the shared `mol-dog-compactor`
+order for the same reason; set the per-database env on the affected city
+instead.
+
 ## Expected Outcome
 
 DoltHub's archive format typically delivers ~30% compression on top of

--- a/examples/bd/dolt/commands/compact/help.md
+++ b/examples/bd/dolt/commands/compact/help.md
@@ -25,6 +25,14 @@ row preservation, and runs `CALL DOLT_GC('--full')`.
 - `--dry-run` — Print the intended actions without issuing any
   `DOLT_RESET` / `DOLT_COMMIT` / `DOLT_GC`.
 
+- `--skip-fetch` — Bypass `CALL DOLT_FETCH` for every database (sets
+  `GC_DOLT_COMPACT_SKIP_FETCH=1`). Against an uncredentialed git+https remote
+  the fetch crashes the managed Dolt sql-server and cascades to every remaining
+  database, so this opt-out lets compaction proceed from the local source of
+  truth; the post-compaction remote push is deferred via a pending-push marker.
+  To skip only specific known-uncredentialed databases while others fetch and
+  push normally, set `GC_DOLT_COMPACT_SKIP_FETCH_DBS=<db>[,<db>...]` instead.
+
 ## Examples
 
 ```bash

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -130,6 +130,11 @@ set -eu
 #   --only-db <name>   restrict to the named database (repeatable; augments
 #                      GC_DOLT_COMPACT_ONLY_DBS).
 #   --dry-run          print intended actions without mutating Dolt.
+#   --skip-fetch       bypass CALL DOLT_FETCH for every database (sets
+#                      GC_DOLT_COMPACT_SKIP_FETCH=1) — opt-out for cities whose
+#                      remote is uncredentialed, where the fetch would crash the
+#                      managed dolt server. Compaction proceeds from the local
+#                      source of truth and any remote push is deferred.
 gc_only=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -166,12 +171,16 @@ while [ "$#" -gt 0 ]; do
       GC_DOLT_COMPACT_DRY_RUN=1
       shift
       ;;
+    --skip-fetch)
+      GC_DOLT_COMPACT_SKIP_FETCH=1
+      shift
+      ;;
     --)
       shift
       break
       ;;
     -*)
-      printf 'compact: unknown flag %s (supported: --gc-only, --only-db <name>, --dry-run)\n' "$1" >&2
+      printf 'compact: unknown flag %s (supported: --gc-only, --only-db <name>, --dry-run, --skip-fetch)\n' "$1" >&2
       exit 2
       ;;
     *)
@@ -287,6 +296,8 @@ compact_remote="${GC_DOLT_COMPACT_REMOTE:-}"
 dry_run="${GC_DOLT_COMPACT_DRY_RUN:-}"
 only_dbs="${GC_DOLT_COMPACT_ONLY_DBS:-}"
 bare_gc_input="${GC_DOLT_COMPACT_BARE_GC:-}"
+skip_fetch_input="${GC_DOLT_COMPACT_SKIP_FETCH:-}"
+skip_fetch_dbs="${GC_DOLT_COMPACT_SKIP_FETCH_DBS:-}"
 compact_alert_to="${GC_DOLT_COMPACT_ALERT_TO:-mayor}"
 case "$bare_gc_input" in
   ''|0|false|FALSE|no|NO)
@@ -298,6 +309,20 @@ case "$bare_gc_input" in
   *)
     printf 'compact: invalid GC_DOLT_COMPACT_BARE_GC=%s (must be 1/true/yes or 0/false/no)\n' \
       "$bare_gc_input" >&2
+    exit 2
+    ;;
+esac
+
+case "$skip_fetch_input" in
+  ''|0|false|FALSE|no|NO)
+    skip_fetch=0
+    ;;
+  1|true|TRUE|yes|YES)
+    skip_fetch=1
+    ;;
+  *)
+    printf 'compact: invalid GC_DOLT_COMPACT_SKIP_FETCH=%s (must be 1/true/yes or 0/false/no)\n' \
+      "$skip_fetch_input" >&2
     exit 2
     ;;
 esac
@@ -830,6 +855,26 @@ fetch_remote() {
   db="$1"
   remote="$2"
   dolt_query "$db" "CALL DOLT_FETCH('$remote')"
+}
+
+# skip_fetch_for_db reports whether CALL DOLT_FETCH must be bypassed for the
+# given database. True when the global GC_DOLT_COMPACT_SKIP_FETCH opt-out is set
+# or when <db> appears in the GC_DOLT_COMPACT_SKIP_FETCH_DBS allowlist. The
+# fetch crashes the managed dolt server for uncredentialed remotes (issue
+# #2361), so this opt-out keeps one misconfigured remote from cascading.
+skip_fetch_for_db() {
+  db="$1"
+  if [ "$skip_fetch" = "1" ]; then
+    return 0
+  fi
+  if [ -n "$skip_fetch_dbs" ]; then
+    case ",$skip_fetch_dbs," in
+      *,"$db",*)
+        return 0
+        ;;
+    esac
+  fi
+  return 1
 }
 
 remote_branch_head() {
@@ -1513,6 +1558,18 @@ push_remote_after_compaction() {
     return 1
   }
 
+  if skip_fetch_for_db "$db"; then
+    # skip-fetch opt-out (#2361): the pre-push fetch carries the same managed-
+    # server crash risk as the pre-flatten one (B23 sibling). Skip both the fetch
+    # and the force-push; local compaction already succeeded, so record a pending-
+    # push marker and defer remote sync until credentials are wired.
+    printf 'compact: db=%s remote=%s — skip-fetch set, deferring remote push after local compaction\n' \
+      "$db" "$remote"
+    write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+      "flatten and full GC succeeded but remote push deferred by skip-fetch" "$local_branch" "$remote_branch" || return 1
+    return 0
+  fi
+
   fetch_rc=0
   fetch_err_tmp=$(mktemp)
   fetch_remote "$db" "$remote" >/dev/null 2>"$fetch_err_tmp" || fetch_rc=$?
@@ -1977,49 +2034,58 @@ flatten_database() {
     local_branch=$(printf '%s\n' "$refspec_pair" | sed -n '1p')
     remote_branch=$(printf '%s\n' "$refspec_pair" | sed -n '2p')
 
-    printf 'compact: db=%s remote=%s — fetching before flatten...\n' "$db" "$remote"
-    fetch_rc=0
-    fetch_err_tmp=$(mktemp)
-    fetch_remote "$db" "$remote" >/dev/null 2>"$fetch_err_tmp" || fetch_rc=$?
-    if [ "$fetch_rc" -ne 0 ]; then
-      printf 'compact: db=%s remote=%s fetch failed rc=%s — proceeding from local source of truth\n' \
-        "$db" "$remote" "$fetch_rc" >&2
-      emit_error_file "$db" "$fetch_err_tmp"
+    if skip_fetch_for_db "$db"; then
+      # skip-fetch opt-out (#2361): the fetch crashes the managed dolt server for
+      # uncredentialed remotes. Bypass it and take the same downstream path the
+      # fetch-failure branch takes — remote stays set, expected_remote_head="" and
+      # expected_remote_head_verified=0 (their initialized values), so the push
+      # after local compaction is deferred via a pending-push marker.
+      printf 'compact: db=%s remote=%s — skip-fetch set, proceeding from local source of truth\n' "$db" "$remote"
     else
-      if ! remote_head=$(remote_branch_head "$db" "$remote" "$remote_branch"); then
-        rm -f "$fetch_err_tmp"
-        return 1
-      fi
-      expected_remote_head="$remote_head"
-      if [ -n "$remote_head" ] && [ "$remote_head" != "$head" ]; then
-        case "$remote_head" in
-          *[!A-Za-z0-9]*)
-            printf 'compact: db=%s remote=%s returned invalid HEAD=%s — fail\n' \
-              "$db" "$remote" "$remote_head" >&2
-            rm -f "$fetch_err_tmp"
-            return 1
-            ;;
-        esac
-        if ! in_local=$(commit_exists_in_local_log "$db" "$remote_head"); then
+      printf 'compact: db=%s remote=%s — fetching before flatten...\n' "$db" "$remote"
+      fetch_rc=0
+      fetch_err_tmp=$(mktemp)
+      fetch_remote "$db" "$remote" >/dev/null 2>"$fetch_err_tmp" || fetch_rc=$?
+      if [ "$fetch_rc" -ne 0 ]; then
+        printf 'compact: db=%s remote=%s fetch failed rc=%s — proceeding from local source of truth\n' \
+          "$db" "$remote" "$fetch_rc" >&2
+        emit_error_file "$db" "$fetch_err_tmp"
+      else
+        if ! remote_head=$(remote_branch_head "$db" "$remote" "$remote_branch"); then
           rm -f "$fetch_err_tmp"
           return 1
         fi
-        if [ "$in_local" != "1" ]; then
-          printf 'compact: db=%s remote=%s remote HEAD=%s is not in local history — proceeding from local source of truth; remote push will remain pending\n' \
-            "$db" "$remote" "$remote_head" >&2
-        else
+        expected_remote_head="$remote_head"
+        if [ -n "$remote_head" ] && [ "$remote_head" != "$head" ]; then
+          case "$remote_head" in
+            *[!A-Za-z0-9]*)
+              printf 'compact: db=%s remote=%s returned invalid HEAD=%s — fail\n' \
+                "$db" "$remote" "$remote_head" >&2
+              rm -f "$fetch_err_tmp"
+              return 1
+              ;;
+          esac
+          if ! in_local=$(commit_exists_in_local_log "$db" "$remote_head"); then
+            rm -f "$fetch_err_tmp"
+            return 1
+          fi
+          if [ "$in_local" != "1" ]; then
+            printf 'compact: db=%s remote=%s remote HEAD=%s is not in local history — proceeding from local source of truth; remote push will remain pending\n' \
+              "$db" "$remote" "$remote_head" >&2
+          else
+            expected_remote_head_verified=1
+            printf 'compact: db=%s remote=%s fetch ok\n' "$db" "$remote"
+          fi
+        elif [ "$remote_head" = "$head" ]; then
           expected_remote_head_verified=1
           printf 'compact: db=%s remote=%s fetch ok\n' "$db" "$remote"
+        else
+          expected_remote_head_verified=0
+          printf 'compact: db=%s remote=%s fetch ok; remote HEAD empty — push will verify after local compaction\n' "$db" "$remote"
         fi
-      elif [ "$remote_head" = "$head" ]; then
-        expected_remote_head_verified=1
-        printf 'compact: db=%s remote=%s fetch ok\n' "$db" "$remote"
-      else
-        expected_remote_head_verified=0
-        printf 'compact: db=%s remote=%s fetch ok; remote HEAD empty — push will verify after local compaction\n' "$db" "$remote"
       fi
+      rm -f "$fetch_err_tmp"
     fi
-    rm -f "$fetch_err_tmp"
   fi
 
   ensure_repair_marker_paths_writable "$db" "$remote" || return 1

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -4913,3 +4913,138 @@ func TestCompactScriptStillQuarantinesRowDecreaseWithStableHead(t *testing.T) {
 		t.Fatalf("stable-HEAD row-decrease must block full GC:\n%s", string(data))
 	}
 }
+
+// --skip-fetch opt-out (issue #2361): CALL DOLT_FETCH against an
+// uncredentialed git+https remote crashes the managed dolt sql-server, which
+// the shell cannot catch across the process boundary and which cascades to
+// every remaining database. The only robust prevention is a declarative
+// opt-out that bypasses the fetch entirely for known-uncredentialed databases.
+// These tests assert the ABSENCE of the fetch (not just a green run), exercise
+// both the flag and env forms, the per-db allowlist, the deferred-push
+// contract, and invalid-value validation.
+
+func TestCompactScriptSkipFetchFlagBypassesFetch(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		extraEnv []string
+	}{
+		{name: "flag", args: []string{"--skip-fetch"}},
+		{name: "env", extraEnv: []string{"GC_DOLT_COMPACT_SKIP_FETCH=1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newCompactScriptFixture(t)
+			env := append([]string{"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500"}, tc.extraEnv...)
+			out, err := fixture.runWithArgs(t, "remote_success", tc.args, env...)
+			if err != nil {
+				t.Fatalf("skip-fetch compact should succeed from local source of truth: %v\n%s", err, out)
+			}
+			if !strings.Contains(out, "skip-fetch set") {
+				t.Fatalf("output should announce skip-fetch:\n%s", out)
+			}
+			data, err := os.ReadFile(fixture.doltLog)
+			if err != nil {
+				t.Fatalf("read dolt log: %v", err)
+			}
+			log := string(data)
+			if strings.Contains(log, "DOLT_FETCH") {
+				t.Fatalf("skip-fetch must bypass the fetch at every call site:\n%s", log)
+			}
+			for _, want := range []string{"DOLT_RESET", "DOLT_COMMIT", "DOLT_GC"} {
+				if !strings.Contains(log, want) {
+					t.Fatalf("skip-fetch must not block local compaction; missing %s:\n%s", want, log)
+				}
+			}
+		})
+	}
+}
+
+func TestCompactScriptSkipFetchPerDBList(t *testing.T) {
+	// db "beads" is the sole database compacted in remote_success mode, so a
+	// list naming it skips the fetch while a list that omits it does not. This
+	// discriminates listed vs non-listed, not merely "green when listed".
+	t.Run("listed_db_skips_fetch", func(t *testing.T) {
+		fixture := newCompactScriptFixture(t)
+		out, err := fixture.run(t, "remote_success",
+			"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+			"GC_DOLT_COMPACT_SKIP_FETCH_DBS=beads")
+		if err != nil {
+			t.Fatalf("listed-db skip-fetch compact should succeed: %v\n%s", err, out)
+		}
+		data, err := os.ReadFile(fixture.doltLog)
+		if err != nil {
+			t.Fatalf("read dolt log: %v", err)
+		}
+		if strings.Contains(string(data), "DOLT_FETCH") {
+			t.Fatalf("db in skip-fetch list must bypass the fetch:\n%s", data)
+		}
+	})
+	t.Run("unlisted_db_fetches", func(t *testing.T) {
+		fixture := newCompactScriptFixture(t)
+		out, err := fixture.run(t, "remote_success",
+			"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+			"GC_DOLT_COMPACT_SKIP_FETCH_DBS=otherdb")
+		if err != nil {
+			t.Fatalf("unlisted-db compact should succeed: %v\n%s", err, out)
+		}
+		data, err := os.ReadFile(fixture.doltLog)
+		if err != nil {
+			t.Fatalf("read dolt log: %v", err)
+		}
+		if !strings.Contains(string(data), "CALL DOLT_FETCH('origin')") {
+			t.Fatalf("db absent from skip-fetch list must still fetch:\n%s", data)
+		}
+	})
+}
+
+func TestCompactScriptSkipFetchDefersPush(t *testing.T) {
+	// Skipping the fetch means we cannot verify the remote contract, so the
+	// post-compaction push is deferred via a pending-push marker rather than
+	// force-pushed blind — remote sync resumes once credentials are wired.
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.runWithArgs(t, "remote_success", []string{"--skip-fetch"},
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("skip-fetch compact should succeed: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	if strings.Contains(log, "DOLT_FETCH") {
+		t.Fatalf("skip-fetch must bypass fetch at the pre-push site too:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_PUSH") {
+		t.Fatalf("skip-fetch must defer the push, not force-push blind:\n%s", log)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	markerData, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("skip-fetch should write a pending-push marker instead of pushing: %v", err)
+	}
+	if !strings.Contains(string(markerData), "remote=origin") {
+		t.Fatalf("pending-push marker should record the deferred remote:\n%s", markerData)
+	}
+}
+
+func TestCompactScriptSkipFetchRejectsInvalidValue(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_SKIP_FETCH=bogus")
+	if err == nil {
+		t.Fatalf("skip-fetch must reject invalid value:\n%s", out)
+	}
+	if !strings.Contains(out, "invalid GC_DOLT_COMPACT_SKIP_FETCH=bogus") {
+		t.Fatalf("skip-fetch output missing invalid-value diagnostic:\n%s", out)
+	}
+	// Invalid env exits during validation, before any dolt query, so the fake
+	// dolt log may not exist. Tolerate that and assert only on presence.
+	if logData, err := os.ReadFile(fixture.doltLog); err == nil {
+		if strings.Contains(string(logData), "DOLT_GC") {
+			t.Fatalf("invalid skip-fetch value must exit before any DOLT_GC call:\n%s", logData)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2361.

## Problem

`CALL DOLT_FETCH('<remote>')` against an **uncredentialed git+https remote** does
not merely return `rc=1` — it **crashes the managed dolt sql-server process**.
The compact shell already tolerates a non-zero return code ("proceeding from
local source of truth") but cannot catch a server-process death across the
process boundary: the supervisor restarts the server seconds later, but by then
every remaining database's probe hits `connection refused`. One misconfigured
remote takes down compaction for the whole city.

Catching the crash in shell is infeasible — auto-detecting a bad remote by
*attempting* the fetch is exactly what triggers the crash. So the robust
prevention is a **declarative opt-out** that skips the fetch for known-
uncredentialed databases.

## Change

A new opt-out, mirroring the existing `--gc-only` / `GC_DOLT_COMPACT_BARE_GC`
pattern exactly:

- `--skip-fetch` flag → sets `GC_DOLT_COMPACT_SKIP_FETCH=1` (skip for every db).
- `GC_DOLT_COMPACT_SKIP_FETCH=1|true|yes` (validated; invalid value → `exit 2`).
- `GC_DOLT_COMPACT_SKIP_FETCH_DBS=<db>[,<db>...]` — per-db allowlist; credentialed
  dbs in the same city still fetch and push normally.

When skip-fetch applies, compaction proceeds from the local source of truth and
the post-compaction remote push is **deferred via a pending-push marker** (not
force-pushed blind), so remote sync resumes automatically once credentials are
wired. Both `DOLT_FETCH` call sites are guarded — pre-flatten in
`flatten_database` **and** the pre-push sibling in `push_remote_after_compaction`.

Default behavior (fetch enabled) is unchanged → no impact on credentialed cities.

Files: `examples/bd/dolt/commands/compact/run.sh`, its `help.md`, the fake-dolt
test harness, and the bloat-recovery troubleshooting doc. No Go production code,
no wire types, no config structs.

## Tests

- `TestCompactScriptSkipFetchFlagBypassesFetch` (flag + env) — asserts `DOLT_FETCH`
  is **absent** from the dolt log while `DOLT_RESET`/`DOLT_COMMIT`/`DOLT_GC` still
  run and the compact succeeds.
- `TestCompactScriptSkipFetchPerDBList` — fetch absent for a listed db, **present**
  for an unlisted db (discriminates, not just "green when listed").
- `TestCompactScriptSkipFetchDefersPush` — writes a pending-push marker instead of
  pushing; no `DOLT_PUSH` in the log.
- `TestCompactScriptSkipFetchRejectsInvalidValue` — invalid env exits before any
  dolt query.

Full `TestCompactScript*` suite green (no regression in non-skip-fetch paths).
`bash -n`, `gofmt`, `go vet ./...`, and `test/docsync` all clean.

## Review notes (self-review + B-rule audit, run before push)

- **B23 parallel siblings** — `fetch_remote` is the only `DOLT_FETCH` caller and
  both its call sites (pre-flatten + pre-push) are guarded. `sync/run.sh` has a
  separate `DOLT_FETCH` but is a different command, intentionally out of scope.
- **B11 nil/empty** — unset vs `0` vs `1` validated explicitly with the same
  `case` pattern as `GC_DOLT_COMPACT_BARE_GC`.
- **B14 test specificity** — assertions check the **absence** of the fetch and
  discriminate listed-vs-unlisted dbs, not just a green run.
- **B26 doc drift** — both the troubleshooting runbook and the command `help.md`
  flag reference updated to document `--skip-fetch`.

## Out of scope (deliberate)

- The mid-loop server-death resilience guard (issue fix #2) — infeasible in shell.
- `examples/bd/dolt/orders/mol-dog-compactor.toml` — setting skip-fetch globally in
  the shared order would disable remote sync for credentialed dbs; operators set
  the per-db env instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
