### PR TITLE
fix: de-flake CI — Interrupt SIGINT-fork race + reaper pipefail/SIGPIPE race

### DIFF
--- a/internal/bootstrap/packs/core/assets/scripts/reaper.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/reaper.sh
@@ -520,10 +520,17 @@ has_dependency_target_column() {
         return 0
     fi
 
-    printf '%s\n' "$fields" | grep -qx 'issue_id' || return 1
-    printf '%s\n' "$fields" | grep -qx 'depends_on_issue_id' || return 1
-    printf '%s\n' "$fields" | grep -qx 'depends_on_wisp_id' || return 1
-    printf '%s\n' "$fields" | grep -qx 'depends_on_external' || return 1
+    # Check membership with a here-string, never `printf ... | grep -q`. `grep -q`
+    # closes its stdin the instant it matches, so the upstream `printf` races into
+    # a SIGPIPE; under `set -o pipefail` that SIGPIPE becomes the pipeline's exit
+    # status and `|| return 1` fires spuriously, making the reaper skip the whole
+    # database's workflow-root cleanup. A here-string is a simple command
+    # (pipefail does not apply) with no upstream writer to kill.
+    local field
+    for field in issue_id depends_on_issue_id depends_on_wisp_id depends_on_external; do
+        grep -qx "$field" <<<"$fields" || return 1
+    done
+    return 0
 }
 
 workflow_root_candidates_cte() {

--- a/internal/runtime/subprocess/seams_test.go
+++ b/internal/runtime/subprocess/seams_test.go
@@ -104,8 +104,18 @@ func TestSeamsInterrupt(t *testing.T) {
 	rt, tp := NewProviderWithDir(t.TempDir()).Seams()
 	ctx := context.Background()
 
+	// Launch with `exec` so the shell replaces itself with `sleep` in place. A
+	// bare `sh -c "sleep 3600"` lets dash FORK `sleep` as a child under load and,
+	// while waiting on that foreground child, set SIGINT to SIG_IGN. Our single
+	// best-effort SIGINT to the group then lands in the window after dash starts
+	// ignoring it but before the `sleep` child exists, so the signal hits only
+	// dash (which drops it) and is lost — `sleep` then runs unmolested for the
+	// full deadline. `exec` removes the intermediate shell parent: the box IS
+	// `sleep` with default SIGINT disposition, so one signal deterministically
+	// lands. (Interrupt is single-shot with no retry/escalation, unlike Stop's
+	// SIGTERM→SIGKILL, which is why only this verb was exposed to the race.)
 	place, err := rt.Provision(ctx, "intr", runtime.ProvisionRequest{
-		Config: runtime.Config{Command: "sleep 3600"},
+		Config: runtime.Config{Command: "exec sleep 3600"},
 	})
 	if err != nil {
 		t.Fatalf("provision: %v", err)
@@ -120,12 +130,10 @@ func TestSeamsInterrupt(t *testing.T) {
 		t.Fatalf("Interrupt: %v", err)
 	}
 
-	// The deadline races a real subprocess death (SIGINT delivery to the process
-	// group, the kernel reaping `sleep`, and cmd.Wait closing sc.done). Under CI
-	// CPU saturation a sub-second/few-second constant flakes — see TESTING.md
-	// "Test deadline rule." This timer is not the subject under test (we prove
-	// Interrupt delegates, not that it lands within N seconds), so use the shared
-	// exec-race floor.
+	// Death is now deterministic, but reaping (SIGINT delivery + cmd.Wait closing
+	// sc.done) still races the scheduler, so poll up to the shared exec-race floor
+	// rather than asserting a constant. The ceiling is a safety margin, not the
+	// subject under test: we prove Interrupt delegates, not that it lands within N.
 	deadline := time.Now().Add(testutil.ExecRaceTimeout)
 	for {
 		alive, _ := place.IsRunning(ctx)


### PR DESCRIPTION
## Summary

Audited the CI flake history on `main` (single-job red runs across independent commits) and root-caused the two highest-frequency flakes, then fixed each deterministically — **no timeout changes**. Both root causes were confirmed by local reproduction under CPU load (in an isolated PID namespace), and both fixes verified to eliminate the failure.

Ground-truth flake signal (single failing leaf job across distinct commits, `main` should always be green):

| Failing job | Occurrences | Test |
|---|---|---|
| `Integration / packages-core-3-of-4` | 4 | `TestSeamsInterrupt` |
| `Preflight / unit cover (noncmdgc)` | 2 | `TestReaper{Closes…,Preserves…}WorkflowRoots` |

(The all-jobs-red runs in history were the known "main broken then unbroken" commits, not flakes.)

## Fix 1 — `reaper.sh` (real production bug, not just a test artifact)

`has_dependency_target_column` gated control flow on `printf '%s\n' "$fields" | grep -qx '<col>'`. `grep -q` closes stdin the instant it matches, so under load `printf` races into a **SIGPIPE**; with `set -o pipefail` that becomes the pipeline's exit status and `|| return 1` fires **spuriously**. The reaper then treats the dependency schema as absent and `continue`s, **skipping the whole database's workflow-root cleanup**.

- Surfaced as the reaper tests intermittently missing the `WITH RECURSIVE workflow_wisp_root_candidates` / `roots_with_live_descendants` SQL.
- Real impact: in production the reaper would occasionally drop a DB's workflow-root maintenance.
- Fix: check membership via a **here-string** (a simple command — `pipefail` doesn't apply, no upstream writer to receive SIGPIPE).
- Repro: minimal pattern failed 16/4000 under load; the two tests ~2/40. After: **0** across 60 runs + minutes of in-process reruns under load.

## Fix 2 — `TestSeamsInterrupt` (deterministic, event-of-death wait kept)

The test ran `sh -c "sleep 3600"` and asserted one SIGINT to the group killed it. Under load dash **forks** `sleep` as a foreground child and, while waiting on it, sets SIGINT to **SIG_IGN**; the single best-effort SIGINT lands in the window after dash starts ignoring it but before the child exists, so it's lost (Interrupt is single-shot, no escalation — unlike `Stop`'s SIGTERM→SIGKILL). The session then survives the full deadline.

- Fix: launch `exec sleep 3600` so dash replaces itself with `sleep` in place — default SIGINT disposition, one signal always lands. **The exec-race ceiling is unchanged** (kept only as a safety margin).
- Repro: ~13% (8/60) under 2× load. After: **0/300** (white-box) and **0/50** test runs under load; full package passes.

## Verification

All reproduction ran inside a `bwrap`/`unshare --pid` private PID namespace so no signal/`pkill`/process-group op could reach host processes.

- `go vet` clean, `go build ./...` OK, `bash -n reaper.sh` OK
- `go test ./internal/runtime/subprocess/` and full `TestReaper*` suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)