### PR TITLE
fix(extmsg): make replace/handoff atomic and preserve SessionName decode

### DIFF
--- a/cmd/gc/cmd_extmsg_test.go
+++ b/cmd/gc/cmd_extmsg_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/extmsg"
+)
+
+func TestCmdExtMsgBindRejectsInvalidTargetFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		sessionID string
+		replace   bool
+		wantMsg   string
+	}{
+		{name: "bind requires a target", wantMsg: "gc extmsg bind: --agent or --session is required"},
+		{name: "handoff requires a target", replace: true, wantMsg: "gc extmsg handoff: --agent or --session is required"},
+		{name: "bind target mutually exclusive", agentName: "myrig/a", sessionID: "sess-1", wantMsg: "gc extmsg bind: --agent and --session are mutually exclusive"},
+		{name: "handoff target mutually exclusive", agentName: "myrig/a", sessionID: "sess-1", replace: true, wantMsg: "gc extmsg handoff: --agent and --session are mutually exclusive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			// These validations short-circuit before the command reaches the
+			// city API, so an unconfigured city does not affect the result.
+			code := cmdExtMsgBind(extMsgConversationFlags{}, tt.agentName, tt.sessionID, tt.replace, false, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("cmdExtMsgBind code = %d, want 1", code)
+			}
+			if got := stderr.String(); !strings.Contains(got, tt.wantMsg) {
+				t.Fatalf("stderr = %q, want it to contain %q", got, tt.wantMsg)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty on validation failure", stdout.String())
+			}
+		})
+	}
+}
+
+func TestConversationRefValidatesRequiredFlags(t *testing.T) {
+	// scope-id is set so conversationRef does not need to load city config.
+	if _, err := (&extMsgConversationFlags{scopeID: "alpha", conversationID: "123"}).conversationRef("/nonexistent"); err == nil || !strings.Contains(err.Error(), "--provider is required") {
+		t.Fatalf("conversationRef(no provider) err = %v, want --provider is required", err)
+	}
+	if _, err := (&extMsgConversationFlags{scopeID: "alpha", provider: "telegram"}).conversationRef("/nonexistent"); err == nil || !strings.Contains(err.Error(), "--conversation-id is required") {
+		t.Fatalf("conversationRef(no conversation-id) err = %v, want --conversation-id is required", err)
+	}
+
+	ref, err := (&extMsgConversationFlags{
+		scopeID:        "alpha",
+		provider:       "telegram",
+		accountID:      "default",
+		conversationID: "7113355",
+		kind:           "dm",
+	}).conversationRef("/nonexistent")
+	if err != nil {
+		t.Fatalf("conversationRef(valid): %v", err)
+	}
+	want := extmsg.ConversationRef{
+		ScopeID:        "alpha",
+		Provider:       "telegram",
+		AccountID:      "default",
+		ConversationID: "7113355",
+		Kind:           extmsg.ConversationDM,
+	}
+	if ref != want {
+		t.Fatalf("conversationRef = %+v, want %+v", ref, want)
+	}
+}
+
+func TestConversationRefIfSetIsNilWhenUnset(t *testing.T) {
+	got, err := (&extMsgConversationFlags{}).conversationRefIfSet("/nonexistent")
+	if err != nil {
+		t.Fatalf("conversationRefIfSet(unset): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("conversationRefIfSet(unset) = %+v, want nil so unbind filters by session/agent", got)
+	}
+
+	ref, err := (&extMsgConversationFlags{scopeID: "alpha", provider: "telegram", conversationID: "123"}).conversationRefIfSet("/nonexistent")
+	if err != nil {
+		t.Fatalf("conversationRefIfSet(set): %v", err)
+	}
+	if ref == nil || ref.Provider != "telegram" || ref.ConversationID != "123" {
+		t.Fatalf("conversationRefIfSet(set) = %+v, want a populated ref", ref)
+	}
+}
+
+func TestPrintExtMsgBindingOutputs(t *testing.T) {
+	record := extmsg.SessionBindingRecord{
+		ID:                "bind-1",
+		Conversation:      extmsg.ConversationRef{Provider: "telegram", ConversationID: "7113355"},
+		AgentName:         "myrig/specialist",
+		Status:            extmsg.BindingActive,
+		BindingGeneration: 3,
+	}
+
+	var jsonOut bytes.Buffer
+	if code := printExtMsgBinding(&jsonOut, true, record, "handed off"); code != 0 {
+		t.Fatalf("printExtMsgBinding(json) code = %d, want 0", code)
+	}
+	var decoded extmsg.SessionBindingRecord
+	if err := json.Unmarshal(jsonOut.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode json output: %v", err)
+	}
+	if decoded.ID != "bind-1" || decoded.AgentName != "myrig/specialist" || decoded.BindingGeneration != 3 {
+		t.Fatalf("decoded json = %+v, want the binding record", decoded)
+	}
+
+	var humanOut bytes.Buffer
+	if code := printExtMsgBinding(&humanOut, false, record, "handed off"); code != 0 {
+		t.Fatalf("printExtMsgBinding(human) code = %d, want 0", code)
+	}
+	human := humanOut.String()
+	for _, want := range []string{"handed off", "telegram/7113355", "agent myrig/specialist", "binding bind-1", "generation 3"} {
+		if !strings.Contains(human, want) {
+			t.Fatalf("human output = %q, want it to contain %q", human, want)
+		}
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1509,6 +1509,7 @@ func extmsgBindingRecordFromWire(record genclient.SessionBindingRecord) extmsg.S
 			Kind:                 extmsg.ConversationKind(record.Conversation.Kind),
 		},
 		SessionID:         record.SessionID,
+		SessionName:       record.SessionName,
 		AgentName:         record.AgentName,
 		Status:            extmsg.BindingStatus(record.Status),
 		BoundAt:           record.BoundAt,

--- a/internal/api/client_extmsg_test.go
+++ b/internal/api/client_extmsg_test.go
@@ -68,6 +68,56 @@ func TestClientBindExtMsgConversationHandoff(t *testing.T) {
 	}
 }
 
+func TestClientBindExtMsgConversationPreservesSessionName(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v0/city/alpha/extmsg/bind" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+		var body struct {
+			Conversation extmsg.ConversationRef `json:"conversation"`
+			SessionID    string                 `json:"session_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode bind body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(extmsg.SessionBindingRecord{ //nolint:errcheck
+			ID:                "bind-1",
+			Conversation:      body.Conversation,
+			SessionID:         body.SessionID,
+			SessionName:       "myrig/worker-1",
+			Status:            extmsg.BindingActive,
+			BoundAt:           time.Now().UTC(),
+			BindingGeneration: 1,
+		})
+	}))
+	defer ts.Close()
+
+	ref := extmsg.ConversationRef{
+		ScopeID:        "alpha",
+		Provider:       "telegram",
+		AccountID:      "default",
+		ConversationID: "7113355",
+		Kind:           extmsg.ConversationDM,
+	}
+	c := NewCityScopedClient(ts.URL, "alpha")
+	record, err := c.BindExtMsgConversation(ExtMsgBindSpec{
+		Conversation: ref,
+		SessionID:    "sess-123",
+	})
+	if err != nil {
+		t.Fatalf("BindExtMsgConversation: %v", err)
+	}
+	// SessionName is the respawn-stable identity; the wire->domain decode must
+	// carry it through, not silently drop it.
+	if record.SessionName != "myrig/worker-1" {
+		t.Fatalf("record.SessionName = %q, want myrig/worker-1", record.SessionName)
+	}
+	if record.SessionID != "sess-123" {
+		t.Fatalf("record.SessionID = %q, want sess-123", record.SessionID)
+	}
+}
+
 func TestClientUnbindExtMsgConversationByAgent(t *testing.T) {
 	var gotBody struct {
 		Conversation *extmsg.ConversationRef `json:"conversation"`

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -259,6 +259,15 @@ func (s *Server) humaHandleExtMsgBind(ctx context.Context, input *ExtMsgBindInpu
 	if subject == "" {
 		subject = agentName
 	}
+	// A handoff (Replace=true) ends the displaced binding and creates the
+	// replacement atomically, but emits only ExtMsgBound — not a paired
+	// ExtMsgUnbound for the displaced binding. ExtMsgBound with an incremented
+	// binding generation is the canonical handoff lifecycle signal; the bound
+	// payload identifies the new target, and the displaced binding's end is
+	// implied by the conversation now resolving to that new binding (whose
+	// generation is greater than 1). Consumers tracking binding lifecycle should
+	// reconcile against the active binding rather than wait for an ExtMsgUnbound
+	// that handoff intentionally does not emit.
 	s.extmsgEmitEvent()(events.ExtMsgBound, subject, extmsg.BoundEventPayload{
 		Provider:       input.Body.Conversation.Provider,
 		ConversationID: input.Body.Conversation.ConversationID,

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -105,6 +105,26 @@ type ConditionalAssignmentReleaser interface {
 	ReleaseIfCurrent(id, expectedAssignee string) (bool, error)
 }
 
+// AtomicTxStore is implemented by stores whose Tx commits the whole callback
+// atomically: when the callback returns an error, none of its writes persist.
+// Stores that do not implement it (or whose AtomicTx returns false) may leave
+// partial writes after a failed Tx — see the Store.Tx contract — so callers that
+// need an all-or-nothing multi-write swap must either require such a store or
+// sequence their writes so a partial failure stays recoverable on non-atomic
+// backends.
+type AtomicTxStore interface {
+	// AtomicTx reports whether Store.Tx rolls the whole callback back on error.
+	AtomicTx() bool
+}
+
+// StoreSupportsAtomicTx reports whether store's Tx provides atomic rollback. It
+// returns false for any store that does not implement AtomicTxStore, matching
+// the conservative Store.Tx contract for backends without native transactions.
+func StoreSupportsAtomicTx(store Store) bool {
+	a, ok := store.(AtomicTxStore)
+	return ok && a.AtomicTx()
+}
+
 // Tx is the write surface available inside a Store.Tx callback.
 // Keep this interface limited to methods needed by current transactional
 // write pairs; do not add Store methods speculatively.

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -80,7 +80,10 @@ type CachingStore struct {
 	applyEventBeforeCommitForTest func()
 }
 
-var _ ConditionalAssignmentReleaser = (*CachingStore)(nil)
+var (
+	_ ConditionalAssignmentReleaser = (*CachingStore)(nil)
+	_ AtomicTxStore                 = (*CachingStore)(nil)
+)
 
 type cacheState int
 

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -476,6 +476,12 @@ func (c *CachingStore) Tx(commitMsg string, fn func(Tx) error) error {
 	return nil
 }
 
+// AtomicTx reports whether Tx is atomic, which for the caching store is exactly
+// whether its backing store provides an atomic transaction: CachingStore.Tx is a
+// transparent pass-through to backing.Tx, so it inherits the backing's
+// all-or-nothing (or partial-write) failure semantics.
+func (c *CachingStore) AtomicTx() bool { return StoreSupportsAtomicTx(c.backing) }
+
 type cachingStoreTx struct {
 	backing Tx
 	seen    map[string]struct{}

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -166,6 +166,7 @@ type NativeDoltStore struct {
 var (
 	_ Store                         = (*NativeDoltStore)(nil)
 	_ ConditionalAssignmentReleaser = (*NativeDoltStore)(nil)
+	_ AtomicTxStore                 = (*NativeDoltStore)(nil)
 	_ GraphApplyStore               = (*NativeDoltStore)(nil)
 	_ StorageGraphApplyStore        = (*NativeDoltStore)(nil)
 	_ EphemeralGraphApplyStore      = (*NativeDoltStore)(nil)
@@ -971,6 +972,10 @@ func (s *NativeDoltStore) Tx(commitMsg string, fn func(Tx) error) error {
 		return fn(&nativeDoltTx{store: s, ctx: ctx, tx: tx})
 	})
 }
+
+// AtomicTx reports that Tx is backed by a native Dolt transaction that rolls
+// back every write when the callback returns an error.
+func (s *NativeDoltStore) AtomicTx() bool { return true }
 
 // nativeDoltTx adapts the Store.Tx write surface onto an open beadslib
 // transaction. Every method routes through the store's applyXInTx helpers so

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -80,6 +80,17 @@ func newBindingService(store beads.Store, delivery bindingCleaner, transcript bi
 	return svc
 }
 
+// bindTarget is the resolved endpoint a Bind call creates a binding for:
+// exactly one of sessionID/agentName is set, and sessionName is the stable
+// session identity captured for session bindings (empty for agent bindings or
+// when no live session bead resolved). It bundles the three values the bind
+// helpers thread together so the create/rebind/handoff paths share one shape.
+type bindTarget struct {
+	sessionID   string
+	agentName   string
+	sessionName string
+}
+
 func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInput) (SessionBindingRecord, error) {
 	if err := checkContext(ctx); err != nil {
 		return SessionBindingRecord{}, err
@@ -101,7 +112,11 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 	}
 	// Capture the target's stable session name so the binding survives respawn.
 	// Best-effort: empty when the selector resolves to no session bead.
-	sessionName := sessionNameForSelector(s.store, sessionID)
+	target := bindTarget{
+		sessionID:   sessionID,
+		agentName:   agentName,
+		sessionName: sessionNameForSelector(s.store, sessionID),
+	}
 	now := zeroNow(input.Now)
 
 	var out SessionBindingRecord
@@ -117,129 +132,235 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 		if err != nil {
 			return err
 		}
-		if active != nil && (active.SessionID != sessionID || active.AgentName != agentName) {
+		switch {
+		case active != nil && (active.SessionID != sessionID || active.AgentName != agentName):
 			if !input.Replace {
 				return fmt.Errorf("%w: conversation already bound to %s", ErrBindingConflict, bindingTarget(*active))
 			}
-			// Handoff: end the active binding and fall through to create
-			// the new one under the same conversation lock.
-			if err := s.endActiveBindingLocked(ctx, caller, *active, now); err != nil {
-				return err
-			}
-			if s.delivery != nil && active.SessionID != "" {
-				if err := s.delivery.ClearForConversation(ctx, active.SessionID, active.Conversation); err != nil {
-					return err
-				}
-			}
-			active = nil
+			out, err = s.handoffActiveBindingLocked(ctx, caller, *active, ref, target, input, history, now)
+			return err
+		case active != nil:
+			out, err = s.rebindActiveLocked(caller, ref, *active, target, input, now)
+			return err
+		default:
+			out, err = s.createBindingLocked(caller, ref, target, input, history, now, "")
+			return err
 		}
-		if active != nil {
-			// Coalesce the rebind's writes — optional session-name backfill,
-			// binding metadata, and transcript membership — into one commit so a
-			// rebind costs a single DOLT_COMMIT instead of 2-4 (gastownhall/gascity#3735).
-			if err := s.store.Tx("gc: extmsg rebind "+conversationLockKey(ref), func(tx beads.Tx) error {
-				if active.SessionName == "" && sessionName != "" {
-					if err := tx.Update(active.ID, beads.UpdateOpts{
-						Labels:   []string{bindingSessionNameLabel(sessionName)},
-						Metadata: map[string]string{"session_name": sessionName},
-					}); err != nil {
-						return fmt.Errorf("backfill session name on binding %s: %w", active.ID, err)
-					}
-				}
-				if err := s.updateBindingMetadata(tx, *active, input.Metadata, input.ExpiresAt, now); err != nil {
-					return err
-				}
-				if s.transcript != nil {
-					if _, err := s.transcript.ensureMembershipLockedWriter(tx, EnsureMembershipInput{
-						Caller:         caller,
-						Conversation:   ref,
-						SessionID:      bindingMembershipKey(*active),
-						BackfillPolicy: MembershipBackfillSinceJoin,
-						Owner:          MembershipOwnerBinding,
-						Now:            now,
-					}); err != nil {
-						return wrapTranscriptSyncError("ensure transcript membership after bind", err)
-					}
-				}
-				return nil
-			}); err != nil {
-				return err
-			}
-			updated, err := s.getBinding(active.ID)
-			if err != nil {
-				return err
-			}
-			out = updated
-			return nil
-		}
-		nextGeneration := nextBindingGeneration(history)
-		// A binding targets either a configured agent (delivery-time resolution)
-		// or a concrete session. Agent bindings get only the agent label; session
-		// bindings get the volatile session-id label plus the stable session-name
-		// label (which survives respawn) when a name is known.
-		labels := []string{"gc:extmsg-binding", labelBindingBase, bindingConversationLabel(ref)}
-		if agentName != "" {
-			labels = append(labels, bindingAgentLabel(agentName))
-		} else {
-			labels = append(labels, bindingSessionLabel(sessionID))
-			if sessionName != "" {
-				labels = append(labels, bindingSessionNameLabel(sessionName))
-			}
-		}
-		// Coalesce the new binding's create and its transcript membership (plus
-		// any first-touch transcript-state create) into one commit so a fresh
-		// bind costs a single DOLT_COMMIT (gastownhall/gascity#3735).
-		return s.store.Tx("gc: extmsg bind "+conversationLockKey(ref), func(tx beads.Tx) error {
-			b, err := tx.Create(beads.Bead{
-				Title:  conversationTitle(ref),
-				Type:   "task",
-				Labels: labels,
-				Metadata: encodeMetadataFields(input.Metadata, map[string]string{
-					"schema_version":         strconv.Itoa(schemaVersion),
-					"scope_id":               ref.ScopeID,
-					"provider":               ref.Provider,
-					"account_id":             ref.AccountID,
-					"conversation_id":        ref.ConversationID,
-					"parent_conversation_id": ref.ParentConversationID,
-					"conversation_kind":      string(ref.Kind),
-					"session_id":             sessionID,
-					"session_name":           sessionName,
-					"agent_name":             agentName,
-					"binding_generation":     strconv.FormatInt(nextGeneration, 10),
-					"bound_at":               formatTime(now),
-					"expires_at":             formatTimePtr(input.ExpiresAt),
-					"last_touched_at":        formatTime(now),
-					"created_by_kind":        string(normalizeCaller(caller).Kind),
-					"created_by_id":          normalizeCaller(caller).ID,
-				}),
-			})
-			if err != nil {
-				return fmt.Errorf("create external binding: %w", err)
-			}
-			decoded, err := decodeBindingBead(b)
-			if err != nil {
-				return err
-			}
-			out = decoded
-			if s.transcript != nil {
-				if _, err := s.transcript.ensureMembershipLockedWriter(tx, EnsureMembershipInput{
-					Caller:         caller,
-					Conversation:   ref,
-					SessionID:      bindingMembershipKey(decoded),
-					BackfillPolicy: MembershipBackfillSinceJoin,
-					Owner:          MembershipOwnerBinding,
-					Now:            now,
-				}); err != nil {
-					return wrapTranscriptSyncError("ensure transcript membership after bind", err)
-				}
-			}
-			return nil
-		})
 	})
 	if err != nil {
 		return SessionBindingRecord{}, err
 	}
 	return out, nil
+}
+
+// createBindingLocked creates a fresh binding for ref under the conversation
+// lock. It coalesces the binding bead, its transcript membership, and an
+// optional displaced-binding close into a single commit so a bind costs one
+// DOLT_COMMIT (gastownhall/gascity#3735). When displaceID is non-empty the
+// displaced binding is closed in the SAME transaction; on a store with atomic
+// transactions (the only caller that passes displaceID, see
+// handoffActiveBindingLocked) a failure creating the replacement or its
+// membership rolls the whole swap back and leaves the displaced binding active,
+// so the conversation is never left unbound. history supplies the next
+// generation.
+func (s *bindingService) createBindingLocked(caller Caller, ref ConversationRef, target bindTarget, input BindInput, history []SessionBindingRecord, now time.Time, displaceID string) (SessionBindingRecord, error) {
+	nextGeneration := nextBindingGeneration(history)
+	// A binding targets either a configured agent (delivery-time resolution)
+	// or a concrete session. Agent bindings get only the agent label; session
+	// bindings get the volatile session-id label plus the stable session-name
+	// label (which survives respawn) when a name is known.
+	labels := []string{"gc:extmsg-binding", labelBindingBase, bindingConversationLabel(ref)}
+	if target.agentName != "" {
+		labels = append(labels, bindingAgentLabel(target.agentName))
+	} else {
+		labels = append(labels, bindingSessionLabel(target.sessionID))
+		if target.sessionName != "" {
+			labels = append(labels, bindingSessionNameLabel(target.sessionName))
+		}
+	}
+	var out SessionBindingRecord
+	if err := s.store.Tx("gc: extmsg bind "+conversationLockKey(ref), func(tx beads.Tx) error {
+		if displaceID != "" {
+			if err := tx.Close(displaceID); err != nil {
+				return fmt.Errorf("close displaced binding %s: %w", displaceID, err)
+			}
+		}
+		b, err := tx.Create(beads.Bead{
+			Title:  conversationTitle(ref),
+			Type:   "task",
+			Labels: labels,
+			Metadata: encodeMetadataFields(input.Metadata, map[string]string{
+				"schema_version":         strconv.Itoa(schemaVersion),
+				"scope_id":               ref.ScopeID,
+				"provider":               ref.Provider,
+				"account_id":             ref.AccountID,
+				"conversation_id":        ref.ConversationID,
+				"parent_conversation_id": ref.ParentConversationID,
+				"conversation_kind":      string(ref.Kind),
+				"session_id":             target.sessionID,
+				"session_name":           target.sessionName,
+				"agent_name":             target.agentName,
+				"binding_generation":     strconv.FormatInt(nextGeneration, 10),
+				"bound_at":               formatTime(now),
+				"expires_at":             formatTimePtr(input.ExpiresAt),
+				"last_touched_at":        formatTime(now),
+				"created_by_kind":        string(normalizeCaller(caller).Kind),
+				"created_by_id":          normalizeCaller(caller).ID,
+			}),
+		})
+		if err != nil {
+			return fmt.Errorf("create external binding: %w", err)
+		}
+		decoded, err := decodeBindingBead(b)
+		if err != nil {
+			return err
+		}
+		out = decoded
+		if s.transcript != nil {
+			if _, err := s.transcript.ensureMembershipLockedWriter(tx, EnsureMembershipInput{
+				Caller:         caller,
+				Conversation:   ref,
+				SessionID:      bindingMembershipKey(decoded),
+				BackfillPolicy: MembershipBackfillSinceJoin,
+				Owner:          MembershipOwnerBinding,
+				Now:            now,
+			}); err != nil {
+				return wrapTranscriptSyncError("ensure transcript membership after bind", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return SessionBindingRecord{}, err
+	}
+	return out, nil
+}
+
+// rebindActiveLocked refreshes the already-active binding when Bind targets the
+// same endpoint: it backfills a now-known session name, updates binding
+// metadata, and re-ensures transcript membership, coalescing all writes into a
+// single commit (gastownhall/gascity#3735).
+func (s *bindingService) rebindActiveLocked(caller Caller, ref ConversationRef, active SessionBindingRecord, target bindTarget, input BindInput, now time.Time) (SessionBindingRecord, error) {
+	if err := s.store.Tx("gc: extmsg rebind "+conversationLockKey(ref), func(tx beads.Tx) error {
+		if active.SessionName == "" && target.sessionName != "" {
+			if err := tx.Update(active.ID, beads.UpdateOpts{
+				Labels:   []string{bindingSessionNameLabel(target.sessionName)},
+				Metadata: map[string]string{"session_name": target.sessionName},
+			}); err != nil {
+				return fmt.Errorf("backfill session name on binding %s: %w", active.ID, err)
+			}
+		}
+		if err := s.updateBindingMetadata(tx, active, input.Metadata, input.ExpiresAt, now); err != nil {
+			return err
+		}
+		if s.transcript != nil {
+			if _, err := s.transcript.ensureMembershipLockedWriter(tx, EnsureMembershipInput{
+				Caller:         caller,
+				Conversation:   ref,
+				SessionID:      bindingMembershipKey(active),
+				BackfillPolicy: MembershipBackfillSinceJoin,
+				Owner:          MembershipOwnerBinding,
+				Now:            now,
+			}); err != nil {
+				return wrapTranscriptSyncError("ensure transcript membership after bind", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return SessionBindingRecord{}, err
+	}
+	return s.getBinding(active.ID)
+}
+
+// handoffActiveBindingLocked swaps the conversation's active binding from
+// displaced to the caller's new target, all under the conversation's binding
+// lock. Delivery contexts for the displaced session are cleared first, so a
+// clear failure leaves the displaced binding fully intact and the whole handoff
+// retryable (the same end-then-clear ordering the expiry path uses). The
+// displaced binding's transcript membership is dropped before the swap and
+// re-ensured if the swap fails while the displaced binding is still active.
+//
+// How the close-of-displaced and create-of-replacement are sequenced depends on
+// the store's transaction guarantee, because a handoff is the first write pair
+// whose atomicity is a correctness requirement rather than a commit-count
+// optimization:
+//
+//   - On a store with atomic transactions, both happen in one store.Tx that
+//     commits or rolls back as a unit (see createBindingLocked). A failure
+//     leaves the displaced binding active and creates no replacement.
+//   - On a non-atomic store, a single Tx cannot do both atomically and partial
+//     writes persist on failure, so the displaced binding is closed first as its
+//     own write and the replacement is created after. A mid-swap failure can then
+//     only leave the conversation unbound (recoverable by a fresh bind) or bound
+//     to the new target without transcript membership (recovered by the next
+//     same-target rebind) — never two active bindings at once, which
+//     selectActiveBinding rejects as an unrecoverable invariant violation.
+func (s *bindingService) handoffActiveBindingLocked(ctx context.Context, caller Caller, displaced SessionBindingRecord, ref ConversationRef, target bindTarget, input BindInput, history []SessionBindingRecord, now time.Time) (SessionBindingRecord, error) {
+	if s.delivery != nil && displaced.SessionID != "" {
+		if err := s.delivery.ClearForConversation(ctx, displaced.SessionID, displaced.Conversation); err != nil {
+			return SessionBindingRecord{}, err
+		}
+	}
+	if err := s.store.SetMetadata(displaced.ID, "last_touched_at", formatTime(now)); err != nil {
+		return SessionBindingRecord{}, fmt.Errorf("update binding %s metadata: %w", displaced.ID, err)
+	}
+	if s.transcript != nil {
+		if err := s.transcript.removeMembershipLocked(RemoveMembershipInput{
+			Caller:       caller,
+			Conversation: displaced.Conversation,
+			SessionID:    bindingMembershipKey(displaced),
+			Owner:        MembershipOwnerBinding,
+			Now:          now,
+		}); err != nil {
+			return SessionBindingRecord{}, wrapTranscriptSyncError("remove transcript membership after unbind", err)
+		}
+	}
+
+	if beads.StoreSupportsAtomicTx(s.store) {
+		out, err := s.createBindingLocked(caller, ref, target, input, history, now, displaced.ID)
+		if err != nil {
+			// The swap rolled back, so the displaced binding is still active —
+			// restore its membership to match.
+			return SessionBindingRecord{}, s.restoreDisplacedMembershipLocked(caller, displaced, now, err)
+		}
+		return out, nil
+	}
+
+	if err := s.store.Close(displaced.ID); err != nil {
+		// The displaced binding is still active because the close did not land —
+		// restore its membership to match.
+		return SessionBindingRecord{}, s.restoreDisplacedMembershipLocked(caller, displaced, now,
+			fmt.Errorf("close displaced binding %s: %w", displaced.ID, err))
+	}
+	out, err := s.createBindingLocked(caller, ref, target, input, history, now, "")
+	if err != nil {
+		// The displaced binding is already closed, so the conversation is unbound
+		// or bound to a replacement still missing its membership; both states are
+		// recoverable on retry. Do not re-open the displaced binding.
+		return SessionBindingRecord{}, err
+	}
+	return out, nil
+}
+
+// restoreDisplacedMembershipLocked re-ensures the displaced binding's transcript
+// membership after a failed swap that left the displaced binding active, and
+// returns cause. If the restore itself fails, it joins that failure onto cause
+// so a transcript that could not be put back is surfaced rather than silently
+// dropped.
+func (s *bindingService) restoreDisplacedMembershipLocked(caller Caller, displaced SessionBindingRecord, now time.Time, cause error) error {
+	if s.transcript == nil {
+		return cause
+	}
+	if _, err := s.transcript.ensureMembershipLocked(EnsureMembershipInput{
+		Caller:         caller,
+		Conversation:   displaced.Conversation,
+		SessionID:      bindingMembershipKey(displaced),
+		BackfillPolicy: MembershipBackfillSinceJoin,
+		Owner:          MembershipOwnerBinding,
+		Now:            now,
+	}); err != nil {
+		return errors.Join(cause, wrapTranscriptSyncError("restore displaced transcript membership after failed handoff", err))
+	}
+	return cause
 }
 
 func (s *bindingService) ResolveByConversation(ctx context.Context, ref ConversationRef) (*SessionBindingRecord, error) {

--- a/internal/extmsg/rebind_test.go
+++ b/internal/extmsg/rebind_test.go
@@ -3,6 +3,7 @@ package extmsg
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,6 +70,269 @@ func TestBindingServiceReplaceRebindsActiveBinding(t *testing.T) {
 	}
 }
 
+func TestBindingServiceHandoffKeepsBindingWhenDeliveryClearFails(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	delivery := &failingDeliveryContextService{err: errors.New("boom")}
+	svc := newBindingService(store, delivery, nil, newBindingLockPool())
+	ref := testConversationRef()
+
+	// Displaced binding to a concrete session so the handoff attempts to clear
+	// that session's delivery contexts.
+	displaced, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-a",
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("Bind(displaced): %v", err)
+	}
+
+	// Handoff to a new session: clearing the displaced session's delivery fails.
+	// The clear runs before the binding swap, so the displaced binding must stay
+	// intact and the whole handoff is retryable — never a window where the
+	// conversation is left unbound.
+	if _, err := svc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-b",
+		Replace:      true,
+		Now:          testNow().Add(time.Minute),
+	}); err == nil {
+		t.Fatal("Bind(handoff) error = nil, want delivery clear failure")
+	}
+
+	item, err := store.Get(displaced.ID)
+	if err != nil {
+		t.Fatalf("Get(displaced): %v", err)
+	}
+	if item.Status != "open" {
+		t.Fatalf("displaced binding status after failed clear = %q, want open", item.Status)
+	}
+	active, err := svc.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if active == nil || active.ID != displaced.ID || active.SessionID != "sess-a" {
+		t.Fatalf("active = %#v, want the displaced sess-a binding still bound", active)
+	}
+	// The replacement binding must not have been created.
+	replacement, err := svc.ListBySession(context.Background(), "sess-b")
+	if err != nil {
+		t.Fatalf("ListBySession(sess-b): %v", err)
+	}
+	if len(replacement) != 0 {
+		t.Fatalf("ListBySession(sess-b) = %#v, want no replacement binding created", replacement)
+	}
+}
+
+func TestBindingServiceHandoffRollsBackMembershipWhenReplacementFails(t *testing.T) {
+	freezeTestClock(t)
+	// A transactional store: the swap rolls back atomically on failure.
+	store := &atomicTxStore{MemStore: beads.NewMemStore()}
+	ref := testConversationRef()
+
+	// Set up the displaced binding with a real transcript so its membership exists.
+	realSvc := NewServices(store).Bindings
+	displaced, err := realSvc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/frontdesk",
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("Bind(displaced): %v", err)
+	}
+
+	// Hand off through a service whose transcript fails the replacement's
+	// membership ensure. On a transactional store the swap (close displaced +
+	// create replacement + ensure replacement membership) must roll back as a
+	// unit: the displaced binding stays the active one, no replacement bead is
+	// left behind, and the displaced membership dropped before the swap is
+	// re-ensured.
+	flaky := &flakyTranscriptService{failEnsureCount: 1, err: errors.New("boom")}
+	flakySvc := newBindingService(store, nil, flaky, newBindingLockPool())
+	if _, err := flakySvc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/specialist",
+		Replace:      true,
+		Now:          testNow().Add(time.Minute),
+	}); err == nil {
+		t.Fatal("Bind(handoff) error = nil, want replacement membership failure")
+	}
+
+	if flaky.removeCalls != 1 {
+		t.Fatalf("removeCalls = %d, want 1 (displaced membership dropped once)", flaky.removeCalls)
+	}
+	if flaky.ensureCalls != 2 {
+		t.Fatalf("ensureCalls = %d, want 2 (replacement ensure failed, displaced membership re-ensured)", flaky.ensureCalls)
+	}
+
+	// The displaced binding is still the one and only active binding — not a
+	// leaked replacement that selectActiveBinding would reject as an invariant
+	// violation.
+	bs := flakySvc.(*bindingService)
+	remaining, err := bs.listBindingsForConversation(ref)
+	if err != nil {
+		t.Fatalf("listBindingsForConversation: %v", err)
+	}
+	var actives []SessionBindingRecord
+	for _, b := range remaining {
+		if b.Status == BindingActive {
+			actives = append(actives, b)
+		}
+		if b.AgentName == "myrig/specialist" {
+			t.Fatalf("found leaked replacement binding %#v, want the swap rolled back", b)
+		}
+	}
+	if len(actives) != 1 {
+		t.Fatalf("active bindings = %d (%#v), want exactly 1 (the displaced)", len(actives), remaining)
+	}
+	if actives[0].ID != displaced.ID || actives[0].AgentName != "myrig/frontdesk" {
+		t.Fatalf("active = %#v, want the displaced frontdesk binding %s", actives[0], displaced.ID)
+	}
+
+	active, err := flakySvc.ResolveByConversation(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveByConversation: %v", err)
+	}
+	if active == nil || active.ID != displaced.ID {
+		t.Fatalf("active = %#v, want the displaced binding %s still bound", active, displaced.ID)
+	}
+}
+
+// TestBindingServiceHandoffReportsDisplacedMembershipRestoreFailure asserts that
+// when the swap rolls back AND re-ensuring the displaced binding's membership
+// also fails, the restore failure is surfaced on the returned error rather than
+// being silently swallowed.
+func TestBindingServiceHandoffReportsDisplacedMembershipRestoreFailure(t *testing.T) {
+	freezeTestClock(t)
+	store := &atomicTxStore{MemStore: beads.NewMemStore()}
+	ref := testConversationRef()
+
+	realSvc := NewServices(store).Bindings
+	displaced, err := realSvc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/frontdesk",
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("Bind(displaced): %v", err)
+	}
+
+	// failEnsureCount: 2 fails both the replacement ensure (driving the rollback)
+	// and the subsequent displaced-membership restore.
+	flaky := &flakyTranscriptService{failEnsureCount: 2, err: errors.New("boom")}
+	flakySvc := newBindingService(store, nil, flaky, newBindingLockPool())
+	_, err = flakySvc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/specialist",
+		Replace:      true,
+		Now:          testNow().Add(time.Minute),
+	})
+	if err == nil {
+		t.Fatal("Bind(handoff) error = nil, want a reported failure")
+	}
+	if !errors.Is(err, ErrTranscriptSyncFailed) {
+		t.Fatalf("error = %v, want it to wrap ErrTranscriptSyncFailed", err)
+	}
+	if !strings.Contains(err.Error(), "restore displaced transcript membership after failed handoff") {
+		t.Fatalf("error = %v, want it to report the displaced membership restore failure", err)
+	}
+	if flaky.ensureCalls != 2 {
+		t.Fatalf("ensureCalls = %d, want 2 (replacement ensure + displaced restore both attempted)", flaky.ensureCalls)
+	}
+
+	// The displaced binding still remains the sole active binding.
+	bs := flakySvc.(*bindingService)
+	remaining, err := bs.listBindingsForConversation(ref)
+	if err != nil {
+		t.Fatalf("listBindingsForConversation: %v", err)
+	}
+	var actives []SessionBindingRecord
+	for _, b := range remaining {
+		if b.Status == BindingActive {
+			actives = append(actives, b)
+		}
+	}
+	if len(actives) != 1 || actives[0].ID != displaced.ID {
+		t.Fatalf("active bindings = %#v, want only the displaced %s", actives, displaced.ID)
+	}
+}
+
+// TestBindingServiceHandoffConvergesOnNonAtomicStore asserts that on a
+// non-transactional backend whose Tx cannot close the displaced binding and
+// create the replacement atomically, a failed handoff never leaves two active
+// bindings (the unrecoverable invariant violation) and a retry converges on the
+// requested target.
+func TestBindingServiceHandoffConvergesOnNonAtomicStore(t *testing.T) {
+	freezeTestClock(t)
+	// bdLikeStore stages Close inside Tx but persists Create immediately, like
+	// BdStore: an in-Tx close+create swap would leave two active bindings here.
+	store := &bdLikeStore{MemStore: beads.NewMemStore()}
+	ref := testConversationRef()
+
+	realSvc := NewServices(store).Bindings
+	displaced, err := realSvc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/frontdesk",
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("Bind(displaced): %v", err)
+	}
+
+	flaky := &flakyTranscriptService{failEnsureCount: 1, err: errors.New("boom")}
+	flakySvc := newBindingService(store, nil, flaky, newBindingLockPool())
+	if _, err := flakySvc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/specialist",
+		Replace:      true,
+		Now:          testNow().Add(time.Minute),
+	}); err == nil {
+		t.Fatal("Bind(handoff) error = nil, want replacement membership failure")
+	}
+
+	// The failed handoff must not have produced two active bindings: at most one
+	// active binding may remain, so a later resolve/bind never hits the
+	// multiple-active invariant violation.
+	bs := flakySvc.(*bindingService)
+	remaining, err := bs.listBindingsForConversation(ref)
+	if err != nil {
+		t.Fatalf("listBindingsForConversation: %v", err)
+	}
+	var actives []SessionBindingRecord
+	for _, b := range remaining {
+		if b.Status == BindingActive {
+			actives = append(actives, b)
+		}
+	}
+	if len(actives) > 1 {
+		t.Fatalf("active bindings = %d (%#v), want at most 1 — the brick is two active bindings", len(actives), remaining)
+	}
+	for _, b := range remaining {
+		if b.ID == displaced.ID && b.Status == BindingActive {
+			t.Fatalf("displaced binding %s is still active, want it closed by the close-first swap", displaced.ID)
+		}
+	}
+
+	// A retry of the same handoff target converges: it rebinds the (now active)
+	// replacement and re-ensures its transcript membership.
+	retry, err := flakySvc.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		AgentName:    "myrig/specialist",
+		Replace:      true,
+		Now:          testNow().Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Bind(retry) error = %v, want convergence", err)
+	}
+	if retry.AgentName != "myrig/specialist" {
+		t.Fatalf("retry AgentName = %q, want myrig/specialist", retry.AgentName)
+	}
+	if flaky.ensureCalls < 2 {
+		t.Fatalf("ensureCalls = %d, want the retry to re-ensure the replacement membership", flaky.ensureCalls)
+	}
+}
+
 func TestBindingServiceReplaceAcrossKindsAndIdempotence(t *testing.T) {
 	freezeTestClock(t)
 	store := beads.NewMemStore()
@@ -130,4 +394,116 @@ func TestBindingServiceReplaceAcrossKindsAndIdempotence(t *testing.T) {
 	if fresh.SessionID != "sess-b" {
 		t.Fatalf("fresh = %#v, want sess-b session binding", fresh)
 	}
+}
+
+// atomicTxStore wraps a MemStore with an atomic Tx: writes made inside the
+// callback are rolled back when the callback returns an error — created beads are
+// deleted and closed beads are reopened — modeling a transactional backend such
+// as NativeDoltStore. It covers exactly the write set of the handoff swap
+// (close the displaced binding, create the replacement); it does not roll back
+// Update/SetMetadataBatch, which that swap does not use.
+type atomicTxStore struct {
+	*beads.MemStore
+}
+
+func (s *atomicTxStore) AtomicTx() bool { return true }
+
+func (s *atomicTxStore) Tx(_ string, fn func(beads.Tx) error) error {
+	rec := &atomicRecordingTx{store: s.MemStore}
+	if err := fn(rec); err != nil {
+		rec.rollback()
+		return err
+	}
+	return nil
+}
+
+type atomicRecordingTx struct {
+	store   *beads.MemStore
+	created []string
+	reopen  []string
+}
+
+func (tx *atomicRecordingTx) Create(b beads.Bead) (beads.Bead, error) {
+	created, err := tx.store.Create(b)
+	if err == nil {
+		tx.created = append(tx.created, created.ID)
+	}
+	return created, err
+}
+
+func (tx *atomicRecordingTx) Update(id string, opts beads.UpdateOpts) error {
+	return tx.store.Update(id, opts)
+}
+
+func (tx *atomicRecordingTx) SetMetadataBatch(id string, kvs map[string]string) error {
+	return tx.store.SetMetadataBatch(id, kvs)
+}
+
+func (tx *atomicRecordingTx) Close(id string) error {
+	prior, getErr := tx.store.Get(id)
+	if err := tx.store.Close(id); err != nil {
+		return err
+	}
+	if getErr == nil && prior.Status != "closed" {
+		tx.reopen = append(tx.reopen, id)
+	}
+	return nil
+}
+
+func (tx *atomicRecordingTx) rollback() {
+	for _, id := range tx.created {
+		_ = tx.store.Delete(id)
+	}
+	for _, id := range tx.reopen {
+		_ = tx.store.Reopen(id)
+	}
+}
+
+// bdLikeStore models an external store such as BdStore: Create persists
+// immediately, while Close inside a Tx is staged and applied only if the
+// callback succeeds, so a failed Tx discards the staged close but keeps the
+// persisted create. A close-of-displaced + create-of-replacement done inside one
+// Tx would therefore leave two active bindings on this backend; the handoff's
+// close-first ordering must converge here instead.
+type bdLikeStore struct {
+	*beads.MemStore
+}
+
+func (s *bdLikeStore) AtomicTx() bool { return false }
+
+func (s *bdLikeStore) Tx(_ string, fn func(beads.Tx) error) error {
+	staged := &bdLikeTx{store: s.MemStore}
+	if err := fn(staged); err != nil {
+		return err // staged closes discarded; immediate creates persist
+	}
+	return staged.apply()
+}
+
+type bdLikeTx struct {
+	store  *beads.MemStore
+	closes []string
+}
+
+func (tx *bdLikeTx) Create(b beads.Bead) (beads.Bead, error) { return tx.store.Create(b) }
+
+func (tx *bdLikeTx) Update(id string, opts beads.UpdateOpts) error {
+	return tx.store.Update(id, opts)
+}
+
+func (tx *bdLikeTx) SetMetadataBatch(id string, kvs map[string]string) error {
+	return tx.store.SetMetadataBatch(id, kvs)
+}
+
+func (tx *bdLikeTx) Close(id string) error {
+	tx.closes = append(tx.closes, id)
+	return nil
+}
+
+func (tx *bdLikeTx) apply() error {
+	for _, id := range tx.closes {
+		if err := tx.store.Close(id); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Follow-up maintainer PR for the already-merged original PR #3438.

Original PR: https://github.com/gastownhall/gascity/pull/3438
Original title: feat(extmsg): handoff/bind/unbind CLI verbs + replace-bind handoff (ga-fxi5zp)
Original state: MERGED
Configured base: main
Original GitHub base: main

This branch carries only the maintainer-side fixup commit needed after the original contribution merged:

- `fix(extmsg): make replace/handoff atomic and preserve SessionName decode`

## Maintainer Changes

- 1 commit, 10 files changed, 825 insertions(+), 110 deletions(-)

## Review Context

The original PR was reviewed and approved on attempt 3. The review loop found and resolved the handoff atomicity issue on non-transactional stores and the API client `SessionName` decode regression. CI was green on the approved head, and this follow-up preserves the maintainer fix as a separate merge surface because the original PR is already merged.
