### PR TITLE
fix(runtime/tmux): de-flake hidden-attach readiness via client-attached hook (closes #3797)

### DIFF
--- a/internal/runtime/tmux/hidden_attach_hook_test.go
+++ b/internal/runtime/tmux/hidden_attach_hook_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHiddenAttachArmsAndClearsClientAttachedHook guards the event-based
+// readiness path: ensureHiddenAttachedClient must arm a per-attach wait-for
+// channel via a client-attached hook (so waitForHiddenAttachReady wakes on a
+// server-pushed event rather than the legacy poll), and CloseHiddenAttachClient
+// must remove it. Without this, a silent fall-back to polling would still pass
+// TestHiddenAttachedClientCanSendText while reintroducing the CI-starvation
+// flake this hook fixes.
+func TestHiddenAttachArmsAndClearsClientAttachedHook(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+	tm := testTmux()
+	session := "gt-test-attach-hook-" + t.Name()
+	_ = tm.KillSession(session)
+	if err := tm.NewSession(session, "sleep 600"); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tm.KillSession(session) }()
+
+	if err := tm.ensureHiddenAttachedClient(session); err != nil {
+		t.Fatalf("ensureHiddenAttachedClient: %v", err)
+	}
+
+	client := tm.hiddenAttachClient(session)
+	if client == nil {
+		t.Fatal("no hidden client tracked after ensureHiddenAttachedClient")
+	}
+	if client.channel == "" {
+		t.Fatal("hook channel empty: readiness fell back to polling instead of the client-attached hook")
+	}
+	hooks, err := tm.run("show-hooks", "-t", session)
+	if err != nil {
+		t.Fatalf("show-hooks: %v", err)
+	}
+	if !strings.Contains(hooks, "client-attached") || !strings.Contains(hooks, client.channel) {
+		t.Fatalf("client-attached hook not armed to signal %q; hooks:\n%s", client.channel, hooks)
+	}
+
+	tm.CloseHiddenAttachClient(session)
+	if hooks, err := tm.run("show-hooks", "-t", session); err == nil && strings.Contains(hooks, "client-attached") {
+		t.Fatalf("client-attached hook not removed on close; hooks:\n%s", hooks)
+	}
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -228,6 +228,7 @@ type Tmux struct {
 	configureOnce        sync.Once
 	hiddenAttachMu       sync.Mutex
 	hiddenAttachClients  map[string]*hiddenAttachClient
+	hiddenAttachSeq      atomic.Uint64
 
 	// pokeMu guards pokes, which tracks gc's own send-keys per session so
 	// GetSessionActivity can discount activity that is only our poke's echo
@@ -259,9 +260,13 @@ const (
 )
 
 type hiddenAttachClient struct {
-	cancel  context.CancelFunc
-	done    chan error
-	stdin   io.WriteCloser
+	cancel context.CancelFunc
+	done   chan error
+	stdin  io.WriteCloser
+	// channel is the per-attach tmux wait-for channel signaled by this
+	// client's client-attached hook. Empty when the hook could not be armed,
+	// in which case readiness falls back to polling.
+	channel string
 	writeMu sync.Mutex
 }
 
@@ -1338,10 +1343,22 @@ func (t *Tmux) ensureHiddenAttachedClient(target string) error {
 		t.hiddenAttachMu.Unlock()
 		return err
 	}
+	// Arm a per-attach wait-for channel so waitForHiddenAttachReady wakes on a
+	// server-pushed client-attached event instead of polling display-message in
+	// a loop, whose per-tick subprocesses otherwise contend with the attach
+	// itself under CI CPU starvation. set-hook here happens-before that wait's
+	// fast-path IsSessionAttached check, so an attach that races ahead of the
+	// hook is still caught; an empty channel (set-hook failed) falls back to the
+	// legacy poll.
+	channel := fmt.Sprintf("gc-hidden-attach-%d", t.hiddenAttachSeq.Add(1))
+	if _, err := t.run("set-hook", "-t", target, "client-attached", "wait-for -S "+channel); err != nil {
+		channel = ""
+	}
 	client := &hiddenAttachClient{
-		cancel: cancel,
-		done:   make(chan error, 1),
-		stdin:  stdin,
+		cancel:  cancel,
+		done:    make(chan error, 1),
+		stdin:   stdin,
+		channel: channel,
 	}
 	if t.hiddenAttachClients == nil {
 		t.hiddenAttachClients = make(map[string]*hiddenAttachClient)
@@ -1379,6 +1396,50 @@ func (t *Tmux) hiddenAttachClient(target string) *hiddenAttachClient {
 }
 
 func (t *Tmux) waitForHiddenAttachReady(target string, client *hiddenAttachClient) error {
+	// Fast path: already attached. Covers a re-resolved live client and an
+	// attach that completed before the hook was armed.
+	if t.IsSessionAttached(target) {
+		return nil
+	}
+	if client.channel == "" {
+		return t.pollForHiddenAttachReady(target, client)
+	}
+
+	// Block on the client-attached hook's wait-for signal: the tmux server wakes
+	// us the instant a client attaches, with no per-tick polling subprocess to
+	// contend with the attach. tmux remembers a signal that precedes the wait, so
+	// there is no signal-before-wait race. The wait-for is bounded by
+	// hiddenAttachReadyTimeout (not extended — it is the same ceiling the poll
+	// used), and IsSessionAttached is the authoritative confirmation on timeout.
+	waitErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), hiddenAttachReadyTimeout)
+		defer cancel()
+		_, err := t.runCtx(ctx, "wait-for", client.channel)
+		waitErr <- err
+	}()
+
+	select {
+	case err := <-waitErr:
+		if err == nil || t.IsSessionAttached(target) {
+			return nil
+		}
+		return fmt.Errorf("timed out waiting for hidden tmux client to attach: %w", err)
+	case err, ok := <-client.done:
+		if t.IsSessionAttached(target) {
+			return nil
+		}
+		if ok && err != nil {
+			return fmt.Errorf("hidden tmux client exited before attaching: %w", err)
+		}
+		return fmt.Errorf("hidden tmux client exited before attaching")
+	}
+}
+
+// pollForHiddenAttachReady is the fallback used when the client-attached hook
+// could not be armed: poll IsSessionAttached until the client attaches, the
+// client exits, or the deadline elapses.
+func (t *Tmux) pollForHiddenAttachReady(target string, client *hiddenAttachClient) error {
 	deadline := time.Now().Add(hiddenAttachReadyTimeout)
 	for time.Now().Before(deadline) {
 		if t.IsSessionAttached(target) {
@@ -1386,10 +1447,7 @@ func (t *Tmux) waitForHiddenAttachReady(target string, client *hiddenAttachClien
 		}
 		select {
 		case err, ok := <-client.done:
-			if !ok {
-				return fmt.Errorf("hidden tmux client exited before attaching")
-			}
-			if err != nil {
+			if ok && err != nil {
 				return fmt.Errorf("hidden tmux client exited before attaching: %w", err)
 			}
 			return fmt.Errorf("hidden tmux client exited before attaching")
@@ -1418,6 +1476,11 @@ func (t *Tmux) CloseHiddenAttachClient(target string) {
 
 	if client == nil {
 		return
+	}
+	if client.channel != "" {
+		// Remove the client-attached hook armed for this client. Best-effort: a
+		// killed session drops its hooks with it.
+		_, _ = t.run("set-hook", "-u", "-t", target, "client-attached")
 	}
 	client.cancel()
 	_ = client.stdin.Close()


### PR DESCRIPTION
Closes #3797.

## Problem

`TestHiddenAttachedClientCanSendText` (job `packages-runtime-tmux-*`) intermittently red on `main`:

```
ensureHiddenAttachedClient: timed out waiting for hidden tmux client to attach
```

`waitForHiddenAttachReady` busy-polled `IsSessionAttached` — a `tmux display-message` **subprocess every 50ms** — against a 2s readiness deadline. On a CPU-starved CI runner the per-tick poll subprocesses contend with the `script`/attach itself, so the 2s budget is occasionally insufficient. The attach is actually fast (~0.1s measured); the budget is eaten by subprocess scheduling under starvation, not a slow attach. Per the de-flake directive, the 2s constant must **not** be extended (it is also a production constant on the Gemini Ctrl-C interrupt path).

## Fix — server-pushed event instead of polling

- Arm a per-attach tmux `wait-for` channel via a `client-attached` hook **before** launching the hidden client.
- `waitForHiddenAttachReady` blocks on `tmux wait-for <channel>`: the server wakes it the instant any client attaches — no per-tick polling subprocess to contend with.
- `set-hook` happens-before the wait's fast-path `IsSessionAttached` check, so an attach that races ahead of the hook is still caught; and tmux **remembers a signal that precedes the wait** (verified on 3.4), so there is no signal-before-wait race.
- The 2s ceiling is **unchanged** — now a generous safety bound since detection is instant.
- If `set-hook` fails, the client falls back to the **legacy poll** (zero regression on that path).
- The hook is removed on `CloseHiddenAttachClient`.

## Verification

All reproduction ran in an isolated PID namespace (no host/tmux-server exposure).

- Verified the tmux mechanics empirically on 3.4: signal-before-wait is remembered (9ms), the `client-attached` hook fires `wait-for -S` on a real `script` attach, and bare `wait-for -S` is accepted in `set-hook`.
- New `TestHiddenAttachArmsAndClearsClientAttachedHook` proves the hook path actually engages (channel armed + `show-hooks` shows it) and is cleared on close — guarding against a silent regression to polling that `TestHiddenAttachedClientCanSendText` would not catch.
- Full `internal/runtime/tmux` integration package green (450 subtests, 0 regressions; the lone `TestGetProcessGroupID` failure is a PID-namespace artifact that also fails on the unmodified binary).
- `TestHidden*` pass repeatedly under 2-core CPU saturation; `go vet -tags integration` and `go build ./...` clean.

Note: the original CI flake is rare (1 observed occurrence) and did not reproduce locally even under 2-core saturation, so this is verified for correctness, the underlying tmux mechanics, and zero regression rather than by reproducing the exact CI timeout. The event-based path is strictly more robust under starvation than the poll it replaces (no per-tick subprocess contention; server-pushed signal). Follow-up to #3796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)