### PR TITLE
perf(test): fast patrol interval for E2E cities — cut the two slowest integration tests ~50%

### DIFF
--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -149,11 +149,22 @@ func normalizeE2EPath(t *testing.T, path string) string {
 	return resolved
 }
 
+// e2eDaemonSection sets a fast patrol interval for E2E cities. The default is
+// 30s (config.go), so every test that waits on a reconcile-driven state change
+// — drain/undrain, nudge, restart, config-drift restart — otherwise pays up to
+// a full 30s patrol cadence per wait. CI gains nothing from the production
+// cadence; reconcile logic is identical at 1s, so this trims wall-clock without
+// changing what is exercised. (Deferral floors such as the named-session
+// config-drift recent-activity window still apply — this only removes the extra
+// patrol-cadence latency on top of them.)
+const e2eDaemonSection = "\n[daemon]\npatrol_interval = \"1s\"\n"
+
 // renderE2EToml generates a full single-file template for gc init --file.
 func renderE2EToml(city e2eCity) string {
 	var b strings.Builder
 	writeE2EWorkspaceSection(&b, city.Workspace)
 	b.WriteString("\n[beads]\nprovider = \"file\"\n")
+	b.WriteString(e2eDaemonSection)
 	writeE2EProviderSections(&b, city.Providers)
 	writeE2EAgentSections(&b, city.Agents)
 	writeE2ENamedSessionSections(&b, city.Agents)
@@ -164,6 +175,7 @@ func renderE2ECityRuntimeToml(city e2eCity) string {
 	var b strings.Builder
 	writeE2EWorkspaceSection(&b, city.Workspace)
 	b.WriteString("\n[beads]\nprovider = \"file\"\n")
+	b.WriteString(e2eDaemonSection)
 	return b.String()
 }
 


### PR DESCRIPTION
## What

A test-only change: set `[daemon] patrol_interval = "1s"` in the E2E integration city config (it was unset, defaulting to **30s**).

## Why

Auditing per-test timings of the integration suite (the `rest-full-*-of-16` shards dominate CI wall-clock), the two slowest tests were both gated on the controller's patrol cadence, not on real work:

| Test | Before | After (isolated) | After (full-suite, contended) |
|---|---|---|---|
| `TestE2E_ConfigDrift` | 68.4s | **13.5s** | ~40s |
| `TestE2E_SuspendResume_City` | 68.5s | — | ~46s |

Each waits for the controller to apply a drift/suspend restart on its **next patrol** — at the default 30s cadence that adds up to ~30s of pure waiting per restart. The reconcile logic is identical at a 1s cadence; only the cadence-induced latency on top of the real work shrinks, so **coverage is unchanged**.

This mirrors the established pattern in the gastown integration suite, which already runs at `patrol_interval = "100ms"` (`gastown_helpers_test.go` etc.); 1s is the more conservative choice. Set in both `renderE2EToml` and the config-rewrite `renderE2ECityRuntimeToml` so it survives the reload in `TestE2E_ConfigDrift`.

## Verification

All reproduction/measurement ran in an isolated PID namespace.

- **All 53 `TestE2E_*` tests pass** with the fast patrol — zero breakage (including the suspended-agent "should not restart" negative-assertion tests, which are correctness invariants, not patrol-timing dependent).
- The patrol-sensitive tests (`ConfigDrift`, `SuspendResume_City`, `SuspendResume_Agent`) pass **3×** with no flakiness — a faster patrol does not destabilize them because the reconciler is idempotent by design (the redundant-observer convergence model).
- `go vet -tags integration`, `gofmt`, and `golangci-lint` clean.

Note: the other heavy integration tests (`TestGastown_*` at 19–37s, `TestHumaBinary_*` at ~25s, the rest of the `TestE2E_*` at 8–22s) are dominated by genuine full-stack startup / pipeline work — not patrol cadence — so they are out of scope here. The gastown suite already uses a fast patrol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)