### PR TITLE
chore(codeowners): scope csells docs ownership to content folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,5 +17,13 @@
 /cmd/gc/dashboard/web/package.json @gastownhall/gascity-admin
 /cmd/gc/dashboard/web/package-lock.json @gastownhall/gascity-admin
 
-# All docs/ is owned by csells (auto-requests review on any docs-touching PR).
-/docs/ @csells
+# Specific docs/ content folders are owned by csells (auto-requests review on
+# matching PRs). Intentionally scoped to authored-content areas, excluding
+# /docs/reference and top-level docs files.
+/docs/diagrams/ @csells
+/docs/getting-started/ @csells
+/docs/guides/ @csells
+/docs/images/ @csells
+/docs/runbooks/ @csells
+/docs/troubleshooting/ @csells
+/docs/tutorials/ @csells


### PR DESCRIPTION
## What

Replaces the broad `/docs/ @csells` CODEOWNERS rule with rules for the specific authored-content folders:

- `/docs/diagrams/`
- `/docs/getting-started/`
- `/docs/guides/`
- `/docs/images/`
- `/docs/runbooks/`
- `/docs/troubleshooting/`
- `/docs/tutorials/`

## Why

The single `/docs/ @csells` rule auto-requested csells's review on **every** docs-touching PR, including `/docs/reference` and top-level docs files (`README.md`, `custom.css`, `docs.json`, `index.mdx`). Scoping ownership to the authored-content folders stops csells from being added as a reviewer on PRs that only touch `/docs/reference` or the top-level docs files.

## Effect

| Path | Before | After |
| --- | --- | --- |
| `/docs/{diagrams,getting-started,guides,images,runbooks,troubleshooting,tutorials}/` | @csells | @csells |
| `/docs/reference/` | @csells | (unowned) |
| top-level `docs/` files | @csells | (unowned) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)