### PR TITLE
restore(controller-image): Dockerfile.controller-crucible + entrypoint (eia-helper COPY)

### DIFF
--- a/contrib/k8s/Dockerfile.controller-crucible
+++ b/contrib/k8s/Dockerfile.controller-crucible
@@ -1,0 +1,44 @@
+# Gas City controller image for the Crucible-sandbox launch model (B6).
+#
+# The autonomous city-provisioner launches this as a Crucible gVisor sandbox with the city's env
+# (GC_CITY_NAME / GC_PACK / GC_DOLT_HOST / GC_DOLT_DATABASE / GC_WORKSPACE_ID). It extends the agent
+# image (gc + bd + dolt baked in) with an ENV-DRIVEN entrypoint that inits the city from its pack,
+# wires bd to the HOSTED beads ledger (never embedded dolt), and starts the controller in-foreground.
+#
+# Unlike Dockerfile.controller (the K8s copy-in model), there is no /city volume copy and no kubectl:
+# child agents are spawned via the Crucible API (Model B), not kubectl.
+#
+# Build (agent image first):
+#   go build -o gc ./cmd/gc && cp "$(which bd)" .
+#   docker build -f contrib/k8s/Dockerfile.base   -t gc-agent-base:latest .
+#   docker build -f contrib/k8s/Dockerfile.agent  -t gc-agent:latest .
+#   docker build -f contrib/k8s/Dockerfile.controller-crucible -t crucible-city-provisioner-controller:latest .
+
+ARG BASE=gc-agent:latest
+FROM ${BASE}
+
+USER root
+
+# Env-driven controller entrypoint.
+COPY contrib/k8s/gc-controller-crucible-entrypoint.sh /usr/local/bin/gc-controller-entrypoint
+RUN chmod 0755 /usr/local/bin/gc-controller-entrypoint
+
+# CREDENTIAL BOOTSTRAP (B6): the eia-helper re-mints a fresh ~90s aud=beads EIA (EIA-as-username) from
+# the controller's orchestrator key on each connect, so bd holds no long-lived ledger credential. It
+# is built from the crucible repo's cmd/eia-helper (reuses the red-teamed STSExchanger); place the
+# binary in the build context like bd/gc:
+#   (in the crucible repo) go build -o eia-helper ./cmd/eia-helper  &&  cp eia-helper <gascity build ctx>/contrib/k8s/eia-helper
+COPY contrib/k8s/eia-helper /usr/local/bin/eia-helper
+RUN chmod 0755 /usr/local/bin/eia-helper
+# bd runs this as its dolt credential command; the helper reads STS_MACHINE_URL/STS_TOKEN_URL +
+# ORCHESTRATOR_KEY_FILE + EIA_AUDIENCE/EIA_SCOPES from the env the entrypoint exports.
+ENV GC_DOLT_CRED_CMD=/usr/local/bin/eia-helper \
+    EIA_AUDIENCE=beads \
+    EIA_SCOPES="beads:read beads:write"
+# REMAINING (live, see B6 spec): mount the orchestrator key at ORCHESTRATOR_KEY_FILE (OpenBao/runtime)
+# and confirm bd's dolt credential-command contract consumes the helper's stdout as the gateway user.
+
+WORKDIR /city
+USER gcagent
+
+ENTRYPOINT ["/usr/local/bin/gc-controller-entrypoint"]

--- a/contrib/k8s/gc-controller-crucible-entrypoint.sh
+++ b/contrib/k8s/gc-controller-crucible-entrypoint.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Entrypoint for the Model-B controller launched as a Crucible gVisor sandbox by the autonomous
+# city-provisioner (B6). Unlike the K8s copy-in controller (Dockerfile.controller), this is ENV-DRIVEN
+# and wires the city to its HOSTED beads ledger (never embedded dolt):
+#
+#   GC_CITY_NAME    the city / workspace name (slug)
+#   GC_PACK         the starting pack: gascity | gastown | minimal | custom  (gc init --template)
+#   GC_DOLT_HOST    the hosted beads dolt gateway host:port (one gateway serves all projects)
+#   GC_DOLT_DATABASE the city's project database on that gateway (bd_prj_<id>)
+#   GC_WORKSPACE_ID  optional pre-created workspace id
+#
+# CREDENTIAL BOOTSTRAP (the one piece that needs the live stack — see B6 spec): bd authenticates to
+# the hosted gateway with a short-lived beads EIA as the dolt username (EIA-as-username). The
+# controller mints it from its orchestrator SP key (delivered to the sandbox out of band, OpenBao/
+# runtime) via STS. Because the EIA is ~90s, bd must RE-MINT on connect — wired here as a dolt
+# credential command (the eia-helper). Until the eia-helper is installed + the orchestrator key is
+# mounted, set GC_DOLT_CRED_CMD to that helper; this script fails closed if neither a credential
+# command nor a static GC_DOLT_USER is present.
+set -euo pipefail
+
+CITY_DIR="${CITY_DIR:-/city}"
+
+require() { # name
+  if [ -z "${!1:-}" ]; then
+    echo "city-controller: missing required env $1" >&2
+    exit 2
+  fi
+}
+require GC_CITY_NAME
+require GC_DOLT_HOST
+require GC_DOLT_DATABASE
+PACK="${GC_PACK:-gascity}"
+
+# 1. Initialize the city non-interactively from the chosen pack (idempotent: a persistent volume
+#    survives restarts, so skip if already initialized).
+if [ ! -d "${CITY_DIR}/.gc" ]; then
+  gc init --template "${PACK}" --name "${GC_CITY_NAME}" "${CITY_DIR}"
+fi
+
+# 2. Point beads at the HOSTED dolt gateway. The canonical source gc resolves the connection from is
+#    .beads/metadata.json (backend=dolt, dolt_mode=server, dolt_database); host/port come from the
+#    GC_DOLT_* env (dolt_host in metadata is deprecated). Written after init so it overrides any
+#    embedded-dolt default the pack would otherwise use.
+mkdir -p "${CITY_DIR}/.beads"
+cat > "${CITY_DIR}/.beads/metadata.json" <<JSON
+{
+  "database": "${GC_CITY_NAME}",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "${GC_DOLT_DATABASE}"
+}
+JSON
+
+# Split GC_DOLT_HOST (host:port) into the host + port env gc projects onto bd.
+RAW_HOST="${GC_DOLT_HOST}"
+export GC_DOLT_HOST="${RAW_HOST%%:*}"
+case "${RAW_HOST}" in
+  *:*) export GC_DOLT_PORT="${RAW_HOST##*:}" ;;
+  *)   export GC_DOLT_PORT="${GC_DOLT_PORT:-3306}" ;;
+esac
+export GC_BEADS_BACKEND="dolt"
+export BEADS_BACKEND="dolt"
+
+# 3. Credential: a re-minting dolt credential command (EIA-as-username) OR a static user. Fail closed.
+if [ -n "${GC_DOLT_CRED_CMD:-}" ]; then
+  export BEADS_DOLT_CREDENTIAL_COMMAND="${GC_DOLT_CRED_CMD}"
+elif [ -n "${GC_DOLT_USER:-}" ]; then
+  : # static credential already in env (dev / short-lived test)
+else
+  echo "city-controller: no beads credential — set GC_DOLT_CRED_CMD (eia-helper) or GC_DOLT_USER" >&2
+  exit 3
+fi
+
+# 4. Run the controller in the foreground (PID 1 of the sandbox).
+exec gc start --foreground "${CITY_DIR}"


### PR DESCRIPTION
Restores `contrib/k8s/Dockerfile.controller-crucible` (+ `gc-controller-crucible-entrypoint.sh`) from dangling commit `b6f5885` so crucible's `controller-image.yml` has a checkoutable ref to build against.

**Why:** the controller image (`ghcr.io/gascity/gascity-controller`) pins this Dockerfile, whose `COPY contrib/k8s/eia-helper /usr/local/bin/eia-helper` ships the in-image `eia-helper relay` bridge (crucible #40) the city-config read proxy needs. The file survived only at a dangling sha — `main` 404s it and `builder/ga-b6y1.1-1` renamed it to `Dockerfile.controller` and dropped the eia-helper COPY, so `actions/checkout` (can't fetch a bare sha) fails the workflow's `gascity_ref` pin.

After this lands, re-dispatch `controller-image.yml` with `gascity_ref=<this branch>` to rebuild with the current (#40) eia-helper; the smoke test confirms relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)