### PR TITLE
fix(dispatch): decorate non-pool graph.v2 molecules so the control-dispatcher wakes

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -805,7 +805,25 @@ conflicting live workflow from the same source is an error.`,
 			printGraphV2Deprecations(stderr, inv.Deprecations)
 			cookVars = inv.Vars
 
-			result, err := molecule.Cook(cmd.Context(), store, args[0], scope.searchPaths, molecule.Options{
+			recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), args[0], scope.searchPaths, cookVars)
+			if err != nil {
+				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+			}
+			if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Title: title, Vars: cookVars}); err != nil {
+				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+			}
+			// sr-2cx: decorate graph.v2 recipes before instantiation so the control
+			// beads route to the control-dispatcher (which gives the reconciler the
+			// demand to wake it). molecule.Cook does compile+Instantiate with no
+			// decoration step, which left standalone-cooked graph.v2 molecules (e.g.
+			// the intake-poller's ticket-lifecycle) undecorated and undriveable.
+			if graphroute.IsCompiledGraphWorkflow(recipe) {
+				storeRef := workflowStoreRefForDir(scope.storeRoot, cityPath, loadedCityName(cfg, cityPath), cfg)
+				if err := decorateFormulaCookGraphV2Recipe(recipe, cookVars, storeRef, store, loadedCityName(cfg, cityPath), cityPath, cfg); err != nil {
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, fmt.Errorf("decorate formulas v2 recipe: %w", err))
+				}
+			}
+			result, err := molecule.Instantiate(cmd.Context(), store, recipe, molecule.Options{
 				Title: title,
 				Vars:  cookVars,
 			})
@@ -823,6 +841,12 @@ conflicting live workflow from the same source is an error.`,
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
 			}
+
+			// sr-2cx: nudge the control-dispatcher to pick up the freshly-cooked
+			// molecule promptly (it also wakes from reconciler demand on the routed
+			// control bead; this just avoids waiting for the next tick), matching
+			// the attach-cook path.
+			_ = pokeControlDispatch(cityPath)
 
 			if jsonOutput {
 				return writeCLIJSONLineOrErr(stdout, stderr, "gc formula cook", formulaCookJSONResult{

--- a/cmd/gc/cmd_formula_sr2cx_test.go
+++ b/cmd/gc/cmd_formula_sr2cx_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/graphroute"
+)
+
+// TestFormulaCookStandaloneGraphV2RoutesControlBeadToDispatcher is the red->green
+// test for the standalone `gc formula cook` half of sr-2cx. A standalone cook
+// (no --attach) is exactly what the intake-poller runs to create the
+// ticket-lifecycle molecule. molecule.Cook does compile+Instantiate with NO
+// routing decoration, so the cooked molecule was UNDECORATED: its control bead
+// (workflow-finalize) was not routed to the control-dispatcher, so the
+// dispatcher never got demand, never woke, and the molecule never drove.
+//
+// The fix inlines compile->decorate->Instantiate in the standalone cook path.
+// Assertions are on the MATERIALIZED (stored) beads, since instantiation
+// defers-and-restores gc.routed_to.
+func TestFormulaCookStandaloneGraphV2RoutesControlBeadToDispatcher(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BOOTSTRAP", "skip")
+	t.Cleanup(func() {
+		applyFeatureFlags(&config.City{Daemon: config.DaemonConfig{FormulaV2: boolPtr(true)}})
+	})
+
+	cityDir := t.TempDir()
+	formulaDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[daemon]
+formula_v2 = true
+
+[[agent]]
+name = "worker"
+max_active_sessions = 1
+
+[[agent]]
+name = "control-dispatcher"
+start_command = "gc convoy control --serve --follow {{.Agent}}"
+prompt_mode = "none"
+process_names = ["gc"]
+max_active_sessions = 1
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	graphFormula := `
+formula  = "graph-cook-nopool"
+version  = 2
+contract = "graph.v2"
+
+[[steps]]
+id    = "poll"
+title = "Poll step"
+metadata = { "gc.run_target" = "worker" }
+`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-cook-nopool.toml"), []byte(graphFormula), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityDir, "formula", "cook", "graph-cook-nopool"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc formula cook = %d, want 0; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+	}
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	items, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true, TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatalf("store.List(): %v", err)
+	}
+
+	var sawRoot, sawControl, sawWorker bool
+	for _, b := range items {
+		kind := b.Metadata["gc.kind"]
+		routedTo := b.Metadata["gc.routed_to"]
+		switch {
+		case kind == "workflow":
+			sawRoot = true
+			if routedTo != "" {
+				t.Errorf("standalone-cook root %s gc.routed_to = %q, want empty (unrouted container)", b.ID, routedTo)
+			}
+		case graphroute.IsControlDispatcherKind(kind):
+			sawControl = true
+			if routedTo != config.ControlDispatcherAgentName {
+				t.Errorf("standalone-cook control bead %s (kind=%s) gc.routed_to = %q, want %q (sr-2cx: dispatcher never wakes without this)",
+					b.ID, kind, routedTo, config.ControlDispatcherAgentName)
+			}
+		case b.Metadata["gc.run_target"] != "":
+			sawWorker = true
+			if routedTo != "worker" {
+				t.Errorf("standalone-cook worker step %s gc.routed_to = %q, want %q (run_target fallback under empty default route)",
+					b.ID, routedTo, "worker")
+			}
+		}
+	}
+	if !sawRoot {
+		t.Error("no workflow root bead found")
+	}
+	if !sawControl {
+		t.Fatal("no control-dispatcher bead found in the cooked molecule")
+	}
+	if !sawWorker {
+		t.Fatal("no worker step found in the cooked molecule")
+	}
+}

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -706,9 +706,20 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 		}
 	}
 
+	// Decorate graph workflow recipes before instantiation so child step beads —
+	// and, critically, the control beads that drive the molecule — get
+	// gc.routed_to. This must run for EVERY graph.v2 molecule, not just pool
+	// orders: a non-pool order (whose formula routes steps via gc.run_target and
+	// whose order only supplies the trigger) still needs its control beads routed
+	// to the control-dispatcher, or the dispatcher never gets demand, never wakes,
+	// and the molecule never drives (sr-2cx). Mirrors dispatchWisp.
 	if a.Pool != "" && cfg != nil {
 		if err := applyGraphRouting(recipe, nil, pool, nil, "", "", "", store, cityName, cityPath, cfg); err != nil {
 			fmt.Fprintf(stderr, "gc order run: routing decoration failed: %v\n", err) //nolint:errcheck // best-effort stderr
+		}
+	} else if cfg != nil {
+		if err := decorateGraphWorkflowDefaultRoute(recipe, store, cityName, cityPath, cfg); err != nil {
+			fmt.Fprintf(stderr, "gc order run: graph routing decoration failed: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
 	}
 

--- a/cmd/gc/cmd_order_sr2cx_test.go
+++ b/cmd/gc/cmd_order_sr2cx_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/graphroute"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// TestOrderRunNonPoolGraphV2RoutesControlBeadToDispatcher is the red->green test
+// for the `gc order run` half of sr-2cx. This is the SAME entry point as the
+// manual live action (doOrderRunWithJSON) — distinct from the controller's
+// dispatchWisp path — so it catches the regression dispatchWisp's test would miss.
+//
+// doOrderRunWithJSON gated routing decoration behind `a.Pool != ""`, so a non-pool
+// order instantiated an UNDECORATED molecule: no control bead routed to the
+// control-dispatcher -> the dispatcher never woke -> the molecule never drove.
+//
+// Assertions are on the MATERIALIZED beads (through Instantiate's defer/restore).
+func TestOrderRunNonPoolGraphV2RoutesControlBeadToDispatcher(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BOOTSTRAP", "skip")
+	t.Cleanup(func() {
+		applyFeatureFlags(&config.City{Daemon: config.DaemonConfig{FormulaV2: boolPtr(true)}})
+	})
+
+	cityDir := t.TempDir()
+	formulaDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[daemon]
+formula_v2 = true
+
+[[agent]]
+name = "worker"
+max_active_sessions = 1
+
+[[agent]]
+name = "control-dispatcher"
+start_command = "gc convoy control --serve --follow {{.Agent}}"
+prompt_mode = "none"
+process_names = ["gc"]
+max_active_sessions = 1
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	graphFormula := `
+formula  = "test-cli-intake"
+version  = 2
+contract = "graph.v2"
+
+[[steps]]
+id    = "poll"
+title = "Poll step"
+metadata = { "gc.run_target" = "worker" }
+`
+	if err := os.WriteFile(filepath.Join(formulaDir, "test-cli-intake.toml"), []byte(graphFormula), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No Pool: routing comes from the step's gc.run_target; the order only triggers.
+	aa := []orders.Order{{Name: "test-cli-intake", Formula: "test-cli-intake", FormulaLayer: formulaDir}}
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRunWithJSON(aa, "test-cli-intake", "", cityDir, store, nil, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRunWithJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	items, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true, TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatalf("store.List(): %v", err)
+	}
+
+	var sawRoot, sawControl, sawWorker bool
+	for _, b := range items {
+		kind := b.Metadata["gc.kind"]
+		routedTo := b.Metadata["gc.routed_to"]
+		switch {
+		case kind == "workflow":
+			sawRoot = true
+			if routedTo != "" {
+				t.Errorf("gc order run root %s gc.routed_to = %q, want empty (unrouted container)", b.ID, routedTo)
+			}
+		case graphroute.IsControlDispatcherKind(kind):
+			sawControl = true
+			if routedTo != config.ControlDispatcherAgentName {
+				t.Errorf("gc order run control bead %s (kind=%s) gc.routed_to = %q, want %q (sr-2cx: dispatcher never wakes without this)",
+					b.ID, kind, routedTo, config.ControlDispatcherAgentName)
+			}
+		case b.Metadata["gc.run_target"] != "":
+			sawWorker = true
+			if routedTo != "worker" {
+				t.Errorf("gc order run worker step %s gc.routed_to = %q, want %q (run_target fallback under empty default route)",
+					b.ID, routedTo, "worker")
+			}
+		}
+	}
+	if !sawRoot {
+		t.Error("no workflow root bead found")
+	}
+	if !sawControl {
+		t.Fatal("no control-dispatcher bead found in the molecule")
+	}
+	if !sawWorker {
+		t.Fatal("no worker step found in the molecule")
+	}
+}

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -75,6 +75,21 @@ func applyGraphRouting(recipe *formula.Recipe, a *config.Agent, routedTo string,
 	return graphroute.ApplyGraphRouting(recipe, a, routedTo, vars, "", scopeKind, scopeRef, storeRef, store, cityName, cfg, cliGraphrouteDeps(cityPath))
 }
 
+// decorateGraphWorkflowDefaultRoute decorates a compiled graph.v2 recipe with an
+// empty default route, for order/cook dispatch that supplies no pool. The root
+// stays an unrouted container, worker steps fall back to their own gc.run_target
+// binding, and the control beads (workflow-finalize, etc.) route to the
+// control-dispatcher. Routing the control beads is what gives the reconciler the
+// demand to wake the dispatcher; without it a non-pool graph.v2 molecule
+// instantiates undecorated and never drives (sr-2cx). No-ops for non-graph
+// recipes, preserving the legacy non-pool behavior.
+func decorateGraphWorkflowDefaultRoute(recipe *formula.Recipe, store beads.Store, cityName, cityPath string, cfg *config.City) error {
+	if !graphroute.IsCompiledGraphWorkflow(recipe) {
+		return nil
+	}
+	return graphroute.DecorateGraphWorkflowRecipe(recipe, graphroute.GraphWorkflowRouteVars(recipe, nil), "", "", "", "", "", "", store, cityName, cfg, cliGraphrouteDeps(cityPath))
+}
+
 var (
 	workflowServeList               = nextWorkflowServeBeads
 	controlDispatcherServe          = runControlDispatcherInStore

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1426,13 +1426,25 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		}
 	}
 
-	// Decorate graph workflow recipes with routing metadata so child step
-	// beads get gc.routed_to set before instantiation.
+	// Decorate graph workflow recipes with routing metadata BEFORE instantiation
+	// so child step beads — and, critically, the control beads that drive the
+	// molecule — get gc.routed_to set. This must run for EVERY graph.v2 molecule,
+	// not just pool orders: a non-pool order whose steps route via gc.run_target
+	// (the order "only supplies the trigger") still needs its control beads
+	// (workflow-finalize, etc.) routed to the control-dispatcher, or the
+	// dispatcher never gets demand, never wakes, and the molecule never drives
+	// (sr-2cx). Pool orders route the root + workers to the pool; non-pool orders
+	// decorate with an empty default route (root stays an unrouted container,
+	// workers fall back to their run_target binding, control beads -> dispatcher).
 	if a.Pool != "" {
 		if err := applyGraphRouting(recipe, nil, pool, nil, "", "", "", store, m.cityName, cityPath, m.cfg); err != nil {
 			logDispatchError(m.stderr, "gc: order %s: routing decoration failed: %v", scoped, err)
 			// Non-fatal — molecule still works, just without step-level routing.
 		}
+	} else if err := decorateGraphWorkflowDefaultRoute(recipe, store, m.cityName, cityPath, m.cfg); err != nil {
+		logDispatchError(m.stderr, "gc: order %s: graph routing decoration failed: %v", scoped, err)
+		// Non-fatal — molecule still instantiates; the control-dispatcher may not
+		// wake until a later re-route.
 	}
 
 	cookResult, err := molecule.Instantiate(ctx, store, recipe, molecule.Options{})

--- a/cmd/gc/order_dispatch_sr2cx_test.go
+++ b/cmd/gc/order_dispatch_sr2cx_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/graphroute"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// TestOrderDispatchNonPoolGraphV2DecoratesAndRoutesControlBead is the red->green
+// test for sr-2cx. A graph.v2 order with NO pool must still have its molecule
+// decorated at instantiation so the control bead (workflow-finalize) is routed
+// to the control-dispatcher — which is what gives the reconciler demand to wake
+// it — and worker steps are routed via their own gc.run_target.
+//
+// Before the fix, dispatchWisp gated routing decoration behind `a.Pool != ""`,
+// so a non-pool order (one whose formula routes its steps via gc.run_target and
+// whose order "only supplies the trigger", e.g. ticket-intake) instantiated an
+// UNDECORATED molecule: no bead routed to the control-dispatcher -> zero
+// reconciler demand -> the dispatcher never woke -> the molecule never drove.
+//
+// The assertions are deliberately on the MATERIALIZED (stored) beads, not the
+// recipe: molecule instantiation defers-and-restores gc.routed_to, so a
+// recipe-level assertion would bypass that mechanism and could pass while the
+// stored beads stayed unrouted.
+func TestOrderDispatchNonPoolGraphV2DecoratesAndRoutesControlBead(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeFile(t, filepath.Join(formulaDir, "test-intake-nopool.toml"), `
+formula  = "test-intake-nopool"
+version  = 2
+contract = "graph.v2"
+
+[[steps]]
+id    = "poll"
+title = "Poll step"
+description = "A single worker step routed via its gc.run_target (the order supplies no pool)."
+metadata = { "gc.run_target" = "worker" }
+`)
+
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Daemon:    config.DaemonConfig{FormulaV2: boolPtr(true)},
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "worker", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	addTestControlDispatcherAgents(cfg, "")
+	applyFeatureFlags(cfg)
+	t.Cleanup(func() { applyFeatureFlags(&config.City{}) })
+
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:         "test-intake-nopool",
+			Trigger:      "cooldown",
+			Interval:     "5m",
+			Formula:      "test-intake-nopool",
+			FormulaLayer: formulaDir,
+			// No Pool on purpose: routing comes from each step's gc.run_target.
+		}},
+		storeFn: func(_ execStoreTarget) (beads.Store, error) { return store, nil },
+		execRun: shellExecRunner,
+		rec:     events.Discard,
+		stderr:  &bytes.Buffer{},
+		cfg:     cfg,
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	m.drain(context.Background())
+
+	root := workBeadByOrderLabel(t, store, "order-run:test-intake-nopool")
+	if got := root.Metadata["gc.routed_to"]; got != "" {
+		t.Errorf("non-pool workflow root gc.routed_to = %q, want empty (a non-pool root is an unrouted container)", got)
+	}
+
+	children, err := store.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.root_bead_id": root.ID},
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+	})
+	if err != nil {
+		t.Fatalf("List(molecule children): %v", err)
+	}
+
+	var sawControl, sawWorker bool
+	for _, b := range children {
+		kind := b.Metadata["gc.kind"]
+		routedTo := b.Metadata["gc.routed_to"]
+		switch {
+		case graphroute.IsControlDispatcherKind(kind):
+			// The fix: control beads must reach the dispatcher so it gets demand.
+			sawControl = true
+			if routedTo != config.ControlDispatcherAgentName {
+				t.Errorf("control bead %s (kind=%s) gc.routed_to = %q, want %q (sr-2cx: dispatcher never wakes without this)",
+					b.ID, kind, routedTo, config.ControlDispatcherAgentName)
+			}
+			if b.Assignee != "" {
+				t.Errorf("control bead %s assignee = %q, want empty routed control-dispatcher queue", b.ID, b.Assignee)
+			}
+		case b.Metadata["gc.run_target"] != "":
+			// The inferred-but-untested path: under an empty default route, a
+			// worker step must fall back to its own run_target binding.
+			sawWorker = true
+			if routedTo != "worker" {
+				t.Errorf("worker step %s gc.routed_to = %q, want %q (run_target fallback under empty default route)",
+					b.ID, routedTo, "worker")
+			}
+		}
+	}
+	if !sawControl {
+		t.Fatal("no control-dispatcher bead found in the molecule")
+	}
+	if !sawWorker {
+		t.Fatal("no worker step found in the molecule")
+	}
+}


### PR DESCRIPTION
## Problem

A graph.v2 order with **no `pool`** — one whose formula routes its steps via `gc.run_target` and whose order only supplies the trigger — instantiates an **undecorated** molecule. The same is true of a standalone `gc formula cook` (no `--attach`).

`dispatchWisp` (`cmd/gc/order_dispatch.go`) gated the graph-routing decoration behind `if a.Pool != ""`, and the standalone-cook path called `molecule.Cook` (compile + `Instantiate`, with no decoration step). With no decoration:

- no `gc.routed_to` is stamped on any step, and
- critically, **no control bead** (`workflow-finalize`, etc.) is routed to the control-dispatcher.

Because nothing is routed to it, `openControlDispatcherDemand` returns empty, the reconciler computes zero demand for the control-dispatcher, and it **never wakes** — so the molecule is never driven (steps never get `run_target` → `routed_to`, no work-nudges are generated). Pool orders were unaffected because their `a.Pool != ""` path already decorated.

## Fix

Decorate graph.v2 recipes regardless of `a.Pool`:

- **Order dispatch** (`dispatchWisp`): pool orders keep routing the root + workers to the pool; non-pool orders now decorate with an **empty default route** (`decorateGraphWorkflowDefaultRoute`) — the root stays an unrouted container, worker steps fall back to their `run_target` binding, and control beads route to the control-dispatcher.
- **Standalone `gc formula cook`**: inline `compile → ValidateRecipeRuntimeVars → decorate (graph.v2 only) → Instantiate` in place of `molecule.Cook`, and poke the dispatcher afterward (matching the attach-cook path). Legacy non-graph cooks are unchanged (gated on `IsCompiledGraphWorkflow`).

## Tests

Two red→green tests, both asserting on the **materialized** beads (through `Instantiate`, which defers-and-restores `gc.routed_to` — a recipe-level assertion would bypass that mechanism):

- a non-pool graph.v2 **order** routes its `workflow-finalize` bead to the control-dispatcher, its worker step to `run_target`, and leaves the root unrouted;
- a standalone graph.v2 **cook** does the same.

`cmd/gc` full suite green.

---

No existing upstream issue — discovered via downstream integration testing of a non-pool intake order whose molecule never drove. Happy to file one if that's preferred for the linkage check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
