### PR TITLE
fix(hooks): dedupe managed Codex SessionStart hooks

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -647,6 +647,9 @@ func upgradeCodexHooks(existing, desired []byte) ([]byte, bool, error) {
 	hasManagedCommand := codexHookValueHasManagedCommand(root)
 	needsPreCompact := codexHookDocCanAddPreCompact(root)
 	changed := upgradeCodexHookValue(root)
+	if desiredCodexPreCompactHook(desired) != nil && normalizeCodexManagedHookEntries(root) {
+		changed = true
+	}
 	if addCodexPreCompactHook(root, desired) {
 		changed = true
 	}
@@ -667,6 +670,9 @@ func normalizeCodexHookCommands(existing []byte) ([]byte, bool, error) {
 	}
 	hasManagedCommand := codexHookValueHasManagedCommand(root)
 	changed := upgradeCodexHookValue(root)
+	if normalizeCodexManagedHookEntries(root) {
+		changed = true
+	}
 	data, err := overlay.MarshalCanonicalJSON(root)
 	if err != nil {
 		return nil, false, err
@@ -743,6 +749,82 @@ func upgradeCodexHookValue(v any) bool {
 	}
 }
 
+func normalizeCodexManagedHookEntries(root any) bool {
+	doc, ok := root.(map[string]any)
+	if !ok {
+		return false
+	}
+	hooksMap, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	changed := false
+	for event, entriesValue := range hooksMap {
+		entries, ok := entriesValue.([]any)
+		if !ok {
+			continue
+		}
+		normalized := entries[:0]
+		seenManaged := map[string]bool{}
+		for _, entry := range entries {
+			if event == "SessionStart" {
+				if normalizeCodexManagedSessionStartEntry(entry) {
+					changed = true
+				}
+			}
+			if codexHookValueHasManagedCommand(entry) {
+				keyData, err := overlay.MarshalCanonicalJSON(entry)
+				if err == nil {
+					key := string(keyData)
+					if seenManaged[key] {
+						changed = true
+						continue
+					}
+					seenManaged[key] = true
+				}
+			}
+			normalized = append(normalized, entry)
+		}
+		if len(normalized) != len(entries) {
+			hooksMap[event] = normalized
+		}
+	}
+	return changed
+}
+
+func normalizeCodexManagedSessionStartEntry(entry any) bool {
+	entryMap, ok := entry.(map[string]any)
+	if !ok || !codexHookEntryHasCommandBody(entryMap, sessionStartCurrentFormBody) {
+		return false
+	}
+	if matcher, ok := entryMap["matcher"].(string); !ok || matcher != "startup" {
+		entryMap["matcher"] = "startup"
+		return true
+	}
+	return false
+}
+
+func codexHookEntryHasCommandBody(entry map[string]any, body string) bool {
+	hooksValue, ok := entry["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, hookValue := range hooksValue {
+		hookMap, ok := hookValue.(map[string]any)
+		if !ok {
+			continue
+		}
+		command, ok := hookMap["command"].(string)
+		if !ok {
+			continue
+		}
+		if commandBodyAfterCanonicalPrefix(command) == body {
+			return true
+		}
+	}
+	return false
+}
+
 var codexManagedHookCommandNeedles = []string{
 	`gc prime --hook`,
 	`gc nudge drain --inject`,
@@ -767,6 +849,11 @@ func upgradeCodexHookCommand(command string) (string, bool) {
 		equalsLegacyCommandBody(body, `GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`) ||
 		equalsLegacyCommandBody(body, `GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex`) ||
 		equalsLegacyCommandBody(body, sessionStartPreviousManagedFormBody) {
+		prefix := strings.TrimSuffix(command, body)
+		return prefix + sessionStartCurrentFormBody, true
+	}
+	if equalsLegacyCommandBody(body, managedPromptHookRunPrefix+`prime --hook`) ||
+		equalsLegacyCommandBody(body, managedPromptHookRunPrefix+`prime --hook --hook-format codex`) {
 		prefix := strings.TrimSuffix(command, body)
 		return prefix + sessionStartCurrentFormBody, true
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -377,6 +377,62 @@ func TestInstallCodexUpgradesSessionStartMissingManagedMarker(t *testing.T) {
 	}
 }
 
+func TestInstallCodexDedupesManagedSessionStartDrift(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.codex/hooks.json"] = []byte(`{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "startup",
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex"
+      }]
+    }, {
+      "matcher": "startup",
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex"
+      }]
+    }, {
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- prime --hook --hook-format codex"
+      }]
+    }],
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format codex"
+      }, {
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format codex"
+      }]
+    }]
+  }
+}`)
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	entries := claudeHookEntries(t, fs.Files["/work/.codex/hooks.json"], "SessionStart")
+	if len(entries) != 1 {
+		t.Fatalf("SessionStart entries = %d, want 1:\n%s", len(entries), string(fs.Files["/work/.codex/hooks.json"]))
+	}
+	if entries[0].Matcher != "startup" {
+		t.Fatalf("SessionStart matcher = %q, want startup", entries[0].Matcher)
+	}
+	sessionStartCommand := codexHookCommand(t, fs.Files["/work/.codex/hooks.json"], "SessionStart")
+	if !strings.Contains(sessionStartCommand, "GC_MANAGED_SESSION_HOOK=1") {
+		t.Fatalf("SessionStart missing managed marker: %s", sessionStartCommand)
+	}
+	if strings.Contains(string(fs.Files["/work/.codex/hooks.json"]), "gc hook run --timeout 15s --timeout-exit-code 0 -- prime --hook") {
+		t.Fatalf("legacy hook-run prime SessionStart survived:\n%s", string(fs.Files["/work/.codex/hooks.json"]))
+	}
+}
+
 func TestInstallCodexUpgradesManagedFileMissingPreCompact(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/work/.codex/hooks.json"] = []byte(`{


### PR DESCRIPTION
## Summary
- normalize managed Codex SessionStart hook entries during install/upgrade
- upgrade legacy `gc hook run -- ... prime --hook` SessionStart commands to current managed form
- dedupe identical managed SessionStart hooks while preserving custom hooks and other hook events

## Tests
- `go test ./internal/hooks -count=1`

## Notes
- Local pre-push fast suite could not complete on this Nix host because packages linking `go-icu-regex` fail with missing `uregex_*_76` symbols in `cmd/gc`, examples, and internal packages. Focused hook tests pass.