### PR TITLE
fix(controller): defer pool sweep + orphan/failed-create session closes on the boot reconcile (#3288)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -600,7 +600,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		}
 
 		if cr.sessionDrains != nil {
-			cr.beadReconcileTick(ctx, result, sessionBeads, startupTrace)
+			cr.beadReconcileTick(ctx, result, sessionBeads, startupTrace, true)
 		}
 		completion = TraceCompletionCompleted
 		startupComplete = true
@@ -1245,7 +1245,7 @@ func (cr *CityRuntime) tick(
 	// Bead-driven reconciliation (requires bead store / drain tracker).
 	if cr.sessionDrains != nil {
 		phaseStart = time.Now()
-		cr.beadReconcileTick(ctx, result, sessionBeads, trace)
+		cr.beadReconcileTick(ctx, result, sessionBeads, trace, false)
 		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile_tick", phaseStart, traceDesiredStateFields(result))
 	}
 
@@ -2117,18 +2117,22 @@ func (cr *CityRuntime) stopConfigWatcher() {
 	}
 }
 
-// beadReconcileTick runs one reconciliation tick using the bead-driven
-// reconciler. It loads session beads from the store, uses the provided
-// desired state, and delegates to reconcileSessionBeads.
-func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStateResult, sessionBeads *sessionBeadSnapshot, trace *sessionReconcilerTraceCycle) {
+// beadReconcileTick runs one bead-driven reconciliation pass. bootReconcile is
+// true only for the synchronous pass on the startup path: that pass must flip
+// readiness quickly, so it skips the undesired-pool-session sweep (a heavy
+// candidate × store × status × identifier bd-read fan-out that, serialized on
+// the readiness path, can exceed the startup watchdog on a heavy-session city —
+// gastownhall/gascity#3288). The first steady-state tick performs the sweep.
+func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStateResult, sessionBeads *sessionBeadSnapshot, trace *sessionReconcilerTraceCycle, bootReconcile bool) {
 	desiredState := result.State
 	store := cr.cityBeadStore()
 	if store == nil {
 		return
 	}
 	// Session-class ops (pool-session sweep, wait-wake state, reconcile) route
-	// through the typed session store; it wraps the same underlying store value
-	// as the work store today, so behavior is unchanged.
+	// through the typed session store (gastownhall/gascity#3773); it wraps the
+	// same underlying store value as the work store today, so behavior is
+	// unchanged.
 	sessStore := cr.sessionsBeadStore()
 	recordPhase := func(site TraceSiteCode, name string, start time.Time, fields map[string]any) {
 		if trace != nil {
@@ -2209,21 +2213,35 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 			fmt.Fprintf(cr.stderr, "scaleCheck: %s = %d\n", tmpl, count) //nolint:errcheck
 		}
 	}
-	phaseStart = time.Now()
-	if sweepUndesiredPoolSessionBeads(
-		sessStore,
-		rigStores,
-		sessionBeads,
-		desiredState,
-		cr.cfg,
-		cr.sp,
-		result.snapshotQueryPartial(),
-	) > 0 {
-		var sessionQueryPartial bool
-		sessionBeads, sessionQueryPartial = cr.loadSessionBeadSnapshotWithPartial()
-		result.SessionQueryPartial = result.SessionQueryPartial || sessionQueryPartial
+	// #3288: defer the undesired-pool-session sweep on the boot tick. The sweep
+	// probes each sweepable candidate against the city store + N rig stores × 2
+	// statuses × identifiers, each a `bd` read (listWispsTier fires two
+	// subprocesses); serialized on the synchronous readiness path that fan-out
+	// can exceed the startup watchdog on a heavy-session city and hang boot.
+	// Skipping it on boot lets readiness flip without waiting on those reads; the
+	// first steady-state tick (fired moments later by the startup poke / patrol
+	// ticker) performs the identical sweep. Safe to defer: the sweep only closes
+	// not-running, unassigned ephemeral pool-session beads and fails closed on
+	// query error, so a few seconds of staleness cannot wrongly close live work.
+	if bootReconcile {
+		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.sweep_undesired_pool_sessions.deferred_on_boot", time.Now(), traceSessionSnapshotFields(sessionBeads))
+	} else {
+		phaseStart = time.Now()
+		if sweepUndesiredPoolSessionBeads(
+			sessStore,
+			rigStores,
+			sessionBeads,
+			desiredState,
+			cr.cfg,
+			cr.sp,
+			result.snapshotQueryPartial(),
+		) > 0 {
+			var sessionQueryPartial bool
+			sessionBeads, sessionQueryPartial = cr.loadSessionBeadSnapshotWithPartial()
+			result.SessionQueryPartial = result.SessionQueryPartial || sessionQueryPartial
+		}
+		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.sweep_undesired_pool_sessions", phaseStart, traceSessionSnapshotFields(sessionBeads))
 	}
-	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.sweep_undesired_pool_sessions", phaseStart, traceSessionSnapshotFields(sessionBeads))
 	open := sessionBeads.Open()
 
 	// Use cr.cityName consistently — it's the authoritative runtime name.
@@ -2256,6 +2274,20 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		"awake_assigned_work_bead_count": len(awakeAssignedWorkBeads),
 	})
 	phaseStart = time.Now()
+	reconcileStartOptions := []startExecutionOption{
+		withAsyncStartExecution(),
+		withAsyncStartFollowUp(cr.requestAsyncStartFollowUpTick),
+		withAsyncStartLimiter(cr.ensureAsyncStartLimiter()),
+		withAsyncStartTracker(&cr.asyncStarts),
+		withAsyncDrainAckStopTracker(&cr.asyncStops),
+		withMaxSessionAgeTracker(cr.mat),
+	}
+	if bootReconcile {
+		// #3288: skip the per-session orphan/failed-create session-bead closes on
+		// the boot tick so readiness does not wait on their wisp-tier work-probe
+		// fan-out; the first steady-state tick performs them.
+		reconcileStartOptions = append(reconcileStartOptions, withDeferSessionClosesOnBoot())
+	}
 	reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, cr.cityPath, open, desiredState, cfgNames, cr.cfg, cr.sp, sessStore,
 		cr.dops,
@@ -2267,12 +2299,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
 		cr.cfg.Daemon.DriftDrainTimeoutDuration(),
 		cr.stdout, cr.stderr, trace,
-		withAsyncStartExecution(),
-		withAsyncStartFollowUp(cr.requestAsyncStartFollowUpTick),
-		withAsyncStartLimiter(cr.ensureAsyncStartLimiter()),
-		withAsyncStartTracker(&cr.asyncStarts),
-		withAsyncDrainAckStopTracker(&cr.asyncStops),
-		withMaxSessionAgeTracker(cr.mat),
+		reconcileStartOptions...,
 	)
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.reconcile_sessions", phaseStart, map[string]any{
 		"open_session_count":             len(open),

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -93,6 +93,99 @@ func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 	}
 }
 
+// wispBlockingStore blocks every wisp-tier read until unblocked, signaling each
+// attempt on hit. The undesired-pool-session sweep's per-candidate wisp probe
+// (sessionHasOpenAssignedWispWork -> List(TierWisps)) is the distinctive read it
+// makes; blocking only TierWisps isolates the sweep from the other boot-path
+// reads (which use TierIssues/Live), so we can prove the boot tick does NOT wait
+// on the sweep while the steady-state tick does.
+type wispBlockingStore struct {
+	beads.Store
+	block <-chan struct{}
+	hit   chan struct{}
+}
+
+func (w *wispBlockingStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if q.TierMode == beads.TierWisps {
+		select {
+		case w.hit <- struct{}{}:
+		default:
+		}
+		<-w.block
+	}
+	return w.Store.List(q)
+}
+
+// TestCityRuntimeBeadReconcileTick_BootDoesNotBlockOnWispSweep verifies the
+// gastownhall/gascity#3288 boot-hang fix: the boot reconcile pass must NOT run
+// the undesired-pool-session sweep, whose synchronous wisp-tier read fan-out
+// (serialized over candidate × store × status × identifier) can exceed the
+// startup watchdog on a heavy-session city. With a store that blocks on every
+// wisp-tier read, the boot tick must still return promptly (sweep deferred),
+// while the first steady-state tick must reach the wisp read (sweep runs).
+func TestCityRuntimeBeadReconcileTick_BootDoesNotBlockOnWispSweep(t *testing.T) {
+	base := beads.NewMemStore()
+	bead, err := base.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-wispblock",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	block := make(chan struct{})
+	var unblockOnce sync.Once
+	unblock := func() { unblockOnce.Do(func() { close(block) }) }
+	t.Cleanup(unblock) // free any goroutine parked on a wisp read
+	store := &wispBlockingStore{Store: base, block: block, hit: make(chan struct{}, 8)}
+
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "maintainer-city",
+		cfg:                 &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		sp:                  runtime.NewFake(), // session NOT running + absent from desiredState => sweepable
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.Discard,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+	snap := func() *sessionBeadSnapshot { return newSessionBeadSnapshot([]beads.Bead{bead}) }
+	result := func() DesiredStateResult { return DesiredStateResult{State: map[string]TemplateParams{}} }
+
+	// Boot tick must NOT block on the wisp-tier sweep read.
+	bootDone := make(chan struct{})
+	go func() { cr.beadReconcileTick(context.Background(), result(), snap(), nil, true); close(bootDone) }()
+	select {
+	case <-bootDone:
+	case <-store.hit:
+		t.Fatal("#3288: boot reconcile attempted a wisp-tier read; the undesired-pool sweep was NOT deferred")
+	case <-time.After(10 * time.Second):
+		t.Fatal("#3288: boot reconcile blocked (~watchdog); the undesired-pool sweep was NOT deferred")
+	}
+
+	// Steady-state tick MUST reach the wisp-tier sweep read.
+	go cr.beadReconcileTick(context.Background(), result(), snap(), nil, false)
+	select {
+	case <-store.hit:
+		// good: the steady-state tick ran the sweep and reached the wisp read.
+	case <-time.After(10 * time.Second):
+		t.Fatal("steady-state reconcile did not reach the wisp-tier sweep read; sweep did not run")
+	}
+	unblock()
+}
+
 func TestPoolSweepWouldDrain(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
@@ -2905,7 +2998,7 @@ func TestCityRuntimeBeadReconcileTick_TransientStoreQueryPartialKeepsRunningPool
 		ScaleCheckCounts:  map[string]int{"worker": 0},
 		StoreQueryPartial: true,
 	}
-	cr.beadReconcileTick(context.Background(), partialResult, newSessionBeadSnapshot([]beads.Bead{session}), nil)
+	cr.beadReconcileTick(context.Background(), partialResult, newSessionBeadSnapshot([]beads.Bead{session}), nil, false)
 
 	afterPartial, err := store.Get(session.ID)
 	if err != nil {
@@ -2925,7 +3018,7 @@ func TestCityRuntimeBeadReconcileTick_TransientStoreQueryPartialKeepsRunningPool
 			workBead("ga-live", "worker", "worker-bd-123", "in_progress", 5),
 		},
 	}
-	cr.beadReconcileTick(context.Background(), recoveredResult, cr.loadSessionBeadSnapshot(), nil)
+	cr.beadReconcileTick(context.Background(), recoveredResult, cr.loadSessionBeadSnapshot(), nil, false)
 
 	afterRecovered, err := store.Get(session.ID)
 	if err != nil {
@@ -3028,7 +3121,7 @@ func TestCityRuntimeBeadReconcileTick_ScaleCheckPartialKeepsOnlyAffectedPoolSess
 	if !result.ScaleCheckPartialTemplates["worker"] || result.ScaleCheckPartialTemplates["helper"] {
 		t.Fatalf("ScaleCheckPartialTemplates = %v, want only worker", result.ScaleCheckPartialTemplates)
 	}
-	cr.beadReconcileTick(context.Background(), result, snapshot, nil)
+	cr.beadReconcileTick(context.Background(), result, snapshot, nil, false)
 
 	if drain := cr.sessionDrains.get(worker.ID); drain != nil {
 		t.Fatalf("affected worker session was scheduled for drain: reason=%s", drain.reason)
@@ -3094,7 +3187,7 @@ func TestCityRuntimeBeadReconcileTick_ScaleCheckPartialPreservesDormantAffectedP
 		t.Fatalf("affected dormant worker session not preserved in desired state: keys=%v stderr=%s", mapKeys(result.State), stderr.String())
 	}
 
-	cr.beadReconcileTick(context.Background(), result, snapshot, nil)
+	cr.beadReconcileTick(context.Background(), result, snapshot, nil, false)
 
 	if drain := cr.sessionDrains.get(worker.ID); drain != nil {
 		t.Fatalf("affected dormant worker session was scheduled for drain: reason=%s", drain.reason)
@@ -3153,7 +3246,7 @@ func TestCityRuntimeBeadReconcileTick_StoreQueryPartialDoesNotReleaseAssignedWor
 		AssignedWorkBeads:  []beads.Bead{work},
 		AssignedWorkStores: []beads.Store{store},
 		StoreQueryPartial:  true,
-	}, newSessionBeadSnapshot(nil), nil)
+	}, newSessionBeadSnapshot(nil), nil, false)
 
 	got, err := store.Get(work.ID)
 	if err != nil {
@@ -3203,7 +3296,7 @@ func TestCityRuntimeBeadReconcileTick_SessionQueryPartialDoesNotReleaseAssignedW
 		ScaleCheckCounts:   map[string]int{"worker": 0},
 		AssignedWorkBeads:  []beads.Bead{work},
 		AssignedWorkStores: []beads.Store{store},
-	}, nil, nil)
+	}, nil, nil, false)
 
 	got, err := base.Get(work.ID)
 	if err != nil {
@@ -3346,7 +3439,7 @@ func TestCityRuntimeBeadReconcileTick_KeepsAssignedPoolWorkerAwake(t *testing.T)
 	}
 
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{session})
-	cr.beadReconcileTick(context.Background(), result, sessionBeads, nil)
+	cr.beadReconcileTick(context.Background(), result, sessionBeads, nil, false)
 
 	got, err := store.Get(session.ID)
 	if err != nil {
@@ -3419,7 +3512,7 @@ func TestCityRuntimeBeadReconcileTick_SweepRespectsLiveAssignedWork(t *testing.T
 	}
 
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{session})
-	cr.beadReconcileTick(context.Background(), result, sessionBeads, nil)
+	cr.beadReconcileTick(context.Background(), result, sessionBeads, nil, false)
 
 	got, err := store.Get(session.ID)
 	if err != nil {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -265,6 +265,15 @@ type startExecutionOptions struct {
 	asyncStopTracker *asyncStartTracker
 	maxSessionAgeTr  maxSessionAgeTracker
 	workDirResolver  taskWorkDirResolver
+	// deferSessionClosesOnBoot suppresses the per-session orphan/failed-create
+	// session-bead closes during the synchronous boot reconcile. Those closes
+	// gate on a per-session open-work probe that reads the wisp tier
+	// (sessionHasOpenAssignedWispWork); serialized over every candidate on the
+	// readiness path that fan-out can exceed the startup watchdog on a
+	// heavy-session city (gastownhall/gascity#3288). The first steady-state tick
+	// performs the closes. Safe to defer: the closes already fail closed and are
+	// deferred under storeQueryPartial today.
+	deferSessionClosesOnBoot bool
 }
 
 type startExecutionOption func(*startExecutionOptions)
@@ -312,6 +321,16 @@ func withMaxSessionAgeTracker(tr maxSessionAgeTracker) startExecutionOption {
 func withTaskWorkDirResolver(resolver taskWorkDirResolver) startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.workDirResolver = resolver
+	}
+}
+
+// withDeferSessionClosesOnBoot defers the per-session orphan/failed-create
+// session-bead closes for this reconcile pass (gastownhall/gascity#3288). Used
+// only on the synchronous boot reconcile so readiness does not wait on the
+// per-session wisp-tier work probe; the first steady-state tick performs them.
+func withDeferSessionClosesOnBoot() startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.deferSessionClosesOnBoot = true
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1267,7 +1267,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if trace != nil {
 						trace.recordDecision("reconciler.session.close_failed_create", template, name, string(sessionpkg.StateFailedCreate), "closed", nil, nil, "")
 					}
-					if storeQueryPartial {
+					if storeQueryPartial || reconcileOpts.deferSessionClosesOnBoot {
 						continue
 					}
 					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, *session, string(sessionpkg.StateFailedCreate), clk.Now().UTC(), stderr) {
@@ -1491,7 +1491,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if trace != nil {
 						trace.recordDecision("reconciler.session.close_orphan", template, name, reason, "closed", nil, nil, "")
 					}
-					if storeQueryPartial {
+					if storeQueryPartial || reconcileOpts.deferSessionClosesOnBoot {
 						continue
 					}
 					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, *session, reason, clk.Now().UTC(), stderr) {

--- a/cmd/gc/session_reconciler_trace_integration_test.go
+++ b/cmd/gc/session_reconciler_trace_integration_test.go
@@ -104,7 +104,7 @@ func TestSessionReconcilerTraceLifecycleRecordsTick(t *testing.T) {
 		},
 		ScaleCheckCounts: map[string]int{"repo/polecat": 1},
 	}
-	cr.beadReconcileTick(context.Background(), result, sessionBeads, cycle)
+	cr.beadReconcileTick(context.Background(), result, sessionBeads, cycle, false)
 	if err := cycle.End(TraceCompletionCompleted, traceRecordPayload{"phase": "tick"}); err != nil {
 		t.Fatalf("cycle.End: %v", err)
 	}
@@ -652,7 +652,7 @@ func TestSessionReconcilerTraceGH1654WorkRequestedStartCandidates(t *testing.T) 
 				stdout:              io.Discard,
 				stderr:              io.Discard,
 			}
-			cr.beadReconcileTick(context.Background(), dsResult, sessionBeads, cycle)
+			cr.beadReconcileTick(context.Background(), dsResult, sessionBeads, cycle, false)
 			if !cr.waitForAsyncStarts() {
 				t.Fatal("async starts did not finish")
 			}

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -2247,7 +2247,11 @@ func (s *BdStore) listEphemeral(query ListQuery) ([]Bead, error) {
 	}
 	args = append(args, "--limit", strconv.Itoa(wispsLimit))
 
-	out, err := s.runner(s.dir, "bd", args...)
+	// #3288: route the wisp `bd query` through the retried/deadline-bounded
+	// transient-read path (as listViaBDList already does) so BOTH subprocesses
+	// inside listWispsTier are bounded — a bare s.runner call here would be the
+	// one unretried read on the hot tier-merge path.
+	out, err := s.runBDTransientRead(args...)
 	if err != nil {
 		if isBdQueryUnsupported(err) {
 			return nil, nil


### PR DESCRIPTION
## Problem
`#3288` boot-hang: on a heavy-session city the controller hangs at startup phase `adopting_sessions` (cities_running=0, ready=false) until the 15m startup watchdog fires. Deterministic on `maintainer-city`; rolled back 3× (a13511794 / c10ab35b9 / c23ce3969), pinning the live city to pre-#3288 `dev-d12ecdf81` and blocking all deploys.

## Root cause
The startup reconcile runs, **synchronously on the readiness path**, a per-session **wisp-tier read fan-out** from two places: the undesired-pool-session **sweep** (`sweepUndesiredPoolSessionBeads`, the site in the original goroutine dump) and the **orphan / failed-create session-bead closes** in `reconcileSessionBeadsTracedWithNamedDemand`. Both gate on `sessionHasOpenAssignedWispWork` (a wisp-tier `bd` read), serialized over candidate × store × status × identifier. Each `bd` call is already deadline-bounded on `main`, but the **serial accumulation** exceeds the 15m watchdog. (The prior `dev-c23ce3969` attempt bounded each call yet left the synchronous fan-out, and was never merged.)

## Fix
- Thread `bootReconcile` into `beadReconcileTick`; on the boot tick **skip the sweep** and **defer the orphan/failed-create closes** (`withDeferSessionClosesOnBoot`, reusing the existing `storeQueryPartial` deferral). The first steady-state tick performs them. Safe: those closes already fail closed and are deferred under `storeQueryPartial` today.
- Route `listEphemeral`'s wisp `bd query` through the retried/bounded transient path.

Deferring **only** the sweep is insufficient — the orphan-close path does the same fan-out; the readiness test caught it.

## Validation
- Readiness test: with a store that blocks on every wisp-tier read, the **boot tick returns with zero wisp reads** while the steady-state tick reaches the sweep.
- `go vet` clean; `internal/beads` unit suite green; broad cmd/gc regression (reconcile/session/sweep/pool/city-runtime/drain/orphan/wisp/Phase0) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)