### PR TITLE
fix(api): raise control-plane HTTP client timeout 10s to 60s so federated reads stop timing out claims

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -265,6 +265,15 @@ type Client struct {
 
 const sessionMessageTimeout = 4 * time.Minute
 
+// defaultClientTimeout is the overall HTTP timeout for control-plane client
+// calls. The read paths (EphemeralBeads, ReadyBeads, ClaimBead, ...) pass
+// context.Background() and rely solely on this ceiling, and several of them
+// federate the city store plus every rig store — a dolt-backed rig store can
+// take many seconds, so a 10s ceiling timed out gc hook --claim and stalled
+// the worker claim path. Most calls return in milliseconds; this only bounds
+// the slow federated reads and genuinely hung requests.
+const defaultClientTimeout = 60 * time.Second
+
 // SessionSubmitResponse is the domain-facing shape of a session submit result.
 type SessionSubmitResponse struct {
 	Status string               `json:"status"`
@@ -424,7 +433,7 @@ func NewCityScopedClient(baseURL, cityName string) *Client {
 }
 
 func newClient(baseURL, cityName string) *Client {
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	httpClient := &http.Client{Timeout: defaultClientTimeout}
 	cw, err := genclient.NewClientWithResponses(
 		baseURL,
 		genclient.WithHTTPClient(httpClient),

--- a/internal/api/client_timeout_test.go
+++ b/internal/api/client_timeout_test.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDefaultClientTimeoutAccommodatesFederatedReads guards the ceiling that
+// governs the worker claim path. EphemeralBeads/ReadyBeads/ClaimBead pass
+// context.Background(), so the HTTP client's overall timeout is their only
+// deadline. Those endpoints federate the city store plus every rig store, and a
+// dolt-backed rig store can take several seconds; a too-tight ceiling times out
+// gc hook --claim and operators cannot claim work. 10s was too tight once the
+// ephemeral read measured ~10s — keep meaningful headroom over the federated
+// read cost.
+func TestDefaultClientTimeoutAccommodatesFederatedReads(t *testing.T) {
+	const minFederatedReadBudget = 30 * time.Second
+	if defaultClientTimeout < minFederatedReadBudget {
+		t.Fatalf("defaultClientTimeout = %v, want >= %v to cover federated multi-store reads on the claim path",
+			defaultClientTimeout, minFederatedReadBudget)
+	}
+}


### PR DESCRIPTION
## Summary

Raises the control-plane HTTP client's overall timeout from **10s to 60s** so slow federated reads stop killing the worker claim path.

The read paths (`EphemeralBeads`, `ReadyBeads`, `ClaimBead`, ...) pass `context.Background()` and rely solely on the HTTP client's overall ceiling as their only deadline. Several of these endpoints federate the city store plus every rig store. A dolt-backed rig store can take many seconds, and after concurrent federation cut the ephemeral read from ~24s to ~10s it still sat right at the 10s ceiling — so `gc hook --claim` kept timing out by a fraction of a second and pool operators could not claim workflow steps.

This raises the ceiling to 60s (matching the work-query context budget). Most calls return in milliseconds; this only bounds the genuinely slow federated reads and hung requests. A guard test (`TestDefaultClientTimeoutAccommodatesFederatedReads`) pins the ceiling at >= 30s so it cannot silently regress below the federated multi-store read cost.

## Provenance

This is a clean, **store-backend-agnostic** change extracted from the local sqlite deploy branch (`deploy/sqlite-b36-probe-attribution`) for upstreaming to `main` ahead of the interface refactor and the sqlite-behind-interfaces swap. The change is a pure timeout-constant adjustment in `internal/api/client.go` plus its guard test — it carries none of the deploy branch's sqlite / graph-store / HTTP-shim code, and applies identically regardless of the bead store backend.

## Slice rationale

Landing this on `main` first means the federated-read timeout fix is available to all backends and is decoupled from the larger store-interface work still in flight on the deploy branch. The federation behavior that exposed the too-tight ceiling is already present on `main`, so the fix is relevant here today.

## Verification

- `go build ./internal/api/` — passes
- `go vet ./internal/api/` — clean
- `go test ./internal/api/ -run TestDefaultClientTimeoutAccommodatesFederatedReads` — passes

Generated with Claude Code.
