### PR TITLE
fix(api): normalize bead assignees to the session-name form, not the bare bead-id

### DIFF
--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -49,16 +49,41 @@ func (s *Server) beadListAssigneeTerms(ctx context.Context, assignee string) []s
 	if assignee == "" {
 		return []string{""}
 	}
-	terms := []string{assignee}
 	store := s.state.CityBeadStore()
 	if store == nil {
-		return terms
+		return []string{assignee}
 	}
 	id, err := s.resolveSessionTargetIDWithContext(ctx, store, assignee, apiSessionResolveOptions{})
-	if err != nil || id == "" || id == assignee {
-		return terms
+	if err != nil || id == "" {
+		return []string{assignee}
 	}
-	return []string{id, assignee}
+	// A work bead's stored assignee may be ANY of the resolved session's
+	// identity forms — the bead ID, session_name, alias, configured named
+	// identity, or a prior alias — so match against all of them (mirrors
+	// sessionBeadAssigneeIdentities used by the reconciler). Without this the
+	// session-name form written by assign/update (and the claim path) would be
+	// invisible to ?assignee=<alias|id> list filters.
+	seen := map[string]bool{}
+	var terms []string
+	add := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" || seen[v] {
+			return
+		}
+		seen[v] = true
+		terms = append(terms, v)
+	}
+	add(assignee)
+	add(id)
+	if b, getErr := store.Get(id); getErr == nil {
+		add(b.Metadata["session_name"])
+		add(b.Metadata["alias"])
+		add(b.Metadata[session.NamedSessionIdentityMetadata])
+		for _, prior := range session.AliasHistory(b.Metadata) {
+			add(prior)
+		}
+	}
+	return terms
 }
 
 func (s *Server) normalizeRawBeadAssignee(ctx context.Context, assignee string) (string, error) {
@@ -88,7 +113,26 @@ func (s *Server) normalizeRawBeadAssignee(ctx context.Context, assignee string) 
 		return "", fmt.Errorf("assignee must resolve to a concrete open session bead ID: %q", assignee)
 	}
 	session.RepairEmptyType(store, &b)
-	return b.ID, nil
+	return sessionBeadAssigneeIdentifier(b), nil
+}
+
+// sessionBeadAssigneeIdentifier returns the durable agent-facing identity form
+// of a session bead — its session_name, else alias, else configured named
+// identity — falling back to the bead ID when no name metadata is present so a
+// resolved assignment is never silently cleared. This is the form the agent
+// claims and verifies work with (BEADS_ACTOR / GC_SESSION_NAME), so stamping it
+// keeps assign/update consistent with the claim path (which already stores the
+// raw session-name) and with the form-agnostic session matching in the
+// reconciler (sessionBeadAssigneeIdentities). Stamping the bare bead ID here
+// instead made template-routed continuation work unclaimable by name-matching
+// agents.
+func sessionBeadAssigneeIdentifier(b beads.Bead) string {
+	for _, key := range []string{"session_name", "alias", session.NamedSessionIdentityMetadata} {
+		if v := strings.TrimSpace(b.Metadata[key]); v != "" {
+			return v
+		}
+	}
+	return b.ID
 }
 
 // findStore returns the bead store for the given rig. If rig is empty, returns

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -1672,8 +1672,8 @@ func TestPhase2BeadAssignNormalizesCurrentSessionAlias(t *testing.T) {
 		t.Fatalf("assign alias status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	got, _ := store.Get(work.ID)
-	if got.Assignee != sessionBead.ID {
-		t.Fatalf("assignee = %q, want alias normalized to session bead ID %q", got.Assignee, sessionBead.ID)
+	if got.Assignee != sessionBead.Metadata["session_name"] {
+		t.Fatalf("assignee = %q, want alias normalized to session_name %q", got.Assignee, sessionBead.Metadata["session_name"])
 	}
 
 	listReq := httptest.NewRequest("GET", cityURL(state, "/beads?assignee=worker"), nil)
@@ -1744,8 +1744,8 @@ func TestPhase2BeadAssignNormalizesCurrentSessionName(t *testing.T) {
 		t.Fatalf("assign session_name status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	got, _ := store.Get(work.ID)
-	if got.Assignee != sessionBead.ID {
-		t.Fatalf("assignee = %q, want session_name normalized to session bead ID %q", got.Assignee, sessionBead.ID)
+	if got.Assignee != sessionBead.Metadata["session_name"] {
+		t.Fatalf("assignee = %q, want session_name preserved as %q", got.Assignee, sessionBead.Metadata["session_name"])
 	}
 }
 
@@ -1766,12 +1766,16 @@ func TestPhase2BeadAssignMaterializesExactConfiguredNamedIdentity(t *testing.T) 
 		t.Fatalf("assign configured named identity status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	got, _ := store.Get(work.ID)
-	if got.Assignee == "" || got.Assignee == "myrig/worker" {
-		t.Fatalf("assignee = %q, want materialized concrete session bead ID", got.Assignee)
+	if got.Assignee == "" {
+		t.Fatalf("assignee = %q, want materialized session identity", got.Assignee)
 	}
-	gotSession, err := state.cityBeadStore.Get(got.Assignee)
+	sessionID, err := session.ResolveSessionID(state.cityBeadStore, got.Assignee)
 	if err != nil {
-		t.Fatalf("Get(materialized session %q): %v", got.Assignee, err)
+		t.Fatalf("ResolveSessionID(materialized assignee %q): %v", got.Assignee, err)
+	}
+	gotSession, err := state.cityBeadStore.Get(sessionID)
+	if err != nil {
+		t.Fatalf("Get(materialized session %q): %v", sessionID, err)
 	}
 	if gotSession.Metadata[apiNamedSessionMetadataKey] != "true" {
 		t.Fatalf("configured_named_session = %q, want true", gotSession.Metadata[apiNamedSessionMetadataKey])
@@ -1875,8 +1879,8 @@ func TestPhase2BeadAssignAcceptsRepairableSessionBeadID(t *testing.T) {
 		t.Fatalf("assign repairable session status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	got, _ := store.Get(work.ID)
-	if got.Assignee != sessionBead.ID {
-		t.Fatalf("assignee = %q, want repairable session bead ID %q", got.Assignee, sessionBead.ID)
+	if got.Assignee != sessionBead.Metadata["session_name"] {
+		t.Fatalf("assignee = %q, want repairable session_name %q", got.Assignee, sessionBead.Metadata["session_name"])
 	}
 	gotSession, _ := state.cityBeadStore.Get(sessionBead.ID)
 	if gotSession.Type != session.BeadType {
@@ -1902,8 +1906,8 @@ func TestPhase2BeadUpdateNormalizesRawAssigneeAlias(t *testing.T) {
 		t.Fatalf("update alias status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	got, _ := store.Get(work.ID)
-	if got.Assignee != sessionBead.ID {
-		t.Fatalf("assignee = %q, want alias normalized to session bead ID %q", got.Assignee, sessionBead.ID)
+	if got.Assignee != sessionBead.Metadata["session_name"] {
+		t.Fatalf("assignee = %q, want alias normalized to session_name %q", got.Assignee, sessionBead.Metadata["session_name"])
 	}
 }
 
@@ -1928,8 +1932,39 @@ func TestPhase2BeadCreateNormalizesRawAssigneeAlias(t *testing.T) {
 	if len(items) != 1 {
 		t.Fatalf("created %d beads, want 1", len(items))
 	}
-	if items[0].Assignee != sessionBead.ID {
-		t.Fatalf("created assignee = %q, want alias normalized to session bead ID %q", items[0].Assignee, sessionBead.ID)
+	if items[0].Assignee != sessionBead.Metadata["session_name"] {
+		t.Fatalf("created assignee = %q, want alias normalized to session_name %q", items[0].Assignee, sessionBead.Metadata["session_name"])
+	}
+}
+
+func TestPhase2BeadAssignFallsBackToBeadIDWhenSessionHasNoName(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	store := state.stores["myrig"]
+	_, _ = store.Create(beads.Bead{Title: "ID offset"})
+	work, _ := store.Create(beads.Bead{Title: "Task"})
+	// A repairable/crash-migrated session bead can carry no session_name, alias,
+	// or configured_named_identity; the normalized assignee must fall back to the
+	// bead ID so the assignment is never silently cleared.
+	sessionBead, _ := state.cityBeadStore.Create(beads.Bead{
+		Title:    "Nameless session",
+		Type:     session.BeadType,
+		Labels:   []string{session.LabelSession},
+		Metadata: map[string]string{"state": "active"},
+	})
+	srv := New(state)
+	h := newTestCityHandlerWith(t, state, srv)
+
+	req := newPostRequest(cityURL(state, "/bead/"+work.ID+"/assign"), bytes.NewBufferString(`{"assignee":"`+sessionBead.ID+`"}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign nameless session status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	got, _ := store.Get(work.ID)
+	if got.Assignee != sessionBead.ID {
+		t.Fatalf("assignee = %q, want bead-ID fallback %q", got.Assignee, sessionBead.ID)
 	}
 }
 


### PR DESCRIPTION
## What

Normalize bead assignees to the durable session-name form on the `assign`, `update`, and `create` API paths, instead of resolving them to the bare session bead-id.

Previously these handlers ran `normalizeRawBeadAssignee`, which resolved any assignee to the session **bead ID** (`b.ID`). The `claim` handler does not normalize and stores the raw session-name (`BEADS_ACTOR` / `GC_SESSION_NAME`). The two paths therefore stamped different forms onto otherwise-equivalent assignments:

- Primary claims kept the session-**name** form.
- `bd update <sibling> --assignee <session-name>` (the continuation-group vacuum that runs on scope teardown / cleanup-worktree steps) went through the `update` endpoint and got rewritten to the bare **bead-id** form.

Run-operators verify claimed work against `BEADS_ACTOR` (the name form) and reject the bead-id form, so vacuumed siblings wedged adopt-pr molecules at the cleanup step in an infinite `CLAIM_REJECTED` loop.

This change resolves the assignee to the session's durable name form (`session_name` > `alias` > `configured_named_identity`), falling back to the bead ID only when no name metadata exists, so assignments are never silently cleared. `assign`/`update`/`create` now converge on the form the claim path already stores, and the reconciler matches form-agnostically (`sessionBeadAssigneeIdentities`). `beadListAssigneeTerms` is also expanded so `?assignee=` filters still match name-form work beads.

## Why this PR exists

This is a clean, **store-backend-agnostic** correctness fix extracted from the local sqlite deploy branch (`deploy/sqlite-b36-probe-attribution`) for upstreaming to `main` ahead of the interface refactor and the sqlite-behind-interfaces swap. It touches only `internal/api/handler_beads.go` and its test; it carries none of the sqlite / graph-store / HTTP-shim code from that branch.

## Test

- `GOCACHE=$(mktemp -d) go build ./internal/api/ ./cmd/gc/` — passes
- `go vet ./internal/api/ ./cmd/gc/` — clean
- Updated `internal/api/handler_beads_test.go` covers the name-form normalization and the expanded assignee-filter terms.

Generated with Claude Code.
