### PR TITLE
fix(session): resolve Codex transcript fallback by session order for shared-workdir siblings

### DIFF
--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -126,16 +126,46 @@ func resolveStoredSessionLogSource(cityPath string, cfg *config.City, store bead
 	if !ok {
 		return "", "", false, ""
 	}
-	if logCtx.sessionID != "" {
-		handle, err := workerHandleForSessionWithConfig(cityPath, store, newSessionProvider(), cfg, logCtx.sessionID)
-		if err == nil {
-			if path, pathErr := handle.TranscriptPath(context.Background()); pathErr == nil && strings.TrimSpace(path) != "" {
-				return path, logCtx.provider, true, ""
-			}
-		}
+	if path := resolveSessionHandleTranscript(cityPath, cfg, store, logCtx); path != "" {
+		return path, logCtx.provider, true, ""
 	}
-	path := ""
 	fallbackAllowed := canFallbackStoredSessionLogByWorkDir(store, logCtx)
+	path := resolveStoredSessionLogPathCandidate(searchPaths, logCtx, fallbackAllowed)
+	if path == "" && fallbackAllowed {
+		path = discoverWorkDirTranscript(searchPaths, logCtx)
+	}
+	if path == "" && !fallbackAllowed {
+		path = resolveCodexSiblingLogPath(store, searchPaths, logCtx)
+	}
+	if path == "" && !fallbackAllowed {
+		return "", logCtx.provider, true, ambiguousSessionLogDiagnostic(logCtx)
+	}
+	return path, logCtx.provider, true, ""
+}
+
+// resolveSessionHandleTranscript returns the transcript path reported by the
+// session's worker handle, or "" when there is no session id, the handle cannot
+// be built, or it reports no transcript.
+func resolveSessionHandleTranscript(cityPath string, cfg *config.City, store beads.Store, logCtx sessionLogContext) string {
+	if logCtx.sessionID == "" {
+		return ""
+	}
+	handle, err := workerHandleForSessionWithConfig(cityPath, store, newSessionProvider(), cfg, logCtx.sessionID)
+	if err != nil {
+		return ""
+	}
+	path, pathErr := handle.TranscriptPath(context.Background())
+	if pathErr != nil || strings.TrimSpace(path) == "" {
+		return ""
+	}
+	return path
+}
+
+// resolveStoredSessionLogPathCandidate resolves the primary stored transcript
+// path from the session key (preferred) or the workdir fallback, returning ""
+// when nothing fresh enough for the session is found.
+func resolveStoredSessionLogPathCandidate(searchPaths []string, logCtx sessionLogContext, fallbackAllowed bool) string {
+	path := ""
 	if strings.TrimSpace(logCtx.sessionKey) != "" {
 		path = resolveSessionKeyedLogPath(searchPaths, logCtx)
 		if path == "" && fallbackAllowed {
@@ -145,29 +175,41 @@ func resolveStoredSessionLogSource(cityPath string, cfg *config.City, store bead
 		path = resolveSessionLogPath(searchPaths, logCtx)
 	}
 	if !sessionLogPathFreshEnough(path, logCtx.createdAt) {
-		path = ""
+		return ""
 	}
-	if path == "" && fallbackAllowed {
-		factory, err := worker.NewFactory(worker.FactoryConfig{SearchPaths: searchPaths})
-		if err == nil {
-			path = factory.DiscoverWorkDirTranscript(logCtx.provider, logCtx.workDir)
-		}
+	return path
+}
+
+// discoverWorkDirTranscript resolves the workdir-based transcript fallback,
+// returning "" when the worker factory cannot be built or the transcript is not
+// fresh enough for the session.
+func discoverWorkDirTranscript(searchPaths []string, logCtx sessionLogContext) string {
+	factory, err := worker.NewFactory(worker.FactoryConfig{SearchPaths: searchPaths})
+	if err != nil {
+		return ""
 	}
+	path := factory.DiscoverWorkDirTranscript(logCtx.provider, logCtx.workDir)
 	if !sessionLogPathFreshEnough(path, logCtx.createdAt) {
-		path = ""
+		return ""
 	}
-	if path == "" && !fallbackAllowed {
-		if siblings, err := sessionLogFallbackSiblings(store, logCtx); err == nil {
-			path = sessionpkg.ResolveCodexTranscriptBySessionOrder(searchPaths, logCtx.provider, logCtx.workDir, logCtx.sessionID, siblings)
-		}
+	return path
+}
+
+// resolveCodexSiblingLogPath resolves an ambiguous same-workdir Codex session to
+// its transcript by session-start ordering. It is used only when the plain
+// workdir fallback is disallowed because multiple live siblings share the
+// workdir. It returns "" when the sibling set cannot be gathered, the group is
+// underspecified, or the resolved transcript is not fresh enough for the session.
+func resolveCodexSiblingLogPath(store beads.Store, searchPaths []string, logCtx sessionLogContext) string {
+	siblings, err := sessionLogFallbackSiblings(store, logCtx)
+	if err != nil {
+		return ""
 	}
+	path := sessionpkg.ResolveCodexTranscriptBySessionOrder(searchPaths, logCtx.provider, logCtx.workDir, logCtx.sessionID, siblings)
 	if !sessionLogPathFreshEnough(path, logCtx.createdAt) {
-		path = ""
+		return ""
 	}
-	if path == "" && !fallbackAllowed {
-		return "", logCtx.provider, true, ambiguousSessionLogDiagnostic(logCtx)
-	}
-	return path, logCtx.provider, true, ""
+	return path
 }
 
 func resolveSessionKeyedLogPath(searchPaths []string, logCtx sessionLogContext) string {

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -157,6 +157,14 @@ func resolveStoredSessionLogSource(cityPath string, cfg *config.City, store bead
 		path = ""
 	}
 	if path == "" && !fallbackAllowed {
+		if siblings, err := sessionLogFallbackSiblings(store, logCtx); err == nil {
+			path = sessionpkg.ResolveCodexTranscriptBySessionOrder(searchPaths, logCtx.provider, logCtx.workDir, logCtx.sessionID, siblings)
+		}
+	}
+	if !sessionLogPathFreshEnough(path, logCtx.createdAt) {
+		path = ""
+	}
+	if path == "" && !fallbackAllowed {
 		return "", logCtx.provider, true, ambiguousSessionLogDiagnostic(logCtx)
 	}
 	return path, logCtx.provider, true, ""
@@ -221,9 +229,14 @@ func canFallbackStoredSessionLogByWorkDir(store beads.Store, logCtx sessionLogCo
 	if store == nil || strings.TrimSpace(logCtx.sessionID) == "" || strings.TrimSpace(logCtx.workDir) == "" {
 		return false
 	}
+	siblings, err := sessionLogFallbackSiblings(store, logCtx)
+	return err == nil && len(siblings) == 1
+}
+
+func sessionLogFallbackSiblings(store beads.Store, logCtx sessionLogContext) ([]beads.Bead, error) {
 	all, err := sessionLogFallbackCandidates(store, logCtx.workDir, logCtx.provider)
 	if err != nil {
-		return false
+		return nil, err
 	}
 	targetLive := false
 	for _, b := range all {
@@ -232,7 +245,7 @@ func canFallbackStoredSessionLogByWorkDir(store beads.Store, logCtx sessionLogCo
 			break
 		}
 	}
-	matches := 0
+	var matches []beads.Bead
 	for _, b := range all {
 		if !sessionpkg.IsSessionBeadOrRepairable(b) {
 			continue
@@ -250,12 +263,9 @@ func canFallbackStoredSessionLogByWorkDir(store beads.Store, logCtx sessionLogCo
 		if targetLive && b.ID != logCtx.sessionID && !sessionLogFallbackCandidateLive(b) {
 			continue
 		}
-		matches++
-		if matches > 1 {
-			return false
-		}
+		matches = append(matches, b)
 	}
-	return matches == 1
+	return matches, nil
 }
 
 func sessionLogFallbackCandidates(store beads.Store, workDir, provider string) ([]beads.Bead, error) {

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -506,6 +506,76 @@ func TestResolveStoredSessionLogSource_CodexDoesNotUseAmbiguousWorkDirFallback(t
 	}
 }
 
+func TestResolveStoredSessionLogSource_CodexAmbiguousWorkDirUsesStartOrder(t *testing.T) {
+	workDir := t.TempDir()
+	firstStarted := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	secondStarted := firstStarted.Add(2 * time.Minute)
+	store := beads.NewMemStoreFrom(2, []beads.Bead{
+		{
+			ID:        "gc-1",
+			Type:      session.BeadType,
+			Status:    "open",
+			Labels:    []string{session.LabelSession},
+			CreatedAt: firstStarted.Add(-time.Hour),
+			UpdatedAt: firstStarted,
+			Metadata: map[string]string{
+				"alias":         "workflows__codex-max-mc-one",
+				"provider":      "codex",
+				"provider_kind": "codex",
+				"session_name":  "workflows__codex-max-mc-one",
+				"state":         "awake",
+				"last_woke_at":  firstStarted.Format(time.RFC3339),
+				"work_dir":      workDir,
+			},
+		},
+		{
+			ID:        "gc-2",
+			Type:      session.BeadType,
+			Status:    "open",
+			Labels:    []string{session.LabelSession},
+			CreatedAt: secondStarted.Add(-time.Hour),
+			UpdatedAt: secondStarted,
+			Metadata: map[string]string{
+				"alias":         "workflows__codex-max-mc-two",
+				"provider":      "codex",
+				"provider_kind": "codex",
+				"session_name":  "workflows__codex-max-mc-two",
+				"state":         "awake",
+				"last_woke_at":  secondStarted.Format(time.RFC3339),
+				"work_dir":      workDir,
+			},
+		},
+	}, nil)
+
+	searchBase := t.TempDir()
+	dayDir := filepath.Join(searchBase, "2026", "05", "04")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	firstPath := filepath.Join(dayDir, "rollout-first.jsonl")
+	if err := os.WriteFile(firstPath, []byte(fmt.Sprintf(`{"timestamp":%q,"type":"session_meta","payload":{"cwd":%q}}`+"\n", firstStarted.Format(time.RFC3339), workDir)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secondPath := filepath.Join(dayDir, "rollout-second.jsonl")
+	if err := os.WriteFile(secondPath, []byte(fmt.Sprintf(`{"timestamp":%q,"type":"session_meta","payload":{"cwd":%q}}`+"\n", secondStarted.Format(time.RFC3339), workDir)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, provider, ok, diagnostic := resolveStoredSessionLogSource("", nil, store, "workflows__codex-max-mc-two", []string{searchBase})
+	if !ok {
+		t.Fatal("resolveStoredSessionLogSource() = not found, want found")
+	}
+	if diagnostic != "" {
+		t.Fatalf("resolveStoredSessionLogSource() diagnostic = %q, want empty", diagnostic)
+	}
+	if provider != "codex" {
+		t.Fatalf("resolveStoredSessionLogSource() provider = %q, want codex", provider)
+	}
+	if got != secondPath {
+		t.Fatalf("resolveStoredSessionLogSource() path = %q, want %q", got, secondPath)
+	}
+}
+
 func TestCanFallbackStoredSessionLogByWorkDirUsesTargetedLookup(t *testing.T) {
 	store := &noLabelScanSessionLogStore{MemStore: beads.NewMemStore()}
 	workDir := t.TempDir()

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -591,6 +591,16 @@ func TestJSONContractAllowsBdPassthrough(t *testing.T) {
 	}
 }
 
+func TestJSONContractAllowsHookClaimJSON(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	root := newRootCmd(&stdout, &stderr)
+
+	handled, code := handleJSONContractRequest(root, []string{"hook", "--claim", "--json"}, &stdout, &stderr)
+	if handled || code != 0 {
+		t.Fatalf("handled=%v code=%d stdout=%q stderr=%q", handled, code, stdout.String(), stderr.String())
+	}
+}
+
 func TestJSONSchemaManifestForBdPassthrough(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"bd", "--json-schema"}, &stdout, &stderr)

--- a/internal/formula/expand_test.go
+++ b/internal/formula/expand_test.go
@@ -1430,6 +1430,52 @@ func TestApplyInlineExpansionsWithVarsAllowsConditionallyExclusiveDuplicateTempl
 	}
 }
 
+func TestApplyInlineExpansionsWithVarsResolvesForwardedParentVarOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	expansion := `{
+		"formula": "inline-route-target",
+		"type": "expansion",
+		"version": 1,
+		"vars": {
+			"implementation_run_target": {"default": "default-worker"}
+		},
+		"template": [
+			{
+				"id": "{target}.fix",
+				"title": "Fix",
+				"metadata": {"gc.run_target": "{implementation_run_target}"}
+			}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "inline-route-target.formula.json"), []byte(expansion), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	parser := NewParser(tmpDir)
+	steps := []*Step{
+		{
+			ID:     "review",
+			Title:  "Review",
+			Expand: "inline-route-target",
+			ExpandVars: map[string]string{
+				"implementation_run_target": "{{worker_target}}",
+			},
+		},
+	}
+
+	result, err := ApplyInlineExpansionsWithVars(steps, parser, map[string]string{"worker_target": "custom-worker"})
+	if err != nil {
+		t.Fatalf("ApplyInlineExpansionsWithVars failed: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if got := result[0].Metadata["gc.run_target"]; got != "custom-worker" {
+		t.Fatalf("gc.run_target = %q, want custom-worker", got)
+	}
+}
+
 func TestApplyInlineExpansionsWithVarsCarriesExpansionVarsIntoNestedInlineExpansions(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -975,6 +975,7 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 		return "", fmt.Errorf("listing sessions: %w", err)
 	}
 	matches := 0
+	var sameWorkDirSessions []beads.Bead
 	for _, other := range all {
 		if !IsSessionBeadOrRepairable(other) {
 			continue
@@ -993,13 +994,17 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 			continue
 		}
 		if other.Metadata["work_dir"] == workDir {
+			sameWorkDirSessions = append(sameWorkDirSessions, other)
 			matches++
-			if matches > 1 {
-				// Without a stable session key, multiple sessions sharing the
-				// same workdir cannot be mapped safely to a single transcript.
-				return "", nil
-			}
 		}
+	}
+	if matches > 1 {
+		if path := ResolveCodexTranscriptBySessionOrder(searchPaths, provider, workDir, b.ID, sameWorkDirSessions); path != "" {
+			return path, nil
+		}
+		// Without a stable session key, multiple sessions sharing the same
+		// workdir cannot be mapped safely to a single transcript.
+		return "", nil
 	}
 	return workertranscript.DiscoverPath(searchPaths, provider, workDir, ""), nil
 }

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -967,22 +967,38 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 		return path, nil
 	}
 
+	sameWorkDirSessions, err := m.sameWorkDirSessionBeads(b, provider, workDir)
+	if err != nil {
+		return "", err
+	}
+	if len(sameWorkDirSessions) > 1 {
+		if path := ResolveCodexTranscriptBySessionOrder(searchPaths, provider, workDir, b.ID, sameWorkDirSessions); path != "" {
+			return path, nil
+		}
+		// Without a stable session key, multiple sessions sharing the same
+		// workdir cannot be mapped safely to a single transcript.
+		return "", nil
+	}
+	return workertranscript.DiscoverPath(searchPaths, provider, workDir, ""), nil
+}
+
+// sameWorkDirSessionBeads returns the session beads that share workDir with the
+// target b, restricted to the same provider family when the target's provider is
+// known. For a live target, closed historical sessions are excluded; for a
+// closed target they are kept so historical same-workdir ambiguity is preserved.
+func (m *Manager) sameWorkDirSessionBeads(b beads.Bead, provider, workDir string) ([]beads.Bead, error) {
 	all, err := m.store.List(beads.ListQuery{
 		Label:         LabelSession,
 		IncludeClosed: b.Status == "closed",
 	})
 	if err != nil {
-		return "", fmt.Errorf("listing sessions: %w", err)
+		return nil, fmt.Errorf("listing sessions: %w", err)
 	}
-	matches := 0
-	var sameWorkDirSessions []beads.Bead
+	var same []beads.Bead
 	for _, other := range all {
 		if !IsSessionBeadOrRepairable(other) {
 			continue
 		}
-		// For a live target, closed historical sessions should not make the
-		// lookup ambiguous. For a closed target, historical siblings sharing
-		// the same workdir are the ambiguity we need to preserve.
 		if b.Status != "closed" && other.Status == "closed" {
 			continue
 		}
@@ -994,19 +1010,10 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 			continue
 		}
 		if other.Metadata["work_dir"] == workDir {
-			sameWorkDirSessions = append(sameWorkDirSessions, other)
-			matches++
+			same = append(same, other)
 		}
 	}
-	if matches > 1 {
-		if path := ResolveCodexTranscriptBySessionOrder(searchPaths, provider, workDir, b.ID, sameWorkDirSessions); path != "" {
-			return path, nil
-		}
-		// Without a stable session key, multiple sessions sharing the same
-		// workdir cannot be mapped safely to a single transcript.
-		return "", nil
-	}
-	return workertranscript.DiscoverPath(searchPaths, provider, workDir, ""), nil
+	return same, nil
 }
 
 // KeyedTranscriptPath returns the transcript path only when it resolves to a
@@ -1038,23 +1045,28 @@ func (m *Manager) KeyedTranscriptPath(id string, searchPaths []string) (string, 
 		searchPaths = sessionlog.DefaultSearchPaths()
 	}
 	sessionKey := strings.TrimSpace(b.Metadata["session_key"])
-	if path := workertranscript.DiscoverKeyedPath(searchPaths, provider, workDir, sessionKey); path != "" {
-		return path, nil
-	}
-	// Codex rollouts are keyed by the session-id suffix in the filename, but
-	// gc's general discovery resolves codex by workdir. For a 1:1 sidecar we use
-	// the identity lookup directly when the session_key (the rollout uuid,
-	// captured by the SessionStart hook) is known, exactly as invocation
-	// telemetry does. A keyed miss returns "" with NO window fallback — a
-	// different-suffix rollout would be a misattribution. The [CreatedAt, anchor]
+	// Codex is resolved here, before the generic keyed discovery below.
+	// workertranscript.DiscoverKeyedPath resolves codex with the newest-first,
+	// no-window resolver (FindCodexSessionFileByIDNoWindow), which is correct for
+	// history rendering but would silently mis-attribute a copied or stale
+	// duplicate rollout (same session uuid + workdir, e.g. an archived copy) on
+	// this 1:1 sidecar path by taking the newest suffix match. Sidecar
+	// attribution must refuse ambiguity, so codex uses the window-bounded,
+	// ambiguity-refusing identity lookup instead: a keyed miss, an ambiguous
+	// in-window match, or a duplicate outside the window returns "" with NO
+	// newest-wins fallback rather than a misattribution. The [CreatedAt, anchor]
 	// window bounds the scan; the anchor is the latest wake, falling back to
-	// bead creation.
+	// bead creation. The session_key is the rollout uuid, captured by the
+	// SessionStart hook, exactly as invocation telemetry uses it.
 	if sessionKey != "" && sessionlog.ProviderFamily(provider) == "codex" {
 		anchor := b.CreatedAt
 		if woke, err := time.Parse(time.RFC3339, strings.TrimSpace(b.Metadata["last_woke_at"])); err == nil {
 			anchor = woke
 		}
 		return sessionlog.FindCodexSessionFileByID(searchPaths, workDir, sessionKey, b.CreatedAt, anchor), nil
+	}
+	if path := workertranscript.DiscoverKeyedPath(searchPaths, provider, workDir, sessionKey); path != "" {
+		return path, nil
 	}
 	return "", nil
 }

--- a/internal/session/transcript_lookup.go
+++ b/internal/session/transcript_lookup.go
@@ -1,0 +1,95 @@
+package session
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/sessionlog"
+	workertranscript "github.com/gastownhall/gascity/internal/worker/transcript"
+)
+
+// ResolveCodexTranscriptBySessionOrder maps an ambiguous same-workdir Codex
+// session group to a transcript by using each session's wake/start timestamp.
+// It returns empty unless the target session has a unique transcript in its
+// start window, preserving ambiguity for underspecified groups.
+func ResolveCodexTranscriptBySessionOrder(searchPaths []string, provider, workDir, targetID string, sessions []beads.Bead) string {
+	if sessionlog.ProviderFamily(provider) != "codex" || strings.TrimSpace(workDir) == "" || strings.TrimSpace(targetID) == "" {
+		return ""
+	}
+	type anchoredSession struct {
+		id     string
+		start  time.Time
+		tieKey string
+	}
+	var anchored []anchoredSession
+	for _, b := range sessions {
+		if b.ID == "" || strings.TrimSpace(b.Metadata["work_dir"]) != workDir {
+			continue
+		}
+		start := transcriptStartAnchor(b)
+		if start.IsZero() {
+			continue
+		}
+		anchored = append(anchored, anchoredSession{
+			id:     b.ID,
+			start:  start,
+			tieKey: strings.TrimSpace(b.Metadata["session_name"]),
+		})
+	}
+	if len(anchored) < 2 {
+		return ""
+	}
+	sort.Slice(anchored, func(i, j int) bool {
+		if anchored[i].start.Equal(anchored[j].start) {
+			if anchored[i].tieKey == anchored[j].tieKey {
+				return anchored[i].id < anchored[j].id
+			}
+			return anchored[i].tieKey < anchored[j].tieKey
+		}
+		return anchored[i].start.Before(anchored[j].start)
+	})
+	for i := 1; i < len(anchored); i++ {
+		if anchored[i].start.Equal(anchored[i-1].start) {
+			return ""
+		}
+	}
+	for i, item := range anchored {
+		if item.id != targetID {
+			continue
+		}
+		var end time.Time
+		for j := i + 1; j < len(anchored); j++ {
+			if anchored[j].start.After(item.start) {
+				end = anchored[j].start
+				break
+			}
+		}
+		return workertranscript.DiscoverCodexPathInTimeWindow(searchPaths, workDir, item.start, end)
+	}
+	return ""
+}
+
+func transcriptStartAnchor(b beads.Bead) time.Time {
+	for _, key := range []string{"last_woke_at", "pending_create_started_at", "creation_complete_at"} {
+		if parsed := parseTranscriptAnchorTime(b.Metadata[key]); !parsed.IsZero() {
+			return parsed
+		}
+	}
+	return b.CreatedAt
+}
+
+func parseTranscriptAnchorTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return parsed
+	}
+	if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+		return parsed
+	}
+	return time.Time{}
+}

--- a/internal/session/transcript_lookup.go
+++ b/internal/session/transcript_lookup.go
@@ -10,6 +10,14 @@ import (
 	workertranscript "github.com/gastownhall/gascity/internal/worker/transcript"
 )
 
+// anchoredCodexSession is a same-workdir Codex session paired with its resolved
+// start-time anchor and the tiebreak key used to order equal-start sessions.
+type anchoredCodexSession struct {
+	id     string
+	start  time.Time
+	tieKey string
+}
+
 // ResolveCodexTranscriptBySessionOrder maps an ambiguous same-workdir Codex
 // session group to a transcript by using each session's wake/start timestamp.
 // It returns empty unless the target session has a unique transcript in its
@@ -18,12 +26,28 @@ func ResolveCodexTranscriptBySessionOrder(searchPaths []string, provider, workDi
 	if sessionlog.ProviderFamily(provider) != "codex" || strings.TrimSpace(workDir) == "" || strings.TrimSpace(targetID) == "" {
 		return ""
 	}
-	type anchoredSession struct {
-		id     string
-		start  time.Time
-		tieKey string
+	anchored := collectAnchoredCodexSessions(sessions, workDir)
+	if len(anchored) < 2 {
+		return ""
 	}
-	var anchored []anchoredSession
+	sortAnchoredCodexSessions(anchored)
+	if hasDuplicateAnchorStart(anchored) {
+		return ""
+	}
+	for i, item := range anchored {
+		if item.id != targetID {
+			continue
+		}
+		end := codexSessionWindowEnd(anchored, i)
+		return workertranscript.DiscoverCodexPathInTimeWindow(searchPaths, workDir, item.start, end)
+	}
+	return ""
+}
+
+// collectAnchoredCodexSessions keeps the same-workdir sessions that carry a
+// non-zero start anchor, dropping ones without an id or a resolvable anchor.
+func collectAnchoredCodexSessions(sessions []beads.Bead, workDir string) []anchoredCodexSession {
+	var anchored []anchoredCodexSession
 	for _, b := range sessions {
 		if b.ID == "" || strings.TrimSpace(b.Metadata["work_dir"]) != workDir {
 			continue
@@ -32,15 +56,18 @@ func ResolveCodexTranscriptBySessionOrder(searchPaths []string, provider, workDi
 		if start.IsZero() {
 			continue
 		}
-		anchored = append(anchored, anchoredSession{
+		anchored = append(anchored, anchoredCodexSession{
 			id:     b.ID,
 			start:  start,
 			tieKey: strings.TrimSpace(b.Metadata["session_name"]),
 		})
 	}
-	if len(anchored) < 2 {
-		return ""
-	}
+	return anchored
+}
+
+// sortAnchoredCodexSessions orders sessions by start time, breaking ties on the
+// session name and then the id so ordering is deterministic.
+func sortAnchoredCodexSessions(anchored []anchoredCodexSession) {
 	sort.Slice(anchored, func(i, j int) bool {
 		if anchored[i].start.Equal(anchored[j].start) {
 			if anchored[i].tieKey == anchored[j].tieKey {
@@ -50,29 +77,45 @@ func ResolveCodexTranscriptBySessionOrder(searchPaths []string, provider, workDi
 		}
 		return anchored[i].start.Before(anchored[j].start)
 	})
-	for i := 1; i < len(anchored); i++ {
-		if anchored[i].start.Equal(anchored[i-1].start) {
-			return ""
-		}
-	}
-	for i, item := range anchored {
-		if item.id != targetID {
-			continue
-		}
-		var end time.Time
-		for j := i + 1; j < len(anchored); j++ {
-			if anchored[j].start.After(item.start) {
-				end = anchored[j].start
-				break
-			}
-		}
-		return workertranscript.DiscoverCodexPathInTimeWindow(searchPaths, workDir, item.start, end)
-	}
-	return ""
 }
 
+// hasDuplicateAnchorStart reports whether any two adjacent (already sorted)
+// sessions share the same start anchor, which collapses the group to ambiguous.
+func hasDuplicateAnchorStart(anchored []anchoredCodexSession) bool {
+	for i := 1; i < len(anchored); i++ {
+		if anchored[i].start.Equal(anchored[i-1].start) {
+			return true
+		}
+	}
+	return false
+}
+
+// codexSessionWindowEnd returns the exclusive end of the start-time window for
+// the session at index i: the next strictly-later session start, or zero when i
+// is the last session (an open-ended window).
+func codexSessionWindowEnd(anchored []anchoredCodexSession, i int) time.Time {
+	for j := i + 1; j < len(anchored); j++ {
+		if anchored[j].start.After(anchored[i].start) {
+			return anchored[j].start
+		}
+	}
+	return time.Time{}
+}
+
+// transcriptStartAnchor returns the best available "start of this session" time
+// for windowing its Codex transcript. Preference runs most-precise first:
+// last_woke_at and pending_create_started_at pin an in-flight wake/create, but
+// both are cleared when a session sleeps or drains (SleepPatch,
+// AcknowledgeDrainPatch). awake_started_at is the immutable
+// start-of-awake-interval epoch that survives those teardowns, so it is
+// preferred over creation_complete_at, which is stamped when the runtime
+// finishes coming up and can land several seconds after the rollout's
+// session_meta timestamp. Anchoring a slept or drained session on
+// creation_complete_at would push the [start-2s, end) window past the true
+// transcript and drop it; awake_started_at keeps the window aligned with the
+// rollout. CreatedAt is the final fallback.
 func transcriptStartAnchor(b beads.Bead) time.Time {
-	for _, key := range []string{"last_woke_at", "pending_create_started_at", "creation_complete_at"} {
+	for _, key := range []string{"last_woke_at", "pending_create_started_at", "awake_started_at", "creation_complete_at"} {
 		if parsed := parseTranscriptAnchorTime(b.Metadata[key]); !parsed.IsZero() {
 			return parsed
 		}

--- a/internal/session/transcript_lookup_test.go
+++ b/internal/session/transcript_lookup_test.go
@@ -1,0 +1,84 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// writeCodexRolloutForAnchor writes a minimal Codex rollout transcript whose
+// session_meta cwd is workDir and whose payload timestamp is startedAt, laid out
+// in the YYYY/MM/DD date tree the time-window resolver scans. It returns the
+// rollout path.
+func writeCodexRolloutForAnchor(t *testing.T, root, workDir, sessionID string, startedAt time.Time) string {
+	t.Helper()
+	day := startedAt.In(time.Local)
+	dayDir := filepath.Join(root, day.Format("2006"), day.Format("01"), day.Format("02"))
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dayDir, "rollout-"+startedAt.UTC().Format("2006-01-02T15-04-05")+"-"+sessionID+".jsonl")
+	meta := fmt.Sprintf(`{"timestamp":%q,"type":"session_meta","payload":{"id":%q,"cwd":%q,"timestamp":%q}}`,
+		startedAt.Format(time.RFC3339Nano), sessionID, workDir, startedAt.Format(time.RFC3339Nano))
+	if err := os.WriteFile(path, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestResolveCodexTranscriptBySessionOrderAnchorsOnAwakeStartedAt proves the
+// same-workdir Codex fallback anchors each session's transcript window on the
+// immutable awake_started_at rather than the later creation_complete_at. Once a
+// session sleeps or drains, last_woke_at and pending_create_started_at are
+// cleared, so without awake_started_at the resolver falls through to
+// creation_complete_at — stamped several seconds after the rollout's
+// session_meta timestamp — and filters the true transcript out of the
+// [start-2s, end) window, which is exactly the historical session this fallback
+// exists to recover.
+func TestResolveCodexTranscriptBySessionOrderAnchorsOnAwakeStartedAt(t *testing.T) {
+	root := t.TempDir()
+	workDir := "/data/projects/myproject"
+	const provider = "codex"
+
+	// Target session A rolled out at startA; a later sibling B fixes A's window
+	// end. Both are slept: last_woke_at and pending_create_started_at are blank,
+	// awake_started_at aligns with the rollout, and creation_complete_at lands 5s
+	// later — late enough that a creation_complete_at anchor (windowStart =
+	// creation_complete_at - 2s) would exclude the rollout from the window.
+	startA := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	startB := startA.Add(30 * time.Second)
+
+	pathA := writeCodexRolloutForAnchor(t, root, workDir, "019e3e8e-3591-7532-a1ef-8b9e882bea2f", startA)
+	writeCodexRolloutForAnchor(t, root, workDir, "019e3e8e-ffff-7000-a1ef-8b9e882bea2f", startB)
+
+	sessions := []beads.Bead{
+		sleptCodexSessionBead("sess-a", workDir, provider, startA),
+		sleptCodexSessionBead("sess-b", workDir, provider, startB),
+	}
+
+	got := ResolveCodexTranscriptBySessionOrder([]string{root}, provider, workDir, "sess-a", sessions)
+	if got != pathA {
+		t.Fatalf("ResolveCodexTranscriptBySessionOrder() = %q, want %q (awake_started_at window must include the rollout)", got, pathA)
+	}
+}
+
+// sleptCodexSessionBead builds a same-workdir Codex session bead in the
+// slept/drained shape: last_woke_at and pending_create_started_at are cleared,
+// awake_started_at pins the rollout start, and creation_complete_at is 5s later.
+func sleptCodexSessionBead(id, workDir, provider string, awakeStart time.Time) beads.Bead {
+	return beads.Bead{
+		ID: id,
+		Metadata: map[string]string{
+			"work_dir":                  workDir,
+			"provider":                  provider,
+			"last_woke_at":              "",
+			"pending_create_started_at": "",
+			"awake_started_at":          awakeStart.Format(time.RFC3339Nano),
+			"creation_complete_at":      awakeStart.Add(5 * time.Second).Format(time.RFC3339),
+		},
+	}
+}

--- a/internal/sessionlog/reader.go
+++ b/internal/sessionlog/reader.go
@@ -1031,6 +1031,88 @@ func startOfLocalDay(t time.Time) time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, time.Local)
 }
 
+// CodexSessionCandidate is a Codex transcript whose session metadata matches a
+// requested workdir.
+type CodexSessionCandidate struct {
+	Path      string
+	SessionID string
+	WorkDir   string
+	StartedAt time.Time
+	ModTime   time.Time
+}
+
+// FindCodexSessionCandidates returns Codex transcripts matching workDir,
+// newest first by transcript start time and then file modification time.
+func FindCodexSessionCandidates(searchPaths []string, workDir string) []CodexSessionCandidate {
+	workDir = strings.TrimSpace(workDir)
+	if workDir == "" {
+		return nil
+	}
+	var candidates []CodexSessionCandidate
+	for _, root := range mergeCodexSearchPaths(searchPaths) {
+		candidates = append(candidates, findCodexSessionCandidatesIn(root, workDir, make(map[string]bool))...)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		left := codexCandidateSortTime(candidates[i])
+		right := codexCandidateSortTime(candidates[j])
+		if left.Equal(right) {
+			return candidates[i].Path > candidates[j].Path
+		}
+		return left.After(right)
+	})
+	return candidates
+}
+
+// FindCodexSessionFileByIDFromCandidates resolves a Codex transcript by provider
+// session ID while still requiring the embedded cwd to match workDir.
+func FindCodexSessionFileByIDFromCandidates(searchPaths []string, workDir, sessionID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" || strings.Contains(sessionID, "..") || strings.ContainsAny(sessionID, `/\`) {
+		return ""
+	}
+	for _, candidate := range FindCodexSessionCandidates(searchPaths, workDir) {
+		if candidate.SessionID == sessionID || strings.Contains(filepath.Base(candidate.Path), sessionID) {
+			return candidate.Path
+		}
+	}
+	return ""
+}
+
+// FindCodexSessionFileInTimeWindow resolves a Codex transcript whose metadata
+// start time uniquely falls inside [start, end). A zero end leaves the window
+// open-ended. If the window matches zero or multiple transcripts, it returns
+// empty to preserve same-workdir ambiguity guards.
+func FindCodexSessionFileInTimeWindow(searchPaths []string, workDir string, start, end time.Time) string {
+	if start.IsZero() {
+		return ""
+	}
+	var matches []CodexSessionCandidate
+	for _, candidate := range FindCodexSessionCandidates(searchPaths, workDir) {
+		candidateTime := codexCandidateSortTime(candidate)
+		if candidateTime.IsZero() {
+			continue
+		}
+		if candidateTime.Before(start.Add(-2 * time.Second)) {
+			continue
+		}
+		if !end.IsZero() && !candidateTime.Before(end) {
+			continue
+		}
+		matches = append(matches, candidate)
+	}
+	if len(matches) != 1 {
+		return ""
+	}
+	return matches[0].Path
+}
+
+func codexCandidateSortTime(candidate CodexSessionCandidate) time.Time {
+	if !candidate.StartedAt.IsZero() {
+		return candidate.StartedAt
+	}
+	return candidate.ModTime
+}
+
 // findCodexSessionFileIn searches a Codex sessions directory for the most
 // recent session matching workDir. Scans date directories in reverse
 // chronological order for efficiency. Also recurses into symlinked
@@ -1076,6 +1158,75 @@ func findCodexSessionFileIn(sessDir, workDir string) string {
 		}
 	}
 	return ""
+}
+
+func findCodexSessionCandidatesIn(sessDir, workDir string, seen map[string]bool) []CodexSessionCandidate {
+	if sessDir == "" {
+		return nil
+	}
+	cleaned := filepath.Clean(sessDir)
+	if seen[cleaned] {
+		return nil
+	}
+	seen[cleaned] = true
+	entries, err := os.ReadDir(cleaned)
+	if err != nil {
+		return nil
+	}
+
+	var candidates []CodexSessionCandidate
+	var yearDirs []string
+	var extraRoots []string
+	for _, e := range entries {
+		if !e.IsDir() && e.Type()&os.ModeSymlink == 0 {
+			continue
+		}
+		name := e.Name()
+		if len(name) == 4 && name >= "2000" && name <= "2099" {
+			yearDirs = append(yearDirs, name)
+		} else if e.Type()&os.ModeSymlink != 0 {
+			extraRoots = append(extraRoots, name)
+		}
+	}
+
+	for _, year := range yearDirs {
+		yearDir := filepath.Join(cleaned, year)
+		for _, month := range listDirsReverse(yearDir) {
+			monthDir := filepath.Join(yearDir, month)
+			for _, day := range listDirsReverse(monthDir) {
+				candidates = append(candidates, findCodexSessionCandidatesInDir(filepath.Join(monthDir, day), workDir)...)
+			}
+		}
+	}
+	for _, root := range extraRoots {
+		rootDir := filepath.Join(cleaned, root)
+		resolved, err := filepath.EvalSymlinks(rootDir)
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, findCodexSessionCandidatesIn(resolved, workDir, seen)...)
+	}
+	return candidates
+}
+
+func findCodexSessionCandidatesInDir(dir, workDir string) []CodexSessionCandidate {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var candidates []CodexSessionCandidate
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		candidate, ok := codexSessionCandidate(path)
+		if !ok || candidate.WorkDir != workDir {
+			continue
+		}
+		candidates = append(candidates, candidate)
+	}
+	return candidates
 }
 
 // scanYearDirs scans YYYY/MM/DD date tree for matching Codex sessions.
@@ -1140,30 +1291,70 @@ func findCodexSessionInDir(dir, workDir string) string {
 // extracts the cwd from the session_meta payload. Returns "" if the file
 // can't be read or doesn't contain a session_meta entry.
 func codexSessionCWD(path string) string {
+	candidate, ok := codexSessionCandidate(path)
+	if !ok {
+		return ""
+	}
+	return candidate.WorkDir
+}
+
+func codexSessionCandidate(path string) (CodexSessionCandidate, bool) {
 	f, err := os.Open(path)
 	if err != nil {
-		return ""
+		return CodexSessionCandidate{}, false
 	}
 	defer f.Close() //nolint:errcheck // read-only
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	if !scanner.Scan() {
-		return ""
+		return CodexSessionCandidate{}, false
 	}
 	var meta struct {
-		Type    string `json:"type"`
-		Payload struct {
-			CWD string `json:"cwd"`
+		Type      string `json:"type"`
+		Timestamp string `json:"timestamp"`
+		Payload   struct {
+			CWD       string `json:"cwd"`
+			ID        string `json:"id"`
+			Timestamp string `json:"timestamp"`
 		} `json:"payload"`
 	}
 	if err := json.Unmarshal(scanner.Bytes(), &meta); err != nil {
-		return ""
+		return CodexSessionCandidate{}, false
 	}
 	if meta.Type != "session_meta" {
-		return ""
+		return CodexSessionCandidate{}, false
 	}
-	return meta.Payload.CWD
+	info, _ := os.Stat(path)
+	var modTime time.Time
+	if info != nil {
+		modTime = info.ModTime()
+	}
+	startedAt := parseCodexSessionTime(meta.Payload.Timestamp)
+	if startedAt.IsZero() {
+		startedAt = parseCodexSessionTime(meta.Timestamp)
+	}
+	return CodexSessionCandidate{
+		Path:      path,
+		SessionID: strings.TrimSpace(meta.Payload.ID),
+		WorkDir:   meta.Payload.CWD,
+		StartedAt: startedAt,
+		ModTime:   modTime,
+	}, true
+}
+
+func parseCodexSessionTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return parsed
+	}
+	if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+		return parsed
+	}
+	return time.Time{}
 }
 
 // listDirsReverse returns directory names sorted in reverse lexicographic

--- a/internal/sessionlog/reader.go
+++ b/internal/sessionlog/reader.go
@@ -1035,44 +1035,87 @@ func startOfLocalDay(t time.Time) time.Time {
 // requested workdir.
 type CodexSessionCandidate struct {
 	Path      string
-	SessionID string
 	WorkDir   string
 	StartedAt time.Time
 	ModTime   time.Time
 }
 
-// FindCodexSessionCandidates returns Codex transcripts matching workDir,
-// newest first by transcript start time and then file modification time.
-func FindCodexSessionCandidates(searchPaths []string, workDir string) []CodexSessionCandidate {
+// FindCodexSessionFileByIDNoWindow resolves a Codex transcript by provider
+// session ID without a creation/wake window. Codex names rollouts
+// "rollout-<localtime>-<session-uuid>.jsonl", so the id keys the file by its
+// exact filename suffix. The scan walks date directories newest-first and
+// returns the first "rollout-*-<sessionID>.jsonl" whose session_meta cwd equals
+// workDir; only that matched transcript is opened, so cost scales with matches
+// rather than with total Codex history. A session id containing path separators
+// or ".." is rejected. Callers that have a creation/wake window should prefer
+// FindCodexSessionFileByID, which bounds the scan by date and refuses ambiguous
+// matches.
+func FindCodexSessionFileByIDNoWindow(searchPaths []string, workDir, sessionID string) string {
 	workDir = strings.TrimSpace(workDir)
-	if workDir == "" {
-		return nil
-	}
-	var candidates []CodexSessionCandidate
-	for _, root := range mergeCodexSearchPaths(searchPaths) {
-		candidates = append(candidates, findCodexSessionCandidatesIn(root, workDir, make(map[string]bool))...)
-	}
-	sort.Slice(candidates, func(i, j int) bool {
-		left := codexCandidateSortTime(candidates[i])
-		right := codexCandidateSortTime(candidates[j])
-		if left.Equal(right) {
-			return candidates[i].Path > candidates[j].Path
-		}
-		return left.After(right)
-	})
-	return candidates
-}
-
-// FindCodexSessionFileByIDFromCandidates resolves a Codex transcript by provider
-// session ID while still requiring the embedded cwd to match workDir.
-func FindCodexSessionFileByIDFromCandidates(searchPaths []string, workDir, sessionID string) string {
 	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" || strings.Contains(sessionID, "..") || strings.ContainsAny(sessionID, `/\`) {
+	if workDir == "" || sessionID == "" || strings.Contains(sessionID, "..") || strings.ContainsAny(sessionID, `/\`) {
 		return ""
 	}
-	for _, candidate := range FindCodexSessionCandidates(searchPaths, workDir) {
-		if candidate.SessionID == sessionID || strings.Contains(filepath.Base(candidate.Path), sessionID) {
-			return candidate.Path
+	suffix := "-" + sessionID + ".jsonl"
+	seen := make(map[string]bool)
+	for _, root := range mergeCodexSearchPaths(searchPaths) {
+		if path := findCodexRolloutBySuffixIn(root, workDir, suffix, seen); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+// findCodexRolloutBySuffixIn walks a Codex sessions directory newest-first and
+// returns the first "rollout-*<suffix>" transcript whose session_meta cwd
+// matches workDir. It recurses into symlinked non-date roots (aimux account
+// roots) like findCodexSessionFileIn, guarding against symlink cycles via seen.
+func findCodexRolloutBySuffixIn(sessDir, workDir, suffix string, seen map[string]bool) string {
+	cleaned := filepath.Clean(sessDir)
+	if seen[cleaned] {
+		return ""
+	}
+	seen[cleaned] = true
+	yearDirs, extraRoots := splitCodexSessionRoots(cleaned)
+	sort.Sort(sort.Reverse(sort.StringSlice(yearDirs)))
+	for _, year := range yearDirs {
+		yearDir := filepath.Join(cleaned, year)
+		for _, month := range listDirsReverse(yearDir) {
+			monthDir := filepath.Join(yearDir, month)
+			for _, day := range listDirsReverse(monthDir) {
+				if path := findCodexRolloutBySuffixInDir(filepath.Join(monthDir, day), workDir, suffix); path != "" {
+					return path
+				}
+			}
+		}
+	}
+	for _, root := range extraRoots {
+		resolved, err := filepath.EvalSymlinks(filepath.Join(cleaned, root))
+		if err != nil {
+			continue
+		}
+		if path := findCodexRolloutBySuffixIn(resolved, workDir, suffix, seen); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+// findCodexRolloutBySuffixInDir returns the first rollout in dir whose name
+// carries suffix and whose session_meta cwd matches workDir.
+func findCodexRolloutBySuffixInDir(dir, workDir, suffix string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, "rollout-") || !strings.HasSuffix(name, suffix) {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if codexSessionCWD(path) == workDir {
+			return path
 		}
 	}
 	return ""
@@ -1081,29 +1124,103 @@ func FindCodexSessionFileByIDFromCandidates(searchPaths []string, workDir, sessi
 // FindCodexSessionFileInTimeWindow resolves a Codex transcript whose metadata
 // start time uniquely falls inside [start, end). A zero end leaves the window
 // open-ended. If the window matches zero or multiple transcripts, it returns
-// empty to preserve same-workdir ambiguity guards.
+// empty to preserve same-workdir ambiguity guards. The disk scan is bounded to
+// the date directories overlapping the window (padded one day for local-time
+// skew) so cost scales with the window, not with total Codex history, and
+// physical duplicates reachable through more than one merged root are counted
+// once.
 func FindCodexSessionFileInTimeWindow(searchPaths []string, workDir string, start, end time.Time) string {
 	if start.IsZero() {
 		return ""
 	}
-	var matches []CodexSessionCandidate
-	for _, candidate := range FindCodexSessionCandidates(searchPaths, workDir) {
+	workDir = strings.TrimSpace(workDir)
+	if workDir == "" {
+		return ""
+	}
+	firstDay := startOfLocalDay(start.In(time.Local)).AddDate(0, 0, -1)
+	lastDay := startOfLocalDay(start.In(time.Local)).AddDate(0, 0, 1)
+	if !end.IsZero() {
+		lastDay = startOfLocalDay(end.In(time.Local)).AddDate(0, 0, 1)
+	}
+	if lastDay.Before(firstDay) {
+		return ""
+	}
+	var candidates []CodexSessionCandidate
+	seen := make(map[string]bool)
+	for _, root := range mergeCodexSearchPaths(searchPaths) {
+		collectCodexCandidatesInDays(root, workDir, firstDay, lastDay, true, seen, &candidates)
+	}
+	windowStart := start.Add(-2 * time.Second)
+	match := ""
+	for _, candidate := range candidates {
 		candidateTime := codexCandidateSortTime(candidate)
-		if candidateTime.IsZero() {
-			continue
-		}
-		if candidateTime.Before(start.Add(-2 * time.Second)) {
+		if candidateTime.IsZero() || candidateTime.Before(windowStart) {
 			continue
 		}
 		if !end.IsZero() && !candidateTime.Before(end) {
 			continue
 		}
-		matches = append(matches, candidate)
+		if match != "" {
+			return ""
+		}
+		match = candidate.Path
 	}
-	if len(matches) != 1 {
-		return ""
+	return match
+}
+
+// collectCodexCandidatesInDays appends Codex candidates matching workDir whose
+// date directory falls within [firstDay, lastDay], newest day first and capped
+// at codexByIDDayDirCap so an oversized range cannot become an unbounded sweep.
+// Physical duplicates (symlink aliases across merged roots) are dropped via
+// seen. followExtraRoots permits one level of recursion into symlinked non-date
+// roots, mirroring collectCodexRolloutsByID.
+func collectCodexCandidatesInDays(root, workDir string, firstDay, lastDay time.Time, followExtraRoots bool, seen map[string]bool, out *[]CodexSessionCandidate) {
+	scanned := 0
+	for day := lastDay; !day.Before(firstDay) && scanned < codexByIDDayDirCap; day = day.AddDate(0, 0, -1) {
+		scanned++
+		dayDir := filepath.Join(root, day.Format("2006"), day.Format("01"), day.Format("02"))
+		appendCodexCandidatesFromDir(dayDir, workDir, seen, out)
 	}
-	return matches[0].Path
+	if !followExtraRoots {
+		return
+	}
+	_, extraRoots := splitCodexSessionRoots(root)
+	for _, name := range extraRoots {
+		resolved, err := filepath.EvalSymlinks(filepath.Join(root, name))
+		if err != nil {
+			continue
+		}
+		collectCodexCandidatesInDays(resolved, workDir, firstDay, lastDay, false, seen, out)
+	}
+}
+
+// appendCodexCandidatesFromDir appends every Codex transcript in dir whose
+// session_meta cwd matches workDir, deduplicated by physical file identity via
+// seen so a rollout reachable through more than one root is counted once.
+func appendCodexCandidatesFromDir(dir, workDir string, seen map[string]bool, out *[]CodexSessionCandidate) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		key := path
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			key = resolved
+		}
+		if seen[key] {
+			continue
+		}
+		candidate, ok := codexSessionCandidate(path)
+		if !ok || candidate.WorkDir != workDir {
+			continue
+		}
+		seen[key] = true
+		*out = append(*out, candidate)
+	}
 }
 
 func codexCandidateSortTime(candidate CodexSessionCandidate) time.Time {
@@ -1113,19 +1230,15 @@ func codexCandidateSortTime(candidate CodexSessionCandidate) time.Time {
 	return candidate.ModTime
 }
 
-// findCodexSessionFileIn searches a Codex sessions directory for the most
-// recent session matching workDir. Scans date directories in reverse
-// chronological order for efficiency. Also recurses into symlinked
-// subdirectories that aren't date components (e.g., aimux session roots).
-func findCodexSessionFileIn(sessDir, workDir string) string {
-	entries, err := os.ReadDir(sessDir)
+// splitCodexSessionRoots reads a Codex sessions directory and separates
+// four-digit year directories (the YYYY/MM/DD date tree) from symlinked
+// non-date roots (aimux-managed account roots). Entries that are neither a
+// directory nor a symlink are ignored, and a read error yields empty slices.
+func splitCodexSessionRoots(dir string) (yearDirs, extraRoots []string) {
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return ""
+		return nil, nil
 	}
-
-	// Separate date-tree roots (YYYY dirs) from symlinked session roots.
-	var yearDirs []string
-	var extraRoots []string
 	for _, e := range entries {
 		if !e.IsDir() && e.Type()&os.ModeSymlink == 0 {
 			continue
@@ -1134,10 +1247,18 @@ func findCodexSessionFileIn(sessDir, workDir string) string {
 		if len(name) == 4 && name >= "2000" && name <= "2099" {
 			yearDirs = append(yearDirs, name)
 		} else if e.Type()&os.ModeSymlink != 0 {
-			// Symlinked directory — treat as an additional session root.
 			extraRoots = append(extraRoots, name)
 		}
 	}
+	return yearDirs, extraRoots
+}
+
+// findCodexSessionFileIn searches a Codex sessions directory for the most
+// recent session matching workDir. Scans date directories in reverse
+// chronological order for efficiency. Also recurses into symlinked
+// subdirectories that aren't date components (e.g., aimux session roots).
+func findCodexSessionFileIn(sessDir, workDir string) string {
+	yearDirs, extraRoots := splitCodexSessionRoots(sessDir)
 
 	// Scan year dirs in reverse chronological order.
 	sort.Sort(sort.Reverse(sort.StringSlice(yearDirs)))
@@ -1147,9 +1268,7 @@ func findCodexSessionFileIn(sessDir, workDir string) string {
 
 	// Scan symlinked session roots (aimux-managed accounts).
 	for _, root := range extraRoots {
-		rootDir := filepath.Join(sessDir, root)
-		// Resolve symlink to get the actual directory.
-		resolved, err := filepath.EvalSymlinks(rootDir)
+		resolved, err := filepath.EvalSymlinks(filepath.Join(sessDir, root))
 		if err != nil {
 			continue
 		}
@@ -1158,75 +1277,6 @@ func findCodexSessionFileIn(sessDir, workDir string) string {
 		}
 	}
 	return ""
-}
-
-func findCodexSessionCandidatesIn(sessDir, workDir string, seen map[string]bool) []CodexSessionCandidate {
-	if sessDir == "" {
-		return nil
-	}
-	cleaned := filepath.Clean(sessDir)
-	if seen[cleaned] {
-		return nil
-	}
-	seen[cleaned] = true
-	entries, err := os.ReadDir(cleaned)
-	if err != nil {
-		return nil
-	}
-
-	var candidates []CodexSessionCandidate
-	var yearDirs []string
-	var extraRoots []string
-	for _, e := range entries {
-		if !e.IsDir() && e.Type()&os.ModeSymlink == 0 {
-			continue
-		}
-		name := e.Name()
-		if len(name) == 4 && name >= "2000" && name <= "2099" {
-			yearDirs = append(yearDirs, name)
-		} else if e.Type()&os.ModeSymlink != 0 {
-			extraRoots = append(extraRoots, name)
-		}
-	}
-
-	for _, year := range yearDirs {
-		yearDir := filepath.Join(cleaned, year)
-		for _, month := range listDirsReverse(yearDir) {
-			monthDir := filepath.Join(yearDir, month)
-			for _, day := range listDirsReverse(monthDir) {
-				candidates = append(candidates, findCodexSessionCandidatesInDir(filepath.Join(monthDir, day), workDir)...)
-			}
-		}
-	}
-	for _, root := range extraRoots {
-		rootDir := filepath.Join(cleaned, root)
-		resolved, err := filepath.EvalSymlinks(rootDir)
-		if err != nil {
-			continue
-		}
-		candidates = append(candidates, findCodexSessionCandidatesIn(resolved, workDir, seen)...)
-	}
-	return candidates
-}
-
-func findCodexSessionCandidatesInDir(dir, workDir string) []CodexSessionCandidate {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	var candidates []CodexSessionCandidate
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
-			continue
-		}
-		path := filepath.Join(dir, e.Name())
-		candidate, ok := codexSessionCandidate(path)
-		if !ok || candidate.WorkDir != workDir {
-			continue
-		}
-		candidates = append(candidates, candidate)
-	}
-	return candidates
 }
 
 // scanYearDirs scans YYYY/MM/DD date tree for matching Codex sessions.
@@ -1315,7 +1365,6 @@ func codexSessionCandidate(path string) (CodexSessionCandidate, bool) {
 		Timestamp string `json:"timestamp"`
 		Payload   struct {
 			CWD       string `json:"cwd"`
-			ID        string `json:"id"`
 			Timestamp string `json:"timestamp"`
 		} `json:"payload"`
 	}
@@ -1336,7 +1385,6 @@ func codexSessionCandidate(path string) (CodexSessionCandidate, bool) {
 	}
 	return CodexSessionCandidate{
 		Path:      path,
-		SessionID: strings.TrimSpace(meta.Payload.ID),
 		WorkDir:   meta.Payload.CWD,
 		StartedAt: startedAt,
 		ModTime:   modTime,

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -1710,6 +1710,53 @@ func TestFindCodexSessionFileUsesObservedRoots(t *testing.T) {
 	}
 }
 
+func TestFindCodexSessionFileByIDUsesSessionMetaID(t *testing.T) {
+	sessDir := t.TempDir()
+	workDir := "/data/projects/myproject"
+	dayDir := filepath.Join(sessDir, "2026", "05", "19")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	targetID := "019e3e8e-3591-7532-a1ef-8b9e882bea2f"
+	targetFile := filepath.Join(dayDir, "rollout-target.jsonl")
+	targetMeta := fmt.Sprintf(`{"timestamp":"2026-05-19T04:46:07.848Z","type":"session_meta","payload":{"id":%q,"timestamp":"2026-05-19T04:46:07.761Z","cwd":%q}}`, targetID, workDir)
+	if err := os.WriteFile(targetFile, []byte(targetMeta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	otherFile := filepath.Join(dayDir, "rollout-other.jsonl")
+	otherMeta := fmt.Sprintf(`{"timestamp":"2026-05-19T04:47:07.848Z","type":"session_meta","payload":{"id":"019e3e8e-ffff-7000-a1ef-8b9e882bea2f","cwd":%q}}`, workDir)
+	if err := os.WriteFile(otherFile, []byte(otherMeta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindCodexSessionFileByIDFromCandidates([]string{sessDir}, workDir, targetID); got != targetFile {
+		t.Fatalf("FindCodexSessionFileByIDFromCandidates() = %q, want %q", got, targetFile)
+	}
+}
+
+func TestFindCodexSessionFileInTimeWindowRequiresUniqueMatch(t *testing.T) {
+	sessDir := t.TempDir()
+	workDir := "/data/projects/myproject"
+	dayDir := filepath.Join(sessDir, "2026", "05", "19")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Date(2026, 5, 19, 4, 46, 0, 0, time.UTC)
+	for _, name := range []string{"rollout-one.jsonl", "rollout-two.jsonl"} {
+		path := filepath.Join(dayDir, name)
+		meta := fmt.Sprintf(`{"timestamp":"2026-05-19T04:46:07Z","type":"session_meta","payload":{"cwd":%q}}`, workDir)
+		if err := os.WriteFile(path, []byte(meta+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := FindCodexSessionFileInTimeWindow([]string{sessDir}, workDir, start, start.Add(time.Minute)); got != "" {
+		t.Fatalf("FindCodexSessionFileInTimeWindow() = %q, want empty for non-unique window", got)
+	}
+}
+
 func TestCodexSessionCWD(t *testing.T) {
 	dir := t.TempDir()
 	f := filepath.Join(dir, "test.jsonl")

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -1710,7 +1710,7 @@ func TestFindCodexSessionFileUsesObservedRoots(t *testing.T) {
 	}
 }
 
-func TestFindCodexSessionFileByIDUsesSessionMetaID(t *testing.T) {
+func TestFindCodexSessionFileByIDNoWindowMatchesRolloutSuffix(t *testing.T) {
 	sessDir := t.TempDir()
 	workDir := "/data/projects/myproject"
 	dayDir := filepath.Join(sessDir, "2026", "05", "19")
@@ -1719,19 +1719,53 @@ func TestFindCodexSessionFileByIDUsesSessionMetaID(t *testing.T) {
 	}
 
 	targetID := "019e3e8e-3591-7532-a1ef-8b9e882bea2f"
-	targetFile := filepath.Join(dayDir, "rollout-target.jsonl")
-	targetMeta := fmt.Sprintf(`{"timestamp":"2026-05-19T04:46:07.848Z","type":"session_meta","payload":{"id":%q,"timestamp":"2026-05-19T04:46:07.761Z","cwd":%q}}`, targetID, workDir)
+	targetFile := filepath.Join(dayDir, "rollout-2026-05-19T04-46-07-"+targetID+".jsonl")
+	targetMeta := fmt.Sprintf(`{"timestamp":"2026-05-19T04:46:07.848Z","type":"session_meta","payload":{"id":%q,"cwd":%q}}`, targetID, workDir)
 	if err := os.WriteFile(targetFile, []byte(targetMeta+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	otherFile := filepath.Join(dayDir, "rollout-other.jsonl")
-	otherMeta := fmt.Sprintf(`{"timestamp":"2026-05-19T04:47:07.848Z","type":"session_meta","payload":{"id":"019e3e8e-ffff-7000-a1ef-8b9e882bea2f","cwd":%q}}`, workDir)
+	otherID := "019e3e8e-ffff-7000-a1ef-8b9e882bea2f"
+	otherFile := filepath.Join(dayDir, "rollout-2026-05-19T04-47-07-"+otherID+".jsonl")
+	otherMeta := fmt.Sprintf(`{"timestamp":"2026-05-19T04:47:07.848Z","type":"session_meta","payload":{"id":%q,"cwd":%q}}`, otherID, workDir)
 	if err := os.WriteFile(otherFile, []byte(otherMeta+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	if got := FindCodexSessionFileByIDFromCandidates([]string{sessDir}, workDir, targetID); got != targetFile {
-		t.Fatalf("FindCodexSessionFileByIDFromCandidates() = %q, want %q", got, targetFile)
+	if got := FindCodexSessionFileByIDNoWindow([]string{sessDir}, workDir, targetID); got != targetFile {
+		t.Fatalf("FindCodexSessionFileByIDNoWindow() = %q, want %q", got, targetFile)
+	}
+	// A workDir mismatch must refuse attribution even when the id suffix matches.
+	if got := FindCodexSessionFileByIDNoWindow([]string{sessDir}, "/data/projects/other", targetID); got != "" {
+		t.Fatalf("FindCodexSessionFileByIDNoWindow(other workDir) = %q, want empty", got)
+	}
+}
+
+func TestFindCodexSessionFileByIDNoWindowRejectsSubstringKey(t *testing.T) {
+	sessDir := t.TempDir()
+	workDir := "/data/projects/myproject"
+	dayDir := filepath.Join(sessDir, "2026", "05", "19")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fullID := "019e3e8e-3591-7532-a1ef-8b9e882bea2f"
+	// The id appears as a substring in these filenames but never as the exact
+	// "-<id>.jsonl" suffix, so the keyed lookup must refuse both.
+	prefixFile := filepath.Join(dayDir, "rollout-2026-05-19T04-46-07-"+fullID+"-resumed.jsonl")
+	meta := fmt.Sprintf(`{"timestamp":"2026-05-19T04:46:07.848Z","type":"session_meta","payload":{"cwd":%q}}`, workDir)
+	if err := os.WriteFile(prefixFile, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A truncated key is a substring of the real filename suffix; the old
+	// strings.Contains matcher would have accepted it, the suffix matcher must not.
+	truncated := fullID[:len(fullID)-4]
+	if got := FindCodexSessionFileByIDNoWindow([]string{sessDir}, workDir, truncated); got != "" {
+		t.Fatalf("FindCodexSessionFileByIDNoWindow(truncated) = %q, want empty (no substring match)", got)
+	}
+	// The full id is present but only as a non-suffix substring; still no match.
+	if got := FindCodexSessionFileByIDNoWindow([]string{sessDir}, workDir, fullID); got != "" {
+		t.Fatalf("FindCodexSessionFileByIDNoWindow(non-suffix substring) = %q, want empty", got)
 	}
 }
 
@@ -1754,6 +1788,34 @@ func TestFindCodexSessionFileInTimeWindowRequiresUniqueMatch(t *testing.T) {
 
 	if got := FindCodexSessionFileInTimeWindow([]string{sessDir}, workDir, start, start.Add(time.Minute)); got != "" {
 		t.Fatalf("FindCodexSessionFileInTimeWindow() = %q, want empty for non-unique window", got)
+	}
+}
+
+func TestFindCodexSessionFileInTimeWindowDedupsSymlinkAliasRoots(t *testing.T) {
+	base := t.TempDir()
+	workDir := "/data/projects/myproject"
+	dayDir := filepath.Join(base, "2026", "05", "19")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Date(2026, 5, 19, 4, 46, 7, 0, time.UTC)
+	rollout := filepath.Join(dayDir, "rollout-2026-05-19T04-46-07-019e3e8e-3591-7532-a1ef-8b9e882bea2f.jsonl")
+	meta := fmt.Sprintf(`{"timestamp":%q,"type":"session_meta","payload":{"cwd":%q}}`, start.Format(time.RFC3339), workDir)
+	if err := os.WriteFile(rollout, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A symlinked "account root" that resolves back into base, so the single
+	// physical rollout is reachable via both the direct date tree and the
+	// symlinked root. Without physical-identity dedup it is counted twice and
+	// the uniqueness gate wrongly collapses the window to empty.
+	if err := os.Symlink(base, filepath.Join(base, "account-alias")); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	if got := FindCodexSessionFileInTimeWindow([]string{base}, workDir, start, time.Time{}); got != rollout {
+		t.Fatalf("FindCodexSessionFileInTimeWindow() = %q, want %q (symlink alias must not double-count)", got, rollout)
 	}
 }
 

--- a/internal/worker/handle_transcriptmeta_test.go
+++ b/internal/worker/handle_transcriptmeta_test.go
@@ -179,6 +179,97 @@ func TestSessionHandleWritesCodexSidecarByID(t *testing.T) {
 	}
 }
 
+// TestSessionHandleCodexSidecarIgnoresOutOfWindowDuplicate is the 1:1 attribution
+// guard for codex: KeyedTranscriptPath (the sidecar path) must resolve the codex
+// rollout by the window-bounded, ambiguity-refusing lookup (FindCodexSessionFileByID),
+// NOT by the newest-first no-window resolver that history rendering uses. When a
+// copied or stale duplicate rollout carries the same session uuid + workdir but
+// sits outside the session's creation/wake window, the newest-wins resolver would
+// stamp this session's id onto that newer duplicate — a silent misattribution that
+// breaks writeTranscriptSessionMeta's documented 1:1 mapping. The sidecar must land
+// on the in-window rollout and leave the out-of-window duplicate untouched.
+func TestSessionHandleCodexSidecarIgnoresOutOfWindowDuplicate(t *testing.T) {
+	transcriptmeta.SetEnabled(true)
+	t.Cleanup(func() { transcriptmeta.SetEnabled(false) })
+
+	const (
+		workDir = "/work/codex-dup"
+		uuid    = "019e9966-cccc-7000-8000-26a2dd7e15b3" // synthetic; never collides with a real rollout
+	)
+	root := t.TempDir()
+
+	// writeRollout drops a codex rollout named "rollout-<localtime>-<uuid>.jsonl"
+	// under YYYY/MM/DD for ts, with session_meta cwd == workDir so both resolvers
+	// would consider it. Returns the rollout path.
+	writeRollout := func(ts time.Time) string {
+		t.Helper()
+		local := ts.In(time.Local)
+		dir := filepath.Join(root, local.Format("2006"), local.Format("01"), local.Format("02"))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		rollout := filepath.Join(dir, "rollout-"+local.Format("2006-01-02T15-04-05")+"-"+uuid+".jsonl")
+		meta := fmt.Sprintf(`{"timestamp":%q,"type":"session_meta","payload":{"id":%q,"timestamp":%q,"cwd":%q,"originator":"codex-tui","cli_version":"0.121.0","source":"cli","model_provider":"openai"}}`+"\n",
+			ts.UTC().Format(time.RFC3339Nano), uuid, ts.UTC().Format(time.RFC3339Nano), workDir)
+		if err := os.WriteFile(rollout, []byte(meta), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return rollout
+	}
+
+	now := time.Now()
+	// The legit rollout is created ~now, inside the started session's
+	// [CreatedAt-1day, wake+1day] window (a fresh test session's CreatedAt is now).
+	inWindow := writeRollout(now)
+	// A copied/stale duplicate with the SAME uuid + workdir, dated well past the
+	// window and NEWER than the legit rollout, so the newest-first no-window
+	// resolver would prefer it. The window-bounded lookup must never scan its day.
+	outOfWindow := writeRollout(now.AddDate(0, 0, 5))
+
+	handle, _, _, manager := newTestSessionHandle(t, SessionSpec{
+		Profile:  ProfileCodexTmuxCLI,
+		Template: "probe",
+		Title:    "Probe",
+		Command:  "codex",
+		WorkDir:  workDir,
+		Provider: "codex",
+	})
+	handle.adapter.SearchPaths = []string{root}
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	id := handle.currentSessionID()
+	// Stamp the codex session_key (production stamps it from the SessionStart hook).
+	if err := manager.PersistSessionKey(id, uuid); err != nil {
+		t.Fatalf("PersistSessionKey: %v", err)
+	}
+
+	// KeyedTranscriptPath must resolve to the in-window rollout, not the newer
+	// out-of-window duplicate the newest-wins resolver would return.
+	got, err := manager.KeyedTranscriptPath(id, []string{root})
+	if err != nil {
+		t.Fatalf("KeyedTranscriptPath: %v", err)
+	}
+	if got != inWindow {
+		t.Fatalf("KeyedTranscriptPath = %q, want in-window rollout %q (out-of-window duplicate %q must be ignored)", got, inWindow, outOfWindow)
+	}
+
+	handle.writeTranscriptSessionMeta()
+
+	// The sidecar lands on the in-window rollout and carries the session bead id.
+	sidecar, err := os.ReadFile(inWindow + transcriptmeta.Suffix)
+	if err != nil {
+		t.Fatalf("read in-window sidecar: %v", err)
+	}
+	if strings.TrimSpace(string(sidecar)) != id {
+		t.Fatalf("in-window sidecar = %q, want session bead id %q", strings.TrimSpace(string(sidecar)), id)
+	}
+	// The out-of-window duplicate must be left untouched — no misattributed sidecar.
+	if _, err := os.Stat(outOfWindow + transcriptmeta.Suffix); !os.IsNotExist(err) {
+		t.Fatalf("out-of-window duplicate got a sidecar (misattribution); stat err = %v", err)
+	}
+}
+
 // TestSessionHandleSkipsSidecarForWorkdirOnlyProvider is the HIGH-finding guard:
 // gemini (like opencode/mimocode) has no 1:1 by-id transcript lookup, so even
 // with a session key present KeyedTranscriptPath returns "" and no sidecar is

--- a/internal/worker/transcript/discovery.go
+++ b/internal/worker/transcript/discovery.go
@@ -3,6 +3,7 @@ package transcript
 
 import (
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/sessionlog"
 )
@@ -35,10 +36,12 @@ func DiscoverPath(searchPaths []string, provider, workDir, gcSessionID string) s
 
 // DiscoverKeyedPath resolves only the session-id-based transcript path.
 func DiscoverKeyedPath(searchPaths []string, provider, workDir, gcSessionID string) string {
-	if strings.TrimSpace(gcSessionID) == "" || !SupportsIDLookup(provider) {
+	if strings.TrimSpace(gcSessionID) == "" {
 		return ""
 	}
 	switch sessionlog.ProviderFamily(provider) {
+	case "codex":
+		return sessionlog.FindCodexSessionFileByIDFromCandidates(searchPaths, workDir, gcSessionID)
 	case "kimi":
 		return sessionlog.FindKimiSessionFileByID(searchPaths, workDir, gcSessionID)
 	case "pi":
@@ -46,7 +49,16 @@ func DiscoverKeyedPath(searchPaths []string, provider, workDir, gcSessionID stri
 	case "antigravity":
 		return sessionlog.FindAntigravitySessionFileByID(searchPaths, workDir, gcSessionID)
 	}
+	if !SupportsIDLookup(provider) {
+		return ""
+	}
 	return sessionlog.FindSessionFileByID(searchPaths, workDir, gcSessionID)
+}
+
+// DiscoverCodexPathInTimeWindow resolves a Codex transcript whose metadata
+// timestamp uniquely matches the supplied session-start window.
+func DiscoverCodexPathInTimeWindow(searchPaths []string, workDir string, start, end time.Time) string {
+	return sessionlog.FindCodexSessionFileInTimeWindow(searchPaths, workDir, start, end)
 }
 
 // DiscoverFallbackPath resolves the narrow provider-specific fallback path to

--- a/internal/worker/transcript/discovery.go
+++ b/internal/worker/transcript/discovery.go
@@ -41,7 +41,7 @@ func DiscoverKeyedPath(searchPaths []string, provider, workDir, gcSessionID stri
 	}
 	switch sessionlog.ProviderFamily(provider) {
 	case "codex":
-		return sessionlog.FindCodexSessionFileByIDFromCandidates(searchPaths, workDir, gcSessionID)
+		return sessionlog.FindCodexSessionFileByIDNoWindow(searchPaths, workDir, gcSessionID)
 	case "kimi":
 		return sessionlog.FindKimiSessionFileByID(searchPaths, workDir, gcSessionID)
 	case "pi":

--- a/internal/worker/transcript/discovery_test.go
+++ b/internal/worker/transcript/discovery_test.go
@@ -132,6 +132,53 @@ func TestDiscoverPathCodexIgnoresGCSessionID(t *testing.T) {
 	}
 }
 
+func TestDiscoverPathCodexPrefersProviderSessionID(t *testing.T) {
+	base := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "codex-project")
+	codexDir := filepath.Join(base, "2026", "05", "19")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	targetID := "019e3e8e-3591-7532-a1ef-8b9e882bea2f"
+	targetPayload, err := json.Marshal(map[string]any{
+		"timestamp": "2026-05-19T04:46:07.848Z",
+		"type":      "session_meta",
+		"payload": map[string]string{
+			"id":  targetID,
+			"cwd": workDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetPath := filepath.Join(codexDir, "rollout-target.jsonl")
+	if err := os.WriteFile(targetPath, append(targetPayload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	newerPayload, err := json.Marshal(map[string]any{
+		"timestamp": "2026-05-19T05:46:07.848Z",
+		"type":      "session_meta",
+		"payload": map[string]string{
+			"id":  "019e3e8e-ffff-7000-a1ef-8b9e882bea2f",
+			"cwd": workDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newerPath := filepath.Join(codexDir, "rollout-newer.jsonl")
+	if err := os.WriteFile(newerPath, append(newerPayload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := DiscoverPath([]string{base}, "codex/tmux-cli", workDir, targetID)
+	if got != targetPath {
+		t.Fatalf("DiscoverPath() = %q, want keyed Codex transcript %q", got, targetPath)
+	}
+}
+
 func TestDiscoverPathKimiPrefersSessionKey(t *testing.T) {
 	base := t.TempDir()
 	workDir := "/tmp/gascity/phase1/kimi"

--- a/internal/worker/transcript/discovery_test.go
+++ b/internal/worker/transcript/discovery_test.go
@@ -152,23 +152,24 @@ func TestDiscoverPathCodexPrefersProviderSessionID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetPath := filepath.Join(codexDir, "rollout-target.jsonl")
+	targetPath := filepath.Join(codexDir, "rollout-2026-05-19T04-46-07-"+targetID+".jsonl")
 	if err := os.WriteFile(targetPath, append(targetPayload, '\n'), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
+	newerID := "019e3e8e-ffff-7000-a1ef-8b9e882bea2f"
 	newerPayload, err := json.Marshal(map[string]any{
 		"timestamp": "2026-05-19T05:46:07.848Z",
 		"type":      "session_meta",
 		"payload": map[string]string{
-			"id":  "019e3e8e-ffff-7000-a1ef-8b9e882bea2f",
+			"id":  newerID,
 			"cwd": workDir,
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	newerPath := filepath.Join(codexDir, "rollout-newer.jsonl")
+	newerPath := filepath.Join(codexDir, "rollout-2026-05-19T05-46-07-"+newerID+".jsonl")
 	if err := os.WriteFile(newerPath, append(newerPayload, '\n'), 0o644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What

Resolves Codex transcript fallback by **session order** when multiple Codex
sessions share the same working directory (shared-workdir siblings). When two
or more Codex sessions run against the same `work_dir`, the prior transcript
lookup could not disambiguate which `.jsonl` transcript belonged to which
session, producing wrong-transcript fallbacks. This change adds
`session.ResolveCodexTranscriptBySessionOrder`, which anchors each session by
its wake/start timestamp and maps a target session to a transcript only when
that transcript is uniquely contained in the target's start window —
preserving ambiguity (returning empty) for underspecified groups rather than
guessing.

Plumbing threads the resolver through `cmd/gc/cmd_session_logs.go`,
`internal/session/chat.go`, the `internal/sessionlog` reader, and the
`internal/worker/transcript` discovery path, with tests covering the
shared-workdir ordering, the unique-window requirement, and the
ambiguity-preserving negative cases.

## Why this is a clean, store-backend-agnostic extraction

This is a self-contained slice extracted from the local sqlite deploy branch
`deploy/sqlite-b36-probe-attribution` and lifted onto `main` ahead of the
beads interface refactor and the sqlite-behind-interfaces swap. It is
**store-backend-agnostic**: the resolver operates purely over `[]beads.Bead`
and the existing `sessionlog` / `worker/transcript` abstractions. It pulls in
**zero** sqlite, graph-store, coordrouter, or bd-shim-HTTP code, so it merges
cleanly today and does not need to wait on the interface work.

## Verification

- `go build ./internal/session/ ./cmd/gc/` — passes
- `go vet ./internal/session/ ./cmd/gc/` — passes
- Diff vs `main` contains only the 10 slice files; no sqlite/graph-store paths

Generated with Claude Code.
