### PR TITLE
fix(beads): tolerate closed-row ready-projection races (unfiltered is_blocked projection)

### DIFF
--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -99,8 +99,11 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 		return result, nil
 	}
 
-	// bd exposes this as a full active-row projection. The ids argument is a
-	// cache-side allow-list so callers can keep their requested surface bounded.
+	// bd exposes this as a full unfiltered row projection across issues and
+	// wisps; selecting closed rows too lets the cache tolerate ready-projection
+	// races where a row closes between the list query and this SQL fetch. The
+	// ids argument is a cache-side allow-list so callers can keep their
+	// requested surface bounded.
 	out, err := s.runner(s.dir, "bd", "sql", readyProjectionSQL(), "--json")
 	if err != nil {
 		return nil, fmt.Errorf("bd sql ready projection: %w", err)
@@ -122,5 +125,5 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 }
 
 func readyProjectionSQL() string {
-	return "select id,is_blocked from issues where status <> 'closed' union all select id,is_blocked from wisps where status <> 'closed'"
+	return "select id,is_blocked from issues union all select id,is_blocked from wisps"
 }

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3317,8 +3317,8 @@ func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
 			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
 				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
 			}
-			if !strings.Contains(query, "status <> 'closed'") || !strings.Contains(query, "from issues where") || !strings.Contains(query, "from wisps where") {
-				t.Fatalf("ready projection SQL = %q, want active row projection", query)
+			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
+				t.Fatalf("ready projection SQL = %q, want unfiltered row projection", query)
 			}
 			return []byte(`[
 					{"id":"bd-ready","is_blocked":0},
@@ -3620,8 +3620,8 @@ func TestCachingStoreBdPrimeActiveToleratesMissingReadyProjectionRowsBD105(t *te
 		case "sql":
 			sqlCalls++
 			query := args[1]
-			if !strings.Contains(query, "status <> 'closed'") {
-				t.Fatalf("ready projection SQL = %q, want active row filter", query)
+			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
+				t.Fatalf("ready projection SQL = %q, want unfiltered row projection", query)
 			}
 			return []byte(`[
 				{"id":"bd-ready","is_blocked":0}
@@ -3693,13 +3693,13 @@ func TestCachingStoreBdPrimeProjectsIsBlockedForAllBDRowsBD105(t *testing.T) {
 			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
 				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
 			}
-			if !strings.Contains(query, "status <> 'closed'") || !strings.Contains(query, "from issues where") || !strings.Contains(query, "from wisps where") {
-				t.Fatalf("ready projection SQL = %q, want every active row", query)
+			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
+				t.Fatalf("ready projection SQL = %q, want every row", query)
 			}
 			return []byte(`[
 					{"id":"bd-ready","is_blocked":0},
 					{"id":"bd-blocked-status","is_blocked":0},
-				{"id":"bd-deferred-status","is_blocked":1}
+					{"id":"bd-deferred-status","is_blocked":1}
 			]`), nil
 		case "list":
 			return []byte(`[


### PR DESCRIPTION
## What

`readyProjectionSQL()` in `internal/beads/bdstore_ready_projection.go`
previously filtered to `status <> 'closed'` on both the `issues` and
`wisps` tables:

```sql
select id,is_blocked from issues where status <> 'closed'
union all
select id,is_blocked from wisps where status <> 'closed'
```

This change drops the status filter so the projection selects every row,
unfiltered:

```sql
select id,is_blocked from issues
union all
select id,is_blocked from wisps
```

## Why

The `BdStore` ready-projection enriches the `CachingStore` view with bd's
denormalized `is_blocked` column. A row can transition to `closed` between
the CachingStore list query and this follow-up SQL fetch. With the
`status <> 'closed'` filter in place, the just-closed row drops out of the
projection, so the cache never observes its final `is_blocked` state and the
reconcile diff cannot converge. Selecting all rows (the unfiltered union)
lets the projection tolerate these closed-row races; the cache-side
allow-list still bounds the requested surface, so the wider `SELECT` does not
widen what the caller actually consumes.

The three `TestCachingStoreBdPrime*BD105` cases are updated to assert the
unfiltered projection shape (no `status` predicate, `from issues union all`).

## Provenance / upstreaming

This is a clean, **store-backend-agnostic** change extracted from the local
sqlite deploy branch (`deploy/sqlite-b36-probe-attribution`) and rebased onto
`main`. It touches only the Dolt-backed `BdStore` ready-projection SQL and its
tests — it does **not** pull in any sqlite graph-store, coordrouter, or
bd-shim/HTTP code from that branch. The three-commit chain on the deploy
branch (active-row → non-closed → unfiltered) is squashed here to its net end
state. Upstreaming it to `main` now keeps it ahead of the interface refactor
and the later sqlite-behind-interfaces swap, so it can ride on whichever store
backend is wired in.

Generated with Claude Code.
