### PR TITLE
perf(beads,api): batch graph child fan-out via ListQuery.ParentIDs

### DIFF
--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -394,23 +394,44 @@ func collectBeadGraph(store beads.Store, root beads.Bead) ([]beads.Bead, []workf
 		parentEdges = append(parentEdges, edge)
 	}
 
-	for i := 0; i < len(graphBeads); i++ {
-		parent := graphBeads[i]
+	// Discover parent-linked descendants and their parent-child edges by walking
+	// the tree one BFS level at a time, fetching each level's children with a
+	// single batched store.List(ParentIDs=...) call. This replaces the former
+	// per-bead store.List(ParentID=...) fan-out — an N+1 (one round-trip per bead)
+	// that serialized on a single read connection and dominated graph-read latency
+	// under load. The returned beads are filtered in memory against the level's
+	// parent set, so the result is correct even on a backend that does not honor
+	// ParentIDs (such a backend returns a superset, which the filter narrows).
+	frontier := make([]string, 0, len(graphBeads))
+	for _, b := range graphBeads {
+		frontier = append(frontier, b.ID)
+	}
+	for len(frontier) > 0 {
+		frontierSet := make(map[string]bool, len(frontier))
+		for _, id := range frontier {
+			frontierSet[id] = true
+		}
 		children, err := store.List(beads.ListQuery{
-			ParentID:      parent.ID,
+			ParentIDs:     frontier,
 			IncludeClosed: true,
+			AllowScan:     true,
 			Sort:          beads.SortCreatedAsc,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("listing child beads for bead %q: %w", parent.ID, err)
+			return nil, nil, fmt.Errorf("listing child beads for graph %q: %w", root.ID, err)
 		}
+		var next []string
 		for _, child := range children {
-			if child.ParentID == "" {
-				child.ParentID = parent.ID
+			if !frontierSet[child.ParentID] {
+				continue
 			}
-			addParentEdge(parent.ID, child.ID)
-			upsert(child)
+			addParentEdge(child.ParentID, child.ID)
+			if _, seen := beadIndex[child.ID]; !seen {
+				upsert(child)
+				next = append(next, child.ID)
+			}
 		}
+		frontier = next
 	}
 
 	return graphBeads, parentEdges, nil

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -70,8 +70,13 @@ type ListQuery struct {
 	Assignee string
 	// Assignees matches beads assigned to any listed assignee.
 	// It is mutually exclusive with Assignee; call Validate to enforce that contract.
-	Assignees     []string
-	ParentID      string
+	Assignees []string
+	ParentID  string
+	// ParentIDs matches beads whose parent_id is any of the listed ids — a
+	// batched form of ParentID for graph/subtree walks. Backends that do not
+	// recognize it should ignore it (returning a superset); callers that need
+	// exact results must filter the returned beads by parent in memory.
+	ParentIDs     []string
 	Metadata      map[string]string
 	CreatedBefore time.Time
 	// UpdatedBefore matches beads whose UpdatedAt is before this timestamp.


### PR DESCRIPTION
## What

This is a clean, **store-backend-agnostic** change extracted from the local SQLite deploy branch (`deploy/sqlite-b36-probe-attribution`, commit `17d65a628`) for upstreaming to `main` ahead of the store-interface refactor and the sqlite-behind-interfaces swap. Landing the generic half now keeps `main` ready for those changes and avoids a later entangled merge.

The source commit `17d65a628` mixed a backend-agnostic optimization with a SQLite-specific query implementation. This PR carries **only the generic half** — the `internal/beads/sqlite_store.go` hunk (the `parent_id IN (...)` SQL and the metadata-filter `EXISTS` → `IN (SELECT …)` rewrite) is intentionally **dropped**; it belongs with the sqlite store and will ride the interface work.

## Why (slice rationale)

The bead-graph endpoint discovered parent-linked descendants by fanning out one `store.List(ParentID=…)` per known bead — an N+1 (one round-trip per bead) that serialized on a single read connection and dominated graph-read latency under load, surfacing as "empty under load" graph reads that stalled PR-review molecules.

## Change

- **`internal/beads/query.go`** — add `ListQuery.ParentIDs`, a batched form of `ParentID` for graph/subtree walks. It is a pure selector field; backends that do not recognize it ignore it (returning a superset), and exact-match callers filter in memory.
- **`internal/api/handler_beads.go`** — rewrite `collectBeadGraph` to walk the tree one BFS level at a time, fetching each level's children with a single batched `store.List(ParentIDs=…)` call (with `AllowScan: true`), then filtering the returned beads against the level's parent set in memory.

Both halves are backend-agnostic and filter in memory, so the result is correct on any `beads.Store` — including stores that do not honor `ParentIDs`.

## Verification

- `go build ./internal/beads/ ./internal/api/ ./cmd/gc/` — clean
- `go vet ./internal/beads/ ./internal/api/ ./cmd/gc/` — clean
- `go test ./internal/beads/` and the graph-related `./internal/api/` tests — pass
- Diff vs `main` touches only `internal/beads/query.go` and `internal/api/handler_beads.go` — no sqlite/graph-store/HTTP-shim code.

Generated with Claude Code.