### PR TITLE
fix(dispatch): serve control-ready from the supervisor cache instead of shelling bd ready

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,15 @@
 # assets, and collapse it in review UIs. Drift is still caught by the content-based
 # `git diff --quiet -- internal/api/dashboardspa/dist` gate in the Makefile.
 internal/api/dashboardspa/dist/** -diff linguist-generated
+
+# internal/api/genclient/client_gen.go is emitted by oapi-codegen from
+# internal/api/openapi.json (it carries the `DO NOT EDIT` generated marker).
+# Its branch structure is a mechanical projection of the spec, not hand-written
+# logic, so treat it as generated output: skip textual diffing and the
+# whitespace lint (`git diff --check`), and collapse it in review UIs. This also
+# keeps the per-changed-function complexity gate (scripts/complexity_report.py,
+# which reads `git diff -U0` hunks) from scoring generated request builders as
+# manually maintainable branch logic. Drift is still caught by the content-based
+# `git diff --quiet -- internal/api/genclient/client_gen.go` gate in the Makefile
+# (`make spec-ci`) and by TestGeneratedClientInSync.
+internal/api/genclient/client_gen.go -diff linguist-generated

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -59,6 +59,10 @@ func (s *readyStaticStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
 	return out, nil
 }
 
+func (s *readyStaticStore) ReadyCacheOnly(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return s.Ready(query...)
+}
+
 type controllerDemandHandlesStore struct {
 	beads.Store
 	handles beads.StoreHandles

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"maps"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -15,6 +18,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -3057,6 +3061,7 @@ func TestControlDispatcherBareRoute(t *testing.T) {
 }
 
 func TestFilterWorkflowServeControlReadyBeadsPreservesPriorityAndPredicates(t *testing.T) {
+	clearGCEnv(t)
 	spec := workflowServeControlReadySpec{
 		Target:             "gascity/control-dispatcher",
 		ControlSessionName: "gascity--control-dispatcher",
@@ -3095,6 +3100,7 @@ func TestFilterWorkflowServeControlReadyBeadsPreservesPriorityAndPredicates(t *t
 }
 
 func TestWorkflowServeControlReadyAssigneesPrioritizeConfiguredRuntimeName(t *testing.T) {
+	clearGCEnv(t)
 	spec := workflowServeControlReadySpec{
 		Target:             "gascity/control-dispatcher",
 		ControlSessionName: "gascity--control-dispatcher",
@@ -3111,11 +3117,262 @@ func TestWorkflowServeControlReadyAssigneesPrioritizeConfiguredRuntimeName(t *te
 }
 
 func TestNextWorkflowServeBeadsRejectsControlReadyWithoutSupervisorAPI(t *testing.T) {
+	clearGCEnv(t)
 	cityDir := t.TempDir()
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
 	_, err := nextWorkflowServeBeads(query, cityDir, map[string]string{"GC_CITY_PATH": cityDir})
 	if err == nil || !strings.Contains(err.Error(), "requires supervisor API") {
 		t.Fatalf("nextWorkflowServeBeads err = %v, want supervisor API requirement", err)
+	}
+	// A down/restarting controller API must be transient so the --follow serve
+	// loop backs off and retries instead of exiting and crash-looping the
+	// long-running dispatcher (the cache-backed scan has no direct-store fallback).
+	if !dispatch.IsTransientControllerError(err) {
+		t.Fatalf("nextWorkflowServeBeads err = %v, want transient classification", err)
+	}
+}
+
+func TestNextWorkflowServeBeadsControlReadyTransientWhenNoAPIEscapeHatch(t *testing.T) {
+	clearGCEnv(t)
+	// GC_NO_API is the documented direct-bd escape hatch, but graph control
+	// dispatch reads control-ready work from the supervisor API and has no
+	// direct-store fallback. The scan must classify the disabled API as transient
+	// so the serve loop retries rather than crash-looping the dispatcher process.
+	t.Setenv("GC_NO_API", "1")
+	cityDir := t.TempDir()
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
+	_, err := nextWorkflowServeBeads(query, cityDir, map[string]string{"GC_CITY_PATH": cityDir})
+	if err == nil || !strings.Contains(err.Error(), "requires supervisor API") {
+		t.Fatalf("nextWorkflowServeBeads err = %v, want supervisor API requirement", err)
+	}
+	if !dispatch.IsTransientControllerError(err) {
+		t.Fatalf("nextWorkflowServeBeads err = %v, want transient classification under GC_NO_API", err)
+	}
+}
+
+// TestNextWorkflowServeControlReadyTransientOnInCallReadFailure pins the
+// in-call failure path: once a supervisor client exists, a transient ready read
+// (cache priming, store slow, generic 5xx, or a dropped connection) must be
+// classified transient so the --follow serve loop backs off and retries instead
+// of exiting and crash-looping the long-running dispatcher. A genuinely
+// unexpected error (e.g. a 4xx) must stay fatal so it surfaces loudly. The seam
+// drives the real api.Client decode path against an httptest server.
+func TestNextWorkflowServeControlReadyTransientOnInCallReadFailure(t *testing.T) {
+	clearGCEnv(t)
+	prev := workflowServeControlReadyList
+	t.Cleanup(func() { workflowServeControlReadyList = prev })
+
+	problem := func(status int, detail string) http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(status)
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"title":  http.StatusText(status),
+				"status": status,
+				"detail": detail,
+			})
+		}
+	}
+	cases := []struct {
+		name          string
+		handler       http.HandlerFunc
+		closeServer   bool
+		wantTransient bool
+	}{
+		{name: "cache_not_live", handler: problem(http.StatusServiceUnavailable, "cache_not_live: supervisor cache is priming"), wantTransient: true},
+		{name: "store_slow", handler: problem(http.StatusServiceUnavailable, "store_slow: ready read timed out"), wantTransient: true},
+		{name: "server_5xx", handler: problem(http.StatusInternalServerError, "boom"), wantTransient: true},
+		{name: "conn_error", handler: func(http.ResponseWriter, *http.Request) {}, closeServer: true, wantTransient: true},
+		{name: "bad_request_stays_fatal", handler: problem(http.StatusBadRequest, "malformed control ready query"), wantTransient: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(tc.handler)
+			if tc.closeServer {
+				ts.Close()
+			} else {
+				defer ts.Close()
+			}
+			client := api.NewCityScopedClient(ts.URL, "test-city")
+			workflowServeControlReadyList = func(_ string, filter beads.ControlReadyFilter) (api.ReadyBeads, error) {
+				return client.ListReadyBeads(filter)
+			}
+
+			cityDir := t.TempDir()
+			query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
+			_, err := nextWorkflowServeBeads(query, cityDir, map[string]string{"GC_CITY_PATH": cityDir})
+			if err == nil {
+				t.Fatalf("nextWorkflowServeBeads err = nil, want error for in-call %s", tc.name)
+			}
+			if got := dispatch.IsTransientControllerError(err); got != tc.wantTransient {
+				t.Fatalf("IsTransientControllerError(%v) = %v, want %v for in-call %s", err, got, tc.wantTransient, tc.name)
+			}
+		})
+	}
+}
+
+// TestNextWorkflowServeControlReadyPartialCityReadIsTransient pins that a
+// partial federated ready read that omitted the city store (where graph control
+// beads live) is treated as a transient, non-authoritative read: acting on it
+// would mistake hidden control work for an idle queue.
+func TestNextWorkflowServeControlReadyPartialCityReadIsTransient(t *testing.T) {
+	clearGCEnv(t)
+	prev := workflowServeControlReadyList
+	t.Cleanup(func() { workflowServeControlReadyList = prev })
+	workflowServeControlReadyList = func(string, beads.ControlReadyFilter) (api.ReadyBeads, error) {
+		return api.ReadyBeads{
+			Partial:       true,
+			PartialErrors: []string{"city: read ready: store slow"},
+		}, nil
+	}
+
+	cityDir := t.TempDir()
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
+	_, err := nextWorkflowServeBeads(query, cityDir, map[string]string{"GC_CITY_PATH": cityDir})
+	if err == nil {
+		t.Fatalf("nextWorkflowServeBeads err = nil, want transient error for city-store partial read")
+	}
+	if !dispatch.IsTransientControllerError(err) {
+		t.Fatalf("IsTransientControllerError(%v) = false, want transient for city-store partial read", err)
+	}
+}
+
+// TestNextWorkflowServeControlReadyPartialRigOnlyStillAuthoritative pins that a
+// partial read that lost only an unrelated rig store still dispatches the
+// present control work: the city store remains authoritative for control beads,
+// so an unrelated rig hiccup must not stall control dispatch.
+func TestNextWorkflowServeControlReadyPartialRigOnlyStillAuthoritative(t *testing.T) {
+	clearGCEnv(t)
+	prev := workflowServeControlReadyList
+	t.Cleanup(func() { workflowServeControlReadyList = prev })
+	workflowServeControlReadyList = func(string, beads.ControlReadyFilter) (api.ReadyBeads, error) {
+		return api.ReadyBeads{
+			Body: []beads.Bead{
+				{ID: "ga-control-ready", Assignee: "gascity/control-dispatcher", Metadata: map[string]string{"gc.kind": "scope-check"}},
+			},
+			Partial:       true,
+			PartialErrors: []string{"rig alpha: read ready: store slow"},
+		}, nil
+	}
+
+	cityDir := t.TempDir()
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
+	got, err := nextWorkflowServeBeads(query, cityDir, map[string]string{
+		"GC_CITY_PATH": cityDir,
+		"GC_ALIAS":     "gascity/control-dispatcher",
+	})
+	if err != nil {
+		t.Fatalf("nextWorkflowServeBeads err = %v, want authoritative read for rig-only partial", err)
+	}
+	var ids []string
+	for _, b := range got {
+		ids = append(ids, b.ID)
+	}
+	if !slices.Contains(ids, "ga-control-ready") {
+		t.Fatalf("filtered ids = %#v, want ga-control-ready dispatched despite rig-only partial", ids)
+	}
+}
+
+// TestFilterWorkflowServeControlReadyBeadsMatchesExecutionRoutedTo pins the
+// intended route-match broadening: a graph-routed control bead carrying only
+// gc.execution_routed_to (no gc.run_target/gc.routed_to) is claimed by the
+// control dispatcher rather than stranded, while one routed to another target is
+// ignored.
+func TestFilterWorkflowServeControlReadyBeadsMatchesExecutionRoutedTo(t *testing.T) {
+	clearGCEnv(t)
+	spec := workflowServeControlReadySpec{Target: "gascity/control-dispatcher"}
+	ready := []beads.Bead{
+		{ID: "ga-exec-routed", Metadata: map[string]string{beadmeta.ExecutionRoutedToMetadataKey: "gascity/control-dispatcher", "gc.kind": "scope-check"}},
+		{ID: "ga-exec-routed-other", Metadata: map[string]string{beadmeta.ExecutionRoutedToMetadataKey: "other/control-dispatcher", "gc.kind": "scope-check"}},
+		{ID: "ga-exec-routed-assigned", Assignee: "someone-else", Metadata: map[string]string{beadmeta.ExecutionRoutedToMetadataKey: "gascity/control-dispatcher", "gc.kind": "scope-check"}},
+	}
+	got := filterWorkflowServeControlReadyBeads(ready, spec, map[string]string{})
+	var ids []string
+	for _, b := range got {
+		ids = append(ids, b.ID)
+	}
+	if !slices.Contains(ids, "ga-exec-routed") {
+		t.Fatalf("filtered ids = %#v, want execution_routed_to-only control bead claimed", ids)
+	}
+	if slices.Contains(ids, "ga-exec-routed-other") {
+		t.Fatalf("filtered ids = %#v, want execution_routed_to bead for another target ignored", ids)
+	}
+	// The route predicate only matches unassigned beads; an already-assigned bead
+	// is claimed by the assignee scan, not broadened in via execution_routed_to.
+	if slices.Contains(ids, "ga-exec-routed-assigned") {
+		t.Fatalf("filtered ids = %#v, want assigned bead excluded from the route predicate", ids)
+	}
+}
+
+// TestControllerWorkQueryEnvIdentityRecoveredByControlReadyScan exercises the
+// production serve-env wiring: controllerWorkQueryEnv builds the control
+// dispatcher's work-query env from store/bd coordinates only and does not carry
+// the live session identity. The cache-backed control-ready assignee scan must
+// recover GC_SESSION_NAME/GC_ALIAS/GC_SESSION_ID from the process environment
+// (as the pre-cache shell scan did) or a control bead assigned to the live
+// session name/alias/id is stranded.
+func TestControllerWorkQueryEnvIdentityRecoveredByControlReadyScan(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_SESSION_NAME", "s-live")
+	t.Setenv("GC_ALIAS", "alias-live")
+	t.Setenv("GC_SESSION_ID", "mc-live")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"+testControlDispatcherAgentTOML("")), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	cfg, err := loadCityConfig(cityDir, io.Discard)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+	agentCfg, ok := resolveAgentIdentity(cfg, config.ControlDispatcherAgentName, currentRigContext(cfg))
+	if !ok {
+		t.Fatalf("resolveAgentIdentity(control-dispatcher) not found")
+	}
+	workEnv, err := controllerWorkQueryEnv(cityDir, cfg, &agentCfg)
+	if err != nil {
+		t.Fatalf("controllerWorkQueryEnv: %v", err)
+	}
+	// Pin the production gap: the serve env builder must not carry session
+	// identity. If this ever changes, the os.Getenv recovery becomes redundant
+	// and this test should be revisited rather than silently masking a wiring bug.
+	for _, key := range []string{"GC_SESSION_NAME", "GC_ALIAS", "GC_SESSION_ID"} {
+		if v := workEnv[key]; v != "" {
+			t.Fatalf("controllerWorkQueryEnv populated %s=%q; production identity gap no longer exists", key, v)
+		}
+	}
+
+	spec := workflowServeControlReadySpec{Target: "gascity/control-dispatcher"}
+	got := workflowServeControlReadyAssignees(spec, workEnv)
+	for _, want := range []string{"s-live", "alias-live", "mc-live"} {
+		if !slices.Contains(got, want) {
+			t.Fatalf("assignees = %#v, want live identity %q recovered from process env", got, want)
+		}
+	}
+}
+
+// TestFilterWorkflowServeControlReadyBeadsExcludesInstantiating pins the
+// defense-in-depth guard that keeps fenced/instantiating control beads out of
+// dispatch even if the upstream ready projection ever returns one.
+func TestFilterWorkflowServeControlReadyBeadsExcludesInstantiating(t *testing.T) {
+	clearGCEnv(t)
+	spec := workflowServeControlReadySpec{Target: "gascity/control-dispatcher"}
+	ready := []beads.Bead{
+		{ID: "ga-instantiating-assigned", Assignee: "gascity/control-dispatcher", Metadata: map[string]string{"gc.kind": "scope-check", beadmeta.InstantiatingMetadataKey: "true"}},
+		{ID: "ga-instantiating-routed", Metadata: map[string]string{"gc.run_target": "gascity/control-dispatcher", "gc.kind": "scope-check", beadmeta.InstantiatingMetadataKey: "true"}},
+		{ID: "ga-ready", Assignee: "gascity/control-dispatcher", Metadata: map[string]string{"gc.kind": "scope-check"}},
+	}
+	got := filterWorkflowServeControlReadyBeads(ready, spec, map[string]string{})
+	var ids []string
+	for _, b := range got {
+		ids = append(ids, b.ID)
+	}
+	if slices.Contains(ids, "ga-instantiating-assigned") || slices.Contains(ids, "ga-instantiating-routed") {
+		t.Fatalf("filtered ids = %#v, want fenced/instantiating control beads excluded", ids)
+	}
+	if !slices.Contains(ids, "ga-ready") {
+		t.Fatalf("filtered ids = %#v, want non-instantiating control bead retained", ids)
 	}
 }
 

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -3,14 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"maps"
 	"os"
 	"path/filepath"
-	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -2946,81 +2944,98 @@ func TestRunWorkflowServeDedupsLegacyTraceWarningsAcrossNestedControlDispatch(t 
 	}
 }
 
-func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
+func TestWorkflowServeControlReadyQueryIsInternalCachedQuery(t *testing.T) {
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
-	if strings.Contains(query, "GC_SESSION_ORIGIN") {
-		t.Fatalf("workflowServeControlReadyQuery should not gate legacy routes on session origin: %q", query)
+	if !strings.HasPrefix(query, workflowServeControlReadyQueryPrefix) {
+		t.Fatalf("workflowServeControlReadyQuery = %q, want internal control query prefix", query)
 	}
-	if strings.Contains(query, "bd list --status in_progress") {
-		t.Fatalf("workflowServeControlReadyQuery should not return in-progress control beads: %q", query)
-	}
-	if !strings.Contains(query, "BD_EXPORT_AUTO=false") {
-		t.Fatalf("workflowServeControlReadyQuery should disable bd auto-export: %q", query)
-	}
-	for _, want := range []string{
-		`bd --readonly --sandbox ready --assignee="$cand" --exclude-type=epic --json --limit=20`,
-		`bd --readonly --sandbox ready --metadata-field "gc.run_target=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
-		`bd --readonly --sandbox ready --metadata-field "gc.routed_to=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
-		`routed_ready "$GC_CONTROL_TARGET"`,
-		`routed_ready "${GC_CONTROL_LEGACY_TARGET:-}"`,
-	} {
-		if !strings.Contains(query, want) {
-			t.Fatalf("workflowServeControlReadyQuery missing %q in %q", want, query)
+	for _, forbidden := range []string{"bd ", "bd --readonly", "sh -c", "BD_EXPORT_AUTO", "GC_SESSION_ORIGIN", "bd list --status in_progress"} {
+		if strings.Contains(query, forbidden) {
+			t.Fatalf("workflowServeControlReadyQuery contains %q: %q", forbidden, query)
 		}
 	}
-	if !strings.Contains(query, `--limit=20`) {
-		t.Fatalf("workflowServeControlReadyQuery missing scan limit: %q", query)
+	spec, ok, err := parseWorkflowServeControlReadyQuery(query)
+	if err != nil || !ok {
+		t.Fatalf("parseWorkflowServeControlReadyQuery() = spec=%+v ok=%v err=%v, want parsed", spec, ok, err)
 	}
-	if strings.Contains(query, "--include-ephemeral") {
-		t.Fatalf("workflowServeControlReadyQuery default must stay bd 1.0.4-compatible: %q", query)
-	}
-}
-
-func TestWorkflowServeWorkQueryRecognizesCoreControlDispatcher(t *testing.T) {
-	query := workflowServeWorkQuery(config.Agent{Name: "core.control-dispatcher", Dir: "fixture"})
-
-	if strings.Contains(query, "bd query --json") {
-		t.Fatalf("core control-dispatcher serve query should avoid generic ephemeral scans: %q", query)
-	}
-	if !strings.Contains(query, "BD_EXPORT_AUTO=false") {
-		t.Fatalf("core control-dispatcher serve query should use the specialized control query: %q", query)
-	}
-	if !strings.Contains(query, "GC_CONTROL_TARGET='fixture/core.control-dispatcher'") {
-		t.Fatalf("core control-dispatcher serve query missing scoped target: %q", query)
+	if spec.Target != config.ControlDispatcherAgentName {
+		t.Fatalf("spec.Target = %q, want %q", spec.Target, config.ControlDispatcherAgentName)
 	}
 }
 
-func TestWorkflowServeControlReadyQueryBD105IncludesEphemeral(t *testing.T) {
-	query := workflowServeControlReadyQueryForBeads(
-		config.Agent{Name: config.ControlDispatcherAgentName},
-		config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105},
+func TestWorkflowServeControlReadyQueryPreservesRuntimeAndLegacyTargets(t *testing.T) {
+	query := workflowServeControlReadyQuery(
+		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
+		"gascity--control-dispatcher",
 	)
-	for _, want := range []string{
-		`bd --readonly --sandbox ready --include-ephemeral --assignee="$cand" --exclude-type=epic --json --limit=20`,
-		`bd --readonly --sandbox ready --include-ephemeral --metadata-field "gc.run_target=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
-		`bd --readonly --sandbox ready --include-ephemeral --metadata-field "gc.routed_to=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
-	} {
-		if !strings.Contains(query, want) {
-			t.Fatalf("workflowServeControlReadyQueryForBeads(bd-1.0.5) missing %q in %q", want, query)
-		}
+	spec, ok, err := parseWorkflowServeControlReadyQuery(query)
+	if err != nil || !ok {
+		t.Fatalf("parseWorkflowServeControlReadyQuery() = spec=%+v ok=%v err=%v, want parsed", spec, ok, err)
+	}
+	if spec.Target != "gascity/control-dispatcher" {
+		t.Fatalf("spec.Target = %q, want gascity/control-dispatcher", spec.Target)
+	}
+	if spec.ControlSessionName != "gascity--control-dispatcher" {
+		t.Fatalf("spec.ControlSessionName = %q, want configured runtime name", spec.ControlSessionName)
+	}
+	if spec.LegacyTarget != "gascity/workflow-control" {
+		t.Fatalf("spec.LegacyTarget = %q, want gascity/workflow-control", spec.LegacyTarget)
 	}
 }
 
 // TestWorkflowServeControlReadyQueryHonorsBareLegacyRoute guards the upgrade
 // gap: a qualified "core.control-dispatcher" serve loop must still claim
 // control beads that pre-1.3 builds routed to the binding-stripped bare name
-// "control-dispatcher". The bare alias is queried alongside the qualified
-// target so persisted in-flight work is not stranded after upgrade.
+// "control-dispatcher". The supervisor-cache spec carries the bare alias and
+// the route consumer scans it alongside the qualified target so persisted
+// in-flight work is not stranded after upgrade.
 func TestWorkflowServeControlReadyQueryHonorsBareLegacyRoute(t *testing.T) {
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, BindingName: "core"})
-	if !strings.Contains(query, "GC_CONTROL_TARGET='core.control-dispatcher'") {
-		t.Fatalf("serve query missing qualified target: %q", query)
+	spec, ok, err := parseWorkflowServeControlReadyQuery(query)
+	if err != nil || !ok {
+		t.Fatalf("parseWorkflowServeControlReadyQuery() = spec=%+v ok=%v err=%v, want parsed", spec, ok, err)
 	}
-	if !strings.Contains(query, "GC_CONTROL_BARE_TARGET='control-dispatcher'") {
-		t.Fatalf("serve query missing bare legacy target: %q", query)
+	if spec.Target != "core.control-dispatcher" {
+		t.Fatalf("spec.Target = %q, want core.control-dispatcher", spec.Target)
 	}
-	if !strings.Contains(query, `routed_ready "${GC_CONTROL_BARE_TARGET:-}"`) {
-		t.Fatalf("serve query missing bare routed_ready scan: %q", query)
+	if spec.BareTarget != "control-dispatcher" {
+		t.Fatalf("spec.BareTarget = %q, want control-dispatcher", spec.BareTarget)
+	}
+	routes := workflowServeControlReadyRoutes(spec)
+	if !slices.Contains(routes, "core.control-dispatcher") {
+		t.Fatalf("routes = %#v, want qualified target", routes)
+	}
+	if !slices.Contains(routes, "control-dispatcher") {
+		t.Fatalf("routes = %#v, want bare legacy route scanned", routes)
+	}
+}
+
+// TestWorkflowServeControlReadyBeadsClaimsBareRoutedWork pins the end-to-end
+// behavior the bare route exists for: a qualified dispatcher must claim an
+// unassigned bead routed to the pre-1.3 bare name out of the supervisor cache.
+func TestWorkflowServeControlReadyBeadsClaimsBareRoutedWork(t *testing.T) {
+	spec := workflowServeControlReadySpec{
+		Target:     "core.control-dispatcher",
+		BareTarget: "control-dispatcher",
+	}
+	ready := []beads.Bead{
+		{ID: "ga-bare-routed", Metadata: map[string]string{"gc.routed_to": "control-dispatcher", "gc.kind": "workflow-finalize"}},
+		{ID: "ga-qualified-routed", Metadata: map[string]string{"gc.run_target": "core.control-dispatcher", "gc.kind": "scope-check"}},
+		{ID: "ga-other", Metadata: map[string]string{"gc.routed_to": "other/control-dispatcher", "gc.kind": "scope-check"}},
+	}
+	got := filterWorkflowServeControlReadyBeads(ready, spec, map[string]string{})
+	var ids []string
+	for _, b := range got {
+		ids = append(ids, b.ID)
+	}
+	if !slices.Contains(ids, "ga-bare-routed") {
+		t.Fatalf("filtered ids = %#v, want bare-routed work claimed", ids)
+	}
+	if !slices.Contains(ids, "ga-qualified-routed") {
+		t.Fatalf("filtered ids = %#v, want qualified-routed work claimed", ids)
+	}
+	if slices.Contains(ids, "ga-other") {
+		t.Fatalf("filtered ids = %#v, want unrelated route excluded", ids)
 	}
 }
 
@@ -3041,436 +3056,66 @@ func TestControlDispatcherBareRoute(t *testing.T) {
 	}
 }
 
-func TestWorkflowServeControlReadyQueryIgnoresInProgressAssigned(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"GC_SESSION_NAME":   "gascity--control-dispatcher",
-		"GC_ALIAS":          "gascity/control-dispatcher",
-		"GC_SESSION_ORIGIN": "named",
-	}, `#!/bin/sh
-set -eu
-case "$*" in
-  "list --status in_progress --assignee=gascity--control-dispatcher --json --limit=20")
-    printf '[{"id":"ga-in-progress"}]'
-    ;;
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --json --limit=20")
-    printf '[{"id":"ga-epic-leak"}]'
-    ;;
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
-    printf '[{"id":"ga-ready"}]'
-    ;;
-  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
-    printf '[{"id":"ga-routed"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`)
-	assertJSONEqual(t, out, `[{"id":"ga-ready"},{"id":"ga-routed"}]`)
-}
+func TestFilterWorkflowServeControlReadyBeadsPreservesPriorityAndPredicates(t *testing.T) {
+	spec := workflowServeControlReadySpec{
+		Target:             "gascity/control-dispatcher",
+		ControlSessionName: "gascity--control-dispatcher",
+		LegacyTarget:       "gascity/workflow-control",
+	}
+	ready := []beads.Bead{
+		{ID: "ga-routed-first-in-input", Metadata: map[string]string{"gc.run_target": "gascity/control-dispatcher", "gc.kind": "scope-check"}},
+		{ID: "ga-epic", Type: "epic", Assignee: "gascity--control-dispatcher", Metadata: map[string]string{"gc.kind": "scope-check"}},
+		{ID: "ga-assigned", Assignee: "gascity--control-dispatcher", Metadata: map[string]string{"gc.kind": "retry"}},
+		{ID: "ga-legacy-assigned", Assignee: "gascity/workflow-control", Metadata: map[string]string{"gc.kind": "retry-eval"}},
+		{ID: "ga-route-dup", Metadata: map[string]string{"gc.run_target": "gascity/control-dispatcher", "gc.kind": "scope-check"}},
+		{ID: "ga-route-dup", Metadata: map[string]string{"gc.routed_to": "gascity/control-dispatcher", "gc.kind": "scope-check-duplicate"}},
+		{ID: "ga-legacy-route", Metadata: map[string]string{"gc.run_target": "gascity/workflow-control", "gc.kind": "workflow-finalize"}},
+		{ID: "ga-unrelated", Metadata: map[string]string{"gc.run_target": "other/control-dispatcher", "gc.kind": "scope-check"}},
+		{ID: "ga-assigned-other", Assignee: "other", Metadata: map[string]string{"gc.kind": "scope-check"}},
+	}
 
-func TestWorkflowServeControlReadyQueryIncludesMetadataRoutedWorkAfterAssignedPending(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"GC_SESSION_NAME": "gascity--control-dispatcher",
+	got := filterWorkflowServeControlReadyBeads(ready, spec, map[string]string{
+		"GC_SESSION_NAME": "manual-session",
 		"GC_ALIAS":        "gascity/control-dispatcher",
-	}, `#!/bin/sh
-set -eu
-case "$*" in
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
-    printf '[{"id":"ga-pending","metadata":{"gc.kind":"retry"}}]'
-    ;;
-  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
-    printf '[{"id":"ga-ready","metadata":{"gc.kind":"scope-check"}}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`)
-	assertJSONEqual(t, out, `[{"id":"ga-pending","metadata":{"gc.kind":"retry"}},{"id":"ga-ready","metadata":{"gc.kind":"scope-check"}}]`)
+	})
+
+	var ids []string
+	var kinds []string
+	for _, b := range got {
+		ids = append(ids, b.ID)
+		kinds = append(kinds, b.Metadata["gc.kind"])
+	}
+	wantIDs := []string{"ga-assigned", "ga-legacy-assigned", "ga-routed-first-in-input", "ga-route-dup", "ga-legacy-route"}
+	if !slices.Equal(ids, wantIDs) {
+		t.Fatalf("filtered ids = %#v, want %#v", ids, wantIDs)
+	}
+	if kinds[3] != "scope-check" {
+		t.Fatalf("duplicate route kept kind = %q, want first routed match", kinds[3])
+	}
 }
 
-func TestWorkflowServeControlReadyQueryIncludesCanonicalRoutedControlWork(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"GC_SESSION_NAME": "gascity--control-dispatcher",
+func TestWorkflowServeControlReadyAssigneesPrioritizeConfiguredRuntimeName(t *testing.T) {
+	spec := workflowServeControlReadySpec{
+		Target:             "gascity/control-dispatcher",
+		ControlSessionName: "gascity--control-dispatcher",
+	}
+	got := workflowServeControlReadyAssignees(spec, map[string]string{
+		"GC_SESSION_ID":   "mc-manual",
+		"GC_SESSION_NAME": "s-mc-manual",
 		"GC_ALIAS":        "gascity/control-dispatcher",
-	}, `#!/bin/sh
-set -eu
-case "$*" in
-  "--readonly --sandbox ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
-    printf '[{"id":"ga-control-routed","metadata":{"gc.routed_to":"gascity/control-dispatcher","gc.kind":"workflow-finalize"}}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`)
-	assertJSONEqual(t, out, `[{"id":"ga-control-routed","metadata":{"gc.routed_to":"gascity/control-dispatcher","gc.kind":"workflow-finalize"}}]`)
-}
-
-func TestWorkflowServeControlReadyQuerySkipsInstantiatingBeads(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"GC_SESSION_NAME": "gascity--control-dispatcher",
-		"GC_ALIAS":        "gascity/control-dispatcher",
-	}, fmt.Sprintf(`#!/bin/sh
-set -eu
-case "$*" in
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
-    printf '[{"id":"ga-instantiating-assigned","metadata":{"%s":"true"}},{"id":"ga-assigned","metadata":{"gc.kind":"retry"}}]'
-    ;;
-  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
-    printf '[{"id":"ga-instantiating-routed","metadata":{"%s":"true"}},{"id":"ga-routed","metadata":{"gc.kind":"scope-check"}}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`, beadmeta.InstantiatingMetadataKey, beadmeta.InstantiatingMetadataKey))
-	assertJSONEqual(t, out, `[{"id":"ga-assigned","metadata":{"gc.kind":"retry"}},{"id":"ga-routed","metadata":{"gc.kind":"scope-check"}}]`)
-}
-
-func TestWorkflowServeControlReadyQueryPreservesQueryPriorityWhenMerging(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"GC_SESSION_NAME": "gascity--control-dispatcher",
-		"GC_ALIAS":        "gascity/control-dispatcher",
-	}, `#!/bin/sh
-set -eu
-case "$*" in
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
-    printf '[{"id":"ga-z-assigned"},{"id":"ga-dup","source":"assigned"}]'
-    ;;
-  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
-    printf '[{"id":"ga-a-routed"},{"id":"ga-route-dup","source":"run-target"}]'
-    ;;
-  "--readonly --sandbox ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
-    printf '[{"id":"ga-route-dup","source":"routed-to"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`)
-	assertJSONEqual(t, out, `[{"id":"ga-z-assigned"},{"id":"ga-dup","source":"assigned"},{"id":"ga-a-routed"},{"id":"ga-route-dup","source":"run-target"}]`)
-}
-
-func TestWorkflowServeControlReadyQueryUsesConfiguredRuntimeNameWhenEnvIsManualSession(t *testing.T) {
-	query := workflowServeControlReadyQuery(
-		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
-		"gascity--control-dispatcher",
-	)
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"GC_SESSION_ID":     "mc-manual",
-		"GC_SESSION_NAME":   "s-mc-manual",
-		"GC_AGENT":          "s-mc-manual",
-		"GC_SESSION_ORIGIN": "manual",
-	}, `#!/bin/sh
-set -eu
-case "$*" in
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
-    printf '[{"id":"ga-control-ready"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`)
-	assertJSONEqual(t, out, `[{"id":"ga-control-ready"}]`)
-}
-
-func TestWorkflowServeControlReadyQueryFailsFastOnBDReadyError(t *testing.T) {
-	query := workflowServeControlReadyQuery(
-		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
-		"gascity--control-dispatcher",
-	)
-	tmp := t.TempDir()
-	bdPath := filepath.Join(tmp, "bd")
-	logPath := filepath.Join(tmp, "bd.log")
-	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
-set -eu
-printf '%s\n' "$*" >> "$BD_LOG"
-printf '[mysql] read tcp 127.0.0.1:1->127.0.0.1:3307: i/o timeout\n' >&2
-printf '{"error":"failed to open database: invalid connection"}\n'
-exit 1
-`), 0o755); err != nil {
-		t.Fatalf("write fake bd: %v", err)
-	}
-
-	_, err := shellWorkQueryWithEnv(query, t.TempDir(), []string{
-		"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
-		"BD_LOG=" + logPath,
-		"GC_SESSION_NAME=gascity--control-dispatcher",
-		"GC_ALIAS=gascity/control-dispatcher",
 	})
-	if err == nil {
-		t.Fatal("workflow serve query succeeded after bd ready failed")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "i/o timeout") || !strings.Contains(msg, "failed to open database") {
-		t.Fatalf("error = %q, want bd stderr/stdout details", msg)
-	}
-	logData, readErr := os.ReadFile(logPath)
-	if readErr != nil {
-		t.Fatalf("read bd log: %v", readErr)
-	}
-	calls := strings.Split(strings.TrimSpace(string(logData)), "\n")
-	if len(calls) != 1 {
-		t.Fatalf("bd calls = %d, want fail-fast after first call; calls:\n%s", len(calls), string(logData))
+	wantPrefix := []string{"gascity--control-dispatcher", "gascity--workflow-control", "s-mc-manual"}
+	if len(got) < len(wantPrefix) || !slices.Equal(got[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("assignees = %#v, want prefix %#v", got, wantPrefix)
 	}
 }
 
-func TestWorkflowServeControlReadyQueryKeepsSuccessfulBDStderrOutOfJSON(t *testing.T) {
-	query := workflowServeControlReadyQuery(
-		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
-		"gascity--control-dispatcher",
-	)
-	tmp := t.TempDir()
-	logPath := filepath.Join(tmp, "bd.log")
-	bdPath := filepath.Join(tmp, "bd")
-	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
-set -eu
-printf '%s\n' "$*" >> "$BD_LOG"
-case "$*" in
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
-    printf '[{"id":"ga-control-ready"}]'
-    printf 'notice: refreshed export metadata\n' >&2
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`), 0o755); err != nil {
-		t.Fatalf("write fake bd: %v", err)
-	}
-	out, err := shellWorkQueryWithEnv(query, t.TempDir(), []string{
-		"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
-		"BD_LOG=" + logPath,
-		"GC_SESSION_NAME=gascity--control-dispatcher",
-		"GC_ALIAS=gascity/control-dispatcher",
-	})
-	if err != nil {
-		t.Fatalf("run workflow serve query: %v", err)
-	}
-	assertJSONEqual(t, out, `[{"id":"ga-control-ready"}]`)
-}
-
-func TestWorkflowServeControlReadyQueryFailsOnMalformedBDJSON(t *testing.T) {
-	query := workflowServeControlReadyQuery(
-		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
-		"gascity--control-dispatcher",
-	)
-	tmp := t.TempDir()
-	bdPath := filepath.Join(tmp, "bd")
-	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
-set -eu
-case "$*" in
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
-    printf 'not-json'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`), 0o755); err != nil {
-		t.Fatalf("write fake bd: %v", err)
-	}
-	_, err := shellWorkQueryWithEnv(query, t.TempDir(), []string{
-		"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
-		"GC_SESSION_NAME=gascity--control-dispatcher",
-		"GC_ALIAS=gascity/control-dispatcher",
-	})
-	if err == nil {
-		t.Fatal("workflow serve query succeeded with malformed bd JSON")
-	}
-}
-
-func TestWorkflowServeControlReadyQueryPrioritizesConfiguredRuntimeName(t *testing.T) {
-	query := workflowServeControlReadyQuery(
-		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
-		"gascity--control-dispatcher",
-	)
-	tmp := t.TempDir()
-	logPath := filepath.Join(tmp, "bd.log")
-	bdPath := filepath.Join(tmp, "bd")
-	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
-set -eu
-[ "${BD_EXPORT_AUTO:-}" = "false" ] || {
-  echo "BD_EXPORT_AUTO=${BD_EXPORT_AUTO:-}" >&2
-  exit 43
-}
-printf '%s\n' "$*" >> "$BD_LOG"
-case "$*" in
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
-    printf '[{"id":"ga-control-ready"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`), 0o755); err != nil {
-		t.Fatalf("write fake bd: %v", err)
-	}
-	out, err := shellWorkQueryWithEnv(query, t.TempDir(), []string{
-		"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
-		"BD_LOG=" + logPath,
-		"GC_SESSION_ID=mc-manual",
-		"GC_SESSION_NAME=s-mc-manual",
-		"GC_AGENT=s-mc-manual",
-		"GC_SESSION_ORIGIN=manual",
-	})
-	if err != nil {
-		t.Fatalf("run workflow serve query: %v", err)
-	}
-	assertJSONEqual(t, out, `[{"id":"ga-control-ready"}]`)
-	logData, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read bd log: %v", err)
-	}
-	firstCall, _, _ := strings.Cut(strings.TrimSpace(string(logData)), "\n")
-	if want := "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20"; firstCall != want {
-		t.Fatalf("first bd call = %q, want %q; all calls:\n%s", firstCall, want, string(logData))
-	}
-}
-
-func TestWorkflowServeControlReadyQueryDeduplicatesAssigneeProbes(t *testing.T) {
-	query := workflowServeControlReadyQuery(
-		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
-		"gascity--control-dispatcher",
-	)
-	tmp := t.TempDir()
-	logPath := filepath.Join(tmp, "bd.log")
-	bdPath := filepath.Join(tmp, "bd")
-	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
-set -eu
-printf '%s\n' "$*" >> "$BD_LOG"
-case "$*" in
-  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
-    printf '[{"id":"ga-control-ready"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`), 0o755); err != nil {
-		t.Fatalf("write fake bd: %v", err)
-	}
-	out, err := shellWorkQueryWithEnv(query, t.TempDir(), []string{
-		"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
-		"BD_LOG=" + logPath,
-		"GC_SESSION_ID=gascity--control-dispatcher",
-		"GC_SESSION_NAME=gascity--control-dispatcher",
-		"GC_ALIAS=gascity/control-dispatcher",
-	})
-	if err != nil {
-		t.Fatalf("run workflow serve query: %v", err)
-	}
-	assertJSONEqual(t, out, `[{"id":"ga-control-ready"}]`)
-	logData, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read bd log: %v", err)
-	}
-	if got := strings.Count(string(logData), "--assignee=gascity--control-dispatcher "); got != 1 {
-		t.Fatalf("gascity--control-dispatcher query count = %d, want 1; calls:\n%s", got, string(logData))
-	}
-	if got := strings.Count(string(logData), "--assignee=gascity--workflow-control "); got != 1 {
-		t.Fatalf("gascity--workflow-control query count = %d, want 1; calls:\n%s", got, string(logData))
-	}
-}
-
-func TestWorkflowServeControlReadyQueryQuotesMetadataFallbackTarget(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "my rig"})
-	tmp := t.TempDir()
-	argsPath := filepath.Join(tmp, "matched.args")
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"BD_MATCHED_ARGS": argsPath,
-	}, `#!/bin/sh
-set -eu
-if [ "$#" -eq 11 ] &&
-   [ "$1" = "--readonly" ] &&
-   [ "$2" = "--sandbox" ] &&
-   [ "$3" = "ready" ] &&
-   [ "$4" = "--metadata-field" ] &&
-   [ "$5" = "gc.run_target=my rig/control-dispatcher" ] &&
-   [ "$6" = "--unassigned" ] &&
-   [ "$7" = "--exclude-type=epic" ] &&
-   [ "$8" = "--json" ] &&
-   [ "$9" = "--sort" ] &&
-   [ "${10}" = "oldest" ] &&
-   [ "${11}" = "--limit=20" ]; then
-  printf '%s\n' "$@" > "$BD_MATCHED_ARGS"
-  printf '[{"id":"ga-routed"}]'
-  exit 0
-fi
-printf '[]'
-`)
-	assertJSONEqual(t, out, `[{"id":"ga-routed"}]`)
-	argsData, err := os.ReadFile(argsPath)
-	if err != nil {
-		t.Fatalf("read matched args: %v", err)
-	}
-	gotArgs := strings.Split(strings.TrimSpace(string(argsData)), "\n")
-	wantArgs := []string{"--readonly", "--sandbox", "ready", "--metadata-field", "gc.run_target=my rig/control-dispatcher", "--unassigned", "--exclude-type=epic", "--json", "--sort", "oldest", "--limit=20"}
-	if !slices.Equal(gotArgs, wantArgs) {
-		t.Fatalf("matched bd args = %#v, want %#v", gotArgs, wantArgs)
-	}
-}
-
-func TestWorkflowServeControlReadyQueryUsesLegacyRouteForNamedSessions(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"GC_SESSION_NAME":   "gascity--control-dispatcher",
-		"GC_ALIAS":          "gascity/control-dispatcher",
-		"GC_SESSION_ORIGIN": "named",
-	}, `#!/bin/sh
-set -eu
-case "$*" in
-  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/workflow-control --unassigned --exclude-type=epic --json --sort oldest --limit=20")
-    printf '[{"id":"ga-legacy-route"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`)
-	assertJSONEqual(t, out, `[{"id":"ga-legacy-route"}]`)
-}
-
-func runWorkflowServeShellQueryForTest(t *testing.T, query string, env map[string]string, bdScript string) string {
-	t.Helper()
-
-	tmp := t.TempDir()
-	bdPath := filepath.Join(tmp, "bd")
-	if err := os.WriteFile(bdPath, []byte(bdScript), 0o755); err != nil {
-		t.Fatalf("write fake bd: %v", err)
-	}
-
-	queryEnv := []string{"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH")}
-	for key, value := range env {
-		queryEnv = append(queryEnv, key+"="+value)
-	}
-	out, err := shellWorkQueryWithEnv(query, t.TempDir(), queryEnv)
-	if err != nil {
-		t.Fatalf("run workflow serve query: %v", err)
-	}
-	return out
-}
-
-func assertJSONEqual(t *testing.T, got, want string) {
-	t.Helper()
-	var gotValue any
-	if err := json.Unmarshal([]byte(got), &gotValue); err != nil {
-		t.Fatalf("unmarshal got JSON %q: %v", got, err)
-	}
-	var wantValue any
-	if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
-		t.Fatalf("unmarshal want JSON %q: %v", want, err)
-	}
-	if !reflect.DeepEqual(gotValue, wantValue) {
-		t.Fatalf("JSON output = %s, want %s", got, want)
+func TestNextWorkflowServeBeadsRejectsControlReadyWithoutSupervisorAPI(t *testing.T) {
+	cityDir := t.TempDir()
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
+	_, err := nextWorkflowServeBeads(query, cityDir, map[string]string{"GC_CITY_PATH": cityDir})
+	if err == nil || !strings.Contains(err.Error(), "requires supervisor API") {
+		t.Fatalf("nextWorkflowServeBeads err = %v, want supervisor API requirement", err)
 	}
 }
 

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,7 +22,6 @@ import (
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/graphroute"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
-	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
 // cliGraphrouteDeps builds the graphroute dependencies used by CLI
@@ -159,7 +159,10 @@ func followSleepDuration(idleSweeps int) time.Duration {
 	return d
 }
 
-const workflowServeScanLimit = 20
+const (
+	workflowServeScanLimit               = 20
+	workflowServeControlReadyQueryPrefix = "gc-control-ready-v1:"
+)
 
 // runConvoyControlServe is the entry point for `gc convoy control --serve`.
 func runConvoyControlServe(args []string, stdout, stderr io.Writer) error {
@@ -362,7 +365,7 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	// on every iteration. #793.
 	workQuery := expandAgentCommandTemplate(cityPath, cityName, &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQueryForBeads(cfg.Beads), stderr)
 	if agentCfg.WorkQuery == "" && isWorkflowServeControlDispatcherAgent(agentCfg) {
-		workQuery = workflowServeControlReadyQueryForBeads(agentCfg, cfg.Beads, config.NamedSessionRuntimeName(cityName, cfg.Workspace, agentCfg.QualifiedName()))
+		workQuery = workflowServeControlReadyQuery(agentCfg, config.NamedSessionRuntimeName(cityName, cfg.Workspace, agentCfg.QualifiedName()))
 	}
 	workflowTracef("serve start agent=%s city=%s dir=%s", agentCfg.QualifiedName(), cityPath, workDir)
 	if !follow {
@@ -765,64 +768,40 @@ func isWorkflowServeControlDispatcherAgent(agentCfg config.Agent) bool {
 }
 
 func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames ...string) string {
-	return workflowServeControlReadyQueryForBeads(agentCfg, config.BeadsConfig{}, controlSessionNames...)
-}
-
-func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg config.BeadsConfig, controlSessionNames ...string) string {
 	target := strings.TrimSpace(agentCfg.QualifiedName())
 	if target == "" {
 		target = config.ControlDispatcherAgentName
 	}
-	limit := fmt.Sprintf("%d", workflowServeScanLimit)
-	includeEphemeral := ""
-	if beadsCfg.UsesBD105ReadySemantics() {
-		includeEphemeral = " --include-ephemeral"
+	spec := workflowServeControlReadySpec{
+		Target:       target,
+		LegacyTarget: workflowServeLegacyControlRoute(target),
+		// Pre-1.3 builds routed control beads to the binding-stripped bare
+		// name "control-dispatcher". Carrying it in the spec lets the
+		// supervisor-cache consumer claim that in-flight work after an upgrade
+		// scaled the qualified dispatcher, mirroring the pre-cache shell loop's
+		// GC_CONTROL_BARE_TARGET routed scan.
+		BareTarget: controlDispatcherBareRoute(target),
 	}
-	jqFilter := fmt.Sprintf(
-		`reduce add[] as $item ([]; if (($item.metadata // {})[%q] // "") != "" then . elif any(.[]; .id == $item.id) then . else . + [$item] end)`,
-		beadmeta.InstantiatingMetadataKey,
-	)
-	jqFilter = strings.ReplaceAll(jqFilter, `\`, `\\`)
-	jqFilter = strings.ReplaceAll(jqFilter, `"`, `\"`)
-	jqFilter = strings.ReplaceAll(jqFilter, `$`, `\$`)
-	queryPrefix := `BD_EXPORT_AUTO=false GC_CONTROL_TARGET=` + shellquote.Quote(target)
 	for _, name := range controlSessionNames {
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue
 		}
-		queryPrefix += ` GC_CONTROL_SESSION_NAME=` + shellquote.Quote(name)
+		spec.ControlSessionName = name
 		break
 	}
-	if legacy := workflowServeLegacyControlRoute(target); legacy != "" {
-		queryPrefix += ` GC_CONTROL_LEGACY_TARGET=` + shellquote.Quote(legacy)
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return ""
 	}
-	if bare := controlDispatcherBareRoute(target); bare != "" {
-		queryPrefix += ` GC_CONTROL_BARE_TARGET=` + shellquote.Quote(bare)
-	}
-	query := queryPrefix + ` sh -c '` +
-		`set -e; ` +
-		`tmp=$(mktemp); seen="$tmp.seen"; err="$tmp.err"; : > "$seen"; trap "rm -f \"$tmp\" \"$seen\" \"$err\"" EXIT; ` +
-		`emit_ready() { r=$("$@" 2>"$err") || { status=$?; [ -n "$r" ] && printf "%s\n" "$r" >&2; cat "$err" >&2; return "$status"; }; [ -n "$r" ] && [ "$r" != "[]" ] && printf "%s\n" "$r" >> "$tmp"; return 0; }; ` +
-		`assignee_ready() { cand="$1"; [ -z "$cand" ] && return 0; if grep -Fxq "$cand" "$seen"; then return 0; fi; printf "%s\n" "$cand" >> "$seen"; ` +
-		`emit_ready bd --readonly --sandbox ready` + includeEphemeral + ` --assignee="$cand" --exclude-type=epic --json --limit=` + limit + `; }; ` +
-		`routed_ready() { route="$1"; [ -z "$route" ] && return 0; ` +
-		`emit_ready bd --readonly --sandbox ready` + includeEphemeral + ` --metadata-field "` + beadmeta.RunTargetMetadataKey + `=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=` + limit + `; ` +
-		`emit_ready bd --readonly --sandbox ready` + includeEphemeral + ` --metadata-field "` + beadmeta.RoutedToMetadataKey + `=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=` + limit + `; ` +
-		`}; ` +
-		`for id in "$GC_CONTROL_SESSION_NAME" "$GC_SESSION_NAME" "$GC_ALIAS" "$GC_CONTROL_TARGET" "$GC_SESSION_ID"; do ` +
-		`[ -z "$id" ] && continue; ` +
-		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
-		`for cand in "$id" "$legacy"; do ` +
-		`[ -z "$cand" ] && continue; ` +
-		`assignee_ready "$cand"; ` +
-		`done; ` +
-		`done; ` +
-		`routed_ready "$GC_CONTROL_TARGET"; ` +
-		`routed_ready "${GC_CONTROL_LEGACY_TARGET:-}"; ` +
-		`routed_ready "${GC_CONTROL_BARE_TARGET:-}"; ` +
-		`if [ -s "$tmp" ]; then jq -s "` + jqFilter + `" "$tmp"; else printf "[]"; fi` + `'`
-	return query
+	return workflowServeControlReadyQueryPrefix + base64.RawURLEncoding.EncodeToString(data)
+}
+
+type workflowServeControlReadySpec struct {
+	Target             string `json:"target"`
+	ControlSessionName string `json:"control_session_name,omitempty"`
+	LegacyTarget       string `json:"legacy_target,omitempty"`
+	BareTarget         string `json:"bare_target,omitempty"`
 }
 
 func workflowServeLegacyControlRoute(target string) string {
@@ -867,6 +846,12 @@ func nextWorkflowServeBeads(workQuery, dir string, env map[string]string) ([]hoo
 	if workQuery == "" {
 		return nil, nil
 	}
+	if spec, ok, err := parseWorkflowServeControlReadyQuery(workQuery); ok || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		return nextWorkflowServeControlReadyBeads(spec, env)
+	}
 	output, err := shellWorkQueryWithEnv(workQuery, dir, mergeRuntimeEnv(os.Environ(), env))
 	if err != nil {
 		return nil, err
@@ -903,4 +888,153 @@ func writeDispatchWakeFile(cityPath string) {
 		return
 	}
 	_ = f.Close()
+}
+
+func parseWorkflowServeControlReadyQuery(workQuery string) (workflowServeControlReadySpec, bool, error) {
+	encoded, ok := strings.CutPrefix(strings.TrimSpace(workQuery), workflowServeControlReadyQueryPrefix)
+	if !ok {
+		return workflowServeControlReadySpec{}, false, nil
+	}
+	data, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return workflowServeControlReadySpec{}, true, fmt.Errorf("decode control ready query: %w", err)
+	}
+	var spec workflowServeControlReadySpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return workflowServeControlReadySpec{}, true, fmt.Errorf("parse control ready query: %w", err)
+	}
+	spec.Target = strings.TrimSpace(spec.Target)
+	spec.ControlSessionName = strings.TrimSpace(spec.ControlSessionName)
+	spec.LegacyTarget = strings.TrimSpace(spec.LegacyTarget)
+	spec.BareTarget = strings.TrimSpace(spec.BareTarget)
+	if spec.Target == "" {
+		return workflowServeControlReadySpec{}, true, fmt.Errorf("control ready query missing target")
+	}
+	return spec, true, nil
+}
+
+func nextWorkflowServeControlReadyBeads(spec workflowServeControlReadySpec, env map[string]string) ([]hookBead, error) {
+	cityPath := strings.TrimSpace(env["GC_CITY_PATH"])
+	if cityPath == "" {
+		cityPath = strings.TrimSpace(env["GC_CITY"])
+	}
+	if cityPath == "" {
+		cityPath = strings.TrimSpace(env["GC_STORE_ROOT"])
+	}
+	if cityPath == "" {
+		return nil, fmt.Errorf("control ready query missing city path")
+	}
+	client := apiClient(cityPath)
+	if client == nil {
+		if disabled, _ := classifyGCNoAPI(os.Getenv("GC_NO_API")); !disabled && apiRouteControllerAliveHook(cityPath) != 0 {
+			client = apiRouteSupervisorClientHook(cityPath)
+		}
+	}
+	if client == nil {
+		return nil, fmt.Errorf("control ready query requires supervisor API: %s", apiClientFallbackReason(cityPath))
+	}
+	ready, err := client.ListReadyBeads()
+	if err != nil {
+		return nil, fmt.Errorf("list ready beads from supervisor cache: %w", err)
+	}
+	return filterWorkflowServeControlReadyBeads(ready.Body, spec, env), nil
+}
+
+func filterWorkflowServeControlReadyBeads(ready []beads.Bead, spec workflowServeControlReadySpec, env map[string]string) []hookBead {
+	seen := map[string]struct{}{}
+	var out []hookBead
+	addMatches := func(match func(beads.Bead) bool) {
+		added := 0
+		for _, b := range ready {
+			if added >= workflowServeScanLimit {
+				return
+			}
+			if !match(b) || !workflowServeControlReadyBeadEligible(b) {
+				continue
+			}
+			if _, ok := seen[b.ID]; ok {
+				continue
+			}
+			seen[b.ID] = struct{}{}
+			out = append(out, hookBead{ID: b.ID, Metadata: hookBeadMetadata(b.Metadata)})
+			added++
+		}
+	}
+
+	for _, assignee := range workflowServeControlReadyAssignees(spec, env) {
+		assignee := assignee
+		addMatches(func(b beads.Bead) bool {
+			return b.Assignee == assignee
+		})
+	}
+	for _, route := range workflowServeControlReadyRoutes(spec) {
+		route := route
+		addMatches(func(b beads.Bead) bool {
+			if strings.TrimSpace(b.Assignee) != "" {
+				return false
+			}
+			return b.Metadata["gc.run_target"] == route ||
+				b.Metadata["gc.routed_to"] == route ||
+				b.Metadata[graphroute.GraphExecutionRouteMetaKey] == route
+		})
+	}
+	return out
+}
+
+func workflowServeControlReadyBeadEligible(b beads.Bead) bool {
+	return strings.TrimSpace(b.ID) != "" && strings.TrimSpace(b.Type) != "epic"
+}
+
+func workflowServeControlReadyAssignees(spec workflowServeControlReadySpec, env map[string]string) []string {
+	var out []string
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		for _, existing := range out {
+			if existing == value {
+				return
+			}
+		}
+		out = append(out, value)
+	}
+	addWithLegacy := func(value string) {
+		add(value)
+		value = strings.TrimSpace(value)
+		if strings.HasSuffix(value, config.ControlDispatcherAgentName) {
+			add(strings.TrimSuffix(value, config.ControlDispatcherAgentName) + "workflow-control")
+		}
+	}
+	addWithLegacy(spec.ControlSessionName)
+	for _, key := range []string{"GC_CONTROL_SESSION_NAME", "GC_SESSION_NAME", "GC_ALIAS"} {
+		addWithLegacy(env[key])
+	}
+	addWithLegacy(spec.Target)
+	addWithLegacy(env["GC_SESSION_ID"])
+	return out
+}
+
+func workflowServeControlReadyRoutes(spec workflowServeControlReadySpec) []string {
+	var out []string
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		for _, existing := range out {
+			if existing == value {
+				return
+			}
+		}
+		out = append(out, value)
+	}
+	add(spec.Target)
+	add(spec.LegacyTarget)
+	// Pre-1.3 builds routed control work to the binding-stripped bare name;
+	// scan it too so an upgraded qualified dispatcher claims that persisted
+	// in-flight work instead of stranding it (mirrors the pre-cache shell
+	// loop's GC_CONTROL_BARE_TARGET routed_ready scan).
+	add(spec.BareTarget)
+	return out
 }

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/citylayout"
@@ -767,6 +768,15 @@ func isWorkflowServeControlDispatcherAgent(agentCfg config.Agent) bool {
 		strings.HasSuffix(qualified, "."+config.ControlDispatcherAgentName)
 }
 
+// workflowServeControlReadyQuery builds the internal control-ready spec the
+// supervisor-cache consumer (api.Client.ListReadyBeads) filters client-side.
+// It relies on an invariant: graph.v2 control beads are always durable
+// (main-tier), never ephemeral/wisp-tier. The /beads/ready cache read this spec
+// drives is a default-tier (TierIssues) read, which excludes ephemeral rows, so
+// every control bead is reachable only because no dispatch/sling/formula/graph
+// creation path materializes control beads in the ephemeral tier. If that ever
+// changes, this scan would silently miss them and tier selection must be plumbed
+// through here.
 func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames ...string) string {
 	target := strings.TrimSpace(agentCfg.QualifiedName())
 	if target == "" {
@@ -913,6 +923,33 @@ func parseWorkflowServeControlReadyQuery(workQuery string) (workflowServeControl
 	return spec, true, nil
 }
 
+// errControlReadyNoSupervisorClient signals that the control-ready reader could
+// not build a supervisor API client (GC_NO_API escape hatch, or the supervisor
+// process is down/restarting). The cache-backed scan has no direct-store
+// fallback, so the caller maps it to a transient ErrControllerAPIUnavailable and
+// the --follow loop retries instead of crash-looping.
+var errControlReadyNoSupervisorClient = errors.New("control ready: no supervisor API client")
+
+// workflowServeControlReadyList obtains the federated ready set the control-ready
+// scan filters, reading through the supervisor API client. The filter is pushed
+// into the request so the supervisor returns only this dispatcher's control work
+// instead of the full federated ready set. It is a package var so tests can
+// inject transient or partial cache responses without standing up the
+// supervisor; production wiring reads through apiClient and returns
+// errControlReadyNoSupervisorClient when no client can be built.
+var workflowServeControlReadyList = func(cityPath string, filter beads.ControlReadyFilter) (api.ReadyBeads, error) {
+	client := apiClient(cityPath)
+	if client == nil {
+		if disabled, _ := classifyGCNoAPI(os.Getenv("GC_NO_API")); !disabled && apiRouteControllerAliveHook(cityPath) != 0 {
+			client = apiRouteSupervisorClientHook(cityPath)
+		}
+	}
+	if client == nil {
+		return api.ReadyBeads{}, errControlReadyNoSupervisorClient
+	}
+	return client.ListReadyBeads(filter)
+}
+
 func nextWorkflowServeControlReadyBeads(spec workflowServeControlReadySpec, env map[string]string) ([]hookBead, error) {
 	cityPath := strings.TrimSpace(env["GC_CITY_PATH"])
 	if cityPath == "" {
@@ -924,65 +961,92 @@ func nextWorkflowServeControlReadyBeads(spec workflowServeControlReadySpec, env 
 	if cityPath == "" {
 		return nil, fmt.Errorf("control ready query missing city path")
 	}
-	client := apiClient(cityPath)
-	if client == nil {
-		if disabled, _ := classifyGCNoAPI(os.Getenv("GC_NO_API")); !disabled && apiRouteControllerAliveHook(cityPath) != 0 {
-			client = apiRouteSupervisorClientHook(cityPath)
-		}
-	}
-	if client == nil {
-		return nil, fmt.Errorf("control ready query requires supervisor API: %s", apiClientFallbackReason(cityPath))
-	}
-	ready, err := client.ListReadyBeads()
+	filter := workflowServeControlReadyFilter(spec, env)
+	ready, err := workflowServeControlReadyList(cityPath, filter)
 	if err != nil {
+		if errors.Is(err, errControlReadyNoSupervisorClient) {
+			warnControlReadySupervisorAPIUnavailable()
+			// The cache-backed control-ready scan has no direct-store fallback, so a
+			// disabled (GC_NO_API escape hatch) or down/restarting controller API
+			// must not be fatal here. Wrap ErrControllerAPIUnavailable so the
+			// --follow serve loop classifies it transient and backs off/retries
+			// instead of exiting and crash-looping the long-running dispatcher.
+			return nil, fmt.Errorf("control ready query requires supervisor API (%s): %w", apiClientFallbackReason(cityPath), dispatch.ErrControllerAPIUnavailable)
+		}
+		// A non-nil supervisor client can still fail a ready read while the cache
+		// is priming/reconciling (cache_not_live), the store is briefly saturated
+		// (store_slow), the supervisor returns a generic 5xx, or the connection
+		// drops. These are all retryable and the scan has no direct-store fallback,
+		// so map them onto ErrControllerAPIUnavailable and let the --follow loop
+		// back off and retry instead of exiting. A genuinely unexpected error stays
+		// fatal so it surfaces loudly rather than spinning forever.
+		if api.ShouldFallbackForRead(err) || api.IsStoreSlowError(err) {
+			return nil, fmt.Errorf("list ready beads from supervisor cache (%w): %w", dispatch.ErrControllerAPIUnavailable, err)
+		}
 		return nil, fmt.Errorf("list ready beads from supervisor cache: %w", err)
+	}
+	if !ready.CityReadAuthoritative() {
+		// A partial federated read that omitted the city store can hide graph
+		// control beads (they live only in the city store) and make a non-idle
+		// queue look idle. Treat it as a transient controller-API condition so the
+		// follow loop retries instead of acting on an incomplete view. An unrelated
+		// rig-store failure leaves the city store authoritative and does not trip
+		// this.
+		return nil, fmt.Errorf("control ready query got a partial ready set omitting the city store (%s): %w", strings.Join(ready.PartialErrors, "; "), dispatch.ErrControllerAPIUnavailable)
 	}
 	return filterWorkflowServeControlReadyBeads(ready.Body, spec, env), nil
 }
 
-func filterWorkflowServeControlReadyBeads(ready []beads.Bead, spec workflowServeControlReadySpec, env map[string]string) []hookBead {
-	seen := map[string]struct{}{}
-	var out []hookBead
-	addMatches := func(match func(beads.Bead) bool) {
-		added := 0
-		for _, b := range ready {
-			if added >= workflowServeScanLimit {
-				return
-			}
-			if !match(b) || !workflowServeControlReadyBeadEligible(b) {
-				continue
-			}
-			if _, ok := seen[b.ID]; ok {
-				continue
-			}
-			seen[b.ID] = struct{}{}
-			out = append(out, hookBead{ID: b.ID, Metadata: hookBeadMetadata(b.Metadata)})
-			added++
-		}
+// warnControlReadySupervisorAPIUnavailable emits a one-time operator warning
+// when GC_NO_API disables the supervisor API that graph control dispatch now
+// reads control-ready work from. GC_NO_API is the documented direct-bd escape
+// hatch, but the cache-backed control-ready scan has no direct-store fallback,
+// so the dispatcher cannot make progress until the API is reachable. The
+// warning routes to the active serve stderr sink and dedupes per command
+// invocation so the retry loop does not spam it. A transient controller-down
+// blip is not warned (it self-heals on restart); only the persistent escape
+// hatch is surfaced.
+func warnControlReadySupervisorAPIUnavailable() {
+	if disabled, _ := classifyGCNoAPI(os.Getenv("GC_NO_API")); !disabled {
+		return
 	}
-
-	for _, assignee := range workflowServeControlReadyAssignees(spec, env) {
-		assignee := assignee
-		addMatches(func(b beads.Bead) bool {
-			return b.Assignee == assignee
-		})
-	}
-	for _, route := range workflowServeControlReadyRoutes(spec) {
-		route := route
-		addMatches(func(b beads.Bead) bool {
-			if strings.TrimSpace(b.Assignee) != "" {
-				return false
-			}
-			return b.Metadata[beadmeta.RunTargetMetadataKey] == route ||
-				b.Metadata[beadmeta.RoutedToMetadataKey] == route ||
-				b.Metadata[graphroute.GraphExecutionRouteMetaKey] == route
-		})
-	}
-	return out
+	workflowTraceWarnings.mu.Lock()
+	writer := workflowTraceWarnings.writer
+	workflowTraceWarnings.mu.Unlock()
+	workflowTraceWarnf(
+		writer,
+		"control-ready-no-api",
+		"gc convoy control --serve: warning: GC_NO_API disables the supervisor API, but graph control dispatch reads control-ready work from it and has no direct-bd fallback; the control-dispatcher will retry until GC_NO_API is unset or the API is reachable.\n",
+	)
 }
 
-func workflowServeControlReadyBeadEligible(b beads.Bead) bool {
-	return strings.TrimSpace(b.ID) != "" && strings.TrimSpace(b.Type) != "epic"
+// workflowServeControlReadyFilter builds the control-ready filter from the serve
+// spec and live session identity: the assignees and routes this dispatcher
+// claims, bounded by the per-scan limit. It is shared by the supervisor request
+// (so the federated ready set is filtered server-side) and the client-side
+// re-filter below, so the two predicates cannot drift. The assignee priority
+// order, the control-dispatcher→workflow-control legacy alias, and the
+// bare/legacy routed targets all live in the assignee/route builders it calls.
+func workflowServeControlReadyFilter(spec workflowServeControlReadySpec, env map[string]string) beads.ControlReadyFilter {
+	return beads.ControlReadyFilter{
+		Assignees:     workflowServeControlReadyAssignees(spec, env),
+		Routes:        workflowServeControlReadyRoutes(spec),
+		PerGroupLimit: workflowServeScanLimit,
+	}
+}
+
+// filterWorkflowServeControlReadyBeads reduces a federated ready set to the
+// control beads this dispatcher should claim and converts them to hook beads.
+// The supervisor already applies the same ControlReadyFilter server-side; this
+// re-filter is idempotent (Apply(Apply(x)) == Apply(x)) and guards against an
+// older supervisor (mixed-version rollout) that ignores the new control_* params
+// and returns the full ready set.
+func filterWorkflowServeControlReadyBeads(ready []beads.Bead, spec workflowServeControlReadySpec, env map[string]string) []hookBead {
+	var out []hookBead
+	for _, b := range workflowServeControlReadyFilter(spec, env).Apply(ready) {
+		out = append(out, hookBead{ID: b.ID, Metadata: hookBeadMetadata(b.Metadata)})
+	}
+	return out
 }
 
 func workflowServeControlReadyAssignees(spec workflowServeControlReadySpec, env map[string]string) []string {
@@ -1008,11 +1072,27 @@ func workflowServeControlReadyAssignees(spec workflowServeControlReadySpec, env 
 	}
 	addWithLegacy(spec.ControlSessionName)
 	for _, key := range []string{"GC_CONTROL_SESSION_NAME", "GC_SESSION_NAME", "GC_ALIAS"} {
-		addWithLegacy(env[key])
+		addWithLegacy(controlReadyEnvIdentity(env, key))
 	}
 	addWithLegacy(spec.Target)
-	addWithLegacy(env["GC_SESSION_ID"])
+	addWithLegacy(controlReadyEnvIdentity(env, "GC_SESSION_ID"))
 	return out
+}
+
+// controlReadyEnvIdentity resolves a live-session identity key for the
+// control-ready assignee scan, preferring an explicit value in the serve env map
+// and falling back to the live process environment. The pre-cache shell scan
+// read GC_SESSION_NAME/GC_ALIAS/GC_SESSION_ID from os.Environ (via
+// mergeRuntimeEnv), but the production controller serve env
+// (controllerWorkQueryEnv) carries only store/bd coordinates, so without this
+// fallback the live session identity is dropped and a control bead assigned to
+// the live session name/alias/id is stranded. Mirrors the existing os.Getenv
+// read of GC_NO_API in this path.
+func controlReadyEnvIdentity(env map[string]string, key string) string {
+	if v := strings.TrimSpace(env[key]); v != "" {
+		return v
+	}
+	return strings.TrimSpace(os.Getenv(key))
 }
 
 func workflowServeControlReadyRoutes(spec workflowServeControlReadySpec) []string {

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -973,8 +973,8 @@ func filterWorkflowServeControlReadyBeads(ready []beads.Bead, spec workflowServe
 			if strings.TrimSpace(b.Assignee) != "" {
 				return false
 			}
-			return b.Metadata["gc.run_target"] == route ||
-				b.Metadata["gc.routed_to"] == route ||
+			return b.Metadata[beadmeta.RunTargetMetadataKey] == route ||
+				b.Metadata[beadmeta.RoutedToMetadataKey] == route ||
 				b.Metadata[graphroute.GraphExecutionRouteMetaKey] == route
 		})
 	}

--- a/cmd/gc/wisp_autoclose_test.go
+++ b/cmd/gc/wisp_autoclose_test.go
@@ -436,6 +436,10 @@ func (s staleCachedWispStore) Get(_ string) (beads.Bead, error) {
 	return beads.Bead{}, beads.ErrCacheUnavailable
 }
 
+func (s staleCachedWispStore) ReadyCacheOnly(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return s.Ready(query...)
+}
+
 func (s staleCachedWispStore) Handles() beads.StoreHandles {
 	return beads.StoreHandles{
 		Cached: s,
@@ -476,6 +480,10 @@ type tierNarrowListWispStore struct {
 
 func (s tierNarrowListWispStore) List(beads.ListQuery) ([]beads.Bead, error) {
 	return nil, nil
+}
+
+func (s tierNarrowListWispStore) ReadyCacheOnly(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return s.Ready(query...)
 }
 
 func (s tierNarrowListWispStore) Handles() beads.StoreHandles {

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -19521,6 +19521,48 @@
               "description": "How long to block waiting for changes (Go duration string, e.g. 30s). Default 30s, max 2m.",
               "type": "string"
             }
+          },
+          {
+            "description": "Serve ready work from the supervisor cache projection (eventually consistent) instead of the authoritative live backing store. Defaults to false (live).",
+            "explode": false,
+            "in": "query",
+            "name": "cached",
+            "schema": {
+              "description": "Serve ready work from the supervisor cache projection (eventually consistent) instead of the authoritative live backing store. Defaults to false (live).",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Comma-separated assignees: keep only ready beads assigned to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+            "explode": false,
+            "in": "query",
+            "name": "control_assignees",
+            "schema": {
+              "description": "Comma-separated assignees: keep only ready beads assigned to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated routes: keep unassigned ready beads routed (run-target/routed-to/execution-routed-to) to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+            "explode": false,
+            "in": "query",
+            "name": "control_routes",
+            "schema": {
+              "description": "Comma-separated routes: keep unassigned ready beads routed (run-target/routed-to/execution-routed-to) to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Per-group cap on ready beads contributed by each control assignee and route. 0 = unbounded. Ignored unless control_assignees or control_routes is set.",
+            "explode": false,
+            "in": "query",
+            "name": "control_limit",
+            "schema": {
+              "description": "Per-group cap on ready beads contributed by each control assignee and route. 0 = unbounded. Ignored unless control_assignees or control_routes is set.",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
           }
         ],
         "responses": {

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -19521,6 +19521,48 @@
               "description": "How long to block waiting for changes (Go duration string, e.g. 30s). Default 30s, max 2m.",
               "type": "string"
             }
+          },
+          {
+            "description": "Serve ready work from the supervisor cache projection (eventually consistent) instead of the authoritative live backing store. Defaults to false (live).",
+            "explode": false,
+            "in": "query",
+            "name": "cached",
+            "schema": {
+              "description": "Serve ready work from the supervisor cache projection (eventually consistent) instead of the authoritative live backing store. Defaults to false (live).",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Comma-separated assignees: keep only ready beads assigned to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+            "explode": false,
+            "in": "query",
+            "name": "control_assignees",
+            "schema": {
+              "description": "Comma-separated assignees: keep only ready beads assigned to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated routes: keep unassigned ready beads routed (run-target/routed-to/execution-routed-to) to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+            "explode": false,
+            "in": "query",
+            "name": "control_routes",
+            "schema": {
+              "description": "Comma-separated routes: keep unassigned ready beads routed (run-target/routed-to/execution-routed-to) to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Per-group cap on ready beads contributed by each control assignee and route. 0 = unbounded. Ignored unless control_assignees or control_routes is set.",
+            "explode": false,
+            "in": "query",
+            "name": "control_limit",
+            "schema": {
+              "description": "Per-group cap on ready beads contributed by each control assignee and route. 0 = unbounded. Ignored unless control_assignees or control_routes is set.",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
           }
         ],
         "responses": {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -855,26 +855,55 @@ func (c *Client) ListBeads(opts ListBeadsOpts) (CachedRead[[]beads.Bead], error)
 }
 
 // ListReadyBeads fetches ready beads across all rigs via
-// GET /v0/city/{cityName}/beads/ready. The endpoint is served from the
-// supervisor cache projection so controller-side consumers can avoid direct
-// backing-store reads.
-func (c *Client) ListReadyBeads() (CachedRead[[]beads.Bead], error) {
+// GET /v0/city/{cityName}/beads/ready with cached=true, so the control
+// dispatcher reads from the supervisor cache projection and avoids the
+// blocking/failing backing-store scan the control-ready cache exists to avoid.
+// (The endpoint itself defaults to authoritative live readiness; this consumer
+// explicitly opts into the cache.) The result preserves the response's
+// partial-aggregation signal (Partial / PartialErrors) so callers can detect
+// when a backing store (such as the city store holding graph control beads)
+// failed and the ready set is incomplete rather than authoritatively empty.
+//
+// An optional ControlReadyFilter pushes the control dispatcher's assignee/route
+// predicate and per-group limit into the request, so the supervisor filters its
+// control work out of the federated ready set server-side, before serialization,
+// instead of returning every rig's ready beads for the dispatcher to filter
+// client-side. An inactive (zero) filter requests the full ready set.
+func (c *Client) ListReadyBeads(filter ...beads.ControlReadyFilter) (ReadyBeads, error) {
 	if err := c.requireCityScope(); err != nil {
-		return CachedRead[[]beads.Bead]{}, err
+		return ReadyBeads{}, err
 	}
-	resp, err := c.cw.GetV0CityByCityNameBeadsReadyWithResponse(context.Background(), c.cityName, &genclient.GetV0CityByCityNameBeadsReadyParams{})
+	cached := true
+	params := &genclient.GetV0CityByCityNameBeadsReadyParams{Cached: &cached}
+	if len(filter) > 0 && filter[0].Active() {
+		f := filter[0]
+		if assignees := strings.Join(f.Assignees, ","); assignees != "" {
+			params.ControlAssignees = &assignees
+		}
+		if routes := strings.Join(f.Routes, ","); routes != "" {
+			params.ControlRoutes = &routes
+		}
+		if f.PerGroupLimit > 0 {
+			limit := int64(f.PerGroupLimit)
+			params.ControlLimit = &limit
+		}
+	}
+	resp, err := c.cw.GetV0CityByCityNameBeadsReadyWithResponse(context.Background(), c.cityName, params)
 	if err != nil {
-		return CachedRead[[]beads.Bead]{}, &connError{err: fmt.Errorf("request failed: %w", err)}
+		return ReadyBeads{}, &connError{err: fmt.Errorf("request failed: %w", err)}
 	}
 	if resp == nil {
-		return CachedRead[[]beads.Bead]{}, &connError{err: fmt.Errorf("nil response")}
+		return ReadyBeads{}, &connError{err: fmt.Errorf("nil response")}
 	}
 	if err := apiErrorFromResponse(resp.StatusCode(), resp.ApplicationproblemJSONDefault); err != nil {
-		return CachedRead[[]beads.Bead]{}, err
+		return ReadyBeads{}, err
 	}
-	return CachedRead[[]beads.Bead]{
-		Body:       beadsFromGenList(resp.JSON200),
-		AgeSeconds: cacheAgeFromResponse(resp.HTTPResponse),
+	partial, partialErrs := readyPartialFromGen(resp.JSON200)
+	return ReadyBeads{
+		Body:          beadsFromGenList(resp.JSON200),
+		AgeSeconds:    cacheAgeFromResponse(resp.HTTPResponse),
+		Partial:       partial,
+		PartialErrors: partialErrs,
 	}, nil
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -854,6 +854,30 @@ func (c *Client) ListBeads(opts ListBeadsOpts) (CachedRead[[]beads.Bead], error)
 	}, nil
 }
 
+// ListReadyBeads fetches ready beads across all rigs via
+// GET /v0/city/{cityName}/beads/ready. The endpoint is served from the
+// supervisor cache projection so controller-side consumers can avoid direct
+// backing-store reads.
+func (c *Client) ListReadyBeads() (CachedRead[[]beads.Bead], error) {
+	if err := c.requireCityScope(); err != nil {
+		return CachedRead[[]beads.Bead]{}, err
+	}
+	resp, err := c.cw.GetV0CityByCityNameBeadsReadyWithResponse(context.Background(), c.cityName, &genclient.GetV0CityByCityNameBeadsReadyParams{})
+	if err != nil {
+		return CachedRead[[]beads.Bead]{}, &connError{err: fmt.Errorf("request failed: %w", err)}
+	}
+	if resp == nil {
+		return CachedRead[[]beads.Bead]{}, &connError{err: fmt.Errorf("nil response")}
+	}
+	if err := apiErrorFromResponse(resp.StatusCode(), resp.ApplicationproblemJSONDefault); err != nil {
+		return CachedRead[[]beads.Bead]{}, err
+	}
+	return CachedRead[[]beads.Bead]{
+		Body:       beadsFromGenList(resp.JSON200),
+		AgeSeconds: cacheAgeFromResponse(resp.HTTPResponse),
+	}, nil
+}
+
 // GetBead fetches one bead by ID via
 // GET /v0/city/{cityName}/bead/{id}. Returns the bead detail with cache age
 // so callers can attach _cache_age_s (JSON) or a staleness banner (human).

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
@@ -1312,6 +1313,82 @@ func TestClientListMailInbox_ConnErrorFallback(t *testing.T) {
 	}
 	if !ShouldFallback(err) {
 		t.Errorf("ShouldFallback = false for conn error: %v", err)
+	}
+}
+
+func TestClientListReadyBeadsPreservesPartial(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/city/alpha/beads/ready" {
+			t.Fatalf("path = %q, want /v0/city/alpha/beads/ready", r.URL.Path)
+		}
+		// The whole point of the control-ready path is that the dispatcher reads
+		// the cache projection, not the live store. If a refactor dropped the
+		// cached opt-in the dispatcher would silently revert to authoritative live
+		// reads — the exact blocking/failing scan this change exists to avoid.
+		if got := r.URL.Query().Get("cached"); got != "true" {
+			t.Errorf("cached query = %q, want %q", got, "true")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"items":          []map[string]any{},
+			"total":          0,
+			"partial":        true,
+			"partial_errors": []string{CityReadyPartialLabel + ": read ready: store slow"},
+		})
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	got, err := c.ListReadyBeads()
+	if err != nil {
+		t.Fatalf("ListReadyBeads: %v", err)
+	}
+	if !got.Partial {
+		t.Errorf("Partial = false, want true")
+	}
+	if len(got.PartialErrors) != 1 || !strings.HasPrefix(got.PartialErrors[0], CityReadyPartialLabel+": ") {
+		t.Errorf("PartialErrors = %v, want a city-store entry", got.PartialErrors)
+	}
+	// A partial read that omitted the city store is not authoritative for the
+	// control-ready scan: graph control beads live only in the city store.
+	if got.CityReadAuthoritative() {
+		t.Errorf("CityReadAuthoritative = true for a city-store partial read")
+	}
+}
+
+// TestClientListReadyBeadsSendsControlFilter proves the dispatcher's control
+// predicate and per-group limit are pushed into the request, so the supervisor
+// filters the federated ready set server-side instead of returning every rig's
+// ready beads for the client to filter.
+func TestClientListReadyBeadsSendsControlFilter(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if got := q.Get("cached"); got != "true" {
+			t.Errorf("cached = %q, want true", got)
+		}
+		if got := q.Get("control_assignees"); got != "sess-a,sess-b" {
+			t.Errorf("control_assignees = %q, want sess-a,sess-b", got)
+		}
+		if got := q.Get("control_routes"); got != "route-1" {
+			t.Errorf("control_routes = %q, want route-1", got)
+		}
+		if got := q.Get("control_limit"); got != "20" {
+			t.Errorf("control_limit = %q, want 20", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"items": []map[string]any{}, "total": 0,
+		})
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	if _, err := c.ListReadyBeads(beads.ControlReadyFilter{
+		Assignees:     []string{"sess-a", "sess-b"},
+		Routes:        []string{"route-1"},
+		PerGroupLimit: 20,
+	}); err != nil {
+		t.Fatalf("ListReadyBeads: %v", err)
 	}
 }
 

--- a/internal/api/decode_beads.go
+++ b/internal/api/decode_beads.go
@@ -21,6 +21,21 @@ func beadsFromGenList(body *genclient.ListBodyBead) []beads.Bead {
 	return out
 }
 
+// readyPartialFromGen extracts the partial-aggregation signal from a federated
+// ready-list response body. Returns (false, nil) when the body or its partial
+// fields are absent, so a complete read is reported as authoritative.
+func readyPartialFromGen(body *genclient.ListBodyBead) (bool, []string) {
+	if body == nil {
+		return false, nil
+	}
+	partial := body.Partial != nil && *body.Partial
+	var errs []string
+	if body.PartialErrors != nil && len(*body.PartialErrors) > 0 {
+		errs = append(errs, *body.PartialErrors...)
+	}
+	return partial, errs
+}
+
 // beadFromGenPtr translates a non-nil *genclient.Bead into a beads.Bead.
 // Returns the zero beads.Bead when given a nil pointer; callers should check
 // for an empty ID to detect the missing-body case.

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -5973,6 +5973,18 @@ type GetV0CityByCityNameBeadsReadyParams struct {
 
 	// Wait How long to block waiting for changes (Go duration string, e.g. 30s). Default 30s, max 2m.
 	Wait *string `form:"wait,omitempty" json:"wait,omitempty"`
+
+	// Cached Serve ready work from the supervisor cache projection (eventually consistent) instead of the authoritative live backing store. Defaults to false (live).
+	Cached *bool `form:"cached,omitempty" json:"cached,omitempty"`
+
+	// ControlAssignees Comma-separated assignees: keep only ready beads assigned to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.
+	ControlAssignees *string `form:"control_assignees,omitempty" json:"control_assignees,omitempty"`
+
+	// ControlRoutes Comma-separated routes: keep unassigned ready beads routed (run-target/routed-to/execution-routed-to) to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.
+	ControlRoutes *string `form:"control_routes,omitempty" json:"control_routes,omitempty"`
+
+	// ControlLimit Per-group cap on ready beads contributed by each control assignee and route. 0 = unbounded. Ignored unless control_assignees or control_routes is set.
+	ControlLimit *int64 `form:"control_limit,omitempty" json:"control_limit,omitempty"`
 }
 
 // DeleteV0CityByCityNameConvoyByIdParams defines parameters for DeleteV0CityByCityNameConvoyById.
@@ -17220,6 +17232,70 @@ func NewGetV0CityByCityNameBeadsReadyRequest(server string, cityName string, par
 		if params.Wait != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "wait", *params.Wait, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cached != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "cached", *params.Cached, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ControlAssignees != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "control_assignees", *params.ControlAssignees, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ControlRoutes != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "control_routes", *params.ControlRoutes, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ControlLimit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "control_limit", *params.ControlLimit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/internal/api/handler_beads_ready_cache_test.go
+++ b/internal/api/handler_beads_ready_cache_test.go
@@ -1,0 +1,236 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestBeadReadyServedFromCacheWhenBackingReadyFails proves GET /v0/beads/ready
+// with cached=true serves ready work from the supervisor cache projection, not
+// the live backing store. The control dispatcher's api.Client.ListReadyBeads
+// sets cached=true and depends on this so a slow or failing backing store
+// cannot block or fail every control serve cycle.
+//
+// The backing store below fails Ready() while its cached projection holds a
+// ready control bead; with cached=true the handler must still return that bead
+// without a partial error. The default (live) path is covered by
+// TestBeadReadyUsesLiveLookup, which proves an omitted cached param reads the
+// authoritative backing store so closed/blocked beads are never reported ready.
+func TestBeadReadyServedFromCacheWhenBackingReadyFails(t *testing.T) {
+	// Backing store whose Ready() always fails but whose List() (used by the
+	// cache prime) still works, so the cache primes while the live read stays
+	// broken — the exact split the handler must honor.
+	backing := beads.NewMemStore()
+	control, err := backing.Create(beads.Bead{Type: "task", Title: "control-ready-bead"})
+	if err != nil {
+		t.Fatalf("seed control bead: %v", err)
+	}
+	failing := &failingBeadStore{Store: backing, readyErr: errors.New("backing Ready() unavailable")}
+
+	cache := beads.NewCachingStoreForTest(failing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+
+	// Test premise: the live backing read is broken, but the cached projection
+	// holds the ready control bead. If this split ever stops holding, the
+	// handler assertion below would pass for the wrong reason.
+	if _, err := beads.HandlesFor(cache).Live.Ready(); err == nil {
+		t.Fatalf("Live.Ready() = nil error, want backing failure (test premise broken)")
+	}
+	cachedReady, err := beads.HandlesFor(cache).Cached.Ready()
+	if err != nil {
+		t.Fatalf("Cached.Ready() unexpected error: %v", err)
+	}
+	if !containsBeadTitle(cachedReady, "control-ready-bead") {
+		t.Fatalf("cached ready = %+v, want control bead %s", cachedReady, control.ID)
+	}
+
+	// Control beads live in the city store; federate the cache there.
+	fs := newFakeState(t)
+	fs.cityBeadStore = cache
+	h := newTestCityHandler(t, fs)
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/beads/ready?cached=true"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Items         []beads.Bead `json:"items"`
+		Partial       bool         `json:"partial"`
+		PartialErrors []string     `json:"partial_errors"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	if body.Partial {
+		t.Errorf("Partial = true (errors=%v), want false: the cached read should succeed without touching the failing backing store", body.PartialErrors)
+	}
+	if !containsBeadTitle(body.Items, "control-ready-bead") {
+		t.Fatalf("Items = %+v, want control bead %s served from cache", body.Items, control.ID)
+	}
+}
+
+// trackingBackingStore counts and fails backing-store reads. A test uses it to
+// prove the cache-only ready path (ReadyCacheOnly / GET ?cached=true) never
+// primes from or reads the backing store, and to confirm — by contrast — that
+// the priming Cached.Ready handle does reach it.
+type trackingBackingStore struct {
+	beads.Store
+	listCalls  int
+	readyCalls int
+}
+
+func (s *trackingBackingStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls++
+	return nil, errors.New("backing List must not be reached on the cache-only ready path")
+}
+
+func (s *trackingBackingStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
+	s.readyCalls++
+	return nil, errors.New("backing Ready must not be reached on the cache-only ready path")
+}
+
+// TestBeadReadyCachedColdCacheNeverPrimesBackingStore is the blocker regression
+// for PR #3821: on a cold (unprimed) supervisor cache, GET /v0/beads/ready?cached=true
+// must answer strictly from the in-memory projection and never prime or read the
+// failing/blocking backing store. Otherwise the control dispatcher's tight serve
+// loop could block on the exact backing-store scan the control-ready cache exists
+// to avoid. The priming Cached.Ready handle, by contrast, does reach the backing
+// store — that is the gap ReadyCacheOnly closes.
+func TestBeadReadyCachedColdCacheNeverPrimesBackingStore(t *testing.T) {
+	backing := &trackingBackingStore{Store: beads.NewMemStore()}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	// No real backoff sleeps: the failing prime would otherwise retry over ~15s.
+	cache.SetPrimeRetryDelayForTest(func(int) time.Duration { return 0 })
+	// Cold: the cache is never primed.
+
+	handles := beads.HandlesFor(cache)
+
+	// Contrast: the priming Ready handle reaches the backing store — this is the
+	// blocking/failing scan the cache-only path must avoid.
+	if _, err := handles.Cached.Ready(); !errors.Is(err, beads.ErrCacheUnavailable) {
+		t.Fatalf("Cached.Ready() err = %v, want ErrCacheUnavailable on a cold cache", err)
+	}
+	if backing.listCalls == 0 {
+		t.Fatal("Cached.Ready() never reached the backing store; test premise broken (it should prime)")
+	}
+
+	// ReadyCacheOnly must not prime: no new backing reads, ever.
+	primeListCalls := backing.listCalls
+	rows, err := handles.Cached.ReadyCacheOnly()
+	if !errors.Is(err, beads.ErrCacheUnavailable) {
+		t.Fatalf("ReadyCacheOnly() err = %v, want ErrCacheUnavailable on a cold cache", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("ReadyCacheOnly() rows = %+v, want none on a cold cache", rows)
+	}
+	if backing.listCalls != primeListCalls || backing.readyCalls != 0 {
+		t.Fatalf("ReadyCacheOnly() touched the backing store: listCalls %d->%d, readyCalls=%d",
+			primeListCalls, backing.listCalls, backing.readyCalls)
+	}
+
+	// Through the handler: GET /beads/ready?cached=true on the cold cache must not
+	// touch the backing store, and must surface the unavailability as a partial
+	// read that omits the city store, so the control dispatcher backs off and
+	// retries instead of acting on a falsely-idle queue.
+	backing.listCalls = 0
+	backing.readyCalls = 0
+	fs := newFakeState(t)
+	fs.cityBeadStore = cache
+	h := newTestCityHandler(t, fs)
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/beads/ready?cached=true"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if backing.listCalls != 0 || backing.readyCalls != 0 {
+		t.Fatalf("handler touched the backing store on a cold cached read: listCalls=%d readyCalls=%d",
+			backing.listCalls, backing.readyCalls)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Items         []beads.Bead `json:"items"`
+		Partial       bool         `json:"partial"`
+		PartialErrors []string     `json:"partial_errors"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	if !body.Partial {
+		t.Errorf("Partial = false, want true: a cold city cache read is non-authoritative")
+	}
+	if len(body.Items) != 0 {
+		t.Errorf("Items = %+v, want none: the cold cache must not fabricate ready work", body.Items)
+	}
+	foundCity := false
+	for _, e := range body.PartialErrors {
+		if strings.HasPrefix(e, CityReadyPartialLabel+": ") {
+			foundCity = true
+		}
+	}
+	if !foundCity {
+		t.Errorf("PartialErrors = %v, want a city-store entry so CityReadAuthoritative is false", body.PartialErrors)
+	}
+}
+
+// TestBeadReadyControlFilterAppliesServerSide proves the control dispatcher's
+// assignee/route predicate is applied server-side, before serialization, when
+// the request carries control_assignees/control_routes. Only the dispatcher's own
+// control work crosses the wire; every other rig's ready bead is filtered out by
+// the supervisor instead of being shipped for the dispatcher to discard.
+func TestBeadReadyControlFilterAppliesServerSide(t *testing.T) {
+	city := beads.NewMemStore()
+	for _, b := range []beads.Bead{
+		{Type: "task", Title: "mine-assigned", Assignee: "ctl-session"},
+		{Type: "task", Title: "other-assigned", Assignee: "someone-else"},
+		{Type: "task", Title: "mine-routed", Metadata: map[string]string{beadmeta.RunTargetMetadataKey: "ctl-route"}},
+		{Type: "task", Title: "unrelated-routed", Metadata: map[string]string{beadmeta.RunTargetMetadataKey: "other-route"}},
+	} {
+		if _, err := city.Create(b); err != nil {
+			t.Fatalf("seed %q: %v", b.Title, err)
+		}
+	}
+
+	fs := newFakeState(t)
+	fs.cityBeadStore = city
+	h := newTestCityHandler(t, fs)
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/beads/ready?cached=true&control_assignees=ctl-session&control_routes=ctl-route&control_limit=10"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Items []beads.Bead `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	got := make(map[string]bool, len(body.Items))
+	var titles []string
+	for _, b := range body.Items {
+		got[b.Title] = true
+		titles = append(titles, b.Title)
+	}
+	if !got["mine-assigned"] || !got["mine-routed"] {
+		t.Errorf("Items = %v, want both mine-assigned (assignee match) and mine-routed (route match)", titles)
+	}
+	if got["other-assigned"] || got["unrelated-routed"] {
+		t.Errorf("Items = %v, want the server-side filter to drop other-assigned and unrelated-routed", titles)
+	}
+}

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -270,6 +271,13 @@ func beadListCountQuery(assignee string, input *BeadListInput) beads.ListQuery {
 	return q
 }
 
+// CityReadyPartialLabel is the partialAggregator label the federated
+// /beads/ready handler records city-store failures under. ReadyBeads.
+// CityReadAuthoritative keys off it (partialAggregator records failures as
+// "<label>: <error>") to tell a partial read that omitted the city store —
+// where graph control beads live — apart from one that only lost a rig store.
+const CityReadyPartialLabel = "city"
+
 // humaHandleBeadReady is the Huma-typed handler for GET /v0/beads/ready.
 func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput) (*ListOutput[beads.Bead], error) {
 	bp := input.toBlockingParams()
@@ -287,7 +295,27 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 			return
 		}
 		pa.attempt()
-		ready, err := beads.HandlesFor(store).Live.Ready()
+		// /beads/ready is authoritative live readiness by default: it reads the
+		// live backing store so no caller ever sees a closed or newly-blocked
+		// bead reported as ready (TestBeadReadyUsesLiveLookup). The control
+		// dispatcher (api.Client.ListReadyBeads) opts into cached=true to read
+		// the supervisor cache projection instead, so its tight serve loop
+		// avoids the blocking/failing backing-store scan the control-ready cache
+		// exists to avoid. For the supervisor's CachingStore the Cached handle's
+		// ReadyCacheOnly reads the in-memory projection and never primes the
+		// backing store (returning ErrCacheUnavailable when the projection is not
+		// live, which the federation surfaces as a partial/outage so the
+		// dispatcher backs off instead of hanging on a cold or dirty cache); for
+		// a plain store both handles delegate to the same Ready, so non-caching
+		// backends behave identically on either path.
+		handles := beads.HandlesFor(store)
+		var ready []beads.Bead
+		var err error
+		if input.Cached {
+			ready, err = handles.Cached.ReadyCacheOnly()
+		} else {
+			ready, err = handles.Live.Ready()
+		}
 		if err != nil {
 			if beads.IsPartialResult(err) && len(ready) > 0 {
 				pa.record(label, err)
@@ -312,7 +340,7 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 	// `bd ready` would never surface it. In production BeadStores() also returns
 	// the city store keyed by CityName() (cmd/gc/api_state.go), so skip that
 	// duplicate key in the rig loop below to avoid querying it twice.
-	federate("city", s.state.CityBeadStore())
+	federate(CityReadyPartialLabel, s.state.CityBeadStore())
 	cityName := s.state.CityName()
 	for _, rigName := range rigNames {
 		if rigName == cityName {
@@ -324,6 +352,14 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 	if pa.totalOutage() {
 		return nil, pa.outageError()
 	}
+
+	// Apply the control-ready predicate and per-group limit server-side, before
+	// serialization, when the caller (the control dispatcher) supplied them. This
+	// keeps the dispatcher from pulling the full federated ready set across the
+	// API just to discard everything that is not its own control work. An
+	// inactive filter (no control params) returns the set unchanged, so generic
+	// callers keep the full ready list.
+	all = beadReadyControlFilter(input).Apply(all)
 
 	if all == nil {
 		all = []beads.Bead{}
@@ -339,6 +375,35 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 			PartialErrors: pa.messages(),
 		},
 	}, nil
+}
+
+// beadReadyControlFilter builds the server-side control-ready filter from the
+// /beads/ready query params. It is inactive (a no-op over the federated set)
+// unless control_assignees or control_routes is set, so generic ready callers
+// (CLI, dashboard) are unaffected.
+func beadReadyControlFilter(input *BeadReadyInput) beads.ControlReadyFilter {
+	return beads.ControlReadyFilter{
+		Assignees:     splitControlReadyList(input.ControlAssignees),
+		Routes:        splitControlReadyList(input.ControlRoutes),
+		PerGroupLimit: input.ControlLimit,
+	}
+}
+
+// splitControlReadyList splits a comma-separated control-ready param into a
+// trimmed, empty-free slice. Control assignees and routes are session names and
+// template/route identifiers, which never contain commas.
+func splitControlReadyList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // humaHandleBeadGraph is the Huma-typed handler for GET /v0/beads/graph/{rootID}.

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -305,9 +305,11 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 		// ReadyCacheOnly reads the in-memory projection and never primes the
 		// backing store (returning ErrCacheUnavailable when the projection is not
 		// live, which the federation surfaces as a partial/outage so the
-		// dispatcher backs off instead of hanging on a cold or dirty cache); for
-		// a plain store both handles delegate to the same Ready, so non-caching
-		// backends behave identically on either path.
+		// dispatcher backs off instead of hanging on a cold cache); an unrelated
+		// dirty bead is scoped out per-bead rather than declining the whole read,
+		// so it cannot stall the fallback-free control lane. For a plain store
+		// both handles delegate to the same Ready, so non-caching backends behave
+		// identically on either path.
 		handles := beads.HandlesFor(store)
 		var ready []beads.Bead
 		var err error

--- a/internal/api/huma_types_beads.go
+++ b/internal/api/huma_types_beads.go
@@ -30,6 +30,31 @@ type BeadListInput struct {
 type BeadReadyInput struct {
 	CityScope
 	BlockingParam
+	// Cached opts into the supervisor cache projection instead of the
+	// authoritative live backing store. The control dispatcher
+	// (api.Client.ListReadyBeads) sets it so its tight serve loop reads ready
+	// work from the in-memory projection and avoids the blocking/failing
+	// backing-store scan the control-ready cache exists to avoid; cache
+	// unavailability surfaces as a partial/outage so the dispatcher backs off.
+	// Omitted (the default) the endpoint stays authoritative live readiness, so
+	// a closed or newly-blocked bead is never reported as ready.
+	Cached bool `query:"cached" required:"false" doc:"Serve ready work from the supervisor cache projection (eventually consistent) instead of the authoritative live backing store. Defaults to false (live)."`
+	// ControlAssignees and ControlRoutes opt into server-side control-ready
+	// filtering: only ready beads assigned to one of the comma-separated
+	// assignees, or unassigned beads routed (by run-target, routed-to, or
+	// execution-routed-to metadata) to one of the comma-separated routes, are
+	// returned. The control dispatcher sends its resolved assignee and route sets
+	// so the supervisor filters its control work out of the federated ready set
+	// before serialization, instead of shipping every rig's ready beads for the
+	// dispatcher to filter client-side. Empty (the default) returns the full
+	// federated ready set unchanged, so generic callers (CLI, dashboard) are
+	// unaffected.
+	ControlAssignees string `query:"control_assignees" required:"false" doc:"Comma-separated assignees: keep only ready beads assigned to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side."`
+	ControlRoutes    string `query:"control_routes" required:"false" doc:"Comma-separated routes: keep unassigned ready beads routed (run-target/routed-to/execution-routed-to) to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side."`
+	// ControlLimit bounds how many ready beads each control assignee and each
+	// control route may contribute (per-group; 0 = unbounded). It is applied with
+	// ControlAssignees/ControlRoutes and ignored when both are empty.
+	ControlLimit int `query:"control_limit" required:"false" minimum:"0" doc:"Per-group cap on ready beads contributed by each control assignee and route. 0 = unbounded. Ignored unless control_assignees or control_routes is set."`
 }
 
 // BeadGraphInput is the Huma input for GET /v0/city/{cityName}/beads/graph/{rootID}.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -19521,6 +19521,48 @@
               "description": "How long to block waiting for changes (Go duration string, e.g. 30s). Default 30s, max 2m.",
               "type": "string"
             }
+          },
+          {
+            "description": "Serve ready work from the supervisor cache projection (eventually consistent) instead of the authoritative live backing store. Defaults to false (live).",
+            "explode": false,
+            "in": "query",
+            "name": "cached",
+            "schema": {
+              "description": "Serve ready work from the supervisor cache projection (eventually consistent) instead of the authoritative live backing store. Defaults to false (live).",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Comma-separated assignees: keep only ready beads assigned to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+            "explode": false,
+            "in": "query",
+            "name": "control_assignees",
+            "schema": {
+              "description": "Comma-separated assignees: keep only ready beads assigned to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated routes: keep unassigned ready beads routed (run-target/routed-to/execution-routed-to) to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+            "explode": false,
+            "in": "query",
+            "name": "control_routes",
+            "schema": {
+              "description": "Comma-separated routes: keep unassigned ready beads routed (run-target/routed-to/execution-routed-to) to one of these. Empty returns the full ready set. Used by the control dispatcher to filter server-side.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Per-group cap on ready beads contributed by each control assignee and route. 0 = unbounded. Ignored unless control_assignees or control_routes is set.",
+            "explode": false,
+            "in": "query",
+            "name": "control_limit",
+            "schema": {
+              "description": "Per-group cap on ready beads contributed by each control assignee and route. 0 = unbounded. Ignored unless control_assignees or control_routes is set.",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
           }
         ],
         "responses": {

--- a/internal/api/types_read.go
+++ b/internal/api/types_read.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
@@ -38,6 +39,38 @@ import (
 type CachedRead[T any] struct {
 	Body       T
 	AgeSeconds float64
+}
+
+// ReadyBeads is the CLI-facing result of the federated GET
+// /v0/city/{cityName}/beads/ready read. Unlike the generic CachedRead wrapper it
+// preserves the partial-aggregation contract (Partial / PartialErrors) so
+// controller-side consumers can tell an authoritative ready set apart from one
+// where a backing store — for example the city store that holds graph control
+// beads — failed and was silently omitted. A zero AgeSeconds means the server
+// surfaced no cache age.
+type ReadyBeads struct {
+	Body          []beads.Bead
+	AgeSeconds    float64
+	Partial       bool
+	PartialErrors []string
+}
+
+// CityReadAuthoritative reports whether the ready read can be trusted to contain
+// every city-store bead. It is false only when a partial federated read recorded
+// a city-store failure; an unrelated rig-store failure still leaves the city
+// store (where graph control beads live) authoritative. The city store is
+// federated under CityReadyPartialLabel and partialAggregator records failures
+// as "<label>: <error>", so a city-store omission is detectable by prefix.
+func (r ReadyBeads) CityReadAuthoritative() bool {
+	if !r.Partial {
+		return true
+	}
+	for _, msg := range r.PartialErrors {
+		if strings.HasPrefix(msg, CityReadyPartialLabel+": ") {
+			return false
+		}
+	}
+	return true
 }
 
 // cacheAgeHeader is the wire name of the X-GC-Cache-Age-S response header,

--- a/internal/api/types_read_test.go
+++ b/internal/api/types_read_test.go
@@ -1,0 +1,44 @@
+package api
+
+import "testing"
+
+func TestReadyBeadsCityReadAuthoritative(t *testing.T) {
+	cases := []struct {
+		name   string
+		ready  ReadyBeads
+		wantOK bool
+	}{
+		{
+			name:   "complete read is authoritative",
+			ready:  ReadyBeads{Partial: false},
+			wantOK: true,
+		},
+		{
+			name:   "partial omitting city store is not authoritative",
+			ready:  ReadyBeads{Partial: true, PartialErrors: []string{CityReadyPartialLabel + ": read ready: store slow"}},
+			wantOK: false,
+		},
+		{
+			name:   "partial losing only a rig store stays authoritative",
+			ready:  ReadyBeads{Partial: true, PartialErrors: []string{"rig alpha: read ready: store slow"}},
+			wantOK: true,
+		},
+		{
+			name:   "partial flag without recorded errors stays authoritative",
+			ready:  ReadyBeads{Partial: true},
+			wantOK: true,
+		},
+		{
+			name:   "city failure among several rigs is detected",
+			ready:  ReadyBeads{Partial: true, PartialErrors: []string{"rig alpha: boom", CityReadyPartialLabel + ": boom"}},
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ready.CityReadAuthoritative(); got != tc.wantOK {
+				t.Fatalf("CityReadAuthoritative() = %v, want %v", got, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -13,10 +13,16 @@ import (
 // historical lookups. List reads across both bead tiers regardless of the
 // caller's TierMode; use the underlying Store directly for intentionally
 // tier-scoped list queries.
+//
+// Ready and the other read methods may perform a one-time synchronous prime
+// from the backing store when the projection is not yet live. ReadyCacheOnly is
+// the strict variant that never primes — see its doc — for hot-path callers
+// that must not block on the backing store.
 type CachedReader interface {
 	Get(id string) (Bead, error)
 	List(query ListQuery) ([]Bead, error)
 	Ready(query ...ReadyQuery) ([]Bead, error)
+	ReadyCacheOnly(query ...ReadyQuery) ([]Bead, error)
 	DepList(id, direction string) ([]Dep, error)
 }
 
@@ -96,6 +102,14 @@ func (r logicalCachedStoreReader) Ready(query ...ReadyQuery) ([]Bead, error) {
 	return r.store.Ready(query...)
 }
 
+// ReadyCacheOnly delegates to the store's Ready: a plain (non-caching) store has
+// no separate backing tier to prime, so its in-process read already cannot block
+// on a remote cache prime. A CachingStore overrides this through its explicit
+// Handles() implementation with a strictly non-priming projection read.
+func (r logicalCachedStoreReader) ReadyCacheOnly(query ...ReadyQuery) ([]Bead, error) {
+	return r.store.Ready(query...)
+}
+
 func (r logicalCachedStoreReader) DepList(id, direction string) ([]Dep, error) {
 	return r.store.DepList(id, direction)
 }
@@ -148,6 +162,16 @@ func (r cachedStoreReader) Ready(query ...ReadyQuery) ([]Bead, error) {
 	if err := r.store.ensureFullPrime(context.Background()); err != nil {
 		return nil, err
 	}
+	return r.store.cachedReadyOnly(readyQueryFromArgs(query))
+}
+
+// ReadyCacheOnly reads ready beads strictly from the in-memory projection and
+// never triggers a backing-store prime. When the projection is not live enough
+// to answer it returns ErrCacheUnavailable instead of priming, so a hot-path
+// caller (the control dispatcher's GET /beads/ready?cached=true) cannot block or
+// fail on the backing store the control-ready cache exists to bypass. Use Ready
+// when a one-time synchronous prime is acceptable.
+func (r cachedStoreReader) ReadyCacheOnly(query ...ReadyQuery) ([]Bead, error) {
 	return r.store.cachedReadyOnly(readyQueryFromArgs(query))
 }
 

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -169,8 +169,12 @@ func (r cachedStoreReader) Ready(query ...ReadyQuery) ([]Bead, error) {
 // never triggers a backing-store prime. When the projection is not live enough
 // to answer it returns ErrCacheUnavailable instead of priming, so a hot-path
 // caller (the control dispatcher's GET /beads/ready?cached=true) cannot block or
-// fail on the backing store the control-ready cache exists to bypass. Use Ready
-// when a one-time synchronous prime is acceptable.
+// fail on the backing store the control-ready cache exists to bypass. Dirtiness
+// is scoped per bead: an unconfirmed cross-process write on an unrelated bead
+// omits only that bead (and any candidate that depends on it) from the result
+// rather than declining the whole read, so one dirty bead cannot stall a
+// cache-only reader that has no live fallback. Use Ready when a one-time
+// synchronous prime is acceptable.
 func (r cachedStoreReader) ReadyCacheOnly(query ...ReadyQuery) ([]Bead, error) {
 	return r.store.cachedReadyOnly(readyQueryFromArgs(query))
 }
@@ -255,15 +259,34 @@ func (c *CachingStore) cachedListOnly(query ListQuery) ([]Bead, error) {
 func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	if (c.state != cacheLive && c.state != cachePartial) || c.primePartialErr != nil || len(c.dirty) > 0 {
+	if (c.state != cacheLive && c.state != cachePartial) || c.primePartialErr != nil {
 		return nil, fmt.Errorf("reading ready beads from cache: %w", ErrCacheUnavailable)
 	}
+	// A dirty bead is an unconfirmed cross-process write-through conflict, not a
+	// reason to decline the whole read: scope the decline to the dirty beads
+	// themselves (and any candidate that depends on one) rather than returning
+	// ErrCacheUnavailable for every caller when len(c.dirty) > 0. The control
+	// dispatcher reads this path cache-only with no live fallback, so a
+	// whole-store decline let one unrelated dirty bead (mail, a session-lifecycle
+	// projection, an unrelated step) stall all graph control-ready dispatch until
+	// the next reconcile. Per-bead scoping mirrors cachedGetOnly's existing dirty
+	// decline and keeps the false-positive guarantee below.
+	hasDirty := len(c.dirty) > 0
 
 	statusByID := make(map[string]string, len(c.beads))
 	openBeads := make([]Bead, 0, len(c.beads))
 	now := time.Now().UTC()
 	for _, b := range c.beads {
 		statusByID[b.ID] = b.Status
+		if hasDirty {
+			if _, dirty := c.dirty[b.ID]; dirty {
+				// Skip only the dirty bead: its cached status/assignee/routing may
+				// be stale, so serving it as ready off that row would strand it (the
+				// #2927 class). It is picked up once a confirming event or reconcile
+				// clears its dirty flag.
+				continue
+			}
+		}
 		if !IsReadyCandidateForTier(b, now, query.TierMode) {
 			continue
 		}
@@ -288,6 +311,13 @@ func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
 		default:
 			return nil, fmt.Errorf("reading ready deps from cache: %w", ErrCacheUnavailable)
 		}
+		if hasDirty && dependencyDirty(c.dirty, deps) {
+			// A candidate whose blocking dependency is dirty cannot have its
+			// readiness confirmed from cache: the dep's cached status may be stale,
+			// so treating it as closed could dispatch a not-actually-ready bead (the
+			// #2927 false-positive class). Skip until the dep's dirty flag clears.
+			continue
+		}
 		if !cachedBeadReady(b, statusByID, deps) {
 			continue
 		}
@@ -297,6 +327,28 @@ func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
 		}
 	}
 	return result, nil
+}
+
+// dependencyDirty reports whether any of a candidate's ready-blocking
+// dependencies is marked dirty. A dirty dependency's cached status is an
+// unconfirmed cross-process write, so it cannot be trusted to decide the
+// dependent bead's readiness from cache. Only ready-blocking types
+// (blocks/waits-for/conditional-blocks) feed cachedBeadReady, so a dirty
+// non-blocking edge — such as the parent-child edge every graph.v2 step holds
+// to its workflow root — cannot change cached readiness and must not suppress
+// the candidate; gating on isReadyBlockingDependencyType keeps the skip set to
+// exactly the deps whose staleness could flip the answer, mirroring
+// cachedBeadReady.
+func dependencyDirty(dirty map[string]struct{}, deps []Dep) bool {
+	for _, dep := range deps {
+		if !isReadyBlockingDependencyType(dep.Type) {
+			continue
+		}
+		if _, ok := dirty[dep.DependsOnID]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *CachingStore) cachedDepListOnly(id, direction string) ([]Dep, error) {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -4276,3 +4276,204 @@ func TestCachingStoreReadyReturnsCanonicalOrder(t *testing.T) {
 		t.Fatalf("cachedReadyOnly limit-3 order = %v, want %v", ids, want[:3])
 	}
 }
+
+// TestCachedReadyOnlySkipsUnrelatedDirtyBeadInsteadOfStalling is a regression
+// for the control-ready whole-store dirtiness stall. cachedReadyOnly used to
+// decline the entire read whenever any bead was dirty (len(c.dirty) > 0), so a
+// single unrelated dirty bead — mail, a session-lifecycle projection, an
+// unrelated step — returned ErrCacheUnavailable for every control-ready read
+// until the next reconcile (up to the 30–120s adaptive interval). The control
+// dispatcher reads cache-only with no live fallback, so that stalled all graph
+// control dispatch on unrelated dirtiness. The dirty bead is now skipped
+// per-bead (mirroring cachedGetOnly's existing per-bead dirty decline): the rest
+// of the ready set is served and the dirty bead is not served from its stale
+// row.
+func TestCachedReadyOnlySkipsUnrelatedDirtyBeadInsteadOfStalling(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	ready1, err := backing.Create(Bead{Title: "ready-1"})
+	if err != nil {
+		t.Fatalf("Create ready-1: %v", err)
+	}
+	ready2, err := backing.Create(Bead{Title: "ready-2"})
+	if err != nil {
+		t.Fatalf("Create ready-2: %v", err)
+	}
+	unrelated, err := backing.Create(Bead{Title: "unrelated"})
+	if err != nil {
+		t.Fatalf("Create unrelated: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// Simulate an unconfirmed cross-process write-through conflict on a bead the
+	// control-ready query does not care about.
+	cache.mu.Lock()
+	cache.dirty[unrelated.ID] = struct{}{}
+	cache.mu.Unlock()
+
+	got, err := cache.cachedReadyOnly(ReadyQuery{})
+	if err != nil {
+		t.Fatalf("cachedReadyOnly with one unrelated dirty bead = %v, want no error", err)
+	}
+	ids := map[string]bool{}
+	for _, b := range got {
+		ids[b.ID] = true
+	}
+	if !ids[ready1.ID] || !ids[ready2.ID] {
+		t.Fatalf("cachedReadyOnly ids = %v, want ready-1 (%s) and ready-2 (%s) served despite unrelated dirty bead", ids, ready1.ID, ready2.ID)
+	}
+	if ids[unrelated.ID] {
+		t.Fatalf("cachedReadyOnly served dirty bead %s from its stale row; want it skipped", unrelated.ID)
+	}
+}
+
+// TestCachedReadyOnlySkipsCandidateWithDirtyDependency proves the per-bead skip
+// preserves the false-positive guarantee the dirty flag exists for (#2927): a
+// candidate whose blocking dependency is dirty cannot have its readiness
+// confirmed from cache — the dep's cached "closed" status may be stale — so it
+// is skipped rather than dispatched off an unconfirmed row. Unrelated ready
+// beads are still served.
+func TestCachedReadyOnlySkipsCandidateWithDirtyDependency(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	dep, err := backing.Create(Bead{Title: "dep"})
+	if err != nil {
+		t.Fatalf("Create dep: %v", err)
+	}
+	dependent, err := backing.Create(Bead{Title: "dependent", Dependencies: []Dep{{DependsOnID: dep.ID, Type: "blocks"}}})
+	if err != nil {
+		t.Fatalf("Create dependent: %v", err)
+	}
+	other, err := backing.Create(Bead{Title: "other"})
+	if err != nil {
+		t.Fatalf("Create other: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// Present the dependency as closed and pin the dependent's blocking edge,
+	// independent of how Prime loaded deps, so the dependent is a ready candidate.
+	cache.mu.Lock()
+	depBead := cache.beads[dep.ID]
+	depBead.Status = "closed"
+	cache.beads[dep.ID] = depBead
+	cache.deps[dependent.ID] = []Dep{{IssueID: dependent.ID, DependsOnID: dep.ID, Type: "blocks"}}
+	cache.mu.Unlock()
+
+	containsID := func(rows []Bead, id string) bool {
+		for _, b := range rows {
+			if b.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Precondition: with a clean cache the dependent is ready (dep closed).
+	clean, err := cache.cachedReadyOnly(ReadyQuery{})
+	if err != nil {
+		t.Fatalf("cachedReadyOnly clean: %v", err)
+	}
+	if !containsID(clean, dependent.ID) {
+		t.Fatalf("clean cachedReadyOnly missing dependent %s; blocking edge not honored", dependent.ID)
+	}
+
+	// Mark the (closed) dependency dirty: its cached status is now unconfirmed,
+	// so the dependent's readiness can no longer be decided from cache.
+	cache.mu.Lock()
+	cache.dirty[dep.ID] = struct{}{}
+	cache.mu.Unlock()
+
+	got, err := cache.cachedReadyOnly(ReadyQuery{})
+	if err != nil {
+		t.Fatalf("cachedReadyOnly with dirty dependency = %v, want no error", err)
+	}
+	if containsID(got, dependent.ID) {
+		t.Fatalf("cachedReadyOnly served dependent %s whose blocking dep %s is dirty; want it skipped", dependent.ID, dep.ID)
+	}
+	if !containsID(got, other.ID) {
+		t.Fatalf("cachedReadyOnly dropped unrelated ready bead %s", other.ID)
+	}
+}
+
+// TestCachedReadyOnlyServesCandidateWithDirtyNonBlockingDependency proves the
+// dirty-dependency skip is scoped to ready-blocking dependency types. A dirty
+// non-blocking dependency (parent-child, tracks, relates-to) can never change a
+// candidate's cached readiness — cachedBeadReady consults only blocking deps —
+// so it must not suppress an otherwise-ready candidate. graph.v2 control steps
+// hold a non-blocking parent-child edge to their workflow root, so gating
+// dependencyDirty on the blocking-type predicate keeps a race-dirty root from
+// starving its ready child control steps (the correlated-skip class this PR
+// removes at whole-store granularity, here at root granularity).
+func TestCachedReadyOnlyServesCandidateWithDirtyNonBlockingDependency(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	root, err := backing.Create(Bead{Title: "root"})
+	if err != nil {
+		t.Fatalf("Create root: %v", err)
+	}
+	child, err := backing.Create(Bead{Title: "child", Dependencies: []Dep{{DependsOnID: root.ID, Type: "parent-child"}}})
+	if err != nil {
+		t.Fatalf("Create child: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// Pin the child's non-blocking parent-child edge to the root, independent of
+	// how Prime loaded deps. The root stays open: a parent-child edge never gates
+	// readiness, so the child is a ready candidate regardless of the root's status.
+	cache.mu.Lock()
+	cache.deps[child.ID] = []Dep{{IssueID: child.ID, DependsOnID: root.ID, Type: "parent-child"}}
+	cache.mu.Unlock()
+
+	containsID := func(rows []Bead, id string) bool {
+		for _, b := range rows {
+			if b.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Precondition: with a clean cache the child is ready (non-blocking dep does
+	// not gate it).
+	clean, err := cache.cachedReadyOnly(ReadyQuery{})
+	if err != nil {
+		t.Fatalf("cachedReadyOnly clean: %v", err)
+	}
+	if !containsID(clean, child.ID) {
+		t.Fatalf("clean cachedReadyOnly missing child %s; non-blocking parent-child edge should not gate readiness", child.ID)
+	}
+
+	// Mark the root dirty: its cached status is now unconfirmed, but it is only a
+	// non-blocking parent-child dependency of the child, so it cannot affect the
+	// child's readiness. The child must still be served; only the dirty root is
+	// skipped from its own stale row.
+	cache.mu.Lock()
+	cache.dirty[root.ID] = struct{}{}
+	cache.mu.Unlock()
+
+	got, err := cache.cachedReadyOnly(ReadyQuery{})
+	if err != nil {
+		t.Fatalf("cachedReadyOnly with dirty non-blocking dependency = %v, want no error", err)
+	}
+	if !containsID(got, child.ID) {
+		t.Fatalf("cachedReadyOnly dropped child %s whose only dirty dep %s is a non-blocking parent-child edge; want it served", child.ID, root.ID)
+	}
+	if containsID(got, root.ID) {
+		t.Fatalf("cachedReadyOnly served dirty root %s from its stale row; want it skipped", root.ID)
+	}
+}

--- a/internal/beads/control_ready_filter.go
+++ b/internal/beads/control_ready_filter.go
@@ -1,0 +1,94 @@
+package beads
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+)
+
+// ControlReadyFilter selects the ready control beads a control dispatcher cares
+// about out of a federated ready set: beads assigned to one of Assignees, or
+// unassigned beads routed — by run-target, routed-to, or execution-routed-to
+// metadata — to one of Routes. PerGroupLimit bounds how many beads each assignee
+// and each route may contribute (0 = unbounded); dedup is global across groups.
+//
+// It exists so GET /beads/ready?cached=true can apply the dispatcher's predicate
+// and limit server-side, before serialization, instead of shipping the entire
+// federated ready set across the API for the dispatcher to filter client-side.
+// The dispatcher applies the same filter again on its side as idempotent
+// defense-in-depth, so the server and client predicates cannot drift.
+type ControlReadyFilter struct {
+	Assignees     []string
+	Routes        []string
+	PerGroupLimit int
+}
+
+// Active reports whether the filter has any assignee or route to match. An
+// inactive filter is a no-op: Apply returns its input unchanged so the generic
+// /beads/ready callers (CLI, dashboard) keep the full federated ready set.
+func (f ControlReadyFilter) Active() bool {
+	return len(f.Assignees) > 0 || len(f.Routes) > 0
+}
+
+// Apply returns the ready control beads matching this filter. It preserves the
+// input order within each group and applies PerGroupLimit per assignee and per
+// route, deduping globally by bead ID. An inactive filter returns in unchanged.
+//
+// The grouped, per-group-limited selection mirrors the control dispatcher's
+// historical scan exactly, and is idempotent — Apply(Apply(x)) == Apply(x) —
+// because assignee groups are mutually disjoint (a bead has one assignee) and
+// route groups only match unassigned beads, so re-applying on an already-filtered
+// set reselects the same beads. That is what lets the server pre-filter and the
+// dispatcher re-filter without changing the result.
+func (f ControlReadyFilter) Apply(in []Bead) []Bead {
+	if !f.Active() {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	var out []Bead
+	addMatches := func(match func(Bead) bool) {
+		added := 0
+		for _, b := range in {
+			if f.PerGroupLimit > 0 && added >= f.PerGroupLimit {
+				return
+			}
+			if !match(b) || !controlReadyEligible(b) {
+				continue
+			}
+			if _, ok := seen[b.ID]; ok {
+				continue
+			}
+			seen[b.ID] = struct{}{}
+			out = append(out, b)
+			added++
+		}
+	}
+	for _, assignee := range f.Assignees {
+		assignee := assignee
+		addMatches(func(b Bead) bool { return b.Assignee == assignee })
+	}
+	for _, route := range f.Routes {
+		route := route
+		addMatches(func(b Bead) bool {
+			if strings.TrimSpace(b.Assignee) != "" {
+				return false
+			}
+			return b.Metadata[beadmeta.RunTargetMetadataKey] == route ||
+				b.Metadata[beadmeta.RoutedToMetadataKey] == route ||
+				b.Metadata[beadmeta.ExecutionRoutedToMetadataKey] == route
+		})
+	}
+	return out
+}
+
+// controlReadyEligible guards which ready beads a control dispatcher may claim:
+// a non-empty ID, not an epic, and no transient gc.instantiating marker (which
+// flags a workflow root whose molecule has not finished instantiating). Fenced
+// workflow roots are already excluded by the ready projection; the marker check
+// is defense-in-depth so a future change to the fencing path cannot let the
+// dispatcher run control work before instantiation clears it.
+func controlReadyEligible(b Bead) bool {
+	return strings.TrimSpace(b.ID) != "" &&
+		strings.TrimSpace(b.Type) != "epic" &&
+		strings.TrimSpace(b.Metadata[beadmeta.InstantiatingMetadataKey]) == ""
+}

--- a/internal/beads/control_ready_filter.go
+++ b/internal/beads/control_ready_filter.go
@@ -67,6 +67,16 @@ func (f ControlReadyFilter) Apply(in []Bead) []Bead {
 		assignee := assignee
 		addMatches(func(b Bead) bool { return b.Assignee == assignee })
 	}
+	// Match an unassigned bead by any routing key that names a control route.
+	// This trusts the routing metadata without re-checking gc.kind: that is safe
+	// because graph routing stamps a control-dispatcher route (run-target,
+	// routed-to, or execution-routed-to) exclusively on control-kind steps —
+	// DecorateGraphWorkflowRecipe gates the control binding on
+	// graphroute.IsControlDispatcherKind, so a non-control bead never carries a
+	// control-dispatcher route to match here (pinned by
+	// TestAssignGraphStepRoute_NonControlStepOmitsControlDispatcherRoute). A bead
+	// admitted here therefore has a control kind the dispatcher's ProcessControl
+	// switch handles, not one it would quarantine.
 	for _, route := range f.Routes {
 		route := route
 		addMatches(func(b Bead) bool {

--- a/internal/beads/control_ready_filter_test.go
+++ b/internal/beads/control_ready_filter_test.go
@@ -1,0 +1,152 @@
+package beads
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+)
+
+func controlReadyIDs(bs []Bead) []string {
+	out := make([]string, 0, len(bs))
+	for _, b := range bs {
+		out = append(out, b.ID)
+	}
+	return out
+}
+
+func TestControlReadyFilterActive(t *testing.T) {
+	if (ControlReadyFilter{}).Active() {
+		t.Error("empty filter Active() = true, want false")
+	}
+	if !(ControlReadyFilter{Assignees: []string{"a"}}).Active() {
+		t.Error("assignee filter Active() = false, want true")
+	}
+	if !(ControlReadyFilter{Routes: []string{"r"}}).Active() {
+		t.Error("route filter Active() = false, want true")
+	}
+	// A limit alone is not a predicate: with nothing to match it must stay a
+	// no-op so generic /beads/ready callers keep the full set.
+	if (ControlReadyFilter{PerGroupLimit: 5}).Active() {
+		t.Error("limit-only filter Active() = true, want false")
+	}
+}
+
+func TestControlReadyFilterApplyInactiveReturnsInputUnchanged(t *testing.T) {
+	in := []Bead{{ID: "a"}, {ID: "b"}}
+	got := (ControlReadyFilter{}).Apply(in)
+	if !reflect.DeepEqual(got, in) {
+		t.Fatalf("inactive Apply = %v, want input unchanged %v", controlReadyIDs(got), controlReadyIDs(in))
+	}
+}
+
+func TestControlReadyFilterApplyMatchesAssigneeAndRoutes(t *testing.T) {
+	in := []Bead{
+		{ID: "assigned-me", Assignee: "session-1"},
+		{ID: "assigned-other", Assignee: "session-2"},
+		{ID: "route-run-target", Metadata: map[string]string{beadmeta.RunTargetMetadataKey: "ctl"}},
+		{ID: "route-routed-to", Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "ctl"}},
+		{ID: "route-exec-routed", Metadata: map[string]string{beadmeta.ExecutionRoutedToMetadataKey: "ctl"}},
+		{ID: "route-but-assigned", Assignee: "someone", Metadata: map[string]string{beadmeta.RunTargetMetadataKey: "ctl"}},
+		{ID: "route-other", Metadata: map[string]string{beadmeta.RunTargetMetadataKey: "different"}},
+	}
+	f := ControlReadyFilter{Assignees: []string{"session-1"}, Routes: []string{"ctl"}}
+	got := controlReadyIDs(f.Apply(in))
+	want := []string{"assigned-me", "route-run-target", "route-routed-to", "route-exec-routed"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Apply = %v, want %v (assigned-other/route-but-assigned/route-other must be excluded)", got, want)
+	}
+}
+
+func TestControlReadyFilterApplyExcludesIneligible(t *testing.T) {
+	in := []Bead{
+		{ID: "", Assignee: "s"},                   // empty ID
+		{ID: "epic", Type: "epic", Assignee: "s"}, // epic
+		{ID: "instantiating", Assignee: "s", Metadata: map[string]string{beadmeta.InstantiatingMetadataKey: "1"}}, // instantiating
+		{ID: "ok", Assignee: "s"},
+	}
+	got := controlReadyIDs(ControlReadyFilter{Assignees: []string{"s"}}.Apply(in))
+	want := []string{"ok"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Apply = %v, want %v (empty-id/epic/instantiating excluded)", got, want)
+	}
+}
+
+func TestControlReadyFilterApplyPerGroupLimitAndDedup(t *testing.T) {
+	in := []Bead{
+		{ID: "a1", Assignee: "s"},
+		{ID: "a2", Assignee: "s"},
+		{ID: "a3", Assignee: "s"},
+		// Matches both routes "r1" and "r2"; dedup must keep it once, under the
+		// first route group it lands in.
+		{ID: "shared", Metadata: map[string]string{beadmeta.RunTargetMetadataKey: "r1", beadmeta.RoutedToMetadataKey: "r2"}},
+	}
+	f := ControlReadyFilter{Assignees: []string{"s"}, Routes: []string{"r1", "r2"}, PerGroupLimit: 2}
+	got := controlReadyIDs(f.Apply(in))
+	want := []string{"a1", "a2", "shared"} // assignee group capped at 2; shared deduped to route r1
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Apply = %v, want %v", got, want)
+	}
+}
+
+// TestControlReadyFilterApplyIdempotent pins the property the split server/client
+// filtering relies on: the supervisor pre-filters server-side and the dispatcher
+// re-filters client-side, so Apply over an already-filtered set must reselect the
+// same beads.
+func TestControlReadyFilterApplyIdempotent(t *testing.T) {
+	in := []Bead{
+		{ID: "a1", Assignee: "s"},
+		{ID: "a2", Assignee: "s"},
+		{ID: "a3", Assignee: "s"},
+		{ID: "r1", Metadata: map[string]string{beadmeta.RunTargetMetadataKey: "ctl"}},
+		{ID: "r2", Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "ctl"}},
+		{ID: "noise", Assignee: "other"},
+	}
+	f := ControlReadyFilter{Assignees: []string{"s"}, Routes: []string{"ctl"}, PerGroupLimit: 2}
+	once := f.Apply(in)
+	twice := f.Apply(once)
+	if !reflect.DeepEqual(controlReadyIDs(once), controlReadyIDs(twice)) {
+		t.Fatalf("Apply not idempotent: once=%v twice=%v", controlReadyIDs(once), controlReadyIDs(twice))
+	}
+}
+
+// TestCachedReadyCacheOnlyDefaultTierExcludesEphemeral pins the storage-tier
+// invariant the control dispatcher's cache-only ready scan relies on: it reads
+// the default tier (TierIssues), which surfaces durable beads and excludes
+// ephemeral (wisp) rows. Graph.v2 control beads are instantiated durable
+// (ApplyGraphPlan → StorageDefault), so the dispatcher sees them; if a future
+// change ever materialized a control bead ephemeral it would be silently dropped
+// from this scan — a silent orchestration stall. This guard turns that into a
+// loud failure. The cache primes both tiers, so the ephemeral bead is present in
+// the projection and genuinely tier-filtered here, not merely absent.
+func TestCachedReadyCacheOnlyDefaultTierExcludesEphemeral(t *testing.T) {
+	backing := NewMemStore()
+	durable, err := backing.Create(Bead{Type: "task", Title: "durable-control"})
+	if err != nil {
+		t.Fatalf("create durable: %v", err)
+	}
+	ephemeral, err := backing.Create(Bead{Type: "task", Title: "ephemeral-control", Ephemeral: true})
+	if err != nil {
+		t.Fatalf("create ephemeral: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	rows, err := HandlesFor(cache).Cached.ReadyCacheOnly()
+	if err != nil {
+		t.Fatalf("ReadyCacheOnly: %v", err)
+	}
+	got := make(map[string]bool, len(rows))
+	for _, b := range rows {
+		got[b.ID] = true
+	}
+	if !got[durable.ID] {
+		t.Errorf("durable control bead %s missing from the default-tier ready scan", durable.ID)
+	}
+	if got[ephemeral.ID] {
+		t.Errorf("ephemeral bead %s surfaced; the default-tier control-ready scan must exclude it, so control beads must be instantiated durable", ephemeral.ID)
+	}
+}

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -369,6 +369,9 @@ func IsTransientControllerError(err error) bool {
 	if errors.Is(err, errTransientControllerBoundary) {
 		return true
 	}
+	if errors.Is(err, ErrControllerAPIUnavailable) {
+		return true
+	}
 	msg := strings.ToLower(err.Error())
 	if isTransientWorkQueryFailure(msg) {
 		return true

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -99,6 +99,15 @@ var ErrControlPending = errors.New("workflow control pending")
 // that cannot become valid by waiting.
 var ErrControlGraphMalformed = errors.New("workflow control graph malformed")
 
+// ErrControllerAPIUnavailable reports that the supervisor/controller API used
+// to read control-ready work could not be reached (disabled via the GC_NO_API
+// escape hatch, or the controller is down/restarting). IsTransientControllerError
+// treats it as transient so the long-running control-dispatcher serve loop backs
+// off and retries instead of exiting the process; the cache-backed control-ready
+// scan has no direct-store fallback, so a hard error there would crash-loop the
+// dispatcher whenever the API blips.
+var ErrControllerAPIUnavailable = errors.New("controller API unavailable")
+
 // ProcessControl executes a graph.v2 control bead.
 //
 // The current graph.v2 runtime assumes a single controller processes a given

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
@@ -891,6 +892,51 @@ func TestAssignGraphStepRoute_ControlBindingPreservesDirectExecutionRoute(t *tes
 	}
 	if got := step.Metadata[GraphExecutionRigContextMetaKey]; got != "frontend" {
 		t.Fatalf("control execution rig context = %q, want frontend", got)
+	}
+}
+
+// TestAssignGraphStepRoute_NonControlStepOmitsControlDispatcherRoute pins the
+// structural guarantee the control-ready filter relies on
+// (internal/beads/control_ready_filter.go). That filter claims a bead for the
+// control dispatcher when its run-target / routed-to / execution-routed-to
+// metadata matches a control-dispatcher route, without checking gc.kind. That is
+// safe only because graph routing stamps a control-dispatcher route exclusively
+// on control-kind steps (DecorateGraphWorkflowRecipe gates the &controlRoute
+// binding on IsControlDispatcherKind). A non-control step routed with a nil
+// control binding gets its worker execution route in gc.routed_to, has its
+// execution-routed-to key cleared, and never carries a control-dispatcher route
+// in any key the filter matches — so it cannot be mis-claimed and quarantined by
+// the control dispatcher.
+func TestAssignGraphStepRoute_NonControlStepOmitsControlDispatcherRoute(t *testing.T) {
+	const controlRoute = "gascity/control-dispatcher"
+	step := &formula.RecipeStep{
+		Metadata: map[string]string{
+			// Stale routing from a prior decoration, including a control route the
+			// re-route must not leave behind.
+			beadmeta.RoutedToMetadataKey:          controlRoute,
+			beadmeta.ExecutionRoutedToMetadataKey: "stale-exec-route",
+		},
+	}
+	execution := GraphRouteBinding{QualifiedName: "gascity/claude", MetadataOnly: true}
+
+	AssignGraphStepRoute(step, execution, nil)
+
+	if got := step.Metadata[beadmeta.RoutedToMetadataKey]; got != "gascity/claude" {
+		t.Fatalf("non-control gc.routed_to = %q, want the worker execution route gascity/claude", got)
+	}
+	if got := step.Metadata[beadmeta.ExecutionRoutedToMetadataKey]; got != "" {
+		t.Fatalf("non-control execution-routed-to = %q, want empty (only control steps carry it)", got)
+	}
+	// None of the keys the control-ready filter matches on may hold a
+	// control-dispatcher route for a non-control step.
+	for _, key := range []string{
+		beadmeta.RunTargetMetadataKey,
+		beadmeta.RoutedToMetadataKey,
+		beadmeta.ExecutionRoutedToMetadataKey,
+	} {
+		if got := step.Metadata[key]; got == controlRoute {
+			t.Fatalf("non-control step carried control-dispatcher route %q in %q; the control-ready filter would mis-claim it", controlRoute, key)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Serve the control-dispatcher's "ready work" query from the supervisor API cache
instead of shelling out to `bd ready` from the workflow-serve loop.

`workflowServeControlReadyQuery` previously emitted a large
`BD_EXPORT_AUTO=false ... sh -c '...'` shell program that ran several
`bd --readonly --sandbox ready` invocations per dispatch sweep and merged
them with `jq`. This change replaces that with a compact, self-describing
internal query: an opaque `gc-control-ready-v1:` prefix carrying a
base64-encoded `workflowServeControlReadySpec` (target, control session name,
legacy target, bare target). `nextWorkflowServeBeads` recognizes that prefix
and resolves ready beads through `Client.ListReadyBeads()`, which hits the
already-present `GET /v0/city/{cityName}/beads/ready` endpoint and its
generated client method. The assignee/route tiering, legacy-route fallback,
bare-route upgrade handling, instantiating-bead exclusion, epic exclusion,
and per-tier scan limit are all reimplemented in Go
(`filterWorkflowServeControlReadyBeads`,
`workflowServeControlReadyAssignees`, `workflowServeControlReadyRoutes`) so
behavior is preserved without the shell/`jq`/`bd` subprocess chain.

New exported surface on the API client: `Client.ListReadyBeads()`. New
unexported symbols on the CLI side: `nextWorkflowServeControlReadyBeads`,
`workflowServeControlReadyQueryPrefix`, `workflowServeControlReadySpec`,
`parseWorkflowServeControlReadyQuery`, and the filter/route/assignee helpers.

## Why

This is a clean, **store-backend-agnostic** slice extracted from the local
sqlite deploy branch (`deploy/sqlite-b36-probe-attribution`) for upstreaming
to `main` ahead of the store-interface refactor and the
sqlite-behind-interfaces swap. It reads through the supervisor API cache
projection, not any backing store directly, so controller-side consumers
avoid direct backing-store reads regardless of which store
(dolt/sqlite/etc.) sits behind the supervisor. Landing it on `main` first
keeps the interface refactor from having to carry this dispatch change.

The slice carries **only** this dispatch/cache change — no
sqlite/graph-store/HTTP-shim code from the source branch. The endpoint and
`GetV0CityByCityNameBeadsReady` genclient method it relies on already exist
on `main`; this change just consumes them.

## Test

- `go build ./cmd/gc/ ./internal/api/` — clean
- `go vet ./cmd/gc/ ./internal/api/` — clean
- `go test ./cmd/gc/ -run 'TestWorkflowServeControlReady|TestNextWorkflowServeBeads|TestFilterWorkflowServeControlReadyBeads|TestControlDispatcherBareRoute'` — pass
- `go test ./internal/api/ -run 'TestClient|BeadsReady'` — pass

The dispatch test file was rewritten to pin the new in-process behavior
(internal cached query shape, route/assignee tiering, bare-route upgrade
claim, supervisor-API requirement) in place of the prior shell-script-driven
fake-`bd` tests.

Generated with Claude Code.
