### PR TITLE
fix(reconciler): compute awake-demand readiness from store deps, not bead status

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -140,19 +140,22 @@ func filterAssignedWorkBeadsForPoolDemand(
 }
 
 // filterAssignedWorkBeadsForSessionWake resolves work through assignment
-// identities because session wake decisions are per concrete session owner.
+// identities because session wake decisions are per concrete session owner. It
+// returns the filtered beads plus their store refs, index-aligned, so callers
+// can resolve store-scoped wake-demand readiness (storeScopedBeadKey) for the
+// surviving beads without re-deriving each bead's originating store.
 func filterAssignedWorkBeadsForSessionWake(
 	cfg *config.City,
 	cityPath string,
 	sessionBeads []beads.Bead,
 	assignedWorkBeads []beads.Bead,
 	assignedWorkStoreRefs []string,
-) []beads.Bead {
+) ([]beads.Bead, []string) {
 	if len(assignedWorkBeads) == 0 || len(assignedWorkStoreRefs) == 0 {
-		return assignedWorkBeads
+		return assignedWorkBeads, assignedWorkStoreRefs
 	}
 	if cfg == nil {
-		return assignedWorkBeads
+		return assignedWorkBeads, assignedWorkStoreRefs
 	}
 	reachableRefsByAssignee := make(map[string]map[string]struct{})
 	// crossStore identities belong to city-scoped (cross-store-eligible) agents
@@ -210,6 +213,7 @@ func filterAssignedWorkBeadsForSessionWake(
 	}
 
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
+	filteredRefs := make([]string, 0, len(assignedWorkBeads))
 	for i, wb := range assignedWorkBeads {
 		if i >= len(assignedWorkStoreRefs) {
 			continue
@@ -221,13 +225,38 @@ func filterAssignedWorkBeadsForSessionWake(
 		if _, ok := crossStore[assignee]; ok {
 			// City-scoped assignee: reachable from any store (vp-kvp).
 			filtered = append(filtered, wb)
+			filteredRefs = append(filteredRefs, assignedWorkStoreRefs[i])
 			continue
 		}
 		if refs := reachableRefsByAssignee[assignee]; refs != nil {
 			if _, ok := refs[assignedWorkStoreRefs[i]]; ok {
 				filtered = append(filtered, wb)
+				filteredRefs = append(filteredRefs, assignedWorkStoreRefs[i])
 			}
 		}
 	}
-	return filtered
+	return filtered, filteredRefs
+}
+
+// readyAssignedFlagsForBeads resolves the store-scoped wake-demand readiness of
+// each assigned-work bead into a slice index-aligned with beadList. Readiness is
+// keyed by (store ref, bead ID) because AssignedWorkBeads can carry the same
+// bead ID from independent city and rig stores; a plain ID lookup would let a
+// ready bead in one store mark a blocked open bead with the same ID in another
+// store as ready and reintroduce the awake-demand hang. storeRefs must be the
+// refs returned alongside beadList by filterAssignedWorkBeadsForSessionWake. A
+// bead whose store ref is unavailable resolves to not-ready, matching the
+// nil-map default the awake bridge applied before readiness was store-scoped.
+func readyAssignedFlagsForBeads(readyAssigned map[storeScopedBeadKey]bool, beadList []beads.Bead, storeRefs []string) []bool {
+	if len(beadList) == 0 {
+		return nil
+	}
+	flags := make([]bool, len(beadList))
+	for i := range beadList {
+		if i >= len(storeRefs) {
+			continue
+		}
+		flags[i] = readyAssigned[storeScopedBeadKey{StoreRef: storeRefs[i], ID: beadList[i].ID}]
+	}
+	return flags
 }

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -42,13 +42,16 @@ func TestFilterAssignedWorkBeadsForSessionWakeKeepsOnlyReachableAssigneeSources(
 	}
 	storeRefs := []string{"", "riga", "", "riga"}
 
-	got := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, sessions, work, storeRefs)
+	got, gotRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, sessions, work, storeRefs)
 
 	if len(got) != 2 {
 		t.Fatalf("filtered work length = %d, want 2: %#v", len(got), got)
 	}
 	if got[0].ID != "rig-named" || got[1].ID != "rig-session" {
 		t.Fatalf("filtered work IDs = [%s %s], want [rig-named rig-session]", got[0].ID, got[1].ID)
+	}
+	if len(gotRefs) != len(got) || gotRefs[0] != "riga" || gotRefs[1] != "riga" {
+		t.Fatalf("filtered store refs = %#v, want [riga riga] aligned with beads", gotRefs)
 	}
 }
 
@@ -78,10 +81,13 @@ func TestFilterAssignedWorkBeadsForSessionWakeCityScopedAgentIsCrossStoreEligibl
 	}
 	storeRefs := []string{"", "riga"} // city store + rig store
 
-	got := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, nil, work, storeRefs)
+	got, gotRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, nil, work, storeRefs)
 
 	if len(got) != 2 {
 		t.Fatalf("city-scoped %q must be reachable from BOTH stores; got %d: %#v", identity, len(got), got)
+	}
+	if len(gotRefs) != len(got) || gotRefs[0] != "" || gotRefs[1] != "riga" {
+		t.Fatalf("filtered store refs = %#v, want [\"\" riga] aligned with beads", gotRefs)
 	}
 }
 

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -25,6 +25,17 @@ import (
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
+// storeScopedBeadKey identifies an assigned-work bead by its store ref and ID.
+// AssignedWorkBeads can carry the same bead ID from independent city and rig
+// stores (see AssignedWorkStores/AssignedWorkStoreRefs), so wake-demand
+// readiness must be scoped by store ref. A plain ID key would let a ready bead
+// in one store mark a blocked open bead with the same ID in another store as
+// ready and reintroduce the awake-demand hang this readiness fix prevents.
+type storeScopedBeadKey struct {
+	StoreRef string
+	ID       string
+}
+
 // DesiredStateResult bundles the desired session state with the scale_check
 // counts that produced it. Callers that need poolDesired for wake decisions
 // can pass ScaleCheckCounts to ComputePoolDesiredStates without re-running
@@ -55,13 +66,16 @@ type DesiredStateResult struct {
 	// direct assignee demand (Assignee == identity). The reconciler merges this
 	// into poolDesired so that on-demand named sessions remain config-eligible.
 	NamedSessionDemand map[string]bool
-	// ReadyAssignedIDs is the set of AssignedWorkBeads IDs that carry real
-	// wake-demand readiness: in-progress work, assigned molecule roots, and
-	// store-Ready()/deps-gated open work. Beads admitted only by the
-	// open-routed orphan-release pass are absent, so the awake bridge does not
-	// treat a blocked open bead as live wake demand. The reconciler threads
-	// this into buildAwakeInputFromReconciler for the AwakeWorkBead.Ready flag.
-	ReadyAssignedIDs map[string]bool
+	// ReadyAssigned is the set of AssignedWorkBeads that carry real wake-demand
+	// readiness, keyed by store ref + bead ID: in-progress work, assigned
+	// molecule roots, and store-Ready()/deps-gated open work. Beads admitted
+	// only by the open-routed orphan-release pass are absent, so the awake
+	// bridge does not treat a blocked open bead as live wake demand. The key is
+	// store-scoped because the same bead ID can appear in independent city and
+	// rig stores; see storeScopedBeadKey. The reconciler resolves this into a
+	// per-bead readiness slice for buildAwakeInputFromReconciler's
+	// AwakeWorkBead.Ready flag.
+	ReadyAssigned map[storeScopedBeadKey]bool
 	// StoreQueryPartial is true when one or more bead store work queries
 	// failed. When set, the reconciler must NOT drain sessions based on the
 	// incomplete desired state — a transient failure would cause running
@@ -682,7 +696,7 @@ func buildDesiredStateWithSessionBeads(
 	var assignedWorkBeads []beads.Bead
 	var assignedWorkStores []beads.Store
 	var assignedWorkStoreRefs []string
-	var readyAssignedIDs map[string]bool
+	var readyAssigned map[storeScopedBeadKey]bool
 	var storePartial bool
 	var scaleCheckCounts map[string]int
 	var scaleCheckDemandByTemplate map[string]scaleCheckDemand
@@ -691,7 +705,7 @@ func buildDesiredStateWithSessionBeads(
 	var scaleCheckPartialTemplates map[string]bool
 	var namedDefaultDemand map[string]bool
 	if store != nil {
-		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, readyAssignedIDs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths, sessionBeads)
+		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, readyAssigned, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths, sessionBeads)
 		if storePartial {
 			fmt.Fprintf(stderr, "assignedWorkBeads: PARTIAL — store query failed, drain decisions suppressed\n") //nolint:errcheck
 		}
@@ -864,7 +878,11 @@ func buildDesiredStateWithSessionBeads(
 			switch wb.Status {
 			case "in_progress":
 			case "open":
-				if !readyAssignedIDs[wb.ID] {
+				ref := ""
+				if i < len(assignedWorkStoreRefs) {
+					ref = assignedWorkStoreRefs[i]
+				}
+				if !readyAssigned[storeScopedBeadKey{StoreRef: ref, ID: wb.ID}] {
 					continue
 				}
 			default:
@@ -945,7 +963,7 @@ func buildDesiredStateWithSessionBeads(
 		AssignedWorkBeads:               assignedWorkBeads,
 		AssignedWorkStores:              assignedWorkStores,
 		AssignedWorkStoreRefs:           assignedWorkStoreRefs,
-		ReadyAssignedIDs:                readyAssignedIDs,
+		ReadyAssigned:                   readyAssigned,
 		NamedSessionDemand:              namedWorkReady,
 		StoreQueryPartial:               storePartial,
 		BeaconTime:                      beaconTime,
@@ -1096,19 +1114,21 @@ func collectAssignedWorkBeads(
 }
 
 // collectAssignedWorkBeadsWithStores returns the actionable assigned-work
-// snapshot plus index-aligned stores/storeRefs, the set of bead IDs that
-// carry real wake-demand readiness (readyAssignedIDs), and a partial flag.
-// readyAssignedIDs holds only beads admitted by the in-progress pass, the
+// snapshot plus index-aligned stores/storeRefs, the store-scoped set of beads
+// that carry real wake-demand readiness (readyAssigned), and a partial flag.
+// readyAssigned holds only beads admitted by the in-progress pass, the
 // assigned-molecule pass, and the store Ready()/deps pass — never the
 // open-routed orphan-release pass, whose beads have not passed a readiness
-// gate and must not, by status alone, hold a session awake.
+// gate and must not, by status alone, hold a session awake. It is keyed by
+// store ref + bead ID so a ready bead in one store cannot mark a blocked open
+// bead with the same ID in another store as ready (storeScopedBeadKey).
 func collectAssignedWorkBeadsWithStores(
 	cfg *config.City,
 	cityStore beads.Store,
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
 	sessionBeads *sessionBeadSnapshot,
-) ([]beads.Bead, []beads.Store, []string, map[string]bool, bool) {
+) ([]beads.Bead, []beads.Store, []string, map[storeScopedBeadKey]bool, bool) {
 	// Work arm of the reconciler frame: iterate the work-class candidate fan-out
 	// (city + non-suspended rigs). The city store carries the empty store-ref so
 	// the index-aligned workBeads/workStores slices stay per-bead aligned for the
@@ -1119,6 +1139,7 @@ func collectAssignedWorkBeadsWithStores(
 	stores := coordClassStoreCandidates(cfg, cityStore, rigStores, suspendedRigPaths, "")
 
 	type storeAssignedWorkResult struct {
+		ref       string // store ref these beads came from (empty = city store)
 		beads     []beads.Bead
 		stores    []beads.Store
 		storeRefs []string
@@ -1170,7 +1191,7 @@ func collectAssignedWorkBeadsWithStores(
 					appendOpenRoutedWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref)
 				}
 			}
-			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, storeRefs: resultStoreRefs, readyIDs: readyIDs, errs: errs}
+			results[idx] = storeAssignedWorkResult{ref: source.ref, beads: result, stores: resultStores, storeRefs: resultStoreRefs, readyIDs: readyIDs, errs: errs}
 		}()
 	}
 	wg.Wait()
@@ -1178,14 +1199,18 @@ func collectAssignedWorkBeadsWithStores(
 	var result []beads.Bead
 	var resultStores []beads.Store
 	var resultStoreRefs []string
-	readyAssignedIDs := make(map[string]bool)
+	// readyAssigned is the store-scoped wake-demand verdict so neither the awake
+	// bridge nor the assignee-probe-skip set below can mistake a blocked open
+	// rig bead for a ready city bead with the same ID. It is keyed by store ref
+	// + bead ID (storeScopedBeadKey).
+	readyAssigned := make(map[storeScopedBeadKey]bool)
 	var partial bool
 	for _, r := range results {
 		result = append(result, r.beads...)
 		resultStores = append(resultStores, r.stores...)
 		resultStoreRefs = append(resultStoreRefs, r.storeRefs...)
 		for id := range r.readyIDs {
-			readyAssignedIDs[id] = true
+			readyAssigned[storeScopedBeadKey{StoreRef: r.ref, ID: id}] = true
 		}
 		for _, err := range r.errs {
 			log.Printf("collectAssignedWorkBeads: %v", err)
@@ -1193,16 +1218,18 @@ func collectAssignedWorkBeadsWithStores(
 		}
 	}
 	// Skip the Ready handoff probe only for assignees that already have a
-	// GENUINELY-ready captured bead (in-progress, molecule root, or a prior
-	// Ready() match) — never for an assignee whose only captured bead came
-	// from the open-routed orphan-release pass. Those beads carry no readiness
-	// verdict; skipping their assignee here would leave readyAssignedIDs blind
-	// to a real Ready() match and silently treat blocked work as live demand.
-	skipReadyAssignees := readyCapturedAssigneeSet(result, readyAssignedIDs)
+	// GENUINELY-ready captured bead in that store (in-progress, molecule root,
+	// or a prior Ready() match) — never for an assignee whose only captured
+	// bead came from the open-routed orphan-release pass. Those beads carry no
+	// readiness verdict; skipping their assignee would silently treat blocked
+	// work as live demand. The lookup is store-scoped (result and
+	// resultStoreRefs are index-aligned), so a ready bead in one store cannot
+	// suppress the Ready probe for a same-ID assignee in another store.
+	skipReadyAssignees := readyCapturedAssigneeSet(result, resultStoreRefs, readyAssigned)
 	expandSkipAssigneesWithSessionIdentities(skipReadyAssignees, sessionBeads)
 	assignees := readyAssignedWorkAssignees(cfg, sessionBeads, skipReadyAssignees)
 	if len(skipReadyAssignees) > 0 && len(assignees) == 0 {
-		return result, resultStores, resultStoreRefs, readyAssignedIDs, partial
+		return result, resultStores, resultStoreRefs, readyAssigned, partial
 	}
 
 	readyResults := make([]storeAssignedWorkResult, len(stores))
@@ -1234,7 +1261,7 @@ func collectAssignedWorkBeadsWithStores(
 			readyIDs := make(map[string]bool)
 			seen := make(map[string]struct{})
 			appendAssignedUnique(&readyBeads, &readyStores, &readyStoreRefs, readyIDs, ready, seen, source.store, source.ref)
-			readyResults[idx] = storeAssignedWorkResult{beads: readyBeads, stores: readyStores, storeRefs: readyStoreRefs, readyIDs: readyIDs, errs: errs}
+			readyResults[idx] = storeAssignedWorkResult{ref: source.ref, beads: readyBeads, stores: readyStores, storeRefs: readyStoreRefs, readyIDs: readyIDs, errs: errs}
 		}()
 	}
 	wg.Wait()
@@ -1243,14 +1270,14 @@ func collectAssignedWorkBeadsWithStores(
 		resultStores = append(resultStores, r.stores...)
 		resultStoreRefs = append(resultStoreRefs, r.storeRefs...)
 		for id := range r.readyIDs {
-			readyAssignedIDs[id] = true
+			readyAssigned[storeScopedBeadKey{StoreRef: r.ref, ID: id}] = true
 		}
 		for _, err := range r.errs {
 			log.Printf("collectAssignedWorkBeads: %v", err)
 			partial = true
 		}
 	}
-	return result, resultStores, resultStoreRefs, readyAssignedIDs, partial
+	return result, resultStores, resultStoreRefs, readyAssigned, partial
 }
 
 func assignedWorkReadyLimit(cfg *config.City) int {
@@ -1261,17 +1288,20 @@ func assignedWorkReadyLimit(cfg *config.City) int {
 }
 
 // readyCapturedAssigneeSet returns the assignees of work beads that have
-// already been captured WITH a readiness verdict (their ID is in readyIDs):
-// in-progress work, assigned molecule roots, and any prior Ready() match.
-// Beads captured only by the open-routed orphan-release pass are excluded, so
-// their assignee is still probed by the Ready handoff pass rather than assumed
-// ready by virtue of having been collected.
-func readyCapturedAssigneeSet(work []beads.Bead, readyIDs map[string]bool) map[string]struct{} {
+// already been captured WITH a readiness verdict in their own store (their
+// store-scoped key is in readyAssigned): in-progress work, assigned molecule
+// roots, and any prior Ready() match. Beads captured only by the open-routed
+// orphan-release pass are excluded, so their assignee is still probed by the
+// Ready handoff pass rather than assumed ready by virtue of having been
+// collected. The readiness lookup is store-scoped: a ready bead in one store
+// never marks a same-ID blocked bead's assignee in another store as
+// already-ready (storeScopedBeadKey). work and storeRefs are index-aligned.
+func readyCapturedAssigneeSet(work []beads.Bead, storeRefs []string, readyAssigned map[storeScopedBeadKey]bool) map[string]struct{} {
 	if len(work) == 0 {
 		return nil
 	}
 	result := make(map[string]struct{})
-	for _, bead := range work {
+	for i, bead := range work {
 		assignee := strings.TrimSpace(bead.Assignee)
 		if assignee == "" {
 			continue
@@ -1279,7 +1309,12 @@ func readyCapturedAssigneeSet(work []beads.Bead, readyIDs map[string]bool) map[s
 		if bead.Status != "open" && bead.Status != "in_progress" {
 			continue
 		}
-		if !readyIDs[bead.ID] {
+		// Fail safe (probe rather than skip) when the index-aligned store ref
+		// is missing, so a short slice never suppresses a real Ready probe.
+		if i >= len(storeRefs) {
+			continue
+		}
+		if !readyAssigned[storeScopedBeadKey{StoreRef: storeRefs[i], ID: bead.ID}] {
 			continue
 		}
 		result[assignee] = struct{}{}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -55,6 +55,13 @@ type DesiredStateResult struct {
 	// direct assignee demand (Assignee == identity). The reconciler merges this
 	// into poolDesired so that on-demand named sessions remain config-eligible.
 	NamedSessionDemand map[string]bool
+	// ReadyAssignedIDs is the set of AssignedWorkBeads IDs that carry real
+	// wake-demand readiness: in-progress work, assigned molecule roots, and
+	// store-Ready()/deps-gated open work. Beads admitted only by the
+	// open-routed orphan-release pass are absent, so the awake bridge does not
+	// treat a blocked open bead as live wake demand. The reconciler threads
+	// this into buildAwakeInputFromReconciler for the AwakeWorkBead.Ready flag.
+	ReadyAssignedIDs map[string]bool
 	// StoreQueryPartial is true when one or more bead store work queries
 	// failed. When set, the reconciler must NOT drain sessions based on the
 	// incomplete desired state — a transient failure would cause running
@@ -675,6 +682,7 @@ func buildDesiredStateWithSessionBeads(
 	var assignedWorkBeads []beads.Bead
 	var assignedWorkStores []beads.Store
 	var assignedWorkStoreRefs []string
+	var readyAssignedIDs map[string]bool
 	var storePartial bool
 	var scaleCheckCounts map[string]int
 	var scaleCheckDemandByTemplate map[string]scaleCheckDemand
@@ -683,7 +691,7 @@ func buildDesiredStateWithSessionBeads(
 	var scaleCheckPartialTemplates map[string]bool
 	var namedDefaultDemand map[string]bool
 	if store != nil {
-		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths, sessionBeads)
+		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, readyAssignedIDs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths, sessionBeads)
 		if storePartial {
 			fmt.Fprintf(stderr, "assignedWorkBeads: PARTIAL — store query failed, drain decisions suppressed\n") //nolint:errcheck
 		}
@@ -848,7 +856,18 @@ func buildDesiredStateWithSessionBeads(
 	// metadata is consumed by the agent-side gc hook path.
 	for identity, spec := range namedSpecs {
 		for i, wb := range assignedWorkBeads {
-			if wb.Status != "open" && wb.Status != "in_progress" {
+			// in_progress work is always actionable; open work is direct named
+			// demand only when it passed the store's readiness/deps gate. Without
+			// the readiness check, an open assigned bead that entered the snapshot
+			// via the open-routed orphan-release pass (no deps gate) would keep an
+			// on-demand named session awake forever even while blocked.
+			switch wb.Status {
+			case "in_progress":
+			case "open":
+				if !readyAssignedIDs[wb.ID] {
+					continue
+				}
+			default:
 				continue
 			}
 			assignee := strings.TrimSpace(wb.Assignee)
@@ -926,6 +945,7 @@ func buildDesiredStateWithSessionBeads(
 		AssignedWorkBeads:               assignedWorkBeads,
 		AssignedWorkStores:              assignedWorkStores,
 		AssignedWorkStoreRefs:           assignedWorkStoreRefs,
+		ReadyAssignedIDs:                readyAssignedIDs,
 		NamedSessionDemand:              namedWorkReady,
 		StoreQueryPartial:               storePartial,
 		BeaconTime:                      beaconTime,
@@ -1071,17 +1091,24 @@ func collectAssignedWorkBeads(
 	cfg *config.City,
 	cityStore beads.Store,
 ) ([]beads.Bead, bool) {
-	result, _, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, nil, nil, nil)
+	result, _, _, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, nil, nil, nil)
 	return result, partial
 }
 
+// collectAssignedWorkBeadsWithStores returns the actionable assigned-work
+// snapshot plus index-aligned stores/storeRefs, the set of bead IDs that
+// carry real wake-demand readiness (readyAssignedIDs), and a partial flag.
+// readyAssignedIDs holds only beads admitted by the in-progress pass, the
+// assigned-molecule pass, and the store Ready()/deps pass — never the
+// open-routed orphan-release pass, whose beads have not passed a readiness
+// gate and must not, by status alone, hold a session awake.
 func collectAssignedWorkBeadsWithStores(
 	cfg *config.City,
 	cityStore beads.Store,
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
 	sessionBeads *sessionBeadSnapshot,
-) ([]beads.Bead, []beads.Store, []string, bool) {
+) ([]beads.Bead, []beads.Store, []string, map[string]bool, bool) {
 	// Work arm of the reconciler frame: iterate the work-class candidate fan-out
 	// (city + non-suspended rigs). The city store carries the empty store-ref so
 	// the index-aligned workBeads/workStores slices stay per-bead aligned for the
@@ -1095,6 +1122,7 @@ func collectAssignedWorkBeadsWithStores(
 		beads     []beads.Bead
 		stores    []beads.Store
 		storeRefs []string
+		readyIDs  map[string]bool
 		errs      []error
 	}
 	results := make([]storeAssignedWorkResult, len(stores))
@@ -1108,17 +1136,18 @@ func collectAssignedWorkBeadsWithStores(
 			var resultStores []beads.Store
 			var resultStoreRefs []string
 			var errs []error
+			readyIDs := make(map[string]bool)
 			seen := make(map[string]struct{})
 			// In-progress beads with an assignee (active work), plus stranded
 			// unassigned pool work that needs to be reopened. This pass runs
 			// across every store before any ready handoff probes, so already
 			// active work never waits behind unrelated ready scans.
 			if inProgress, err := listBothTiersForControllerDemand(source.store, beads.ListQuery{Status: "in_progress"}); err == nil {
-				appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
+				appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, readyIDs, inProgress, seen, source.store, source.ref)
 			} else {
 				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
 				if beads.IsPartialResult(err) && len(inProgress) > 0 {
-					appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
+					appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, readyIDs, inProgress, seen, source.store, source.ref)
 				}
 			}
 			// Open pool-routed beads that still carry an assignee. These are
@@ -1132,16 +1161,16 @@ func collectAssignedWorkBeadsWithStores(
 			// openSessionOwnsWork / liveOpenSessionAssignmentExists, so
 			// live-session step beads in the same range are skipped untouched.
 			if openRouted, err := listBothTiersForControllerDemand(source.store, beads.ListQuery{Status: "open"}); err == nil {
-				appendOpenAssignedMoleculeWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref)
+				appendOpenAssignedMoleculeWorkUnique(&result, &resultStores, &resultStoreRefs, readyIDs, openRouted, seen, source.store, source.ref)
 				appendOpenRoutedWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref)
 			} else {
 				errs = append(errs, fmt.Errorf("List(open): %w", err))
 				if beads.IsPartialResult(err) && len(openRouted) > 0 {
-					appendOpenAssignedMoleculeWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref)
+					appendOpenAssignedMoleculeWorkUnique(&result, &resultStores, &resultStoreRefs, readyIDs, openRouted, seen, source.store, source.ref)
 					appendOpenRoutedWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref)
 				}
 			}
-			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, storeRefs: resultStoreRefs, errs: errs}
+			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, storeRefs: resultStoreRefs, readyIDs: readyIDs, errs: errs}
 		}()
 	}
 	wg.Wait()
@@ -1149,21 +1178,31 @@ func collectAssignedWorkBeadsWithStores(
 	var result []beads.Bead
 	var resultStores []beads.Store
 	var resultStoreRefs []string
+	readyAssignedIDs := make(map[string]bool)
 	var partial bool
 	for _, r := range results {
 		result = append(result, r.beads...)
 		resultStores = append(resultStores, r.stores...)
 		resultStoreRefs = append(resultStoreRefs, r.storeRefs...)
+		for id := range r.readyIDs {
+			readyAssignedIDs[id] = true
+		}
 		for _, err := range r.errs {
 			log.Printf("collectAssignedWorkBeads: %v", err)
 			partial = true
 		}
 	}
-	skipReadyAssignees := assignedWorkAssigneeSet(result)
+	// Skip the Ready handoff probe only for assignees that already have a
+	// GENUINELY-ready captured bead (in-progress, molecule root, or a prior
+	// Ready() match) — never for an assignee whose only captured bead came
+	// from the open-routed orphan-release pass. Those beads carry no readiness
+	// verdict; skipping their assignee here would leave readyAssignedIDs blind
+	// to a real Ready() match and silently treat blocked work as live demand.
+	skipReadyAssignees := readyCapturedAssigneeSet(result, readyAssignedIDs)
 	expandSkipAssigneesWithSessionIdentities(skipReadyAssignees, sessionBeads)
 	assignees := readyAssignedWorkAssignees(cfg, sessionBeads, skipReadyAssignees)
 	if len(skipReadyAssignees) > 0 && len(assignees) == 0 {
-		return result, resultStores, resultStoreRefs, partial
+		return result, resultStores, resultStoreRefs, readyAssignedIDs, partial
 	}
 
 	readyResults := make([]storeAssignedWorkResult, len(stores))
@@ -1192,9 +1231,10 @@ func collectAssignedWorkBeadsWithStores(
 			var readyBeads []beads.Bead
 			var readyStores []beads.Store
 			var readyStoreRefs []string
+			readyIDs := make(map[string]bool)
 			seen := make(map[string]struct{})
-			appendAssignedUnique(&readyBeads, &readyStores, &readyStoreRefs, ready, seen, source.store, source.ref)
-			readyResults[idx] = storeAssignedWorkResult{beads: readyBeads, stores: readyStores, storeRefs: readyStoreRefs, errs: errs}
+			appendAssignedUnique(&readyBeads, &readyStores, &readyStoreRefs, readyIDs, ready, seen, source.store, source.ref)
+			readyResults[idx] = storeAssignedWorkResult{beads: readyBeads, stores: readyStores, storeRefs: readyStoreRefs, readyIDs: readyIDs, errs: errs}
 		}()
 	}
 	wg.Wait()
@@ -1202,12 +1242,15 @@ func collectAssignedWorkBeadsWithStores(
 		result = append(result, r.beads...)
 		resultStores = append(resultStores, r.stores...)
 		resultStoreRefs = append(resultStoreRefs, r.storeRefs...)
+		for id := range r.readyIDs {
+			readyAssignedIDs[id] = true
+		}
 		for _, err := range r.errs {
 			log.Printf("collectAssignedWorkBeads: %v", err)
 			partial = true
 		}
 	}
-	return result, resultStores, resultStoreRefs, partial
+	return result, resultStores, resultStoreRefs, readyAssignedIDs, partial
 }
 
 func assignedWorkReadyLimit(cfg *config.City) int {
@@ -1217,7 +1260,13 @@ func assignedWorkReadyLimit(cfg *config.City) int {
 	return cfg.Daemon.MaxWakesPerTickOrDefault()
 }
 
-func assignedWorkAssigneeSet(work []beads.Bead) map[string]struct{} {
+// readyCapturedAssigneeSet returns the assignees of work beads that have
+// already been captured WITH a readiness verdict (their ID is in readyIDs):
+// in-progress work, assigned molecule roots, and any prior Ready() match.
+// Beads captured only by the open-routed orphan-release pass are excluded, so
+// their assignee is still probed by the Ready handoff pass rather than assumed
+// ready by virtue of having been collected.
+func readyCapturedAssigneeSet(work []beads.Bead, readyIDs map[string]bool) map[string]struct{} {
 	if len(work) == 0 {
 		return nil
 	}
@@ -1228,6 +1277,9 @@ func assignedWorkAssigneeSet(work []beads.Bead) map[string]struct{} {
 			continue
 		}
 		if bead.Status != "open" && bead.Status != "in_progress" {
+			continue
+		}
+		if !readyIDs[bead.ID] {
 			continue
 		}
 		result[assignee] = struct{}{}
@@ -1815,35 +1867,54 @@ func mergeNamedSessionDemand(poolDesired map[string]int, namedDemand map[string]
 	}
 }
 
-func appendInProgressWorkUnique(cfg *config.City, dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
+func appendInProgressWorkUnique(cfg *config.City, dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, readyIDs map[string]bool, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" && !isRecoverableUnassignedInProgressPoolWork(cfg, b) {
 			continue
 		}
-		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)
+		if appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef) {
+			markReadyAssigned(readyIDs, b)
+		}
 	}
 }
 
-func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
+func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, readyIDs map[string]bool, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" {
 			continue
 		}
-		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)
+		if appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef) {
+			markReadyAssigned(readyIDs, b)
+		}
 	}
 }
 
 // appendOpenAssignedMoleculeWorkUnique includes root-only molecule wisps that
 // are direct assignments. Ready() intentionally hides molecule roots from
 // generic work queues, but an assigned root-only wisp is the executable turn
-// for on-demand named sessions such as the Gas Town refinery patrol.
-func appendOpenAssignedMoleculeWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
+// for on-demand named sessions such as the Gas Town refinery patrol — so these
+// beads contribute to readyIDs (their assigned turn is genuinely actionable),
+// unlike the open-routed orphan-release pass.
+func appendOpenAssignedMoleculeWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, readyIDs map[string]bool, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
 	for _, b := range beadList {
 		if !isOpenAssignedMoleculeWork(b) {
 			continue
 		}
-		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)
+		if appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef) {
+			markReadyAssigned(readyIDs, b)
+		}
 	}
+}
+
+// markReadyAssigned records a bead ID as wake-demand-ready. It is called only
+// by the assigned-work passes that establish real readiness (in-progress,
+// store-Ready()/deps, and assigned molecule roots) — never by the open-routed
+// orphan-release pass, whose beads have not passed any readiness gate.
+func markReadyAssigned(readyIDs map[string]bool, b beads.Bead) {
+	if readyIDs == nil {
+		return
+	}
+	readyIDs[b.ID] = true
 }
 
 func isOpenAssignedMoleculeWork(b beads.Bead) bool {
@@ -1874,7 +1945,11 @@ func appendOpenRoutedWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeR
 	}
 }
 
-func appendWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, b beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
+// appendWorkUnique appends b to the aligned dst/stores/storeRefs slices unless
+// it is a session bead or already seen. It reports whether the bead was
+// actually appended, so ready-pass callers can record readiness only for beads
+// this call admitted (and not for beads a prior pass already claimed via seen).
+func appendWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, b beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) bool {
 	// Invariant: dst, stores, and storeRefs are kept index-aligned by this
 	// shared growth path and the shared seen guard.
 	// Session beads are not actionable work — filter them at the source
@@ -1883,10 +1958,10 @@ func appendWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]str
 	// idle nudge filters messages locally since mail nudging is handled
 	// separately by the mail system.
 	if b.Type == sessionBeadType {
-		return
+		return false
 	}
 	if _, ok := seen[b.ID]; ok {
-		return
+		return false
 	}
 	seen[b.ID] = struct{}{}
 	*dst = append(*dst, b)
@@ -1896,6 +1971,7 @@ func appendWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]str
 	if storeRefs != nil {
 		*storeRefs = append(*storeRefs, storeRef)
 	}
+	return true
 }
 
 func controlDispatcherOnlyConfig(cfg *config.City) *config.City {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -2325,6 +2325,179 @@ func TestCollectAssignedWorkBeadsWithStores_PreservesCrossStoreIDCollisions(t *t
 	}
 }
 
+// TestCollectAssignedWorkBeadsWithStores_ReadinessIsStoreScoped pins the
+// producer side of the cross-store readiness fix: a ready city bead and a
+// blocked open rig bead share the same ID, and ReadyAssigned must mark only the
+// city copy ready. Keying readiness by bead ID alone would leak the city copy's
+// readiness onto the blocked rig copy and reintroduce the awake-demand hang.
+func TestCollectAssignedWorkBeadsWithStores_ReadinessIsStoreScoped(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	// Decoy bumps the city sequence so cityWork shares rigWork's generated ID;
+	// closed, it is never collected.
+	decoy, err := cityStore.Create(beads.Bead{Title: "decoy", Type: "task"})
+	if err != nil {
+		t.Fatalf("create city decoy: %v", err)
+	}
+	closed := "closed"
+	if err := cityStore.Update(decoy.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("close city decoy: %v", err)
+	}
+	cityWork, err := cityStore.Create(beads.Bead{
+		Title:    "ready city work",
+		Type:     "task",
+		Assignee: "worker-city",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create city work: %v", err)
+	}
+	if err := cityStore.Update(cityWork.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("set city work in_progress: %v", err)
+	}
+
+	// Blocker keeps rigWork un-ready; rigWork shares cityWork's generated ID and
+	// is admitted only by the open-routed orphan-release pass (no readiness gate).
+	blocker, err := rigStore.Create(beads.Bead{Title: "blocker", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("create rig blocker: %v", err)
+	}
+	rigWork, err := rigStore.Create(beads.Bead{
+		Title:    "blocked rig work",
+		Type:     "task",
+		Assignee: "worker-rig",
+		Needs:    []string{blocker.ID},
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create rig work: %v", err)
+	}
+	if cityWork.ID != rigWork.ID {
+		t.Fatalf("test setup expected overlapping city/rig IDs, got city %q rig %q", cityWork.ID, rigWork.ID)
+	}
+
+	got, _, _, readyAssigned, partial := collectAssignedWorkBeadsWithStores(
+		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
+		cityStore,
+		map[string]beads.Store{"repo": rigStore},
+		nil,
+		nil,
+	)
+	if partial {
+		t.Fatal("partial = true, want false")
+	}
+	if len(got) != 2 {
+		t.Fatalf("collected %d beads, want 2 (city ready + rig blocked): %#v", len(got), got)
+	}
+	if !readyAssigned[storeScopedBeadKey{StoreRef: "", ID: cityWork.ID}] {
+		t.Fatalf("city copy %q must be store-scoped ready; ReadyAssigned=%#v", cityWork.ID, readyAssigned)
+	}
+	if readyAssigned[storeScopedBeadKey{StoreRef: "repo", ID: rigWork.ID}] {
+		t.Fatalf("blocked rig copy %q must NOT be ready despite the same-ID city bead; ReadyAssigned=%#v", rigWork.ID, readyAssigned)
+	}
+}
+
+// TestCollectAssignedWorkBeadsWithStores_SkipSetIsStoreScopedAcrossSameID pins
+// the assignee Ready-probe skip set to store scope. A ready city bead and a
+// blocked rig bead can share a generated ID; the rig assignee also owns a
+// separate, genuinely-ready bead reachable only via the Ready probe. The
+// same-ID city bead must not collapse the skip set by bare ID and suppress the
+// rig assignee's probe, or that separate ready work is silently dropped and the
+// rig session stays asleep.
+func TestCollectAssignedWorkBeadsWithStores_SkipSetIsStoreScopedAcrossSameID(t *testing.T) {
+	cityStore := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+	rigStore := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+
+	// Decoy bumps the city sequence so cityWork shares rigWork's generated ID;
+	// closed, it is never collected.
+	decoy, err := cityStore.Create(beads.Bead{Title: "decoy", Type: "task"})
+	if err != nil {
+		t.Fatalf("create city decoy: %v", err)
+	}
+	if err := cityStore.Update(decoy.ID, beads.UpdateOpts{Status: stringPtr("closed")}); err != nil {
+		t.Fatalf("close city decoy: %v", err)
+	}
+	// Ready city work for worker-city, captured by the in-progress pass.
+	cityWork, err := cityStore.Create(beads.Bead{
+		Title:    "ready city work",
+		Type:     "task",
+		Assignee: "worker-city",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create city work: %v", err)
+	}
+	if err := cityStore.Update(cityWork.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("set city work in_progress: %v", err)
+	}
+
+	// Blocker keeps rigWork un-ready; rigWork shares cityWork's generated ID and
+	// is admitted only by the open-routed orphan-release pass (no readiness gate).
+	blocker, err := rigStore.Create(beads.Bead{Title: "blocker", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("create rig blocker: %v", err)
+	}
+	rigWork, err := rigStore.Create(beads.Bead{
+		Title:    "blocked rig work",
+		Type:     "task",
+		Assignee: "worker-rig",
+		Needs:    []string{blocker.ID},
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create rig work: %v", err)
+	}
+	if cityWork.ID != rigWork.ID {
+		t.Fatalf("test setup expected overlapping city/rig IDs, got city %q rig %q", cityWork.ID, rigWork.ID)
+	}
+	// worker-rig's genuinely-ready bead, discoverable ONLY by the assignee Ready
+	// probe: not in_progress, not a molecule root, not pool-routed, no blocker.
+	rigReadyWork, err := rigStore.Create(beads.Bead{
+		Title:    "separate ready rig work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "worker-rig",
+	})
+	if err != nil {
+		t.Fatalf("create rig ready work: %v", err)
+	}
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{
+		{ID: "sess-city", Type: sessionBeadType, Status: "open", Metadata: map[string]string{"session_name": "worker-city", "template": "worker", "state": "asleep"}},
+		{ID: "sess-rig", Type: sessionBeadType, Status: "open", Metadata: map[string]string{"session_name": "worker-rig", "template": "worker", "state": "asleep"}},
+	})
+
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(
+		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
+		cityStore,
+		map[string]beads.Store{"repo": rigStore},
+		nil,
+		snapshot,
+	)
+	if partial {
+		t.Fatal("partial = true, want false")
+	}
+
+	gotIDs := make(map[string]bool)
+	for _, bead := range got {
+		gotIDs[bead.ID] = true
+	}
+	if !gotIDs[rigReadyWork.ID] {
+		t.Fatalf("worker-rig ready bead %q was dropped: the same-ID city ready bead collapsed the skip set and suppressed worker-rig's store-scoped Ready probe; collected=%#v", rigReadyWork.ID, gotIDs)
+	}
+
+	rigProbedForRigAssignee := false
+	for _, query := range rigStore.readyQueries {
+		if query.Assignee == "worker-rig" {
+			rigProbedForRigAssignee = true
+		}
+	}
+	if !rigProbedForRigAssignee {
+		t.Fatalf("rig Ready queries = %#v, want a probe for worker-rig despite the same-ID city ready bead", rigStore.readyQueries)
+	}
+}
+
 func TestBuildDesiredState_UsesAgentHookOverride(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1852,7 +1852,7 @@ func TestCollectAssignedWorkBeads_PreservesPartialInProgressSurvivors(t *testing
 		t.Fatalf("reload work bead: %v", err)
 	}
 
-	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, nil)
+	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, nil)
 	if !partial {
 		t.Fatal("partial = false, want true")
 	}
@@ -1883,7 +1883,7 @@ func TestCollectAssignedWorkBeads_PreservesPartialReadySurvivors(t *testing.T) {
 		t.Fatalf("create work bead: %v", err)
 	}
 
-	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, nil)
+	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, nil)
 	if !partial {
 		t.Fatal("partial = false, want true")
 	}
@@ -1930,7 +1930,7 @@ func TestCollectAssignedWorkBeads_SkipsReadyProbeForInProgressAssignee(t *testin
 	}
 	snapshot := newSessionBeadSnapshot([]beads.Bead{session})
 
-	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -1975,7 +1975,7 @@ func TestCollectAssignedWorkBeads_SkipsCityReadyProbeForRigInProgressAssignee(t 
 	}
 	snapshot := newSessionBeadSnapshot([]beads.Bead{session})
 
-	got, _, _, partial := collectAssignedWorkBeadsWithStores(
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -2047,7 +2047,7 @@ func TestCollectAssignedWorkBeads_ReadyProbeStillRunsForOtherAssignees(t *testin
 	}
 	snapshot := newSessionBeadSnapshot([]beads.Bead{activeSession, readySession})
 
-	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -2111,7 +2111,7 @@ func TestCollectAssignedWorkBeads_ReadyProbeIncludesActiveSessionAssignees(t *te
 	}
 	snapshot := newSessionBeadSnapshot([]beads.Bead{activeSession, sleepySession})
 
-	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -2181,7 +2181,7 @@ func TestCollectAssignedWorkBeads_ReadyProbeExcludesFutureNamedSessionRuntimeAss
 		t.Fatalf("create ready work bead: %v", err)
 	}
 
-	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(
+	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(
 		cfg,
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -2232,7 +2232,7 @@ func TestCollectAssignedWorkBeadsWithStores_TracksRigStore(t *testing.T) {
 		t.Fatalf("reload rig work bead: %v", err)
 	}
 
-	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(
+	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -2292,7 +2292,7 @@ func TestCollectAssignedWorkBeadsWithStores_PreservesCrossStoreIDCollisions(t *t
 		t.Fatalf("test setup expected overlapping city/rig IDs, got city %q rig %q", cityWork.ID, rigWork.ID)
 	}
 
-	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(
+	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2268,7 +2268,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	cr.recordReconcileTraceInputs(trace, open, desiredState, poolDesired, workSet, traceWorkRequested, readyWaitSet, result, recordPhase)
 
 	phaseStart = time.Now()
-	awakeAssignedWorkBeads := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, open, assignedWorkBeads, assignedWorkStoreRefs)
+	awakeAssignedWorkBeads, awakeAssignedStoreRefs := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, open, assignedWorkBeads, assignedWorkStoreRefs)
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.filter_assigned_work_for_wake", phaseStart, map[string]any{
 		"assigned_work_bead_count":       len(assignedWorkBeads),
 		"awake_assigned_work_bead_count": len(awakeAssignedWorkBeads),
@@ -2281,7 +2281,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		withAsyncStartTracker(&cr.asyncStarts),
 		withAsyncDrainAckStopTracker(&cr.asyncStops),
 		withMaxSessionAgeTracker(cr.mat),
-		withReadyAssignedIDs(result.ReadyAssignedIDs),
+		withReadyAssignedFlags(readyAssignedFlagsForBeads(result.ReadyAssigned, awakeAssignedWorkBeads, awakeAssignedStoreRefs)),
 	}
 	if bootReconcile {
 		// #3288: skip the per-session orphan/failed-create session-bead closes on

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2281,6 +2281,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		withAsyncStartTracker(&cr.asyncStarts),
 		withAsyncDrainAckStopTracker(&cr.asyncStops),
 		withMaxSessionAgeTracker(cr.mat),
+		withReadyAssignedIDs(result.ReadyAssignedIDs),
 	}
 	if bootReconcile {
 		// #3288: skip the per-session orphan/failed-create session-bead closes on

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -931,7 +931,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		poolDesired = make(map[string]int)
 	}
 	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
-	awakeAssignedWorkBeads := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, open, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
+	awakeAssignedWorkBeads, awakeAssignedStoreRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, open, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
 	reconcileSessionBeadsAtPathWithNamedDemand(
 		sigCtx, cityPath, open, ds, cfgNames, cfg, sp, oneShotStore,
 		nil, awakeAssignedWorkBeads, rigStores, nil, dt, nil, poolDesired,
@@ -940,7 +940,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		nil, cityName,
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,
 		stdout, stderr,
-		withReadyAssignedIDs(dsResult.ReadyAssignedIDs),
+		withReadyAssignedFlags(readyAssignedFlagsForBeads(dsResult.ReadyAssigned, awakeAssignedWorkBeads, awakeAssignedStoreRefs)),
 	)
 
 	// Post-reconcile sync: update bead state to reflect post-start reality.

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -940,6 +940,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		nil, cityName,
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,
 		stdout, stderr,
+		withReadyAssignedIDs(dsResult.ReadyAssignedIDs),
 	)
 
 	// Post-reconcile sync: update bead state to reflect post-start reality.

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -24,6 +24,7 @@ func buildAwakeInputFromReconciler(
 	workSet map[string]bool,
 	readyWaitSet map[string]bool,
 	assignedWorkBeads []beads.Bead,
+	readyAssignedIDs map[string]bool,
 	wakeTargets []wakeTarget,
 	sp runtime.Provider,
 	clk time.Time,
@@ -72,15 +73,18 @@ func buildAwakeInputFromReconciler(
 		})
 	}
 
-	// Work beads
+	// Work beads. Readiness is the store's verdict (readyAssignedIDs), not a
+	// status-only guess: assignedWorkBeads mixes the open-routed orphan-release
+	// pass (which admits any open assigned+routed bead with no deps check) into
+	// the same slice as the genuinely-ready passes. Fabricating Ready from
+	// status alone held a blocked open bead's session awake forever (it never
+	// slept, so the resume-on-ShouldWake path never fired). readyAssignedIDs is
+	// populated only by the ready passes, matching gc hook --claim's deps gate.
 	for _, wb := range assignedWorkBeads {
 		a := strings.TrimSpace(wb.Assignee)
 		if a != "" && (wb.Status == "open" || wb.Status == "in_progress") {
-			// assignedWorkBeads is the reconciler's actionable snapshot:
-			// in-progress work plus open work that has already passed readiness
-			// and blocker filtering.
 			input.WorkBeads = append(input.WorkBeads, AwakeWorkBead{
-				ID: wb.ID, Assignee: a, Status: wb.Status, Ready: wb.Status == "open",
+				ID: wb.ID, Assignee: a, Status: wb.Status, Ready: readyAssignedIDs[wb.ID],
 			})
 		}
 	}

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -24,7 +24,7 @@ func buildAwakeInputFromReconciler(
 	workSet map[string]bool,
 	readyWaitSet map[string]bool,
 	assignedWorkBeads []beads.Bead,
-	readyAssignedIDs map[string]bool,
+	readyAssignedFlags []bool,
 	wakeTargets []wakeTarget,
 	sp runtime.Provider,
 	clk time.Time,
@@ -73,18 +73,22 @@ func buildAwakeInputFromReconciler(
 		})
 	}
 
-	// Work beads. Readiness is the store's verdict (readyAssignedIDs), not a
+	// Work beads. Readiness is the store's verdict (readyAssignedFlags), not a
 	// status-only guess: assignedWorkBeads mixes the open-routed orphan-release
 	// pass (which admits any open assigned+routed bead with no deps check) into
 	// the same slice as the genuinely-ready passes. Fabricating Ready from
 	// status alone held a blocked open bead's session awake forever (it never
-	// slept, so the resume-on-ShouldWake path never fired). readyAssignedIDs is
-	// populated only by the ready passes, matching gc hook --claim's deps gate.
-	for _, wb := range assignedWorkBeads {
+	// slept, so the resume-on-ShouldWake path never fired). readyAssignedFlags is
+	// index-aligned with assignedWorkBeads and resolved from the store-scoped
+	// readiness verdict, so a blocked open rig bead is not marked ready by a
+	// same-ID ready bead in another store. A missing flag defaults to not-ready.
+	for i := range assignedWorkBeads {
+		wb := assignedWorkBeads[i]
 		a := strings.TrimSpace(wb.Assignee)
 		if a != "" && (wb.Status == "open" || wb.Status == "in_progress") {
+			ready := i < len(readyAssignedFlags) && readyAssignedFlags[i]
 			input.WorkBeads = append(input.WorkBeads, AwakeWorkBead{
-				ID: wb.ID, Assignee: a, Status: wb.Status, Ready: readyAssignedIDs[wb.ID],
+				ID: wb.ID, Assignee: a, Status: wb.Status, Ready: ready,
 			})
 		}
 	}

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -32,6 +32,7 @@ func TestBuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilitySta
 		nil,
 		nil,
 		nil,
+		nil,
 		now,
 	)
 
@@ -70,6 +71,7 @@ func TestBuildAwakeInputFromReconcilerCanonicalizesLegacyBoundTemplate(t *testin
 				"wake_request": "explicit",
 			},
 		}},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -123,6 +125,7 @@ func TestBuildAwakeInputFromReconcilerKeepsUnresolvableTemplateRaw(t *testing.T)
 		nil,
 		nil,
 		nil,
+		nil,
 		now,
 	)
 
@@ -152,6 +155,7 @@ func TestBuildAwakeInputFromReconcilerCarriesResetPendingMetadata(t *testing.T) 
 				session.ResetCommittedAtKey:  now.Format(time.RFC3339),
 			},
 		}},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -202,6 +206,7 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 		nil,
 		nil,
 		nil,
+		nil,
 		[]wakeTarget{{session: &session, alive: true}},
 		sp,
 		now,
@@ -214,6 +219,155 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 	got := decisions["s-worker"]
 	if !got.ShouldWake || got.Reason != "pending" {
 		t.Fatalf("decision = %+v, want pending wake", got)
+	}
+}
+
+// TestBuildAwakeInputFromReconciler_BlockedAssignedOpenBeadDoesNotKeepSessionAwake
+// pins the reconciler readiness fix: a blocked open assigned bead arrives via
+// the open-routed orphan-release pass with readyAssignedIDs[id]=false. It must
+// NOT keep its owning session awake — neither via assigned-work nor via
+// named-demand — so the session can sleep and the existing resume-on-ShouldWake
+// path can later re-wake it once its blocker clears (graph-store hang).
+func TestBuildAwakeInputFromReconciler_BlockedAssignedOpenBeadDoesNotKeepSessionAwake(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &config.City{Agents: []config.Agent{{Name: "gc.run-operator"}}}
+	sessionBead := beads.Bead{
+		ID:     "mc-session-1",
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"state":        "active",
+			"session_name": "gc__run-operator-mc-1",
+			"template":     "gc.run-operator",
+		},
+	}
+	blockedWork := beads.Bead{
+		ID:       "ga-blocked",
+		Status:   "open",
+		Assignee: "gc__run-operator-mc-1",
+		Metadata: map[string]string{"gc.routed_to": "gc.run-operator"},
+	}
+
+	input := buildAwakeInputFromReconciler(
+		cfg,
+		"",
+		[]beads.Bead{sessionBead},
+		nil,
+		nil,
+		nil,
+		nil,
+		[]beads.Bead{blockedWork},
+		map[string]bool{}, // readyAssignedIDs: blocked bead is NOT ready
+		nil,
+		runtime.NewFake(),
+		now,
+	)
+
+	if len(input.WorkBeads) != 1 {
+		t.Fatalf("WorkBeads length = %d, want 1", len(input.WorkBeads))
+	}
+	if input.WorkBeads[0].Ready {
+		t.Fatalf("WorkBeads[0].Ready = true, want false for a blocked open bead")
+	}
+
+	decisions := ComputeAwakeSet(input)
+	got := decisions["gc__run-operator-mc-1"]
+	if got.ShouldWake {
+		t.Fatalf("session should sleep for blocked open work; got decision = %+v", got)
+	}
+}
+
+// TestBuildAwakeInputFromReconciler_ReadyAssignedOpenBeadWakesSession is the
+// positive companion: the same open assigned bead admitted via the Ready()/deps
+// pass (readyAssignedIDs[id]=true) still wakes/holds its session.
+func TestBuildAwakeInputFromReconciler_ReadyAssignedOpenBeadWakesSession(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &config.City{Agents: []config.Agent{{Name: "gc.run-operator"}}}
+	sessionBead := beads.Bead{
+		ID:     "mc-session-1",
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"state":        "active",
+			"session_name": "gc__run-operator-mc-1",
+			"template":     "gc.run-operator",
+		},
+	}
+	readyWork := beads.Bead{
+		ID:       "ga-ready",
+		Status:   "open",
+		Assignee: "gc__run-operator-mc-1",
+		Metadata: map[string]string{"gc.routed_to": "gc.run-operator"},
+	}
+
+	input := buildAwakeInputFromReconciler(
+		cfg,
+		"",
+		[]beads.Bead{sessionBead},
+		nil,
+		nil,
+		nil,
+		nil,
+		[]beads.Bead{readyWork},
+		map[string]bool{"ga-ready": true}, // readyAssignedIDs: bead IS ready
+		nil,
+		runtime.NewFake(),
+		now,
+	)
+
+	if len(input.WorkBeads) != 1 || !input.WorkBeads[0].Ready {
+		t.Fatalf("WorkBeads = %+v, want one bead with Ready=true", input.WorkBeads)
+	}
+
+	decisions := ComputeAwakeSet(input)
+	got := decisions["gc__run-operator-mc-1"]
+	if !got.ShouldWake || got.Reason != "assigned-work" {
+		t.Fatalf("ready assigned open bead should wake session; got decision = %+v", got)
+	}
+}
+
+// TestBuildAwakeInputFromReconciler_InProgressAssignedBeadStillWakes is the
+// regression guard: in-progress assigned work keeps its session awake
+// regardless of readyAssignedIDs (workBeadHasAwakeDemand returns true for
+// in_progress unconditionally).
+func TestBuildAwakeInputFromReconciler_InProgressAssignedBeadStillWakes(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &config.City{Agents: []config.Agent{{Name: "gc.run-operator"}}}
+	sessionBead := beads.Bead{
+		ID:     "mc-session-1",
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"state":        "active",
+			"session_name": "gc__run-operator-mc-1",
+			"template":     "gc.run-operator",
+		},
+	}
+	inProgressWork := beads.Bead{
+		ID:       "ga-active",
+		Status:   "in_progress",
+		Assignee: "gc__run-operator-mc-1",
+	}
+
+	input := buildAwakeInputFromReconciler(
+		cfg,
+		"",
+		[]beads.Bead{sessionBead},
+		nil,
+		nil,
+		nil,
+		nil,
+		[]beads.Bead{inProgressWork},
+		nil, // readyAssignedIDs omitted entirely: in_progress must still wake
+		nil,
+		runtime.NewFake(),
+		now,
+	)
+
+	decisions := ComputeAwakeSet(input)
+	got := decisions["gc__run-operator-mc-1"]
+	if !got.ShouldWake || got.Reason != "assigned-work" {
+		t.Fatalf("in-progress assigned bead should wake session; got decision = %+v", got)
 	}
 }
 
@@ -288,6 +442,7 @@ func TestBuildAwakeInputFromReconcilerCarriesNamedSessionDemand(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		runtime.NewFake(),
 		now,
 	)
@@ -336,6 +491,7 @@ func TestBuildAwakeInputFromReconciler_RigNamedWorkQueryDemandWakesCanonicalSess
 		nil,
 		nil,
 		map[string]bool{"rig-a/worker": true},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -393,7 +549,7 @@ func TestBuildAwakeInputFromReconcilerNamedAlwaysPostChurnRewakes(t *testing.T) 
 		cfg,
 		"", // cityPath: empty exercises zero suspension state
 		[]beads.Bead{postChurnBead},
-		nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil,
 		runtime.NewFake(),
 		now,
 	)

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -224,7 +224,7 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 
 // TestBuildAwakeInputFromReconciler_BlockedAssignedOpenBeadDoesNotKeepSessionAwake
 // pins the reconciler readiness fix: a blocked open assigned bead arrives via
-// the open-routed orphan-release pass with readyAssignedIDs[id]=false. It must
+// the open-routed orphan-release pass with readyAssignedFlags[i]=false. It must
 // NOT keep its owning session awake — neither via assigned-work nor via
 // named-demand — so the session can sleep and the existing resume-on-ShouldWake
 // path can later re-wake it once its blocker clears (graph-store hang).
@@ -257,7 +257,7 @@ func TestBuildAwakeInputFromReconciler_BlockedAssignedOpenBeadDoesNotKeepSession
 		nil,
 		nil,
 		[]beads.Bead{blockedWork},
-		map[string]bool{}, // readyAssignedIDs: blocked bead is NOT ready
+		[]bool{false}, // readyAssignedFlags: blocked bead is NOT ready
 		nil,
 		runtime.NewFake(),
 		now,
@@ -279,7 +279,7 @@ func TestBuildAwakeInputFromReconciler_BlockedAssignedOpenBeadDoesNotKeepSession
 
 // TestBuildAwakeInputFromReconciler_ReadyAssignedOpenBeadWakesSession is the
 // positive companion: the same open assigned bead admitted via the Ready()/deps
-// pass (readyAssignedIDs[id]=true) still wakes/holds its session.
+// pass (readyAssignedFlags[i]=true) still wakes/holds its session.
 func TestBuildAwakeInputFromReconciler_ReadyAssignedOpenBeadWakesSession(t *testing.T) {
 	now := time.Now().UTC()
 	cfg := &config.City{Agents: []config.Agent{{Name: "gc.run-operator"}}}
@@ -309,7 +309,7 @@ func TestBuildAwakeInputFromReconciler_ReadyAssignedOpenBeadWakesSession(t *test
 		nil,
 		nil,
 		[]beads.Bead{readyWork},
-		map[string]bool{"ga-ready": true}, // readyAssignedIDs: bead IS ready
+		[]bool{true}, // readyAssignedFlags: bead IS ready
 		nil,
 		runtime.NewFake(),
 		now,
@@ -328,7 +328,7 @@ func TestBuildAwakeInputFromReconciler_ReadyAssignedOpenBeadWakesSession(t *test
 
 // TestBuildAwakeInputFromReconciler_InProgressAssignedBeadStillWakes is the
 // regression guard: in-progress assigned work keeps its session awake
-// regardless of readyAssignedIDs (workBeadHasAwakeDemand returns true for
+// regardless of readyAssignedFlags (workBeadHasAwakeDemand returns true for
 // in_progress unconditionally).
 func TestBuildAwakeInputFromReconciler_InProgressAssignedBeadStillWakes(t *testing.T) {
 	now := time.Now().UTC()
@@ -358,7 +358,7 @@ func TestBuildAwakeInputFromReconciler_InProgressAssignedBeadStillWakes(t *testi
 		nil,
 		nil,
 		[]beads.Bead{inProgressWork},
-		nil, // readyAssignedIDs omitted entirely: in_progress must still wake
+		nil, // readyAssignedFlags omitted entirely: in_progress must still wake
 		nil,
 		runtime.NewFake(),
 		now,
@@ -368,6 +368,99 @@ func TestBuildAwakeInputFromReconciler_InProgressAssignedBeadStillWakes(t *testi
 	got := decisions["gc__run-operator-mc-1"]
 	if !got.ShouldWake || got.Reason != "assigned-work" {
 		t.Fatalf("in-progress assigned bead should wake session; got decision = %+v", got)
+	}
+}
+
+// TestBuildAwakeInputFromReconciler_CrossStoreSameIDReadinessIsStoreScoped pins
+// the cross-store readiness fix: AssignedWorkBeads can carry the same bead ID
+// from independent city and rig stores. A ready city bead must NOT mark a
+// blocked open rig bead with the SAME ID as ready in the awake bridge — that
+// store-blind leak (readiness keyed by bead ID alone) reintroduced the
+// awake-demand hang. readyAssignedFlagsForBeads resolves readiness by
+// (store ref, bead ID), so the blocked rig bead reaches the bridge Ready=false
+// and its session sleeps while the ready city bead's session wakes.
+func TestBuildAwakeInputFromReconciler_CrossStoreSameIDReadinessIsStoreScoped(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &config.City{Agents: []config.Agent{{Name: "gc.run-operator"}}}
+	citySession := beads.Bead{
+		ID:     "mc-session-city",
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"state":        "active",
+			"session_name": "gc__run-operator-city",
+			"template":     "gc.run-operator",
+		},
+	}
+	rigSession := beads.Bead{
+		ID:     "mc-session-rig",
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"state":        "active",
+			"session_name": "gc__run-operator-rig",
+			"template":     "gc.run-operator",
+		},
+	}
+	// Same bead ID lives in two stores: the city copy is genuinely ready, the rig
+	// copy is a blocked open bead admitted via the open-routed orphan-release pass.
+	const sharedID = "ga-shared"
+	cityWork := beads.Bead{
+		ID:       sharedID,
+		Status:   "open",
+		Assignee: "gc__run-operator-city",
+		Metadata: map[string]string{"gc.routed_to": "gc.run-operator"},
+	}
+	rigWork := beads.Bead{
+		ID:       sharedID,
+		Status:   "open",
+		Assignee: "gc__run-operator-rig",
+		Metadata: map[string]string{"gc.routed_to": "gc.run-operator"},
+	}
+
+	work := []beads.Bead{cityWork, rigWork}
+	storeRefs := []string{"", "repo"}
+	// Store-scoped readiness verdict: only the city copy (store ref "") is ready.
+	readyAssigned := map[storeScopedBeadKey]bool{
+		{StoreRef: "", ID: sharedID}: true,
+	}
+	flags := readyAssignedFlagsForBeads(readyAssigned, work, storeRefs)
+	if len(flags) != 2 || !flags[0] || flags[1] {
+		t.Fatalf("readyAssignedFlagsForBeads = %#v, want [true false] (city ready, rig blocked despite shared ID)", flags)
+	}
+
+	input := buildAwakeInputFromReconciler(
+		cfg,
+		"",
+		[]beads.Bead{citySession, rigSession},
+		nil,
+		nil,
+		nil,
+		nil,
+		work,
+		flags,
+		nil,
+		runtime.NewFake(),
+		now,
+	)
+
+	readyByAssignee := make(map[string]bool, len(input.WorkBeads))
+	for _, wb := range input.WorkBeads {
+		readyByAssignee[wb.Assignee] = wb.Ready
+	}
+	if !readyByAssignee["gc__run-operator-city"] {
+		t.Fatal("city copy of the shared-ID bead must reach the bridge Ready=true")
+	}
+	if readyByAssignee["gc__run-operator-rig"] {
+		t.Fatal("rig copy of the shared-ID bead must reach the bridge Ready=false (store-scoped readiness)")
+	}
+
+	decisions := ComputeAwakeSet(input)
+	if got := decisions["gc__run-operator-rig"]; got.ShouldWake {
+		t.Fatalf("rig session should sleep for its blocked same-ID bead; got decision = %+v", got)
+	}
+	if got := decisions["gc__run-operator-city"]; !got.ShouldWake || got.Reason != "assigned-work" {
+		t.Fatalf("city session should wake for its ready bead; got decision = %+v", got)
 	}
 }
 

--- a/cmd/gc/compute_awake_set_min_active_test.go
+++ b/cmd/gc/compute_awake_set_min_active_test.go
@@ -155,7 +155,7 @@ func TestBuildAwakeInputPropagatesMinActiveSessions(t *testing.T) {
 	input := buildAwakeInputFromReconciler(
 		&config.City{Agents: []config.Agent{{Name: "pl", MinActiveSessions: &minSess}}},
 		"", // cityPath: empty exercises zero suspension state
-		nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
 		time.Now().UTC(),
 	)
 	var found bool
@@ -197,7 +197,7 @@ func TestMinActive_LegacyBoundTemplateRevivedThroughBridge(t *testing.T) {
 				"template":     "rig/gc.pl",
 			},
 		}},
-		nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil,
 		time.Now().UTC(),
 	)
 	result := ComputeAwakeSet(input)

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1159,7 +1159,7 @@ func TestCollectAndReleaseOrphanPoolStepBead_Issue2793(t *testing.T) {
 
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
 
-	found, foundStores, foundStoreRefs, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	found, foundStores, foundStoreRefs, _, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -1210,7 +1210,7 @@ func TestCollectAndReleaseOrphanWorkflowRunTargetBead(t *testing.T) {
 
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
 
-	found, foundStores, foundStoreRefs, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	found, foundStores, foundStoreRefs, _, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -1260,7 +1260,7 @@ func TestCollectAndReleaseNonWorkflowRunTargetBeadStaysAssigned(t *testing.T) {
 
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
 
-	found, foundStores, foundStoreRefs, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	found, foundStores, foundStoreRefs, _, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -1298,7 +1298,7 @@ func TestCollectAssignedWorkBeadsIncludesUnassignedInProgressPoolWorkForRecovery
 		t.Fatalf("Set work status: %v", err)
 	}
 
-	found, stores, _, partial := collectAssignedWorkBeadsWithStores(
+	found, stores, _, _, partial := collectAssignedWorkBeadsWithStores(
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		store,
 		nil,

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -274,6 +274,7 @@ type startExecutionOptions struct {
 	// performs the closes. Safe to defer: the closes already fail closed and are
 	// deferred under storeQueryPartial today.
 	deferSessionClosesOnBoot bool
+	readyAssignedIDs         map[string]bool
 }
 
 type startExecutionOption func(*startExecutionOptions)
@@ -331,6 +332,17 @@ func withTaskWorkDirResolver(resolver taskWorkDirResolver) startExecutionOption 
 func withDeferSessionClosesOnBoot() startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.deferSessionClosesOnBoot = true
+	}
+}
+
+// withReadyAssignedIDs installs the set of assigned-work bead IDs that carry
+// real wake-demand readiness (from DesiredStateResult.ReadyAssignedIDs). The
+// awake bridge uses it to set AwakeWorkBead.Ready from the store's deps gate
+// rather than guessing from status, so a blocked open bead does not hold its
+// session awake. Nil leaves every open assigned bead non-ready.
+func withReadyAssignedIDs(readyAssignedIDs map[string]bool) startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.readyAssignedIDs = readyAssignedIDs
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -274,7 +274,7 @@ type startExecutionOptions struct {
 	// performs the closes. Safe to defer: the closes already fail closed and are
 	// deferred under storeQueryPartial today.
 	deferSessionClosesOnBoot bool
-	readyAssignedIDs         map[string]bool
+	readyAssignedFlags       []bool
 }
 
 type startExecutionOption func(*startExecutionOptions)
@@ -335,14 +335,15 @@ func withDeferSessionClosesOnBoot() startExecutionOption {
 	}
 }
 
-// withReadyAssignedIDs installs the set of assigned-work bead IDs that carry
-// real wake-demand readiness (from DesiredStateResult.ReadyAssignedIDs). The
-// awake bridge uses it to set AwakeWorkBead.Ready from the store's deps gate
-// rather than guessing from status, so a blocked open bead does not hold its
-// session awake. Nil leaves every open assigned bead non-ready.
-func withReadyAssignedIDs(readyAssignedIDs map[string]bool) startExecutionOption {
+// withReadyAssignedFlags installs the per-bead wake-demand readiness slice,
+// index-aligned with the assignedWorkBeads passed to the same reconcile pass
+// and resolved from DesiredStateResult.ReadyAssigned. The awake bridge uses it
+// to set AwakeWorkBead.Ready from the store's deps gate rather than guessing
+// from status, so a blocked open bead does not hold its session awake. Nil
+// leaves every open assigned bead non-ready.
+func withReadyAssignedFlags(readyAssignedFlags []bool) startExecutionOption {
 	return func(opts *startExecutionOptions) {
-		opts.readyAssignedIDs = readyAssignedIDs
+		opts.readyAssignedFlags = readyAssignedFlags
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -819,10 +819,12 @@ func reconcileSessionBeads(
 	startupTimeout time.Duration,
 	driftDrainTimeout time.Duration,
 	stdout, stderr io.Writer,
+	startOptions ...startExecutionOption,
 ) int {
 	return reconcileSessionBeadsAtPath(
 		ctx, "", sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, nil, readyWaitSet, dt,
 		poolDesired, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr,
+		startOptions...,
 	)
 }
 
@@ -858,10 +860,12 @@ func reconcileSessionBeadsAtPath(
 	startupTimeout time.Duration,
 	driftDrainTimeout time.Duration,
 	stdout, stderr io.Writer,
+	startOptions ...startExecutionOption,
 ) int {
 	return reconcileSessionBeadsAtPathWithNamedDemand(
 		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, rigStores, readyWaitSet, dt, nil,
 		poolDesired, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr,
+		startOptions...,
 	)
 }
 
@@ -891,10 +895,12 @@ func reconcileSessionBeadsAtPathWithNamedDemand(
 	startupTimeout time.Duration,
 	driftDrainTimeout time.Duration,
 	stdout, stderr io.Writer,
+	startOptions ...startExecutionOption,
 ) int {
 	return reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, beads.SessionStore{Store: store}, dops, assignedWorkBeads, rigStores, readyWaitSet, dt, gate,
 		poolDesired, namedSessionDemand, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
+		startOptions...,
 	)
 }
 
@@ -2406,7 +2412,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	phaseStart = time.Now()
 	awakeInput := buildAwakeInputFromReconciler(
 		cfg, cityPath, ordered, poolDesired, namedSessionDemand, workSet, readyWaitSet,
-		assignedWorkBeads, wakeTargets, sp, clk.Now(),
+		assignedWorkBeads, reconcileOpts.readyAssignedIDs, wakeTargets, sp, clk.Now(),
 	)
 	awakeDecisions := ComputeAwakeSet(awakeInput)
 	wakeEvals := awakeSetToWakeEvals(awakeDecisions, awakeInput.SessionBeads)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2412,7 +2412,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	phaseStart = time.Now()
 	awakeInput := buildAwakeInputFromReconciler(
 		cfg, cityPath, ordered, poolDesired, namedSessionDemand, workSet, readyWaitSet,
-		assignedWorkBeads, reconcileOpts.readyAssignedIDs, wakeTargets, sp, clk.Now(),
+		assignedWorkBeads, reconcileOpts.readyAssignedFlags, wakeTargets, sp, clk.Now(),
 	)
 	awakeDecisions := ComputeAwakeSet(awakeInput)
 	wakeEvals := awakeSetToWakeEvals(awakeDecisions, awakeInput.SessionBeads)

--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -336,6 +336,7 @@ func TestReconcileSessionBeads_AssignedNamedSessionByBeadIDOverridesNonInteracti
 		0,
 		&env.stdout,
 		&env.stderr,
+		withReadyAssignedIDs(map[string]bool{work.ID: true}),
 	)
 
 	if woken != 0 {
@@ -496,6 +497,7 @@ func TestReconcileSessionBeads_AssignedWorkWithReadyWaitOverridesNonInteractiveS
 		0,
 		&env.stdout,
 		&env.stderr,
+		withReadyAssignedIDs(map[string]bool{work.ID: true}),
 	)
 
 	if woken != 0 {
@@ -614,6 +616,7 @@ func TestReconcileSessionBeads_AssignedWorkWakesIdleLatchedInteractiveSession(t 
 		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, env.sp,
 		env.store, nil, []beads.Bead{work}, nil, env.dt, map[string]int{}, false, nil, "",
 		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+		withReadyAssignedIDs(map[string]bool{work.ID: true}),
 	)
 
 	if woken != 1 {

--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -336,7 +336,7 @@ func TestReconcileSessionBeads_AssignedNamedSessionByBeadIDOverridesNonInteracti
 		0,
 		&env.stdout,
 		&env.stderr,
-		withReadyAssignedIDs(map[string]bool{work.ID: true}),
+		withReadyAssignedFlags([]bool{true}),
 	)
 
 	if woken != 0 {
@@ -497,7 +497,7 @@ func TestReconcileSessionBeads_AssignedWorkWithReadyWaitOverridesNonInteractiveS
 		0,
 		&env.stdout,
 		&env.stderr,
-		withReadyAssignedIDs(map[string]bool{work.ID: true}),
+		withReadyAssignedFlags([]bool{true}),
 	)
 
 	if woken != 0 {
@@ -616,7 +616,7 @@ func TestReconcileSessionBeads_AssignedWorkWakesIdleLatchedInteractiveSession(t 
 		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, env.sp,
 		env.store, nil, []beads.Bead{work}, nil, env.dt, map[string]int{}, false, nil, "",
 		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
-		withReadyAssignedIDs(map[string]bool{work.ID: true}),
+		withReadyAssignedFlags([]bool{true}),
 	)
 
 	if woken != 1 {


### PR DESCRIPTION
## What

Computes awake-demand readiness for assigned work beads from the store's real
`Ready()`/deps gate instead of fabricating it from bead status alone.

Previously the reconciler's awake-set set `AwakeWorkBead.Ready = (wb.Status == "open")`.
A **blocked** open assigned bead that entered the actionable snapshot via the
open-routed orphan-release pass (which has no deps gate) was therefore treated
as live wake-demand, and its owning session was held active forever. Because
the session never slept, the resume-on-`ShouldWake` path never fired and
adopt-pr molecules hung at cleanup/finalize. `gc hook --claim` already does this
correctly via the store's real `Ready()`/deps gate; this change brings the
reconciler's awake bridge in line with it.

## How

- `collectAssignedWorkBeadsWithStores` now also returns `readyAssignedIDs`,
  populated **only** by the genuinely-ready passes (in-progress, assigned
  molecule roots, and the store `Ready()`/deps pass) and never by the
  open-routed orphan-release pass.
- The awake bridge sets `AwakeWorkBead.Ready` from `readyAssignedIDs`, and
  named-demand requires it for open beads — closing both the assigned-work and
  named-demand leaks.
- The Ready handoff probe is skipped only for assignees that already have a
  genuinely-ready captured bead, so open-routed beads still get a real
  `Ready()` verdict.
- The open-routed bead stays in `assignedWorkBeads` so
  `releaseOrphanedPoolAssignments` still clears dead-session step beads — only
  its wake-demand contribution is removed.

## Why this PR

This is a clean, store-backend-agnostic change extracted from the local sqlite
deploy branch (`deploy/sqlite-b36-probe-attribution`) for upstreaming to `main`
ahead of the interface refactor and the sqlite-behind-interfaces swap. The diff
has **zero** `graph_store`/`sqlite` gating — the awake-demand-from-store-deps fix
is generic and depends only on the existing `beads.Store` `Ready()`/deps
abstraction. Landing it on `main` now keeps it from re-deriving against the
upcoming interface changes.

## Slice rationale

Extracted as a single coherent reconciler fix. One source commit
(`9a490bb03`), cherry-picked onto current `main` with context-drift conflicts
resolved by applying only this commit's hunks (`reconcileStartOptions` plumbing,
the `coordClassStoreCandidates` store-candidate builder, and the
`deferSessionClosesOnBoot` option on `main` were all preserved; nothing was
pulled in from sibling deploy-branch commits). One additional test call site on
`main` was updated to discard the new `readyAssignedIDs` return value.

## Verification

- `go build ./cmd/gc/` — clean
- `go vet ./cmd/gc/` — clean
- Targeted tests pass: `TestComputeAwake*`, `TestBuildDesiredState*`,
  `TestCollectAssignedWork*`, `TestSessionSleep*`, `TestPoolSessionName*`

Generated with Claude Code
