### PR TITLE
fix(api): correct control-plane client timeout rationale to name main's real read call sites

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -266,12 +266,12 @@ type Client struct {
 const sessionMessageTimeout = 4 * time.Minute
 
 // defaultClientTimeout is the overall HTTP timeout for control-plane client
-// calls. The read paths (EphemeralBeads, ReadyBeads, ClaimBead, ...) pass
-// context.Background() and rely solely on this ceiling, and several of them
-// federate the city store plus every rig store — a dolt-backed rig store can
-// take many seconds, so a 10s ceiling timed out gc hook --claim and stalled
-// the worker claim path. Most calls return in milliseconds; this only bounds
-// the slow federated reads and genuinely hung requests.
+// calls. The read paths (ListBeads, GetBead, GetStatus, ListMailInbox,
+// ListConvoys, ...) pass context.Background() and rely solely on this ceiling,
+// and several of them federate the city store plus every rig store — a
+// dolt-backed rig store can take many seconds, so a 10s ceiling false-timed-out
+// healthy-but-slow federated reads. Most calls return in milliseconds; this
+// only bounds the slow federated reads and genuinely hung requests.
 const defaultClientTimeout = 60 * time.Second
 
 // SessionSubmitResponse is the domain-facing shape of a session submit result.

--- a/internal/api/client_timeout_test.go
+++ b/internal/api/client_timeout_test.go
@@ -6,17 +6,17 @@ import (
 )
 
 // TestDefaultClientTimeoutAccommodatesFederatedReads guards the ceiling that
-// governs the worker claim path. EphemeralBeads/ReadyBeads/ClaimBead pass
-// context.Background(), so the HTTP client's overall timeout is their only
-// deadline. Those endpoints federate the city store plus every rig store, and a
-// dolt-backed rig store can take several seconds; a too-tight ceiling times out
-// gc hook --claim and operators cannot claim work. 10s was too tight once the
-// ephemeral read measured ~10s — keep meaningful headroom over the federated
-// read cost.
+// governs the control-plane read paths. ListBeads/GetBead/GetStatus/
+// ListMailInbox pass context.Background(), so the HTTP client's overall timeout
+// is their only deadline. Those endpoints federate the city store plus every
+// rig store, and a dolt-backed rig store can take several seconds; a too-tight
+// ceiling false-times-out healthy-but-slow federated reads. 10s was too tight
+// once a federated read measured ~10s — keep meaningful headroom over the
+// federated read cost.
 func TestDefaultClientTimeoutAccommodatesFederatedReads(t *testing.T) {
 	const minFederatedReadBudget = 30 * time.Second
 	if defaultClientTimeout < minFederatedReadBudget {
-		t.Fatalf("defaultClientTimeout = %v, want >= %v to cover federated multi-store reads on the claim path",
+		t.Fatalf("defaultClientTimeout = %v, want >= %v to cover federated multi-store control-plane reads",
 			defaultClientTimeout, minFederatedReadBudget)
 	}
 }


### PR DESCRIPTION
## Maintainer follow-up to #3814

[#3814](https://github.com/gastownhall/gascity/pull/3814) — _"fix(api): raise
control-plane HTTP client timeout 10s to 60s so federated reads stop timing out
claims"_ (state: **MERGED**) — was squash-merged into `main` before its
adoption-review fixup could land on the PR branch. This follow-up carries only
that maintainer fixup forward.

### What this changes

The merged change documented `defaultClientTimeout` (and its guard test) with
read paths that do **not** exist as `Client` methods on `main` —
`EphemeralBeads`, `ReadyBeads`, `ClaimBead` — and framed the symptom as a
stalled `gc hook --claim` worker claim path. Adoption review flagged the
rationale as inaccurate.

This patch corrects the comments to name the real control-plane read methods
that pass `context.Background()` and are bounded solely by this ceiling —
`ListBeads`, `GetBead`, `GetStatus`, `ListMailInbox`, `ListConvoys` — and
reframes the rationale as a false-timeout of healthy-but-slow federated reads.

**No functional change:** `defaultClientTimeout` stays `60 * time.Second`; only
the doc comment in `internal/api/client.go` and the comment/failure-message in
`internal/api/client_timeout_test.go` change.

### Provenance

- Original PR: #3814 (state **MERGED**)
- Configured base: `main`
- Original GitHub base: `main` (no base mismatch)
- Maintainer fixup commit cherry-picked onto current `main`.

Comment-only change. `go vet ./internal/api/` is clean and
`TestDefaultClientTimeoutAccommodatesFederatedReads` passes.

---
_Adopted via `/adopt-pr` workflow. Original contributor commit preserved._
