### PR TITLE
fix(beads): bound ready-projection SQL; preserve raced-close is_blocked in reconcile (follow-up to #3819)

### DIFF
--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -99,11 +99,14 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 		return result, nil
 	}
 
-	// bd exposes this as a full unfiltered row projection across issues and
-	// wisps; selecting closed rows too lets the cache tolerate ready-projection
-	// races where a row closes between the list query and this SQL fetch. The
-	// ids argument is a cache-side allow-list so callers can keep their
-	// requested surface bounded.
+	// bd exposes this as an active-row projection: the SQL filters out closed
+	// rows so cache prime/reconcile cost stays O(active work) instead of
+	// scanning unbounded closed issue/wisp history every cycle. The ids
+	// argument is a cache-side allow-list so callers can keep their requested
+	// surface bounded. A row that races closed between the list snapshot and
+	// this fetch drops out of the projection; the reconciler preserves its last
+	// cached is_blocked (preserveCachedReadyProjectionLocked) so the absence
+	// does not flap a spurious bead.updated.
 	out, err := s.runner(s.dir, "bd", "sql", readyProjectionSQL(), "--json")
 	if err != nil {
 		return nil, fmt.Errorf("bd sql ready projection: %w", err)
@@ -125,5 +128,5 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 }
 
 func readyProjectionSQL() string {
-	return "select id,is_blocked from issues union all select id,is_blocked from wisps"
+	return "select id,is_blocked from issues where status <> 'closed' union all select id,is_blocked from wisps where status <> 'closed'"
 }

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3317,8 +3317,8 @@ func TestCachingStoreBdPrimeActiveUsesReadyProjectionForBD105(t *testing.T) {
 			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
 				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
 			}
-			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
-				t.Fatalf("ready projection SQL = %q, want unfiltered row projection", query)
+			if !strings.Contains(query, "status <> 'closed'") || !strings.Contains(query, "from issues where") || !strings.Contains(query, "from wisps where") {
+				t.Fatalf("ready projection SQL = %q, want active row projection", query)
 			}
 			return []byte(`[
 					{"id":"bd-ready","is_blocked":0},
@@ -3603,6 +3603,78 @@ func TestCachingStoreBdReconcileDropsPreservedReadyProjectionWhenDepTargetStatus
 	}
 }
 
+// TestCachingStoreBdReconcilePreservesReadyProjectionForRacedClosedRowBD105 is
+// the reconcile-level regression for the race the bounded projection cannot see
+// directly: a bead that is still open in the list snapshot but closes before the
+// active-row projection query runs drops out of the projection entirely. The
+// reconciler must preserve its last cached is_blocked rather than flip it to nil
+// and emit a spurious bead.updated.
+func TestCachingStoreBdReconcilePreservesReadyProjectionForRacedClosedRowBD105(t *testing.T) {
+	t.Parallel()
+
+	racedClosed := false
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) == 0 {
+			t.Fatal("empty bd command")
+		}
+		switch args[0] {
+		case "version":
+			return []byte("bd version 1.0.5 (test)\n"), nil
+		case "sql":
+			// The bounded active-row projection stops returning the bead once it
+			// closes, exactly as the production status<>'closed' SQL would.
+			if racedClosed {
+				return []byte(`[]`), nil
+			}
+			return []byte(`[{"id":"bd-raced","is_blocked":0}]`), nil
+		case "list":
+			// The list snapshot is taken before the close lands, so the bead is
+			// still reported open on the racing reconcile cycle.
+			return []byte(`[
+				{"id":"bd-raced","title":"raced","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}}
+			]`), nil
+		case "query":
+			return []byte(`[]`), nil
+		case "dep":
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		return []byte(`[]`), nil
+	}
+
+	var events []string
+	cache := NewCachingStoreForTest(NewBdStore("/city", runner), func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	initial, err := cache.Get("bd-raced")
+	if err != nil {
+		t.Fatalf("Get initial: %v", err)
+	}
+	if initial.IsBlocked == nil || *initial.IsBlocked {
+		t.Fatalf("initial IsBlocked = %v, want false projection", initial.IsBlocked)
+	}
+
+	events = nil
+	racedClosed = true
+	cache.runReconciliation()
+
+	if len(events) != 0 {
+		t.Fatalf("events after raced-closed projection reconcile = %v, want none (cached IsBlocked preserved)", events)
+	}
+	got, err := cache.Get("bd-raced")
+	if err != nil {
+		t.Fatalf("Get after reconcile: %v", err)
+	}
+	if got.IsBlocked == nil || *got.IsBlocked {
+		t.Fatalf("IsBlocked after raced-closed projection reconcile = %v, want preserved false", got.IsBlocked)
+	}
+}
+
 func TestCachingStoreBdPrimeActiveToleratesMissingReadyProjectionRowsBD105(t *testing.T) {
 	t.Parallel()
 
@@ -3620,8 +3692,8 @@ func TestCachingStoreBdPrimeActiveToleratesMissingReadyProjectionRowsBD105(t *te
 		case "sql":
 			sqlCalls++
 			query := args[1]
-			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
-				t.Fatalf("ready projection SQL = %q, want unfiltered row projection", query)
+			if !strings.Contains(query, "status <> 'closed'") || !strings.Contains(query, "from issues where") || !strings.Contains(query, "from wisps where") {
+				t.Fatalf("ready projection SQL = %q, want active row filter", query)
 			}
 			return []byte(`[
 				{"id":"bd-ready","is_blocked":0}
@@ -3693,8 +3765,8 @@ func TestCachingStoreBdPrimeProjectsIsBlockedForAllBDRowsBD105(t *testing.T) {
 			if strings.Contains(query, " in ('bd-ready'") || strings.Contains(query, " in (\"bd-ready\"") {
 				t.Fatalf("ready projection SQL = %q, must not use per-id IN list", query)
 			}
-			if strings.Contains(query, "status") || !strings.Contains(query, "from issues union all") {
-				t.Fatalf("ready projection SQL = %q, want every row", query)
+			if !strings.Contains(query, "status <> 'closed'") || !strings.Contains(query, "from issues where") || !strings.Contains(query, "from wisps where") {
+				t.Fatalf("ready projection SQL = %q, want every active row", query)
 			}
 			return []byte(`[
 					{"id":"bd-ready","is_blocked":0},

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -312,7 +312,6 @@ func (c *CachingStore) runReconciliation() {
 	}
 	enriched, enrichErr := c.enrichReadyProjectionForCache(fresh)
 	bdLatency := time.Since(bdStart)
-	projectionFailed := enrichErr != nil
 	if enrichErr != nil {
 		c.recordProblem("reconcile ready projection", enrichErr)
 	} else {
@@ -334,9 +333,16 @@ func (c *CachingStore) runReconciliation() {
 
 	c.mu.Lock()
 	now := time.Now()
-	if projectionFailed {
-		c.preserveCachedReadyProjectionLocked(freshByID, depMap, useFreshDeps)
-	}
+	// Preserve a cached is_blocked for any row the projection did not return
+	// this cycle. Two cases land here: a full projection failure (enrichErr
+	// left every row unenriched) and the narrower race where a row is still
+	// open in the list snapshot but closes before the bounded active-row
+	// projection query, so the SQL no longer returns it. Without preservation
+	// the row's is_blocked flips false->nil and beadChanged emits a spurious
+	// bead.updated. The guards inside drop the preservation when the row's deps
+	// or a blocking target's status actually changed, so a real transition is
+	// never masked.
+	c.preserveCachedReadyProjectionLocked(freshByID, depMap, useFreshDeps)
 	if c.mutationSeq != startSeq {
 		var adds, removes, updates int64
 		notifications := make([]cacheNotification, 0, len(freshByID))


### PR DESCRIPTION
## Maintainer follow-up to #3819

Original PR: https://github.com/gastownhall/gascity/pull/3819 — *fix(beads): tolerate closed-row ready-projection races (unfiltered is_blocked projection)*
- Author: @julianknutsen
- State: **MERGED**
- Configured base: `main` · Original GitHub base: `main` (no base mismatch)

### Why this follow-up exists

PR #3819 fixed a real ready-projection race — a row that races closed between the
list snapshot and the projection fetch dropped its `is_blocked` — but it did so by
removing the `status <> 'closed'` filter from the ready projection. Maintainer
adoption review found that this makes cache prime/reconcile scan and serialize
**all** closed issue/wisp history on every cycle: unbounded growth that scales
with total ledger history on a long-lived city rather than with active work.

#3819 merged before this maintainer fix could land on its branch, so this
follow-up carries the fix forward on top of current `main`. It contains **only**
the maintainer fix; the original contributor change is already on `main` via
#3819.

### What this changes

- Restore the bounded active-row SQL in `readyProjectionSQL` so cache
  prime/reconcile scales with active/requested work, not total closed history.
- Close the same raced-close `is_blocked` race in the reconcile layer instead:
  run `preserveCachedReadyProjectionLocked` on every cycle (not only on a full
  projection failure), so a row absent from the bounded projection keeps its
  cached `is_blocked`. The existing deps-unchanged and
  blocking-target-status-unchanged guards drop the preservation when a real
  transition occurred, so no genuine ready-state change is masked.
- Add a reconcile-level regression test for the open-list/closed-projection race
  that asserts no spurious `bead.updated` is emitted, and tighten the SQL-shape
  assertions to target the active-row filter rather than a bare `status`
  substring.

Net cost stays O(active work) while preserving the raced-close `is_blocked`
behavior that #3819 was fixing.

---
_Adopted via `/adopt-pr` workflow. Original contributor commits preserved on `main` via #3819._
