### PR TITLE
fix(hook-claim): wake pool graph.v2 roots after claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pool graph.v2 sessions no longer idle after claiming a workflow root.**
+  When `gc hook --claim` self-claims a pool-routed graph.v2 workflow root, it now
+  enqueues a queued nudge to the concrete claiming session (e.g.
+  `pool-worker/slot-0`) and starts a sidecar poller for it. Previously the only
+  propulsion nudge was the sling-time nudge, whose poller was keyed to the pool
+  template session that never runs, so the concrete slot was never polled and
+  idled until manual operator intervention via `gc session nudge`. The hook-claim
+  nudge is fenced to the claiming session generation (session id + continuation
+  epoch from the claim env), so a recycled slot that reuses the runtime session
+  name cannot pick up a stale nudge.
+
+  **ACP operator note:** in default (non-supervisor) dispatcher mode, the
+  hook-claim nudge is delivered by a sidecar poller for tmux/subprocess sessions.
+  ACP sessions do not support a sidecar poller; the nudge is consumed at the next
+  hook-drain instead. For reliable ACP queued delivery, configure:
+
+  ```toml
+  [daemon]
+  nudge_dispatcher = "supervisor"
+  ```
+
+  In supervisor mode the dispatcher owns queued delivery, so the claim no longer
+  starts a per-session sidecar poller that would race it.
+
+  **In-flight sizing:** with `nudge_dispatcher = "supervisor"`, plan capacity for
+  `max_concurrent_formulas × (1 + max_parallel_steps)` in-flight sessions. A
+  typical graph.v2 run holds one workflow root plus one active step; a formula
+  with two parallel steps holds one root plus two active steps at peak.
+
 - **Pin the `beads` dependency to the stable v1.0.4.** v1.3.0 built against
   `beads v1.0.5`, which was subsequently withdrawn (demoted to a pre-release;
   `v1.0.4` is the current stable release). v1.3.1 repins the `beads` Go module

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -379,6 +379,11 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 			Env:          queryEnv,
 			DrainAck:     opts.DrainAck,
 			JSON:         opts.JSON,
+			// Thread the real city root and config (not a per-store dir) so the
+			// pool-root continuation nudge reaches the city nudge store and
+			// honors daemon.nudge_dispatcher = "supervisor".
+			CityPath: cityPath,
+			Cfg:      cfg,
 		}
 		return claimHookWork(workQuery, workDir, queryEnv, stores, claimOpts, emitQueryFailure, stdout, stderr)
 	}

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 )
 
@@ -26,6 +27,17 @@ type hookClaimOptions struct {
 	Env                []string
 	DrainAck           bool
 	JSON               bool
+	// CityPath is the city root directory, threaded to the pool-root
+	// continuation-nudge enqueue so the production seam can locate the nudge
+	// store, controller, and poller PID tree. Empty in tests that inject a fake
+	// EnqueuePoolRootNudge.
+	CityPath string
+	// Cfg is the loaded city config, threaded to the pool-root continuation
+	// nudge so maybeStartNudgePoller can honor daemon.nudge_dispatcher =
+	// "supervisor" (a nil cfg reads as legacy mode and would spawn a sidecar
+	// poller that races the supervisor dispatcher) and so the claiming agent's
+	// transport resolves for the ACP guard. Nil in tests that inject a fake.
+	Cfg *config.City
 }
 
 type hookClaimOps struct {
@@ -49,7 +61,9 @@ type hookClaimOps struct {
 	RecordSessionPointers hookRecordSessionPointersFunc
 	// EnqueuePoolRootNudge, when non-nil, is called after a pool graph.v2
 	// workflow root is successfully claimed to enqueue the initial continuation
-	// nudge. Nil skips enqueue (tests that don't exercise this path).
+	// nudge and start its poller. Nil skips enqueue (tests that don't exercise
+	// this path). Faked in unit tests so the production poller/store I/O stays
+	// out of the claim path.
 	EnqueuePoolRootNudge hookEnqueuePoolRootNudgeFunc
 	Now                  func() time.Time
 }
@@ -63,7 +77,7 @@ type (
 	hookResolveWorkBranchFunc     func(dir string) string
 	hookStampWorkBranchFunc       func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
 	hookRecordSessionPointersFunc func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
-	hookEnqueuePoolRootNudgeFunc  func(cityPath, assignee, sessionID, sessionName string) error
+	hookEnqueuePoolRootNudgeFunc  func(cfg *config.City, cityPath, sessionName, sessionID, continuationEpoch string) error
 )
 
 type hookClaimJSONResult struct {
@@ -325,8 +339,14 @@ func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead
 	}
 	result.ContinuationAssigned = assigned
 	if ops.EnqueuePoolRootNudge != nil && isPoolGraphV2WorkflowRoot(bead) {
-		sessionID := strings.TrimSpace(bead.Metadata[beadmeta.SessionIDMetadataKey])
-		if err := ops.EnqueuePoolRootNudge(dir, opts.Assignee, sessionID, opts.Assignee); err != nil {
+		// Fence to the live session generation from the claim env
+		// (GC_SESSION_ID / GC_CONTINUATION_EPOCH) — pool roots carry no
+		// gc.session_id in metadata, so the bead value would be empty. The
+		// real CityPath/Cfg (not the per-store dir) are threaded so the
+		// production seam reaches the city nudge store and honors the
+		// supervisor dispatcher.
+		if err := ops.EnqueuePoolRootNudge(opts.Cfg, opts.CityPath, opts.Assignee,
+			hookClaimSessionID(opts.Env), hookClaimContinuationEpoch(opts.Env)); err != nil {
 			fmt.Fprintf(stderr, "gc hook --claim: pool-root continuation nudge for %s: %v\n", bead.ID, err) //nolint:errcheck
 		}
 	}
@@ -518,6 +538,20 @@ func hookClaimSessionID(env []string) string {
 	return strings.TrimSpace(sessionID)
 }
 
+// hookClaimContinuationEpoch returns the continuation epoch
+// (GC_CONTINUATION_EPOCH) from the claim env. It seeds the pool-root
+// continuation nudge's session fence alongside the session id; empty when unset
+// (the session-id fence alone still binds the nudge to the current generation).
+func hookClaimContinuationEpoch(env []string) string {
+	epoch := ""
+	for _, entry := range env {
+		if k, v, ok := strings.Cut(entry, "="); ok && k == "GC_CONTINUATION_EPOCH" {
+			epoch = v
+		}
+	}
+	return strings.TrimSpace(epoch)
+}
+
 // hookResolveWorkBranch returns the current git branch of dir, or "" when dir
 // is not a worktree or HEAD is detached (no meaningful branch to stamp).
 func hookResolveWorkBranch(dir string) string {
@@ -592,14 +626,40 @@ func isPoolGraphV2WorkflowRoot(bead beads.Bead) bool {
 }
 
 // enqueuePoolRootContinuationNudge enqueues the initial continuation nudge for
-// a self-claimed pool graph.v2 workflow root. The nudge message is a neutral
-// structural signal — it does not reference formula or step content.
-func enqueuePoolRootContinuationNudge(cityPath, _ /*assignee*/, sessionID, sessionName string) error {
-	target := nudgeTarget{
-		cityPath:    cityPath,
-		sessionID:   sessionID,
-		sessionName: sessionName,
+// a self-claimed pool graph.v2 workflow root and starts its per-session poller.
+// The nudge message is a neutral structural signal — it does not reference
+// formula or step content.
+//
+// The target is assembled the same way buildSlingNudgeTarget assembles its
+// target, which is what resolves all three hazards of a hand-built target:
+//   - cfg is threaded so maybeStartNudgePoller honors daemon.nudge_dispatcher =
+//     "supervisor". With a nil cfg, nudgeDispatcherIsSupervisor reports false
+//     and a sidecar `gc nudge poll` would spawn on every pool-root claim,
+//     racing the supervisor dispatcher.
+//   - the resolved agent gives sessionTransport() the data its ACP guard needs,
+//     so an ACP pool session does not get a sidecar poller that cannot deliver.
+//   - withNudgeTargetFence fills SessionID / ContinuationEpoch from the live
+//     session bead so a stale nudge cannot land on a recycled pool slot. The
+//     sessionID / continuationEpoch arguments seed the fence from the claim env
+//     (GC_SESSION_ID / GC_CONTINUATION_EPOCH), matching cmd_prime.go.
+func enqueuePoolRootContinuationNudge(cfg *config.City, cityPath, sessionName, sessionID, continuationEpoch string) error {
+	var agent config.Agent
+	var resolved *config.ResolvedProvider
+	if cfg != nil {
+		if a, ok := resolveAgentIdentity(cfg, sessionName, currentRigContext(cfg)); ok {
+			agent = a
+			resolved, _ = config.ResolveProvider(&agent, &cfg.Workspace, cfg.Providers, exec.LookPath)
+		}
 	}
+	target := withNudgeTargetFence(openNudgeBeadStore(cityPath).Store, nudgeTarget{
+		cityPath:          cityPath,
+		cfg:               cfg,
+		agent:             agent,
+		resolved:          resolved,
+		sessionID:         sessionID,
+		continuationEpoch: continuationEpoch,
+		sessionName:       sessionName,
+	})
 	const msg = "Pool workflow root claimed. Check your work hook for available steps."
 	if err := enqueueQueuedNudge(cityPath, newQueuedNudgeWithOptions(
 		target.agentKey(), msg, "hook-claim", time.Now(), queuedNudgeOptionsFromTarget(target),

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -47,7 +47,11 @@ type hookClaimOps struct {
 	// AND gc.active_work_bead (the claimed work bead's gc.step_id) — in ONE update, so
 	// the (run, step) tuple stays atomically consistent. Best-effort.
 	RecordSessionPointers hookRecordSessionPointersFunc
-	Now                   func() time.Time
+	// EnqueuePoolRootNudge, when non-nil, is called after a pool graph.v2
+	// workflow root is successfully claimed to enqueue the initial continuation
+	// nudge. Nil skips enqueue (tests that don't exercise this path).
+	EnqueuePoolRootNudge hookEnqueuePoolRootNudgeFunc
+	Now                  func() time.Time
 }
 
 type (
@@ -59,6 +63,7 @@ type (
 	hookResolveWorkBranchFunc     func(dir string) string
 	hookStampWorkBranchFunc       func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
 	hookRecordSessionPointersFunc func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
+	hookEnqueuePoolRootNudgeFunc  func(cityPath, assignee, sessionID, sessionName string) error
 )
 
 type hookClaimJSONResult struct {
@@ -181,6 +186,9 @@ func (ops *hookClaimOps) applyDefaults() {
 	}
 	if ops.RecordSessionPointers == nil {
 		ops.RecordSessionPointers = hookRecordSessionPointersWithBdStore
+	}
+	if ops.EnqueuePoolRootNudge == nil {
+		ops.EnqueuePoolRootNudge = enqueuePoolRootContinuationNudge
 	}
 }
 
@@ -316,6 +324,12 @@ func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead
 		return 1
 	}
 	result.ContinuationAssigned = assigned
+	if ops.EnqueuePoolRootNudge != nil && isPoolGraphV2WorkflowRoot(bead) {
+		sessionID := strings.TrimSpace(bead.Metadata[beadmeta.SessionIDMetadataKey])
+		if err := ops.EnqueuePoolRootNudge(dir, opts.Assignee, sessionID, opts.Assignee); err != nil {
+			fmt.Fprintf(stderr, "gc hook --claim: pool-root continuation nudge for %s: %v\n", bead.ID, err) //nolint:errcheck
+		}
+	}
 	if opts.JSON {
 		if err := writeCLIJSONLine(stdout, result); err != nil {
 			fmt.Fprintf(stderr, "gc hook --claim: writing JSON: %v\n", err) //nolint:errcheck
@@ -565,6 +579,34 @@ func hookRuntimeDrainAck(stderr io.Writer) error {
 	if code := cmdRuntimeDrainAck(nil, false, io.Discard, stderr); code != 0 {
 		return errors.New("runtime drain-ack returned non-zero")
 	}
+	return nil
+}
+
+// isPoolGraphV2WorkflowRoot reports whether bead is a pool-routed graph.v2
+// workflow root that needs an initial continuation nudge at claim time.
+// All three conditions must hold to avoid false positives.
+func isPoolGraphV2WorkflowRoot(bead beads.Bead) bool {
+	return strings.TrimSpace(bead.Metadata[beadmeta.KindMetadataKey]) == beadmeta.KindWorkflow &&
+		strings.TrimSpace(bead.Metadata[beadmeta.FormulaContractMetadataKey]) == beadmeta.FormulaContractGraphV2 &&
+		strings.TrimSpace(bead.Metadata[beadmeta.ContinuationGroupMetadataKey]) == beadmeta.PoolWorkflowContinuationGroup
+}
+
+// enqueuePoolRootContinuationNudge enqueues the initial continuation nudge for
+// a self-claimed pool graph.v2 workflow root. The nudge message is a neutral
+// structural signal — it does not reference formula or step content.
+func enqueuePoolRootContinuationNudge(cityPath, _ /*assignee*/, sessionID, sessionName string) error {
+	target := nudgeTarget{
+		cityPath:    cityPath,
+		sessionID:   sessionID,
+		sessionName: sessionName,
+	}
+	const msg = "Pool workflow root claimed. Check your work hook for available steps."
+	if err := enqueueQueuedNudge(cityPath, newQueuedNudgeWithOptions(
+		target.agentKey(), msg, "hook-claim", time.Now(), queuedNudgeOptionsFromTarget(target),
+	)); err != nil {
+		return err
+	}
+	maybeStartNudgePoller(target)
 	return nil
 }
 

--- a/cmd/gc/cmd_hook_claim_test.go
+++ b/cmd/gc/cmd_hook_claim_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"reflect"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
@@ -90,5 +92,201 @@ func TestDoHookClaimUsesSelectedStoreContextForMutationAndContinuation(t *testin
 	}
 	if assignedBead != "sib-1" {
 		t.Fatalf("assignedBead = %q, want sib-1", assignedBead)
+	}
+}
+
+// poolGraphV2RootBead returns a minimal pool-routed graph.v2 workflow root bead
+// with the given id, assignee, and optional session id stamped in metadata.
+func poolGraphV2RootBead(id, routeTarget, sessionID string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:              beadmeta.KindWorkflow,
+			beadmeta.FormulaContractMetadataKey:   beadmeta.FormulaContractGraphV2,
+			beadmeta.ContinuationGroupMetadataKey: beadmeta.PoolWorkflowContinuationGroup,
+			beadmeta.RunTargetMetadataKey:         routeTarget,
+			beadmeta.SessionIDMetadataKey:         sessionID,
+		},
+	}
+}
+
+// minimalPoolRootOps returns a hookClaimOps that claims successfully and
+// exercises no continuation pre-assignment (no root_bead_id on the bead).
+func minimalPoolRootOps(bead beads.Bead, nudgeFn func(string, string, string, string) error) hookClaimOps {
+	return hookClaimOps{
+		Runner: func(string, string) (string, error) {
+			out, _ := json.Marshal([]beads.Bead{bead})
+			return string(out), nil
+		},
+		Claim: func(_ context.Context, _ string, _ []string, _, assignee string) (beads.Bead, bool, error) {
+			b := bead
+			b.Assignee = assignee
+			b.Status = "in_progress"
+			return b, true, nil
+		},
+		ListContinuation:     func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) { return nil, nil },
+		AssignContinuation:   func(_ context.Context, _ string, _ []string, _, _ string) error { return nil },
+		EnqueuePoolRootNudge: nudgeFn,
+	}
+}
+
+// TestHookClaimPoolGraphV2Root_EnqueuesNudge verifies that claiming a pool
+// graph.v2 workflow root calls EnqueuePoolRootNudge exactly once with the
+// correct assignee, sessionID, and sessionName.
+func TestHookClaimPoolGraphV2Root_EnqueuesNudge(t *testing.T) {
+	bead := poolGraphV2RootBead("wf-root-1", "worker-1", "sess-abc")
+
+	var calls []struct{ cityPath, assignee, sessionID, sessionName string }
+	ops := minimalPoolRootOps(bead, func(cityPath, assignee, sessionID, sessionName string) error {
+		calls = append(calls, struct{ cityPath, assignee, sessionID, sessionName string }{cityPath, assignee, sessionID, sessionName})
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "city-dir", hookClaimOptions{
+		Assignee:     "worker-1",
+		RouteTargets: []string{"worker-1"},
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if len(calls) != 1 {
+		t.Fatalf("EnqueuePoolRootNudge called %d times, want 1", len(calls))
+	}
+	if calls[0].assignee != "worker-1" {
+		t.Fatalf("assignee = %q, want worker-1", calls[0].assignee)
+	}
+	if calls[0].sessionID != "sess-abc" {
+		t.Fatalf("sessionID = %q, want sess-abc", calls[0].sessionID)
+	}
+	if calls[0].sessionName != "worker-1" {
+		t.Fatalf("sessionName = %q, want worker-1", calls[0].sessionName)
+	}
+	if calls[0].cityPath != "city-dir" {
+		t.Fatalf("cityPath = %q, want city-dir", calls[0].cityPath)
+	}
+}
+
+// TestHookClaimNonGraphV2Bead_NoNudge verifies that claiming a non-graph.v2
+// bead does not call EnqueuePoolRootNudge.
+func TestHookClaimNonGraphV2Bead_NoNudge(t *testing.T) {
+	bead := beads.Bead{
+		ID:     "task-1",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:     "task",
+			beadmeta.RoutedToMetadataKey: "worker-1",
+		},
+	}
+	var called int
+	ops := minimalPoolRootOps(bead, func(_, _, _, _ string) error { called++; return nil })
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "city-dir", hookClaimOptions{
+		Assignee:     "worker-1",
+		RouteTargets: []string{"worker-1"},
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if called != 0 {
+		t.Fatalf("EnqueuePoolRootNudge called %d times, want 0", called)
+	}
+}
+
+// TestHookClaimPoolStepBead_NoNudge verifies that a pool step bead (same
+// continuation group but kind != "workflow") does not call EnqueuePoolRootNudge.
+func TestHookClaimPoolStepBead_NoNudge(t *testing.T) {
+	bead := beads.Bead{
+		ID:     "step-1",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:              "task",
+			beadmeta.FormulaContractMetadataKey:   beadmeta.FormulaContractGraphV2,
+			beadmeta.ContinuationGroupMetadataKey: beadmeta.PoolWorkflowContinuationGroup,
+			beadmeta.RoutedToMetadataKey:          "worker-1",
+		},
+	}
+	var called int
+	ops := minimalPoolRootOps(bead, func(_, _, _, _ string) error { called++; return nil })
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "city-dir", hookClaimOptions{
+		Assignee:     "worker-1",
+		RouteTargets: []string{"worker-1"},
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if called != 0 {
+		t.Fatalf("EnqueuePoolRootNudge called %d times, want 0 (kind != workflow)", called)
+	}
+}
+
+// TestHookClaimNamedSessionBead_NoNudge verifies that a named-session graph.v2
+// workflow root (no pool continuation group) does not call EnqueuePoolRootNudge.
+func TestHookClaimNamedSessionBead_NoNudge(t *testing.T) {
+	bead := beads.Bead{
+		ID:     "named-wf-1",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+			beadmeta.RunTargetMetadataKey:       "worker-1",
+			// No ContinuationGroupMetadataKey → not pool-routed.
+		},
+	}
+	var called int
+	ops := minimalPoolRootOps(bead, func(_, _, _, _ string) error { called++; return nil })
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "city-dir", hookClaimOptions{
+		Assignee:     "worker-1",
+		RouteTargets: []string{"worker-1"},
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if called != 0 {
+		t.Fatalf("EnqueuePoolRootNudge called %d times, want 0 (no continuation group)", called)
+	}
+}
+
+// TestHookClaimPoolGraphV2Root_NudgeError verifies that a nudge-enqueue error
+// does not cause the claim to fail: exit code is still 0 and the error appears
+// on stderr.
+func TestHookClaimPoolGraphV2Root_NudgeError(t *testing.T) {
+	bead := poolGraphV2RootBead("wf-root-2", "worker-1", "sess-def")
+	ops := minimalPoolRootOps(bead, func(_, _, _, _ string) error {
+		return errors.New("nudge queue full")
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "city-dir", hookClaimOptions{
+		Assignee:     "worker-1",
+		RouteTargets: []string{"worker-1"},
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d after nudge error, want 0", code)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("nudge queue full")) {
+		t.Fatalf("stderr %q does not contain nudge error", stderr.String())
+	}
+}
+
+// TestHookClaimPoolGraphV2Root_NilNudgeSeam verifies that a nil
+// EnqueuePoolRootNudge seam does not panic and the claim still succeeds.
+func TestHookClaimPoolGraphV2Root_NilNudgeSeam(t *testing.T) {
+	bead := poolGraphV2RootBead("wf-root-3", "worker-1", "sess-ghi")
+	ops := minimalPoolRootOps(bead, nil) // nil seam
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "city-dir", hookClaimOptions{
+		Assignee:     "worker-1",
+		RouteTargets: []string{"worker-1"},
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d with nil nudge seam, want 0; stderr=%s", code, stderr.String())
 	}
 }

--- a/cmd/gc/cmd_hook_claim_test.go
+++ b/cmd/gc/cmd_hook_claim_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestDoHookClaimUsesSelectedStoreContextForMutationAndContinuation(t *testing.T) {
@@ -113,7 +114,7 @@ func poolGraphV2RootBead(id, routeTarget, sessionID string) beads.Bead {
 
 // minimalPoolRootOps returns a hookClaimOps that claims successfully and
 // exercises no continuation pre-assignment (no root_bead_id on the bead).
-func minimalPoolRootOps(bead beads.Bead, nudgeFn func(string, string, string, string) error) hookClaimOps {
+func minimalPoolRootOps(bead beads.Bead, nudgeFn hookEnqueuePoolRootNudgeFunc) hookClaimOps {
 	return hookClaimOps{
 		Runner: func(string, string) (string, error) {
 			out, _ := json.Marshal([]beads.Bead{bead})
@@ -132,14 +133,23 @@ func minimalPoolRootOps(bead beads.Bead, nudgeFn func(string, string, string, st
 }
 
 // TestHookClaimPoolGraphV2Root_EnqueuesNudge verifies that claiming a pool
-// graph.v2 workflow root calls EnqueuePoolRootNudge exactly once with the
-// correct assignee, sessionID, and sessionName.
+// graph.v2 workflow root calls EnqueuePoolRootNudge exactly once, threading the
+// real CityPath and Cfg and seeding the session fence from the claim env
+// (GC_SESSION_ID / GC_CONTINUATION_EPOCH) — pool roots carry no gc.session_id
+// in metadata, so the env is the authoritative fence source.
 func TestHookClaimPoolGraphV2Root_EnqueuesNudge(t *testing.T) {
-	bead := poolGraphV2RootBead("wf-root-1", "worker-1", "sess-abc")
+	bead := poolGraphV2RootBead("wf-root-1", "worker-1", "")
 
-	var calls []struct{ cityPath, assignee, sessionID, sessionName string }
-	ops := minimalPoolRootOps(bead, func(cityPath, assignee, sessionID, sessionName string) error {
-		calls = append(calls, struct{ cityPath, assignee, sessionID, sessionName string }{cityPath, assignee, sessionID, sessionName})
+	cfg := &config.City{}
+	var calls []struct {
+		cfg                                         *config.City
+		cityPath, sessionName, sessionID, contEpoch string
+	}
+	ops := minimalPoolRootOps(bead, func(c *config.City, cityPath, sessionName, sessionID, contEpoch string) error {
+		calls = append(calls, struct {
+			cfg                                         *config.City
+			cityPath, sessionName, sessionID, contEpoch string
+		}{c, cityPath, sessionName, sessionID, contEpoch})
 		return nil
 	})
 
@@ -147,6 +157,9 @@ func TestHookClaimPoolGraphV2Root_EnqueuesNudge(t *testing.T) {
 	code := doHookClaim("query", "city-dir", hookClaimOptions{
 		Assignee:     "worker-1",
 		RouteTargets: []string{"worker-1"},
+		CityPath:     "city-root",
+		Cfg:          cfg,
+		Env:          []string{"GC_SESSION_ID=sess-abc", "GC_CONTINUATION_EPOCH=epoch-7"},
 	}, ops, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
@@ -154,17 +167,20 @@ func TestHookClaimPoolGraphV2Root_EnqueuesNudge(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("EnqueuePoolRootNudge called %d times, want 1", len(calls))
 	}
-	if calls[0].assignee != "worker-1" {
-		t.Fatalf("assignee = %q, want worker-1", calls[0].assignee)
+	if calls[0].cfg != cfg {
+		t.Fatalf("cfg = %p, want threaded %p", calls[0].cfg, cfg)
 	}
-	if calls[0].sessionID != "sess-abc" {
-		t.Fatalf("sessionID = %q, want sess-abc", calls[0].sessionID)
+	if calls[0].cityPath != "city-root" {
+		t.Fatalf("cityPath = %q, want city-root (threaded, not per-store dir)", calls[0].cityPath)
 	}
 	if calls[0].sessionName != "worker-1" {
 		t.Fatalf("sessionName = %q, want worker-1", calls[0].sessionName)
 	}
-	if calls[0].cityPath != "city-dir" {
-		t.Fatalf("cityPath = %q, want city-dir", calls[0].cityPath)
+	if calls[0].sessionID != "sess-abc" {
+		t.Fatalf("sessionID = %q, want sess-abc (from GC_SESSION_ID)", calls[0].sessionID)
+	}
+	if calls[0].contEpoch != "epoch-7" {
+		t.Fatalf("continuationEpoch = %q, want epoch-7 (from GC_CONTINUATION_EPOCH)", calls[0].contEpoch)
 	}
 }
 
@@ -180,7 +196,7 @@ func TestHookClaimNonGraphV2Bead_NoNudge(t *testing.T) {
 		},
 	}
 	var called int
-	ops := minimalPoolRootOps(bead, func(_, _, _, _ string) error { called++; return nil })
+	ops := minimalPoolRootOps(bead, func(_ *config.City, _, _, _, _ string) error { called++; return nil })
 
 	var stdout, stderr bytes.Buffer
 	code := doHookClaim("query", "city-dir", hookClaimOptions{
@@ -209,7 +225,7 @@ func TestHookClaimPoolStepBead_NoNudge(t *testing.T) {
 		},
 	}
 	var called int
-	ops := minimalPoolRootOps(bead, func(_, _, _, _ string) error { called++; return nil })
+	ops := minimalPoolRootOps(bead, func(_ *config.City, _, _, _, _ string) error { called++; return nil })
 
 	var stdout, stderr bytes.Buffer
 	code := doHookClaim("query", "city-dir", hookClaimOptions{
@@ -238,7 +254,7 @@ func TestHookClaimNamedSessionBead_NoNudge(t *testing.T) {
 		},
 	}
 	var called int
-	ops := minimalPoolRootOps(bead, func(_, _, _, _ string) error { called++; return nil })
+	ops := minimalPoolRootOps(bead, func(_ *config.City, _, _, _, _ string) error { called++; return nil })
 
 	var stdout, stderr bytes.Buffer
 	code := doHookClaim("query", "city-dir", hookClaimOptions{
@@ -258,7 +274,7 @@ func TestHookClaimNamedSessionBead_NoNudge(t *testing.T) {
 // on stderr.
 func TestHookClaimPoolGraphV2Root_NudgeError(t *testing.T) {
 	bead := poolGraphV2RootBead("wf-root-2", "worker-1", "sess-def")
-	ops := minimalPoolRootOps(bead, func(_, _, _, _ string) error {
+	ops := minimalPoolRootOps(bead, func(_ *config.City, _, _, _, _ string) error {
 		return errors.New("nudge queue full")
 	})
 
@@ -288,5 +304,46 @@ func TestHookClaimPoolGraphV2Root_NilNudgeSeam(t *testing.T) {
 	}, ops, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doHookClaim() = %d with nil nudge seam, want 0; stderr=%s", code, stderr.String())
+	}
+}
+
+// TestEnqueuePoolRootContinuationNudge_HonorsSupervisorDispatcher exercises the
+// production seam (not a fake) to prove the blocker fix: with
+// daemon.nudge_dispatcher = "supervisor" the per-session sidecar poller is NOT
+// started — the supervisor dispatcher owns queued delivery and a sidecar
+// `gc nudge poll` would race it and reintroduce the bd-shellout load it exists
+// to eliminate. In legacy mode the poller IS started. The regression this
+// guards: nudgeDispatcherIsSupervisor reads target.cfg, so a hand-built target
+// with a nil cfg silently defeats the guard and always spawns the sidecar.
+func TestEnqueuePoolRootContinuationNudge_HonorsSupervisorDispatcher(t *testing.T) {
+	origPoller := startNudgePoller
+	origStore := openNudgeBeadStore
+	t.Cleanup(func() { startNudgePoller = origPoller; openNudgeBeadStore = origStore })
+	// Zero store: the seeded fence below short-circuits withNudgeTargetFence
+	// before any store read, so no session beads are needed.
+	openNudgeBeadStore = func(string) beads.NudgesStore { return beads.NudgesStore{} }
+
+	for _, tc := range []struct {
+		name       string
+		dispatcher string
+		wantPoller bool
+	}{
+		{"supervisor skips sidecar poller", "supervisor", false},
+		{"legacy starts sidecar poller", "legacy", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var started bool
+			startNudgePoller = func(_, _, _ string) error { started = true; return nil }
+			cfg := &config.City{Daemon: config.DaemonConfig{NudgeDispatcher: tc.dispatcher}}
+			// Seed both fence fields (sessionID + continuationEpoch) so
+			// withNudgeTargetFence returns without touching the store: this
+			// test isolates the poller decision, not the fence lookup.
+			if err := enqueuePoolRootContinuationNudge(cfg, t.TempDir(), "pool-worker/slot-0", "sess-1", "epoch-1"); err != nil {
+				t.Fatalf("enqueuePoolRootContinuationNudge() error = %v", err)
+			}
+			if started != tc.wantPoller {
+				t.Fatalf("startNudgePoller called = %v, want %v (dispatcher=%q)", started, tc.wantPoller, tc.dispatcher)
+			}
+		})
 	}
 }

--- a/cmd/gc/session_progress_test.go
+++ b/cmd/gc/session_progress_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestSessionProgressStalled(t *testing.T) {
@@ -136,9 +137,9 @@ func TestPoolGraphV2AutoAdvance_NudgeEnqueuedAtClaim(t *testing.T) {
 		},
 		ListContinuation:   func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) { return nil, nil },
 		AssignContinuation: func(_ context.Context, _ string, _ []string, _, _ string) error { return nil },
-		EnqueuePoolRootNudge: func(_, assignee, sessionID, _ string) error {
-			if assignee != "pool-worker" {
-				t.Errorf("nudge assignee = %q, want pool-worker", assignee)
+		EnqueuePoolRootNudge: func(_ *config.City, _, sessionName, sessionID, _ string) error {
+			if sessionName != "pool-worker" {
+				t.Errorf("nudge sessionName = %q, want pool-worker", sessionName)
 			}
 			if sessionID != "sess-pool-1" {
 				t.Errorf("nudge sessionID = %q, want sess-pool-1", sessionID)
@@ -152,6 +153,7 @@ func TestPoolGraphV2AutoAdvance_NudgeEnqueuedAtClaim(t *testing.T) {
 	code := doHookClaim("query", "city-path", hookClaimOptions{
 		Assignee:     "pool-worker",
 		RouteTargets: []string{"pool-worker"},
+		Env:          []string{"GC_SESSION_ID=sess-pool-1"},
 	}, ops, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())

--- a/cmd/gc/session_progress_test.go
+++ b/cmd/gc/session_progress_test.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
 )
 
 func TestSessionProgressStalled(t *testing.T) {
@@ -97,5 +103,60 @@ func TestProgressStall_DemandWorkerLostClaim_IsRecycled(t *testing.T) {
 					tc.min, tc.open, floorExempt, recycled, tc.wantRecycle)
 			}
 		})
+	}
+}
+
+// TestPoolGraphV2AutoAdvance_NudgeEnqueuedAtClaim verifies the full
+// doHookClaim path for a pool-routed graph.v2 workflow root: claiming the root
+// automatically enqueues a continuation nudge so the pool session advances
+// through its formula steps without requiring a manual nudge. This is the
+// mechanism that enables pool graph.v2 auto-advance.
+func TestPoolGraphV2AutoAdvance_NudgeEnqueuedAtClaim(t *testing.T) {
+	root := beads.Bead{
+		ID:     "wf-auto-1",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:              beadmeta.KindWorkflow,
+			beadmeta.FormulaContractMetadataKey:   beadmeta.FormulaContractGraphV2,
+			beadmeta.ContinuationGroupMetadataKey: beadmeta.PoolWorkflowContinuationGroup,
+			beadmeta.RunTargetMetadataKey:         "pool-worker",
+			beadmeta.SessionIDMetadataKey:         "sess-pool-1",
+		},
+	}
+	out, _ := json.Marshal([]beads.Bead{root})
+
+	var nudgeEnqueued bool
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(out), nil },
+		Claim: func(_ context.Context, _ string, _ []string, _, assignee string) (beads.Bead, bool, error) {
+			b := root
+			b.Assignee = assignee
+			b.Status = "in_progress"
+			return b, true, nil
+		},
+		ListContinuation:   func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) { return nil, nil },
+		AssignContinuation: func(_ context.Context, _ string, _ []string, _, _ string) error { return nil },
+		EnqueuePoolRootNudge: func(_, assignee, sessionID, _ string) error {
+			if assignee != "pool-worker" {
+				t.Errorf("nudge assignee = %q, want pool-worker", assignee)
+			}
+			if sessionID != "sess-pool-1" {
+				t.Errorf("nudge sessionID = %q, want sess-pool-1", sessionID)
+			}
+			nudgeEnqueued = true
+			return nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "city-path", hookClaimOptions{
+		Assignee:     "pool-worker",
+		RouteTargets: []string{"pool-worker"},
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !nudgeEnqueued {
+		t.Fatal("continuation nudge was not enqueued after claiming pool graph.v2 root; pool session will not auto-advance")
 	}
 }

--- a/internal/beadmeta/values.go
+++ b/internal/beadmeta/values.go
@@ -81,6 +81,11 @@ const (
 // contract — the single most-branched-on metadata value in the engine.
 const FormulaContractGraphV2 = "graph.v2"
 
+// PoolWorkflowContinuationGroup is the value of ContinuationGroupMetadataKey
+// stamped on pool-routed graph.v2 steps so preassignHookContinuationGroup
+// keeps all steps of a molecule on the same pool slot (fixes #2978).
+const PoolWorkflowContinuationGroup = "pool-workflow"
+
 // Values of ScopeRoleMetadataKey ("gc.scope_role"): the role a bead plays
 // inside a scope. The scope reconciler in internal/dispatch/runtime.go branches
 // on exact agreement between writers (dispatch, formula, cmd/gc) and readers.

--- a/internal/beadmeta/values_test.go
+++ b/internal/beadmeta/values_test.go
@@ -59,6 +59,7 @@ func TestPinnedOutcomeAndFailureClassValues(t *testing.T) {
 func TestPinnedVocabularyValues(t *testing.T) {
 	pinned := map[string]string{
 		FormulaContractGraphV2:          "graph.v2",
+		PoolWorkflowContinuationGroup:   "pool-workflow",
 		ScopeRoleBody:                   "body",
 		ScopeRoleMember:                 "member",
 		ScopeRoleControl:                "control",

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -25,10 +25,10 @@ const (
 	GraphExecutionRigContextMetaKey = beadmeta.ExecutionRigContextMetadataKey
 )
 
-// poolWorkflowContinuationGroup is the continuation group value stamped on
-// pool-routed graph.v2 steps so preassignHookContinuationGroup keeps all steps
-// of a molecule on the same pool slot (fixes #2978).
-const poolWorkflowContinuationGroup = "pool-workflow"
+// poolWorkflowContinuationGroup aliases beadmeta.PoolWorkflowContinuationGroup
+// for local use. Exported via beadmeta so cmd/gc can reference it without a
+// graphroute import.
+const poolWorkflowContinuationGroup = beadmeta.PoolWorkflowContinuationGroup
 
 // AgentResolver resolves an agent name to a config.Agent.
 type AgentResolver interface {

--- a/release-gates/ga-sxe4sc-2-hook-claim-gate.md
+++ b/release-gates/ga-sxe4sc-2-hook-claim-gate.md
@@ -1,0 +1,54 @@
+# Release Gate: hook-claim pool graph.v2 root nudge
+
+Bead: ga-sxe4sc.2
+Candidate branch: fix/ga-cx1hbq-hook-claim-pool-graph-v2-nudge
+Candidate input head: 4daf5e1fda5151d2b3f1f8eda99e18198131a579
+Base: origin/main
+Gate run: 2026-06-29T23:16:51-07:00
+
+`docs/PROJECT_MANIFEST.md` was not present in this Gas City checkout. This
+gate uses the deployer release criteria from the active rig prompt.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead ga-an3le0 contains `REVIEW VERDICT: PASS` from gascity/reviewer for commit 3ec937bd30c325e8f827c47d92babd50e97e9a45. Parent deploy bead ga-sxe4sc records the same reviewed PASS and was split only because the original branch mixed independent themes. |
+| 2 | Acceptance criteria met | PASS | Builder handoff ga-sxe4sc.1 produced clean branch `fix/ga-cx1hbq-hook-claim-pool-graph-v2-nudge` at 4daf5e1fda5151d2b3f1f8eda99e18198131a579. Diff against origin/main is limited to hook-claim continuation nudge behavior and tests. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc` passed. `go vet ./...` passed. Focused hook-claim/nudge tests passed: `ok github.com/gastownhall/gascity/cmd/gc 20.985s`. Full rig baseline `make test` passed with `observable go test: PASS log=/tmp/gascity-test.jsonl.yzmc4z`. |
+| 4 | No high-severity review findings open | PASS | Review bead ga-an3le0 records Style, Security, Architecture, Spec Compliance, and Coverage as PASS; no HIGH findings are recorded. |
+| 5 | Final branch is clean | PASS | Clean gate worktree before the gate: `git status --short --branch` showed only `## HEAD (no branch)`. The gate file is the only added artifact. |
+| 6 | Branch diverges cleanly from main | PASS | After `git fetch origin main`, `git merge-base --is-ancestor origin/main fix/ga-cx1hbq-hook-claim-pool-graph-v2-nudge` exited 0. |
+| 7 | Single feature theme | PASS | Diff is one hook-claim release theme: enqueue a continuation nudge when a pool session self-claims a graph.v2 workflow root, plus regression coverage and shared metadata constants. No extmsg/SSE/API/dashboard files are present. |
+
+## Candidate Diff
+
+`git log origin/main..HEAD --oneline`:
+
+```text
+4daf5e1fd fix(hook-claim): enqueue continuation nudge for self-claimed pool graph.v2 roots (ga-cx1hbq)
+```
+
+`git diff --name-status origin/main..HEAD`:
+
+```text
+M	cmd/gc/cmd_hook_claim.go
+M	cmd/gc/cmd_hook_claim_test.go
+M	cmd/gc/session_progress_test.go
+M	internal/beadmeta/values.go
+M	internal/beadmeta/values_test.go
+M	internal/graphroute/graphroute.go
+```
+
+## Commands
+
+```text
+git fetch origin main
+git merge-base --is-ancestor origin/main fix/ga-cx1hbq-hook-claim-pool-graph-v2-nudge
+go build ./cmd/gc
+go vet ./...
+go test ./cmd/gc -run 'TestHookClaimPoolGraphV2Root_EnqueuesNudge|TestHookClaimNonGraphV2Bead_NoNudge|TestHookClaimPoolStepBead_NoNudge|TestHookClaimNamedSessionBead_NoNudge|TestHookClaimPoolGraphV2Root_NudgeError|TestHookClaimPoolGraphV2Root_NilNudgeSeam|TestHookClaimJSONPassesRootJSONContract|TestPoolGraphV2AutoAdvance_NudgeEnqueuedAtClaim|TestSessionProgressStalled'
+make test
+```
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

When a pool worker self-claims a graph.v2 workflow root, `gc hook claim` now enqueues the same continuation nudge that ordinary routing uses. That lets the claimed root advance immediately instead of sitting idle until another manual or patrol-driven prompt wakes the worker.

The nudge is scoped to pool-routed graph.v2 workflow roots only; step beads, named sessions, and non-graph work keep their current behavior.

## Review notes

- The detection path is in `cmd/gc/cmd_hook_claim.go`, with shared metadata constants in `internal/beadmeta` and the `graphroute` alias kept as a compatibility shim.
- Nudge enqueue remains best-effort: claim success is not converted into a failure if nudge delivery cannot be queued.
- No API, dashboard, schema, or external-message surfaces are changed.

## Test plan

- [x] `go build ./cmd/gc`
- [x] `go vet ./...`
- [x] `go test ./cmd/gc -run 'TestHookClaimPoolGraphV2Root_EnqueuesNudge|TestHookClaimNonGraphV2Bead_NoNudge|TestHookClaimPoolStepBead_NoNudge|TestHookClaimNamedSessionBead_NoNudge|TestHookClaimPoolGraphV2Root_NudgeError|TestHookClaimPoolGraphV2Root_NilNudgeSeam|TestHookClaimJSONPassesRootJSONContract|TestPoolGraphV2AutoAdvance_NudgeEnqueuedAtClaim|TestSessionProgressStalled'`
- [x] `make test`
- [x] Release gate: [`release-gates/ga-sxe4sc-2-hook-claim-gate.md`](release-gates/ga-sxe4sc-2-hook-claim-gate.md)


## Update — addressed review (supervisor-cfg fold-in)

Folded the supervisor-dispatcher / session-fence fix from the sibling #3833 into this branch (its better base), per the review. The pool-root nudge target is now assembled the same way `buildSlingNudgeTarget` assembles its target:

- **[blocker] Supervisor-mode poller race** — the loaded city `Cfg` (and the real city path, not the per-store `dir`) is threaded into the enqueue seam, so `maybeStartNudgePoller` honors `daemon.nudge_dispatcher = "supervisor"` and no longer spawns a sidecar `gc nudge poll` on every pool-root claim that would race the supervisor dispatcher.
- **[med] Session fence** — the nudge is fenced to the live session generation (`GC_SESSION_ID` / `GC_CONTINUATION_EPOCH`, then `withNudgeTargetFence` fills from the session bead), so a recycled pool slot cannot pick up a stale nudge.
- **[med] ACP edge** — the claiming agent is resolved so `sessionTransport()` drives the ACP guard; an ACP pool session no longer gets a sidecar poller it cannot use.

New `TestEnqueuePoolRootContinuationNudge_HonorsSupervisorDispatcher` exercises the production seam (not a fake): supervisor mode skips the sidecar poller, legacy starts it. CHANGELOG entry folded from #3833.

Supersedes #3833 (same #3554 root cause, same call site).

Closes #3554
