### PR TITLE
feat(init): first-class hosted/external Dolt endpoint for gc init

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -260,6 +260,16 @@ func initDirIfReady(cityPath, dir, prefix string) (deferred bool, err error) {
 			return false, err
 		}
 		if !owned {
+			// An unverified external (hosted) endpoint has no guaranteed
+			// credentials at init time. Write the canonical scope files and
+			// defer the live bd init to gc start, which carries the credential
+			// command; init never requires a live connection (R5).
+			if cityExternalDoltEndpointUnverified(cityPath) {
+				if err := seedDeferredManagedBeadsErr(cityPath, dir, prefix, ""); err != nil {
+					return false, err
+				}
+				return true, nil
+			}
 			if err := initDirIfReadyInitAndHookDir(cityPath, dir, prefix); err != nil {
 				return false, err
 			}

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -1411,10 +1411,12 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	// When a hosted/external Dolt endpoint was supplied, write the full
 	// canonical external config now (R2/R3/R4/R5) so the unconditional
 	// initDirIfReady that follows resolves the city as external and skips the
-	// managed-local Dolt bootstrap. Requires a bd-backed beads provider.
+	// managed-local Dolt bootstrap. Reject incompatible effective backends
+	// (file or doltlite) before writing any canonical files so a rejected init
+	// leaves no mixed ledger state.
 	if wiz.hostedDolt.enabled() {
-		if !cityUsesBdStoreContract(cityPath) {
-			fmt.Fprintln(stderr, "gc init: --dolt-host requires a bd-backed beads provider (use the gascity or gastown template)") //nolint:errcheck // best-effort stderr
+		if err := hostedDoltBackendError(cityPath); err != nil {
+			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if err := applyInitHostedDoltCanonicalConfig(fs, cityPath, cityPrefix, wiz.hostedDolt); err != nil {

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -82,9 +82,10 @@ type wizardConfig struct {
 	configName       string // canonical values: "minimal", "gastown", "gascity", or "custom"
 	defaultProvider  string // selected default provider key
 	providers        []string
-	provider         string // compatibility mirror for older internal callers
-	startCommand     string // custom start command (workspace-level)
-	bootstrapProfile string // hosted bootstrap profile, or "" for local defaults
+	provider         string                // compatibility mirror for older internal callers
+	startCommand     string                // custom start command (workspace-level)
+	bootstrapProfile string                // hosted bootstrap profile, or "" for local defaults
+	hostedDolt       hostedDoltInitOptions // external/hosted Dolt ledger endpoint (disabled when zero)
 	err              error
 }
 
@@ -320,6 +321,11 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 	var providersFlag []string
 	var defaultProviderFlag string
 	var bootstrapProfileFlag string
+	var doltHostFlag string
+	var doltPortFlag string
+	var doltUserFlag string
+	var doltDatabaseFlag string
+	var doltProjectIDFlag string
 	var skipProviderReadiness bool
 	var preserveExisting bool
 	var jsonOut bool
@@ -348,7 +354,10 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
   gc init --name my-city
   gc init --from ~/elan --name elan /city
   gc init --file ./my-city.toml ~/bright-lights
-  gc init --file city.toml --preserve-existing .`,
+  gc init --file city.toml --preserve-existing .
+  gc init --template gascity --default-provider claude \
+    --dolt-host db.example.com --dolt-port 4406 \
+    --dolt-database bd_prj_x --dolt-project-id prj_x --no-start /city`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(runCmd *cobra.Command, args []string) error {
 			out := stdout
@@ -366,7 +375,14 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 				code := cmdInitFromFileWithOptionsInternal(fileFlag, args, nameFlag, out, stderr, skipProviderReadiness, preserveExisting, noStart)
 				return writeInitJSONOrExit(code, jsonOut, args, nameFlag, "", "", nil, bootstrapProfileFlag, mode, stdout)
 			}
-			wiz, flagMode, err := initWizardConfigFromFlags(runCmd, providerFlag, defaultProviderFlag, providersFlag, templateFlag, bootstrapProfileFlag)
+			hosted := resolveHostedDoltInitOptions(hostedDoltInitFlagValues{
+				Host:      doltHostFlag,
+				Port:      doltPortFlag,
+				User:      doltUserFlag,
+				Database:  doltDatabaseFlag,
+				ProjectID: doltProjectIDFlag,
+			}, os.Getenv)
+			wiz, flagMode, err := initWizardConfigFromFlags(runCmd, providerFlag, defaultProviderFlag, providersFlag, templateFlag, bootstrapProfileFlag, hosted)
 			if err != nil {
 				fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 				return err
@@ -386,6 +402,11 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 	cmd.Flags().StringArrayVar(&providersFlag, "providers", nil, "readiness-aware providers to write to city.toml (repeatable or comma-separated)")
 	cmd.Flags().StringVar(&templateFlag, "template", "", "non-interactive template to write: minimal, gastown, gascity, or custom")
 	cmd.Flags().StringVar(&bootstrapProfileFlag, "bootstrap-profile", "", "bootstrap profile to apply for hosted/container defaults")
+	cmd.Flags().StringVar(&doltHostFlag, "dolt-host", "", "external/hosted Dolt host for the city beads ledger (or "+envDoltHost+"); pins the city to an external endpoint instead of bootstrapping a managed-local Dolt")
+	cmd.Flags().StringVar(&doltPortFlag, "dolt-port", "", "external/hosted Dolt port (or "+envDoltPort+"); required with --dolt-host")
+	cmd.Flags().StringVar(&doltUserFlag, "dolt-user", "", "external/hosted Dolt user (or "+envDoltUser+"); optional")
+	cmd.Flags().StringVar(&doltDatabaseFlag, "dolt-database", "", "hosted beads project database, e.g. bd_prj_… (or "+envDoltDatabase+"); required with --dolt-host")
+	cmd.Flags().StringVar(&doltProjectIDFlag, "dolt-project-id", "", "authoritative beads project_id for the identity handshake (or "+envBeadsProjectID+"); derived from a bd_<id> --dolt-database when omitted")
 	cmd.Flags().BoolVar(&skipProviderReadiness, "skip-provider-readiness", false, "skip provider login/readiness checks during init and continue startup")
 	cmd.Flags().BoolVar(&noStart, "no-start", false, "initialize files and imports without registering or starting the city")
 	cmd.Flags().BoolVar(&preserveExisting, "preserve-existing", false, "keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them")
@@ -402,6 +423,10 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 	cmd.MarkFlagsMutuallyExclusive("template", "from")
 	cmd.MarkFlagsMutuallyExclusive("bootstrap-profile", "file")
 	cmd.MarkFlagsMutuallyExclusive("bootstrap-profile", "from")
+	for _, doltFlag := range []string{"dolt-host", "dolt-port", "dolt-user", "dolt-database", "dolt-project-id"} {
+		cmd.MarkFlagsMutuallyExclusive(doltFlag, "file")
+		cmd.MarkFlagsMutuallyExclusive(doltFlag, "from")
+	}
 	_ = cmd.Flags().MarkHidden("provider")
 	return cmd
 }
@@ -570,15 +595,18 @@ func initWizardConfig(providerFlag, bootstrapProfileFlag string) (wizardConfig, 
 	}, nil
 }
 
-func initWizardConfigFromFlags(cmd *cobra.Command, providerFlag, defaultProviderFlag string, providersFlag []string, templateFlag, bootstrapProfileFlag string) (wizardConfig, string, error) {
+func initWizardConfigFromFlags(cmd *cobra.Command, providerFlag, defaultProviderFlag string, providersFlag []string, templateFlag, bootstrapProfileFlag string, hosted hostedDoltInitOptions) (wizardConfig, string, error) {
 	legacyChanged := cmd.Flags().Changed("provider")
 	defaultChanged := cmd.Flags().Changed("default-provider")
 	providersChanged := cmd.Flags().Changed("providers")
 	templateChanged := cmd.Flags().Changed("template")
 	bootstrapChanged := strings.TrimSpace(bootstrapProfileFlag) != ""
 
-	if !legacyChanged && !defaultChanged && !providersChanged && !templateChanged && !bootstrapChanged {
+	if !legacyChanged && !defaultChanged && !providersChanged && !templateChanged && !bootstrapChanged && !hosted.enabled() {
 		return wizardConfig{}, "", nil
+	}
+	if err := hosted.validate(); err != nil {
+		return wizardConfig{}, "", err
 	}
 	if legacyChanged && defaultChanged {
 		return wizardConfig{}, "", fmt.Errorf("--provider is deprecated; use --default-provider, not both")
@@ -633,6 +661,7 @@ func initWizardConfigFromFlags(cmd *cobra.Command, providerFlag, defaultProvider
 		providers:        providers,
 		provider:         defaultProvider,
 		bootstrapProfile: bootstrapProfile,
+		hostedDolt:       hosted,
 	}, mode, nil
 }
 
@@ -1313,6 +1342,12 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		cfg = config.DefaultCity(cityName)
 	}
 	applyBootstrapProfile(&cfg, wiz.bootstrapProfile)
+	if wiz.hostedDolt.enabled() {
+		if err := wiz.hostedDolt.applyToCityConfig(&cfg); err != nil {
+			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+	}
 	cityPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
 
 	// Write prompt files only for the agents declared by the init template.
@@ -1371,6 +1406,21 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	if err := persistInitWorkspaceIdentity(fs, cityPath, tomlPath, &cityCfg, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+
+	// When a hosted/external Dolt endpoint was supplied, write the full
+	// canonical external config now (R2/R3/R4/R5) so the unconditional
+	// initDirIfReady that follows resolves the city as external and skips the
+	// managed-local Dolt bootstrap. Requires a bd-backed beads provider.
+	if wiz.hostedDolt.enabled() {
+		if !cityUsesBdStoreContract(cityPath) {
+			fmt.Fprintln(stderr, "gc init: --dolt-host requires a bd-backed beads provider (use the gascity or gastown template)") //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if err := applyInitHostedDoltCanonicalConfig(fs, cityPath, cityPrefix, wiz.hostedDolt); err != nil {
+			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	// Write .gitignore entries for city-managed directories.

--- a/cmd/gc/init_hosted_dolt.go
+++ b/cmd/gc/init_hosted_dolt.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// Environment fallbacks for the hosted-dolt init flags. These mirror the
+// variables the create-city controller already exports, so a controller
+// entrypoint can reduce to "set env -> gc init -> gc start" without passing
+// flags explicitly.
+const (
+	envDoltHost       = "GC_DOLT_HOST"
+	envDoltPort       = "GC_DOLT_PORT"
+	envDoltUser       = "GC_DOLT_USER"
+	envDoltDatabase   = "GC_DOLT_DATABASE"
+	envBeadsProjectID = "GC_BEADS_PROJECT_ID"
+)
+
+// hostedDoltInitFlagValues is the raw --dolt-* flag input captured by the
+// init command, before environment fallback is applied.
+type hostedDoltInitFlagValues struct {
+	Host      string
+	Port      string
+	User      string
+	Database  string
+	ProjectID string
+}
+
+// hostedDoltInitOptions is the resolved external/hosted Dolt endpoint that
+// `gc init` pins for a city's beads ledger. When enabled, init writes the
+// canonical external endpoint config (gc.endpoint_origin=city_canonical,
+// gc.endpoint_status=unverified) plus the project identity, and the existing
+// lifecycle machinery skips the managed-local Dolt bootstrap.
+type hostedDoltInitOptions struct {
+	Host      string
+	Port      string
+	User      string
+	Database  string
+	ProjectID string
+}
+
+// resolveHostedDoltInitOptions merges explicit flag values with environment
+// fallbacks — flags win, env fills the gaps. When no project id is supplied
+// it is derived from a "bd_"-prefixed database name (the create-city
+// provisioner builds dolt_database as "bd_"+project_id, so the suffix is the
+// authoritative id by construction). getenv is injected for testability;
+// production callers pass os.Getenv.
+func resolveHostedDoltInitOptions(flags hostedDoltInitFlagValues, getenv func(string) string) hostedDoltInitOptions {
+	pick := func(flag, env string) string {
+		if v := strings.TrimSpace(flag); v != "" {
+			return v
+		}
+		return strings.TrimSpace(getenv(env))
+	}
+	opts := hostedDoltInitOptions{
+		Host:      pick(flags.Host, envDoltHost),
+		Port:      pick(flags.Port, envDoltPort),
+		User:      pick(flags.User, envDoltUser),
+		Database:  pick(flags.Database, envDoltDatabase),
+		ProjectID: pick(flags.ProjectID, envBeadsProjectID),
+	}
+	if opts.ProjectID == "" {
+		opts.ProjectID = deriveProjectIDFromDoltDatabase(opts.Database)
+	}
+	return opts
+}
+
+// deriveProjectIDFromDoltDatabase returns the beads project id encoded in a
+// "bd_"-prefixed managed database name, or "" when the name is not in that
+// form.
+func deriveProjectIDFromDoltDatabase(database string) string {
+	database = strings.TrimSpace(database)
+	if rest, ok := strings.CutPrefix(database, "bd_"); ok {
+		return strings.TrimSpace(rest)
+	}
+	return ""
+}
+
+// enabled reports whether a hosted/external Dolt endpoint was requested.
+func (o hostedDoltInitOptions) enabled() bool {
+	return strings.TrimSpace(o.Host) != ""
+}
+
+// validate enforces the hosted-dolt init contract. It performs no live
+// connection (R5): a hosted endpoint is recorded as unverified and verified
+// later by gc start, so init never requires credentials.
+func (o hostedDoltInitOptions) validate() error {
+	if !o.enabled() {
+		if strings.TrimSpace(o.Port) != "" || strings.TrimSpace(o.User) != "" ||
+			strings.TrimSpace(o.Database) != "" || strings.TrimSpace(o.ProjectID) != "" {
+			return fmt.Errorf("--dolt-host (or %s) is required when any other --dolt-* flag is set", envDoltHost)
+		}
+		return nil
+	}
+	if err := validateExplicitExternalHost(o.Host); err != nil {
+		return err
+	}
+	port := strings.TrimSpace(o.Port)
+	if port == "" {
+		return fmt.Errorf("--dolt-port (or %s) is required with --dolt-host", envDoltPort)
+	}
+	if value, err := strconv.Atoi(port); err != nil || value <= 0 {
+		return fmt.Errorf("invalid --dolt-port %q", port)
+	}
+	if strings.TrimSpace(o.Database) == "" {
+		return fmt.Errorf("--dolt-database (or %s) is required with --dolt-host", envDoltDatabase)
+	}
+	if isReservedManagedDoltDatabase(o.Database) {
+		return fmt.Errorf("invalid --dolt-database %q: reserved internally by managed Dolt; choose the provisioner-created project database", o.Database)
+	}
+	if strings.TrimSpace(o.ProjectID) == "" {
+		return fmt.Errorf("--dolt-project-id (or %s) is required with --dolt-host: the beads project_id is needed for the identity handshake (or pass a bd_<id> --dolt-database to derive it)", envBeadsProjectID)
+	}
+	return nil
+}
+
+// applyToCityConfig pins the external Dolt host/port into the in-memory city
+// config so doInit serializes a [dolt] section into city.toml. This is what
+// makes the lifecycle ownership probe (resolveConfiguredCityDoltTarget) and
+// the runtime resolve the city as external rather than managed-local.
+func (o hostedDoltInitOptions) applyToCityConfig(cfg *config.City) error {
+	port, err := strconv.Atoi(strings.TrimSpace(o.Port))
+	if err != nil {
+		return fmt.Errorf("invalid --dolt-port %q: %w", o.Port, err)
+	}
+	cfg.Dolt.Host = strings.TrimSpace(o.Host)
+	cfg.Dolt.Port = port
+	return nil
+}
+
+// configState builds the canonical .beads/config.yaml endpoint state for the
+// hosted endpoint: an external city-canonical endpoint recorded as
+// unverified. gc start performs the live verification once credentials are
+// wired.
+func (o hostedDoltInitOptions) configState(issuePrefix string) contract.ConfigState {
+	return contract.ConfigState{
+		IssuePrefix:    issuePrefix,
+		EndpointOrigin: contract.EndpointOriginCityCanonical,
+		EndpointStatus: contract.EndpointStatusUnverified,
+		DoltHost:       strings.TrimSpace(o.Host),
+		DoltPort:       strings.TrimSpace(o.Port),
+		DoltUser:       strings.TrimSpace(o.User),
+	}
+}
+
+// cityExternalDoltEndpointUnverified reports whether the city's canonical
+// endpoint config pins an external (city_canonical) Dolt endpoint that has not
+// yet been verified. init-time bd init against such an endpoint must be
+// deferred to gc start, which carries the credential command — init itself
+// never requires a live connection (R5).
+func cityExternalDoltEndpointUnverified(cityPath string) bool {
+	state, ok, err := contract.ReadConfigState(fsys.OSFS{}, filepath.Join(cityPath, ".beads", "config.yaml"))
+	if err != nil || !ok {
+		return false
+	}
+	return state.EndpointOrigin == contract.EndpointOriginCityCanonical &&
+		state.EndpointStatus == contract.EndpointStatusUnverified
+}
+
+// applyInitHostedDoltCanonicalConfig writes the full canonical external
+// endpoint config for a freshly scaffolded city (R3/R4/R5), identical in
+// shape to what `gc beads city use-external --adopt-unverified` produces plus
+// the pinned dolt_database and project identity:
+//
+//   - .beads/identity.toml  — the authoritative project_id (L1 identity)
+//   - .beads/config.yaml     — city_canonical + unverified + dolt host/port/user
+//   - .beads/metadata.json   — backend=dolt, dolt_mode=server, dolt_database,
+//     and project_id (stamped from identity.toml)
+//
+// It writes the identity first so the canonical metadata write picks up
+// project_id. No live connection is attempted.
+func applyInitHostedDoltCanonicalConfig(fs fsys.FS, cityPath, issuePrefix string, opts hostedDoltInitOptions) error {
+	if !opts.enabled() {
+		return nil
+	}
+	if err := opts.validate(); err != nil {
+		return err
+	}
+	if err := contract.WriteProjectIdentity(fs, cityPath, strings.TrimSpace(opts.ProjectID)); err != nil {
+		return fmt.Errorf("writing project identity: %w", err)
+	}
+	if err := ensureCanonicalScopeConfigState(fs, cityPath, opts.configState(issuePrefix)); err != nil {
+		return fmt.Errorf("writing canonical endpoint config: %w", err)
+	}
+	if err := enforceCanonicalScopeMetadataForInit(fs, cityPath, strings.TrimSpace(opts.Database)); err != nil {
+		return fmt.Errorf("writing canonical metadata: %w", err)
+	}
+	return nil
+}

--- a/cmd/gc/init_hosted_dolt.go
+++ b/cmd/gc/init_hosted_dolt.go
@@ -169,10 +169,11 @@ func cityExternalDoltEndpointUnverified(cityPath string) bool {
 // shape to what `gc beads city use-external --adopt-unverified` produces plus
 // the pinned dolt_database and project identity:
 //
-//   - .beads/identity.toml  — the authoritative project_id (L1 identity)
+//   - the L1 project identity (contract.ProjectIdentityPath) — the
+//     authoritative project_id, written via contract.WriteProjectIdentity
 //   - .beads/config.yaml     — city_canonical + unverified + dolt host/port/user
 //   - .beads/metadata.json   — backend=dolt, dolt_mode=server, dolt_database,
-//     and project_id (stamped from identity.toml)
+//     and project_id (stamped from the L1 identity)
 //
 // It writes the identity first so the canonical metadata write picks up
 // project_id. No live connection is attempted.

--- a/cmd/gc/init_hosted_dolt.go
+++ b/cmd/gc/init_hosted_dolt.go
@@ -13,8 +13,11 @@ import (
 
 // Environment fallbacks for the hosted-dolt init flags. These mirror the
 // variables the create-city controller already exports, so a controller
-// entrypoint can reduce to "set env -> gc init -> gc start" without passing
-// flags explicitly.
+// entrypoint can supply the external Dolt endpoint through the environment as
+// "set env -> gc init -> gc start" without passing the --dolt-* flags
+// explicitly. The env vars only fill the --dolt-* endpoint inputs; the
+// controller still selects the city template and provider, because a
+// non-interactive bd-backed `gc init` requires --template/--default-provider.
 const (
 	envDoltHost       = "GC_DOLT_HOST"
 	envDoltPort       = "GC_DOLT_PORT"
@@ -162,6 +165,30 @@ func cityExternalDoltEndpointUnverified(cityPath string) bool {
 	}
 	return state.EndpointOrigin == contract.EndpointOriginCityCanonical &&
 		state.EndpointStatus == contract.EndpointStatusUnverified
+}
+
+// hostedDoltBackendError reports why a city's effective beads backend cannot
+// host the external Dolt *server* endpoint pinned by --dolt-host, or nil when
+// the backend is compatible. The effective provider and backend are resolved
+// from the same env/city.toml inputs the runtime uses, so this init-time guard
+// agrees with how the city will actually resolve its ledger:
+//
+//   - a non-bd (file) store cannot carry the bd Dolt-server contract; and
+//   - the doltlite backend is a local embedded store, not an external server,
+//     so pinning --dolt-host would write backend=dolt server metadata that
+//     permanently disagrees with the configured doltlite backend (split-brain)
+//     and skip the external-endpoint init defer.
+//
+// Both incompatibilities must be rejected before any canonical hosted-Dolt
+// files are written so a rejected init leaves no mixed ledger state behind.
+func hostedDoltBackendError(cityPath string) error {
+	if !cityUsesBdStoreContract(cityPath) {
+		return fmt.Errorf("--dolt-host requires a bd-backed beads provider (use the gascity or gastown template)")
+	}
+	if cityUsesDoltliteBeadsBackend(cityPath) {
+		return fmt.Errorf("--dolt-host configures an external Dolt server and is incompatible with the doltlite beads backend; unset the doltlite backend (GC_BEADS_BACKEND or [beads] backend) to use the dolt (server) backend")
+	}
+	return nil
 }
 
 // applyInitHostedDoltCanonicalConfig writes the full canonical external

--- a/cmd/gc/init_hosted_dolt_test.go
+++ b/cmd/gc/init_hosted_dolt_test.go
@@ -340,12 +340,15 @@ func TestInitDirIfReadyInitsVerifiedExternalDolt(t *testing.T) {
 	}
 }
 
-// The controller contract is "set env -> gc init -> gc start": the hosted
-// endpoint can be supplied entirely through GC_DOLT_*/GC_BEADS_PROJECT_ID.
-// This exercises that path end to end through finalizeInit with no provider
-// readiness and confirms init exits 0 without any managed-local bootstrap or
-// live connection (AC1/AC3/R5), recording the env-derived endpoint.
-func TestGcInitHostedDoltEnvOnlyEndToEnd(t *testing.T) {
+// Command-level regression: the hosted endpoint can be supplied entirely
+// through GC_DOLT_*/GC_BEADS_PROJECT_ID, mirroring the --dolt-* flags so the
+// create-city controller need not pass them explicitly. The controller still
+// selects the city template/provider, so this drives the real
+// newInitCmd(...).Execute() path with the hosted env vars set (no --dolt-*
+// flags) and --template/--default-provider supplied, and confirms init exits 0
+// recording the env-derived endpoint without a managed-local bootstrap or live
+// connection (R5): verification is deferred to gc start.
+func TestGcInitCommandHostedDoltEnvOnlyEndpoint(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
 	t.Setenv("GC_SESSION", "fake")
@@ -359,35 +362,21 @@ func TestGcInitHostedDoltEnvOnlyEndToEnd(t *testing.T) {
 
 	stubInitDependencyChecks(t)
 	stubInitDoltAuthorIdentity(t, map[string]string{"user.name": "ci", "user.email": "ci@example.com"})
-	origRegister := registerCityWithSupervisorTestHook
-	registerCityWithSupervisorTestHook = func(_, _ string, _, _ io.Writer) (bool, int) { return true, 0 }
-	t.Cleanup(func() { registerCityWithSupervisorTestHook = origRegister })
-
-	// Resolve the hosted endpoint from the environment exactly as the init
-	// command's RunE does (no --dolt-* flags supplied).
-	hosted := resolveHostedDoltInitOptions(hostedDoltInitFlagValues{}, os.Getenv)
-	if !hosted.enabled() || hosted.Database != "bd_prj_envonly" || hosted.ProjectID != "prj_envonly" {
-		t.Fatalf("env resolution = %+v", hosted)
-	}
-	wiz := wizardConfig{
-		configName:      "gascity",
-		defaultProvider: "claude",
-		provider:        "claude",
-		providers:       []string{"claude"},
-		hostedDolt:      hosted,
-	}
 
 	cityPath := filepath.Join(t.TempDir(), "env-city")
 	var stdout, stderr bytes.Buffer
-	if code := doInit(fsys.OSFS{}, cityPath, wiz, "env-city", &stdout, &stderr, false); code != 0 {
-		t.Fatalf("doInit = %d, want 0; stderr=%s", code, stderr.String())
-	}
-	code := finalizeInit(cityPath, &stdout, &stderr, initFinalizeOptions{
-		commandName:           "gc init",
-		skipProviderReadiness: true,
+	cmd := newInitCmd(&stdout, &stderr)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{
+		"--template", "gascity",
+		"--default-provider", "claude",
+		"--skip-provider-readiness",
+		"--no-start",
+		cityPath,
 	})
-	if code != 0 {
-		t.Fatalf("finalizeInit = %d, want 0; stderr=%s", code, stderr.String())
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc init env-only hosted dolt = %v, want success; stderr=%s", err, stderr.String())
 	}
 
 	if !isExternalDolt(cityPath) {
@@ -402,6 +391,37 @@ func TestGcInitHostedDoltEnvOnlyEndToEnd(t *testing.T) {
 			t.Fatalf("metadata.json missing env-derived %q:\n%s", want, metaRaw)
 		}
 	}
+}
+
+// Command-level regression for the controller contract boundary: env-only
+// hosted-Dolt input does NOT make `gc init` flagless — the controller must
+// still pass --template/--default-provider. With the hosted endpoint supplied
+// through the environment and no provider flags, the real
+// newInitCmd(...).Execute() path rejects the invocation at the existing
+// provider requirement (the default gascity template needs a provider) rather
+// than silently dropping the hosted endpoint into an interactive wizard, and
+// writes no ledger artifacts.
+func TestGcInitCommandHostedDoltEnvOnlyRequiresProvider(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "")
+	t.Setenv(envDoltHost, "gateway.example.com")
+	t.Setenv(envDoltPort, "4406")
+	t.Setenv(envDoltDatabase, "bd_prj_x")
+	t.Setenv(envBeadsProjectID, "prj_x")
+
+	cityPath := filepath.Join(t.TempDir(), "env-noprov-city")
+	var stdout, stderr bytes.Buffer
+	cmd := newInitCmd(&stdout, &stderr)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"--skip-provider-readiness", "--no-start", cityPath})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("gc init env-only hosted dolt without --default-provider = nil error, want failure; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "default-provider") {
+		t.Fatalf("stderr = %q, want a --default-provider requirement", stderr.String())
+	}
+	assertNoHostedDoltStoreArtifacts(t, cityPath)
 }
 
 // A hosted endpoint only makes sense for a bd-backed ledger; supplying
@@ -423,5 +443,121 @@ func TestDoInitHostedDoltRequiresBdBackedProvider(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "bd-backed") {
 		t.Fatalf("stderr = %q, want a bd-backed-provider error", stderr.String())
+	}
+	assertNoHostedDoltStoreArtifacts(t, cityPath)
+}
+
+// The doltlite backend is bd-backed (so the provider guard passes) but is a
+// local embedded store, not an external Dolt server. Pinning --dolt-host for a
+// doltlite city would write backend=dolt server metadata that permanently
+// disagrees with the configured doltlite backend (split-brain) and skip the
+// external-endpoint defer, so init must reject it before writing any canonical
+// hosted-Dolt files. The backend is supplied through GC_BEADS_BACKEND, the
+// documented "set env -> gc init -> gc start" controller path.
+func TestDoInitHostedDoltRejectsDoltliteBackend(t *testing.T) {
+	t.Setenv("GC_BEADS_BACKEND", "doltlite")
+	t.Setenv("GC_DOLT", "")
+	cityPath := filepath.Join(t.TempDir(), "doltlite-city")
+	wiz := wizardConfig{
+		configName:      "gascity",
+		defaultProvider: "claude",
+		provider:        "claude",
+		providers:       []string{"claude"},
+		hostedDolt:      hostedDoltInitOptions{Host: "gateway.example.com", Port: "4406", Database: "bd_prj_x", ProjectID: "prj_x"},
+	}
+	var stdout, stderr bytes.Buffer
+	if code := doInit(fsys.OSFS{}, cityPath, wiz, "doltlite-city", &stdout, &stderr, false); code == 0 {
+		t.Fatalf("doInit = 0, want failure for hosted dolt on a doltlite city; stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "doltlite") {
+		t.Fatalf("stderr = %q, want a doltlite-incompatibility error", stderr.String())
+	}
+	assertNoHostedDoltStoreArtifacts(t, cityPath)
+}
+
+// Command-level regression: the real `gc init` RunE resolves --dolt-* flags,
+// reads GC_BEADS_BACKEND, builds the wizard config, and runs doInit. A doltlite
+// effective backend must fail the command and leave no canonical/mixed ledger
+// artifacts behind.
+func TestGcInitCommandHostedDoltRejectsDoltliteBackend(t *testing.T) {
+	t.Setenv("GC_BEADS_BACKEND", "doltlite")
+	t.Setenv("GC_DOLT", "")
+	cityPath := filepath.Join(t.TempDir(), "doltlite-cmd-city")
+	var stdout, stderr bytes.Buffer
+	cmd := newInitCmd(&stdout, &stderr)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{
+		"--template", "gascity",
+		"--default-provider", "claude",
+		"--skip-provider-readiness",
+		"--no-start",
+		"--dolt-host", "gateway.example.com",
+		"--dolt-port", "4406",
+		"--dolt-database", "bd_prj_x",
+		"--dolt-project-id", "prj_x",
+		cityPath,
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("gc init --dolt-host with doltlite backend = nil error, want failure; stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "doltlite") {
+		t.Fatalf("stderr = %q, want a doltlite-incompatibility error", stderr.String())
+	}
+	assertNoHostedDoltStoreArtifacts(t, cityPath)
+}
+
+// Command-level regression: a non-bd (file) effective backend must fail the
+// real `gc init` command with a clear bd-backed-provider error and leave no
+// canonical/mixed ledger artifacts behind. This is the full-RunE sibling of
+// TestGcInitCommandHostedDoltRejectsDoltliteBackend, closing the RunE
+// flag/env-wiring coverage gap for the file case.
+func TestGcInitCommandHostedDoltRejectsFileBackend(t *testing.T) {
+	t.Setenv("GC_BEADS", "file") // force a non-bd backend
+	t.Setenv("GC_DOLT", "")
+	cityPath := filepath.Join(t.TempDir(), "file-cmd-city")
+	var stdout, stderr bytes.Buffer
+	cmd := newInitCmd(&stdout, &stderr)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{
+		"--template", "gascity",
+		"--default-provider", "claude",
+		"--skip-provider-readiness",
+		"--no-start",
+		"--dolt-host", "gateway.example.com",
+		"--dolt-port", "4406",
+		"--dolt-database", "bd_prj_x",
+		"--dolt-project-id", "prj_x",
+		cityPath,
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("gc init --dolt-host with file backend = nil error, want failure; stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "bd-backed") {
+		t.Fatalf("stderr = %q, want a bd-backed-provider error", stderr.String())
+	}
+	assertNoHostedDoltStoreArtifacts(t, cityPath)
+}
+
+// assertNoHostedDoltStoreArtifacts fails when a rejected hosted-Dolt init left
+// any canonical Dolt ledger files or file-store markers on disk — the contract
+// is that an incompatible-backend rejection writes no ledger state, so reruns
+// after fixing the backend are not poisoned by a split-brain scaffold.
+func assertNoHostedDoltStoreArtifacts(t *testing.T, cityPath string) {
+	t.Helper()
+	for _, rel := range []string{
+		filepath.Join(".beads", "config.yaml"),
+		filepath.Join(".beads", "metadata.json"),
+		filepath.Join(".beads", "identity.toml"),
+		filepath.Join(".gc", "beads.json"),
+		filepath.Join(".gc", "file-beads-layout"),
+	} {
+		switch _, err := os.Stat(filepath.Join(cityPath, rel)); {
+		case err == nil:
+			t.Fatalf("rejected hosted-dolt init left a store artifact: %s", rel)
+		case !os.IsNotExist(err):
+			t.Fatalf("stat %s: %v", rel, err)
+		}
 	}
 }

--- a/cmd/gc/init_hosted_dolt_test.go
+++ b/cmd/gc/init_hosted_dolt_test.go
@@ -1,0 +1,427 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func initHostedCity(t *testing.T) (cityPath, prefix string) {
+	t.Helper()
+	t.Setenv("GC_DOLT", "") // exercise the external defer branch, not gcDoltSkip
+	cityPath = filepath.Join(t.TempDir(), "hosted-city")
+	wiz := wizardConfig{
+		configName:      "gascity",
+		defaultProvider: "claude",
+		provider:        "claude",
+		providers:       []string{"claude"},
+		hostedDolt: hostedDoltInitOptions{
+			Host:      "gateway.example.com",
+			Port:      "4406",
+			User:      "eia",
+			Database:  "bd_prj_abc",
+			ProjectID: "prj_abc",
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	if code := doInit(fsys.OSFS{}, cityPath, wiz, "hosted-city", &stdout, &stderr, false); code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("load city config: %v", err)
+	}
+	return cityPath, config.EffectiveHQPrefix(cfg)
+}
+
+func envGetterFromMap(m map[string]string) func(string) string {
+	return func(key string) string { return m[key] }
+}
+
+func TestResolveHostedDoltInitOptionsFlagsWinOverEnv(t *testing.T) {
+	flags := hostedDoltInitFlagValues{
+		Host:      "gateway.example.com",
+		Port:      "4406",
+		User:      "flaguser",
+		Database:  "bd_prj_flag",
+		ProjectID: "prj_flag",
+	}
+	env := map[string]string{
+		envDoltHost:       "env.example.com",
+		envDoltPort:       "9999",
+		envDoltUser:       "envuser",
+		envDoltDatabase:   "bd_prj_env",
+		envBeadsProjectID: "prj_env",
+	}
+	got := resolveHostedDoltInitOptions(flags, envGetterFromMap(env))
+	want := hostedDoltInitOptions{
+		Host:      "gateway.example.com",
+		Port:      "4406",
+		User:      "flaguser",
+		Database:  "bd_prj_flag",
+		ProjectID: "prj_flag",
+	}
+	if got != want {
+		t.Fatalf("resolveHostedDoltInitOptions flags-win = %+v, want %+v", got, want)
+	}
+}
+
+func TestResolveHostedDoltInitOptionsEnvFallback(t *testing.T) {
+	env := map[string]string{
+		envDoltHost:       "env.example.com",
+		envDoltPort:       "4406",
+		envDoltDatabase:   "bd_prj_env",
+		envBeadsProjectID: "prj_env",
+	}
+	got := resolveHostedDoltInitOptions(hostedDoltInitFlagValues{}, envGetterFromMap(env))
+	if got.Host != "env.example.com" || got.Port != "4406" || got.Database != "bd_prj_env" || got.ProjectID != "prj_env" {
+		t.Fatalf("resolveHostedDoltInitOptions env-fallback = %+v", got)
+	}
+}
+
+func TestResolveHostedDoltInitOptionsDerivesProjectIDFromDatabase(t *testing.T) {
+	flags := hostedDoltInitFlagValues{Host: "h", Port: "4406", Database: "bd_prj_abc123"}
+	got := resolveHostedDoltInitOptions(flags, envGetterFromMap(nil))
+	if got.ProjectID != "prj_abc123" {
+		t.Fatalf("derived ProjectID = %q, want prj_abc123", got.ProjectID)
+	}
+}
+
+func TestResolveHostedDoltInitOptionsDoesNotDeriveWhenExplicit(t *testing.T) {
+	flags := hostedDoltInitFlagValues{Host: "h", Port: "4406", Database: "bd_prj_abc", ProjectID: "prj_explicit"}
+	got := resolveHostedDoltInitOptions(flags, envGetterFromMap(nil))
+	if got.ProjectID != "prj_explicit" {
+		t.Fatalf("explicit ProjectID overwritten = %q", got.ProjectID)
+	}
+}
+
+func TestResolveHostedDoltInitOptionsDoesNotDeriveWithoutBdPrefix(t *testing.T) {
+	flags := hostedDoltInitFlagValues{Host: "h", Port: "4406", Database: "weird_name"}
+	got := resolveHostedDoltInitOptions(flags, envGetterFromMap(nil))
+	if got.ProjectID != "" {
+		t.Fatalf("ProjectID should not be derived from non-bd_ database, got %q", got.ProjectID)
+	}
+}
+
+func TestHostedDoltInitOptionsEnabled(t *testing.T) {
+	if (hostedDoltInitOptions{}).enabled() {
+		t.Fatal("empty options should not be enabled")
+	}
+	if !(hostedDoltInitOptions{Host: "h"}).enabled() {
+		t.Fatal("options with host should be enabled")
+	}
+	if (hostedDoltInitOptions{Host: "   "}).enabled() {
+		t.Fatal("whitespace-only host should not be enabled")
+	}
+}
+
+func TestHostedDoltInitOptionsValidate(t *testing.T) {
+	base := hostedDoltInitOptions{Host: "gateway.example.com", Port: "4406", Database: "bd_prj_x", ProjectID: "prj_x"}
+	tests := []struct {
+		name    string
+		mutate  func(o hostedDoltInitOptions) hostedDoltInitOptions
+		wantErr string // substring; "" means no error
+	}{
+		{"valid", func(o hostedDoltInitOptions) hostedDoltInitOptions { return o }, ""},
+		{"not-enabled-empty", func(_ hostedDoltInitOptions) hostedDoltInitOptions { return hostedDoltInitOptions{} }, ""},
+		{"port-without-host", func(_ hostedDoltInitOptions) hostedDoltInitOptions {
+			return hostedDoltInitOptions{Port: "4406"}
+		}, "--dolt-host"},
+		{"missing-port", func(o hostedDoltInitOptions) hostedDoltInitOptions { o.Port = ""; return o }, "--dolt-port"},
+		{"bad-port", func(o hostedDoltInitOptions) hostedDoltInitOptions { o.Port = "abc"; return o }, "invalid --dolt-port"},
+		{"zero-port", func(o hostedDoltInitOptions) hostedDoltInitOptions { o.Port = "0"; return o }, "invalid --dolt-port"},
+		{"missing-database", func(o hostedDoltInitOptions) hostedDoltInitOptions { o.Database = ""; return o }, "--dolt-database"},
+		{"reserved-database", func(o hostedDoltInitOptions) hostedDoltInitOptions { o.Database = "mysql"; return o }, "reserved"},
+		{"missing-project-id", func(o hostedDoltInitOptions) hostedDoltInitOptions {
+			o.ProjectID = ""
+			o.Database = "weird" // non-bd_ so no derivation; but reserved check... "weird" is fine
+			return o
+		}, "--dolt-project-id"},
+		{"wildcard-host", func(o hostedDoltInitOptions) hostedDoltInitOptions { o.Host = "0.0.0.0"; return o }, "concrete host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.mutate(base).validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validate() = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestInitWizardConfigFromFlagsCapturesHostedDolt(t *testing.T) {
+	cmd := newInitCmd(io.Discard, io.Discard)
+	if err := cmd.Flags().Set("template", "custom"); err != nil {
+		t.Fatalf("set template: %v", err)
+	}
+	hosted := hostedDoltInitOptions{Host: "gateway.example.com", Port: "4406", Database: "bd_prj_x", ProjectID: "prj_x"}
+	wiz, _, err := initWizardConfigFromFlags(cmd, "", "", nil, "custom", "", hosted)
+	if err != nil {
+		t.Fatalf("initWizardConfigFromFlags: %v", err)
+	}
+	if !wiz.hostedDolt.enabled() {
+		t.Fatal("expected wiz.hostedDolt to be enabled")
+	}
+	if wiz.hostedDolt.ProjectID != "prj_x" || wiz.hostedDolt.Database != "bd_prj_x" {
+		t.Fatalf("wiz.hostedDolt = %+v", wiz.hostedDolt)
+	}
+}
+
+func TestInitWizardConfigFromFlagsRejectsInvalidHostedDolt(t *testing.T) {
+	cmd := newInitCmd(io.Discard, io.Discard)
+	if err := cmd.Flags().Set("template", "custom"); err != nil {
+		t.Fatalf("set template: %v", err)
+	}
+	hosted := hostedDoltInitOptions{Host: "gateway.example.com"} // missing port/database/project-id
+	_, _, err := initWizardConfigFromFlags(cmd, "", "", nil, "custom", "", hosted)
+	if err == nil || !strings.Contains(err.Error(), "--dolt-port") {
+		t.Fatalf("initWizardConfigFromFlags = %v, want --dolt-port error", err)
+	}
+}
+
+// Hosted-dolt alone must defeat the early "no flags changed" return so the
+// non-interactive path runs; with the default (gascity) template that then
+// surfaces the existing provider requirement rather than silently dropping
+// the hosted endpoint into an interactive wizard.
+func TestInitWizardConfigFromFlagsHostedDoltDefaultTemplateRequiresProvider(t *testing.T) {
+	cmd := newInitCmd(io.Discard, io.Discard)
+	hosted := hostedDoltInitOptions{Host: "gateway.example.com", Port: "4406", Database: "bd_prj_x", ProjectID: "prj_x"}
+	_, _, err := initWizardConfigFromFlags(cmd, "", "", nil, "", "", hosted)
+	if err == nil || !strings.Contains(err.Error(), "default-provider") {
+		t.Fatalf("initWizardConfigFromFlags = %v, want default-provider requirement", err)
+	}
+}
+
+// doInit with a hosted endpoint writes the full canonical external config
+// (R2/R3/R4/R5): city.toml [dolt], .beads/config.yaml (city_canonical +
+// unverified), .beads/metadata.json (backend=dolt, dolt_mode=server,
+// dolt_database, project_id), and .beads/identity.toml — and the lifecycle
+// machinery then resolves the city as external (no managed-local bootstrap).
+func TestDoInitWritesCanonicalHostedDoltConfig(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "hosted-city")
+	wiz := wizardConfig{
+		configName:      "gascity",
+		defaultProvider: "claude",
+		provider:        "claude",
+		providers:       []string{"claude"},
+		hostedDolt: hostedDoltInitOptions{
+			Host:      "gateway.example.com",
+			Port:      "4406",
+			User:      "eia",
+			Database:  "bd_prj_abc",
+			ProjectID: "prj_abc",
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	if code := doInit(fsys.OSFS{}, cityPath, wiz, "hosted-city", &stdout, &stderr, false); code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	cityData, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("read city.toml: %v", err)
+	}
+	if !strings.Contains(string(cityData), "gateway.example.com") {
+		t.Fatalf("city.toml missing [dolt] host:\n%s", cityData)
+	}
+
+	state, ok, err := contract.ReadConfigState(fsys.OSFS{}, filepath.Join(cityPath, ".beads", "config.yaml"))
+	if err != nil || !ok {
+		t.Fatalf("ReadConfigState ok=%v err=%v", ok, err)
+	}
+	if state.EndpointOrigin != contract.EndpointOriginCityCanonical {
+		t.Fatalf("EndpointOrigin = %q, want city_canonical", state.EndpointOrigin)
+	}
+	if state.EndpointStatus != contract.EndpointStatusUnverified {
+		t.Fatalf("EndpointStatus = %q, want unverified", state.EndpointStatus)
+	}
+	if state.DoltHost != "gateway.example.com" || state.DoltPort != "4406" {
+		t.Fatalf("config dolt host/port = %q/%q", state.DoltHost, state.DoltPort)
+	}
+
+	metaRaw, err := os.ReadFile(filepath.Join(cityPath, ".beads", "metadata.json"))
+	if err != nil {
+		t.Fatalf("read metadata.json: %v", err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(metaRaw, &meta); err != nil {
+		t.Fatalf("parse metadata.json: %v", err)
+	}
+	for k, want := range map[string]string{"backend": "dolt", "dolt_mode": "server", "dolt_database": "bd_prj_abc", "project_id": "prj_abc"} {
+		if got, _ := meta[k].(string); got != want {
+			t.Fatalf("metadata.json[%q] = %q, want %q (full: %s)", k, got, want, metaRaw)
+		}
+	}
+
+	id, ok, err := contract.ReadProjectIdentity(fsys.OSFS{}, cityPath)
+	if err != nil || !ok || id != "prj_abc" {
+		t.Fatalf("ReadProjectIdentity id=%q ok=%v err=%v", id, ok, err)
+	}
+
+	owned, err := managedDoltLifecycleOwned(cityPath)
+	if err != nil {
+		t.Fatalf("managedDoltLifecycleOwned: %v", err)
+	}
+	if owned {
+		t.Fatal("managedDoltLifecycleOwned = true, want false (external endpoint)")
+	}
+	if !isExternalDolt(cityPath) {
+		t.Fatal("isExternalDolt = false, want true")
+	}
+}
+
+// An unverified external endpoint must not require a live connection at init
+// time (R5): initDirIfReady writes the canonical files and defers the bd init
+// to gc start (which has credentials) instead of running it now.
+func TestInitDirIfReadyDefersUnverifiedExternalDolt(t *testing.T) {
+	cityPath, prefix := initHostedCity(t)
+
+	orig := initDirIfReadyInitAndHookDir
+	t.Cleanup(func() { initDirIfReadyInitAndHookDir = orig })
+	called := false
+	initDirIfReadyInitAndHookDir = func(_, _, _ string) error { called = true; return nil }
+
+	deferred, err := initDirIfReady(cityPath, cityPath, prefix)
+	if err != nil {
+		t.Fatalf("initDirIfReady: %v", err)
+	}
+	if !deferred {
+		t.Fatal("initDirIfReady deferred = false, want true for unverified external")
+	}
+	if called {
+		t.Fatal("initDirIfReadyInitAndHookDir ran; the live bd init must be deferred for an unverified external endpoint")
+	}
+}
+
+// A verified external endpoint keeps the existing behavior: init-and-hook runs
+// now (credentials are presumed available), so this change does not regress
+// `gc rig add` against an already-validated external city.
+func TestInitDirIfReadyInitsVerifiedExternalDolt(t *testing.T) {
+	cityPath, prefix := initHostedCity(t)
+
+	cfgPath := filepath.Join(cityPath, ".beads", "config.yaml")
+	state, ok, err := contract.ReadConfigState(fsys.OSFS{}, cfgPath)
+	if err != nil || !ok {
+		t.Fatalf("ReadConfigState ok=%v err=%v", ok, err)
+	}
+	state.EndpointStatus = contract.EndpointStatusVerified
+	if _, err := contract.EnsureCanonicalConfig(fsys.OSFS{}, cfgPath, state); err != nil {
+		t.Fatalf("EnsureCanonicalConfig verified: %v", err)
+	}
+
+	orig := initDirIfReadyInitAndHookDir
+	t.Cleanup(func() { initDirIfReadyInitAndHookDir = orig })
+	called := false
+	initDirIfReadyInitAndHookDir = func(_, _, _ string) error { called = true; return nil }
+
+	deferred, err := initDirIfReady(cityPath, cityPath, prefix)
+	if err != nil {
+		t.Fatalf("initDirIfReady: %v", err)
+	}
+	if deferred {
+		t.Fatal("initDirIfReady deferred = true for a verified external endpoint; want init-and-hook")
+	}
+	if !called {
+		t.Fatal("initDirIfReadyInitAndHookDir did not run for a verified external endpoint")
+	}
+}
+
+// The controller contract is "set env -> gc init -> gc start": the hosted
+// endpoint can be supplied entirely through GC_DOLT_*/GC_BEADS_PROJECT_ID.
+// This exercises that path end to end through finalizeInit with no provider
+// readiness and confirms init exits 0 without any managed-local bootstrap or
+// live connection (AC1/AC3/R5), recording the env-derived endpoint.
+func TestGcInitHostedDoltEnvOnlyEndToEnd(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "") // not "skip": exercise the external defer branch
+	t.Setenv("GC_BOOTSTRAP", "skip")
+	t.Setenv(envDoltHost, "gateway.example.com")
+	t.Setenv(envDoltPort, "4406")
+	t.Setenv(envDoltDatabase, "bd_prj_envonly")
+	t.Setenv(envBeadsProjectID, "prj_envonly")
+
+	stubInitDependencyChecks(t)
+	stubInitDoltAuthorIdentity(t, map[string]string{"user.name": "ci", "user.email": "ci@example.com"})
+	origRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = func(_, _ string, _, _ io.Writer) (bool, int) { return true, 0 }
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = origRegister })
+
+	// Resolve the hosted endpoint from the environment exactly as the init
+	// command's RunE does (no --dolt-* flags supplied).
+	hosted := resolveHostedDoltInitOptions(hostedDoltInitFlagValues{}, os.Getenv)
+	if !hosted.enabled() || hosted.Database != "bd_prj_envonly" || hosted.ProjectID != "prj_envonly" {
+		t.Fatalf("env resolution = %+v", hosted)
+	}
+	wiz := wizardConfig{
+		configName:      "gascity",
+		defaultProvider: "claude",
+		provider:        "claude",
+		providers:       []string{"claude"},
+		hostedDolt:      hosted,
+	}
+
+	cityPath := filepath.Join(t.TempDir(), "env-city")
+	var stdout, stderr bytes.Buffer
+	if code := doInit(fsys.OSFS{}, cityPath, wiz, "env-city", &stdout, &stderr, false); code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	code := finalizeInit(cityPath, &stdout, &stderr, initFinalizeOptions{
+		commandName:           "gc init",
+		skipProviderReadiness: true,
+	})
+	if code != 0 {
+		t.Fatalf("finalizeInit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if !isExternalDolt(cityPath) {
+		t.Fatal("isExternalDolt = false after env-only hosted init")
+	}
+	metaRaw, err := os.ReadFile(filepath.Join(cityPath, ".beads", "metadata.json"))
+	if err != nil {
+		t.Fatalf("read metadata.json: %v", err)
+	}
+	for _, want := range []string{"bd_prj_envonly", "prj_envonly"} {
+		if !strings.Contains(string(metaRaw), want) {
+			t.Fatalf("metadata.json missing env-derived %q:\n%s", want, metaRaw)
+		}
+	}
+}
+
+// A hosted endpoint only makes sense for a bd-backed ledger; supplying
+// --dolt-host for a non-bd (file) city must fail fast with a clear message.
+func TestDoInitHostedDoltRequiresBdBackedProvider(t *testing.T) {
+	t.Setenv("GC_BEADS", "file") // force a non-bd backend
+	t.Setenv("GC_DOLT", "")
+	cityPath := filepath.Join(t.TempDir(), "file-city")
+	wiz := wizardConfig{
+		configName:      "gascity",
+		defaultProvider: "claude",
+		provider:        "claude",
+		providers:       []string{"claude"},
+		hostedDolt:      hostedDoltInitOptions{Host: "gateway.example.com", Port: "4406", Database: "bd_prj_x", ProjectID: "prj_x"},
+	}
+	var stdout, stderr bytes.Buffer
+	if code := doInit(fsys.OSFS{}, cityPath, wiz, "file-city", &stdout, &stderr, false); code == 0 {
+		t.Fatalf("doInit = 0, want failure for hosted dolt on a non-bd city")
+	}
+	if !strings.Contains(stderr.String(), "bd-backed") {
+		t.Fatalf("stderr = %q, want a bd-backed-provider error", stderr.String())
+	}
+}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3753,7 +3753,7 @@ func TestInitWizardConfigFromFlagsRejectsUnknownTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 	template, _ := cmd.Flags().GetString("template")
-	if _, _, err := initWizardConfigFromFlags(cmd, "", "", nil, template, ""); err == nil {
+	if _, _, err := initWizardConfigFromFlags(cmd, "", "", nil, template, "", hostedDoltInitOptions{}); err == nil {
 		t.Fatal("expected error for unknown template")
 	}
 }
@@ -3802,7 +3802,7 @@ func TestInitWizardConfigFromFlagsDefaultProviderInfersProviders(t *testing.T) {
 		t.Fatal(err)
 	}
 	defaultProvider, _ := cmd.Flags().GetString("default-provider")
-	wiz, mode, err := initWizardConfigFromFlags(cmd, "", defaultProvider, nil, "", "")
+	wiz, mode, err := initWizardConfigFromFlags(cmd, "", defaultProvider, nil, "", "", hostedDoltInitOptions{})
 	if err != nil {
 		t.Fatalf("initWizardConfigFromFlags: %v", err)
 	}
@@ -3827,7 +3827,7 @@ func TestInitWizardConfigFromFlagsProvidersCanonicalOrder(t *testing.T) {
 	}
 	defaultProvider, _ := cmd.Flags().GetString("default-provider")
 	providers, _ := cmd.Flags().GetStringArray("providers")
-	wiz, _, err := initWizardConfigFromFlags(cmd, "", defaultProvider, providers, "", "")
+	wiz, _, err := initWizardConfigFromFlags(cmd, "", defaultProvider, providers, "", "", hostedDoltInitOptions{})
 	if err != nil {
 		t.Fatalf("initWizardConfigFromFlags: %v", err)
 	}
@@ -3842,7 +3842,7 @@ func TestInitWizardConfigFromFlagsProvidersRequireDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 	providers, _ := cmd.Flags().GetStringArray("providers")
-	if _, _, err := initWizardConfigFromFlags(cmd, "", "", providers, "", ""); err == nil {
+	if _, _, err := initWizardConfigFromFlags(cmd, "", "", providers, "", "", hostedDoltInitOptions{}); err == nil {
 		t.Fatal("expected --providers without --default-provider to fail")
 	}
 }
@@ -3853,7 +3853,7 @@ func TestInitWizardConfigFromFlagsRejectsProviderListTypo(t *testing.T) {
 		t.Fatal(err)
 	}
 	provider, _ := cmd.Flags().GetString("provider")
-	_, _, err := initWizardConfigFromFlags(cmd, provider, "", nil, "", "")
+	_, _, err := initWizardConfigFromFlags(cmd, provider, "", nil, "", "", hostedDoltInitOptions{})
 	if err == nil {
 		t.Fatal("expected deprecated --provider list typo to fail")
 	}
@@ -3872,7 +3872,7 @@ func TestInitWizardConfigFromFlagsTemplateCustomRejectsProviders(t *testing.T) {
 	}
 	template, _ := cmd.Flags().GetString("template")
 	defaultProvider, _ := cmd.Flags().GetString("default-provider")
-	if _, _, err := initWizardConfigFromFlags(cmd, "", defaultProvider, nil, template, ""); err == nil {
+	if _, _, err := initWizardConfigFromFlags(cmd, "", defaultProvider, nil, template, "", hostedDoltInitOptions{}); err == nil {
 		t.Fatal("expected --template custom with provider flags to fail")
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1930,12 +1930,20 @@ gc init --name my-city
 gc init --from ~/elan --name elan /city
 gc init --file ./my-city.toml ~/bright-lights
 gc init --file city.toml --preserve-existing .
+gc init --template gascity --default-provider claude \
+  --dolt-host db.example.com --dolt-port 4406 \
+  --dolt-database bd_prj_x --dolt-project-id prj_x --no-start /city
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--bootstrap-profile` | string |  | bootstrap profile to apply for hosted/container defaults |
 | `--default-provider` | string |  | default readiness-aware provider to select from --providers |
+| `--dolt-database` | string |  | hosted beads project database, e.g. bd_prj_… (or GC_DOLT_DATABASE); required with --dolt-host |
+| `--dolt-host` | string |  | external/hosted Dolt host for the city beads ledger (or GC_DOLT_HOST); pins the city to an external endpoint instead of bootstrapping a managed-local Dolt |
+| `--dolt-port` | string |  | external/hosted Dolt port (or GC_DOLT_PORT); required with --dolt-host |
+| `--dolt-project-id` | string |  | authoritative beads project_id for the identity handshake (or GC_BEADS_PROJECT_ID); derived from a bd_&lt;id&gt; --dolt-database when omitted |
+| `--dolt-user` | string |  | external/hosted Dolt user (or GC_DOLT_USER); optional |
 | `--file` | string |  | path to a TOML file to use as city.toml |
 | `--from` | string |  | path to an example city directory to copy |
 | `--json` | bool |  | emit JSON summary |


### PR DESCRIPTION
## Problem

`gc init` could only bootstrap a **managed-local** Dolt. A city whose beads ledger is a **hosted/external Dolt gateway** (the create-city / Model-B controller case) had no way to pin that endpoint during init: it always tried to publish a local Dolt runtime and died with `recover missing provider dolt runtime state: no published dolt runtime state hint`. Pinning was only possible *after* a (failed) init via `gc beads city use-external`, and the hosted identity handshake (`project_id`) was never wired. The create-city controller image papered over this with a chain of entrypoint hacks (`gc init … || true`, hand-written `metadata.json`, post-init `use-external`).

## What this does

Makes a hosted/external Dolt endpoint a **first-class `gc init` input**.

New flags, each with an env fallback so a controller entrypoint can reduce to `set env → gc init → gc start`:

| Flag | Env | Notes |
|------|-----|-------|
| `--dolt-host` | `GC_DOLT_HOST` | presence pins the city to an external endpoint |
| `--dolt-port` | `GC_DOLT_PORT` | required with `--dolt-host` |
| `--dolt-user` | `GC_DOLT_USER` | optional |
| `--dolt-database` | `GC_DOLT_DATABASE` | the provisioner-created project DB, e.g. `bd_prj_…` |
| `--dolt-project-id` | `GC_BEADS_PROJECT_ID` | identity handshake; derived from a `bd_<id>` database when omitted |

When supplied, `doInit` writes the full canonical external config **atomically** — identical in shape to `gc beads city use-external --adopt-unverified`, plus the pinned database and project identity:

- `city.toml` `[dolt]` host/port
- `.beads/config.yaml` → `gc.endpoint_origin=city_canonical`, `gc.endpoint_status=unverified`, dolt host/port/user
- `.beads/metadata.json` → `backend=dolt`, `dolt_mode=server`, `dolt_database`
- `.beads/identity.toml` → `project_id` (which the canonical metadata write stamps into `metadata.json`, so the `identity_match` preflight passes at `gc start`)

The existing lifecycle then resolves the city as external (`managedDoltLifecycleOwned=false`) and **skips the managed-local bootstrap**. `initDirIfReady` **defers** the live `bd init` to `gc start` for an *unverified* external endpoint, so **init never requires credentials** (R5): it records `endpoint_status=unverified` and `gc start` verifies once `BEADS_DOLT_CREDENTIAL_COMMAND` is wired.

Managed, postgres, doltlite, and **verified**-external paths are unchanged — every new branch is gated on the hosted endpoint being supplied / unverified.

## Requirements mapping (`gc-init-hosted-dolt-requirements.md`)

- **R1** native init flags + env — ✅
- **R2** don't bootstrap managed-local dolt when hosted — ✅ (canonical config written in `doInit`, before the unconditional `initDirIfReady`)
- **R3** write the full canonical external config atomically — ✅ (the four files above)
- **R4** set `project_id` — ✅ (via `.beads/identity.toml`; explicit `--dolt-project-id` or `bd_<id>` derivation)
- **R5** tolerate a not-yet-credentialed connection — ✅ (`unverified`; init defers `bd init`)
- **R6** land in OSS `main`; verify the runtime prereqs are present — ✅ **The runtime side already landed via #3777** (the `isExternalDolt` skips in `startBeadsLifecycle` / `verifyManagedDoltDatabaseExistsAfterInit`, credential-command env passthrough, and the `gc-beads-bd.sh` hosted branch). This PR completes the **init** half; no cherry-picks needed.

## Acceptance criteria

1. ✅ `gc init --template gascity --default-provider … --dolt-host … --dolt-port … --dolt-database bd_prj_x --dolt-project-id prj_x --skip-provider-readiness …` exits 0 with no managed-dolt bootstrap, and `.beads/{config.yaml,metadata.json}` + `city.toml` declare `city_canonical` + `project_id` (`TestGcInitHostedDoltEnvOnlyEndToEnd`, `TestDoInitWritesCanonicalHostedDoltConfig`).
2. `gc start` connect + `identity_match` PASS + supervisor `:9443` — relies on the #3777 runtime path; this PR makes init produce the config that path consumes.
3. ✅ Controller entrypoint reduces to `set env → gc init <hosted flags> → gc start` — covered by the env-only end-to-end test.
4. `GET …/api/status` returns 200 — downstream/deploy verification, out of scope for this code change.

> Note: `--template gascity` still requires `--default-provider` (existing rule). The spec's AC1 example omits it; the controller supplies one.

## Tests

New `cmd/gc/init_hosted_dolt_test.go`: flag/env resolution + validation (table-driven), `project_id` derivation, `doInit` canonical-config write, env-only end-to-end through `finalizeInit`, unverified→defer vs verified→init-and-hook, and the bd-backed-provider requirement. Local fast suite is green (enforced by the pre-push gate).

## Review

Ran an adversarial multi-lens review (correctness / regression / R5-no-connection / idioms / test-gaps) with per-finding verification: no correctness, regression, R5, or idiom findings survived; the only confirmed findings were test-coverage gaps, now closed.

## Out of scope (enabled-by, follow-ups)

- Simplifying the `gascity/crucible` controller entrypoint (drop `|| true`, hand-written metadata, post-init `use-external`).
- The provisioner passing `GC_BEADS_PROJECT_ID` on the controller launch env (R4 preferred source).
- An optional `--beads-credential-command` flag (credentials arrive via `BEADS_DOLT_CREDENTIAL_COMMAND` env at `gc start`, not init).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
