### PR TITLE
fix(hook): enqueue continuation nudges for pool graph.v2 roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pool graph.v2 sessions no longer idle after claiming a workflow root.**
   `gc hook --claim` now enqueues a queued nudge to the concrete claiming session
   (e.g. `pool-worker/slot-0`) when it newly claims a workflow root and
-  pre-assigns at least one continuation sibling. Previously the sling-time nudge
-  targeted the pool template name, which is pruned as undeliverable once the
-  concrete session exists, leaving the session idle until manual operator
-  intervention via `gc session nudge`.
+  pre-assigns at least one continuation sibling, and starts a sidecar poller for
+  that concrete session. Previously the only propulsion nudge was the sling-time
+  nudge, whose poller was keyed to the pool template session that never runs, so
+  the concrete slot was never polled and idled until manual operator
+  intervention via `gc session nudge`. The hook-claim nudge is fenced to the
+  claiming session generation (session id + continuation epoch), so a recycled
+  slot that reuses the runtime session name cannot pick up a stale nudge. If a
+  residual template-targeted sling nudge is still pending, the concrete slot's
+  poller claims it alongside the continuation nudge and the two are coalesced
+  into a single hook re-entry — one redundant line, not a second propulsion.
 
   **ACP operator note:** in default (non-supervisor) dispatcher mode, the
   hook-claim nudge is delivered by a sidecar poller for tmux/subprocess sessions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pool graph.v2 sessions no longer idle after claiming a workflow root.**
+  `gc hook --claim` now enqueues a queued nudge to the concrete claiming session
+  (e.g. `pool-worker/slot-0`) when it newly claims a workflow root and
+  pre-assigns at least one continuation sibling. Previously the sling-time nudge
+  targeted the pool template name, which is pruned as undeliverable once the
+  concrete session exists, leaving the session idle until manual operator
+  intervention via `gc session nudge`.
+
+  **ACP operator note:** in default (non-supervisor) dispatcher mode, the
+  hook-claim nudge is delivered by a sidecar poller for tmux/subprocess sessions.
+  ACP sessions do not support a sidecar poller; the nudge will be consumed at
+  the next hook-drain instead. For reliable ACP queued delivery, configure:
+
+  ```toml
+  [daemon]
+  nudge_dispatcher = "supervisor"
+  ```
+
+  **In-flight sizing:** with `nudge_dispatcher = "supervisor"`, plan capacity
+  for `max_concurrent_formulas × (1 + max_parallel_steps)` in-flight sessions.
+  A typical graph.v2 run holds one workflow root plus one active step; a formula
+  with two parallel steps holds one root plus two active steps at peak.
+
 - **Pin the `beads` dependency to the stable v1.0.4.** v1.3.0 built against
   `beads v1.0.5`, which was subsequently withdrawn (demoted to a pre-release;
   `v1.0.4` is the current stable release). v1.3.1 repins the `beads` Go module

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -379,6 +379,7 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 			Env:          queryEnv,
 			DrainAck:     opts.DrainAck,
 			JSON:         opts.JSON,
+			CityPath:     cityPath,
 		}
 		return claimHookWork(workQuery, workDir, queryEnv, stores, claimOpts, emitQueryFailure, stdout, stderr)
 	}

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -380,6 +380,7 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 			DrainAck:     opts.DrainAck,
 			JSON:         opts.JSON,
 			CityPath:     cityPath,
+			Cfg:          cfg,
 		}
 		return claimHookWork(workQuery, workDir, queryEnv, stores, claimOpts, emitQueryFailure, stdout, stderr)
 	}

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -26,6 +26,10 @@ type hookClaimOptions struct {
 	Env                []string
 	DrainAck           bool
 	JSON               bool
+	// CityPath is the city root directory, threaded to the continuation nudge
+	// enqueue seam so the production implementation can locate the nudge store.
+	// Empty in tests that inject a fake EnqueueContinuationNudge.
+	CityPath string
 }
 
 type hookClaimOps struct {
@@ -47,18 +51,26 @@ type hookClaimOps struct {
 	// AND gc.active_work_bead (the claimed work bead's gc.step_id) — in ONE update, so
 	// the (run, step) tuple stays atomically consistent. Best-effort.
 	RecordSessionPointers hookRecordSessionPointersFunc
-	Now                   func() time.Time
+	// EnqueueContinuationNudge enqueues the hook-claim-continuation nudge that
+	// propels a pool graph.v2 session from root-claim into step 1 without
+	// operator intervention. Called when a new workflow root is claimed and at
+	// least one continuation sibling was pre-assigned. Best-effort; enqueue
+	// failure is logged but never blocks the claim. See ga-7n7vth.2 for the
+	// call site that activates this seam in production.
+	EnqueueContinuationNudge hookEnqueueContinuationNudgeFunc
+	Now                      func() time.Time
 }
 
 type (
-	hookClaimFunc                 func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
-	hookListContinuationFunc      func(context.Context, string, []string, string, string) ([]beads.Bead, error)
-	hookAssignContinuationFunc    func(context.Context, string, []string, string, string) error
-	hookDrainAckFunc              func(io.Writer) error
-	hookEmitClaimRejectedFunc     func(beadID, existingClaimant, attemptedClaimant string)
-	hookResolveWorkBranchFunc     func(dir string) string
-	hookStampWorkBranchFunc       func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
-	hookRecordSessionPointersFunc func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
+	hookClaimFunc                    func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
+	hookListContinuationFunc         func(context.Context, string, []string, string, string) ([]beads.Bead, error)
+	hookAssignContinuationFunc       func(context.Context, string, []string, string, string) error
+	hookDrainAckFunc                 func(io.Writer) error
+	hookEmitClaimRejectedFunc        func(beadID, existingClaimant, attemptedClaimant string)
+	hookResolveWorkBranchFunc        func(dir string) string
+	hookStampWorkBranchFunc          func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
+	hookEnqueueContinuationNudgeFunc func(cityPath string, item queuedNudge) error
+	hookRecordSessionPointersFunc    func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
 )
 
 type hookClaimJSONResult struct {
@@ -181,6 +193,9 @@ func (ops *hookClaimOps) applyDefaults() {
 	}
 	if ops.RecordSessionPointers == nil {
 		ops.RecordSessionPointers = hookRecordSessionPointersWithBdStore
+	}
+	if ops.EnqueueContinuationNudge == nil {
+		ops.EnqueueContinuationNudge = enqueueQueuedNudge
 	}
 }
 

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 )
 
@@ -40,6 +41,12 @@ type hookClaimOptions struct {
 	// enqueue seam so the production implementation can locate the nudge store.
 	// Empty in tests that inject a fake EnqueueContinuationNudge.
 	CityPath string
+	// Cfg is the loaded city config, threaded to the continuation-nudge poller
+	// so maybeStartNudgePoller can honor daemon.nudge_dispatcher = "supervisor"
+	// (a nil cfg reads as legacy mode and would start a sidecar poller that
+	// races the supervisor dispatcher). Nil in tests that short-circuit on an
+	// empty CityPath before the poller is reached.
+	Cfg *config.City
 }
 
 type hookClaimOps struct {
@@ -63,10 +70,10 @@ type hookClaimOps struct {
 	RecordSessionPointers hookRecordSessionPointersFunc
 	// EnqueueContinuationNudge enqueues the hook-claim-continuation nudge that
 	// propels a pool graph.v2 session from root-claim into step 1 without
-	// operator intervention. Called when a new workflow root is claimed and at
-	// least one continuation sibling was pre-assigned. Best-effort; enqueue
-	// failure is logged but never blocks the claim. See ga-7n7vth.2 for the
-	// call site that activates this seam in production.
+	// operator intervention. Called from writeHookClaimWorkResultForBead when a
+	// new workflow root is claimed and at least one continuation sibling was
+	// pre-assigned. Best-effort; enqueue failure is logged but never blocks the
+	// claim.
 	EnqueueContinuationNudge hookEnqueueContinuationNudgeFunc
 	Now                      func() time.Time
 }
@@ -366,18 +373,64 @@ func hookClaimEnqueueContinuationNudge(opts hookClaimOptions, ops hookClaimOps, 
 	if ops.Now != nil {
 		now = ops.Now
 	}
-	item := newQueuedNudgeWithOptions(opts.Assignee, hookClaimContinuationNudgeMessage, hookClaimContinuationNudgeSource, now(), queuedNudgeOptions{})
+	// Fence the nudge to this concrete session generation, reading the session
+	// id and continuation epoch from the claim env the same way the rest of the
+	// claim path reads GC_SESSION_ID. Every other newQueuedNudgeWithOptions
+	// caller passes this fence; without it a continuation nudge enqueued for
+	// pool-worker/slot-0 stays claimable by a later generation that reuses the
+	// same runtime session name after a recycle.
+	sessionID := hookClaimSessionID(opts.Env)
+	continuationEpoch := hookClaimContinuationEpoch(opts.Env)
+	item := newQueuedNudgeWithOptions(opts.Assignee, hookClaimContinuationNudgeMessage, hookClaimContinuationNudgeSource, now(), queuedNudgeOptions{
+		SessionID:         sessionID,
+		ContinuationEpoch: continuationEpoch,
+	})
 	if err := ops.EnqueueContinuationNudge(opts.CityPath, item); err != nil {
 		fmt.Fprintf(stderr, "gc hook --claim: enqueue continuation nudge: %v\n", err) //nolint:errcheck
 		return
 	}
+	// With no city path there is no nudge poller PID tree, controller socket, or
+	// supervisor to reach: the enqueue seam above is faked in tests and the
+	// production caller always threads a real city path. Returning here keeps
+	// the unit path free of process spawning and controller/supervisor I/O,
+	// matching the cityPath guard in rollbackQueuedNudge/existingPollerPID.
+	if opts.CityPath == "" {
+		return
+	}
+	// cfg is threaded so the supervisor-dispatcher guard inside
+	// maybeStartNudgePoller fires: in supervisor mode the dispatcher owns queued
+	// delivery and a sidecar poller would race it (nudgeDispatcherIsSupervisor
+	// reads target.cfg, so a nil cfg silently defeats the guard). sessionID and
+	// continuationEpoch give the poller the concrete-generation key, matching
+	// the canonical launch in cmd_prime.go.
+	//
 	// ACP note: maybeStartNudgePoller returns early without transport context
 	// when the target session uses the ACP runtime. In that case the queued
 	// nudge is delivered only at the next hook-drain, not by a sidecar poller.
 	// Configure daemon.nudge_dispatcher = "supervisor" for reliable queued
 	// delivery to ACP sessions.
-	maybeStartNudgePoller(nudgeTarget{cityPath: opts.CityPath, sessionName: opts.Assignee})
+	maybeStartNudgePoller(nudgeTarget{
+		cityPath:          opts.CityPath,
+		cfg:               opts.Cfg,
+		sessionID:         sessionID,
+		continuationEpoch: continuationEpoch,
+		sessionName:       opts.Assignee,
+	})
 	_ = pokeController(opts.CityPath)
+}
+
+// hookClaimContinuationEpoch returns the continuation epoch
+// (GC_CONTINUATION_EPOCH) from the claim env, used alongside the session id to
+// fence the continuation nudge to this session generation. Empty when unset —
+// the session-id fence alone still binds the nudge to the current generation.
+func hookClaimContinuationEpoch(env []string) string {
+	epoch := ""
+	for _, entry := range env {
+		if k, v, ok := strings.Cut(entry, "="); ok && k == "GC_CONTINUATION_EPOCH" {
+			epoch = v
+		}
+	}
+	return strings.TrimSpace(epoch)
 }
 
 // writeHookClaimNoWork writes the single drain result for a hook that claimed

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -17,6 +17,16 @@ import (
 
 const hookClaimCommandName = "hook"
 
+const (
+	// hookClaimContinuationNudgeSource is the source tag on the queued nudge
+	// that propels a pool graph.v2 session from root-claim into step 1.
+	hookClaimContinuationNudgeSource = "hook-claim-continuation"
+	// hookClaimContinuationNudgeMessage is the standard propulsion message
+	// delivered to the claiming session after a workflow root is claimed with
+	// continuation siblings pre-assigned.
+	hookClaimContinuationNudgeMessage = "Work slung. Check your hook."
+)
+
 var hookClaimMutationTimeout = 10 * time.Second
 
 type hookClaimOptions struct {
@@ -331,6 +341,11 @@ func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead
 		return 1
 	}
 	result.ContinuationAssigned = assigned
+	if result.Reason == "claimed" &&
+		len(assigned) > 0 &&
+		strings.TrimSpace(bead.Metadata[beadmeta.KindMetadataKey]) == beadmeta.KindWorkflow {
+		hookClaimEnqueueContinuationNudge(opts, ops, stderr)
+	}
 	if opts.JSON {
 		if err := writeCLIJSONLine(stdout, result); err != nil {
 			fmt.Fprintf(stderr, "gc hook --claim: writing JSON: %v\n", err) //nolint:errcheck
@@ -340,6 +355,24 @@ func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead
 	}
 	fmt.Fprintln(stdout, result.BeadID) //nolint:errcheck
 	return 0
+}
+
+// hookClaimEnqueueContinuationNudge enqueues the per-session nudge that
+// propels a pool graph.v2 session from root-claim into step 1 without operator
+// intervention. Best-effort: enqueue failure is logged but never converts a
+// successful hook claim into a user-visible error.
+func hookClaimEnqueueContinuationNudge(opts hookClaimOptions, ops hookClaimOps, stderr io.Writer) {
+	now := time.Now
+	if ops.Now != nil {
+		now = ops.Now
+	}
+	item := newQueuedNudgeWithOptions(opts.Assignee, hookClaimContinuationNudgeMessage, hookClaimContinuationNudgeSource, now(), queuedNudgeOptions{})
+	if err := ops.EnqueueContinuationNudge(opts.CityPath, item); err != nil {
+		fmt.Fprintf(stderr, "gc hook --claim: enqueue continuation nudge: %v\n", err) //nolint:errcheck
+		return
+	}
+	maybeStartNudgePoller(nudgeTarget{cityPath: opts.CityPath, sessionName: opts.Assignee})
+	_ = pokeController(opts.CityPath)
 }
 
 // writeHookClaimNoWork writes the single drain result for a hook that claimed

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -371,6 +371,11 @@ func hookClaimEnqueueContinuationNudge(opts hookClaimOptions, ops hookClaimOps, 
 		fmt.Fprintf(stderr, "gc hook --claim: enqueue continuation nudge: %v\n", err) //nolint:errcheck
 		return
 	}
+	// ACP note: maybeStartNudgePoller returns early without transport context
+	// when the target session uses the ACP runtime. In that case the queued
+	// nudge is delivered only at the next hook-drain, not by a sidecar poller.
+	// Configure daemon.nudge_dispatcher = "supervisor" for reliable queued
+	// delivery to ACP sessions.
 	maybeStartNudgePoller(nudgeTarget{cityPath: opts.CityPath, sessionName: opts.Assignee})
 	_ = pokeController(opts.CityPath)
 }

--- a/cmd/gc/cmd_hook_claim_nudge_test.go
+++ b/cmd/gc/cmd_hook_claim_nudge_test.go
@@ -1,0 +1,298 @@
+package main
+
+// Tests for the hook-claim-continuation nudge enqueue seam (ga-7n7vth.1).
+//
+// These tests define the expected behavior for ga-7n7vth.2:
+//
+//   - A newly claimed pool graph.v2 workflow root that pre-assigns at least one
+//     continuation sibling must enqueue exactly one queued nudge with source
+//     "hook-claim-continuation", targeting the claiming session by name, using
+//     the canonical propulsion message.
+//   - Non-workflow step-bead claims must not enqueue the nudge.
+//   - Re-found existing assignments must not enqueue the nudge (idempotence).
+//   - Workflow root claims with zero continuation siblings must not enqueue.
+//
+// All tests that assert the nudge IS enqueued (TestHookClaimWorkflowRootEnqueuesContinuationNudge)
+// fail against the current codebase until ga-7n7vth.2 adds the call site in
+// writeHookClaimWorkResultForBead. Tests that assert the nudge is NOT enqueued
+// pass now and serve as guardrails against over-enqueueing after the fix lands.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+const (
+	hookClaimContinuationNudgeSource  = "hook-claim-continuation"
+	hookClaimContinuationNudgeMessage = "Work slung. Check your hook."
+)
+
+// makeWorkflowRootBead returns a bead shaped like a pool graph.v2 workflow root
+// ready to be claimed: gc.kind=workflow, gc.run_target pointing at the pool
+// template, and gc.root_bead_id / gc.continuation_group so pre-assignment runs.
+func makeWorkflowRootBead(id, runTarget, rootID, continuationGroup string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "workflow",
+			"gc.run_target":         runTarget,
+			"gc.root_bead_id":       rootID,
+			"gc.continuation_group": continuationGroup,
+		},
+	}
+}
+
+// makeStepBead returns a bead shaped like a formula step (gc.kind=step) with
+// the same continuation metadata a workflow root has. Step beads reach the
+// work queue via gc.routed_to (set by preassignHookContinuationGroup), not
+// via gc.run_target, so routedTo is the claiming session name.
+func makeStepBead(id, routedTo, rootID, continuationGroup string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "step",
+			"gc.routed_to":          routedTo,
+			"gc.root_bead_id":       rootID,
+			"gc.continuation_group": continuationGroup,
+		},
+	}
+}
+
+// captureNudgeOps returns a hookClaimOps that captures the city path and nudge
+// item passed to EnqueueContinuationNudge. The capture is written to *calls.
+func captureNudgeOps(t *testing.T, calls *[]queuedNudge, bead beads.Bead, sibling beads.Bead) hookClaimOps {
+	t.Helper()
+	output, err := json.Marshal([]beads.Bead{bead})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(output), nil },
+		Claim: func(_ context.Context, _ string, _ []string, _, assignee string) (beads.Bead, bool, error) {
+			claimed := bead
+			claimed.Assignee = assignee
+			claimed.Status = "in_progress"
+			return claimed, true, nil
+		},
+		ListContinuation: func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) {
+			if sibling.ID == "" {
+				return nil, nil
+			}
+			return []beads.Bead{sibling}, nil
+		},
+		AssignContinuation: func(_ context.Context, _ string, _ []string, _, _ string) error {
+			return nil
+		},
+		DrainAck:          func(io.Writer) error { return nil },
+		ResolveWorkBranch: func(string) string { return "" },
+		StampWorkBranch:   func(_ context.Context, _ string, _ []string, _, _, _ string) error { return nil },
+		RecordSessionPointers: func(_ context.Context, _ string, _ []string, _, _, _, _ string) error {
+			return nil
+		},
+		EnqueueContinuationNudge: func(_ string, item queuedNudge) error {
+			*calls = append(*calls, item)
+			return nil
+		},
+	}
+}
+
+// TestHookClaimWorkflowRootEnqueuesContinuationNudge verifies that claiming a
+// new pool graph.v2 workflow root with at least one pre-assigned continuation
+// sibling enqueues exactly one queued nudge with the canonical propulsion
+// semantics (source, message, agent equal to the claiming session name).
+//
+// This test is skipped until ga-7n7vth.2 removes the t.Skip call below and
+// adds the production call site in writeHookClaimWorkResultForBead. After the
+// Skip is removed this test will fail (RED) until the call site is added, then
+// pass (GREEN). That is the intended TDD sequence.
+func TestHookClaimWorkflowRootEnqueuesContinuationNudge(t *testing.T) {
+	t.Skip("ga-7n7vth.2: remove this Skip and add the EnqueueContinuationNudge call site in writeHookClaimWorkResultForBead")
+	root := makeWorkflowRootBead("root-1", "pool-worker", "root-1", "group-a")
+	sibling := beads.Bead{
+		ID:     "step-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "step",
+			"gc.run_target":         "pool-worker",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}
+
+	var calls []queuedNudge
+	ops := captureNudgeOps(t, &calls, root, sibling)
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "", hookClaimOptions{
+		Assignee:           "pool-worker/slot-0",
+		IdentityCandidates: []string{"pool-worker/slot-0"},
+		RouteTargets:       []string{"pool-worker"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("EnqueueContinuationNudge called %d times, want exactly 1; stderr=%s", len(calls), stderr.String())
+	}
+	got := calls[0]
+	if got.Agent != "pool-worker/slot-0" {
+		t.Errorf("nudge.Agent = %q, want %q", got.Agent, "pool-worker/slot-0")
+	}
+	if got.Source != hookClaimContinuationNudgeSource {
+		t.Errorf("nudge.Source = %q, want %q", got.Source, hookClaimContinuationNudgeSource)
+	}
+	if got.Message != hookClaimContinuationNudgeMessage {
+		t.Errorf("nudge.Message = %q, want %q", got.Message, hookClaimContinuationNudgeMessage)
+	}
+}
+
+// TestHookClaimStepBeadDoesNotEnqueueContinuationNudge verifies that claiming a
+// non-workflow step bead — even one that has continuation metadata and pre-assigns
+// siblings — does not enqueue the hook-claim-continuation nudge. Only workflow
+// root claims propel the session; step claims happen while the session is already
+// active.
+func TestHookClaimStepBeadDoesNotEnqueueContinuationNudge(t *testing.T) {
+	// Step beads are routed to the concrete session name (set by
+	// preassignHookContinuationGroup on the prior root claim), so the route
+	// target here is the session name, not the pool template.
+	step := makeStepBead("step-1", "pool-worker/slot-0", "root-1", "group-a")
+	sibling := beads.Bead{
+		ID:     "step-2",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "step",
+			"gc.routed_to":          "pool-worker/slot-0",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}
+
+	var calls []queuedNudge
+	ops := captureNudgeOps(t, &calls, step, sibling)
+
+	var stdout, stderr bytes.Buffer
+	// A step bead's route target is the concrete session name (pool-worker/slot-0),
+	// not the pool template name; include both to mirror real hook invocation.
+	code := doHookClaim("query", "", hookClaimOptions{
+		Assignee:           "pool-worker/slot-0",
+		IdentityCandidates: []string{"pool-worker/slot-0"},
+		RouteTargets:       []string{"pool-worker/slot-0", "pool-worker"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if len(calls) != 0 {
+		t.Errorf("EnqueueContinuationNudge called %d times for step-bead claim, want 0", len(calls))
+	}
+}
+
+// TestHookClaimExistingAssignmentDoesNotEnqueueContinuationNudge verifies that
+// re-finding a workflow root that is already assigned to the claiming session
+// (idempotent re-find on retry) does not enqueue an additional continuation
+// nudge. The session is already active; a second nudge would cause a redundant
+// hook re-entry.
+func TestHookClaimExistingAssignmentDoesNotEnqueueContinuationNudge(t *testing.T) {
+	root := beads.Bead{
+		ID:       "root-1",
+		Status:   "in_progress",
+		Assignee: "pool-worker/slot-0",
+		Metadata: map[string]string{
+			"gc.kind":               "workflow",
+			"gc.run_target":         "pool-worker",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}
+	output, err := json.Marshal([]beads.Bead{root})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var calls []queuedNudge
+	sibling := beads.Bead{
+		ID:     "step-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "step",
+			"gc.run_target":         "pool-worker",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(output), nil },
+		// Claim is not called for existing assignments; provide a no-op to satisfy applyDefaults.
+		Claim: func(_ context.Context, _ string, _ []string, _, _ string) (beads.Bead, bool, error) {
+			return beads.Bead{}, false, nil
+		},
+		ListContinuation: func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) {
+			return []beads.Bead{sibling}, nil
+		},
+		AssignContinuation: func(_ context.Context, _ string, _ []string, _, _ string) error {
+			return nil
+		},
+		DrainAck:          func(io.Writer) error { return nil },
+		ResolveWorkBranch: func(string) string { return "" },
+		StampWorkBranch:   func(_ context.Context, _ string, _ []string, _, _, _ string) error { return nil },
+		RecordSessionPointers: func(_ context.Context, _ string, _ []string, _, _, _, _ string) error {
+			return nil
+		},
+		EnqueueContinuationNudge: func(_ string, item queuedNudge) error {
+			calls = append(calls, item)
+			return nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "", hookClaimOptions{
+		Assignee:           "pool-worker/slot-0",
+		IdentityCandidates: []string{"pool-worker/slot-0"},
+		RouteTargets:       []string{"pool-worker"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if len(calls) != 0 {
+		t.Errorf("EnqueueContinuationNudge called %d times for re-found assignment, want 0", len(calls))
+	}
+}
+
+// TestHookClaimZeroContinuationDoesNotEnqueueContinuationNudge verifies that
+// claiming a workflow root where no continuation siblings are available — either
+// because the formula has no steps or all step beads are already assigned —
+// does not enqueue the nudge. There is nothing to propel into.
+func TestHookClaimZeroContinuationDoesNotEnqueueContinuationNudge(t *testing.T) {
+	root := makeWorkflowRootBead("root-1", "pool-worker", "root-1", "group-a")
+
+	var calls []queuedNudge
+	// sibling is empty: ListContinuation returns nothing.
+	ops := captureNudgeOps(t, &calls, root, beads.Bead{})
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "", hookClaimOptions{
+		Assignee:           "pool-worker/slot-0",
+		IdentityCandidates: []string{"pool-worker/slot-0"},
+		RouteTargets:       []string{"pool-worker"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if len(calls) != 0 {
+		t.Errorf("EnqueueContinuationNudge called %d times for zero-continuation claim, want 0", len(calls))
+	}
+}

--- a/cmd/gc/cmd_hook_claim_nudge_test.go
+++ b/cmd/gc/cmd_hook_claim_nudge_test.go
@@ -1,27 +1,29 @@
 package main
 
-// Tests for the hook-claim-continuation nudge enqueue seam (ga-7n7vth.1).
+// Tests for the hook-claim-continuation nudge enqueue seam.
 //
-// These tests define the expected behavior for ga-7n7vth.2:
+// Invariant: gc hook --claim enqueues the hook-claim-continuation nudge exactly
+// when a newly claimed pool graph.v2 workflow root pre-assigns at least one
+// continuation sibling, and never otherwise:
 //
-//   - A newly claimed pool graph.v2 workflow root that pre-assigns at least one
-//     continuation sibling must enqueue exactly one queued nudge with source
-//     "hook-claim-continuation", targeting the claiming session by name, using
-//     the canonical propulsion message.
-//   - Non-workflow step-bead claims must not enqueue the nudge.
-//   - Re-found existing assignments must not enqueue the nudge (idempotence).
-//   - Workflow root claims with zero continuation siblings must not enqueue.
-//
-// All tests that assert the nudge IS enqueued (TestHookClaimWorkflowRootEnqueuesContinuationNudge)
-// fail against the current codebase until ga-7n7vth.2 adds the call site in
-// writeHookClaimWorkResultForBead. Tests that assert the nudge is NOT enqueued
-// pass now and serve as guardrails against over-enqueueing after the fix lands.
+//   - A newly claimed workflow root that pre-assigns at least one continuation
+//     sibling enqueues exactly one queued nudge with source
+//     "hook-claim-continuation", targeting the claiming session by name, fenced
+//     to the session generation (SessionID/ContinuationEpoch from the claim
+//     env), using the canonical propulsion message.
+//   - Non-workflow step-bead claims do not enqueue the nudge.
+//   - Re-found existing assignments do not enqueue the nudge (idempotence): the
+//     session is already active, so a second nudge would only force a redundant
+//     hook re-entry.
+//   - Workflow root claims with zero continuation siblings do not enqueue: there
+//     is nothing to propel into.
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -114,10 +116,14 @@ func TestHookClaimWorkflowRootEnqueuesContinuationNudge(t *testing.T) {
 	ops := captureNudgeOps(t, &calls, root, sibling)
 
 	var stdout, stderr bytes.Buffer
+	// The claim env carries the concrete session generation; the enqueued nudge
+	// must be fenced to it (SessionID/ContinuationEpoch) so a recycled slot that
+	// reuses the runtime session name cannot pick up a stale continuation nudge.
 	code := doHookClaim("query", "", hookClaimOptions{
 		Assignee:           "pool-worker/slot-0",
 		IdentityCandidates: []string{"pool-worker/slot-0"},
 		RouteTargets:       []string{"pool-worker"},
+		Env:                []string{"GC_SESSION_ID=sess-123", "GC_CONTINUATION_EPOCH=2"},
 		JSON:               true,
 	}, ops, &stdout, &stderr)
 	if code != 0 {
@@ -136,6 +142,12 @@ func TestHookClaimWorkflowRootEnqueuesContinuationNudge(t *testing.T) {
 	}
 	if got.Message != hookClaimContinuationNudgeMessage {
 		t.Errorf("nudge.Message = %q, want %q", got.Message, hookClaimContinuationNudgeMessage)
+	}
+	if got.SessionID != "sess-123" {
+		t.Errorf("nudge.SessionID = %q, want %q (session-generation fence)", got.SessionID, "sess-123")
+	}
+	if got.ContinuationEpoch != "2" {
+		t.Errorf("nudge.ContinuationEpoch = %q, want %q (session-generation fence)", got.ContinuationEpoch, "2")
 	}
 }
 
@@ -278,5 +290,100 @@ func TestHookClaimZeroContinuationDoesNotEnqueueContinuationNudge(t *testing.T) 
 
 	if len(calls) != 0 {
 		t.Errorf("EnqueueContinuationNudge called %d times for zero-continuation claim, want 0", len(calls))
+	}
+}
+
+// concreteSlotNudgeTarget builds the nudgeTarget a running pool slot resolves to
+// (mirroring resolveNudgeTargetFromSessionBead): its identity is the pool
+// template name and its sessionName is the concrete slot, so queueKeys() carries
+// BOTH the template and the concrete name.
+func concreteSlotNudgeTarget(sessionID, epoch string) nudgeTarget {
+	return nudgeTarget{
+		cityPath:          "/city",
+		identity:          "pool-worker",        // template name (agent_name/template on the session bead)
+		sessionID:         sessionID,            // concrete generation
+		continuationEpoch: epoch,                //
+		sessionName:       "pool-worker/slot-0", // concrete runtime session
+	}
+}
+
+// TestConcreteSessionMatchesTemplateSlingNudge documents that the pre-existing
+// sling-time nudge — enqueued under the pool TEMPLATE name before the concrete
+// slot existed — is NOT "pruned as undeliverable" for the concrete session.
+// Because a pool slot's queueKeys() includes the template identity, the slot's
+// poller claims the template-named sling nudge just as it claims the
+// concrete-named, fenced continuation nudge. This is the mechanism behind the
+// reviewer's double-nudge concern on PR #3833.
+func TestConcreteSessionMatchesTemplateSlingNudge(t *testing.T) {
+	target := concreteSlotNudgeTarget("sess-123", "2")
+
+	// The sling nudge predates the concrete slot, so it carries the template
+	// agent name and no session fence.
+	slingNudge := queuedNudge{Agent: "pool-worker", Source: "sling", Message: hookClaimContinuationNudgeMessage}
+	// The continuation nudge targets the concrete slot and is fenced to it.
+	continuationNudge := queuedNudge{
+		Agent:             "pool-worker/slot-0",
+		Source:            hookClaimContinuationNudgeSource,
+		Message:           hookClaimContinuationNudgeMessage,
+		SessionID:         "sess-123",
+		ContinuationEpoch: "2",
+	}
+
+	// Claimable: the concrete slot matches BOTH (so the sling nudge is not pruned).
+	if !queuedNudgeClaimableForTarget(target, slingNudge) {
+		t.Errorf("concrete slot does NOT claim the template-named sling nudge; it would if 'pruned as undeliverable' were accurate")
+	}
+	if !queuedNudgeClaimableForTarget(target, continuationNudge) {
+		t.Errorf("concrete slot does not claim its own fenced continuation nudge")
+	}
+	// Delivery fence: both pass for this generation (the unfenced sling nudge is
+	// exempt; the continuation nudge matches sess-123/epoch 2).
+	if !queuedNudgeMatchesTargetFence(target, slingNudge) {
+		t.Errorf("unfenced sling nudge unexpectedly rejected by the generation fence")
+	}
+	if !queuedNudgeMatchesTargetFence(target, continuationNudge) {
+		t.Errorf("fenced continuation nudge rejected by its own generation fence")
+	}
+
+	// The two nudges differ in Source and neither carries a Reference, so the
+	// (agent, source, reference) supersession at enqueue cannot collapse them.
+	if slingNudge.Source == continuationNudge.Source {
+		t.Errorf("test premise broken: sources should differ (%q vs %q)", slingNudge.Source, continuationNudge.Source)
+	}
+	if continuationNudge.Reference != nil {
+		t.Errorf("continuation nudge has a Reference %v; it must be nil so the test reflects production", continuationNudge.Reference)
+	}
+
+	// A recycled slot (new session id) must NOT pick up the fenced continuation nudge.
+	recycled := concreteSlotNudgeTarget("sess-999", "1")
+	if queuedNudgeClaimableForTarget(recycled, continuationNudge) {
+		t.Errorf("recycled slot (sess-999) wrongly claims a continuation nudge fenced to sess-123")
+	}
+}
+
+// TestSlingAndContinuationNudgesCoalesceForConcreteSession documents the
+// mitigating reality behind the double-nudge concern: when the poller claims
+// both the template sling nudge and the concrete continuation nudge in one tick,
+// tryDeliverQueuedNudgesByPoller renders them through formatNudgeInjectOutput
+// into a SINGLE delivered message (one hook re-entry), not two separate wakes.
+// The two identical "Work slung" lines are cosmetic, not a double propulsion.
+func TestSlingAndContinuationNudgesCoalesceForConcreteSession(t *testing.T) {
+	items := []queuedNudge{
+		{Agent: "pool-worker", Source: "sling", Message: hookClaimContinuationNudgeMessage},
+		{Agent: "pool-worker/slot-0", Source: hookClaimContinuationNudgeSource, Message: hookClaimContinuationNudgeMessage, SessionID: "sess-123"},
+	}
+	out := formatNudgeInjectOutput(items)
+
+	if got := strings.Count(out, "</system-reminder>"); got != 1 {
+		t.Errorf("formatNudgeInjectOutput emitted %d reminder blocks, want 1 (single coalesced delivery):\n%s", got, out)
+	}
+	if !strings.Contains(out, "[sling]") {
+		t.Errorf("coalesced message missing the sling source tag:\n%s", out)
+	}
+	if !strings.Contains(out, "["+hookClaimContinuationNudgeSource+"]") {
+		t.Errorf("coalesced message missing the continuation source tag:\n%s", out)
+	}
+	if got := strings.Count(out, hookClaimContinuationNudgeMessage); got != 2 {
+		t.Errorf("coalesced message contains the propulsion line %d times, want 2 (both nudges, one delivery):\n%s", got, out)
 	}
 }

--- a/cmd/gc/cmd_hook_claim_nudge_test.go
+++ b/cmd/gc/cmd_hook_claim_nudge_test.go
@@ -27,11 +27,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-const (
-	hookClaimContinuationNudgeSource  = "hook-claim-continuation"
-	hookClaimContinuationNudgeMessage = "Work slung. Check your hook."
-)
-
 // makeWorkflowRootBead returns a bead shaped like a pool graph.v2 workflow root
 // ready to be claimed: gc.kind=workflow, gc.run_target pointing at the pool
 // template, and gc.root_bead_id / gc.continuation_group so pre-assignment runs.
@@ -107,24 +102,13 @@ func captureNudgeOps(t *testing.T, calls *[]queuedNudge, bead beads.Bead, siblin
 // new pool graph.v2 workflow root with at least one pre-assigned continuation
 // sibling enqueues exactly one queued nudge with the canonical propulsion
 // semantics (source, message, agent equal to the claiming session name).
-//
-// This test is skipped until ga-7n7vth.2 removes the t.Skip call below and
-// adds the production call site in writeHookClaimWorkResultForBead. After the
-// Skip is removed this test will fail (RED) until the call site is added, then
-// pass (GREEN). That is the intended TDD sequence.
 func TestHookClaimWorkflowRootEnqueuesContinuationNudge(t *testing.T) {
-	t.Skip("ga-7n7vth.2: remove this Skip and add the EnqueueContinuationNudge call site in writeHookClaimWorkResultForBead")
 	root := makeWorkflowRootBead("root-1", "pool-worker", "root-1", "group-a")
-	sibling := beads.Bead{
-		ID:     "step-1",
-		Status: "open",
-		Metadata: map[string]string{
-			"gc.kind":               "step",
-			"gc.run_target":         "pool-worker",
-			"gc.root_bead_id":       "root-1",
-			"gc.continuation_group": "group-a",
-		},
-	}
+	// Continuation siblings in a graph.v2 formula use gc.kind=workflow and gc.run_target
+	// for pre-assignment routing — the same shape as the root, just a different bead ID.
+	// preassignHookContinuationGroup uses hookClaimMatchesRoute to filter, which only
+	// matches unrouted beads via run_target when gc.kind=workflow.
+	sibling := makeWorkflowRootBead("step-1", "pool-worker", "root-1", "group-a")
 
 	var calls []queuedNudge
 	ops := captureNudgeOps(t, &calls, root, sibling)

--- a/release-gates/ga-vkfkfm-acp-hook-continuation-nudge-gate.md
+++ b/release-gates/ga-vkfkfm-acp-hook-continuation-nudge-gate.md
@@ -1,0 +1,71 @@
+# Release Gate: ACP Hook-Claim Continuation Nudge
+
+Gate run: 2026-06-30T00:30:19-07:00
+Deployer bead: ga-vkfkfm
+Reviewed source bead: ga-swmq4l
+Source branch: builder/ga-7n7vth.3-acp-comment-docs
+Base: origin/main at c91105e2bedac416c6feba48cb0e1c81e9ab3a22
+Reviewed head before gate artifact: 3147f597951b29251d974d055b416e6880c3e870
+
+## Scope
+
+This is a single-bead deploy for the hook-claim continuation nudge feature.
+The branch carries the three dependent commits for one feature theme:
+
+| Commit | Bead | Scope |
+| --- | --- | --- |
+| d5a8208f5 | ga-7n7vth.1 | Regression coverage for hook-claim continuation nudge behavior |
+| 988a08eb6 | ga-7n7vth.2 | Production enqueue call site for newly claimed workflow roots |
+| 3147f5979 | ga-7n7vth.3 | ACP dispatcher note and CHANGELOG guidance |
+
+Touched paths:
+
+- CHANGELOG.md
+- cmd/gc/cmd_hook.go
+- cmd/gc/cmd_hook_claim.go
+- cmd/gc/cmd_hook_claim_nudge_test.go
+
+`docs/PROJECT_MANIFEST.md` is not present in this repository checkout
+(`rg --files` found no `PROJECT_MANIFEST.md`), so this gate uses the deployer
+role release criteria.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+| --- | --- | --- | --- |
+| 1 | Review PASS present | PASS | Review bead ga-swmq4l is CLOSED with close reason `pass`; notes say `PASS - reviewer verdict`, reviewed branch `builder/ga-7n7vth.3-acp-comment-docs`, commit `3147f5979`, and no blockers. |
+| 2 | Acceptance criteria met | PASS | Code gates enqueue on `reason == "claimed"`, non-empty continuation assignment, and `gc.kind == workflow`; target is `opts.Assignee`; source/message constants are `hook-claim-continuation` and `Work slung. Check your hook.`; enqueue failure logs non-fatally; `maybeStartNudgePoller` and `pokeController` are called after enqueue; ACP supervisor dispatcher dependency is documented at the enqueue site and in CHANGELOG. |
+| 3 | Tests pass | PASS | See test evidence below. Initial `make test-fast-parallel` hit an unrelated timing miss in `internal/eventfeed` (`TestMuxSource_YieldsAndPicksUpNewCity`); the touched paths do not include that package, the exact failing test passed immediately in isolation, and the full `make test-fast-parallel` rerun passed all shards. |
+| 4 | No high-severity review findings open | PASS | Review notes list only one non-blocking Style/Minor finding about stale test prose; no HIGH or blocking findings. |
+| 5 | Final branch is clean | PASS | Pre-gate worktree was clean before adding this gate artifact. The only expected delta is this gate file, to be committed as the branch tip before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` exited 0 and produced tree `0d87ecc0a964a2a94283b9be33a4feebbf99555c`. |
+| 7 | Single feature theme | PASS | All commits touch the `gc hook --claim` continuation-nudge path, its focused tests, and release guidance. No independent subsystem or unrelated user behavior is bundled. |
+
+## Acceptance Evidence
+
+- ga-7n7vth.1 acceptance: focused tests cover workflow root enqueue, step bead no-enqueue, existing assignment idempotence, and zero-continuation no-enqueue.
+- ga-7n7vth.2 acceptance: production path enqueues only for newly claimed workflow roots with continuation siblings; uses concrete session target; uses wait-idle queued nudge defaults; starts the nudge poller and pokes the controller; logs enqueue failures without failing the claim.
+- ga-7n7vth.3 acceptance: ACP limitation is documented at the enqueue site, CHANGELOG documents `daemon.nudge_dispatcher = "supervisor"` for reliable ACP delivery, and in-flight sizing uses `max_concurrent_formulas x (1 + max_parallel_steps)`.
+- ga-7n7vth.4 status: still open as a validation task, but no additional branch diff exists (`builder/ga-7n7vth.4-validation` equals `3147f5979`). This deploy gate ran and recorded its validation requirements; deployer did not close the child bead.
+
+## Test Evidence
+
+Commands run from `/home/jaword/gascity-deploy-ga-vkfkfm-acp-hook-gate`:
+
+- PASS: `go test ./cmd/gc -run 'TestHookClaim|TestDoHookClaim|TestJSONSchemaManifestForHookClaim|TestJSONSchemaResultForGraphWorkflowClaim' -count=1`
+  - `ok github.com/gastownhall/gascity/cmd/gc 0.868s`
+- PASS: `go test ./cmd/gc -run 'Test(BuildDesiredState_OnDemandNamedSession|BuildDesiredState_SingletonTemplate|DoSlingNudgePool|OnFormulaGraphWorkflowPreassignsNonLatchBeadsForFixedAgent|CmdSlingDefaultFormulaDoesNotMaterializePoolSession|DoSlingFormulaToAgent|OnFormulaGraphWorkflowPokesOnce)' -count=1`
+  - `ok github.com/gastownhall/gascity/cmd/gc 0.633s`
+- PASS: `go test ./cmd/gc -count=1`
+  - `ok github.com/gastownhall/gascity/cmd/gc 374.382s`
+- PASS: `go build ./cmd/gc`
+- PASS: `go vet ./...`
+- TRANSIENT then PASS: `make test-fast-parallel`
+  - First run: failed only `internal/eventfeed TestMuxSource_YieldsAndPicksUpNewCity` after 10s.
+  - Isolation rerun: `go test ./internal/eventfeed -run '^TestMuxSource_YieldsAndPicksUpNewCity$' -count=1 -v` passed in 0.097s.
+  - Full rerun: `make test-fast-parallel` passed all fast jobs.
+
+## Decision
+
+PASS. Open a PR from `builder/ga-7n7vth.3-acp-comment-docs` to `main`, then
+route a merge-request to mayor/mpr. Do not merge from the deployer seat.


### PR DESCRIPTION
Closes #3554

## What this changes

`gc hook --claim` now enqueues a queued nudge to the concrete pool session when that session newly claims a graph.v2 workflow root and pre-assigns continuation siblings. Pool formula sessions can move from the root latch into the first step without an operator manually running `gc session nudge`.

The change also documents the ACP delivery edge: sidecar nudge pollers do not run for ACP sessions, so reliable ACP queued-nudge delivery depends on `daemon.nudge_dispatcher = "supervisor"`. The CHANGELOG includes the operator-facing capacity sizing formula for supervisor-driven graph.v2 runs.

## Review notes

- Main behavior is in `cmd/gc/cmd_hook_claim.go`; `cmd/gc/cmd_hook.go` only threads the city path into the claim path.
- The continuation nudge is best-effort: enqueue failures are logged, but a successful hook claim remains successful.
- No config defaults change. The ACP supervisor dispatcher requirement is documentation, not a behavior flip.
- Focused regression coverage lives in `cmd/gc/cmd_hook_claim_nudge_test.go`.

## Test plan

- [x] `go test ./cmd/gc -run 'TestHookClaim|TestDoHookClaim|TestJSONSchemaManifestForHookClaim|TestJSONSchemaResultForGraphWorkflowClaim' -count=1`
- [x] `go test ./cmd/gc -run 'Test(BuildDesiredState_OnDemandNamedSession|BuildDesiredState_SingletonTemplate|DoSlingNudgePool|OnFormulaGraphWorkflowPreassignsNonLatchBeadsForFixedAgent|CmdSlingDefaultFormulaDoesNotMaterializePoolSession|DoSlingFormulaToAgent|OnFormulaGraphWorkflowPokesOnce)' -count=1`
- [x] `go test ./cmd/gc -count=1`
- [x] `go build ./cmd/gc`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-vkfkfm-acp-hook-continuation-nudge-gate.md`](release-gates/ga-vkfkfm-acp-hook-continuation-nudge-gate.md)
