### PR TITLE
feat(formula): resolve ralph check paths through formula layers

### DIFF
--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -254,7 +254,7 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 }
 
 func ralphCheckTrustedAbsoluteRoots(cityPath, storePath string, formulaSearchPaths []string) []string {
-	roots := make([]string, 0, 2+2*len(formulaSearchPaths))
+	roots := make([]string, 0, 2+3*len(formulaSearchPaths))
 	add := func(root string) {
 		root = strings.TrimSpace(root)
 		if root == "" {
@@ -278,6 +278,11 @@ func ralphCheckTrustedAbsoluteRoots(cityPath, storePath string, formulaSearchPat
 		}
 		clean := filepath.Clean(formulaPath)
 		add(clean)
+		// formula.winningAssetPath resolves a step's "../assets/..." check path
+		// to the layer's sibling assets/ tree, regardless of the layer dir's
+		// name, so trust that sibling for every layer — a formula layer need not
+		// be named "formulas" (e.g. a custom or absolute formulas_dir).
+		add(filepath.Join(filepath.Dir(clean), "assets"))
 		if filepath.Base(clean) == "formulas" {
 			add(filepath.Dir(clean))
 		}

--- a/internal/dispatch/ralph_check_asset_test.go
+++ b/internal/dispatch/ralph_check_asset_test.go
@@ -1,0 +1,214 @@
+package dispatch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/convergence"
+	"github.com/gastownhall/gascity/internal/formula"
+)
+
+// End-to-end for the ../assets check-path feature: a formula authored with the
+// documented "../assets/scripts/checks/<name>" form must (1) compile to the
+// absolute path of the highest-priority layer that ships the script, and
+// (2) that absolute path must pass the ralph check runner's trusted-roots gate
+// via FormulaSearchPaths and actually execute. This is the chain the brittle
+// ".gc/scripts/checks/..." references are migrating to.
+func TestRunRalphCheckAcceptsResolvedAssetPathFromFormulaLayer(t *testing.T) {
+	tmp := t.TempDir()
+	packFormulas := filepath.Join(tmp, "pack", "formulas")
+	packChecks := filepath.Join(tmp, "pack", "assets", "scripts", "checks")
+	cityFormulas := filepath.Join(tmp, "city", "formulas")
+	cityChecks := filepath.Join(tmp, "city", "assets", "scripts", "checks")
+	for _, dir := range []string{packFormulas, packChecks, cityFormulas, cityChecks} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	formulaText := `
+formula = "review"
+
+[[steps]]
+id = "gate"
+title = "Gate"
+[steps.check.check]
+mode = "exec"
+path = "../assets/scripts/checks/review-approved.sh"
+`
+	if err := os.WriteFile(filepath.Join(packFormulas, "review.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	// Both layers ship the script; the city (highest-priority) copy must win and
+	// be the one that runs.
+	for _, dir := range []string{packChecks, cityChecks} {
+		if err := os.WriteFile(filepath.Join(dir, "review-approved.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("write check %s: %v", dir, err)
+		}
+	}
+
+	searchPaths := []string{packFormulas, cityFormulas}
+	f, err := formula.NewParser(searchPaths...).LoadByName("review")
+	if err != nil {
+		t.Fatalf("LoadByName(review): %v", err)
+	}
+	resolved := f.Steps[0].Ralph.Check.Path
+	wantWinner := filepath.Join(cityChecks, "review-approved.sh")
+	if resolved != wantWinner {
+		t.Fatalf("resolved check path = %q, want city shadow %q", resolved, wantWinner)
+	}
+
+	// CityPath/StorePath are deliberately unrelated to the resolved script's
+	// location: the gate must trust it via FormulaSearchPaths (the pack/layer
+	// roots), not via the city/store roots.
+	cityPath := filepath.Join(tmp, "runtime-city")
+	storePath := filepath.Join(tmp, "runtime-store")
+	for _, dir := range []string{cityPath, storePath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-asset-resolved",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    resolved,
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-asset-resolved", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:           cityPath,
+		StorePath:          storePath,
+		FormulaSearchPaths: searchPaths,
+	})
+	if err != nil {
+		t.Fatalf("runRalphCheck rejected the resolved asset path: %v", err)
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("Outcome = %q (stderr=%q), want pass", result.Outcome, result.Stderr)
+	}
+}
+
+// A resolved asset path must still be rejected when its layer is NOT among the
+// trusted FormulaSearchPaths — confirming the feature widens trust only to the
+// formula layers actually in play, not to arbitrary absolute paths.
+func TestRunRalphCheckRejectsAssetPathWhenLayerNotTrusted(t *testing.T) {
+	tmp := t.TempDir()
+	packChecks := filepath.Join(tmp, "pack", "assets", "scripts", "checks")
+	if err := os.MkdirAll(packChecks, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	script := filepath.Join(packChecks, "review-approved.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write check: %v", err)
+	}
+
+	cityPath := filepath.Join(tmp, "city")
+	storePath := filepath.Join(tmp, "store")
+	for _, dir := range []string{cityPath, storePath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-untrusted",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    script,
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-untrusted", Type: "task"}
+
+	// No FormulaSearchPaths → the pack dir is not a trusted root.
+	_, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:  cityPath,
+		StorePath: storePath,
+	})
+	if err == nil {
+		t.Fatalf("expected rejection for asset path outside trusted roots")
+	}
+}
+
+// Regression: a resolved ../assets check path must pass the trusted-roots gate
+// even when the formula layer directory is NOT named "formulas" (e.g. a custom
+// or absolute formulas_dir) and lives outside the city/store trees. The gate
+// must trust the layer's sibling assets/ tree, not just a "formulas"-named
+// layer's parent. Before the fix this failed with "escapes trusted roots".
+func TestRunRalphCheckAcceptsResolvedAssetPathFromNonFormulasLayerName(t *testing.T) {
+	tmp := t.TempDir()
+	// Layer dir named "flows" (a custom formulas_dir), outside city/store.
+	layerDir := filepath.Join(tmp, "ext", "flows")
+	checksDir := filepath.Join(tmp, "ext", "assets", "scripts", "checks")
+	for _, dir := range []string{layerDir, checksDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	formulaText := `
+formula = "review"
+
+[[steps]]
+id = "gate"
+title = "Gate"
+[steps.check.check]
+mode = "exec"
+path = "../assets/scripts/checks/review-approved.sh"
+`
+	if err := os.WriteFile(filepath.Join(layerDir, "review.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(checksDir, "review-approved.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write check: %v", err)
+	}
+
+	searchPaths := []string{layerDir}
+	f, err := formula.NewParser(searchPaths...).LoadByName("review")
+	if err != nil {
+		t.Fatalf("LoadByName(review): %v", err)
+	}
+	resolved := f.Steps[0].Ralph.Check.Path
+	if want := filepath.Join(checksDir, "review-approved.sh"); resolved != want {
+		t.Fatalf("resolved check path = %q, want %q", resolved, want)
+	}
+
+	cityPath := filepath.Join(tmp, "runtime-city")
+	storePath := filepath.Join(tmp, "runtime-store")
+	for _, dir := range []string{cityPath, storePath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-nonformulas-layer",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    resolved,
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-nonformulas-layer", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:           cityPath,
+		StorePath:          storePath,
+		FormulaSearchPaths: searchPaths,
+	})
+	if err != nil {
+		t.Fatalf("runRalphCheck rejected a non-\"formulas\" layer asset path: %v", err)
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("Outcome = %q (stderr=%q), want pass", result.Outcome, result.Stderr)
+	}
+}

--- a/internal/dispatch/ralph_check_asset_test.go
+++ b/internal/dispatch/ralph_check_asset_test.go
@@ -1,10 +1,12 @@
 package dispatch
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/convergence"
 	"github.com/gastownhall/gascity/internal/formula"
@@ -135,6 +137,114 @@ func TestRunRalphCheckRejectsAssetPathWhenLayerNotTrusted(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("expected rejection for asset path outside trusted roots")
+	}
+}
+
+// End-to-end for the templated ../assets check-path fix: an expansion formula
+// authored with "../assets/scripts/checks/{target}.sh" is deferred at parse
+// time, then resolved when runtime fan-out (CompileExpansionFragment)
+// substitutes {target}. The materialized ralph control bead must carry the
+// ABSOLUTE highest-priority layer asset path in gc.check_path — not the relative
+// "../assets/..." form the runtime would resolve against the store/work dir and
+// fail to find — and that absolute path must pass the ralph runner's
+// trusted-roots gate and actually execute.
+func TestRunRalphCheckAcceptsExpandedTemplatedAssetPath(t *testing.T) {
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
+
+	tmp := t.TempDir()
+	packFormulas := filepath.Join(tmp, "pack", "formulas")
+	packChecks := filepath.Join(tmp, "pack", "assets", "scripts", "checks")
+	cityFormulas := filepath.Join(tmp, "city", "formulas")
+	cityChecks := filepath.Join(tmp, "city", "assets", "scripts", "checks")
+	for _, dir := range []string{packFormulas, packChecks, cityFormulas, cityChecks} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	formulaText := `
+formula = "expand-gate"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[[template]]
+id = "{target}.gate"
+title = "Gate"
+[template.ralph]
+max_attempts = 3
+[template.ralph.check]
+mode = "exec"
+path = "../assets/scripts/checks/{target}.sh"
+`
+	if err := os.WriteFile(filepath.Join(packFormulas, "expand-gate.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	// {target} -> "build"; both layers ship build.sh, city (highest) must win.
+	for _, dir := range []string{packChecks, cityChecks} {
+		if err := os.WriteFile(filepath.Join(dir, "build.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("write check %s: %v", dir, err)
+		}
+	}
+
+	searchPaths := []string{packFormulas, cityFormulas}
+	target := &formula.Step{ID: "build", Title: "Build"}
+	fragment, err := formula.CompileExpansionFragment(context.Background(), "expand-gate", searchPaths, target, nil)
+	if err != nil {
+		t.Fatalf("CompileExpansionFragment(expand-gate): %v", err)
+	}
+
+	var resolved string
+	for _, step := range fragment.Steps {
+		if p := step.Metadata[beadmeta.CheckPathMetadataKey]; p != "" {
+			resolved = p
+			break
+		}
+	}
+	if resolved == "" {
+		t.Fatal("no materialized step carried a gc.check_path")
+	}
+	if !filepath.IsAbs(resolved) {
+		t.Fatalf("materialized gc.check_path = %q, want an absolute layer asset path", resolved)
+	}
+	if want := filepath.Join(cityChecks, "build.sh"); resolved != want {
+		t.Fatalf("materialized gc.check_path = %q, want city shadow %q", resolved, want)
+	}
+
+	// The resolved absolute path must pass the runtime trusted-roots gate (via
+	// FormulaSearchPaths) and actually execute. CityPath/StorePath are unrelated
+	// to the script location on purpose.
+	cityPath := filepath.Join(tmp, "runtime-city")
+	storePath := filepath.Join(tmp, "runtime-store")
+	for _, dir := range []string{cityPath, storePath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-expanded-templated",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    resolved,
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-expanded-templated", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:           cityPath,
+		StorePath:          storePath,
+		FormulaSearchPaths: searchPaths,
+	})
+	if err != nil {
+		t.Fatalf("runRalphCheck rejected the expanded templated asset path: %v", err)
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("Outcome = %q (stderr=%q), want pass", result.Outcome, result.Stderr)
 	}
 }
 

--- a/internal/formula/check_path_resolve_test.go
+++ b/internal/formula/check_path_resolve_test.go
@@ -1,9 +1,12 @@
 package formula
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
 )
 
 // A ralph check path written in the documented ../assets/ form must resolve,
@@ -141,8 +144,11 @@ path = "/opt/tooling/checks/foo.sh"
 }
 
 // A check path whose script name still carries a template placeholder is
-// substituted later (expand time), so resolveCheckPaths must leave it untouched
-// — even in strict mode — rather than failing on the literal placeholder.
+// substituted later (expand time), so parse-time resolveCheckPaths must leave it
+// untouched — even in strict mode — rather than failing on the literal
+// placeholder. The placeholder is resolved once expansion substitutes it; see
+// TestCompileResolvesExpandedTemplatedAssetCheckPath and the dispatch end-to-end
+// TestRunRalphCheckAcceptsExpandedTemplatedAssetPath.
 func TestResolveCheckPathsDefersTemplatedAssetPathInStrictMode(t *testing.T) {
 	tmp := t.TempDir()
 	layer := filepath.Join(tmp, "pack", "formulas")
@@ -182,5 +188,67 @@ func TestResolveCheckPathsStrictErrorsOnMissingLiteralAsset(t *testing.T) {
 	p := NewParser(layer)
 	if err := p.resolveCheckPaths(steps, layer, true /* strict */); err == nil {
 		t.Fatalf("expected strict error for missing ../assets check script")
+	}
+}
+
+// A templated "../assets/..." check path in an expansion formula is deferred at
+// parse time, then resolved once Compile materializes the expansion and
+// substitutes {target}. The compiled control bead must carry the absolute layer
+// asset path in gc.check_path — not the relative "../assets/..." form, which the
+// runtime would resolve against the store/work dir and fail to find. This covers
+// the compile-time materialization path (Stage 9 MaterializeExpansion).
+func TestCompileResolvesExpandedTemplatedAssetCheckPath(t *testing.T) {
+	enableV2ForTest(t)
+	tmp := t.TempDir()
+	packFormulas := filepath.Join(tmp, "pack", "formulas")
+	packChecks := filepath.Join(tmp, "pack", "assets", "scripts", "checks")
+	for _, dir := range []string{packFormulas, packChecks} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	// Standalone expansion: Compile materializes it with target id "main", so
+	// "{target}" substitutes to "main" before the check path is resolved.
+	formulaText := `
+formula = "gated-expansion"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[[template]]
+id = "{target}.gate"
+title = "Gate"
+[template.ralph]
+max_attempts = 3
+[template.ralph.check]
+mode = "exec"
+path = "../assets/scripts/checks/{target}.sh"
+`
+	if err := os.WriteFile(filepath.Join(packFormulas, "gated-expansion.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	script := filepath.Join(packChecks, "main.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write check: %v", err)
+	}
+
+	recipe, err := Compile(context.Background(), "gated-expansion", []string{packFormulas}, nil)
+	if err != nil {
+		t.Fatalf("Compile(gated-expansion): %v", err)
+	}
+
+	var got string
+	for _, step := range recipe.Steps {
+		if p := step.Metadata[beadmeta.CheckPathMetadataKey]; p != "" {
+			got = p
+			break
+		}
+	}
+	if got == "" {
+		t.Fatal("no materialized recipe step carried a gc.check_path")
+	}
+	if got != script {
+		t.Fatalf("materialized gc.check_path = %q, want absolute layer asset %q", got, script)
 	}
 }

--- a/internal/formula/check_path_resolve_test.go
+++ b/internal/formula/check_path_resolve_test.go
@@ -1,0 +1,186 @@
+package formula
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A ralph check path written in the documented ../assets/ form must resolve,
+// at parse time, to the highest-priority formula layer that ships the script —
+// mirroring how description_file assets shadow. This lets a city/local layer
+// override a pack's check script without forking the formula.
+func TestCheckPathUsesHighestPriorityAssetLayer(t *testing.T) {
+	tmp := t.TempDir()
+	coreFormulas := filepath.Join(tmp, "core", "formulas")
+	coreChecks := filepath.Join(tmp, "core", "assets", "scripts", "checks")
+	cityFormulas := filepath.Join(tmp, "city", "formulas")
+	cityChecks := filepath.Join(tmp, "city", "assets", "scripts", "checks")
+	for _, dir := range []string{coreFormulas, coreChecks, cityFormulas, cityChecks} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	formulaText := `
+formula = "review"
+
+[[steps]]
+id = "gate"
+title = "Gate"
+[steps.check]
+max_attempts = 3
+[steps.check.check]
+mode = "exec"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
+`
+	if err := os.WriteFile(filepath.Join(coreFormulas, "review.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	// Both layers ship the script; the city (highest-priority) copy must win.
+	for _, dir := range []string{coreChecks, cityChecks} {
+		if err := os.WriteFile(filepath.Join(dir, "build-artifact-valid.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("write check %s: %v", dir, err)
+		}
+	}
+
+	p := NewParser(coreFormulas, cityFormulas)
+	f, err := p.LoadByName("review")
+	if err != nil {
+		t.Fatalf("LoadByName(review): %v", err)
+	}
+	want := filepath.Join(cityChecks, "build-artifact-valid.sh")
+	got := f.Steps[0].Ralph.Check.Path
+	if got != want {
+		t.Fatalf("check path = %q, want city asset shadow %q", got, want)
+	}
+}
+
+// When only a lower-priority layer ships the script, the check path resolves to
+// that pack's copy (fallback), exactly like description_file resolution.
+func TestCheckPathFallsBackToFormulaPackAsset(t *testing.T) {
+	tmp := t.TempDir()
+	coreFormulas := filepath.Join(tmp, "core", "formulas")
+	coreChecks := filepath.Join(tmp, "core", "assets", "scripts", "checks")
+	cityFormulas := filepath.Join(tmp, "city", "formulas")
+	for _, dir := range []string{coreFormulas, coreChecks, cityFormulas} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	formulaText := `
+formula = "triage"
+
+[[steps]]
+id = "gate"
+title = "Gate"
+[steps.check.check]
+mode = "exec"
+path = "../assets/scripts/checks/review-approved.sh"
+`
+	if err := os.WriteFile(filepath.Join(coreFormulas, "triage.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(coreChecks, "review-approved.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write core check: %v", err)
+	}
+
+	p := NewParser(coreFormulas, cityFormulas)
+	f, err := p.LoadByName("triage")
+	if err != nil {
+		t.Fatalf("LoadByName(triage): %v", err)
+	}
+	want := filepath.Join(coreChecks, "review-approved.sh")
+	got := f.Steps[0].Ralph.Check.Path
+	if got != want {
+		t.Fatalf("check path = %q, want core asset fallback %q", got, want)
+	}
+}
+
+// Non-asset check paths (legacy .gc/ runtime paths, absolute paths) must be
+// left exactly as authored — the resolver only rewrites the ../assets/ form.
+func TestCheckPathKeepsNonAssetPathsUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+	formulas := filepath.Join(tmp, "pack", "formulas")
+	if err := os.MkdirAll(formulas, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	formulaText := `
+formula = "legacy"
+
+[[steps]]
+id = "gate-gc"
+title = "Legacy runtime path"
+[steps.check.check]
+mode = "exec"
+path = ".gc/scripts/checks/build-artifact-valid.sh"
+
+[[steps]]
+id = "gate-abs"
+title = "Absolute path"
+[steps.check.check]
+mode = "exec"
+path = "/opt/tooling/checks/foo.sh"
+`
+	if err := os.WriteFile(filepath.Join(formulas, "legacy.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	f, err := NewParser(formulas).LoadByName("legacy")
+	if err != nil {
+		t.Fatalf("LoadByName(legacy): %v", err)
+	}
+	if got := f.Steps[0].Ralph.Check.Path; got != ".gc/scripts/checks/build-artifact-valid.sh" {
+		t.Fatalf("legacy .gc path rewritten to %q, want unchanged", got)
+	}
+	if got := f.Steps[1].Ralph.Check.Path; got != "/opt/tooling/checks/foo.sh" {
+		t.Fatalf("absolute path rewritten to %q, want unchanged", got)
+	}
+}
+
+// A check path whose script name still carries a template placeholder is
+// substituted later (expand time), so resolveCheckPaths must leave it untouched
+// — even in strict mode — rather than failing on the literal placeholder.
+func TestResolveCheckPathsDefersTemplatedAssetPathInStrictMode(t *testing.T) {
+	tmp := t.TempDir()
+	layer := filepath.Join(tmp, "pack", "formulas")
+	if err := os.MkdirAll(layer, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	const templated = "../assets/scripts/checks/{target}.sh"
+	steps := []*Step{{
+		ID:    "gate",
+		Ralph: &RalphSpec{Check: &RalphCheckSpec{Mode: "exec", Path: templated}},
+	}}
+
+	p := NewParser(layer)
+	if err := p.resolveCheckPaths(steps, layer, true /* strict */); err != nil {
+		t.Fatalf("strict resolveCheckPaths errored on templated check path: %v", err)
+	}
+	if got := steps[0].Ralph.Check.Path; got != templated {
+		t.Fatalf("templated check path = %q, want left untouched %q", got, templated)
+	}
+}
+
+// Strict mode must still fail fast on a genuinely missing (non-templated)
+// ../assets check script — surfacing the typo/missing file at cook time.
+func TestResolveCheckPathsStrictErrorsOnMissingLiteralAsset(t *testing.T) {
+	tmp := t.TempDir()
+	layer := filepath.Join(tmp, "pack", "formulas")
+	if err := os.MkdirAll(layer, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	steps := []*Step{{
+		ID:    "gate",
+		Ralph: &RalphSpec{Check: &RalphCheckSpec{Mode: "exec", Path: "../assets/scripts/checks/missing.sh"}},
+	}}
+
+	p := NewParser(layer)
+	if err := p.resolveCheckPaths(steps, layer, true /* strict */); err == nil {
+		t.Fatalf("expected strict error for missing ../assets check script")
+	}
+}

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -181,6 +181,14 @@ func compileFormula(name string, searchPaths []string, vars map[string]string, v
 	}
 	resolved.Steps = retrySteps
 
+	// Resolve "../assets/..." check paths whose {target}/{{var}} placeholders
+	// expansion has now substituted, before ApplyRalph freezes them into
+	// gc.check_path. Parse time defers templated asset paths; this is where the
+	// now-concrete path becomes the absolute layer asset.
+	if err := parser.resolveExpandedCheckPaths(resolved); err != nil {
+		return nil, fmt.Errorf("resolving expanded check paths in %q: %w", name, err)
+	}
+
 	// Stage 11: Expand inline Ralph steps
 	ralphSteps, err := ApplyRalph(resolved.Steps)
 	if err != nil {

--- a/internal/formula/fragment.go
+++ b/internal/formula/fragment.go
@@ -123,6 +123,14 @@ func CompileExpansionFragment(_ context.Context, name string, searchPaths []stri
 	}
 	resolved.Steps = retrySteps
 
+	// Resolve "../assets/..." check paths whose {target}/{{var}} placeholders
+	// MaterializeExpansionForTarget has now substituted, before ApplyRalph
+	// freezes them into gc.check_path. Without this a templated asset check
+	// materializes a relative path the runtime cannot find in the layer tree.
+	if err := parser.resolveExpandedCheckPaths(resolved); err != nil {
+		return nil, fmt.Errorf("resolving expanded check paths in expansion %q: %w", name, err)
+	}
+
 	ralphSteps, err := ApplyRalph(resolved.Steps)
 	if err != nil {
 		return nil, fmt.Errorf("applying ralph transforms to expansion %q: %w", name, err)

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -874,7 +874,8 @@ func (p *Parser) winningAssetPath(rawPath string) (string, bool) {
 	return winner, true
 }
 
-// resolveCheckPaths rewrites ralph check paths written in the documented
+// resolveCheckPaths walks steps (and their children and loop bodies) and
+// rewrites each ralph check path written in the documented
 // "../assets/scripts/checks/<name>" form to the absolute path of the
 // highest-priority formula layer that ships the script, mirroring how
 // description_file assets shadow. Legacy/non-asset paths (e.g. ".gc/..." or
@@ -887,22 +888,8 @@ func (p *Parser) resolveCheckPaths(steps []*Step, baseDir string, strict bool) e
 		if step == nil {
 			continue
 		}
-		if step.Ralph != nil && step.Ralph.Check != nil {
-			raw := step.Ralph.Check.Path
-			// A check path that still carries a template placeholder (e.g.
-			// "../assets/scripts/checks/{target}.sh") is substituted later, at
-			// expand time, so it cannot be layer-resolved against on-disk files
-			// here. Leave it untouched rather than misresolving — or, in strict
-			// mode, erroring — on the literal placeholder.
-			if !strings.Contains(raw, "{") {
-				if resolved, ok := p.resolveCheckAssetPath(raw, baseDir); ok {
-					step.Ralph.Check.Path = resolved
-				} else if strict {
-					if _, isAsset := descriptionAssetRelPath(raw); isAsset {
-						return fmt.Errorf("step %q: check path %q not found in any formula layer", step.ID, raw)
-					}
-				}
-			}
+		if err := p.resolveStepCheckPath(step, baseDir, strict); err != nil {
+			return err
 		}
 		if err := p.resolveCheckPaths(step.Children, baseDir, strict); err != nil {
 			return err
@@ -914,6 +901,45 @@ func (p *Parser) resolveCheckPaths(steps []*Step, baseDir string, strict bool) e
 		}
 	}
 	return nil
+}
+
+// resolveStepCheckPath rewrites a single step's "../assets/..." ralph check
+// path to its absolute layer asset. A path that still carries a template
+// placeholder (e.g. "../assets/scripts/checks/{target}.sh") is deferred: the
+// placeholder is substituted at expand time, so it cannot be matched against
+// on-disk files here. resolveExpandedCheckPaths re-runs this resolution once
+// expansion has substituted the placeholder. In strict (graph.v2) mode a
+// non-templated ../assets path that no formula layer ships is a compile error.
+func (p *Parser) resolveStepCheckPath(step *Step, baseDir string, strict bool) error {
+	if step.Ralph == nil || step.Ralph.Check == nil {
+		return nil
+	}
+	raw := step.Ralph.Check.Path
+	if strings.Contains(raw, "{") {
+		return nil
+	}
+	if resolved, ok := p.resolveCheckAssetPath(raw, baseDir); ok {
+		step.Ralph.Check.Path = resolved
+		return nil
+	}
+	if strict {
+		if _, isAsset := descriptionAssetRelPath(raw); isAsset {
+			return fmt.Errorf("step %q: check path %q not found in any formula layer", step.ID, raw)
+		}
+	}
+	return nil
+}
+
+// resolveExpandedCheckPaths re-resolves "../assets/..." ralph check paths after
+// expansion substitutes {target}/{{var}} placeholders into them. A templated
+// check path is deferred at parse time (see resolveStepCheckPath); once
+// expansion makes it concrete the path must be resolved to its absolute layer
+// asset before ApplyRalph stamps it into gc.check_path, otherwise the runtime
+// receives a relative "../assets/..." path, resolves it against the store/work
+// dir, and the check fails instead of running the shipped script. Idempotent
+// for paths that are already absolute, non-asset, or still templated.
+func (p *Parser) resolveExpandedCheckPaths(f *Formula) error {
+	return p.resolveCheckPaths(f.Steps, descriptionFileBaseDir(f.Source), UsesGraphCompiler(f))
 }
 
 // resolveCheckAssetPath resolves a "../assets/<rel>" check path to an absolute

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -190,6 +190,12 @@ func (p *Parser) parseResolvedAt(data []byte, absPath, label string) (*Formula, 
 	if err := p.resolveDescriptionFiles(f.Template, formulaDir, strictDescriptionFiles, f.Vars); err != nil {
 		return nil, fmt.Errorf("resolve description_file in %s: %w", label, err)
 	}
+	if err := p.resolveCheckPaths(f.Steps, formulaDir, strictDescriptionFiles); err != nil {
+		return nil, fmt.Errorf("resolve check path in %s: %w", label, err)
+	}
+	if err := p.resolveCheckPaths(f.Template, formulaDir, strictDescriptionFiles); err != nil {
+		return nil, fmt.Errorf("resolve check path in %s: %w", label, err)
+	}
 
 	p.cache[absPath] = f
 
@@ -832,18 +838,9 @@ func (p *Parser) resolveDescriptionFiles(steps []*Step, baseDir string, strict b
 }
 
 func (p *Parser) readDescriptionFile(rawPath, baseDir string) ([]byte, string, error) {
-	if assetRel, ok := descriptionAssetRelPath(rawPath); ok {
-		var winner string
-		for _, layer := range p.searchPaths {
-			candidate := filepath.Join(filepath.Dir(layer), "assets", filepath.FromSlash(assetRel))
-			if p.source.Stat(candidate) {
-				winner = candidate
-			}
-		}
-		if winner != "" {
-			data, err := p.source.ReadFile(winner)
-			return data, winner, err
-		}
+	if winner, ok := p.winningAssetPath(rawPath); ok {
+		data, err := p.source.ReadFile(winner)
+		return data, winner, err
 	}
 
 	path := rawPath
@@ -852,6 +849,90 @@ func (p *Parser) readDescriptionFile(rawPath, baseDir string) ([]byte, string, e
 	}
 	data, err := p.source.ReadFile(path)
 	return data, path, err
+}
+
+// winningAssetPath resolves a documented "../assets/<rel>" reference to the
+// highest-priority formula layer that ships the asset. searchPaths are ordered
+// lowest→highest priority, so the last matching layer wins — the same
+// shadowing rule description_file assets use. Returns ("", false) when rawPath
+// is not in the ../assets/ form or no layer ships the asset.
+func (p *Parser) winningAssetPath(rawPath string) (string, bool) {
+	assetRel, ok := descriptionAssetRelPath(rawPath)
+	if !ok {
+		return "", false
+	}
+	var winner string
+	for _, layer := range p.searchPaths {
+		candidate := filepath.Join(filepath.Dir(layer), "assets", filepath.FromSlash(assetRel))
+		if p.source.Stat(candidate) {
+			winner = candidate
+		}
+	}
+	if winner == "" {
+		return "", false
+	}
+	return winner, true
+}
+
+// resolveCheckPaths rewrites ralph check paths written in the documented
+// "../assets/scripts/checks/<name>" form to the absolute path of the
+// highest-priority formula layer that ships the script, mirroring how
+// description_file assets shadow. Legacy/non-asset paths (e.g. ".gc/..." or
+// an absolute path) are left untouched. In strict (graph.v2) mode an
+// ../assets/ check that resolves to nothing is a compile error, surfacing a
+// missing or misspelled check script at cook time instead of as a confusing
+// runtime "escapes trusted roots" failure.
+func (p *Parser) resolveCheckPaths(steps []*Step, baseDir string, strict bool) error {
+	for _, step := range steps {
+		if step == nil {
+			continue
+		}
+		if step.Ralph != nil && step.Ralph.Check != nil {
+			raw := step.Ralph.Check.Path
+			// A check path that still carries a template placeholder (e.g.
+			// "../assets/scripts/checks/{target}.sh") is substituted later, at
+			// expand time, so it cannot be layer-resolved against on-disk files
+			// here. Leave it untouched rather than misresolving — or, in strict
+			// mode, erroring — on the literal placeholder.
+			if !strings.Contains(raw, "{") {
+				if resolved, ok := p.resolveCheckAssetPath(raw, baseDir); ok {
+					step.Ralph.Check.Path = resolved
+				} else if strict {
+					if _, isAsset := descriptionAssetRelPath(raw); isAsset {
+						return fmt.Errorf("step %q: check path %q not found in any formula layer", step.ID, raw)
+					}
+				}
+			}
+		}
+		if err := p.resolveCheckPaths(step.Children, baseDir, strict); err != nil {
+			return err
+		}
+		if step.Loop != nil {
+			if err := p.resolveCheckPaths(step.Loop.Body, baseDir, strict); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// resolveCheckAssetPath resolves a "../assets/<rel>" check path to an absolute
+// script path: the highest-priority layer that ships it, falling back to the
+// formula's own pack asset (baseDir-relative) so a formula parsed outside its
+// layer set still resolves its shipped script. Returns ("", false) for
+// non-asset paths or when nothing ships the script.
+func (p *Parser) resolveCheckAssetPath(rawPath, baseDir string) (string, bool) {
+	if _, ok := descriptionAssetRelPath(rawPath); !ok {
+		return "", false
+	}
+	if winner, ok := p.winningAssetPath(rawPath); ok {
+		return winner, true
+	}
+	candidate := filepath.Clean(filepath.Join(baseDir, filepath.FromSlash(rawPath)))
+	if p.source.Stat(candidate) {
+		return candidate, true
+	}
+	return "", false
 }
 
 func descriptionAssetRelPath(rawPath string) (string, bool) {


### PR DESCRIPTION
## Summary

Lets a formula's ralph exec-check `path` be written in the documented `../assets/scripts/checks/<name>.sh` form — symmetric with `description_file` — and resolves it **at parse time** to the absolute path of the highest-priority formula layer that ships the script (last-wins shadowing). Packs can then reference check scripts by their real, layered location instead of hardcoding the brittle `.gc/scripts/checks/...` runtime path, and a city/local layer can override a pack's check script without forking the formula.

## Why

`.gc/scripts/checks/` is not populated from pack `assets/scripts/checks/` by any in-tree mechanism on `main` (the legacy `ResolveScripts` symlink shim is retired — `script_resolve.go` only prunes it now; `template_resolve.go` copies the deprecated top-level city `scripts/`, which packs no longer ship). Integration tests stage those scripts by hand (`review_check_scripts_test.go` copies the embedded pack's `assets/scripts/checks/` into `.gc/scripts/checks/`), so a pack-shipped check referenced as `.gc/scripts/checks/X.sh` has nothing materializing it in a real city. This change gives formulas a way to point at the script's actual layered location directly, with layer shadowing, and no materialization step.

## What changed

- **`internal/formula/parser.go`** — `resolveCheckPaths` / `resolveCheckAssetPath` reuse the existing `description_file` asset-shadowing walk (`winningAssetPath`, last-wins across `searchPaths`). Wired into `Parse` alongside `resolveDescriptionFiles` for `f.Steps` and `f.Template`.
  - Non-asset paths (`.gc/...`, absolute) are left **untouched**.
  - In strict (graph.v2) mode a missing `../assets` check is a **compile error** (surfaces a typo at cook time rather than a confusing runtime failure).
  - Paths still carrying a template placeholder (e.g. `{target}`) are **deferred** to expand time, not resolved/errored here.
- **`internal/dispatch/ralph.go`** — `ralphCheckTrustedAbsoluteRoots` trusts each formula layer's sibling `assets/` tree, so a resolved absolute check path passes the runtime trusted-roots gate regardless of the layer dir's name (custom or absolute `formulas_dir`), not only when it is literally `"formulas"`.

## Backward compatibility

Purely additive. Existing `.gc/scripts/...` and absolute check paths behave exactly as before; **no current formula uses the `../assets` form**, so nothing changes at runtime today. The `readDescriptionFile` refactor (extracting `winningAssetPath`) is behavior-preserving.

## Quality

Built with TDD (red → green). Ran an adversarial red-team workflow over the diff; it confirmed two issues, both fixed here with regression tests, then re-verified clean:
1. **Trusted-roots asymmetry** — the resolver targets `<layer-parent>/assets` for any layer, but the gate only trusted the parent of a literally-`"formulas"`-named layer → a resolved path under a custom/absolute `formulas_dir` was rejected at runtime. Fixed by trusting the `assets/` sibling of every layer (narrowly — the sibling, not the whole parent; fail-closed semantics preserved).
2. **Templated check path in strict mode** — resolution runs before var-substitution, so `../assets/.../{target}.sh` hard-errored on the literal placeholder. Fixed by deferring placeholder-bearing paths.

## Known limitations (deferred, fail-closed)

- A `../assets` check shipped by a **rig** pack whose ralph step executes in **city** context can resolve to a rig-layer path not in the control bead's runtime `FormulaSearchPaths` → rejected at runtime. The bundled gascity pack installs as a **city** pack (compile/runtime layers agree), so the migration target is unaffected.
- The `baseDir` fallback in `resolveCheckAssetPath` can stamp a path outside trusted roots for a formula loaded outside its layer set; the runtime gate rejects it (fail-closed), never admits it.

## Test plan

- `internal/formula`: layer shadowing, lower-layer fallback, non-asset passthrough, strict missing-asset error, templated-path deferral.
- `internal/dispatch`: resolved asset path passes the gate and execs; non-`"formulas"`-named layer accepted; untrusted layer rejected.
- `go build ./...`, `go vet`, and full `./internal/formula` + `./internal/dispatch` suites green.

## Follow-up (separate PR, dependent on this)

Migrate gascity-packs formulas from `.gc/scripts/checks/*` → `../assets/scripts/checks/*` (78 check-path lines, 3 scripts) and update the prompt bodies that instruct manual runs; then bump the embedded pack pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)