### PR TITLE
fix(hook): self-propel pool graph workflows after root claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pool graph.v2 sessions no longer idle after claiming a workflow root.**
+  `gc hook --claim` now enqueues a queued nudge to the concrete claiming session
+  (e.g. `pool-worker/slot-0`) when it newly claims a workflow root and
+  pre-assigns at least one continuation sibling. Previously the sling-time nudge
+  targeted the pool template name, which is pruned as undeliverable once the
+  concrete session exists, leaving the session idle until manual operator
+  intervention via `gc session nudge`.
+
+  **ACP operator note:** in default (non-supervisor) dispatcher mode, the
+  hook-claim nudge is delivered by a sidecar poller for tmux/subprocess sessions.
+  ACP sessions do not support a sidecar poller; the nudge will be consumed at
+  the next hook-drain instead. For reliable ACP queued delivery, configure:
+
+  ```toml
+  [daemon]
+  nudge_dispatcher = "supervisor"
+  ```
+
+  **In-flight sizing:** with `nudge_dispatcher = "supervisor"`, plan capacity
+  for `max_concurrent_formulas × (1 + max_parallel_steps)` in-flight sessions.
+  A typical graph.v2 run holds one workflow root plus one active step; a formula
+  with two parallel steps holds one root plus two active steps at peak.
+
 - **Pin the `beads` dependency to the stable v1.0.4.** v1.3.0 built against
   `beads v1.0.5`, which was subsequently withdrawn (demoted to a pre-release;
   `v1.0.4` is the current stable release). v1.3.1 repins the `beads` Go module

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -379,6 +379,7 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 			Env:          queryEnv,
 			DrainAck:     opts.DrainAck,
 			JSON:         opts.JSON,
+			CityPath:     cityPath,
 		}
 		return claimHookWork(workQuery, workDir, queryEnv, stores, claimOpts, emitQueryFailure, stdout, stderr)
 	}

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -26,6 +26,10 @@ type hookClaimOptions struct {
 	Env                []string
 	DrainAck           bool
 	JSON               bool
+	// CityPath is the city root directory, threaded to the continuation nudge
+	// enqueue seam so the production implementation can locate the nudge store.
+	// Empty in tests that inject a fake EnqueueContinuationNudge.
+	CityPath string
 }
 
 type hookClaimOps struct {
@@ -47,18 +51,26 @@ type hookClaimOps struct {
 	// AND gc.active_work_bead (the claimed work bead's gc.step_id) — in ONE update, so
 	// the (run, step) tuple stays atomically consistent. Best-effort.
 	RecordSessionPointers hookRecordSessionPointersFunc
-	Now                   func() time.Time
+	// EnqueueContinuationNudge enqueues the hook-claim-continuation nudge that
+	// propels a pool graph.v2 session from root-claim into step 1 without
+	// operator intervention. Called when a new workflow root is claimed and at
+	// least one continuation sibling was pre-assigned. Best-effort; enqueue
+	// failure is logged but never blocks the claim. See ga-7n7vth.2 for the
+	// call site that activates this seam in production.
+	EnqueueContinuationNudge hookEnqueueContinuationNudgeFunc
+	Now                      func() time.Time
 }
 
 type (
-	hookClaimFunc                 func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
-	hookListContinuationFunc      func(context.Context, string, []string, string, string) ([]beads.Bead, error)
-	hookAssignContinuationFunc    func(context.Context, string, []string, string, string) error
-	hookDrainAckFunc              func(io.Writer) error
-	hookEmitClaimRejectedFunc     func(beadID, existingClaimant, attemptedClaimant string)
-	hookResolveWorkBranchFunc     func(dir string) string
-	hookStampWorkBranchFunc       func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
-	hookRecordSessionPointersFunc func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
+	hookClaimFunc                    func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
+	hookListContinuationFunc         func(context.Context, string, []string, string, string) ([]beads.Bead, error)
+	hookAssignContinuationFunc       func(context.Context, string, []string, string, string) error
+	hookDrainAckFunc                 func(io.Writer) error
+	hookEmitClaimRejectedFunc        func(beadID, existingClaimant, attemptedClaimant string)
+	hookResolveWorkBranchFunc        func(dir string) string
+	hookStampWorkBranchFunc          func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
+	hookEnqueueContinuationNudgeFunc func(cityPath string, item queuedNudge) error
+	hookRecordSessionPointersFunc    func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
 )
 
 type hookClaimJSONResult struct {
@@ -181,6 +193,9 @@ func (ops *hookClaimOps) applyDefaults() {
 	}
 	if ops.RecordSessionPointers == nil {
 		ops.RecordSessionPointers = hookRecordSessionPointersWithBdStore
+	}
+	if ops.EnqueueContinuationNudge == nil {
+		ops.EnqueueContinuationNudge = enqueueQueuedNudge
 	}
 }
 

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -17,6 +17,16 @@ import (
 
 const hookClaimCommandName = "hook"
 
+const (
+	// hookClaimContinuationNudgeSource is the source tag on the queued nudge
+	// that propels a pool graph.v2 session from root-claim into step 1.
+	hookClaimContinuationNudgeSource = "hook-claim-continuation"
+	// hookClaimContinuationNudgeMessage is the standard propulsion message
+	// delivered to the claiming session after a workflow root is claimed with
+	// continuation siblings pre-assigned.
+	hookClaimContinuationNudgeMessage = "Work slung. Check your hook."
+)
+
 var hookClaimMutationTimeout = 10 * time.Second
 
 type hookClaimOptions struct {
@@ -331,6 +341,11 @@ func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead
 		return 1
 	}
 	result.ContinuationAssigned = assigned
+	if result.Reason == "claimed" &&
+		len(assigned) > 0 &&
+		strings.TrimSpace(bead.Metadata[beadmeta.KindMetadataKey]) == beadmeta.KindWorkflow {
+		hookClaimEnqueueContinuationNudge(opts, ops, stderr)
+	}
 	if opts.JSON {
 		if err := writeCLIJSONLine(stdout, result); err != nil {
 			fmt.Fprintf(stderr, "gc hook --claim: writing JSON: %v\n", err) //nolint:errcheck
@@ -340,6 +355,24 @@ func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead
 	}
 	fmt.Fprintln(stdout, result.BeadID) //nolint:errcheck
 	return 0
+}
+
+// hookClaimEnqueueContinuationNudge enqueues the per-session nudge that
+// propels a pool graph.v2 session from root-claim into step 1 without operator
+// intervention. Best-effort: enqueue failure is logged but never converts a
+// successful hook claim into a user-visible error.
+func hookClaimEnqueueContinuationNudge(opts hookClaimOptions, ops hookClaimOps, stderr io.Writer) {
+	now := time.Now
+	if ops.Now != nil {
+		now = ops.Now
+	}
+	item := newQueuedNudgeWithOptions(opts.Assignee, hookClaimContinuationNudgeMessage, hookClaimContinuationNudgeSource, now(), queuedNudgeOptions{})
+	if err := ops.EnqueueContinuationNudge(opts.CityPath, item); err != nil {
+		fmt.Fprintf(stderr, "gc hook --claim: enqueue continuation nudge: %v\n", err) //nolint:errcheck
+		return
+	}
+	maybeStartNudgePoller(nudgeTarget{cityPath: opts.CityPath, sessionName: opts.Assignee})
+	_ = pokeController(opts.CityPath)
 }
 
 // writeHookClaimNoWork writes the single drain result for a hook that claimed

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -371,6 +371,11 @@ func hookClaimEnqueueContinuationNudge(opts hookClaimOptions, ops hookClaimOps, 
 		fmt.Fprintf(stderr, "gc hook --claim: enqueue continuation nudge: %v\n", err) //nolint:errcheck
 		return
 	}
+	// ACP note: maybeStartNudgePoller returns early without transport context
+	// when the target session uses the ACP runtime. In that case the queued
+	// nudge is delivered only at the next hook-drain, not by a sidecar poller.
+	// Configure daemon.nudge_dispatcher = "supervisor" for reliable queued
+	// delivery to ACP sessions.
 	maybeStartNudgePoller(nudgeTarget{cityPath: opts.CityPath, sessionName: opts.Assignee})
 	_ = pokeController(opts.CityPath)
 }

--- a/cmd/gc/cmd_hook_claim_nudge_test.go
+++ b/cmd/gc/cmd_hook_claim_nudge_test.go
@@ -1,0 +1,298 @@
+package main
+
+// Tests for the hook-claim-continuation nudge enqueue seam (ga-7n7vth.1).
+//
+// These tests define the expected behavior for ga-7n7vth.2:
+//
+//   - A newly claimed pool graph.v2 workflow root that pre-assigns at least one
+//     continuation sibling must enqueue exactly one queued nudge with source
+//     "hook-claim-continuation", targeting the claiming session by name, using
+//     the canonical propulsion message.
+//   - Non-workflow step-bead claims must not enqueue the nudge.
+//   - Re-found existing assignments must not enqueue the nudge (idempotence).
+//   - Workflow root claims with zero continuation siblings must not enqueue.
+//
+// All tests that assert the nudge IS enqueued (TestHookClaimWorkflowRootEnqueuesContinuationNudge)
+// fail against the current codebase until ga-7n7vth.2 adds the call site in
+// writeHookClaimWorkResultForBead. Tests that assert the nudge is NOT enqueued
+// pass now and serve as guardrails against over-enqueueing after the fix lands.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+const (
+	hookClaimContinuationNudgeSource  = "hook-claim-continuation"
+	hookClaimContinuationNudgeMessage = "Work slung. Check your hook."
+)
+
+// makeWorkflowRootBead returns a bead shaped like a pool graph.v2 workflow root
+// ready to be claimed: gc.kind=workflow, gc.run_target pointing at the pool
+// template, and gc.root_bead_id / gc.continuation_group so pre-assignment runs.
+func makeWorkflowRootBead(id, runTarget, rootID, continuationGroup string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "workflow",
+			"gc.run_target":         runTarget,
+			"gc.root_bead_id":       rootID,
+			"gc.continuation_group": continuationGroup,
+		},
+	}
+}
+
+// makeStepBead returns a bead shaped like a formula step (gc.kind=step) with
+// the same continuation metadata a workflow root has. Step beads reach the
+// work queue via gc.routed_to (set by preassignHookContinuationGroup), not
+// via gc.run_target, so routedTo is the claiming session name.
+func makeStepBead(id, routedTo, rootID, continuationGroup string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "step",
+			"gc.routed_to":          routedTo,
+			"gc.root_bead_id":       rootID,
+			"gc.continuation_group": continuationGroup,
+		},
+	}
+}
+
+// captureNudgeOps returns a hookClaimOps that captures the city path and nudge
+// item passed to EnqueueContinuationNudge. The capture is written to *calls.
+func captureNudgeOps(t *testing.T, calls *[]queuedNudge, bead beads.Bead, sibling beads.Bead) hookClaimOps {
+	t.Helper()
+	output, err := json.Marshal([]beads.Bead{bead})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(output), nil },
+		Claim: func(_ context.Context, _ string, _ []string, _, assignee string) (beads.Bead, bool, error) {
+			claimed := bead
+			claimed.Assignee = assignee
+			claimed.Status = "in_progress"
+			return claimed, true, nil
+		},
+		ListContinuation: func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) {
+			if sibling.ID == "" {
+				return nil, nil
+			}
+			return []beads.Bead{sibling}, nil
+		},
+		AssignContinuation: func(_ context.Context, _ string, _ []string, _, _ string) error {
+			return nil
+		},
+		DrainAck:          func(io.Writer) error { return nil },
+		ResolveWorkBranch: func(string) string { return "" },
+		StampWorkBranch:   func(_ context.Context, _ string, _ []string, _, _, _ string) error { return nil },
+		RecordSessionPointers: func(_ context.Context, _ string, _ []string, _, _, _, _ string) error {
+			return nil
+		},
+		EnqueueContinuationNudge: func(_ string, item queuedNudge) error {
+			*calls = append(*calls, item)
+			return nil
+		},
+	}
+}
+
+// TestHookClaimWorkflowRootEnqueuesContinuationNudge verifies that claiming a
+// new pool graph.v2 workflow root with at least one pre-assigned continuation
+// sibling enqueues exactly one queued nudge with the canonical propulsion
+// semantics (source, message, agent equal to the claiming session name).
+//
+// This test is skipped until ga-7n7vth.2 removes the t.Skip call below and
+// adds the production call site in writeHookClaimWorkResultForBead. After the
+// Skip is removed this test will fail (RED) until the call site is added, then
+// pass (GREEN). That is the intended TDD sequence.
+func TestHookClaimWorkflowRootEnqueuesContinuationNudge(t *testing.T) {
+	t.Skip("ga-7n7vth.2: remove this Skip and add the EnqueueContinuationNudge call site in writeHookClaimWorkResultForBead")
+	root := makeWorkflowRootBead("root-1", "pool-worker", "root-1", "group-a")
+	sibling := beads.Bead{
+		ID:     "step-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "step",
+			"gc.run_target":         "pool-worker",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}
+
+	var calls []queuedNudge
+	ops := captureNudgeOps(t, &calls, root, sibling)
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "", hookClaimOptions{
+		Assignee:           "pool-worker/slot-0",
+		IdentityCandidates: []string{"pool-worker/slot-0"},
+		RouteTargets:       []string{"pool-worker"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("EnqueueContinuationNudge called %d times, want exactly 1; stderr=%s", len(calls), stderr.String())
+	}
+	got := calls[0]
+	if got.Agent != "pool-worker/slot-0" {
+		t.Errorf("nudge.Agent = %q, want %q", got.Agent, "pool-worker/slot-0")
+	}
+	if got.Source != hookClaimContinuationNudgeSource {
+		t.Errorf("nudge.Source = %q, want %q", got.Source, hookClaimContinuationNudgeSource)
+	}
+	if got.Message != hookClaimContinuationNudgeMessage {
+		t.Errorf("nudge.Message = %q, want %q", got.Message, hookClaimContinuationNudgeMessage)
+	}
+}
+
+// TestHookClaimStepBeadDoesNotEnqueueContinuationNudge verifies that claiming a
+// non-workflow step bead — even one that has continuation metadata and pre-assigns
+// siblings — does not enqueue the hook-claim-continuation nudge. Only workflow
+// root claims propel the session; step claims happen while the session is already
+// active.
+func TestHookClaimStepBeadDoesNotEnqueueContinuationNudge(t *testing.T) {
+	// Step beads are routed to the concrete session name (set by
+	// preassignHookContinuationGroup on the prior root claim), so the route
+	// target here is the session name, not the pool template.
+	step := makeStepBead("step-1", "pool-worker/slot-0", "root-1", "group-a")
+	sibling := beads.Bead{
+		ID:     "step-2",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "step",
+			"gc.routed_to":          "pool-worker/slot-0",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}
+
+	var calls []queuedNudge
+	ops := captureNudgeOps(t, &calls, step, sibling)
+
+	var stdout, stderr bytes.Buffer
+	// A step bead's route target is the concrete session name (pool-worker/slot-0),
+	// not the pool template name; include both to mirror real hook invocation.
+	code := doHookClaim("query", "", hookClaimOptions{
+		Assignee:           "pool-worker/slot-0",
+		IdentityCandidates: []string{"pool-worker/slot-0"},
+		RouteTargets:       []string{"pool-worker/slot-0", "pool-worker"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if len(calls) != 0 {
+		t.Errorf("EnqueueContinuationNudge called %d times for step-bead claim, want 0", len(calls))
+	}
+}
+
+// TestHookClaimExistingAssignmentDoesNotEnqueueContinuationNudge verifies that
+// re-finding a workflow root that is already assigned to the claiming session
+// (idempotent re-find on retry) does not enqueue an additional continuation
+// nudge. The session is already active; a second nudge would cause a redundant
+// hook re-entry.
+func TestHookClaimExistingAssignmentDoesNotEnqueueContinuationNudge(t *testing.T) {
+	root := beads.Bead{
+		ID:       "root-1",
+		Status:   "in_progress",
+		Assignee: "pool-worker/slot-0",
+		Metadata: map[string]string{
+			"gc.kind":               "workflow",
+			"gc.run_target":         "pool-worker",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}
+	output, err := json.Marshal([]beads.Bead{root})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var calls []queuedNudge
+	sibling := beads.Bead{
+		ID:     "step-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "step",
+			"gc.run_target":         "pool-worker",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(output), nil },
+		// Claim is not called for existing assignments; provide a no-op to satisfy applyDefaults.
+		Claim: func(_ context.Context, _ string, _ []string, _, _ string) (beads.Bead, bool, error) {
+			return beads.Bead{}, false, nil
+		},
+		ListContinuation: func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) {
+			return []beads.Bead{sibling}, nil
+		},
+		AssignContinuation: func(_ context.Context, _ string, _ []string, _, _ string) error {
+			return nil
+		},
+		DrainAck:          func(io.Writer) error { return nil },
+		ResolveWorkBranch: func(string) string { return "" },
+		StampWorkBranch:   func(_ context.Context, _ string, _ []string, _, _, _ string) error { return nil },
+		RecordSessionPointers: func(_ context.Context, _ string, _ []string, _, _, _, _ string) error {
+			return nil
+		},
+		EnqueueContinuationNudge: func(_ string, item queuedNudge) error {
+			calls = append(calls, item)
+			return nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "", hookClaimOptions{
+		Assignee:           "pool-worker/slot-0",
+		IdentityCandidates: []string{"pool-worker/slot-0"},
+		RouteTargets:       []string{"pool-worker"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if len(calls) != 0 {
+		t.Errorf("EnqueueContinuationNudge called %d times for re-found assignment, want 0", len(calls))
+	}
+}
+
+// TestHookClaimZeroContinuationDoesNotEnqueueContinuationNudge verifies that
+// claiming a workflow root where no continuation siblings are available — either
+// because the formula has no steps or all step beads are already assigned —
+// does not enqueue the nudge. There is nothing to propel into.
+func TestHookClaimZeroContinuationDoesNotEnqueueContinuationNudge(t *testing.T) {
+	root := makeWorkflowRootBead("root-1", "pool-worker", "root-1", "group-a")
+
+	var calls []queuedNudge
+	// sibling is empty: ListContinuation returns nothing.
+	ops := captureNudgeOps(t, &calls, root, beads.Bead{})
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "", hookClaimOptions{
+		Assignee:           "pool-worker/slot-0",
+		IdentityCandidates: []string{"pool-worker/slot-0"},
+		RouteTargets:       []string{"pool-worker"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if len(calls) != 0 {
+		t.Errorf("EnqueueContinuationNudge called %d times for zero-continuation claim, want 0", len(calls))
+	}
+}

--- a/cmd/gc/cmd_hook_claim_nudge_test.go
+++ b/cmd/gc/cmd_hook_claim_nudge_test.go
@@ -27,11 +27,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-const (
-	hookClaimContinuationNudgeSource  = "hook-claim-continuation"
-	hookClaimContinuationNudgeMessage = "Work slung. Check your hook."
-)
-
 // makeWorkflowRootBead returns a bead shaped like a pool graph.v2 workflow root
 // ready to be claimed: gc.kind=workflow, gc.run_target pointing at the pool
 // template, and gc.root_bead_id / gc.continuation_group so pre-assignment runs.
@@ -107,24 +102,13 @@ func captureNudgeOps(t *testing.T, calls *[]queuedNudge, bead beads.Bead, siblin
 // new pool graph.v2 workflow root with at least one pre-assigned continuation
 // sibling enqueues exactly one queued nudge with the canonical propulsion
 // semantics (source, message, agent equal to the claiming session name).
-//
-// This test is skipped until ga-7n7vth.2 removes the t.Skip call below and
-// adds the production call site in writeHookClaimWorkResultForBead. After the
-// Skip is removed this test will fail (RED) until the call site is added, then
-// pass (GREEN). That is the intended TDD sequence.
 func TestHookClaimWorkflowRootEnqueuesContinuationNudge(t *testing.T) {
-	t.Skip("ga-7n7vth.2: remove this Skip and add the EnqueueContinuationNudge call site in writeHookClaimWorkResultForBead")
 	root := makeWorkflowRootBead("root-1", "pool-worker", "root-1", "group-a")
-	sibling := beads.Bead{
-		ID:     "step-1",
-		Status: "open",
-		Metadata: map[string]string{
-			"gc.kind":               "step",
-			"gc.run_target":         "pool-worker",
-			"gc.root_bead_id":       "root-1",
-			"gc.continuation_group": "group-a",
-		},
-	}
+	// Continuation siblings in a graph.v2 formula use gc.kind=workflow and gc.run_target
+	// for pre-assignment routing — the same shape as the root, just a different bead ID.
+	// preassignHookContinuationGroup uses hookClaimMatchesRoute to filter, which only
+	// matches unrouted beads via run_target when gc.kind=workflow.
+	sibling := makeWorkflowRootBead("step-1", "pool-worker", "root-1", "group-a")
 
 	var calls []queuedNudge
 	ops := captureNudgeOps(t, &calls, root, sibling)

--- a/release-gates/ga-941pst-hook-continuation-nudge-gate.md
+++ b/release-gates/ga-941pst-hook-continuation-nudge-gate.md
@@ -1,0 +1,65 @@
+# Release Gate: Hook-claim continuation nudge + ACP guidance
+
+- Deploy bead: `ga-941pst`
+- Source beads: `ga-7n7vth.1`, `ga-7n7vth.2`, `ga-7n7vth.3`, `ga-7n7vth.4`
+- Review bead: `ga-swmq4l`
+- Deploy branch: `release/ga-941pst-hook-continuation-nudge`
+- Original reviewed branch: `builder/ga-7n7vth.3-acp-comment-docs`
+- Original reviewed tip: `3147f597951b29251d974d055b416e6880c3e870`
+- Fresh deploy tip before gate: `9c5587f20c138b4dfb7409426d46d2283ef9fc34`
+- Base: `origin/main` at `1b5999531ddb646b99fadf785aa5811896d2db4b`
+- Gate worktree: `/home/jaword/gascity-deploy-ga-941pst-hook-continuation-gate`
+- Gate date: 2026-06-30
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate uses
+the release criteria from the deployer role prompt and `TESTING.md`.
+
+## Scope
+
+The branch named by the deploy bead, `builder/ga-7n7vth.3-acp-comment-docs`,
+has since been reused for unrelated later commits. To keep this PR reviewable,
+the deployer cut `release/ga-941pst-hook-continuation-nudge` from current
+`origin/main` and cherry-picked the reviewed hook-continuation series
+oldest-first:
+
+| Source commit | Deploy commit | Purpose |
+|---|---|---|
+| `d5a8208f5` | `b836e4f42` | Hook-claim continuation nudge regression coverage |
+| `988a08eb6` | `b9e3fd56e` | Enqueue continuation nudge after workflow-root claim |
+| `3147f5979` | `9c5587f20` | ACP dispatcher source comment and CHANGELOG guidance |
+
+The final diff is limited to one hook-claim continuation-nudge feature theme:
+
+- `CHANGELOG.md`
+- `cmd/gc/cmd_hook.go`
+- `cmd/gc/cmd_hook_claim.go`
+- `cmd/gc/cmd_hook_claim_nudge_test.go`
+
+## Checklist
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | `ga-swmq4l` is closed with reviewer PASS for branch `builder/ga-7n7vth.3-acp-comment-docs`, commit `3147f5979`, and diff scope covering `CHANGELOG.md`, `cmd/gc/cmd_hook.go`, `cmd/gc/cmd_hook_claim.go`, and `cmd/gc/cmd_hook_claim_nudge_test.go`. |
+| 2 | Acceptance criteria met | PASS | The source beads require root-claim continuation nudge coverage, concrete session-targeted queued nudge creation, non-fatal enqueue behavior, ACP dispatcher guidance, and in-flight sizing guidance. The code enqueues `hook-claim-continuation` nudges for newly claimed workflow roots with continuation assignments, skips step/non-workflow/idempotent cases, documents the ACP supervisor dispatcher requirement, and adds the release-note sizing guidance. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc/ -run 'TestHookClaim\|TestCmdHook\|TestHookCommand\|TestNudge\|TestQueuedNudge\|TestEnqueueNudge\|TestMaybeStartNudge' -count=1` passed (`ok github.com/gastownhall/gascity/cmd/gc 5.521s`). `go vet ./cmd/gc/` passed. `go vet ./...` passed. `make test-fast-parallel` passed all fast jobs. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list one minor stale-comment observation and no HIGH or blocking findings. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` reported `release/ga-941pst-hook-continuation-nudge...origin/main [ahead 3]` with no uncommitted changes. |
+| 6 | Branch diverges cleanly from main | PASS | The deploy branch was created directly from current `origin/main` and the three reviewed commits cherry-picked without conflicts. `git diff --check origin/main...HEAD` passed. |
+| 7 | Single feature theme | PASS | The commit set is one hook-claim continuation-nudge theme: regression tests, enqueue call site, and ACP/operator guidance for that same behavior. |
+
+## Commands
+
+```text
+git fetch origin main
+git worktree add /home/jaword/gascity-deploy-ga-941pst-hook-continuation-gate -b release/ga-941pst-hook-continuation-nudge origin/main
+git cherry-pick d5a8208f5 988a08eb6 3147f5979
+go test ./cmd/gc/ -run 'TestHookClaim|TestCmdHook|TestHookCommand|TestNudge|TestQueuedNudge|TestEnqueueNudge|TestMaybeStartNudge' -count=1
+go vet ./cmd/gc/
+go vet ./...
+make test-fast-parallel
+git diff --check origin/main...HEAD
+```
+
+## Decision
+
+PASS. The fresh deploy branch is ready for PR creation.


### PR DESCRIPTION
## What this changes

`gc hook --claim` now enqueues a queued continuation nudge for the concrete session that just claimed a graph workflow root and pre-assigned follow-up work. Pool graph.v2 workflows can move from the root claim into their first step without an operator manually nudging the slot session.

The change also documents the ACP edge at the enqueue site and in the changelog: ACP-backed sessions need `daemon.nudge_dispatcher = "supervisor"` for queued nudge delivery, and pool formula capacity should account for `max_concurrent_formulas * (1 + max_parallel_steps)` in-flight work.

## Review notes

- The nudge enqueue is a command-level side effect after a successful new workflow-root claim; it does not add flags, config defaults, schema fields, or wire changes.
- The nudge targets the actual claiming session name, not the pool template, uses wait-idle delivery, and remains best-effort so a nudge enqueue failure does not turn a successful claim into a user-visible failure.
- This PR was cut from current `origin/main` because the original builder branch was later reused for unrelated commits; the release gate records the reviewed-source-to-deploy commit mapping.

## Test plan

- [x] `go test ./cmd/gc/ -run 'TestHookClaim|TestCmdHook|TestHookCommand|TestNudge|TestQueuedNudge|TestEnqueueNudge|TestMaybeStartNudge' -count=1`
- [x] `go vet ./cmd/gc/`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-941pst-hook-continuation-nudge-gate.md`](release-gates/ga-941pst-hook-continuation-nudge-gate.md)
