### PR TITLE
Propel pool graph.v2 root claims with continuation nudges

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1842,8 +1842,21 @@ func readyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([
 	return rows, nil
 }
 
+// liveReadyForControllerDemandQuery returns the live ready set that feeds the
+// controller-demand awake/readiness gate (readyAssignedIDs). Under
+// graph_store=sqlite it prefers the graph-class ready slice (ReadyGraphOnly):
+// a worker only executes graph nodes, and the full federated Router.Ready
+// unions the Dolt work-leg backlog and truncates to the per-tick wake limit,
+// which evicts genuinely-ready assigned graph wisps (routed cleanup/finalize
+// steps) out of the window and leaves their sessions un-woken. This mirrors
+// readyStoreSet (gc ready) and the dispatch/API read paths; default Dolt-only
+// cities lack the capability and fall back to the federated Live.Ready
+// byte-identically.
 func liveReadyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([]beads.Bead, error) {
 	query.TierMode = beads.TierBoth
+	if probe, ok := beads.GraphOnlyReadyFor(store); ok {
+		return probe.ReadyGraphOnly(query)
+	}
 	handles := beads.HandlesFor(store)
 	return handles.Live.Ready(query)
 }

--- a/cmd/gc/build_desired_state_graph_ready_test.go
+++ b/cmd/gc/build_desired_state_graph_ready_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// graphDemandReadyReader is a CachedReader/LiveReader whose Ready returns a
+// fixed slice. In these tests it stands in for the FULL FEDERATED ready set
+// under graph_store=sqlite: the per-tick Limit has already evicted a
+// genuinely-ready graph wisp because the Dolt work leg filled the window.
+type graphDemandReadyReader struct {
+	ready []beads.Bead
+}
+
+func (r graphDemandReadyReader) Get(string) (beads.Bead, error)              { return beads.Bead{}, nil }
+func (r graphDemandReadyReader) List(beads.ListQuery) ([]beads.Bead, error)  { return nil, nil }
+func (r graphDemandReadyReader) DepList(string, string) ([]beads.Dep, error) { return nil, nil }
+func (r graphDemandReadyReader) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
+	return append([]beads.Bead(nil), r.ready...), nil
+}
+
+// graphDemandGraphOnlyReader returns the ClassGraph ready slice alone, where the
+// assigned wisp survives the per-tick limit because the Dolt work leg is excluded.
+type graphDemandGraphOnlyReader struct {
+	ready []beads.Bead
+}
+
+func (r graphDemandGraphOnlyReader) ReadyGraphOnly(...beads.ReadyQuery) ([]beads.Bead, error) {
+	return append([]beads.Bead(nil), r.ready...), nil
+}
+
+// graphDemandStore models a graph_store=sqlite Router store: the federated
+// Cached/Live Ready returns a work-leg backlog that has truncated a
+// genuinely-ready graph wisp out of the per-tick limit window, while the
+// graph-only capability returns the wisp. The controller-demand readiness
+// probes must prefer the graph-only slice (mirroring readyStoreSet) so an
+// assigned, deps-satisfied wisp is recognized as ready. When hasGraph is false
+// (identity phase, no distinct ClassGraph backend) the capability is absent and
+// the federated path must be used byte-identically.
+type graphDemandStore struct {
+	beads.Store
+	federated []beads.Bead
+	graphOnly []beads.Bead
+	hasGraph  bool
+}
+
+func (s *graphDemandStore) Handles() beads.StoreHandles {
+	r := graphDemandReadyReader{ready: s.federated}
+	return beads.StoreHandles{Cached: r, Live: r}
+}
+
+func (s *graphDemandStore) ReadyGraphOnlyHandle() (beads.GraphOnlyReadyStore, bool) {
+	if !s.hasGraph {
+		return nil, false
+	}
+	return graphDemandGraphOnlyReader{ready: s.graphOnly}, true
+}
+
+func graphDemandContains(rows []beads.Bead, id string) bool {
+	for _, b := range rows {
+		if b.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// The assigned cleanup wisp, ready (its sole blocks-dep closed), but evicted
+// from the federated per-tick limit window by older work-leg beads.
+func graphDemandWisp() beads.Bead {
+	return beads.Bead{ID: "gcg-1590", Status: "open", Assignee: "mc-test"}
+}
+
+func TestLiveReadyForControllerDemandPrefersGraphOnly(t *testing.T) {
+	store := &graphDemandStore{
+		federated: []beads.Bead{{ID: "work-1", Status: "open"}, {ID: "work-2", Status: "open"}},
+		graphOnly: []beads.Bead{graphDemandWisp()},
+		hasGraph:  true,
+	}
+	got, err := liveReadyForControllerDemandQuery(store, beads.ReadyQuery{Assignee: "mc-test", Limit: 5})
+	if err != nil {
+		t.Fatalf("liveReadyForControllerDemandQuery: %v", err)
+	}
+	if !graphDemandContains(got, "gcg-1590") {
+		t.Fatalf("expected graph-only ready slice to contain the assigned wisp gcg-1590, got %v", got)
+	}
+}
+
+func TestControllerDemandReadyFallsBackWithoutGraphCapability(t *testing.T) {
+	// Identity phase: no distinct ClassGraph backend -> GraphOnlyReadyFor=false
+	// -> the federated Live.Ready set is returned byte-identically, so default
+	// (Dolt-only) cities are unaffected by the fix.
+	store := &graphDemandStore{
+		federated: []beads.Bead{{ID: "work-1", Status: "open"}},
+		graphOnly: []beads.Bead{graphDemandWisp()},
+		hasGraph:  false,
+	}
+	got, err := liveReadyForControllerDemandQuery(store, beads.ReadyQuery{Limit: 5})
+	if err != nil {
+		t.Fatalf("liveReadyForControllerDemandQuery: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "work-1" {
+		t.Fatalf("expected federated fallback [work-1], got %v", got)
+	}
+	if graphDemandContains(got, "gcg-1590") {
+		t.Fatalf("graph-only wisp must NOT appear when the graph capability is absent")
+	}
+}

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 )
 
@@ -318,6 +319,17 @@ func hookClaimExistingOrAssigned(candidates []beads.Bead, opts hookClaimOptions)
 	return hookClaimJSONResult{}, beads.Bead{}, false
 }
 
+// isPoolGraphV2WorkflowRoot reports whether bead is a pool-routed graph.v2
+// workflow root that needs an initial continuation nudge at claim time. All
+// three conditions must hold so the nudge fires only for the case it targets —
+// a named-session workflow root binds a concrete session and never carries the
+// pool continuation group, so it is correctly excluded (#3554).
+func isPoolGraphV2WorkflowRoot(bead beads.Bead) bool {
+	return strings.TrimSpace(bead.Metadata[beadmeta.KindMetadataKey]) == beadmeta.KindWorkflow &&
+		strings.TrimSpace(bead.Metadata[beadmeta.FormulaContractMetadataKey]) == beadmeta.FormulaContractGraphV2 &&
+		strings.TrimSpace(bead.Metadata[beadmeta.ContinuationGroupMetadataKey]) == beadmeta.PoolWorkflowContinuationGroup
+}
+
 func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stdout, stderr io.Writer) int {
 	stampHookWorkBranch(bead, opts, ops, dir, stderr)
 	recordHookClaimSessionPointers(bead, opts, ops, dir, stderr)
@@ -327,7 +339,7 @@ func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead
 		return 1
 	}
 	result.ContinuationAssigned = assigned
-	if len(assigned) > 0 && bead.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflow {
+	if len(assigned) > 0 && isPoolGraphV2WorkflowRoot(bead) {
 		ops.EnqueueContinuationNudge(opts.Assignee)
 	}
 	if opts.JSON {
@@ -576,11 +588,31 @@ func hookContinuationNudgeEnqueue(assignee string) {
 	if err := enqueueQueuedNudgeWithStore(cityPath, beads.NudgesStore{}, item); err != nil {
 		return
 	}
-	maybeStartNudgePoller(nudgeTarget{
-		cityPath:    cityPath,
-		sessionName: assignee,
-	})
+	// Resolve config so the poller-spawn decision honors supervisor mode and ACP
+	// transport. Skipping the builtin-pack refresh keeps this hot claim path
+	// cheap; the daemon mode and agent transport live in already-materialized
+	// config. Warnings are discarded — a claim must not emit config noise.
+	cfg, _ := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
+	maybeStartNudgePoller(hookContinuationNudgeTarget(cityPath, assignee, cfg))
 	_ = pokeController(cityPath)
+}
+
+// hookContinuationNudgeTarget builds the nudge target used to decide whether a
+// per-session poller must be spawned. Populating cfg (and the resolved agent,
+// for its transport) is load-bearing: maybeStartNudgePoller only short-circuits
+// supervisor-mode cities via nudgeDispatcherIsSupervisor(target.cfg), and a nil
+// cfg defaults to legacy mode — so a bare {cityPath, sessionName} target spawns
+// a sidecar `gc nudge poll` that races the supervisor dispatcher and reinstates
+// the bd-shellout load supervisor mode exists to remove. Best-effort: falls
+// back to a cfg-only or bare target when the agent can't be resolved.
+func hookContinuationNudgeTarget(cityPath, assignee string, cfg *config.City) nudgeTarget {
+	if cfg == nil {
+		return nudgeTarget{cityPath: cityPath, sessionName: assignee}
+	}
+	if agent, ok := resolveAgentIdentity(cfg, assignee, currentRigContext(cfg)); ok {
+		return buildSlingNudgeTarget(agent, loadedCityName(cfg, cityPath), cityPath, cfg, nil, assignee)
+	}
+	return nudgeTarget{cityPath: cityPath, cfg: cfg, sessionName: assignee}
 }
 
 func hookListContinuationWithBdStore(_ context.Context, dir string, env []string, rootID, group string) ([]beads.Bead, error) {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -47,18 +47,26 @@ type hookClaimOps struct {
 	// AND gc.active_work_bead (the claimed work bead's gc.step_id) — in ONE update, so
 	// the (run, step) tuple stays atomically consistent. Best-effort.
 	RecordSessionPointers hookRecordSessionPointersFunc
-	Now                   func() time.Time
+	// EnqueueContinuationNudge enqueues a hook-claim-continuation nudge for the
+	// claiming session when a pool graph.v2 workflow root was freshly claimed and
+	// has at least one pre-assigned sibling step. This propels the root → step-1
+	// transition without requiring an external gc session nudge. Best-effort.
+	// ACP-transport sessions require daemon.nudge_dispatcher = "supervisor" for
+	// delivery; the legacy per-session poller cannot deliver to ACP sessions.
+	EnqueueContinuationNudge hookEnqueueContinuationNudgeFunc
+	Now                      func() time.Time
 }
 
 type (
-	hookClaimFunc                 func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
-	hookListContinuationFunc      func(context.Context, string, []string, string, string) ([]beads.Bead, error)
-	hookAssignContinuationFunc    func(context.Context, string, []string, string, string) error
-	hookDrainAckFunc              func(io.Writer) error
-	hookEmitClaimRejectedFunc     func(beadID, existingClaimant, attemptedClaimant string)
-	hookResolveWorkBranchFunc     func(dir string) string
-	hookStampWorkBranchFunc       func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
-	hookRecordSessionPointersFunc func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
+	hookClaimFunc                    func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
+	hookListContinuationFunc         func(context.Context, string, []string, string, string) ([]beads.Bead, error)
+	hookAssignContinuationFunc       func(context.Context, string, []string, string, string) error
+	hookDrainAckFunc                 func(io.Writer) error
+	hookEmitClaimRejectedFunc        func(beadID, existingClaimant, attemptedClaimant string)
+	hookResolveWorkBranchFunc        func(dir string) string
+	hookStampWorkBranchFunc          func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
+	hookRecordSessionPointersFunc    func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
+	hookEnqueueContinuationNudgeFunc func(assignee string)
 )
 
 type hookClaimJSONResult struct {
@@ -181,6 +189,9 @@ func (ops *hookClaimOps) applyDefaults() {
 	}
 	if ops.RecordSessionPointers == nil {
 		ops.RecordSessionPointers = hookRecordSessionPointersWithBdStore
+	}
+	if ops.EnqueueContinuationNudge == nil {
+		ops.EnqueueContinuationNudge = hookContinuationNudgeEnqueue
 	}
 }
 
@@ -316,6 +327,9 @@ func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead
 		return 1
 	}
 	result.ContinuationAssigned = assigned
+	if len(assigned) > 0 && bead.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflow {
+		ops.EnqueueContinuationNudge(opts.Assignee)
+	}
 	if opts.JSON {
 		if err := writeCLIJSONLine(stdout, result); err != nil {
 			fmt.Fprintf(stderr, "gc hook --claim: writing JSON: %v\n", err) //nolint:errcheck
@@ -542,6 +556,31 @@ func hookEmitClaimRejected(beadID, existingClaimant, attemptedClaimant string) {
 	if closer, ok := rec.(io.Closer); ok {
 		_ = closer.Close()
 	}
+}
+
+// hookContinuationNudgeEnqueue is the production EnqueueContinuationNudge
+// implementation. It enqueues a queued nudge for the claiming session so the
+// pool agent re-enters its hook after claiming the workflow root and propels
+// the root → step-1 transition without an external gc session nudge. The city
+// path is resolved from the environment so this call is self-contained — the
+// same pattern as hookEmitClaimRejected / openCityRecorder. Best-effort: any
+// error is swallowed so a nudge-queue failure never blocks the claim.
+// ACP sessions: maybeStartNudgePoller is a no-op for acp transport; configure
+// daemon.nudge_dispatcher = "supervisor" for delivery to ACP pool sessions.
+func hookContinuationNudgeEnqueue(assignee string) {
+	cityPath, err := resolveCity()
+	if err != nil {
+		return
+	}
+	item := newQueuedNudgeWithOptions(assignee, "Work slung. Check your hook.", "hook-claim-continuation", time.Now(), queuedNudgeOptions{})
+	if err := enqueueQueuedNudgeWithStore(cityPath, beads.NudgesStore{}, item); err != nil {
+		return
+	}
+	maybeStartNudgePoller(nudgeTarget{
+		cityPath:    cityPath,
+		sessionName: assignee,
+	})
+	_ = pokeController(cityPath)
 }
 
 func hookListContinuationWithBdStore(_ context.Context, dir string, env []string, rootID, group string) ([]beads.Bead, error) {

--- a/cmd/gc/cmd_hook_claim_continuation_nudge_test.go
+++ b/cmd/gc/cmd_hook_claim_continuation_nudge_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// workflowRootCandidates returns a slice of candidates suitable for testing
+// the hook-claim-continuation-nudge path: a workflow root that routes to
+// route-1 and carries a continuation group so preassignHookContinuationGroup
+// will assign siblings.
+func workflowRootCandidates() []beads.Bead {
+	return []beads.Bead{{
+		ID:     "root-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "workflow",
+			"gc.run_target":         "route-1",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}}
+}
+
+// stepBeadCandidates returns candidates whose gc.kind is "task" (a step
+// bead), which must NOT trigger the hook-claim-continuation nudge even when
+// siblings are assigned. Step beads are routed via gc.routed_to (not
+// gc.run_target), so we set that for route matching.
+func stepBeadCandidates() []beads.Bead {
+	return []beads.Bead{{
+		ID:     "step-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "task",
+			"gc.routed_to":          "route-1",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "group-a",
+		},
+	}}
+}
+
+// buildContinuationNudgeOps returns a hookClaimOps that captures nudge
+// enqueue calls. siblingIDs controls what ListContinuation returns.
+func buildContinuationNudgeOps(candidates []beads.Bead, siblingIDs []string, enqueued *[]string) hookClaimOps {
+	siblings := make([]beads.Bead, 0, len(siblingIDs))
+	for _, id := range siblingIDs {
+		siblings = append(siblings, beads.Bead{
+			ID:     id,
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.kind":               "workflow",
+				"gc.run_target":         "route-1",
+				"gc.root_bead_id":       "root-1",
+				"gc.continuation_group": "group-a",
+			},
+		})
+	}
+	return hookClaimOps{
+		Runner: func(string, string) (string, error) {
+			out, _ := json.Marshal(candidates)
+			return string(out), nil
+		},
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+			meta := candidates[0].Metadata
+			return beads.Bead{ID: beadID, Assignee: assignee, Status: "in_progress", Metadata: meta}, true, nil
+		},
+		ListContinuation: func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) {
+			return siblings, nil
+		},
+		AssignContinuation: func(_ context.Context, _ string, _ []string, _, _ string) error {
+			return nil
+		},
+		DrainAck: func(io.Writer) error { return nil },
+		EnqueueContinuationNudge: func(assignee string) {
+			*enqueued = append(*enqueued, assignee)
+		},
+	}
+}
+
+// TestHookClaimContinuationNudge_WorkflowRootEnqueuesNudge verifies that
+// claiming a workflow root that pre-assigns at least one sibling enqueues a
+// hook-claim-continuation nudge for the claiming session name.
+func TestHookClaimContinuationNudge_WorkflowRootEnqueuesNudge(t *testing.T) {
+	var enqueued []string
+	ops := buildContinuationNudgeOps(workflowRootCandidates(), []string{"sib-1", "sib-2"}, &enqueued)
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", ".", hookClaimOptions{
+		Assignee:           "gascity/worker/slot-0",
+		IdentityCandidates: []string{"gascity/worker/slot-0"},
+		RouteTargets:       []string{"route-1"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if len(enqueued) != 1 || enqueued[0] != "gascity/worker/slot-0" {
+		t.Fatalf("continuation nudge enqueued for %v, want [gascity/worker/slot-0]", enqueued)
+	}
+}
+
+// TestHookClaimContinuationNudge_StepBeadNoNudge verifies that claiming a
+// step bead (gc.kind="task") does NOT enqueue a hook-claim-continuation
+// nudge even when siblings are pre-assigned. The nudge is only needed for
+// self-propelling pool workflow roots; step claims happen while the session
+// is already executing and will naturally poll.
+func TestHookClaimContinuationNudge_StepBeadNoNudge(t *testing.T) {
+	var enqueued []string
+	ops := buildContinuationNudgeOps(stepBeadCandidates(), []string{"sib-1"}, &enqueued)
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", ".", hookClaimOptions{
+		Assignee:           "gascity/worker/slot-0",
+		IdentityCandidates: []string{"gascity/worker/slot-0"},
+		RouteTargets:       []string{"route-1"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if len(enqueued) != 0 {
+		t.Fatalf("continuation nudge must not be enqueued for a step-bead claim, got %v", enqueued)
+	}
+}
+
+// TestHookClaimContinuationNudge_NoSiblingsNoNudge verifies that claiming a
+// workflow root that has NO unassigned siblings does NOT enqueue a nudge.
+// An empty continuation means the session has no further work queued and
+// should not be immediately propelled.
+func TestHookClaimContinuationNudge_NoSiblingsNoNudge(t *testing.T) {
+	var enqueued []string
+	ops := buildContinuationNudgeOps(workflowRootCandidates(), nil /* no siblings */, &enqueued)
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", ".", hookClaimOptions{
+		Assignee:           "gascity/worker/slot-0",
+		IdentityCandidates: []string{"gascity/worker/slot-0"},
+		RouteTargets:       []string{"route-1"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if len(enqueued) != 0 {
+		t.Fatalf("continuation nudge must not be enqueued when no siblings assigned, got %v", enqueued)
+	}
+}

--- a/cmd/gc/cmd_hook_claim_continuation_nudge_test.go
+++ b/cmd/gc/cmd_hook_claim_continuation_nudge_test.go
@@ -8,13 +8,35 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // workflowRootCandidates returns a slice of candidates suitable for testing
-// the hook-claim-continuation-nudge path: a workflow root that routes to
-// route-1 and carries a continuation group so preassignHookContinuationGroup
-// will assign siblings.
+// the hook-claim-continuation-nudge path: a pool-routed graph.v2 workflow root
+// that routes to route-1 and carries the pool continuation group so
+// preassignHookContinuationGroup will assign siblings. The formula_contract and
+// pool continuation_group are required by isPoolGraphV2WorkflowRoot — they are
+// what a real pool graph.v2 root carries (graphroute stamps the pool group on
+// MetadataOnly bindings; compile stamps the contract on the root).
 func workflowRootCandidates() []beads.Bead {
+	return []beads.Bead{{
+		ID:     "root-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":               "workflow",
+			"gc.formula_contract":   "graph.v2",
+			"gc.run_target":         "route-1",
+			"gc.root_bead_id":       "root-1",
+			"gc.continuation_group": "pool-workflow",
+		},
+	}}
+}
+
+// namedWorkflowRootCandidates returns a workflow root that pre-assigns siblings
+// but is NOT a pool graph.v2 root — it lacks the graph.v2 contract and carries
+// a non-pool continuation group, mirroring a named-session workflow root. It
+// must NOT enqueue a continuation nudge.
+func namedWorkflowRootCandidates() []beads.Bead {
 	return []beads.Bead{{
 		ID:     "root-1",
 		Status: "open",
@@ -128,6 +150,31 @@ func TestHookClaimContinuationNudge_StepBeadNoNudge(t *testing.T) {
 	}
 }
 
+// TestHookClaimContinuationNudge_NamedWorkflowRootNoNudge verifies that
+// claiming a workflow root that pre-assigns siblings but is NOT a pool graph.v2
+// root (no graph.v2 contract, non-pool continuation group) does NOT enqueue a
+// nudge. This is the named-session workflow root case the narrowed gate
+// (isPoolGraphV2WorkflowRoot) excludes — the broader gc.kind==workflow gate
+// fired for it incorrectly (#3554 review).
+func TestHookClaimContinuationNudge_NamedWorkflowRootNoNudge(t *testing.T) {
+	var enqueued []string
+	ops := buildContinuationNudgeOps(namedWorkflowRootCandidates(), []string{"sib-1", "sib-2"}, &enqueued)
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", ".", hookClaimOptions{
+		Assignee:           "gascity/worker/slot-0",
+		IdentityCandidates: []string{"gascity/worker/slot-0"},
+		RouteTargets:       []string{"route-1"},
+		JSON:               true,
+	}, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if len(enqueued) != 0 {
+		t.Fatalf("continuation nudge must not be enqueued for a non-pool-graph.v2 workflow root, got %v", enqueued)
+	}
+}
+
 // TestHookClaimContinuationNudge_NoSiblingsNoNudge verifies that claiming a
 // workflow root that has NO unassigned siblings does NOT enqueue a nudge.
 // An empty continuation means the session has no further work queued and
@@ -148,5 +195,72 @@ func TestHookClaimContinuationNudge_NoSiblingsNoNudge(t *testing.T) {
 	}
 	if len(enqueued) != 0 {
 		t.Fatalf("continuation nudge must not be enqueued when no siblings assigned, got %v", enqueued)
+	}
+}
+
+// supervisorCityConfig builds a minimal city config with one pool agent whose
+// transport is `session`, for the poller-spawn tests.
+func nudgeTargetCityConfig(dispatcher, session string) *config.City {
+	return &config.City{
+		Daemon: config.DaemonConfig{NudgeDispatcher: dispatcher},
+		Agents: []config.Agent{{Name: "worker", Dir: "gascity", Session: session}},
+	}
+}
+
+// TestHookContinuationNudgeTarget_NilCfgFallsBackToBare verifies the
+// best-effort fallback: with no resolvable config the target is the bare
+// {cityPath, sessionName} shape (legacy behavior), never a panic.
+func TestHookContinuationNudgeTarget_NilCfgFallsBackToBare(t *testing.T) {
+	target := hookContinuationNudgeTarget("/city", "gascity/worker", nil)
+	if target.cfg != nil {
+		t.Fatalf("nil cfg must leave target.cfg nil, got %+v", target.cfg)
+	}
+	if target.cityPath != "/city" || target.sessionName != "gascity/worker" {
+		t.Fatalf("bare target mismatch: %+v", target)
+	}
+}
+
+// TestHookContinuationNudgeTarget_PopulatesCfg verifies the poller-race fix:
+// the target carries the city config so maybeStartNudgePoller's
+// nudgeDispatcherIsSupervisor(target.cfg) check can fire. A nil cfg there
+// defaults to legacy mode and spawns a sidecar poller that races the supervisor
+// dispatcher (#3838 review).
+func TestHookContinuationNudgeTarget_PopulatesCfg(t *testing.T) {
+	cfg := nudgeTargetCityConfig("supervisor", "acp")
+	target := hookContinuationNudgeTarget("/city", "gascity/worker", cfg)
+	if !nudgeDispatcherIsSupervisor(target.cfg) {
+		t.Fatal("target must carry cfg so the supervisor short-circuit fires")
+	}
+}
+
+// TestMaybeStartNudgePoller_HookContinuationTargets exercises the end-to-end
+// spawn decision for the hook-continuation target across dispatcher modes and
+// transports. Supervisor mode and ACP transport must NOT spawn a per-session
+// poller; legacy mode with a pollable transport must.
+func TestMaybeStartNudgePoller_HookContinuationTargets(t *testing.T) {
+	cases := []struct {
+		name       string
+		dispatcher string
+		session    string
+		wantSpawn  bool
+	}{
+		{"supervisor mode skips (race fix)", "supervisor", "tmux", false},
+		{"legacy acp skips (sidecar cannot deliver)", "legacy", "acp", false},
+		{"legacy tmux spawns", "legacy", "tmux", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := startNudgePoller
+			t.Cleanup(func() { startNudgePoller = orig })
+			var spawned int
+			startNudgePoller = func(_, _, _ string) error { spawned++; return nil }
+
+			target := hookContinuationNudgeTarget(t.TempDir(), "gascity/worker", nudgeTargetCityConfig(tc.dispatcher, tc.session))
+			maybeStartNudgePoller(target)
+
+			if got := spawned > 0; got != tc.wantSpawn {
+				t.Fatalf("spawned=%d, want spawn=%v", spawned, tc.wantSpawn)
+			}
+		})
 	}
 }

--- a/cmd/gc/session_idle_respawn_test.go
+++ b/cmd/gc/session_idle_respawn_test.go
@@ -151,3 +151,85 @@ func TestBeginIdleRespawnDrainIfIdle_SkipsNonInteractive(t *testing.T) {
 		t.Fatal("a non-interactive assigned-work session must not be idle-respawn-drained")
 	}
 }
+
+// idleRespawnEligible gates BOTH the idle-respawn sleep path and (as its
+// complement) the awake-maintenance block. Only a pool interactive
+// assigned-work-only session qualifies; a named or non-interactive session does
+// not, even when awake solely for assigned work — those must keep running the
+// maintenance block (recordCurrentBeadIDOnWake / cancelSessionDrain /
+// clearCompletedIdleProbe / sleep_intent clear). A named session CAN present
+// Reason=="assigned-work" because ComputeAwakeSet's assigned-work pass
+// overwrites the earlier named reason when the session owns a ready bead (#3554
+// review).
+func TestIdleRespawnEligible(t *testing.T) {
+	pool := &beads.Bead{ID: "p", Metadata: map[string]string{"session_name": "worker-1"}}
+	named := &beads.Bead{ID: "n", Metadata: map[string]string{"session_name": "run-operator", "configured_named_session": "true"}}
+	interactive := resolvedSessionSleepPolicy{Class: config.SessionSleepInteractiveResume}
+	nonInteractive := resolvedSessionSleepPolicy{Class: config.SessionSleepNonInteractive}
+	assignedWork := func(p resolvedSessionSleepPolicy) wakeEvaluation {
+		return wakeEvaluation{Reason: "assigned-work", Reasons: []WakeReason{WakeWork}, Policy: p}
+	}
+
+	if !idleRespawnEligible(pool, assignedWork(interactive)) {
+		t.Fatal("pool interactive assigned-work-only session must be idle-respawn-eligible")
+	}
+	if idleRespawnEligible(named, assignedWork(interactive)) {
+		t.Fatal("named assigned-work-only session must NOT be eligible (it keeps the maintenance block)")
+	}
+	if idleRespawnEligible(pool, assignedWork(nonInteractive)) {
+		t.Fatal("non-interactive assigned-work-only session must NOT be eligible")
+	}
+	if idleRespawnEligible(pool, wakeEvaluation{Reason: "min-active", Reasons: []WakeReason{WakeConfig}, Policy: interactive}) {
+		t.Fatal("non-assigned-work session must NOT be eligible")
+	}
+	if idleRespawnEligible(nil, assignedWork(interactive)) {
+		t.Fatal("nil session must NOT be eligible")
+	}
+}
+
+// A named session awake solely for assigned work must be excluded from idle
+// probing: it can never sleep-and-respawn, so probing it only churns (the probe
+// completes, beginIdleRespawnDrainIfIdle declines, the maintenance block clears
+// it next tick).
+func TestSelectIdleProbeTargets_SkipsNamedSession(t *testing.T) {
+	policy := resolvedSessionSleepPolicy{
+		Class:      config.SessionSleepInteractiveResume,
+		Effective:  "60s",
+		Capability: runtime.SessionSleepCapabilityFull,
+	}
+	target := wakeTarget{
+		session: &beads.Bead{ID: "s1", Metadata: map[string]string{"session_name": "run-operator", "configured_named_session": "true"}},
+		alive:   true,
+	}
+	wakeEvals := map[string]wakeEvaluation{
+		"s1": {Reason: "assigned-work", Reasons: []WakeReason{WakeWork}, Policy: policy},
+	}
+	got := selectIdleProbeTargets([]wakeTarget{target}, wakeEvals, newDrainTracker())
+	if got["s1"] {
+		t.Fatalf("a named assigned-work session must not be idle-probe-eligible, got %v", got)
+	}
+}
+
+// A named session awake solely for assigned work must not begin an idle-respawn
+// drain even with a completed idle probe — named sessions are materialized by
+// the named-session loop, not pool respawn.
+func TestBeginIdleRespawnDrainIfIdle_SkipsNamedSession(t *testing.T) {
+	clk := &clock.Fake{Time: time.Now().UTC()}
+	sp := runtime.NewFake()
+	name := "run-operator"
+	if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session := &beads.Bead{ID: "s1", Metadata: map[string]string{"session_name": name, "generation": "1", "configured_named_session": "true"}}
+	eval := wakeEvaluation{
+		Reason:  "assigned-work",
+		Reasons: []WakeReason{WakeWork},
+		Policy:  resolvedSessionSleepPolicy{Class: config.SessionSleepInteractiveResume, Capability: runtime.SessionSleepCapabilityFull},
+	}
+	dt := newDrainTracker()
+	probe := dt.startIdleProbe(session.ID)
+	dt.finishIdleProbe(session.ID, probe, true, clk.Now().Add(-time.Second))
+	if beginIdleRespawnDrainIfIdle(session, eval, dt, sp, clk) {
+		t.Fatal("a named assigned-work session must not be idle-respawn-drained")
+	}
+}

--- a/cmd/gc/session_idle_respawn_test.go
+++ b/cmd/gc/session_idle_respawn_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// A session that is awake ONLY because it owns ready assigned work is the
+// sleep-and-respawn case; anything with another (or no) wake reason is not.
+func TestIdleAssignedWorkOnly(t *testing.T) {
+	if !idleAssignedWorkOnly(wakeEvaluation{Reason: "assigned-work", Reasons: []WakeReason{WakeWork}}) {
+		t.Fatal("assigned-work-only eval should qualify")
+	}
+	if idleAssignedWorkOnly(wakeEvaluation{Reason: "assigned-work", Reasons: []WakeReason{WakeWork, WakePending}}) {
+		t.Fatal("eval with an extra wake reason must not qualify")
+	}
+	if idleAssignedWorkOnly(wakeEvaluation{Reason: "min-active", Reasons: []WakeReason{WakeConfig}}) {
+		t.Fatal("non-assigned-work eval must not qualify")
+	}
+	if idleAssignedWorkOnly(wakeEvaluation{}) {
+		t.Fatal("empty eval must not qualify")
+	}
+}
+
+// The idle-respawn drain must survive the per-tick cancel checks so the
+// persistent assigned-work demand cannot undo it before the session sleeps.
+func TestDrainReasonCancelable_IdleRespawnNotCancelable(t *testing.T) {
+	if drainReasonCancelable(idleRespawnDrainReason) {
+		t.Fatalf("%q must be non-cancelable (drainReasonCancelable)", idleRespawnDrainReason)
+	}
+	if assignedWorkDrainReasonCancelable(idleRespawnDrainReason) {
+		t.Fatalf("%q must not be cancelable by the assigned-work cancel path", idleRespawnDrainReason)
+	}
+	if !drainReasonCancelable("idle") {
+		t.Fatal("ordinary idle drain should remain cancelable")
+	}
+}
+
+// An idle session awake solely for assigned work must be eligible for an idle
+// probe (so it can sleep-and-respawn) even though it carries a wake reason and
+// is not ConfigSuppressed — the original gate skipped it.
+func TestSelectIdleProbeTargets_IncludesAssignedWorkOnly(t *testing.T) {
+	policy := resolvedSessionSleepPolicy{
+		Class:      config.SessionSleepInteractiveResume,
+		Effective:  "60s",
+		Capability: runtime.SessionSleepCapabilityFull,
+	}
+	target := wakeTarget{
+		session: &beads.Bead{ID: "s1", Metadata: map[string]string{"session_name": "run-operator-1"}},
+		alive:   true,
+	}
+	wakeEvals := map[string]wakeEvaluation{
+		"s1": {Reason: "assigned-work", Reasons: []WakeReason{WakeWork}, Policy: policy},
+	}
+	dt := newDrainTracker()
+	got := selectIdleProbeTargets([]wakeTarget{target}, wakeEvals, dt)
+	if !got["s1"] {
+		t.Fatalf("assigned-work-only idle session must be idle-probe-eligible, got %v", got)
+	}
+}
+
+// A non-assigned-work (or no-reason) session must still be skipped unless it is
+// the classic ConfigSuppressed-with-no-reasons idle case.
+func TestSelectIdleProbeTargets_SkipsOtherWakeReasons(t *testing.T) {
+	policy := resolvedSessionSleepPolicy{
+		Class:      config.SessionSleepInteractiveResume,
+		Effective:  "60s",
+		Capability: runtime.SessionSleepCapabilityFull,
+	}
+	target := wakeTarget{
+		session: &beads.Bead{ID: "s1", Metadata: map[string]string{"session_name": "worker-1"}},
+		alive:   true,
+	}
+	// A pending wake reason (not assigned-work-only) must NOT be probe-eligible.
+	wakeEvals := map[string]wakeEvaluation{
+		"s1": {Reason: "pending", Reasons: []WakeReason{WakePending}, Policy: policy},
+	}
+	got := selectIdleProbeTargets([]wakeTarget{target}, wakeEvals, newDrainTracker())
+	if got["s1"] {
+		t.Fatalf("a pending-wake session must not be idle-probe-eligible, got %v", got)
+	}
+}
+
+// With a COMPLETED idle probe proving the agent idle, an alive assigned-work
+// session begins an idle-respawn drain (→ asleep, resume-on-ready re-spawns it).
+// Without a completed probe, or for a non-assigned-work session, it does not.
+func TestBeginIdleRespawnDrainIfIdle(t *testing.T) {
+	clk := &clock.Fake{Time: time.Now().UTC()}
+	sp := runtime.NewFake()
+	name := "run-operator-1"
+	if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session := &beads.Bead{ID: "s1", Metadata: map[string]string{"session_name": name, "generation": "1"}}
+	policy := resolvedSessionSleepPolicy{Class: config.SessionSleepInteractiveResume, Capability: runtime.SessionSleepCapabilityFull}
+	eval := wakeEvaluation{Reason: "assigned-work", Reasons: []WakeReason{WakeWork}, Policy: policy}
+
+	// Positive: completed, successful idle probe + idle agent.
+	dt := newDrainTracker()
+	probe := dt.startIdleProbe(session.ID)
+	dt.finishIdleProbe(session.ID, probe, true, clk.Now().Add(-time.Second))
+	if !beginIdleRespawnDrainIfIdle(session, eval, dt, sp, clk) {
+		t.Fatal("idle assigned-work session with a completed idle probe should begin an idle-respawn drain")
+	}
+	if ds := dt.get(session.ID); ds == nil || ds.reason != idleRespawnDrainReason {
+		t.Fatalf("expected an idle-respawn drain, got %+v", ds)
+	}
+
+	// Negative: not assigned-work-only (a different wake reason) → no drain.
+	dt2 := newDrainTracker()
+	p2 := dt2.startIdleProbe(session.ID)
+	dt2.finishIdleProbe(session.ID, p2, true, clk.Now().Add(-time.Second))
+	other := wakeEvaluation{Reason: "min-active", Reasons: []WakeReason{WakeConfig}, Policy: policy}
+	if beginIdleRespawnDrainIfIdle(session, other, dt2, sp, clk) {
+		t.Fatal("non-assigned-work session must not begin an idle-respawn drain")
+	}
+
+	// Negative: no completed idle probe → no drain (guards against false sleep).
+	dt3 := newDrainTracker()
+	if beginIdleRespawnDrainIfIdle(session, eval, dt3, sp, clk) {
+		t.Fatal("without a completed idle probe, no idle-respawn drain should begin")
+	}
+}
+
+// Non-interactive sessions short-circuit shouldBeginIdleDrain to true without a
+// probe; they must be excluded from idle-respawn so an assigned non-interactive
+// (e.g. named) session is not wrongly drained.
+func TestBeginIdleRespawnDrainIfIdle_SkipsNonInteractive(t *testing.T) {
+	clk := &clock.Fake{Time: time.Now().UTC()}
+	sp := runtime.NewFake()
+	name := "ni-1"
+	if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session := &beads.Bead{ID: "ni", Metadata: map[string]string{"session_name": name, "generation": "1"}}
+	eval := wakeEvaluation{
+		Reason:  "assigned-work",
+		Reasons: []WakeReason{WakeWork},
+		Policy:  resolvedSessionSleepPolicy{Class: config.SessionSleepNonInteractive},
+	}
+	dt := newDrainTracker()
+	probe := dt.startIdleProbe(session.ID)
+	dt.finishIdleProbe(session.ID, probe, true, clk.Now().Add(-time.Second))
+	if beginIdleRespawnDrainIfIdle(session, eval, dt, sp, clk) {
+		t.Fatal("a non-interactive assigned-work session must not be idle-respawn-drained")
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2578,18 +2578,30 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					continue
 				}
 			}
-			// Stamp currently_processing_bead_id so the next divergence
-			// check has a baseline. Backfills legacy sessions that were
-			// already alive before this metadata existed and refreshes the
-			// record after the agent picks up its next bead in resume mode.
-			recordCurrentBeadIDOnWake(target.session, sessFront, decision.AssignedWorkBeadID, stderr)
-			// Session is correctly awake. Cancel any non-drift drain
-			// (handles scale-back-up: agent returns to desired set while draining).
-			cancelSessionDrain(*target.session, sp, dt)
-			clearCompletedIdleProbe(target.session.ID, dt)
-			if target.session.Metadata["sleep_intent"] == "idle-stop-pending" {
-				_ = sessionFrontDoor(store).SetMarker(target.session.ID, "sleep_intent", "")
-				target.session.Metadata["sleep_intent"] = ""
+			if beginIdleRespawnDrainIfIdle(target.session, eval, dt, sp, clk) {
+				// Idle session awake only for assigned work: drained to asleep
+				// (open bead) so resume-on-ready re-spawns it fresh to run its
+				// own ready bead. No nudge, no cancel.
+				fmt.Fprintf(stdout, "Draining session '%s': %s\n", target.session.Metadata["session_name"], idleRespawnDrainReason) //nolint:errcheck
+				if trace != nil {
+					trace.recordDecision("reconciler.session.drain", target.tp.TemplateName, target.session.Metadata["session_name"], idleRespawnDrainReason, "idle_respawn_drain", nil, nil, "")
+				}
+			} else if !idleAssignedWorkOnly(eval) {
+				// Stamp currently_processing_bead_id so the next divergence
+				// check has a baseline. Backfills legacy sessions that were
+				// already alive before this metadata existed and refreshes the
+				// record after the agent picks up its next bead in resume mode.
+				recordCurrentBeadIDOnWake(target.session, sessFront, decision.AssignedWorkBeadID, stderr)
+				// Session is correctly awake. Cancel any non-drift drain
+				// (handles scale-back-up: agent returns to desired set while draining).
+				// Assigned-work-only sessions are intentionally skipped here so
+				// their idle probe can run to completion (sleep-and-respawn).
+				cancelSessionDrain(*target.session, sp, dt)
+				clearCompletedIdleProbe(target.session.ID, dt)
+				if target.session.Metadata["sleep_intent"] == "idle-stop-pending" {
+					_ = sessionFrontDoor(store).SetMarker(target.session.ID, "sleep_intent", "")
+					target.session.Metadata["sleep_intent"] = ""
+				}
 			}
 		}
 
@@ -3727,6 +3739,43 @@ func shouldBeginIdleDrain(
 	return lastActivity.IsZero() || !lastActivity.After(probe.completedAt)
 }
 
+// idleRespawnDrainReason marks a drain begun on an idle session that is awake
+// only because it owns ready assigned work. The session sleeps (its bead stays
+// open, never closed) so resume-on-ready re-spawns it fresh to run that work.
+// The reason is non-cancelable (drainReasonCancelable) so the persistent
+// assigned-work demand cannot undo the drain before the session sleeps.
+const idleRespawnDrainReason = "idle-respawn"
+
+// idleAssignedWorkOnly reports whether a session's sole reason to be awake is
+// owning assigned work — the case eligible to sleep-and-respawn rather than
+// stay pinned awake-but-idle.
+func idleAssignedWorkOnly(eval wakeEvaluation) bool {
+	return eval.Reason == "assigned-work" && len(eval.Reasons) == 1 && containsWakeReason(eval.Reasons, WakeWork)
+}
+
+// beginIdleRespawnDrainIfIdle drains an alive session that is awake only for
+// assigned work to asleep when a completed idle probe proves its agent idle, so
+// resume-on-ready can re-spawn it fresh. It returns true when a drain was begun.
+// It deliberately neither cancels the drain nor clears the idle probe for these
+// sessions — that cancel/clear is what previously pinned them awake-but-idle.
+func beginIdleRespawnDrainIfIdle(session *beads.Bead, eval wakeEvaluation, dt *drainTracker, sp runtime.Provider, clk clock.Clock) bool {
+	if session == nil || !idleAssignedWorkOnly(eval) {
+		return false
+	}
+	// Restrict to pool sessions on the interactive-resume sleep path. Named
+	// sessions are materialized by the named-session loop, not pool respawn, and
+	// non-interactive sessions do not re-spawn from a fresh prompt (and
+	// shouldBeginIdleDrain short-circuits true for them without a probe). Both
+	// keep their existing "stay awake with assigned work" behavior.
+	if isNamedSessionBead(*session) || eval.Policy.Class == config.SessionSleepNonInteractive {
+		return false
+	}
+	if !shouldBeginIdleDrain(session, eval, dt, sp) {
+		return false
+	}
+	return beginSessionDrain(*session, sp, dt, idleRespawnDrainReason, clk, defaultDrainTimeout)
+}
+
 func selectIdleProbeTargets(
 	wakeTargets []wakeTarget,
 	wakeEvals map[string]wakeEvaluation,
@@ -3765,7 +3814,14 @@ func selectIdleProbeTargets(
 			continue
 		}
 		eval, ok := wakeEvals[target.session.ID]
-		if !ok || len(eval.Reasons) > 0 || !eval.ConfigSuppressed || !eval.Policy.enabled() {
+		if !ok || !eval.Policy.enabled() {
+			continue
+		}
+		// Probe a session that is either idle with no wake demand (the original
+		// case) OR awake solely for assigned work. The latter must be probed so
+		// an idle assigned-work session can sleep-and-respawn (resume-on-ready)
+		// instead of staying pinned awake-but-idle.
+		if !((len(eval.Reasons) == 0 && eval.ConfigSuppressed) || idleAssignedWorkOnly(eval)) {
 			continue
 		}
 		if eval.Policy.Class == config.SessionSleepNonInteractive {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2586,7 +2586,13 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				if trace != nil {
 					trace.recordDecision("reconciler.session.drain", target.tp.TemplateName, target.session.Metadata["session_name"], idleRespawnDrainReason, "idle_respawn_drain", nil, nil, "")
 				}
-			} else if !idleAssignedWorkOnly(eval) {
+			} else if !idleRespawnEligible(target.session, eval) {
+				// Reachable for every session that will NOT sleep-and-respawn —
+				// including a named or non-interactive session that is awake only
+				// for assigned work (idleAssignedWorkOnly but respawn-ineligible).
+				// Gating on idleAssignedWorkOnly alone stripped this maintenance
+				// from those sessions (#3554 review).
+				//
 				// Stamp currently_processing_bead_id so the next divergence
 				// check has a baseline. Backfills legacy sessions that were
 				// already alive before this metadata existed and refreshes the
@@ -2594,8 +2600,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				recordCurrentBeadIDOnWake(target.session, sessFront, decision.AssignedWorkBeadID, stderr)
 				// Session is correctly awake. Cancel any non-drift drain
 				// (handles scale-back-up: agent returns to desired set while draining).
-				// Assigned-work-only sessions are intentionally skipped here so
-				// their idle probe can run to completion (sleep-and-respawn).
+				// Idle-respawn-eligible (pool interactive assigned-work-only)
+				// sessions are intentionally skipped via the branch guard so their
+				// idle probe can run to completion (sleep-and-respawn).
 				cancelSessionDrain(*target.session, sp, dt)
 				clearCompletedIdleProbe(target.session.ID, dt)
 				if target.session.Metadata["sleep_intent"] == "idle-stop-pending" {
@@ -3753,21 +3760,35 @@ func idleAssignedWorkOnly(eval wakeEvaluation) bool {
 	return eval.Reason == "assigned-work" && len(eval.Reasons) == 1 && containsWakeReason(eval.Reasons, WakeWork)
 }
 
+// idleRespawnEligible reports whether a session is a candidate for the
+// idle-respawn sleep path: it is awake solely for assigned work AND is a pool
+// interactive session. Named sessions are materialized by the named-session
+// loop, not pool respawn, and non-interactive sessions do not re-spawn from a
+// fresh prompt (shouldBeginIdleDrain short-circuits true for them without a
+// probe); both keep their existing "stay awake with assigned work" behavior.
+//
+// It is the precise complement of the awake-maintenance block: every session
+// that is NOT idle-respawn-eligible must keep running that maintenance
+// (recordCurrentBeadIDOnWake, cancelSessionDrain, clearCompletedIdleProbe,
+// sleep_intent clear). A named session can present Reason=="assigned-work" —
+// the assigned-work pass in ComputeAwakeSet overwrites the earlier
+// named-always/named-demand reason when the session owns a ready bead — so
+// gating maintenance on idleAssignedWorkOnly alone would wrongly strip it from
+// named sessions (#3554 review).
+func idleRespawnEligible(session *beads.Bead, eval wakeEvaluation) bool {
+	if session == nil || !idleAssignedWorkOnly(eval) {
+		return false
+	}
+	return !isNamedSessionBead(*session) && eval.Policy.Class != config.SessionSleepNonInteractive
+}
+
 // beginIdleRespawnDrainIfIdle drains an alive session that is awake only for
 // assigned work to asleep when a completed idle probe proves its agent idle, so
 // resume-on-ready can re-spawn it fresh. It returns true when a drain was begun.
 // It deliberately neither cancels the drain nor clears the idle probe for these
 // sessions — that cancel/clear is what previously pinned them awake-but-idle.
 func beginIdleRespawnDrainIfIdle(session *beads.Bead, eval wakeEvaluation, dt *drainTracker, sp runtime.Provider, clk clock.Clock) bool {
-	if session == nil || !idleAssignedWorkOnly(eval) {
-		return false
-	}
-	// Restrict to pool sessions on the interactive-resume sleep path. Named
-	// sessions are materialized by the named-session loop, not pool respawn, and
-	// non-interactive sessions do not re-spawn from a fresh prompt (and
-	// shouldBeginIdleDrain short-circuits true for them without a probe). Both
-	// keep their existing "stay awake with assigned work" behavior.
-	if isNamedSessionBead(*session) || eval.Policy.Class == config.SessionSleepNonInteractive {
+	if !idleRespawnEligible(session, eval) {
 		return false
 	}
 	if !shouldBeginIdleDrain(session, eval, dt, sp) {
@@ -3825,6 +3846,15 @@ func selectIdleProbeTargets(
 			continue
 		}
 		if eval.Policy.Class == config.SessionSleepNonInteractive {
+			continue
+		}
+		// A named session never sleep-and-respawns (it is materialized by the
+		// named-session loop), so probing it for the assigned-work-only respawn
+		// path would only churn: the probe completes, beginIdleRespawnDrainIfIdle
+		// still declines, and the maintenance block clears it every tick. Scope
+		// this skip to that path only — a named session with NO wake demand still
+		// uses the original idle-drain probe (#3554 review).
+		if idleAssignedWorkOnly(eval) && isNamedSessionBead(*target.session) {
 			continue
 		}
 		candidates = append(candidates, target.session.ID)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -3821,7 +3821,7 @@ func selectIdleProbeTargets(
 		// case) OR awake solely for assigned work. The latter must be probed so
 		// an idle assigned-work session can sleep-and-respawn (resume-on-ready)
 		// instead of staying pinned awake-but-idle.
-		if !((len(eval.Reasons) == 0 && eval.ConfigSuppressed) || idleAssignedWorkOnly(eval)) {
+		if (len(eval.Reasons) != 0 || !eval.ConfigSuppressed) && !idleAssignedWorkOnly(eval) {
 			continue
 		}
 		if eval.Policy.Class == config.SessionSleepNonInteractive {

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -187,7 +187,7 @@ func beginSessionDrain(
 }
 
 func drainReasonCancelable(reason string) bool {
-	return reason != "config-drift" && reason != "orphaned" && reason != "suspended"
+	return reason != "config-drift" && reason != "orphaned" && reason != "suspended" && reason != idleRespawnDrainReason
 }
 
 func pendingDrainReasonCancelable(reason string) bool {

--- a/internal/api/handler_extmsg_default_route_test.go
+++ b/internal/api/handler_extmsg_default_route_test.go
@@ -53,16 +53,7 @@ func TestHandleExtMsgInboundDefaultRouteBindsAndColdWakes(t *testing.T) {
 	}
 
 	// The notify fan-out cold-wakes the routed agent's named session.
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if id, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil && id != "" {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for default-routed inbound to cold-wake myrig/worker")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	awaitColdWakeMaterialized(t, fs, "myrig/worker")
 }
 
 func TestHandleExtMsgInboundDefaultRouteMatchesMixedCaseProvider(t *testing.T) {
@@ -107,6 +98,12 @@ func TestHandleExtMsgInboundDefaultRouteMatchesMixedCaseProvider(t *testing.T) {
 	if binding == nil || binding.AgentName != "myrig/worker" {
 		t.Fatalf("binding = %#v, want sticky agent binding myrig/worker", binding)
 	}
+
+	// A successfully routed inbound message cold-wakes the agent's named
+	// session in a detached goroutine. Wait for that to finish before the test
+	// returns; otherwise t.TempDir() cleanup races the session-name-lock write
+	// (see awaitColdWakeMaterialized).
+	awaitColdWakeMaterialized(t, fs, "myrig/worker")
 }
 
 func TestHandleExtMsgInboundDefaultRouteUnknownAgentStaysUnbound(t *testing.T) {
@@ -142,5 +139,29 @@ func TestHandleExtMsgInboundDefaultRouteUnknownAgentStaysUnbound(t *testing.T) {
 	}
 	if binding != nil {
 		t.Fatalf("binding = %#v, want none for unresolvable route agent", binding)
+	}
+}
+
+// awaitColdWakeMaterialized blocks until the detached inbound cold-wake
+// goroutine (dispatched as `go s.extmsgNotifyInboundMembers` in
+// huma_handlers_extmsg.go) has materialized agentName's named session. That
+// goroutine reserves session-name locks under <city>/.gc/session-name-locks
+// while creating the session bead. A test that posts a default-routed inbound
+// message and returns without waiting lets t.TempDir()'s RemoveAll race that
+// lock-file creation, failing cleanup with "directory not empty". Resolving the
+// session confirms the reservation has completed, so the lock dir is stable
+// before teardown. This is the same barrier TestHandleExtMsgInboundDefaultRoute
+// BindsAndColdWakes already relies on.
+func awaitColdWakeMaterialized(t *testing.T, fs *fakeState, agentName string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if id, err := session.ResolveSessionID(fs.cityBeadStore, agentName); err == nil && id != "" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for default-routed inbound to cold-wake %s", agentName)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/beadmeta/values.go
+++ b/internal/beadmeta/values.go
@@ -81,6 +81,14 @@ const (
 // contract — the single most-branched-on metadata value in the engine.
 const FormulaContractGraphV2 = "graph.v2"
 
+// PoolWorkflowContinuationGroup is the value of ContinuationGroupMetadataKey
+// ("gc.continuation_group") stamped on pool-routed graph.v2 steps so that
+// preassignHookContinuationGroup keeps every step of a molecule on the same
+// pool slot (fixes #2978). It is the discriminator between a pool graph.v2
+// workflow root and a named-session workflow root: named-session steps bind a
+// concrete session and never carry this group.
+const PoolWorkflowContinuationGroup = "pool-workflow"
+
 // Values of ScopeRoleMetadataKey ("gc.scope_role"): the role a bead plays
 // inside a scope. The scope reconciler in internal/dispatch/runtime.go branches
 // on exact agreement between writers (dispatch, formula, cmd/gc) and readers.

--- a/internal/beads/ready_graph_only.go
+++ b/internal/beads/ready_graph_only.go
@@ -1,0 +1,38 @@
+package beads
+
+// GraphOnlyReadyStore is an optional store capability: a per-class Router exposes
+// the ready set of its ClassGraph backend ALONE, so the worker/dispatcher
+// execution-readiness hot loop skips the ClassWork (Dolt) leg under
+// graph_store=sqlite. A worker only ever executes graph nodes (molecule
+// steps/wisps); the full federated Ready still serves the human/diagnostic
+// backlog. In the identity phase (no distinct ClassGraph backend) an
+// implementation MUST fall back to the full Ready so default cities stay
+// byte-identical.
+type GraphOnlyReadyStore interface {
+	ReadyGraphOnly(query ...ReadyQuery) ([]Bead, error)
+}
+
+// GraphOnlyReadyProvider exposes a graph-only-ready handle for wrappers whose
+// capability depends on wrapped runtime state. A wrapper returns ok=false when
+// its backing has no distinct ClassGraph backend, so capability presence gates
+// the worker-readiness path on graph_store=sqlite without a config lookup.
+type GraphOnlyReadyProvider interface {
+	ReadyGraphOnlyHandle() (GraphOnlyReadyStore, bool)
+}
+
+// GraphOnlyReadyFor returns the graph-only-ready capability for store when one is
+// available, walking wrapper delegation. It mirrors GraphApplyFor: a plain
+// implementation is used directly, while a wrapper delegates through its handle
+// without claiming the interface globally.
+func GraphOnlyReadyFor(store Store) (GraphOnlyReadyStore, bool) {
+	if store == nil {
+		return nil, false
+	}
+	if provider, ok := store.(GraphOnlyReadyProvider); ok {
+		return provider.ReadyGraphOnlyHandle()
+	}
+	if g, ok := store.(GraphOnlyReadyStore); ok {
+		return g, true
+	}
+	return nil, false
+}

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -25,11 +25,6 @@ const (
 	GraphExecutionRigContextMetaKey = beadmeta.ExecutionRigContextMetadataKey
 )
 
-// poolWorkflowContinuationGroup is the continuation group value stamped on
-// pool-routed graph.v2 steps so preassignHookContinuationGroup keeps all steps
-// of a molecule on the same pool slot (fixes #2978).
-const poolWorkflowContinuationGroup = "pool-workflow"
-
 // AgentResolver resolves an agent name to a config.Agent.
 type AgentResolver interface {
 	ResolveAgent(cfg *config.City, name, rigContext string) (config.Agent, bool)
@@ -197,7 +192,7 @@ func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding)
 		// Pool-routed step: stamp continuation group so preassignHookContinuationGroup
 		// pre-assigns all molecule steps to the claiming slot, preventing scatter
 		// across pool slots (fixes #2978).
-		step.Metadata[beadmeta.ContinuationGroupMetadataKey] = poolWorkflowContinuationGroup
+		step.Metadata[beadmeta.ContinuationGroupMetadataKey] = beadmeta.PoolWorkflowContinuationGroup
 		step.Metadata[beadmeta.SessionAffinityMetadataKey] = "require"
 		step.Assignee = ""
 		return

--- a/release-gates/ga-g0kbyr-hook-continuation-nudge-gate.md
+++ b/release-gates/ga-g0kbyr-hook-continuation-nudge-gate.md
@@ -1,0 +1,59 @@
+# Release Gate: hook-claim continuation nudge
+
+Date: 2026-06-30
+Deployer: gascity/deployer
+
+## Scope
+
+- Deploy bead: ga-g0kbyr
+- Source bead: ga-zdunsh
+- Review bead: ga-kxo9pk
+- Reviewed branch: origin/work/ga-zdunsh-hook-claim-continuation-nudge
+- Reviewed commit: 614468a1944cc342b80b49138a5b459efbf338f8
+- Gate branch: release/ga-g0kbyr-hook-continuation-nudge
+- Base checked: origin/main@4a07b03c256b837a9b409609a46cd7e016eb4d8c
+
+The reviewed branch is stacked on the graph-only readiness / idle-respawn base
+commits bfa6a0a1f and b3e98d2cb, already proposed separately as PR #3835.
+Those base commits touch the same session/reconciler propagation path and are a
+functional dependency for this hook-claim continuation nudge.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-kxo9pk` is closed with close reason `pass`; notes contain `VERDICT: PASS` for commit `614468a1944cc342b80b49138a5b459efbf338f8`. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/cmd_hook_claim.go` enqueues `hook-claim-continuation` only when a freshly claimed bead has `gc.kind=workflow` and assigned continuation siblings; it targets the claiming session name. `cmd/gc/cmd_hook_claim_continuation_nudge_test.go` covers workflow root enqueues, step bead does not enqueue, and root with no siblings does not enqueue. ACP dispatcher dependency is documented at the enqueue site. In-flight ceiling sizing guidance is carried into the PR review notes so merge authority can publish it without deployer replying to an external issue thread. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestHookClaimContinuationNudge|TestSelectIdleProbeTargets|TestBeginIdleRespawnDrainIfIdle|TestDrainReasonCancelable'` -> `ok github.com/gastownhall/gascity/cmd/gc 0.588s`; `make test-fast-parallel` -> `All fast jobs passed`; `go vet ./...` -> clean; `GOCACHE=$(mktemp -d) go build ./cmd/gc` -> clean; `go run honnef.co/go/tools/cmd/staticcheck@latest -checks=QF1001 ./cmd/gc ./internal/beads ./test/docsync` -> clean. |
+| 4 | No high-severity review findings open | PASS | Review notes for ga-kxo9pk report no blockers and only a non-code public-response note; no HIGH findings are present. |
+| 5 | Final branch is clean | PASS | Before adding this gate file, `git status --short --branch` showed a clean branch tracking `origin/work/ga-zdunsh-hook-claim-continuation-nudge`. Deployer verifies clean status again after committing this gate file and before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `b849474dea300fc5604aa43b56ececca1941b53d`; `git diff --check origin/main...HEAD` passed. |
+| 7 | Single feature theme | PASS | The commit set is one session/reconciler propulsion theme: graph-only readiness, idle-respawn safety net, and hook-claim continuation nudge for pool graph.v2 roots. Removing the base readiness commits would undermine the nudge feature, so the stack is not a bundle of independent features. |
+
+## Test Log Summary
+
+- PASS: focused `cmd/gc` acceptance tests for hook continuation nudge and idle-probe eligibility.
+- PASS: fast unit baseline via `make test-fast-parallel`.
+- PASS: `go vet ./...`.
+- PASS: clean-cache build of `./cmd/gc`.
+- PASS: QF1001-only staticcheck over touched packages using a Go 1.26-built analyzer.
+
+Note: the installed `/home/jaword/go/bin/staticcheck` binary is built with Go
+1.25.8 and cannot analyze this Go 1.26 module graph. A full local
+`staticcheck ./...` invocation fails before branch diagnostics with Go-version
+compile errors from dependencies. The targeted QF1001 check above was run via
+`go run honnef.co/go/tools/cmd/staticcheck@latest` with the repo's Go 1.26
+toolchain to cover the prior lint failure class.
+
+## PR Notes To Carry Forward
+
+- The user-visible behavior change is that a pool graph.v2 root claimed by a
+  newly spawned pool session now queues a continuation nudge to the concrete
+  session slot, so the first step can start without an operator-issued
+  `gc session nudge`.
+- No new config, schema, or bead metadata keys are introduced.
+- ACP pool sessions still require `daemon.nudge_dispatcher = "supervisor"` for
+  queued delivery; the legacy per-session poller cannot deliver to ACP sessions.
+- Operators using in-flight ceilings should size for at least one workflow root
+  plus the active step per concurrent formula. In shorthand:
+  `max_concurrent_formulas * (1 + max_parallel_steps)`.

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -797,7 +797,7 @@ func TestDocDirCoverage(t *testing.T) {
 			continue
 		}
 		name := e.Name()
-		if strings.HasPrefix(name, ".") || name == "vendor" || name == "node_modules" {
+		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "ga-") || name == "vendor" || name == "node_modules" {
 			continue
 		}
 		if known[name] {

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -797,7 +797,7 @@ func TestDocDirCoverage(t *testing.T) {
 			continue
 		}
 		name := e.Name()
-		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "ga-") || name == "vendor" || name == "node_modules" {
+		if strings.HasPrefix(name, ".") || name == "vendor" || name == "node_modules" {
 			continue
 		}
 		if known[name] {


### PR DESCRIPTION
## What this changes

Pool `graph.v2` formulas routed to a `min=0` pool can now advance from the workflow root claim into the first step without an operator manually running `gc session nudge`. When `gc hook --claim` claims a workflow root and pre-assigns continuation siblings, it queues a `hook-claim-continuation` nudge to the concrete session slot that made the claim.

This PR also carries the graph-only readiness and idle-respawn base needed for the pool path to recover idle assigned-work sessions, plus the Staticcheck cleanup in the idle-probe eligibility expression.

## Why it is built this way

Hook-claim time is the first point where Gas City knows the concrete pool session name, such as `gascity/worker/slot-0`, rather than only the pool template. Queueing a normal nudge there keeps the fix structural: no timeout loop, no role-specific decision logic, and no new primitive.

## Review notes

- The hook enqueue path is in `cmd/gc/cmd_hook_claim.go`; it only fires for `gc.kind=workflow` roots with assigned continuation siblings.
- Step beads and roots with no assigned siblings are explicitly tested to avoid extra nudges.
- ACP pool sessions still require `daemon.nudge_dispatcher = "supervisor"` for queued delivery; the legacy per-session poller cannot deliver to ACP sessions.
- This branch is stacked on the graph-only readiness / idle-respawn work in PR #3835, so those session/reconciler changes appear in the diff until that base lands.
- There are no config, schema, or bead metadata shape changes.
- Operators using in-flight ceilings should size for at least one workflow root plus the active step per concurrent formula: `max_concurrent_formulas * (1 + max_parallel_steps)`.

## Test plan

- [x] `go test ./cmd/gc -run 'TestHookClaimContinuationNudge|TestSelectIdleProbeTargets|TestBeginIdleRespawnDrainIfIdle|TestDrainReasonCancelable'`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `GOCACHE=$(mktemp -d) go build ./cmd/gc`
- [x] `go run honnef.co/go/tools/cmd/staticcheck@latest -checks=QF1001 ./cmd/gc ./internal/beads ./test/docsync`
- [x] Pre-push fast suite from `git push -u origin release/ga-g0kbyr-hook-continuation-nudge`
- [x] Release gate: [`release-gates/ga-g0kbyr-hook-continuation-nudge-gate.md`](release-gates/ga-g0kbyr-hook-continuation-nudge-gate.md)

Closes #3554
