### PR TITLE
perf(orders): bound large-history due checks

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -926,6 +926,45 @@ type orderCheckJSONRow struct {
 	Reason     string `json:"reason"`
 }
 
+const orderLastRunLookupConcurrency = 8
+
+type orderCheckReadModelRow struct {
+	stores  []beads.Store
+	lastRun time.Time
+}
+
+func loadOrderCheckReadModel(aa []orders.Order, resolveStores orderStoresResolver) ([]orderCheckReadModelRow, error) {
+	model := make([]orderCheckReadModelRow, len(aa))
+	requests := make([]orders.LastRunRequest, 0, len(aa))
+	requestRows := make([]int, 0, len(aa))
+	for i, a := range aa {
+		if err := validateOrderCheckPreflight(a); err != nil {
+			return nil, err
+		}
+		typedStores, err := resolveStores(a)
+		if err != nil {
+			return nil, err
+		}
+		model[i].stores = unwrapOrdersStores(typedStores)
+		if !orderTriggerUsesLastRun(a) {
+			continue
+		}
+		requests = append(requests, orders.LastRunRequest{
+			Name:   a.ScopedName(),
+			Stores: model[i].stores,
+		})
+		requestRows = append(requestRows, i)
+	}
+
+	for i, result := range orders.LoadLastRuns(requests, orderLastRunLookupConcurrency) {
+		if result.Err != nil {
+			return nil, fmt.Errorf("reading last run for %s: %w", result.Name, result.Err)
+		}
+		model[requestRows[i]].lastRun = result.LastRun
+	}
+	return model, nil
+}
+
 func doOrderCheckJSON(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc, jsonOutput bool, stdout, stderr io.Writer) int {
 	if len(aa) == 0 {
 		if jsonOutput {
@@ -1033,6 +1072,11 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
 		return 1
 	}
+	model, err := loadOrderCheckReadModel(aa, resolveStores)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
 	if jsonOutput {
 		result := orderCheckJSON{
@@ -1041,26 +1085,9 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 			OrdersTotal:   len(aa),
 			Orders:        make([]orderCheckJSONRow, 0, len(aa)),
 		}
-		for _, a := range aa {
-			if err := validateOrderCheckPreflight(a); err != nil {
-				fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
-				return 1
-			}
-			typedStores, err := resolveStores(a)
-			if err != nil {
-				fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
-				return 1
-			}
-			stores := unwrapOrdersStores(typedStores)
-			baseLastRunFn := orders.LastRunAcrossStores(stores...)
-			var lastRunErr error
-			lastRunFn := func(orderName string) (time.Time, error) {
-				last, err := baseLastRunFn(orderName)
-				if err != nil {
-					lastRunErr = err
-				}
-				return last, err
-			}
+		for i, a := range aa {
+			stores := model[i].stores
+			lastRunFn := func(string) (time.Time, error) { return model[i].lastRun, nil }
 			cursorFn := orders.CursorAcrossStores(stores...)
 			if a.Trigger == "event" {
 				cursor, err := bdCursorAcrossStores(a.ScopedName(), stores...)
@@ -1078,10 +1105,6 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 				return 1
 			}
 			check := orders.CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, triggerOpts)
-			if lastRunErr != nil {
-				fmt.Fprintf(stderr, "gc order check: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
-				return 1
-			}
 			if check.Due {
 				result.AnyDue = true
 				result.DueTotal++
@@ -1111,26 +1134,9 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 		fmt.Fprintf(stdout, "%-20s %-12s %-5s %s\n", "NAME", "TRIGGER", "DUE", "REASON") //nolint:errcheck
 	}
 	anyDue := false
-	for _, a := range aa {
-		if err := validateOrderCheckPreflight(a); err != nil {
-			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		typedStores, err := resolveStores(a)
-		if err != nil {
-			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		stores := unwrapOrdersStores(typedStores)
-		baseLastRunFn := orders.LastRunAcrossStores(stores...)
-		var lastRunErr error
-		lastRunFn := func(orderName string) (time.Time, error) {
-			last, err := baseLastRunFn(orderName)
-			if err != nil {
-				lastRunErr = err
-			}
-			return last, err
-		}
+	for i, a := range aa {
+		stores := model[i].stores
+		lastRunFn := func(string) (time.Time, error) { return model[i].lastRun, nil }
 		cursorFn := orders.CursorAcrossStores(stores...)
 		if a.Trigger == "event" {
 			cursor, err := bdCursorAcrossStores(a.ScopedName(), stores...)
@@ -1148,10 +1154,6 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 			return 1
 		}
 		result := orders.CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, triggerOpts)
-		if lastRunErr != nil {
-			fmt.Fprintf(stderr, "gc order check: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
-			return 1
-		}
 		due := "no"
 		if result.Due {
 			due = "yes"

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,6 +40,107 @@ type partialListStore struct {
 	beads.Store
 	rows []beads.Bead
 	err  error
+}
+
+type largeOrderHistoryStore struct {
+	beads.Store
+
+	mu         sync.Mutex
+	history    map[string][]time.Time
+	active     int
+	maxActive  int
+	exactReads int
+}
+
+func (s *largeOrderHistoryStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if !strings.HasPrefix(query.Label, "order-run:") || !query.IncludeClosed || query.Limit != 1 {
+		return s.Store.List(query)
+	}
+	s.mu.Lock()
+	s.active++
+	s.exactReads++
+	if s.active > s.maxActive {
+		s.maxActive = s.active
+	}
+	s.mu.Unlock()
+	// A serial 25-order check would take at least 6.25 seconds and violate the
+	// regression budget. The bounded loader keeps the same fixture below 5s.
+	time.Sleep(250 * time.Millisecond)
+	s.mu.Lock()
+	s.active--
+	history := s.history[query.Label]
+	s.mu.Unlock()
+	if len(history) == 0 {
+		return nil, nil
+	}
+	return []beads.Bead{{
+		ID:        query.Label,
+		CreatedAt: history[len(history)-1],
+		Labels:    []string{query.Label},
+	}}, nil
+}
+
+func TestLoadOrderCheckReadModelBoundsLargeCityAndRigHistory(t *testing.T) {
+	const (
+		orderCount      = 25
+		historyPerOrder = 5000
+	)
+	now := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	cityHistory := make(map[string][]time.Time, orderCount)
+	rigHistory := make(map[string][]time.Time, orderCount)
+	aa := make([]orders.Order, orderCount)
+	for i := range aa {
+		name := fmt.Sprintf("hot-%02d", i)
+		aa[i] = orders.Order{Name: name, Trigger: "cooldown", Interval: "30s"}
+		label := "order-run:" + name
+		cityHistory[label] = make([]time.Time, historyPerOrder)
+		for j := range cityHistory[label] {
+			cityHistory[label][j] = now.Add(-time.Duration(historyPerOrder-j) * time.Minute)
+		}
+		if i%2 == 1 {
+			aa[i].Rig = "repo"
+			rigHistory["order-run:"+aa[i].ScopedName()] = append([]time.Time(nil), cityHistory[label]...)
+			delete(cityHistory, label)
+			cityHistory["order-run:"+aa[i].ScopedName()] = []time.Time{now.Add(-time.Second)}
+		}
+	}
+	cityStore := &largeOrderHistoryStore{Store: beads.NewMemStore(), history: cityHistory}
+	rigStore := &largeOrderHistoryStore{Store: beads.NewMemStore(), history: rigHistory}
+	resolver := func(a orders.Order) ([]beads.OrdersStore, error) {
+		if a.Rig == "" {
+			return []beads.OrdersStore{{Store: cityStore}}, nil
+		}
+		return []beads.OrdersStore{{Store: rigStore}, {Store: cityStore}}, nil
+	}
+
+	started := time.Now()
+	model, err := loadOrderCheckReadModel(aa, resolver)
+	if err != nil {
+		t.Fatalf("loadOrderCheckReadModel: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= 5*time.Second {
+		t.Fatalf("loadOrderCheckReadModel took %s, want < 5s", elapsed)
+	}
+	if len(model) != orderCount {
+		t.Fatalf("model length = %d, want %d", len(model), orderCount)
+	}
+	for i, row := range model {
+		if row.lastRun.IsZero() {
+			t.Fatalf("model[%d].lastRun is zero", i)
+		}
+		if i%2 == 1 {
+			want := now.Add(-time.Second)
+			if !row.lastRun.Equal(want) {
+				t.Fatalf("model[%d].lastRun = %s, want newer legacy city fallback %s", i, row.lastRun, want)
+			}
+		}
+	}
+	cityStore.mu.Lock()
+	cityMax := cityStore.maxActive
+	cityStore.mu.Unlock()
+	if cityMax <= 1 {
+		t.Fatalf("city store max concurrent reads = %d, want > 1", cityMax)
+	}
 }
 
 func (s *partialListStore) List(_ beads.ListQuery) ([]beads.Bead, error) {

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -298,21 +298,31 @@ type memoryOrderDispatcher struct {
 }
 
 type orderDispatchTrackingIndex struct {
-	// mu guards entries and errs. dispatch shares ONE index across every
+	// mu guards entries, errs, and the per-tick latest-run prime. dispatch shares ONE index across every
 	// order's open-work gate, and gateOpenWorkBounded runs each gate in a
 	// goroutine it abandons on timeout/ctx-cancel (#2893) — so multiple gate
 	// goroutines touch these maps concurrently. The lock is held only around
 	// the map reads/writes below, never across the listCanonical* bd calls, so
 	// one slow or contended store read cannot stall sibling gates (the property
 	// gateOpenWorkBounded exists to preserve).
-	mu      sync.Mutex
-	entries map[string]map[string]orderTrackingSummary
-	errs    map[string]error
+	mu          sync.Mutex
+	entries     map[string]map[string]orderTrackingSummary
+	errs        map[string]error
+	lastRuns    map[string]time.Time
+	lastRunErrs map[string]error
 }
 
 type orderTrackingSummary struct {
 	openTracking bool
 	lastRun      time.Time
+}
+
+type preparedOrderDispatchStore struct {
+	target     execStoreTarget
+	store      beads.Store
+	gateStores []beads.Store
+	gateKeys   []string
+	ok         bool
 }
 
 // buildOrderDispatcher scans formula layers for orders and returns a
@@ -423,6 +433,39 @@ func buildOrderDispatcherFromOrderSet(cityPath string, cfg *config.City, allAA [
 	}
 }
 
+func (m *memoryOrderDispatcher) prepareOrderDispatchStore(cityPath string, a orders.Order, stores map[string]beads.Store) (preparedOrderDispatchStore, error) {
+	target, err := resolveOrderStoreTarget(cityPath, m.cfg, a)
+	if err != nil {
+		return preparedOrderDispatchStore{}, fmt.Errorf("resolving target: %w", err)
+	}
+	storeKey := orderStoreTargetKey(target)
+	store, ok := stores[storeKey]
+	if !ok {
+		store, err = m.storeFn(target)
+		if err != nil {
+			return preparedOrderDispatchStore{}, fmt.Errorf("opening %s store: %w", target.ScopeKind, err)
+		}
+		stores[storeKey] = store
+	}
+
+	resolved := preparedOrderDispatchStore{
+		target:     target,
+		store:      store,
+		gateStores: []beads.Store{store},
+		gateKeys:   []string{storeKey},
+		ok:         true,
+	}
+	legacyStore, err := m.legacyCityStoreForTarget(cityPath, target, stores)
+	if err != nil {
+		return preparedOrderDispatchStore{}, err
+	}
+	if legacyStore != nil {
+		resolved.gateStores = append(resolved.gateStores, legacyStore)
+		resolved.gateKeys = append(resolved.gateKeys, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
+	}
+	return resolved, nil
+}
+
 func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, now time.Time) {
 	// Skip all order dispatch when the city is suspended. Use the
 	// dispatcher's in-scope city path so suspension state resolves
@@ -462,6 +505,40 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 	if total == 0 {
 		return
 	}
+	prepared := make([]preparedOrderDispatchStore, total)
+	lastRunRequests := make([]orders.LastRunRequest, 0, total)
+	lastRunRequestIndexes := make([]int, 0, total)
+	for i, a := range m.aa {
+		if m.orderRigSuspended(a) {
+			continue
+		}
+		resolved, err := m.prepareOrderDispatchStore(cityPath, a, stores)
+		if err != nil {
+			logDispatchError(m.stderr, "gc: order dispatch: preparing stores for %s: %v", a.ScopedName(), err)
+			continue
+		}
+		prepared[i] = resolved
+		if !orderTriggerUsesLastRun(a) {
+			continue
+		}
+		if cached, ok := m.peekCachedLastRun(a.ScopedName(), resolved.gateKeys); ok {
+			cachedResult := orders.CheckTrigger(a, now, func(string) (time.Time, error) {
+				return cached, nil
+			}, nil, nil)
+			if !cachedResult.Due {
+				continue
+			}
+		}
+		lastRunRequests = append(lastRunRequests, orders.LastRunRequest{
+			Name:   a.ScopedName(),
+			Stores: resolved.gateStores,
+		})
+		lastRunRequestIndexes = append(lastRunRequestIndexes, i)
+	}
+	for i, result := range orders.LoadLastRuns(lastRunRequests, orderLastRunLookupConcurrency) {
+		resolved := prepared[lastRunRequestIndexes[i]]
+		trackingIndex.primeLastRun(result.Name, resolved.gateKeys, result.LastRun, result.Err)
+	}
 	start := 0
 	if m.maxDispatchesPerTick > 0 {
 		start = m.nextDispatchStart % total
@@ -477,40 +554,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 	for offset := 0; offset < total; offset++ {
 		idx := (start + offset) % total
 		a := m.aa[idx]
-		// Skip orders targeting suspended rigs.
-		if m.orderRigSuspended(a) {
+		resolved := prepared[idx]
+		if !resolved.ok {
 			continue
 		}
-
-		target, err := resolveOrderStoreTarget(cityPath, m.cfg, a)
-		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: resolving target for %s: %v", a.ScopedName(), err)
-			continue
-		}
-
-		storeKey := orderStoreTargetKey(target)
-		store, ok := stores[storeKey]
-		if !ok {
-			store, err = m.storeFn(target)
-			if err != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: opening %s store for %s: %v", target.ScopeKind, a.ScopedName(), err)
-				continue
-			}
-			stores[storeKey] = store
-		}
-
-		storesForGate := []beads.Store{store}
-		legacyStore, legacyOK := m.legacyCityStoreForTarget(cityPath, target, stores)
-		if !legacyOK {
-			continue
-		}
-		if legacyStore != nil {
-			storesForGate = append(storesForGate, legacyStore)
-		}
-		storeKeysForGate := []string{storeKey}
-		if legacyStore != nil {
-			storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
-		}
+		target := resolved.target
+		store := resolved.store
+		storesForGate := resolved.gateStores
+		storeKeysForGate := resolved.gateKeys
 		scoped := a.ScopedName()
 		if m.gateBackoffActive(scoped, now) {
 			continue
@@ -736,9 +787,38 @@ func (m *memoryOrderDispatcher) drain(ctx context.Context) bool {
 
 func newOrderDispatchTrackingIndex() *orderDispatchTrackingIndex {
 	return &orderDispatchTrackingIndex{
-		entries: make(map[string]map[string]orderTrackingSummary),
-		errs:    make(map[string]error),
+		entries:     make(map[string]map[string]orderTrackingSummary),
+		errs:        make(map[string]error),
+		lastRuns:    make(map[string]time.Time),
+		lastRunErrs: make(map[string]error),
 	}
+}
+
+func (idx *orderDispatchTrackingIndex) primeLastRun(orderName string, storeKeys []string, lastRun time.Time, err error) {
+	if idx == nil {
+		return
+	}
+	key := orderHistoryCacheKey(orderName, storeKeys)
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.lastRuns[key] = lastRun
+	if err != nil {
+		idx.lastRunErrs[key] = err
+	}
+}
+
+func (idx *orderDispatchTrackingIndex) primedLastRun(orderName string, storeKeys []string) (time.Time, bool, error) {
+	if idx == nil {
+		return time.Time{}, false, nil
+	}
+	key := orderHistoryCacheKey(orderName, storeKeys)
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	if err, ok := idx.lastRunErrs[key]; ok {
+		return time.Time{}, true, err
+	}
+	lastRun, ok := idx.lastRuns[key]
+	return lastRun, ok, nil
 }
 
 func (idx *orderDispatchTrackingIndex) hasOpenTracking(
@@ -812,6 +892,9 @@ func (idx *orderDispatchTrackingIndex) lastRunFunc(
 	return func(scopedName string) (time.Time, error) {
 		if idx == nil {
 			return fallback(scopedName)
+		}
+		if lastRun, ok, err := idx.primedLastRun(scopedName, storeKeys); ok {
+			return lastRun, err
 		}
 		var latest time.Time
 		for i, store := range stores {
@@ -937,22 +1020,21 @@ func indexStoreKey(storeKeys []string, index int) string {
 	return fmt.Sprintf("store:%d", index)
 }
 
-func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target execStoreTarget, stores map[string]beads.Store) (beads.Store, bool) {
+func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target execStoreTarget, stores map[string]beads.Store) (beads.Store, error) {
 	if !legacyOrderCityFallbackNeeded(cityPath, target) {
-		return nil, true
+		return nil, nil
 	}
 	legacyTarget := legacyOrderCityTarget(cityPath, m.cfg)
 	key := orderStoreTargetKey(legacyTarget)
 	if store, ok := stores[key]; ok {
-		return store, true
+		return store, nil
 	}
 	store, err := m.storeFn(legacyTarget)
 	if err != nil {
-		logDispatchError(m.stderr, "gc: order dispatch: opening legacy city store for rig order fallback: %v", err)
-		return nil, false
+		return nil, fmt.Errorf("opening legacy city store for rig order fallback: %w", err)
 	}
 	stores[key] = store
-	return store, true
+	return store, nil
 }
 
 func (m *memoryOrderDispatcher) cachedLastRun(orderName string, storeKeys []string, read orders.LastRunFunc) (time.Time, bool, error) {
@@ -972,6 +1054,14 @@ func (m *memoryOrderDispatcher) cachedLastRun(orderName string, storeKeys []stri
 	}
 	m.rememberLastRun(orderName, storeKeys, last)
 	return last, false, nil
+}
+
+func (m *memoryOrderDispatcher) peekCachedLastRun(orderName string, storeKeys []string) (time.Time, bool) {
+	key := orderHistoryCacheKey(orderName, storeKeys)
+	m.cacheMu.Lock()
+	defer m.cacheMu.Unlock()
+	lastRun, ok := m.lastRunCache[key]
+	return lastRun, ok
 }
 
 func (m *memoryOrderDispatcher) rememberLastRun(orderName string, storeKeys []string, last time.Time) {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1472,6 +1472,78 @@ func TestOrderDispatchCachesLastRunBetweenDispatches(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchColdAndWarmCacheBoundLargeTrackingHistory(t *testing.T) {
+	const (
+		orderCount      = 25
+		historyPerOrder = 5000
+	)
+	now := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	history := make(map[string][]time.Time, orderCount)
+	aa := make([]orders.Order, orderCount)
+	for i := range aa {
+		name := fmt.Sprintf("hot-%02d", i)
+		aa[i] = orders.Order{Name: name, Trigger: "cooldown", Interval: "1h", Exec: "true"}
+		label := "order-run:" + name
+		history[label] = make([]time.Time, historyPerOrder)
+		for j := range history[label] {
+			history[label][j] = now.Add(-time.Duration(historyPerOrder-j) * time.Second)
+		}
+	}
+	store := &largeOrderHistoryStore{Store: beads.NewMemStore(), history: history}
+	dispatcher := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if dispatcher == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	cityPath := t.TempDir()
+	started := time.Now()
+	dispatcher.dispatch(context.Background(), cityPath, now)
+	if elapsed := time.Since(started); elapsed >= 5*time.Second {
+		t.Fatalf("cold-cache dispatch took %s, want < 5s", elapsed)
+	}
+	store.mu.Lock()
+	coldMax := store.maxActive
+	coldReads := store.exactReads
+	store.maxActive = 0
+	store.exactReads = 0
+	store.mu.Unlock()
+	if coldMax <= 1 {
+		t.Fatalf("cold-cache max concurrent reads = %d, want > 1", coldMax)
+	}
+	if coldReads != orderCount {
+		t.Fatalf("cold-cache exact reads = %d, want %d", coldReads, orderCount)
+	}
+
+	dispatcher.dispatch(context.Background(), cityPath, now.Add(time.Second))
+	store.mu.Lock()
+	warmReads := store.exactReads
+	store.mu.Unlock()
+	if warmReads != 0 {
+		t.Fatalf("warm-cache exact reads = %d, want 0", warmReads)
+	}
+
+	store.mu.Lock()
+	store.maxActive = 0
+	store.exactReads = 0
+	store.mu.Unlock()
+	dispatcher.dispatch(context.Background(), cityPath, now.Add(2*time.Hour))
+	store.mu.Lock()
+	dueWarmMax := store.maxActive
+	dueWarmReads := store.exactReads
+	store.mu.Unlock()
+	if dueWarmMax <= 1 {
+		t.Fatalf("due warm-cache max concurrent reads = %d, want > 1", dueWarmMax)
+	}
+	if dueWarmReads != orderCount {
+		t.Fatalf("due warm-cache exact reads = %d, want %d", dueWarmReads, orderCount)
+	}
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !dispatcher.drain(drainCtx) {
+		t.Fatal("dispatcher did not drain")
+	}
+}
+
 func TestOrderDispatchRefreshesCachedLastRunBeforeDueDispatch(t *testing.T) {
 	baseStore := &createdAtOverrideStore{Store: beads.NewMemStore()}
 	store := &countingListStore{Store: baseStore}

--- a/internal/orders/runtime_helpers.go
+++ b/internal/orders/runtime_helpers.go
@@ -2,12 +2,67 @@ package orders
 
 import (
 	"log"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
 var runtimeHelpersLogf = log.Printf
+
+// LastRunRequest describes one order whose latest persisted run must be read
+// across one or more stores.
+type LastRunRequest struct {
+	Name   string
+	Stores []beads.Store
+}
+
+// LastRunResult is the result corresponding to one LastRunRequest.
+type LastRunResult struct {
+	Name    string
+	LastRun time.Time
+	Err     error
+}
+
+// LoadLastRuns resolves latest-run requests concurrently while bounding the
+// number of requests in flight. Results preserve request order. A non-positive
+// maxConcurrent value uses one worker.
+func LoadLastRuns(requests []LastRunRequest, maxConcurrent int) []LastRunResult {
+	results := make([]LastRunResult, len(requests))
+	if len(requests) == 0 {
+		return results
+	}
+	if maxConcurrent < 1 {
+		maxConcurrent = 1
+	}
+	if maxConcurrent > len(requests) {
+		maxConcurrent = len(requests)
+	}
+
+	jobs := make(chan int)
+	var workers sync.WaitGroup
+	workers.Add(maxConcurrent)
+	for range maxConcurrent {
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				request := requests[index]
+				lastRun, err := LastRunAcrossStores(request.Stores...)(request.Name)
+				results[index] = LastRunResult{
+					Name:    request.Name,
+					LastRun: lastRun,
+					Err:     err,
+				}
+			}
+		}()
+	}
+	for index := range requests {
+		jobs <- index
+	}
+	close(jobs)
+	workers.Wait()
+	return results
+}
 
 // LastRunFuncForStore returns the latest order-run bead time for one store.
 func LastRunFuncForStore(store beads.Store) LastRunFunc {

--- a/internal/orders/runtime_helpers_test.go
+++ b/internal/orders/runtime_helpers_test.go
@@ -4,11 +4,77 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
+
+type concurrentLastRunStore struct {
+	beads.Store
+
+	mu        sync.Mutex
+	active    int
+	maxActive int
+}
+
+func (s *concurrentLastRunStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.mu.Lock()
+	s.active++
+	if s.active > s.maxActive {
+		s.maxActive = s.active
+	}
+	s.mu.Unlock()
+
+	time.Sleep(10 * time.Millisecond)
+
+	s.mu.Lock()
+	s.active--
+	s.mu.Unlock()
+	return []beads.Bead{{
+		ID:        query.Label,
+		CreatedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		Labels:    []string{query.Label},
+	}}, nil
+}
+
+func TestLoadLastRunsBoundsConcurrentStoreQueries(t *testing.T) {
+	store := &concurrentLastRunStore{Store: beads.NewMemStore()}
+	requests := make([]LastRunRequest, 16)
+	for i := range requests {
+		requests[i] = LastRunRequest{
+			Name:   fmt.Sprintf("order-%02d", i),
+			Stores: []beads.Store{store},
+		}
+	}
+
+	results := LoadLastRuns(requests, 4)
+	if len(results) != len(requests) {
+		t.Fatalf("LoadLastRuns returned %d results, want %d", len(results), len(requests))
+	}
+	for i, result := range results {
+		if result.Name != requests[i].Name {
+			t.Fatalf("result[%d].Name = %q, want %q", i, result.Name, requests[i].Name)
+		}
+		if result.Err != nil {
+			t.Fatalf("result[%d].Err = %v", i, result.Err)
+		}
+		if result.LastRun.IsZero() {
+			t.Fatalf("result[%d].LastRun is zero", i)
+		}
+	}
+
+	store.mu.Lock()
+	maxActive := store.maxActive
+	store.mu.Unlock()
+	if maxActive <= 1 {
+		t.Fatalf("max concurrent List calls = %d, want > 1", maxActive)
+	}
+	if maxActive > 4 {
+		t.Fatalf("max concurrent List calls = %d, want <= 4", maxActive)
+	}
+}
 
 type rowsErrorStore struct {
 	*beads.MemStore


### PR DESCRIPTION
## Summary

- batch latest-run lookups through a bounded worker pool
- prime controller cold-cache and due warm-cache reads concurrently
- reuse the same read model for gc order check across city and rig fallback stores
- cover 25 orders with 5,000 history entries each under a five-second regression budget

## Root cause

The bounded 2,048-row tracking index could miss orders when hot histories contained thousands of entries. Each miss then paid a label query inside a serial order loop, so 25 enabled orders could block controller cadence and gc order check for tens of seconds.

## Validation

- focused internal/orders and cmd/gc order tests pass with CGO disabled
- large-history controller and CLI regression tests pass in about four seconds combined
- go vet ./... passes
- pre-commit formatting, lint, generation, and vet gates pass
- the full fast sharded sweep was attempted; unrelated host failures were filed as gsc-v2k (fake standalone-Dolt processes become defunct, one oddball-root environment expectation, and one timing flake that passed in isolation)