### PR TITLE
test(supervisor): inject controller probe in standalone-reject tests

### DIFF
--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -38,6 +38,11 @@ var (
 	registerCityWithSupervisorTestHook func(cityPath, commandName string, stdout, stderr io.Writer) (bool, int)
 	supervisorCityErrorHook            = supervisorCityError
 	reloadSupervisorNoWaitHook         = reloadSupervisorNoWait
+	// controllerAliveHook is the standalone-controller probe. Defaults to the
+	// real socket probe; tests override it to detect a controller without
+	// depending on a live socket-accept handshake racing the probe's read
+	// deadline under parallel/high-load runs (#3847).
+	controllerAliveHook = controllerAlive
 )
 
 // assumeYesForSupervisorCycle is set by the --yes flag on commands that
@@ -179,7 +184,7 @@ func cityUsesManagedReconciler(cityPath string) bool {
 var justRestartedSupervisorPID int
 
 func ensureNoStandaloneController(cityPath string) (int, error) {
-	if pid := controllerAlive(cityPath); pid != 0 {
+	if pid := controllerAliveHook(cityPath); pid != 0 {
 		// If we just auto-restarted the supervisor in this invocation,
 		// the new supervisor process is briefly visible on the controller
 		// socket before the registry catches up. Treat that as our own

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -22,6 +22,18 @@ import (
 	"github.com/gastownhall/gascity/internal/supervisor"
 )
 
+// withControllerAlive overrides the standalone-controller probe so the
+// registration-rejection tests exercise the reject path deterministically,
+// without depending on a real socket-accept handshake winning a race against
+// controllerAlive's read deadline under parallel/high-load runs (#3847). The
+// real probe mechanics stay covered by controller_test.go.
+func withControllerAlive(t *testing.T, pid int) {
+	t.Helper()
+	prev := controllerAliveHook
+	controllerAliveHook = func(string) int { return pid }
+	t.Cleanup(func() { controllerAliveHook = prev })
+}
+
 //nolint:unparam // tests override hook behavior but keep fixed timeout/poll values for determinism
 func withSupervisorTestHooks(t *testing.T, ensure func(stdout, stderr io.Writer) int, reload func(stdout, stderr io.Writer) int, alive func() int, running func(string) (bool, string, bool), timeout, poll time.Duration) {
 	t.Helper()
@@ -705,25 +717,8 @@ func TestRegisterCityWithSupervisorRejectsStandaloneController(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sockPath := filepath.Join(cityPath, ".gc", "controller.sock")
-	lis, err := net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer lis.Close() //nolint:errcheck // test cleanup
-
-	go func() {
-		conn, acceptErr := lis.Accept()
-		if acceptErr != nil {
-			return
-		}
-		defer conn.Close() //nolint:errcheck // test cleanup
-		buf := make([]byte, 32)
-		n, _ := conn.Read(buf)
-		if strings.Contains(string(buf[:n]), "ping") {
-			conn.Write([]byte("4242\n")) //nolint:errcheck // best-effort reply
-		}
-	}()
+	// Inject the standalone-controller probe (PID 4242) — no live socket (#3847).
+	withControllerAlive(t, 4242)
 
 	var stdout, stderr bytes.Buffer
 	code := registerCityWithSupervisor(cityPath, &stdout, &stderr, "gc start", true)
@@ -867,25 +862,8 @@ func TestRegisterCityWithSupervisorRejectsStandaloneControllerForStoppedManagedC
 		t.Fatal(err)
 	}
 
-	sockPath := filepath.Join(cityPath, ".gc", "controller.sock")
-	lis, err := net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer lis.Close() //nolint:errcheck // test cleanup
-
-	go func() {
-		conn, acceptErr := lis.Accept()
-		if acceptErr != nil {
-			return
-		}
-		defer conn.Close() //nolint:errcheck // test cleanup
-		buf := make([]byte, 32)
-		n, _ := conn.Read(buf)
-		if strings.Contains(string(buf[:n]), "ping") {
-			conn.Write([]byte("4242\n")) //nolint:errcheck // best-effort reply
-		}
-	}()
+	// Inject the standalone-controller probe (PID 4242) — no live socket (#3847).
+	withControllerAlive(t, 4242)
 
 	withSupervisorTestHooks(
 		t,
@@ -985,25 +963,8 @@ func TestRegisterCityWithSupervisorRejectsStandaloneControllerDuringSupervisorSt
 		t.Fatal(err)
 	}
 
-	sockPath := filepath.Join(cityPath, ".gc", "controller.sock")
-	lis, err := net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer lis.Close() //nolint:errcheck // test cleanup
-
-	go func() {
-		conn, acceptErr := lis.Accept()
-		if acceptErr != nil {
-			return
-		}
-		defer conn.Close() //nolint:errcheck // test cleanup
-		buf := make([]byte, 32)
-		n, _ := conn.Read(buf)
-		if strings.Contains(string(buf[:n]), "ping") {
-			conn.Write([]byte("4242\n")) //nolint:errcheck // best-effort reply
-		}
-	}()
+	// Inject the standalone-controller probe (PID 4242) — no live socket (#3847).
+	withControllerAlive(t, 4242)
 
 	withSupervisorTestHooks(
 		t,


### PR DESCRIPTION
## What

The `TestRegisterCityWithSupervisorRejectsStandaloneController*` family
(`RejectsStandaloneController`, `...ForStoppedManagedCity`,
`...DuringSupervisorStartupPhase`) in `cmd/gc/cmd_supervisor_city_test.go`
stood up a real unix-socket controller listener whose accept-goroutine
replied `4242` to a `ping`, then relied on the un-mocked production
`controllerAlive` probe (via `ensureNoStandaloneController`) to detect it.

This adds a `controllerAliveHook` seam — default `= controllerAlive`, so
runtime behavior is unchanged and it matches the file's existing `*Hook`
pattern — and has the three tests inject it via a `withControllerAlive(t, pid)`
helper (saves/restores the hook via `t.Cleanup`) instead of a live socket.

## Why

Under parallel/high-load runs (`make test-fast-parallel`, `LOCAL_TEST_JOBS>=2`)
the accept-goroutine is starved and the probe burns its full ~2s read deadline
then misses, so `ensureNoStandaloneController` reports no standalone controller
and the test drifts toward its ~60s cap — tripping the pre-commit hook
intermittently on shared dev boxes. Detection is now deterministic and
independent of accept scheduling.

The real socket→PID probe mechanics stay covered by `controller_test.go`
(`TestControllerSocketFallbackUsesShortPathForLongCityPath`,
`TestSendControllerCommandWithReadTimeout`,
`TestSendControllerCommandWithTimeoutsTimesOutOnRead`), so this loses no
coverage; the three tests now own only the registration-rejection behavior.

Closes #3847.