### PR TITLE
Ensure gascity rigs inherit formula roles

### DIFF
--- a/internal/doctor/checks_rig_coverage.go
+++ b/internal/doctor/checks_rig_coverage.go
@@ -112,7 +112,7 @@ func (c *RigPackCoverageCheck) Run(_ *CheckContext) *CheckResult {
 	r.Status = StatusWarning
 	r.Message = fmt.Sprintf("%d rig-scoped named_session(s) not covered by rig imports", len(issues))
 	r.Details = issues
-	r.FixHint = "add [defaults.rig.imports.<pack>] to pack.toml or add the pack to each rig's [imports]"
+	r.FixHint = "add [defaults.rig.imports.<pack>] to city.toml or add the pack to each rig's [imports]"
 	return r
 }
 

--- a/internal/doctor/checks_rig_coverage_test.go
+++ b/internal/doctor/checks_rig_coverage_test.go
@@ -271,6 +271,9 @@ mode = "always"
 	if !strings.Contains(r.FixHint, "defaults.rig.imports") {
 		t.Errorf("FixHint = %q, want it to mention [defaults.rig.imports] to guide the operator to the actual config knob", r.FixHint)
 	}
+	if strings.Contains(r.FixHint, "pack.toml") {
+		t.Errorf("FixHint = %q, want default rig imports to point at city.toml", r.FixHint)
+	}
 }
 
 // TestRigPackCoverageCheck_PackWithoutRigSessions asserts that a pack


### PR DESCRIPTION
## Summary
- make fresh `gascity` template cities add `gascity/roles` as a default rig import
- keep the roles import pinned to the same gascity-packs content commit as the formula pack
- correct the rig-pack-coverage doctor hint so default rig imports point at `city.toml`, not `pack.toml`

## Why
The public `gascity` pack exposes formulas such as `build-basic`, and those formulas dispatch work to rig-local `gc.*` role agents, especially `gc.run-operator`. A fresh `gc init` followed by `gc rig add` could therefore create a rig that can see the formulas but cannot run them, failing with messages like `unknown formulas v2 target "gc.run-operator"` or `agent "gc.run-operator" not found`.

`gc rig add` already knows how to copy `[defaults.rig.imports]` into new rigs. This PR wires the gascity template into that existing mechanism so newly added rigs inherit the companion roles pack automatically.

## Tests
- `go test ./cmd/gc ./internal/config ./internal/doctor -run 'TestDoInitWritesExpectedTOML|TestDoInitWithGascityTemplate|TestDoInitDefaultTemplateImportsGascityPack|TestDoRigAdd_RootPackDefaultRigImports|TestBundledSourcePinnedVersionNormalizesSpellings|TestSupersededPublicPackVersionsAreUnique|TestRigPackCoverageCheck_FixHint'`