### PR TITLE
fix(nudge): wake dormant managed sessions from the supervisor dispatcher (#1543)

### DIFF
--- a/cmd/gc/nudge_dispatcher.go
+++ b/cmd/gc/nudge_dispatcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 // pingNudgeWakeSocketDialTimeout bounds how long a producer waits to dial
@@ -184,6 +185,28 @@ func dispatchAllQueuedNudges(cityPath string, cfg *config.City, store beads.Stor
 			continue
 		}
 		if !obs.Running {
+			// A dormant session (process gone) with a due queued nudge must be
+			// woken so the managed reconciler restarts it and the drain/dispatch
+			// path can then deliver; otherwise the item strands forever
+			// (issue #1543). Mirror the direct `gc session nudge` path
+			// (queueManagedSessionNudgeWake -> requestManagedNudgeWake): stamp an
+			// explicit wake request and poke the controller. We deliberately do
+			// NOT send-keys to the dead pane and do NOT increment delivered — a
+			// wake is not a live delivery, and the queued item stays Pending until
+			// the woken session drains it exactly once (atomic claim guards
+			// against double-delivery). requestManagedNudgeWake already guards
+			// terminal lifecycle states via session.WakeSession, returning a
+			// *session.WakeConflictError we swallow so a genuinely closed/closing
+			// session cannot be resurrected and does not fail the whole tick.
+			if canRequestManagedNudgeWake(target, store) {
+				if wErr := requestManagedNudgeWake(target, store); wErr != nil {
+					if _, conflict := session.WakeConflictState(wErr); !conflict && firstErr == nil {
+						firstErr = wErr
+					}
+				} else if pErr := nudgePokeController(cityPath); pErr != nil && firstErr == nil {
+					firstErr = pErr
+				}
+			}
 			continue
 		}
 		ok, err := tryDeliverQueuedNudgesByPoller(target, store, sp, defaultNudgePollQuiescence, obs)

--- a/cmd/gc/nudge_dispatcher_test.go
+++ b/cmd/gc/nudge_dispatcher_test.go
@@ -398,6 +398,111 @@ func TestDispatchAllQueuedNudgesNilCfg(t *testing.T) {
 	}
 }
 
+// TestDispatchAllQueuedNudgesWakesDormantSession is the regression guard for
+// issue #1543: a managed pool session that has gone dormant (process gone,
+// obs.Running == false) but that has a due queued nudge must be WOKEN by the
+// supervisor dispatcher, not silently skipped. Prior to the fix the dispatcher
+// hit the `!obs.Running` branch and `continue`d, so the queued item stranded
+// forever and routed work handed to an idle/dormant pool session was never
+// picked up. The fix routes the dormant case through the SAME managed-wake
+// primitive the direct `gc session nudge` path uses
+// (requestManagedNudgeWake -> session.WakeSession), which stamps
+// wake_request=explicit so the reconciler restarts the session; the queued
+// item stays Pending and is delivered exactly once after restart.
+func TestDispatchAllQueuedNudgesWakesDormantSession(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	clearInheritedCityRoutingEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+
+	// Create a managed session, then Suspend it so obs.Running == false while
+	// the session bead remains in a wakeable (non-terminal) lifecycle state.
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store.Store, fake, nil)
+	info, err := mgr.Create(context.Background(), "worker", "Worker", "claude", dir, "claude", nil, session.ProviderResume{}, runtime.Config{WorkDir: dir})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	// Consider the managed reconciler active for this city and count controller
+	// pokes so we can assert the dispatcher kicks the reconciler tick promptly.
+	prevManaged := nudgeCityUsesManagedReconciler
+	prevPoke := nudgePokeController
+	pokes := 0
+	nudgeCityUsesManagedReconciler = func(cityPath string) bool { return cityPath == dir }
+	nudgePokeController = func(cityPath string) error {
+		if cityPath != dir {
+			t.Fatalf("poke cityPath = %q, want %q", cityPath, dir)
+		}
+		pokes++
+		return nil
+	}
+	t.Cleanup(func() {
+		nudgeCityUsesManagedReconciler = prevManaged
+		nudgePokeController = prevPoke
+	})
+
+	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "review the deploy logs", time.Now().Add(-time.Minute))); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	snapshot, err := loadSessionBeadSnapshot(store.Store)
+	if err != nil {
+		t.Fatalf("loadSessionBeadSnapshot: %v", err)
+	}
+
+	delivered, err := dispatchAllQueuedNudges(dir, supervisorCfg(), store.Store, fake, snapshot)
+	if err != nil {
+		t.Fatalf("dispatchAllQueuedNudges: %v", err)
+	}
+
+	// Core assertion: the dormant session bead is stamped with an explicit wake
+	// request so the reconciler will restart it. RED before the fix (dispatcher
+	// just `continue`s → no wake), GREEN after.
+	updated, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := updated.Metadata["wake_request"]; got != string(session.WakeCauseExplicit) {
+		t.Fatalf("wake_request = %q, want %q (dormant session must be woken for issue #1543)", got, string(session.WakeCauseExplicit))
+	}
+	if got := updated.Metadata["wake_requested_at"]; got == "" {
+		t.Fatal("wake_requested_at = empty, want timestamp after dormant wake")
+	}
+
+	// The controller must be poked so the reconciler tick runs promptly.
+	if pokes != 1 {
+		t.Fatalf("pokes = %d, want 1 (controller must be kicked to restart the dormant session)", pokes)
+	}
+
+	// A wake is NOT a live delivery: the dispatcher must not send-keys to a
+	// stopped pane, and must not count the wake as a delivery (preserves the
+	// existing delivered-count contract). Guards against an over-eager fix.
+	if delivered != 0 {
+		t.Fatalf("delivered = %d, want 0 (waking a dormant session is not a live delivery)", delivered)
+	}
+	for _, call := range fake.Calls {
+		if call.Method == "Nudge" || call.Method == "NudgeNow" {
+			t.Fatalf("dispatcher delivered to a stopped session; saw runtime call %+v", call)
+		}
+	}
+
+	// The queued item is preserved (still Pending) so the woken session's
+	// start-hook drain / next dispatcher tick delivers it once it is running.
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("queue not preserved for post-wake delivery: pending=%d inFlight=%d dead=%d, want 1/0/0", len(pending), len(inFlight), len(dead))
+	}
+}
+
 // TestMaybeStartNudgePollerSkipsACPSessionInLegacyMode verifies the
 // legacy per-session poller still skips ACP sessions. A sidecar `gc
 // nudge poll` process can observe the ACP control socket, but it does


### PR DESCRIPTION
## Problem

Issue #1543: queued nudges are accepted but a dormant session never wakes to consume them.

The surviving open half is the supervisor-mode dispatcher. `dispatchAllQueuedNudges` (`cmd/gc/nudge_dispatcher.go`) scans the queue, resolves each pending agent to a `nudgeTarget`, and observes it. When the target's process is gone (`obs.Running == false`) the loop simply did:

```go
if !obs.Running {
    continue
}
```

For a **dormant managed pool session** that still holds a due queued nudge, this strands the item Pending forever: nothing ever restarts the session, so its start-hook drain never runs and the next dispatcher tick observes it dormant again and skips it once more. Routed work handed to an idle/dormant pool session is therefore never picked up.

## Root cause

The dispatcher never asked the managed reconciler to bring a dormant-but-wakeable session back. The wake mechanism already exists and is used everywhere else a nudge meets a stopped managed session:

- direct `gc session nudge` → `queueManagedSessionNudgeWake` → `requestManagedNudgeWake` → `session.WakeSession`
- `gc mail notify` (`cmd/gc/cmd_nudge.go:1057`): `if !obs.Running && canRequestManagedNudgeWake(target, store) { … wake + poke }`

The supervisor dispatcher loop was the one delivery path that omitted it. This is a genuine root-cause fix (make the dispatcher use the established wake primitive), not a symptom mask.

## The fix

`cmd/gc/nudge_dispatcher.go` (+1 import, ~+23 lines): in the `!obs.Running` branch, before continuing, request a managed wake for the dormant target using the **same** primitives the direct path uses:

```go
if canRequestManagedNudgeWake(target, store) {
    if wErr := requestManagedNudgeWake(target, store); wErr != nil {
        if _, conflict := session.WakeConflictState(wErr); !conflict && firstErr == nil {
            firstErr = wErr
        }
    } else if pErr := nudgePokeController(cityPath); pErr != nil && firstErr == nil {
        firstErr = pErr
    }
}
```

`requestManagedNudgeWake` → `session.WakeSession` stamps `wake_request=explicit` (+`wake_requested_at`), which `lifecycle_projection` turns into `WakeCauseExplicit` → `projectDesiredState` returns `DesiredStateRunning` → the reconciler restarts the session → the start-hook drain (and the now-`obs.Running` dispatcher) delivers.

Design choices, all verified correct:
- **Wake only, not enqueue-then-wake.** Unlike the mail path (`enqueueManagedNudgeThenWake`), the item is *already* enqueued here (that is why the agent is in `pendingAgents`); re-enqueueing would duplicate it. The queued item is left untouched (Pending) and the atomic claim in `claimDueQueuedNudgesForTarget` guarantees exactly-once delivery after restart.
- **No send-keys to the dead pane; `delivered` is not incremented.** A wake is not a live delivery, preserving the existing delivered-count contract.
- **Cannot resurrect a genuinely dead session.** `session.WakeSession` rejects `Closed`/`Closing`/non-continuity `Archived` via `lifecycleWakeConflictState`, returning `*session.WakeConflictError`, which is swallowed via `session.WakeConflictState` — so a terminal target is skipped and does not fail the whole tick.
- **Correctly gated.** `canRequestManagedNudgeWake` requires `store != nil`, a non-empty cityPath/sessionID, and a live reconciler (`cityUsesManagedReconciler` → `controllerAlive`/`supervisorAlive`). Non-managed / `store==nil` / legacy-mode cases short-circuit, so the pre-existing `SkipsACPSessionWhenNotRunning` contract still holds.

## Test evidence (RED → GREEN, independently reproduced)

New regression guard `TestDispatchAllQueuedNudgesWakesDormantSession` (`cmd/gc/nudge_dispatcher_test.go`) suspends a **real** managed session via `session.Manager`, enqueues a real queued nudge, runs the real `dispatchAllQueuedNudges`, and reads back the session bead. It is not a greppy tautology — it exercises the real Manager + dispatcher + `session.WakeSession` metadata path.

RED (production block + its import reverted to base `35fb51511`, test present) — reproduced independently in an isolated worktree:
```
--- FAIL: TestDispatchAllQueuedNudgesWakesDormantSession (0.04s)
    nudge_dispatcher_test.go:472: wake_request = "", want "explicit" (dormant session must be woken for issue #1543)
FAIL  github.com/gastownhall/gascity/cmd/gc
```

GREEN (committed fix):
```
--- PASS: TestDispatchAllQueuedNudgesWakesDormantSession (0.04s)
ok  github.com/gastownhall/gascity/cmd/gc
```

The test also asserts the anti-over-fix guards: `pokes==1`, `delivered==0`, no runtime `Nudge`/`NudgeNow` call, and the queue item stays Pending (1/0/0).

No-regression (independently re-run in isolation):
- All 8 `TestDispatchAllQueuedNudges*` PASS, including `SkipsACPSessionWhenNotRunning` (store==nil → wake path correctly not taken), `DeliversAndAcks`, and `DeliversToIdleACPSession`.
- `go build -buildvcs=false ./...` → exit 0; `go vet -buildvcs=false ./cmd/gc/` → exit 0.
- `go test ./internal/session/` (the wake primitive) → ok.

## Risks

Low, confined to the previously-inert dormant branch in supervisor mode. Repeated patrol ticks re-stamp `wake_request=explicit` + re-poke a still-dormant session until the reconciler restarts it; this is idempotent metadata (identical to the direct-nudge/mail semantics), self-limiting (the branch is not taken once running), and mutates no queue state, so exactly-once holds. Validated by unit tests over the real Manager/dispatcher/session-wake code paths, full-package + internal/session suites, build, and vet; a live supervisor-mode smoke (suspend a pool session, enqueue a nudge, observe reconciler restart + delivery) is recommended before deploy per the standard review-gate.

Closes #1543