### PR TITLE
docs: fix "cancellation" comment spelling

### DIFF
--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -517,7 +517,7 @@ func advanceSessionDrainsWithSessionsTraced(
 			}
 		}
 
-		// Cancelation check: if wake reasons reappeared, cancel the in-memory
+		// Cancellation check: if wake reasons reappeared, cancel the in-memory
 		// drain. Orphaned, suspended, and ordinary config-drift drains are not
 		// canceled here.
 		if drainReasonCancelable(ds.reason) {
@@ -569,7 +569,7 @@ func advanceSessionDrainsWithSessionsTraced(
 			}
 		}
 
-		// Pending-interaction guards and wake-based cancelation run before this
+		// Pending-interaction guards and wake-based cancellation run before this
 		// timeout path. Preserve that ordering if this block is refactored.
 		if clk.Now().After(ds.deadline) {
 			// Drain timed out — force stop.

--- a/cmd/gc/soft_reload.go
+++ b/cmd/gc/soft_reload.go
@@ -78,7 +78,7 @@ func formatSoftReloadFailedSessions(names []string) string {
 // The hash computation uses sessionCoreConfigForHash, the same canonical
 // reconciler drift-hash helper used by live and asleep drift detection.
 //
-// Returns accepted-session, failed-session, stale-drain-cancelation, and
+// Returns accepted-session, failed-session, stale-drain-cancellation, and
 // empty-desired-state diagnostics for the controller reply.
 func acceptConfigDriftAcrossSessions(
 	sessFront *session.InfoStore,


### PR DESCRIPTION
Fixes the misspelling `cancelation` → `cancellation` (double-l is the standard noun spelling) in three code comments:

- `cmd/gc/session_wake.go` (2 sites — drain cancellation check + wake-based cancellation note)
- `cmd/gc/soft_reload.go` (1 site — `stale-drain-cancellation` diagnostic doc)

Comment-only; zero runtime/behavior change.

Closes #3852

---
Provenance: prepared by an automated contributor (Sakana Fugu via the `pi` CLI) and validated end-to-end through our contribution pipeline — `make vet`, routed-test-rows check, the full `go test` fan-out, and a multi-pass automated review + city-knowledge scrutineer gate — all green on this commit before push.