### PR TITLE
fix(beads): tolerate non-string bead metadata on decode

### DIFF
--- a/cmd/gc/cmd_hook_claim_metadata_test.go
+++ b/cmd/gc/cmd_hook_claim_metadata_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+// TestDecodeHookClaimBeadsToleratesNonStringMetadata pins the fix for the
+// rig-wide claim outage (gcw-d95): the external `bd` CLI type-infers
+// `--set-metadata key=true` as a JSON boolean (and numbers as JSON numbers),
+// so a single bead carrying such a value used to poison the whole work_query
+// decode with "cannot unmarshal bool into Go struct field Bead.metadata of
+// type string" — failing decodeHookClaimBeads for the entire batch and
+// blocking every worker in the rig from claiming any work.
+//
+// The decoder must tolerate non-string metadata values by coercing them to
+// their string form, exactly as beads.StringMap already does on the bd list
+// path.
+func TestDecodeHookClaimBeadsToleratesNonStringMetadata(t *testing.T) {
+	output := `[{"id":"gcw-1","metadata":{"refinery_reviewed":true,"count":42,"note":"ok"}}]`
+
+	got, err := decodeHookClaimBeads(output)
+	if err != nil {
+		t.Fatalf("decodeHookClaimBeads returned error on non-string metadata: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("decoded %d beads, want 1", len(got))
+	}
+
+	meta := got[0].Metadata
+	for _, tc := range []struct{ key, want string }{
+		{"refinery_reviewed", "true"},
+		{"count", "42"},
+		{"note", "ok"},
+	} {
+		if meta[tc.key] != tc.want {
+			t.Errorf("metadata[%q] = %q, want %q", tc.key, meta[tc.key], tc.want)
+		}
+	}
+}
+
+// TestDecodeHookClaimBeadsOneBadBeadDoesNotPoisonBatch proves the batch-level
+// invariant that was the actual outage: a boolean-metadata bead sitting next to
+// ordinary beads must not drop the good beads from the claim candidate set.
+func TestDecodeHookClaimBeadsOneBadBeadDoesNotPoisonBatch(t *testing.T) {
+	output := `[{"id":"a","metadata":{"note":"fine"}},{"id":"b","metadata":{"gc.parked":true}},{"id":"c"}]`
+
+	got, err := decodeHookClaimBeads(output)
+	if err != nil {
+		t.Fatalf("decodeHookClaimBeads returned error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("decoded %d beads, want 3 (one bool-metadata bead must not drop the batch)", len(got))
+	}
+	if got[1].Metadata["gc.parked"] != "true" {
+		t.Errorf("metadata[gc.parked] = %q, want %q", got[1].Metadata["gc.parked"], "true")
+	}
+}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -55,16 +55,24 @@ type Bead struct {
 	Priority  *int      `json:"priority,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	// UpdatedAt is zero for legacy beads; UpdatedBefore falls back to CreatedAt.
-	UpdatedAt    time.Time         `json:"updated_at,omitempty,omitzero"`
-	Assignee     string            `json:"assignee,omitempty"`
-	From         string            `json:"from,omitempty"`
-	ParentID     string            `json:"parent,omitempty"`      // step → molecule; matches bd wire format
-	Ref          string            `json:"ref,omitempty"`         // formula step ID or formula name
-	Needs        []string          `json:"needs,omitempty"`       // dependency step refs
-	Description  string            `json:"description,omitempty"` // step instructions
-	Labels       []string          `json:"labels,omitempty"`
-	Metadata     map[string]string `json:"metadata,omitempty"`
-	Dependencies []Dep             `json:"dependencies,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at,omitempty,omitzero"`
+	Assignee    string    `json:"assignee,omitempty"`
+	From        string    `json:"from,omitempty"`
+	ParentID    string    `json:"parent,omitempty"`      // step → molecule; matches bd wire format
+	Ref         string    `json:"ref,omitempty"`         // formula step ID or formula name
+	Needs       []string  `json:"needs,omitempty"`       // dependency step refs
+	Description string    `json:"description,omitempty"` // step instructions
+	Labels      []string  `json:"labels,omitempty"`
+	// Metadata uses StringMap (not map[string]string) so decode tolerates the
+	// non-string JSON values the external bd CLI emits — `--set-metadata
+	// key=true` is type-inferred to a JSON boolean, and a strict decode of a
+	// single such bead used to poison the whole `gc hook --claim` work_query
+	// batch, blocking every worker in the rig from claiming. StringMap coerces
+	// bool/number values to their string form on decode and its underlying type
+	// is map[string]string, so every read/write call site is unaffected and the
+	// marshaled wire form is unchanged (still string-valued).
+	Metadata     StringMap `json:"metadata,omitempty"`
+	Dependencies []Dep     `json:"dependencies,omitempty"`
 	// Ephemeral routes the bead to the wisps tier on Create. Wisps live in
 	// a separate Dolt table, are not git-synced, and are eligible for TTL
 	// garbage collection. Reads must opt in via ListQuery.TierMode (or the

--- a/internal/nudgequeue/store_test.go
+++ b/internal/nudgequeue/store_test.go
@@ -50,7 +50,7 @@ func TestSaveEmitsByteIdenticalCreate(t *testing.T) {
 		t.Fatalf("Create calls = %d, want 1", len(creates))
 	}
 	got := creates[0].Bead
-	wantMeta := map[string]string{
+	wantMeta := beads.StringMap{
 		"nudge_id":           "nudge-xyz",
 		"agent":              "polecat-3",
 		"session_id":         "sess-1",

--- a/internal/session/create_test.go
+++ b/internal/session/create_test.go
@@ -137,8 +137,8 @@ func TestCreateSessionByteIdenticalPoolWithExplicitID(t *testing.T) {
 	if !reflect.DeepEqual(got.Labels, wantLabels) {
 		t.Errorf("Create bead Labels = %#v, want %#v", got.Labels, wantLabels)
 	}
-	if !reflect.DeepEqual(got.Metadata, meta) {
-		t.Errorf("Create bead Metadata = %#v, want %#v", got.Metadata, meta)
+	if !reflect.DeepEqual(got.Metadata, beads.StringMap(meta)) {
+		t.Errorf("Create bead Metadata = %#v, want %#v", got.Metadata, beads.StringMap(meta))
 	}
 }
 
@@ -199,8 +199,8 @@ func TestCreateSessionByteIdenticalAdoptionBarrier(t *testing.T) {
 	if !reflect.DeepEqual(got.Labels, wantLabels) {
 		t.Errorf("Create bead Labels = %#v, want %#v", got.Labels, wantLabels)
 	}
-	if !reflect.DeepEqual(got.Metadata, meta) {
-		t.Errorf("Create bead Metadata = %#v, want %#v", got.Metadata, meta)
+	if !reflect.DeepEqual(got.Metadata, beads.StringMap(meta)) {
+		t.Errorf("Create bead Metadata = %#v, want %#v", got.Metadata, beads.StringMap(meta))
 	}
 }
 


### PR DESCRIPTION
## Problem

`bd`'s `--set-metadata key=true` (and numeric values) are persisted as JSON **booleans/numbers** rather than strings. `decodeHookClaimBeads` unmarshals the entire `work_query` result into `[]beads.Bead` in a single pass, and `Bead.Metadata` is `map[string]string`, so a single bead carrying a non-string metadata value fails the **whole batch** decode:

```
json: cannot unmarshal bool into Go struct field Bead.metadata of type string
```

Because the decode is one pass over the whole result set, one such bead makes `gc hook --claim` return an error for **every** worker sharing that `work_query` — i.e. a single bead can block an entire rig from claiming work. Keys observed in the wild: `refinery_reviewed`, `no_e2e_waiver`, `gc.parked`.

## Fix

Change `Bead.Metadata` from `map[string]string` to the existing **`beads.StringMap`**, which was introduced in #1051 for cache-event metadata and coerces bool/number values to their string form on decode. This just applies that same tolerance to the bead decode path.

`StringMap`'s underlying type is `map[string]string`, so:
- every read/write call site is unchanged (`go build ./...` clean);
- the marshaled wire form is unchanged (still string-valued);
- the generated OpenAPI spec is unchanged — confirmed by the spec-in-sync test (Huma renders it identically as `additionalProperties: string`, no new `$ref`).

## Tests

- `TestDecodeHookClaimBeadsToleratesNonStringMetadata` — boolean/number metadata decodes, coerced to `"true"` / `"42"`.
- `TestDecodeHookClaimBeadsOneBadBeadDoesNotPoisonBatch` — a bool-metadata bead alongside good beads no longer drops the batch.

Both fail on `main` with the error above and pass with the change.

## Notes

The `--set-metadata` type-inference itself lives in `bd`; this change makes the reader tolerant so a boolean/number value is harmless regardless. Other `map[string]string` metadata decode sites that consume bd bead output (`bdIssue`, cache events) already use `StringMap`; this closes the remaining one on the `Bead` decode path.