### PR TITLE
fix(session): poke controller on gc session kill so named sessions revive promptly

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -2206,6 +2206,10 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 	return cmd
 }
 
+// sessionKillPokeController is a mutable global test seam over pokeController.
+// Tests that swap it MUST NOT call t.Parallel().
+var sessionKillPokeController = pokeController
+
 // cmdSessionKill is the CLI entry point for "gc session kill".
 func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
 	asJSON := sessionJSONRequested(jsonOutput)
@@ -2273,6 +2277,17 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 		if err := store.SetMetadataBatch(sessionID, patch); err != nil {
 			fmt.Fprintf(stderr, "gc session kill: warning: syncing session %s to asleep: %v\n", sessionID, err) //nolint:errcheck // best-effort stderr
 		}
+	}
+
+	// Poke the controller after the asleep sync so the reconciler observes the
+	// killed state immediately instead of waiting a full patrol interval to
+	// revive an always-named session (#3812), the same poke-after-state-write
+	// approach the drain-ack path uses (doRuntimeDrainAck). Best-effort and
+	// unconditional: a poke failure (e.g. no controller running) is non-fatal,
+	// and a spurious poke when the asleep sync was skipped is harmless — the
+	// reconciler observes unchanged state and continues.
+	if err := sessionKillPokeController(cityPath); err != nil {
+		fmt.Fprintf(stderr, "gc session kill: warning: poke failed: %v\n", err) //nolint:errcheck // best-effort stderr
 	}
 
 	// Use the resolved session ID as the canonical Subject for event

--- a/cmd/gc/cmd_session_kill_poke_test.go
+++ b/cmd/gc/cmd_session_kill_poke_test.go
@@ -63,11 +63,11 @@ func newKillPokeSession(t *testing.T, identity, sessionName string) (beads.Store
 }
 
 // TestCmdSessionKill_PokesControllerAfterSleep pins #3812: a successful
-// `gc session kill` of an always-named session must poke the controller so the
-// reconciler revives it on the next poke-driven tick instead of waiting a full
-// patrol interval. The poke must fire exactly once, with the resolved cityPath,
-// and only AFTER the bead has been synced asleep (so the reconciler observes
-// the killed state when it converges).
+// `gc session kill` must poke the controller so the reconciler observes the
+// killed state promptly instead of waiting a full patrol interval. The poke
+// must fire exactly once, with the resolved cityPath, and only AFTER the bead
+// has been synced asleep (so the reconciler observes the killed state when it
+// converges).
 func TestCmdSessionKill_PokesControllerAfterSleep(t *testing.T) {
 	const identity = "session-a"
 	const sessionName = "s-gc-kill-poke"
@@ -104,7 +104,8 @@ func TestCmdSessionKill_PokesControllerAfterSleep(t *testing.T) {
 
 // TestCmdSessionKill_PokeFailureIsNonFatal pins the best-effort contract: a
 // poke failure (e.g. no controller running) must not fail the kill — the
-// session is already synced asleep and revives on the next patrol tick.
+// session state has already been synced asleep, so the reconciler observes it
+// on its normal convergence pass regardless of whether the poke landed.
 func TestCmdSessionKill_PokeFailureIsNonFatal(t *testing.T) {
 	const identity = "session-a"
 	const sessionName = "s-gc-kill-poke-fail"

--- a/cmd/gc/cmd_session_kill_poke_test.go
+++ b/cmd/gc/cmd_session_kill_poke_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// newKillPokeSession stands up a city, store, and fake runtime for an awake
+// named session, returning the store and the session bead. The fake provider
+// is wired through buildSessionProviderByName so cmdSessionKill resolves a real
+// handle and reaches the asleep-sync + poke tail.
+func newKillPokeSession(t *testing.T, identity, sessionName string) (beads.Store, beads.Bead, string) {
+	t.Helper()
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-kill-poke-")
+	t.Setenv("GC_CITY", cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
+
+	fakeProvider := runtime.NewFake()
+	oldBuild := buildSessionProviderByName
+	buildSessionProviderByName = func(*config.City, string, config.SessionConfig, string, string) (runtime.Provider, error) {
+		return fakeProvider, nil
+	}
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:  "named session",
+		Type:   sessionpkg.BeadType,
+		Labels: []string{sessionpkg.LabelSession, "template:worker"},
+		Metadata: map[string]string{
+			"alias":                      identity,
+			"template":                   "worker",
+			"agent_name":                 "gascity/gc.worker",
+			"session_name":               sessionName,
+			"state":                      "awake",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+	if err := fakeProvider.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("fakeProvider.Start: %v", err)
+	}
+	if err := fakeProvider.SetMeta(sessionName, "GC_SESSION_ID", bead.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+	return store, bead, cityDir
+}
+
+// TestCmdSessionKill_PokesControllerAfterSleep pins #3812: a successful
+// `gc session kill` of an always-named session must poke the controller so the
+// reconciler revives it on the next poke-driven tick instead of waiting a full
+// patrol interval. The poke must fire exactly once, with the resolved cityPath,
+// and only AFTER the bead has been synced asleep (so the reconciler observes
+// the killed state when it converges).
+func TestCmdSessionKill_PokesControllerAfterSleep(t *testing.T) {
+	const identity = "session-a"
+	const sessionName = "s-gc-kill-poke"
+	store, bead, cityDir := newKillPokeSession(t, identity, sessionName)
+
+	calls := 0
+	var gotCityPath, stateAtPoke string
+	old := sessionKillPokeController
+	sessionKillPokeController = func(cityPath string) error {
+		calls++
+		gotCityPath = cityPath
+		if b, gErr := store.Get(bead.ID); gErr == nil {
+			stateAtPoke = b.Metadata["state"]
+		}
+		return nil
+	}
+	t.Cleanup(func() { sessionKillPokeController = old })
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionKill([]string{identity}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionKill = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if calls != 1 {
+		t.Fatalf("poke called %d times, want exactly 1", calls)
+	}
+	if gotCityPath != cityDir {
+		t.Errorf("poke cityPath = %q, want %q", gotCityPath, cityDir)
+	}
+	if stateAtPoke != string(sessionpkg.StateAsleep) {
+		t.Errorf("state at poke time = %q, want %q (poke must run after the SleepPatch write)", stateAtPoke, sessionpkg.StateAsleep)
+	}
+}
+
+// TestCmdSessionKill_PokeFailureIsNonFatal pins the best-effort contract: a
+// poke failure (e.g. no controller running) must not fail the kill — the
+// session is already synced asleep and revives on the next patrol tick.
+func TestCmdSessionKill_PokeFailureIsNonFatal(t *testing.T) {
+	const identity = "session-a"
+	const sessionName = "s-gc-kill-poke-fail"
+	_, _, _ = newKillPokeSession(t, identity, sessionName)
+
+	old := sessionKillPokeController
+	sessionKillPokeController = func(string) error { return errors.New("dial failed") }
+	t.Cleanup(func() { sessionKillPokeController = old })
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionKill([]string{identity}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionKill = %d, want 0 (poke failure is best-effort); stderr=%s", code, stderr.String())
+	}
+}


### PR DESCRIPTION
Fixes #3812.

## What

`cmdSessionKill` synced the killed session's bead to `asleep` and recorded `SessionStopped`, but never poked the controller. An always-named session then waited for the reconcile loop's next patrol tick (~4-5m) to revive, instead of reviving immediately off the poke channel.

This adds a best-effort controller poke right after the asleep sync, mirroring the drain-ack path's poke-after-state-write. A poke failure stays non-fatal: the session still revives on the next tick, so the change only removes the latency, it never adds a new failure mode.

## Why it matters

`gc session kill` is the documented recovery step for a wedged named session (mayor, supervisor-managed singletons). The multi-minute revive gap made kill-then-wait feel broken during recovery, and it was the specific delay behind the mayor revive-latency this fixes.

## Changes

- `cmd/gc/cmd_session.go` (+15) — poke the controller after the asleep state-write in `cmdSessionKill`.
- `cmd/gc/cmd_session_kill_poke_test.go` (+121) — test seam asserting the poke fires on kill.

## Test plan

- `make build`, `go vet ./cmd/gc/...`, `golangci-lint run ./cmd/gc/...` — green.
- `go test ./cmd/gc/ -run PokesController` — the new test asserts the controller poke is issued after the kill state-write.
- Rebased onto current `origin/main` and re-verified before push (branch was a day old).
