### PR TITLE
Fix session scaffold staging for task work_dir

### DIFF
--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -616,7 +616,7 @@ func TestResolveTaskWorkDirIncludesAssignedWisp(t *testing.T) {
 		t.Fatalf("mark wisp in progress: %v", err)
 	}
 
-	if got := resolveTaskWorkDir(store, "worker-session"); got != workDir {
+	if got := resolveTaskWorkDir("", store, "worker-session"); got != workDir {
 		t.Fatalf("resolveTaskWorkDir = %q, want assigned wisp work_dir %q", got, workDir)
 	}
 }

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -780,7 +780,7 @@ func prepareStartCandidateForCity(
 		return nil, err
 	}
 	candidate = refreshConfiguredNamedStartCandidate(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
-	return buildPreparedStartWithWorkDirResolver(candidate, cfg, store, workDirResolver)
+	return buildPreparedStartWithWorkDirResolver(candidate, cityPath, cfg, store, workDirResolver)
 }
 
 func refreshConfiguredNamedStartCandidate(
@@ -822,11 +822,12 @@ func buildPreparedStart(
 	cfg *config.City,
 	store beads.Store,
 ) (*preparedStart, error) {
-	return buildPreparedStartWithWorkDirResolver(candidate, cfg, store, nil)
+	return buildPreparedStartWithWorkDirResolver(candidate, "", cfg, store, nil)
 }
 
 func buildPreparedStartWithWorkDirResolver(
 	candidate startCandidate,
+	cityPath string,
 	cfg *config.City,
 	store beads.Store,
 	workDirResolver taskWorkDirResolver,
@@ -871,11 +872,18 @@ func buildPreparedStartWithWorkDirResolver(
 		applySchemaOptionOverridesForLaunch(&agentCfg, &tp, session.ID, launchOverrides)
 	}
 
-	if wd := resolvePreparedTaskWorkDir(candidate, cfg, store, workDirResolver); wd != "" {
+	preOverrideWorkDir := agentCfg.WorkDir
+	if wd := resolvePreparedTaskWorkDir(candidate, cityPath, cfg, store, workDirResolver); wd != "" {
 		agentCfg.WorkDir = wd
 	} else if wd := session.Metadata["work_dir"]; wd != "" {
-		agentCfg.WorkDir = wd
+		agentCfg.WorkDir = resolveWorkDirAgainstCity(cityPath, wd)
 	}
+	// The task work_dir override above can replace agentCfg.WorkDir after
+	// template resolution already rendered PreStart commands (materialize-
+	// skills, MCP projection) against the pre-override directory. Retarget
+	// those already-rendered strings so scaffold staging lands next to the
+	// session it actually launches into, not the directory templating assumed.
+	agentCfg.PreStart = retargetPreStartWorkDir(agentCfg.PreStart, preOverrideWorkDir, agentCfg.WorkDir)
 	// Pre-flight stale-resume guard: if the bead carries a session_key whose
 	// keyed transcript is no longer on disk (provider session retention
 	// disabled, manual cleanup, worktree rebuild), a resume would hard-fail
@@ -1100,6 +1108,7 @@ func applySchemaOptionOverridesForLaunch(agentCfg *runtime.Config, tp *TemplateP
 
 func resolvePreparedTaskWorkDir(
 	candidate startCandidate,
+	cityPath string,
 	cfg *config.City,
 	store beads.Store,
 	workDirResolver taskWorkDirResolver,
@@ -1109,7 +1118,21 @@ func resolvePreparedTaskWorkDir(
 			return workDir
 		}
 	}
-	return resolveTaskWorkDir(store, taskWorkDirAssignees(candidate, cfg)...)
+	return resolveTaskWorkDir(cityPath, store, taskWorkDirAssignees(candidate, cfg)...)
+}
+
+// retargetPreStartWorkDir rewrites PreStart command strings rendered against
+// oldWorkDir so they instead reference newWorkDir. A no-op when the task
+// work_dir override left WorkDir unchanged, which is the common case.
+func retargetPreStartWorkDir(preStart []string, oldWorkDir, newWorkDir string) []string {
+	if oldWorkDir == "" || newWorkDir == "" || oldWorkDir == newWorkDir || len(preStart) == 0 {
+		return preStart
+	}
+	retargeted := make([]string, len(preStart))
+	for i, cmd := range preStart {
+		retargeted[i] = strings.ReplaceAll(cmd, oldWorkDir, newWorkDir)
+	}
+	return retargeted
 }
 
 func taskWorkDirAssignees(candidate startCandidate, cfg *config.City) []string {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1124,13 +1124,23 @@ func resolvePreparedTaskWorkDir(
 // retargetPreStartWorkDir rewrites PreStart command strings rendered against
 // oldWorkDir so they instead reference newWorkDir. A no-op when the task
 // work_dir override left WorkDir unchanged, which is the common case.
+//
+// The generated materialize-skills and project-mcp PreStart commands embed the
+// workdir as a shell-quoted token (see appendMaterializeSkillsPreStart and
+// appendProjectMCPPreStart). Swap the shell-quoted old token for the
+// shell-quoted new token so the rewritten `sh -c` command keeps valid POSIX
+// quoting even when the resolved workdir contains spaces or shell
+// metacharacters. Splicing the raw path in would break argument boundaries or
+// open a command-substitution surface.
 func retargetPreStartWorkDir(preStart []string, oldWorkDir, newWorkDir string) []string {
 	if oldWorkDir == "" || newWorkDir == "" || oldWorkDir == newWorkDir || len(preStart) == 0 {
 		return preStart
 	}
+	oldToken := shellquote.Join([]string{oldWorkDir})
+	newToken := shellquote.Join([]string{newWorkDir})
 	retargeted := make([]string, len(preStart))
 	for i, cmd := range preStart {
-		retargeted[i] = strings.ReplaceAll(cmd, oldWorkDir, newWorkDir)
+		retargeted[i] = strings.ReplaceAll(cmd, oldToken, newToken)
 	}
 	return retargeted
 }

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -820,7 +820,7 @@ func TestPrepareStartCandidate_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing
 		Agents: []config.Agent{
 			{Name: "worker", Dir: "frontend", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
 		},
-	}, nil, store, &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}, nil, newAssignedTaskWorkDirResolver([]beads.Bead{task}))
+	}, nil, store, &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}, nil, newAssignedTaskWorkDirResolver("", []beads.Bead{task}))
 	if err != nil {
 		t.Fatalf("prepareStartCandidateForCity: %v", err)
 	}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -1007,7 +1008,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	}
 	effectiveStartOptions := startOptions
 	if !storeQueryPartial && reconcileOpts.workDirResolver == nil && len(assignedWorkBeads) > 0 {
-		effectiveStartOptions = append(append([]startExecutionOption(nil), startOptions...), withTaskWorkDirResolver(newAssignedTaskWorkDirResolver(assignedWorkBeads)))
+		effectiveStartOptions = append(append([]startExecutionOption(nil), startOptions...), withTaskWorkDirResolver(newAssignedTaskWorkDirResolver(cityPath, assignedWorkBeads)))
 	}
 	if startupTimeout <= 0 && cfg != nil {
 		startupTimeout = cfg.Session.StartupTimeoutDuration()
@@ -3848,12 +3849,26 @@ func clearMissingIdleProbes(dt *drainTracker, beadByID map[string]*beads.Bead) {
 	}
 }
 
+// resolveWorkDirAgainstCity anchors a bead-stored work_dir value to the city
+// root. Worktree-per-bead dispatch stores this metadata city-relative (e.g.
+// ".gc/worktrees/gascity/builder/<slug>") so the value stays valid across
+// machines with different absolute city paths; resolving it with os.Stat
+// directly would instead resolve against the calling process's cwd, which is
+// how scaffold staging leaked into shared long-lived worktrees (ga-ajw1no).
+// Already-absolute values (the legacy convention) pass through unchanged.
+func resolveWorkDirAgainstCity(cityPath, workDir string) string {
+	if workDir == "" || cityPath == "" || filepath.IsAbs(workDir) {
+		return workDir
+	}
+	return filepath.Join(cityPath, workDir)
+}
+
 // resolveTaskWorkDir checks the agent's assigned task beads for a work_dir
 // metadata field. If a task bead has work_dir set and the directory exists
 // on disk, that path is returned. This lets the reconciler start the agent
 // in the worktree that the previous session (or this session's prior run)
 // created, without any prompt-side logic.
-func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
+func resolveTaskWorkDir(cityPath string, store beads.Store, assignees ...string) string {
 	if store == nil {
 		return ""
 	}
@@ -3876,10 +3891,12 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 		}
 		for _, b := range assigned {
 			wd := strings.TrimSpace(b.Metadata["work_dir"])
-			if wd != "" {
-				if info, err := os.Stat(wd); err == nil && info.IsDir() {
-					return wd
-				}
+			if wd == "" {
+				continue
+			}
+			resolved := resolveWorkDirAgainstCity(cityPath, wd)
+			if info, err := os.Stat(resolved); err == nil && info.IsDir() {
+				return resolved
 			}
 		}
 	}
@@ -3962,7 +3979,7 @@ type assignedTaskWorkDir struct {
 
 // newAssignedTaskWorkDirResolver resolves work_dir values from the
 // reconciler's snapshot; misses intentionally fall back to the live lookup.
-func newAssignedTaskWorkDirResolver(assignedWorkBeads []beads.Bead) taskWorkDirResolver {
+func newAssignedTaskWorkDirResolver(cityPath string, assignedWorkBeads []beads.Bead) taskWorkDirResolver {
 	index := make(map[string]assignedTaskWorkDir)
 	for _, bead := range assignedWorkBeads {
 		if bead.Status != "in_progress" {
@@ -3976,6 +3993,7 @@ func newAssignedTaskWorkDirResolver(assignedWorkBeads []beads.Bead) taskWorkDirR
 		if workDir == "" {
 			continue
 		}
+		workDir = resolveWorkDirAgainstCity(cityPath, workDir)
 		info, err := os.Stat(workDir)
 		if err != nil || !info.IsDir() {
 			continue

--- a/cmd/gc/session_scaffold_staging_test.go
+++ b/cmd/gc/session_scaffold_staging_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestPrepareStartCandidateStagesScaffoldInResolvedTaskWorkDirWhenCWDIsSharedWorktree(t *testing.T) {
+	root := t.TempDir()
+	cityPath := filepath.Join(root, "city")
+	sharedWorktree := filepath.Join(root, "shared-builder")
+	beadSlug := "ga-ajw1no-1-as-a-maintainer-i-can-reproduce-stray-session-scaffold-leakage"
+	leakedWorkDir := filepath.Join(sharedWorktree, beadSlug)
+	relativeTargetWorkDir := filepath.Join(".gc", "worktrees", "gascity", "builder", beadSlug)
+	targetWorkDir := filepath.Join(cityPath, relativeTargetWorkDir)
+	packOverlay := filepath.Join(cityPath, "packs", "core", "overlay")
+
+	writeScaffoldFixture(t, filepath.Join(packOverlay, ".claude", "skills", "triage", "SKILL.md"), "---\nname: triage\n---\n")
+	writeScaffoldFixture(t, filepath.Join(packOverlay, ".codex", "hooks.json"), `{"hooks":{"SessionStart":[]}}`+"\n")
+	writeScaffoldFixture(t, filepath.Join(packOverlay, ".gc", "settings.json"), "{}\n")
+	if err := os.MkdirAll(targetWorkDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", targetWorkDir, err)
+	}
+	if err := os.MkdirAll(sharedWorktree, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", sharedWorktree, err)
+	}
+	t.Chdir(sharedWorktree)
+
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "builder",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity/builder"},
+		Metadata: map[string]string{
+			"template":     "builder",
+			"session_name": "builder-ga-ajw1no",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := store.Create(beads.Bead{
+		Title: "task",
+		Metadata: map[string]string{
+			"work_dir": relativeTargetWorkDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := "in_progress"
+	assignee := session.ID
+	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := prepareStartCandidateForCity(startCandidate{
+		session: &session,
+		tp: TemplateParams{
+			TemplateName: "gascity/builder",
+			SessionName:  "builder-ga-ajw1no",
+			WorkDir:      leakedWorkDir,
+			Env: map[string]string{
+				"GC_DIR": leakedWorkDir,
+			},
+			Hints: agent.StartupHints{
+				ProviderName:        "codex",
+				ProviderOverlayName: "codex",
+				PackOverlayDirs:     []string{packOverlay},
+				PreStart:            appendMaterializeSkillsPreStart(nil, "gascity/builder", leakedWorkDir),
+			},
+		},
+		order: 0,
+	}, cityPath, "city", &config.City{
+		Agents: []config.Agent{
+			{
+				Name:              "builder",
+				Dir:               "gascity",
+				MinActiveSessions: intPtrScaffoldRegression(1),
+				MaxActiveSessions: intPtrScaffoldRegression(2),
+			},
+		},
+	}, nil, store, &clock.Fake{Time: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)}, io.Discard, nil)
+	if err != nil {
+		t.Fatalf("prepareStartCandidateForCity: %v", err)
+	}
+
+	if prepared.cfg.WorkDir != targetWorkDir {
+		t.Errorf("prepared.cfg.WorkDir = %q, want resolved task work_dir %q", prepared.cfg.WorkDir, targetWorkDir)
+	}
+	if prepared.cfg.Env["GC_DIR"] != targetWorkDir {
+		t.Errorf("prepared.cfg.Env[GC_DIR] = %q, want %q", prepared.cfg.Env["GC_DIR"], targetWorkDir)
+	}
+	if len(prepared.cfg.PreStart) != 1 {
+		t.Fatalf("PreStart = %v, want materialize-skills entry", prepared.cfg.PreStart)
+	}
+	if !strings.Contains(prepared.cfg.PreStart[0], "--workdir "+targetWorkDir) {
+		t.Errorf("materialize-skills PreStart = %q, want resolved target workdir %q", prepared.cfg.PreStart[0], targetWorkDir)
+	}
+	if strings.Contains(prepared.cfg.PreStart[0], leakedWorkDir) {
+		t.Errorf("materialize-skills PreStart still targets shared-cwd bead slug %q: %q", leakedWorkDir, prepared.cfg.PreStart[0])
+	}
+
+	if err := runtime.StageSessionWorkDir(prepared.cfg); err != nil {
+		t.Fatalf("StageSessionWorkDir: %v", err)
+	}
+
+	for _, rel := range []string{
+		filepath.Join(".claude", "skills", "triage", "SKILL.md"),
+		filepath.Join(".codex", "hooks.json"),
+		filepath.Join(".gc", "settings.json"),
+	} {
+		if _, err := os.Stat(filepath.Join(targetWorkDir, rel)); err != nil {
+			t.Errorf("target scaffold %s missing under resolved workdir %q: %v", rel, targetWorkDir, err)
+		}
+	}
+	if _, err := os.Stat(leakedWorkDir); err == nil {
+		t.Fatalf("shared cwd contains stray bead-slug scaffold directory %q; scaffold must stay under %q", leakedWorkDir, targetWorkDir)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat leaked workdir %q: %v", leakedWorkDir, err)
+	}
+}
+
+func writeScaffoldFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func intPtrScaffoldRegression(n int) *int {
+	return &n
+}

--- a/cmd/gc/session_scaffold_staging_test.go
+++ b/cmd/gc/session_scaffold_staging_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
 func TestPrepareStartCandidateStagesScaffoldInResolvedTaskWorkDirWhenCWDIsSharedWorktree(t *testing.T) {
@@ -143,4 +144,95 @@ func writeScaffoldFixture(t *testing.T, path, content string) {
 
 func intPtrScaffoldRegression(n int) *int {
 	return &n
+}
+
+// TestRetargetPreStartWorkDirPreservesShellQuoting proves that retargeting a
+// generated materialize-skills / project-mcp PreStart command onto a resolved
+// task work_dir keeps the `--workdir` argument shell-safe. The generators emit
+// the workdir as a shell-quoted token; a resolved work_dir that contains a
+// space (macOS "/Users/First Last/...") or a shell metacharacter must not be
+// spliced in raw, or the rendered `sh -c` command breaks argument boundaries or
+// opens a command-substitution surface.
+func TestRetargetPreStartWorkDirPreservesShellQuoting(t *testing.T) {
+	t.Parallel()
+
+	const (
+		agentName  = "gascity/builder"
+		identity   = "gascity/gc.builder"
+		oldWorkDir = "/data/worktrees/gascity/builder/ga-clean"
+	)
+
+	generators := []struct {
+		label    string
+		preStart func(workDir string) []string
+	}{
+		{
+			label: "materialize-skills",
+			preStart: func(workDir string) []string {
+				return appendMaterializeSkillsPreStart(nil, agentName, workDir)
+			},
+		},
+		{
+			label: "project-mcp",
+			preStart: func(workDir string) []string {
+				return appendProjectMCPPreStart(nil, agentName, identity, workDir)
+			},
+		},
+	}
+
+	cases := []struct {
+		name       string
+		newWorkDir string
+	}{
+		{name: "space", newWorkDir: "/Users/John Doe/city/worktrees/gascity/builder/ga-target"},
+		{name: "command_substitution_with_space", newWorkDir: "/opt/proj $(touch pwned)/builder"},
+		{name: "command_substitution_no_space", newWorkDir: "/opt/$(id)/builder"},
+	}
+
+	for _, g := range generators {
+		for _, tc := range cases {
+			t.Run(g.label+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+				retargeted := retargetPreStartWorkDir(g.preStart(oldWorkDir), oldWorkDir, tc.newWorkDir)
+				if len(retargeted) != 1 {
+					t.Fatalf("retarget produced %d entries, want 1: %v", len(retargeted), retargeted)
+				}
+				cmd := retargeted[0]
+
+				// Structural: the new value must be embedded shell-quoted, exactly as
+				// a from-scratch generation would emit it. This catches metacharacter
+				// injection even when no whitespace forces a re-split.
+				wantToken := "--workdir " + shellquote.Join([]string{tc.newWorkDir})
+				if !strings.Contains(cmd, wantToken) {
+					t.Errorf("retargeted command missing shell-quoted workdir token %q:\n%s", wantToken, cmd)
+				}
+
+				// Behavioral: parsing the command with the same quoting rules the
+				// generator used must recover the intended workdir as a single arg.
+				if got := workdirArgFromCommand(t, cmd); got != tc.newWorkDir {
+					t.Errorf("parsed --workdir = %q, want %q\ncommand: %s", got, tc.newWorkDir, cmd)
+				}
+
+				// The stale pre-override path must be gone entirely.
+				if strings.Contains(cmd, oldWorkDir) {
+					t.Errorf("retargeted command still references old workdir %q:\n%s", oldWorkDir, cmd)
+				}
+			})
+		}
+	}
+}
+
+// workdirArgFromCommand parses a generated PreStart command with the same
+// POSIX quoting rules the generators use and returns the argument following the
+// final --workdir flag.
+func workdirArgFromCommand(t *testing.T, command string) string {
+	t.Helper()
+	args := shellquote.Split(command)
+	for i := len(args) - 1; i > 0; i-- {
+		if args[i-1] == "--workdir" {
+			return args[i]
+		}
+	}
+	t.Fatalf("no --workdir argument in command: %s", command)
+	return ""
 }

--- a/internal/runtime/tmux/staging_test.go
+++ b/internal/runtime/tmux/staging_test.go
@@ -48,3 +48,59 @@ func TestStageStartFilesSurfacesKiroPreservationWarning(t *testing.T) {
 		t.Fatalf("AGENTS.md = %q, want project instructions preserved", string(data))
 	}
 }
+
+func TestStageStartFilesKeepsScaffoldOutOfSpawnerCWD(t *testing.T) {
+	root := t.TempDir()
+	sharedWorktree := filepath.Join(root, "shared-builder")
+	beadSlug := "ga-ajw1no-1-as-a-maintainer-i-can-reproduce-stray-session-scaffold-leakage"
+	leakedWorkDir := filepath.Join(sharedWorktree, beadSlug)
+	workDir := filepath.Join(root, "city", ".gc", "worktrees", "gascity", "builder", beadSlug)
+	packOverlay := filepath.Join(root, "city", "packs", "core", "overlay")
+
+	writeTmuxScaffoldFixture(t, filepath.Join(packOverlay, ".claude", "skills", "triage", "SKILL.md"), "---\nname: triage\n---\n")
+	writeTmuxScaffoldFixture(t, filepath.Join(packOverlay, ".codex", "hooks.json"), `{"hooks":{"SessionStart":[]}}`+"\n")
+	writeTmuxScaffoldFixture(t, filepath.Join(packOverlay, ".gc", "settings.json"), "{}\n")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", workDir, err)
+	}
+	if err := os.MkdirAll(sharedWorktree, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", sharedWorktree, err)
+	}
+	t.Chdir(sharedWorktree)
+
+	var warnings bytes.Buffer
+	err := stageStartFiles(runtime.Config{
+		WorkDir:             workDir,
+		ProviderName:        "codex",
+		ProviderOverlayName: "codex",
+		PackOverlayDirs:     []string{packOverlay},
+	}, &warnings)
+	if err != nil {
+		t.Fatalf("stageStartFiles: %v", err)
+	}
+
+	for _, rel := range []string{
+		filepath.Join(".claude", "skills", "triage", "SKILL.md"),
+		filepath.Join(".codex", "hooks.json"),
+		filepath.Join(".gc", "settings.json"),
+	} {
+		if _, err := os.Stat(filepath.Join(workDir, rel)); err != nil {
+			t.Errorf("target scaffold %s missing under workdir %q: %v", rel, workDir, err)
+		}
+	}
+	if _, err := os.Stat(leakedWorkDir); err == nil {
+		t.Fatalf("shared cwd contains stray bead-slug scaffold directory %q; scaffold must stay under %q", leakedWorkDir, workDir)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat leaked workdir %q: %v", leakedWorkDir, err)
+	}
+}
+
+func writeTmuxScaffoldFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}

--- a/release-gates/ga-m9rkmi-session-scaffold-workdir-gate.md
+++ b/release-gates/ga-m9rkmi-session-scaffold-workdir-gate.md
@@ -1,0 +1,66 @@
+# Release Gate: session scaffold staging work_dir resolution
+
+Bead: `ga-m9rkmi`
+
+Source review beads: `ga-yuij34`, `ga-ji89ce`
+
+Candidate branch: `origin/builder/ga-ajw1no.2-session-scaffold-workdir`
+
+Deploy gate branch: `deploy/ga-m9rkmi-session-scaffold-workdir-gate`
+
+Candidate SHA: `74fdd38a7eb8c1bc8b2dd411c5c695507b965f90`
+
+Candidate cut point: `origin/main` at `5becf8854dc357392bef81e8da6eea9486a49999`
+
+Current `origin/main` during deploy gate: `5becf8854dc357392bef81e8da6eea9486a49999`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout; this gate uses the deployer prompt criteria and the repo testing guidance in `TESTING.md`.
+
+## Release Unit
+
+Included commits:
+
+| Commit | Summary |
+| --- | --- |
+| `5456d8ecf` | Reproduce session scaffold workdir leakage. |
+| `74fdd38a7` | Resolve task `work_dir` against the city root, not the reconciler process cwd. |
+
+Scoped file diff from the candidate cut point:
+
+```text
+M cmd/gc/assigned_work_scope_test.go
+M cmd/gc/session_lifecycle_parallel.go
+M cmd/gc/session_lifecycle_parallel_test.go
+M cmd/gc/session_reconciler.go
+A cmd/gc/session_scaffold_staging_test.go
+M internal/runtime/tmux/staging_test.go
+```
+
+The branch is based directly on current `origin/main`. Merge conflict check passed with `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD`; no conflict diagnostics were emitted.
+
+## Acceptance Evidence
+
+The candidate addresses the reviewed failure mode:
+
+- `resolveTaskWorkDir` and `newAssignedTaskWorkDirResolver` now resolve relative bead `work_dir` metadata against `cityPath` before statting it.
+- Already absolute `work_dir` values pass through unchanged via `filepath.IsAbs`.
+- `buildPreparedStartWithWorkDirResolver` and `resolvePreparedTaskWorkDir` receive `cityPath` so the prepared start path and reconciler snapshot path agree.
+- Rendered `PreStart` commands are retargeted when a task-level workdir override replaces the original template workdir, keeping scaffold materialization under the final session workdir.
+- The new regression proves a shared builder cwd does not receive a bead-slug scaffold directory, while the resolved city worktree receives `.claude`, `.codex`, and `.gc` scaffold files.
+- The companion cleanup review `ga-ji89ce` verified no separate deployable artifact: it confirmed live stray scaffold cleanup and the same code branch reviewed under `ga-yuij34`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+| --- | --- | --- | --- |
+| 1 | Review PASS present | PASS | `ga-yuij34` is closed with `REVIEWER VERDICT: PASS` for commits `5456d8ecf` and `74fdd38a7`. `ga-ji89ce` is closed with `REVIEWER VERDICT: PASS` for the companion cleanup verification. |
+| 2 | Acceptance criteria met | PASS | Code inspection confirmed city-root-relative resolution for task `work_dir`, absolute-path preservation, retargeting of rendered `PreStart` commands, and generic session/work_dir handling with no role-specific branch. New tests cover the shared-cwd leak and tmux scaffold staging guard. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc ./internal/runtime/tmux -run 'TestPrepareStartCandidateStagesScaffoldInResolvedTaskWorkDirWhenCWDIsSharedWorktree|TestStageStartFilesKeepsScaffoldOutOfSpawnerCWD|TestStartCandidate|TestResolveTaskWorkDir|TestSessionStart' -count=1`; `go build ./...`; `go vet ./...`; `go test ./internal/api -run TestHandleExtMsgInboundDefaultRouteMatchesMixedCaseProvider -count=1 -v`; `go test ./internal/api -run TestHandleExtMsgInboundDefaultRouteMatchesMixedCaseProvider -count=3 -v`; `go test ./internal/api -count=1`; final `make test-fast-parallel` retry passed all 8 fast jobs. Initial `make test-fast-parallel` attempt failed only in unrelated `internal/api` with `TempDir RemoveAll cleanup: directory not empty`; the failing test and full package passed immediately on rerun before the clean full fast-target retry. |
+| 4 | No high-severity review findings open | PASS | Review notes contain PASS verdicts and no unresolved HIGH findings. The reviewer recorded two optional non-blocking observations for future audit only: a similar relative-path pattern in retry dispatch and a harmless `cityPath=""` rebuild path. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before adding this gate artifact; the gate artifact is the only deployer change and is committed on the deploy gate branch. |
+| 6 | Branch diverges cleanly from main | PASS | `origin/main` and `HEAD` share merge base `5becf8854dc357392bef81e8da6eea9486a49999`; `git merge-tree` against current `origin/main` emitted a clean merged tree with no conflicts. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem and one behavior: session startup workdir resolution and scaffold staging for assigned task worktrees. All changed files are in `cmd/gc` session lifecycle/reconciler tests or `internal/runtime/tmux` staging tests. |
+
+## Gate Verdict
+
+PASS.


### PR DESCRIPTION
## What this changes

Session startup now resolves task `work_dir` metadata relative to the city root before checking or staging the session work directory. That fixes the case where worktree-per-bead dispatch stores a city-relative path and the reconciler process happens to be running from a shared builder checkout.

The practical effect is that scaffold files such as `.claude`, `.codex`, and `.gc` are staged into the assigned task worktree, not into a stray bead-named directory under the spawner's current directory. Existing absolute `work_dir` values keep their current behavior.

## Review notes

- The behavior change is limited to `cmd/gc` session lifecycle/reconciler workdir resolution and scaffold-staging tests.
- Rendered `PreStart` commands are retargeted when a task-level workdir override changes the final launch directory, so materialize-skills and related setup use the same workdir as the session launch.
- No config, API, database, or migration shape changes are introduced.
- Internal tracking: `ga-m9rkmi`; full release evidence is in the gate file.

## Test plan

- [x] `go test ./cmd/gc ./internal/runtime/tmux -run 'TestPrepareStartCandidateStagesScaffoldInResolvedTaskWorkDirWhenCWDIsSharedWorktree|TestStageStartFilesKeepsScaffoldOutOfSpawnerCWD|TestStartCandidate|TestResolveTaskWorkDir|TestSessionStart' -count=1`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api -count=1`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-m9rkmi-session-scaffold-workdir-gate.md`](release-gates/ga-m9rkmi-session-scaffold-workdir-gate.md)
