### PR TITLE
Gate pool resume decisions on bead readiness

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -310,10 +310,20 @@ func workBeadResumeReady(status string, ready bool) bool {
 // into a plain bead-ID map, built while beadList and storeRefs are still
 // index-aligned — i.e., before filterAssignedWorkBeadsForPoolDemand or any
 // other bead-dropping filter runs, since those filters do not produce a
-// correspondingly-filtered storeRefs slice. Bead IDs are globally unique
-// across stores in this fleet (unlike the small-integer-style IDs the
-// store-scoped key defends against elsewhere), so collapsing to a plain ID
-// key is safe for this map's consumer, the pool reconciler's resume tier.
+// correspondingly-filtered storeRefs slice.
+//
+// The collapse to a plain bead-ID key is a deliberate operational trade-off,
+// not an enforced invariant. Nothing asserts distinct bead-ID prefixes across
+// stores at config load — BdStore tracks only an owned prefix per store, not a
+// cross-store uniqueness guarantee — so on a shared-ID collision the last bead
+// written for that ID wins (last-write-wins by iteration order). The sibling
+// readyAssignedFlagsForBeads above keeps its store-scoped key precisely to
+// defend the wake path against that collision; this map's sole consumer, the
+// pool reconciler's resume tier, tolerates it because bead IDs are globally
+// unique across this fleet's stores in practice. That trade-off is pinned by
+// TestReadyAssignedByBeadIDAcceptsCrossStoreCollisionForPoolResumeUse, so a
+// future change in the ID-uniqueness assumption is caught there rather than
+// silently altering pool resume decisions.
 func readyAssignedByBeadID(readyAssigned map[storeScopedBeadKey]bool, beadList []beads.Bead, storeRefs []string) map[string]bool {
 	if len(beadList) == 0 {
 		return nil

--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -285,3 +285,46 @@ func readyAssignedFlagsForBeads(readyAssigned map[storeScopedBeadKey]bool, beadL
 	}
 	return flags
 }
+
+// workBeadResumeReady reports whether a work bead's status represents
+// actionable demand for a session to resume, wake, or stay awake:
+// in-progress work is always actionable; open work is actionable only when
+// it already passed a readiness/deps gate upstream (ready==true); any other
+// status is never actionable. This is the shared judgment that must be
+// applied everywhere a work bead can hold a session awake or trigger a
+// spawn — see ga-ebxikh, where the pool reconciler's resume tier was found
+// to be the third independent copy of this switch, and the only one
+// missing the readiness half of the check.
+func workBeadResumeReady(status string, ready bool) bool {
+	switch status {
+	case "in_progress":
+		return true
+	case "open":
+		return ready
+	default:
+		return false
+	}
+}
+
+// readyAssignedByBeadID collapses the store-scoped wake-demand readiness map
+// into a plain bead-ID map, built while beadList and storeRefs are still
+// index-aligned — i.e., before filterAssignedWorkBeadsForPoolDemand or any
+// other bead-dropping filter runs, since those filters do not produce a
+// correspondingly-filtered storeRefs slice. Bead IDs are globally unique
+// across stores in this fleet (unlike the small-integer-style IDs the
+// store-scoped key defends against elsewhere), so collapsing to a plain ID
+// key is safe for this map's consumer, the pool reconciler's resume tier.
+func readyAssignedByBeadID(readyAssigned map[storeScopedBeadKey]bool, beadList []beads.Bead, storeRefs []string) map[string]bool {
+	if len(beadList) == 0 {
+		return nil
+	}
+	byID := make(map[string]bool, len(beadList))
+	for i, wb := range beadList {
+		ref := ""
+		if i < len(storeRefs) {
+			ref = storeRefs[i]
+		}
+		byID[wb.ID] = readyAssigned[storeScopedBeadKey{StoreRef: ref, ID: wb.ID}]
+	}
+	return byID
+}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -863,11 +863,12 @@ func buildDesiredStateWithSessionBeads(
 		if len(scaleCheckPartialTemplates) > 0 {
 			fmt.Fprintf(stderr, "scaleCheck: PARTIAL — scale_check failed for %s, retaining affected sessions\n", strings.Join(sortedBoolMapKeys(scaleCheckPartialTemplates), ",")) //nolint:errcheck
 		}
+		poolReadyByID := readyAssignedByBeadID(readyAssigned, assignedWorkBeads, assignedWorkStoreRefs)
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.OpenInfos(), assignedWorkBeads, assignedWorkStoreRefs)
 		bp.assignedWorkBeads = poolWorkBeads
 		bp.poolScaleCheckPartialTemplates = poolScaleCheckPartialTemplates
 		bp.providerHealthSnapshot = loadProviderHealthSnapshot(cityPath)
-		poolDesiredStates := ComputePoolDesiredStatesWithDemandTraced(cfg, poolWorkBeads, sessionBeads.OpenInfos(), scaleCheckCounts, scaleCheckDemandByTemplate, trace)
+		poolDesiredStates := ComputePoolDesiredStatesWithDemandTraced(cfg, poolWorkBeads, sessionBeads.OpenInfos(), scaleCheckCounts, scaleCheckDemandByTemplate, trace, poolReadyByID)
 		bp.configurePoolSessionCreateFairShare(poolDesiredStates)
 		for _, poolState := range poolDesiredStates {
 			cfgAgent := findAgentByTemplate(cfg, poolState.Template)
@@ -938,17 +939,11 @@ func buildDesiredStateWithSessionBeads(
 			// the readiness check, an open assigned bead that entered the snapshot
 			// via the open-routed orphan-release pass (no deps gate) would keep an
 			// on-demand named session awake forever even while blocked.
-			switch wb.Status {
-			case "in_progress":
-			case "open":
-				ref := ""
-				if i < len(assignedWorkStoreRefs) {
-					ref = assignedWorkStoreRefs[i]
-				}
-				if !readyAssigned[storeScopedBeadKey{StoreRef: ref, ID: wb.ID}] {
-					continue
-				}
-			default:
+			ref := ""
+			if i < len(assignedWorkStoreRefs) {
+				ref = assignedWorkStoreRefs[i]
+			}
+			if !workBeadResumeReady(wb.Status, readyAssigned[storeScopedBeadKey{StoreRef: ref, ID: wb.ID}]) {
 				continue
 			}
 			assignee := strings.TrimSpace(wb.Assignee)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4195,7 +4195,7 @@ func TestRealizePoolDesiredSessionsLiveRetryPreservesLauncherWorkDir(t *testing.
 			bp.sessionBeads = snapshot
 
 			retry := workBead("fi-new", "worker", reusable.ID, "in_progress", 1)
-			states := ComputePoolDesiredStates(cfg, []beads.Bead{retry}, snapshot.OpenInfos(), nil)
+			states := ComputePoolDesiredStates(cfg, []beads.Bead{retry}, snapshot.OpenInfos(), nil, nil)
 			if len(states) != 1 || len(states[0].Requests) != 1 {
 				t.Fatalf("retry desired state = %#v, want one request", states)
 			}
@@ -6544,7 +6544,7 @@ func TestBuildDesiredState_RigOnDemandNamedSessionAssigneeWithRouteMaterializesN
 			if err != nil {
 				t.Fatalf("loadSessionBeads: %v", err)
 			}
-			poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts))
+			poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts, nil))
 			if poolDesired == nil {
 				poolDesired = map[string]int{}
 			}
@@ -7983,7 +7983,7 @@ func TestBuildDesiredState_ScaleCheckErrorPreservesDormantAffectedPoolSessionWit
 
 	poolDesired := retainScaleCheckPartialPoolDesired(
 		cfg,
-		PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts)),
+		PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts, nil)),
 		snapshot,
 		result.PoolScaleCheckPartialTemplates,
 	)
@@ -11983,7 +11983,7 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		snapshot := newSessionBeadSnapshot([]beads.Bead{activeSession})
 		poolDesired := retainScaleCheckPartialPoolDesired(
 			cfg,
-			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts)),
+			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts, nil)),
 			snapshot,
 			result.PoolScaleCheckPartialTemplates,
 		)
@@ -12024,7 +12024,7 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		snapshot := newSessionBeadSnapshot([]beads.Bead{awakeSession})
 		poolDesired := retainScaleCheckPartialPoolDesired(
 			cfg,
-			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts)),
+			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts, nil)),
 			snapshot,
 			result.PoolScaleCheckPartialTemplates,
 		)
@@ -12056,7 +12056,7 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		snapshot := newSessionBeadSnapshot([]beads.Bead{})
 		poolDesired := retainScaleCheckPartialPoolDesired(
 			cfg,
-			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts)),
+			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts, nil)),
 			snapshot,
 			result.PoolScaleCheckPartialTemplates,
 		)
@@ -12093,7 +12093,7 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		snapshot := newSessionBeadSnapshot([]beads.Bead{activeSession, creatingSession})
 		poolDesired := retainScaleCheckPartialPoolDesired(
 			cfg,
-			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts)),
+			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), result.ScaleCheckCounts, nil)),
 			snapshot,
 			result.PoolScaleCheckPartialTemplates,
 		)
@@ -12165,7 +12165,7 @@ func TestBuildDesiredState_ScaleCheckPartialPoolBlocksNewCreates(t *testing.T) {
 		}
 		poolDesired := retainScaleCheckPartialPoolDesired(
 			cfg,
-			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), partialResult.ScaleCheckCounts)),
+			PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.OpenInfos(), partialResult.ScaleCheckCounts, nil)),
 			snapshot,
 			partialResult.PoolScaleCheckPartialTemplates,
 		)

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2159,6 +2159,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
 	assignedWorkStoreRefs := result.AssignedWorkStoreRefs
+	poolReadyByID := readyAssignedByBeadID(result.ReadyAssigned, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
 	phaseStart := time.Now()
 	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores)
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments", phaseStart, map[string]any{
@@ -2199,7 +2200,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		poolDesired = retainScaleCheckPartialPoolDesired(
 			cr.cfg,
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-				cr.cfg, poolWorkBeads, sessionBeads.OpenInfos(), result.ScaleCheckCounts, trace)),
+				cr.cfg, poolWorkBeads, sessionBeads.OpenInfos(), result.ScaleCheckCounts, trace, poolReadyByID)),
 			sessionBeads,
 			result.PoolScaleCheckPartialTemplates,
 		)
@@ -2985,10 +2986,11 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 	filteredSnap := newSessionBeadSnapshotFromReconcileRows(filteredRows)
 	openInfos := filterSessionInfosByName(updated, reconcileNames)
 	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(filteredCfg, cr.cityPath, openInfos, wfcResult.AssignedWorkBeads, wfcResult.AssignedWorkStoreRefs)
+	poolReadyByID := readyAssignedByBeadID(wfcResult.ReadyAssigned, wfcResult.AssignedWorkBeads, wfcResult.AssignedWorkStoreRefs)
 	poolDesired := retainScaleCheckPartialPoolDesired(
 		filteredCfg,
 		PoolDesiredCounts(ComputePoolDesiredStates(
-			filteredCfg, poolWorkBeads, openInfos, wfcResult.ScaleCheckCounts)),
+			filteredCfg, poolWorkBeads, openInfos, wfcResult.ScaleCheckCounts, poolReadyByID)),
 		filteredSnap,
 		wfcResult.PoolScaleCheckPartialTemplates,
 	)
@@ -3200,10 +3202,11 @@ func (cr *CityRuntime) loadDemandSnapshot(
 			openSessionInfos = sessionBeads.OpenInfos()
 		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
+		poolReadyByID := readyAssignedByBeadID(result.ReadyAssigned, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
 		result.PoolDesiredCounts = retainScaleCheckPartialPoolDesired(
 			cr.cfg,
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-				cr.cfg, poolWorkBeads, openSessionInfos, result.ScaleCheckCounts, trace)),
+				cr.cfg, poolWorkBeads, openSessionInfos, result.ScaleCheckCounts, trace, poolReadyByID)),
 			sessionBeads,
 			result.PoolScaleCheckPartialTemplates,
 		)

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1505,7 +1505,7 @@ func TestBuiltInSlingPoolRouteContractUsesMetadataOnly(t *testing.T) {
 			"template":     "saitoc/polecat",
 			"session_name": polecatSession,
 		},
-	}}), map[string]int{"saitoc/polecat": 0})
+	}}), map[string]int{"saitoc/polecat": 0}, nil)
 	if len(states) != 1 || len(states[0].Requests) != 1 {
 		t.Fatalf("resume states = %#v, want one polecat resume request", states)
 	}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -944,10 +944,11 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	dt := newDrainTracker()
 	openInfos := sessionBeads.OpenInfos()
 	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, openInfos, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
+	poolReadyByID := readyAssignedByBeadID(dsResult.ReadyAssigned, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
 	poolDesired := retainScaleCheckPartialPoolDesired(
 		cfg,
 		PoolDesiredCounts(ComputePoolDesiredStates(
-			cfg, poolWorkBeads, openInfos, dsResult.ScaleCheckCounts)),
+			cfg, poolWorkBeads, openInfos, dsResult.ScaleCheckCounts, poolReadyByID)),
 		sessionBeads,
 		dsResult.PoolScaleCheckPartialTemplates,
 	)

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -498,6 +498,74 @@ func TestBuildAwakeInputFromReconciler_CrossStoreSameIDReadinessIsStoreScoped(t 
 	}
 }
 
+// TestReadyAssignedByBeadIDResolvesStoreScopedReadiness verifies the basic
+// contract: for beads with distinct IDs, readyAssignedByBeadID resolves each
+// one's store-scoped readiness verdict into a plain ID-keyed map, matching
+// what readyAssignedFlagsForBeads would report index-aligned.
+func TestReadyAssignedByBeadIDResolvesStoreScopedReadiness(t *testing.T) {
+	work := []beads.Bead{{ID: "ga-ready"}, {ID: "ga-blocked"}}
+	storeRefs := []string{"", "rig"}
+	readyAssigned := map[storeScopedBeadKey]bool{
+		{StoreRef: "", ID: "ga-ready"}: true,
+	}
+
+	got := readyAssignedByBeadID(readyAssigned, work, storeRefs)
+
+	if !got["ga-ready"] {
+		t.Fatal("ga-ready must resolve to true")
+	}
+	if got["ga-blocked"] {
+		t.Fatal("ga-blocked must resolve to false")
+	}
+}
+
+// TestReadyAssignedByBeadIDAcceptsCrossStoreCollisionForPoolResumeUse
+// documents the deliberate trade-off readyAssignedByBeadID makes for its one
+// consumer (the pool reconciler's resume tier, ga-ebxikh): unlike
+// readyAssignedFlagsForBeads (store-scoped, see
+// TestBuildAwakeInputFromReconciler_CrossStoreSameIDReadinessIsStoreScoped
+// above), collapsing to a plain bead-ID key means the LAST entry for a
+// shared ID wins. This is accepted because bead IDs are globally unique in
+// this fleet in practice; this test pins the resulting behavior so a future
+// change in ID-generation uniqueness assumptions is caught here rather than
+// silently changing pool resume decisions.
+func TestReadyAssignedByBeadIDAcceptsCrossStoreCollisionForPoolResumeUse(t *testing.T) {
+	const sharedID = "ga-shared"
+	work := []beads.Bead{{ID: sharedID}, {ID: sharedID}}
+	storeRefs := []string{"", "rig"}
+	readyAssigned := map[storeScopedBeadKey]bool{
+		{StoreRef: "", ID: sharedID}: true,
+	}
+
+	got := readyAssignedByBeadID(readyAssigned, work, storeRefs)
+
+	if got[sharedID] {
+		t.Fatal("last-write-wins: the rig copy (store ref \"rig\", not ready) must overwrite the city copy's true verdict")
+	}
+}
+
+func TestWorkBeadResumeReady(t *testing.T) {
+	cases := []struct {
+		name   string
+		status string
+		ready  bool
+		want   bool
+	}{
+		{"in_progress always actionable even when not marked ready", "in_progress", false, true},
+		{"open requires ready", "open", false, false},
+		{"open honors ready", "open", true, true},
+		{"closed never actionable", "closed", true, false},
+		{"empty status never actionable", "", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := workBeadResumeReady(tc.status, tc.ready); got != tc.want {
+				t.Errorf("workBeadResumeReady(%q, %v) = %v, want %v", tc.status, tc.ready, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAwakeSetToWakeEvalsPreservesDecisionReason(t *testing.T) {
 	evals := awakeSetToWakeEvals(
 		map[string]AwakeDecision{

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -695,14 +695,7 @@ func sessionHasAssignedWork(workBeads []AwakeWorkBead, named []AwakeNamedSession
 }
 
 func workBeadHasAwakeDemand(bead AwakeWorkBead) bool {
-	switch bead.Status {
-	case "in_progress":
-		return true
-	case "open":
-		return bead.Ready
-	default:
-		return false
-	}
+	return workBeadResumeReady(bead.Status, bead.Ready)
 }
 
 func sessionAssigneeMatches(named []AwakeNamedSession, bead AwakeSessionBead, assignee string) bool {

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -75,13 +75,24 @@ func PoolDesiredCounts(states []PoolDesiredState) map[string]int {
 // Each bead's gc.routed_to determines which agent template it belongs to.
 // scaleCheckCounts maps agent template → new session demand from scale_check.
 // Pass nil for either when unavailable.
+//
+// readyAssigned reports, per assignedWorkBeads[i].ID, whether an "open" bead
+// already passed a readiness/deps gate upstream (build via
+// readyAssignedByBeadID). A nil readyAssigned means no readiness snapshot
+// was threaded through by this caller yet and preserves legacy status-only
+// gating (every "open" bead is treated as ready) so existing callers are
+// unaffected; a non-nil map is authoritative and an unlisted bead ID is
+// treated as not ready. Production callers must always pass a real map —
+// see ga-ebxikh, where the absence of this gate let a BLOCKED-but-routed
+// bead repeatedly redispatch a session.
 func ComputePoolDesiredStates(
 	cfg *config.City,
 	assignedWorkBeads []beads.Bead,
 	sessionInfos []sessionpkg.Info,
 	scaleCheckCounts map[string]int,
+	readyAssigned map[string]bool,
 ) []PoolDesiredState {
-	return computePoolDesiredStates(cfg, assignedWorkBeads, sessionInfos, scaleCheckCounts, nil, nil)
+	return computePoolDesiredStates(cfg, assignedWorkBeads, sessionInfos, scaleCheckCounts, nil, nil, readyAssigned)
 }
 
 func ComputePoolDesiredStatesTraced(
@@ -90,8 +101,9 @@ func ComputePoolDesiredStatesTraced(
 	sessionInfos []sessionpkg.Info,
 	scaleCheckCounts map[string]int,
 	trace *sessionReconcilerTraceCycle,
+	readyAssigned map[string]bool,
 ) []PoolDesiredState {
-	return computePoolDesiredStates(cfg, assignedWorkBeads, sessionInfos, scaleCheckCounts, nil, trace)
+	return computePoolDesiredStates(cfg, assignedWorkBeads, sessionInfos, scaleCheckCounts, nil, trace, readyAssigned)
 }
 
 func ComputePoolDesiredStatesWithDemandTraced(
@@ -101,8 +113,9 @@ func ComputePoolDesiredStatesWithDemandTraced(
 	scaleCheckCounts map[string]int,
 	scaleCheckDemand map[string]scaleCheckDemand,
 	trace *sessionReconcilerTraceCycle,
+	readyAssigned map[string]bool,
 ) []PoolDesiredState {
-	return computePoolDesiredStates(cfg, assignedWorkBeads, sessionInfos, scaleCheckCounts, scaleCheckDemand, trace)
+	return computePoolDesiredStates(cfg, assignedWorkBeads, sessionInfos, scaleCheckCounts, scaleCheckDemand, trace, readyAssigned)
 }
 
 func computePoolDesiredStates(
@@ -112,6 +125,7 @@ func computePoolDesiredStates(
 	scaleCheckCounts map[string]int,
 	scaleCheckDemand map[string]scaleCheckDemand,
 	trace *sessionReconcilerTraceCycle,
+	readyAssigned map[string]bool,
 ) []PoolDesiredState {
 	// Build reverse lookup: any identifier → session bead ID.
 	// Assignee on work beads may be a bead ID, session name, alias, or
@@ -160,7 +174,11 @@ func computePoolDesiredStates(
 		// to a non-closed session bead. These sessions must stay alive.
 		for _, wb := range assignedWorkBeads {
 			routedTo := routedToOrLegacyWorkflowTarget(wb)
-			if wb.Status != "in_progress" && wb.Status != "open" {
+			ready := true
+			if readyAssigned != nil {
+				ready = readyAssigned[wb.ID]
+			}
+			if !workBeadResumeReady(wb.Status, ready) {
 				continue
 			}
 			assignee := strings.TrimSpace(wb.Assignee)

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -198,7 +198,7 @@ func TestComputePoolDesiredStates_ResumeBeatsNew(t *testing.T) {
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
 	scaleCheck := map[string]int{"rig/claude": 2}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -244,7 +244,7 @@ func TestComputePoolDesiredStates_ResumeResolvesAssigneeByAlias(t *testing.T) {
 		},
 	}}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -288,7 +288,7 @@ func TestComputePoolDesiredStates_ResumeUsesLegacyWorkflowRunTarget(t *testing.T
 		},
 	}}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -326,7 +326,7 @@ func TestComputePoolDesiredStates_ResumeResolvesAssigneeByAliasHistory(t *testin
 		},
 	}}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	reqs := result[0].Requests
 	if len(reqs) != 1 || reqs[0].SessionBeadID != "sess-vi6hhp" {
@@ -354,7 +354,7 @@ func TestComputePoolDesiredStates_ResumeResolvesPersistedBoundTemplate(t *testin
 		},
 	}}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -384,7 +384,7 @@ func TestComputePoolDesiredStates_WakeKnownIdentityResolvesPersistedBoundAssigne
 		workBead("gp-qx1o", legacyIdentity, legacyIdentity, "in_progress", 5),
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, nil, nil)
+	result := ComputePoolDesiredStates(cfg, work, nil, nil, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -405,7 +405,7 @@ func TestComputePoolDesiredStates_MaxCapsTotal(t *testing.T) {
 	// scale_check reports 3 demand, but max=2.
 	scaleCheck := map[string]int{"rig/claude": 3}
 
-	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -434,7 +434,7 @@ func TestComputePoolDesiredStates_TerminalProviderErrorSessionsDoNotBlockNewDema
 		sessionProviderTerminalErrorMetadataKey: "model_not_found",
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{stale}), map[string]int{"claude": 1})
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{stale}), map[string]int{"claude": 1}, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -458,7 +458,7 @@ func TestComputePoolDesiredStates_TraceListsActiveCapacityBlockers(t *testing.T)
 	sessions := []beads.Bead{sessionBead("sess-active", "open")}
 	trace := newPoolDesiredStateTestTrace("claude")
 
-	result := computePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), map[string]int{"claude": 1}, nil, trace)
+	result := computePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), map[string]int{"claude": 1}, nil, trace, nil)
 
 	if len(result) != 1 || len(result[0].Requests) != 1 || result[0].Requests[0].Tier != "resume" {
 		t.Fatalf("result = %#v, want only the active resume request under max_active_sessions=1", result)
@@ -499,7 +499,7 @@ func TestComputePoolDesiredStates_MaxCapsResumeBeads(t *testing.T) {
 		sessionBead("s3", "open"),
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	// Max=2: only 2 of the 3 in-progress beads get sessions.
 	if len(result) != 1 {
@@ -515,7 +515,7 @@ func TestComputePoolDesiredStates_MinFillsIdle(t *testing.T) {
 		Agents: []config.Agent{poolAgent("wf-ctrl", "", intPtr(1), 1)},
 	}
 
-	result := ComputePoolDesiredStates(cfg, nil, nil, nil)
+	result := ComputePoolDesiredStates(cfg, nil, nil, nil, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -530,7 +530,7 @@ func TestComputePoolDesiredStates_MinRespectsMax(t *testing.T) {
 		Agents: []config.Agent{poolAgent("worker", "", intPtr(0), 5)},
 	}
 
-	result := ComputePoolDesiredStates(cfg, nil, nil, nil)
+	result := ComputePoolDesiredStates(cfg, nil, nil, nil, nil)
 
 	// Max=0 should prevent any sessions even though min=5.
 	total := 0
@@ -556,7 +556,7 @@ func TestComputePoolDesiredStates_MaxOneTemplatesStillParticipateInDemand(t *tes
 		sessionBead("worker", "open"),
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1 for max=1 demand", len(result))
@@ -580,7 +580,7 @@ func TestComputePoolDesiredStates_WorkspaceCap(t *testing.T) {
 	}
 	scaleCheck := map[string]int{"rig/claude": 2, "rig/codex": 2}
 
-	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck, nil)
 
 	total := 0
 	for _, ds := range result {
@@ -602,7 +602,7 @@ func TestComputePoolDesiredStates_RigCap(t *testing.T) {
 	}
 	scaleCheck := map[string]int{"rig/claude": 2, "rig/codex": 1}
 
-	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck, nil)
 
 	total := 0
 	for _, ds := range result {
@@ -626,7 +626,7 @@ func TestComputePoolDesiredStates_NestedCaps(t *testing.T) {
 	}
 	scaleCheck := map[string]int{"rig/claude": 2, "rig/codex": 2}
 
-	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck, nil)
 
 	total := 0
 	perAgent := make(map[string]int)
@@ -653,7 +653,7 @@ func TestComputePoolDesiredStates_UnlimitedWhenUnset(t *testing.T) {
 	}
 	scaleCheck := map[string]int{"claude": 5}
 
-	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck, nil)
 
 	total := 0
 	for _, ds := range result {
@@ -673,7 +673,7 @@ func TestComputePoolDesiredStates_ClosedSessionNotResumed(t *testing.T) {
 	}
 	sessions := []beads.Bead{sessionBead("dead-session", "closed")}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	// The session bead is closed, so this shouldn't be a resume request.
 	// It also shouldn't be a new request because it has an assignee.
@@ -697,7 +697,7 @@ func TestComputePoolDesiredStates_DedupsResumeForSameSession(t *testing.T) {
 	}
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	// Should deduplicate — only one resume request for sess-1.
 	resumeCount := 0
@@ -729,7 +729,7 @@ func TestComputePoolDesiredStates_ResumePriorityOrder(t *testing.T) {
 		sessionBead("s3", "open"),
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	if len(result) != 1 || len(result[0].Requests) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(result[0].Requests))
@@ -751,7 +751,7 @@ func TestComputePoolDesiredStates_SuspendedAgentSkipped(t *testing.T) {
 	}
 	scaleCheck := map[string]int{"claude": 1}
 
-	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck, nil)
 
 	total := 0
 	for _, ds := range result {
@@ -769,7 +769,7 @@ func TestComputePoolDesiredStates_ScaleCheckMerge(t *testing.T) {
 	// No work beads visible (they're in the rig store, not passed here).
 	// But scale_check says 2.
 	scaleCheck := map[string]int{"rig/claude": 2}
-	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -803,7 +803,7 @@ func TestComputePoolDesiredStates_ManualSessionDoesNotConsumeSingletonNewDemand(
 		},
 	}
 
-	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads([]beads.Bead{manual}), map[string]int{"claude": 1})
+	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads([]beads.Bead{manual}), map[string]int{"claude": 1}, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -853,7 +853,7 @@ func TestComputePoolDesiredStates_NamedSessionBeadSkipsPoolResume(t *testing.T) 
 		},
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{namedBead}), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{namedBead}), nil, nil)
 
 	resumeCount := 0
 	for _, ds := range result {
@@ -877,7 +877,7 @@ func TestComputePoolDesiredStates_UnassignedRoutedBeadDoesNotCreateDemand(t *tes
 	work := []beads.Bead{
 		workBead("w1", "rig/claude", "", "open", 5),
 	}
-	result := ComputePoolDesiredStates(cfg, work, nil, map[string]int{"rig/claude": 0})
+	result := ComputePoolDesiredStates(cfg, work, nil, map[string]int{"rig/claude": 0}, nil)
 
 	total := 0
 	for _, ds := range result {
@@ -894,7 +894,7 @@ func TestComputePoolDesiredStates_ScaleCheckRespectsCaps(t *testing.T) {
 	}
 	// scale_check says 10, but max=3.
 	scaleCheck := map[string]int{"rig/claude": 10}
-	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -916,7 +916,7 @@ func TestComputePoolDesiredStates_CapsNewDemandBeforeMaterializingRequests(t *te
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
 	trace := newPoolDesiredStateTestTrace("claude")
 
-	result := computePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), map[string]int{"claude": 10}, nil, trace)
+	result := computePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), map[string]int{"claude": 10}, nil, trace, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -950,7 +950,7 @@ func TestComputePoolDesiredStates_OpenAssignedWorkResumes(t *testing.T) {
 	}
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	if len(result) != 1 || len(result[0].Requests) != 1 {
 		t.Fatalf("expected 1 request, got %#v", result)
@@ -960,6 +960,53 @@ func TestComputePoolDesiredStates_OpenAssignedWorkResumes(t *testing.T) {
 	}
 	if result[0].Requests[0].SessionBeadID != "sess-1" {
 		t.Fatalf("session = %q, want sess-1", result[0].Requests[0].SessionBeadID)
+	}
+}
+
+// TestComputePoolDesiredStates_ResumeSkipsUnreadyOpenBead is the regression
+// test for ga-ebxikh: the resume tier gated only on wb.Status, so an
+// open+assigned+routed bead with an unresolved blocking dependency was
+// redispatched every reconcile tick even though it could never be worked
+// (observed 19+ times in one day against ga-48vlc3/ga-uqxysq.7). readyAssigned
+// is non-nil but does not mark w1 ready, mirroring a bead the store's
+// readiness/deps gate rejected.
+func TestComputePoolDesiredStates_ResumeSkipsUnreadyOpenBead(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(5), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "claude", "sess-1", "open", 5),
+	}
+	sessions := []beads.Bead{sessionBead("sess-1", "open")}
+
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, map[string]bool{})
+
+	if counts := PoolDesiredCounts(result); counts["claude"] != 0 {
+		t.Fatalf("poolDesired[claude] = %d, want 0 — a blocked open bead must not resume a session", counts["claude"])
+	}
+}
+
+// TestComputePoolDesiredStates_ResumeIncludesReadyOpenBead is the positive
+// control for TestComputePoolDesiredStates_ResumeSkipsUnreadyOpenBead: the
+// identical bead shape still resumes once readyAssigned marks it ready,
+// proving the gate checks the readiness value and does not simply suppress
+// every open bead.
+func TestComputePoolDesiredStates_ResumeIncludesReadyOpenBead(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(5), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "claude", "sess-1", "open", 5),
+	}
+	sessions := []beads.Bead{sessionBead("sess-1", "open")}
+
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, map[string]bool{"w1": true})
+
+	if len(result) != 1 || len(result[0].Requests) != 1 {
+		t.Fatalf("expected 1 request for a ready open bead, got %#v", result)
+	}
+	if result[0].Requests[0].Tier != "resume" {
+		t.Fatalf("tier = %q, want resume", result[0].Requests[0].Tier)
 	}
 }
 
@@ -976,7 +1023,7 @@ func TestComputePoolDesiredStates_ResumeOverridesZeroScaleCheck(t *testing.T) {
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
 	scaleCheck := map[string]int{"claude": 0}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -997,7 +1044,7 @@ func TestComputePoolDesiredStates_NoDemandNoAssignment(t *testing.T) {
 		Agents: []config.Agent{poolAgent("claude", "", intPtr(5), 0)},
 	}
 	// No work beads, no scale_check demand.
-	result := ComputePoolDesiredStates(cfg, nil, nil, map[string]int{"claude": 0})
+	result := ComputePoolDesiredStates(cfg, nil, nil, map[string]int{"claude": 0}, nil)
 
 	counts := PoolDesiredCounts(result)
 	if counts["claude"] != 0 {
@@ -1016,7 +1063,7 @@ func TestComputePoolDesiredStates_ScaleCheckAndResumeAddUp(t *testing.T) {
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
 	scaleCheck := map[string]int{"claude": 2}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -1052,7 +1099,7 @@ func TestComputePoolDesiredStates_AssignedSessionsDoNotConsumeNewDemand(t *testi
 		sessions = append(sessions, sessionBead(sessionID, "open"))
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), map[string]int{"claude": 5})
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), map[string]int{"claude": 5}, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -1090,7 +1137,7 @@ func TestComputePoolDesiredStates_InFlightNewSessionsConsumeScaleDemand(t *testi
 	}
 	scaleCheck := map[string]int{"claude": 3}
 
-	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), scaleCheck, nil)
 
 	counts := PoolDesiredCounts(result)
 	if counts["claude"] != 3 {
@@ -1122,7 +1169,7 @@ func TestComputePoolDesiredStates_InFlightNewSessionsDoNotCreateZeroDemand(t *te
 	}
 	scaleCheck := map[string]int{"claude": 0}
 
-	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), scaleCheck, nil)
 
 	counts := PoolDesiredCounts(result)
 	if counts["claude"] != 0 {
@@ -1140,7 +1187,7 @@ func TestComputePoolDesiredStates_InFlightNewSessionsOnlySubtractCoveredDemand(t
 	}
 	scaleCheck := map[string]int{"claude": 5}
 
-	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), scaleCheck)
+	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), scaleCheck, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -1184,7 +1231,7 @@ func TestComputePoolDesiredStates_InFlightResumeBeadsDoNotConsumeNewDemand(t *te
 	}
 	scaleCheck := map[string]int{"claude": 3}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -1238,7 +1285,7 @@ func TestComputePoolDesiredStates_DoesNotResumeSessionAcrossExplicitRouteMismatc
 		workBead("w-mismatched-route", "codex-min", "workflows__codex-max-mc-codex-max", "in_progress", 5),
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{session}), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{session}), nil, nil)
 
 	for _, state := range result {
 		for _, req := range state.Requests {
@@ -1271,7 +1318,7 @@ func TestComputePoolDesiredStates_DoesNotResumeLegacySessionAcrossExplicitRouteM
 		workBead("w-mismatched-route", "codex-min", "workflows__codex-max-mc-codex-max", "in_progress", 5),
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{session}), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{session}), nil, nil)
 
 	for _, state := range result {
 		for _, req := range state.Requests {
@@ -1301,7 +1348,7 @@ func TestComputePoolDesiredStates_InFlightPredicateBranches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads([]beads.Bead{tt.session}), map[string]int{"claude": 1})
+			result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads([]beads.Bead{tt.session}), map[string]int{"claude": 1}, nil)
 
 			if len(result) != 1 || len(result[0].Requests) != 1 {
 				t.Fatalf("result = %#v, want one in-flight request", result)
@@ -1320,7 +1367,7 @@ func TestComputePoolDesiredStates_StaleCreatingBeadStillConsumesNewDemand(t *tes
 	stale := poolSessionBeadWithState("sess-stale", "creating", "")
 	stale.CreatedAt = time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC).Add(-2 * staleCreatingStateTimeout)
 
-	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads([]beads.Bead{stale}), map[string]int{"claude": 1})
+	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads([]beads.Bead{stale}), map[string]int{"claude": 1}, nil)
 
 	if len(result) != 1 || len(result[0].Requests) != 1 {
 		t.Fatalf("result = %#v, want one stale creating request preserving already-spent demand", result)
@@ -1342,7 +1389,7 @@ func TestComputePoolDesiredStates_InFlightSelectionRespectsCapsInStableOrder(t *
 		pendingPoolSessionBeadAt("sess-tie-a", base.Add(2*time.Minute)),
 	}
 
-	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), map[string]int{"claude": 10})
+	result := ComputePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), map[string]int{"claude": 10}, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))
@@ -1369,7 +1416,7 @@ func TestComputePoolDesiredStates_InFlightDemandRecordsTrace(t *testing.T) {
 	}
 	trace := newPoolDesiredStateTestTrace("claude")
 
-	result := computePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), map[string]int{"claude": 5}, nil, trace)
+	result := computePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), map[string]int{"claude": 5}, nil, trace, nil)
 
 	if len(result) != 1 || len(result[0].Requests) != 5 {
 		t.Fatalf("result = %#v, want five desired requests", result)
@@ -1402,7 +1449,7 @@ func TestComputePoolDesiredStates_InFlightDemandRecordsTraceWhenCapsSuppressReus
 	}
 	trace := newPoolDesiredStateTestTrace("claude")
 
-	result := computePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), map[string]int{"claude": 5}, nil, trace)
+	result := computePoolDesiredStates(cfg, nil, sessionInfosFromBeads(sessions), map[string]int{"claude": 5}, nil, trace, nil)
 
 	if len(result) != 0 {
 		t.Fatalf("result = %#v, want no desired requests when workspace cap is exhausted", result)
@@ -1468,7 +1515,7 @@ func TestComputePoolDesiredStates_PerRigScoping(t *testing.T) {
 	}
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	counts := PoolDesiredCounts(result)
 	if counts["claude"] != 0 {
@@ -1507,7 +1554,7 @@ func TestResumeTier_AsleepSessionWithAssignedWork(t *testing.T) {
 
 	scaleCheck := map[string]int{"hello-world/polecat": 1}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), scaleCheck, nil)
 
 	// Must have a resume request pointing to mc-sctve.
 	var resumeFound bool
@@ -1539,7 +1586,7 @@ func TestComputePoolDesiredStates_RoutedButUnassignedDoesNotSpawnNew(t *testing.
 		workBead("w1", "claude", "", "open", 5),
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, nil, nil)
+	result := ComputePoolDesiredStates(cfg, work, nil, nil, nil)
 
 	total := 0
 	for _, ds := range result {
@@ -1559,7 +1606,7 @@ func TestComputePoolDesiredStates_RoutedRigScopedDoesNotSpawnNew(t *testing.T) {
 		workBead("w1", "myrig/claude", "", "open", 3),
 	}
 
-	result := ComputePoolDesiredStates(cfg, work, nil, nil)
+	result := ComputePoolDesiredStates(cfg, work, nil, nil, nil)
 
 	total := 0
 	for _, ds := range result {

--- a/cmd/gc/pool_desired_state_wake_test.go
+++ b/cmd/gc/pool_desired_state_wake_test.go
@@ -8,16 +8,17 @@ import (
 )
 
 // closedPoolSessionBead creates a closed pool-managed session bead whose
-// template metadata matches the given qualified template name. Used to
-// construct "session bead closed but template still configured" scenarios.
-func closedPoolSessionBead(id, template string) beads.Bead {
+// template metadata matches "rig/claude", the qualified template name every
+// caller in this file constructs. Used to construct "session bead closed but
+// template still configured" scenarios.
+func closedPoolSessionBead() beads.Bead {
 	return beads.Bead{
-		ID:     id,
+		ID:     "sess-1",
 		Status: "closed",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel},
 		Metadata: map[string]string{
-			"template":             template,
+			"template":             "rig/claude",
 			poolManagedMetadataKey: boolMetadata(true),
 		},
 	}
@@ -39,9 +40,9 @@ func TestComputePoolDesiredStates_WakeKnownIdentityForClosedSession(t *testing.T
 	work := []beads.Bead{
 		workBead("w1", "rig/claude", "rig/claude", "in_progress", 5),
 	}
-	closed := closedPoolSessionBead("sess-1", "rig/claude")
+	closed := closedPoolSessionBead()
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{closed}), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{closed}), nil, nil)
 
 	wakeCount := 0
 	for _, ds := range result {
@@ -53,6 +54,59 @@ func TestComputePoolDesiredStates_WakeKnownIdentityForClosedSession(t *testing.T
 	}
 	if wakeCount != 1 {
 		t.Errorf("wake-known-identity count = %d, want 1 — closed session with known template must produce a wake request", wakeCount)
+	}
+}
+
+// TestComputePoolDesiredStates_WakeKnownIdentitySkipsUnreadyOpenBead is the
+// wake-known-identity-tier counterpart to
+// TestComputePoolDesiredStates_ResumeSkipsUnreadyOpenBead (ga-ebxikh): an
+// "open" work bead assigned directly to a known template with no live
+// session (the closed-session/orphan-recovery shape) must not produce a
+// wake request when readyAssigned does not mark it ready.
+func TestComputePoolDesiredStates_WakeKnownIdentitySkipsUnreadyOpenBead(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "rig", nil, 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "rig/claude", "rig/claude", "open", 5),
+	}
+	closed := closedPoolSessionBead()
+
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{closed}), nil, map[string]bool{})
+
+	total := 0
+	for _, ds := range result {
+		total += len(ds.Requests)
+	}
+	if total != 0 {
+		t.Errorf("total requests = %d, want 0 — a blocked open bead must not wake a known identity", total)
+	}
+}
+
+// TestComputePoolDesiredStates_WakeKnownIdentityIncludesReadyOpenBead is the
+// positive control: the identical shape still produces a wake-known-identity
+// request once readyAssigned marks the bead ready.
+func TestComputePoolDesiredStates_WakeKnownIdentityIncludesReadyOpenBead(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "rig", nil, 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "rig/claude", "rig/claude", "open", 5),
+	}
+	closed := closedPoolSessionBead()
+
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{closed}), nil, map[string]bool{"w1": true})
+
+	wakeCount := 0
+	for _, ds := range result {
+		for _, req := range ds.Requests {
+			if req.Tier == "wake-known-identity" {
+				wakeCount++
+			}
+		}
+	}
+	if wakeCount != 1 {
+		t.Errorf("wake-known-identity count = %d, want 1 — a ready open bead must still wake a known identity", wakeCount)
 	}
 }
 
@@ -68,7 +122,7 @@ func TestComputePoolDesiredStates_WakeKnownIdentityUnknownAssigneeProducesNoRequ
 		workBead("w1", "rig/claude", "unknown-session-id", "in_progress", 5),
 	}
 	// No session beads at all — assignee doesn't resolve.
-	result := ComputePoolDesiredStates(cfg, work, nil, nil)
+	result := ComputePoolDesiredStates(cfg, work, nil, nil, nil)
 
 	total := 0
 	for _, ds := range result {
@@ -90,9 +144,9 @@ func TestComputePoolDesiredStates_WakeKnownIdentityDedupsMultipleBeadsForSameSes
 		workBead("w1", "rig/claude", "rig/claude", "in_progress", 5),
 		workBead("w2", "rig/claude", "rig/claude", "open", 3),
 	}
-	closed := closedPoolSessionBead("sess-1", "rig/claude")
+	closed := closedPoolSessionBead()
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{closed}), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads([]beads.Bead{closed}), nil, nil)
 
 	wakeCount := 0
 	for _, ds := range result {
@@ -119,7 +173,7 @@ func TestComputePoolDesiredStates_LiveSessionContinuesAsResumeTier(t *testing.T)
 	}
 	sessions := []beads.Bead{sessionBead("sess-live", "open")}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	if len(result) != 1 || len(result[0].Requests) != 1 {
 		t.Fatalf("expected 1 request, got %#v", result)

--- a/cmd/gc/session_model_phase0_demand_spec_test.go
+++ b/cmd/gc/session_model_phase0_demand_spec_test.go
@@ -71,7 +71,7 @@ func TestPhase0PoolDesiredStates_AssigneeOnlyKeepsConcreteSessionAlive(t *testin
 	}}
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
 
-	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d, want 1", len(result))

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -4561,7 +4561,7 @@ func reconcileExistingAsleepNamedSessionWithRoutedWork(t *testing.T, cfg *config
 	if err != nil {
 		t.Fatalf("loadSessionBeads: %v", err)
 	}
-	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts))
+	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts, nil))
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
 	}
@@ -9980,7 +9980,7 @@ func TestReconcileSessionBeads_FileStoreAlwaysNamedRecoversWithLeakedDuplicateOp
 	if err != nil {
 		t.Fatalf("loadSessionBeads: %v", err)
 	}
-	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts))
+	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts, nil))
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
 	}
@@ -10116,7 +10116,7 @@ func reconcileConfiguredSessionsOnce(
 	if err != nil {
 		t.Fatalf("loadSessionBeads: %v", err)
 	}
-	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts))
+	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts, nil))
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
 	}
@@ -10628,7 +10628,7 @@ func TestReconcileSessionBeads_BuildDesiredStateSkipsFailedCreatePoolSession(t *
 				t.Fatalf("loadSessionBeads: %v", err)
 			}
 			cfgNames := configuredSessionNames(cfg, cfg.EffectiveCityName(), store)
-			poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts))
+			poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts, nil))
 			if poolDesired == nil {
 				poolDesired = make(map[string]int)
 			}
@@ -10755,7 +10755,7 @@ func TestReconcileSessionBeads_SyncReplacesFailedCreateNamedSession(t *testing.T
 		t.Fatalf("fresh named-session state = %q, want start-pending", fresh.Metadata["state"])
 	}
 
-	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts))
+	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts, nil))
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
 	}

--- a/release-gates/ga-omtqm5-pool-resume-readiness-gate.md
+++ b/release-gates/ga-omtqm5-pool-resume-readiness-gate.md
@@ -1,0 +1,52 @@
+# Release gate: pool reconciler resume-tier readiness gate
+
+Result: PASS
+
+Deploy bead: ga-omtqm5
+Source review bead: ga-pigugn
+Source implementation bead: ga-fnhyyk
+Branch: deploy/ga-omtqm5-pool-resume-readiness-gate
+Code head evaluated: fda233f2d49d7c7e756a1f037038a087394386f4
+Base checked: origin/main at f5cc23fefd73dffaf04034671950a035e461688a
+
+Note: this repository does not currently contain `docs/PROJECT_MANIFEST.md`;
+the release criteria below are the deployer prompt criteria.
+
+## Summary
+
+The branch fixes the pool reconciler resume tier so open assigned work only
+causes a resume or wake-known-identity request when the bead is actually ready.
+Blocked open beads still represented as `Status: "open"` no longer repeatedly
+restart pool sessions just because they are assigned and routed.
+
+The change centralizes the status/readiness judgment in `workBeadResumeReady`,
+threads the existing ready-assigned snapshot through all production pool demand
+call sites, and resolves store-scoped readiness to bead IDs before the pool
+demand filter loses store-ref alignment.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-pigugn` contains `REVIEWER VERDICT: PASS` and records independent build, vet, formatting, targeted regression, and full fast-unit verification. |
+| 2 | Acceptance criteria met | PASS | The resume tier now gates `open` work on readiness while preserving unconditional `in_progress` behavior; both resume and wake-known-identity sub-tiers share the gate. All 5 production `ComputePoolDesiredStates*` call sites pass a real readiness map. Tests cover blocked-vs-ready resume behavior, blocked-vs-ready wake-known-identity behavior, `workBeadResumeReady`, and `readyAssignedByBeadID` store-scoped resolution. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc/...`; targeted `go test ./cmd/gc/ -run 'TestComputePoolDesiredStates|TestWorkBeadHasAwakeDemand|TestWorkBeadResumeReady|TestReadyAssignedByBeadID|TestBuildAwakeInputFromReconciler|TestBuildDesiredState|TestFilterAssignedWorkBeadsForPoolDemand|TestComputePoolDesiredStatesWithDemandTraced' -count=1`; `go vet ./...`; `make test-fast-parallel` all passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list one low-severity, non-blocking defensive-code consistency follow-up in `readyAssignedByBeadID`; no HIGH or MEDIUM finding is recorded. |
+| 5 | Final branch is clean | PASS | Pre-gate `git status --short --branch` was clean. Final clean status is rechecked after committing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | Current `origin/main` is `f5cc23fefd73dffaf04034671950a035e461688a`; `git merge-base origin/main HEAD` returned `5becf8854dc357392bef81e8da6eea9486a49999`; `git merge-tree --write-tree origin/main HEAD` succeeded with no conflicts. |
+| 7 | Single feature theme | PASS | The commit set is one `cmd/gc` reconciler/pool-demand theme: readiness-aware pool resume decisions plus direct unit/regression tests. No unrelated package or user-facing feature is bundled. |
+
+## Commands run
+
+```text
+gh auth status
+git fetch origin main builder/ga-fnhyyk-pool-resume-readiness-gate
+git diff --check origin/main...HEAD
+gofmt -l cmd/gc/assigned_work_scope.go cmd/gc/build_desired_state.go cmd/gc/build_desired_state_test.go cmd/gc/city_runtime.go cmd/gc/cmd_sling_test.go cmd/gc/cmd_start.go cmd/gc/compute_awake_bridge_test.go cmd/gc/compute_awake_set.go cmd/gc/pool_desired_state.go cmd/gc/pool_desired_state_test.go cmd/gc/pool_desired_state_wake_test.go cmd/gc/session_model_phase0_demand_spec_test.go cmd/gc/session_reconciler_test.go
+git merge-base origin/main HEAD
+git merge-tree --write-tree origin/main HEAD
+go build ./cmd/gc/...
+go test ./cmd/gc/ -run 'TestComputePoolDesiredStates|TestWorkBeadHasAwakeDemand|TestWorkBeadResumeReady|TestReadyAssignedByBeadID|TestBuildAwakeInputFromReconciler|TestBuildDesiredState|TestFilterAssignedWorkBeadsForPoolDemand|TestComputePoolDesiredStatesWithDemandTraced' -count=1
+go vet ./...
+make test-fast-parallel
+```


### PR DESCRIPTION
## What this changes

Gas City's pool reconciler no longer treats every open, assigned, routed bead as actionable when deciding whether to resume or wake a pool session. Open work must now be ready according to the existing dependency/readiness snapshot; in-progress work still resumes as before.

This stops blocked work from repeatedly triggering pool session churn while preserving the current behavior for active work.

## Review notes

- Main logic is in `cmd/gc/pool_desired_state.go` and `cmd/gc/assigned_work_scope.go`.
- The readiness map is built before pool demand filtering loses store-ref alignment, then passed through all production `ComputePoolDesiredStates*` call sites.
- No config, API, schema, or migration surface changes.
- Release gate: [`release-gates/ga-omtqm5-pool-resume-readiness-gate.md`](release-gates/ga-omtqm5-pool-resume-readiness-gate.md)

## Test plan

- [x] `go build ./cmd/gc/...`
- [x] `go test ./cmd/gc/ -run 'TestComputePoolDesiredStates|TestWorkBeadHasAwakeDemand|TestWorkBeadResumeReady|TestReadyAssignedByBeadID|TestBuildAwakeInputFromReconciler|TestBuildDesiredState|TestFilterAssignedWorkBeadsForPoolDemand|TestComputePoolDesiredStatesWithDemandTraced' -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Pre-push fast gate passed while pushing `deploy/ga-omtqm5-pool-resume-readiness-gate`
