### PR TITLE
fix(hook): prevent pool workers from adopting named-session work

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -367,13 +367,22 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 		assignee := firstNonEmptyHookValue(sessionName, sessionID, alias, agentForQuery, resolvedAgentName)
 		claimOpts := hookClaimOptions{
 			Assignee: assignee,
+			// IdentityCandidates governs ADOPTION of already-owned in_progress/open
+			// work (hookClaimExistingOrAssigned); it must be scoped to this
+			// session's OWN runtime identity, never the bare pool template. A
+			// suffixed pool worker resolves config via the GC_TEMPLATE fallback, so
+			// resolvedAgentName == a.QualifiedName() is the bare template, which is
+			// ALSO the [[named_session]] holder's identity — including it let a
+			// suffixed worker adopt the holder's in_progress bead (ga-80pen8). The
+			// bare template stays in RouteTargets, which governs FRESH claims of
+			// UNASSIGNED routed work. The canonical slot / named holder keep it via
+			// `alias` (GC_ALIAS == qualified bare name); only suffixed workers drop it.
 			IdentityCandidates: hookClaimIdentityCandidates(
 				assignee,
 				sessionID,
 				sessionName,
 				alias,
 				agentForQuery,
-				resolvedAgentName,
 			),
 			RouteTargets: hookClaimRouteTargets(hookClaimPrimaryRouteTarget(&a), resolvedAgentName, strings.TrimSpace(overrides["GC_TEMPLATE"])),
 			Env:          queryEnv,

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -1617,8 +1617,12 @@ printf '[]'
 	if result.Action != "drain" || result.Reason != "no_work" {
 		t.Fatalf("result = %+v, want action=drain reason=no_work", result)
 	}
+	// A foreign in_progress bead must never reach the claim mutation. bd may
+	// not run at all once the candidate is excluded from both the adoption
+	// and fresh-claim paths — that's an even stronger signal than an empty
+	// log, so a missing log file is not a failure.
 	logData, err := os.ReadFile(logPath)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		t.Fatalf("ReadFile(%s): %v", logPath, err)
 	}
 	if strings.Contains(string(logData), "--claim") {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -1548,6 +1548,191 @@ esac
 	}
 }
 
+// TestCmdHookClaimSuffixedPoolWorkerDoesNotAdoptBareTemplateInProgressWork is
+// the ga-80pen8 end-to-end regression: "builder" is BOTH a [[named_session]]
+// holder's own identity AND a pool template shared by suffixed instances
+// (max_active_sessions > 1), mirroring the config shape confirmed in the
+// field incident. A suffixed pool worker resolves its config via the
+// GC_TEMPLATE fallback, so its resolvedAgentName is the bare template — which
+// is ALSO the named holder's identity. Before the fix, that let the worker
+// adopt the holder's in_progress bead through hookClaimExistingOrAssigned
+// without ever going through the store.Claim CAS, so two identities worked
+// (and closed) the same bead. The worker must instead drain no_work, and the
+// claim mutation must never run for a bead it does not own.
+func TestCmdHookClaimSuffixedPoolWorkerDoesNotAdoptBareTemplateInProgressWork(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "builder"
+max_active_sessions = 3
+work_query = "printf '[{\"id\":\"ga-frpt4k\",\"status\":\"in_progress\",\"assignee\":\"builder\",\"metadata\":{\"gc.routed_to\":\"builder\"}}]'"
+
+[[named_session]]
+template = "builder"
+mode = "on_demand"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBin := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+printf '[]'
+`, logPath)
+	if err := os.WriteFile(filepath.Join(fakeBin, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY", cityDir)
+	// Suffixed pool worker: GC_TEMPLATE is the bare pool binding, GC_ALIAS and
+	// GC_SESSION_NAME are this instance's own suffixed runtime identity.
+	t.Setenv("GC_TEMPLATE", "builder")
+	t.Setenv("GC_ALIAS", "builder-1")
+	t.Setenv("GC_SESSION_NAME", "builder-1")
+	t.Setenv("GC_SESSION_ID", "session-builder-1")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHookWithOptions(nil, hookCommandOptions{Claim: true, JSON: true}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdHookWithOptions(--claim, suffixed pool worker) = %d, want 1 (no_work drain); stdout=%q stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.Action == "work" && result.Reason == "existing_assignment" {
+		t.Fatalf("REGRESSION ga-80pen8: suffixed pool worker %q adopted named holder %q's in_progress bead %q (%+v)",
+			"builder-1", "builder", result.BeadID, result)
+	}
+	if result.Action != "drain" || result.Reason != "no_work" {
+		t.Fatalf("result = %+v, want action=drain reason=no_work", result)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", logPath, err)
+	}
+	if strings.Contains(string(logData), "--claim") {
+		t.Fatalf("claim mutation ran for a foreign in_progress bead; bd log:\n%s", logData)
+	}
+}
+
+// TestCmdHookClaimNamedHolderStillAdoptsOwnInProgressWork is the companion
+// guard for ga-80pen8: the named-session holder (or a canonical max=1 pool
+// slot) whose own runtime identity IS the bare template must still adopt its
+// own in_progress bead. Its alias/assignee already carry the bare qualified
+// name via GC_ALIAS independent of resolvedAgentName, so the fix (dropping
+// resolvedAgentName from the suffixed-worker IdentityCandidates) must not
+// change this case.
+func TestCmdHookClaimNamedHolderStillAdoptsOwnInProgressWork(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "builder"
+max_active_sessions = 3
+work_query = "printf '[{\"id\":\"ga-frpt4k\",\"status\":\"in_progress\",\"assignee\":\"builder\",\"metadata\":{\"gc.routed_to\":\"builder\"}}]'"
+
+[[named_session]]
+template = "builder"
+mode = "on_demand"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fakeBin, "bd"), []byte("#!/bin/sh\nprintf '[]'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY", cityDir)
+	// Named holder / canonical slot: GC_ALIAS IS the bare template.
+	t.Setenv("GC_TEMPLATE", "builder")
+	t.Setenv("GC_ALIAS", "builder")
+	t.Setenv("GC_SESSION_NAME", "builder-session")
+	t.Setenv("GC_SESSION_ID", "session-builder")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHookWithOptions(nil, hookCommandOptions{Claim: true, JSON: true}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHookWithOptions(--claim, named holder) = %d, want 0; stdout=%q stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.Action != "work" || result.Reason != "existing_assignment" || result.BeadID != "ga-frpt4k" {
+		t.Fatalf("over-fix regression: named holder no longer adopts its own in_progress bead: %+v", result)
+	}
+}
+
+// TestPoolWorkerIdentityCandidatesExcludeBareTemplate is a mechanism-level
+// guard for ga-80pen8, pinned to the post-fix contract: a suffixed pool
+// worker's claim IdentityCandidates must never include the bare pool
+// template, because the bare template is also the [[named_session]] holder's
+// own identity. Including it let a suffixed worker adopt the holder's
+// in_progress bead via hookClaimExistingOrAssigned without ever reaching the
+// store.Claim CAS.
+func TestPoolWorkerIdentityCandidatesExcludeBareTemplate(t *testing.T) {
+	const (
+		poolTemplate  = "gascity/builder"   // bare template == named-session holder's identity
+		workerReal    = "gascity/builder-1" // this suffixed pool worker's own identity
+		foreignBeadID = "ga-frpt4k"
+	)
+	// Fixed contract: cmd_hook.go's --claim block passes only this session's
+	// own runtime identity (assignee, sessionID, sessionName, alias,
+	// agentForQuery) into hookClaimIdentityCandidates — never the bare
+	// template resolved via the GC_TEMPLATE fallback.
+	identityCandidates := hookClaimIdentityCandidates(workerReal, "", workerReal, workerReal, workerReal)
+	runner := func(string, string) (string, error) {
+		return `[{"id":"` + foreignBeadID + `","status":"in_progress","assignee":"` + poolTemplate +
+			`","metadata":{"gc.routed_to":"` + poolTemplate + `"}}]`, nil
+	}
+	ops := hookClaimOps{
+		Runner: runner,
+		Claim: func(context.Context, string, []string, string, string) (beads.Bead, bool, error) {
+			t.Fatal("store.Claim ran: a foreign in_progress bead must never reach the CAS")
+			return beads.Bead{}, false, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           workerReal,
+		IdentityCandidates: identityCandidates,
+		RouteTargets:       hookClaimRouteTargets(poolTemplate, poolTemplate),
+		JSON:               true,
+	}
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr)
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.Action == "work" && result.Reason == "existing_assignment" {
+		t.Fatalf("REGRESSION ga-80pen8: pool worker %q adopted %q's in_progress bead %q (%+v)",
+			workerReal, poolTemplate, result.BeadID, result)
+	}
+	if result.Action != "drain" || result.Reason != "no_work" || code != 1 {
+		t.Fatalf("want no_work drain, got action=%q reason=%q code=%d", result.Action, result.Reason, code)
+	}
+}
+
 func TestHookInjectAlwaysExitsZero(t *testing.T) {
 	// Even on command failure, inject mode exits 0.
 	runner := func(string, string) (string, error) { return "", fmt.Errorf("command failed") }

--- a/release-gates/pool-worker-claim-identity-gate.md
+++ b/release-gates/pool-worker-claim-identity-gate.md
@@ -1,0 +1,45 @@
+# Release Gate: Pool worker claim identity
+
+Bead: ga-h9lsg4
+Source bead: ga-aq6xfs
+Implementation bead: ga-0cymgz
+Branch under review: builder/ga-0cymgz
+Reviewed commit: 6ee9ba04f49df788a5d7ec134c4b02d44c9d9d6c
+Gate date: 2026-07-01
+
+Note: docs/PROJECT_MANIFEST.md is not present in this worktree. This gate uses
+the deployer release criteria and the repo testing guidance in TESTING.md.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-aq6xfs is closed with `REVIEW VERDICT: PASS`; deploy bead ga-h9lsg4 was created by reviewer-gm-u4aay with reviewed commit 6ee9ba04f49df788a5d7ec134c4b02d44c9d9d6c. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/cmd_hook.go` removes `resolvedAgentName` from `IdentityCandidates` while retaining it in `RouteTargets`. The branch adds the required suffixed-worker acceptance test, named-holder over-fix guard, and mechanism-level identity-candidate test. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestCmdHookClaimSuffixedPoolWorkerDoesNotAdoptBareTemplateInProgressWork|TestCmdHookClaimNamedHolderStillAdoptsOwnInProgressWork|TestPoolWorkerIdentityCandidatesExcludeBareTemplate' -count=1` passed. `make test-fast-parallel` passed all 8 fast shards. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list no unresolved HIGH findings; the review classifies the change as an access-control correctness improvement with no new attack surface. |
+| 5 | Final branch is clean | PASS | No uncommitted changes before gate file creation; this gate file is committed as the branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded and produced tree d4889ccb4dd55e295788597b4a03757ed70f77a1. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem: `gc hook --claim` identity adoption behavior in `cmd/gc`, plus tests for that behavior. |
+
+## Acceptance Checks
+
+- PASS: Suffixed pool workers no longer include the bare pool template in
+  adoption identity candidates.
+- PASS: Fresh-claim routing still includes the resolved template through
+  `RouteTargets`.
+- PASS: Named holders and canonical slots still adopt their own in-progress
+  work.
+- PASS: The change is scoped to `cmd/gc/cmd_hook.go` and
+  `cmd/gc/cmd_hook_test.go`.
+
+## Commands
+
+```text
+gofmt -l cmd/gc/cmd_hook.go cmd/gc/cmd_hook_test.go
+go test ./cmd/gc -run 'TestCmdHookClaimSuffixedPoolWorkerDoesNotAdoptBareTemplateInProgressWork|TestCmdHookClaimNamedHolderStillAdoptsOwnInProgressWork|TestPoolWorkerIdentityCandidatesExcludeBareTemplate' -count=1
+make test-fast-parallel
+go vet ./...
+git diff --check origin/main...HEAD
+git merge-tree --write-tree origin/main HEAD
+```


### PR DESCRIPTION
## What this changes

`gc hook --claim` no longer lets a suffixed pool worker treat the bare pool template name as one of its own identities when adopting already-assigned work. That prevents a pool worker such as `builder-1` from picking up an in-progress bead owned by the named holder `builder`.

Fresh routed claims still use the template route target, so unassigned work can continue to wake and claim through the normal pool path. The change only narrows the identity set used for adopting existing work.

## Review notes

- The production change is in `cmd/gc/cmd_hook.go`, where `IdentityCandidates` and `RouteTargets` intentionally diverge.
- `cmd/gc/cmd_hook_test.go` covers the suffixed-worker rejection case, the named-holder adoption guard, and the identity-candidate constructor contract.
- This does not change pool demand calculation, named-session config, or other bare-template routing surfaces.

## Test plan

- [x] `go test ./cmd/gc -run 'TestCmdHookClaimSuffixedPoolWorkerDoesNotAdoptBareTemplateInProgressWork|TestCmdHookClaimNamedHolderStillAdoptsOwnInProgressWork|TestPoolWorkerIdentityCandidatesExcludeBareTemplate' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/pool-worker-claim-identity-gate.md`](release-gates/pool-worker-claim-identity-gate.md)
