### PR TITLE
docs: document concrete claim identity convention

### DIFF
--- a/engdocs/architecture/prompt-templates.md
+++ b/engdocs/architecture/prompt-templates.md
@@ -181,6 +181,44 @@ append_fragments = ["safety"]
 | `RoutedPoolQuery` | Unassigned routed pool-work command | `bd ready --metadata-field gc.routed_to=... --unassigned` |
 | `SlingQuery` | Work routing command | `gc sling ...` |
 
+### Claim Identity Convention
+
+The `AssignedInProgressQuery` (Tier 1) and `RoutedPoolQuery` (Tier 3) rows
+above are rendered once, at session start, from Go `text/template`
+variables. But the *literal* prompt text written into `prompts/*.md.tmpl`
+files also references two OS environment variables directly — `$GC_TEMPLATE`
+and `$GC_ALIAS` — which the agent's own shell commands expand at run time,
+not at template-render time. These are a separate injection mechanism from
+the table above, and the two env vars are not interchangeable:
+
+- `$GC_TEMPLATE` is the qualified template identity, shared by *every* live
+  session of that template (the named-session holder and every pool slot
+  alike).
+- `$GC_ALIAS` is the current session's own concrete identity — the bare
+  qualified name for a named holder or canonical singleton slot, or the
+  suffixed `-N` identity (e.g. `rig/builder-1`) for a pool slot.
+
+Convention for which one to use in a prompt template's startup section:
+
+| Line | Token | Why |
+|---|---|---|
+| Tier 1 (crash-recovery query) | `${GC_ALIAS:-$GC_TEMPLATE}` | Ownership read — must resolve to *this session's own* prior claim, not a sibling's. |
+| Claim (`bd update <id> --claim --assignee=...`) | `${GC_ALIAS:-$GC_TEMPLATE}` | Ownership write — must stamp *this session's* concrete identity. |
+| Tier 2 (pre-assigned ready-work query) | bare `$GC_TEMPLATE` | Shared role discovery — pre-assigned work is deliberately assigned to the bare template. |
+| Tier 3 (routed-pool queue query) | bare `$GC_TEMPLATE` | Shared queue key — `gc.routed_to` is a role-level routing target, not a per-session claim. |
+
+Getting this wrong is not cosmetic: a template that is both a
+`[[named_session]]` and a multi-slot pool has more than one live identity
+sharing a single template string. If Tier 1 or the claim line uses the bare
+template, two sessions can independently "recover" or adopt the same
+in-progress bead and both complete it — duplicate commits, duplicate PRs,
+duplicate closes. See `engdocs/design/session-model-unification.md` (Runtime
+Environment) for where `GC_ALIAS`/`GC_TEMPLATE` are defined, and the
+`ga-i1d0tr` architecture decision for the full incident writeup. The
+`${GC_ALIAS:-$GC_TEMPLATE}` fallback form degrades safely to today's
+behavior for sessions where `GC_ALIAS` is unset (pure singleton/named
+templates, where the two values are identical anyway).
+
 ### Template Functions
 
 | Function | Usage | Returns |

--- a/engdocs/design/session-model-unification.md
+++ b/engdocs/design/session-model-unification.md
@@ -632,6 +632,14 @@ The synthesized default remains, but becomes origin-aware at runtime:
 - all sessions check assigned ready work
 - only `origin=ephemeral` checks unassigned `gc.routed_to=$GC_TEMPLATE`
 
+The assigned `in_progress` check (Tier 1) is an ownership read and must key
+off `${GC_ALIAS:-$GC_TEMPLATE}`, not the bare template — see "Claim Identity
+Convention" in `engdocs/architecture/prompt-templates.md` and the
+`ga-i1d0tr` decision for why a bare-template Tier 1 query lets one session
+cross-adopt another live session's in-progress claim on templates with more
+than one concurrent identity (a `[[named_session]]` paired with a
+multi-slot pool).
+
 Named and manual sessions stop at explicit ownership.
 
 Custom `work_query` and `scale_check` remain escape hatches.

--- a/release-gates/concrete-identity-claims-gate.md
+++ b/release-gates/concrete-identity-claims-gate.md
@@ -1,0 +1,78 @@
+# Release Gate: Concrete identity claims
+
+Deploy bead: ga-2igrdw
+Source review bead: ga-qlzkjn
+Implementation bead: ga-98gjgb
+Gate date: 2026-07-01
+
+This deploy spans two repositories under one feature theme:
+
+- `gc-management` local-only repo: commit
+  `a7654c1364d48c2adf6e6b3690b005471aa252f0` on
+  `builder/ga-98gjgb-concrete-identity-claims`.
+- `gascity` SDK repo: commit
+  `5bcabe3e638e90abb3ee8938b2389aec25b3e346` on
+  `builder/ga-98gjgb-docs-convention`.
+
+The `gc-management` repo has no git remote, so no PR can be opened there. This
+gate is committed to the `gascity` docs PR branch and the local-only merge is
+handed to mayor/mpr as a merge authority action.
+
+Note: docs/PROJECT_MANIFEST.md is not present in this worktree. This gate uses
+the deployer release criteria and the relevant repo guidance.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-qlzkjn is closed with `REVIEW VERDICT: PASS` for both branches. Deploy bead ga-2igrdw was created by reviewer-gm-u4aay after review PASS. |
+| 2 | Acceptance criteria met | PASS | `gc-management`: 37 concrete-identity replacements are present; the remaining 14 `assignee="$GC_TEMPLATE"` matches are Tier-2 `bd ready --assignee` lines only. The irregular TOML formula parses with `tomllib`. `gascity`: docs add the claim identity convention and a cross-reference. |
+| 3 | Tests pass | PASS | `gascity`: `make check-docs` passed. `gc-management`: `git diff --check main...HEAD` passed; `gc lint .` was run and exits nonzero only with pre-existing baseline categories also reproduced on a temporary detached `main` worktree. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list no unresolved HIGH findings. The known post-merge runtime observation gap is documented as non-blocking and requires the prompt fix to be live. |
+| 5 | Final branch is clean | PASS | `gascity` branch is clean apart from this committed gate file. `gc-management` feature worktree is clean. |
+| 6 | Branch diverges cleanly from main | PASS | `gascity`: `git merge-tree --write-tree origin/main HEAD` succeeded and produced tree ef21eaae42cd81f9c11fabdecdf42a70e266de11. `gc-management`: `git merge-tree --write-tree main HEAD` succeeded and produced tree 4d439b3e9c2afdf2c511b4e5f7d79b9715d2d3a4. |
+| 7 | Single feature theme | PASS | Both branches implement the same claim-identity convention: Tier-1 recovery and claims use concrete session identity; shared Tier-2/Tier-3 queue discovery remains template-routed. |
+
+## Acceptance Checks
+
+- PASS: `grep -RInF 'assignee="${GC_ALIAS:-$GC_TEMPLATE}"' packs | wc -l`
+  returned `37` in the `gc-management` feature worktree.
+- PASS: `grep -RIn 'assignee="\$GC_TEMPLATE"' packs` returned exactly the 14
+  expected Tier-2 `bd ready --assignee="$GC_TEMPLATE"` lines.
+- PASS: `packs/actual/deployer/formulas/mol-deployer-gate.formula.toml`
+  parsed successfully with Python `tomllib`.
+- PASS: `gc-management` has no remote, confirmed by empty `git remote -v`.
+- PASS: `gascity` docs changed only
+  `engdocs/architecture/prompt-templates.md` and
+  `engdocs/design/session-model-unification.md`.
+
+## Commands
+
+```text
+# gascity SDK repo
+git diff --check origin/main...HEAD
+git merge-tree --write-tree origin/main HEAD
+make check-docs
+
+# gc-management local-only repo
+git diff --check main...HEAD
+git merge-tree --write-tree main HEAD
+grep -RIn 'assignee="\$GC_TEMPLATE"' packs | sort
+grep -RInF 'assignee="${GC_ALIAS:-$GC_TEMPLATE}"' packs | wc -l
+python3 - <<'PY'
+import tomllib
+from pathlib import Path
+path = Path('packs/actual/deployer/formulas/mol-deployer-gate.formula.toml')
+tomllib.loads(path.read_text())
+print('toml ok')
+PY
+gc lint .
+```
+
+## Known Baseline
+
+`gc lint .` in `gc-management` returns nonzero on this branch and on a temporary
+detached `main` worktree. The reproduced baseline categories are named-session
+plus pool coexistence warnings, missing shared prompt-template includes for
+existing packs, and legacy PackV1 order-path warnings. The changed files did not
+introduce new lint categories.


### PR DESCRIPTION
## What this changes

This documents the claim identity convention for pack authors: Tier-1 recovery and claim commands should use the concrete running session identity (`${GC_ALIAS:-$GC_TEMPLATE}`), while Tier-2 and Tier-3 discovery should continue to use the shared template route.

The main addition lives beside the existing prompt-template tier table, with a short cross-reference from the session identity design note. That keeps the rule close to the place pack authors already look when writing prompt claim loops.

## Review notes

- This PR is docs-only in the Gas City repo: `engdocs/architecture/prompt-templates.md` and `engdocs/design/session-model-unification.md`.
- The related prompt-template changes are in the local-only `gc-management` repo, which has no remote and cannot have a GitHub PR. The merge authority has to handle that local merge separately.
- No Go code, config schema, generated docs, OpenAPI, or dashboard files change here.

## Test plan

- [x] `make check-docs`
- [x] Local pack-branch acceptance checks: remaining bare `$GC_TEMPLATE` matches are only Tier-2 `bd ready --assignee` lines; 37 concrete-identity replacements present
- [x] Local pack-branch TOML parse check for `packs/actual/deployer/formulas/mol-deployer-gate.formula.toml`
- [x] Release gate: [`release-gates/concrete-identity-claims-gate.md`](release-gates/concrete-identity-claims-gate.md)
