### PR TITLE
fix(reconciler): ignore bare-template demand for expanded identity templates

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -892,6 +892,20 @@ func buildDesiredStateWithSessionBeads(
 			if assignee != identity {
 				continue
 			}
+			if spec.Agent.SupportsExpandedSessionIdentities() {
+				// Defense in depth (ga-i1d0tr Candidate B): a bare-template Assignee
+				// is only a legitimate "this IS my identity" match for a template
+				// with exactly one possible live identity. For a template that
+				// supports expanded per-instance identities (a multi-slot pool or
+				// namepool coexisting with this named session), a bare-template
+				// Assignee means some other path wrote the wrong value — a pool
+				// slot's claim, a human running `bd update --assignee=<template>`
+				// directly, or an older client — not a genuine claim by this named
+				// session. Do not treat it as this named session's demand; the
+				// durable fix (claims under the concrete alias, ga-2xqke7) prevents
+				// the pool-claim case from producing this shape going forward.
+				continue
+			}
 			if !assignedWorkIndexReachableFromAgent(cityPath, cfg, spec.Agent, assignedWorkStoreRefs, i) {
 				continue
 			}

--- a/cmd/gc/build_desired_state_ga80pen8_test.go
+++ b/cmd/gc/build_desired_state_ga80pen8_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestBuildDesiredState_MultiSlotPoolNamedSession_OneRoutedBeadProvisionsTwoWorkers
+// is the ga-80pen8 repro: two gascity/builder identities (the [[named_session]]
+// and a pool slot) concurrently claimed+completed the same routed bead.
+//
+// Root cause: an agent template configured as BOTH a [[named_session]] AND a
+// multi-slot pool (max_active_sessions > 1, so UsesCanonicalSingletonPoolIdentity()
+// is false and the #3697 canonical-singleton standby suppression does not apply)
+// overloads ONE identity string ("gascity/builder") as:
+//   - the named-session wake identity,
+//   - the pool template / gc.routed_to queue key,
+//   - the pool claim assignee (bd update --claim --assignee="$GC_TEMPLATE"), and
+//   - the Tier-1 crash-recovery key (bd list --assignee="$GC_TEMPLATE" --status=in_progress).
+//
+// A single routed bead, once a pool slot claims it, carries BOTH
+// gc.routed_to=gascity/builder AND Assignee=gascity/builder (the bare template —
+// exactly how live ga-frpt4k ended up). On the reconcile tick that one bead then
+// drives TWO independent demand paths:
+//   - filterAssignedWorkBeadsForPoolDemand (gc.routed_to) -> a pool slot, and
+//   - namedWorkReady (build_desired_state.go ~892, `if assignee != identity`)
+//     (Assignee==identity) -> the on_demand named session.
+//
+// so buildDesiredState provisions BOTH gascity/builder (named) and
+// gascity/builder-1 (pool slot) for the same unit of work. Both then run the
+// shared claim/Tier-1 protocol and work the bead to completion — the observed
+// double-claim, duplicate commit, duplicate reviewer handoff, and duplicate
+// bd close.
+//
+// Invariant (fix-agnostic): one unit of routed work must not simultaneously
+// provision the named session AND a pool slot of the same template. Holds under
+// every candidate fix — pool claims under its concrete alias (so Assignee is
+// gascity/builder-1, not the bare template, and namedWorkReady no longer
+// matches); the reconciler excludes multi-slot-pool self-claims from named
+// demand; or config forbids a [[named_session]] on a max>1 pool template.
+//
+// MUST fail on current code (2 desired builder sessions) and pass after the fix.
+func TestBuildDesiredState_MultiSlotPoolNamedSession_OneRoutedBeadProvisionsTwoWorkers(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "gascity")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	// One routed bead, already claimed by a pool slot: the claim stamped the bare
+	// template as assignee (bd update --claim --assignee="$GC_TEMPLATE") and moved
+	// it to in_progress — mirroring live ga-frpt4k (Assignee: gascity/builder,
+	// gc.routed_to: gascity/builder).
+	b, err := rigStore.Create(beads.Bead{
+		Title:    "routed builder work claimed by a pool slot",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "gascity/builder",
+		Metadata: map[string]string{"gc.routed_to": "gascity/builder"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProgress := "in_progress"
+	if err := rigStore.Update(b.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gc"},
+		Rigs:      []config.Rig{{Name: "gascity", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "builder",
+			Dir:               "gascity",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(3), // multi-slot pool: not a canonical singleton
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "builder",
+			Dir:      "gascity",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"gascity": rigStore}, nil, nil, io.Discard,
+	)
+
+	var builderIdentities []string
+	for key, tp := range dsResult.State {
+		if tp.TemplateName == "gascity/builder" {
+			builderIdentities = append(builderIdentities, key+"(alias="+tp.Alias+",named="+tp.ConfiguredNamedIdentity+")")
+		}
+	}
+	if len(builderIdentities) != 1 {
+		t.Fatalf("one routed builder bead provisioned %d gascity/builder sessions, want 1: %v\n"+
+			"The bead's Assignee==bare template fired named-session demand (namedWorkReady) while its "+
+			"gc.routed_to fired pool demand, so the [[named_session]] gascity/builder AND pool slot "+
+			"gascity/builder-1 are both provisioned for the same unit of work — the ga-80pen8 "+
+			"double-claim. NamedSessionDemand=%v",
+			len(builderIdentities), builderIdentities, dsResult.NamedSessionDemand)
+	}
+}
+
+// TestSharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts proves the direct
+// mechanism by which the two provisioned sessions both do the work: the Tier-1
+// crash-recovery query every builder session runs,
+//
+//	bd list --assignee="$GC_TEMPLATE" --status=in_progress
+//
+// keys on the shared $GC_TEMPLATE ("gascity/builder"). A bead a sibling session
+// already claimed (Assignee="gascity/builder", in_progress) is returned by that
+// query, so a second live session "resumes" it as if it were its own abandoned
+// work. The store query is the exact surface bd wraps.
+//
+// The companion assertion shows the fix direction: had the pool slot claimed
+// under its concrete alias ("gascity/builder-1"), the named session's Tier-1
+// scan (assignee="gascity/builder") would NOT surface it — no cross-adoption.
+//
+// This test does not exercise the reconciler guard (that's the test above) —
+// it documents the *other*, prompt-level failure surface (ga-i1d0tr) that the
+// guard does not fix on its own. Kept unmodified as a regression guard per
+// ga-n2szjj's done-when.
+func TestSharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Sibling A (a pool slot) claimed shared routed work under the bare template.
+	shared, err := store.Create(beads.Bead{Title: "shared-claim", Type: "task", Status: "open", Assignee: "gascity/builder"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sibling B (a hypothetical fixed pool slot) claimed under its concrete alias.
+	concrete, err := store.Create(beads.Bead{Title: "concrete-claim", Type: "task", Status: "open", Assignee: "gascity/builder-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProgress := "in_progress"
+	for _, id := range []string{shared.ID, concrete.ID} {
+		if err := store.Update(id, beads.UpdateOpts{Status: &inProgress}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The named session's Tier-1 crash-recovery query: assignee == $GC_TEMPLATE.
+	tier1, err := store.List(beads.ListQuery{Assignee: "gascity/builder", Status: "in_progress"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ids []string
+	for _, b := range tier1 {
+		ids = append(ids, b.ID)
+	}
+
+	sawShared, sawConcrete := false, false
+	for _, id := range ids {
+		if id == shared.ID {
+			sawShared = true
+		}
+		if id == concrete.ID {
+			sawConcrete = true
+		}
+	}
+	if !sawShared {
+		t.Fatalf("Tier-1 (assignee=gascity/builder) did not return the shared-template claim %s; ids=%v", shared.ID, ids)
+	}
+	if sawConcrete {
+		t.Fatalf("Tier-1 (assignee=gascity/builder) returned the concrete-alias claim %s — it must not; "+
+			"claiming under a concrete pool identity is what prevents cross-adoption; ids=%v", concrete.ID, ids)
+	}
+	// sawShared==true: a sibling's active work is indistinguishable from this
+	// session's own crash-recovery work under the shared $GC_TEMPLATE assignee.
+	t.Logf("Tier-1 crash-recovery surfaced a live sibling's shared-template claim %s (cross-adoption); "+
+		"a concrete-alias claim %s was correctly invisible", shared.ID, concrete.ID)
+}

--- a/release-gates/reconciler-named-work-ready-guard-gate.md
+++ b/release-gates/reconciler-named-work-ready-guard-gate.md
@@ -19,7 +19,7 @@ the deployer release criteria and the repo testing guidance in TESTING.md.
 | 3 | Tests pass | PASS | Required repro tests passed. Broader desired-state/pool regression family passed. `make test-fast-parallel` passed all 8 fast shards. `go vet ./...` passed. |
 | 4 | No high-severity review findings open | PASS | Reviewer notes list no unresolved HIGH findings; the change is described as a defense-in-depth correctness guard with no new attack surface. |
 | 5 | Final branch is clean | PASS | No uncommitted changes before gate file creation; this gate file is committed as the branch tip. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded and produced tree 389a0345e96f58c5cb50aefeb6124ca2d57eaa67. |
+| 6 | Branch diverges cleanly from main | PASS | After refreshing `origin/main` to 87bbc7b36be171d6e2271eb0b887d547e0db0cf6, `git merge-tree --write-tree origin/main HEAD` succeeded and produced tree 9019c2a3caa1b79b95d8704aff3b136fb5826f43. |
 | 7 | Single feature theme | PASS | The commit set touches one subsystem: reconciler desired-state demand calculation for named sessions and tests for that behavior. |
 
 ## Acceptance Checks

--- a/release-gates/reconciler-named-work-ready-guard-gate.md
+++ b/release-gates/reconciler-named-work-ready-guard-gate.md
@@ -1,0 +1,46 @@
+# Release Gate: Reconciler namedWorkReady guard
+
+Bead: ga-ghhxvv
+Source bead: ga-uxzzey
+Implementation bead: ga-n2szjj
+Branch under review: builder/ga-n2szjj
+Reviewed commit: 615d85b1475e604573d8aa8c525f93a16395a8ec
+Gate date: 2026-07-01
+
+Note: docs/PROJECT_MANIFEST.md is not present in this worktree. This gate uses
+the deployer release criteria and the repo testing guidance in TESTING.md.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-uxzzey is closed with `REVIEW VERDICT: PASS`; deploy bead ga-ghhxvv was created by reviewer-gm-u4aay with reviewed commit 615d85b1475e604573d8aa8c525f93a16395a8ec. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/build_desired_state.go` skips bare-template assigned work for templates that support expanded session identities. The branch adds `TestBuildDesiredState_MultiSlotPoolNamedSession_OneRoutedBeadProvisionsTwoWorkers` and retains `TestSharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts`. |
+| 3 | Tests pass | PASS | Required repro tests passed. Broader desired-state/pool regression family passed. `make test-fast-parallel` passed all 8 fast shards. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list no unresolved HIGH findings; the change is described as a defense-in-depth correctness guard with no new attack surface. |
+| 5 | Final branch is clean | PASS | No uncommitted changes before gate file creation; this gate file is committed as the branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded and produced tree 389a0345e96f58c5cb50aefeb6124ca2d57eaa67. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem: reconciler desired-state demand calculation for named sessions and tests for that behavior. |
+
+## Acceptance Checks
+
+- PASS: Bare-template assigned work no longer counts as named-session demand
+  when the agent supports expanded session identities.
+- PASS: Plain named-only and canonical singleton pool behavior remains covered
+  by the existing `SupportsExpandedSessionIdentities` contract.
+- PASS: The complementary prompt-level failure surface remains documented by
+  `TestSharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts`.
+- PASS: The change is scoped to `cmd/gc/build_desired_state.go` and
+  `cmd/gc/build_desired_state_ga80pen8_test.go`.
+
+## Commands
+
+```text
+gofmt -l cmd/gc/build_desired_state.go cmd/gc/build_desired_state_ga80pen8_test.go
+go test ./cmd/gc -run 'TestBuildDesiredState_MultiSlotPoolNamedSession_OneRoutedBeadProvisionsTwoWorkers|TestSharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts' -count=1
+go test ./cmd/gc -run 'TestBuildDesiredState|TestComputePoolDesiredStates|TestBuildAwakeInputFromReconciler|TestNamedWorkReady' -count=1
+make test-fast-parallel
+go vet ./...
+git diff --check origin/main...HEAD
+git merge-tree --write-tree origin/main HEAD
+```


### PR DESCRIPTION
## What this changes

The reconciler no longer treats a bead assigned to the bare template name as named-session demand when that template can also have expanded per-instance identities. In the reported shape, a template is both a `[[named_session]]` and a multi-slot pool, so one bare-template assignment could make the named holder and a pool slot both look eligible for the same work.

The guard uses the existing `Agent.SupportsExpandedSessionIdentities()` contract. Plain named-only agents and canonical singleton pools keep their current behavior; templates that can produce concrete `-N` identities do not count a bare-template assignee as named-session demand.

## Review notes

- This touches shared reconciler desired-state code used by pool reconciliation across rigs.
- This is defense-in-depth for misassigned work; it does not change prompt templates, pool demand calculation, or config validation for named-session plus pool coexistence.
- The new tests are self-contained in-memory desired-state tests, not subprocess or timing-sensitive tests.

## Test plan

- [x] `go test ./cmd/gc -run 'TestBuildDesiredState_MultiSlotPoolNamedSession_OneRoutedBeadProvisionsTwoWorkers|TestSharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts' -count=1`
- [x] `go test ./cmd/gc -run 'TestBuildDesiredState|TestComputePoolDesiredStates|TestBuildAwakeInputFromReconciler|TestNamedWorkReady' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/reconciler-named-work-ready-guard-gate.md`](release-gates/reconciler-named-work-ready-guard-gate.md)
