### PR TITLE
fix(hooks): bind managed Codex hooks to city root

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -230,7 +230,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewServiceSecretsPermsCheck(cfg, cityPath))
 		register(doctor.NewSkillCollisionCheck(cfg, cityPath))
 		register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath, doctor.WithOrderFiringCurrentLastRunFunc(doctorOrderFiringCurrentLastRunFunc(cityPath, cfg, opts.Stderr))))
-		register(newCodexHooksDriftCheck(codexHookWorkDirs(cityPath, cfg)))
+		register(newCodexHooksDriftCheck(cityPath, codexHookWorkDirs(cityPath, cfg)))
 		register(doctor.NewRigPackCoverageCheck(cfg, cityPath))
 		register(newPackRuntimesDoctorCheck(cfg))
 		register(newMCPConfigDoctorCheck(cityPath, cfg, exec.LookPath))

--- a/cmd/gc/doctor_codex_hooks.go
+++ b/cmd/gc/doctor_codex_hooks.go
@@ -16,11 +16,16 @@ import (
 )
 
 type codexHooksDriftCheck struct {
-	dirs []string
+	cityPath string
+	dirs     []string
 }
 
-func newCodexHooksDriftCheck(dirs []string) *codexHooksDriftCheck {
-	return &codexHooksDriftCheck{dirs: cleanCodexHookDirs(dirs)}
+func newCodexHooksDriftCheck(cityPath string, dirs []string) *codexHooksDriftCheck {
+	cityPath = strings.TrimSpace(cityPath)
+	if cityPath != "" {
+		cityPath = filepath.Clean(cityPath)
+	}
+	return &codexHooksDriftCheck{cityPath: cityPath, dirs: cleanCodexHookDirs(dirs)}
 }
 
 func codexHookWorkDirs(cityPath string, cfg *config.City) []string {
@@ -183,10 +188,10 @@ func (c *codexHooksDriftCheck) CanFix() bool { return true }
 
 func (c *codexHooksDriftCheck) Fix(_ *doctor.CheckContext) error {
 	for _, dir := range c.dirs {
-		if !codexHooksMissingPreCompact(filepath.Join(dir, ".codex", "hooks.json")) {
+		if !codexHooksNeedUpgrade(filepath.Join(dir, ".codex", "hooks.json"), c.cityPath) {
 			continue
 		}
-		if err := hooks.Install(fsys.OSFS{}, dir, dir, []string{"codex"}); err != nil {
+		if err := hooks.Install(fsys.OSFS{}, c.cityPath, dir, []string{"codex"}); err != nil {
 			return fmt.Errorf("upgrading Codex hooks in %s: %w", dir, err)
 		}
 	}
@@ -197,7 +202,7 @@ func (c *codexHooksDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 	var stale []string
 	for _, dir := range c.dirs {
 		path := filepath.Join(dir, ".codex", "hooks.json")
-		if codexHooksMissingPreCompact(path) {
+		if codexHooksNeedUpgrade(path, c.cityPath) {
 			stale = append(stale, path)
 		}
 	}
@@ -205,9 +210,17 @@ func (c *codexHooksDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 		return okCheck(c.Name(), "Codex hooks are current or user-owned")
 	}
 	return warnCheck(c.Name(),
-		fmt.Sprintf("%d managed Codex hook file(s) missing PreCompact handoff", len(stale)),
+		fmt.Sprintf("%d managed Codex hook file(s) need upgrade", len(stale)),
 		"run `gc doctor --fix` or restart the city to upgrade managed Codex hooks",
 		stale)
+}
+
+func codexHooksNeedUpgrade(path, cityPath string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return hooks.CodexHooksNeedManagedUpgrade(data, cityPath)
 }
 
 func codexHooksMissingPreCompact(path string) bool {

--- a/cmd/gc/doctor_codex_hooks_test.go
+++ b/cmd/gc/doctor_codex_hooks_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
 func TestCodexHooksDriftCheckReportsManagedMissingPreCompact(t *testing.T) {
@@ -23,37 +25,37 @@ func TestCodexHooksDriftCheckReportsManagedMissingPreCompact(t *testing.T) {
   }
 }`)
 
-	check := newCodexHooksDriftCheck([]string{dir})
+	check := newCodexHooksDriftCheck(dir, []string{dir})
 	result := check.Run(&doctor.CheckContext{})
 
 	if result.Status != doctor.StatusWarning {
 		t.Fatalf("status = %v, want warning; message=%s", result.Status, result.Message)
 	}
-	if !strings.Contains(result.Message, "missing PreCompact") {
-		t.Fatalf("message = %q, want missing PreCompact", result.Message)
+	if !strings.Contains(result.Message, "need upgrade") {
+		t.Fatalf("message = %q, want need upgrade", result.Message)
 	}
 }
 
 func TestCodexHooksDriftCheckPassesCurrentHooks(t *testing.T) {
 	dir := t.TempDir()
-	writeCodexHooksForDoctorTest(t, dir, `{
+	writeCodexHooksForDoctorTest(t, dir, fmt.Sprintf(`{
   "hooks": {
     "SessionStart": [{
       "hooks": [{
         "type": "command",
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook --hook-format codex"
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city %s prime --hook --hook-format codex"
       }]
     }],
     "PreCompact": [{
       "hooks": [{
         "type": "command",
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff --auto --hook-format codex \"context cycle\""
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc --city %s handoff --auto --hook-format codex \"context cycle\""
       }]
     }]
   }
-}`)
+}`, shellquote.Quote(dir), shellquote.Quote(dir)))
 
-	check := newCodexHooksDriftCheck([]string{dir})
+	check := newCodexHooksDriftCheck(dir, []string{dir})
 	result := check.Run(&doctor.CheckContext{})
 
 	if result.Status != doctor.StatusOK {
@@ -74,7 +76,7 @@ func TestCodexHooksDriftCheckIgnoresCustomHooks(t *testing.T) {
   }
 }`)
 
-	check := newCodexHooksDriftCheck([]string{dir})
+	check := newCodexHooksDriftCheck(dir, []string{dir})
 	result := check.Run(&doctor.CheckContext{})
 
 	if result.Status != doctor.StatusOK {
@@ -95,7 +97,7 @@ func TestCodexHooksDriftCheckFixUpgradesManagedHooks(t *testing.T) {
   }
 }`)
 
-	check := newCodexHooksDriftCheck([]string{dir})
+	check := newCodexHooksDriftCheck(dir, []string{dir})
 	if err := check.Fix(&doctor.CheckContext{}); err != nil {
 		t.Fatalf("Fix: %v", err)
 	}
@@ -113,7 +115,7 @@ func TestCodexHooksDriftCheckFixUpgradesManagedHooks(t *testing.T) {
 }
 
 func TestNewCodexHooksDriftCheckCleansDedupesAndSortsDirs(t *testing.T) {
-	check := newCodexHooksDriftCheck([]string{" /z/../z ", "", "/a", "/a/."})
+	check := newCodexHooksDriftCheck("/city", []string{" /z/../z ", "", "/a", "/a/."})
 
 	if got, want := strings.Join(check.dirs, ","), "/a,/z"; got != want {
 		t.Fatalf("dirs = %q, want %q", got, want)
@@ -123,6 +125,104 @@ func TestNewCodexHooksDriftCheckCleansDedupesAndSortsDirs(t *testing.T) {
 	}
 	if !check.CanFix() {
 		t.Fatal("CanFix = false, want true")
+	}
+}
+
+func TestCodexHooksDriftCheckFixBindsAgentWorkDirToCityRoot(t *testing.T) {
+	cityDir := t.TempDir()
+	agentDir := filepath.Join(cityDir, ".gc", "agents", "reviewer")
+	writeCodexHooksForDoctorTest(t, agentDir, `{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook --hook-format codex"
+      }]
+    }]
+  }
+}`)
+
+	check := newCodexHooksDriftCheck(cityDir, []string{agentDir})
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(agentDir, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `gc --city `) {
+		t.Fatalf("fixed hooks missing explicit --city binding:\n%s", got)
+	}
+	if !strings.Contains(got, shellquote.Quote(cityDir)) {
+		t.Fatalf("fixed hooks missing city root %q:\n%s", cityDir, got)
+	}
+	if strings.Contains(got, shellquote.Quote(agentDir)) {
+		t.Fatalf("fixed hooks rebound to agent workdir %q:\n%s", agentDir, got)
+	}
+}
+
+func TestCodexHooksDriftCheckReportsManagedWrongCityBinding(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCodexHooksForDoctorTest(t, cityDir, `{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city /old/city prime --hook --hook-format codex"
+      }]
+    }],
+    "PreCompact": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc --city /old/city handoff --auto --hook-format codex \"context cycle\""
+      }]
+    }]
+  }
+}`)
+
+	check := newCodexHooksDriftCheck(cityDir, []string{cityDir})
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning; message=%s", result.Status, result.Message)
+	}
+}
+
+func TestCodexHooksDriftCheckFixRebindsManagedWrongCityBinding(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCodexHooksForDoctorTest(t, cityDir, `{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city /old/city prime --hook --hook-format codex"
+      }]
+    }],
+    "PreCompact": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc --city /old/city handoff --auto --hook-format codex \"context cycle\""
+      }]
+    }]
+  }
+}`)
+
+	check := newCodexHooksDriftCheck(cityDir, []string{cityDir})
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityDir, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, shellquote.Quote(cityDir)) {
+		t.Fatalf("fixed hooks missing city root %q:\n%s", cityDir, got)
+	}
+	if strings.Contains(got, "/old/city") {
+		t.Fatalf("stale city binding survived:\n%s", got)
 	}
 }
 
@@ -230,6 +330,24 @@ func TestCodexHooksMissingPreCompactRequiresManagedCommand(t *testing.T) {
 
 	if codexHooksMissingPreCompact(path) {
 		t.Fatal("custom-only hooks reported as missing managed PreCompact")
+	}
+}
+
+func TestCodexHooksNeedUpgradeRejectsUnreadableMalformedAndCustomFiles(t *testing.T) {
+	dir := t.TempDir()
+	missingPath := filepath.Join(dir, ".codex", "hooks.json")
+	if codexHooksNeedUpgrade(missingPath, "/city") {
+		t.Fatal("missing file reported stale")
+	}
+
+	writeCodexHooksForDoctorTest(t, dir, `{not-json`)
+	if codexHooksNeedUpgrade(missingPath, "/city") {
+		t.Fatal("malformed JSON reported stale")
+	}
+
+	writeCodexHooksForDoctorTest(t, dir, `{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"FOO=1 gc mail check --inject --hook-format codex"}]}]}}`)
+	if codexHooksNeedUpgrade(missingPath, "/city") {
+		t.Fatal("env-prefixed custom hooks reported stale")
 	}
 }
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/overlay"
+	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
 //go:embed config/*
@@ -157,9 +158,9 @@ func InstallWithResolver(fs fsys.FS, cityDir, workDir string, providers []string
 		case "claude":
 			err = installClaude(fs, cityDir)
 		case "codex", "gemini", "antigravity", "kiro", "opencode", "mimocode", "copilot", "cursor", "pi", "omp", "kimi":
-			err = installOverlayManaged(fs, workDir, family)
+			err = installOverlayManaged(fs, cityDir, workDir, family)
 		case "groq", "cerebras":
-			err = installOverlayManaged(fs, workDir, "opencode")
+			err = installOverlayManaged(fs, cityDir, workDir, "opencode")
 		default:
 			return fmt.Errorf("unsupported hook provider %q", p)
 		}
@@ -170,7 +171,7 @@ func InstallWithResolver(fs fsys.FS, cityDir, workDir string, providers []string
 	return nil
 }
 
-func installOverlayManaged(fs fsys.FS, workDir, provider string) error {
+func installOverlayManaged(fs fsys.FS, cityDir, workDir, provider string) error {
 	if strings.TrimSpace(workDir) == "" {
 		return nil
 	}
@@ -195,7 +196,7 @@ func installOverlayManaged(fs fsys.FS, workDir, provider string) error {
 			return writeJSONOverlayManaged(fs, dst, data)
 		}
 		if provider == "codex" && rel == path.Join(".codex", "hooks.json") {
-			return writeCodexHooksManaged(fs, dst, data)
+			return writeCodexHooksManaged(fs, cityDir, dst, data)
 		}
 		if overlay.IsMergeablePath(filepath.FromSlash(rel)) {
 			if normalized, normErr := overlay.CanonicalJSON(data); normErr == nil {
@@ -611,19 +612,18 @@ func readClaudeSettingsCandidate(fs fsys.FS, path string) (claudeCandidateState,
 	return candidateUnreadable, nil, err
 }
 
-func writeCodexHooksManaged(fs fsys.FS, dst string, data []byte) error {
+func writeCodexHooksManaged(fs fsys.FS, cityDir, dst string, data []byte) error {
+	if normalized, _, err := normalizeCodexHookCommands(data, cityDir); err == nil {
+		data = normalized
+	}
 	if existing, err := fs.ReadFile(dst); err == nil {
-		upgraded, changed, upgradeErr := upgradeCodexHooks(existing, data)
+		upgraded, changed, upgradeErr := upgradeCodexHooks(existing, data, cityDir)
 		if upgradeErr != nil || !changed {
 			return nil
 		}
 		return writeManagedData(fs, dst, upgraded)
 	} else if _, statErr := fs.Stat(dst); statErr == nil {
 		return nil
-	}
-	normalized, _, err := normalizeCodexHookCommands(data)
-	if err == nil {
-		data = normalized
 	}
 	return writeManagedData(fs, dst, data)
 }
@@ -639,20 +639,14 @@ func writeManagedData(fs fsys.FS, dst string, data []byte) error {
 	return nil
 }
 
-func upgradeCodexHooks(existing, desired []byte) ([]byte, bool, error) {
+func upgradeCodexHooks(existing, desired []byte, cityDir string) ([]byte, bool, error) {
 	var root any
 	if err := json.Unmarshal(existing, &root); err != nil {
 		return nil, false, err
 	}
-	hasManagedCommand := codexHookValueHasManagedCommand(root)
+	hasManagedCommand := codexHookValueHasManagedCommand(root, "")
 	needsPreCompact := codexHookDocCanAddPreCompact(root)
-	changed := upgradeCodexHookValue(root)
-	if desiredCodexPreCompactHook(desired) != nil && normalizeCodexManagedHookEntries(root) {
-		changed = true
-	}
-	if addCodexPreCompactHook(root, desired) {
-		changed = true
-	}
+	changed := applyCodexManagedHookUpgrade(root, desired, cityDir)
 	data, err := overlay.MarshalCanonicalJSON(root)
 	if err != nil {
 		return nil, false, err
@@ -663,14 +657,14 @@ func upgradeCodexHooks(existing, desired []byte) ([]byte, bool, error) {
 	return data, changed, nil
 }
 
-func normalizeCodexHookCommands(existing []byte) ([]byte, bool, error) {
+func normalizeCodexHookCommands(existing []byte, cityDir string) ([]byte, bool, error) {
 	var root any
 	if err := json.Unmarshal(existing, &root); err != nil {
 		return nil, false, err
 	}
-	hasManagedCommand := codexHookValueHasManagedCommand(root)
-	changed := upgradeCodexHookValue(root)
-	if normalizeCodexManagedHookEntries(root) {
+	hasManagedCommand := codexHookValueHasManagedCommand(root, "")
+	changed := upgradeCodexHookValue(root, "", cityDir)
+	if normalizeCodexManagedHookEntries(root, cityDir) {
 		changed = true
 	}
 	data, err := overlay.MarshalCanonicalJSON(root)
@@ -693,23 +687,55 @@ func CodexHooksMissingManagedPreCompact(data []byte) bool {
 	return codexHookDocCanAddPreCompact(root)
 }
 
-func codexHookValueHasManagedCommand(v any) bool {
+// CodexHooksNeedManagedUpgrade reports whether data is a recognizable Gas City
+// managed Codex hooks document that would be upgraded to current managed form
+// for cityDir, including explicit --city rebinding and missing PreCompact.
+func CodexHooksNeedManagedUpgrade(data []byte, cityDir string) bool {
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false
+	}
+	return applyCodexManagedHookUpgrade(root, nil, cityDir)
+}
+
+func applyCodexManagedHookUpgrade(root any, desired []byte, cityDir string) bool {
+	changed := upgradeCodexHookValue(root, "", cityDir)
+	if normalizeCodexManagedHookEntries(root, cityDir) {
+		changed = true
+	}
+	if addCodexPreCompactHook(root, desired) {
+		changed = true
+	}
+	return changed
+}
+
+func codexHookValueHasManagedCommand(v any, event string) bool {
 	switch node := v.(type) {
 	case map[string]any:
 		for key, val := range node {
+			if key == "hooks" {
+				if hooksMap, ok := val.(map[string]any); ok {
+					for eventName, eventVal := range hooksMap {
+						if codexHookValueHasManagedCommand(eventVal, eventName) {
+							return true
+						}
+					}
+					continue
+				}
+			}
 			if key == "command" {
-				if command, ok := val.(string); ok && isCodexManagedHookCommand(command) {
+				if command, ok := val.(string); ok && codexHookCommandLooksManaged(event, command) {
 					return true
 				}
 				continue
 			}
-			if codexHookValueHasManagedCommand(val) {
+			if codexHookValueHasManagedCommand(val, event) {
 				return true
 			}
 		}
 	case []any:
 		for _, elem := range node {
-			if codexHookValueHasManagedCommand(elem) {
+			if codexHookValueHasManagedCommand(elem, event) {
 				return true
 			}
 		}
@@ -717,21 +743,31 @@ func codexHookValueHasManagedCommand(v any) bool {
 	return false
 }
 
-func upgradeCodexHookValue(v any) bool {
+func upgradeCodexHookValue(v any, event, cityDir string) bool {
 	switch node := v.(type) {
 	case map[string]any:
 		changed := false
 		for key, val := range node {
+			if key == "hooks" {
+				if hooksMap, ok := val.(map[string]any); ok {
+					for eventName, eventVal := range hooksMap {
+						if upgradeCodexHookValue(eventVal, eventName, cityDir) {
+							changed = true
+						}
+					}
+					continue
+				}
+			}
 			if key == "command" {
 				if command, ok := val.(string); ok {
-					if upgraded, didUpgrade := upgradeCodexHookCommand(command); didUpgrade {
+					if upgraded, didUpgrade := upgradeCodexHookCommand(event, command, cityDir); didUpgrade {
 						node[key] = upgraded
 						changed = true
 					}
 				}
 				continue
 			}
-			if upgradeCodexHookValue(val) {
+			if upgradeCodexHookValue(val, event, cityDir) {
 				changed = true
 			}
 		}
@@ -739,7 +775,7 @@ func upgradeCodexHookValue(v any) bool {
 	case []any:
 		changed := false
 		for _, elem := range node {
-			if upgradeCodexHookValue(elem) {
+			if upgradeCodexHookValue(elem, event, cityDir) {
 				changed = true
 			}
 		}
@@ -749,7 +785,7 @@ func upgradeCodexHookValue(v any) bool {
 	}
 }
 
-func normalizeCodexManagedHookEntries(root any) bool {
+func normalizeCodexManagedHookEntries(root any, cityDir string) bool {
 	doc, ok := root.(map[string]any)
 	if !ok {
 		return false
@@ -768,11 +804,11 @@ func normalizeCodexManagedHookEntries(root any) bool {
 		seenManaged := map[string]bool{}
 		for _, entry := range entries {
 			if event == "SessionStart" {
-				if normalizeCodexManagedSessionStartEntry(entry) {
+				if normalizeCodexManagedSessionStartEntry(entry, cityDir) {
 					changed = true
 				}
 			}
-			if codexHookValueHasManagedCommand(entry) {
+			if codexHookValueHasManagedCommand(entry, event) {
 				keyData, err := overlay.MarshalCanonicalJSON(entry)
 				if err == nil {
 					key := string(keyData)
@@ -792,9 +828,9 @@ func normalizeCodexManagedHookEntries(root any) bool {
 	return changed
 }
 
-func normalizeCodexManagedSessionStartEntry(entry any) bool {
+func normalizeCodexManagedSessionStartEntry(entry any, cityDir string) bool {
 	entryMap, ok := entry.(map[string]any)
-	if !ok || !codexHookEntryHasCommandBody(entryMap, sessionStartCurrentFormBody) {
+	if !ok || !codexHookEntryHasCommandBody(entryMap, sessionStartCurrentFormBody(cityDir)) {
 		return false
 	}
 	if matcher, ok := entryMap["matcher"].(string); !ok || matcher != "startup" {
@@ -825,71 +861,324 @@ func codexHookEntryHasCommandBody(entry map[string]any, body string) bool {
 	return false
 }
 
-var codexManagedHookCommandNeedles = []string{
-	`gc prime --hook`,
-	`gc nudge drain --inject`,
-	`gc mail check --inject`,
-	`gc hook --inject`,
-	`gc handoff --auto`,
+func codexHookCommandLooksManaged(event, command string) bool {
+	_, env, args, ok := parseManagedGCCommand(command)
+	if !ok {
+		return false
+	}
+	switch event {
+	case "SessionStart":
+		return codexSessionStartArgsMatch(env, args) || codexLegacySessionStartRunArgsMatch(args)
+	case "PreCompact":
+		return codexPreCompactArgsMatch(args)
+	case "UserPromptSubmit":
+		return codexManagedPromptArgsMatch(args, "codex")
+	default:
+		return codexSessionStartArgsMatch(env, args) ||
+			codexLegacySessionStartRunArgsMatch(args) ||
+			codexPreCompactArgsMatch(args) ||
+			codexManagedPromptArgsMatch(args, "codex")
+	}
 }
 
-func isCodexManagedHookCommand(command string) bool {
-	for _, needle := range codexManagedHookCommandNeedles {
-		if strings.Contains(command, needle) {
-			return true
-		}
-	}
-	return false
-}
-
-func upgradeCodexHookCommand(command string) (string, bool) {
-	body := commandBodyAfterCanonicalPrefix(command)
-	if equalsLegacyCommandBody(body, `gc prime --hook`) ||
-		equalsLegacyCommandBody(body, `gc prime --hook --hook-format codex`) ||
-		equalsLegacyCommandBody(body, `GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`) ||
-		equalsLegacyCommandBody(body, `GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex`) ||
-		equalsLegacyCommandBody(body, sessionStartPreviousManagedFormBody) {
-		prefix := strings.TrimSuffix(command, body)
-		return prefix + sessionStartCurrentFormBody, true
-	}
-	if equalsLegacyCommandBody(body, managedPromptHookRunPrefix+`prime --hook`) ||
-		equalsLegacyCommandBody(body, managedPromptHookRunPrefix+`prime --hook --hook-format codex`) {
-		prefix := strings.TrimSuffix(command, body)
-		return prefix + sessionStartCurrentFormBody, true
-	}
-	if upgraded, ok := upgradeManagedPromptHookCommand(command, "codex"); ok {
-		return upgraded, true
-	}
-	if strings.Contains(command, `--hook-format codex`) {
+func upgradeCodexHookCommand(event, command, cityDir string) (string, bool) {
+	prefix, env, args, ok := parseManagedGCCommand(command)
+	if !ok {
 		return "", false
 	}
-	for _, needle := range codexManagedHookCommandNeedles {
-		if strings.Contains(command, needle) {
-			return strings.Replace(command, needle, needle+` --hook-format codex`, 1), true
+	switch event {
+	case "SessionStart":
+		if !codexSessionStartArgsMatch(env, args) && !codexLegacySessionStartRunArgsMatch(args) {
+			return "", false
 		}
+		desired := sessionStartCurrentFormBody(cityDir)
+		return prefix + desired, strings.TrimPrefix(command, prefix) != desired
+	case "PreCompact":
+		if !codexPreCompactArgsMatch(args) {
+			return "", false
+		}
+		desired := preCompactCurrentFormBody(cityDir)
+		return prefix + desired, strings.TrimPrefix(command, prefix) != desired
+	case "UserPromptSubmit":
+		return upgradeManagedPromptHookCommand(command, "codex", cityDir)
+	default:
+		if upgraded, ok := upgradeManagedPromptHookCommand(command, "codex", cityDir); ok {
+			return upgraded, true
+		}
+		if codexSessionStartArgsMatch(env, args) || codexLegacySessionStartRunArgsMatch(args) {
+			desired := sessionStartCurrentFormBody(cityDir)
+			return prefix + desired, strings.TrimPrefix(command, prefix) != desired
+		}
+		if codexPreCompactArgsMatch(args) {
+			desired := preCompactCurrentFormBody(cityDir)
+			return prefix + desired, strings.TrimPrefix(command, prefix) != desired
+		}
+		return "", false
+	}
+}
+
+func managedPromptHookRunPrefix(cityDir string) string {
+	return `gc ` + codexCityFlag(cityDir) + `hook run --timeout 15s --timeout-exit-code 0 -- `
+}
+
+func upgradeManagedPromptHookCommand(command, hookFormat, cityDir string) (string, bool) {
+	prefix, _, args, ok := parseManagedGCCommand(command)
+	if !ok {
+		return "", false
+	}
+	target, ok := codexManagedPromptTargetArgs(args, hookFormat)
+	if !ok {
+		return "", false
+	}
+	desired := managedPromptHookRunPrefix(cityDir) + target
+	return prefix + desired, strings.TrimPrefix(command, prefix) != desired
+}
+
+func codexCityFlag(cityDir string) string {
+	cityDir = strings.TrimSpace(cityDir)
+	if cityDir == "" {
+		return ""
+	}
+	return `--city ` + shellquote.Quote(cityDir) + ` `
+}
+
+func isCodexSessionStartCommandBody(body string) bool {
+	env, args, ok := parseGCCommandBody(body)
+	if !ok {
+		return false
+	}
+	if event, ok := env["GC_HOOK_EVENT_NAME"]; ok && event != "SessionStart" {
+		return false
+	}
+	if len(args) == 2 && args[0] == "prime" && args[1] == "--hook" {
+		return true
+	}
+	return len(args) == 4 && args[0] == "prime" && args[1] == "--hook" && args[2] == "--hook-format" && args[3] == "codex"
+}
+
+func isCodexPreCompactCommandBody(body string) bool {
+	_, args, ok := parseGCCommandBody(body)
+	if !ok || len(args) < 2 || args[0] != "handoff" {
+		return false
+	}
+	switch {
+	case len(args) == 2 && args[1] == "context cycle":
+		return true
+	case len(args) == 3 && args[1] == "--auto" && args[2] == "context cycle":
+		return true
+	case len(args) == 5 && args[1] == "--auto" && args[2] == "--hook-format" && args[3] == "codex" && args[4] == "context cycle":
+		return true
+	default:
+		return false
+	}
+}
+
+func codexManagedPromptTarget(body, hookFormat string) bool {
+	_, args, ok := parseGCCommandBody(body)
+	if !ok {
+		return false
+	}
+	if len(args) >= 3 && args[0] == "nudge" && args[1] == "drain" && args[2] == "--inject" {
+		_, ok := managedPromptTarget("nudge drain --inject", args[3:], hookFormat)
+		return ok
+	}
+	if len(args) >= 3 && args[0] == "mail" && args[1] == "check" && args[2] == "--inject" {
+		_, ok := managedPromptTarget("mail check --inject", args[3:], hookFormat)
+		return ok
+	}
+	if len(args) < 8 || args[0] != "hook" || args[1] != "run" {
+		return false
+	}
+	if args[2] != "--timeout" || args[3] != "15s" || args[4] != "--timeout-exit-code" || args[5] != "0" || args[6] != "--" {
+		return false
+	}
+	targetArgs := args[7:]
+	switch {
+	case len(targetArgs) >= 3 && targetArgs[0] == "nudge" && targetArgs[1] == "drain" && targetArgs[2] == "--inject":
+		_, ok := managedPromptTarget("nudge drain --inject", targetArgs[3:], hookFormat)
+		return ok
+	case len(targetArgs) >= 3 && targetArgs[0] == "mail" && targetArgs[1] == "check" && targetArgs[2] == "--inject":
+		_, ok := managedPromptTarget("mail check --inject", targetArgs[3:], hookFormat)
+		return ok
+	default:
+		return false
+	}
+}
+
+func managedPromptTarget(base string, rest []string, hookFormat string) (string, bool) {
+	if len(rest) == 0 {
+		if hookFormat == "" {
+			return base, true
+		}
+		return base + ` --hook-format ` + hookFormat, true
+	}
+	if hookFormat == "" {
+		return "", false
+	}
+	if len(rest) == 2 && rest[0] == "--hook-format" && rest[1] == hookFormat {
+		return base + ` --hook-format ` + hookFormat, true
 	}
 	return "", false
 }
 
-const managedPromptHookRunPrefix = `gc hook run --timeout 15s --timeout-exit-code 0 -- `
-
-func upgradeManagedPromptHookCommand(command, hookFormat string) (string, bool) {
-	body := commandBodyAfterCanonicalPrefix(command)
-	for _, base := range []string{
-		`gc nudge drain --inject`,
-		`gc mail check --inject`,
-	} {
-		if equalsLegacyCommandBody(body, base) ||
-			(hookFormat != "" && equalsLegacyCommandBody(body, base+` --hook-format `+hookFormat)) {
-			target := strings.TrimPrefix(base, `gc `)
-			if hookFormat != "" {
-				target += ` --hook-format ` + hookFormat
-			}
-			prefix := strings.TrimSuffix(command, body)
-			return prefix + managedPromptHookRunPrefix + target, true
-		}
+func parseGCCommandBody(body string) (map[string]string, []string, bool) {
+	tokens := shellquote.Split(body)
+	if len(tokens) == 0 {
+		return nil, nil, false
 	}
-	return "", false
+	env := map[string]string{}
+	i := 0
+	for i < len(tokens) && strings.Contains(tokens[i], "=") && !strings.HasPrefix(tokens[i], "=") {
+		key, value, ok := strings.Cut(tokens[i], "=")
+		if !ok || key == "" {
+			break
+		}
+		if !isManagedGCCommandEnvKey(key) {
+			return nil, nil, false
+		}
+		env[key] = value
+		i++
+	}
+	if i >= len(tokens) || tokens[i] != "gc" {
+		return nil, nil, false
+	}
+	args := tokens[i+1:]
+	if len(args) >= 2 && args[0] == "--city" {
+		args = args[2:]
+	} else if len(args) >= 1 && strings.HasPrefix(args[0], "--city=") {
+		args = args[1:]
+	}
+	return env, args, true
+}
+
+func isManagedGCCommandEnvKey(key string) bool {
+	switch key {
+	case "GC_MANAGED_SESSION_HOOK", "GC_HOOK_EVENT_NAME":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseManagedGCCommand(command string) (string, map[string]string, []string, bool) {
+	prefix := ""
+	body := command
+	if strings.HasPrefix(body, canonicalGCPathPrefix) {
+		prefix = canonicalGCPathPrefix
+		body = strings.TrimPrefix(body, canonicalGCPathPrefix)
+	}
+	tokens := shellquote.Split(body)
+	if len(tokens) == 0 {
+		return "", nil, nil, false
+	}
+	env := map[string]string{}
+	var envTokens []string
+	var extraEnvTokens []string
+	i := 0
+	hasManagedEnv := false
+	for i < len(tokens) && strings.Contains(tokens[i], "=") && !strings.HasPrefix(tokens[i], "=") {
+		key, value, ok := strings.Cut(tokens[i], "=")
+		if !ok || key == "" {
+			break
+		}
+		if isManagedGCCommandEnvKey(key) {
+			hasManagedEnv = true
+		} else {
+			extraEnvTokens = append(extraEnvTokens, tokens[i])
+		}
+		env[key] = value
+		envTokens = append(envTokens, tokens[i])
+		i++
+	}
+	if i >= len(tokens) || tokens[i] != "gc" {
+		return "", nil, nil, false
+	}
+	if len(envTokens) > 0 && prefix == "" && !hasManagedEnv {
+		return "", nil, nil, false
+	}
+	if len(extraEnvTokens) > 0 {
+		prefix += shellquote.Join(extraEnvTokens) + " "
+	}
+	args := tokens[i+1:]
+	if len(args) >= 2 && args[0] == "--city" {
+		args = args[2:]
+	} else if len(args) >= 1 && strings.HasPrefix(args[0], "--city=") {
+		args = args[1:]
+	}
+	return prefix, env, args, true
+}
+
+func codexSessionStartArgsMatch(env map[string]string, args []string) bool {
+	if event, ok := env["GC_HOOK_EVENT_NAME"]; ok && event != "SessionStart" {
+		return false
+	}
+	if len(args) == 2 && args[0] == "prime" && args[1] == "--hook" {
+		return true
+	}
+	return len(args) == 4 && args[0] == "prime" && args[1] == "--hook" && args[2] == "--hook-format" && args[3] == "codex"
+}
+
+func codexLegacySessionStartRunArgsMatch(args []string) bool {
+	if len(args) < 8 || args[0] != "hook" || args[1] != "run" {
+		return false
+	}
+	if args[2] != "--timeout" || args[3] != "15s" || args[4] != "--timeout-exit-code" || args[5] != "0" || args[6] != "--" {
+		return false
+	}
+	targetArgs := args[7:]
+	return len(targetArgs) == 2 && targetArgs[0] == "prime" && targetArgs[1] == "--hook" ||
+		(len(targetArgs) == 4 && targetArgs[0] == "prime" && targetArgs[1] == "--hook" && targetArgs[2] == "--hook-format" && targetArgs[3] == "codex")
+}
+
+func codexPreCompactArgsMatch(args []string) bool {
+	if len(args) < 2 || args[0] != "handoff" {
+		return false
+	}
+	switch {
+	case len(args) == 2 && args[1] == "context cycle":
+		return true
+	case len(args) == 3 && args[1] == "--auto" && args[2] == "context cycle":
+		return true
+	case len(args) == 5 && args[1] == "--auto" && args[2] == "--hook-format" && args[3] == "codex" && args[4] == "context cycle":
+		return true
+	default:
+		return false
+	}
+}
+
+func codexManagedPromptArgsMatch(args []string, hookFormat string) bool {
+	_, ok := codexManagedPromptTargetArgs(args, hookFormat)
+	if ok {
+		return true
+	}
+	if hookFormat != "" {
+		_, ok = codexManagedPromptTargetArgs(args, "")
+	}
+	return ok
+}
+
+func codexManagedPromptTargetArgs(args []string, hookFormat string) (string, bool) {
+	if len(args) >= 3 && args[0] == "nudge" && args[1] == "drain" && args[2] == "--inject" {
+		return managedPromptTarget("nudge drain --inject", args[3:], hookFormat)
+	}
+	if len(args) >= 3 && args[0] == "mail" && args[1] == "check" && args[2] == "--inject" {
+		return managedPromptTarget("mail check --inject", args[3:], hookFormat)
+	}
+	if len(args) < 8 || args[0] != "hook" || args[1] != "run" {
+		return "", false
+	}
+	if args[2] != "--timeout" || args[3] != "15s" || args[4] != "--timeout-exit-code" || args[5] != "0" || args[6] != "--" {
+		return "", false
+	}
+	targetArgs := args[7:]
+	switch {
+	case len(targetArgs) >= 3 && targetArgs[0] == "nudge" && targetArgs[1] == "drain" && targetArgs[2] == "--inject":
+		return managedPromptTarget("nudge drain --inject", targetArgs[3:], hookFormat)
+	case len(targetArgs) >= 3 && targetArgs[0] == "mail" && targetArgs[1] == "check" && targetArgs[2] == "--inject":
+		return managedPromptTarget("mail check --inject", targetArgs[3:], hookFormat)
+	default:
+		return "", false
+	}
 }
 
 func addCodexPreCompactHook(root any, desired []byte) bool {
@@ -930,9 +1219,13 @@ func codexHookDocLooksManaged(doc map[string]any) bool {
 		}
 		switch node := v.(type) {
 		case map[string]any:
-			if command, ok := node["command"].(string); ok && isCodexManagedHookCommand(command) {
-				found = true
-				return
+			if hooksMap, ok := node["hooks"].(map[string]any); ok {
+				for eventName, val := range hooksMap {
+					if codexHookValueHasManagedCommand(val, eventName) {
+						found = true
+						return
+					}
+				}
 			}
 			for _, val := range node {
 				walk(val)
@@ -1152,16 +1445,17 @@ func isLegacyGCManagedCommand(event, command string) bool {
 	case "PreCompact":
 		return equalsLegacyCommandBody(body, "gc prime --hook") ||
 			equalsLegacyCommandBody(body, `gc handoff "context cycle"`) ||
-			equalsLegacyCommandBody(body, `gc handoff --auto "context cycle"`)
+			equalsLegacyCommandBody(body, `gc handoff --auto "context cycle"`) ||
+			isCodexPreCompactCommandBody(body)
 	case "SessionStart":
 		return equalsLegacyCommandBody(body, "gc prime --hook") ||
 			equalsLegacyCommandBody(body, "gc prime --hook --hook-format codex") ||
 			equalsLegacyCommandBody(body, sessionStartPreviousManagedFormBody) ||
-			equalsLegacyCommandBody(body, sessionStartCurrentFormBody)
+			isCodexSessionStartCommandBody(body)
 	case "UserPromptSubmit":
 		return equalsLegacyCommandBody(body, `gc nudge drain --inject`) ||
 			equalsLegacyCommandBody(body, `gc mail check --inject`) ||
-			strings.HasPrefix(body, managedPromptHookRunPrefix)
+			codexManagedPromptTarget(body, "")
 	}
 	return false
 }
@@ -1174,9 +1468,18 @@ func isLegacyGCManagedCommand(event, command string) bool {
 // full env-var preamble. If gc ever extends the current-form command
 // with additional arguments, update this constant alongside the
 // emission site so legacy detection remains tight.
-const sessionStartCurrentFormBody = `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex`
+func sessionStartCurrentFormBody(cityDir string) string {
+	return `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc ` + codexCityFlag(cityDir) + `prime --hook --hook-format codex`
+}
 
 const sessionStartPreviousManagedFormBody = `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`
+
+// preCompactCurrentFormBody is the canonical current-form managed PreCompact
+// command body (post-canonical-PATH-prefix). If gc ever extends this command
+// with additional arguments, update this constant alongside the emission site.
+func preCompactCurrentFormBody(cityDir string) string {
+	return `gc ` + codexCityFlag(cityDir) + `handoff --auto --hook-format codex "context cycle"`
+}
 
 // equalsLegacyCommandBody reports whether the command body is exactly the
 // legacy token. gc historically emitted these tokens as the complete
@@ -1230,10 +1533,10 @@ func upgradeClaudeHookCommand(event, command string) (string, bool) {
 			equalsLegacyCommandBody(body, `gc prime --hook --hook-format codex`) ||
 			equalsLegacyCommandBody(body, sessionStartPreviousManagedFormBody) {
 			prefix := strings.TrimSuffix(command, body)
-			return prefix + sessionStartCurrentFormBody, true
+			return prefix + sessionStartCurrentFormBody(""), true
 		}
 	case "UserPromptSubmit":
-		return upgradeManagedPromptHookCommand(command, "")
+		return upgradeManagedPromptHookCommand(command, "", "")
 	}
 	return "", false
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -646,7 +646,13 @@ func upgradeCodexHooks(existing, desired []byte, cityDir string) ([]byte, bool, 
 	}
 	hasManagedCommand := codexHookValueHasManagedCommand(root, "")
 	needsPreCompact := codexHookDocCanAddPreCompact(root)
-	changed := applyCodexManagedHookUpgrade(root, desired, cityDir)
+	changed := upgradeCodexHookValue(root, "", cityDir)
+	if desiredCodexPreCompactHook(desired) != nil && normalizeCodexManagedHookEntries(root, cityDir) {
+		changed = true
+	}
+	if addCodexPreCompactHook(root, desired) {
+		changed = true
+	}
 	data, err := overlay.MarshalCanonicalJSON(root)
 	if err != nil {
 		return nil, false, err
@@ -700,9 +706,6 @@ func CodexHooksNeedManagedUpgrade(data []byte, cityDir string) bool {
 
 func applyCodexManagedHookUpgrade(root any, desired []byte, cityDir string) bool {
 	changed := upgradeCodexHookValue(root, "", cityDir)
-	if normalizeCodexManagedHookEntries(root, cityDir) {
-		changed = true
-	}
 	if addCodexPreCompactHook(root, desired) {
 		changed = true
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
 func claudeHookCommand(t *testing.T, data []byte, event string) string {
@@ -259,7 +260,7 @@ func TestInstallClaudeUpgradesPreviousCanonicalSessionStart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("readEmbedded: %v", err)
 	}
-	stale := strings.Replace(string(current), sessionStartCurrentFormBody, sessionStartPreviousManagedFormBody, 1)
+	stale := strings.Replace(string(current), sessionStartCurrentFormBody(""), sessionStartPreviousManagedFormBody, 1)
 	if stale == string(current) {
 		t.Fatal("stale fixture did not diverge from current embedded config — check previous SessionStart pattern")
 	}
@@ -273,8 +274,8 @@ func TestInstallClaudeUpgradesPreviousCanonicalSessionStart(t *testing.T) {
 	hookData := fs.Files["/city/hooks/claude.json"]
 	runtimeData := fs.Files["/city/.gc/settings.json"]
 	sessionStartCommand := claudeHookCommand(t, hookData, "SessionStart")
-	if got := commandBodyAfterCanonicalPrefix(sessionStartCommand); got != sessionStartCurrentFormBody {
-		t.Fatalf("upgraded SessionStart body = %q, want %q", got, sessionStartCurrentFormBody)
+	if got := commandBodyAfterCanonicalPrefix(sessionStartCommand); got != sessionStartCurrentFormBody("") {
+		t.Fatalf("upgraded SessionStart body = %q, want %q", got, sessionStartCurrentFormBody(""))
 	}
 	if string(runtimeData) != string(hookData) {
 		t.Fatalf("runtime Claude settings should mirror upgraded hook settings:\n%s", string(runtimeData))
@@ -343,7 +344,7 @@ func TestInstallCodexUpgradesGeneratedFileMissingHookFormat(t *testing.T) {
 	if !strings.Contains(got, `"PreCompact"`) {
 		t.Errorf("upgraded codex hooks missing PreCompact:\n%s", got)
 	}
-	if !strings.Contains(got, `gc handoff --auto --hook-format codex \"context cycle\"`) {
+	if !strings.Contains(got, `gc --city '/city' handoff --auto --hook-format codex \"context cycle\"`) {
 		t.Errorf("upgraded codex PreCompact missing auto handoff command:\n%s", got)
 	}
 }
@@ -372,7 +373,7 @@ func TestInstallCodexUpgradesSessionStartMissingManagedMarker(t *testing.T) {
 	if !strings.Contains(sessionStartCommand, "GC_HOOK_EVENT_NAME=SessionStart") {
 		t.Fatalf("upgraded codex SessionStart missing event marker: %s", sessionStartCommand)
 	}
-	if !strings.Contains(sessionStartCommand, "gc prime --hook --hook-format codex") {
+	if !strings.Contains(sessionStartCommand, "gc --city '/city' prime --hook --hook-format codex") {
 		t.Fatalf("upgraded codex SessionStart missing hook format: %s", sessionStartCommand)
 	}
 }
@@ -460,10 +461,10 @@ func TestInstallCodexUpgradesManagedFileMissingPreCompact(t *testing.T) {
 	if !strings.Contains(got, `"PreCompact"`) {
 		t.Errorf("upgraded codex hooks missing PreCompact:\n%s", got)
 	}
-	if !strings.Contains(got, `gc handoff --auto --hook-format codex \"context cycle\"`) {
+	if !strings.Contains(got, `gc --city '/city' handoff --auto --hook-format codex \"context cycle\"`) {
 		t.Errorf("upgraded codex PreCompact missing auto handoff command:\n%s", got)
 	}
-	if !strings.Contains(got, `gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format codex`) {
+	if !strings.Contains(got, `gc --city '/city' hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format codex`) {
 		t.Errorf("upgraded codex UserPromptSubmit missing bounded mail check command:\n%s", got)
 	}
 }
@@ -475,12 +476,26 @@ func TestInstallCodexWritesCanonicalHookBytes(t *testing.T) {
 	}
 
 	got := fs.Files["/work/.codex/hooks.json"]
-	normalized, changed, err := normalizeCodexHookCommands(got)
+	normalized, changed, err := normalizeCodexHookCommands(got, "/city")
 	if err != nil {
 		t.Fatalf("normalizeCodexHookCommands: %v", err)
 	}
 	if changed || !bytes.Equal(normalized, got) {
 		t.Fatalf("codex hook install should write canonical bytes")
+	}
+}
+
+func TestInstallCodexBindsExplicitCity(t *testing.T) {
+	fs := fsys.NewFake()
+	cityDir := "/city with spaces"
+	if err := Install(fs, cityDir, "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := string(fs.Files["/work/.codex/hooks.json"])
+	wantCity := `--city ` + shellquote.Quote(cityDir)
+	if !strings.Contains(got, wantCity) {
+		t.Fatalf("codex hooks missing explicit city binding %q:\n%s", wantCity, got)
 	}
 }
 
@@ -518,6 +533,23 @@ func TestCodexHooksMissingManagedPreCompact(t *testing.T) {
 
 	if CodexHooksMissingManagedPreCompact([]byte(`{not-json`)) {
 		t.Fatal("malformed Codex hooks were reported stale")
+	}
+}
+
+func TestCodexHooksNeedManagedUpgrade(t *testing.T) {
+	wrongCity := []byte(`{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city /old/city prime --hook --hook-format codex"}]}],"PreCompact":[{"hooks":[{"type":"command","command":"export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc --city /old/city handoff --auto --hook-format codex \"context cycle\""}]}]}}`)
+	if !CodexHooksNeedManagedUpgrade(wrongCity, "/new city") {
+		t.Fatal("managed Codex hooks with stale city binding were not reported stale")
+	}
+
+	currentCity := []byte(`{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city '/old/city' prime --hook --hook-format codex"}]}],"PreCompact":[{"hooks":[{"type":"command","command":"export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc --city '/old/city' handoff --auto --hook-format codex \"context cycle\""}]}]}}`)
+	if CodexHooksNeedManagedUpgrade(currentCity, "/old/city") {
+		t.Fatal("managed Codex hooks already bound to requested city were reported stale")
+	}
+
+	custom := []byte(`{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"FOO=1 gc mail check --inject --hook-format codex"}]}]}}`)
+	if CodexHooksNeedManagedUpgrade(custom, "/city") {
+		t.Fatal("env-prefixed custom Codex hooks were reported stale")
 	}
 }
 
@@ -562,11 +594,81 @@ func TestInstallCodexUpgradePreservesCustomHooks(t *testing.T) {
 	if !strings.Contains(got, "--hook-format codex") {
 		t.Errorf("upgraded codex hooks missing Codex hook output format:\n%s", got)
 	}
+	if !strings.Contains(got, `gc --city '/city' prime --hook --hook-format codex`) {
+		t.Errorf("upgraded codex hooks missing explicit city binding:\n%s", got)
+	}
 	if !strings.Contains(got, "printf custom-codex-hook") {
 		t.Errorf("custom codex hook was not preserved:\n%s", got)
 	}
 	if !strings.Contains(got, `"PreCompact"`) {
 		t.Errorf("managed codex upgrade should add PreCompact while preserving custom hooks:\n%s", got)
+	}
+}
+
+func TestInstallCodexRebindsManagedHooksAndAddsPreCompact(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.codex/hooks.json"] = []byte(`{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city /old/city prime --hook --hook-format codex"
+      }]
+    }]
+  }
+}`)
+
+	if err := Install(fs, "/new city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := string(fs.Files["/work/.codex/hooks.json"])
+	if !strings.Contains(got, `gc --city '/new city' prime --hook --hook-format codex`) {
+		t.Fatalf("SessionStart not rebound to current city:\n%s", got)
+	}
+	if !strings.Contains(got, `"PreCompact"`) {
+		t.Fatalf("managed codex upgrade missing PreCompact:\n%s", got)
+	}
+	if !strings.Contains(got, `gc --city '/new city' handoff --auto --hook-format codex \"context cycle\"`) {
+		t.Fatalf("PreCompact not added for current city:\n%s", got)
+	}
+	if strings.Contains(got, "/old/city") {
+		t.Fatalf("stale city binding survived:\n%s", got)
+	}
+}
+
+func TestInstallCodexRebindsManagedHooksToCurrentCity(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.codex/hooks.json"] = []byte(`{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city /old/city prime --hook --hook-format codex"
+      }]
+    }],
+    "PreCompact": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc --city /old/city handoff --auto --hook-format codex \"context cycle\""
+      }]
+    }]
+  }
+}`)
+
+	if err := Install(fs, "/new city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := string(fs.Files["/work/.codex/hooks.json"])
+	if !strings.Contains(got, `gc --city '/new city' prime --hook --hook-format codex`) {
+		t.Fatalf("SessionStart not rebound to current city:\n%s", got)
+	}
+	if !strings.Contains(got, `gc --city '/new city' handoff --auto --hook-format codex \"context cycle\"`) {
+		t.Fatalf("PreCompact not rebound to current city:\n%s", got)
+	}
+	if strings.Contains(got, "/old/city") {
+		t.Fatalf("stale city binding survived:\n%s", got)
 	}
 }
 
@@ -593,6 +695,55 @@ func TestInstallCodexPreservesFullyCustomHooks(t *testing.T) {
 	}
 }
 
+func TestInstallCodexPreservesEnvPrefixedManagedLookingCustomHooks(t *testing.T) {
+	fs := fsys.NewFake()
+	custom := []byte(`{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "hooks": [{
+        "type": "command",
+        "command": "FOO=1 gc mail check --inject --hook-format codex"
+      }]
+    }]
+  }
+}`)
+	fs.Files["/work/.codex/hooks.json"] = custom
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if got := string(fs.Files["/work/.codex/hooks.json"]); got != string(custom) {
+		t.Fatalf("env-prefixed custom codex hooks were rewritten:\n%s", got)
+	}
+}
+
+func TestInstallCodexPreservesExtraEnvOnManagedHooks(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.codex/hooks.json"] = []byte(`{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && FOO=1 GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex"
+      }]
+    }]
+  }
+}`)
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := string(fs.Files["/work/.codex/hooks.json"])
+	if !strings.Contains(got, `FOO=1 GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city '/city' prime --hook --hook-format codex`) {
+		t.Fatalf("managed codex hook lost extra env prefix:\n%s", got)
+	}
+	if !strings.Contains(got, `"PreCompact"`) {
+		t.Fatalf("managed codex hook with extra env missing PreCompact:\n%s", got)
+	}
+}
+
 func TestUpgradeCodexHooksSkipsWhenDesiredPreCompactUnavailable(t *testing.T) {
 	existing := []byte(`{
   "hooks": {
@@ -609,7 +760,7 @@ func TestUpgradeCodexHooksSkipsWhenDesiredPreCompactUnavailable(t *testing.T) {
 		"missing":   []byte(`{"hooks":{}}`),
 	} {
 		t.Run(name, func(t *testing.T) {
-			if _, changed, err := upgradeCodexHooks(existing, desired); err != nil || changed {
+			if _, changed, err := upgradeCodexHooks(existing, desired, ""); err != nil || changed {
 				t.Fatalf("changed = %v, err = %v, want unchanged without error", changed, err)
 			}
 		})
@@ -1528,8 +1679,8 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	codexHooks := fs.Files["/work/.codex/hooks.json"]
 	codexHooksText := string(codexHooks)
 	sessionStartCommand := codexHookCommand(t, codexHooks, "SessionStart")
-	if !strings.Contains(sessionStartCommand, "gc prime --hook --hook-format codex") {
-		t.Fatalf("codex SessionStart hook command = %q, want gc prime --hook --hook-format codex", sessionStartCommand)
+	if !strings.Contains(sessionStartCommand, `gc --city '/city' prime --hook --hook-format codex`) {
+		t.Fatalf("codex SessionStart hook command = %q, want city-bound gc prime --hook --hook-format codex", sessionStartCommand)
 	}
 	if !strings.Contains(sessionStartCommand, "GC_HOOK_EVENT_NAME=SessionStart") {
 		t.Fatalf("codex SessionStart hook command = %q, want GC_HOOK_EVENT_NAME=SessionStart", sessionStartCommand)
@@ -1540,12 +1691,12 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	if !strings.Contains(codexHooksText, `"PreCompact"`) {
 		t.Error("codex hooks should include PreCompact")
 	}
-	if !strings.Contains(codexHooksText, `gc handoff --auto --hook-format codex \"context cycle\"`) {
+	if !strings.Contains(codexHooksText, `gc --city '/city' handoff --auto --hook-format codex \"context cycle\"`) {
 		t.Error("codex PreCompact should use auto handoff with Codex hook output format")
 	}
 	for _, want := range []string{
-		`gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format codex`,
-		`gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format codex`,
+		`gc --city '/city' hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format codex`,
+		`gc --city '/city' hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format codex`,
 	} {
 		if !strings.Contains(codexHooksText, want) {
 			t.Errorf("codex prompt hooks missing bounded command %q:\n%s", want, codexHooksText)
@@ -2227,7 +2378,7 @@ func TestInstallCodexWritesCanonicalJSON(t *testing.T) {
 	if bytes.Contains(data, []byte(`\u0026`)) {
 		t.Fatalf("codex hook escaped command operator:\n%s", data)
 	}
-	if !bytes.Contains(data, []byte(` && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime`)) {
+	if !bytes.Contains(data, []byte(` && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city '/city' prime`)) {
 		t.Fatalf("codex hook missing literal command operator:\n%s", data)
 	}
 	if !bytes.HasSuffix(data, []byte("\n")) {


### PR DESCRIPTION
## Summary
- bind managed Codex hook commands to explicit city root instead of relying on cwd discovery
- preserve managed-hook upgrade semantics and drift detection for stale/missing Codex entries
- avoid rewriting custom env-prefixed hook commands while normalizing managed hooks

## Root cause
Managed Codex hooks ran bare `gc ...` from agent workdirs. In nested agent dirs, implicit city discovery could latch onto ancestor `.gc/` runtime state and create nested pseudo-city hook trees, which led to duplicated managed hooks.

## Testing
- go test ./internal/hooks -run Codex -count=1
- go test ./cmd/gc -run 'Codex|Doctor' -count=1