### PR TITLE
fix(control-dispatcher): route rig-store control beads to the resident rig dispatcher

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,38 +93,81 @@ func IsDeterministicControlDispatcher(agent *Agent) bool {
 }
 
 // PreferredDeterministicControlDispatcher returns the deterministic control-
-// dispatcher to route a scope's control beads to, binding-agnostic. The
-// city-level singleton (Dir == "") is preferred for every scope — given
-// max_active_sessions=1, it is the one whose session actually runs and claims
-// the control queue — and a rig-scoped instance (Dir == rigContext) is used only
-// when no city-level deterministic dispatcher is configured. Routing to a
-// rig-scoped copy when a city singleton exists strands the control bead, since
-// the singleton session never claims a <rig>/... route. This is the canonical
-// selection shared by the graph.v2 decoration path (internal/graphroute) and the
-// attempt-time control re-route path (internal/dispatch); keep them in lockstep.
+// dispatcher to route a scope's control beads to, binding-agnostic. A RESIDENT
+// rig-scoped instance (Dir == rigContext, kept live by a [[named_session]]
+// mode="always" or a min_active_sessions>=1 floor) is preferred when one exists:
+// it is the session that actually runs and serves that rig's OWN prefix bead
+// store, so a control bead living in that store can only be claimed there — never
+// by the city singleton, which serves the city (HQ) store. Otherwise the
+// city-level singleton (Dir == "") is preferred — given the shipped pack's
+// max_active_sessions=1 it is the one session that runs and claims the control
+// queue, and routing a rig-store bead to a NON-resident rig copy (configured but
+// never launched) would strand it (the #3764/#3765 shape). A rig-scoped copy is
+// used as a last resort only when no city-level dispatcher is configured. This is
+// the canonical selection shared by the graph.v2 decoration path
+// (internal/graphroute) and the attempt-time control re-route path
+// (internal/dispatch); keep them in lockstep.
 func PreferredDeterministicControlDispatcher(cfg *City, rigContext string) (Agent, bool) {
 	if cfg == nil {
 		return Agent{}, false
 	}
 	rigContext = strings.TrimSpace(rigContext)
-	var rigScoped Agent
-	haveRigScoped := false
+	var citySingleton, rigScoped Agent
+	haveCity, haveRig := false, false
 	for _, a := range cfg.Agents {
 		if !IsDeterministicControlDispatcher(&a) {
 			continue
 		}
 		if strings.TrimSpace(a.Dir) == "" {
-			return a, true
+			if !haveCity {
+				citySingleton, haveCity = a, true
+			}
+			continue
 		}
-		if !haveRigScoped && strings.TrimSpace(a.Dir) == rigContext {
-			rigScoped = a
-			haveRigScoped = true
+		if !haveRig && rigContext != "" && strings.TrimSpace(a.Dir) == rigContext {
+			rigScoped, haveRig = a, true
 		}
 	}
-	if haveRigScoped {
+	// (1) A resident rig-scoped dispatcher runs and serves that rig's own prefix
+	// store; its rig-store control beads must route to it (the singleton can
+	// never claim a <rig>/... route in that store). This is the multi-store case.
+	if haveRig && controlDispatcherIsResident(cfg, &rigScoped) {
+		return rigScoped, true
+	}
+	// (2) Otherwise the city-level singleton — the session that runs given the
+	// shipped pack's max_active_sessions=1. Preserves the #3764 unpinned shape.
+	if haveCity {
+		return citySingleton, true
+	}
+	// (3) Rig-scoped fallback only when no city-level dispatcher exists at all.
+	if haveRig {
 		return rigScoped, true
 	}
 	return Agent{}, false
+}
+
+// controlDispatcherIsResident reports whether a control-dispatcher agent is kept
+// live by the controller — pinned by a [[named_session]] mode="always" bound to
+// it (the same TemplateQualifiedName↔QualifiedName correlation validateNamedSessions
+// uses) or carrying a min_active_sessions>=1 floor. Only a resident rig-scoped
+// dispatcher is a session that actually runs and serves its rig's own prefix bead
+// store, so only then may a rig-store control bead route to it instead of the
+// city singleton.
+func controlDispatcherIsResident(cfg *City, agent *Agent) bool {
+	if cfg == nil || agent == nil {
+		return false
+	}
+	if agent.MinActiveSessions != nil && *agent.MinActiveSessions >= 1 {
+		return true
+	}
+	qn := agent.QualifiedName()
+	for i := range cfg.NamedSessions {
+		ns := &cfg.NamedSessions[i]
+		if ns.ModeOrDefault() == "always" && ns.TemplateQualifiedName() == qn {
+			return true
+		}
+	}
+	return false
 }
 
 // BindingQualifiedName returns the binding-qualified agent identity without a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7852,15 +7852,28 @@ func TestPreferredDeterministicControlDispatcher(t *testing.T) {
 	rigCopy := deterministic("fixture")
 	plain := Agent{Name: ControlDispatcherAgentName, Dir: "fixture"} // no StartCommand
 
+	// A rig-scoped dispatcher made RESIDENT by a min_active_sessions>=1 floor.
+	minOne := 1
+	rigCopyMinActive := deterministic("fixture")
+	rigCopyMinActive.MinActiveSessions = &minOne
+
+	// alwaysPin returns a [[named_session]] mode="always" pinning the rig-scoped
+	// core.control-dispatcher for dir; its TemplateQualifiedName matches the agent
+	// QualifiedName "<dir>/core.control-dispatcher", mirroring atlas's city.toml.
+	alwaysPin := func(dir string) NamedSession {
+		return NamedSession{Template: "core.control-dispatcher", Dir: dir, Mode: "always"}
+	}
+
 	tests := []struct {
-		name       string
-		agents     []Agent
-		rigContext string
-		wantQN     string
-		wantOK     bool
+		name          string
+		agents        []Agent
+		namedSessions []NamedSession
+		rigContext    string
+		wantQN        string
+		wantOK        bool
 	}{
 		{
-			name:       "singleton preferred over rig copy for rig scope",
+			name:       "singleton preferred over NON-resident rig copy for rig scope",
 			agents:     []Agent{rigCopy, citySingleton},
 			rigContext: "fixture",
 			wantQN:     "core.control-dispatcher",
@@ -7892,11 +7905,59 @@ func TestPreferredDeterministicControlDispatcher(t *testing.T) {
 			rigContext: "other",
 			wantOK:     false,
 		},
+		{
+			// Multi-store city (atlas): the rig dispatcher is pinned always-on,
+			// so it runs + serves its own rig store — its control beads route to
+			// it, not the singleton (which cannot claim a <rig>/... route).
+			name:          "RESIDENT rig copy (named_session always) preferred for its rig scope",
+			agents:        []Agent{rigCopy, citySingleton},
+			namedSessions: []NamedSession{alwaysPin("fixture")},
+			rigContext:    "fixture",
+			wantQN:        "fixture/core.control-dispatcher",
+			wantOK:        true,
+		},
+		{
+			name:       "RESIDENT rig copy (min_active_sessions>=1) preferred for its rig scope",
+			agents:     []Agent{rigCopyMinActive, citySingleton},
+			rigContext: "fixture",
+			wantQN:     "fixture/core.control-dispatcher",
+			wantOK:     true,
+		},
+		{
+			// Residency must not leak into city-scope work: a pinned rig
+			// dispatcher does NOT capture rigContext=="" (run-operator-city).
+			name:          "resident rig copy still yields singleton for empty scope",
+			agents:        []Agent{rigCopy, citySingleton},
+			namedSessions: []NamedSession{alwaysPin("fixture")},
+			rigContext:    "",
+			wantQN:        "core.control-dispatcher",
+			wantOK:        true,
+		},
+		{
+			// on_demand pinning does NOT make the rig dispatcher resident (only
+			// the singleton runs given max_active_sessions=1) — singleton wins.
+			name:          "on_demand-pinned rig copy is NOT resident — singleton wins",
+			agents:        []Agent{rigCopy, citySingleton},
+			namedSessions: []NamedSession{{Template: "core.control-dispatcher", Dir: "fixture", Mode: "on_demand"}},
+			rigContext:    "fixture",
+			wantQN:        "core.control-dispatcher",
+			wantOK:        true,
+		},
+		{
+			// A pin for a DIFFERENT rig does not make THIS rig's dispatcher
+			// resident (the QualifiedName correlation is rig-specific).
+			name:          "always-pin for another rig does not make this rig resident",
+			agents:        []Agent{rigCopy, citySingleton},
+			namedSessions: []NamedSession{alwaysPin("other")},
+			rigContext:    "fixture",
+			wantQN:        "core.control-dispatcher",
+			wantOK:        true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := PreferredDeterministicControlDispatcher(&City{Agents: tt.agents}, tt.rigContext)
+			got, ok := PreferredDeterministicControlDispatcher(&City{Agents: tt.agents, NamedSessions: tt.namedSessions}, tt.rigContext)
 			if ok != tt.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
 			}

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -1240,6 +1240,64 @@ func TestApplyAttemptControlStepRoute_PrefersCitySingletonOverRigScoped(t *testi
 	}
 }
 
+// TestApplyAttemptControlStepRoute_PrefersResidentRigScoped is the multi-store
+// (atlas) counterpart to PrefersCitySingletonOverRigScoped: the SAME city, but
+// the rig-scoped dispatcher is pinned RESIDENT by a [[named_session]]
+// mode="always". Its attempt-time control bead must route to the rig dispatcher
+// that actually serves the rig store — the unit-level proof of the atlas re-home
+// result (a rig-store control bead can only be advanced by the dispatcher
+// serving that store, never the city singleton).
+func TestApplyAttemptControlStepRoute_PrefersResidentRigScoped(t *testing.T) {
+	t.Parallel()
+
+	maxActive := 1
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "atlas-like-city"},
+		Daemon:    config.DaemonConfig{FormulaV2: boolPtr(true)},
+		Rigs: []config.Rig{{
+			Name: "fixture",
+			Path: t.TempDir(),
+		}},
+		Agents: []config.Agent{{
+			Name:              config.ControlDispatcherAgentName,
+			BindingName:       "core",
+			StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+			ProcessNames:      []string{"gc"},
+			MaxActiveSessions: &maxActive,
+		}, {
+			Name:              config.ControlDispatcherAgentName,
+			BindingName:       "core",
+			Dir:               "fixture",
+			StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+			ProcessNames:      []string{"gc"},
+			MaxActiveSessions: &maxActive,
+		}, {
+			Name: "superpowers.brainstorming",
+			Dir:  "fixture",
+		}},
+		NamedSessions: []config.NamedSession{
+			{Template: "core.control-dispatcher", Dir: "fixture", Mode: "always"},
+		},
+	}
+
+	step := &formula.RecipeStep{
+		Metadata: map[string]string{
+			"gc.routed_to": "stale-route",
+		},
+	}
+	applyAttemptControlStepRoute(step, "fixture/superpowers.brainstorming", cfg, beads.NewMemStore())
+
+	if step.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty routed control-dispatcher queue", step.Assignee)
+	}
+	if got := step.Metadata["gc.routed_to"]; got != "fixture/core.control-dispatcher" {
+		t.Fatalf("gc.routed_to = %q, want resident rig dispatcher fixture/core.control-dispatcher", got)
+	}
+	if got := step.Metadata["gc.execution_routed_to"]; got != "fixture/superpowers.brainstorming" {
+		t.Fatalf("gc.execution_routed_to = %q, want fixture/superpowers.brainstorming", got)
+	}
+}
+
 func TestSpawnNextAttemptUsesSourceRigForBareChildControlRoute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -772,6 +772,55 @@ func TestControlDispatcherBinding_PrefersCitySingletonOverRigScoped(t *testing.T
 	}
 }
 
+// TestControlDispatcherBinding_PrefersResidentRigScoped is the multi-store
+// (atlas) counterpart to PrefersCitySingletonOverRigScoped: the SAME city, but
+// the rig-scoped dispatcher is pinned RESIDENT by a [[named_session]]
+// mode="always". A resident rig dispatcher runs and serves its own rig store, so
+// a rig-scope (rigContext="fixture") control bead must route to it — while a
+// city-scope (rigContext="") bead still routes to the singleton.
+func TestControlDispatcherBinding_PrefersResidentRigScoped(t *testing.T) {
+	maxActive := 1
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:              config.ControlDispatcherAgentName,
+				BindingName:       "core",
+				StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+				MaxActiveSessions: &maxActive,
+			},
+			{
+				Name:              config.ControlDispatcherAgentName,
+				BindingName:       "core",
+				Dir:               "fixture",
+				StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+				MaxActiveSessions: &maxActive,
+			},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "core.control-dispatcher", Dir: "fixture", Mode: "always"},
+		},
+	}
+
+	cases := map[string]string{
+		"fixture": "fixture/core.control-dispatcher", // rig scope → resident rig dispatcher
+		"":        "core.control-dispatcher",         // city scope → singleton
+	}
+	for rigContext, wantQN := range cases {
+		t.Run("rigContext="+rigContext, func(t *testing.T) {
+			binding, err := ControlDispatcherBinding(nil, "test-city", cfg, rigContext, Deps{Resolver: noMatchAgentResolver{}})
+			if err != nil {
+				t.Fatalf("ControlDispatcherBinding: %v", err)
+			}
+			if binding.QualifiedName != wantQN {
+				t.Fatalf("QualifiedName = %q, want %q", binding.QualifiedName, wantQN)
+			}
+			if !binding.MetadataOnly {
+				t.Fatalf("MetadataOnly = false, want true")
+			}
+		})
+	}
+}
+
 // TestControlDispatcherBinding_CityOnlyBoundDispatcher covers a city with only
 // the bound city-level singleton (no per-rig copies). It must resolve for both
 // the empty and a non-empty rig context, and must NOT depend on bare-name


### PR DESCRIPTION
### TL;DR

In a **multi-store city** — one where rigs have their own bead stores and each is served by its own always-on `<rig>/core.control-dispatcher` — every graph.v2 workflow slung at a rig target **wedges at its first control step**. `PreferredDeterministicControlDispatcher` unconditionally stamps rig-store control beads with `gc.routed_to=core.control-dispatcher` (the city singleton), but the singleton serves only the city (HQ) store and can never claim a `<rig>/`-prefixed bead. The dispatcher that *does* serve the rig store is never told to look.

This is the multi-store regression left by #3765 (which correctly fixed the *single-store* strand in #3764). The fix makes the resolver prefer a **resident** rig-scoped dispatcher — one actually kept alive by a `[[named_session]] mode="always"` or `min_active_sessions>=1` — for its rig scope, while leaving the singleton as the target for city-scope work and for non-resident rig copies. No new config surface, no caller changes, and **every existing #3765 assertion stays green**.

### Why this is critical

On a multi-rig city (the canonical topology per `docs/internals/beads-topology.md` — one shared Dolt server, per-scope prefix isolation, an auto-injected control-dispatcher per rig), **all graph.v2 dev work is dead on arrival**:

- Any formula slung at `<rig>/…` (`mol-dev`, `mol-dev-deep`, `mol-pr-fix`, `mol-evidence`, `product-architect`'s per-rig `plan-<rig>` steps, …) creates its ralph / finalize / attempt control beads in the rig store.
- Those beads are stamped `gc.routed_to=core.control-dispatcher`.
- The rig's own dispatcher (`<rig>/core.control-dispatcher`), which serves that store, filters its claim query to `gc.routed_to=<rig>/core.control-dispatcher` and skips them. The singleton claims that route but serves only the HQ store, so it never sees them.
- Result: the workflow advances through its polecat steps, then **stalls forever** at the first control (ralph/finalize) gate. The dispatcher sits active-but-idle; the convoy strands; the witness escalates it HIGH.

It silently breaks the entire graph.v2 execution model for multi-rig cities — the failure is invisible (no error; the dispatcher is "healthy") until you notice work never finishes.

### Root cause

`internal/config/config.go` → `PreferredDeterministicControlDispatcher(cfg, rigContext)` short-circuits on the first city singleton it sees:

```go
for _, a := range cfg.Agents {
    if !IsDeterministicControlDispatcher(&a) { continue }
    if strings.TrimSpace(a.Dir) == "" {
        return a, true            // singleton wins for EVERY rigContext
    }
    if !haveRigScoped && strings.TrimSpace(a.Dir) == rigContext {
        rigScoped = a; haveRigScoped = true   // only used if NO singleton exists
    }
}
```

Both stamping paths delegate here — `internal/graphroute/graphroute.go` (`resolveControlDispatcherBinding`, the compile/decoration path) and `internal/dispatch/control.go` (`controlDispatcherTargetForExecutionTarget`, the attempt-time path) — so the mis-route is applied uniformly.

`gc` runs **one dispatcher process per store** (`cmd/gc/dispatch_runtime.go` → `drainWorkflowServeWork(agentCfg, cityPath, storePath, …)` binds a dispatcher to a single `storePath`; its claim query sets `GC_CONTROL_TARGET = agentCfg.QualifiedName()` and runs `bd ready --metadata-field gc.routed_to=<QN>` inside that store). So a rig-store control bead is claimable **only** by the dispatcher serving that store — never by the singleton.

#3765 chose the singleton deliberately, "matching the shipped pack's `max_active_sessions=1`" — a city where only the singleton session runs and any rig-scoped copy is configured-but-idle (routing to it there would strand, which was #3764). That assumption does not hold for a multi-store city where the per-rig dispatchers are pinned always-on and actively serve their stores.

### The fix

Prefer a **resident** rig-scoped dispatcher for its rig scope; fall back to the singleton otherwise.

*Residency* = the dispatcher is actually kept alive by the controller: pinned by a `[[named_session]] mode="always"` bound to it (the same `TemplateQualifiedName ↔ QualifiedName` correlation `validateNamedSessions` already uses), or carrying a `min_active_sessions>=1` floor. Only a resident rig dispatcher runs and serves its rig's own store, so only then may a rig-store control bead route to it.

```go
// (1) resident rig-scoped dispatcher → serves the rig store → route to it
if haveRig && controlDispatcherIsResident(cfg, &rigScoped) {
    return rigScoped, true
}
// (2) otherwise the city singleton (the session that runs at max_active_sessions=1)
if haveCity {
    return citySingleton, true
}
// (3) rig-scoped last resort when no city singleton is configured at all
if haveRig {
    return rigScoped, true
}
```

Key properties:
- **Discriminator is `cfg`-derivable** — uses existing `City.NamedSessions` + `Agent.MinActiveSessions`; both call sites already receive `cfg`. No new config field, no method signature change, no caller change.
- **`rigContext==""` (city-scope work) still resolves to the singleton** — residency is only consulted for a non-empty rig scope, so `run-operator-city`'s city-scope handoffs are unaffected.
- **Preserves #3764/#3765** — the shipped `max_active_sessions=1` pack has no resident rig dispatcher, so it still routes to the singleton, byte-for-byte.

### Evidence

**Empirical (production multi-rig city).** 12 convoys were stranded across `mol-pr-fix` and `mol-evidence` runs; 22 rig-store control beads carried `gc.routed_to=core.control-dispatcher` while `backend/core.control-dispatcher` sat active-but-idle (`idle_sweeps` climbing, `processed=0`). Re-homing those beads by hand —

```
bd update <id> --set-metadata gc.routed_to=backend/core.control-dispatcher
```

— drained them **immediately**: all 5 `mol-pr-fix` implement ralphs closed within seconds of the re-home, polecats woke to their push-reply steps, workflows finalized, and the stranded count went 12 → 0. That is direct proof the rig dispatcher is the correct target and the only one that can advance a rig-store control bead. This PR makes `gc` stamp that target in the first place.

**Unit (this PR).** `TestApplyAttemptControlStepRoute_PrefersResidentRigScoped` reproduces exactly that scenario at the attempt-time path: a registered rig + a `mode="always"` pin for `fixture/core.control-dispatcher` ⇒ the control bead is stamped `gc.routed_to=fixture/core.control-dispatcher` (pre-fix: `core.control-dispatcher`).

### Reproduction

**Wedge (before this fix), on any multi-rig city with pinned per-rig dispatchers:**
1. `gc sling <rig>/gastown.polecat mol-dev --formula --var rig=<rig> --var repo=<owner/name> --var base_branch=main --var task='…'`
2. Watch the workflow's control beads: `gc bd show <ralph-id> --json | jq '.metadata["gc.routed_to"]'` → `core.control-dispatcher`.
3. The workflow advances through polecat steps, then stalls at the implement (ralph) gate forever; `gc convoy stranded --rig <rig>` lists it. `<rig>/core.control-dispatcher` is active but `processed=0`.

**Verify the fix (unit, no city needed):**
```
export CGO_CPPFLAGS="-I$(brew --prefix icu4c)/include"    # macOS keg-only ICU; no-op on Linux/CI
export CGO_LDFLAGS="-L$(brew --prefix icu4c)/lib"
go test ./internal/config/ ./internal/graphroute/ ./internal/dispatch/ \
  -run 'PreferredDeterministicControlDispatcher|ControlDispatcherBinding|ApplyAttemptControlStepRoute' -count=1 -v
```

### Tests

- **`internal/config/config_test.go`** — extends `TestPreferredDeterministicControlDispatcher` with a `namedSessions` column and 5 new cases: resident-via-`always`, resident-via-`min_active_sessions`, empty-scope-guard (still singleton), `on_demand`-pin-is-not-resident, and wrong-rig-pin-is-not-resident. All 5 original cases unchanged.
- **`internal/graphroute/graphroute_test.go`** — `TestControlDispatcherBinding_PrefersResidentRigScoped` (the compile/decoration path).
- **`internal/dispatch/control_integration_test.go`** — `TestApplyAttemptControlStepRoute_PrefersResidentRigScoped` (the attempt-time path).
- **Every committed #3765 assertion stays green**, including the regression guard `TestApplyAttemptControlStepRoute_PrefersCitySingletonOverRigScoped` (registered rig + no pin ⇒ still the singleton) — none of #3765's fixtures set the residency signal, so their output is unchanged.

Local results (all green): `go build ./cmd/gc`; full `internal/config`, `internal/graphroute`, `internal/dispatch` suites; `cmd/gc` control-dispatcher / convoy / workflow-serve tests; `go vet ./…`; `gofmt`; `golangci-lint run` (0 issues); `golangci-lint fmt` (clean).

### Blast radius

Touches one function + one small helper in `internal/config/config.go`; both stamping paths inherit it via the existing delegation. Behavior changes **only** for a city that both (a) has a rig-scoped deterministic control-dispatcher for the scope and (b) has pinned it resident — i.e. exactly the multi-store case that is broken today. Single-store / unpinned cities are byte-for-byte unchanged.

### Notes / follow-ups (not in this PR)

- The attempt-time path (`controlDispatcherTargetForExecutionTarget`) has no runtime-health fallback the way `graphroute.ControlDispatcherBinding` does (#3454). A *dead* pinned rig dispatcher would strand attempt-kind beads — pre-existing asymmetry, not worsened here; a follow-up could extend the #3454 fallback to the attempt path.
- Operationally, a multi-store city must pin **every** rig it runs graph.v2 work on; an unpinned rig correctly resolves to the singleton and would still strand (that is a city-config omission, and the fix behaving so is correct).
