### PR TITLE
fix(gc): bound pack preflight and status event scans

### DIFF
--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -207,7 +207,7 @@ func ensureRequiredBuiltinSourcesCached(cityPath string) error {
 		if err != nil {
 			return fmt.Errorf("resolving cache path for bundled %s pack: %w", name, err)
 		}
-		if builtinpacks.ValidateSyntheticRepo(cachePath, commit) == nil {
+		if builtinpacks.ValidateSyntheticRepoFast(cachePath, commit) == nil {
 			continue
 		}
 		if _, err := packman.EnsureRepoInCache(source, commit); err != nil {
@@ -224,7 +224,7 @@ func requiredBuiltinSourcesUsable(cityPath string) bool {
 		if err != nil {
 			return false
 		}
-		if builtinpacks.ValidateSyntheticRepo(cachePath, commit) != nil {
+		if builtinpacks.ValidateSyntheticRepoFast(cachePath, commit) != nil {
 			return false
 		}
 	}

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -990,20 +990,21 @@ func TestPruneRetiredSystemPacksKeepsTreeWhenManifestUnreadable(t *testing.T) {
 	}
 }
 
-// TestEnsureBuiltinRuntimeAssetsRehydratesCorruptedCache pins the
-// self-healing contract that replaced per-city materialization refresh:
-// stale or corrupted bundled-source cache content is detected on the next
-// EnsureBuiltinRuntimeAssets call — even after the per-city ready cache
-// reported success, because the ready fast path revalidates via
-// requiredBuiltinSourcesUsable — and rehydrated from the embedded packs.
-func TestEnsureBuiltinRuntimeAssetsRehydratesCorruptedCache(t *testing.T) {
+// TestEnsureBuiltinRuntimeAssetsWarmPathLeavesContentDriftToFullValidation
+// keeps command-time preflight cheap: after a city is ready,
+// EnsureBuiltinRuntimeAssets validates the marker/hash contract rather than
+// walking every bundled cache file. Full file-content validation remains the
+// responsibility of builtinpacks.ValidateSyntheticRepo and the repair/install
+// paths that call it before materializing.
+func TestEnsureBuiltinRuntimeAssetsWarmPathLeavesContentDriftToFullValidation(t *testing.T) {
 	clearGCEnv(t) // isolated GC_HOME so the corruption never touches the shared test cache
 	city := t.TempDir()
 
 	materializeBuiltinPacksForTest(t, city)
 
 	target := bundledGcBeadsBdScriptForTest(t)
-	if err := os.WriteFile(target, []byte("#!/bin/sh\necho corrupted\n"), 0o755); err != nil {
+	corrupted := []byte("#!/bin/sh\necho corrupted\n")
+	if err := os.WriteFile(target, corrupted, 0o755); err != nil {
 		t.Fatalf("corrupting cached script: %v", err)
 	}
 
@@ -1011,13 +1012,60 @@ func TestEnsureBuiltinRuntimeAssetsRehydratesCorruptedCache(t *testing.T) {
 		t.Fatalf("EnsureBuiltinRuntimeAssets after corruption: %v", err)
 	}
 
-	want := readBundledPackFileForTest(t, "bd", "assets/scripts/gc-beads-bd.sh")
 	got, err := os.ReadFile(target)
 	if err != nil {
-		t.Fatalf("ReadFile(rehydrated script): %v", err)
+		t.Fatalf("ReadFile(corrupted script): %v", err)
 	}
-	if string(got) != want {
-		t.Fatalf("corrupted cached script was not rehydrated to embedded content; got:\n%s", got)
+	if string(got) != string(corrupted) {
+		t.Fatalf("warm runtime preflight repaired corrupted content; got:\n%s", got)
+	}
+
+	source, ok := builtinpacks.Source("bd")
+	if !ok {
+		t.Fatal("bundled bd pack is not registered")
+	}
+	cachePath, err := packman.RepoCachePath(source, bundledPackImportCommit())
+	if err != nil {
+		t.Fatalf("RepoCachePath(bd): %v", err)
+	}
+	if err := builtinpacks.ValidateSyntheticRepo(cachePath, bundledPackImportCommit()); err == nil {
+		t.Fatal("full synthetic validation unexpectedly accepted corrupted cached content")
+	}
+}
+
+// TestEnsureBuiltinRuntimeAssetsWarmPathSkipsFullSyntheticValidation guards
+// the command hot path: once a city is ready, runtime preflight must not walk
+// the whole synthetic cache tree. Full file-set validation belongs to repair
+// and doctor/install paths; the warm preflight only needs the marker contract
+// so every gc command does not repeatedly rescan the embedded pack cache.
+func TestEnsureBuiltinRuntimeAssetsWarmPathSkipsFullSyntheticValidation(t *testing.T) {
+	clearGCEnv(t) // isolated GC_HOME so the sentinel never touches shared cache state
+	city := t.TempDir()
+
+	materializeBuiltinPacksForTest(t, city)
+
+	source, ok := builtinpacks.Source("bd")
+	if !ok {
+		t.Fatal("bundled bd pack is not registered")
+	}
+	cachePath, err := packman.RepoCachePath(source, bundledPackImportCommit())
+	if err != nil {
+		t.Fatalf("RepoCachePath(bd): %v", err)
+	}
+	sentinel := filepath.Join(cachePath, "hot-path-full-validation-sentinel")
+	if err := os.WriteFile(sentinel, []byte("left for the full validator"), 0o644); err != nil {
+		t.Fatalf("writing sentinel: %v", err)
+	}
+
+	if err := EnsureBuiltinRuntimeAssets(city, io.Discard); err != nil {
+		t.Fatalf("EnsureBuiltinRuntimeAssets warm path: %v", err)
+	}
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("warm runtime preflight performed full synthetic validation and repaired the cache; sentinel stat err = %v", err)
+	}
+	if err := builtinpacks.ValidateSyntheticRepo(cachePath, bundledPackImportCommit()); err == nil {
+		t.Fatal("full synthetic validation unexpectedly accepted the sentinel fixture")
 	}
 }
 

--- a/cmd/gc/legacy_pack_preflight.go
+++ b/cmd/gc/legacy_pack_preflight.go
@@ -71,10 +71,10 @@ func lockedBundledCanonicalImports(cityPath string) ([]lockedBundledImport, erro
 // ensureBundledLockedRemoteImportsCached hydrates the shared repo cache for
 // every bundled pack source pinned in packs.lock so config load can resolve
 // locked bundled imports without network access or a prior "gc import
-// install". A cache that already validates is skipped lock-free; only on
-// validation failure does the preflight take the write-locked
-// packman.EnsureRepoInCache repair path, which revalidates under the lock
-// (a concurrent repair between the two checks is therefore benign).
+// install". A cache that already passes marker/hash validation is skipped
+// lock-free; only on validation failure does the preflight take the
+// write-locked packman.EnsureRepoInCache repair path, which revalidates under
+// the lock (a concurrent repair between the two checks is therefore benign).
 func ensureBundledLockedRemoteImportsCached(cityPath string) error {
 	imports, err := lockedBundledCanonicalImports(cityPath)
 	if err != nil {
@@ -85,7 +85,7 @@ func ensureBundledLockedRemoteImportsCached(cityPath string) error {
 		if err != nil {
 			return fmt.Errorf("resolving cache path for bundled import %q from packs.lock: %w", imp.source, err)
 		}
-		if builtinpacks.ValidateSyntheticRepo(cachePath, imp.commit) == nil {
+		if builtinpacks.ValidateSyntheticRepoFast(cachePath, imp.commit) == nil {
 			continue
 		}
 		if _, err := packman.EnsureRepoInCache(imp.source, imp.commit); err != nil {
@@ -96,14 +96,15 @@ func ensureBundledLockedRemoteImportsCached(cityPath string) error {
 }
 
 // lockedBundledImportsUsable reports whether every bundled pack source pinned
-// at its canonical commit in packs.lock has a valid synthetic cache. The ready
-// fast path in EnsureBuiltinRuntimeAssets pairs it with
-// requiredBuiltinSourcesUsable so an evicted or corrupted optional locked
-// bundled cache (for example gastown or gascity) still forces re-hydration
-// after the city was marked ready, instead of letting config load fail on the
-// locked-but-missing synthetic cache. A lockfile that cannot be read or that
-// has a malformed entry is reported unusable so the caller falls through to
-// ensureBundledLockedRemoteImportsCached, which surfaces the underlying error.
+// at its canonical commit in packs.lock has a marker/hash-valid synthetic
+// cache. The ready fast path in EnsureBuiltinRuntimeAssets pairs it with
+// requiredBuiltinSourcesUsable so an evicted or marker/hash-invalid optional
+// locked bundled cache (for example gastown or gascity) still forces
+// re-hydration after the city was marked ready, instead of letting config load
+// fail on the locked-but-missing synthetic cache. A lockfile that cannot be
+// read or that has a malformed entry is reported unusable so the caller falls
+// through to ensureBundledLockedRemoteImportsCached, which surfaces the
+// underlying error.
 func lockedBundledImportsUsable(cityPath string) bool {
 	imports, err := lockedBundledCanonicalImports(cityPath)
 	if err != nil {
@@ -114,7 +115,7 @@ func lockedBundledImportsUsable(cityPath string) bool {
 		if err != nil {
 			return false
 		}
-		if builtinpacks.ValidateSyntheticRepo(cachePath, imp.commit) != nil {
+		if builtinpacks.ValidateSyntheticRepoFast(cachePath, imp.commit) != nil {
 			return false
 		}
 	}

--- a/internal/api/huma_handlers_events.go
+++ b/internal/api/huma_handlers_events.go
@@ -138,8 +138,8 @@ func toWireEvents(evts []events.Event) []WireEvent {
 }
 
 func filterIsEmpty(f events.Filter) bool {
-	return f.Type == "" && f.Actor == "" && f.Subject == "" &&
-		f.Since.IsZero() && f.Until.IsZero() && f.AfterSeq == 0
+	return f.Type == "" && len(f.Types) == 0 && f.Actor == "" && f.Subject == "" &&
+		f.Since.IsZero() && f.Until.IsZero() && f.AfterSeq == 0 && f.Limit == 0
 }
 
 func parseEventSince(value string) (time.Duration, bool, error) {

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -679,7 +679,14 @@ func (sm *SupervisorMux) humaHandleEventList(_ context.Context, input *Superviso
 }
 
 func supervisorEventListFilterIsEmpty(filter events.Filter) bool {
-	return filter == (events.Filter{})
+	return filter.Type == "" &&
+		len(filter.Types) == 0 &&
+		filter.Actor == "" &&
+		filter.Subject == "" &&
+		filter.Since.IsZero() &&
+		filter.Until.IsZero() &&
+		filter.AfterSeq == 0 &&
+		filter.Limit == 0
 }
 
 func (sm *SupervisorMux) currentSupervisorEventTotal() int {

--- a/internal/api/supervisor_test.go
+++ b/internal/api/supervisor_test.go
@@ -823,6 +823,33 @@ func TestSupervisorEventListFilterIsEmptyMatchesEventsFilterZeroValue(t *testing
 	}
 }
 
+func TestEventListFilterIsEmptyMatchesEventsFilterZeroValue(t *testing.T) {
+	if !filterIsEmpty(events.Filter{}) {
+		t.Fatal("zero-value filter reported non-empty")
+	}
+
+	tests := []struct {
+		name   string
+		filter events.Filter
+	}{
+		{name: "type", filter: events.Filter{Type: events.BeadCreated}},
+		{name: "types", filter: events.Filter{Types: []string{events.BeadCreated}}},
+		{name: "actor", filter: events.Filter{Actor: "human"}},
+		{name: "subject", filter: events.Filter{Subject: "gc-1"}},
+		{name: "since", filter: events.Filter{Since: time.Unix(1, 0)}},
+		{name: "until", filter: events.Filter{Until: time.Unix(1, 0)}},
+		{name: "after_seq", filter: events.Filter{AfterSeq: 1}},
+		{name: "limit", filter: events.Filter{Limit: 1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if filterIsEmpty(tt.filter) {
+				t.Fatalf("filter %+v reported empty", tt.filter)
+			}
+		})
+	}
+}
+
 func TestSupervisorGlobalEventListWithFilter(t *testing.T) {
 	s1 := newFakeState(t)
 	s1.cityName = "alpha"

--- a/internal/api/supervisor_test.go
+++ b/internal/api/supervisor_test.go
@@ -806,6 +806,7 @@ func TestSupervisorEventListFilterIsEmptyMatchesEventsFilterZeroValue(t *testing
 		filter events.Filter
 	}{
 		{name: "type", filter: events.Filter{Type: events.BeadCreated}},
+		{name: "types", filter: events.Filter{Types: []string{events.BeadCreated}}},
 		{name: "actor", filter: events.Filter{Actor: "human"}},
 		{name: "subject", filter: events.Filter{Subject: "gc-1"}},
 		{name: "since", filter: events.Filter{Since: time.Unix(1, 0)}},

--- a/internal/events/exec/exec.go
+++ b/internal/events/exec/exec.go
@@ -34,6 +34,7 @@ type Provider struct {
 
 type listScriptFilter struct {
 	Type     string
+	Types    []string `json:"Types,omitempty"`
 	Actor    string
 	Since    time.Time
 	AfterSeq uint64
@@ -69,6 +70,7 @@ func (p *Provider) List(filter events.Filter) ([]events.Event, error) {
 	p.ensureRunning()
 	scriptFilter := listScriptFilter{
 		Type:     filter.Type,
+		Types:    filter.Types,
 		Actor:    filter.Actor,
 		Since:    filter.Since,
 		AfterSeq: filter.AfterSeq,

--- a/internal/events/exec/exec_test.go
+++ b/internal/events/exec/exec_test.go
@@ -161,6 +161,39 @@ esac
 	}
 }
 
+func TestListSendsTypesFilter(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "stdin.json")
+
+	script := writeScript(t, dir, `
+case "$1" in
+  ensure-running) exit 2 ;;
+  list) cat > "`+outFile+`"
+    echo '[]'
+    ;;
+  *) exit 2 ;;
+esac
+`)
+	p := NewProvider(script, os.Stderr)
+
+	_, err := p.List(events.Filter{Types: []string{events.BeadCreated, events.BeadClosed}})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read filter: %v", err)
+	}
+	var f events.Filter
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("unmarshal filter: %v", err)
+	}
+	if len(f.Types) != 2 || f.Types[0] != events.BeadCreated || f.Types[1] != events.BeadClosed {
+		t.Fatalf("filter.Types = %#v, want bead created+closed", f.Types)
+	}
+}
+
 func TestListAppliesSDKFilterAndStripsScriptLimit(t *testing.T) {
 	dir := t.TempDir()
 	outFile := filepath.Join(dir, "stdin.json")
@@ -478,6 +511,8 @@ case "$op" in
     # Read filter from stdin, apply filters, output JSON array.
     filter=$(cat)
     type_filter=$(echo "$filter" | jq -r '.Type // empty')
+    types_filter=$(echo "$filter" | jq -c '.Types // []')
+    types_len=$(echo "$types_filter" | jq -r 'length')
     actor_filter=$(echo "$filter" | jq -r '.Actor // empty')
     after_seq=$(echo "$filter" | jq -r '.AfterSeq // 0')
     since=$(echo "$filter" | jq -r '.Since // empty')
@@ -491,6 +526,9 @@ case "$op" in
     jq_filter="."
     if [ -n "$type_filter" ]; then
       jq_filter="$jq_filter | select(.type == \"$type_filter\")"
+    fi
+    if [ "$types_len" != "0" ]; then
+      jq_filter="$jq_filter | select(.type as \$event_type | $types_filter | index(\$event_type))"
     fi
     if [ -n "$actor_filter" ]; then
       jq_filter="$jq_filter | select(.actor == \"$actor_filter\")"

--- a/internal/events/query_test.go
+++ b/internal/events/query_test.go
@@ -36,6 +36,15 @@ func TestMatchesFilter_Until(t *testing.T) {
 	}
 }
 
+func TestMatchesFilter_Types(t *testing.T) {
+	if !matchesFilter(Event{Type: BeadClosed}, Filter{Types: []string{BeadCreated, BeadClosed}}) {
+		t.Error("event type in Types should match")
+	}
+	if matchesFilter(Event{Type: SessionWoke}, Filter{Types: []string{BeadCreated, BeadClosed}}) {
+		t.Error("event type outside Types should not match")
+	}
+}
+
 func TestFakeList_Limit(t *testing.T) {
 	// Create a fake with 5 events and request only 3.
 	f := NewFake()

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -7,11 +7,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
 	"time"
 )
+
+const readFilteredTailArchiveScanLimit = 8
 
 // Filter specifies predicates for ReadFiltered. Zero values are ignored.
 type Filter struct {
@@ -253,12 +256,22 @@ func ReadFilteredTail(path string, filter Filter, limit int) ([]Event, error) {
 	if err != nil {
 		return result, nil
 	}
+	archivesScanned := 0
 	for i := len(archives) - 1; i >= 0 && len(result) < limit; i-- {
+		if !archiveOverlapsFilter(archives[i], filter) {
+			continue
+		}
+		if archivesScanned >= readFilteredTailArchiveScanLimit {
+			log.Printf("events: tail fallback: archive scan cap reached after %d archives for %s", archivesScanned, filepath.Base(path))
+			break
+		}
+		archivesScanned++
 		remaining := limit - len(result)
 		archivePath := filepath.Join(filepath.Dir(path), archives[i].Basename)
 		tail, err := readFilteredTailFromArchive(archivePath, filter, remaining)
 		if err != nil {
-			return result, fmt.Errorf("reading archive %q tail: %w", archives[i].Basename, err)
+			log.Printf("events: tail fallback: skipping archive %q: %v", archives[i].Basename, err)
+			continue
 		}
 		if len(tail) == 0 {
 			continue

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -16,6 +16,7 @@ import (
 // Filter specifies predicates for ReadFiltered. Zero values are ignored.
 type Filter struct {
 	Type     string    // match events with this Type
+	Types    []string  // match events with any of these types
 	Actor    string    // match events with this Actor
 	Subject  string    // match events with this Subject
 	Since    time.Time // match events at or after this time
@@ -32,6 +33,18 @@ func matchesFilter(e Event, f Filter) bool {
 	}
 	if f.Type != "" && e.Type != f.Type {
 		return false
+	}
+	if len(f.Types) > 0 {
+		matched := false
+		for _, typ := range f.Types {
+			if e.Type == typ {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
 	}
 	if f.Actor != "" && e.Actor != f.Actor {
 		return false
@@ -208,27 +221,73 @@ func streamArchive(path string, _ Filter, fn func(Event) bool) error {
 	return nil
 }
 
-// ReadFilteredTail reads the trailing matching events from path. A positive
-// limit returns at most that many events in chronological order; limit <= 0
-// falls back to ReadFiltered.
+// ReadFilteredTail reads the trailing matching events from path and canonical
+// sibling archives. A positive limit returns at most that many events in
+// chronological order; limit <= 0 falls back to ReadFiltered.
 func ReadFilteredTail(path string, filter Filter, limit int) ([]Event, error) {
 	if limit <= 0 {
 		return ReadFiltered(path, filter)
 	}
+	var result []Event
 	f, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("reading events tail: %w", err)
 		}
-		return nil, fmt.Errorf("reading events tail: %w", err)
-	}
-	defer f.Close() //nolint:errcheck // read-only file
+	} else {
+		defer f.Close() //nolint:errcheck // read-only file
 
-	info, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat events tail: %w", err)
+		info, err := f.Stat()
+		if err != nil {
+			return nil, fmt.Errorf("stat events tail: %w", err)
+		}
+		result, err = readFilteredTailFromFile(f, info.Size(), filter, limit)
+		if err != nil {
+			return nil, err
+		}
+		if len(result) >= limit {
+			return result, nil
+		}
 	}
-	return readFilteredTailFromFile(f, info.Size(), filter, limit)
+	archives, err := archiveFilesIn(filepath.Dir(path))
+	if err != nil {
+		return result, nil
+	}
+	for i := len(archives) - 1; i >= 0 && len(result) < limit; i-- {
+		remaining := limit - len(result)
+		archivePath := filepath.Join(filepath.Dir(path), archives[i].Basename)
+		tail, err := readFilteredTailFromArchive(archivePath, filter, remaining)
+		if err != nil {
+			return result, fmt.Errorf("reading archive %q tail: %w", archives[i].Basename, err)
+		}
+		if len(tail) == 0 {
+			continue
+		}
+		combined := make([]Event, 0, len(tail)+len(result))
+		combined = append(combined, tail...)
+		combined = append(combined, result...)
+		result = combined
+	}
+	return result, nil
+}
+
+func readFilteredTailFromArchive(path string, filter Filter, limit int) ([]Event, error) {
+	var tail []Event
+	err := streamArchive(path, filter, func(e Event) bool {
+		if !matchesFilter(e, filter) {
+			return true
+		}
+		tail = append(tail, e)
+		if len(tail) > limit {
+			copy(tail, tail[1:])
+			tail = tail[:limit]
+		}
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tail, nil
 }
 
 func readFilteredTailFromFile(f *os.File, size int64, filter Filter, limit int) ([]Event, error) {

--- a/internal/events/rotation_reader_test.go
+++ b/internal/events/rotation_reader_test.go
@@ -176,6 +176,85 @@ func TestReadFilteredTailFallsBackToNewestArchive(t *testing.T) {
 	}
 }
 
+func TestReadFilteredTailBoundsArchiveFallback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	rec.Record(Event{Type: SessionWoke, Actor: "human", Subject: "too-old"})
+	res, err := rec.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate matching archive: %v", err)
+	}
+	if res.Done != nil {
+		<-res.Done
+	}
+
+	for i := 0; i < 12; i++ {
+		rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: fmt.Sprintf("archive-%02d", i)})
+		res, err = rec.ForceRotate()
+		if err != nil {
+			t.Fatalf("ForceRotate %d: %v", i, err)
+		}
+		if res.Done != nil {
+			<-res.Done
+		}
+	}
+
+	got, err := ReadFilteredTail(path, Filter{Type: SessionWoke}, 1000)
+	if err != nil {
+		t.Fatalf("ReadFilteredTail: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ReadFilteredTail returned %d sparse matches, want 0", len(got))
+	}
+}
+
+func TestReadFilteredTailSkipsUnreadableArchive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "archive-match"})
+	res, err := rec.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate valid archive: %v", err)
+	}
+	if res.Done != nil {
+		<-res.Done
+	}
+
+	rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "bad-archive"})
+	res, err = rec.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate corrupt archive target: %v", err)
+	}
+	if res.Done != nil {
+		<-res.Done
+	}
+	if err := os.WriteFile(res.ArchivePath, []byte("not gzip"), 0o644); err != nil {
+		t.Fatalf("corrupt archive: %v", err)
+	}
+
+	got, err := ReadFilteredTail(path, Filter{Type: BeadCreated}, 1)
+	if err != nil {
+		t.Fatalf("ReadFilteredTail: %v", err)
+	}
+	if len(got) != 1 || got[0].Subject != "archive-match" {
+		t.Fatalf("ReadFilteredTail = %+v, want valid older archive match", got)
+	}
+}
+
 func TestReadLatestSeqSpansArchiveOnlyLog(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")

--- a/internal/events/rotation_reader_test.go
+++ b/internal/events/rotation_reader_test.go
@@ -134,6 +134,48 @@ func TestReadFilteredAcrossArchivesAppliesLimit(t *testing.T) {
 	}
 }
 
+func TestReadFilteredTailFallsBackToNewestArchive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "old-archive"})
+	res, err := rec.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate old archive: %v", err)
+	}
+	if res.Done != nil {
+		<-res.Done
+	}
+
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "newest-archive"})
+	res, err = rec.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate newest archive: %v", err)
+	}
+	if res.Done != nil {
+		<-res.Done
+	}
+
+	rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "active-nonmatch"})
+
+	got, err := ReadFilteredTail(path, Filter{Type: BeadCreated}, 1)
+	if err != nil {
+		t.Fatalf("ReadFilteredTail: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ReadFilteredTail returned %d events, want 1", len(got))
+	}
+	if got[0].Subject != "newest-archive" {
+		t.Fatalf("ReadFilteredTail subject = %q, want newest-archive", got[0].Subject)
+	}
+}
+
 func TestReadLatestSeqSpansArchiveOnlyLog(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")

--- a/internal/storehealth/storehealth.go
+++ b/internal/storehealth/storehealth.go
@@ -90,8 +90,10 @@ func WalkSize(path string) int64 {
 	return total
 }
 
-// LastMaintenance returns the timestamp and status ("success" or
-// "failed") of the most-recent store-maintenance event in provider.
+// LastMaintenance returns the timestamp and status ("success" or "failed") of
+// the latest-appended store-maintenance event in provider order. Event logs are
+// append-only, and this intentionally does not reinterpret out-of-order event
+// timestamps as recency.
 // Zero time and empty status when no events, provider is nil, or the
 // provider returns an error.
 func LastMaintenance(ep events.Provider) (time.Time, string) {
@@ -122,10 +124,9 @@ func LastMaintenance(ep events.Provider) (time.Time, string) {
 	if err != nil {
 		return latestTs, latestStatus
 	}
-	for _, e := range evts {
-		if e.Ts.After(latestTs) {
-			latestTs = e.Ts
-			latestStatus = statusForType[e.Type]
+	for i := len(evts) - 1; i >= 0; i-- {
+		if status, ok := statusForType[evts[i].Type]; ok {
+			return evts[i].Ts, status
 		}
 	}
 	return latestTs, latestStatus

--- a/internal/storehealth/storehealth.go
+++ b/internal/storehealth/storehealth.go
@@ -102,22 +102,30 @@ func LastMaintenance(ep events.Provider) (time.Time, string) {
 		latestTs     time.Time
 		latestStatus string
 	)
-	for _, spec := range []struct {
-		typ    string
-		status string
-	}{
-		{events.StoreMaintenanceDone, "success"},
-		{events.StoreMaintenanceFailed, "failed"},
-	} {
-		evts, err := ep.List(events.Filter{Type: spec.typ})
-		if err != nil {
-			continue
-		}
-		for _, e := range evts {
-			if e.Ts.After(latestTs) {
-				latestTs = e.Ts
-				latestStatus = spec.status
-			}
+	statusForType := map[string]string{
+		events.StoreMaintenanceDone:   "success",
+		events.StoreMaintenanceFailed: "failed",
+	}
+	filter := events.Filter{Types: []string{
+		events.StoreMaintenanceDone,
+		events.StoreMaintenanceFailed,
+	}}
+	var (
+		evts []events.Event
+		err  error
+	)
+	if tail, ok := ep.(events.TailProvider); ok {
+		evts, err = tail.ListTail(filter, 1)
+	} else {
+		evts, err = ep.List(filter)
+	}
+	if err != nil {
+		return latestTs, latestStatus
+	}
+	for _, e := range evts {
+		if e.Ts.After(latestTs) {
+			latestTs = e.Ts
+			latestStatus = statusForType[e.Type]
 		}
 	}
 	return latestTs, latestStatus

--- a/internal/storehealth/storehealth_test.go
+++ b/internal/storehealth/storehealth_test.go
@@ -192,6 +192,25 @@ func TestLastMaintenanceUsesTailProvider(t *testing.T) {
 	}
 }
 
+func TestLastMaintenanceUsesLatestAppendedEvent(t *testing.T) {
+	olderTs := time.Date(2026, 4, 8, 3, 0, 0, 0, time.UTC)
+	newerTs := time.Date(2026, 4, 9, 3, 0, 0, 0, time.UTC)
+	ep := &listOnlyMaintenanceProvider{
+		events: []events.Event{
+			{Type: events.StoreMaintenanceFailed, Ts: newerTs},
+			{Type: events.StoreMaintenanceDone, Ts: olderTs},
+		},
+	}
+
+	ts, status := LastMaintenance(ep)
+	if !ts.Equal(olderTs) {
+		t.Fatalf("ts = %v, want latest-appended timestamp %v", ts, olderTs)
+	}
+	if status != "success" {
+		t.Fatalf("status = %q, want success from latest-appended event", status)
+	}
+}
+
 func TestLastMaintenanceOnlyDoneEvents(t *testing.T) {
 	ep := events.NewFake()
 	t1 := time.Date(2026, 4, 1, 3, 0, 0, 0, time.UTC)
@@ -246,3 +265,21 @@ func (p *tailOnlyMaintenanceProvider) Watch(context.Context, uint64) (events.Wat
 }
 
 func (p *tailOnlyMaintenanceProvider) Close() error { return nil }
+
+type listOnlyMaintenanceProvider struct {
+	events []events.Event
+}
+
+func (p *listOnlyMaintenanceProvider) Record(events.Event) {}
+
+func (p *listOnlyMaintenanceProvider) List(filter events.Filter) ([]events.Event, error) {
+	return events.ApplyFilter(p.events, filter), nil
+}
+
+func (p *listOnlyMaintenanceProvider) LatestSeq() (uint64, error) { return 0, nil }
+
+func (p *listOnlyMaintenanceProvider) Watch(context.Context, uint64) (events.Watcher, error) {
+	return nil, errors.New("watch not implemented")
+}
+
+func (p *listOnlyMaintenanceProvider) Close() error { return nil }

--- a/internal/storehealth/storehealth_test.go
+++ b/internal/storehealth/storehealth_test.go
@@ -1,7 +1,9 @@
 package storehealth
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -165,6 +167,31 @@ func TestLastMaintenanceReturnsLatestAcrossTypes(t *testing.T) {
 	}
 }
 
+func TestLastMaintenanceUsesTailProvider(t *testing.T) {
+	older := time.Date(2026, 4, 1, 3, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 4, 8, 3, 0, 0, 0, time.UTC)
+	ep := &tailOnlyMaintenanceProvider{
+		events: []events.Event{
+			{Type: events.StoreMaintenanceDone, Ts: older},
+			{Type: events.StoreMaintenanceFailed, Ts: newer},
+		},
+	}
+
+	ts, status := LastMaintenance(ep)
+	if !ts.Equal(newer) {
+		t.Fatalf("ts = %v, want %v", ts, newer)
+	}
+	if status != "failed" {
+		t.Fatalf("status = %q, want failed", status)
+	}
+	if ep.listCalls != 0 {
+		t.Fatalf("LastMaintenance called full List %d times; want tail-only lookup", ep.listCalls)
+	}
+	if ep.tailCalls != 1 {
+		t.Fatalf("LastMaintenance called ListTail %d times, want 1", ep.tailCalls)
+	}
+}
+
 func TestLastMaintenanceOnlyDoneEvents(t *testing.T) {
 	ep := events.NewFake()
 	t1 := time.Date(2026, 4, 1, 3, 0, 0, 0, time.UTC)
@@ -189,3 +216,33 @@ func TestLastMaintenanceNoEvents(t *testing.T) {
 		t.Fatalf("LastMaintenance(empty) = (%v,%q), want (zero,\"\")", ts, status)
 	}
 }
+
+type tailOnlyMaintenanceProvider struct {
+	events    []events.Event
+	listCalls int
+	tailCalls int
+}
+
+func (p *tailOnlyMaintenanceProvider) Record(events.Event) {}
+
+func (p *tailOnlyMaintenanceProvider) List(events.Filter) ([]events.Event, error) {
+	p.listCalls++
+	return nil, errors.New("full list should not be used")
+}
+
+func (p *tailOnlyMaintenanceProvider) ListTail(filter events.Filter, limit int) ([]events.Event, error) {
+	p.tailCalls++
+	matches := events.ApplyFilter(p.events, filter)
+	if limit > 0 && len(matches) > limit {
+		matches = matches[len(matches)-limit:]
+	}
+	return matches, nil
+}
+
+func (p *tailOnlyMaintenanceProvider) LatestSeq() (uint64, error) { return 0, nil }
+
+func (p *tailOnlyMaintenanceProvider) Watch(context.Context, uint64) (events.Watcher, error) {
+	return nil, errors.New("watch not implemented")
+}
+
+func (p *tailOnlyMaintenanceProvider) Close() error { return nil }


### PR DESCRIPTION
## Summary

`gc hook`, `gc status`, and related control-plane commands were burning CPU on repeated full bundled-pack cache validation and unbounded event archive reads. On the affected city, the matching-stack staged fix reduced `gc hook developer` from 9.78s wall / 3.41s user to 2.56s wall / 1.40s user, and `gc status --json` from 47.27s wall / 32.22s user to 4.06s wall / 3.56s user.

## Root cause

Two hot paths were doing scale-sensitive work:

- `EnsureBuiltinRuntimeAssets` / legacy bundled import preflight used `builtinpacks.ValidateSyntheticRepo`, which walks and validates the full synthetic pack tree on warm runtime paths.
- `storehealth.LastMaintenance` queried `EventProvider.List` separately for done/failed maintenance events. The file-backed provider scans active events plus canonical archives, so status could decode event archives even though it only needs the newest maintenance result.

## Fix

- Use `ValidateSyntheticRepoFast` for warm runtime/bundled import usability checks. Full validation remains in install/repair/materialization paths.
- Add `events.Filter.Types` so callers can ask for a small set of event types in one pass.
- Teach `ReadFilteredTail` to fall back through canonical archives newest-to-oldest until the requested limit is satisfied.
- Make `storehealth.LastMaintenance` use `TailProvider.ListTail` with a single done/failed type-set filter when available, with a compatible fallback for non-tail providers.

No bead/event/cache state is deleted or repurposed by this change.

## Tests

- TDD proof on the pre-fix branch: the warm preflight tests failed before the code change because warm runtime preflight performed full synthetic validation and repaired content drift.
- `go test ./internal/events ./internal/storehealth ./internal/api ./cmd/gc -run 'TestMatchesFilter_Types|TestReadFilteredTailFallsBackToNewestArchive|TestLastMaintenanceUsesTailProvider|TestLastMaintenanceReturnsLatestAcrossTypes|TestLastMaintenanceOnlyDoneEvents|TestSupervisorEventListFilterIsEmptyMatchesEventsFilterZeroValue|TestEnsureBuiltinRuntimeAssetsWarmPath|TestEnsureBuiltinRuntimeAssetsRehydratesEvictedOptionalLockedBundledCache|TestEnsureBuiltinRuntimeAssetsHydratesCacheAndShim' -count=1`
- `go test ./internal/events ./internal/storehealth ./internal/api -count=1`
- `go test ./cmd/gc -count=1` (509.262s)
- `go vet ./internal/events ./internal/storehealth ./internal/api ./cmd/gc`
- `git diff --check HEAD~1..HEAD`

## Validation

Built a staged binary without replacing live `gc`:

- matching live DoltLite-stack branch: `/tmp/gc-ga-th5y`
- current-main PR branch: `/tmp/gc-ga-th5y-main`

Real-data validation on the matching live stack:

- `gc hook developer`: 9.78s wall / 3.41s user before, 2.56s wall / 1.40s user after.
- `gc status --json`: 47.27s wall / 32.22s user before, 4.06s wall / 3.56s user after.
- `strace -e openat` for hook cache opens: 46,955 before, 1,637 after.
- Final status sample: 2,099 cache opens and 4 event archive opens.

The clean current-main staged binary builds, but this local dev city cannot fully dogfood it because the city config imports the DoltLite pack from the old migration stack (`examples/beads-doltlite`), which is not present on current upstream `main`. Running the current-main staged binary exits during import cache hydration with that unrelated missing pack path rather than exercising the control-plane hot paths.