### PR TITLE
fix(init): seed gascity role pack so Mayor can launch built-in formulas (#3832) — v1.3.3 cherry-picks

### DIFF
--- a/cmd/gc/cmd_init_gascity_test.go
+++ b/cmd/gc/cmd_init_gascity_test.go
@@ -131,6 +131,44 @@ func TestDoInitWithGascityTemplate(t *testing.T) {
 	}
 }
 
+// TestDoInitGascityTemplateSeedsRolesDefaultRigImport pins gascity#3832: a
+// fresh gascity city must seed the gc-roles pack as a default rig import (bound
+// "gc") so rigs added to the city receive the role agents the built-in formulas
+// route to (gc.run-operator, ...). doInit writes default rig imports into
+// city.toml under [defaults.rig.imports]. Without this a freshly initialized
+// city failed `build-from-requirements` with `agent "gc.run-operator" not found
+// in city.toml`.
+func TestDoInitGascityTemplateSeedsRolesDefaultRigImport(t *testing.T) {
+	f := fsys.NewFake()
+
+	wiz := defaultWizardConfig()
+	wiz.configName = "gascity"
+	wiz.provider = "claude"
+	wiz.providers = []string{"claude"}
+
+	var stdout, stderr bytes.Buffer
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr, false)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	cityData := f.Files[filepath.Join("/bright-lights", "city.toml")]
+	cityCfg, err := config.Parse(cityData)
+	if err != nil {
+		t.Fatalf("parsing city.toml: %v", err)
+	}
+	roles, ok := cityCfg.Defaults.Rig.Imports["gc"]
+	if !ok {
+		t.Fatalf("city.toml [defaults.rig.imports] = %v, want gc roles entry:\n%s", cityCfg.Defaults.Rig.Imports, cityData)
+	}
+	if roles.Source != config.PublicGascityRolesPackSource {
+		t.Errorf("roles default rig import source = %q, want %q", roles.Source, config.PublicGascityRolesPackSource)
+	}
+	if roles.Version != config.PublicGascityPackVersion {
+		t.Errorf("roles default rig import version = %q, want %q", roles.Version, config.PublicGascityPackVersion)
+	}
+}
+
 // TestInitTemplateHelpAndErrorAdvertiseAcceptedTemplates keeps the public
 // --template flag help and the unknown-template error synchronized with the
 // set normalizeInitTemplate accepts. gascity regressed here once: the parser

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -2777,11 +2777,20 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	// city.toml keeps only the runtime-local [workspace]; builtin packs
-	// compose via pinned [imports] in pack.toml. workspace.name lives in
-	// .gc/site.toml.
+	// city.toml keeps the runtime-local [workspace] plus the canonical
+	// default-rig imports: the gascity template seeds the gc-roles pack (bound
+	// "gc") so rigs added to the city inherit the role agents the built-in
+	// formulas route to (gascity#3832). Builtin packs compose via pinned
+	// [imports] in pack.toml; workspace.name lives in .gc/site.toml.
 	got := string(f.Files[filepath.Join("/bright-lights", "city.toml")])
 	want := `[workspace]
+
+[defaults]
+[defaults.rig]
+[defaults.rig.imports]
+[defaults.rig.imports.gc]
+source = "` + config.PublicGascityRolesPackSource + `"
+version = "` + config.PublicGascityPackVersion + `"
 
 # [mail]
 # retention_ttl controls how long read messages are retained before purge.

--- a/cmd/gc/suggest.go
+++ b/cmd/gc/suggest.go
@@ -70,15 +70,87 @@ func formatAvailable(label string, names []string) string {
 	return fmt.Sprintf("; available %s: %s%s", label, strings.Join(show, ", "), suffix)
 }
 
-// agentNotFoundMsg returns a user-friendly error string for when an agent
-// name is not found. Includes "did you mean?" and available agents list.
-func agentNotFoundMsg(prefix, input string, cfg *config.City) string {
-	names := availableAgentNames(cfg)
-	hint := suggestSimilar(input, names)
-	if hint != "" {
-		return fmt.Sprintf("%s: agent %q not found in city.toml%s", prefix, input, hint)
+// importBindingOf extracts the pack-import binding from a (possibly
+// rig-qualified) agent target. "rig/gc.run-operator" and "gc.run-operator"
+// both yield "gc"; a bare name ("mayor") or pool instance ("rig/polecat-2")
+// yields "" because it carries no binding.
+func importBindingOf(input string) string {
+	name := input
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
 	}
-	return fmt.Sprintf("%s: agent %q not found in city.toml%s", prefix, input, formatAvailable("agents", names))
+	if i := strings.Index(name, "."); i > 0 {
+		return name[:i]
+	}
+	return ""
+}
+
+// declaredImportSource returns the authored source for a pack-import binding
+// declared anywhere in the city config — city-scope [imports.*], the
+// [defaults.rig.imports.*] table, or any rig's [rigs.imports.*] — and whether
+// the binding was found. It reads only what the city itself declares, so no
+// pack or role name is hard-coded.
+func declaredImportSource(cfg *config.City, binding string) (string, bool) {
+	if cfg == nil || binding == "" {
+		return "", false
+	}
+	if imp, ok := cfg.Imports[binding]; ok {
+		return imp.Source, true
+	}
+	if imp, ok := cfg.Defaults.Rig.Imports[binding]; ok {
+		return imp.Source, true
+	}
+	if imp, ok := cfg.DefaultRigImports[binding]; ok {
+		return imp.Source, true
+	}
+	for _, r := range cfg.Rigs {
+		if imp, ok := r.Imports[binding]; ok {
+			return imp.Source, true
+		}
+	}
+	return "", false
+}
+
+// uninstalledImportHint returns a remediation hint when a not-found target is
+// qualified by a pack-import binding that the city declares but whose agents
+// are not installed here — the case behind gascity#3832, where a fresh city
+// imports the formulas pack but the roles those formulas route to live in a
+// declared-but-not-yet-installed pack. The fix is to install the declared pack,
+// not to pick a different agent name, so we point at `gc import install`.
+// Returns "" when the binding is unknown (caller falls back to the
+// available-agents list) or when an agent with that binding is already
+// composed (then the miss is a wrong/typo'd name, not a missing pack).
+func uninstalledImportHint(input string, cfg *config.City) string {
+	binding := importBindingOf(input)
+	if binding == "" || cfg == nil {
+		return ""
+	}
+	src, ok := declaredImportSource(cfg, binding)
+	if !ok {
+		return ""
+	}
+	for _, a := range cfg.Agents {
+		if importBindingOf(a.QualifiedName()) == binding {
+			return "" // pack is installed; the agent name itself is wrong
+		}
+	}
+	return fmt.Sprintf("\n  the %q pack is imported (%s) but its agents are not installed here; run `gc import install`", binding, src)
+}
+
+// agentNotFoundMsg returns a user-friendly error string for when an agent
+// name is not found. When the target names a declared-but-uninstalled pack
+// import it surfaces the `gc import install` repair; otherwise it falls back to
+// a "did you mean?" hint and the available-agents list.
+func agentNotFoundMsg(prefix, input string, cfg *config.City) string {
+	base := fmt.Sprintf("%s: agent %q not found in city.toml", prefix, input)
+	if hint := uninstalledImportHint(input, cfg); hint != "" {
+		return base + hint
+	}
+	names := availableAgentNames(cfg)
+	if hint := suggestSimilar(input, names); hint != "" {
+		return base + hint
+	}
+	return base + formatAvailable("agents", names)
 }
 
 // rigNotFoundMsg returns a user-friendly error string for when a rig

--- a/cmd/gc/suggest_test.go
+++ b/cmd/gc/suggest_test.go
@@ -123,6 +123,70 @@ func TestAgentNotFoundMsg(t *testing.T) {
 	}
 }
 
+func TestImportBindingOf(t *testing.T) {
+	cases := map[string]string{
+		"gc.run-operator":          "gc",
+		"todo-app/gc.run-operator": "gc",
+		"mayor":                    "",
+		"hw/polecat-2":             "",
+		"":                         "",
+		".leading-dot":             "",
+	}
+	for in, want := range cases {
+		if got := importBindingOf(in); got != want {
+			t.Errorf("importBindingOf(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestAgentNotFoundMsgUninstalledImportHint covers gascity#3832: when a
+// not-found target names a declared-but-uninstalled pack import, the message
+// must point at `gc import install` rather than just a "did you mean?" list.
+func TestAgentNotFoundMsgUninstalledImportHint(t *testing.T) {
+	const rolesSrc = "https://github.com/gastownhall/gascity-packs/tree/main/gascity/roles"
+
+	// Declared (as a default rig import) but no agent with that binding is
+	// composed → install hint with the declared source.
+	declared := &config.City{
+		Agents:            []config.Agent{{Name: "mayor"}},
+		DefaultRigImports: map[string]config.Import{"gc": {Source: rolesSrc}},
+	}
+	msg := agentNotFoundMsg("gc sling", "gc.run-operator", declared)
+	if !strings.Contains(msg, "gc import install") {
+		t.Errorf("declared-but-uninstalled should advise install: %q", msg)
+	}
+	if !strings.Contains(msg, rolesSrc) {
+		t.Errorf("install hint should include the declared source: %q", msg)
+	}
+	if strings.Contains(msg, "did you mean") {
+		t.Errorf("install hint should replace the did-you-mean noise: %q", msg)
+	}
+
+	// Same miss, but resolved via a rig-qualified target → still hint.
+	if msg := agentNotFoundMsg("gc sling", "todo-app/gc.run-operator", declared); !strings.Contains(msg, "gc import install") {
+		t.Errorf("rig-qualified miss should advise install: %q", msg)
+	}
+
+	// Declared AND installed (an agent carries the binding) → the miss is a
+	// typo, not a missing pack, so do NOT advise install.
+	installed := &config.City{
+		Agents: []config.Agent{
+			{Name: "mayor"},
+			{Name: "gc.run-operator", Dir: "todo-app"},
+		},
+		Imports: map[string]config.Import{"gc": {Source: rolesSrc}},
+	}
+	if msg := agentNotFoundMsg("gc sling", "todo-app/gc.run-oprator", installed); strings.Contains(msg, "gc import install") {
+		t.Errorf("installed pack + typo'd name should not advise install: %q", msg)
+	}
+
+	// Unknown binding → fall back to the available-agents list (no install hint).
+	unknown := &config.City{Agents: []config.Agent{{Name: "mayor"}}}
+	if msg := agentNotFoundMsg("gc sling", "gc.run-operator", unknown); strings.Contains(msg, "gc import install") {
+		t.Errorf("unknown binding should not advise install: %q", msg)
+	}
+}
+
 func TestRigNotFoundMsg(t *testing.T) {
 	cfg := &config.City{
 		Rigs: []config.Rig{

--- a/cmd/gc/testdata/pack-commands-doctor.txtar
+++ b/cmd/gc/testdata/pack-commands-doctor.txtar
@@ -13,7 +13,12 @@ env GC_DOLT=skip
 env GC_SESSION=fake
 
 # Initialize a real city scaffold, then swap in the pack-import config.
-exec gc init $WORK/city
+# Use the minimal template: the default gascity template seeds the gc-roles
+# pack as a default-rig import (gascity#3832), and swapping in the ops-only
+# city.toml below would orphan that pack's packs.lock entry, tripping the
+# packv2-import-state doctor check. The minimal scaffold imports only the
+# bundled core pack, which the swap leaves declared and reachable.
+exec gc init --template minimal --default-provider claude $WORK/city
 cp $WORK/city.toml.custom $WORK/city/city.toml
 cp $WORK/site.toml.custom $WORK/city/.gc/site.toml
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4758,9 +4758,13 @@ func GastownCity(name, provider, startCommand string) City {
 
 // GascityCityWithProviders returns a minimal managed city that imports the
 // public gascity planning/implementation skills pack: a single mayor agent
-// plus [imports.gascity] pinned to the registry release. The pack ships
-// skills and formulas only (no agents), so the city shape matches the
-// minimal template with the pack layered on top.
+// plus [imports.gascity] (skills and formulas) pinned to the registry release.
+// The gascity formulas route their steps to role agents (gc.run-operator,
+// gc.requirements-planner, ...) that ship in the separate gc-roles subpack, so
+// the template also seeds that pack as a default rig import bound "gc" — every
+// rig added to the city then inherits the providerless, rig-scoped roles the
+// formulas coordinate. Without it a fresh city can discover a formula but fails
+// to launch with `agent "gc.run-operator" not found in city.toml` (gascity#3832).
 func GascityCityWithProviders(name, defaultProvider string, providers []string) City {
 	city := WizardCityWithProviders(name, defaultProvider, providers)
 	city.Imports = map[string]Import{
@@ -4769,6 +4773,13 @@ func GascityCityWithProviders(name, defaultProvider string, providers []string) 
 			Version: PublicGascityPackVersion,
 		},
 	}
+	city.DefaultRigImports = map[string]Import{
+		"gc": {
+			Source:  PublicGascityRolesPackSource,
+			Version: PublicGascityPackVersion,
+		},
+	}
+	city.DefaultRigImportOrder = []string{"gc"}
 	return city
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1197,6 +1197,37 @@ func TestGastownCity(t *testing.T) {
 	}
 }
 
+// TestGascityCitySeedsRolesDefaultRigImport pins gascity#3832: the gascity
+// template imports the formulas pack at city scope AND seeds the gc-roles pack
+// as a default rig import bound "gc", so every rig added to the city receives
+// the providerless role agents (gc.run-operator, gc.requirements-planner, ...)
+// that the built-in formulas route to. Without this, a fresh city could launch
+// a formula but failed with `agent "gc.run-operator" not found in city.toml`.
+func TestGascityCitySeedsRolesDefaultRigImport(t *testing.T) {
+	c := GascityCityWithProviders("bright-lights", "claude", []string{"claude"})
+
+	// City-scope formulas/skills import is unchanged.
+	if len(c.Imports) != 1 || c.Imports["gascity"].Source != PublicGascityPackSource || c.Imports["gascity"].Version != PublicGascityPackVersion {
+		t.Errorf("Imports = %v, want gascity=%s %s", c.Imports, PublicGascityPackSource, PublicGascityPackVersion)
+	}
+
+	// Roles ride along as a default rig import, bound "gc" so the formula's
+	// gc.* targets resolve, pinned to the same commit as the formulas pack.
+	roles, ok := c.DefaultRigImports["gc"]
+	if !ok || len(c.DefaultRigImports) != 1 {
+		t.Fatalf("DefaultRigImports = %v, want single gc entry", c.DefaultRigImports)
+	}
+	if roles.Source != PublicGascityRolesPackSource {
+		t.Errorf("roles import source = %q, want %q", roles.Source, PublicGascityRolesPackSource)
+	}
+	if roles.Version != PublicGascityPackVersion {
+		t.Errorf("roles import version = %q, want %q (same commit as the formulas pack)", roles.Version, PublicGascityPackVersion)
+	}
+	if len(c.DefaultRigImportOrder) != 1 || c.DefaultRigImportOrder[0] != "gc" {
+		t.Errorf("DefaultRigImportOrder = %v, want [gc]", c.DefaultRigImportOrder)
+	}
+}
+
 func TestGastownCityStartCommand(t *testing.T) {
 	c := GastownCity("test", "", "my-agent --auto")
 	if c.Workspace.StartCommand != "my-agent --auto" {

--- a/internal/config/public_packs.go
+++ b/internal/config/public_packs.go
@@ -19,6 +19,15 @@ const (
 	// (gascity 0.1.6).
 	PublicGascityPackVersion = "sha:3b3b89f2011e06d84459aa7bea1552382f13930a"
 
+	// PublicGascityRolesPackSource is the concrete durable source for the
+	// gascity role-agents subpack (gc-roles): the providerless, rig-scoped
+	// agents (run-operator, requirements-planner, design-author, ...) that the
+	// gascity formulas route to. It lives in the same repo as
+	// PublicGascityPackSource and is pinned to the same release commit
+	// (PublicGascityPackVersion), so a fresh gascity city's formulas and the
+	// rig roles they coordinate always come from one matching release.
+	PublicGascityRolesPackSource = "https://github.com/gastownhall/gascity-packs/tree/main/gascity/roles"
+
 	// BundledPackImportVersion pins the [imports.core]/[imports.bd] entries
 	// gc init writes for the gascity.git packs bundled with the binary.
 	// This is the CANONICAL pin: the only commit the binary pre-seeds into

--- a/internal/doctor/checks_rig_coverage.go
+++ b/internal/doctor/checks_rig_coverage.go
@@ -112,7 +112,7 @@ func (c *RigPackCoverageCheck) Run(_ *CheckContext) *CheckResult {
 	r.Status = StatusWarning
 	r.Message = fmt.Sprintf("%d rig-scoped named_session(s) not covered by rig imports", len(issues))
 	r.Details = issues
-	r.FixHint = "add [defaults.rig.imports.<pack>] to pack.toml or add the pack to each rig's [imports]"
+	r.FixHint = "add [defaults.rig.imports.<pack>] to city.toml or add the pack to each rig's [imports]"
 	return r
 }
 

--- a/internal/doctor/checks_rig_coverage_test.go
+++ b/internal/doctor/checks_rig_coverage_test.go
@@ -271,6 +271,9 @@ mode = "always"
 	if !strings.Contains(r.FixHint, "defaults.rig.imports") {
 		t.Errorf("FixHint = %q, want it to mention [defaults.rig.imports] to guide the operator to the actual config knob", r.FixHint)
 	}
+	if strings.Contains(r.FixHint, "pack.toml") {
+		t.Errorf("FixHint = %q, want default rig imports to point at city.toml", r.FixHint)
+	}
 }
 
 // TestRigPackCoverageCheck_PackWithoutRigSessions asserts that a pack


### PR DESCRIPTION
## Summary

Cherry-picks the #3832 fix chain from `main` onto `release/v1.3.0` for the **v1.3.3 hotfix**. csells hit this on the release: a fresh `gc init` gascity city couldn't run a built-in formula through the Mayor — `gc sling: agent "gc.run-operator" not found in city.toml` — because the gascity template imported only the city-scope formulas pack and never seeded the `gascity/roles` subpack that the formulas' `gc.*` coordinator targets live in.

## Cherry-picks (byte-identical to the reviewed main commits, `-x` provenance trailers)

| Release commit | From main | Original PR |
| --- | --- | --- |
| c5277df7d | 17b016372 | #3841 — seed `gc-roles` as a default rig import at init (pinned to the same gascity-packs commit as the formulas pack via `PublicGascityRolesPackSource`) + actionable `gc import install` remediation when a missing agent target names a declared-but-uninstalled import |
| f764dbe9f | 9e9990665 | #3851 — rig-pack-coverage doctor FixHint points at `city.toml`, not `pack.toml` |

Both picks applied without conflicts. `internal/config/public_packs.go` auto-merged cleanly — the release branch pins the same `PublicGascityPackVersion` (`sha:3b3b89f2…`) as main, so the roles subpack pin stays consistent, and the superseded-version list has no duplicate entries.

## Verification on this branch

- `go build ./...` clean, `go vet ./...` clean
- Targeted tests green: `TestDoInitGascityTemplateSeedsRolesDefaultRigImport`, `TestGascityCitySeedsRolesDefaultRigImport`, `TestImportBindingOf`, `TestAgentNotFoundMsgUninstalledImportHint`, `TestDoInitWithGascityTemplate`, `TestDoInitDefaultTemplateImportsGascityPack`, `TestDoRigAdd_RootPackDefaultRigImports`, plus full `./internal/config` and `./internal/doctor` packages
- Fast suite green twice (`make test`, and the pre-push hook's sharded `test-local-parallel fast` — "All fast jobs passed")
- Live E2E smoke with the branch binary: `gc init --template gascity --providers claude,codex` writes `[defaults.rig.imports.gc] source = …/gascity/roles, version = sha:3b3b89f2…`, and `gc rig add` of an **out-of-tree** rig inherits the roles import into its `[[rigs]]` entry (throwaway city stopped and unregistered afterwards)

## Release plan

After merge: cut `v1.3.3-rc1` from `release/v1.3.0` via `rc-release.yml` (tag push or workflow_dispatch), RC-test, then `chore: release v1.3.3` CHANGELOG bump + final tag, matching the v1.3.2 flow (#3647/#3652).

Fixes the release-line occurrence of #3832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)