### PR TITLE
fix(gc): preserve session release route

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -2402,6 +2402,7 @@ func releaseWorkFromClosedSessionBead(store beads.Store, sessionBead beads.Bead,
 		addAssignee(id)
 	}
 
+	fallbackRoute := retiredSessionFallbackRoute(sessionBead)
 	seenWork := make(map[string]struct{})
 	wa := workAssignmentForStore(beads.WorkStore{Store: store})
 	for assignee := range seenAssignees {
@@ -2423,10 +2424,11 @@ func releaseWorkFromClosedSessionBead(store beads.Store, sessionBead beads.Bead,
 				// fully detached (not preserved to a new assignee). The
 				// release primitive clears the assignee (empty-string) and
 				// stale session-affinity metadata and resets in_progress to
-				// open — the same stale-affinity bug fixed on the retry,
-				// reopen, and orphan-pool release paths. No run_target
-				// fallback on the close-release path (passed "").
-				if err := wa.ReleaseWorkBead(item, ""); err != nil {
+				// open. When the work has no route, preserve the session's
+				// configured route as gc.run_target so route recovery can
+				// restore gc.routed_to and the work re-enters demand instead
+				// of going open/unassigned/invisible.
+				if err := wa.ReleaseWorkBead(item, fallbackRoute); err != nil {
 					fmt.Fprintf(stderr, "session beads: releasing work %s from closing session %s: %v\n", item.ID, sessionBead.ID, err) //nolint:errcheck
 				}
 			}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -4573,6 +4573,72 @@ func TestCloseBeadReleasesWorkAssignedByNamedIdentity(t *testing.T) {
 	}
 }
 
+func TestCloseBeadReleasesDirectWorkWithRecoverableRoute(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Date(2026, 7, 2, 18, 2, 31, 0, time.UTC)
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "developer",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "developer-ga-wisp-dead",
+			"template":     "developer",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:    "direct named-session work",
+		Type:     "task",
+		Assignee: "developer-ga-wisp-dead",
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: strPtr("in_progress")}); err != nil {
+		t.Fatalf("set work in_progress: %v", err)
+	}
+
+	if !closeBead(store, sessionBead.ID, "dead-runtime", now, ioDiscard{}) {
+		t.Fatal("closeBead returned false, want true")
+	}
+
+	gotWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if gotWork.Assignee != "" {
+		t.Fatalf("work assignee = %q, want empty", gotWork.Assignee)
+	}
+	if gotWork.Status != "open" {
+		t.Fatalf("work status = %q, want open", gotWork.Status)
+	}
+	if gotWork.Metadata["gc.run_target"] != "developer" {
+		t.Fatalf("gc.run_target = %q, want developer", gotWork.Metadata["gc.run_target"])
+	}
+	if gotWork.Metadata["gc.routed_to"] != "" {
+		t.Fatalf("gc.routed_to = %q, want empty until route recovery runs", gotWork.Metadata["gc.routed_to"])
+	}
+
+	restored, err := restoreCarriedWorkRoutes(store)
+	if err != nil {
+		t.Fatalf("restoreCarriedWorkRoutes: %v", err)
+	}
+	if restored != 1 {
+		t.Fatalf("restored routes = %d, want 1", restored)
+	}
+	gotWork, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead after route recovery: %v", err)
+	}
+	if gotWork.Metadata["gc.routed_to"] != "developer" {
+		t.Fatalf("gc.routed_to = %q, want developer after route recovery", gotWork.Metadata["gc.routed_to"])
+	}
+}
+
 func TestCloseBeadLeavesUnrelatedWorkAlone(t *testing.T) {
 	store := beads.NewMemStore()
 	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary
- Preserve a retired session's configured route as `gc.run_target` when session finalization releases work assigned directly to the dead session.
- Add a regression covering the ga-q3x4 failure mode: session close releases the bead, then route recovery restores `gc.routed_to` so the work re-enters demand instead of sitting open/unassigned/invisible.

## Evidence
- `go test ./cmd/gc -run TestCloseBeadReleasesDirectWorkWithRecoverableRoute -count=1`
- `go test ./cmd/gc -run 'TestCloseBeadReleases|TestCleanupDeadRuntimeSessionCorpsesReleases|TestUnclaimWorkAssignedToRetiredSessionBead|TestWorkAssignmentReleaseWorkBead|TestRestoreCarriedWorkRoutes' -count=1`
- `go vet ./cmd/gc`
- `git diff --check -- cmd/gc/session_beads.go cmd/gc/session_beads_test.go`

## Notes
- A full `go test ./cmd/gc -count=1` run hit the package's 10m timeout in the broad suite after the targeted session-release tests had passed.
- The pre-commit hook was configured and attempted, but `golangci-lint run --new-from-rev=HEAD --whole-files --fix ./cmd/gc` stayed active for over 10 minutes at high memory and was interrupted. `golangci-lint fmt --stdin` on the touched files passed, and `go vet ./cmd/gc` passed.