### PR TITLE
fix(runtime): tolerate a missing session bead during drain-ack

### DIFF
--- a/cmd/gc/cmd_hook_claim_runid_test.go
+++ b/cmd/gc/cmd_hook_claim_runid_test.go
@@ -178,6 +178,54 @@ func TestDoHookClaimRecordsRunIDOnExistingAssignment(t *testing.T) {
 	}
 }
 
+// TestDoHookClaimExistingAssignmentMissingSessionBeadStillReturnsWork pins the
+// observed gcw-2y6 symptom at the claim seam: when the live worker still owns an
+// in-progress bead but its GC_SESSION_ID bead is already gone, the best-effort
+// session-pointer write logs the missing-bead error and hook claim STILL returns
+// the same existing assignment. That behavior means the repeated work result is
+// not itself evidence that claim-time stamping is wedging the worker.
+func TestDoHookClaimExistingAssignmentMissingSessionBeadStillReturnsWork(t *testing.T) {
+	spy := &recordRunIDSpy{err: errors.New(`updating bead "sess-1": bead not found`)}
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) {
+			return `[{"id":"hw-existing","status":"in_progress","assignee":"worker-1","metadata":{"gc.routed_to":"worker","gc.root_bead_id":"root-R2"}}]`, nil
+		},
+		Claim: func(context.Context, string, []string, string, string) (beads.Bead, bool, error) {
+			t.Error("Claim must not be called on the existing-assignment path")
+			return beads.Bead{}, false, nil
+		},
+		ResolveWorkBranch:     func(string) string { return "" },
+		RecordSessionPointers: spy.fn,
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		Env:                []string{"GC_SESSION_ID=sess-1"},
+		JSON:               true,
+	}
+
+	for i := 0; i < 2; i++ {
+		var stdout, stderr bytes.Buffer
+		if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+			t.Fatalf("attempt %d: doHookClaim = %d, want 0; stderr=%s", i+1, code, stderr.String())
+		}
+		var result hookClaimJSONResult
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("attempt %d: stdout is not JSON: %v\nraw: %s", i+1, err, stdout.String())
+		}
+		if result.Action != "work" || result.Reason != "existing_assignment" || result.BeadID != "hw-existing" {
+			t.Fatalf("attempt %d: result = %+v, want existing-assignment for hw-existing", i+1, result)
+		}
+		if !strings.Contains(stderr.String(), `recording session pointers on session bead sess-1: updating bead "sess-1": bead not found`) {
+			t.Fatalf("attempt %d: stderr = %q, want missing session bead warning", i+1, stderr.String())
+		}
+	}
+	if spy.calls != 2 {
+		t.Fatalf("record calls = %d, want 2 (one per claim attempt)", spy.calls)
+	}
+}
+
 // TestDoHookClaimRecordsActiveWorkBeadAsStepID: the active-work-bead pointer is the
 // work bead's BARE gc.step_id, NOT its namespaced bead id — the cross-plane join key
 // the events plane also uses. The fixture makes them differ (bead id

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -94,7 +95,7 @@ func (o *providerDrainOps) drainStartTime(sessionName string) (time.Time, error)
 }
 
 func (o *providerDrainOps) setDrainAck(sessionName string) error {
-	return errors.Join(
+	return joinDrainAckMutationErrors(
 		o.sp.RemoveMeta(sessionName, reconcilerDrainAckReasonKey),
 		o.sp.RemoveMeta(sessionName, reconcilerDrainAckGenerationKey),
 		o.sp.SetMeta(sessionName, reconcilerDrainAckSourceKey, drainAckSourceAgentValue),
@@ -147,6 +148,21 @@ func (o *providerDrainOps) isDriftRestart(sessionName string) (bool, error) {
 
 func (o *providerDrainOps) clearDriftRestart(sessionName string) error {
 	return o.sp.RemoveMeta(sessionName, "GC_DRIFT_RESTART")
+}
+
+func joinDrainAckMutationErrors(errs ...error) error {
+	var joined []error
+	for _, err := range errs {
+		if err == nil || drainAckMissingSessionBeadError(err) {
+			continue
+		}
+		joined = append(joined, err)
+	}
+	return errors.Join(joined...)
+}
+
+func drainAckMissingSessionBeadError(err error) bool {
+	return runtime.IsSessionGone(err) || errors.Is(err, beads.ErrNotFound)
 }
 
 // newDrainOps creates a drainOps from a runtime.Provider.

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -474,6 +474,16 @@ func TestDoRuntimeDrainAckError(t *testing.T) {
 	}
 }
 
+func TestJoinDrainAckMutationErrorsMissingSessionBeadIsIdempotent(t *testing.T) {
+	err := joinDrainAckMutationErrors(
+		fmt.Errorf("setting metadata on %q: %w", "gc-missing", beads.ErrNotFound),
+		fmt.Errorf("removing metadata on %q: %w", "gc-missing", beads.ErrNotFound),
+	)
+	if err != nil {
+		t.Fatalf("joinDrainAckMutationErrors(...) = %v, want nil for missing session bead", err)
+	}
+}
+
 func TestDoRuntimeDrainAckJSON(t *testing.T) {
 	old := drainAckPokeController
 	drainAckPokeController = func(string) error { return nil }


### PR DESCRIPTION
## Summary

Make drain-ack idempotent when the session bead has already been deleted. `setDrainAck` currently `errors.Join`s its mutations and surfaces a hard error if the bead is gone; this swallows the "already gone" case (`runtime.IsSessionGone` / `beads.ErrNotFound`) while still propagating real failures. Plus a small regression test pinning the sibling hook-claim path's best-effort behavior when the session-pointer write hits a missing bead.

## Motivation

When a session is torn down concurrently with its own drain acknowledgement, the metadata mutations in `setDrainAck` can hit a bead that no longer exists. Today that returns `ErrNotFound` and drain-ack reports failure for what is actually a benign, expected race — the bead we'd have marked is already gone.

This continues the drain-path robustness line upstream has been working (#2470/#2440 async stop signalling + panic recovery; #3299 defer drain-ack stops during partial store queries). It's **orthogonal** to #3855/#2520 (that's the no-work drain-ack *pool over-count* — a supply-counting seam, not a mutation erroring on a vanished bead).

Anecdotally, in a 24h sample of one running city we saw ~10 `session.drain_acked_with_assigned_work` events — the drain-ack path runs routinely under normal churn, which is what surfaced the missing-bead case.

## What changed

- `cmd/gc/cmd_runtime_drain.go`: new `joinDrainAckMutationErrors` that drops `IsSessionGone`/`ErrNotFound` and joins the rest.
- `cmd/gc/cmd_runtime_drain_test.go`: coverage for the missing-bead case.
- `cmd/gc/cmd_hook_claim_runid_test.go`: pins that a missing bead on the session-pointer write logs and still returns the existing assignment.

## Testing

- `go build ./...`, `go vet ./cmd/gc/`.
- `go test ./cmd/gc/ -run 'Drain|HookClaim'` passes locally.
- Full suite via CI.

## Open questions / happy to adjust

- Is swallowing `ErrNotFound` here the behavior you want, or would you prefer a typed "already drained/gone" sentinel callers can branch on?
- The pinning test locks behavior you already guarantee — keep it as regression coverage, or drop it as redundant? Either is fine.

## References

#2470, #2440, #3299, #3855, #2520.
