### PR TITLE
feat(dispatch): fail fast when a min=0 pool order finds no route-visible ready work

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1431,6 +1431,22 @@ func poolOrderRouteVisibilityWarning(a orders.Order, recipe *formula.Recipe) str
 	return fmt.Sprintf("warning: pool order %q uses formula %q whose root is a molecule container, not Ready-visible work; scale-from-zero pools will not wake for this wisp. Convert the formula to phase=\"vapor\"/root-only or formulas v2 before routing it to a pool.", a.ScopedName(), a.Formula)
 }
 
+func poolOrderRouteVisibilityFailFast(a orders.Order, recipe *formula.Recipe, cfg *config.City) bool {
+	if poolOrderRouteVisibilityWarning(a, recipe) == "" || cfg == nil {
+		return false
+	}
+	qualified, err := qualifyOrderPool(a, cfg)
+	if err != nil {
+		return false
+	}
+	for i := range cfg.Agents {
+		if cfg.Agents[i].QualifiedName() == qualified {
+			return cfg.Agents[i].EffectiveMinActiveSessions() == 0
+		}
+	}
+	return false
+}
+
 // applyOrderRecipeRouting decorates an order recipe before it is instantiated.
 // The resolved store target is authoritative: order pool/step targets describe
 // execution, while target.ScopeRoot describes the store that will own every
@@ -1561,6 +1577,17 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		return
 	}
 	if warning := poolOrderRouteVisibilityWarning(a, recipe); warning != "" {
+		if poolOrderRouteVisibilityFailFast(a, recipe, m.cfg) {
+			logDispatchError(m.stderr, "gc: order %s: %s", scoped, warning)
+			m.rec.Record(events.Event{
+				Type:    events.OrderFailed,
+				Actor:   "controller",
+				Subject: scoped,
+				Message: warning,
+			})
+			m.markTrackingFailure(store, trackingID, scoped, a, headSeq)
+			return
+		}
 		logDispatchError(m.stderr, "gc: order %s: %s", scoped, warning)
 	}
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1340,6 +1340,22 @@ func poolOrderRouteVisibilityWarning(a orders.Order, recipe *formula.Recipe) str
 	return fmt.Sprintf("warning: pool order %q uses formula %q whose root is a molecule container, not Ready-visible work; scale-from-zero pools will not wake for this wisp. Convert the formula to phase=\"vapor\"/root-only or formulas v2 before routing it to a pool.", a.ScopedName(), a.Formula)
 }
 
+func poolOrderRouteVisibilityFailFast(a orders.Order, recipe *formula.Recipe, cfg *config.City) bool {
+	if poolOrderRouteVisibilityWarning(a, recipe) == "" || cfg == nil {
+		return false
+	}
+	qualified, err := qualifyOrderPool(a, cfg)
+	if err != nil {
+		return false
+	}
+	for i := range cfg.Agents {
+		if cfg.Agents[i].QualifiedName() == qualified {
+			return cfg.Agents[i].EffectiveMinActiveSessions() == 0
+		}
+	}
+	return false
+}
+
 func redactOrderEnvError(err error, env []string) string {
 	if err == nil {
 		return ""
@@ -1408,6 +1424,17 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		return
 	}
 	if warning := poolOrderRouteVisibilityWarning(a, recipe); warning != "" {
+		if poolOrderRouteVisibilityFailFast(a, recipe, m.cfg) {
+			logDispatchError(m.stderr, "gc: order %s: %s", scoped, warning)
+			m.rec.Record(events.Event{
+				Type:    events.OrderFailed,
+				Actor:   "controller",
+				Subject: scoped,
+				Message: warning,
+			})
+			m.markTrackingFailure(store, trackingID, scoped, a, headSeq)
+			return
+		}
 		logDispatchError(m.stderr, "gc: order %s: %s", scoped, warning)
 	}
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -429,6 +429,172 @@ description = "Do the cleanup."
 	}
 }
 
+func TestOrderDispatchPoolLegacyFormulaFailsFastWhenScaleFromZeroRootIsNotReadyVisible(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeFile(t, filepath.Join(formulaDir, "mol-legacy-cleanup.toml"), `
+formula = "mol-legacy-cleanup"
+version = 1
+
+[[steps]]
+id = "work"
+title = "Do legacy cleanup"
+description = "Do the cleanup."
+`)
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var stderr bytes.Buffer
+	minZero := 0
+	maxOne := 1
+
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:         "legacy-cleanup",
+			Trigger:      "cooldown",
+			Interval:     "5m",
+			Formula:      "mol-legacy-cleanup",
+			Pool:         "dog",
+			FormulaLayer: formulaDir,
+		}},
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     &rec,
+		stderr:  &stderr,
+		cfg: &config.City{Agents: []config.Agent{{
+			Name:              "dog",
+			MinActiveSessions: &minZero,
+			MaxActiveSessions: &maxOne,
+		}}},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	m.drain(context.Background())
+
+	if !rec.hasType(events.OrderFailed) {
+		t.Fatal("missing order.failed event for scale-from-zero pool route visibility failure")
+	}
+	all := trackingBeads(t, store, "order-run:legacy-cleanup")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label = %d, want 1", len(all))
+	}
+	if !strings.HasPrefix(all[0].Title, "order:") {
+		t.Fatalf("created bead title = %q, want only the tracking bead", all[0].Title)
+	}
+	if !containsString(all[0].Labels, "wisp-failed") {
+		t.Fatalf("tracking bead labels = %v, want wisp-failed marker", all[0].Labels)
+	}
+}
+
+func TestOrderDispatchPoolLegacyFormulaStillWarnsWhenFloorPoolRootIsNotReadyVisible(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeFile(t, filepath.Join(formulaDir, "mol-legacy-cleanup.toml"), `
+formula = "mol-legacy-cleanup"
+version = 1
+
+[[steps]]
+id = "work"
+title = "Do legacy cleanup"
+description = "Do the cleanup."
+`)
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var stderr bytes.Buffer
+	minOne := 1
+	maxOne := 1
+
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:         "legacy-cleanup",
+			Trigger:      "cooldown",
+			Interval:     "5m",
+			Formula:      "mol-legacy-cleanup",
+			Pool:         "dog",
+			FormulaLayer: formulaDir,
+		}},
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     &rec,
+		stderr:  &stderr,
+		cfg: &config.City{Agents: []config.Agent{{
+			Name:              "dog",
+			MinActiveSessions: &minOne,
+			MaxActiveSessions: &maxOne,
+		}}},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	m.drain(context.Background())
+
+	if rec.hasType(events.OrderFailed) {
+		t.Fatal("unexpected order.failed event for floor pool route visibility warning")
+	}
+	if !strings.Contains(stderr.String(), "scale-from-zero pools will not wake") {
+		t.Fatalf("stderr = %q, want pool visibility warning", stderr.String())
+	}
+	work := workBeadByOrderLabel(t, store, "order-run:legacy-cleanup")
+	if work.Type != "molecule" {
+		t.Fatalf("legacy root Type = %q, want molecule", work.Type)
+	}
+}
+
+func TestOrderDispatchPoolRootOnlyFormulaDoesNotWarnOrFailForScaleFromZeroPool(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeFile(t, filepath.Join(formulaDir, "root-only-cleanup.toml"), `
+formula = "root-only-cleanup"
+version = 1
+phase = "vapor"
+
+[[steps]]
+id = "work"
+title = "Do root-only cleanup"
+description = "Do the cleanup."
+`)
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var stderr bytes.Buffer
+	minZero := 0
+	maxOne := 1
+
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:         "root-only-cleanup",
+			Trigger:      "cooldown",
+			Interval:     "5m",
+			Formula:      "root-only-cleanup",
+			Pool:         "dog",
+			FormulaLayer: formulaDir,
+		}},
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     &rec,
+		stderr:  &stderr,
+		cfg: &config.City{Agents: []config.Agent{{
+			Name:              "dog",
+			MinActiveSessions: &minZero,
+			MaxActiveSessions: &maxOne,
+		}}},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	m.drain(context.Background())
+
+	if rec.hasType(events.OrderFailed) {
+		t.Fatal("unexpected order.failed event for Ready-visible formula")
+	}
+	if strings.Contains(stderr.String(), "scale-from-zero pools will not wake") {
+		t.Fatalf("stderr = %q, want no pool visibility warning", stderr.String())
+	}
+	work := workBeadByOrderLabel(t, store, "order-run:root-only-cleanup")
+	if work.Type != "task" {
+		t.Fatalf("root-only wisp Type = %q, want task", work.Type)
+	}
+}
+
 func TestOrderDispatchPrefersCityShadowForPool(t *testing.T) {
 	store := beads.NewMemStore()
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -351,7 +351,7 @@ func TestOrderDispatchResolvesPackBindingForPool(t *testing.T) {
 
 	cfg := &config.City{
 		Agents: []config.Agent{
-			{Name: "dog", BindingName: "maintenance"},
+			{Name: "dog", BindingName: "maintenance", MinActiveSessions: intPtr(1)},
 		},
 	}
 
@@ -600,8 +600,8 @@ func TestOrderDispatchPrefersCityShadowForPool(t *testing.T) {
 
 	cfg := &config.City{
 		Agents: []config.Agent{
-			{Name: "dog"},
-			{Name: "dog", BindingName: "maintenance", SourceDir: "/city/packs/maintenance"},
+			{Name: "dog", MinActiveSessions: intPtr(1)},
+			{Name: "dog", BindingName: "maintenance", SourceDir: "/city/packs/maintenance", MinActiveSessions: intPtr(1)},
 		},
 	}
 
@@ -7116,8 +7116,9 @@ pool = "dog"
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "demo", Prefix: "ct"},
 		Agents: []config.Agent{{
-			Name:        "dog",
-			BindingName: "maintenance",
+			Name:              "dog",
+			BindingName:       "maintenance",
+			MinActiveSessions: intPtr(1),
 		}},
 		FormulaLayers: config.FormulaLayers{
 			City: []string{cityLayer},
@@ -7817,6 +7818,7 @@ name = "test-city"
 [[agent]]
 name = "dog"
 scope = "city"
+min_active_sessions = 1
 `
 	}
 	writeFile(t, filepath.Join(cityDir, "city.toml"), cityToml)
@@ -7850,6 +7852,7 @@ schema = 1
 [[agent]]
 name = "dog"
 scope = "city"
+min_active_sessions = 1
 `)
 		if binding == orderBinding {
 			writeFile(t, filepath.Join(packDir, "orders", "digest.toml"), `

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -427,6 +427,172 @@ description = "Do the cleanup."
 	}
 }
 
+func TestOrderDispatchPoolLegacyFormulaFailsFastWhenScaleFromZeroRootIsNotReadyVisible(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeFile(t, filepath.Join(formulaDir, "mol-legacy-cleanup.toml"), `
+formula = "mol-legacy-cleanup"
+version = 1
+
+[[steps]]
+id = "work"
+title = "Do legacy cleanup"
+description = "Do the cleanup."
+`)
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var stderr bytes.Buffer
+	minZero := 0
+	maxOne := 1
+
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:         "legacy-cleanup",
+			Trigger:      "cooldown",
+			Interval:     "5m",
+			Formula:      "mol-legacy-cleanup",
+			Pool:         "dog",
+			FormulaLayer: formulaDir,
+		}},
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     &rec,
+		stderr:  &stderr,
+		cfg: &config.City{Agents: []config.Agent{{
+			Name:              "dog",
+			MinActiveSessions: &minZero,
+			MaxActiveSessions: &maxOne,
+		}}},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	m.drain(context.Background())
+
+	if !rec.hasType(events.OrderFailed) {
+		t.Fatal("missing order.failed event for scale-from-zero pool route visibility failure")
+	}
+	all := trackingBeads(t, store, "order-run:legacy-cleanup")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label = %d, want 1", len(all))
+	}
+	if !strings.HasPrefix(all[0].Title, "order:") {
+		t.Fatalf("created bead title = %q, want only the tracking bead", all[0].Title)
+	}
+	if !containsString(all[0].Labels, "wisp-failed") {
+		t.Fatalf("tracking bead labels = %v, want wisp-failed marker", all[0].Labels)
+	}
+}
+
+func TestOrderDispatchPoolLegacyFormulaStillWarnsWhenFloorPoolRootIsNotReadyVisible(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeFile(t, filepath.Join(formulaDir, "mol-legacy-cleanup.toml"), `
+formula = "mol-legacy-cleanup"
+version = 1
+
+[[steps]]
+id = "work"
+title = "Do legacy cleanup"
+description = "Do the cleanup."
+`)
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var stderr bytes.Buffer
+	minOne := 1
+	maxOne := 1
+
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:         "legacy-cleanup",
+			Trigger:      "cooldown",
+			Interval:     "5m",
+			Formula:      "mol-legacy-cleanup",
+			Pool:         "dog",
+			FormulaLayer: formulaDir,
+		}},
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     &rec,
+		stderr:  &stderr,
+		cfg: &config.City{Agents: []config.Agent{{
+			Name:              "dog",
+			MinActiveSessions: &minOne,
+			MaxActiveSessions: &maxOne,
+		}}},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	m.drain(context.Background())
+
+	if rec.hasType(events.OrderFailed) {
+		t.Fatal("unexpected order.failed event for floor pool route visibility warning")
+	}
+	if !strings.Contains(stderr.String(), "scale-from-zero pools will not wake") {
+		t.Fatalf("stderr = %q, want pool visibility warning", stderr.String())
+	}
+	work := workBeadByOrderLabel(t, store, "order-run:legacy-cleanup")
+	if work.Type != "molecule" {
+		t.Fatalf("legacy root Type = %q, want molecule", work.Type)
+	}
+}
+
+func TestOrderDispatchPoolRootOnlyFormulaDoesNotWarnOrFailForScaleFromZeroPool(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeFile(t, filepath.Join(formulaDir, "root-only-cleanup.toml"), `
+formula = "root-only-cleanup"
+version = 1
+phase = "vapor"
+
+[[steps]]
+id = "work"
+title = "Do root-only cleanup"
+description = "Do the cleanup."
+`)
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var stderr bytes.Buffer
+	minZero := 0
+	maxOne := 1
+
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:         "root-only-cleanup",
+			Trigger:      "cooldown",
+			Interval:     "5m",
+			Formula:      "root-only-cleanup",
+			Pool:         "dog",
+			FormulaLayer: formulaDir,
+		}},
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     &rec,
+		stderr:  &stderr,
+		cfg: &config.City{Agents: []config.Agent{{
+			Name:              "dog",
+			MinActiveSessions: &minZero,
+			MaxActiveSessions: &maxOne,
+		}}},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	m.drain(context.Background())
+
+	if rec.hasType(events.OrderFailed) {
+		t.Fatal("unexpected order.failed event for Ready-visible formula")
+	}
+	if strings.Contains(stderr.String(), "scale-from-zero pools will not wake") {
+		t.Fatalf("stderr = %q, want no pool visibility warning", stderr.String())
+	}
+	work := workBeadByOrderLabel(t, store, "order-run:root-only-cleanup")
+	if work.Type != "task" {
+		t.Fatalf("root-only wisp Type = %q, want task", work.Type)
+	}
+}
+
 func TestOrderDispatchPrefersCityShadowForPool(t *testing.T) {
 	store := beads.NewMemStore()
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -349,7 +349,7 @@ func TestOrderDispatchResolvesPackBindingForPool(t *testing.T) {
 
 	cfg := &config.City{
 		Agents: []config.Agent{
-			{Name: "dog", BindingName: "maintenance"},
+			{Name: "dog", BindingName: "maintenance", MinActiveSessions: intPtr(1)},
 		},
 	}
 
@@ -598,8 +598,8 @@ func TestOrderDispatchPrefersCityShadowForPool(t *testing.T) {
 
 	cfg := &config.City{
 		Agents: []config.Agent{
-			{Name: "dog"},
-			{Name: "dog", BindingName: "maintenance", SourceDir: "/city/packs/maintenance"},
+			{Name: "dog", MinActiveSessions: intPtr(1)},
+			{Name: "dog", BindingName: "maintenance", SourceDir: "/city/packs/maintenance", MinActiveSessions: intPtr(1)},
 		},
 	}
 
@@ -6729,8 +6729,9 @@ pool = "dog"
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "demo", Prefix: "ct"},
 		Agents: []config.Agent{{
-			Name:        "dog",
-			BindingName: "maintenance",
+			Name:              "dog",
+			BindingName:       "maintenance",
+			MinActiveSessions: intPtr(1),
 		}},
 		FormulaLayers: config.FormulaLayers{
 			City: []string{cityLayer},
@@ -7430,6 +7431,7 @@ name = "test-city"
 [[agent]]
 name = "dog"
 scope = "city"
+min_active_sessions = 1
 `
 	}
 	writeFile(t, filepath.Join(cityDir, "city.toml"), cityToml)
@@ -7463,6 +7465,7 @@ schema = 1
 [[agent]]
 name = "dog"
 scope = "city"
+min_active_sessions = 1
 `)
 		if binding == orderBinding {
 			writeFile(t, filepath.Join(packDir, "orders", "digest.toml"), `


### PR DESCRIPTION
## The juicy parts

Today a `min_active_sessions = 0` pool order that materializes work no pool can see logs a warning to stderr and carries on. Upstream's own warning text says what happens next — "scale-from-zero pools will not wake for this wisp" — so the work is created, nothing spins up, and the only signal is a line that scrolls past. This PR turns that one case into an `order.failed` event plus a `wisp-failed` tracking bead, so a misrouted order shows up where you already look for order failures rather than in controller stderr.

Two honest caveats. This is a behaviour change with an open design question I have twice offered to resolve either way — fail-fast default vs an opt-in flag — and that call is yours; it is the only thing blocking the PR. And the blast radius is visible in the diff: several existing test fixtures with an unset `min` had to gain an explicit `min_active_sessions = 1` to keep passing, which is a fair proxy for configs that would newly trip the gate.

> **Draft — filing to ask, not to push.** This is a behavior change (warn → fail) and I'd rather get your read on whether it should be opt-in before it's mergeable.

## Summary

Upstream already emits `poolOrderRouteVisibilityWarning` when a pool order finds ready work that isn't route-visible. This turns that warning into a hard `OrderFailed` **for scale-from-zero pools** (`min_active_sessions == 0`), where warn-and-continue means the pool never scales up and the work just sits.

## Motivation

For a `min=0` pool, "there's ready work but none of it is route-visible" is usually a misconfiguration or a routing gap — and because the pool is at zero, nothing spins up to surface it. A warning is easy to miss; failing the order makes the misroute loud at dispatch time. Adjacent in spirit to #3811 (making pool lifecycle edge cases explicit rather than silent).

Anecdotally, on one running city we see ~118 order dispatches fired in a 24h sample, so the route-visibility check runs constantly; the failure mode is rare but effectively invisible when it lands on a zeroed pool.

## What changed

- `cmd/gc/order_dispatch.go`: `poolOrderRouteVisibilityFailFast` — for `min_active_sessions == 0` pools with ready-but-not-route-visible work, fail the order instead of warning.
- `cmd/gc/order_dispatch_test.go`: fixtures + coverage (min=0 fixtures get a `min_active_sessions=1` floor so they don't trip the new gate).

**Deliberately not included:** a separate fork change that re-nudges tmux pool slots — it removes an explicit upstream guard (`!CanReportActivity`) whose comment says tmux self-heals a missed startup nudge, and it touches the churn-sensitive nudge path (cf. #3824). If we keep seeing stuck tmux slots we'll file a separate issue with a repro rather than quietly delete the guard.

## Testing

- `go build ./...`; `go test ./cmd/gc/ -run 'OrderDispatch|Pool'` passes locally.

## Open questions (the reason this is a draft)

- **Should this be opt-in** (a config flag / `[pool]` setting), or is failing the default acceptable for `min=0` pools? I'm genuinely unsure and would rather match your preference.
- Should it also cover `min>0` pools, or is the zero case the only one where warning-and-continuing is clearly wrong?

Happy to close this if it's the wrong shape.

## References

#3811, #3824.

