### PR TITLE
test(tutorial-goldens): tolerate provider footer chrome in tutorial 03 reviewer peek

### DIFF
--- a/test/acceptance/tutorial_goldens/tutorial03_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial03_test.go
@@ -4,6 +4,7 @@ package tutorialgoldens
 
 import (
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -220,14 +221,34 @@ func TestTutorial03Sessions(t *testing.T) {
 	})
 
 	t.Run("gc session peek mc-8sfd", func(t *testing.T) {
+		reviewerIdentityPeekLines := 200
+		peekIdentifiesReviewer := func(out string) bool {
+			lower := strings.ToLower(out)
+			return strings.Contains(lower, "reviewer") || strings.Contains(lower, "codex")
+		}
 		out, err := ws.runShell("gc session peek "+reviewerSessionID, "")
 		if err != nil {
 			t.Fatalf("gc session peek %s: %v\n%s", reviewerSessionID, err, out)
 		}
-		lower := strings.ToLower(out)
-		if strings.TrimSpace(out) == "" || (!strings.Contains(lower, "reviewer") && !strings.Contains(lower, "codex")) {
-			t.Fatalf("peek reviewer output mismatch:\n%s", out)
+		if strings.TrimSpace(out) == "" {
+			t.Fatal("peek reviewer output is empty")
 		}
+		if peekIdentifiesReviewer(out) {
+			return
+		}
+		// The identifying "You are `reviewer`" prompt text sits above the
+		// session's skills appendix and review transcript, so provider chrome
+		// (e.g. a Claude CLI footer banner) can slide it out of the default
+		// 50-line window (#3877). The session is still the right one; only
+		// the window position moved.
+		deepOut, deepErr := ws.runShell("gc session peek "+reviewerSessionID+" --lines "+strconv.Itoa(reviewerIdentityPeekLines), "")
+		if deepErr != nil {
+			t.Fatalf("gc session peek %s --lines %d: %v\n%s", reviewerSessionID, reviewerIdentityPeekLines, deepErr, deepOut)
+		}
+		if !peekIdentifiesReviewer(deepOut) {
+			t.Fatalf("peek reviewer output mismatch; default window:\n%s\n\nhidden %d-line window:\n%s", out, reviewerIdentityPeekLines, deepOut)
+		}
+		ws.noteWarning("tutorial 03 runtime workaround: the default peek window slid past the reviewer-identifying prompt text (provider footer chrome can shift the visible window, issue #3877), so the page driver confirmed the same session identity in a wider hidden %d-line peek window", reviewerIdentityPeekLines)
 	})
 
 	t.Run("gc session list", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Hardens the tutorial 03 reviewer-peek golden against vertical drift in the live tmux window. The subtest asserted that "reviewer"/"codex" appears in the **default 50-line** `gc session peek` capture; provider chrome — concretely, the Claude CLI footer banner `installMethod is native, but claude command not found at /home/runner/…` that started appearing on CI runners — slides the identifying ``You are `reviewer`.`` prompt text out of that window while the session itself is correct. This exact failure cost the v1.3.3 release two rc-gate attempts (run 28611530724, attempts 1–2) before passing on the third.

Addresses the test-hardening half of #3877 (the runner-side banner investigation remains open there).

## Fix

Mirrors tutorial 04's established idiom (`tutorial04_communication_test.go` — "the 6-line peek window slid past the routing text, so the page driver confirmed the same communication in a wider hidden peek window"):

1. Judge the visible tutorial step (`gc session peek <id>`) as before — if the identifying text is in the default window, nothing changes.
2. Only when the default window misses it, re-peek with a hidden `--lines 200` capture (`tmux capture-pane -S -200` reaches into scrollback, so window position can't hide the prompt header) and judge that.
3. Record the fallback via `ws.noteWarning(...)` so the diagnostics show the soft workaround, same as every other tutorial 03 page-driver workaround.

A session that genuinely isn't the reviewer still fails: the assertion now reports both the default-window and deep-window captures.

## Verification

- `gofmt` clean; `go vet -tags acceptance_c ./test/acceptance/tutorial_goldens/` clean; package compiles under the `acceptance_c` tag.
- Executing `TestTutorial03Sessions` requires the live Ollama-backed model environment (rc-gate/nightly); not run locally. Behavior evidence is from the v1.3.3 gate logs: the failing capture began mid-skills-appendix a few lines below ``You are `reviewer`.``, with the footer banner at the bottom — a 200-line history capture contains the header in that exact transcript.

## Why not a golden update

The banner is environmental (pinned claude 2.1.123 setup unchanged since the passing June 22 gate; the v1.3.2 control run 28616182046 showed the same class of live-CLI drift on unchanged code). Content-anchored assertions survive both the banner appearing and it disappearing again.

Part of #3877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
