### PR TITLE
fix(mail): make recipient/target resolution config-aware (symmetric with sender)

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1059,6 +1059,18 @@ type mailIdentitySessionCache struct {
 	fetched bool
 }
 
+func ambientMailTargetConfig() (string, *config.City) {
+	cityPath, err := resolveCity()
+	if err != nil {
+		return "", nil
+	}
+	cfg, err := loadCityConfig(cityPath, io.Discard)
+	if err != nil {
+		return cityPath, nil
+	}
+	return cityPath, cfg
+}
+
 func listMailIdentitySessions(store beads.Store, cache *mailIdentitySessionCache) ([]beads.Bead, error) {
 	if cache == nil {
 		return session.ListAllSessionBeads(store, beads.ListQuery{})
@@ -1130,6 +1142,37 @@ func resolveMailTargets(store beads.Store, identifier string) (resolvedMailTarge
 	return resolveMailTargetsCached(store, identifier, nil)
 }
 
+func resolveMailTargetsWithConfig(cityPath string, cfg *config.City, store beads.Store, identifier string) (resolvedMailTarget, error) {
+	return resolveMailTargetsWithConfigCached(cityPath, cfg, store, identifier, nil)
+}
+
+func resolveMailTargetsWithConfigCached(cityPath string, cfg *config.City, store beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, error) {
+	if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
+		return resolvedMailTarget{display: "human", recipients: []string{"human"}}, nil
+	}
+	if store != nil && cfg != nil {
+		sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, identifier)
+		if err == nil {
+			b, err := store.Get(sessionID)
+			if err != nil {
+				return resolvedMailTarget{}, err
+			}
+			addresses := sessionMailboxAddresses(b)
+			if len(addresses) == 0 {
+				return resolvedMailTarget{}, fmt.Errorf("session %q has no mailbox identity", identifier)
+			}
+			return resolvedMailTarget{
+				display:    addresses[0],
+				recipients: addresses,
+			}, nil
+		}
+		if !errors.Is(err, session.ErrSessionNotFound) {
+			return resolvedMailTarget{}, err
+		}
+	}
+	return resolveMailTargetsCached(store, identifier, cache)
+}
+
 func resolveMailTargetsCached(store beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, error) {
 	if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
 		return resolvedMailTarget{display: "human", recipients: []string{"human"}}, nil
@@ -1173,7 +1216,8 @@ func resolveMailTargetsForCommand(identifier string, stderr io.Writer, cmdName s
 		_ = code
 		return resolvedMailTarget{}, false
 	}
-	target, err := resolveMailTargets(store, identifier)
+	cityPath, cfg := ambientMailTargetConfig()
+	target, err := resolveMailTargetsWithConfig(cityPath, cfg, store, identifier)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
 		return resolvedMailTarget{}, false
@@ -1197,9 +1241,10 @@ func resolveDefaultMailTargetsForCommand(stderr io.Writer, cmdName string) (reso
 	}
 	// Memoize the gc:session enumeration so multi-candidate retry shares one
 	// broad scan instead of issuing one per candidate (ga-q6ct Layer 2).
+	cityPath, cfg := ambientMailTargetConfig()
 	cache := &mailIdentitySessionCache{}
 	for _, c := range candidates {
-		target, err := resolveMailTargetsCached(store, c, cache)
+		target, err := resolveMailTargetsWithConfigCached(cityPath, cfg, store, c, cache)
 		if err == nil {
 			return target, true
 		}

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -974,6 +974,52 @@ func TestResolveMailTargets_BareRigScopedNamedUsesUniqueLiveConfiguredNamedSessi
 	}
 }
 
+func TestResolveMailTargetsWithConfig_RuntimeNameUsesLiveConfiguredNamedSessionMailbox(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{
+			Name:            "gas-city-wbern",
+			SessionTemplate: "{{.City}}/{{.Name}}",
+		},
+		Agents: []config.Agent{{
+			Name:         "gas-city-architect",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "gas-city-architect",
+			Mode:     "always",
+		}},
+	}
+	runtimeName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "gas-city-architect")
+	b, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":                     "gcw/gas-city-architect",
+			"alias_history":             "gas-city-architect",
+			"session_name":              runtimeName,
+			"configured_named_session":  "true",
+			"configured_named_identity": "gas-city-architect",
+			"configured_named_mode":     "always",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	target, err := resolveMailTargetsWithConfigCached(t.TempDir(), cfg, store, runtimeName, nil)
+	if err != nil {
+		t.Fatalf("resolveMailTargetsWithConfigCached: %v", err)
+	}
+	if target.display != "gcw/gas-city-architect" {
+		t.Fatalf("display = %q, want gcw/gas-city-architect", target.display)
+	}
+	want := []string{"gcw/gas-city-architect", b.ID, "gas-city-architect"}
+	if strings.Join(target.recipients, ",") != strings.Join(want, ",") {
+		t.Fatalf("recipients = %#v, want %#v", target.recipients, want)
+	}
+}
+
 func TestResolveMailTargetsForCommand_FakeProviderDoesNotResolveHistoricalAlias(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_MAIL", "fake")
@@ -1011,6 +1057,68 @@ func TestResolveMailTargetsForCommand_FakeProviderDoesNotResolveHistoricalAlias(
 		t.Fatalf("display = %q, want mayor", target.display)
 	}
 	want := []string{"mayor"}
+	if strings.Join(target.recipients, ",") != strings.Join(want, ",") {
+		t.Fatalf("recipients = %#v, want %#v", target.recipients, want)
+	}
+}
+
+func TestResolveMailTargetsForCommand_RuntimeNameUsesLiveConfiguredNamedSessionMailbox(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "fake")
+
+	cityPath := t.TempDir()
+	cityToml := `[workspace]
+name = "gas-city-wbern"
+session_template = "{{.City}}/{{.Name}}"
+
+[[agent]]
+name = "gas-city-architect"
+provider = "missing-provider"
+
+[providers.missing-provider]
+command = "missing-provider"
+
+[[named_session]]
+template = "gas-city-architect"
+mode = "always"
+`
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	runtimeName := config.NamedSessionRuntimeName("gas-city-wbern", config.Workspace{SessionTemplate: "{{.City}}/{{.Name}}"}, "gas-city-architect")
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":                     "gcw/gas-city-architect",
+			"alias_history":             "gas-city-architect",
+			"session_name":              runtimeName,
+			"configured_named_session":  "true",
+			"configured_named_identity": "gas-city-architect",
+			"configured_named_mode":     "always",
+		},
+	}); err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	var stderr bytes.Buffer
+	target, ok := resolveMailTargetsForCommand(runtimeName, &stderr, "gc mail inbox")
+	if !ok {
+		t.Fatal("resolveMailTargetsForCommand() = not ok, want ok")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if target.display != "gcw/gas-city-architect" {
+		t.Fatalf("display = %q, want gcw/gas-city-architect", target.display)
+	}
+	want := []string{"gcw/gas-city-architect", "gc-1", "gas-city-architect"}
 	if strings.Join(target.recipients, ",") != strings.Join(want, ",") {
 		t.Fatalf("recipients = %#v, want %#v", target.recipients, want)
 	}


### PR DESCRIPTION
## Summary

Make mail **recipient/target** resolution config-aware, mirroring what the **sender/identity** path already does. Today the two sides are asymmetric:

- Sender: `resolveMailIdentityWithConfig` → `resolveSessionIDWithConfig` (config-aware, from the ga-q6ct work).
- Recipient: `resolveMailTargets` → `resolveSessionID` (`cmd/gc/cmd_mail.go:1129,1137`) — **no config**, and this is the resolver the send loop actually uses (~`:1255`).

Because the recipient path is config-blind, a full runtime identity addressed as a recipient doesn't canonicalize to its configured named-session mailbox (and full delivery set), so messages can split across two inboxes.

## Motivation — addresses the split described in #3104

#3104 (open, `kind/bug` / `priority/p1`) describes the symptom directly: an agent aliased by a binding-qualified name but *addressed* by its bare role → *"messages to `mayor` and the live `gastown.mayor` session can land in two different inboxes."* That mismatch happens on the recipient side, which is exactly what this makes config-aware.

This is the **symmetric completion** of a change upstream already accepted for senders (`c8a24d88f`, ga-q6ct), and #858 shows mail-identity resolution is a category upstream fixes.

**Scope note / honest framing:** #3104's *proposed* root-cause fix is deeper — splitting `QualifiedName()` into a bare addressable identity vs a binding-qualified template key. This PR is narrower: it relieves the routing-split **symptom** at the resolution layer without that refactor, and is likely complementary to (or an interim for) the deeper fix. Happy to align with whatever the maintainers prefer there.

## What changed

- `cmd/gc/cmd_mail.go`: thread the city config into target resolution (`resolveMailTargetsWithConfig` → `resolveSessionIDWithConfig`) so recipient resolution gets `template:` targets, configured-named-session canonicalization, and staleness rejection of named beads no longer in config — the same behaviors the sender path already has.
- `cmd/gc/cmd_mail_test.go`: coverage for config-aware target resolution.

## Testing

- `go build ./...`, `go vet ./cmd/gc/`.
- `go test ./cmd/gc/ -run Mail` passes locally (CGO/ICU env).
- No new/changed types and nothing asserts the target shape via `reflect.DeepEqual`, so no golden/byte-identical tests are affected.

## Open questions / happy to adjust

- In the fallback branch of `resolveMailTargetsWithConfigCached`, the already-loaded `cfg` could be threaded down instead of reloading config via `configuredMailboxAddress` — a small cleanup I left out to keep this diff minimal; glad to fold it in if you'd like.
- If you'd rather solve #3104 at the `QualifiedName()` split level, treat this as an interim symptom fix or close it — no attachment.

## References

#3104 (primary), #858; precedent `c8a24d88f` (ga-q6ct, sender-side config-aware resolution).
