### PR TITLE
perf(dispatch): deep-idle backoff for the --follow serve loop

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -5376,6 +5376,93 @@ func TestRunWorkflowServeFollowSurvivesDoltCircuitBreakerOutage(t *testing.T) {
 	}
 }
 
+// TestRunWorkflowServeFollowDeepIdlesUnderSustainedTransientFailures pins the
+// deliberate behavior documented on workflowServeDeepIdleSleep: a run of
+// transient work-query failures (a saturated/timed-out store) is treated like
+// sustained emptiness, so idleSweeps keeps climbing and the retry cap stretches
+// from the responsive 5s to the 30s deep-idle cap. That is intended
+// load-shedding — each sweep is itself a multi-fork `bd ready` scan against the
+// struggling store (#2463) — not an accident. The existing transient-timeout
+// test stubs the wait without observing sleepDur, so it cannot see this; this
+// test captures the sleepDur passed to workflowServeWaitForWake across the
+// failure run.
+func TestRunWorkflowServeFollowDeepIdlesUnderSustainedTransientFailures(t *testing.T) {
+	eventsDir := t.TempDir()
+	ep := newTestProvider(t, eventsDir)
+
+	prevList := workflowServeList
+	prevProvider := workflowServeOpenEventsProvider
+	prevWait := workflowServeWaitForWake
+	prevSweep := workflowServeWakeSweepInterval
+	prevMax := workflowServeMaxIdleSleep
+	prevDeep := workflowServeDeepIdleSleep
+	prevThreshold := workflowServeDeepIdleThreshold
+	t.Cleanup(func() {
+		workflowServeList = prevList
+		workflowServeOpenEventsProvider = prevProvider
+		workflowServeWaitForWake = prevWait
+		workflowServeWakeSweepInterval = prevSweep
+		workflowServeMaxIdleSleep = prevMax
+		workflowServeDeepIdleSleep = prevDeep
+		workflowServeDeepIdleThreshold = prevThreshold
+	})
+	workflowServeWakeSweepInterval = 1 * time.Second
+	workflowServeMaxIdleSleep = 5 * time.Second
+	workflowServeDeepIdleSleep = 30 * time.Second
+	workflowServeDeepIdleThreshold = 12
+
+	workflowServeOpenEventsProvider = func(io.Writer) (events.Provider, error) { return ep, nil }
+
+	// Every drain hits the transient work-query timeout (wraps DeadlineExceeded),
+	// so the loop survives each one and downgrades it to an empty sweep.
+	transientErr := fmt.Errorf("querying control work: running work query %q: timed out after 30s: %w", "bd ready", context.DeadlineExceeded)
+	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+		return nil, transientErr
+	}
+
+	// Capture the sleepDur handed to each wait; after enough samples to cross the
+	// deep-idle threshold, return a fatal wait error to break the serve loop.
+	stopErr := errors.New("stop serve loop")
+	const samples = 14 // > threshold (12), so idleSweeps 0..13 are all observed
+	var sleeps []time.Duration
+	workflowServeWaitForWake = func(_ <-chan workflowWatchResult, sleepDur time.Duration, _ int) (bool, error) {
+		sleeps = append(sleeps, sleepDur)
+		if len(sleeps) >= samples {
+			return false, stopErr
+		}
+		return false, nil
+	}
+
+	agent := config.Agent{Name: "control-dispatcher"}
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
+	if !errors.Is(err, stopErr) {
+		t.Fatalf("runWorkflowServeFollow err = %v, want %v after the sampled failure run", err, stopErr)
+	}
+	if len(sleeps) != samples {
+		t.Fatalf("captured %d sleepDur samples, want %d", len(sleeps), samples)
+	}
+
+	// sleeps[i] is followSleepDuration(i): the first wait runs at idleSweeps=0 and
+	// each surviving transient failure increments it (no reset, no relevant event).
+	if sleeps[0] != workflowServeWakeSweepInterval {
+		t.Errorf("sleeps[0] = %v, want base %v (first sweep, idleSweeps=0)", sleeps[0], workflowServeWakeSweepInterval)
+	}
+	// Below the threshold the responsive cap holds — a transient failure must not
+	// jump straight to deep idle.
+	for i := 0; i < workflowServeDeepIdleThreshold; i++ {
+		if sleeps[i] > workflowServeMaxIdleSleep {
+			t.Errorf("sleeps[%d] = %v, want <= responsive cap %v below the deep threshold", i, sleeps[i], workflowServeMaxIdleSleep)
+		}
+	}
+	// At and past the threshold the sustained failures engage the deep-idle cap
+	// (the documented load-shedding behavior for a saturated store).
+	for i := workflowServeDeepIdleThreshold; i < samples; i++ {
+		if sleeps[i] != workflowServeDeepIdleSleep {
+			t.Errorf("sleeps[%d] = %v, want deep cap %v (sustained transient failures engage deep idle)", i, sleeps[i], workflowServeDeepIdleSleep)
+		}
+	}
+}
+
 func TestWorkflowEventRelevantAcceptsBeadLifecycleEvents(t *testing.T) {
 	for _, evt := range []events.Event{
 		{Type: events.BeadCreated},

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -6390,6 +6390,52 @@ func TestFollowSleepDurationBacksOffThenCaps(t *testing.T) {
 	}
 }
 
+func TestFollowSleepDurationDeepIdleCap(t *testing.T) {
+	prevSweep := workflowServeWakeSweepInterval
+	prevMax := workflowServeMaxIdleSleep
+	prevDeep := workflowServeDeepIdleSleep
+	prevThreshold := workflowServeDeepIdleThreshold
+	workflowServeWakeSweepInterval = 1 * time.Second
+	workflowServeMaxIdleSleep = 5 * time.Second
+	workflowServeDeepIdleSleep = 30 * time.Second
+	workflowServeDeepIdleThreshold = 12
+	t.Cleanup(func() {
+		workflowServeWakeSweepInterval = prevSweep
+		workflowServeMaxIdleSleep = prevMax
+		workflowServeDeepIdleSleep = prevDeep
+		workflowServeDeepIdleThreshold = prevThreshold
+	})
+
+	// Below the threshold the responsive ladder and its 5s cap are unchanged.
+	if got := followSleepDuration(11); got != 5*time.Second {
+		t.Errorf("followSleepDuration(11) = %v, want 5s (responsive cap below threshold)", got)
+	}
+	// At and past the threshold the deep-idle cap engages.
+	if got := followSleepDuration(12); got != 30*time.Second {
+		t.Errorf("followSleepDuration(12) = %v, want 30s (deep idle at threshold)", got)
+	}
+	if got := followSleepDuration(1000); got != 30*time.Second {
+		t.Errorf("followSleepDuration(1000) = %v, want 30s (deep idle)", got)
+	}
+	// A wake resets idleSweeps to 0 in the serve loop; 0 must return the base.
+	if got := followSleepDuration(0); got != 1*time.Second {
+		t.Errorf("followSleepDuration(0) = %v, want base 1s after wake reset", got)
+	}
+
+	// threshold <= 0 disables deep idle entirely.
+	workflowServeDeepIdleThreshold = 0
+	if got := followSleepDuration(1000); got != 5*time.Second {
+		t.Errorf("followSleepDuration(1000) with threshold=0 = %v, want 5s (deep idle disabled)", got)
+	}
+	workflowServeDeepIdleThreshold = 12
+
+	// A deep cap accidentally set below the responsive cap must not shorten sleeps.
+	workflowServeDeepIdleSleep = 2 * time.Second
+	if got := followSleepDuration(12); got != 5*time.Second {
+		t.Errorf("followSleepDuration(12) with deep<max = %v, want 5s (never below responsive cap)", got)
+	}
+}
+
 func TestWaitForRelevantWorkflowWakeReturnsTrueOnRelevantEvent(t *testing.T) {
 	// Set the debounce explicitly so a lone relevant wake is fast and
 	// intentional rather than silently inheriting the package default.

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -63,6 +63,26 @@ var (
 	// (Complementary to the wake-debounce coalescing below, which only helps
 	// the event-arrival path; a raw-bd-write close publishes no event.)
 	workflowServeMaxIdleSleep = 5 * time.Second
+	// workflowServeDeepIdleSleep is the sleep cap once the loop has been
+	// continuously empty for workflowServeDeepIdleThreshold consecutive sweeps.
+	// Each sweep runs the full work query — a shell that forks several
+	// `bd --readonly --sandbox ready` subprocesses (one per identity candidate
+	// plus two per routed target). At the 5s cap a fully idle city therefore
+	// pays that multi-fork scan ~12x/min per dispatcher forever; on a
+	// multi-dispatcher city this idle polling is the dominant residual store
+	// load behind gastownhall/gascity#2463 (measured: ~50 serve events/min per
+	// dispatcher, dolt pegged while the city was otherwise quiescent). The deep
+	// cap only engages after ~52s of continuous emptiness (the 1s/2s/4s ramp
+	// plus nine 5s sweeps), and any relevant event or non-empty drain resets
+	// idleSweeps to 0, restoring the responsive 1s→5s ladder while a workflow
+	// is in flight. The only cost is worst-case pickup latency for transitions
+	// that publish no city event (raw `bd` writes, see workflowServeMaxIdleSleep
+	// comment above) arriving after a sustained quiet period: ≤30s for the
+	// first hop, after which the loop is active again at 1–5s.
+	workflowServeDeepIdleSleep = 30 * time.Second
+	// workflowServeDeepIdleThreshold is the consecutive-empty-sweep count at
+	// which the deep-idle cap engages. ≤0 disables deep idle entirely.
+	workflowServeDeepIdleThreshold = 12
 	// workflowServeWakeDebounce is the coalescing window opened once the first
 	// relevant event wakes the --follow loop. Additional buffered events that
 	// arrive during the window are drained and folded into the same wake so a
@@ -104,6 +124,14 @@ var (
 func followSleepDuration(idleSweeps int) time.Duration {
 	if idleSweeps <= 0 {
 		return workflowServeWakeSweepInterval
+	}
+	if workflowServeDeepIdleThreshold > 0 && idleSweeps >= workflowServeDeepIdleThreshold {
+		// Sustained emptiness: back off to the deep-idle cap (never below the
+		// responsive cap, in case a test or override inverts the two).
+		if workflowServeDeepIdleSleep > workflowServeMaxIdleSleep {
+			return workflowServeDeepIdleSleep
+		}
+		return workflowServeMaxIdleSleep
 	}
 	const maxShift = 30
 	shift := idleSweeps

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -58,8 +58,11 @@ var (
 	// At the former 30s cap each graph hop could wait up to ~30s, so a
 	// multi-step workflow accumulated minutes of pure wake latency (the bulk of
 	// the TestGraphWorkflowSuccessPath flake). 5s keeps the loop responsive
-	// across hops while still backing off from the 1s base; the cost is one
-	// serve loop polling every 5s rather than 30s when a city is fully idle.
+	// across hops while still backing off from the 1s base. This is the
+	// responsive-tier cap; once the loop has been continuously empty for
+	// workflowServeDeepIdleThreshold sweeps it relaxes further to
+	// workflowServeDeepIdleSleep (see below), so a fully idle city eventually
+	// polls every 30s rather than every 5s.
 	// (Complementary to the wake-debounce coalescing below, which only helps
 	// the event-arrival path; a raw-bd-write close publishes no event.)
 	workflowServeMaxIdleSleep = 5 * time.Second
@@ -79,6 +82,19 @@ var (
 	// that publish no city event (raw `bd` writes, see workflowServeMaxIdleSleep
 	// comment above) arriving after a sustained quiet period: ≤30s for the
 	// first hop, after which the loop is active again at 1–5s.
+	//
+	// Sustained transient work-query failures engage this deep tier too: a
+	// timed-out/saturated-store drain is downgraded to an empty sweep in
+	// runWorkflowServeFollow (it must not kill the long-running dispatcher), and
+	// the SessionWorkQueryFailed event it publishes is not workflowEventRelevant,
+	// so it does not reset idleSweeps. After ~52s of continuous failures the cap
+	// therefore stretches to 30s. This is deliberate, not incidental: each sweep
+	// is itself a multi-fork `bd ready` scan against the very store that is
+	// struggling, so backing off is load-shedding that helps a pegged store
+	// recover — the goal of #2463 — rather than hammering it 12x/min. The
+	// residual exposure is narrow: bead events published through normal paths
+	// still wake the loop immediately, so only work written by a raw `bd` write
+	// *during* an active outage is discovered up to 30s late instead of 5s.
 	workflowServeDeepIdleSleep = 30 * time.Second
 	// workflowServeDeepIdleThreshold is the consecutive-empty-sweep count at
 	// which the deep-idle cap engages. ≤0 disables deep idle entirely.


### PR DESCRIPTION
Closes #3892. Refs #2463.

## What

A second idle-backoff tier for the control-dispatcher `--follow` serve loop: after 12 consecutive empty sweeps (~52s of continuous quiet through the existing 1s/2s/4s ramp plus nine 5s sweeps), the sleep cap extends from `workflowServeMaxIdleSleep` (5s) to `workflowServeDeepIdleSleep` (30s).

## Why

Each sweep runs the full work query — a shell forking several `bd --readonly --sandbox ready` subprocesses (one per identity candidate plus two per routed target). At the 5s cap a fully idle city pays that multi-fork scan up to ~12×/min per dispatcher forever; we measured ~50 serve trace events/min per dispatcher (two dispatchers, 1-rig city) with the city otherwise quiescent. With the controller reading in-process (native store), this is the dominant residual `bd`-subprocess producer behind #2463.

## Why it doesn't regress workflow latency

- Any relevant event or non-empty drain resets `idleSweeps` to 0, restoring the responsive 1s→5s ladder while a workflow is in flight — multi-hop latency unchanged (the #1028/#3206 behaviors are preserved; existing tests untouched and passing).
- The only cost is worst-case first-hop pickup for a transition that publishes no city event (raw `bd` write — the reason the 5s cap exists, per the in-code comment) arriving after ≥52s of proven quiet: ≤30s once, then the loop is active again.

## Safety

- Both knobs are injectable vars in the existing style.
- `workflowServeDeepIdleThreshold <= 0` disables deep idle entirely.
- A deep cap accidentally set below the responsive cap is clamped up, so a bad override can never shorten sleeps.

## Testing

`TestFollowSleepDurationDeepIdleCap` covers: responsive cap below threshold, deep cap at/past threshold, wake-reset to base, threshold-0 disable, and the inverted-override clamp. Existing `TestFollowSleepDurationBacksOffThenCaps` / `...PathologicalInputs` pass unchanged. `go vet` + full `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
