### PR TITLE
fix(order): ignore no-history bead events

### DIFF
--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -816,6 +816,41 @@ func TestOrderCheckWithStoresResolverUsesLegacyCityStore(t *testing.T) {
 	}
 }
 
+func TestOrderCheckIgnoresNoHistoryBeadEvents(t *testing.T) {
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{
+		Type:  events.BeadClosed,
+		Actor: "bd-hook",
+		Payload: []byte(`{
+			"bead": {
+				"id": "iy-wisp-session",
+				"title": "bd.dog-1",
+				"labels": ["gc:session", "agent:bd.dog-1"],
+				"no_history": true
+			}
+		}`),
+	})
+
+	aa := []orders.Order{{
+		Name:    "cascade-nudge-on-blocker-close",
+		Trigger: "event",
+		On:      events.BeadClosed,
+		Exec:    "scripts/cascade.sh",
+	}}
+	resolver := func(orders.Order) ([]beads.OrdersStore, error) {
+		return []beads.OrdersStore{{Store: beads.NewMemStore()}}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoresResolverScoped(t.TempDir(), &config.City{}, aa, time.Now(), eventLog, resolver, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderCheckWithStoresResolverScoped = %d, want 1; stderr: %s; stdout: %s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "no") {
+		t.Fatalf("stdout missing not-due row:\n%s", stdout.String())
+	}
+}
+
 func TestOrderCheckConditionUsesCityScope(t *testing.T) {
 	cityDir := t.TempDir()
 	orderDir := filepath.Join(cityDir, "packs", "workflows", "orders")

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -688,6 +688,52 @@ func TestOrderDispatchEventExecAdvancesCursor(t *testing.T) {
 	}
 }
 
+// Guards against event-triggered orders firing on their own internal
+// order-tracking bead lifecycle events.
+func TestOrderDispatchEventIgnoresInternalOrderTrackingBeadEvents(t *testing.T) {
+	store := beads.NewMemStore()
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{
+		Type:  events.BeadUpdated,
+		Actor: "bd-hook",
+		Payload: []byte(`{
+			"bead": {
+				"id": "iy-wisp-tracking",
+				"title": "order:nudge-on-route",
+				"labels": ["order-run:nudge-on-route", "order-tracking", "seq:42"],
+				"no_history": true
+			}
+		}`),
+	})
+
+	var calls int
+	execRun := func(context.Context, string, string, []string) ([]byte, error) {
+		calls++
+		return []byte("ok"), nil
+	}
+
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name:    "nudge-on-route",
+		Trigger: "event",
+		On:      events.BeadUpdated,
+		Exec:    "scripts/nudge.sh",
+	}}, store, eventLog, execRun, events.Discard)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+
+	all := trackingBeads(t, store, "order-run:nudge-on-route")
+	if len(all) != 0 {
+		t.Fatalf("tracking beads with order-run label = %d, want 0", len(all))
+	}
+	if calls != 0 {
+		t.Fatalf("exec calls = %d, want 0", calls)
+	}
+}
+
 func TestOrderDispatchEventExecFailureAdvancesCursor(t *testing.T) {
 	store := beads.NewMemStore()
 	eventLog := events.NewFake()

--- a/cmd/gc/order_event_filter.go
+++ b/cmd/gc/order_event_filter.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+type orderTriggerEventPayload struct {
+	Bead         *orderTriggerEventBead `json:"bead"`
+	Labels       []string               `json:"labels"`
+	NoHistory    bool                   `json:"no_history"`
+	NoHistoryAlt bool                   `json:"noHistory"`
+}
+
+type orderTriggerEventBead struct {
+	Labels       []string `json:"labels"`
+	NoHistory    bool     `json:"no_history"`
+	NoHistoryAlt bool     `json:"noHistory"`
+}
+
+func orderTriggerEventPredicate(event events.Event) bool {
+	return !isNoHistoryBeadLifecycleEvent(event)
+}
+
+func isNoHistoryBeadLifecycleEvent(event events.Event) bool {
+	switch event.Type {
+	case events.BeadCreated, events.BeadUpdated, events.BeadClosed:
+	default:
+		return false
+	}
+	bead, ok := orderTriggerEventBeadFromPayload(event.Payload)
+	if !ok {
+		return false
+	}
+	return bead.noHistory()
+}
+
+func orderTriggerEventBeadFromPayload(raw json.RawMessage) (orderTriggerEventBead, bool) {
+	if len(raw) == 0 {
+		return orderTriggerEventBead{}, false
+	}
+	var payload orderTriggerEventPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return orderTriggerEventBead{}, false
+	}
+	if payload.Bead != nil {
+		return *payload.Bead, true
+	}
+	if len(payload.Labels) > 0 || payload.NoHistory || payload.NoHistoryAlt {
+		return orderTriggerEventBead{
+			Labels:       payload.Labels,
+			NoHistory:    payload.NoHistory,
+			NoHistoryAlt: payload.NoHistoryAlt,
+		}, true
+	}
+	return orderTriggerEventBead{}, false
+}
+
+func (bead orderTriggerEventBead) noHistory() bool {
+	return bead.NoHistory || bead.NoHistoryAlt
+}

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -216,8 +216,9 @@ func isReservedOrderExecEnvKey(key string) bool {
 }
 
 func orderTriggerOptions(cityPath string, cfg *config.City, a orders.Order) (orders.TriggerOptions, error) {
+	opts := defaultOrderTriggerOptions()
 	if a.Trigger != "condition" || strings.TrimSpace(cityPath) == "" {
-		return orders.TriggerOptions{}, nil
+		return opts, nil
 	}
 	target, err := resolveOrderExecTarget(cityPath, cfg, a)
 	if err != nil {
@@ -227,17 +228,23 @@ func orderTriggerOptions(cityPath string, cfg *config.City, a orders.Order) (ord
 }
 
 func orderTriggerOptionsForTarget(cityPath string, cfg *config.City, target execStoreTarget, a orders.Order) (orders.TriggerOptions, error) {
+	opts := defaultOrderTriggerOptions()
 	if a.Trigger != "condition" || strings.TrimSpace(cityPath) == "" {
-		return orders.TriggerOptions{}, nil
+		return opts, nil
 	}
 	env, err := orderExecEnvWithError(cityPath, cfg, target, a)
 	if err != nil {
 		return orders.TriggerOptions{}, err
 	}
+	opts.ConditionDir = target.ScopeRoot
+	opts.ConditionEnv = env
+	return opts, nil
+}
+
+func defaultOrderTriggerOptions() orders.TriggerOptions {
 	return orders.TriggerOptions{
-		ConditionDir: target.ScopeRoot,
-		ConditionEnv: env,
-	}, nil
+		EventPredicate: orderTriggerEventPredicate,
+	}
 }
 
 func applyOrderExecCanonicalDoltEnv(cityPath, scopeRoot string, env map[string]string) {

--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -38,6 +38,9 @@ type TriggerOptions struct {
 	ConditionDir     string
 	ConditionEnv     []string
 	ConditionTimeout time.Duration
+	// EventPredicate optionally filters events after type and cursor matching.
+	// Returning false excludes the event from making an event trigger due.
+	EventPredicate func(events.Event) bool
 }
 
 var (
@@ -67,7 +70,7 @@ func CheckTriggerWithOptions(a Order, now time.Time, lastRunFn LastRunFunc, ep e
 	case "condition":
 		return checkCondition(a, opts)
 	case "event":
-		return checkEvent(a, ep, cursorFn)
+		return checkEvent(a, ep, cursorFn, opts.EventPredicate)
 	case "manual":
 		return TriggerResult{Due: false, Reason: "manual trigger — use gc order run"}
 	default:
@@ -235,7 +238,7 @@ func mergeConditionEnv(environ, extra []string) []string {
 }
 
 // checkEvent checks if matching events exist after the last cursor position.
-func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc) TriggerResult {
+func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc, predicate func(events.Event) bool) TriggerResult {
 	if ep == nil {
 		return TriggerResult{Due: false, Reason: "event: no events provider"}
 	}
@@ -250,6 +253,15 @@ func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc) TriggerResult 
 	})
 	if err != nil {
 		return TriggerResult{Due: false, Reason: fmt.Sprintf("event: read error: %v", err)}
+	}
+	if predicate != nil {
+		filtered := matched[:0]
+		for _, event := range matched {
+			if predicate(event) {
+				filtered = append(filtered, event)
+			}
+		}
+		matched = filtered
 	}
 	if len(matched) == 0 {
 		return TriggerResult{Due: false, Reason: "event: no matching events"}


### PR DESCRIPTION
## Summary
- add an event predicate hook to order trigger evaluation
- make CLI/dispatcher event orders ignore bead lifecycle events for `no_history` beads
- cover the observed loop with dispatcher and `gc order check` regression tests

## Verification
- `CGO_CPPFLAGS="-I$(brew --prefix icu4c)/include" CGO_LDFLAGS="-L$(brew --prefix icu4c)/lib" go test ./cmd/gc -run 'TestOrderDispatchEvent|TestOrderCheckIgnoresNoHistoryBeadEvents' -count=1`\n- `CGO_CPPFLAGS="-I$(brew --prefix icu4c)/include" CGO_LDFLAGS="-L$(brew --prefix icu4c)/lib" go test ./internal/orders -count=1`\n- Yakushido live check: `nudge-on-route` and `cascade-nudge-on-blocker-close` stop reporting due on internal no-history session/order-tracking events\n\n## Operational context\nIyashi hit a supervisor CPU loop because event orders consumed bead lifecycle events emitted by Gas City internal bookkeeping beads. Those tracking/session beads are `no_history=true`; they should remain observable, but should not make event-triggered orders due by default.