### PR TITLE
fix(orders): fail OPEN on store-query timeout for idempotent orders (vp-gprv)

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -508,6 +508,7 @@ type orderJSON struct {
 	Timeout      string            `json:"timeout,omitempty"`
 	CheckTimeout string            `json:"check_timeout,omitempty"`
 	Enabled      bool              `json:"enabled"`
+	Idempotent   bool              `json:"idempotent"`
 	Source       string            `json:"source,omitempty"`
 	FormulaLayer string            `json:"formula_layer,omitempty"`
 	Env          map[string]string `json:"env,omitempty"`
@@ -578,6 +579,7 @@ func orderToJSON(a orders.Order) orderJSON {
 		Timeout:      a.Timeout,
 		CheckTimeout: a.CheckTimeout,
 		Enabled:      a.IsEnabled(),
+		Idempotent:   a.Idempotent,
 		Source:       a.Source,
 		FormulaLayer: a.FormulaLayer,
 		Env:          a.Env,
@@ -663,6 +665,10 @@ func doOrderShow(aa []orders.Order, name, rig string, stdout, stderr io.Writer) 
 			w(fmt.Sprintf("  %s=%s", key, a.Env[key]))
 		}
 	}
+	// Idempotent decides whether the order fails OPEN when its open-work gate
+	// times out under store contention (see order_dispatch gateFailClosed). It is
+	// load-bearing for diagnosing starved single-flight orders, so surface it.
+	w(fmt.Sprintf("Idempotent:  %t", a.Idempotent))
 	w(fmt.Sprintf("Source:      %s", a.Source))
 	return 0
 }

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -125,6 +125,44 @@ func TestOrderListJSON(t *testing.T) {
 	}
 }
 
+// TestOrderListJSONExposesIdempotent guards that the `idempotent` order flag is
+// visible in the JSON projection. Without it, an operator debugging a starved
+// single-flight order (vp-gprv: code-review-gate never dispatched because the
+// open-work gate timed out) cannot tell from `gc order list/show --json`
+// whether the order is idempotent — i.e. whether it is eligible to fail OPEN on
+// a gate timeout. The flag is the single most load-bearing field for that
+// diagnosis, so it must be serialized.
+func TestOrderListJSONExposesIdempotent(t *testing.T) {
+	aa := []orders.Order{
+		{Name: "sweep", Trigger: "cooldown", Interval: "2m", Exec: "true", Idempotent: true},
+		{Name: "review", Trigger: "cooldown", Interval: "2m", Exec: "true", Idempotent: false},
+	}
+
+	var stdout bytes.Buffer
+	if code := doOrderListJSON("/city", &config.City{}, aa, &stdout); code != 0 {
+		t.Fatalf("doOrderListJSON = %d, want 0", code)
+	}
+
+	var got struct {
+		Orders []struct {
+			Name       string `json:"name"`
+			Idempotent bool   `json:"idempotent"`
+		} `json:"orders"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("order list JSON invalid: %v\n%s", err, stdout.String())
+	}
+	if len(got.Orders) != 2 {
+		t.Fatalf("orders = %+v, want 2", got.Orders)
+	}
+	if got.Orders[0].Name != "sweep" || !got.Orders[0].Idempotent {
+		t.Errorf("idempotent order should serialize idempotent=true; got %+v", got.Orders[0])
+	}
+	if got.Orders[1].Name != "review" || got.Orders[1].Idempotent {
+		t.Errorf("non-idempotent order should serialize idempotent=false; got %+v", got.Orders[1])
+	}
+}
+
 func TestOrderListExecType(t *testing.T) {
 	aa := []orders.Order{
 		{Name: "poll", Trigger: "cooldown", Interval: "2m", Exec: "scripts/poll.sh"},

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -191,6 +191,7 @@ func TestOrderShowJSON(t *testing.T) {
 		Trigger:      "cron",
 		Schedule:     "0 3 * * *",
 		Pool:         "dog",
+		Idempotent:   true,
 		Source:       "/city/orders/digest.toml",
 		FormulaLayer: "/city/formulas",
 	}}
@@ -210,11 +211,20 @@ func TestOrderShowJSON(t *testing.T) {
 			Trigger      string `json:"trigger"`
 			Schedule     string `json:"schedule"`
 			Target       string `json:"target"`
+			Idempotent   bool   `json:"idempotent"`
 			FormulaLayer string `json:"formula_layer"`
 		} `json:"order"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("order show JSON invalid: %v\n%s", err, stdout.String())
+	}
+	// The list projection asserts idempotent directly
+	// (TestOrderListJSONExposesIdempotent); without the same assertion here half
+	// the diagnostic contract could regress silently. idempotent is what decides
+	// whether an order fails open on a gate timeout, so operators reading
+	// `gc order show --json` need it to be accurate.
+	if !got.Order.Idempotent {
+		t.Error("order show JSON: idempotent = false, want true (the show projection must expose the flag the list projection does)")
 	}
 	if got.SchemaVersion != "1" || got.Order.Name != "digest" || got.Order.Target != "dog" || got.Order.FormulaLayer != "/city/formulas" {
 		t.Fatalf("payload = %+v", got)

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -717,9 +717,13 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			})
 			if err != nil {
 				if m.gateFailClosed(ctx, a, scoped, err) {
-					if errors.Is(err, errGateTimeout) {
-						// Anchor to actual wall clock after the gate consumed orderGateTimeout;
-						// using the tick-start 'now' would set a deadline that has already passed.
+					if isGateContentionTimeout(err) {
+						// Anchor to actual wall clock after the gate consumed its time
+						// budget (the per-order bound OR the underlying store query
+						// timing out, vp-gprv); using the tick-start 'now' would set a
+						// deadline that has already passed. Backing off on the store-query
+						// timeout too keeps a non-idempotent order from re-hammering a
+						// contended Dolt every tick (#3688 #3770).
 						m.setGateBackoff(scoped, time.Now().Add(orderGateBackoffDuration))
 					}
 					continue
@@ -867,9 +871,13 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			})
 			if err != nil {
 				if m.gateFailClosed(ctx, a, scoped, err) {
-					if errors.Is(err, errGateTimeout) {
-						// Anchor to actual wall clock after the gate consumed orderGateTimeout;
-						// using the tick-start 'now' would set a deadline that has already passed.
+					if isGateContentionTimeout(err) {
+						// Anchor to actual wall clock after the gate consumed its time
+						// budget (the per-order bound OR the underlying store query
+						// timing out, vp-gprv); using the tick-start 'now' would set a
+						// deadline that has already passed. Backing off on the store-query
+						// timeout too keeps a non-idempotent order from re-hammering a
+						// contended Dolt every tick (#3688 #3770).
 						m.setGateBackoff(scoped, time.Now().Add(orderGateBackoffDuration))
 					}
 					continue
@@ -2697,20 +2705,38 @@ func gateOpenWorkBounded(ctx context.Context, timeout time.Duration, scoped stri
 	}
 }
 
+// isGateContentionTimeout reports whether a gate error is a store-contention
+// timeout that is safe to relax for idempotent orders. Two layers produce it:
+// the per-order gate bound elapsing (errGateTimeout, #2893) and the underlying
+// store/bd query itself timing out (beads.IsTimeoutError — e.g. the wisp-tier
+// "bd list both tiers: bd query: timed out after 30s", vp-gprv). Both mean the
+// gate could not complete because the store ran out of time, not because it
+// read a definitive answer or hit a genuine failure. A canceled dispatch
+// context and a real store-read error (parse/connection/"read failed") are NOT
+// contention timeouts.
+func isGateContentionTimeout(err error) bool {
+	return errors.Is(err, errGateTimeout) || beads.IsTimeoutError(err)
+}
+
 // gateFailClosed decides whether an open-work gate error must block dispatch of
 // this order, and logs the error. The blanket "skip on any gate error" was
-// wrong: idempotent sweep orders (feeders, nudger, route-reclaim) are safe to
-// double-dispatch, so a gate that times out under store contention must not
-// starve them forever (#2893 #2'). Policy:
+// wrong: idempotent sweep orders (feeders, nudger, route-reclaim, the
+// code-review-gate) are safe to double-dispatch, so a gate that times out under
+// store contention must not starve them forever (#2893 #2', vp-gprv). Policy:
 //   - dispatch context done (shutdown / tick deadline): always block — there is
 //     no point dispatching into a canceled context.
-//   - a per-order gate TIMEOUT (errGateTimeout): a non-idempotent order fails
-//     CLOSED (block, preserving single-flight); an idempotent order fails OPEN
-//     (dispatch anyway), since its re-run is a no-op.
+//   - a gate contention TIMEOUT (the per-order bound errGateTimeout OR the
+//     underlying store/bd query timing out, isGateContentionTimeout): a
+//     non-idempotent order fails CLOSED (block, preserving single-flight); an
+//     idempotent order fails OPEN (dispatch anyway), since its re-run is a
+//     no-op. The store-query timeout is folded in here because it is the same
+//     contention signal as the bound — before vp-gprv it reached this function
+//     as a raw store error and blocked even idempotent orders, starving
+//     code-review-gate fleet-wide whenever the wisp query timed out.
 //   - any other gate error (e.g. a genuine store-read failure): always block.
-//     Only the bounded-gate timeout is the #2893 contention signal that is
-//     safe to relax; a real store/gate error is a different signal where the
-//     conservative response is to fail CLOSED, matching the pre-#2893 behavior.
+//     Only a contention timeout is safe to relax; a real store/gate error is a
+//     different signal where the conservative response is to fail CLOSED,
+//     matching the pre-#2893 behavior.
 //
 // Failing open deliberately relaxes single-flight for idempotent orders: it may
 // dispatch while a prior run is still in flight. That is safe by the
@@ -2725,8 +2751,8 @@ func (m *memoryOrderDispatcher) gateFailClosed(ctx context.Context, a orders.Ord
 	if ctx.Err() != nil {
 		return true
 	}
-	if a.Idempotent && errors.Is(err, errGateTimeout) {
-		logDispatchError(m.stderr, "gc: order dispatch: %s open-work gate failed but order is idempotent; dispatching anyway (#2893)", scoped)
+	if a.Idempotent && isGateContentionTimeout(err) {
+		logDispatchError(m.stderr, "gc: order dispatch: %s open-work gate timed out but order is idempotent; dispatching anyway (#2893, vp-gprv)", scoped)
 		return false
 	}
 	return true

--- a/cmd/gc/order_dispatch_gate_policy_test.go
+++ b/cmd/gc/order_dispatch_gate_policy_test.go
@@ -102,6 +102,59 @@ func TestOrderDispatchIdempotentFailsOpenOnGateTimeout(t *testing.T) {
 	}
 }
 
+// gateErrorStore returns a supplied error (not a hang) from the strict
+// open-work gate scan, reproducing vp-gprv where the wisp-tier bd query fails
+// with "bd query: timed out after 30s" under Dolt contention. Unlike
+// gateTimeoutStore (which sleeps until the per-order bound fires and yields an
+// errGateTimeout), the error arrives promptly and reaches gateFailClosed as a
+// store-read error. Only the exact strict-gate query shape is failed; every
+// other read (including trackingBeads' IncludeClosed verification query) stays
+// live.
+type gateErrorStore struct {
+	beads.Store
+	err error
+}
+
+func (s *gateErrorStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if strings.HasPrefix(query.Label, "order-run:") && !query.IncludeClosed && query.Limit == 0 {
+		return nil, s.err
+	}
+	return s.Store.List(query)
+}
+
+// TestOrderDispatchIdempotentFailsOpenOnStoreTimeout is the vp-gprv regression:
+// when the open-work gate's wisp bd query TIMES OUT (returns a timeout error
+// rather than merely hanging past the per-order bound), an idempotent order
+// must still fail OPEN and dispatch, while a non-idempotent order fails CLOSED.
+// code-review-gate (idempotent) was starved fleet-wide because this store-layer
+// timeout was misclassified as a genuine read failure and failed closed even
+// though the order opted into idempotent fail-open.
+func TestOrderDispatchIdempotentFailsOpenOnStoreTimeout(t *testing.T) {
+	store := &gateErrorStore{
+		Store: beads.NewMemStore(),
+		err:   fmt.Errorf("bd list both tiers: bd query: %w", errors.New("timed out after 30s")),
+	}
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+
+	aa := []orders.Order{
+		{Name: "code-review-gate", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: true},
+		{Name: "merge-loop-sweep", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: false},
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	ad.dispatch(context.Background(), t.TempDir(), now)
+	ad.drain(context.Background())
+
+	if got := trackingBeads(t, store, "order-run:code-review-gate"); len(got) == 0 {
+		t.Error("idempotent order should fail OPEN on a store-query timeout and dispatch, but no tracking bead was created (vp-gprv starvation)")
+	}
+	if got := trackingBeads(t, store, "order-run:merge-loop-sweep"); len(got) != 0 {
+		t.Errorf("non-idempotent order should fail CLOSED on a store-query timeout and skip; got %d tracking beads", len(got))
+	}
+}
+
 // TestGateFailClosed covers the gate-error decision logic directly: a per-order
 // gate timeout fails open only for idempotent orders, but a done dispatch
 // context (shutdown / tick deadline) always blocks, even for idempotent orders.
@@ -116,7 +169,21 @@ func TestGateFailClosed(t *testing.T) {
 		t.Error("non-idempotent order on gate timeout should fail CLOSED (blocked)")
 	}
 	if !m.gateFailClosed(context.Background(), orders.Order{Idempotent: true}, "feeder", errors.New("dolt: read failed")) {
-		t.Error("idempotent order must fail CLOSED on a non-timeout gate error (only the bounded-gate timeout fails open)")
+		t.Error("idempotent order must fail CLOSED on a non-timeout gate error (only a timeout fails open)")
+	}
+
+	// A raw store/bd query timeout (the wisp "bd query: timed out after 30s"
+	// case, vp-gprv) is the same store-contention signal as the per-order gate
+	// bound, just surfaced from a different layer: an idempotent order must fail
+	// OPEN on it, a non-idempotent order still fails CLOSED. Before the fix this
+	// reached gateFailClosed as a non-errGateTimeout error and blocked even
+	// idempotent orders, starving code-review-gate fleet-wide.
+	storeTimeoutErr := fmt.Errorf("checking open work: %w", errors.New("bd list both tiers: bd query: timed out after 30s"))
+	if m.gateFailClosed(context.Background(), orders.Order{Idempotent: true}, "review", storeTimeoutErr) {
+		t.Error("idempotent order on a store-query timeout should fail OPEN (vp-gprv)")
+	}
+	if !m.gateFailClosed(context.Background(), orders.Order{Idempotent: false}, "sweep", storeTimeoutErr) {
+		t.Error("non-idempotent order on a store-query timeout should still fail CLOSED")
 	}
 
 	canceledCtx, cancel := context.WithCancel(context.Background())

--- a/cmd/gc/order_dispatch_gate_policy_test.go
+++ b/cmd/gc/order_dispatch_gate_policy_test.go
@@ -102,21 +102,47 @@ func TestOrderDispatchIdempotentFailsOpenOnGateTimeout(t *testing.T) {
 	}
 }
 
-// gateErrorStore returns a supplied error (not a hang) from the strict
-// open-work gate scan, reproducing vp-gprv where the wisp-tier bd query fails
-// with "bd query: timed out after 30s" under Dolt contention. Unlike
-// gateTimeoutStore (which sleeps until the per-order bound fires and yields an
-// errGateTimeout), the error arrives promptly and reaches gateFailClosed as a
-// store-read error. Only the exact strict-gate query shape is failed; every
-// other read (including trackingBeads' IncludeClosed verification query) stays
-// live.
+// gateErrorStore returns a supplied error (not a hang) from the open-work gate
+// reads, reproducing vp-gprv where the wisp-tier bd query fails with "bd query:
+// timed out after 30s" under Dolt contention. Unlike gateTimeoutStore (which
+// sleeps until the per-order bound fires and yields an errGateTimeout), the
+// error arrives promptly and reaches gateFailClosed as a store-read error.
+//
+// The gate reads the store on TWO legs, and both must fail for the gate itself
+// to fail, because they are each other's fallback:
+//
+//   - the per-tick batched order-run index (orderDispatchTrackingIndex's
+//     entriesForStore), a LABEL-LESS AllowScan read of the store's whole
+//     non-closed corpus, folded by label for every order at once; and
+//   - hasOpenWorkStrict, the per-order "order-run:<scoped>" label query the
+//     index falls back to when its scan errors, so an index hole is not read as
+//     an absence of work.
+//
+// Failing only the label query lets the batched scan succeed and answer "no open
+// work" for every order, so the gate never errors, every order dispatches, and
+// the test passes for entirely the wrong reason while exercising none of the
+// timeout path. Every other read stays live: notably the order-run history query
+// behind lastRun must succeed, or dispatch bails at its lastRunErr check before
+// gateFailClosed is ever consulted.
 type gateErrorStore struct {
 	beads.Store
 	err error
 }
 
+// isGateIndexScan reports whether the query is the batched, label-less order-run
+// index scan the tracking index issues once per store per tick.
+func isGateIndexScan(query beads.ListQuery) bool {
+	return query.AllowScan && query.Label == ""
+}
+
+// isStrictGateQuery reports whether the query is the per-order single-flight
+// "order-run:<scoped>" label read the index falls back to.
+func isStrictGateQuery(query beads.ListQuery) bool {
+	return strings.HasPrefix(query.Label, "order-run:") && !query.IncludeClosed && query.Limit == 0
+}
+
 func (s *gateErrorStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if strings.HasPrefix(query.Label, "order-run:") && !query.IncludeClosed && query.Limit == 0 {
+	if isGateIndexScan(query) || isStrictGateQuery(query) {
 		return nil, s.err
 	}
 	return s.Store.List(query)
@@ -155,6 +181,51 @@ func TestOrderDispatchIdempotentFailsOpenOnStoreTimeout(t *testing.T) {
 	}
 }
 
+// TestOrderDispatchIdempotentFailsOpenOnBothTiersDown pins the end-to-end
+// consequence of the mixed-chain classification decision, at the layer where
+// starvation actually shows up.
+//
+// When BOTH list tiers fail, mergeListTierResults returns
+// errors.Join(primaryErr, ephemeralErr) — in practice a timeout leaf joined to a
+// hard-failure leaf. Requiring every leaf to be timeout-shaped before relaxing
+// the gate would fail an idempotent order CLOSED here, and both-tiers-down is
+// strictly WORSE store contention than the single-tier timeout that starved
+// code-review-gate fleet-wide in the first place. That would reinstate vp-gprv
+// at exactly the moment the fail-open matters most, and would make this
+// classifier stricter than isBdAmbiguousWriteError, which already treats
+// "timed out after" and "connection reset" as one transient family.
+//
+// So an idempotent order must still dispatch, and a non-idempotent order must
+// still be skipped — single-flight is not relaxed for anyone who did not opt in.
+func TestOrderDispatchIdempotentFailsOpenOnBothTiersDown(t *testing.T) {
+	store := &gateErrorStore{
+		Store: beads.NewMemStore(),
+		err: fmt.Errorf("bd list both tiers: %w", errors.Join(
+			errors.New("bd query: timed out after 30s"),
+			errors.New("dolt: read failed"),
+		)),
+	}
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+
+	aa := []orders.Order{
+		{Name: "code-review-gate", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: true},
+		{Name: "merge-loop-sweep", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: false},
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	ad.dispatch(context.Background(), t.TempDir(), now)
+	ad.drain(context.Background())
+
+	if got := trackingBeads(t, store, "order-run:code-review-gate"); len(got) == 0 {
+		t.Error("idempotent order should fail OPEN when both list tiers fail with a joined timeout and dispatch, but no tracking bead was created (vp-gprv starvation under maximal contention)")
+	}
+	if got := trackingBeads(t, store, "order-run:merge-loop-sweep"); len(got) != 0 {
+		t.Errorf("non-idempotent order should still fail CLOSED when both tiers are down; got %d tracking beads", len(got))
+	}
+}
+
 // TestGateFailClosed covers the gate-error decision logic directly: a per-order
 // gate timeout fails open only for idempotent orders, but a done dispatch
 // context (shutdown / tick deadline) always blocks, even for idempotent orders.
@@ -184,6 +255,31 @@ func TestGateFailClosed(t *testing.T) {
 	}
 	if !m.gateFailClosed(context.Background(), orders.Order{Idempotent: false}, "sweep", storeTimeoutErr) {
 		t.Error("non-idempotent order on a store-query timeout should still fail CLOSED")
+	}
+
+	// Both list tiers failing at once produces errors.Join(timeout, read-failure)
+	// from mergeListTierResults, and an idempotent order fails OPEN on it. That
+	// is the reviewed decision, pinned here so a later "only fail open when every
+	// leaf is a timeout" tightening cannot quietly restore the vp-gprv
+	// starvation: both-tiers-down is strictly worse contention than the
+	// single-tier failure that starved code-review-gate, so it is precisely where
+	// an idempotent order must keep dispatching. Non-idempotent orders are
+	// unaffected — they still fail CLOSED and keep single-flight.
+	bothTiersDownErr := fmt.Errorf("checking open work: %w",
+		errors.Join(errors.New("bd query: timed out after 30s"), errors.New("dolt: read failed")))
+	if m.gateFailClosed(context.Background(), orders.Order{Idempotent: true}, "review", bothTiersDownErr) {
+		t.Error("idempotent order on a both-tiers-down join carrying a timeout leaf should fail OPEN (vp-gprv); failing CLOSED here starves it under the worst contention")
+	}
+	if !m.gateFailClosed(context.Background(), orders.Order{Idempotent: false}, "sweep", bothTiersDownErr) {
+		t.Error("non-idempotent order on a both-tiers-down join should still fail CLOSED")
+	}
+	// Control: the same join shape with NO timeout leaf is a plain store failure
+	// and must block even an idempotent order, so the assertion above pins the
+	// timeout leaf rather than "any joined error".
+	noTimeoutJoinErr := fmt.Errorf("checking open work: %w",
+		errors.Join(errors.New("dolt: read failed"), errors.New("connection reset by peer")))
+	if !m.gateFailClosed(context.Background(), orders.Order{Idempotent: true}, "review", noTimeoutJoinErr) {
+		t.Error("idempotent order must fail CLOSED on a joined store failure with no timeout leaf")
 	}
 
 	canceledCtx, cancel := context.WithCancel(context.Background())

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -115,6 +115,7 @@ Formula:     pancakes
 Trigger:     cooldown
 Interval:    5m
 Target:      worker
+Idempotent:  false
 Source:      /Users/you/my-city/orders/pancakes-check.toml
 ```
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -962,7 +962,7 @@ func IsPartialResult(err error) bool {
 // the only join that reaches the gate carrying a timeout leaf is
 // mergeListTierResults, which fires only when BOTH list tiers fail — maximal
 // contention, where relaxing an idempotent gate is exactly the intended
-// behaviour. Do not generalize that reasoning to another call site.
+// behavior. Do not generalize that reasoning to another call site.
 //
 // This is the fourth transient-error classifier in the tree, each with an
 // overlapping but deliberately different needle set. Keep them in sync only

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -937,6 +937,27 @@ func IsPartialResult(err error) bool {
 	return errors.As(err, &partial)
 }
 
+// IsTimeoutError reports whether err was caused by a store/bd query exceeding
+// its time budget — a per-command bd exec timeout (bdExecTimeoutError, "timed
+// out after ...") or a context deadline. It deliberately excludes cancellation
+// (context.Canceled) and genuine store-read failures (parse errors, connection
+// resets, "read failed"): those are not contention signals. Callers use it to
+// tell a query that merely ran out of time under store contention — safe to
+// relax for idempotent work — apart from an error that must be treated as a
+// hard failure. Message matching is required because bd exec timeouts are
+// formatted strings that do not wrap the context.DeadlineExceeded sentinel.
+func IsTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "timed out after") ||
+		strings.Contains(msg, "deadline exceeded")
+}
+
 // parseIssuesTolerant unmarshals bd list output, skipping any entries that
 // fail to parse (e.g. corrupt metadata with non-string values). bd 1.0.4 emits
 // a top-level array; bd 1.0.5 may emit an object envelope with an issues array.

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -962,7 +962,11 @@ func IsPartialResult(err error) bool {
 // the only join that reaches the gate carrying a timeout leaf is
 // mergeListTierResults, which fires only when BOTH list tiers fail — maximal
 // contention, where relaxing an idempotent gate is exactly the intended
-// behavior. Do not generalize that reasoning to another call site.
+// behavior. Do not generalize that reasoning to another call site. Tightening
+// this to "every leaf must be timeout-shaped" would fail an idempotent gate
+// CLOSED under the worst contention there is, restoring the vp-gprv starvation;
+// TestIsTimeoutError and TestGateFailClosed pin the mixed-chain outcome in both
+// directions so that regression cannot land silently.
 //
 // This is the fourth transient-error classifier in the tree, each with an
 // overlapping but deliberately different needle set. Keep them in sync only

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -945,7 +945,35 @@ func IsPartialResult(err error) bool {
 // tell a query that merely ran out of time under store contention — safe to
 // relax for idempotent work — apart from an error that must be treated as a
 // hard failure. Message matching is required because bd exec timeouts are
-// formatted strings that do not wrap the context.DeadlineExceeded sentinel.
+// formatted strings that do not wrap the context.DeadlineExceeded sentinel
+// (bdExecTimeoutError, and the second formatter in execPurge).
+//
+// SCOPE WARNING — substring-based, and safe only where a false positive is
+// harmless. The current caller (isGateContentionTimeout) relaxes a gate for
+// orders whose re-run is a no-op by contract, so a wrong "yes" costs a
+// duplicate dispatch and nothing more. On any path where timeout-versus-hard-
+// failure carries real weight, do not use this: a genuine outage whose message
+// happens to embed "deadline exceeded" would be misread as contention, and a
+// parse failure carries up to 200 bytes of raw bd output (bead titles) that the
+// caller does not control.
+//
+// It also matches on the flattened text of an errors.Join, so a chain mixing a
+// timeout with a hard failure reports true. That is deliberate for this caller:
+// the only join that reaches the gate carrying a timeout leaf is
+// mergeListTierResults, which fires only when BOTH list tiers fail — maximal
+// contention, where relaxing an idempotent gate is exactly the intended
+// behaviour. Do not generalize that reasoning to another call site.
+//
+// This is the fourth transient-error classifier in the tree, each with an
+// overlapping but deliberately different needle set. Keep them in sync only
+// where the semantics genuinely match:
+//   - isBdAmbiguousWriteError (this file) — write-path ambiguity; a broader
+//     connection-error set, because a half-applied write must be retried on
+//     transport faults this function ignores.
+//   - isTransientWorkQueryFailure (internal/dispatch/control.go) and
+//     isTransientGraphApplyError (internal/molecule/graph_apply.go) — both gate
+//     on an operation marker before matching needles, which bounds the text
+//     they can misread. This function has no such gate.
 func IsTimeoutError(err error) bool {
 	if err == nil {
 		return false

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -5123,6 +5123,25 @@ func TestIsTimeoutError(t *testing.T) {
 		{"context canceled is NOT a timeout", fmt.Errorf("gate: %w", context.Canceled), false},
 		{"genuine store read failure", errors.New("dolt: read failed"), false},
 		{"connection reset is NOT a timeout", errors.New("connection reset by peer"), false},
+
+		// A chain mixing a timeout leaf with a hard-failure leaf reports TRUE.
+		// This is a deliberate, reviewed decision, not an accident of substring
+		// matching, and it is pinned here so a later "tightening" to
+		// all-leaves-must-be-timeout cannot silently reintroduce the vp-gprv
+		// starvation. The only join that reaches the gate carrying a timeout leaf
+		// is mergeListTierResults, which fires ONLY when both list tiers fail —
+		// i.e. worse store contention than the single-tier failure that starved
+		// code-review-gate in the first place. Failing CLOSED there would starve
+		// an idempotent order at exactly the moment relaxing it matters most, and
+		// would make this classifier stricter than isBdAmbiguousWriteError, which
+		// already groups "timed out after" and "connection reset" as one transient
+		// family. Both leaf orderings are pinned because errors.Join flattens to
+		// newline-joined text and the guarantee must not depend on leaf order.
+		{"join of timeout and hard failure is a contention timeout", errors.Join(errors.New("timed out after 30s"), errors.New("dolt: read failed")), true},
+		{"join with the hard failure first is still a contention timeout", errors.Join(errors.New("dolt: read failed"), errors.New("timed out after 30s")), true},
+		// Negative control: a join carrying NO timeout leaf must stay false, so
+		// the two cases above pin "a timeout leaf is present", not "any join".
+		{"join of two hard failures is NOT a timeout", errors.Join(errors.New("dolt: read failed"), errors.New("connection reset by peer")), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -5101,3 +5101,34 @@ func TestBdStoreReadyRetryBoundedReturnsErrorAfterExhaustion(t *testing.T) {
 		t.Fatalf("calls = %d, want >= 2 (retry must be attempted)", calls)
 	}
 }
+
+// TestIsTimeoutError pins the narrow timeout classifier used to distinguish a
+// store/bd query that ran out of time (a contention signal callers may safely
+// relax for idempotent work) from a genuine store-read failure or a plain
+// cancellation. Both must NOT be treated as timeouts: a connection failure is a
+// real error, and a cancellation is a shutdown signal, not contention.
+func TestIsTimeoutError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"bd exec timeout", errors.New("timed out after 30s"), true},
+		{"bd list both tiers wisp timeout", fmt.Errorf("bd list both tiers: bd query: %w", errors.New("timed out after 30s")), true},
+		{"caller-deadline timeout", errors.New("timed out after 500ms (caller deadline)"), true},
+		{"context deadline sentinel", fmt.Errorf("gate: %w", context.DeadlineExceeded), true},
+		{"deadline exceeded text", errors.New("context deadline exceeded"), true},
+		{"partial result wrapping timeout", &beads.PartialResultError{Op: "bd list both tiers", Err: errors.New("bd query: timed out after 30s")}, true},
+		{"context canceled is NOT a timeout", fmt.Errorf("gate: %w", context.Canceled), false},
+		{"genuine store read failure", errors.New("dolt: read failed"), false},
+		{"connection reset is NOT a timeout", errors.New("connection reset by peer"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := beads.IsTimeoutError(tc.err); got != tc.want {
+				t.Errorf("IsTimeoutError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`code-review-gate` (idempotent, 120s cooldown) stopped dispatching autonomously ~2026-07-01: its pre-dispatch open-work gate died with `bd list both tiers: bd query: timed out after 30s` under Dolt/wisp contention. That raw store-query timeout reached `gateFailClosed` as a **generic store-read error**, so even an idempotent order failed **CLOSED** and was starved fleet-wide — reviews stopped → `code-review/blocking` never posted → tacit-consent merges never fired → PR throughput went to 0.

`#2893` already relaxed the gate for idempotent orders, but only for the **per-order bound** (`errGateTimeout`). The underlying bd/store query timing out is the *same* store-contention signal from a lower layer — it just wasn't classified as a timeout, so it reached `gateFailClosed` as a raw store error and blocked even idempotent orders.

## Changes

- **`internal/beads`**: add `IsTimeoutError(err)` — classifies a store/bd query that ran out of time (`bd exec "timed out after ..."`, `context.DeadlineExceeded`), deliberately **excluding** cancellation (`context.Canceled`) and genuine read failures (`dolt: read failed`, connection reset).
- **`cmd/gc`**: `isGateContentionTimeout(err) = errGateTimeout || beads.IsTimeoutError(err)`; `gateFailClosed` and both dispatch-site backoffs use it, so an idempotent order fails **OPEN** on a store-query timeout (its re-run is a no-op) while a non-idempotent order still fails **CLOSED**, preserving single-flight.
- **`cmd/gc`**: surface the `idempotent` flag in `gc order list/show --json` so a starved single-flight order is diagnosable from the CLI.

`packs/voxist-city/orders/code-review-gate.toml` is `idempotent = true`, so this directly unstarves it.

## Test plan

- [x] `internal/beads` full suite — green; `TestIsTimeoutError` covers 10 cases incl. a `PartialResultError`-wrapped timeout and the negative cases (cancellation, read-failure, connection-reset all correctly rejected).
- [x] `cmd/gc` `Order|Gate|Dispatch` (`GC_FAST_UNIT=1`) — green (47.7s).
- [x] **Red→green verified**: reverting `gateFailClosed` to the pre-fix `errors.Is(err, errGateTimeout)` makes `TestOrderDispatchIdempotentFailsOpenOnStoreTimeout` and `TestGateFailClosed` fail with *"no tracking bead created (vp-gprv starvation)"*; restoring `isGateContentionTimeout` makes them green — proving the new tests exercise the fix (not vacuous).

## Notes

- Policy for **non-idempotent** orders is unchanged — they still fail CLOSED on a gate/store timeout, preserving single-flight.
- The alternative direction floated in the bead (drop the open-work precondition entirely) was **not** taken; folding the store-timeout into the existing idempotent fail-open path is narrower and reuses the proven `#2893` policy.

Bead: **vp-gprv** (left for `merge-loop-sweep` to close on merge — DoD is PR merged, not opened).
