### PR TITLE
fix(supervisor): sweep leaked isolated-home supervisor services on install/uninstall

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -1306,7 +1306,7 @@ func supervisorLaunchdLabel() string {
 
 func supervisorSystemdServiceName() string {
 	if suffix := supervisorServiceSuffix(); suffix != "" {
-		return "gascity-supervisor-" + suffix + ".service"
+		return supervisorSystemdUnitPrefix + suffix + ".service"
 	}
 	return defaultSupervisorSystemdUnit
 }
@@ -1744,6 +1744,7 @@ func warnSupervisorSystemdWarmRefreshPreservedUnit(stderr io.Writer, service str
 }
 
 func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Writer) int {
+	sweepStaleIsolatedSupervisorServices(stderr)
 	content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, data)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc supervisor install: rendering plist: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1814,6 +1815,7 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 }
 
 func uninstallSupervisorLaunchd(_ *supervisorServiceData, stdout, stderr io.Writer) int {
+	sweepStaleIsolatedSupervisorServices(stderr)
 	path := supervisorLaunchdPlistPath()
 	active := supervisorLaunchdActive(supervisorLaunchdLabel())
 	if sockPath, _ := runningSupervisorSocket(); sockPath != "" {
@@ -1890,6 +1892,7 @@ func stopSupervisorSystemdForWarmRefresh(service string) ([]string, error) {
 }
 
 func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Writer) int {
+	sweepStaleIsolatedSupervisorServices(stderr)
 	// Check the binary guard before probing systemd so a refused install
 	// emits no systemctl calls.
 	path := supervisorSystemdServicePath()
@@ -2083,6 +2086,7 @@ func currentUsernameForSystemdHint() string {
 var currentUserForSystemdHint = osuser.Current
 
 func uninstallSupervisorSystemd(_ *supervisorServiceData, stdout, stderr io.Writer) int {
+	sweepStaleIsolatedSupervisorServices(stderr)
 	path := supervisorSystemdServicePath()
 	service := supervisorSystemdServiceName()
 	active := supervisorSystemctlActive(service)

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -1894,7 +1894,8 @@ func stopSupervisorSystemdForWarmRefresh(service string) ([]string, error) {
 func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Writer) int {
 	sweepStaleIsolatedSupervisorServices(stderr)
 	// Check the binary guard before probing systemd so a refused install
-	// emits no systemctl calls.
+	// emits no systemctl calls for the install itself (the stale-service
+	// sweep above may still have issued best-effort systemctl calls).
 	path := supervisorSystemdServicePath()
 	existing, err := os.ReadFile(path)
 	hadCurrent := err == nil

--- a/cmd/gc/cmd_supervisor_stale_services.go
+++ b/cmd/gc/cmd_supervisor_stale_services.go
@@ -1,0 +1,152 @@
+package main
+
+// Stale isolated supervisor-service sweep (gascity#3896).
+//
+// Every `gc supervisor install` under an isolated GC_HOME writes a
+// per-home service file (com.gascity.supervisor.<suffix>.plist on
+// launchd, gascity-supervisor-<suffix>.service on systemd) with
+// RunAtLoad / Restart=always semantics. Test and e2e harnesses that
+// crash or are interrupted before their `gc supervisor uninstall`
+// teardown leak that service permanently: the service manager
+// resurrects it on every login even after its temp GC_HOME is deleted,
+// and nothing else ever removes it. The sweep below runs on the
+// install and uninstall paths and boots out gc-owned *suffixed*
+// service files whose GC_HOME no longer exists. It never touches the
+// default (unsuffixed) service, the current process's own service
+// file, or any file whose GC_HOME cannot be parsed or still exists.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// supervisorSystemdUnitPrefix is the shared prefix of suffixed
+// (isolated-GC_HOME) supervisor units; keep in sync with
+// supervisorSystemdServiceName.
+const supervisorSystemdUnitPrefix = "gascity-supervisor-"
+
+// sweepStaleIsolatedSupervisorServices removes leaked isolated-home
+// supervisor services for the active platform. Failures are warnings
+// on stderr; the sweep never blocks the caller.
+func sweepStaleIsolatedSupervisorServices(stderr io.Writer) {
+	switch supervisorRuntimeGOOS {
+	case "darwin":
+		sweepStaleIsolatedSupervisorLaunchd(stderr)
+	case "linux":
+		sweepStaleIsolatedSupervisorSystemd(stderr)
+	}
+}
+
+// supervisorServiceGCHomeMissing reports whether a service file's
+// GC_HOME is definitively gone. Only a clean not-exist counts:
+// empty values, permission errors, and transient failures leave the
+// service alone.
+func supervisorServiceGCHomeMissing(gcHome string) bool {
+	if strings.TrimSpace(gcHome) == "" {
+		return false
+	}
+	_, err := os.Stat(gcHome)
+	return errors.Is(err, os.ErrNotExist)
+}
+
+// sweepStaleIsolatedSupervisorLaunchd boots out and removes suffixed
+// com.gascity.supervisor.* launch agents whose GC_HOME no longer
+// exists.
+func sweepStaleIsolatedSupervisorLaunchd(stderr io.Writer) {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return
+	}
+	dir := filepath.Join(home, "Library", "LaunchAgents")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Missing or unreadable LaunchAgents dir: nothing to sweep.
+		return
+	}
+	ownPath := supervisorLaunchdPlistPath()
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".plist") {
+			continue
+		}
+		label := strings.TrimSuffix(name, ".plist")
+		// Only suffixed labels: the default com.gascity.supervisor
+		// agent is the user's real supervisor and is never swept.
+		if !strings.HasPrefix(label, defaultSupervisorLaunchdLabel+".") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if samePath(path, ownPath) {
+			continue
+		}
+		// legacySupervisorHome parses GC_HOME out of any gc-rendered
+		// service file, not only the legacy-labeled one.
+		gcHome, ok := legacySupervisorHome(path)
+		if !ok || !supervisorServiceGCHomeMissing(gcHome) {
+			continue
+		}
+		_ = supervisorLaunchctlRun("unload", path)
+		_ = supervisorLaunchctlRun("disable", supervisorLaunchdServiceTarget(label))
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "gc supervisor: removing stale isolated supervisor plist %s: %v\n", path, err) //nolint:errcheck // best-effort stderr
+			continue
+		}
+		fmt.Fprintf(stderr, "gc supervisor: removed stale isolated supervisor service %s (GC_HOME %s no longer exists)\n", label, gcHome) //nolint:errcheck // best-effort stderr
+	}
+}
+
+// sweepStaleIsolatedSupervisorSystemd stops, disables, and removes
+// suffixed gascity-supervisor-*.service user units whose GC_HOME no
+// longer exists.
+func sweepStaleIsolatedSupervisorSystemd(stderr io.Writer) {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return
+	}
+	dir := filepath.Join(home, ".local", "share", "systemd", "user")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Missing or unreadable unit dir: nothing to sweep.
+		return
+	}
+	ownPath := supervisorSystemdServicePath()
+	removed := false
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		// Only suffixed units: the default gascity-supervisor.service
+		// (no trailing dash) is the user's real supervisor and is
+		// never swept.
+		if !strings.HasPrefix(name, supervisorSystemdUnitPrefix) || !strings.HasSuffix(name, ".service") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if samePath(path, ownPath) {
+			continue
+		}
+		gcHome, ok := legacySupervisorHome(path)
+		if !ok || !supervisorServiceGCHomeMissing(gcHome) {
+			continue
+		}
+		_ = supervisorSystemctlRun("--user", "stop", name)
+		_ = supervisorSystemctlRun("--user", "disable", name)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "gc supervisor: removing stale isolated supervisor unit %s: %v\n", path, err) //nolint:errcheck // best-effort stderr
+			continue
+		}
+		removed = true
+		fmt.Fprintf(stderr, "gc supervisor: removed stale isolated supervisor service %s (GC_HOME %s no longer exists)\n", name, gcHome) //nolint:errcheck // best-effort stderr
+	}
+	if removed {
+		_ = supervisorSystemctlRun("--user", "daemon-reload")
+	}
+}

--- a/cmd/gc/cmd_supervisor_stale_services_test.go
+++ b/cmd/gc/cmd_supervisor_stale_services_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// writeStaleSweepLaunchdPlist renders a real supervisor plist for label
+// pointing at gcHome and writes it into dir, mirroring what
+// installSupervisorLaunchd produces.
+func writeStaleSweepLaunchdPlist(t *testing.T, dir, label, gcHome string) string {
+	t.Helper()
+	content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/tmp/gc-test",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: label,
+		Path:         "/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, label+".plist")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// writeStaleSweepSystemdUnit renders a real supervisor unit named unit
+// pointing at gcHome and writes it into dir, mirroring what
+// installSupervisorSystemd produces.
+func writeStaleSweepSystemdUnit(t *testing.T, dir, unit, gcHome string) string {
+	t.Helper()
+	content, err := renderSupervisorTemplate(supervisorSystemdTemplate, &supervisorServiceData{
+		GCPath:  "/tmp/gc-test",
+		LogPath: filepath.Join(gcHome, "supervisor.log"),
+		GCHome:  gcHome,
+		Path:    "/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, unit)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSweepStaleIsolatedSupervisorLaunchdRemovesOnlyStale(t *testing.T) {
+	homeDir := t.TempDir()
+	ownGCHome := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", ownGCHome)
+	oldGOOS := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "darwin"
+	t.Cleanup(func() { supervisorRuntimeGOOS = oldGOOS })
+
+	launchAgents := filepath.Join(homeDir, "Library", "LaunchAgents")
+	if err := os.MkdirAll(launchAgents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	staleHome := filepath.Join(t.TempDir(), "deleted-gc-home")
+	liveHome := t.TempDir()
+
+	// The default (unsuffixed) agent must never be swept, even when its
+	// GC_HOME is gone.
+	defaultPath := writeStaleSweepLaunchdPlist(t, launchAgents, defaultSupervisorLaunchdLabel, staleHome)
+	// The current process's own suffixed agent must never be swept.
+	ownPath := writeStaleSweepLaunchdPlist(t, launchAgents, supervisorLaunchdLabel(), ownGCHome)
+	// A leaked agent whose GC_HOME no longer exists must be removed.
+	staleLabel := defaultSupervisorLaunchdLabel + ".gc-home-12345678"
+	stalePath := writeStaleSweepLaunchdPlist(t, launchAgents, staleLabel, staleHome)
+	// Another isolated agent whose GC_HOME still exists must be kept.
+	livePath := writeStaleSweepLaunchdPlist(t, launchAgents, defaultSupervisorLaunchdLabel+".other-abcd1234", liveHome)
+	// A suffixed plist that cannot be parsed must be left alone.
+	junkPath := filepath.Join(launchAgents, defaultSupervisorLaunchdLabel+".junk-ffffffff.plist")
+	if err := os.WriteFile(junkPath, []byte("<not-a-plist>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// An unrelated plist must be ignored entirely.
+	otherPath := filepath.Join(launchAgents, "com.example.other.plist")
+	if err := os.WriteFile(otherPath, []byte("<not-a-plist>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	t.Cleanup(func() { supervisorLaunchctlRun = oldRun })
+
+	var stderr bytes.Buffer
+	sweepStaleIsolatedSupervisorServices(&stderr)
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale plist %q should be removed; err=%v", stalePath, err)
+	}
+	for _, keep := range []string{defaultPath, ownPath, livePath, junkPath, otherPath} {
+		if _, err := os.Stat(keep); err != nil {
+			t.Fatalf("plist %q should be untouched: %v", keep, err)
+		}
+	}
+
+	joined := strings.Join(calls, "\n")
+	target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + staleLabel
+	for _, want := range []string{"unload " + stalePath, "disable " + target} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("launchctl calls = %v, want %q", calls, want)
+		}
+	}
+	for _, path := range []string{defaultPath, ownPath, livePath, junkPath, otherPath} {
+		if strings.Contains(joined, path) {
+			t.Fatalf("launchctl calls %v must not reference %q", calls, path)
+		}
+	}
+	if !strings.Contains(stderr.String(), staleLabel) {
+		t.Fatalf("stderr = %q, want removal notice for %q", stderr.String(), staleLabel)
+	}
+}
+
+func TestSweepStaleIsolatedSupervisorSystemdRemovesOnlyStale(t *testing.T) {
+	homeDir := t.TempDir()
+	ownGCHome := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", ownGCHome)
+	oldGOOS := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "linux"
+	t.Cleanup(func() { supervisorRuntimeGOOS = oldGOOS })
+
+	unitDir := filepath.Join(homeDir, ".local", "share", "systemd", "user")
+	if err := os.MkdirAll(unitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	staleHome := filepath.Join(t.TempDir(), "deleted-gc-home")
+	liveHome := t.TempDir()
+
+	defaultPath := writeStaleSweepSystemdUnit(t, unitDir, defaultSupervisorSystemdUnit, staleHome)
+	ownPath := writeStaleSweepSystemdUnit(t, unitDir, supervisorSystemdServiceName(), ownGCHome)
+	staleUnit := "gascity-supervisor-gc-home-12345678.service"
+	stalePath := writeStaleSweepSystemdUnit(t, unitDir, staleUnit, staleHome)
+	livePath := writeStaleSweepSystemdUnit(t, unitDir, "gascity-supervisor-other-abcd1234.service", liveHome)
+	unrelatedPath := filepath.Join(unitDir, "other.service")
+	if err := os.WriteFile(unrelatedPath, []byte("[Unit]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRun := supervisorSystemctlRun
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	t.Cleanup(func() { supervisorSystemctlRun = oldRun })
+
+	var stderr bytes.Buffer
+	sweepStaleIsolatedSupervisorServices(&stderr)
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale unit %q should be removed; err=%v", stalePath, err)
+	}
+	for _, keep := range []string{defaultPath, ownPath, livePath, unrelatedPath} {
+		if _, err := os.Stat(keep); err != nil {
+			t.Fatalf("unit %q should be untouched: %v", keep, err)
+		}
+	}
+
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"--user stop " + staleUnit,
+		"--user disable " + staleUnit,
+		"--user daemon-reload",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("systemctl calls = %v, want %q", calls, want)
+		}
+	}
+	for _, unit := range []string{defaultSupervisorSystemdUnit, supervisorSystemdServiceName(), "gascity-supervisor-other-abcd1234.service"} {
+		if strings.Contains(joined, "stop "+unit) || strings.Contains(joined, "disable "+unit) {
+			t.Fatalf("systemctl calls %v must not stop/disable %q", calls, unit)
+		}
+	}
+}
+
+func TestSweepStaleIsolatedSupervisorSystemdNoStaleMakesNoSystemctlCalls(t *testing.T) {
+	homeDir := t.TempDir()
+	ownGCHome := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", ownGCHome)
+	oldGOOS := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "linux"
+	t.Cleanup(func() { supervisorRuntimeGOOS = oldGOOS })
+
+	unitDir := filepath.Join(homeDir, ".local", "share", "systemd", "user")
+	if err := os.MkdirAll(unitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	liveHome := t.TempDir()
+	writeStaleSweepSystemdUnit(t, unitDir, "gascity-supervisor-live-abcd1234.service", liveHome)
+
+	oldRun := supervisorSystemctlRun
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	t.Cleanup(func() { supervisorSystemctlRun = oldRun })
+
+	var stderr bytes.Buffer
+	sweepStaleIsolatedSupervisorServices(&stderr)
+
+	if len(calls) != 0 {
+		t.Fatalf("systemctl calls = %v, want none when nothing is stale", calls)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty when nothing is stale", stderr.String())
+	}
+}
+
+func TestSweepStaleIsolatedSupervisorServicesMissingDirIsNoop(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	oldGOOS := supervisorRuntimeGOOS
+	t.Cleanup(func() { supervisorRuntimeGOOS = oldGOOS })
+
+	for _, goos := range []string{"darwin", "linux"} {
+		supervisorRuntimeGOOS = goos
+		var stderr bytes.Buffer
+		sweepStaleIsolatedSupervisorServices(&stderr)
+		if stderr.Len() != 0 {
+			t.Fatalf("goos=%s: stderr = %q, want empty for missing service dir", goos, stderr.String())
+		}
+	}
+}
+
+func TestInstallSupervisorLaunchdSweepsStaleSiblings(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+	oldGOOS := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "darwin"
+	t.Cleanup(func() { supervisorRuntimeGOOS = oldGOOS })
+
+	launchAgents := filepath.Join(homeDir, "Library", "LaunchAgents")
+	if err := os.MkdirAll(launchAgents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	staleHome := filepath.Join(t.TempDir(), "deleted-gc-home")
+	stalePath := writeStaleSweepLaunchdPlist(t, launchAgents, defaultSupervisorLaunchdLabel+".gc-home-87654321", staleHome)
+
+	oldRun := supervisorLaunchctlRun
+	supervisorLaunchctlRun = func(_ ...string) error { return nil }
+	t.Cleanup(func() { supervisorLaunchctlRun = oldRun })
+
+	data := &supervisorServiceData{
+		GCPath:       "/tmp/gc-new",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: supervisorLaunchdLabel(),
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale sibling plist %q should be swept during install; err=%v", stalePath, err)
+	}
+	if _, err := os.Stat(supervisorLaunchdPlistPath()); err != nil {
+		t.Fatalf("own plist should be installed: %v", err)
+	}
+}
+
+func TestUninstallSupervisorLaunchdSweepsStaleSiblings(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+	oldGOOS := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "darwin"
+	t.Cleanup(func() { supervisorRuntimeGOOS = oldGOOS })
+
+	launchAgents := filepath.Join(homeDir, "Library", "LaunchAgents")
+	if err := os.MkdirAll(launchAgents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	staleHome := filepath.Join(t.TempDir(), "deleted-gc-home")
+	stalePath := writeStaleSweepLaunchdPlist(t, launchAgents, defaultSupervisorLaunchdLabel+".gc-home-13572468", staleHome)
+	ownPath := writeStaleSweepLaunchdPlist(t, launchAgents, supervisorLaunchdLabel(), gcHome)
+
+	oldRun := supervisorLaunchctlRun
+	supervisorLaunchctlRun = func(_ ...string) error { return nil }
+	t.Cleanup(func() { supervisorLaunchctlRun = oldRun })
+	oldActive := supervisorLaunchdActive
+	supervisorLaunchdActive = func(string) bool { return false }
+	t.Cleanup(func() { supervisorLaunchdActive = oldActive })
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorLaunchd(nil, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstallSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale sibling plist %q should be swept during uninstall; err=%v", stalePath, err)
+	}
+	if _, err := os.Stat(ownPath); !os.IsNotExist(err) {
+		t.Fatalf("own plist %q should be removed by uninstall; err=%v", ownPath, err)
+	}
+}


### PR DESCRIPTION
Fixes #3896.

Every `gc supervisor install` under an isolated `GC_HOME` writes a per-home service file: `com.gascity.supervisor.<suffix>.plist` with `RunAtLoad` and `KeepAlive` on launchd, `gascity-supervisor-<suffix>.service` with `Restart=always` and `WantedBy=default.target` on systemd. Teardown depends entirely on the harness reaching `gc supervisor uninstall`, so any test or e2e run that crashes or is interrupted first leaks the service permanently: the service manager resurrects it on every login after the temp `GC_HOME` is gone, and nothing ever removes it. The issue reports 20 leaked launch agents on macOS; the Linux analog on the machine this was debugged on was 18 leaked `gascity-supervisor-gc-home-*.service` user units crash-looping every 5 seconds, 4,791 restarts in a single day.

The fix adds `sweepStaleIsolatedSupervisorServices`, called at the top of the four install and uninstall paths (`installSupervisorLaunchd`, `uninstallSupervisorLaunchd`, `installSupervisorSystemd`, `uninstallSupervisorSystemd`). The sweep removes a service file only when all of the following hold: the file carries the suffixed isolated-home naming (the default unsuffixed service is never a candidate), it is not the current process's own service file, and its `GC_HOME` parses out of the rendered file and fails `os.Stat` with a clean not-exist. Empty values, parse failures, permission errors, and transient stat failures all leave the file alone. Sweep failures degrade to stderr warnings and never block install or uninstall.

`supervisorSystemdServiceName` now shares the `supervisorSystemdUnitPrefix` constant with the sweep so the unit naming cannot drift between the two.

Test plan:

- `TestSweepStaleIsolatedSupervisorLaunchdRemovesOnlyStale` / `TestSweepStaleIsolatedSupervisorSystemdRemovesOnlyStale`: stale suffixed services are removed while the default service, live-home services, and unparseable files survive.
- `TestSweepStaleIsolatedSupervisorSystemdNoStaleMakesNoSystemctlCalls`: a sweep with nothing stale issues no systemctl calls.
- `TestSweepStaleIsolatedSupervisorServicesMissingDirIsNoop`: a missing service directory is a no-op.
- `TestInstallSupervisorLaunchdSweepsStaleSiblings` / `TestUninstallSupervisorLaunchdSweepsStaleSiblings`: the sweep fires on the install and uninstall paths.
- `go build ./...`, `go vet ./...`, `go test ./cmd/gc` green.
