### PR TITLE
fix(cmd/gc): ignore expired pending pool creates

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/hooks"
@@ -2157,6 +2158,10 @@ func discoverSessionBeadsWithRoots(
 				!sessionAlreadyDesired && !templateDesired && !poolPartialAlive {
 				continue
 			}
+			if controllerManagedPool && !manualSession && !isNamedSessionBead(b) &&
+				!sessionAlreadyDesired && creating && !pendingCreate && isStaleCreating(b) && !scaleCheckPartial {
+				continue
+			}
 			if !manualSession && (!creating || isStaleCreating(b)) && !templateDesired && !pendingCreate && !scaleCheckPartial {
 				continue
 			}
@@ -2225,7 +2230,8 @@ func discoverSessionBeadsWithRoots(
 }
 
 func isPendingPoolCreate(b beads.Bead) bool {
-	return isPoolManagedSessionBead(b) && strings.TrimSpace(b.Metadata["pending_create_claim"]) == boolMetadata(true)
+	return isPoolManagedSessionBead(b) && strings.TrimSpace(b.Metadata["pending_create_claim"]) == boolMetadata(true) &&
+		pendingCreateLeaseActive(b, clock.Real{}, 0)
 }
 
 func realizeDependencyFloors(
@@ -3512,6 +3518,10 @@ func reusablePoolSessionBead(bp *agentBuildParams, cfgAgent *config.Agent, templ
 		return false
 	}
 	if isFailedCreateSessionBead(bead) {
+		return false
+	}
+	if strings.TrimSpace(bead.Metadata["pending_create_claim"]) == boolMetadata(true) &&
+		!pendingCreateLeaseActive(bead, clock.Real{}, 0) {
 		return false
 	}
 	if bead.Metadata["state"] == "asleep" {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -8521,6 +8521,73 @@ func TestBuildDesiredState_PendingCreatePoolSessionCountsTowardScaleDemand(t *te
 	}
 }
 
+func TestBuildDesiredState_ExpiredNeverStartedPendingCreateDoesNotConsumeScaleDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	const template = "worker"
+	now := time.Now().UTC()
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": template,
+		},
+	}); err != nil {
+		t.Fatalf("create queued work: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  template,
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker-1"},
+		Metadata: map[string]string{
+			"template":                  template,
+			"session_name":              "worker-mc-stale",
+			"agent_name":                "worker-1",
+			"session_origin":            "ephemeral",
+			"pool_managed":              boolMetadata(true),
+			"pool_slot":                 "1",
+			"pending_create_claim":      boolMetadata(true),
+			"pending_create_started_at": pendingCreateStartedAtNow(now.Add(-(pendingCreateNeverStartedTimeout + time.Second))),
+			"state":                     string(sessionpkg.StateStartPending),
+		},
+		CreatedAt: now.Add(-24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("create stale session bead: %v", err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              template,
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		}},
+	}
+	sessionSnapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("load session snapshot: %v", err)
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, now, cfg, runtime.NewFake(),
+		store, nil, sessionSnapshot, nil, io.Discard,
+	)
+
+	if _, ok := dsResult.State["worker-mc-stale"]; ok {
+		t.Fatalf("expired pending-create session stayed desired: keys=%v", mapKeys(dsResult.State))
+	}
+	for _, tp := range dsResult.State {
+		if tp.TemplateName != template {
+			continue
+		}
+		if tp.SessionName == "worker-mc-stale" {
+			t.Fatalf("expired pending-create session reused stale identity: %+v", tp)
+		}
+		return
+	}
+	t.Fatalf("expected fresh desired session for %s; keys=%v", template, mapKeys(dsResult.State))
+}
+
 func TestBuildDesiredState_LegacyAliaslessEphemeralPoolSessionFallsBackToSessionNameIdentity(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
@@ -411,8 +412,12 @@ func poolInFlightNewRequests(cfg *config.City, sessionBeads []beads.Bead, resume
 
 func poolSessionConsumesNewDemand(session beads.Bead) bool {
 	if strings.TrimSpace(session.Metadata["pending_create_claim"]) == boolMetadata(true) {
-		return true
+		return pendingCreateLeaseActive(session, clock.Real{}, 0)
 	}
+	return poolSessionConsumesResidualNewDemand(session)
+}
+
+func poolSessionConsumesResidualNewDemand(session beads.Bead) bool {
 	// This pure desired-state pass has no reconciler clock. Creating sessions
 	// still represent already-spent new demand; lifecycle code owns stale
 	// creating recovery with its clock-aware predicate.

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 func intPtr(n int) *int { return &n }
@@ -1256,6 +1257,25 @@ func TestComputePoolDesiredStates_StaleCreatingBeadStillConsumesNewDemand(t *tes
 	}
 	if got := result[0].Requests[0].SessionBeadID; got != stale.ID {
 		t.Fatalf("SessionBeadID = %q, want %q", got, stale.ID)
+	}
+}
+
+func TestComputePoolDesiredStates_ExpiredNeverStartedPendingCreateStopsConsumingDemand(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	now := time.Now().UTC()
+	stale := poolSessionBeadWithState("sess-stale", string(sessionpkg.StateStartPending), boolMetadata(true))
+	stale.CreatedAt = now.Add(-24 * time.Hour)
+	stale.Metadata["pending_create_started_at"] = pendingCreateStartedAtNow(now.Add(-(pendingCreateNeverStartedTimeout + time.Second)))
+
+	result := ComputePoolDesiredStates(cfg, nil, []beads.Bead{stale}, map[string]int{"claude": 1})
+
+	if len(result) != 1 || len(result[0].Requests) != 1 {
+		t.Fatalf("result = %#v, want one fresh demand request after stale lease expires", result)
+	}
+	if got := result[0].Requests[0].SessionBeadID; got != "" {
+		t.Fatalf("SessionBeadID = %q, want anonymous fresh demand request", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop expired never-started `pending_create_claim=true` pool session beads from consuming pool demand
- prevent expired pending-create pool session beads from being reused as fresh desired-state slots
- keep stale `creating` beads consuming demand where existing behavior expects that protection

## Root cause
When a dispatcher/provider died after claiming a pool create but before starting runtime, the session bead could remain `start-pending` with `pending_create_claim=true` past its lease. Desired-state planning still counted that bead as satisfying pool scale demand, and reuse logic could select it as a fresh slot. That blocked new worker spawn even though no runtime existed.

## Tests
- `go test ./cmd/gc -run 'TestComputePoolDesiredStates_ExpiredNeverStartedPendingCreateStopsConsumingDemand|TestBuildDesiredState_ExpiredNeverStartedPendingCreateDoesNotConsumeScaleDemand|TestBuildDesiredState_PendingCreatePoolSessionCountsTowardScaleDemand|TestComputePoolDesiredStates_StaleCreatingBeadStillConsumesNewDemand' -count=1`
- `go test ./cmd/gc -run 'TestReconcileSessionBeads_PreservesNeverStartedPendingCreateBeforeLeaseExpires|TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntime|TestReapStaleSessionBeads_NeverStartedPendingCreateNotReapedInPendingWindow|TestReapStaleSessionBeads_StartedPendingCreateReapedPastPendingGrace' -count=1`

Note: local pre-push `scripts/test-local-parallel fast` failed before push in the clean hook env with ICU linker errors (`undefined reference to uregex_*_76`). The targeted `./cmd/gc` regressions above pass in the repo shell.
