### PR TITLE
Bound status bd reads to request context

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1187,6 +1187,18 @@ func (cs *controllerState) CityBeadStore() beads.Store {
 	return cs.cityBeadStore
 }
 
+// ScopedStoreLike implements api.State. See the interface doc comment for
+// the contract; scopedStoreLike (cmd/gc/scoped_store.go) does the actual
+// unwrap-and-rebuild work, reusing the same credential/env resolution as
+// every other bd-CLI store this package constructs.
+func (cs *controllerState) ScopedStoreLike(ctx context.Context, existing beads.Store) (beads.Store, error) {
+	cs.mu.RLock()
+	cityPath := cs.cityPath
+	cfg := cs.cfg
+	cs.mu.RUnlock()
+	return scopedStoreLike(ctx, cityPath, cfg, existing)
+}
+
 // NudgesBeadStore returns the store backing the nudge-queue shadow beads. At the
 // default backend resolveNudgesStore returns cityBeadStore, so this is byte-identical
 // to CityBeadStore; when [beads.classes.nudges] is relocated it returns the per-class

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1246,7 +1246,18 @@ func cityPostgresProjectionErrorCanBeBypassed(cityPath string, err error) bool {
 }
 
 func bdRuntimeEnvForRigWithError(cityPath string, cfg *config.City, rigPath string) (map[string]string, error) {
-	env, cityErr := bdRuntimeEnvWithError(cityPath)
+	return bdRuntimeEnvForRigWithErrorRecovery(cityPath, cfg, rigPath, true)
+}
+
+// bdRuntimeEnvForRigWithErrorNoRecovery is bdRuntimeEnvForRigWithError
+// without the managed-dolt recovery side effects; see
+// bdRuntimeEnvWithErrorNoRecovery for why (gascity ga-cdmx6x).
+func bdRuntimeEnvForRigWithErrorNoRecovery(cityPath string, cfg *config.City, rigPath string) (map[string]string, error) {
+	return bdRuntimeEnvForRigWithErrorRecovery(cityPath, cfg, rigPath, false)
+}
+
+func bdRuntimeEnvForRigWithErrorRecovery(cityPath string, cfg *config.City, rigPath string, allowRecovery bool) (map[string]string, error) {
+	env, cityErr := bdRuntimeEnvWithErrorRecovery(cityPath, allowRecovery)
 	rigPath = filepath.Clean(rigPath)
 	// Pin the rig store explicitly. The gc-beads-bd provider derives its Dolt
 	// data root from GC_CITY_PATH unless BEADS_DIR is set, so cwd-based
@@ -1270,7 +1281,7 @@ func bdRuntimeEnvForRigWithError(cityPath string, cfg *config.City, rigPath stri
 		mirrorBeadsDoltEnv(env)
 		return env, nil
 	}
-	if err := applyResolvedRigDoltEnv(env, cityPath, rigPath, explicitRig, true); err != nil {
+	if err := applyResolvedRigDoltEnv(env, cityPath, rigPath, explicitRig, allowRecovery); err != nil {
 		clearProjectedDoltEnv(env)
 		clearProjectedPostgresEnv(env)
 		mirrorBeadsDoltEnv(env)
@@ -1301,6 +1312,23 @@ func nativeDoltOpenEnvForScope(cityPath string, cfg *config.City, scopeRoot stri
 }
 
 func bdRuntimeEnvWithError(cityPath string) (map[string]string, error) {
+	return bdRuntimeEnvWithErrorRecovery(cityPath, true)
+}
+
+// bdRuntimeEnvWithErrorNoRecovery is bdRuntimeEnvWithError without the
+// managed-dolt recovery/health-check/autostart side effects: it reads
+// existing published or configured connection state only, and fails fast
+// (env still gets the non-Dolt opt-out vars set) when no managed server is
+// currently reachable. Recovering a managed dolt server is legitimate
+// work, but doing it from every concurrent, short-budget scoped-store
+// construction would multiply exactly the load a read-storm mitigation
+// exists to bound (gascity ga-cdmx6x) — those callers use this instead of
+// bdRuntimeEnvWithError.
+func bdRuntimeEnvWithErrorNoRecovery(cityPath string) (map[string]string, error) {
+	return bdRuntimeEnvWithErrorRecovery(cityPath, false)
+}
+
+func bdRuntimeEnvWithErrorRecovery(cityPath string, allowRecovery bool) (map[string]string, error) {
 	env := cityRuntimeEnvMapForCity(cityPath)
 	env["BEADS_DIR"] = filepath.Join(cityPath, ".beads")
 	env["GC_RIG"] = ""
@@ -1353,7 +1381,7 @@ func bdRuntimeEnvWithError(cityPath string) (map[string]string, error) {
 	} else if usedPostgres {
 		return env, nil
 	}
-	if err := applyResolvedCityDoltEnv(env, cityPath, true); err != nil {
+	if err := applyResolvedCityDoltEnv(env, cityPath, allowRecovery); err != nil {
 		clearProjectedDoltEnv(env)
 		mirrorBeadsDoltEnv(env)
 		if isRecoverableManagedDoltEnvError(err) {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -318,6 +318,67 @@ func TestBdRuntimeEnvIncludesDoltHost(t *testing.T) {
 	}
 }
 
+// TestBdRuntimeEnvNoRecoveryMatchesRecoveryForExternalTarget proves the
+// NoRecovery variant (used by ga-cdmx6x's scoped throwaway stores) still
+// resolves an explicitly configured external Dolt target identically to
+// the recovery-allowing default — only the managed-dolt
+// recovery/health-check/autostart side effect is skipped, not the
+// ordinary external-config path.
+func TestBdRuntimeEnvNoRecoveryMatchesRecoveryForExternalTarget(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT_HOST", "mini2.hippo-tilapia.ts.net")
+	t.Setenv("GC_DOLT_PORT", "3307")
+	t.Setenv("GC_DOLT_USER", "agent")
+	t.Setenv("GC_DOLT_PASSWORD", "s3cret")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityPath := t.TempDir()
+	env, err := bdRuntimeEnvWithErrorNoRecovery(cityPath)
+	if err != nil {
+		t.Fatalf("bdRuntimeEnvWithErrorNoRecovery() error = %v", err)
+	}
+
+	if got := env["GC_DOLT_HOST"]; got != "mini2.hippo-tilapia.ts.net" {
+		t.Errorf("GC_DOLT_HOST = %q, want %q", got, "mini2.hippo-tilapia.ts.net")
+	}
+	if got := env["GC_DOLT_PORT"]; got != "3307" {
+		t.Errorf("GC_DOLT_PORT = %q, want %q", got, "3307")
+	}
+	if got := env["BEADS_DOLT_AUTO_START"]; got != "0" {
+		t.Errorf("BEADS_DOLT_AUTO_START = %q, want %q", got, "0")
+	}
+}
+
+// TestBdRuntimeEnvForRigNoRecoveryMatchesRecoveryForExternalTarget is
+// TestBdRuntimeEnvNoRecoveryMatchesRecoveryForExternalTarget for the
+// rig-scoped resolver.
+func TestBdRuntimeEnvForRigNoRecoveryMatchesRecoveryForExternalTarget(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT_HOST", "mini2.hippo-tilapia.ts.net")
+	t.Setenv("GC_DOLT_PORT", "3307")
+	t.Setenv("GC_DOLT_USER", "agent")
+	t.Setenv("GC_DOLT_PASSWORD", "s3cret")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "repo")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: "rigs/repo"}}}
+
+	env, err := bdRuntimeEnvForRigWithErrorNoRecovery(cityPath, cfg, rigPath)
+	if err != nil {
+		t.Fatalf("bdRuntimeEnvForRigWithErrorNoRecovery() error = %v", err)
+	}
+	if got := env["GC_DOLT_HOST"]; got != "mini2.hippo-tilapia.ts.net" {
+		t.Errorf("GC_DOLT_HOST = %q, want %q", got, "mini2.hippo-tilapia.ts.net")
+	}
+	if got := env["GC_RIG"]; got != "repo" {
+		t.Errorf("GC_RIG = %q, want repo", got)
+	}
+}
+
 func TestBdRuntimeEnvDisablesCLIRemoteSync(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("BD_DOLT_SYNC_CLI_REMOTES", "true")

--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -146,7 +146,7 @@ func buildCityStoreHealth(cityPath string, store beads.Store, stderr io.Writer) 
 }
 
 func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath string, store beads.Store, stderr io.Writer) cityStatusSnapshot {
-	return collectCityStatusSnapshotFromStoreSnapshot(sp, cfg, cityPath, store, loadStatusSessionSnapshot(store, stderr), stderr)
+	return collectCityStatusSnapshotFromStoreSnapshot(sp, cfg, cityPath, store, loadStatusSessionSnapshot(cityPath, cfg, store, stderr), stderr)
 }
 
 func collectCityStatusSnapshotFromStoreSnapshot(

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/processgroup/processgrouptest"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/suspensionstate"
@@ -53,7 +56,7 @@ func TestCityStatusNamedSessionsUseProvidedStore(t *testing.T) {
 	if snapshot.NamedSessions[0].Status != "materialized" {
 		t.Fatalf("named session status = %q, want materialized", snapshot.NamedSessions[0].Status)
 	}
-	code := doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, loadStatusSessionSnapshot(store, &stderr), &stdout, &stderr)
+	code := doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, loadStatusSessionSnapshot(cityPath, cfg, store, &stderr), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -162,7 +165,7 @@ func TestLoadStatusSessionSnapshotTimesOut(t *testing.T) {
 
 	var stderr bytes.Buffer
 	start := time.Now()
-	snapshot := loadStatusSessionSnapshot(store, &stderr)
+	snapshot := loadStatusSessionSnapshot("/city", &config.City{}, store, &stderr)
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("loadStatusSessionSnapshot elapsed %s, want bounded timeout", elapsed)
 	}
@@ -182,6 +185,55 @@ func TestLoadStatusSessionSnapshotTimesOut(t *testing.T) {
 	if !strings.Contains(loadErr.Error(), "timed out") {
 		t.Fatalf("snapshot.LoadError() = %v, want timeout text", loadErr)
 	}
+}
+
+// TestLoadStatusSessionSnapshotKillsBdChildOnTimeout is the ga-cdmx6x
+// regression test for `gc status`'s session-snapshot read: a bd child
+// spawned via the store loadStatusSessionSnapshot builds internally must
+// be killed when its budget expires, instead of surviving to
+// bdCommandTimeout the way the pre-fix abandon-the-goroutine pattern let
+// it. Mirrors TestScopedBdStoreForCityKillsChildOnCtxCancel's pidfile
+// pattern, driven through loadStatusSessionSnapshot itself so the whole
+// call site — not just scopedBdStoreForCity in isolation — is covered.
+func TestLoadStatusSessionSnapshotKillsBdChildOnTimeout(t *testing.T) {
+	processgrouptest.RequireRealProcessSignals(t)
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh unavailable")
+	}
+
+	oldTimeout := statusSessionSnapshotTimeout
+	statusSessionSnapshotTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { statusSessionSnapshotTimeout = oldTimeout })
+
+	cityDir := t.TempDir()
+	writeMinimalCityToml(t, cityDir)
+
+	binDir := t.TempDir()
+	pidFile := filepath.Join(binDir, "bd-child.pid")
+	writeExecutable(t, filepath.Join(binDir, "bd"), "#!/bin/sh\n"+
+		"sleep 30 &\n"+
+		"echo \"$!\" > "+pidFile+"\n"+
+		"wait\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	realStore := bdStoreForCity(cityDir, cityDir)
+
+	var stderr bytes.Buffer
+	start := time.Now()
+	_ = loadStatusSessionSnapshot(cityDir, &config.City{}, realStore, &stderr)
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("loadStatusSessionSnapshot blocked %s; want bounded by statusSessionSnapshotTimeout", elapsed)
+	}
+
+	childPid := waitForNonEmptyFileContent(t, pidFile, 5*time.Second)
+	for range 50 {
+		if err := exec.Command("kill", "-0", childPid).Run(); err != nil {
+			return // child is gone
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = exec.Command("kill", "-KILL", childPid).Run()
+	t.Fatalf("bd child process %s survived loadStatusSessionSnapshot's timeout", childPid)
 }
 
 // TestCityStatusNamedSessionSurfacesLookupErrorWhenSnapshotDegraded is the
@@ -610,7 +662,7 @@ func TestCityStatusNamedSessionsUseLoadedSnapshotWithoutGet(t *testing.T) {
 		t.Fatalf("snapshot named session status = %q, want materialized", got)
 	}
 
-	code := doCityStatusWithStoreAndSnapshot(sp, dops, cfg, "/home/user/city", store, loadStatusSessionSnapshot(store, &stderr), &stdout, &stderr)
+	code := doCityStatusWithStoreAndSnapshot(sp, dops, cfg, "/home/user/city", store, loadStatusSessionSnapshot("/home/user/city", cfg, store, &stderr), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -179,7 +180,7 @@ func cmdCityStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int
 		}
 		return code
 	}
-	statusSnapshot := loadStatusSessionSnapshot(store, stderr)
+	statusSnapshot := loadStatusSessionSnapshot(cityPath, cfg, store, stderr)
 	sp := newStatusSessionProviderForCityWithSnapshot(cfg, cityPath, statusSnapshot)
 	dops := newDrainOps(sp)
 	c, reason := cityStatusAPIClient(cityPath)
@@ -230,7 +231,7 @@ func routeCityStatus(
 	if code != 0 {
 		return code
 	}
-	statusSnapshot := loadStatusSessionSnapshot(store, stderr)
+	statusSnapshot := loadStatusSessionSnapshot(cityPath, cfg, store, stderr)
 	if jsonOutput {
 		return doCityStatusJSONWithDiagnosticAndSnapshot(sp, cfg, cityPath, store, diagnostic, statusSnapshot, stdout, stderr)
 	}
@@ -387,17 +388,36 @@ type statusObservationTarget struct {
 	suspended          bool
 }
 
-func loadStatusSessionSnapshot(store beads.Store, stderr io.Writer) *sessionBeadSnapshot {
+func loadStatusSessionSnapshot(cityPath string, cfg *config.City, store beads.Store, stderr io.Writer) *sessionBeadSnapshot {
 	if store == nil {
 		return newSessionBeadSnapshot(nil)
 	}
+
+	// A throwaway, ctx-bound clone of store when it's bd-CLI-backed: on
+	// timeout below, canceling reqCtx kills an in-flight bd child instead
+	// of abandoning it to run past this function's return (gascity
+	// ga-cdmx6x). scopedStoreLike answers (nil, nil) for non-bd-CLI
+	// backends, which have no subprocess to leak — those keep reading
+	// through store directly, unchanged.
+	reqCtx, cancel := context.WithTimeout(context.Background(), statusSessionSnapshotTimeout)
+	defer cancel()
+	readStore := store
+	if scoped, err := scopedStoreLike(reqCtx, cityPath, cfg, store); err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "gc status: loading session snapshot: resolving store: %v\n", err) //nolint:errcheck // best-effort stderr
+		}
+		return newSessionBeadSnapshotWithError(fmt.Errorf("loading session snapshot: resolving store: %w", err))
+	} else if scoped != nil {
+		readStore = scoped
+	}
+
 	type snapshotResult struct {
 		snapshot *sessionBeadSnapshot
 		err      error
 	}
 	done := make(chan snapshotResult, 1)
 	go func() {
-		snapshot, err := loadSessionBeadSnapshot(store)
+		snapshot, err := loadSessionBeadSnapshot(readStore)
 		done <- snapshotResult{snapshot: snapshot, err: err}
 	}()
 
@@ -478,7 +498,7 @@ func doCityStatus(
 	if code != 0 {
 		return code
 	}
-	return doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, loadStatusSessionSnapshot(store, stderr), stdout, stderr)
+	return doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, loadStatusSessionSnapshot(cityPath, cfg, store, stderr), stdout, stderr)
 }
 
 func doCityStatusWithStoreAndSnapshot(
@@ -528,7 +548,7 @@ func doCityStatusJSON(
 	if code != 0 {
 		return code
 	}
-	return doCityStatusJSONWithDiagnosticAndSnapshot(sp, cfg, cityPath, store, diagnostic, loadStatusSessionSnapshot(store, stderr), stdout, stderr)
+	return doCityStatusJSONWithDiagnosticAndSnapshot(sp, cfg, cityPath, store, diagnostic, loadStatusSessionSnapshot(cityPath, cfg, store, stderr), stdout, stderr)
 }
 
 func doCityStatusJSONWithDiagnosticAndSnapshot(

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -89,7 +89,7 @@ func cmdRigStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int 
 			store = opened
 		}
 	}
-	statusSnapshot := loadStatusSessionSnapshot(store, stderr)
+	statusSnapshot := loadStatusSessionSnapshot(cityPath, cfg, store, stderr)
 	sp := newStatusSessionProviderForCityWithSnapshot(cfg, cityPath, statusSnapshot)
 	dops := newDrainOps(sp)
 	c, reason := rigStatusAPIClient(cityPath)

--- a/cmd/gc/cmd_status_test.go
+++ b/cmd/gc/cmd_status_test.go
@@ -38,7 +38,7 @@ func runDoRigStatus(
 			store = opened
 		}
 	}
-	statusSnapshot := loadStatusSessionSnapshot(store, stderr)
+	statusSnapshot := loadStatusSessionSnapshot(cityPath, nil, store, stderr)
 	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, agents, cityPath, "city", "", nil, store, statusSnapshot, false, stdout, stderr)
 }
 

--- a/cmd/gc/scoped_store.go
+++ b/cmd/gc/scoped_store.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// scopedBdStoreForCity returns a throwaway BdStore for cityPath whose bd
+// subprocess is bound to ctx: on cancellation the child is killed instead
+// of surviving past the caller's own budget, unlike the long-lived shared
+// store, whose runner is fixed to context.Background() at construction.
+// Reuses the same credential/env resolution as bdStoreForCity, minus
+// managed-dolt recovery (bdRuntimeEnvWithErrorNoRecovery, not
+// bdRuntimeEnvWithError): a short best-effort read should fail fast
+// rather than pay a multi-second recovery/health-check/autostart sequence
+// — and every concurrent scoped-store construction attempting that
+// recovery would multiply exactly the load a read-storm mitigation exists
+// to bound. Skips the managed-retry wrapper for the same reason (gascity
+// ga-cdmx6x).
+func scopedBdStoreForCity(ctx context.Context, cityPath string) (*beads.BdStore, error) {
+	env, err := bdRuntimeEnvWithErrorNoRecovery(cityPath)
+	if err != nil {
+		return nil, err
+	}
+	return beads.NewBdStore(cityPath, beads.ExecCommandRunnerWithEnvContext(ctx, env)), nil
+}
+
+// scopedBdStoreForRig is scopedBdStoreForCity for a rig-scoped store.
+func scopedBdStoreForRig(ctx context.Context, cityPath string, cfg *config.City, rigDir string) (*beads.BdStore, error) {
+	env, err := bdRuntimeEnvForRigWithErrorNoRecovery(cityPath, cfg, rigDir)
+	if err != nil {
+		return nil, err
+	}
+	return beads.NewBdStore(rigDir, beads.ExecCommandRunnerWithEnvContext(ctx, env)), nil
+}
+
+// bdStoreBacking unwraps store through any CachingStore/beadPolicyStore
+// layers to find the underlying *beads.BdStore. It returns ok=false for
+// stores that aren't bd-CLI-backed (native, file, exec, mem, ...) — those
+// have no subprocess to leak, so ga-cdmx6x's mitigation doesn't apply to
+// them. Bounded to a handful of iterations: real store stacks are at most
+// two layers deep (CachingStore wrapping a beadPolicyStore wrapping the
+// raw store); the bound just guards against an unexpected wrap cycle.
+func bdStoreBacking(store beads.Store) (*beads.BdStore, bool) {
+	for range 8 {
+		switch v := store.(type) {
+		case *beads.BdStore:
+			return v, v != nil
+		case *beads.CachingStore:
+			if v == nil {
+				return nil, false
+			}
+			backing := v.Backing()
+			if backing == nil {
+				return nil, false
+			}
+			store = backing
+			continue
+		}
+		if inner, _, ok := unwrapBeadPolicyStore(store); ok {
+			store = inner
+			continue
+		}
+		return nil, false
+	}
+	return nil, false
+}
+
+// scopedStoreLike returns a throwaway, ctx-bound clone of existing when
+// existing is (or wraps, via CachingStore/beadPolicyStore) a bd-CLI-shell
+// backed store: cancellation kills the backend bd subprocess instead of
+// abandoning it past ctx's deadline. Returns (nil, nil) when existing is
+// not bd-CLI backed — callers should keep reading through existing
+// directly in that case (gascity ga-cdmx6x).
+func scopedStoreLike(ctx context.Context, cityPath string, cfg *config.City, existing beads.Store) (beads.Store, error) {
+	bs, ok := bdStoreBacking(existing)
+	if !ok {
+		return nil, nil
+	}
+	dir := bs.Dir()
+	if samePath(dir, cityPath) {
+		return scopedBdStoreForCity(ctx, cityPath)
+	}
+	return scopedBdStoreForRig(ctx, cityPath, cfg, dir)
+}

--- a/cmd/gc/scoped_store_test.go
+++ b/cmd/gc/scoped_store_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/processgroup/processgrouptest"
+)
+
+func noopBdRunner() beads.CommandRunner {
+	return func(string, string, ...string) ([]byte, error) {
+		return nil, nil
+	}
+}
+
+func TestBdStoreBackingFindsDirectBdStore(t *testing.T) {
+	store := beads.NewBdStore("/city", noopBdRunner())
+	got, ok := bdStoreBacking(store)
+	if !ok || got != store {
+		t.Fatalf("bdStoreBacking() = (%p, %v), want (%p, true)", got, ok, store)
+	}
+}
+
+func TestBdStoreBackingUnwrapsCachingStore(t *testing.T) {
+	inner := beads.NewBdStore("/city", noopBdRunner())
+	cached := beads.NewCachingStoreForTest(inner, nil)
+	got, ok := bdStoreBacking(cached)
+	if !ok || got != inner {
+		t.Fatalf("bdStoreBacking() = (%p, %v), want (%p, true)", got, ok, inner)
+	}
+}
+
+// TestBdStoreBackingUnwrapsCachingAndPolicyLayers mirrors the real
+// production nesting order: openRigStore/openStoreResultAtForCity wrap the
+// raw store with wrapStoreWithBeadPolicies, then buildStores/newControllerState
+// wrap that again with CachingStore. bdStoreBacking must see through both
+// layers to reach the *beads.BdStore whose subprocess ga-cdmx6x is about.
+func TestBdStoreBackingUnwrapsCachingAndPolicyLayers(t *testing.T) {
+	inner := beads.NewBdStore("/city", noopBdRunner())
+	policyWrapped := wrapStoreWithBeadPolicies(inner, &config.City{})
+	cached := beads.NewCachingStoreForTest(policyWrapped, nil)
+	got, ok := bdStoreBacking(cached)
+	if !ok || got != inner {
+		t.Fatalf("bdStoreBacking() = (%p, %v), want (%p, true)", got, ok, inner)
+	}
+}
+
+func TestBdStoreBackingReturnsFalseForNonBdStore(t *testing.T) {
+	if got, ok := bdStoreBacking(beads.NewMemStore()); ok {
+		t.Fatalf("bdStoreBacking() = (%v, true), want ok=false for a MemStore", got)
+	}
+}
+
+func TestBdStoreBackingReturnsFalseForNil(t *testing.T) {
+	if _, ok := bdStoreBacking(nil); ok {
+		t.Fatal("bdStoreBacking(nil) ok = true, want false")
+	}
+}
+
+// TestScopedStoreLikeReturnsNilForNonBdBackedStore proves the mitigation
+// leaves non-bd-CLI backends (native, file, exec, mem) untouched — they
+// have no subprocess to leak, so callers should keep reading through the
+// existing store rather than pay for (or risk breaking) a reconstruction.
+func TestScopedStoreLikeReturnsNilForNonBdBackedStore(t *testing.T) {
+	scoped, err := scopedStoreLike(context.Background(), "/city", &config.City{}, beads.NewMemStore())
+	if err != nil {
+		t.Fatalf("scopedStoreLike: %v", err)
+	}
+	if scoped != nil {
+		t.Fatalf("scopedStoreLike() = %v, want nil for a non-bd-backed store", scoped)
+	}
+}
+
+// TestScopedStoreLikeSelectsCityScopeWhenDirMatchesCityPath proves the
+// city/rig branch selection: when the backing BdStore's dir equals
+// cityPath, the clone must be built via the city-level env resolution
+// (scopedBdStoreForCity), not the rig-level one.
+func TestScopedStoreLikeSelectsCityScopeWhenDirMatchesCityPath(t *testing.T) {
+	cityDir := t.TempDir()
+	writeMinimalCityToml(t, cityDir)
+	existing := beads.NewBdStore(cityDir, noopBdRunner())
+
+	scoped, err := scopedStoreLike(context.Background(), cityDir, &config.City{}, existing)
+	if err != nil {
+		t.Fatalf("scopedStoreLike: %v", err)
+	}
+	bs, ok := scoped.(*beads.BdStore)
+	if !ok {
+		t.Fatalf("scopedStoreLike() = %T, want *beads.BdStore", scoped)
+	}
+	if got := bs.Dir(); got != cityDir {
+		t.Fatalf("scoped store Dir() = %q, want city path %q", got, cityDir)
+	}
+}
+
+// TestScopedStoreLikeSelectsRigScopeWhenDirIsARig proves the rig branch:
+// when the backing BdStore's dir is a rig root (not the city root), the
+// clone is built via the rig-level env resolution (scopedBdStoreForRig),
+// pointed at the rig's own dir.
+func TestScopedStoreLikeSelectsRigScopeWhenDirIsARig(t *testing.T) {
+	cityDir := t.TempDir()
+	writeMinimalCityToml(t, cityDir)
+	rigDir := filepath.Join(cityDir, "rigs", "repo")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: "rigs/repo"}}}
+	existing := beads.NewBdStore(rigDir, noopBdRunner())
+
+	scoped, err := scopedStoreLike(context.Background(), cityDir, cfg, existing)
+	if err != nil {
+		t.Fatalf("scopedStoreLike: %v", err)
+	}
+	bs, ok := scoped.(*beads.BdStore)
+	if !ok {
+		t.Fatalf("scopedStoreLike() = %T, want *beads.BdStore", scoped)
+	}
+	if got := bs.Dir(); got != rigDir {
+		t.Fatalf("scoped store Dir() = %q, want rig dir %q", got, rigDir)
+	}
+}
+
+// TestScopedStoreLikeAvoidsManagedDoltRecovery is a regression test: an
+// earlier version of scopedBdStoreForCity/scopedBdStoreForRig called
+// bdRuntimeEnvWithError/bdRuntimeEnvForRigWithError (allowRecovery=true),
+// which — the first time a city's bd-CLI store is constructed and no
+// managed dolt server is yet running — spawns and waits on a real `dolt
+// sql-server` before returning env, taking 10+ seconds. That defeats "fast
+// bounded mitigation" and, worse, means every concurrent short-budget
+// status read would each attempt that recovery simultaneously during
+// exactly the kind of incident this bead exists to bound.
+// scopedBdStoreForCity/scopedBdStoreForRig must stay on the NoRecovery env
+// resolution so this path is fast-fail, not fast-fix, when no managed
+// server is reachable.
+func TestScopedStoreLikeAvoidsManagedDoltRecovery(t *testing.T) {
+	cityDir := t.TempDir()
+	writeMinimalCityToml(t, cityDir)
+
+	// bdStoreForCity mirrors how the real shared store gets constructed at
+	// controller/CLI startup; its first call materializes
+	// .gc/scripts/gc-beads-bd.sh, which is what made a later env
+	// resolution believe a managed dolt server ought to exist and attempt
+	// to start/recover one.
+	realStore := bdStoreForCity(cityDir, cityDir)
+
+	start := time.Now()
+	scoped, err := scopedStoreLike(context.Background(), cityDir, &config.City{}, realStore)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("scopedStoreLike took %s, want fast (no managed-dolt recovery attempt)", elapsed)
+	}
+	if err != nil {
+		t.Fatalf("scopedStoreLike: %v", err)
+	}
+	if _, ok := scoped.(*beads.BdStore); !ok {
+		t.Fatalf("scopedStoreLike() = %T, want *beads.BdStore", scoped)
+	}
+}
+
+// TestScopedBdStoreForCityKillsChildOnCtxCancel is the ga-cdmx6x regression
+// test: proves a bd child spawned through scopedBdStoreForCity is killed
+// when ctx is canceled, instead of surviving to bdCommandTimeout the way
+// the long-lived context.Background()-bound shared store's child would.
+// Mirrors TestKillCommandTreeKillsProcessGroup's pidfile pattern
+// (internal/beads/bdstore_exec_internal_test.go), applied through the real
+// scopedBdStoreForCity construction path instead of a bare exec.Command.
+func TestScopedBdStoreForCityKillsChildOnCtxCancel(t *testing.T) {
+	processgrouptest.RequireRealProcessSignals(t)
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh unavailable")
+	}
+
+	cityDir := t.TempDir()
+	writeMinimalCityToml(t, cityDir)
+
+	binDir := t.TempDir()
+	pidFile := filepath.Join(binDir, "bd-child.pid")
+	writeExecutable(t, filepath.Join(binDir, "bd"), "#!/bin/sh\n"+
+		"sleep 30 &\n"+
+		"echo \"$!\" > "+pidFile+"\n"+
+		"wait\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	store, err := scopedBdStoreForCity(ctx, cityDir)
+	if err != nil {
+		t.Fatalf("scopedBdStoreForCity: %v", err)
+	}
+
+	start := time.Now()
+	if _, listErr := store.List(beads.ListQuery{AllowScan: true}); listErr == nil {
+		t.Fatal("List unexpectedly succeeded against a sleeping bd stub")
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("List blocked %s; the 200ms ctx deadline was not honored", elapsed)
+	}
+
+	childPid := waitForNonEmptyFileContent(t, pidFile, 5*time.Second)
+	for range 50 {
+		if err := exec.Command("kill", "-0", childPid).Run(); err != nil {
+			return // child is gone
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = exec.Command("kill", "-KILL", childPid).Run()
+	t.Fatalf("bd child process %s survived scopedBdStoreForCity's ctx cancellation", childPid)
+}
+
+func waitForNonEmptyFileContent(t *testing.T, path string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil && len(strings.TrimSpace(string(data))) > 0 {
+			return strings.TrimSpace(string(data))
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s to be written", path)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/api/fake_state_test.go
+++ b/internal/api/fake_state_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -56,6 +57,11 @@ type fakeState struct {
 	extmsgSvc         *extmsg.Services
 	adapterReg        *extmsg.AdapterRegistry
 	maintenance       MaintenanceProvider
+	// scopedStoreFn backs ScopedStoreLike. Nil (the default) returns
+	// (nil, nil) — "existing isn't bd-CLI backed, keep using it directly" —
+	// matching the real implementation's answer for the MemStore fakes most
+	// tests use.
+	scopedStoreFn func(ctx context.Context, existing beads.Store) (beads.Store, error)
 }
 
 func newFakeState(t testing.TB) *fakeState {
@@ -108,6 +114,13 @@ func (f *fakeState) StartedAt() time.Time                  { return f.startedAt 
 func (f *fakeState) IsQuarantined(sessionName string) bool { return f.quarantined[sessionName] }
 func (f *fakeState) ClearCrashHistory(sessionName string)  { delete(f.quarantined, sessionName) }
 func (f *fakeState) CityBeadStore() beads.Store            { return f.cityBeadStore }
+func (f *fakeState) ScopedStoreLike(ctx context.Context, existing beads.Store) (beads.Store, error) {
+	if f.scopedStoreFn == nil {
+		return nil, nil
+	}
+	return f.scopedStoreFn(ctx, existing)
+}
+
 func (f *fakeState) NudgesBeadStore() beads.NudgesStore {
 	if f.nudgesBeadStore != nil {
 		return beads.NudgesStore{Store: f.nudgesBeadStore}

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -124,7 +124,7 @@ func (s *Server) buildStatusBody(ctx context.Context, lite bool) StatusBody {
 	sp := s.state.SessionProvider()
 	cityName := s.state.CityName()
 	sessTmpl := cfg.Workspace.SessionTemplate
-	sessionSnapshot := s.statusSessionSnapshot()
+	sessionSnapshot := s.statusSessionSnapshot(ctx)
 	partialErrors := append([]string(nil), sessionSnapshot.partialErrors...)
 
 	citySt, _ := suspensionstate.Load(fsys.OSFS{}, s.state.CityPath())
@@ -285,7 +285,7 @@ func (s *Server) buildStatusBody(ctx context.Context, lite bool) StatusBody {
 	// sub-cache). Omitted in lite mode so a cold lite poll never triggers it.
 	var storeHealth *StatusStoreHealth
 	if !lite {
-		storeHealth = s.cachedStoreHealth(time.Now())
+		storeHealth = s.cachedStoreHealth(ctx, time.Now())
 	}
 
 	return StatusBody{
@@ -436,7 +436,7 @@ type statusSessionInfo struct {
 	state       session.State
 }
 
-func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
+func (s *Server) statusSessionSnapshot(ctx context.Context) statusSessionSnapshot {
 	snapshot := statusSessionSnapshot{
 		bySessionName: make(map[string]statusSessionInfo),
 		byTemplate:    make(map[string][]statusSessionInfo),
@@ -446,6 +446,22 @@ func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
 		return snapshot
 	}
 
+	// A throwaway, ctx-bound clone of store when it's bd-CLI-backed: on
+	// timeout below, canceling reqCtx kills an in-flight bd child instead
+	// of abandoning it to run past this function's return (gascity
+	// ga-cdmx6x). ScopedStoreLike answers (nil, nil) for non-bd-CLI
+	// backends, which have no subprocess to leak — those keep reading
+	// through store directly, unchanged.
+	reqCtx, cancel := context.WithTimeout(ctx, statusStoreReadTimeout)
+	defer cancel()
+	readStore := store
+	if scoped, err := s.state.ScopedStoreLike(reqCtx, store); err != nil {
+		snapshot.partialErrors = []string{fmt.Sprintf("sessions: resolving scoped store: %v", err)}
+		return snapshot
+	} else if scoped != nil {
+		readStore = scoped
+	}
+
 	type snapshotResult struct {
 		rows          []beads.Bead
 		partialErrors []string
@@ -453,7 +469,7 @@ func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
 	}
 	done := make(chan snapshotResult, 1)
 	go func() {
-		rows, partialErrors, err := sessionReadModelRows(store)
+		rows, partialErrors, err := sessionReadModelRows(readStore)
 		done <- snapshotResult{rows: rows, partialErrors: partialErrors, err: err}
 	}()
 
@@ -532,7 +548,7 @@ func (s *Server) statusWorkCounts(ctx context.Context) (workCounts, []string) {
 		wg.Add(1)
 		go func(i int, rigName string, store beads.Store) {
 			defer wg.Done()
-			results[i] = statusStoreWorkCounts(ctx, rigName, store)
+			results[i] = statusStoreWorkCounts(ctx, s.state, rigName, store)
 		}(i, rigName, stores[rigName])
 	}
 	wg.Wait()
@@ -552,7 +568,7 @@ func (s *Server) statusWorkCounts(ctx context.Context) (workCounts, []string) {
 // hydration-free Counter path. Operational count failures (timeouts,
 // connection errors) report a partial error without retrying via List —
 // the List scan would hit the same backend and pay the timeout again.
-func statusStoreWorkCounts(ctx context.Context, rigName string, store beads.Store) statusWorkResult {
+func statusStoreWorkCounts(ctx context.Context, state State, rigName string, store beads.Store) statusWorkResult {
 	if counter, ok := store.(beads.Counter); ok {
 		wc, err := statusCountWork(ctx, counter)
 		if err == nil {
@@ -563,7 +579,7 @@ func statusStoreWorkCounts(ctx context.Context, rigName string, store beads.Stor
 		}
 	}
 
-	list, err := statusListStoreWithTimeout(store, beads.ListQuery{AllowScan: true})
+	list, err := statusListStoreWithTimeout(ctx, state, store, beads.ListQuery{AllowScan: true})
 	var result statusWorkResult
 	if err != nil {
 		result.errs = append(result.errs, fmt.Sprintf("rig %s work: %v", rigName, err))
@@ -616,12 +632,22 @@ func statusCountWork(ctx context.Context, counter beads.Counter) (workCounts, er
 
 // statusListStoreWithTimeout lists with the per-store read timeout.
 // Store.List takes no context, so on timeout the goroutine is abandoned
-// (it keeps its connection until the scan returns). Counter-capable
-// stores avoid this path entirely; fixing it for the remaining stores
-// requires plumbing context through Store.List.
-func statusListStoreWithTimeout(store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {
+// (it keeps its connection until the scan returns) — unless state offers a
+// ctx-bound scoped clone of store (bd-CLI-backed stores do; native/file/mem
+// stores don't and are read unchanged), in which case cancellation kills
+// the in-flight backend command instead of abandoning it (gascity
+// ga-cdmx6x). Counter-capable stores avoid this path entirely.
+func statusListStoreWithTimeout(ctx context.Context, state State, store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {
 	if store == nil {
 		return nil, nil
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, statusStoreReadTimeout)
+	defer cancel()
+	readStore := store
+	if scoped, err := state.ScopedStoreLike(reqCtx, store); err != nil {
+		return nil, fmt.Errorf("resolving scoped store: %w", err)
+	} else if scoped != nil {
+		readStore = scoped
 	}
 	type listResult struct {
 		rows []beads.Bead
@@ -629,7 +655,7 @@ func statusListStoreWithTimeout(store beads.Store, query beads.ListQuery) ([]bea
 	}
 	done := make(chan listResult, 1)
 	go func() {
-		rows, err := store.List(query)
+		rows, err := readStore.List(query)
 		done <- listResult{rows: rows, err: err}
 	}()
 	select {

--- a/internal/api/handler_status_scoped_store_test.go
+++ b/internal/api/handler_status_scoped_store_test.go
@@ -1,0 +1,286 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/processgroup/processgrouptest"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+func newSessionBead(sessionName string) beads.Bead {
+	return beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateActive),
+			"template":     "myrig/worker",
+			"session_name": sessionName,
+		},
+	}
+}
+
+// TestStatusSessionSnapshotUsesScopedStoreWhenAvailable proves
+// statusSessionSnapshot reads through state.ScopedStoreLike's result
+// instead of the shared CityBeadStore when one is available — the shared
+// store here carries a bead that must NOT show up in the snapshot.
+func TestStatusSessionSnapshotUsesScopedStoreWhenAvailable(t *testing.T) {
+	shared := beads.NewMemStore()
+	if _, err := shared.Create(newSessionBead("shared-session")); err != nil {
+		t.Fatalf("Create shared session bead: %v", err)
+	}
+	scoped := beads.NewMemStore()
+	if _, err := scoped.Create(newSessionBead("scoped-session")); err != nil {
+		t.Fatalf("Create scoped session bead: %v", err)
+	}
+
+	state := newFakeState(t)
+	state.cityBeadStore = shared
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		return scoped, nil
+	}
+	s := &Server{state: state}
+
+	snapshot := s.statusSessionSnapshot(context.Background())
+
+	if _, ok := snapshot.bySessionName["scoped-session"]; !ok {
+		t.Errorf("snapshot missing scoped-session; bySessionName = %+v, want the scoped store's read used", snapshot.bySessionName)
+	}
+	if _, ok := snapshot.bySessionName["shared-session"]; ok {
+		t.Error("snapshot contains shared-session, want the shared store bypassed in favor of the scoped one")
+	}
+}
+
+// TestStatusSessionSnapshotFallsBackWhenScopedStoreUnavailable pins the
+// pre-ga-cdmx6x behavior for non-bd-CLI-backed stores (native, file, mem):
+// when ScopedStoreLike answers (nil, nil), the read goes through the
+// shared store exactly as before.
+func TestStatusSessionSnapshotFallsBackWhenScopedStoreUnavailable(t *testing.T) {
+	shared := beads.NewMemStore()
+	if _, err := shared.Create(newSessionBead("shared-session")); err != nil {
+		t.Fatalf("Create shared session bead: %v", err)
+	}
+
+	state := newFakeState(t)
+	state.cityBeadStore = shared
+	// scopedStoreFn left nil: defaults to (nil, nil), matching the real
+	// ScopedStoreLike's answer for a MemStore-backed shared store.
+	s := &Server{state: state}
+
+	snapshot := s.statusSessionSnapshot(context.Background())
+
+	if _, ok := snapshot.bySessionName["shared-session"]; !ok {
+		t.Errorf("snapshot missing shared-session; bySessionName = %+v, want fallback to the shared store", snapshot.bySessionName)
+	}
+}
+
+// TestStatusSessionSnapshotSurfacesScopedStoreResolutionError proves a
+// ScopedStoreLike failure (e.g. Dolt credential resolution) surfaces as a
+// "sessions:" partial error instead of silently degrading or panicking.
+func TestStatusSessionSnapshotSurfacesScopedStoreResolutionError(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		return nil, errors.New("resolving dolt credentials: boom")
+	}
+	s := &Server{state: state}
+
+	snapshot := s.statusSessionSnapshot(context.Background())
+
+	if len(snapshot.partialErrors) == 0 {
+		t.Fatal("partialErrors empty, want the scoped-store resolution error surfaced")
+	}
+	joined := strings.Join(snapshot.partialErrors, "; ")
+	if !strings.Contains(joined, "sessions:") || !strings.Contains(joined, "boom") {
+		t.Fatalf("partialErrors = %v, want a sessions: ...boom entry", snapshot.partialErrors)
+	}
+}
+
+// TestStatusSessionSnapshotKillsBdChildOnTimeout is the ga-cdmx6x
+// regression test for the API-side call site: statusSessionSnapshot must
+// bind whatever ScopedStoreLike hands back to a request-scoped ctx tightly
+// enough that a slow bd child is killed instead of surviving past the
+// caller's budget. ScopedStoreLike here builds a real ctx-bound BdStore
+// (mirroring what cmd/gc's scopedStoreLike does in production) pointed at
+// a fake `bd` that backgrounds a long sleep and records its PID, proving
+// the ctx statusSessionSnapshot constructs actually propagates end to end.
+func TestStatusSessionSnapshotKillsBdChildOnTimeout(t *testing.T) {
+	processgrouptest.RequireRealProcessSignals(t)
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh unavailable")
+	}
+
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	binDir := t.TempDir()
+	pidFile := filepath.Join(binDir, "bd-child.pid")
+	writeExecutableScopedTest(t, filepath.Join(binDir, "bd"), "#!/bin/sh\n"+
+		"sleep 30 &\n"+
+		"echo \"$!\" > "+pidFile+"\n"+
+		"wait\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.scopedStoreFn = func(ctx context.Context, _ beads.Store) (beads.Store, error) {
+		return beads.NewBdStore(t.TempDir(), beads.ExecCommandRunnerWithEnvContext(ctx, nil)), nil
+	}
+	s := &Server{state: state}
+
+	start := time.Now()
+	_ = s.statusSessionSnapshot(context.Background())
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("statusSessionSnapshot blocked %s; want bounded by statusStoreReadTimeout", elapsed)
+	}
+
+	childPid := waitForNonEmptyFileScopedTest(t, pidFile, 5*time.Second)
+	for range 50 {
+		if err := exec.Command("kill", "-0", childPid).Run(); err != nil {
+			return // child is gone
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = exec.Command("kill", "-KILL", childPid).Run()
+	t.Fatalf("bd child process %s survived statusSessionSnapshot's timeout", childPid)
+}
+
+// TestStatusListStoreWithTimeoutUsesScopedStoreWhenAvailable proves the
+// per-rig work-count fallback (statusListStoreWithTimeout, reached when a
+// store isn't Counter-capable) reads through state.ScopedStoreLike's
+// result instead of the store it was handed, when one is available.
+func TestStatusListStoreWithTimeoutUsesScopedStoreWhenAvailable(t *testing.T) {
+	shared := beads.NewMemStore()
+	if _, err := shared.Create(beads.Bead{Type: "task", Title: "shared work", Status: "open"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	scoped := beads.NewMemStore()
+	if _, err := scoped.Create(beads.Bead{Type: "task", Title: "scoped work 1", Status: "open"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := scoped.Create(beads.Bead{Type: "task", Title: "scoped work 2", Status: "open"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	state := newFakeState(t)
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		return scoped, nil
+	}
+
+	rows, err := statusListStoreWithTimeout(context.Background(), state, shared, beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("statusListStoreWithTimeout: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2 from the scoped store (the shared store has only 1)", len(rows))
+	}
+}
+
+// TestStatusListStoreWithTimeoutFallsBackWhenScopedStoreUnavailable pins
+// the pre-ga-cdmx6x behavior: when ScopedStoreLike answers (nil, nil), the
+// read goes through the store it was handed, exactly as before.
+func TestStatusListStoreWithTimeoutFallsBackWhenScopedStoreUnavailable(t *testing.T) {
+	shared := beads.NewMemStore()
+	if _, err := shared.Create(beads.Bead{Type: "task", Title: "shared work", Status: "open"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	state := newFakeState(t)
+
+	rows, err := statusListStoreWithTimeout(context.Background(), state, shared, beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("statusListStoreWithTimeout: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1 from the fallback store", len(rows))
+	}
+}
+
+// TestStatusListStoreWithTimeoutSurfacesScopedStoreResolutionError proves
+// a ScopedStoreLike failure surfaces as an error instead of silently
+// falling back or panicking — statusStoreWorkCounts already formats
+// whatever error this returns into a "rig %s work: ..." partial error.
+func TestStatusListStoreWithTimeoutSurfacesScopedStoreResolutionError(t *testing.T) {
+	state := newFakeState(t)
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		return nil, errors.New("resolving dolt credentials: boom")
+	}
+
+	_, err := statusListStoreWithTimeout(context.Background(), state, beads.NewMemStore(), beads.ListQuery{AllowScan: true})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("statusListStoreWithTimeout error = %v, want it to contain the resolution error", err)
+	}
+}
+
+// TestStatusListStoreWithTimeoutKillsBdChildOnTimeout is the ga-cdmx6x
+// regression test for the per-rig work-count call site: mirrors
+// TestStatusSessionSnapshotKillsBdChildOnTimeout, but through
+// statusListStoreWithTimeout directly.
+func TestStatusListStoreWithTimeoutKillsBdChildOnTimeout(t *testing.T) {
+	processgrouptest.RequireRealProcessSignals(t)
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh unavailable")
+	}
+
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	binDir := t.TempDir()
+	pidFile := filepath.Join(binDir, "bd-child.pid")
+	writeExecutableScopedTest(t, filepath.Join(binDir, "bd"), "#!/bin/sh\n"+
+		"sleep 30 &\n"+
+		"echo \"$!\" > "+pidFile+"\n"+
+		"wait\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	state := newFakeState(t)
+	state.scopedStoreFn = func(ctx context.Context, _ beads.Store) (beads.Store, error) {
+		return beads.NewBdStore(t.TempDir(), beads.ExecCommandRunnerWithEnvContext(ctx, nil)), nil
+	}
+
+	start := time.Now()
+	_, _ = statusListStoreWithTimeout(context.Background(), state, beads.NewMemStore(), beads.ListQuery{AllowScan: true})
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("statusListStoreWithTimeout blocked %s; want bounded by statusStoreReadTimeout", elapsed)
+	}
+
+	childPid := waitForNonEmptyFileScopedTest(t, pidFile, 5*time.Second)
+	for range 50 {
+		if err := exec.Command("kill", "-0", childPid).Run(); err != nil {
+			return // child is gone
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = exec.Command("kill", "-KILL", childPid).Run()
+	t.Fatalf("bd child process %s survived statusListStoreWithTimeout's timeout", childPid)
+}
+
+func writeExecutableScopedTest(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func waitForNonEmptyFileScopedTest(t *testing.T, path string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil && len(strings.TrimSpace(string(data))) > 0 {
+			return strings.TrimSpace(string(data))
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s to be written", path)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -82,7 +82,7 @@ type Server struct {
 	storeHealthMu       sync.Mutex
 	storeHealthEntry    *StatusStoreHealth
 	storeHealthExpires  time.Time
-	storeHealthComputer func() *StatusStoreHealth
+	storeHealthComputer func(ctx context.Context) *StatusStoreHealth
 
 	// componentVersions caches the dolt engine and bd CLI versions the
 	// supervisor drives for /v0/status. Binary versions are immutable for

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -107,6 +107,21 @@ type State interface {
 	// Returns nil if no store is available.
 	CityBeadStore() beads.Store
 
+	// ScopedStoreLike returns a throwaway, ctx-bound clone of existing when
+	// existing is (or wraps) a bd-CLI-shell-backed store: cancellation kills
+	// the backend bd subprocess instead of abandoning it to run past ctx's
+	// deadline, unlike existing's own long-lived runner (fixed to
+	// context.Background() at construction). Returns (nil, nil) when
+	// existing is not bd-CLI backed (e.g. a native, file, or in-memory
+	// store) — those have no subprocess to leak, so callers should keep
+	// reading through existing directly in that case.
+	//
+	// Read paths with their own short request budget (e.g. GET /status) use
+	// this instead of reading through the shared store so a slow bd command
+	// cannot pin a Dolt connection past the caller's own deadline
+	// (gascity ga-cdmx6x).
+	ScopedStoreLike(ctx context.Context, existing beads.Store) (beads.Store, error)
+
 	// NudgesBeadStore returns the store backing the nudge-queue shadow beads
 	// (gc:nudge). At the default backend this is the same store as
 	// CityBeadStore; when [beads.classes.nudges] is relocated it is the

--- a/internal/api/store_health.go
+++ b/internal/api/store_health.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -15,7 +16,7 @@ const storeHealthCacheTTL = 30 * time.Second
 
 // cachedStoreHealth returns the memoized StoreHealth block, refreshing
 // when the TTL has elapsed. Safe for concurrent callers.
-func (s *Server) cachedStoreHealth(now time.Time) *StatusStoreHealth {
+func (s *Server) cachedStoreHealth(ctx context.Context, now time.Time) *StatusStoreHealth {
 	s.storeHealthMu.Lock()
 	if s.storeHealthEntry != nil && now.Before(s.storeHealthExpires) {
 		entry := s.storeHealthEntry
@@ -28,7 +29,7 @@ func (s *Server) cachedStoreHealth(now time.Time) *StatusStoreHealth {
 	}
 	s.storeHealthMu.Unlock()
 
-	h := compute()
+	h := compute(ctx)
 
 	s.storeHealthMu.Lock()
 	defer s.storeHealthMu.Unlock()
@@ -43,7 +44,7 @@ func (s *Server) cachedStoreHealth(now time.Time) *StatusStoreHealth {
 // computeStoreHealth measures the Dolt store on disk and the latest
 // gc.store.maintenance event via the server's State. Returns nil when
 // the city path is empty (no state to measure against).
-func (s *Server) computeStoreHealth() *StatusStoreHealth {
+func (s *Server) computeStoreHealth(ctx context.Context) *StatusStoreHealth {
 	cityPath := s.state.CityPath()
 	if cityPath == "" {
 		return nil
@@ -53,7 +54,7 @@ func (s *Server) computeStoreHealth() *StatusStoreHealth {
 	// context/timeout through WalkSize is deferred until it shows up
 	// in profiles.
 	size := storehealth.WalkSize(storehealth.StorePath(cityPath))
-	rows := countBeadStoreRows(s.state.CityBeadStore())
+	rows := countBeadStoreRows(ctx, s.state, s.state.CityBeadStore())
 	lastAt, lastStatus := storehealth.LastMaintenance(s.state.EventProvider())
 	h := storehealth.Compute(cityPath, size, rows, lastAt, lastStatus)
 	return statusStoreHealthFromDomain(h)
@@ -81,12 +82,15 @@ func statusStoreHealthFromDomain(h storehealth.Health) *StatusStoreHealth {
 // store is nil or the scan fails — the ratio is best-effort. The
 // closed-inclusive query is never answerable from the in-memory cache,
 // so this path always hydrates; counting closed history without
-// hydration needs backend support (#1896 follow-up).
-func countBeadStoreRows(store beads.Store) int {
+// hydration needs backend support (#1896 follow-up). Because it always
+// hydrates, this is the store-health block's exposure to ga-cdmx6x's
+// bd-child leak; statusListStoreWithTimeout's state.ScopedStoreLike wiring
+// covers it the same way as the work-count fallback.
+func countBeadStoreRows(ctx context.Context, state State, store beads.Store) int {
 	if store == nil {
 		return 0
 	}
-	list, err := statusListStoreWithTimeout(store, beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	list, err := statusListStoreWithTimeout(ctx, state, store, beads.ListQuery{AllowScan: true, IncludeClosed: true})
 	if err != nil {
 		return 0
 	}

--- a/internal/api/store_health_test.go
+++ b/internal/api/store_health_test.go
@@ -18,13 +18,13 @@ func TestCachedStoreHealthServesMemoized(t *testing.T) {
 	var calls int
 	want := &StatusStoreHealth{Path: "/c/.beads/dolt", SizeBytes: 123}
 	s := &Server{}
-	s.storeHealthComputer = func() *StatusStoreHealth {
+	s.storeHealthComputer = func(context.Context) *StatusStoreHealth {
 		calls++
 		return want
 	}
 
 	now := time.Unix(1_000_000, 0)
-	got := s.cachedStoreHealth(now)
+	got := s.cachedStoreHealth(context.Background(), now)
 	if got != want {
 		t.Fatalf("cachedStoreHealth = %+v, want %+v", got, want)
 	}
@@ -33,7 +33,7 @@ func TestCachedStoreHealthServesMemoized(t *testing.T) {
 	}
 
 	// Within TTL: no recomputation.
-	got2 := s.cachedStoreHealth(now.Add(storeHealthCacheTTL - time.Second))
+	got2 := s.cachedStoreHealth(context.Background(), now.Add(storeHealthCacheTTL-time.Second))
 	if got2 != want {
 		t.Fatalf("second cachedStoreHealth = %+v, want %+v", got2, want)
 	}
@@ -45,15 +45,15 @@ func TestCachedStoreHealthServesMemoized(t *testing.T) {
 func TestCachedStoreHealthRefreshesAfterTTL(t *testing.T) {
 	var calls int
 	s := &Server{}
-	s.storeHealthComputer = func() *StatusStoreHealth {
+	s.storeHealthComputer = func(context.Context) *StatusStoreHealth {
 		calls++
 		return &StatusStoreHealth{SizeBytes: int64(calls)}
 	}
 
 	now := time.Unix(1_000_000, 0)
-	_ = s.cachedStoreHealth(now)
+	_ = s.cachedStoreHealth(context.Background(), now)
 	later := now.Add(storeHealthCacheTTL + time.Second)
-	got := s.cachedStoreHealth(later)
+	got := s.cachedStoreHealth(context.Background(), later)
 	if calls != 2 {
 		t.Fatalf("computer calls = %d, want 2", calls)
 	}
@@ -65,7 +65,7 @@ func TestCachedStoreHealthRefreshesAfterTTL(t *testing.T) {
 func TestCachedStoreHealthDoesNotHoldMutexDuringRefreshCompute(t *testing.T) {
 	s := &Server{}
 	canLockDuringCompute := make(chan bool, 1)
-	s.storeHealthComputer = func() *StatusStoreHealth {
+	s.storeHealthComputer = func(context.Context) *StatusStoreHealth {
 		locked := make(chan struct{})
 		go func() {
 			s.storeHealthMu.Lock()
@@ -81,7 +81,7 @@ func TestCachedStoreHealthDoesNotHoldMutexDuringRefreshCompute(t *testing.T) {
 		return &StatusStoreHealth{SizeBytes: 1}
 	}
 
-	_ = s.cachedStoreHealth(time.Unix(1_000_000, 0))
+	_ = s.cachedStoreHealth(context.Background(), time.Unix(1_000_000, 0))
 	if !<-canLockDuringCompute {
 		t.Fatal("cachedStoreHealth held storeHealthMu while running the refresh computer")
 	}
@@ -137,7 +137,7 @@ func TestComputeStoreHealthServerIntegration(t *testing.T) {
 		cityBeadStore: store,
 	}
 	s := &Server{state: state}
-	got := s.computeStoreHealth()
+	got := s.computeStoreHealth(context.Background())
 	if got == nil {
 		t.Fatal("computeStoreHealth returned nil")
 	}
@@ -180,13 +180,13 @@ func TestComputeStoreHealthUsesDoltlitePathFromMetadata(t *testing.T) {
 func TestComputeStoreHealthEmptyCityPath(t *testing.T) {
 	state := &fakeState{cityPath: ""}
 	s := &Server{state: state}
-	if got := s.computeStoreHealth(); got != nil {
+	if got := s.computeStoreHealth(context.Background()); got != nil {
 		t.Fatalf("computeStoreHealth = %+v, want nil for empty city path", got)
 	}
 }
 
 func TestCountBeadStoreRowsNil(t *testing.T) {
-	if got := countBeadStoreRows(nil); got != 0 {
+	if got := countBeadStoreRows(context.Background(), newFakeState(t), nil); got != 0 {
 		t.Fatalf("countBeadStoreRows(nil) = %d, want 0", got)
 	}
 }
@@ -204,7 +204,7 @@ func TestCountBeadStoreRowsIncludesClosedBeads(t *testing.T) {
 	if err := store.Close(closed.ID); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if got := countBeadStoreRows(store); got != 2 {
+	if got := countBeadStoreRows(context.Background(), newFakeState(t), store); got != 2 {
 		t.Fatalf("countBeadStoreRows = %d, want 2 including closed bead %s and open bead %s", got, closed.ID, open.ID)
 	}
 }

--- a/internal/api/store_health_test.go
+++ b/internal/api/store_health_test.go
@@ -168,7 +168,7 @@ func TestComputeStoreHealthUsesDoltlitePathFromMetadata(t *testing.T) {
 		cityBeadStore: beads.NewMemStore(),
 	}
 	s := &Server{state: state}
-	got := s.computeStoreHealth()
+	got := s.computeStoreHealth(context.Background())
 	if got == nil {
 		t.Fatal("computeStoreHealth returned nil")
 	}

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -347,6 +347,17 @@ func (s *BdStore) IDPrefix() string {
 	return s.idPrefix
 }
 
+// Dir returns the root directory this store was constructed with (where
+// .beads/ lives). Callers that need to build an equivalent throwaway store
+// bound to a different context (e.g. a per-request scoped clone) use this
+// to target the same backend without a second, parallel way to track it.
+func (s *BdStore) Dir() string {
+	if s == nil {
+		return ""
+	}
+	return s.dir
+}
+
 // ListSkipLabelsEnabled reports whether this store may ask bd list to skip
 // label hydration.
 func (s *BdStore) ListSkipLabelsEnabled() bool {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -57,6 +57,27 @@ func doltliteBdStoreMetadataTestDir(t *testing.T, metadata string) string {
 	return dir
 }
 
+// --- Dir ---
+
+// TestBdStoreDirReturnsConstructionDir proves Dir() reports the exact root
+// a BdStore was constructed with, so callers that need to build an
+// equivalent throwaway store elsewhere (e.g. a ctx-bound clone for a
+// bounded read, gascity ga-cdmx6x) don't need a second, parallel way to
+// track it.
+func TestBdStoreDirReturnsConstructionDir(t *testing.T) {
+	store := beads.NewBdStore("/city/root", fakeRunner(nil))
+	if got := store.Dir(); got != "/city/root" {
+		t.Fatalf("Dir() = %q, want /city/root", got)
+	}
+}
+
+func TestBdStoreDirHandlesNilReceiver(t *testing.T) {
+	var store *beads.BdStore
+	if got := store.Dir(); got != "" {
+		t.Fatalf("Dir() on nil store = %q, want empty string", got)
+	}
+}
+
 // --- Create ---
 
 func TestBdStoreCreate(t *testing.T) {

--- a/release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md
+++ b/release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md
@@ -24,10 +24,10 @@ origin/main. The cherry-pick applied without conflicts.
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
 | 1 | Review PASS present | PASS | ga-bytd3q is closed with `REVIEW VERDICT: PASS` for commit 5e8459b3893fdc2e18f127c8200c98fc1fac1cf2. |
-| 2 | Acceptance criteria met | PASS | Verified on the final clean branch (a61385aa2) after the compile fix below; `go build ./...` and `go vet ./...` clean, `gofmt -l` clean on the touched file. |
-| 3 | Tests pass | PASS | See "Test verification after fix" below. |
+| 2 | Acceptance criteria met | PASS | Verified on the final clean branch (code commit a61385aa2, gate tip 00b7977a); `go build ./...`, `go vet ./...`, `git diff --check`, and `gofmt -l` on touched Go files are clean. |
+| 3 | Tests pass | PASS | See "Deployer re-verification before PR" below; `make test-fast-parallel` passed all 8 shards on the final branch. |
 | 4 | No high-severity review findings open | PASS | Reviewer notes report no blockers and only one non-blocking security observation; unresolved HIGH finding count is 0. |
-| 5 | Final branch is clean | PASS | Worktree clean at a61385aa2. |
+| 5 | Final branch is clean | PASS | Worktree clean before this evidence refresh; final status rechecked after committing the refreshed gate. |
 | 6 | Branch diverges cleanly from main | PASS | Clean branch was cut from origin/main and the reviewed commit cherry-picked with no merge conflicts. |
 | 7 | Single feature theme | PASS | The clean branch contains only the status/API scoped BdStore cancellation change (plus the one-line test compile fix), not the unrelated graph-only readiness parent stack. |
 
@@ -44,30 +44,21 @@ Fix: commit a61385aa2 on `release/ga-nlz18e-ctx-bound-scoped-bdstore` — one-li
 compile-only, no behavior change (passes `context.Background()`, matching the
 sibling call sites).
 
-## Test verification after fix
+## Deployer re-verification before PR
 
-Ran with `TMPDIR=/var/tmp/gc-nlz18e-verify2*` (this box's `/tmp` tmpfs is at
-~100% full independent of this change — see mail to mayor 2026-07-04; using
-`/var/tmp` avoids spurious "no space left on device" noise).
+Ran with `TMPDIR=/var/tmp/gc-nlz18e-deploy` from branch tip 00b7977a (same code
+candidate a61385aa2; the only later commit is this release gate).
 
-- `go build ./...`, `go vet ./...`: clean.
-- `gofmt -l internal/api/store_health_test.go`: clean.
-- `go test ./internal/api/... -run TestComputeStoreHealthUsesDoltlitePathFromMetadata -v`: PASS.
-- `go test ./internal/api/...` (full package): all PASS (58.0s).
-- `TMPDIR=/var/tmp/gc-nlz18e-verify2-full make test-fast-parallel`: 5/8 shards
-  PASS. 3 shards failed, all on the same 3 tests:
-  `TestRegisterCityWithSupervisorRejectsStandaloneController`,
-  `TestRegisterCityWithSupervisorRejectsStandaloneControllerForStoppedManagedCity`,
-  `TestSupervisorCreatesControllerSocketForManagedCity` (`cmd/gc`, unrelated
-  supervisor/dolt-lifecycle package — no import relationship to
-  `internal/api/store_health_test.go`). All three fail on a hard 50-60s
-  supervisor/dolt-city startup timeout, not an assertion mismatch.
-  **Confirmed pre-existing/environmental, not caused by this change:** re-ran
-  the same 3 tests in isolation against a clean, unmodified `origin/main`
-  checkout (`git worktree add --detach /var/tmp/gc-main-verify-nlz18e
-  origin/main`, commit d82074594) under the same load — identical failures,
-  identical signatures, comparable timings (46-60s). This box is running a
-  very large number of concurrent agent/test workloads right now; these tests
-  spin up a real supervisor + dolt sql-server and are sensitive to that load.
-  Worktree removed after comparison (`git worktree remove
-  /var/tmp/gc-main-verify-nlz18e`).
+- `git fetch origin main`: origin/main remains d82074594.
+- `git merge-tree --write-tree HEAD origin/main`: PASS, tree
+  a9fe60a569e349d2eed6213de90f28aa85fa00c1, no conflicts.
+- `git diff --check origin/main...HEAD`: clean.
+- `gofmt -l` on all touched Go files: clean.
+- `go build ./...`: PASS.
+- `go vet ./...`: PASS.
+- `go test ./internal/api/... ./internal/beads/...`: PASS.
+- `GC_REAL_PROCESS_SIGNAL_TESTS=1 GC_FAST_UNIT=0 go test ./cmd/gc ./internal/api
+  -run 'Test(ScopedBdStoreForCityKillsChildOnCtxCancel|LoadStatusSessionSnapshotKillsBdChildOnTimeout|StatusSessionSnapshotKillsBdChildOnTimeout|StatusListStoreWithTimeoutKillsBdChildOnTimeout|ComputeStoreHealthUsesDoltlitePathFromMetadata)$'
+  -count=1 -v`: PASS.
+- `make test-fast-parallel`: PASS, all 8 fast shards passed.
+- `make dashboard-check`: PASS; OpenAPI/generated dashboard paths have no diff.

--- a/release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md
+++ b/release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md
@@ -1,0 +1,39 @@
+# Release gate: ga-nlz18e ctx-bound scoped BdStore
+
+Date: 2026-07-04
+Result: FAIL
+
+## Candidate
+
+- Deploy bead: ga-nlz18e
+- Source implementation bead: ga-cdmx6x
+- Review bead: ga-bytd3q
+- Reviewed commit: 5e8459b3893fdc2e18f127c8200c98fc1fac1cf2 on gc-builder-3-dad840a7d698
+- Clean release branch tested: release/ga-nlz18e-ctx-bound-scoped-bdstore
+- Base: origin/main at d82074594d7594eea890e5300d7936540f30bd9e
+- Tested commit: 4e45acbd4 (clean cherry-pick of 5e8459b38)
+
+The reviewed builder branch was stacked on deploy/ga-oz3ow5.1-graphonlyready-clean,
+which is not in origin/main and carries a separate graph-only readiness feature.
+For the single-bead gate, I tested the reviewed status patch by itself on current
+origin/main. The cherry-pick applied without conflicts.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-bytd3q is closed with `REVIEW VERDICT: PASS` for commit 5e8459b3893fdc2e18f127c8200c98fc1fac1cf2. |
+| 2 | Acceptance criteria met | FAIL | Cannot verify acceptance on the final clean branch because the branch does not compile under the fast unit gate. |
+| 3 | Tests pass | FAIL | `TMPDIR=/var/tmp/gc-nlz18e-test make test-fast-parallel` failed in `unit-core`: `internal/api/store_health_test.go:171:9: not enough arguments in call to s.computeStoreHealth; have (); want ("context".Context)`. All six `cmd/gc` fast shards completed ok after the core failure. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes report no blockers and only one non-blocking security observation; unresolved HIGH finding count is 0. |
+| 5 | Final branch is clean | PASS | Worktree was clean after the clean cherry-pick and before writing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | Clean branch was cut from origin/main and the reviewed commit cherry-picked with no merge conflicts. |
+| 7 | Single feature theme | PASS | The clean branch contains only the status/API scoped BdStore cancellation change, not the unrelated graph-only readiness parent stack. |
+
+## Failure diagnosis
+
+The isolated status patch needs a rebase/update against current origin/main.
+`computeStoreHealth` now requires a `context.Context`, but
+`TestComputeStoreHealthUsesDoltlitePathFromMetadata` still calls it with no
+argument after the clean cherry-pick. This is a technical gate failure; no PR was
+opened.

--- a/release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md
+++ b/release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md
@@ -1,7 +1,7 @@
 # Release gate: ga-nlz18e ctx-bound scoped BdStore
 
 Date: 2026-07-04
-Result: FAIL
+Result: PASS
 
 ## Candidate
 
@@ -11,7 +11,8 @@ Result: FAIL
 - Reviewed commit: 5e8459b3893fdc2e18f127c8200c98fc1fac1cf2 on gc-builder-3-dad840a7d698
 - Clean release branch tested: release/ga-nlz18e-ctx-bound-scoped-bdstore
 - Base: origin/main at d82074594d7594eea890e5300d7936540f30bd9e
-- Tested commit: 4e45acbd4 (clean cherry-pick of 5e8459b38)
+- Tested commit: a61385aa2 (4e45acbd4 clean cherry-pick of 5e8459b38, plus a
+  compile-only fix for the gap below)
 
 The reviewed builder branch was stacked on deploy/ga-oz3ow5.1-graphonlyready-clean,
 which is not in origin/main and carries a separate graph-only readiness feature.
@@ -23,22 +24,50 @@ origin/main. The cherry-pick applied without conflicts.
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
 | 1 | Review PASS present | PASS | ga-bytd3q is closed with `REVIEW VERDICT: PASS` for commit 5e8459b3893fdc2e18f127c8200c98fc1fac1cf2. |
-| 2 | Acceptance criteria met | FAIL | Cannot verify acceptance on the final clean branch because the branch does not compile under the fast unit gate. |
-| 3 | Tests pass | FAIL | `TMPDIR=/var/tmp/gc-nlz18e-test make test-fast-parallel` failed in `unit-core` on rerun 2026-07-04; logs: `/var/tmp/gc-nlz18e-test/gc-local-tests.4AZgID`. Blocking compile error: `internal/api/store_health_test.go:171:9: not enough arguments in call to s.computeStoreHealth; have (); want ("context".Context)`. All six `cmd/gc` fast shards completed ok after the core failure. |
+| 2 | Acceptance criteria met | PASS | Verified on the final clean branch (a61385aa2) after the compile fix below; `go build ./...` and `go vet ./...` clean, `gofmt -l` clean on the touched file. |
+| 3 | Tests pass | PASS | See "Test verification after fix" below. |
 | 4 | No high-severity review findings open | PASS | Reviewer notes report no blockers and only one non-blocking security observation; unresolved HIGH finding count is 0. |
-| 5 | Final branch is clean | PASS | Worktree was clean after the clean cherry-pick and before writing this gate file. |
+| 5 | Final branch is clean | PASS | Worktree clean at a61385aa2. |
 | 6 | Branch diverges cleanly from main | PASS | Clean branch was cut from origin/main and the reviewed commit cherry-picked with no merge conflicts. |
-| 7 | Single feature theme | PASS | The clean branch contains only the status/API scoped BdStore cancellation change, not the unrelated graph-only readiness parent stack. |
+| 7 | Single feature theme | PASS | The clean branch contains only the status/API scoped BdStore cancellation change (plus the one-line test compile fix), not the unrelated graph-only readiness parent stack. |
 
-## Failure diagnosis
+## Fix applied (previous FAIL -> this PASS)
 
-The isolated status patch needs a rebase/update against current origin/main.
-`computeStoreHealth` now requires a `context.Context`, but
-`TestComputeStoreHealthUsesDoltlitePathFromMetadata` still calls it with no
-argument after the clean cherry-pick. This is a technical gate failure; no PR was
-opened.
+Prior FAIL: `internal/api/store_health_test.go:171:9: not enough arguments in
+call to s.computeStoreHealth; have (); want ("context".Context)`.
+`TestComputeStoreHealthUsesDoltlitePathFromMetadata` still called
+`computeStoreHealth()` with no argument after the clean cherry-pick changed the
+signature to require `context.Context`, unlike its two sibling call sites in the
+same file which already passed `context.Background()`.
 
-The same rerun also reported unrelated `/tmp` tmpfs exhaustion failures in
-`examples/bd/dolt` and `internal/mail/exec` despite using `/var/tmp` for the Go
-test runner. Those environmental failures are not the routing reason; the
-`internal/api` compile error is deterministic and sufficient to fail the gate.
+Fix: commit a61385aa2 on `release/ga-nlz18e-ctx-bound-scoped-bdstore` — one-line,
+compile-only, no behavior change (passes `context.Background()`, matching the
+sibling call sites).
+
+## Test verification after fix
+
+Ran with `TMPDIR=/var/tmp/gc-nlz18e-verify2*` (this box's `/tmp` tmpfs is at
+~100% full independent of this change — see mail to mayor 2026-07-04; using
+`/var/tmp` avoids spurious "no space left on device" noise).
+
+- `go build ./...`, `go vet ./...`: clean.
+- `gofmt -l internal/api/store_health_test.go`: clean.
+- `go test ./internal/api/... -run TestComputeStoreHealthUsesDoltlitePathFromMetadata -v`: PASS.
+- `go test ./internal/api/...` (full package): all PASS (58.0s).
+- `TMPDIR=/var/tmp/gc-nlz18e-verify2-full make test-fast-parallel`: 5/8 shards
+  PASS. 3 shards failed, all on the same 3 tests:
+  `TestRegisterCityWithSupervisorRejectsStandaloneController`,
+  `TestRegisterCityWithSupervisorRejectsStandaloneControllerForStoppedManagedCity`,
+  `TestSupervisorCreatesControllerSocketForManagedCity` (`cmd/gc`, unrelated
+  supervisor/dolt-lifecycle package — no import relationship to
+  `internal/api/store_health_test.go`). All three fail on a hard 50-60s
+  supervisor/dolt-city startup timeout, not an assertion mismatch.
+  **Confirmed pre-existing/environmental, not caused by this change:** re-ran
+  the same 3 tests in isolation against a clean, unmodified `origin/main`
+  checkout (`git worktree add --detach /var/tmp/gc-main-verify-nlz18e
+  origin/main`, commit d82074594) under the same load — identical failures,
+  identical signatures, comparable timings (46-60s). This box is running a
+  very large number of concurrent agent/test workloads right now; these tests
+  spin up a real supervisor + dolt sql-server and are sensitive to that load.
+  Worktree removed after comparison (`git worktree remove
+  /var/tmp/gc-main-verify-nlz18e`).

--- a/release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md
+++ b/release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md
@@ -24,7 +24,7 @@ origin/main. The cherry-pick applied without conflicts.
 |---|-----------|--------|----------|
 | 1 | Review PASS present | PASS | ga-bytd3q is closed with `REVIEW VERDICT: PASS` for commit 5e8459b3893fdc2e18f127c8200c98fc1fac1cf2. |
 | 2 | Acceptance criteria met | FAIL | Cannot verify acceptance on the final clean branch because the branch does not compile under the fast unit gate. |
-| 3 | Tests pass | FAIL | `TMPDIR=/var/tmp/gc-nlz18e-test make test-fast-parallel` failed in `unit-core`: `internal/api/store_health_test.go:171:9: not enough arguments in call to s.computeStoreHealth; have (); want ("context".Context)`. All six `cmd/gc` fast shards completed ok after the core failure. |
+| 3 | Tests pass | FAIL | `TMPDIR=/var/tmp/gc-nlz18e-test make test-fast-parallel` failed in `unit-core` on rerun 2026-07-04; logs: `/var/tmp/gc-nlz18e-test/gc-local-tests.4AZgID`. Blocking compile error: `internal/api/store_health_test.go:171:9: not enough arguments in call to s.computeStoreHealth; have (); want ("context".Context)`. All six `cmd/gc` fast shards completed ok after the core failure. |
 | 4 | No high-severity review findings open | PASS | Reviewer notes report no blockers and only one non-blocking security observation; unresolved HIGH finding count is 0. |
 | 5 | Final branch is clean | PASS | Worktree was clean after the clean cherry-pick and before writing this gate file. |
 | 6 | Branch diverges cleanly from main | PASS | Clean branch was cut from origin/main and the reviewed commit cherry-picked with no merge conflicts. |
@@ -37,3 +37,8 @@ The isolated status patch needs a rebase/update against current origin/main.
 `TestComputeStoreHealthUsesDoltlitePathFromMetadata` still calls it with no
 argument after the clean cherry-pick. This is a technical gate failure; no PR was
 opened.
+
+The same rerun also reported unrelated `/tmp` tmpfs exhaustion failures in
+`examples/bd/dolt` and `internal/mail/exec` despite using `/var/tmp` for the Go
+test runner. Those environmental failures are not the routing reason; the
+`internal/api` compile error is deterministic and sufficient to fail the gate.


### PR DESCRIPTION
## What this changes

`gc status`, `gc rig status`, and `GET /v0/city/{city}/status` now use short-lived request-scoped `BdStore` instances for bd-backed status reads. When the status snapshot, work-count fallback, or store-health read times out under Dolt/bd pressure, the underlying `bd` subprocess is canceled with the request instead of continuing until the full command timeout.

The normal shared store path stays intact for ordinary reads and for non-bd-backed stores. This is a bounded mitigation for the status surfaces that operators use while the city is already under load.

The implementation reuses the existing bd credential and target resolution instead of adding a second secrets path. The scoped status path deliberately uses no-recovery resolution so a best-effort status request does not trigger managed-Dolt recovery work during a read storm.

## Review notes

- New `cmd/gc/scoped_store.go` unwraps cache/policy store layers back to the backing `BdStore` and builds a request-scoped replacement only when that is safe.
- `cmd/gc/bd_env.go` adds no-recovery variants for the scoped status path; the existing recovery-allowing callers remain on the original wrappers.
- `internal/api.State` now exposes `ScopedStoreLike(ctx, existing)` so the API layer can use the cmd/gc-owned store construction without duplicating runtime credential logic.
- No OpenAPI, generated dashboard type, or dashboard asset changes are expected from this change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api/... ./internal/beads/...`
- [x] `GC_REAL_PROCESS_SIGNAL_TESTS=1 GC_FAST_UNIT=0 go test ./cmd/gc ./internal/api -run 'Test(ScopedBdStoreForCityKillsChildOnCtxCancel|LoadStatusSessionSnapshotKillsBdChildOnTimeout|StatusSessionSnapshotKillsBdChildOnTimeout|StatusListStoreWithTimeoutKillsBdChildOnTimeout|ComputeStoreHealthUsesDoltlitePathFromMetadata)$' -count=1 -v`
- [x] `make test-fast-parallel`
- [x] `make dashboard-check`
- [x] Release gate: [`release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md`](release-gates/ga-nlz18e-ctx-bound-scoped-bdstore-gate.md)
