### PR TITLE
fix(tmux): dismiss mid-session Codex model-switch modal so sessions don't hang

### DIFF
--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -1008,6 +1008,18 @@ func ContainsRateLimitDialog(content string) bool {
 		strings.Contains(content, "Rate limit")
 }
 
+// ContainsModelSwitchModal reports whether pane content shows the mid-session
+// "approaching rate limits — switch to a cheaper model?" modal that Codex/GPT
+// raises (offering to downgrade the model). Unlike ContainsRateLimitDialog — a
+// permissive matcher used only at startup — this requires BOTH the switch offer
+// and the keep-current-model option, so ordinary agent output that merely
+// mentions "rate limit" cannot false-match and receive spurious keystrokes when
+// checked mid-session against an arbitrary working pane.
+func ContainsModelSwitchModal(content string) bool {
+	return strings.Contains(content, "Keep current model") &&
+		strings.Contains(content, "Switch to ")
+}
+
 // ContainsProviderRateLimitScreen reports whether pane content has
 // high-confidence provider rate-limit screen evidence.
 func ContainsProviderRateLimitScreen(content string) bool {

--- a/internal/runtime/dialog_model_switch_test.go
+++ b/internal/runtime/dialog_model_switch_test.go
@@ -1,0 +1,51 @@
+package runtime
+
+import "testing"
+
+// TestContainsModelSwitchModal verifies the high-confidence matcher for the
+// mid-session Codex/GPT "approaching rate limits — switch to a cheaper model?"
+// modal. It must match the real modal but NOT ordinary agent output that merely
+// mentions rate limits, so a mid-session dismiss cannot send spurious keystrokes
+// into a working pane.
+func TestContainsModelSwitchModal(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "codex model-switch modal",
+			content: "Approaching rate limits\n" +
+				"Switch to gpt-5.4-mini for lower credit usage?\n" +
+				"› 1. Switch to gpt-5.4-mini\n" +
+				"  2. Keep current model\n" +
+				"  3. Keep current model (never show again)\n" +
+				"Press enter to confirm or esc to go back",
+			want: true,
+		},
+		{
+			name: "ordinary work output mentioning rate limits does not match",
+			content: "We're approaching rate limits on the gpt endpoint; the rate " +
+				"limit is 1000 req/min. I'll switch to exponential backoff and " +
+				"keep the current model config.",
+			want: false,
+		},
+		{
+			name:    "switch offer alone (no keep option) does not match",
+			content: "Switch to a faster branch strategy for the release.",
+			want:    false,
+		},
+		{
+			name:    "empty",
+			content: "",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ContainsModelSwitchModal(tt.content); got != tt.want {
+				t.Errorf("ContainsModelSwitchModal(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -504,7 +504,14 @@ func (p *Provider) Nudge(name string, content []runtime.ContentBlock) error {
 		// Best-effort wait — if it fails (session gone, timeout), proceed
 		// with the nudge anyway. The message may arrive during active work,
 		// but Claude's cooperative queue will handle it at the next turn.
-		_ = p.tm.WaitForIdle(context.Background(), name, idleTimeout)
+		if err := p.tm.WaitForIdle(context.Background(), name, idleTimeout); err != nil {
+			// Not idle within the window. A mid-session Codex/GPT model-switch
+			// modal ("approaching rate limits — switch model?") blocks input and
+			// would otherwise hang the session; dismiss it (keep current model,
+			// no downgrade) so the nudge can land. No-op if the modal is absent,
+			// so this never disturbs a genuinely busy pane.
+			p.tm.DismissModelSwitchModalIfPresent(name)
+		}
 	}
 	return p.NudgeNow(name, content)
 }

--- a/internal/runtime/tmux/dialog_model_switch_integration_test.go
+++ b/internal/runtime/tmux/dialog_model_switch_integration_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildModelSwitchModalAgent compiles a fake agent that prints the Codex/GPT
+// "approaching rate limits — switch model?" modal, then treats the next Enter as
+// confirming "Keep current model" by printing a MODEL_KEPT marker. It stays
+// alive so the tmux pane persists for capture.
+func buildModelSwitchModalAgent(t *testing.T, dir, name string) string {
+	t.Helper()
+	bin := dir + "/" + name
+	src := dir + "/" + name + ".go"
+	prog := `package main
+import ("bufio";"fmt";"os")
+func main(){
+	fmt.Println("Approaching rate limits")
+	fmt.Println("Switch to gpt-5.4-mini for lower credit usage?")
+	fmt.Println("  1. Switch to gpt-5.4-mini")
+	fmt.Println("  2. Keep current model")
+	fmt.Println("  3. Keep current model (never show again)")
+	fmt.Println("Press enter to confirm or esc to go back")
+	r:=bufio.NewReader(os.Stdin)
+	for{
+		b,err:=r.ReadByte()
+		if err!=nil{ return }
+		if b=='\r'||b=='\n'{
+			fmt.Println("MODEL_KEPT modal dismissed keeping current model")
+			continue
+		}
+	}
+}
+`
+	if err := os.WriteFile(src, []byte(prog), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", src, err)
+	}
+	build := exec.Command("go", "build", "-o", bin, src)
+	build.Dir = dir
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build %s: %v\n%s", name, err, string(out))
+	}
+	return bin
+}
+
+// TestDismissModelSwitchModalIfPresentClearsModalOnRealTmux proves ga-3syh's fix
+// end-to-end on real tmux: a session showing the mid-session model-switch modal
+// is dismissed to "Keep current model" (Down+Enter) so it stops hanging.
+func TestDismissModelSwitchModalIfPresentClearsModalOnRealTmux(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+	tm := testTmux()
+	dir := t.TempDir()
+	fake := buildModelSwitchModalAgent(t, dir, "fakecodex")
+	sessionName := fmt.Sprintf("gt-test-modal-%d", time.Now().UnixNano()%100000)
+
+	_ = tm.KillSession(sessionName)
+	if err := tm.NewSessionWithCommandAndEnv(sessionName, dir, fake, map[string]string{
+		"GC_PROVIDER": "codex",
+	}); err != nil {
+		t.Fatalf("NewSessionWithCommandAndEnv: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+	time.Sleep(500 * time.Millisecond)
+
+	// Precondition: the pane shows the model-switch modal.
+	pre, err := tm.CapturePaneAll(sessionName)
+	if err != nil {
+		t.Fatalf("CapturePaneAll: %v", err)
+	}
+	if !strings.Contains(pre, "Keep current model") || !strings.Contains(pre, "Switch to ") {
+		t.Fatalf("precondition: model-switch modal not shown:\n%s", pre)
+	}
+
+	tm.DismissModelSwitchModalIfPresent(sessionName)
+	time.Sleep(500 * time.Millisecond)
+
+	post, err := tm.CapturePaneAll(sessionName)
+	if err != nil {
+		t.Fatalf("CapturePaneAll: %v", err)
+	}
+	if !strings.Contains(post, "MODEL_KEPT") {
+		t.Fatalf("modal was not dismissed (no MODEL_KEPT after DismissModelSwitchModalIfPresent):\n%s", post)
+	}
+}

--- a/internal/runtime/tmux/dialog_model_switch_test.go
+++ b/internal/runtime/tmux/dialog_model_switch_test.go
@@ -1,0 +1,50 @@
+package tmux
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDismissModelSwitchModal proves that when the pane shows the Codex/GPT
+// model-switch modal, the dismisser selects "Keep current model" (Down off the
+// default "Switch" option, then Enter) — keeping the model with no downgrade.
+func TestDismissModelSwitchModal(t *testing.T) {
+	modal := "Approaching rate limits\n" +
+		"Switch to gpt-5.4-mini for lower credit usage?\n" +
+		"  2. Keep current model\n" +
+		"Press enter to confirm or esc to go back"
+	var keys []string
+	sendKeys := func(k ...string) error { keys = append(keys, k...); return nil }
+
+	dismissed, err := dismissModelSwitchModal(modal, sendKeys, func(time.Duration) {})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !dismissed {
+		t.Fatal("dismissed = false, want true for the model-switch modal")
+	}
+	if len(keys) != 2 || keys[0] != "Down" || keys[1] != "Enter" {
+		t.Fatalf("keys = %v, want [Down Enter] (select Keep-current-model, then confirm)", keys)
+	}
+}
+
+// TestDismissModelSwitchModalNoOpOnWorkingPane proves the dismisser never sends
+// keystrokes into an ordinary working pane, even one whose output mentions rate
+// limits — the safety property that lets it run mid-session.
+func TestDismissModelSwitchModalNoOpOnWorkingPane(t *testing.T) {
+	content := "Working (3s • esc to interrupt)\n" +
+		"> I'm adding backoff because we're near the rate limit; keeping the current model."
+	var keys []string
+	sendKeys := func(k ...string) error { keys = append(keys, k...); return nil }
+
+	dismissed, err := dismissModelSwitchModal(content, sendKeys, func(time.Duration) {})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if dismissed {
+		t.Fatal("dismissed = true, want false on a non-modal working pane")
+	}
+	if len(keys) != 0 {
+		t.Fatalf("keys = %v, want none (must not type into a working pane)", keys)
+	}
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -1961,6 +1961,55 @@ func (t *Tmux) DismissKnownDialogs(ctx context.Context, sess string, timeout tim
 	)
 }
 
+// modelSwitchDismissConfirmDelay lets the model-switch modal register the
+// selection move before the confirm keypress, so Enter does not race the Down.
+const modelSwitchDismissConfirmDelay = 150 * time.Millisecond
+
+// dismissModelSwitchModal dismisses the Codex/GPT mid-session "approaching rate
+// limits — switch to a cheaper model?" modal by selecting "Keep current model"
+// (Down off the default "Switch" option, then Enter). It is a no-op unless the
+// high-confidence runtime.ContainsModelSwitchModal matcher fires, so it never
+// sends stray keystrokes into ordinary working panes. Side effects are injected
+// so the decision is unit-testable without a live tmux server. Returns whether
+// the modal was present (i.e. a dismiss was attempted).
+func dismissModelSwitchModal(content string, sendKeys func(keys ...string) error, sleep func(time.Duration)) (bool, error) {
+	if !runtime.ContainsModelSwitchModal(content) {
+		return false, nil
+	}
+	if err := sendKeys("Down"); err != nil {
+		return true, err
+	}
+	sleep(modelSwitchDismissConfirmDelay)
+	return true, sendKeys("Enter")
+}
+
+// DismissModelSwitchModalIfPresent clears a mid-session Codex/GPT model-switch
+// modal on the session's agent pane (keeping the current model — no downgrade,
+// no spend change) so a session that would otherwise hang on it can proceed.
+// No-op when the modal is absent. Best-effort: capture/send failures are
+// swallowed (the caller retries on the next wake).
+func (t *Tmux) DismissModelSwitchModalIfPresent(session string) {
+	target := session
+	if agentPane, err := t.FindAgentPane(session); err == nil && agentPane != "" {
+		target = agentPane
+	}
+	content, err := t.CapturePane(target, promptObservationLines)
+	if err != nil {
+		return
+	}
+	_, _ = dismissModelSwitchModal(content,
+		func(keys ...string) error {
+			for _, k := range keys {
+				if _, err := t.run("send-keys", "-t", target, k); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		time.Sleep,
+	)
+}
+
 // GetPaneCommand returns the current command running in a pane.
 // Returns "bash", "zsh", "claude", "node", etc.
 func (t *Tmux) GetPaneCommand(session string) (string, error) {


### PR DESCRIPTION
## Symptom

Codex/GPT raises an "Approaching rate limits — Switch to a cheaper model?" modal **mid-session**. When it appears during work, the session hangs: the pane is input-blocked (neither an idle prompt nor a busy indicator), `WaitForIdle` can't confirm idle, idle-kill may not fire, and the agent sits forever. Observed live as a `tester` session stuck ~35 min after its QA work completed (committed + pushed) — an operator had to key the modal by hand to free it.

## Root cause

gc's dialog handling (`AcceptStartupDialogs` / `DismissKnownDialogs`, `internal/runtime/dialog.go`) — which already includes a rate-limit dismisser — runs **only at startup / early-session** (`session/chat.go` gates it behind codex `needsDeferredStartupDialogVerification`). Once startup dialogs are verified it is never re-run, so a rate-limit modal that appears mid-session is never dismissed.

The existing recognizer `ContainsRateLimitDialog` matches the broad substring `"rate limit"`. That is safe at startup (the pane is a known dialog or fresh prompt), but running it mid-session over arbitrary panes would **false-match ordinary agent output** that merely mentions rate limits and fire stray `Down`/`Enter` keystrokes into live work.

## Fix

- **High-confidence matcher** `ContainsModelSwitchModal` (`dialog.go`): requires **both** the switch offer (`"Switch to "`) and the keep-current-model option (`"Keep current model"`), so it fires only on the actual modal — never on prose that mentions rate limits.
- **Mid-session dismissal** (`Tmux.DismissModelSwitchModalIfPresent`, split from a pure, injectable `dismissModelSwitchModal` for testability): selects **"Keep current model"** (`Down` off the default "Switch", then `Enter`) — no downgrade, no spend change. No-op when the modal is absent.
- **Hook** (`Provider.Nudge`): when the pre-send `WaitForIdle` fails (session not idle), dismiss a blocking model-switch modal before delivering. On a genuinely busy pane the high-confidence matcher does not fire → no keystrokes → no regression. Every pool session self-polls "check for assigned work", so a modal clears on the next wake instead of hanging.

## Blast radius

- Adds one extra pane capture per nudge to a non-idle session; sends keys only on a high-confidence modal match. Safe-by-construction: it cannot type into a working pane.
- The keep-current-model dismissal is the safe default (matches the operator's own manual choice when this was first hit); it does not select "never show again", so a fresh modal can recur — but the hook re-dismisses it on the next wake.

## Testing

- **Unit** (`internal/runtime/dialog_model_switch_test.go`): matcher matches the real modal; does NOT match work output mentioning rate limits, nor a bare "switch to" phrase.
- **Unit** (`internal/runtime/tmux/dialog_model_switch_test.go`): dismisser sends `Down`+`Enter` on the modal; sends nothing on a working pane (the safety property).
- **Integration, real tmux** (`//go:build integration`): a fake agent showing the modal is dismissed end-to-end (keeps current model).
- `go vet` clean · `golangci-lint run ./internal/runtime/...` **0 issues** · `gofmt` clean · full `internal/runtime` + `internal/runtime/tmux` unit suites pass · `go build ./cmd/gc/` ok.

## Follow-up (separate)

Reaper / idle-kill resilience: reap a session that remains input-blocked after dismissal so it cannot hang indefinitely even if a future modal isn't recognized. Left out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
