### PR TITLE
fix(supervisor): harden log rotation against racing supervisor starts

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1154,17 +1154,28 @@ func runSupervisor(stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc supervisor: ensuring home dir %s: %v\n", supervisor.DefaultHome(), err) //nolint:errcheck
 		return 1
 	}
+	// Capture prior-instance evidence before acquireSupervisorLockAndRotateLog
+	// (re)creates the lock file: its existence means a supervisor ran
+	// on this machine before, which lets the restart-cause derivation
+	// distinguish a crashed prior instance from a first start.
+	_, lockStatErr := os.Stat(supervisorLockPath())
+	priorInstanceRan := lockStatErr == nil
+
 	// Bound supervisor.log before attaching to it. A supervisor that fails
 	// the same way on every start crash-loops under its service manager
 	// (systemd Restart=always, launchd KeepAlive) and appends identical
 	// failure lines through every restart — 645MB in one two-day
 	// bind-conflict incident (#3897) — so every start size-gates the log
-	// and archives it at the cap. Rotation failures are surfaced but never
-	// block startup: a supervisor with an oversized log beats no
-	// supervisor.
-	if err := maybeRotateSupervisorLog(supervisorLogPath(), time.Now()); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: rotating supervisor log: %v\n", err) //nolint:errcheck // best-effort stderr
+	// and archives it at the cap, under the single-instance lock so racing
+	// starts cannot interleave the compress/truncate sequence. Rotation
+	// failures are surfaced but never block startup: a supervisor with an
+	// oversized log beats no supervisor.
+	lock, err := acquireSupervisorLockAndRotateLog(supervisorLogPath(), time.Now(), stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc supervisor: %v\n", err) //nolint:errcheck
+		return 1
 	}
+	defer lock.Close() //nolint:errcheck
 	// Always tee to ~/.gc/supervisor.log so `gc supervisor logs` works
 	// regardless of how the supervisor was invoked. We skip the tee when
 	// stdout/stderr already point at the same file (manual `gc supervisor
@@ -1184,20 +1195,6 @@ func runSupervisor(stdout, stderr io.Writer) int {
 			stderr = io.MultiWriter(stderr, logFile)
 		}
 	}
-
-	// Capture prior-instance evidence before acquireSupervisorLock
-	// (re)creates the lock file: its existence means a supervisor ran
-	// on this machine before, which lets the restart-cause derivation
-	// distinguish a crashed prior instance from a first start.
-	_, lockStatErr := os.Stat(supervisorLockPath())
-	priorInstanceRan := lockStatErr == nil
-
-	lock, err := acquireSupervisorLock()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: %v\n", err) //nolint:errcheck
-		return 1
-	}
-	defer lock.Close() //nolint:errcheck
 
 	// Holding the instance lock, consume the clean-shutdown handoff
 	// token the previous instance's STOPPING path left behind (if any)

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1154,6 +1154,17 @@ func runSupervisor(stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc supervisor: ensuring home dir %s: %v\n", supervisor.DefaultHome(), err) //nolint:errcheck
 		return 1
 	}
+	// Bound supervisor.log before attaching to it. A supervisor that fails
+	// the same way on every start crash-loops under its service manager
+	// (systemd Restart=always, launchd KeepAlive) and appends identical
+	// failure lines through every restart — 645MB in one two-day
+	// bind-conflict incident (#3897) — so every start size-gates the log
+	// and archives it at the cap. Rotation failures are surfaced but never
+	// block startup: a supervisor with an oversized log beats no
+	// supervisor.
+	if err := maybeRotateSupervisorLog(supervisorLogPath(), time.Now()); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor: rotating supervisor log: %v\n", err) //nolint:errcheck // best-effort stderr
+	}
 	// Always tee to ~/.gc/supervisor.log so `gc supervisor logs` works
 	// regardless of how the supervisor was invoked. We skip the tee when
 	// stdout/stderr already point at the same file (manual `gc supervisor

--- a/cmd/gc/supervisor_log_rotation.go
+++ b/cmd/gc/supervisor_log_rotation.go
@@ -29,6 +29,14 @@ var (
 	// supervisorLogKeepArchives is how many compressed archives to keep
 	// next to the active log; the oldest are pruned on rotation.
 	supervisorLogKeepArchives = 3
+
+	// supervisorLogArchiveMaxBytes bounds how much of an oversized log a
+	// single rotation reads into an archive. A pathological log (far past
+	// the rotation cap because rotation was disabled or failing) is
+	// archived only up to this bound; the tail beyond it is dropped with a
+	// warning and the active file is still truncated, because bounding the
+	// log is the point of rotating at all.
+	supervisorLogArchiveMaxBytes int64 = 1 << 30 // 1 GiB
 )
 
 // supervisorLogArchiveTimestampLayout is the compact UTC-pinned timestamp
@@ -36,11 +44,36 @@ var (
 // convention) so directory listings sort chronologically.
 const supervisorLogArchiveTimestampLayout = "20060102T150405Z"
 
+// acquireSupervisorLockAndRotateLog acquires the supervisor single-instance
+// lock and, while holding it, size-gates the supervisor log. Rotation must
+// only ever run under this lock: two supervisor processes rotating the same
+// log concurrently can interleave the compress/truncate sequence and
+// destroy log content, so the losing process has to give up before touching
+// the log. Rotation failures are warned to warn and never block startup — a
+// supervisor with an oversized log beats no supervisor. Only lock
+// acquisition failure is returned; the caller owns closing the lock.
+func acquireSupervisorLockAndRotateLog(logPath string, now time.Time, warn io.Writer) (*os.File, error) {
+	lock, err := acquireSupervisorLock()
+	if err != nil {
+		return nil, err
+	}
+	if err := maybeRotateSupervisorLog(logPath, now, warn); err != nil {
+		fmt.Fprintf(warn, "gc supervisor: rotating supervisor log: %v\n", err) //nolint:errcheck // best-effort warning
+	}
+	return lock, nil
+}
+
 // maybeRotateSupervisorLog archives the supervisor log when it has reached
-// supervisorLogMaxBytes and prunes archives beyond
-// supervisorLogKeepArchives. A missing log is a no-op; all other failures
-// return an error with context so the caller can surface them.
-func maybeRotateSupervisorLog(path string, now time.Time) error {
+// supervisorLogMaxBytes, prunes archives beyond supervisorLogKeepArchives,
+// and sweeps staging leftovers from crashed rotations. Non-fatal notices
+// (an over-bound tail dropped from the archive) go to warn. A missing log
+// is a no-op; all other failures return an error with context so the
+// caller can surface them.
+//
+// Callers must hold the supervisor single-instance lock (see
+// acquireSupervisorLockAndRotateLog): the compress/truncate sequence is
+// not safe against a concurrent rotation of the same file.
+func maybeRotateSupervisorLog(path string, now time.Time, warn io.Writer) error {
 	if supervisorLogMaxBytes <= 0 {
 		return nil
 	}
@@ -57,10 +90,13 @@ func maybeRotateSupervisorLog(path string, now time.Time) error {
 	if info.Size() < supervisorLogMaxBytes {
 		return nil
 	}
-	if err := rotateSupervisorLog(path, now); err != nil {
+	if err := rotateSupervisorLog(path, now, warn); err != nil {
 		return err
 	}
-	return pruneSupervisorLogArchives(path, supervisorLogKeepArchives)
+	if err := pruneSupervisorLogArchives(path, supervisorLogKeepArchives); err != nil {
+		return err
+	}
+	return sweepSupervisorLogStagingFiles(path)
 }
 
 // rotateSupervisorLog compresses the current log contents into a
@@ -70,20 +106,32 @@ func maybeRotateSupervisorLog(path string, now time.Time) error {
 // (systemd StandardOutput=append:, launchd StandardOutPath), and renaming
 // the active file would divert the running instance's own output into the
 // archive. Truncation keeps the inode, so O_APPEND writers continue at
-// offset 0. The archive is staged under a fixed temp name and moved into
-// place with an atomic os.Rename; a crash mid-copy leaves only the temp
-// file, which the next rotation overwrites.
-func rotateSupervisorLog(path string, now time.Time) error {
+// offset 0. The archive is staged under a per-rotation unique name
+// (os.CreateTemp in the log's directory) and moved into place with an
+// atomic os.Rename, so no partially written archive is ever visible under
+// the archive name and a crash mid-copy leaves only a staging file for the
+// next successful rotation to sweep. The copy is bounded at
+// supervisorLogArchiveMaxBytes; a tail beyond the bound is dropped from
+// the archive and reported to warn after the truncate so the notice lands
+// in the fresh log.
+func rotateSupervisorLog(path string, now time.Time, warn io.Writer) error {
 	src, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("opening supervisor log %s for archiving: %w", path, err)
 	}
 	defer src.Close() //nolint:errcheck // read-only handle
 
-	tmp := path + ".archive.tmp"
-	if err := compressSupervisorLog(src, tmp); err != nil {
+	tmp, err := stageCompressedSupervisorLog(src, path)
+	if err != nil {
 		return err
 	}
+	// Probe one byte past the bounded copy to learn whether a tail was
+	// dropped. A probe error is treated as end-of-input: the archive
+	// already holds everything the bounded copy could read, and the worst
+	// outcome of a misread here is a missing warning line.
+	var probe [1]byte
+	n, _ := src.Read(probe[:])
+	tailDropped := n > 0
 
 	archive, err := supervisorLogArchivePath(path, now)
 	if err != nil {
@@ -97,32 +145,43 @@ func rotateSupervisorLog(path string, now time.Time) error {
 	if err := os.Truncate(path, 0); err != nil {
 		return fmt.Errorf("truncating supervisor log %s after archiving to %s: %w", path, archive, err)
 	}
+	if tailDropped {
+		fmt.Fprintf(warn, "gc supervisor: supervisor log %s exceeded the %d-byte archive bound; archived the first %d bytes to %s and dropped the rest\n", //nolint:errcheck // best-effort warning
+			path, supervisorLogArchiveMaxBytes, supervisorLogArchiveMaxBytes, archive)
+	}
 	return nil
 }
 
-// compressSupervisorLog gzip-streams src into a staging file at tmp,
-// truncating any leftover from a previously crashed rotation.
-func compressSupervisorLog(src io.Reader, tmp string) error {
-	dst, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+// stageCompressedSupervisorLog gzip-streams at most
+// supervisorLogArchiveMaxBytes of src into a uniquely named staging file
+// created with os.CreateTemp next to the log, and returns the staging
+// path. The per-rotation staging name is load-bearing: a fixed name lets a
+// concurrent rotation O_TRUNC this one's staged bytes mid-write, which is
+// exactly how racing supervisor starts used to corrupt the archive and
+// then truncate away the only intact copy. The bounded copy keeps a
+// pathological log from tying the rotation to unbounded input.
+func stageCompressedSupervisorLog(src io.Reader, path string) (string, error) {
+	dst, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".archive-*.tmp")
 	if err != nil {
-		return fmt.Errorf("creating supervisor log archive staging file %s: %w", tmp, err)
+		return "", fmt.Errorf("creating supervisor log archive staging file next to %s: %w", path, err)
 	}
+	tmp := dst.Name()
 	gz := gzip.NewWriter(dst)
-	if _, err := io.Copy(gz, src); err != nil {
+	if _, err := io.Copy(gz, io.LimitReader(src, supervisorLogArchiveMaxBytes)); err != nil {
 		dst.Close()    //nolint:errcheck // surfacing the copy error instead
 		os.Remove(tmp) //nolint:errcheck // best-effort cleanup of staged archive
-		return fmt.Errorf("compressing supervisor log into %s: %w", tmp, err)
+		return "", fmt.Errorf("compressing supervisor log into %s: %w", tmp, err)
 	}
 	if err := gz.Close(); err != nil {
 		dst.Close()    //nolint:errcheck // surfacing the gzip error instead
 		os.Remove(tmp) //nolint:errcheck // best-effort cleanup of staged archive
-		return fmt.Errorf("flushing supervisor log archive %s: %w", tmp, err)
+		return "", fmt.Errorf("flushing supervisor log archive %s: %w", tmp, err)
 	}
 	if err := dst.Close(); err != nil {
 		os.Remove(tmp) //nolint:errcheck // best-effort cleanup of staged archive
-		return fmt.Errorf("closing supervisor log archive staging file %s: %w", tmp, err)
+		return "", fmt.Errorf("closing supervisor log archive staging file %s: %w", tmp, err)
 	}
-	return nil
+	return tmp, nil
 }
 
 // supervisorLogArchivePath returns a not-yet-existing archive path of the
@@ -188,6 +247,25 @@ func pruneSupervisorLogArchives(path string, keep int) error {
 		stale := filepath.Join(dir, a.name)
 		if err := os.Remove(stale); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("pruning supervisor log archive %s: %w", stale, err)
+		}
+	}
+	return nil
+}
+
+// sweepSupervisorLogStagingFiles removes <log>.archive-*.tmp leftovers
+// from rotations that crashed between staging and rename. Staging names
+// are unique per rotation (os.CreateTemp), so without a sweep the
+// leftovers would accumulate one file per crashed rotation forever. Runs
+// after a successful rotation, under the supervisor single-instance lock,
+// so no concurrent rotation can be mid-staging while the sweep deletes.
+func sweepSupervisorLogStagingFiles(path string) error {
+	stale, err := filepath.Glob(path + ".archive-*.tmp")
+	if err != nil {
+		return fmt.Errorf("globbing supervisor log staging leftovers for %s: %w", path, err)
+	}
+	for _, p := range stale {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing stale supervisor log staging file %s: %w", p, err)
 		}
 	}
 	return nil

--- a/cmd/gc/supervisor_log_rotation.go
+++ b/cmd/gc/supervisor_log_rotation.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Supervisor log rotation tunables. Nothing bounded ~/.gc/supervisor.log:
+// a supervisor that fails the same way on every start crash-loops under
+// its service manager (systemd Restart=always, launchd KeepAlive) and
+// appends identical failure lines through every restart — 645MB in one
+// two-day bind-conflict incident (gastownhall/gascity#3897). Rotation is
+// size-gated at supervisor startup, before the new instance writes
+// anything, which bounds exactly that shape: every relaunch re-runs the
+// check, so the file never exceeds the cap by more than one instance's
+// output. Vars (not consts) so tests can lower the thresholds.
+var (
+	// supervisorLogMaxBytes is the size at or above which a supervisor
+	// start archives the log before appending. Non-positive disables
+	// rotation.
+	supervisorLogMaxBytes int64 = 64 * 1024 * 1024 // 64 MiB
+
+	// supervisorLogKeepArchives is how many compressed archives to keep
+	// next to the active log; the oldest are pruned on rotation.
+	supervisorLogKeepArchives = 3
+)
+
+// supervisorLogArchiveTimestampLayout is the compact UTC-pinned timestamp
+// embedded in archive filenames (same layout as the events.jsonl archive
+// convention) so directory listings sort chronologically.
+const supervisorLogArchiveTimestampLayout = "20060102T150405Z"
+
+// maybeRotateSupervisorLog archives the supervisor log when it has reached
+// supervisorLogMaxBytes and prunes archives beyond
+// supervisorLogKeepArchives. A missing log is a no-op; all other failures
+// return an error with context so the caller can surface them.
+func maybeRotateSupervisorLog(path string, now time.Time) error {
+	if supervisorLogMaxBytes <= 0 {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("checking supervisor log %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("supervisor log path %s is a directory", path)
+	}
+	if info.Size() < supervisorLogMaxBytes {
+		return nil
+	}
+	if err := rotateSupervisorLog(path, now); err != nil {
+		return err
+	}
+	return pruneSupervisorLogArchives(path, supervisorLogKeepArchives)
+}
+
+// rotateSupervisorLog compresses the current log contents into a
+// timestamped .gz archive next to the active file and truncates the active
+// file in place. Copy-then-truncate (not rename) is deliberate: service
+// managers hold O_APPEND fds on the log across the supervisor's lifetime
+// (systemd StandardOutput=append:, launchd StandardOutPath), and renaming
+// the active file would divert the running instance's own output into the
+// archive. Truncation keeps the inode, so O_APPEND writers continue at
+// offset 0. The archive is staged under a fixed temp name and moved into
+// place with an atomic os.Rename; a crash mid-copy leaves only the temp
+// file, which the next rotation overwrites.
+func rotateSupervisorLog(path string, now time.Time) error {
+	src, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening supervisor log %s for archiving: %w", path, err)
+	}
+	defer src.Close() //nolint:errcheck // read-only handle
+
+	tmp := path + ".archive.tmp"
+	if err := compressSupervisorLog(src, tmp); err != nil {
+		return err
+	}
+
+	archive, err := supervisorLogArchivePath(path, now)
+	if err != nil {
+		os.Remove(tmp) //nolint:errcheck // best-effort cleanup of staged archive
+		return err
+	}
+	if err := os.Rename(tmp, archive); err != nil {
+		os.Remove(tmp) //nolint:errcheck // best-effort cleanup of staged archive
+		return fmt.Errorf("finalizing supervisor log archive %s: %w", archive, err)
+	}
+	if err := os.Truncate(path, 0); err != nil {
+		return fmt.Errorf("truncating supervisor log %s after archiving to %s: %w", path, archive, err)
+	}
+	return nil
+}
+
+// compressSupervisorLog gzip-streams src into a staging file at tmp,
+// truncating any leftover from a previously crashed rotation.
+func compressSupervisorLog(src io.Reader, tmp string) error {
+	dst, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("creating supervisor log archive staging file %s: %w", tmp, err)
+	}
+	gz := gzip.NewWriter(dst)
+	if _, err := io.Copy(gz, src); err != nil {
+		dst.Close()    //nolint:errcheck // surfacing the copy error instead
+		os.Remove(tmp) //nolint:errcheck // best-effort cleanup of staged archive
+		return fmt.Errorf("compressing supervisor log into %s: %w", tmp, err)
+	}
+	if err := gz.Close(); err != nil {
+		dst.Close()    //nolint:errcheck // surfacing the gzip error instead
+		os.Remove(tmp) //nolint:errcheck // best-effort cleanup of staged archive
+		return fmt.Errorf("flushing supervisor log archive %s: %w", tmp, err)
+	}
+	if err := dst.Close(); err != nil {
+		os.Remove(tmp) //nolint:errcheck // best-effort cleanup of staged archive
+		return fmt.Errorf("closing supervisor log archive staging file %s: %w", tmp, err)
+	}
+	return nil
+}
+
+// supervisorLogArchivePath returns a not-yet-existing archive path of the
+// form <path>.archive-<UTC timestamp>.gz, appending a numeric
+// disambiguator when a rotation already landed in the same second.
+func supervisorLogArchivePath(path string, now time.Time) (string, error) {
+	base := fmt.Sprintf("%s.archive-%s", path, now.UTC().Format(supervisorLogArchiveTimestampLayout))
+	candidate := base + ".gz"
+	for i := 1; ; i++ {
+		_, err := os.Stat(candidate)
+		if os.IsNotExist(err) {
+			return candidate, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("probing supervisor log archive name %s: %w", candidate, err)
+		}
+		candidate = fmt.Sprintf("%s-%d.gz", base, i)
+	}
+}
+
+// pruneSupervisorLogArchives deletes the oldest supervisor log archives so
+// at most keep remain, ordered by modification time with filename as the
+// tiebreaker.
+func pruneSupervisorLogArchives(path string, keep int) error {
+	if keep < 1 {
+		keep = 1
+	}
+	dir := filepath.Dir(path)
+	prefix := filepath.Base(path) + ".archive-"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("listing supervisor log archives in %s: %w", dir, err)
+	}
+	type archive struct {
+		name string
+		mod  time.Time
+	}
+	var archives []archive
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".gz") {
+			continue
+		}
+		info, err := e.Info()
+		if os.IsNotExist(err) {
+			continue // removed concurrently; nothing to prune
+		}
+		if err != nil {
+			return fmt.Errorf("inspecting supervisor log archive %s: %w", name, err)
+		}
+		archives = append(archives, archive{name: name, mod: info.ModTime()})
+	}
+	if len(archives) <= keep {
+		return nil
+	}
+	sort.Slice(archives, func(i, j int) bool {
+		if archives[i].mod.Equal(archives[j].mod) {
+			return archives[i].name < archives[j].name
+		}
+		return archives[i].mod.Before(archives[j].mod)
+	})
+	for _, a := range archives[:len(archives)-keep] {
+		stale := filepath.Join(dir, a.name)
+		if err := os.Remove(stale); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("pruning supervisor log archive %s: %w", stale, err)
+		}
+	}
+	return nil
+}

--- a/cmd/gc/supervisor_log_rotation_test.go
+++ b/cmd/gc/supervisor_log_rotation_test.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/supervisor"
+)
+
+// setSupervisorLogRotation lowers the supervisor log rotation tunables for
+// the duration of a test and restores the defaults afterwards.
+func setSupervisorLogRotation(t *testing.T, maxBytes int64, keep int) {
+	t.Helper()
+	prevMax, prevKeep := supervisorLogMaxBytes, supervisorLogKeepArchives
+	supervisorLogMaxBytes, supervisorLogKeepArchives = maxBytes, keep
+	t.Cleanup(func() {
+		supervisorLogMaxBytes, supervisorLogKeepArchives = prevMax, prevKeep
+	})
+}
+
+// gunzipSupervisorLogArchive decompresses one supervisor log archive and
+// returns its contents.
+func gunzipSupervisorLogArchive(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open archive %s: %v", path, err)
+	}
+	defer f.Close() //nolint:errcheck // read-only test handle
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip reader for %s: %v", path, err)
+	}
+	defer gz.Close() //nolint:errcheck // read-only test handle
+	data, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatalf("decompress %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// listSupervisorLogArchives returns the sorted archive paths next to the
+// given supervisor log path.
+func listSupervisorLogArchives(t *testing.T, path string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(path + ".archive-*.gz")
+	if err != nil {
+		t.Fatalf("glob archives for %s: %v", path, err)
+	}
+	sort.Strings(matches)
+	return matches
+}
+
+func TestMaybeRotateSupervisorLogBelowCapIsNoop(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "supervisor.log")
+	setSupervisorLogRotation(t, 1<<20, 3)
+	content := "steady operational line\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	if err := maybeRotateSupervisorLog(logPath, time.Now()); err != nil {
+		t.Fatalf("maybeRotateSupervisorLog: %v", err)
+	}
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("log = %q, want untouched %q", got, content)
+	}
+	if archives := listSupervisorLogArchives(t, logPath); len(archives) != 0 {
+		t.Fatalf("archives = %v, want none below cap", archives)
+	}
+}
+
+func TestMaybeRotateSupervisorLogMissingFileIsNoop(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "supervisor.log")
+	setSupervisorLogRotation(t, 1, 3)
+
+	if err := maybeRotateSupervisorLog(logPath, time.Now()); err != nil {
+		t.Fatalf("maybeRotateSupervisorLog on missing file: %v", err)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("stat log = %v, want not-exist (rotation must not create it)", err)
+	}
+}
+
+func TestMaybeRotateSupervisorLogArchivesAndTruncates(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "supervisor.log")
+	setSupervisorLogRotation(t, 1024, 3)
+	content := strings.Repeat("api: listen 127.0.0.1:8372 failed: bind: address already in use\n", 64)
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	now := time.Date(2026, 7, 3, 10, 11, 12, 0, time.UTC)
+	if err := maybeRotateSupervisorLog(logPath, now); err != nil {
+		t.Fatalf("maybeRotateSupervisorLog: %v", err)
+	}
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat active log after rotation: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("active log size = %d, want 0 after rotation", info.Size())
+	}
+
+	archives := listSupervisorLogArchives(t, logPath)
+	want := []string{logPath + ".archive-20260703T101112Z.gz"}
+	if len(archives) != 1 || archives[0] != want[0] {
+		t.Fatalf("archives = %v, want %v", archives, want)
+	}
+	if got := gunzipSupervisorLogArchive(t, archives[0]); got != content {
+		t.Fatalf("archive content mismatch: got %d bytes, want %d bytes", len(got), len(content))
+	}
+	if _, err := os.Stat(logPath + ".archive.tmp"); !os.IsNotExist(err) {
+		t.Fatalf("stat archive tmp = %v, want not-exist after successful rotation", err)
+	}
+}
+
+// TestMaybeRotateSupervisorLogPreservesAppendWriters proves the
+// copy-then-truncate strategy keeps already-open O_APPEND writers attached
+// to the active file — the shape service managers use (systemd
+// StandardOutput=append:, launchd StandardOutPath). A rename-based rotation
+// would divert those writers into the archive.
+func TestMaybeRotateSupervisorLogPreservesAppendWriters(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "supervisor.log")
+	setSupervisorLogRotation(t, 8, 3)
+	if err := os.WriteFile(logPath, []byte("historic crash-loop noise\n"), 0o644); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	writer, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open append writer: %v", err)
+	}
+	defer writer.Close() //nolint:errcheck // test handle
+
+	if err := maybeRotateSupervisorLog(logPath, time.Now()); err != nil {
+		t.Fatalf("maybeRotateSupervisorLog: %v", err)
+	}
+
+	if _, err := writer.WriteString("post-rotation line\n"); err != nil {
+		t.Fatalf("write via pre-rotation fd: %v", err)
+	}
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read active log: %v", err)
+	}
+	if string(got) != "post-rotation line\n" {
+		t.Fatalf("active log = %q, want only the post-rotation line at offset 0", got)
+	}
+}
+
+func TestMaybeRotateSupervisorLogSameSecondRotationsGetUniqueNames(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "supervisor.log")
+	setSupervisorLogRotation(t, 8, 5)
+	now := time.Date(2026, 7, 3, 10, 11, 12, 0, time.UTC)
+
+	for _, generation := range []string{"first generation\n", "second generation\n"} {
+		if err := os.WriteFile(logPath, []byte(generation), 0o644); err != nil {
+			t.Fatalf("seed log: %v", err)
+		}
+		if err := maybeRotateSupervisorLog(logPath, now); err != nil {
+			t.Fatalf("maybeRotateSupervisorLog(%q): %v", generation, err)
+		}
+	}
+
+	archives := listSupervisorLogArchives(t, logPath)
+	want := []string{
+		logPath + ".archive-20260703T101112Z-1.gz",
+		logPath + ".archive-20260703T101112Z.gz",
+	}
+	if len(archives) != 2 || archives[0] != want[0] || archives[1] != want[1] {
+		t.Fatalf("archives = %v, want %v", archives, want)
+	}
+	if got := gunzipSupervisorLogArchive(t, logPath+".archive-20260703T101112Z.gz"); got != "first generation\n" {
+		t.Fatalf("first archive = %q, want first generation", got)
+	}
+	if got := gunzipSupervisorLogArchive(t, logPath+".archive-20260703T101112Z-1.gz"); got != "second generation\n" {
+		t.Fatalf("second archive = %q, want second generation", got)
+	}
+}
+
+func TestMaybeRotateSupervisorLogPrunesOldestArchives(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "supervisor.log")
+	setSupervisorLogRotation(t, 8, 2)
+
+	now := time.Date(2026, 7, 3, 10, 11, 12, 0, time.UTC)
+	preexisting := []struct {
+		name string
+		mod  time.Time
+	}{
+		{"supervisor.log.archive-20260703T070000Z.gz", now.Add(-3 * time.Hour)},
+		{"supervisor.log.archive-20260703T080000Z.gz", now.Add(-2 * time.Hour)},
+		{"supervisor.log.archive-20260703T090000Z.gz", now.Add(-1 * time.Hour)},
+	}
+	for _, a := range preexisting {
+		p := filepath.Join(dir, a.name)
+		if err := os.WriteFile(p, []byte("old archive"), 0o644); err != nil {
+			t.Fatalf("seed archive %s: %v", a.name, err)
+		}
+		if err := os.Chtimes(p, a.mod, a.mod); err != nil {
+			t.Fatalf("chtimes %s: %v", a.name, err)
+		}
+	}
+	if err := os.WriteFile(logPath, []byte("over-cap active log\n"), 0o644); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	if err := maybeRotateSupervisorLog(logPath, now); err != nil {
+		t.Fatalf("maybeRotateSupervisorLog: %v", err)
+	}
+
+	archives := listSupervisorLogArchives(t, logPath)
+	want := []string{
+		logPath + ".archive-20260703T090000Z.gz",
+		logPath + ".archive-20260703T101112Z.gz",
+	}
+	if len(archives) != 2 || archives[0] != want[0] || archives[1] != want[1] {
+		t.Fatalf("archives = %v, want oldest pruned down to %v", archives, want)
+	}
+}
+
+func TestMaybeRotateSupervisorLogDirectoryPathErrors(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "supervisor.log")
+	setSupervisorLogRotation(t, 1, 3)
+	if err := os.Mkdir(logPath, 0o700); err != nil {
+		t.Fatalf("seed log path as directory: %v", err)
+	}
+
+	err := maybeRotateSupervisorLog(logPath, time.Now())
+	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Fatalf("maybeRotateSupervisorLog on directory = %v, want is-a-directory error", err)
+	}
+}
+
+// TestRunSupervisorRotatesOversizedLogAtStartup confirms the wiring: a
+// supervisor start with an over-cap supervisor.log archives it before any
+// new output is appended, so a service-manager crash-loop (the #3897
+// incident shape: launchd KeepAlive relaunching a bind-failing supervisor
+// every few seconds for two days, 645MB log) is bounded at the cap plus a
+// handful of compressed archives.
+func TestRunSupervisorRotatesOversizedLogAtStartup(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+	setSupervisorLogRotation(t, 1024, 3)
+
+	logPath := filepath.Join(gcHome, "supervisor.log")
+	historic := strings.Repeat("api: listen 127.0.0.1:8372 failed: bind: address already in use\n", 64)
+	if err := os.WriteFile(logPath, []byte(historic), 0o644); err != nil {
+		t.Fatalf("seed oversized log: %v", err)
+	}
+
+	oldLoadConfig := supervisorLoadConfig
+	supervisorLoadConfig = func(string) (supervisor.Config, error) {
+		return supervisor.Config{}, errors.New("stop after log setup")
+	}
+	t.Cleanup(func() { supervisorLoadConfig = oldLoadConfig })
+
+	var stdout, stderr bytes.Buffer
+	if code := runSupervisor(&stdout, &stderr); code != 1 {
+		t.Fatalf("runSupervisor code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+
+	archives := listSupervisorLogArchives(t, logPath)
+	if len(archives) != 1 {
+		t.Fatalf("archives = %v, want exactly one after startup rotation", archives)
+	}
+	if got := gunzipSupervisorLogArchive(t, archives[0]); got != historic {
+		t.Fatalf("archive content mismatch: got %d bytes, want %d bytes", len(got), len(historic))
+	}
+
+	active, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read active log: %v", err)
+	}
+	if strings.Contains(string(active), "address already in use") {
+		t.Fatalf("active log still holds pre-rotation content: %q", active)
+	}
+	if !strings.Contains(string(active), "stop after log setup") {
+		t.Fatalf("active log = %q, want the new instance's output after rotation", active)
+	}
+}

--- a/cmd/gc/supervisor_log_rotation_test.go
+++ b/cmd/gc/supervisor_log_rotation_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -67,7 +68,7 @@ func TestMaybeRotateSupervisorLogBelowCapIsNoop(t *testing.T) {
 		t.Fatalf("seed log: %v", err)
 	}
 
-	if err := maybeRotateSupervisorLog(logPath, time.Now()); err != nil {
+	if err := maybeRotateSupervisorLog(logPath, time.Now(), io.Discard); err != nil {
 		t.Fatalf("maybeRotateSupervisorLog: %v", err)
 	}
 
@@ -87,7 +88,7 @@ func TestMaybeRotateSupervisorLogMissingFileIsNoop(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "supervisor.log")
 	setSupervisorLogRotation(t, 1, 3)
 
-	if err := maybeRotateSupervisorLog(logPath, time.Now()); err != nil {
+	if err := maybeRotateSupervisorLog(logPath, time.Now(), io.Discard); err != nil {
 		t.Fatalf("maybeRotateSupervisorLog on missing file: %v", err)
 	}
 	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
@@ -104,7 +105,7 @@ func TestMaybeRotateSupervisorLogArchivesAndTruncates(t *testing.T) {
 	}
 
 	now := time.Date(2026, 7, 3, 10, 11, 12, 0, time.UTC)
-	if err := maybeRotateSupervisorLog(logPath, now); err != nil {
+	if err := maybeRotateSupervisorLog(logPath, now, io.Discard); err != nil {
 		t.Fatalf("maybeRotateSupervisorLog: %v", err)
 	}
 
@@ -147,7 +148,7 @@ func TestMaybeRotateSupervisorLogPreservesAppendWriters(t *testing.T) {
 	}
 	defer writer.Close() //nolint:errcheck // test handle
 
-	if err := maybeRotateSupervisorLog(logPath, time.Now()); err != nil {
+	if err := maybeRotateSupervisorLog(logPath, time.Now(), io.Discard); err != nil {
 		t.Fatalf("maybeRotateSupervisorLog: %v", err)
 	}
 
@@ -172,7 +173,7 @@ func TestMaybeRotateSupervisorLogSameSecondRotationsGetUniqueNames(t *testing.T)
 		if err := os.WriteFile(logPath, []byte(generation), 0o644); err != nil {
 			t.Fatalf("seed log: %v", err)
 		}
-		if err := maybeRotateSupervisorLog(logPath, now); err != nil {
+		if err := maybeRotateSupervisorLog(logPath, now, io.Discard); err != nil {
 			t.Fatalf("maybeRotateSupervisorLog(%q): %v", generation, err)
 		}
 	}
@@ -220,7 +221,7 @@ func TestMaybeRotateSupervisorLogPrunesOldestArchives(t *testing.T) {
 		t.Fatalf("seed log: %v", err)
 	}
 
-	if err := maybeRotateSupervisorLog(logPath, now); err != nil {
+	if err := maybeRotateSupervisorLog(logPath, now, io.Discard); err != nil {
 		t.Fatalf("maybeRotateSupervisorLog: %v", err)
 	}
 
@@ -241,9 +242,159 @@ func TestMaybeRotateSupervisorLogDirectoryPathErrors(t *testing.T) {
 		t.Fatalf("seed log path as directory: %v", err)
 	}
 
-	err := maybeRotateSupervisorLog(logPath, time.Now())
+	err := maybeRotateSupervisorLog(logPath, time.Now(), io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "is a directory") {
 		t.Fatalf("maybeRotateSupervisorLog on directory = %v, want is-a-directory error", err)
+	}
+}
+
+// TestMaybeRotateSupervisorLogBoundsArchiveAndWarnsOnDroppedTail pins the
+// archive bound: an oversized log is archived only up to
+// supervisorLogArchiveMaxBytes, the tail beyond the bound is dropped with a
+// warning, and the active log is still truncated.
+func TestMaybeRotateSupervisorLogBoundsArchiveAndWarnsOnDroppedTail(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "supervisor.log")
+	setSupervisorLogRotation(t, 1024, 3)
+	prevBound := supervisorLogArchiveMaxBytes
+	supervisorLogArchiveMaxBytes = 2048
+	t.Cleanup(func() { supervisorLogArchiveMaxBytes = prevBound })
+
+	content := strings.Repeat("b", 8192)
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	var warn bytes.Buffer
+	if err := maybeRotateSupervisorLog(logPath, time.Now(), &warn); err != nil {
+		t.Fatalf("maybeRotateSupervisorLog: %v", err)
+	}
+
+	archives := listSupervisorLogArchives(t, logPath)
+	if len(archives) != 1 {
+		t.Fatalf("archives = %v, want exactly one", archives)
+	}
+	if got := gunzipSupervisorLogArchive(t, archives[0]); got != content[:2048] {
+		t.Fatalf("archive holds %d bytes, want the first 2048 bytes of the log", len(got))
+	}
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat active log: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("active log size = %d, want 0 after rotation", info.Size())
+	}
+	if !strings.Contains(warn.String(), "archive bound") {
+		t.Fatalf("warn = %q, want dropped-tail notice mentioning the archive bound", warn.String())
+	}
+}
+
+// TestMaybeRotateSupervisorLogSweepsStagingLeftovers pins the staging
+// sweep: .archive-*.tmp leftovers from rotations that crashed between
+// staging and rename are removed by the next successful rotation.
+func TestMaybeRotateSupervisorLogSweepsStagingLeftovers(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "supervisor.log")
+	setSupervisorLogRotation(t, 1024, 3)
+	leftover := logPath + ".archive-12345.tmp"
+	if err := os.WriteFile(leftover, []byte("half-staged archive"), 0o644); err != nil {
+		t.Fatalf("seed staging leftover: %v", err)
+	}
+	content := strings.Repeat("api: listen 127.0.0.1:8372 failed\n", 64)
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	if err := maybeRotateSupervisorLog(logPath, time.Now(), io.Discard); err != nil {
+		t.Fatalf("maybeRotateSupervisorLog: %v", err)
+	}
+
+	if _, err := os.Stat(leftover); !os.IsNotExist(err) {
+		t.Fatalf("stat staging leftover = %v, want swept away", err)
+	}
+	if archives := listSupervisorLogArchives(t, logPath); len(archives) != 1 {
+		t.Fatalf("archives = %v, want exactly one intact archive", archives)
+	}
+}
+
+// tryGunzipSupervisorLogArchive decompresses one archive, returning an
+// error instead of failing the test so concurrency tests can treat a
+// corrupt archive as "contributes nothing" rather than aborting.
+func tryGunzipSupervisorLogArchive(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close() //nolint:errcheck // read-only test handle
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", err
+	}
+	defer gz.Close() //nolint:errcheck // read-only test handle
+	data, err := io.ReadAll(gz)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// TestMaybeRotateSupervisorLogConcurrentRotationsNeverLoseContent is the
+// concurrency regression for the #3897 hardening. Rotation used to stage
+// every racer's archive at one fixed path (<log>.archive.tmp), so one
+// racer's O_TRUNC wiped another's staged bytes before its rename: the
+// corrupt archive was renamed into place and the truncate then destroyed
+// the only intact copy of the log. Production serializes rotation under
+// the supervisor single-instance lock; this test drives the unlocked
+// rotation directly to pin the second layer of defense — per-rotation
+// os.CreateTemp staging must never lose content even without the lock.
+func TestMaybeRotateSupervisorLogConcurrentRotationsNeverLoseContent(t *testing.T) {
+	// keep must exceed the racer count: pruning a racer's full archive
+	// mid-race would read as a false content loss.
+	setSupervisorLogRotation(t, 1024, 32)
+	// Multi-megabyte content forces the gzip copy through several write
+	// syscalls, so racing rotations genuinely interleave instead of each
+	// landing one atomic write.
+	content := strings.Repeat("api: listen 127.0.0.1:8372 failed: bind: address already in use\n", 32*1024)
+
+	const rounds = 10
+	const racers = 16
+	for round := 0; round < rounds; round++ {
+		logPath := filepath.Join(t.TempDir(), "supervisor.log")
+		if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("round %d: seed log: %v", round, err)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for i := 0; i < racers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				// Stagger arrivals across the rotation window so late
+				// racers hit every phase of an in-flight rotation, the
+				// shape of supervisor processes racing at startup.
+				time.Sleep(time.Duration(i) * 500 * time.Microsecond)
+				// Individual racers may error (losing a staging or rename
+				// race); the invariant under test is content survival, not
+				// per-call success.
+				_ = maybeRotateSupervisorLog(logPath, time.Now(), io.Discard)
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		fullCopies := 0
+		archives := listSupervisorLogArchives(t, logPath)
+		for _, a := range archives {
+			if got, err := tryGunzipSupervisorLogArchive(a); err == nil && got == content {
+				fullCopies++
+			}
+		}
+		if active, err := os.ReadFile(logPath); err == nil && string(active) == content {
+			fullCopies++
+		}
+		if fullCopies == 0 {
+			t.Fatalf("round %d: original log content lost: no intact copy across %d archives and the active log", round, len(archives))
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #3897.

Supervisor log rotation could race with a restarting supervisor: a second instance starting while the first rotated the log left a truncated or doubly-rotated file, and an unbounded archive set could grow without limit.

## Changes
- Rotate the supervisor log under the single-instance lock. The prior-instance stat now runs ahead of lock acquisition, and a losing racer exits before touching the log, so only the lock holder rotates.
- Bound the archive set to 1GiB, dropping the oldest tail with a warning rather than growing unbounded.
- Sweep leftover staging files from an interrupted prior rotation.

## Tests
- Rotation suite 19/19, including a new concurrency regression for racing starts, the 1GiB archive bound with dropped-tail warning, and the staging-leftover sweep. Tests ship in the same commit.

## Verification
`make build`, `go vet`, and `make check` all pass.
