### PR TITLE
fix(hooks): stop build_desired_state staging from double-writing reconciler-owned codex hooks

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -4917,13 +4917,19 @@ func materializeProviderOverlaysBeforeFingerprint(
 		PackOverlayDirs:     packDirs,
 		OverlayDir:          overlayDir,
 	})
+	// Skip reconciler-owned mergeable hook/settings files here: hooks.Install
+	// runs immediately after this staging on the SAME workDir (see
+	// prepareTemplateResolution), so it must be the sole writer of those files.
+	// Staging them too leaves two writers with disagreeing hook-entry matchers
+	// and a permanent codex-hooks-drift hybrid. The runtime
+	// task-worktree staging path keeps staging them — it is their sole writer.
 	for _, od := range packDirs {
-		if err := runtime.StageProviderOverlayDir(od, workDir, overlayProviders, stderr); err != nil {
+		if err := runtime.StageProviderOverlayDirSkippingMergeable(od, workDir, overlayProviders, stderr); err != nil {
 			fmt.Fprintf(stderr, "agent %q: pack overlay %q: %v\n", qualifiedName, od, err) //nolint:errcheck
 		}
 	}
 	if overlayDir != "" {
-		if err := runtime.StageProviderOverlayDir(overlayDir, workDir, overlayProviders, stderr); err != nil {
+		if err := runtime.StageProviderOverlayDirSkippingMergeable(overlayDir, workDir, overlayProviders, stderr); err != nil {
 			fmt.Fprintf(stderr, "agent %q: overlay %q: %v\n", qualifiedName, overlayDir, err) //nolint:errcheck
 		}
 	}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -4919,10 +4919,21 @@ func materializeProviderOverlaysBeforeFingerprint(
 	})
 	// Skip reconciler-owned mergeable hook/settings files here: hooks.Install
 	// runs immediately after this staging on the SAME workDir (see
-	// prepareTemplateResolution), so it must be the sole writer of those files.
-	// Staging them too leaves two writers with disagreeing hook-entry matchers
-	// and a permanent codex-hooks-drift hybrid. The runtime
-	// task-worktree staging path keeps staging them — it is their sole writer.
+	// prepareTemplateResolution), so it must be the sole writer of those files
+	// ON THE RECONCILE TICK. Staging them too leaves two writers with
+	// disagreeing hook-entry matchers and a permanent codex-hooks-drift hybrid.
+	// The runtime task-worktree staging path keeps staging them — it is their
+	// sole writer.
+	//
+	// "Sole writer" is scoped to the tick on purpose. For a persistent
+	// (non-task) agent the home dir is also the session workDir, and
+	// session-start staging writes these same files through the NON-skipping
+	// path — internal/runtime/tmux.stageStartFiles and
+	// runtime.StageSessionWorkDir (subprocess/acp) both call
+	// StageProviderOverlayDir with a nil skip. So a hybrid document can
+	// reappear at session start; the next tick converges it. That turns the
+	// permanent drift this fix targets into a transient one, which is the
+	// actual invariant — not that nothing else ever writes these paths.
 	for _, od := range packDirs {
 		if err := runtime.StageProviderOverlayDirSkippingMergeable(od, workDir, overlayProviders, stderr); err != nil {
 			fmt.Fprintf(stderr, "agent %q: pack overlay %q: %v\n", qualifiedName, od, err) //nolint:errcheck

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1238,7 +1238,7 @@ func stageHookFiles(copyFiles []runtime.CopyEntry, cityPath, workDir string, hoo
 			if _, err := os.Stat(abs); err == nil {
 				copyFiles = append(copyFiles, runtime.CopyEntry{
 					Src: abs, RelDst: path.Join(relWorkDir, rel),
-					Probed: true, ContentHash: runtime.HashPathContent(abs),
+					Probed: true, ContentHash: runtime.HashHookSettingsContent(abs, rel),
 				})
 			}
 		}

--- a/cmd/gc/codex_hooks_dual_write_test.go
+++ b/cmd/gc/codex_hooks_dual_write_test.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/bootstrap/packs/core"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/hooks"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// seedCodexOverlay writes the real embedded core codex hooks overlay into a
+// temp overlay source dir (per-provider/codex/.codex/hooks.json) so staging and
+// hooks.Install operate on the same bytes the reconciler uses in production.
+func seedCodexOverlay(t *testing.T) string {
+	t.Helper()
+	data, err := core.PackFS.ReadFile("overlay/per-provider/codex/.codex/hooks.json")
+	if err != nil {
+		t.Fatalf("read embedded codex hooks overlay: %v", err)
+	}
+	src := t.TempDir()
+	dstDir := filepath.Join(src, "per-provider", "codex", ".codex")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatalf("mkdir codex overlay: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dstDir, "hooks.json"), data, 0o644); err != nil {
+		t.Fatalf("write codex overlay: %v", err)
+	}
+	return src
+}
+
+// codexSessionStartMatchers returns the "matcher" value of every SessionStart
+// hook entry in a codex hooks.json document.
+func codexSessionStartMatchers(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	matchers := make([]string, 0, len(doc.Hooks["SessionStart"]))
+	for _, e := range doc.Hooks["SessionStart"] {
+		matchers = append(matchers, e.Matcher)
+	}
+	return matchers
+}
+
+// driftedCodexHooks is a live hybrid captured from a drifted Codex
+// agent (see #3866 / #3808): the reconciler's bound `matcher:"startup"`
+// SessionStart entry coexisting with the overlay's pre-#3866 unbound
+// `matcher:""` `gc prime` entry, plus the unbound PreCompact/UserPromptSubmit
+// entries. `gc doctor` flags this as codex-hooks-drift ("needs upgrade")
+// forever because the two writers keep re-seeding disagreeing matchers.
+const driftedCodexHooks = `{
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff --auto --hook-format codex \"context cycle\"",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc --city '__CITY__' prime --hook --hook-format codex",
+            "type": "command"
+          }
+        ],
+        "matcher": "startup"
+      },
+      {
+        "hooks": [
+          {
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- nudge drain --inject --hook-format codex",
+            "type": "command"
+          },
+          {
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook run --timeout 15s --timeout-exit-code 0 -- mail check --inject --hook-format codex",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  }
+}`
+
+// seedDriftedHybrid writes the live hybrid fixture into workDir/.codex/hooks.json
+// with its bound SessionStart entry pinned to cityDir, reproducing the drifted
+// starting state a reconcile tick must converge.
+func seedDriftedHybrid(t *testing.T, cityDir, workDir string) {
+	t.Helper()
+	dir := filepath.Join(workDir, ".codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	body := strings.ReplaceAll(driftedCodexHooks, "__CITY__", cityDir)
+	if err := os.WriteFile(filepath.Join(dir, "hooks.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("seed drifted hybrid: %v", err)
+	}
+}
+
+// stageCodex runs the staging half of the build_desired_state home-dir tick.
+// skipMergeable selects the fixed (skip) vs legacy (no-skip) path.
+func stageCodex(t *testing.T, overlaySrc, workDir string, skipMergeable bool) {
+	t.Helper()
+	var err error
+	if skipMergeable {
+		err = runtime.StageProviderOverlayDirSkippingMergeable(overlaySrc, workDir, []string{"codex"}, nil)
+	} else {
+		err = runtime.StageProviderOverlayDir(overlaySrc, workDir, []string{"codex"}, nil)
+	}
+	if err != nil {
+		t.Fatalf("stage codex overlay (skip=%v): %v", skipMergeable, err)
+	}
+}
+
+// installCodex runs the hooks.Install half of the tick on the same workDir.
+func installCodex(t *testing.T, cityDir, workDir string) {
+	t.Helper()
+	if err := hooks.Install(fsys.OSFS{}, cityDir, workDir, []string{"codex"}); err != nil {
+		t.Fatalf("hooks.Install codex: %v", err)
+	}
+}
+
+// TestCodexHooksConvergeWithSkipStaging is the dual-writer reproduce+fix test.
+//
+// The build_desired_state home-dir tick is staging followed by hooks.Install on
+// the SAME dir. Starting from the live drifted hybrid, hooks.Install converges
+// the document to a single bound SessionStart entry — but the LEGACY staging
+// path re-merges the overlay's unbound `matcher:""` entry back in on the very
+// next tick, so the on-disk document a fresh `gc doctor`/session-start reads
+// right after staging is perpetually drifted ([startup, ""]). That oscillation
+// is why codex-hooks-drift never clears without --fix.
+//
+// The observation point that matters is therefore the post-staging state. With
+// the skip path staging no longer touches the mergeable file, so the converged
+// [startup] document is stable at every point in the cycle.
+func TestCodexHooksConvergeWithSkipStaging(t *testing.T) {
+	overlaySrc := seedCodexOverlay(t)
+	cityDir := t.TempDir()
+
+	assertSingleBound := func(t *testing.T, workDir, when string) {
+		t.Helper()
+		hooksPath := filepath.Join(workDir, ".codex", "hooks.json")
+		matchers := codexSessionStartMatchers(t, hooksPath)
+		data, _ := os.ReadFile(hooksPath)
+		if len(matchers) != 1 || matchers[0] != "startup" {
+			t.Fatalf("%s: SessionStart matchers = %v, want exactly [startup] (converged, bound)\n%s", when, matchers, data)
+		}
+		if !strings.Contains(string(data), "--city") {
+			t.Fatalf("%s: converged SessionStart not bound to city root (missing --city)\n%s", when, data)
+		}
+		if strings.Contains(string(data), "gc prime --hook") {
+			t.Fatalf("%s: unbound `gc prime` SessionStart entry still present (drift)\n%s", when, data)
+		}
+	}
+
+	// assertManagedEventsIntact guards the dual-writer regression surface. Because
+	// the home-dir staging path now skips the ENTIRE .codex/hooks.json, hooks.Install
+	// must remain the sole, COMPLETE writer: the converged document has to keep the
+	// managed PreCompact (context-cycle handoff) and UserPromptSubmit (mail check +
+	// nudge drain) hooks, not just SessionStart. A future change to the installer's
+	// fresh-write/upgrade path that dropped either event would otherwise slip past
+	// assertSingleBound, which only inspects SessionStart.
+	assertManagedEventsIntact := func(t *testing.T, workDir, when string) {
+		t.Helper()
+		hooksPath := filepath.Join(workDir, ".codex", "hooks.json")
+		data, err := os.ReadFile(hooksPath)
+		if err != nil {
+			t.Fatalf("%s: read %s: %v", when, hooksPath, err)
+		}
+		var doc struct {
+			Hooks map[string][]struct {
+				Hooks []struct {
+					Command string `json:"command"`
+				} `json:"hooks"`
+			} `json:"hooks"`
+		}
+		if err := json.Unmarshal(data, &doc); err != nil {
+			t.Fatalf("%s: unmarshal %s: %v", when, hooksPath, err)
+		}
+		commandsFor := func(event string) string {
+			var b strings.Builder
+			for _, e := range doc.Hooks[event] {
+				for _, h := range e.Hooks {
+					b.WriteString(h.Command)
+					b.WriteByte('\n')
+				}
+			}
+			return b.String()
+		}
+		if !strings.Contains(commandsFor("PreCompact"), "handoff") {
+			t.Fatalf("%s: converged doc dropped the managed PreCompact handoff hook\n%s", when, data)
+		}
+		prompt := commandsFor("UserPromptSubmit")
+		if !strings.Contains(prompt, "mail check") || !strings.Contains(prompt, "nudge drain") {
+			t.Fatalf("%s: converged doc dropped managed UserPromptSubmit hooks (want mail check + nudge drain)\n%s", when, data)
+		}
+	}
+
+	// Fixed path: seed the drifted hybrid, then run stage → install → stage.
+	// The file must be converged and bound at EVERY observation point, including
+	// the post-staging states where the legacy path re-drifts.
+	fixedWork := t.TempDir()
+	seedDriftedHybrid(t, cityDir, fixedWork)
+	stageCodex(t, overlaySrc, fixedWork, true)
+	installCodex(t, cityDir, fixedWork)
+	assertSingleBound(t, fixedWork, "fixed after install")
+	assertManagedEventsIntact(t, fixedWork, "fixed after install")
+	stageCodex(t, overlaySrc, fixedWork, true)
+	assertSingleBound(t, fixedWork, "fixed after re-stage")
+	assertManagedEventsIntact(t, fixedWork, "fixed after re-stage")
+
+	// Legacy path: identical sequence with non-skip staging. After the trailing
+	// staging step the unbound overlay entry is merged back in, re-creating the
+	// hybrid a reconcile tick can never settle. This is the drift the fix removes.
+	legacyWork := t.TempDir()
+	seedDriftedHybrid(t, cityDir, legacyWork)
+	stageCodex(t, overlaySrc, legacyWork, false)
+	installCodex(t, cityDir, legacyWork)
+	stageCodex(t, overlaySrc, legacyWork, false)
+	legacyMatchers := codexSessionStartMatchers(t, filepath.Join(legacyWork, ".codex", "hooks.json"))
+	if len(legacyMatchers) <= 1 {
+		t.Fatalf("expected legacy non-skip staging to re-drift the hybrid (>1 SessionStart entry) after re-staging, got %v; if this no longer reproduces, the dual-write may have been fixed elsewhere — re-verify the skip is still required", legacyMatchers)
+	}
+}
+
+// TestMaterializeProviderOverlays_SkipsMergeableCodexHook guards the production
+// caller wiring: materializeProviderOverlaysBeforeFingerprint (the
+// staging-only half of prepareTemplateResolution) must skip the reconciler-owned
+// mergeable .codex/hooks.json while still staging non-mergeable overlay
+// siblings. This is the observation point where skip vs non-skip staging
+// diverge — the trailing hooks.Install converges either way, so only the
+// staging-only state distinguishes a reverted caller wiring.
+func TestMaterializeProviderOverlays_SkipsMergeableCodexHook(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "myrig")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	overlayDir := filepath.Join(cityDir, "packs", "myrig", "overlay")
+	codexOverlay := filepath.Join(overlayDir, "per-provider", "codex", ".codex")
+	if err := os.MkdirAll(codexOverlay, 0o755); err != nil {
+		t.Fatalf("MkdirAll(overlay): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexOverlay, "hooks.json"), []byte(`{"hooks":{"SessionStart":[]}}`), 0o644); err != nil {
+		t.Fatalf("write codex hooks overlay: %v", err)
+	}
+	sibling := filepath.Join(overlayDir, "per-provider", "codex", "AGENTS.codex.md")
+	if err := os.WriteFile(sibling, []byte("codex"), 0o644); err != nil {
+		t.Fatalf("write codex sibling overlay: %v", err)
+	}
+
+	codexBase := "builtin:codex"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:     "polecat",
+			Provider: "codex",
+			Scope:    "rig",
+			Dir:      "myrig",
+		}},
+		Providers: map[string]config.ProviderSpec{
+			// Explicit command + resume_command so resolution does not depend on
+			// a real codex binary on PATH; base still yields the codex family.
+			"codex": {Base: &codexBase, Command: "/bin/echo", ResumeCommand: "/bin/echo resume {{.SessionKey}}"},
+		},
+		Rigs:           []config.Rig{{Name: "myrig", Path: rigDir}},
+		RigOverlayDirs: map[string][]string{"myrig": {overlayDir}},
+	}
+
+	bp := newAgentBuildParams("test-city", cityDir, cfg, runtime.NewFake(), time.Now().UTC(), nil, io.Discard)
+	cfgAgent := &cfg.Agents[0]
+	resolved, err := config.ResolveProvider(cfgAgent, bp.workspace, bp.providers, bp.lookPath)
+	if err != nil {
+		t.Fatalf("ResolveProvider: %v", err)
+	}
+	workDir, err := resolveConfiguredWorkDir(bp.cityPath, bp.cityName, "myrig/polecat", cfgAgent, bp.rigs)
+	if err != nil {
+		t.Fatalf("resolveConfiguredWorkDir: %v", err)
+	}
+	rigName := sessionSetupContextForAgent(bp.cityPath, bp.cityName, "myrig/polecat", cfgAgent, bp.rigs).Rig
+
+	// Staging only — hooks.Install is a separate step in prepareTemplateResolution.
+	materializeProviderOverlaysBeforeFingerprint(bp, cfgAgent, resolved, "myrig/polecat", rigName, workDir, io.Discard)
+
+	if _, err := os.Stat(filepath.Join(workDir, ".codex", "hooks.json")); !os.IsNotExist(err) {
+		t.Fatalf("build_desired_state staging wrote reconciler-owned .codex/hooks.json (err=%v); caller must use the skip variant so hooks.Install is sole writer", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "AGENTS.codex.md")); err != nil {
+		t.Fatalf("non-mergeable codex overlay sibling not staged: %v", err)
+	}
+}

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -45,7 +45,7 @@ func CopyFileOrDir(src, dst string, stderr io.Writer) error {
 // If srcDir does not exist, returns nil (no-op).
 // Individual file copy failures are logged to stderr but don't abort.
 func CopyDir(srcDir, dstDir string, stderr io.Writer) error {
-	return copyDir(srcDir, dstDir, stderr, nil)
+	return copyDir(srcDir, dstDir, stderr, nil, nil)
 }
 
 type preserveExistingFunc func(relPath string) bool
@@ -61,12 +61,15 @@ type preserveExistingFunc func(relPath string) bool
 // legitimately needs to copy a tree containing a top-level `.gc/` would need a
 // variant that does not carry this guard. Names merely prefixed with ".gc"
 // (e.g. ".gcignore") are not matched.
+//
+// It is unconditional: a caller-supplied SkipFunc can only skip more, never
+// re-enable staging of the runtime mirror.
 func skipRuntimeMirror(relPath string) bool {
 	clean := filepath.Clean(relPath)
 	return clean == ".gc" || strings.HasPrefix(clean, ".gc"+string(filepath.Separator))
 }
 
-func copyDir(srcDir, dstDir string, stderr io.Writer, preserveExisting preserveExistingFunc) error {
+func copyDir(srcDir, dstDir string, stderr io.Writer, preserveExisting preserveExistingFunc, skip SkipFunc) error {
 	info, err := os.Stat(srcDir)
 	if os.IsNotExist(err) {
 		return nil // Missing source dir is a no-op (like Gas Town).
@@ -77,11 +80,14 @@ func copyDir(srcDir, dstDir string, stderr io.Writer, preserveExisting preserveE
 	if !info.IsDir() {
 		return fmt.Errorf("overlay: %q is not a directory", srcDir)
 	}
-	return copyDirRecursive(srcDir, dstDir, "", stderr, preserveExisting)
+	return copyDirRecursive(srcDir, dstDir, "", stderr, preserveExisting, skip)
 }
 
-// copyDirRecursive walks srcBase/rel and copies files into dstBase/rel.
-func copyDirRecursive(srcBase, dstBase, rel string, stderr io.Writer, preserveExisting preserveExistingFunc) error {
+// copyDirRecursive walks srcBase/rel and copies files into dstBase/rel. The
+// runtime `.gc` mirror is always skipped. When skip is non-nil, entries for
+// which it returns true are additionally omitted (files and whole subtrees),
+// matching CopyDirWithSkip semantics on the best-effort path.
+func copyDirRecursive(srcBase, dstBase, rel string, stderr io.Writer, preserveExisting preserveExistingFunc, skip SkipFunc) error {
 	srcPath := srcBase
 	if rel != "" {
 		srcPath = filepath.Join(srcBase, rel)
@@ -98,7 +104,7 @@ func copyDirRecursive(srcBase, dstBase, rel string, stderr io.Writer, preserveEx
 			entryRel = filepath.Join(rel, entry.Name())
 		}
 
-		if skipRuntimeMirror(entryRel) {
+		if skipRuntimeMirror(entryRel) || (skip != nil && skip(entryRel, entry.IsDir())) {
 			continue
 		}
 
@@ -109,7 +115,7 @@ func copyDirRecursive(srcBase, dstBase, rel string, stderr io.Writer, preserveEx
 				fmt.Fprintf(stderr, "overlay: mkdir %q: %v\n", dstSubDir, err) //nolint:errcheck
 				continue
 			}
-			if err := copyDirRecursive(srcBase, dstBase, entryRel, stderr, preserveExisting); err != nil {
+			if err := copyDirRecursive(srcBase, dstBase, entryRel, stderr, preserveExisting, skip); err != nil {
 				fmt.Fprintf(stderr, "overlay: %v\n", err) //nolint:errcheck
 			}
 			continue
@@ -216,6 +222,29 @@ func HasProviderDir(srcDir, providerName string) bool {
 	return err == nil && info.IsDir()
 }
 
+// isPerProviderPath reports whether relPath is the per-provider/ directory
+// itself or any entry beneath it. Universal overlay copies skip this subtree so
+// per-provider files are staged only for the resolved provider slots.
+func isPerProviderPath(relPath string) bool {
+	return relPath == PerProviderDir || filepath.Dir(relPath) == PerProviderDir ||
+		len(relPath) > len(PerProviderDir)+1 && relPath[:len(PerProviderDir)+1] == PerProviderDir+string(filepath.Separator)
+}
+
+// universalOverlaySkip composes the skips for the universal (non per-provider)
+// copy phase. That phase runs through CopyDirWithSkip, which does not carry
+// copyDirRecursive's unconditional runtime-mirror guard, so the guard is
+// applied here explicitly: the runtime `.gc` mirror is never staged, the
+// per-provider/ subtree is deferred to the resolved provider slots, and the
+// caller's optional skip may only skip more.
+func universalOverlaySkip(skip SkipFunc) SkipFunc {
+	return func(relPath string, isDir bool) bool {
+		if skipRuntimeMirror(relPath) || isPerProviderPath(relPath) {
+			return true
+		}
+		return skip != nil && skip(relPath, isDir)
+	}
+}
+
 // CopyDirForProvider copies overlay files with provider awareness:
 //  1. Copies everything EXCEPT the per-provider/ subtree (universal files).
 //  2. If per-provider/<providerName>/ exists, copies its contents into dst
@@ -234,23 +263,15 @@ func CopyDirForProvider(srcDir, dstDir, providerName string, stderr io.Writer) e
 		return fmt.Errorf("overlay: %q is not a directory", srcDir)
 	}
 
-	// Step 1: copy universal files (skip per-provider/).
-	skip := func(relPath string, _ bool) bool {
-		if skipRuntimeMirror(relPath) {
-			return true
-		}
-		// Skip the per-provider directory itself and all its contents.
-		return relPath == PerProviderDir || filepath.Dir(relPath) == PerProviderDir ||
-			len(relPath) > len(PerProviderDir)+1 && relPath[:len(PerProviderDir)+1] == PerProviderDir+string(filepath.Separator)
-	}
-	if err := CopyDirWithSkip(srcDir, dstDir, skip, stderr); err != nil {
+	// Step 1: copy universal files (skip per-provider/ and the runtime mirror).
+	if err := CopyDirWithSkip(srcDir, dstDir, universalOverlaySkip(nil), stderr); err != nil {
 		return err
 	}
 
 	// Step 2: copy provider-specific files (flattened into dst).
 	if providerName != "" {
 		providerDir := filepath.Join(srcDir, PerProviderDir, providerName)
-		if err := copyDir(providerDir, dstDir, stderr, providerPreserveExisting(providerName)); err != nil {
+		if err := copyDir(providerDir, dstDir, stderr, providerPreserveExisting(providerName), nil); err != nil {
 			return err
 		}
 	}
@@ -270,6 +291,21 @@ func CopyDirForProvider(srcDir, dstDir, providerName string, stderr io.Writer) e
 // wins when two providers ship the same rel path (last-writer-wins via
 // overwrite or JSON merge).
 func CopyDirForProviders(srcDir, dstDir string, providers []string, stderr io.Writer) error {
+	return CopyDirForProvidersWithSkip(srcDir, dstDir, providers, nil, stderr)
+}
+
+// CopyDirForProvidersWithSkip behaves like CopyDirForProviders but additionally
+// omits any file for which skip returns true, in BOTH the universal and the
+// per-provider copy phases.
+//
+// It exists for the build_desired_state home-dir staging path: that
+// path stages provider overlays and then runs hooks.Install on the SAME
+// directory. Reconciler-owned mergeable files (overlay.IsMergeablePath —
+// .codex/hooks.json et al.) must be skipped here so hooks.Install is the sole
+// writer and the two writers cannot leave a permanent hybrid hook document. The
+// runtime task-worktree staging path passes a nil skip and keeps staging those
+// files, because there hooks.Install never runs and staging is the sole writer.
+func CopyDirForProvidersWithSkip(srcDir, dstDir string, providers []string, skip SkipFunc, stderr io.Writer) error {
 	info, err := os.Stat(srcDir)
 	if os.IsNotExist(err) {
 		return nil
@@ -281,19 +317,14 @@ func CopyDirForProviders(srcDir, dstDir string, providers []string, stderr io.Wr
 		return fmt.Errorf("overlay: %q is not a directory", srcDir)
 	}
 
-	// Step 1: copy universal files (skip per-provider/).
-	skip := func(relPath string, _ bool) bool {
-		if skipRuntimeMirror(relPath) {
-			return true
-		}
-		return relPath == PerProviderDir || filepath.Dir(relPath) == PerProviderDir ||
-			len(relPath) > len(PerProviderDir)+1 && relPath[:len(PerProviderDir)+1] == PerProviderDir+string(filepath.Separator)
-	}
-	if err := CopyDirWithSkip(srcDir, dstDir, skip, stderr); err != nil {
+	// Step 1: copy universal files (skip per-provider/, the runtime mirror, and
+	// caller-skipped paths).
+	if err := CopyDirWithSkip(srcDir, dstDir, universalOverlaySkip(skip), stderr); err != nil {
 		return err
 	}
 
-	// Step 2: copy per-provider slots in order, deduped.
+	// Step 2: copy per-provider slots in order, deduped. The caller skip is
+	// applied to the flattened per-provider rel paths (e.g. .codex/hooks.json).
 	seen := make(map[string]bool, len(providers))
 	for _, p := range providers {
 		if p == "" || seen[p] {
@@ -301,7 +332,7 @@ func CopyDirForProviders(srcDir, dstDir string, providers []string, stderr io.Wr
 		}
 		seen[p] = true
 		providerDir := filepath.Join(srcDir, PerProviderDir, p)
-		if err := copyDir(providerDir, dstDir, stderr, providerPreserveExisting(p)); err != nil {
+		if err := copyDir(providerDir, dstDir, stderr, providerPreserveExisting(p), skip); err != nil {
 			return err
 		}
 	}

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -302,9 +302,14 @@ func CopyDirForProviders(srcDir, dstDir string, providers []string, stderr io.Wr
 // path stages provider overlays and then runs hooks.Install on the SAME
 // directory. Reconciler-owned mergeable files (overlay.IsMergeablePath —
 // .codex/hooks.json et al.) must be skipped here so hooks.Install is the sole
-// writer and the two writers cannot leave a permanent hybrid hook document. The
-// runtime task-worktree staging path passes a nil skip and keeps staging those
-// files, because there hooks.Install never runs and staging is the sole writer.
+// writer on that reconcile tick and the two writers cannot leave a permanent
+// hybrid hook document. The runtime task-worktree staging path passes a nil
+// skip and keeps staging those files, because there hooks.Install never runs
+// and staging is the sole writer.
+//
+// The skip does not make hooks.Install the only writer everywhere: for a
+// persistent agent, session-start staging writes the same paths via the
+// nil-skip path, so a hybrid can reappear until the next tick converges it.
 func CopyDirForProvidersWithSkip(srcDir, dstDir string, providers []string, skip SkipFunc, stderr io.Writer) error {
 	info, err := os.Stat(srcDir)
 	if os.IsNotExist(err) {

--- a/internal/overlay/skip_mergeable_test.go
+++ b/internal/overlay/skip_mergeable_test.go
@@ -1,0 +1,99 @@
+package overlay
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCopyDirForProvidersWithSkip_SkipsMergeablePerProviderFile locks the core
+// of the codex-hooks-drift fix: when the build_desired_state home-dir
+// staging path passes an IsMergeablePath skip, the reconciler-owned mergeable
+// hook file (.codex/hooks.json, shipped under per-provider/codex/) must NOT be
+// staged, so a subsequent hooks.Install pass is the sole writer. Non-mergeable
+// siblings and universal files must still be copied.
+func TestCopyDirForProvidersWithSkip_SkipsMergeablePerProviderFile(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Universal, non-mergeable file (must always copy).
+	mustWriteFile(t, filepath.Join(src, "AGENTS.md"), []byte("universal"), 0o644)
+	// Per-provider mergeable file (must be skipped when skip is supplied).
+	mustMkdirAll(t, filepath.Join(src, "per-provider", "codex", ".codex"))
+	mustWriteFile(t, filepath.Join(src, "per-provider", "codex", ".codex", "hooks.json"), []byte(`{"hooks":{}}`), 0o644)
+	// Per-provider non-mergeable file (must still copy).
+	mustWriteFile(t, filepath.Join(src, "per-provider", "codex", "AGENTS.codex.md"), []byte("codex"), 0o644)
+
+	skip := func(relPath string, isDir bool) bool {
+		return !isDir && IsMergeablePath(relPath)
+	}
+	if err := CopyDirForProvidersWithSkip(src, dst, []string{"codex"}, skip, io.Discard); err != nil {
+		t.Fatalf("CopyDirForProvidersWithSkip: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, ".codex", "hooks.json")); !os.IsNotExist(err) {
+		t.Fatalf("mergeable .codex/hooks.json staged despite skip (err=%v); hooks.Install must be sole writer", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(dst, "AGENTS.md")); err != nil || string(got) != "universal" {
+		t.Fatalf("universal AGENTS.md = %q err=%v, want %q staged", string(got), err, "universal")
+	}
+	if got, err := os.ReadFile(filepath.Join(dst, "AGENTS.codex.md")); err != nil || string(got) != "codex" {
+		t.Fatalf("per-provider non-mergeable AGENTS.codex.md = %q err=%v, want %q staged", string(got), err, "codex")
+	}
+}
+
+// TestCopyDirForProvidersWithSkip_StillSkipsRuntimeMirrors locks the guard that
+// a caller-supplied SkipFunc is strictly additive: supplying a skip must never
+// re-enable staging of the runtime `.gc` mirror, in either the universal or the
+// per-provider copy phase. TestCopyDirForProviders_SkipsRuntimeMirrors covers
+// the nil-skip path; this is its non-nil counterpart.
+func TestCopyDirForProvidersWithSkip_StillSkipsRuntimeMirrors(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(src, "AGENTS.md"), []byte("universal"), 0o644)
+	// Universal-phase runtime mirror.
+	mustMkdirAll(t, filepath.Join(src, ".gc", "agents", "mayor"))
+	mustWriteFile(t, filepath.Join(src, ".gc", "agents", "mayor", "AGENTS.md"), []byte("mirror"), 0o644)
+	// Per-provider-phase runtime mirror (flattens to a top-level .gc/).
+	mustMkdirAll(t, filepath.Join(src, "per-provider", "codex", ".gc", "worktrees", "polecat"))
+	mustWriteFile(t, filepath.Join(src, "per-provider", "codex", ".gc", "worktrees", "polecat", "AGENTS.md"), []byte("mirror"), 0o644)
+	mustWriteFile(t, filepath.Join(src, "per-provider", "codex", "AGENTS.codex.md"), []byte("codex"), 0o644)
+
+	skip := func(relPath string, isDir bool) bool {
+		return !isDir && IsMergeablePath(relPath)
+	}
+	if err := CopyDirForProvidersWithSkip(src, dst, []string{"codex"}, skip, io.Discard); err != nil {
+		t.Fatalf("CopyDirForProvidersWithSkip: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, ".gc")); !os.IsNotExist(err) {
+		t.Fatalf("runtime .gc mirror staged despite the unconditional guard, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "AGENTS.md")); err != nil {
+		t.Fatalf("universal file should still be copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "AGENTS.codex.md")); err != nil {
+		t.Fatalf("per-provider file should still be copied: %v", err)
+	}
+}
+
+// TestCopyDirForProviders_StagesMergeableFileWithoutSkip is the contrast case:
+// the runtime task-worktree path passes no skip, so the mergeable codex hook
+// file is still staged there (that path is codex's sole hook source for live
+// task sessions and must not regress).
+func TestCopyDirForProviders_StagesMergeableFileWithoutSkip(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	mustMkdirAll(t, filepath.Join(src, "per-provider", "codex", ".codex"))
+	mustWriteFile(t, filepath.Join(src, "per-provider", "codex", ".codex", "hooks.json"), []byte(`{"hooks":{}}`), 0o644)
+
+	if err := CopyDirForProviders(src, dst, []string{"codex"}, io.Discard); err != nil {
+		t.Fatalf("CopyDirForProviders: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, ".codex", "hooks.json")); err != nil {
+		t.Fatalf("runtime path must still stage .codex/hooks.json: %v", err)
+	}
+}

--- a/internal/runtime/staging.go
+++ b/internal/runtime/staging.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,31 @@ import (
 
 	"github.com/gastownhall/gascity/internal/overlay"
 )
+
+// HashHookSettingsContent returns a content hash for a probed hook/settings
+// file that is stable across JSON serialization differences. For reconciler-owned
+// mergeable settings files (overlay.IsMergeablePath — .gemini/settings.json,
+// .codex/hooks.json, etc.) it hashes the canonical JSON form, so a compact
+// document and its pretty-printed equivalent fingerprint identically.
+//
+// This keeps the CopyFiles fingerprint deterministic even though these files
+// are rewritten into canonical form out of band by the reconciler — runtime
+// overlay staging (StageProviderOverlayDir → MergeSettingsJSON) or hooks.Install.
+// Without canonicalization the pre-fingerprint probe could hash a raw
+// non-canonical document on one tick and its canonical rewrite on the next,
+// producing spurious core-fingerprint drift. Non-mergeable paths, unreadable
+// files, and non-JSON content fall back to raw content hashing (HashPathContent).
+func HashHookSettingsContent(path, relPath string) string {
+	if overlay.IsMergeablePath(relPath) {
+		if data, err := os.ReadFile(path); err == nil {
+			if canon, cErr := overlay.CanonicalJSON(data); cErr == nil {
+				sum := sha256.Sum256(canon)
+				return fmt.Sprintf("%x", sum)
+			}
+		}
+	}
+	return HashPathContent(path)
+}
 
 // StageWorkDir applies a legacy overlay directory and CopyFiles staging before
 // a provider starts the session process.
@@ -102,10 +128,43 @@ func stageCopyFiles(workDir string, copyFiles []CopyEntry) error {
 }
 
 // StageProviderOverlayDir copies a provider-aware overlay directory into a
-// work directory and writes nonfatal preservation warnings to warnings.
+// work directory and writes nonfatal preservation warnings to warnings. This is
+// the runtime task-worktree staging path: it stages every overlay file
+// (including reconciler-owned mergeable hook files) because staging is the sole
+// writer for live task sessions — hooks.Install never runs against these dirs.
 func StageProviderOverlayDir(srcDir, dstDir string, providers []string, warnings io.Writer) error {
+	return stageProviderOverlayDir(srcDir, dstDir, providers, nil, warnings)
+}
+
+// StageProviderOverlayDirSkippingMergeable copies a provider-aware overlay
+// directory into a work directory like StageProviderOverlayDir, but skips
+// reconciler-owned mergeable settings/hook files (overlay.IsMergeablePath —
+// .codex/hooks.json, .claude/settings.json, etc.).
+//
+// It is used only by the build_desired_state home-dir staging path,
+// which stages overlays and then immediately runs hooks.Install on the SAME
+// directory. Skipping the mergeable files here makes hooks.Install the sole
+// writer, so the two writers can no longer disagree on hook-entry matchers and
+// leave a permanent codex-hooks-drift hybrid.
+func StageProviderOverlayDirSkippingMergeable(srcDir, dstDir string, providers []string, warnings io.Writer) error {
+	skip := func(relPath string, isDir bool) bool {
+		return !isDir && overlay.IsMergeablePath(relPath)
+	}
+	return stageProviderOverlayDir(srcDir, dstDir, providers, skip, warnings)
+}
+
+// stageProviderOverlayDir stages srcDir into dstDir for the given provider
+// slots, omitting any entry for which skip returns true (nil skips nothing).
+//
+// skip is spelled as an unnamed func type rather than overlay.SkipFunc — to
+// which it stays assignable — because every declaration in package runtime must
+// type-check with module-local imports stubbed out: the provider-double
+// boundary guard (internal/testutil/providerledger) checks this package
+// hermetically and requires module-local references to stay inside function
+// bodies.
+func stageProviderOverlayDir(srcDir, dstDir string, providers []string, skip func(relPath string, isDir bool) bool, warnings io.Writer) error {
 	var stderr bytes.Buffer
-	if err := overlay.CopyDirForProviders(srcDir, dstDir, providers, &stderr); err != nil {
+	if err := overlay.CopyDirForProvidersWithSkip(srcDir, dstDir, providers, skip, &stderr); err != nil {
 		return err
 	}
 	nonfatal, fatal := splitOverlayWarnings(stderr.String())

--- a/internal/runtime/staging.go
+++ b/internal/runtime/staging.go
@@ -144,8 +144,14 @@ func StageProviderOverlayDir(srcDir, dstDir string, providers []string, warnings
 // It is used only by the build_desired_state home-dir staging path,
 // which stages overlays and then immediately runs hooks.Install on the SAME
 // directory. Skipping the mergeable files here makes hooks.Install the sole
-// writer, so the two writers can no longer disagree on hook-entry matchers and
-// leave a permanent codex-hooks-drift hybrid.
+// writer ON THE RECONCILE TICK, so the two writers can no longer disagree on
+// hook-entry matchers and leave a permanent codex-hooks-drift hybrid.
+//
+// Not a global invariant: for a persistent (non-task) agent the home dir is
+// also the session workDir, and session-start staging reaches these same paths
+// through the non-skipping StageProviderOverlayDir (tmux.stageStartFiles,
+// StageSessionWorkDir). A hybrid can therefore reappear at session start and is
+// converged by the next tick — permanent drift becomes transient.
 func StageProviderOverlayDirSkippingMergeable(srcDir, dstDir string, providers []string, warnings io.Writer) error {
 	skip := func(relPath string, isDir bool) bool {
 		return !isDir && overlay.IsMergeablePath(relPath)

--- a/internal/runtime/staging_hash_test.go
+++ b/internal/runtime/staging_hash_test.go
@@ -1,0 +1,110 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// HashHookSettingsContent canonicalizes JSON only for overlay.IsMergeablePath
+// files, so that a compact document and its pretty-printed equivalent produce
+// the same fingerprint. Everything else — non-mergeable paths, non-JSON bodies,
+// unreadable/missing files — must fall back to raw HashPathContent.
+//
+// These cases pin the fingerprint contract directly. The convergence tests
+// exercise it only indirectly, so a regression that made canonicalization a
+// no-op (or applied it too widely) would otherwise surface as spurious
+// core-fingerprint drift and an extra agent restart, not as a test failure.
+
+// writeHashTestFile writes body to a temp file named after relPath's base and
+// returns its absolute path.
+func writeHashTestFile(t *testing.T, relPath, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, filepath.Base(relPath))
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func TestHashHookSettingsContent_MergeableCanonicalizesJSON(t *testing.T) {
+	const relPath = ".codex/hooks.json"
+	compact := `{"hooks":{"SessionStart":[{"matcher":"","hooks":[]}]}}`
+	pretty := `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": []
+      }
+    ]
+  }
+}
+`
+	compactHash := HashHookSettingsContent(writeHashTestFile(t, relPath, compact), relPath)
+	prettyHash := HashHookSettingsContent(writeHashTestFile(t, relPath, pretty), relPath)
+
+	if compactHash == "" || prettyHash == "" {
+		t.Fatalf("empty hash: compact=%q pretty=%q", compactHash, prettyHash)
+	}
+	if compactHash != prettyHash {
+		t.Errorf("compact and pretty-printed %s must hash identically:\n compact=%s\n pretty =%s",
+			relPath, compactHash, prettyHash)
+	}
+}
+
+func TestHashHookSettingsContent_MergeableIgnoresKeyOrder(t *testing.T) {
+	const relPath = ".claude/settings.json"
+	first := HashHookSettingsContent(
+		writeHashTestFile(t, relPath, `{"alpha":1,"beta":2}`), relPath)
+	second := HashHookSettingsContent(
+		writeHashTestFile(t, relPath, `{"beta":2,"alpha":1}`), relPath)
+
+	if first != second {
+		t.Errorf("canonical JSON must sort keys, so these must hash identically:\n first =%s\n second=%s",
+			first, second)
+	}
+}
+
+func TestHashHookSettingsContent_NonMergeablePathFallsBackToRaw(t *testing.T) {
+	// Same logical document, different serialization, on a path that is NOT
+	// mergeable: no canonicalization, so the raw bytes decide the hash.
+	const relPath = ".codex/config.json"
+	compactPath := writeHashTestFile(t, relPath, `{"a":1}`)
+	prettyPath := writeHashTestFile(t, relPath, "{\n  \"a\": 1\n}\n")
+
+	compactHash := HashHookSettingsContent(compactPath, relPath)
+	prettyHash := HashHookSettingsContent(prettyPath, relPath)
+
+	if want := HashPathContent(compactPath); compactHash != want {
+		t.Errorf("non-mergeable path must fall back to HashPathContent: got %s want %s", compactHash, want)
+	}
+	if compactHash == prettyHash {
+		t.Errorf("non-mergeable path must NOT canonicalize; compact and pretty both hashed %s", compactHash)
+	}
+}
+
+func TestHashHookSettingsContent_NonJSONBodyFallsBackToRaw(t *testing.T) {
+	// A mergeable path whose content does not parse: CanonicalJSON fails and the
+	// raw content hash is used rather than an empty or panicking result.
+	const relPath = ".codex/hooks.json"
+	path := writeHashTestFile(t, relPath, "this is not json\n")
+
+	got := HashHookSettingsContent(path, relPath)
+	if want := HashPathContent(path); got != want {
+		t.Errorf("unparseable mergeable file must fall back to HashPathContent: got %s want %s", got, want)
+	}
+}
+
+func TestHashHookSettingsContent_MissingFileMatchesRawHash(t *testing.T) {
+	// An absent probe target must agree with HashPathContent so a file that has
+	// not been staged yet does not read as a distinct fingerprint.
+	const relPath = ".codex/hooks.json"
+	missing := filepath.Join(t.TempDir(), "hooks.json")
+
+	got := HashHookSettingsContent(missing, relPath)
+	if want := HashPathContent(missing); got != want {
+		t.Errorf("missing mergeable file must match HashPathContent: got %s want %s", got, want)
+	}
+}

--- a/internal/runtime/staging_skip_mergeable_test.go
+++ b/internal/runtime/staging_skip_mergeable_test.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// codexHooksOverlaySrc seeds a provider overlay dir with a codex hooks file
+// (mergeable) and a non-mergeable sibling under per-provider/codex/, returning
+// the overlay source root.
+func codexHooksOverlaySrc(t *testing.T) string {
+	t.Helper()
+	src := t.TempDir()
+	codexDir := filepath.Join(src, "per-provider", "codex", ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatalf("mkdir codex overlay: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(`{"hooks":{"SessionStart":[]}}`), 0o644); err != nil {
+		t.Fatalf("write codex hooks overlay: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "per-provider", "codex", "AGENTS.codex.md"), []byte("codex"), 0o644); err != nil {
+		t.Fatalf("write codex sibling overlay: %v", err)
+	}
+	return src
+}
+
+// TestStageProviderOverlayDirSkippingMergeableSkipsCodexHooks is the horizon
+// guard (invariant #3): the build_desired_state staging entry point
+// must skip reconciler-owned mergeable files while still staging non-mergeable
+// siblings, so hooks.Install remains the sole writer in the home dir.
+func TestStageProviderOverlayDirSkippingMergeableSkipsCodexHooks(t *testing.T) {
+	t.Parallel()
+
+	src := codexHooksOverlaySrc(t)
+	workDir := t.TempDir()
+
+	if err := StageProviderOverlayDirSkippingMergeable(src, workDir, []string{"codex"}, nil); err != nil {
+		t.Fatalf("StageProviderOverlayDirSkippingMergeable: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".codex", "hooks.json")); !os.IsNotExist(err) {
+		t.Fatalf(".codex/hooks.json staged by home-dir path (err=%v); must be skipped so hooks.Install is sole writer", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "AGENTS.codex.md")); err != nil {
+		t.Fatalf("non-mergeable sibling should still stage: %v", err)
+	}
+}
+
+// TestStageProviderOverlayDirStagesCodexHooks locks the no-regression contract
+// (invariant #3 / #2): the runtime task-worktree path (plain
+// StageProviderOverlayDir, used by StageSessionWorkDir) still writes the codex
+// hook file, which is the only hook source for live task sessions.
+func TestStageProviderOverlayDirStagesCodexHooks(t *testing.T) {
+	t.Parallel()
+
+	src := codexHooksOverlaySrc(t)
+	workDir := t.TempDir()
+
+	if err := StageProviderOverlayDir(src, workDir, []string{"codex"}, nil); err != nil {
+		t.Fatalf("StageProviderOverlayDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".codex", "hooks.json")); err != nil {
+		t.Fatalf("runtime path must stage .codex/hooks.json (codex live-session hook source): %v", err)
+	}
+}
+
+// TestStageSessionWorkDirStagesFunctionalCodexHooks is the no-regression test
+// (invariant #2) at the session-staging boundary: StageSessionWorkDir, invoked
+// on every codex task-session Start, must still write a functional
+// .codex/hooks.json (SessionStart present). The fix must not touch this path.
+func TestStageSessionWorkDirStagesFunctionalCodexHooks(t *testing.T) {
+	t.Parallel()
+
+	src := codexHooksOverlaySrc(t)
+	workDir := t.TempDir()
+
+	if err := StageSessionWorkDir(Config{
+		WorkDir:         workDir,
+		ProviderName:    "codex",
+		PackOverlayDirs: []string{src},
+	}); err != nil {
+		t.Fatalf("StageSessionWorkDir: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(workDir, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatalf("codex task worktree missing .codex/hooks.json (P1 regression): %v", err)
+	}
+	if !strings.Contains(string(data), "SessionStart") {
+		t.Fatalf("staged codex hooks not functional, want SessionStart: %s", data)
+	}
+}


### PR DESCRIPTION
## Problem

The `build_desired_state` home-dir reconcile tick has **two writers** of a
Codex agent's `.codex/hooks.json`, and they disagree — leaving a permanent
hybrid document that `gc doctor` flags as `codex-hooks-drift` ("needs upgrade")
forever, never converging even across `gc stop/start` bounces or repeated
`--fix`.

Both writers run in `prepareTemplateResolution`
(`cmd/gc/build_desired_state.go`) against the **same** home `workDir`:

1. **Overlay staging** — `materializeProviderOverlaysBeforeFingerprint` →
   `runtime.StageProviderOverlayDir` → `internal/overlay` merge writes the
   overlay's SessionStart entry with **`matcher:""`** (unbound `gc prime`).
2. **Reconciler** — `hooks.InstallWithResolver` writes the SessionStart entry
   with **`matcher:"startup"`** (bound `gc --city '<root>' prime`, per #3866).

The overlay merge keys hook-entry identity on the `matcher` value (the dedupe
introduced in #3808), so the bound and unbound entries are treated as distinct
and **both survive**. `hooks.Install` converges the document to the single
bound entry, but the very next staging tick re-merges the unbound `matcher:""`
entry back in — so the on-disk document a fresh session-start / `gc doctor`
reads is perpetually `[startup, ""]`.

This is a regression surfaced by #3866 (which introduced the bound matcher) in
combination with #3808's matcher-keyed dedupe. **It reproduces on a clean
`main`** — see the TDD proof below.

## Fix

Make the `build_desired_state` home-dir staging path **skip reconciler-owned
mergeable files** (`overlay.IsMergeablePath` — `.codex/hooks.json`,
`.claude/settings.json`, …) so `hooks.Install` is the **sole writer** of those
files in the home dir. The two writers can no longer disagree because there is
only one.

- `internal/overlay`: factor the existing per-provider skip into
  `isPerProviderPath`; thread an optional `SkipFunc` through `copyDir`; add
  `CopyDirForProvidersWithSkip`.
- `internal/runtime`: add `StageProviderOverlayDirSkippingMergeable` wrapping
  the shared staging with an `IsMergeablePath` skip.
- `cmd/gc`: `materializeProviderOverlaysBeforeFingerprint` uses the skip
  variant (6-line call-site swap).

### No-regression boundary (important)

The **runtime task-worktree** staging path (`StageSessionWorkDir` →
`StageProviderOverlayDir`, nil skip) is deliberately **left untouched**. For
live task sessions `hooks.Install` never runs against those dirs, so overlay
staging is their *sole* hook source and must keep staging the mergeable files.
Only the home-dir path — where `hooks.Install` runs immediately after staging —
gets the skip. Tests guard both entry points.

## TDD proof (on a clean `main`)

- **RED:** with the production call-site reverted to the non-skip variant,
  `TestMaterializeProviderOverlays_SkipsMergeableCodexHook` fails —
  `build_desired_state staging wrote reconciler-owned .codex/hooks.json`.
  `TestCodexHooksConvergeWithSkipStaging` also demonstrates the legacy path
  re-drifting the hybrid (>1 SessionStart entry) after a re-stage.
- **GREEN:** with the fix, both converge to a single bound `[startup]` entry
  that stays stable across stage → install → stage, and the converged document
  keeps the managed `PreCompact` (context-cycle handoff) and `UserPromptSubmit`
  (mail check + nudge drain) hooks.

`go vet ./cmd/gc/ ./internal/overlay/ ./internal/runtime/` is clean.

## Notes for reviewers

- cc @ the author of #3866 / #3808 (Saren) — this builds directly on the
  matcher-binding + dedupe those PRs introduced.
- `gcw-mnck` / `gcw-zd0v` in code comments are our downstream fork's tracker
  IDs for provenance; the fix itself is upstream-general (shared overlay /
  runtime / build_desired_state code, no fork- or deployment-specific
  behavior).
