### PR TITLE
fix(doctor): recognize external Dolt endpoints in the dolt-backup check (#3868)

### DIFF
--- a/internal/doctor/checks_dolt_backup.go
+++ b/internal/doctor/checks_dolt_backup.go
@@ -9,7 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 // DoltBackupCheck verifies that a rig's Dolt database has a backup remote
@@ -60,6 +62,19 @@ func (c *DoltBackupCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 
 	rigPath := c.normalizedRigPath()
+
+	// An external Dolt endpoint self-manages its backups on the remote server;
+	// the local .dolt-backup directory and managed-Dolt repo_state.json signals
+	// never apply to it, and the localhost fix hint below is actively wrong for
+	// it. Treat a resolved external endpoint as satisfied rather than warning.
+	// See gastownhall/gascity#3868. A resolution error falls through to the
+	// local-signal checks so a genuinely missing local backup still surfaces.
+	if target, err := contract.ResolveDoltConnectionTarget(fsys.OSFS{}, c.cityPath, rigPath); err == nil && target.External {
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("rig %q: external Dolt endpoint %s:%s — backups self-managed on the external server", c.rig.Name, target.Host, target.Port)
+		return r
+	}
+
 	dbName, details := c.resolveDBName(rigPath)
 	r.Details = append(r.Details, details...)
 	backupDir := filepath.Join(c.cityPath, ".dolt-backup", dbName)

--- a/internal/doctor/checks_dolt_backup_test.go
+++ b/internal/doctor/checks_dolt_backup_test.go
@@ -247,3 +247,47 @@ func TestDoltBackupCheck_Name(t *testing.T) {
 		t.Errorf("Name() = %q, want %q", got, want)
 	}
 }
+
+// writeScopeConfig writes a minimal .beads/config.yaml for a scope (city or rig).
+func writeScopeConfig(t *testing.T, scopePath, body string) {
+	t.Helper()
+	beadsDir := filepath.Join(scopePath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("create .beads dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+}
+
+// A rig whose Dolt lives on an external endpoint self-manages its backups on
+// that server; the local .dolt-backup / repo_state.json signals never apply, so
+// the check must not warn or emit a localhost fix hint. Regression for #3868.
+func TestDoltBackupCheck_ExternalEndpoint_NoWarn(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "extdb")
+	writeScopeConfig(t, cityPath, "issue_prefix: gc\ngc.endpoint_origin: managed_city\ndolt.auto-start: false\n")
+	writeScopeConfig(t, rigPath, "issue_prefix: fe\ngc.endpoint_origin: explicit\ndolt.host: db.example.com\ndolt.port: \"3307\"\ndolt.auto-start: false\n")
+
+	rig := config.Rig{Name: "extrig", Path: rigPath}
+	c := NewDoltBackupCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want StatusOK (external endpoint self-manages backups); msg=%q", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "external") {
+		t.Errorf("Message should note the external endpoint: %s", r.Message)
+	}
+	if !strings.Contains(r.Message, "db.example.com") {
+		t.Errorf("Message should name the external host: %s", r.Message)
+	}
+	if r.FixHint != "" {
+		t.Errorf("external endpoint must not emit a localhost fix hint: %s", r.FixHint)
+	}
+}


### PR DESCRIPTION
\`gc doctor\`'s per-rig dolt-backup check accepts only local signals — a populated
\`<city>/.dolt-backup/<db>/\` directory or a backup remote in the local managed-Dolt
\`repo_state.json\`. For a rig whose Dolt lives on an **external** SQL-server endpoint, neither local
signal ever exists, so the check always warns \`no dolt backup registered\` and hands the operator a
\`dolt --host 127.0.0.1 …\` fix command that is wrong for an external host (and, per #3868, times out
client-side against the external server).

This teaches the check the endpoint it's actually checking. Before the local-signal checks, it
resolves the rig's connection target via \`contract.ResolveDoltConnectionTarget\` — the same
authoritative resolver \`validateBDStoreTarget\` already uses — and when \`target.External\` is set,
returns \`StatusOK\` ("external Dolt endpoint … — backups self-managed on the external server")
instead of the warning. Because that returns before the warning path, no misleading localhost fix
hint is emitted for external rigs either. A resolution error falls through to the existing
local-signal path, so a genuinely missing local backup on a managed rig still surfaces exactly as
before.

Scope is deliberately minimal: one early-return in one check, no constructor-signature change, and
no new host-classification logic (it reuses the existing external-endpoint resolution). I took the
skip/degrade approach rather than actively probing the external server for registered remotes —
that would add a network dependency to a doctor check, and the external accessory self-manages its
own backups — but happy to switch to an active probe if you'd prefer that.

Test: \`TestDoltBackupCheck_ExternalEndpoint_NoWarn\` asserts an external endpoint resolves to
\`StatusOK\`, names the host, and emits no fix hint. All existing dolt-backup tests are unchanged and
green; \`go vet\` + \`gofmt\` clean.

Addresses #3868.