### PR TITLE
Route gc status provider resolution through cache

### DIFF
--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -256,8 +256,13 @@ func resolveSessionTransportProvider(ctx sessionProviderContext, sessionBeads *s
 	// auto provider that routes per-session.
 	// NOTE: agents comes from loadCityConfig which applies pack overrides, so the
 	// Session field from overrides is already resolved here.
-	requireACPWrapper := requiresACPProviderWrapper(sessionBeads, ctx.cityName, ctx.cfg)
-	if ctx.providerName != "acp" && needsACPProviderWrapper(sessionBeads, ctx.cityName, ctx.cfg) {
+	// acpRouteNames is computed once and reused for both the requires/needs
+	// checks and the route registration below, instead of recomputing the
+	// (agent + named-session) x provider-resolution walk up to 3x per call.
+	acpRouteNames := configuredACPRouteNames(sessionBeads, ctx.cityName, ctx.cfg)
+	requireACPWrapper := len(acpRouteNames) > 0
+	needsACPWrapper := requireACPWrapper || (ctx.cfg != nil && hasACPProviderTargets(ctx.cfg))
+	if ctx.providerName != "acp" && needsACPWrapper {
 		acpSP, acpErr := buildSessionProviderByName(ctx.cfg, "acp", ctx.sc, ctx.cityName, ctx.cityPath)
 		if acpErr != nil {
 			if requireACPWrapper {
@@ -266,7 +271,7 @@ func resolveSessionTransportProvider(ctx sessionProviderContext, sessionBeads *s
 			return base, nil
 		}
 		autoSP := sessionauto.New(base, acpSP)
-		for _, sessName := range configuredACPRouteNames(sessionBeads, ctx.cityName, ctx.cfg) {
+		for _, sessName := range acpRouteNames {
 			autoSP.RouteACP(sessName)
 		}
 		return autoSP, nil
@@ -277,6 +282,20 @@ func resolveSessionTransportProvider(ctx sessionProviderContext, sessionBeads *s
 func agentSessionCreateTransport(cfg *config.City, agentCfg config.Agent) string {
 	if cfg == nil {
 		return strings.TrimSpace(agentCfg.Session)
+	}
+	// StartCommand is ResolveProvider's escape hatch (step 1): it bypasses
+	// provider-catalog resolution entirely, so a cache entry for
+	// agentCfg.Provider would not describe this agent's actual resolution.
+	if agentCfg.StartCommand == "" {
+		name := agentCfg.Provider
+		if name == "" {
+			name = cfg.Workspace.Provider
+		}
+		if name != "" {
+			if resolved, ok := config.ResolvedProviderCached(cfg, name); ok {
+				return config.ResolveSessionCreateTransport(agentCfg.Session, &resolved)
+			}
+		}
 	}
 	resolved, err := config.ResolveProvider(
 		&agentCfg,
@@ -310,14 +329,6 @@ func configuredACPSessionNames(snapshot *sessionBeadSnapshot, cityName, sessionT
 	return names
 }
 
-func needsACPProviderWrapper(snapshot *sessionBeadSnapshot, cityName string, cfg *config.City) bool {
-	return requiresACPProviderWrapper(snapshot, cityName, cfg) || (cfg != nil && hasACPProviderTargets(cfg))
-}
-
-func requiresACPProviderWrapper(snapshot *sessionBeadSnapshot, cityName string, cfg *config.City) bool {
-	return len(configuredACPRouteNames(snapshot, cityName, cfg)) > 0
-}
-
 func hasACPProviderTargets(cfg *config.City) bool {
 	if cfg == nil {
 		return false
@@ -347,6 +358,9 @@ func hasACPProviderTargets(cfg *config.City) bool {
 func resolveProviderForACPTransport(cfg *config.City, providerName string) *config.ResolvedProvider {
 	if cfg == nil || strings.TrimSpace(providerName) == "" {
 		return nil
+	}
+	if resolved, ok := config.ResolvedProviderCached(cfg, providerName); ok {
+		return &resolved
 	}
 	resolved, err := config.ResolveProvider(
 		&config.Agent{Provider: providerName},

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -451,6 +451,175 @@ func TestConfiguredACPRouteNames_IncludeLegacyObservedCustomACPProviderSessionsW
 	}
 }
 
+// TestResolveProviderForACPTransport_PrefersResolvedProviderCache proves the
+// cache-first path (ga-soqo5g): the raw ProviderSpec here has no ACP fields
+// at all, so a fresh chain-walk would never produce an ACP-capable result.
+// The populated ResolvedProviders cache entry deliberately diverges from the
+// raw spec — if the function returns ACP, it read the cache, not the spec.
+func TestResolveProviderForACPTransport_PrefersResolvedProviderCache(t *testing.T) {
+	cfg := &config.City{
+		Providers: map[string]config.ProviderSpec{
+			"custom": {Command: "custom-cli"},
+		},
+		ResolvedProviders: map[string]config.ResolvedProvider{
+			"custom": {
+				Name:        "custom",
+				SupportsACP: true,
+				ACPCommand:  "/bin/echo",
+				ACPArgs:     []string{"acp"},
+			},
+		},
+	}
+	got := resolveProviderForACPTransport(cfg, "custom")
+	if got == nil || got.ProviderSessionCreateTransport() != "acp" {
+		t.Fatalf("resolveProviderForACPTransport = %+v, want cached ACP-capable provider", got)
+	}
+}
+
+// TestResolveProviderForACPTransport_FallsBackWhenNoCache keeps Phase A
+// configs working: when ResolvedProviders is unpopulated, the raw
+// config.ResolveProvider chain-walk still runs and produces the same answer
+// it always has.
+func TestResolveProviderForACPTransport_FallsBackWhenNoCache(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Providers: map[string]config.ProviderSpec{
+			"opencode": {
+				Command:     "/bin/echo",
+				SupportsACP: boolPtr(true),
+				ACPCommand:  "/bin/echo",
+				ACPArgs:     []string{"acp"},
+			},
+		},
+	}
+	got := resolveProviderForACPTransport(cfg, "opencode")
+	if got == nil || got.ProviderSessionCreateTransport() != "acp" {
+		t.Fatalf("resolveProviderForACPTransport = %+v, want raw-resolved ACP-capable provider", got)
+	}
+}
+
+// TestAgentSessionCreateTransport_PrefersResolvedProviderCache mirrors
+// TestResolveProviderForACPTransport_PrefersResolvedProviderCache for the
+// agent-level entry point.
+func TestAgentSessionCreateTransport_PrefersResolvedProviderCache(t *testing.T) {
+	cfg := &config.City{
+		Providers: map[string]config.ProviderSpec{
+			"custom": {Command: "custom-cli"},
+		},
+		ResolvedProviders: map[string]config.ResolvedProvider{
+			"custom": {
+				Name:        "custom",
+				SupportsACP: true,
+				ACPCommand:  "/bin/echo",
+				ACPArgs:     []string{"acp"},
+			},
+		},
+	}
+	got := agentSessionCreateTransport(cfg, config.Agent{Provider: "custom"})
+	if got != "acp" {
+		t.Fatalf("agentSessionCreateTransport = %q, want acp (from cache)", got)
+	}
+}
+
+// TestAgentSessionCreateTransport_UsesWorkspaceProviderWhenAgentHasNoOverride
+// proves the cache lookup falls back to the workspace-level provider name
+// (matching ResolveProvider's own name-resolution order) when the agent
+// itself has no per-agent Provider override.
+func TestAgentSessionCreateTransport_UsesWorkspaceProviderWhenAgentHasNoOverride(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Provider: "custom"},
+		Providers: map[string]config.ProviderSpec{
+			"custom": {Command: "custom-cli"},
+		},
+		ResolvedProviders: map[string]config.ResolvedProvider{
+			"custom": {
+				Name:        "custom",
+				SupportsACP: true,
+				ACPCommand:  "/bin/echo",
+				ACPArgs:     []string{"acp"},
+			},
+		},
+	}
+	got := agentSessionCreateTransport(cfg, config.Agent{})
+	if got != "acp" {
+		t.Fatalf("agentSessionCreateTransport = %q, want acp (from cache via workspace provider)", got)
+	}
+}
+
+// TestAgentSessionCreateTransport_FallsBackWhenNoCache is
+// TestResolveProviderForACPTransport_FallsBackWhenNoCache for the
+// agent-level entry point.
+func TestAgentSessionCreateTransport_FallsBackWhenNoCache(t *testing.T) {
+	cfg := &config.City{
+		Providers: map[string]config.ProviderSpec{
+			"opencode": {
+				Command:     "/bin/echo",
+				SupportsACP: boolPtr(true),
+				ACPCommand:  "/bin/echo",
+				ACPArgs:     []string{"acp"},
+			},
+		},
+	}
+	got := agentSessionCreateTransport(cfg, config.Agent{Provider: "opencode"})
+	if got != "acp" {
+		t.Fatalf("agentSessionCreateTransport = %q, want acp (raw fallback)", got)
+	}
+}
+
+// TestAgentSessionCreateTransport_SkipsCacheForStartCommandEscapeHatch proves
+// an agent using the StartCommand escape hatch (ResolveProvider's step 1,
+// which bypasses provider-catalog/cache resolution entirely and constructs a
+// synthetic ResolvedProvider with SupportsACP left at its zero value) is not
+// short-circuited into reading an unrelated cache entry for its Provider
+// name. Session is left empty so the decision routes through the resolved
+// provider rather than an explicit per-agent override.
+func TestAgentSessionCreateTransport_SkipsCacheForStartCommandEscapeHatch(t *testing.T) {
+	cfg := &config.City{
+		ResolvedProviders: map[string]config.ResolvedProvider{
+			"custom": {Name: "custom", SupportsACP: true, ACPCommand: "/bin/echo", ACPArgs: []string{"acp"}},
+		},
+	}
+	got := agentSessionCreateTransport(cfg, config.Agent{Provider: "custom", StartCommand: "/bin/my-agent"})
+	if got != "" {
+		t.Fatalf("agentSessionCreateTransport = %q, want \"\" (StartCommand escape hatch must bypass provider/cache resolution)", got)
+	}
+}
+
+// TestAgentSessionCreateTransport_CachedMatchesRawForOverrideAgent is the
+// bead's equivalence check: the cached path and the raw config.ResolveProvider
+// path must agree for an agent with its own Provider override, given a cache
+// entry that mirrors what BuildResolvedProviderCache would actually produce
+// for the same spec.
+func TestAgentSessionCreateTransport_CachedMatchesRawForOverrideAgent(t *testing.T) {
+	providers := map[string]config.ProviderSpec{
+		"opencode": {
+			Command:     "/bin/echo",
+			SupportsACP: boolPtr(true),
+			ACPCommand:  "/bin/echo",
+			ACPArgs:     []string{"acp"},
+		},
+	}
+	agentCfg := config.Agent{Provider: "opencode", Name: "myagent"}
+
+	rawCfg := &config.City{Providers: providers}
+	rawGot := agentSessionCreateTransport(rawCfg, agentCfg)
+
+	cachedCfg := &config.City{
+		Providers: providers,
+		ResolvedProviders: map[string]config.ResolvedProvider{
+			"opencode": {Name: "opencode", SupportsACP: true, ACPCommand: "/bin/echo", ACPArgs: []string{"acp"}},
+		},
+	}
+	cachedGot := agentSessionCreateTransport(cachedCfg, agentCfg)
+
+	if rawGot != cachedGot {
+		t.Fatalf("cached path = %q, raw path = %q; want equal", cachedGot, rawGot)
+	}
+	if cachedGot != "acp" {
+		t.Fatalf("agentSessionCreateTransport = %q, want acp", cachedGot)
+	}
+}
+
 func TestNewSessionProvider_PreregistersACPBeadAndLegacyNames(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")

--- a/release-gates/ga-3ojbg1-provider-cache-gate.md
+++ b/release-gates/ga-3ojbg1-provider-cache-gate.md
@@ -1,0 +1,131 @@
+# Release Gate: gc status provider cache adoption
+
+Bead: `ga-3ojbg1` - needs-deploy for `ga-soqo5g`
+Review bead: `ga-qapqi0`
+Branch: `deploy/ga-3ojbg1-provider-cache`
+Reviewed source branch: `origin/gc-builder-2-6fa6ba1e8999`
+Reviewed commit: `d7bb52816619a566f437c723400ffc5be49d4693`
+Base checked: `origin/main` at `3be7535bc41a2210af21c33bbf67d94022c84ef2`
+Merge base: `1ce90331a13e08ba8c1ba649a210e656080c32a5`
+Gate date: 2026-07-04
+
+## Summary
+
+This release routes `gc status` CLI provider-transport resolution through
+`config.ResolvedProviderCached` where the resolved-provider cache is populated,
+with fallback to the existing uncached `config.ResolveProvider` path. It also
+computes the ACP route-name set once during status provider construction instead
+of recomputing it for each wrapper decision.
+
+The diff is limited to `cmd/gc/providers.go` and
+`cmd/gc/providers_test.go`. `docs/PROJECT_MANIFEST.md` is not present in this
+checkout, so this gate uses the deployer release criteria and the `TESTING.md`
+sharded-runner guidance.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-qapqi0` is closed with `REVIEW VERDICT: PASS` for commit `d7bb52816619a566f437c723400ffc5be49d4693` on `gc-builder-2-6fa6ba1e8999`. |
+| 2 | Acceptance criteria met | PASS | `resolveProviderForACPTransport` and `agentSessionCreateTransport` now prefer `config.ResolvedProviderCached` and fall back to `config.ResolveProvider` on cache miss or the `StartCommand` escape hatch. `resolveSessionTransportProvider` computes ACP route names once for provider construction. New tests cover cache preference, cache fallback, workspace-provider fallback, `StartCommand` bypass, and cached/raw transport equivalence. |
+| 3 | Tests pass | PASS | Branch-scoped checks passed: focused provider/ACP tests, `go test ./internal/config/...`, `go build ./cmd/gc`, and `go vet ./...`. The first `make test-fast-parallel` run failed in unrelated supervisor/runtime tests; the exact focused failure set reproduces on current `origin/main`. A later pre-push dry-run reran `make test-fast-parallel` on this branch and passed all fast jobs. |
+| 4 | No high-severity review findings open | PASS | Review notes state "No findings" and no HIGH/request-changes findings are listed for `ga-qapqi0` or `ga-3ojbg1`. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed a clean branch at the reviewed source commit. After this file is committed, the only extra delta is this gate artifact. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` produced tree `49509a3283df55fab67f536c2660cb00f195735c` with no conflicts. `git diff --check origin/main...HEAD` passed. |
+| 7 | Single feature theme | PASS | Commit set is one CLI status provider-resolution performance fix touching only `cmd/gc/providers.go` and `cmd/gc/providers_test.go`. |
+
+## Acceptance Mapping
+
+| Done-when item | Result | Evidence |
+|---|---|---|
+| Status provider build performs O(1) cached lookups when populated | PASS | Cache-preference tests use deliberately divergent raw specs and cache entries, so ACP results prove the cached path was used. |
+| `configuredACPRouteNames` computed once per status build | PASS | `resolveSessionTransportProvider` computes `acpRouteNames` once and reuses it for wrapper decisions and route registration during provider construction. The separate `registerStatusProviderACPRoutes` refresh path remains intentionally separate because it runs against a later snapshot. |
+| Transport-decision equivalence and no per-item recompute covered | PASS | `TestAgentSessionCreateTransport_CachedMatchesRawForOverrideAgent`, fallback tests, and existing ACP route/provider tests passed. |
+
+## Commands Run
+
+```text
+gc prime
+bd prime
+gc hook gascity/deployer --claim --json
+bd show ga-3ojbg1
+bd show ga-qapqi0
+bd show ga-soqo5g
+gh auth status
+git fetch origin main gc-builder-2-6fa6ba1e8999
+git rev-parse origin/main origin/gc-builder-2-6fa6ba1e8999 d7bb52816
+git show --stat --oneline --decorate --no-renames d7bb52816
+git diff --name-status origin/main...origin/gc-builder-2-6fa6ba1e8999
+git merge-tree --write-tree origin/main origin/gc-builder-2-6fa6ba1e8999
+git diff --check origin/main...HEAD
+env TMPDIR=/var/tmp/gc-deploy-ga-3ojbg1-tmp make test-fast-parallel
+env TMPDIR=/var/tmp/gc-deploy-ga-3ojbg1-tmp go test ./cmd/gc -run '^(TestCityRuntimeRun_ConvergenceStartupErrorDoesNotBlockStarted|TestRegisterCityWithSupervisorRejectsStandaloneController|TestRegisterCityWithSupervisorRejectsStandaloneControllerDuringSupervisorStartupPhase|TestRegisterCityWithSupervisorRejectsStandaloneControllerForStoppedManagedCity|TestSupervisorCreatesControllerSocketForManagedCity)$' -count=1 -v
+env TMPDIR=/var/tmp/gc-main-ga-3ojbg1-tmp go test ./cmd/gc -run '^(TestCityRuntimeRun_ConvergenceStartupErrorDoesNotBlockStarted|TestRegisterCityWithSupervisorRejectsStandaloneController|TestRegisterCityWithSupervisorRejectsStandaloneControllerDuringSupervisorStartupPhase|TestRegisterCityWithSupervisorRejectsStandaloneControllerForStoppedManagedCity|TestSupervisorCreatesControllerSocketForManagedCity)$' -count=1 -v
+env TMPDIR=/var/tmp/gc-deploy-ga-3ojbg1-tmp go test ./cmd/gc/... -run 'TestResolveProviderForACPTransport|TestAgentSessionCreateTransport|TestConfiguredACPRouteNames|TestNewSessionProvider|TestSessionProviderContext|TestConfiguredACPSessionNames' -count=1 -v
+env TMPDIR=/var/tmp/gc-deploy-ga-3ojbg1-tmp go test ./internal/config/... -count=1
+env TMPDIR=/var/tmp/gc-deploy-ga-3ojbg1-tmp go build ./cmd/gc
+env TMPDIR=/var/tmp/gc-deploy-ga-3ojbg1-tmp go vet ./...
+git config core.hooksPath
+```
+
+## Test Results
+
+```text
+go test ./cmd/gc/... -run 'TestResolveProviderForACPTransport|TestAgentSessionCreateTransport|TestConfiguredACPRouteNames|TestNewSessionProvider|TestSessionProviderContext|TestConfiguredACPSessionNames' -count=1 -v
+PASS
+ok  	github.com/gastownhall/gascity/cmd/gc	0.722s
+
+go test ./internal/config/... -count=1
+ok  	github.com/gastownhall/gascity/internal/config	2.482s
+
+go build ./cmd/gc
+PASS
+
+go vet ./...
+PASS
+
+make test-fast-parallel
+FAIL: unit-cmd-gc-2-of-6
+  TestRegisterCityWithSupervisorRejectsStandaloneControllerForStoppedManagedCity
+  TestSupervisorCreatesControllerSocketForManagedCity
+
+FAIL: unit-cmd-gc-4-of-6
+  TestRegisterCityWithSupervisorRejectsStandaloneControllerDuringSupervisorStartupPhase
+
+FAIL: unit-cmd-gc-5-of-6
+  TestRegisterCityWithSupervisorRejectsStandaloneController
+
+FAIL: unit-cmd-gc-6-of-6
+  TestCityRuntimeRun_ConvergenceStartupErrorDoesNotBlockStarted
+```
+
+Pre-push dry-run rerun after the gate commit:
+
+```text
+make test-fast-parallel
+All fast jobs passed
+```
+
+Focused reproduction on this branch:
+
+```text
+TestCityRuntimeRun_ConvergenceStartupErrorDoesNotBlockStarted: PASS in isolation.
+The four supervisor tests above fail with `bd schema not visible for hq after init`,
+`city did not become ready under supervisor within 1m0s`, and missing
+`controller.sock` diagnostics.
+```
+
+Focused reproduction on current `origin/main`:
+
+```text
+The same four supervisor tests fail with the same `bd schema not visible for hq
+after init`, one-minute readiness timeout, and missing `controller.sock`
+diagnostics. This is a repo-wide supervisor/bd test-state failure, not a
+regression from the provider-cache diff.
+```
+
+## Notes
+
+`core.hooksPath` is `.githooks`; the gate commit runs the local pre-commit hook.
+The deployer did not rebase the reviewed source branch. The branch merges
+cleanly with current `origin/main` according to `git merge-tree`.


### PR DESCRIPTION
## What this changes

`gc status` now uses the resolved-provider cache when deciding ACP and session-create transport for configured providers. That avoids repeatedly walking provider chains and cloning the builtin provider catalog while building a status view for many agents, named sessions, and open beads.

The original uncached resolution remains the fallback, and agents that use `StartCommand` still bypass the cache because that path builds a synthetic provider from agent fields. ACP route-name discovery is also computed once during status provider construction; the later route refresh that reads a fresh snapshot remains separate.

## Review notes

- Scope is limited to `cmd/gc/providers.go` and `cmd/gc/providers_test.go`.
- No config syntax, API shape, dashboard surface, or user-visible command output changes.
- The cache is only used for provider properties that are equivalent to the raw resolution path; cache-miss and `StartCommand` paths preserve existing behavior.
- Release gate: [`release-gates/ga-3ojbg1-provider-cache-gate.md`](release-gates/ga-3ojbg1-provider-cache-gate.md)

## Test plan

- [x] `make test-fast-parallel` passed in the real pre-push hook.
- [x] `go test ./cmd/gc/... -run 'TestResolveProviderForACPTransport|TestAgentSessionCreateTransport|TestConfiguredACPRouteNames|TestNewSessionProvider|TestSessionProviderContext|TestConfiguredACPSessionNames' -count=1 -v`
- [x] `go test ./internal/config/... -count=1`
- [x] `go build ./cmd/gc`
- [x] `go vet ./...`
- [x] Release gate linked above.
