### PR TITLE
fix(dashboard): run-view regression guardrails — canonical bead-event decoder + observable fold

### DIFF
--- a/internal/api/dashboardbff/runtailer.go
+++ b/internal/api/dashboardbff/runtailer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -117,6 +118,9 @@ type tailState struct {
 	offset     int64
 	activeInfo os.FileInfo
 	marks      map[string]runproj.LaneProgressMark
+	// loggedDecodeMisses is the projector's cumulative bead.* decode-miss count
+	// already surfaced to the log, so logDecodeMisses only warns on the delta.
+	loggedDecodeMisses int
 }
 
 // captureTailCursor snapshots the active log's byte size and identity from a
@@ -154,6 +158,7 @@ func (t *cityRunTailer) loop(ctx context.Context) {
 	st := captureTailCursor(t.eventsPath)
 	loadErr := proj.ColdLoad(t.eventsPath)
 	st.marks = t.build(proj, nil, loadErr)
+	t.logDecodeMisses(proj, st)
 	close(t.readyCh)
 
 	poll := time.NewTicker(runTailPollInterval)
@@ -164,8 +169,26 @@ func (t *cityRunTailer) loop(ctx context.Context) {
 			return
 		case <-poll.C:
 			t.foldNext(proj, st)
+			t.logDecodeMisses(proj, st)
 		}
 	}
+}
+
+// logDecodeMisses surfaces new bead.* payload decode misses since the last poll.
+// A silent projection starve — a payload-shape or correlation-spine drift that
+// stops bead.* events from decoding — is the exact failure the run-view RCA
+// flagged: the view goes blank while every request still returns 200. Logging
+// the miss delta makes that loud. Called only from the single loop goroutine, so
+// st.loggedDecodeMisses needs no lock.
+func (t *cityRunTailer) logDecodeMisses(proj *runproj.Projector, st *tailState) {
+	total := proj.DecodeMisses()
+	if total <= st.loggedDecodeMisses {
+		return
+	}
+	delta := total - st.loggedDecodeMisses
+	st.loggedDecodeMisses = total
+	log.Printf("run-tailer: city %q dropped %d bead.* event(s) on decode miss (%d total) — run view may be stale",
+		t.name, delta, total)
 }
 
 // readRotationCatchUp is the rotation catch-up read, indirected through a

--- a/internal/api/event_payloads.go
+++ b/internal/api/event_payloads.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -195,77 +196,19 @@ type BeadEventPayload struct {
 // IsEventPayload marks BeadEventPayload as an events.Payload variant.
 func (BeadEventPayload) IsEventPayload() {}
 
-// UnmarshalJSON accepts the current {"bead": ...} payload shape and the
-// legacy raw-bead shape emitted by older bd hook scripts.
+// UnmarshalJSON decodes a bead.* event payload via the shared canonical decoder
+// (beads.DecodeBeadEventPayload): the raw bead snapshot CachingStore.notifyChange
+// emits, with the wrapped {"bead": ...} form accepted as a tolerant fallback. A
+// non-empty payload that does not decode to a bead with an id is an error, so a
+// malformed payload surfaces at this typed boundary instead of decoding to a
+// zero bead.
 func (p *BeadEventPayload) UnmarshalJSON(data []byte) error {
-	var wrapped struct {
-		Bead *json.RawMessage `json:"bead"`
-	}
-	if err := json.Unmarshal(data, &wrapped); err != nil {
-		return err
-	}
-	if wrapped.Bead != nil {
-		bead, err := decodeBeadEventPayloadBead(*wrapped.Bead)
-		if err != nil {
-			return err
-		}
-		p.Bead = bead
-		return nil
-	}
-
-	bead, err := decodeBeadEventPayloadBead(data)
-	if err != nil {
-		return err
+	bead, ok := beads.DecodeBeadEventPayload(data)
+	if !ok {
+		return fmt.Errorf("decode bead event payload: not a bead snapshot with an id: %s", data)
 	}
 	p.Bead = bead
 	return nil
-}
-
-func decodeBeadEventPayloadBead(data []byte) (beads.Bead, error) {
-	var wire struct {
-		ID           string          `json:"id"`
-		Title        string          `json:"title"`
-		Status       string          `json:"status"`
-		Type         string          `json:"issue_type"`
-		TypeCompat   string          `json:"type,omitempty"`
-		Priority     *int            `json:"priority,omitempty"`
-		CreatedAt    time.Time       `json:"created_at"`
-		Assignee     string          `json:"assignee,omitempty"`
-		From         string          `json:"from,omitempty"`
-		ParentID     string          `json:"parent,omitempty"`
-		Ref          string          `json:"ref,omitempty"`
-		Needs        []string        `json:"needs,omitempty"`
-		Description  string          `json:"description,omitempty"`
-		Labels       []string        `json:"labels,omitempty"`
-		Metadata     beads.StringMap `json:"metadata,omitempty"`
-		Dependencies []beads.Dep     `json:"dependencies,omitempty"`
-	}
-	if err := json.Unmarshal(data, &wire); err != nil {
-		return beads.Bead{}, err
-	}
-	bead := beads.Bead{
-		ID:           wire.ID,
-		Title:        wire.Title,
-		Status:       wire.Status,
-		Type:         wire.Type,
-		Priority:     wire.Priority,
-		CreatedAt:    wire.CreatedAt,
-		Assignee:     wire.Assignee,
-		From:         wire.From,
-		ParentID:     wire.ParentID,
-		Ref:          wire.Ref,
-		Needs:        wire.Needs,
-		Description:  wire.Description,
-		Labels:       wire.Labels,
-		Dependencies: wire.Dependencies,
-	}
-	if bead.Type == "" {
-		bead.Type = wire.TypeCompat
-	}
-	if wire.Metadata != nil {
-		bead.Metadata = map[string]string(wire.Metadata)
-	}
-	return bead, nil
 }
 
 // SessionLifecyclePayload is the typed payload for terminal session

--- a/internal/api/event_payloads_test.go
+++ b/internal/api/event_payloads_test.go
@@ -33,7 +33,11 @@ func TestDecodeBeadEventPayloadWrapped(t *testing.T) {
 	}
 }
 
-func TestDecodeBeadEventPayloadLegacyRawBead(t *testing.T) {
+// TestDecodeBeadEventPayloadCanonicalRawBead covers the CANONICAL producer
+// shape: the raw bead snapshot json.Marshal(b) emits (what notifyChange writes
+// and every events.jsonl row holds). The wrapped {"bead":...} form
+// (TestDecodeBeadEventPayloadWrapped) is the tolerant fallback, not the reverse.
+func TestDecodeBeadEventPayloadCanonicalRawBead(t *testing.T) {
 	raw := json.RawMessage(`{"id":"bd-123","title":"test bead","status":"open","issue_type":"task","created_at":"2026-04-26T21:37:46Z","metadata":{"state":"awake"}}`)
 
 	got, registered, err := events.DecodePayload(events.BeadUpdated, raw)

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -617,6 +617,13 @@ func cacheEventLooksComplete(fields map[string]json.RawMessage) bool {
 		(hasCacheEventField(fields, "issue_type") || hasCacheEventField(fields, "type"))
 }
 
+// decodeCacheEvent decodes a bead.* event payload into a bead patch AND the raw
+// top-level field set the cache uses for change-detection (hasCacheEventField).
+// It unwraps the tolerant {"bead": ...} envelope for the fields map, then routes
+// the bead itself through the shared canonical decoder so the cache and the
+// run-view projection can never drift apart on the wire shape or the
+// issue_type/type compat. An empty id is a decode miss (error), matching the
+// prior contract.
 func decodeCacheEvent(payload json.RawMessage) (Bead, map[string]json.RawMessage, error) {
 	eventPayload := payload
 	var envelope map[string]json.RawMessage
@@ -631,24 +638,9 @@ func decodeCacheEvent(payload json.RawMessage) (Bead, map[string]json.RawMessage
 	if err := json.Unmarshal(eventPayload, &fields); err != nil {
 		return Bead{}, nil, err
 	}
-	var wire struct {
-		Bead
-		Metadata   StringMap `json:"metadata,omitempty"`
-		TypeCompat string    `json:"type,omitempty"`
-	}
-	if err := json.Unmarshal(eventPayload, &wire); err != nil {
-		return Bead{}, nil, err
-	}
-	b := wire.Bead
-	if wire.Metadata != nil {
-		b.Metadata = map[string]string(wire.Metadata)
-	}
-	if b.ID == "" {
+	b, ok := DecodeBeadEventPayload(eventPayload)
+	if !ok {
 		return Bead{}, nil, fmt.Errorf("missing bead id")
-	}
-	// bd hook payloads use "issue_type" while exec-style payloads may use "type".
-	if b.Type == "" && wire.TypeCompat != "" {
-		b.Type = wire.TypeCompat
 	}
 	return b, fields, nil
 }

--- a/internal/beads/event_payload.go
+++ b/internal/beads/event_payload.go
@@ -1,0 +1,58 @@
+package beads
+
+import "encoding/json"
+
+// DecodeBeadEventPayload extracts a Bead from a bead.* event payload. It is the
+// single shared decoder for the bead-event wire shape; the API layer, the
+// caching store, and the run-view projection all route through it so their
+// tolerance can never drift apart on a future cleanup.
+//
+// Canonical shape = the RAW bead snapshot (json.Marshal(b)) — that is exactly
+// what CachingStore.notifyChange emits and what every .gc/events.jsonl row
+// holds. The wrapped {"bead":<snapshot>} shape (the registered BeadEventPayload
+// contract) is accepted as a tolerant fallback so a producer that ever emits it
+// does not silently starve consumers. A payload that decodes to a bead with an
+// empty id, an undecodable payload, or an empty payload is a decode miss:
+// (Bead{}, false).
+//
+// Bead's own json tags round-trip the raw wire faithfully (issue_type→Type,
+// parent→ParentID, ref/from/needs/metadata/dependencies, and StringMap coerces
+// the non-string metadata values the external bd CLI emits). The one field a
+// plain unmarshal misses is the exec-style "type" alias for issue_type, so the
+// decoder applies that compat fallback after the raw unmarshal.
+func DecodeBeadEventPayload(payload json.RawMessage) (Bead, bool) {
+	if len(payload) == 0 {
+		return Bead{}, false
+	}
+	if b, ok := decodeRawBead(payload); ok {
+		return b, true
+	}
+	// Tolerant fallback: the wrapped {"bead":<snapshot>} shape.
+	var env struct {
+		Bead json.RawMessage `json:"bead"`
+	}
+	if err := json.Unmarshal(payload, &env); err == nil && len(env.Bead) > 0 {
+		if b, ok := decodeRawBead(env.Bead); ok {
+			return b, true
+		}
+	}
+	return Bead{}, false
+}
+
+// decodeRawBead unmarshals a raw bead snapshot and applies the exec-style "type"
+// alias for issue_type. Returns false on decode error or empty id.
+func decodeRawBead(data json.RawMessage) (Bead, bool) {
+	var b Bead
+	if err := json.Unmarshal(data, &b); err != nil || b.ID == "" {
+		return Bead{}, false
+	}
+	if b.Type == "" {
+		var compat struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(data, &compat); err == nil && compat.Type != "" {
+			b.Type = compat.Type
+		}
+	}
+	return b, true
+}

--- a/internal/beads/event_payload_contract_test.go
+++ b/internal/beads/event_payload_contract_test.go
@@ -1,0 +1,66 @@
+package beads
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestNotifyChangePayloadDecodesViaSharedDecoder is the producer↔consumer
+// contract test the run-view RCA asked for: the exact bytes
+// CachingStore.notifyChange emits for a bead.* event must decode back to the
+// same bead through the shared canonical decoder. This pins the raw-bead wire
+// shape so a future "fix" that switches the producer to the wrapped
+// {"bead":...} form (or tightens a consumer's tolerance) fails here instead of
+// silently starving the run-view projection.
+func TestNotifyChangePayloadDecodesViaSharedDecoder(t *testing.T) {
+	prio := 2
+	seed := Bead{
+		ID:        "gcg-run-1",
+		Title:     "adopt PR #42",
+		Status:    "in_progress",
+		Type:      "molecule",
+		Priority:  &prio,
+		CreatedAt: time.Date(2026, 7, 4, 9, 0, 0, 0, time.UTC),
+		Assignee:  "worker-a",
+		ParentID:  "gcg-root",
+		Ref:       "mol-adopt-pr-v2",
+		Metadata: map[string]string{
+			"gc.formula_contract": "graph.v2",
+			"gc.kind":             "run",
+			"gc.step_id":          "gcg-step-1",
+		},
+	}
+
+	var got json.RawMessage
+	cs := NewCachingStore(NewMemStore(), func(_, _, _, _, _ string, payload json.RawMessage) {
+		got = payload
+	})
+	cs.notifyChange("bead.created", seed)
+
+	if len(got) == 0 {
+		t.Fatal("notifyChange emitted an empty payload")
+	}
+
+	decoded, ok := DecodeBeadEventPayload(got)
+	if !ok {
+		t.Fatalf("shared decoder could not decode notifyChange bytes: %s", got)
+	}
+	if decoded.ID != seed.ID {
+		t.Errorf("id = %q, want %q", decoded.ID, seed.ID)
+	}
+	if decoded.Title != seed.Title || decoded.Status != seed.Status || decoded.Type != seed.Type {
+		t.Errorf("decoded = %+v, want title/status/type of %+v", decoded, seed)
+	}
+	if decoded.Priority == nil || *decoded.Priority != prio {
+		t.Errorf("priority = %v, want %d", decoded.Priority, prio)
+	}
+	if !decoded.CreatedAt.Equal(seed.CreatedAt) {
+		t.Errorf("created_at = %v, want %v", decoded.CreatedAt, seed.CreatedAt)
+	}
+	for k, want := range seed.Metadata {
+		if decoded.Metadata[k] != want {
+			t.Errorf("metadata[%q] = %q, want %q", k, decoded.Metadata[k], want)
+		}
+	}
+}

--- a/internal/beads/event_payload_test.go
+++ b/internal/beads/event_payload_test.go
@@ -1,0 +1,137 @@
+package beads
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestDecodeBeadEventPayloadRawCanonical proves the canonical raw-bead shape —
+// what CachingStore.notifyChange actually marshals (json.Marshal(b)) and what
+// every .gc/events.jsonl row holds — decodes with full field fidelity.
+func TestDecodeBeadEventPayloadRawCanonical(t *testing.T) {
+	prio := 3
+	created := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	want := Bead{
+		ID:          "gcg-1",
+		Title:       "port the fold",
+		Status:      "in_progress",
+		Type:        "task",
+		Priority:    &prio,
+		CreatedAt:   created,
+		Assignee:    "worker-a",
+		From:        "sling",
+		ParentID:    "gcg-root",
+		Ref:         "step-a",
+		Needs:       []string{"step-x"},
+		Description: "instructions",
+		Labels:      []string{"lane:a"},
+		Metadata:    map[string]string{"gc.kind": "run", "gc.step_id": "gcg-step-1"},
+		Dependencies: []Dep{
+			{IssueID: "gcg-1", DependsOnID: "gcg-dep", Type: "blocks"},
+		},
+	}
+	raw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got, ok := DecodeBeadEventPayload(raw)
+	if !ok {
+		t.Fatalf("raw canonical decode returned ok=false for %s", raw)
+	}
+	if got.ID != want.ID || got.Title != want.Title || got.Status != want.Status ||
+		got.Type != want.Type || got.Assignee != want.Assignee || got.From != want.From ||
+		got.ParentID != want.ParentID || got.Ref != want.Ref || got.Description != want.Description {
+		t.Fatalf("scalar fields mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+	if got.Priority == nil || *got.Priority != prio {
+		t.Errorf("priority = %v, want %d", got.Priority, prio)
+	}
+	if !got.CreatedAt.Equal(created) {
+		t.Errorf("created_at = %v, want %v", got.CreatedAt, created)
+	}
+	if len(got.Needs) != 1 || got.Needs[0] != "step-x" {
+		t.Errorf("needs = %v, want [step-x]", got.Needs)
+	}
+	if len(got.Labels) != 1 || got.Labels[0] != "lane:a" {
+		t.Errorf("labels = %v, want [lane:a]", got.Labels)
+	}
+	if got.Metadata["gc.kind"] != "run" || got.Metadata["gc.step_id"] != "gcg-step-1" {
+		t.Errorf("metadata = %v, want gc.kind=run gc.step_id=gcg-step-1", got.Metadata)
+	}
+	if len(got.Dependencies) != 1 || got.Dependencies[0].DependsOnID != "gcg-dep" {
+		t.Errorf("dependencies = %v, want one dep on gcg-dep", got.Dependencies)
+	}
+}
+
+// TestDecodeBeadEventPayloadWrappedFallback proves the tolerant {"bead":<snap>}
+// fallback still decodes (older/registered-contract shape), so a producer that
+// switched to the wrapped shape would not silently starve consumers.
+func TestDecodeBeadEventPayloadWrappedFallback(t *testing.T) {
+	inner := Bead{ID: "gcg-2", Status: "open", Type: "bug"}
+	wrapped, err := json.Marshal(struct {
+		Bead Bead `json:"bead"`
+	}{inner})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got, ok := DecodeBeadEventPayload(wrapped)
+	if !ok {
+		t.Fatalf("wrapped fallback decode returned ok=false for %s", wrapped)
+	}
+	if got.ID != "gcg-2" || got.Type != "bug" || got.Status != "open" {
+		t.Errorf("wrapped decode = %+v, want id=gcg-2 type=bug status=open", got)
+	}
+}
+
+// TestDecodeBeadEventPayloadTypeCompat proves the bd-hook "type" field is honored
+// as an issue_type compat fallback (exec-style payloads use "type", bd hooks use
+// "issue_type"). A plain Bead unmarshal alone would drop it.
+func TestDecodeBeadEventPayloadTypeCompat(t *testing.T) {
+	got, ok := DecodeBeadEventPayload([]byte(`{"id":"gcg-3","type":"chore","status":"open"}`))
+	if !ok {
+		t.Fatal("type-compat decode returned ok=false")
+	}
+	if got.Type != "chore" {
+		t.Errorf("Type = %q, want chore (from compat \"type\" field)", got.Type)
+	}
+
+	// issue_type wins when both are present.
+	got2, ok := DecodeBeadEventPayload([]byte(`{"id":"gcg-4","issue_type":"feature","type":"chore"}`))
+	if !ok {
+		t.Fatal("issue_type-precedence decode returned ok=false")
+	}
+	if got2.Type != "feature" {
+		t.Errorf("Type = %q, want feature (issue_type wins over type)", got2.Type)
+	}
+}
+
+// TestDecodeBeadEventPayloadNonStringMetadata proves StringMap coercion survives
+// the shared decoder (bd CLI type-inference emits bool/number metadata values).
+func TestDecodeBeadEventPayloadNonStringMetadata(t *testing.T) {
+	got, ok := DecodeBeadEventPayload([]byte(`{"id":"gcg-5","metadata":{"gc.iteration":3,"done":true}}`))
+	if !ok {
+		t.Fatal("non-string metadata decode returned ok=false")
+	}
+	if got.Metadata["gc.iteration"] != "3" || got.Metadata["done"] != "true" {
+		t.Errorf("metadata = %v, want gc.iteration=3 done=true (coerced)", got.Metadata)
+	}
+}
+
+// TestDecodeBeadEventPayloadMisses proves the decode-miss cases return
+// (Bead{}, false): empty payload, empty id, and undecodable bytes.
+func TestDecodeBeadEventPayloadMisses(t *testing.T) {
+	cases := map[string]json.RawMessage{
+		"empty":       nil,
+		"blank id":    json.RawMessage(`{"id":"","status":"open"}`),
+		"no id":       json.RawMessage(`{"status":"open"}`),
+		"garbage":     json.RawMessage(`not json`),
+		"wrapped-nil": json.RawMessage(`{"bead":null}`),
+	}
+	for name, payload := range cases {
+		if b, ok := DecodeBeadEventPayload(payload); ok {
+			t.Errorf("%s: ok=true bead=%+v, want (Bead{}, false)", name, b)
+		}
+	}
+}

--- a/internal/beads/export_test.go
+++ b/internal/beads/export_test.go
@@ -5,3 +5,13 @@ package beads
 func NewNativeDoltStoreForConformance() Store {
 	return newNativeDoltStoreForTest(newNativeDoltMemStorage())
 }
+
+// NotifyChangeForTest drives the real producer (CachingStore.notifyChange) with
+// a caller-supplied bead, bypassing the store-write path that rewrites ids and
+// status. It lets cross-package guardrail tests (e.g. the run-view round-trip)
+// emit an exact run-shaped bead through the production event-marshal + run/session
+// id-resolution seam. The onChange callback receives the same 6-tuple the record
+// site (cmd/gc/api_state.go) wraps into an events.Event.
+func (c *CachingStore) NotifyChangeForTest(eventType string, b Bead) {
+	c.notifyChange(eventType, b)
+}

--- a/internal/beads/runview_roundtrip_test.go
+++ b/internal/beads/runview_roundtrip_test.go
@@ -1,0 +1,130 @@
+package beads_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runproj"
+)
+
+type beadSeed struct {
+	eventType string
+	bead      beads.Bead
+}
+
+// TestRunViewRoundTripFromNotifyChange is the anchor guardrail from the run-view
+// RCA: a run-shaped bead is emitted through the REAL producer
+// (beads.CachingStore.notifyChange) to build real events.Events, those events
+// are folded by runproj.Fold and projected by runproj.BuildRunSummary, and the
+// summary must contain the seeded run. Producer and consumer were previously
+// tested in separate hermetic bubbles, so an event-shape or metadata-migration
+// drift between them could not register. This test spans the exact seam that
+// broke: if the fold starves (wire-shape mismatch, silent drop), the summary
+// comes back empty and this fails.
+func TestRunViewRoundTripFromNotifyChange(t *testing.T) {
+	created := time.Date(2026, 7, 4, 8, 0, 0, 0, time.UTC)
+	// A graph.v2 run root (gc.formula_contract=graph.v2 / gc.kind=run) plus a
+	// child step bead carrying gc.step_id — the shape the run view groups on.
+	root := beads.Bead{
+		ID:        "gcg-run-root",
+		Title:     "adopt PR #7",
+		Status:    "in_progress",
+		Type:      "molecule",
+		CreatedAt: created,
+		Metadata: map[string]string{
+			beadmeta.FormulaContractMetadataKey: "graph.v2",
+			beadmeta.KindMetadataKey:            "run",
+			beadmeta.FormulaMetadataKey:         "mol-adopt-pr-v2",
+		},
+	}
+	step := beads.Bead{
+		ID:        "gcg-run-step",
+		Title:     "review",
+		Status:    "in_progress",
+		Type:      "task",
+		CreatedAt: created,
+		ParentID:  "gcg-run-root",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: "gcg-run-root",
+			beadmeta.StepIDMetadataKey:     "gcg-run-step",
+		},
+	}
+
+	evts := recordThroughNotifyChange(t,
+		beadSeed{events.BeadCreated, root},
+		beadSeed{events.BeadCreated, step},
+	)
+
+	folded := runproj.Fold(evts)
+	if len(folded) != 2 {
+		t.Fatalf("fold size = %d, want 2 (root + step); the fold starved", len(folded))
+	}
+
+	summary := runproj.BuildRunSummary(runproj.FilterRunBeads(beadsInSeenOrder(evts, folded)))
+	if summary.TotalActive == 0 {
+		t.Fatalf("run summary has no active lanes — the projection starved.\nsummary=%+v", summary)
+	}
+	var lane *runproj.RunLane
+	for i := range summary.Lanes {
+		if summary.Lanes[i].ID == "gcg-run-root" {
+			lane = &summary.Lanes[i]
+		}
+	}
+	if lane == nil {
+		t.Fatalf("seeded run gcg-run-root not present in summary lanes: %+v", summary.Lanes)
+	}
+	if lane.Formula.Status != "known" || lane.Formula.Name != "mol-adopt-pr-v2" {
+		t.Errorf("lane formula = %+v, want known/mol-adopt-pr-v2", lane.Formula)
+	}
+}
+
+// recordThroughNotifyChange emits each seed through the real
+// CachingStore.notifyChange producer and captures the events.Events the record
+// site (cmd/gc/api_state.go onChange closure) would build from the
+// (eventType, id, runID, sessionID, stepID, payload) callback.
+func recordThroughNotifyChange(t *testing.T, seeds ...beadSeed) []events.Event {
+	t.Helper()
+	var out []events.Event
+	seq := uint64(0)
+	cs := beads.NewCachingStore(beads.NewMemStore(), func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage) {
+		seq++
+		out = append(out, events.Event{
+			Seq:       seq,
+			Type:      eventType,
+			Actor:     "cache-reconcile",
+			Subject:   beadID,
+			RunID:     runID,
+			SessionID: sessionID,
+			StepID:    stepID,
+			Payload:   payload,
+		})
+	})
+	for _, s := range seeds {
+		cs.NotifyChangeForTest(s.eventType, s.bead)
+	}
+	if len(out) != len(seeds) {
+		t.Fatalf("emitted %d events, want %d (one per seed)", len(out), len(seeds))
+	}
+	return out
+}
+
+// beadsInSeenOrder returns the folded beads in the order their ids first appear
+// in the event stream, mirroring the Projector's first-seen ordering that
+// BuildRunSummary expects (a plain Fold map has random iteration order).
+func beadsInSeenOrder(evts []events.Event, folded map[string]beads.Bead) []beads.Bead {
+	var order []beads.Bead
+	seen := map[string]bool{}
+	for _, e := range evts {
+		b, ok := folded[e.Subject]
+		if !ok || seen[e.Subject] {
+			continue
+		}
+		seen[e.Subject] = true
+		order = append(order, b)
+	}
+	return order
+}

--- a/internal/runproj/fold.go
+++ b/internal/runproj/fold.go
@@ -10,11 +10,19 @@
 package runproj
 
 import (
-	"encoding/json"
-
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
 )
+
+// FoldStats reports observable signal from a fold pass. DecodeMisses counts
+// bead.* events whose payload did not decode to a bead with an id — the exact
+// silent-starve signature the run-view RCA identified. A non-zero value on a
+// live tail means the projection is dropping bead snapshots and the run view
+// will render blank/stale; the caller (the dashboard run tailer) surfaces it.
+type FoldStats struct {
+	DecodeMisses int
+}
 
 // beadEventTypes are the event types the fold consumes; everything else is
 // ignored. Kept as a set so callers can pre-filter a read if they want.
@@ -37,8 +45,9 @@ func Fold(evts []events.Event) map[string]beads.Bead {
 
 // Apply folds evts into an existing bead map in place (the live-tail path:
 // apply newly-watched events to the warm snapshot). Returns the highest seq
-// applied, so the caller can advance its cursor.
-func Apply(into map[string]beads.Bead, evts []events.Event) (lastSeq uint64) {
+// applied (so the caller can advance its cursor) and the pass's FoldStats (so a
+// silent decode-starve becomes observable rather than a bare continue).
+func Apply(into map[string]beads.Bead, evts []events.Event) (lastSeq uint64, stats FoldStats) {
 	for i := range evts {
 		e := &evts[i]
 		if e.Seq > lastSeq {
@@ -47,8 +56,9 @@ func Apply(into map[string]beads.Bead, evts []events.Event) (lastSeq uint64) {
 		if !beadEventTypes[e.Type] {
 			continue
 		}
-		b, ok := decodeBead(e.Payload)
+		b, ok := decodeBead(*e)
 		if !ok {
+			stats.DecodeMisses++
 			continue
 		}
 		if e.Type == events.BeadDeleted {
@@ -57,26 +67,46 @@ func Apply(into map[string]beads.Bead, evts []events.Event) (lastSeq uint64) {
 		}
 		into[b.ID] = b
 	}
-	return lastSeq
+	return lastSeq, stats
 }
 
-// decodeBead extracts a beads.Bead from a bead.* event payload. The current
-// payload shape is {"bead": <snapshot>}; older logs wrote the raw snapshot
-// directly, so both are accepted. A payload without an id is treated as a
-// decode miss.
-func decodeBead(payload json.RawMessage) (beads.Bead, bool) {
-	if len(payload) == 0 {
+// decodeBead extracts a beads.Bead from a bead.* event via the shared canonical
+// decoder (beads.DecodeBeadEventPayload) — the raw bead snapshot
+// CachingStore.notifyChange emits, with the wrapped {"bead": ...} form accepted
+// as a tolerant fallback. A payload without an id is a decode miss.
+//
+// After decoding, it backfills the run/step correlation ids from the event
+// envelope onto the bead's metadata when the envelope carries them and the
+// payload does not. The correlation spine promoted run_id/session_id/step_id to
+// typed envelope fields and is removing the metadata duplication the run view
+// still groups on; backfilling here keeps run/step grouping alive once the
+// duplicate metadata is gone. run_id is intentionally NOT synthesized —
+// ResolveRunID already falls back to the bead's own id.
+func decodeBead(e events.Event) (beads.Bead, bool) {
+	b, ok := beads.DecodeBeadEventPayload(e.Payload)
+	if !ok {
 		return beads.Bead{}, false
 	}
-	var env struct {
-		Bead beads.Bead `json:"bead"`
+	b.Metadata = backfillEnvelopeIDs(b.Metadata, e)
+	return b, true
+}
+
+// backfillEnvelopeIDs fills the step/session correlation ids from the event
+// envelope into a bead metadata map, but only when the envelope carries the id
+// and the payload metadata does not (the payload snapshot stays authoritative).
+func backfillEnvelopeIDs(md map[string]string, e events.Event) map[string]string {
+	md = fillIfAbsent(md, beadmeta.StepIDMetadataKey, e.StepID)
+	md = fillIfAbsent(md, beadmeta.SessionIDMetadataKey, e.SessionID)
+	return md
+}
+
+func fillIfAbsent(md map[string]string, key, value string) map[string]string {
+	if value == "" || md[key] != "" {
+		return md
 	}
-	if err := json.Unmarshal(payload, &env); err == nil && env.Bead.ID != "" {
-		return env.Bead, true
+	if md == nil {
+		md = make(map[string]string, 1)
 	}
-	var raw beads.Bead
-	if err := json.Unmarshal(payload, &raw); err == nil && raw.ID != "" {
-		return raw, true
-	}
-	return beads.Bead{}, false
+	md[key] = value
+	return md
 }

--- a/internal/runproj/fold_test.go
+++ b/internal/runproj/fold_test.go
@@ -4,14 +4,16 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
 )
 
+// beadEvent builds a bead.* event with the REAL producer payload shape — the
+// raw bead snapshot json.Marshal(b) emits (never the wrapped {"bead":...} form,
+// which no producer writes). See CachingStore.notifyChange.
 func beadEvent(seq uint64, typ, id, status string) events.Event {
-	payload, _ := json.Marshal(struct {
-		Bead beads.Bead `json:"bead"`
-	}{beads.Bead{ID: id, Status: status, Type: "task"}})
+	payload, _ := json.Marshal(beads.Bead{ID: id, Status: status, Type: "task"})
 	return events.Event{Seq: seq, Type: typ, Payload: payload}
 }
 
@@ -45,7 +47,7 @@ func TestFoldKeepsLatestSnapshotPerID(t *testing.T) {
 func TestApplyAdvancesCursorAndMutatesInPlace(t *testing.T) {
 	state := Fold([]events.Event{beadEvent(10, events.BeadCreated, "a", "open")})
 
-	last := Apply(state, []events.Event{
+	last, _ := Apply(state, []events.Event{
 		beadEvent(11, events.BeadUpdated, "a", "closed"),
 		beadEvent(12, events.BeadCreated, "d", "open"),
 	})
@@ -65,7 +67,7 @@ func TestApplyCursorTracksMaxSeqEvenForIgnoredEvents(t *testing.T) {
 	// A non-bead event still advances the cursor so the tailer does not re-read
 	// it; only the fold map is unaffected.
 	state := map[string]beads.Bead{}
-	last := Apply(state, []events.Event{{Seq: 99, Type: events.SessionStopped, Subject: "w"}})
+	last, _ := Apply(state, []events.Event{{Seq: 99, Type: events.SessionStopped, Subject: "w"}})
 	if last != 99 {
 		t.Errorf("lastSeq = %d, want 99 (cursor advances past ignored events)", last)
 	}
@@ -74,11 +76,78 @@ func TestApplyCursorTracksMaxSeqEvenForIgnoredEvents(t *testing.T) {
 	}
 }
 
-func TestDecodeBeadAcceptsLegacyRawShape(t *testing.T) {
-	// Older logs wrote the raw bead snapshot with no {"bead": ...} envelope.
-	raw, _ := json.Marshal(beads.Bead{ID: "legacy", Status: "open", Type: "task"})
-	b, ok := decodeBead(raw)
-	if !ok || b.ID != "legacy" {
-		t.Fatalf("legacy raw-shape decode failed: ok=%v bead=%+v", ok, b)
+func TestDecodeBeadAcceptsCanonicalRawShape(t *testing.T) {
+	// The canonical producer shape is the raw bead snapshot (json.Marshal(b),
+	// exactly what CachingStore.notifyChange emits) — NOT the wrapped
+	// {"bead": ...} form. The fold must decode it, and an envelope carrying no
+	// correlation ids leaves the bead's own metadata untouched.
+	raw, _ := json.Marshal(beads.Bead{ID: "canon", Status: "open", Type: "task"})
+	b, ok := decodeBead(events.Event{Payload: raw})
+	if !ok || b.ID != "canon" {
+		t.Fatalf("canonical raw-shape decode failed: ok=%v bead=%+v", ok, b)
+	}
+}
+
+// TestApplyCountsDecodeMisses proves a bead.* event whose payload does not decode
+// to a bead with an id is counted as a decode miss (observable), not swallowed
+// silently. Non-bead events do not count.
+func TestApplyCountsDecodeMisses(t *testing.T) {
+	evts := []events.Event{
+		beadEvent(1, events.BeadCreated, "a", "open"),
+		{Seq: 2, Type: events.BeadUpdated, Payload: json.RawMessage(`{"status":"open"}`)}, // no id → miss
+		{Seq: 3, Type: events.BeadClosed, Payload: json.RawMessage(`garbage`)},            // undecodable → miss
+		{Seq: 4, Type: events.SessionWoke, Subject: "w"},                                  // not a bead event → not a miss
+	}
+	state := map[string]beads.Bead{}
+	last, stats := Apply(state, evts)
+	if last != 4 {
+		t.Errorf("lastSeq = %d, want 4", last)
+	}
+	if stats.DecodeMisses != 2 {
+		t.Errorf("DecodeMisses = %d, want 2 (id-less + garbage bead.* events)", stats.DecodeMisses)
+	}
+	if len(state) != 1 {
+		t.Errorf("fold size = %d, want 1 (only 'a' decoded)", len(state))
+	}
+}
+
+// TestApplyBackfillsEnvelopeCorrelationIDs proves the correlation-spine
+// guardrail: when a bead.* envelope carries step_id/session_id but the decoded
+// bead's metadata lacks them, Apply backfills them onto the bead metadata so
+// run/step grouping survives the spine work removing the metadata duplication.
+func TestApplyBackfillsEnvelopeCorrelationIDs(t *testing.T) {
+	// Bead payload deliberately omits gc.step_id / gc.session_id from metadata.
+	raw, _ := json.Marshal(beads.Bead{ID: "b1", Status: "open", Type: "task"})
+	state := map[string]beads.Bead{}
+	Apply(state, []events.Event{{
+		Seq:       1,
+		Type:      events.BeadCreated,
+		Payload:   raw,
+		StepID:    "gcg-step-9",
+		SessionID: "sess-9",
+	}})
+	got := state["b1"]
+	if got.Metadata[beadmeta.StepIDMetadataKey] != "gcg-step-9" {
+		t.Errorf("gc.step_id = %q, want gcg-step-9 (backfilled from envelope)", got.Metadata[beadmeta.StepIDMetadataKey])
+	}
+	if got.Metadata[beadmeta.SessionIDMetadataKey] != "sess-9" {
+		t.Errorf("gc.session_id = %q, want sess-9 (backfilled from envelope)", got.Metadata[beadmeta.SessionIDMetadataKey])
+	}
+}
+
+// TestApplyEnvelopeBackfillDoesNotClobberPayloadMetadata proves the backfill is
+// a fill-if-absent: a value already carried in the bead payload metadata wins
+// over the envelope copy (the payload is the authoritative snapshot).
+func TestApplyEnvelopeBackfillDoesNotClobberPayloadMetadata(t *testing.T) {
+	raw, _ := json.Marshal(beads.Bead{
+		ID: "b2", Status: "open", Type: "task",
+		Metadata: map[string]string{beadmeta.StepIDMetadataKey: "payload-step"},
+	})
+	state := map[string]beads.Bead{}
+	Apply(state, []events.Event{{
+		Seq: 1, Type: events.BeadCreated, Payload: raw, StepID: "envelope-step",
+	}})
+	if got := state["b2"].Metadata[beadmeta.StepIDMetadataKey]; got != "payload-step" {
+		t.Errorf("gc.step_id = %q, want payload-step (payload metadata wins over envelope)", got)
 	}
 }

--- a/internal/runproj/projector.go
+++ b/internal/runproj/projector.go
@@ -16,9 +16,10 @@ import (
 // A Projector is not safe for concurrent use; the tailer mutates it from its
 // single loop goroutine and publishes the built summary under its own lock.
 type Projector struct {
-	beads   map[string]beads.Bead
-	order   []string
-	lastSeq uint64
+	beads        map[string]beads.Bead
+	order        []string
+	lastSeq      uint64
+	decodeMisses int
 }
 
 // NewProjector returns an empty projector.
@@ -46,6 +47,8 @@ func (p *Projector) ColdLoad(path string) error {
 // snapshots and removing bead.deleted ones, preserving first-seen order for new
 // ids. It advances the cursor past every event (bead or not) and reports whether
 // any bead snapshot changed, so the caller can skip a rebuild on a no-op tick.
+// A bead.* event whose payload does not decode is counted (DecodeMisses) rather
+// than swallowed, so a silent projection starve is observable to the caller.
 func (p *Projector) Apply(evts []events.Event) (changed bool) {
 	for i := range evts {
 		e := &evts[i]
@@ -55,8 +58,9 @@ func (p *Projector) Apply(evts []events.Event) (changed bool) {
 		if !beadEventTypes[e.Type] {
 			continue
 		}
-		b, ok := decodeBead(e.Payload)
+		b, ok := decodeBead(*e)
 		if !ok {
+			p.decodeMisses++
 			continue
 		}
 		if e.Type == events.BeadDeleted {
@@ -91,6 +95,12 @@ func (p *Projector) Beads() []beads.Bead {
 // LastSeq returns the highest event seq applied — the cursor a live tail resumes
 // from.
 func (p *Projector) LastSeq() uint64 { return p.lastSeq }
+
+// DecodeMisses returns the cumulative count of bead.* events whose payload did
+// not decode to a bead with an id. It is monotonic across Apply calls; the
+// tailer watches the delta so a live projection starve (the run-view RCA
+// signature) surfaces as a log line instead of a blank view.
+func (p *Projector) DecodeMisses() int { return p.decodeMisses }
 
 func (p *Projector) removeOrder(id string) {
 	for i, oid := range p.order {

--- a/internal/runproj/projector_test.go
+++ b/internal/runproj/projector_test.go
@@ -1,6 +1,7 @@
 package runproj
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -68,6 +69,27 @@ func TestProjectorNoOpTickReportsUnchanged(t *testing.T) {
 	}
 	if p.LastSeq() != 7 {
 		t.Errorf("lastSeq = %d, want 7 (cursor advances past ignored events)", p.LastSeq())
+	}
+}
+
+// TestProjectorCountsDecodeMisses proves the tailer-driven path (Projector.Apply,
+// not the free Apply) counts bead.* payload decode misses instead of swallowing
+// them — the observable signal the run tailer logs so a live projection starve
+// surfaces. Non-bead events are not misses, and the count is cumulative.
+func TestProjectorCountsDecodeMisses(t *testing.T) {
+	p := NewProjector()
+	p.Apply([]events.Event{
+		beadEvent(1, events.BeadCreated, "a", "open"),
+		{Seq: 2, Type: events.BeadUpdated, Payload: json.RawMessage(`{"status":"open"}`)}, // no id → miss
+		{Seq: 3, Type: events.SessionWoke, Subject: "w"},                                  // not a bead event
+	})
+	if p.DecodeMisses() != 1 {
+		t.Fatalf("DecodeMisses = %d, want 1 after first pass", p.DecodeMisses())
+	}
+	// A second pass with another undecodable bead.* event accumulates the count.
+	p.Apply([]events.Event{{Seq: 4, Type: events.BeadClosed, Payload: json.RawMessage(`garbage`)}})
+	if p.DecodeMisses() != 2 {
+		t.Errorf("DecodeMisses = %d, want 2 (cumulative across passes)", p.DecodeMisses())
 	}
 }
 


### PR DESCRIPTION
## Summary
Makes the event-shape-drift class that can silently blank the run view **loud**, and fixes the two latent bombs the RCA found. The Runs view is a Go projection folding `.gc/events.jsonl` (#3804); two type-invisible defects could starve it silently — blank view, every request 200, every test green:

1. The registered `BeadEventPayload` contract says `{"bead":…}` but **no producer emits it** — `CachingStore.notifyChange` marshals the raw bead; three decoders each tolerated both shapes independently, one cleanup away from drifting apart.
2. The fold re-derived run/step identity from `payload.metadata["gc.step_id"]` **shadow copies** while the correlation spine (#3680/#3696) moved the authoritative ids to typed envelope fields — the spine removing the metadata duplication would blank the view.

## Changes
- **One shared canonical decoder** `beads.DecodeBeadEventPayload` — raw-first (what's actually emitted), wrapped `{"bead":…}` as tolerant fallback. The API layer, caching store, and run projection all route through it so their tolerance can never drift apart.
- **Observable fold** — `runproj` counts decode misses (`FoldStats.DecodeMisses`) and the dashboard run tailer logs them, instead of a bare silent `continue`.
- **Envelope-id backfill** — the fold backfills `gc.step_id`/`gc.session_id` from the typed event envelope when the payload lacks them, so run/step grouping survives the spine removing the metadata duplication (payload stays authoritative; `run_id` not synthesized).
- **Contract + round-trip tests** — a producer-contract test pins `notifyChange`'s raw shape; **the round-trip net test** fires a run-shaped bead through `notifyChange` → events → `Fold` → `BuildRunSummary` and asserts a non-empty run (verified to starve if the decoder drifts). Retires the inverted "raw is legacy" comments/test labels.

## Testing
`go build ./...` clean; `go vet` clean; `go test ./internal/beads/ ./internal/runproj/ ./internal/api/... ./internal/api/dashboardbff/` green.

First of the dashboard-health program — the safety net before the event-first refactors. A broader serve-level + Playwright e2e harness follows in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)