### PR TITLE
perf(dashboard): cache run-tailer session + formula enrichments (single-flight + TTL)

### DIFF
--- a/internal/api/dashboardbff/enrichment_cache.go
+++ b/internal/api/dashboardbff/enrichment_cache.go
@@ -32,6 +32,15 @@ var (
 	// promptly instead of being pinned missing for the full success TTL. A var so
 	// tests can shorten it.
 	formulaNotFoundTTL = 5 * time.Second
+	// singleFlightComputeTimeout bounds the elected single-flight compute, which
+	// runs under a context DETACHED from the electing caller's request (see get).
+	// Detaching stops the caller disconnecting from canceling the shared upstream
+	// fetch, but a detached context also loses the request deadline, so this
+	// timeout backstops a wedged upstream and keeps a stuck flight from pinning the
+	// elector goroutine (and every joiner) forever. It sits above the per-fetch
+	// http.Client timeout (runSessionsFetchTimeout), which stays the primary bound
+	// in practice. A var so tests can shorten it.
+	singleFlightComputeTimeout = 30 * time.Second
 )
 
 // ── Generic single-flight TTL cache ───────────────────────────────────────
@@ -62,9 +71,26 @@ type cacheEntry[V any] struct {
 	// cold-miss degrade so a stale not-found never masks a later upstream error.
 	staleServeable bool
 	// inflight is non-nil while exactly one caller computes this key; joiners wait
-	// on it and then re-read the entry. It is set under the cache lock, closed by
-	// the computing caller after publishing, and cleared under the lock.
-	inflight chan struct{}
+	// on its done channel and then return its published result (never re-electing),
+	// so a burst of concurrent callers collapses onto ONE upstream fetch even when
+	// that fetch fails. It is set under the cache lock, resolved and closed by the
+	// computing caller after publishing, and cleared under the lock.
+	inflight *flight[V]
+}
+
+// flight is one in-flight compute for a key. It carries the channel joiners wait
+// on plus the single result the elected computer publishes for every caller
+// joined to this flight to return: a fresh success, a served-stale positive
+// last-good, or a transient cold/expired-negative failure. Sharing one flight's
+// result is what collapses a concurrent burst onto ONE upstream fetch even when
+// the fetch fails — the failure is NOT written to the cache entry, so a LATER
+// request still re-elects and refetches. value/ok are written once (under the
+// cache lock, before done is closed) and read by joiners only after done closes,
+// so the channel close supplies the happens-before with no extra locking.
+type flight[V any] struct {
+	done  chan struct{}
+	value V
+	ok    bool
 }
 
 // singleFlightCache is a small per-key TTL cache with single-flight: concurrent
@@ -94,99 +120,142 @@ func newSingleFlightCache[K comparable, V any]() *singleFlightCache[K, V] {
 // staleServeable last-good the stale value is served (available); on a cold miss
 // with no serveable last-good the zero value is returned so the caller can apply
 // its own honest degrade. Exactly one caller runs compute per key per miss; the
-// rest block until it publishes, then re-read.
+// rest block until it publishes, then return that same shared result — so a
+// concurrent burst, INCLUDING a failed one, collapses onto that single fetch.
+// The elected compute runs under a context detached from the electing caller's
+// request (its values kept, its cancellation and deadline dropped) plus a bounded
+// timeout, so an elector that disconnects mid-fetch cannot cancel the shared
+// upstream request its joiners are still waiting on; each joiner still abandons
+// its own wait via ctx. A caller whose ctx is already canceled at a miss does not
+// elect at all — it degrades to the serveable last-good — so only a caller that
+// was live at election ever detaches a compute for nobody.
 //
 // The returned bool reports whether a usable value is being served: true for a
 // fresh success, a within-TTL hit, or a served-stale positive last-good; false
 // for a cold miss whose fetch failed and left no last-good, or an expired
 // negative whose refetch failed.
 func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(context.Context) (V, time.Duration, bool, bool)) (V, bool) {
-	for {
-		c.mu.Lock()
-		e, ok := c.entries[key]
-		if !ok {
-			e = &cacheEntry[V]{}
-			c.entries[key] = e
-		}
-		// Fresh hit: serve without touching the upstream.
-		if e.hasValue && e.inflight == nil && time.Since(e.computed) < e.ttl {
-			v := e.value
-			c.mu.Unlock()
-			return v, true
-		}
-		// Someone is already computing this key: join and re-read once they publish.
-		if e.inflight != nil {
-			wait := e.inflight
-			c.mu.Unlock()
-			select {
-			case <-wait:
-				// Loop: re-read the now-published entry (or re-elect a computer if the
-				// prior compute failed and left the entry stale/empty and expired).
-				continue
-			case <-ctx.Done():
-				// The caller gave up. Serve the last-good if we have one (never block a
-				// canceled caller on an in-flight fetch); otherwise degrade.
-				return c.lastGoodOrZero(key)
-			}
-		}
-		// We are the elected computer for this key.
-		done := make(chan struct{})
-		e.inflight = done
-		c.mu.Unlock()
-
-		// The in-flight handshake MUST be released on every exit — including a
-		// panic in compute. The dashboardbff plane runs under the supervisor's
-		// withRecovery middleware, so a compute panic is caught and turned into a
-		// 500 while the process keeps serving; without a deferred release the
-		// entry's inflight channel would be orphaned (never closed) and every
-		// future caller for this key would block on it forever (or degrade to a
-		// frozen last-good that never refetches). The deferred cleanup runs
-		// before the panic propagates, so the next caller re-elects and recovers
-		// while withRecovery still logs and 500s the panicking request.
-		var (
-			value          V
-			ttl            time.Duration
-			computeOK      bool
-			staleServeable bool
-			served         V
-			servedStaleOK  bool
-		)
-		func() {
-			defer func() {
-				c.mu.Lock()
-				if computeOK {
-					e.value = value
-					e.computed = time.Now()
-					e.ttl = ttl
-					e.hasValue = true
-					e.staleServeable = staleServeable
-				}
-				// else: keep the prior last-good (if any) untouched — degrade,
-				// don't blank.
-				served, servedStaleOK = e.value, e.hasValue && e.staleServeable
-				e.inflight = nil
-				c.mu.Unlock()
-				close(done)
-			}()
-			// Compute with NO cache lock held (the samplers.go contract). A panic
-			// here still runs the deferred release above, then propagates.
-			value, ttl, computeOK, staleServeable = compute(ctx)
-		}()
-
-		if computeOK {
-			return value, true
-		}
-		if servedStaleOK {
-			// A failed refetch with a serveable positive last-good: serve it stale.
-			// A negative last-good is NOT serveable stale, so it falls through to the
-			// cold-miss degrade below rather than masking this upstream error.
-			return served, true
-		}
-		// Cold miss (or expired negative), fetch failed, no serveable last-good:
-		// honest degrade to the zero value.
-		var zero V
-		return zero, false
+	c.mu.Lock()
+	e, ok := c.entries[key]
+	if !ok {
+		e = &cacheEntry[V]{}
+		c.entries[key] = e
 	}
+	// Fresh hit: serve without touching the upstream.
+	if e.hasValue && e.inflight == nil && time.Since(e.computed) < e.ttl {
+		v := e.value
+		c.mu.Unlock()
+		return v, true
+	}
+	// Someone is already computing this key: join that flight and return its
+	// shared result instead of re-electing. A failed cold or expired-negative
+	// flight is shared here too, so N concurrent callers collapse onto the ONE
+	// upstream fetch rather than each waking, re-electing, and refetching
+	// serially. A later request (after the flight clears inflight) still elects a
+	// fresh compute, since the failure was never cached on the entry.
+	if e.inflight != nil {
+		fl := e.inflight
+		c.mu.Unlock()
+		select {
+		case <-fl.done:
+			return fl.value, fl.ok
+		case <-ctx.Done():
+			// The caller gave up. Serve the last-good if we have one (never block a
+			// canceled caller on an in-flight fetch); otherwise degrade.
+			return c.lastGoodOrZero(key)
+		}
+	}
+	// A caller whose request context is already canceled must NOT elect a new
+	// flight. Electing sets the inflight slot and runs compute under a context
+	// DETACHED from this caller (context.WithoutCancel below), so a request that
+	// was already gone before the miss would still drive a full upstream fetch —
+	// bounded only by the fetch/backstop timeout — on nobody's behalf. The
+	// fresh-hit and join paths above are already safe for a canceled caller (a
+	// hit does no upstream work; a joiner abandons via its own ctx.Done()); only
+	// election has to guard. Degrade to the serveable last-good exactly as the
+	// canceled-joiner branch does. WithoutCancel below therefore only ever
+	// detaches a compute elected by a caller that was live at election, so a
+	// mid-flight disconnect still cannot cancel the shared fetch for joiners.
+	if ctx.Err() != nil {
+		c.mu.Unlock()
+		return c.lastGoodOrZero(key)
+	}
+	// We are the elected computer for this key.
+	fl := &flight[V]{done: make(chan struct{})}
+	e.inflight = fl
+	c.mu.Unlock()
+
+	// The in-flight handshake MUST be released on every exit — including a panic
+	// in compute. The dashboardbff plane runs under the supervisor's withRecovery
+	// middleware, so a compute panic is caught and turned into a 500 while the
+	// process keeps serving; without a deferred release the entry's inflight
+	// channel would be orphaned (never closed) and every future caller for this
+	// key would block on it forever (or degrade to a frozen last-good that never
+	// refetches). The deferred cleanup runs before the panic propagates, so the
+	// next caller re-elects and recovers while withRecovery still logs and 500s
+	// the panicking request.
+	var (
+		value          V
+		ttl            time.Duration
+		computeOK      bool
+		staleServeable bool
+		resultValue    V
+		resultOK       bool
+	)
+	func() {
+		defer func() {
+			c.mu.Lock()
+			if computeOK {
+				e.value = value
+				e.computed = time.Now()
+				e.ttl = ttl
+				e.hasValue = true
+				e.staleServeable = staleServeable
+			}
+			// else: keep the prior last-good (if any) untouched — degrade,
+			// don't blank.
+			//
+			// Resolve the single result this flight publishes to every joined caller
+			// (the elector and all current waiters): a fresh success, a served-stale
+			// positive last-good, or an honest degrade. Because a failure is never
+			// written to the entry above, a LATER request re-elects and refetches —
+			// only the concurrent burst is collapsed.
+			switch {
+			case computeOK:
+				resultValue, resultOK = value, true
+			case e.hasValue && e.staleServeable:
+				// A failed refetch with a serveable positive last-good: serve it stale.
+				// A negative last-good is NOT serveable stale, so it falls through to
+				// the degrade below rather than masking this upstream error.
+				resultValue, resultOK = e.value, true
+			default:
+				// Cold miss (or expired negative), fetch failed, no serveable
+				// last-good: honest degrade to the zero value.
+				var zero V
+				resultValue, resultOK = zero, false
+			}
+			fl.value, fl.ok = resultValue, resultOK
+			e.inflight = nil
+			c.mu.Unlock()
+			close(fl.done)
+		}()
+		// Compute with NO cache lock held (the samplers.go contract), under a
+		// context DETACHED from the electing caller's request. This elected compute
+		// is the single upstream fetch every joined caller shares; if it ran on the
+		// elector's ctx, that caller disconnecting or hitting its deadline mid-fetch
+		// would cancel the shared request and hand every still-waiting joiner a
+		// canceled/failed result instead of their own enrichment. context.WithoutCancel
+		// keeps the request's values (auth, tracing) while dropping its cancellation
+		// and deadline; a bounded timeout backstops a wedged upstream so the detached
+		// compute can never pin the flight forever. Joiners still abandon their own
+		// wait via ctx.Done() above — only the shared compute is decoupled. A panic
+		// here still runs the deferred release above, then propagates.
+		computeCtx, cancelCompute := context.WithTimeout(context.WithoutCancel(ctx), singleFlightComputeTimeout)
+		defer cancelCompute()
+		value, ttl, computeOK, staleServeable = compute(computeCtx)
+	}()
+
+	return resultValue, resultOK
 }
 
 // lastGoodOrZero returns the entry's serveable last-good value (available) if one

--- a/internal/api/dashboardbff/enrichment_cache.go
+++ b/internal/api/dashboardbff/enrichment_cache.go
@@ -53,6 +53,14 @@ type cacheEntry[V any] struct {
 	// definitively-negative) compute, so a cold miss whose fetch fails does not
 	// publish a zero value as if it were last-good.
 	hasValue bool
+	// staleServeable reports whether this entry may be served AFTER a failed
+	// refetch (the last-good/serve-stale contract). A positive result (a real
+	// success) is safe to serve stale — a slow-changing formula or a session list
+	// is still a useful answer. A negative result (a cached not-found) is
+	// fresh-serveable within its TTL via the fast-hit path, but must NOT be served
+	// stale: once it expires, an errored refetch falls through to the caller's
+	// cold-miss degrade so a stale not-found never masks a later upstream error.
+	staleServeable bool
 	// inflight is non-nil while exactly one caller computes this key; joiners wait
 	// on it and then re-read the entry. It is set under the cache lock, closed by
 	// the computing caller after publishing, and cleared under the lock.
@@ -76,17 +84,23 @@ func newSingleFlightCache[K comparable, V any]() *singleFlightCache[K, V] {
 
 // get returns the value for key, computing it via compute on a miss or expiry.
 // compute returns the fetched value, the TTL that value should live for (so the
-// formula cache can pick a shorter window for a not-found outcome), and ok
-// reporting whether the fetch succeeded well enough to cache as last-good. On a
-// compute failure with an existing last-good value the stale value is served
-// (available); on a cold miss with no last-good the zero value is returned so the
-// caller can apply its own honest degrade. Exactly one caller runs compute per
-// key per miss; the rest block until it publishes, then re-read.
+// formula cache can pick a shorter window for a not-found outcome), ok reporting
+// whether the fetch succeeded well enough to cache, and staleServeable reporting
+// whether that cached value may be served AFTER a later failed refetch. A
+// positive result is staleServeable (serve last-good on error); a definitive
+// negative (a cached not-found) is cached but NOT staleServeable, so once it
+// expires an errored refetch falls through to the caller's cold-miss degrade
+// rather than surfacing the stale negative. On a compute failure with an existing
+// staleServeable last-good the stale value is served (available); on a cold miss
+// with no serveable last-good the zero value is returned so the caller can apply
+// its own honest degrade. Exactly one caller runs compute per key per miss; the
+// rest block until it publishes, then re-read.
 //
 // The returned bool reports whether a usable value is being served: true for a
-// fresh success, a within-TTL hit, or a served-stale last-good; false only for a
-// cold miss whose fetch failed and left no last-good.
-func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(context.Context) (V, time.Duration, bool)) (V, bool) {
+// fresh success, a within-TTL hit, or a served-stale positive last-good; false
+// for a cold miss whose fetch failed and left no last-good, or an expired
+// negative whose refetch failed.
+func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(context.Context) (V, time.Duration, bool, bool)) (V, bool) {
 	for {
 		c.mu.Lock()
 		e, ok := c.entries[key]
@@ -130,11 +144,12 @@ func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(c
 		// before the panic propagates, so the next caller re-elects and recovers
 		// while withRecovery still logs and 500s the panicking request.
 		var (
-			value     V
-			ttl       time.Duration
-			computeOK bool
-			served    V
-			hadValue  bool
+			value          V
+			ttl            time.Duration
+			computeOK      bool
+			staleServeable bool
+			served         V
+			servedStaleOK  bool
 		)
 		func() {
 			defer func() {
@@ -144,40 +159,46 @@ func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(c
 					e.computed = time.Now()
 					e.ttl = ttl
 					e.hasValue = true
+					e.staleServeable = staleServeable
 				}
 				// else: keep the prior last-good (if any) untouched — degrade,
 				// don't blank.
-				served, hadValue = e.value, e.hasValue
+				served, servedStaleOK = e.value, e.hasValue && e.staleServeable
 				e.inflight = nil
 				c.mu.Unlock()
 				close(done)
 			}()
 			// Compute with NO cache lock held (the samplers.go contract). A panic
 			// here still runs the deferred release above, then propagates.
-			value, ttl, computeOK = compute(ctx)
+			value, ttl, computeOK, staleServeable = compute(ctx)
 		}()
 
 		if computeOK {
 			return value, true
 		}
-		if hadValue {
-			// A failed refetch with a prior success: serve the stale last-good.
+		if servedStaleOK {
+			// A failed refetch with a serveable positive last-good: serve it stale.
+			// A negative last-good is NOT serveable stale, so it falls through to the
+			// cold-miss degrade below rather than masking this upstream error.
 			return served, true
 		}
-		// Cold miss, fetch failed, no last-good: honest degrade to the zero value.
+		// Cold miss (or expired negative), fetch failed, no serveable last-good:
+		// honest degrade to the zero value.
 		var zero V
 		return zero, false
 	}
 }
 
-// lastGoodOrZero returns the entry's last-good value (available) if one exists,
-// else the zero value (unavailable). Used when a caller's ctx is canceled while
-// joining an in-flight fetch: a canceled caller must never block, but should
-// still serve the last-good if the cache holds one.
+// lastGoodOrZero returns the entry's serveable last-good value (available) if one
+// exists, else the zero value (unavailable). Used when a caller's ctx is canceled
+// while joining an in-flight fetch: a canceled caller must never block, but should
+// still serve a serveable last-good if the cache holds one. A cached negative is
+// not serveable stale (see cacheEntry.staleServeable), so it degrades here too
+// rather than surfacing a stale not-found on cancellation.
 func (c *singleFlightCache[K, V]) lastGoodOrZero(key K) (V, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if e, ok := c.entries[key]; ok && e.hasValue {
+	if e, ok := c.entries[key]; ok && e.hasValue && e.staleServeable {
 		return e.value, true
 	}
 	var zero V

--- a/internal/api/dashboardbff/enrichment_cache.go
+++ b/internal/api/dashboardbff/enrichment_cache.go
@@ -1,0 +1,217 @@
+package dashboardbff
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/runproj"
+)
+
+// The two per-request loopback reads the run-detail path layers on top of the
+// warm fold — GET /v0/city/{name}/sessions and GET /v0/city/{name}/formulas/... —
+// are cached per city with single-flight + TTL so a burst of detail/summary GETs
+// (a dashboard tab re-polling on every bead nudge) collapses onto ONE upstream
+// fetch per key rather than one per request. This follows the samplers.go
+// contract: the blocking upstream fetch runs with no cache lock held, exactly one
+// caller performs it per key during a miss (the rest join its result), and a
+// fetch failure degrades by serving the last-good value with its availability
+// flag rather than blanking — except a cold miss with no last-good, which
+// degrades EXACTLY as the uncached path did (so the honest partial/warming states
+// are preserved).
+var (
+	// sessionsCacheTTL bounds how long a cached sessions read is served before a
+	// refetch. A var (not a const) so tests can shorten it.
+	sessionsCacheTTL = 3 * time.Second
+	// formulaCacheTTL bounds how long a successfully-compiled formula detail is
+	// served. Compiled formulas change rarely (an authored TOML edit), so this is
+	// long. A var so tests can shorten it.
+	formulaCacheTTL = 60 * time.Second
+	// formulaNotFoundTTL bounds how long a 404 (genuinely-missing formula) outcome
+	// is served before a re-check. It is short so a newly-added formula appears
+	// promptly instead of being pinned missing for the full success TTL. A var so
+	// tests can shorten it.
+	formulaNotFoundTTL = 5 * time.Second
+)
+
+// ── Generic single-flight TTL cache ───────────────────────────────────────
+
+// cacheEntry is one keyed slot in a singleFlightCache: the last-computed value,
+// when it was computed (for TTL expiry), and — while a fetch is in flight — the
+// channel a joining caller waits on. The value type V is copied by value on
+// read, so V must be safe to share (a value type or an immutable-after-build
+// pointer/slice, which both cached payloads are).
+type cacheEntry[V any] struct {
+	value    V
+	computed time.Time
+	// ttl is the entry's own expiry window, captured at compute time. The formula
+	// cache uses a shorter window for a not-found outcome than for a success, so
+	// the window travels with the entry rather than being a single cache-wide
+	// constant.
+	ttl time.Duration
+	// hasValue is false until the first successful (or, for the not-found case,
+	// definitively-negative) compute, so a cold miss whose fetch fails does not
+	// publish a zero value as if it were last-good.
+	hasValue bool
+	// inflight is non-nil while exactly one caller computes this key; joiners wait
+	// on it and then re-read the entry. It is set under the cache lock, closed by
+	// the computing caller after publishing, and cleared under the lock.
+	inflight chan struct{}
+}
+
+// singleFlightCache is a small per-key TTL cache with single-flight: concurrent
+// cold-miss callers for the same key collapse to one compute; a hit within TTL
+// serves the stored value with no upstream work; an expired entry triggers one
+// refetch while other callers join it. The cache lock is NEVER held across the
+// compute function — the samplers.go contract — so a slow upstream fetch never
+// blocks a reader of a different key or a joiner re-reading a fresh value.
+type singleFlightCache[K comparable, V any] struct {
+	mu      sync.Mutex
+	entries map[K]*cacheEntry[V]
+}
+
+func newSingleFlightCache[K comparable, V any]() *singleFlightCache[K, V] {
+	return &singleFlightCache[K, V]{entries: make(map[K]*cacheEntry[V])}
+}
+
+// get returns the value for key, computing it via compute on a miss or expiry.
+// compute returns the fetched value, the TTL that value should live for (so the
+// formula cache can pick a shorter window for a not-found outcome), and ok
+// reporting whether the fetch succeeded well enough to cache as last-good. On a
+// compute failure with an existing last-good value the stale value is served
+// (available); on a cold miss with no last-good the zero value is returned so the
+// caller can apply its own honest degrade. Exactly one caller runs compute per
+// key per miss; the rest block until it publishes, then re-read.
+//
+// The returned bool reports whether a usable value is being served: true for a
+// fresh success, a within-TTL hit, or a served-stale last-good; false only for a
+// cold miss whose fetch failed and left no last-good.
+func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(context.Context) (V, time.Duration, bool)) (V, bool) {
+	for {
+		c.mu.Lock()
+		e, ok := c.entries[key]
+		if !ok {
+			e = &cacheEntry[V]{}
+			c.entries[key] = e
+		}
+		// Fresh hit: serve without touching the upstream.
+		if e.hasValue && e.inflight == nil && time.Since(e.computed) < e.ttl {
+			v := e.value
+			c.mu.Unlock()
+			return v, true
+		}
+		// Someone is already computing this key: join and re-read once they publish.
+		if e.inflight != nil {
+			wait := e.inflight
+			c.mu.Unlock()
+			select {
+			case <-wait:
+				// Loop: re-read the now-published entry (or re-elect a computer if the
+				// prior compute failed and left the entry stale/empty and expired).
+				continue
+			case <-ctx.Done():
+				// The caller gave up. Serve the last-good if we have one (never block a
+				// canceled caller on an in-flight fetch); otherwise degrade.
+				return c.lastGoodOrZero(key)
+			}
+		}
+		// We are the elected computer for this key.
+		done := make(chan struct{})
+		e.inflight = done
+		c.mu.Unlock()
+
+		// The in-flight handshake MUST be released on every exit — including a
+		// panic in compute. The dashboardbff plane runs under the supervisor's
+		// withRecovery middleware, so a compute panic is caught and turned into a
+		// 500 while the process keeps serving; without a deferred release the
+		// entry's inflight channel would be orphaned (never closed) and every
+		// future caller for this key would block on it forever (or degrade to a
+		// frozen last-good that never refetches). The deferred cleanup runs
+		// before the panic propagates, so the next caller re-elects and recovers
+		// while withRecovery still logs and 500s the panicking request.
+		var (
+			value     V
+			ttl       time.Duration
+			computeOK bool
+			served    V
+			hadValue  bool
+		)
+		func() {
+			defer func() {
+				c.mu.Lock()
+				if computeOK {
+					e.value = value
+					e.computed = time.Now()
+					e.ttl = ttl
+					e.hasValue = true
+				}
+				// else: keep the prior last-good (if any) untouched — degrade,
+				// don't blank.
+				served, hadValue = e.value, e.hasValue
+				e.inflight = nil
+				c.mu.Unlock()
+				close(done)
+			}()
+			// Compute with NO cache lock held (the samplers.go contract). A panic
+			// here still runs the deferred release above, then propagates.
+			value, ttl, computeOK = compute(ctx)
+		}()
+
+		if computeOK {
+			return value, true
+		}
+		if hadValue {
+			// A failed refetch with a prior success: serve the stale last-good.
+			return served, true
+		}
+		// Cold miss, fetch failed, no last-good: honest degrade to the zero value.
+		var zero V
+		return zero, false
+	}
+}
+
+// lastGoodOrZero returns the entry's last-good value (available) if one exists,
+// else the zero value (unavailable). Used when a caller's ctx is canceled while
+// joining an in-flight fetch: a canceled caller must never block, but should
+// still serve the last-good if the cache holds one.
+func (c *singleFlightCache[K, V]) lastGoodOrZero(key K) (V, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.entries[key]; ok && e.hasValue {
+		return e.value, true
+	}
+	var zero V
+	return zero, false
+}
+
+// ── Cached payload shapes ─────────────────────────────────────────────────
+
+// cachedSessions is the value stored in the sessions cache: the projected
+// dashboard session slice. Immutable after build (fetchSessionsUpstream returns a
+// fresh slice), so it is safe to share across callers by value.
+type cachedSessions struct {
+	items []runproj.DashboardSession
+}
+
+// cachedFormulaDetail is the value stored in the formula cache. It preserves the
+// full fetch outcome — the compiled detail on success, or the NotFound vs
+// UpstreamError distinction on a definitive failure — so runproj renders the
+// right operator diagnostic. A cached not-found is a real (negative) cache entry,
+// distinct from a transient upstream error which is not cached (the cold-miss
+// degrade path handles it).
+type cachedFormulaDetail struct {
+	detail  *runproj.FormulaOrderingDetail
+	failure runproj.RunFormulaDetailFetchFailure
+}
+
+// formulaCacheKey is the full identity a compiled formula resolves against: the
+// city, the formula name, the run target, and the scope (kind+ref) that selects
+// the formula search layer. Two runs that differ in any of these resolve to
+// different compiled formulas, so all four are part of the key.
+type formulaCacheKey struct {
+	name      string
+	formula   string
+	target    string
+	scopeKind string
+	scopeRef  string
+}

--- a/internal/api/dashboardbff/enrichment_cache_test.go
+++ b/internal/api/dashboardbff/enrichment_cache_test.go
@@ -1,0 +1,399 @@
+package dashboardbff
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/runproj"
+)
+
+// enrichmentCacheTestServer stands up a fake supervisor that counts sessions and
+// formula hits and can gate a request open on a barrier so a test can force
+// concurrent callers to overlap inside one in-flight fetch. sessionsBody /
+// formulaStatus are read once per request; formulaStatus 0 means "200 with the
+// canonical body".
+type enrichmentCacheTestServer struct {
+	sessionsHits atomic.Int64
+	formulaHits  atomic.Int64
+
+	// gate, when non-nil, blocks every handler until it is closed, so a test can
+	// hold N callers inside one in-flight fetch and prove single-flight.
+	gate chan struct{}
+
+	formulaStatus atomic.Int64 // 0 -> 200 canonical body; else the status to return
+}
+
+func (s *enrichmentCacheTestServer) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.gate != nil {
+			<-s.gate
+		}
+		switch r.URL.Path {
+		case "/v0/city/alpha/sessions":
+			s.sessionsHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"items":[{"id":"s1","template":"t","session_name":"alpha__worker-1","title":"W","alias":"worker-1","state":"active","created_at":"2026-06-01T10:00:00Z","last_active":"2026-06-01T11:00:00Z","attached":false,"running":true,"activity":"thinking","provider":"claude"}],"total":1}`))
+		case "/v0/city/alpha/formulas/mol-adopt-pr-v2":
+			s.formulaHits.Add(1)
+			if code := s.formulaStatus.Load(); code != 0 {
+				w.WriteHeader(int(code))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"mol-adopt-pr-v2","steps":[{"id":"preflight"},{"id":"apply-fixes"}],"preview":{"nodes":[{"id":"preflight"},{"id":"apply-fixes"}]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+func newEnrichmentManager(t *testing.T, baseURL string) *runTailerManager {
+	t.Helper()
+	m := newRunTailerManager(Deps{SupervisorBaseURL: baseURL})
+	return m
+}
+
+// TestSingleFlightCacheRecoversAfterComputePanic proves a panic inside compute
+// does not permanently wedge the key. The dashboardbff plane runs under
+// withRecovery, so a compute panic is caught and the process keeps serving; the
+// deferred release in get() must still clear inflight and close the in-flight
+// channel so a later caller re-elects and succeeds instead of blocking forever
+// on an orphaned channel.
+func TestSingleFlightCacheRecoversAfterComputePanic(t *testing.T) {
+	c := newSingleFlightCache[string, cachedSessions]()
+
+	// First caller: compute panics. Recover it here, mimicking withRecovery. The
+	// panic must PROPAGATE out of get (not be swallowed), while the deferred
+	// release still clears the key.
+	func() {
+		defer func() { _ = recover() }()
+		c.get(context.Background(), "alpha", func(context.Context) (cachedSessions, time.Duration, bool) {
+			panic("boom")
+		})
+		t.Fatal("expected the panicking compute to propagate out of get")
+	}()
+
+	// A subsequent caller for the SAME key must make progress, not deadlock on an
+	// orphaned inflight channel.
+	done := make(chan struct{})
+	var ok bool
+	go func() {
+		defer close(done)
+		_, ok = c.get(context.Background(), "alpha", func(context.Context) (cachedSessions, time.Duration, bool) {
+			return cachedSessions{items: []runproj.DashboardSession{}}, sessionsCacheTTL, true
+		})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-panic get deadlocked on an orphaned inflight channel")
+	}
+	if !ok {
+		t.Fatal("post-panic get: want available=true after a clean re-election, got false")
+	}
+}
+
+// TestSessionsCacheServesWithinTTL proves two reads inside the TTL hit the
+// supervisor exactly once (the second is served from cache).
+func TestSessionsCacheServesWithinTTL(t *testing.T) {
+	srv := &enrichmentCacheTestServer{}
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	s1, ok1 := m.fetchSessions(ctx, "alpha")
+	s2, ok2 := m.fetchSessions(ctx, "alpha")
+	if !ok1 || !ok2 {
+		t.Fatalf("both reads must be available: %v %v", ok1, ok2)
+	}
+	if len(s1) != 1 || len(s2) != 1 {
+		t.Fatalf("both reads must carry the one session: %d %d", len(s1), len(s2))
+	}
+	if got := srv.sessionsHits.Load(); got != 1 {
+		t.Fatalf("sessions upstream hits = %d, want 1 (second read is cached)", got)
+	}
+}
+
+// TestSessionsCacheRefetchesAfterTTL proves a read past the TTL triggers a fresh
+// upstream fetch.
+func TestSessionsCacheRefetchesAfterTTL(t *testing.T) {
+	defer func(prev time.Duration) { sessionsCacheTTL = prev }(sessionsCacheTTL)
+	sessionsCacheTTL = 20 * time.Millisecond
+
+	srv := &enrichmentCacheTestServer{}
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	if _, ok := m.fetchSessions(ctx, "alpha"); !ok {
+		t.Fatal("first read must be available")
+	}
+	time.Sleep(40 * time.Millisecond)
+	if _, ok := m.fetchSessions(ctx, "alpha"); !ok {
+		t.Fatal("second read must be available")
+	}
+	if got := srv.sessionsHits.Load(); got != 2 {
+		t.Fatalf("sessions upstream hits = %d, want 2 (TTL expired between reads)", got)
+	}
+}
+
+// TestSessionsCacheSingleFlight proves N concurrent cold-miss callers collapse
+// to exactly one upstream fetch. The fake handler blocks on a gate so every
+// caller is provably in-flight at once.
+func TestSessionsCacheSingleFlight(t *testing.T) {
+	srv := &enrichmentCacheTestServer{gate: make(chan struct{})}
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	const n = 8
+	var wg sync.WaitGroup
+	var available atomic.Int64
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if _, ok := m.fetchSessions(ctx, "alpha"); ok {
+				available.Add(1)
+			}
+		}()
+	}
+	// Give every goroutine time to reach the in-flight join before releasing.
+	time.Sleep(50 * time.Millisecond)
+	close(srv.gate)
+	wg.Wait()
+
+	if got := srv.sessionsHits.Load(); got != 1 {
+		t.Fatalf("sessions upstream hits = %d, want 1 (single-flight)", got)
+	}
+	if got := available.Load(); got != n {
+		t.Fatalf("available callers = %d, want %d (all joiners see the shared result)", got, n)
+	}
+}
+
+// TestSessionsCacheServesLastGoodOnError proves a fetch failure after a prior
+// success serves the last-good value with available=true (degrade, don't blank).
+func TestSessionsCacheServesLastGoodOnError(t *testing.T) {
+	defer func(prev time.Duration) { sessionsCacheTTL = prev }(sessionsCacheTTL)
+	sessionsCacheTTL = 20 * time.Millisecond
+
+	var down atomic.Bool
+	var hits atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		if down.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"id":"s1","alias":"worker-1","state":"active"}],"total":1}`))
+	}))
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	if s, ok := m.fetchSessions(ctx, "alpha"); !ok || len(s) != 1 {
+		t.Fatalf("first read must succeed with one session: ok=%v n=%d", ok, len(s))
+	}
+	down.Store(true)
+	time.Sleep(40 * time.Millisecond) // let the TTL lapse so the next read refetches
+
+	s, ok := m.fetchSessions(ctx, "alpha")
+	if !ok {
+		t.Fatal("read after a failure must serve last-good (available=true)")
+	}
+	if len(s) != 1 {
+		t.Fatalf("last-good sessions = %d, want 1", len(s))
+	}
+	if hits.Load() < 2 {
+		t.Fatalf("upstream hits = %d, want >=2 (the failing refetch was attempted)", hits.Load())
+	}
+}
+
+// TestSessionsCacheColdFailureDegrades proves a cold-miss failure with no
+// last-good degrades EXACTLY as the uncached path: (nil, false).
+func TestSessionsCacheColdFailureDegrades(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	s, ok := m.fetchSessions(context.Background(), "alpha")
+	if ok || s != nil {
+		t.Fatalf("cold failure must degrade to (nil,false); got n=%d ok=%v", len(s), ok)
+	}
+}
+
+// TestFormulaCacheServesWithinTTL proves two formula reads inside the TTL hit the
+// supervisor once and both resolve to the same available detail.
+func TestFormulaCacheServesWithinTTL(t *testing.T) {
+	srv := &enrichmentCacheTestServer{}
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	d1, f1, ok1 := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	d2, f2, ok2 := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	if !ok1 || !ok2 {
+		t.Fatalf("both formula reads must succeed: %v %v (failures %q %q)", ok1, ok2, f1, f2)
+	}
+	if d1 == nil || d2 == nil || d1.Name != "mol-adopt-pr-v2" {
+		t.Fatalf("both reads must carry the compiled detail: %+v %+v", d1, d2)
+	}
+	if got := srv.formulaHits.Load(); got != 1 {
+		t.Fatalf("formula upstream hits = %d, want 1 (second read cached)", got)
+	}
+}
+
+// TestFormulaCacheSingleFlight proves concurrent cold-miss formula callers
+// collapse to one upstream fetch.
+func TestFormulaCacheSingleFlight(t *testing.T) {
+	srv := &enrichmentCacheTestServer{gate: make(chan struct{})}
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	const n = 8
+	var wg sync.WaitGroup
+	var okCount atomic.Int64
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if _, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); ok {
+				okCount.Add(1)
+			}
+		}()
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(srv.gate)
+	wg.Wait()
+
+	if got := srv.formulaHits.Load(); got != 1 {
+		t.Fatalf("formula upstream hits = %d, want 1 (single-flight)", got)
+	}
+	if got := okCount.Load(); got != n {
+		t.Fatalf("ok callers = %d, want %d", got, n)
+	}
+}
+
+// TestFormulaCacheNotFoundReCheckedOnShortTTL proves a 404 is cached as
+// FormulaDetailNotFound and re-checked on the SHORT not-found TTL — not the long
+// success TTL — so a newly-added formula appears promptly.
+func TestFormulaCacheNotFoundReCheckedOnShortTTL(t *testing.T) {
+	defer func(prevOK, prevMiss time.Duration) {
+		formulaCacheTTL = prevOK
+		formulaNotFoundTTL = prevMiss
+	}(formulaCacheTTL, formulaNotFoundTTL)
+	// A long success TTL and a short not-found TTL: if the 404 were cached on the
+	// success TTL it would never re-check inside the test window.
+	formulaCacheTTL = 10 * time.Second
+	formulaNotFoundTTL = 20 * time.Millisecond
+
+	srv := &enrichmentCacheTestServer{}
+	srv.formulaStatus.Store(http.StatusNotFound)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	// First read: 404 -> not_found, cached.
+	_, failure, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	if ok {
+		t.Fatal("a 404 formula fetch must not report ok")
+	}
+	if failure != runproj.FormulaDetailNotFound {
+		t.Fatalf("failure = %q, want not_found", failure)
+	}
+	// Second read inside the short TTL: served from the cached not-found entry, no
+	// new upstream hit.
+	if _, f2, ok2 := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); ok2 || f2 != runproj.FormulaDetailNotFound {
+		t.Fatalf("cached not-found read: ok=%v failure=%q, want not_found", ok2, f2)
+	}
+	if got := srv.formulaHits.Load(); got != 1 {
+		t.Fatalf("formula hits = %d, want 1 (second read within short TTL is cached)", got)
+	}
+
+	// After the SHORT not-found TTL lapses, the formula becomes available upstream.
+	time.Sleep(40 * time.Millisecond)
+	srv.formulaStatus.Store(0) // 200 canonical body
+	d, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	if !ok || d == nil {
+		t.Fatalf("after the short not-found TTL the newly-added formula must resolve: ok=%v d=%+v", ok, d)
+	}
+	if got := srv.formulaHits.Load(); got != 2 {
+		t.Fatalf("formula hits = %d, want 2 (the not-found entry expired and refetched)", got)
+	}
+}
+
+// TestFormulaCacheColdFailureDegrades proves a cold-miss upstream error (non-404)
+// with no last-good degrades to (nil, upstream_error, false) — the uncached
+// contract.
+func TestFormulaCacheColdFailureDegrades(t *testing.T) {
+	srv := &enrichmentCacheTestServer{}
+	srv.formulaStatus.Store(http.StatusInternalServerError)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	d, failure, ok := m.fetchFormulaDetail(context.Background(), "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	if ok || d != nil {
+		t.Fatalf("cold upstream error must degrade to (nil,...,false); got d=%+v ok=%v", d, ok)
+	}
+	if failure != runproj.FormulaDetailUpstreamError {
+		t.Fatalf("failure = %q, want upstream_error", failure)
+	}
+}
+
+// TestFormulaCacheKeyedByScope proves the cache is keyed by the full
+// (name,target,scopeKind,scopeRef) tuple: two distinct scopes each get their own
+// upstream fetch rather than colliding on the formula name.
+func TestFormulaCacheKeyedByScope(t *testing.T) {
+	var hits atomic.Int64
+	seen := map[string]bool{}
+	var mu sync.Mutex
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		mu.Lock()
+		seen[r.URL.RawQuery] = true
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"mol-adopt-pr-v2","steps":[],"preview":{"nodes":[]}}`))
+	}))
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	if _, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); !ok {
+		t.Fatal("first scope must resolve")
+	}
+	if _, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:other", "rig", "other"); !ok {
+		t.Fatal("second scope must resolve")
+	}
+	// Same key as the first read -> cached, no new hit.
+	if _, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); !ok {
+		t.Fatal("repeat of the first scope must resolve")
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("formula hits = %d, want 2 (two distinct scope keys, third read cached)", got)
+	}
+}

--- a/internal/api/dashboardbff/enrichment_cache_test.go
+++ b/internal/api/dashboardbff/enrichment_cache_test.go
@@ -72,7 +72,7 @@ func TestSingleFlightCacheRecoversAfterComputePanic(t *testing.T) {
 	// release still clears the key.
 	func() {
 		defer func() { _ = recover() }()
-		c.get(context.Background(), "alpha", func(context.Context) (cachedSessions, time.Duration, bool) {
+		c.get(context.Background(), "alpha", func(context.Context) (cachedSessions, time.Duration, bool, bool) {
 			panic("boom")
 		})
 		t.Fatal("expected the panicking compute to propagate out of get")
@@ -84,8 +84,8 @@ func TestSingleFlightCacheRecoversAfterComputePanic(t *testing.T) {
 	var ok bool
 	go func() {
 		defer close(done)
-		_, ok = c.get(context.Background(), "alpha", func(context.Context) (cachedSessions, time.Duration, bool) {
-			return cachedSessions{items: []runproj.DashboardSession{}}, sessionsCacheTTL, true
+		_, ok = c.get(context.Background(), "alpha", func(context.Context) (cachedSessions, time.Duration, bool, bool) {
+			return cachedSessions{items: []runproj.DashboardSession{}}, sessionsCacheTTL, true, true
 		})
 	}()
 	select {
@@ -360,6 +360,46 @@ func TestFormulaCacheColdFailureDegrades(t *testing.T) {
 	}
 	if failure != runproj.FormulaDetailUpstreamError {
 		t.Fatalf("failure = %q, want upstream_error", failure)
+	}
+}
+
+// TestFormulaCacheExpiredNotFoundDoesNotMaskUpstreamError proves a cached 404 is
+// NOT served stale once its short TTL lapses: after the not-found window a fresh
+// upstream 500 must surface as FormulaDetailUpstreamError, not the stale
+// not_found. A negative last-good would otherwise pin a genuinely-missing verdict
+// over a live upstream failure, hiding the real operator diagnostic.
+func TestFormulaCacheExpiredNotFoundDoesNotMaskUpstreamError(t *testing.T) {
+	defer func(prev time.Duration) { formulaNotFoundTTL = prev }(formulaNotFoundTTL)
+	formulaNotFoundTTL = 20 * time.Millisecond
+
+	srv := &enrichmentCacheTestServer{}
+	srv.formulaStatus.Store(http.StatusNotFound)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	// First read: 404 -> cached not_found.
+	if _, failure, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); ok || failure != runproj.FormulaDetailNotFound {
+		t.Fatalf("first read: ok=%v failure=%q, want not_found", ok, failure)
+	}
+
+	// Let the short not-found TTL lapse, then the upstream starts erroring (500).
+	time.Sleep(40 * time.Millisecond)
+	srv.formulaStatus.Store(http.StatusInternalServerError)
+
+	// The expired not_found MUST NOT be served stale to mask the live 500: the
+	// honest reason is upstream_error.
+	d, failure, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	if ok || d != nil {
+		t.Fatalf("expired not_found + upstream 500 must degrade to (nil,...,false); got d=%+v ok=%v", d, ok)
+	}
+	if failure != runproj.FormulaDetailUpstreamError {
+		t.Fatalf("failure = %q, want upstream_error (stale not_found must not mask the 500)", failure)
+	}
+	if got := srv.formulaHits.Load(); got != 2 {
+		t.Fatalf("formula hits = %d, want 2 (the expired not_found refetched and hit the 500)", got)
 	}
 }
 

--- a/internal/api/dashboardbff/enrichment_cache_test.go
+++ b/internal/api/dashboardbff/enrichment_cache_test.go
@@ -98,6 +98,153 @@ func TestSingleFlightCacheRecoversAfterComputePanic(t *testing.T) {
 	}
 }
 
+// TestSingleFlightCacheElectorCancelDoesNotCancelSharedCompute proves the elected
+// single-flight compute is decoupled from the electing caller's request context:
+// if the elector's ctx is canceled while a joiner is still waiting on the shared
+// flight, the shared compute must NOT be canceled, and the still-live joiner must
+// receive the compute's real (successful) result instead of a canceled/degraded
+// one. Before the fix the elector ran compute on its own request ctx, so an
+// elector whose client disconnected mid-fetch canceled the shared upstream request
+// and handed every joined caller a failed result rather than their own enrichment.
+func TestSingleFlightCacheElectorCancelDoesNotCancelSharedCompute(t *testing.T) {
+	c := newSingleFlightCache[string, int]()
+
+	var (
+		startOnce     sync.Once
+		started       = make(chan struct{}) // closed when the elected compute begins
+		release       = make(chan struct{}) // closed by the test to let compute finish
+		computeCalls  atomic.Int64          // must stay 1: the joiner joins, never re-elects
+		computeCtxErr error                 // compute's own ctx error, sampled after release
+	)
+	compute := func(cctx context.Context) (int, time.Duration, bool, bool) {
+		computeCalls.Add(1)
+		startOnce.Do(func() { close(started) })
+		<-release
+		// Sample the compute context AFTER the elector's ctx was canceled. With the
+		// fix this stays nil (detached); the pre-fix code would see context.Canceled
+		// here, and a real upstream fetch on that ctx would abort.
+		computeCtxErr = cctx.Err()
+		if cctx.Err() != nil {
+			// Mirror a real upstream fetch aborting on a canceled ctx: report failure.
+			return 0, 0, false, false
+		}
+		return 42, time.Minute, true, true
+	}
+
+	electorCtx, cancelElector := context.WithCancel(context.Background())
+	joinerCtx := context.Background() // the joiner stays live throughout
+
+	var (
+		electorVal, joinerVal int
+		electorOK, joinerOK   bool
+	)
+	electorDone := make(chan struct{})
+	go func() {
+		defer close(electorDone)
+		electorVal, electorOK = c.get(electorCtx, "k", compute)
+	}()
+
+	<-started // the elector was elected and is inside compute
+
+	joinerDone := make(chan struct{})
+	go func() {
+		defer close(joinerDone)
+		joinerVal, joinerOK = c.get(joinerCtx, "k", compute)
+	}()
+
+	// Let the joiner reach the in-flight join before we cancel the elector.
+	time.Sleep(50 * time.Millisecond)
+
+	// The electing caller's client disconnects: cancel its request ctx while the
+	// joiner is still waiting on the shared flight.
+	cancelElector()
+	time.Sleep(20 * time.Millisecond) // give cancellation a chance to (wrongly) propagate
+
+	close(release) // let the shared compute finish
+
+	select {
+	case <-joinerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("joiner never returned; the shared flight wedged")
+	}
+	<-electorDone
+
+	if got := computeCalls.Load(); got != 1 {
+		t.Fatalf("compute ran %d times, want 1 (the joiner must join the flight, not re-elect)", got)
+	}
+	if computeCtxErr != nil {
+		t.Fatalf("shared compute ctx was canceled (%v); the elected compute must be decoupled from the electing caller's request", computeCtxErr)
+	}
+	if !joinerOK || joinerVal != 42 {
+		t.Fatalf("joiner result = (%d,%v), want (42,true): a still-live joiner must get the shared compute's real result, not the canceled elector's degrade", joinerVal, joinerOK)
+	}
+	if !electorOK || electorVal != 42 {
+		t.Fatalf("elector result = (%d,%v), want (42,true): the elected compute completes under its detached ctx", electorVal, electorOK)
+	}
+}
+
+// TestSingleFlightCachePreCanceledColdCallerDoesNotElect proves a caller whose
+// request context is already canceled before a cold-miss get does NOT elect the
+// single-flight compute: it degrades to unavailable instead. Before the fix an
+// already-canceled request could still become the elector, and because the
+// elected compute runs under context.WithoutCancel(ctx) the detached fetch would
+// then run a full upstream loopback (bounded only by the fetch/backstop timeout)
+// on behalf of a caller that was already gone.
+func TestSingleFlightCachePreCanceledColdCallerDoesNotElect(t *testing.T) {
+	c := newSingleFlightCache[string, int]()
+
+	var computeCalls atomic.Int64
+	compute := func(context.Context) (int, time.Duration, bool, bool) {
+		computeCalls.Add(1)
+		return 42, time.Minute, true, true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled before get is even called
+
+	v, ok := c.get(ctx, "k", compute)
+	if got := computeCalls.Load(); got != 0 {
+		t.Fatalf("compute ran %d times, want 0 (a pre-canceled caller must not elect a detached flight)", got)
+	}
+	if ok || v != 0 {
+		t.Fatalf("pre-canceled cold get = (%d,%v), want (0,false): degrade to unavailable, not a detached compute", v, ok)
+	}
+}
+
+// TestSingleFlightCachePreCanceledCallerServesLastGoodOnExpiredKey proves a caller
+// whose context is already canceled at an EXPIRED key (past its TTL, so the
+// fresh-hit path no longer applies) still does not elect a refetch: it degrades to
+// the serveable last-good instead of driving a detached upstream compute for a
+// caller that is already gone. Before the fix the pre-canceled caller re-elected
+// and refetched, so compute ran a second time.
+func TestSingleFlightCachePreCanceledCallerServesLastGoodOnExpiredKey(t *testing.T) {
+	c := newSingleFlightCache[string, int]()
+
+	var computeCalls atomic.Int64
+	compute := func(context.Context) (int, time.Duration, bool, bool) {
+		computeCalls.Add(1)
+		return 7, 20 * time.Millisecond, true, true // staleServeable positive last-good, short TTL
+	}
+
+	// Seed a staleServeable positive last-good on a live ctx, then let it expire so
+	// the next get can no longer take the fresh-hit path.
+	if v, ok := c.get(context.Background(), "k", compute); !ok || v != 7 {
+		t.Fatalf("seed get = (%d,%v), want (7,true)", v, ok)
+	}
+	time.Sleep(40 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	v, ok := c.get(ctx, "k", compute)
+	if got := computeCalls.Load(); got != 1 {
+		t.Fatalf("compute ran %d times, want 1 (a pre-canceled caller must not elect a refetch on the expired key)", got)
+	}
+	if !ok || v != 7 {
+		t.Fatalf("pre-canceled expired get = (%d,%v), want (7,true): serve the staleServeable last-good instead of a detached refetch", v, ok)
+	}
+}
+
 // TestSessionsCacheServesWithinTTL proves two reads inside the TTL hit the
 // supervisor exactly once (the second is served from cache).
 func TestSessionsCacheServesWithinTTL(t *testing.T) {
@@ -237,6 +384,49 @@ func TestSessionsCacheColdFailureDegrades(t *testing.T) {
 	}
 }
 
+// TestSessionsCacheColdFailureSingleFlight proves a burst of concurrent cold-miss
+// callers whose shared fetch FAILS collapses onto ONE upstream hit — every waiter
+// returns that one failed flight's (nil,false) degrade instead of waking and
+// re-electing itself to refetch serially. Regression for the single-flight
+// burst-collapse contract on the negative path (the pre-fix code re-elected each
+// waiter, producing one supervisor request per dashboard request).
+func TestSessionsCacheColdFailureSingleFlight(t *testing.T) {
+	var hits atomic.Int64
+	gate := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-gate // hold every caller in-flight until released, proving overlap
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	const n = 8
+	var wg sync.WaitGroup
+	var degraded atomic.Int64
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if s, ok := m.fetchSessions(ctx, "alpha"); !ok && s == nil {
+				degraded.Add(1)
+			}
+		}()
+	}
+	time.Sleep(50 * time.Millisecond) // let every caller reach the in-flight join
+	close(gate)
+	wg.Wait()
+
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("sessions upstream hits = %d, want 1 (a failed cold flight is shared, not re-elected per waiter)", got)
+	}
+	if got := degraded.Load(); got != n {
+		t.Fatalf("degraded callers = %d, want %d (every waiter shares the one failed flight's (nil,false))", got, n)
+	}
+}
+
 // TestFormulaCacheServesWithinTTL proves two formula reads inside the TTL hit the
 // supervisor once and both resolve to the same available detail.
 func TestFormulaCacheServesWithinTTL(t *testing.T) {
@@ -363,6 +553,47 @@ func TestFormulaCacheColdFailureDegrades(t *testing.T) {
 	}
 }
 
+// TestFormulaCacheColdFailureSingleFlight proves the same negative-path
+// burst-collapse for the formula cache: concurrent cold-miss callers whose shared
+// fetch returns a non-404 upstream error all resolve to (nil, upstream_error,
+// false) from ONE upstream hit, not one re-elected refetch per waiter.
+func TestFormulaCacheColdFailureSingleFlight(t *testing.T) {
+	var hits atomic.Int64
+	gate := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-gate
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	const n = 8
+	var wg sync.WaitGroup
+	var upstreamErr atomic.Int64
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if d, f, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); !ok && d == nil && f == runproj.FormulaDetailUpstreamError {
+				upstreamErr.Add(1)
+			}
+		}()
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("formula upstream hits = %d, want 1 (a failed cold flight is shared, not re-elected per waiter)", got)
+	}
+	if got := upstreamErr.Load(); got != n {
+		t.Fatalf("upstream_error degrades = %d, want %d (every waiter shares the one failed flight)", got, n)
+	}
+}
+
 // TestFormulaCacheExpiredNotFoundDoesNotMaskUpstreamError proves a cached 404 is
 // NOT served stale once its short TTL lapses: after the not-found window a fresh
 // upstream 500 must surface as FormulaDetailUpstreamError, not the stale
@@ -400,6 +631,67 @@ func TestFormulaCacheExpiredNotFoundDoesNotMaskUpstreamError(t *testing.T) {
 	}
 	if got := srv.formulaHits.Load(); got != 2 {
 		t.Fatalf("formula hits = %d, want 2 (the expired not_found refetched and hit the 500)", got)
+	}
+}
+
+// TestFormulaCacheExpiredNotFoundConcurrent500SingleFlight proves the hardest
+// negative-path case: after a cached not_found expires, a concurrent burst that
+// now hits a 500 collapses onto ONE refetch, and every waiter sees the honest
+// upstream_error degrade. It combines two contracts under concurrency — the
+// expired not_found must not be served stale to mask the 500, and it must not be
+// re-probed once per waiter.
+func TestFormulaCacheExpiredNotFoundConcurrent500SingleFlight(t *testing.T) {
+	defer func(prev time.Duration) { formulaNotFoundTTL = prev }(formulaNotFoundTTL)
+	formulaNotFoundTTL = 20 * time.Millisecond
+
+	var hits atomic.Int64
+	var status atomic.Int64
+	status.Store(http.StatusNotFound)
+	var gateActive atomic.Bool
+	gate := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if gateActive.Load() {
+			<-gate // hold only the concurrent burst in-flight together
+		}
+		hits.Add(1)
+		w.WriteHeader(int(status.Load()))
+	}))
+	defer ts.Close()
+
+	m := newEnrichmentManager(t, ts.URL)
+	ctx := context.Background()
+
+	// Seed a cached not_found (ungated), then let its short TTL lapse.
+	if _, f, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); ok || f != runproj.FormulaDetailNotFound {
+		t.Fatalf("seed read: ok=%v failure=%q, want not_found", ok, f)
+	}
+	time.Sleep(40 * time.Millisecond) // expire the not-found entry
+	status.Store(http.StatusInternalServerError)
+	gateActive.Store(true)
+
+	const n = 8
+	var wg sync.WaitGroup
+	var upstreamErr atomic.Int64
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if d, f, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); !ok && d == nil && f == runproj.FormulaDetailUpstreamError {
+				upstreamErr.Add(1)
+			}
+		}()
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	// One seed hit + exactly one shared burst hit: the expired not_found refetch
+	// collapses to a single 500 flight, not one probe per waiter.
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("formula upstream hits = %d, want 2 (1 seed + 1 shared burst flight)", got)
+	}
+	if got := upstreamErr.Load(); got != n {
+		t.Fatalf("upstream_error degrades = %d, want %d (expired not_found must not mask the shared 500)", got, n)
 	}
 }
 

--- a/internal/api/dashboardbff/runtailer.go
+++ b/internal/api/dashboardbff/runtailer.go
@@ -414,12 +414,14 @@ func (t *cityRunTailer) enrichedSummary(ctx context.Context) runproj.RunSummary 
 // the caller's honest partial/warming states are preserved. detail() and
 // enrichedSummary() consume this.
 func (m *runTailerManager) fetchSessions(ctx context.Context, name string) ([]runproj.DashboardSession, bool) {
-	got, ok := m.sessionsCache.get(ctx, name, func(ctx context.Context) (cachedSessions, time.Duration, bool) {
+	got, ok := m.sessionsCache.get(ctx, name, func(ctx context.Context) (cachedSessions, time.Duration, bool, bool) {
 		items, upstreamOK := m.fetchSessionsUpstream(ctx, name)
 		if !upstreamOK {
-			return cachedSessions{}, 0, false
+			return cachedSessions{}, 0, false, false
 		}
-		return cachedSessions{items: items}, sessionsCacheTTL, true
+		// A successful sessions read is a positive last-good: serve it stale on a
+		// later failed refetch rather than blanking the health card.
+		return cachedSessions{items: items}, sessionsCacheTTL, true, true
 	})
 	if !ok {
 		return nil, false
@@ -482,18 +484,23 @@ type formulaNodeRef struct {
 // runproj renders as the operator diagnostic. detail() consumes this.
 func (m *runTailerManager) fetchFormulaDetail(ctx context.Context, name, formula, target, scopeKind, scopeRef string) (*runproj.FormulaOrderingDetail, runproj.RunFormulaDetailFetchFailure, bool) {
 	key := formulaCacheKey{name: name, formula: formula, target: target, scopeKind: scopeKind, scopeRef: scopeRef}
-	got, ok := m.formulaCache.get(ctx, key, func(ctx context.Context) (cachedFormulaDetail, time.Duration, bool) {
+	got, ok := m.formulaCache.get(ctx, key, func(ctx context.Context) (cachedFormulaDetail, time.Duration, bool, bool) {
 		detail, failure, upstreamOK := m.fetchFormulaDetailUpstream(ctx, name, formula, target, scopeKind, scopeRef)
 		switch {
 		case upstreamOK:
-			return cachedFormulaDetail{detail: detail}, formulaCacheTTL, true
+			// A compiled formula is a positive last-good: serve it stale on a later
+			// failed refetch.
+			return cachedFormulaDetail{detail: detail}, formulaCacheTTL, true, true
 		case failure == runproj.FormulaDetailNotFound:
 			// A definitive 404 is a real negative result: cache it briefly so a burst
 			// of GETs does not re-probe a known-missing formula, but re-check soon.
-			return cachedFormulaDetail{failure: runproj.FormulaDetailNotFound}, formulaNotFoundTTL, true
+			// It is NOT stale-serveable, so once formulaNotFoundTTL lapses an errored
+			// refetch degrades to upstream_error instead of pinning this stale
+			// not-found over a live upstream failure.
+			return cachedFormulaDetail{failure: runproj.FormulaDetailNotFound}, formulaNotFoundTTL, true, false
 		default:
 			// A transient upstream error is not cached; degrade like a cold miss.
-			return cachedFormulaDetail{}, 0, false
+			return cachedFormulaDetail{}, 0, false, false
 		}
 	})
 	if !ok {

--- a/internal/api/dashboardbff/runtailer.go
+++ b/internal/api/dashboardbff/runtailer.go
@@ -46,6 +46,12 @@ type runTailerManager struct {
 	deps  Deps
 	httpc *http.Client
 
+	// sessionsCache and formulaCache absorb the two per-request loopback reads so
+	// a burst of detail/summary GETs collapses onto one upstream fetch per key
+	// (single-flight + TTL). See enrichment_cache.go for the contract.
+	sessionsCache *singleFlightCache[string, cachedSessions]
+	formulaCache  *singleFlightCache[formulaCacheKey, cachedFormulaDetail]
+
 	mu      sync.Mutex
 	cities  map[string]*cityRunTailer
 	ctx     context.Context
@@ -55,9 +61,11 @@ type runTailerManager struct {
 
 func newRunTailerManager(deps Deps) *runTailerManager {
 	return &runTailerManager{
-		deps:   deps,
-		httpc:  &http.Client{Timeout: runSessionsFetchTimeout},
-		cities: make(map[string]*cityRunTailer),
+		deps:          deps,
+		httpc:         &http.Client{Timeout: runSessionsFetchTimeout},
+		cities:        make(map[string]*cityRunTailer),
+		sessionsCache: newSingleFlightCache[string, cachedSessions](),
+		formulaCache:  newSingleFlightCache[formulaCacheKey, cachedFormulaDetail](),
 	}
 }
 
@@ -398,11 +406,32 @@ func (t *cityRunTailer) enrichedSummary(ctx context.Context) runproj.RunSummary 
 	return enriched
 }
 
-// fetchSessions reads GET {base}/v0/city/{name}/sessions over loopback and
-// projects the items into the dashboard session shape (equivalent to the
-// frontend normalizeSessions). Any failure returns (nil, false) so health
-// degrades to unavailable rather than failing the load.
+// fetchSessions returns the projected dashboard sessions for a city, served from
+// the per-city sessions cache (TTL + single-flight). A cache hit within the TTL
+// does no upstream work; concurrent cold-miss callers collapse to one upstream
+// fetch; a failed refetch serves the last-good with available=true; a cold miss
+// whose fetch fails degrades to (nil, false) exactly as the uncached path did, so
+// the caller's honest partial/warming states are preserved. detail() and
+// enrichedSummary() consume this.
 func (m *runTailerManager) fetchSessions(ctx context.Context, name string) ([]runproj.DashboardSession, bool) {
+	got, ok := m.sessionsCache.get(ctx, name, func(ctx context.Context) (cachedSessions, time.Duration, bool) {
+		items, upstreamOK := m.fetchSessionsUpstream(ctx, name)
+		if !upstreamOK {
+			return cachedSessions{}, 0, false
+		}
+		return cachedSessions{items: items}, sessionsCacheTTL, true
+	})
+	if !ok {
+		return nil, false
+	}
+	return got.items, true
+}
+
+// fetchSessionsUpstream reads GET {base}/v0/city/{name}/sessions over loopback
+// and projects the items into the dashboard session shape (equivalent to the
+// frontend normalizeSessions). Any failure returns (nil, false) so the cache
+// degrades to unavailable (or serves last-good) rather than failing the load.
+func (m *runTailerManager) fetchSessionsUpstream(ctx context.Context, name string) ([]runproj.DashboardSession, bool) {
 	base := strings.TrimRight(m.deps.SupervisorBaseURL, "/")
 	if base == "" {
 		return nil, false
@@ -442,19 +471,60 @@ type formulaNodeRef struct {
 	ID string `json:"id"`
 }
 
-// fetchFormulaDetail reads
+// fetchFormulaDetail returns a run's compiled formula detail, served from the
+// per-city formula cache keyed by (name, formula, target, scopeKind, scopeRef).
+// A success is cached for formulaCacheTTL; a definitive 404 (genuinely-missing
+// formula) is cached as FormulaDetailNotFound for the shorter formulaNotFoundTTL
+// so a newly-added formula appears promptly; a transient upstream error is NOT
+// cached — it degrades like a cold miss so a real re-check happens on the next
+// GET. On success it returns (detail, "", true); on a failure it returns
+// (nil, reason, false), preserving the NotFound vs UpstreamError distinction
+// runproj renders as the operator diagnostic. detail() consumes this.
+func (m *runTailerManager) fetchFormulaDetail(ctx context.Context, name, formula, target, scopeKind, scopeRef string) (*runproj.FormulaOrderingDetail, runproj.RunFormulaDetailFetchFailure, bool) {
+	key := formulaCacheKey{name: name, formula: formula, target: target, scopeKind: scopeKind, scopeRef: scopeRef}
+	got, ok := m.formulaCache.get(ctx, key, func(ctx context.Context) (cachedFormulaDetail, time.Duration, bool) {
+		detail, failure, upstreamOK := m.fetchFormulaDetailUpstream(ctx, name, formula, target, scopeKind, scopeRef)
+		switch {
+		case upstreamOK:
+			return cachedFormulaDetail{detail: detail}, formulaCacheTTL, true
+		case failure == runproj.FormulaDetailNotFound:
+			// A definitive 404 is a real negative result: cache it briefly so a burst
+			// of GETs does not re-probe a known-missing formula, but re-check soon.
+			return cachedFormulaDetail{failure: runproj.FormulaDetailNotFound}, formulaNotFoundTTL, true
+		default:
+			// A transient upstream error is not cached; degrade like a cold miss.
+			return cachedFormulaDetail{}, 0, false
+		}
+	})
+	if !ok {
+		// Cold miss whose fetch failed with a non-404 error, or a canceled join
+		// with no last-good: the honest reason is upstream_error.
+		return nil, runproj.FormulaDetailUpstreamError, false
+	}
+	if got.detail == nil {
+		// A cached not-found (or a cached-then-served negative): not available, and
+		// the failure reason travels with the cached value.
+		failure := got.failure
+		if failure == "" {
+			failure = runproj.FormulaDetailUpstreamError
+		}
+		return nil, failure, false
+	}
+	return got.detail, "", true
+}
+
+// fetchFormulaDetailUpstream reads
 // GET {base}/v0/city/{name}/formulas/{formula}?target={target}&scope_kind={kind}&scope_ref={ref}
 // over loopback and projects the compiled formula's ordering-relevant preview
 // nodes and steps into runproj's FormulaOrderingDetail. The scope is required by
 // the endpoint and selects the formula search layer, so a rig-scoped run must
 // send its scope or the lookup resolves the wrong layer (or is rejected). On
 // success it returns (detail, "", true). On failure it returns (nil, reason,
-// false) so the detail falls back to the un-enriched projection: the reason is
-// FormulaDetailNotFound for a supervisor 404 (the compiled formula is genuinely
-// missing) and FormulaDetailUpstreamError for every other failure, preserving the
-// distinction runproj renders as the operator diagnostic. Mirrors fetchSessions;
-// the reason mapping ports the TS formulaDetailFetchFailure helper.
-func (m *runTailerManager) fetchFormulaDetail(ctx context.Context, name, formula, target, scopeKind, scopeRef string) (*runproj.FormulaOrderingDetail, runproj.RunFormulaDetailFetchFailure, bool) {
+// false): the reason is FormulaDetailNotFound for a supervisor 404 (the compiled
+// formula is genuinely missing) and FormulaDetailUpstreamError for every other
+// failure. Mirrors fetchSessionsUpstream; the reason mapping ports the TS
+// formulaDetailFetchFailure helper.
+func (m *runTailerManager) fetchFormulaDetailUpstream(ctx context.Context, name, formula, target, scopeKind, scopeRef string) (*runproj.FormulaOrderingDetail, runproj.RunFormulaDetailFetchFailure, bool) {
 	base := strings.TrimRight(m.deps.SupervisorBaseURL, "/")
 	if base == "" {
 		return nil, runproj.FormulaDetailUpstreamError, false


### PR DESCRIPTION
## What

The run-detail (`/api/city/{c}/runs/{id}/detail`) and run-summary (`/runs/summary`) BFF paths serve run state from the **warm in-memory event-log fold** (`cityRunTailer`) with **zero synchronous beads-DB reads** — that part already won. But on top of the fold, `detail()`/`enrichedSummary()` layer **two per-request loopback HTTP reads** that were **uncached**:

- `GET /v0/city/{name}/sessions` (live session health/links)
- `GET /v0/city/{name}/formulas/{f}?...` (compiled formula step order)

So a dashboard tab re-polling on every bead nudge hit the supervisor once per request for each. This caches both **per-city with single-flight + TTL**, following the `samplers.go` contract (the blocking fetch runs with **no cache lock held**; exactly one caller computes per key during a miss; the rest join its result).

- `sessionsCacheTTL = 3s`, `formulaCacheTTL = 60s`, `formulaNotFoundTTL = 5s` (a newly-added formula appears promptly instead of being pinned missing).
- **Degrade semantics are byte-identical to the uncached path:** a cold-miss failure returns `(nil,false)` / `(nil,upstream_error|not_found,false)` exactly as before; a failure *after* a prior success serves the last-good (degrade, don't blank). A transient upstream error is **not** cached (only success + a definitive 404), so a real re-check happens next GET.
- **Panic-safe:** the plane runs under `withRecovery`, so a `compute` panic would be caught and the process would keep serving — a deferred release guarantees the in-flight channel is always closed so a panic can't permanently wedge a cache key.

## Why

Phase 1 of making run detail **extremely fast + event-first**. The warm event-log fold already beats the beads DB (an in-process slice snapshot vs a `bd` subprocess / Dolt query — 2–4 orders of magnitude); the remaining per-GET latency is these two uncached loopback reads (+ redundant re-projection + the client's repull-on-nudge, addressed in later phases).

## Tests

New `enrichment_cache_test.go` (fake supervisor, atomic hit counters, gated overlap): within-TTL → 1 hit, N concurrent → 1 hit (single-flight, `-race`), TTL expiry → refetch, 404 cached on the short TTL, cold-failure degrade, keyed-by-scope isolation, and a compute-panic recovery test. All existing `runtailer`/`rundetailtailer`/`runproj` golden tests pass unchanged.

Gates: `go test -race ./internal/api/dashboardbff/... ./internal/runproj/...`, `go build`/`go vet`, `make dashboard-check` — all green. Adversarially reviewed (concurrency + shared-mutation): the cached slice/pointer are strictly read-only downstream (`runproj` is allocate-fresh-and-copy), so sharing them within a TTL is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)