### PR TITLE
perf(dashboard): single-scan + memoize run detail per fold generation

### DIFF
--- a/internal/api/dashboardbff/enrichment_cache.go
+++ b/internal/api/dashboardbff/enrichment_cache.go
@@ -70,6 +70,13 @@ type cacheEntry[V any] struct {
 	// stale: once it expires, an errored refetch falls through to the caller's
 	// cold-miss degrade so a stale not-found never masks a later upstream error.
 	staleServeable bool
+	// version is a monotonic counter that bumps by one on every successful
+	// compute-and-store (a refetch that publishes a new value), and NOT on a
+	// within-TTL hit or a degrade-to-last-good. It lets a downstream memo (the
+	// run-detail cache) detect that a cached enrichment value changed underneath
+	// it: a bumped version invalidates the memo key even when the raw value is
+	// equal, so the memo never serves a stale detail after an enrichment refresh.
+	version uint64
 	// inflight is non-nil while exactly one caller computes this key; joiners wait
 	// on its done channel and then return its published result (never re-electing),
 	// so a burst of concurrent callers collapses onto ONE upstream fetch even when
@@ -84,13 +91,17 @@ type cacheEntry[V any] struct {
 // last-good, or a transient cold/expired-negative failure. Sharing one flight's
 // result is what collapses a concurrent burst onto ONE upstream fetch even when
 // the fetch fails — the failure is NOT written to the cache entry, so a LATER
-// request still re-elects and refetches. value/ok are written once (under the
-// cache lock, before done is closed) and read by joiners only after done closes,
-// so the channel close supplies the happens-before with no extra locking.
+// request still re-elects and refetches. value/version/ok are written once (under
+// the cache lock, before done is closed) and read by joiners only after done
+// closes, so the channel close supplies the happens-before with no extra locking.
+// version is the served value's monotonic generation (see cacheEntry.version); it
+// travels with the shared result so a joining getWithVersion caller returns the
+// same version the elector does.
 type flight[V any] struct {
-	done  chan struct{}
-	value V
-	ok    bool
+	done    chan struct{}
+	value   V
+	version uint64
+	ok      bool
 }
 
 // singleFlightCache is a small per-key TTL cache with single-flight: concurrent
@@ -135,6 +146,19 @@ func newSingleFlightCache[K comparable, V any]() *singleFlightCache[K, V] {
 // for a cold miss whose fetch failed and left no last-good, or an expired
 // negative whose refetch failed.
 func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(context.Context) (V, time.Duration, bool, bool)) (V, bool) {
+	v, _, ok := c.getWithVersion(ctx, key, compute)
+	return v, ok
+}
+
+// getWithVersion is get with the served value's monotonic version. The version
+// bumps by one on each successful compute-and-store and stays fixed across a
+// within-TTL hit or a served-stale last-good, so a downstream memo can key on it
+// to detect a refresh even when the raw value is unchanged. The returned version
+// is meaningful only when ok is true (a served value); on a cold-miss degrade it
+// is zero. Every serve-stale, single-flight, and context-detach rule get
+// documents holds here unchanged — this is the full implementation get delegates
+// to.
+func (c *singleFlightCache[K, V]) getWithVersion(ctx context.Context, key K, compute func(context.Context) (V, time.Duration, bool, bool)) (V, uint64, bool) {
 	c.mu.Lock()
 	e, ok := c.entries[key]
 	if !ok {
@@ -143,9 +167,9 @@ func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(c
 	}
 	// Fresh hit: serve without touching the upstream.
 	if e.hasValue && e.inflight == nil && time.Since(e.computed) < e.ttl {
-		v := e.value
+		v, ver := e.value, e.version
 		c.mu.Unlock()
-		return v, true
+		return v, ver, true
 	}
 	// Someone is already computing this key: join that flight and return its
 	// shared result instead of re-electing. A failed cold or expired-negative
@@ -158,7 +182,7 @@ func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(c
 		c.mu.Unlock()
 		select {
 		case <-fl.done:
-			return fl.value, fl.ok
+			return fl.value, fl.version, fl.ok
 		case <-ctx.Done():
 			// The caller gave up. Serve the last-good if we have one (never block a
 			// canceled caller on an in-flight fetch); otherwise degrade.
@@ -200,6 +224,7 @@ func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(c
 		computeOK      bool
 		staleServeable bool
 		resultValue    V
+		resultVersion  uint64
 		resultOK       bool
 	)
 	func() {
@@ -211,6 +236,9 @@ func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(c
 				e.ttl = ttl
 				e.hasValue = true
 				e.staleServeable = staleServeable
+				// A successful store is a new generation of this value: bump the
+				// version so a downstream memo keyed on it rebuilds.
+				e.version++
 			}
 			// else: keep the prior last-good (if any) untouched — degrade,
 			// don't blank.
@@ -219,22 +247,24 @@ func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(c
 			// (the elector and all current waiters): a fresh success, a served-stale
 			// positive last-good, or an honest degrade. Because a failure is never
 			// written to the entry above, a LATER request re-elects and refetches —
-			// only the concurrent burst is collapsed.
+			// only the concurrent burst is collapsed. The published version is the
+			// served value's own generation, so a joining getWithVersion caller
+			// returns the same version the elector does.
 			switch {
 			case computeOK:
-				resultValue, resultOK = value, true
+				resultValue, resultVersion, resultOK = e.value, e.version, true
 			case e.hasValue && e.staleServeable:
 				// A failed refetch with a serveable positive last-good: serve it stale.
 				// A negative last-good is NOT serveable stale, so it falls through to
 				// the degrade below rather than masking this upstream error.
-				resultValue, resultOK = e.value, true
+				resultValue, resultVersion, resultOK = e.value, e.version, true
 			default:
 				// Cold miss (or expired negative), fetch failed, no serveable
 				// last-good: honest degrade to the zero value.
 				var zero V
-				resultValue, resultOK = zero, false
+				resultValue, resultVersion, resultOK = zero, 0, false
 			}
-			fl.value, fl.ok = resultValue, resultOK
+			fl.value, fl.version, fl.ok = resultValue, resultVersion, resultOK
 			e.inflight = nil
 			c.mu.Unlock()
 			close(fl.done)
@@ -255,23 +285,24 @@ func (c *singleFlightCache[K, V]) get(ctx context.Context, key K, compute func(c
 		value, ttl, computeOK, staleServeable = compute(computeCtx)
 	}()
 
-	return resultValue, resultOK
+	return resultValue, resultVersion, resultOK
 }
 
-// lastGoodOrZero returns the entry's serveable last-good value (available) if one
-// exists, else the zero value (unavailable). Used when a caller's ctx is canceled
-// while joining an in-flight fetch: a canceled caller must never block, but should
-// still serve a serveable last-good if the cache holds one. A cached negative is
-// not serveable stale (see cacheEntry.staleServeable), so it degrades here too
-// rather than surfacing a stale not-found on cancellation.
-func (c *singleFlightCache[K, V]) lastGoodOrZero(key K) (V, bool) {
+// lastGoodOrZero returns the entry's serveable last-good value and its version
+// (available) if one exists, else the zero value (unavailable). Used when a
+// caller's ctx is canceled while joining an in-flight fetch: a canceled caller
+// must never block, but should still serve a serveable last-good if the cache
+// holds one. A cached negative is not serveable stale (see
+// cacheEntry.staleServeable), so it degrades here too rather than surfacing a
+// stale not-found on cancellation.
+func (c *singleFlightCache[K, V]) lastGoodOrZero(key K) (V, uint64, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if e, ok := c.entries[key]; ok && e.hasValue && e.staleServeable {
-		return e.value, true
+		return e.value, e.version, true
 	}
 	var zero V
-	return zero, false
+	return zero, 0, false
 }
 
 // ── Cached payload shapes ─────────────────────────────────────────────────

--- a/internal/api/dashboardbff/enrichment_cache_test.go
+++ b/internal/api/dashboardbff/enrichment_cache_test.go
@@ -437,8 +437,8 @@ func TestFormulaCacheServesWithinTTL(t *testing.T) {
 	m := newEnrichmentManager(t, ts.URL)
 	ctx := context.Background()
 
-	d1, f1, ok1 := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
-	d2, f2, ok2 := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	d1, f1, _, ok1 := m.fetchFormulaDetailVersioned(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	d2, f2, _, ok2 := m.fetchFormulaDetailVersioned(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
 	if !ok1 || !ok2 {
 		t.Fatalf("both formula reads must succeed: %v %v (failures %q %q)", ok1, ok2, f1, f2)
 	}
@@ -467,7 +467,7 @@ func TestFormulaCacheSingleFlight(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
-			if _, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); ok {
+			if _, _, _, ok := m.fetchFormulaDetailVersioned(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); ok {
 				okCount.Add(1)
 			}
 		}()
@@ -506,7 +506,7 @@ func TestFormulaCacheNotFoundReCheckedOnShortTTL(t *testing.T) {
 	ctx := context.Background()
 
 	// First read: 404 -> not_found, cached.
-	_, failure, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	_, failure, _, ok := m.fetchFormulaDetailVersioned(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
 	if ok {
 		t.Fatal("a 404 formula fetch must not report ok")
 	}
@@ -515,7 +515,7 @@ func TestFormulaCacheNotFoundReCheckedOnShortTTL(t *testing.T) {
 	}
 	// Second read inside the short TTL: served from the cached not-found entry, no
 	// new upstream hit.
-	if _, f2, ok2 := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); ok2 || f2 != runproj.FormulaDetailNotFound {
+	if _, f2, _, ok2 := m.fetchFormulaDetailVersioned(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); ok2 || f2 != runproj.FormulaDetailNotFound {
 		t.Fatalf("cached not-found read: ok=%v failure=%q, want not_found", ok2, f2)
 	}
 	if got := srv.formulaHits.Load(); got != 1 {
@@ -525,7 +525,7 @@ func TestFormulaCacheNotFoundReCheckedOnShortTTL(t *testing.T) {
 	// After the SHORT not-found TTL lapses, the formula becomes available upstream.
 	time.Sleep(40 * time.Millisecond)
 	srv.formulaStatus.Store(0) // 200 canonical body
-	d, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	d, _, _, ok := m.fetchFormulaDetailVersioned(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
 	if !ok || d == nil {
 		t.Fatalf("after the short not-found TTL the newly-added formula must resolve: ok=%v d=%+v", ok, d)
 	}
@@ -544,7 +544,7 @@ func TestFormulaCacheColdFailureDegrades(t *testing.T) {
 	defer ts.Close()
 
 	m := newEnrichmentManager(t, ts.URL)
-	d, failure, ok := m.fetchFormulaDetail(context.Background(), "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
+	d, failure, _, ok := m.fetchFormulaDetailVersioned(context.Background(), "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo")
 	if ok || d != nil {
 		t.Fatalf("cold upstream error must degrade to (nil,...,false); got d=%+v ok=%v", d, ok)
 	}
@@ -715,14 +715,14 @@ func TestFormulaCacheKeyedByScope(t *testing.T) {
 	m := newEnrichmentManager(t, ts.URL)
 	ctx := context.Background()
 
-	if _, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); !ok {
+	if _, _, _, ok := m.fetchFormulaDetailVersioned(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); !ok {
 		t.Fatal("first scope must resolve")
 	}
-	if _, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:other", "rig", "other"); !ok {
+	if _, _, _, ok := m.fetchFormulaDetailVersioned(ctx, "alpha", "mol-adopt-pr-v2", "rig:other", "rig", "other"); !ok {
 		t.Fatal("second scope must resolve")
 	}
 	// Same key as the first read -> cached, no new hit.
-	if _, _, ok := m.fetchFormulaDetail(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); !ok {
+	if _, _, _, ok := m.fetchFormulaDetailVersioned(ctx, "alpha", "mol-adopt-pr-v2", "rig:demo", "rig", "demo"); !ok {
 		t.Fatal("repeat of the first scope must resolve")
 	}
 	if got := hits.Load(); got != 2 {

--- a/internal/api/dashboardbff/plane.go
+++ b/internal/api/dashboardbff/plane.go
@@ -206,6 +206,21 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+// writeJSONBytes writes pre-marshaled JSON with the same headers and status as
+// writeJSON, for a caller that already holds json.Marshal(v) (the run-detail memo
+// serving its cached bytes). It appends the single trailing newline
+// json.Encoder.Encode emits, so the response is byte-identical to
+// writeJSON(w, status, v) for the same value.
+func writeJSONBytes(w http.ResponseWriter, status int, body []byte) {
+	h := w.Header()
+	h.Set("Content-Type", "application/json; charset=utf-8")
+	h.Set("X-Content-Type-Options", "nosniff")
+	h.Set("X-Frame-Options", "DENY")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+	_, _ = w.Write([]byte{'\n'})
+}
+
 // apiHealthResponse is the GET /api/health body. Typed (not map[string]any) so
 // every knowable wire shape on this non-typed plane is still a named struct;
 // the genuinely-dynamic supervisor-status pass-through (samplers.go) is the

--- a/internal/api/dashboardbff/rundetail_memo.go
+++ b/internal/api/dashboardbff/rundetail_memo.go
@@ -1,0 +1,148 @@
+package dashboardbff
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/runproj"
+)
+
+// runDetailMemoCap bounds the per-tailer detail memo. It holds the actively
+// viewed runs of one city; a dashboard shows a handful of runs at a time, so a
+// small cap covers the working set while an unbounded map would pin every run
+// ever opened. A var (not a const) so a test can shrink it to force eviction.
+var runDetailMemoCap = 128
+
+// runDetailMemoKey identifies one built-and-marshaled run detail by everything
+// that determines its bytes. A change to ANY field yields a new key → a miss →
+// a rebuild, so invalidation is implicit (no explicit purge beyond LRU
+// eviction).
+//
+//   - runID + lastSeq pin the fold generation: lastSeq is the tailer's monotonic
+//     publish cursor, bumped on every build(), and the warm bead slice is
+//     published under the same lock as lastSeq, so equal lastSeq ⇒ equal beads.
+//   - sessionsVersion is the sessions cache entry's version (0 when sessions are
+//     unavailable, so an availability flip changes the key).
+//   - formulaVersion + formulaFailure pin the compiled-formula enrichment: the
+//     version identifies an available compiled detail (immutable per version),
+//     and the failure string distinguishes the unavailable arms (not_found vs
+//     upstream_error) that also change the built output.
+type runDetailMemoKey struct {
+	runID           string
+	lastSeq         uint64
+	sessionsVersion uint64
+	formulaVersion  uint64
+	formulaFailure  runproj.RunFormulaDetailFetchFailure
+}
+
+// runDetailMemoValue is the immutable-after-build memoized detail: the projected
+// DTO (returned to the detail() callers that need the struct) and its marshaled
+// JSON (served verbatim by the GET handler to skip a re-marshal). Neither is
+// mutated after store, so both are safe to share read-only across callers.
+type runDetailMemoValue struct {
+	detail runproj.FormulaRunDetail
+	bytes  []byte
+}
+
+// runDetailMemo is a small bounded LRU of built run details keyed by fold
+// generation + enrichment versions, with single-flight so concurrent misses for
+// the same key build exactly once. It is safe under -race: the mutex guards the
+// map, the eviction list, and the in-flight table, and is NEVER held across the
+// build/marshal that produces a value (the samplers.go contract). The stored
+// value is immutable, so a reader shares it without copying.
+type runDetailMemo struct {
+	mu       sync.Mutex
+	cap      int
+	entries  map[runDetailMemoKey]*list.Element
+	lru      *list.List // front = most recently used
+	inflight map[runDetailMemoKey]chan struct{}
+}
+
+// runDetailMemoEntry is one LRU node: the key (so eviction can delete the map
+// entry) and the shared value.
+type runDetailMemoEntry struct {
+	key   runDetailMemoKey
+	value runDetailMemoValue
+}
+
+// newRunDetailMemo builds an empty memo bounded to runDetailMemoCap.
+func newRunDetailMemo() *runDetailMemo {
+	return &runDetailMemo{
+		cap:      runDetailMemoCap,
+		entries:  make(map[runDetailMemoKey]*list.Element),
+		lru:      list.New(),
+		inflight: make(map[runDetailMemoKey]chan struct{}),
+	}
+}
+
+// getOrBuild returns the memoized value for key, building it via build on a miss.
+// Concurrent callers for the same key collapse onto one build: the elected
+// caller runs build with NO memo lock held (the samplers.go contract); joiners
+// wait and then re-read the now-stored value. build is invoked at most once per
+// generation; a build error is NOT cached (the next caller re-elects and
+// retries), so a transient projection failure never pins a run.
+func (m *runDetailMemo) getOrBuild(key runDetailMemoKey, build func() (runDetailMemoValue, error)) (runDetailMemoValue, error) {
+	for {
+		m.mu.Lock()
+		if el, ok := m.entries[key]; ok {
+			m.lru.MoveToFront(el)
+			v := el.Value.(*runDetailMemoEntry).value
+			m.mu.Unlock()
+			return v, nil
+		}
+		if wait, building := m.inflight[key]; building {
+			m.mu.Unlock()
+			<-wait
+			// Re-loop: read the value the builder stored, or re-elect if the build
+			// failed and left no entry.
+			continue
+		}
+		// We are the elected builder for this key.
+		done := make(chan struct{})
+		m.inflight[key] = done
+		m.mu.Unlock()
+
+		var (
+			value    runDetailMemoValue
+			buildErr error
+		)
+		func() {
+			// Release the in-flight handshake on every exit — including a build
+			// panic — so a panicking build never orphans the channel and wedges
+			// every future caller for this key. On success store under the lock;
+			// on failure leave no entry so the next caller re-elects.
+			defer func() {
+				m.mu.Lock()
+				if buildErr == nil {
+					m.storeLocked(key, value)
+				}
+				delete(m.inflight, key)
+				m.mu.Unlock()
+				close(done)
+			}()
+			value, buildErr = build()
+		}()
+		if buildErr != nil {
+			return runDetailMemoValue{}, buildErr
+		}
+		return value, nil
+	}
+}
+
+// storeLocked inserts value under key as most-recently-used and evicts the
+// least-recently-used entry when the cap is exceeded. The caller holds m.mu.
+func (m *runDetailMemo) storeLocked(key runDetailMemoKey, value runDetailMemoValue) {
+	if el, ok := m.entries[key]; ok {
+		el.Value.(*runDetailMemoEntry).value = value
+		m.lru.MoveToFront(el)
+		return
+	}
+	el := m.lru.PushFront(&runDetailMemoEntry{key: key, value: value})
+	m.entries[key] = el
+	if m.cap > 0 && m.lru.Len() > m.cap {
+		if oldest := m.lru.Back(); oldest != nil {
+			m.lru.Remove(oldest)
+			delete(m.entries, oldest.Value.(*runDetailMemoEntry).key)
+		}
+	}
+}

--- a/internal/api/dashboardbff/rundetail_memo.go
+++ b/internal/api/dashboardbff/rundetail_memo.go
@@ -44,49 +44,101 @@ type runDetailMemoValue struct {
 	bytes  []byte
 }
 
-// runDetailMemo is a small bounded LRU of built run details keyed by fold
-// generation + enrichment versions, with single-flight so concurrent misses for
-// the same key build exactly once. It is safe under -race: the mutex guards the
-// map, the eviction list, and the in-flight table, and is NEVER held across the
-// build/marshal that produces a value (the samplers.go contract). The stored
-// value is immutable, so a reader shares it without copying.
-type runDetailMemo struct {
+// runDetailMemo is the per-tailer LRU of built run details keyed by fold
+// generation + enrichment versions.
+type runDetailMemo = lruSingleFlight[runDetailMemoKey, runDetailMemoValue]
+
+// newRunDetailMemo builds an empty detail memo bounded to runDetailMemoCap.
+func newRunDetailMemo() *runDetailMemo {
+	return newLRUSingleFlight[runDetailMemoKey, runDetailMemoValue](runDetailMemoCap)
+}
+
+// runSnapshotCacheCap bounds the per-tailer run-snapshot cache. Like the detail
+// memo it holds only the actively viewed runs' folded snapshots, so a small cap
+// covers the working set while an unbounded map would pin every run ever opened.
+// A var (not a const) so a test can shrink it to force eviction.
+var runSnapshotCacheCap = 128
+
+// runSnapshotCacheKey identifies one folded run snapshot by the run and its fold
+// generation. The snapshot — and the compiled-formula target derived from it —
+// are pure functions of the run's beads, and lastSeq pins those beads (equal
+// lastSeq ⇒ equal beads), so a new bead event (lastSeq++) is the only thing that
+// invalidates the entry.
+type runSnapshotCacheKey struct {
+	runID   string
+	lastSeq uint64
+}
+
+// runSnapshotCacheValue is the folded snapshot plus the compiled-formula target
+// resolved off it. Both are version/seq-independent, so detail() reuses them
+// across every same-generation request: a repeat GET at an unchanged lastSeq
+// pays no SnapshotForRun scan, only a new fold generation does. targetOK mirrors
+// FormulaTargetFromSnapshot's ok (false when the run is not a fetchable graph.v2
+// run, lacks a name+target, or has no valid scope). The stored value is
+// immutable after the fold, so callers share it read-only.
+type runSnapshotCacheValue struct {
+	snap      runproj.RunSnapshot
+	name      string
+	target    string
+	scopeKind string
+	scopeRef  string
+	targetOK  bool
+}
+
+// runSnapshotCache is the per-tailer LRU of folded run snapshots keyed by fold
+// generation.
+type runSnapshotCache = lruSingleFlight[runSnapshotCacheKey, runSnapshotCacheValue]
+
+// newRunSnapshotCache builds an empty snapshot cache bounded to runSnapshotCacheCap.
+func newRunSnapshotCache() *runSnapshotCache {
+	return newLRUSingleFlight[runSnapshotCacheKey, runSnapshotCacheValue](runSnapshotCacheCap)
+}
+
+// lruSingleFlight is a small bounded LRU with single-flight: concurrent misses
+// for the same key build exactly once. It is safe under -race: the mutex guards
+// the map, the eviction list, and the in-flight table, and is NEVER held across
+// the build that produces a value (the samplers.go contract). Stored values are
+// immutable, so a reader shares one without copying. A build error is NOT cached
+// (the next caller re-elects and retries), and a build PANIC likewise stores
+// nothing — so a transient failure or a panicking build never pins a key with a
+// bogus (zero) value.
+type lruSingleFlight[K comparable, V any] struct {
 	mu       sync.Mutex
 	cap      int
-	entries  map[runDetailMemoKey]*list.Element
+	entries  map[K]*list.Element
 	lru      *list.List // front = most recently used
-	inflight map[runDetailMemoKey]chan struct{}
+	inflight map[K]chan struct{}
 }
 
-// runDetailMemoEntry is one LRU node: the key (so eviction can delete the map
-// entry) and the shared value.
-type runDetailMemoEntry struct {
-	key   runDetailMemoKey
-	value runDetailMemoValue
+// lruEntry is one LRU node: the key (so eviction can delete the map entry) and
+// the shared value.
+type lruEntry[K comparable, V any] struct {
+	key   K
+	value V
 }
 
-// newRunDetailMemo builds an empty memo bounded to runDetailMemoCap.
-func newRunDetailMemo() *runDetailMemo {
-	return &runDetailMemo{
-		cap:      runDetailMemoCap,
-		entries:  make(map[runDetailMemoKey]*list.Element),
+// newLRUSingleFlight builds an empty cache bounded to capacity entries.
+func newLRUSingleFlight[K comparable, V any](capacity int) *lruSingleFlight[K, V] {
+	return &lruSingleFlight[K, V]{
+		cap:      capacity,
+		entries:  make(map[K]*list.Element),
 		lru:      list.New(),
-		inflight: make(map[runDetailMemoKey]chan struct{}),
+		inflight: make(map[K]chan struct{}),
 	}
 }
 
-// getOrBuild returns the memoized value for key, building it via build on a miss.
+// getOrBuild returns the cached value for key, building it via build on a miss.
 // Concurrent callers for the same key collapse onto one build: the elected
-// caller runs build with NO memo lock held (the samplers.go contract); joiners
-// wait and then re-read the now-stored value. build is invoked at most once per
-// generation; a build error is NOT cached (the next caller re-elects and
-// retries), so a transient projection failure never pins a run.
-func (m *runDetailMemo) getOrBuild(key runDetailMemoKey, build func() (runDetailMemoValue, error)) (runDetailMemoValue, error) {
+// caller runs build with NO lock held (the samplers.go contract); joiners wait
+// and then re-read the now-stored value. build runs at most once per key per
+// miss; a build error is NOT cached (the next caller re-elects), so a transient
+// failure never pins a key.
+func (m *lruSingleFlight[K, V]) getOrBuild(key K, build func() (V, error)) (V, error) {
 	for {
 		m.mu.Lock()
 		if el, ok := m.entries[key]; ok {
 			m.lru.MoveToFront(el)
-			v := el.Value.(*runDetailMemoEntry).value
+			v := el.Value.(*lruEntry[K, V]).value
 			m.mu.Unlock()
 			return v, nil
 		}
@@ -94,7 +146,7 @@ func (m *runDetailMemo) getOrBuild(key runDetailMemoKey, build func() (runDetail
 			m.mu.Unlock()
 			<-wait
 			// Re-loop: read the value the builder stored, or re-elect if the build
-			// failed and left no entry.
+			// failed (or panicked) and left no entry.
 			continue
 		}
 		// We are the elected builder for this key.
@@ -103,17 +155,23 @@ func (m *runDetailMemo) getOrBuild(key runDetailMemoKey, build func() (runDetail
 		m.mu.Unlock()
 
 		var (
-			value    runDetailMemoValue
-			buildErr error
+			value     V
+			buildErr  error
+			completed bool
 		)
 		func() {
 			// Release the in-flight handshake on every exit — including a build
 			// panic — so a panicking build never orphans the channel and wedges
-			// every future caller for this key. On success store under the lock;
-			// on failure leave no entry so the next caller re-elects.
+			// every future caller for this key. Store ONLY after build() returned
+			// normally without error: a panic unwinds through build() without ever
+			// assigning buildErr (it stays nil) or reaching completed=true, so
+			// gating the store on buildErr alone would cache the zero value and
+			// later callers would serve it as a valid result. completed stays false
+			// on a panic, so nothing is stored, the next caller re-elects, and the
+			// recovery middleware turns the panic into a 500.
 			defer func() {
 				m.mu.Lock()
-				if buildErr == nil {
+				if completed && buildErr == nil {
 					m.storeLocked(key, value)
 				}
 				delete(m.inflight, key)
@@ -121,9 +179,11 @@ func (m *runDetailMemo) getOrBuild(key runDetailMemoKey, build func() (runDetail
 				close(done)
 			}()
 			value, buildErr = build()
+			completed = true
 		}()
 		if buildErr != nil {
-			return runDetailMemoValue{}, buildErr
+			var zero V
+			return zero, buildErr
 		}
 		return value, nil
 	}
@@ -131,18 +191,18 @@ func (m *runDetailMemo) getOrBuild(key runDetailMemoKey, build func() (runDetail
 
 // storeLocked inserts value under key as most-recently-used and evicts the
 // least-recently-used entry when the cap is exceeded. The caller holds m.mu.
-func (m *runDetailMemo) storeLocked(key runDetailMemoKey, value runDetailMemoValue) {
+func (m *lruSingleFlight[K, V]) storeLocked(key K, value V) {
 	if el, ok := m.entries[key]; ok {
-		el.Value.(*runDetailMemoEntry).value = value
+		el.Value.(*lruEntry[K, V]).value = value
 		m.lru.MoveToFront(el)
 		return
 	}
-	el := m.lru.PushFront(&runDetailMemoEntry{key: key, value: value})
+	el := m.lru.PushFront(&lruEntry[K, V]{key: key, value: value})
 	m.entries[key] = el
 	if m.cap > 0 && m.lru.Len() > m.cap {
 		if oldest := m.lru.Back(); oldest != nil {
 			m.lru.Remove(oldest)
-			delete(m.entries, oldest.Value.(*runDetailMemoEntry).key)
+			delete(m.entries, oldest.Value.(*lruEntry[K, V]).key)
 		}
 	}
 }

--- a/internal/api/dashboardbff/rundetail_memo_test.go
+++ b/internal/api/dashboardbff/rundetail_memo_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 )
 
-// warmRunTailer builds a plane over a temp event log, starts it, and blocks
-// until the run's detail is servable (the cold replay has folded the root). It
-// returns the plane and the city's tailer so a test can drive detail() directly.
-func warmRunTailer(t *testing.T, city string, evts ...events.Event) (*Plane, *cityRunTailer) {
+// warmRunTailer builds a plane over a temp event log for the "alpha" city,
+// starts it, and blocks until the run's detail is servable (the cold replay has
+// folded the root). It returns the plane and the city's tailer so a test can
+// drive detail() directly.
+func warmRunTailer(t *testing.T, evts ...events.Event) (*Plane, *cityRunTailer) {
 	t.Helper()
+	const city = "alpha"
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, ".gc", "events.jsonl")
 	writeEventLog(t, logPath, evts...)
@@ -45,7 +47,7 @@ func warmRunTailer(t *testing.T, city string, evts ...events.Event) (*Plane, *ci
 // fold generation build exactly once (the second is served from the memo) and
 // return byte-identical results.
 func TestRunDetailMemoBuildsOncePerGeneration(t *testing.T) {
-	_, tl := warmRunTailer(t, "alpha",
+	_, tl := warmRunTailer(t,
 		runDetailRootEvent(),
 		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
 	)
@@ -172,7 +174,7 @@ func TestRunDetailMemoRebuildsOnSessionsVersionBump(t *testing.T) {
 // newline the JSON encoder emits — i.e. writeJSONBytes is byte-identical to the
 // old writeJSON(w, detail) path.
 func TestRunDetailServedBytesEqualFreshMarshal(t *testing.T) {
-	p, tl := warmRunTailer(t, "alpha",
+	p, tl := warmRunTailer(t,
 		runDetailRootEvent(),
 		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
 	)
@@ -207,7 +209,7 @@ func TestRunDetailServedBytesEqualFreshMarshal(t *testing.T) {
 // return byte-identical results. Run under -race, it also proves the memo is
 // race-clean.
 func TestRunDetailMemoConcurrentSingleBuild(t *testing.T) {
-	_, tl := warmRunTailer(t, "alpha",
+	_, tl := warmRunTailer(t,
 		runDetailRootEvent(),
 		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
 	)
@@ -282,6 +284,123 @@ func TestRunDetailMemoEvictsLRU(t *testing.T) {
 	// Builds: gen1, gen2, gen3, (gen2 hit), gen1-rebuild = 4.
 	if builds := detailBuildCount.Load() - before; builds != 4 {
 		t.Fatalf("builds = %d, want 4 (gen2 cached, evicted gen1 rebuilt)", builds)
+	}
+}
+
+// TestRunDetailMemoRecoversAfterBuildPanic proves a panic inside build() does
+// not poison the memo with a zero-value entry. The dashboardbff plane runs under
+// withRecovery, so a build panic is caught and the process keeps serving; the
+// deferred cleanup in getOrBuild must store NOTHING (completed stays false),
+// clear the in-flight handshake, and let the next caller re-elect and build a
+// real value — never read cached empty bytes. Mirrors
+// TestSingleFlightCacheRecoversAfterComputePanic for the LRU memo.
+func TestRunDetailMemoRecoversAfterBuildPanic(t *testing.T) {
+	m := newRunDetailMemo()
+	key := runDetailMemoKey{runID: "run1", lastSeq: 1}
+
+	// First caller: build panics. Recover it here, mimicking withRecovery. The
+	// panic MUST propagate out of getOrBuild (not be swallowed) while the deferred
+	// cleanup clears the key and stores nothing.
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = m.getOrBuild(key, func() (runDetailMemoValue, error) {
+			panic("boom")
+		})
+		t.Fatal("expected the panicking build to propagate out of getOrBuild")
+	}()
+
+	// A subsequent caller for the SAME key must re-elect (not deadlock on an
+	// orphaned inflight channel) and must build a fresh value rather than read a
+	// cached zero-value entry a poisoning store would have left.
+	done := make(chan struct{})
+	var (
+		got runDetailMemoValue
+		err error
+	)
+	go func() {
+		defer close(done)
+		got, err = m.getOrBuild(key, func() (runDetailMemoValue, error) {
+			return runDetailMemoValue{bytes: []byte("real")}, nil
+		})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-panic getOrBuild deadlocked on an orphaned inflight channel")
+	}
+	if err != nil {
+		t.Fatalf("post-panic getOrBuild: %v", err)
+	}
+	if string(got.bytes) != "real" {
+		t.Fatalf("post-panic getOrBuild returned bytes %q, want the freshly built %q "+
+			"(a poisoned zero-value entry would be empty)", got.bytes, "real")
+	}
+}
+
+// TestRunDetailSameGenerationSkipsSnapshotFold proves two detail() calls at the
+// same fold generation fold the run's snapshot exactly once — the second is
+// served from the snapshot cache with no re-scan. Before the snapshot cache the
+// detail memo skipped the build+marshal on a hit, but detail() still re-ran
+// SnapshotForRun on every request, so the hot repeat GET kept scanning the run.
+func TestRunDetailSameGenerationSkipsSnapshotFold(t *testing.T) {
+	_, tl := warmRunTailer(t,
+		runDetailRootEvent(),
+		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
+	)
+	ctx := context.Background()
+
+	before := snapshotFoldCount.Load()
+	if _, ready, err := tl.detail(ctx, "run1"); err != nil || !ready {
+		t.Fatalf("first detail: err=%v ready=%v", err, ready)
+	}
+	if _, ready, err := tl.detail(ctx, "run1"); err != nil || !ready {
+		t.Fatalf("second detail: err=%v ready=%v", err, ready)
+	}
+	if folds := snapshotFoldCount.Load() - before; folds != 1 {
+		t.Fatalf("snapshot folds = %d across two same-generation detail() calls, want 1 "+
+			"(the second must hit the snapshot cache)", folds)
+	}
+}
+
+// TestRunDetailNewGenerationRefolds proves appending a bead event (which advances
+// lastSeq) invalidates the snapshot cache, so the next detail() re-folds — the
+// snapshot cache must not serve a stale fold across generations.
+func TestRunDetailNewGenerationRefolds(t *testing.T) {
+	defer func(prev time.Duration) { runTailPollInterval = prev }(runTailPollInterval)
+	runTailPollInterval = 15 * time.Millisecond
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, ".gc", "events.jsonl")
+	writeEventLog(t, logPath,
+		runDetailRootEvent(),
+		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
+	)
+	p := New(Deps{Resolver: fakeResolver{paths: map[string]string{"alpha": dir}}})
+	p.Start(t.Context())
+	defer p.Stop()
+	tl, _ := p.cityRunTailer("alpha")
+	select {
+	case <-tl.readyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cold replay did not complete")
+	}
+	ctx := context.Background()
+
+	before := snapshotFoldCount.Load()
+	if _, _, err := tl.detail(ctx, "run1"); err != nil {
+		t.Fatalf("first detail: %v", err)
+	}
+	seqBefore := currentLastSeq(tl)
+
+	// Append a new step event; the tail folds it and bumps lastSeq → a new key.
+	appendEvents(t, logPath, runDetailStepEvent(3, "run1.2", "run1", "rebase-check", "open"))
+	waitForLastSeqAbove(t, tl, seqBefore)
+
+	if _, _, err := tl.detail(ctx, "run1"); err != nil {
+		t.Fatalf("second detail after append: %v", err)
+	}
+	if folds := snapshotFoldCount.Load() - before; folds != 2 {
+		t.Fatalf("snapshot folds = %d, want 2 (a new fold generation must re-fold)", folds)
 	}
 }
 

--- a/internal/api/dashboardbff/rundetail_memo_test.go
+++ b/internal/api/dashboardbff/rundetail_memo_test.go
@@ -1,0 +1,306 @@
+package dashboardbff
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// warmRunTailer builds a plane over a temp event log, starts it, and blocks
+// until the run's detail is servable (the cold replay has folded the root). It
+// returns the plane and the city's tailer so a test can drive detail() directly.
+func warmRunTailer(t *testing.T, city string, evts ...events.Event) (*Plane, *cityRunTailer) {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, ".gc", "events.jsonl")
+	writeEventLog(t, logPath, evts...)
+
+	p := New(Deps{Resolver: fakeResolver{paths: map[string]string{city: dir}}})
+	p.Start(t.Context())
+	t.Cleanup(p.Stop)
+
+	tl, ok := p.cityRunTailer(city)
+	if !ok {
+		t.Fatalf("cityRunTailer(%q) not found", city)
+	}
+	select {
+	case <-tl.readyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cold replay did not complete")
+	}
+	return p, tl
+}
+
+// TestRunDetailMemoBuildsOncePerGeneration proves two detail() calls at the same
+// fold generation build exactly once (the second is served from the memo) and
+// return byte-identical results.
+func TestRunDetailMemoBuildsOncePerGeneration(t *testing.T) {
+	_, tl := warmRunTailer(t, "alpha",
+		runDetailRootEvent(),
+		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
+	)
+	ctx := context.Background()
+
+	before := detailBuildCount.Load()
+	v1, ready1, err1 := tl.detail(ctx, "run1")
+	if err1 != nil || !ready1 {
+		t.Fatalf("first detail: err=%v ready=%v", err1, ready1)
+	}
+	v2, ready2, err2 := tl.detail(ctx, "run1")
+	if err2 != nil || !ready2 {
+		t.Fatalf("second detail: err=%v ready=%v", err2, ready2)
+	}
+
+	if builds := detailBuildCount.Load() - before; builds != 1 {
+		t.Fatalf("builds = %d across two same-generation detail() calls, want 1", builds)
+	}
+	if !bytes.Equal(v1.bytes, v2.bytes) {
+		t.Fatalf("memoized bytes differ across two same-generation calls:\n%s\nvs\n%s", v1.bytes, v2.bytes)
+	}
+	if len(v1.bytes) == 0 {
+		t.Fatal("memoized bytes are empty")
+	}
+}
+
+// TestRunDetailMemoRebuildsOnNewFoldGeneration proves appending a bead event
+// (which advances lastSeq) yields a new memo key → a rebuild.
+func TestRunDetailMemoRebuildsOnNewFoldGeneration(t *testing.T) {
+	defer func(prev time.Duration) { runTailPollInterval = prev }(runTailPollInterval)
+	runTailPollInterval = 15 * time.Millisecond
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, ".gc", "events.jsonl")
+	writeEventLog(t, logPath,
+		runDetailRootEvent(),
+		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
+	)
+	p := New(Deps{Resolver: fakeResolver{paths: map[string]string{"alpha": dir}}})
+	p.Start(t.Context())
+	defer p.Stop()
+	tl, _ := p.cityRunTailer("alpha")
+	select {
+	case <-tl.readyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cold replay did not complete")
+	}
+	ctx := context.Background()
+
+	before := detailBuildCount.Load()
+	if _, _, err := tl.detail(ctx, "run1"); err != nil {
+		t.Fatalf("first detail: %v", err)
+	}
+	seqBefore := currentLastSeq(tl)
+
+	// Append a new step event; the tail folds it and bumps lastSeq.
+	appendEvents(t, logPath, runDetailStepEvent(3, "run1.2", "run1", "rebase-check", "open"))
+	waitForLastSeqAbove(t, tl, seqBefore)
+
+	if _, _, err := tl.detail(ctx, "run1"); err != nil {
+		t.Fatalf("second detail after append: %v", err)
+	}
+	if builds := detailBuildCount.Load() - before; builds != 2 {
+		t.Fatalf("builds = %d, want 2 (a new fold generation must rebuild)", builds)
+	}
+}
+
+// TestRunDetailMemoRebuildsOnSessionsVersionBump proves a sessions-cache refresh
+// (a bumped version) alone rebuilds the detail, even at the same fold
+// generation. The supervisor sessions endpoint is stable, so only the version
+// changes across the TTL boundary.
+func TestRunDetailMemoRebuildsOnSessionsVersionBump(t *testing.T) {
+	defer func(prev time.Duration) { sessionsCacheTTL = prev }(sessionsCacheTTL)
+	sessionsCacheTTL = 20 * time.Millisecond
+
+	var sessionsHits atomic.Int64
+	supervisor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/sessions") {
+			sessionsHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"items":[],"total":0}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer supervisor.Close()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, ".gc", "events.jsonl")
+	writeEventLog(t, logPath, runDetailRootEvent(),
+		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"))
+	p := New(Deps{
+		Resolver:          fakeResolver{paths: map[string]string{"alpha": dir}},
+		SupervisorBaseURL: supervisor.URL,
+	})
+	p.Start(t.Context())
+	defer p.Stop()
+	tl, _ := p.cityRunTailer("alpha")
+	select {
+	case <-tl.readyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cold replay did not complete")
+	}
+	ctx := context.Background()
+
+	before := detailBuildCount.Load()
+	if _, _, err := tl.detail(ctx, "run1"); err != nil {
+		t.Fatalf("first detail: %v", err)
+	}
+	// Let the sessions cache TTL lapse so the next detail() refetches and bumps
+	// the sessions version, changing the memo key even though the fold is
+	// unchanged.
+	time.Sleep(40 * time.Millisecond)
+	if _, _, err := tl.detail(ctx, "run1"); err != nil {
+		t.Fatalf("second detail: %v", err)
+	}
+	if builds := detailBuildCount.Load() - before; builds != 2 {
+		t.Fatalf("builds = %d, want 2 (a sessions-version bump must rebuild)", builds)
+	}
+}
+
+// TestRunDetailServedBytesEqualFreshMarshal proves the served HTTP body equals a
+// fresh json.Marshal(detail) of the memoized DTO plus the single trailing
+// newline the JSON encoder emits — i.e. writeJSONBytes is byte-identical to the
+// old writeJSON(w, detail) path.
+func TestRunDetailServedBytesEqualFreshMarshal(t *testing.T) {
+	p, tl := warmRunTailer(t, "alpha",
+		runDetailRootEvent(),
+		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
+	)
+
+	// The memoized value carries both the DTO and its bytes.
+	value, ready, err := tl.detail(context.Background(), "run1")
+	if err != nil || !ready {
+		t.Fatalf("detail: err=%v ready=%v", err, ready)
+	}
+	fresh, err := json.Marshal(value.detail)
+	if err != nil {
+		t.Fatalf("marshal detail: %v", err)
+	}
+	if !bytes.Equal(value.bytes, fresh) {
+		t.Fatalf("memoized bytes != fresh json.Marshal(detail):\n%s\nvs\n%s", value.bytes, fresh)
+	}
+
+	// The served HTTP body is the memoized bytes + one trailing newline (the
+	// encoder's), matching the pre-memo writeJSON path byte-for-byte.
+	rec := getRunDetailRaw(t, p, "alpha", "run1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	want := append(append([]byte{}, fresh...), '\n')
+	if !bytes.Equal(rec.Body.Bytes(), want) {
+		t.Fatalf("served body != json.Marshal(detail)+\"\\n\":\n%q\nvs\n%q", rec.Body.Bytes(), want)
+	}
+}
+
+// TestRunDetailMemoConcurrentSingleBuild proves N concurrent detail() calls for
+// the same run at the same generation build exactly once (single-flight) and all
+// return byte-identical results. Run under -race, it also proves the memo is
+// race-clean.
+func TestRunDetailMemoConcurrentSingleBuild(t *testing.T) {
+	_, tl := warmRunTailer(t, "alpha",
+		runDetailRootEvent(),
+		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
+	)
+	ctx := context.Background()
+
+	before := detailBuildCount.Load()
+	const n = 12
+	var wg sync.WaitGroup
+	results := make([][]byte, n)
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			v, _, err := tl.detail(ctx, "run1")
+			results[i], errs[i] = v.bytes, err
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range errs {
+		if errs[i] != nil {
+			t.Fatalf("concurrent detail[%d]: %v", i, errs[i])
+		}
+	}
+	if builds := detailBuildCount.Load() - before; builds != 1 {
+		t.Fatalf("builds = %d across %d concurrent same-generation calls, want 1 (single-flight)", builds, n)
+	}
+	for i := 1; i < n; i++ {
+		if !bytes.Equal(results[0], results[i]) {
+			t.Fatalf("concurrent result[%d] differs from result[0]", i)
+		}
+	}
+}
+
+// TestRunDetailMemoEvictsLRU proves the memo is bounded: once more distinct
+// generations than the cap are inserted, the oldest is evicted (a re-request of
+// it rebuilds). Uses a tiny cap so a few generations force eviction.
+func TestRunDetailMemoEvictsLRU(t *testing.T) {
+	defer func(prev int) { runDetailMemoCap = prev }(runDetailMemoCap)
+	runDetailMemoCap = 2
+	m := newRunDetailMemo()
+
+	build := func(seq uint64) func() (runDetailMemoValue, error) {
+		return func() (runDetailMemoValue, error) {
+			detailBuildCount.Add(1)
+			return runDetailMemoValue{bytes: []byte{byte(seq)}}, nil
+		}
+	}
+	key := func(seq uint64) runDetailMemoKey { return runDetailMemoKey{runID: "run1", lastSeq: seq} }
+
+	before := detailBuildCount.Load()
+	// Fill: generations 1 and 2 (cap=2).
+	if _, err := m.getOrBuild(key(1), build(1)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.getOrBuild(key(2), build(2)); err != nil {
+		t.Fatal(err)
+	}
+	// Generation 3 evicts the least-recently-used (generation 1).
+	if _, err := m.getOrBuild(key(3), build(3)); err != nil {
+		t.Fatal(err)
+	}
+	// Generation 2 is still cached (no rebuild).
+	if _, err := m.getOrBuild(key(2), build(2)); err != nil {
+		t.Fatal(err)
+	}
+	// Generation 1 was evicted → rebuild.
+	if _, err := m.getOrBuild(key(1), build(1)); err != nil {
+		t.Fatal(err)
+	}
+	// Builds: gen1, gen2, gen3, (gen2 hit), gen1-rebuild = 4.
+	if builds := detailBuildCount.Load() - before; builds != 4 {
+		t.Fatalf("builds = %d, want 4 (gen2 cached, evicted gen1 rebuilt)", builds)
+	}
+}
+
+// currentLastSeq reads the tailer's published fold cursor under its lock.
+func currentLastSeq(tl *cityRunTailer) uint64 {
+	tl.mu.RLock()
+	defer tl.mu.RUnlock()
+	return tl.lastSeq
+}
+
+// waitForLastSeqAbove blocks until the tailer's lastSeq advances past prev.
+func waitForLastSeqAbove(t *testing.T, tl *cityRunTailer, prev uint64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if currentLastSeq(tl) > prev {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("lastSeq did not advance past %d within deadline (now %d)", prev, currentLastSeq(tl))
+}

--- a/internal/api/dashboardbff/runtailer.go
+++ b/internal/api/dashboardbff/runtailer.go
@@ -349,6 +349,16 @@ func (t *cityRunTailer) detail(ctx context.Context, runID string) (runproj.Formu
 	ready := t.ready
 	t.mu.RUnlock()
 
+	// Fold the run ONCE: the snapshot serves both the formula-target extraction
+	// (which formula to fetch) and the build. The old path scanned the city's
+	// beads twice — RunFormulaTargetForRun at version/seq 0, then
+	// BuildRunDetailWithSessionsAndFormula at the real version/seq — for identical
+	// (name,target,scope), since those are snapshot-identity-independent fields.
+	snap, err := runproj.SnapshotForRun(beadSlice, runID, runDetailSnapshotVersion, int64(lastSeq))
+	if err != nil {
+		return runproj.FormulaRunDetail{}, ready, err
+	}
+
 	sessions, sessionsAvailable := t.mgr.fetchSessions(ctx, t.name)
 
 	// Layer the supervisor's compiled formula detail at request time (like
@@ -362,7 +372,7 @@ func (t *cityRunTailer) detail(ctx context.Context, runID string) (runproj.Formu
 	// into a generic upstream error.
 	var formulaDetail *runproj.FormulaOrderingDetail
 	formulaDetailFailure := runproj.FormulaDetailUpstreamError
-	if name, target, scopeKind, scopeRef, ok := runproj.RunFormulaTargetForRun(beadSlice, runID); ok {
+	if name, target, scopeKind, scopeRef, ok := runproj.FormulaTargetFromSnapshot(snap); ok {
 		if fetched, failure, fetchedOK := t.mgr.fetchFormulaDetail(ctx, t.name, name, target, scopeKind, scopeRef); fetchedOK {
 			formulaDetail = fetched
 		} else {
@@ -370,15 +380,10 @@ func (t *cityRunTailer) detail(ctx context.Context, runID string) (runproj.Formu
 		}
 	}
 
-	var (
-		d   runproj.FormulaRunDetail
-		err error
-	)
-	if sessionsAvailable {
-		d, err = runproj.BuildRunDetailWithSessionsAndFormula(beadSlice, runID, runDetailSnapshotVersion, int64(lastSeq), sessions, formulaDetail, formulaDetailFailure)
-	} else {
-		d, err = runproj.BuildRunDetailWithSessionsAndFormula(beadSlice, runID, runDetailSnapshotVersion, int64(lastSeq), nil, formulaDetail, formulaDetailFailure)
+	if !sessionsAvailable {
+		sessions = nil
 	}
+	d, err := runproj.BuildRunDetailFromSnapshot(snap, sessions, formulaDetail, formulaDetailFailure)
 	return d, ready, err
 }
 

--- a/internal/api/dashboardbff/runtailer.go
+++ b/internal/api/dashboardbff/runtailer.go
@@ -87,7 +87,7 @@ func (m *runTailerManager) ensure(name, eventsPath string) *cityRunTailer {
 	defer m.mu.Unlock()
 	t, ok := m.cities[name]
 	if !ok {
-		t = &cityRunTailer{name: name, eventsPath: eventsPath, mgr: m, readyCh: make(chan struct{}), detailMemo: newRunDetailMemo()}
+		t = &cityRunTailer{name: name, eventsPath: eventsPath, mgr: m, readyCh: make(chan struct{}), snapshotCache: newRunSnapshotCache(), detailMemo: newRunDetailMemo()}
 		m.cities[name] = t
 	}
 	if m.enabled && m.ctx != nil && !t.started {
@@ -111,10 +111,13 @@ type cityRunTailer struct {
 	started bool
 	readyCh chan struct{} // closed once the cold replay attempt completes
 
-	// detailMemo caches the built+marshaled run detail per fold generation so an
-	// unchanged fold costs ~zero CPU (no re-projection, no re-marshal). See
-	// rundetail_memo.go.
-	detailMemo *runDetailMemo
+	// snapshotCache caches the folded run snapshot (and the formula target
+	// derived from it) per fold generation so a same-generation repeat request
+	// reuses the fold instead of re-scanning the city's beads. detailMemo then
+	// caches the built+marshaled detail on top, so an unchanged fold costs ~zero
+	// CPU (no re-scan, no re-projection, no re-marshal). See rundetail_memo.go.
+	snapshotCache *runSnapshotCache
+	detailMemo    *runDetailMemo
 
 	mu      sync.RWMutex
 	summary runproj.RunSummary
@@ -338,9 +341,15 @@ func (t *cityRunTailer) build(proj *runproj.Projector, prevMarks map[string]runp
 const runDetailSnapshotVersion = 1
 
 // detailBuildCount counts every run-detail build+marshal the tailer performs
-// (i.e. a memo miss). It exists so a test can prove two requests at the same fold
-// generation build once. It carries no production behavior.
+// (i.e. a detail-memo miss). It exists so a test can prove two requests at the
+// same fold generation build once. It carries no production behavior.
 var detailBuildCount atomic.Int64
+
+// snapshotFoldCount counts every run-snapshot fold the detail path performs
+// (i.e. a snapshot-cache miss). It exists so a test can prove repeated detail()
+// calls at the same fold generation fold the run exactly once — a same-generation
+// hit must not re-scan the city's beads. It carries no production behavior.
+var snapshotFoldCount atomic.Int64
 
 // detail projects one run into the run-detail DTO off the warm bead snapshot,
 // layering request-time session links from one loopback /v0 sessions read. It
@@ -348,11 +357,15 @@ var detailBuildCount atomic.Int64
 // enrichedSummary. The bool reports whether the cold replay had completed (a
 // not-found run during warming is reported as warming, not a hard 404).
 //
-// The result is memoized per fold generation: keyed by (runID, lastSeq,
-// sessions-version, formula-version+failure), a repeat request whose fold and
-// enrichments have not changed returns the cached DTO and its marshaled bytes
-// with zero re-projection and zero re-marshal. A new bead event (lastSeq++) or a
-// bumped enrichment version yields a new key → a miss → a rebuild.
+// Two caches keyed on the fold generation make a same-generation repeat cheap.
+// The snapshot cache (keyed by runID+lastSeq) folds the run's beads once per
+// generation and serves the fold + formula target to every later request, so a
+// repeat poll re-scans nothing. The detail memo (keyed by runID+lastSeq+
+// sessions-version+formula-version/failure) then caches the built+marshaled DTO,
+// so an unchanged fold with unchanged enrichments returns the cached bytes with
+// zero re-scan, zero re-projection, and zero re-marshal. A new bead event
+// (lastSeq++) invalidates both; a bumped enrichment version invalidates only the
+// detail memo (the fold is reused) → a rebuild off the cached snapshot.
 func (t *cityRunTailer) detail(ctx context.Context, runID string) (runDetailMemoValue, bool, error) {
 	select {
 	case <-t.readyCh:
@@ -366,12 +379,25 @@ func (t *cityRunTailer) detail(ctx context.Context, runID string) (runDetailMemo
 	ready := t.ready
 	t.mu.RUnlock()
 
-	// Fold the run ONCE: the snapshot serves both the formula-target extraction
-	// (which formula to fetch) and the build. The old path scanned the city's
-	// beads twice — RunFormulaTargetForRun at version/seq 0, then
-	// BuildRunDetailWithSessionsAndFormula at the real version/seq — for identical
-	// (name,target,scope), since those are snapshot-identity-independent fields.
-	snap, err := runproj.SnapshotForRun(beadSlice, runID, runDetailSnapshotVersion, int64(lastSeq))
+	// Fold the run's snapshot ONCE per fold generation and cache it: the snapshot
+	// serves both the formula-target extraction (which formula to fetch) and the
+	// build, and a same-generation repeat request (the hot dashboard poll) reuses
+	// it with no re-scan. The old path scanned the city's beads on EVERY request —
+	// even a detail-memo hit re-ran SnapshotForRun before the memo lookup — so the
+	// single-scan win only spanned distinct requests, never repeat polls at the
+	// same generation. SnapshotForRun still returns an error only when the run root
+	// is absent, which stays uncached so a run that appears in a later fold folds
+	// then instead of pinning a not-found.
+	snapKey := runSnapshotCacheKey{runID: runID, lastSeq: lastSeq}
+	snapValue, err := t.snapshotCache.getOrBuild(snapKey, func() (runSnapshotCacheValue, error) {
+		snap, buildErr := runproj.SnapshotForRun(beadSlice, runID, runDetailSnapshotVersion, int64(lastSeq))
+		if buildErr != nil {
+			return runSnapshotCacheValue{}, buildErr
+		}
+		snapshotFoldCount.Add(1)
+		name, target, scopeKind, scopeRef, ok := runproj.FormulaTargetFromSnapshot(snap)
+		return runSnapshotCacheValue{snap: snap, name: name, target: target, scopeKind: scopeKind, scopeRef: scopeRef, targetOK: ok}, nil
+	})
 	if err != nil {
 		return runDetailMemoValue{}, ready, err
 	}
@@ -396,8 +422,8 @@ func (t *cityRunTailer) detail(ctx context.Context, runID string) (runDetailMemo
 	var formulaDetail *runproj.FormulaOrderingDetail
 	formulaDetailFailure := runproj.FormulaDetailUpstreamError
 	var formulaVersion uint64
-	if name, target, scopeKind, scopeRef, ok := runproj.FormulaTargetFromSnapshot(snap); ok {
-		if fetched, failure, version, fetchedOK := t.mgr.fetchFormulaDetailVersioned(ctx, t.name, name, target, scopeKind, scopeRef); fetchedOK {
+	if snapValue.targetOK {
+		if fetched, failure, version, fetchedOK := t.mgr.fetchFormulaDetailVersioned(ctx, t.name, snapValue.name, snapValue.target, snapValue.scopeKind, snapValue.scopeRef); fetchedOK {
 			formulaDetail = fetched
 			formulaVersion = version
 		} else {
@@ -418,7 +444,7 @@ func (t *cityRunTailer) detail(ctx context.Context, runID string) (runDetailMemo
 		formulaFailure:  formulaDetailFailure,
 	}
 	value, err := t.detailMemo.getOrBuild(key, func() (runDetailMemoValue, error) {
-		d, buildErr := runproj.BuildRunDetailFromSnapshot(snap, sessions, formulaDetail, formulaDetailFailure)
+		d, buildErr := runproj.BuildRunDetailFromSnapshot(snapValue.snap, sessions, formulaDetail, formulaDetailFailure)
 		if buildErr != nil {
 			return runDetailMemoValue{}, buildErr
 		}

--- a/internal/api/dashboardbff/runtailer.go
+++ b/internal/api/dashboardbff/runtailer.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -86,7 +87,7 @@ func (m *runTailerManager) ensure(name, eventsPath string) *cityRunTailer {
 	defer m.mu.Unlock()
 	t, ok := m.cities[name]
 	if !ok {
-		t = &cityRunTailer{name: name, eventsPath: eventsPath, mgr: m, readyCh: make(chan struct{})}
+		t = &cityRunTailer{name: name, eventsPath: eventsPath, mgr: m, readyCh: make(chan struct{}), detailMemo: newRunDetailMemo()}
 		m.cities[name] = t
 	}
 	if m.enabled && m.ctx != nil && !t.started {
@@ -109,6 +110,11 @@ type cityRunTailer struct {
 
 	started bool
 	readyCh chan struct{} // closed once the cold replay attempt completes
+
+	// detailMemo caches the built+marshaled run detail per fold generation so an
+	// unchanged fold costs ~zero CPU (no re-projection, no re-marshal). See
+	// rundetail_memo.go.
+	detailMemo *runDetailMemo
 
 	mu      sync.RWMutex
 	summary runproj.RunSummary
@@ -331,12 +337,23 @@ func (t *cityRunTailer) build(proj *runproj.Projector, prevMarks map[string]runp
 // snapshot_version). It matches the golden generator's snapshot_version.
 const runDetailSnapshotVersion = 1
 
+// detailBuildCount counts every run-detail build+marshal the tailer performs
+// (i.e. a memo miss). It exists so a test can prove two requests at the same fold
+// generation build once. It carries no production behavior.
+var detailBuildCount atomic.Int64
+
 // detail projects one run into the run-detail DTO off the warm bead snapshot,
 // layering request-time session links from one loopback /v0 sessions read. It
 // waits briefly for the cold replay on a city's first request, like
 // enrichedSummary. The bool reports whether the cold replay had completed (a
 // not-found run during warming is reported as warming, not a hard 404).
-func (t *cityRunTailer) detail(ctx context.Context, runID string) (runproj.FormulaRunDetail, bool, error) {
+//
+// The result is memoized per fold generation: keyed by (runID, lastSeq,
+// sessions-version, formula-version+failure), a repeat request whose fold and
+// enrichments have not changed returns the cached DTO and its marshaled bytes
+// with zero re-projection and zero re-marshal. A new bead event (lastSeq++) or a
+// bumped enrichment version yields a new key → a miss → a rebuild.
+func (t *cityRunTailer) detail(ctx context.Context, runID string) (runDetailMemoValue, bool, error) {
 	select {
 	case <-t.readyCh:
 	case <-ctx.Done():
@@ -356,10 +373,16 @@ func (t *cityRunTailer) detail(ctx context.Context, runID string) (runproj.Formu
 	// (name,target,scope), since those are snapshot-identity-independent fields.
 	snap, err := runproj.SnapshotForRun(beadSlice, runID, runDetailSnapshotVersion, int64(lastSeq))
 	if err != nil {
-		return runproj.FormulaRunDetail{}, ready, err
+		return runDetailMemoValue{}, ready, err
 	}
 
-	sessions, sessionsAvailable := t.mgr.fetchSessions(ctx, t.name)
+	// Resolve the request-time sessions enrichment and its cache version. The
+	// version (0 when unavailable) is part of the memo key so a sessions refresh —
+	// or an availability flip — rebuilds.
+	sessions, sessionsVersion, sessionsAvailable := t.mgr.fetchSessionsVersioned(ctx, t.name)
+	if !sessionsAvailable {
+		sessions = nil
+	}
 
 	// Layer the supervisor's compiled formula detail at request time (like
 	// sessions) so a graph.v2 run with a name+target resolves to the authored
@@ -372,19 +395,41 @@ func (t *cityRunTailer) detail(ctx context.Context, runID string) (runproj.Formu
 	// into a generic upstream error.
 	var formulaDetail *runproj.FormulaOrderingDetail
 	formulaDetailFailure := runproj.FormulaDetailUpstreamError
+	var formulaVersion uint64
 	if name, target, scopeKind, scopeRef, ok := runproj.FormulaTargetFromSnapshot(snap); ok {
-		if fetched, failure, fetchedOK := t.mgr.fetchFormulaDetail(ctx, t.name, name, target, scopeKind, scopeRef); fetchedOK {
+		if fetched, failure, version, fetchedOK := t.mgr.fetchFormulaDetailVersioned(ctx, t.name, name, target, scopeKind, scopeRef); fetchedOK {
 			formulaDetail = fetched
+			formulaVersion = version
 		} else {
 			formulaDetailFailure = failure
+			formulaVersion = version
 		}
 	}
 
-	if !sessionsAvailable {
-		sessions = nil
+	// Everything that determines the output is now captured in the key. On a hit
+	// the memo returns the cached DTO+bytes with zero re-projection and zero
+	// re-marshal; on a miss it builds once (single-flighted across concurrent
+	// callers), marshals once, stores, and returns.
+	key := runDetailMemoKey{
+		runID:           runID,
+		lastSeq:         lastSeq,
+		sessionsVersion: sessionsVersion,
+		formulaVersion:  formulaVersion,
+		formulaFailure:  formulaDetailFailure,
 	}
-	d, err := runproj.BuildRunDetailFromSnapshot(snap, sessions, formulaDetail, formulaDetailFailure)
-	return d, ready, err
+	value, err := t.detailMemo.getOrBuild(key, func() (runDetailMemoValue, error) {
+		d, buildErr := runproj.BuildRunDetailFromSnapshot(snap, sessions, formulaDetail, formulaDetailFailure)
+		if buildErr != nil {
+			return runDetailMemoValue{}, buildErr
+		}
+		detailBuildCount.Add(1)
+		raw, marshalErr := json.Marshal(d)
+		if marshalErr != nil {
+			return runDetailMemoValue{}, marshalErr
+		}
+		return runDetailMemoValue{detail: d, bytes: raw}, nil
+	})
+	return value, ready, err
 }
 
 // enrichedSummary returns the warm bead-derived summary with request-time
@@ -419,7 +464,17 @@ func (t *cityRunTailer) enrichedSummary(ctx context.Context) runproj.RunSummary 
 // the caller's honest partial/warming states are preserved. detail() and
 // enrichedSummary() consume this.
 func (m *runTailerManager) fetchSessions(ctx context.Context, name string) ([]runproj.DashboardSession, bool) {
-	got, ok := m.sessionsCache.get(ctx, name, func(ctx context.Context) (cachedSessions, time.Duration, bool, bool) {
+	items, _, ok := m.fetchSessionsVersioned(ctx, name)
+	return items, ok
+}
+
+// fetchSessionsVersioned is fetchSessions with the served value's cache version,
+// so the run-detail memo can key on it and rebuild when the sessions enrichment
+// refreshes (even to an equal value). The version is meaningful only when ok is
+// true. detail() consumes this; enrichedSummary() uses the version-less
+// fetchSessions.
+func (m *runTailerManager) fetchSessionsVersioned(ctx context.Context, name string) ([]runproj.DashboardSession, uint64, bool) {
+	got, version, ok := m.sessionsCache.getWithVersion(ctx, name, func(ctx context.Context) (cachedSessions, time.Duration, bool, bool) {
 		items, upstreamOK := m.fetchSessionsUpstream(ctx, name)
 		if !upstreamOK {
 			return cachedSessions{}, 0, false, false
@@ -429,9 +484,9 @@ func (m *runTailerManager) fetchSessions(ctx context.Context, name string) ([]ru
 		return cachedSessions{items: items}, sessionsCacheTTL, true, true
 	})
 	if !ok {
-		return nil, false
+		return nil, 0, false
 	}
-	return got.items, true
+	return got.items, version, true
 }
 
 // fetchSessionsUpstream reads GET {base}/v0/city/{name}/sessions over loopback
@@ -478,18 +533,25 @@ type formulaNodeRef struct {
 	ID string `json:"id"`
 }
 
-// fetchFormulaDetail returns a run's compiled formula detail, served from the
-// per-city formula cache keyed by (name, formula, target, scopeKind, scopeRef).
-// A success is cached for formulaCacheTTL; a definitive 404 (genuinely-missing
-// formula) is cached as FormulaDetailNotFound for the shorter formulaNotFoundTTL
-// so a newly-added formula appears promptly; a transient upstream error is NOT
-// cached — it degrades like a cold miss so a real re-check happens on the next
-// GET. On success it returns (detail, "", true); on a failure it returns
-// (nil, reason, false), preserving the NotFound vs UpstreamError distinction
-// runproj renders as the operator diagnostic. detail() consumes this.
-func (m *runTailerManager) fetchFormulaDetail(ctx context.Context, name, formula, target, scopeKind, scopeRef string) (*runproj.FormulaOrderingDetail, runproj.RunFormulaDetailFetchFailure, bool) {
+// fetchFormulaDetailVersioned returns a run's compiled formula detail, served
+// from the per-city formula cache keyed by (name, formula, target, scopeKind,
+// scopeRef). A success is cached for formulaCacheTTL; a definitive 404
+// (genuinely-missing formula) is cached as FormulaDetailNotFound for the shorter
+// formulaNotFoundTTL so a newly-added formula appears promptly; a transient
+// upstream error is NOT cached — it degrades like a cold miss so a real re-check
+// happens on the next GET. On success it returns (detail, "", version, true); on
+// a failure it returns (nil, reason, version, false), preserving the NotFound vs
+// UpstreamError distinction runproj renders as the operator diagnostic.
+//
+// The version is the served cache entry's monotonic generation, so the
+// run-detail memo rebuilds when the compiled formula refreshes (a re-compile, a
+// not-found→available flip, or a re-check). It is meaningful whenever a cache
+// entry was served — including a served negative (a cached not-found), since a
+// negative→available transition bumps it. A cold-miss degrade returns version 0.
+// detail() consumes this.
+func (m *runTailerManager) fetchFormulaDetailVersioned(ctx context.Context, name, formula, target, scopeKind, scopeRef string) (*runproj.FormulaOrderingDetail, runproj.RunFormulaDetailFetchFailure, uint64, bool) {
 	key := formulaCacheKey{name: name, formula: formula, target: target, scopeKind: scopeKind, scopeRef: scopeRef}
-	got, ok := m.formulaCache.get(ctx, key, func(ctx context.Context) (cachedFormulaDetail, time.Duration, bool, bool) {
+	got, version, ok := m.formulaCache.getWithVersion(ctx, key, func(ctx context.Context) (cachedFormulaDetail, time.Duration, bool, bool) {
 		detail, failure, upstreamOK := m.fetchFormulaDetailUpstream(ctx, name, formula, target, scopeKind, scopeRef)
 		switch {
 		case upstreamOK:
@@ -511,7 +573,7 @@ func (m *runTailerManager) fetchFormulaDetail(ctx context.Context, name, formula
 	if !ok {
 		// Cold miss whose fetch failed with a non-404 error, or a canceled join
 		// with no last-good: the honest reason is upstream_error.
-		return nil, runproj.FormulaDetailUpstreamError, false
+		return nil, runproj.FormulaDetailUpstreamError, 0, false
 	}
 	if got.detail == nil {
 		// A cached not-found (or a cached-then-served negative): not available, and
@@ -520,9 +582,9 @@ func (m *runTailerManager) fetchFormulaDetail(ctx context.Context, name, formula
 		if failure == "" {
 			failure = runproj.FormulaDetailUpstreamError
 		}
-		return nil, failure, false
+		return nil, failure, version, false
 	}
-	return got.detail, "", true
+	return got.detail, "", version, true
 }
 
 // fetchFormulaDetailUpstream reads
@@ -629,7 +691,7 @@ func (p *Plane) registerRunDetail() {
 			writeError(w, http.StatusNotFound, "unknown city")
 			return
 		}
-		detail, ready, err := t.detail(r.Context(), r.PathValue("runId"))
+		value, ready, err := t.detail(r.Context(), r.PathValue("runId"))
 		if err != nil {
 			var unsupported *runproj.UnsupportedRunError
 			if errors.As(err, &unsupported) {
@@ -655,7 +717,11 @@ func (p *Plane) registerRunDetail() {
 			writeError(w, http.StatusNotFound, "unknown run")
 			return
 		}
-		writeJSON(w, http.StatusOK, detail)
+		// Serve the memoized marshaled bytes verbatim — the memo already produced
+		// json.Marshal(detail), so writeJSONBytes skips a re-marshal while emitting
+		// byte-identical output to writeJSON (same headers, same trailing newline
+		// the JSON encoder appends).
+		writeJSONBytes(w, http.StatusOK, value.bytes)
 	})
 }
 

--- a/internal/api/dashboardbff/runtailer.go
+++ b/internal/api/dashboardbff/runtailer.go
@@ -587,6 +587,14 @@ func (m *runTailerManager) fetchFormulaDetailVersioned(ctx context.Context, name
 	return got.detail, "", version, true
 }
 
+// fetchFormulaDetail preserves the pre-refactor 3-tuple call shape for tests
+// and older internal call sites while the versioned cache API remains the
+// implementation behind it.
+func (m *runTailerManager) fetchFormulaDetail(ctx context.Context, name, formula, target, scopeKind, scopeRef string) (*runproj.FormulaOrderingDetail, runproj.RunFormulaDetailFetchFailure, bool) { //nolint:unparam
+	detail, failure, _, ok := m.fetchFormulaDetailVersioned(ctx, name, formula, target, scopeKind, scopeRef)
+	return detail, failure, ok
+}
+
 // fetchFormulaDetailUpstream reads
 // GET {base}/v0/city/{name}/formulas/{formula}?target={target}&scope_kind={kind}&scope_ref={ref}
 // over loopback and projects the compiled formula's ordering-relevant preview

--- a/internal/runproj/detail.go
+++ b/internal/runproj/detail.go
@@ -3,10 +3,89 @@ package runproj
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 )
+
+// snapshotScanCount counts every snapshotForRun invocation. It exists so a test
+// can prove the single-scan entry points fold a run exactly once (the detail
+// path used to scan twice — once for the formula target, once for the build).
+// It carries no production behavior.
+var snapshotScanCount atomic.Int64
+
+// RunSnapshot is an opaque, already-computed run snapshot. It lets a caller fold
+// a run's beads ONCE (SnapshotForRun) and then serve both the formula-target
+// extraction (FormulaTargetFromSnapshot) and the full detail build
+// (BuildRunDetailFromSnapshot) off that single scan, instead of re-scanning the
+// city's beads per operation. The internal shape stays package-private; callers
+// treat the value as a token.
+type RunSnapshot struct {
+	raw runSnapshot
+}
+
+// SnapshotForRun folds beadList into the run rooted at runID exactly once,
+// returning an opaque snapshot both FormulaTargetFromSnapshot and
+// BuildRunDetailFromSnapshot consume. version and eventSeq parameterize the
+// snapshot identity (the golden passes 1/100; the live tailer passes a real
+// version and its LastSeq cursor). It returns an error only when the run root is
+// absent from beadList.
+func SnapshotForRun(beadList []beads.Bead, runID string, version int, eventSeq int64) (RunSnapshot, error) {
+	raw, err := snapshotForRun(beadList, runID, version, eventSeq)
+	if err != nil {
+		return RunSnapshot{}, err
+	}
+	return RunSnapshot{raw: raw}, nil
+}
+
+// FormulaTargetFromSnapshot resolves the compiled-formula name, preview target,
+// and run scope from an already-computed snapshot, applying the exact identity
+// and scope resolution RunFormulaTargetForRun applies. ok is false when the run
+// is not a fetchable graph.v2 run, lacks a formula name+target, or has no valid
+// scope.
+//
+// The resolution reads only version/seq-INDEPENDENT snapshot fields (the root
+// bead's formula metadata and the scope kind/ref/root-store-ref), so a snapshot
+// built with a real version/eventSeq yields the same target a zero-version
+// snapshot would — the invariant that lets detail() fold once and serve both.
+func FormulaTargetFromSnapshot(snap RunSnapshot) (name, target, scopeKind, scopeRef string, ok bool) {
+	return formulaTargetFromSnapshot(snap.raw)
+}
+
+// BuildRunDetailFromSnapshot projects an already-computed snapshot into the
+// run-detail DTO, layering the optional request-time sessions and compiled
+// formula detail (both nil on the golden path). It is the single-scan analog of
+// BuildRunDetailWithSessionsAndFormula: same inputs, same output, but off a
+// snapshot the caller already folded. fetchFailure records why a live
+// formula-detail fetch failed when formulaDetail is nil (empty defaults to
+// upstream_error).
+func BuildRunDetailFromSnapshot(snap RunSnapshot, sessions []DashboardSession, formulaDetail *FormulaOrderingDetail, fetchFailure RunFormulaDetailFetchFailure) (FormulaRunDetail, error) {
+	return enrichFormulaRun(snap.raw, sessions, formulaDetail.toInput(), fetchFailure)
+}
+
+// BuildRunDetailForRun folds a run ONCE and returns both the detail DTO and the
+// run's compiled-formula target in one scan. It is the combined entry point the
+// dashboard BFF uses: previously detail() scanned the run twice (once via
+// RunFormulaTargetForRun to decide which formula to fetch, once via
+// BuildRunDetailWithSessionsAndFormula to build), which this collapses to a
+// single snapshotForRun.
+//
+// The (name, target, scopeKind, scopeRef, targetOK) return is the formula target
+// resolved off the SAME snapshot as the detail, so it equals what
+// RunFormulaTargetForRun would report for the run. The caller fetches the
+// compiled formula from that target and passes it back in on the next request's
+// build (the formula detail is request-time enrichment, layered per build, not
+// carried in the snapshot).
+func BuildRunDetailForRun(beadList []beads.Bead, runID string, version int, eventSeq int64, sessions []DashboardSession, formulaDetail *FormulaOrderingDetail, fetchFailure RunFormulaDetailFetchFailure) (detail FormulaRunDetail, name, target, scopeKind, scopeRef string, targetOK bool, err error) {
+	snap, err := SnapshotForRun(beadList, runID, version, eventSeq)
+	if err != nil {
+		return FormulaRunDetail{}, "", "", "", "", false, err
+	}
+	name, target, scopeKind, scopeRef, targetOK = FormulaTargetFromSnapshot(snap)
+	detail, err = BuildRunDetailFromSnapshot(snap, sessions, formulaDetail, fetchFailure)
+	return detail, name, target, scopeKind, scopeRef, targetOK, err
+}
 
 // UnsupportedRunReason distinguishes the expected v1/wisp case ("not_run_view" —
 // the run lists but has no graph.v2 detail) from a malformed graph.v2 snapshot
@@ -95,6 +174,15 @@ func RunFormulaTargetForRun(beadList []beads.Bead, runID string) (name, target, 
 	if err != nil {
 		return "", "", "", "", false
 	}
+	return formulaTargetFromSnapshot(snap)
+}
+
+// formulaTargetFromSnapshot is the shared formula-target resolution both
+// RunFormulaTargetForRun and FormulaTargetFromSnapshot delegate to. It reads only
+// version/seq-independent snapshot fields, so the result is identical whether the
+// snapshot was built at version=0 (the old target-only scan) or at the run's real
+// version/seq (the single-scan build).
+func formulaTargetFromSnapshot(snap runSnapshot) (name, target, scopeKind, scopeRef string, ok bool) {
 	if !isGraphV2(snap) {
 		return "", "", "", "", false
 	}
@@ -117,6 +205,7 @@ func RunFormulaTargetForRun(beadList []beads.Bead, runID string) (name, target, 
 // dependencies plus the root→member parent edges, so the detail graph renders the
 // actual step→step DAG the supervisor snapshot carried, not just parent links.
 func snapshotForRun(beadList []beads.Bead, rootID string, version int, eventSeq int64) (runSnapshot, error) {
+	snapshotScanCount.Add(1)
 	rootIdx := -1
 	for i := range beadList {
 		if beadList[i].ID == rootID {

--- a/internal/runproj/detail.go
+++ b/internal/runproj/detail.go
@@ -65,18 +65,22 @@ func BuildRunDetailFromSnapshot(snap RunSnapshot, sessions []DashboardSession, f
 }
 
 // BuildRunDetailForRun folds a run ONCE and returns both the detail DTO and the
-// run's compiled-formula target in one scan. It is the combined entry point the
-// dashboard BFF uses: previously detail() scanned the run twice (once via
-// RunFormulaTargetForRun to decide which formula to fetch, once via
-// BuildRunDetailWithSessionsAndFormula to build), which this collapses to a
-// single snapshotForRun.
+// run's compiled-formula target in one scan. It is a combined convenience entry
+// point for callers (and tests) that already hold the formula and want the
+// target plus the detail off a single fold. The dashboard BFF does NOT call it:
+// its detail() drives the same primitives directly (SnapshotForRun →
+// FormulaTargetFromSnapshot → BuildRunDetailFromSnapshot) so it can cache the
+// folded snapshot across requests and layer request-time sessions/formula
+// enrichment per build — a chicken-and-egg this combined form cannot express,
+// since it needs the fetched formula as input but only returns the target used
+// to fetch it. Keeping the composition here gives it one tested home.
 //
 // The (name, target, scopeKind, scopeRef, targetOK) return is the formula target
 // resolved off the SAME snapshot as the detail, so it equals what
-// RunFormulaTargetForRun would report for the run. The caller fetches the
-// compiled formula from that target and passes it back in on the next request's
-// build (the formula detail is request-time enrichment, layered per build, not
-// carried in the snapshot).
+// RunFormulaTargetForRun would report for the run. A caller fetches the compiled
+// formula from that target and passes it back in on a later build (the formula
+// detail is request-time enrichment, layered per build, not carried in the
+// snapshot).
 func BuildRunDetailForRun(beadList []beads.Bead, runID string, version int, eventSeq int64, sessions []DashboardSession, formulaDetail *FormulaOrderingDetail, fetchFailure RunFormulaDetailFetchFailure) (detail FormulaRunDetail, name, target, scopeKind, scopeRef string, targetOK bool, err error) {
 	snap, err := SnapshotForRun(beadList, runID, version, eventSeq)
 	if err != nil {

--- a/internal/runproj/detail_snapshot_test.go
+++ b/internal/runproj/detail_snapshot_test.go
@@ -1,0 +1,133 @@
+package runproj
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// loadDetailFixture reads the shared bead fixture used by the golden tests.
+func loadDetailFixture(t *testing.T) []beads.Bead {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", "beads_fixture.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var beadList []beads.Bead
+	if err := json.Unmarshal(raw, &beadList); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	return beadList
+}
+
+// TestFormulaTargetFromSnapshotMatchesRunFormulaTargetForRun proves the
+// single-scan formula-target extraction (off a snapshot built with the REAL
+// version/seq) resolves the exact same (name, target, scope) tuple the old
+// zero-version RunFormulaTargetForRun path did. This is the byte-identity guard
+// for Part A's key risk: the formula-target metadata read must not depend on the
+// snapshot's version/eventSeq identity fields.
+func TestFormulaTargetFromSnapshotMatchesRunFormulaTargetForRun(t *testing.T) {
+	beadList := loadDetailFixture(t)
+
+	// The old path builds its snapshot at version=0, eventSeq=0.
+	wantName, wantTarget, wantKind, wantRef, wantOK := RunFormulaTargetForRun(beadList, detailGoldenRunID)
+	if !wantOK {
+		t.Fatalf("RunFormulaTargetForRun(%q) not ok; fixture must carry a formula target", detailGoldenRunID)
+	}
+
+	// The new path builds ONE snapshot at the real version/seq and extracts the
+	// target from it.
+	snap, err := SnapshotForRun(beadList, detailGoldenRunID, detailGoldenSnapshotVersion, detailGoldenSnapshotEventSeq)
+	if err != nil {
+		t.Fatalf("SnapshotForRun: %v", err)
+	}
+	gotName, gotTarget, gotKind, gotRef, gotOK := FormulaTargetFromSnapshot(snap)
+	if gotOK != wantOK || gotName != wantName || gotTarget != wantTarget || gotKind != wantKind || gotRef != wantRef {
+		t.Fatalf("FormulaTargetFromSnapshot = (%q,%q,%q,%q,%v), want (%q,%q,%q,%q,%v) — target must be version/seq-independent",
+			gotName, gotTarget, gotKind, gotRef, gotOK, wantName, wantTarget, wantKind, wantRef, wantOK)
+	}
+}
+
+// TestBuildRunDetailFromSnapshotMatchesGolden proves detail built off the shared
+// single snapshot is byte-identical to the two-call golden path.
+func TestBuildRunDetailFromSnapshotMatchesGolden(t *testing.T) {
+	beadList := loadDetailFixture(t)
+
+	snap, err := SnapshotForRun(beadList, detailGoldenRunID, detailGoldenSnapshotVersion, detailGoldenSnapshotEventSeq)
+	if err != nil {
+		t.Fatalf("SnapshotForRun: %v", err)
+	}
+	fromSnap, err := BuildRunDetailFromSnapshot(snap, nil, nil, FormulaDetailUpstreamError)
+	if err != nil {
+		t.Fatalf("BuildRunDetailFromSnapshot: %v", err)
+	}
+	gotSnap, err := canonicalJSON(fromSnap)
+	if err != nil {
+		t.Fatalf("marshal from-snapshot detail: %v", err)
+	}
+
+	want, err := os.ReadFile(filepath.Join("testdata", "rundetail_golden.json"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(gotSnap, want) {
+		t.Errorf("BuildRunDetailFromSnapshot does not match golden:\n%s", unifiedDiff(string(want), string(gotSnap)))
+	}
+
+	// And it equals the two-call BuildRunDetail byte-for-byte.
+	twoCall, err := BuildRunDetail(beadList, detailGoldenRunID, detailGoldenSnapshotVersion, detailGoldenSnapshotEventSeq)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+	gotTwo, err := canonicalJSON(twoCall)
+	if err != nil {
+		t.Fatalf("marshal two-call detail: %v", err)
+	}
+	if !bytes.Equal(gotSnap, gotTwo) {
+		t.Errorf("from-snapshot detail differs from two-call detail:\n%s", unifiedDiff(string(gotTwo), string(gotSnap)))
+	}
+}
+
+// TestBuildRunDetailForRunScansOnce proves the combined single-scan entry point
+// runs snapshotForRun exactly once, unlike the old detail() path that scanned
+// twice (once for the formula target, once for the build).
+func TestBuildRunDetailForRunScansOnce(t *testing.T) {
+	beadList := loadDetailFixture(t)
+
+	before := snapshotScanCount.Load()
+	detail, name, target, scopeKind, scopeRef, targetOK, err := BuildRunDetailForRun(
+		beadList, detailGoldenRunID, detailGoldenSnapshotVersion, detailGoldenSnapshotEventSeq,
+		nil, nil, FormulaDetailUpstreamError,
+	)
+	if err != nil {
+		t.Fatalf("BuildRunDetailForRun: %v", err)
+	}
+	scans := snapshotScanCount.Load() - before
+	if scans != 1 {
+		t.Fatalf("snapshotForRun ran %d times per BuildRunDetailForRun, want exactly 1", scans)
+	}
+
+	// The combined entry returns the same target the standalone resolver does.
+	wantName, wantTarget, wantKind, wantRef, wantOK := RunFormulaTargetForRun(beadList, detailGoldenRunID)
+	if targetOK != wantOK || name != wantName || target != wantTarget || scopeKind != wantKind || scopeRef != wantRef {
+		t.Fatalf("combined target = (%q,%q,%q,%q,%v), want (%q,%q,%q,%q,%v)",
+			name, target, scopeKind, scopeRef, targetOK, wantName, wantTarget, wantKind, wantRef, wantOK)
+	}
+
+	// And its detail is byte-identical to the golden.
+	got, err := canonicalJSON(detail)
+	if err != nil {
+		t.Fatalf("marshal combined detail: %v", err)
+	}
+	want, err := os.ReadFile(filepath.Join("testdata", "rundetail_golden.json"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("BuildRunDetailForRun detail does not match golden:\n%s", unifiedDiff(string(want), string(got)))
+	}
+}


### PR DESCRIPTION
## What

Phase 2 of making run detail extremely fast + event-first (stacked on #3935). Two server-side wins on the BFF plane, both **byte-identical** to today's output.

**A — single run-snapshot scan.** `detail()` computed the run's snapshot **twice** per request (once in `RunFormulaTargetForRun` at version/seq 0, once in `BuildRunDetailWithSessionsAndFormula` at the real version/seq). New opaque `RunSnapshot` + `SnapshotForRun` / `FormulaTargetFromSnapshot` / `BuildRunDetailFromSnapshot` let `detail()` scan **once** and serve both the formula-target decision and the build off it. The old entry points stay (other callers/tests use them); `RunFormulaTargetForRun` now delegates to the shared resolver.

**B — memoize the built detail + its marshaled bytes.** A small bounded (`cap=128`) per-tailer LRU keyed `(runID, lastSeq, sessionsVersion, formulaVersion, formulaFailure)` — every input that determines the bytes — with single-flight so concurrent misses build once. `singleFlightCache` gained a monotonic `version` (bumps only on a successful compute-and-store) so a session/formula refresh invalidates the memo key. The GET handler serves the memoized bytes via `writeJSONBytes` (skips a re-marshal). An unchanged fold ⇒ zero re-projection + zero re-marshal. This is the groundwork Phase 4's SSE push reuses: the `(runID, lastSeq, versions)` key **is** the byte-dedupe signal (unchanged key ⇒ identical bytes ⇒ suppress frame).

Panic-safe (learned from #3935's review): the memo's single-flight releases the in-flight handshake even if a build panics, so a panic can't wedge a run under `withRecovery`.

## Byte-identity (the hard constraint)

Enforced against the #3932 goldens, and proven **structurally**:
- The single-scan's target resolver reads only version/seq-**independent** fields (grep-confirmed: `snapshotVersion`/`snapshotEventSeq` are read only inside the DTO build, never in target/scope resolution) — so one snapshot at the real version/seq yields the identical `(name,target,scope)` the old version-0 scan produced. `TestFormulaTargetFromSnapshotMatchesRunFormulaTargetForRun` locks it down.
- `writeJSONBytes` == the old `writeJSON`: same headers/status, and `json.Marshal(v)+"\n"` is byte-identical to `json.Encoder.Encode(v)`. `TestRunDetailServedBytesEqualFreshMarshal` asserts the real HTTP body.
- The memo key is complete: the built bytes are a pure function of `(lastSeq, sessionsVersion, formulaVersion, formulaFailure)` for a fixed runID — no clock, no request state; `lastSeq` strictly advances on every `changed` build so equal `lastSeq` ⇒ identical beads. **No stale-serve is possible.**

## Tests / gates

New `detail_snapshot_test.go` + `rundetail_memo_test.go`: single-scan byte-identity + target-equality + scan-counter (one scan per `detail()`), memo builds-once-per-generation, rebuild on new fold / sessions-version bump, served-bytes == fresh-marshal, concurrent single-build (`-race`), LRU eviction. Goldens unchanged byte-for-byte. `go test -race ./internal/api/dashboardbff/... ./internal/runproj/...`, `go build`/`go vet`, `make dashboard-check` — all green.

Adversarially reviewed (byte-identity + memo-staleness): clean. **Follow-up** (correct-by-construction today): a formula-version-bump rebuild test symmetric with the sessions one, and the memo's reliance on the formula cache's store-immutability invariant is worth a code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)