### PR TITLE
fix(beads): activate native store when bd context is unreachable but identity is verified

### DIFF
--- a/internal/beads/contract/preflight.go
+++ b/internal/beads/contract/preflight.go
@@ -75,6 +75,10 @@ type PreflightResult struct {
 	NativeStoreEligible bool                   `json:"native_store_eligible"`
 	Fallback            PreflightFallback      `json:"fallback,omitempty"`
 	FallbackReason      string                 `json:"fallback_reason,omitempty"`
+	// NativeEligibleViaIdentityFallback records that the verdict was upgraded
+	// from DEGRADED to ELIGIBLE solely because identity_match independently
+	// PASSED while bd context was unreachable.
+	NativeEligibleViaIdentityFallback bool `json:"native_eligible_via_identity_fallback,omitempty"`
 }
 
 // NewPreflightResult returns result with all nested diagnostic details redacted.

--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -61,12 +61,25 @@ func (c PreflightChecker) Check(scope string) (PreflightResult, error) {
 		c.checkContractShape(metadata),
 	}
 	verdict := preflightVerdictForChecks(checks)
+	// A DEGRADED verdict caused solely by an unreachable bd context (e.g. a
+	// non-git city root where `bd context` cannot resolve a repo root) is
+	// upgraded to ELIGIBLE when gc has INDEPENDENTLY verified the dolt backend
+	// — the identity_match check connects to the dolt server and matches
+	// project_id. That direct verification is stronger evidence than bd
+	// context's cross-check, so an inability to also cross-verify via bd's
+	// cwd-sensitive context command must not force the per-call bd fallback.
+	eligibleViaIdentityFallback := false
+	if verdict == PreflightVerdictDegraded && bdCtxErr != nil && degradedOnlyByUnreachableBDContext(checks) {
+		verdict = PreflightVerdictEligible
+		eligibleViaIdentityFallback = true
+	}
 	result := PreflightResult{
-		Verdict:             verdict,
-		Scope:               scope,
-		Checks:              checks,
-		RepairSteps:         preflightRepairSteps(checks),
-		NativeStoreEligible: verdict == PreflightVerdictEligible,
+		Verdict:                           verdict,
+		Scope:                             scope,
+		Checks:                            checks,
+		RepairSteps:                       preflightRepairSteps(checks),
+		NativeStoreEligible:               verdict == PreflightVerdictEligible,
+		NativeEligibleViaIdentityFallback: eligibleViaIdentityFallback,
 	}
 	if verdict != PreflightVerdictEligible {
 		result.Fallback = PreflightFallbackBdStore
@@ -391,6 +404,43 @@ func preflightVerdictForChecks(checks []PreflightCheckResult) PreflightVerdict {
 		return PreflightVerdictDegraded
 	}
 	return PreflightVerdictEligible
+}
+
+// degradedOnlyByUnreachableBDContext reports whether a DEGRADED verdict is safe
+// to upgrade to ELIGIBLE. It is true only when the identity_match check PASSED
+// (gc independently connected to the dolt server and matched project_id) and
+// every non-passing check is a WARN from a bd-context-dependent check — i.e.
+// the sole cause of the degrade is that `bd context` could not run. Any FAIL,
+// or any WARN from a non-bd-context check, makes it false so the per-call bd
+// fallback is preserved.
+func degradedOnlyByUnreachableBDContext(checks []PreflightCheckResult) bool {
+	identityVerified := false
+	for _, check := range checks {
+		switch check.State {
+		case PreflightCheckFail:
+			return false
+		case PreflightCheckWarn:
+			if !isBDContextDependentCheck(check.ID) {
+				return false
+			}
+		}
+		if check.ID == PreflightCheckIdentityMatch && check.State == PreflightCheckPass {
+			identityVerified = true
+		}
+	}
+	return identityVerified
+}
+
+// isBDContextDependentCheck reports whether a check derives its verdict from
+// `bd context` output and therefore WARNs (rather than FAILs) when bd context
+// is unreachable.
+func isBDContextDependentCheck(id PreflightCheckID) bool {
+	switch id {
+	case PreflightCheckBDContextAgreement, PreflightCheckDoltModeSafe, PreflightCheckVersionCompat:
+		return true
+	default:
+		return false
+	}
 }
 
 func preflightRepairSteps(checks []PreflightCheckResult) []PreflightRepairStep {

--- a/internal/beads/contract/preflight_checker_test.go
+++ b/internal/beads/contract/preflight_checker_test.go
@@ -84,11 +84,14 @@ func TestPreflightBlocksNativeOnContextDisagreement(t *testing.T) {
 
 // An UNREACHABLE bd context (e.g. a non-git city root where `bd context` cannot
 // run) is not evidence of a backend disagreement — it only means the native
-// store's bd-context cross-checks cannot be verified. It must DEGRADE eligibility
-// (operator opt-in) rather than hard-BLOCK it, so the bd-context-derived checks
-// report WARN, not FAIL. (A real disagreement, with a readable bd context, still
+// store's bd-context cross-checks cannot be verified. The bd-context-derived
+// checks report WARN, not FAIL. When gc has INDEPENDENTLY confirmed the dolt
+// backend by connecting to the server and matching project_id (identity_match
+// PASS), that direct verification is stronger evidence than bd context's
+// cross-check, so eligibility is upgraded to ELIGIBLE rather than falling back
+// to per-call bd. (A real disagreement, with a readable bd context, still
 // blocks — see TestPreflightBlocksNativeOnContextDisagreement.)
-func TestPreflightDegradesNativeOnUnreachableBDContext(t *testing.T) {
+func TestPreflightEligibleOnUnreachableBDContextWhenIdentityVerified(t *testing.T) {
 	scope := "/city"
 	fs := fsys.NewFake()
 	fs.Dirs[filepath.Join(scope, ".beads")] = true
@@ -115,11 +118,60 @@ func TestPreflightDegradesNativeOnUnreachableBDContext(t *testing.T) {
 		t.Fatalf("Check() error = %v", err)
 	}
 
-	// Unreachable (not disagreeing) bd context => DEGRADED + opt-in, never BLOCKED.
+	// Unreachable bd context + independent identity proof => ELIGIBLE.
+	assertPreflightVerdict(t, result, PreflightVerdictEligible, true)
+	// The bd-context cross-checks still report WARN; they are informational —
+	// the verdict is upgraded on the strength of the independent identity match.
+	assertCheckState(t, result, PreflightCheckBDContextAgreement, PreflightCheckWarn)
+	assertCheckState(t, result, PreflightCheckDoltModeSafe, PreflightCheckWarn)
+	assertCheckState(t, result, PreflightCheckVersionCompat, PreflightCheckWarn)
+	assertCheckState(t, result, PreflightCheckIdentityMatch, PreflightCheckPass)
+	// The result flags that eligibility came via the identity-fallback path.
+	if !result.NativeEligibleViaIdentityFallback {
+		t.Errorf("NativeEligibleViaIdentityFallback = false, want true on the identity-verified upgrade")
+	}
+}
+
+// Without independent identity proof, an unreachable bd context must stay
+// DEGRADED (per-call bd fallback): gc has no other evidence that the native
+// store would read the correct dolt backend.
+func TestPreflightDegradesOnUnreachableBDContextWithoutIdentityProof(t *testing.T) {
+	scope := "/city"
+	fs := fsys.NewFake()
+	fs.Dirs[filepath.Join(scope, ".beads")] = true
+	fs.Files[filepath.Join(scope, ".beads", "metadata.json")] = []byte(`{
+		"backend": "dolt",
+		"dolt_mode": "server",
+		"dolt_database": "gascity",
+		"project_id": "gc-local"
+	}`)
+	checker := PreflightChecker{
+		FS:                  fs,
+		Provider:            "bd",
+		BeadsLibraryVersion: "1.0.4",
+		BDContext: func(string) (PreflightBDContext, error) {
+			return PreflightBDContext{}, errors.New("bd context unavailable: not a git repository")
+		},
+		DatabaseProjectID: func(string) (string, bool, error) {
+			return "", false, nil
+		},
+	}
+
+	result, err := checker.Check(scope)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	// Unreachable bd context, no independent proof => DEGRADED, never BLOCKED.
 	assertPreflightVerdict(t, result, PreflightVerdictDegraded, false)
 	assertCheckState(t, result, PreflightCheckBDContextAgreement, PreflightCheckWarn)
 	assertCheckState(t, result, PreflightCheckDoltModeSafe, PreflightCheckWarn)
 	assertCheckState(t, result, PreflightCheckVersionCompat, PreflightCheckWarn)
+	assertCheckState(t, result, PreflightCheckIdentityMatch, PreflightCheckWarn)
+	// No upgrade happened, so the identity-fallback flag stays false.
+	if result.NativeEligibleViaIdentityFallback {
+		t.Errorf("NativeEligibleViaIdentityFallback = true, want false when the verdict stays DEGRADED")
+	}
 }
 
 func TestPreflightBlocksNativeOnIdentityMismatch(t *testing.T) {


### PR DESCRIPTION
## TL;DR — silent footgun remover

At a **non-git city root**, the native-store preflight silently degrades to a **per-call `bd` subprocess for every city-scope read** — measured **9–25 s per read** against an *idle* Dolt server — even when gc has already **independently proven** the Dolt backend is correct. No error is surfaced; the city just becomes mysteriously slow. This wires the opt-in that #3219 documented but never implemented, so the fast in-process path is used whenever it is provably safe.

## What triggers it

The native-store preflight runs `bd context` at the scope root to cross-verify the backend. **`bd context` requires a git repository at cwd.** So at a non-git city root:

1. `bd context` errors (`exit 128`, *"not a git repository"*).
2. The three checks that derive their verdict from `bd context` — `bd_context_agreement`, `dolt_mode_safe`, `version_compat` — all **WARN** (they can't run, so they can't confirm).
3. Any WARN makes the overall verdict **`DEGRADED`**, which is not `ELIGIBLE`.
4. `DEGRADED` ⇒ **every city-scope read shells out to a per-call `bd` subprocess** (measured 9–25 s against an idle Dolt server).

**The footgun:** #3219 documented these WARN branches as *"degrade (opt-in) rather than hard-block"* — but **no opt-in was ever wired**, so `DEGRADED` behaved identically to `BLOCKED`. An operator running a city at a non-git root gets the worst-case fallback with **no error and no signal** — just uniform multi-second slowness on every read.

## The fix

Upgrade a `DEGRADED` verdict to `ELIGIBLE` **only** when the degrade is *entirely* explained by an unreachable `bd context` **and** gc has independent proof the backend is right:

- `identity_match` **PASSED** — gc connected to the Dolt server directly and matched `project_id`, **and**
- every non-passing check is a **WARN from a `bd-context`-dependent check** (`bd_context_agreement`, `dolt_mode_safe`, `version_compat`), **and**
- **no check FAILed.**

Direct `identity_match` is strictly stronger evidence than `bd context`'s cross-check, so the inability to *also* cross-verify via bd's cwd-sensitive `context` command must not force the slow per-call fallback.

The upgrade records `PreflightResult.NativeEligibleViaIdentityFallback` so a follow-up can surface it through `gc status` / `gc doctor`. Wiring that flag into `BeadsDiagnostic` (and the status API) is intentionally left out here to keep this change focused — it is **not** reported to users yet.

## Behavior (Given / When / Then)

**Scenario: non-git city root with an independently verified backend — the footgun case**
- **Given** a city whose root is not a git repository
- **And** `identity_match` PASSED (gc connected to Dolt and matched `project_id`)
- **When** preflight runs and `bd context` errors, so `bd_context_agreement` / `dolt_mode_safe` / `version_compat` WARN
- **Then** the verdict is **`ELIGIBLE`** (fast in-process native store), and `NativeEligibleViaIdentityFallback` is set — *previously* `DEGRADED` → per-call `bd`

**Scenario: unreachable bd context with no independent proof — unchanged, conservative**
- **Given** `bd context` is unreachable
- **And** `identity_match` did **not** pass (no independent evidence the backend is correct)
- **When** preflight runs
- **Then** the verdict stays **`DEGRADED`** (per-call `bd` fallback) — gc never trusts an unverified backend

**Scenario: a genuine problem — unchanged, safe**
- **Given** any check **FAILs** (e.g. `identity_match` fails — wrong `project_id`), **or** a non-`bd-context` check WARNs
- **When** preflight runs
- **Then** the upgrade does **not** apply; the verdict degrades/blocks exactly as before

## Why it's safe

The upgrade is deliberately narrow: it fires only on *independent* proof (`identity_match` PASS) and only when the *sole* cause of the degrade is the unreachable `bd context`. A single FAIL, or any WARN from a check that isn't `bd-context`-dependent, preserves the existing fallback. It never turns a real disagreement into `ELIGIBLE` (a reachable-but-disagreeing `bd context` has no error, so the guard does not fire).

## Related work

- Builds on **#3219** (degrade — not block — native store when `bd context` is unreachable): this wires the opt-in that PR documented.
- **#3248** is a *separate* native-store-disable path (gc-installed `bd` hooks gate off the in-process store, reinstalled each reconcile tick) — orthogonal to this change but part of the same "native store silently unavailable" surface.
- **#2463 / #1978** track the per-call `bd` subprocess churn that this fallback contributes to; removing spurious fallback here reduces it.

## Scope

`internal/beads/contract/preflight_checker.go` (+ helpers `degradedOnlyByUnreachableBDContext`, `isBDContextDependentCheck`) and `preflight.go` (the fallback-eligibility flag, recorded for a follow-up to surface), plus tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

