### PR TITLE
fix(ci): key golangci-lint cache on Go toolchain version (fixes main SA5011 flood)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,18 +193,24 @@ jobs:
         run: make check-eventexport-isolation
       - name: Native DoltLite beads tests
         run: make test-native-doltlite-beads
-      - name: Get golangci-lint version for cache key
+      - name: Get golangci-lint + Go toolchain versions for cache key
         id: glint-version
         run: |
           version=$(grep -m1 '^GOLANGCI_LINT_VERSION := ' Makefile | awk '{print $3}')
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          # staticcheck (bundled in golangci-lint) caches type/CFG facts whose
+          # validity depends on the Go toolchain it was built with. Keying the
+          # cache on GOVERSION prevents a cache populated under one Go toolchain
+          # from being replayed under another, which produced a stale-fact
+          # SA5011 false-positive flood on main (ga-v7x9vk).
+          echo "goversion=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
       - name: Restore golangci-lint cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/golangci-lint
-          key: ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ hashFiles('go.sum', '.golangci.yml') }}
+          key: ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-${{ hashFiles('go.sum', '.golangci.yml') }}
           restore-keys: |
-            ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-
+            ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-
       - name: Lint
         env:
           GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -137,18 +137,24 @@ jobs:
           install-claude-cli: "false"
       - name: Install tools
         run: make install-tools
-      - name: Get golangci-lint version for cache key
+      - name: Get golangci-lint + Go toolchain versions for cache key
         id: glint-version
         run: |
           version=$(grep -m1 '^GOLANGCI_LINT_VERSION := ' Makefile | awk '{print $3}')
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          # staticcheck (bundled in golangci-lint) caches type/CFG facts whose
+          # validity depends on the Go toolchain it was built with. Keying the
+          # cache on GOVERSION prevents a cache populated under one Go toolchain
+          # from being replayed under another, which produced a stale-fact
+          # SA5011 false-positive flood on main (ga-v7x9vk).
+          echo "goversion=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
       - name: Restore golangci-lint cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/golangci-lint
-          key: ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ hashFiles('go.sum', '.golangci.yml') }}
+          key: ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-${{ hashFiles('go.sum', '.golangci.yml') }}
           restore-keys: |
-            ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-
+            ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-
       - name: Lint
         env:
           GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint


### PR DESCRIPTION
## TL;DR
`main` CI has been **persistently red** since 2026-07-04 21:43 UTC with a **264-finding `SA5011: possible nil pointer dereference` flood** across 63 existing `*_test.go` files. **The code is clean** — a fresh-cache run of the pinned linter reports **0 issues**. The flood is entirely a **poisoned golangci-lint analysis cache**, and the fix is a one-line-per-workflow cache-key change.

Bead: `ga-v7x9vk` (P1). Failing run: https://github.com/gastownhall/gascity/actions/runs/28727625953

## Symptom
`Preflight / static checks → Lint` fails with 457 SA5011 lines (264 derefs + 193 related-info), e.g.:
```
cmd/gc/city_registry_test.go:21:5: SA5011(related information): this check suggests that the pointer can be nil
cmd/gc/city_registry_test.go:24:14: SA5011: possible nil pointer dereference (staticcheck)
```
Every finding is on the **safe** guard idiom:
```go
snap := reg.Snapshot()
if snap == nil { t.Fatal("...") }   // t.Fatal never returns
_ = len(snap.all)                   // <- flagged, but snap is provably non-nil
```
These are **false positives**: staticcheck has lost the fact that `(*testing.T).Fatal` is no-return.

## Root cause
The golangci-lint analysis cache is keyed as:
```
${{ runner.os }}-golangci-lint-${version}-${hashFiles('go.sum', '.golangci.yml')}
```
This **omits the Go toolchain version**. staticcheck (bundled in golangci-lint) caches type/CFG **facts** — including `testing.T.Fatal` = no-return — whose validity depends on the Go toolchain staticcheck was built with. staticcheck v0.6.1 (bundled in golangci-lint 2.9.0) **refuses to analyze a module requiring a newer Go than staticcheck was built with** ([2025.1.1 notes](https://staticcheck.dev/changes/); go.mod here requires `go 1.26.4`). A CI run whose golangci-lint was built with a Go older than 1.26.4 therefore cached a fact-set **missing** the `t.Fatal` no-return fact.

Because the cache key is stable across Go toolchains, that poisoned cache is **restored on every subsequent run and never re-saved** (an exact-key hit does not re-upload), so SA5011 fires on every guard-idiom deref — persistently red.

## Why we know the code is fine (proof)
Running the **exact pinned** `golangci-lint 2.9.0` on **current `origin/main`** under **Go 1.26.4** with a **fresh cache**:

| Scope | Result |
|---|---|
| `./cmd/gc/...` (holds the top flooded files) | **0 issues** |
| `./...` (matches `make lint`) | **0 issues** |

The only difference between clean (local) and flood (CI) is the **restored cache**. Also note the regression boundary (`8b17c6403`, last-green→first-red) touched only `internal/doctor/` and changed **no** lint config, go.mod, or go.sum — the cache key was identical across the boundary, so this was never a code change.

## The fix
Fold `go env GOVERSION` into the golangci-lint cache key **and** `restore-keys` in both `ci.yml` and `mac-regression.yml`. Effects:
- **Busts the currently-poisoned cache** — the first run after merge is a cache miss and recomputes from clean (proven above → green).
- **Prevents recurrence** — a cache built under one Go toolchain can never be replayed under another.

This extends the version-in-key guard from #3602 (`ga-kikn9h`, which added the golangci-lint version) to also cover the Go toolchain — the missing dimension that let this recur.

## Verification
- Local fresh-cache reproduction: clean (table above).
- **This PR's own `Preflight / static checks` run is the live test** — with the new key it will cache-miss, recompute, and should pass green.

## Optional follow-up (not in this PR)
Bumping `GOLANGCI_LINT_VERSION` 2.9.0 → ≥2.12.0 (staticcheck v0.7.0, which formally supports Go 1.25/1.26 and relaxes patch-level mismatch) would remove the *degradation source* entirely. It risks new findings from newer linters, so it should be validated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)