### PR TITLE
ci(dashboard): gate typecheck:test in dashboard-check + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1158,6 +1158,9 @@ jobs:
       - name: Typecheck (tsc --noEmit)
         run: npm run typecheck
         working-directory: internal/api/dashboardspa/web
+      - name: Typecheck test files (tsc -p tsconfig.test.json)
+        run: npm run --workspace gas-city-dashboard-frontend typecheck:test
+        working-directory: internal/api/dashboardspa/web
       - name: Vitest
         run: npm run --workspace gas-city-dashboard-frontend test
         working-directory: internal/api/dashboardspa/web

--- a/Makefile
+++ b/Makefile
@@ -713,9 +713,9 @@ dashboard-build:
 dashboard-dev:
 	cd internal/api/dashboardspa/web && npm run --workspace gas-city-dashboard-frontend dev
 
-## dashboard-check: typecheck + build the SPA, then go test the embedded handler + BFF
+## dashboard-check: typecheck (src + test files) + build the SPA, then go test the embedded handler + BFF
 dashboard-check: dashboard-build
-	cd internal/api/dashboardspa/web && npm run typecheck
+	cd internal/api/dashboardspa/web && npm run typecheck && npm run --workspace gas-city-dashboard-frontend typecheck:test
 	$(TEST_ENV) go test ./internal/api/dashboardspa/... ./internal/api/dashboardbff/...
 
 ## dashboard-smoke: serve the built SPA bundle via Vite preview and verify it responds


### PR DESCRIPTION
## What

Closes the gate gap surfaced during the run-detail review: `make dashboard-check` and the CI `dashboard` job ran `npm run typecheck` (`tsc --noEmit` on **src**) but never `typecheck:test` (`tsc --noEmit -p tsconfig.test.json`). Vitest uses esbuild and does no type-checking, so **test-file type errors slipped through both gates** — that's how three fixtures missing `FormulaRunProgress.terminal` (from #3941) and two type issues in the stream test (from #3942) reached shipped PRs.

Adds `typecheck:test` to both gates, right after the existing typecheck (which builds the shared package the frontend test tsconfig resolves against). The whole frontend test suite is currently type-clean, so the gate is green.

## Dependency / merge order

Stacked on #3943, which fixes the five pre-existing `typecheck:test` errors. This gate must land **after** those fixes are on `main` (guaranteed by the stack order) — otherwise `main` would be red. At every bottom-up merge step main stays green (the fixes land in #3943, the gate lands here on top).

## Verify

`make dashboard-check` → exit 0 (now runs `typecheck:test`); `npm run --workspace gas-city-dashboard-frontend typecheck:test` → exit 0. The gate provably catches test-file type errors — it's the same `typecheck:test` that flagged the five that were fixed.

Note: only the frontend workspace has a separate test tsconfig; shared's `typecheck` already covers its sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)