### PR TITLE
feat(dashboard): push run-detail on session events (idle-run session-link freshness)

### DIFF
--- a/internal/api/dashboardbff/enrichment_cache.go
+++ b/internal/api/dashboardbff/enrichment_cache.go
@@ -305,6 +305,24 @@ func (c *singleFlightCache[K, V]) lastGoodOrZero(key K) (V, uint64, bool) {
 	return zero, 0, false
 }
 
+// invalidate forces the next get for key to recompute — and bump the version —
+// even within its TTL, while preserving the last-good value (for serve-stale)
+// and the monotonic version. It expires the entry rather than deleting it so the
+// version counter keeps advancing (a delete would reset it to zero and could
+// collide with a memo key). Used to eagerly refresh an enrichment the moment an
+// out-of-band signal says it changed (e.g. a session.* event in the tail),
+// rather than waiting for the TTL to lapse. A no-op if the key is absent.
+func (c *singleFlightCache[K, V]) invalidate(key K) {
+	c.mu.Lock()
+	if e, ok := c.entries[key]; ok {
+		// ttl 0 makes the fresh-hit check (time.Since(computed) < ttl) always
+		// false, so the next get recomputes. An in-flight compute is unaffected —
+		// it publishes and bumps the version as usual.
+		e.ttl = 0
+	}
+	c.mu.Unlock()
+}
+
 // ── Cached payload shapes ─────────────────────────────────────────────────
 
 // cachedSessions is the value stored in the sessions cache: the projected

--- a/internal/api/dashboardbff/rundetail_session_push_test.go
+++ b/internal/api/dashboardbff/rundetail_session_push_test.go
@@ -1,0 +1,294 @@
+package dashboardbff
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// TestFoldNextSessionEventRefreshesSessionsAndNotifies proves that a session
+// lifecycle event observed in the tail — with NO accompanying bead event, so the
+// bead fold does not change and build() does not fire — still (a) expires the
+// per-city sessions cache and (b) bumps the publish generation (waking any
+// detail-stream subscribers). That is what lets an idle run's session-link flip
+// push over the SSE stream promptly instead of waiting for the next bead event
+// or the sessions TTL.
+func TestFoldNextSessionEventRefreshesSessionsAndNotifies(t *testing.T) {
+	defer func(prev time.Duration) { runTailPollInterval = prev }(runTailPollInterval)
+	runTailPollInterval = 15 * time.Millisecond
+
+	// A counting supervisor so we can prove the sessions cache was invalidated: a
+	// read after the session event must re-hit upstream (the cached entry expired).
+	var sessionsHits atomic.Int64
+	supervisor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/sessions") {
+			sessionsHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"items":[],"total":0}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer supervisor.Close()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, ".gc", "events.jsonl")
+	writeEventLog(t, logPath,
+		runDetailRootEvent(),
+		runDetailStepEvent(2, "run1.1", "run1", "preflight", "in_progress"),
+	)
+	p := New(Deps{
+		Resolver:          fakeResolver{paths: map[string]string{"alpha": dir}},
+		SupervisorBaseURL: supervisor.URL,
+	})
+	p.Start(t.Context())
+	defer p.Stop()
+	tl, _ := p.cityRunTailer("alpha")
+	select {
+	case <-tl.readyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cold replay did not complete")
+	}
+	ctx := context.Background()
+
+	// Warm the sessions cache (a hit if the eager prime hasn't already), then
+	// snapshot the hit count and the generation.
+	if _, ok := tl.mgr.fetchSessions(ctx, "alpha"); !ok {
+		t.Fatal("sessions prime must be available")
+	}
+	hitsBefore := sessionsHits.Load()
+	genBefore := generationForTest(tl)
+
+	// Append a session lifecycle event ONLY — seq past the fold cursor, no bead
+	// change, so proj.Apply ignores it and build() (its subscriber notify) never
+	// fires. Only the new session-aware path can react to it.
+	appendEvents(t, logPath, events.Event{
+		Type:    events.SessionUpdated,
+		Seq:     currentLastSeq(tl) + 1,
+		Ts:      time.Now(),
+		Subject: "alpha__worker-1",
+	})
+
+	// The tail folds it: containsSessionEvent → refreshSessionEnrichment →
+	// invalidate(sessions) + notifySubscribers → generation advances.
+	waitForGenerationAbove(t, tl, genBefore)
+
+	// The cache was invalidated: the next read re-hits upstream.
+	if _, ok := tl.mgr.fetchSessions(ctx, "alpha"); !ok {
+		t.Fatal("post-event sessions read must be available")
+	}
+	if got := sessionsHits.Load(); got <= hitsBefore {
+		t.Fatalf("sessions upstream hits = %d, want > %d (a session event must invalidate the cache)", got, hitsBefore)
+	}
+}
+
+// generationForTest reads the tailer's publish generation under subMu.
+func generationForTest(tl *cityRunTailer) uint64 {
+	tl.subMu.Lock()
+	defer tl.subMu.Unlock()
+	return tl.generation
+}
+
+// waitForGenerationAbove blocks until the tailer's generation advances past prev
+// (the session event was folded and notified) or a bounded deadline elapses.
+func waitForGenerationAbove(t *testing.T, tl *cityRunTailer, prev uint64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if generationForTest(tl) > prev {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("generation did not advance above %d within 2s (session event did not notify subscribers)", prev)
+}
+
+// sessionLinkedStepEvent builds a step bead that resolves a session link: an
+// in_progress status (→ presentation "active", not pending/ready) plus a
+// session_id in metadata. detail()'s session enrichment then joins that id
+// against the /v0 sessions read, so the resolved link's sessionName tracks the
+// live session's alias — the exact field a session.updated must be able to move.
+func sessionLinkedStepEvent(seq uint64, sessionID string) events.Event {
+	return beadCreatedEvent(seq, beads.Bead{
+		ID:        "run1.1",
+		Title:     "preflight",
+		Status:    "in_progress",
+		Type:      "task",
+		ParentID:  "run1",
+		Ref:       "mol-adopt-pr-v2.preflight",
+		CreatedAt: time.Date(2026, 6, 1, 10, 1, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 6, 1, 10, 5, 0, 0, time.UTC),
+		Metadata: map[string]string{
+			"gc.kind":         "step",
+			"gc.root_bead_id": "run1",
+			"gc.step_id":      "preflight",
+			"gc.scope_ref":    "demo",
+			"session_id":      sessionID,
+		},
+	})
+}
+
+// TestRunDetailStreamPushesFrameOnSessionAliasFlip is the end-to-end proof the
+// mechanism test cannot give: a real session change flows all the way to a pushed
+// SSE frame. A run resolves a session link (step bead → session_id gc-333573),
+// the stateful fake supervisor first reports that session with alias
+// "alpha-worker", then flips it to "beta-worker". A session.updated event (NO
+// bead event, so the bead fold is unchanged and build() never fires) drives
+// foldNext → refreshSessionEnrichment → invalidate(sessions) + notify → each
+// subscriber rebuilds detail(), refetches the now-expired sessions, and the
+// per-connection byte-dedupe lets the frame through BECAUSE the resolved link's
+// sessionName actually moved. This closes the invalidate→refetch→rebuild→
+// new-bytes→frame gap the empty-sessions mechanism test leaves open.
+func TestRunDetailStreamPushesFrameOnSessionAliasFlip(t *testing.T) {
+	defer func(prev time.Duration) { runTailPollInterval = prev }(runTailPollInterval)
+	runTailPollInterval = 15 * time.Millisecond
+	defer func(prev time.Duration) { runDetailStreamHeartbeat = prev }(runDetailStreamHeartbeat)
+	runDetailStreamHeartbeat = time.Hour // keep heartbeats out of the frame stream
+
+	const sessionID = "gc-333573"
+	// flipped=false → alias "alpha-worker"; flipped=true → alias "beta-worker".
+	var flipped atomic.Bool
+	supervisor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/sessions") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		alias := "alpha-worker"
+		if flipped.Load() {
+			alias = "beta-worker"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"items":[{"id":%q,"alias":%q,"state":"active","running":true}],"total":1}`, sessionID, alias)
+	}))
+	defer supervisor.Close()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, ".gc", "events.jsonl")
+	writeEventLog(t, logPath,
+		runDetailRootEvent(),
+		sessionLinkedStepEvent(2, sessionID),
+	)
+	p := New(Deps{
+		Resolver:          fakeResolver{paths: map[string]string{"alpha": dir}},
+		SupervisorBaseURL: supervisor.URL,
+	})
+	p.Start(t.Context())
+	defer p.Stop()
+
+	srv := httptest.NewServer(p.Handler())
+	defer srv.Close()
+
+	resp, sc, closeStream := startDetailStream(t, srv)
+	defer closeStream()
+	_ = resp
+
+	// First frame: the link resolves against the initial "alpha-worker" alias.
+	first, ok := readSSEFrame(t, sc)
+	if !ok {
+		t.Fatal("no first frame")
+	}
+	if !sessionLinkNameEquals(t, first.data, "alpha-worker") {
+		t.Fatalf("first frame session link name != alpha-worker; data=%q", first.data)
+	}
+
+	// Flip the supervisor's alias, then land a session.updated ONLY (no bead
+	// event). The bead fold does not change, so only the session-aware push path
+	// can surface the new alias.
+	flipped.Store(true)
+	appendEvents(t, logPath, events.Event{
+		Type:    events.SessionUpdated,
+		Seq:     currentLastSeq(tl(t, p, "alpha")) + 1,
+		Ts:      time.Now(),
+		Subject: "alpha__" + sessionID,
+	})
+
+	// The pushed frame must reflect the moved link name — proving invalidate →
+	// refetch → rebuild → new bytes → frame end-to-end, and that byte-dedupe did
+	// NOT suppress it (the run's own link genuinely moved). Bounded so a
+	// regression (no push) fails promptly here rather than hanging to the test
+	// timeout.
+	next, ok := readSSEFrameWithin(t, sc, 2*time.Second)
+	if !ok {
+		t.Fatal("no push frame after session.updated (the session alias flip did not reach the SSE stream)")
+	}
+	if !sessionLinkNameEquals(t, next.data, "beta-worker") {
+		t.Fatalf("push frame session link name != beta-worker (session alias flip did not reach the frame); data=%q", next.data)
+	}
+	if next.data == first.data {
+		t.Fatal("push frame bytes equal the first frame — byte-dedupe should have let the moved link through")
+	}
+}
+
+// readSSEFrameWithin reads one SSE frame but gives up after d, returning
+// (zero,false) on the deadline so a "no push" regression fails fast instead of
+// blocking on the scanner until the whole test times out. The reader goroutine
+// is abandoned on timeout (the deferred stream close unblocks it), which is
+// acceptable in a test.
+func readSSEFrameWithin(t *testing.T, sc *bufio.Scanner, d time.Duration) (sseFrame, bool) {
+	t.Helper()
+	type res struct {
+		frame sseFrame
+		ok    bool
+	}
+	ch := make(chan res, 1)
+	go func() {
+		f, ok := readSSEFrame(t, sc)
+		ch <- res{f, ok}
+	}()
+	select {
+	case r := <-ch:
+		return r.frame, r.ok
+	case <-time.After(d):
+		return sseFrame{}, false
+	}
+}
+
+// tl resolves the started tailer for a city in a test.
+func tl(t *testing.T, p *Plane, city string) *cityRunTailer {
+	t.Helper()
+	tailer, ok := p.cityRunTailer(city)
+	if !ok {
+		t.Fatalf("no tailer for city %q", city)
+	}
+	return tailer
+}
+
+// sessionLinkNameEquals reports whether the run detail in data carries an
+// attached session link whose sessionName equals want on any execution instance.
+func sessionLinkNameEquals(t *testing.T, data, want string) bool {
+	t.Helper()
+	var detail struct {
+		Nodes []struct {
+			ExecutionInstances []struct {
+				Session struct {
+					Kind string `json:"kind"`
+					Link struct {
+						SessionName string `json:"sessionName"`
+					} `json:"link"`
+				} `json:"session"`
+			} `json:"executionInstances"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal([]byte(data), &detail); err != nil {
+		t.Fatalf("decode detail frame: %v; data=%q", err, data)
+	}
+	for _, n := range detail.Nodes {
+		for _, inst := range n.ExecutionInstances {
+			if inst.Session.Kind == "attached" && inst.Session.Link.SessionName == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/api/dashboardbff/rundetail_session_push_test.go
+++ b/internal/api/dashboardbff/rundetail_session_push_test.go
@@ -20,8 +20,8 @@ import (
 // TestFoldNextSessionEventRefreshesSessionsAndNotifies proves that a session
 // lifecycle event observed in the tail — with NO accompanying bead event, so the
 // bead fold does not change and build() does not fire — still (a) expires the
-// per-city sessions cache and (b) bumps the publish generation (waking any
-// detail-stream subscribers). That is what lets an idle run's session-link flip
+// per-city sessions cache and (b) wakes any detail-stream subscribers (via
+// notifySubscribers). That is what lets an idle run's session-link flip
 // push over the SSE stream promptly instead of waiting for the next bead event
 // or the sessions TTL.
 func TestFoldNextSessionEventRefreshesSessionsAndNotifies(t *testing.T) {
@@ -63,12 +63,21 @@ func TestFoldNextSessionEventRefreshesSessionsAndNotifies(t *testing.T) {
 	ctx := context.Background()
 
 	// Warm the sessions cache (a hit if the eager prime hasn't already), then
-	// snapshot the hit count and the generation.
+	// snapshot the hit count.
 	if _, ok := tl.mgr.fetchSessions(ctx, "alpha"); !ok {
 		t.Fatal("sessions prime must be available")
 	}
 	hitsBefore := sessionsHits.Load()
-	genBefore := generationForTest(tl)
+
+	// Subscribe to the detail stream so we can observe the wakeup a session event
+	// triggers, then drain any notify already pending from the cold replay / prime
+	// so the next receive is unambiguously the session event's notify.
+	sub := tl.subscribe()
+	defer tl.unsubscribe(sub)
+	select {
+	case <-sub.notify:
+	default:
+	}
 
 	// Append a session lifecycle event ONLY — seq past the fold cursor, no bead
 	// change, so proj.Apply ignores it and build() (its subscriber notify) never
@@ -81,8 +90,12 @@ func TestFoldNextSessionEventRefreshesSessionsAndNotifies(t *testing.T) {
 	})
 
 	// The tail folds it: containsSessionEvent → refreshSessionEnrichment →
-	// invalidate(sessions) + notifySubscribers → generation advances.
-	waitForGenerationAbove(t, tl, genBefore)
+	// invalidate(sessions) + notifySubscribers → our subscriber wakes.
+	select {
+	case <-sub.notify:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session event did not notify detail-stream subscribers within 2s")
+	}
 
 	// The cache was invalidated: the next read re-hits upstream.
 	if _, ok := tl.mgr.fetchSessions(ctx, "alpha"); !ok {
@@ -91,27 +104,6 @@ func TestFoldNextSessionEventRefreshesSessionsAndNotifies(t *testing.T) {
 	if got := sessionsHits.Load(); got <= hitsBefore {
 		t.Fatalf("sessions upstream hits = %d, want > %d (a session event must invalidate the cache)", got, hitsBefore)
 	}
-}
-
-// generationForTest reads the tailer's publish generation under subMu.
-func generationForTest(tl *cityRunTailer) uint64 {
-	tl.subMu.Lock()
-	defer tl.subMu.Unlock()
-	return tl.generation
-}
-
-// waitForGenerationAbove blocks until the tailer's generation advances past prev
-// (the session event was folded and notified) or a bounded deadline elapses.
-func waitForGenerationAbove(t *testing.T, tl *cityRunTailer, prev uint64) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if generationForTest(tl) > prev {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("generation did not advance above %d within 2s (session event did not notify subscribers)", prev)
 }
 
 // sessionLinkedStepEvent builds a step bead that resolves a session link: an

--- a/internal/api/dashboardbff/runtailer.go
+++ b/internal/api/dashboardbff/runtailer.go
@@ -320,9 +320,56 @@ func (t *cityRunTailer) foldNext(proj *runproj.Projector, st *tailState) {
 	if len(fresh) == 0 {
 		return
 	}
+	sessionChanged := containsSessionEvent(fresh)
 	if proj.Apply(fresh) {
 		st.marks = t.build(proj, st.marks, nil)
 	}
+	if sessionChanged {
+		// Session lifecycle events don't change the bead fold (proj.Apply ignores
+		// them), so build() — and its subscriber notify — may not have fired. But
+		// they DO change the live session links the detail projection layers on, so
+		// eagerly refresh the sessions enrichment and wake the detail-stream
+		// subscribers: an idle run's session-link flip then pushes without waiting
+		// for the next bead event or the sessions TTL. Rare session events that land
+		// only in the rotation catch-up path recover on the next poll / the TTL.
+		t.refreshSessionEnrichment()
+	}
+}
+
+// sessionEventPrefix is the common prefix of every session lifecycle event
+// (session.updated / .woke / .stopped / .crashed / …).
+const sessionEventPrefix = "session."
+
+// containsSessionEvent reports whether any freshly-folded event is a session
+// lifecycle event. Such events do not change the bead fold, so build() ignores
+// them, but they change the live session enrichment the detail projection layers
+// on — the reason foldNext refreshes sessions and wakes the detail stream.
+func containsSessionEvent(fresh []events.Event) bool {
+	for i := range fresh {
+		if strings.HasPrefix(fresh[i].Type, sessionEventPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// refreshSessionEnrichment eagerly expires the per-city sessions cache and wakes
+// the detail-stream subscribers so a session-link change on an otherwise-idle
+// run pushes a fresh frame promptly. Each subscriber rebuilds via detail(),
+// which refetches the now-expired sessions (single-flight collapses concurrent
+// rebuilds to one loopback read); the per-connection byte-dedupe drops the frame
+// when the run's own links did not move — e.g. the event was for an unrelated
+// session in the same city. It is naturally rate-limited to at most once per
+// tail poll (runTailPollInterval).
+//
+// The invalidate can be masked by a sessions compute that elected BEFORE it: that
+// in-flight compute's deferred publish resets the TTL and bumps the version with a
+// value that may predate this session change, so a subscriber joining it can push
+// one transiently-stale frame. This matches the cache's eventual-consistency
+// contract and self-heals on the next session/bead event or the reset TTL.
+func (t *cityRunTailer) refreshSessionEnrichment() {
+	t.mgr.sessionsCache.invalidate(t.name)
+	t.notifySubscribers()
 }
 
 // eventsAfter keeps only events past the projector's cursor, dropping the


### PR DESCRIPTION
## What

The follow-up to the run-detail SSE stream (#3942): close the idle-run session-link staleness the stream shipped with. The per-run detail stream only pushed when the **bead fold** changed (a bead event fired `build()` → `notifySubscribers`). Session lifecycle events (`session.updated`/`woke`/`stopped`/…) change the live session links the detail projection layers on, but **not** the bead fold — so on an otherwise-idle run a session-link flip stayed stale until the next bead event or the 3s sessions TTL.

`foldNext` now detects `session.*` events in the tail (they share the `session.` prefix; `proj.Apply` ignores them) and calls `refreshSessionEnrichment`:
- `sessionsCache.invalidate(city)` — a new `singleFlightCache.invalidate` that expires the entry (sets ttl 0) while **preserving the last-good value and the monotonic version** (a delete would reset the version and risk a memo-key collision), and
- `notifySubscribers()` — wake the detail-stream subscribers.

Each subscriber then rebuilds via `detail()`, refetches the now-expired sessions (single-flight collapses concurrent rebuilds to one loopback read), and the per-connection **byte-dedup** drops the frame when the run's own links didn't move (e.g. the event was for an unrelated session in the same city).

## Correctness (adversarially reviewed)

- **No fold-storm:** the projector advances `LastSeq` for every event and the byte offset advances past the session event, so it is never re-folded — **at most one refresh per tail poll**. (The rare rotation-catch-up path is left to recover via the next poll / TTL.)
- **Not a no-op:** session state genuinely feeds the detail bytes (`RunSessionLink` via `resolveRunSessionLink`, `progress.sessionLinkCount`), so a real session change produces different bytes and the dedup emits a frame.
- **Concurrency:** `invalidate` is race-clean under the cache lock; invalidate-before-notify ordering means a woken subscriber recomputes. One documented narrow window: an `invalidate` can be masked by a compute that elected before it (self-heals on the next event / reset TTL) — matches the cache's eventual-consistency contract.

## Tests

- `TestFoldNextSessionEventRefreshesSessionsAndNotifies` — the mechanism: a `session.*`-only event bumps the generation + invalidates the sessions cache. **Verified it fails without the change** (generation never advances).
- `TestRunDetailStreamPushesFrameOnSessionAliasFlip` — **end-to-end**: a session-linked run, a stateful supervisor flipping the linked session's alias `alpha-worker`→`beta-worker`, a `session.updated` (no bead event) → asserts a **second SSE frame arrives with the moved link bytes** (and dedup let it through). Verified it hangs+fails without the change.

`go test -race ./internal/api/dashboardbff/...`, `make dashboard-check`, `go vet` — all green. No OpenAPI/wire change.

Stacked on #3949 (the typecheck:test gate) → #3943 → the run-detail stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)