### PR TITLE
Fix pool named-session wake ambiguity

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -955,20 +955,18 @@ func buildDesiredStateWithSessionBeads(
 			if assignee != identity {
 				continue
 			}
-			if spec.Agent.SupportsExpandedSessionIdentities() {
-				// Defense in depth (ga-i1d0tr Candidate B): a bare-template Assignee
-				// is only a legitimate "this IS my identity" match for a template
-				// with exactly one possible live identity. For a template that
-				// supports expanded per-instance identities (a multi-slot pool or
-				// namepool coexisting with this named session), a bare-template
-				// Assignee means some other path wrote the wrong value — a pool
-				// slot's claim, a human running `bd update --assignee=<template>`
-				// directly, or an older client — not a genuine claim by this named
-				// session. Do not treat it as this named session's demand; the
-				// durable fix (claims under the concrete alias, ga-2xqke7) prevents
-				// the pool-claim case from producing this shape going forward.
-				continue
-			}
+			// ga-i1d0tr Candidate B: a bare-template Assignee used to be
+			// distrusted for templates supporting expanded per-instance
+			// identities (a multi-slot pool or namepool coexisting with this
+			// named session), because pool's wake-known-identity tier had no
+			// awareness of cfg.NamedSessions and could independently wake a
+			// competing pool worker for the same bare identity. That read-side
+			// ambiguity is now resolved structurally at the source
+			// (isConfiguredNamedSessionIdentity, pool_desired_state.go): pool
+			// can no longer generate wake-known-identity demand for a
+			// configured named session's own bare identity, so this bare match
+			// is trustworthy unconditionally — no per-template-shape guard
+			// needed here anymore (ga-p0u752).
 			if !assignedWorkIndexReachableFromAgent(cityPath, cfg, spec.Agent, assignedWorkStoreRefs, i) {
 				continue
 			}

--- a/cmd/gc/build_desired_state_ga80pen8_test.go
+++ b/cmd/gc/build_desired_state_ga80pen8_test.go
@@ -184,19 +184,26 @@ func TestSharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts(t *testing.T) {
 		"a concrete-alias claim %s was correctly invisible", shared.ID, concrete.ID)
 }
 
-// TestNamedWorkReady_ExpandedIdentityTemplate_NoCanonicalBead_DoesNotMaterialize
-// pins down the CURRENT, INTENTIONAL behavior described in ga-tpe9od: a named
-// session on a template that SupportsExpandedSessionIdentities() (named_session
-// + max_active_sessions>1, the same shape as the test above), whose canonical
-// session bead is absent (crash + reap), holding in-progress work self-claimed
-// under its own bare identity, does NOT get namedWorkReady demand from that
-// bead — the Candidate-B guard (ga-i1d0tr) discards the match unconditionally,
-// regardless of whether it's a legitimate self-claim. This is accepted today
-// because Candidate A (concrete-alias claims, ga-98gjgb) is not yet live
-// fleet-wide, so a bare-identity assignee on such a template can't yet be
-// trusted as unambiguous. See bd show ga-tpe9od for the full decision and the
-// trigger for revisiting this guard.
-func TestNamedWorkReady_ExpandedIdentityTemplate_NoCanonicalBead_DoesNotMaterialize(t *testing.T) {
+// TestBuildDesiredState_NamedSessionBareIdentityReaped_RecoversViaNamedTier is
+// the ga-p0u752 target scenario: a named+expanded-identity session's canonical
+// bead is gone (reaped/closed, or never materialized this tick) while it
+// still holds an in-progress work bead under its own bare identity. Same
+// fixture shape as TestBuildDesiredState_MultiSlotPoolNamedSession_OneRoutedBeadProvisionsTwoWorkers
+// (which only asserts the *count* stays 1), but this test asserts *which*
+// tier recovers it: after the fix, the named-session tier must recover the
+// bead (a session materializes with ConfiguredNamedIdentity set) and pool
+// must NOT also spin up a competing wake-known-identity worker for the same
+// bead — the actual double-provisioning ga-i1d0tr/ga-80pen8 was about.
+//
+// Supersedes TestNamedWorkReady_ExpandedIdentityTemplate_NoCanonicalBead_DoesNotMaterialize
+// (added on main by e1ba0a131), which pinned the opposite outcome for this
+// same fixture shape under ga-tpe9od's original "Candidate A not yet live"
+// premise. That test queued for days behind an unrelated prerequisite PR and
+// landed on main on 2026-07-06 — two days after ga-wfcfoe (2026-07-04)
+// confirmed Candidate A live fleet-wide and authorized removing the guard via
+// this fix (ga-p0u752, closed 2026-07-04) — so it merged already asserting a
+// stale premise. See bd show ga-wfcfoe and bd show ga-p0u752.
+func TestBuildDesiredState_NamedSessionBareIdentityReaped_RecoversViaNamedTier(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "gascity")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -205,15 +212,12 @@ func TestNamedWorkReady_ExpandedIdentityTemplate_NoCanonicalBead_DoesNotMaterial
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()
 
-	// The named session's own in-progress work, self-claimed under its bare
-	// identity (not a pool slot's claim — no gc.routed_to here). Simulates a
-	// crash + reap: sessionBeads is nil below, so no canonical session bead
-	// exists for this identity; only this orphaned in-progress work remains.
 	b, err := rigStore.Create(beads.Bead{
-		Title:    "builder's own in-progress work, orphaned by crash+reap",
+		Title:    "routed builder work, named session's canonical bead reaped",
 		Type:     "task",
 		Status:   "open",
 		Assignee: "gascity/builder",
+		Metadata: map[string]string{"gc.routed_to": "gascity/builder"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -230,7 +234,7 @@ func TestNamedWorkReady_ExpandedIdentityTemplate_NoCanonicalBead_DoesNotMaterial
 			Name:              "builder",
 			Dir:               "gascity",
 			StartCommand:      "true",
-			MaxActiveSessions: intPtr(3), // expanded identities: SupportsExpandedSessionIdentities() == true
+			MaxActiveSessions: intPtr(3), // multi-slot pool: not a canonical singleton
 			WorkQuery:         "printf ''",
 		}},
 		NamedSessions: []config.NamedSession{{
@@ -240,23 +244,27 @@ func TestNamedWorkReady_ExpandedIdentityTemplate_NoCanonicalBead_DoesNotMaterial
 		}},
 	}
 
-	// sessionBeads=nil => findCanonicalNamedSessionBead reports hasCanonical=false
-	// for every identity (no canonical session bead present at all).
+	// No session beads at all: the named session's own canonical bead is gone.
 	dsResult := buildDesiredStateWithSessionBeads(
 		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
 		cityStore, map[string]beads.Store{"gascity": rigStore}, nil, nil, io.Discard,
 	)
 
-	if demand := dsResult.NamedSessionDemand["gascity/builder"]; demand {
-		t.Fatalf("NamedSessionDemand[gascity/builder] = true, want false — the Candidate-B guard "+
-			"should have discarded the bare-identity match on this expanded-identity template; "+
-			"NamedSessionDemand=%v", dsResult.NamedSessionDemand)
-	}
+	var builderIdentities []string
+	namedCount := 0
 	for key, tp := range dsResult.State {
 		if tp.TemplateName == "gascity/builder" {
-			t.Fatalf("gascity/builder materialized as %q despite no canonical bead and no namedWorkReady "+
-				"demand (mode=on_demand) — ga-tpe9od's accepted gap should leave it un-materialized, not "+
-				"silently start provisioning it; State=%v", key, dsResult.State)
+			builderIdentities = append(builderIdentities, key+"(alias="+tp.Alias+",named="+tp.ConfiguredNamedIdentity+")")
+			if tp.ConfiguredNamedIdentity != "" {
+				namedCount++
+			}
 		}
+	}
+	if len(builderIdentities) != 1 {
+		t.Fatalf("got %d gascity/builder sessions, want exactly 1: %v", len(builderIdentities), builderIdentities)
+	}
+	if namedCount != 1 {
+		t.Fatalf("the one gascity/builder session was not recovered via the named-session tier "+
+			"(ConfiguredNamedIdentity unset) — pool spun up a competing worker instead: %v", builderIdentities)
 	}
 }

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -206,6 +206,15 @@ func computePoolDesiredStates(
 				})
 				continue
 			}
+			if isConfiguredNamedSessionIdentity(cfg, assignee) {
+				// A configured named session's own bare identity never
+				// generates pool demand — namedWorkReady recovers it
+				// instead (ga-i1d0tr Candidate B). Mirrors the resume
+				// tier's namedSessionBeadIDs skip above, extended to the
+				// case where no live session bead resolves the assignee
+				// at all.
+				continue
+			}
 			if !agentTemplateIdentitiesEquivalent(cfg, assignee, template) || !isKnownPoolTemplate(assignee, cfg) {
 				// Assignee set but session closed/unknown and not a configured
 				// pool template — orphaned work, not our job to respawn. The
@@ -777,4 +786,24 @@ func isKnownPoolTemplate(assignee string, cfg *config.City) bool {
 
 func isResumeLikeTier(tier string) bool {
 	return tier == "resume" || tier == "wake-known-identity"
+}
+
+// isConfiguredNamedSessionIdentity reports whether assignee names a
+// configured [[named_session]]'s own identity — checked structurally via
+// cfg.NamedSessions, with no live-session/store lookup, so it holds even
+// when the named session has no live session bead at all. A named session
+// whose backing agent is suspended is excluded: the named-session tier
+// never claims work for a suspended agent (mirrors the namedSpecs filter in
+// build_desired_state.go), so exempting it here too would orphan the bead
+// with neither side picking it up.
+func isConfiguredNamedSessionIdentity(cfg *config.City, assignee string) bool {
+	assignee = strings.TrimSpace(assignee)
+	if assignee == "" || cfg == nil {
+		return false
+	}
+	spec, ok := findNamedSessionSpec(cfg, "", assignee)
+	if !ok || spec.Agent == nil {
+		return false
+	}
+	return !spec.Agent.Suspended
 }

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -868,6 +868,81 @@ func TestComputePoolDesiredStates_NamedSessionBeadSkipsPoolResume(t *testing.T) 
 	}
 }
 
+// TestComputePoolDesiredStates_WakeKnownIdentitySkipsConfiguredNamedSession is
+// the ga-p0u752 fix: the wake-known-identity tier (no live session bead
+// resolves the assignee) must NOT treat a bare assignee as generic pool demand
+// when that identity is structurally a configured [[named_session]] — even
+// though the resume-tier guard (namedSessionBeadIDs, lines 194-196) never
+// fires here because there is no session bead at all. Without this fix,
+// isKnownPoolTemplate has zero awareness of cfg.NamedSessions and wakes a
+// competing pool worker for a named session's own orphaned bare self-claim
+// (ga-i1d0tr Candidate B).
+func TestComputePoolDesiredStates_WakeKnownIdentitySkipsConfiguredNamedSession(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("builder", "gascity", intPtr(3), 0)},
+		NamedSessions: []config.NamedSession{
+			{Template: "builder", Dir: "gascity", Mode: "on_demand"},
+		},
+	}
+	// No live session bead at all: the named session's canonical bead is
+	// reaped/closed, but the bare-identity in-progress claim survives.
+	work := []beads.Bead{
+		workBead("w1", "gascity/builder", "gascity/builder", "in_progress", 5),
+	}
+
+	result := ComputePoolDesiredStates(cfg, work, nil, nil)
+
+	total := 0
+	for _, ds := range result {
+		total += len(ds.Requests)
+	}
+	if total != 0 {
+		t.Errorf("total pool requests = %d, want 0 (bare identity belongs to a configured named session; pool must not compete for it)", total)
+	}
+}
+
+// TestComputePoolDesiredStates_WakeKnownIdentityFiresForSuspendedNamedSession
+// covers the suspension-awareness risk the architecture review flagged
+// (ga-wfcfoe): a suspended named session must not be silently exempted from
+// pool demand, or the bead would orphan with neither side picking it up.
+// isConfiguredNamedSessionIdentity is unit-tested directly below
+// (TestIsConfiguredNamedSessionIdentity) because computePoolDesiredStates'
+// own outer loop already skips a suspended agent's entire per-template pass
+// (line ~151), so this exact scenario can't be reconstructed end-to-end
+// through ComputePoolDesiredStates for the overlapping bare-identity shape
+// this bug family targets — suspending the shared agent suspends both tiers
+// uniformly by design, which is correct (not orphaning), not a gap.
+func TestIsConfiguredNamedSessionIdentity(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			poolAgent("builder", "gascity", intPtr(3), 0),
+			{Name: "reviewer", Dir: "gascity", Suspended: true, MaxActiveSessions: intPtr(1)},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "builder", Dir: "gascity", Mode: "on_demand"},
+			{Template: "reviewer", Dir: "gascity", Mode: "on_demand"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		assignee string
+		want     bool
+	}{
+		{"matches active named session", "gascity/builder", true},
+		{"matches named session with suspended backing agent", "gascity/reviewer", false},
+		{"no matching named session", "gascity/other", false},
+		{"empty assignee", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isConfiguredNamedSessionIdentity(cfg, tt.assignee); got != tt.want {
+				t.Errorf("isConfiguredNamedSessionIdentity(%q) = %v, want %v", tt.assignee, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestComputePoolDesiredStates_UnassignedRoutedBeadDoesNotCreateDemand(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(5), 0)},

--- a/release-gates/ga-cjhqf0-pool-identity-gate.md
+++ b/release-gates/ga-cjhqf0-pool-identity-gate.md
@@ -1,0 +1,65 @@
+# Release Gate: pool wake-known-identity vs named-session ambiguity
+
+- Bead: ga-cjhqf0
+- Feature branch: builder/ga-p0u752-pool-desired-state-identity-fix
+- Evaluated implementation head: 20bce6d3d30910f97e5b29edf4cd43356dbce1b2
+- Current base: origin/main @ 4189caf4fcac0d7b199a143346c2c1b704674994
+- Merge base: d9225156f9b30fa4fe7fee28c30699ee2cc8cc3d
+- Reviewer bead: ga-sd5w70
+- Implementation bead: ga-p0u752
+
+Note: `docs/PROJECT_MANIFEST.md` is absent in this Gas City checkout. This gate uses the deployer prompt's seven release criteria and the repository's `TESTING.md` guidance.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-sd5w70` is closed with `REVIEWER VERDICT: PASS` and no blocking findings. |
+| 2 | Acceptance criteria met | PASS | Diff contains the structural named-session skip in `cmd/gc/pool_desired_state.go`, removes the old expanded-identity guard in `cmd/gc/build_desired_state.go`, and adds/reuses the required tests. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc/...`, `go vet ./...`, focused `cmd/gc` tests, and `make test-fast-parallel` passed on the final branch. First fast run failed in unrelated supervisor-city tests under a longer TMPDIR; the exact failures passed on both branch and `origin/main` with short TMPDIR, then the full fast baseline passed with short TMPDIR. |
+| 4 | No high-severity review findings open | PASS | Review notes contain no unresolved HIGH findings. Prior Medium/Low findings from the design chain are resolved or documented as non-blocking. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before this gate file was added; this file is the only gate commit payload. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` exited 0 and produced tree `acdc91b0de0eed899a1ed8d33e13bfe6aca23d22`. The new main commit since the branch base touches only `.github/workflows/ci.yml`, `Makefile`, and `scripts/check-core-boundary.sh`. |
+| 7 | Single feature theme | PASS | Commit set is one `cmd/gc` reconciler/session-demand fix: `cmd/gc/build_desired_state.go`, `cmd/gc/build_desired_state_ga80pen8_test.go`, `cmd/gc/pool_desired_state.go`, `cmd/gc/pool_desired_state_test.go`. |
+
+## Acceptance Evidence
+
+Implementation bead `ga-p0u752` required:
+
+- Add a suspension-aware configured-named-session identity check before `wake-known-identity` pool demand: PASS.
+- Delete the named-work-ready `SupportsExpandedSessionIdentities` suppression guard: PASS.
+- Keep `TestBuildDesiredState_MultiSlotPoolNamedSession_OneRoutedBeadProvisionsTwoWorkers` green with the guard deleted: PASS.
+- Add a reaped named-session bare-identity recovery test proving named-tier recovery without a competing pool worker: PASS.
+- Cover the suspended-agent helper behavior: PASS via `TestIsConfiguredNamedSessionIdentity`.
+- Keep `TestSharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts` green: PASS.
+
+## Test Log
+
+- `gofmt -l cmd/gc/build_desired_state.go cmd/gc/build_desired_state_ga80pen8_test.go cmd/gc/pool_desired_state.go cmd/gc/pool_desired_state_test.go`: PASS, no output.
+- `git diff --check origin/main...HEAD`: PASS.
+- `git config core.hooksPath`: `.githooks`.
+- `TMPDIR=/var/tmp/gascity-test-ga-cjhqf0 go build ./cmd/gc/...`: PASS.
+- `TMPDIR=/var/tmp/gascity-test-ga-cjhqf0 go vet ./...`: PASS.
+- `TMPDIR=/var/tmp/gascity-test-ga-cjhqf0 go test ./cmd/gc/ -run 'ControlReady|WorkflowServeControlReadyQuery|RunWorkflowServe|ComputePoolDesiredStates_WakeKnownIdentitySkipsConfiguredNamedSession|IsConfiguredNamedSessionIdentity|BuildDesiredState_NamedSessionBareIdentityReaped_RecoversViaNamedTier|BuildDesiredState_MultiSlotPoolNamedSession_OneRoutedBeadProvisionsTwoWorkers|SharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts' -count=1 -v`: PASS.
+- `TMPDIR=/var/tmp/gascity-test-ga-cjhqf0 make test-fast-parallel`: initial FAIL in supervisor-city tests unrelated to the diff.
+- Exact initial failures rerun on branch with short TMPDIR: PASS.
+- Exact initial failures rerun on `origin/main` with short TMPDIR: PASS.
+- `TMPDIR=$(mktemp -d /var/tmp/gf.XXXXXX) make test-fast-parallel`: PASS, all 8 fast jobs passed.
+
+## Scope Evidence
+
+`git log --oneline --no-merges origin/main..20bce6d3d30910f97e5b29edf4cd43356dbce1b2` contains one implementation commit:
+
+```text
+20bce6d3d fix(reconciler): resolve pool wake-known-identity vs named-session ambiguity (ga-p0u752)
+```
+
+`git diff --stat origin/main...20bce6d3d30910f97e5b29edf4cd43356dbce1b2`:
+
+```text
+cmd/gc/build_desired_state.go               | 26 +++++-----
+cmd/gc/build_desired_state_ga80pen8_test.go | 76 +++++++++++++++++++++++++++++
+cmd/gc/pool_desired_state.go                | 29 +++++++++++
+cmd/gc/pool_desired_state_test.go           | 75 ++++++++++++++++++++++++++++
+4 files changed, 192 insertions(+), 14 deletions(-)
+```


### PR DESCRIPTION
## What this changes

Pool reconciliation no longer treats a configured named session's own bare identity as generic pool demand after the named session's session bead has been reaped. In that recovery case, the named-session tier now owns rematerializing the session instead of racing a pool worker for the same work.

The change also removes the older expanded-identity suppression guard from named-work recovery. That guard was compensating for the pool ambiguity; once pool demand is structurally prevented for configured named-session identities, the guard would block the recovery path this fix is meant to restore.

## Review notes

- The behavioral change is limited to `cmd/gc` desired-state computation and its tests.
- The named-session check is configuration-backed, not based on live session state, so it still works when the session bead is missing.
- Suspended backing agents remain non-exempt; suspension continues to suppress demand rather than silently transferring work to another path.
- No config schema, API, generated client, or migration changes are included.
- `origin/main` advanced after the implementation rebase by a CI/core-boundary commit; merge-tree conflict check is clean.

## Test plan

- [x] `go build ./cmd/gc/...`
- [x] `go vet ./...`
- [x] Focused `go test ./cmd/gc/` run covering the new pool/named-session tests, existing falsifiers, and control-ready workflow tests
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-cjhqf0-pool-identity-gate.md`](release-gates/ga-cjhqf0-pool-identity-gate.md)
