### PR TITLE
test(reconciler): pin namedWorkReady no-canonical guard behavior

### DIFF
--- a/cmd/gc/build_desired_state_ga80pen8_test.go
+++ b/cmd/gc/build_desired_state_ga80pen8_test.go
@@ -183,3 +183,80 @@ func TestSharedTemplateAssignee_Tier1CrashRecoveryCrossAdopts(t *testing.T) {
 	t.Logf("Tier-1 crash-recovery surfaced a live sibling's shared-template claim %s (cross-adoption); "+
 		"a concrete-alias claim %s was correctly invisible", shared.ID, concrete.ID)
 }
+
+// TestNamedWorkReady_ExpandedIdentityTemplate_NoCanonicalBead_DoesNotMaterialize
+// pins down the CURRENT, INTENTIONAL behavior described in ga-tpe9od: a named
+// session on a template that SupportsExpandedSessionIdentities() (named_session
+// + max_active_sessions>1, the same shape as the test above), whose canonical
+// session bead is absent (crash + reap), holding in-progress work self-claimed
+// under its own bare identity, does NOT get namedWorkReady demand from that
+// bead — the Candidate-B guard (ga-i1d0tr) discards the match unconditionally,
+// regardless of whether it's a legitimate self-claim. This is accepted today
+// because Candidate A (concrete-alias claims, ga-98gjgb) is not yet live
+// fleet-wide, so a bare-identity assignee on such a template can't yet be
+// trusted as unambiguous. See bd show ga-tpe9od for the full decision and the
+// trigger for revisiting this guard.
+func TestNamedWorkReady_ExpandedIdentityTemplate_NoCanonicalBead_DoesNotMaterialize(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "gascity")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	// The named session's own in-progress work, self-claimed under its bare
+	// identity (not a pool slot's claim — no gc.routed_to here). Simulates a
+	// crash + reap: sessionBeads is nil below, so no canonical session bead
+	// exists for this identity; only this orphaned in-progress work remains.
+	b, err := rigStore.Create(beads.Bead{
+		Title:    "builder's own in-progress work, orphaned by crash+reap",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "gascity/builder",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProgress := "in_progress"
+	if err := rigStore.Update(b.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gc"},
+		Rigs:      []config.Rig{{Name: "gascity", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "builder",
+			Dir:               "gascity",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(3), // expanded identities: SupportsExpandedSessionIdentities() == true
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "builder",
+			Dir:      "gascity",
+			Mode:     "on_demand",
+		}},
+	}
+
+	// sessionBeads=nil => findCanonicalNamedSessionBead reports hasCanonical=false
+	// for every identity (no canonical session bead present at all).
+	dsResult := buildDesiredStateWithSessionBeads(
+		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"gascity": rigStore}, nil, nil, io.Discard,
+	)
+
+	if demand := dsResult.NamedSessionDemand["gascity/builder"]; demand {
+		t.Fatalf("NamedSessionDemand[gascity/builder] = true, want false — the Candidate-B guard "+
+			"should have discarded the bare-identity match on this expanded-identity template; "+
+			"NamedSessionDemand=%v", dsResult.NamedSessionDemand)
+	}
+	for key, tp := range dsResult.State {
+		if tp.TemplateName == "gascity/builder" {
+			t.Fatalf("gascity/builder materialized as %q despite no canonical bead and no namedWorkReady "+
+				"demand (mode=on_demand) — ga-tpe9od's accepted gap should leave it un-materialized, not "+
+				"silently start provisioning it; State=%v", key, dsResult.State)
+		}
+	}
+}

--- a/release-gates/ga-9e524n-namedworkready-candidate-b-guard-regression-test-gate.md
+++ b/release-gates/ga-9e524n-namedworkready-candidate-b-guard-regression-test-gate.md
@@ -1,0 +1,50 @@
+# Release Gate: namedWorkReady Candidate-B guard regression test
+
+- Bead: ga-9e524n
+- Source builder bead: ga-7x9khs
+- Source review bead: ga-mojprz
+- Final branch: deploy/ga-9e524n-namedworkready-candidate-b-guard-clean
+- Base: origin/main at 4189caf4fcac0d7b199a143346c2c1b704674994
+- Candidate commit: 14a9fba2be5c7bf3b764c244b6c4d16ebb71ab74
+- Original reviewed commit: 5de45c92488a5ee40d847faaf5ce1398e3e0fd57
+- Evaluated: 2026-07-05T21:54:30Z
+
+## Summary
+
+PASS. Prerequisite PR #3865 is merged, so this deploy branch was evaluated as
+a clean single-commit branch from current origin/main. The candidate only adds
+the regression test for namedWorkReady Candidate-B behavior when an
+expanded-identity named session has no canonical session bead.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-mojprz` is closed with reason `pass` and notes include `REVIEW: PASS (gascity/reviewer)`. |
+| 2 | Acceptance criteria met | PASS | `bd show ga-7x9khs` asks for one self-contained in-memory test in `cmd/gc/build_desired_state_ga80pen8_test.go`, matching sibling test style, with gofmt/go vet/fast-unit coverage clean and a doc comment referencing ga-tpe9od. The candidate adds only `TestNamedWorkReady_ExpandedIdentityTemplate_NoCanonicalBead_DoesNotMaterialize`. |
+| 3 | Tests pass | PASS | `TMPDIR=/var/tmp/gc-ga-9e524n-test make test-fast-parallel` passed all fast shards. `TMPDIR=/var/tmp/gc-ga-9e524n-test go vet ./...` passed. `git diff --check origin/main..HEAD` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes have no open HIGH findings; the review marks security N/A because this is a pure in-memory Go unit test with no external input, auth, serialization, or injection surface. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty before writing this gate file. The only release-only change is this gate checklist, committed as the branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | The deploy branch is based directly on current `origin/main`; `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reports a clean merge. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem and one purpose: one `cmd/gc` desired-state regression test for namedWorkReady Candidate-B behavior. |
+
+## Diff Scope
+
+```text
+cmd/gc/build_desired_state_ga80pen8_test.go | 77 +++++++++++++++++++++++++++++
+1 file changed, 77 insertions(+)
+```
+
+## Commits
+
+```text
+14a9fba2b test(reconciler): pin down namedWorkReady Candidate-B guard vs. no-canonical crash recovery
+```
+
+## Notes
+
+The original reviewed branch commit was `5de45c924` on
+`builder/ga-7x9khs-namedworkready-nocanonical-test`. That branch was stacked on
+the pre-squash prerequisite for PR #3865, so it is not suitable as a PR head
+after #3865 merged. This deploy branch keeps the reviewed test-only change and
+drops the obsolete prerequisite stack from the review surface.


### PR DESCRIPTION
## What this changes

Adds a regression test for `namedWorkReady` desired-state construction when an expanded-identity named session has in-progress work assigned to its bare template identity but its canonical session bead is absent. The expected behavior stays unchanged: the Candidate-B guard ignores that ambiguous bare-template match, so the named session is not materialized from orphaned work alone.

This is test-only coverage. No production code, runtime behavior, config, API shape, or generated artifacts change.

## Review notes

- The branch is a clean deploy branch from current `origin/main`; the earlier prerequisite PR has already merged.
- The only code diff is `cmd/gc/build_desired_state_ga80pen8_test.go`.
- The release gate is committed at `release-gates/ga-9e524n-namedworkready-candidate-b-guard-regression-test-gate.md`.

## Test plan

- [x] `TMPDIR=/var/tmp/gc-ga-9e524n-test make test-fast-parallel`
- [x] `TMPDIR=/var/tmp/gc-ga-9e524n-test go vet ./...`
- [x] `.githooks/pre-commit`
- [x] Pre-push fast suite on branch push
- [x] Release gate: [`release-gates/ga-9e524n-namedworkready-candidate-b-guard-regression-test-gate.md`](release-gates/ga-9e524n-namedworkready-candidate-b-guard-regression-test-gate.md)
