### PR TITLE
fix(orders): resolve labelOrderTracking redeclaration that breaks main build (#3720 x #3800)

### DIFF
--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -16,9 +16,9 @@ import (
 	"github.com/gastownhall/gascity/internal/execenv"
 )
 
-// labelOrderTracking is applied to order bookkeeping beads by the dispatcher.
-// Event orders must not self-fire on lifecycle events emitted by these beads.
-const labelOrderTracking = "order-tracking"
+// labelOrderTracking ("order-tracking") is declared in the canonical
+// order-class label block in store.go. It marks order bookkeeping beads so
+// event orders do not self-fire on lifecycle events emitted by these beads.
 
 // TriggerResult holds the outcome of a trigger check.
 type TriggerResult struct {


### PR DESCRIPTION
## Problem
`upstream/main` HEAD does not compile:
```
internal/orders/triggers.go:21: labelOrderTracking redeclared in this block
    (previously declared at internal/orders/store.go:37)
```
## Root cause
#3720 (orders: exclude order-tracking bead events) and #3800 (object-model front-door refactor) were merged independently. Both introduce a package-level `labelOrderTracking` const in package `internal/orders` — #3720 in triggers.go, #3800 in store.go. There is no textual overlap, so git did not surface a conflict, but Go rejects the redeclaration and main is currently un-buildable.
## Fix
Drop the duplicate declaration in triggers.go and keep store.go's canonical synced label block; triggers.go references the same-package const. No behavior change — the two declarations were identical in intent.
## Verification
`go build ./...` succeeds, `go vet ./...` clean, `internal/orders` tests pass.
