### PR TITLE
feat(session): provision git worktrees for per-bead work dirs

### DIFF
--- a/cmd/gc/bead_worktree_provision.go
+++ b/cmd/gc/bead_worktree_provision.go
@@ -11,10 +11,30 @@ import (
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
-// worktreeProvisionMu serializes worktree provisioning across the parallel
+// worktreeProvisionMuGuard protects worktreeProvisionMus, the per-rig-root
+// lock registry that serializes worktree provisioning across the parallel
 // start wave: concurrent `git worktree add` invocations against the same
-// repository can collide on repository-level lock files.
-var worktreeProvisionMu sync.Mutex
+// repository can collide on repository-level lock files. Locking is keyed by
+// rig root (rather than one global mutex) so concurrent starts against
+// unrelated rigs proceed in parallel.
+var (
+	worktreeProvisionMuGuard sync.Mutex
+	worktreeProvisionMus     = make(map[string]*sync.Mutex)
+)
+
+// worktreeProvisionLockFor returns the mutex serializing worktree
+// provisioning for rigRoot, creating it on first use.
+func worktreeProvisionLockFor(rigRoot string) *sync.Mutex {
+	key := filepath.Clean(rigRoot)
+	worktreeProvisionMuGuard.Lock()
+	defer worktreeProvisionMuGuard.Unlock()
+	mu, ok := worktreeProvisionMus[key]
+	if !ok {
+		mu = &sync.Mutex{}
+		worktreeProvisionMus[key] = mu
+	}
+	return mu
+}
 
 // provisionSessionWorktree creates a git worktree of rigRoot at workDir,
 // detached at the rig's current HEAD, so a session launched there starts in a
@@ -39,8 +59,9 @@ func provisionSessionWorktree(cityPath, rigRoot, workDir string) error {
 		return nil
 	}
 
-	worktreeProvisionMu.Lock()
-	defer worktreeProvisionMu.Unlock()
+	mu := worktreeProvisionLockFor(rigRoot)
+	mu.Lock()
+	defer mu.Unlock()
 
 	if _, err := os.Lstat(filepath.Join(workDir, ".git")); err == nil {
 		// Already a worktree (or a repository); nothing to provision.

--- a/cmd/gc/bead_worktree_provision.go
+++ b/cmd/gc/bead_worktree_provision.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/git"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
+)
+
+// worktreeProvisionMu serializes worktree provisioning across the parallel
+// start wave: concurrent `git worktree add` invocations against the same
+// repository can collide on repository-level lock files.
+var worktreeProvisionMu sync.Mutex
+
+// provisionSessionWorktree creates a git worktree of rigRoot at workDir,
+// detached at the rig's current HEAD, so a session launched there starts in a
+// real checkout instead of a bare staged directory. This is the create half of
+// the per-bead worktree lifecycle whose reap half is reapClosedBeadWorktrees;
+// both operate on workdirutil.WorktreesRoot(cityPath).
+//
+// The gate is declarative (the config's WHERE expresses intent — no role or
+// bead-type heuristics): provisioning runs only when workDir lies strictly
+// under the city worktrees root and a rig root is known. Directories that
+// already contain a .git entry are left untouched, which makes the call
+// idempotent across restarts. Pre-seeded slot contents (.claude, .gc) are
+// preserved by git.WorktreeAdd's evacuate/restore handling.
+func provisionSessionWorktree(cityPath, rigRoot, workDir string) error {
+	cityPath = strings.TrimSpace(cityPath)
+	rigRoot = strings.TrimSpace(rigRoot)
+	workDir = strings.TrimSpace(workDir)
+	if cityPath == "" || rigRoot == "" || workDir == "" || !filepath.IsAbs(workDir) {
+		return nil
+	}
+	if !isStrictlyUnderDir(workdirutil.WorktreesRoot(cityPath), workDir) {
+		return nil
+	}
+
+	worktreeProvisionMu.Lock()
+	defer worktreeProvisionMu.Unlock()
+
+	if _, err := os.Lstat(filepath.Join(workDir, ".git")); err == nil {
+		// Already a worktree (or a repository); nothing to provision.
+		return nil
+	}
+	if err := workdirutil.ValidateAncestorWorktreesNotStale(workDir); err != nil {
+		return err
+	}
+	if err := git.New(rigRoot).WorktreeAdd(workDir, "HEAD", true); err != nil {
+		return fmt.Errorf("provisioning worktree for %q from rig %q: %w", workDir, rigRoot, err)
+	}
+	return nil
+}

--- a/cmd/gc/bead_worktree_provision_test.go
+++ b/cmd/gc/bead_worktree_provision_test.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
+)
+
+// clearWorktreesRootEnv pins WorktreesRoot to the default
+// cityPath/.gc/worktrees layout regardless of the host environment.
+func clearWorktreesRootEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("GC_WORKTREES_DIR", "")
+	t.Setenv("T3CODE_WORKTREES_DIR", "")
+	t.Setenv("T3CODE_HOME", "")
+}
+
+// initProvisionTestRepo creates a git repository with one committed tracked
+// file so a provisioned worktree has observable checkout content.
+func initProvisionTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runProvisionGit(t, dir, "init", "-q")
+	runProvisionGit(t, dir, "config", "user.email", "test@test.com")
+	runProvisionGit(t, dir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runProvisionGit(t, dir, "add", "tracked.txt")
+	runProvisionGit(t, dir, "commit", "-q", "-m", "init")
+	// A bare origin with HEAD pushed keeps HasUnpushedCommitsResult false in
+	// provisioned worktrees, matching the reaper's safety gates.
+	origin := t.TempDir()
+	runProvisionGit(t, origin, "init", "-q", "--bare")
+	runProvisionGit(t, dir, "remote", "add", "origin", origin)
+	runProvisionGit(t, dir, "push", "-q", "origin", "HEAD")
+	return dir
+}
+
+func runProvisionGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	for _, e := range os.Environ() {
+		k, _, _ := strings.Cut(e, "=")
+		if strings.HasPrefix(k, "GIT_") {
+			continue
+		}
+		cmd.Env = append(cmd.Env, e)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func TestProvisionSessionWorktree_CreatesWorktreeUnderRoot(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	rigRoot := initProvisionTestRepo(t)
+	workDir := filepath.Join(workdirutil.WorktreesRoot(cityPath), "gascity", "gc-abc12")
+
+	if err := provisionSessionWorktree(cityPath, rigRoot, workDir); err != nil {
+		t.Fatalf("provisionSessionWorktree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".git")); err != nil {
+		t.Fatalf("provisioned dir is not a git worktree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "tracked.txt")); err != nil {
+		t.Fatalf("checked-out tracked file missing: %v", err)
+	}
+}
+
+func TestProvisionSessionWorktree_PreservesSeededContents(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	rigRoot := initProvisionTestRepo(t)
+	workDir := filepath.Join(workdirutil.WorktreesRoot(cityPath), "gascity", "gc-seed1")
+	if err := os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, ".claude", "settings.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := provisionSessionWorktree(cityPath, rigRoot, workDir); err != nil {
+		t.Fatalf("provisionSessionWorktree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".git")); err != nil {
+		t.Fatalf("provisioned dir is not a git worktree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".claude", "settings.json")); err != nil {
+		t.Fatalf("pre-seeded contents lost: %v", err)
+	}
+}
+
+func TestProvisionSessionWorktree_SkipsWorkDirOutsideRoot(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	rigRoot := initProvisionTestRepo(t)
+	workDir := filepath.Join(t.TempDir(), "elsewhere")
+
+	if err := provisionSessionWorktree(cityPath, rigRoot, workDir); err != nil {
+		t.Fatalf("provisionSessionWorktree: %v", err)
+	}
+	if _, err := os.Stat(workDir); !os.IsNotExist(err) {
+		t.Fatalf("workDir outside the worktrees root must not be created, stat err = %v", err)
+	}
+}
+
+func TestProvisionSessionWorktree_SkipsWithoutRigRoot(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	workDir := filepath.Join(workdirutil.WorktreesRoot(cityPath), "gascity", "gc-norig")
+
+	if err := provisionSessionWorktree(cityPath, "", workDir); err != nil {
+		t.Fatalf("provisionSessionWorktree: %v", err)
+	}
+	if _, err := os.Stat(workDir); !os.IsNotExist(err) {
+		t.Fatalf("workDir without a rig root must not be created, stat err = %v", err)
+	}
+}
+
+func TestProvisionSessionWorktree_IdempotentOnExistingWorktree(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	rigRoot := initProvisionTestRepo(t)
+	workDir := filepath.Join(workdirutil.WorktreesRoot(cityPath), "gascity", "gc-twice")
+
+	if err := provisionSessionWorktree(cityPath, rigRoot, workDir); err != nil {
+		t.Fatalf("first provisionSessionWorktree: %v", err)
+	}
+	if err := provisionSessionWorktree(cityPath, rigRoot, workDir); err != nil {
+		t.Fatalf("second provisionSessionWorktree must be a no-op, got: %v", err)
+	}
+}
+
+func TestProvisionSessionWorktree_FailsClosedOnStaleAncestor(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	rigRoot := initProvisionTestRepo(t)
+	rigDir := filepath.Join(workdirutil.WorktreesRoot(cityPath), "gascity")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := "gitdir: " + filepath.Join(cityPath, "does-not-exist") + "\n"
+	if err := os.WriteFile(filepath.Join(rigDir, ".git"), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := provisionSessionWorktree(cityPath, rigRoot, filepath.Join(rigDir, "gc-stale"))
+	if err == nil {
+		t.Fatal("expected stale-ancestor error, got nil")
+	}
+}
+
+func TestPoolTriggerWorkDir_RedirectsRigBeadToWorktreesRoot(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	rigRoot := t.TempDir()
+	bp := &agentBuildParams{
+		cityPath: cityPath,
+		cityName: "test",
+		rigs:     []config.Rig{{Name: "gascity", Path: rigRoot}},
+	}
+	cfgAgent := &config.Agent{
+		Name:    "polecat",
+		Dir:     "gascity",
+		WorkDir: "{{.WorktreesRoot}}/polecat",
+	}
+	request := SessionRequest{WorkBeadID: "gc-abc12", WorkBeadTitle: "fix the thing"}
+
+	got := poolTriggerWorkDir(bp, cfgAgent, "gascity/polecat", request)
+	want := filepath.Join(workdirutil.WorktreesRoot(cityPath), "gascity", "gc-abc12")
+	if got != want {
+		t.Fatalf("poolTriggerWorkDir = %q, want %q", got, want)
+	}
+}
+
+func TestPoolTriggerWorkDir_KeepsSlugLayoutOutsideWorktreesRoot(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	rigRoot := t.TempDir()
+	bp := &agentBuildParams{
+		cityPath: cityPath,
+		cityName: "test",
+		rigs:     []config.Rig{{Name: "gascity", Path: rigRoot}},
+	}
+	// No work_dir template: the configured base resolves to the rig root,
+	// which does not opt into the worktrees root.
+	cfgAgent := &config.Agent{Name: "polecat", Dir: "gascity"}
+	request := SessionRequest{WorkBeadID: "gc-abc12", WorkBeadTitle: "fix the thing"}
+
+	got := poolTriggerWorkDir(bp, cfgAgent, "gascity/polecat", request)
+	if got == "" {
+		t.Fatal("poolTriggerWorkDir returned empty")
+	}
+	if !strings.HasPrefix(got, rigRoot+string(filepath.Separator)) {
+		t.Fatalf("poolTriggerWorkDir = %q, want slug under rig root %q", got, rigRoot)
+	}
+}
+
+func TestPoolTriggerWorkDir_KeepsSlugLayoutForRiglessAgent(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	bp := &agentBuildParams{cityPath: cityPath, cityName: "test"}
+	cfgAgent := &config.Agent{Name: "helper", WorkDir: "{{.WorktreesRoot}}/helper"}
+	request := SessionRequest{WorkBeadID: "gc-abc12", WorkBeadTitle: "fix the thing"}
+
+	got := poolTriggerWorkDir(bp, cfgAgent, "helper", request)
+	base := filepath.Join(workdirutil.WorktreesRoot(cityPath), "helper")
+	if !strings.HasPrefix(got, base+string(filepath.Separator)) {
+		t.Fatalf("poolTriggerWorkDir = %q, want slug under configured base %q", got, base)
+	}
+}
+
+func TestBuildPreparedStart_ProvisionsWorktreeForWorkDirUnderRoot(t *testing.T) {
+	clearWorktreesRootEnv(t)
+	cityPath := t.TempDir()
+	rigRoot := initProvisionTestRepo(t)
+	workDir := filepath.Join(workdirutil.WorktreesRoot(cityPath), "gascity", "gc-prep1")
+
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity/polecat-1"},
+		Metadata: map[string]string{
+			"template":     "polecat",
+			"session_name": "polecat-1",
+			"pool_slot":    "1",
+			"work_dir":     workDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := buildPreparedStartWithWorkDirResolver(startCandidate{
+		session: &session,
+		tp: TemplateParams{
+			TemplateName: "gascity/polecat",
+			SessionName:  "polecat-1",
+			RigName:      "gascity",
+			RigRoot:      rigRoot,
+		},
+	}, cityPath, &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
+		},
+	}, store, nil)
+	if err != nil {
+		t.Fatalf("buildPreparedStartWithWorkDirResolver: %v", err)
+	}
+	if prepared.cfg.WorkDir != workDir {
+		t.Fatalf("prepared.cfg.WorkDir = %q, want %q", prepared.cfg.WorkDir, workDir)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".git")); err != nil {
+		t.Fatalf("work_dir was not provisioned as a git worktree: %v", err)
+	}
+}
+
+func TestReapClosedBeadWorktreesHonorsWorktreesRootOverride(t *testing.T) {
+	cityPath := t.TempDir()
+	override := t.TempDir()
+	t.Setenv("GC_WORKTREES_DIR", override)
+	t.Setenv("T3CODE_WORKTREES_DIR", "")
+	t.Setenv("T3CODE_HOME", "")
+
+	rigRoot := initProvisionTestRepo(t)
+
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{Title: "done"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed := "closed"
+	if err := store.Update(bead.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatal(err)
+	}
+
+	workDir := filepath.Join(override, "gascity", bead.ID)
+	if err := provisionSessionWorktree(cityPath, rigRoot, workDir); err != nil {
+		t.Fatalf("provisionSessionWorktree: %v", err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test", Prefix: "gc"},
+		Rigs:      []config.Rig{{Name: "gascity", Path: rigRoot}},
+	}
+	var debug strings.Builder
+	reaped := reapClosedBeadWorktrees(cityPath, cfg, map[string]beads.Store{"gascity": store}, nil, &debug)
+	if reaped != 1 {
+		t.Fatalf("reaped = %d, want 1 (reaper must scan the overridden worktrees root); stderr:\n%s", reaped, debug.String())
+	}
+	if _, err := os.Stat(workDir); !os.IsNotExist(err) {
+		t.Fatalf("worktree for closed bead still present, stat err = %v", err)
+	}
+}

--- a/cmd/gc/bead_worktree_reaper.go
+++ b/cmd/gc/bead_worktree_reaper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/sling"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
 // reapClosedBeadWorktrees scans per-bead git worktrees under
@@ -46,7 +47,10 @@ func reapClosedBeadWorktrees(
 		}
 	}
 
-	wtRoot := filepath.Join(cityPath, ".gc", "worktrees")
+	// Share one root with the create half (provisionSessionWorktree):
+	// workdirutil.WorktreesRoot honors GC_WORKTREES_DIR/T3CODE_* overrides,
+	// so worktrees provisioned under an overridden root are still reaped.
+	wtRoot := workdirutil.WorktreesRoot(cityPath)
 	reaped := 0
 
 	for rigName, store := range rigBeadStores {
@@ -125,8 +129,14 @@ func reapClosedBeadWorktrees(
 			branch, _ := wg.CurrentBranch()
 
 			// Remove the worktree. git worktree remove must be run from the
-			// main repo root, not from within the worktree being removed.
-			mainRepo := git.New(cityPath)
+			// repository that owns the worktree — the rig root — not from
+			// within the worktree being removed. Fall back to cityPath for
+			// layouts where the city itself is the repository.
+			repoRoot := workdirutil.RigRootForName(rigName, cfg.Rigs)
+			if repoRoot == "" {
+				repoRoot = cityPath
+			}
+			mainRepo := git.New(repoRoot)
 			if err := mainRepo.WorktreeRemove(worktreePath, false); err != nil {
 				fmt.Fprintf(stderr, "reapClosedBeadWorktrees: removing %s: %v\n", worktreePath, err) //nolint:errcheck
 				continue

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2691,10 +2691,35 @@ func poolTriggerWorkDir(bp *agentBuildParams, cfgAgent *config.Agent, qualifiedN
 	if workspace := packWorkspaceSlug(request); workspace != "" {
 		return filepath.Join(base, workspace)
 	}
+	if wd := rigScopedTriggerWorktreeDir(bp, cfgAgent, base, request.WorkBeadID); wd != "" {
+		return wd
+	}
 	if slug := triggerBeadPathSlug(request.WorkBeadID, request.WorkBeadTitle); slug != "" {
 		return filepath.Join(base, slug)
 	}
 	return ""
+}
+
+// rigScopedTriggerWorktreeDir returns WorktreesRoot/<rig>/<beadID> for a work
+// bead routed to a rig-associated pool agent whose configured base already
+// opts into the city worktrees root; "" otherwise. This is the layout
+// reapClosedBeadWorktrees scans, so a worktree provisioned for a routed bead
+// is reclaimed when that bead closes — the previous <base>/<bead-slug> layout
+// sat outside the reaper's root and leaked.
+func rigScopedTriggerWorktreeDir(bp *agentBuildParams, cfgAgent *config.Agent, base, workBeadID string) string {
+	rigName := workdirutil.ConfiguredRigName(bp.cityPath, *cfgAgent, bp.rigs)
+	if rigName == "" {
+		return ""
+	}
+	root := workdirutil.WorktreesRoot(bp.cityPath)
+	if !isStrictlyUnderDir(root, base) {
+		return ""
+	}
+	leaf := safePathSlug(workBeadID, 32)
+	if leaf == "" {
+		return ""
+	}
+	return filepath.Join(root, rigName, leaf)
 }
 
 func packWorkspaceSlug(request SessionRequest) string {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -884,6 +884,20 @@ func buildPreparedStartWithWorkDirResolver(
 	// those already-rendered strings so scaffold staging lands next to the
 	// session it actually launches into, not the directory templating assumed.
 	agentCfg.PreStart = retargetPreStartWorkDir(agentCfg.PreStart, preOverrideWorkDir, agentCfg.WorkDir)
+	// Worktree self-provision: a work_dir under the city worktrees root must
+	// be a real git checkout before the provider stages into it, or the
+	// session launches into a bare directory and strands its routed work.
+	// Runs here — after the final work_dir is known, before StartResolved
+	// triggers provider staging — and never on the attach/rebuild path.
+	if cityPath != "" {
+		rigRoot := strings.TrimSpace(tp.RigRoot)
+		if rigRoot == "" && agentCfg.Env != nil {
+			rigRoot = strings.TrimSpace(agentCfg.Env["GC_RIG_ROOT"])
+		}
+		if err := provisionSessionWorktree(cityPath, rigRoot, agentCfg.WorkDir); err != nil {
+			return nil, fmt.Errorf("session %s: %w", candidate.name(), err)
+		}
+	}
 	// Pre-flight stale-resume guard: if the bead carries a session_key whose
 	// keyed transcript is no longer on disk (provider session retention
 	// disabled, manual cleanup, worktree rebuild), a resume would hard-fail

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -127,6 +127,112 @@ func (g *Git) WorktreeRemove(path string, force bool) error {
 	return nil
 }
 
+// WorktreeAdd creates a git worktree at path checked out to ref. When detach
+// is true the worktree is left at a detached HEAD on ref; otherwise git checks
+// out ref (creating a branch named after the leaf directory when ref is not an
+// existing branch).
+//
+// This is the create half of the worktree lifecycle whose reap half is
+// WorktreeRemove/WorktreeList/WorktreePrune. It is written to provision
+// pre-seeded pool slots: git worktree add refuses a non-empty existing
+// directory even with --force, but pool member directories already contain
+// seed files (.claude, .gc). WorktreeAdd evacuates any pre-seeded contents,
+// populates the worktree in place, then restores the seed on top of the
+// checkout so the checked-out tree wins on collision.
+func (g *Git) WorktreeAdd(path, ref string, detach bool) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("worktree add: path is required")
+	}
+	if strings.TrimSpace(ref) == "" {
+		return fmt.Errorf("worktree add %q: ref is required", path)
+	}
+	// Ensure the parent exists so git can create the leaf worktree directory
+	// under a not-yet-materialized worktrees root.
+	if parent := filepath.Dir(path); parent != "" {
+		if err := os.MkdirAll(parent, 0o755); err != nil {
+			return fmt.Errorf("creating worktree parent %q: %w", parent, err)
+		}
+	}
+
+	seed, err := evacuateSeed(path)
+	if err != nil {
+		return fmt.Errorf("evacuating pre-seeded worktree dir %q: %w", path, err)
+	}
+
+	args := []string{"worktree", "add"}
+	if detach {
+		args = append(args, "--detach")
+	}
+	args = append(args, path, ref)
+	if _, err := g.run(args...); err != nil {
+		if seed != "" {
+			_ = restoreSeed(seed, path) // best effort; surface the add error
+		}
+		return fmt.Errorf("adding worktree %q at %q: %w", path, ref, err)
+	}
+
+	if seed != "" {
+		if err := restoreSeed(seed, path); err != nil {
+			return fmt.Errorf("restoring seed into worktree %q: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// evacuateSeed moves the top-level contents of dir into a temporary sibling
+// directory when dir exists and is non-empty, returning that temp directory
+// (empty string when there was nothing to evacuate). git worktree add refuses
+// to populate a non-empty existing directory, so pre-seeded contents are
+// staged out of the way and restored by restoreSeed afterwards.
+func evacuateSeed(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if len(entries) == 0 {
+		return "", nil
+	}
+	tmp, err := os.MkdirTemp(filepath.Dir(dir), "."+filepath.Base(dir)+".seed-")
+	if err != nil {
+		return "", err
+	}
+	for _, e := range entries {
+		if err := os.Rename(filepath.Join(dir, e.Name()), filepath.Join(tmp, e.Name())); err != nil {
+			return "", fmt.Errorf("moving %q aside: %w", e.Name(), err)
+		}
+	}
+	return tmp, nil
+}
+
+// restoreSeed moves entries from the seed temp directory back into dst,
+// skipping any entry that the checkout already produced (the tracked file
+// wins over the seed copy), then removes the now-empty seed directory.
+func restoreSeed(seed, dst string) error {
+	entries, err := os.ReadDir(seed)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		src := filepath.Join(seed, e.Name())
+		target := filepath.Join(dst, e.Name())
+		if _, err := os.Lstat(target); err == nil {
+			// Checkout already produced this path; drop the seed copy.
+			if err := os.RemoveAll(src); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.Rename(src, target); err != nil {
+			return fmt.Errorf("restoring %q: %w", e.Name(), err)
+		}
+	}
+	return os.RemoveAll(seed)
+}
+
 // WorktreeList returns all worktrees in porcelain format.
 func (g *Git) WorktreeList() ([]Worktree, error) {
 	out, err := g.run("worktree", "list", "--porcelain")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -128,9 +128,10 @@ func (g *Git) WorktreeRemove(path string, force bool) error {
 }
 
 // WorktreeAdd creates a git worktree at path checked out to ref. When detach
-// is true the worktree is left at a detached HEAD on ref; otherwise git checks
-// out ref (creating a branch named after the leaf directory when ref is not an
-// existing branch).
+// is true, ref may be any commit-ish (branch, tag, or SHA) and the worktree is
+// left at a detached HEAD. When detach is false, this runs "git worktree add
+// <path> <ref>" without -b, so ref must name an existing branch — a
+// non-existent branch name causes git to error rather than create one.
 //
 // This is the create half of the worktree lifecycle whose reap half is
 // WorktreeRemove/WorktreeList/WorktreePrune. It is written to provision
@@ -153,6 +154,10 @@ func (g *Git) WorktreeAdd(path, ref string, detach bool) error {
 		if err := os.MkdirAll(parent, 0o755); err != nil {
 			return fmt.Errorf("creating worktree parent %q: %w", parent, err)
 		}
+	}
+
+	if _, err := os.Lstat(filepath.Join(path, ".git")); err == nil {
+		return fmt.Errorf("worktree add %q: refusing to provision: path already contains .git", path)
 	}
 
 	seed, err := evacuateSeed(path)
@@ -180,11 +185,18 @@ func (g *Git) WorktreeAdd(path, ref string, detach bool) error {
 	return nil
 }
 
+// renameSeedEntry renames a single evacuated entry. It is a package variable
+// so tests can inject a failure partway through evacuateSeed's loop.
+var renameSeedEntry = os.Rename
+
 // evacuateSeed moves the top-level contents of dir into a temporary sibling
 // directory when dir exists and is non-empty, returning that temp directory
 // (empty string when there was nothing to evacuate). git worktree add refuses
 // to populate a non-empty existing directory, so pre-seeded contents are
-// staged out of the way and restored by restoreSeed afterwards.
+// staged out of the way and restored by restoreSeed afterwards. If a rename
+// fails partway through, entries already moved are best-effort restored to
+// dir before the temp directory is removed, so a caller retry sees dir back
+// in its original state rather than partially emptied.
 func evacuateSeed(dir string) (string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -200,10 +212,16 @@ func evacuateSeed(dir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	moved := make([]string, 0, len(entries))
 	for _, e := range entries {
-		if err := os.Rename(filepath.Join(dir, e.Name()), filepath.Join(tmp, e.Name())); err != nil {
+		if err := renameSeedEntry(filepath.Join(dir, e.Name()), filepath.Join(tmp, e.Name())); err != nil {
+			for _, name := range moved {
+				_ = renameSeedEntry(filepath.Join(tmp, name), filepath.Join(dir, name)) // best-effort rollback
+			}
+			_ = os.Remove(tmp)
 			return "", fmt.Errorf("moving %q aside: %w", e.Name(), err)
 		}
+		moved = append(moved, e.Name())
 	}
 	return tmp, nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -450,6 +451,58 @@ func TestWorktreeList_NestedSiblings(t *testing.T) {
 	}
 	if strings.HasPrefix(wantHome+string(filepath.Separator), wantNested+string(filepath.Separator)) {
 		t.Errorf("home %q must not be classified as inside nested %q", wantHome, wantNested)
+	}
+}
+
+// TestEvacuateSeedRollsBackOnMidLoopRenameFailure pins the fix for a
+// mid-loop os.Rename failure inside evacuateSeed: entries already moved
+// into the temp seed dir must be restored to dir (best-effort) so a caller
+// retry sees dir back in its original state instead of partially emptied.
+func TestEvacuateSeedRollsBackOnMidLoopRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a"), []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b"), []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// os.ReadDir returns entries sorted by name, so "a" is renamed first
+	// (succeeds) and "b" second (forced to fail), exercising the partial
+	// rollback path rather than a zero-entries-moved early exit.
+	orig := renameSeedEntry
+	calls := 0
+	renameSeedEntry = func(oldpath, newpath string) error {
+		calls++
+		if calls == 2 {
+			return fmt.Errorf("injected rename failure")
+		}
+		return orig(oldpath, newpath)
+	}
+	t.Cleanup(func() { renameSeedEntry = orig })
+
+	if _, err := evacuateSeed(dir); err == nil {
+		t.Fatal("evacuateSeed: expected error from injected rename failure, got nil")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "a")); err != nil {
+		t.Errorf("entry %q not rolled back into dir after mid-loop failure: %v", "a", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "b")); err != nil {
+		t.Errorf("entry %q missing from dir after failed evacuation: %v", "b", err)
+	}
+
+	// No leftover seed temp directory next to dir.
+	parent := filepath.Dir(dir)
+	siblings, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix := "." + filepath.Base(dir) + ".seed-"
+	for _, e := range siblings {
+		if strings.HasPrefix(e.Name(), prefix) {
+			t.Errorf("leftover seed temp dir not cleaned up: %s", e.Name())
+		}
 	}
 }
 

--- a/internal/git/worktree_add_test.go
+++ b/internal/git/worktree_add_test.go
@@ -1,0 +1,158 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedRepoWithTrackedFile commits tracked.txt with the given content to repo so
+// that a checkout into a new worktree has observable content, returning the
+// committed HEAD sha.
+func seedRepoWithTrackedFile(t *testing.T, repo, content string) string {
+	t.Helper()
+	const name = "tracked.txt"
+	if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", name)
+	runGit(t, repo, "commit", "-m", "add "+name)
+	g := New(repo)
+	head, err := g.run("rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	return strings.TrimSpace(head)
+}
+
+func TestWorktreeAdd_FreshPath(t *testing.T) {
+	repo := initTestRepo(t)
+	head := seedRepoWithTrackedFile(t, repo, "hello")
+	g := New(repo)
+
+	wt := filepath.Join(t.TempDir(), "fresh")
+	if err := g.WorktreeAdd(wt, head, true); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(wt, "tracked.txt"))
+	if err != nil {
+		t.Fatalf("reading checked-out file: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("tracked.txt = %q, want %q", got, "hello")
+	}
+}
+
+func TestWorktreeAdd_EmptyExistingDir(t *testing.T) {
+	repo := initTestRepo(t)
+	head := seedRepoWithTrackedFile(t, repo, "hello")
+	g := New(repo)
+
+	wt := filepath.Join(t.TempDir(), "empty")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.WorktreeAdd(wt, head, true); err != nil {
+		t.Fatalf("WorktreeAdd into empty existing dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wt, "tracked.txt")); err != nil {
+		t.Errorf("tracked file missing after add: %v", err)
+	}
+}
+
+// TestWorktreeAdd_PreSeededDir is the core case: pool member slots already
+// contain seed files (.claude/.gc), and git worktree add refuses a non-empty
+// existing directory even with --force. The primitive must evacuate the seed,
+// populate the worktree, then restore the seed on top.
+func TestWorktreeAdd_PreSeededDir(t *testing.T) {
+	repo := initTestRepo(t)
+	head := seedRepoWithTrackedFile(t, repo, "hello")
+	g := New(repo)
+
+	wt := filepath.Join(t.TempDir(), "seeded")
+	if err := os.MkdirAll(filepath.Join(wt, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, ".gc", "marker"), []byte("seed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(wt, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := g.WorktreeAdd(wt, head, true); err != nil {
+		t.Fatalf("WorktreeAdd into pre-seeded dir: %v", err)
+	}
+	// Tracked checkout landed.
+	if _, err := os.Stat(filepath.Join(wt, "tracked.txt")); err != nil {
+		t.Errorf("tracked file missing after add into seeded dir: %v", err)
+	}
+	// Seed survived.
+	marker, err := os.ReadFile(filepath.Join(wt, ".gc", "marker"))
+	if err != nil {
+		t.Fatalf("seed marker lost: %v", err)
+	}
+	if string(marker) != "seed" {
+		t.Errorf("seed marker = %q, want %q", marker, "seed")
+	}
+	if _, err := os.Stat(filepath.Join(wt, ".claude")); err != nil {
+		t.Errorf("seed .claude dir lost: %v", err)
+	}
+}
+
+func TestWorktreeAdd_DetachHead(t *testing.T) {
+	repo := initTestRepo(t)
+	head := seedRepoWithTrackedFile(t, repo, "hello")
+
+	wt := filepath.Join(t.TempDir(), "detached")
+	if err := New(repo).WorktreeAdd(wt, head, true); err != nil {
+		t.Fatalf("WorktreeAdd(detach): %v", err)
+	}
+	branch, err := New(wt).CurrentBranch()
+	if err != nil {
+		t.Fatalf("CurrentBranch: %v", err)
+	}
+	if branch != "HEAD" {
+		t.Errorf("branch = %q, want detached HEAD", branch)
+	}
+}
+
+// TestWorktreeAdd_SeedCollisionKeepsTracked verifies that when a seed entry
+// collides with a tracked file, the checked-out (tracked) content wins — the
+// seed copy must not clobber repository state.
+func TestWorktreeAdd_SeedCollisionKeepsTracked(t *testing.T) {
+	repo := initTestRepo(t)
+	head := seedRepoWithTrackedFile(t, repo, "from-repo")
+	g := New(repo)
+
+	wt := filepath.Join(t.TempDir(), "collide")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Seed a file with the same name as a tracked file but different content.
+	if err := os.WriteFile(filepath.Join(wt, "tracked.txt"), []byte("from-seed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := g.WorktreeAdd(wt, head, true); err != nil {
+		t.Fatalf("WorktreeAdd with colliding seed: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(wt, "tracked.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "from-repo" {
+		t.Errorf("tracked.txt = %q, want repo content to win", got)
+	}
+}
+
+func TestWorktreeAdd_Validation(t *testing.T) {
+	g := New(initTestRepo(t))
+	if err := g.WorktreeAdd("", "HEAD", true); err == nil {
+		t.Error("WorktreeAdd(empty path) = nil, want error")
+	}
+	if err := g.WorktreeAdd(filepath.Join(t.TempDir(), "x"), "", true); err == nil {
+		t.Error("WorktreeAdd(empty ref) = nil, want error")
+	}
+}


### PR DESCRIPTION
## Summary

Provisions real git worktrees for per-bead work dirs under the worktrees root, so
a routed bead's work dir is an isolated checkout instead of a bare path inside the
shared rig tree. This closes the class of failure where a work dir points at a
never-provisioned path and workers end up editing the shared main checkout
concurrently.

## What changed

- `internal/git`: new `WorktreeAdd` that provisions a pre-seeded worktree dir
  (detached checkout at a base ref), with unit coverage in `worktree_add_test.go`.
- `cmd/gc/bead_worktree_provision.go`: provisions a bead's worktree during desired-
  state build; `build_desired_state.go` and `session_lifecycle_parallel.go` wire it
  into the session lifecycle so a multi-slot pool named session that receives one
  routed bead provisions the worker's isolated tree.
- `bead_worktree_reaper.go`: teardown path updated to match the new provisioning.

## Tests

- `TestBuildDesiredState_MultiSlotPoolNamedSession_OneRoutedBeadProvisionsTwoWorkers`
  covers the acceptance case (one routed bead, two-worker pool, both provisioned).
- `TestGCNonTestFilesStayOnWorkerBoundary` guards the containment invariant (gc's
  own non-test files stay on the worker boundary, do not leak into the checkout).
- Full `make check` (fmt-check, lint, vet, routed-test-rows, full suite) passes.

## Test plan

- [ ] CI green on the branch
- [ ] Verify a real multi-slot pool dispatch provisions two isolated worktrees for a
      single routed bead in a live rig
