### PR TITLE
fix(orders): remove duplicate labelOrderTracking declaration (fixes main build break)

### DIFF
--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -16,10 +16,6 @@ import (
 	"github.com/gastownhall/gascity/internal/execenv"
 )
 
-// labelOrderTracking is applied to order bookkeeping beads by the dispatcher.
-// Event orders must not self-fire on lifecycle events emitted by these beads.
-const labelOrderTracking = "order-tracking"
-
 // TriggerResult holds the outcome of a trigger check.
 type TriggerResult struct {
 	// Due is true if the trigger condition is satisfied and the order should run.
@@ -260,6 +256,8 @@ func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc) TriggerResult 
 	}
 	var count int
 	for _, e := range matched {
+		// Exclude the dispatcher's own order-tracking bookkeeping beads so an event
+		// order never self-fires on lifecycle events emitted by those beads (#3720).
 		if !payloadHasLabel(e.Payload, labelOrderTracking) {
 			count++
 		}


### PR DESCRIPTION
## What

`origin/main` currently **does not compile**: `internal/orders` declares `const labelOrderTracking = "order-tracking"` **twice** —

- `store.go` — in the canonical grouped block of order-class label constants (the one that mirrors `cmd/gc/order_dispatch.go`), and
- `triggers.go` — a standalone const added by #3720.

Result: `labelOrderTracking redeclared in this block` → `go build ./...` fails repo-wide → every integration shard fails with `[build failed]`, and the Preflight **Lint** step fails too (golangci-lint is type-aware and can't run on a non-compiling tree). main HEAD has carried this since **#3720** merged (2026-07-05 17:06), so it blocks CI on *every* open PR that gets a fresh run against main.

This removes the duplicate in `triggers.go` (keeping `store.go`'s canonical declaration — the usage in `triggers.go` resolves to the same package-level const) and relocates #3720's intent comment to the call site so the "why" isn't lost.

## Verified locally

`go build ./...`, `go test ./internal/orders/...`, `go vet ./...`, and a full `golangci-lint run ./...` — **all clean** (the one-line dedup un-cascades the build, the lint, and the integration shards).

/cc the #3720 author — this is a merge-order collision (independently-added declaration), not a logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)