### PR TITLE
optimize: bypass slow Dolt last-run queries in gc order check and doctor

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -1036,11 +1036,7 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 
 	var firedEvents []events.Event
 	if ep != nil {
-		var err error
-		firedEvents, err = ep.List(events.Filter{Type: events.OrderFired})
-		if err != nil {
-			// best-effort
-		}
+		firedEvents, _ = ep.List(events.Filter{Type: events.OrderFired})
 	}
 	latestFired := make(map[string]time.Time)
 	for _, event := range firedEvents {

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -1034,6 +1034,21 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 		return 1
 	}
 
+	var firedEvents []events.Event
+	if ep != nil {
+		var err error
+		firedEvents, err = ep.List(events.Filter{Type: events.OrderFired})
+		if err != nil {
+			// best-effort
+		}
+	}
+	latestFired := make(map[string]time.Time)
+	for _, event := range firedEvents {
+		if event.Ts.After(latestFired[event.Subject]) {
+			latestFired[event.Subject] = event.Ts
+		}
+	}
+
 	if jsonOutput {
 		result := orderCheckJSON{
 			SchemaVersion: "1",
@@ -1055,6 +1070,15 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 			baseLastRunFn := orders.LastRunAcrossStores(stores...)
 			var lastRunErr error
 			lastRunFn := func(orderName string) (time.Time, error) {
+				if t, ok := latestFired[orderName]; ok && !t.IsZero() {
+					if a.Trigger == "cooldown" {
+						if interval, err := time.ParseDuration(a.Interval); err == nil && interval > 0 {
+							if now.Sub(t) < interval {
+								return t, nil
+							}
+						}
+					}
+				}
 				last, err := baseLastRunFn(orderName)
 				if err != nil {
 					lastRunErr = err
@@ -1125,6 +1149,15 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 		baseLastRunFn := orders.LastRunAcrossStores(stores...)
 		var lastRunErr error
 		lastRunFn := func(orderName string) (time.Time, error) {
+			if t, ok := latestFired[orderName]; ok && !t.IsZero() {
+				if a.Trigger == "cooldown" {
+					if interval, err := time.ParseDuration(a.Interval); err == nil && interval > 0 {
+						if now.Sub(t) < interval {
+							return t, nil
+						}
+					}
+				}
+			}
 			last, err := baseLastRunFn(orderName)
 			if err != nil {
 				lastRunErr = err

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -3611,3 +3611,76 @@ func TestOrderScopedName(t *testing.T) {
 		}
 	}
 }
+
+// TestOrderCheckCooldownFastPathBypassesLastRunStore proves the cooldown
+// short-circuit: a recent order.fired event keeps a cooldown order not-due
+// without ever consulting the (slow, Dolt-backed) last-run store. The store
+// is rigged to error if queried, so a clean not-due result confirms the
+// fast path took over.
+func TestOrderCheckCooldownFastPathBypassesLastRunStore(t *testing.T) {
+	now := time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)
+	aa := []orders.Order{{
+		Name:     "digest",
+		Trigger:  "cooldown",
+		Interval: "24h",
+		Formula:  "mol-digest",
+	}}
+	// Any query against this store errors — it must not be reached.
+	failStore := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order-run:digest",
+	}
+	resolver := func(orders.Order) ([]beads.OrdersStore, error) {
+		return []beads.OrdersStore{{Store: failStore}}, nil
+	}
+
+	// Recent order.fired event, well within the 24h cooldown.
+	ep := events.NewFake()
+	ep.Record(events.Event{Type: events.OrderFired, Subject: "digest", Ts: now.Add(-1 * time.Hour)})
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoresResolverScoped(t.TempDir(), &config.City{}, aa, now, ep, resolver, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderCheckWithStoresResolverScoped = %d, want 1 (cooldown active, not due); stderr: %s; stdout: %s", code, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stderr.String(), "last run") {
+		t.Fatalf("last-run store was consulted despite in-window event; fast path did not bypass it:\n%s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "cooldown") {
+		t.Fatalf("stdout missing not-due cooldown row:\n%s", stdout.String())
+	}
+}
+
+// TestOrderCheckCooldownStaleEventFallsThroughToLastRunStore proves the other
+// half of the guarantee: an order.fired event older than the cooldown interval
+// does not short-circuit, so the last-run store is still consulted (and here,
+// its error surfaces).
+func TestOrderCheckCooldownStaleEventFallsThroughToLastRunStore(t *testing.T) {
+	now := time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)
+	aa := []orders.Order{{
+		Name:     "digest",
+		Trigger:  "cooldown",
+		Interval: "24h",
+		Formula:  "mol-digest",
+	}}
+	failStore := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order-run:digest",
+	}
+	resolver := func(orders.Order) ([]beads.OrdersStore, error) {
+		return []beads.OrdersStore{{Store: failStore}}, nil
+	}
+
+	// Stale order.fired event, older than the 24h cooldown.
+	ep := events.NewFake()
+	ep.Record(events.Event{Type: events.OrderFired, Subject: "digest", Ts: now.Add(-25 * time.Hour)})
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoresResolverScoped(t.TempDir(), &config.City{}, aa, now, ep, resolver, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderCheckWithStoresResolverScoped = %d, want 1 when last-run store errors after stale event; stdout: %s", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "last run") {
+		t.Fatalf("stale event did not fall through to last-run store; expected last-run error in stderr:\n%s", stderr.String())
+	}
+}

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -135,7 +135,7 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 			blockingErrors++
 			continue
 		}
-		lastFired, err := c.latestOrderFiredAt(firedEvents, order)
+		lastFired, err := c.latestOrderFiredAt(firedEvents, order, expected, now)
 		if err != nil {
 			worst = worseStatus(worst, StatusError)
 			result.Details = append(result.Details, fmt.Sprintf("%s: cannot read order history: %v", orderDisplayName(order), err))
@@ -533,9 +533,12 @@ func latestControllerStartedAt(eventPath string) (time.Time, error) {
 	return latest, nil
 }
 
-func (c *OrderFiringCurrentCheck) latestOrderFiredAt(evts []events.Event, order orders.Order) (time.Time, error) {
+func (c *OrderFiringCurrentCheck) latestOrderFiredAt(evts []events.Event, order orders.Order, expected time.Duration, now time.Time) (time.Time, error) {
 	latest := latestOrderFiredAt(evts, order.ScopedName())
 	if c.lastRun == nil {
+		return latest, nil
+	}
+	if !latest.IsZero() && now.Sub(latest) < expected+expected/2 {
 		return latest, nil
 	}
 	runAt, err := c.lastRun(order)

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -576,4 +577,63 @@ func runOrderFiringCurrentTest(t *testing.T, cfg *config.City, cityPath string, 
 	check := NewOrderFiringCurrentCheck(cfg, cityPath)
 	check.clock = func() time.Time { return now }
 	return check.Run(&CheckContext{CityPath: cityPath})
+}
+
+func TestLatestOrderFiredAt_RecentEventSkipsLastRun(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	expected := 4 * time.Hour
+	order := orders.Order{Name: "cleanup-cooldown", Trigger: "cooldown"}
+	evts := []events.Event{
+		{Type: events.OrderFired, Subject: order.ScopedName(), Ts: now.Add(-1 * time.Hour)},
+	}
+
+	lastRunCalled := false
+	check := &OrderFiringCurrentCheck{
+		lastRun: func(orders.Order) (time.Time, error) {
+			lastRunCalled = true
+			return time.Time{}, fmt.Errorf("lastRun must not be consulted for a recent event")
+		},
+	}
+
+	got, err := check.latestOrderFiredAt(evts, order, expected, now)
+	if err != nil {
+		t.Fatalf("latestOrderFiredAt returned error: %v", err)
+	}
+	if lastRunCalled {
+		t.Fatalf("lastRun was consulted for an in-band event; want fast path to skip it")
+	}
+	if want := now.Add(-1 * time.Hour); !got.Equal(want) {
+		t.Fatalf("latest = %v, want %v (event timestamp)", got, want)
+	}
+}
+
+func TestLatestOrderFiredAt_StaleEventConsultsLastRun(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	expected := 4 * time.Hour
+	order := orders.Order{Name: "mol-dog-stale-db", Trigger: "cron"}
+	// Event age (13h) exceeds expected*1.5 (6h), so the fast path must not apply.
+	staleEvent := now.Add(-13 * time.Hour)
+	freshRun := now.Add(-1 * time.Hour)
+	evts := []events.Event{
+		{Type: events.OrderFired, Subject: order.ScopedName(), Ts: staleEvent},
+	}
+
+	lastRunCalled := false
+	check := &OrderFiringCurrentCheck{
+		lastRun: func(orders.Order) (time.Time, error) {
+			lastRunCalled = true
+			return freshRun, nil
+		},
+	}
+
+	got, err := check.latestOrderFiredAt(evts, order, expected, now)
+	if err != nil {
+		t.Fatalf("latestOrderFiredAt returned error: %v", err)
+	}
+	if !lastRunCalled {
+		t.Fatalf("lastRun was not consulted for a stale event; want order-run history queried")
+	}
+	if !got.Equal(freshRun) {
+		t.Fatalf("latest = %v, want %v (newer order-run history)", got, freshRun)
+	}
 }


### PR DESCRIPTION
Bypasses slow Dolt last-run queries when the events.jsonl history indicates the order is already fresh and within expected intervals.