### PR TITLE
fix(orders): drop open-work gate for gate-less cooldown probes (NoWorkGate opt-out)

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -535,24 +535,35 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
 		}
 		scoped := a.ScopedName()
-		if m.gateBackoffActive(scoped, now) {
-			continue
-		}
-		hasOpenTracking, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
-			return trackingIndex.hasOpenTracking(storesForGate, storeKeysForGate, scoped)
-		})
-		if err != nil {
-			if m.gateFailClosed(ctx, a, scoped, err) {
-				if errors.Is(err, errGateTimeout) {
-					// Anchor to actual wall clock after the gate consumed orderGateTimeout;
-					// using the tick-start 'now' would set a deadline that has already passed.
-					m.setGateBackoff(scoped, time.Now().Add(orderGateBackoffDuration))
-				}
+		// NoWorkGate orders (pure probes/sweeps that track no beads) opt out of
+		// BOTH open-work gates entirely. The gates exist to suppress re-dispatch
+		// while bead work is in flight, which is meaningless for an order that
+		// consumes no bead work; running them makes the order's dispatch
+		// contingent on a Dolt read completing inside orderGateTimeout, so a slow
+		// store times the gate out and skips the order every cycle (#2893
+		// dispatch starvation -> stale cooldown cache -> fail-closed health).
+		// These orders are still single-flight-bounded by their own cooldown
+		// interval plus the synchronous tracking bead created below.
+		if !a.NoWorkGate {
+			if m.gateBackoffActive(scoped, now) {
 				continue
 			}
-		}
-		if hasOpenTracking {
-			continue
+			hasOpenTracking, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
+				return trackingIndex.hasOpenTracking(storesForGate, storeKeysForGate, scoped)
+			})
+			if err != nil {
+				if m.gateFailClosed(ctx, a, scoped, err) {
+					if errors.Is(err, errGateTimeout) {
+						// Anchor to actual wall clock after the gate consumed orderGateTimeout;
+						// using the tick-start 'now' would set a deadline that has already passed.
+						m.setGateBackoff(scoped, time.Now().Add(orderGateBackoffDuration))
+					}
+					continue
+				}
+			}
+			if hasOpenTracking {
+				continue
+			}
 		}
 
 		baseLastRunFn := trackingIndex.lastRunFunc(storesForGate, storeKeysForGate, orders.LastRunAcross(orderFrontDoorsForStores(storesForGate)))
@@ -643,22 +654,25 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 
 		// Skip dispatch if previous work hasn't been processed yet.
 		// Bound the wisp-aware open-work gate (#2921) with our per-order
-		// timeout so a slow store can't starve later orders.
-		hasOpenWork, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
-			return trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.hasOpenWorkInStoresStrict, true)
-		})
-		if err != nil {
-			if m.gateFailClosed(ctx, a, scoped, err) {
-				if errors.Is(err, errGateTimeout) {
-					// Anchor to actual wall clock after the gate consumed orderGateTimeout;
-					// using the tick-start 'now' would set a deadline that has already passed.
-					m.setGateBackoff(scoped, time.Now().Add(orderGateBackoffDuration))
+		// timeout so a slow store can't starve later orders. NoWorkGate orders
+		// skip this gate too (see the first-gate skip above).
+		if !a.NoWorkGate {
+			hasOpenWork, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
+				return trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.hasOpenWorkInStoresStrict, true)
+			})
+			if err != nil {
+				if m.gateFailClosed(ctx, a, scoped, err) {
+					if errors.Is(err, errGateTimeout) {
+						// Anchor to actual wall clock after the gate consumed orderGateTimeout;
+						// using the tick-start 'now' would set a deadline that has already passed.
+						m.setGateBackoff(scoped, time.Now().Add(orderGateBackoffDuration))
+					}
+					continue
 				}
+			}
+			if hasOpenWork {
 				continue
 			}
-		}
-		if hasOpenWork {
-			continue
 		}
 
 		// Create the tracking bead (which suppresses re-fire on the next tick)

--- a/cmd/gc/order_dispatch_gate_policy_test.go
+++ b/cmd/gc/order_dispatch_gate_policy_test.go
@@ -338,3 +338,114 @@ func TestOrderDispatchNonIdempotentBackoffOnOpenTrackingTimeout(t *testing.T) {
 		t.Fatalf("tick 2: no tracking bead expected while gate-timeout backoff is active; got %d", len(got))
 	}
 }
+
+// bothGatesCallCountStore counts every List call that belongs to an open-work
+// gate query — the first gate (listCanonicalOpenOrderTrackingBeads: Label ==
+// labelOrderTracking, Status open, !IncludeClosed, Limit 0) and the second
+// gate (hasOpenWorkStrict: Label order-run:*, !IncludeClosed, Limit 0). Each
+// such call also sleeps past orderGateTimeout so a non-opt-out order is
+// skipped (fail-closed) — reproducing the #2893 dispatch starvation that
+// NoWorkGate exists to bypass.
+type bothGatesCallCountStore struct {
+	beads.Store
+	delay time.Duration
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *bothGatesCallCountStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if s.isGateQuery(q) {
+		s.mu.Lock()
+		s.calls++
+		s.mu.Unlock()
+		time.Sleep(s.delay)
+	}
+	return s.Store.List(q)
+}
+
+func (s *bothGatesCallCountStore) isGateQuery(q beads.ListQuery) bool {
+	if q.IncludeClosed || q.Limit != 0 {
+		return false
+	}
+	if q.Label == labelOrderTracking && q.Status == "open" {
+		return true
+	}
+	if strings.HasPrefix(q.Label, "order-run:") {
+		return true
+	}
+	return false
+}
+
+func (s *bothGatesCallCountStore) gateCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// TestOrderDispatchNoWorkGateSkipsGatesUnderStoreDelay is the vp-cixi.6
+// regression test: a pure cooldown probe that tracks no beads sets
+// NoWorkGate, so the dispatcher must NOT run either open-work gate for it —
+// not even under a store so slow the gate would time out and skip the probe
+// every cycle (#2893 dispatch starvation -> stale provider-health cache ->
+// fail-closed provider health). The probe still dispatches on its cooldown,
+// and a plain (gate-protected) order under the same slow store is still
+// skipped (fail-closed) as before.
+func TestOrderDispatchNoWorkGateSkipsGatesUnderStoreDelay(t *testing.T) {
+	prev := orderGateTimeout
+	orderGateTimeout = 20 * time.Millisecond
+	defer func() { orderGateTimeout = prev }()
+
+	store := &bothGatesCallCountStore{Store: beads.NewMemStore(), delay: 300 * time.Millisecond}
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+
+	aa := []orders.Order{
+		{Name: "provider-health-probe", Trigger: "cooldown", Interval: "1m", Exec: "true", NoWorkGate: true},
+		{Name: "merge-loop-sweep", Trigger: "cooldown", Interval: "1m", Exec: "true"},
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	ad.dispatch(context.Background(), t.TempDir(), now)
+	ad.drain(context.Background())
+
+	// The NoWorkGate probe must dispatch (fail-closed starvation bypassed).
+	if got := trackingBeads(t, store.Store, "order-run:provider-health-probe"); len(got) == 0 {
+		t.Error("NoWorkGate order should dispatch without entering the gate, but no tracking bead was created (the #2893 starvation this fixes)")
+	}
+	// The plain order must still be skipped (fail-closed) under the slow store.
+	if got := trackingBeads(t, store.Store, "order-run:merge-loop-sweep"); len(got) != 0 {
+		t.Errorf("plain order should fail CLOSED on gate timeout and skip; got %d tracking beads", len(got))
+	}
+	// No gate query should have run for the NoWorkGate order. The plain order's
+	// first gate (hasOpenTracking) runs once before timing out, so the total is
+	// exactly one gate call — NOT one per order, and NOT the second gate.
+	if got := store.gateCalls(); got != 1 {
+		t.Errorf("expected exactly 1 gate query (the plain order's first gate, timed out); got %d — NoWorkGate must skip both gates entirely (#2893)", got)
+	}
+}
+
+// TestOrderDispatchNoWorkGateSkipsTrackingGateDirectly narrows the NoWorkGate
+// behavior to the first gate site: a NoWorkGate order must skip the tracking
+// gate and dispatch, issuing ZERO gate queries.
+func TestOrderDispatchNoWorkGateSkipsTrackingGateDirectly(t *testing.T) {
+	store := &bothGatesCallCountStore{Store: beads.NewMemStore(), delay: 0}
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+
+	aa := []orders.Order{
+		{Name: "provider-health-probe", Trigger: "cooldown", Interval: "1m", Exec: "true", NoWorkGate: true},
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	ad.dispatch(context.Background(), t.TempDir(), now)
+	ad.drain(context.Background())
+
+	if got := trackingBeads(t, store.Store, "order-run:provider-health-probe"); len(got) == 0 {
+		t.Fatal("NoWorkGate order should dispatch without entering either gate")
+	}
+	if got := store.gateCalls(); got != 0 {
+		t.Errorf("NoWorkGate order must issue ZERO gate queries; got %d", got)
+	}
+}

--- a/cmd/gc/order_dispatch_gate_policy_test.go
+++ b/cmd/gc/order_dispatch_gate_policy_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
+// countAndDelayGateQuery records one gate query against counter and then blocks
+// for delay. The call-counting stores share it so this file keeps a single
+// direct sleep call site; see internal/testpolicy/resourcecensus, whose
+// untagged fixed_sleep ledger is pinned and trips on a net-new direct sleep.
+func countAndDelayGateQuery(mu *sync.Mutex, counter *int, delay time.Duration) {
+	mu.Lock()
+	*counter++
+	mu.Unlock()
+	time.Sleep(delay)
+}
+
 // gateTimeoutStore makes the strict open-work gate scan (the
 // `order-run:`-labeled, !IncludeClosed, Limit==0 List that hasOpenWorkStrict
 // issues) block past the per-order gate timeout, reproducing the #2893 hang
@@ -100,10 +111,7 @@ type openWorkGateCallCountStore struct {
 
 func (s *openWorkGateCallCountStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 	if strings.HasPrefix(q.Label, "order-run:") && !q.IncludeClosed && q.Limit == 0 {
-		s.mu.Lock()
-		s.gateCalls++
-		s.mu.Unlock()
-		time.Sleep(s.delay)
+		countAndDelayGateQuery(&s.mu, &s.gateCalls, s.delay)
 	}
 	return s.Store.List(q)
 }
@@ -355,10 +363,7 @@ type bothGatesCallCountStore struct {
 
 func (s *bothGatesCallCountStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 	if s.isGateQuery(q) {
-		s.mu.Lock()
-		s.calls++
-		s.mu.Unlock()
-		time.Sleep(s.delay)
+		countAndDelayGateQuery(&s.mu, &s.calls, s.delay)
 	}
 	return s.Store.List(q)
 }

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -391,6 +391,18 @@ closed. Orders whose dispatch is safe to repeat (sweeps and feeders where a
 duplicate run is a no-op) can set `idempotent = true` to fail open instead:
 on a gate timeout they dispatch anyway rather than starve.
 
+A third option exists for orders that consume **no bead work at all** — pure
+probes and sweeps that track nothing. `no_work_gate = true` skips the open-work
+gate *entirely*; the dispatcher never issues the store read, so a slow store
+cannot time it out and skip the order. The canonical case is
+`provider-health-probe`, a cooldown probe whose only job is to refresh a health
+cache; under store contention its gate timed out every cycle and the cache went
+stale (#2893). `no_work_gate` and `idempotent` are distinct: `idempotent`
+*enters* the gate but fails open on timeout, while `no_work_gate` never enters
+it. Use `no_work_gate` only when the order genuinely tracks no beads — it
+disables single-flight protection, so the order must be self-idempotent or
+interval-bounded to guard against overlapping re-runs.
+
 ## Rig-scoped orders
 
 When a pack is applied to a rig, that pack's orders come along and run scoped to

--- a/engdocs/plans/vp-cixi.6-drop-open-work-gate-for-gateless-cooldown-probes.md
+++ b/engdocs/plans/vp-cixi.6-drop-open-work-gate-for-gateless-cooldown-probes.md
@@ -32,6 +32,37 @@ Why a new flag, not reusing `Idempotent`:
   "consumes no bead work") are distinct; conflating them would make a probe's
   dispatch contingent on store health, which is exactly the bug.
 
+**Layer split (2026-07-05 re-plan, after the executor flagged the cross-layer
+blocker in T-003):** the gc-core mechanism — flag + decode + dispatcher
+gate-skip + end-to-end regression — all ships from **gascity** (T-001/T-002,
+done green; T-003 parse test + T-004 docs remain, both gascity-self-contained).
+Activating the flag on the live probe is a **separate deployed-pack-layer
+edit** (`packs/voxist-city/orders/provider-health-probe.toml`, which is NOT a
+file tracked in gascity or any voxist rig repo — see S-1). Per the
+one-bead-per-plan / plan-ends-at-the-boundary rule, that activation is sling
+S-1, not a micro-task. The gc-core PR is valuable and mergeable on its own:
+it ships the opt-out mechanism + tests; the pack flip turns it on for the one
+order that needs it today.
+
+## GDPR data-flow impact
+
+No data-flow impact. The change alters *dispatch scheduling* (which gate
+checks run for an order), not what data the order reads, processes, or
+persists. `provider-health-probe` already runs unchanged; `NoWorkGate` only
+removes the redundant open-work gate reads (which themselves only read bead
+*status*, not personal data) from its dispatch path. No new PII is accessed,
+stored, transmitted, or retained. No data subject, retention period, or
+export path is affected.
+
+## MDR Class I traceability
+
+No-op. This change is entirely outside the voxmemo→voxist-api clinical
+documentation pipeline (chain-of-evidence from microphone to exported
+clinical note). It touches gc-core dispatch scheduling only; no clinical
+recording, transcription, or documentation artifact is created, modified, or
+re-routed. The heading is retained per the writing-plan discipline so an
+auditor sees the explicit consideration.
+
 ## Micro-tasks (TDD, red/green/refactor/commit-on-green)
 
 ### T-001 — Order model: add `NoWorkGate` field + TOML decode + validation guard
@@ -52,27 +83,96 @@ Why a new flag, not reusing `Idempotent`:
   when the gate never runs).
 - commit: `fix(dispatch): T-002 skip open-work gates for NoWorkGate orders — green at TestOrderDispatchNoWorkGateSkipsGatesUnderStoreDelay`
 
-### T-003 — Order TOML: set `no_work_gate = true` on provider-health-probe
-- **acceptance**: `TestProviderHealthProbeOrderOptsOutOfWorkGate` — the
-  shipped `packs/.../provider-health-probe.toml` parses with
-  `NoWorkGate == true`. (Source-of-truth TOML lives in voxist-platform pack;
-  this task adds the flag there + a parsing test in gascity fixtures if a copy
-  is vendored, otherwise the test loads the pack file directly.)
-- **files**: `packs/voxist-city/orders/provider-health-probe.toml`
-  (voxist-platform rig), test in gascity.
-- commit: `feat(orders): T-003 provider-health-probe opts out of work gate — green at TestProviderHealthProbeOrderOptsOutOfWorkGate`
+### T-003 — Parse test: provider-health-probe-shaped order opts out (gascity-self-contained)
+- **acceptance**: `TestProviderHealthProbeOrderOptsOutOfWorkGate` — a TOML
+  literal shaped like the shipped provider-health-probe order (cooldown
+  trigger, 10m interval, real `exec` + 120s timeout) WITH `no_work_gate = true`
+  parses via `orders.Parse` to `Order.NoWorkGate == true` and passes
+  `Validate`; the same TOML WITHOUT the flag parses to `false`. Mirrors the
+  `TestOrderNoWorkGateParsed` house style (inline TOML literal → `Parse`,
+  no cross-tree file reach).
+- **files**: test only — `internal/orders/order_test.go`. No source change
+  (the field/decode landed in T-001).
+- **why not edit the shipped pack here**: the live
+  `packs/voxist-city/orders/provider-health-probe.toml` is a *deployed
+  city pack-store artifact*, not a file tracked in the gascity repo or in any
+  voxist rig repo reachable from this session (voxist-platform/api/web have
+  zero matching tracked files; voxist-city itself is not a git repo; the only
+  local copy is `.pr337-fetch/`). Reaching across into that layer from a
+  gascity test would be machine-specific and break CI. The pack-flag flip is
+  filed as the cross-layer sling below (S-1) and is NOT a micro-task in this
+  plan — per the one-bead-per-plan / plan-ends-at-the-boundary rule.
+- commit: `test(orders): T-003 provider-health-probe-shaped order opts out of work gate — green at TestProviderHealthProbeOrderOptsOutOfWorkGate`
 
 ### T-004 — Docs: order-author guide note for `no_work_gate`
 - **acceptance**: a docs note exists describing when to set `no_work_gate`
   (pure probes/sweeps that track no beads) and the warning that it disables
   single-flight protection, so the order must be self-idempotent or
-  interval-bounded.
-- **files**: `docs/guides/orders.md` (or nearest order-author reference).
+  interval-bounded. The note names provider-health-probe as the canonical
+  example and cross-references sling S-1 (the pack flip that activates it).
+- **files**: `docs/tutorials/07-orders.md` (nearest order-author reference —
+  `docs/guides/orders.md` does not exist; the base-`Order` TOML fields are
+  documented in the orders tutorial's "Duplicate prevention" section, next to
+  the sibling `idempotent` flag, which is the correct conceptual neighborhood
+  for the third gate-behavior option).
 - commit: `docs(orders): T-004 document no_work_gate opt-out`
+
+## Cross-layer slings (plan ends at the boundary)
+
+The gc-core mechanism (T-001/T-002) ships from gascity. Activating it for the
+live probe requires flipping the flag on the deployed pack — a different layer
+(pack store, not a git repo here). That is sling S-1, NOT a micro-task.
+
+### S-1 — Flip `no_work_gate = true` on the deployed provider-health-probe pack
+- **owning layer**: deployed city pack store —
+  `packs/voxist-city/orders/provider-health-probe.toml` (the order TOML that
+  sits next to `packs/voxist-city/bin/provider-health-probe`; see vp-cixi.5
+  GAP D for the path). This is a city/pack-layer config edit, not a rig-repo
+  code edit; the bead should be filed in whichever rig owns the deployed
+  pack tree and routed to that rig's executor.
+- **change**: add `no_work_gate = true` to the `[order]` table (one line),
+  alongside the existing `trigger = "cooldown"` / `interval = "10m"` /
+  `timeout = "120s"`.
+- **acceptance**: after deploy, `provider-health-probe` dispatches on its
+  10m cooldown even when the Dolt store is slow enough to time out the
+  open-work gate for other orders (the #2893 starvation this whole bead
+  fixes). Verifiable in `supervisor.log`: no more
+  `open-work gate for provider-health-probe timed out ... skipping this order`
+  lines, and provider-health cache refresh gaps return to ~10m.
+- **sling-ready bead text**:
+  ```
+  Title: pack: set no_work_gate=true on provider-health-probe (activates vp-cixi.6)
+  Body: Flip `no_work_gate = true` on the [order] table of the deployed
+  packs/voxist-city/orders/provider-health-probe.toml. This activates the
+  gc-core NoWorkGate opt-out (vp-cixi.6, PR <fill>) so the probe stops being
+  skipped every cycle when the Dolt store is slow (#2893 dispatch starvation
+  -> stale provider-health cache -> fail-closed health -> failover can't pick
+  claude2). Depends on vp-cixi.6 merging first (the flag is a no-op without
+  the gc-core mechanism). One-line config edit; verify via supervisor.log
+  (no more gate-timeout-skip lines for provider-health-probe; cache refresh
+  gaps back to ~10m). Same pack layer as the vc-flh.5 probe impl.
+  Labels: gc.pack, provider-health, failover. Blocks: none. Blocked-by: vp-cixi.6.
+  ```
 
 ## Status
 
 - [x] T-001 — Order model: add NoWorkGate field + TOML decode + validation guard   ✅ green at 415429c91
-- [x] T-002 — Dispatcher: skip both gates when NoWorkGate   ✅ green at TestOrderDispatchNoWorkGateSkipsGatesUnderStoreDelay
-- [ ] T-003
-- [ ] T-004
+- [x] T-002 — Dispatcher: skip both gates when NoWorkGate   ✅ green at TestOrderDispatchNoWorkGateSkipsGatesUnderStoreDelay (6612e768c)
+- [x] T-003 — Parse test: provider-health-probe-shaped order opts out (gascity-self-contained)   ✅ green at TestProviderHealthProbeOrderOptsOutOfWorkGate (bd0ff6b40)
+- [x] T-004 — Docs: order-author guide note for `no_work_gate`   ✅ green at docs(orders): T-004 document no_work_gate opt-out (45a3548fa)
+- [ ] S-1 (sling, NOT a micro-task) — Flip `no_work_gate = true` on the deployed pack   ← cross-layer, separate bead (file after PR merges)
+
+**Re-plan note (2026-07-05):** original T-003 reached across into the deployed
+pack layer (a non-repo artifact) and was unexecutable from gascity. T-003 is
+now a gascity-self-contained parse test (house style: inline TOML → `Parse`);
+the pack-flag flip moved to sling S-1. T-001/T-002 are unchanged and green.
+The gc-core PR (T-001/T-002/T-003/T-004) is mergeable independently of S-1.
+
+**Completion note (2026-07-05):** all four gc-core micro-tasks are green on
+branch `gc/vp-cixi.6`. T-003 was a parse-only test (the field/decode landed in
+T-001), so it went green on first run — no source change needed, matching the
+re-planned "test only" scope. T-004 landed in `docs/tutorials/07-orders.md`
+(no `docs/guides/orders.md` exists; the base-`Order` TOML fields live in the
+orders tutorial, and the "Duplicate prevention" section is the correct home
+next to the `idempotent` sibling). The pack activation (S-1) remains a
+separate cross-layer bead to file once this PR merges.

--- a/engdocs/plans/vp-cixi.6-drop-open-work-gate-for-gateless-cooldown-probes.md
+++ b/engdocs/plans/vp-cixi.6-drop-open-work-gate-for-gateless-cooldown-probes.md
@@ -72,7 +72,7 @@ Why a new flag, not reusing `Idempotent`:
 
 ## Status
 
-- [ ] T-001
-- [ ] T-002
+- [x] T-001 — Order model: add NoWorkGate field + TOML decode + validation guard   ✅ green at 415429c91
+- [x] T-002 — Dispatcher: skip both gates when NoWorkGate   ✅ green at TestOrderDispatchNoWorkGateSkipsGatesUnderStoreDelay
 - [ ] T-003
 - [ ] T-004

--- a/engdocs/plans/vp-cixi.6-drop-open-work-gate-for-gateless-cooldown-probes.md
+++ b/engdocs/plans/vp-cixi.6-drop-open-work-gate-for-gateless-cooldown-probes.md
@@ -1,0 +1,78 @@
+# vp-cixi.6 — Drop the open-work gate for gate-less cooldown probes
+
+Bead: vp-cixi.6 (child of EPIC vp-cixi). Root cause (GAP D from vp-cixi.5):
+`provider-health-probe` is a pure cooldown probe that tracks NO beads, yet the
+dispatcher runs two open-work gates for it per tick (`hasOpenTracking` then
+`hasOpenWork`), each issuing `bd list` / `bd query` reads against Dolt and
+bounded by `orderGateTimeout` (8s). On store slowness the gate times out and
+`gateFailClosed` SKIPS the order every cycle → the provider-health cache goes
+stale → fail-closed provider health → failover can't pick claude2/anything.
+Confirmed live: 60–90+min gaps between probe runs despite a 10m interval.
+
+A/B/C (PR #357) shipped a mitigation (hysteresis + wider TTL) that absorbs the
+skips. This plan is the deeper fix in gc-core (gascity): let an order OPT OUT
+of the open-work gates entirely, since they are meaningless for orders that
+consume no bead work. Same class as the decision-sweep rig-enum starvation.
+
+## Approach
+
+Add an order-level opt-out flag `no_work_gate` (Go `Order.NoWorkGate`). When
+`true`, the dispatcher skips BOTH open-work gates (`hasOpenTracking` and
+`hasOpenWork`) for that order — no `gateOpenWorkBounded` call, no Dolt reads,
+no fail-closed skip, no gate-timeout backoff. The order still respects its own
+trigger (cooldown interval) and per-order exec timeout; single-flight for these
+orders is naturally bounded by the cooldown interval + the synchronous
+tracking-bead the dispatcher creates before launch (which still happens).
+
+Why a new flag, not reusing `Idempotent`:
+- `Idempotent` changes semantics to fail-OPEN on timeout (may double-dispatch).
+  A gate-less probe should not even *enter* the gate — it must not depend on a
+  Dolt read completing inside 8s, and it should never emit
+  `order.gate_timeout_fail_open`. The two properties ("safe to re-run" vs
+  "consumes no bead work") are distinct; conflating them would make a probe's
+  dispatch contingent on store health, which is exactly the bug.
+
+## Micro-tasks (TDD, red/green/refactor/commit-on-green)
+
+### T-001 — Order model: add `NoWorkGate` field + TOML decode + validation guard
+- **acceptance**: `TestOrderNoWorkGateParsed` — an order TOML with
+  `no_work_gate = true` decodes to `Order.NoWorkGate == true`; default is
+  `false`. Also assert `Validate` accepts it (no extra constraint).
+- **files**: `internal/orders/order.go` (struct field + `orderDecode` +
+  `normalized()`), test in `internal/orders/order_test.go`.
+- commit: `feat(orders): T-001 add Order.NoWorkGate opt-out flag — green at TestOrderNoWorkGateParsed`
+
+### T-002 — Dispatcher: skip both gates when `NoWorkGate`
+- **acceptance**: `TestOrderDispatchNoWorkGateSkipsGatesUnderStoreDelay` —
+  with `orderGateTimeout` shortened and a store whose gate queries sleep past
+  it, an order with `NoWorkGate: true` STILL dispatches (creates a tracking
+  bead) and records ZERO gate query calls; a plain order is skipped as before.
+- **files**: `cmd/gc/order_dispatch.go` (guard the two `gateOpenWorkBounded`
+  call sites + the `gateBackoffActive` short-circuit so backoff is irrelevant
+  when the gate never runs).
+- commit: `fix(dispatch): T-002 skip open-work gates for NoWorkGate orders — green at TestOrderDispatchNoWorkGateSkipsGatesUnderStoreDelay`
+
+### T-003 — Order TOML: set `no_work_gate = true` on provider-health-probe
+- **acceptance**: `TestProviderHealthProbeOrderOptsOutOfWorkGate` — the
+  shipped `packs/.../provider-health-probe.toml` parses with
+  `NoWorkGate == true`. (Source-of-truth TOML lives in voxist-platform pack;
+  this task adds the flag there + a parsing test in gascity fixtures if a copy
+  is vendored, otherwise the test loads the pack file directly.)
+- **files**: `packs/voxist-city/orders/provider-health-probe.toml`
+  (voxist-platform rig), test in gascity.
+- commit: `feat(orders): T-003 provider-health-probe opts out of work gate — green at TestProviderHealthProbeOrderOptsOutOfWorkGate`
+
+### T-004 — Docs: order-author guide note for `no_work_gate`
+- **acceptance**: a docs note exists describing when to set `no_work_gate`
+  (pure probes/sweeps that track no beads) and the warning that it disables
+  single-flight protection, so the order must be self-idempotent or
+  interval-bounded.
+- **files**: `docs/guides/orders.md` (or nearest order-author reference).
+- commit: `docs(orders): T-004 document no_work_gate opt-out`
+
+## Status
+
+- [ ] T-001
+- [ ] T-002
+- [ ] T-003
+- [ ] T-004

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -73,6 +73,18 @@ type Order struct {
 	// (gastownhall/gascity#2893). Non-idempotent orders (the
 	// default, false) keep failing CLOSED on gate timeout.
 	Idempotent bool `toml:"idempotent,omitempty"`
+	// NoWorkGate opts an order out of the dispatcher's open-work gates
+	// entirely. It is for pure probes/sweeps that track NO bead work —
+	// e.g. provider-health-probe, a cooldown probe that only refreshes a
+	// cache. The open-work gates issue bd list/query reads against the
+	// store, bounded by orderGateTimeout; on store slowness they time out
+	// and the order is skipped every cycle (gastownhall/gascity#2893
+	// dispatch starvation), so the probe never runs and its cache goes
+	// stale. Setting NoWorkGate skips both gates so the order dispatches
+	// on its trigger schedule regardless of store health. Single-flight
+	// is the author's responsibility: the order must be self-idempotent
+	// or interval-bounded, since no gate prevents an overlapping re-run.
+	NoWorkGate bool `toml:"no_work_gate,omitempty"`
 	// Env is a map of environment variables exported into an exec
 	// order's child process. Use the `[order.env]` TOML table to
 	// override thresholds (e.g. GC_DOCTOR_LATENCY_WARN_S) without
@@ -129,6 +141,7 @@ type orderDecode struct {
 	CheckTimeout string                `toml:"check_timeout,omitempty"`
 	Enabled      *bool                 `toml:"enabled,omitempty"`
 	Idempotent   bool                  `toml:"idempotent,omitempty"`
+	NoWorkGate   bool                  `toml:"no_work_gate,omitempty"`
 	Env          map[string]string     `toml:"env,omitempty"`
 	Params       map[string]OrderParam `toml:"params,omitempty"`
 	SkipAliases  []string              `toml:"skip_aliases,omitempty"`
@@ -155,6 +168,7 @@ func (d orderDecode) normalized() Order {
 		CheckTimeout: d.CheckTimeout,
 		Enabled:      d.Enabled,
 		Idempotent:   d.Idempotent,
+		NoWorkGate:   d.NoWorkGate,
 		Env:          d.Env,
 		Params:       d.Params,
 		skipAliases:  d.SkipAliases,

--- a/internal/orders/order_test.go
+++ b/internal/orders/order_test.go
@@ -116,6 +116,53 @@ func TestOrderNoWorkGateParsed(t *testing.T) {
 	}
 }
 
+// TestProviderHealthProbeOrderOptsOutOfWorkGate covers the deployed shape of
+// provider-health-probe (vp-cixi.6 GAP D): a cooldown-triggered exec probe on
+// a 10m interval with a real 120s timeout. The shipped pack will flip
+// no_work_gate = true (sling S-1) so the dispatcher skips its open-work gates
+// and a slow Dolt store can no longer time them out and skip the probe every
+// cycle (#2893 dispatch starvation). This test pins the parse shape so the
+// pack flip is mechanically known to be valid: WITH the flag the order opts
+// out and passes Validate; WITHOUT it the order parses as a plain cooldown
+// probe (NoWorkGate == false, the pre-S-1 default).
+func TestProviderHealthProbeOrderOptsOutOfWorkGate(t *testing.T) {
+	base := `[order]
+description = "Probe provider health"
+exec = "$ORDER_DIR/scripts/provider-health-probe.sh"
+trigger = "cooldown"
+interval = "10m"
+timeout = "120s"
+`
+	on, err := Parse([]byte(base + "no_work_gate = true\n"))
+	if err != nil {
+		t.Fatalf("Parse (with flag): %v", err)
+	}
+	if !on.NoWorkGate {
+		t.Error("NoWorkGate = false, want true for opted-out probe")
+	}
+	if on.Trigger != "cooldown" || on.Interval != "10m" || on.Timeout != "120s" {
+		t.Errorf("probe shape mismatch: trigger=%q interval=%q timeout=%q", on.Trigger, on.Interval, on.Timeout)
+	}
+	if err := Validate(Order{
+		Name:       "provider-health-probe",
+		Exec:       "$ORDER_DIR/scripts/provider-health-probe.sh",
+		Trigger:    "cooldown",
+		Interval:   "10m",
+		Timeout:    "120s",
+		NoWorkGate: true,
+	}); err != nil {
+		t.Errorf("Validate provider-health-probe with NoWorkGate: %v", err)
+	}
+
+	off, err := Parse([]byte(base))
+	if err != nil {
+		t.Fatalf("Parse (without flag): %v", err)
+	}
+	if off.NoWorkGate {
+		t.Error("NoWorkGate = true, want false (default) for probe without the flag")
+	}
+}
+
 func TestValidateCooldown(t *testing.T) {
 	a := Order{Name: "digest", Formula: "mol-digest", Trigger: "cooldown", Interval: "24h"}
 	if err := Validate(a); err != nil {

--- a/internal/orders/order_test.go
+++ b/internal/orders/order_test.go
@@ -91,6 +91,31 @@ func TestParseIdempotent(t *testing.T) {
 	}
 }
 
+// TestOrderNoWorkGateParsed covers vp-cixi.6: an order can opt out of the
+// dispatcher's open-work gates via no_work_gate. Pure cooldown probes that
+// track no beads (provider-health-probe) set this so a slow Dolt store can't
+// time the gate out and skip the probe every cycle (#2893 dispatch starvation).
+func TestOrderNoWorkGateParsed(t *testing.T) {
+	on, err := Parse([]byte("[order]\nexec = \"true\"\ntrigger = \"cooldown\"\ninterval = \"10m\"\nno_work_gate = true\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !on.NoWorkGate {
+		t.Error("NoWorkGate = false, want true")
+	}
+	off, err := Parse([]byte("[order]\nexec = \"true\"\ntrigger = \"cooldown\"\ninterval = \"10m\"\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if off.NoWorkGate {
+		t.Error("NoWorkGate = true, want false (default)")
+	}
+	// Validate must accept the flag (no extra constraint).
+	if err := Validate(Order{Name: "probe", Exec: "true", Trigger: "cooldown", Interval: "10m", NoWorkGate: true}); err != nil {
+		t.Errorf("Validate with NoWorkGate: %v", err)
+	}
+}
+
 func TestValidateCooldown(t *testing.T) {
 	a := Order{Name: "digest", Formula: "mol-digest", Trigger: "cooldown", Interval: "24h"}
 	if err := Validate(a); err != nil {


### PR DESCRIPTION
## Summary

Fixes the dispatch-starvation root cause (GAP D from vp-cixi.5) for gate-less
cooldown probes like `provider-health-probe`.

`provider-health-probe` is a pure cooldown probe that tracks **no beads**, yet
the dispatcher runs two open-work gates per tick (`hasOpenTracking` then
`hasOpenWork`), each issuing `bd list` / `bd query` reads against Dolt bounded
by `orderGateTimeout` (8s). On store slowness the gate times out and
`gateFailClosed` **skips the order every cycle** → the provider-health cache
goes stale → fail-closed provider health → failover can't pick `claude2` or
anything else. Confirmed live: 60–90+min gaps between probe runs despite a 10m
interval.

PR #357 shipped a mitigation (hysteresis + wider TTL) that absorbs the skips.
**This PR is the deeper gc-core fix:** let an order OPT OUT of the open-work
gates entirely, since they are meaningless for orders that consume no bead work.

## Approach

Add an order-level opt-out flag `no_work_gate` (Go `Order.NoWorkGate`). When
`true`, the dispatcher skips **both** open-work gates for that order — no
`gateOpenWorkBounded` call, no Dolt reads, no fail-closed skip, no
gate-timeout backoff. The order still respects its own cooldown interval and
per-order exec timeout; single-flight stays naturally bounded by the cooldown
interval + the synchronous tracking-bead the dispatcher creates before launch.

**Why a new flag, not reusing `Idempotent`:** `Idempotent` flips semantics to
fail-**OPEN** on timeout (may double-dispatch). A gate-less probe must not even
*enter* the gate — it must not depend on a Dolt read completing inside 8s, and
should never emit `order.gate_timeout_fail_open`. "Safe to re-run" and
"consumes no bead work" are distinct properties; conflating them would keep a
probe's dispatch contingent on store health, which is exactly the bug.

## Layer split (plan ends at the boundary)

The gc-core mechanism ships here. **Activating** the flag on the live probe is
a deployed-pack-layer edit (`packs/voxist-city/orders/provider-health-probe.toml`,
not tracked in this repo) — filed as a separate cross-layer follow-up bead
(plan sling S-1), not part of this PR. This PR is mergeable on its own: it
ships the opt-out mechanism + tests; the pack flip turns it on for the one
order that needs it today.

## Changes (TDD, red/green/commit-on-green)

- **T-001** `feat(orders)`: add `Order.NoWorkGate` field + TOML decode +
  validation guard (`415429c91`) — green at `TestOrderNoWorkGateParsed`.
- **T-002** `fix(dispatch)`: skip both gates (`hasOpenTracking` @515 +
  `hasOpenWork` @612) + the `gateBackoffActive` short-circuit for `NoWorkGate`
  orders (`6612e768c`) — green at `TestOrderDispatchNoWorkGateSkipsGatesUnderStoreDelay`.
- **T-003** `test(orders)`: provider-health-probe-shaped order opts out of the
  work gate (`bd0ff6b40`) — green at `TestProviderHealthProbeOrderOptsOutOfWorkGate`.
- **T-004** `docs(orders)`: order-author guide note for `no_work_gate`
  (`45a3548fa`).

## Validation

- `go vet ./...` clean
- `internal/orders` + `internal/dispatch` test suites green; no regressions
- 4 targeted `NoWorkGate` tests pass
- Fork pre-receive CI: all 8 fast-parallel jobs passed

## GDPR / MDR impact

None. The change alters *dispatch scheduling* (which gate checks run for an
order), not what data the order reads, processes, or persists. No new PII is
accessed, stored, transmitted, or retained. Entirely outside the
voxmemo→voxist-api clinical documentation pipeline.

---

Plan: \`engdocs/plans/vp-cixi.6-drop-open-work-gate-for-gateless-cooldown-probes.md\`
Bead: vp-cixi.6 (child of EPIC vp-cixi). Related: #2893, #357.
