### PR TITLE
Centralize gc.routed_to routing identity

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -255,10 +256,7 @@ func effectiveOverlayDirs(cityDirs []string, rigDirs map[string][]string, rigNam
 // back to the template, so `gc internal materialize-skills` exits 1.
 // For regular agents, qualifiedName already equals the template name.
 func templateNameFor(cfgAgent *config.Agent, qualifiedName string) string {
-	if cfgAgent.PoolName != "" {
-		return cfgAgent.PoolName
-	}
-	if t := cfgAgent.QualifiedName(); t != "" && t != qualifiedName {
+	if t := agentutil.RoutedToIdentity(cfgAgent); t != "" && t != qualifiedName {
 		return t
 	}
 	return qualifiedName

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -750,7 +751,7 @@ func graphFallbackBindingForBead(source beads.Bead, store beads.Store, cityName,
 		return graphRouteBinding{}, fmt.Errorf("unknown formulas v2 fallback target %q on %s", routedTo, source.ID)
 	}
 
-	binding := graphRouteBinding{QualifiedName: agentCfg.QualifiedName()}
+	binding := graphRouteBinding{QualifiedName: agentutil.RoutedToIdentity(&agentCfg)}
 	if agentCfg.SupportsInstanceExpansion() {
 		binding.MetadataOnly = true
 		return binding, nil

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -666,13 +667,7 @@ func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, store
 }
 
 func hookClaimPrimaryRouteTarget(a *config.Agent) string {
-	if a == nil {
-		return ""
-	}
-	if target := strings.TrimSpace(a.PoolName); target != "" {
-		return target
-	}
-	return a.QualifiedName()
+	return agentutil.RoutedToIdentity(a)
 }
 
 func firstNonEmptyHookValue(values ...string) string {

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1440,7 +1440,7 @@ func resolveGraphStepBindingWithVars(stepID string, stepByID map[string]*formula
 	if !ok {
 		return graphRouteBinding{}, fmt.Errorf("step %s: unknown formulas v2 target %q", stepID, target.value)
 	}
-	binding := graphRouteBinding{QualifiedName: agentCfg.QualifiedName()}
+	binding := graphRouteBinding{QualifiedName: agentutil.RoutedToIdentity(&agentCfg)}
 	if agentCfg.SupportsInstanceExpansion() {
 		binding.MetadataOnly = true
 		cache[stepID] = binding

--- a/cmd/gc/doctor_routed_to_checks.go
+++ b/cmd/gc/doctor_routed_to_checks.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -25,9 +27,28 @@ func newV2RoutedToNamespaceCheck(cfg *config.City, cityPath string, newStore fun
 
 func (c *v2RoutedToNamespaceCheck) Name() string { return "v2-routed-to-namespace" }
 
-func (c *v2RoutedToNamespaceCheck) CanFix() bool { return false }
+func (c *v2RoutedToNamespaceCheck) CanFix() bool { return true }
 
-func (c *v2RoutedToNamespaceCheck) Fix(_ *doctor.CheckContext) error { return nil }
+// routedToDriftFinding is a single bead whose gc.routed_to value is a short
+// (binding-unqualified) form of a route that is bound in this city's config,
+// and so needs rewriting to the binding-qualified canonical form. canonicals
+// holds every distinct qualified route that short form could mean; when more
+// than one candidate exists there is no single unambiguous rewrite target, so
+// Fix leaves it for manual resolution.
+type routedToDriftFinding struct {
+	label      string
+	store      beads.Store
+	beadID     string
+	route      string
+	canonicals []string
+}
+
+func (f routedToDriftFinding) describe() string {
+	if len(f.canonicals) == 1 {
+		return fmt.Sprintf("%s bead %s has gc.routed_to=%q; use %q", f.label, f.beadID, f.route, f.canonicals[0])
+	}
+	return fmt.Sprintf("%s bead %s has gc.routed_to=%q; use one of %s", f.label, f.beadID, f.route, strings.Join(f.canonicals, ", "))
+}
 
 func (c *v2RoutedToNamespaceCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 	aliases := boundRoutedToAliases(c.cfg)
@@ -35,23 +56,14 @@ func (c *v2RoutedToNamespaceCheck) Run(_ *doctor.CheckContext) *doctor.CheckResu
 		return okCheck(c.Name(), "no binding-qualified route targets configured")
 	}
 
-	var findings []string
-	var skipped []string
-	c.scanScope(&findings, &skipped, aliases, "city", c.cityPath)
-	if c.cfg != nil {
-		suspState, _ := loadSuspensionState(fsys.OSFS{}, c.cityPath)
-		for _, rig := range c.cfg.Rigs {
-			if suspensionstate.EffectiveRigSuspended(suspState, rig.Name, rig.EffectiveSuspendedOnStart()) || strings.TrimSpace(rig.Path) == "" {
-				continue
-			}
-			c.scanScope(&findings, &skipped, aliases, "rig "+rig.Name, rig.Path)
-		}
-	}
-
+	findings, skipped := c.collect(aliases)
 	if len(findings) == 0 && len(skipped) == 0 {
 		return okCheck(c.Name(), "no short-form gc.routed_to values targeting bound agents found")
 	}
-	details := append([]string{}, findings...)
+	details := make([]string, 0, len(findings)+len(skipped))
+	for _, f := range findings {
+		details = append(details, f.describe())
+	}
 	details = append(details, skipped...)
 	sort.Strings(details)
 	if len(findings) == 0 {
@@ -63,24 +75,86 @@ func (c *v2RoutedToNamespaceCheck) Run(_ *doctor.CheckContext) *doctor.CheckResu
 	if len(skipped) > 0 {
 		return warnCheck(c.Name(),
 			fmt.Sprintf("%d short-form gc.routed_to value(s) target bound PackV2 agents; %d scope(s) skipped", len(findings), len(skipped)),
-			"rewrite gc.routed_to to the binding-qualified agent name, fix skipped store access, then rerun gc doctor",
+			"run gc doctor --fix to rewrite the unambiguous ones, fix skipped store access, then rerun gc doctor",
 			details)
 	}
 	return warnCheck(c.Name(),
 		fmt.Sprintf("%d short-form gc.routed_to value(s) target bound PackV2 agents", len(findings)),
-		"rewrite gc.routed_to to the binding-qualified agent name, then rerun gc doctor",
+		"run gc doctor --fix to rewrite gc.routed_to to the binding-qualified agent name, then rerun gc doctor",
 		details)
 }
 
-func (c *v2RoutedToNamespaceCheck) scanScope(findings, skipped *[]string, aliases map[string][]string, label, path string) {
-	if c.newStore == nil || strings.TrimSpace(path) == "" {
-		return
+// Fix rewrites every unambiguous finding's gc.routed_to to its canonical
+// binding-qualified form. Findings with more than one candidate canonical
+// (boundRoutedToAliases could not resolve a single rewrite target) are left
+// untouched for manual resolution. Fix is partial-failure-tolerant: a
+// SetMetadata error on one bead, or a store this check could not scan, does
+// not stop it from attempting every other unambiguous finding — every error
+// encountered is accumulated and returned together via errors.Join.
+func (c *v2RoutedToNamespaceCheck) Fix(_ *doctor.CheckContext) error {
+	aliases := boundRoutedToAliases(c.cfg)
+	if len(aliases) == 0 {
+		return nil
 	}
-	store, err := c.newStore(path)
-	if err != nil {
-		*skipped = append(*skipped, fmt.Sprintf("%s skipped: opening bead store: %v", label, err))
-		return
+	findings, skipped := c.collect(aliases)
+	var errs []error
+	for _, f := range findings {
+		if len(f.canonicals) != 1 {
+			continue
+		}
+		if err := f.store.SetMetadata(f.beadID, beadmeta.RoutedToMetadataKey, f.canonicals[0]); err != nil {
+			errs = append(errs, fmt.Errorf("%s bead %s: rewrite gc.routed_to to %q: %w", f.label, f.beadID, f.canonicals[0], err))
+		}
 	}
+	if len(skipped) > 0 {
+		errs = append(errs, fmt.Errorf("v2-routed-to-namespace skipped %d scope(s): %s", len(skipped), strings.Join(skipped, "; ")))
+	}
+	return errors.Join(errs...)
+}
+
+// collect scans every in-scope bead store for beads whose gc.routed_to names
+// a short form present in aliases. Callers must only call this with a
+// non-empty aliases map (both Run and Fix short-circuit before calling it
+// otherwise), since an empty aliases map would make every per-store route
+// query a no-op.
+func (c *v2RoutedToNamespaceCheck) collect(aliases map[string][]string) (findings []routedToDriftFinding, skipped []string) {
+	scopes := []struct{ label, path string }{{"city", c.cityPath}}
+	if c.cfg != nil {
+		suspState, _ := loadSuspensionState(fsys.OSFS{}, c.cityPath)
+		for _, rig := range c.cfg.Rigs {
+			if suspensionstate.EffectiveRigSuspended(suspState, rig.Name, rig.EffectiveSuspendedOnStart()) || strings.TrimSpace(rig.Path) == "" {
+				continue
+			}
+			scopes = append(scopes, struct{ label, path string }{"rig " + rig.Name, rig.Path})
+		}
+	}
+	for _, sc := range scopes {
+		if c.newStore == nil || strings.TrimSpace(sc.path) == "" {
+			continue
+		}
+		store, err := c.newStore(sc.path)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s skipped: opening bead store: %v", sc.label, err))
+			continue
+		}
+		scopeFindings, err := c.collectStoreFindings(store, aliases, sc.label)
+		findings = append(findings, scopeFindings...)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s skipped: listing beads: %v", sc.label, err))
+		}
+	}
+	return findings, skipped
+}
+
+// collectStoreFindings queries store once per candidate short-form route
+// (a targeted metadata lookup, not a full-store scan) and returns every
+// distinct bead found carrying one of those short forms. It stops and
+// returns whatever it already found, plus the error, the first time a route
+// query fails — mirroring the targeted-query error handling the rest of this
+// check relies on, so a single flaky query does not silently drop the routes
+// that already succeeded.
+func (c *v2RoutedToNamespaceCheck) collectStoreFindings(store beads.Store, aliases map[string][]string, label string) ([]routedToDriftFinding, error) {
+	var findings []routedToDriftFinding
 	seen := make(map[string]bool)
 	routes := make([]string, 0, len(aliases))
 	for route := range aliases {
@@ -92,34 +166,31 @@ func (c *v2RoutedToNamespaceCheck) scanScope(findings, skipped *[]string, aliase
 			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: route},
 		})
 		if err != nil {
-			*skipped = append(*skipped, fmt.Sprintf("%s skipped: listing beads: %v", label, err))
-			return
+			return findings, err
 		}
 		for _, bead := range items {
 			if seen[bead.ID] {
 				continue
 			}
 			seen[bead.ID] = true
-			c.scanRoutedToBead(findings, aliases, label, bead)
+			route := strings.TrimSpace(bead.Metadata[beadmeta.RoutedToMetadataKey])
+			if route == "" {
+				continue
+			}
+			canonicals, ok := aliases[route]
+			if !ok {
+				continue
+			}
+			findings = append(findings, routedToDriftFinding{
+				label:      label,
+				store:      store,
+				beadID:     bead.ID,
+				route:      route,
+				canonicals: canonicals,
+			})
 		}
 	}
-}
-
-func (c *v2RoutedToNamespaceCheck) scanRoutedToBead(findings *[]string, aliases map[string][]string, label string, bead beads.Bead) {
-	route := strings.TrimSpace(bead.Metadata[beadmeta.RoutedToMetadataKey])
-	if route == "" {
-		return
-	}
-	canonicals, ok := aliases[route]
-	if !ok {
-		return
-	}
-	switch len(canonicals) {
-	case 1:
-		*findings = append(*findings, fmt.Sprintf("%s bead %s has gc.routed_to=%q; use %q", label, bead.ID, route, canonicals[0]))
-	default:
-		*findings = append(*findings, fmt.Sprintf("%s bead %s has gc.routed_to=%q; use one of %s", label, bead.ID, route, strings.Join(canonicals, ", ")))
-	}
+	return findings, nil
 }
 
 func boundRoutedToAliases(cfg *config.City) map[string][]string {
@@ -141,7 +212,7 @@ func boundRoutedToAliases(cfg *config.City) map[string][]string {
 		if strings.TrimSpace(agent.BindingName) == "" {
 			continue
 		}
-		addAlias(unboundRouteIdentity(agent), agent.QualifiedName())
+		addAlias(unboundRouteIdentity(agent), agentutil.RoutedToIdentity(&agent))
 	}
 	for i := range cfg.NamedSessions {
 		session := cfg.NamedSessions[i]

--- a/cmd/gc/doctor_routed_to_checks_test.go
+++ b/cmd/gc/doctor_routed_to_checks_test.go
@@ -202,6 +202,142 @@ func TestV2RoutedToNamespaceCheckWarnsOnSkippedStoreScopes(t *testing.T) {
 	}
 }
 
+func TestV2RoutedToNamespaceCheckCanFix(t *testing.T) {
+	check := newV2RoutedToNamespaceCheck(&config.City{}, t.TempDir(), nil)
+	if !check.CanFix() {
+		t.Fatal("expected CanFix to return true")
+	}
+}
+
+func TestV2RoutedToNamespaceCheckFixRewritesUnambiguousShortRoute(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog", BindingName: "gastown"},
+		},
+	}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "warrant", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "dog"}},
+	}, nil)
+
+	check := newV2RoutedToNamespaceCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status after fix = %v, want ok: %#v", result.Status, result)
+	}
+
+	items, err := cityStore.List(beads.ListQuery{Metadata: map[string]string{"gc.routed_to": "gastown.dog"}})
+	if err != nil {
+		t.Fatalf("listing city store: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "CITY-1" {
+		t.Fatalf("expected CITY-1 rewritten to gastown.dog, got %+v", items)
+	}
+}
+
+func TestV2RoutedToNamespaceCheckFixLeavesAmbiguousRoutesUntouched(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog", BindingName: "gastown"},
+			{Name: "dog", BindingName: "otherpack"},
+		},
+	}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "warrant", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "dog"}},
+	}, nil)
+
+	check := newV2RoutedToNamespaceCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status after fix = %v, want warning (ambiguous route must stay unresolved): %#v", result.Status, result)
+	}
+	details := strings.Join(result.Details, "\n")
+	want := `city bead CITY-1 has gc.routed_to="dog"; use one of gastown.dog, otherpack.dog`
+	if !strings.Contains(details, want) {
+		t.Fatalf("details missing %q:\n%s", want, details)
+	}
+
+	items, err := cityStore.List(beads.ListQuery{Metadata: map[string]string{"gc.routed_to": "dog"}})
+	if err != nil {
+		t.Fatalf("listing city store: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "CITY-1" {
+		t.Fatalf("expected CITY-1 to still carry the unresolved short route, got %+v", items)
+	}
+}
+
+func TestV2RoutedToNamespaceCheckFixIsPartialFailureTolerant(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog", BindingName: "gastown"},
+			{Name: "polecat", Dir: "repo", BindingName: "gastown"},
+		},
+		Rigs: []config.Rig{
+			{Name: "repo", Path: rigDir},
+		},
+	}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "warrant", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "dog"}},
+	}, nil)
+	failingRigStore := routeSetMetadataErrorStore{
+		Store: beads.NewMemStoreFrom(0, []beads.Bead{
+			{ID: "RIG-1", Title: "work", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "repo/polecat"}},
+		}, nil),
+		err: errors.New("write denied"),
+	}
+	stores := map[string]beads.Store{
+		cityDir: cityStore,
+		rigDir:  failingRigStore,
+	}
+
+	check := newV2RoutedToNamespaceCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		store, ok := stores[path]
+		if !ok {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return store, nil
+	})
+
+	err := check.Fix(&doctor.CheckContext{})
+	if err == nil {
+		t.Fatal("expected Fix to return an error for the failing store, got nil")
+	}
+	if !strings.Contains(err.Error(), "write denied") {
+		t.Fatalf("error %q does not mention the underlying SetMetadata failure", err.Error())
+	}
+
+	items, listErr := cityStore.List(beads.ListQuery{Metadata: map[string]string{"gc.routed_to": "gastown.dog"}})
+	if listErr != nil {
+		t.Fatalf("listing city store: %v", listErr)
+	}
+	if len(items) != 1 || items[0].ID != "CITY-1" {
+		t.Fatalf("expected CITY-1 rewritten to gastown.dog despite the rig store's failure, got %+v", items)
+	}
+}
+
 type routeListErrorStore struct {
 	beads.Store
 	err error
@@ -209,6 +345,15 @@ type routeListErrorStore struct {
 
 func (s routeListErrorStore) List(beads.ListQuery) ([]beads.Bead, error) {
 	return nil, s.err
+}
+
+type routeSetMetadataErrorStore struct {
+	beads.Store
+	err error
+}
+
+func (s routeSetMetadataErrorStore) SetMetadata(string, string, string) error {
+	return s.err
 }
 
 type routeQuerySpyStore struct {

--- a/cmd/gc/work_query_probe.go
+++ b/cmd/gc/work_query_probe.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/shellquote"
@@ -168,7 +169,7 @@ func prefixedWorkQueryForProbeWithEnv(
 	}
 	env["GC_AGENT"] = agentCfg.QualifiedName()
 	env["GC_SESSION_NAME"] = sessionName
-	env["GC_TEMPLATE"] = agentCfg.QualifiedName()
+	env["GC_TEMPLATE"] = agentutil.RoutedToIdentity(agentCfg)
 	return prefixShellEnv(env, command)
 }
 

--- a/internal/agentutil/resolve.go
+++ b/internal/agentutil/resolve.go
@@ -188,6 +188,29 @@ func resolvePoolInstanceQualified(cfg *config.City, input string) (config.Agent,
 	return config.Agent{}, false
 }
 
+// RoutedToIdentity returns the canonical gc.routed_to value for agent: its
+// PoolName when set, otherwise its own QualifiedName(). PoolName is set only
+// on pool-instance copies synthesized from a base template (see
+// cmd/gc/pool.go), and always holds that base template's own
+// QualifiedName() — so this collapses a pool instance back to the identity
+// its base template routes under.
+//
+// Every writer that stamps gc.routed_to and every reader that resolves it
+// must derive the value through this function. Calling QualifiedName()
+// directly bypasses the PoolName collapse: a pool-instance agent's routing
+// then diverges from what gc sling stamped for its base template, and the
+// bead becomes invisible to pool demand/claim (this has been independently
+// gotten wrong at multiple call sites — see ga-79uuwq).
+func RoutedToIdentity(agent *config.Agent) string {
+	if agent == nil {
+		return ""
+	}
+	if agent.PoolName != "" {
+		return agent.PoolName
+	}
+	return agent.QualifiedName()
+}
+
 // NormalizePoolRouteTarget collapses a slot-suffixed pool target qualified
 // name (e.g. "myrig/polecat-2") back to its base pool qualified name
 // ("myrig/polecat"). Slinging to a slot-suffixed target expresses a
@@ -211,7 +234,7 @@ func NormalizePoolRouteTarget(cfg *config.City, target string) string {
 		if !IsMultiSessionAgent(&a) {
 			continue
 		}
-		base := a.QualifiedName()
+		base := RoutedToIdentity(&a)
 		prefix := base + "-"
 		if !strings.HasPrefix(target, prefix) {
 			continue

--- a/internal/agentutil/resolve_test.go
+++ b/internal/agentutil/resolve_test.go
@@ -212,6 +212,47 @@ func TestResolveAgentNotFound(t *testing.T) {
 	}
 }
 
+func TestRoutedToIdentity(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent *config.Agent
+		want  string
+	}{
+		{
+			name:  "pool instance collapses to PoolName",
+			agent: &config.Agent{Name: "polecat-2", Dir: "myrig", PoolName: "myrig/polecat"},
+			want:  "myrig/polecat",
+		},
+		{
+			name:  "bound agent with no PoolName uses QualifiedName",
+			agent: &config.Agent{Name: "dog", BindingName: "gastown"},
+			want:  "gastown.dog",
+		},
+		{
+			name:  "doubled qualified name is unaffected when PoolName unset",
+			agent: &config.Agent{Name: "dog", BindingName: "dog"},
+			want:  "dog.dog",
+		},
+		{
+			name:  "unbound agent uses bare QualifiedName",
+			agent: &config.Agent{Name: "mayor"},
+			want:  "mayor",
+		},
+		{
+			name:  "nil agent returns empty string",
+			agent: nil,
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RoutedToIdentity(tt.agent); got != tt.want {
+				t.Errorf("RoutedToIdentity(%+v) = %q, want %q", tt.agent, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizePoolRouteTarget(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{

--- a/internal/agentutil/routed_to_boundary_test.go
+++ b/internal/agentutil/routed_to_boundary_test.go
@@ -1,0 +1,126 @@
+package agentutil
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// repoRoot returns the repository root by navigating from this file's location.
+func repoRoot() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..")
+}
+
+// TestRoutedToIdentityDerivationIsCentralized enforces that every gc.routed_to
+// derivation (PoolName-first, falling back to QualifiedName()) flows through
+// RoutedToIdentity. Reimplementing the check inline lets a pool instance's
+// routing diverge from what gc sling stamped for its base template, making
+// the bead invisible to pool demand/claim — this has independently regressed
+// at multiple call sites (see ga-79uuwq, ga-s635qm).
+//
+// Not violations (allowed):
+//   - internal/agentutil/resolve.go — RoutedToIdentity's own implementation.
+//   - internal/config/workquery.go — poolDemandTarget, DefaultSlingQuery,
+//     effectiveOnDeath, and effectiveOnBoot must inline the check: agentutil
+//     imports config, so config cannot call back into agentutil without an
+//     import cycle. This is a reviewed, permanent exception, not a pending
+//     migration.
+func TestRoutedToIdentityDerivationIsCentralized(t *testing.T) {
+	root := repoRoot()
+
+	allowedFiles := []string{
+		filepath.Join("internal", "agentutil", "resolve.go"),
+		filepath.Join("internal", "config", "workquery.go"),
+	}
+
+	var violations []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			base := filepath.Base(path)
+			if base == ".git" || base == "vendor" || base == ".claude" || base == ".gc" || strings.HasPrefix(base, ".beads-src") {
+				return filepath.SkipDir
+			}
+			// Skip git worktrees embedded in the repo (have a .git file, not
+			// dir) — but never apply this to root itself. gc builder/reviewer/
+			// deployer sessions run from inside a worktree, so root legitimately
+			// has a .git file rather than a .git directory; skipping on that
+			// condition here would SkipDir the walk's very first entry and
+			// silently visit zero files.
+			if path != root {
+				if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		for _, allowed := range allowedFiles {
+			if rel == allowed {
+				return nil
+			}
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+		lineNum := 0
+		for scanner.Scan() {
+			lineNum++
+			line := scanner.Text()
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "//") {
+				continue
+			}
+			if strings.Contains(line, `PoolName != ""`) {
+				violations = append(violations, rel+":"+itoa(lineNum)+": "+trimmed)
+			}
+		}
+		return scanner.Err()
+	})
+	if err != nil {
+		t.Fatalf("walking repo: %v", err)
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Errorf("inline PoolName collapse found outside RoutedToIdentity (%d violations):", len(violations))
+		for _, v := range violations {
+			t.Errorf("  %s", v)
+		}
+		t.Error("Call agentutil.RoutedToIdentity(agent) instead of reimplementing the PoolName-first collapse.")
+	}
+}
+
+// itoa converts an int to a string without importing strconv.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	s := ""
+	for n > 0 {
+		s = string(rune('0'+n%10)) + s
+		n /= 10
+	}
+	return s
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2347,6 +2347,9 @@ esac
 }
 
 func TestEffectiveSlingQueryPoolNameOverride(t *testing.T) {
+	// Pool instance: the stamped gc.routed_to must be the collapsed PoolName
+	// (template identity), not the raw per-instance QualifiedName() — matching
+	// the PoolName-first idiom in poolDemandTarget/effectiveOnDeath/effectiveOnBoot.
 	a := Agent{
 		Name:              "dog-1",
 		Dir:               "hello-world",
@@ -2354,9 +2357,20 @@ func TestEffectiveSlingQueryPoolNameOverride(t *testing.T) {
 		PoolName: "hello-world/dog",
 	}
 	got := a.EffectiveSlingQuery()
-	want := "bd update {} --set-metadata gc.routed_to=hello-world/dog-1"
+	want := "bd update {} --set-metadata gc.routed_to=hello-world/dog"
 	if got != want {
 		t.Errorf("EffectiveSlingQuery() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultSlingQueryPoolNameCollapse(t *testing.T) {
+	// Same PoolName-collapse idiom, asserted directly against DefaultSlingQuery()
+	// rather than through the EffectiveSlingQuery() wrapper.
+	a := Agent{Name: "dog-1", Dir: "hello-world", PoolName: "hello-world/dog"}
+	got := a.DefaultSlingQuery()
+	want := "bd update {} --set-metadata gc.routed_to=hello-world/dog"
+	if got != want {
+		t.Errorf("DefaultSlingQuery() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/config/workquery.go
+++ b/internal/config/workquery.go
@@ -470,7 +470,11 @@ func (a *Agent) EffectiveSlingQuery() string {
 // this agent. Callers outside config should prefer this helper over rebuilding
 // the command string to preserve the bd boundary invariant.
 func (a *Agent) DefaultSlingQuery() string {
-	return "bd update {} --set-metadata " + beadmeta.RoutedToMetadataKey + "=" + a.QualifiedName()
+	route := a.QualifiedName()
+	if a.PoolName != "" {
+		route = a.PoolName
+	}
+	return "bd update {} --set-metadata " + beadmeta.RoutedToMetadataKey + "=" + route
 }
 
 // EffectivePoolDemandQuery returns the count-form pool-demand query the

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -291,7 +291,7 @@ func resolveControlDispatcherBinding(_ beads.Store, _ string, cfg *config.City, 
 	// Resolver-based lookup. ControlDispatcherForScope selects the configured
 	// dispatcher whose scope matches the graph store.
 	if agentCfg, ok := config.ControlDispatcherForScope(cfg, rigContext); ok {
-		return GraphRouteBinding{QualifiedName: agentCfg.QualifiedName(), MetadataOnly: true}, nil
+		return GraphRouteBinding{QualifiedName: agentutil.RoutedToIdentity(&agentCfg), MetadataOnly: true}, nil
 	}
 	// Fallback for configs without a deterministic dispatcher (e.g. a plain
 	// control-dispatcher agent carrying no convoy-control StartCommand): defer
@@ -303,7 +303,7 @@ func resolveControlDispatcherBinding(_ beads.Store, _ string, cfg *config.City, 
 		}
 		return GraphRouteBinding{}, fmt.Errorf("city control-dispatcher agent %q not found", config.ControlDispatcherAgentName)
 	}
-	return GraphRouteBinding{QualifiedName: agentCfg.QualifiedName(), MetadataOnly: true}, nil
+	return GraphRouteBinding{QualifiedName: agentutil.RoutedToIdentity(&agentCfg), MetadataOnly: true}, nil
 }
 
 // ResolveGraphStepBinding resolves the routing binding for a graph step
@@ -431,7 +431,7 @@ func ResolveGraphStepBindingWithVars(stepID string, stepByID map[string]*formula
 	if !ok {
 		return GraphRouteBinding{}, fmt.Errorf("step %s: unknown formulas v2 target %q", stepID, target.value)
 	}
-	binding := GraphRouteBinding{QualifiedName: agentCfg.QualifiedName()}
+	binding := GraphRouteBinding{QualifiedName: agentutil.RoutedToIdentity(&agentCfg)}
 	if agentCfg.SupportsInstanceExpansion() {
 		binding.MetadataOnly = true
 		cache[stepID] = binding

--- a/internal/materialize/mcp_runtime.go
+++ b/internal/materialize/mcp_runtime.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -58,10 +59,7 @@ func MCPTemplateData(
 	}
 	rigName := workdirutil.ConfiguredRigName(cityPath, *agent, rigs)
 	rigRoot := workdirutil.RigRootForName(rigName, rigs)
-	templateName := agent.QualifiedName()
-	if agent.PoolName != "" {
-		templateName = agent.PoolName
-	}
+	templateName := agentutil.RoutedToIdentity(agent)
 	if templateName == "" {
 		templateName = identity
 	}

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -1347,7 +1347,7 @@ func InstantiateCompiledSlingFormula(ctx context.Context, recipe *formula.Recipe
 // atomic across processes.
 func materializeCompiledSlingFormula(ctx context.Context, recipe *formula.Recipe, formulaName string, opts molecule.Options, sourceBeadID, scopeKind, scopeRef string, graphWorkflow bool, a config.Agent, deps SlingDeps, forceGraphV2Replace ...bool) (*molecule.Result, error) {
 	graphStore := deps.graphStore()
-	if err := graphroute.ApplyGraphRouting(recipe, &a, a.QualifiedName(), opts.Vars, sourceBeadID, scopeKind, scopeRef, deps.StoreRef, graphStore, deps.CityName, deps.Cfg, deps.graphrouteDeps()); err != nil {
+	if err := graphroute.ApplyGraphRouting(recipe, &a, agentutil.RoutedToIdentity(&a), opts.Vars, sourceBeadID, scopeKind, scopeRef, deps.StoreRef, graphStore, deps.CityName, deps.Cfg, deps.graphrouteDeps()); err != nil {
 		SlingTracef("instantiate decorate-error formula=%s err=%v", formulaName, err)
 		return nil, err
 	}

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -451,7 +451,7 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 		return BeadCheckResult{Warnings: routedStateWarnings(b, beadID)}
 	}
 
-	target := a.QualifiedName()
+	target := agentutil.RoutedToIdentity(&a)
 	if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) == target {
 		if b.Assignee == "" || b.Assignee == target {
 			return resolveConvoyRecovery(q, b, deps, opts, beadID)

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -534,7 +534,7 @@ func finalize(opts SlingOpts, deps SlingDeps, beadID, method string, result Slin
 		}
 		req := RouteRequest{
 			BeadID:  beadID,
-			Target:  a.QualifiedName(),
+			Target:  agentutil.RoutedToIdentity(&a),
 			WorkDir: rigDir,
 			Env:     slingEnv,
 			Force:   opts.Force,

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -412,6 +412,40 @@ func TestCheckBeadStateRoutedWithSyntheticTrackingConvoyIsIdempotent(t *testing.
 	}
 }
 
+// TestCheckBeadStatePoolInstanceRoutedToCollapsedIdentityIsIdempotent guards
+// the ga-79uuwq PoolName-bypass regression: a pool-instance agent's bead is
+// stamped with the pool's collapsed identity (agentutil.RoutedToIdentity),
+// not the instance's own raw QualifiedName. The idempotency check must
+// resolve that same collapsed identity to recognize the bead as already
+// routed, or every pool-instance sling would spuriously re-route work that
+// was already correctly dispatched to the pool.
+func TestCheckBeadStatePoolInstanceRoutedToCollapsedIdentityIsIdempotent(t *testing.T) {
+	store := beads.NewMemStore()
+	convoy, err := store.Create(beads.Bead{Title: "auto convoy", Type: "convoy", Status: "open"})
+	if err != nil {
+		t.Fatalf("store.Create(convoy): %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:    "route me",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "myrig/polecat"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+	if err := store.DepAdd(convoy.ID, bead.ID, "tracks"); err != nil {
+		t.Fatalf("store.DepAdd(tracks): %v", err)
+	}
+
+	poolInstance := config.Agent{Name: "polecat-2", Dir: "myrig", PoolName: "myrig/polecat"}
+	result := CheckBeadState(store, bead.ID, poolInstance, SlingDeps{Store: store})
+
+	if !result.Idempotent {
+		t.Fatalf("expected Idempotent=true when pool-instance bead is routed to the collapsed pool identity, got %+v", result)
+	}
+}
+
 func TestCheckBeadStateRoutedWithClosedTrackingConvoyIsNotIdempotent(t *testing.T) {
 	store := beads.NewMemStore()
 	convoy, err := store.Create(beads.Bead{Title: "old convoy", Type: "convoy", Status: "open"})

--- a/release-gates/ga-imtb36-routed-to-resolver-clean-gate.md
+++ b/release-gates/ga-imtb36-routed-to-resolver-clean-gate.md
@@ -1,0 +1,67 @@
+# Release Gate: ga-imtb36.2 - routed_to resolver clean branch
+
+- Bead: `ga-imtb36.2` - Deploy clean routed_to resolver release branch
+- Source review bead: `ga-7fqxay`
+- Branch under gate: `deploy/ga-imtb36-routed-to-resolver-clean`
+- Base: `origin/main` at `dd8730a9c30821ea7ed6555505b1524cbaa5d2fa`
+- Candidate head before this gate: `202a64eb0013cd5457d883060955c581909ced89`
+- Release criteria source: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses the deployer release criteria from the active role prompt plus `TESTING.md`.
+
+## Candidate Diff
+
+`git log origin/main..HEAD --oneline` before this gate:
+
+```text
+202a64eb0 fix(config): collapse PoolName in DefaultSlingQuery (ga-7fqxay)
+57991b77c fix(routing): centralize gc.routed_to derivation, make doctor --fix reconcile drift
+```
+
+`git diff --stat origin/main..HEAD` before this gate:
+
+```text
+ cmd/gc/agent_build_params.go           |   6 +-
+ cmd/gc/cmd_convoy_dispatch.go          |   3 +-
+ cmd/gc/cmd_hook.go                     |   9 +-
+ cmd/gc/cmd_sling.go                    |   2 +-
+ cmd/gc/doctor_routed_to_checks.go      | 163 +++++++++++++++++++++++----------
+ cmd/gc/doctor_routed_to_checks_test.go | 145 +++++++++++++++++++++++++++++
+ cmd/gc/work_query_probe.go             |   3 +-
+ internal/agentutil/resolve.go          |  25 ++++-
+ internal/agentutil/resolve_test.go     |  41 +++++++++
+ internal/config/config.go              |   6 +-
+ internal/config/config_test.go         |  16 +++-
+ internal/graphroute/graphroute.go      |   6 +-
+ internal/sling/sling.go                |   2 +-
+ internal/sling/sling_attachment.go     |   2 +-
+ internal/sling/sling_core.go           |   2 +-
+ internal/sling/sling_test.go           |  34 +++++++
+ 16 files changed, 396 insertions(+), 69 deletions(-)
+```
+
+## Release Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-7fqxay` notes contain re-review verdict `PASS` for commit `c93d9a7bf` after the first review's medium `DefaultSlingQuery` finding was fixed. Single-pass review is sufficient while gemini second-pass is disabled. |
+| 2 | Acceptance criteria met | PASS | `ga-imtb36.1` produced the clean release branch from current `origin/main`, recorded branch/head/log/changed files, and verified no behavior drift from the reviewed range. This gate independently confirmed the release branch contains only the two routed_to resolver commits listed above. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed in a private `/tmp` namespace (`bwrap --tmpfs /tmp`) with short `/var/tmp/gf.*` `TMPDIR`, after initial host-environment attempts exposed the shared `/tmp` tmpfs at 100% and Unix socket path-length artifacts. `go vet ./...` clean. `go build ./...` clean. `gofmt -l` over all 16 changed Go files clean. `git diff --check origin/main..HEAD` clean. |
+| 4 | No high-severity review findings open | PASS | `ga-7fqxay` had one medium finding in the first review; the fix was applied in `c93d9a7bf` and the re-review verdict is PASS. No unresolved HIGH findings are present in the review notes. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` before writing this gate reported only `## HEAD (no branch)` in the detached gate worktree. The only deployer-authored change is this release gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` passed, `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` produced no conflicts, and `git diff --check origin/main..HEAD` passed. |
+| 7 | Single feature theme | PASS | The diff is one release theme: centralizing `gc.routed_to` derivation via `agentutil.RoutedToIdentity`, making `doctor --fix` reconcile v2 routed_to namespace drift, and the directly related `DefaultSlingQuery` PoolName-collapse regression fix. The unrelated pool-resume readiness commits `3ed3a448b` and `b9f3c4239` are not ancestors of this branch (`git merge-base --is-ancestor` returned non-zero for both). |
+
+## Bead Acceptance
+
+| Acceptance | Result | Evidence |
+|------------|--------|----------|
+| Wait for `ga-imtb36.1` clean branch details | PASS | `ga-imtb36.1` is closed and recorded branch `deploy/ga-imtb36-routed-to-resolver-clean`, head `202a64eb0013cd5457d883060955c581909ced89`, and fork push evidence. |
+| Run standard deploy gate and verify single feature theme | PASS | Release criteria above are all PASS; criterion 7 records the theme and exclusion checks. |
+| Confirm unrelated pool-resume readiness changes are excluded | PASS | Candidate log contains only `57991b77c` and `202a64eb0`; `3ed3a448b` and `b9f3c4239` are absent from the candidate ancestry. |
+| Record build, smoke, vet, and test evidence | PASS | Evidence is recorded in criterion 3. |
+| On PASS, open/update PR and route merge request | PENDING | To be completed after committing and pushing this gate file. |
+| On FAIL, route back to PM | PASS | Not applicable: no failed gate criterion. |
+
+## Push Target
+
+- `git push --dry-run --no-verify origin HEAD:refs/heads/deploy/ga-imtb36-routed-to-resolver-clean` succeeded, so the push target is `origin`.
+- `git push --dry-run --no-verify fork HEAD:refs/heads/deploy/ga-imtb36-routed-to-resolver-clean` reported `Everything up-to-date`; the original clean branch also exists on `fork`.


### PR DESCRIPTION
## What this changes

Gas City now derives `gc.routed_to` through one shared routing identity helper for the paths that stamp, compare, and inspect work routing. Pool-backed agents use the pool template identity consistently instead of drifting between a concrete qualified session name and the queue identity, so hook display, sling routing, graph routing, convoy dispatch, startup environment, and work-query probes agree on the same target.

`gc doctor --fix` can also repair v2 routed_to namespace drift by rewriting stale route metadata through the store. The default sling query now applies the same PoolName collapse so fallback routing does not reintroduce the old mismatch.

## Review notes

- New helper: `internal/agentutil.RoutedToIdentity` centralizes route identity for packages that can import `internal/config`.
- `internal/config` keeps its small local PoolName-first logic to avoid an import cycle.
- `doctor --fix` for the v2 routed_to namespace check mutates bead metadata through the store and reports partial failures instead of hiding them.
- No HTTP API, OpenAPI, dashboard, or generated schema changes are included.
- This branch intentionally excludes unrelated pool-resume readiness work from an earlier mixed candidate.

## Test plan

- [x] `make test-fast-parallel` - all fast jobs passed under a private `/tmp` namespace because the shared host `/tmp` was full during the gate.
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `gofmt -l` over the changed Go files
- [x] Release gate: [`release-gates/ga-imtb36-routed-to-resolver-clean-gate.md`](release-gates/ga-imtb36-routed-to-resolver-clean-gate.md)
