### PR TITLE
fix(doctor): clarify external Dolt backup message — endpoint may be local (#3868 follow-up)

### DIFF
--- a/internal/doctor/checks_dolt_backup.go
+++ b/internal/doctor/checks_dolt_backup.go
@@ -63,15 +63,18 @@ func (c *DoltBackupCheck) Run(_ *CheckContext) *CheckResult {
 
 	rigPath := c.normalizedRigPath()
 
-	// An external Dolt endpoint self-manages its backups on the remote server;
-	// the local .dolt-backup directory and managed-Dolt repo_state.json signals
-	// never apply to it, and the localhost fix hint below is actively wrong for
-	// it. Treat a resolved external endpoint as satisfied rather than warning.
-	// See gastownhall/gascity#3868. A resolution error falls through to the
+	// An external (non-managed) Dolt endpoint owns its own backups; gc does not
+	// manage them, so the local .dolt-backup directory and managed-Dolt
+	// repo_state.json signals never apply, and the localhost fix hint below is
+	// actively wrong for it. Treat a resolved external endpoint as satisfied
+	// rather than warning. Note that External classifies the endpoint's
+	// ownership, not its location — an explicit endpoint can resolve to a local
+	// host — so the message must not imply a remote machine. See
+	// gastownhall/gascity#3868. A resolution error falls through to the
 	// local-signal checks so a genuinely missing local backup still surfaces.
 	if target, err := contract.ResolveDoltConnectionTarget(fsys.OSFS{}, c.cityPath, rigPath); err == nil && target.External {
 		r.Status = StatusOK
-		r.Message = fmt.Sprintf("rig %q: external Dolt endpoint %s:%s — backups self-managed on the external server", c.rig.Name, target.Host, target.Port)
+		r.Message = fmt.Sprintf("rig %q: external Dolt endpoint %s:%s — backups assumed self-managed at the endpoint", c.rig.Name, target.Host, target.Port)
 		return r
 	}
 

--- a/internal/doctor/checks_dolt_backup_test.go
+++ b/internal/doctor/checks_dolt_backup_test.go
@@ -260,8 +260,8 @@ func writeScopeConfig(t *testing.T, scopePath, body string) {
 	}
 }
 
-// A rig whose Dolt lives on an external endpoint self-manages its backups on
-// that server; the local .dolt-backup / repo_state.json signals never apply, so
+// A rig pointing at an external (non-managed) Dolt endpoint owns its own
+// backups; the local .dolt-backup / repo_state.json signals never apply, so
 // the check must not warn or emit a localhost fix hint. Regression for #3868.
 func TestDoltBackupCheck_ExternalEndpoint_NoWarn(t *testing.T) {
 	cityPath := t.TempDir()


### PR DESCRIPTION
Follow-up to #3922 (merged) addressing the Copilot review nit on that PR.

The dolt-backup check's external-endpoint StatusOK message read
"backups self-managed on the external server". But `contract.ResolveDoltConnectionTarget`
marks a target `External` based on endpoint *ownership* (gc does not manage it), not its
*location* — an explicit endpoint can resolve to a local host (empty host → 127.0.0.1).
The old wording implied a remote machine that may not exist.

Reword the message to "backups assumed self-managed at the endpoint" and clarify the code
comment that `External` classifies ownership, not location. Message-and-comment only — no
behavior change. The existing regression test still asserts the message names "external"
and the resolved host, and stays green.

Follows the same skip/degrade posture @quad341 endorsed on #3922.