### PR TITLE
fix(cmd): imported command groups exit non-zero on unknown subcommands (#3966)

### DIFF
--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -51,6 +51,11 @@ func newDiscoveredNamespaceCmd(binding string, entries []config.DiscoveredComman
 		Use:         binding,
 		Short:       fmt.Sprintf("Commands from the %s import", binding),
 		Annotations: map[string]string{docgenSkipAnnotation: "true"},
+		// NoArgs makes an unknown subcommand ("gc <binding> bogus") fail with
+		// "unknown command" and a non-zero exit, matching native command groups.
+		// A bare invocation ("gc <binding>") passes NoArgs and falls through to
+		// RunE, which still prints help and exits 0. See gastownhall/gascity#3966.
+		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			return c.Help()
 		},
@@ -76,6 +81,10 @@ func addDiscoveredLeaf(root *cobra.Command, entry config.DiscoveredCommand, city
 		}
 		next := &cobra.Command{
 			Use: word,
+			// Intermediate namespace nodes reject unknown subcommands too, so a
+			// deep "gc <binding> repo bogus" fails non-zero like a native group
+			// rather than printing help and exiting 0. See gastownhall/gascity#3966.
+			Args: cobra.NoArgs,
 			RunE: func(c *cobra.Command, _ []string) error {
 				return c.Help()
 			},

--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -896,3 +896,56 @@ func TestAddDiscoveredCommandsToRoot_CanSuppressCollisionWarnings(t *testing.T) 
 		t.Fatalf("got %d import commands, want 1", importCount)
 	}
 }
+
+// An imported command group must reject unknown subcommands with a non-zero
+// exit ("unknown command"), matching native command groups, rather than
+// printing help and exiting 0. Regression for #3966.
+func TestDiscoveredNamespace_UnknownSubcommandErrors(t *testing.T) {
+	newRoot := func() *cobra.Command {
+		root := &cobra.Command{Use: "gc", SilenceUsage: true, SilenceErrors: true}
+		entries := []config.DiscoveredCommand{
+			{BindingName: "gs", Command: []string{"status"}, Description: "Show status"},
+			{BindingName: "gs", Command: []string{"repo", "sync"}, Description: "Sync repo"},
+		}
+		addDiscoveredCommandsToRoot(root, entries, "/city", "testcity", os.Stdout, os.Stderr, true)
+		root.SetOut(new(bytes.Buffer))
+		root.SetErr(new(bytes.Buffer))
+		return root
+	}
+
+	t.Run("unknown subcommand under namespace fails", func(t *testing.T) {
+		root := newRoot()
+		root.SetArgs([]string{"gs", "bogus"})
+		err := root.Execute()
+		if err == nil {
+			t.Fatal("expected error for unknown subcommand, got nil (would exit 0)")
+		}
+		if !strings.Contains(err.Error(), "unknown command") {
+			t.Fatalf("error = %q, want it to mention \"unknown command\"", err.Error())
+		}
+	})
+
+	t.Run("unknown subcommand under nested namespace fails", func(t *testing.T) {
+		root := newRoot()
+		root.SetArgs([]string{"gs", "repo", "bogus"})
+		if err := root.Execute(); err == nil {
+			t.Fatal("expected error for unknown nested subcommand, got nil (would exit 0)")
+		}
+	})
+
+	t.Run("bare namespace still succeeds (prints help)", func(t *testing.T) {
+		root := newRoot()
+		root.SetArgs([]string{"gs"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("bare namespace should succeed with help, got error: %v", err)
+		}
+	})
+
+	t.Run("bare nested namespace still succeeds (prints help)", func(t *testing.T) {
+		root := newRoot()
+		root.SetArgs([]string{"gs", "repo"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("bare nested namespace should succeed with help, got error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Addresses #3966 (part a — the gascity-core dispatch half; part b, shipping `dolt stop`,
is cross-filed in gascity-packs).

Pack-imported command groups printed help and exited 0 for an unknown subcommand
(`gc dolt bogus`), while native groups (`gc dolt-state bogus`) correctly emit
"unknown command" and exit 1. In a scripted runbook the rc=0 "success" silently skips
the intended command.

Cause: newDiscoveredNamespaceCmd and the intermediate namespace nodes set
`RunE: c.Help()` with no Args guard, so cobra runs the parent (help) for unknown
subcommands instead of erroring. Add `cobra.NoArgs` to both group-node constructors:
an unknown subcommand now fails with "unknown command …" (exit 1), while a bare group
invocation still falls through to RunE and prints help (exit 0). Valid subcommands route
into their leaf unchanged.

Regression test covers unknown vs. bare, at both the top and nested namespace level.