### PR TITLE
fix(deps): floor joserfc>=1.6.8 to clear CVE-2026-49852 (Container Scan red on main)

### DIFF
--- a/.github/requirements/mcp-agent-mail.in
+++ b/.github/requirements/mcp-agent-mail.in
@@ -25,6 +25,12 @@ idna>=3.15
 # transitive constraint carries the patched version itself.
 litellm>=1.84.0
 
+# Security floor: CVE-2026-49852 (HIGH, HS256/HS384/HS512 verify accepts an
+# empty/nil HMAC key — cross-language sibling of CVE-2026-45363) in joserfc
+# < 1.6.8. joserfc arrives transitively via authlib; pin the floor until
+# authlib's transitive constraint carries the patched version itself.
+joserfc>=1.6.8
+
 # Authlib and FastMCP security floors live in
 # .github/requirements/mcp-agent-mail.overrides.txt because mcp-agent-mail
 # v0.3.2 still caps Authlib below the fixed release.

--- a/.github/requirements/mcp-agent-mail.txt
+++ b/.github/requirements/mcp-agent-mail.txt
@@ -1211,10 +1211,12 @@ jiter==0.14.0 \
     --hash=sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3 \
     --hash=sha256:ffb2a08a406465bb076b7cc1df41d833106d3cf7905076cc73f0cb90078c7d10
     # via openai
-joserfc==1.6.5 \
-    --hash=sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48 \
-    --hash=sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e
-    # via authlib
+joserfc==1.7.2 \
+    --hash=sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947 \
+    --hash=sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5
+    # via
+    #   -r .github/requirements/mcp-agent-mail.in
+    #   authlib
 jsonref==1.1.0 \
     --hash=sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552 \
     --hash=sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9


### PR DESCRIPTION
## What

Floors `joserfc>=1.6.8` in `.github/requirements/mcp-agent-mail.in` and recompiles the pinned lock. The resolver moves joserfc **1.6.5 → 1.7.2** (latest, past the fix); no other package changes.

## Why

The **Container Scan** gate went red on `main` (commit `0f0bb10`, run [28805115030](https://github.com/gastownhall/gascity/actions/runs/28805115030)):

```
Python (python-pkg)  Total: 1 (HIGH: 1, CRITICAL: 0)
joserfc (METADATA)  CVE-2026-49852  HIGH  fixed  1.6.5 -> 1.6.8
  joserfc: HS256/HS384/HS512 verify accepts empty/nil HMAC key
  (cross-language sibling of CVE-2026-45363)
```

`joserfc` ships in the `mcp-agent-mail` image transitively via `authlib`. It was **not** covered by any `.trivyignore.yaml` waiver, so it tripped the vuln-policy enforcement step. This follows the existing transitive security-floor precedent already used for `gitpython` / `urllib3` / `idna` / `litellm` in the same `.in` file.

## Verification

- `uv pip compile` produces a **minimal diff** — only `joserfc` moved.
- New pin verified installable under `pip install --no-deps --require-hashes` (the gate used at `ci.yml`).
- Container Scan re-runs on this PR (paths include `mcp-agent-mail.{in,txt}`) and should now pass the Python image.

## Scope note

This PR fixes only the joserfc HIGH. The other two red signals on `main` were triaged as **not** code-fixable here and intentionally left alone:
- **Contract radar (gc HEAD x bd main HEAD)** — advisory-by-design, explicitly non-required ("a bd-main break must never block a gascity merge"); its red is the intended early-warning that beads `main` drifted.
- **Notify Image Rebuilds** — chronic infra: needs the `GASCITY_HOSTED_TOKEN` secret to dispatch into the private `gascity/gasworks-internal` repo; not provisionable via a code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)