### PR TITLE
fix(build): detect Nix/Flox ICU, embed rpath, and gate 'install' on a self-contained gc binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,41 @@ export CGO_LDFLAGS
 endif
 endif
 
+# Nix/Flox: when the installed gc binary links ICU from the Nix store, system
+# ICU headers in /usr/include may exist but link to the wrong libicuuc version,
+# causing a __vdso_gettimeofday dlopen error at test/run time. Detect the ICU
+# version the installed gc binary actually links (following symlinks to the real
+# Nix store path), find the matching dev package, point CGO at it, disable the
+# /usr/include fallback, and embed an rpath so the rebuilt binary finds its libs
+# without LD_LIBRARY_PATH (important for the systemd supervisor service unit).
+#
+# Gate: _NIX_ICU_RT must resolve (after readlink -f) to a /nix/store path.
+# This keeps the block inert in hermetic test environments where gc is not
+# installed pointing at Nix ICU (CC being a temp-dir fake binary is not a
+# reliable signal on Flox hosts where CC is system gcc but libs are Nix-managed).
+ifeq ($(shell uname),Linux)
+_GC_BIN         := $(shell command -v gc 2>/dev/null)
+_NIX_ICU_RT_RAW := $(shell ldd $(_GC_BIN) 2>/dev/null | grep -m1 'libicuuc' | awk '{print $$3}')
+_NIX_ICU_RT     := $(shell readlink -f '$(_NIX_ICU_RT_RAW)' 2>/dev/null)
+ifneq ($(filter /nix/store/%,$(_NIX_ICU_RT)),)
+_NIX_ICU_HASH   := $(shell printf '%s' "$(_NIX_ICU_RT)" | sed 's|/nix/store/\([^-]*\)-.*|\1|')
+_NIX_ICU_LIBDIR := $(dir $(_NIX_ICU_RT))
+_NIX_ICU_DEV    := $(shell for d in /nix/store/*-icu4c-*-dev; do grep -q "$(_NIX_ICU_HASH)" "$$d/nix-support/propagated-build-inputs" 2>/dev/null && printf '%s' "$$d" && break; done)
+ifneq ($(_NIX_ICU_DEV),)
+CGO_CPPFLAGS += -I$(_NIX_ICU_DEV)/include
+CGO_LDFLAGS  += -L$(_NIX_ICU_LIBDIR) -Wl,-rpath,$(_NIX_ICU_LIBDIR)
+export CGO_CPPFLAGS
+export CGO_LDFLAGS
+SYS_USR_CGO_FALLBACK := 0
+$(info Nix/Flox ICU detected: -I$(_NIX_ICU_DEV)/include -L$(_NIX_ICU_LIBDIR) -rpath $(_NIX_ICU_LIBDIR); SYS_USR_CGO_FALLBACK disabled)
+endif
+endif
+endif
 # Linux: some non-system compilers (Nix, Flox, etc.) don't search /usr/include
 # or /usr/lib by default. If system ICU headers exist but the compiler doesn't
 # see them, intentionally let system paths participate in the whole CGO build.
 # Set SYS_USR_CGO_FALLBACK=0 to disable this fallback for hermetic or cross-CGO
-# builds.
+# builds. (Nix block above sets SYS_USR_CGO_FALLBACK=0 when Nix ICU is found.)
 ifeq ($(shell uname),Linux)
 SYS_USR_CGO_FALLBACK ?= 1
 ifneq ($(SYS_USR_CGO_FALLBACK),0)
@@ -64,7 +94,7 @@ endif
 endif
 endif
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-eventexport-isolation check-gomod-replace check-core-boundary check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-bd-cli-contract test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-openclaw-bridge test-docker test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke dashboard-e2e-go
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-eventexport-isolation check-gomod-replace check-core-boundary check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-bd-cli-contract test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-openclaw-bridge test-docker test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover check-self-contained install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke dashboard-e2e-go
 .PHONY: check-release-dist-ignore
 
 ## build: compile gc binary with version metadata
@@ -74,8 +104,36 @@ ifeq ($(shell uname),Darwin)
 	@scripts/sign-darwin-local.sh $(BUILD_DIR)/$(BINARY)
 endif
 
+## check-self-contained: assert the built gc binary is self-contained (Linux/Nix ICU rpath).
+## Only enforced when the Nix/Flox ICU block above fired (_NIX_ICU_DEV set):
+## on those hosts a binary without an ICU RUNPATH loads interactively (the
+## shell has the Nix/Flox env) but silently boot-fails EVERY supervisor-spawned
+## agent, which has no LD_LIBRARY_PATH -> town-wide stall. This gate makes
+## that impossible to ship. On non-Nix hosts the target is a no-op.
+check-self-contained: build
+ifneq ($(_NIX_ICU_DEV),)
+	@set -e; \
+		bin="$(BUILD_DIR)/$(BINARY)"; \
+		if command -v readelf >/dev/null 2>&1; then \
+			if ! readelf -d "$$bin" 2>/dev/null | grep -qiE 'RUNPATH|RPATH'; then \
+				echo "FATAL: $$bin has no RUNPATH/RPATH — NOT self-contained."; \
+				echo "       Use 'make build' (bakes ICU -Wl,-rpath), not raw 'go build'."; \
+				exit 1; \
+			fi; \
+		else \
+			echo "WARN: readelf not found; skipping RUNPATH check (install discouraged)"; \
+		fi; \
+		if ! env -i HOME="$(HOME)" PATH=/usr/bin:/bin "$$bin" version >/dev/null 2>&1; then \
+			echo "FATAL: $$bin failed clean-env boot (no LD_LIBRARY_PATH)."; \
+			echo "       Supervisor-spawned agents will silently boot-fail on ICU."; \
+			echo "       Build with 'make build' so the ICU rpath is embedded."; \
+			exit 1; \
+		fi; \
+		echo "OK: $$bin self-contained (RUNPATH present + clean-env boot passes)"
+endif
+
 ## install: build and install gc to GOPATH/bin (same location as go install)
-install: build
+install: check-self-contained
 	@mkdir -p $(INSTALL_DIR)
 	@set -e; \
 		tmp="$(INSTALL_DIR)/.$(BINARY).tmp.$$$$"; \

--- a/scripts/makefile_cgo_test.go
+++ b/scripts/makefile_cgo_test.go
@@ -308,6 +308,13 @@ print-cgo-flags:
 		t.Fatalf("write test Makefile: %v", err)
 	}
 
+	// Write a fake gc stub so the Nix/Flox ICU detection block (which runs
+	// `ldd $(command -v gc)`) finds a shell script rather than the real binary.
+	// ldd on a shell script emits nothing useful, so _NIX_ICU_RT resolves to ""
+	// and the Nix block stays inert — letting the SYS_USR_CGO_FALLBACK logic
+	// under test run unobstructed.
+	writeExecutable(t, filepath.Join(binDir, "gc"), "#!/bin/sh\n")
+
 	cmdArgs := append([]string{"--no-print-directory", "-f", testMakefile, "print-cgo-flags"}, args...)
 	cmd := makeCommand(cmdArgs...)
 	cmd.Dir = repoRoot

--- a/scripts/makefile_install_test.go
+++ b/scripts/makefile_install_test.go
@@ -54,10 +54,10 @@ exit 1
 	}
 	testMakefile := filepath.Join(tmp, "Makefile")
 	makefileText := string(makefile)
-	if !strings.Contains(makefileText, "\ninstall: build\n") {
-		t.Fatal("Makefile install target no longer depends on build as expected")
+	if !strings.Contains(makefileText, "\ninstall: check-self-contained\n") {
+		t.Fatal("Makefile install target no longer depends on check-self-contained as expected")
 	}
-	makefileContent := strings.Replace(makefileText, "\ninstall: build\n", "\ninstall:\n", 1)
+	makefileContent := strings.Replace(makefileText, "\ninstall: check-self-contained\n", "\ninstall:\n", 1)
 	if err := os.WriteFile(testMakefile, []byte(makefileContent), 0o644); err != nil {
 		t.Fatalf("write test Makefile: %v", err)
 	}


### PR DESCRIPTION
## Problem

On Nix/Flox hosts, `make build` produces a `gc` binary that works in the dev shell but breaks in production:

1. The Linux `SYS_USR_CGO_FALLBACK` block adds `/usr/include` (system ICU, e.g. 74) to CGO flags while the toolchain/runtime ICU (e.g. 76) comes from the Nix store. Mixing the two at link time causes `__vdso_gettimeofday: invalid mode for dlopen` failures in every CGO test binary.
2. Even with correct link paths, no rpath is embedded, so the binary needs `LD_LIBRARY_PATH` at runtime. The systemd supervisor service doesn't have it — so the binary passes `gc version` interactively, but every supervisor-spawned agent silently boot-fails on `libicui18n.so`, stalling the whole town. This failure mode recurred repeatedly; docs alone did not prevent it.

## Fix (Makefile — all inert on non-Nix hosts)

- Detect Nix-store ICU by `ldd`'ing the installed `gc` binary and resolving `libicuuc` with `readlink -f`; a `/nix/store` path is the gate. This fires correctly on Flox hosts where `CC` is system gcc but libs are Nix-managed (a CC-realpath gate does not).
- Find the matching `icu4c-*-dev` store path, point CGO at it, disable `SYS_USR_CGO_FALLBACK`, and add `-Wl,-rpath,<nix lib dir>` so rebuilt binaries carry the runtime library path in their ELF RUNPATH — no `LD_LIBRARY_PATH` needed.
- New `check-self-contained` target: when Nix ICU was detected, assert the built binary has a RUNPATH and boots under `env -i` (exactly how the supervisor launches children). `make install` now depends on it, so a raw `go build` binary can no longer be deployed on such hosts. On non-Nix hosts the target is a no-op and `install` behaves as before.
- Test helper: hermetic `TestMakefileLinuxCGO*` tests get a fake `gc` shell-script stub on PATH so the detection block stays inert and the fallback logic under test runs unobstructed.

## Testing

- `go build ./...`, `go vet ./scripts/` clean.
- `go test ./scripts/ -run 'CGO|Makefile'` passes on a Flox host where the real installed gc previously bled through into the hermetic tests.
- On a Flox/Nix host: `make check-self-contained` detects ICU 76 from the store, builds with rpath, and reports `OK: bin/gc self-contained (RUNPATH present + clean-env boot passes)`.
- Non-Nix simulation (PATH with a stub `gc`): detection stays inert, `make -n check-self-contained` shows no gate recipe, plain build path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)