### PR TITLE
feat(doctor): warn when a shell alias shadows the gc binary in agent-inherited environments

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -305,6 +305,11 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 	// (gc -> bd.real -> dolt) that operators routinely misread as CPU saturation.
 	// Advisory + read-only (/proc/stat); no config needed.
 	register(newForkRateCheck())
+	// Host-level shell-config watch: a `gc` alias/function (oh-my-zsh's git
+	// plugin) shadows the gc binary in agent-inherited shell snapshots, so
+	// agents silently run `git commit` instead of gc and idle as if no work
+	// is hooked. Advisory + read-only; no config needed.
+	register(newGCShadowCheck())
 	if cfgErr == nil && doctorWorkspaceHasPostgresScope(cityPath, cfg) {
 		register(doctor.NewPostgresAuthCheck(cityPath, cfg))
 	}

--- a/cmd/gc/doctor_gc_shadow.go
+++ b/cmd/gc/doctor_gc_shadow.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+// gcShadowCheck warns when the `gc` command is shadowed by a shell alias or
+// function in contexts that agent sessions inherit.
+//
+// The field failure this catches: oh-my-zsh's git plugin defines
+// `alias gc='git commit --verbose'`. Claude Code agent shells source the
+// operator's shell snapshots (~/.claude/shell-snapshots/snapshot-*.sh), so an
+// agent running `gc hook --claim --json` actually executes
+// `git commit --verbose hook --claim --json` (exit 129, "error: unknown
+// option 'claim'"), reports "No hooked work", and idles until manually
+// nudged. The town looks dispatch-broken; the cause is operator shell config.
+//
+// Pure observability (SeverityAdvisory): it reads snapshot and rc files only,
+// never mutates anything, and never gates. Detection is deterministic file
+// scanning — no interactive shell is spawned (an interactive `$SHELL -ic` can
+// hang on prompts and is not testable).
+type gcShadowCheck struct {
+	// homeDir is the operator home directory scanned for shell snapshots and
+	// rc files. Injectable for tests.
+	homeDir string
+}
+
+func newGCShadowCheck() *gcShadowCheck {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+	return &gcShadowCheck{homeDir: home}
+}
+
+func (c *gcShadowCheck) Name() string                     { return "gc-shell-alias-shadow" }
+func (c *gcShadowCheck) CanFix() bool                     { return false }
+func (c *gcShadowCheck) Fix(_ *doctor.CheckContext) error { return nil }
+func (c *gcShadowCheck) WarmupEligible() bool             { return false }
+
+// gcShadowLineRe matches an uncommented shell line that (re)defines `gc` as
+// an alias or function: `alias gc=...`, `alias -- gc=...`, `gc () {`, or
+// `function gc ...`. It deliberately does not match other names (gcb, gca).
+var gcShadowLineRe = regexp.MustCompile(`^\s*(alias\s+(--\s+)?gc=|gc\s*\(\)|function\s+gc\b)`)
+
+// scanFileForGCShadow reports whether any line of the file defines a `gc`
+// alias or function. Unreadable files report false: this check must never
+// warn on what it cannot see.
+func scanFileForGCShadow(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if gcShadowLineRe.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// findGCShadowFiles returns the files under homeDir where `gc` is shadowed:
+// Claude Code shell snapshots (the exact vector agent sessions inherit) plus
+// the common interactive rc files that regenerate those snapshots.
+func findGCShadowFiles(homeDir string) (snapshots, rcFiles []string) {
+	if strings.TrimSpace(homeDir) == "" {
+		return nil, nil
+	}
+	pattern := filepath.Join(homeDir, ".claude", "shell-snapshots", "*.sh")
+	matches, _ := filepath.Glob(pattern)
+	sort.Strings(matches)
+	for _, path := range matches {
+		if scanFileForGCShadow(path) {
+			snapshots = append(snapshots, path)
+		}
+	}
+	for _, rc := range []string{".zshrc", ".bashrc"} {
+		path := filepath.Join(homeDir, rc)
+		if scanFileForGCShadow(path) {
+			rcFiles = append(rcFiles, path)
+		}
+	}
+	return snapshots, rcFiles
+}
+
+func (c *gcShadowCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	res := &doctor.CheckResult{Name: c.Name(), Severity: doctor.SeverityAdvisory}
+
+	snapshots, rcFiles := findGCShadowFiles(c.homeDir)
+	if len(snapshots) == 0 && len(rcFiles) == 0 {
+		res.Status = doctor.StatusOK
+		res.Message = "gc is not shadowed by a shell alias or function in agent-inherited shell config"
+		return res
+	}
+
+	res.Status = doctor.StatusWarning
+	res.Message = fmt.Sprintf("gc is shadowed by a shell alias/function in %d file(s) agent sessions can inherit", len(snapshots)+len(rcFiles))
+	res.FixHint = "remove the gc alias from your shell config (e.g. `unalias gc` after oh-my-zsh loads), then start a fresh Claude Code session so shell snapshots regenerate"
+	res.Details = []string{
+		"A shell alias or function named `gc` (commonly oh-my-zsh's git plugin: alias gc='git commit --verbose')",
+		"shadows the gc binary in agent sessions: Claude Code agent shells source the operator's shell snapshots,",
+		"so `gc hook --claim --json` becomes `git commit --verbose hook --claim --json` (exit 129). Agents then",
+		"report \"No hooked work\" and idle — polecats/refinery look dispatch-broken when the cause is shell config.",
+	}
+	for _, path := range snapshots {
+		res.Details = append(res.Details, "shadowed in agent-inherited snapshot: "+path)
+	}
+	for _, path := range rcFiles {
+		res.Details = append(res.Details, "shadowed in shell rc file: "+path)
+	}
+	return res
+}

--- a/cmd/gc/doctor_gc_shadow_test.go
+++ b/cmd/gc/doctor_gc_shadow_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+// writeGCShadowFile writes content at path, creating parent directories.
+func writeGCShadowFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func snapshotPath(home, name string) string {
+	return filepath.Join(home, ".claude", "shell-snapshots", name)
+}
+
+func TestGCShadowCheck_AliasInSnapshotWarns(t *testing.T) {
+	home := t.TempDir()
+	writeGCShadowFile(t, snapshotPath(home, "snapshot-zsh-1.sh"),
+		"# oh-my-zsh git plugin\nalias gc='git commit --verbose'\n")
+
+	c := &gcShadowCheck{homeDir: home}
+	r := c.Run(nil)
+	if r.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want StatusWarning", r.Status)
+	}
+	if r.Severity != doctor.SeverityAdvisory {
+		t.Fatalf("severity = %v, want SeverityAdvisory (observability, never gates)", r.Severity)
+	}
+	if r.FixHint == "" {
+		t.Fatalf("a warning should carry a FixHint (unalias + fresh session)")
+	}
+	if !strings.Contains(strings.Join(r.Details, "\n"), "snapshot-zsh-1.sh") {
+		t.Fatalf("details should name the offending snapshot file, got %v", r.Details)
+	}
+}
+
+func TestGCShadowCheck_AliasDoubleDashForm(t *testing.T) {
+	home := t.TempDir()
+	writeGCShadowFile(t, snapshotPath(home, "snapshot-zsh-2.sh"),
+		"alias -- gc='git commit --verbose'\n")
+
+	r := (&gcShadowCheck{homeDir: home}).Run(nil)
+	if r.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want StatusWarning for `alias -- gc=`", r.Status)
+	}
+}
+
+func TestGCShadowCheck_FunctionForms(t *testing.T) {
+	for name, content := range map[string]string{
+		"posix":   "gc () {\n  git commit \"$@\"\n}\n",
+		"keyword": "function gc {\n  git commit \"$@\"\n}\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			writeGCShadowFile(t, snapshotPath(home, "snapshot-bash-1.sh"), content)
+			r := (&gcShadowCheck{homeDir: home}).Run(nil)
+			if r.Status != doctor.StatusWarning {
+				t.Fatalf("status = %v, want StatusWarning for gc function form %q", r.Status, content)
+			}
+		})
+	}
+}
+
+func TestGCShadowCheck_RCFileWarns(t *testing.T) {
+	home := t.TempDir()
+	writeGCShadowFile(t, filepath.Join(home, ".zshrc"), "alias gc='git commit --verbose'\n")
+
+	r := (&gcShadowCheck{homeDir: home}).Run(nil)
+	if r.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want StatusWarning for alias in ~/.zshrc", r.Status)
+	}
+	if !strings.Contains(strings.Join(r.Details, "\n"), ".zshrc") {
+		t.Fatalf("details should name .zshrc, got %v", r.Details)
+	}
+}
+
+func TestGCShadowCheck_NegativesStayOK(t *testing.T) {
+	home := t.TempDir()
+	writeGCShadowFile(t, snapshotPath(home, "snapshot-zsh-3.sh"), strings.Join([]string{
+		"# alias gc='git commit --verbose'",  // commented out
+		"alias gcb='git checkout -b'",        // different name, gc prefix
+		"alias mygc='true'",                  // suffix
+		"echo alias gc is fine inside words", // not a definition
+		"gcloud () { true; }",                // different function
+	}, "\n")+"\n")
+	writeGCShadowFile(t, filepath.Join(home, ".bashrc"), "# alias gc=nope\nalias gca='git commit -a'\n")
+
+	r := (&gcShadowCheck{homeDir: home}).Run(nil)
+	if r.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want StatusOK; details: %v", r.Status, r.Details)
+	}
+}
+
+func TestGCShadowCheck_NoSnapshotDirOK(t *testing.T) {
+	r := (&gcShadowCheck{homeDir: t.TempDir()}).Run(nil)
+	if r.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want StatusOK when nothing exists", r.Status)
+	}
+}
+
+func TestGCShadowCheck_EmptyHomeSkips(t *testing.T) {
+	r := (&gcShadowCheck{homeDir: ""}).Run(nil)
+	if r.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want StatusOK when home dir is unknown", r.Status)
+	}
+}

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -62,6 +62,7 @@ order-tracking-retention
 session-model
 dolt-server
 fork-rate
+gc-shell-alias-shadow
 dolt-noms-size
 dolt-journal-size
 dolt-config


### PR DESCRIPTION
## Problem

We root-caused a town-wide "polecats idle until nudged" outage to oh-my-zsh's git plugin, which defines `alias gc='git commit --verbose'`. Claude Code agent shells source the operator's shell snapshots (`~/.claude/shell-snapshots/snapshot-*.sh`), so every agent running `gc hook --claim --json` actually executed `git commit --verbose hook --claim --json` (exit 129), reported "No hooked work", and idled. The town looks dispatch-broken when the real cause is operator shell config — extremely hard to diagnose from the town side.

## Fix

New advisory doctor check `gc-shell-alias-shadow`:

- Scans agent-inherited shell snapshots (`~/.claude/shell-snapshots/*.sh`) plus `~/.zshrc` / `~/.bashrc` for uncommented definitions that shadow `gc`: `alias gc=`, `alias -- gc=`, `gc ()`, and `function gc`.
- Warns with the offending files and remediation (`unalias gc`, then start a fresh Claude Code session so snapshots regenerate).
- Advisory-only: `StatusWarning` / `SeverityAdvisory`, never fails doctor.
- Deterministic file scanning only — deliberately avoids probing via interactive `$SHELL -ic`, which would be slow and could hang doctor on misbehaving shell configs.

## Testing

- `go build ./...`, `go vet ./cmd/gc/` clean.
- New unit tests in `cmd/gc/doctor_gc_shadow_test.go` covering alias/function detection, commented-out lines, and absent files; `doctor_check_names.golden` updated.
- `go test ./cmd/gc/` — new tests pass; the only failures (`TestImportMigrateScript`, `TestPackV2ImportsScript`) also fail on unmodified `upstream/main` in this environment and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)