### PR TITLE
feat(controller): config-driven session liveness tracker + session.liveness_stale event

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -57,6 +58,7 @@ type CityRuntime struct {
 	cityName     string
 	configName   string
 	tomlPath     string
+	startedAt    time.Time // when this runtime started; used as grace period for liveness checks
 	watchTargets []config.WatchTarget
 	configRev    string
 	configDirty  *atomic.Bool
@@ -100,8 +102,9 @@ type CityRuntime struct {
 	standaloneRigStores map[string]beads.Store
 
 	// Bead-driven reconciler state (Phase 2f).
-	sessionDrains      *drainTracker       // in-memory drain tracker; nil when bead reconciler disabled
-	providerHealthGate *providerHealthGate // ADR-0013 A1 M3a; nil until bead reconciler initialized
+	sessionDrains      *drainTracker          // in-memory drain tracker; nil when bead reconciler disabled
+	providerHealthGate *providerHealthGate    // ADR-0013 A1 M3a; nil until bead reconciler initialized
+	livenessTracker    sessionLivenessTracker // nil when no session_liveness_checks configured
 	asyncStartLimiter  *asyncStartLimiter
 	asyncStarts        asyncStartTracker
 	asyncStops         asyncStartTracker
@@ -334,6 +337,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		managedDoltHealth: managedDoltHealth,
 		managedDoltOwned:  managedDoltOwned,
 		managedDoltPort:   managedDoltPort,
+		startedAt:         time.Now(),
 		logPrefix:         logPrefix,
 		stdout:            p.Stdout,
 		stderr:            p.Stderr,
@@ -407,6 +411,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		cr.sessionDrains = newDrainTracker()
 		cr.providerHealthGate = newProviderHealthGate()
 	}
+	cr.livenessTracker = newSessionLivenessTracker(len(cr.cfg.Daemon.SessionLivenessChecks) > 0)
 	if ctx.Err() != nil {
 		return
 	}
@@ -1311,6 +1316,7 @@ func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) {
 	cr.runOrderTrackingSweepWatchdog(now)
 	cr.runOrderTrackingRetentionWatchdog(now)
 	cr.runNudgeMailSweepWatchdog(now)
+	cr.runSessionLivenessChecks(now)
 	if cr.od != nil {
 		cr.od.dispatch(ctx, cityRoot, now)
 	}
@@ -1554,6 +1560,67 @@ func (cr *CityRuntime) runNudgeMailSweepWatchdog(now time.Time) {
 	total := result.NudgeClosed + result.MailClosed
 	if total > 0 && cr.stderr != nil {
 		fmt.Fprintf(cr.stderr, "%s: nudge-mail-sweep watchdog closed %d nudge bead(s), %d mail bead(s)\n", cr.logPrefix, result.NudgeClosed, result.MailClosed) //nolint:errcheck // best-effort stderr
+	}
+}
+
+// runSessionLivenessChecks evaluates every entry in
+// [daemon.session_liveness_checks] on each patrol tick. For any session whose
+// last activity exceeds its freshness_window, a session.liveness_stale event
+// is emitted exactly once per stale episode. If escalate_to is set, the named
+// session is also nudged. Escalation clears when the session becomes active
+// again (next patrol tick where activity is within the window).
+//
+// This provides the controller-supervised, bounded-cadence patrol that replaces
+// reliance on pack formula self-scheduling (e.g., a deacon ScheduleWakeup that
+// can fail silently and produce multi-hour gaps).
+func (cr *CityRuntime) runSessionLivenessChecks(now time.Time) {
+	if cr.livenessTracker == nil {
+		return
+	}
+	for i := range cr.cfg.Daemon.SessionLivenessChecks {
+		check := &cr.cfg.Daemon.SessionLivenessChecks[i]
+		window := check.FreshnessWindowDuration()
+		if window <= 0 {
+			continue
+		}
+		for _, sessionName := range check.Sessions {
+			sn := sessionName // capture for closure
+			chk := check      // capture for closure
+			cr.livenessTracker.checkFreshness(
+				sn,
+				window,
+				cr.sp,
+				now,
+				cr.startedAt,
+				func(episodeID string, staleSince time.Time, lastActivity time.Time) {
+					if cr.rec != nil {
+						p := events.SessionLivenessStalePayload{
+							Session:         sn,
+							EpisodeID:       episodeID,
+							StaleSince:      staleSince,
+							FreshnessWindow: chk.FreshnessWindow,
+							LastActivity:    lastActivity,
+							EscalateTo:      chk.EscalateTo,
+						}
+						payload, _ := json.Marshal(p)
+						cr.rec.Record(events.Event{
+							Type:    events.SessionLivenessStale,
+							Ts:      staleSince.UTC(),
+							Actor:   "gc",
+							Subject: sn,
+							Message: fmt.Sprintf("session %s stale for %s (last activity: %s)",
+								sn, chk.FreshnessWindow, lastActivity.UTC().Format(time.RFC3339)),
+							Payload: payload,
+						})
+					}
+					if chk.EscalateTo != "" {
+						if err := cr.sp.Nudge(chk.EscalateTo, runtime.TextContent("session.liveness_stale: "+sn+" is stale")); err != nil && cr.stderr != nil {
+							fmt.Fprintf(cr.stderr, "%s: session liveness check: nudge %s: %v\n", cr.logPrefix, chk.EscalateTo, err) //nolint:errcheck // best-effort stderr
+						}
+					}
+				},
+			)
+		}
 	}
 }
 
@@ -2021,6 +2088,8 @@ func (cr *CityRuntime) reloadConfigTraced(
 		cr.sessionDrains = newDrainTracker()
 		cr.providerHealthGate = newProviderHealthGate()
 	}
+	// Rebuild liveness tracker when session_liveness_checks changes.
+	cr.livenessTracker = newSessionLivenessTracker(len(nextCfg.Daemon.SessionLivenessChecks) > 0)
 	cr.configRev = result.Revision
 	cr.watchTargets = config.WatchTargets(result.Prov, nextCfg, cityRoot)
 	cr.restartConfigWatcher()

--- a/cmd/gc/session_liveness_tracker.go
+++ b/cmd/gc/session_liveness_tracker.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/google/uuid"
+)
+
+// sessionLivenessTracker monitors whether named sessions have had recent
+// activity within a configured freshness window. It fires an escalation
+// callback exactly once per stale episode (fresh→stale transition) and
+// resets when the session becomes active again (stale→fresh).
+//
+// This provides the controller-supervised, tight-cadence patrol described
+// in the health monitoring architecture: instead of relying on a pack
+// formula's self-scheduled ScheduleWakeup (which can fail silently), the
+// controller checks freshness on every patrol tick and escalates once per
+// stale episode.
+//
+// Nil means the feature is disabled (no checks configured). Callers check
+// for nil before using, following the same nil-guard pattern as idleTracker.
+type sessionLivenessTracker interface {
+	// checkFreshness checks whether sessionName's last activity is within
+	// window. If the session is stale and no alert has been sent for the
+	// current episode, emitStale is called exactly once. Returns true if the
+	// session is stale, false if fresh. A zero LastActivity time is treated as
+	// stale once window has elapsed since the controller started (startedAt).
+	checkFreshness(
+		sessionName string,
+		window time.Duration,
+		sp runtime.Provider,
+		now time.Time,
+		startedAt time.Time,
+		emitStale func(episodeID string, staleSince time.Time, lastActivity time.Time),
+	) bool
+
+	// recordFreshTick clears the stale episode for sessionName. Call when
+	// checkFreshness determines the session is fresh so the next stale
+	// transition opens a new episode and fires a new alert.
+	recordFreshTick(sessionName string)
+}
+
+// sessionEpisodeState tracks one session's stale/fresh episode.
+type sessionEpisodeState struct {
+	stale      bool
+	alertSent  bool
+	episodeID  string
+	staleSince time.Time
+}
+
+// memorySessionLivenessTracker is the production implementation.
+type memorySessionLivenessTracker struct {
+	mu       sync.Mutex
+	episodes map[string]*sessionEpisodeState
+}
+
+// newSessionLivenessTracker allocates a tracker. Returns nil if checks is empty.
+func newSessionLivenessTracker(hasAny bool) *memorySessionLivenessTracker {
+	if !hasAny {
+		return nil
+	}
+	return &memorySessionLivenessTracker{
+		episodes: make(map[string]*sessionEpisodeState),
+	}
+}
+
+func (m *memorySessionLivenessTracker) checkFreshness(
+	sessionName string,
+	window time.Duration,
+	sp runtime.Provider,
+	now time.Time,
+	startedAt time.Time,
+	emitStale func(episodeID string, staleSince time.Time, lastActivity time.Time),
+) bool {
+	if window <= 0 {
+		return false
+	}
+	lastActivity, err := sp.GetLastActivity(sessionName)
+	if err != nil {
+		// Provider error: fail-open (don't escalate on probe errors).
+		return false
+	}
+
+	// A zero last-activity means the session has never been observed active.
+	// Treat it as stale only once the freshness window has elapsed since the
+	// controller started, to avoid false positives on fresh city startup.
+	isStale := false
+	if lastActivity.IsZero() {
+		isStale = now.Sub(startedAt) > window
+	} else {
+		isStale = now.Sub(lastActivity) > window
+	}
+
+	if !isStale {
+		m.recordFreshTick(sessionName)
+		return false
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := m.episodeFor(sessionName)
+	if !s.stale {
+		s.stale = true
+		s.alertSent = false
+		s.episodeID = uuid.New().String()
+		s.staleSince = now
+	}
+	if !s.alertSent {
+		emitStale(s.episodeID, s.staleSince, lastActivity)
+		s.alertSent = true
+	}
+	return true
+}
+
+func (m *memorySessionLivenessTracker) recordFreshTick(sessionName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s, ok := m.episodes[sessionName]; ok {
+		s.stale = false
+		s.alertSent = false
+	}
+}
+
+func (m *memorySessionLivenessTracker) episodeFor(sessionName string) *sessionEpisodeState {
+	if s, ok := m.episodes[sessionName]; ok {
+		return s
+	}
+	s := &sessionEpisodeState{}
+	m.episodes[sessionName] = s
+	return s
+}

--- a/cmd/gc/session_liveness_tracker_test.go
+++ b/cmd/gc/session_liveness_tracker_test.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// livenessBaseTime is a fixed reference time for all liveness tracker tests.
+var livenessBaseTime = time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+// startSession adds a named session to a Fake and optionally sets its activity time.
+func startSession(f *runtime.Fake, name string, lastActivity time.Time) {
+	_ = f.Start(context.Background(), name, runtime.Config{})
+	if !lastActivity.IsZero() {
+		f.SetActivity(name, lastActivity)
+	}
+}
+
+// noopEmit is a convenience no-op escalation callback.
+var noopEmit = func(_ string, _ time.Time, _ time.Time) {}
+
+// --- Reproduction test: before fix, controller does NOT escalate stale sessions ---
+
+// TestLivenessTracker_ReproductionBeforeFix demonstrates the gap this feature
+// closes. Without a configured livenessTracker (nil), no escalation fires even
+// when a refinery session has had no activity for many hours — matching the
+// pre-fix behavior where the deacon's self-scheduling was the only path.
+func TestLivenessTracker_ReproductionBeforeFix(t *testing.T) {
+	// Pre-fix: no tracker → no escalation, regardless of session state.
+	var tracker sessionLivenessTracker // nil
+
+	f := runtime.NewFake()
+	startSession(f, "gastown.refinery", time.Time{}) // dead: never ran
+	window := 2 * time.Hour
+	now := livenessBaseTime.Add(8 * time.Hour) // 8 hours elapsed — well past window
+	startedAt := livenessBaseTime
+
+	escalated := false
+	if tracker != nil {
+		tracker.checkFreshness("gastown.refinery", window, f, now, startedAt,
+			func(_ string, _ time.Time, _ time.Time) { escalated = true })
+	}
+
+	// Without the fix (nil tracker), no escalation fires.
+	if escalated {
+		t.Fatal("reproduction: expected no escalation without a configured tracker (pre-fix behavior)")
+	}
+}
+
+// --- Post-fix: tracker escalates correctly ---
+
+// TestLivenessTracker_StaleSessionEscalates verifies that a session whose last
+// activity exceeds the freshness window triggers escalation exactly once.
+func TestLivenessTracker_StaleSessionEscalates(t *testing.T) {
+	tracker := newSessionLivenessTracker(true)
+	window := 2 * time.Hour
+
+	// Session active 3 hours ago — stale.
+	f := runtime.NewFake()
+	startSession(f, "gastown.refinery", livenessBaseTime.Add(-3*time.Hour))
+	now := livenessBaseTime
+	startedAt := now.Add(-8 * time.Hour) // controller has been running 8 hours
+
+	escalations := 0
+	stale := tracker.checkFreshness("gastown.refinery", window, f, now, startedAt,
+		func(_ string, _ time.Time, _ time.Time) { escalations++ })
+
+	if !stale {
+		t.Fatal("expected stale=true for session with activity 3h ago and 2h window")
+	}
+	if escalations != 1 {
+		t.Fatalf("expected 1 escalation, got %d", escalations)
+	}
+}
+
+// TestLivenessTracker_FreshSessionNoEscalation verifies that a session with
+// recent activity does not trigger escalation (healthy rig produces no alert).
+func TestLivenessTracker_FreshSessionNoEscalation(t *testing.T) {
+	tracker := newSessionLivenessTracker(true)
+	window := 2 * time.Hour
+
+	// Session active 30 minutes ago — fresh.
+	f := runtime.NewFake()
+	startSession(f, "gastown.refinery", livenessBaseTime.Add(-30*time.Minute))
+	now := livenessBaseTime
+	startedAt := now.Add(-8 * time.Hour)
+
+	escalations := 0
+	stale := tracker.checkFreshness("gastown.refinery", window, f, now, startedAt,
+		func(_ string, _ time.Time, _ time.Time) { escalations++ })
+
+	if stale {
+		t.Fatal("expected stale=false for session with activity 30m ago and 2h window")
+	}
+	if escalations != 0 {
+		t.Fatalf("expected 0 escalations for fresh session, got %d", escalations)
+	}
+}
+
+// TestLivenessTracker_EscalatesExactlyOncePerEpisode verifies that repeated
+// patrol ticks with a stale session only emit the escalation once per stale
+// episode. Subsequent ticks finding the same stale session must not re-fire.
+func TestLivenessTracker_EscalatesExactlyOncePerEpisode(t *testing.T) {
+	tracker := newSessionLivenessTracker(true)
+	window := 2 * time.Hour
+	f := runtime.NewFake()
+	startSession(f, "gastown.refinery", livenessBaseTime.Add(-3*time.Hour))
+	startedAt := livenessBaseTime.Add(-8 * time.Hour)
+
+	escalations := 0
+	emit := func(_ string, _ time.Time, _ time.Time) { escalations++ }
+
+	// Simulate ten patrol ticks at 30s intervals with the session still stale.
+	for i := range 10 {
+		now := livenessBaseTime.Add(time.Duration(i) * 30 * time.Second)
+		tracker.checkFreshness("gastown.refinery", window, f, now, startedAt, emit)
+	}
+
+	if escalations != 1 {
+		t.Fatalf("expected exactly 1 escalation across 10 stale ticks, got %d", escalations)
+	}
+}
+
+// TestLivenessTracker_NewEpisodeAfterRecovery verifies that after a stale
+// session recovers (becomes fresh), a subsequent stale period opens a new
+// episode and fires a new escalation.
+func TestLivenessTracker_NewEpisodeAfterRecovery(t *testing.T) {
+	tracker := newSessionLivenessTracker(true)
+	window := 2 * time.Hour
+	startedAt := livenessBaseTime.Add(-24 * time.Hour)
+	f := runtime.NewFake()
+	startSession(f, "gastown.refinery", time.Time{})
+
+	escalations := 0
+	emit := func(_ string, _ time.Time, _ time.Time) { escalations++ }
+
+	// Episode 1: session stale.
+	f.SetActivity("gastown.refinery", livenessBaseTime.Add(-3*time.Hour))
+	tracker.checkFreshness("gastown.refinery", window, f, livenessBaseTime, startedAt, emit)
+	if escalations != 1 {
+		t.Fatalf("episode 1: expected 1 escalation, got %d", escalations)
+	}
+
+	// Session recovers — mark fresh.
+	freshTime := livenessBaseTime.Add(10 * time.Minute)
+	f.SetActivity("gastown.refinery", freshTime)
+	now2 := livenessBaseTime.Add(30 * time.Minute)
+	tracker.checkFreshness("gastown.refinery", window, f, now2, startedAt, emit)
+	if escalations != 1 {
+		t.Fatalf("after recovery: escalation should not re-fire, got %d", escalations)
+	}
+
+	// Episode 2: session goes stale again.
+	f.SetActivity("gastown.refinery", livenessBaseTime.Add(-3*time.Hour))
+	now3 := livenessBaseTime.Add(5 * time.Hour)
+	tracker.checkFreshness("gastown.refinery", window, f, now3, startedAt, emit)
+	if escalations != 2 {
+		t.Fatalf("episode 2: expected 2 total escalations, got %d", escalations)
+	}
+}
+
+// TestLivenessTracker_PerRigMultipleSessions verifies that for each rig the
+// liveness check asserts both refinery AND witness sessions independently.
+// Escalation fires for each stale session; a healthy session produces no alert.
+func TestLivenessTracker_PerRigMultipleSessions(t *testing.T) {
+	tracker := newSessionLivenessTracker(true)
+	window := 2 * time.Hour
+	startedAt := livenessBaseTime.Add(-24 * time.Hour)
+
+	// refinery: stale (3h since last activity).
+	// witness: fresh (30m since last activity).
+	f := runtime.NewFake()
+	startSession(f, "gastown.refinery", livenessBaseTime.Add(-3*time.Hour))
+	startSession(f, "gastown.witness", livenessBaseTime.Add(-30*time.Minute))
+	now := livenessBaseTime
+
+	staleCount := 0
+	escalations := make(map[string]int)
+	for _, session := range []string{"gastown.refinery", "gastown.witness"} {
+		sn := session
+		stale := tracker.checkFreshness(sn, window, f, now, startedAt,
+			func(_ string, _ time.Time, _ time.Time) { escalations[sn]++ })
+		if stale {
+			staleCount++
+		}
+	}
+
+	if staleCount != 1 {
+		t.Fatalf("expected 1 stale session (refinery), got %d", staleCount)
+	}
+	if escalations["gastown.refinery"] != 1 {
+		t.Fatalf("expected 1 escalation for stale refinery, got %d", escalations["gastown.refinery"])
+	}
+	if escalations["gastown.witness"] != 0 {
+		t.Fatalf("expected 0 escalations for fresh witness, got %d", escalations["gastown.witness"])
+	}
+}
+
+// TestLivenessTracker_ZeroActivityTreatedAsStaleAfterWindow verifies that a
+// session that has never run (zero last activity) is treated as stale only
+// once the freshness window has elapsed since the controller started, to
+// avoid false positives at startup.
+func TestLivenessTracker_ZeroActivityTreatedAsStaleAfterWindow(t *testing.T) {
+	tracker := newSessionLivenessTracker(true)
+	window := 2 * time.Hour
+	startedAt := livenessBaseTime
+
+	f := runtime.NewFake()
+	startSession(f, "gastown.refinery", time.Time{}) // never active
+
+	escalations := 0
+	emit := func(_ string, _ time.Time, _ time.Time) { escalations++ }
+
+	// At startup (now == startedAt), elapsed = 0 < window. Should not escalate.
+	tracker.checkFreshness("gastown.refinery", window, f, startedAt, startedAt, emit)
+	if escalations != 0 {
+		t.Fatal("expected no escalation at startup for zero-activity session")
+	}
+
+	// After 1h (half the window). Still should not escalate.
+	tracker.checkFreshness("gastown.refinery", window, f,
+		startedAt.Add(1*time.Hour), startedAt, emit)
+	if escalations != 0 {
+		t.Fatal("expected no escalation at 1h for zero-activity session with 2h window")
+	}
+
+	// After 3h (past the window). Should escalate.
+	tracker.checkFreshness("gastown.refinery", window, f,
+		startedAt.Add(3*time.Hour), startedAt, emit)
+	if escalations != 1 {
+		t.Fatalf("expected 1 escalation at 3h for zero-activity session with 2h window, got %d", escalations)
+	}
+}
+
+// TestLivenessTracker_BoundedCadence asserts that the patrol is controller-driven:
+// on every patrol tick, the tracker checks the session and reports stale=true
+// when the session is stale, regardless of whether a self-scheduled loop in the
+// pack would have woken the deacon. The max check gap equals patrol_interval.
+func TestLivenessTracker_BoundedCadence(t *testing.T) {
+	tracker := newSessionLivenessTracker(true)
+	window := 30 * time.Minute
+	startedAt := livenessBaseTime
+
+	// Session last active 2h ago — stale.
+	f := runtime.NewFake()
+	startSession(f, "gastown.deacon", livenessBaseTime.Add(-2*time.Hour))
+
+	// Simulate 5 patrol ticks at 30s intervals (the default patrol_interval).
+	// The session remains stale. The tracker should observe stale on every tick.
+	patrolInterval := 30 * time.Second
+	staleObservations := 0
+	for i := range 5 {
+		now := livenessBaseTime.Add(time.Duration(i) * patrolInterval)
+		stale := tracker.checkFreshness("gastown.deacon", window, f, now, startedAt, noopEmit)
+		if stale {
+			staleObservations++
+		}
+	}
+
+	// Every tick should observe stale state — the controller checks on each
+	// patrol tick regardless of the session's self-scheduling state.
+	if staleObservations != 5 {
+		t.Fatalf("expected stale=true on all 5 patrol ticks, got %d/5", staleObservations)
+	}
+}
+
+// TestLivenessTracker_NilTrackerIsNoop verifies that a nil tracker is the
+// safe no-op created when no session_liveness_checks are configured.
+func TestLivenessTracker_NilTrackerIsNoop(t *testing.T) {
+	tracker := newSessionLivenessTracker(false) // no checks configured → nil
+	if tracker != nil {
+		t.Fatal("expected nil tracker when hasAny=false")
+	}
+}
+
+// TestLivenessTracker_ProviderErrorFailsOpen verifies that a provider error
+// does not trigger escalation (fail-open, no false alarms).
+func TestLivenessTracker_ProviderErrorFailsOpen(t *testing.T) {
+	tracker := newSessionLivenessTracker(true)
+	window := 2 * time.Hour
+	startedAt := livenessBaseTime
+
+	brokenProvider := runtime.NewFailFake()
+	escalations := 0
+	stale := tracker.checkFreshness("gastown.refinery", window, brokenProvider, livenessBaseTime, startedAt,
+		func(_ string, _ time.Time, _ time.Time) { escalations++ })
+
+	if stale {
+		t.Fatal("expected stale=false when provider returns error (fail-open)")
+	}
+	if escalations != 0 {
+		t.Fatalf("expected 0 escalations on provider error, got %d", escalations)
+	}
+}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -331,6 +331,7 @@ DaemonConfig holds controller daemon settings.
 | `start_ready_timeout` | string |  | `5m` | StartReadyTimeout is how long `gc start` and `gc register` wait for the supervisor to report the city as Running. Cities with many registered or adopted sessions take longer to start because the per-tick wake budget (max_wakes_per_tick) throttles startup: wall time to wake N sessions is roughly ceil(N / max_wakes_per_tick) * patrol_interval. At the defaults (5 wakes / 30s), ~40 sessions need ~4 minutes. Duration string (e.g., "5m", "10m"). Defaults to DefaultStartReadyTimeout (5m). When set, this value replaces the default start/register budget; [session].startup_timeout may still extend the effective wait for a slow single session. |
 | `tick_debounce` | string |  |  | TickDebounce coalesces bursty event-driven ticks (pokeCh, controlDispatcherCh) within this window. A first event in a quiet period arms a timer; subsequent events arriving before the timer fires are dropped (the single delayed tick re-reads authoritative state covering all collapsed events). Zero (the default) disables debouncing — each event fires its own tick, matching pre-existing behavior. Duration string (e.g., "250ms", "500ms"). Trade-off: adds tick latency up to this value when set. |
 | `auto_prune_worker_dir` | boolean |  | `true` | AutoPruneWorkerDir controls whether the reconciler removes a pool-managed session's worker_dir (agent worktree) after the session bead is closed. Removal is gated on: path lives under the city's .gc/worktrees/ tree, clean working tree, no unpushed commits, no stashed work. Nil (unset) defaults to true so pool worktrees do not accumulate without bound across pool recycles. Set to false to retain worktrees for post-session diagnostics. |
+| `session_liveness_checks` | []SessionLivenessCheck |  |  | SessionLivenessChecks configures per-session freshness monitoring. The controller checks each entry on every patrol tick: if any listed session has had no activity within FreshnessWindow, it emits a session.liveness_stale event exactly once per stale episode and optionally nudges EscalateTo. Escalation clears when the session becomes active again. This gives the controller-supervised, tight-cadence patrol required by the health monitoring architecture without hardcoding role names in Go (the session names come from operator-supplied config). |
 
 ## DoctorConfig
 
@@ -799,6 +800,16 @@ SessionConfig holds session provider settings.
 | `progress_stall_timeout` | string |  |  | ProgressStallTimeout, when set, enables progress-aware session recycling: a desired, alive, claim-less session on a healthy provider whose last provider-reported activity is older than this duration is restarted fresh. Such a session has likely parked (e.g. its turn ended on a provider auth error) and will not self-recover. Set this above the longest legitimate alive-idle period for the city; values below 5m are clamped to 5m. Duration string (e.g. "30m"). Unset/zero disables it. |
 | `socket` | string |  |  | Socket specifies the tmux socket name for per-city isolation. When set, all tmux commands use "tmux -L &lt;socket&gt;" to connect to a dedicated server. When empty, defaults to the city name (workspace.name) — giving every city its own tmux server automatically. Set explicitly to override. |
 | `remote_match` | string |  |  | RemoteMatch is a substring pattern for the hybrid provider to route sessions to the remote (K8s) backend. Sessions whose names contain this pattern go to K8s; all others stay local (tmux). Overridden by the GC_HYBRID_REMOTE_MATCH env var if set. |
+
+## SessionLivenessCheck
+
+SessionLivenessCheck is one entry in DaemonConfig.SessionLivenessChecks.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `sessions` | []string | **yes** |  | Sessions lists the runtime session names to monitor for freshness. |
+| `freshness_window` | string | **yes** |  | FreshnessWindow is the maximum allowed gap since last session activity. Duration string (e.g., "2h", "30m"). Required; empty entries are skipped. |
+| `escalate_to` | string |  |  | EscalateTo is an optional session name to nudge when any listed session is stale. If empty, only the event is emitted (no nudge). |
 
 ## SessionSleepConfig
 

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1349,6 +1349,13 @@
           "type": "boolean",
           "description": "AutoPruneWorkerDir controls whether the reconciler removes a\npool-managed session's worker_dir (agent worktree) after the session\nbead is closed. Removal is gated on: path lives under the city's\n.gc/worktrees/ tree, clean working tree, no unpushed commits, no\nstashed work. Nil (unset) defaults to true so pool worktrees do not\naccumulate without bound across pool recycles. Set to false to\nretain worktrees for post-session diagnostics.",
           "default": true
+        },
+        "session_liveness_checks": {
+          "items": {
+            "$ref": "#/$defs/SessionLivenessCheck"
+          },
+          "type": "array",
+          "description": "SessionLivenessChecks configures per-session freshness monitoring.\nThe controller checks each entry on every patrol tick: if any listed\nsession has had no activity within FreshnessWindow, it emits a\nsession.liveness_stale event exactly once per stale episode and\noptionally nudges EscalateTo. Escalation clears when the session\nbecomes active again. This gives the controller-supervised, tight-cadence\npatrol required by the health monitoring architecture without hardcoding\nrole names in Go (the session names come from operator-supplied config)."
         }
       },
       "additionalProperties": false,
@@ -2750,6 +2757,32 @@
       "additionalProperties": false,
       "type": "object",
       "description": "SessionConfig holds session provider settings."
+    },
+    "SessionLivenessCheck": {
+      "properties": {
+        "sessions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Sessions lists the runtime session names to monitor for freshness."
+        },
+        "freshness_window": {
+          "type": "string",
+          "description": "FreshnessWindow is the maximum allowed gap since last session activity.\nDuration string (e.g., \"2h\", \"30m\"). Required; empty entries are skipped."
+        },
+        "escalate_to": {
+          "type": "string",
+          "description": "EscalateTo is an optional session name to nudge when any listed session\nis stale. If empty, only the event is emitted (no nudge)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessions",
+        "freshness_window"
+      ],
+      "description": "SessionLivenessCheck is one entry in DaemonConfig.SessionLivenessChecks."
     },
     "SessionSleepConfig": {
       "properties": {

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1349,6 +1349,13 @@
           "type": "boolean",
           "description": "AutoPruneWorkerDir controls whether the reconciler removes a\npool-managed session's worker_dir (agent worktree) after the session\nbead is closed. Removal is gated on: path lives under the city's\n.gc/worktrees/ tree, clean working tree, no unpushed commits, no\nstashed work. Nil (unset) defaults to true so pool worktrees do not\naccumulate without bound across pool recycles. Set to false to\nretain worktrees for post-session diagnostics.",
           "default": true
+        },
+        "session_liveness_checks": {
+          "items": {
+            "$ref": "#/$defs/SessionLivenessCheck"
+          },
+          "type": "array",
+          "description": "SessionLivenessChecks configures per-session freshness monitoring.\nThe controller checks each entry on every patrol tick: if any listed\nsession has had no activity within FreshnessWindow, it emits a\nsession.liveness_stale event exactly once per stale episode and\noptionally nudges EscalateTo. Escalation clears when the session\nbecomes active again. This gives the controller-supervised, tight-cadence\npatrol required by the health monitoring architecture without hardcoding\nrole names in Go (the session names come from operator-supplied config)."
         }
       },
       "additionalProperties": false,
@@ -2750,6 +2757,32 @@
       "additionalProperties": false,
       "type": "object",
       "description": "SessionConfig holds session provider settings."
+    },
+    "SessionLivenessCheck": {
+      "properties": {
+        "sessions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Sessions lists the runtime session names to monitor for freshness."
+        },
+        "freshness_window": {
+          "type": "string",
+          "description": "FreshnessWindow is the maximum allowed gap since last session activity.\nDuration string (e.g., \"2h\", \"30m\"). Required; empty entries are skipped."
+        },
+        "escalate_to": {
+          "type": "string",
+          "description": "EscalateTo is an optional session name to nudge when any listed session\nis stale. If empty, only the event is emitted (no nudge)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessions",
+        "freshness_window"
+      ],
+      "description": "SessionLivenessCheck is one entry in DaemonConfig.SessionLivenessChecks."
     },
     "SessionSleepConfig": {
       "properties": {

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -2270,6 +2270,9 @@
             "$ref": "#/components/schemas/SessionLifecyclePayload"
           },
           {
+            "$ref": "#/components/schemas/SessionLivenessStalePayload"
+          },
+          {
             "$ref": "#/components/schemas/SessionMessageSucceededPayload"
           },
           {
@@ -6687,6 +6690,38 @@
         ],
         "type": "object"
       },
+      "SessionLivenessStalePayload": {
+        "additionalProperties": false,
+        "properties": {
+          "episode_id": {
+            "type": "string"
+          },
+          "escalate_to": {
+            "type": "string"
+          },
+          "freshness_window": {
+            "type": "string"
+          },
+          "last_activity": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "session": {
+            "type": "string"
+          },
+          "stale_since": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session",
+          "episode_id",
+          "stale_since",
+          "freshness_window"
+        ],
+        "type": "object"
+      },
       "SessionMessageInputBody": {
         "additionalProperties": false,
         "properties": {
@@ -8286,6 +8321,7 @@
             "session.drain_acked_with_assigned_work": "#/components/schemas/TypedEventStreamEnvelopeSessionDrainAckedWithAssignedWork",
             "session.draining": "#/components/schemas/TypedEventStreamEnvelopeSessionDraining",
             "session.idle_killed": "#/components/schemas/TypedEventStreamEnvelopeSessionIdleKilled",
+            "session.liveness_stale": "#/components/schemas/TypedEventStreamEnvelopeSessionLivenessStale",
             "session.max_age_killed": "#/components/schemas/TypedEventStreamEnvelopeSessionMaxAgeKilled",
             "session.quarantined": "#/components/schemas/TypedEventStreamEnvelopeSessionQuarantined",
             "session.reset_stalled": "#/components/schemas/TypedEventStreamEnvelopeSessionResetStalled",
@@ -8471,6 +8507,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionIdleKilled"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionLivenessStale"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionMaxAgeKilled"
@@ -9343,6 +9382,7 @@
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
+                "session.liveness_stale",
                 "bead.created",
                 "bead.closed",
                 "bead.deleted",
@@ -11458,6 +11498,48 @@
         "title": "TypedEventStreamEnvelope session.idle_killed",
         "type": "object"
       },
+      "TypedEventStreamEnvelopeSessionLivenessStale": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionLivenessStalePayload"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.liveness_stale",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope session.liveness_stale",
+        "type": "object"
+      },
       "TypedEventStreamEnvelopeSessionMaxAgeKilled": {
         "additionalProperties": false,
         "properties": {
@@ -12384,6 +12466,7 @@
             "session.drain_acked_with_assigned_work": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionDrainAckedWithAssignedWork",
             "session.draining": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionDraining",
             "session.idle_killed": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionIdleKilled",
+            "session.liveness_stale": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionLivenessStale",
             "session.max_age_killed": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled",
             "session.quarantined": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionQuarantined",
             "session.reset_stalled": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionResetStalled",
@@ -12569,6 +12652,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionIdleKilled"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionLivenessStale"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled"
@@ -13504,6 +13590,7 @@
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
+                "session.liveness_stale",
                 "bead.created",
                 "bead.closed",
                 "bead.deleted",
@@ -15778,6 +15865,52 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope session.idle_killed",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeSessionLivenessStale": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionLivenessStalePayload"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.liveness_stale",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope session.liveness_stale",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled": {

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -2270,6 +2270,9 @@
             "$ref": "#/components/schemas/SessionLifecyclePayload"
           },
           {
+            "$ref": "#/components/schemas/SessionLivenessStalePayload"
+          },
+          {
             "$ref": "#/components/schemas/SessionMessageSucceededPayload"
           },
           {
@@ -6687,6 +6690,38 @@
         ],
         "type": "object"
       },
+      "SessionLivenessStalePayload": {
+        "additionalProperties": false,
+        "properties": {
+          "episode_id": {
+            "type": "string"
+          },
+          "escalate_to": {
+            "type": "string"
+          },
+          "freshness_window": {
+            "type": "string"
+          },
+          "last_activity": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "session": {
+            "type": "string"
+          },
+          "stale_since": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session",
+          "episode_id",
+          "stale_since",
+          "freshness_window"
+        ],
+        "type": "object"
+      },
       "SessionMessageInputBody": {
         "additionalProperties": false,
         "properties": {
@@ -8286,6 +8321,7 @@
             "session.drain_acked_with_assigned_work": "#/components/schemas/TypedEventStreamEnvelopeSessionDrainAckedWithAssignedWork",
             "session.draining": "#/components/schemas/TypedEventStreamEnvelopeSessionDraining",
             "session.idle_killed": "#/components/schemas/TypedEventStreamEnvelopeSessionIdleKilled",
+            "session.liveness_stale": "#/components/schemas/TypedEventStreamEnvelopeSessionLivenessStale",
             "session.max_age_killed": "#/components/schemas/TypedEventStreamEnvelopeSessionMaxAgeKilled",
             "session.quarantined": "#/components/schemas/TypedEventStreamEnvelopeSessionQuarantined",
             "session.reset_stalled": "#/components/schemas/TypedEventStreamEnvelopeSessionResetStalled",
@@ -8471,6 +8507,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionIdleKilled"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionLivenessStale"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionMaxAgeKilled"
@@ -9343,6 +9382,7 @@
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
+                "session.liveness_stale",
                 "bead.created",
                 "bead.closed",
                 "bead.deleted",
@@ -11458,6 +11498,48 @@
         "title": "TypedEventStreamEnvelope session.idle_killed",
         "type": "object"
       },
+      "TypedEventStreamEnvelopeSessionLivenessStale": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionLivenessStalePayload"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.liveness_stale",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope session.liveness_stale",
+        "type": "object"
+      },
       "TypedEventStreamEnvelopeSessionMaxAgeKilled": {
         "additionalProperties": false,
         "properties": {
@@ -12384,6 +12466,7 @@
             "session.drain_acked_with_assigned_work": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionDrainAckedWithAssignedWork",
             "session.draining": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionDraining",
             "session.idle_killed": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionIdleKilled",
+            "session.liveness_stale": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionLivenessStale",
             "session.max_age_killed": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled",
             "session.quarantined": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionQuarantined",
             "session.reset_stalled": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionResetStalled",
@@ -12569,6 +12652,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionIdleKilled"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionLivenessStale"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled"
@@ -13504,6 +13590,7 @@
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
+                "session.liveness_stale",
                 "bead.created",
                 "bead.closed",
                 "bead.deleted",
@@ -15778,6 +15865,52 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope session.idle_killed",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeSessionLivenessStale": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionLivenessStalePayload"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.liveness_stale",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope session.liveness_stale",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled": {

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
@@ -778,7 +778,7 @@ export type EventEmitRequest = {
     type: string;
 };
 
-export type EventPayload = AdapterEventPayload | BeadEventPayload | BoundEventPayload | CityCreateSucceededPayload | CityLifecyclePayload | CityUnregisterSucceededPayload | GroupCreatedEventPayload | InboundEventPayload | MailEventPayload | NoPayload | OutboundEventPayload | PostgresCredentialResolvedPayload | ProjectIdentityStampedPayload | RequestFailedPayload | RotatedPayload | SessionCreateSucceededPayload | SessionDrainAckedWithAssignedWorkPayload | SessionLifecyclePayload | SessionMessageSucceededPayload | SessionSubmitSucceededPayload | StoreMaintenanceDonePayload | StoreMaintenanceFailedPayload | SupervisorFsPressureSkippedTickPayload | SupervisorShutdownPayload | UnboundEventPayload | WorkerOperationEventPayload;
+export type EventPayload = AdapterEventPayload | BeadEventPayload | BoundEventPayload | CityCreateSucceededPayload | CityLifecyclePayload | CityUnregisterSucceededPayload | GroupCreatedEventPayload | InboundEventPayload | MailEventPayload | NoPayload | OutboundEventPayload | PostgresCredentialResolvedPayload | ProjectIdentityStampedPayload | RequestFailedPayload | RotatedPayload | SessionCreateSucceededPayload | SessionDrainAckedWithAssignedWorkPayload | SessionLifecyclePayload | SessionLivenessStalePayload | SessionMessageSucceededPayload | SessionSubmitSucceededPayload | StoreMaintenanceDonePayload | StoreMaintenanceFailedPayload | SupervisorFsPressureSkippedTickPayload | SupervisorShutdownPayload | UnboundEventPayload | WorkerOperationEventPayload;
 
 export type EventRotateAnchor = {
     /**
@@ -2513,6 +2513,15 @@ export type SessionLifecyclePayload = {
     template?: string;
 };
 
+export type SessionLivenessStalePayload = {
+    episode_id: string;
+    escalate_to?: string;
+    freshness_window: string;
+    last_activity?: string;
+    session: string;
+    stale_since: string;
+};
+
 export type SessionMessageInputBody = {
     /**
      * Message text to send.
@@ -3305,6 +3314,8 @@ export type TypedEventStreamEnvelope = ({
 } & TypedEventStreamEnvelopeSessionDraining) | ({
     type: 'session.idle_killed';
 } & TypedEventStreamEnvelopeSessionIdleKilled) | ({
+    type: 'session.liveness_stale';
+} & TypedEventStreamEnvelopeSessionLivenessStale) | ({
     type: 'session.max_age_killed';
 } & TypedEventStreamEnvelopeSessionMaxAgeKilled) | ({
     type: 'session.quarantined';
@@ -4098,6 +4109,20 @@ export type TypedEventStreamEnvelopeSessionIdleKilled = {
 };
 
 /**
+ * TypedEventStreamEnvelope session.liveness_stale
+ */
+export type TypedEventStreamEnvelopeSessionLivenessStale = {
+    actor: string;
+    message?: string;
+    payload: SessionLivenessStalePayload;
+    seq: number;
+    subject?: string;
+    ts: string;
+    type: 'session.liveness_stale';
+    workflow?: WorkflowEventProjection;
+};
+
+/**
  * TypedEventStreamEnvelope session.max_age_killed
  */
 export type TypedEventStreamEnvelopeSessionMaxAgeKilled = {
@@ -4395,6 +4420,8 @@ export type TypedTaggedEventStreamEnvelope = ({
 } & TypedTaggedEventStreamEnvelopeSessionDraining) | ({
     type: 'session.idle_killed';
 } & TypedTaggedEventStreamEnvelopeSessionIdleKilled) | ({
+    type: 'session.liveness_stale';
+} & TypedTaggedEventStreamEnvelopeSessionLivenessStale) | ({
     type: 'session.max_age_killed';
 } & TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled) | ({
     type: 'session.quarantined';
@@ -5229,6 +5256,21 @@ export type TypedTaggedEventStreamEnvelopeSessionIdleKilled = {
     subject?: string;
     ts: string;
     type: 'session.idle_killed';
+    workflow?: WorkflowEventProjection;
+};
+
+/**
+ * TypedTaggedEventStreamEnvelope session.liveness_stale
+ */
+export type TypedTaggedEventStreamEnvelopeSessionLivenessStale = {
+    actor: string;
+    city: string;
+    message?: string;
+    payload: SessionLivenessStalePayload;
+    seq: number;
+    subject?: string;
+    ts: string;
+    type: 'session.liveness_stale';
     workflow?: WorkflowEventProjection;
 };
 

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2778,6 +2778,16 @@ type SessionLifecyclePayload struct {
 	Template *string `json:"template,omitempty"`
 }
 
+// SessionLivenessStalePayload defines model for SessionLivenessStalePayload.
+type SessionLivenessStalePayload struct {
+	EpisodeId       string     `json:"episode_id"`
+	EscalateTo      *string    `json:"escalate_to,omitempty"`
+	FreshnessWindow string     `json:"freshness_window"`
+	LastActivity    *time.Time `json:"last_activity,omitempty"`
+	Session         string     `json:"session"`
+	StaleSince      time.Time  `json:"stale_since"`
+}
+
 // SessionMessageInputBody defines model for SessionMessageInputBody.
 type SessionMessageInputBody struct {
 	// Message Message text to send.
@@ -4279,6 +4289,18 @@ type TypedEventStreamEnvelopeSessionIdleKilled struct {
 	Workflow  *WorkflowEventProjection `json:"workflow,omitempty"`
 }
 
+// TypedEventStreamEnvelopeSessionLivenessStale defines model for TypedEventStreamEnvelopeSessionLivenessStale.
+type TypedEventStreamEnvelopeSessionLivenessStale struct {
+	Actor    string                      `json:"actor"`
+	Message  *string                     `json:"message,omitempty"`
+	Payload  SessionLivenessStalePayload `json:"payload"`
+	Seq      int64                       `json:"seq"`
+	Subject  *string                     `json:"subject,omitempty"`
+	Ts       time.Time                   `json:"ts"`
+	Type     string                      `json:"type"`
+	Workflow *WorkflowEventProjection    `json:"workflow,omitempty"`
+}
+
 // TypedEventStreamEnvelopeSessionMaxAgeKilled defines model for TypedEventStreamEnvelopeSessionMaxAgeKilled.
 type TypedEventStreamEnvelopeSessionMaxAgeKilled struct {
 	Actor     string                   `json:"actor"`
@@ -5433,6 +5455,19 @@ type TypedTaggedEventStreamEnvelopeSessionIdleKilled struct {
 	Ts        time.Time                `json:"ts"`
 	Type      string                   `json:"type"`
 	Workflow  *WorkflowEventProjection `json:"workflow,omitempty"`
+}
+
+// TypedTaggedEventStreamEnvelopeSessionLivenessStale defines model for TypedTaggedEventStreamEnvelopeSessionLivenessStale.
+type TypedTaggedEventStreamEnvelopeSessionLivenessStale struct {
+	Actor    string                      `json:"actor"`
+	City     string                      `json:"city"`
+	Message  *string                     `json:"message,omitempty"`
+	Payload  SessionLivenessStalePayload `json:"payload"`
+	Seq      int64                       `json:"seq"`
+	Subject  *string                     `json:"subject,omitempty"`
+	Ts       time.Time                   `json:"ts"`
+	Type     string                      `json:"type"`
+	Workflow *WorkflowEventProjection    `json:"workflow,omitempty"`
 }
 
 // TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled defines model for TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled.
@@ -7678,6 +7713,32 @@ func (t *EventPayload) MergeSessionLifecyclePayload(v SessionLifecyclePayload) e
 	return err
 }
 
+// AsSessionLivenessStalePayload returns the union data inside the EventPayload as a SessionLivenessStalePayload
+func (t EventPayload) AsSessionLivenessStalePayload() (SessionLivenessStalePayload, error) {
+	var body SessionLivenessStalePayload
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromSessionLivenessStalePayload overwrites any union data inside the EventPayload as the provided SessionLivenessStalePayload
+func (t *EventPayload) FromSessionLivenessStalePayload(v SessionLivenessStalePayload) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeSessionLivenessStalePayload performs a merge with any union data inside the EventPayload, using the provided SessionLivenessStalePayload
+func (t *EventPayload) MergeSessionLivenessStalePayload(v SessionLivenessStalePayload) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsSessionMessageSucceededPayload returns the union data inside the EventPayload as a SessionMessageSucceededPayload
 func (t EventPayload) AsSessionMessageSucceededPayload() (SessionMessageSucceededPayload, error) {
 	var body SessionMessageSucceededPayload
@@ -9732,6 +9793,34 @@ func (t *TypedEventStreamEnvelope) MergeTypedEventStreamEnvelopeSessionIdleKille
 	return err
 }
 
+// AsTypedEventStreamEnvelopeSessionLivenessStale returns the union data inside the TypedEventStreamEnvelope as a TypedEventStreamEnvelopeSessionLivenessStale
+func (t TypedEventStreamEnvelope) AsTypedEventStreamEnvelopeSessionLivenessStale() (TypedEventStreamEnvelopeSessionLivenessStale, error) {
+	var body TypedEventStreamEnvelopeSessionLivenessStale
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromTypedEventStreamEnvelopeSessionLivenessStale overwrites any union data inside the TypedEventStreamEnvelope as the provided TypedEventStreamEnvelopeSessionLivenessStale
+func (t *TypedEventStreamEnvelope) FromTypedEventStreamEnvelopeSessionLivenessStale(v TypedEventStreamEnvelopeSessionLivenessStale) error {
+	v.Type = "session.liveness_stale"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeTypedEventStreamEnvelopeSessionLivenessStale performs a merge with any union data inside the TypedEventStreamEnvelope, using the provided TypedEventStreamEnvelopeSessionLivenessStale
+func (t *TypedEventStreamEnvelope) MergeTypedEventStreamEnvelopeSessionLivenessStale(v TypedEventStreamEnvelopeSessionLivenessStale) error {
+	v.Type = "session.liveness_stale"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsTypedEventStreamEnvelopeSessionMaxAgeKilled returns the union data inside the TypedEventStreamEnvelope as a TypedEventStreamEnvelopeSessionMaxAgeKilled
 func (t TypedEventStreamEnvelope) AsTypedEventStreamEnvelopeSessionMaxAgeKilled() (TypedEventStreamEnvelopeSessionMaxAgeKilled, error) {
 	var body TypedEventStreamEnvelopeSessionMaxAgeKilled
@@ -10362,6 +10451,8 @@ func (t TypedEventStreamEnvelope) ValueByDiscriminator() (interface{}, error) {
 		return t.AsTypedEventStreamEnvelopeSessionDraining()
 	case "session.idle_killed":
 		return t.AsTypedEventStreamEnvelopeSessionIdleKilled()
+	case "session.liveness_stale":
+		return t.AsTypedEventStreamEnvelopeSessionLivenessStale()
 	case "session.max_age_killed":
 		return t.AsTypedEventStreamEnvelopeSessionMaxAgeKilled()
 	case "session.quarantined":
@@ -11951,6 +12042,34 @@ func (t *TypedTaggedEventStreamEnvelope) MergeTypedTaggedEventStreamEnvelopeSess
 	return err
 }
 
+// AsTypedTaggedEventStreamEnvelopeSessionLivenessStale returns the union data inside the TypedTaggedEventStreamEnvelope as a TypedTaggedEventStreamEnvelopeSessionLivenessStale
+func (t TypedTaggedEventStreamEnvelope) AsTypedTaggedEventStreamEnvelopeSessionLivenessStale() (TypedTaggedEventStreamEnvelopeSessionLivenessStale, error) {
+	var body TypedTaggedEventStreamEnvelopeSessionLivenessStale
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromTypedTaggedEventStreamEnvelopeSessionLivenessStale overwrites any union data inside the TypedTaggedEventStreamEnvelope as the provided TypedTaggedEventStreamEnvelopeSessionLivenessStale
+func (t *TypedTaggedEventStreamEnvelope) FromTypedTaggedEventStreamEnvelopeSessionLivenessStale(v TypedTaggedEventStreamEnvelopeSessionLivenessStale) error {
+	v.Type = "session.liveness_stale"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeTypedTaggedEventStreamEnvelopeSessionLivenessStale performs a merge with any union data inside the TypedTaggedEventStreamEnvelope, using the provided TypedTaggedEventStreamEnvelopeSessionLivenessStale
+func (t *TypedTaggedEventStreamEnvelope) MergeTypedTaggedEventStreamEnvelopeSessionLivenessStale(v TypedTaggedEventStreamEnvelopeSessionLivenessStale) error {
+	v.Type = "session.liveness_stale"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsTypedTaggedEventStreamEnvelopeSessionMaxAgeKilled returns the union data inside the TypedTaggedEventStreamEnvelope as a TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled
 func (t TypedTaggedEventStreamEnvelope) AsTypedTaggedEventStreamEnvelopeSessionMaxAgeKilled() (TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled, error) {
 	var body TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled
@@ -12581,6 +12700,8 @@ func (t TypedTaggedEventStreamEnvelope) ValueByDiscriminator() (interface{}, err
 		return t.AsTypedTaggedEventStreamEnvelopeSessionDraining()
 	case "session.idle_killed":
 		return t.AsTypedTaggedEventStreamEnvelopeSessionIdleKilled()
+	case "session.liveness_stale":
+		return t.AsTypedTaggedEventStreamEnvelopeSessionLivenessStale()
 	case "session.max_age_killed":
 		return t.AsTypedTaggedEventStreamEnvelopeSessionMaxAgeKilled()
 	case "session.quarantined":

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -2270,6 +2270,9 @@
             "$ref": "#/components/schemas/SessionLifecyclePayload"
           },
           {
+            "$ref": "#/components/schemas/SessionLivenessStalePayload"
+          },
+          {
             "$ref": "#/components/schemas/SessionMessageSucceededPayload"
           },
           {
@@ -6687,6 +6690,38 @@
         ],
         "type": "object"
       },
+      "SessionLivenessStalePayload": {
+        "additionalProperties": false,
+        "properties": {
+          "episode_id": {
+            "type": "string"
+          },
+          "escalate_to": {
+            "type": "string"
+          },
+          "freshness_window": {
+            "type": "string"
+          },
+          "last_activity": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "session": {
+            "type": "string"
+          },
+          "stale_since": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session",
+          "episode_id",
+          "stale_since",
+          "freshness_window"
+        ],
+        "type": "object"
+      },
       "SessionMessageInputBody": {
         "additionalProperties": false,
         "properties": {
@@ -8286,6 +8321,7 @@
             "session.drain_acked_with_assigned_work": "#/components/schemas/TypedEventStreamEnvelopeSessionDrainAckedWithAssignedWork",
             "session.draining": "#/components/schemas/TypedEventStreamEnvelopeSessionDraining",
             "session.idle_killed": "#/components/schemas/TypedEventStreamEnvelopeSessionIdleKilled",
+            "session.liveness_stale": "#/components/schemas/TypedEventStreamEnvelopeSessionLivenessStale",
             "session.max_age_killed": "#/components/schemas/TypedEventStreamEnvelopeSessionMaxAgeKilled",
             "session.quarantined": "#/components/schemas/TypedEventStreamEnvelopeSessionQuarantined",
             "session.reset_stalled": "#/components/schemas/TypedEventStreamEnvelopeSessionResetStalled",
@@ -8471,6 +8507,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionIdleKilled"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionLivenessStale"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionMaxAgeKilled"
@@ -9343,6 +9382,7 @@
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
+                "session.liveness_stale",
                 "bead.created",
                 "bead.closed",
                 "bead.deleted",
@@ -11458,6 +11498,48 @@
         "title": "TypedEventStreamEnvelope session.idle_killed",
         "type": "object"
       },
+      "TypedEventStreamEnvelopeSessionLivenessStale": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionLivenessStalePayload"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.liveness_stale",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope session.liveness_stale",
+        "type": "object"
+      },
       "TypedEventStreamEnvelopeSessionMaxAgeKilled": {
         "additionalProperties": false,
         "properties": {
@@ -12384,6 +12466,7 @@
             "session.drain_acked_with_assigned_work": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionDrainAckedWithAssignedWork",
             "session.draining": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionDraining",
             "session.idle_killed": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionIdleKilled",
+            "session.liveness_stale": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionLivenessStale",
             "session.max_age_killed": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled",
             "session.quarantined": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionQuarantined",
             "session.reset_stalled": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionResetStalled",
@@ -12569,6 +12652,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionIdleKilled"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionLivenessStale"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled"
@@ -13504,6 +13590,7 @@
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
+                "session.liveness_stale",
                 "bead.created",
                 "bead.closed",
                 "bead.deleted",
@@ -15778,6 +15865,52 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope session.idle_killed",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeSessionLivenessStale": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionLivenessStalePayload"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.liveness_stale",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope session.liveness_stale",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopeSessionMaxAgeKilled": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2521,6 +2521,41 @@ type DaemonConfig struct {
 	// accumulate without bound across pool recycles. Set to false to
 	// retain worktrees for post-session diagnostics.
 	AutoPruneWorkerDir *bool `toml:"auto_prune_worker_dir,omitempty" jsonschema:"default=true"`
+
+	// SessionLivenessChecks configures per-session freshness monitoring.
+	// The controller checks each entry on every patrol tick: if any listed
+	// session has had no activity within FreshnessWindow, it emits a
+	// session.liveness_stale event exactly once per stale episode and
+	// optionally nudges EscalateTo. Escalation clears when the session
+	// becomes active again. This gives the controller-supervised, tight-cadence
+	// patrol required by the health monitoring architecture without hardcoding
+	// role names in Go (the session names come from operator-supplied config).
+	SessionLivenessChecks []SessionLivenessCheck `toml:"session_liveness_checks,omitempty"`
+}
+
+// SessionLivenessCheck is one entry in DaemonConfig.SessionLivenessChecks.
+type SessionLivenessCheck struct {
+	// Sessions lists the runtime session names to monitor for freshness.
+	Sessions []string `toml:"sessions"`
+	// FreshnessWindow is the maximum allowed gap since last session activity.
+	// Duration string (e.g., "2h", "30m"). Required; empty entries are skipped.
+	FreshnessWindow string `toml:"freshness_window"`
+	// EscalateTo is an optional session name to nudge when any listed session
+	// is stale. If empty, only the event is emitted (no nudge).
+	EscalateTo string `toml:"escalate_to,omitempty"`
+}
+
+// FreshnessWindowDuration parses and returns FreshnessWindow as a
+// time.Duration. Returns 0 if the field is empty or unparseable.
+func (c *SessionLivenessCheck) FreshnessWindowDuration() time.Duration {
+	if c.FreshnessWindow == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(c.FreshnessWindow)
+	if err != nil {
+		return 0
+	}
+	return d
 }
 
 // AutoRestartOnDriftEnabled reports whether the supervisor should be

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -59,6 +59,9 @@ func ValidateDurations(cfg *City, source string) []string {
 
 	// Daemon config durations.
 	check("[daemon]", "patrol_interval", cfg.Daemon.PatrolInterval)
+	for i, slc := range cfg.Daemon.SessionLivenessChecks {
+		check(fmt.Sprintf("[daemon.session_liveness_checks[%d]]", i), "freshness_window", slc.FreshnessWindow)
+	}
 	check("[daemon]", "restart_window", cfg.Daemon.RestartWindow)
 	check("[daemon]", "session_circuit_breaker_window", cfg.Daemon.SessionCircuitBreakerWindow)
 	check("[daemon]", "session_circuit_breaker_reset_after", cfg.Daemon.SessionCircuitBreakerResetAfter)

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -85,10 +85,19 @@ const (
 	// Emitted by the session reconciler's start-result commit path; the
 	// envelope's Subject carries the session name.
 	SessionColdStartTimeout = "session.cold_start_timeout"
-	ConvoyCreated           = "convoy.created"
-	ConvoyClosed            = "convoy.closed"
-	ControllerStarted       = "controller.started"
-	ControllerStopped       = "controller.stopped"
+	// SessionLivenessStale fires when a session configured in
+	// [daemon.session_liveness_checks] has had no activity within its
+	// freshness_window. Fires exactly once per stale episode (green→stale
+	// transition); subsequent patrol ticks that find the same session still
+	// stale do not re-fire. Clears when the session becomes active again.
+	// Operators use this event to detect monitoring-chain gaps (e.g., a
+	// dead refinery or witness that a deacon-equivalent patrol agent would
+	// normally detect, but missed because of a self-scheduling failure).
+	SessionLivenessStale = "session.liveness_stale"
+	ConvoyCreated        = "convoy.created"
+	ConvoyClosed         = "convoy.closed"
+	ControllerStarted    = "controller.started"
+	ControllerStopped    = "controller.stopped"
 	// SupervisorStarted fires once per supervisor startup, after the
 	// instance lock is acquired. Its payload classifies how the previous
 	// supervisor instance exited (clean, crash, or unknown), derived from
@@ -218,6 +227,7 @@ var KnownEventTypes = []string{
 	SessionResetStalled,
 	SessionWorkQueryFailed,
 	SessionColdStartTimeout,
+	SessionLivenessStale,
 	BeadCreated, BeadClosed, BeadDeleted, BeadUpdated,
 	BeadWorktreeReaped, BeadWorktreeReapSkipped,
 	BeadClaimRejected,

--- a/internal/events/session_liveness_payloads.go
+++ b/internal/events/session_liveness_payloads.go
@@ -1,0 +1,35 @@
+package events
+
+import "time"
+
+// SessionLivenessStalePayload is the typed payload for session.liveness_stale
+// events. Emitted by the controller's session liveness checker when a
+// configured session's last activity exceeds its freshness_window. Fires
+// exactly once per stale episode; a new episode begins only after the session
+// becomes active again.
+type SessionLivenessStalePayload struct {
+	// Session is the runtime session name that is stale.
+	Session string `json:"session"`
+	// EpisodeID uniquely identifies this stale episode for correlation
+	// across multiple patrol ticks and downstream alerts.
+	EpisodeID string `json:"episode_id"`
+	// StaleSince is when the controller first observed the session as stale
+	// (first tick where last activity exceeded freshness_window).
+	StaleSince time.Time `json:"stale_since"`
+	// FreshnessWindow is the configured maximum allowed inactivity duration.
+	FreshnessWindow string `json:"freshness_window"`
+	// LastActivity is the last observed activity time for the session.
+	// Zero value means the session has never been observed active (or
+	// the provider does not support activity tracking).
+	LastActivity time.Time `json:"last_activity,omitempty"`
+	// EscalateTo is the session name that will be nudged, if configured.
+	// Empty when no escalation target is configured.
+	EscalateTo string `json:"escalate_to,omitempty"`
+}
+
+// IsEventPayload marks SessionLivenessStalePayload as an events.Payload variant.
+func (SessionLivenessStalePayload) IsEventPayload() {}
+
+func init() {
+	RegisterPayload(SessionLivenessStale, SessionLivenessStalePayload{})
+}


### PR DESCRIPTION
## Motivation

Sessions can appear alive to the controller while their agent process is dead or stalled: the tmux session exists, the reconciler sees a known state, but no activity has happened for a long time. Today nothing at the controller level notices this, so a stalled deacon/witness/refinery just sits there until a human looks (related: #571, the non-LLM detection half of soft-recovery).

This PR adds an opt-in, config-driven session liveness tracker. Operators declare per-session freshness windows; on each patrol tick the controller checks last-activity against the window and emits a `session.liveness_stale` event (optionally nudging a configured escalation session) so watchdogs and dashboards can react.

## What's in here (2 commits)

**1. `feat(config,events)` — config + event surface**
- `session_liveness_checks` entries under `[daemon]`: session name, `freshness_window`, optional `escalate_to`. Windows validated alongside other daemon durations.
- New `session.liveness_stale` event constant, `KnownEventTypes` registration, and typed `SessionLivenessStalePayload` (`episode_id`, `stale_since`, `freshness_window`, `last_activity`, `escalate_to`).
- Docs + generated schema/openapi/client updates.

**2. `feat(controller)` — tracker + wiring**
- `sessionLivenessTracker` (`cmd/gc/session_liveness_tracker.go`) follows the same nil-guard + episode pattern as `idleTracker` and `providerHealthGate`:
  - fires exactly once per stale episode (green→stale edge), clears on recovery so a new stale period is a new episode;
  - startup grace: zero last-activity is only stale after the window elapses since session start (no false positives on fresh city launch);
  - provider errors fail open (no false alarms);
  - tracker is `nil` when no checks are configured — zero cost for existing deployments.
- Controller wiring in `cmd/gc/city_runtime.go`: initialized on startup and config reload; `runSessionLivenessChecks(now)` runs each patrol tick, emits events, and nudges `escalate_to` when set.

## Testing

- `go build ./...`, `go vet` on touched packages: clean.
- New tests in `cmd/gc/session_liveness_tracker_test.go` (297 lines): stale fires / fresh doesn't, exactly-once per episode across N stale ticks, new episode after recovery, per-rig multi-session isolation, startup grace, provider-error fail-open, nil tracker when unconfigured. All pass.
- `go test ./internal/config/... ./internal/events/...`: pass.
- Full `go test ./cmd/gc/`: same result as pristine `upstream/main` — the only failures (`TestImportMigrateScript`, `TestPackV2ImportsScript`) are pre-existing on main and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
