### PR TITLE
fix(beads): store correctness bundle — drift guard, malformed-metadata skip, wisp-tier Get fallback

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -747,6 +747,9 @@ func filterUnreadyHookCandidates(output string, now time.Time) string {
 			filtered = append(filtered, item)
 			continue
 		}
+		if isClosedHookCandidate(obj) {
+			continue
+		}
 		if isFutureDeferredHookCandidate(obj, now) {
 			continue
 		}
@@ -806,7 +809,7 @@ func isDepBlockedHookCandidate(item map[string]any) bool {
 // isSelfBlockedHookCandidate reports whether a candidate carries bd's own
 // is_blocked marker or an explicit status=="blocked", independent of the
 // blocked_by dependency array checked by isDepBlockedHookCandidate. An
-// absent is_blocked field is treated as NOT blocked — bd's denormalized
+// absent is_blocked field is treated as NOT blocked - bd's denormalized
 // projection is not always populated, and over-filtering here would strand
 // otherwise-ready work.
 func isSelfBlockedHookCandidate(item map[string]any) bool {
@@ -817,6 +820,14 @@ func isSelfBlockedHookCandidate(item map[string]any) bool {
 		return true
 	}
 	return false
+}
+
+// isClosedHookCandidate reports whether item is a closed bead. Defense-in-depth
+// against upstream Dolt status-index drift that can cause bd list --status=open
+// to return closed beads (gcy-1on).
+func isClosedHookCandidate(item map[string]any) bool {
+	status, ok := item["status"].(string)
+	return ok && strings.EqualFold(strings.TrimSpace(status), "closed")
 }
 
 func normalizeWorkQueryOutput(output string) string {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -2565,3 +2565,42 @@ func TestClaimHookWorkDrainsClaimsErroredWhenEveryCandidateErrors(t *testing.T) 
 		t.Fatalf("claim result = %+v, want drain/claims_errored", result)
 	}
 }
+
+// TestFilterUnreadyHookCandidatesExcludesClosedBeads guards against upstream
+// Dolt status-index drift where bd list --status=open returns closed beads
+// (gcy-1on). filterUnreadyHookCandidates must strip them before they reach the
+// agent hook output.
+func TestFilterUnreadyHookCandidatesExcludesClosedBeads(t *testing.T) {
+	now := time.Now()
+	input := `[{"id":"gc-closed","status":"closed","title":"Already done"},{"id":"gc-open","status":"open","title":"Real work"}]`
+	got := filterUnreadyHookCandidates(input, now)
+
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(got), &items); err != nil {
+		t.Fatalf("unmarshal result: %v; raw=%q", err, got)
+	}
+	if len(items) != 1 {
+		t.Fatalf("filterUnreadyHookCandidates returned %d items, want 1; got %q", len(items), got)
+	}
+	if id, _ := items[0]["id"].(string); id != "gc-open" {
+		t.Fatalf("remaining bead id = %q, want gc-open", id)
+	}
+}
+
+// TestFilterUnreadyHookCandidatesExcludesClosedBeadsFromReworkDrift verifies
+// that a closed bead with started_at set (the rework probe shape) is stripped
+// even when it carries gc.routed_to, simulating the phantom-witness-escalation
+// scenario from gcy-1on.
+func TestFilterUnreadyHookCandidatesExcludesClosedBeadsFromReworkDrift(t *testing.T) {
+	now := time.Now()
+	input := `[{"id":"gcy-oqf","status":"closed","started_at":"2026-06-01T00:00:00Z","metadata":{"gc.routed_to":"gascity-source/gastown.refinery"}}]`
+	got := filterUnreadyHookCandidates(input, now)
+
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(got), &items); err != nil {
+		t.Fatalf("unmarshal result: %v; raw=%q", err, got)
+	}
+	if len(items) != 0 {
+		t.Fatalf("filterUnreadyHookCandidates returned %d items for closed bead, want 0; got %q", len(items), got)
+	}
+}

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3478,6 +3478,38 @@ func TestMailCheckInjectArchivesAutoHandoffMessages(t *testing.T) {
 	}
 }
 
+// TestMailCheckInjectArchivesEphemeralAutoHandoffMessages verifies that
+// ephemeral (wisp-tier) auto-handoff mail is archived after injection.
+// gc handoff --auto creates Ephemeral:true beads; BdStore.Get must fall back
+// to the wisp tier so ArchiveInjectedAutoHandoffs can delete them.
+func TestMailCheckInjectArchivesEphemeralAutoHandoffMessages(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	auto, err := store.Create(beads.Bead{
+		Title:     "context cycle",
+		Type:      "message",
+		Assignee:  "mayor",
+		From:      "mayor",
+		Labels:    []string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel},
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create ephemeral auto handoff: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doMailCheck(mp, "mayor", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailCheck = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), auto.ID) {
+		t.Fatalf("injected output missing auto handoff id %s:\n%s", auto.ID, stdout.String())
+	}
+	if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("ephemeral auto handoff mail should be archived after injection, got err=%v", err)
+	}
+}
+
 func TestMailCheckInjectLeavesTruncatedAutoHandoffMessages(t *testing.T) {
 	store := beads.NewMemStore()
 	mp := beadmail.New(store)

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1040,10 +1040,27 @@ func (s *BdStore) Get(id string) (Bead, error) {
 	// BdStore read/write path (ga-gellq1).
 	out, err := s.runBDTransientRead("show", "--json", id)
 	if err != nil {
-		if isBdNotFound(err) {
-			return Bead{}, fmt.Errorf("getting bead %q: %w", id, ErrNotFound)
+		if !isBdNotFound(err) {
+			return Bead{}, fmt.Errorf("getting bead %q: %w", id, err)
 		}
-		return Bead{}, fmt.Errorf("getting bead %q: %w", id, err)
+		// bd show only queries the issues table; ephemeral beads live in the
+		// wisps table and are invisible to it. Fall back to bd query with
+		// ephemeral=true and id=<id> so Get succeeds for wisp-tier beads
+		// (e.g. auto-handoff mail created by gc handoff --auto). Only IDs
+		// that look like bead IDs are eligible: callers also pass through
+		// non-bead names (e.g. slash-qualified session recipients), which
+		// must not leak into a supplemental wisp query.
+		if isWispQueryableID(id) {
+			wisps, queryErr := s.getEphemeralByID(id)
+			if queryErr == nil {
+				for _, b := range wisps {
+					if b.ID == id {
+						return b, nil
+					}
+				}
+			}
+		}
+		return Bead{}, fmt.Errorf("getting bead %q: %w", id, ErrNotFound)
 	}
 	var issues []bdIssue
 	if err := json.Unmarshal(extractJSON(out), &issues); err != nil {
@@ -2408,6 +2425,48 @@ func (s *BdStore) listEphemeral(query ListQuery) ([]Bead, error) {
 		return filtered, fmt.Errorf("bd query: %w", parseErr)
 	}
 	return filtered, nil
+}
+
+// getEphemeralByID looks up a single wisp-tier bead by exact ID using bd query.
+// bd show does not expose the wisps table, so this is the fallback for Get.
+// isWispQueryableID reports whether id is safe to interpolate into a bd query
+// clause as a bead ID: non-empty, ASCII letters/digits/hyphens only. Session
+// names ("rig/agent.name") and other non-bead identifiers are excluded so the
+// wisp-tier Get fallback never issues supplemental queries for them.
+func isWispQueryableID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func (s *BdStore) getEphemeralByID(id string) ([]Bead, error) {
+	clause := "ephemeral=true AND id=" + id
+	args := []string{"query", "--json", clause, "--all", "--limit", "1"}
+	out, err := s.runner(s.dir, "bd", args...)
+	if err != nil {
+		if isBdQueryUnsupported(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("bd query (wisp by id): %w", err)
+	}
+	issues, parseErr := parseIssuesTolerant(extractJSON(out))
+	result := make([]Bead, len(issues))
+	for i := range issues {
+		result[i] = issues[i].toBead()
+		result[i].Ephemeral = true
+	}
+	if parseErr != nil {
+		return result, fmt.Errorf("bd query (wisp by id): %w", parseErr)
+	}
+	return result, nil
 }
 
 func isBdQueryUnsupported(err error) bool {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -370,6 +370,54 @@ func TestBdStoreGet(t *testing.T) {
 	}
 }
 
+func TestBdStoreGetFallsBackToEphemeralForWisps(t *testing.T) {
+	// bd show does not query the wisps table, so Get for a wisp ID returns
+	// ErrNotFound from bd show. Get must fall back to bd query with
+	// ephemeral=true so that wisp-tier beads (e.g. auto-handoff mail created
+	// by gc handoff --auto) are retrievable.
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd show --json gc-wisp-abc`: {
+			err: fmt.Errorf("issue gc-wisp-abc not found"),
+		},
+		`bd query --json ephemeral=true AND id=gc-wisp-abc --all --limit 1`: {
+			out: []byte(`[{"id":"gc-wisp-abc","title":"context cycle","status":"open","issue_type":"message","assignee":"claude","ephemeral":true}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	b, err := s.Get("gc-wisp-abc")
+	if err != nil {
+		t.Fatalf("Get wisp: %v", err)
+	}
+	if b.ID != "gc-wisp-abc" {
+		t.Errorf("ID = %q, want %q", b.ID, "gc-wisp-abc")
+	}
+	if !b.Ephemeral {
+		t.Error("Ephemeral = false, want true")
+	}
+}
+
+func TestBdStoreGetEphemeralFallbackReturnsErrNotFoundWhenMissing(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd show --json gc-wisp-missing`: {
+			err: fmt.Errorf("issue gc-wisp-missing not found"),
+		},
+		`bd query --json ephemeral=true AND id=gc-wisp-missing --all --limit 1`: {
+			out: []byte(`[]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	_, err := s.Get("gc-wisp-missing")
+	if !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
 func TestBdStoreListUsesDecodedUpdatedAtForUpdatedBefore(t *testing.T) {
 	cutoff := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
 	runner := func(_, name string, args ...string) ([]byte, error) {

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -73,6 +73,7 @@ var nativeDoltOpenReadyStatuses = []beadslib.Status{
 var (
 	nativeDoltOpenBestAvailable = beadslib.OpenBestAvailable
 	nativeDoltOpenEnvMu         sync.Mutex
+	errNativeIssueMetadataParse = errors.New("native issue metadata parse")
 )
 
 var nativeDoltOpenEnvKeys = []string{
@@ -1128,6 +1129,9 @@ func (s *NativeDoltStore) List(query ListQuery) ([]Bead, error) {
 		for _, issue := range issues {
 			bead, err := beadFromNativeIssue(issue)
 			if err != nil {
+				if isNativeIssueMetadataParseError(err) {
+					continue
+				}
 				return err
 			}
 			beads = append(beads, bead)
@@ -1856,7 +1860,7 @@ func beadFromNativeIssue(issue *beadslib.Issue) (Bead, error) {
 	}
 	metadata, err := metadataMapFromNative(issue.Metadata)
 	if err != nil {
-		return Bead{}, fmt.Errorf("parsing metadata for bead %q: %w", issue.ID, err)
+		return Bead{}, fmt.Errorf("parsing metadata for bead %q: %w: %w", issue.ID, errNativeIssueMetadataParse, err)
 	}
 	b := Bead{
 		ID:          issue.ID,
@@ -1889,6 +1893,10 @@ func beadFromNativeIssue(issue *beadslib.Issue) (Bead, error) {
 		}
 	}
 	return b, nil
+}
+
+func isNativeIssueMetadataParseError(err error) bool {
+	return errors.Is(err, errNativeIssueMetadataParse)
 }
 
 func nativePriorityFromIssue(issue *beadslib.Issue) *int {

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -824,6 +824,52 @@ func TestNativeDoltStoreListDelegatesAndConvertsIssues(t *testing.T) {
 	}
 }
 
+func TestNativeDoltStoreListSkipsInvalidMetadataRows(t *testing.T) {
+	corrupt := &beadslib.Issue{
+		ID:        "gc-corrupt",
+		Title:     "corrupt metadata",
+		Status:    beadslib.StatusOpen,
+		IssueType: beadslib.IssueType("convoy"),
+		Priority:  2,
+		Metadata:  json.RawMessage(`metadata is not json`),
+	}
+	storage := &nativeDoltStorageSpy{
+		searchIssues: func(_ context.Context, query string, _ beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			if query == "gc-corrupt" {
+				return []*beadslib.Issue{corrupt}, nil
+			}
+			return []*beadslib.Issue{
+				corrupt,
+				{
+					ID:        "gc-listed",
+					Title:     "valid convoy",
+					Status:    beadslib.StatusOpen,
+					IssueType: beadslib.IssueType("convoy"),
+					Priority:  2,
+					Metadata:  json.RawMessage(`{"gc.step_ref":"list"}`),
+				},
+			}, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	got, err := store.List(ListQuery{AllowScan: true, Type: "convoy"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("List len = %d, want only valid rows: %#v", len(got), got)
+	}
+	if got[0].ID != "gc-listed" {
+		t.Fatalf("List[0].ID = %q, want gc-listed", got[0].ID)
+	}
+	if _, err := store.Get("gc-corrupt"); err == nil {
+		t.Fatal("Get error = nil, want invalid metadata error")
+	} else if !strings.Contains(err.Error(), `parsing metadata for bead "gc-corrupt"`) {
+		t.Fatalf("Get error = %v, want bead metadata context", err)
+	}
+}
+
 func TestNativeDoltStoreListDoesNotPushLimitBeforeLocalSort(t *testing.T) {
 	createdAt := time.Date(2026, 5, 17, 11, 0, 0, 0, time.UTC)
 	storage := &nativeDoltStorageSpy{

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -299,6 +299,37 @@ func TestNativeDoltStoreListStatusOpenMatchesOpenNormalizedUpstreamStatuses(t *t
 	}
 }
 
+// TestNativeDoltStoreListStatusOpenExcludesClosedBeadsFromUpstreamDrift guards
+// against Dolt status-index drift (gcy-1on) where SearchIssues returns a bead
+// with status="closed" even though the ExcludeStatus filter asked to exclude it.
+// ApplyListQuery must catch leaked closed beads so List(Status: "open") never
+// returns them regardless of upstream inconsistency.
+func TestNativeDoltStoreListStatusOpenExcludesClosedBeadsFromUpstreamDrift(t *testing.T) {
+	// Spy that ignores the ExcludeStatus filter and returns a closed bead,
+	// simulating Dolt status-index drift.
+	storage := &nativeDoltStorageSpy{
+		searchIssues: func(_ context.Context, _ string, _ beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			return []*beadslib.Issue{
+				{ID: "gc-closed-drift", Title: "closed but leaking from index", Status: beadslib.StatusClosed, IssueType: beadslib.TypeTask, Priority: 2},
+				{ID: "gc-open", Title: "genuinely open", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2},
+			}, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	got, err := store.List(ListQuery{AllowScan: true, Status: "open", TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("List(Status: open) len = %d, want 1 (closed drift bead must be excluded); got %+v", len(got), got)
+	}
+	if got[0].ID != "gc-open" {
+		t.Fatalf("List(Status: open) returned unexpected bead %q, want gc-open", got[0].ID)
+	}
+}
+
 func TestNativeDoltStoreReadyIncludesOpenNormalizedUpstreamStatuses(t *testing.T) {
 	issues := []*beadslib.Issue{
 		{ID: "gc-open", Title: "open", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2},


### PR DESCRIPTION
Three independent beads-store correctness fixes observed on a production rig, kept as separate logical commits.

## 1. Guard against Dolt status-index drift leaking closed beads
**Problem:** upstream Dolt can drift its status secondary index so `bd list --status=open` returns beads whose primary row is `status=closed`. Hook dispatch then acts on closed beads.
**Fix:** `filterUnreadyHookCandidates` (cmd/gc/cmd_hook.go) now drops closed beads via a new `isClosedHookCandidate` check — defense-in-depth even when bd returns them. `NativeDoltStore.List` already handles this via `ApplyListQuery`; an explicit test now pins that protection.

## 2. Skip malformed metadata rows in native list (gcy-48q)
**Problem:** native Dolt list scans failed the whole query when any returned issue had malformed metadata, so read paths like `gc convoy list` aborted before rendering valid rows.
**Fix:** mark native metadata parse failures with the `errNativeIssueMetadataParse` sentinel; `List` skips only those rows. Direct `Get` and metadata mutation paths still surface corrupt metadata for targeted repair.

## 3. BdStore.Get falls back to wisp tier for ephemeral beads (gcy-ht3)
**Problem:** `bd show` only queries the issues table, so `BdStore.Get` returned not-found for wisp-tier ephemeral beads. `ArchiveInjectedAutoHandoffs` calls `Get` before `Delete`, so ephemeral auto-handoff mail was never archived and `gc mail check --inject` repeatedly re-reported the same phantom unread message.
**Fix:** on `bd show` not-found, fall back to `bd query "ephemeral=true AND id=<id>"` (wisps table) before concluding absence — consistent with how `TierBoth` list queries already union both tiers. The fallback is gated by `isWispQueryableID` (ASCII alnum/hyphen only) so non-bead identifiers such as slash-qualified session recipients never leak into a supplemental wisp query (keeps `TestCheckUsesSingleAssigneeMessageScanForSlashRecipient` green).

## Testing
- `go build ./...`, `go vet ./cmd/gc ./internal/beads ./internal/mail/beadmail` clean
- `go test ./internal/beads ./internal/mail/beadmail` pass
- `go test ./cmd/gc`: only `TestImportMigrateScript` / `TestPackV2ImportsScript` fail, and both fail identically on unmodified upstream/main in this environment (pre-existing, unrelated)
- New/carried tests: `TestFilterUnreadyHookCandidatesExcludesClosedBeads*`, `TestNativeDoltStoreListStatusOpenExcludesClosedBeadsFromUpstreamDrift`, `TestNativeDoltStoreListSkipsInvalidMetadataRows`, `TestBdStoreGetEphemeralFallback*`, plus an end-to-end ephemeral auto-handoff archive test in cmd/gc/cmd_mail_test.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)