### PR TITLE
fix(nudge): reliability bundle — poll-loop backoff, codex wait-idle delivery, bounded prompt-hook drain

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -213,6 +213,10 @@ func (t nudgeTarget) sessionTransport() string {
 	return t.agent.Session
 }
 
+func (t nudgeTarget) providerFamily() string {
+	return session.ProviderFamilyFromMetadata(nil, t.providerName())
+}
+
 func (t nudgeTarget) providerName() string {
 	if t.resolved != nil && strings.TrimSpace(t.resolved.Name) != "" {
 		return strings.TrimSpace(t.resolved.Name)
@@ -1051,7 +1055,10 @@ func sendMailNotifyWithWorker(target nudgeTarget, store beads.Store, sp runtime.
 	if err != nil {
 		return err
 	}
-	if obs.Running {
+	// Codex sessions use a poller to deliver queued nudges when ready; skip
+	// the synchronous WaitIdle delivery so the poller is always started for
+	// running codex sessions. Other providers still try direct delivery first.
+	if obs.Running && target.providerFamily() != "codex" {
 		handle, err := workerHandleForNudgeTarget(target, store, sp)
 		if err == nil {
 			result, nudgeErr := handle.Nudge(context.Background(), worker.NudgeRequest{

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -595,6 +595,10 @@ func configureNudgePollRuntime(stderr io.Writer) func() {
 	}
 }
 
+var nudgePollSleep = time.Sleep
+
+var deliverQueuedNudgesByPoller = tryDeliverQueuedNudgesByPoller
+
 func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.Duration, _ io.Writer, stderr io.Writer) int {
 	targetID := os.Getenv("GC_ALIAS")
 	if targetID == "" {
@@ -665,7 +669,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 				if missingSince.IsZero() {
 					missingSince = now
 				}
-				time.Sleep(interval)
+				nudgePollSleep(interval)
 				continue
 			}
 			return 1
@@ -676,20 +680,22 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 				if missingSince.IsZero() {
 					missingSince = now
 				}
-				time.Sleep(interval)
+				nudgePollSleep(interval)
 				continue
 			}
 			return 0
 		}
 		missingSince = time.Time{}
-		delivered, pollErr := tryDeliverQueuedNudgesByPoller(target, store.Store, sp, quiescence, obs)
+		_, pollErr := deliverQueuedNudgesByPoller(target, store.Store, sp, quiescence, obs)
 		if pollErr != nil {
 			fmt.Fprintf(stderr, "gc nudge poll: %v\n", pollErr) //nolint:errcheck
 		}
-		if delivered {
-			continue
-		}
-		time.Sleep(interval)
+		// Always back off at least `interval` between iterations, including on
+		// the delivered path. Without this, a delivery that keeps reporting
+		// success (e.g. the ack/clear failed and the same nudge stays PENDING
+		// and re-delivers) tight-spins, opening a fresh Dolt connection every
+		// iteration and saturating the handshake path (gcy-5b1).
+		nudgePollSleep(interval)
 	}
 }
 

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -403,7 +404,45 @@ func nonNilQueuedNudges(items []queuedNudge) []queuedNudge {
 	return items
 }
 
+var nudgeDrainInjectTimeout = 2 * time.Second
+
 func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdout, stderr io.Writer) int {
+	if inject {
+		return cmdNudgeDrainInjectBounded(args, hookFormat, readHookStdin(), stdout, stderr)
+	}
+	return cmdNudgeDrainWithFormatCore(args, false, hookFormat, nil, stdout, stderr)
+}
+
+func cmdNudgeDrainInjectBounded(args []string, hookFormat string, hookInput []byte, stdout, stderr io.Writer) int {
+	type result struct {
+		code   int
+		stdout string
+		stderr string
+	}
+	done := make(chan result, 1)
+	go func() {
+		var out bytes.Buffer
+		var errOut bytes.Buffer
+		code := cmdNudgeDrainWithFormatCore(args, true, hookFormat, hookInput, &out, &errOut)
+		done <- result{code: code, stdout: out.String(), stderr: errOut.String()}
+	}()
+
+	timer := time.NewTimer(nudgeDrainInjectTimeout)
+	defer timer.Stop()
+	select {
+	case res := <-done:
+		_, _ = io.WriteString(stdout, res.stdout)
+		_, _ = io.WriteString(stderr, res.stderr)
+		return res.code
+	case <-timer.C:
+		prefix := clockInjectLine() + contextInjectLine(hookInput)
+		prefix += "<system-reminder>\ngc nudge drain degraded: queued reminders were not checked before the prompt-hook timeout budget expired. Continue this turn; deferred reminders remain queued for a later drain or poller pass.\n</system-reminder>\n"
+		_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", prefix)
+		return 0
+	}
+}
+
+func cmdNudgeDrainWithFormatCore(args []string, inject bool, hookFormat string, hookInput []byte, stdout, stderr io.Writer) int {
 	// On every prompt, emit a live clock (operator-local + UTC + epoch) as
 	// UserPromptSubmit hook context. When a nudge also fires we fold the clock
 	// into that nudge's single provider-formatted payload (see the combined
@@ -418,7 +457,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		// pipe-only — see readHookStdin) and build the shared inject prefix:
 		// the clock line plus, when context pressure crosses its threshold,
 		// the context-usage guidance (see context_inject.go).
-		injectPrefix = clockInjectLine() + contextInjectLine(readHookStdin())
+		injectPrefix = clockInjectLine() + contextInjectLine(hookInput)
 		defer func() {
 			if !emittedHookContext && injectPrefix != "" {
 				_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", injectPrefix)

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -460,13 +460,14 @@ func TestExpiredNudgeCleanupSurvivesNilFrontDoor(t *testing.T) {
 	}
 }
 
-func TestDeliverSessionNudgeWithProviderWaitIdleQueuesForCodex(t *testing.T) {
+func TestDeliverSessionNudgeWithProviderWaitIdleDeliversCodexImmediately(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
 	fake := runtime.NewFake()
 	if err := fake.Start(context.Background(), "sess-worker", runtime.Config{}); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
+	fake.WaitForIdleErrors["sess-worker"] = context.DeadlineExceeded
 
 	target := nudgeTarget{
 		cityPath:    dir,
@@ -480,30 +481,39 @@ func TestDeliverSessionNudgeWithProviderWaitIdleQueuesForCodex(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("deliverSessionNudgeWithProvider = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Queued nudge for worker") {
-		t.Fatalf("stdout = %q, want queued confirmation", stdout.String())
+	if !strings.Contains(stdout.String(), "Nudged worker") {
+		t.Fatalf("stdout = %q, want delivered confirmation", stdout.String())
 	}
+	var waitForIdle, nudgeNow int
 	for _, call := range fake.Calls {
-		if call.Method == "Nudge" {
+		switch call.Method {
+		case "WaitForIdle":
+			waitForIdle++
+		case "NudgeNow":
+			nudgeNow++
+		case "Nudge":
 			t.Fatalf("unexpected direct nudge call: %+v", call)
 		}
+	}
+	if waitForIdle != 1 {
+		t.Fatalf("WaitForIdle calls = %d, want 1", waitForIdle)
+	}
+	if nudgeNow != 1 {
+		t.Fatalf("NudgeNow calls = %d, want 1", nudgeNow)
 	}
 
 	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
 	if err != nil {
 		t.Fatalf("listQueuedNudges: %v", err)
 	}
-	if len(pending) != 1 {
-		t.Fatalf("pending = %d, want 1", len(pending))
+	if len(pending) != 0 {
+		t.Fatalf("pending = %d, want 0", len(pending))
 	}
 	if len(inFlight) != 0 {
 		t.Fatalf("inFlight = %d, want 0", len(inFlight))
 	}
 	if len(dead) != 0 {
 		t.Fatalf("dead = %d, want 0", len(dead))
-	}
-	if pending[0].Source != "session" {
-		t.Fatalf("source = %q, want session", pending[0].Source)
 	}
 }
 
@@ -1050,7 +1060,7 @@ func TestDeliverSessionNudgeWithWorkerWaitIdleQueuesUnsupportedProviderAfterResu
 	fake := runtime.NewFake()
 	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
 
-	info, err := mgr.Create(context.Background(), "worker", "Worker", "codex", dir, "codex", nil, session.ProviderResume{}, runtime.Config{})
+	info, err := mgr.Create(context.Background(), "worker", "Worker", "pi", dir, "pi", nil, session.ProviderResume{}, runtime.Config{})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -1103,7 +1113,7 @@ func TestDeliverSessionNudgeWithWorkerWaitIdleQueuesUnsupportedProviderAfterResu
 	}
 }
 
-func TestDeliverSessionNudgeWithProviderWaitIdleStartsCodexPollerWhenQueued(t *testing.T) {
+func TestDeliverSessionNudgeWithProviderWaitIdleStartsUnsupportedProviderPollerWhenQueued(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
 	fake := runtime.NewFake()
@@ -1114,7 +1124,7 @@ func TestDeliverSessionNudgeWithProviderWaitIdleStartsCodexPollerWhenQueued(t *t
 	target := nudgeTarget{
 		cityPath:    dir,
 		agent:       config.Agent{Name: "worker"},
-		resolved:    &config.ResolvedProvider{Name: "codex"},
+		resolved:    &config.ResolvedProvider{Name: "pi"},
 		sessionName: "sess-worker",
 	}
 
@@ -2463,12 +2473,15 @@ func TestTryDeliverQueuedNudgesByPollerDeliversAndAcks(t *testing.T) {
 
 	var nudgeCalls []runtime.Call
 	for _, call := range fake.Calls {
-		if call.Method == "Nudge" {
+		if call.Method == "NudgeNow" {
 			nudgeCalls = append(nudgeCalls, call)
+		}
+		if call.Method == "Nudge" {
+			t.Fatalf("unexpected provider-default nudge call: %+v", call)
 		}
 	}
 	if len(nudgeCalls) != 1 {
-		t.Fatalf("nudge calls = %d, want 1", len(nudgeCalls))
+		t.Fatalf("NudgeNow calls = %d, want 1", len(nudgeCalls))
 	}
 	if !strings.Contains(nudgeCalls[0].Message, "<system-reminder>") {
 		t.Fatalf("nudge message = %q, want system-reminder wrapper", nudgeCalls[0].Message)
@@ -2888,12 +2901,15 @@ func TestTryDeliverQueuedNudgesByPollerDeliversDespiteStaleFenceBeadMarkFailure(
 
 	var nudgeCalls []runtime.Call
 	for _, call := range fake.Calls {
-		if call.Method == "Nudge" {
+		if call.Method == "NudgeNow" {
 			nudgeCalls = append(nudgeCalls, call)
+		}
+		if call.Method == "Nudge" {
+			t.Fatalf("unexpected provider-default nudge call: %+v", call)
 		}
 	}
 	if len(nudgeCalls) != 1 {
-		t.Fatalf("nudge calls = %d, want 1", len(nudgeCalls))
+		t.Fatalf("NudgeNow calls = %d, want 1", len(nudgeCalls))
 	}
 	if !strings.Contains(nudgeCalls[0].Message, "wake up and resume your wisp") {
 		t.Fatalf("nudge message = %q, want fence-matching reminder", nudgeCalls[0].Message)

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -3188,6 +3189,83 @@ func TestCmdNudgeDrainStampsLastNudgeDeliveredAt(t *testing.T) {
 				t.Fatalf("%s timestamp drift %s is outside the 1-minute test window (raw=%q)", session.MetadataLastNudgeDeliveredAt, drift, raw)
 			}
 		})
+	}
+}
+
+func TestCmdNudgeDrainInjectDegradesWhenQueueLockExceedsHookBudget(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_INJECT_CLOCK", "1")
+
+	cityDir := t.TempDir()
+	writeNamedSessionCityTOML(t, cityDir)
+	t.Setenv("GC_CITY", cityDir)
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	created, err := store.Create(beads.Bead{
+		Title:  "Session: worker",
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "worker-session",
+			"agent_name":   "worker",
+			"template":     "worker",
+			"state":        string(session.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create session: %v", err)
+	}
+	lockPath := nudgequeue.LockPath(cityDir)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll lock dir: %v", err)
+	}
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile lock: %v", err)
+	}
+	defer lockFile.Close() //nolint:errcheck
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("Flock lock: %v", err)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
+
+	origTimeout := nudgeDrainInjectTimeout
+	nudgeDrainInjectTimeout = 25 * time.Millisecond
+	defer func() { nudgeDrainInjectTimeout = origTimeout }()
+
+	start := time.Now()
+	var stdout, stderr bytes.Buffer
+	code := cmdNudgeDrainWithFormat([]string{created.ID}, true, "codex", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdNudgeDrainWithFormat = %d, want degraded success; stderr=%s", code, stderr.String())
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("Flock unlock: %v", err)
+	}
+	if err := nudgequeue.WithState(cityDir, func(*nudgequeue.State) error { return nil }); err != nil {
+		t.Fatalf("waiting for background drain to release queue lock: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("cmdNudgeDrainWithFormat took %s, want bounded hook return", elapsed)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty degraded hook stderr", stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "UserPromptSubmit") {
+		t.Fatalf("stdout = %q, want provider-formatted UserPromptSubmit context", out)
+	}
+	if !strings.Contains(out, "gc nudge drain degraded") {
+		t.Fatalf("stdout = %q, want degraded hook notice", out)
+	}
+	if !strings.Contains(out, "Current time:") {
+		t.Fatalf("stdout = %q, want clock context preserved", out)
 	}
 }
 

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -3035,6 +3035,74 @@ func TestCmdNudgePollSurvivesTransientObserveErrors(t *testing.T) {
 	}
 }
 
+func TestCmdNudgePollSleepsAfterSuccessfulDelivery(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	writeNamedSessionCityTOML(t, cityDir)
+	t.Setenv("GC_CITY", cityDir)
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	created, err := store.Create(beads.Bead{
+		Title:  "Session: worker",
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "worker-session",
+			"agent_name":   "worker",
+			"template":     "worker",
+			"state":        string(session.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create session: %v", err)
+	}
+
+	observeCalls := 0
+	origObserve := nudgeObserveTarget
+	nudgeObserveTarget = func(_ nudgeTarget, _ beads.Store, _ runtime.Provider) (worker.LiveObservation, error) {
+		observeCalls++
+		if observeCalls == 1 {
+			return worker.LiveObservation{Running: true}, nil
+		}
+		return worker.LiveObservation{Running: false}, nil
+	}
+	defer func() { nudgeObserveTarget = origObserve }()
+
+	deliverCalls := 0
+	origDeliver := deliverQueuedNudgesByPoller
+	deliverQueuedNudgesByPoller = func(nudgeTarget, beads.Store, runtime.Provider, time.Duration, worker.LiveObservation) (bool, error) {
+		deliverCalls++
+		return true, nil
+	}
+	defer func() { deliverQueuedNudgesByPoller = origDeliver }()
+
+	var slept []time.Duration
+	origSleep := nudgePollSleep
+	nudgePollSleep = func(d time.Duration) {
+		slept = append(slept, d)
+	}
+	defer func() { nudgePollSleep = origSleep }()
+
+	var stdout, stderr bytes.Buffer
+	code := cmdNudgePoll([]string{created.ID}, "worker-session", 5*time.Millisecond, 0, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdNudgePoll = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if deliverCalls != 1 {
+		t.Fatalf("deliver calls = %d, want 1", deliverCalls)
+	}
+	if len(slept) != 1 || slept[0] != 5*time.Millisecond {
+		t.Fatalf("slept = %v, want one poll interval after successful delivery", slept)
+	}
+}
+
 func TestCmdNudgeDrainStampsLastNudgeDeliveredAt(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/cmd/gc/nudge_dispatcher_test.go
+++ b/cmd/gc/nudge_dispatcher_test.go
@@ -211,12 +211,15 @@ func TestDispatchAllQueuedNudgesDeliversAndAcks(t *testing.T) {
 
 	var nudgeMessages []string
 	for _, call := range fake.Calls {
-		if call.Method == "Nudge" {
+		if call.Method == "NudgeNow" {
 			nudgeMessages = append(nudgeMessages, call.Message)
+		}
+		if call.Method == "Nudge" {
+			t.Fatalf("unexpected provider-default nudge call: %+v", call)
 		}
 	}
 	if len(nudgeMessages) != 1 {
-		t.Fatalf("nudge calls = %d, want 1", len(nudgeMessages))
+		t.Fatalf("NudgeNow calls = %d, want 1", len(nudgeMessages))
 	}
 	if !strings.Contains(nudgeMessages[0], "review the deploy logs") {
 		t.Fatalf("nudge message = %q, want original reminder", nudgeMessages[0])

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -626,7 +626,8 @@ func (m *Manager) tryWaitIdleNudgeLocked(ctx context.Context, id string, b beads
 	if err := m.ensureRunning(ctx, id, b, sessName, resumeCommand, hints); err != nil {
 		return false, err
 	}
-	if providerKind(b) != "claude" {
+	kind := providerKind(b)
+	if kind != "claude" && kind != "codex" {
 		return false, nil
 	}
 	waiter, ok := m.sp.(runtime.IdleWaitProvider)
@@ -634,7 +635,12 @@ func (m *Manager) tryWaitIdleNudgeLocked(ctx context.Context, id string, b beads
 		return false, nil
 	}
 	if err := waiter.WaitForIdle(ctx, sessName, waitIdleNudgeTimeout); err != nil {
-		return false, nil
+		if errors.Is(err, context.Canceled) {
+			return false, err
+		}
+		if kind != "codex" {
+			return false, nil
+		}
 	}
 	if err := m.nudgeSession(ctx, sessName, formatWaitIdleReminder(normalizeWaitIdleNudgeSource(source), message), true); err != nil {
 		return false, nil
@@ -652,7 +658,8 @@ func (m *Manager) tryWaitIdleNudgeLiveOnlyLocked(ctx context.Context, b beads.Be
 		}
 		return true, nil
 	}
-	if providerKind(b) != "claude" {
+	kind := providerKind(b)
+	if kind != "claude" && kind != "codex" {
 		return false, nil
 	}
 	waiter, ok := m.sp.(runtime.IdleWaitProvider)
@@ -660,7 +667,12 @@ func (m *Manager) tryWaitIdleNudgeLiveOnlyLocked(ctx context.Context, b beads.Be
 		return false, nil
 	}
 	if err := waiter.WaitForIdle(ctx, sessName, waitIdleNudgeTimeout); err != nil {
-		return false, nil
+		if errors.Is(err, context.Canceled) {
+			return false, err
+		}
+		if kind != "codex" {
+			return false, nil
+		}
 	}
 	if err := m.nudgeSession(ctx, sessName, formatWaitIdleReminder(normalizeWaitIdleNudgeSource(source), message), true); err != nil {
 		return false, nil
@@ -725,6 +737,9 @@ func (m *Manager) send(ctx context.Context, id, message, resumeCommand string, h
 		b, sessName, err := m.sessionBead(id)
 		if err != nil {
 			return err
+		}
+		if !immediate {
+			immediate = usesImmediateDefaultSubmit(b, false)
 		}
 		return m.sendLocked(ctx, id, b, sessName, message, resumeCommand, hints, immediate)
 	})

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3139,6 +3139,73 @@ func TestSendImmediateFallsBackToDefaultNudge(t *testing.T) {
 	}
 }
 
+func TestSendDefaultCodexUsesImmediateNudge(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "codex", "/tmp", "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := mgr.Send(context.Background(), info.ID, "hello", "", runtime.Config{}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	found := false
+	for _, call := range sp.Calls {
+		if call.Method == "NudgeNow" && call.Name == info.SessionName && call.Message == "hello" {
+			found = true
+			break
+		}
+		if call.Method == "Nudge" && call.Name == info.SessionName {
+			t.Fatalf("calls = %#v, want default codex send to avoid provider wait-idle Nudge", sp.Calls)
+		}
+	}
+	if !found {
+		t.Fatalf("calls = %#v, want NudgeNow hello", sp.Calls)
+	}
+}
+
+func TestTryWaitIdleNudgeCodexFallsBackToImmediateAfterIdleTimeout(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "codex", "/tmp", "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sp.WaitForIdleErrors[info.SessionName] = context.DeadlineExceeded
+
+	delivered, err := mgr.TryWaitIdleNudge(context.Background(), info.ID, "session", "hello", "", runtime.Config{})
+	if err != nil {
+		t.Fatalf("TryWaitIdleNudge: %v", err)
+	}
+	if !delivered {
+		t.Fatal("TryWaitIdleNudge delivered = false, want true after codex idle-timeout fallback")
+	}
+
+	var waitForIdle, nudgeNow int
+	for _, call := range sp.Calls {
+		switch call.Method {
+		case "WaitForIdle":
+			waitForIdle++
+		case "NudgeNow":
+			nudgeNow++
+		case "Nudge":
+			t.Fatalf("calls = %#v, want immediate fallback without provider-default Nudge", sp.Calls)
+		}
+	}
+	if waitForIdle != 1 {
+		t.Fatalf("WaitForIdle calls = %d, want 1", waitForIdle)
+	}
+	if nudgeNow != 1 {
+		t.Fatalf("NudgeNow calls = %d, want 1", nudgeNow)
+	}
+}
+
 func TestSendResumesSuspendedSession_SyncsGCDirFromBeadWorkDir(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/worker/handle_test.go
+++ b/internal/worker/handle_test.go
@@ -739,12 +739,12 @@ func TestSessionHandleNudgeWaitIdleUsesWorkerBoundary(t *testing.T) {
 
 func TestSessionHandleNudgeWaitIdleReturnsUndeliveredForUnsupportedProvider(t *testing.T) {
 	handle, _, sp, _ := newTestSessionHandle(t, SessionSpec{
-		Profile:  ProfileCodexTmuxCLI,
+		Profile:  ProfileGeminiTmuxCLI,
 		Template: "probe",
 		Title:    "Probe",
-		Command:  "codex",
+		Command:  "gemini",
 		WorkDir:  t.TempDir(),
-		Provider: "codex",
+		Provider: "gemini",
 	})
 
 	if err := handle.Start(context.Background()); err != nil {
@@ -1532,6 +1532,48 @@ func TestRuntimeHandleNudgeImmediateUsesImmediateProvider(t *testing.T) {
 	}
 }
 
+func TestRuntimeHandleNudgeDefaultCodexUsesImmediateProvider(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "legacy-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	handle, err := NewRuntimeHandle(RuntimeHandleConfig{
+		Provider:     sp,
+		SessionName:  "legacy-worker",
+		ProviderName: "codex/tmux-cli",
+	})
+	if err != nil {
+		t.Fatalf("NewRuntimeHandle: %v", err)
+	}
+
+	result, err := handle.Nudge(context.Background(), NudgeRequest{
+		Text: "check deploy status",
+	})
+	if err != nil {
+		t.Fatalf("Nudge(default): %v", err)
+	}
+	if !result.Delivered {
+		t.Fatal("Nudge(default) Delivered = false, want true")
+	}
+
+	var nudgeNow, nudge int
+	for _, call := range sp.Calls {
+		switch call.Method {
+		case "NudgeNow":
+			nudgeNow++
+		case "Nudge":
+			nudge++
+		}
+	}
+	if nudgeNow != 1 {
+		t.Fatalf("NudgeNow calls = %d, want 1", nudgeNow)
+	}
+	if nudge != 0 {
+		t.Fatalf("Nudge calls = %d, want 0", nudge)
+	}
+}
+
 func TestRuntimeHandleNudgeWaitIdleClaudeWrapsReminder(t *testing.T) {
 	sp := runtime.NewFake()
 	if err := sp.Start(context.Background(), "legacy-worker", runtime.Config{}); err != nil {
@@ -1673,7 +1715,7 @@ func TestRuntimeHandleNudgeWaitIdleUnsupportedProviderReturnsUndelivered(t *test
 	handle, err := NewRuntimeHandle(RuntimeHandleConfig{
 		Provider:     sp,
 		SessionName:  "legacy-worker",
-		ProviderName: "codex",
+		ProviderName: "unsupported",
 	})
 	if err != nil {
 		t.Fatalf("NewRuntimeHandle: %v", err)

--- a/internal/worker/runtime_handle.go
+++ b/internal/worker/runtime_handle.go
@@ -263,8 +263,15 @@ func (h *RuntimeHandle) Nudge(ctx context.Context, req NudgeRequest) (result Nud
 	}
 	switch req.Delivery {
 	case "", NudgeDeliveryDefault:
-		if err := h.provider.Nudge(h.sessionName, runtime.TextContent(req.Text)); err != nil {
-			return NudgeResult{}, err
+		if runtimeHandleUsesImmediateDefaultNudge(h.providerName, h.transport) &&
+			!runtimeHandleIsActivitylessTimedOnly(h.provider, h.sessionName) {
+			if err := h.nudgeNow(req.Text); err != nil {
+				return NudgeResult{}, err
+			}
+		} else {
+			if err := h.provider.Nudge(h.sessionName, runtime.TextContent(req.Text)); err != nil {
+				return NudgeResult{}, err
+			}
 		}
 		result = NudgeResult{Delivered: true}
 		return result, nil
@@ -384,6 +391,29 @@ func (h *RuntimeHandle) Respond(_ context.Context, req InteractionResponse) erro
 
 const runtimeHandleWaitIdleTimeout = 30 * time.Second
 
+func runtimeHandleUsesImmediateDefaultNudge(providerName, transport string) bool {
+	if strings.TrimSpace(transport) == "acp" {
+		return false
+	}
+	return runtimeHandleProviderFamily(providerName) == "codex"
+}
+
+// runtimeHandleIsActivitylessTimedOnly reports whether the provider+sessionName
+// combination is an activityless timed-only session (no activity signal, timer
+// wakes only). For such sessions, regular Nudge is preferable to NudgeNow so
+// the message waits for the next natural wake instead of interrupting.
+func runtimeHandleIsActivitylessTimedOnly(provider runtime.Provider, sessionName string) bool {
+	if provider == nil || provider.Capabilities().CanReportActivity {
+		return false
+	}
+	sleeper, ok := provider.(runtime.SleepCapabilityProvider)
+	return ok && sleeper.SleepCapability(sessionName) == runtime.SessionSleepCapabilityTimedOnly
+}
+
+func runtimeHandleProviderFamily(providerName string) string {
+	return sessionpkg.ProviderFamilyFromMetadata(nil, providerName)
+}
+
 func (h *RuntimeHandle) nudgeNow(message string) error {
 	content := runtime.TextContent(message)
 	if immediate, ok := h.provider.(runtime.ImmediateNudgeProvider); ok {
@@ -402,7 +432,8 @@ func (h *RuntimeHandle) nudgeWaitIdle(ctx context.Context, req NudgeRequest) (Nu
 		}
 		return NudgeResult{Delivered: true}, nil
 	}
-	if h.providerName != "claude" {
+	providerFamily := runtimeHandleProviderFamily(h.providerName)
+	if providerFamily != "claude" && providerFamily != "codex" {
 		return NudgeResult{Delivered: false}, nil
 	}
 	waiter, ok := h.provider.(runtime.IdleWaitProvider)
@@ -417,9 +448,12 @@ func (h *RuntimeHandle) nudgeWaitIdle(ctx context.Context, req NudgeRequest) (Nu
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return NudgeResult{Delivered: false}, ctxErr
 			}
+			if providerFamily != "codex" {
+				return NudgeResult{Delivered: false}, nil
+			}
+		} else if providerFamily != "codex" {
 			return NudgeResult{Delivered: false}, nil
 		}
-		return NudgeResult{Delivered: false}, nil
 	}
 	if err := h.nudgeNow(formatRuntimeWaitIdleReminder(req.Source, req.Text)); err != nil {
 		return NudgeResult{}, err


### PR DESCRIPTION
Three related nudge-delivery reliability fixes, one logical commit each.

## 1. Always back off the poll interval, including after successful delivery

**Problem:** the `gc nudge poll` loop only slept on the failure path; a successful delivery `continue`d immediately. When a delivered nudge stayed PENDING (ack failure is joined into the error but `delivered=true` still returns), the loop re-claimed and re-delivered the same item every iteration with no backoff — observed opening a fresh Dolt connection each pass (~34 conn/sec), saturating the handshake path and stalling the controller's order/scale_check loop.

**Fix:** remove the delivered-path `continue` so the interval sleep runs every iteration. A test seam (`nudgePollSleep` / `deliverQueuedNudgesByPoller` vars) plus a regression test verify the successful-delivery branch sleeps before polling again.

## 2. Deliver codex wait-idle nudges via bounded immediate fallback

**Problem:** wait-idle nudge delivery (`tryWaitIdleNudge*Locked`, `RuntimeHandle.nudgeWaitIdle`) is gated on provider `claude`, so codex sessions never receive live wait-idle nudges — they queue and sit until a poller pass, or forever when no poller runs (related: #3889).

**Fix:** extend the wait-idle path to the codex provider family; on idle-wait timeout, fall back to immediate (`NudgeNow`) delivery instead of silently queueing. Default-delivery nudges for codex likewise use immediate submit. Carve-outs: ACP transports and context cancellation unchanged; activityless timed-only sessions still use regular `Nudge` (message waits for the next timer wake); `sendMailNotifyWithWorker` skips the synchronous wait-idle attempt for codex so the poller is always started for running codex sessions.

## 3. Bound the prompt-hook drain with a timeout budget

**Problem:** `gc nudge drain --inject` runs as a UserPromptSubmit hook but walks the nudge queue under the queue flock; when another process holds the lock (or the store is slow) it blocks indefinitely, wedging every prompt submission for the session.

**Fix:** run the drain in a goroutine with a 2s budget. On expiry, emit the normal clock/context inject prefix plus a degraded-mode system-reminder (queued reminders remain for a later drain or poller pass) and return success so the prompt proceeds. Non-inject drains unchanged; hook stdin is read once up front. Complementary to #3906, which bounds the queue-maintenance walk inside the drain — this bounds the hook's total wall-clock, covering lock acquisition and store latency too.

## Testing

- `go build ./...`, `go vet ./cmd/gc/... ./internal/session/... ./internal/worker/...` clean; `gofmt -l` clean on touched packages
- `go test ./internal/session/... ./internal/worker/...` all green
- `go test ./cmd/gc/` green except `TestImportMigrateScript` / `TestPackV2ImportsScript`, which fail identically on pristine `main` in this environment (pre-existing, unrelated)
- New regression tests: poll-loop sleep after successful delivery; codex wait-idle immediate delivery (incl. queue state assertions); drain-inject degraded output when the queue lock is held past the hook budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
