### PR TITLE
fix(convoy): tolerate malformed tracked metadata in membership resolution

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -21,6 +21,10 @@ var ErrNotFound = errors.New("bead not found")
 // absent bead should check errors.Is(err, ErrIDCollision).
 var ErrIDCollision = fmt.Errorf("bd resolved a different bead ID (substring collision): %w", ErrNotFound)
 
+// ErrMetadataParse is returned when a bead exists but its stored metadata
+// cannot be decoded into the Store object model.
+var ErrMetadataParse = errors.New("bead metadata parse")
+
 // ErrCacheUnavailable is returned by cache-only read handles when the cache
 // cannot answer without consulting the backing store.
 var ErrCacheUnavailable = errors.New("bead cache unavailable")

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -73,7 +73,7 @@ var nativeDoltOpenReadyStatuses = []beadslib.Status{
 var (
 	nativeDoltOpenBestAvailable = beadslib.OpenBestAvailable
 	nativeDoltOpenEnvMu         sync.Mutex
-	errNativeIssueMetadataParse = errors.New("native issue metadata parse")
+	errNativeIssueMetadataParse = ErrMetadataParse
 )
 
 var nativeDoltOpenEnvKeys = []string{

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -747,6 +747,8 @@ func TestNativeDoltStoreGetRejectsInvalidMetadata(t *testing.T) {
 
 	if _, err := store.Get("gc-corrupt"); err == nil {
 		t.Fatal("Get error = nil, want invalid metadata error")
+	} else if !errors.Is(err, ErrMetadataParse) {
+		t.Fatalf("Get error = %v, want ErrMetadataParse", err)
 	} else if !strings.Contains(err.Error(), `parsing metadata for bead "gc-corrupt"`) {
 		t.Fatalf("Get error = %v, want bead metadata context", err)
 	}

--- a/internal/convoy/convoy_test.go
+++ b/internal/convoy/convoy_test.go
@@ -1,6 +1,7 @@
 package convoy
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -217,6 +218,30 @@ func TestConvoyMembersKeepsDanglingTracksUnknownOps(t *testing.T) {
 	}
 }
 
+func TestConvoyMembersKeepsMalformedTrackedItemUnknownOps(t *testing.T) {
+	backing := beads.NewMemStore()
+	convoy, _ := backing.Create(beads.Bead{Title: "test", Type: "convoy"})
+	item, _ := backing.Create(beads.Bead{Title: "task"})
+	if err := backing.DepAdd(convoy.ID, item.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+	store := metadataParseErrorStore{Store: backing, corruptID: item.ID}
+
+	members, err := Members(store, convoy.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("members = %d, want 1", len(members))
+	}
+	if members[0].ID != item.ID {
+		t.Errorf("member ID = %q, want %s", members[0].ID, item.ID)
+	}
+	if members[0].Status != "unknown" {
+		t.Errorf("member status = %q, want unknown", members[0].Status)
+	}
+}
+
 func TestConvoyAddItemsOps(t *testing.T) {
 	store := beads.NewMemStore()
 	deps := testConvoyDeps(store)
@@ -305,4 +330,16 @@ func requireTracksDep(t *testing.T, store beads.Store, convoyID, itemID string) 
 		}
 	}
 	t.Fatalf("missing tracks dep %s -> %s; deps=%v", convoyID, itemID, deps)
+}
+
+type metadataParseErrorStore struct {
+	beads.Store
+	corruptID string
+}
+
+func (s metadataParseErrorStore) Get(id string) (beads.Bead, error) {
+	if id == s.corruptID {
+		return beads.Bead{}, fmt.Errorf("parsing metadata for bead %q: %w", id, beads.ErrMetadataParse)
+	}
+	return s.Store.Get(id)
 }

--- a/internal/convoy/membership.go
+++ b/internal/convoy/membership.go
@@ -130,7 +130,9 @@ func Members(store beads.Store, convoyID string, includeClosed bool, memberStore
 		}
 		item, err := storeref.Resolve(dep.DependsOnID, probe)
 		if err != nil {
-			if errors.Is(err, beads.ErrNotFound) {
+			if errors.Is(err, beads.ErrNotFound) || errors.Is(err, beads.ErrMetadataParse) {
+				// Convoy membership is an edge inventory. Keep the edge visible
+				// even when the target bead cannot be projected into a Bead.
 				add(unresolvedTrackedItem(dep.DependsOnID))
 				continue
 			}


### PR DESCRIPTION
## Problem
Convoy membership resolution aborted the entire member listing when any single tracked bead's stored metadata failed to decode: `storeref.Resolve` surfaced the metadata parse error and `convoy.Members` bailed, hiding every other member of the convoy. One corrupt bead made the whole convoy unreadable.

## Root cause
`Members` only tolerated `beads.ErrNotFound` from `storeref.Resolve`; a metadata decode failure in the native Dolt store was an opaque `fmt.Errorf` with no sentinel, so callers could not distinguish "bead unreadable" from a real store error.

## Fix
- Add exported sentinel `beads.ErrMetadataParse` and wrap it at the native store's metadata decode site (`beadFromNativeIssue`).
- In `convoy.Members`, treat `ErrMetadataParse` like `ErrNotFound`: keep the edge visible as an unresolved tracked item instead of failing the listing. Convoy membership is an edge inventory — a single undecodable target should not hide the rest.

Note: #3997 (open) introduces the same internal `errNativeIssueMetadataParse` sentinel for List-side skipping; this PR uses the exported `ErrMetadataParse` as its value, so the two reconcile trivially whichever lands first.

## Testing
- `go build ./...`, `go vet ./internal/beads ./internal/convoy` clean
- `go test ./internal/beads ./internal/convoy`: ok
- New coverage: `Get` on a corrupt-metadata bead asserts `errors.Is(err, ErrMetadataParse)`; convoy test asserts a malformed tracked member is listed as unresolved instead of failing `Members`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)