### PR TITLE
fix(reconciler): don't preserve named session beads for suspended rigs

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -248,6 +248,13 @@ func canRebindConfiguredNamedSession(b beads.Bead, identity, sessionName, backin
 }
 
 func preserveConfiguredNamedSessionBead(b beads.Bead, cfg *config.City, cityName string) bool {
+	return preserveConfiguredNamedSessionBeadAtPath(b, cfg, cityName, "")
+}
+
+// preserveConfiguredNamedSessionBeadAtPath is like preserveConfiguredNamedSessionBead
+// but also suppresses preservation when the backing agent is in a suspended rig.
+// Pass cityPath="" to skip the rig-suspension check.
+func preserveConfiguredNamedSessionBeadAtPath(b beads.Bead, cfg *config.City, cityName, cityPath string) bool {
 	if cfg == nil || !isNamedSessionBead(b) {
 		return false
 	}
@@ -258,6 +265,14 @@ func preserveConfiguredNamedSessionBead(b beads.Bead, cfg *config.City, cityName
 	spec, ok := findNamedSessionSpec(cfg, cityName, identity)
 	if !ok {
 		return false
+	}
+	// Don't preserve sessions whose backing agent is in a suspended rig.
+	// A suspended rig's sessions should wind down, not be held open.
+	if cityPath != "" && spec.Agent != nil {
+		suspState := loadSuspensionStateBestEffort(cityPath)
+		if isAgentEffectivelySuspendedWith(cfg, spec.Agent, suspState) {
+			return false
+		}
 	}
 	if strings.TrimSpace(b.Metadata["session_name"]) != spec.SessionName {
 		return false
@@ -1598,7 +1613,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 					continue
 				}
 			}
-			if preserveConfiguredNamedSessionBead(b, cfg, cityName) {
+			if preserveConfiguredNamedSessionBeadAtPath(b, cfg, cityName, cityPath) {
 				continue
 			}
 			if spec, conflict, err := findConflictingNamedSessionSpecForBead(cfg, cityName, b); err != nil {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
 )
 
 type countingMetadataStore struct {
@@ -8138,6 +8139,62 @@ func TestPreserveConfiguredNamedSessionBead_StateGate(t *testing.T) {
 					tc.state, tc.sleepReason, tc.lastWokeAt, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestPreserveConfiguredNamedSessionBead_SuspendedRig: a named
+// session bead for an agent in a suspended rig must NOT be preserved — the rig
+// suspension should wind it down rather than holding it open.
+func TestPreserveConfiguredNamedSessionBead_SuspendedRig(t *testing.T) {
+	cityName := "test-city"
+	workspace := config.Workspace{Name: cityName}
+	rigName := "my-rig"
+	cfg := &config.City{
+		Workspace: workspace,
+		Agents: []config.Agent{
+			{Name: "witness", Dir: rigName, StartCommand: "true"},
+		},
+		Rigs: []config.Rig{
+			{Name: rigName, Path: "/some/path"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "witness", Dir: rigName, Mode: "always"},
+		},
+	}
+	identity := rigName + "/witness"
+	sessionName := config.NamedSessionRuntimeName(cityName, workspace, identity)
+	bead := beads.Bead{
+		ID:     "gm-test-rig-suspended",
+		Title:  "witness",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:witness"},
+		Metadata: map[string]string{
+			"session_name":                sessionName,
+			"state":                       "active",
+			namedSessionIdentityMetadata:  identity,
+			namedSessionModeMetadata:      "always",
+			"configured_named_session":    "true",
+		},
+	}
+
+	// Without suspension state: should preserve (normal operation).
+	got := preserveConfiguredNamedSessionBeadAtPath(bead, cfg, cityName, "")
+	if !got {
+		t.Fatal("preserveConfiguredNamedSessionBeadAtPath with empty cityPath should preserve active named session")
+	}
+
+	// With a city dir where the rig is suspended: should NOT preserve.
+	cityDir := t.TempDir()
+	st := suspensionstate.State{
+		Rigs: map[string]suspensionstate.Override{rigName: {Suspended: boolPtrTest(true)}},
+	}
+	if err := saveSuspensionState(fsys.OSFS{}, cityDir, st); err != nil {
+		t.Fatalf("saving suspension state: %v", err)
+	}
+	got = preserveConfiguredNamedSessionBeadAtPath(bead, cfg, cityName, cityDir)
+	if got {
+		t.Fatal("preserveConfiguredNamedSessionBeadAtPath should NOT preserve a named session whose rig is suspended")
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1224,10 +1224,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					continue
 				}
 			}
-			preserveNamed := preserveConfiguredNamedSessionBead(*session, cfg, cityName)
-			// #3630: the configured spec is present this tick — reset any
-			// suspend-drain confirmation window so a later genuine removal still
-			// gets the full confirmation buffer.
+			preserveNamed := preserveConfiguredNamedSessionBeadAtPath(*session, cfg, cityName, cityPath)
+			// #3630: the configured spec is present (and not suspended) this
+			// tick — reset any suspend-drain confirmation window so a later
+			// genuine removal still gets the full confirmation buffer.
 			if preserveNamed {
 				dt.clearSuspendDeferral(session.ID)
 			}


### PR DESCRIPTION
## Problem
After `gc rig suspend`, witness/refinery named sessions belonging to the suspended rig stayed active: the reconciler re-opened them as "preserve configured named" on every tick, so rig suspension never actually wound them down.

## Root cause
`preserveConfiguredNamedSessionBead` checked only that a named-session spec exists in config (plus the terminal-state gates). It never consulted runtime suspension state, so a bead whose backing agent lives in a suspended rig was still treated as preserve-worthy.

## Fix
Add `preserveConfiguredNamedSessionBeadAtPath(b, cfg, cityName, cityPath)`: when `cityPath` is provided and the spec's agent is effectively suspended (`loadSuspensionStateBestEffort` + `isAgentEffectivelySuspendedWith`), preservation is refused so the normal orphan/suspended drain path takes over. Both call sites (`session_reconciler.go`, `session_beads.go`) now pass `cityPath`. The existing wrapper keeps the old signature for callers without a city path.

The #3630 suspend-deferral reset is preserved: it still runs whenever preservation holds, so a later genuine spec removal gets the full confirmation buffer; a suspended rig now correctly falls through to the deferral/drain window instead of being cleared each tick.

## Testing
- `go build ./...`, `go vet ./cmd/gc` clean
- `go test ./cmd/gc -run 'TestPreserveConfiguredNamedSession|SuspendedRig|TestSyncSessionBeads'`: ok
- New test `TestPreserveConfiguredNamedSessionBead_SuspendedRig`: preserves an active named session normally, refuses preservation once the rig is marked suspended on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)