### PR TITLE
chore(security): extend Container Scan waiver horizon 2026-07-07 → 2026-08-07

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,4 +1,13 @@
 vulnerabilities:
+  # Expiry horizon bulk-extended 2026-07-06: 2026-07-07 -> 2026-08-07. Re-audit
+  # confirmed every waived upstream is still pinned at its vulnerable version, so
+  # nothing is droppable yet: dolt v2.1.7 (Go 1.26.2 stdlib + old
+  # x/net/x/crypto/thrift), bundled bd v1.0.4 (beads repin: thrift/go-jose/
+  # x-net/x-crypto), kubectl base binary (external x/net), and gc (go.mod still
+  # golang.org/x/net v0.52.0 / golang.org/x/crypto v0.49.0). gh already cleared
+  # by cli/cli v2.94.0. Drop each entry per its own `statement:` once that
+  # upstream actually rebuilds.
+  #
   # Go stdlib CVEs disclosed 2026-05-12. Fixed in Go 1.25.10 / 1.26.3 for
   # the first batch (33811–42499); Go 1.26.4 / 1.25.11 for CVE-2026-42504.
   # As of 2026-06-15: cli/cli v2.94.0 ships Go 1.26.4 (clears all entries);
@@ -13,7 +22,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Upstream bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+). gh cleared by v2.94.0 (Go 1.26.4) on base-image rebuild.
   - id: CVE-2026-33814
     paths:
@@ -21,7 +30,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Upstream bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+). gh cleared by v2.94.0 (Go 1.26.4) on base-image rebuild.
   - id: CVE-2026-39820
     paths:
@@ -29,7 +38,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Upstream bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+). gh cleared by v2.94.0 (Go 1.26.4) on base-image rebuild.
   - id: CVE-2026-39823
     paths:
@@ -37,7 +46,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Upstream bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+). gh cleared by v2.94.0 (Go 1.26.4) on base-image rebuild.
   - id: CVE-2026-39825
     paths:
@@ -45,7 +54,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Upstream bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+). gh cleared by v2.94.0 (Go 1.26.4) on base-image rebuild.
   - id: CVE-2026-39826
     paths:
@@ -53,7 +62,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Upstream bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+). gh cleared by v2.94.0 (Go 1.26.4) on base-image rebuild.
   - id: CVE-2026-39836
     paths:
@@ -61,7 +70,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Upstream bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+). gh cleared by v2.94.0 (Go 1.26.4) on base-image rebuild.
   - id: CVE-2026-42499
     paths:
@@ -69,7 +78,7 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Upstream bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+). gh cleared by v2.94.0 (Go 1.26.4) on base-image rebuild.
   - id: CVE-2026-42504
     paths:
@@ -77,102 +86,102 @@ vulnerabilities:
       - "usr/local/bin/br"
       - "usr/local/bin/dolt"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Go stdlib MIME-header DoS (CVE-2026-42504), fixed in Go 1.26.4 / 1.25.11. bd, br, dolt, and kubectl still embed an older Go stdlib; remove once each rebuilds against 1.26.4+. gh cleared by v2.94.0 on rebuild; gc cleared by go.mod bump to 1.26.4 (PR #3297).
   - id: CVE-2026-27145
     paths:
       - "usr/local/bin/bd"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Go stdlib x509 hostname verification issue (CVE-2026-27145), fixed in Go 1.26.4 / 1.25.11. bd v1.0.4 is the deliberate beads repin; remove once the bundled CLI rebuilds against 1.26.4+.
   - id: CVE-2026-27145
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Go stdlib x509 hostname verification issue (CVE-2026-27145), fixed in Go 1.26.4 / 1.25.11. Dolt v2.1.7 still embeds Go 1.26.2; remove once upstream rebuilds against 1.26.4+.
   - id: CVE-2026-27145
     paths:
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Go stdlib x509 hostname verification issue (CVE-2026-27145), fixed in Go 1.26.4 / 1.25.11. kubectl in the base image still embeds Go 1.26.2; remove once the bundled CLI rebuilds against 1.26.4+.
   - id: CVE-2026-41602
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Latest Dolt 1.88.0 still embeds github.com/apache/thrift v0.13.1; remove after a Dolt release includes thrift 0.23.0 or later.
   - id: CVE-2026-25680
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML parsing issue; remove once upstream rebuilds against the fixed x/net release.
   - id: CVE-2026-25681
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML rendering issue; remove once upstream rebuilds against the fixed x/net release.
   - id: CVE-2026-27136
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML rendering issue; remove once upstream rebuilds against the fixed x/net release.
   - id: CVE-2026-39821
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles a Go module set with this x/net idna issue; remove once upstream rebuilds against the fixed x/net release.
   - id: CVE-2026-42502
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML rendering issue; remove once upstream rebuilds against the fixed x/net release.
   - id: CVE-2026-42506
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles a Go module set with this x/net HTML rendering issue; remove once upstream rebuilds against the fixed x/net release.
   - id: CVE-2026-39827
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   - id: CVE-2026-39828
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   - id: CVE-2026-39829
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   - id: CVE-2026-39830
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   - id: CVE-2026-39832
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   - id: CVE-2026-39835
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   - id: CVE-2026-42508
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   - id: CVE-2026-46595
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   - id: CVE-2026-46597
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
   # HIGH severity, fixed upstream. Both CVEs below are present ONLY via the
   # deliberate steveyegge/beads v1.0.4 repin (v1.0.5 has data corruption) in the
@@ -183,12 +192,12 @@ vulnerabilities:
   - id: CVE-2026-41602
     paths:
       - "usr/local/bin/bd"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: "HIGH, fixed upstream (apache/thrift). Present only via the deliberate steveyegge/beads v1.0.4 repin (v1.0.5 has data corruption), in the bundled bd CLI binary on non-network thrift paths. Remove when gascity moves off bd 1.0.4 (tracking: move gascity off bd v1.0.4)."
   - id: CVE-2026-34986
     paths:
       - "usr/local/bin/bd"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: "HIGH, fixed upstream (go-jose/go-jose/v4). Present only via the deliberate steveyegge/beads v1.0.4 repin (v1.0.5 has data corruption), in the bundled bd CLI binary on non-network JWE paths. Remove when gascity moves off bd 1.0.4 (tracking: move gascity off bd v1.0.4)."
   # The golang.org/x/net (HTML/idna/http2) and golang.org/x/crypto/ssh CVEs in
   # the same series the dolt entries above waive are also reported against the
@@ -208,99 +217,99 @@ vulnerabilities:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/net HTML parsing DoS; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-25681
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-27136
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-39821
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/net/idna issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-42502
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-42506
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-33814
     paths:
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/net http2 issue; base-pre-existing (also red on main 2026-06-24). gc only (indirect x/net v0.52.0); bd/br/dolt/kubectl already covered by the stdlib waiver above. Remove once gc bumps golang.org/x/net >= 0.53.0.
   - id: CVE-2026-39827
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39828
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39829
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39830
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39832
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/crypto/ssh/agent CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39835
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-42508
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/crypto/ssh/knownhosts CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-46595
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-46597
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
-    expired_at: 2026-07-07
+    expired_at: 2026-08-07
     statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.


### PR DESCRIPTION
## What

Bumps all 46 `expired_at` dates in `.trivyignore.yaml` from **2026-07-07 → 2026-08-07**, and adds an inline audit note. Statements and waived `(id, path)` pairs are unchanged.

## Why

Every waiver expired **2026-07-07** (tomorrow). On the next Container Scan run after that (weekly Wed cron `43 6 * * 3`, or any push touching a scan path), ~40 Go-stdlib / `x/net` / `x/crypto` / thrift CVEs would un-waive at once and turn **Container Scan red across the board** — a fleet-wide cliff, separate from the joserfc HIGH already fixed in #3988.

## Re-audit — nothing droppable yet

I checked each waived upstream against current pins; all remain at their vulnerable versions, so this is a pure time-box extension (no removals, scan stays green):

| Upstream | Current pin | Status |
|---|---|---|
| dolt | `2.1.7` (deps.env) | Go 1.26.2 stdlib + old x/net/x/crypto/thrift — **still waived** |
| bd (bundled) | `v1.0.4` (deps.env `BD_VERSION`) | beads repin: thrift/go-jose/x-net/x-crypto — **still waived** |
| kubectl | base image (external) | external x/net — **still waived** |
| gc | `go.mod` x/net `v0.52.0`, x/crypto `v0.49.0` | needs x/net ≥0.55.0 / x/crypto ≥0.52.0 — **still waived** |
| gh | cli/cli v2.94.0 | already cleared (not waived) |

Each entry keeps its own `statement:` removal condition; drop it when that upstream actually rebuilds. The 1-month horizon preserves the periodic re-audit intent without churning every week on upstreams that move slowly (dolt, kubectl).

## Verification

- `.trivyignore.yaml` re-parses as valid YAML (46 entries); no live `expired_at` remains on the old date.
- Container Scan re-runs on this PR (`.trivyignore.yaml` is in its trigger paths) and should stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)