### PR TITLE
fix(reconciler): reap interrupted-close session beads instead of skip-spinning (#2085)

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -1295,6 +1295,50 @@ func isKnownState(session beads.Bead) bool {
 	return knownSessionStates[session.Metadata["state"]]
 }
 
+// interruptedCloseSessionStates lists terminal close stateCodes that
+// session.ClosePatch stamps onto a session bead immediately before the
+// status flips to closed. A crash or failed status write between the two
+// leaves an open bead carrying a terminal state outside knownSessionStates;
+// without intervention the reconciler skips it on every tick forever while
+// the bead holds its agent's pool slot, and gc restart cannot recover
+// because bd is the source of truth (#2085). The reconciler treats these as
+// interrupted closes and finishes the close (guarded on provider-not-running
+// and no assigned work) instead of spinning.
+//
+// Sources: the stateCodes actually passed to closeBead/ClosePatch at their
+// call sites — session_beads.go (stale-session, duplicate, reconfigured,
+// dead-runtime), pool_session_name.go (gc_swept), and the sleep_reason
+// passthrough on the pool retire path (IsDeliberateSleepReason vocabulary
+// plus runtime-missing) — minus codes already in knownSessionStates.
+// "duplicate-repair" is deliberately absent: RetireNamedSessionPatch routes
+// it through ArchivePatch (state="archived", status stays open), so it never
+// lands in the state field as an interrupted close. States outside this set
+// and knownSessionStates remain skipped untouched for forward-compatible
+// rollback.
+var interruptedCloseSessionStates = map[string]bool{
+	"gc_swept":                true,
+	"stale-session":           true,
+	"duplicate":               true,
+	"reconfigured":            true,
+	"dead-runtime":            true,
+	"idle":                    true,
+	"idle-timeout":            true,
+	"no-wake-reason":          true,
+	"config-drift":            true,
+	"city-stop":               true,
+	"user-hold":               true,
+	"wait-hold":               true,
+	"rate_limit":              true,
+	"provider-terminal-error": true,
+	sleepReasonRuntimeMissing: true,
+}
+
+// isInterruptedCloseState reports whether the bead's metadata state is an
+// interrupted terminal close that the reconciler should finish.
+func isInterruptedCloseState(session beads.Bead) bool {
+	return interruptedCloseSessionStates[session.Metadata["state"]]
+}
+
 // reverseBeads returns a reversed copy of the bead slice.
 func reverseBeads(beadSlice []beads.Bead) []beads.Bead {
 	n := len(beadSlice)

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2507,6 +2507,233 @@ func TestForwardCompatibility_UnknownState(t *testing.T) {
 	}
 }
 
+// --- interrupted-close reap tests (#2085) ---
+
+// TestReconcile_InterruptedCloseStateReaped verifies that an open session
+// bead stamped with a terminal ClosePatch stateCode the reconciler doesn't
+// otherwise process (an interrupted close: state written, status flip lost)
+// is closed rather than skipped forever. Before the fix these beads spun in
+// the unknown-state skip on every tick, permanently holding their agent's
+// pool slot, and gc restart could not recover because bd is the source of
+// truth (#2085).
+func TestReconcile_InterruptedCloseStateReaped(t *testing.T) {
+	// Covers the uncontroversial terminal codes plus the higher-risk
+	// hold-flavored reasons the pool retire path passes through
+	// (sleep_reason vocabulary) — all of which can only land on a
+	// pool-managed bead at their sole write site, so all must reap.
+	states := []string{
+		"duplicate", "stale-session", "gc_swept", "idle-timeout",
+		"idle", "no-wake-reason", "config-drift", "city-stop",
+		"user-hold", "wait-hold", "rate_limit", "provider-terminal-error",
+	}
+	for _, state := range states {
+		t.Run(state, func(t *testing.T) {
+			env := newReconcilerTestEnv()
+			env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+			env.addDesired("worker", "worker", false)
+
+			session := env.createSessionBead("worker", "worker")
+			env.setSessionMetadata(&session, map[string]string{
+				"state":                state,
+				poolManagedMetadataKey: boolMetadata(true),
+			})
+
+			woken := env.reconcile([]beads.Bead{session})
+			if woken != 0 {
+				t.Errorf("expected 0 woken for interrupted-close state, got %d", woken)
+			}
+
+			got, err := env.store.Get(session.ID)
+			if err != nil {
+				t.Fatalf("Get(session): %v", err)
+			}
+			if got.Status != "closed" {
+				t.Errorf("expected bead closed for interrupted-close state %q, got status %q", state, got.Status)
+			}
+			if !strings.Contains(env.stderr.String(), "interrupted-close") {
+				t.Errorf("expected interrupted-close reap message in stderr, got: %s", env.stderr.String())
+			}
+		})
+	}
+}
+
+// TestReconcile_InterruptedCloseStateKeptWhileWorkAssigned verifies the reap
+// defers to the assigned-work guard: a bead with open assigned work is not
+// closed, so the work is not orphaned mid-flight.
+func TestReconcile_InterruptedCloseStateKeptWhileWorkAssigned(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "duplicate",
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+
+	task, err := env.store.Create(beads.Bead{Title: "assigned task", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create(task): %v", err)
+	}
+	status := "in_progress"
+	assignee := session.ID
+	if err := env.store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update(task): %v", err)
+	}
+
+	env.reconcile([]beads.Bead{session})
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Status == "closed" {
+		t.Errorf("expected bead kept open while work is assigned, got status %q", got.Status)
+	}
+}
+
+// TestReconcile_InterruptedCloseStateKeptWhileRuntimeAlive verifies the reap
+// only fires when the provider session is not running: a live runtime under
+// an interrupted-close bead is left for the owning close path to finish.
+func TestReconcile_InterruptedCloseStateKeptWhileRuntimeAlive(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "duplicate",
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Status == "closed" {
+		t.Errorf("expected bead kept open while runtime is alive, got status %q", got.Status)
+	}
+}
+
+// TestReconcile_InterruptedCloseStateDeferredUnderPartialStore verifies the
+// reap defers when the store view is degraded: a partial view is exactly when
+// a false "no assigned work" read is most likely, so no closes may fire.
+func TestReconcile_InterruptedCloseStateDeferredUnderPartialStore(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "duplicate",
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, nil, nil, nil, env.dt, map[string]int{"worker": 1},
+		true, // storeQueryPartial: degraded view, closes must defer
+		nil, "", nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Status == "closed" {
+		t.Errorf("expected bead kept open under storeQueryPartial, got status %q", got.Status)
+	}
+}
+
+// TestReconcile_InterruptedCloseStateDeferredOnBoot verifies the reap honors
+// the boot-window close deferral, matching the orphan/failed-create paths.
+func TestReconcile_InterruptedCloseStateDeferredOnBoot(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "duplicate",
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, nil, nil, nil, env.dt, map[string]int{"worker": 1},
+		false, nil, "", nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+		withDeferSessionClosesOnBoot(),
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Status == "closed" {
+		t.Errorf("expected bead kept open under boot close deferral, got status %q", got.Status)
+	}
+}
+
+// TestReconcile_GenuinelyUnknownStateStillSkipped pins the forward-compat
+// contract alongside the interrupted-close reap: a state outside both
+// knownSessionStates and interruptedCloseSessionStates (e.g. written by a
+// newer version) is skipped untouched, exactly as before.
+func TestReconcile_GenuinelyUnknownStateStillSkipped(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{"state": "archived"})
+
+	env.reconcile([]beads.Bead{session})
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Status == "closed" {
+		t.Errorf("expected genuinely-unknown state left open, got status %q", got.Status)
+	}
+	if !strings.Contains(env.stderr.String(), "unknown state") {
+		t.Errorf("expected unknown-state skip message in stderr, got: %s", env.stderr.String())
+	}
+}
+
+// TestReconcile_InterruptedCloseStateNamedSessionNotReaped pins the
+// pool-managed guard: a named/singleton (non-pool) session bead carrying an
+// interrupted-close stateCode is NOT reaped — it falls through to the skip, so
+// a named session never loses its identity to the reap path even if a future
+// write stamped one of these reasons onto its state field. The reap is scoped
+// to pool slots, whose loss is a cheap respawn. Runtime is not alive here, so
+// the pool-managed guard is the sole reason the bead is kept open.
+func TestReconcile_InterruptedCloseStateNamedSessionNotReaped(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+
+	// No pool_managed / pool_slot metadata -> isPoolManagedSessionBead is false.
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{"state": "duplicate"})
+
+	env.reconcile([]beads.Bead{session})
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Status == "closed" {
+		t.Errorf("expected non-pool session kept open (identity-preserving skip), got status %q", got.Status)
+	}
+	if !strings.Contains(env.stderr.String(), "unknown state") {
+		t.Errorf("expected unknown-state skip message for non-pool bead, got: %s", env.stderr.String())
+	}
+}
+
 // TestReconcileSessionBeads_FailedCreateDesiredTargetNotStarted verifies that
 // state=failed-create cannot reach the provider start path even if a stale
 // desired-state entry points at that session_name.

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2517,16 +2517,13 @@ func TestForwardCompatibility_UnknownState(t *testing.T) {
 // pool slot, and gc restart could not recover because bd is the source of
 // truth (#2085).
 func TestReconcile_InterruptedCloseStateReaped(t *testing.T) {
-	// Covers the uncontroversial terminal codes plus the higher-risk
-	// hold-flavored reasons the pool retire path passes through
-	// (sleep_reason vocabulary) — all of which can only land on a
-	// pool-managed bead at their sole write site, so all must reap.
-	states := []string{
-		"duplicate", "stale-session", "gc_swept", "idle-timeout",
-		"idle", "no-wake-reason", "config-drift", "city-stop",
-		"user-hold", "wait-hold", "rate_limit", "provider-terminal-error",
-	}
-	for _, state := range states {
+	// Every stateCode in interruptedCloseSessionStates must reap: each can only
+	// land on a pool-managed bead at its sole close write site, and all share
+	// the identical guarded-close path. Iterate the production set directly so
+	// a future addition is covered without a parallel list that can silently
+	// drift (Copilot review on #4003: reconfigured, dead-runtime, and
+	// runtime-missing were omitted from the old hand-list).
+	for state := range interruptedCloseSessionStates {
 		t.Run(state, func(t *testing.T) {
 			env := newReconcilerTestEnv()
 			env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1183,11 +1183,44 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// rollback: if a newer version writes "draining" or "archived", the
 		// older reconciler ignores those beads rather than crashing.
 		if !isKnownState(*session) {
+			state := session.Metadata["state"]
+			// Interrupted close: ClosePatch stamped a terminal state but the
+			// status flip to closed was lost. Finish the close so the bead
+			// stops holding its pool slot (#2085); fall through to the skip
+			// when the runtime is still alive, the store view is partial, or
+			// the work guard declines.
+			//
+			// Gated on isPoolManagedSessionBead as defense-in-depth: every
+			// stateCode in interruptedCloseSessionStates is written only at
+			// the pool retire path (session_reconciler.go closeBead call site),
+			// which is itself pool-managed-gated, so today these states can
+			// only land on a pool bead. Enforcing that here rather than relying
+			// on the cross-file invariant means a future write that stamped one
+			// of these reasons onto a named/singleton session's state field
+			// would be skipped (the older, safe behavior) instead of finishing
+			// a close that costs a named session its identity/continuity.
+			if isInterruptedCloseState(*session) && isPoolManagedSessionBead(*session) && !storeQueryPartial && !reconcileOpts.deferSessionClosesOnBoot {
+				providerAlive, aliveErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, session.ID)
+				if aliveErr != nil {
+					providerAlive = false
+				}
+				if !providerAlive && closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, *session, state, clk.Now().UTC(), stderr) {
+					fmt.Fprintf(stderr, "session reconciler: reaped %s with interrupted-close state %q\n", //nolint:errcheck // best-effort stderr
+						name, state)
+					if trace != nil {
+						trace.recordDecision("reconciler.session.unknown_state", session.Metadata["template"], name, "interrupted_close_reaped", "closed", traceRecordPayload{
+							"state": state,
+						}, nil, "")
+					}
+					session.Status = "closed"
+					continue
+				}
+			}
 			fmt.Fprintf(stderr, "session reconciler: skipping %s with unknown state %q\n", //nolint:errcheck // best-effort stderr
-				session.Metadata["session_name"], session.Metadata["state"])
+				name, state)
 			if trace != nil {
-				trace.recordDecision("reconciler.session.unknown_state", session.Metadata["template"], session.Metadata["session_name"], "unknown_state_skipped", "skipped", traceRecordPayload{
-					"state": session.Metadata["state"],
+				trace.recordDecision("reconciler.session.unknown_state", session.Metadata["template"], name, "unknown_state_skipped", "skipped", traceRecordPayload{
+					"state": state,
 				}, nil, "")
 			}
 			continue


### PR DESCRIPTION
## Summary

The session reconciler stalled on session beads left in an unknown or interrupted-close state, and `gc restart` did not recover them; it skip-spun on the zombie bead every tick while the bead held its agent's pool slot. This finishes the interrupted close so the slot is freed and the loop makes progress.

An interrupted close is a bead where `ClosePatch` stamped a terminal state code but the status flip to `closed` was lost (a crash or failed write between the two).

## Changes

- `cmd/gc/session_reconcile.go`: `interruptedCloseSessionStates` set + `isInterruptedCloseState`, derived from the terminal codes the pool retire path passes to `ClosePatch`.
- `cmd/gc/session_reconciler.go`: reap branch in the unknown-state handler, gated on `isPoolManagedSessionBead` (a named session is never reaped, so it cannot lose its identity), provider-not-running, no assigned work (re-checked at reap time via `closeSessionBeadIfReachableStoreUnassigned`), store view not partial, and outside the boot close-defer window. States outside both `knownSessionStates` and `interruptedCloseSessionStates` still fall through to the existing skip, so a state written by a newer version is ignored rather than crashing.

## Test plan

- `go test ./cmd/gc/ -run Reconcile`: new tests cover all 12 interrupted-close states, the assigned-work / runtime-alive / partial-store / boot-defer guards, a named (non-pool) session left untouched, and the forward-compat skip for genuinely-unknown states.
- Full `make test-fast-parallel` green.

## Review

Multi-model review (Claude; Codex rate-limited) plus a prior reviewer pass. Two hardening items from the first review are addressed: the `isPoolManagedSessionBead` guard makes the pool-only invariant explicit rather than relying on a cross-file coincidence, and the risky hold-flavored state codes plus the named-session non-reap case are now covered by tests. Confirmation review found both resolved with no new findings.

Fixes #2085
