### PR TITLE
fix(ci): point Notify Image Rebuilds at renamed gasworks-control-plane repo

### DIFF
--- a/.github/workflows/notify-image-build.yaml
+++ b/.github/workflows/notify-image-build.yaml
@@ -1,10 +1,12 @@
-# Notify gasworks-internal to rebuild the gc-runtime image when Go source changes.
+# Notify gasworks-control-plane to rebuild the gc-runtime image when Go source
+# changes.
 #
 # gascity provides the gc binary embedded in runtime images.
 # When source code changes, images need rebuilding.
 #
-# Required secret: GASCITY_HOSTED_TOKEN — PAT with repo scope for
-# gascity/gasworks-internal (needed for repository_dispatch).
+# Required secret: GASCITY_HOSTED_TOKEN — a token with contents:write on
+# gascity/gasworks-control-plane (needed for repository_dispatch). A
+# fine-grained PAT scoped to that repo, or a classic PAT with repo scope.
 
 name: Notify Image Rebuilds
 
@@ -33,5 +35,5 @@ jobs:
         run: |
           gh api \
             --method POST \
-            repos/gascity/gasworks-internal/dispatches \
+            repos/gascity/gasworks-control-plane/dispatches \
             -f event_type=runtime-dep-updated


### PR DESCRIPTION
## What

Updates `notify-image-build.yaml` to POST `repository_dispatch` to **`gascity/gasworks-control-plane`** instead of the old `gascity/gasworks-internal` name, and refreshes the header docs.

## Why

`gascity/gasworks-internal` was **renamed to `gasworks-control-plane`** (the API GET redirects). The workflow still targeted the old name, relying on GitHub's rename redirect.

Separately, the `GASCITY_HOSTED_TOKEN` secret had **expired** (last set 2026-03-22), producing `gh: Bad credentials (HTTP 401)` on every run for weeks — that was the *immediate* cause of this workflow being red. The secret has now been refreshed with a fine-grained PAT scoped to `gasworks-control-plane` (contents:write). This PR removes the remaining redirect dependency so the dispatch targets the real repo directly.

## Verification

- Token already validated out-of-band (authenticates; push+admin on `gascity/gasworks-control-plane`).
- After merge, the push to `main` touches `.github/workflows/notify-image-build.yaml` (a trigger path), so the notify workflow runs on the merge commit — the live end-to-end confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)