### PR TITLE
fix(control-dispatcher): prefer rig-scoped dispatcher for its own scope (revert #3765's static city-preference)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,36 +93,39 @@ func IsDeterministicControlDispatcher(agent *Agent) bool {
 }
 
 // PreferredDeterministicControlDispatcher returns the deterministic control-
-// dispatcher to route a scope's control beads to, binding-agnostic. The
-// city-level singleton (Dir == "") is preferred for every scope — given
-// max_active_sessions=1, it is the one whose session actually runs and claims
-// the control queue — and a rig-scoped instance (Dir == rigContext) is used only
-// when no city-level deterministic dispatcher is configured. Routing to a
-// rig-scoped copy when a city singleton exists strands the control bead, since
-// the singleton session never claims a <rig>/... route. This is the canonical
-// selection shared by the graph.v2 decoration path (internal/graphroute) and the
-// attempt-time control re-route path (internal/dispatch); keep them in lockstep.
+// dispatcher to route a scope's control beads to, binding-agnostic. A rig-scoped
+// instance (Dir == rigContext, when rigContext != "") is preferred for its own
+// scope — a rig that runs its own dispatcher owns its control queue, so its
+// control beads must be stamped with the <rig>/... route that instance claims —
+// and the city-level singleton (Dir == "") is used only when the rig runs none
+// of its own. This selection is purely about static ownership; the liveness of a
+// configured-but-asleep rig dispatcher is handled downstream by graphroute's
+// ControlDispatcherRuntimeMissing demotion (#3454), not here. This is the
+// canonical selection shared by the graph.v2 decoration path
+// (internal/graphroute) and the attempt-time control re-route path
+// (internal/dispatch); keep them in lockstep.
 func PreferredDeterministicControlDispatcher(cfg *City, rigContext string) (Agent, bool) {
 	if cfg == nil {
 		return Agent{}, false
 	}
 	rigContext = strings.TrimSpace(rigContext)
-	var rigScoped Agent
-	haveRigScoped := false
+	var cityScoped Agent
+	haveCityScoped := false
 	for _, a := range cfg.Agents {
 		if !IsDeterministicControlDispatcher(&a) {
 			continue
 		}
-		if strings.TrimSpace(a.Dir) == "" {
+		dir := strings.TrimSpace(a.Dir)
+		if rigContext != "" && dir == rigContext {
 			return a, true
 		}
-		if !haveRigScoped && strings.TrimSpace(a.Dir) == rigContext {
-			rigScoped = a
-			haveRigScoped = true
+		if !haveCityScoped && dir == "" {
+			cityScoped = a
+			haveCityScoped = true
 		}
 	}
-	if haveRigScoped {
-		return rigScoped, true
+	if haveCityScoped {
+		return cityScoped, true
 	}
 	return Agent{}, false
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7859,11 +7859,12 @@ printf 'TRACE=%%s\nARGS=%%s\n' "$GC_WORKFLOW_TRACE" "$*" > %q
 	return tracePath, args
 }
 
-// TestPreferredDeterministicControlDispatcher locks the singleton-first
-// selection both graphroute and dispatch route control beads with. The city-
-// level singleton (Dir == "") must win for every scope; a rig-scoped instance is
-// used only when no city-level deterministic dispatcher exists. Non-deterministic
-// control-dispatcher agents (no convoy-control StartCommand) are ignored.
+// TestPreferredDeterministicControlDispatcher locks the rig-scoped-first
+// selection both graphroute and dispatch route control beads with. A rig-scoped
+// instance (Dir == rigContext) must win for its own scope; the city-level
+// singleton (Dir == "") is used only when the rig runs none of its own, and for
+// the empty scope. Non-deterministic control-dispatcher agents (no convoy-control
+// StartCommand) are ignored.
 func TestPreferredDeterministicControlDispatcher(t *testing.T) {
 	deterministic := func(dir string) Agent {
 		return Agent{
@@ -7886,10 +7887,10 @@ func TestPreferredDeterministicControlDispatcher(t *testing.T) {
 		wantOK     bool
 	}{
 		{
-			name:       "singleton preferred over rig copy for rig scope",
+			name:       "rig copy preferred over singleton for its own scope",
 			agents:     []Agent{rigCopy, citySingleton},
 			rigContext: "fixture",
-			wantQN:     "core.control-dispatcher",
+			wantQN:     "fixture/core.control-dispatcher",
 			wantOK:     true,
 		},
 		{

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -1049,12 +1049,12 @@ func controlDispatcherTargetForExecutionTarget(executionTarget, rigContext strin
 			rigContext = executionTarget[:slash]
 		}
 	}
-	// Prefer the city-level singleton deterministic dispatcher for every scope
-	// (the one whose session actually runs given max_active_sessions=1), falling
-	// back to a rig-scoped instance only when no city-level dispatcher exists.
+	// Prefer a rig-scoped deterministic dispatcher for its own scope (a rig that
+	// runs its own dispatcher owns and claims its <rig>/... control queue), falling
+	// back to the city-level singleton only when the rig runs none of its own.
 	// This keeps attempt-time control re-routing in lockstep with the graph.v2
-	// decoration path; without it an attempt-kind control bead would re-stamp a
-	// <rig>/control-dispatcher route the lone singleton session never claims.
+	// decoration path; liveness of an asleep rig-local dispatcher is a downstream
+	// (#3454) concern, not conflated into this static ownership selection.
 	if agentCfg, ok := config.PreferredDeterministicControlDispatcher(cfg, rigContext); ok {
 		return agentCfg.QualifiedName()
 	}

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -924,6 +924,18 @@ func applyAttemptRecipeScopeChecks(recipe *formula.Recipe) {
 				meta[key] = value
 			}
 		}
+		// The scope-check gate carries no run_target of its own, so downstream
+		// control routing (applyAttemptControlStepRoute) would derive an empty rig
+		// context and stamp the CITY-level dispatcher — even when the subject
+		// execution lane lives in a rig that runs and owns its own dispatcher.
+		// Inherit the subject step's rig context so the gate lands on
+		// <rig>/control-dispatcher, in lockstep with #4006's rig-scoped ownership
+		// model (the sibling execution lane already carries the rig via its own
+		// run_target). Prefer any explicit rig context on the subject, else derive
+		// it from the rig prefix of the subject's own routing target.
+		if rigContext := attemptScopeCheckSubjectRigContext(step); rigContext != "" {
+			meta[beadmeta.ExecutionRigContextMetadataKey] = rigContext
+		}
 		controls = append(controls, formula.RecipeStep{
 			ID:       controlID,
 			Title:    "Finalize scope for " + step.Title,
@@ -958,6 +970,31 @@ func attemptRecipeStepNeedsScopeCheck(step formula.RecipeStep) bool {
 		return false
 	}
 	return !beadmeta.IsScopeCheckExemptKind(step.Metadata[beadmeta.KindMetadataKey])
+}
+
+// attemptScopeCheckSubjectRigContext derives the rig context of a scoped subject
+// step so its minted scope-check gate can route to the rig-scoped control
+// dispatcher (matching #4006). It prefers an explicit gc.execution_rig_context on
+// the subject, then falls back to the rig prefix of the subject's own routing
+// target (gc.run_target, gc.routed_to, or a rig-qualified assignee) — the same
+// target-precedence spawnNextAttempt uses to route the sibling execution lane.
+// Returns "" when the subject carries no rig signal, leaving the gate to inherit
+// the parent execution lane exactly as before.
+func attemptScopeCheckSubjectRigContext(step formula.RecipeStep) string {
+	if rigContext := strings.TrimSpace(step.Metadata[beadmeta.ExecutionRigContextMetadataKey]); rigContext != "" {
+		return rigContext
+	}
+	candidates := []string{
+		step.Metadata[beadmeta.RunTargetMetadataKey],
+		step.Metadata[beadmeta.RoutedToMetadataKey],
+		step.Assignee,
+	}
+	for _, candidate := range candidates {
+		if dir, _ := config.ParseQualifiedName(strings.TrimSpace(candidate)); dir != "" {
+			return dir
+		}
+	}
+	return ""
 }
 
 func loadAttemptRouteConfig(cityPath string) *config.City {

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -1340,6 +1340,122 @@ max_active_sessions = 1
 	}
 }
 
+// TestSpawnNextAttemptScopeCheckGateInheritsSubjectRigDispatcher pins the third
+// call-site of the rig-scoped-dispatcher fix (#4006 extension): the mid-run
+// finalize-scope gate minted by applyAttemptRecipeScopeChecks during an attempt
+// re-spawn. The gate carries no run_target of its own, so before the fix its
+// rig context resolved empty and it routed to the CITY-level dispatcher
+// (bare "control-dispatcher") even though its subject execution lane lives in a
+// rig. With both a city singleton (Dir="") and a rig-scoped copy (Dir="frontend")
+// configured, and a subject whose only rig signal is its own rig-prefixed
+// gc.run_target (the control bead carries no gc.execution_routed_to), the minted
+// "Finalize scope for ..." gate must route to the rig dispatcher the rig owns.
+func TestSpawnNextAttemptScopeCheckGateInheritsSubjectRigDispatcher(t *testing.T) {
+	t.Parallel()
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`
+[workspace]
+name = "maintainer-city"
+
+[daemon]
+formula_v2 = true
+
+[[rigs]]
+name = "frontend"
+path = "/tmp/frontend"
+
+[[agent]]
+name = "reviewer"
+dir = "frontend"
+
+[[agent]]
+name = "control-dispatcher"
+max_active_sessions = 1
+start_command = "sh -c 'exec gc convoy control --serve --follow control-dispatcher'"
+
+[[agent]]
+name = "control-dispatcher"
+dir = "frontend"
+max_active_sessions = 1
+start_command = "sh -c 'exec gc convoy control --serve --follow frontend/control-dispatcher'"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	spec := &formula.Step{
+		ID:    "review-loop",
+		Title: "Review loop",
+		Type:  "task",
+		Ralph: &formula.RalphSpec{MaxAttempts: 3},
+		Children: []*formula.Step{
+			{
+				ID:    "review",
+				Title: "Review",
+				Type:  "task",
+				// The subject's ONLY rig signal: an explicit rig-prefixed target.
+				// The control bead below deliberately carries no
+				// gc.execution_routed_to, so the gate cannot inherit the rig from
+				// the parent — it must derive it from this subject.
+				Metadata: map[string]string{
+					"gc.run_target": "frontend/reviewer",
+				},
+			},
+		},
+	}
+	specJSON, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal step spec: %v", err)
+	}
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review-loop",
+		Metadata: map[string]string{
+			"gc.kind":             "ralph",
+			"gc.root_bead_id":     root.ID,
+			"gc.step_ref":         "mol-review-v2.review-loop",
+			"gc.step_id":          "review-loop",
+			"gc.source_step_spec": string(specJSON),
+			"gc.control_epoch":    "1",
+			// NOTE: no gc.execution_routed_to on purpose.
+		},
+	})
+
+	if err := spawnNextAttempt(t.Context(), store, control, 2, ProcessOptions{CityPath: cityPath}); err != nil {
+		t.Fatalf("spawnNextAttempt: %v", err)
+	}
+
+	// Sibling execution lane routes to the rig via its own run_target.
+	review := findAttemptByRef(t, store, root.ID, "mol-review-v2.review-loop.iteration.2.review")
+	if review.ID == "" {
+		t.Fatal("review child not created")
+	}
+	if got := review.Metadata["gc.routed_to"]; got != "frontend/reviewer" {
+		t.Fatalf("review child gc.routed_to = %q, want frontend/reviewer", got)
+	}
+
+	// The finalize-scope gate minted alongside must route to the rig dispatcher,
+	// not the bare city singleton.
+	gate := findAttemptByRef(t, store, root.ID, "mol-review-v2.review-loop.iteration.2.review-scope-check")
+	if gate.ID == "" {
+		t.Fatal("finalize-scope gate not created")
+	}
+	if got := gate.Metadata["gc.kind"]; got != "scope-check" {
+		t.Fatalf("gate gc.kind = %q, want scope-check", got)
+	}
+	if got := gate.Metadata["gc.routed_to"]; got != "frontend/control-dispatcher" {
+		t.Fatalf("finalize-scope gate gc.routed_to = %q, want rig-scoped frontend/control-dispatcher", got)
+	}
+	if gate.Assignee != "" {
+		t.Fatalf("gate assignee = %q, want empty routed control-dispatcher queue", gate.Assignee)
+	}
+}
+
 func TestApplyAttemptControlStepRoute_MinimalRigScopedDispatcherUsesMetadataRoute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -1185,14 +1185,15 @@ func TestApplyAttemptControlStepRoute_UsesExecutionRigContextForDirectSessionTar
 	}
 }
 
-// TestApplyAttemptControlStepRoute_PrefersCitySingletonOverRigScoped covers the
+// TestApplyAttemptControlStepRoute_PrefersRigScopedOverCitySingleton covers the
 // attempt-time analog of the graph.v2 decoration fix: with a bound city-level
-// singleton (core.control-dispatcher, Dir="", max_active_sessions=1) plus a
-// per-rig copy (fixture/core.control-dispatcher), an attempt-kind control bead
-// whose execution target lives in the rig must still route to the city singleton
-// — the session that actually runs — not the rig-scoped copy that no session
-// claims (which would re-strand the control bead at attempt time).
-func TestApplyAttemptControlStepRoute_PrefersCitySingletonOverRigScoped(t *testing.T) {
+// singleton (core.control-dispatcher, Dir="") plus a per-rig copy
+// (fixture/core.control-dispatcher), an attempt-kind control bead whose execution
+// target lives in the rig must route to the rig-scoped dispatcher the rig runs and
+// owns — not the city singleton. Rig ownership is static (this selection);
+// liveness of an asleep rig dispatcher is graphroute's #3454 runtime concern.
+// Inverts #3765's static city-preference.
+func TestApplyAttemptControlStepRoute_PrefersRigScopedOverCitySingleton(t *testing.T) {
 	t.Parallel()
 
 	maxActive := 1
@@ -1232,8 +1233,8 @@ func TestApplyAttemptControlStepRoute_PrefersCitySingletonOverRigScoped(t *testi
 	if step.Assignee != "" {
 		t.Fatalf("assignee = %q, want empty routed control-dispatcher queue", step.Assignee)
 	}
-	if got := step.Metadata["gc.routed_to"]; got != "core.control-dispatcher" {
-		t.Fatalf("gc.routed_to = %q, want city-level singleton core.control-dispatcher", got)
+	if got := step.Metadata["gc.routed_to"]; got != "fixture/core.control-dispatcher" {
+		t.Fatalf("gc.routed_to = %q, want rig-scoped fixture/core.control-dispatcher", got)
 	}
 	if got := step.Metadata["gc.execution_routed_to"]; got != "fixture/superpowers.brainstorming" {
 		t.Fatalf("gc.execution_routed_to = %q, want fixture/superpowers.brainstorming", got)

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -324,10 +324,13 @@ func resolveControlDispatcherBinding(_ beads.Store, _ string, cfg *config.City, 
 	// match. Since 9fa6b7fec the dispatcher ships bound (core.control-dispatcher),
 	// so AgentMatchesIdentity rejects the bare-name fallback for it and the
 	// per-rig fleet makes the bare-name scan ambiguous — both break a
-	// Resolver-based lookup. PreferredDeterministicControlDispatcher prefers the
-	// city-level singleton (Dir == "") across every scope, keeping the stamped
-	// route on the one session that actually runs (max_active_sessions=1) and
-	// curing the stranded-control-bead.
+	// Resolver-based lookup. PreferredDeterministicControlDispatcher prefers a
+	// rig-scoped dispatcher (Dir == rigContext) for its own scope, so a rig that
+	// runs its own dispatcher gets the <rig>/... route it claims, and falls back
+	// to the city-level singleton (Dir == "") only when the rig runs none. The
+	// liveness of an asleep rig-local dispatcher is handled by the
+	// ControlDispatcherRuntimeMissing demotion in ControlDispatcherBinding (#3454),
+	// not by this static ownership lookup.
 	if agentCfg, ok := config.PreferredDeterministicControlDispatcher(cfg, rigContext); ok {
 		return GraphRouteBinding{QualifiedName: agentCfg.QualifiedName(), MetadataOnly: true}, nil
 	}

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -312,6 +312,56 @@ func TestDecorateGraphWorkflowRecipe_RootStampsRoutedToForClaim(t *testing.T) {
 	}
 }
 
+// TestDecorateGraphWorkflowRecipe_ControlStepPrefersRigScopedDispatcher is the
+// instantiation-level proof of the sc-mfx8l3 fix: a graph.v2 recipe with an
+// auto-injected control-kind step (workflow-finalize), decorated under a config
+// that holds BOTH a city-level deterministic dispatcher (core.control-dispatcher,
+// Dir="") and a rig-scoped one (fixture/core.control-dispatcher, Dir="fixture"),
+// with the run routed into the rig, must stamp the control step's gc.routed_to
+// with the rig-scoped dispatcher the rig owns and claims. Pre-fix (#3765's static
+// city-preference) this stamped the unprefixed core.control-dispatcher, which the
+// rig dispatcher never claimed — stranding the finalize step and stalling the
+// compound build at its first control gate.
+func TestDecorateGraphWorkflowRecipe_ControlStepPrefersRigScopedDispatcher(t *testing.T) {
+	maxActive := 1
+	cfg := &config.City{Agents: []config.Agent{
+		{
+			Name:              config.ControlDispatcherAgentName,
+			BindingName:       "core",
+			StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+			MaxActiveSessions: &maxActive,
+		},
+		{
+			Name:              config.ControlDispatcherAgentName,
+			BindingName:       "core",
+			Dir:               "fixture",
+			StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+			MaxActiveSessions: &maxActive,
+		},
+		{Name: "worker", Dir: "fixture", MaxActiveSessions: intPtr(4)},
+	}}
+	r := &formula.Recipe{
+		Name: "wf-test",
+		Steps: []formula.RecipeStep{
+			{ID: "wf-test.root", IsRoot: true, Metadata: map[string]string{
+				"gc.kind": "workflow", "gc.formula_contract": "graph.v2",
+			}},
+			{ID: "wf-test.finalize", Metadata: map[string]string{
+				"gc.kind": "workflow-finalize",
+			}},
+		},
+	}
+	deps := Deps{Resolver: testAgentResolver{}}
+	// Root routed into the rig ("fixture/worker") → routingRigContext == "fixture".
+	if err := DecorateGraphWorkflowRecipe(r, nil, "src-1", "city", "test-city", "city:test", "fixture/worker", "", nil, "test-city", cfg, deps); err != nil {
+		t.Fatalf("DecorateGraphWorkflowRecipe: %v", err)
+	}
+	finalize := r.Steps[1]
+	if got := finalize.Metadata["gc.routed_to"]; got != "fixture/core.control-dispatcher" {
+		t.Fatalf("finalize gc.routed_to = %q, want rig-scoped fixture/core.control-dispatcher (the rig owns and claims its own control queue; sc-mfx8l3 / revert #3765)", got)
+	}
+}
+
 func TestDecorateGraphWorkflowRecipe_NilRecipe(t *testing.T) {
 	err := DecorateGraphWorkflowRecipe(nil, nil, "", "", "", "", "", "", nil, "", nil, Deps{})
 	if err == nil {
@@ -727,15 +777,16 @@ func TestControlDispatcherBinding_ConfiguredDispatcherUsesCanonicalQueue(t *test
 	}
 }
 
-// TestControlDispatcherBinding_PrefersCitySingletonOverRigScoped covers the
+// TestControlDispatcherBinding_PrefersRigScopedOverCitySingleton covers the
 // production shape after 9fa6b7fec: a bound city-level singleton
-// (core.control-dispatcher, Dir="", max_active_sessions=1) plus a per-rig
-// materialized copy (fixture/core.control-dispatcher). For every scope the
-// binding must resolve to the city-level singleton — the one whose session
-// actually runs — not the rig-scoped copy (which would strand the control bead).
-// The resolver returns no match, exercising the binding-agnostic deterministic
-// lookup directly.
-func TestControlDispatcherBinding_PrefersCitySingletonOverRigScoped(t *testing.T) {
+// (core.control-dispatcher, Dir="") plus a per-rig materialized copy
+// (fixture/core.control-dispatcher). A rig that runs its own dispatcher owns its
+// control queue, so the rig scope must resolve to the rig-scoped instance while
+// the empty scope falls back to the city singleton. The resolver returns no
+// match, exercising the binding-agnostic deterministic lookup directly. Inverts
+// #3765's static city-preference; the static lookup is about ownership, the
+// runtime-missing demotion (#3454) is about liveness — kept separate.
+func TestControlDispatcherBinding_PrefersRigScopedOverCitySingleton(t *testing.T) {
 	maxActive := 1
 	cfg := &config.City{Agents: []config.Agent{
 		{
@@ -753,14 +804,21 @@ func TestControlDispatcherBinding_PrefersCitySingletonOverRigScoped(t *testing.T
 		},
 	}}
 
-	for _, rigContext := range []string{"", "fixture"} {
-		t.Run("rigContext="+rigContext, func(t *testing.T) {
-			binding, err := ControlDispatcherBinding(nil, "test-city", cfg, rigContext, Deps{Resolver: noMatchAgentResolver{}})
+	cases := []struct {
+		rigContext string
+		wantQN     string
+	}{
+		{rigContext: "", wantQN: "core.control-dispatcher"},                // no rig scope → city fallback
+		{rigContext: "fixture", wantQN: "fixture/core.control-dispatcher"}, // rig owns its queue → rig-scoped
+	}
+	for _, tc := range cases {
+		t.Run("rigContext="+tc.rigContext, func(t *testing.T) {
+			binding, err := ControlDispatcherBinding(nil, "test-city", cfg, tc.rigContext, Deps{Resolver: noMatchAgentResolver{}})
 			if err != nil {
 				t.Fatalf("ControlDispatcherBinding: %v", err)
 			}
-			if binding.QualifiedName != "core.control-dispatcher" {
-				t.Fatalf("QualifiedName = %q, want city-level singleton core.control-dispatcher", binding.QualifiedName)
+			if binding.QualifiedName != tc.wantQN {
+				t.Fatalf("QualifiedName = %q, want %q", binding.QualifiedName, tc.wantQN)
 			}
 			if binding.SessionName != "" {
 				t.Fatalf("SessionName = %q, want empty for routed control-dispatcher queue", binding.SessionName)


### PR DESCRIPTION
## Summary

In a multi-rig deployment where a rig runs its **own** deterministic control-dispatcher (e.g. DIP's `dip/core.control-dispatcher`), compound-build control/machinery steps are stamped with the **unprefixed** city-level `core.control-dispatcher` route instead of the rig-scoped `<rig>/core.control-dispatcher`. The rig dispatcher never claims a route it isn't named on, so those control beads strand and **compound builds stall at their first control gate**.

Observed live: a 108-bead compound program in the `dip` rig had all 45 control/machinery steps routed to unprefixed `core.control-dispatcher` and never advanced; an earlier program built on v1.3.3 routed the identical step-class to `dip/core.control-dispatcher` and ran to completion.

## Root cause

**#3765 (`41785d976`, edge-only — not in v1.3.3)** made `config.PreferredDeterministicControlDispatcher` (`internal/config/config.go`) *hard-prefer the city-level singleton* (`Dir==""`) over a rig-scoped instance (`Dir==rigContext`) for **every** scope, using a rig-scoped dispatcher only as a fallback:

```go
if strings.TrimSpace(a.Dir) == "" { return a, true }                 // city-level WINS
if !haveRigScoped && strings.TrimSpace(a.Dir) == rigContext { ... }   // rig only as fallback
```

Both routing-stamp call-sites delegate to this one helper — graph.v2 decoration (`graphroute.resolveControlDispatcherBinding`) and attempt-time re-route (`dispatch.controlDispatcherTargetForExecutionTarget`) — so the mis-route hits both the instantiation and re-route paths. The rig prefix itself comes from `config.Agent.QualifiedName()` (prepends `Dir+"/"` when `Dir!=""`), so the entire bug reduces to *which* agent the helper returns.

#3765 was fixing #3764 (a city-only `core.control-dispatcher` that the old `Dir==rigContext` matcher failed to find) and assumed `max_active_sessions=1` ⇒ a single dispatcher session city-wide. **That assumption is false for multi-rig deployments**, where a rig runs its own dispatcher whose session is the only thing that claims that rig's `<rig>/…` routes.

## Fix

Invert the preference: **a rig that runs its own dispatcher owns its control queue**, so its scope resolves to the rig-scoped instance; the city singleton is the fallback, used only when the active rig runs none of its own (or for city-scoped work, `rigContext==""`). One edit in the single shared helper fixes both call-sites.

Correct for all three deployment shapes:
- **city-only + rigContext** (#3764): no `Dir==rigContext` match → city fallback ✓
- **rig-with-own** (DIP): matches `Dir==rig` → `<rig>/core.control-dispatcher` ✓ (regression cured)
- **pure singleton** (`rigContext==""`): never matches rig → city ✓

### Why this is the *clean* fix, not a revert-and-reintroduce-the-bug

#3765 tried to answer a **dynamic** question — "which dispatcher session is actually alive?" — with a **static** rule ("always city-level"). That dynamic question is **already** answered downstream by #3454's `ControlDispatcherRuntimeMissing` demotion in `graphroute.ControlDispatcherBinding`, which demotes to the city-level dispatcher when the rig-scoped one is configured-but-asleep. This change keeps those two concerns cleanly separated:

- **static** (`PreferredDeterministicControlDispatcher`) = *which dispatcher owns this scope* → the rig's own when present.
- **runtime** (#3454) = *is the owner alive; if not, demote city-ward.*

No static liveness preference is re-added, so #3764 stays fixed via the runtime layer rather than a static override that strands healthy rig dispatchers.

## Tests / proof

- `go build ./...` passes; `go vet` and `gofmt -l` clean.
- **Regression genuinely caught:** temporarily reverting the fix makes the new instantiation test fail with `finalize gc.routed_to = "core.control-dispatcher", want fixture/core.control-dispatcher` — proving the pre-fix strand.
- Config unit: flipped the both-configured rig-scope case to expect the rig-scoped route; the other four cases (empty-scope→city, rig-only→rig, non-deterministic→none, wrong-rig→none) unchanged and green.
- Added instantiation-level `TestDecorateGraphWorkflowRecipe_ControlStepPrefersRigScopedDispatcher` (graph.v2 recipe, both dispatchers configured, root routed into the rig → asserts the control step routes `<rig>/core.control-dispatcher`).
- Inverted #3765's graphroute-binding and dispatch attempt-time both-configured cases to expect the rig-scoped route.
- Broader `go test ./internal/config/... ./internal/graphroute/... ./internal/dispatch/...` all `ok`.

**Live corroboration:** on the affected deployment, manually re-prefixing the 70 stranded routings to `dip/…` un-stuck the program immediately (the first control gate closed and 30 machinery beads processed) — confirming that the rig-scoped route is the correct target this change now produces automatically.

## Third call-site — mid-run attempt re-spawn (added in this PR)

The config-level inversion above covers the graph.v2 decoration paths (initial instantiation and execution-lane minting). A third path needed a separate touch: the **attempt/iteration re-spawn** loop (`internal/dispatch/control.go`, `applyAttemptRecipeScopeChecks`) re-mints "Finalize scope for &lt;lane&gt;" scope-check gates during ralph/retry re-spawns. Those gates carry **no `gc.run_target` of their own**, so `applyAttemptControlStepRoute` fed an empty rig context into `PreferredDeterministicControlDispatcher` and stamped the bare city singleton — even though the sibling execution lanes minted in the same batch correctly carried the `&lt;rig&gt;/` prefix via their own `gc.run_target`. The config fix could not reach this on its own because the gate never supplied a rig context.

Fixed by inheriting the subject step's rig context onto the minted gate (`attemptScopeCheckSubjectRigContext`, using the same target precedence `spawnNextAttempt` uses to route the sibling lane), so the gate lands on `&lt;rig&gt;/control-dispatcher` in lockstep with the rig-scoped-ownership model. Returns "" (unchanged behavior) when the subject has no rig signal, so bare/city cases and the existing parent-execution-lane inheritance are untouched. Covered by `TestSpawnNextAttemptScopeCheckGateInheritsSubjectRigDispatcher` (pre-fix: gate routes `control-dispatcher`; post-fix: `frontend/control-dispatcher`).

Both fixes verified on a live multi-rig deployment: execution lanes and finalize-scope gates now both mint `<rig>/`-prefixed automatically.

Refs #3765, #3454.
