### PR TITLE
chore(deps): bump bundled bd CLI v1.0.4 → v1.1.0 (close the library/CLI skew)

### DIFF
--- a/.github/scripts/install-bd-archive.sh
+++ b/.github/scripts/install-bd-archive.sh
@@ -57,6 +57,10 @@ version_no_v="${version#v}"
 platform_tuple="${os}_${arch}"
 expected_sha=""
 case "${version}:${platform_tuple}" in
+  v1.1.0:linux_amd64) expected_sha="b0f3dd607c3fb989ee08d0a6854fba80d0402971eb108f9af6170bc14d491a34" ;;
+  v1.1.0:linux_arm64) expected_sha="e64eb6f5f998c9eae3ef9ec786f5f1c907ab3ed04fe220ebf265ca9952e21b2f" ;;
+  v1.1.0:darwin_amd64) expected_sha="5d7d30fdadcf012b7e0c1933a62cdfaef106e2561509b904e50a6733621cf8da" ;;
+  v1.1.0:darwin_arm64) expected_sha="c42e24d83b258f7ba9f52a6d2d5f6b055869dfe7807165055988b12e7ea8c564" ;;
   v1.0.5:linux_amd64) expected_sha="24706f65c7131c7b3261388709ae8781c8db53f0795398f67aa40538750aacf3" ;;
   v1.0.5:linux_arm64) expected_sha="ccae5eb4478876ae224687ba98baef46848e603470b241966b63ccd3e01129a4" ;;
   v1.0.5:darwin_amd64) expected_sha="0b0b017a3f2b23a1a9b53056ff160de318ebbca6a991c3db5924f5f48390e490" ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
       DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.1.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -237,7 +237,7 @@ jobs:
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
       DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.1.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -266,7 +266,7 @@ jobs:
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
       DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.1.0"
     strategy:
       fail-fast: false
       matrix:
@@ -298,7 +298,7 @@ jobs:
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
       DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.1.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -498,7 +498,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     env:
       DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.1.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -630,7 +630,7 @@ jobs:
             command: ./scripts/test-integration-shard rest-full-16-of-16
     env:
       DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.1.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -1131,7 +1131,7 @@ jobs:
           GC_TEST_GASCITY_PACKS_REGISTRY: main
     env:
       DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.1.0"
 
   # Dashboard SPA typecheck + tests + build. Runs on every push/PR
   # so TS drift against the spec (e.g. a query param tightening from

--- a/.github/workflows/fork-verify.yml
+++ b/.github/workflows/fork-verify.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.1.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -75,7 +75,7 @@ concurrency:
 
 env:
   DOLT_VERSION: "2.1.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.1.0"
 
 # Trigger gate re-used by every job below via `if:`.
 # We want each job to run when EITHER:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   DOLT_VERSION: "2.1.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.1.0"
 
 jobs:
   tier-b:
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 30
     env:
       DOLT_VERSION: "2.1.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.1.0"
       GC_BEADS: sqlite
       GC_ACCEPTANCE_BEADS_PROVIDER: sqlite
     steps:

--- a/.github/workflows/ollama-acceptance-c.yml
+++ b/.github/workflows/ollama-acceptance-c.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   DOLT_VERSION: "2.1.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.1.0"
   ANTHROPIC_BASE_URL: https://ollama.com
   ANTHROPIC_API_KEY: ""
   ANTHROPIC_AUTH_TOKEN: ${{ secrets.OLLAMA_API_KEY }}

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   DOLT_VERSION: "2.1.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.1.0"
   # Bypass the systemd gascity-test.slice re-exec on CI runners. The Blacksmith
   # runners' user systemd cannot reliably create a transient --scope for the
   # heavy acceptance workloads; gc_test_slice_reexec then exec's

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -37,7 +37,7 @@ concurrency:
 
 env:
   DOLT_VERSION: "2.1.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.1.0"
 
 jobs:
   runner-policy:

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -2,8 +2,9 @@ vulnerabilities:
   # Expiry horizon bulk-extended 2026-07-06: 2026-07-07 -> 2026-08-07. Re-audit
   # confirmed every waived upstream is still pinned at its vulnerable version, so
   # nothing is droppable yet: dolt v2.1.7 (Go 1.26.2 stdlib + old
-  # x/net/x/crypto/thrift), bundled bd v1.0.4 (beads repin: thrift/go-jose/
-  # x-net/x-crypto), kubectl base binary (external x/net), and gc (go.mod still
+  # x/net/x/crypto/thrift), bundled bd v1.1.0 (beads repin: x-net/x-crypto;
+  # thrift+go-jose cleared by the v1.1.0 rebuild), kubectl base binary (external
+  # x/net), and gc (go.mod still
   # golang.org/x/net v0.52.0 / golang.org/x/crypto v0.49.0). gh already cleared
   # by cli/cli v2.94.0. Drop each entry per its own `statement:` once that
   # upstream actually rebuilds.
@@ -92,7 +93,7 @@ vulnerabilities:
     paths:
       - "usr/local/bin/bd"
     expired_at: 2026-08-07
-    statement: Go stdlib x509 hostname verification issue (CVE-2026-27145), fixed in Go 1.26.4 / 1.25.11. bd v1.0.4 is the deliberate beads repin; remove once the bundled CLI rebuilds against 1.26.4+.
+    statement: Go stdlib x509 hostname verification issue (CVE-2026-27145), fixed in Go 1.26.4 / 1.25.11. bd v1.1.0 is the deliberate beads repin (still built with Go 1.26.2); remove once the bundled CLI rebuilds against 1.26.4+.
   - id: CVE-2026-27145
     paths:
       - "usr/local/bin/dolt"
@@ -183,25 +184,9 @@ vulnerabilities:
       - "usr/local/bin/dolt"
     expired_at: 2026-08-07
     statement: Dolt v2.1.7 still bundles golang.org/x/crypto v0.48.0; remove once upstream rebuilds against the fixed release.
-  # HIGH severity, fixed upstream. Both CVEs below are present ONLY via the
-  # deliberate steveyegge/beads v1.0.4 repin (v1.0.5 has data corruption) in the
-  # bundled bd CLI binary. bd is a local CLI: the affected apache/thrift and
-  # go-jose/go-jose/v4 code paths are non-network in this usage (no thrift RPC
-  # server, no JWE handling). Waiver expires when gascity moves off bd 1.0.4
-  # (tracking: move gascity off bd v1.0.4). Do not bump bd here.
-  - id: CVE-2026-41602
-    paths:
-      - "usr/local/bin/bd"
-    expired_at: 2026-08-07
-    statement: "HIGH, fixed upstream (apache/thrift). Present only via the deliberate steveyegge/beads v1.0.4 repin (v1.0.5 has data corruption), in the bundled bd CLI binary on non-network thrift paths. Remove when gascity moves off bd 1.0.4 (tracking: move gascity off bd v1.0.4)."
-  - id: CVE-2026-34986
-    paths:
-      - "usr/local/bin/bd"
-    expired_at: 2026-08-07
-    statement: "HIGH, fixed upstream (go-jose/go-jose/v4). Present only via the deliberate steveyegge/beads v1.0.4 repin (v1.0.5 has data corruption), in the bundled bd CLI binary on non-network JWE paths. Remove when gascity moves off bd 1.0.4 (tracking: move gascity off bd v1.0.4)."
   # The golang.org/x/net (HTML/idna/http2) and golang.org/x/crypto/ssh CVEs in
   # the same series the dolt entries above waive are also reported against the
-  # bd CLI binary (steveyegge/beads v1.0.4 repin, external), the gc binary
+  # bd CLI binary (steveyegge/beads v1.1.0, external), the gc binary
   # (indirect golang.org/x/net v0.52.0 / golang.org/x/crypto v0.49.0), and the
   # external kubectl binary (golang.org/x/net v0.49.0; the gc-controller image
   # adds kubectl on top of the agent image). With set -e the Container Scan
@@ -218,42 +203,42 @@ vulnerabilities:
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
     expired_at: 2026-08-07
-    statement: golang.org/x/net HTML parsing DoS; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+    statement: golang.org/x/net HTML parsing DoS; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-25681
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
     expired_at: 2026-08-07
-    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-27136
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
     expired_at: 2026-08-07
-    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-39821
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
     expired_at: 2026-08-07
-    statement: golang.org/x/net/idna issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+    statement: golang.org/x/net/idna issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-42502
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
     expired_at: 2026-08-07
-    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-42506
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
       - "usr/local/bin/kubectl"
     expired_at: 2026-08-07
-    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
+    statement: golang.org/x/net HTML rendering issue; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0), gc (indirect x/net v0.52.0), and kubectl (external, x/net v0.49.0). Remove once bd/kubectl rebuild upstream and gc bumps golang.org/x/net >= 0.55.0.
   - id: CVE-2026-33814
     paths:
       - "usr/local/bin/gc"
@@ -264,52 +249,52 @@ vulnerabilities:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
     expired_at: 2026-08-07
-    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39828
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
     expired_at: 2026-08-07
-    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39829
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
     expired_at: 2026-08-07
-    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39830
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
     expired_at: 2026-08-07
-    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39832
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
     expired_at: 2026-08-07
-    statement: golang.org/x/crypto/ssh/agent CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+    statement: golang.org/x/crypto/ssh/agent CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-39835
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
     expired_at: 2026-08-07
-    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-42508
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
     expired_at: 2026-08-07
-    statement: golang.org/x/crypto/ssh/knownhosts CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+    statement: golang.org/x/crypto/ssh/knownhosts CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-46595
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
     expired_at: 2026-08-07
-    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
   - id: CVE-2026-46597
     paths:
       - "usr/local/bin/bd"
       - "usr/local/bin/gc"
     expired_at: 2026-08-07
-    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.0.4 repin) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.
+    statement: golang.org/x/crypto/ssh CVE; base-pre-existing (also red on main 2026-06-24). Present in bd (beads v1.1.0) and gc (indirect x/crypto v0.49.0). Remove once bd rebuilds and gc bumps golang.org/x/crypto >= 0.52.0.

--- a/deps.env
+++ b/deps.env
@@ -6,7 +6,7 @@
 
 DOLT_VERSION=2.1.7
 BD_REPO=gastownhall/beads
-BD_VERSION=v1.0.4
+BD_VERSION=v1.1.0
 BR_VERSION=0.1.20
 
 # Cross-version contract-test matrix pins.


### PR DESCRIPTION
## Why

`go.mod` already links **beads v1.1.0** — #3921 bumped it 3 days ago. But that PR moved only the linked library and left the **bundled `bd` CLI binary** pinned at `v1.0.4` in `deps.env`, re-opening the exact library↔CLI version skew #3921 set out to close (`native_store_unavailable (gate=version_compat)`). This brings the CLI up to match.

## What

**Bundled bd bump (commit 1)**
- `deps.env`: `BD_VERSION` `v1.0.4` → `v1.1.0` (the single source of truth).
- All 7 workflows that pin `BD_VERSION` (14 assignments) updated in lockstep — enforced by `scripts/bd_version_pin_test.go::TestBDVersionPins`.
- `install-bd-archive.sh`: added the four **v1.1.0** release SHA-256 pins (linux/darwin × amd64/arm64), each verified by downloading the `gastownhall/beads` tarball and hashing it.
- `BD_PREV_VERSION` stays `v1.0.4` (the min-supported contract-matrix floor), so `bdMinVersion`, `bdReadyProjectionMinVersion`, and the `bd_compatibility` enum are unchanged.

**Security-waiver reconcile (commit 2)**
Diffing a trivy v0.70.0 (CI-pinned scanner, fresh DB) scan of bd v1.1.0 vs v1.0.4 shows the bump clears **exactly two** bd-only HIGH CVEs and adds **none**:
- `CVE-2026-41602` — apache/thrift `v0.19.0` → `v0.23.0` → **waiver dropped**
- `CVE-2026-34986` — go-jose/go-jose/v4 `v4.1.3` → `v4.1.4` → **waiver dropped**

The x/net (`v0.52.0`), x/crypto (`v0.49.0`), and Go 1.26.2 stdlib sets are unchanged in v1.1.0, so those waivers stay — retexted `beads v1.0.4 repin` → `v1.1.0`. The dolt-scoped thrift waiver (thrift `v0.13.1`) is unrelated and untouched.

## Verification (local)

- `go test ./scripts -run 'TestBDVersionPins|TestScanPinAssignments'` ✅ (proves `deps.env` ↔ workflow pins ↔ SHA table are in lockstep)
- `install-bd-archive.sh v1.1.0` end-to-end: downloads, SHA-verifies via the pinned path (no API fallback), prints `bd version 1.1.0` ✅
- `trivy rootfs --severity HIGH,CRITICAL --ignore-unfixed --ignorefile .trivyignore.yaml --exit-code 1` on the bd v1.1.0 binary → **0 findings** ✅
- `go vet ./scripts` + `go build ./cmd/gc` ✅

## Non-goals (follow-ups)

- **Contract bleeding-edge cell** (`BD_CURRENT_VERSION=v1.1.0-rc.1`, `BD_CURRENT_REF`): now stale since final v1.1.0 shipped, but advancing it must move in lockstep with the vendored corpus per the contract-test coordination protocol — out of scope here.
- **Corpus refresh** (`make sync-bd-corpus`): the decoder test is offline/version-tolerant, so not required for green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)