### PR TITLE
chore(k8s): add lsof + util-linux to the agent base image

### DIFF
--- a/contrib/k8s/Dockerfile.base
+++ b/contrib/k8s/Dockerfile.base
@@ -21,10 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     jq \
+    lsof \
     procps \
     python3 \
     sudo \
     tmux \
+    util-linux \
     && rm -rf /var/lib/apt/lists/*
 
 COPY .github/scripts/install-claude-native.sh /tmp/install-claude-native.sh

--- a/contrib/k8s/Dockerfile.base
+++ b/contrib/k8s/Dockerfile.base
@@ -21,11 +21,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     jq \
+    # lsof: TCP-LISTEN / port discovery for Dolt — runtime hard dep (gc doctor), not optional diagnostics.
     lsof \
     procps \
     python3 \
     sudo \
     tmux \
+    # util-linux: provides flock(1) for the bd/Dolt beads lock — runtime hard dep, not optional diagnostics.
     util-linux \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What

Adds \`lsof\` and \`util-linux\` to \`contrib/k8s/Dockerfile.base\`.

## Why

\`gc\` discovers live process/port state via \`lsof\` (the "no status files — query live state" principle), so \`gc init\` / \`gc start\` need it at runtime; the agent base did not carry it. \`util-linux\` provides standard utilities (e.g. \`setpriv\`/\`flock\`) used by the pod entrypoint when it creates a dynamic user and drops privileges.

Two-line dependency addition; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)