### PR TITLE
fix(bd-env): mirror GC_DOLT_CRED_CMD into BEADS_DOLT_CREDENTIAL_COMMAND

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1431,7 +1431,7 @@ func cityRuntimeProcessEnvWithError(cityPath string) ([]string, error) {
 				clearProjectedDoltEnv(source)
 			}
 		}
-		keys := execProjectedBackendEnvKeys()
+		keys := execProjectedBackendCopyKeys()
 		keys = append(keys, "BEADS_DOLT_AUTO_START")
 		for _, key := range keys {
 			if value, ok := source[key]; ok {
@@ -1522,6 +1522,18 @@ func mirrorBeadsDoltEnv(env map[string]string) {
 	// BEADS_DOLT_CREDENTIAL_COMMAND here (map value wins, else the ambient value
 	// of either key) so bd authenticates the same way the in-process native store
 	// does.
+	//
+	// Two intentional asymmetries with the sibling BEADS_DOLT_* branches above,
+	// kept deliberately (do not "normalize" them into the map->map convention):
+	//  1. Ambient fallback: this is the only branch that reads process env
+	//     (os.Getenv), because a controller commonly exports only the helper and
+	//     never seeds it into the projected map.
+	//  2. Preserve-not-clear: when no source exists this branch leaves any
+	//     existing target value untouched instead of deleting/emptying it. The
+	//     siblings clear their target to defeat stale tmux inheritance; the
+	//     credential key is instead preserved from ambient by
+	//     preserveHostedBeadsCredentialEnv on the slice-merge paths, so clearing
+	//     it here would fight that pass.
 	if cred := strings.TrimSpace(env["GC_DOLT_CRED_CMD"]); cred != "" {
 		env["BEADS_DOLT_CREDENTIAL_COMMAND"] = cred
 	} else if cred := strings.TrimSpace(env["BEADS_DOLT_CREDENTIAL_COMMAND"]); cred != "" {

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1507,6 +1507,30 @@ func mirrorBeadsDoltEnv(env map[string]string) {
 	} else {
 		delete(env, "BEADS_DOLT_PASSWORD")
 	}
+	// Carry the hosted beads-gateway credential command into the projected env.
+	// bd authenticates to the gateway by running the helper named in
+	// BEADS_DOLT_CREDENTIAL_COMMAND; without it bd falls back to the static/root
+	// user and the gateway rejects the connection (MySQL Error 1045). That key
+	// contains "CREDENTIAL", so execenv.FilterInherited strips it from every
+	// gc-spawned bd subprocess and agent session. preserveHostedBeadsCredentialEnv
+	// re-adds it on the slice-merge paths (overlayEnvEntries / mergeRuntimeEnv),
+	// but only when it is already present in the pre-filter environ and only on
+	// those paths — the agent session env is built from this projected map, which
+	// does not carry the ambient value, and a controller that exports the helper
+	// under only the non-sensitive GC_DOLT_CRED_CMD (which survives filtering) has
+	// nothing for that pass to preserve. Mirror GC_DOLT_CRED_CMD into
+	// BEADS_DOLT_CREDENTIAL_COMMAND here (map value wins, else the ambient value
+	// of either key) so bd authenticates the same way the in-process native store
+	// does.
+	if cred := strings.TrimSpace(env["GC_DOLT_CRED_CMD"]); cred != "" {
+		env["BEADS_DOLT_CREDENTIAL_COMMAND"] = cred
+	} else if cred := strings.TrimSpace(env["BEADS_DOLT_CREDENTIAL_COMMAND"]); cred != "" {
+		env["BEADS_DOLT_CREDENTIAL_COMMAND"] = cred
+	} else if ambient := strings.TrimSpace(os.Getenv("GC_DOLT_CRED_CMD")); ambient != "" {
+		env["BEADS_DOLT_CREDENTIAL_COMMAND"] = ambient
+	} else if ambient := strings.TrimSpace(os.Getenv("BEADS_DOLT_CREDENTIAL_COMMAND")); ambient != "" {
+		env["BEADS_DOLT_CREDENTIAL_COMMAND"] = ambient
+	}
 }
 
 // cityForStoreDir resolves ambient store contexts. GC_CITY intentionally wins

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -5506,6 +5506,19 @@ func TestMirrorBeadsDoltEnvPropagatesCredentialCommand(t *testing.T) {
 			t.Fatalf("BEADS_DOLT_CREDENTIAL_COMMAND = %q, want %q (map GC_DOLT_CRED_CMD wins)", got, "/map/helper")
 		}
 	})
+	t.Run("map BEADS_DOLT_CREDENTIAL_COMMAND wins over ambient GC_DOLT_CRED_CMD", func(t *testing.T) {
+		// Locks the branch-2-over-branch-3 precedence: an explicit map
+		// BEADS_DOLT_CREDENTIAL_COMMAND must beat an ambient GC_DOLT_CRED_CMD.
+		// Without this a branches-2/3 reorder would silently flip precedence and
+		// still pass every other subtest.
+		t.Setenv("GC_DOLT_CRED_CMD", "/ambient/helper")
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "")
+		env := map[string]string{"GC_DOLT_HOST": "gw.beads.example", "BEADS_DOLT_CREDENTIAL_COMMAND": "/map/helper"}
+		mirrorBeadsDoltEnv(env)
+		if got := env["BEADS_DOLT_CREDENTIAL_COMMAND"]; got != "/map/helper" {
+			t.Fatalf("BEADS_DOLT_CREDENTIAL_COMMAND = %q, want %q (explicit map value wins over ambient GC_DOLT_CRED_CMD)", got, "/map/helper")
+		}
+	})
 	t.Run("absent when no credential command anywhere", func(t *testing.T) {
 		t.Setenv("GC_DOLT_CRED_CMD", "")
 		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "")

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -5460,3 +5460,59 @@ func TestReapStaleBdExportJSONLLeavesFileOnUnmanagedScope(t *testing.T) {
 		t.Fatalf("jsonl removed on unmanaged scope; stat err = %v, want nil", err)
 	}
 }
+
+// TestMirrorBeadsDoltEnvPropagatesCredentialCommand covers the hosted
+// beads-gateway credential helper. bd authenticates by running the command in
+// BEADS_DOLT_CREDENTIAL_COMMAND; that key contains "CREDENTIAL" so
+// execenv.FilterInherited strips it from every gc-spawned bd subprocess and
+// agent session, and the gateway then rejects the root fallback with Error
+// 1045. The controller entrypoint also exports the same helper under the
+// non-sensitive GC_DOLT_CRED_CMD (which survives filtering), so
+// mirrorBeadsDoltEnv must re-derive BEADS_DOLT_CREDENTIAL_COMMAND from it.
+func TestMirrorBeadsDoltEnvPropagatesCredentialCommand(t *testing.T) {
+	t.Run("from GC_DOLT_CRED_CMD in the map", func(t *testing.T) {
+		t.Setenv("GC_DOLT_CRED_CMD", "")
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "")
+		env := map[string]string{"GC_DOLT_HOST": "gw.beads.example", "GC_DOLT_CRED_CMD": "/usr/local/bin/eia-helper"}
+		mirrorBeadsDoltEnv(env)
+		if got := env["BEADS_DOLT_CREDENTIAL_COMMAND"]; got != "/usr/local/bin/eia-helper" {
+			t.Fatalf("BEADS_DOLT_CREDENTIAL_COMMAND = %q, want %q (from GC_DOLT_CRED_CMD)", got, "/usr/local/bin/eia-helper")
+		}
+	})
+	t.Run("from ambient GC_DOLT_CRED_CMD when map is unset", func(t *testing.T) {
+		t.Setenv("GC_DOLT_CRED_CMD", "/usr/local/bin/eia-helper")
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "")
+		env := map[string]string{"GC_DOLT_HOST": "gw.beads.example"}
+		mirrorBeadsDoltEnv(env)
+		if got := env["BEADS_DOLT_CREDENTIAL_COMMAND"]; got != "/usr/local/bin/eia-helper" {
+			t.Fatalf("BEADS_DOLT_CREDENTIAL_COMMAND = %q, want %q (from ambient GC_DOLT_CRED_CMD)", got, "/usr/local/bin/eia-helper")
+		}
+	})
+	t.Run("from ambient BEADS_DOLT_CREDENTIAL_COMMAND fallback", func(t *testing.T) {
+		t.Setenv("GC_DOLT_CRED_CMD", "")
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "/usr/local/bin/eia-helper")
+		env := map[string]string{"GC_DOLT_HOST": "gw.beads.example"}
+		mirrorBeadsDoltEnv(env)
+		if got := env["BEADS_DOLT_CREDENTIAL_COMMAND"]; got != "/usr/local/bin/eia-helper" {
+			t.Fatalf("BEADS_DOLT_CREDENTIAL_COMMAND = %q, want %q (from ambient fallback)", got, "/usr/local/bin/eia-helper")
+		}
+	})
+	t.Run("GC_DOLT_CRED_CMD in map wins over ambient BEADS_DOLT_CREDENTIAL_COMMAND", func(t *testing.T) {
+		t.Setenv("GC_DOLT_CRED_CMD", "")
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "/ambient/helper")
+		env := map[string]string{"GC_DOLT_HOST": "gw.beads.example", "GC_DOLT_CRED_CMD": "/map/helper"}
+		mirrorBeadsDoltEnv(env)
+		if got := env["BEADS_DOLT_CREDENTIAL_COMMAND"]; got != "/map/helper" {
+			t.Fatalf("BEADS_DOLT_CREDENTIAL_COMMAND = %q, want %q (map GC_DOLT_CRED_CMD wins)", got, "/map/helper")
+		}
+	})
+	t.Run("absent when no credential command anywhere", func(t *testing.T) {
+		t.Setenv("GC_DOLT_CRED_CMD", "")
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "")
+		env := map[string]string{"GC_DOLT_HOST": "gw.beads.example"}
+		mirrorBeadsDoltEnv(env)
+		if got, ok := env["BEADS_DOLT_CREDENTIAL_COMMAND"]; ok && got != "" {
+			t.Fatalf("BEADS_DOLT_CREDENTIAL_COMMAND = %q, want unset/empty", got)
+		}
+	})
+}

--- a/cmd/gc/hosted_beads_gateway_test.go
+++ b/cmd/gc/hosted_beads_gateway_test.go
@@ -191,3 +191,53 @@ dolt.user: orchestrator
 		t.Fatalf("managed-catalog lister was called for an external dolt endpoint; the SHOW DATABASES guard must be skipped")
 	}
 }
+
+// TestCityRuntimeProcessEnvProjectsHostedBeadsCredentialCommand pins the
+// exec-provider / city process-env projection path. mirrorBeadsDoltEnv derives
+// BEADS_DOLT_CREDENTIAL_COMMAND for a controller that exports only the
+// non-sensitive GC_DOLT_CRED_CMD, but cityRuntimeProcessEnvWithError copies the
+// resolved source map through a backend-key whitelist. That whitelist
+// (execProjectedBackendEnvKeys) omits the credential command because it is a
+// preserve-from-ambient passthrough key, not a strip-and-reproject projectedDolt
+// key — so before execProjectedBackendCopyKeys carried it, a GC_DOLT_CRED_CMD-only
+// controller silently dropped the helper on the projected process env and bd fell
+// back to the root user (gateway Error 1045). The ambient BEADS_DOLT_CREDENTIAL_COMMAND
+// is left unset here so preserveHostedBeadsCredentialEnv has nothing to fall back
+// on: the projection is the only channel that can carry the derived value.
+func TestCityRuntimeProcessEnvProjectsHostedBeadsCredentialCommand(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT_CRED_CMD", "/usr/local/bin/eia-helper")
+	t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "")
+	_ = os.Unsetenv("BEADS_DOLT_CREDENTIAL_COMMAND")
+	for _, k := range []string{"GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER", "GC_DOLT_PASSWORD"} {
+		t.Setenv(k, "")
+		_ = os.Unsetenv(k)
+	}
+
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: e2e
+gc.endpoint_origin: city_canonical
+gc.endpoint_status: verified
+dolt.auto-start: false
+dolt.host: gw.beads.example.com
+dolt.port: 3306
+dolt.user: orchestrator
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !cityUsesBdStoreContract(cityPath) {
+		t.Fatalf("precondition: expected cityUsesBdStoreContract(cityPath)=true for the default bd provider")
+	}
+
+	env, err := cityRuntimeProcessEnvWithError(cityPath)
+	if err != nil {
+		t.Fatalf("cityRuntimeProcessEnvWithError() error = %v", err)
+	}
+	if got := hostedEnvEntriesToMap(env)["BEADS_DOLT_CREDENTIAL_COMMAND"]; got != "/usr/local/bin/eia-helper" {
+		t.Fatalf("BEADS_DOLT_CREDENTIAL_COMMAND = %q, want %q (projected from ambient GC_DOLT_CRED_CMD)", got, "/usr/local/bin/eia-helper")
+	}
+}

--- a/cmd/gc/store_target_exec.go
+++ b/cmd/gc/store_target_exec.go
@@ -37,8 +37,29 @@ func setExecProjectedBackendEnvEmpty(env map[string]string) {
 	applyBdContributorRoutingOptOut(env)
 }
 
+// execProjectedBackendCopyKeys returns the keys carried when projecting a
+// resolved backend env map onto an exec-provider / city process env. It extends
+// execProjectedBackendEnvKeys with BEADS_DOLT_CREDENTIAL_COMMAND, the hosted
+// beads-gateway credential helper mirrorBeadsDoltEnv derives from
+// GC_DOLT_CRED_CMD.
+//
+// That key is intentionally NOT in projectedDoltEnvKeys: it is a
+// preserve-from-ambient passthrough key (hostedBeadsCredentialPassthroughKeys),
+// not a strip-and-reproject key. Forcing it into projectedDoltEnvKeys would
+// break the mergeRuntimeEnv strip symmetry TestProjectedKeysCoverage pins and
+// collide with preserveHostedBeadsCredentialEnv. But the whitelist COPY paths
+// must still carry the derived value, or a controller that exports only the
+// non-sensitive GC_DOLT_CRED_CMD loses the helper on projected exec/process
+// envs and bd falls back to the root user (gateway Error 1045). The empty-set
+// path (setExecProjectedBackendEnvEmpty) deliberately keeps the original key
+// set so it never blanks an ambient credential command for providers that skip
+// the copy.
+func execProjectedBackendCopyKeys() []string {
+	return append(execProjectedBackendEnvKeys(), "BEADS_DOLT_CREDENTIAL_COMMAND")
+}
+
 func copyExecProjectedBackendEnv(dst, src map[string]string) {
-	for _, key := range execProjectedBackendEnvKeys() {
+	for _, key := range execProjectedBackendCopyKeys() {
 		if value, ok := src[key]; ok {
 			dst[key] = value
 		}


### PR DESCRIPTION
## Summary

`bd` authenticates to a hosted beads-gateway by running the helper named in `BEADS_DOLT_CREDENTIAL_COMMAND`. That key contains `CREDENTIAL`, so `execenv.FilterInherited` strips it from every gc-spawned `bd` subprocess and agent session, and the gateway then rejects the static/root fallback with MySQL `Error 1045 (28000): access denied`.

`preserveHostedBeadsCredentialEnv` already re-adds the key on the slice-merge env paths (`overlayEnvEntries` / `mergeRuntimeEnv`), but only when it is already present in the pre-filter environ and only on those paths. Two residual gaps remain:

- the agent session env is projected from the `mirrorBeadsDoltEnv` map, which does not carry the ambient value; and
- a controller that exports the helper under only the non-sensitive `GC_DOLT_CRED_CMD` (which survives filtering) has nothing for that pass to preserve.

This mirrors `GC_DOLT_CRED_CMD` into `BEADS_DOLT_CREDENTIAL_COMMAND` inside `mirrorBeadsDoltEnv` (map value wins, else the ambient value of either key), so gc-spawned `bd` authenticates the same way the in-process native store does. It mirrors the existing `GC_DOLT_*` -> `BEADS_DOLT_*` handling in the same function.

## Testing

- [x] `go test ./cmd/gc/ -run TestMirrorBeadsDoltEnvPropagatesCredentialCommand` (new; 5 subtests)
- [x] `go vet ./cmd/gc/`
- [ ] `make check` (full pre-push shard suite ran; the only failure was `TestMuxSource_YieldsAndPicksUpNewCity` in `internal/eventfeed`, a pre-existing timing flake unrelated to this change — passes in isolation)
- [ ] `make check-docs` — n/a (no docs/nav/links changed)

## Checklist

- [x] Linked an issue, or explained why one is not needed — no issue; a small, self-contained hosted-gateway credential-projection fix
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — n/a (internal env projection)
- [ ] Called out breaking changes or migration notes — none
