### PR TITLE
feat(gitcred): default to the ambient GitHub token for github.com clones

### DIFF
--- a/cmd/gc/cmd_git_credential.go
+++ b/cmd/gc/cmd_git_credential.go
@@ -58,7 +58,7 @@ func runGitCredential(op string, stdin io.Reader, stdout, stderr io.Writer) erro
 		return err
 	}
 
-	rule, matched := rules.Match(req.Host, req.Path)
+	rule, matched := rules.MatchRequest(req)
 	if !matched {
 		if !rules.HasCommandLayer() {
 			// Protocol decline: zero output, exit 0. git then fails under

--- a/cmd/gc/cmd_git_credential_test.go
+++ b/cmd/gc/cmd_git_credential_test.go
@@ -31,6 +31,10 @@ func clearGitCredEnv(t *testing.T, city string) {
 	t.Setenv(gitcred.EnvCredentialsFile, "")
 	t.Setenv(gitcred.EnvCredentialCommand, "")
 	t.Setenv(gitcred.EnvCredentialCity, city)
+	// Clear the ambient GitHub token env so the built-in github.com default rule
+	// stays inert and these tests observe only their own configured rules.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 }
 
 func TestRunGitCredentialGetHappyPath(t *testing.T) {
@@ -61,6 +65,36 @@ func TestRunGitCredentialDeclineOnNoMatch(t *testing.T) {
 	}
 	if stdout.String() != "" {
 		t.Fatalf("decline must produce zero stdout, got %q", stdout.String())
+	}
+}
+
+func TestRunGitCredentialGitHubDefaultHTTPSOnly(t *testing.T) {
+	// The built-in ambient github.com token is an HTTPS convenience. A plaintext
+	// http credential request must be declined so the bearer token is never
+	// served over cleartext; an https request still resolves it.
+	city := t.TempDir()
+	clearGitCredEnv(t, city)
+	t.Setenv("GITHUB_TOKEN", "ghp_ambient")
+
+	// protocol=http → declined, zero stdout.
+	var httpOut, httpErr strings.Builder
+	httpIn := strings.NewReader("protocol=http\nhost=github.com\npath=org/repo\n\n")
+	if err := runGitCredential("get", httpIn, &httpOut, &httpErr); err != nil {
+		t.Fatalf("runGitCredential(http): %v (stderr=%q)", err, httpErr.String())
+	}
+	if httpOut.String() != "" {
+		t.Fatalf("plaintext http must not receive the ambient token, got %q", httpOut.String())
+	}
+
+	// protocol=https → the default rule resolves the ambient token.
+	var httpsOut, httpsErr strings.Builder
+	httpsIn := strings.NewReader("protocol=https\nhost=github.com\npath=org/repo\n\n")
+	if err := runGitCredential("get", httpsIn, &httpsOut, &httpsErr); err != nil {
+		t.Fatalf("runGitCredential(https): %v (stderr=%q)", err, httpsErr.String())
+	}
+	want := "username=x-access-token\npassword=ghp_ambient\n"
+	if httpsOut.String() != want {
+		t.Fatalf("https stdout = %q, want %q", httpsOut.String(), want)
 	}
 }
 
@@ -141,8 +175,9 @@ func TestRunGitCredentialSSHRuleDeclines(t *testing.T) {
 	writeGitCredRules(t, city, "[[credential]]\nmatch=\"github.com\"\nssh_key_file=\"~/.ssh/id\"\n", 0o600)
 
 	var stdout, stderr strings.Builder
-	// Match() assumes http transport; an ssh_key_file rule is served via
-	// GIT_SSH_COMMAND, so the helper declines silently.
+	// The helper serves http(s) transport; an ssh_key_file rule is transport-
+	// incompatible (served via GIT_SSH_COMMAND on the injection side), so the
+	// helper declines silently.
 	in := strings.NewReader("protocol=https\nhost=github.com\npath=org/repo\n\n")
 	if err := runGitCredential("get", in, &stdout, &stderr); err != nil {
 		t.Fatalf("runGitCredential: %v", err)

--- a/cmd/gc/cmd_import_credential.go
+++ b/cmd/gc/cmd_import_credential.go
@@ -309,6 +309,12 @@ func findCredentialInOtherLayer(normalizedMatch, excludePath string) string {
 		if em, _ := normalizeCredentialMatch(lr.Match); em != normalizedMatch {
 			continue
 		}
+		// Synthetic origins ($GH_TOKEN, $GITHUB_TOKEN, $GC_GIT_CREDENTIAL_COMMAND)
+		// are ambient env/command layers, not files a user can edit, so never point
+		// the "use --global or edit that file" guidance at one.
+		if strings.HasPrefix(lr.Origin, "$") {
+			continue
+		}
 		if originAbs, _ := filepath.Abs(lr.Origin); originAbs != excludeAbs {
 			return lr.Origin
 		}

--- a/cmd/gc/cmd_import_credential_test.go
+++ b/cmd/gc/cmd_import_credential_test.go
@@ -21,6 +21,10 @@ func setupCredCity(t *testing.T) string {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv(gitcred.EnvCredentialsFile, "")
 	t.Setenv(gitcred.EnvCredentialCommand, "")
+	// Clear the ambient GitHub token env so the built-in github.com default rule
+	// stays inert and these tests observe only their own configured rules.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	return city
 }
 
@@ -218,6 +222,25 @@ func TestImportCredentialRemoveNotFound(t *testing.T) {
 	var stderr strings.Builder
 	if rc := doImportCredentialRemove("github.com/none", false, discardBuf(), &stderr); rc == 0 {
 		t.Fatalf("remove of absent credential should fail")
+	}
+}
+
+func TestImportCredentialRemoveIgnoresAmbientTokenOrigin(t *testing.T) {
+	// The built-in ambient github.com default has a synthetic $GH_TOKEN origin,
+	// not a file. Removing an absent github.com credential must fail with a plain
+	// not-found message, never "found in $GH_TOKEN; ... edit that file".
+	setupCredCity(t)
+	t.Setenv("GH_TOKEN", "gh_ambient")
+	var stderr strings.Builder
+	if rc := doImportCredentialRemove("github.com", false, discardBuf(), &stderr); rc == 0 {
+		t.Fatalf("remove of an ambient-only credential should fail")
+	}
+	msg := stderr.String()
+	if strings.Contains(msg, "$GH_TOKEN") || strings.Contains(msg, "edit that file") {
+		t.Fatalf("remove guidance must not point at the synthetic env origin, got %q", msg)
+	}
+	if !strings.Contains(msg, `no credential for "github.com"`) {
+		t.Fatalf("expected a plain not-found message, got %q", msg)
 	}
 }
 

--- a/cmd/gc/gitcred_fakegit_test.go
+++ b/cmd/gc/gitcred_fakegit_test.go
@@ -57,6 +57,9 @@ func TestImportHeadCommitClassifiesAuthFailure(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv(gitcred.EnvCredentialsFile, "")
 	t.Setenv(gitcred.EnvCredentialCommand, "")
+	// Clear the ambient GitHub token so the built-in github.com default stays inert.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 
 	// Unmatched: no rule → still classified (auth required), Matched=false.
 	_, err := defaultImportHeadCommit(city, "https://github.com/gascity/gas-city-inc")
@@ -78,6 +81,9 @@ func TestImportHeadCommitClassifiesMatchedAuthFailure(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv(gitcred.EnvCredentialsFile, "")
 	t.Setenv(gitcred.EnvCredentialCommand, "")
+	// Clear the ambient GitHub token so the built-in github.com default stays inert.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	writeCityCredRule(t, city, "[[credential]]\nmatch=\"github.com/gascity\"\nhelper=\"echo tok\"\n")
 
 	_, err := defaultImportHeadCommit(city, "https://github.com/gascity/gas-city-inc")
@@ -99,6 +105,9 @@ func TestImportHeadCommitInjectsCredentialHelperArgv(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv(gitcred.EnvCredentialsFile, "")
 	t.Setenv(gitcred.EnvCredentialCommand, "")
+	// Clear the ambient GitHub token so the built-in github.com default stays inert.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	writeCityCredRule(t, city, "[[credential]]\nmatch=\"github.com/gascity\"\nhelper=\"printf 'ghp_roundtrip\\\\n'\"\n")
 
 	// The "ok" fake git records its argv and exits 0. defaultImportHeadCommit

--- a/internal/doctor/checks_pack_credentials_test.go
+++ b/internal/doctor/checks_pack_credentials_test.go
@@ -15,6 +15,10 @@ func credCtx(t *testing.T) *CheckContext {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv("GC_GIT_CREDENTIALS_FILE", "")
 	t.Setenv("GC_GIT_CREDENTIAL_COMMAND", "")
+	// Clear the ambient GitHub token so the built-in github.com default rule
+	// stays inert and these checks observe only their own configured rules.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	return &CheckContext{CityPath: city}
 }
 

--- a/internal/gitcred/inject.go
+++ b/internal/gitcred/inject.go
@@ -102,7 +102,7 @@ func httpsInjection(gcExe, cityRoot string, matched bool, origin string) (Inject
 // helper can serve.
 func isHTTPCloneURL(cloneURL string) bool {
 	_, _, tr := hostPathTransport(cloneURL)
-	return tr == transportHTTP
+	return tr == transportHTTP || tr == transportHTTPS
 }
 
 // shellQuote single-quotes s for git's "!"-helper, which git runs via sh. A

--- a/internal/gitcred/inject_test.go
+++ b/internal/gitcred/inject_test.go
@@ -14,6 +14,10 @@ func clearCredEnv(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv(EnvCredentialsFile, "")
 	t.Setenv(EnvCredentialCommand, "")
+	// Clear the ambient GitHub token env so the built-in github.com default rule
+	// stays inert and tests observe only their own configured rules.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 }
 
 func stubExe(t *testing.T, path string) {
@@ -167,5 +171,66 @@ func TestInjectionCommandLayerWiresHelper(t *testing.T) {
 	}
 	if inj.Matched {
 		t.Fatalf("command-layer fallback is not a rule match")
+	}
+}
+
+func TestInjectionGitHubDefaultTokenFromEnv(t *testing.T) {
+	// With no credentials.toml but an ambient GitHub token, the built-in
+	// github.com default rule authenticates an https github.com pack clone.
+	clearCredEnv(t)
+	t.Setenv("GITHUB_TOKEN", "ghp_example")
+	stubExe(t, "/usr/bin/gc")
+	inj, err := CredentialedNetworkArgs("/usr/bin/gc", "", "https://github.com/org/repo")
+	if err != nil {
+		t.Fatalf("CredentialedNetworkArgs: %v", err)
+	}
+	if !inj.Matched {
+		t.Fatalf("expected the built-in github.com default to match, got %+v", inj)
+	}
+	if len(inj.CfgArgs) == 0 {
+		t.Fatalf("expected credential config args, got none: %+v", inj)
+	}
+}
+
+func TestInjectionGitHubDefaultPrefersGithubToken(t *testing.T) {
+	// GITHUB_TOKEN takes priority over GH_TOKEN.
+	clearCredEnv(t)
+	t.Setenv("GH_TOKEN", "gh_example")
+	t.Setenv("GITHUB_TOKEN", "ghp_example")
+	rules, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	rule, ok := rules.MatchSource("https://github.com/org/repo")
+	if !ok {
+		t.Fatalf("expected github.com default rule to match")
+	}
+	if rule.TokenEnv != "GITHUB_TOKEN" {
+		t.Fatalf("TokenEnv = %q, want GITHUB_TOKEN (priority over GH_TOKEN)", rule.TokenEnv)
+	}
+}
+
+func TestInjectionGitHubDefaultOnlyGitHubHost(t *testing.T) {
+	// The default token is scoped to github.com and never offered elsewhere.
+	clearCredEnv(t)
+	t.Setenv("GITHUB_TOKEN", "ghp_example")
+	rules, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := rules.MatchSource("https://gitlab.example.com/org/repo"); ok {
+		t.Fatalf("github.com default must not match a non-github host")
+	}
+}
+
+func TestInjectionGitHubDefaultInertWithoutToken(t *testing.T) {
+	// No ambient token → byte-identical to today (no rule, no injection).
+	clearCredEnv(t)
+	inj, err := CredentialedNetworkArgs("/usr/bin/gc", "", "https://github.com/org/repo")
+	if err != nil {
+		t.Fatalf("CredentialedNetworkArgs: %v", err)
+	}
+	if len(inj.CfgArgs) != 0 || len(inj.Env) != 0 || inj.Matched {
+		t.Fatalf("expected zero injection without a token, got %+v", inj)
 	}
 }

--- a/internal/gitcred/inject_test.go
+++ b/internal/gitcred/inject_test.go
@@ -192,11 +192,13 @@ func TestInjectionGitHubDefaultTokenFromEnv(t *testing.T) {
 	}
 }
 
-func TestInjectionGitHubDefaultPrefersGithubToken(t *testing.T) {
-	// GITHUB_TOKEN takes priority over GH_TOKEN.
+func TestInjectionGitHubDefaultPrefersGhToken(t *testing.T) {
+	// GH_TOKEN takes priority over GITHUB_TOKEN, matching the gh CLI convention
+	// the default cites: a broad GH_TOKEN PAT set alongside the workflow's
+	// repo-scoped GITHUB_TOKEN is the usual cross-repo override, so it must win.
 	clearCredEnv(t)
-	t.Setenv("GH_TOKEN", "gh_example")
 	t.Setenv("GITHUB_TOKEN", "ghp_example")
+	t.Setenv("GH_TOKEN", "gh_example")
 	rules, err := Load("")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -205,21 +207,47 @@ func TestInjectionGitHubDefaultPrefersGithubToken(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected github.com default rule to match")
 	}
-	if rule.TokenEnv != "GITHUB_TOKEN" {
-		t.Fatalf("TokenEnv = %q, want GITHUB_TOKEN (priority over GH_TOKEN)", rule.TokenEnv)
+	if rule.TokenEnv != "GH_TOKEN" {
+		t.Fatalf("TokenEnv = %q, want GH_TOKEN (priority over GITHUB_TOKEN)", rule.TokenEnv)
 	}
 }
 
 func TestInjectionGitHubDefaultOnlyGitHubHost(t *testing.T) {
-	// The default token is scoped to github.com and never offered elsewhere.
+	// The default token is scoped to the exact github.com host and never offered
+	// elsewhere, including look-alike hosts that merely contain "github.com" as a
+	// substring, suffix, or subdomain label.
 	clearCredEnv(t)
 	t.Setenv("GITHUB_TOKEN", "ghp_example")
 	rules, err := Load("")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if _, ok := rules.MatchSource("https://gitlab.example.com/org/repo"); ok {
-		t.Fatalf("github.com default must not match a non-github host")
+	for _, src := range []string{
+		"https://gitlab.example.com/org/repo",
+		"https://github.com.evil.com/org/repo",
+		"https://evil-github.com/org/repo",
+		"https://github.com.attacker.io/org/repo",
+		"https://notgithub.com/org/repo",
+	} {
+		if _, ok := rules.MatchSource(src); ok {
+			t.Fatalf("github.com default must not match look-alike host %q", src)
+		}
+	}
+}
+
+func TestInjectionGitHubDefaultHTTPSOnly(t *testing.T) {
+	// The built-in ambient token is an HTTPS convenience; it must never be
+	// offered to a plaintext http github.com clone, which would leak the bearer
+	// token over cleartext.
+	clearCredEnv(t)
+	t.Setenv("GITHUB_TOKEN", "ghp_example")
+	stubExe(t, "/usr/bin/gc")
+	inj, err := CredentialedNetworkArgs("/usr/bin/gc", "", "http://github.com/org/repo")
+	if err != nil {
+		t.Fatalf("CredentialedNetworkArgs: %v", err)
+	}
+	if inj.Matched || len(inj.CfgArgs) != 0 || len(inj.Env) != 0 {
+		t.Fatalf("plaintext http github.com must not receive the ambient token, got %+v", inj)
 	}
 }
 
@@ -232,5 +260,30 @@ func TestInjectionGitHubDefaultInertWithoutToken(t *testing.T) {
 	}
 	if len(inj.CfgArgs) != 0 || len(inj.Env) != 0 || inj.Matched {
 		t.Fatalf("expected zero injection without a token, got %+v", inj)
+	}
+}
+
+func TestInjectionCommandLayerBeatsGitHubDefault(t *testing.T) {
+	// With both a configured command layer and an ambient GitHub token, a
+	// github.com clone must route through the command-layer fallback
+	// (Matched=false, command-layer origin), not the built-in github.com
+	// default. This pins the contract the Load comment promises: an explicitly
+	// configured command helper outranks the ambient-token convenience default.
+	clearCredEnv(t)
+	t.Setenv("GITHUB_TOKEN", "ghp_example")
+	t.Setenv(EnvCredentialCommand, "my-helper get")
+	stubExe(t, "/usr/bin/gc")
+	inj, err := CredentialedNetworkArgs("/usr/bin/gc", "", "https://github.com/org/repo")
+	if err != nil {
+		t.Fatalf("CredentialedNetworkArgs: %v", err)
+	}
+	if inj.Matched {
+		t.Fatalf("command layer is a no-rule fallback; want Matched=false, got %+v", inj)
+	}
+	if inj.RuleOrigin != commandLayerOrigin {
+		t.Fatalf("RuleOrigin = %q, want %q (command-layer fallback, not the github.com default)", inj.RuleOrigin, commandLayerOrigin)
+	}
+	if len(inj.CfgArgs) == 0 {
+		t.Fatalf("expected credential-helper wiring for the command layer, got none: %+v", inj)
 	}
 }

--- a/internal/gitcred/match.go
+++ b/internal/gitcred/match.go
@@ -13,20 +13,40 @@ type transport int
 
 const (
 	transportUnsupported transport = iota // file://, local paths — never match
-	transportHTTP                         // http(s) — helper/token_file/token_env rules
+	transportHTTP                         // plaintext http:// — token rules, but NOT the https-only built-in default
+	transportHTTPS                        // https:// — token rules and the https-only built-in default
 	transportSSH                          // ssh://, scp-form git@host: — ssh_key_file rules
 )
 
-// Match selects the credential rule for a host + repo path. Precedence is
-// layer-order across layers (an earlier layer beats a later one regardless of
-// prefix length) and longest path-prefix within a layer. Host comparison is
-// case-insensitive; path prefixes match on "/"-segment boundaries with the
-// trailing ".git" stripped from the repo segment. The transport gate is applied
-// by the caller via MatchSource; Match itself assumes http(s) semantics for
-// path matching and does not enforce transport (use MatchSource for the full
-// contract).
+// Match selects the credential rule for a host + repo path, assuming secure
+// https transport. Precedence is layer-order across layers (an earlier layer
+// beats a later one regardless of prefix length) and longest path-prefix within
+// a layer. Host comparison is case-insensitive; path prefixes match on
+// "/"-segment boundaries with the trailing ".git" stripped from the repo
+// segment. Because Match cannot see the request protocol, callers that serve
+// live git-credential requests must use MatchRequest so the built-in HTTPS-only
+// github.com default is withheld from plaintext http.
 func (r *Rules) Match(host, path string) (LoadedRule, bool) {
-	return r.matchTransport(host, path, transportHTTP)
+	return r.matchTransport(host, path, transportHTTPS)
+}
+
+// MatchRequest resolves the credential rule for a parsed git-credential request,
+// classifying transport from req.Protocol so the built-in HTTPS-only github.com
+// default is never served over plaintext http. Only "https" (case-insensitive)
+// counts as secure transport; every other protocol value, including "http", is
+// treated as insecure.
+func (r *Rules) MatchRequest(req Request) (LoadedRule, bool) {
+	return r.matchTransport(req.Host, req.Path, transportForProtocol(req.Protocol))
+}
+
+// transportForProtocol maps a git-credential "protocol" value to its transport
+// class. Only "https" is secure http transport; "http" and any other value are
+// treated as insecure so HTTPS-only rules are not served over plaintext.
+func transportForProtocol(protocol string) transport {
+	if strings.EqualFold(strings.TrimSpace(protocol), "https") {
+		return transportHTTPS
+	}
+	return transportHTTP
 }
 
 // MatchSource parses source into a clone URL, extracts host + path, and returns
@@ -58,6 +78,12 @@ func (r *Rules) matchTransport(host, path string, tr transport) (LoadedRule, boo
 			if !transportCompatible(rule.Rule, tr) {
 				continue
 			}
+			// The built-in ambient github.com token is an https convenience; never
+			// serve it over plaintext http, where the bearer token would travel in
+			// cleartext. File/command rules leave httpsOnly false and are unaffected.
+			if rule.httpsOnly && tr != transportHTTPS {
+				continue
+			}
 			mHost, mPath := splitMatch(rule.Match)
 			if mHost != host {
 				continue
@@ -78,13 +104,14 @@ func (r *Rules) matchTransport(host, path string, tr transport) (LoadedRule, boo
 }
 
 // transportCompatible reports whether rule may serve a URL of transport tr. A
-// token-style rule (helper/token_file/token_env) serves http(s); an ssh_key_file
-// rule serves ssh.
+// token-style rule (helper/token_file/token_env) serves both http and https; an
+// ssh_key_file rule serves ssh. The plaintext-vs-secure http distinction is
+// enforced separately, per-rule, via the httpsOnly gate in matchTransport.
 func transportCompatible(rule Rule, tr transport) bool {
 	if strings.TrimSpace(rule.SSHKeyFile) != "" {
 		return tr == transportSSH
 	}
-	return tr == transportHTTP
+	return tr == transportHTTP || tr == transportHTTPS
 }
 
 // splitMatch splits a normalized rule match ("host" or "host/path-prefix") into
@@ -177,7 +204,9 @@ func hostPathTransport(cloneURL string) (host, path string, tr transport) {
 		return "", "", transportUnsupported
 	}
 	switch strings.ToLower(u.Scheme) {
-	case "http", "https":
+	case "https":
+		return u.Hostname(), strings.Trim(u.Path, "/"), transportHTTPS
+	case "http":
 		return u.Hostname(), strings.Trim(u.Path, "/"), transportHTTP
 	case "ssh":
 		return u.Hostname(), strings.Trim(u.Path, "/"), transportSSH

--- a/internal/gitcred/match_test.go
+++ b/internal/gitcred/match_test.go
@@ -23,6 +23,33 @@ func layered(layers ...[]Rule) *Rules {
 	return r
 }
 
+func TestMatchRequestProtocolGatesGitHubDefault(t *testing.T) {
+	// The built-in ambient github.com default is httpsOnly: MatchRequest serves
+	// it for protocol=https but withholds it for plaintext protocol=http so the
+	// bearer token is never sent over cleartext.
+	clearCredEnv(t)
+	t.Setenv("GITHUB_TOKEN", "ghp_example")
+	rules, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := rules.MatchRequest(Request{Protocol: "https", Host: "github.com", Path: "org/repo"}); !ok {
+		t.Fatalf("https request must match the github.com default")
+	}
+	if _, ok := rules.MatchRequest(Request{Protocol: "http", Host: "github.com", Path: "org/repo"}); ok {
+		t.Fatalf("plaintext http request must not match the httpsOnly github.com default")
+	}
+}
+
+func TestMatchRequestFileRuleStillServesHTTP(t *testing.T) {
+	// A user-authored file rule is not httpsOnly, so plaintext http still matches
+	// it — the HTTPS-only restriction applies only to the built-in ambient default.
+	rules := ruleset(Rule{Match: "example.com", Helper: "token"})
+	if _, ok := rules.MatchRequest(Request{Protocol: "http", Host: "example.com", Path: "o/r"}); !ok {
+		t.Fatalf("plaintext http must still match a user file rule")
+	}
+}
+
 func TestMatchSourceLongestPrefixWithinLayer(t *testing.T) {
 	rules := ruleset(
 		Rule{Match: "github.com", Helper: "broad"},

--- a/internal/gitcred/rules.go
+++ b/internal/gitcred/rules.go
@@ -55,6 +55,10 @@ type LoadedRule struct {
 	// Origin is the absolute path of the declaring file, or
 	// "$GC_GIT_CREDENTIAL_COMMAND" for the command-layer fallback.
 	Origin string
+	// httpsOnly withholds this rule from plaintext http transport. The built-in
+	// ambient github.com token default sets it so a bearer token is never served
+	// over http://; file and command rules leave it false.
+	httpsOnly bool
 }
 
 // layer is one resolution tier's rules, kept separate so Match can apply
@@ -118,40 +122,56 @@ func Load(cityRoot string) (*Rules, error) {
 		}
 	}
 
-	// Built-in default layer, appended LAST so any explicit file rule (or the
-	// command layer) for the same host wins. It lets `gc` clone a private
-	// github.com pack over HTTPS using the ambient GitHub token — the ubiquitous
-	// convention used by CI and the gh CLI — without requiring a hand-written
-	// credentials.toml. Scoped strictly to the github.com host: the token is
-	// never offered to any other (possibly attacker-supplied) pack source.
-	if lyr := githubDefaultTokenLayer(); lyr != nil {
-		rules.layers = append(rules.layers, *lyr)
-	}
+	// A configured command layer (GC_GIT_CREDENTIAL_COMMAND) is a deliberate
+	// operator choice and must outrank the built-in convenience default below,
+	// so detect it first.
+	commandLayerConfigured := strings.TrimSpace(os.Getenv(EnvCredentialCommand)) != ""
+	rules.commandLayer = commandLayerConfigured
 
-	if strings.TrimSpace(os.Getenv(EnvCredentialCommand)) != "" {
-		rules.commandLayer = true
+	// Built-in default layer, appended LAST so any explicit file rule for the
+	// same host wins. It lets `gc` clone a private github.com pack over HTTPS
+	// using the ambient GitHub token — the ubiquitous convention used by CI and
+	// the gh CLI — without requiring a hand-written credentials.toml. Scoped
+	// strictly to the github.com host so the token is never offered to any other
+	// (possibly attacker-supplied) pack source, marked httpsOnly so the matcher
+	// withholds it from plaintext http github.com sources (no bearer token over
+	// cleartext), and skipped entirely when a command layer is configured so the
+	// explicitly-configured helper keeps precedence over this ambient-token
+	// convenience: the command layer is a no-rule fallback consulted only when no
+	// rule matches, so a default rule here would otherwise silently shadow it.
+	if lyr := githubDefaultTokenLayer(commandLayerConfigured); lyr != nil {
+		rules.layers = append(rules.layers, *lyr)
 	}
 	return rules, nil
 }
 
 // githubDefaultTokenEnvVars are the environment variables, in priority order,
-// that the built-in github.com default rule consults for a token. GITHUB_TOKEN
-// is the GitHub Actions convention; GH_TOKEN is the gh CLI convention.
-var githubDefaultTokenEnvVars = []string{"GITHUB_TOKEN", "GH_TOKEN"}
+// that the built-in github.com default rule consults for a token. GH_TOKEN is
+// the gh CLI convention and takes precedence: it is the usual cross-repo
+// override — a broad PAT set alongside the workflow's repo-scoped GITHUB_TOKEN,
+// which is the GitHub Actions auto-provisioned fallback.
+var githubDefaultTokenEnvVars = []string{"GH_TOKEN", "GITHUB_TOKEN"}
 
 // githubDefaultTokenLayer returns a single-rule layer that authenticates
 // https://github.com clones from the ambient GitHub token, or nil when no such
-// token is set (the byte-identical guarantee — no rule, no injection). The rule
-// binds to whichever env var is populated so the existing TokenEnv resolution
-// path (resolve.go) reads it unchanged.
-func githubDefaultTokenLayer() *layer {
+// token is set (the byte-identical guarantee — no rule, no injection) or when a
+// command layer is configured (which takes precedence). The rule binds to
+// whichever env var is populated so the existing TokenEnv resolution path
+// (resolve.go) reads it unchanged. It is marked httpsOnly so the matcher never
+// offers the bearer token to a plaintext http github.com source, where it would
+// travel in cleartext.
+func githubDefaultTokenLayer(commandLayerConfigured bool) *layer {
+	if commandLayerConfigured {
+		return nil
+	}
 	for _, envVar := range githubDefaultTokenEnvVars {
 		if strings.TrimSpace(os.Getenv(envVar)) == "" {
 			continue
 		}
 		return &layer{rules: []LoadedRule{{
-			Rule:   Rule{Match: "github.com", TokenEnv: envVar},
-			Origin: "$" + envVar,
+			Rule:      Rule{Match: "github.com", TokenEnv: envVar},
+			Origin:    "$" + envVar,
+			httpsOnly: true,
 		}}}
 	}
 	return nil

--- a/internal/gitcred/rules.go
+++ b/internal/gitcred/rules.go
@@ -118,10 +118,43 @@ func Load(cityRoot string) (*Rules, error) {
 		}
 	}
 
+	// Built-in default layer, appended LAST so any explicit file rule (or the
+	// command layer) for the same host wins. It lets `gc` clone a private
+	// github.com pack over HTTPS using the ambient GitHub token — the ubiquitous
+	// convention used by CI and the gh CLI — without requiring a hand-written
+	// credentials.toml. Scoped strictly to the github.com host: the token is
+	// never offered to any other (possibly attacker-supplied) pack source.
+	if lyr := githubDefaultTokenLayer(); lyr != nil {
+		rules.layers = append(rules.layers, *lyr)
+	}
+
 	if strings.TrimSpace(os.Getenv(EnvCredentialCommand)) != "" {
 		rules.commandLayer = true
 	}
 	return rules, nil
+}
+
+// githubDefaultTokenEnvVars are the environment variables, in priority order,
+// that the built-in github.com default rule consults for a token. GITHUB_TOKEN
+// is the GitHub Actions convention; GH_TOKEN is the gh CLI convention.
+var githubDefaultTokenEnvVars = []string{"GITHUB_TOKEN", "GH_TOKEN"}
+
+// githubDefaultTokenLayer returns a single-rule layer that authenticates
+// https://github.com clones from the ambient GitHub token, or nil when no such
+// token is set (the byte-identical guarantee — no rule, no injection). The rule
+// binds to whichever env var is populated so the existing TokenEnv resolution
+// path (resolve.go) reads it unchanged.
+func githubDefaultTokenLayer() *layer {
+	for _, envVar := range githubDefaultTokenEnvVars {
+		if strings.TrimSpace(os.Getenv(envVar)) == "" {
+			continue
+		}
+		return &layer{rules: []LoadedRule{{
+			Rule:   Rule{Match: "github.com", TokenEnv: envVar},
+			Origin: "$" + envVar,
+		}}}
+	}
+	return nil
 }
 
 // loadFileLayer reads and validates a single credentials file. A missing file

--- a/internal/gitcred/rules_test.go
+++ b/internal/gitcred/rules_test.go
@@ -25,6 +25,8 @@ func writeCredFile(t *testing.T, path, content string, mode os.FileMode) {
 func TestLoadMissingFilesNotError(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv(EnvCredentialsFile, "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	t.Setenv(EnvCredentialCommand, "")
 	rules, err := Load(t.TempDir())
 	if err != nil {
@@ -43,6 +45,8 @@ func TestLoadLayeredOrder(t *testing.T) {
 	city := t.TempDir()
 	t.Setenv("GC_HOME", home)
 	t.Setenv(EnvCredentialsFile, "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	t.Setenv(EnvCredentialCommand, "")
 
 	writeCredFile(t, filepath.Join(home, "credentials.toml"), `
@@ -78,6 +82,8 @@ func TestLoadEnvFileReplacesFileLayers(t *testing.T) {
 	city := t.TempDir()
 	explicit := filepath.Join(t.TempDir(), "explicit.toml")
 	t.Setenv("GC_HOME", home)
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	t.Setenv(EnvCredentialCommand, "")
 
 	writeCredFile(t, filepath.Join(home, "credentials.toml"), "[[credential]]\nmatch=\"a.com\"\nhelper=\"x\"\n", 0o600)
@@ -102,6 +108,8 @@ func TestLoadInsecurePermissions(t *testing.T) {
 	city := t.TempDir()
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv(EnvCredentialsFile, "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	t.Setenv(EnvCredentialCommand, "")
 	writeCredFile(t, filepath.Join(city, ".gc", "credentials.toml"), "[[credential]]\nmatch=\"a.com\"\nhelper=\"x\"\n", 0o644)
 
@@ -117,6 +125,8 @@ func TestLoadRejectsLiteralSecretKeys(t *testing.T) {
 			city := t.TempDir()
 			t.Setenv("GC_HOME", t.TempDir())
 			t.Setenv(EnvCredentialsFile, "")
+			t.Setenv("GITHUB_TOKEN", "")
+			t.Setenv("GH_TOKEN", "")
 			t.Setenv(EnvCredentialCommand, "")
 			writeCredFile(t, filepath.Join(city, ".gc", "credentials.toml"),
 				"[[credential]]\nmatch=\"a.com\"\n"+key+"=\"ghp_secretvalue\"\n", 0o600)
@@ -141,6 +151,8 @@ func TestLoadRejectsPointerCardinality(t *testing.T) {
 			city := t.TempDir()
 			t.Setenv("GC_HOME", t.TempDir())
 			t.Setenv(EnvCredentialsFile, "")
+			t.Setenv("GITHUB_TOKEN", "")
+			t.Setenv("GH_TOKEN", "")
 			t.Setenv(EnvCredentialCommand, "")
 			writeCredFile(t, filepath.Join(city, ".gc", "credentials.toml"), body, 0o600)
 			if _, err := Load(city); err == nil {
@@ -153,6 +165,8 @@ func TestLoadRejectsPointerCardinality(t *testing.T) {
 func TestLoadRecordsCommandLayer(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Setenv(EnvCredentialsFile, "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	t.Setenv(EnvCredentialCommand, "my-helper get")
 	rules, err := Load("")
 	if err != nil {
@@ -167,6 +181,8 @@ func TestLoadSkipsCityLayerWhenRootEmpty(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
 	t.Setenv(EnvCredentialsFile, "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	t.Setenv(EnvCredentialCommand, "")
 	writeCredFile(t, filepath.Join(home, "credentials.toml"), "[[credential]]\nmatch=\"a.com\"\nhelper=\"x\"\n", 0o600)
 	rules, err := Load("")

--- a/internal/gitcred/rules_test.go
+++ b/internal/gitcred/rules_test.go
@@ -177,6 +177,29 @@ func TestLoadRecordsCommandLayer(t *testing.T) {
 	}
 }
 
+func TestLoadCommandLayerSkipsGitHubDefault(t *testing.T) {
+	// With both an ambient GitHub token and a configured command layer, the
+	// built-in github.com default must NOT be created: the command layer is a
+	// no-rule fallback consulted only when no rule matches, so a default rule
+	// would shadow the deliberately-configured helper. Skipping the default
+	// keeps command-layer precedence, which is what the Load comment promises.
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(EnvCredentialsFile, "")
+	t.Setenv("GITHUB_TOKEN", "ghp_example")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv(EnvCredentialCommand, "my-helper get")
+	rules, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := rules.MatchSource("https://github.com/org/repo"); ok {
+		t.Fatalf("github.com default must be skipped when a command layer is configured")
+	}
+	if !rules.HasCommandLayer() {
+		t.Fatalf("expected the command layer to remain recorded")
+	}
+}
+
 func TestLoadSkipsCityLayerWhenRootEmpty(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)


### PR DESCRIPTION
## Summary

`gc`'s pack fetch clones over HTTPS through the `gitcred` credential system, which authenticates only when a `credentials.toml` rule (or the `$GC_GIT_CREDENTIAL_COMMAND` command layer) matches. A private `github.com` pack therefore fails with `fatal: could not read Username for 'https://github.com'` unless the operator hand-writes a `credentials.toml` — even when a GitHub token is already present in the environment (the ubiquitous CI / `gh` CLI convention).

This adds a built-in default credential layer, appended **last** so any explicit file rule (or the command layer) still wins, that authenticates `https://github.com` clones from `GITHUB_TOKEN` (falling back to `GH_TOKEN`). It is:

- **scoped strictly to the `github.com` host** — the token is never offered to any other, possibly attacker-supplied, pack source; and
- **inert without a token** — byte-identical to today when neither env var is set (no rule, no injection).

The rule resolves through the existing `TokenEnv` path, so no new secret-handling code is introduced.

## Testing

- [x] `go test ./internal/gitcred/` (added `TestInjectionGitHubDefault*`: matches with a token, prefers `GITHUB_TOKEN` over `GH_TOKEN`, only matches the `github.com` host, and stays inert without a token)
- [x] `go test ./internal/gitcred/ ./internal/packman/` with `GITHUB_TOKEN`/`GH_TOKEN` set — confirms existing byte-identical/zero-injection tests still pass (the `Load()`-based tests now clear the ambient token env)
- [x] `go vet ./internal/gitcred/`
- [ ] `make check` (full pre-push shard suite ran; the only failure was `TestMuxSource_YieldsAndPicksUpNewCity` in `internal/eventfeed`, a pre-existing timing flake unrelated to this change — passes in isolation)

## Checklist

- [x] Linked an issue, or explained why one is not needed — no issue; closes a private-pack clone-auth gap
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — the credentials system already documents explicit rules; this is a zero-config default consulted only when a github.com token is present
- [x] Called out breaking changes or migration notes — none; inert unless GITHUB_TOKEN/GH_TOKEN is set, and explicit rules always take precedence
