### PR TITLE
feat(config): gc config explain renders idle/lifecycle-timeout agent keys (#3965)

### DIFF
--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -627,6 +627,24 @@ func explainAgent(w io.Writer, a *config.Agent, prov *config.Provenance) {
 			explainField(w, "drain_timeout", a.DrainTimeout, source)
 		}
 	}
+
+	// Lifecycle timeouts. These resolved keys drive idle-suspend and
+	// session-age recycling but were previously omitted from explain output,
+	// forcing operators to read their provenance from the pack agent.toml
+	// directly (#3965). Only render keys that are set, matching the
+	// conditional pattern used for the fields above.
+	if a.IdleTimeout != "" {
+		explainField(w, "idle_timeout", a.IdleTimeout, source)
+	}
+	if a.SleepAfterIdle != "" {
+		explainField(w, "sleep_after_idle", a.SleepAfterIdle, source)
+	}
+	if a.MaxSessionAge != "" {
+		explainField(w, "max_session_age", a.MaxSessionAge, source)
+	}
+	if a.MaxSessionAgeJitter != "" {
+		explainField(w, "max_session_age_jitter", a.MaxSessionAgeJitter, source)
+	}
 }
 
 // doConfigExplainProvider explains a single provider's resolved chain.

--- a/cmd/gc/cmd_config_explain_idle_test.go
+++ b/cmd/gc/cmd_config_explain_idle_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestExplainAgentRendersLifecycleTimeoutKeys guards #3965: gc config explain
+// agent blocks omitted the idle/lifecycle-timeout keys (idle_timeout,
+// sleep_after_idle, max_session_age, max_session_age_jitter) entirely, so their
+// resolved values and provenance had to be read from the pack agent.toml
+// directly. Each set key must now render a row.
+func TestExplainAgentRendersLifecycleTimeoutKeys(t *testing.T) {
+	const source = "/city/packs/refinery/agent.toml"
+	agent := config.Agent{
+		Name:                "refinery",
+		IdleTimeout:         "15m",
+		SleepAfterIdle:      "30m",
+		MaxSessionAge:       "6h",
+		MaxSessionAgeJitter: "10m",
+	}
+	prov := config.Provenance{
+		Root:   source,
+		Agents: map[string]string{agent.QualifiedName(): source},
+	}
+
+	var buf bytes.Buffer
+	explainAgent(&buf, &agent, &prov)
+	out := buf.String()
+
+	for _, want := range []struct{ key, value string }{
+		{"idle_timeout", "15m"},
+		{"sleep_after_idle", "30m"},
+		{"max_session_age", "6h"},
+		{"max_session_age_jitter", "10m"},
+	} {
+		if !strings.Contains(out, want.key) {
+			t.Errorf("explain output missing key %q; got:\n%s", want.key, out)
+			continue
+		}
+		if !strings.Contains(out, want.value) {
+			t.Errorf("explain output missing value %q for key %q; got:\n%s", want.value, want.key, out)
+		}
+	}
+}
+
+// TestExplainAgentOmitsUnsetLifecycleTimeoutKeys confirms the new rows follow
+// the existing conditional pattern: keys left empty produce no row (no spurious
+// "= " lines for unconfigured timeouts).
+func TestExplainAgentOmitsUnsetLifecycleTimeoutKeys(t *testing.T) {
+	agent := config.Agent{Name: "plain"}
+	prov := config.Provenance{Root: "/city/city.toml"}
+
+	var buf bytes.Buffer
+	explainAgent(&buf, &agent, &prov)
+	out := buf.String()
+
+	for _, key := range []string{"idle_timeout", "sleep_after_idle", "max_session_age", "max_session_age_jitter"} {
+		if strings.Contains(out, key) {
+			t.Errorf("explain output should omit unset key %q; got:\n%s", key, out)
+		}
+	}
+}


### PR DESCRIPTION
## What

`gc config explain <agent>` omitted the resolved idle/lifecycle-timeout keys
from its agent block, so their values and provenance had to be read from the
pack `agent.toml` directly. This adds rows for the four timeout keys that are
set on an agent:

- `idle_timeout`         (Agent.IdleTimeout)
- `sleep_after_idle`     (Agent.SleepAfterIdle)
- `max_session_age`      (Agent.MaxSessionAge)
- `max_session_age_jitter` (Agent.MaxSessionAgeJitter)

## Why

Reported in #3965: `explainAgent` renders name/dir/provider/scaling/etc. but no
idle rows, even when a refinery agent configures both `idle_timeout` and
`sleep_after_idle`. These keys drive idle-suspend (compute_awake_set) and
session-age recycling, so their resolved value + source file matter when
debugging why a session slept or was recycled — exactly what `explain` exists
to surface.

## Scope

Intentionally scoped to the idle/lifecycle-timeout cluster the issue names,
rather than dumping every `config.Agent` field. `explainAgent` renders a curated
subset today; a blanket "render all resolved keys" change is a larger,
separate design call (field ordering, truncation of slice/map fields, whether
`toml:"-"` internals should ever appear). Happy to follow up on that if the
maintainers want it — this PR closes the concrete idle-provenance gap with the
minimal, consistent addition.

## How

Each key follows the existing conditional `explainField(w, key, value, source)`
pattern — a key is rendered only when set, so unconfigured agents get no
spurious rows.

## Test

`TestExplainAgentRendersLifecycleTimeoutKeys` — an agent with all four keys set
renders a row (key + value) for each. Reverting the fix reproduces the reported
"missing key" symptom (RED).
`TestExplainAgentOmitsUnsetLifecycleTimeoutKeys` — an agent with none set
renders no timeout rows (guards the conditional pattern).

Validated with `-tags gms_pure_go`: gofmt clean, `go vet` clean, targeted +
`ConfigExplain|ConfigShow|ExplainAgent` suites green.