### PR TITLE
refactor(demand): consolidate control-dispatcher pending-work probe into one rule

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -765,7 +765,10 @@ func buildDesiredStateWithSessionBeads(
 		subPhaseStart = time.Now()
 		unassignedRoutedBeads, unassignedRoutedStores := collectOpenUnassignedRoutedWork(cfg, store, rigStores, suspendedRigPaths, stderr)
 		canonicalizeLegacyBoundUnassignedRoutedWork(cfg, unassignedRoutedBeads, unassignedRoutedStores, stderr)
-		controlDispatcherOpenDemand := openControlDispatcherDemand(cfg, unassignedRoutedBeads)
+		singletonPending := singletonPendingDemand{
+			aliasToCanonical: deterministicControlDispatcherRouteAliases(cfg),
+			workBeads:        unassignedRoutedBeads,
+		}
 		recordDemandSubPhase(trace, "demand_snapshot.collect_unassigned_routed", subPhaseStart, map[string]any{
 			"beads": len(unassignedRoutedBeads),
 		})
@@ -813,16 +816,17 @@ func buildDesiredStateWithSessionBeads(
 				scaleCheckDemandByTemplate[template] = mergeScaleCheckDemand(scaleCheckDemandByTemplate[template], defaultDemand[template], count)
 			}
 		}
-		if len(controlDispatcherOpenDemand) > 0 {
-			if scaleCheckCounts == nil {
-				scaleCheckCounts = make(map[string]int)
-			}
-			for template, hasDemand := range controlDispatcherOpenDemand {
-				if hasDemand && scaleCheckCounts[template] < 1 {
-					scaleCheckCounts[template] = 1
-				}
-			}
+		// Singleton pending-work pass: fold the deterministic control-dispatcher
+		// pending-work floor into the one pool-demand count. This is the readiness-
+		// independent half the Ready()-gated demand above cannot express — a
+		// blocked open control bead — so an idle singleton stays warm to finish it
+		// instead of draining and never respawning (#3454). Runs on the merged
+		// scaleCheckCounts so it covers both default-probe and custom-scale_check
+		// control dispatchers; clamped to one slot per template.
+		if scaleCheckCounts == nil {
+			scaleCheckCounts = make(map[string]int)
 		}
+		applySingletonPendingDemand(scaleCheckCounts, singletonPending)
 		if len(defaultNamedScaleTargets) > 0 {
 			var namedErrs []error
 			var partialTemplates map[string]bool
@@ -1474,6 +1478,55 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 	return counts, partialTemplates, errs
 }
 
+// singletonPendingDemand carries the readiness-independent pending-work probe
+// for deterministic control dispatchers, folded into the single pool-demand
+// count via applySingletonPendingDemand. A control dispatcher's pending
+// work is the *not-ready* kind — an open, unassigned, routed control bead still
+// blocked on the attempt/scope it manages — which the Ready()-gated generic scan
+// deliberately excludes. Without this, a control dispatcher that goes fully idle
+// drains on demand<=0 (by design) and, because named/generic demand is computed
+// from readiness-gated signals, never respawns to finish the blocked work
+// (gastownhall/gascity#3454). Scoped to IsDeterministicControlDispatcher and
+// clamped to one slot per template so the singleton stays warm without spawning
+// {name}-N phantoms.
+type singletonPendingDemand struct {
+	// aliasToCanonical maps every route a deterministic control dispatcher
+	// answers to — its qualified name plus the pre-1.3 binding-stripped bare
+	// alias — back to its canonical qualified template key.
+	aliasToCanonical map[string]string
+	// workBeads is the cross-store set of open, unassigned, routed candidate
+	// beads already collected for the unassigned-routed re-home pass.
+	workBeads []beads.Bead
+}
+
+// deterministicControlDispatcherRouteAliases builds the route-alias -> canonical
+// template map for every deterministic control dispatcher configured on the
+// city. Pre-1.3 builds routed control beads to the binding-stripped bare name,
+// so honoring both keeps in-flight work persisted across an upgrade scaling the
+// qualified dispatcher (keyed by the template name the scaler matches).
+func deterministicControlDispatcherRouteAliases(cfg *config.City) map[string]string {
+	if cfg == nil {
+		return nil
+	}
+	aliasToCanonical := make(map[string]string)
+	for i := range cfg.Agents {
+		if !config.IsDeterministicControlDispatcher(&cfg.Agents[i]) {
+			continue
+		}
+		qualified := cfg.Agents[i].QualifiedName()
+		aliasToCanonical[qualified] = qualified
+		if bare := controlDispatcherBareRoute(qualified); bare != "" {
+			if _, taken := aliasToCanonical[bare]; !taken {
+				aliasToCanonical[bare] = qualified
+			}
+		}
+	}
+	if len(aliasToCanonical) == 0 {
+		return nil
+	}
+	return aliasToCanonical
+}
+
 func defaultScaleCheckCountsAndDemand(targets []defaultScaleCheckTarget) (map[string]int, map[string]scaleCheckDemand, map[string]bool, []error) {
 	counts := make(map[string]int, len(targets))
 	demand := make(map[string]scaleCheckDemand, len(targets))
@@ -1574,6 +1627,43 @@ func defaultScaleCheckCountsAndDemand(targets []defaultScaleCheckTarget) (map[st
 		}
 	}
 	return counts, demand, partialTemplates, errs
+}
+
+// applySingletonPendingDemand folds the deterministic control-dispatcher
+// pending-work probe into the single pool-demand count. For each open,
+// unassigned, routed candidate whose route resolves to a configured control
+// dispatcher, it raises that template's count to at least one so the singleton
+// stays warm to drain the queue. It is deliberately readiness-independent (the
+// pending control bead may still be blocked) yet still requires an actual
+// open+unassigned routed bead: an in_progress or already-assigned bead — a state
+// a control bead never reaches (open -> closed with an empty assignee, see
+// internal/dispatch/control.go) — raises no demand, so no worker-unclaimable
+// shape can hold a phantom singleton awake. The clamp to one preserves the
+// singleton invariant; drain-on-idle (isPoolExcess/beginSessionDrain) is
+// untouched.
+func applySingletonPendingDemand(counts map[string]int, singleton singletonPendingDemand) {
+	if len(singleton.aliasToCanonical) == 0 || len(singleton.workBeads) == 0 || counts == nil {
+		return
+	}
+	for _, wb := range singleton.workBeads {
+		if wb.Status != "open" || strings.TrimSpace(wb.Assignee) != "" {
+			continue
+		}
+		for _, candidate := range controllerDemandRouteCandidates(wb) {
+			canonical, ok := singleton.aliasToCanonical[candidate]
+			if !ok {
+				continue
+			}
+			// Clamp to a single slot: the Ready()-gated arm may leave this
+			// template absent (count 0 for a blocked-only queue), so create the
+			// key at one; a queue of N pending control beads still drains
+			// sequentially through the one singleton.
+			if counts[canonical] < 1 {
+				counts[canonical] = 1
+			}
+			break
+		}
+	}
 }
 
 func mergeScaleCheckDemand(existing, incoming scaleCheckDemand, count int) scaleCheckDemand {
@@ -1701,47 +1791,6 @@ func controllerDemandRouteTarget(b beads.Bead, templates map[string]struct{}) st
 // stamped before root routing switched to gc.routed_to.
 func controllerDemandRouteCandidates(b beads.Bead) []string {
 	return routedToAndLegacyWorkflowCandidates(b)
-}
-
-func openControlDispatcherDemand(cfg *config.City, workBeads []beads.Bead) map[string]bool {
-	demand := make(map[string]bool)
-	if cfg == nil || len(workBeads) == 0 {
-		return demand
-	}
-	// Map every route a deterministic control dispatcher answers to — its
-	// qualified name plus the pre-1.3 binding-stripped bare alias — back to its
-	// canonical qualified template key. Pre-1.3 builds routed control beads to
-	// the bare name; honoring it keeps in-flight work persisted across an
-	// upgrade scaling the qualified dispatcher (keyed by the template name the
-	// scaler matches).
-	aliasToCanonical := make(map[string]string)
-	for i := range cfg.Agents {
-		if !config.IsDeterministicControlDispatcher(&cfg.Agents[i]) {
-			continue
-		}
-		qualified := cfg.Agents[i].QualifiedName()
-		aliasToCanonical[qualified] = qualified
-		if bare := controlDispatcherBareRoute(qualified); bare != "" {
-			if _, taken := aliasToCanonical[bare]; !taken {
-				aliasToCanonical[bare] = qualified
-			}
-		}
-	}
-	if len(aliasToCanonical) == 0 {
-		return demand
-	}
-	for _, wb := range workBeads {
-		if wb.Status != "open" || strings.TrimSpace(wb.Assignee) != "" {
-			continue
-		}
-		for _, candidate := range controllerDemandRouteCandidates(wb) {
-			if canonical, ok := aliasToCanonical[candidate]; ok {
-				demand[canonical] = true
-				break
-			}
-		}
-	}
-	return demand
 }
 
 func markScaleCheckPartialTemplate(partials map[string]bool, template string) map[string]bool {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -10983,6 +10983,92 @@ func TestBuildDesiredState_OpenBlockedControlDispatcherWorkRetainsDemand(t *test
 	}
 }
 
+// TestBuildDesiredState_ControlDispatcherDemandShapes pins the observable
+// demand contract of the consolidated singleton pending-work rule across every
+// control-bead shape. It is the regression guard that the fold neither lost the
+// real pending-work coverage nor started raising demand for a shape a worker
+// cannot claim:
+//   - open + unassigned + BLOCKED routed  -> demand 1 (the not-ready floor)
+//   - open + unassigned + READY routed     -> demand 1 (readiness-gated arm)
+//   - in_progress + assigned (dead session) -> demand 0 (a shape control beads
+//     never reach; open->closed with an empty assignee, so raising demand here
+//     would strand a phantom singleton the work_query cannot claim)
+//   - no control bead at all                -> demand 0
+func TestBuildDesiredState_ControlDispatcherDemandShapes(t *testing.T) {
+	maxActive := 1
+	newCfg := func() *config.City {
+		return &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Agents: []config.Agent{{
+				Name:              config.ControlDispatcherAgentName,
+				BindingName:       "core",
+				StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+				MaxActiveSessions: &maxActive,
+			}},
+		}
+	}
+	controlMeta := map[string]string{"gc.kind": "retry", "gc.routed_to": "core.control-dispatcher"}
+	demandFor := func(t *testing.T, seed func(store beads.Store)) int {
+		t.Helper()
+		store := beads.NewMemStore()
+		seed(store)
+		result := buildDesiredStateWithSessionBeads(
+			"test-city", t.TempDir(), time.Now().UTC(), newCfg(),
+			runtime.NewFake(), store, nil, newSessionBeadSnapshot(nil), nil, io.Discard,
+		)
+		return result.ScaleCheckCounts["core.control-dispatcher"]
+	}
+
+	t.Run("blocked open raises demand", func(t *testing.T) {
+		got := demandFor(t, func(store beads.Store) {
+			blocker, _ := store.Create(beads.Bead{Title: "blocker", Type: "task", Status: "open"})
+			control, _ := store.Create(beads.Bead{Title: "cleanup", Type: "task", Status: "open", Metadata: controlMeta})
+			if err := store.DepAdd(control.ID, blocker.ID, "blocks"); err != nil {
+				t.Fatalf("block: %v", err)
+			}
+		})
+		if got != 1 {
+			t.Fatalf("blocked-open demand = %d, want 1", got)
+		}
+	})
+
+	t.Run("ready open raises demand", func(t *testing.T) {
+		got := demandFor(t, func(store beads.Store) {
+			if _, err := store.Create(beads.Bead{Title: "cleanup", Type: "task", Status: "open", Metadata: controlMeta}); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+		})
+		if got != 1 {
+			t.Fatalf("ready-open demand = %d, want 1", got)
+		}
+	})
+
+	t.Run("in_progress assigned raises no demand", func(t *testing.T) {
+		got := demandFor(t, func(store beads.Store) {
+			c, _ := store.Create(beads.Bead{Title: "cleanup", Type: "task", Status: "open", Metadata: controlMeta})
+			ip := "in_progress"
+			assignee := "s-dead-session-12345"
+			if err := store.Update(c.ID, beads.UpdateOpts{Status: &ip, Assignee: &assignee}); err != nil {
+				t.Fatalf("update: %v", err)
+			}
+		})
+		if got != 0 {
+			t.Fatalf("in_progress+assigned demand = %d, want 0 (unclaimable shape)", got)
+		}
+	})
+
+	t.Run("no control bead raises no demand", func(t *testing.T) {
+		got := demandFor(t, func(store beads.Store) {
+			if _, err := store.Create(beads.Bead{Title: "root", Type: "task", Status: "open"}); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+		})
+		if got != 0 {
+			t.Fatalf("no-control-bead demand = %d, want 0", got)
+		}
+	})
+}
+
 // TestOpenControlDispatcherDemandHonorsBareLegacyRoute guards the upgrade gap:
 // control beads created by pre-1.3 builds route to the binding-stripped bare
 // name ("control-dispatcher"), not the qualified "core.control-dispatcher".
@@ -11007,9 +11093,13 @@ func TestOpenControlDispatcherDemandHonorsBareLegacyRoute(t *testing.T) {
 			"gc.routed_to": config.ControlDispatcherAgentName, // bare, pre-1.3 route
 		},
 	}}
-	demand := openControlDispatcherDemand(cfg, work)
-	if !demand["core.control-dispatcher"] {
-		t.Fatalf("openControlDispatcherDemand = %v, want demand keyed by qualified name from bare route", demand)
+	counts := map[string]int{}
+	applySingletonPendingDemand(counts, singletonPendingDemand{
+		aliasToCanonical: deterministicControlDispatcherRouteAliases(cfg),
+		workBeads:        work,
+	})
+	if counts["core.control-dispatcher"] != 1 {
+		t.Fatalf("applySingletonPendingDemand counts = %v, want demand keyed by qualified name from bare route", counts)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fold the parallel `openControlDispatcherDemand` probe into one first-class `applySingletonPendingDemand` pass, so there is a single pool-demand computation for deterministic control-dispatcher singletons instead of two. **No behavior change on any reachable control-bead shape** — this is a consolidation of the June-2026 stabilization (`005f3d963`) plus a regression test that pins the full demand contract.

## Background — the demand asymmetry this guards

The reconciler keys **both** drain and respawn of a deterministic `core.control-dispatcher` singleton off one pool-demand count:

- **Drain-on-idle** (`isPoolExcess`/`beginSessionDrain`, `demand<=0 → excess → drain`) is by design.
- **Respawn** demand is computed from **`Ready()`-gated** signals (`defaultScaleCheckCountsAndDemand` → `readyForControllerDemand`; named demand deliberately excludes `gc.routed_to`).

But a control dispatcher's pending work is characteristically the **not-ready** kind: an `open`, unassigned, routed control bead still *blocked* on the attempt/scope it manages (`internal/dispatch/control.go` returns `ErrControlPending` and leaves it `open`+unassigned; control beads go `open → closed` with an empty assignee and never enter an assigned/`in_progress` state). So the `Ready()`-gated arm sees nothing, demand stays 0, and a **drained singleton never respawns to finish the blocked work** — the pathology documented in `engdocs/architecture/dispatch.md` and #3454. The rig-scoped `dip/core.control-dispatcher` never exhibits it because it has continuous ready demand (the diagnostic asymmetry).

A readiness-independent floor for exactly this was first added as a **second, parallel** demand probe, `openControlDispatcherDemand` (`005f3d963`, June 2026), bolted beside the main pipeline and merged in a detached block.

## Change

- **Delete** `openControlDispatcherDemand` and its detached merge block; **add** one named pass `applySingletonPendingDemand(counts, singletonPending)` invoked once on the merged `scaleCheckCounts`, plus a small `singletonPendingDemand` struct and a `deterministicControlDispatcherRouteAliases(cfg)` helper (the alias-mapping logic extracted verbatim).
- Semantics preserved **exactly**: gated to `IsDeterministicControlDispatcher`, matches only `Status=="open" && Assignee==""` routed beads (via the shared `controllerDemandRouteCandidates`), honors the pre-1.3 binding-stripped bare route, clamps to one slot. Running on the merged counts covers both default-probe and custom-`scale_check` dispatchers.

## Why correct / preserved invariants

- **Drain-on-idle is untouched** (`isPoolExcess`/`beginSessionDrain`): idle-with-no-work still drains to zero. The rule only adds a respawn floor when a real pending routed bead exists.
- **Singleton invariant held**: clamp-to-1 means a queue of N pending control beads drains sequentially through the one session (no `{name}-N` phantoms). Provider-backed `max_active_sessions=1` singletons (refinery/witness/convoymaster) are excluded by the `IsDeterministicControlDispatcher` gate.
- **No phantom-wake**: the rule requires an `open`+unassigned routed bead. An `in_progress`/assigned shape — which control beads never reach — raises no demand, so no worker-unclaimable bead can hold a phantom singleton awake.
- **Predicate symmetry unchanged**: the generic `scale_check ↔ work_query` symmetry (`dispatch.md:145,264-270`, guarded by `TestPoolDemandPredicateSharedWithWorkQuery` / `TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics`) is not modified. The deliberate reconciler/worker asymmetry for *blocked* control work is pre-existing and storm-safe — `demand=1` holds one idle session rather than reap+respawn.

## Tests / proof

- `go build ./...`, `go vet ./cmd/gc/...`, `gofmt -l` clean.
- New `TestBuildDesiredState_ControlDispatcherDemandShapes` pins the full contract: **blocked-open = 1, ready-open = 1, in_progress+assigned = 0, no-bead = 0**.
- `TestBuildDesiredState_OpenBlockedControlDispatcherWorkRetainsDemand` (the original stabilization guard) and `TestOpenControlDispatcherDemandHonorsBareLegacyRoute` stay green, rewired onto the new helper.
- **Load-bearing proof:** neutering the rule fails the blocked-open cases (`demand 0, want 1`) while the ready-open subtest still passes — confirming the floor covers exactly the not-ready case the `Ready()`-gated arm cannot, and nothing more.
- Symmetry guards green; full `go test ./cmd/gc/... ./internal/config/... ./internal/dispatch/...` pass.

Refs #3454, #2819, #2890, #3413.
