### PR TITLE
perf(nudge): lazy-open the Dolt front door on idle poll ticks

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1739,6 +1739,68 @@ func queuedNudgeClaimableForTarget(target nudgeTarget, item queuedNudge) bool {
 	return true
 }
 
+// nudgeMaintenanceStore lazily opens the Dolt-backed nudge front-door store the
+// first time a poll helper actually has front-door work to do — i.e. the flock'd
+// state.json queue is non-empty and a recover/prune/terminalize pass may need to
+// shadow a terminal-state bead. On the common idle tick the queue is empty, the
+// maintenance passes are no-ops, and the store is never opened, so N idle
+// `gc nudge poll` sidecars no longer each dial the sql-server (~2 connections:
+// main pool + a SHOW DATABASES init probe) every 2s. See
+// TestNudgePollHelpersSkipDoltOpenOnEmptyQueue.
+//
+// It owns the handle it opens and closes exactly that handle (and only if it
+// opened one), preserving the closeBeadStoreHandle ownership contract the
+// …WithStore variants model.
+type nudgeMaintenanceStore struct {
+	cityPath string
+	opened   bool
+	store    beads.NudgesStore
+	front    *nudgequeue.Store
+}
+
+// frontForState returns the front-door handle to use for the maintenance passes
+// over state, opening the underlying store on first need. When the queue has no
+// Pending/InFlight/Dead items there is nothing for recover/prune/terminalize to
+// do, so the store is left closed and the returned front is nil — every
+// maintenance pass only dereferences front while iterating a non-empty slice, so
+// a nil front is never touched on an empty queue.
+func (m *nudgeMaintenanceStore) frontForState(state *nudgeQueueState) *nudgequeue.Store {
+	if nudgeQueueHasWork(state) {
+		m.ensureOpen()
+	}
+	return m.front
+}
+
+// ensureOpen opens the underlying store exactly once (idempotent) and returns
+// it. ack uses it directly to stamp terminal beads once it has confirmed
+// terminal items to terminalize.
+func (m *nudgeMaintenanceStore) ensureOpen() beads.NudgesStore {
+	if !m.opened {
+		m.opened = true
+		m.store = openNudgeBeadStore(m.cityPath)
+		if m.store.Store != nil {
+			m.front = nudgeFrontDoor(m.store)
+		}
+	}
+	return m.store
+}
+
+// close releases the store this frame opened (if any). It never touches a
+// caller-passed store because this type only ever holds a store it opened.
+func (m *nudgeMaintenanceStore) close() error {
+	if !m.opened {
+		return nil
+	}
+	return closeBeadStoreHandle(m.store.Store)
+}
+
+// nudgeQueueHasWork reports whether the queue holds any item a maintenance pass
+// could act on. An empty queue means recover/prune/terminalize are all no-ops,
+// so the Dolt front door need not be opened for this tick.
+func nudgeQueueHasWork(state *nudgeQueueState) bool {
+	return len(state.Pending) > 0 || len(state.InFlight) > 0 || len(state.Dead) > 0
+}
+
 func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, error) {
 	return claimDueQueuedNudgesMatching(cityPath, now, func(item queuedNudge) bool {
 		return queuedNudgeClaimableForTarget(target, item)
@@ -1746,14 +1808,11 @@ func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time
 }
 
 func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(queuedNudge) bool) ([]queuedNudge, error) {
-	store := openNudgeBeadStore(cityPath)
-	defer closeBeadStoreHandle(store.Store) //nolint:errcheck // best-effort
-	var front *nudgequeue.Store
-	if store.Store != nil {
-		front = nudgeFrontDoor(store)
-	}
+	maint := nudgeMaintenanceStore{cityPath: cityPath}
+	defer maint.close() //nolint:errcheck // best-effort
 	var claimed []queuedNudge
 	err := withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
+		front := maint.frontForState(state)
 		deadline := noMaintenanceDeadline()
 		if err := recoverExpiredInFlightNudges(state, front, now, deadline); err != nil {
 			return err
@@ -1787,16 +1846,13 @@ func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(que
 }
 
 func listQueuedNudges(cityPath, agentName string, now time.Time) ([]queuedNudge, []queuedNudge, []queuedNudge, error) {
-	store := openNudgeBeadStore(cityPath)
-	defer closeBeadStoreHandle(store.Store) //nolint:errcheck // best-effort
-	var front *nudgequeue.Store
-	if store.Store != nil {
-		front = nudgeFrontDoor(store)
-	}
+	maint := nudgeMaintenanceStore{cityPath: cityPath}
+	defer maint.close() //nolint:errcheck // best-effort
 	var pending []queuedNudge
 	var inFlight []queuedNudge
 	var dead []queuedNudge
 	err := withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
+		front := maint.frontForState(state)
 		deadline := noMaintenanceDeadline()
 		if err := recoverExpiredInFlightNudges(state, front, now, deadline); err != nil {
 			return err
@@ -1828,16 +1884,13 @@ func listQueuedNudges(cityPath, agentName string, now time.Time) ([]queuedNudge,
 }
 
 func listQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, []queuedNudge, []queuedNudge, error) {
-	store := openNudgeBeadStore(cityPath)
-	defer closeBeadStoreHandle(store.Store) //nolint:errcheck // best-effort
-	var front *nudgequeue.Store
-	if store.Store != nil {
-		front = nudgeFrontDoor(store)
-	}
+	maint := nudgeMaintenanceStore{cityPath: cityPath}
+	defer maint.close() //nolint:errcheck // best-effort
 	var pending []queuedNudge
 	var inFlight []queuedNudge
 	var dead []queuedNudge
 	err := withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
+		front := maint.frontForState(state)
 		deadline := noMaintenanceDeadline()
 		if err := recoverExpiredInFlightNudges(state, front, now, deadline); err != nil {
 			return err
@@ -2033,18 +2086,15 @@ func ackQueuedNudgesWithOutcome(cityPath string, ids []string, outcome, reason, 
 	if len(ids) == 0 {
 		return nil
 	}
-	store := openNudgeBeadStore(cityPath)
-	defer closeBeadStoreHandle(store.Store) //nolint:errcheck // best-effort
-	var front *nudgequeue.Store
-	if store.Store != nil {
-		front = nudgeFrontDoor(store)
-	}
+	maint := nudgeMaintenanceStore{cityPath: cityPath}
+	defer maint.close() //nolint:errcheck // best-effort
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		want[id] = true
 	}
 	return withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
 		now := time.Now()
+		front := maint.frontForState(state)
 		deadline := noMaintenanceDeadline()
 		if err := recoverExpiredInFlightNudges(state, front, now, deadline); err != nil {
 			return err
@@ -2075,7 +2125,10 @@ func ackQueuedNudgesWithOutcome(cityPath string, ids []string, outcome, reason, 
 		}
 		state.InFlight = inFlight
 		for _, item := range terminal {
-			if err := markQueuedNudgeTerminal(store, item, outcome, reason, commitBoundary, now); err != nil {
+			// terminal items come from a non-empty Pending/InFlight, so the
+			// store is already open; ensureOpen is idempotent and just returns
+			// the cached handle here.
+			if err := markQueuedNudgeTerminal(maint.ensureOpen(), item, outcome, reason, commitBoundary, now); err != nil {
 				return err
 			}
 		}
@@ -2087,18 +2140,15 @@ func releaseQueuedNudgeClaims(cityPath string, ids []string) error {
 	if len(ids) == 0 {
 		return nil
 	}
-	store := openNudgeBeadStore(cityPath)
-	defer closeBeadStoreHandle(store.Store) //nolint:errcheck // best-effort
-	var front *nudgequeue.Store
-	if store.Store != nil {
-		front = nudgeFrontDoor(store)
-	}
+	maint := nudgeMaintenanceStore{cityPath: cityPath}
+	defer maint.close() //nolint:errcheck // best-effort
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		want[id] = true
 	}
 	return withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
 		now := time.Now()
+		front := maint.frontForState(state)
 		deadline := noMaintenanceDeadline()
 		if err := recoverExpiredInFlightNudges(state, front, now, deadline); err != nil {
 			return err

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -4763,6 +4763,100 @@ func TestNudgePollHelpersCloseEveryStoreTheyOpen(t *testing.T) {
 	}
 }
 
+// TestNudgePollHelpersSkipDoltOpenOnEmptyQueue pins the connection-churn fix:
+// on the common idle tick the flock'd state.json queue is empty, so the per-tick
+// poll helpers must NOT open the Dolt-backed front-door store at all. Every open
+// dials ~2 sql-server connections (main pool + a SHOW DATABASES init probe); N
+// idle `gc nudge poll` sidecars each opening once per 2s tick is the measured
+// churn that pins the server. Pre-fix these helpers opened unconditionally
+// (opens == N calls); post-fix an empty queue yields opens == 0.
+func TestNudgePollHelpersSkipDoltOpenOnEmptyQueue(t *testing.T) {
+	opens, closes := installCountingNudgeStoreSeam(t)
+	dir := t.TempDir()
+	now := time.Now()
+
+	// No enqueue: the state.json queue is empty (the idle-session steady state).
+	const ticks = 5
+	for i := 0; i < ticks; i++ {
+		if _, err := claimDueQueuedNudgesMatching(dir, now, func(queuedNudge) bool { return true }); err != nil {
+			t.Fatalf("claimDueQueuedNudgesMatching: %v", err)
+		}
+		if _, _, _, err := listQueuedNudges(dir, "worker", now); err != nil {
+			t.Fatalf("listQueuedNudges: %v", err)
+		}
+		target := nudgeTarget{cityPath: dir}
+		if _, _, _, err := listQueuedNudgesForTarget(dir, target, now); err != nil {
+			t.Fatalf("listQueuedNudgesForTarget: %v", err)
+		}
+		if err := releaseQueuedNudgeClaims(dir, []string{"absent"}); err != nil {
+			t.Fatalf("releaseQueuedNudgeClaims: %v", err)
+		}
+		if err := ackQueuedNudgesWithOutcome(dir, []string{"absent"}, "injected", "", "test"); err != nil {
+			t.Fatalf("ackQueuedNudgesWithOutcome: %v", err)
+		}
+	}
+
+	if *opens != 0 {
+		t.Fatalf("empty-queue poll opened the Dolt store %d times, want 0 (idle ticks must not dial the sql-server)", *opens)
+	}
+	if *closes != 0 {
+		t.Fatalf("empty-queue poll closed a store %d times, want 0 (nothing should have been opened)", *closes)
+	}
+}
+
+// TestNudgePollHelpersOpenOnceWhenQueueHasWork pins the no-regression edge: when
+// the queue is non-empty the maintenance passes (recover/prune/terminalize) must
+// still run against Dolt, so each helper opens the front-door store exactly once
+// per call and releases it (open == close, no leak, no double-open).
+func TestNudgePollHelpersOpenOnceWhenQueueHasWork(t *testing.T) {
+	now := time.Now()
+
+	assertOneOpenOneClose := func(t *testing.T, name string, run func(dir string)) {
+		t.Helper()
+		opens, closes := installCountingNudgeStoreSeam(t)
+		dir := t.TempDir()
+		item := newQueuedNudgeWithOptions("worker", "do work", "session", now, queuedNudgeOptions{ID: "n-work"})
+		if err := enqueueQueuedNudge(dir, item); err != nil {
+			t.Fatalf("%s: enqueueQueuedNudge: %v", name, err)
+		}
+		// enqueue opened+closed its own store; measure deltas around the helper.
+		opensBefore, closesBefore := *opens, *closes
+		run(dir)
+		if got := *opens - opensBefore; got != 1 {
+			t.Fatalf("%s: opens delta=%d, want 1 (non-empty queue must open the front door exactly once)", name, got)
+		}
+		if got := *closes - closesBefore; got != 1 {
+			t.Fatalf("%s: closes delta=%d, want 1 (the opened store must be released)", name, got)
+		}
+	}
+
+	assertOneOpenOneClose(t, "claim", func(dir string) {
+		if _, err := claimDueQueuedNudgesMatching(dir, now, func(queuedNudge) bool { return false }); err != nil {
+			t.Fatalf("claimDueQueuedNudgesMatching: %v", err)
+		}
+	})
+	assertOneOpenOneClose(t, "list", func(dir string) {
+		if _, _, _, err := listQueuedNudges(dir, "worker", now); err != nil {
+			t.Fatalf("listQueuedNudges: %v", err)
+		}
+	})
+	assertOneOpenOneClose(t, "listForTarget", func(dir string) {
+		if _, _, _, err := listQueuedNudgesForTarget(dir, nudgeTarget{cityPath: dir}, now); err != nil {
+			t.Fatalf("listQueuedNudgesForTarget: %v", err)
+		}
+	})
+	assertOneOpenOneClose(t, "release", func(dir string) {
+		if err := releaseQueuedNudgeClaims(dir, []string{"absent"}); err != nil {
+			t.Fatalf("releaseQueuedNudgeClaims: %v", err)
+		}
+	})
+	assertOneOpenOneClose(t, "ack", func(dir string) {
+		if err := ackQueuedNudgesWithOutcome(dir, []string{"n-work"}, "injected", "", "test-boundary"); err != nil {
+			t.Fatalf("ackQueuedNudgesWithOutcome: %v", err)
+		}
+	})
+}
+
 // TestEnqueueQueuedNudgeWithStoreClosesOnlyOwnedStore pins the ownStore guard:
 // enqueueQueuedNudgeWithStore must close the store it opens itself (store==nil
 // path) but must NOT close a store passed in by the caller, since the caller


### PR DESCRIPTION
## Summary

On a busy town the Dolt `sql-server` sits at ~2 cores doing almost nothing but TCP accept + auth + session-init — connection churn measured at ~41 opens/sec — because every idle nudge-poll tick dials Dolt before it looks at the (non-Dolt) queue. Read `state.json` first; open the Dolt front door only when there's real maintenance work.

## Root cause

In the shipped-default legacy nudge mode (`daemon.nudge_dispatcher="legacy"`, `internal/config/config.go:2646`), one `gc nudge poll` sidecar runs per session and ticks every 2s (`defaultNudgePollInterval`, `cmd/gc/cmd_nudge.go:53`). Each idle tick, `claimDueQueuedNudgesForTarget` → `claimDueQueuedNudgesMatching` opened a fresh Dolt store **before** inspecting the queue; its siblings `listQueuedNudges` / `listQueuedNudgesForTarget` / `ackQueuedNudgesWithOutcome` / `releaseQueuedNudgeClaims` did the same.

But the queue-of-record is the flock'd `state.json` (`nudgequeue.WithState`), **not** Dolt — the store is opened only to shadow terminal-state beads during recover/prune/terminalize, which are **no-ops on an empty queue**. Each `openNudgeBeadStore` (`nudge_beads.go:37` → `openStoreAtForCity`) dials ~2 server connections (main pool + a `SHOW DATABASES` init probe). So N idle sidecars × 1 open / 2s × ~2 conns is the churn that pins the sql-server at ~2 cores. A prior fix (`TestNudgePollHelpersCloseEveryStoreTheyOpen`) made these helpers *close* what they open — but a balanced open+close every idle tick is itself the churn. The beads library documents the intended contract explicitly ("open once, reuse for the daemon's lifetime"); this per-tick open/close fights it.

## Fix

Read `state.json` first and open Dolt only when there's real front-door work. A small `nudgeMaintenanceStore` opens the store lazily on first need — gated by `nudgeQueueHasWork` (non-empty Pending/InFlight/Dead) inside the `withNudgeQueueState` transaction — and closes only a handle it opened. Idle ticks now open **zero** stores; non-empty queues open **exactly once** and run every maintenance pass unchanged. `ack`'s terminal-stamp path uses an idempotent `ensureOpen()`, so the store is present exactly when there are terminal items (which only exist when Pending/InFlight were non-empty). No signature changes to the maintenance/delivery functions, so the store-owns-vs-borrows close contract is untouched.

## Proof

- New `TestNudgePollHelpersSkipDoltOpenOnEmptyQueue`: 5 idle ticks × 5 helpers ⇒ **`opens == 0`** (pre-fix `opens == 25`, captured verbatim below).
- New `TestNudgePollHelpersOpenOnceWhenQueueHasWork`: each helper opens+closes exactly once on a non-empty queue (no regression).
- Existing `TestNudgePollHelpersCloseEveryStoreTheyOpen` (the open/close balance guard) stays green.

```
pre-fix:  cmd_nudge_test.go:4800: empty-queue poll opened the Dolt store 25 times, want 0
post-fix: PASS TestNudgePollHelpersSkipDoltOpenOnEmptyQueue / ...OpenOnceWhenQueueHasWork / ...CloseEveryStoreTheyOpen
```

`go build ./...`, `go vet ./cmd/gc/...`, `gofmt -l` clean; `go test ./cmd/gc/ -run Nudge` ok.

## Complementary operational lever

`daemon.nudge_dispatcher="supervisor"` replaces the per-session polling sidecars with a single supervised dispatcher and is the other half of the churn story. This PR fixes the shipped **legacy default** so operators aren't forced to flip modes to get a healthy sql-server.

## Risks

- A non-empty queue whose items need no bead write (e.g. all Pending still in the future) now opens a store it may not dereference — a deliberately conservative over-open that keeps behavior byte-identical to today and preserves the nil-front invariant (front is only dereferenced while iterating a non-empty slice).
- If `openNudgeBeadStore` fails, `front` stays nil exactly as before — unchanged failure semantics.
- Follow-ups (not bundled): thread the sidecar's already-open persistent handle (`cmd_nudge.go:642`) into the delivery hot path via a `…WithStore` variant to skip the single non-idle open too; adaptive idle backoff (2s→~30s, reset on `pingNudgeWakeSocket`).
