### PR TITLE
simplify(S16): surface swallowed errors on destructive/routing paths (+ F1/F2/F3 fail-closed follow-ups)

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1594,8 +1594,8 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// Handle BEFORE heal/stability to avoid false crash detection —
 		// a running session that leaves the desired set is not a crash.
 		if !desired {
-			providerAlive, err := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, session.ID)
-			if err != nil {
+			providerAlive, livenessErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, session.ID)
+			if livenessErr != nil {
 				providerAlive = false
 			}
 			// Run this before configured named-session preservation. A stale
@@ -1993,6 +1993,22 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					template := normalizedSessionTemplateInfo(infoPostHeal, cfg)
 					if template == "" {
 						template = infoPostHeal.Template
+					}
+					if livenessErr != nil {
+						// Fail CLOSED: the runtime liveness probe errored, so
+						// providerAlive=false is "observation unavailable", not
+						// "confirmed dead". Closing here would orphan a bead whose
+						// session may still be alive on a transient tmux/store blip
+						// (#3872-family). The level-triggered loop re-observes next
+						// tick; skip the destructive close for now. (The drain path
+						// above is unaffected — it only runs when providerAlive.)
+						fmt.Fprintf(stderr, "session reconciler: skipping close of '%s': liveness observation failed: %v\n", name, livenessErr) //nolint:errcheck
+						if trace != nil {
+							trace.recordDecision("reconciler.session.close_orphan", template, name, reason, "skipped_liveness_error", traceRecordPayload{
+								"liveness_error": livenessErr.Error(),
+							}, nil, "")
+						}
+						continue
 					}
 					if trace != nil {
 						trace.RecordDecision(TraceSiteReconcilerCloseOrphan, TraceReasonCode(reason), TraceOutcomeClosed, template, name, nil)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1620,6 +1620,21 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if template == "" {
 						template = info.Template
 					}
+					if livenessErr != nil {
+						// Fail CLOSED: providerAlive=false here is "observation
+						// unavailable", not "confirmed dead". Rolling back this
+						// pending-create bead when its session may still be alive on a
+						// transient tmux/store blip would orphan it (#3872-family). The
+						// level-triggered loop re-observes next tick; skip the
+						// destructive rollback for now.
+						fmt.Fprintf(stderr, "session reconciler: skipping pending-create rollback of '%s': liveness observation failed: %v\n", name, livenessErr) //nolint:errcheck
+						if trace != nil {
+							trace.recordDecision("reconciler.session.rollback_pending_create", template, name, "pending_create_lease_expired", "skipped_liveness_error", traceRecordPayload{
+								"liveness_error": livenessErr.Error(),
+							}, nil, "")
+						}
+						continue
+					}
 					peek := cachedSessionPeek(cityPath, store, sp, cfg, session.ID, nil)
 					rateLimitHit, rlBatch, rateLimitErr := checkRateLimitStability(session, cfg, providerAlive, dt, sessFront, clk, peek)
 					if rateLimitHit || rateLimitErr != nil {
@@ -1716,6 +1731,21 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					continue
 				}
 				if !providerAlive {
+					if livenessErr != nil {
+						// Fail CLOSED: providerAlive=false here is "observation
+						// unavailable", not "confirmed dead". Closing this
+						// failed-create bead when its session may still be alive on a
+						// transient tmux/store blip would orphan it (#3872-family). The
+						// level-triggered loop re-observes next tick; skip the
+						// destructive close for now.
+						fmt.Fprintf(stderr, "session reconciler: skipping failed-create close of '%s': liveness observation failed: %v\n", name, livenessErr) //nolint:errcheck
+						if trace != nil {
+							trace.recordDecision("reconciler.session.close_failed_create", template, name, string(sessionpkg.StateFailedCreate), "skipped_liveness_error", traceRecordPayload{
+								"liveness_error": livenessErr.Error(),
+							}, nil, "")
+						}
+						continue
+					}
 					if trace != nil {
 						trace.RecordDecision(TraceSiteReconcilerCloseFailedCreate, TraceReasonCode(sessionpkg.StateFailedCreate), TraceOutcomeClosed, template, name, nil)
 					}
@@ -1895,6 +1925,21 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						if template == "" {
 							template = infoPostHeal.Template
 						}
+						if livenessErr != nil {
+							// Fail CLOSED: providerAlive=false here is "observation
+							// unavailable", not "confirmed dead". Finalizing (closing)
+							// this drain-acked session when its runtime may still be
+							// alive on a transient tmux/store blip would orphan it
+							// (#3872-family). The level-triggered loop re-observes next
+							// tick; skip the destructive finalize for now.
+							fmt.Fprintf(stderr, "session reconciler: skipping drain-ack finalize of '%s': liveness observation failed: %v\n", name, livenessErr) //nolint:errcheck
+							if trace != nil {
+								trace.recordDecision("reconciler.session.drain_ack", template, name, "orphaned", "skipped_liveness_error", traceRecordPayload{
+									"liveness_error": livenessErr.Error(),
+								}, nil, "")
+							}
+							continue
+						}
 						result := finalizeDrainAckStoppedSession(
 							cityPath, cfg, store, rigStores, session, infoByID[session.ID], template,
 							true, dops, dt, clk, rec, stderr,
@@ -2000,8 +2045,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// "confirmed dead". Closing here would orphan a bead whose
 						// session may still be alive on a transient tmux/store blip
 						// (#3872-family). The level-triggered loop re-observes next
-						// tick; skip the destructive close for now. (The drain path
-						// above is unaffected — it only runs when providerAlive.)
+						// tick; skip the destructive close for now. (The plain Ctrl-C
+						// drain path above is unaffected — it only runs when
+						// providerAlive. The other !providerAlive destructive paths in
+						// this block — pending-create rollback, failed-create close, and
+						// drain-ack finalize — carry the same fail-closed guard.)
 						fmt.Fprintf(stderr, "session reconciler: skipping close of '%s': liveness observation failed: %v\n", name, livenessErr) //nolint:errcheck
 						if trace != nil {
 							trace.recordDecision("reconciler.session.close_orphan", template, name, reason, "skipped_liveness_error", traceRecordPayload{

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1629,9 +1629,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// destructive rollback for now.
 						fmt.Fprintf(stderr, "session reconciler: skipping pending-create rollback of '%s': liveness observation failed: %v\n", name, livenessErr) //nolint:errcheck
 						if trace != nil {
-							trace.recordDecision("reconciler.session.rollback_pending_create", template, name, "pending_create_lease_expired", "skipped_liveness_error", traceRecordPayload{
+							trace.RecordDecision(TraceSiteReconcilerPendingCreate, TraceReasonCode("pending_create_lease_expired"), TraceOutcomeSkippedLivenessError, template, name, traceRecordPayload{
 								"liveness_error": livenessErr.Error(),
-							}, nil, "")
+							})
 						}
 						continue
 					}
@@ -1740,9 +1740,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// destructive close for now.
 						fmt.Fprintf(stderr, "session reconciler: skipping failed-create close of '%s': liveness observation failed: %v\n", name, livenessErr) //nolint:errcheck
 						if trace != nil {
-							trace.recordDecision("reconciler.session.close_failed_create", template, name, string(sessionpkg.StateFailedCreate), "skipped_liveness_error", traceRecordPayload{
+							trace.RecordDecision(TraceSiteReconcilerCloseFailedCreate, TraceReasonCode(sessionpkg.StateFailedCreate), TraceOutcomeSkippedLivenessError, template, name, traceRecordPayload{
 								"liveness_error": livenessErr.Error(),
-							}, nil, "")
+							})
 						}
 						continue
 					}
@@ -1934,9 +1934,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							// tick; skip the destructive finalize for now.
 							fmt.Fprintf(stderr, "session reconciler: skipping drain-ack finalize of '%s': liveness observation failed: %v\n", name, livenessErr) //nolint:errcheck
 							if trace != nil {
-								trace.recordDecision("reconciler.session.drain_ack", template, name, "orphaned", "skipped_liveness_error", traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonOrphaned, TraceOutcomeSkippedLivenessError, template, name, traceRecordPayload{
 									"liveness_error": livenessErr.Error(),
-								}, nil, "")
+								})
 							}
 							continue
 						}
@@ -2052,9 +2052,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// drain-ack finalize — carry the same fail-closed guard.)
 						fmt.Fprintf(stderr, "session reconciler: skipping close of '%s': liveness observation failed: %v\n", name, livenessErr) //nolint:errcheck
 						if trace != nil {
-							trace.recordDecision("reconciler.session.close_orphan", template, name, reason, "skipped_liveness_error", traceRecordPayload{
+							trace.RecordDecision(TraceSiteReconcilerCloseOrphan, TraceReasonCode(reason), TraceOutcomeSkippedLivenessError, template, name, traceRecordPayload{
 								"liveness_error": livenessErr.Error(),
-							}, nil, "")
+							})
 						}
 						continue
 					}

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -615,6 +616,107 @@ func TestSessionReconcilePhaseTraceUsesDistinctSites(t *testing.T) {
 			t.Fatalf("%s site = %q, want %q; all sites: %#v", name, got[name], site, got)
 		}
 	}
+}
+
+// livenessGetErrStore forces Get(target) to fail so the reconciler's runtime
+// liveness probe returns an observation error (livenessErr != nil) for that one
+// session, without disturbing any other store access. The reconcile loop body
+// never re-reads the session bead through the store (it works off the passed-in
+// slice and the mid-tick snapshot), so this affects only the liveness probe.
+type livenessGetErrStore struct {
+	beads.Store
+	target string
+	err    error
+}
+
+func (s livenessGetErrStore) Get(id string) (beads.Bead, error) {
+	if id == s.target {
+		return beads.Bead{}, s.err
+	}
+	return s.Store.Get(id)
+}
+
+// TestReconcileOrphanCloseFailsClosedOnLivenessError proves the S16 fail-closed
+// gate fires end to end in the running reconciler (F1). A healthy liveness
+// observation closes the undesired, dead orphan (baseline). But when the
+// liveness probe errors — providerAlive=false then means "observation
+// unavailable", not "confirmed dead" — the destructive orphan CLOSE is skipped
+// this tick and the bead is kept open for re-observation, rather than orphaning
+// a session that may still be alive on a transient blip (#3872-family). The
+// only variable between the two runs is the liveness observation error, so the
+// close→keep-open flip (plus the guard's stderr line) isolates the guard. The
+// three sibling !providerAlive destructive paths (pending-create rollback,
+// failed-create close, drain-ack finalize) carry the identical guard added in
+// this PR.
+func TestReconcileOrphanCloseFailsClosedOnLivenessError(t *testing.T) {
+	run := func(t *testing.T, injectLivenessErr bool) (status, stderr string) {
+		t.Helper()
+		env := newReconcilerTestEnv()
+		env.cfg = &config.City{}
+		// An asleep, undesired session with a dead runtime is the plain
+		// orphan-close case: createSessionBead defaults state=asleep and an empty
+		// desiredState makes it undesired.
+		session := env.createSessionBead("worker", "worker")
+
+		var store beads.Store = env.store
+		if injectLivenessErr {
+			// Fail the liveness probe's read of just this session. With sp=nil,
+			// handle construction surfaces the failure as an observation error —
+			// the same class a transient tmux/store blip produces at runtime.
+			store = livenessGetErrStore{
+				Store:  env.store,
+				target: session.ID,
+				err:    errors.New("boom: transient store failure"),
+			}
+		}
+
+		var stderrBuf bytes.Buffer
+		reconcileSessionBeads(
+			context.Background(),
+			[]beads.Bead{session},
+			nil, // desiredState — empty ⇒ orphan
+			nil, // configuredNames
+			env.cfg,
+			nil,   // sp — nil ⇒ dead runtime; with the wrapped store the probe errors
+			store, // store
+			nil,   // dops
+			nil,   // assignedWorkBeads
+			nil,   // readyWaitSet
+			newDrainTracker(),
+			nil,   // poolDesired
+			false, // storeQueryPartial
+			nil,   // workSet
+			"",    // cityName
+			nil,   // idleTracker
+			env.clk,
+			events.Discard,
+			0, 0,
+			io.Discard, &stderrBuf,
+		)
+
+		got, err := env.store.Get(session.ID)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", session.ID, err)
+		}
+		return got.Status, stderrBuf.String()
+	}
+
+	t.Run("healthy liveness closes orphan (baseline)", func(t *testing.T) {
+		status, _ := run(t, false)
+		if status != "closed" {
+			t.Fatalf("baseline orphan close: status = %q, want closed (the close path must be reachable for the guard to matter)", status)
+		}
+	})
+
+	t.Run("liveness error skips the close (fail closed)", func(t *testing.T) {
+		status, stderr := run(t, true)
+		if status == "closed" {
+			t.Fatalf("orphan bead was closed despite a liveness observation error; want kept open (fail closed)")
+		}
+		if !strings.Contains(stderr, "skipping close of 'worker': liveness observation failed") {
+			t.Fatalf("expected the fail-closed guard's stderr line, got %q", stderr)
+		}
+	})
 }
 
 func TestTraceFlushAfterEndOnlyPersistsPostEndRecords(t *testing.T) {

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -658,7 +658,7 @@ func TestReconcileOrphanCloseFailsClosedOnLivenessError(t *testing.T) {
 		// desiredState makes it undesired.
 		session := env.createSessionBead("worker", "worker")
 
-		var store beads.Store = env.store
+		store := env.store
 		if injectLivenessErr {
 			// Fail the liveness probe's read of just this session. With sp=nil,
 			// handle construction surfaces the failure as an observation error —

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -270,6 +270,15 @@ const (
 	TraceOutcomeDeferredUserHold    TraceOutcomeCode = "deferred_user_hold"
 	TraceOutcomeDeferredQuarantine  TraceOutcomeCode = "deferred_quarantine"
 	TraceOutcomeDeferredBusy        TraceOutcomeCode = "deferred_busy"
+
+	// TraceOutcomeSkippedLivenessError marks a destructive reconciler action
+	// (pending-create rollback, failed-create close, drain-ack finalize, or
+	// orphan close) skipped this tick because the runtime liveness probe
+	// returned an observation error. providerAlive=false then means
+	// "observation unavailable", not "confirmed dead", so the level-triggered
+	// loop fails closed and re-observes next tick rather than orphaning a
+	// possibly-live session (#3872-family).
+	TraceOutcomeSkippedLivenessError TraceOutcomeCode = "skipped_liveness_error"
 )
 
 type TraceCompletionStatus string

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -138,7 +138,7 @@ func processAttemptControl(store beads.Store, bead beads.Bead, opts ProcessOptio
 	if err != nil {
 		return ControlResult{}, err
 	}
-	attemptLog, err := appendAttemptLogValue(bead.Metadata[beadmeta.AttemptLogMetadataKey], attemptNum, eval.logOutcome, eval.logDetail)
+	attemptLog, err := appendAttemptLogValue(bead.Metadata[beadmeta.AttemptLogMetadataKey], attemptNum, eval.logOutcome, eval.logDetail, opts.tracef)
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
 	}
@@ -342,18 +342,26 @@ func markControllerSpawnError(store beads.Store, beadID string, err error, opts 
 	if IsTransientControllerError(err) && !isPartialAttemptAttachError(err) {
 		metadata[beadmeta.ControllerErrorClassMetadataKey] = beadmeta.FailureClassTransient
 		metadata[beadmeta.ControllerRetryableMetadataKey] = "true"
-		_ = store.SetMetadataBatch(beadID, metadata)
+		if writeErr := store.SetMetadataBatch(beadID, metadata); writeErr != nil {
+			opts.tracef("controller-spawn-error bead=%s recording transient failure metadata failed err=%v", beadID, writeErr)
+		}
 		return true
 	}
 
 	metadata[beadmeta.ControllerErrorClassMetadataKey] = beadmeta.FailureClassHard
 	metadata[beadmeta.ControllerRetryableMetadataKey] = ""
 	metadata[beadmeta.FinalDispositionMetadataKey] = beadmeta.DispositionControllerError
-	_ = store.SetMetadataBatch(beadID, metadata)
-	_ = setOutcomeAndClose(store, beadID, beadmeta.OutcomeFail)
+	if writeErr := store.SetMetadataBatch(beadID, metadata); writeErr != nil {
+		opts.tracef("controller-spawn-error bead=%s recording hard failure metadata failed err=%v", beadID, writeErr)
+	}
+	if closeErr := setOutcomeAndClose(store, beadID, beadmeta.OutcomeFail); closeErr != nil {
+		opts.tracef("controller-spawn-error bead=%s closing failed bead failed err=%v", beadID, closeErr)
+	}
 	// Reconcile any enclosing scope so a controller_error terminal closure
 	// does not leave the scope body stalled.
-	_, _ = reconcileClosedScopeMemberWithOptions(store, beadID, opts)
+	if _, scopeErr := reconcileClosedScopeMemberWithOptions(store, beadID, opts); scopeErr != nil {
+		opts.tracef("controller-spawn-error bead=%s reconciling enclosing scope failed err=%v", beadID, scopeErr)
+	}
 	return false
 }
 
@@ -495,7 +503,7 @@ func spawnNextAttempt(ctx context.Context, store beads.Store, control beads.Bead
 	// available, and only inherit the parent execution lane as a fallback.
 	executionRoute := strings.TrimSpace(control.Metadata[beadmeta.ExecutionRoutedToMetadataKey])
 	executionRigContext := strings.TrimSpace(control.Metadata[beadmeta.ExecutionRigContextMetadataKey])
-	routeCfg := loadAttemptRouteConfig(opts.CityPath)
+	routeCfg, _ := opts.routeConfig()
 	for i := range recipe.Steps {
 		if recipe.Steps[i].Metadata[beadmeta.KindMetadataKey] == beadmeta.KindSpec {
 			continue
@@ -982,15 +990,19 @@ func attemptRecipeStepNeedsScopeCheck(step formula.RecipeStep) bool {
 	return !beadmeta.IsScopeCheckExemptKind(step.Metadata[beadmeta.KindMetadataKey])
 }
 
-func loadAttemptRouteConfig(cityPath string) *config.City {
+// loadAttemptRouteConfigE loads the city.toml used for attempt-time routing.
+// An empty cityPath yields (nil, nil) — routing legitimately runs metadata-only
+// when no city config is present. A genuine parse failure is returned rather
+// than swallowed so callers (via ProcessOptions.routeConfig) can surface it.
+func loadAttemptRouteConfigE(cityPath string) (*config.City, error) {
 	if strings.TrimSpace(cityPath) == "" {
-		return nil
+		return nil, nil
 	}
 	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("loading attempt-route config from %s: %w", cityPath, err)
 	}
-	return cfg
+	return cfg, nil
 }
 
 func applyAttemptStepRoute(step *formula.RecipeStep, target string, cfg *config.City, store beads.Store) {
@@ -1167,10 +1179,6 @@ func isAttemptMultiSessionTarget(target string, cfg *config.City) bool {
 	}
 	agentCfg := config.FindAgent(cfg, target)
 	return agentCfg != nil && agentCfg.SupportsInstanceExpansion()
-}
-
-func beadUsesMetadataPoolRoute(bead beads.Bead, cityPath string) bool {
-	return beadUsesMetadataPoolRouteWithConfig(bead, loadAttemptRouteConfig(cityPath))
 }
 
 func beadUsesMetadataPoolRouteWithConfig(bead beads.Bead, cfg *config.City) bool {
@@ -1500,17 +1508,24 @@ func appendAttemptLog(store beads.Store, controlID string, attempt int, outcome,
 	if err != nil {
 		return err
 	}
-	logJSON, err := appendAttemptLogValue(control.Metadata[beadmeta.AttemptLogMetadataKey], attempt, outcome, reason)
+	logJSON, err := appendAttemptLogValue(control.Metadata[beadmeta.AttemptLogMetadataKey], attempt, outcome, reason, nil)
 	if err != nil {
 		return err
 	}
 	return store.SetMetadata(controlID, beadmeta.AttemptLogMetadataKey, logJSON)
 }
 
-func appendAttemptLogValue(existing string, attempt int, outcome, reason string) (string, error) {
+func appendAttemptLogValue(existing string, attempt int, outcome, reason string, tracef func(string, ...any)) (string, error) {
 	var log []map[string]string
 	if existing != "" {
-		_ = json.Unmarshal([]byte(existing), &log)
+		if err := json.Unmarshal([]byte(existing), &log); err != nil {
+			// A corrupt audit history cannot be recovered, so we start fresh —
+			// but surface the reset instead of silently discarding the log.
+			if tracef != nil {
+				tracef("attempt-log corrupt, resetting history existing=%q err=%v", existing, err)
+			}
+			log = nil
+		}
 	}
 
 	entry := map[string]string{
@@ -1580,5 +1595,5 @@ func updateMetadataAndClose(store beads.Store, beadID string, metadata map[strin
 }
 
 // Note: listByWorkflowRoot, setOutcomeAndClose, propagateRetrySubjectMetadata,
-// classifyRetryAttempt, retryPreservedAssignee, and runRalphCheck are defined
-// in runtime.go, retry.go, and ralph.go respectively.
+// classifyRetryAttempt, retryPreservedAssigneeWithConfig, and runRalphCheck are
+// defined in runtime.go, retry.go, and ralph.go respectively.

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -2753,6 +2754,94 @@ func TestAttemptLogJSONRoundTrips(t *testing.T) {
 	}
 	if roundTripped[0]["reason"] != "auth_error" {
 		t.Errorf("round-trip log[0].reason = %q, want auth_error", roundTripped[0]["reason"])
+	}
+}
+
+// TestAppendAttemptLogValueCorruptHistoryTracesReset proves the corrupt-log
+// fix: a malformed existing gc.attempt_log is no longer silently discarded — it
+// is traced and a valid fresh entry is written.
+func TestAppendAttemptLogValueCorruptHistoryTracesReset(t *testing.T) {
+	t.Parallel()
+	var traced []string
+	tracef := func(format string, args ...any) {
+		traced = append(traced, fmt.Sprintf(format, args...))
+	}
+
+	out, err := appendAttemptLogValue("{not valid json", 3, "transient", "rate_limited", tracef)
+	if err != nil {
+		t.Fatalf("appendAttemptLogValue: %v", err)
+	}
+	if len(traced) != 1 || !strings.Contains(traced[0], "attempt-log corrupt") {
+		t.Fatalf("expected one corrupt-log trace, got %v", traced)
+	}
+	var log []map[string]string
+	if err := json.Unmarshal([]byte(out), &log); err != nil {
+		t.Fatalf("output not valid JSON: %v (raw=%q)", err, out)
+	}
+	if len(log) != 1 || log[0]["attempt"] != "3" {
+		t.Fatalf("expected fresh single-entry log, got %v", log)
+	}
+}
+
+// TestAppendAttemptLogValueValidHistoryDoesNotTrace guards against noise: a
+// well-formed history appends normally and never fires the corrupt-log trace.
+func TestAppendAttemptLogValueValidHistoryDoesNotTrace(t *testing.T) {
+	t.Parallel()
+	traced := 0
+	tracef := func(string, ...any) { traced++ }
+
+	out, err := appendAttemptLogValue(`[{"attempt":"1","outcome":"transient","action":"retry"}]`, 2, "pass", "", tracef)
+	if err != nil {
+		t.Fatalf("appendAttemptLogValue: %v", err)
+	}
+	if traced != 0 {
+		t.Fatalf("valid history must not trace, got %d traces", traced)
+	}
+	var log []map[string]string
+	if err := json.Unmarshal([]byte(out), &log); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if len(log) != 2 {
+		t.Fatalf("expected two entries, got %d", len(log))
+	}
+}
+
+// TestRouteConfigSurfacesLoadErrorOnce proves the swallowed city.toml parse
+// error is now surfaced (returned + traced) and that the lazy cache parses at
+// most once per invocation.
+func TestRouteConfigSurfacesLoadErrorOnce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("key = \"unterminated"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	traces := 0
+	opts := ProcessOptions{
+		CityPath: dir,
+		Tracef:   func(string, ...any) { traces++ },
+		routeCfg: &routeConfigCache{},
+	}
+
+	cfg, err := opts.routeConfig()
+	if err == nil {
+		t.Fatalf("expected the load error to be surfaced, got nil (cfg=%v)", cfg)
+	}
+	if _, err2 := opts.routeConfig(); err2 == nil {
+		t.Fatalf("expected the cached load error on the second call")
+	}
+	if traces != 1 {
+		t.Fatalf("expected exactly one trace across two cached calls, got %d", traces)
+	}
+}
+
+// TestRouteConfigEmptyCityPathIsNilNoError confirms an absent city path stays a
+// legitimate metadata-only route (nil cfg, nil error) — not an error.
+func TestRouteConfigEmptyCityPathIsNilNoError(t *testing.T) {
+	t.Parallel()
+	opts := ProcessOptions{routeCfg: &routeConfigCache{}}
+	cfg, err := opts.routeConfig()
+	if err != nil || cfg != nil {
+		t.Fatalf("empty CityPath must yield (nil,nil), got cfg=%v err=%v", cfg, err)
 	}
 }
 

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -191,7 +191,11 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 		return ControlResult{}, fmt.Errorf("%s: recording expanded drain: %w", bead.ID, err)
 	}
 	if len(manifest.Rows) == 0 {
-		return completeDrain(store, mustReloadDrain(store, bead), opts)
+		reloaded, err := reloadDrain(store, bead)
+		if err != nil {
+			return ControlResult{}, err
+		}
+		return completeDrain(store, reloaded, opts)
 	}
 	return ControlResult{Processed: true, Action: "drain-expanded", Created: totalCreated}, nil
 }
@@ -1468,10 +1472,14 @@ func drainOnItemFailure(bead beads.Bead) string {
 	return beadmeta.DrainOnItemFailureContinue
 }
 
-func mustReloadDrain(store beads.Store, bead beads.Bead) beads.Bead {
+// reloadDrain re-reads the drain control bead so completeDrain sees the freshly
+// persisted post-expansion state. On a read error it returns the error rather
+// than the stale pre-transition bead, so the caller can retry next tick instead
+// of completing the drain against a stale snapshot.
+func reloadDrain(store beads.Store, bead beads.Bead) (beads.Bead, error) {
 	reloaded, err := store.Get(bead.ID)
 	if err != nil {
-		return bead
+		return beads.Bead{}, fmt.Errorf("%s: reloading drain before completion: %w", bead.ID, err)
 	}
-	return reloaded
+	return reloaded, nil
 }

--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -286,7 +286,7 @@ func routeFanoutFragmentSteps(fragment *formula.FragmentRecipe, control beads.Be
 	}
 	executionRoute := strings.TrimSpace(control.Metadata[beadmeta.ExecutionRoutedToMetadataKey])
 	executionRigContext := strings.TrimSpace(control.Metadata[beadmeta.ExecutionRigContextMetadataKey])
-	routeCfg := loadAttemptRouteConfig(opts.CityPath)
+	routeCfg, _ := opts.routeConfig()
 	for i := range fragment.Steps {
 		step := &fragment.Steps[i]
 		if step.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindSpec {

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -440,7 +440,7 @@ func appendRalphRetry(store beads.Store, logicalID string, prevSubject, prevChec
 		}
 		return existing, nil
 	}
-	cfg := loadAttemptRouteConfig(opts.CityPath)
+	cfg, _ := opts.routeConfig()
 	if molecule.IsGraphApplyEnabled() {
 		if applier, ok := beads.GraphApplyFor(store); ok {
 			return appendRalphRetryViaGraphApply(store, applier, logicalID, prevSubject, prevCheck, attemptSet, oldAttempt, nextAttempt, oldScopeRef, newScopeRef, cfg, opts)
@@ -720,10 +720,6 @@ func buildRalphRetryGraphNode(old beads.Bead, logicalID, oldScopeRef, newScopeRe
 		ParentKey:         parentKey,
 		ParentID:          parentID,
 	}
-}
-
-func retryPreservedAssignee(bead beads.Bead, cityPath string) string {
-	return retryPreservedAssigneeWithConfig(bead, loadAttemptRouteConfig(cityPath))
 }
 
 func retryPreservedAssigneeWithConfig(bead beads.Bead, cfg *config.City) string {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
@@ -162,7 +163,8 @@ func processRetryEval(store beads.Store, bead beads.Bead, opts ProcessOptions) (
 		return ControlResult{}, fmt.Errorf("%s: unsupported gc.retry_state %q", bead.ID, bead.Metadata[beadmeta.RetryStateMetadataKey])
 	}
 
-	if beadUsesMetadataPoolRoute(subject, opts.CityPath) {
+	routeCfg, _ := opts.routeConfig()
+	if beadUsesMetadataPoolRouteWithConfig(subject, routeCfg) {
 		if opts.RecycleSession == nil {
 			return ControlResult{}, fmt.Errorf("%s: pooled retry subject %s requires RecycleSession callback", bead.ID, subject.ID)
 		}
@@ -180,7 +182,7 @@ func processRetryEval(store beads.Store, bead beads.Bead, opts ProcessOptions) (
 	}
 
 	if bead.Metadata[beadmeta.RetryStateMetadataKey] != beadmeta.SpawnStateSpawned {
-		if err := appendRetryAttempt(store, logicalID, subject, bead, nextAttempt, opts.CityPath); err != nil {
+		if err := appendRetryAttempt(store, logicalID, subject, bead, nextAttempt, routeCfg); err != nil {
 			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
@@ -491,7 +493,7 @@ func propagateRetrySubjectMetadata(store beads.Store, logicalID string, subject 
 	return store.SetMetadataBatch(logicalID, batch)
 }
 
-func appendRetryAttempt(store beads.Store, logicalID string, prevRun, prevEval beads.Bead, nextAttempt int, cityPath string) error {
+func appendRetryAttempt(store beads.Store, logicalID string, prevRun, prevEval beads.Bead, nextAttempt int, routeCfg *config.City) error {
 	oldAttempt, err := strconv.Atoi(prevRun.Metadata[beadmeta.AttemptMetadataKey])
 	if err != nil || oldAttempt < 1 {
 		return fmt.Errorf("%s: invalid gc.attempt %q", prevRun.ID, prevRun.Metadata[beadmeta.AttemptMetadataKey])
@@ -522,7 +524,7 @@ func appendRetryAttempt(store beads.Store, logicalID string, prevRun, prevEval b
 	}
 
 	if nextRun.ID == "" {
-		nextRun, err = store.Create(retryAttemptBead(prevRun, logicalID, runRef, nextAttempt, cityPath))
+		nextRun, err = store.Create(retryAttemptBead(prevRun, logicalID, runRef, nextAttempt, routeCfg))
 		if err != nil {
 			return fmt.Errorf("creating retry run bead: %w", err)
 		}
@@ -543,10 +545,10 @@ func appendRetryAttempt(store beads.Store, logicalID string, prevRun, prevEval b
 	return nil
 }
 
-func retryAttemptBead(prev beads.Bead, logicalID, stepRef string, attempt int, cityPath string) beads.Bead {
+func retryAttemptBead(prev beads.Bead, logicalID, stepRef string, attempt int, routeCfg *config.City) beads.Bead {
 	meta := cloneMetadata(prev.Metadata)
 	clearRetryEphemera(meta)
-	assignee := retryPreservedAssignee(prev, cityPath)
+	assignee := retryPreservedAssigneeWithConfig(prev, routeCfg)
 	if assignee == "" {
 		clearSessionAffinityMetadata(meta)
 	}

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -7,11 +7,13 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
@@ -71,6 +73,40 @@ type ProcessOptions struct {
 	// the primary store, exactly matching the pre-seam single-store behavior.
 	MemberStores []beads.Store
 	Tracef       func(format string, args ...any)
+
+	// routeCfg lazily caches the city.toml used for attempt-time routing
+	// decisions so a single ProcessControl invocation parses it at most once
+	// (previously it was re-parsed per processed bead via loadAttemptRouteConfig,
+	// beadUsesMetadataPoolRoute, and retryPreservedAssignee). It is a pointer so
+	// the cache is shared across the by-value opts copies handed to sub-steps.
+	routeCfg *routeConfigCache
+}
+
+// routeConfigCache memoizes a single attempt-route config load (and its error)
+// for the lifetime of one ProcessControl invocation.
+type routeConfigCache struct {
+	once sync.Once
+	cfg  *config.City
+	err  error
+}
+
+// routeConfig returns the attempt-route config for this invocation, loading it
+// at most once. The load error is no longer swallowed: it is memoized, traced
+// once, and returned to callers so routing decisions can observe it. Callers
+// that bypass ProcessControl (direct-called sub-steps in tests) get a fresh
+// uncached load, preserving their prior behavior.
+func (opts ProcessOptions) routeConfig() (*config.City, error) {
+	cache := opts.routeCfg
+	if cache == nil {
+		return loadAttemptRouteConfigE(opts.CityPath)
+	}
+	cache.once.Do(func() {
+		cache.cfg, cache.err = loadAttemptRouteConfigE(opts.CityPath)
+		if cache.err != nil {
+			opts.tracef("process-control route-config load failed city_path=%q err=%v (routing falls back to metadata-only)", opts.CityPath, cache.err)
+		}
+	})
+	return cache.cfg, cache.err
 }
 
 var (
@@ -108,6 +144,12 @@ var ErrControlGraphMalformed = errors.New("workflow control graph malformed")
 func ProcessControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, error) {
 	if store == nil {
 		return ControlResult{}, fmt.Errorf("store is nil")
+	}
+	// Resolve the attempt-route config once per invocation. opts is copied by
+	// value into every sub-step, so a shared pointer cache collapses the former
+	// up-to-N-per-cycle city.toml parses to one lazy load.
+	if opts.routeCfg == nil {
+		opts.routeCfg = &routeConfigCache{}
 	}
 	if bead.Status != "open" {
 		// A control bead that is not open — typically stuck at in_progress

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -323,45 +323,54 @@ func checkBatchNoMoleculeChildren(q BeadChildQuerier, open []beads.Bead, store b
 
 // needsConvoyRecovery reports whether an already-routed bead should re-enter
 // finalize to repair missing or closed auto-convoy membership.
-func needsConvoyRecovery(q BeadQuerier, b beads.Bead, deps SlingDeps, opts BeadCheckOptions) bool {
+//
+// It fails CLOSED on a store error: rather than reporting "recovery needed"
+// (which re-runs finalize and mints a duplicate auto-convoy under a transient
+// store hiccup, #2987), it returns the error so callers can treat the convoy
+// as already present. A read error is never evidence that recovery is needed.
+func needsConvoyRecovery(q BeadQuerier, b beads.Bead, deps SlingDeps, opts BeadCheckOptions) (bool, error) {
 	if opts.NoConvoy {
-		return false
+		return false, nil
 	}
-	if hasLiveTrackingConvoy(deps.Store, b.ID) {
-		return false
+	live, err := hasLiveTrackingConvoy(deps.Store, b.ID)
+	if err != nil {
+		return false, err
+	}
+	if live {
+		return false, nil
 	}
 	parentID := strings.TrimSpace(b.ParentID)
 	if parentID == "" {
-		return true
+		return true, nil
 	}
 	if q == nil {
-		return false
+		return false, nil
 	}
 	parent, err := q.Get(parentID)
 	if err != nil {
-		return true
+		return false, fmt.Errorf("reading parent %s for convoy recovery of %s: %w", parentID, b.ID, err)
 	}
 	if parent.Type == "convoy" {
-		return convoycore.IsTerminalStatus(parent.Status)
+		return convoycore.IsTerminalStatus(parent.Status), nil
 	}
 	if sourceworkflow.IsWorkflowRoot(parent) {
-		return false
+		return false, nil
 	}
 	// Ordinary parent beads do not own the routing lifecycle. A routed child
 	// without a live tracking convoy needs finalize to run again so the missing
 	// auto-convoy can be recreated; finalize is idempotent for an already-routed
 	// bead because CheckBeadState preserves the routed metadata and only repairs
 	// the missing tracking attachment.
-	return true
+	return true, nil
 }
 
-func hasLiveTrackingConvoy(store beads.Store, itemID string) bool {
+func hasLiveTrackingConvoy(store beads.Store, itemID string) (bool, error) {
 	if store == nil {
-		return false
+		return false, nil
 	}
 	convoys, err := convoycore.TrackingConvoysForItem(store, itemID)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("listing tracking convoys for %s: %w", itemID, err)
 	}
 	for _, convoy := range convoys {
 		// These are convoys by construction, so the convoy type's Ready
@@ -371,10 +380,31 @@ func hasLiveTrackingConvoy(store beads.Store, itemID string) bool {
 			continue
 		}
 		if !convoycore.IsTerminalStatus(convoy.Status) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
+}
+
+// resolveConvoyRecovery maps needsConvoyRecovery onto a BeadCheckResult for an
+// already-routed bead: an empty result when finalize must re-run to recreate a
+// missing auto-convoy, or Idempotent otherwise. On a store error it fails
+// CLOSED — assuming the convoy already exists rather than minting a duplicate
+// (#2987) — and surfaces the error as a warning instead of swallowing it.
+func resolveConvoyRecovery(q BeadQuerier, b beads.Bead, deps SlingDeps, opts BeadCheckOptions, beadID string) BeadCheckResult {
+	needRecovery, err := needsConvoyRecovery(q, b, deps, opts)
+	if err != nil {
+		return BeadCheckResult{
+			Idempotent: true,
+			Warnings:   []string{fmt.Sprintf("warning: bead %s convoy-recovery check failed, assuming convoy exists: %v", beadID, err)},
+		}
+	}
+	if needRecovery {
+		// Prior sling set gc.routed_to but left no convoy — let finalize
+		// re-run to create it and poke the controller.
+		return BeadCheckResult{}
+	}
+	return BeadCheckResult{Idempotent: true}
 }
 
 // CheckBeadState checks whether a bead is already routed and returns a
@@ -401,12 +431,7 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 	target := a.QualifiedName()
 	if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) == target {
 		if b.Assignee == "" || b.Assignee == target {
-			if needsConvoyRecovery(q, b, deps, opts) {
-				// Prior sling set gc.routed_to but left no convoy — let
-				// finalize re-run to create it and poke the controller.
-				return BeadCheckResult{}
-			}
-			return BeadCheckResult{Idempotent: true}
+			return resolveConvoyRecovery(q, b, deps, opts, beadID)
 		}
 		return BeadCheckResult{
 			Warnings: []string{fmt.Sprintf("warning: bead %s routed to %q but assigned to %q", beadID, target, b.Assignee)},
@@ -416,10 +441,7 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 	isMulti := agentutil.IsMultiSessionAgent(&a)
 	if !isMulti {
 		if b.Assignee == target {
-			if needsConvoyRecovery(q, b, deps, opts) {
-				return BeadCheckResult{}
-			}
-			return BeadCheckResult{Idempotent: true}
+			return resolveConvoyRecovery(q, b, deps, opts, beadID)
 		}
 		return BeadCheckResult{Warnings: routedStateWarnings(b, beadID)}
 	}
@@ -428,10 +450,7 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 		poolLabel := "pool:" + target
 		for _, l := range b.Labels {
 			if l == poolLabel {
-				if needsConvoyRecovery(q, b, deps, opts) {
-					return BeadCheckResult{}
-				}
-				return BeadCheckResult{Idempotent: true}
+				return resolveConvoyRecovery(q, b, deps, opts, beadID)
 			}
 		}
 	}

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -348,6 +348,14 @@ func needsConvoyRecovery(q BeadQuerier, b beads.Bead, deps SlingDeps, opts BeadC
 	}
 	parent, err := q.Get(parentID)
 	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			// A genuinely deleted parent is not a transient store hiccup: the
+			// routed child is orphaned, so finalize must re-run to recreate its
+			// missing auto-convoy. Return recovery-needed rather than failing
+			// closed. Only ambiguous/transient store errors fail closed below
+			// (assuming the convoy already exists, #2987).
+			return true, nil
+		}
 		return false, fmt.Errorf("reading parent %s for convoy recovery of %s: %w", parentID, b.ID, err)
 	}
 	if parent.Type == "convoy" {

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -511,6 +511,71 @@ func TestCheckBeadStateConvoyLookupErrorFailsClosed(t *testing.T) {
 	}
 }
 
+// parentGetErrStore forces q.Get(parentID) to fail with a chosen error while
+// serving every other bead from the backing store, isolating the parent-read
+// error path in needsConvoyRecovery.
+type parentGetErrStore struct {
+	beads.Store
+	parentID string
+	err      error
+}
+
+func (s parentGetErrStore) Get(id string) (beads.Bead, error) {
+	if id == s.parentID {
+		return beads.Bead{}, s.err
+	}
+	return s.Store.Get(id)
+}
+
+// TestNeedsConvoyRecoveryDistinguishesDeletedParent proves the F3 fix: a routed
+// child whose parent is genuinely deleted (ErrNotFound) still needs finalize to
+// re-run (Idempotent=false), because a persistently-missing parent is not a
+// transient hiccup. A transient parent-read error, by contrast, fails closed
+// (Idempotent=true + warning) so a store blip never mints a duplicate
+// auto-convoy (#2987).
+func TestNeedsConvoyRecoveryDistinguishesDeletedParent(t *testing.T) {
+	newRoutedChild := func(t *testing.T, store beads.Store, parentID string) string {
+		t.Helper()
+		bead, err := store.Create(beads.Bead{
+			Title:    "routed child",
+			Type:     "task",
+			Status:   "open",
+			ParentID: parentID,
+			Metadata: map[string]string{"gc.routed_to": "mayor"},
+		})
+		if err != nil {
+			t.Fatalf("store.Create(): %v", err)
+		}
+		return bead.ID
+	}
+
+	t.Run("deleted parent triggers recovery", func(t *testing.T) {
+		store := beads.NewMemStore()
+		beadID := newRoutedChild(t, store, "gcg-deleted-parent")
+
+		result := CheckBeadState(store, beadID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+
+		if result.Idempotent {
+			t.Fatalf("expected Idempotent=false (recovery needed) for a routed child with a deleted parent, got %+v", result)
+		}
+	})
+
+	t.Run("transient parent error fails closed", func(t *testing.T) {
+		backing := beads.NewMemStore()
+		beadID := newRoutedChild(t, backing, "gcg-parent")
+		store := parentGetErrStore{Store: backing, parentID: "gcg-parent", err: errors.New("boom: store unavailable")}
+
+		result := CheckBeadState(store, beadID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+
+		if !result.Idempotent {
+			t.Fatalf("expected Idempotent=true (fail closed) on a transient parent-read error, got %+v", result)
+		}
+		if len(result.Warnings) == 0 {
+			t.Fatalf("expected a surfaced warning on transient parent-read error, got %+v", result)
+		}
+	})
+}
+
 func TestCheckBeadStateRoutedWithWorkflowParentIsIdempotent(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -470,6 +470,47 @@ func TestCheckBeadStateRoutedWithClosedConvoyIsNotIdempotent(t *testing.T) {
 	}
 }
 
+// depListErrStore wraps a real store but forces DepList to fail, simulating a
+// transient store hiccup during the tracking-convoy lookup (#2987).
+type depListErrStore struct {
+	beads.Store
+	err error
+}
+
+func (s depListErrStore) DepList(string, string) ([]beads.Dep, error) {
+	return nil, s.err
+}
+
+// TestCheckBeadStateConvoyLookupErrorFailsClosed proves the fail-closed fix:
+// when the tracking-convoy lookup errors (transient store failure), the routed
+// bead is reported Idempotent with a surfaced warning instead of re-running
+// finalize and minting a duplicate auto-convoy. Without the fix, the same
+// setup returns Idempotent=false (convoy recovery), the #2987 silent-duplicate
+// vector.
+func TestCheckBeadStateConvoyLookupErrorFailsClosed(t *testing.T) {
+	backing := beads.NewMemStore()
+	bead, err := backing.Create(beads.Bead{
+		Title:    "route me",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(): %v", err)
+	}
+
+	store := depListErrStore{Store: backing, err: errors.New("boom: store unavailable")}
+
+	result := CheckBeadState(store, bead.ID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+
+	if !result.Idempotent {
+		t.Fatalf("expected Idempotent=true (fail closed) on convoy-lookup error, got %+v", result)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatalf("expected a surfaced warning on convoy-lookup error, got %+v", result)
+	}
+}
+
 func TestCheckBeadStateRoutedWithWorkflowParentIsIdempotent(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## What this does

Lands **S16** — surfaces the seven swallowed errors on the reconciler's
destructive/routing paths (trace/log + retry-next-tick; fail CLOSED on
destructive paths) — and folds in the three review follow-ups (F1/F2/F3).

**Commit 1** (`simplify(S16)`): the original S16 change (sling
convoy-recovery fail-closed, reconciler orphan-close fail-closed on liveness
error, dispatch route-config error surfacing + lazy cache, drain reload
error, attempt-log corruption trace).

**Commit 2** (folded follow-ups):

- **F1** — direct end-to-end test that the liveness-error fail-closed gate
  fires in the running reconciler. A healthy liveness observation closes an
  undesired, dead orphan; an injected observation error keeps the bead open
  (skip) and logs the guard line. The two runs differ only in the liveness
  error, isolating the guard. (`TestReconcileOrphanCloseFailsClosedOnLivenessError`.)
- **F2** — extend the liveness-error fail-closed gate to the three sibling
  `!providerAlive` destructive paths S16 left ungated, each mirroring the
  orphan-close guard (trace `skipped_liveness_error` + skip this tick):
  **pending-create rollback**, **failed-create close**, **drain-ack
  finalize**. The plain Ctrl-C drain path is `providerAlive`-only and already
  safe — left untouched; the misleading orphan-close comment is corrected.
- **F3** — distinguish `beads.ErrNotFound` in `needsConvoyRecovery`: a
  genuinely deleted parent still triggers convoy recovery, while transient
  parent-read errors keep failing closed against the #2987 duplicate-convoy
  vector. (`TestNeedsConvoyRecoveryDistinguishesDeletedParent`, both branches.)

## F2 safety (wedge review)

At the reconciler call site the liveness handle resolves from the loaded
session bead, so a **dead-but-observable** runtime returns `(Running=false,
nil)`. `livenessErr` is non-nil **only** on a genuine observation failure
(handle construction, or the store re-read in `manager.Get`). So the gate
fails closed on real errors and **never** wedges cleanup of a confirmed-dead
session (that path keeps `livenessErr == nil` and proceeds). The failure mode
under a persistent observation error is "leave the bead open and re-observe
next tick" — the safe direction.

## Gates

- `go build ./...` — pass
- `go vet ./cmd/gc ./internal/sling ./internal/dispatch` — pass
- `go test ./internal/sling ./internal/dispatch` — pass
- `go test ./cmd/gc` reconciler suite (`-run` reconcile/session/drain/heal/
  orphan/liveness/pending/failed/close/trace/convoy) — pass

_(The full `cmd/gc` package exceeds the raw 600s `go test` timeout — a known
sharding limit per `TESTING.md`, not an assertion failure.)_

## Review verdict

LAND via label PR (`status/needs-review-auto`) — destructive-path behavior
change (fail-closed extension); routed through auto-review per the
simplification walkthrough decision.
