### PR TITLE
simplify(S20): throttled unknown-state signal + escalation for the session reconciler

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1581,8 +1581,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// rollback: if a newer version writes "draining" or "archived", the
 		// older reconciler ignores those beads rather than crashing.
 		if !isKnownStateInfo(info) {
-			fmt.Fprintf(stderr, "session reconciler: skipping %s with unknown state %q\n", //nolint:errcheck // best-effort stderr
-				info.SessionNameMetadata, info.MetadataState)
+			emitSessionUnknownStateDiagnostic(store, session, info, rec, clk, stderr)
 			if trace != nil {
 				trace.RecordDecision(TraceSiteReconcilerUnknownState, TraceReasonUnknownStateSkipped, TraceOutcomeSkipped, info.Template, info.SessionNameMetadata, traceRecordPayload{
 					"state": info.MetadataState,
@@ -3831,6 +3830,109 @@ const strandedEventEmittedKey = "stranded_event_emitted_at"
 // session.stranded message body. Anything beyond that is summarized as
 // "+N more" so a runaway count doesn't produce an unbounded message.
 const strandedWorkIDListLimit = 10
+
+// Unknown-state throttle markers. unknownStateFirstSeenKey records when the
+// reconciler first observed the current unrecognized state and
+// unknownStateValueKey records the raw value it was seen with; together they
+// gate the diagnostic to first sight and state transitions (not every tick,
+// #2389) and survive reconciler restarts (#2085) so the first-seen clock and
+// its escalation are queryable off the bead (#1497). unknownStateEscalatedKey
+// guards the single past-threshold escalation emit.
+const (
+	unknownStateFirstSeenKey = "unknown_state_first_seen"
+	unknownStateValueKey     = "unknown_state_value"
+	unknownStateEscalatedKey = "unknown_state_escalated_at"
+)
+
+// unknownStateEscalationAge is how long a session bead may sit in an
+// unrecognized state before the reconciler re-emits session.unknown_state with
+// escalated=true. The forward-compat skip still defers all action; escalation
+// is a signal for operators and pack-level subscribers, never an auto-mutation.
+const unknownStateEscalationAge = 30 * time.Minute
+
+// emitSessionUnknownStateDiagnostic surfaces a session bead whose metadata
+// state the reconciler does not recognize. The caller preserves the
+// forward-compatible skip (an older reconciler ignores a newer writer's state
+// rather than crashing); this turns the previously per-tick stderr line into a
+// throttled signal. It logs and records events.SessionUnknownState only on
+// first sight or when the raw state changes to a different unrecognized value,
+// then re-records once with escalated=true after the bead has sat unrecognized
+// past unknownStateEscalationAge. Throttle markers are stamped durably via the
+// session front door so the throttle and the escalation clock survive
+// reconciler restarts. It never mutates session state — escalation is a
+// notification, not a recovery action (keep judgment out of Go).
+func emitSessionUnknownStateDiagnostic(
+	store beads.Store,
+	session *beads.Bead,
+	info sessionpkg.Info,
+	rec events.Recorder,
+	clk clock.Clock,
+	stderr io.Writer,
+) {
+	if session == nil {
+		return
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string, 3)
+	}
+	state := strings.TrimSpace(info.MetadataState)
+	name := strings.TrimSpace(info.SessionNameMetadata)
+	now := clk.Now().UTC()
+
+	setMarker := func(key, value string) {
+		session.Metadata[key] = value
+		if err := sessionFrontDoor(store).SetMarker(session.ID, key, value); err != nil {
+			fmt.Fprintf(stderr, "session reconciler: stamping unknown-state marker %s on %s: %v\n", key, session.ID, err) //nolint:errcheck // best-effort stderr
+		}
+	}
+	emit := func(escalated bool, firstSeen time.Time) {
+		if rec == nil {
+			return
+		}
+		age := now.Sub(firstSeen).Round(time.Second)
+		msg := fmt.Sprintf("session %q has unrecognized state %q; reconciler is skipping it (forward-compatible rollback)", name, state)
+		if escalated {
+			msg = fmt.Sprintf("session %q still has unrecognized state %q after %s; reconciler continues to skip it — operator or pack recovery required", name, state, age)
+		}
+		rec.Record(events.Event{
+			Type:      events.SessionUnknownState,
+			Ts:        now,
+			Actor:     "gc",
+			Subject:   session.ID,
+			Message:   msg,
+			SessionID: session.ID,
+			Payload:   api.SessionUnknownStatePayloadJSON(session.ID, name, state, firstSeen, escalated),
+		})
+	}
+
+	firstSeenRaw := strings.TrimSpace(session.Metadata[unknownStateFirstSeenKey])
+	transition := firstSeenRaw == "" || session.Metadata[unknownStateValueKey] != info.MetadataState
+	if transition {
+		// First sight, or the unrecognized state changed to a different value:
+		// (re)stamp the first-seen clock, log once, emit, and clear any prior
+		// escalation guard so the new state gets its own escalation window.
+		fmt.Fprintf(stderr, "session reconciler: skipping %s with unknown state %q\n", name, state) //nolint:errcheck // best-effort stderr
+		emit(false, now)
+		setMarker(unknownStateFirstSeenKey, now.Format(time.RFC3339))
+		setMarker(unknownStateValueKey, info.MetadataState)
+		if strings.TrimSpace(session.Metadata[unknownStateEscalatedKey]) != "" {
+			setMarker(unknownStateEscalatedKey, "")
+		}
+		return
+	}
+
+	// Same unrecognized state as a previous tick: stay silent unless it has now
+	// aged past the escalation threshold and has not escalated yet.
+	if strings.TrimSpace(session.Metadata[unknownStateEscalatedKey]) != "" {
+		return
+	}
+	firstSeen, err := time.Parse(time.RFC3339, firstSeenRaw)
+	if err != nil || now.Sub(firstSeen) < unknownStateEscalationAge {
+		return
+	}
+	emit(true, firstSeen)
+	setMarker(unknownStateEscalatedKey, now.Format(time.RFC3339))
+}
 
 // emitSessionStrandedDiagnostic records a session.stranded event when
 // the reconciler observes a pool-managed session bead that is no

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1589,6 +1589,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 			continue
 		}
+		// Back in a known state: drop any stale unknown-state throttle markers so a
+		// later recurrence of the same unrecognized value is signaled afresh rather
+		// than suppressed as "same state as last tick" (no-op when unmarked).
+		clearSessionUnknownStateMarkers(store, session, stderr)
 
 		// Orphan/suspended: bead exists but not in desired state.
 		// Handle BEFORE heal/stability to avoid false crash detection —
@@ -3932,6 +3936,42 @@ func emitSessionUnknownStateDiagnostic(
 	}
 	emit(true, firstSeen)
 	setMarker(unknownStateEscalatedKey, now.Format(time.RFC3339))
+}
+
+// clearSessionUnknownStateMarkers removes the unknown-state throttle markers
+// once a session is observed back in a known state. The markers are durable
+// (they survive reconciler restarts by design), so without clearing them on
+// recovery a later recurrence of the *same* unrecognized value would look like
+// "same state as the last tick" to emitSessionUnknownStateDiagnostic and be
+// silently suppressed — the recurrence would never re-signal. Clearing on the
+// known-state path means a recurrence is treated as a fresh first-sight. It is
+// a no-op (no in-memory change, no store write) when the session carries no
+// unknown-state markers, so the common known-state tick pays nothing.
+func clearSessionUnknownStateMarkers(store beads.Store, session *beads.Bead, stderr io.Writer) {
+	if session == nil || session.Metadata == nil {
+		return
+	}
+	markerKeys := [...]string{unknownStateFirstSeenKey, unknownStateValueKey, unknownStateEscalatedKey}
+	hasMarker := false
+	for _, key := range markerKeys {
+		if strings.TrimSpace(session.Metadata[key]) != "" {
+			hasMarker = true
+			break
+		}
+	}
+	if !hasMarker {
+		return
+	}
+	front := sessionFrontDoor(store)
+	for _, key := range markerKeys {
+		if strings.TrimSpace(session.Metadata[key]) == "" {
+			continue
+		}
+		session.Metadata[key] = ""
+		if err := front.SetMarker(session.ID, key, ""); err != nil {
+			fmt.Fprintf(stderr, "session reconciler: clearing unknown-state marker %s on %s: %v\n", key, session.ID, err) //nolint:errcheck // best-effort stderr
+		}
+	}
 }
 
 // emitSessionStrandedDiagnostic records a session.stranded event when

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -3879,7 +3879,12 @@ func emitSessionUnknownStateDiagnostic(
 	if session.Metadata == nil {
 		session.Metadata = make(map[string]string, 3)
 	}
-	state := strings.TrimSpace(info.MetadataState)
+	// Report the raw, untrimmed state: classification (isKnownStateInfo) keys off
+	// the raw value, so a known value wrapped in whitespace like " active " is
+	// skipped as unrecognized and must surface verbatim, not trimmed to "active".
+	// This matches SessionUnknownStatePayload.State's documented "raw ... value"
+	// contract and the raw comparison the transition/value markers below use.
+	state := info.MetadataState
 	name := strings.TrimSpace(info.SessionNameMetadata)
 	now := clk.Now().UTC()
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2309,6 +2309,56 @@ func TestEmitSessionUnknownStateDiagnostic_StateChangeReemits(t *testing.T) {
 	}
 }
 
+// A metadata state that is a known value wrapped in whitespace (e.g. " active ")
+// is classified as UNKNOWN because isKnownStateInfo keys off the raw, untrimmed
+// value. The diagnostic must then report that raw value verbatim — in the event
+// payload, the operator message, and the durable value marker — so operators see
+// the actual invalid metadata rather than a trimmed, known-looking "active" that
+// hides why the bead was skipped. Regression guard for
+// SessionUnknownStatePayload.State's documented "raw ... value" contract.
+func TestEmitSessionUnknownStateDiagnostic_ReportsRawWhitespaceState(t *testing.T) {
+	const rawState = " active "
+	if isKnownStateInfo(sessionpkg.Info{MetadataState: rawState}) {
+		t.Fatalf("precondition: %q must classify as unknown (raw, untrimmed)", rawState)
+	}
+
+	store, id := newUnknownStateSession(t, "worker-ws", rawState)
+	clk := &clock.Fake{Time: time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)}
+	rec := &capturingRecorder{}
+	var stderr bytes.Buffer
+
+	fresh, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get session bead: %v", err)
+	}
+	emitSessionUnknownStateDiagnostic(store, &fresh, sessionpkg.InfoFromPersistedBead(fresh), rec, clk, &stderr)
+
+	got := rec.unknownStateEvents()
+	if len(got) != 1 {
+		t.Fatalf("first-sight events = %d, want 1", len(got))
+	}
+	var payload api.SessionUnknownStatePayload
+	if err := json.Unmarshal(got[0].Payload, &payload); err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	if payload.State != rawState {
+		t.Fatalf("payload.State = %q, want raw %q (untrimmed)", payload.State, rawState)
+	}
+	if !strings.Contains(got[0].Message, rawState) {
+		t.Fatalf("event message %q, want it to contain the raw state %q", got[0].Message, rawState)
+	}
+
+	// The durable value marker must also store the raw value so the throttle
+	// compares like-for-like against info.MetadataState on subsequent ticks.
+	reloaded, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if marker := reloaded.Metadata[unknownStateValueKey]; marker != rawState {
+		t.Fatalf("value marker = %q, want raw %q", marker, rawState)
+	}
+}
+
 // After a session recovers to a known state, the reconciler clears the
 // unknown-state throttle markers so that a later recurrence of the SAME
 // unrecognized value re-emits instead of being silently suppressed as "same

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2309,6 +2309,66 @@ func TestEmitSessionUnknownStateDiagnostic_StateChangeReemits(t *testing.T) {
 	}
 }
 
+// After a session recovers to a known state, the reconciler clears the
+// unknown-state throttle markers so that a later recurrence of the SAME
+// unrecognized value re-emits instead of being silently suppressed as "same
+// state as last tick". Without clearSessionUnknownStateMarkers the recurrence
+// stays silent because the durable first-seen/value markers still match.
+func TestClearSessionUnknownStateMarkers_RecurrenceReemitsAfterRecovery(t *testing.T) {
+	store, id := newUnknownStateSession(t, "worker-z", "quantum-limbo")
+	clk := &clock.Fake{Time: time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)}
+	rec := &capturingRecorder{}
+	var stderr bytes.Buffer
+
+	emit := func() {
+		fresh, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		emitSessionUnknownStateDiagnostic(store, &fresh, sessionpkg.InfoFromPersistedBead(fresh), rec, clk, &stderr)
+	}
+
+	emit() // first sight of quantum-limbo
+	if got := rec.unknownStateEvents(); len(got) != 1 {
+		t.Fatalf("first-sight events = %d, want 1", len(got))
+	}
+
+	// The session recovers to a known state; the reconciler clears the markers.
+	if err := store.SetMetadata(id, "state", "active"); err != nil {
+		t.Fatalf("SetMetadata(active): %v", err)
+	}
+	fresh, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !isKnownStateInfo(sessionpkg.InfoFromPersistedBead(fresh)) {
+		t.Fatal("expected \"active\" to be a known state for this test")
+	}
+	clearSessionUnknownStateMarkers(store, &fresh, &stderr)
+
+	// The durable markers must be gone.
+	reloaded, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for _, key := range []string{unknownStateFirstSeenKey, unknownStateValueKey, unknownStateEscalatedKey} {
+		if v := strings.TrimSpace(reloaded.Metadata[key]); v != "" {
+			t.Fatalf("marker %s = %q, want cleared after recovery to a known state", key, v)
+		}
+	}
+
+	// The same unrecognized value recurs later. It must re-emit (fresh
+	// first-sight), not stay throttled behind the now-cleared markers.
+	if err := store.SetMetadata(id, "state", "quantum-limbo"); err != nil {
+		t.Fatalf("SetMetadata(recurrence): %v", err)
+	}
+	clk.Advance(time.Minute)
+	emit()
+	if got := rec.unknownStateEvents(); len(got) != 2 {
+		t.Fatalf("recurrence events = %d, want 2 (recurrence re-emits after marker clear)", len(got))
+	}
+}
+
 // TestReconcileSessionBeads_PoolSlotWithStrandedWorkEmitsDiagnostic
 // covers issue #1424: when a pool-managed session is observed
 // asleep + not-alive AND still has open in-progress work assigned, the

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2148,6 +2148,167 @@ func emitStrandedDiagnosticForTest(t *testing.T, store beads.Store, session *bea
 	return rec
 }
 
+// unknownStateEvents returns the captured events.SessionUnknownState events in
+// emission order.
+func (c *capturingRecorder) unknownStateEvents() []events.Event {
+	out := make([]events.Event, 0, len(c.events))
+	for _, e := range c.events {
+		if e.Type == events.SessionUnknownState {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// newUnknownStateSession creates a session bead carrying the given unrecognized
+// state and returns the store plus bead ID. Reloading the bead per call models
+// how the reconciler re-projects each session from the store every tick, so the
+// durable throttle markers stamped by the diagnostic are read back next tick.
+func newUnknownStateSession(t *testing.T, name, state string) (beads.Store, string) {
+	t.Helper()
+	store := beads.NewMemStore()
+	b, err := store.Create(beads.Bead{
+		Title:  name,
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": name,
+			"state":        state,
+		},
+	})
+	if err != nil {
+		t.Fatalf("creating session bead: %v", err)
+	}
+	return store, b.ID
+}
+
+// The unknown-state diagnostic must fire once on first sight, stay silent while
+// the same unrecognized state persists (no per-tick #2389 spam), and re-fire
+// exactly once with escalated=true after the bead has sat unrecognized past the
+// threshold — the durable markers making the throttle survive reconciler
+// restarts (#2085) and the first-seen clock queryable (#1497).
+func TestEmitSessionUnknownStateDiagnostic_ThrottlesAndEscalates(t *testing.T) {
+	if sample, ok := events.LookupPayload(events.SessionUnknownState); !ok {
+		t.Fatal("no payload registered for session.unknown_state")
+	} else if _, typed := sample.(api.SessionUnknownStatePayload); !typed {
+		t.Fatalf("registered session.unknown_state payload = %T, want api.SessionUnknownStatePayload", sample)
+	}
+
+	store, id := newUnknownStateSession(t, "worker-x", "quantum-limbo")
+	clk := &clock.Fake{Time: time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)}
+	rec := &capturingRecorder{}
+	var stderr bytes.Buffer
+
+	call := func() {
+		fresh, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get session bead: %v", err)
+		}
+		emitSessionUnknownStateDiagnostic(store, &fresh, sessionpkg.InfoFromPersistedBead(fresh), rec, clk, &stderr)
+	}
+
+	call() // first sight
+	if got := rec.unknownStateEvents(); len(got) != 1 {
+		t.Fatalf("first-sight events = %d, want 1; events: %+v", len(got), rec.events)
+	}
+	first := rec.unknownStateEvents()[0]
+	if first.Subject != id || first.SessionID != id {
+		t.Fatalf("event subject/session = %q/%q, want %q", first.Subject, first.SessionID, id)
+	}
+	var payload api.SessionUnknownStatePayload
+	if err := json.Unmarshal(first.Payload, &payload); err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	if payload.State != "quantum-limbo" || payload.SessionName != "worker-x" || payload.Escalated {
+		t.Fatalf("payload = %+v, want state=quantum-limbo name=worker-x escalated=false", payload)
+	}
+	firstLogLines := strings.Count(stderr.String(), "unknown state")
+	if firstLogLines != 1 {
+		t.Fatalf("stderr unknown-state lines = %d after first sight, want 1: %q", firstLogLines, stderr.String())
+	}
+
+	call() // same state, before threshold: throttled
+	if got := rec.unknownStateEvents(); len(got) != 1 {
+		t.Fatalf("post-throttle events = %d, want 1 (no re-emit while state persists)", len(got))
+	}
+	if lines := strings.Count(stderr.String(), "unknown state"); lines != 1 {
+		t.Fatalf("stderr unknown-state lines = %d, want 1 (no per-tick spam)", lines)
+	}
+
+	clk.Advance(unknownStateEscalationAge + time.Minute)
+	call() // now past threshold: escalate once
+	esc := rec.unknownStateEvents()
+	if len(esc) != 2 {
+		t.Fatalf("post-threshold events = %d, want 2", len(esc))
+	}
+	if err := json.Unmarshal(esc[1].Payload, &payload); err != nil {
+		t.Fatalf("decoding escalation payload: %v", err)
+	}
+	if !payload.Escalated {
+		t.Fatalf("escalation payload escalated = false, want true")
+	}
+
+	clk.Advance(time.Hour)
+	call() // escalation is once-only
+	if got := rec.unknownStateEvents(); len(got) != 2 {
+		t.Fatalf("post-escalation events = %d, want 2 (escalation fires once)", len(got))
+	}
+}
+
+// A change to a *different* unrecognized state resets the first-seen clock and
+// re-emits (escalated=false), clearing any prior escalation guard.
+func TestEmitSessionUnknownStateDiagnostic_StateChangeReemits(t *testing.T) {
+	store, id := newUnknownStateSession(t, "worker-y", "state-a")
+	clk := &clock.Fake{Time: time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)}
+	rec := &capturingRecorder{}
+	var stderr bytes.Buffer
+
+	call := func() {
+		fresh, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get session bead: %v", err)
+		}
+		emitSessionUnknownStateDiagnostic(store, &fresh, sessionpkg.InfoFromPersistedBead(fresh), rec, clk, &stderr)
+	}
+
+	call() // first sight of state-a
+	// Escalate state-a so the escalation guard is set.
+	clk.Advance(unknownStateEscalationAge + time.Minute)
+	call()
+	if got := rec.unknownStateEvents(); len(got) != 2 {
+		t.Fatalf("state-a events = %d, want 2 (first sight + escalation)", len(got))
+	}
+
+	// A different unrecognized state is a fresh transition: re-emit, not throttle.
+	if err := store.SetMetadata(id, "state", "state-b"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	call()
+	got := rec.unknownStateEvents()
+	if len(got) != 3 {
+		t.Fatalf("post-change events = %d, want 3", len(got))
+	}
+	var payload api.SessionUnknownStatePayload
+	if err := json.Unmarshal(got[2].Payload, &payload); err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	if payload.State != "state-b" || payload.Escalated {
+		t.Fatalf("payload = %+v, want state=state-b escalated=false (fresh window)", payload)
+	}
+
+	// The escalation guard for the previous state must have been cleared.
+	fresh, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if v := strings.TrimSpace(fresh.Metadata[unknownStateEscalatedKey]); v != "" {
+		t.Fatalf("escalation marker = %q, want cleared after state change", v)
+	}
+	if fresh.Metadata[unknownStateValueKey] != "state-b" {
+		t.Fatalf("value marker = %q, want state-b", fresh.Metadata[unknownStateValueKey])
+	}
+}
+
 // TestReconcileSessionBeads_PoolSlotWithStrandedWorkEmitsDiagnostic
 // covers issue #1424: when a pool-managed session is observed
 // asleep + not-alive AND still has open in-progress work assigned, the

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -2306,6 +2306,9 @@
             "$ref": "#/components/schemas/SessionSubmitSucceededPayload"
           },
           {
+            "$ref": "#/components/schemas/SessionUnknownStatePayload"
+          },
+          {
             "$ref": "#/components/schemas/StoreDiskCriticalPayload"
           },
           {
@@ -7218,6 +7221,37 @@
         ],
         "type": "object"
       },
+      "SessionUnknownStatePayload": {
+        "additionalProperties": false,
+        "properties": {
+          "escalated": {
+            "description": "False on the first-sight emission; true when re-emitted after the bead has sat unrecognized past the escalation threshold.",
+            "type": "boolean"
+          },
+          "first_seen": {
+            "description": "RFC3339 timestamp the reconciler first observed this unrecognized state; the escalation clock counts from here.",
+            "type": "string"
+          },
+          "session_id": {
+            "description": "Canonical session bead ID for the unrecognized-state session (also the envelope Subject).",
+            "type": "string"
+          },
+          "session_name": {
+            "description": "Runtime session name from the session bead metadata, when set.",
+            "type": "string"
+          },
+          "state": {
+            "description": "The raw, unrecognized metadata state value the reconciler skipped.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "state",
+          "escalated"
+        ],
+        "type": "object"
+      },
       "SlingInputBody": {
         "additionalProperties": false,
         "properties": {
@@ -8318,6 +8352,7 @@
             "session.stranded": "#/components/schemas/TypedEventStreamEnvelopeSessionStranded",
             "session.suspended": "#/components/schemas/TypedEventStreamEnvelopeSessionSuspended",
             "session.undrained": "#/components/schemas/TypedEventStreamEnvelopeSessionUndrained",
+            "session.unknown_state": "#/components/schemas/TypedEventStreamEnvelopeSessionUnknownState",
             "session.updated": "#/components/schemas/TypedEventStreamEnvelopeSessionUpdated",
             "session.woke": "#/components/schemas/TypedEventStreamEnvelopeSessionWoke",
             "session.work_query_failed": "#/components/schemas/TypedEventStreamEnvelopeSessionWorkQueryFailed",
@@ -8520,6 +8555,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionUndrained"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionUnknownState"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionUpdated"
@@ -9419,6 +9457,7 @@
                 "session.updated",
                 "session.drain_acked_with_assigned_work",
                 "session.stranded",
+                "session.unknown_state",
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
@@ -11895,6 +11934,57 @@
         "title": "TypedEventStreamEnvelope session.undrained",
         "type": "object"
       },
+      "TypedEventStreamEnvelopeSessionUnknownState": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionUnknownStatePayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.unknown_state",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope session.unknown_state",
+        "type": "object"
+      },
       "TypedEventStreamEnvelopeSessionUpdated": {
         "additionalProperties": false,
         "properties": {
@@ -12472,6 +12562,7 @@
             "session.stranded": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionStranded",
             "session.suspended": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionSuspended",
             "session.undrained": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUndrained",
+            "session.unknown_state": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUnknownState",
             "session.updated": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUpdated",
             "session.woke": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionWoke",
             "session.work_query_failed": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionWorkQueryFailed",
@@ -12674,6 +12765,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUndrained"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUnknownState"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUpdated"
@@ -13640,6 +13734,7 @@
                 "session.updated",
                 "session.drain_acked_with_assigned_work",
                 "session.stranded",
+                "session.unknown_state",
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
@@ -16303,6 +16398,61 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope session.undrained",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeSessionUnknownState": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionUnknownStatePayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.unknown_state",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope session.unknown_state",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopeSessionUpdated": {

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -2306,6 +2306,9 @@
             "$ref": "#/components/schemas/SessionSubmitSucceededPayload"
           },
           {
+            "$ref": "#/components/schemas/SessionUnknownStatePayload"
+          },
+          {
             "$ref": "#/components/schemas/StoreDiskCriticalPayload"
           },
           {
@@ -7218,6 +7221,37 @@
         ],
         "type": "object"
       },
+      "SessionUnknownStatePayload": {
+        "additionalProperties": false,
+        "properties": {
+          "escalated": {
+            "description": "False on the first-sight emission; true when re-emitted after the bead has sat unrecognized past the escalation threshold.",
+            "type": "boolean"
+          },
+          "first_seen": {
+            "description": "RFC3339 timestamp the reconciler first observed this unrecognized state; the escalation clock counts from here.",
+            "type": "string"
+          },
+          "session_id": {
+            "description": "Canonical session bead ID for the unrecognized-state session (also the envelope Subject).",
+            "type": "string"
+          },
+          "session_name": {
+            "description": "Runtime session name from the session bead metadata, when set.",
+            "type": "string"
+          },
+          "state": {
+            "description": "The raw, unrecognized metadata state value the reconciler skipped.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "state",
+          "escalated"
+        ],
+        "type": "object"
+      },
       "SlingInputBody": {
         "additionalProperties": false,
         "properties": {
@@ -8318,6 +8352,7 @@
             "session.stranded": "#/components/schemas/TypedEventStreamEnvelopeSessionStranded",
             "session.suspended": "#/components/schemas/TypedEventStreamEnvelopeSessionSuspended",
             "session.undrained": "#/components/schemas/TypedEventStreamEnvelopeSessionUndrained",
+            "session.unknown_state": "#/components/schemas/TypedEventStreamEnvelopeSessionUnknownState",
             "session.updated": "#/components/schemas/TypedEventStreamEnvelopeSessionUpdated",
             "session.woke": "#/components/schemas/TypedEventStreamEnvelopeSessionWoke",
             "session.work_query_failed": "#/components/schemas/TypedEventStreamEnvelopeSessionWorkQueryFailed",
@@ -8520,6 +8555,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionUndrained"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionUnknownState"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionUpdated"
@@ -9419,6 +9457,7 @@
                 "session.updated",
                 "session.drain_acked_with_assigned_work",
                 "session.stranded",
+                "session.unknown_state",
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
@@ -11895,6 +11934,57 @@
         "title": "TypedEventStreamEnvelope session.undrained",
         "type": "object"
       },
+      "TypedEventStreamEnvelopeSessionUnknownState": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionUnknownStatePayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.unknown_state",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope session.unknown_state",
+        "type": "object"
+      },
       "TypedEventStreamEnvelopeSessionUpdated": {
         "additionalProperties": false,
         "properties": {
@@ -12472,6 +12562,7 @@
             "session.stranded": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionStranded",
             "session.suspended": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionSuspended",
             "session.undrained": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUndrained",
+            "session.unknown_state": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUnknownState",
             "session.updated": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUpdated",
             "session.woke": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionWoke",
             "session.work_query_failed": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionWorkQueryFailed",
@@ -12674,6 +12765,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUndrained"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUnknownState"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUpdated"
@@ -13640,6 +13734,7 @@
                 "session.updated",
                 "session.drain_acked_with_assigned_work",
                 "session.stranded",
+                "session.unknown_state",
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
@@ -16303,6 +16398,61 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope session.undrained",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeSessionUnknownState": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionUnknownStatePayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.unknown_state",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope session.unknown_state",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopeSessionUpdated": {

--- a/internal/api/event_payloads.go
+++ b/internal/api/event_payloads.go
@@ -533,6 +533,41 @@ func BeadDeadAssigneeReopenedPayloadJSON(beadID, deadAssignee, routedTo string) 
 	return b
 }
 
+// SessionUnknownStatePayload carries the machine-readable context for a
+// session.unknown_state event: a session bead whose metadata state the
+// reconciler does not recognize and therefore skips (forward-compatible
+// rollback). The envelope Message renders the same facts as operator text;
+// this payload is the machine contract so subscribers can correlate the stuck
+// bead, compute how long it has been unrecognized, and distinguish the
+// first-sight emission from the past-threshold escalation.
+type SessionUnknownStatePayload struct {
+	SessionID   string `json:"session_id" doc:"Canonical session bead ID for the unrecognized-state session (also the envelope Subject)."`
+	SessionName string `json:"session_name,omitempty" doc:"Runtime session name from the session bead metadata, when set."`
+	State       string `json:"state" doc:"The raw, unrecognized metadata state value the reconciler skipped."`
+	FirstSeen   string `json:"first_seen,omitempty" doc:"RFC3339 timestamp the reconciler first observed this unrecognized state; the escalation clock counts from here."`
+	Escalated   bool   `json:"escalated" doc:"False on the first-sight emission; true when re-emitted after the bead has sat unrecognized past the escalation threshold."`
+}
+
+// IsEventPayload marks SessionUnknownStatePayload as an events.Payload variant.
+func (SessionUnknownStatePayload) IsEventPayload() {}
+
+// SessionUnknownStatePayloadJSON builds the JSON wire form for attachment to an
+// events.Event.Payload field. SessionName and FirstSeen are emitted only when
+// set.
+func SessionUnknownStatePayloadJSON(sessionID, sessionName, state string, firstSeen time.Time, escalated bool) json.RawMessage {
+	p := SessionUnknownStatePayload{
+		SessionID:   sessionID,
+		SessionName: sessionName,
+		State:       state,
+		Escalated:   escalated,
+	}
+	if !firstSeen.IsZero() {
+		p.FirstSeen = firstSeen.UTC().Format(time.RFC3339)
+	}
+	b, _ := json.Marshal(p)
+	return b
+}
+
 func init() {
 	// mail.* — all seven types share one payload shape.
 	events.RegisterPayload(events.MailSent, MailEventPayload{})
@@ -568,6 +603,7 @@ func init() {
 	events.RegisterPayload(events.SessionUpdated, events.NoPayload{})
 	events.RegisterPayload(events.SessionDrainAckedWithAssignedWork, SessionDrainAckedWithAssignedWorkPayload{})
 	events.RegisterPayload(events.SessionStranded, SessionStrandedPayload{})
+	events.RegisterPayload(events.SessionUnknownState, SessionUnknownStatePayload{})
 	events.RegisterPayload(events.SessionResetStalled, events.SessionResetStalledPayload{})
 	events.RegisterPayload(events.SessionWorkQueryFailed, SessionLifecyclePayload{})
 	events.RegisterPayload(events.SessionColdStartTimeout, events.NoPayload{})

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2988,6 +2988,24 @@ type SessionTranscriptGetResponse struct {
 	Turns *[]OutputTurn `json:"turns,omitempty"`
 }
 
+// SessionUnknownStatePayload defines model for SessionUnknownStatePayload.
+type SessionUnknownStatePayload struct {
+	// Escalated False on the first-sight emission; true when re-emitted after the bead has sat unrecognized past the escalation threshold.
+	Escalated bool `json:"escalated"`
+
+	// FirstSeen RFC3339 timestamp the reconciler first observed this unrecognized state; the escalation clock counts from here.
+	FirstSeen *string `json:"first_seen,omitempty"`
+
+	// SessionId Canonical session bead ID for the unrecognized-state session (also the envelope Subject).
+	SessionId string `json:"session_id"`
+
+	// SessionName Runtime session name from the session bead metadata, when set.
+	SessionName *string `json:"session_name,omitempty"`
+
+	// State The raw, unrecognized metadata state value the reconciler skipped.
+	State string `json:"state"`
+}
+
 // SlingInputBody defines model for SlingInputBody.
 type SlingInputBody struct {
 	// AttachedBeadId Bead ID to attach a formula to.
@@ -4411,6 +4429,21 @@ type TypedEventStreamEnvelopeSessionUndrained struct {
 	Workflow  *WorkflowEventProjection `json:"workflow,omitempty"`
 }
 
+// TypedEventStreamEnvelopeSessionUnknownState defines model for TypedEventStreamEnvelopeSessionUnknownState.
+type TypedEventStreamEnvelopeSessionUnknownState struct {
+	Actor     string                     `json:"actor"`
+	Message   *string                    `json:"message,omitempty"`
+	Payload   SessionUnknownStatePayload `json:"payload"`
+	RunId     *string                    `json:"run_id,omitempty"`
+	Seq       int64                      `json:"seq"`
+	SessionId *string                    `json:"session_id,omitempty"`
+	StepId    *string                    `json:"step_id,omitempty"`
+	Subject   *string                    `json:"subject,omitempty"`
+	Ts        time.Time                  `json:"ts"`
+	Type      string                     `json:"type"`
+	Workflow  *WorkflowEventProjection   `json:"workflow,omitempty"`
+}
+
 // TypedEventStreamEnvelopeSessionUpdated defines model for TypedEventStreamEnvelopeSessionUpdated.
 type TypedEventStreamEnvelopeSessionUpdated struct {
 	Actor     string                   `json:"actor"`
@@ -5588,6 +5621,22 @@ type TypedTaggedEventStreamEnvelopeSessionUndrained struct {
 	Ts        time.Time                `json:"ts"`
 	Type      string                   `json:"type"`
 	Workflow  *WorkflowEventProjection `json:"workflow,omitempty"`
+}
+
+// TypedTaggedEventStreamEnvelopeSessionUnknownState defines model for TypedTaggedEventStreamEnvelopeSessionUnknownState.
+type TypedTaggedEventStreamEnvelopeSessionUnknownState struct {
+	Actor     string                     `json:"actor"`
+	City      string                     `json:"city"`
+	Message   *string                    `json:"message,omitempty"`
+	Payload   SessionUnknownStatePayload `json:"payload"`
+	RunId     *string                    `json:"run_id,omitempty"`
+	Seq       int64                      `json:"seq"`
+	SessionId *string                    `json:"session_id,omitempty"`
+	StepId    *string                    `json:"step_id,omitempty"`
+	Subject   *string                    `json:"subject,omitempty"`
+	Ts        time.Time                  `json:"ts"`
+	Type      string                     `json:"type"`
+	Workflow  *WorkflowEventProjection   `json:"workflow,omitempty"`
 }
 
 // TypedTaggedEventStreamEnvelopeSessionUpdated defines model for TypedTaggedEventStreamEnvelopeSessionUpdated.
@@ -7851,6 +7900,32 @@ func (t *EventPayload) MergeSessionSubmitSucceededPayload(v SessionSubmitSucceed
 	return err
 }
 
+// AsSessionUnknownStatePayload returns the union data inside the EventPayload as a SessionUnknownStatePayload
+func (t EventPayload) AsSessionUnknownStatePayload() (SessionUnknownStatePayload, error) {
+	var body SessionUnknownStatePayload
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromSessionUnknownStatePayload overwrites any union data inside the EventPayload as the provided SessionUnknownStatePayload
+func (t *EventPayload) FromSessionUnknownStatePayload(v SessionUnknownStatePayload) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeSessionUnknownStatePayload performs a merge with any union data inside the EventPayload, using the provided SessionUnknownStatePayload
+func (t *EventPayload) MergeSessionUnknownStatePayload(v SessionUnknownStatePayload) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsStoreDiskCriticalPayload returns the union data inside the EventPayload as a StoreDiskCriticalPayload
 func (t EventPayload) AsStoreDiskCriticalPayload() (StoreDiskCriticalPayload, error) {
 	var body StoreDiskCriticalPayload
@@ -10025,6 +10100,34 @@ func (t *TypedEventStreamEnvelope) MergeTypedEventStreamEnvelopeSessionUndrained
 	return err
 }
 
+// AsTypedEventStreamEnvelopeSessionUnknownState returns the union data inside the TypedEventStreamEnvelope as a TypedEventStreamEnvelopeSessionUnknownState
+func (t TypedEventStreamEnvelope) AsTypedEventStreamEnvelopeSessionUnknownState() (TypedEventStreamEnvelopeSessionUnknownState, error) {
+	var body TypedEventStreamEnvelopeSessionUnknownState
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromTypedEventStreamEnvelopeSessionUnknownState overwrites any union data inside the TypedEventStreamEnvelope as the provided TypedEventStreamEnvelopeSessionUnknownState
+func (t *TypedEventStreamEnvelope) FromTypedEventStreamEnvelopeSessionUnknownState(v TypedEventStreamEnvelopeSessionUnknownState) error {
+	v.Type = "session.unknown_state"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeTypedEventStreamEnvelopeSessionUnknownState performs a merge with any union data inside the TypedEventStreamEnvelope, using the provided TypedEventStreamEnvelopeSessionUnknownState
+func (t *TypedEventStreamEnvelope) MergeTypedEventStreamEnvelopeSessionUnknownState(v TypedEventStreamEnvelopeSessionUnknownState) error {
+	v.Type = "session.unknown_state"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsTypedEventStreamEnvelopeSessionUpdated returns the union data inside the TypedEventStreamEnvelope as a TypedEventStreamEnvelopeSessionUpdated
 func (t TypedEventStreamEnvelope) AsTypedEventStreamEnvelopeSessionUpdated() (TypedEventStreamEnvelopeSessionUpdated, error) {
 	var body TypedEventStreamEnvelopeSessionUpdated
@@ -10475,6 +10578,8 @@ func (t TypedEventStreamEnvelope) ValueByDiscriminator() (interface{}, error) {
 		return t.AsTypedEventStreamEnvelopeSessionSuspended()
 	case "session.undrained":
 		return t.AsTypedEventStreamEnvelopeSessionUndrained()
+	case "session.unknown_state":
+		return t.AsTypedEventStreamEnvelopeSessionUnknownState()
 	case "session.updated":
 		return t.AsTypedEventStreamEnvelopeSessionUpdated()
 	case "session.woke":
@@ -12274,6 +12379,34 @@ func (t *TypedTaggedEventStreamEnvelope) MergeTypedTaggedEventStreamEnvelopeSess
 	return err
 }
 
+// AsTypedTaggedEventStreamEnvelopeSessionUnknownState returns the union data inside the TypedTaggedEventStreamEnvelope as a TypedTaggedEventStreamEnvelopeSessionUnknownState
+func (t TypedTaggedEventStreamEnvelope) AsTypedTaggedEventStreamEnvelopeSessionUnknownState() (TypedTaggedEventStreamEnvelopeSessionUnknownState, error) {
+	var body TypedTaggedEventStreamEnvelopeSessionUnknownState
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromTypedTaggedEventStreamEnvelopeSessionUnknownState overwrites any union data inside the TypedTaggedEventStreamEnvelope as the provided TypedTaggedEventStreamEnvelopeSessionUnknownState
+func (t *TypedTaggedEventStreamEnvelope) FromTypedTaggedEventStreamEnvelopeSessionUnknownState(v TypedTaggedEventStreamEnvelopeSessionUnknownState) error {
+	v.Type = "session.unknown_state"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeTypedTaggedEventStreamEnvelopeSessionUnknownState performs a merge with any union data inside the TypedTaggedEventStreamEnvelope, using the provided TypedTaggedEventStreamEnvelopeSessionUnknownState
+func (t *TypedTaggedEventStreamEnvelope) MergeTypedTaggedEventStreamEnvelopeSessionUnknownState(v TypedTaggedEventStreamEnvelopeSessionUnknownState) error {
+	v.Type = "session.unknown_state"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsTypedTaggedEventStreamEnvelopeSessionUpdated returns the union data inside the TypedTaggedEventStreamEnvelope as a TypedTaggedEventStreamEnvelopeSessionUpdated
 func (t TypedTaggedEventStreamEnvelope) AsTypedTaggedEventStreamEnvelopeSessionUpdated() (TypedTaggedEventStreamEnvelopeSessionUpdated, error) {
 	var body TypedTaggedEventStreamEnvelopeSessionUpdated
@@ -12724,6 +12857,8 @@ func (t TypedTaggedEventStreamEnvelope) ValueByDiscriminator() (interface{}, err
 		return t.AsTypedTaggedEventStreamEnvelopeSessionSuspended()
 	case "session.undrained":
 		return t.AsTypedTaggedEventStreamEnvelopeSessionUndrained()
+	case "session.unknown_state":
+		return t.AsTypedTaggedEventStreamEnvelopeSessionUnknownState()
 	case "session.updated":
 		return t.AsTypedTaggedEventStreamEnvelopeSessionUpdated()
 	case "session.woke":

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -2306,6 +2306,9 @@
             "$ref": "#/components/schemas/SessionSubmitSucceededPayload"
           },
           {
+            "$ref": "#/components/schemas/SessionUnknownStatePayload"
+          },
+          {
             "$ref": "#/components/schemas/StoreDiskCriticalPayload"
           },
           {
@@ -7218,6 +7221,37 @@
         ],
         "type": "object"
       },
+      "SessionUnknownStatePayload": {
+        "additionalProperties": false,
+        "properties": {
+          "escalated": {
+            "description": "False on the first-sight emission; true when re-emitted after the bead has sat unrecognized past the escalation threshold.",
+            "type": "boolean"
+          },
+          "first_seen": {
+            "description": "RFC3339 timestamp the reconciler first observed this unrecognized state; the escalation clock counts from here.",
+            "type": "string"
+          },
+          "session_id": {
+            "description": "Canonical session bead ID for the unrecognized-state session (also the envelope Subject).",
+            "type": "string"
+          },
+          "session_name": {
+            "description": "Runtime session name from the session bead metadata, when set.",
+            "type": "string"
+          },
+          "state": {
+            "description": "The raw, unrecognized metadata state value the reconciler skipped.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "state",
+          "escalated"
+        ],
+        "type": "object"
+      },
       "SlingInputBody": {
         "additionalProperties": false,
         "properties": {
@@ -8318,6 +8352,7 @@
             "session.stranded": "#/components/schemas/TypedEventStreamEnvelopeSessionStranded",
             "session.suspended": "#/components/schemas/TypedEventStreamEnvelopeSessionSuspended",
             "session.undrained": "#/components/schemas/TypedEventStreamEnvelopeSessionUndrained",
+            "session.unknown_state": "#/components/schemas/TypedEventStreamEnvelopeSessionUnknownState",
             "session.updated": "#/components/schemas/TypedEventStreamEnvelopeSessionUpdated",
             "session.woke": "#/components/schemas/TypedEventStreamEnvelopeSessionWoke",
             "session.work_query_failed": "#/components/schemas/TypedEventStreamEnvelopeSessionWorkQueryFailed",
@@ -8520,6 +8555,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionUndrained"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionUnknownState"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeSessionUpdated"
@@ -9419,6 +9457,7 @@
                 "session.updated",
                 "session.drain_acked_with_assigned_work",
                 "session.stranded",
+                "session.unknown_state",
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
@@ -11895,6 +11934,57 @@
         "title": "TypedEventStreamEnvelope session.undrained",
         "type": "object"
       },
+      "TypedEventStreamEnvelopeSessionUnknownState": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionUnknownStatePayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.unknown_state",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope session.unknown_state",
+        "type": "object"
+      },
       "TypedEventStreamEnvelopeSessionUpdated": {
         "additionalProperties": false,
         "properties": {
@@ -12472,6 +12562,7 @@
             "session.stranded": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionStranded",
             "session.suspended": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionSuspended",
             "session.undrained": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUndrained",
+            "session.unknown_state": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUnknownState",
             "session.updated": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUpdated",
             "session.woke": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionWoke",
             "session.work_query_failed": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionWorkQueryFailed",
@@ -12674,6 +12765,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUndrained"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUnknownState"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeSessionUpdated"
@@ -13640,6 +13734,7 @@
                 "session.updated",
                 "session.drain_acked_with_assigned_work",
                 "session.stranded",
+                "session.unknown_state",
                 "session.reset_stalled",
                 "session.work_query_failed",
                 "session.cold_start_timeout",
@@ -16303,6 +16398,61 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope session.undrained",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeSessionUnknownState": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/SessionUnknownStatePayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.unknown_state",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope session.unknown_state",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopeSessionUpdated": {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -75,6 +75,15 @@ const (
 	// the reconciler-detected leak so pack-level subscribers can decide
 	// whether to clear-assignee-and-respawn or escalate.
 	SessionStranded = "session.stranded"
+	// SessionUnknownState fires when the reconciler observes a session bead
+	// whose metadata state it does not recognize. The reconciler skips such
+	// beads (forward-compatible rollback: an older reconciler ignores a newer
+	// writer's state rather than crashing), so this is the only durable signal
+	// that a bead is stuck outside the state machine. Emitted on first sight
+	// (and again with escalated=true once the bead has sat unrecognized past a
+	// threshold), never as a recovery action — pack-level subscribers or
+	// operators own recovery. See gastownhall/gascity#1497, #2085, #2389.
+	SessionUnknownState = "session.unknown_state"
 	// SessionResetStalled fires when a session reset was committed but
 	// the follow-up wake remains pending past the configured startup
 	// timeout. Operators use the typed payload to correlate the stuck
@@ -224,6 +233,7 @@ var KnownEventTypes = []string{
 	SessionIdleKilled, SessionMaxAgeKilled, SessionSuspended, SessionUpdated,
 	SessionDrainAckedWithAssignedWork,
 	SessionStranded,
+	SessionUnknownState,
 	SessionResetStalled,
 	SessionWorkQueryFailed,
 	SessionColdStartTimeout,


### PR DESCRIPTION
## What this does

Lands **S20** — turns the session reconciler's forward-compat unknown-state
skip from a silent per-tick stderr storm into a durable, throttled signal —
and folds the review follow-up + completes the OpenAPI change the source
commit left half-done.

**Commit 1** (`simplify(S20)`, slice-a, signal-only): new typed event
`session.unknown_state` (constant + `KnownEventTypes`) with a registered
`api.SessionUnknownStatePayload`; `emitSessionUnknownStateDiagnostic` reuses
the stranded-diagnostic throttle-marker pattern — durable
`unknown_state_first_seen` / `_value` / `_escalated_at` markers, emit only on
first sight or a changed unrecognized value (#2389), survives restarts
(#2085), and one escalated re-emit past 30m (#1497). No state mutation;
recovery stays with operators/pack subscribers.

**Commit 2** (folded follow-up + genclient regen):

- **Follow-up** — clear the unknown-state markers when a session recovers to
  a known state (`clearSessionUnknownStateMarkers`, called on the known-state
  path). The markers are durable, so without this a later recurrence of the
  *same* unrecognized value would look like "same state as last tick" and be
  silently suppressed — the recurrence would never re-signal. No-op (no write)
  when the session carries no markers. Covered by
  `TestClearSessionUnknownStateMarkers_RecurrenceReemitsAfterRecovery`.
- **genclient regen** — the source commit added the event payload to
  `internal/api/openapi.json` but did not regenerate the Go client, so
  `TestGeneratedClientInSync` (CI: `preflight-generated` → `spec-ci`) was red.
  Ran `go generate ./internal/api/genclient` to add the
  `SessionUnknownStatePayload` client types. The vendored dashboard hey-api
  client (`types.gen.ts`) is sourced from the external `gascity-dashboard`
  repo and is not regenerated/drift-checked by this repo's `dashboard-ci`
  gate, so it is intentionally untouched.

## Deferred

Slice-b — the actual typed `SessionState` enum simplification the title
promises — is deferred and filed as bead **ga-cx470v** so it isn't lost.

## Gates

- `go build ./...` — pass
- `go vet ./cmd/gc ./internal/api ./internal/api/genclient ./internal/events` — pass
- `go test ./internal/api ./internal/events ./internal/api/genclient` — pass
  (incl. `TestGeneratedClientInSync`, `TestOpenAPISpecInSync`,
  `TestEveryKnownEventTypeHasRegisteredPayload`)
- `go test ./cmd/gc` reconciler + unknown-state suite (`-run`) — pass

## Review verdict

APPROVED — land with the follow-up folded into the same PR (per the
simplification walkthrough). Routed via label PR (`status/needs-review-auto`)
because it touches the typed-event / OpenAPI wire surface.
