### PR TITLE
simplify(S13): collapse three formula-attachment pipelines into one (+ dead-branch removal)

### DIFF
--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -361,11 +361,11 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 	}); err != nil {
 		return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 	}
-	checkAttachments := CheckNoMoleculeChildren
-	if isGraph && opts.Force {
-		checkAttachments = CheckNoMoleculeChildrenAllowLiveWorkflow
-	}
-	if err := checkAttachments(querier, beadID, deps.Store, &result); err != nil {
+	// The graph path returned above, so this is the legacy (non-graph) region:
+	// isGraph is always false here, so the former `isGraph && opts.Force`
+	// live-workflow allowance could never fire. Attachments are always checked
+	// with CheckNoMoleculeChildren on this path.
+	if err := CheckNoMoleculeChildren(querier, beadID, deps.Store, &result); err != nil {
 		return result, fmt.Errorf("%w", err)
 	}
 	run := func() (SlingResult, error) {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -293,22 +293,38 @@ func rootOnlyVaporPourHint(formulaName string, recipe *formula.Recipe) string {
 
 // slingOnFormula handles the --on formula attachment path.
 func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
+	return attachFormulaToBead(opts, deps, querier, beadID, opts.OnFormula, "on-formula", "formula", result)
+}
+
+// slingDefaultFormula handles the default formula attachment path.
+func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
+	return attachFormulaToBead(opts, deps, querier, beadID, opts.Target.EffectiveDefaultSlingFormula(), "default-on-formula", "default formula", result)
+}
+
+// attachFormulaToBead runs the shared formula-attachment pipeline for both the
+// --on-formula and default-formula paths: prepare the graph invocation,
+// validate runtime vars, then either drive the graph-v2 branch
+// (lock -> snapshot -> instantiate -> start -> rollback) or the legacy branch
+// (check attachments -> instantiate -> set molecule_id -> finalize). The
+// caller supplies the formula name, the sling method, and the error-label
+// prefix ("formula" vs "default formula"); graph-vs-legacy behavior is
+// byte-identical across both entry points.
+func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID, formulaName, method, errLabel string, result SlingResult) (SlingResult, error) {
 	a := opts.Target
-	method := "on-formula"
-	formulaVars := BuildSlingFormulaVars(opts.OnFormula, beadID, opts.Vars, a, deps)
+	formulaVars := BuildSlingFormulaVars(formulaName, beadID, opts.Vars, a, deps)
 	searchPaths := SlingFormulaSearchPaths(deps, a)
-	graphInv, isGraph, err := prepareGraphV2FormulaInvocation(context.Background(), opts.OnFormula, beadID, opts, deps, a)
+	graphInv, isGraph, err := prepareGraphV2FormulaInvocation(context.Background(), formulaName, beadID, opts, deps, a)
 	if err != nil {
-		return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+		return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 	}
 	if isGraph {
 		formulaVars = graphInv.Vars
 		result.Deprecations = append(result.Deprecations, graphInv.Deprecations...)
-		if err := validateSlingFormulaRuntimeVars(context.Background(), opts.OnFormula, searchPaths, molecule.Options{
+		if err := validateSlingFormulaRuntimeVars(context.Background(), formulaName, searchPaths, molecule.Options{
 			Title: opts.Title,
 			Vars:  formulaVars,
 		}); err != nil {
-			return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+			return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 		}
 		return withGraphV2SourceWorkflowLock(context.Background(), deps, beadID, func() (SlingResult, error) {
 			if err := CheckNoMoleculeChildrenAllowLiveWorkflow(querier, beadID, deps.Store, &result); err != nil {
@@ -317,20 +333,20 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 			if err := checkLegacySourceWorkflowConflict(deps, beadID); err != nil {
 				return result, fmt.Errorf("%w", err)
 			}
-			replacedSnapshot, err := snapshotGraphV2ReplacementRoot(deps.Store, opts.OnFormula, formulaVars, opts.ScopeKind, opts.ScopeRef, opts.Force)
+			replacedSnapshot, err := snapshotGraphV2ReplacementRoot(deps.Store, formulaName, formulaVars, opts.ScopeKind, opts.ScopeRef, opts.Force)
 			if err != nil {
-				return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+				return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 			}
-			mResult, err := InstantiateSlingFormula(context.Background(), opts.OnFormula, searchPaths, molecule.Options{
+			mResult, err := InstantiateSlingFormula(context.Background(), formulaName, searchPaths, molecule.Options{
 				Title:            opts.Title,
 				Vars:             formulaVars,
 				PriorityOverride: BeadPriorityOverride(deps.Store, graphInv.InputConvoy),
 			}, "", opts.ScopeKind, opts.ScopeRef, a, deps, opts.Force)
 			if err != nil {
-				return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+				return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 			}
 			wfResult, wfErr := doStartGraphWorkflow(mResult.RootID, "", a, method, deps)
-			wfResult.FormulaName = opts.OnFormula
+			wfResult.FormulaName = formulaName
 			if wfErr != nil {
 				if rollbackErr := rollbackGraphV2ReplacementLaunch(deps.Store, mResult.RootID, replacedSnapshot); rollbackErr != nil {
 					return wfResult, errors.Join(wfErr, rollbackErr)
@@ -339,11 +355,11 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 			return wfResult, wfErr
 		})
 	}
-	if err := validateSlingFormulaRuntimeVars(context.Background(), opts.OnFormula, searchPaths, molecule.Options{
+	if err := validateSlingFormulaRuntimeVars(context.Background(), formulaName, searchPaths, molecule.Options{
 		Title: opts.Title,
 		Vars:  formulaVars,
 	}); err != nil {
-		return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+		return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 	}
 	checkAttachments := CheckNoMoleculeChildren
 	if isGraph && opts.Force {
@@ -353,18 +369,18 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 		return result, fmt.Errorf("%w", err)
 	}
 	run := func() (SlingResult, error) {
-		mResult, err := InstantiateSlingFormula(context.Background(), opts.OnFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
+		mResult, err := InstantiateSlingFormula(context.Background(), formulaName, SlingFormulaSearchPaths(deps, a), molecule.Options{
 			Title:            opts.Title,
 			Vars:             formulaVars,
 			PriorityOverride: BeadPriorityOverride(querier, beadID),
 		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
 		if err != nil {
-			return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+			return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 		}
 		wispRootID := mResult.RootID
 		if mResult.GraphWorkflow || IsGraphWorkflowAttachment(deps.Store, wispRootID) {
 			wfResult, wfErr := doStartGraphWorkflow(mResult.RootID, beadID, a, method, deps)
-			wfResult.FormulaName = opts.OnFormula
+			wfResult.FormulaName = formulaName
 			return wfResult, wfErr
 		}
 		if err := deps.Store.SetMetadata(beadID, "molecule_id", wispRootID); err != nil {
@@ -372,12 +388,12 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 				fmt.Sprintf("setting molecule_id on %s: %v", beadID, err))
 		}
 		result.WispRootID = wispRootID
-		result.FormulaName = opts.OnFormula
+		result.FormulaName = formulaName
 		// Route the SOURCE bead, not wispRootID. An attached wisp (--on
-		// <formula>) is driven through its source bead: the source carries
-		// gc.routed_to + molecule_id and is the claimable unit of work, while
-		// the wisp root is deliberately left unrouted (and, when root-only,
-		// privatized out of Ready() by privatizeAttachedRootOnlyWisp).
+		// <formula> or default formula) is driven through its source bead: the
+		// source carries gc.routed_to + molecule_id and is the claimable unit
+		// of work, while the wisp root is deliberately left unrouted (and, when
+		// root-only, privatized out of Ready() by privatizeAttachedRootOnlyWisp).
 		// ApplyGraphRouting likewise stamps no routing on an attached recipe
 		// (graphroute: sourceBeadID != "" early-return). This is the
 		// intentional counterpart to slingFormula, which routes the standalone
@@ -386,121 +402,15 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 		return finalize(opts, deps, beadID, method, result)
 	}
 	runGraph := func() (pendingSourceWorkflowLaunch, error) {
-		mResult, err := InstantiateSlingFormula(context.Background(), opts.OnFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
+		mResult, err := InstantiateSlingFormula(context.Background(), formulaName, SlingFormulaSearchPaths(deps, a), molecule.Options{
 			Title:            opts.Title,
 			Vars:             formulaVars,
 			PriorityOverride: BeadPriorityOverride(querier, beadID),
 		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
 		if err != nil {
-			return pendingSourceWorkflowLaunch{}, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+			return pendingSourceWorkflowLaunch{}, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 		}
-		return pendingGraphWorkflowLaunch(mResult.RootID, beadID, a, method, opts.OnFormula, deps), nil
-	}
-	if !isGraph {
-		return run()
-	}
-	return withSourceWorkflowLaunchLock(context.Background(), deps, beadID, opts.Force, runGraph)
-}
-
-// slingDefaultFormula handles the default formula attachment path.
-func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
-	a := opts.Target
-	method := "default-on-formula"
-	defaultFormula := a.EffectiveDefaultSlingFormula()
-	defaultVars := BuildSlingFormulaVars(defaultFormula, beadID, opts.Vars, a, deps)
-	searchPaths := SlingFormulaSearchPaths(deps, a)
-	graphInv, isGraph, err := prepareGraphV2FormulaInvocation(context.Background(), defaultFormula, beadID, opts, deps, a)
-	if err != nil {
-		return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
-	}
-	if isGraph {
-		defaultVars = graphInv.Vars
-		result.Deprecations = append(result.Deprecations, graphInv.Deprecations...)
-		if err := validateSlingFormulaRuntimeVars(context.Background(), defaultFormula, searchPaths, molecule.Options{
-			Title: opts.Title,
-			Vars:  defaultVars,
-		}); err != nil {
-			return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
-		}
-		return withGraphV2SourceWorkflowLock(context.Background(), deps, beadID, func() (SlingResult, error) {
-			if err := CheckNoMoleculeChildrenAllowLiveWorkflow(querier, beadID, deps.Store, &result); err != nil {
-				return result, fmt.Errorf("%w", err)
-			}
-			if err := checkLegacySourceWorkflowConflict(deps, beadID); err != nil {
-				return result, fmt.Errorf("%w", err)
-			}
-			replacedSnapshot, err := snapshotGraphV2ReplacementRoot(deps.Store, defaultFormula, defaultVars, opts.ScopeKind, opts.ScopeRef, opts.Force)
-			if err != nil {
-				return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
-			}
-			mResult, err := InstantiateSlingFormula(context.Background(), defaultFormula, searchPaths, molecule.Options{
-				Title:            opts.Title,
-				Vars:             defaultVars,
-				PriorityOverride: BeadPriorityOverride(deps.Store, graphInv.InputConvoy),
-			}, "", opts.ScopeKind, opts.ScopeRef, a, deps, opts.Force)
-			if err != nil {
-				return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
-			}
-			wfResult, wfErr := doStartGraphWorkflow(mResult.RootID, "", a, method, deps)
-			wfResult.FormulaName = defaultFormula
-			if wfErr != nil {
-				if rollbackErr := rollbackGraphV2ReplacementLaunch(deps.Store, mResult.RootID, replacedSnapshot); rollbackErr != nil {
-					return wfResult, errors.Join(wfErr, rollbackErr)
-				}
-			}
-			return wfResult, wfErr
-		})
-	}
-	if err := validateSlingFormulaRuntimeVars(context.Background(), defaultFormula, searchPaths, molecule.Options{
-		Title: opts.Title,
-		Vars:  defaultVars,
-	}); err != nil {
-		return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
-	}
-	checkAttachments := CheckNoMoleculeChildren
-	if isGraph && opts.Force {
-		checkAttachments = CheckNoMoleculeChildrenAllowLiveWorkflow
-	}
-	if err := checkAttachments(querier, beadID, deps.Store, &result); err != nil {
-		return result, fmt.Errorf("%w", err)
-	}
-	run := func() (SlingResult, error) {
-		mResult, err := InstantiateSlingFormula(context.Background(), defaultFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
-			Title:            opts.Title,
-			Vars:             defaultVars,
-			PriorityOverride: BeadPriorityOverride(querier, beadID),
-		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
-		if err != nil {
-			return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
-		}
-		wispRootID := mResult.RootID
-		if mResult.GraphWorkflow || IsGraphWorkflowAttachment(deps.Store, wispRootID) {
-			wfResult, wfErr := doStartGraphWorkflow(mResult.RootID, beadID, a, method, deps)
-			wfResult.FormulaName = defaultFormula
-			return wfResult, wfErr
-		}
-		if err := deps.Store.SetMetadata(beadID, "molecule_id", wispRootID); err != nil {
-			result.MetadataErrors = append(result.MetadataErrors,
-				fmt.Sprintf("setting molecule_id on %s: %v", beadID, err))
-		}
-		result.WispRootID = wispRootID
-		result.FormulaName = defaultFormula
-		// Route the SOURCE bead, not wispRootID — see the matching note in
-		// slingOnFormula. The default formula attaches the wisp to the source
-		// bead, which stays the routed, claimable unit of work; the wisp root
-		// is intentionally left unrouted. Do not "fix" this to wispRootID.
-		return finalize(opts, deps, beadID, method, result)
-	}
-	runGraph := func() (pendingSourceWorkflowLaunch, error) {
-		mResult, err := InstantiateSlingFormula(context.Background(), defaultFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
-			Title:            opts.Title,
-			Vars:             defaultVars,
-			PriorityOverride: BeadPriorityOverride(querier, beadID),
-		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
-		if err != nil {
-			return pendingSourceWorkflowLaunch{}, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
-		}
-		return pendingGraphWorkflowLaunch(mResult.RootID, beadID, a, method, defaultFormula, deps), nil
+		return pendingGraphWorkflowLaunch(mResult.RootID, beadID, a, method, formulaName, deps), nil
 	}
 	if !isGraph {
 		return run()

--- a/internal/sling/sling_core_test.go
+++ b/internal/sling/sling_core_test.go
@@ -1,0 +1,90 @@
+package sling
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestAttachFormulaToBeadEntryShapes exercises the two attachment entry points
+// that share attachFormulaToBead — --on-formula and default-formula — and
+// pins the per-path pieces the wrappers select: the sling method and the
+// error-label prefix ("formula" vs "default formula"). This is the drift the
+// S13 consolidation eliminated: before the merge these copies could diverge
+// independently, so the test asserts both success method and error prefix for
+// each entry shape.
+func TestAttachFormulaToBeadEntryShapes(t *testing.T) {
+	newDeps := func(t *testing.T) (SlingDeps, string) {
+		t.Helper()
+		cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+		deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+		b, err := deps.Store.Create(beads.Bead{Title: "work", Type: "task", Status: "open"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return deps, b.ID
+	}
+
+	t.Run("on-formula success", func(t *testing.T) {
+		deps, beadID := newDeps(t)
+		a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+		result, err := DoSling(SlingOpts{Target: a, BeadOrFormula: beadID, OnFormula: "code-review"}, deps, deps.Store)
+		if err != nil {
+			t.Fatalf("DoSling on-formula: %v", err)
+		}
+		if result.Method != "on-formula" {
+			t.Errorf("Method = %q, want on-formula", result.Method)
+		}
+		if result.FormulaName != "code-review" {
+			t.Errorf("FormulaName = %q, want code-review", result.FormulaName)
+		}
+		if result.WispRootID == "" {
+			t.Error("expected non-empty WispRootID")
+		}
+	})
+
+	t.Run("default-formula success", func(t *testing.T) {
+		deps, beadID := newDeps(t)
+		a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1), DefaultSlingFormula: stringPtr("code-review")}
+		result, err := DoSling(SlingOpts{Target: a, BeadOrFormula: beadID}, deps, deps.Store)
+		if err != nil {
+			t.Fatalf("DoSling default-formula: %v", err)
+		}
+		if result.Method != "default-on-formula" {
+			t.Errorf("Method = %q, want default-on-formula", result.Method)
+		}
+		if result.FormulaName != "code-review" {
+			t.Errorf("FormulaName = %q, want code-review", result.FormulaName)
+		}
+		if result.WispRootID == "" {
+			t.Error("expected non-empty WispRootID")
+		}
+	})
+
+	t.Run("on-formula error label", func(t *testing.T) {
+		deps, beadID := newDeps(t)
+		a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+		_, err := DoSling(SlingOpts{Target: a, BeadOrFormula: beadID, OnFormula: "nonexistent-formula"}, deps, deps.Store)
+		if err == nil {
+			t.Fatal("expected instantiation error for nonexistent on-formula")
+		}
+		if want := `instantiating formula "nonexistent-formula" on`; !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want prefix %q", err.Error(), want)
+		}
+	})
+
+	t.Run("default-formula error label", func(t *testing.T) {
+		deps, beadID := newDeps(t)
+		a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1), DefaultSlingFormula: stringPtr("nonexistent-formula")}
+		_, err := DoSling(SlingOpts{Target: a, BeadOrFormula: beadID}, deps, deps.Store)
+		if err == nil {
+			t.Fatal("expected instantiation error for nonexistent default formula")
+		}
+		if want := `instantiating default formula "nonexistent-formula" on`; !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want prefix %q", err.Error(), want)
+		}
+	})
+}


### PR DESCRIPTION
## What this does

Lands **S13** — collapses the two ~105-line copy-pasted formula-attachment
pipelines (`slingOnFormula` / `slingDefaultFormula`) into one
`attachFormulaToBead`; both become thin wrappers that differ only in formula
name, sling method, and error-label prefix. Graph-vs-legacy behavior is
byte-identical per path (6 closures → 2). Kills the #1053 duplicate-molecule
drift vector; a new `TestAttachFormulaToBeadEntryShapes` table test pins the
success method + FormulaName and error-label prefix for both entry shapes.

**Folded follow-up** (reviewer-flagged, commit 2): the `isGraph==true` case
returns early, so the code below it is the legacy non-graph region where
`isGraph` is always false. The `if isGraph && opts.Force { checkAttachments =
CheckNoMoleculeChildrenAllowLiveWorkflow }` branch there could never fire —
inlined the always-taken `CheckNoMoleculeChildren` and dropped the dead
branch. No behavior change.

## Gates

- `go build ./internal/sling ./cmd/gc` — pass
- `go vet ./internal/sling` — pass
- `go test ./internal/sling` — pass

## Review verdict

LAND — fast-track (no `status/needs-review-auto` label), behavior-preserving
dedup + reviewer-flagged dead-branch removal, per the simplification
walkthrough. Merge after CI green; delete branch on merge.
