### PR TITLE
simplify(S37): single scope-close/abort reconciler in dispatch

### DIFF
--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -35,11 +35,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing fanout: %w", bead.ID, err)
 		}
-		closedBead, err := store.Get(bead.ID)
-		if err != nil {
-			return ControlResult{}, fmt.Errorf("%s: reloading closed fanout: %w", bead.ID, err)
-		}
-		scopeResult, err := reconcileTerminalScopedMemberWithOptions(store, closedBead, opts)
+		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
 		if err != nil {
 			return ControlResult{}, err
 		}
@@ -77,11 +73,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		if err := setOutcomeAndClose(store, bead.ID, beadmeta.OutcomeFail); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing failed fanout: %w", bead.ID, err)
 		}
-		closedBead, err := store.Get(bead.ID)
-		if err != nil {
-			return ControlResult{}, fmt.Errorf("%s: reloading failed fanout: %w", bead.ID, err)
-		}
-		scopeResult, err := reconcileTerminalScopedMemberWithOptions(store, closedBead, opts)
+		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
 		if err != nil {
 			return ControlResult{}, err
 		}
@@ -96,11 +88,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		if err := setOutcomeAndClose(store, bead.ID, beadmeta.OutcomePass); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing empty fanout: %w", bead.ID, err)
 		}
-		closedBead, err := store.Get(bead.ID)
-		if err != nil {
-			return ControlResult{}, fmt.Errorf("%s: reloading empty fanout: %w", bead.ID, err)
-		}
-		scopeResult, err := reconcileTerminalScopedMemberWithOptions(store, closedBead, opts)
+		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
 		if err != nil {
 			return ControlResult{}, err
 		}

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -257,36 +257,8 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 			if err != nil {
 				return ControlResult{}, err
 			}
-			if err := tracePhaseErr(opts, bead.ID, "propagate-metadata", func() error {
-				return snapshot.propagateScopeMemberMetadata(store, body.ID)
-			}); err != nil {
-				return ControlResult{}, fmt.Errorf("%s: propagating scope metadata: %w", bead.ID, err)
-			}
-			outputJSON, err := tracePhase(opts, bead.ID, "resolve-output", func() (string, error) {
-				return snapshot.resolveScopeOutputJSON(subject)
-			})
-			if err != nil {
-				return ControlResult{}, fmt.Errorf("%s: resolving scope output: %w", bead.ID, err)
-			}
-			if outputJSON != "" {
-				if err := tracePhaseErr(opts, bead.ID, "write-output", func() error {
-					return store.SetMetadata(body.ID, beadmeta.OutputJSONMetadataKey, outputJSON)
-				}); err != nil {
-					return ControlResult{}, fmt.Errorf("%s: propagating scope output: %w", body.ID, err)
-				}
-			}
-			bodyAfter, getErr := tracePhase(opts, bead.ID, "reload-body", func() (beads.Bead, error) {
-				return store.Get(body.ID)
-			})
-			if getErr != nil {
-				return ControlResult{}, fmt.Errorf("%s: reloading scope body: %w", body.ID, getErr)
-			}
-			if bodyAfter.Status != "closed" {
-				if err := tracePhaseErr(opts, bead.ID, "close-body", func() error {
-					return setOutcomeAndClose(store, body.ID, beadmeta.OutcomePass)
-				}); err != nil {
-					return ControlResult{}, fmt.Errorf("%s: completing scope body: %w", body.ID, err)
-				}
+			if err := closeScopeAsPassed(store, snapshot, subject, opts, bead.ID); err != nil {
+				return ControlResult{}, err
 			}
 			if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
 				return setOutcomeAndClose(store, bead.ID, beadmeta.OutcomePass)
@@ -317,21 +289,9 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		if err != nil {
 			return ControlResult{}, err
 		}
-		skipped, err := tracePhase(opts, bead.ID, "skip-open-members", func() (int, error) {
-			return snapshot.skipOpenScopeMembers(store, bead.ID)
-		})
+		skipped, err := abortScope(store, snapshot, opts, bead.ID)
 		if err != nil {
-			return ControlResult{}, fmt.Errorf("%s: aborting scope: %w", bead.ID, err)
-		}
-		if err := tracePhaseErr(opts, bead.ID, "propagate-metadata", func() error {
-			return snapshot.propagateScopeMemberMetadata(store, body.ID)
-		}); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: propagating scope metadata: %w", bead.ID, err)
-		}
-		if err := tracePhaseErr(opts, bead.ID, "close-body-fail", func() error {
-			return setOutcomeAndClose(store, body.ID, beadmeta.OutcomeFail)
-		}); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: completing scope body: %w", body.ID, err)
+			return ControlResult{}, err
 		}
 		if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
 			return setOutcomeAndClose(store, bead.ID, beadmeta.OutcomePass)
@@ -353,39 +313,8 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		if err != nil {
 			return ControlResult{}, err
 		}
-		// Propagate non-gc metadata from scope members to the scope body.
-		// This enables compositional metadata bubbling: attempt → retry →
-		// scope → ralph → parent scope, etc.
-		if err := tracePhaseErr(opts, bead.ID, "propagate-metadata", func() error {
-			return snapshot.propagateScopeMemberMetadata(store, body.ID)
-		}); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: propagating scope metadata: %w", bead.ID, err)
-		}
-		outputJSON, err := tracePhase(opts, bead.ID, "resolve-output", func() (string, error) {
-			return snapshot.resolveScopeOutputJSON(subject)
-		})
-		if err != nil {
-			return ControlResult{}, fmt.Errorf("%s: resolving scope output: %w", bead.ID, err)
-		}
-		if outputJSON != "" {
-			if err := tracePhaseErr(opts, bead.ID, "write-output", func() error {
-				return store.SetMetadata(body.ID, beadmeta.OutputJSONMetadataKey, outputJSON)
-			}); err != nil {
-				return ControlResult{}, fmt.Errorf("%s: propagating scope output: %w", body.ID, err)
-			}
-		}
-		bodyAfter, getErr := tracePhase(opts, bead.ID, "reload-body", func() (beads.Bead, error) {
-			return store.Get(body.ID)
-		})
-		if getErr != nil {
-			return ControlResult{}, fmt.Errorf("%s: reloading scope body: %w", body.ID, getErr)
-		}
-		if bodyAfter.Status != "closed" {
-			if err := tracePhaseErr(opts, bead.ID, "close-body", func() error {
-				return setOutcomeAndClose(store, body.ID, beadmeta.OutcomePass)
-			}); err != nil {
-				return ControlResult{}, fmt.Errorf("%s: completing scope body: %w", body.ID, err)
-			}
+		if err := closeScopeAsPassed(store, snapshot, subject, opts, bead.ID); err != nil {
+			return ControlResult{}, err
 		}
 		if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
 			return setOutcomeAndClose(store, bead.ID, beadmeta.OutcomePass)
@@ -413,6 +342,82 @@ func loadScopeSnapshotForControl(store beads.Store, rootID, scopeRef string, bod
 	opts.tracef("scope-check bead=%s snapshot root=%s scope=%s all=%d members=%d body=%s subject=%s outcome=%s",
 		controlID, rootID, scopeRef, len(snapshot.all), len(snapshot.members), snapshot.body.ID, subject.ID, subject.Metadata[beadmeta.OutcomeMetadataKey])
 	return snapshot, nil
+}
+
+// closeScopeAsPassed runs the shared convergence sequence for a scope whose
+// members have all completed successfully: propagate non-gc.* member metadata
+// onto the scope body, resolve the scope's output_json from subject, then close
+// the body with outcome=pass (unless it is already closed). subject supplies the
+// output_json source and traceID identifies the bead driving the trace. The
+// caller owns closing its own control bead. This is the single implementation
+// shared by both processScopeCheck branches and reconcileTerminalScopedMember,
+// so every convergence observer closes a scope identically.
+func closeScopeAsPassed(store beads.Store, snapshot scopeSnapshot, subject beads.Bead, opts ProcessOptions, traceID string) error {
+	bodyID := snapshot.body.ID
+	// Propagate non-gc metadata from scope members to the scope body. This
+	// enables compositional metadata bubbling: attempt → retry → scope →
+	// ralph → parent scope, etc.
+	if err := tracePhaseErr(opts, traceID, "propagate-metadata", func() error {
+		return snapshot.propagateScopeMemberMetadata(store, bodyID)
+	}); err != nil {
+		return fmt.Errorf("%s: propagating scope metadata: %w", traceID, err)
+	}
+	outputJSON, err := tracePhase(opts, traceID, "resolve-output", func() (string, error) {
+		return snapshot.resolveScopeOutputJSON(subject)
+	})
+	if err != nil {
+		return fmt.Errorf("%s: resolving scope output: %w", traceID, err)
+	}
+	if outputJSON != "" {
+		if err := tracePhaseErr(opts, traceID, "write-output", func() error {
+			return store.SetMetadata(bodyID, beadmeta.OutputJSONMetadataKey, outputJSON)
+		}); err != nil {
+			return fmt.Errorf("%s: propagating scope output: %w", bodyID, err)
+		}
+	}
+	bodyAfter, err := tracePhase(opts, traceID, "reload-body", func() (beads.Bead, error) {
+		return store.Get(bodyID)
+	})
+	if err != nil {
+		return fmt.Errorf("%s: reloading scope body: %w", bodyID, err)
+	}
+	if bodyAfter.Status != "closed" {
+		if err := tracePhaseErr(opts, traceID, "close-body", func() error {
+			return setOutcomeAndClose(store, bodyID, beadmeta.OutcomePass)
+		}); err != nil {
+			return fmt.Errorf("%s: completing scope body: %w", bodyID, err)
+		}
+	}
+	return nil
+}
+
+// abortScope runs the shared convergence sequence for a scope whose subject
+// failed: skip any still-open members, propagate non-gc.* member metadata (e.g.
+// review.verdict) onto the scope body so diagnostics survive failure auto-close,
+// then close the body with outcome=fail. It returns the number of members
+// skipped. traceID identifies the bead driving the trace and is also the id
+// ignored when skipping open members. The caller owns closing its own control
+// bead. This is the single implementation shared by processScopeCheck and
+// reconcileTerminalScopedMember.
+func abortScope(store beads.Store, snapshot scopeSnapshot, opts ProcessOptions, traceID string) (int, error) {
+	bodyID := snapshot.body.ID
+	skipped, err := tracePhase(opts, traceID, "skip-open-members", func() (int, error) {
+		return snapshot.skipOpenScopeMembers(store, traceID)
+	})
+	if err != nil {
+		return 0, fmt.Errorf("%s: aborting scope: %w", traceID, err)
+	}
+	if err := tracePhaseErr(opts, traceID, "propagate-metadata", func() error {
+		return snapshot.propagateScopeMemberMetadata(store, bodyID)
+	}); err != nil {
+		return 0, fmt.Errorf("%s: propagating scope metadata: %w", traceID, err)
+	}
+	if err := tracePhaseErr(opts, traceID, "close-body-fail", func() error {
+		return setOutcomeAndClose(store, bodyID, beadmeta.OutcomeFail)
+	}); err != nil {
+		return 0, fmt.Errorf("%s: completing scope body: %w", bodyID, err)
+	}
+	return skipped, nil
 }
 
 type scopeSnapshot struct {
@@ -1134,17 +1139,9 @@ func reconcileTerminalScopedMemberWithOptions(store beads.Store, bead beads.Bead
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: loading scope snapshot for %s: %w", bead.ID, scopeRef, err)
 		}
-		skipped, err := snapshot.skipOpenScopeMembers(store, bead.ID)
+		skipped, err := abortScope(store, snapshot, opts, bead.ID)
 		if err != nil {
-			return ControlResult{}, fmt.Errorf("%s: aborting scope: %w", bead.ID, err)
-		}
-		// Propagate non-gc.* member metadata (e.g., review.verdict) onto the
-		// scope body before closing, so diagnostics survive failure auto-close.
-		if err := snapshot.propagateScopeMemberMetadata(store, body.ID); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: propagating scope metadata: %w", bead.ID, err)
-		}
-		if err := setOutcomeAndClose(store, body.ID, beadmeta.OutcomeFail); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: completing scope body: %w", body.ID, err)
+			return ControlResult{}, err
 		}
 		return ControlResult{Processed: true, Action: "scope-fail", Skipped: skipped}, nil
 	}
@@ -1168,20 +1165,8 @@ func reconcileTerminalScopedMemberWithOptions(store beads.Store, bead beads.Bead
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: loading scope snapshot for %s: %w", bead.ID, scopeRef, err)
 	}
-	if err := snapshot.propagateScopeMemberMetadata(store, body.ID); err != nil {
-		return ControlResult{}, fmt.Errorf("%s: propagating scope metadata: %w", bead.ID, err)
-	}
-	outputJSON, err := snapshot.resolveScopeOutputJSON(bead)
-	if err != nil {
-		return ControlResult{}, fmt.Errorf("%s: resolving scope output: %w", bead.ID, err)
-	}
-	if outputJSON != "" {
-		if err := store.SetMetadata(body.ID, beadmeta.OutputJSONMetadataKey, outputJSON); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: propagating scope output: %w", body.ID, err)
-		}
-	}
-	if err := setOutcomeAndClose(store, body.ID, beadmeta.OutcomePass); err != nil {
-		return ControlResult{}, fmt.Errorf("%s: completing scope body: %w", body.ID, err)
+	if err := closeScopeAsPassed(store, snapshot, bead, opts, bead.ID); err != nil {
+		return ControlResult{}, err
 	}
 	return ControlResult{Processed: true, Action: "scope-pass"}, nil
 }

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -9624,3 +9624,178 @@ func TestProcessWorkflowFinalize_PurgeOnMissingDir(t *testing.T) {
 		t.Fatalf("result = %+v, want processed", result)
 	}
 }
+
+// TestCloseScopeAsPassedSharedConvergence exercises the single scope-close
+// helper that both processScopeCheck branches and reconcileTerminalScopedMember
+// now share: propagate non-gc.* member metadata onto the body, write the
+// resolved output_json, and close the body pass unless it is already closed.
+func TestCloseScopeAsPassedSharedConvergence(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		bodyStatus     string
+		wantCloseTrace bool
+	}{
+		{name: "open body closes pass", bodyStatus: "open", wantCloseTrace: true},
+		{name: "already closed body is not re-closed", bodyStatus: "closed", wantCloseTrace: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := beads.NewMemStore()
+			workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+				Title:    "workflow",
+				Type:     "task",
+				Metadata: map[string]string{"gc.kind": "workflow", "gc.formula_contract": "graph.v2"},
+			})
+			body := mustCreateWorkflowBead(t, store, beads.Bead{
+				Title:  "body",
+				Type:   "task",
+				Status: tc.bodyStatus,
+				Metadata: map[string]string{
+					"gc.kind":         "scope",
+					"gc.scope_role":   "body",
+					"gc.root_bead_id": workflow.ID,
+					"gc.scope_ref":    "body",
+					"gc.step_ref":     "demo.body",
+				},
+			})
+			subject := mustCreateWorkflowBead(t, store, beads.Bead{
+				Title:  "member",
+				Type:   "task",
+				Status: "closed",
+				Metadata: map[string]string{
+					"gc.root_bead_id": workflow.ID,
+					"gc.scope_ref":    "body",
+					"gc.scope_role":   "member",
+					"gc.outcome":      "pass",
+					"gc.output_json":  `{"verdict":"approved"}`,
+					"review.verdict":  "done",
+				},
+			})
+
+			snapshot, err := loadScopeSnapshotWithBody(store, workflow.ID, "body", body)
+			if err != nil {
+				t.Fatalf("loadScopeSnapshotWithBody: %v", err)
+			}
+			var trace bytes.Buffer
+			opts := ProcessOptions{Tracef: func(format string, args ...any) {
+				fmt.Fprintf(&trace, format+"\n", args...) //nolint:errcheck // test buffer
+			}}
+			if err := closeScopeAsPassed(store, snapshot, subject, opts, subject.ID); err != nil {
+				t.Fatalf("closeScopeAsPassed: %v", err)
+			}
+
+			bodyAfter := mustGetBead(t, store, body.ID)
+			if bodyAfter.Status != "closed" {
+				t.Fatalf("body status = %q, want closed", bodyAfter.Status)
+			}
+			// Member metadata and output_json bubble onto the body regardless of
+			// whether the body was already closed.
+			if got := bodyAfter.Metadata["review.verdict"]; got != "done" {
+				t.Fatalf("body review.verdict = %q, want done", got)
+			}
+			if got := bodyAfter.Metadata["gc.output_json"]; got != `{"verdict":"approved"}` {
+				t.Fatalf("body gc.output_json = %q, want approved payload", got)
+			}
+			if tc.wantCloseTrace {
+				if got := bodyAfter.Metadata["gc.outcome"]; got != "pass" {
+					t.Fatalf("body outcome = %q, want pass", got)
+				}
+			}
+
+			traceText := trace.String()
+			for _, want := range []string{"phase=propagate-metadata", "phase=resolve-output", "phase=write-output", "phase=reload-body"} {
+				if !strings.Contains(traceText, want) {
+					t.Fatalf("trace missing %q:\n%s", want, traceText)
+				}
+			}
+			gotClose := strings.Contains(traceText, "phase=close-body ")
+			if gotClose != tc.wantCloseTrace {
+				t.Fatalf("close-body trace present=%v, want %v:\n%s", gotClose, tc.wantCloseTrace, traceText)
+			}
+		})
+	}
+}
+
+// TestAbortScopeSharedConvergence exercises the single scope-abort helper shared
+// by processScopeCheck and reconcileTerminalScopedMember: skip still-open
+// members, propagate closed-member metadata onto the body, and close the body
+// fail.
+func TestAbortScopeSharedConvergence(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:    "workflow",
+		Type:     "task",
+		Metadata: map[string]string{"gc.kind": "workflow", "gc.formula_contract": "graph.v2"},
+	})
+	body := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.step_ref":     "demo.body",
+		},
+	})
+	failed := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "failed member",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.outcome":      "fail",
+			"review.verdict":  "blocked",
+		},
+	})
+	openMember := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "open member",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+		},
+	})
+
+	snapshot, err := loadScopeSnapshotWithBody(store, workflow.ID, "body", body)
+	if err != nil {
+		t.Fatalf("loadScopeSnapshotWithBody: %v", err)
+	}
+	var trace bytes.Buffer
+	opts := ProcessOptions{Tracef: func(format string, args ...any) {
+		fmt.Fprintf(&trace, format+"\n", args...) //nolint:errcheck // test buffer
+	}}
+	skipped, err := abortScope(store, snapshot, opts, failed.ID)
+	if err != nil {
+		t.Fatalf("abortScope: %v", err)
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", skipped)
+	}
+
+	bodyAfter := mustGetBead(t, store, body.ID)
+	if bodyAfter.Status != "closed" || bodyAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("body = status %q outcome %q, want closed/fail", bodyAfter.Status, bodyAfter.Metadata["gc.outcome"])
+	}
+	if got := bodyAfter.Metadata["review.verdict"]; got != "blocked" {
+		t.Fatalf("body review.verdict = %q, want blocked", got)
+	}
+	openAfter := mustGetBead(t, store, openMember.ID)
+	if openAfter.Status != "closed" || openAfter.Metadata["gc.outcome"] != "skipped" {
+		t.Fatalf("open member = status %q outcome %q, want closed/skipped", openAfter.Status, openAfter.Metadata["gc.outcome"])
+	}
+
+	traceText := trace.String()
+	for _, want := range []string{"phase=skip-open-members", "phase=propagate-metadata", "phase=close-body-fail"} {
+		if !strings.Contains(traceText, want) {
+			t.Fatalf("trace missing %q:\n%s", want, traceText)
+		}
+	}
+}


### PR DESCRIPTION
## What this does

Lands **S37** — extracts a single scope-close/scope-abort reconciler in
`internal/dispatch`: byte-matched behavior-preserving dedup (3 close paths →
1, 2 abort paths → 1, 3 fanout epilogues → one-liners), independently
verified. New `runtime_test.go` coverage pins the unified behavior.

## Gates

- `go build ./internal/dispatch ./cmd/gc` — pass
- `go vet ./internal/dispatch` — pass
- `go test ./internal/dispatch` — pass

## Review verdict

LAND — fast-track (no `status/needs-review-auto` label), byte-matched
behavior-preserving dedup, per the simplification walkthrough. Merge after CI
green; delete branch on merge.
