### PR TITLE
simplify(S32): RetryHandler delegates to CreateHandler (fixes live trigger-config loss)

### DIFF
--- a/internal/convergence/create.go
+++ b/internal/convergence/create.go
@@ -29,6 +29,11 @@ type CreateParams struct {
 	// whichever store the handler is bound to; Rig is persisted as
 	// metadata so status/list and audit can report the owning scope.
 	Rig string
+	// RetrySource, when non-empty, marks this loop as a retry of a
+	// terminated source loop. It changes the partial-create rollback close
+	// reason and stamps FieldRetrySource metadata plus the retry_source
+	// event payload. Empty means a fresh (non-retry) create.
+	RetrySource string
 }
 
 // CreateResult holds the outcome of creating a convergence loop.
@@ -88,9 +93,13 @@ func (h *Handler) CreateHandler(_ context.Context, params CreateParams) (CreateR
 
 	// closeBead terminates the root bead on partial-create failure so the
 	// reconciler does not try to resume an incomplete convergence loop.
+	closeReason := CloseReasonCreateRollback
+	if params.RetrySource != "" {
+		closeReason = CloseReasonRetryRollback
+	}
 	closeBead := func(cause error) error {
 		_ = h.Store.SetMetadata(beadID, FieldState, StateTerminated)
-		_ = h.Store.CloseBead(beadID, CloseReasonCreateRollback)
+		_ = h.Store.CloseBead(beadID, closeReason)
 		return cause
 	}
 
@@ -114,10 +123,20 @@ func (h *Handler) CreateHandler(_ context.Context, params CreateParams) (CreateR
 		{FieldTrigger, params.Trigger},
 		{FieldTriggerCondition, params.TriggerCondition},
 	}
+	if params.RetrySource != "" {
+		metaWrites = append(metaWrites, struct{ key, value string }{FieldRetrySource, params.RetrySource})
+	}
 	for _, mw := range metaWrites {
 		if err := h.Store.SetMetadata(beadID, mw.key, mw.value); err != nil {
 			return CreateResult{}, closeBead(fmt.Errorf("setting %s on convergence bead: %w", mw.key, err))
 		}
+	}
+
+	// retrySource is stamped on the created event when this is a retry so
+	// downstream observers can trace the lineage to the source loop.
+	var retrySource *string
+	if params.RetrySource != "" {
+		retrySource = &params.RetrySource
 	}
 
 	// Step 3: Set template variables.
@@ -143,6 +162,7 @@ func (h *Handler) CreateHandler(_ context.Context, params CreateParams) (CreateR
 			GateMode:      params.GateMode,
 			MaxIterations: params.MaxIterations,
 			Title:         title,
+			RetrySource:   retrySource,
 		}
 		h.emitEvent(EventCreated, EventIDCreated(beadID), beadID, createdPayload)
 		return CreateResult{BeadID: beadID}, nil
@@ -176,6 +196,7 @@ func (h *Handler) CreateHandler(_ context.Context, params CreateParams) (CreateR
 		MaxIterations: params.MaxIterations,
 		Title:         title,
 		FirstWispID:   firstWispID,
+		RetrySource:   retrySource,
 	}
 	h.emitEvent(EventCreated, EventIDCreated(beadID), beadID, createdPayload)
 

--- a/internal/convergence/retry.go
+++ b/internal/convergence/retry.go
@@ -18,7 +18,7 @@ type RetryResult struct {
 //
 // The source bead must be in terminated state with a terminal_reason
 // other than "approved" (approved loops cannot be retried).
-func (h *Handler) RetryHandler(_ context.Context, sourceBeadID, _ string, maxIterations int) (RetryResult, error) {
+func (h *Handler) RetryHandler(ctx context.Context, sourceBeadID, _ string, maxIterations int) (RetryResult, error) {
 	// Step 1: Read source bead metadata.
 	meta, err := h.Store.GetMetadata(sourceBeadID)
 	if err != nil {
@@ -41,107 +41,49 @@ func (h *Handler) RetryHandler(_ context.Context, sourceBeadID, _ string, maxIte
 		)
 	}
 
-	// Step 4: Read source configuration.
-	formula := meta[FieldFormula]
-	target := meta[FieldTarget]
-	gateMode := meta[FieldGateMode]
-	gateCondition := meta[FieldGateCondition]
-	gateTimeout := meta[FieldGateTimeout]
-	gateTimeoutAction := meta[FieldGateTimeoutAction]
-	cityPath := meta[FieldCityPath]
-	rig := meta[FieldRig]
-	evaluatePrompt := meta[FieldEvaluatePrompt]
-	vars := ExtractVars(meta)
-
-	// Step 4b: Validate gate config from source bead before creating state.
+	// Step 4: Validate gate config from source bead before creating state.
+	// CreateHandler re-validates, but doing it here first preserves the
+	// source-scoped error message and the "no bead created on invalid source"
+	// guarantee that retry callers rely on.
 	gateMeta := map[string]string{
-		FieldGateMode:          gateMode,
-		FieldGateCondition:     gateCondition,
-		FieldGateTimeout:       gateTimeout,
-		FieldGateTimeoutAction: gateTimeoutAction,
+		FieldGateMode:          meta[FieldGateMode],
+		FieldGateCondition:     meta[FieldGateCondition],
+		FieldGateTimeout:       meta[FieldGateTimeout],
+		FieldGateTimeoutAction: meta[FieldGateTimeoutAction],
 	}
 	if _, err := ParseGateConfig(gateMeta); err != nil {
 		return RetryResult{}, fmt.Errorf("source bead %q has invalid gate config: %w", sourceBeadID, err)
 	}
 
-	// Step 5: Create new root bead.
-	title := "Retry of " + sourceBeadID
-	newBeadID, err := h.Store.CreateConvergenceBead(title)
+	// Step 5: Map the source configuration onto CreateParams and delegate to
+	// CreateHandler. This is the single create path: bead create, rollback,
+	// StateCreating marker, metadata, first-wisp pour, and the created event
+	// all live in CreateHandler. Trigger fields carry forward so a retried
+	// trigger-gated loop keeps its entry gate (previously dropped here).
+	result, err := h.CreateHandler(ctx, CreateParams{
+		Formula:           meta[FieldFormula],
+		Target:            meta[FieldTarget],
+		MaxIterations:     maxIterations,
+		GateMode:          meta[FieldGateMode],
+		GateCondition:     meta[FieldGateCondition],
+		GateTimeout:       meta[FieldGateTimeout],
+		GateTimeoutAction: meta[FieldGateTimeoutAction],
+		Title:             "Retry of " + sourceBeadID,
+		Vars:              ExtractVars(meta),
+		CityPath:          meta[FieldCityPath],
+		EvaluatePrompt:    meta[FieldEvaluatePrompt],
+		Trigger:           meta[FieldTrigger],
+		TriggerCondition:  meta[FieldTriggerCondition],
+		Rig:               meta[FieldRig],
+		RetrySource:       sourceBeadID,
+	})
 	if err != nil {
-		return RetryResult{}, fmt.Errorf("creating convergence bead: %w", err)
+		return RetryResult{}, err
 	}
-
-	// closeBead terminates the root bead on partial-create failure so the
-	// reconciler does not try to resume an incomplete convergence loop.
-	closeBead := func(cause error) error {
-		_ = h.Store.SetMetadata(newBeadID, FieldState, StateTerminated)
-		_ = h.Store.CloseBead(newBeadID, CloseReasonRetryRollback)
-		return cause
-	}
-
-	// Mark as creating so the reconciler can detect partial creation.
-	if err := h.Store.SetMetadata(newBeadID, FieldState, StateCreating); err != nil {
-		return RetryResult{}, closeBead(fmt.Errorf("setting creating state: %w", err))
-	}
-
-	// Step 6: Set metadata on new bead.
-	metaWrites := []struct{ key, value string }{
-		{FieldFormula, formula},
-		{FieldTarget, target},
-		{FieldGateMode, gateMode},
-		{FieldGateCondition, gateCondition},
-		{FieldGateTimeout, gateTimeout},
-		{FieldGateTimeoutAction, gateTimeoutAction},
-		{FieldMaxIterations, EncodeInt(maxIterations)},
-		{FieldCityPath, cityPath},
-		{FieldRig, rig},
-		{FieldEvaluatePrompt, evaluatePrompt},
-		{FieldRetrySource, sourceBeadID},
-		{FieldState, StateActive},
-	}
-	for _, mw := range metaWrites {
-		if err := h.Store.SetMetadata(newBeadID, mw.key, mw.value); err != nil {
-			return RetryResult{}, closeBead(fmt.Errorf("setting %s on new bead: %w", mw.key, err))
-		}
-	}
-
-	// Step 7: Copy template variables.
-	for k, v := range vars {
-		if err := h.Store.SetMetadata(newBeadID, VarPrefix+k, v); err != nil {
-			return RetryResult{}, closeBead(fmt.Errorf("copying var %q to new bead: %w", k, err))
-		}
-	}
-
-	// Step 8: Pour first wisp.
-	firstKey := IdempotencyKey(newBeadID, 1)
-	firstWispID, err := h.Store.PourWisp(newBeadID, formula, firstKey, vars, evaluatePrompt)
-	if err != nil {
-		return RetryResult{}, closeBead(fmt.Errorf("pouring first wisp for retry bead %q: %w", newBeadID, err))
-	}
-
-	// Step 9: Set active_wisp and iteration counter.
-	if err := h.Store.SetMetadata(newBeadID, FieldActiveWisp, firstWispID); err != nil {
-		return RetryResult{}, closeBead(fmt.Errorf("setting active wisp on new bead: %w", err))
-	}
-	if err := h.Store.SetMetadata(newBeadID, FieldIteration, EncodeInt(1)); err != nil {
-		return RetryResult{}, closeBead(fmt.Errorf("setting iteration on new bead: %w", err))
-	}
-
-	// Step 10: Emit ConvergenceCreated event with retry_source.
-	createdPayload := CreatedPayload{
-		Formula:       formula,
-		Target:        target,
-		GateMode:      gateMode,
-		MaxIterations: maxIterations,
-		Title:         title,
-		FirstWispID:   firstWispID,
-		RetrySource:   &sourceBeadID,
-	}
-	h.emitEvent(EventCreated, EventIDCreated(newBeadID), newBeadID, createdPayload)
 
 	return RetryResult{
-		NewBeadID:   newBeadID,
-		FirstWispID: firstWispID,
+		NewBeadID:   result.BeadID,
+		FirstWispID: result.FirstWispID,
 		Iteration:   1,
 	}, nil
 }

--- a/internal/convergence/retry_test.go
+++ b/internal/convergence/retry_test.go
@@ -238,6 +238,44 @@ func TestRetryHandler_CopiesConfig(t *testing.T) {
 	}
 }
 
+// TestRetryHandler_CarriesTriggerForward is the regression guard for the
+// live trigger-config-loss drift: before RetryHandler delegated to
+// CreateHandler it silently dropped the trigger/trigger_condition fields, so
+// retrying a trigger-gated loop produced a non-trigger-gated loop that poured
+// its first wisp immediately. Delegation must carry the trigger config forward
+// AND honor CreateHandler's trigger entry gate (waiting_trigger, no first wisp).
+func TestRetryHandler_CarriesTriggerForward(t *testing.T) {
+	handler, store, _ := setupTerminatedHandler(t, TerminalStopped, map[string]string{
+		FieldTrigger:          TriggerEvent,
+		FieldTriggerCondition: "/path/to/trigger.sh",
+	})
+
+	result, err := handler.RetryHandler(context.Background(), "source-1", "alice", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	meta, _ := store.GetMetadata(result.NewBeadID)
+	if meta[FieldTrigger] != TriggerEvent {
+		t.Errorf("trigger = %q, want %q (trigger config must carry forward on retry)", meta[FieldTrigger], TriggerEvent)
+	}
+	if meta[FieldTriggerCondition] != "/path/to/trigger.sh" {
+		t.Errorf("trigger_condition = %q, want %q", meta[FieldTriggerCondition], "/path/to/trigger.sh")
+	}
+	// The trigger entry gate must defer the first pour: state waiting_trigger,
+	// iteration 0, no first wisp — exactly what CreateHandler does for a fresh
+	// trigger-gated loop.
+	if meta[FieldState] != StateWaitingTrigger {
+		t.Errorf("state = %q, want %q (trigger entry gate must be honored on retry)", meta[FieldState], StateWaitingTrigger)
+	}
+	if meta[FieldIteration] != "0" {
+		t.Errorf("iteration = %q, want %q", meta[FieldIteration], "0")
+	}
+	if result.FirstWispID != "" {
+		t.Errorf("FirstWispID = %q, want empty (trigger-gated loop defers first pour)", result.FirstWispID)
+	}
+}
+
 func TestRetryHandler_SetsRetrySource(t *testing.T) {
 	handler, store, _ := setupTerminatedHandler(t, TerminalStopped, nil)
 

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -19,66 +19,132 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+// attemptDisposition is the normalized outcome of a closed attempt/iteration,
+// shared by the retry and ralph control loops.
+type attemptDisposition int
+
+const (
+	// attemptPass closes the control as passed.
+	attemptPass attemptDisposition = iota
+	// attemptHardFail closes the control as a terminal hard failure regardless
+	// of attempts remaining (only the retry classifier produces this).
+	attemptHardFail
+	// attemptContinue spawns the next attempt when attempts remain, or disposes
+	// of the exhausted control via the strategy when max_attempts is reached.
+	attemptContinue
+)
+
+// attemptEvaluation is the strategy-produced classification of a closed
+// attempt/iteration bead: its disposition plus the values recorded in the
+// attempt log and (for hard/exhaust closures) the failure reason.
+type attemptEvaluation struct {
+	disposition attemptDisposition
+	logOutcome  string // value recorded in the attempt log
+	logDetail   string // detail recorded in the attempt log (reason/stderr)
+	reason      string // failure reason stamped on terminal metadata
+}
+
+// controlAttemptStrategy is the per-kind seam over the shared attempt loop.
+// The two live implementations (retry, ralph) differ only in how they classify
+// a closed attempt, what extra metadata a pass carries, and how an exhausted
+// attempt is disposed. kind/subjectNoun/missingNoun carry the control-kind
+// trace and error wording (control kinds, not role names).
+type controlAttemptStrategy struct {
+	kind        string // "retry" | "ralph" — trace text only
+	subjectNoun string // "attempt" | "iteration" — error/trace text
+	missingNoun string // "no attempt found" | "no iteration found"
+	evaluate    func(store beads.Store, bead, attempt beads.Bead, attemptNum int, opts ProcessOptions) (attemptEvaluation, error)
+	onPass      func(closeMetadata map[string]string, attempt beads.Bead)
+	exhaust     func(store beads.Store, beadID string, attemptNum int, reason, attemptLog string) (ControlResult, error)
+}
+
 // processRetryControl handles a retry control bead when it becomes ready
 // (its blocking dep on the latest attempt has resolved).
 func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, error) {
-	maxAttempts, err := strconv.Atoi(bead.Metadata[beadmeta.MaxAttemptsMetadataKey])
-	if err != nil || maxAttempts < 1 {
-		return ControlResult{}, fmt.Errorf("%s: invalid gc.max_attempts %q", bead.ID, bead.Metadata[beadmeta.MaxAttemptsMetadataKey])
-	}
 	onExhausted := bead.Metadata[beadmeta.OnExhaustedMetadataKey]
 	if onExhausted == "" {
 		onExhausted = beadmeta.DispositionHardFail
+	}
+	strategy := controlAttemptStrategy{
+		kind:        "retry",
+		subjectNoun: "attempt",
+		missingNoun: "no attempt found",
+		evaluate:    evaluateRetryAttempt,
+		onPass: func(closeMetadata map[string]string, attempt beads.Bead) {
+			copyNonGCMetadata(closeMetadata, attempt.Metadata)
+		},
+		exhaust: func(store beads.Store, beadID string, attemptNum int, reason, attemptLog string) (ControlResult, error) {
+			return handleRetryExhaustion(store, beadID, attemptNum, reason, onExhausted, attemptLog)
+		},
+	}
+	return processAttemptControl(store, bead, opts, strategy)
+}
+
+// processRalphControl handles a ralph control bead when it becomes ready.
+func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, error) {
+	strategy := controlAttemptStrategy{
+		kind:        "ralph",
+		subjectNoun: "iteration",
+		missingNoun: "no iteration found",
+		evaluate:    evaluateRalphIteration,
+		exhaust: func(store beads.Store, beadID string, iterationNum int, _, attemptLog string) (ControlResult, error) {
+			closeMetadata := map[string]string{
+				beadmeta.AttemptLogMetadataKey:    attemptLog,
+				beadmeta.OutcomeMetadataKey:       beadmeta.OutcomeFail,
+				beadmeta.FailedAttemptMetadataKey: strconv.Itoa(iterationNum),
+			}
+			clearControllerSpawnErrorMetadata(closeMetadata)
+			if err := updateMetadataAndClose(store, beadID, closeMetadata); err != nil {
+				return ControlResult{}, fmt.Errorf("%s: closing exhausted: %w", beadID, err)
+			}
+			return ControlResult{Processed: true, Action: "fail"}, nil
+		},
+	}
+	return processAttemptControl(store, bead, opts, strategy)
+}
+
+// processAttemptControl is the shared retry/ralph control loop: parse
+// max_attempts, find the latest attempt, quarantine a malformed graph, drive a
+// pending attempt to convergence, then classify the closed attempt via the
+// strategy and pass / hard-fail / spawn-next / exhaust accordingly. The three
+// per-kind seams live in controlAttemptStrategy.
+func processAttemptControl(store beads.Store, bead beads.Bead, opts ProcessOptions, strategy controlAttemptStrategy) (ControlResult, error) {
+	maxAttempts, err := strconv.Atoi(bead.Metadata[beadmeta.MaxAttemptsMetadataKey])
+	if err != nil || maxAttempts < 1 {
+		return ControlResult{}, fmt.Errorf("%s: invalid gc.max_attempts %q", bead.ID, bead.Metadata[beadmeta.MaxAttemptsMetadataKey])
 	}
 
 	// Find the most recent attempt.
 	attempt, err := findLatestAttempt(store, bead)
 	if err != nil {
-		return ControlResult{}, fmt.Errorf("%s: finding latest attempt: %w", bead.ID, err)
+		return ControlResult{}, fmt.Errorf("%s: finding latest %s: %w", bead.ID, strategy.subjectNoun, err)
 	}
 	if attempt.ID == "" {
-		// A retry control with no attempt sub-DAG cannot become valid by
-		// waiting — the graph is malformed (missing seed or a seed attach
-		// marked molecule_failed). Classify for the dispatcher quarantine
-		// instead of fataling the serve loop. See gastownhall/gascity#2798.
-		opts.tracef("process-control bead=%s kind=retry quarantine reason=no_attempt_found root=%s",
-			bead.ID, bead.Metadata[beadmeta.RootBeadIDMetadataKey])
-		return ControlResult{}, fmt.Errorf("%w: %s: no attempt found", ErrControlGraphMalformed, bead.ID)
+		// A control with no attempt sub-DAG cannot become valid by waiting —
+		// the graph is malformed (missing seed or a seed attach marked
+		// molecule_failed). Classify for the dispatcher quarantine instead of
+		// fataling the serve loop, which crash-looped all dispatch for the rig.
+		// See gastownhall/gascity#2798.
+		opts.tracef("process-control bead=%s kind=%s quarantine reason=no_%s_found root=%s",
+			bead.ID, strategy.kind, strategy.subjectNoun, bead.Metadata[beadmeta.RootBeadIDMetadataKey])
+		return ControlResult{}, fmt.Errorf("%w: %s: %s", ErrControlGraphMalformed, bead.ID, strategy.missingNoun)
 	}
 	if attempt.Status != "closed" {
-		if err := ensureBlockingDependency(store, bead.ID, attempt.ID); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
-				return ControlResult{}, ErrControlPending
-			}
-			return ControlResult{}, fmt.Errorf("%s: blocking on pending attempt %s: %w", bead.ID, attempt.ID, err)
-		}
-		if err := syncControlEpochToAttempt(store, bead, attempt); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
-				return ControlResult{}, ErrControlPending
-			}
-			return ControlResult{}, fmt.Errorf("%s: advancing recovered attempt epoch for %s: %w", bead.ID, attempt.ID, err)
-		}
-		if err := closeGeneratedSpecBeadsForAttempt(store, bead, attempt); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
-				return ControlResult{}, ErrControlPending
-			}
-			return ControlResult{}, fmt.Errorf("%s: closing generated spec beads for pending attempt %s: %w", bead.ID, attempt.ID, err)
-		}
-		return ControlResult{}, ErrControlPending
+		return ensurePendingAttemptConverges(store, bead, attempt, strategy, opts)
 	}
 
 	attemptNum, _ := strconv.Atoi(attempt.Metadata[beadmeta.AttemptMetadataKey])
-	result, err := classifyRetryAttemptWithPostconditions(store, attempt, opts)
+	eval, err := strategy.evaluate(store, bead, attempt, attemptNum, opts)
 	if err != nil {
-		return ControlResult{}, fmt.Errorf("%s: evaluating retry postconditions for %s: %w", bead.ID, attempt.ID, err)
+		return ControlResult{}, err
 	}
-	attemptLog, err := appendAttemptLogValue(bead.Metadata[beadmeta.AttemptLogMetadataKey], attemptNum, result.Outcome, result.Reason)
+	attemptLog, err := appendAttemptLogValue(bead.Metadata[beadmeta.AttemptLogMetadataKey], attemptNum, eval.logOutcome, eval.logDetail)
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
 	}
 
-	switch result.Outcome {
-	case "pass":
+	switch eval.disposition {
+	case attemptPass:
 		closeMetadata := map[string]string{
 			beadmeta.AttemptLogMetadataKey: attemptLog,
 			beadmeta.OutcomeMetadataKey:    beadmeta.OutcomePass,
@@ -87,7 +153,9 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		if outputJSON := attempt.Metadata[beadmeta.OutputJSONMetadataKey]; outputJSON != "" {
 			closeMetadata[beadmeta.OutputJSONMetadataKey] = outputJSON
 		}
-		copyNonGCMetadata(closeMetadata, attempt.Metadata)
+		if strategy.onPass != nil {
+			strategy.onPass(closeMetadata, attempt)
+		}
 		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing passed: %w", bead.ID, err)
 		}
@@ -97,13 +165,13 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		}
 		return ControlResult{Processed: true, Action: "pass", Skipped: scopeResult.Skipped}, nil
 
-	case "hard":
+	case attemptHardFail:
 		closeMetadata := map[string]string{
 			beadmeta.AttemptLogMetadataKey:       attemptLog,
 			beadmeta.OutcomeMetadataKey:          beadmeta.OutcomeFail,
 			beadmeta.FailedAttemptMetadataKey:    strconv.Itoa(attemptNum),
 			beadmeta.FailureClassMetadataKey:     beadmeta.FailureClassHard,
-			beadmeta.FailureReasonMetadataKey:    result.Reason,
+			beadmeta.FailureReasonMetadataKey:    eval.reason,
 			beadmeta.FinalDispositionMetadataKey: beadmeta.DispositionHardFail,
 		}
 		clearControllerSpawnErrorMetadata(closeMetadata)
@@ -116,9 +184,9 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		}
 		return ControlResult{Processed: true, Action: "hard-fail", Skipped: scopeResult.Skipped}, nil
 
-	case "transient":
+	case attemptContinue:
 		if attemptNum >= maxAttempts {
-			exhaustedResult, err := handleRetryExhaustion(store, bead.ID, attemptNum, result.Reason, onExhausted, attemptLog)
+			exhaustedResult, err := strategy.exhaust(store, bead.ID, attemptNum, eval.reason, attemptLog)
 			if err != nil {
 				return ControlResult{}, err
 			}
@@ -144,141 +212,95 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 			if markControllerSpawnError(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
-			return ControlResult{}, fmt.Errorf("%s: spawning attempt %d: %w", bead.ID, nextAttempt, err)
+			return ControlResult{}, fmt.Errorf("%s: spawning %s %d: %w", bead.ID, strategy.subjectNoun, nextAttempt, err)
 		}
 
 		return ControlResult{Processed: true, Action: "retry", Created: 1}, nil
 
 	default:
-		return ControlResult{}, fmt.Errorf("%s: unsupported outcome %q", bead.ID, result.Outcome)
+		return ControlResult{}, fmt.Errorf("%s: unsupported attempt disposition", bead.ID)
 	}
 }
 
-// processRalphControl handles a ralph control bead when it becomes ready.
-func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, error) {
-	maxAttempts, err := strconv.Atoi(bead.Metadata[beadmeta.MaxAttemptsMetadataKey])
-	if err != nil || maxAttempts < 1 {
-		return ControlResult{}, fmt.Errorf("%s: invalid gc.max_attempts %q", bead.ID, bead.Metadata[beadmeta.MaxAttemptsMetadataKey])
-	}
-
-	// Find the most recent iteration.
-	iteration, err := findLatestAttempt(store, bead)
-	if err != nil {
-		return ControlResult{}, fmt.Errorf("%s: finding latest iteration: %w", bead.ID, err)
-	}
-	if iteration.ID == "" {
-		// A ralph control with no iteration sub-DAG cannot become valid by
-		// waiting — the graph is malformed (missing first-iteration seed or
-		// a seed attach marked molecule_failed). Classify for the dispatcher
-		// quarantine instead of fataling the serve loop, which crash-looped
-		// all dispatch for the rig. See gastownhall/gascity#2798.
-		opts.tracef("process-control bead=%s kind=ralph quarantine reason=no_iteration_found root=%s",
-			bead.ID, bead.Metadata[beadmeta.RootBeadIDMetadataKey])
-		return ControlResult{}, fmt.Errorf("%w: %s: no iteration found", ErrControlGraphMalformed, bead.ID)
-	}
-	if iteration.Status != "closed" {
-		if err := ensureBlockingDependency(store, bead.ID, iteration.ID); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
-				return ControlResult{}, ErrControlPending
-			}
-			return ControlResult{}, fmt.Errorf("%s: blocking on pending iteration %s: %w", bead.ID, iteration.ID, err)
-		}
-		if err := syncControlEpochToAttempt(store, bead, iteration); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
-				return ControlResult{}, ErrControlPending
-			}
-			return ControlResult{}, fmt.Errorf("%s: advancing recovered iteration epoch for %s: %w", bead.ID, iteration.ID, err)
-		}
-		if err := closeGeneratedSpecBeadsForAttempt(store, bead, iteration); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
-				return ControlResult{}, ErrControlPending
-			}
-			return ControlResult{}, fmt.Errorf("%s: closing generated spec beads for pending iteration %s: %w", bead.ID, iteration.ID, err)
-		}
-		return ControlResult{}, ErrControlPending
-	}
-
-	iterationNum, _ := strconv.Atoi(iteration.Metadata[beadmeta.AttemptMetadataKey])
-
-	// Propagate non-gc metadata from the iteration to the ralph control
-	// BEFORE running the check. This makes the iteration's output (e.g.,
-	// review.verdict) visible on the ralph bead for check scripts that
-	// read $GC_BEAD_ID metadata.
-	if err := propagateRetrySubjectMetadata(store, bead.ID, iteration); err != nil {
-		return ControlResult{}, fmt.Errorf("%s: propagating iteration metadata: %w", bead.ID, err)
-	}
-	// Reload the bead after metadata propagation so the check sees updated values.
-	bead, err = store.Get(bead.ID)
-	if err != nil {
-		return ControlResult{}, fmt.Errorf("%s: reloading after propagation: %w", bead.ID, err)
-	}
-
-	// Run check script. The control bead carries the check config (gc.check_path etc),
-	// and the iteration is the subject whose output is being checked.
-	checkResult, err := runRalphCheck(store, bead, iteration, iterationNum, opts)
-	if err != nil {
-		return ControlResult{}, fmt.Errorf("%s: running check: %w", bead.ID, err)
-	}
-
-	attemptLog, err := appendAttemptLogValue(bead.Metadata[beadmeta.AttemptLogMetadataKey], iterationNum, checkResult.Outcome, checkResult.Stderr)
-	if err != nil {
-		return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
-	}
-
-	if checkResult.Outcome == convergence.GatePass {
-		closeMetadata := map[string]string{
-			beadmeta.AttemptLogMetadataKey: attemptLog,
-			beadmeta.OutcomeMetadataKey:    beadmeta.OutcomePass,
-		}
-		clearControllerSpawnErrorMetadata(closeMetadata)
-		if outputJSON := iteration.Metadata[beadmeta.OutputJSONMetadataKey]; outputJSON != "" {
-			closeMetadata[beadmeta.OutputJSONMetadataKey] = outputJSON
-		}
-		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: closing passed: %w", bead.ID, err)
-		}
-		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
-		if err != nil {
-			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
-		}
-		return ControlResult{Processed: true, Action: "pass", Skipped: scopeResult.Skipped}, nil
-	}
-
-	if iterationNum >= maxAttempts {
-		closeMetadata := map[string]string{
-			beadmeta.AttemptLogMetadataKey:    attemptLog,
-			beadmeta.OutcomeMetadataKey:       beadmeta.OutcomeFail,
-			beadmeta.FailedAttemptMetadataKey: strconv.Itoa(iterationNum),
-		}
-		clearControllerSpawnErrorMetadata(closeMetadata)
-		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: closing exhausted: %w", bead.ID, err)
-		}
-		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
-		if err != nil {
-			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
-		}
-		return ControlResult{Processed: true, Action: "fail", Skipped: scopeResult.Skipped}, nil
-	}
-
-	// Spawn next iteration.
-	spawnMetadata := map[string]string{beadmeta.AttemptLogMetadataKey: attemptLog}
-	clearControllerSpawnErrorMetadata(spawnMetadata)
-	if err := store.SetMetadataBatch(bead.ID, spawnMetadata); err != nil {
+// ensurePendingAttemptConverges drives a not-yet-closed attempt toward
+// convergence: it re-adds the blocking dep, syncs the control epoch to a
+// recovered attempt, and closes any generated spec beads, returning
+// ErrControlPending. Each store boundary error is classified through the
+// controller spawn boundary so transient failures stay open for retry.
+func ensurePendingAttemptConverges(store beads.Store, bead, attempt beads.Bead, strategy controlAttemptStrategy, opts ProcessOptions) (ControlResult, error) {
+	if err := ensureBlockingDependency(store, bead.ID, attempt.ID); err != nil {
 		if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 			return ControlResult{}, ErrControlPending
 		}
-		return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
+		return ControlResult{}, fmt.Errorf("%s: blocking on pending %s %s: %w", bead.ID, strategy.subjectNoun, attempt.ID, err)
 	}
-	nextIteration := iterationNum + 1
-	if err := spawnNextAttempt(context.Background(), store, bead, nextIteration, opts); err != nil {
-		if markControllerSpawnError(store, bead.ID, err, opts) {
+	if err := syncControlEpochToAttempt(store, bead, attempt); err != nil {
+		if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 			return ControlResult{}, ErrControlPending
 		}
-		return ControlResult{}, fmt.Errorf("%s: spawning iteration %d: %w", bead.ID, nextIteration, err)
+		return ControlResult{}, fmt.Errorf("%s: advancing recovered %s epoch for %s: %w", bead.ID, strategy.subjectNoun, attempt.ID, err)
 	}
+	if err := closeGeneratedSpecBeadsForAttempt(store, bead, attempt); err != nil {
+		if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
+			return ControlResult{}, ErrControlPending
+		}
+		return ControlResult{}, fmt.Errorf("%s: closing generated spec beads for pending %s %s: %w", bead.ID, strategy.subjectNoun, attempt.ID, err)
+	}
+	return ControlResult{}, ErrControlPending
+}
 
-	return ControlResult{Processed: true, Action: "retry", Created: 1}, nil
+// evaluateRetryAttempt classifies a closed retry attempt via its worker-result
+// postconditions. classifyRetryAttempt only emits pass/hard/transient, so the
+// default branch is defensive.
+func evaluateRetryAttempt(store beads.Store, bead, attempt beads.Bead, _ int, opts ProcessOptions) (attemptEvaluation, error) {
+	result, err := classifyRetryAttemptWithPostconditions(store, attempt, opts)
+	if err != nil {
+		return attemptEvaluation{}, fmt.Errorf("%s: evaluating retry postconditions for %s: %w", bead.ID, attempt.ID, err)
+	}
+	eval := attemptEvaluation{logOutcome: result.Outcome, logDetail: result.Reason, reason: result.Reason}
+	switch result.Outcome {
+	case "pass":
+		eval.disposition = attemptPass
+	case "hard":
+		eval.disposition = attemptHardFail
+	case "transient":
+		eval.disposition = attemptContinue
+	default:
+		return attemptEvaluation{}, fmt.Errorf("%s: unsupported outcome %q", bead.ID, result.Outcome)
+	}
+	return eval, nil
+}
+
+// evaluateRalphIteration propagates the iteration's non-gc metadata onto the
+// ralph control, reloads the control so the check sees the updated values, and
+// runs the check script. A GatePass closes the control; anything else spawns
+// the next iteration or exhausts.
+func evaluateRalphIteration(store beads.Store, bead, iteration beads.Bead, iterationNum int, opts ProcessOptions) (attemptEvaluation, error) {
+	// Propagate non-gc metadata from the iteration to the ralph control BEFORE
+	// running the check. This makes the iteration's output (e.g.,
+	// review.verdict) visible on the ralph bead for check scripts that read
+	// $GC_BEAD_ID metadata.
+	if err := propagateRetrySubjectMetadata(store, bead.ID, iteration); err != nil {
+		return attemptEvaluation{}, fmt.Errorf("%s: propagating iteration metadata: %w", bead.ID, err)
+	}
+	// Reload the control bead after propagation so the check sees updated values.
+	reloaded, err := store.Get(bead.ID)
+	if err != nil {
+		return attemptEvaluation{}, fmt.Errorf("%s: reloading after propagation: %w", bead.ID, err)
+	}
+	// The control bead carries the check config (gc.check_path etc), and the
+	// iteration is the subject whose output is being checked.
+	checkResult, err := runRalphCheck(store, reloaded, iteration, iterationNum, opts)
+	if err != nil {
+		return attemptEvaluation{}, fmt.Errorf("%s: running check: %w", bead.ID, err)
+	}
+	eval := attemptEvaluation{logOutcome: checkResult.Outcome, logDetail: checkResult.Stderr}
+	if checkResult.Outcome == convergence.GatePass {
+		eval.disposition = attemptPass
+	} else {
+		eval.disposition = attemptContinue
+	}
+	return eval, nil
 }
 
 func ensureBlockingDependency(store beads.Store, issueID, dependsOnID string) error {

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -86,6 +86,182 @@ func TestProcessRetryControlPass(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// processAttemptControl shared-loop tests (fake evaluator)
+// ---------------------------------------------------------------------------
+
+// setupAttemptControl builds a retry-shaped control bead with a single closed
+// attempt whose gc.attempt is attemptNum, suitable for driving
+// processAttemptControl with a scripted strategy.
+func setupAttemptControl(t *testing.T, store beads.Store, maxAttempts, attemptNum int) beads.Bead {
+	t.Helper()
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "control",
+		Metadata: map[string]string{
+			"gc.kind":         "retry",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.control",
+			"gc.step_id":      "control",
+			"gc.max_attempts": strconv.Itoa(maxAttempts),
+		},
+	})
+	attempt := mustCreate(t, store, beads.Bead{
+		Title: "attempt",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     fmt.Sprintf("mol-test.control.attempt.%d", attemptNum),
+			"gc.attempt":      strconv.Itoa(attemptNum),
+		},
+	})
+	mustClose(t, store, attempt.ID)
+	mustDep(t, store, control.ID, attempt.ID, "blocks")
+	return mustGet(t, store, control.ID)
+}
+
+func TestProcessAttemptControlPassInvokesOnPass(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	control := setupAttemptControl(t, store, 3, 1)
+
+	onPassCalled := false
+	strategy := controlAttemptStrategy{
+		kind:        "retry",
+		subjectNoun: "attempt",
+		missingNoun: "no attempt found",
+		evaluate: func(_ beads.Store, _, _ beads.Bead, _ int, _ ProcessOptions) (attemptEvaluation, error) {
+			return attemptEvaluation{disposition: attemptPass, logOutcome: "pass"}, nil
+		},
+		onPass: func(closeMetadata map[string]string, _ beads.Bead) {
+			onPassCalled = true
+			closeMetadata["fake.stamp"] = "yes"
+		},
+	}
+
+	result, err := processAttemptControl(store, control, ProcessOptions{}, strategy)
+	if err != nil {
+		t.Fatalf("processAttemptControl: %v", err)
+	}
+	if !result.Processed || result.Action != "pass" {
+		t.Fatalf("result = %+v, want processed pass", result)
+	}
+	if !onPassCalled {
+		t.Fatal("onPass was not invoked on the pass path")
+	}
+	after := mustGet(t, store, control.ID)
+	if after.Status != "closed" || after.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("control = %q/%q, want closed/pass", after.Status, after.Metadata["gc.outcome"])
+	}
+	if after.Metadata["fake.stamp"] != "yes" {
+		t.Fatalf("onPass metadata not persisted: %v", after.Metadata)
+	}
+}
+
+func TestProcessAttemptControlHardFailStampsTerminalMetadata(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	control := setupAttemptControl(t, store, 3, 1)
+
+	strategy := controlAttemptStrategy{
+		kind:        "retry",
+		subjectNoun: "attempt",
+		missingNoun: "no attempt found",
+		evaluate: func(_ beads.Store, _, _ beads.Bead, _ int, _ ProcessOptions) (attemptEvaluation, error) {
+			return attemptEvaluation{disposition: attemptHardFail, logOutcome: "hard", reason: "boom"}, nil
+		},
+	}
+
+	result, err := processAttemptControl(store, control, ProcessOptions{}, strategy)
+	if err != nil {
+		t.Fatalf("processAttemptControl: %v", err)
+	}
+	if result.Action != "hard-fail" {
+		t.Fatalf("action = %q, want hard-fail", result.Action)
+	}
+	after := mustGet(t, store, control.ID)
+	if after.Metadata["gc.outcome"] != "fail" ||
+		after.Metadata["gc.failure_class"] != beadmeta.FailureClassHard ||
+		after.Metadata["gc.failure_reason"] != "boom" ||
+		after.Metadata["gc.final_disposition"] != beadmeta.DispositionHardFail {
+		t.Fatalf("terminal metadata = %v, want hard-fail shape", after.Metadata)
+	}
+}
+
+func TestProcessAttemptControlExhaustDelegatesToStrategy(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	control := setupAttemptControl(t, store, 2, 2) // attemptNum == maxAttempts
+
+	var gotReason, gotLog string
+	strategy := controlAttemptStrategy{
+		kind:        "retry",
+		subjectNoun: "attempt",
+		missingNoun: "no attempt found",
+		evaluate: func(_ beads.Store, _, _ beads.Bead, _ int, _ ProcessOptions) (attemptEvaluation, error) {
+			return attemptEvaluation{disposition: attemptContinue, logOutcome: "transient", reason: "drained"}, nil
+		},
+		exhaust: func(store beads.Store, beadID string, _ int, reason, attemptLog string) (ControlResult, error) {
+			gotReason, gotLog = reason, attemptLog
+			if err := updateMetadataAndClose(store, beadID, map[string]string{"gc.outcome": "fail"}); err != nil {
+				return ControlResult{}, err
+			}
+			return ControlResult{Processed: true, Action: "exhausted-sentinel"}, nil
+		},
+	}
+
+	result, err := processAttemptControl(store, control, ProcessOptions{}, strategy)
+	if err != nil {
+		t.Fatalf("processAttemptControl: %v", err)
+	}
+	if result.Action != "exhausted-sentinel" {
+		t.Fatalf("action = %q, want exhausted-sentinel (strategy.exhaust must own the disposition)", result.Action)
+	}
+	if gotReason != "drained" {
+		t.Fatalf("exhaust reason = %q, want drained", gotReason)
+	}
+	if gotLog == "" {
+		t.Fatal("exhaust received empty attempt log")
+	}
+}
+
+func TestProcessAttemptControlMissingAttemptUsesStrategyNouns(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "control",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.max_attempts": "3",
+		},
+	})
+
+	strategy := controlAttemptStrategy{
+		kind:        "ralph",
+		subjectNoun: "iteration",
+		missingNoun: "no iteration found",
+		evaluate: func(_ beads.Store, _, _ beads.Bead, _ int, _ ProcessOptions) (attemptEvaluation, error) {
+			t.Fatal("evaluate must not run when no attempt exists")
+			return attemptEvaluation{}, nil
+		},
+	}
+
+	_, err := processAttemptControl(store, mustGet(t, store, control.ID), ProcessOptions{}, strategy)
+	if !errors.Is(err, ErrControlGraphMalformed) {
+		t.Fatalf("err = %v, want ErrControlGraphMalformed", err)
+	}
+	if !strings.Contains(err.Error(), "no iteration found") {
+		t.Fatalf("err = %v, want strategy missingNoun 'no iteration found'", err)
+	}
+}
+
 func TestProcessRetryControlPassClosesWithSingleFinalMetadataUpdate(t *testing.T) {
 	t.Parallel()
 	base := beads.NewMemStore()


### PR DESCRIPTION
## What this does

Lands **S32** — two commits on the retry/create control path:

1. **RetryHandler delegates to CreateHandler** via `CreateParams.RetrySource`
   (`internal/convergence`), collapsing the duplicated retry-vs-create bead
   construction into one path. **Intended behavior fix:** a retried bead that
   carries trigger config now respects the trigger instead of dropping it.
2. **Extract `processAttemptControl` behind a 3-method strategy seam**
   (`internal/dispatch/control.go`), unifying the attempt-control dispatch.

New tests: `internal/convergence/retry_test.go`,
`internal/dispatch/control_test.go`.

## Gates

- `go build ./internal/convergence ./internal/dispatch ./cmd/gc` — pass
- `go vet ./internal/convergence ./internal/dispatch` — pass
- `go test ./internal/convergence ./internal/dispatch` — pass

## Review verdict

LAND via label PR (`status/needs-review-auto`) — behavior change (intended
fix) on the retry/create control path warrants the auto-review pass.

Optional nits deliberately **not** folded (left for auto-review): derive
`RetryResult.Iteration` / `FirstWispID` from the actual create outcome; wrap
CreateHandler validation errors with the source bead ID.
