### PR TITLE
simplify(S09): typed SleepReason vocabulary + beadmeta dispatch keys

### DIFF
--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -241,6 +241,22 @@ const (
 	LegacyWorkDirMetadataKey = "work_dir"
 )
 
+// Dispatch metadata keys: a non-"gc."-prefixed family that sling writes onto
+// work and source beads to wire molecules together and record the merge
+// strategy. They predate the gc. namespace convention and their on-store
+// strings are load-bearing (the run-chain resolver in runid.go and the graph
+// dispatch readers key on them), so they are declared here — like the
+// directory keys above — to give the vocabulary one home without changing any
+// wire value. They are intentionally NOT in KnownMetadataKeys, whose drift
+// guard only covers the gc. namespace.
+const (
+	// MoleculeIDMetadataKey links a poured/wisp work bead to its molecule root.
+	MoleculeIDMetadataKey = "molecule_id"
+
+	// MergeStrategyMetadataKey records the merge strategy chosen for a slung bead.
+	MergeStrategyMetadataKey = "merge_strategy"
+)
+
 // OptionMetadataPrefix is the dynamic non-"gc."-prefixed key prefix under
 // which provider option choices are stored as opt_<OptionsSchema key> (e.g.
 // opt_model, opt_effort) on session and work beads. The suffix is open-world

--- a/internal/beadmeta/runid.go
+++ b/internal/beadmeta/runid.go
@@ -7,7 +7,7 @@ import "strings"
 // nested-workflow root (gc.root_bead_id). workflow_id and molecule_id are the
 // engine's bare (non-"gc."-namespaced) run-chain keys written by internal/sling;
 // RootBeadIDMetadataKey is the gc.-namespaced nesting root.
-var runIDChainKeys = []string{"workflow_id", "molecule_id", RootBeadIDMetadataKey}
+var runIDChainKeys = []string{"workflow_id", MoleculeIDMetadataKey, RootBeadIDMetadataKey}
 
 // ResolveRunID derives the run-root identifier for a bead from its metadata run
 // chain, falling back to the bead's own id and then a caller-supplied fallback.

--- a/internal/session/lifecycle_exits.go
+++ b/internal/session/lifecycle_exits.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -129,29 +128,6 @@ func DecideSessionExit(f ExitFacts) ExitOutcome {
 	return ExitChurn
 }
 
-// IsDeliberateSleepReason reports whether a sleep_reason records an
-// intentional stop rather than a crash, so the death must not accrue churn.
-// "city-stop" mirrors the CLI's stop sleep reason.
-// "provider-terminal-error" is a classified, non-retryable provider failure
-// (set by markProviderTerminalError); it is suppressed here so a session
-// already parked terminal cannot also accrue a spurious wake failure, making
-// the invariant explicit rather than relying on last_woke_at being cleared in
-// the same metadata batch.
-// The reason list deliberately diverges from shouldResetContinuation's
-// near-identical list (this one has "failed-create" and lacks
-// "runtime-missing"): that one decides continuation reset on wake, this one
-// decides churn suppression — do not merge the lists.
-func IsDeliberateSleepReason(reason string) bool {
-	switch strings.TrimSpace(reason) {
-	case "idle", "idle-timeout", "no-wake-reason", "config-drift", "drained",
-		"city-stop", "user-hold", "wait-hold", "rate_limit", "failed-create",
-		"provider-terminal-error":
-		return true
-	default:
-		return false
-	}
-}
-
 func parseWakeStamp(raw string) (time.Time, bool) {
 	if raw == "" {
 		return time.Time{}, false
@@ -176,14 +152,14 @@ type ExitAccrual struct {
 // session until the given time with sleep reason "quarantine". The patch is
 // metadata-only; unlike QuarantinePatch it does not move the state machine.
 func WakeFailureAccrualPatch(priorAttempts, maxAttempts int, until time.Time) ExitAccrual {
-	return exitAccrual("wake_attempts", priorAttempts+1, maxAttempts, "quarantine", until)
+	return exitAccrual("wake_attempts", priorAttempts+1, maxAttempts, string(SleepReasonQuarantine), until)
 }
 
 // ChurnAccrualPatch builds the write for one more churn cycle on top of
 // priorCycles. Reaching maxCycles quarantines the session until the given
 // time with sleep reason "context-churn".
 func ChurnAccrualPatch(priorCycles, maxCycles int, until time.Time) ExitAccrual {
-	return exitAccrual("churn_count", priorCycles+1, maxCycles, "context-churn", until)
+	return exitAccrual("churn_count", priorCycles+1, maxCycles, string(SleepReasonContextChurn), until)
 }
 
 func exitAccrual(counterKey string, next, threshold int, sleepReason string, until time.Time) ExitAccrual {
@@ -223,7 +199,7 @@ func RateLimitQuarantinePatch(until time.Time) MetadataPatch {
 	return MetadataPatch{
 		"state":                     string(StateAsleep),
 		"quarantined_until":         until.UTC().Format(time.RFC3339),
-		"sleep_reason":              "rate_limit",
+		"sleep_reason":              string(SleepReasonRateLimit),
 		"last_woke_at":              "",
 		"pending_create_claim":      "",
 		"pending_create_started_at": "",

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -360,25 +360,26 @@ func lifecycleDisplayReasonFromView(view LifecycleView, metadata map[string]stri
 	if strings.TrimSpace(metadata[SessionCircuitStateMetadataKey]) == SessionCircuitStateOpen {
 		return LifecycleReasonCircuitOpen
 	}
-	if reason := strings.TrimSpace(metadata["sleep_reason"]); reason != "" {
-		staleTimedQuarantine := (reason == "quarantine" || reason == "context-churn" || reason == "rate_limit") &&
+	if raw := strings.TrimSpace(metadata["sleep_reason"]); raw != "" {
+		reason := SleepReason(raw)
+		staleTimedQuarantine := (reason == SleepReasonQuarantine || reason == SleepReasonContextChurn || reason == SleepReasonRateLimit) &&
 			strings.TrimSpace(metadata["quarantined_until"]) != "" &&
 			!view.HasBlocker(BlockerQuarantined)
-		staleTimedHold := reason == "user-hold" &&
+		staleTimedHold := reason == SleepReasonUserHold &&
 			strings.TrimSpace(metadata["held_until"]) != "" &&
 			!view.HasBlocker(BlockerHeld)
 		if !staleTimedQuarantine && !staleTimedHold {
-			return reason
+			return raw
 		}
 	}
 	if view.HasBlocker(BlockerQuarantined) {
-		return "quarantine"
+		return string(SleepReasonQuarantine)
 	}
 	if strings.TrimSpace(metadata["wait_hold"]) != "" {
-		return "wait-hold"
+		return string(SleepReasonWaitHold)
 	}
 	if view.HasBlocker(BlockerHeld) {
-		return "user-hold"
+		return string(SleepReasonUserHold)
 	}
 	return ""
 }
@@ -692,8 +693,15 @@ func shouldResetContinuation(base BaseState, input LifecycleInput, sleepReason s
 	if strings.TrimSpace(input.SessionKey) == "" && strings.TrimSpace(input.StartedConfigHash) == "" {
 		return false
 	}
-	switch strings.TrimSpace(sleepReason) {
-	case "idle", "idle-timeout", "no-wake-reason", "config-drift", "drained", "city-stop", "user-hold", "wait-hold", "rate_limit", "runtime-missing":
+	// This list deliberately diverges from IsDeliberateSleepReason's near-identical
+	// list (this one has "runtime-missing" and lacks "failed-create"): that one
+	// decides churn suppression, this one decides continuation reset on wake — do
+	// not merge the lists.
+	switch SleepReason(strings.TrimSpace(sleepReason)) {
+	case SleepReasonIdle, SleepReasonIdleTimeout, SleepReasonNoWakeReason,
+		SleepReasonConfigDrift, SleepReasonDrained, SleepReasonCityStop,
+		SleepReasonUserHold, SleepReasonWaitHold, SleepReasonRateLimit,
+		SleepReasonRuntimeMissing:
 		return false
 	}
 	return base == BaseStateActive || base == BaseStateCreating

--- a/internal/session/lifecycle_timers.go
+++ b/internal/session/lifecycle_timers.go
@@ -120,7 +120,7 @@ func DecideMaxSessionAge(f TimerFacts) TimerDecision {
 		Action:       TimerActionStop,
 		TraceReason:  "max_session_age",
 		TraceOutcome: "stop",
-		SleepReason:  "max-session-age",
+		SleepReason:  string(SleepReasonMaxSessionAge),
 	}
 }
 
@@ -149,7 +149,7 @@ func DecideIdleTimeout(f TimerFacts) TimerDecision {
 		Action:       TimerActionStop,
 		TraceReason:  "idle_timeout",
 		TraceOutcome: "stop",
-		SleepReason:  "idle-timeout",
+		SleepReason:  string(SleepReasonIdleTimeout),
 	}
 }
 

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -172,8 +172,9 @@ func ClearWakeBlockersPatch(state State, sleepReason string) MetadataPatch {
 	case StateSuspended, StateDrained:
 		patch["state"] = string(StateAsleep)
 	}
-	switch sleepReason {
-	case "user-hold", "wait-hold", "quarantine", "context-churn", "rate_limit", string(StateDrained):
+	switch SleepReason(sleepReason) {
+	case SleepReasonUserHold, SleepReasonWaitHold, SleepReasonQuarantine,
+		SleepReasonContextChurn, SleepReasonRateLimit, SleepReasonDrained:
 		patch["sleep_reason"] = ""
 	}
 	return patch
@@ -185,7 +186,7 @@ func ClearExpiredHoldPatch(sleepReason string) MetadataPatch {
 	patch := MetadataPatch{
 		"held_until": "",
 	}
-	if sleepReason == "user-hold" {
+	if SleepReason(sleepReason) == SleepReasonUserHold {
 		patch["sleep_reason"] = ""
 	}
 	return patch
@@ -199,8 +200,8 @@ func ClearExpiredQuarantinePatch(sleepReason string) MetadataPatch {
 		"wake_attempts":     "0",
 		"churn_count":       "0",
 	}
-	switch sleepReason {
-	case "quarantine", "context-churn", "rate_limit":
+	switch SleepReason(sleepReason) {
+	case SleepReasonQuarantine, SleepReasonContextChurn, SleepReasonRateLimit:
 		patch["sleep_reason"] = ""
 	}
 	return patch

--- a/internal/session/sleep_reason.go
+++ b/internal/session/sleep_reason.go
@@ -1,0 +1,61 @@
+package session
+
+import "strings"
+
+// SleepReason is the typed vocabulary for the sleep_reason bead-metadata
+// marker. Before this type the ~fifteen sleep-reason strings were matched as
+// raw literals across four independent classifier case lists (churn
+// suppression, continuation reset, display reason, wake-blocker clearing) plus
+// scattered writers, so a misspelled writer ("rate-limit" vs "rate_limit")
+// silently escaped every classifier. Routing both the writers and the
+// classifiers through these constants makes such a typo a compile error.
+//
+// The on-store string values are unchanged; SleepReason is a thin string alias
+// so a raw metadata value converts with SleepReason(value) at the read edge.
+type SleepReason string
+
+// Sleep-reason values written to and read from the sleep_reason metadata key.
+// SleepReasonRuntimeMissing shares its string with LifecycleReasonRuntimeMissing
+// (the display-reason surface of the same posture); it is defined from that
+// constant so the two never drift.
+const (
+	SleepReasonIdle                  SleepReason = "idle"
+	SleepReasonIdleTimeout           SleepReason = "idle-timeout"
+	SleepReasonNoWakeReason          SleepReason = "no-wake-reason"
+	SleepReasonConfigDrift           SleepReason = "config-drift"
+	SleepReasonDrained               SleepReason = "drained"
+	SleepReasonCityStop              SleepReason = "city-stop"
+	SleepReasonUserHold              SleepReason = "user-hold"
+	SleepReasonWaitHold              SleepReason = "wait-hold"
+	SleepReasonRateLimit             SleepReason = "rate_limit"
+	SleepReasonFailedCreate          SleepReason = "failed-create"
+	SleepReasonProviderTerminalError SleepReason = "provider-terminal-error"
+	SleepReasonRuntimeMissing        SleepReason = SleepReason(LifecycleReasonRuntimeMissing)
+	SleepReasonQuarantine            SleepReason = "quarantine"
+	SleepReasonContextChurn          SleepReason = "context-churn"
+	SleepReasonMaxSessionAge         SleepReason = "max-session-age"
+)
+
+// IsDeliberateSleepReason reports whether a sleep_reason records an
+// intentional stop rather than a crash, so the death must not accrue churn.
+// "city-stop" mirrors the CLI's stop sleep reason.
+// "provider-terminal-error" is a classified, non-retryable provider failure
+// (set by markProviderTerminalError); it is suppressed here so a session
+// already parked terminal cannot also accrue a spurious wake failure, making
+// the invariant explicit rather than relying on last_woke_at being cleared in
+// the same metadata batch.
+// The reason list deliberately diverges from shouldResetContinuation's
+// near-identical list (this one has "failed-create" and lacks
+// "runtime-missing"): that one decides continuation reset on wake, this one
+// decides churn suppression — do not merge the lists.
+func IsDeliberateSleepReason(reason string) bool {
+	switch SleepReason(strings.TrimSpace(reason)) {
+	case SleepReasonIdle, SleepReasonIdleTimeout, SleepReasonNoWakeReason,
+		SleepReasonConfigDrift, SleepReasonDrained, SleepReasonCityStop,
+		SleepReasonUserHold, SleepReasonWaitHold, SleepReasonRateLimit,
+		SleepReasonFailedCreate, SleepReasonProviderTerminalError:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/session/sleep_reason_test.go
+++ b/internal/session/sleep_reason_test.go
@@ -1,0 +1,69 @@
+package session
+
+import "testing"
+
+// TestSleepReasonConstantValues pins the on-store string of every sleep reason
+// so a constant edit that would change the wire value is caught here rather
+// than silently reclassifying live beads.
+func TestSleepReasonConstantValues(t *testing.T) {
+	want := map[SleepReason]string{
+		SleepReasonIdle:                  "idle",
+		SleepReasonIdleTimeout:           "idle-timeout",
+		SleepReasonNoWakeReason:          "no-wake-reason",
+		SleepReasonConfigDrift:           "config-drift",
+		SleepReasonDrained:               "drained",
+		SleepReasonCityStop:              "city-stop",
+		SleepReasonUserHold:              "user-hold",
+		SleepReasonWaitHold:              "wait-hold",
+		SleepReasonRateLimit:             "rate_limit",
+		SleepReasonFailedCreate:          "failed-create",
+		SleepReasonProviderTerminalError: "provider-terminal-error",
+		SleepReasonRuntimeMissing:        "runtime-missing",
+		SleepReasonQuarantine:            "quarantine",
+		SleepReasonContextChurn:          "context-churn",
+		SleepReasonMaxSessionAge:         "max-session-age",
+	}
+	for reason, str := range want {
+		if string(reason) != str {
+			t.Errorf("SleepReason %q = %q, want %q", str, string(reason), str)
+		}
+	}
+	// SleepReasonRuntimeMissing must stay pinned to the shared display-reason
+	// constant so the two surfaces of the same posture never drift apart.
+	if string(SleepReasonRuntimeMissing) != LifecycleReasonRuntimeMissing {
+		t.Errorf("SleepReasonRuntimeMissing = %q, want %q (LifecycleReasonRuntimeMissing)",
+			SleepReasonRuntimeMissing, LifecycleReasonRuntimeMissing)
+	}
+}
+
+// TestSleepReasonListDivergence locks in the documented, deliberate divergence
+// between the churn-suppression list (IsDeliberateSleepReason) and the
+// continuation-reset list (shouldResetContinuation): the former has
+// "failed-create" and lacks "runtime-missing"; the latter is the reverse.
+// Merging the two lists is a bug, so this test fails if they ever converge on
+// those two elements.
+func TestSleepReasonListDivergence(t *testing.T) {
+	// failed-create: deliberate stop (no churn) but NOT a reset-suppressor.
+	if !IsDeliberateSleepReason(string(SleepReasonFailedCreate)) {
+		t.Error("failed-create must be a deliberate sleep reason")
+	}
+	if resetSuppressed(t, SleepReasonFailedCreate) {
+		t.Error("failed-create must NOT suppress continuation reset")
+	}
+
+	// runtime-missing: reset-suppressor but NOT churn-deliberate.
+	if IsDeliberateSleepReason(string(SleepReasonRuntimeMissing)) {
+		t.Error("runtime-missing must NOT be a deliberate sleep reason")
+	}
+	if !resetSuppressed(t, SleepReasonRuntimeMissing) {
+		t.Error("runtime-missing must suppress continuation reset")
+	}
+}
+
+// resetSuppressed reports whether shouldResetContinuation returns false (reset
+// suppressed) for the given reason on an otherwise reset-eligible input.
+func resetSuppressed(t *testing.T, reason SleepReason) bool {
+	t.Helper()
+	input := LifecycleInput{SessionKey: "sk-1"}
+	return !shouldResetContinuation(BaseStateActive, input, string(reason))
+}

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -56,7 +56,7 @@ func CollectAttachedBeads(parent beads.Bead, store beads.Store, childQuerier Bea
 		attachments = append(attachments, attached)
 	}
 
-	addByID(parent.Metadata["molecule_id"])
+	addByID(parent.Metadata[beadmeta.MoleculeIDMetadataKey])
 	addByID(parent.Metadata["workflow_id"])
 
 	if childQuerier != nil {
@@ -163,8 +163,8 @@ func clearAttachmentMetadata(store beads.Store, parent beads.Bead, attached bead
 			return err
 		}
 	}
-	if strings.TrimSpace(parent.Metadata["molecule_id"]) == attached.ID {
-		if err := store.SetMetadata(parent.ID, "molecule_id", ""); err != nil {
+	if strings.TrimSpace(parent.Metadata[beadmeta.MoleculeIDMetadataKey]) == attached.ID {
+		if err := store.SetMetadata(parent.ID, beadmeta.MoleculeIDMetadataKey, ""); err != nil {
 			return err
 		}
 	}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -367,7 +367,7 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 			wfResult.FormulaName = opts.OnFormula
 			return wfResult, wfErr
 		}
-		if err := deps.Store.SetMetadata(beadID, "molecule_id", wispRootID); err != nil {
+		if err := deps.Store.SetMetadata(beadID, beadmeta.MoleculeIDMetadataKey, wispRootID); err != nil {
 			result.MetadataErrors = append(result.MetadataErrors,
 				fmt.Sprintf("setting molecule_id on %s: %v", beadID, err))
 		}
@@ -479,7 +479,7 @@ func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 			wfResult.FormulaName = defaultFormula
 			return wfResult, wfErr
 		}
-		if err := deps.Store.SetMetadata(beadID, "molecule_id", wispRootID); err != nil {
+		if err := deps.Store.SetMetadata(beadID, beadmeta.MoleculeIDMetadataKey, wispRootID); err != nil {
 			result.MetadataErrors = append(result.MetadataErrors,
 				fmt.Sprintf("setting molecule_id on %s: %v", beadID, err))
 		}
@@ -551,7 +551,7 @@ func finalize(opts SlingOpts, deps SlingDeps, beadID, method string, result Slin
 
 	// Merge strategy metadata.
 	if opts.Merge != "" && deps.Store != nil {
-		if err := deps.Store.SetMetadata(beadID, "merge_strategy", opts.Merge); err != nil {
+		if err := deps.Store.SetMetadata(beadID, beadmeta.MergeStrategyMetadataKey, opts.Merge); err != nil {
 			result.MetadataErrors = append(result.MetadataErrors,
 				fmt.Sprintf("setting merge strategy: %v", err))
 		}
@@ -1094,7 +1094,7 @@ func attachBatchFormula(ctx context.Context, opts SlingOpts, deps SlingDeps, chi
 			WispRootID:  mResult.RootID,
 			FormulaName: formulaName,
 		}
-		if err := deps.Store.SetMetadata(child.ID, "molecule_id", mResult.RootID); err != nil {
+		if err := deps.Store.SetMetadata(child.ID, beadmeta.MoleculeIDMetadataKey, mResult.RootID); err != nil {
 			result.MetadataErrors = append(result.MetadataErrors,
 				fmt.Sprintf("setting molecule_id on %s: %v", child.ID, err))
 		}


### PR DESCRIPTION
## What this does

Lands **S09** — kills stringly-typed session/dispatch metadata by introducing a
typed `SleepReason` vocabulary (`internal/session/sleep_reason.go`) and typed
`beadmeta` dispatch/attachment keys, then routing the call sites through them.
Byte-identical typed-constant unification; new `sleep_reason_test.go`.

Touches `internal/beadmeta`, `internal/session`, `internal/sling`.

## Gates

- `go build ./internal/beadmeta ./internal/session ./internal/sling ./cmd/gc` — pass
- `go vet ./internal/beadmeta ./internal/session ./internal/sling` — pass
- `go test ./internal/beadmeta ./internal/session ./internal/sling` — pass

## Review verdict

LAND — fast-track (no `status/needs-review-auto` label), byte-identical
typed-constant unification, per the simplification walkthrough. Merge after CI
green; delete branch on merge.

Follow-ups deliberately not folded: migrate `cmd/gc` parallel sleep-reason
literals (~6 files); the deferred Part-1 table-driven Info codec.
