### PR TITLE
simplify(S19) stage 1: level-triggered session convergence

### DIFF
--- a/cmd/gc/adoption_barrier.go
+++ b/cmd/gc/adoption_barrier.go
@@ -168,14 +168,15 @@ func runAdoptionBarrier(
 		}
 
 		// Build bead metadata. Config/live hashes are left empty —
-		// syncSessionBeads populates them from built agent objects.
-		meta := map[string]string{
-			"session_name":       sessionName,
-			"state":              "active",
-			"generation":         strconv.Itoa(sessionpkg.DefaultGeneration),
-			"continuation_epoch": strconv.Itoa(sessionpkg.DefaultContinuationEpoch),
-			"instance_token":     sessionpkg.NewInstanceToken(),
-		}
+		// syncSessionBeads populates them from built agent objects. agent_name
+		// and pool_slot are stamped below once pool-base resolution completes.
+		meta := desiredSessionIdentity(sessionIdentityInputs{
+			SessionName:       sessionName,
+			State:             "active",
+			Generation:        sessionpkg.DefaultGeneration,
+			ContinuationEpoch: sessionpkg.DefaultContinuationEpoch,
+			InstanceToken:     sessionpkg.NewInstanceToken(),
+		})
 
 		detail := adoptionDetail{SessionName: sessionName}
 

--- a/cmd/gc/prompt_delivery.go
+++ b/cmd/gc/prompt_delivery.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/shellquote"
+)
+
+// promptDeliveryResult is the resolved plan for delivering a rendered startup
+// prompt to a freshly launched session: which argv suffix / flag / nudge
+// carries it, and whether any mechanism actually delivered it.
+type promptDeliveryResult struct {
+	PromptSuffix string
+	PromptFlag   string
+	Nudge        string
+	// Delivered reports whether the startup prompt reached a first-turn
+	// delivery mechanism. Callers stamp the GC_STARTUP_PROMPT_DELIVERED marker
+	// from this so observers can distinguish "primed" from "live but never
+	// primed".
+	Delivered bool
+}
+
+// promptDelivery decides how a rendered startup prompt is delivered for a
+// session launch. It is the single pure statement of the priming policy that
+// was previously duplicated across the launch, ACP, and prompt-mode branches.
+//
+// Delivery mechanism, in precedence order:
+//   - ACP or a "none" prompt-mode provider: prepend the prompt to the nudge.
+//   - flag prompt-mode with a configured flag: pass the prompt via argv suffix
+//     plus the provider's prompt flag.
+//   - default: pass the prompt as a quoted argv suffix.
+//
+// An empty prompt delivers nothing. Judgment about prompt *content* stays in
+// templates; this function only routes an already-rendered prompt and reports
+// delivered/not-delivered.
+func promptDelivery(prompt string, isACP bool, rp *config.ResolvedProvider, nudge string) promptDeliveryResult {
+	res := promptDeliveryResult{Nudge: nudge}
+	if prompt == "" {
+		return res
+	}
+	switch {
+	case isACP:
+		res.Nudge = prependStartupPromptToNudge(prompt, nudge)
+		res.Delivered = true
+	case rp != nil && rp.PromptMode == "none":
+		res.Nudge = prependStartupPromptToNudge(prompt, nudge)
+		res.Delivered = true
+	default:
+		res.PromptSuffix = shellquote.Quote(prompt)
+		res.Delivered = res.PromptSuffix != ""
+		if rp != nil && rp.PromptMode == "flag" {
+			if rp.PromptFlag != "" {
+				res.PromptFlag = rp.PromptFlag
+			} else {
+				res.Delivered = false
+			}
+		}
+	}
+	return res
+}

--- a/cmd/gc/prompt_delivery_test.go
+++ b/cmd/gc/prompt_delivery_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/shellquote"
+)
+
+func TestPromptDelivery(t *testing.T) {
+	const prompt = "do the work"
+	quoted := shellquote.Quote(prompt)
+
+	tests := []struct {
+		name  string
+		promp string
+		isACP bool
+		rp    *config.ResolvedProvider
+		nudge string
+		want  promptDeliveryResult
+	}{
+		{
+			name:  "empty prompt delivers nothing",
+			promp: "",
+			nudge: "wake",
+			want:  promptDeliveryResult{Nudge: "wake"},
+		},
+		{
+			name:  "acp prepends to nudge",
+			promp: prompt,
+			isACP: true,
+			nudge: "wake",
+			want: promptDeliveryResult{
+				Nudge:     prependStartupPromptToNudge(prompt, "wake"),
+				Delivered: true,
+			},
+		},
+		{
+			name:  "prompt-mode none prepends to nudge",
+			promp: prompt,
+			rp:    &config.ResolvedProvider{PromptMode: "none"},
+			nudge: "",
+			want: promptDeliveryResult{
+				Nudge:     prependStartupPromptToNudge(prompt, ""),
+				Delivered: true,
+			},
+		},
+		{
+			name:  "default arg mode uses quoted suffix",
+			promp: prompt,
+			rp:    &config.ResolvedProvider{PromptMode: "arg"},
+			nudge: "wake",
+			want: promptDeliveryResult{
+				PromptSuffix: quoted,
+				Nudge:        "wake",
+				Delivered:    true,
+			},
+		},
+		{
+			name:  "nil provider defaults to quoted suffix",
+			promp: prompt,
+			rp:    nil,
+			want: promptDeliveryResult{
+				PromptSuffix: quoted,
+				Delivered:    true,
+			},
+		},
+		{
+			name:  "flag mode with flag sets both suffix and flag",
+			promp: prompt,
+			rp:    &config.ResolvedProvider{PromptMode: "flag", PromptFlag: "--prompt"},
+			want: promptDeliveryResult{
+				PromptSuffix: quoted,
+				PromptFlag:   "--prompt",
+				Delivered:    true,
+			},
+		},
+		{
+			name:  "flag mode without flag is not delivered",
+			promp: prompt,
+			rp:    &config.ResolvedProvider{PromptMode: "flag"},
+			want: promptDeliveryResult{
+				PromptSuffix: quoted,
+				Delivered:    false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := promptDelivery(tt.promp, tt.isACP, tt.rp, tt.nudge)
+			if got != tt.want {
+				t.Errorf("promptDelivery() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1154,16 +1154,16 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				createState = string(session.StateStartPending)
 			}
 			instanceToken := session.NewInstanceToken()
-			meta := map[string]string{
-				"agent_name":         agentName,
-				"live_hash":          liveHash,
-				"session_origin":     origin,
-				"generation":         strconv.Itoa(session.DefaultGeneration),
-				"continuation_epoch": strconv.Itoa(session.DefaultContinuationEpoch),
-				"instance_token":     instanceToken,
-				"state":              createState,
-				"synced_at":          now.Format("2006-01-02T15:04:05Z07:00"),
-			}
+			meta := desiredSessionIdentity(sessionIdentityInputs{
+				AgentName:         agentName,
+				State:             createState,
+				Generation:        session.DefaultGeneration,
+				ContinuationEpoch: session.DefaultContinuationEpoch,
+				InstanceToken:     instanceToken,
+			})
+			meta["live_hash"] = liveHash
+			meta["session_origin"] = origin
+			meta["synced_at"] = now.Format("2006-01-02T15:04:05Z07:00")
 			if !isPoolInstance {
 				meta["session_name"] = sn
 			}

--- a/cmd/gc/session_identity.go
+++ b/cmd/gc/session_identity.go
@@ -1,0 +1,56 @@
+package main
+
+import "strconv"
+
+// sessionIdentityInputs are the durable facts that determine a session bead's
+// canonical identity metadata. It is deliberately a flat value so the identity
+// contract can be derived purely and table-tested, independent of the tmux /
+// provider boot paths that historically stamped identity inline.
+type sessionIdentityInputs struct {
+	// AgentName is the qualified agent (or instance) name. When empty, the
+	// caller stamps agent_name itself on a later path (the adoption barrier
+	// resolves it after pool-base matching).
+	AgentName string
+	// SessionName is the canonical runtime session name. When empty, the
+	// canonical name is assigned later (pending pool instances derive it from
+	// the instance token at create time).
+	SessionName string
+	// State is the lifecycle state metadata value (e.g. "active" or the
+	// start-pending sentinel).
+	State string
+	// Generation and ContinuationEpoch are the monotonic identity counters.
+	Generation        int
+	ContinuationEpoch int
+	// InstanceToken uniquely identifies this incarnation of the session.
+	InstanceToken string
+	// PoolSlot is the pool instance slot; 0 for singleton / non-pool sessions.
+	PoolSlot int
+}
+
+// desiredSessionIdentity states the canonical session-identity contract once,
+// as a pure derivation from durable facts. Every arrival path (fresh create,
+// adoption) previously hand-rolled its own subset of these keys; centralizing
+// the derivation is the S19 seed that makes "identity key omitted because you
+// arrived via the wrong path" harder to reintroduce.
+//
+// Keys are emitted only when meaningful: agent_name/session_name/pool_slot are
+// omitted when their inputs are zero so callers that assign those later (the
+// adoption barrier, pending pool creates) stay byte-identical.
+func desiredSessionIdentity(in sessionIdentityInputs) map[string]string {
+	meta := map[string]string{
+		"state":              in.State,
+		"generation":         strconv.Itoa(in.Generation),
+		"continuation_epoch": strconv.Itoa(in.ContinuationEpoch),
+		"instance_token":     in.InstanceToken,
+	}
+	if in.AgentName != "" {
+		meta["agent_name"] = in.AgentName
+	}
+	if in.SessionName != "" {
+		meta["session_name"] = in.SessionName
+	}
+	if in.PoolSlot > 0 {
+		meta["pool_slot"] = strconv.Itoa(in.PoolSlot)
+	}
+	return meta
+}

--- a/cmd/gc/session_identity_test.go
+++ b/cmd/gc/session_identity_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDesiredSessionIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		in   sessionIdentityInputs
+		want map[string]string
+	}{
+		{
+			name: "adoption base omits agent_name and pool_slot",
+			in: sessionIdentityInputs{
+				SessionName:       "city-worker",
+				State:             "active",
+				Generation:        1,
+				ContinuationEpoch: 1,
+				InstanceToken:     "tok-1",
+			},
+			want: map[string]string{
+				"session_name":       "city-worker",
+				"state":              "active",
+				"generation":         "1",
+				"continuation_epoch": "1",
+				"instance_token":     "tok-1",
+			},
+		},
+		{
+			name: "create base carries agent_name, omits session_name",
+			in: sessionIdentityInputs{
+				AgentName:         "gastown/worker",
+				State:             "start-pending",
+				Generation:        1,
+				ContinuationEpoch: 1,
+				InstanceToken:     "tok-2",
+			},
+			want: map[string]string{
+				"agent_name":         "gastown/worker",
+				"state":              "start-pending",
+				"generation":         "1",
+				"continuation_epoch": "1",
+				"instance_token":     "tok-2",
+			},
+		},
+		{
+			name: "pool slot stamped when positive",
+			in: sessionIdentityInputs{
+				AgentName:         "gastown/worker-3",
+				SessionName:       "city-worker-3",
+				State:             "active",
+				Generation:        2,
+				ContinuationEpoch: 5,
+				InstanceToken:     "tok-3",
+				PoolSlot:          3,
+			},
+			want: map[string]string{
+				"agent_name":         "gastown/worker-3",
+				"session_name":       "city-worker-3",
+				"state":              "active",
+				"generation":         "2",
+				"continuation_epoch": "5",
+				"instance_token":     "tok-3",
+				"pool_slot":          "3",
+			},
+		},
+		{
+			name: "zero pool slot omitted",
+			in: sessionIdentityInputs{
+				AgentName:         "a",
+				State:             "active",
+				Generation:        1,
+				ContinuationEpoch: 1,
+				InstanceToken:     "t",
+				PoolSlot:          0,
+			},
+			want: map[string]string{
+				"agent_name":         "a",
+				"state":              "active",
+				"generation":         "1",
+				"continuation_epoch": "1",
+				"instance_token":     "t",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := desiredSessionIdentity(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("desiredSessionIdentity() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/session_level_converge.go
+++ b/cmd/gc/session_level_converge.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"strings"
+	"time"
+)
+
+// Level-triggered session convergence core (S19, approach b — Stage 1 slice).
+//
+// The reconciler's Phase 1 today applies session side effects (identity
+// stamping, prompt priming, firstStart classification, rollback) edge-triggered
+// and path-dependent: each arrival path (fresh spawn, adoption, resume, drift
+// relaunch, rollback) stamps its own subset, so any new path silently ships a
+// missing side effect (#3872 / #3849 / #2073). This file replaces the *decision*
+// with a pure observe -> diff -> act core:
+//
+//   observe : build durableFacts (persisted bead metadata) + runtimeFacts
+//             (observed, non-persisted signals) up front.
+//   diff    : deriveConvergeActions turns (durable x runtime) into an ordered,
+//             idempotent action list — the same every tick regardless of how the
+//             session arrived.
+//   act     : the reconciler executes the actions under the existing
+//             alias/identifier locks and the worker boundary.
+//
+// This package decides WHICH actions are needed; it performs no I/O. That keeps
+// identity heal, prompt delivery, firstStart, and rollback table-testable
+// without a tmux or provider boot — the whole point of the level-triggered shape.
+//
+// Stage 1 amends the s19-b spike to the S19 spec §2 two-phase priming
+// vocabulary: a write-ahead attempt marker plus an explicit confirmation, so a
+// crash between the two never permanently loses the startup prompt (the s19-b
+// spike's at-most-once flaw). Nothing reads the action list yet; it is exercised
+// only by tests until Stage 3 wires the act loop.
+//
+// Naming note: this is unrelated to `gc converge` (convergence loops); this is
+// per-tick session-lifecycle convergence.
+
+// primeReattemptInterval bounds delivery-attempt backoff for the startup prompt:
+// once a delivery has been declared (priming_attempted_at stamped) but not yet
+// confirmed, no fresh attempt is emitted until this interval has elapsed. This
+// is mechanical transport backoff, not judgment. Default is 2× the reconcile
+// tick (patrol) interval, floored at 60s; the default patrol interval is 30s, so
+// the floor governs.
+const primeReattemptInterval = 60 * time.Second
+
+// sessTranscriptState is a tri-state observation of whether the runtime
+// transcript backing a session's resume key currently exists on disk. Unknown
+// means the converger did not (or could not) probe — a caller that cannot probe
+// must pass sessTranscriptUnknown so its decision matches the durable-only
+// legacy signal exactly.
+type sessTranscriptState int
+
+const (
+	// sessTranscriptUnknown means the transcript was not probed.
+	sessTranscriptUnknown sessTranscriptState = iota
+	// sessTranscriptPresent means the keyed transcript exists on disk.
+	sessTranscriptPresent
+	// sessTranscriptAbsent means the keyed transcript is known to be gone.
+	sessTranscriptAbsent
+)
+
+// durableFacts are the persisted (session-bead metadata) signals the converger
+// reads. Building these once, up front, is the "observe" half of the durable
+// world; every field maps to a single bead-metadata key so there is one source
+// of truth per fact rather than a precedence ladder. Time enters as a fact
+// (now, primingAttemptedAt) so the core stays clock-free and table-testable.
+type durableFacts struct {
+	// startedConfigHash mirrors "started_config_hash": "" means no durable record
+	// of a completed start yet.
+	startedConfigHash string
+	// primedAt mirrors "primed_at": non-empty means the startup prompt delivery
+	// was durably CONFIRMED (stamped only after a delivery mechanism reported
+	// success). It makes "live but never primed" detectable by any observer,
+	// unlike the runtime-only GC_STARTUP_PROMPT_DELIVERED.
+	primedAt string
+	// primingAttemptedAt mirrors "priming_attempted_at": the write-ahead attempt
+	// marker, stamped BEFORE any delivery I/O. Zero value means no attempt was
+	// ever declared. Its age gates re-attempts via primeReattemptInterval.
+	primingAttemptedAt time.Time
+	// primedPromptHash mirrors "prompt_hash": the hash of the rendered prompt the
+	// markers refer to. When it differs from currentPromptHash a stale attempt is
+	// re-eligible (the template's prompt changed under the session).
+	primedPromptHash string
+	// currentPromptHash is the hash of the currently-rendered startup prompt. It
+	// is a template-derived fact captured by the observe step, not persisted.
+	currentPromptHash string
+	// canonicalIdentity is the one canonical qualified instance name persisted on
+	// the session bead. "" means no canonical identity record exists yet, so the
+	// legacy read ladders would be consulted — the converger heals that by
+	// stamping the record.
+	canonicalIdentity string
+	// promptConfigured is true when the resolved template carries a startup
+	// prompt to deliver. When false there is nothing to prime and priming actions
+	// are never emitted (P5).
+	promptConfigured bool
+	// absent means the durable world says this session should not be running (the
+	// bead was closed or a pending create was rolled back). A lingering live
+	// runtime under an absent durable intent is the #2073 pane-leak shape.
+	absent bool
+	// now is the tick's wall clock, captured once by the observe step so the core
+	// reads no clock itself.
+	now time.Time
+}
+
+// runtimeFacts are the observed, non-persisted signals the converger reads —
+// the "observe" half of the runtime world. No I/O happens here; the caller has
+// already probed.
+type runtimeFacts struct {
+	// observed reports whether the runtime was actually probed this tick. When
+	// false, NO live-only or start/teardown action may be emitted (C5 observed
+	// gating); only durable-only heals are permitted.
+	observed bool
+	// live is true when a matching runtime session is present and alive.
+	live bool
+	// transcript is whether the keyed transcript exists on disk (tri-state).
+	transcript sessTranscriptState
+	// primedEnv is true when the live runtime env carries
+	// GC_STARTUP_PROMPT_DELIVERED — the prompt was delivered this runtime but may
+	// not yet be durably recorded.
+	primedEnv bool
+}
+
+// sessConvergeAction is one idempotent side effect the reconciler must apply to
+// bring the runtime and durable worlds into agreement. Emitting an action is a
+// pure decision; the reconciler performs the effect.
+type sessConvergeAction int
+
+const (
+	// actionRollbackRuntimeToAbsent tears down a runtime that lingers under an
+	// absent durable intent (rollback / closed bead), killing the pane leak. It
+	// dominates every other action and is never emitted when the runtime was not
+	// observed.
+	actionRollbackRuntimeToAbsent sessConvergeAction = iota
+	// actionStampCanonicalIdentity persists the canonical identity record when it
+	// is absent, collapsing the legacy read ladders into a single healed field. It
+	// is a durable-only heal, permitted even when the runtime was not observed.
+	actionStampCanonicalIdentity
+	// actionStampPrimedFromRuntime persists primed_at from an observed-live
+	// runtime that already carries GC_STARTUP_PROMPT_DELIVERED but lacks the
+	// durable confirmation. It heals the durable world with NO nudge — the prompt
+	// already landed this incarnation.
+	actionStampPrimedFromRuntime
+	// actionAttemptPrime is the two-phase delivery: stamp the write-ahead attempt
+	// marker, deliver via worker.Handle.Nudge, then stamp the confirmation. It is
+	// emitted only for an observed-live, prompt-bearing, unconfirmed session whose
+	// last attempt is stale enough to retry (attemptEligible).
+	actionAttemptPrime
+)
+
+// deriveFirstStart decides whether a launch should be treated as a first start
+// (fresh session via --session-id) rather than a resume (--resume), as a pure
+// function of the durable start hash and the observed transcript state.
+//
+// Legacy behavior was durable-only: firstStart == (started_config_hash == "").
+// Stage 1 preserves that EXACTLY — the comparison is the raw `== ""` the legacy
+// site used, with no TrimSpace (M10 / D4). Passing sessTranscriptUnknown
+// reproduces the legacy signal byte-for-byte, so existing call sites stay
+// behavior-preserving until they opt in to probing the transcript. The TrimSpace
+// variant is adopted deliberately at Stage 4 with its own test.
+//
+// S19 intent: firstStart is "no durable hash AND/OR no runtime transcript". A
+// present hash whose transcript is known-absent is the #3849 crash-loop shape —
+// the bead claims a prior start but the conversation a resume would target is
+// gone, so --resume hard-fails and the pane dies every tick. Classifying it as a
+// first start makes the launch use --session-id and breaks the loop by
+// construction. That branch is inert until a real probe is passed (Stage 4).
+func deriveFirstStart(startedConfigHash string, transcript sessTranscriptState) bool {
+	if startedConfigHash == "" {
+		return true
+	}
+	if transcript == sessTranscriptAbsent {
+		return true
+	}
+	return false
+}
+
+// attemptEligible reports whether a fresh startup-prompt delivery attempt may be
+// declared for a session that is live, prompt-bearing, and not yet confirmed
+// (primed_at == ""). It is pure delivery backoff (transport, not judgment):
+//
+//   - no attempt has ever been declared, or
+//   - the last attempt is at least primeReattemptInterval old (bounded retry),
+//     or
+//   - the markers refer to a different prompt than the one currently rendered
+//     (the template's prompt changed, so the old attempt is stale).
+func attemptEligible(d durableFacts) bool {
+	if d.primingAttemptedAt.IsZero() {
+		return true
+	}
+	if d.now.Sub(d.primingAttemptedAt) >= primeReattemptInterval {
+		return true
+	}
+	if d.primedPromptHash != d.currentPromptHash {
+		return true
+	}
+	return false
+}
+
+// deriveConvergeActions is the pure diff: given the durable and runtime facts
+// for one session, it returns the ordered, idempotent action list needed to
+// converge them. The order is load-bearing:
+//
+//   - Rollback dominates: an absent durable intent with an observed-live runtime
+//     means the only correct action is to converge the runtime to absent;
+//     identity/priming on a doomed runtime would be wasted work. Never emitted
+//     when the runtime was not observed (C5).
+//   - Otherwise, heal the canonical identity record first (so downstream readers
+//     see one agreed identity), then handle priming.
+//   - Priming is two-phase (§2). When the runtime already carries the delivered
+//     env marker we only heal the durable world (actionStampPrimedFromRuntime,
+//     no nudge). Otherwise we attempt a fresh delivery — but only when the last
+//     attempt is stale enough (attemptEligible), so a crash between the
+//     write-ahead attempt stamp and the confirmation re-delivers at most one
+//     duplicate per interval instead of nudging every tick forever.
+//
+// The function is total and side-effect-free, so (durable x runtime) -> actions
+// is fully table-testable. Re-running it after its actions have durably landed
+// yields the empty list (C2 idempotence).
+func deriveConvergeActions(d durableFacts, r runtimeFacts) []sessConvergeAction {
+	if d.absent {
+		// Rollback dominates, but only on an observed-live runtime: an unobserved
+		// runtime tells us nothing to tear down (C5).
+		if r.observed && r.live {
+			return []sessConvergeAction{actionRollbackRuntimeToAbsent}
+		}
+		return nil
+	}
+
+	var actions []sessConvergeAction
+
+	// Identity heal is a durable-only fact; permitted even when the runtime was
+	// not observed this tick.
+	if strings.TrimSpace(d.canonicalIdentity) == "" {
+		actions = append(actions, actionStampCanonicalIdentity)
+	}
+
+	// Priming requires an observed-live runtime, a prompt-bearing template, and no
+	// durable confirmation yet (P5 gates on promptConfigured).
+	if r.observed && r.live && d.promptConfigured && d.primedAt == "" {
+		switch {
+		case r.primedEnv:
+			// The runtime already got the prompt this incarnation; persist the
+			// confirmation without re-nudging.
+			actions = append(actions, actionStampPrimedFromRuntime)
+		case attemptEligible(d):
+			actions = append(actions, actionAttemptPrime)
+		}
+	}
+
+	return actions
+}

--- a/cmd/gc/session_level_converge.go
+++ b/cmd/gc/session_level_converge.go
@@ -65,9 +65,6 @@ const (
 // of truth per fact rather than a precedence ladder. Time enters as a fact
 // (now, primingAttemptedAt) so the core stays clock-free and table-testable.
 type durableFacts struct {
-	// startedConfigHash mirrors "started_config_hash": "" means no durable record
-	// of a completed start yet.
-	startedConfigHash string
 	// primedAt mirrors "primed_at": non-empty means the startup prompt delivery
 	// was durably CONFIRMED (stamped only after a delivery mechanism reported
 	// success). It makes "live but never primed" detectable by any observer,
@@ -112,8 +109,6 @@ type runtimeFacts struct {
 	observed bool
 	// live is true when a matching runtime session is present and alive.
 	live bool
-	// transcript is whether the keyed transcript exists on disk (tri-state).
-	transcript sessTranscriptState
 	// primedEnv is true when the live runtime env carries
 	// GC_STARTUP_PROMPT_DELIVERED — the prompt was delivered this runtime but may
 	// not yet be durably recorded.

--- a/cmd/gc/session_level_converge_test.go
+++ b/cmd/gc/session_level_converge_test.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestDeriveFirstStart(t *testing.T) {
+	tests := []struct {
+		name       string
+		hash       string
+		transcript sessTranscriptState
+		want       bool
+	}{
+		{"no hash, unknown transcript -> first start", "", sessTranscriptUnknown, true},
+		{"no hash, present transcript -> first start", "", sessTranscriptPresent, true},
+		{"no hash, absent transcript -> first start", "", sessTranscriptAbsent, true},
+		{"whitespace hash NOT trimmed in stage 1 -> resume", "   ", sessTranscriptUnknown, false},
+		{"hash present, unknown transcript -> resume (legacy behavior)", "abc123", sessTranscriptUnknown, false},
+		{"hash present, present transcript -> resume", "abc123", sessTranscriptPresent, false},
+		{"hash present, absent transcript -> first start (#3849 fix, inert until probe)", "abc123", sessTranscriptAbsent, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveFirstStart(tt.hash, tt.transcript); got != tt.want {
+				t.Errorf("deriveFirstStart(%q, %v) = %v, want %v", tt.hash, tt.transcript, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDeriveFirstStartMatchesLegacyWhenUnprobed is the permanent legacy-parity
+// pin (spec §7.2): with sessTranscriptUnknown, the result MUST equal the legacy
+// `started_config_hash == ""` expression for every hash, byte-for-byte, with no
+// TrimSpace. The trim variant is adopted with its own test at Stage 4.
+func TestDeriveFirstStartMatchesLegacyWhenUnprobed(t *testing.T) {
+	for _, hash := range []string{"", "x", "core-hash-42", " ", "\t"} {
+		legacy := hash == ""
+		got := deriveFirstStart(hash, sessTranscriptUnknown)
+		if got != legacy {
+			t.Errorf("deriveFirstStart(%q, unknown) = %v, legacy (== \"\") = %v", hash, got, legacy)
+		}
+	}
+}
+
+func TestAttemptEligible(t *testing.T) {
+	now := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		d    durableFacts
+		want bool
+	}{
+		{
+			name: "never attempted -> eligible",
+			d:    durableFacts{now: now},
+			want: true,
+		},
+		{
+			name: "attempted just now, same prompt -> not eligible (backoff)",
+			d:    durableFacts{now: now, primingAttemptedAt: now, primedPromptHash: "h", currentPromptHash: "h"},
+			want: false,
+		},
+		{
+			name: "attempted beyond interval -> eligible",
+			d:    durableFacts{now: now, primingAttemptedAt: now.Add(-primeReattemptInterval), primedPromptHash: "h", currentPromptHash: "h"},
+			want: true,
+		},
+		{
+			name: "attempted within interval but prompt changed -> eligible",
+			d:    durableFacts{now: now, primingAttemptedAt: now.Add(-time.Second), primedPromptHash: "old", currentPromptHash: "new"},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := attemptEligible(tt.d); got != tt.want {
+				t.Errorf("attemptEligible(%+v) = %v, want %v", tt.d, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveConvergeActions(t *testing.T) {
+	now := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	observedLive := runtimeFacts{observed: true, live: true}
+
+	tests := []struct {
+		name    string
+		durable durableFacts
+		runtime runtimeFacts
+		want    []sessConvergeAction
+	}{
+		{
+			name:    "absent durable + observed-live runtime -> rollback only",
+			durable: durableFacts{absent: true, canonicalIdentity: "", promptConfigured: true, now: now},
+			runtime: observedLive,
+			want:    []sessConvergeAction{actionRollbackRuntimeToAbsent},
+		},
+		{
+			name:    "absent durable + observed-dead runtime -> nothing",
+			durable: durableFacts{absent: true, now: now},
+			runtime: runtimeFacts{observed: true, live: false},
+			want:    nil,
+		},
+		{
+			name:    "absent durable + UNOBSERVED runtime -> nothing (C5)",
+			durable: durableFacts{absent: true, now: now},
+			runtime: runtimeFacts{observed: false, live: true},
+			want:    nil,
+		},
+		{
+			name:    "missing canonical identity -> stamp identity (durable-only, unobserved ok)",
+			durable: durableFacts{canonicalIdentity: "", now: now},
+			runtime: runtimeFacts{observed: false},
+			want:    []sessConvergeAction{actionStampCanonicalIdentity},
+		},
+		{
+			name:    "whitespace canonical identity treated as missing",
+			durable: durableFacts{canonicalIdentity: "  ", now: now},
+			runtime: runtimeFacts{observed: false},
+			want:    []sessConvergeAction{actionStampCanonicalIdentity},
+		},
+		{
+			name:    "identity present, nothing else -> no actions",
+			durable: durableFacts{canonicalIdentity: "worker-1", now: now},
+			runtime: observedLive,
+			want:    nil,
+		},
+		{
+			name:    "observed-live, prompt configured, never primed/attempted -> attempt prime",
+			durable: durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", now: now},
+			runtime: observedLive,
+			want:    []sessConvergeAction{actionAttemptPrime},
+		},
+		{
+			name:    "observed-live, primedEnv set but no durable confirmation -> stamp from runtime (no nudge)",
+			durable: durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", now: now},
+			runtime: runtimeFacts{observed: true, live: true, primedEnv: true},
+			want:    []sessConvergeAction{actionStampPrimedFromRuntime},
+		},
+		{
+			name:    "observed-live, attempted within interval, same prompt -> no re-attempt (bounded)",
+			durable: durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", primingAttemptedAt: now, primedPromptHash: "h", currentPromptHash: "h", now: now},
+			runtime: observedLive,
+			want:    nil,
+		},
+		{
+			name:    "observed-live, attempt stale beyond interval -> re-attempt",
+			durable: durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", primingAttemptedAt: now.Add(-primeReattemptInterval), primedPromptHash: "h", currentPromptHash: "h", now: now},
+			runtime: observedLive,
+			want:    []sessConvergeAction{actionAttemptPrime},
+		},
+		{
+			name:    "observed-live, prompt hash changed under attempt -> re-attempt",
+			durable: durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", primingAttemptedAt: now, primedPromptHash: "old", currentPromptHash: "new", now: now},
+			runtime: observedLive,
+			want:    []sessConvergeAction{actionAttemptPrime},
+		},
+		{
+			name:    "observed-live, already durably confirmed -> no priming",
+			durable: durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "2026-07-07T00:00:00Z", now: now},
+			runtime: observedLive,
+			want:    nil,
+		},
+		{
+			name:    "not live -> no priming even if unprimed",
+			durable: durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", now: now},
+			runtime: runtimeFacts{observed: true, live: false},
+			want:    nil,
+		},
+		{
+			name:    "unobserved runtime -> no priming even if durable says prompt configured (C5)",
+			durable: durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", now: now},
+			runtime: runtimeFacts{observed: false, live: true},
+			want:    nil,
+		},
+		{
+			name:    "observed-live but no prompt configured -> no priming (P5)",
+			durable: durableFacts{canonicalIdentity: "worker-1", promptConfigured: false, primedAt: "", now: now},
+			runtime: observedLive,
+			want:    nil,
+		},
+		{
+			name:    "missing identity AND unprimed -> identity then priming order",
+			durable: durableFacts{canonicalIdentity: "", promptConfigured: true, primedAt: "", now: now},
+			runtime: observedLive,
+			want:    []sessConvergeAction{actionStampCanonicalIdentity, actionAttemptPrime},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveConvergeActions(tt.durable, tt.runtime)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("deriveConvergeActions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDeriveConvergeActionsIdempotent asserts C2: applying an action's durable
+// effect to the facts and re-deriving yields the empty list. This encodes the
+// "converged session emits nothing" invariant for each action.
+func TestDeriveConvergeActionsIdempotent(t *testing.T) {
+	now := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	observedLive := runtimeFacts{observed: true, live: true}
+
+	t.Run("identity stamp then re-derive", func(t *testing.T) {
+		d := durableFacts{canonicalIdentity: "", now: now}
+		r := runtimeFacts{observed: false}
+		if got := deriveConvergeActions(d, r); !reflect.DeepEqual(got, []sessConvergeAction{actionStampCanonicalIdentity}) {
+			t.Fatalf("pre-heal = %v", got)
+		}
+		d.canonicalIdentity = "worker-1" // action landed
+		if got := deriveConvergeActions(d, r); got != nil {
+			t.Errorf("post-heal re-derive = %v, want nil", got)
+		}
+	})
+
+	t.Run("attempt prime confirmed then re-derive", func(t *testing.T) {
+		d := durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", now: now}
+		if got := deriveConvergeActions(d, observedLive); !reflect.DeepEqual(got, []sessConvergeAction{actionAttemptPrime}) {
+			t.Fatalf("pre-prime = %v", got)
+		}
+		d.primedAt = now.Format(time.RFC3339) // confirmation landed
+		if got := deriveConvergeActions(d, observedLive); got != nil {
+			t.Errorf("post-confirm re-derive = %v, want nil", got)
+		}
+	})
+
+	t.Run("attempt stamped but not confirmed -> bounded (no re-attempt within interval)", func(t *testing.T) {
+		d := durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", now: now}
+		if got := deriveConvergeActions(d, observedLive); !reflect.DeepEqual(got, []sessConvergeAction{actionAttemptPrime}) {
+			t.Fatalf("pre-prime = %v", got)
+		}
+		// Crash after write-ahead attempt stamp, before confirmation.
+		d.primingAttemptedAt = now
+		d.primedPromptHash = d.currentPromptHash
+		if got := deriveConvergeActions(d, observedLive); got != nil {
+			t.Errorf("re-derive within interval = %v, want nil (bounded)", got)
+		}
+		// After the interval elapses, exactly one re-attempt is emitted.
+		d.now = now.Add(primeReattemptInterval)
+		if got := deriveConvergeActions(d, observedLive); !reflect.DeepEqual(got, []sessConvergeAction{actionAttemptPrime}) {
+			t.Errorf("re-derive after interval = %v, want re-attempt", got)
+		}
+	})
+
+	t.Run("stamp from runtime confirmed then re-derive", func(t *testing.T) {
+		d := durableFacts{canonicalIdentity: "worker-1", promptConfigured: true, primedAt: "", now: now}
+		r := runtimeFacts{observed: true, live: true, primedEnv: true}
+		if got := deriveConvergeActions(d, r); !reflect.DeepEqual(got, []sessConvergeAction{actionStampPrimedFromRuntime}) {
+			t.Fatalf("pre-stamp = %v", got)
+		}
+		d.primedAt = now.Format(time.RFC3339) // confirmation landed
+		if got := deriveConvergeActions(d, r); got != nil {
+			t.Errorf("post-stamp re-derive = %v, want nil", got)
+		}
+	})
+
+	t.Run("rollback torn down then re-derive", func(t *testing.T) {
+		d := durableFacts{absent: true, now: now}
+		if got := deriveConvergeActions(d, runtimeFacts{observed: true, live: true}); !reflect.DeepEqual(got, []sessConvergeAction{actionRollbackRuntimeToAbsent}) {
+			t.Fatalf("pre-rollback = %v", got)
+		}
+		// Runtime torn down: no longer live.
+		if got := deriveConvergeActions(d, runtimeFacts{observed: true, live: false}); got != nil {
+			t.Errorf("post-rollback re-derive = %v, want nil", got)
+		}
+	})
+}

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -923,7 +923,12 @@ func buildPreparedStartWithWorkDirResolver(
 		}
 		session.Metadata["session_key"] = sessionKey
 	}
-	firstStart := session.Metadata["started_config_hash"] == ""
+	// firstStart classification routes through the level-triggered converge core
+	// (deriveFirstStart). This call passes sessTranscriptUnknown, which reproduces
+	// the legacy durable-only signal (started_config_hash == "") byte-for-byte;
+	// probing the transcript here to activate the #3849 crash-loop fix is the
+	// remaining wiring (see session_level_converge.go).
+	firstStart := deriveFirstStart(session.Metadata["started_config_hash"], sessTranscriptUnknown)
 	forceFresh := session.Metadata["wake_mode"] == "fresh"
 	// Fork-launch validation (fail loud, never silent fresh). A session carrying
 	// gc.brain_parent_sid is a warm arm that must fork off a pre-built brain;

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -778,35 +778,16 @@ func sessionBackendEnvWithError(cityPath, rigRoot string, rigs []config.Rig) (ma
 // launch or nudge path, it marks the runtime env so SessionStart hooks can add
 // context without repeating the full startup prompt.
 func templateParamsToConfig(tp TemplateParams) runtime.Config {
-	var promptSuffix string
-	var promptFlag string
-	nudge := tp.Hints.Nudge
+	// SessionStart hooks can enrich context, but the startup prompt still needs
+	// a first-turn delivery mechanism. Without argv/flag/nudge delivery, freshly
+	// spawned workers sit idle at the provider prompt. The routing policy lives
+	// in the pure promptDelivery derivation.
+	delivery := promptDelivery(tp.Prompt, tp.IsACP, tp.ResolvedProvider, tp.Hints.Nudge)
+	promptSuffix := delivery.PromptSuffix
+	promptFlag := delivery.PromptFlag
+	nudge := delivery.Nudge
 	env := maps.Clone(tp.Env)
-	startupPromptDelivered := false
-	if tp.Prompt != "" {
-		// SessionStart hooks can enrich context, but the startup prompt still
-		// needs a first-turn delivery mechanism. Without argv/flag/nudge
-		// delivery, freshly spawned workers sit idle at the provider prompt.
-		switch {
-		case tp.IsACP:
-			nudge = prependStartupPromptToNudge(tp.Prompt, nudge)
-			startupPromptDelivered = true
-		case tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "none":
-			nudge = prependStartupPromptToNudge(tp.Prompt, nudge)
-			startupPromptDelivered = true
-		default:
-			promptSuffix = shellquote.Quote(tp.Prompt)
-			startupPromptDelivered = promptSuffix != ""
-			if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "flag" {
-				if tp.ResolvedProvider.PromptFlag != "" {
-					promptFlag = tp.ResolvedProvider.PromptFlag
-				} else {
-					startupPromptDelivered = false
-				}
-			}
-		}
-	}
-	if startupPromptDelivered {
+	if delivery.Delivered {
 		if env == nil {
 			env = map[string]string{}
 		}


### PR DESCRIPTION
Stage 1 of a staged migration replacing edge-triggered session reconciliation with level-triggered convergence — the headline cure for #3872 (edge-triggered events dropped on the floor leave sessions permanently unreconciled; a level-triggered convergence loop re-derives desired state each pass, so missed edges self-heal).

Spike-grade: staged for review, not auto-merge. Gates green. Fable-reviewed, behavior-preserved.

Spec: /data/projects/gascity/.claude/worktrees/simplification/engdocs/simplification/specs/S19-level-triggered-convergence-spec.md

NOTE: spike/staged for review, not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)