### PR TITLE
fix(dispatch): hard-fail ralph loops + supersession guard for hard aborts

### DIFF
--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -77,6 +77,33 @@ func processRalphCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		return ControlResult{Processed: true, Action: "pass"}, nil
 	}
 
+	// A hard-class subject failure is terminal: stop the loop immediately in a
+	// single attempt instead of cloning further attempts (the treadmill that
+	// abort_scope-killed molecules). This mirrors the retry dispatcher's hard
+	// handling (see processRetryEval in retry.go) so both loops read
+	// gc.failure_class identically. Only an explicit "hard" class terminates;
+	// an empty or transient class stays repairable and clones up to
+	// gc.max_attempts below.
+	if subject.Metadata[beadmeta.OutcomeMetadataKey] == beadmeta.OutcomeFail &&
+		strings.TrimSpace(subject.Metadata[beadmeta.FailureClassMetadataKey]) == beadmeta.FailureClassHard {
+		if err := store.SetMetadataBatch(logicalID, map[string]string{
+			beadmeta.OutcomeMetadataKey:          beadmeta.OutcomeFail,
+			beadmeta.FailedAttemptMetadataKey:    strconv.Itoa(attempt),
+			beadmeta.FailureClassMetadataKey:     beadmeta.FailureClassHard,
+			beadmeta.FailureReasonMetadataKey:    retryFailureReason(subject),
+			beadmeta.FinalDispositionMetadataKey: beadmeta.DispositionHardFail,
+		}); err != nil {
+			return ControlResult{}, fmt.Errorf("%s: marking logical hard failure: %w", logicalID, err)
+		}
+		if err := setOutcomeAndClose(store, bead.ID, beadmeta.OutcomeFail); err != nil {
+			return ControlResult{}, fmt.Errorf("%s: closing hard-failed check: %w", bead.ID, err)
+		}
+		if err := setOutcomeAndClose(store, logicalID, beadmeta.OutcomeFail); err != nil {
+			return ControlResult{}, fmt.Errorf("%s: closing hard-failed logical bead: %w", logicalID, err)
+		}
+		return ControlResult{Processed: true, Action: "hard-fail"}, nil
+	}
+
 	if attempt >= maxAttempts {
 		if err := store.SetMetadataBatch(logicalID, map[string]string{
 			beadmeta.OutcomeMetadataKey:       beadmeta.OutcomeFail,

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -79,11 +79,12 @@ func processRalphCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 
 	// A hard-class subject failure is terminal: stop the loop immediately in a
 	// single attempt instead of cloning further attempts (the treadmill that
-	// abort_scope-killed molecules). This mirrors the retry dispatcher's hard
-	// handling (see processRetryEval in retry.go) so both loops read
-	// gc.failure_class identically. Only an explicit "hard" class terminates;
-	// an empty or transient class stays repairable and clones up to
-	// gc.max_attempts below.
+	// abort_scope-killed molecules). This mirrors the retry dispatcher's explicit
+	// hard disposition (see processRetryEval in retry.go) but deliberately
+	// diverges on the empty class: classifyRetryAttempt maps an empty
+	// gc.failure_class to hard (retry.go: `case beadmeta.FailureClassHard, "":`),
+	// whereas this loop keeps an empty or transient class repairable and clones up
+	// to gc.max_attempts below. Only an explicit "hard" class terminates here.
 	if subject.Metadata[beadmeta.OutcomeMetadataKey] == beadmeta.OutcomeFail &&
 		strings.TrimSpace(subject.Metadata[beadmeta.FailureClassMetadataKey]) == beadmeta.FailureClassHard {
 		if err := store.SetMetadataBatch(logicalID, map[string]string{

--- a/internal/dispatch/ralph_test.go
+++ b/internal/dispatch/ralph_test.go
@@ -301,3 +301,112 @@ func TestRunRalphCheckEnvTracksSubject(t *testing.T) {
 		t.Errorf("artifact dir wrongly keyed by control bead %q; got %q", control.ID, result.Stdout)
 	}
 }
+
+// TestProcessRalphCheckHardSubjectFailureTerminatesWithoutRetry proves FIX 1:
+// when the ralph subject closed with gc.failure_class=hard, the loop stops in a
+// single attempt (Action "hard-fail") instead of cloning attempts up to
+// gc.max_attempts (the treadmill that abort_scope-killed molecules).
+func TestProcessRalphCheckHardSubjectFailureTerminatesWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	cityPath := t.TempDir()
+	// A passing check script proves termination is driven by the subject's
+	// hard-class failure alone; the check never gets a chance to pass.
+	checkPath := writeCheckScript(t, cityPath, "check.sh", "#!/bin/bash\nexit 0\n")
+	store, logical, run1, check1 := newSimpleRalphLoop(t, "implement", checkPath, 5)
+
+	if err := store.SetMetadataBatch(run1.ID, map[string]string{
+		"gc.outcome":        "fail",
+		"gc.failure_class":  "hard",
+		"gc.failure_reason": "external_live_head_changed",
+	}); err != nil {
+		t.Fatalf("stamp hard subject failure: %v", err)
+	}
+	if err := store.Close(run1.ID); err != nil {
+		t.Fatalf("close run1: %v", err)
+	}
+
+	result, err := ProcessControl(store, check1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("ProcessControl(check1): %v", err)
+	}
+	if !result.Processed || result.Action != "hard-fail" {
+		t.Fatalf("result = %+v, want processed hard-fail", result)
+	}
+
+	logicalAfter := mustGetBead(t, store, logical.ID)
+	if logicalAfter.Status != "closed" || logicalAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("logical = status %q outcome %q, want closed/fail", logicalAfter.Status, logicalAfter.Metadata["gc.outcome"])
+	}
+	if logicalAfter.Metadata["gc.failure_class"] != "hard" {
+		t.Fatalf("logical gc.failure_class = %q, want hard", logicalAfter.Metadata["gc.failure_class"])
+	}
+	if logicalAfter.Metadata["gc.failure_reason"] != "external_live_head_changed" {
+		t.Fatalf("logical gc.failure_reason = %q, want external_live_head_changed", logicalAfter.Metadata["gc.failure_reason"])
+	}
+
+	checkAfter := mustGetBead(t, store, check1.ID)
+	if checkAfter.Status != "closed" || checkAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("check = status %q outcome %q, want closed/fail", checkAfter.Status, checkAfter.Metadata["gc.outcome"])
+	}
+
+	rootID := run1.Metadata["gc.root_bead_id"]
+	all, err := listByWorkflowRoot(store, rootID)
+	if err != nil {
+		t.Fatalf("listByWorkflowRoot: %v", err)
+	}
+	for _, bead := range all {
+		if bead.Metadata["gc.attempt"] == "2" {
+			t.Fatalf("hard-fail must not clone another attempt; found %s (kind %q)", bead.ID, bead.Metadata["gc.kind"])
+		}
+	}
+}
+
+// TestProcessRalphCheckSoftSubjectFailureStillRetries is the FIX 1 regression
+// guard: a non-hard (repairable) subject failure must still clone up to
+// gc.max_attempts. Crucially an empty gc.failure_class stays repairable here,
+// unlike retry-eval which maps empty to hard.
+func TestProcessRalphCheckSoftSubjectFailureStillRetries(t *testing.T) {
+	t.Parallel()
+
+	cityPath := t.TempDir()
+	checkPath := writeCheckScript(t, cityPath, "check.sh", "#!/bin/bash\nexit 1\n")
+	store, logical, run1, check1 := newSimpleRalphLoop(t, "implement", checkPath, 5)
+
+	// gc.outcome=fail with no gc.failure_class is the ordinary repairable case.
+	if err := store.SetMetadata(run1.ID, "gc.outcome", "fail"); err != nil {
+		t.Fatalf("stamp soft subject failure: %v", err)
+	}
+	if err := store.Close(run1.ID); err != nil {
+		t.Fatalf("close run1: %v", err)
+	}
+
+	result, err := ProcessControl(store, check1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("ProcessControl(check1): %v", err)
+	}
+	if !result.Processed || result.Action != "retry" {
+		t.Fatalf("result = %+v, want processed retry", result)
+	}
+
+	logicalAfter := mustGetBead(t, store, logical.ID)
+	if logicalAfter.Status != "open" {
+		t.Fatalf("logical status = %q, want open (loop continues)", logicalAfter.Status)
+	}
+
+	rootID := run1.Metadata["gc.root_bead_id"]
+	all, err := listByWorkflowRoot(store, rootID)
+	if err != nil {
+		t.Fatalf("listByWorkflowRoot: %v", err)
+	}
+	sawAttempt2 := false
+	for _, bead := range all {
+		if bead.Metadata["gc.attempt"] == "2" {
+			sawAttempt2 = true
+			break
+		}
+	}
+	if !sawAttempt2 {
+		t.Fatalf("soft failure must clone attempt 2; none found under root %s", rootID)
+	}
+}

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -1524,12 +1524,15 @@ func terminalAbortScopeFailure(bead beads.Bead) bool {
 	if !beadOutcomeFailed(bead) {
 		return false
 	}
-	switch strings.TrimSpace(bead.Metadata[beadmeta.FailureClassMetadataKey]) {
-	case beadmeta.FailureClassTransient:
+	if strings.TrimSpace(bead.Metadata[beadmeta.FailureClassMetadataKey]) == beadmeta.FailureClassTransient {
 		return false
-	case beadmeta.FailureClassHard:
-		return true
-	default:
-		return !isRetryAttemptSubject(bead)
 	}
+	// The hard and absent/unknown classes are terminal only when the bead is
+	// NOT a superseded attempt. A superseded attempt carries gc.attempt +
+	// gc.logical_bead_id, meaning a later attempt/iteration of the same logical
+	// bead ran; its own failure must not outvote a passing later iteration at
+	// finalize (#4008). The logical bead's own final disposition is the
+	// authoritative signal. A genuinely terminal, non-superseded hard failure
+	// still returns true.
+	return !isRetryAttemptSubject(bead)
 }

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -2533,6 +2533,137 @@ func TestProcessWorkflowFinalizeIgnoresTransientRetryDescendant(t *testing.T) {
 	}
 }
 
+// TestTerminalAbortScopeFailureSupersededHardAttemptIsNotTerminal proves FIX 2:
+// the supersession guard applies to the hard failure class too. A closed
+// abort_scope bead that carries gc.attempt + gc.logical_bead_id is one attempt
+// among many, so it must not count as a terminal abort even when it closed
+// hard; a genuinely terminal, non-superseded hard failure still counts.
+func TestTerminalAbortScopeFailureSupersededHardAttemptIsNotTerminal(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]string{
+		"gc.on_fail":       "abort_scope",
+		"gc.outcome":       "fail",
+		"gc.failure_class": "hard",
+	}
+	clone := func(extra map[string]string) beads.Bead {
+		meta := map[string]string{}
+		for k, v := range base {
+			meta[k] = v
+		}
+		for k, v := range extra {
+			meta[k] = v
+		}
+		return beads.Bead{Status: "closed", Metadata: meta}
+	}
+
+	// v1 pattern: a cloned retry-run attempt of a logical bead that later passed.
+	superseded := clone(map[string]string{
+		"gc.kind":            "retry-run",
+		"gc.attempt":         "3",
+		"gc.logical_bead_id": "logical-1",
+	})
+	if terminalAbortScopeFailure(superseded) {
+		t.Fatalf("superseded (v1) hard abort_scope attempt must not be terminal")
+	}
+
+	// v2 pattern: original kind, distinguished by gc.attempt + gc.logical_bead_id.
+	supersededV2 := clone(map[string]string{
+		"gc.attempt":         "5",
+		"gc.logical_bead_id": "logical-2",
+	})
+	if terminalAbortScopeFailure(supersededV2) {
+		t.Fatalf("superseded (v2) hard abort_scope attempt must not be terminal")
+	}
+
+	// Non-superseded hard abort_scope failure is still terminal.
+	if !terminalAbortScopeFailure(clone(nil)) {
+		t.Fatalf("non-superseded hard abort_scope failure must be terminal")
+	}
+}
+
+// TestProcessWorkflowFinalizeIgnoresSupersededHardRetryDescendant is the FIX 2
+// integration guard for #4008: a review loop whose iteration.3 attempt closed
+// control_dispatch_error/hard but whose later iterations passed must finalize
+// as pass, not fail. The superseded hard attempt must not outvote the passing
+// later iterations at finalize.
+func TestProcessWorkflowFinalizeIgnoresSupersededHardRetryDescendant(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	// Logical review step that ultimately PASSED on a later iteration.
+	logical := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "review-codex logical",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.kind":         "retry",
+			"gc.root_bead_id": workflow.ID,
+			"gc.outcome":      "pass",
+		},
+	})
+	// Superseded attempt.3 that closed control_dispatch_error/hard before the
+	// later iterations recovered. Carries gc.attempt + gc.logical_bead_id.
+	_ = mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "review-codex attempt 3 (superseded)",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.kind":            "retry-run",
+			"gc.root_bead_id":    workflow.ID,
+			"gc.scope_ref":       "body",
+			"gc.scope_role":      "member",
+			"gc.outcome":         "fail",
+			"gc.failure_class":   "hard",
+			"gc.failure_reason":  "control_dispatch_error",
+			"gc.on_fail":         "abort_scope",
+			"gc.attempt":         "3",
+			"gc.logical_bead_id": logical.ID,
+		},
+	})
+	cleanup := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "cleanup",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.kind":         "cleanup",
+			"gc.outcome":      "pass",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+
+	mustDepAdd(t, store, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("workflow result = %+v, want processed workflow-pass", result)
+	}
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	if rootAfter.Status != "closed" || rootAfter.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("workflow = status %q outcome %q, want closed/pass", rootAfter.Status, rootAfter.Metadata["gc.outcome"])
+	}
+}
+
 func TestProcessWorkflowFinalizeUsesCloseOperationForTerminalBeads(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Two surgical fixes to how the control dispatcher consumes `gc.failure_class`, root-caused from two production adopt-pr-v2 molecule deaths in maintainer-city.

## FIX 1 — ralph treadmill (`internal/dispatch/ralph.go`)
`processRalphCheck` branched only on GatePass vs `attempt >= maxAttempts` and never read `gc.failure_class`, so a HARD-class subject failure (e.g. `external_live_head_changed`) cloned attempts 1..N — a treadmill — before `abort_scope`-killing the molecule (observed on gascity#3943: pre-approval-ci iterations 1→5, all `external_live_head_changed`/hard, then abort). Now a subject that closed `gc.outcome=fail` with `gc.failure_class=hard` terminates the loop in **one attempt** (`Action "hard-fail"`), mirroring `processRetryEval`'s hard handling in `retry.go`. Empty/transient classes stay repairable and still clone up to `max_attempts`.

## FIX 2 — superseded hard abort outvotes passing iterations (`internal/dispatch/runtime.go`)
`terminalAbortScopeFailure` applied the `isRetryAttemptSubject` supersession guard only in the default/unknown-class branch; the `hard` branch returned `true` unconditionally. A superseded `abort_scope` attempt (carries `gc.attempt` + `gc.logical_bead_id`) whose logical bead later passed therefore flipped the workflow root to fail at finalize even though later iterations recovered (observed on gascity#4008: a transient `control_dispatch_error` on `review-loop.iteration.3.review-codex` attempt 3, superseded by passing iterations 4-5, still failed the molecule at finalize). The guard now applies to the `hard` class too; a genuinely terminal, non-superseded hard `abort_scope` failure still fails the root.

## Interaction (verified)
The review loop **is** a ralph loop, but the transient `control_dispatch_error` is stamped on a nested scope **member**, and `propagateScopeMemberMetadata` drops all `gc.*` keys while `setOutcomeAndClose` sets only `gc.outcome` — so `gc.failure_class` never reaches the iteration scope body the ralph check reads as its subject. FIX 1 therefore cannot hard-terminate the review loop on a transient `control_dispatch_error`; FIX 2 alone covers #4008. No quarantine reclassification needed.

## Tests
`go test ./internal/dispatch/...` → 294 pass (incl. new `ralph_test.go` hard-terminate + soft-still-retries, and `runtime_test.go` superseded-hard-not-terminal + non-superseded-still-terminal). `go build ./cmd/gc/` + `go vet ./internal/dispatch/...` clean.

Deployed to maintainer-city as `dev-d0a41db54` for live validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)