### PR TITLE
simplify(S26): collapse the trace double-record API to one typed surface

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -375,7 +375,7 @@ func evaluatePendingPools(
 				if err != nil {
 					outcome = "failed"
 				}
-				trace.recordOperation("trace.scale_check_exec", template, "", "", "scale_check", outcome, traceRecordPayload{
+				trace.RecordOperation(TraceSiteScaleCheckExec, TraceReasonScaleCheck, TraceOutcomeCode(outcome), "", template, "", time.Since(started), traceRecordPayload{
 					"pool_dir":       dir,
 					"command":        sp.Check,
 					"desired":        d,
@@ -383,7 +383,7 @@ func evaluatePendingPools(
 					"duration_ms":    time.Since(started).Milliseconds(),
 					"agent_template": template,
 					"agent_index":    agentIndex,
-				}, "")
+				})
 			}
 		}(j, template, agentName, agentIndex, sp, pw.poolDir, newDemand)
 	}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -3392,11 +3392,11 @@ func (cr *CityRuntime) recordPreservedShutdownTrace() {
 	if trace == nil {
 		return
 	}
-	trace.recordOperation("lifecycle.shutdown.preserve_sessions", "", "", "", "retained", string(TraceOutcomeApplied), traceRecordPayload{
+	trace.RecordOperation(TraceSiteLifecycleShutdownPreserveSessions, TraceReasonRetained, TraceOutcomeApplied, "", "", "", 0, traceRecordPayload{
 		"city_path": cr.cityPath,
 		"city_name": cr.cityName,
 		"reason":    "supervisor_shutdown_preserve_mode",
-	}, "")
+	})
 	trace.end(TraceCompletionCompleted, traceRecordPayload{
 		"phase":     "shutdown",
 		"mode":      "preserve_sessions",

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -229,10 +229,10 @@ func computePoolDesiredStates(
 				BrainParentSID: strings.TrimSpace(wb.Metadata[beadmeta.BrainParentSIDMetadataKey]),
 			})
 			if trace != nil {
-				trace.recordDecision(string(TraceSitePoolWakeKnownIdentity), template, "", "assigned_work", "scheduled", traceRecordPayload{
+				trace.RecordDecision(TraceSitePoolWakeKnownIdentity, TraceReasonAssignedWork, TraceOutcomeScheduled, template, "", traceRecordPayload{
 					"tier":      "wake-known-identity",
 					"work_bead": wb.ID,
-				}, nil, "")
+				})
 			}
 		}
 	}
@@ -273,12 +273,12 @@ func computePoolDesiredStates(
 			inFlight := inFlightNewRequests[template]
 			inFlightCount := minInt(len(inFlight), newCount)
 			if scaleCount > 0 && len(inFlight) > 0 && trace != nil {
-				trace.recordDecision(string(TraceSitePoolInFlightReuse), template, "", string(TraceReasonInFlightReuse), "accepted", traceRecordPayload{
+				trace.RecordDecision(TraceSitePoolInFlightReuse, TraceReasonInFlightReuse, TraceOutcomeAccepted, template, "", traceRecordPayload{
 					"scale_check":   scaleCount,
 					"in_flight":     len(inFlight),
 					"reused":        inFlightCount,
 					"anonymous_new": newCount - inFlightCount,
-				}, nil, "")
+				})
 			}
 			for j := 0; j < inFlightCount; j++ {
 				req := inFlight[j]
@@ -459,7 +459,7 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, aliasHeldTempl
 		}
 		if site, reason, payload, rejected := usage.rejection(req, limits); rejected {
 			if trace != nil {
-				trace.recordDecision(site, template, "", reason, "rejected", payload, nil, "")
+				trace.RecordDecision(TraceSiteCode(site), TraceReasonCode(reason), TraceOutcomeRejected, template, "", payload)
 			}
 			continue
 		}
@@ -467,9 +467,9 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, aliasHeldTempl
 		// Accept.
 		accepted[template] = append(accepted[template], req)
 		if trace != nil {
-			trace.recordDecision("reconciler.pool.accept", template, "", "cap", "accepted", traceRecordPayload{
+			trace.RecordDecision(TraceSitePoolAccept, TraceReasonCap, TraceOutcomeAccepted, template, "", traceRecordPayload{
 				"tier": req.Tier,
-			}, nil, "")
+			})
 		}
 		usage.accept(req, limits)
 	}
@@ -496,11 +496,11 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, aliasHeldTempl
 			}
 			accepted[template] = append(accepted[template], req)
 			if trace != nil {
-				trace.recordDecision("reconciler.pool.min_fill", template, "", "min_fill", "accepted", traceRecordPayload{
+				trace.RecordDecision(TraceSitePoolMinFill, TraceReasonMinFill, TraceOutcomeAccepted, template, "", traceRecordPayload{
 					"min":     minSess,
 					"current": usage.agentCount[template],
 					"tier":    "new",
-				}, nil, "")
+				})
 			}
 			usage.accept(req, limits)
 		}
@@ -706,7 +706,7 @@ func recordNewDemandCapTrace(
 			blockingWork = append(blockingWork, req.WorkBeadID)
 		}
 	}
-	trace.recordDecision(site, template, "", reason, "rejected", traceRecordPayload{
+	trace.RecordDecision(TraceSiteCode(site), TraceReasonCode(reason), TraceOutcomeRejected, template, "", traceRecordPayload{
 		"scale_check":          scaleCount,
 		"accepted_new":         newCount,
 		"blocked_new":          scaleCount - newCount,
@@ -715,7 +715,7 @@ func recordNewDemandCapTrace(
 		"blocking_sessions":    blockingSessions,
 		"blocking_work_beads":  blockingWork,
 		"active_capacity_kind": reason,
-	}, nil, "")
+	})
 }
 
 func newDemandBlockingScope(

--- a/cmd/gc/session_bead_cycle.go
+++ b/cmd/gc/session_bead_cycle.go
@@ -131,10 +131,10 @@ func cycleAliveSessionForFreshReassign(
 		fmt.Fprintf(stdout, "Cycled fresh-mode session '%s' for bead reassign: %s → %s\n", name, prevBeadID, newBeadID) //nolint:errcheck
 	}
 	if trace != nil {
-		trace.recordDecision("reconciler.session.bead_reassign_cycle", tp.TemplateName, name, "fresh_cycle", "restart", traceRecordPayload{
+		trace.RecordDecision(TraceSiteReconcilerBeadReassignCycle, TraceReasonFreshCycle, TraceOutcomeRestart, tp.TemplateName, name, traceRecordPayload{
 			"previous_bead_id": prevBeadID,
 			"new_bead_id":      newBeadID,
-		}, nil, "")
+		})
 	}
 	return true, fold
 }

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1985,10 +1985,14 @@ func commitStartResultTraced(
 		clearPendingStartInFlightLease(session, sessFront, stderr)
 		fmt.Fprintf(stderr, "session reconciler: storing hashes for %s: %v\n", name, err) //nolint:errcheck
 		if trace != nil {
-			trace.recordMutation("bead_metadata", tp.TemplateName, name, "metadata_batch", session.ID, "started_config_hash", "", result.prepared.coreHash, "failed", traceRecordPayload{
-				"wave":  wave,
-				"error": err.Error(),
-			}, "")
+			trace.RecordMutation(TraceSiteMutationBeadMetadata, TraceReasonUnknown, TraceOutcomeFailed, "metadata_batch", session.ID, "started_config_hash", traceRecordPayload{
+				"wave":     wave,
+				"error":    err.Error(),
+				"template": tp.TemplateName,
+				"before":   "",
+				"after":    result.prepared.coreHash,
+				"field":    "started_config_hash",
+			})
 		}
 		// The runtime started, but we failed to persist metadata
 		// (including the state transition to active). Report failure so
@@ -2016,9 +2020,13 @@ func commitStartResultTraced(
 	})
 	telemetry.RecordAgentStart(context.Background(), name, tp.DisplayName(), nil)
 	if trace != nil {
-		trace.recordMutation("bead_metadata", tp.TemplateName, name, "metadata_batch", session.ID, "started_config_hash", "", result.prepared.coreHash, "success", traceRecordPayload{
-			"wave": wave,
-		}, "")
+		trace.RecordMutation(TraceSiteMutationBeadMetadata, TraceReasonUnknown, TraceOutcomeSuccess, "metadata_batch", session.ID, "started_config_hash", traceRecordPayload{
+			"wave":     wave,
+			"template": tp.TemplateName,
+			"before":   "",
+			"after":    result.prepared.coreHash,
+			"field":    "started_config_hash",
+		})
 	}
 	logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil, result.phases)
 	return true
@@ -2039,10 +2047,10 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 			fmt.Fprintf(stderr, "session reconciler: marking terminal provider error for %s: %v\n", name, err) //nolint:errcheck
 		}
 		if trace != nil {
-			trace.recordOperation("reconciler.start.terminal_provider_error", tp.TemplateName, name, "", "start", result.outcome, traceRecordPayload{
+			trace.RecordOperation(TraceSiteLifecycleStartTerminalProviderError, TraceReasonStart, TraceOutcomeCode(result.outcome), "", tp.TemplateName, name, 0, traceRecordPayload{
 				"error":  formatLifecycleError(result.err),
 				"reason": reason,
-			}, "")
+			})
 		}
 		if result.rollbackPending {
 			rollbackPendingCreate(session, sessFront, clk.Now().UTC(), stderr)
@@ -2054,18 +2062,18 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 		if _, err := recordRateLimitQuarantine(session, sessFront, clk); err != nil {
 			fmt.Fprintf(stderr, "session reconciler: recording startup rate-limit hold for %s: %v\n", name, err) //nolint:errcheck
 			if trace != nil {
-				trace.recordOperation("reconciler.start.rate_limit_hold", tp.TemplateName, name, "", "start", "hold_deferred", traceRecordPayload{
+				trace.RecordOperation(TraceSiteLifecycleStartRateLimitHold, TraceReasonStart, TraceOutcomeHoldDeferred, "", tp.TemplateName, name, 0, traceRecordPayload{
 					"error": formatLifecycleError(result.err),
 					"cause": err.Error(),
-				}, "")
+				})
 			}
 			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
 			return
 		}
 		if trace != nil {
-			trace.recordOperation("reconciler.start.rate_limit_hold", tp.TemplateName, name, "", "start", "held", traceRecordPayload{
+			trace.RecordOperation(TraceSiteLifecycleStartRateLimitHold, TraceReasonStart, TraceOutcomeHeld, "", tp.TemplateName, name, 0, traceRecordPayload{
 				"error": formatLifecycleError(result.err),
-			}, "")
+			})
 		}
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
 		return
@@ -2085,9 +2093,9 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 		// Genuine wake-failure accounting happens on the non-rollback path
 		// below via recordWakeFailure.
 		if trace != nil {
-			trace.recordOperation("reconciler.start.rollback_pending", tp.TemplateName, name, "", "start", result.outcome, traceRecordPayload{
+			trace.RecordOperation(TraceSiteLifecycleStartRollback, TraceReasonStart, TraceOutcomeCode(result.outcome), "", tp.TemplateName, name, 0, traceRecordPayload{
 				"error": formatLifecycleError(result.err),
-			}, "")
+			})
 		}
 		rollbackPendingCreate(session, sessFront, clk.Now().UTC(), stderr)
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
@@ -2103,9 +2111,9 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 	// even for a namepool-themed pool instance whose bead predates agent_name.
 	recordWakeFailure(session, sessFront, clk, tp.DisplayName())
 	if trace != nil {
-		trace.recordOperation("reconciler.start.failed", tp.TemplateName, name, "", "start", result.outcome, traceRecordPayload{
+		trace.RecordOperation(TraceSiteLifecycleStartFailed, TraceReasonStart, TraceOutcomeCode(result.outcome), "", tp.TemplateName, name, 0, traceRecordPayload{
 			"error": formatLifecycleError(result.err),
-		}, "")
+		})
 	}
 	logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
 }
@@ -2129,9 +2137,9 @@ func recoverRunningPendingCreate(
 	prepared, err := buildPreparedStart(startCandidate{session: session, tp: tp}, cfg, store)
 	if err != nil {
 		if trace != nil {
-			trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, tp.SessionName, "pending_create_rebuild_failed", "failed", traceRecordPayload{
+			trace.RecordDecision(TraceSiteReconcilerPendingCreate, TraceReasonPendingCreateRebuildFailed, TraceOutcomeFailed, tp.TemplateName, tp.SessionName, traceRecordPayload{
 				"error": err.Error(),
-			}, nil, "")
+			})
 		}
 		return false, pendingCreateResidueFold(session)
 	}
@@ -2170,9 +2178,9 @@ func recoverRunningPendingCreate(
 	})
 	if err := sessionFrontDoor(store).ApplyPatch(session.ID, metadata); err != nil {
 		if trace != nil {
-			trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, tp.SessionName, "pending_create_commit_failed", "failed", traceRecordPayload{
+			trace.RecordDecision(TraceSiteReconcilerPendingCreate, TraceReasonPendingCreateCommitFailed, TraceOutcomeFailed, tp.TemplateName, tp.SessionName, traceRecordPayload{
 				"error": err.Error(),
-			}, nil, "")
+			})
 		}
 		return false, pendingCreateResidueFold(session)
 	}
@@ -2191,7 +2199,7 @@ func recoverRunningPendingCreate(
 		metadata["instance_token"] = tok
 	}
 	if trace != nil {
-		trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, tp.SessionName, "pending_create_healed", "healed", nil, nil, "")
+		trace.RecordDecision(TraceSiteReconcilerPendingCreate, TraceReasonPendingCreateHealed, TraceOutcomeHealed, tp.TemplateName, tp.SessionName, nil)
 	}
 	return true, metadata
 }
@@ -2512,9 +2520,9 @@ func executePlannedStartsTraced(
 							}
 							cb.LogOpenOnce(identity, stderr)
 							if trace != nil {
-								trace.recordDecision("reconciler.session.circuit_open", candidate.tp.TemplateName, candidate.name(), "circuit_open", "skipped", traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerCircuitOpen, TraceReasonCircuitOpen, TraceOutcomeSkipped, candidate.tp.TemplateName, candidate.name(), traceRecordPayload{
 									"identity": identity,
-								}, nil, "")
+								})
 							}
 							continue
 						}
@@ -2539,9 +2547,9 @@ func executePlannedStartsTraced(
 							}
 							cb.LogOpenOnce(identity, stderr)
 							if trace != nil {
-								trace.recordDecision("reconciler.session.circuit_trip", candidate.tp.TemplateName, candidate.name(), "circuit_trip", "skipped", traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerCircuitTrip, TraceReasonCircuitTrip, TraceOutcomeSkipped, candidate.tp.TemplateName, candidate.name(), traceRecordPayload{
 									"identity": identity,
-								}, nil, "")
+								})
 							}
 							continue
 						}
@@ -2581,10 +2589,10 @@ func executePlannedStartsTraced(
 			}
 			for _, result := range results {
 				if trace != nil {
-					trace.recordOperation("reconciler.start.execute", result.prepared.candidate.tp.TemplateName, result.prepared.candidate.name(), "", "start", result.outcome, traceRecordPayload{
+					trace.RecordOperation(TraceSiteLifecycleStartRun, TraceReasonStart, TraceOutcomeCode(result.outcome), "", result.prepared.candidate.tp.TemplateName, result.prepared.candidate.name(), result.finished.Sub(result.started), traceRecordPayload{
 						"rollback_pending": result.rollbackPending,
 						"duration_ms":      result.finished.Sub(result.started).Milliseconds(),
-					}, "")
+					})
 				}
 				if result.outcome == "start_enqueued" {
 					logLifecycleOutcome(stderr, "start", wave, result.prepared.candidate.name(), result.prepared.candidate.logicalTemplate(cfg), result.outcome, result.started, result.finished, nil)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2541,7 +2541,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rebaseBatch)
 							if trace != nil {
-								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeCode(outcome), tp.TemplateName, name, traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, outcome, tp.TemplateName, name, traceRecordPayload{
 									"stored_hash":  storedHash,
 									"current_hash": currentHash,
 								})
@@ -2755,7 +2755,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rebaseBatch)
 							if trace != nil {
-								trace.RecordDecision(TraceSiteReconcilerLiveDrift, TraceReasonLiveDrift, TraceOutcomeCode(outcome), tp.TemplateName, name, traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerLiveDrift, TraceReasonLiveDrift, outcome, tp.TemplateName, name, traceRecordPayload{
 									"stored_hash":  storedLive,
 									"current_hash": currentLive,
 								})
@@ -2825,7 +2825,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rebaseBatch)
 							if trace != nil {
-								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeCode(outcome), tp.TemplateName, name, traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, outcome, tp.TemplateName, name, traceRecordPayload{
 									"stored_hash":  storedHash,
 									"current_hash": currentHash,
 								})

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1454,17 +1454,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		if rollbacksThisTick >= maxRollbacksPerTick {
 			fmt.Fprintf(stderr, "session reconciler: deferring rollback of %s (%s): rollback budget exhausted this tick\n", name, detail) //nolint:errcheck
 			if trace != nil {
-				trace.recordDecision("reconciler.session.pending_create", templateName, name, action, "rollback_deferred", traceRecordPayload{
+				trace.RecordDecision(TraceSiteReconcilerPendingCreate, TraceReasonCode(action), TraceOutcomeRollbackDeferred, templateName, name, traceRecordPayload{
 					"rollbacks_this_tick":    rollbacksThisTick,
 					"max_rollbacks_per_tick": maxRollbacksPerTick,
-				}, nil, "")
+				})
 			}
 			return nil
 		}
 		rollbacksThisTick++
 		fmt.Fprintf(stderr, "session reconciler: rolling back pending create %s: %s\n", name, detail) //nolint:errcheck
 		if trace != nil {
-			trace.recordDecision("reconciler.session.pending_create", templateName, name, action, "rollback", nil, nil, "")
+			trace.RecordDecision(TraceSiteReconcilerPendingCreate, TraceReasonCode(action), TraceOutcomeRollback, templateName, name, nil)
 		}
 		if clearClaim {
 			return rollbackPendingCreateClearingClaim(session, sessFront, clk.Now().UTC(), stderr)
@@ -1524,9 +1524,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			fmt.Fprintf(stderr, "session reconciler: skipping %s with unknown state %q\n", //nolint:errcheck // best-effort stderr
 				info.SessionNameMetadata, info.MetadataState)
 			if trace != nil {
-				trace.recordDecision("reconciler.session.unknown_state", info.Template, info.SessionNameMetadata, "unknown_state_skipped", "skipped", traceRecordPayload{
+				trace.RecordDecision(TraceSiteReconcilerUnknownState, TraceReasonUnknownStateSkipped, TraceOutcomeSkipped, info.Template, info.SessionNameMetadata, traceRecordPayload{
 					"state": info.MetadataState,
-				}, nil, "")
+				})
 			}
 			continue
 		}
@@ -1632,9 +1632,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if rateLimitErr != nil {
 						result = "hold_deferred"
 					}
-					trace.recordDecision("reconciler.session.preserve_configured_named", template, name, "rate_limit", result, traceRecordPayload{
+					trace.RecordDecision(TraceSiteReconcilerPreserveConfiguredNamed, TraceReasonRateLimit, TraceOutcomeCode(result), template, name, traceRecordPayload{
 						"provider_alive": providerAlive,
-					}, nil, "")
+					})
 				}
 				// Fold the rate-limit batch onto the snapshot (Step 6d write-returns-Info).
 				// Pre-pass-masked (STEP6-PREPASS-AUDIT group 1).
@@ -1648,17 +1648,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				}
 				if pendingCreateSessionStillLeasedInfo(info, cfg, clk) {
 					if trace != nil {
-						trace.recordDecision("reconciler.session.pending_create_preserved", template, name, "pending_create", "kept_open", traceRecordPayload{
+						trace.RecordDecision(TraceSiteReconcilerPendingCreatePreserved, TraceReasonPendingCreate, TraceOutcomeKeptOpen, template, name, traceRecordPayload{
 							"pending_create_claim": strings.TrimSpace(infoByID[session.ID].PendingCreateClaimMetadata),
 							"provider_alive":       providerAlive,
 							"state":                infoByID[session.ID].MetadataState,
-						}, nil, "")
+						})
 					}
 					continue
 				}
 				if !providerAlive {
 					if trace != nil {
-						trace.recordDecision("reconciler.session.close_failed_create", template, name, string(sessionpkg.StateFailedCreate), "closed", nil, nil, "")
+						trace.RecordDecision(TraceSiteReconcilerCloseFailedCreate, TraceReasonCode(sessionpkg.StateFailedCreate), TraceOutcomeClosed, template, name, nil)
 					}
 					if storeQueryPartial || reconcileOpts.deferSessionClosesOnBoot {
 						continue
@@ -1742,13 +1742,13 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					desired = true
 				}
 				if trace != nil {
-					trace.recordDecision("reconciler.session.preserve_configured_named", template, name, "preserve", map[bool]string{
+					trace.RecordDecision(TraceSiteReconcilerPreserveConfiguredNamed, TraceReasonPreserve, TraceOutcomeCode(map[bool]string{
 						true:  "kept_open",
 						false: "resolution_failed",
-					}[desired], traceRecordPayload{
+					}[desired]), template, name, traceRecordPayload{
 						"provider_alive": providerAlive,
 						"degraded":       preserveErr != nil,
-					}, nil, "")
+					})
 				}
 			case pendingCreateSessionStillLeasedInfo(infoPostHeal, cfg, clk):
 				template := normalizedSessionTemplateInfo(infoPostHeal, cfg)
@@ -1756,11 +1756,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					template = infoPostHeal.Template
 				}
 				if trace != nil {
-					trace.recordDecision("reconciler.session.pending_create_preserved", template, name, "pending_create", "kept_open", traceRecordPayload{
+					trace.RecordDecision(TraceSiteReconcilerPendingCreatePreserved, TraceReasonPendingCreate, TraceOutcomeKeptOpen, template, name, traceRecordPayload{
 						"pending_create_claim": strings.TrimSpace(infoByID[session.ID].PendingCreateClaimMetadata),
 						"provider_alive":       providerAlive,
 						"state":                infoByID[session.ID].MetadataState,
-					}, nil, "")
+					})
 				}
 				continue
 			default:
@@ -1781,10 +1781,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								if template == "" {
 									template = infoPostHeal.Template
 								}
-								trace.recordDecision("reconciler.session.drain_ack", template, name, "store_query_partial", "deferred", traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonStoreQueryPartial, TraceOutcomeDeferred, template, name, traceRecordPayload{
 									"store_query_partial": true,
 									"provider_alive":      providerAlive,
-								}, nil, "")
+								})
 							}
 							continue
 						}
@@ -1804,7 +1804,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								}
 								fmt.Fprintf(stdout, "Canceled drain-acked session '%s' (assigned work)\n", name) //nolint:errcheck
 								if trace != nil {
-									trace.recordDecision("reconciler.drain.cancel", template, name, ackReason, "cancel_assigned_work", nil, nil, "")
+									trace.RecordDecision(TraceSiteDrainCancel, TraceReasonCode(ackReason), TraceOutcomeCancelAssignedWork, template, name, nil)
 								}
 								continue
 							}
@@ -1826,7 +1826,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								clearDrainTrackerForStopPending(session, dt)
 								queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
 								if trace != nil {
-									trace.recordDecision("reconciler.session.drain_ack", template, name, "orphaned", "stop_pending", nil, nil, "")
+									trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonOrphaned, TraceOutcomeStopPending, template, name, nil)
 								}
 							}
 							continue
@@ -1874,11 +1874,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							if template == "" {
 								template = infoPostHeal.Template
 							}
-							trace.recordDecision("reconciler.session.orphan_or_suspended", template, name, reason, "kept_open", traceRecordPayload{
+							trace.RecordDecision(TraceSiteReconcilerOrphaned, TraceReasonCode(reason), TraceOutcomeKeptOpen, template, name, traceRecordPayload{
 								"store_query_partial": storeQueryPartial,
 								"provider_alive":      providerAlive,
 								"live_assigned_work":  true,
-							}, nil, "")
+							})
 						}
 						fmt.Fprintf(stdout, "Skipping drain for '%s': live assigned work found\n", name) //nolint:errcheck
 						continue
@@ -1901,11 +1901,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								if template == "" {
 									template = infoPostHeal.Template
 								}
-								trace.recordDecision("reconciler.session.orphan_or_suspended", template, name, reason, "deferred_confirm", traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerOrphaned, TraceReasonCode(reason), TraceOutcomeDeferredConfirm, template, name, traceRecordPayload{
 									"confirm_ticks":    n,
 									"confirm_required": namedSuspendConfirmTicks,
 									"provider_alive":   providerAlive,
-								}, nil, "")
+								})
 							}
 							fmt.Fprintf(stdout, "Deferring drain for named session '%s': awaiting spec-absence confirmation (%d/%d) — transient enumeration-collapse guard (#3630)\n", name, n, namedSuspendConfirmTicks) //nolint:errcheck
 							continue
@@ -1917,10 +1917,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							if template == "" {
 								template = infoPostHeal.Template
 							}
-							trace.recordDecision("reconciler.session.orphan_or_suspended", template, name, reason, "drain", traceRecordPayload{
+							trace.RecordDecision(TraceSiteReconcilerOrphaned, TraceReasonCode(reason), TraceOutcomeDrain, template, name, traceRecordPayload{
 								"store_query_partial": storeQueryPartial,
 								"provider_alive":      providerAlive,
-							}, nil, "")
+							})
 						}
 						fmt.Fprintf(stdout, "Draining session '%s': %s\n", name, reason) //nolint:errcheck
 					}
@@ -1935,7 +1935,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						template = infoPostHeal.Template
 					}
 					if trace != nil {
-						trace.recordDecision("reconciler.session.close_orphan", template, name, reason, "closed", nil, nil, "")
+						trace.RecordDecision(TraceSiteReconcilerCloseOrphan, TraceReasonCode(reason), TraceOutcomeClosed, template, name, nil)
 					}
 					if storeQueryPartial || reconcileOpts.deferSessionClosesOnBoot {
 						continue
@@ -1981,9 +1981,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					}
 					terminalErrBatch = markBatch
 					if trace != nil {
-						trace.recordDecision("reconciler.session.terminal_provider_error", tp.TemplateName, name, reason, "unhealthy", traceRecordPayload{
+						trace.RecordDecision(TraceSiteReconcilerTerminalProviderError, TraceReasonCode(reason), TraceOutcomeUnhealthy, tp.TemplateName, name, traceRecordPayload{
 							"session_bead_id": session.ID,
-						}, nil, "")
+						})
 					}
 				}
 				if !runtime.ContainsProviderRateLimitScreen(output) {
@@ -2067,7 +2067,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if staleReconcilerDrainAck(*session, sp, name) {
 						_ = clearReconcilerDrainAckMetadata(sp, name)
 						if trace != nil {
-							trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "stale_generation", "clear", nil, nil, "")
+							trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonStaleGeneration, TraceOutcomeClear, tp.TemplateName, name, nil)
 						}
 						continue
 					}
@@ -2082,10 +2082,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if reconcilerOwnedAck && storeQueryPartial {
 						fmt.Fprintf(stdout, "Skipping reconciler drain-ack stop for '%s': store query partial (transient failure)\n", name) //nolint:errcheck
 						if trace != nil {
-							trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "store_query_partial", "deferred", traceRecordPayload{
+							trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonStoreQueryPartial, TraceOutcomeDeferred, tp.TemplateName, name, traceRecordPayload{
 								"store_query_partial":  true,
 								"reconciler_owned_ack": true,
-							}, nil, "")
+							})
 						}
 						continue
 					}
@@ -2099,7 +2099,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							(cancelSessionDrainForAssignedWork(*session, sp, dt) || cancelRecoveredDrainForAssignedWork(*session, sp, name)) {
 							_ = dops.clearDrain(name)
 							if trace != nil {
-								trace.recordDecision("reconciler.drain.cancel", tp.TemplateName, name, ackReason, "cancel_assigned_work", nil, nil, "")
+								trace.RecordDecision(TraceSiteDrainCancel, TraceReasonCode(ackReason), TraceOutcomeCancelAssignedWork, tp.TemplateName, name, nil)
 							}
 							continue
 						}
@@ -2120,10 +2120,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								_ = clearReconcilerDrainAckMetadata(sp, name)
 							}
 							if trace != nil {
-								trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "config_drift_attachment_error", "cancel_reconciler_ack", traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonConfigDriftAttachmentError, TraceOutcomeCancelReconcilerAck, tp.TemplateName, name, traceRecordPayload{
 									"drain_canceled": drainCancelled,
 									"error":          attachErr.Error(),
-								}, nil, "")
+								})
 							}
 							continue
 						}
@@ -2138,9 +2138,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								_ = clearReconcilerDrainAckMetadata(sp, name)
 							}
 							if trace != nil {
-								trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "config_drift_attached", "cancel_reconciler_ack", traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonConfigDriftAttached, TraceOutcomeCancelReconcilerAck, tp.TemplateName, name, traceRecordPayload{
 									"drain_canceled": drainCancelled,
-								}, nil, "")
+								})
 							}
 							continue
 						}
@@ -2150,9 +2150,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								_ = clearReconcilerDrainAckMetadata(sp, name)
 							}
 							if trace != nil {
-								trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "config_drift_recently_attached", "cancel_reconciler_ack", traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonConfigDriftRecentlyAttached, TraceOutcomeCancelReconcilerAck, tp.TemplateName, name, traceRecordPayload{
 									"drain_canceled": drainCancelled,
-								}, nil, "")
+								})
 							}
 							continue
 						}
@@ -2160,7 +2160,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if pendingInteractionKeepsAwake(*session, sp, name, clk) &&
 						(cancelReconcilerAckedDrain(*session, sp, dt) || cancelRecoveredReconcilerAckedDrain(*session, sp, name)) {
 						if trace != nil {
-							trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "pending", "cancel_reconciler_ack", nil, nil, "")
+							trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonPending, TraceOutcomeCancelReconcilerAck, tp.TemplateName, name, nil)
 						}
 						continue
 					}
@@ -2173,7 +2173,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							clearDrainTrackerForStopPending(session, dt)
 							queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
 							if trace != nil {
-								trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "acknowledged", "stop_pending", nil, nil, "")
+								trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonAcknowledged, TraceOutcomeStopPending, tp.TemplateName, name, nil)
 							}
 						}
 						continue
@@ -2243,10 +2243,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							if isMinFloorIdleWorker(minFloor, openInPool) {
 								exempt = true
 								if trace != nil {
-									trace.recordDecision(string(TraceSiteReconcilerProgressStallExempt), tp.TemplateName, name, "min_floor_idle_worker", "exempt", traceRecordPayload{
+									trace.RecordDecision(TraceSiteReconcilerProgressStallExempt, TraceReasonMinFloorIdleWorker, TraceOutcomeExempt, tp.TemplateName, name, traceRecordPayload{
 										"pool_min":  minFloor,
 										"pool_open": openInPool,
-									}, nil, "")
+									})
 								}
 							}
 						}
@@ -2475,7 +2475,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			case sessionpkg.StateStartPending, sessionpkg.StateCreating:
 				if pendingCreateStartInFlight(*session, clk, startupTimeout) {
 					if trace != nil {
-						trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_recovery_in_flight", "deferred", nil, nil, "")
+						trace.RecordDecision(TraceSiteReconcilerPendingCreate, TraceReasonPendingCreateRecoveryInFlight, TraceOutcomeDeferred, tp.TemplateName, name, nil)
 					}
 					continue
 				}
@@ -2541,10 +2541,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rebaseBatch)
 							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(outcome), traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeCode(outcome), tp.TemplateName, name, traceRecordPayload{
 									"stored_hash":  storedHash,
 									"current_hash": currentHash,
-								}, nil, "")
+								})
 							}
 							continue
 						}
@@ -2586,18 +2586,18 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							drainCancelled := cancelSessionConfigDriftDrain(*session, sp, dt)
 							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredAttached), configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeDeferredAttached, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
 									"active_reason":  "attached",
 									"drain_canceled": drainCancelled,
-								}), nil, "")
+								}))
 							}
 							continue
 						}
 						if recentlyDeferredSessionAttachedConfigDrift(*session, clk, driftKey) {
 							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredAttached), configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeDeferredAttached, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
 									"active_reason": "attached_recently",
-								}), nil, "")
+								}))
 							}
 							continue
 						}
@@ -2613,9 +2613,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							if active {
 								if trace != nil {
-									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredActive), configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
+									trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeDeferredActive, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
 										"active_reason": activeReason,
-									}), nil, "")
+									}))
 								}
 								continue
 							}
@@ -2635,7 +2635,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							// that refresh's retirement (STEP6-PREPASS-AUDIT group 10).
 							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, string(sessionpkg.StateStartPending), clk.Now().UTC(), stderr))
 							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "restart_in_place", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
+								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeRestartInPlace, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, nil))
 							}
 							rec.Record(events.Event{
 								Type:      events.SessionDraining,
@@ -2658,9 +2658,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 									drainCancelled = cancelSessionDrainForPending(*session, sp, dt)
 								}
 								if trace != nil {
-									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "pending", "deferred_pending", configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
+									trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonPending, TraceOutcomeDeferredPending, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
 										"drain_canceled": drainCancelled,
-									}), nil, "")
+									}))
 								}
 								continue
 							}
@@ -2683,9 +2683,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							if hasAssignedWork {
 								if trace != nil {
-									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredActive), configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
+									trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeDeferredActive, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
 										"active_reason": "live_assigned_work",
-									}), nil, "")
+									}))
 								}
 								fmt.Fprintf(stdout, "Skipping config-drift drain for '%s': live assigned work found\n", name) //nolint:errcheck
 								continue
@@ -2707,7 +2707,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							if beginSessionDrain(*session, sp, dt, "config-drift", clk, ddt) {
 								fmt.Fprintf(stdout, "Draining session '%s': config-drift\n", name) //nolint:errcheck
 								if trace != nil {
-									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "drain", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
+									trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeDrain, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, nil))
 								}
 								rec.Record(events.Event{
 									Type:      events.SessionDraining,
@@ -2755,10 +2755,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rebaseBatch)
 							if trace != nil {
-								trace.recordDecision("reconciler.session.live_drift", tp.TemplateName, name, "live_drift", string(outcome), traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerLiveDrift, TraceReasonLiveDrift, TraceOutcomeCode(outcome), tp.TemplateName, name, traceRecordPayload{
 									"stored_hash":  storedLive,
 									"current_hash": currentLive,
-								}, nil, "")
+								})
 							}
 						default:
 							fmt.Fprintf(stdout, "Live config changed for '%s', re-applying...\n", tp.DisplayName()) //nolint:errcheck
@@ -2825,10 +2825,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rebaseBatch)
 							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(outcome), traceRecordPayload{
+								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeCode(outcome), tp.TemplateName, name, traceRecordPayload{
 									"stored_hash":  storedHash,
 									"current_hash": currentHash,
-								}, nil, "")
+								})
 							}
 							continue
 						}
@@ -2839,7 +2839,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// (#2574). Pre-pass-masked (STEP6-PREPASS-AUDIT group 10).
 						infoByID[session.ID] = infoByID[session.ID].ApplyPatch(resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, false, "asleep", clk.Now().UTC(), stderr))
 						if trace != nil {
-							trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "repair_in_place", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
+							trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeRepairInPlace, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, nil))
 						}
 						continue
 					}
@@ -2895,12 +2895,12 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				// by wake evaluation: bypass the max-age restart so SleepPatch
 				// does not rewrite the intended sleep state.
 				if trace != nil {
-					trace.recordDecision("reconciler.session.max_session_age", tp.TemplateName, name, dec.TraceReason, dec.TraceOutcome, nil, nil, "")
+					trace.RecordDecision(TraceSiteReconcilerMaxSessionAge, TraceReasonCode(dec.TraceReason), TraceOutcomeCode(dec.TraceOutcome), tp.TemplateName, name, nil)
 				}
 			case sessionpkg.TimerActionStop:
 				fmt.Fprintf(stderr, "session reconciler: preemptive max-age restart for %s (age=%s)\n", tp.DisplayName(), clk.Now().Sub(creationCompleteAt).Round(time.Second)) //nolint:errcheck // best-effort stderr
 				if trace != nil {
-					trace.recordDecision("reconciler.session.max_session_age", tp.TemplateName, name, dec.TraceReason, dec.TraceOutcome, nil, nil, "")
+					trace.RecordDecision(TraceSiteReconcilerMaxSessionAge, TraceReasonCode(dec.TraceReason), TraceOutcomeCode(dec.TraceOutcome), tp.TemplateName, name, nil)
 				}
 				if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
 					fmt.Fprintf(stderr, "session reconciler: stopping aged %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
@@ -2976,7 +2976,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					payload = traceRecordPayload{"drain_canceled": drainCancelled}
 				}
 				if trace != nil {
-					trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, dec.TraceReason, dec.TraceOutcome, payload, nil, "")
+					trace.RecordDecision(TraceSiteReconcilerIdleTimeout, TraceReasonCode(dec.TraceReason), TraceOutcomeCode(dec.TraceOutcome), tp.TemplateName, name, payload)
 				}
 				if dec.SkipWakePass {
 					continue
@@ -2984,7 +2984,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			case sessionpkg.TimerActionStop:
 				fmt.Fprintf(stderr, "session reconciler: idle timeout for %s\n", tp.DisplayName()) //nolint:errcheck // best-effort stderr
 				if trace != nil {
-					trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, dec.TraceReason, dec.TraceOutcome, nil, nil, "")
+					trace.RecordDecision(TraceSiteReconcilerIdleTimeout, TraceReasonCode(dec.TraceReason), TraceOutcomeCode(dec.TraceOutcome), tp.TemplateName, name, nil)
 				}
 				if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
 					fmt.Fprintf(stderr, "session reconciler: stopping idle %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
@@ -3144,9 +3144,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// Session should be awake but isn't — wake it.
 			if isFailedCreateSessionInfo(info) {
 				if trace != nil {
-					trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "failed_create", traceRecordPayload{
+					trace.RecordDecision(TraceSiteReconcilerWakeDecision, TraceReasonWake, TraceOutcomeFailedCreate, target.tp.TemplateName, name, traceRecordPayload{
 						"pending_create_claim": strings.TrimSpace(info.PendingCreateClaimMetadata),
-					}, nil, "")
+					})
 				}
 				continue
 			}
@@ -3155,10 +3155,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 			if pendingCreateStartInFlightInfo(info, clk, startupTimeout) {
 				if trace != nil {
-					trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "start_in_flight", traceRecordPayload{
+					trace.RecordDecision(TraceSiteReconcilerWakeDecision, TraceReasonWake, TraceOutcomeStartInFlight, target.tp.TemplateName, name, traceRecordPayload{
 						"pending_create_claim": strings.TrimSpace(info.PendingCreateClaimMetadata),
 						"last_woke_at":         info.LastWokeAt,
-					}, nil, "")
+					})
 				}
 				continue
 			}
@@ -3175,9 +3175,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						}
 						cb.LogOpenOnce(identity, stderr)
 						if trace != nil {
-							trace.recordDecision("reconciler.session.circuit_open", target.tp.TemplateName, name, "circuit_open", "skipped", traceRecordPayload{
+							trace.RecordDecision(TraceSiteReconcilerCircuitOpen, TraceReasonCircuitOpen, TraceOutcomeSkipped, target.tp.TemplateName, name, traceRecordPayload{
 								"identity": identity,
-							}, nil, "")
+							})
 						}
 						continue
 					}
@@ -3198,18 +3198,18 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						emitProviderHealthGateAlert(rec, stdout, p, epID, since, count)
 					})
 					if trace != nil {
-						trace.recordDecision("reconciler.session.provider_health_gate", target.tp.TemplateName, name, "provider_red", "respawn_skipped", traceRecordPayload{
+						trace.RecordDecision(TraceSiteReconcilerProviderHealthGate, TraceReasonProviderRed, TraceOutcomeRespawnSkipped, target.tp.TemplateName, name, traceRecordPayload{
 							"provider": phProvider,
-						}, nil, "")
+						})
 					}
 					continue // skip startCandidates; wake budget is NOT consumed
 				}
 			}
 
 			if trace != nil {
-				trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "start_candidate", traceRecordPayload{
+				trace.RecordDecision(TraceSiteReconcilerWakeDecision, TraceReasonWake, TraceOutcomeStartCandidate, target.tp.TemplateName, name, traceRecordPayload{
 					"should_wake": shouldWake,
-				}, nil, "")
+				})
 			}
 			if fold := recordCurrentBeadIDOnWake(target.session, sessFront, decision.AssignedWorkBeadID, stderr); fold != nil {
 				infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
@@ -3292,9 +3292,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if beginSessionDrainInfo(info, sp, dt, reason, clk, defaultDrainTimeout) {
 				fmt.Fprintf(stdout, "Draining session '%s': %s\n", name, reason) //nolint:errcheck
 				if trace != nil {
-					trace.recordDecision("reconciler.session.drain", target.tp.TemplateName, name, reason, "drain", traceRecordPayload{
+					trace.RecordDecision(TraceSiteReconcilerDrainDecision, TraceReasonCode(reason), TraceOutcomeDrain, target.tp.TemplateName, name, traceRecordPayload{
 						"sleep_intent": intent,
-					}, nil, "")
+					})
 				}
 			}
 		}
@@ -4251,13 +4251,13 @@ func traceHealClearedPendingCreateLease(
 	if name == "" {
 		name = session.Metadata["session_name"]
 	}
-	trace.recordDecision("reconciler.session.pending_create", template, name, "heal_cleared_stale_lease", string(TraceOutcomeApplied), traceRecordPayload{
+	trace.RecordDecision(TraceSiteReconcilerPendingCreate, TraceReasonHealClearedStaleLease, TraceOutcomeApplied, template, name, traceRecordPayload{
 		"last_woke_at":              lastWokeAtBeforeHeal,
 		"pending_create_started_at": pendingCreateStartedAtBeforeHeal,
 		"provider_alive":            providerAlive,
 		"state_after":               session.Metadata["state"],
 		"state_before":              stateBeforeHeal,
-	}, nil, "")
+	})
 }
 
 func applyTemplateOverridesToConfig(agentCfg *runtime.Config, session beads.Bead, tp TemplateParams) {
@@ -4870,7 +4870,7 @@ func relaunchAgentForLaunchDrift(
 		fmt.Fprintf(stderr, "session reconciler: rebaselining launch-drift hashes for %s: %v\n", name, rebaseErr) //nolint:errcheck
 	}
 	if trace != nil {
-		trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "relaunch", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
+		trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeRelaunch, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, nil))
 	}
 	rec.Record(events.Event{
 		Type:    events.SessionUpdated,

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -6803,14 +6803,64 @@ func TestTraceHealClearedPendingCreateLeaseRecordsDecision(t *testing.T) {
 	if rec.OutcomeCode != TraceOutcomeApplied {
 		t.Fatalf("outcome = %q, want %q", rec.OutcomeCode, TraceOutcomeApplied)
 	}
-	if got := rec.Fields["raw_reason_code"]; got != "heal_cleared_stale_lease" {
-		t.Fatalf("raw_reason_code = %#v, want heal_cleared_stale_lease", got)
+	if rec.ReasonCode != TraceReasonHealClearedStaleLease {
+		t.Fatalf("reason = %q, want %q", rec.ReasonCode, TraceReasonHealClearedStaleLease)
 	}
 	if got := rec.Fields["state_before"]; got != "creating" {
 		t.Fatalf("state_before = %#v, want creating", got)
 	}
 	if got := rec.Fields["state_after"]; got != "asleep" {
 		t.Fatalf("state_after = %#v, want asleep", got)
+	}
+}
+
+// TestRecordDecisionKeepsBackfilledCodesTyped proves the S26 collapse: codes
+// that the deleted normalize allowlists used to silently rewrite to "unknown"
+// (dumping the real value into a raw_*_code field) now land directly in the
+// typed primary fields, with no raw_*_code shadow left behind.
+func TestRecordDecisionKeepsBackfilledCodesTyped(t *testing.T) {
+	trace := &sessionReconcilerTraceCycle{
+		tracer: &SessionReconcilerTracer{
+			detail: map[string]TraceSource{"repo/worker": TraceSourceManual},
+		},
+		dropReasons:       map[string]int{},
+		pendingDetail:     map[string][]SessionReconcilerTraceRecord{},
+		pendingDropped:    map[string]int{},
+		templatesTouched:  map[string]struct{}{},
+		detailedTemplates: map[string]struct{}{},
+		decisionCounts:    map[string]int{},
+		operationCounts:   map[string]int{},
+		mutationCounts:    map[string]int{},
+		reasonCounts:      map[string]int{},
+		outcomeCounts:     map[string]int{},
+	}
+
+	trace.RecordDecision(
+		TraceSiteReconcilerDrainAck,
+		TraceReasonConfigDriftAttached,
+		TraceOutcomeCancelReconcilerAck,
+		"repo/worker",
+		"worker-1",
+		nil,
+	)
+
+	if len(trace.records) != 1 {
+		t.Fatalf("records = %d, want 1", len(trace.records))
+	}
+	rec := trace.records[0]
+	if rec.SiteCode != TraceSiteReconcilerDrainAck {
+		t.Fatalf("site = %q, want %q", rec.SiteCode, TraceSiteReconcilerDrainAck)
+	}
+	if rec.ReasonCode != TraceReasonConfigDriftAttached {
+		t.Fatalf("reason = %q, want %q", rec.ReasonCode, TraceReasonConfigDriftAttached)
+	}
+	if rec.OutcomeCode != TraceOutcomeCancelReconcilerAck {
+		t.Fatalf("outcome = %q, want %q", rec.OutcomeCode, TraceOutcomeCancelReconcilerAck)
+	}
+	for _, k := range []string{"raw_site_code", "raw_reason_code", "raw_outcome_code"} {
+		if _, ok := rec.Fields[k]; ok {
+			t.Fatalf("field %q present, want absent", k)
+		}
 	}
 }
 

--- a/cmd/gc/session_reconciler_trace_cycle.go
+++ b/cmd/gc/session_reconciler_trace_cycle.go
@@ -51,29 +51,6 @@ func (c *SessionReconcilerTraceCycle) sourceFor(template string) string {
 	return string(TraceSourceAlwaysOn)
 }
 
-func (c *SessionReconcilerTraceCycle) recordDecision(siteCode, template, sessionName, reason, outcome string, data traceRecordPayload, _ []string, _ string) {
-	if c == nil {
-		return
-	}
-	fields := make(map[string]any, len(data))
-	for k, v := range data {
-		fields[k] = v
-	}
-	normSite, rawSite := normalizeTraceSiteCode(siteCode)
-	normReason, rawReason := normalizeTraceReasonCode(reason)
-	normOutcome, rawOutcome := normalizeTraceOutcomeCode(outcome)
-	if rawSite != "" {
-		fields["raw_site_code"] = rawSite
-	}
-	if rawReason != "" {
-		fields["raw_reason_code"] = rawReason
-	}
-	if rawOutcome != "" {
-		fields["raw_outcome_code"] = rawOutcome
-	}
-	c.RecordDecision(normSite, normReason, normOutcome, template, sessionName, fields)
-}
-
 // RecordControllerDecision records a baseline daemon-level decision that is
 // not scoped to a specific session template.
 func (c *SessionReconcilerTraceCycle) RecordControllerDecision(site TraceSiteCode, reason TraceReasonCode, outcome TraceOutcomeCode, fields map[string]any) {
@@ -114,56 +91,6 @@ func (c *SessionReconcilerTraceCycle) RecordControllerOperation(site TraceSiteCo
 		rec.Fields[k] = v
 	}
 	c.addRecord(rec)
-}
-
-func (c *SessionReconcilerTraceCycle) recordOperation(siteCode, template, sessionName, _ string, reason, outcome string, data traceRecordPayload, _ string) {
-	if c == nil {
-		return
-	}
-	fields := make(map[string]any, len(data)+1)
-	for k, v := range data {
-		fields[k] = v
-	}
-	var duration time.Duration
-	if durMs, ok := fields["duration_ms"].(int64); ok {
-		duration = time.Duration(durMs) * time.Millisecond
-	}
-	normSite, rawSite := normalizeTraceSiteCode(siteCode)
-	normReason, rawReason := normalizeTraceReasonCode(reason)
-	normOutcome, rawOutcome := normalizeTraceOutcomeCode(outcome)
-	if rawSite != "" {
-		fields["raw_site_code"] = rawSite
-	}
-	if rawReason != "" {
-		fields["raw_reason_code"] = rawReason
-	}
-	if rawOutcome != "" {
-		fields["raw_outcome_code"] = rawOutcome
-	}
-	c.RecordOperation(normSite, normReason, normOutcome, "", template, sessionName, duration, fields)
-}
-
-func (c *SessionReconcilerTraceCycle) recordMutation(siteCode, template, _ string, targetKind, targetID, writeMethod string, before, after any, outcome string, data traceRecordPayload, _ string) {
-	if c == nil {
-		return
-	}
-	fields := make(map[string]any)
-	for k, v := range data {
-		fields[k] = v
-	}
-	fields["template"] = template
-	fields["before"] = before
-	fields["after"] = after
-	fields["field"] = writeMethod
-	normSite, rawSite := normalizeTraceSiteCode(siteCode)
-	normOutcome, rawOutcome := normalizeTraceOutcomeCode(outcome)
-	if rawSite != "" {
-		fields["raw_site_code"] = rawSite
-	}
-	if rawOutcome != "" {
-		fields["raw_outcome_code"] = rawOutcome
-	}
-	c.RecordMutation(normSite, TraceReasonUnknown, normOutcome, targetKind, targetID, writeMethod, fields)
 }
 
 func (c *SessionReconcilerTraceCycle) end(completion TraceCompletionStatus, data traceRecordPayload) {

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -46,16 +46,6 @@ func TestTraceDetailScopesIncludesDependencies(t *testing.T) {
 	}
 }
 
-func TestNormalizeTraceOutcomeCodeAcceptsDeferredActive(t *testing.T) {
-	got, raw := normalizeTraceOutcomeCode(string(TraceOutcomeDeferredActive))
-	if got != TraceOutcomeDeferredActive {
-		t.Fatalf("outcome = %q, want %q", got, TraceOutcomeDeferredActive)
-	}
-	if raw != "" {
-		t.Fatalf("raw outcome = %q, want empty", raw)
-	}
-}
-
 func TestConfigDriftTracePayloadIncludesDriftedFields(t *testing.T) {
 	payload := configDriftTracePayload("stored", "current", []string{"CopyFiles"}, traceRecordPayload{
 		"active_reason": "attached",

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -4,7 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 )
@@ -113,6 +115,21 @@ const (
 	TraceSiteLifecycleDrainAdvance          TraceSiteCode = "lifecycle.drain.advance"
 	TraceSiteSupervisorFSPressure           TraceSiteCode = "supervisor.fs_pressure"
 	TraceSiteTraceControl                   TraceSiteCode = "trace.control"
+
+	TraceSiteReconcilerPreserveConfiguredNamed   TraceSiteCode = "reconciler.session.preserve_configured_named"
+	TraceSiteReconcilerPendingCreatePreserved    TraceSiteCode = "reconciler.session.pending_create_preserved"
+	TraceSiteReconcilerCloseFailedCreate         TraceSiteCode = "reconciler.session.close_failed_create"
+	TraceSiteReconcilerDrainAck                  TraceSiteCode = "reconciler.session.drain_ack"
+	TraceSiteReconcilerTerminalProviderError     TraceSiteCode = "reconciler.session.terminal_provider_error"
+	TraceSiteReconcilerMaxSessionAge             TraceSiteCode = "reconciler.session.max_session_age"
+	TraceSiteReconcilerLiveDrift                 TraceSiteCode = "reconciler.session.live_drift"
+	TraceSiteReconcilerCircuitOpen               TraceSiteCode = "reconciler.session.circuit_open"
+	TraceSiteReconcilerCircuitTrip               TraceSiteCode = "reconciler.session.circuit_trip"
+	TraceSiteReconcilerProviderHealthGate        TraceSiteCode = "reconciler.session.provider_health_gate"
+	TraceSiteReconcilerBeadReassignCycle         TraceSiteCode = "reconciler.session.bead_reassign_cycle"
+	TraceSiteLifecycleStartTerminalProviderError TraceSiteCode = "reconciler.start.terminal_provider_error"
+	TraceSiteLifecycleStartRateLimitHold         TraceSiteCode = "reconciler.start.rate_limit_hold"
+	TraceSiteLifecycleShutdownPreserveSessions   TraceSiteCode = "lifecycle.shutdown.preserve_sessions"
 )
 
 type TraceReasonCode string
@@ -150,6 +167,29 @@ const (
 	TraceReasonNoWakeReason           TraceReasonCode = "no_wake_reason"
 	TraceReasonFSPressure             TraceReasonCode = "fs_pressure"
 	TraceReasonResetStalled           TraceReasonCode = "reset_stalled"
+
+	TraceReasonRateLimit                     TraceReasonCode = "rate_limit"
+	TraceReasonPendingCreate                 TraceReasonCode = "pending_create"
+	TraceReasonPreserve                      TraceReasonCode = "preserve"
+	TraceReasonConfigDriftAttachmentError    TraceReasonCode = "config_drift_attachment_error"
+	TraceReasonConfigDriftAttached           TraceReasonCode = "config_drift_attached"
+	TraceReasonConfigDriftRecentlyAttached   TraceReasonCode = "config_drift_recently_attached"
+	TraceReasonPending                       TraceReasonCode = "pending"
+	TraceReasonAcknowledged                  TraceReasonCode = "acknowledged"
+	TraceReasonMinFloorIdleWorker            TraceReasonCode = "min_floor_idle_worker"
+	TraceReasonLiveDrift                     TraceReasonCode = "live_drift"
+	TraceReasonCircuitOpen                   TraceReasonCode = "circuit_open"
+	TraceReasonCircuitTrip                   TraceReasonCode = "circuit_trip"
+	TraceReasonProviderRed                   TraceReasonCode = "provider_red"
+	TraceReasonHealClearedStaleLease         TraceReasonCode = "heal_cleared_stale_lease"
+	TraceReasonPendingCreateRecoveryInFlight TraceReasonCode = "pending_create_recovery_in_flight"
+	TraceReasonPendingCreateRebuildFailed    TraceReasonCode = "pending_create_rebuild_failed"
+	TraceReasonPendingCreateCommitFailed     TraceReasonCode = "pending_create_commit_failed"
+	TraceReasonPendingCreateHealed           TraceReasonCode = "pending_create_healed"
+	TraceReasonAssignedWork                  TraceReasonCode = "assigned_work"
+	TraceReasonFreshCycle                    TraceReasonCode = "fresh_cycle"
+	TraceReasonScaleCheck                    TraceReasonCode = "scale_check"
+	TraceReasonStart                         TraceReasonCode = "start"
 )
 
 type TraceOutcomeCode string
@@ -194,6 +234,30 @@ const (
 	// current FingerprintVersion (older or future binary). No drain, no
 	// event.
 	TraceOutcomeRebaselinedVersionMismatch TraceOutcomeCode = "rebaselined_version_mismatch"
+
+	TraceOutcomeRollbackDeferred    TraceOutcomeCode = "rollback_deferred"
+	TraceOutcomeKeptOpen            TraceOutcomeCode = "kept_open"
+	TraceOutcomeDeferred            TraceOutcomeCode = "deferred"
+	TraceOutcomeCancelPending       TraceOutcomeCode = "cancel_pending"
+	TraceOutcomeCancelAssignedWork  TraceOutcomeCode = "cancel_assigned_work"
+	TraceOutcomeCancelReconcilerAck TraceOutcomeCode = "cancel_reconciler_ack"
+	TraceOutcomeStopPending         TraceOutcomeCode = "stop_pending"
+	TraceOutcomeDeferredConfirm     TraceOutcomeCode = "deferred_confirm"
+	TraceOutcomeExempt              TraceOutcomeCode = "exempt"
+	TraceOutcomeRestartInPlace      TraceOutcomeCode = "restart_in_place"
+	TraceOutcomeDeferredPending     TraceOutcomeCode = "deferred_pending"
+	TraceOutcomeRepairInPlace       TraceOutcomeCode = "repair_in_place"
+	TraceOutcomeFailedCreate        TraceOutcomeCode = "failed_create"
+	TraceOutcomeStartInFlight       TraceOutcomeCode = "start_in_flight"
+	TraceOutcomeRespawnSkipped      TraceOutcomeCode = "respawn_skipped"
+	TraceOutcomeRelaunch            TraceOutcomeCode = "relaunch"
+	TraceOutcomeClear               TraceOutcomeCode = "clear"
+	TraceOutcomeUnhealthy           TraceOutcomeCode = "unhealthy"
+	TraceOutcomeRestart             TraceOutcomeCode = "restart"
+	TraceOutcomeScheduled           TraceOutcomeCode = "scheduled"
+	TraceOutcomeHoldDeferred        TraceOutcomeCode = "hold_deferred"
+	TraceOutcomeHeld                TraceOutcomeCode = "held"
+	TraceOutcomeHealed              TraceOutcomeCode = "healed"
 )
 
 type TraceCompletionStatus string
@@ -360,69 +424,37 @@ func (r *SessionReconcilerTraceRecord) ensureFields() {
 
 func (r SessionReconcilerTraceRecord) clone() SessionReconcilerTraceRecord {
 	if len(r.CausedByRecordIDs) > 0 {
-		r.CausedByRecordIDs = append([]string(nil), r.CausedByRecordIDs...)
+		r.CausedByRecordIDs = slices.Clone(r.CausedByRecordIDs)
 	}
 	if len(r.TemplatesTouched) > 0 {
-		r.TemplatesTouched = append([]string(nil), r.TemplatesTouched...)
+		r.TemplatesTouched = slices.Clone(r.TemplatesTouched)
 	}
 	if len(r.AutoArmsTriggered) > 0 {
-		r.AutoArmsTriggered = append([]string(nil), r.AutoArmsTriggered...)
+		r.AutoArmsTriggered = slices.Clone(r.AutoArmsTriggered)
 	}
 	if len(r.DropReasonCounts) > 0 {
-		cp := make(map[string]int, len(r.DropReasonCounts))
-		for k, v := range r.DropReasonCounts {
-			cp[k] = v
-		}
-		r.DropReasonCounts = cp
+		r.DropReasonCounts = maps.Clone(r.DropReasonCounts)
 	}
 	if len(r.DecisionCounts) > 0 {
-		cp := make(map[string]int, len(r.DecisionCounts))
-		for k, v := range r.DecisionCounts {
-			cp[k] = v
-		}
-		r.DecisionCounts = cp
+		r.DecisionCounts = maps.Clone(r.DecisionCounts)
 	}
 	if len(r.OperationCounts) > 0 {
-		cp := make(map[string]int, len(r.OperationCounts))
-		for k, v := range r.OperationCounts {
-			cp[k] = v
-		}
-		r.OperationCounts = cp
+		r.OperationCounts = maps.Clone(r.OperationCounts)
 	}
 	if len(r.MutationCounts) > 0 {
-		cp := make(map[string]int, len(r.MutationCounts))
-		for k, v := range r.MutationCounts {
-			cp[k] = v
-		}
-		r.MutationCounts = cp
+		r.MutationCounts = maps.Clone(r.MutationCounts)
 	}
 	if len(r.ReasonCounts) > 0 {
-		cp := make(map[string]int, len(r.ReasonCounts))
-		for k, v := range r.ReasonCounts {
-			cp[k] = v
-		}
-		r.ReasonCounts = cp
+		r.ReasonCounts = maps.Clone(r.ReasonCounts)
 	}
 	if len(r.OutcomeCounts) > 0 {
-		cp := make(map[string]int, len(r.OutcomeCounts))
-		for k, v := range r.OutcomeCounts {
-			cp[k] = v
-		}
-		r.OutcomeCounts = cp
+		r.OutcomeCounts = maps.Clone(r.OutcomeCounts)
 	}
 	if len(r.DemandSummary) > 0 {
-		cp := make(map[string]any, len(r.DemandSummary))
-		for k, v := range r.DemandSummary {
-			cp[k] = v
-		}
-		r.DemandSummary = cp
+		r.DemandSummary = maps.Clone(r.DemandSummary)
 	}
 	if len(r.Fields) > 0 {
-		cp := make(map[string]any, len(r.Fields))
-		for k, v := range r.Fields {
-			cp[k] = v
-		}
-		r.Fields = cp
+		r.Fields = maps.Clone(r.Fields)
 	}
 	return r
 }
@@ -538,168 +570,6 @@ func normalizedTraceTemplate(v string) string {
 		return ""
 	}
 	return strings.TrimSpace(filepath.Clean(v))
-}
-
-func normalizeTraceSiteCode(raw string) (TraceSiteCode, string) {
-	raw = strings.TrimSpace(raw)
-	switch raw {
-	case "reconciler.session.unknown_state":
-		return TraceSiteReconcilerUnknownState, ""
-	case "reconciler.session.pending_create":
-		return TraceSiteReconcilerPendingCreate, ""
-	case "reconciler.session.wake":
-		return TraceSiteReconcilerWakeDecision, ""
-	case "reconciler.session.drain":
-		return TraceSiteReconcilerDrainDecision, ""
-	}
-	switch TraceSiteCode(raw) {
-	case TraceSiteUnknown,
-		TraceSiteScaleCheckExec,
-		TraceSiteCycleStart,
-		TraceSiteCycleFinish,
-		TraceSiteConfigReload,
-		TraceSiteControllerTickPhase,
-		TraceSiteDesiredStateBuild,
-		TraceSiteDemandSnapshot,
-		TraceSiteOrderDispatch,
-		TraceSitePoolDemandCompute,
-		TraceSiteSessionSnapshot,
-		TraceSiteSessionSync,
-		TraceSiteSessionReconcileBuildDeps,
-		TraceSiteSessionReconcileHealRetire,
-		TraceSiteSessionReconcileTopoOrder,
-		TraceSiteSessionReconcileCircuitBreaker,
-		TraceSiteSessionReconcileForwardPass,
-		TraceSiteSessionReconcileAwakeSet,
-		TraceSiteSessionReconcileWakeSleep,
-		TraceSiteSessionReconcileStartExecution,
-		TraceSiteSessionReconcileDrainAdvance,
-		TraceSitePoolAgentCap,
-		TraceSitePoolRigCap,
-		TraceSitePoolWorkspaceCap,
-		TraceSitePoolAccept,
-		TraceSitePoolMinFill,
-		TraceSitePoolInFlightReuse,
-		TraceSitePoolWakeKnownIdentity,
-		TraceSitePoolNewDemandCap,
-		TraceSiteReconcilerUnknownState,
-		TraceSiteReconcilerOrphaned,
-		TraceSiteReconcilerCloseOrphan,
-		TraceSiteReconcilerPendingCreate,
-		TraceSiteReconcilerConfigDrift,
-		TraceSiteReconcilerIdleDrain,
-		TraceSiteReconcilerIdleTimeout,
-		TraceSiteReconcilerResetStalled,
-		TraceSiteReconcilerProgressStallExempt,
-		TraceSiteReconcilerWakeDecision,
-		TraceSiteReconcilerDrainDecision,
-		TraceSiteDrainStale,
-		TraceSiteDrainComplete,
-		TraceSiteDrainCancel,
-		TraceSiteDrainTimeout,
-		TraceSiteMutationBeadMetadata,
-		TraceSiteMutationRuntimeMeta,
-		TraceSiteLifecycleStartRollback,
-		TraceSiteLifecycleStartFailed,
-		TraceSiteLifecycleStartRun,
-		TraceSiteLifecycleStartPrepare,
-		TraceSiteLifecycleStartExecute,
-		TraceSiteLifecycleStartCommit,
-		TraceSiteLifecycleDrainBegin,
-		TraceSiteLifecycleDrainAdvance,
-		TraceSiteSupervisorFSPressure,
-		TraceSiteTraceControl:
-		return TraceSiteCode(raw), ""
-	default:
-		return TraceSiteUnknown, raw
-	}
-}
-
-func normalizeTraceReasonCode(raw string) (TraceReasonCode, string) {
-	raw = strings.TrimSpace(raw)
-	switch raw {
-	case "config-drift":
-		return TraceReasonConfigDrift, ""
-	case "store-partial":
-		return TraceReasonStorePartial, ""
-	case "no-wake-reason":
-		return TraceReasonNoWakeReason, ""
-	}
-	switch TraceReasonCode(raw) {
-	case TraceReasonUnknown,
-		TraceReasonNoDemand,
-		TraceReasonNoMatchingSession,
-		TraceReasonDependencyBlocked,
-		TraceReasonStorePartial,
-		TraceReasonConfigDrift,
-		TraceReasonIdle,
-		TraceReasonPendingCreateRollback,
-		TraceReasonWakeFailureIncremented,
-		TraceReasonQuarantineEntered,
-		TraceReasonUnknownStateSkipped,
-		TraceReasonTemplateMissing,
-		TraceReasonNoEffectTemplateMatch,
-		TraceReasonAutoArmSuppressed,
-		TraceReasonRetained,
-		TraceReasonExpired,
-		TraceReasonAgentCap,
-		TraceReasonRigCap,
-		TraceReasonWorkspaceCap,
-		TraceReasonCap,
-		TraceReasonMinFill,
-		TraceReasonInFlightReuse,
-		TraceReasonWake,
-		TraceReasonIdleTimeout,
-		TraceReasonStaleGeneration,
-		TraceReasonSuspended,
-		TraceReasonOrphaned,
-		TraceReasonDrainTimeout,
-		TraceReasonStoreQueryPartial,
-		TraceReasonNoWakeReason,
-		TraceReasonFSPressure,
-		TraceReasonResetStalled:
-		return TraceReasonCode(raw), ""
-	default:
-		return TraceReasonUnknown, raw
-	}
-}
-
-func normalizeTraceOutcomeCode(raw string) (TraceOutcomeCode, string) {
-	switch TraceOutcomeCode(strings.TrimSpace(raw)) {
-	case TraceOutcomeUnknown,
-		TraceOutcomeComplete,
-		TraceOutcomePartial,
-		TraceOutcomeApplied,
-		TraceOutcomeNoChange,
-		TraceOutcomeFailed,
-		TraceOutcomeSuccess,
-		TraceOutcomeDeferredByWakeBudget,
-		TraceOutcomeSessionExists,
-		TraceOutcomeSessionExistsConverged,
-		TraceOutcomeBlockedOnDependencies,
-		TraceOutcomeProviderError,
-		TraceOutcomePanicRecovered,
-		TraceOutcomeDeadlineExceeded,
-		TraceOutcomeCanceled,
-		TraceOutcomeSlowStorageDegraded,
-		TraceOutcomeLowSpaceDegraded,
-		TraceOutcomePromotionPartialContext,
-		TraceOutcomeAccepted,
-		TraceOutcomeRejected,
-		TraceOutcomeSkipped,
-		TraceOutcomeDrain,
-		TraceOutcomeClosed,
-		TraceOutcomeRollback,
-		TraceOutcomeDeferredAttached,
-		TraceOutcomeDeferredActive,
-		TraceOutcomeStop,
-		TraceOutcomeStartCandidate,
-		TraceOutcomeRetry,
-		TraceOutcomeCancel:
-		return TraceOutcomeCode(strings.TrimSpace(raw)), ""
-	default:
-		return TraceOutcomeUnknown, strings.TrimSpace(raw)
-	}
 }
 
 func newTraceID(prefix string) string {

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -539,11 +539,11 @@ func advanceSessionDrainsWithSessionsTraced(
 			}
 			dt.remove(id)
 			if trace != nil {
-				trace.recordDecision("reconciler.drain.stale", normalizedSessionTemplateInfo(info, cfg), name, "stale_generation", "cancel", traceRecordPayload{
+				trace.RecordDecision(TraceSiteDrainStale, TraceReasonStaleGeneration, TraceOutcomeCancel, normalizedSessionTemplateInfo(info, cfg), name, traceRecordPayload{
 					"drain_reason":       ds.reason,
 					"drain_generation":   ds.generation,
 					"session_generation": gen,
-				}, nil, "")
+				})
 			}
 			continue
 		}
@@ -560,9 +560,9 @@ func advanceSessionDrainsWithSessionsTraced(
 			dt.remove(id)
 			telemetry.RecordDrainTransition(context.Background(), name, ds.reason, "complete")
 			if trace != nil {
-				trace.recordDecision("reconciler.drain.complete", normalizedSessionTemplateInfo(info, cfg), name, ds.reason, "complete", traceRecordPayload{
+				trace.RecordDecision(TraceSiteDrainComplete, TraceReasonCode(ds.reason), TraceOutcomeComplete, normalizedSessionTemplateInfo(info, cfg), name, traceRecordPayload{
 					"drain_started_at": ds.startedAt,
-				}, nil, "")
+				})
 			}
 			continue
 		}
@@ -572,7 +572,7 @@ func advanceSessionDrainsWithSessionsTraced(
 			pendingDrainReasonCancelable(ds.reason) {
 			if cancelSessionDrainForPendingInfo(info, sp, dt) {
 				if trace != nil {
-					trace.recordDecision("reconciler.drain.cancel", normalizedSessionTemplateInfo(info, cfg), name, ds.reason, "cancel_pending", nil, nil, "")
+					trace.RecordDecision(TraceSiteDrainCancel, TraceReasonCode(ds.reason), TraceOutcomeCancelPending, normalizedSessionTemplateInfo(info, cfg), name, nil)
 				}
 				continue
 			}
@@ -584,7 +584,7 @@ func advanceSessionDrainsWithSessionsTraced(
 			assignedWorkDrainReasonCancelable(ds.reason) {
 			if cancelSessionDrainForAssignedWorkInfo(info, sp, dt) {
 				if trace != nil {
-					trace.recordDecision("reconciler.drain.cancel", normalizedSessionTemplateInfo(info, cfg), name, ds.reason, "cancel_assigned_work", nil, nil, "")
+					trace.RecordDecision(TraceSiteDrainCancel, TraceReasonCode(ds.reason), TraceOutcomeCancelAssignedWork, normalizedSessionTemplateInfo(info, cfg), name, nil)
 				}
 				continue
 			}
@@ -603,7 +603,7 @@ func advanceSessionDrainsWithSessionsTraced(
 				}
 				dt.remove(id)
 				if trace != nil {
-					trace.recordDecision("reconciler.drain.cancel", normalizedSessionTemplateInfo(info, cfg), name, ds.reason, "cancel", nil, nil, "")
+					trace.RecordDecision(TraceSiteDrainCancel, TraceReasonCode(ds.reason), TraceOutcomeCancel, normalizedSessionTemplateInfo(info, cfg), name, nil)
 				}
 				continue
 			}
@@ -638,7 +638,11 @@ func advanceSessionDrainsWithSessionsTraced(
 					outcome = "failed"
 					fields["error"] = err.Error()
 				}
-				trace.recordMutation("runtime_meta", normalizedSessionTemplateInfo(info, cfg), name, "provider_meta", name, "GC_DRAIN_ACK", "", "1", outcome, fields, "")
+				fields["template"] = normalizedSessionTemplateInfo(info, cfg)
+				fields["before"] = ""
+				fields["after"] = "1"
+				fields["field"] = "GC_DRAIN_ACK"
+				trace.RecordMutation(TraceSiteMutationRuntimeMeta, TraceReasonUnknown, TraceOutcomeCode(outcome), "provider_meta", name, "GC_DRAIN_ACK", fields)
 			}
 		}
 
@@ -656,9 +660,9 @@ func advanceSessionDrainsWithSessionsTraced(
 				// Other errors (transient stop failure): keep drain
 				// active for retry on next tick.
 				if trace != nil {
-					trace.recordDecision("reconciler.drain.timeout", normalizedSessionTemplateInfo(info, cfg), name, ds.reason, "retry", traceRecordPayload{
+					trace.RecordDecision(TraceSiteDrainTimeout, TraceReasonCode(ds.reason), TraceOutcomeRetry, normalizedSessionTemplateInfo(info, cfg), name, traceRecordPayload{
 						"error": err.Error(),
-					}, nil, "")
+					})
 				}
 				continue
 			}
@@ -674,7 +678,7 @@ func advanceSessionDrainsWithSessionsTraced(
 				dt.remove(id)
 				telemetry.RecordDrainTransition(context.Background(), name, ds.reason, "timeout")
 				if trace != nil {
-					trace.recordDecision("reconciler.drain.timeout", normalizedSessionTemplateInfo(info, cfg), name, ds.reason, "complete", nil, nil, "")
+					trace.RecordDecision(TraceSiteDrainTimeout, TraceReasonCode(ds.reason), TraceOutcomeComplete, normalizedSessionTemplateInfo(info, cfg), name, nil)
 				}
 			}
 			// If still running after stop, keep drain for next tick.


### PR DESCRIPTION
## What this does

Lands **S26** — collapses the trace double-record API to one typed surface.
Introduces typed `TraceSiteCode` / `TraceReasonCode` / `TraceOutcomeCode` and
routes the trace call sites through them, deleting the string-normalize
allowlists (and a whole file). Real −151-line reduction in the diagnostic trace
subsystem; low blast radius, behavior-preserving.

Touches `cmd/gc` trace subsystem (`session_reconciler_trace_*`,
`session_reconciler.go`, `build_desired_state.go`, `city_runtime.go`,
`session_wake.go`, `pool_desired_state.go`, etc.).

## Gates

- `go build ./cmd/gc` — pass
- `go vet ./cmd/gc` — pass
- `go test ./cmd/gc` trace + reconciler + session (`-run`) — pass

## Review verdict

LAND — fast-track (no `status/needs-review-auto` label), diagnostic-layer typed
reduction, behavior-preserving, per the simplification walkthrough. Merge after
CI green; delete branch on merge.
