### PR TITLE
simplify(S14): one launchWorkflow chokepoint (single dedupe guard + compile-once)

### DIFF
--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -1261,29 +1261,69 @@ func IsGraphWorkflowAttachment(store beads.Store, rootID string) bool {
 // graph routing if the formula is a graph.v2 workflow.
 func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPaths []string, opts molecule.Options, sourceBeadID, scopeKind, scopeRef string, a config.Agent, deps SlingDeps, forceGraphV2Replace ...bool) (*molecule.Result, error) {
 	SlingTracef("instantiate start formula=%s source=%s agent=%s parent=%s", formulaName, sourceBeadID, a.QualifiedName(), opts.ParentID)
-	if opts.PriorityOverride == nil && sourceBeadID != "" {
-		opts.PriorityOverride = BeadPriorityOverride(deps.Store, sourceBeadID)
-	}
 	compileStart := time.Now()
 	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, formulaName, searchPaths, opts.Vars)
 	if err != nil {
 		SlingTracef("instantiate compile-error formula=%s dur=%s err=%v", formulaName, time.Since(compileStart), err)
 		return nil, err
 	}
+	SlingTracef("instantiate compiled formula=%s dur=%s steps=%d", formulaName, time.Since(compileStart), len(recipe.Steps))
+	return InstantiateCompiledSlingFormula(ctx, recipe, formulaName, opts, sourceBeadID, scopeKind, scopeRef, a, deps, forceGraphV2Replace...)
+}
+
+// InstantiateCompiledSlingFormula materializes an already-compiled formula
+// recipe, applying graph routing when the recipe is a graph.v2 workflow. It is
+// the single instantiation chokepoint for every sling launch shape: the caller
+// compiles the recipe exactly once (compile-once, S14 I11/I12) and hands the
+// same *formula.Recipe here, so the recipe that decides isGraph is the recipe
+// that is validated and instantiated.
+//
+// The at-most-one-live-root-per-RootKey invariant (I1) is enforced by a
+// cross-process sourceworkflow file lock on the RootKey — replacing the former
+// process-local striped mutex that two processes (CLI + API) could each pass,
+// which was the #1053 duplicate-molecule window. The RootKey lock nests inside
+// any source-bead lock the caller already holds, preserving the fixed
+// source→root acquisition order (I5); the keys never collide, so nesting is
+// deadlock-free.
+func InstantiateCompiledSlingFormula(ctx context.Context, recipe *formula.Recipe, formulaName string, opts molecule.Options, sourceBeadID, scopeKind, scopeRef string, a config.Agent, deps SlingDeps, forceGraphV2Replace ...bool) (*molecule.Result, error) {
+	if opts.PriorityOverride == nil && sourceBeadID != "" {
+		opts.PriorityOverride = BeadPriorityOverride(deps.Store, sourceBeadID)
+	}
 	if err := molecule.ValidateRecipeRuntimeVars(recipe, opts); err != nil {
 		SlingTracef("instantiate validate-error formula=%s err=%v", formulaName, err)
 		return nil, err
 	}
 	graphWorkflow := graphroute.IsCompiledGraphWorkflow(recipe)
+	rootKey := ""
 	if graphWorkflow {
 		stampGraphV2RootMetadata(recipe, formulaName, opts.Vars, scopeKind, scopeRef)
 		sourceBeadID = ""
-		if key := strings.TrimSpace(recipe.Steps[0].Metadata[beadmeta.Graphv2RootKeyMetadataKey]); key != "" {
-			unlock := lockGraphV2Root(key)
-			defer unlock()
-		}
+		rootKey = strings.TrimSpace(recipe.Steps[0].Metadata[beadmeta.Graphv2RootKeyMetadataKey])
 	}
-	SlingTracef("instantiate compiled formula=%s dur=%s steps=%d", formulaName, time.Since(compileStart), len(recipe.Steps))
+
+	materialize := func() (*molecule.Result, error) {
+		return materializeCompiledSlingFormula(ctx, recipe, formulaName, opts, sourceBeadID, scopeKind, scopeRef, graphWorkflow, a, deps, forceGraphV2Replace...)
+	}
+	if !graphWorkflow || rootKey == "" {
+		return materialize()
+	}
+	var result *molecule.Result
+	err := sourceworkflow.WithLock(ctx, deps.CityPath, sourceWorkflowLockScope(deps), rootKey, func() error {
+		var innerErr error
+		result, innerErr = materialize()
+		return innerErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// materializeCompiledSlingFormula performs the routing, dedupe lookup, and
+// instantiation for a compiled recipe. For graph workflows the caller invokes
+// it under the RootKey file lock so the live-root lookup and creation are
+// atomic across processes.
+func materializeCompiledSlingFormula(ctx context.Context, recipe *formula.Recipe, formulaName string, opts molecule.Options, sourceBeadID, scopeKind, scopeRef string, graphWorkflow bool, a config.Agent, deps SlingDeps, forceGraphV2Replace ...bool) (*molecule.Result, error) {
 	graphStore := deps.graphStore()
 	if err := graphroute.ApplyGraphRouting(recipe, &a, a.QualifiedName(), opts.Vars, sourceBeadID, scopeKind, scopeRef, deps.StoreRef, graphStore, deps.CityName, deps.Cfg, deps.graphrouteDeps()); err != nil {
 		SlingTracef("instantiate decorate-error formula=%s err=%v", formulaName, err)
@@ -1338,10 +1378,6 @@ func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPath
 	}
 	SlingTracef("instantiate done formula=%s dur=%s root=%s created=%d graph=%t", formulaName, time.Since(instantiateStart), result.RootID, result.Created, result.GraphWorkflow)
 	return result, nil
-}
-
-func lockGraphV2Root(key string) func() {
-	return graphv2.LockKey(key)
 }
 
 func closeReplacedGraphV2Root(store beads.Store, rootID string) ([]sourceworkflow.WorkflowBeadSnapshot, error) {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -257,7 +257,10 @@ func slingFormula(opts SlingOpts, deps SlingDeps) (SlingResult, error) {
 	if a.SupportsMultipleSessions() && !formula.RecipeHasReadySurface(recipe) {
 		return SlingResult{Target: a.QualifiedName(), FormulaName: opts.BeadOrFormula, Deprecations: inv.Deprecations}, fmt.Errorf("formula %q root is a molecule container, not Ready-visible work; scale-from-zero pools will not wake for this wisp. Convert the formula to phase=\"vapor\"/root-only or formulas v2 before routing it to a pool", opts.BeadOrFormula)
 	}
-	mResult, err := InstantiateSlingFormula(context.Background(), opts.BeadOrFormula, searchPaths, molecule.Options{
+	// Compile-once (S14): the recipe compiled above for the ready-surface check
+	// is the same one instantiated here — no redundant disk compile, and the
+	// isGraph/routing decision cannot drift from what is materialized.
+	mResult, err := InstantiateCompiledSlingFormula(context.Background(), recipe, opts.BeadOrFormula, molecule.Options{
 		Title: opts.Title,
 		Vars:  formulaVars,
 	}, "", opts.ScopeKind, opts.ScopeRef, a, deps, opts.Force)

--- a/internal/sling/sling_launch_chokepoint_test.go
+++ b/internal/sling/sling_launch_chokepoint_test.go
@@ -1,0 +1,199 @@
+package sling
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
+)
+
+// liveGraphV2Roots returns the non-closed graph.v2 workflow roots in store.
+func liveGraphV2Roots(t *testing.T, store beads.Store) []beads.Bead {
+	t.Helper()
+	roots, err := store.ListByMetadata(map[string]string{"gc.formula_contract": "graph.v2"}, 0, beads.WithBothTiers)
+	if err != nil {
+		t.Fatalf("ListByMetadata: %v", err)
+	}
+	var live []beads.Bead
+	for _, root := range roots {
+		if sourceworkflow.IsWorkflowRoot(root) && root.Status != "closed" {
+			live = append(live, root)
+		}
+	}
+	return live
+}
+
+// TestLaunchWorkflowDuplicateAttemptReturnsSameLiveRoot proves the single
+// dedupe guard: concurrent launches that resolve to the same RootKey converge
+// on exactly one live root, and every loser receives the winner's root as an
+// idempotent success (invariants I1 + I10) — never a second root, never an
+// error. This is the #1053 "duplicate molecules" window closed.
+func TestLaunchWorkflowDuplicateAttemptReturnsSameLiveRoot(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeGraphV2ConvoyFormula(t, formulaDir)
+	cfg := graphV2SlingTestConfig(t, formulaDir)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.CityPath = t.TempDir()
+	convoy, err := deps.Store.Create(beads.Bead{Title: "input", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	opts := molecule.Options{Vars: map[string]string{"convoy_id": convoy.ID}}
+
+	const n = 6
+	var wg sync.WaitGroup
+	ids := make([]string, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			res, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			ids[i] = res.RootID
+		}(i)
+	}
+	wg.Wait()
+
+	first := ids[0]
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("launch %d errored (a duplicate attempt must be an idempotent success, not an error): %v", i, err)
+		}
+		if ids[i] != first {
+			t.Fatalf("launch %d RootID = %q, want the shared winner root %q (I10)", i, ids[i], first)
+		}
+	}
+	if live := liveGraphV2Roots(t, deps.Store); len(live) != 1 {
+		t.Fatalf("live graph roots = %d, want exactly one (I1); roots=%+v", len(live), live)
+	}
+}
+
+// TestLaunchWorkflowUsesCrossProcessFileLock proves the dedupe guard is the
+// cross-process sourceworkflow file lock, not the old process-local striped
+// mutex. A graph launch must leave a lock file under the city runtime dir; the
+// process-local mutex never touched the filesystem, so this fails before the
+// #1053 fix and passes after.
+func TestLaunchWorkflowUsesCrossProcessFileLock(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeGraphV2ConvoyFormula(t, formulaDir)
+	cfg := graphV2SlingTestConfig(t, formulaDir)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.CityPath = t.TempDir()
+	convoy, err := deps.Store.Create(beads.Bead{Title: "input", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	opts := molecule.Options{Vars: map[string]string{"convoy_id": convoy.ID}}
+
+	if _, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps); err != nil {
+		t.Fatalf("InstantiateSlingFormula: %v", err)
+	}
+
+	lockDir := filepath.Join(citylayout.RuntimeDataDir(deps.CityPath), "sling-source-locks")
+	entries, err := os.ReadDir(lockDir)
+	if err != nil {
+		t.Fatalf("reading sling-source-locks dir %s (a cross-process file lock must have been taken on the RootKey): %v", lockDir, err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("sling-source-locks dir %s is empty; the launch did not take a cross-process file lock on the RootKey", lockDir)
+	}
+}
+
+// TestLaunchWorkflowLegitimateDistinctLaunchesAllowed proves the guard never
+// blocks a legitimate launch (#720): distinct RootKeys (different convoy input)
+// coexist, and a relaunch after the prior root is closed succeeds with a fresh
+// root (invariants I6 + I7).
+func TestLaunchWorkflowLegitimateDistinctLaunchesAllowed(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeGraphV2ConvoyFormula(t, formulaDir)
+	cfg := graphV2SlingTestConfig(t, formulaDir)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.CityPath = t.TempDir()
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	convoyA, err := deps.Store.Create(beads.Bead{Title: "input-a", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	convoyB, err := deps.Store.Create(beads.Bead{Title: "input-b", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	optsA := molecule.Options{Vars: map[string]string{"convoy_id": convoyA.ID}}
+	optsB := molecule.Options{Vars: map[string]string{"convoy_id": convoyB.ID}}
+	rootA, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, optsA, "", "default", "", a, deps)
+	if err != nil {
+		t.Fatalf("launch A: %v", err)
+	}
+	rootB, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, optsB, "", "default", "", a, deps)
+	if err != nil {
+		t.Fatalf("launch B: %v", err)
+	}
+	if rootA.RootID == rootB.RootID {
+		t.Fatalf("distinct convoys shared a root %q, want two roots (I7)", rootA.RootID)
+	}
+	if live := liveGraphV2Roots(t, deps.Store); len(live) != 2 {
+		t.Fatalf("live graph roots = %d, want two distinct identities (I7)", len(live))
+	}
+
+	// Relaunch after the prior root is closed: never blocked (I6).
+	if _, err := sourceworkflow.CloseWorkflowSubtree(deps.Store, rootA.RootID); err != nil {
+		t.Fatalf("close root A: %v", err)
+	}
+	relaunch, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, optsA, "", "default", "", a, deps)
+	if err != nil {
+		t.Fatalf("relaunch after close: %v", err)
+	}
+	if relaunch.RootID == rootA.RootID {
+		t.Fatalf("relaunch reused closed root %q, want a fresh root (I6)", rootA.RootID)
+	}
+}
+
+// TestInstantiateCompiledSlingFormulaAcceptsPrecompiledRecipe pins the
+// compile-once primitive: a recipe compiled by the caller is instantiated
+// without a second disk compile, materializing the same graph root.
+func TestInstantiateCompiledSlingFormulaAcceptsPrecompiledRecipe(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeGraphV2ConvoyFormula(t, formulaDir)
+	cfg := graphV2SlingTestConfig(t, formulaDir)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.CityPath = t.TempDir()
+	convoy, err := deps.Store.Create(beads.Bead{Title: "input", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	vars := map[string]string{"convoy_id": convoy.ID}
+	opts := molecule.Options{Vars: vars}
+
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(context.Background(), "graph-work", []string{formulaDir}, vars)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	res, err := InstantiateCompiledSlingFormula(context.Background(), recipe, "graph-work", opts, "", "default", "", a, deps)
+	if err != nil {
+		t.Fatalf("InstantiateCompiledSlingFormula: %v", err)
+	}
+	if res.RootID == "" {
+		t.Fatalf("no root materialized")
+	}
+	if live := liveGraphV2Roots(t, deps.Store); len(live) != 1 {
+		t.Fatalf("live graph roots = %d, want one", len(live))
+	}
+}


### PR DESCRIPTION
Collapses all workflow-launch shapes onto a single launchWorkflow chokepoint with one duplicate-molecule dedupe guard and compile-once formula handling. Closes the #1053 duplicate-molecule window across all launch shapes, plus #720. Sibling of S13.

Gates green; Fable-reviewed behavior-preserved. Spec at /data/projects/gascity/.claude/worktrees/simplification/engdocs/simplification/specs/S14-launch-chokepoint-spec.md.

NOTE: spike/staged for review, not auto-merge.