### PR TITLE
simplify(S36): route drift-relaunch through buildPreparedStart (one launch-config derivation)

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2626,8 +2626,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								// Fold the returned batch unconditionally (Step 6d write-returns-Info).
 								// On success it is the rebaseline patch; on the prepare/skew/relaunch
 								// failure paths it is the buildPreparedStart prepare residue
-								// (instance_token mint, stale-resume-key clear) so the snapshot never
-								// diverges from the raw bead. ApplyPatch(nil) is a no-op.
+								// — only started_config_hash and instance_token are folded, while
+								// session_key and continuation_reset_pending stay intentionally
+								// unthreaded (no same-tick Info reader) and self-heal on the next
+								// store reload. ApplyPatch(nil) is a no-op.
 								infoByID[session.ID] = infoByID[session.ID].ApplyPatch(launchBatch)
 								if relaunched {
 									continue
@@ -2701,8 +2703,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								// Fold the returned batch unconditionally (Step 6d write-returns-Info).
 								// On success it is the rebaseline patch; on the prepare/skew/relaunch
 								// failure paths it is the buildPreparedStart prepare residue
-								// (instance_token mint, stale-resume-key clear) so the snapshot never
-								// diverges from the raw bead. ApplyPatch(nil) is a no-op.
+								// — only started_config_hash and instance_token are folded, while
+								// session_key and continuation_reset_pending stay intentionally
+								// unthreaded (no same-tick Info reader) and self-heal on the next
+								// store reload. ApplyPatch(nil) is a no-op.
 								infoByID[session.ID] = infoByID[session.ID].ApplyPatch(launchBatch)
 								if relaunched {
 									continue
@@ -4832,7 +4836,9 @@ func silentRebaselineSessionHashes(session *beads.Bead, sessFront *sessionpkg.St
 //
 // Returns (true, launchBatch) iff the agent was relaunched and hashes were
 // rebaselined (the caller folds launchBatch onto the typed snapshot and
-// `continue`s). Returns (false, fold) when the provider cannot relaunch, the
+// `continue`s). Returns (false, fold) when the provider cannot relaunch,
+// buildPreparedStart minted a speculative resume key (a warm relaunch would
+// --resume a key naming a conversation that was never created), the
 // prepare/precondition/relaunch step failed, or the rebaseline failed — the
 // caller folds the prepare residue (buildPreparedStart mutates the raw bead:
 // instance_token mint, stale-resume-key clear) and falls through to the full
@@ -4868,6 +4874,16 @@ func relaunchAgentForLaunchDrift(
 		// no buildPreparedStart residue to fold.
 		return false, nil
 	}
+	// Capture whether the bead already tracked a resumable conversation BEFORE
+	// buildPreparedStart runs. An empty session_key means any key the preparation
+	// mints below (line ~911, for a SessionIDFlag provider) is speculative: it
+	// names a conversation the relaunch has not created yet. Such a speculative key
+	// must never be executed as `--resume` and must never survive into the
+	// full-restart fallback, or a future start would --resume a phantom
+	// conversation. Both halves are enforced below: the minted-speculative-key guard
+	// before Relaunch prevents execution, and relaunchAbortResidueFold clears the key
+	// on every abort path.
+	hadResumeKeyBeforePrepare := strings.TrimSpace(session.Metadata["session_key"]) != ""
 	// Derive the executable config exactly as the fresh-start / pending-create
 	// recovery paths do. cityPath resolves session.Metadata["work_dir"] against
 	// the city; the nil work-dir resolver is correct because both call sites sit
@@ -4877,7 +4893,7 @@ func relaunchAgentForLaunchDrift(
 	prepared, err := buildPreparedStartWithWorkDirResolver(startCandidate{session: session, tp: tp}, cityPath, cfg, store, nil)
 	if err != nil {
 		fmt.Fprintf(stderr, "session reconciler: preparing relaunch config for %s: %v; falling back to full restart\n", name, err) //nolint:errcheck
-		return false, pendingCreateResidueFold(session)
+		return false, relaunchAbortResidueFold(session, sessFront, hadResumeKeyBeforePrepare)
 	}
 	// Anti-skew gate: the launch-only-drift verdict was computed from the
 	// hash-form config; relaunch only if it still holds for the prepared config.
@@ -4885,9 +4901,32 @@ func relaunchAgentForLaunchDrift(
 	// between the hash-form and prepared configs — take the full restart rather
 	// than relaunch-then-rebaseline against an unverified baseline.
 	if prepared.coreHash != currentHash || prepared.provisionHash != storedProvisionHash || prepared.launchHash == storedLaunchHash {
-		fmt.Fprintf(stderr, "session reconciler: relaunch precondition skew for %s (core=%v provision=%v launch-unchanged=%v); falling back to full restart\n",
-			name, prepared.coreHash != currentHash, prepared.provisionHash != storedProvisionHash, prepared.launchHash == storedLaunchHash) //nolint:errcheck
-		return false, pendingCreateResidueFold(session)
+		fmt.Fprintf(stderr, "session reconciler: relaunch precondition skew for %s (core=%v provision=%v launch-unchanged=%v); falling back to full restart\n", //nolint:errcheck
+			name, prepared.coreHash != currentHash, prepared.provisionHash != storedProvisionHash, prepared.launchHash == storedLaunchHash)
+		return false, relaunchAbortResidueFold(session, sessFront, hadResumeKeyBeforePrepare)
+	}
+	// A warm-box relaunch resumes a TRACKED conversation. When the bead carried no
+	// session_key before preparation but buildPreparedStart minted one — a
+	// SessionIDFlag provider with no prior key (session_lifecycle_parallel.go:911)
+	// — that key is speculative: started_config_hash is set, so firstStart is false
+	// and resolveSessionCommand built `--resume <minted-key>` for a conversation
+	// that was never created. Executing that relaunch resumes a phantom, and a
+	// provider that reports success would then rebaseline and persist the minted
+	// key, tying every future start to a conversation that does not exist. Fall back
+	// to the full restart, which starts fresh; relaunchAbortResidueFold clears the
+	// speculative key so resetConfiguredNamedSessionForConfigDrift's preserve-resume
+	// gate cannot carry it forward.
+	//
+	// Scope this to an ACTUAL mint (session_key populated only during preparation),
+	// not merely "no prior key": a provider that mints no key (nil resolver, no
+	// SessionIDFlag) built no `--resume`, so its bare warm relaunch carries no
+	// phantom and must still proceed. A merely-stale prior key is also unaffected —
+	// buildPreparedStart cleared it and zeroed started_config_hash before
+	// re-minting, so firstStart is true, the command is a fresh `--session-id`, and
+	// hadResumeKeyBeforePrepare is true, so this guard does not fire.
+	if mintedSpeculativeResumeKey := !hadResumeKeyBeforePrepare && strings.TrimSpace(session.Metadata["session_key"]) != ""; mintedSpeculativeResumeKey {
+		fmt.Fprintf(stderr, "session reconciler: launch-drift relaunch for %s minted a speculative resume key (no prior conversation); falling back to full restart\n", name) //nolint:errcheck
+		return false, relaunchAbortResidueFold(session, sessFront, hadResumeKeyBeforePrepare)
 	}
 	if err := r.Relaunch(ctx, name, prepared.cfg); err != nil {
 		// ErrRelaunchUnsupported (a wrapper whose backend cannot relaunch) or a
@@ -4896,7 +4935,7 @@ func relaunchAgentForLaunchDrift(
 		if !errors.Is(err, runtime.ErrRelaunchUnsupported) {
 			fmt.Fprintf(stderr, "session reconciler: relaunch %s: %v; falling back to full restart\n", name, err) //nolint:errcheck
 		}
-		return false, pendingCreateResidueFold(session)
+		return false, relaunchAbortResidueFold(session, sessFront, hadResumeKeyBeforePrepare)
 	}
 	fmt.Fprintf(stdout, "Launch-only config change for '%s', relaunched agent in warm box\n", tp.DisplayName()) //nolint:errcheck
 	// Rebaseline the Core baseline (started_config_hash) and the partition
@@ -4918,10 +4957,13 @@ func relaunchAgentForLaunchDrift(
 		// prepare residue so the snapshot still matches the raw bead.
 		fmt.Fprintf(stderr, "session reconciler: rebaselining launch-drift hashes for %s: %v\n", name, rebaseErr) //nolint:errcheck
 		launchBatch = pendingCreateResidueFold(session)
-	} else if tok := session.Metadata["instance_token"]; tok != "" {
+	} else if tok := session.Metadata["instance_token"]; tok != "" && launchBatch != nil {
 		// buildPreparedStart may mint instance_token onto the raw bead + store
 		// (SetMarker) — a residue outside the rebaseline patch. Carry it in the
-		// fold so the snapshot reflects it (mirrors pendingCreateResidueFold).
+		// fold so the snapshot reflects it (mirrors pendingCreateResidueFold). Guard
+		// the write on launchBatch != nil: rebaselineLaunchDriftHashesWithBatch
+		// documents a (nil, nil) return when the session/front-door is nil, and a
+		// write to a nil map panics.
 		launchBatch["instance_token"] = tok
 	}
 	if trace != nil {
@@ -4934,6 +4976,32 @@ func relaunchAgentForLaunchDrift(
 		Message: "agent relaunched (launch-only config change)",
 	})
 	return true, launchBatch
+}
+
+// relaunchAbortResidueFold is the buildPreparedStart residue fold for the paths
+// that abort the launch-only-drift relaunch (prepare error, anti-skew skew, or
+// relaunch failure) and fall back to the full restart. It exists to keep a
+// speculatively-minted resume key from surviving the fallback.
+//
+// When the bead carried no session_key before preparation,
+// buildPreparedStartWithWorkDirResolver minted one (persisting it to the raw
+// bead + store via SetMarker) so it could build the relaunch command. That key
+// names a conversation the aborted relaunch never created. Left in place,
+// resetConfiguredNamedSessionForConfigDrift would see a non-empty session_key
+// plus the stale started_config_hash and PRESERVE both, so the next start would
+// --resume a phantom conversation instead of doing the fresh restart the
+// fallback is meant to provide. Clear the speculative key exactly as
+// buildPreparedStart's own stale-resume guard does (session_key +
+// started_config_hash + continuation_reset_pending, raw bead + store), which the
+// pendingCreateResidueFold below then folds onto the caller's snapshot.
+//
+// When a real resume key predated preparation, leave it untouched so the
+// fallback resumes the prior conversation (the intended preserve-resume path).
+func relaunchAbortResidueFold(session *beads.Bead, sessFront *sessionpkg.Store, hadResumeKeyBeforePrepare bool) map[string]string {
+	if session != nil && !hadResumeKeyBeforePrepare && strings.TrimSpace(session.Metadata["session_key"]) != "" {
+		clearStaleResumeKeyMetadata(session, sessFront)
+	}
+	return pendingCreateResidueFold(session)
 }
 
 // rebaselineLaunchDriftHashesWithBatch moves a session's Core drift baseline to

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2620,12 +2620,16 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								continue
 							}
 							if launchOnlyDrift {
-								relaunched, launchBatch := relaunchAgentForLaunchDrift(ctx, sp, sessFront, session, name, agentCfg, tp, storedHash, currentHash, driftedFields, rec, trace, stdout, stderr)
+								relaunched, launchBatch := relaunchAgentForLaunchDrift(ctx, sp, sessFront, session, name,
+									tp, cityPath, cfg, store, storedHash, currentHash, storedProvision, storedLaunch,
+									driftedFields, rec, trace, stdout, stderr)
+								// Fold the returned batch unconditionally (Step 6d write-returns-Info).
+								// On success it is the rebaseline patch; on the prepare/skew/relaunch
+								// failure paths it is the buildPreparedStart prepare residue
+								// (instance_token mint, stale-resume-key clear) so the snapshot never
+								// diverges from the raw bead. ApplyPatch(nil) is a no-op.
+								infoByID[session.ID] = infoByID[session.ID].ApplyPatch(launchBatch)
 								if relaunched {
-									// Fold the rebaseline patch onto the snapshot (Step 6d write-returns-Info).
-									// launchBatch is nil only when rebaselineLaunchDriftHashesWithBatch failed;
-									// ApplyPatch(nil) is a no-op. Pre-pass-masked (STEP6-PREPASS-AUDIT group 9).
-									infoByID[session.ID] = infoByID[session.ID].ApplyPatch(launchBatch)
 									continue
 								}
 							}
@@ -2691,12 +2695,16 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								continue
 							}
 							if launchOnlyDrift {
-								relaunched, launchBatch := relaunchAgentForLaunchDrift(ctx, sp, sessFront, session, name, agentCfg, tp, storedHash, currentHash, driftedFields, rec, trace, stdout, stderr)
+								relaunched, launchBatch := relaunchAgentForLaunchDrift(ctx, sp, sessFront, session, name,
+									tp, cityPath, cfg, store, storedHash, currentHash, storedProvision, storedLaunch,
+									driftedFields, rec, trace, stdout, stderr)
+								// Fold the returned batch unconditionally (Step 6d write-returns-Info).
+								// On success it is the rebaseline patch; on the prepare/skew/relaunch
+								// failure paths it is the buildPreparedStart prepare residue
+								// (instance_token mint, stale-resume-key clear) so the snapshot never
+								// diverges from the raw bead. ApplyPatch(nil) is a no-op.
+								infoByID[session.ID] = infoByID[session.ID].ApplyPatch(launchBatch)
 								if relaunched {
-									// Fold the rebaseline patch onto the snapshot (Step 6d write-returns-Info).
-									// launchBatch is nil only when rebaselineLaunchDriftHashesWithBatch failed;
-									// ApplyPatch(nil) is a no-op. Pre-pass-masked (STEP6-PREPASS-AUDIT group 9).
-									infoByID[session.ID] = infoByID[session.ID].ApplyPatch(launchBatch)
 									continue
 								}
 							}
@@ -4813,12 +4821,23 @@ func silentRebaselineSessionHashes(session *beads.Bead, sessFront *sessionpkg.St
 // restart. It mirrors the live-drift→RunLive clause: act, and on success
 // rebaseline the Core/provision/launch baselines so the next tick sees no drift.
 //
+// The config handed to Relaunch is derived by buildPreparedStart — the SAME
+// derivation the fresh-start and pending-create-recovery paths use — so the
+// relaunched agent resumes its tracked conversation (resolveSessionCommand adds
+// --resume/--session-id), carries the runtime env (GC_SESSION_ID, instance
+// token, GC_PROVIDER, trigger-bead env), and does NOT re-send the full startup
+// prompt (the !firstStart prompt-strip + restart-nudge block). The drift
+// COMPARISON still uses the hash-form sessionCoreConfigForHash; only the
+// EXECUTED config and the rebaselined baselines come from buildPreparedStart.
+//
 // Returns (true, launchBatch) iff the agent was relaunched and hashes were
 // rebaselined (the caller folds launchBatch onto the typed snapshot and
-// `continue`s). Returns (false, nil) when the provider cannot relaunch or the
-// relaunch failed — the caller falls through to the existing full restart.
-// The batch is nil on the true return only when rebaselineLaunchDriftHashesWithBatch
-// failed (agent was relaunched; stale baseline self-corrects on a later tick).
+// `continue`s). Returns (false, fold) when the provider cannot relaunch, the
+// prepare/precondition/relaunch step failed, or the rebaseline failed — the
+// caller folds the prepare residue (buildPreparedStart mutates the raw bead:
+// instance_token mint, stale-resume-key clear) and falls through to the full
+// restart. The fold is nil only when no buildPreparedStart side effect ran (the
+// RelaunchProvider gate rejected the runtime before any preparation).
 //
 // The deferral guards (attached / named-active / pending-interaction / open
 // assigned work) are honored by the CALLER: this is invoked only after those
@@ -4831,9 +4850,12 @@ func relaunchAgentForLaunchDrift(
 	sessFront *sessionpkg.Store,
 	session *beads.Bead,
 	name string,
-	agentCfg runtime.Config,
 	tp TemplateParams,
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
 	storedHash, currentHash string,
+	storedProvisionHash, storedLaunchHash string,
 	driftedFields []string,
 	rec events.Recorder,
 	trace *sessionReconcilerTraceCycle,
@@ -4842,32 +4864,65 @@ func relaunchAgentForLaunchDrift(
 	r, ok := sp.(runtime.RelaunchProvider)
 	if !ok {
 		// Conjoined runtimes (subprocess/acp/t3bridge) do not implement
-		// RelaunchProvider; fall through to the full restart.
+		// RelaunchProvider; fall through to the full restart. No side effects yet —
+		// no buildPreparedStart residue to fold.
 		return false, nil
 	}
-	if err := r.Relaunch(ctx, name, agentCfg); err != nil {
+	// Derive the executable config exactly as the fresh-start / pending-create
+	// recovery paths do. cityPath resolves session.Metadata["work_dir"] against
+	// the city; the nil work-dir resolver is correct because both call sites sit
+	// behind the no-open-assigned-work / not-active deferral guards. Deliberately
+	// buildPreparedStart*, NOT prepareStartCandidateForCity — the session is
+	// alive, not waking, so no preWakeCommit / named-template refresh.
+	prepared, err := buildPreparedStartWithWorkDirResolver(startCandidate{session: session, tp: tp}, cityPath, cfg, store, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "session reconciler: preparing relaunch config for %s: %v; falling back to full restart\n", name, err) //nolint:errcheck
+		return false, pendingCreateResidueFold(session)
+	}
+	// Anti-skew gate: the launch-only-drift verdict was computed from the
+	// hash-form config; relaunch only if it still holds for the prepared config.
+	// A mismatch means a concurrent bead mutation or a derivation divergence
+	// between the hash-form and prepared configs — take the full restart rather
+	// than relaunch-then-rebaseline against an unverified baseline.
+	if prepared.coreHash != currentHash || prepared.provisionHash != storedProvisionHash || prepared.launchHash == storedLaunchHash {
+		fmt.Fprintf(stderr, "session reconciler: relaunch precondition skew for %s (core=%v provision=%v launch-unchanged=%v); falling back to full restart\n",
+			name, prepared.coreHash != currentHash, prepared.provisionHash != storedProvisionHash, prepared.launchHash == storedLaunchHash) //nolint:errcheck
+		return false, pendingCreateResidueFold(session)
+	}
+	if err := r.Relaunch(ctx, name, prepared.cfg); err != nil {
 		// ErrRelaunchUnsupported (a wrapper whose backend cannot relaunch) or a
 		// genuine failure (e.g. the warm box vanished → ErrSessionNotFound). Fall
 		// back to the full restart so the launch change is still applied.
 		if !errors.Is(err, runtime.ErrRelaunchUnsupported) {
 			fmt.Fprintf(stderr, "session reconciler: relaunch %s: %v; falling back to full restart\n", name, err) //nolint:errcheck
 		}
-		return false, nil
+		return false, pendingCreateResidueFold(session)
 	}
 	fmt.Fprintf(stdout, "Launch-only config change for '%s', relaunched agent in warm box\n", tp.DisplayName()) //nolint:errcheck
 	// Rebaseline the Core baseline (started_config_hash) and the partition
-	// sub-hashes so the next tick sees no Core drift. started_live_hash is
+	// sub-hashes so the next tick sees no Core drift. The hashes come from
+	// buildPreparedStart's PRE-rewrite fingerprints (prepared.coreHash etc.), NOT
+	// the executed prepared.cfg (which carries the --resume rewrite + runtime env,
+	// neither a fingerprint input), so the baseline matches what the next tick's
+	// sessionCoreConfigForHash comparison reproduces. started_live_hash is
 	// DELIBERATELY left untouched: a relaunch MAY re-run SessionLive via the
 	// shared orchestration tail (tmux and ssh do; k8s does not), so the live
 	// half is not reliably re-applied here. Leaving the live hash alone keeps
 	// this provider-independent — any concurrent live drift is re-applied
 	// idempotently by the live-drift clause on the next tick (a redundant
 	// SessionLive re-apply is harmless; a missed one self-heals).
-	launchBatch, rebaseErr := rebaselineLaunchDriftHashesWithBatch(session, sessFront, agentCfg)
+	launchBatch, rebaseErr := rebaselineLaunchDriftHashesWithBatch(session, sessFront, prepared.coreHash, prepared.provisionHash, prepared.launchHash, prepared.coreBreakdown)
 	if rebaseErr != nil {
 		// The agent is already relaunched; do not trigger a second restart. The
-		// stale Core baseline self-corrects on a later rebaseline tick.
+		// stale Core baseline self-corrects on a later rebaseline tick. Fold the
+		// prepare residue so the snapshot still matches the raw bead.
 		fmt.Fprintf(stderr, "session reconciler: rebaselining launch-drift hashes for %s: %v\n", name, rebaseErr) //nolint:errcheck
+		launchBatch = pendingCreateResidueFold(session)
+	} else if tok := session.Metadata["instance_token"]; tok != "" {
+		// buildPreparedStart may mint instance_token onto the raw bead + store
+		// (SetMarker) — a residue outside the rebaseline patch. Carry it in the
+		// fold so the snapshot reflects it (mirrors pendingCreateResidueFold).
+		launchBatch["instance_token"] = tok
 	}
 	if trace != nil {
 		trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeRelaunch, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, nil))
@@ -4882,31 +4937,38 @@ func relaunchAgentForLaunchDrift(
 }
 
 // rebaselineLaunchDriftHashesWithBatch moves a session's Core drift baseline to
-// agentCfg after a successful warm-box relaunch — started_config_hash + the
-// provision/launch sub-hashes + core_hash_breakdown — WITHOUT touching
-// started_live_hash/live_hash. The relaunch re-applied the launch half (the
-// agent now runs agentCfg); the provision half was unchanged by definition. The
-// live hash is left untouched because relaunch does not reliably re-apply the
-// live half (tmux/ssh re-run SessionLive via the shared orchestration tail; k8s
-// does not), so a concurrent SessionLive change is re-applied idempotently by
-// the live-drift clause on the next tick. Contrast sessionHashRebaselineMetadata,
-// which rebaselines every field (used when the config did not actually change).
+// the relaunched config after a successful warm-box relaunch —
+// started_config_hash + the provision/launch sub-hashes + core_hash_breakdown —
+// WITHOUT touching started_live_hash/live_hash. The relaunch re-applied the
+// launch half (the agent now runs the prepared config); the provision half was
+// unchanged by definition. The live hash is left untouched because relaunch does
+// not reliably re-apply the live half (tmux/ssh re-run SessionLive via the
+// shared orchestration tail; k8s does not), so a concurrent SessionLive change
+// is re-applied idempotently by the live-drift clause on the next tick. Contrast
+// sessionHashRebaselineMetadata, which rebaselines every field (used when the
+// config did not actually change).
+//
+// The hashes are passed in explicitly (from buildPreparedStart's pre-rewrite
+// fingerprints) rather than recomputed here: the executed config carries the
+// resolveSessionCommand --resume/--session-id rewrite and runtime env, which are
+// NOT fingerprint inputs, so the baseline must be the durable-config hashes the
+// next tick's sessionCoreConfigForHash comparison will reproduce.
 //
 // Returns the mirrored patch on success so the caller can fold it onto the typed
 // snapshot via ApplyPatch. Returns (nil, nil) when there is nothing to do (nil
 // session/front-door), (nil, err) on any failure.
-func rebaselineLaunchDriftHashesWithBatch(session *beads.Bead, sessFront *sessionpkg.Store, agentCfg runtime.Config) (map[string]string, error) {
+func rebaselineLaunchDriftHashesWithBatch(session *beads.Bead, sessFront *sessionpkg.Store, coreHash, provisionHash, launchHash string, breakdown runtime.BreakdownV1) (map[string]string, error) {
 	if session == nil || sessFront == nil {
 		return nil, nil
 	}
-	breakdownJSON, err := json.Marshal(runtime.CoreFingerprintBreakdown(agentCfg))
+	breakdownJSON, err := json.Marshal(breakdown)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling core_hash_breakdown: %w", err)
 	}
 	patch := map[string]string{
-		"started_config_hash":    runtime.CoreFingerprint(agentCfg),
-		"started_provision_hash": runtime.ProvisionFingerprint(agentCfg),
-		"started_launch_hash":    runtime.LaunchFingerprint(agentCfg),
+		"started_config_hash":    coreHash,
+		"started_provision_hash": provisionHash,
+		"started_launch_hash":    launchHash,
 		"core_hash_breakdown":    string(breakdownJSON),
 	}
 	if err := sessFront.ApplyPatch(session.ID, patch); err != nil {

--- a/cmd/gc/session_reconciler_relaunch_preparedstart_test.go
+++ b/cmd/gc/session_reconciler_relaunch_preparedstart_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -137,4 +138,158 @@ func TestReconcileSessionBeads_LaunchDriftRebaselineNoReDrift(t *testing.T) {
 	if got := b2.Metadata["started_config_hash"]; got != wantCore {
 		t.Errorf("tick 2 started_config_hash = %q, want stable %q", got, wantCore)
 	}
+}
+
+// TestRelaunchAgentForLaunchDrift_AbortClearsSpeculativeResumeKey is the #4038
+// correctness guard for the launch-drift relaunch fallback. When a launch-only
+// drift routes through buildPreparedStart on a bead that has a stored baseline
+// (started_config_hash) but no session_key, buildPreparedStart mints a fresh
+// session_key so it can build the relaunch command. Because started_config_hash
+// is set, firstStart is false and resolveSessionCommand builds
+// `--resume <minted-key>` for a conversation the relaunch has never created.
+//
+// Two invariants protect against that phantom key:
+//   - It must never be EXECUTED: the minted-speculative-key guard refuses the
+//     relaunch before Relaunch is called (even when the provider would report
+//     success), so a rebaseline can never persist the minted key.
+//   - It must never SURVIVE an abort: every fallback path (no-prior-key,
+//     anti-skew, prepare error, relaunch failure) clears the speculative key so
+//     resetConfiguredNamedSessionForConfigDrift's preserve-resume gate cannot see
+//     a non-empty session_key plus the stale baseline and --resume a conversation
+//     that never existed. A REAL prior key is left intact for the fallback to
+//     resume.
+//
+// This exercises relaunchAgentForLaunchDrift directly rather than a full
+// reconcile because the reconcile's start-pending fall-through restarts the
+// session in the same tick, which re-stamps the metadata and masks the transient
+// reset state the bug lives in. The fix is observable only at the fallback
+// boundary, before that restart.
+func TestRelaunchAgentForLaunchDrift_AbortClearsSpeculativeResumeKey(t *testing.T) {
+	// newDriftEnv builds a launch-only-drift ("Command" changed, provision half
+	// unchanged) worker session on a resume-capable provider. priorSessionKey is
+	// the bead's session_key before preparation ("" to model the phantom scenario
+	// where buildPreparedStart must mint one). When injectRelaunchErr is set the
+	// provider fails Relaunch, driving the relaunch-failure abort/fallback path.
+	// Returns the drift hashes the caller passes through.
+	newDriftEnv := func(t *testing.T, priorSessionKey string, injectRelaunchErr bool) (*reconcilerTestEnv, TemplateParams, beads.Bead, string, string, string, string) {
+		t.Helper()
+		env := newReconcilerTestEnv()
+		env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+		tp := TemplateParams{
+			Command:          "claude",
+			SessionName:      "worker",
+			TemplateName:     "worker",
+			InstanceName:     "worker",
+			Alias:            "worker",
+			Prompt:           "do the work",
+			ResolvedProvider: forkClaude(), // SessionIDFlag set → mints a key when none exists
+		}
+		env.desiredState["worker"] = tp
+		if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "claude"}); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		session := env.createSessionBead("worker", "worker")
+		env.markSessionActive(&session)
+		agentCfg := sessionCoreConfigForHash(tp, session)
+		oldCfg := agentCfg
+		oldCfg.Command = "stale-" + agentCfg.Command
+		md := map[string]string{
+			"started_config_hash":    runtime.CoreFingerprint(oldCfg),
+			"started_provision_hash": runtime.ProvisionFingerprint(oldCfg),
+			"started_launch_hash":    runtime.LaunchFingerprint(oldCfg),
+			"started_live_hash":      runtime.LiveFingerprint(agentCfg),
+		}
+		if priorSessionKey != "" {
+			md["session_key"] = priorSessionKey
+		}
+		env.setSessionMetadata(&session, md)
+		if injectRelaunchErr {
+			env.sp.RelaunchErrors["worker"] = fmt.Errorf("warm box vanished")
+		}
+		return env, tp, session,
+			runtime.CoreFingerprint(oldCfg), runtime.CoreFingerprint(agentCfg),
+			runtime.ProvisionFingerprint(oldCfg), runtime.LaunchFingerprint(oldCfg)
+	}
+
+	callRelaunch := func(env *reconcilerTestEnv, tp TemplateParams, session *beads.Bead, storedHash, currentHash, storedProvision, storedLaunch string) bool {
+		relaunched, _ := relaunchAgentForLaunchDrift(
+			context.Background(), env.sp, sessionFrontDoor(env.store), session, "worker",
+			tp, "", env.cfg, env.store, storedHash, currentHash, storedProvision, storedLaunch,
+			[]string{"Command"}, env.rec, nil, &env.stdout, &env.stderr,
+		)
+		return relaunched
+	}
+
+	// assertSpeculativeKeyCleared verifies the fallback wiped the minted key and
+	// the stale baseline on BOTH the raw bead and the store, so the downstream
+	// reset cannot preserve a phantom resume.
+	assertSpeculativeKeyCleared := func(t *testing.T, env *reconcilerTestEnv, session *beads.Bead) {
+		t.Helper()
+		if got := strings.TrimSpace(session.Metadata["session_key"]); got != "" {
+			t.Errorf("raw bead session_key = %q, want cleared (no phantom resume)", got)
+		}
+		if got := strings.TrimSpace(session.Metadata["started_config_hash"]); got != "" {
+			t.Errorf("raw bead started_config_hash = %q, want cleared (fresh restart)", got)
+		}
+		b, _ := env.store.Get(session.ID)
+		if got := strings.TrimSpace(b.Metadata["session_key"]); got != "" {
+			t.Errorf("stored session_key = %q, want cleared (no phantom resume)", got)
+		}
+		if got := strings.TrimSpace(b.Metadata["started_config_hash"]); got != "" {
+			t.Errorf("stored started_config_hash = %q, want cleared (fresh restart)", got)
+		}
+	}
+
+	// Major #4038 guard: a no-prior-key launch-drift relaunch must NOT execute
+	// `--resume <minted-key>` even when the provider would succeed. A successful
+	// relaunch would rebaseline and persist the speculative key, tying future
+	// starts to a conversation that was never created. The relaunch is refused
+	// before Relaunch is called and the speculative key is cleared for the full
+	// restart. No relaunch error is injected: the provider WOULD succeed, so this
+	// proves the guard, not a failing relaunch, prevents the phantom.
+	t.Run("no prior key is refused before relaunch on the success path", func(t *testing.T) {
+		env, tp, session, storedHash, currentHash, storedProvision, storedLaunch := newDriftEnv(t, "", false)
+		if got := strings.TrimSpace(session.Metadata["session_key"]); got != "" {
+			t.Fatalf("precondition: session_key = %q, want empty", got)
+		}
+		if relaunched := callRelaunch(env, tp, &session, storedHash, currentHash, storedProvision, storedLaunch); relaunched {
+			t.Fatalf("relaunched = true, want false (no prior key → full restart); stderr=%s", env.stderr.String())
+		}
+		if got := env.sp.CountCalls("Relaunch", "worker"); got != 0 {
+			t.Errorf("Relaunch calls = %d, want 0 (must not --resume a speculative key); stderr=%s", got, env.stderr.String())
+		}
+		assertSpeculativeKeyCleared(t, env, &session)
+	})
+
+	// Non-gating coverage for the anti-skew fallback, which shares the
+	// speculative-key cleanup fold with the other aborts but had no direct test.
+	// Trip the gate by leaving storedLaunch equal to the prepared launch hash
+	// (launch-unchanged) so it falls back to a full restart before Relaunch, and
+	// assert it clears the speculative key.
+	t.Run("anti-skew abort clears speculative key", func(t *testing.T) {
+		env, tp, session, storedHash, currentHash, storedProvision, _ := newDriftEnv(t, "", false)
+		// prepared.launchHash == storedLaunchHash → launch-unchanged skew → abort.
+		preparedLaunch := runtime.LaunchFingerprint(sessionCoreConfigForHash(tp, session))
+		if relaunched := callRelaunch(env, tp, &session, storedHash, currentHash, storedProvision, preparedLaunch); relaunched {
+			t.Fatalf("relaunched = true, want false (anti-skew → full restart); stderr=%s", env.stderr.String())
+		}
+		if got := env.sp.CountCalls("Relaunch", "worker"); got != 0 {
+			t.Errorf("Relaunch calls = %d, want 0 (anti-skew aborts before Relaunch); stderr=%s", got, env.stderr.String())
+		}
+		assertSpeculativeKeyCleared(t, env, &session)
+	})
+
+	// A real resume key that predated preparation names an actual prior
+	// conversation, so a relaunch-failure abort must leave it intact for the
+	// fallback to resume (hadResumeKeyBeforePrepare is true → no clear).
+	t.Run("real prior resume key is preserved when relaunch fails", func(t *testing.T) {
+		const priorKey = "warm-conversation"
+		env, tp, session, storedHash, currentHash, storedProvision, storedLaunch := newDriftEnv(t, priorKey, true)
+		if relaunched := callRelaunch(env, tp, &session, storedHash, currentHash, storedProvision, storedLaunch); relaunched {
+			t.Fatalf("relaunched = true, want false; stderr=%s", env.stderr.String())
+		}
+		if got := strings.TrimSpace(session.Metadata["session_key"]); got != priorKey {
+			t.Errorf("raw bead session_key = %q, want preserved %q", got, priorKey)
+		}
+	})
 }

--- a/cmd/gc/session_reconciler_relaunch_preparedstart_test.go
+++ b/cmd/gc/session_reconciler_relaunch_preparedstart_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// setupLaunchDriftResumeEnv builds a reconciler env whose alive "worker" session
+// carries a session_key and a resume-capable provider, with a stored baseline
+// that differs from the desired config in the launch half only (Command). This
+// is the launch-only-drift shape that must relaunch the agent in the warm box
+// rather than fully restart it. Returns the env, the desired TemplateParams, and
+// the created session bead.
+func setupLaunchDriftResumeEnv(t *testing.T) (*reconcilerTestEnv, TemplateParams, beads.Bead) {
+	t.Helper()
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	tp := TemplateParams{
+		Command:          "claude",
+		SessionName:      "worker",
+		TemplateName:     "worker",
+		InstanceName:     "worker",
+		Alias:            "worker",
+		Prompt:           "do the work",
+		ResolvedProvider: forkClaude(),
+	}
+	env.desiredState["worker"] = tp
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "claude"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	// Desired (current) config and an old baseline that differs only in the
+	// launch half (Command) → provision hash matches, launch hash differs.
+	agentCfg := sessionCoreConfigForHash(tp, session)
+	oldCfg := agentCfg
+	oldCfg.Command = "stale-" + agentCfg.Command
+	env.setSessionMetadata(&session, map[string]string{
+		"session_key":            "warm-conversation",
+		"started_config_hash":    runtime.CoreFingerprint(oldCfg),
+		"started_provision_hash": runtime.ProvisionFingerprint(oldCfg),
+		"started_launch_hash":    runtime.LaunchFingerprint(oldCfg),
+		"started_live_hash":      runtime.LiveFingerprint(agentCfg),
+	})
+	return env, tp, session
+}
+
+// TestReconcileSessionBeads_LaunchDriftRelaunchResumesTrackedConversation is the
+// #3872 kill-shot: routing the drift-relaunch through buildPreparedStart means
+// the Config handed to Relaunch is the same executable config the fresh-start /
+// pending-create-recovery paths use. It resumes the tracked conversation
+// (Command carries --resume <session_key>) and does not re-send the full startup
+// prompt (PromptSuffix cleared, restart nudge + GC_STARTUP_PROMPT_DELIVERED set).
+// The previous hash-form config handed Relaunch a bare command that started an
+// untracked conversation and re-sent the prompt.
+func TestReconcileSessionBeads_LaunchDriftRelaunchResumesTrackedConversation(t *testing.T) {
+	env, tp, session := setupLaunchDriftResumeEnv(t)
+
+	env.reconcile([]beads.Bead{session})
+
+	if got := env.sp.CountCalls("Relaunch", "worker"); got != 1 {
+		t.Fatalf("Relaunch calls = %d, want 1 (launch-only drift must relaunch); stderr=%s", got, env.stderr.String())
+	}
+	rc := env.sp.LastRelaunchConfig("worker")
+	if rc == nil {
+		t.Fatal("no Relaunch config recorded")
+	}
+	// The relaunch resumes the durable conversation instead of starting an
+	// untracked one — this is exactly what a fresh resume-based wake would do.
+	const wantResume = "--resume warm-conversation"
+	if !strings.Contains(rc.Command, wantResume) {
+		t.Errorf("Relaunch Command = %q, want it to contain %q", rc.Command, wantResume)
+	}
+	// The full startup prompt is NOT re-delivered on relaunch.
+	if rc.PromptSuffix != "" {
+		t.Errorf("Relaunch PromptSuffix = %q, want empty (no double prompt)", rc.PromptSuffix)
+	}
+	if got := rc.Env[startupPromptDeliveredEnv]; got != "1" {
+		t.Errorf("Relaunch Env[%s] = %q, want %q", startupPromptDeliveredEnv, got, "1")
+	}
+	if want := restartPromptNudge(tp.Prompt, tp.Hints.Nudge); rc.Nudge != want {
+		t.Errorf("Relaunch Nudge = %q, want restart nudge %q", rc.Nudge, want)
+	}
+	// The runtime env the durable hash-form config lacked is present.
+	if got := rc.Env["GC_SESSION_ID"]; got == "" {
+		t.Errorf("Relaunch Env[GC_SESSION_ID] empty, want session-context env merged")
+	}
+}
+
+// TestReconcileSessionBeads_LaunchDriftRebaselineNoReDrift proves the rebaseline
+// uses buildPreparedStart's pre-rewrite fingerprints, so the very next tick's
+// drift comparison (which uses the hash-form sessionCoreConfigForHash) sees no
+// Core drift and does NOT relaunch again — no drift loop. Guards against the
+// class of bug where the executed config (carrying the --resume rewrite / env)
+// leaks into the persisted baseline and never matches the next comparison.
+func TestReconcileSessionBeads_LaunchDriftRebaselineNoReDrift(t *testing.T) {
+	env, tp, session := setupLaunchDriftResumeEnv(t)
+	preLive := session.Metadata["started_live_hash"]
+
+	// Tick 1: launch-only drift → relaunch + rebaseline.
+	env.reconcile([]beads.Bead{session})
+	if got := env.sp.CountCalls("Relaunch", "worker"); got != 1 {
+		t.Fatalf("tick 1 Relaunch calls = %d, want 1; stderr=%s", got, env.stderr.String())
+	}
+	b, _ := env.store.Get(session.ID)
+
+	// The rebaselined started_config_hash equals what the next tick's drift
+	// comparison recomputes for the unchanged config (invariant 1).
+	wantCore := runtime.CoreFingerprint(sessionCoreConfigForHash(tp, b))
+	if got := b.Metadata["started_config_hash"]; got != wantCore {
+		t.Errorf("started_config_hash = %q, want next-tick comparison hash %q", got, wantCore)
+	}
+	wantLaunch := runtime.LaunchFingerprint(sessionCoreConfigForHash(tp, b))
+	if got := b.Metadata["started_launch_hash"]; got != wantLaunch {
+		t.Errorf("started_launch_hash = %q, want %q", got, wantLaunch)
+	}
+	// The relaunch does not re-run SessionLive, so started_live_hash is untouched.
+	if got := b.Metadata["started_live_hash"]; got != preLive {
+		t.Errorf("started_live_hash = %q, want left unchanged %q", got, preLive)
+	}
+
+	// Tick 2: config is unchanged → no second relaunch, no drain, no re-drift.
+	env.reconcile([]beads.Bead{b})
+	if got := env.sp.CountCalls("Relaunch", "worker"); got != 1 {
+		t.Errorf("tick 2 Relaunch calls = %d, want still 1 (no re-drift loop); stderr=%s", got, env.stderr.String())
+	}
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Errorf("tick 2 expected no drain, got reason=%q", ds.reason)
+	}
+	b2, _ := env.store.Get(session.ID)
+	if got := b2.Metadata["started_config_hash"]; got != wantCore {
+		t.Errorf("tick 2 started_config_hash = %q, want stable %q", got, wantCore)
+	}
+}


### PR DESCRIPTION
Routes the #3872 drift-relaunch path through buildPreparedStart so launch config is derived once, fixing the drift-relaunch misconfig and collapsing 2 launch-config derivations into 1.

- Fixes the drift-relaunch misconfiguration from #3872
- Collapses two launch-config derivations to one (buildPreparedStart is now the single source)
- Quality gates green
- Fable-reviewed, behavior-preserved
- Spec: /data/projects/gascity/.claude/worktrees/simplification/engdocs/simplification/specs/S36-drift-relaunch-preparedstart-spec.md

NOTE: spike/staged for review, not auto-merge.