### PR TITLE
simplify(S31): one childStats() scan replacing six duplicate loops

### DIFF
--- a/internal/convergence/childstats.go
+++ b/internal/convergence/childstats.go
@@ -1,0 +1,78 @@
+package convergence
+
+import (
+	"strings"
+	"time"
+)
+
+// ChildStats holds the projections derived from a bead's children, filtered
+// to convergence wisps (children whose idempotency key carries the bead's
+// convergence prefix). It is computed once from a single Children() fetch so
+// the scan sites that used to re-derive these values independently share one
+// filter definition.
+//
+// The per-projection filters intentionally differ, and those differences are
+// load-bearing (they predate this consolidation):
+//
+//   - ClosedCount and CumulativeDur count every closed convergence child,
+//     including wisps whose iteration number does not parse.
+//   - HighestClosed and HighestOpen additionally require a parseable
+//     iteration number, since their whole purpose is to pick the
+//     highest-iteration wisp.
+type ChildStats struct {
+	// ClosedCount is the number of closed convergence wisps.
+	ClosedCount int
+	// CumulativeDur is the summed lifetime of every closed convergence wisp
+	// that has both a non-zero created and closed timestamp.
+	CumulativeDur time.Duration
+
+	// HighestClosed is the closed convergence wisp with the highest parseable
+	// iteration number. HighestClosedFound is false when none qualifies, and
+	// HighestClosedIter is then -1.
+	HighestClosed      BeadInfo
+	HighestClosedIter  int
+	HighestClosedFound bool
+
+	// HighestOpen is the open/in_progress convergence wisp with the highest
+	// parseable iteration number. HighestOpenFound is false when none
+	// qualifies, and HighestOpenIter is then -1.
+	HighestOpen      BeadInfo
+	HighestOpenIter  int
+	HighestOpenFound bool
+}
+
+// childStats derives every convergence child projection from a single
+// pre-fetched child list. It is pure: it performs no store I/O, so callers can
+// fetch Children() once per transition and read the fields they need.
+func childStats(children []BeadInfo, beadID string) ChildStats {
+	prefix := IdempotencyKeyPrefix(beadID)
+	stats := ChildStats{HighestClosedIter: -1, HighestOpenIter: -1}
+
+	for _, child := range children {
+		if !strings.HasPrefix(child.IdempotencyKey, prefix) {
+			continue
+		}
+		iter, iterOK := ParseIterationFromKey(child.IdempotencyKey)
+
+		switch child.Status {
+		case "closed":
+			stats.ClosedCount++
+			if !child.ClosedAt.IsZero() && !child.CreatedAt.IsZero() {
+				stats.CumulativeDur += child.ClosedAt.Sub(child.CreatedAt)
+			}
+			if iterOK && iter > stats.HighestClosedIter {
+				stats.HighestClosed = child
+				stats.HighestClosedIter = iter
+				stats.HighestClosedFound = true
+			}
+		case "open", "in_progress":
+			if iterOK && iter > stats.HighestOpenIter {
+				stats.HighestOpen = child
+				stats.HighestOpenIter = iter
+				stats.HighestOpenFound = true
+			}
+		}
+	}
+
+	return stats
+}

--- a/internal/convergence/childstats_test.go
+++ b/internal/convergence/childstats_test.go
@@ -1,0 +1,108 @@
+package convergence
+
+import (
+	"testing"
+	"time"
+)
+
+func TestChildStats(t *testing.T) {
+	const bead = "root-1"
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// prefixedNonParseable has the convergence prefix but an iteration segment
+	// that does not parse — it must count toward ClosedCount/CumulativeDur but
+	// never win HighestClosed. This is the intentional filter drift the
+	// consolidation preserves.
+	prefixedNonParseable := IdempotencyKeyPrefix(bead) + "abc"
+
+	tests := []struct {
+		name string
+		in   []BeadInfo
+		want ChildStats
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			want: ChildStats{HighestClosedIter: -1, HighestOpenIter: -1},
+		},
+		{
+			name: "unrelated keys ignored",
+			in: []BeadInfo{
+				{ID: "x", Status: "closed", IdempotencyKey: "unrelated-key"},
+				{ID: "y", Status: "open", IdempotencyKey: "converge:other-bead:iter:1"},
+			},
+			want: ChildStats{HighestClosedIter: -1, HighestOpenIter: -1},
+		},
+		{
+			name: "closed count and highest closed",
+			in: []BeadInfo{
+				{ID: "w1", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 1)},
+				{ID: "w3", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 3)},
+				{ID: "w2", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 2)},
+				{ID: "wo", Status: "in_progress", IdempotencyKey: IdempotencyKey(bead, 4)},
+			},
+			want: ChildStats{
+				ClosedCount:        3,
+				HighestClosed:      BeadInfo{ID: "w3", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 3)},
+				HighestClosedIter:  3,
+				HighestClosedFound: true,
+				HighestOpen:        BeadInfo{ID: "wo", Status: "in_progress", IdempotencyKey: IdempotencyKey(bead, 4)},
+				HighestOpenIter:    4,
+				HighestOpenFound:   true,
+			},
+		},
+		{
+			name: "closed without parseable iteration counts but does not win highest",
+			in: []BeadInfo{
+				{ID: "w1", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 1)},
+				{ID: "bad", Status: "closed", IdempotencyKey: prefixedNonParseable},
+			},
+			want: ChildStats{
+				ClosedCount:        2,
+				HighestClosed:      BeadInfo{ID: "w1", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 1)},
+				HighestClosedIter:  1,
+				HighestClosedFound: true,
+				HighestOpenIter:    -1,
+			},
+		},
+		{
+			name: "cumulative duration skips zero timestamps",
+			in: []BeadInfo{
+				{ID: "w1", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 1), CreatedAt: base, ClosedAt: base.Add(2 * time.Second)},
+				{ID: "w2", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 2), CreatedAt: base}, // ClosedAt zero -> skipped
+				{ID: "w3", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 3), ClosedAt: base},  // CreatedAt zero -> skipped
+			},
+			want: ChildStats{
+				ClosedCount:        3,
+				CumulativeDur:      2 * time.Second,
+				HighestClosed:      BeadInfo{ID: "w3", Status: "closed", IdempotencyKey: IdempotencyKey(bead, 3), ClosedAt: base},
+				HighestClosedIter:  3,
+				HighestClosedFound: true,
+				HighestOpenIter:    -1,
+			},
+		},
+		{
+			name: "highest open picks max across open and in_progress",
+			in: []BeadInfo{
+				{ID: "o1", Status: "open", IdempotencyKey: IdempotencyKey(bead, 5)},
+				{ID: "o2", Status: "in_progress", IdempotencyKey: IdempotencyKey(bead, 7)},
+				{ID: "o3", Status: "open", IdempotencyKey: IdempotencyKey(bead, 6)},
+			},
+			want: ChildStats{
+				HighestClosedIter: -1,
+				HighestOpen:       BeadInfo{ID: "o2", Status: "in_progress", IdempotencyKey: IdempotencyKey(bead, 7)},
+				HighestOpenIter:   7,
+				HighestOpenFound:  true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := childStats(tt.in, bead)
+			if got != tt.want {
+				t.Errorf("childStats() =\n  %+v\nwant\n  %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/convergence/handler.go
+++ b/internal/convergence/handler.go
@@ -814,14 +814,7 @@ func (h *Handler) deriveIterationCount(rootBeadID string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	prefix := IdempotencyKeyPrefix(rootBeadID)
-	count := 0
-	for _, child := range children {
-		if strings.HasPrefix(child.IdempotencyKey, prefix) && child.Status == "closed" {
-			count++
-		}
-	}
-	return count, nil
+	return childStats(children, rootBeadID).ClosedCount, nil
 }
 
 // computeDurations computes iteration and cumulative durations.
@@ -839,14 +832,7 @@ func (h *Handler) computeDurations(rootBeadID, wispID string) (iterDur, cumDur t
 	if err != nil {
 		return iterDur, 0
 	}
-	prefix := IdempotencyKeyPrefix(rootBeadID)
-	for _, child := range children {
-		if strings.HasPrefix(child.IdempotencyKey, prefix) && child.Status == "closed" &&
-			!child.ClosedAt.IsZero() && !child.CreatedAt.IsZero() {
-			cumDur += child.ClosedAt.Sub(child.CreatedAt)
-		}
-	}
-	return iterDur, cumDur
+	return iterDur, childStats(children, rootBeadID).CumulativeDur
 }
 
 // emitEvent emits a convergence event through the EventEmitter.

--- a/internal/convergence/manual.go
+++ b/internal/convergence/manual.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
@@ -483,37 +482,14 @@ func (h *Handler) recoverCurrentActiveWisp(beadID, lastProcessedWisp string) (Be
 		return BeadInfo{}, false, nil
 	}
 
-	var bestOpen BeadInfo
-	bestOpenIter := -1
-	var bestClosed BeadInfo
-	bestClosedIter := -1
-	prefix := IdempotencyKeyPrefix(beadID)
-	for _, child := range children {
-		if !strings.HasPrefix(child.IdempotencyKey, prefix) {
-			continue
-		}
-		iter, ok := ParseIterationFromKey(child.IdempotencyKey)
-		if !ok {
-			continue
-		}
-		switch child.Status {
-		case "open", "in_progress":
-			if iter > bestOpenIter {
-				bestOpen = child
-				bestOpenIter = iter
-			}
-		case "closed":
-			if iter > bestClosedIter {
-				bestClosed = child
-				bestClosedIter = iter
-			}
-		}
+	// Fall back to the highest-iteration open wisp, then the highest-iteration
+	// closed wisp, among the convergence children.
+	stats := childStats(children, beadID)
+	if stats.HighestOpenFound {
+		return stats.HighestOpen, true, nil
 	}
-	if bestOpenIter >= 0 {
-		return bestOpen, true, nil
-	}
-	if bestClosedIter >= 0 {
-		return bestClosed, true, nil
+	if stats.HighestClosedFound {
+		return stats.HighestClosed, true, nil
 	}
 	return BeadInfo{}, false, nil
 }

--- a/internal/convergence/reconcile.go
+++ b/internal/convergence/reconcile.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
@@ -259,8 +258,10 @@ func (r *Reconciler) reconcileTerminatedNotClosed(beadID string, meta map[string
 		}
 	}
 
-	// Derive total iterations for the terminated event.
-	totalIterations, _ := r.deriveIterationFromChildrenViaStore(beadID)
+	// Derive iteration count and cumulative duration for the terminated event
+	// from a single child fetch (best-effort: zeros on error).
+	children, _ := r.Handler.Store.Children(beadID)
+	stats := childStats(children, beadID)
 
 	// Emit ConvergenceTerminated (recovery).
 	reason := meta[FieldTerminalReason]
@@ -272,15 +273,12 @@ func (r *Reconciler) reconcileTerminatedNotClosed(beadID string, meta map[string
 		actor = "recovery"
 	}
 
-	// Compute cumulative duration (best-effort).
-	cumDur := r.cumulativeDuration(beadID)
-
 	termPayload := TerminatedPayload{
 		TerminalReason:       reason,
-		TotalIterations:      totalIterations,
+		TotalIterations:      stats.ClosedCount,
 		FinalStatus:          "closed",
 		Actor:                actor,
-		CumulativeDurationMs: cumDur,
+		CumulativeDurationMs: stats.CumulativeDur.Milliseconds(),
 	}
 	r.emitRecoveryEvent(EventTerminated, EventIDTerminated(beadID), beadID, termPayload)
 
@@ -314,28 +312,29 @@ func (r *Reconciler) reconcileWaitingManual(beadID string, meta map[string]strin
 		// event was lost in a crash.
 		iteration, _ := DecodeInt(meta[FieldIteration])
 		wispID := meta[FieldLastProcessedWisp]
-		cumDur := r.cumulativeDuration(beadID)
+		// One child fetch feeds both the cumulative duration (best-effort:
+		// zero on error) and the last_processed_wisp repair below.
+		children, childErr := r.Handler.Store.Children(beadID)
+		stats := childStats(children, beadID)
 		wmPayload := WaitingManualPayload{
 			Iteration:            iteration,
 			WispID:               wispID,
 			GateMode:             meta[FieldGateMode],
 			Reason:               waitingReason,
-			CumulativeDurationMs: cumDur,
+			CumulativeDurationMs: stats.CumulativeDur.Milliseconds(),
 		}
 		r.emitRecoveryEvent(EventWaitingManual, EventIDWaitingManual(beadID, iteration), beadID, wmPayload)
 
 		// Repair last_processed_wisp if needed: find the highest-iteration
 		// closed wisp and ensure last_processed_wisp points to it.
-		children, err := r.Handler.Store.Children(beadID)
-		if err != nil {
+		if childErr != nil {
 			return ReconcileDetail{
 				BeadID: beadID, Action: "no_action",
-				Error: fmt.Errorf("listing children: %w", err),
+				Error: fmt.Errorf("listing children: %w", childErr),
 			}
 		}
-		highestWisp, _, found := highestClosedWisp(children, beadID)
-		if found && meta[FieldLastProcessedWisp] != highestWisp.ID {
-			if err := r.Handler.Store.SetMetadata(beadID, FieldLastProcessedWisp, highestWisp.ID); err != nil {
+		if stats.HighestClosedFound && meta[FieldLastProcessedWisp] != stats.HighestClosed.ID {
+			if err := r.Handler.Store.SetMetadata(beadID, FieldLastProcessedWisp, stats.HighestClosed.ID); err != nil {
 				return ReconcileDetail{
 					BeadID: beadID, Action: "repaired_state",
 					Error: fmt.Errorf("repairing last_processed_wisp: %w", err),
@@ -356,8 +355,7 @@ func (r *Reconciler) reconcileWaitingManual(beadID string, meta map[string]strin
 			Error: fmt.Errorf("listing children: %w", err),
 		}
 	}
-	_, _, found := highestClosedWisp(children, beadID)
-	if found {
+	if childStats(children, beadID).HighestClosedFound {
 		// There are closed wisps but no waiting_reason — set a default.
 		if err := r.Handler.Store.SetMetadata(beadID, FieldWaitingReason, WaitManual); err != nil {
 			return ReconcileDetail{
@@ -482,7 +480,7 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 		}
 	}
 
-	closedIter := deriveIterationFromChildren(children, beadID)
+	closedIter := childStats(children, beadID).ClosedCount
 	nextIter := closedIter + 1
 	nextKey := IdempotencyKey(beadID, nextIter)
 
@@ -557,15 +555,19 @@ func (r *Reconciler) completeTerminalTransition(beadID string, meta map[string]s
 		actor = "recovery"
 	}
 
-	totalIterations, _ := r.deriveIterationFromChildrenViaStore(beadID)
-	cumDur := r.cumulativeDuration(beadID)
+	// One child fetch feeds the iteration count, cumulative duration, and the
+	// last_processed_wisp repair below. The intervening writes only touch the
+	// parent bead's metadata/status, not its children, so the highest closed
+	// wisp is unchanged by the time we write it (best-effort: zeros on error).
+	children, _ := r.Handler.Store.Children(beadID)
+	stats := childStats(children, beadID)
 
 	termPayload := TerminatedPayload{
 		TerminalReason:       reason,
-		TotalIterations:      totalIterations,
+		TotalIterations:      stats.ClosedCount,
 		FinalStatus:          "closed",
 		Actor:                actor,
-		CumulativeDurationMs: cumDur,
+		CumulativeDurationMs: stats.CumulativeDur.Milliseconds(),
 	}
 	r.emitRecoveryEvent(EventTerminated, EventIDTerminated(beadID), beadID, termPayload)
 
@@ -589,11 +591,8 @@ func (r *Reconciler) completeTerminalTransition(beadID string, meta map[string]s
 
 	// Write last_processed_wisp if there is a highest closed wisp
 	// (write ordering: always last).
-	children, err := r.Handler.Store.Children(beadID)
-	if err == nil {
-		if hw, _, found := highestClosedWisp(children, beadID); found {
-			_ = r.Handler.Store.SetMetadata(beadID, FieldLastProcessedWisp, hw.ID)
-		}
+	if stats.HighestClosedFound {
+		_ = r.Handler.Store.SetMetadata(beadID, FieldLastProcessedWisp, stats.HighestClosed.ID)
 	}
 
 	return ReconcileDetail{BeadID: beadID, Action: "completed_terminal"}
@@ -609,74 +608,16 @@ func (r *Reconciler) backfillTerminalActor(beadID string, meta map[string]string
 }
 
 // deriveIterationFromChildren counts closed convergence wisps among the
-// children of beadID. This is the same logic as Handler.deriveIterationCount
-// but operates on a pre-fetched child list.
+// children of beadID. Thin accessor over childStats for the closed-wisp count.
 func deriveIterationFromChildren(children []BeadInfo, beadID string) int {
-	prefix := IdempotencyKeyPrefix(beadID)
-	count := 0
-	for _, child := range children {
-		if strings.HasPrefix(child.IdempotencyKey, prefix) && child.Status == "closed" {
-			count++
-		}
-	}
-	return count
+	return childStats(children, beadID).ClosedCount
 }
 
 // highestClosedWisp finds the closed convergence wisp with the highest
-// iteration number among the children of beadID.
+// iteration number among the children of beadID. Thin accessor over childStats.
 func highestClosedWisp(children []BeadInfo, beadID string) (BeadInfo, int, bool) {
-	prefix := IdempotencyKeyPrefix(beadID)
-	var best BeadInfo
-	bestIter := -1
-	found := false
-
-	for _, child := range children {
-		if !strings.HasPrefix(child.IdempotencyKey, prefix) {
-			continue
-		}
-		if child.Status != "closed" {
-			continue
-		}
-		iter, ok := ParseIterationFromKey(child.IdempotencyKey)
-		if !ok {
-			continue
-		}
-		if iter > bestIter {
-			best = child
-			bestIter = iter
-			found = true
-		}
-	}
-
-	return best, bestIter, found
-}
-
-// deriveIterationFromChildrenViaStore fetches children from the store
-// and delegates to deriveIterationFromChildren.
-func (r *Reconciler) deriveIterationFromChildrenViaStore(beadID string) (int, error) {
-	children, err := r.Handler.Store.Children(beadID)
-	if err != nil {
-		return 0, err
-	}
-	return deriveIterationFromChildren(children, beadID), nil
-}
-
-// cumulativeDuration computes the cumulative duration across all closed
-// convergence wisps (best-effort, returns 0 on error).
-func (r *Reconciler) cumulativeDuration(beadID string) int64 {
-	children, err := r.Handler.Store.Children(beadID)
-	if err != nil {
-		return 0
-	}
-	prefix := IdempotencyKeyPrefix(beadID)
-	var total int64
-	for _, child := range children {
-		if strings.HasPrefix(child.IdempotencyKey, prefix) && child.Status == "closed" &&
-			!child.ClosedAt.IsZero() && !child.CreatedAt.IsZero() {
-			total += child.ClosedAt.Sub(child.CreatedAt).Milliseconds()
-		}
-	}
-	return total
+	s := childStats(children, beadID)
+	return s.HighestClosed, s.HighestClosedIter, s.HighestClosedFound
 }
 
 // emitRecoveryEvent emits a convergence event with the recovery flag


### PR DESCRIPTION
## What this does

Lands **S31** — replaces six duplicate child-projection loops (+2 helpers) in
`internal/convergence` with one pure `childStats()` scan (`childstats.go`).
Behavior-preserving (filter-drift verbatim, fetch consolidation verified safe)
and a perf win: 3–4 `Children()` round-trips per transition collapse to 1. New
`childstats_test.go` coverage.

## Gates

- `go build ./internal/convergence ./cmd/gc` — pass
- `go vet ./internal/convergence` — pass
- `golangci-lint ./internal/convergence/...` — 0 issues
- `go test ./internal/convergence` — pass

## Review verdict

LAND — fast-track (no `status/needs-review-auto` label), behavior-preserving
dedup + perf win, per the simplification walkthrough. Merge after CI green;
delete branch on merge.
