### PR TITLE
simplify(S33): flatten reconcile.go error plumbing

### DIFF
--- a/internal/convergence/reconcile.go
+++ b/internal/convergence/reconcile.go
@@ -9,11 +9,24 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
+// ReconcileAction names the outcome of reconciling a single bead. The values
+// are stable and surface verbatim in ReconcileReport details.
+type ReconcileAction string
+
+// ReconcileAction values describing what a recovery path did.
+const (
+	ActionNoAction          ReconcileAction = "no_action"
+	ActionCompletedTerminal ReconcileAction = "completed_terminal"
+	ActionAdoptedWisp       ReconcileAction = "adopted_wisp"
+	ActionPouredWisp        ReconcileAction = "poured_wisp"
+	ActionRepairedState     ReconcileAction = "repaired_state"
+)
+
 // ReconcileDetail records the outcome of reconciling a single bead.
 type ReconcileDetail struct {
 	BeadID string
-	Action string // "completed_terminal", "adopted_wisp", "poured_wisp", "repaired_state", "no_action"
-	Error  error  // nil if successful
+	Action ReconcileAction
+	Error  error // nil if successful
 }
 
 // ReconcileReport summarizes a full reconciliation pass.
@@ -50,7 +63,7 @@ func (r *Reconciler) ReconcileBeads(ctx context.Context, beadIDs []string) (Reco
 		report.Details = append(report.Details, detail)
 		if detail.Error != nil {
 			report.Errors++
-		} else if detail.Action != "no_action" {
+		} else if detail.Action != ActionNoAction {
 			report.Recovered++
 		}
 	}
@@ -60,11 +73,19 @@ func (r *Reconciler) ReconcileBeads(ctx context.Context, beadIDs []string) (Reco
 
 // reconcileBead inspects a single convergence bead and performs whatever
 // recovery action is needed.  It never returns an error directly —
-// errors are captured in the returned ReconcileDetail.
+// the (action, error) result of the chosen recovery path is wrapped into
+// the returned ReconcileDetail at this single site.
 func (r *Reconciler) reconcileBead(ctx context.Context, beadID string) ReconcileDetail {
+	action, err := r.reconcileState(ctx, beadID)
+	return ReconcileDetail{BeadID: beadID, Action: action, Error: err}
+}
+
+// reconcileState reads the bead's convergence state and dispatches to the
+// recovery path for that state, returning the resulting (action, error).
+func (r *Reconciler) reconcileState(ctx context.Context, beadID string) (ReconcileAction, error) {
 	meta, err := r.Handler.Store.GetMetadata(beadID)
 	if err != nil {
-		return ReconcileDetail{BeadID: beadID, Action: "no_action", Error: fmt.Errorf("reading metadata: %w", err)}
+		return ActionNoAction, fmt.Errorf("reading metadata: %w", err)
 	}
 
 	state := meta[FieldState]
@@ -99,42 +120,30 @@ func (r *Reconciler) reconcileBead(ctx context.Context, beadID string) Reconcile
 		return r.reconcileActive(ctx, beadID, meta)
 
 	default:
-		return ReconcileDetail{
-			BeadID: beadID, Action: "no_action",
-			Error: fmt.Errorf("unknown convergence state %q", state),
-		}
+		return ActionNoAction, fmt.Errorf("unknown convergence state %q", state)
 	}
 }
 
 // --- Path 1: Missing/empty state ---
 
-func (r *Reconciler) reconcileMissingState(ctx context.Context, beadID string, meta map[string]string) ReconcileDetail {
+func (r *Reconciler) reconcileMissingState(ctx context.Context, beadID string, meta map[string]string) (ReconcileAction, error) {
 	// Check if there is already a wisp for iteration 1 (idempotency key
 	// lookup).
 	key1 := IdempotencyKey(beadID, 1)
 	existingID, found, err := r.Handler.Store.FindByIdempotencyKey(key1)
 	if err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "no_action",
-			Error: fmt.Errorf("looking up iter-1 wisp: %w", err),
-		}
+		return ActionNoAction, fmt.Errorf("looking up iter-1 wisp: %w", err)
 	}
 
 	if found {
 		// Wisp exists — adopt it, but check if it's already closed.
 		wispInfo, err := r.Handler.Store.GetBead(existingID)
 		if err != nil {
-			return ReconcileDetail{
-				BeadID: beadID, Action: "adopted_wisp",
-				Error: fmt.Errorf("reading wisp %q info: %w", existingID, err),
-			}
+			return ActionAdoptedWisp, fmt.Errorf("reading wisp %q info: %w", existingID, err)
 		}
 
 		if err := r.Handler.Store.SetMetadata(beadID, FieldActiveWisp, existingID); err != nil {
-			return ReconcileDetail{
-				BeadID: beadID, Action: "adopted_wisp",
-				Error: fmt.Errorf("setting active_wisp: %w", err),
-			}
+			return ActionAdoptedWisp, fmt.Errorf("setting active_wisp: %w", err)
 		}
 		// Set iteration to match the adopted wisp: 1 if closed (we know
 		// iteration 1 exists), 0 if still open (HandleWispClosed will
@@ -144,30 +153,21 @@ func (r *Reconciler) reconcileMissingState(ctx context.Context, beadID string, m
 			adoptedIteration = 1
 		}
 		if err := r.Handler.Store.SetMetadata(beadID, FieldIteration, EncodeInt(adoptedIteration)); err != nil {
-			return ReconcileDetail{
-				BeadID: beadID, Action: "adopted_wisp",
-				Error: fmt.Errorf("setting iteration: %w", err),
-			}
+			return ActionAdoptedWisp, fmt.Errorf("setting iteration: %w", err)
 		}
 		if err := r.Handler.Store.SetMetadata(beadID, FieldState, StateActive); err != nil {
-			return ReconcileDetail{
-				BeadID: beadID, Action: "adopted_wisp",
-				Error: fmt.Errorf("setting state: %w", err),
-			}
+			return ActionAdoptedWisp, fmt.Errorf("setting state: %w", err)
 		}
 
 		// If the adopted wisp is already closed, replay the transition
 		// so the convergence loop doesn't stall in active with a dead wisp.
 		if wispInfo.Status == "closed" {
 			if _, err := r.Handler.HandleWispClosed(ctx, beadID, existingID); err != nil {
-				return ReconcileDetail{
-					BeadID: beadID, Action: "adopted_wisp",
-					Error: fmt.Errorf("replaying wisp_closed for adopted wisp %q: %w", existingID, err),
-				}
+				return ActionAdoptedWisp, fmt.Errorf("replaying wisp_closed for adopted wisp %q: %w", existingID, err)
 			}
 		}
 
-		return ReconcileDetail{BeadID: beadID, Action: "adopted_wisp"}
+		return ActionAdoptedWisp, nil
 	}
 
 	// No wisp exists — pour the first one.
@@ -177,86 +177,56 @@ func (r *Reconciler) reconcileMissingState(ctx context.Context, beadID string, m
 
 	wispID, err := r.Handler.Store.PourWisp(beadID, formula, key1, vars, evaluatePrompt)
 	if err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "poured_wisp",
-			Error: fmt.Errorf("pouring first wisp: %w", err),
-		}
+		return ActionPouredWisp, fmt.Errorf("pouring first wisp: %w", err)
 	}
 
 	if err := r.Handler.Store.SetMetadata(beadID, FieldActiveWisp, wispID); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "poured_wisp",
-			Error: fmt.Errorf("setting active_wisp: %w", err),
-		}
+		return ActionPouredWisp, fmt.Errorf("setting active_wisp: %w", err)
 	}
 	if err := r.Handler.Store.SetMetadata(beadID, FieldIteration, EncodeInt(0)); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "poured_wisp",
-			Error: fmt.Errorf("setting iteration: %w", err),
-		}
+		return ActionPouredWisp, fmt.Errorf("setting iteration: %w", err)
 	}
 	if err := r.Handler.Store.SetMetadata(beadID, FieldState, StateActive); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "poured_wisp",
-			Error: fmt.Errorf("setting state: %w", err),
-		}
+		return ActionPouredWisp, fmt.Errorf("setting state: %w", err)
 	}
 
-	return ReconcileDetail{BeadID: beadID, Action: "poured_wisp"}
+	return ActionPouredWisp, nil
 }
 
 // --- Path 1b: state=creating (partial creation) ---
 
-func (r *Reconciler) reconcileCreating(beadID string) ReconcileDetail {
+func (r *Reconciler) reconcileCreating(beadID string) (ReconcileAction, error) {
 	if err := r.Handler.Store.SetMetadata(beadID, FieldTerminalReason, TerminalPartialCreation); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "completed_terminal",
-			Error: fmt.Errorf("setting terminal_reason: %w", err),
-		}
+		return ActionCompletedTerminal, fmt.Errorf("setting terminal_reason: %w", err)
 	}
 	if err := r.Handler.Store.SetMetadata(beadID, FieldTerminalActor, "recovery"); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "completed_terminal",
-			Error: fmt.Errorf("setting terminal_actor: %w", err),
-		}
+		return ActionCompletedTerminal, fmt.Errorf("setting terminal_actor: %w", err)
 	}
 	if err := r.Handler.Store.SetMetadata(beadID, FieldState, StateTerminated); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "completed_terminal",
-			Error: fmt.Errorf("setting state to terminated: %w", err),
-		}
+		return ActionCompletedTerminal, fmt.Errorf("setting state to terminated: %w", err)
 	}
 	if err := r.Handler.Store.CloseBead(beadID, CloseReasonReconcileDone); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "completed_terminal",
-			Error: fmt.Errorf("closing bead: %w", err),
-		}
+		return ActionCompletedTerminal, fmt.Errorf("closing bead: %w", err)
 	}
-	return ReconcileDetail{BeadID: beadID, Action: "completed_terminal"}
+	return ActionCompletedTerminal, nil
 }
 
 // --- Path 2: state=terminated but bead not closed ---
 
-func (r *Reconciler) reconcileTerminatedNotClosed(beadID string, meta map[string]string) ReconcileDetail {
+func (r *Reconciler) reconcileTerminatedNotClosed(beadID string, meta map[string]string) (ReconcileAction, error) {
 	// Check if the bead is actually already closed.
 	beadInfo, err := r.Handler.Store.GetBead(beadID)
 	if err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "no_action",
-			Error: fmt.Errorf("reading bead info: %w", err),
-		}
+		return ActionNoAction, fmt.Errorf("reading bead info: %w", err)
 	}
 	if beadInfo.Status == "closed" {
 		// Already fully terminated.
-		return ReconcileDetail{BeadID: beadID, Action: "no_action"}
+		return ActionNoAction, nil
 	}
 
 	// Backfill terminal_actor if missing.
 	if err := r.backfillTerminalActor(beadID, meta); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "completed_terminal",
-			Error: fmt.Errorf("backfilling terminal_actor: %w", err),
-		}
+		return ActionCompletedTerminal, fmt.Errorf("backfilling terminal_actor: %w", err)
 	}
 
 	// Derive total iterations for the terminated event.
@@ -286,18 +256,15 @@ func (r *Reconciler) reconcileTerminatedNotClosed(beadID string, meta map[string
 
 	// Close the bead.
 	if err := r.Handler.Store.CloseBead(beadID, CloseReasonReconcileDone); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "completed_terminal",
-			Error: fmt.Errorf("closing bead: %w", err),
-		}
+		return ActionCompletedTerminal, fmt.Errorf("closing bead: %w", err)
 	}
 
-	return ReconcileDetail{BeadID: beadID, Action: "completed_terminal"}
+	return ActionCompletedTerminal, nil
 }
 
 // --- Path 3: state=waiting_manual ---
 
-func (r *Reconciler) reconcileWaitingManual(beadID string, meta map[string]string) ReconcileDetail {
+func (r *Reconciler) reconcileWaitingManual(beadID string, meta map[string]string) (ReconcileAction, error) {
 	terminalReason := meta[FieldTerminalReason]
 	waitingReason := meta[FieldWaitingReason]
 
@@ -328,22 +295,16 @@ func (r *Reconciler) reconcileWaitingManual(beadID string, meta map[string]strin
 		// closed wisp and ensure last_processed_wisp points to it.
 		children, err := r.Handler.Store.Children(beadID)
 		if err != nil {
-			return ReconcileDetail{
-				BeadID: beadID, Action: "no_action",
-				Error: fmt.Errorf("listing children: %w", err),
-			}
+			return ActionNoAction, fmt.Errorf("listing children: %w", err)
 		}
 		highestWisp, _, found := highestClosedWisp(children, beadID)
 		if found && meta[FieldLastProcessedWisp] != highestWisp.ID {
 			if err := r.Handler.Store.SetMetadata(beadID, FieldLastProcessedWisp, highestWisp.ID); err != nil {
-				return ReconcileDetail{
-					BeadID: beadID, Action: "repaired_state",
-					Error: fmt.Errorf("repairing last_processed_wisp: %w", err),
-				}
+				return ActionRepairedState, fmt.Errorf("repairing last_processed_wisp: %w", err)
 			}
-			return ReconcileDetail{BeadID: beadID, Action: "repaired_state"}
+			return ActionRepairedState, nil
 		}
-		return ReconcileDetail{BeadID: beadID, Action: "no_action"}
+		return ActionNoAction, nil
 	}
 
 	// Sub-path C: no waiting_reason, no terminal_reason — orphaned state.
@@ -351,29 +312,23 @@ func (r *Reconciler) reconcileWaitingManual(beadID string, meta map[string]strin
 	// just repair the waiting_reason so the loop is in a known state.
 	children, err := r.Handler.Store.Children(beadID)
 	if err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "no_action",
-			Error: fmt.Errorf("listing children: %w", err),
-		}
+		return ActionNoAction, fmt.Errorf("listing children: %w", err)
 	}
 	_, _, found := highestClosedWisp(children, beadID)
 	if found {
 		// There are closed wisps but no waiting_reason — set a default.
 		if err := r.Handler.Store.SetMetadata(beadID, FieldWaitingReason, WaitManual); err != nil {
-			return ReconcileDetail{
-				BeadID: beadID, Action: "repaired_state",
-				Error: fmt.Errorf("setting default waiting_reason: %w", err),
-			}
+			return ActionRepairedState, fmt.Errorf("setting default waiting_reason: %w", err)
 		}
-		return ReconcileDetail{BeadID: beadID, Action: "repaired_state"}
+		return ActionRepairedState, nil
 	}
 
-	return ReconcileDetail{BeadID: beadID, Action: "no_action"}
+	return ActionNoAction, nil
 }
 
 // --- Path 3t: state=waiting_trigger ---
 
-func (r *Reconciler) reconcileWaitingTrigger(beadID string, meta map[string]string) ReconcileDetail {
+func (r *Reconciler) reconcileWaitingTrigger(beadID string, meta map[string]string) (ReconcileAction, error) {
 	// A stop requested while waiting on the trigger may have crashed before
 	// the terminal transition completed.
 	if meta[FieldTerminalReason] != "" {
@@ -381,12 +336,12 @@ func (r *Reconciler) reconcileWaitingTrigger(beadID string, meta map[string]stri
 	}
 	// Otherwise nothing to repair: no wisp is in flight and the controller
 	// tick re-evaluates the trigger condition.
-	return ReconcileDetail{BeadID: beadID, Action: "no_action"}
+	return ActionNoAction, nil
 }
 
 // --- Path 4: state=active ---
 
-func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta map[string]string) ReconcileDetail {
+func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta map[string]string) (ReconcileAction, error) {
 	// Sub-path A: terminal_reason set — a stop was requested while active
 	// but the transition crashed before completing.
 	if meta[FieldTerminalReason] != "" {
@@ -401,17 +356,11 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 		wispInfo, err := r.Handler.Store.GetBead(activeWispID)
 		if err != nil {
 			if !errors.Is(err, beads.ErrNotFound) {
-				return ReconcileDetail{
-					BeadID: beadID, Action: "no_action",
-					Error: fmt.Errorf("reading active wisp %q: %w", activeWispID, err),
-				}
+				return ActionNoAction, fmt.Errorf("reading active wisp %q: %w", activeWispID, err)
 			}
 			recoveredWisp, found, recoverErr := r.Handler.recoverCurrentActiveWisp(beadID, meta[FieldLastProcessedWisp])
 			if recoverErr != nil {
-				return ReconcileDetail{
-					BeadID: beadID, Action: "no_action",
-					Error: recoverErr,
-				}
+				return ActionNoAction, recoverErr
 			}
 			if !found {
 				// A crashed loop can leave active_wisp pointing at a bead that
@@ -427,20 +376,16 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 		if activeWispID != "" {
 			if recoveredActiveWisp {
 				if err := r.Handler.Store.SetMetadata(beadID, FieldActiveWisp, activeWispID); err != nil {
-					return ReconcileDetail{
-						BeadID: beadID, Action: "repaired_state",
-						Error: fmt.Errorf("setting recovered active wisp %q: %w", activeWispID, err),
-					}
+					return ActionRepairedState, fmt.Errorf("setting recovered active wisp %q: %w", activeWispID, err)
 				}
 			}
 			switch wispInfo.Status {
 			case "open", "in_progress":
 				// Wisp still running — nothing to do.
-				action := "no_action"
 				if recoveredActiveWisp {
-					action = "repaired_state"
+					return ActionRepairedState, nil
 				}
-				return ReconcileDetail{BeadID: beadID, Action: action}
+				return ActionNoAction, nil
 
 			case "closed":
 				// Wisp is closed. Check if it was already processed.
@@ -449,25 +394,17 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 					// Already processed — check if the commit completed.
 					// The commit was done because last_processed_wisp is
 					// set (it is always the last write). Nothing to do.
-					return ReconcileDetail{BeadID: beadID, Action: "no_action"}
+					return ActionNoAction, nil
 				}
 
 				// Closed but not processed — replay the wisp_closed event.
-				result, err := r.Handler.HandleWispClosed(ctx, beadID, activeWispID)
-				if err != nil {
-					return ReconcileDetail{
-						BeadID: beadID, Action: "repaired_state",
-						Error: fmt.Errorf("replaying wisp_closed for %q: %w", activeWispID, err),
-					}
+				if _, err := r.Handler.HandleWispClosed(ctx, beadID, activeWispID); err != nil {
+					return ActionRepairedState, fmt.Errorf("replaying wisp_closed for %q: %w", activeWispID, err)
 				}
-				_ = result
-				return ReconcileDetail{BeadID: beadID, Action: "repaired_state"}
+				return ActionRepairedState, nil
 
 			default:
-				return ReconcileDetail{
-					BeadID: beadID, Action: "no_action",
-					Error: fmt.Errorf("active wisp %q has unexpected status %q", activeWispID, wispInfo.Status),
-				}
+				return ActionNoAction, fmt.Errorf("active wisp %q has unexpected status %q", activeWispID, wispInfo.Status)
 			}
 		}
 	}
@@ -476,10 +413,7 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 	// adopt the next wisp.
 	children, err := r.Handler.Store.Children(beadID)
 	if err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "no_action",
-			Error: fmt.Errorf("listing children: %w", err),
-		}
+		return ActionNoAction, fmt.Errorf("listing children: %w", err)
 	}
 
 	closedIter := deriveIterationFromChildren(children, beadID)
@@ -487,7 +421,7 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 	nextKey := IdempotencyKey(beadID, nextIter)
 
 	var wispID string
-	action := "adopted_wisp"
+	action := ActionAdoptedWisp
 
 	if pendingID := r.Handler.validPendingNextWisp(beadID, nextKey, meta[FieldPendingNextWisp]); pendingID != "" {
 		wispID = pendingID
@@ -495,10 +429,7 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 		// Check if a wisp for the next iteration already exists.
 		existingID, found, err := r.Handler.Store.FindByIdempotencyKey(nextKey)
 		if err != nil {
-			return ReconcileDetail{
-				BeadID: beadID, Action: "no_action",
-				Error: fmt.Errorf("looking up next wisp: %w", err),
-			}
+			return ActionNoAction, fmt.Errorf("looking up next wisp: %w", err)
 		}
 
 		if found {
@@ -511,44 +442,32 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 
 			wispID, err = r.Handler.Store.PourWisp(beadID, formula, nextKey, vars, evaluatePrompt)
 			if err != nil {
-				return ReconcileDetail{
-					BeadID: beadID, Action: "poured_wisp",
-					Error: fmt.Errorf("pouring wisp for iter %d: %w", nextIter, err),
-				}
+				return ActionPouredWisp, fmt.Errorf("pouring wisp for iter %d: %w", nextIter, err)
 			}
-			action = "poured_wisp"
+			action = ActionPouredWisp
 		}
 	}
 
 	if err := r.Handler.Store.ActivateWisp(wispID); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: action,
-			Error: fmt.Errorf("activating wisp %q: %w", wispID, err),
-		}
+		return action, fmt.Errorf("activating wisp %q: %w", wispID, err)
 	}
 
 	if err := r.Handler.Store.SetMetadata(beadID, FieldActiveWisp, wispID); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: action,
-			Error: fmt.Errorf("setting active_wisp: %w", err),
-		}
+		return action, fmt.Errorf("setting active_wisp: %w", err)
 	}
 	_ = r.Handler.Store.SetMetadata(beadID, FieldPendingNextWisp, "")
 
-	return ReconcileDetail{BeadID: beadID, Action: action}
+	return action, nil
 }
 
 // --- Shared helpers ---
 
 // completeTerminalTransition finishes a terminal transition that was
 // interrupted.  Used by both Path 3A and Path 4A.
-func (r *Reconciler) completeTerminalTransition(beadID string, meta map[string]string) ReconcileDetail {
+func (r *Reconciler) completeTerminalTransition(beadID string, meta map[string]string) (ReconcileAction, error) {
 	// Backfill terminal_actor if missing.
 	if err := r.backfillTerminalActor(beadID, meta); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "completed_terminal",
-			Error: fmt.Errorf("backfilling terminal_actor: %w", err),
-		}
+		return ActionCompletedTerminal, fmt.Errorf("backfilling terminal_actor: %w", err)
 	}
 
 	reason := meta[FieldTerminalReason]
@@ -572,19 +491,13 @@ func (r *Reconciler) completeTerminalTransition(beadID string, meta map[string]s
 	// Write state=terminated if not already set.
 	if meta[FieldState] != StateTerminated {
 		if err := r.Handler.Store.SetMetadata(beadID, FieldState, StateTerminated); err != nil {
-			return ReconcileDetail{
-				BeadID: beadID, Action: "completed_terminal",
-				Error: fmt.Errorf("setting state to terminated: %w", err),
-			}
+			return ActionCompletedTerminal, fmt.Errorf("setting state to terminated: %w", err)
 		}
 	}
 
 	// Close the bead.
 	if err := r.Handler.Store.CloseBead(beadID, CloseReasonReconcileDone); err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "completed_terminal",
-			Error: fmt.Errorf("closing bead: %w", err),
-		}
+		return ActionCompletedTerminal, fmt.Errorf("closing bead: %w", err)
 	}
 
 	// Write last_processed_wisp if there is a highest closed wisp
@@ -596,7 +509,7 @@ func (r *Reconciler) completeTerminalTransition(beadID string, meta map[string]s
 		}
 	}
 
-	return ReconcileDetail{BeadID: beadID, Action: "completed_terminal"}
+	return ActionCompletedTerminal, nil
 }
 
 // backfillTerminalActor sets terminal_actor to "recovery" if it is

--- a/internal/convergence/reconcile_test.go
+++ b/internal/convergence/reconcile_test.go
@@ -42,7 +42,7 @@ func TestReconcile_WaitingTrigger_NoAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(report.Details) != 1 || report.Details[0].Action != "no_action" {
+	if len(report.Details) != 1 || report.Details[0].Action != ActionNoAction {
 		t.Errorf("action = %+v, want no_action", report.Details)
 	}
 	// State must be preserved so the tick re-evaluates the trigger.
@@ -67,7 +67,7 @@ func TestReconcile_WaitingTrigger_CompletesInterruptedStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(report.Details) != 1 || report.Details[0].Action != "completed_terminal" {
+	if len(report.Details) != 1 || report.Details[0].Action != ActionCompletedTerminal {
 		t.Errorf("action = %+v, want completed_terminal", report.Details)
 	}
 	info, _ := store.GetBead("root-1")
@@ -103,8 +103,8 @@ func TestReconcile_MissingState_NoWisps_PoursFirst(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "poured_wisp" {
-		t.Errorf("Action = %q, want %q", d.Action, "poured_wisp")
+	if d.Action != ActionPouredWisp {
+		t.Errorf("Action = %q, want %q", d.Action, ActionPouredWisp)
 	}
 	if d.Error != nil {
 		t.Errorf("unexpected error: %v", d.Error)
@@ -139,8 +139,8 @@ func TestReconcile_MissingState_WispExists_Adopts(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "adopted_wisp" {
-		t.Errorf("Action = %q, want %q", d.Action, "adopted_wisp")
+	if d.Action != ActionAdoptedWisp {
+		t.Errorf("Action = %q, want %q", d.Action, ActionAdoptedWisp)
 	}
 	if d.Error != nil {
 		t.Errorf("unexpected error: %v", d.Error)
@@ -177,8 +177,8 @@ func TestReconcile_StateCreating_TerminatesPartialCreation(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "completed_terminal" {
-		t.Errorf("Action = %q, want %q", d.Action, "completed_terminal")
+	if d.Action != ActionCompletedTerminal {
+		t.Errorf("Action = %q, want %q", d.Action, ActionCompletedTerminal)
 	}
 	if d.Error != nil {
 		t.Errorf("unexpected error: %v", d.Error)
@@ -224,8 +224,8 @@ func TestReconcile_TerminatedNotClosed_CompletesClosure(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "completed_terminal" {
-		t.Errorf("Action = %q, want %q", d.Action, "completed_terminal")
+	if d.Action != ActionCompletedTerminal {
+		t.Errorf("Action = %q, want %q", d.Action, ActionCompletedTerminal)
 	}
 	if d.Error != nil {
 		t.Errorf("unexpected error: %v", d.Error)
@@ -270,8 +270,8 @@ func TestReconcile_TerminatedNotClosed_BackfillsActor(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "completed_terminal" {
-		t.Errorf("Action = %q, want %q", d.Action, "completed_terminal")
+	if d.Action != ActionCompletedTerminal {
+		t.Errorf("Action = %q, want %q", d.Action, ActionCompletedTerminal)
 	}
 
 	meta, _ := store.GetMetadata("root-1")
@@ -295,8 +295,8 @@ func TestReconcile_TerminatedAlreadyClosed_NoAction(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "no_action" {
-		t.Errorf("Action = %q, want %q", d.Action, "no_action")
+	if d.Action != ActionNoAction {
+		t.Errorf("Action = %q, want %q", d.Action, ActionNoAction)
 	}
 }
 
@@ -322,8 +322,8 @@ func TestReconcile_WaitingManual_TerminalReasonSet_CompletesTerminal(t *testing.
 	}
 
 	d := report.Details[0]
-	if d.Action != "completed_terminal" {
-		t.Errorf("Action = %q, want %q", d.Action, "completed_terminal")
+	if d.Action != ActionCompletedTerminal {
+		t.Errorf("Action = %q, want %q", d.Action, ActionCompletedTerminal)
 	}
 	if d.Error != nil {
 		t.Errorf("unexpected error: %v", d.Error)
@@ -366,8 +366,8 @@ func TestReconcile_WaitingManual_GenuineHold_NoStateChange(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "no_action" {
-		t.Errorf("Action = %q, want %q", d.Action, "no_action")
+	if d.Action != ActionNoAction {
+		t.Errorf("Action = %q, want %q", d.Action, ActionNoAction)
 	}
 
 	// State should remain waiting_manual.
@@ -414,8 +414,8 @@ func TestReconcile_WaitingManual_GenuineHold_RepairsLastProcessedWisp(t *testing
 	}
 
 	d := report.Details[0]
-	if d.Action != "repaired_state" {
-		t.Errorf("Action = %q, want %q", d.Action, "repaired_state")
+	if d.Action != ActionRepairedState {
+		t.Errorf("Action = %q, want %q", d.Action, ActionRepairedState)
 	}
 
 	meta, _ := store.GetMetadata("root-1")
@@ -452,8 +452,8 @@ func TestReconcile_Active_ClosedUnprocessedWisp_Replays(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "repaired_state" {
-		t.Errorf("Action = %q, want %q", d.Action, "repaired_state")
+	if d.Action != ActionRepairedState {
+		t.Errorf("Action = %q, want %q", d.Action, ActionRepairedState)
 	}
 	if d.Error != nil {
 		t.Errorf("unexpected error: %v", d.Error)
@@ -503,8 +503,8 @@ func TestReconcile_Active_MissingActiveWisp_ReconstructsChain(t *testing.T) {
 	if d.Error != nil {
 		t.Fatalf("reconcile error: %v", d.Error)
 	}
-	if d.Action != "poured_wisp" && d.Action != "adopted_wisp" {
-		t.Fatalf("Action = %q, want %q or %q", d.Action, "poured_wisp", "adopted_wisp")
+	if d.Action != ActionPouredWisp && d.Action != ActionAdoptedWisp {
+		t.Fatalf("Action = %q, want %q or %q", d.Action, ActionPouredWisp, ActionAdoptedWisp)
 	}
 
 	meta, _ := store.GetMetadata("root-1")
@@ -546,8 +546,8 @@ func TestReconcile_Active_MissingActiveWisp_ReplaysRecoveredClosedReplacement(t 
 	if d.Error != nil {
 		t.Fatalf("reconcile error: %v", d.Error)
 	}
-	if d.Action != "repaired_state" {
-		t.Fatalf("Action = %q, want %q", d.Action, "repaired_state")
+	if d.Action != ActionRepairedState {
+		t.Fatalf("Action = %q, want %q", d.Action, ActionRepairedState)
 	}
 
 	meta, _ := store.GetMetadata("root-1")
@@ -586,8 +586,8 @@ func TestReconcile_Active_MissingActiveWisp_RepairsOpenReplacementMetadata(t *te
 	if d.Error != nil {
 		t.Fatalf("reconcile error: %v", d.Error)
 	}
-	if d.Action != "repaired_state" {
-		t.Fatalf("Action = %q, want %q", d.Action, "repaired_state")
+	if d.Action != ActionRepairedState {
+		t.Fatalf("Action = %q, want %q", d.Action, ActionRepairedState)
 	}
 
 	meta, _ := store.GetMetadata("root-1")
@@ -620,8 +620,8 @@ func TestReconcile_Active_StoreErrorReadingActiveWisp_ReportsError(t *testing.T)
 	if got := d.Error.Error(); !strings.Contains(got, "store unavailable for wisp-iter-1") {
 		t.Fatalf("reconcile error = %q, want store failure", got)
 	}
-	if d.Action != "no_action" {
-		t.Fatalf("Action = %q, want %q", d.Action, "no_action")
+	if d.Action != ActionNoAction {
+		t.Fatalf("Action = %q, want %q", d.Action, ActionNoAction)
 	}
 }
 
@@ -643,8 +643,8 @@ func TestReconcile_Active_OpenWisp_NoAction(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "no_action" {
-		t.Errorf("Action = %q, want %q", d.Action, "no_action")
+	if d.Action != ActionNoAction {
+		t.Errorf("Action = %q, want %q", d.Action, ActionNoAction)
 	}
 }
 
@@ -666,8 +666,8 @@ func TestReconcile_Active_TerminalReasonSet_CompletesStop(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "completed_terminal" {
-		t.Errorf("Action = %q, want %q", d.Action, "completed_terminal")
+	if d.Action != ActionCompletedTerminal {
+		t.Errorf("Action = %q, want %q", d.Action, ActionCompletedTerminal)
 	}
 	if d.Error != nil {
 		t.Errorf("unexpected error: %v", d.Error)
@@ -707,8 +707,8 @@ func TestReconcile_Active_EmptyActiveWisp_PoursNext(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "poured_wisp" {
-		t.Errorf("Action = %q, want %q", d.Action, "poured_wisp")
+	if d.Action != ActionPouredWisp {
+		t.Errorf("Action = %q, want %q", d.Action, ActionPouredWisp)
 	}
 	if d.Error != nil {
 		t.Errorf("unexpected error: %v", d.Error)
@@ -741,8 +741,8 @@ func TestReconcile_Active_EmptyActiveWisp_AdoptsExisting(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "adopted_wisp" {
-		t.Errorf("Action = %q, want %q", d.Action, "adopted_wisp")
+	if d.Action != ActionAdoptedWisp {
+		t.Errorf("Action = %q, want %q", d.Action, ActionAdoptedWisp)
 	}
 
 	meta, _ := store.GetMetadata("root-1")
@@ -771,8 +771,8 @@ func TestReconcile_Active_AlreadyProcessed_NoAction(t *testing.T) {
 	}
 
 	d := report.Details[0]
-	if d.Action != "no_action" {
-		t.Errorf("Action = %q, want %q", d.Action, "no_action")
+	if d.Action != ActionNoAction {
+		t.Errorf("Action = %q, want %q", d.Action, ActionNoAction)
 	}
 }
 
@@ -818,8 +818,8 @@ func TestReconcile_MultipleBeads_ContinuesOnError(t *testing.T) {
 	}
 
 	// bead-1: completed_terminal
-	if report.Details[0].Action != "completed_terminal" {
-		t.Errorf("bead-1 Action = %q, want %q", report.Details[0].Action, "completed_terminal")
+	if report.Details[0].Action != ActionCompletedTerminal {
+		t.Errorf("bead-1 Action = %q, want %q", report.Details[0].Action, ActionCompletedTerminal)
 	}
 
 	// bead-2: error
@@ -828,8 +828,8 @@ func TestReconcile_MultipleBeads_ContinuesOnError(t *testing.T) {
 	}
 
 	// bead-3: no_action (already closed)
-	if report.Details[2].Action != "no_action" {
-		t.Errorf("bead-3 Action = %q, want %q", report.Details[2].Action, "no_action")
+	if report.Details[2].Action != ActionNoAction {
+		t.Errorf("bead-3 Action = %q, want %q", report.Details[2].Action, ActionNoAction)
 	}
 }
 


### PR DESCRIPTION
## What this does

Lands **S33** — flattens `internal/convergence/reconcile.go` error plumbing to a
uniform `(action, error)` shape: a typed `ReconcileAction` set + a single wrap
site (net −87). Zero behavior change.

## Gates

- `go build ./internal/convergence ./cmd/gc` — pass
- `go vet ./internal/convergence` — pass
- `golangci-lint ./internal/convergence/...` — 0 issues
- `go test ./internal/convergence` — pass

## Review verdict

LAND — fast-track (no `status/needs-review-auto` label), zero-behavior-change
error-plumbing flatten, per the simplification walkthrough. Merge after CI
green; delete branch on merge.

Note: same `internal/convergence/reconcile.go` cluster as S31 (#4040) and S30 —
whichever lands second will be rebased/merged with conflict resolution.
