### PR TITLE
simplify(S30): convergence commit-point helper (crash-safe write ordering)

### DIFF
--- a/internal/convergence/handler.go
+++ b/internal/convergence/handler.go
@@ -435,21 +435,17 @@ func (h *Handler) transitionToWaitingManual(
 	}
 	h.emitEvent(EventIteration, EventIDIteration(rootBeadID, iteration), rootBeadID, iterPayload)
 
-	// Step 9: Commit point — write state changes.
-	// Write last_processed_wisp LAST (write ordering contract):
-	// it is the dedup/idempotency marker — if the process crashes before
-	// this write, recovery re-processes this wisp rather than skipping it.
-	if err := h.Store.SetMetadata(rootBeadID, FieldActiveWisp, ""); err != nil {
-		return HandlerResult{}, fmt.Errorf("clearing active wisp: %w", err)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldWaitingReason, reason); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting waiting reason: %w", err)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldState, StateWaitingManual); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting state to waiting_manual: %w", err)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldLastProcessedWisp, wispID); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting last processed wisp: %w", err)
+	// Step 9: Commit point — write state changes, dedup marker LAST.
+	if err := h.commit(rootBeadID,
+		[]metaWrite{
+			{FieldActiveWisp, "", "clearing active wisp"},
+			{FieldWaitingReason, reason, "setting waiting reason"},
+			{FieldState, StateWaitingManual, "setting state to waiting_manual"},
+		},
+		nil,
+		metaWrite{FieldLastProcessedWisp, wispID, "setting last processed wisp"},
+	); err != nil {
+		return HandlerResult{}, err
 	}
 
 	// Emit ConvergenceWaitingManual event.
@@ -552,13 +548,15 @@ func (h *Handler) iterate(
 	}
 	h.emitEvent(EventIteration, EventIDIteration(rootBeadID, iteration), rootBeadID, iterPayload)
 
-	// Step 9: Commit point.
-	// Write last_processed_wisp LAST — it is the dedup marker.
-	if err := h.Store.SetMetadata(rootBeadID, FieldActiveWisp, nextWispID); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting active wisp: %w", err)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldLastProcessedWisp, wispID); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting last processed wisp: %w", err)
+	// Step 9: Commit point — active wisp then dedup marker LAST.
+	if err := h.commit(rootBeadID,
+		[]metaWrite{
+			{FieldActiveWisp, nextWispID, "setting active wisp"},
+		},
+		nil,
+		metaWrite{FieldLastProcessedWisp, wispID, "setting last processed wisp"},
+	); err != nil {
+		return HandlerResult{}, err
 	}
 	// Clear pending_next_wisp after the dedup marker commits. If this best-effort
 	// cleanup fails, validPendingNextWisp will self-heal on the next entry.
@@ -616,15 +614,16 @@ func (h *Handler) transitionToWaitingTrigger(
 	}
 	h.emitEvent(EventIteration, EventIDIteration(rootBeadID, iteration), rootBeadID, iterPayload)
 
-	// Step 9: Commit point. Write last_processed_wisp LAST (dedup marker).
-	if err := h.Store.SetMetadata(rootBeadID, FieldActiveWisp, ""); err != nil {
-		return HandlerResult{}, fmt.Errorf("clearing active wisp: %w", err)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldState, StateWaitingTrigger); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting state to waiting_trigger: %w", err)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldLastProcessedWisp, wispID); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting last processed wisp: %w", err)
+	// Step 9: Commit point — clear active wisp, set state, dedup marker LAST.
+	if err := h.commit(rootBeadID,
+		[]metaWrite{
+			{FieldActiveWisp, "", "clearing active wisp"},
+			{FieldState, StateWaitingTrigger, "setting state to waiting_trigger"},
+		},
+		nil,
+		metaWrite{FieldLastProcessedWisp, wispID, "setting last processed wisp"},
+	); err != nil {
+		return HandlerResult{}, err
 	}
 
 	return HandlerResult{
@@ -685,22 +684,23 @@ func (h *Handler) terminate(
 	h.emitEvent(EventTerminated, EventIDTerminated(rootBeadID), rootBeadID, termPayload)
 
 	// Step 9: Commit point.
-	// Write terminal_reason and terminal_actor BEFORE state=terminated,
-	// then last_processed_wisp LAST — it is the dedup marker.
-	if err := h.Store.SetMetadata(rootBeadID, FieldTerminalReason, reason); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting terminal reason: %w", err)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldTerminalActor, actor); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting terminal actor: %w", err)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldState, StateTerminated); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting state to terminated: %w", err)
-	}
-	if err := h.Store.CloseBead(rootBeadID, CloseReasonHandlerRoot); err != nil {
-		return HandlerResult{}, fmt.Errorf("closing root bead: %w", err)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldLastProcessedWisp, wispID); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting last processed wisp: %w", err)
+	// Write terminal_reason and terminal_actor BEFORE state=terminated, close
+	// the root bead, then last_processed_wisp LAST — it is the dedup marker.
+	if err := h.commit(rootBeadID,
+		[]metaWrite{
+			{FieldTerminalReason, reason, "setting terminal reason"},
+			{FieldTerminalActor, actor, "setting terminal actor"},
+			{FieldState, StateTerminated, "setting state to terminated"},
+		},
+		func() error {
+			if err := h.Store.CloseBead(rootBeadID, CloseReasonHandlerRoot); err != nil {
+				return fmt.Errorf("closing root bead: %w", err)
+			}
+			return nil
+		},
+		metaWrite{FieldLastProcessedWisp, wispID, "setting last processed wisp"},
+	); err != nil {
+		return HandlerResult{}, err
 	}
 
 	return HandlerResult{
@@ -770,41 +770,68 @@ func (h *Handler) evaluateGate(
 	}
 }
 
+// metaWrite is a single root-bead metadata assignment applied by commit.
+// desc supplies the error context wrapped around a store failure for that write.
+type metaWrite struct {
+	key, value, desc string
+}
+
+// commit applies a convergence state transition to the root bead, writing the
+// dedup marker LAST. The non-marker writes are applied in order; then preMarker
+// (if non-nil) runs — used to emit critical events and close the root bead
+// before the marker commits; then the marker is written, unless its value is
+// empty (callers that only conditionally stamp the marker pass "").
+//
+// The marker is a dedicated trailing parameter rather than an entry in writes,
+// which makes the "dedup marker written last" ordering contract unrepresentable
+// to violate at a call site: a crash before the marker commits re-processes the
+// wisp instead of skipping it, preserving replay-idempotency.
+func (h *Handler) commit(rootID string, writes []metaWrite, preMarker func() error, marker metaWrite) error {
+	for _, w := range writes {
+		if err := h.Store.SetMetadata(rootID, w.key, w.value); err != nil {
+			return fmt.Errorf("%s: %w", w.desc, err)
+		}
+	}
+	if preMarker != nil {
+		if err := preMarker(); err != nil {
+			return err
+		}
+	}
+	if marker.value == "" {
+		return nil
+	}
+	if err := h.Store.SetMetadata(rootID, marker.key, marker.value); err != nil {
+		return fmt.Errorf("%s: %w", marker.desc, err)
+	}
+	return nil
+}
+
 // persistGateOutcome writes gate results to bead metadata (step 5).
 // Persists the full result for replay fidelity: stdout, stderr, duration,
 // and truncated flag are needed to reconstruct event payloads after crash recovery.
+// gate_outcome_wisp is the idempotency marker and is written LAST via commit.
 func (h *Handler) persistGateOutcome(rootBeadID, wispID string, result GateResult) error {
-	if err := h.Store.SetMetadata(rootBeadID, FieldGateOutcome, result.Outcome); err != nil {
-		return err
-	}
 	exitCode := ""
 	if result.ExitCode != nil {
 		exitCode = EncodeInt(*result.ExitCode)
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldGateExitCode, exitCode); err != nil {
-		return err
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldGateRetryCount, EncodeInt(result.RetryCount)); err != nil {
-		return err
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldGateStdout, result.Stdout); err != nil {
-		return err
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldGateStderr, result.Stderr); err != nil {
-		return err
-	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldGateDurationMs, strconv.FormatInt(result.Duration.Milliseconds(), 10)); err != nil {
-		return err
 	}
 	truncated := ""
 	if result.Truncated {
 		truncated = "true"
 	}
-	if err := h.Store.SetMetadata(rootBeadID, FieldGateTruncated, truncated); err != nil {
-		return err
-	}
-	// Write gate_outcome_wisp LAST — this is the idempotency marker.
-	return h.Store.SetMetadata(rootBeadID, FieldGateOutcomeWisp, wispID)
+	return h.commit(rootBeadID,
+		[]metaWrite{
+			{FieldGateOutcome, result.Outcome, "setting gate outcome"},
+			{FieldGateExitCode, exitCode, "setting gate exit code"},
+			{FieldGateRetryCount, EncodeInt(result.RetryCount), "setting gate retry count"},
+			{FieldGateStdout, result.Stdout, "setting gate stdout"},
+			{FieldGateStderr, result.Stderr, "setting gate stderr"},
+			{FieldGateDurationMs, strconv.FormatInt(result.Duration.Milliseconds(), 10), "setting gate duration"},
+			{FieldGateTruncated, truncated, "setting gate truncated"},
+		},
+		nil,
+		metaWrite{FieldGateOutcomeWisp, wispID, "setting gate outcome wisp"},
+	)
 }
 
 // deriveIterationCount counts closed child wisps with convergence idempotency

--- a/internal/convergence/handler_test.go
+++ b/internal/convergence/handler_test.go
@@ -38,6 +38,10 @@ type fakeStore struct {
 	// enabling tests to verify write ordering contracts.
 	WriteLog []string
 
+	// SetMetadataErrFunc, when non-nil, is consulted before each SetMetadata
+	// write; a non-nil return fails the write (nothing is recorded or stored).
+	SetMetadataErrFunc func(key string) error
+
 	ActivatedWispIDs []string
 }
 
@@ -99,6 +103,11 @@ func (s *fakeStore) GetMetadata(id string) (map[string]string, error) {
 }
 
 func (s *fakeStore) SetMetadata(id, key, value string) error {
+	if s.SetMetadataErrFunc != nil {
+		if err := s.SetMetadataErrFunc(key); err != nil {
+			return err
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	rec, ok := s.beads[id]
@@ -947,6 +956,128 @@ func TestHandleWispClosed_WriteOrdering_WaitingManualLastProcessedWispLast(t *te
 	lastKey := store.WriteLog[len(store.WriteLog)-1]
 	if lastKey != FieldLastProcessedWisp {
 		t.Errorf("last write = %q, want %q (dedup marker must be last)", lastKey, FieldLastProcessedWisp)
+	}
+}
+
+func TestCommit_MarkerWrittenLast(t *testing.T) {
+	writes := []metaWrite{
+		{FieldActiveWisp, "", "clearing active wisp"},
+		{FieldState, StateWaitingManual, "setting state"},
+	}
+
+	tests := []struct {
+		name      string
+		marker    metaWrite
+		preMarker func(recorded *[]string) func() error
+		wantOrder []string
+	}{
+		{
+			name:      "marker after writes",
+			marker:    metaWrite{FieldLastProcessedWisp, "wisp-iter-1", "setting last processed wisp"},
+			wantOrder: []string{FieldActiveWisp, FieldState, FieldLastProcessedWisp},
+		},
+		{
+			name:      "empty marker is skipped",
+			marker:    metaWrite{FieldLastProcessedWisp, "", "setting last processed wisp"},
+			wantOrder: []string{FieldActiveWisp, FieldState},
+		},
+		{
+			name:   "preMarker runs after writes and before marker",
+			marker: metaWrite{FieldLastProcessedWisp, "wisp-iter-1", "setting last processed wisp"},
+			preMarker: func(recorded *[]string) func() error {
+				return func() error {
+					*recorded = append(*recorded, "pre-marker")
+					return nil
+				}
+			},
+			wantOrder: []string{FieldActiveWisp, FieldState, "pre-marker", FieldLastProcessedWisp},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newFakeStore()
+			store.addBead("root-1", "in_progress", "", "", nil)
+			h := &Handler{Store: store}
+
+			var recorded []string
+			var pre func() error
+			if tt.preMarker != nil {
+				// Bridge WriteLog and the pre-marker sentinel into one order slice.
+				pre = func() error {
+					recorded = append(recorded, store.WriteLog...)
+					store.WriteLog = nil
+					return tt.preMarker(&recorded)()
+				}
+			}
+
+			if err := h.commit("root-1", writes, pre, tt.marker); err != nil {
+				t.Fatalf("commit returned error: %v", err)
+			}
+			recorded = append(recorded, store.WriteLog...)
+
+			if len(recorded) != len(tt.wantOrder) {
+				t.Fatalf("write order = %v, want %v", recorded, tt.wantOrder)
+			}
+			for i := range tt.wantOrder {
+				if recorded[i] != tt.wantOrder[i] {
+					t.Errorf("write order = %v, want %v", recorded, tt.wantOrder)
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestCommit_WriteErrorShortCircuitsMarker(t *testing.T) {
+	store := newFakeStore()
+	store.addBead("root-1", "in_progress", "", "", nil)
+	store.SetMetadataErrFunc = func(key string) error {
+		if key == FieldState {
+			return fmt.Errorf("boom")
+		}
+		return nil
+	}
+	h := &Handler{Store: store}
+
+	err := h.commit("root-1",
+		[]metaWrite{
+			{FieldActiveWisp, "", "clearing active wisp"},
+			{FieldState, StateWaitingManual, "setting state"},
+		},
+		nil,
+		metaWrite{FieldLastProcessedWisp, "wisp-iter-1", "setting last processed wisp"},
+	)
+	if err == nil {
+		t.Fatal("commit should return an error when a write fails")
+	}
+	if !contains(err.Error(), "setting state") {
+		t.Errorf("error %q should carry the failing write's desc", err.Error())
+	}
+	for _, key := range store.WriteLog {
+		if key == FieldLastProcessedWisp {
+			t.Fatal("dedup marker must not be written after an earlier write fails")
+		}
+	}
+}
+
+func TestCommit_PreMarkerErrorShortCircuitsMarker(t *testing.T) {
+	store := newFakeStore()
+	store.addBead("root-1", "in_progress", "", "", nil)
+	h := &Handler{Store: store}
+
+	err := h.commit("root-1",
+		[]metaWrite{{FieldState, StateTerminated, "setting state"}},
+		func() error { return fmt.Errorf("close failed") },
+		metaWrite{FieldLastProcessedWisp, "wisp-iter-1", "setting last processed wisp"},
+	)
+	if err == nil {
+		t.Fatal("commit should propagate a preMarker error")
+	}
+	for _, key := range store.WriteLog {
+		if key == FieldLastProcessedWisp {
+			t.Fatal("dedup marker must not be written when preMarker fails")
+		}
 	}
 }
 

--- a/internal/convergence/manual.go
+++ b/internal/convergence/manual.go
@@ -59,22 +59,6 @@ func (h *Handler) ApproveHandler(_ context.Context, beadID, username, _ string) 
 	// Compute cumulative duration for terminated event.
 	_, cumDur := h.computeDurations(beadID, eventWispID)
 
-	// Write ordering: terminal_reason, terminal_actor, clear waiting_reason,
-	// then state=terminated, then EventTerminated (TierCritical, before CloseBead),
-	// then CloseBead, then ManualApprove (TierBestEffort), then last_processed_wisp LAST.
-	if err := h.Store.SetMetadata(beadID, FieldTerminalReason, TerminalApproved); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting terminal reason: %w", err)
-	}
-	if err := h.Store.SetMetadata(beadID, FieldTerminalActor, actor); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting terminal actor: %w", err)
-	}
-	if err := h.Store.SetMetadata(beadID, FieldWaitingReason, ""); err != nil {
-		return HandlerResult{}, fmt.Errorf("clearing waiting reason: %w", err)
-	}
-	if err := h.Store.SetMetadata(beadID, FieldState, StateTerminated); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting state to terminated: %w", err)
-	}
-
 	// Emit EventTerminated BEFORE CloseBead — TierCritical requires at-least-once
 	// delivery, so it must be emitted while the bead is still open for reconciliation
 	// replay if the controller crashes before CloseBead completes.
@@ -85,12 +69,6 @@ func (h *Handler) ApproveHandler(_ context.Context, beadID, username, _ string) 
 		Actor:                actor,
 		CumulativeDurationMs: cumDur.Milliseconds(),
 	}
-	h.emitEvent(EventTerminated, EventIDTerminated(beadID), beadID, termPayload)
-
-	if err := h.Store.CloseBead(beadID, CloseReasonManualApprove); err != nil {
-		return HandlerResult{}, fmt.Errorf("closing bead %q: %w", beadID, err)
-	}
-
 	// Emit ManualApprove AFTER CloseBead — TierBestEffort, fire-and-forget.
 	approvePayload := ManualActionPayload{
 		Actor:      actor,
@@ -99,13 +77,28 @@ func (h *Handler) ApproveHandler(_ context.Context, beadID, username, _ string) 
 		Iteration:  iterationCount,
 		WispID:     NullableString(eventWispID),
 	}
-	h.emitEvent(EventManualApprove, EventIDManualApprove(beadID), beadID, approvePayload)
 
-	// last_processed_wisp LAST — dedup marker contract.
-	if lastProcessedWisp != "" {
-		if err := h.Store.SetMetadata(beadID, FieldLastProcessedWisp, lastProcessedWisp); err != nil {
-			return HandlerResult{}, fmt.Errorf("setting last processed wisp: %w", err)
-		}
+	// Write ordering: terminal_reason, terminal_actor, clear waiting_reason,
+	// then state=terminated, then EventTerminated (TierCritical, before CloseBead),
+	// then CloseBead, then ManualApprove (TierBestEffort), then last_processed_wisp LAST.
+	if err := h.commit(beadID,
+		[]metaWrite{
+			{FieldTerminalReason, TerminalApproved, "setting terminal reason"},
+			{FieldTerminalActor, actor, "setting terminal actor"},
+			{FieldWaitingReason, "", "clearing waiting reason"},
+			{FieldState, StateTerminated, "setting state to terminated"},
+		},
+		func() error {
+			h.emitEvent(EventTerminated, EventIDTerminated(beadID), beadID, termPayload)
+			if err := h.Store.CloseBead(beadID, CloseReasonManualApprove); err != nil {
+				return fmt.Errorf("closing bead %q: %w", beadID, err)
+			}
+			h.emitEvent(EventManualApprove, EventIDManualApprove(beadID), beadID, approvePayload)
+			return nil
+		},
+		metaWrite{FieldLastProcessedWisp, lastProcessedWisp, "setting last processed wisp"},
+	); err != nil {
+		return HandlerResult{}, err
 	}
 
 	return HandlerResult{
@@ -364,59 +357,7 @@ func (h *Handler) StopHandler(ctx context.Context, beadID, username, _ string) (
 	// Compute cumulative duration for terminated event.
 	_, cumDur := h.computeDurations(beadID, eventWispID)
 
-	// Step 6: Write ordering: terminal_reason, terminal_actor, clear waiting_reason,
-	// then state=terminated.
-	if err := h.Store.SetMetadata(beadID, FieldTerminalReason, TerminalStopped); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting terminal reason: %w", err)
-	}
-	if err := h.Store.SetMetadata(beadID, FieldTerminalActor, actor); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting terminal actor: %w", err)
-	}
-	if err := h.Store.SetMetadata(beadID, FieldWaitingReason, ""); err != nil {
-		return HandlerResult{}, fmt.Errorf("clearing waiting reason: %w", err)
-	}
-	if err := h.Store.SetMetadata(beadID, FieldState, StateTerminated); err != nil {
-		return HandlerResult{}, fmt.Errorf("setting state to terminated: %w", err)
-	}
-
-	// Step 7a: Emit synthetic ConvergenceIteration for force-closed wisp
-	// BEFORE CloseBead — TierCritical requires at-least-once delivery.
-	if forceClosedWisp && activeWisp != "" {
-		wispIteration := iterationCount // force-closed wisp is the latest
-		iterDur, synthCumDur := h.computeDurations(beadID, activeWisp)
-		gateMode := meta[FieldGateMode]
-		if gateMode == "" {
-			gateMode = GateModeManual
-		}
-		synthPayload := IterationPayload{
-			Iteration:            wispIteration,
-			WispID:               activeWisp,
-			Action:               string(ActionStopped),
-			GateMode:             gateMode,
-			IterationDurationMs:  iterDur.Milliseconds(),
-			CumulativeDurationMs: synthCumDur.Milliseconds(),
-		}
-		h.emitEvent(EventIteration, EventIDIteration(beadID, wispIteration), beadID, synthPayload)
-	}
-
-	// Step 7b: Emit EventTerminated BEFORE CloseBead — TierCritical requires
-	// at-least-once delivery, so it must be emitted while the bead is still
-	// open for reconciliation replay if the controller crashes.
-	termPayload := TerminatedPayload{
-		TerminalReason:       TerminalStopped,
-		TotalIterations:      iterationCount,
-		FinalStatus:          "closed",
-		Actor:                actor,
-		CumulativeDurationMs: cumDur.Milliseconds(),
-	}
-	h.emitEvent(EventTerminated, EventIDTerminated(beadID), beadID, termPayload)
-
-	// Step 8: CloseBead.
-	if err := h.Store.CloseBead(beadID, CloseReasonManualStop); err != nil {
-		return HandlerResult{}, fmt.Errorf("closing bead %q: %w", beadID, err)
-	}
-
-	// Step 9: Emit ManualStop AFTER CloseBead — TierBestEffort, fire-and-forget.
+	// Step 9: ManualStop is emitted AFTER CloseBead — TierBestEffort, fire-and-forget.
 	stopPayload := ManualActionPayload{
 		Actor:      actor,
 		PriorState: state,
@@ -424,18 +365,69 @@ func (h *Handler) StopHandler(ctx context.Context, beadID, username, _ string) (
 		Iteration:  iterationCount,
 		WispID:     NullableString(eventWispID),
 	}
-	h.emitEvent(EventManualStop, EventIDManualStop(beadID), beadID, stopPayload)
 
-	// Step 10: last_processed_wisp LAST — dedup marker contract.
-	// After force-close, the force-closed wisp becomes the highest closed wisp.
+	// Step 10: after force-close, the force-closed wisp becomes the highest
+	// closed wisp, so it is the dedup marker.
 	finalLPW := lastProcessedWisp
 	if forceClosedWisp && activeWisp != "" {
 		finalLPW = activeWisp
 	}
-	if finalLPW != "" {
-		if err := h.Store.SetMetadata(beadID, FieldLastProcessedWisp, finalLPW); err != nil {
-			return HandlerResult{}, fmt.Errorf("setting last processed wisp: %w", err)
-		}
+
+	// Steps 6-10 commit: terminal_reason, terminal_actor, clear waiting_reason,
+	// state=terminated; then (7a synthetic iteration, 7b EventTerminated,
+	// 8 CloseBead, 9 ManualStop) before the dedup marker; last_processed_wisp LAST.
+	if err := h.commit(beadID,
+		[]metaWrite{
+			{FieldTerminalReason, TerminalStopped, "setting terminal reason"},
+			{FieldTerminalActor, actor, "setting terminal actor"},
+			{FieldWaitingReason, "", "clearing waiting reason"},
+			{FieldState, StateTerminated, "setting state to terminated"},
+		},
+		func() error {
+			// Step 7a: Emit synthetic ConvergenceIteration for force-closed wisp
+			// BEFORE CloseBead — TierCritical requires at-least-once delivery.
+			if forceClosedWisp && activeWisp != "" {
+				wispIteration := iterationCount // force-closed wisp is the latest
+				iterDur, synthCumDur := h.computeDurations(beadID, activeWisp)
+				gateMode := meta[FieldGateMode]
+				if gateMode == "" {
+					gateMode = GateModeManual
+				}
+				synthPayload := IterationPayload{
+					Iteration:            wispIteration,
+					WispID:               activeWisp,
+					Action:               string(ActionStopped),
+					GateMode:             gateMode,
+					IterationDurationMs:  iterDur.Milliseconds(),
+					CumulativeDurationMs: synthCumDur.Milliseconds(),
+				}
+				h.emitEvent(EventIteration, EventIDIteration(beadID, wispIteration), beadID, synthPayload)
+			}
+
+			// Step 7b: Emit EventTerminated BEFORE CloseBead — TierCritical requires
+			// at-least-once delivery, so it must be emitted while the bead is still
+			// open for reconciliation replay if the controller crashes.
+			termPayload := TerminatedPayload{
+				TerminalReason:       TerminalStopped,
+				TotalIterations:      iterationCount,
+				FinalStatus:          "closed",
+				Actor:                actor,
+				CumulativeDurationMs: cumDur.Milliseconds(),
+			}
+			h.emitEvent(EventTerminated, EventIDTerminated(beadID), beadID, termPayload)
+
+			// Step 8: CloseBead.
+			if err := h.Store.CloseBead(beadID, CloseReasonManualStop); err != nil {
+				return fmt.Errorf("closing bead %q: %w", beadID, err)
+			}
+
+			// Step 9: Emit ManualStop AFTER CloseBead.
+			h.emitEvent(EventManualStop, EventIDManualStop(beadID), beadID, stopPayload)
+			return nil
+		},
+		metaWrite{FieldLastProcessedWisp, finalLPW, "setting last processed wisp"},
+	); err != nil {
+		return HandlerResult{}, err
 	}
 
 	return HandlerResult{


### PR DESCRIPTION
## What this does

Lands **S30** — centralizes the convergence marker-last write ordering (the
crash-safety contract) into a structural commit-point helper
(`internal/convergence`, handler.go + manual.go). Zero interface change,
behavior-preserving; new `handler_test.go` coverage.

## Gates

- `go build ./internal/convergence ./cmd/gc` — pass
- `go vet ./internal/convergence` — pass
- `golangci-lint ./internal/convergence/...` — 0 issues
- `go test ./internal/convergence` — pass

## Review verdict

LAND — fast-track (no `status/needs-review-auto` label), crash-safety-ordering
centralization, behavior-preserving, per the simplification walkthrough. Merge
after CI green; delete branch on merge.

Note: same `internal/convergence` cluster as S31 (#4040, handler/manual) and
S33 (#4041, reconcile) — whichever lands after the first will be merged with
conflict resolution. Doc-overclaim nit ("type-impossible" → convention-enforced)
left for auto-review.
