### PR TITLE
simplify(S34): rebuild convergence scopes on reload; delete the #2403 taxonomy

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2017,6 +2017,12 @@ func (cr *CityRuntime) reloadConfigTraced(
 		cr.standaloneRigStores = buildStandaloneRigStores(nextCfg, cr.cityPath, cr.stderr)
 	}
 
+	// Rebuild convergence scopes against the reloaded config so rigs added,
+	// removed, or rebound by this reload are honored live (#2403). New
+	// scopes repopulate their active index via the needsStartupReconcile
+	// path on the next tick.
+	cr.rebuildConvergenceHandler()
+
 	// Ensure drain tracker and provider-health gate are initialized when bead store becomes available.
 	if cr.cityBeadStore() != nil && cr.tomlPath != "" && cr.sessionDrains == nil {
 		cr.sessionDrains = newDrainTracker()

--- a/cmd/gc/convergence_integration_test.go
+++ b/cmd/gc/convergence_integration_test.go
@@ -656,54 +656,27 @@ func TestConvergence_StartupReconcileRetriesFailedScopeOnTick(t *testing.T) {
 	}
 }
 
-func TestConvergenceScopeForRigRejectsStaleCachedScope(t *testing.T) {
+func TestConvergenceScopeForRigUnboundAndUnknown(t *testing.T) {
 	tests := []struct {
 		name      string
 		setup     func(t *testing.T, cr *CityRuntime)
 		wantError string
 	}{
 		{
-			name: "cached rig path changed",
+			name: "unbound rig fails loud (#2357)",
 			setup: func(t *testing.T, cr *CityRuntime) {
 				t.Helper()
-				oldPath := filepath.Join(cr.cityPath, "rigs", "prod-old")
-				newPath := filepath.Join(cr.cityPath, "rigs", "prod-new")
-				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
-				addConvergenceRigScopeAt(cr, "prod", beads.NewMemStore(), oldPath)
-				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: newPath}}
-			},
-			wantError: "changed after config reload",
-		},
-		{
-			name: "cached rig became unbound",
-			setup: func(t *testing.T, cr *CityRuntime) {
-				t.Helper()
-				oldPath := filepath.Join(cr.cityPath, "rigs", "prod")
-				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
-				addConvergenceRigScopeAt(cr, "prod", beads.NewMemStore(), oldPath)
 				cr.cfg.Rigs = []config.Rig{{Name: "prod"}}
 			},
-			wantError: "became unbound after config reload",
+			wantError: "no bead store",
 		},
 		{
-			name: "cached rig removed",
+			name: "unregistered rig",
 			setup: func(t *testing.T, cr *CityRuntime) {
 				t.Helper()
-				oldPath := filepath.Join(cr.cityPath, "rigs", "prod")
-				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
-				addConvergenceRigScopeAt(cr, "prod", beads.NewMemStore(), oldPath)
 				cr.cfg.Rigs = nil
 			},
-			wantError: "was removed from city config",
-		},
-		{
-			name: "bound rig lacks cached scope",
-			setup: func(t *testing.T, cr *CityRuntime) {
-				t.Helper()
-				path := filepath.Join(cr.cityPath, "rigs", "prod")
-				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: path}}
-			},
-			wantError: "is bound but convergence scopes were not rebuilt",
+			wantError: "is not registered in this city",
 		},
 	}
 
@@ -714,7 +687,7 @@ func TestConvergenceScopeForRigRejectsStaleCachedScope(t *testing.T) {
 
 			scope, err := cr.convergenceScopeForRig("prod")
 			if err == nil {
-				t.Fatal("expected stale cached scope error")
+				t.Fatal("expected error for unbound/unknown rig")
 			}
 			if scope != nil {
 				t.Fatalf("scope = %#v, want nil", scope)
@@ -726,85 +699,71 @@ func TestConvergenceScopeForRigRejectsStaleCachedScope(t *testing.T) {
 	}
 }
 
-func TestConvergenceTickSkipsStaleCachedRigScope(t *testing.T) {
+// TestConvergenceRebuildAddsRigScope proves the #2403 fix: a rig added by a
+// config reload is picked up live by rebuildConvergenceHandler instead of
+// requiring a controller restart. The new scope is marked
+// needsStartupReconcile so the tick machinery populates its active index.
+func TestConvergenceRebuildAddsRigScope(t *testing.T) {
 	cr, _ := setupConvergenceRuntime(t)
+	if _, err := cr.convergenceScopeForRig("prod"); err == nil {
+		t.Fatal("prod scope should not exist before reload")
+	}
+
 	rigStore := beads.NewMemStore()
-	oldPath := filepath.Join(cr.cityPath, "rigs", "prod-old")
-	newPath := filepath.Join(cr.cityPath, "rigs", "prod-new")
-	cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
-	rigScope := addConvergenceRigScopeAt(cr, "prod", rigStore, oldPath)
+	rigPath := filepath.Join(cr.cityPath, "rigs", "prod")
+	cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: rigPath}}
+	cr.standaloneRigStores = map[string]beads.Store{"prod": rigStore}
 
-	createReply := sendAndReceive(t, cr, convergenceRequest{
-		Command: "create",
-		Params: map[string]string{
-			"formula":        "test-formula",
-			"target":         "test-agent",
-			"max_iterations": "5",
-			"rig":            "prod",
-		},
-	})
-	if createReply.Error != "" {
-		t.Fatalf("create error: %s", createReply.Error)
-	}
-	var created convergence.CreateResult
-	if err := json.Unmarshal(createReply.Result, &created); err != nil {
-		t.Fatalf("unmarshaling: %v", err)
-	}
-	if err := rigScope.adapter.populateIndex(); err != nil {
-		t.Fatalf("populateIndex: %v", err)
-	}
-	if err := rigStore.Close(created.FirstWispID); err != nil {
-		t.Fatalf("closing wisp: %v", err)
-	}
-	cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: newPath}}
+	cr.rebuildConvergenceHandler()
 
-	cr.convergenceTick(context.Background())
-
-	meta, err := rigScope.handler.Store.GetMetadata(created.BeadID)
+	scope, err := cr.convergenceScopeForRig("prod")
 	if err != nil {
-		t.Fatalf("GetMetadata: %v", err)
+		t.Fatalf("prod scope missing after rebuild: %v", err)
 	}
-	if got := meta[convergence.FieldState]; got != convergence.StateActive {
-		t.Fatalf("state after stale-scope tick = %q, want %q", got, convergence.StateActive)
+	if scope == nil {
+		t.Fatal("prod scope nil after rebuild")
 	}
-	if !strings.Contains(cr.stderr.(*bytes.Buffer).String(), "changed after config reload") {
-		t.Fatalf("stderr = %q, want stale-scope diagnostic", cr.stderr.(*bytes.Buffer).String())
+	if !scope.needsStartupReconcile {
+		t.Fatal("rebuilt scope should be marked needsStartupReconcile")
+	}
+
+	// The next tick reconciles and populates the new scope's active index.
+	cr.convergenceTickScope(context.Background(), scope)
+	if scope.needsStartupReconcile {
+		t.Fatal("scope should be reconciled after a tick")
+	}
+	if scope.adapter.activeIndex == nil {
+		t.Fatal("active index should be populated after a tick")
 	}
 }
 
-func TestConvergenceStartupReconcileSkipsRemovedRigScope(t *testing.T) {
+// TestConvergenceRebuildDropsRemovedRigScope proves a rig removed by a
+// config reload no longer resolves to a scope after rebuild.
+func TestConvergenceRebuildDropsRemovedRigScope(t *testing.T) {
 	cr, _ := setupConvergenceRuntime(t)
 	rigStore := beads.NewMemStore()
-	oldPath := filepath.Join(cr.cityPath, "rigs", "prod")
-	cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
-	addConvergenceRigScopeAt(cr, "prod", rigStore, oldPath)
+	rigPath := filepath.Join(cr.cityPath, "rigs", "prod")
+	cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: rigPath}}
+	cr.standaloneRigStores = map[string]beads.Store{"prod": rigStore}
+	cr.rebuildConvergenceHandler()
+	if _, err := cr.convergenceScopeForRig("prod"); err != nil {
+		t.Fatalf("prod scope should exist after first rebuild: %v", err)
+	}
 
-	b, err := rigStore.Create(beads.Bead{Title: "terminated", Type: "convergence", Status: "in_progress"})
-	if err != nil {
-		t.Fatalf("creating bead: %v", err)
-	}
-	for key, value := range map[string]string{
-		convergence.FieldState:          convergence.StateTerminated,
-		convergence.FieldTerminalReason: convergence.TerminalApproved,
-		convergence.FieldTerminalActor:  "controller",
-	} {
-		if err := rigStore.SetMetadata(b.ID, key, value); err != nil {
-			t.Fatalf("setting %s: %v", key, err)
-		}
-	}
+	// Remove the rig from config and rebuild.
 	cr.cfg.Rigs = nil
+	cr.standaloneRigStores = nil
+	cr.rebuildConvergenceHandler()
 
-	cr.convergenceStartupReconcile(context.Background())
-
-	got, err := rigStore.Get(b.ID)
-	if err != nil {
-		t.Fatalf("Get: %v", err)
+	scope, err := cr.convergenceScopeForRig("prod")
+	if err == nil {
+		t.Fatal("prod scope should be gone after removal rebuild")
 	}
-	if got.Status == "closed" {
-		t.Fatalf("status after stale-scope startup reconcile = %q, want unclosed", got.Status)
+	if scope != nil {
+		t.Fatalf("scope = %#v, want nil", scope)
 	}
-	if !strings.Contains(cr.stderr.(*bytes.Buffer).String(), "was removed from city config") {
-		t.Fatalf("stderr = %q, want removed-rig diagnostic", cr.stderr.(*bytes.Buffer).String())
+	if !strings.Contains(err.Error(), "is not registered in this city") {
+		t.Fatalf("error = %q, want not-registered diagnostic", err)
 	}
 }
 

--- a/cmd/gc/convergence_tick.go
+++ b/cmd/gc/convergence_tick.go
@@ -65,16 +65,14 @@ func (s *convergenceScope) triggerName(prefix string) string {
 	return prefix + "-rig-" + s.rig
 }
 
-// initConvergenceHandler builds one convergence scope per available bead
-// store: the city/HQ store plus every bound rig store. Called once during
-// CityRuntime.run() initialization.
-//
-// TODO(#2403): rigs added by a later config reload are not picked up until
-// the controller restarts — convScopes is not rebuilt on reload.
-func (cr *CityRuntime) initConvergenceHandler() {
+// buildConvergenceScopes derives one convergence scope per available bead
+// store from the current config: the city/HQ store plus every bound rig
+// store. Returns nil when no city store is available yet, in which case
+// callers leave the existing scopes untouched.
+func (cr *CityRuntime) buildConvergenceScopes() map[string]*convergenceScope {
 	cityStore := cr.cityBeadStore()
 	if cityStore == nil {
-		return
+		return nil
 	}
 	scopes := map[string]*convergenceScope{
 		"": cr.newConvergenceScope("", cityStore, cr.cityPath, cr.cfg.FormulaLayers.City),
@@ -86,6 +84,39 @@ func (cr *CityRuntime) initConvergenceHandler() {
 		}
 		scopes[rigName] = cr.newConvergenceScope(
 			rigName, store, rigStorePaths[rigName], cr.cfg.FormulaLayers.SearchPaths(rigName))
+	}
+	return scopes
+}
+
+// initConvergenceHandler builds one convergence scope per available bead
+// store: the city/HQ store plus every bound rig store. Called once during
+// CityRuntime.run() initialization; convergenceStartupReconcile then
+// reconciles and populates each scope's active index.
+func (cr *CityRuntime) initConvergenceHandler() {
+	scopes := cr.buildConvergenceScopes()
+	if scopes == nil {
+		return
+	}
+	cr.convScopesMu.Lock()
+	cr.convScopes = scopes
+	cr.convScopesMu.Unlock()
+}
+
+// rebuildConvergenceHandler re-derives all convergence scopes from the
+// current config after a reload, replacing the in-memory scope map
+// wholesale. Rigs added, removed, or rebound by the reload are honored
+// live instead of divergence being detected and punted to a controller
+// restart (the #2403 bug class). Each rebuilt scope is marked
+// needsStartupReconcile so the existing tick machinery
+// (convergenceTickScope) reconciles interrupted beads and repopulates its
+// active index on the next tick.
+func (cr *CityRuntime) rebuildConvergenceHandler() {
+	scopes := cr.buildConvergenceScopes()
+	if scopes == nil {
+		return
+	}
+	for _, scope := range scopes {
+		scope.needsStartupReconcile = true
 	}
 	cr.convScopesMu.Lock()
 	cr.convScopes = scopes
@@ -167,59 +198,30 @@ func unboundRigConvergenceError(rig string) error {
 }
 
 // convergenceScopeForRig returns the convergence scope for a rig name. An
-// empty rig selects the city/HQ scope. An unknown or unbound rig is an
-// error so a mistyped or unbound --rig fails loudly instead of silently
-// writing the bead to HQ (the defect tracked in issue #2357). The error
-// distinguishes a misspelled rig from a registered-but-unusable one.
+// empty rig selects the city/HQ scope. Config reloads rebuild convScopes
+// (rebuildConvergenceHandler), so a bound rig always has a live scope. An
+// unknown or unbound rig is an error so a mistyped or unbound --rig fails
+// loudly instead of silently writing the bead to HQ (the defect tracked in
+// issue #2357).
 func (cr *CityRuntime) convergenceScopeForRig(rig string) (*convergenceScope, error) {
 	if cr.convScopes == nil {
 		return nil, fmt.Errorf("convergence not available (no bead store)")
 	}
 	if scope, ok := cr.convScopes[rig]; ok {
-		if rig == "" {
-			return scope, nil
-		}
-		for _, candidate := range cr.convergenceRigSnapshot() {
-			if candidate.Name != rig {
-				continue
-			}
-			if strings.TrimSpace(candidate.Path) == "" {
-				return nil, fmt.Errorf("rig %q became unbound after config reload but convergence scopes were not rebuilt; restart the controller (#2403)", rig)
-			}
-			currentPath := resolveStoreScopeRoot(cr.cityPath, candidate.Path)
-			if currentPath != scope.storePath {
-				return nil, fmt.Errorf("rig %q bead store changed after config reload from %q to %q; restart the controller (#2403)", rig, scope.storePath, currentPath)
-			}
-			return scope, nil
-		}
-		return nil, fmt.Errorf("rig %q was removed from city config but convergence scopes were not rebuilt; restart the controller (#2403)", rig)
+		return scope, nil
 	}
+	// No scope for this rig: distinguish an unbound rig (#2357: fail loud
+	// instead of silently writing to HQ) from a misspelled or unregistered
+	// one.
 	for _, candidate := range cr.convergenceRigSnapshot() {
 		if candidate.Name == rig {
 			if strings.TrimSpace(candidate.Path) == "" {
 				return nil, unboundRigConvergenceError(rig)
 			}
-			return nil, fmt.Errorf("rig %q is bound but convergence scopes were not rebuilt after config reload; restart the controller (#2403)", rig)
+			return nil, fmt.Errorf("rig %q is registered but has no convergence scope", rig)
 		}
 	}
 	return nil, fmt.Errorf("rig %q is not registered in this city", rig)
-}
-
-func (cr *CityRuntime) validateConvergenceScopeCurrent(scope *convergenceScope) error {
-	if scope == nil {
-		return fmt.Errorf("convergence scope is nil")
-	}
-	current, err := cr.convergenceScopeForRig(scope.rig)
-	if err != nil {
-		return err
-	}
-	if current != scope {
-		if scope.rig == "" {
-			return fmt.Errorf("city/HQ convergence scope was rebuilt; skipping stale cached scope")
-		}
-		return fmt.Errorf("rig %q convergence scope was rebuilt; skipping stale cached scope", scope.rig)
-	}
-	return nil
 }
 
 // convergenceTick processes active convergence loops in every scope — the
@@ -242,11 +244,6 @@ func (cr *CityRuntime) convergenceTick(ctx context.Context) {
 // instead of O(all beads)).
 func (cr *CityRuntime) convergenceTickScope(ctx context.Context, scope *convergenceScope) {
 	if scope == nil || scope.adapter == nil {
-		return
-	}
-	if err := cr.validateConvergenceScopeCurrent(scope); err != nil {
-		fmt.Fprintf(cr.stderr, "%s: convergence%s: skipping stale scope: %v\n", //nolint:errcheck
-			cr.logPrefix, scope.logSuffix(), err)
 		return
 	}
 	if scope.needsStartupReconcile {
@@ -559,11 +556,6 @@ func (cr *CityRuntime) convergenceStartupReconcile(ctx context.Context) {
 // beads in one scope's store and then populates that scope's active index.
 func (cr *CityRuntime) convergenceStartupReconcileScope(ctx context.Context, scope *convergenceScope) {
 	if scope == nil {
-		return
-	}
-	if err := cr.validateConvergenceScopeCurrent(scope); err != nil {
-		fmt.Fprintf(cr.stderr, "%s: convergence reconcile%s: skipping stale scope: %v\n", //nolint:errcheck
-			cr.logPrefix, scope.logSuffix(), err)
 		return
 	}
 	// List() waits for CachingStore prime if not yet live, then serves


### PR DESCRIPTION
## What this does

Lands **S34** (approach **b**, wholesale re-derive) — rebuilds convergence
scopes on reload and deletes the whole #2403 detect-and-punt staleness taxonomy
(+ 4 restart-controller branches). `convergenceScopeForRig` becomes a map lookup
with #2357 fail-loud. Net −43. Touches `cmd/gc/convergence_tick.go` +
`city_runtime.go` (distinct from the S31/S33/S30 `internal/convergence` files,
so low conflict risk).

## Gates

- `go build ./cmd/gc` — pass
- `go vet ./cmd/gc` — pass
- `golangci-lint ./cmd/gc/...` — 0 issues
- `go test ./cmd/gc` convergence/reload/scope (`-run`) — pass

## Review verdict

LAND via label PR (`status/needs-review-auto`) — deletes a whole taxonomy +
restart branches; auto-review pass per the simplification walkthrough.

Optional nits left for auto-review (not folded): add a rebound-rig test; a
one-line comment on the nil-activeIndex window.
