### PR TITLE
simplify(S38): durable gc.control_for lineage (retire findLatestAttempt ref-string surgery)

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -1462,13 +1462,16 @@ func controlIdentitySet(control beads.Bead) map[string]bool {
 
 // legacyAttemptLineageHits counts attempt-lineage recoveries served by the
 // deprecated pre-S38 ref-string cascade rather than the gc.control_for stamp.
-// Operators watch this drain to zero before the legacy path is deleted (S38
-// Phase 4). Package-level counter (not an event type) per the S38
-// trace-observability note.
+// It is an in-process test hook, not a production operator surface: the
+// deletion gate for the legacy cascade (S38 Phase 4) is enforced by the
+// shadow-parity tests proving the primary stamp path subsumes the cascade,
+// with this counter asserted to stay at zero over post-S38 candidate shapes.
+// Package-level counter (not an event type) per the S38 trace-observability
+// note; wire it to a trace/metric before relying on it in production.
 var legacyAttemptLineageHits int64
 
 // legacyAttemptLineageHitCount reports the number of attempt-lineage recoveries
-// served by the deprecated ref-string cascade. Observability/test hook.
+// served by the deprecated ref-string cascade. In-process test hook.
 func legacyAttemptLineageHitCount() int64 {
 	return atomic.LoadInt64(&legacyAttemptLineageHits)
 }

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -1476,7 +1476,7 @@ func legacyAttemptLineageHitCount() int64 {
 // latestAttemptFromCandidatesLegacyRefSurgery recovers attempt lineage by
 // parsing dotted step refs through a four-stage cascade.
 //
-// DEPRECATED: remove after the release following S38 — serves only molecules
+// Deprecated: remove after the release following S38 — serves only molecules
 // minted before the gc.control_for stamp existed. New attempts resolve on the
 // primary equality path in latestAttemptFromCandidates.
 func latestAttemptFromCandidatesLegacyRefSurgery(control beads.Bead, candidates []beads.Bead) beads.Bead {

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -633,6 +634,13 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 	rootMeta[beadmeta.AttemptMetadataKey] = strconv.Itoa(attemptNum)
 	rootMeta[beadmeta.StepIDMetadataKey] = stepID
 	rootMeta[beadmeta.StepRefMetadataKey] = attemptPrefix
+	// gc.control_for is the durable lineage pointer back to the control bead.
+	// Written AFTER the step.Metadata copy loop so a formula-authored value
+	// cannot shadow it. control.ID is a real store bead ID for top-level mints
+	// and the control's namespaced step ref for nested seeds
+	// (buildNestedControlSeed) — both are covered by findLatestAttempt's
+	// identity set.
+	rootMeta[beadmeta.ControlForMetadataKey] = control.ID
 	if step.OnComplete != nil {
 		rootMeta[beadmeta.OutputJSONRequiredMetadataKey] = "true"
 	}
@@ -1342,9 +1350,11 @@ func isFailedPartialMolecule(bead beads.Bead) bool {
 	return strings.TrimSpace(bead.Metadata["molecule_failed"]) == "true"
 }
 
-// findLatestAttempt finds the most recent attempt/iteration child of a control bead.
-// Matches by gc.step_ref pattern: the attempt's step_ref ends with
-// .attempt.N or .iteration.N where the prefix matches the control's step_ref.
+// findLatestAttempt finds the most recent attempt/iteration child of a control
+// bead. It lists beads under the workflow root and, on empty result, walks the
+// control's blocks-dependencies; both feed latestAttemptFromCandidates, which
+// matches the durable gc.control_for lineage stamp (with a legacy ref-string
+// fallback for pre-S38 molecules) and returns the max gc.attempt.
 func findLatestAttempt(store beads.Store, control beads.Bead) (beads.Bead, error) {
 	rootID := control.Metadata[beadmeta.RootBeadIDMetadataKey]
 	if rootID == "" {
@@ -1391,7 +1401,85 @@ func latestAttemptFromDependencies(store beads.Store, control beads.Bead) (beads
 	return latestAttemptFromCandidates(control, candidates), nil
 }
 
+// latestAttemptFromCandidates selects the control's latest attempt/iteration
+// root among candidates.
+//
+// Primary path (S38): match the durable gc.control_for lineage stamp against
+// the control's identity set — one string equality plus an integer max, no ref
+// parsing. Every attempt/iteration root minted since S38 carries this stamp
+// (buildAttemptRecipe and the compile-time first-attempt seeds). When no
+// candidate carries a matching stamp (in-flight molecules minted before S38),
+// it falls back to the deprecated ref-string cascade.
 func latestAttemptFromCandidates(control beads.Bead, candidates []beads.Bead) beads.Bead {
+	identity := controlIdentitySet(control)
+
+	var latest beads.Bead
+	latestAttempt := 0
+	for _, b := range candidates {
+		if isFailedPartialMolecule(b) {
+			continue
+		}
+		// Skip beads that are control infrastructure, not actual work. On the
+		// primary path only this control's own attempt roots carry its identity,
+		// so no scope-unless-ralph skip is needed (see legacy fallback).
+		if latestAttemptCandidateIsControlInfrastructure(b.Metadata[beadmeta.KindMetadataKey]) {
+			continue
+		}
+		cf := strings.TrimSpace(b.Metadata[beadmeta.ControlForMetadataKey])
+		if cf == "" || !identity[cf] {
+			continue
+		}
+		attemptNum, _ := strconv.Atoi(b.Metadata[beadmeta.AttemptMetadataKey])
+		if attemptNum > latestAttempt {
+			latestAttempt = attemptNum
+			latest = b
+		}
+	}
+	if latest.ID != "" {
+		return latest
+	}
+	return latestAttemptFromCandidatesLegacyRefSurgery(control, candidates)
+}
+
+// controlIdentitySet returns the non-empty members of the control's identity:
+// its store bead ID plus its namespaced step ref and bare step id. A
+// gc.control_for stamp equal to any member points at this control (bead-ID
+// stamps come from runtime top-level mints; step-ref/step-id stamps come from
+// compile-time and nested seeds — see S38).
+func controlIdentitySet(control beads.Bead) map[string]bool {
+	identity := make(map[string]bool, 3)
+	for _, v := range []string{
+		control.ID,
+		control.Metadata[beadmeta.StepRefMetadataKey],
+		control.Metadata[beadmeta.StepIDMetadataKey],
+	} {
+		if v = strings.TrimSpace(v); v != "" {
+			identity[v] = true
+		}
+	}
+	return identity
+}
+
+// legacyAttemptLineageHits counts attempt-lineage recoveries served by the
+// deprecated pre-S38 ref-string cascade rather than the gc.control_for stamp.
+// Operators watch this drain to zero before the legacy path is deleted (S38
+// Phase 4). Package-level counter (not an event type) per the S38
+// trace-observability note.
+var legacyAttemptLineageHits int64
+
+// legacyAttemptLineageHitCount reports the number of attempt-lineage recoveries
+// served by the deprecated ref-string cascade. Observability/test hook.
+func legacyAttemptLineageHitCount() int64 {
+	return atomic.LoadInt64(&legacyAttemptLineageHits)
+}
+
+// latestAttemptFromCandidatesLegacyRefSurgery recovers attempt lineage by
+// parsing dotted step refs through a four-stage cascade.
+//
+// DEPRECATED: remove after the release following S38 — serves only molecules
+// minted before the gc.control_for stamp existed. New attempts resolve on the
+// primary equality path in latestAttemptFromCandidates.
+func latestAttemptFromCandidatesLegacyRefSurgery(control beads.Bead, candidates []beads.Bead) beads.Bead {
 	controlRef := control.Metadata[beadmeta.StepRefMetadataKey]
 	if controlRef == "" {
 		controlRef = control.ID
@@ -1467,6 +1555,9 @@ func latestAttemptFromCandidates(control beads.Bead, candidates []beads.Bead) be
 			latestAttempt = attemptNum
 			latest = b
 		}
+	}
+	if latest.ID != "" {
+		atomic.AddInt64(&legacyAttemptLineageHits, 1)
 	}
 	return latest
 }

--- a/internal/dispatch/control_for_lineage_test.go
+++ b/internal/dispatch/control_for_lineage_test.go
@@ -1,0 +1,271 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/formula"
+)
+
+// TestBuildAttemptRecipeStampsControlFor asserts W4/W5: buildAttemptRecipe
+// stamps gc.control_for = control.ID on the attempt root, after the
+// step.Metadata copy loop so a formula-authored value cannot shadow it.
+func TestBuildAttemptRecipeStampsControlFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("top-level mint uses control bead ID", func(t *testing.T) {
+		step := &formula.Step{
+			ID:    "review",
+			Type:  "task",
+			Retry: &formula.RetrySpec{MaxAttempts: 3},
+			// A formula-authored control_for must NOT survive — the stamp is
+			// written after the copy loop.
+			Metadata: map[string]string{"gc.control_for": "formula-authored-junk"},
+		}
+		control := beads.Bead{
+			ID: "gc-control-1",
+			Metadata: map[string]string{
+				"gc.step_id":  "review",
+				"gc.step_ref": "mol-test.review",
+			},
+		}
+		recipe := buildAttemptRecipe(step, control, 2)
+		root := recipe.Steps[0]
+		if got := root.Metadata["gc.control_for"]; got != "gc-control-1" {
+			t.Fatalf("root gc.control_for = %q, want gc-control-1 (formula value must be overridden)", got)
+		}
+	})
+
+	t.Run("nested seed uses namespaced child ref", func(t *testing.T) {
+		child := &formula.Step{
+			ID:    "inner",
+			Type:  "task",
+			Ralph: &formula.RalphSpec{MaxAttempts: 2, Check: &formula.RalphCheckSpec{Mode: "exec", Path: "c.sh"}},
+		}
+		// buildNestedControlSeed mints via a synthetic control whose .ID is the
+		// namespaced child ref; W4's stamp yields that ref.
+		synthetic := beads.Bead{
+			ID:       "mol.outer.iteration.2.inner",
+			Metadata: map[string]string{"gc.step_id": "inner", "gc.step_ref": "mol.outer.iteration.2.inner"},
+		}
+		recipe := buildAttemptRecipe(child, synthetic, 1)
+		root := recipe.Steps[0]
+		if got := root.Metadata["gc.control_for"]; got != "mol.outer.iteration.2.inner" {
+			t.Fatalf("nested seed gc.control_for = %q, want mol.outer.iteration.2.inner", got)
+		}
+	})
+}
+
+// controlBead is a small helper to build a control bead with an identity set.
+func controlBead(id, stepRef, stepID, kind string) beads.Bead {
+	return beads.Bead{ID: id, Metadata: map[string]string{
+		"gc.kind":     kind,
+		"gc.step_ref": stepRef,
+		"gc.step_id":  stepID,
+	}}
+}
+
+// stampedAttempt builds an attempt-root candidate carrying gc.control_for.
+func stampedAttempt(id, controlFor string, attempt string, kind string) beads.Bead {
+	m := map[string]string{
+		"gc.control_for": controlFor,
+		"gc.attempt":     attempt,
+	}
+	if kind != "" {
+		m["gc.kind"] = kind
+	}
+	return beads.Bead{ID: id, Metadata: m}
+}
+
+// TestLatestAttemptFromCandidatesPrimary is the T2 read-side table test: the
+// primary path matches gc.control_for against the control identity set, skips
+// infrastructure and molecule_failed, and selects max(gc.attempt).
+func TestLatestAttemptFromCandidatesPrimary(t *testing.T) {
+	control := controlBead("gc-ctl", "mol.review", "review", "retry")
+
+	tests := []struct {
+		name       string
+		candidates []beads.Bead
+		wantID     string
+	}{
+		{
+			name:       "match by bead ID",
+			candidates: []beads.Bead{stampedAttempt("a1", "gc-ctl", "1", "")},
+			wantID:     "a1",
+		},
+		{
+			name:       "match by step_ref",
+			candidates: []beads.Bead{stampedAttempt("a1", "mol.review", "1", "")},
+			wantID:     "a1",
+		},
+		{
+			name:       "match by step_id",
+			candidates: []beads.Bead{stampedAttempt("a1", "review", "1", "")},
+			wantID:     "a1",
+		},
+		{
+			name: "max attempt wins",
+			candidates: []beads.Bead{
+				stampedAttempt("a1", "gc-ctl", "1", ""),
+				stampedAttempt("a3", "gc-ctl", "3", ""),
+				stampedAttempt("a2", "gc-ctl", "2", ""),
+			},
+			wantID: "a3",
+		},
+		{
+			name: "molecule_failed skipped",
+			candidates: []beads.Bead{
+				func() beads.Bead {
+					b := stampedAttempt("a2", "gc-ctl", "2", "")
+					b.Metadata["molecule_failed"] = "true"
+					return b
+				}(),
+				stampedAttempt("a1", "gc-ctl", "1", ""),
+			},
+			wantID: "a1",
+		},
+		{
+			name: "infrastructure kind carrying same control_for is not selected",
+			candidates: []beads.Bead{
+				// A scope-check control whose control_for equals the retry step
+				// ref must NOT be picked even though it has a higher attempt.
+				stampedAttempt("chk", "mol.review", "9", "scope-check"),
+				stampedAttempt("a1", "gc-ctl", "1", ""),
+			},
+			wantID: "a1",
+		},
+		{
+			name:       "non-matching control_for ignored",
+			candidates: []beads.Bead{stampedAttempt("a1", "gc-other", "1", "")},
+			wantID:     "", // no primary match, no legacy ref → empty
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := latestAttemptFromCandidates(control, tc.candidates)
+			if got.ID != tc.wantID {
+				t.Fatalf("latestAttemptFromCandidates = %q, want %q", got.ID, tc.wantID)
+			}
+		})
+	}
+}
+
+// TestLatestAttemptShadowParity is the I1 deletion-gate check (T3): whenever a
+// candidate set carries stamps, the primary path selects exactly what the
+// legacy ref-string cascade would have.
+func TestLatestAttemptShadowParity(t *testing.T) {
+	control := controlBead("gc-ctl", "mol-feature.review", "review", "retry")
+
+	// Build candidates that BOTH the legacy ref parser and the stamp resolve:
+	// step_ref shaped as the legacy cascade expects AND carrying the stamp.
+	mk := func(id, stepRef, attempt string) beads.Bead {
+		return beads.Bead{ID: id, Metadata: map[string]string{
+			"gc.step_ref":    stepRef,
+			"gc.attempt":     attempt,
+			"gc.control_for": "gc-ctl",
+		}}
+	}
+	candidates := []beads.Bead{
+		mk("a1", "mol-feature.review.attempt.1", "1"),
+		mk("a2", "mol-feature.review.attempt.2", "2"),
+	}
+
+	primary := latestAttemptFromCandidates(control, candidates)
+	legacy := latestAttemptFromCandidatesLegacyRefSurgery(control, candidates)
+	if primary.ID != legacy.ID {
+		t.Fatalf("shadow parity broken: primary=%q legacy=%q", primary.ID, legacy.ID)
+	}
+	if primary.ID != "a2" {
+		t.Fatalf("primary selected %q, want a2", primary.ID)
+	}
+}
+
+// TestLatestAttemptLegacyFallbackForUnstamped is T4: candidates minted before
+// the stamp (no gc.control_for) still resolve via the guarded legacy cascade,
+// and the legacy-hit counter advances so operators can watch it drain.
+func TestLatestAttemptLegacyFallbackForUnstamped(t *testing.T) {
+	control := controlBead("gc-ctl", "mol-feature.review", "review", "retry")
+
+	// Pre-stamp shapes: legacy ref surgery only.
+	candidates := []beads.Bead{
+		{ID: "a1", Metadata: map[string]string{"gc.step_ref": "mol-feature.review.attempt.1", "gc.attempt": "1"}},
+		{ID: "a2", Metadata: map[string]string{"gc.step_ref": "mol-feature.review.attempt.2", "gc.attempt": "2"}},
+	}
+
+	before := legacyAttemptLineageHitCount()
+	got := latestAttemptFromCandidates(control, candidates)
+	if got.ID != "a2" {
+		t.Fatalf("legacy fallback selected %q, want a2", got.ID)
+	}
+	if after := legacyAttemptLineageHitCount(); after <= before {
+		t.Fatalf("legacy-hit counter did not advance: before=%d after=%d", before, after)
+	}
+}
+
+// TestRemappedControlForBeadID covers the W6 remap helper: bead-ID pointers at
+// re-minted beads map to the new ID; step-ref pointers and pointers outside the
+// clone set return "" (left to rewriteRetryControlFor / untouched).
+func TestRemappedControlForBeadID(t *testing.T) {
+	t.Parallel()
+	mapping := map[string]string{"old-ctl": "new-ctl"}
+
+	if got := remappedControlForBeadID(mapping, "old-ctl"); got != "new-ctl" {
+		t.Fatalf("bead-ID in mapping = %q, want new-ctl", got)
+	}
+	if got := remappedControlForBeadID(mapping, "mol.outer.iteration.1.inner"); got != "" {
+		t.Fatalf("step-ref value = %q, want empty (not remapped)", got)
+	}
+	if got := remappedControlForBeadID(mapping, "some-other-bead"); got != "" {
+		t.Fatalf("bead-ID outside clone set = %q, want empty", got)
+	}
+	if got := remappedControlForBeadID(mapping, ""); got != "" {
+		t.Fatalf("empty value = %q, want empty", got)
+	}
+}
+
+// TestBuildRalphRetryGraphNodeControlForRemap covers W7: a bead-ID-valued
+// gc.control_for pointing at a bead re-minted in the plan is moved to
+// MetadataRefs (so the applier substitutes the new ID); a step-ref-valued
+// pointer stays on the string rewrite path in meta.
+func TestBuildRalphRetryGraphNodeControlForRemap(t *testing.T) {
+	t.Parallel()
+
+	attemptIDs := map[string]bool{"nested-ctl": true, "subject-old": true}
+
+	t.Run("bead-ID pointer moves to MetadataRefs", func(t *testing.T) {
+		old := beads.Bead{
+			ID:  "attempt-old",
+			Ref: "mol.loop.iteration.1.inner.attempt.1",
+			Metadata: map[string]string{
+				"gc.control_for": "nested-ctl",
+				"gc.attempt":     "1",
+			},
+		}
+		node := buildRalphRetryGraphNode(old, "logical", "mol.loop.iteration.1", "mol.loop.iteration.2", 1, 2, attemptIDs, nil)
+		if _, ok := node.Metadata["gc.control_for"]; ok {
+			t.Fatalf("gc.control_for must be removed from Metadata when remapped, got %q", node.Metadata["gc.control_for"])
+		}
+		if node.MetadataRefs["gc.control_for"] != "nested-ctl" {
+			t.Fatalf("MetadataRefs[gc.control_for] = %q, want nested-ctl", node.MetadataRefs["gc.control_for"])
+		}
+	})
+
+	t.Run("step-ref pointer stays in Metadata", func(t *testing.T) {
+		old := beads.Bead{
+			ID:  "check-old",
+			Ref: "mol.loop.iteration.1.check",
+			Metadata: map[string]string{
+				"gc.control_for": "mol.loop.iteration.1.inner",
+				"gc.attempt":     "1",
+			},
+		}
+		node := buildRalphRetryGraphNode(old, "logical", "mol.loop.iteration.1", "mol.loop.iteration.2", 1, 2, attemptIDs, nil)
+		if node.MetadataRefs["gc.control_for"] != "" {
+			t.Fatalf("step-ref pointer must not go to MetadataRefs, got %q", node.MetadataRefs["gc.control_for"])
+		}
+		if node.Metadata["gc.control_for"] == "" {
+			t.Fatalf("step-ref pointer must remain in Metadata")
+		}
+	})
+}

--- a/internal/dispatch/control_for_lineage_test.go
+++ b/internal/dispatch/control_for_lineage_test.go
@@ -56,10 +56,11 @@ func TestBuildAttemptRecipeStampsControlFor(t *testing.T) {
 	})
 }
 
-// controlBead is a small helper to build a control bead with an identity set.
-func controlBead(id, stepRef, stepID, kind string) beads.Bead {
+// controlBead is a small helper to build a retry control bead with an identity
+// set (store ID, namespaced step_ref, bare step_id).
+func controlBead(id, stepRef, stepID string) beads.Bead {
 	return beads.Bead{ID: id, Metadata: map[string]string{
-		"gc.kind":     kind,
+		"gc.kind":     "retry",
 		"gc.step_ref": stepRef,
 		"gc.step_id":  stepID,
 	}}
@@ -81,7 +82,7 @@ func stampedAttempt(id, controlFor string, attempt string, kind string) beads.Be
 // primary path matches gc.control_for against the control identity set, skips
 // infrastructure and molecule_failed, and selects max(gc.attempt).
 func TestLatestAttemptFromCandidatesPrimary(t *testing.T) {
-	control := controlBead("gc-ctl", "mol.review", "review", "retry")
+	control := controlBead("gc-ctl", "mol.review", "review")
 
 	tests := []struct {
 		name       string
@@ -155,7 +156,7 @@ func TestLatestAttemptFromCandidatesPrimary(t *testing.T) {
 // candidate set carries stamps, the primary path selects exactly what the
 // legacy ref-string cascade would have.
 func TestLatestAttemptShadowParity(t *testing.T) {
-	control := controlBead("gc-ctl", "mol-feature.review", "review", "retry")
+	control := controlBead("gc-ctl", "mol-feature.review", "review")
 
 	// Build candidates that BOTH the legacy ref parser and the stamp resolve:
 	// step_ref shaped as the legacy cascade expects AND carrying the stamp.
@@ -183,9 +184,10 @@ func TestLatestAttemptShadowParity(t *testing.T) {
 
 // TestLatestAttemptLegacyFallbackForUnstamped is T4: candidates minted before
 // the stamp (no gc.control_for) still resolve via the guarded legacy cascade,
-// and the legacy-hit counter advances so operators can watch it drain.
+// and the in-process legacy-hit counter advances so the deletion-gate tests
+// can observe legacy usage.
 func TestLatestAttemptLegacyFallbackForUnstamped(t *testing.T) {
-	control := controlBead("gc-ctl", "mol-feature.review", "review", "retry")
+	control := controlBead("gc-ctl", "mol-feature.review", "review")
 
 	// Pre-stamp shapes: legacy ref surgery only.
 	candidates := []beads.Bead{
@@ -200,6 +202,62 @@ func TestLatestAttemptLegacyFallbackForUnstamped(t *testing.T) {
 	}
 	if after := legacyAttemptLineageHitCount(); after <= before {
 		t.Fatalf("legacy-hit counter did not advance: before=%d after=%d", before, after)
+	}
+}
+
+// TestLatestAttemptStampedShapesNeverHitLegacyCascade is the executable form of
+// the S38 Phase-4 deletion gate: over post-S38 candidate shapes — every
+// attempt/iteration root carries a gc.control_for stamp matching its control's
+// identity — latestAttemptFromCandidates resolves on the primary equality path
+// and never falls through to latestAttemptFromCandidatesLegacyRefSurgery, so
+// legacyAttemptLineageHitCount() stays unchanged. This is the "stays at zero
+// over post-S38 candidate shapes" guarantee the legacyAttemptLineageHits comment
+// relies on; the advancing-counter test (unstamped shapes) and the shadow-parity
+// tests (which call the legacy cascade directly) do not prove it. Serial (no
+// t.Parallel) so the package-global counter delta is observed without
+// interference — dispatch spawns no background goroutine that touches it, and Go
+// defers every parallel test until the serial phase completes.
+func TestLatestAttemptStampedShapesNeverHitLegacyCascade(t *testing.T) {
+	simpleControl := controlBead("gc-ctl", "mol-feature.review", "review")
+	iter1Control := controlBead(
+		"mol.review-loop.iteration.1.inner",
+		"review-loop.iteration.1.inner", "inner")
+	iter2Control := controlBead(
+		"mol.review-loop.iteration.2.inner",
+		"mol.review-loop.iteration.2.inner", "inner")
+
+	// Fully-stamped candidates covering the simple and nested shapes. Each control
+	// matches its own attempt roots on the gc.control_for identity, so the primary
+	// path returns non-empty and the legacy cascade is never reached. No
+	// gc.step_ref is set, so the counter can only move if a primary match is
+	// missing — exactly what this gate forbids for stamped shapes.
+	stamped := []beads.Bead{
+		stampedAttempt("a1", "gc-ctl", "1", ""),
+		stampedAttempt("a2", "gc-ctl", "2", ""),
+		stampedAttempt("i1a1", "review-loop.iteration.1.inner", "1", ""),
+		stampedAttempt("i1a2", "review-loop.iteration.1.inner", "2", ""),
+		stampedAttempt("i2a1", "mol.review-loop.iteration.2.inner", "1", ""),
+	}
+
+	for _, tc := range []struct {
+		name    string
+		control beads.Bead
+		wantID  string
+	}{
+		{"simple retry control", simpleControl, "a2"},
+		{"nested outer-iteration-1 inner", iter1Control, "i1a2"},
+		{"nested outer-iteration-2 inner", iter2Control, "i2a1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := legacyAttemptLineageHitCount()
+			got := latestAttemptFromCandidates(tc.control, stamped)
+			if got.ID != tc.wantID {
+				t.Fatalf("latestAttemptFromCandidates = %q, want %q", got.ID, tc.wantID)
+			}
+			if after := legacyAttemptLineageHitCount(); after != before {
+				t.Fatalf("stamped shape hit the deprecated cascade: legacy-hit counter advanced before=%d after=%d", before, after)
+			}
+		})
 	}
 }
 
@@ -268,4 +326,91 @@ func TestBuildRalphRetryGraphNodeControlForRemap(t *testing.T) {
 			t.Fatalf("step-ref pointer must remain in Metadata")
 		}
 	})
+}
+
+// TestLatestAttemptNestedControlIsolatedAcrossOuterIterations is the S38
+// nested-lineage regression guard for the read side: each outer ralph
+// iteration's inner control must resolve ONLY its own latest attempt, never a
+// sibling outer iteration's, even when the sibling has a higher gc.attempt.
+//
+// Shapes match what the producers emit after the fix: outer iteration 1 is the
+// compile-time seed (non-mol-prefixed inner step_ref, so its attempt roots
+// carry the namespaced ref "review-loop.iteration.1.inner"); outer iteration 2
+// is the runtime buildNestedControlSeed (mol-prefixed inner ref). Before the
+// fix both iterations' attempt roots carried the bare "inner" stamp, so the
+// iteration-2 lookup matched iteration-1's attempt.2 through the shared
+// gc.step_id identity member and the max(gc.attempt) tiebreak.
+func TestLatestAttemptNestedControlIsolatedAcrossOuterIterations(t *testing.T) {
+	iter1Control := controlBead(
+		"mol.review-loop.iteration.1.inner",
+		"review-loop.iteration.1.inner", "inner")
+	iter2Control := controlBead(
+		"mol.review-loop.iteration.2.inner",
+		"mol.review-loop.iteration.2.inner", "inner")
+
+	candidates := []beads.Bead{
+		// Outer iteration 1's inner retried once: attempt.1 and attempt.2.
+		stampedAttempt("i1a1", "review-loop.iteration.1.inner", "1", ""),
+		stampedAttempt("i1a2", "review-loop.iteration.1.inner", "2", ""),
+		// Outer iteration 2's inner has only attempt.1 (lower than i1's max).
+		stampedAttempt("i2a1", "mol.review-loop.iteration.2.inner", "1", ""),
+	}
+
+	if got := latestAttemptFromCandidates(iter1Control, candidates); got.ID != "i1a2" {
+		t.Fatalf("iteration-1 inner resolved %q, want i1a2 (its own latest attempt)", got.ID)
+	}
+	// Decisive assertion: iteration-2 inner must not pick up iteration-1's
+	// higher-numbered attempt through a shared bare step id.
+	if got := latestAttemptFromCandidates(iter2Control, candidates); got.ID != "i2a1" {
+		t.Fatalf("iteration-2 inner resolved %q, want i2a1 (must not match sibling iteration-1 attempt.2)", got.ID)
+	}
+}
+
+// TestLatestAttemptShadowParityNested extends the I1 deletion-gate check to the
+// nested-control shape the reviewers flagged: with namespaced gc.control_for
+// stamps and legacy-shaped gc.step_refs present, the primary stamp path and the
+// deprecated ref-string cascade must select the SAME per-iteration attempt
+// root. This is the shape where a bare stamp made them diverge before S38.
+func TestLatestAttemptShadowParityNested(t *testing.T) {
+	iter1Control := controlBead(
+		"mol.review-loop.iteration.1.inner",
+		"review-loop.iteration.1.inner", "inner")
+	iter2Control := controlBead(
+		"mol.review-loop.iteration.2.inner",
+		"mol.review-loop.iteration.2.inner", "inner")
+
+	// Candidates carry BOTH the namespaced stamp (primary) and a legacy-shaped
+	// step_ref (ref cascade), so the two paths can be compared directly.
+	mk := func(id, controlFor, stepRef, attempt string) beads.Bead {
+		return beads.Bead{ID: id, Metadata: map[string]string{
+			"gc.control_for": controlFor,
+			"gc.step_ref":    stepRef,
+			"gc.attempt":     attempt,
+		}}
+	}
+	candidates := []beads.Bead{
+		mk("i1a1", "review-loop.iteration.1.inner", "review-loop.iteration.1.inner.attempt.1", "1"),
+		mk("i1a2", "review-loop.iteration.1.inner", "review-loop.iteration.1.inner.attempt.2", "2"),
+		mk("i2a1", "mol.review-loop.iteration.2.inner", "mol.review-loop.iteration.2.inner.attempt.1", "1"),
+	}
+
+	for _, tc := range []struct {
+		name    string
+		control beads.Bead
+		wantID  string
+	}{
+		{"outer-iteration-1 inner", iter1Control, "i1a2"},
+		{"outer-iteration-2 inner", iter2Control, "i2a1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			primary := latestAttemptFromCandidates(tc.control, candidates)
+			legacy := latestAttemptFromCandidatesLegacyRefSurgery(tc.control, candidates)
+			if primary.ID != legacy.ID {
+				t.Fatalf("shadow parity broken: primary=%q legacy=%q", primary.ID, legacy.ID)
+			}
+			if primary.ID != tc.wantID {
+				t.Fatalf("resolved %q, want %q (own iteration's latest attempt)", primary.ID, tc.wantID)
+			}
+		})
+	}
 }

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -548,10 +548,20 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 				return nil, fmt.Errorf("remapping logical bead for retry clone %s: %w", newID, err)
 			}
 		}
+		if remapped := remappedControlForBeadID(mapping, old.Metadata[beadmeta.ControlForMetadataKey]); remapped != "" {
+			if err := store.SetMetadata(newID, beadmeta.ControlForMetadataKey, remapped); err != nil {
+				return nil, fmt.Errorf("remapping control_for for retry clone %s: %w", newID, err)
+			}
+		}
 	}
 	if remapped := remappedLogicalBeadID(mapping, prevCheck.Metadata[beadmeta.LogicalBeadIDMetadataKey]); remapped != "" {
 		if err := store.SetMetadata(newCheck.ID, beadmeta.LogicalBeadIDMetadataKey, remapped); err != nil {
 			return nil, fmt.Errorf("remapping logical bead for retry check %s: %w", newCheck.ID, err)
+		}
+	}
+	if remapped := remappedControlForBeadID(mapping, prevCheck.Metadata[beadmeta.ControlForMetadataKey]); remapped != "" {
+		if err := store.SetMetadata(newCheck.ID, beadmeta.ControlForMetadataKey, remapped); err != nil {
+			return nil, fmt.Errorf("remapping control_for for retry check %s: %w", newCheck.ID, err)
 		}
 	}
 
@@ -653,13 +663,25 @@ func buildRalphRetryGraphNode(old beads.Bead, logicalID, oldScopeRef, newScopeRe
 		meta[beadmeta.ScopeRefMetadataKey] = rewriteRetryScopeRef(currentScopeRef, oldScopeRef, newScopeRef, old.ID)
 	}
 	meta[beadmeta.StepRefMetadataKey] = rewriteRetryStepRef(meta, old.Ref, oldScopeRef, newScopeRef, oldAttempt, nextAttempt)
-	if controlFor := strings.TrimSpace(meta[beadmeta.ControlForMetadataKey]); controlFor != "" {
-		meta[beadmeta.ControlForMetadataKey] = rewriteRetryControlFor(meta, controlFor, oldScopeRef, newScopeRef, oldAttempt, nextAttempt)
-	}
 	metadataRefs := map[string]string(nil)
+	// gc.control_for: a bead-ID-valued pointer at a bead re-minted in this plan
+	// is remapped to the clone's new ID via MetadataRefs (the applier
+	// substitutes the created ID), mirroring gc.logical_bead_id below (S38 W7).
+	// Step-ref-valued pointers stay on the string rewrite.
+	if controlFor := strings.TrimSpace(meta[beadmeta.ControlForMetadataKey]); controlFor != "" {
+		if attemptIDs[controlFor] {
+			metadataRefs = make(map[string]string, 1)
+			metadataRefs[beadmeta.ControlForMetadataKey] = controlFor
+			delete(meta, beadmeta.ControlForMetadataKey)
+		} else {
+			meta[beadmeta.ControlForMetadataKey] = rewriteRetryControlFor(meta, controlFor, oldScopeRef, newScopeRef, oldAttempt, nextAttempt)
+		}
+	}
 	if oldLogicalID := strings.TrimSpace(old.Metadata[beadmeta.LogicalBeadIDMetadataKey]); oldLogicalID != "" {
 		if attemptIDs[oldLogicalID] {
-			metadataRefs = make(map[string]string, 1)
+			if metadataRefs == nil {
+				metadataRefs = make(map[string]string, 1)
+			}
 			metadataRefs[beadmeta.LogicalBeadIDMetadataKey] = oldLogicalID
 			delete(meta, beadmeta.LogicalBeadIDMetadataKey)
 		} else {
@@ -1112,6 +1134,21 @@ func remappedLogicalBeadID(mapping map[string]string, raw string) string {
 		return mapped
 	}
 	return logicalID
+}
+
+// remappedControlForBeadID returns the new bead ID for a bead-ID-valued
+// gc.control_for pointer that referenced a bead re-minted in this retry clone
+// (i.e. the old value is a mapping key). It returns "" for step-ref-valued
+// pointers and for bead IDs outside the clone set — those keep the value
+// produced by rewriteRetryControlFor at clone time. This mirrors the
+// gc.logical_bead_id remap so cloned attempt roots point at the cloned
+// nested control's NEW bead ID (S38 W6).
+func remappedControlForBeadID(mapping map[string]string, raw string) string {
+	controlFor := strings.TrimSpace(raw)
+	if controlFor == "" {
+		return ""
+	}
+	return mapping[controlFor]
 }
 
 func resolveExistingRalphRetryFromBeads(store beads.Store, all []beads.Bead, logicalID string, prevSubject, prevCheck beads.Bead, attemptSet map[string]beads.Bead, oldAttempt, nextAttempt int, oldScopeRef, newScopeRef string) (map[string]string, error) {

--- a/internal/formula/ralph.go
+++ b/internal/formula/ralph.go
@@ -101,6 +101,9 @@ func expandRalph(step *Step) ([]*Step, error) {
 		beadmeta.StepIDMetadataKey:      step.ID,
 		beadmeta.RalphStepIDMetadataKey: step.ID,
 		beadmeta.StepRefMetadataKey:     iterationID,
+		// gc.control_for is the durable lineage pointer to the ralph control
+		// (step.ID here, which the control carries as gc.step_id).
+		beadmeta.ControlForMetadataKey: step.ID,
 	})
 	delete(iteration.Metadata, beadmeta.ScopeRefMetadataKey)
 	delete(iteration.Metadata, beadmeta.ScopeRoleMetadataKey)
@@ -142,6 +145,9 @@ func expandNestedRalph(step, control, specStep *Step, iterationID string, attemp
 		beadmeta.RalphStepIDMetadataKey: step.ID,
 		beadmeta.AttemptMetadataKey:     strconv.Itoa(attempt),
 		beadmeta.StepRefMetadataKey:     iterationID,
+		// gc.control_for on the scope root only (body children hang off it via
+		// gc.scope_ref and are not attempt roots — they must not be stamped).
+		beadmeta.ControlForMetadataKey: step.ID,
 	})
 	if step.OnComplete != nil {
 		iteration.Metadata[beadmeta.OutputJSONRequiredMetadataKey] = "true"

--- a/internal/formula/ralph.go
+++ b/internal/formula/ralph.go
@@ -3,6 +3,7 @@ package formula
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 )
@@ -199,7 +200,7 @@ func namespaceRalphBodySteps(steps []*Step, iterationID string, owner *Step, att
 			if childStepID == "" {
 				childStepID = node.ID
 			}
-			clone.Metadata = withMetadata(clone.Metadata, map[string]string{
+			childMeta := map[string]string{
 				beadmeta.ScopeRefMetadataKey:    iterationID,
 				beadmeta.OnFailMetadataKey:      metadataDefault(node.Metadata, beadmeta.OnFailMetadataKey, "abort_scope"),
 				beadmeta.ScopeRoleMetadataKey:   metadataDefault(node.Metadata, beadmeta.ScopeRoleMetadataKey, beadmeta.ScopeRoleMember),
@@ -207,7 +208,22 @@ func namespaceRalphBodySteps(steps []*Step, iterationID string, owner *Step, att
 				beadmeta.RalphStepIDMetadataKey: owner.ID,
 				beadmeta.AttemptMetadataKey:     strconv.Itoa(attempt),
 				beadmeta.StepRefMetadataKey:     clone.ID,
-			})
+			}
+			// A nested control's attempt/iteration root carries gc.control_for as
+			// the bare inner-control step id (stamped by expandRetry/expandRalph
+			// before this body was namespaced). Rewrite it to the namespaced
+			// control ref (iterationID-prefixed, matching the cloned inner
+			// control's gc.step_ref above) so findLatestAttempt scopes it to THIS
+			// outer iteration's inner control instead of matching every sibling
+			// outer iteration through the shared bare step id. This mirrors the
+			// runtime buildNestedControlSeed stamp for outer iterations 2+ (both
+			// yield the inner control's namespaced ref); the bare value only
+			// remains on top-level attempt roots, where the step id is unique per
+			// workflow root so no cross-iteration collision exists (S38).
+			if cf := strings.TrimSpace(node.Metadata[beadmeta.ControlForMetadataKey]); cf != "" {
+				childMeta[beadmeta.ControlForMetadataKey] = iterationID + "." + cf
+			}
+			clone.Metadata = withMetadata(clone.Metadata, childMeta)
 			if top {
 				topLevel = append(topLevel, clone.ID)
 				clone.DependsOn = append(clone.DependsOn, owner.DependsOn...)

--- a/internal/formula/ralph_test.go
+++ b/internal/formula/ralph_test.go
@@ -753,3 +753,70 @@ func TestApplyRalph_StampsControlForOnIterationRoot(t *testing.T) {
 		t.Fatalf("body child %q must not carry gc.control_for", applyChild.ID)
 	}
 }
+
+// TestApplyRalph_NamespacesNestedControlForAcrossBody is the S38 nested-lineage
+// regression guard for the producer side. An outer ralph with a retry child
+// must stamp the nested retry's attempt root with the *namespaced* control ref
+// (the cloned inner control's gc.step_ref), not the bare inner step id.
+//
+// The bare step id ("inner") is shared by the inner control of every sibling
+// outer ralph iteration, so a bare gc.control_for let findLatestAttempt's
+// primary lookup match a foreign iteration's inner control through the shared
+// gc.step_id identity member. Namespacing the stamp scopes it to this outer
+// iteration's inner control, mirroring the runtime buildNestedControlSeed path.
+func TestApplyRalph_NamespacesNestedControlForAcrossBody(t *testing.T) {
+	// Mirror the compile pipeline order: retries expand before ralph, so the
+	// ralph body already holds the inner control + attempt beads when
+	// namespaceRalphBodySteps runs over them.
+	steps := []*Step{
+		{
+			ID:    "review-loop",
+			Title: "Review loop",
+			Type:  "task",
+			Ralph: &RalphSpec{MaxAttempts: 3, Check: &RalphCheckSpec{Mode: "exec", Path: "c.sh"}},
+			Children: []*Step{
+				{
+					ID:    "inner",
+					Title: "Inner",
+					Retry: &RetrySpec{MaxAttempts: 2},
+				},
+			},
+		},
+	}
+	retried, err := ApplyRetries(steps)
+	if err != nil {
+		t.Fatalf("ApplyRetries: %v", err)
+	}
+	expanded, err := ApplyRalph(retried)
+	if err != nil {
+		t.Fatalf("ApplyRalph: %v", err)
+	}
+
+	var innerControl, innerAttempt *Step
+	for _, s := range expanded {
+		switch {
+		case s.ID == "review-loop.iteration.1.inner" && s.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindRetry:
+			innerControl = s
+		case s.ID == "review-loop.iteration.1.inner.attempt.1":
+			innerAttempt = s
+		}
+	}
+	if innerControl == nil {
+		t.Fatalf("nested inner control not found among expanded steps")
+	}
+	if innerAttempt == nil {
+		t.Fatalf("nested inner attempt root not found among expanded steps")
+	}
+
+	wantCF := innerControl.Metadata[beadmeta.StepRefMetadataKey]
+	if wantCF == "" || wantCF == "inner" {
+		t.Fatalf("inner control gc.step_ref = %q, want a namespaced ref", wantCF)
+	}
+	got := innerAttempt.Metadata[beadmeta.ControlForMetadataKey]
+	if got == "inner" {
+		t.Fatalf("nested attempt gc.control_for is the bare step id %q; must be namespaced to the inner control ref", got)
+	}
+	if got != wantCF {
+		t.Fatalf("nested attempt gc.control_for = %q, want %q (must equal inner control gc.step_ref)", got, wantCF)
+	}
+}

--- a/internal/formula/ralph_test.go
+++ b/internal/formula/ralph_test.go
@@ -698,3 +698,58 @@ func TestMarkRalphBodyOutputSinksTracksBeadmetaExemptKinds(t *testing.T) {
 		t.Error("teardown-role step was marked as an output sink")
 	}
 }
+
+func TestApplyRalph_StampsControlForOnIterationRoot(t *testing.T) {
+	// Simple ralph (no children): iteration.1 work bead carries the stamp.
+	simple := []*Step{
+		{
+			ID:    "implement",
+			Title: "Implement",
+			Type:  "task",
+			Ralph: &RalphSpec{MaxAttempts: 3, Check: &RalphCheckSpec{Mode: "exec", Path: "c.sh"}},
+		},
+	}
+	got, err := ApplyRalph(simple)
+	if err != nil {
+		t.Fatalf("ApplyRalph failed: %v", err)
+	}
+	control, iteration := got[0], got[2]
+	if iteration.Metadata[beadmeta.ControlForMetadataKey] != "implement" {
+		t.Fatalf("simple iteration gc.control_for = %q, want implement", iteration.Metadata[beadmeta.ControlForMetadataKey])
+	}
+	if control.Metadata[beadmeta.StepIDMetadataKey] != "implement" {
+		t.Fatalf("control gc.step_id = %q, want implement (must match iteration gc.control_for)", control.Metadata[beadmeta.StepIDMetadataKey])
+	}
+	if _, ok := control.Metadata[beadmeta.ControlForMetadataKey]; ok {
+		t.Fatalf("control must not carry gc.control_for")
+	}
+
+	// Nested ralph: only the iteration scope root carries the stamp; body
+	// children (which are not attempt roots) must not.
+	nested := []*Step{
+		{
+			ID:    "review-loop",
+			Title: "Review loop",
+			Type:  "task",
+			Ralph: &RalphSpec{MaxAttempts: 3, Check: &RalphCheckSpec{Mode: "exec", Path: "c.sh"}},
+			Children: []*Step{
+				{ID: "review", Title: "Review"},
+				{ID: "apply", Title: "Apply", Needs: []string{"review"}},
+			},
+		},
+	}
+	got2, err := ApplyRalph(nested)
+	if err != nil {
+		t.Fatalf("ApplyRalph nested failed: %v", err)
+	}
+	scope, reviewChild, applyChild := got2[2], got2[3], got2[4]
+	if scope.Metadata[beadmeta.ControlForMetadataKey] != "review-loop" {
+		t.Fatalf("nested scope gc.control_for = %q, want review-loop", scope.Metadata[beadmeta.ControlForMetadataKey])
+	}
+	if _, ok := reviewChild.Metadata[beadmeta.ControlForMetadataKey]; ok {
+		t.Fatalf("body child %q must not carry gc.control_for", reviewChild.ID)
+	}
+	if _, ok := applyChild.Metadata[beadmeta.ControlForMetadataKey]; ok {
+		t.Fatalf("body child %q must not carry gc.control_for", applyChild.ID)
+	}
+}

--- a/internal/formula/retry.go
+++ b/internal/formula/retry.go
@@ -89,6 +89,12 @@ func expandRetry(step *Step) ([]*Step, error) {
 	run.Metadata = withMetadata(run.Metadata, map[string]string{
 		beadmeta.AttemptMetadataKey: strconv.Itoa(attempt),
 		beadmeta.StepIDMetadataKey:  step.ID,
+		// gc.control_for records the durable lineage pointer back to the retry
+		// control. At compile time no store bead ID exists yet, so the value is
+		// the control's identity as known now (step.ID, which the control also
+		// carries as gc.step_id). findLatestAttempt matches on this metadata
+		// instead of parsing ref strings.
+		beadmeta.ControlForMetadataKey: step.ID,
 		// gc.step_ref is NOT set here — molecule.Instantiate fills it from
 		// step.ID which includes the formula prefix (e.g., "mol.finalize.attempt.1"
 		// instead of the bare "finalize.attempt.1").

--- a/internal/formula/retry_test.go
+++ b/internal/formula/retry_test.go
@@ -262,3 +262,36 @@ func TestApplyRetriesFrozenSpecRoundTrips(t *testing.T) {
 		}
 	})
 }
+
+func TestApplyRetriesStampsControlForOnAttemptRoot(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "review",
+			Title: "Review change",
+			Type:  "task",
+			Retry: &RetrySpec{MaxAttempts: 3},
+		},
+	}
+
+	got, err := ApplyRetries(steps)
+	if err != nil {
+		t.Fatalf("ApplyRetries failed: %v", err)
+	}
+	control, spec, attempt := got[0], got[1], got[2]
+
+	// The attempt root carries the durable lineage pointer to the control,
+	// which equals the control's step id.
+	if attempt.Metadata["gc.control_for"] != "review" {
+		t.Fatalf("attempt gc.control_for = %q, want review", attempt.Metadata["gc.control_for"])
+	}
+	if control.Metadata["gc.step_id"] != "review" {
+		t.Fatalf("control gc.step_id = %q, want review (must match attempt gc.control_for)", control.Metadata["gc.step_id"])
+	}
+	// Control and spec beads are not attempt roots — they must not be stamped.
+	if _, ok := control.Metadata["gc.control_for"]; ok {
+		t.Fatalf("control must not carry gc.control_for, got %q", control.Metadata["gc.control_for"])
+	}
+	if _, ok := spec.Metadata["gc.control_for"]; ok {
+		t.Fatalf("spec must not carry gc.control_for, got %q", spec.Metadata["gc.control_for"])
+	}
+}


### PR DESCRIPTION
## What this does

Lands **S38** (part of the simplification track, #3789): replaces `findLatestAttempt`'s four-stage dotted-step-ref string surgery with a durable `gc.control_for` lineage stamp.

Every attempt/iteration root is now stamped with `gc.control_for` at mint time (compile-time seeds in `formula/retry.go` + `formula/ralph.go`; runtime mints in `dispatch/control.go:buildAttemptRecipe`, written *after* the metadata copy loop so a formula-authored value can't shadow it). Attempt-lineage recovery then becomes one string equality against the control's identity set `{ID, gc.step_ref, gc.step_id}` plus an integer `max(gc.attempt)` — no ref parsing. Clone coherence for in-iteration ralph retries is kept via a post-create bead-ID remap (`dispatch/ralph.go`) and `MetadataRefs`.

Leans on the existing `beadmeta.ControlForMetadataKey` (`gc.control_for`) — no new metadata key, no wire/event changes. Confined to `internal/dispatch` + `internal/formula`; typed-wire/events, worker boundary, `config.Agent` field-sync, and `cmd/gc` projections are untouched.

## Behavior-preserving

The dense four-stage cascade is **demoted**, not deleted: `latestAttemptFromCandidatesLegacyRefSurgery` is moved verbatim and marked DEPRECATED, invoked only as a guarded fallback when no candidate carries a stamp (pre-S38 in-flight molecules). A package-level `legacyAttemptLineageHits` counter makes the pre-stamp drain observable. Existing unstamped fixtures resolve through this fallback unchanged.

**Phase 4 (cascade deletion, ~80 LOC of the densest dispatch code) is deferred** to the release after the legacy-hit counter drains to zero in production — this PR is Phases 1-3 (write, clone-coherence, read-flip-with-fallback).

## Tests

Stamp coverage per mint path (T1), read-side table test (T2), shadow parity primary==legacy on stamped fixtures (T3), legacy-population fallback + counter (T4), and W6/W7 clone-remap mechanisms (T5).

## Notes

- Rebased onto current `main` (over S12/S13/S37/S04/S09/S06/S26). S37 (`dispatch/fanout.go`+`runtime.go`) and S13 (`sling/`) touch different files than S38 (`dispatch/control.go`+`ralph.go`), so the rebase was clean; S38 semantics unchanged.
- Spec: `engdocs/simplification/specs/S38-control-for-lineage-spec.md` (on the simplification audit branch).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)