### PR TITLE
simplify(S23) phase 1: tick-scoped Info fold front-door + source-scan guard

### DIFF
--- a/cmd/gc/reconcile_tick.go
+++ b/cmd/gc/reconcile_tick.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"github.com/gastownhall/gascity/internal/beads"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// reconcileTick owns the reconciler's coherent typed snapshot (infoByID) for a
+// single tick and is the ONE front door for folding a mutation onto it.
+//
+// Every forward-pass metadata write in the reconciler produces a patch that is
+// mirrored to three representations kept coherent by hand: the store (via
+// sessFront.ApplyPatch), the raw beads.Bead (session.Metadata[k]=v), and this
+// typed snapshot. The store write and raw-bead mirror stay where the write
+// helpers perform them (healStateWithRollback, checkRateLimitStability,
+// rollbackPendingCreate, …) — this type does not duplicate them. What it owns
+// is the third write: the infoByID fold. Historically that fold was an open-
+// coded `infoByID[id] = infoByID[id].ApplyPatch(patch)` repeated at ~30 sites,
+// and a forgotten fold was a silent, compile-clean coherence bug in the
+// cross-session min-floor / awake / drain scans that read the snapshot. Routing
+// every fold through apply/applyResult/markClosed makes that bug class
+// unrepresentable: there is one fold path, guarded by TestReconcileTickFold
+// FrontDoor (which forbids a bare `infoByID[...] =` outside this file) and by
+// the property test TestReconcileTickApplyMatchesRawFold.
+//
+// The struct holds the same map instances the reconciler reads from, so callers
+// may keep reading through a plain `infoByID` alias and passing it to scan
+// helpers; only the write path is funneled here.
+type reconcileTick struct {
+	// infoByID is the coherent typed snapshot of the tick's working set, keyed
+	// by session ID. Built once from the post-Phase-0.5 `ordered` beads.
+	infoByID map[string]sessionpkg.Info
+	// orderedIDs carries the tick's topo order as plain session IDs. Order is
+	// load-bearing: ComputeAwakeSet resolves the non-unique SessionName
+	// last-write-wins, so order-sensitive rebuilds walk this instead of ranging
+	// the (unordered) map.
+	orderedIDs []string
+}
+
+// newReconcileTick builds the tick snapshot from the tick's ordered working
+// set. Each entry is byte-identical to a fresh projection of that session's
+// bead at loop entry; the forward pass mutates only the current iteration's
+// session, so no entry goes stale before it is visited.
+func newReconcileTick(ordered []beads.Bead) *reconcileTick {
+	t := &reconcileTick{
+		infoByID:   make(map[string]sessionpkg.Info, len(ordered)),
+		orderedIDs: make([]string, len(ordered)),
+	}
+	for i := range ordered {
+		t.orderedIDs[i] = ordered[i].ID
+		t.infoByID[ordered[i].ID] = sessionpkg.InfoFromPersistedBead(ordered[i])
+	}
+	return t
+}
+
+// apply folds a metadata patch onto the snapshot entry for id and returns the
+// updated Info. Equivalent to the former `infoByID[id] = infoByID[id].ApplyPatch
+// (patch)`; the store write and raw-bead mirror are performed by the caller's
+// write helper before this fold.
+func (t *reconcileTick) apply(id string, patch sessionpkg.MetadataPatch) sessionpkg.Info {
+	next := t.infoByID[id].ApplyPatch(patch)
+	t.infoByID[id] = next
+	return next
+}
+
+// applyResult folds a drainAckFinalizeResult onto the snapshot entry for id and
+// returns the updated Info. Equivalent to the former
+// `infoByID[id] = result.applyTo(infoByID[id])`.
+func (t *reconcileTick) applyResult(id string, r drainAckFinalizeResult) sessionpkg.Info {
+	next := r.applyTo(t.infoByID[id])
+	t.infoByID[id] = next
+	return next
+}
+
+// markClosed records an in-memory close on the snapshot entry for id (Closed
+// =true, State=""). Equivalent to the former
+// `infoByID[id] = infoByID[id].MarkClosed()`; the store close was already
+// stamped by the caller's close helper.
+func (t *reconcileTick) markClosed(id string) sessionpkg.Info {
+	next := t.infoByID[id].MarkClosed()
+	t.infoByID[id] = next
+	return next
+}

--- a/cmd/gc/reconcile_tick_test.go
+++ b/cmd/gc/reconcile_tick_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+func tickTestBead(id, name, state string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Status: "open",
+		Type:   "session",
+		Metadata: beads.StringMap{
+			"session_name": name,
+			"state":        state,
+		},
+	}
+}
+
+// TestNewReconcileTickMatchesProjection pins that the tick snapshot is built
+// byte-identically to a fresh projection of each bead, in topo order.
+func TestNewReconcileTickMatchesProjection(t *testing.T) {
+	ordered := []beads.Bead{
+		tickTestBead("s-1", "alpha", "awake"),
+		tickTestBead("s-2", "beta", "asleep"),
+		tickTestBead("s-3", "gamma", "creating"),
+	}
+	tick := newReconcileTick(ordered)
+
+	if len(tick.orderedIDs) != len(ordered) {
+		t.Fatalf("orderedIDs len = %d, want %d", len(tick.orderedIDs), len(ordered))
+	}
+	for i := range ordered {
+		if tick.orderedIDs[i] != ordered[i].ID {
+			t.Errorf("orderedIDs[%d] = %q, want %q", i, tick.orderedIDs[i], ordered[i].ID)
+		}
+		want := sessionpkg.InfoFromPersistedBead(ordered[i])
+		if got := tick.infoByID[ordered[i].ID]; !reflect.DeepEqual(got, want) {
+			t.Errorf("infoByID[%q] = %+v, want %+v", ordered[i].ID, got, want)
+		}
+	}
+}
+
+// TestReconcileTickApplyMatchesRawFold is the property test for the mutator:
+// tick.apply / tick.markClosed must fold the snapshot identically to applying
+// the same operation directly on a fresh projection, and the stored entry must
+// equal the returned Info. This is the coherence guarantee that the front door
+// enforces at every fold site (store == raw == snapshot, with store/raw
+// performed by the caller's write helper).
+func TestReconcileTickApplyMatchesRawFold(t *testing.T) {
+	base := tickTestBead("s-1", "alpha", "creating")
+	patches := []sessionpkg.MetadataPatch{
+		{"state": "awake"},
+		{"state": "asleep", "sleep_reason": "drained"},
+		{"pending_create_claim": "", "pending_create_started_at": ""},
+		{"session_name": "renamed"},
+	}
+
+	for _, patch := range patches {
+		tick := newReconcileTick([]beads.Bead{base})
+		want := sessionpkg.InfoFromPersistedBead(base).ApplyPatch(patch)
+		got := tick.apply(base.ID, patch)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("apply(%v) returned %+v, want %+v", map[string]string(patch), got, want)
+		}
+		if stored := tick.infoByID[base.ID]; !reflect.DeepEqual(stored, want) {
+			t.Errorf("apply(%v) stored %+v, want %+v", map[string]string(patch), stored, want)
+		}
+	}
+
+	// markClosed folds identically to a direct MarkClosed on the projection.
+	tick := newReconcileTick([]beads.Bead{base})
+	wantClosed := sessionpkg.InfoFromPersistedBead(base).MarkClosed()
+	gotClosed := tick.markClosed(base.ID)
+	if !reflect.DeepEqual(gotClosed, wantClosed) {
+		t.Errorf("markClosed returned %+v, want %+v", gotClosed, wantClosed)
+	}
+	if stored := tick.infoByID[base.ID]; !reflect.DeepEqual(stored, wantClosed) {
+		t.Errorf("markClosed stored %+v, want %+v", stored, wantClosed)
+	}
+}
+
+// TestReconcileTickApplyResultMatchesApplyTo pins that applyResult folds a
+// drainAckFinalizeResult identically to calling result.applyTo on the snapshot
+// entry.
+func TestReconcileTickApplyResultMatchesApplyTo(t *testing.T) {
+	base := tickTestBead("s-1", "alpha", "awake")
+	res := drainAckFinalizeResult{batch: map[string]string{"state": "asleep"}, closed: true}
+
+	tick := newReconcileTick([]beads.Bead{base})
+	want := res.applyTo(sessionpkg.InfoFromPersistedBead(base))
+	got := tick.applyResult(base.ID, res)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("applyResult returned %+v, want %+v", got, want)
+	}
+	if stored := tick.infoByID[base.ID]; !reflect.DeepEqual(stored, want) {
+		t.Errorf("applyResult stored %+v, want %+v", stored, want)
+	}
+}
+
+// infoByIDBareAssign matches a direct assignment into a bare infoByID map —
+// `infoByID[<expr>] = <expr>` (but not `==`) — the open-coded fold the mutator
+// replaces.
+var infoByIDBareAssign = regexp.MustCompile(`\binfoByID\[[^\]]*\]\s*=[^=]`)
+
+// TestReconcileTickFoldFrontDoor forbids reintroducing a direct
+// `infoByID[...] =` fold in session_reconciler.go: every mutation of the tick
+// snapshot must route through the reconcileTick front door (apply / applyResult
+// / markClosed) so a forgotten fold cannot silently desync the cross-session
+// min-floor / awake / drain scans from the store and raw bead. The only place a
+// bare `t.infoByID[...] =` write is allowed is reconcile_tick.go itself.
+func TestReconcileTickFoldFrontDoor(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	path := filepath.Join(filepath.Dir(currentFile), "session_reconciler.go")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	for i, line := range strings.Split(string(data), "\n") {
+		code := line
+		if idx := strings.Index(code, "//"); idx >= 0 {
+			code = code[:idx] // strip line/inline comment
+		}
+		if infoByIDBareAssign.MatchString(code) {
+			t.Errorf("session_reconciler.go:%d writes infoByID directly (%q); route the fold through the reconcileTick front door (tick.apply / tick.applyResult / tick.markClosed) instead", i+1, strings.TrimSpace(line))
+		}
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1477,20 +1477,21 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	// — Phase 1 mutates only the current iteration's session, so no entry goes
 	// stale before it is visited. Entries are refreshed from the store (via Get)
 	// after a mutation as the post-mutation reads migrate onto them (Step 3+).
-	infoByID := make(map[string]sessionpkg.Info, len(ordered))
-	// orderedIDs carries the tick's topo order as plain session IDs (Step 5e). The
-	// order-sensitive decision-domain rebuilds (the awake-scan `sessionInfos` feed
-	// and the preserve-template feed) walk it instead of the raw `ordered` beads,
-	// so those rebuilds no longer reach into `ordered[i]` — `ordered` is demoted to
-	// the load-time slice that builds this snapshot and carries raw beads into the
-	// documented raw-by-design / start-execution consumers. Order is load-bearing:
-	// ComputeAwakeSet resolves the non-unique SessionName last-write-wins, so these
-	// rebuilds must stay in topo order and never `range infoByID`.
-	orderedIDs := make([]string, len(ordered))
-	for i := range ordered {
-		orderedIDs[i] = ordered[i].ID
-		infoByID[ordered[i].ID] = sessionpkg.InfoFromPersistedBead(ordered[i])
-	}
+	// tick owns the coherent typed snapshot for this tick and is the single
+	// front door for folding a mutation onto it (see reconcileTick). Every
+	// forward-pass write below routes its infoByID fold through tick.apply /
+	// tick.applyResult / tick.markClosed; a bare `infoByID[...] =` here is
+	// forbidden by TestReconcileTickFoldFrontDoor. Reads still go through the
+	// plain `infoByID` alias (same map instance) and scan helpers still take it
+	// by value. orderedIDs carries the tick's topo order as plain session IDs;
+	// the order-sensitive rebuilds (the awake-scan `sessionInfos` feed and the
+	// preserve-template feed) walk it instead of the raw `ordered` beads. Order
+	// is load-bearing: ComputeAwakeSet resolves the non-unique SessionName
+	// last-write-wins, so these rebuilds must stay in topo order and never
+	// `range infoByID`.
+	tick := newReconcileTick(ordered)
+	infoByID := tick.infoByID
+	orderedIDs := tick.orderedIDs
 	// Phase 1: Forward pass (topo order) — wake sessions, handle alive state.
 	var startCandidates []startCandidate
 	var wakeTargets []wakeTarget
@@ -1572,7 +1573,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// unmutated bead. infoByID[session.ID] is coherent here (top-of-loop
 			// snapshot, no *session mutation before the finalize call). Guarded by
 			// TestReconcileSessionBeads_MinFloorCountReflectsMidTickCloseDrainAck.
-			infoByID[session.ID] = result.applyTo(infoByID[session.ID])
+			tick.applyResult(session.ID, result)
 			continue
 		}
 
@@ -1640,14 +1641,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if rateLimitHit || rateLimitErr != nil {
 						// Fold the rate-limit batch onto the snapshot (Step 6d write-returns-Info).
 						// Pre-pass-masked (STEP6-PREPASS-AUDIT group 1).
-						infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rlBatch)
+						tick.apply(session.ID, rlBatch)
 						continue
 					}
 					clearClaim := configuredNamedSessionBeadHasSpecInfo(info, cfg, cityName)
 					// Fold the rollback's mirrored metadata onto the snapshot (Step 6d
 					// write-returns-Info; no Closed change — store-only close).
 					// Pre-pass-masked (STEP6-PREPASS-AUDIT group 2).
-					infoByID[session.ID] = infoByID[session.ID].ApplyPatch(attemptRollbackPendingCreate(session, template, name, "pending_create_lease_expired", "lease expired and no live runtime", clearClaim))
+					tick.apply(session.ID, attemptRollbackPendingCreate(session, template, name, "pending_create_lease_expired", "lease expired and no live runtime", clearClaim))
 					continue
 				}
 			}
@@ -1712,7 +1713,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				}
 				// Fold the rate-limit batch onto the snapshot (Step 6d write-returns-Info).
 				// Pre-pass-masked (STEP6-PREPASS-AUDIT group 1).
-				infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rlBatchNamed)
+				tick.apply(session.ID, rlBatchNamed)
 				continue
 			}
 			if isFailedCreateSessionInfo(info) {
@@ -1765,7 +1766,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// half of the Step-6d front-door cutover; the raw session.Status
 						// lockstep above stays until the final lockstep drop. Guarded by
 						// TestReconcileSessionBeads_MinFloorCountReflectsMidTickClose.
-						infoByID[session.ID] = infoByID[session.ID].MarkClosed()
+						tick.markClosed(session.ID)
 					}
 					continue
 				}
@@ -1815,7 +1816,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// post-zombie rollback read on the preserveNamed fall-through) through this
 			// fold alone. Guarded by
 			// TestReconcileSessionBeads_HealStateReflectedOnSnapshot.
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(healBatch)
+			tick.apply(session.ID, healBatch)
 			infoPostHeal := infoByID[session.ID]
 			switch {
 			case preserveNamed:
@@ -1912,7 +1913,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								// time-independent, so reconstructing the patch reproduces the
 								// mirror (drain_at is non-Info). Cross-session isDrainAckStopPendingInfo
 								// reader. Pre-pass-masked (STEP6-PREPASS-AUDIT group 3).
-								infoByID[session.ID] = infoByID[session.ID].ApplyPatch(sessionpkg.DrainAckStopPendingPatch(clk.Now().UTC()))
+								tick.apply(session.ID, sessionpkg.DrainAckStopPendingPatch(clk.Now().UTC()))
 								clearDrainTrackerForStopPending(session, dt)
 								queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, session.Metadata["instance_token"], asyncStopTracker, stderr)
 								if trace != nil {
@@ -1950,7 +1951,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// refreshSessionInfo re-projection). infoByID[session.ID] holds the
 						// coherent post-heal Info (refreshed at the heal above; no *session
 						// mutation reaches here on this !providerAlive path).
-						infoByID[session.ID] = result.applyTo(infoByID[session.ID])
+						tick.applyResult(session.ID, result)
 						continue
 					}
 				}
@@ -2077,7 +2078,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// The heal refresh (~1628) already synced this entry, so
 						// MarkClosed folds onto a coherent pre-close Info. Guarded by
 						// TestReconcileSessionBeads_MinFloorCountReflectsMidTickCloseOrphan.
-						infoByID[session.ID] = infoByID[session.ID].MarkClosed()
+						tick.markClosed(session.ID)
 					}
 				}
 				continue
@@ -2144,12 +2145,12 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// paths (attemptRollbackPendingCreate; checkRateLimitStability on hit), so
 		// infoPostZombie stays byte-identical throughout. Guarded by
 		// TestReconcileSessionBeads_ZombieTerminalErrorReflectedOnSnapshot.
-		infoByID[session.ID] = infoByID[session.ID].ApplyPatch(terminalErrBatch)
+		tick.apply(session.ID, terminalErrBatch)
 		infoPostZombie := infoByID[session.ID]
 		if alive && shouldRollbackPendingCreateInfo(infoPostZombie) && !runningSessionMatchesPendingCreate(session, name, sp) {
 			// Fold the rollback's mirrored metadata onto the snapshot (Step 6d;
 			// no Closed change — store-only close). STEP6-PREPASS-AUDIT group 2.
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_rollback", "live runtime belongs to another session", false))
+			tick.apply(session.ID, attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_rollback", "live runtime belongs to another session", false))
 			continue
 		}
 		// Desired-branch counterpart to pendingCreateSessionStillLeased: a
@@ -2169,12 +2170,12 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				if rateLimitHit || rateLimitErr != nil {
 					// Fold the rate-limit batch onto the snapshot (Step 6d write-returns-Info).
 					// Pre-pass-masked (STEP6-PREPASS-AUDIT group 1).
-					infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rlBatch)
+					tick.apply(session.ID, rlBatch)
 					continue
 				}
 				// Fold the rollback's mirrored metadata onto the snapshot (Step 6d;
 				// no Closed change — store-only close). STEP6-PREPASS-AUDIT group 2.
-				infoByID[session.ID] = infoByID[session.ID].ApplyPatch(attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_lease_expired", "lease expired and no live runtime", false))
+				tick.apply(session.ID, attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_lease_expired", "lease expired and no live runtime", false))
 				continue
 			}
 		}
@@ -2293,7 +2294,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							// Fold the stop-pending transition onto the snapshot (Step 6d);
 							// deterministic DrainAckStopPendingPatch reconstruction, same as the
 							// orphan-arm site above (STEP6-PREPASS-AUDIT group 3).
-							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(sessionpkg.DrainAckStopPendingPatch(clk.Now().UTC()))
+							tick.apply(session.ID, sessionpkg.DrainAckStopPendingPatch(clk.Now().UTC()))
 							clearDrainTrackerForStopPending(session, dt)
 							queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, session.Metadata["instance_token"], asyncStopTracker, stderr)
 							if trace != nil {
@@ -2318,7 +2319,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					// refreshSessionInfo re-projection). infoByID[session.ID] holds the
 					// coherent post-zombie Info (refreshed above; no *session mutation
 					// reaches here on this !alive fall-through path).
-					infoByID[session.ID] = result.applyTo(infoByID[session.ID])
+					tick.applyResult(session.ID, result)
 					continue
 				}
 			}
@@ -2408,7 +2409,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					// clears it on the snapshot (else #2574 re-fires a phantom second
 					// restart). The base is coherent here (the zombie fold synced
 					// infoByID and every intervening mutating block `continue`s).
-					infoByID[session.ID] = infoByID[session.ID].ApplyPatch(sessionpkg.MetadataPatch{"restart_requested": "true"})
+					tick.apply(session.ID, sessionpkg.MetadataPatch{"restart_requested": "true"})
 					fmt.Fprintf(stderr, "session reconciler: %s progress-stalled (no progress for >%s, no open claim, provider healthy); requesting fresh restart\n", name, threshold) //nolint:errcheck
 				}
 			}
@@ -2487,7 +2488,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					session.Metadata[key] = value
 					restartFold[key] = value
 				}
-				infoByID[session.ID] = infoByID[session.ID].ApplyPatch(restartFold)
+				tick.apply(session.ID, restartFold)
 				if runtimeRunning {
 					if tmuxRequested && dops != nil {
 						if err := dops.clearRestartRequested(name); err != nil {
@@ -2515,7 +2516,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		if rateLimitHit || rateLimitErr != nil {
 			// Fold the rate-limit batch onto the snapshot (Step 6d write-returns-Info).
 			// Pre-pass-masked (STEP6-PREPASS-AUDIT group 1).
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rlBatchFwd)
+			tick.apply(session.ID, rlBatchFwd)
 			continue // rate-limit hold recorded before state healing resets continuity metadata
 		}
 
@@ -2543,7 +2544,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// restart/drain-ack blocks above either `continue` or self-refresh. This is
 		// one of the forward-pass writers the blanket pre-pass still masks; folding it
 		// is a prerequisite for that pre-pass's deletion (STEP6-PREPASS-AUDIT group 4).
-		infoByID[session.ID] = infoByID[session.ID].ApplyPatch(healBatch)
+		tick.apply(session.ID, healBatch)
 		if recoverPendingIdleSleep(session, sessFront, running, clk) {
 			alive = false
 			// Fold the idle-stop-pending recovery sleep onto the snapshot (Step 6d).
@@ -2552,12 +2553,12 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// the same SleepPatch reproduces the mirror exactly (slept_at /
 			// sleep_policy_fingerprint are non-Info). Pre-pass-masked (STEP6-PREPASS-AUDIT
 			// group 6).
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(sessionpkg.SleepPatch(clk.Now().UTC(), string(sessionpkg.SleepReasonIdle)))
+			tick.apply(session.ID, sessionpkg.SleepPatch(clk.Now().UTC(), string(sessionpkg.SleepReasonIdle)))
 		}
 		// Fold detached_at change onto the snapshot (Step 6d write-returns-Info).
 		// reconcileDetachedAt returns the {"detached_at": <value>} batch it mirrored,
 		// or nil on no-op. Pre-pass-masked (STEP6-PREPASS-AUDIT group 6).
-		infoByID[session.ID] = infoByID[session.ID].ApplyPatch(reconcileDetachedAt(session, store, policy, alive, sp, clk))
+		tick.apply(session.ID, reconcileDetachedAt(session, store, policy, alive, sp, clk))
 
 		// Stability check: detect rapid crash after state healing. Rate-limit
 		// detection intentionally ran above before healState.
@@ -2565,7 +2566,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// nil (no-op) when no stability event was recorded.
 		// Pre-pass-masked (STEP6-PREPASS-AUDIT group 2).
 		if stab, stabBatch := checkStability(session, cfg, alive, dt, sessFront, clk, nil); stab {
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(stabBatch)
+			tick.apply(session.ID, stabBatch)
 			continue // rapid exit recorded, skip further processing
 		}
 
@@ -2577,7 +2578,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// regardless of the bool — ExitProductiveDeath may clear churn_count.
 		// Pre-pass-masked (STEP6-PREPASS-AUDIT group 5).
 		churn, churnBatch := checkChurn(session, cfg, alive, dt, sessFront, clk)
-		infoByID[session.ID] = infoByID[session.ID].ApplyPatch(churnBatch)
+		tick.apply(session.ID, churnBatch)
 		if churn {
 			continue // churn recorded, skip further processing
 		}
@@ -2586,13 +2587,13 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// Fold the returned batch onto the snapshot (Step 6d write-returns-Info);
 		// nil (no-op) when nothing was cleared. Pre-pass-masked (STEP6-PREPASS-AUDIT group 5).
 		if alive && stableLongEnough(*session, clk) {
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(clearWakeFailures(session, sessFront))
+			tick.apply(session.ID, clearWakeFailures(session, sessFront))
 		}
 		// Clear churn counter for sessions that have been productive.
 		// Fold the returned batch onto the snapshot (Step 6d write-returns-Info);
 		// nil (no-op) when churn_count was already absent/zero. Pre-pass-masked (STEP6-PREPASS-AUDIT group 5).
 		if alive && productiveLongEnough(*session, clk) {
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(clearChurn(session, sessFront))
+			tick.apply(session.ID, clearChurn(session, sessFront))
 		}
 		if alive && shouldRollbackPendingCreate(session) {
 			switch stateBeforeHeal {
@@ -2619,7 +2620,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if !ok {
 				fmt.Fprintf(stderr, "session reconciler: recovering pending create %s: metadata repair incomplete\n", name) //nolint:errcheck
 			}
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(commitBatch)
+			tick.apply(session.ID, commitBatch)
 		}
 
 		// driftRestartedInPlace tracks whether the alive-restart branch ran
@@ -2663,7 +2664,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							} else {
 								fmt.Fprintf(stderr, "rebaselined legacy hash for %s (stored=%s current=%s)\n", name, truncateHashForLog(storedHash), truncateHashForLog(currentHash)) //nolint:errcheck
 							}
-							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rebaseBatch)
+							tick.apply(session.ID, rebaseBatch)
 							if trace != nil {
 								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, outcome, tp.TemplateName, name, traceRecordPayload{
 									"stored_hash":  storedHash,
@@ -2754,7 +2755,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								// session_key and continuation_reset_pending stay intentionally
 								// unthreaded (no same-tick Info reader) and self-heal on the next
 								// store reload. ApplyPatch(nil) is a no-op.
-								infoByID[session.ID] = infoByID[session.ID].ApplyPatch(launchBatch)
+								tick.apply(session.ID, launchBatch)
 								if relaunched {
 									continue
 								}
@@ -2763,7 +2764,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							// write-returns-Info). The alive lane falls through to the
 							// aggregating refresh @~2710 today, but folding here future-proofs
 							// that refresh's retirement (STEP6-PREPASS-AUDIT group 10).
-							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, string(sessionpkg.StateStartPending), clk.Now().UTC(), stderr))
+							tick.apply(session.ID, resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, string(sessionpkg.StateStartPending), clk.Now().UTC(), stderr))
 							if trace != nil {
 								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeRestartInPlace, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, nil))
 							}
@@ -2831,7 +2832,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								// session_key and continuation_reset_pending stay intentionally
 								// unthreaded (no same-tick Info reader) and self-heal on the next
 								// store reload. ApplyPatch(nil) is a no-op.
-								infoByID[session.ID] = infoByID[session.ID].ApplyPatch(launchBatch)
+								tick.apply(session.ID, launchBatch)
 								if relaunched {
 									continue
 								}
@@ -2889,7 +2890,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							} else {
 								fmt.Fprintf(stderr, "rebaselined legacy live hash for %s (stored=%s current=%s)\n", name, truncateHashForLog(storedLive), truncateHashForLog(currentLive)) //nolint:errcheck
 							}
-							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rebaseBatch)
+							tick.apply(session.ID, rebaseBatch)
 							if trace != nil {
 								trace.RecordDecision(TraceSiteReconcilerLiveDrift, TraceReasonLiveDrift, outcome, tp.TemplateName, name, traceRecordPayload{
 									"stored_hash":  storedLive,
@@ -2959,7 +2960,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							} else {
 								fmt.Fprintf(stderr, "rebaselined legacy hash for %s (stored=%s current=%s)\n", name, truncateHashForLog(storedHash), truncateHashForLog(currentHash)) //nolint:errcheck
 							}
-							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(rebaseBatch)
+							tick.apply(session.ID, rebaseBatch)
 							if trace != nil {
 								trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, outcome, tp.TemplateName, name, traceRecordPayload{
 									"stored_hash":  storedHash,
@@ -2973,7 +2974,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// write-returns-Info); this asleep lane `continue`s, so the fold must
 						// run before the continue. Clears restart_requested on the snapshot
 						// (#2574). Pre-pass-masked (STEP6-PREPASS-AUDIT group 10).
-						infoByID[session.ID] = infoByID[session.ID].ApplyPatch(resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, false, "asleep", clk.Now().UTC(), stderr))
+						tick.apply(session.ID, resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, false, "asleep", clk.Now().UTC(), stderr))
 						if trace != nil {
 							trace.RecordDecision(TraceSiteReconcilerConfigDrift, TraceReasonConfigDrift, TraceOutcomeRepairInPlace, tp.TemplateName, name, configDriftTracePayload(storedHash, currentHash, driftedFields, nil))
 						}
@@ -3070,7 +3071,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					// startCandidates, and the start executor reads last_woke_at (cleared
 					// by SleepPatch) off the raw bead via wakeFairnessTime before it
 					// re-Gets from the store; dropping the mirror would perturb ordering.
-					infoByID[session.ID] = infoByID[session.ID].ApplyPatch(batch)
+					tick.apply(session.ID, batch)
 					alive = false
 				}
 			}
@@ -3157,7 +3158,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					// loop above is RETAINED — same rationale as the max-age kill: the
 					// same-tick re-wake reads last_woke_at (cleared by SleepPatch) off the
 					// raw bead via wakeFairnessTime before the start executor re-Gets it.
-					infoByID[session.ID] = infoByID[session.ID].ApplyPatch(batch)
+					tick.apply(session.ID, batch)
 					alive = false
 				}
 			}
@@ -3288,7 +3289,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// inheriting the first episode's stale timestamp. See clearStrandedEventMarker.
 		if target.alive {
 			if fold := clearStrandedEventMarker(target.session, sessFront, stderr); fold != nil {
-				infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
+				tick.apply(target.session.ID, fold)
 			}
 		}
 
@@ -3364,7 +3365,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				})
 			}
 			if fold := recordCurrentBeadIDOnWake(target.session, sessFront, decision.AssignedWorkBeadID, stderr); fold != nil {
-				infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
+				tick.apply(target.session.ID, fold)
 			}
 			startCandidates = append(startCandidates, startCandidate{
 				session: target.session,
@@ -3385,7 +3386,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if decision.RequiresFreshCycle && info.WakeMode == "fresh" {
 				if ran, fold := cycleAliveSessionForFreshReassign(target.session, target.tp, sp, store, cfg, cb, name, decision.AssignedWorkBeadID, clk.Now(), stdout, stderr, trace); ran {
 					if fold != nil {
-						infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
+						tick.apply(target.session.ID, fold)
 					}
 					continue
 				}
@@ -3395,7 +3396,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// already alive before this metadata existed and refreshes the
 			// record after the agent picks up its next bead in resume mode.
 			if fold := recordCurrentBeadIDOnWake(target.session, sessFront, decision.AssignedWorkBeadID, stderr); fold != nil {
-				infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
+				tick.apply(target.session.ID, fold)
 			}
 			// Session is correctly awake. Cancel any non-drift drain
 			// (handles scale-back-up: agent returns to desired set while draining).
@@ -3408,7 +3409,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				// session bead anywhere downstream this tick — so Step 5c dropped the
 				// raw session.Metadata mirror.
 				_ = sessionFrontDoor(store).SetMarker(target.session.ID, "sleep_intent", "")
-				infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(sessionpkg.MetadataPatch{"sleep_intent": ""})
+				tick.apply(target.session.ID, sessionpkg.MetadataPatch{"sleep_intent": ""})
 			}
 		}
 
@@ -3437,7 +3438,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				}
 				if intent != "idle-stop-pending" {
 					if fold := markIdleSleepPending(target.session, sessFront); fold != nil {
-						infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
+						tick.apply(target.session.ID, fold)
 					}
 				}
 			}
@@ -3486,7 +3487,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// generation; the throttle marker on the bead itself
 			// keeps subsequent reconciler ticks quiet.
 			if fold := emitSessionStrandedDiagnostic(cityPath, cfg, store, rigStores, target.session, target.tp.TemplateName, rec, clk, stderr); fold != nil {
-				infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
+				tick.apply(target.session.ID, fold)
 			}
 			// Beyond diagnosis: once THIS stranding episode has been confirmed
 			// across the confirmation window (stranded_event_emitted_at aged past
@@ -3504,7 +3505,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// named-session retirement uses.
 			if !storeQueryPartial &&
 				repairStrandedPoolWorkerBead(store, rigStores, target.session, retiredSessionFallbackRoute(*target.session), clk, stderr) {
-				infoByID[target.session.ID] = infoByID[target.session.ID].MarkClosed()
+				tick.markClosed(target.session.ID)
 				pruneAgentHomeWorktreeIfSafe(*target.session, cityPath, cfg, stderr)
 			}
 		}
@@ -3526,7 +3527,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if closeBead(store, target.session.ID, closeReason, clk.Now().UTC(), stderr) {
 				// Store-only close family: mirror the close onto the snapshot
 				// (write-returns-Info) so a later reader sees Closed=true.
-				infoByID[target.session.ID] = infoByID[target.session.ID].MarkClosed()
+				tick.markClosed(target.session.ID)
 				// Pool worktrees are transient by design — reclaim disk
 				// when the session bead is retired. Skipped under safety
 				// gates (uncommitted, unpushed, stashed) and overridable


### PR DESCRIPTION
Phase 1 of the Info-migration: routes all Info writes through one tick-scoped mutator + a source-scan guard that makes the forgotten-fold coherence bug class unrepresentable; raw-bead mirror retained so behavior is unchanged. Phases 2 (mirror removal) & 3 (god-file split) are folded into the S19 reconciler roadmap. #3789/#1029/#3872.