### PR TITLE
simplify(S01) phase 1: beads cache absorb/evict primitives

### DIFF
--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -367,6 +367,124 @@ func (c *CachingStore) noteLocalMutationLocked(ids ...string) uint64 {
 	return seq
 }
 
+// absorbDepsMode selects how absorbFreshLocked sources the deps row for a bead.
+type absorbDepsMode int
+
+const (
+	// depsExplicit installs the caller-supplied opts.deps (cloned).
+	depsExplicit absorbDepsMode = iota
+	// depsFromFields recomputes deps from the bead's own fields, unconditionally
+	// (setting a nil entry when the bead carries no dependency fields).
+	depsFromFields
+	// depsFromFieldsIfCarried recomputes deps from the bead's fields only when
+	// the bead carries dependency fields; otherwise the cached deps row is left
+	// untouched.
+	depsFromFieldsIfCarried
+	// depsKeepCached leaves the cached deps row untouched.
+	depsKeepCached
+	// depsDrop removes the deps row.
+	depsDrop
+)
+
+// absorbSeqMode selects how absorbFreshLocked treats the beadSeq/localBeadAt
+// staleness fences for a bead.
+type absorbSeqMode int
+
+const (
+	// seqKeep touches neither fence. Used by write/event paths that ran
+	// noteMutationLocked/noteLocalMutationLocked immediately before the absorb
+	// and MUST preserve the fence they just set (the #2210 staleness defense).
+	seqKeep absorbSeqMode = iota
+	// seqClearGuarded clears both fences unless a recent local write-through is
+	// still inside the recency window.
+	seqClearGuarded
+	// seqClearBeadSeqOnly clears the beadSeq fence unconditionally and leaves
+	// localBeadAt untouched.
+	seqClearBeadSeqOnly
+)
+
+// absorbOpts describes the two axes of variation observed across the cache's
+// absorb sites: how the deps row is sourced and how the staleness fences are
+// treated. clearDirty is separate because a small number of sites (prime's
+// slow path, PrimeActive) deliberately leave a dirty mark in place across an
+// absorb.
+type absorbOpts struct {
+	depsMode   absorbDepsMode
+	deps       []Dep // consulted only for depsExplicit
+	seqMode    absorbSeqMode
+	clearDirty bool
+}
+
+// absorbFreshLocked installs a fresh row for id per opts. It is the only code
+// that installs a cached row alongside clearing the row's tombstone/staleness
+// state. now is the caller's clock read for the whole pass; it is consulted
+// only by seqClearGuarded. Caller must hold c.mu in write mode.
+func (c *CachingStore) absorbFreshLocked(id string, bead Bead, now time.Time, opts absorbOpts) {
+	c.beads[id] = cloneBead(bead)
+	switch opts.depsMode {
+	case depsExplicit:
+		c.deps[id] = cloneDeps(opts.deps)
+	case depsFromFields:
+		c.deps[id] = depsFromBeadFields(bead)
+	case depsFromFieldsIfCarried:
+		if beadCarriesDependencyFields(bead) {
+			c.deps[id] = depsFromBeadFields(bead)
+		}
+	case depsKeepCached:
+		// leave c.deps[id] untouched
+	case depsDrop:
+		delete(c.deps, id)
+	}
+	if opts.clearDirty {
+		delete(c.dirty, id)
+	}
+	delete(c.deletedSeq, id)
+	switch opts.seqMode {
+	case seqClearGuarded:
+		if !recentLocalMutation(c.localBeadAt[id], now) {
+			delete(c.beadSeq, id)
+			delete(c.localBeadAt, id)
+		}
+	case seqClearBeadSeqOnly:
+		delete(c.beadSeq, id)
+	}
+}
+
+// evictLocked removes every trace of id from the six per-row maps. It does not
+// touch mutationSeq, depsComplete, state, or stats. Caller must hold c.mu in
+// write mode.
+func (c *CachingStore) evictLocked(id string) {
+	delete(c.beads, id)
+	delete(c.deps, id)
+	delete(c.dirty, id)
+	delete(c.deletedSeq, id)
+	delete(c.beadSeq, id)
+	delete(c.localBeadAt, id)
+}
+
+// tombstoneLocked evicts id and installs a deletion fence at seq. seq must be a
+// mutationSeq value obtained under the same lock hold so the fence exceeds any
+// startSeq captured before this section. Caller must hold c.mu in write mode.
+func (c *CachingStore) tombstoneLocked(id string, seq uint64) {
+	c.evictLocked(id)
+	c.deletedSeq[id] = seq
+}
+
+// markDirtyLocked flags id as known-stale so reads bypass the cache until a
+// refresh clears the mark. Caller must hold c.mu in write mode.
+func (c *CachingStore) markDirtyLocked(id string) {
+	c.dirty[id] = struct{}{}
+}
+
+// clearStalenessMarksLocked clears the dirty flag and deletion fence for id
+// without touching the cached row or its deps. Used by the deps-overlay
+// fallbacks that trust an in-place dependency mutation. Caller must hold c.mu
+// in write mode.
+func (c *CachingStore) clearStalenessMarksLocked(id string) {
+	delete(c.dirty, id)
+	delete(c.deletedSeq, id)
+}
+
 // PrimeActive loads the common active bead statuses (open + in_progress) across
 // both persistent issues and ephemeral wisps into the cache. These are fast indexed
 // queries that populate enough data for
@@ -423,17 +541,14 @@ func (c *CachingStore) PrimeActive() error {
 		if _, keep := c.recentLocalBeadConflictLocked(b.ID, b, now, false); keep {
 			continue
 		}
-		c.beads[b.ID] = cloneBead(b)
+		opts := absorbOpts{seqMode: seqClearGuarded, clearDirty: false}
 		if depsComplete && depErr == nil {
-			c.deps[b.ID] = cloneDeps(depMap[b.ID])
+			opts.depsMode = depsExplicit
+			opts.deps = depMap[b.ID]
 		} else {
-			c.deps[b.ID] = depsFromBeadFields(b)
+			opts.depsMode = depsFromFields
 		}
-		delete(c.deletedSeq, b.ID)
-		if !recentLocalMutation(c.localBeadAt[b.ID], now) {
-			delete(c.beadSeq, b.ID)
-			delete(c.localBeadAt, b.ID)
-		}
+		c.absorbFreshLocked(b.ID, b, now, opts)
 	}
 	if c.state == cacheUninitialized {
 		c.state = cachePartial
@@ -576,14 +691,14 @@ func (c *CachingStore) prime(ctx context.Context) error {
 			if _, exists := c.beads[id]; exists {
 				continue
 			}
-			c.beads[id] = b
-			delete(c.deletedSeq, id)
-			delete(c.beadSeq, id)
+			opts := absorbOpts{seqMode: seqClearBeadSeqOnly, clearDirty: false}
 			if depsComplete && depErr == nil {
-				c.deps[id] = cloneDeps(depMap[id])
+				opts.depsMode = depsExplicit
+				opts.deps = depMap[id]
 			} else {
-				c.deps[id] = depsFromBeadFields(b)
+				opts.depsMode = depsFromFields
 			}
+			c.absorbFreshLocked(id, b, now, opts)
 		}
 		c.depsComplete = false
 	}

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -112,7 +112,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			// backing and are intentionally tolerated without declining.
 			if fieldConflictCached {
 				c.mu.Lock()
-				c.dirty[patch.ID] = struct{}{}
+				c.markDirtyLocked(patch.ID)
 				c.mu.Unlock()
 			}
 			return
@@ -217,10 +217,14 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	case "bead.created":
 		if _, exists := c.beads[b.ID]; !exists {
 			c.noteMutationLocked(b.ID)
-			c.beads[b.ID] = cloneBead(b)
+			// OC-3: absorb installs the row before updateEventDepsLocked, whose
+			// clearReadyProjectionLocked must observe the newly absorbed row.
+			c.absorbFreshLocked(b.ID, b, time.Now(), absorbOpts{
+				depsMode:   depsKeepCached,
+				seqMode:    seqKeep,
+				clearDirty: true,
+			})
 			c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking)
-			delete(c.dirty, b.ID)
-			delete(c.deletedSeq, b.ID)
 		}
 		c.updateStatsLocked()
 		mutated = true
@@ -231,9 +235,11 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		existing, cached := c.beads[b.ID]
 		if !cached || beadChanged(existing, b, false) {
 			c.noteMutationLocked(b.ID)
-			c.beads[b.ID] = cloneBead(b)
-			delete(c.dirty, b.ID)
-			delete(c.deletedSeq, b.ID)
+			c.absorbFreshLocked(b.ID, b, time.Now(), absorbOpts{
+				depsMode:   depsKeepCached,
+				seqMode:    seqKeep,
+				clearDirty: true,
+			})
 			mutated = true
 		}
 		if depsMutated := c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking); depsMutated && !mutated {
@@ -248,22 +254,20 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		if _, exists := c.beads[b.ID]; !exists {
 			c.updateStatsLocked()
 		}
-		c.beads[b.ID] = cloneBead(b)
+		// OC-3: absorb before updateEventDepsLocked (see bead.created).
+		c.absorbFreshLocked(b.ID, b, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking)
-		delete(c.dirty, b.ID)
-		delete(c.deletedSeq, b.ID)
 		mutated = true
 		if c.clearDependentReadyProjectionsLocked(b.ID) {
 			mutated = true
 		}
 	case "bead.deleted":
 		c.noteMutationLocked(b.ID)
-		delete(c.beads, b.ID)
-		delete(c.deps, b.ID)
-		delete(c.dirty, b.ID)
-		delete(c.beadSeq, b.ID)
-		delete(c.localBeadAt, b.ID)
-		c.deletedSeq[b.ID] = c.mutationSeq
+		c.tombstoneLocked(b.ID, c.mutationSeq)
 		c.updateStatsLocked()
 		mutated = true
 		if c.clearDependentReadyProjectionsLocked(b.ID) {
@@ -351,8 +355,7 @@ func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 	c.noteMutationLocked(beadID)
 	c.deps[beadID] = cloneDeps(deps)
 	c.clearReadyProjectionLocked(beadID)
-	delete(c.dirty, beadID)
-	delete(c.deletedSeq, beadID)
+	c.clearStalenessMarksLocked(beadID)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 }

--- a/internal/beads/caching_store_graph_apply.go
+++ b/internal/beads/caching_store_graph_apply.go
@@ -89,17 +89,19 @@ func (c *CachingStore) refreshGraphAppliedBeads(result *GraphApplyResult) {
 	for _, item := range refreshed {
 		if item.found {
 			fresh := cloneBead(item.bead)
-			c.beads[item.id] = fresh
-			c.deps[item.id] = cloneDeps(item.bead.Dependencies)
-			delete(c.dirty, item.id)
-			delete(c.deletedSeq, item.id)
+			c.absorbFreshLocked(item.id, item.bead, now, absorbOpts{
+				depsMode:   depsExplicit,
+				deps:       item.bead.Dependencies,
+				seqMode:    seqKeep,
+				clearDirty: true,
+			})
 			notifications = append(notifications, cacheNotification{
 				eventType: "bead.created",
 				bead:      fresh,
 			})
 			continue
 		}
-		c.dirty[item.id] = struct{}{}
+		c.markDirtyLocked(item.id)
 	}
 	c.markFreshLocked(now)
 	c.updateStatsLocked()

--- a/internal/beads/caching_store_primitives_test.go
+++ b/internal/beads/caching_store_primitives_test.go
@@ -1,0 +1,469 @@
+package beads
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// newPrimitiveTestStore builds a CachingStore with pre-seeded six-map state so
+// the primitive unit tests can assert exact post-state across ALL six maps —
+// the contract is as much about which maps do NOT move as which do.
+func newPrimitiveTestStore() *CachingStore {
+	return &CachingStore{
+		beads:       make(map[string]Bead),
+		deps:        make(map[string][]Dep),
+		dirty:       make(map[string]struct{}),
+		beadSeq:     make(map[string]uint64),
+		localBeadAt: make(map[string]time.Time),
+		deletedSeq:  make(map[string]uint64),
+	}
+}
+
+func TestEvictLockedRemovesAllSixMaps(t *testing.T) {
+	c := newPrimitiveTestStore()
+	id := "gc-1"
+	c.beads[id] = Bead{ID: id}
+	c.deps[id] = []Dep{{IssueID: id, DependsOnID: "gc-2", Type: "blocks"}}
+	c.dirty[id] = struct{}{}
+	c.beadSeq[id] = 7
+	c.localBeadAt[id] = time.Now()
+	c.deletedSeq[id] = 3
+	// Unrelated row must survive.
+	c.beads["gc-9"] = Bead{ID: "gc-9"}
+	c.beadSeq["gc-9"] = 4
+
+	c.evictLocked(id)
+
+	assertAbsent(t, c, id)
+	if _, ok := c.beads["gc-9"]; !ok {
+		t.Fatal("evictLocked removed an unrelated row")
+	}
+	if c.beadSeq["gc-9"] != 4 {
+		t.Fatal("evictLocked disturbed an unrelated beadSeq")
+	}
+}
+
+func TestTombstoneLockedEvictsThenFences(t *testing.T) {
+	c := newPrimitiveTestStore()
+	id := "gc-1"
+	c.beads[id] = Bead{ID: id}
+	c.deps[id] = []Dep{{IssueID: id}}
+	c.dirty[id] = struct{}{}
+	c.beadSeq[id] = 7
+	c.localBeadAt[id] = time.Now()
+	c.deletedSeq[id] = 2
+
+	c.tombstoneLocked(id, 42)
+
+	if _, ok := c.beads[id]; ok {
+		t.Fatal("tombstone left a live row")
+	}
+	if _, ok := c.deps[id]; ok {
+		t.Fatal("tombstone left deps")
+	}
+	if _, ok := c.dirty[id]; ok {
+		t.Fatal("tombstone left dirty")
+	}
+	if _, ok := c.beadSeq[id]; ok {
+		t.Fatal("tombstone left beadSeq")
+	}
+	if _, ok := c.localBeadAt[id]; ok {
+		t.Fatal("tombstone left localBeadAt")
+	}
+	if c.deletedSeq[id] != 42 {
+		t.Fatalf("tombstone fence = %d, want 42", c.deletedSeq[id])
+	}
+}
+
+func TestAbsorbFreshLockedDepsModes(t *testing.T) {
+	now := time.Now()
+	blocking := Bead{ID: "gc-1", Needs: []string{"gc-2"}}
+	bare := Bead{ID: "gc-1"}
+	cachedDeps := []Dep{{IssueID: "gc-1", DependsOnID: "gc-9", Type: "blocks"}}
+	explicit := []Dep{{IssueID: "gc-1", DependsOnID: "gc-3", Type: "blocks"}}
+
+	cases := []struct {
+		name     string
+		bead     Bead
+		opts     absorbOpts
+		wantDeps func(t *testing.T, deps []Dep, present bool)
+	}{
+		{
+			name: "explicit",
+			bead: bare,
+			opts: absorbOpts{depsMode: depsExplicit, deps: explicit, seqMode: seqKeep, clearDirty: true},
+			wantDeps: func(t *testing.T, deps []Dep, present bool) {
+				if !present || len(deps) != 1 || deps[0].DependsOnID != "gc-3" {
+					t.Fatalf("depsExplicit: got %v present=%v", deps, present)
+				}
+			},
+		},
+		{
+			name: "fromFields carrying",
+			bead: blocking,
+			opts: absorbOpts{depsMode: depsFromFields, seqMode: seqKeep, clearDirty: true},
+			wantDeps: func(t *testing.T, deps []Dep, present bool) {
+				if !present || len(deps) != 1 || deps[0].DependsOnID != "gc-2" {
+					t.Fatalf("depsFromFields carrying: got %v present=%v", deps, present)
+				}
+			},
+		},
+		{
+			name: "fromFields bare writes nil unconditionally",
+			bead: bare,
+			opts: absorbOpts{depsMode: depsFromFields, seqMode: seqKeep, clearDirty: true},
+			wantDeps: func(t *testing.T, deps []Dep, present bool) {
+				if !present || deps != nil {
+					t.Fatalf("depsFromFields bare: want present nil, got %v present=%v", deps, present)
+				}
+			},
+		},
+		{
+			name: "fromFieldsIfCarried skips bare",
+			bead: bare,
+			opts: absorbOpts{depsMode: depsFromFieldsIfCarried, seqMode: seqKeep, clearDirty: true},
+			wantDeps: func(t *testing.T, deps []Dep, present bool) {
+				if !present || len(deps) != 1 || deps[0].DependsOnID != "gc-9" {
+					t.Fatalf("depsFromFieldsIfCarried bare should keep cached: got %v present=%v", deps, present)
+				}
+			},
+		},
+		{
+			name: "keepCached",
+			bead: blocking,
+			opts: absorbOpts{depsMode: depsKeepCached, seqMode: seqKeep, clearDirty: true},
+			wantDeps: func(t *testing.T, deps []Dep, present bool) {
+				if !present || len(deps) != 1 || deps[0].DependsOnID != "gc-9" {
+					t.Fatalf("depsKeepCached: got %v present=%v", deps, present)
+				}
+			},
+		},
+		{
+			name: "drop",
+			bead: blocking,
+			opts: absorbOpts{depsMode: depsDrop, seqMode: seqKeep, clearDirty: true},
+			wantDeps: func(t *testing.T, deps []Dep, present bool) {
+				if present {
+					t.Fatalf("depsDrop: deps should be absent, got %v", deps)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newPrimitiveTestStore()
+			c.deps["gc-1"] = cachedDeps
+			c.dirty["gc-1"] = struct{}{}
+			c.deletedSeq["gc-1"] = 5
+			c.absorbFreshLocked("gc-1", tc.bead, now, tc.opts)
+
+			if _, ok := c.beads["gc-1"]; !ok {
+				t.Fatal("absorb did not install the row")
+			}
+			if _, ok := c.deletedSeq["gc-1"]; ok {
+				t.Fatal("absorb must always clear the tombstone")
+			}
+			if _, ok := c.dirty["gc-1"]; ok {
+				t.Fatal("clearDirty:true must clear the dirty mark")
+			}
+			deps, present := c.deps["gc-1"]
+			tc.wantDeps(t, deps, present)
+		})
+	}
+}
+
+func TestAbsorbFreshLockedSeqModes(t *testing.T) {
+	now := time.Now()
+
+	t.Run("seqKeep touches neither fence", func(t *testing.T) {
+		c := newPrimitiveTestStore()
+		c.beadSeq["gc-1"] = 9
+		c.localBeadAt["gc-1"] = now
+		c.absorbFreshLocked("gc-1", Bead{ID: "gc-1"}, now, absorbOpts{depsMode: depsKeepCached, seqMode: seqKeep, clearDirty: true})
+		if c.beadSeq["gc-1"] != 9 {
+			t.Fatal("seqKeep cleared beadSeq")
+		}
+		if _, ok := c.localBeadAt["gc-1"]; !ok {
+			t.Fatal("seqKeep cleared localBeadAt")
+		}
+	})
+
+	t.Run("seqClearGuarded keeps recent local", func(t *testing.T) {
+		c := newPrimitiveTestStore()
+		c.beadSeq["gc-1"] = 9
+		c.localBeadAt["gc-1"] = now // recent -> keep
+		c.absorbFreshLocked("gc-1", Bead{ID: "gc-1"}, now, absorbOpts{depsMode: depsKeepCached, seqMode: seqClearGuarded, clearDirty: true})
+		if c.beadSeq["gc-1"] != 9 {
+			t.Fatal("seqClearGuarded cleared a recent-local fence")
+		}
+		if _, ok := c.localBeadAt["gc-1"]; !ok {
+			t.Fatal("seqClearGuarded cleared a recent-local localBeadAt")
+		}
+	})
+
+	t.Run("seqClearGuarded clears stale local", func(t *testing.T) {
+		c := newPrimitiveTestStore()
+		c.beadSeq["gc-1"] = 9
+		c.localBeadAt["gc-1"] = now.Add(-10 * time.Second) // stale -> clear
+		c.absorbFreshLocked("gc-1", Bead{ID: "gc-1"}, now, absorbOpts{depsMode: depsKeepCached, seqMode: seqClearGuarded, clearDirty: true})
+		if _, ok := c.beadSeq["gc-1"]; ok {
+			t.Fatal("seqClearGuarded left a stale beadSeq")
+		}
+		if _, ok := c.localBeadAt["gc-1"]; ok {
+			t.Fatal("seqClearGuarded left a stale localBeadAt")
+		}
+	})
+
+	t.Run("seqClearBeadSeqOnly clears beadSeq keeps localBeadAt", func(t *testing.T) {
+		c := newPrimitiveTestStore()
+		c.beadSeq["gc-1"] = 9
+		c.localBeadAt["gc-1"] = now
+		c.absorbFreshLocked("gc-1", Bead{ID: "gc-1"}, now, absorbOpts{depsMode: depsKeepCached, seqMode: seqClearBeadSeqOnly, clearDirty: true})
+		if _, ok := c.beadSeq["gc-1"]; ok {
+			t.Fatal("seqClearBeadSeqOnly left beadSeq")
+		}
+		if _, ok := c.localBeadAt["gc-1"]; !ok {
+			t.Fatal("seqClearBeadSeqOnly cleared localBeadAt")
+		}
+	})
+}
+
+func TestAbsorbFreshLockedClearDirtyFalseKeepsMark(t *testing.T) {
+	now := time.Now()
+	c := newPrimitiveTestStore()
+	c.dirty["gc-1"] = struct{}{}
+	c.absorbFreshLocked("gc-1", Bead{ID: "gc-1"}, now, absorbOpts{depsMode: depsKeepCached, seqMode: seqKeep, clearDirty: false})
+	if _, ok := c.dirty["gc-1"]; !ok {
+		t.Fatal("clearDirty:false must leave the dirty mark in place")
+	}
+	if _, ok := c.deletedSeq["gc-1"]; ok {
+		t.Fatal("absorb must clear the tombstone even when clearDirty is false")
+	}
+}
+
+// T7 — seqKeep divergence guard.
+//
+// Event paths run noteMutationLocked (beadSeq only, NO localBeadAt) immediately
+// before absorbing. seqKeep is load-bearing there: a seqClearGuarded at an
+// event site would find no recent localBeadAt and DELETE the beadSeq fence the
+// event just installed, so the next in-flight snapshot (an older-startSeq List
+// or reconcile) would clobber the event's row — the #2210/#2987 stale-read
+// class. These tests pin that the real event sites keep the fence and that a
+// stale snapshot is rejected by it.
+
+// TestApplyEventSitesPreserveBeadSeqFence exercises each real event absorb site
+// (EV1 created, EV2 updated, EV3 closed) and asserts the beadSeq fence set by
+// the event's noteMutationLocked survives the absorb (seqKeep).
+func TestApplyEventSitesPreserveBeadSeqFence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bead.created", func(t *testing.T) {
+		t.Parallel()
+		backing := NewMemStore()
+		cache := NewCachingStoreForTest(backing, nil)
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime: %v", err)
+		}
+		cache.ApplyEvent("bead.created", json.RawMessage(`{"id":"gc-created","status":"open","issue_type":"task"}`))
+		assertBeadSeqPresent(t, cache, "gc-created")
+	})
+
+	t.Run("bead.updated", func(t *testing.T) {
+		t.Parallel()
+		backing := NewMemStore()
+		bead, err := backing.Create(Bead{Title: "before", Status: "open", Type: "task"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		cache := NewCachingStoreForTest(backing, nil)
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime: %v", err)
+		}
+		after := "after"
+		if err := backing.Update(bead.ID, UpdateOpts{Title: &after}); err != nil {
+			t.Fatalf("Update backing: %v", err)
+		}
+		cache.ApplyEvent("bead.updated", json.RawMessage(`{"id":"`+bead.ID+`","title":"after"}`))
+		assertBeadSeqPresent(t, cache, bead.ID)
+	})
+
+	t.Run("bead.closed", func(t *testing.T) {
+		t.Parallel()
+		backing := NewMemStore()
+		bead, err := backing.Create(Bead{Title: "open", Status: "open", Type: "task"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		cache := NewCachingStoreForTest(backing, nil)
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime: %v", err)
+		}
+		if err := backing.Close(bead.ID); err != nil {
+			t.Fatalf("Close backing: %v", err)
+		}
+		cache.ApplyEvent("bead.closed", json.RawMessage(`{"id":"`+bead.ID+`","status":"closed"}`))
+		assertBeadSeqPresent(t, cache, bead.ID)
+	})
+}
+
+// TestStaleSnapshotDoesNotClobberFencedEventRow drives the real List-refresh
+// merge (refreshCachedBeads) with a startSeq captured BEFORE an event and a
+// stale snapshot of the pre-event row. The beadSeq fence the event installed
+// (> startSeq) must reject the stale row: the cached (event) row survives and
+// the stale value is never absorbed.
+func TestStaleSnapshotDoesNotClobberFencedEventRow(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "before-event", Status: "open", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	cache.mu.RLock()
+	staleStartSeq := cache.mutationSeq
+	cache.mu.RUnlock()
+
+	// The event advances the row past staleStartSeq and installs the beadSeq
+	// fence via noteMutationLocked; the backing is updated first so the event
+	// carries no field conflict against the cache.
+	after := "after-event"
+	if err := backing.Update(bead.ID, UpdateOpts{Title: &after}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+	cache.ApplyEvent("bead.updated", json.RawMessage(`{"id":"`+bead.ID+`","title":"after-event"}`))
+
+	cache.mu.RLock()
+	fenced := cache.beadSeq[bead.ID] > staleStartSeq
+	cache.mu.RUnlock()
+	if !fenced {
+		t.Fatalf("precondition: event did not install a beadSeq fence past startSeq")
+	}
+
+	staleItem := Bead{ID: bead.ID, Title: "before-event", Status: "open", Type: "task"}
+	refreshed := cache.refreshCachedBeads(ListQuery{Status: "open"}, staleStartSeq, []Bead{staleItem})
+
+	cache.mu.RLock()
+	cachedTitle := cache.beads[bead.ID].Title
+	cache.mu.RUnlock()
+	if cachedTitle != "after-event" {
+		t.Fatalf("stale snapshot clobbered the fenced row: cached title = %q, want %q", cachedTitle, "after-event")
+	}
+	for _, b := range refreshed {
+		if b.ID == bead.ID && b.Title == "before-event" {
+			t.Fatal("stale snapshot value was served past the beadSeq fence")
+		}
+	}
+}
+
+// TestAbsorbSeqModeDivergenceAtEventPreState meta-verifies the seqKeep vs
+// seqClearGuarded divergence against the exact pre-state an event site leaves:
+// beadSeq set, localBeadAt absent (noteMutationLocked stamps only beadSeq).
+// seqKeep preserves the fence; seqClearGuarded — the wrong choice at an event
+// site — deletes it, which is precisely the silent stale-read regression T7
+// exists to catch.
+func TestAbsorbSeqModeDivergenceAtEventPreState(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	seqKeepStore := newPrimitiveTestStore()
+	seqKeepStore.beadSeq["gc-1"] = 9 // noteMutationLocked-style: beadSeq only
+	seqKeepStore.absorbFreshLocked("gc-1", Bead{ID: "gc-1"}, now, absorbOpts{depsMode: depsKeepCached, seqMode: seqKeep, clearDirty: true})
+	if seqKeepStore.beadSeq["gc-1"] != 9 {
+		t.Fatal("seqKeep must preserve the event-installed beadSeq fence")
+	}
+
+	seqClearStore := newPrimitiveTestStore()
+	seqClearStore.beadSeq["gc-1"] = 9 // same event pre-state: no localBeadAt
+	seqClearStore.absorbFreshLocked("gc-1", Bead{ID: "gc-1"}, now, absorbOpts{depsMode: depsKeepCached, seqMode: seqClearGuarded, clearDirty: true})
+	if _, ok := seqClearStore.beadSeq["gc-1"]; ok {
+		t.Fatal("expected seqClearGuarded to DELETE the fence at the event pre-state (this is why event sites MUST use seqKeep)")
+	}
+}
+
+// T6 — ApplyEvent OC-3 ordering: absorb installs the row BEFORE the
+// deps-overlay (updateEventDepsLocked → setEventDepsLocked →
+// clearReadyProjectionLocked), so the overlay observes the newly absorbed row.
+// If the order were inverted, clearReadyProjectionLocked would no-op on the
+// still-absent row and the projected IsBlocked would survive.
+func TestApplyEventAbsorbsBeforeDepsOverlay_OC3(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	blocker, err := backing.Create(Bead{Title: "blocker", Status: "open", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// A created event that carries a projected IsBlocked AND dependency fields.
+	// EV1 absorbs the row (IsBlocked=true) then runs the deps overlay, which
+	// clears the projection now that authoritative deps are known.
+	payload, err := json.Marshal(map[string]any{
+		"id":         "gc-blocked",
+		"status":     "open",
+		"issue_type": "task",
+		"is_blocked": true,
+		"needs":      []string{blocker.ID},
+	})
+	if err != nil {
+		t.Fatalf("marshal created event: %v", err)
+	}
+	cache.ApplyEvent("bead.created", payload)
+
+	got, err := cache.Get("gc-blocked")
+	if err != nil {
+		t.Fatalf("Get after created event: %v", err)
+	}
+	if got.IsBlocked != nil {
+		t.Fatalf("OC-3 violated: projected IsBlocked = %v, want nil (overlay must clear the newly absorbed row)", *got.IsBlocked)
+	}
+
+	cache.mu.RLock()
+	_, hasDeps := cache.deps["gc-blocked"]
+	cache.mu.RUnlock()
+	if !hasDeps {
+		t.Fatal("expected the deps overlay to install authoritative deps for the absorbed row")
+	}
+}
+
+func assertBeadSeqPresent(t *testing.T, c *CachingStore, id string) {
+	t.Helper()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if _, ok := c.beadSeq[id]; !ok {
+		t.Fatalf("event site did not preserve the beadSeq fence for %s (seqKeep regression)", id)
+	}
+}
+
+func assertAbsent(t *testing.T, c *CachingStore, id string) {
+	t.Helper()
+	if _, ok := c.beads[id]; ok {
+		t.Fatalf("%s still in beads", id)
+	}
+	if _, ok := c.deps[id]; ok {
+		t.Fatalf("%s still in deps", id)
+	}
+	if _, ok := c.dirty[id]; ok {
+		t.Fatalf("%s still in dirty", id)
+	}
+	if _, ok := c.beadSeq[id]; ok {
+		t.Fatalf("%s still in beadSeq", id)
+	}
+	if _, ok := c.localBeadAt[id]; ok {
+		t.Fatalf("%s still in localBeadAt", id)
+	}
+	if _, ok := c.deletedSeq[id]; ok {
+		t.Fatalf("%s still in deletedSeq", id)
+	}
+}

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -230,16 +230,11 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 				continue
 			}
 		}
-		c.beads[item.ID] = cloneBead(item)
-		if beadCarriesDependencyFields(item) {
-			c.deps[item.ID] = depsFromBeadFields(item)
-		}
-		delete(c.dirty, item.ID)
-		delete(c.deletedSeq, item.ID)
-		if !recentLocalMutation(c.localBeadAt[item.ID], now) {
-			delete(c.beadSeq, item.ID)
-			delete(c.localBeadAt, item.ID)
-		}
+		c.absorbFreshLocked(item.ID, item, now, absorbOpts{
+			depsMode:   depsFromFieldsIfCarried,
+			seqMode:    seqClearGuarded,
+			clearDirty: true,
+		})
 		if query.Matches(item) {
 			refreshed = append(refreshed, cloneBead(item))
 		}
@@ -251,16 +246,11 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 		if _, keep := c.recentLocalBeadConflictLocked(id, bead, now, false); keep {
 			continue
 		}
-		c.beads[id] = bead
-		if beadCarriesDependencyFields(bead) {
-			c.deps[id] = depsFromBeadFields(bead)
-		}
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
-		if !recentLocalMutation(c.localBeadAt[id], now) {
-			delete(c.beadSeq, id)
-			delete(c.localBeadAt, id)
-		}
+		c.absorbFreshLocked(id, bead, now, absorbOpts{
+			depsMode:   depsFromFieldsIfCarried,
+			seqMode:    seqClearGuarded,
+			clearDirty: true,
+		})
 	}
 	for id := range removedParents {
 		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
@@ -269,12 +259,7 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 		if current, ok := c.beads[id]; ok && current.Status != "closed" && recentLocalMutation(c.localBeadAt[id], now) {
 			continue
 		}
-		delete(c.beads, id)
-		delete(c.deps, id)
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
-		delete(c.beadSeq, id)
-		delete(c.localBeadAt, id)
+		c.evictLocked(id)
 	}
 	for id, bead := range refreshedLiveMissing {
 		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
@@ -283,16 +268,11 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 		if _, keep := c.recentLocalBeadConflictLocked(id, bead, now, false); keep {
 			continue
 		}
-		c.beads[id] = bead
-		if beadCarriesDependencyFields(bead) {
-			c.deps[id] = depsFromBeadFields(bead)
-		}
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
-		if !recentLocalMutation(c.localBeadAt[id], now) {
-			delete(c.beadSeq, id)
-			delete(c.localBeadAt, id)
-		}
+		c.absorbFreshLocked(id, bead, now, absorbOpts{
+			depsMode:   depsFromFieldsIfCarried,
+			seqMode:    seqClearGuarded,
+			clearDirty: true,
+		})
 	}
 	for id := range removedLiveMissing {
 		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
@@ -301,12 +281,7 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 		if current, ok := c.beads[id]; ok && current.Status != "closed" && recentLocalMutation(c.localBeadAt[id], now) {
 			continue
 		}
-		delete(c.beads, id)
-		delete(c.deps, id)
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
-		delete(c.beadSeq, id)
-		delete(c.localBeadAt, id)
+		c.evictLocked(id)
 	}
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
@@ -424,11 +399,11 @@ func (c *CachingStore) Get(id string) (Bead, error) {
 				c.mu.Unlock()
 				return Bead{}, ErrNotFound
 			}
-			c.beads[id] = cloneBead(fresh)
-			c.deps[id] = depsFromBeadFields(fresh)
-			delete(c.dirty, id)
-			delete(c.deletedSeq, id)
-			delete(c.beadSeq, id)
+			c.absorbFreshLocked(id, fresh, time.Now(), absorbOpts{
+				depsMode:   depsFromFields,
+				seqMode:    seqClearBeadSeqOnly,
+				clearDirty: true,
+			})
 			c.markFreshLocked(time.Now())
 			c.updateStatsLocked()
 			c.mu.Unlock()

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -387,14 +387,12 @@ func (c *CachingStore) runReconciliation() {
 				})
 			}
 
-			c.beads[id] = cloneBead(freshBead)
-			c.deps[id] = cloneDeps(freshDeps)
-			delete(c.dirty, id)
-			delete(c.deletedSeq, id)
-			if !recentLocalMutation(c.localBeadAt[id], now) {
-				delete(c.beadSeq, id)
-				delete(c.localBeadAt, id)
-			}
+			c.absorbFreshLocked(id, freshBead, now, absorbOpts{
+				depsMode:   depsExplicit,
+				deps:       freshDeps,
+				seqMode:    seqClearGuarded,
+				clearDirty: true,
+			})
 		}
 
 		for id, old := range c.beads {
@@ -419,12 +417,7 @@ func (c *CachingStore) runReconciliation() {
 					bead:      closed,
 				})
 			}
-			delete(c.beads, id)
-			delete(c.deps, id)
-			delete(c.dirty, id)
-			delete(c.deletedSeq, id)
-			delete(c.beadSeq, id)
-			delete(c.localBeadAt, id)
+			c.evictLocked(id)
 		}
 
 		c.syncFailures = 0

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -39,10 +39,11 @@ func (c *CachingStore) createWith(create func() (Bead, error)) (Bead, error) {
 
 	c.mu.Lock()
 	c.noteLocalMutationLocked(created.ID)
-	c.beads[created.ID] = cloneBead(created)
-	c.deps[created.ID] = depsFromBeadFields(created)
-	delete(c.dirty, created.ID)
-	delete(c.deletedSeq, created.ID)
+	c.absorbFreshLocked(created.ID, created, time.Now(), absorbOpts{
+		depsMode:   depsFromFields,
+		seqMode:    seqKeep,
+		clearDirty: true,
+	})
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	c.mu.Unlock()
@@ -79,12 +80,7 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 				closed.Status = "closed"
 				notifyClosed = true
 			}
-			delete(c.beads, id)
-			delete(c.deps, id)
-			delete(c.dirty, id)
-			delete(c.beadSeq, id)
-			delete(c.localBeadAt, id)
-			c.deletedSeq[id] = seq
+			c.tombstoneLocked(id, seq)
 			c.clearDependentReadyProjectionsLocked(id)
 			c.markFreshLocked(time.Now())
 			c.updateStatsLocked()
@@ -96,20 +92,22 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 		}
 		if current, ok := c.beads[id]; ok {
 			fresh = applyUpdateOptsToBead(current, opts)
-			c.beads[id] = cloneBead(fresh)
-			c.deps[id] = depsFromBeadFields(fresh)
+			c.absorbFreshLocked(id, fresh, time.Now(), absorbOpts{
+				depsMode:   depsFromFields,
+				seqMode:    seqKeep,
+				clearDirty: false,
+			})
 			if opts.Status != nil {
 				c.clearDependentReadyProjectionsLocked(id)
 			}
-			c.dirty[id] = struct{}{}
-			delete(c.deletedSeq, id)
+			c.markDirtyLocked(id)
 			c.updateStatsLocked()
 			c.mu.Unlock()
 			c.recordProblem("refresh bead after update", fmt.Errorf("%s: %w", id, err))
 			c.notifyChange("bead.updated", fresh)
 			return nil
 		}
-		c.dirty[id] = struct{}{}
+		c.markDirtyLocked(id)
 		c.mu.Unlock()
 		c.recordProblem("refresh bead after update", fmt.Errorf("%s: %w", id, err))
 		return nil
@@ -118,13 +116,14 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 
 	c.mu.Lock()
 	c.noteLocalMutationLocked(id)
-	c.beads[id] = cloneBead(fresh)
-	c.deps[id] = depsFromBeadFields(fresh)
+	c.absorbFreshLocked(id, fresh, time.Now(), absorbOpts{
+		depsMode:   depsFromFields,
+		seqMode:    seqKeep,
+		clearDirty: true,
+	})
 	if opts.Status != nil {
 		c.clearDependentReadyProjectionsLocked(id)
 	}
-	delete(c.dirty, id)
-	delete(c.deletedSeq, id)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	c.mu.Unlock()
@@ -151,23 +150,27 @@ func (c *CachingStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, erro
 	c.mu.Lock()
 	c.noteLocalMutationLocked(id)
 	if refreshed {
-		c.beads[id] = cloneBead(fresh)
-		c.deps[id] = depsFromBeadFields(fresh)
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, fresh, time.Now(), absorbOpts{
+			depsMode:   depsFromFields,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		updated = cloneBead(fresh)
 		notify = true
 	} else if b, ok := c.beads[id]; ok {
 		b.Status = "open"
 		b.Assignee = ""
 		b.UpdatedAt = time.Now()
-		c.beads[id] = b
-		c.dirty[id] = struct{}{}
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: false,
+		})
+		c.markDirtyLocked(id)
 		updated = cloneBead(b)
 		notify = true
 	} else {
-		c.dirty[id] = struct{}{}
+		c.markDirtyLocked(id)
 	}
 	c.clearDependentReadyProjectionsLocked(id)
 	c.markFreshLocked(time.Now())
@@ -206,15 +209,19 @@ func (c *CachingStore) Close(id string) error {
 	c.noteLocalMutationLocked(id)
 	if b, ok := c.beads[id]; ok {
 		b.Status = "closed"
-		c.beads[id] = b
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		closed = cloneBead(b)
 		found = true
 	} else if found {
-		c.beads[id] = cloneBead(closed)
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, closed, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 	}
 	dependentProjectionCleared := c.clearDependentReadyProjectionsLocked(id)
 	if found || dependentProjectionCleared {
@@ -249,15 +256,19 @@ func (c *CachingStore) Reopen(id string) error {
 	c.noteLocalMutationLocked(id)
 	if b, ok := c.beads[id]; ok {
 		b.Status = "open"
-		c.beads[id] = b
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		reopened = cloneBead(b)
 		found = true
 	} else if found {
-		c.beads[id] = cloneBead(reopened)
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, reopened, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 	}
 	dependentProjectionCleared := c.clearDependentReadyProjectionsLocked(id)
 	if found || dependentProjectionCleared {
@@ -303,15 +314,16 @@ func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, 
 		c.recordProblemLocked("close-all refresh", refreshErr)
 	}
 	for id := range refreshFailed {
-		c.dirty[id] = struct{}{}
+		c.markDirtyLocked(id)
 	}
 	for _, item := range refreshed {
 		previous, hadPrevious := c.beads[item.id]
-		c.beads[item.id] = cloneBead(item.bead)
-		delete(c.dirty, item.id)
-		delete(c.deletedSeq, item.id)
+		opts := absorbOpts{depsMode: depsKeepCached, seqMode: seqKeep, clearDirty: true}
 		if item.bead.Status == "closed" {
-			delete(c.deps, item.id)
+			opts.depsMode = depsDrop
+		}
+		c.absorbFreshLocked(item.id, item.bead, time.Now(), opts)
+		if item.bead.Status == "closed" {
 			c.clearDependentReadyProjectionsLocked(item.id)
 		}
 		if hadPrevious && previous.Status != "closed" && item.bead.Status == "closed" {
@@ -352,10 +364,11 @@ func (c *CachingStore) SetMetadata(id, key, value string) error {
 	c.mu.Lock()
 	c.noteLocalMutationLocked(id)
 	if refreshed {
-		c.beads[id] = cloneBead(fresh)
-		c.deps[id] = depsFromBeadFields(fresh)
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, fresh, time.Now(), absorbOpts{
+			depsMode:   depsFromFields,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		updated = cloneBead(fresh)
 		notify = true
 	} else if b, ok := c.beads[id]; ok {
@@ -363,13 +376,15 @@ func (c *CachingStore) SetMetadata(id, key, value string) error {
 			b.Metadata = make(map[string]string)
 		}
 		b.Metadata[key] = value
-		c.beads[id] = b
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		updated = cloneBead(b)
 		notify = true
 	} else {
-		c.dirty[id] = struct{}{}
+		c.markDirtyLocked(id)
 	}
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
@@ -404,10 +419,11 @@ func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error 
 	c.mu.Lock()
 	c.noteLocalMutationLocked(id)
 	if refreshed {
-		c.beads[id] = cloneBead(fresh)
-		c.deps[id] = depsFromBeadFields(fresh)
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, fresh, time.Now(), absorbOpts{
+			depsMode:   depsFromFields,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		updated = cloneBead(fresh)
 		notify = true
 	} else if b, ok := c.beads[id]; ok {
@@ -417,13 +433,15 @@ func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error 
 		for k, v := range kvs {
 			b.Metadata[k] = v
 		}
-		c.beads[id] = b
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		updated = cloneBead(b)
 		notify = true
 	} else {
-		c.dirty[id] = struct{}{}
+		c.markDirtyLocked(id)
 	}
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
@@ -587,10 +605,11 @@ func (c *CachingStore) refreshTxTouchedBeads(ids []string, closed map[string]str
 			if hadPrevious && previous.Status != fresh.Status {
 				statusChanged = true
 			}
-			c.beads[item.id] = fresh
-			c.deps[item.id] = depsFromBeadFields(fresh)
-			delete(c.dirty, item.id)
-			delete(c.deletedSeq, item.id)
+			c.absorbFreshLocked(item.id, fresh, now, absorbOpts{
+				depsMode:   depsFromFields,
+				seqMode:    seqKeep,
+				clearDirty: true,
+			})
 			if statusChanged {
 				c.clearDependentReadyProjectionsLocked(item.id)
 			}
@@ -609,9 +628,11 @@ func (c *CachingStore) refreshTxTouchedBeads(ids []string, closed map[string]str
 		if item.closed {
 			if b, ok := c.beads[item.id]; ok {
 				b.Status = "closed"
-				c.beads[item.id] = b
-				delete(c.dirty, item.id)
-				delete(c.deletedSeq, item.id)
+				c.absorbFreshLocked(item.id, b, now, absorbOpts{
+					depsMode:   depsKeepCached,
+					seqMode:    seqKeep,
+					clearDirty: true,
+				})
 				c.clearDependentReadyProjectionsLocked(item.id)
 				notifications = append(notifications, cacheNotification{
 					eventType: "bead.closed",
@@ -621,7 +642,7 @@ func (c *CachingStore) refreshTxTouchedBeads(ids []string, closed map[string]str
 			continue
 		}
 		if item.err != nil {
-			c.dirty[item.id] = struct{}{}
+			c.markDirtyLocked(item.id)
 		}
 	}
 	c.markFreshLocked(now)
@@ -794,11 +815,13 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 	c.mu.Lock()
 	c.noteLocalMutationLocked(issueID)
 	if refreshed {
-		c.beads[issueID] = cloneBead(fresh)
-		c.deps[issueID] = cloneDeps(deps)
+		c.absorbFreshLocked(issueID, fresh, time.Now(), absorbOpts{
+			depsMode:   depsExplicit,
+			deps:       deps,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		c.clearReadyProjectionLocked(issueID)
-		delete(c.dirty, issueID)
-		delete(c.deletedSeq, issueID)
 		c.markFreshLocked(time.Now())
 		c.updateStatsLocked()
 		c.mu.Unlock()
@@ -807,8 +830,7 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 	}
 	if !c.depsComplete {
 		if _, known := c.deps[issueID]; !known {
-			delete(c.dirty, issueID)
-			delete(c.deletedSeq, issueID)
+			c.clearStalenessMarksLocked(issueID)
 			c.markFreshLocked(time.Now())
 			c.updateStatsLocked()
 			c.mu.Unlock()
@@ -821,8 +843,7 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 			cachedDeps[i].Type = depType
 			c.deps[issueID] = cachedDeps
 			c.clearReadyProjectionLocked(issueID)
-			delete(c.dirty, issueID)
-			delete(c.deletedSeq, issueID)
+			c.clearStalenessMarksLocked(issueID)
 			c.markFreshLocked(time.Now())
 			c.updateStatsLocked()
 			c.mu.Unlock()
@@ -831,8 +852,7 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 	}
 	c.deps[issueID] = append(cachedDeps, Dep{IssueID: issueID, DependsOnID: dependsOnID, Type: depType})
 	c.clearReadyProjectionLocked(issueID)
-	delete(c.dirty, issueID)
-	delete(c.deletedSeq, issueID)
+	c.clearStalenessMarksLocked(issueID)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	c.mu.Unlock()
@@ -849,11 +869,13 @@ func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
 	c.mu.Lock()
 	c.noteLocalMutationLocked(issueID)
 	if refreshed {
-		c.beads[issueID] = cloneBead(fresh)
-		c.deps[issueID] = cloneDeps(deps)
+		c.absorbFreshLocked(issueID, fresh, time.Now(), absorbOpts{
+			depsMode:   depsExplicit,
+			deps:       deps,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
 		c.clearReadyProjectionLocked(issueID)
-		delete(c.dirty, issueID)
-		delete(c.deletedSeq, issueID)
 		c.markFreshLocked(time.Now())
 		c.updateStatsLocked()
 		c.mu.Unlock()
@@ -862,8 +884,7 @@ func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
 	}
 	if !c.depsComplete {
 		if _, known := c.deps[issueID]; !known {
-			delete(c.dirty, issueID)
-			delete(c.deletedSeq, issueID)
+			c.clearStalenessMarksLocked(issueID)
 			c.markFreshLocked(time.Now())
 			c.updateStatsLocked()
 			c.mu.Unlock()
@@ -875,8 +896,7 @@ func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
 		if d.DependsOnID == dependsOnID {
 			c.deps[issueID] = append(cachedDeps[:i], cachedDeps[i+1:]...)
 			c.clearReadyProjectionLocked(issueID)
-			delete(c.dirty, issueID)
-			delete(c.deletedSeq, issueID)
+			c.clearStalenessMarksLocked(issueID)
 			break
 		}
 	}
@@ -895,12 +915,7 @@ func (c *CachingStore) Delete(id string) error {
 
 	c.mu.Lock()
 	seq := c.noteLocalMutationLocked(id)
-	delete(c.beads, id)
-	delete(c.deps, id)
-	delete(c.dirty, id)
-	delete(c.beadSeq, id)
-	delete(c.localBeadAt, id)
-	c.deletedSeq[id] = seq
+	c.tombstoneLocked(id, seq)
 	c.clearDependentReadyProjectionsLocked(id)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()


### PR DESCRIPTION
<Phase 1 only: two locked primitives (absorbFreshLocked/evictLocked) become the sole writers of the six cache maps; ~15 mutation sites repointed. Byte-identical — the existing internal/beads white-box corpus passes unmodified; -race clean; T6/T7 lock the seqKeep/ordering risk. Phase 2 (runReconciliation collapse) deferred pending sign-off. #2987/#2153. Spec: engdocs/simplification/specs/S01-cache-primitives-spec.md>