### PR TITLE
refactor(beadmeta): MoleculeFailedMetadataKey constant, retire bare "molecule_failed" literals

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -950,7 +950,7 @@ func closeFormulaCookFailedGraphV2Roots(store beads.Store, recipe *formula.Recip
 		return fmt.Errorf("looking up failed formulas v2 roots for key %s: %w", key, err)
 	}
 	for _, root := range matches {
-		if root.Status == "closed" || root.Metadata["molecule_failed"] != "true" {
+		if root.Status == "closed" || root.Metadata[beadmeta.MoleculeFailedMetadataKey] != "true" {
 			continue
 		}
 		if _, err := sourceworkflow.CloseWorkflowSubtree(store, root.ID); err != nil {

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -253,6 +253,12 @@ const (
 	// MoleculeIDMetadataKey links a poured/wisp work bead to its molecule root.
 	MoleculeIDMetadataKey = "molecule_id"
 
+	// MoleculeFailedMetadataKey marks the beads of a partially-instantiated
+	// molecule as failed (value "true"). Written best-effort by
+	// internal/molecule markFailed on instantiation error paths; read by
+	// dispatch/sling/cmd/gc to skip or close failed roots.
+	MoleculeFailedMetadataKey = "molecule_failed"
+
 	// MergeStrategyMetadataKey records the merge strategy chosen for a slung bead.
 	MergeStrategyMetadataKey = "merge_strategy"
 )

--- a/internal/beadmeta/keys_test.go
+++ b/internal/beadmeta/keys_test.go
@@ -64,6 +64,7 @@ func TestPinnedValues(t *testing.T) {
 		FormulaVarPrefix:             "gc.var.",
 		Namespace:                    "gc.",
 		OptionMetadataPrefix:         "opt_",
+		MoleculeFailedMetadataKey:    "molecule_failed",
 	}
 	for got, want := range pinned {
 		if got != want {

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -566,7 +566,7 @@ func failedAttemptAttachRootID(store beads.Store, control beads.Bead, attemptNum
 		Metadata: map[string]string{
 			beadmeta.IdempotencyKeyMetadataKey: fmt.Sprintf("%s:attempt:%d", control.ID, attemptNum),
 			beadmeta.RootBeadIDMetadataKey:     rootID,
-			"molecule_failed":                  "true",
+			beadmeta.MoleculeFailedMetadataKey: "true",
 		},
 	})
 	if err != nil {
@@ -1339,7 +1339,7 @@ func recipeStepRef(step formula.RecipeStep) string {
 }
 
 func isFailedPartialMolecule(bead beads.Bead) bool {
-	return strings.TrimSpace(bead.Metadata["molecule_failed"]) == "true"
+	return strings.TrimSpace(bead.Metadata[beadmeta.MoleculeFailedMetadataKey]) == "true"
 }
 
 // findLatestAttempt finds the most recent attempt/iteration child of a control bead.

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -1012,7 +1012,7 @@ func ensureDrainItemRoot(store beads.Store, control, unit, member beads.Bead, co
 		return "", false, fmt.Errorf("%s: looking up item root %s: %w", control.ID, row.ItemRootKey, err)
 	}
 	for _, candidate := range existing {
-		if candidate.Metadata["molecule_failed"] == "true" {
+		if candidate.Metadata[beadmeta.MoleculeFailedMetadataKey] == "true" {
 			continue
 		}
 		return candidate.ID, false, nil
@@ -1125,7 +1125,7 @@ func closeFailedDrainItemRoots(store beads.Store, controlID, itemRootKey string)
 		return fmt.Errorf("%s: looking up failed drain item roots for key %s: %w", controlID, itemRootKey, err)
 	}
 	for _, root := range matches {
-		if root.Status == "closed" || root.Metadata["molecule_failed"] != "true" {
+		if root.Status == "closed" || root.Metadata[beadmeta.MoleculeFailedMetadataKey] != "true" {
 			continue
 		}
 		if _, err := sourceworkflow.CloseWorkflowSubtree(store, root.ID); err != nil {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -340,7 +340,7 @@ func findExistingAttach(store beads.Store, recipe *formula.Recipe, rootBeadID, a
 		if b.Metadata[beadmeta.RootBeadIDMetadataKey] != rootBeadID {
 			continue
 		}
-		if b.Metadata["molecule_failed"] == "true" {
+		if b.Metadata[beadmeta.MoleculeFailedMetadataKey] == "true" {
 			return nil, fmt.Errorf("existing attach root %s for idempotency key %q is marked molecule_failed", b.ID, key)
 		}
 		// Found existing sub-DAG root. Ensure dep is wired.
@@ -419,7 +419,7 @@ func existingAttachIDMapping(store beads.Store, recipe *formula.Recipe, rootBead
 		return nil, err
 	}
 	for _, bead := range all {
-		if bead.Metadata["molecule_failed"] == "true" {
+		if bead.Metadata[beadmeta.MoleculeFailedMetadataKey] == "true" {
 			continue
 		}
 		ref := strings.TrimSpace(bead.Metadata[beadmeta.StepRefMetadataKey])
@@ -1288,14 +1288,14 @@ func unresolvedTitleValidationErrorsWithVars(recipe *formula.Recipe, opts Option
 	return errs
 }
 
-// markFailed sets "molecule_failed" metadata on all created beads.
+// markFailed sets beadmeta.MoleculeFailedMetadataKey on all created beads.
 // Best-effort: errors are silently ignored since we're already in an
 // error path.
 func markFailed(store beads.Store, ids []string) {
 	for _, id := range ids {
 		_ = store.SetMetadataBatch(id, map[string]string{
-			"molecule_failed":        "true",
-			InstantiatingMetadataKey: "",
+			beadmeta.MoleculeFailedMetadataKey: "true",
+			InstantiatingMetadataKey:           "",
 		})
 	}
 }

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -1449,7 +1449,7 @@ func closeFailedGraphV2RootsByKey(store beads.Store, key string) error {
 		return fmt.Errorf("looking up failed formulas v2 roots for key %s: %w", key, err)
 	}
 	for _, root := range matches {
-		if root.Status == "closed" || root.Metadata["molecule_failed"] != "true" {
+		if root.Status == "closed" || root.Metadata[beadmeta.MoleculeFailedMetadataKey] != "true" {
 			continue
 		}
 		if _, err := sourceworkflow.CloseWorkflowSubtree(store, root.ID); err != nil {


### PR DESCRIPTION
## Summary

Extracts the bare `"molecule_failed"` metadata-key string into a single
compiler-checked `beadmeta.MoleculeFailedMetadataKey` constant and routes the
**9 production map-key / composite-literal-key sites** through it:

- `internal/molecule/molecule.go` — `findExistingAttach`, `existingAttachIDMapping`, `markFailed`
- `internal/dispatch/control.go` — `failedAttemptAttachRootID` ListQuery, `isFailedPartialMolecule`
- `internal/dispatch/drain.go` — `ensureDrainItemRoot`, `closeFailedDrainItemRoots`
- `internal/sling/sling.go` — `closeFailedGraphV2RootsByKey`
- `cmd/gc/cmd_formula.go` — `closeFormulaCookFailedGraphV2Roots`

**Byte-identical on-store value.** The constant equals the old literal, so no
bead round-trips differently. Error-message prose (`molecule.go` "is marked
molecule_failed") and the test-file literals are intentionally left as string
literals — they are the wire-string drift guards proving the constant emits the
identical value.

Placed in the existing non-`gc.` "dispatch metadata keys" const block (alongside
`MoleculeIDMetadataKey`), **not** in `KnownMetadataKeys` — that block's drift
guard only covers the `gc.` namespace, exactly like the sibling `molecule_id` key.

## Scope

This is the smallest, lowest-risk slice of a larger cleanup that routes business
logic through typed domain objects / confined codecs instead of cracking raw
beads inline. Deliberately **constant-only**: no `molecule.State` typed view was
added, because every reader of `molecule_failed` is the dispatcher/substrate
(where the bead legitimately *is* the domain object).

## Verification

- `go build ./...`, `go vet ./...` clean
- `go test ./internal/beadmeta ./internal/molecule ./internal/dispatch ./internal/sling` green
- `go test ./cmd/gc -run 'Formula|Molecule|Drain'` green
- `rg '"molecule_failed"'` confirms zero remaining production map-key literals
- TDD: pinned-value test added first (red on undefined constant), then constant (green)

Part of the raw-bead-leak cleanup epic. Refs `ga-vpemze`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
