### PR TITLE
refactor(api): route workflow-bead snapshot loops through a molecule codec

### DIFF
--- a/internal/api/convoy_event_stream.go
+++ b/internal/api/convoy_event_stream.go
@@ -365,20 +365,9 @@ func projectWorkflowEvent(state State, event events.Event) *workflowEventProject
 		WorkflowSeq:     event.Seq,
 		EventTS:         event.Ts.UTC().Format(time.RFC3339),
 		EventType:       event.Type,
-		Bead: workflowBeadResponse{
-			ID:            bead.ID,
-			Title:         bead.Title,
-			Status:        workflowStatus(bead),
-			Kind:          workflowKind(bead),
-			StepRef:       strings.TrimSpace(bead.Metadata[beadmeta.StepRefMetadataKey]),
-			Attempt:       workflowAttempt(bead),
-			LogicalBeadID: strings.TrimSpace(bead.Metadata[beadmeta.LogicalBeadIDMetadataKey]),
-			ScopeRef:      strings.TrimSpace(bead.Metadata[beadmeta.ScopeRefMetadataKey]),
-			Assignee:      strings.TrimSpace(bead.Assignee),
-			Metadata:      cloneStringMap(bead.Metadata),
-		},
-		ChangedFields: changedFields,
-		LogicalNodeID: logicalNodeID,
+		Bead:            workflowBeadResponseFromBead(bead),
+		ChangedFields:   changedFields,
+		LogicalNodeID:   logicalNodeID,
 	}
 	if event.Type == events.BeadUpdated {
 		projection.RequiresResync = true

--- a/internal/api/convoy_sql.go
+++ b/internal/api/convoy_sql.go
@@ -480,18 +480,7 @@ func (s *Server) tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScope
 	storeRef := chosen.info.ref
 	beadResponses := make([]workflowBeadResponse, 0, len(workflowBeads))
 	for _, bead := range workflowBeads {
-		beadResponses = append(beadResponses, workflowBeadResponse{
-			ID:            bead.ID,
-			Title:         bead.Title,
-			Status:        workflowStatus(bead),
-			Kind:          workflowKind(bead),
-			StepRef:       strings.TrimSpace(bead.Metadata[beadmeta.StepRefMetadataKey]),
-			Attempt:       workflowAttempt(bead),
-			LogicalBeadID: strings.TrimSpace(bead.Metadata[beadmeta.LogicalBeadIDMetadataKey]),
-			ScopeRef:      strings.TrimSpace(bead.Metadata[beadmeta.ScopeRefMetadataKey]),
-			Assignee:      strings.TrimSpace(bead.Assignee),
-			Metadata:      cloneStringMap(bead.Metadata),
-		})
+		beadResponses = append(beadResponses, workflowBeadResponseFromBead(bead))
 	}
 
 	snapshot := &workflowSnapshotResponse{

--- a/internal/api/handler_convoy_dispatch.go
+++ b/internal/api/handler_convoy_dispatch.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/molecule"
 )
 
 var errWorkflowNotFound = errors.New("workflow not found")
@@ -233,18 +234,7 @@ func (s *Server) snapshotFromStore(info workflowStoreInfo, root beads.Bead, fall
 
 	beadResponses := make([]workflowBeadResponse, 0, len(workflowBeads))
 	for _, bead := range workflowBeads {
-		beadResponses = append(beadResponses, workflowBeadResponse{
-			ID:            bead.ID,
-			Title:         bead.Title,
-			Status:        workflowStatus(bead),
-			Kind:          workflowKind(bead),
-			StepRef:       strings.TrimSpace(bead.Metadata[beadmeta.StepRefMetadataKey]),
-			Attempt:       workflowAttempt(bead),
-			LogicalBeadID: strings.TrimSpace(bead.Metadata[beadmeta.LogicalBeadIDMetadataKey]),
-			ScopeRef:      strings.TrimSpace(bead.Metadata[beadmeta.ScopeRefMetadataKey]),
-			Assignee:      strings.TrimSpace(bead.Assignee),
-			Metadata:      cloneStringMap(bead.Metadata),
-		})
+		beadResponses = append(beadResponses, workflowBeadResponseFromBead(bead))
 	}
 
 	snapshot := &workflowSnapshotResponse{
@@ -475,12 +465,7 @@ func workflowAttempt(bead beads.Bead) *int {
 }
 
 func workflowAttemptValue(bead beads.Bead) int {
-	raw := strings.TrimSpace(bead.Metadata[beadmeta.AttemptMetadataKey])
-	if raw == "" {
-		return 0
-	}
-	v, _ := strconv.Atoi(raw)
-	return v
+	return molecule.WorkflowAttempt(bead)
 }
 
 func isTerminalWorkflowStatus(status string) bool {
@@ -543,41 +528,35 @@ func cloneStringMap(src map[string]string) map[string]string {
 }
 
 func workflowKind(bead beads.Bead) string {
-	if bead.Metadata != nil {
-		if kind := strings.TrimSpace(bead.Metadata[beadmeta.KindMetadataKey]); kind != "" {
-			return kind
-		}
-	}
-	return strings.TrimSpace(bead.Type)
+	return molecule.WorkflowKind(bead)
 }
 
 func workflowStatus(bead beads.Bead) string {
-	outcome := strings.TrimSpace(bead.Metadata[beadmeta.OutcomeMetadataKey])
-	hasAssignment := strings.TrimSpace(bead.Assignee) != ""
-	switch strings.TrimSpace(bead.Status) {
-	case "closed":
-		switch outcome {
-		case beadmeta.OutcomeFail:
-			return "failed"
-		case beadmeta.OutcomeSkipped:
-			return "skipped"
-		}
-		return "completed"
-	case "in_progress":
-		if hasAssignment {
-			return "active"
-		}
-		return "pending"
-	case "open":
-		return "pending"
-	default:
-		switch outcome {
-		case beadmeta.OutcomeFail:
-			return "failed"
-		case beadmeta.OutcomeSkipped:
-			return "skipped"
-		}
-		return strings.TrimSpace(bead.Status)
+	return molecule.WorkflowStatus(bead)
+}
+
+// workflowBeadResponseFromBead maps a workflow bead onto its snapshot response
+// node through the molecule.WorkflowBead codec — the single mapping shared by the
+// snapshot, SQL-fast-path, and event-projection build loops. The codec already
+// clones the metadata map (preserving nil -> nil for the wire's "metadata":
+// null), so cloneStringMap is not called here.
+func workflowBeadResponseFromBead(bead beads.Bead) workflowBeadResponse {
+	wb := molecule.WorkflowBeadFromBead(bead)
+	var attempt *int
+	if wb.Attempt > 0 {
+		attempt = &wb.Attempt
+	}
+	return workflowBeadResponse{
+		ID:            wb.ID,
+		Title:         wb.Title,
+		Status:        wb.Status,
+		Kind:          wb.Kind,
+		StepRef:       wb.StepRef,
+		Attempt:       attempt,
+		LogicalBeadID: wb.LogicalBeadID,
+		ScopeRef:      wb.ScopeRef,
+		Assignee:      wb.Assignee,
+		Metadata:      wb.Metadata,
 	}
 }
 

--- a/internal/api/handler_convoy_dispatch_test.go
+++ b/internal/api/handler_convoy_dispatch_test.go
@@ -11,9 +11,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
@@ -1039,6 +1041,94 @@ func TestWorkflowStatusTreatsSkippedAsSkipped(t *testing.T) {
 
 	if got := workflowStatus(bead); got != "skipped" {
 		t.Fatalf("workflowStatus(closed skipped) = %q, want skipped", got)
+	}
+}
+
+// oldInlineWorkflowBeadResponse reproduces the pre-refactor inline
+// struct-literal construction that the three build loops used, so
+// TestWorkflowBeadResponseFromBeadEquivalence can pin the new codec-backed
+// mapper against it field-for-field.
+func oldInlineWorkflowBeadResponse(bead beads.Bead) workflowBeadResponse {
+	return workflowBeadResponse{
+		ID:            bead.ID,
+		Title:         bead.Title,
+		Status:        workflowStatus(bead),
+		Kind:          workflowKind(bead),
+		StepRef:       strings.TrimSpace(bead.Metadata[beadmeta.StepRefMetadataKey]),
+		Attempt:       workflowAttempt(bead),
+		LogicalBeadID: strings.TrimSpace(bead.Metadata[beadmeta.LogicalBeadIDMetadataKey]),
+		ScopeRef:      strings.TrimSpace(bead.Metadata[beadmeta.ScopeRefMetadataKey]),
+		Assignee:      strings.TrimSpace(bead.Assignee),
+		Metadata:      cloneStringMap(bead.Metadata),
+	}
+}
+
+func TestWorkflowBeadResponseFromBeadEquivalence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		bead beads.Bead
+	}{
+		{
+			name: "fully populated with padded metadata",
+			bead: beads.Bead{
+				ID:       "step-1",
+				Title:    "Do the thing",
+				Status:   "in_progress",
+				Assignee: "  worker-1  ",
+				Type:     "task",
+				Metadata: map[string]string{
+					beadmeta.KindMetadataKey:          "  run  ",
+					beadmeta.OutcomeMetadataKey:       "",
+					beadmeta.AttemptMetadataKey:       "  2  ",
+					beadmeta.StepRefMetadataKey:       "  iteration.1.review  ",
+					beadmeta.LogicalBeadIDMetadataKey: "  logical-9  ",
+					beadmeta.ScopeRefMetadataKey:      "  gascity  ",
+				},
+			},
+		},
+		{
+			name: "minimal bead with nil metadata",
+			bead: beads.Bead{ID: "root-2", Title: "bare"},
+		},
+		{
+			name: "closed with fail outcome",
+			bead: beads.Bead{
+				ID:       "step-3",
+				Title:    "failed step",
+				Status:   "closed",
+				Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomeFail},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := workflowBeadResponseFromBead(tc.bead)
+			want := oldInlineWorkflowBeadResponse(tc.bead)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("workflowBeadResponseFromBead mismatch:\n got=%#v\nwant=%#v", got, want)
+			}
+			// Attempt pointer semantics: nil when unset, non-nil when > 0.
+			if (got.Attempt == nil) != (want.Attempt == nil) {
+				t.Fatalf("attempt pointer nilness mismatch: got=%v want=%v", got.Attempt, want.Attempt)
+			}
+			// nil source metadata must stay nil so the wire keeps "metadata": null.
+			if tc.bead.Metadata == nil && got.Metadata != nil {
+				t.Fatalf("nil metadata projected to non-nil: %#v", got.Metadata)
+			}
+		})
+	}
+
+	// Clone independence: mutating the source metadata after projection must
+	// not change the response map.
+	src := map[string]string{beadmeta.KindMetadataKey: "workflow"}
+	resp := workflowBeadResponseFromBead(beads.Bead{ID: "root-1", Metadata: src})
+	src[beadmeta.KindMetadataKey] = "mutated"
+	if resp.Metadata[beadmeta.KindMetadataKey] != "workflow" {
+		t.Fatalf("response metadata not independent of source: %q", resp.Metadata[beadmeta.KindMetadataKey])
 	}
 }
 

--- a/internal/molecule/workflow_bead.go
+++ b/internal/molecule/workflow_bead.go
@@ -1,0 +1,146 @@
+package molecule
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// WorkflowBead is the typed projection of a workflow root or step bead: the
+// derived status/kind/attempt plus the gc.* metadata a snapshot presentation
+// consumes, read once through a confined codec instead of cracking the raw
+// bead inline at every call site.
+//
+// It is the workflow-domain analogue of session.InfoFromPersistedBead's Info:
+// molecule is the package that materializes a formula run as a root bead plus
+// child step beads, so it owns what a workflow bead means. WorkflowBeadFromBead
+// is pure, side-effect-free, and backend-invariant — it reads only stored bead
+// fields, so a bead round-trips to the same WorkflowBead whether it was persisted
+// to bd, sqlite, or postgres.
+//
+// Not to be confused with internal/runproj.toRunSnapshotBead (detail.go) and
+// internal/runproj.fromBead (summary.go). Those are a deliberately DIFFERENT
+// projection: a byte-parity port of the TS golden run-view generator that reads
+// the raw bead status (not this file's derived pending/active/completed/failed/
+// skipped vocabulary), uses b.Ref for the step ref (not gc.step_ref), and honors
+// gc.original_kind over b.Type (not gc.kind). Those semantics are locked by
+// detail_golden_test.go / detail_parity_test.go. Do NOT merge the two codecs:
+// unifying them would break golden parity or force a dual-mode codec.
+type WorkflowBead struct {
+	// ID and Title mirror the bead's identity fields verbatim.
+	ID    string
+	Title string
+	// Status is the derived presentation status (see WorkflowStatus).
+	Status string
+	// Kind is the workflow kind (see WorkflowKind).
+	Kind string
+	// StepRef is the trimmed gc.step_ref metadata.
+	StepRef string
+	// Attempt is the parsed gc.attempt metadata (0 when unset or unparseable).
+	Attempt int
+	// LogicalBeadID is the trimmed gc.logical_bead_id metadata.
+	LogicalBeadID string
+	// ScopeRef is the trimmed gc.scope_ref metadata.
+	ScopeRef string
+	// Assignee is the trimmed bead assignee.
+	Assignee string
+	// Metadata is an independent clone of the bead metadata. A nil source map
+	// stays nil so the wire keeps emitting "metadata": null for nil-metadata
+	// beads.
+	Metadata map[string]string
+}
+
+// WorkflowBeadFromBead projects a workflow root or step bead onto WorkflowBead.
+// It composes WorkflowStatus/WorkflowKind/WorkflowAttempt and trims the gc.*
+// metadata scalars, cloning the metadata map so callers never share the bead's
+// backing storage. See WorkflowBead for the purity and runproj-divergence notes.
+func WorkflowBeadFromBead(b beads.Bead) WorkflowBead {
+	return WorkflowBead{
+		ID:            b.ID,
+		Title:         b.Title,
+		Status:        WorkflowStatus(b),
+		Kind:          WorkflowKind(b),
+		StepRef:       strings.TrimSpace(b.Metadata[beadmeta.StepRefMetadataKey]),
+		Attempt:       WorkflowAttempt(b),
+		LogicalBeadID: strings.TrimSpace(b.Metadata[beadmeta.LogicalBeadIDMetadataKey]),
+		ScopeRef:      strings.TrimSpace(b.Metadata[beadmeta.ScopeRefMetadataKey]),
+		Assignee:      strings.TrimSpace(b.Assignee),
+		Metadata:      cloneMetadata(b.Metadata),
+	}
+}
+
+// WorkflowStatus derives a workflow bead's presentation status from its bead
+// status and gc.outcome metadata: closed+fail -> "failed", closed+skipped ->
+// "skipped", closed -> "completed", in_progress with an assignee -> "active",
+// in_progress or open -> "pending". Any other raw status honors gc.outcome
+// (fail/skipped) and otherwise passes through trimmed. It is exported separately
+// so hot loops can derive status without paying the full-projection metadata
+// clone.
+func WorkflowStatus(b beads.Bead) string {
+	outcome := strings.TrimSpace(b.Metadata[beadmeta.OutcomeMetadataKey])
+	hasAssignment := strings.TrimSpace(b.Assignee) != ""
+	switch strings.TrimSpace(b.Status) {
+	case "closed":
+		switch outcome {
+		case beadmeta.OutcomeFail:
+			return "failed"
+		case beadmeta.OutcomeSkipped:
+			return "skipped"
+		}
+		return "completed"
+	case "in_progress":
+		if hasAssignment {
+			return "active"
+		}
+		return "pending"
+	case "open":
+		return "pending"
+	default:
+		switch outcome {
+		case beadmeta.OutcomeFail:
+			return "failed"
+		case beadmeta.OutcomeSkipped:
+			return "skipped"
+		}
+		return strings.TrimSpace(b.Status)
+	}
+}
+
+// WorkflowKind returns the workflow kind: the trimmed gc.kind metadata when
+// present, falling back to the trimmed bead Type.
+func WorkflowKind(b beads.Bead) string {
+	if b.Metadata != nil {
+		if kind := strings.TrimSpace(b.Metadata[beadmeta.KindMetadataKey]); kind != "" {
+			return kind
+		}
+	}
+	return strings.TrimSpace(b.Type)
+}
+
+// WorkflowAttempt returns the parsed gc.attempt metadata as an int, or 0 when
+// the metadata is empty or non-numeric. The API mapper converts 0 to the wire's
+// omitted *int.
+func WorkflowAttempt(b beads.Bead) int {
+	raw := strings.TrimSpace(b.Metadata[beadmeta.AttemptMetadataKey])
+	if raw == "" {
+		return 0
+	}
+	v, _ := strconv.Atoi(raw)
+	return v
+}
+
+// cloneMetadata returns an independent copy of a metadata map, preserving
+// nil -> nil so a nil-metadata bead projects to nil metadata (and the wire keeps
+// emitting "metadata": null). Port of api.cloneStringMap.
+func cloneMetadata(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/internal/molecule/workflow_bead.go
+++ b/internal/molecule/workflow_bead.go
@@ -13,7 +13,7 @@ import (
 // consumes, read once through a confined codec instead of cracking the raw
 // bead inline at every call site.
 //
-// It is the workflow-domain analogue of session.InfoFromPersistedBead's Info:
+// It is the workflow-domain analog of session.InfoFromPersistedBead's Info:
 // molecule is the package that materializes a formula run as a root bead plus
 // child step beads, so it owns what a workflow bead means. WorkflowBeadFromBead
 // is pure, side-effect-free, and backend-invariant — it reads only stored bead

--- a/internal/molecule/workflow_bead_test.go
+++ b/internal/molecule/workflow_bead_test.go
@@ -1,0 +1,275 @@
+package molecule
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestWorkflowStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		bead beads.Bead
+		want string
+	}{
+		// Direct ports of the api workflowStatus subtests so the body move is
+		// oracle-checked against the pre-refactor behavior.
+		{
+			name: "open assigned is pending",
+			bead: beads.Bead{
+				Status:   "open",
+				Assignee: "mayor",
+				Metadata: map[string]string{"gc.routed_to": "mayor"},
+			},
+			want: "pending",
+		},
+		{
+			name: "in_progress unassigned is pending",
+			bead: beads.Bead{Status: "in_progress"},
+			want: "pending",
+		},
+		{
+			name: "in_progress routed-only is pending",
+			bead: beads.Bead{
+				Status:   "in_progress",
+				Metadata: map[string]string{"gc.routed_to": "mayor"},
+			},
+			want: "pending",
+		},
+		{
+			name: "closed skipped is skipped",
+			bead: beads.Bead{
+				Status:   "closed",
+				Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomeSkipped},
+			},
+			want: "skipped",
+		},
+		// Full coverage of the remaining switch arms.
+		{
+			name: "in_progress assigned is active",
+			bead: beads.Bead{Status: "in_progress", Assignee: "worker-1"},
+			want: "active",
+		},
+		{
+			name: "closed plain is completed",
+			bead: beads.Bead{Status: "closed"},
+			want: "completed",
+		},
+		{
+			name: "closed fail is failed",
+			bead: beads.Bead{
+				Status:   "closed",
+				Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomeFail},
+			},
+			want: "failed",
+		},
+		{
+			name: "unknown status passes through",
+			bead: beads.Bead{Status: "quarantined"},
+			want: "quarantined",
+		},
+		{
+			name: "unknown status with fail outcome is failed",
+			bead: beads.Bead{
+				Status:   "quarantined",
+				Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomeFail},
+			},
+			want: "failed",
+		},
+		{
+			name: "unknown status with skipped outcome is skipped",
+			bead: beads.Bead{
+				Status:   "quarantined",
+				Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomeSkipped},
+			},
+			want: "skipped",
+		},
+		{
+			name: "whitespace-padded status and outcome are trimmed",
+			bead: beads.Bead{
+				Status:   "  closed  ",
+				Metadata: map[string]string{beadmeta.OutcomeMetadataKey: "  fail  "},
+			},
+			want: "failed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := WorkflowStatus(tc.bead); got != tc.want {
+				t.Fatalf("WorkflowStatus(%q) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowKind(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		bead beads.Bead
+		want string
+	}{
+		{
+			name: "gc.kind wins over Type",
+			bead: beads.Bead{
+				Type:     "task",
+				Metadata: map[string]string{beadmeta.KindMetadataKey: "workflow"},
+			},
+			want: "workflow",
+		},
+		{
+			name: "falls back to Type when gc.kind absent",
+			bead: beads.Bead{Type: "task"},
+			want: "task",
+		},
+		{
+			name: "falls back to Type when gc.kind blank",
+			bead: beads.Bead{
+				Type:     "task",
+				Metadata: map[string]string{beadmeta.KindMetadataKey: "   "},
+			},
+			want: "task",
+		},
+		{
+			name: "trims padded gc.kind",
+			bead: beads.Bead{
+				Type:     "task",
+				Metadata: map[string]string{beadmeta.KindMetadataKey: "  workflow  "},
+			},
+			want: "workflow",
+		},
+		{
+			name: "trims padded Type fallback",
+			bead: beads.Bead{Type: "  run  "},
+			want: "run",
+		},
+		{
+			name: "nil metadata is safe",
+			bead: beads.Bead{Type: "run"},
+			want: "run",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := WorkflowKind(tc.bead); got != tc.want {
+				t.Fatalf("WorkflowKind(%q) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowAttempt(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		bead beads.Bead
+		want int
+	}{
+		{
+			name: "numeric attempt parses",
+			bead: beads.Bead{Metadata: map[string]string{beadmeta.AttemptMetadataKey: "3"}},
+			want: 3,
+		},
+		{
+			name: "missing attempt is zero",
+			bead: beads.Bead{},
+			want: 0,
+		},
+		{
+			name: "empty attempt is zero",
+			bead: beads.Bead{Metadata: map[string]string{beadmeta.AttemptMetadataKey: ""}},
+			want: 0,
+		},
+		{
+			name: "non-numeric attempt is zero",
+			bead: beads.Bead{Metadata: map[string]string{beadmeta.AttemptMetadataKey: "abc"}},
+			want: 0,
+		},
+		{
+			name: "padded numeric attempt is trimmed then parsed",
+			bead: beads.Bead{Metadata: map[string]string{beadmeta.AttemptMetadataKey: "  7  "}},
+			want: 7,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := WorkflowAttempt(tc.bead); got != tc.want {
+				t.Fatalf("WorkflowAttempt(%q) = %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowBeadFromBead_AllFields(t *testing.T) {
+	t.Parallel()
+
+	b := beads.Bead{
+		ID:       "step-1",
+		Title:    "Do the thing",
+		Status:   "in_progress",
+		Assignee: "  worker-1  ",
+		Type:     "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:          "  run  ",
+			beadmeta.OutcomeMetadataKey:       "",
+			beadmeta.AttemptMetadataKey:       "  2  ",
+			beadmeta.StepRefMetadataKey:       "  iteration.1.review  ",
+			beadmeta.LogicalBeadIDMetadataKey: "  logical-9  ",
+			beadmeta.ScopeRefMetadataKey:      "  gascity  ",
+		},
+	}
+
+	got := WorkflowBeadFromBead(b)
+	want := WorkflowBead{
+		ID:            "step-1",
+		Title:         "Do the thing",
+		Status:        "active",
+		Kind:          "run",
+		StepRef:       "iteration.1.review",
+		Attempt:       2,
+		LogicalBeadID: "logical-9",
+		ScopeRef:      "gascity",
+		Assignee:      "worker-1",
+		Metadata:      b.Metadata,
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("WorkflowBeadFromBead mismatch:\n got=%#v\nwant=%#v", got, want)
+	}
+}
+
+func TestWorkflowBeadFromBead_MetadataClone(t *testing.T) {
+	t.Parallel()
+
+	src := map[string]string{beadmeta.KindMetadataKey: "workflow"}
+	b := beads.Bead{ID: "root-1", Metadata: src}
+
+	got := WorkflowBeadFromBead(b)
+	if got.Metadata == nil {
+		t.Fatal("expected cloned metadata, got nil")
+	}
+	// Mutating the source after projection must not change the clone.
+	src[beadmeta.KindMetadataKey] = "mutated"
+	if got.Metadata[beadmeta.KindMetadataKey] != "workflow" {
+		t.Fatalf("clone not independent: got %q", got.Metadata[beadmeta.KindMetadataKey])
+	}
+
+	// nil source metadata projects to nil (not an empty map) so the wire keeps
+	// emitting "metadata": null for nil-metadata beads.
+	nilGot := WorkflowBeadFromBead(beads.Bead{ID: "root-2"})
+	if nilGot.Metadata != nil {
+		t.Fatalf("nil metadata projected to non-nil: %#v", nilGot.Metadata)
+	}
+}

--- a/internal/molecule/workflow_bead_test.go
+++ b/internal/molecule/workflow_bead_test.go
@@ -22,8 +22,8 @@ func TestWorkflowStatus(t *testing.T) {
 			name: "open assigned is pending",
 			bead: beads.Bead{
 				Status:   "open",
-				Assignee: "mayor",
-				Metadata: map[string]string{"gc.routed_to": "mayor"},
+				Assignee: "assigned-role",
+				Metadata: map[string]string{"gc.routed_to": "routed-role"},
 			},
 			want: "pending",
 		},
@@ -36,7 +36,7 @@ func TestWorkflowStatus(t *testing.T) {
 			name: "in_progress routed-only is pending",
 			bead: beads.Bead{
 				Status:   "in_progress",
-				Metadata: map[string]string{"gc.routed_to": "mayor"},
+				Metadata: map[string]string{"gc.routed_to": "routed-role"},
 			},
 			want: "pending",
 		},


### PR DESCRIPTION
## Summary

Mints a single `molecule.WorkflowBeadFromBead` codec and routes the **three
byte-identical `workflowBeadResponse` build loops** in `internal/api` through
one mapper, eliminating triplicated raw-bead metadata cracks:

- `handler_convoy_dispatch.go` — `snapshotFromStore`
- `convoy_sql.go` — `tryFullWorkflowSQL`
- `convoy_event_stream.go` — `projectWorkflowEvent`

`WorkflowBeadFromBead` (+ standalone `WorkflowStatus`/`WorkflowKind`/`WorkflowAttempt`)
are verbatim moves of the former inline `internal/api` helpers, so status
(`Status` + `gc.outcome`), kind, and attempt derivation are unchanged.

## No wire change

`BeadGraphResponse` continues to ship `beads.Bead` as before — this PR is the
internal codec + loop-consolidation only. `TestOpenAPISpecInSync` and
`make dashboard-check` both pass; no `openapi.json`, generated TS, or dashboard
file is touched. (Returning a typed view on the wire is a deliberate, separate
follow-up.)

## Scope discipline

`WorkflowBead` carries **only** the 10 fields the mapper consumes. It does not
duplicate `api.resolvedWorkflowID` (which stays the single implementation at its
6 call sites) or project speculative unused fields — no premature abstraction,
one source of truth.

## Verification

- `go build ./...`, `go vet ./internal/molecule ./internal/api` clean; `gofmt` clean
- `go test ./internal/molecule ./internal/api` green (incl. `TestOpenAPISpecInSync`)
- `make dashboard-check` green
- TDD: codec unit tests written first (status table, kind, attempt, nil-metadata clone);
  `TestWorkflowBeadResponseFromBeadEquivalence` pins the mapper byte-equal to the old inline expression
- Fable adversarial review: behavior-preservation verified clean; the one blocker (speculative field over-reach) fixed by trimming

Part of the raw-bead-leak cleanup epic. Refs `ga-rt98y1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
