### PR TITLE
refactor(orders,api): route order feed/history through OrderRun + convergence GateOutput

### DIFF
--- a/internal/api/handler_orders.go
+++ b/internal/api/handler_orders.go
@@ -94,17 +94,3 @@ func toOrderResponse(a orders.Order) orderResponse {
 		Env:           a.Env,
 	}
 }
-
-// lastRunOutcomeFromLabels extracts the run outcome from bead labels.
-func lastRunOutcomeFromLabels(labels []string) string {
-	switch {
-	case orderLabelsContainExecFailure(labels), orderLabelsContainTriggerEnvFailure(labels), containsString(labels, "wisp-failed"):
-		return "failed"
-	case containsString(labels, "wisp-canceled"):
-		return "canceled"
-	case containsString(labels, "exec"), containsString(labels, "wisp"):
-		return "success"
-	default:
-		return ""
-	}
-}

--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -517,31 +517,6 @@ func TestHandleOrderCheckRunsConditionByDefault(t *testing.T) {
 	}
 }
 
-func TestLastRunOutcomeFromLabelsPrioritizesTerminalLabels(t *testing.T) {
-	tests := []struct {
-		name   string
-		labels []string
-		want   string
-	}{
-		{name: "wisp failed dominates success", labels: []string{"wisp", "wisp-failed"}, want: "failed"},
-		{name: "failed alone", labels: []string{"wisp-failed"}, want: "failed"},
-		{name: "exec failed dominates success", labels: []string{"exec", "exec-failed"}, want: "failed"},
-		{name: "exec env failed is failed", labels: []string{"exec-env-failed"}, want: "failed"},
-		{name: "trigger env failed is failed", labels: []string{"trigger-env-failed"}, want: "failed"},
-		{name: "canceled dominates success", labels: []string{"wisp", "wisp-canceled"}, want: "canceled"},
-		{name: "success fallback", labels: []string{"exec"}, want: "success"},
-		{name: "unknown", labels: []string{"order-tracking"}, want: ""},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := lastRunOutcomeFromLabels(tc.labels); got != tc.want {
-				t.Fatalf("lastRunOutcomeFromLabels(%v) = %q, want %q", tc.labels, got, tc.want)
-			}
-		})
-	}
-}
-
 func TestHandleOrdersFeedIgnoresUnrelatedStoreListFailures(t *testing.T) {
 	fs := newFakeState(t)
 	fs.stores["alpha"] = failListStore{Store: beads.NewMemStore()}

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -12,6 +12,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/convergence"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/orders"
 )
@@ -101,9 +102,10 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, input *OrderCheckInput)
 			cr.LastRun = &ts
 		}
 		if len(history) > 0 {
-			outcome := lastRunOutcomeFromLabels(history[0].bead.Labels)
-			if outcome != "" {
-				cr.LastRunOutcome = &outcome
+			if run, ok := orders.RunFromTrackingBead(history[0].bead); ok {
+				if outcome := run.Outcome.Display(); outcome != "" {
+					cr.LastRunOutcome = &outcome
+				}
 			}
 		}
 		checks = append(checks, cr)
@@ -254,16 +256,14 @@ func (s *Server) humaHandleOrderHistory(_ context.Context, input *OrderHistoryIn
 			CaptureOutput: auto != nil && auto.IsExec(),
 		}
 
-		if b.Metadata != nil {
-			if v, ok := b.Metadata["convergence.gate_duration_ms"]; ok && v != "" {
-				entry.DurationMs = &v
-			}
-			if v, ok := b.Metadata["convergence.gate_exit_code"]; ok && v != "" {
-				entry.ExitCode = &v
-			}
+		gate := convergence.GateOutputFromMetadata(b.Metadata)
+		if gate.DurationMs != "" {
+			entry.DurationMs = &gate.DurationMs
 		}
-
-		entry.HasOutput = entry.CaptureOutput || orderRunHasOutput(b)
+		if gate.ExitCode != "" {
+			entry.ExitCode = &gate.ExitCode
+		}
+		entry.HasOutput = entry.CaptureOutput || gate.HasOutput()
 
 		entries = append(entries, entry)
 		if len(entries) >= limit {
@@ -276,13 +276,6 @@ func (s *Server) humaHandleOrderHistory(_ context.Context, input *OrderHistoryIn
 	}
 	out.Body.Entries = entries
 	return out, nil
-}
-
-func orderRunHasOutput(b beads.Bead) bool {
-	if b.Metadata == nil {
-		return false
-	}
-	return b.Metadata["convergence.gate_stdout"] != "" || b.Metadata["convergence.gate_stderr"] != ""
 }
 
 // orderHistoryEntry is a single entry in the order history response.
@@ -328,18 +321,7 @@ func (s *Server) humaHandleOrderHistoryDetail(_ context.Context, input *OrderHis
 	}
 	b := result.bead
 
-	output := ""
-	if b.Metadata != nil {
-		if stdout := b.Metadata["convergence.gate_stdout"]; stdout != "" {
-			output = stdout
-		}
-		if stderr := b.Metadata["convergence.gate_stderr"]; stderr != "" {
-			if output != "" {
-				output += "\n"
-			}
-			output += stderr
-		}
-	}
+	output := convergence.GateOutputFromMetadata(b.Metadata).CombinedOutput()
 
 	return &struct {
 		Body orderHistoryDetailResponse

--- a/internal/api/orders_feed.go
+++ b/internal/api/orders_feed.go
@@ -314,11 +314,8 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 		if info.store == nil {
 			continue
 		}
-		results, err := info.store.List(beads.ListQuery{
-			Label:    "order-tracking",
-			Sort:     beads.SortCreatedDesc,
-			TierMode: beads.TierBoth,
-		})
+		front := orders.NewStore(beads.OrdersStore{Store: info.store})
+		runs, err := front.ListTracking()
 		if err != nil {
 			if requestedScopeErr == nil && info.scopeKind == requestedScopeKind && info.scopeRef == requestedScopeRef {
 				requestedScopeErr = err
@@ -331,32 +328,28 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 			continue
 		}
 
-		for _, bead := range results {
-			scopedName := orderTrackingScopedName(bead)
-			if scopedName == "" {
-				continue
-			}
-			scopeKind, scopeRef := orderTrackingScope(scopedName, cityScopeRef)
+		for _, run := range runs {
+			scopeKind, scopeRef := orderTrackingScope(run.Scoped, cityScopeRef)
 			if !includeAllForCity && (scopeKind != requestedScopeKind || scopeRef != requestedScopeRef) {
 				continue
 			}
 
-			updatedAt := orderTrackingUpdatedAt(info.store, bead, scopedName)
-			orderDef, ok := orderByScopedName[scopedName]
-			title := orderTrackingTitle(scopedName, orderDef, ok)
-			target := orderTrackingTarget(orderDef, ok, bead)
-			itemType := orderTrackingType(orderDef, ok, bead)
+			updatedAt := orderTrackingUpdatedAt(front, run)
+			orderDef, ok := orderByScopedName[run.Scoped]
+			title := orderTrackingTitle(run.Scoped, orderDef, ok)
+			target := orderTrackingTarget(orderDef, ok, run)
+			itemType := orderTrackingType(orderDef, ok, run)
 			item := monitorFeedItemResponse{
-				ID:                 "order:" + info.ref + ":" + bead.ID,
+				ID:                 "order:" + info.ref + ":" + run.ID,
 				Type:               itemType,
-				Status:             normalizeMonitorStatus(orderTrackingStatus(bead)),
+				Status:             normalizeMonitorStatus(run.State()),
 				Title:              title,
 				ScopeKind:          scopeKind,
 				ScopeRef:           scopeRef,
 				Target:             target,
-				StartedAt:          bead.CreatedAt.Format(time.RFC3339Nano),
+				StartedAt:          run.CreatedAt.Format(time.RFC3339Nano),
 				UpdatedAt:          updatedAt.Format(time.RFC3339Nano),
-				BeadID:             bead.ID,
+				BeadID:             run.ID,
 				StoreRef:           info.ref,
 				DetailAvailable:    ok && orderDef.IsExec(),
 				RunDetailAvailable: ok && orderDef.IsExec(),
@@ -376,27 +369,18 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 	}, nil
 }
 
-func orderTrackingUpdatedAt(store beads.Store, tracking beads.Bead, scopedName string) time.Time {
-	updatedAt := tracking.CreatedAt
-	if store == nil || strings.TrimSpace(scopedName) == "" {
-		return updatedAt
-	}
-
-	runs, err := store.List(beads.ListQuery{
-		Label:    "order-run:" + scopedName,
-		Limit:    1,
-		Sort:     beads.SortCreatedDesc,
-		TierMode: beads.TierBoth,
-	})
-	if err != nil && len(runs) == 0 {
-		orderFeedLogf("api: order feed update lookup failed for %s bead %s: %v", scopedName, tracking.ID, err)
+func orderTrackingUpdatedAt(front *orders.Store, run orders.OrderRun) time.Time {
+	updatedAt := run.CreatedAt
+	latest, found, err := front.LatestOpenRun(run.Scoped)
+	if err != nil && !found {
+		orderFeedLogf("api: order feed update lookup failed for %s bead %s: %v", run.Scoped, run.ID, err)
 		return updatedAt
 	}
 	if err != nil {
-		orderFeedLogf("api: order feed update lookup partially failed for %s bead %s: %v", scopedName, tracking.ID, err)
+		orderFeedLogf("api: order feed update lookup partially failed for %s bead %s: %v", run.Scoped, run.ID, err)
 	}
-	if len(runs) > 0 && runs[0].CreatedAt.After(updatedAt) {
-		updatedAt = runs[0].CreatedAt
+	if found && latest.CreatedAt.After(updatedAt) {
+		updatedAt = latest.CreatedAt
 	}
 	return updatedAt
 }
@@ -468,15 +452,6 @@ func aggregateWorkflowRunStatus(root beads.Bead, beadsForRun []beads.Bead) strin
 	return best
 }
 
-func orderTrackingScopedName(bead beads.Bead) string {
-	for _, label := range bead.Labels {
-		if scopedName, ok := strings.CutPrefix(label, "order-run:"); ok && strings.TrimSpace(scopedName) != "" {
-			return strings.TrimSpace(scopedName)
-		}
-	}
-	return ""
-}
-
 func orderTrackingScope(scopedName, cityScopeRef string) (string, string) {
 	if idx := strings.LastIndex(scopedName, ":rig:"); idx >= 0 {
 		return "rig", scopedName[idx+5:]
@@ -494,7 +469,7 @@ func orderTrackingTitle(scopedName string, orderDef orders.Order, found bool) st
 	return scopedName
 }
 
-func orderTrackingTarget(orderDef orders.Order, found bool, bead beads.Bead) string {
+func orderTrackingTarget(orderDef orders.Order, found bool, run orders.OrderRun) string {
 	if found {
 		if orderDef.IsExec() {
 			return "exec"
@@ -506,7 +481,7 @@ func orderTrackingTarget(orderDef orders.Order, found bool, bead beads.Bead) str
 			return orderDef.Formula
 		}
 	}
-	if orderLabelsContainExec(bead.Labels) {
+	if run.Outcome.IsExec() {
 		return "exec"
 	}
 	return "formula"
@@ -519,45 +494,17 @@ func qualifyOrderFeedTarget(pool, rig string) string {
 	return rig + "/" + pool
 }
 
-func orderTrackingType(orderDef orders.Order, found bool, bead beads.Bead) string {
+func orderTrackingType(orderDef orders.Order, found bool, run orders.OrderRun) string {
 	if found {
 		if orderDef.IsExec() {
 			return "exec"
 		}
 		return "formula"
 	}
-	if orderLabelsContainExec(bead.Labels) {
+	if run.Outcome.IsExec() {
 		return "exec"
 	}
 	return "formula"
-}
-
-func orderTrackingStatus(bead beads.Bead) string {
-	if orderLabelsContainExecFailure(bead.Labels) ||
-		orderLabelsContainTriggerEnvFailure(bead.Labels) ||
-		containsString(bead.Labels, "wisp-canceled") ||
-		containsString(bead.Labels, "wisp-failed") {
-		return "failed"
-	}
-	if strings.TrimSpace(bead.Status) != "closed" {
-		return "active"
-	}
-	return "completed"
-}
-
-func orderLabelsContainExec(labels []string) bool {
-	return containsString(labels, "exec") ||
-		containsString(labels, "exec-failed") ||
-		containsString(labels, "exec-env-failed")
-}
-
-func orderLabelsContainExecFailure(labels []string) bool {
-	return containsString(labels, "exec-failed") ||
-		containsString(labels, "exec-env-failed")
-}
-
-func orderLabelsContainTriggerEnvFailure(labels []string) bool {
-	return containsString(labels, "trigger-env-failed")
 }
 
 // normalizeFeedLimit clamps a caller-supplied feed limit to a sensible

--- a/internal/api/orders_feed_test.go
+++ b/internal/api/orders_feed_test.go
@@ -24,27 +24,33 @@ func TestParseOrdersFeedLimitCapsLargeValues(t *testing.T) {
 }
 
 func TestOrderTrackingStatusTreatsWispFailedAsFailed(t *testing.T) {
-	bead := beads.Bead{
+	run, ok := orders.RunFromTrackingBead(beads.Bead{
 		Status: "closed",
-		Labels: []string{"order-tracking", "wisp", "wisp-failed"},
+		Labels: []string{"order-tracking", "order-run:nightly", "wisp", "wisp-failed"},
+	})
+	if !ok {
+		t.Fatal("RunFromTrackingBead ok = false")
 	}
-	if got := orderTrackingStatus(bead); got != "failed" {
-		t.Fatalf("orderTrackingStatus = %q, want failed", got)
+	if got := run.State(); got != "failed" {
+		t.Fatalf("run.State() = %q, want failed", got)
 	}
 }
 
 func TestOrderTrackingExecEnvFailedClassifiesAsFailedExec(t *testing.T) {
-	bead := beads.Bead{
+	run, ok := orders.RunFromTrackingBead(beads.Bead{
 		Status: "closed",
 		Labels: []string{"order-tracking", "order-run:nightly", "exec-env-failed"},
+	})
+	if !ok {
+		t.Fatal("RunFromTrackingBead ok = false")
 	}
-	if got := orderTrackingStatus(bead); got != "failed" {
-		t.Fatalf("orderTrackingStatus = %q, want failed", got)
+	if got := run.State(); got != "failed" {
+		t.Fatalf("run.State() = %q, want failed", got)
 	}
-	if got := orderTrackingTarget(orders.Order{}, false, bead); got != "exec" {
+	if got := orderTrackingTarget(orders.Order{}, false, run); got != "exec" {
 		t.Fatalf("orderTrackingTarget = %q, want exec", got)
 	}
-	if got := orderTrackingType(orders.Order{}, false, bead); got != "exec" {
+	if got := orderTrackingType(orders.Order{}, false, run); got != "exec" {
 		t.Fatalf("orderTrackingType = %q, want exec", got)
 	}
 }
@@ -61,12 +67,15 @@ func TestWorkflowProjectionTargetKeepsRunTargetMigrationFallback(t *testing.T) {
 func TestOrderTrackingTriggerEnvFailedClassifiesOpenAndClosedAsFailed(t *testing.T) {
 	for _, status := range []string{"open", "closed"} {
 		t.Run(status, func(t *testing.T) {
-			bead := beads.Bead{
+			run, ok := orders.RunFromTrackingBead(beads.Bead{
 				Status: status,
 				Labels: []string{"order-tracking", "order-run:nightly", "trigger-env-failed"},
+			})
+			if !ok {
+				t.Fatal("RunFromTrackingBead ok = false")
 			}
-			if got := orderTrackingStatus(bead); got != "failed" {
-				t.Fatalf("orderTrackingStatus(%s) = %q, want failed", status, got)
+			if got := run.State(); got != "failed" {
+				t.Fatalf("run.State(%s) = %q, want failed", status, got)
 			}
 		})
 	}
@@ -175,11 +184,12 @@ func TestBuildOrderRunFeedItemsUsesAllOrdersForDisabledExecMetadata(t *testing.T
 }
 
 func TestOrderTrackingUpdatedAtLogsLookupFailure(t *testing.T) {
-	store := labelFailListStore{
+	front := orders.NewStore(beads.OrdersStore{Store: labelFailListStore{
 		Store:     beads.NewMemStore(),
 		failLabel: "order-run:digest",
-	}
-	tracking := beads.Bead{
+	}})
+	run := orders.OrderRun{
+		Scoped:    "digest",
 		CreatedAt: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
 	}
 
@@ -191,9 +201,9 @@ func TestOrderTrackingUpdatedAtLogsLookupFailure(t *testing.T) {
 	}
 	defer func() { orderFeedLogf = origLogf }()
 
-	got := orderTrackingUpdatedAt(store, tracking, "digest")
-	if !got.Equal(tracking.CreatedAt) {
-		t.Fatalf("updatedAt = %s, want %s", got, tracking.CreatedAt)
+	got := orderTrackingUpdatedAt(front, run)
+	if !got.Equal(run.CreatedAt) {
+		t.Fatalf("updatedAt = %s, want %s", got, run.CreatedAt)
 	}
 	if !strings.Contains(logs.String(), "order feed update lookup failed") {
 		t.Fatalf("logs = %q, want update lookup failure warning", logs.String())

--- a/internal/convergence/gate_output.go
+++ b/internal/convergence/gate_output.go
@@ -1,0 +1,56 @@
+package convergence
+
+// GateOutput is the read-side projection of the exec-gate output vocabulary —
+// the convergence.gate_* metadata keys that Handler.persistGateOutcome stamps on
+// convergence-loop root beads. It is the confinement boundary for that
+// vocabulary: consumers (the orders API history handlers) read a GateOutput and
+// never touch the convergence.gate_* keys directly, so internal/convergence
+// stays the sole owner of the key literals. GateOutput is the read-side twin of
+// the persistGateOutcome write path.
+//
+// The fields are raw strings on purpose: every consumer either forwards a value
+// verbatim on the wire or does a presence check, and for these keys a
+// present-but-empty value is indistinguishable from absent — so plain strings
+// match the callers' `ok && v != ""` semantics exactly.
+type GateOutput struct {
+	// DurationMs is the wall-clock gate duration in milliseconds.
+	DurationMs string
+	// ExitCode is the gate command's process exit code.
+	ExitCode string
+	// Stdout is the captured gate standard output.
+	Stdout string
+	// Stderr is the captured gate standard error.
+	Stderr string
+}
+
+// GateOutputFromMetadata projects a bead's metadata onto a GateOutput, reading
+// only the convergence.gate_* fields. It is nil-map safe: a nil map yields the
+// zero GateOutput.
+func GateOutputFromMetadata(meta map[string]string) GateOutput {
+	return GateOutput{
+		DurationMs: meta[FieldGateDurationMs],
+		ExitCode:   meta[FieldGateExitCode],
+		Stdout:     meta[FieldGateStdout],
+		Stderr:     meta[FieldGateStderr],
+	}
+}
+
+// HasOutput reports whether the gate captured any stdout or stderr.
+func (g GateOutput) HasOutput() bool {
+	return g.Stdout != "" || g.Stderr != ""
+}
+
+// CombinedOutput returns the gate's combined output for display: stdout first,
+// then stderr appended after a newline separator when both are present. It
+// matches the order-history detail handler's prior inline assembly byte for
+// byte.
+func (g GateOutput) CombinedOutput() string {
+	output := g.Stdout
+	if g.Stderr != "" {
+		if output != "" {
+			output += "\n"
+		}
+		output += g.Stderr
+	}
+	return output
+}

--- a/internal/convergence/gate_output_test.go
+++ b/internal/convergence/gate_output_test.go
@@ -1,0 +1,65 @@
+package convergence
+
+import "testing"
+
+// TestGateOutputFromMetadataAndCombinedOutput pins the read-side gate-output
+// projection: full metadata populates every field; a nil map yields the zero
+// value; HasOutput reflects stdout/stderr presence; and CombinedOutput matches
+// the order-history detail handler's prior inline stdout/stderr join byte for
+// byte.
+func TestGateOutputFromMetadataAndCombinedOutput(t *testing.T) {
+	full := map[string]string{
+		FieldGateDurationMs: "1200",
+		FieldGateExitCode:   "0",
+		FieldGateStdout:     "out",
+		FieldGateStderr:     "err",
+	}
+	g := GateOutputFromMetadata(full)
+	if g.DurationMs != "1200" || g.ExitCode != "0" || g.Stdout != "out" || g.Stderr != "err" {
+		t.Fatalf("GateOutputFromMetadata = %+v, want all four fields populated", g)
+	}
+	if !g.HasOutput() {
+		t.Errorf("HasOutput = false, want true")
+	}
+	if got := g.CombinedOutput(); got != "out\nerr" {
+		t.Errorf("CombinedOutput = %q, want %q", got, "out\nerr")
+	}
+
+	zero := GateOutputFromMetadata(nil)
+	if zero != (GateOutput{}) {
+		t.Errorf("GateOutputFromMetadata(nil) = %+v, want zero value", zero)
+	}
+	if zero.HasOutput() {
+		t.Errorf("HasOutput(nil) = true, want false")
+	}
+	if got := zero.CombinedOutput(); got != "" {
+		t.Errorf("CombinedOutput(nil) = %q, want empty", got)
+	}
+
+	cases := []struct {
+		name          string
+		stdout        string
+		stderr        string
+		wantHasOutput bool
+		wantCombined  string
+	}{
+		{"both", "out", "err", true, "out\nerr"},
+		{"stdout only", "out", "", true, "out"},
+		{"stderr only", "", "err", true, "err"},
+		{"neither", "", "", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GateOutputFromMetadata(map[string]string{
+				FieldGateStdout: tc.stdout,
+				FieldGateStderr: tc.stderr,
+			})
+			if got.HasOutput() != tc.wantHasOutput {
+				t.Errorf("HasOutput = %v, want %v", got.HasOutput(), tc.wantHasOutput)
+			}
+			if out := got.CombinedOutput(); out != tc.wantCombined {
+				t.Errorf("CombinedOutput = %q, want %q", out, tc.wantCombined)
+			}
+		})
+	}
+}

--- a/internal/orders/store.go
+++ b/internal/orders/store.go
@@ -2,6 +2,7 @@ package orders
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -96,6 +97,37 @@ func (o RunOutcome) Labels() []string {
 	}
 }
 
+// IsExec reports whether the outcome belongs to the synchronous-exec family
+// (Exec, ExecFailed, ExecEnvFailed). It is the typed replacement for the order
+// feed's exec-label fallback (orderLabelsContainExec) used to derive an exec
+// target/type for a run whose order definition is no longer registered.
+func (o RunOutcome) IsExec() bool {
+	switch o {
+	case RunOutcomeExec, RunOutcomeExecFailed, RunOutcomeExecEnvFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Display returns the human-facing outcome string the check/history API reports
+// for a run: "" for no outcome yet, "success" for a clean exec or wisp dispatch,
+// "failed" for any failure family (exec/env/trigger failure or a failed wisp),
+// and "canceled" for a canceled wisp. It is the typed replacement for the API's
+// lastRunOutcomeFromLabels label crack.
+func (o RunOutcome) Display() string {
+	switch o {
+	case RunOutcomeExec, RunOutcomeWisp:
+		return "success"
+	case RunOutcomeExecFailed, RunOutcomeExecEnvFailed, RunOutcomeWispFailed, RunOutcomeTriggerEnvFailed:
+		return "failed"
+	case RunOutcomeWispCanceled:
+		return "canceled"
+	default:
+		return ""
+	}
+}
+
 // EventCursor is the per-order event-bus cursor, encoded on the tracking bead
 // as the label pair ("order:<scoped>", "seq:<N>"). It is the high-water mark of
 // events the order has already consumed.
@@ -118,6 +150,21 @@ type OrderRun struct {
 	Open bool
 	// Cursor is the decoded EventCursor (max seq across the run's labels).
 	Cursor EventCursor
+}
+
+// State returns the feed-facing lifecycle status of the run: "failed" when the
+// terminal outcome is a failure or cancellation, "active" for an open run with
+// no failure, and "completed" for a closed run with no failure. It is the exact
+// truth-table replacement for the order feed's orderTrackingStatus label crack.
+func (r OrderRun) State() string {
+	switch r.Outcome.Display() {
+	case "failed", "canceled":
+		return "failed"
+	}
+	if r.Open {
+		return "active"
+	}
+	return "completed"
 }
 
 // RunOpts configures CreateRun.
@@ -269,6 +316,75 @@ func (s *Store) RecentRuns(scoped string, limit int) ([]OrderRun, error) {
 	return decodeRuns(scoped, beadsList), nil
 }
 
+// ListTracking lists every order tracking bead across both tiers, newest-first,
+// decoded into OrderRun values. It is the typed face of the /v0/orders/feed read
+// it replaces: it confines the order-tracking List and the tracking-bead decode
+// the feed previously performed inline. Beads with no order-run label (which
+// RunFromTrackingBead rejects) are skipped. The query is byte-identical to the
+// feed's prior raw scan — order-tracking label, created-desc, both tiers, and no
+// IncludeClosed so only in-flight/open tracking beads surface. Decoded rows and
+// any list error are returned together (the RecentRuns pattern) so callers keep
+// the feed's err-branch semantics.
+func (s *Store) ListTracking() ([]OrderRun, error) {
+	if s.store.Store == nil {
+		return nil, nil
+	}
+	list, err := s.store.List(beads.ListQuery{
+		Label:    labelOrderTracking,
+		Sort:     beads.SortCreatedDesc,
+		TierMode: beads.TierBoth,
+	})
+	runs := make([]OrderRun, 0, len(list))
+	for _, b := range list {
+		if run, ok := RunFromTrackingBead(b); ok {
+			runs = append(runs, run)
+		}
+	}
+	return runs, err
+}
+
+// LatestOpenRun returns the newest OPEN order-run bead for scoped, if any. The
+// query deliberately omits IncludeClosed: the order feed uses the most recent
+// OPEN run as the freshness signal for a tracking row's UpdatedAt, so a closed
+// run must not advance it. It is byte-identical to the feed's prior raw
+// order-run:<scoped> lookup (limit 1, created-desc, both tiers). The decoded
+// row, a found flag, and any list error are returned together; found can be true
+// alongside a partial-tier error, mirroring the feed's prior handling.
+func (s *Store) LatestOpenRun(scoped string) (OrderRun, bool, error) {
+	if s.store.Store == nil {
+		return OrderRun{}, false, nil
+	}
+	list, err := s.store.List(beads.ListQuery{
+		Label:    labelOrderRunPrefix + scoped,
+		Limit:    1,
+		Sort:     beads.SortCreatedDesc,
+		TierMode: beads.TierBoth,
+	})
+	if len(list) == 0 {
+		return OrderRun{}, false, err
+	}
+	return decodeRun(scoped, list[0]), true, err
+}
+
+// RunFromTrackingBead projects an order tracking/run bead onto an OrderRun and
+// is the exported decode entry other front-door callers (the API feed/history
+// edges) use; decodeRun stays private. It is pure, side-effect-free, and
+// backend-invariant (reads only bead fields), mirroring decodeRun and
+// session.InfoFromPersistedBead. The scoped order name is taken from the first
+// non-empty "order-run:<scoped>" label (identical to the feed's former
+// orderTrackingScopedName scan); a bead with no such label is not an order
+// tracking record, so ok=false.
+func RunFromTrackingBead(b beads.Bead) (OrderRun, bool) {
+	for _, label := range b.Labels {
+		if scoped, ok := strings.CutPrefix(label, labelOrderRunPrefix); ok {
+			if scoped = strings.TrimSpace(scoped); scoped != "" {
+				return decodeRun(scoped, b), true
+			}
+		}
+	}
+	return OrderRun{}, false
+}
+
 // decodeRun projects an order tracking/run bead onto an OrderRun. It is pure,
 // side-effect-free, and backend-invariant (reads only bead fields), matching the
 // projection-invariance invariant. The cooldown clock (CreatedAt), open flag,
@@ -294,6 +410,14 @@ func decodeRuns(scoped string, list []beads.Bead) []OrderRun {
 
 // outcomeFromLabels reverses RunOutcome.Labels, reporting the terminal outcome a
 // tracking bead's labels encode, or RunOutcomeNone for an in-flight run.
+//
+// This relies on the invariant that a tracking bead is stamped with exactly ONE
+// outcome family: either a single RunOutcome via SetOutcome, or the fixed
+// {wisp, wisp-failed} pair from the failure path. Given that, the decode order
+// (wisp family before exec/trigger) is unambiguous. A future writer that
+// double-stamps mixed families (e.g. {wisp, exec-failed}) would be silently
+// reclassified by this precedence; such a case must instead be modeled
+// explicitly as its own RunOutcome rather than allowed to fall through here.
 func outcomeFromLabels(labels []string) RunOutcome {
 	wisp := beadLabelsContain(labels, labelWisp)
 	switch {

--- a/internal/orders/store_test.go
+++ b/internal/orders/store_test.go
@@ -3,6 +3,7 @@ package orders
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/beadstest"
@@ -228,5 +229,215 @@ func TestRecentRunsReadsHistory(t *testing.T) {
 		if r.Scoped != "rig/agent" || r.CreatedAt.IsZero() {
 			t.Errorf("run = %+v, want scoped rig/agent with cooldown clock", r)
 		}
+	}
+}
+
+// TestRunFromTrackingBeadDecodesScopedOutcomeOpenCursor proves the exported
+// tracking-bead decode extracts the scoped name from the first non-empty
+// order-run label and folds outcome / open / cursor exactly like decodeRun, and
+// rejects beads that carry no order-run label (ok=false).
+func TestRunFromTrackingBeadDecodesScopedOutcomeOpenCursor(t *testing.T) {
+	b := beads.Bead{
+		ID:     "gc-42",
+		Status: "open",
+		Labels: []string{
+			"order-tracking",
+			"order-run:digest:rig:demo",
+			"wisp",
+			"wisp-failed",
+			"order:digest:rig:demo",
+			"seq:7",
+		},
+	}
+	run, ok := RunFromTrackingBead(b)
+	if !ok {
+		t.Fatal("RunFromTrackingBead ok = false, want true")
+	}
+	want := OrderRun{
+		ID:        "gc-42",
+		Scoped:    "digest:rig:demo",
+		Outcome:   RunOutcomeWispFailed,
+		CreatedAt: b.CreatedAt,
+		Open:      true,
+		Cursor:    EventCursor(7),
+	}
+	if !reflect.DeepEqual(run, want) {
+		t.Fatalf("run = %+v, want %+v", run, want)
+	}
+
+	if _, ok := RunFromTrackingBead(beads.Bead{Labels: []string{"order-tracking"}}); ok {
+		t.Errorf("RunFromTrackingBead(order-tracking only) ok = true, want false")
+	}
+	if _, ok := RunFromTrackingBead(beads.Bead{Labels: []string{"order-tracking", "order-run:"}}); ok {
+		t.Errorf("RunFromTrackingBead(empty order-run suffix) ok = true, want false")
+	}
+	if _, ok := RunFromTrackingBead(beads.Bead{Labels: []string{"order-run:   "}}); ok {
+		t.Errorf("RunFromTrackingBead(whitespace order-run suffix) ok = true, want false")
+	}
+}
+
+// TestRunOutcomeDisplayAndIsExec pins the display/exec vocabulary that replaces
+// the API's inline label cracks. The label sub-table is ported verbatim from the
+// deleted API test TestLastRunOutcomeFromLabelsPrioritizesTerminalLabels so the
+// pre-refactor outcome truth table survives through outcomeFromLabels + Display.
+func TestRunOutcomeDisplayAndIsExec(t *testing.T) {
+	cases := []struct {
+		outcome     RunOutcome
+		wantDisplay string
+		wantIsExec  bool
+	}{
+		{RunOutcomeNone, "", false},
+		{RunOutcomeExec, "success", true},
+		{RunOutcomeExecFailed, "failed", true},
+		{RunOutcomeExecEnvFailed, "failed", true},
+		{RunOutcomeWisp, "success", false},
+		{RunOutcomeWispFailed, "failed", false},
+		{RunOutcomeWispCanceled, "canceled", false},
+		{RunOutcomeTriggerEnvFailed, "failed", false},
+	}
+	for _, tc := range cases {
+		if got := tc.outcome.Display(); got != tc.wantDisplay {
+			t.Errorf("Display(%v) = %q, want %q", tc.outcome, got, tc.wantDisplay)
+		}
+		if got := tc.outcome.IsExec(); got != tc.wantIsExec {
+			t.Errorf("IsExec(%v) = %v, want %v", tc.outcome, got, tc.wantIsExec)
+		}
+	}
+
+	labelCases := []struct {
+		name   string
+		labels []string
+		want   string
+	}{
+		{"wisp failed dominates success", []string{"wisp", "wisp-failed"}, "failed"},
+		{"failed alone", []string{"wisp-failed"}, "failed"},
+		{"exec failed dominates success", []string{"exec", "exec-failed"}, "failed"},
+		{"exec env failed is failed", []string{"exec-env-failed"}, "failed"},
+		{"trigger env failed is failed", []string{"trigger-env-failed"}, "failed"},
+		{"canceled dominates success", []string{"wisp", "wisp-canceled"}, "canceled"},
+		{"success fallback", []string{"exec"}, "success"},
+		{"unknown", []string{"order-tracking"}, ""},
+	}
+	for _, tc := range labelCases {
+		if got := outcomeFromLabels(tc.labels).Display(); got != tc.want {
+			t.Errorf("%s: outcomeFromLabels(%v).Display() = %q, want %q", tc.name, tc.labels, got, tc.want)
+		}
+	}
+}
+
+// TestOrderRunStateMatchesLegacyFeedStatus is the equivalence tripwire for the
+// deleted orderTrackingStatus: each single-outcome-family bead decodes and its
+// State() must match the pre-refactor active/failed/completed classification.
+func TestOrderRunStateMatchesLegacyFeedStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status string
+		labels []string
+		want   string
+	}{
+		{"open exec-failed", "open", []string{"order-run:s", "exec-failed"}, "failed"},
+		{"open exec-env-failed", "open", []string{"order-run:s", "exec-env-failed"}, "failed"},
+		{"open trigger-env-failed", "open", []string{"order-run:s", "trigger-env-failed"}, "failed"},
+		{"open wisp-canceled", "open", []string{"order-run:s", "wisp", "wisp-canceled"}, "failed"},
+		{"open wisp-failed", "open", []string{"order-run:s", "wisp", "wisp-failed"}, "failed"},
+		{"open no-outcome", "open", []string{"order-run:s"}, "active"},
+		{"closed wisp", "closed", []string{"order-run:s", "wisp"}, "completed"},
+		{"closed exec", "closed", []string{"order-run:s", "exec"}, "completed"},
+		{"closed no-outcome", "closed", []string{"order-run:s"}, "completed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			run, ok := RunFromTrackingBead(beads.Bead{Status: tc.status, Labels: tc.labels})
+			if !ok {
+				t.Fatalf("RunFromTrackingBead ok = false")
+			}
+			if got := run.State(); got != tc.want {
+				t.Fatalf("State() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestListTrackingDecodesTrackingBeadsNewestFirst proves ListTracking mirrors
+// the /v0/orders/feed order-tracking scan: newest-first, fully decoded, skipping
+// beads without an order-run label, and returning (nil, nil) for a nil store.
+func TestListTrackingDecodesTrackingBeadsNewestFirst(t *testing.T) {
+	now := time.Now()
+	older := beads.Bead{
+		ID:        "gc-1",
+		Status:    "open",
+		CreatedAt: now.Add(-time.Hour),
+		Labels:    []string{"order-tracking", "order-run:rig/a"},
+	}
+	newer := beads.Bead{
+		ID:        "gc-2",
+		Status:    "open",
+		CreatedAt: now,
+		Labels:    []string{"order-tracking", "order-run:rig/b"},
+	}
+	unlabeled := beads.Bead{
+		ID:        "gc-3",
+		Status:    "open",
+		CreatedAt: now.Add(-30 * time.Minute),
+	}
+	mem := beads.NewMemStoreFrom(3, []beads.Bead{older, newer, unlabeled}, nil)
+	front := NewStore(beads.OrdersStore{Store: mem})
+
+	runs, err := front.ListTracking()
+	if err != nil {
+		t.Fatalf("ListTracking: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("runs = %d, want 2", len(runs))
+	}
+	if runs[0].Scoped != "rig/b" || runs[1].Scoped != "rig/a" {
+		t.Fatalf("order = [%s %s], want [rig/b rig/a] (newest first)", runs[0].Scoped, runs[1].Scoped)
+	}
+
+	got, err := NewStore(beads.OrdersStore{}).ListTracking()
+	if err != nil || got != nil {
+		t.Fatalf("nil-store ListTracking = (%v, %v), want (nil, nil)", got, err)
+	}
+}
+
+// TestLatestOpenRunIgnoresClosedRuns pins the deliberate IncludeClosed omission
+// (adjustment B): the freshness signal is the newest OPEN run, so a newer closed
+// run must not win, and an all-closed scoped name reports found=false.
+func TestLatestOpenRunIgnoresClosedRuns(t *testing.T) {
+	now := time.Now()
+	olderOpen := beads.Bead{
+		ID:        "gc-1",
+		Status:    "open",
+		CreatedAt: now.Add(-time.Hour),
+		Labels:    []string{"order-tracking", "order-run:rig/agent"},
+	}
+	newerClosed := beads.Bead{
+		ID:        "gc-2",
+		Status:    "closed",
+		CreatedAt: now,
+		Labels:    []string{"order-tracking", "order-run:rig/agent", "wisp"},
+	}
+	mem := beads.NewMemStoreFrom(2, []beads.Bead{olderOpen, newerClosed}, nil)
+	front := NewStore(beads.OrdersStore{Store: mem})
+
+	run, found, err := front.LatestOpenRun("rig/agent")
+	if err != nil {
+		t.Fatalf("LatestOpenRun: %v", err)
+	}
+	if !found {
+		t.Fatal("found = false, want true (older open run)")
+	}
+	if run.ID != "gc-1" {
+		t.Errorf("run.ID = %q, want gc-1 (open run, not the newer closed run)", run.ID)
+	}
+
+	allClosed := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:        "gc-9",
+		Status:    "closed",
+		CreatedAt: now,
+		Labels:    []string{"order-tracking", "order-run:rig/agent"},
+	}}, nil)
+	if _, found, err := NewStore(beads.OrdersStore{Store: allClosed}).LatestOpenRun("rig/agent"); err != nil || found {
+		t.Fatalf("all-closed LatestOpenRun = (found=%v, err=%v), want (false, nil)", found, err)
 	}
 }


### PR DESCRIPTION
## Summary

Routes the order feed/history read edges through the typed `orders.OrderRun`
decode instead of cracking tracking-bead labels/`Status` inline, and gives the
`convergence.gate_*` exec-gate vocabulary its **own** `internal/convergence`
projection rather than folding it into orders.

- `internal/orders/store.go` — new `RunFromTrackingBead`, `RunOutcome.IsExec/Display`,
  `OrderRun.State`, `Store.ListTracking`, `Store.LatestOpenRun`
- `internal/convergence/gate_output.go` (new) — `GateOutput` + `GateOutputFromMetadata`/
  `HasOutput`/`CombinedOutput`; convergence owns the `convergence.gate_*` keys
- `internal/api/orders_feed.go`, `huma_handlers_orders.go`, `handler_orders.go` —
  decode `OrderRun`s + `GateOutput`; deleted `orderTrackingStatus`,
  `orderTrackingScopedName`, `orderLabelsContain*`, `lastRunOutcomeFromLabels`,
  `orderRunHasOutput` (6 raw `convergence.gate_*` reads removed)

## Ownership note

`convergence.gate_*` is a distinct exec-gate vocabulary, so it lives in
`internal/convergence`, **not** `orders.OrderRun` — the order tracking bead does
not own those keys.

## Behavior preservation

Display status and scoped-name derivation are byte-identical to the deleted
inline logic; the store reads mirror the prior raw queries (including
`LatestOpenRun`'s deliberate `IncludeClosed` omission, pin-tested). `Display()`
was verified byte-equivalent to `lastRunOutcomeFromLabels` for every outcome
label set a production writer emits; a doc comment on `outcomeFromLabels` now
records the single-outcome-family-per-bead invariant this relies on.

## Verification

- `go build ./...`, `go vet` clean; `gofmt` clean
- `go test ./internal/orders ./internal/convergence ./internal/api` green; `go test ./cmd/gc -run Order` green
- `TestOpenAPISpecInSync` green (no wire drift; no generated/dashboard file touched)
- TDD: decode/projection tests written first; API outcome table ported verbatim into the orders package
- Fable adversarial review: approve (behavior byte-identical on all reachable inputs)

## Follow-ups (pre-existing, out of scope)

`huma_handlers_orders.go` history-fetch still hand-builds the `order-run:` label /
raw `ListQuery`, and `cmd/gc/order_dispatch.go markTrackingFailure` writes the
`{wisp,wisp-failed}` pair via raw `store.Update` — both are pre-existing sites
for a later `orders.Store` history-read / `SetOutcomeWithCursor` slice.

Part of the raw-bead-leak cleanup epic. Refs `ga-wp0309`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
