### PR TITLE
refactor(api,session): dedup API session codecs via session.Info projections

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -46,27 +46,12 @@ func sessionBeadAssigneeIdentities(sb beads.Bead) []string {
 
 // sessionBeadAssigneeIdentitiesInfo is the session.Info mirror of
 // sessionBeadAssigneeIdentities. It reads the RAW session_name
-// (Info.SessionNameMetadata) and the pre-normalized Info.AliasHistory.
+// (Info.SessionNameMetadata) and the pre-normalized Info.AliasHistory. The body
+// is the confined session.AssigneeIdentities codec; the bead-form peer above
+// stays inline to avoid a per-iteration Info projection in the hot reconciler
+// loops (the classifier-equivalence oracle guards their agreement).
 func sessionBeadAssigneeIdentitiesInfo(i session.Info) []string {
-	identities := make([]string, 0, 5)
-	if id := strings.TrimSpace(i.ID); id != "" {
-		identities = append(identities, id)
-	}
-	if sn := strings.TrimSpace(i.SessionNameMetadata); sn != "" {
-		identities = append(identities, sn)
-	}
-	if ni := strings.TrimSpace(i.ConfiguredNamedIdentity); ni != "" {
-		identities = append(identities, ni)
-	}
-	if al := strings.TrimSpace(i.Alias); al != "" {
-		identities = append(identities, al)
-	}
-	for _, prior := range i.AliasHistory {
-		if prior = strings.TrimSpace(prior); prior != "" {
-			identities = append(identities, prior)
-		}
-	}
-	return identities
+	return session.AssigneeIdentities(i)
 }
 
 type releasedPoolAssignment struct {

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -59,10 +59,10 @@ func (s *Server) beadListAssigneeTerms(ctx context.Context, assignee string) []s
 	}
 	// A work bead's stored assignee may be ANY of the resolved session's
 	// identity forms — the bead ID, session_name, alias, configured named
-	// identity, or a prior alias — so match against all of them (mirrors
-	// sessionBeadAssigneeIdentities used by the reconciler). Without this the
-	// session-name form written by assign/update (and the claim path) would be
-	// invisible to ?assignee=<alias|id> list filters.
+	// identity, or a prior alias — so match against all of them via the confined
+	// session.AssigneeIdentities codec. Without this the session-name form
+	// written by assign/update (and the claim path) would be invisible to
+	// ?assignee=<alias|id> list filters.
 	seen := map[string]bool{}
 	var terms []string
 	add := func(v string) {
@@ -76,11 +76,8 @@ func (s *Server) beadListAssigneeTerms(ctx context.Context, assignee string) []s
 	add(assignee)
 	add(id)
 	if b, getErr := store.Get(id); getErr == nil {
-		add(b.Metadata["session_name"])
-		add(b.Metadata["alias"])
-		add(b.Metadata[session.NamedSessionIdentityMetadata])
-		for _, prior := range session.AliasHistory(b.Metadata) {
-			add(prior)
+		for _, identity := range session.AssigneeIdentities(session.InfoFromPersistedBead(b)) {
+			add(identity)
 		}
 	}
 	return terms
@@ -113,26 +110,7 @@ func (s *Server) normalizeRawBeadAssignee(ctx context.Context, assignee string) 
 		return "", fmt.Errorf("assignee must resolve to a concrete open session bead ID: %q", assignee)
 	}
 	session.RepairEmptyType(store, &b)
-	return sessionBeadAssigneeIdentifier(b), nil
-}
-
-// sessionBeadAssigneeIdentifier returns the durable agent-facing identity form
-// of a session bead — its session_name, else alias, else configured named
-// identity — falling back to the bead ID when no name metadata is present so a
-// resolved assignment is never silently cleared. This is the form the agent
-// claims and verifies work with (BEADS_ACTOR / GC_SESSION_NAME), so stamping it
-// keeps assign/update consistent with the claim path (which already stores the
-// raw session-name) and with the form-agnostic session matching in the
-// reconciler (sessionBeadAssigneeIdentities). Stamping the bare bead ID here
-// instead made template-routed continuation work unclaimable by name-matching
-// agents.
-func sessionBeadAssigneeIdentifier(b beads.Bead) string {
-	for _, key := range []string{"session_name", "alias", session.NamedSessionIdentityMetadata} {
-		if v := strings.TrimSpace(b.Metadata[key]); v != "" {
-			return v
-		}
-	}
-	return b.ID
+	return session.AssigneeIdentifier(session.InfoFromPersistedBead(b)), nil
 }
 
 // findStore returns the bead store for the given rig. If rig is empty, returns

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -1800,6 +1800,45 @@ func TestPhase2BeadListAssigneeAliasKeepsCrossRigDuplicateIDs(t *testing.T) {
 	}
 }
 
+// TestBeadListAssigneeTermsIncludesAllSessionIdentityForms pins the term SET
+// beadListAssigneeTerms enumerates for a resolved session: the input term, the
+// bead ID, session_name, alias, configured named identity, and every prior
+// alias. Order is not part of the contract (huma_handlers_beads re-sorts
+// globally when len(terms)>1); the set must stay stable across the codec swap
+// onto session.AssigneeIdentities.
+func TestBeadListAssigneeTermsIncludesAllSessionIdentityForms(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	sessionBead, err := state.cityBeadStore.Create(beads.Bead{
+		Title:  "Worker session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name":              "test-city--worker",
+			"alias":                     "worker",
+			"configured_named_identity": "reviewer",
+			"alias_history":             "nux,rictus",
+			"template":                  "myrig/worker",
+			"state":                     "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+	srv := New(state)
+
+	terms := srv.beadListAssigneeTerms(context.Background(), "worker")
+	got := make(map[string]bool, len(terms))
+	for _, term := range terms {
+		got[term] = true
+	}
+	for _, want := range []string{"worker", sessionBead.ID, "test-city--worker", "reviewer", "nux", "rictus"} {
+		if !got[want] {
+			t.Errorf("beadListAssigneeTerms(worker) missing %q; got %v", want, terms)
+		}
+	}
+}
+
 func TestPhase2BeadAssignNormalizesCurrentSessionName(t *testing.T) {
 	state := newFakeState(t)
 	state.cityBeadStore = beads.NewMemStore()

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -92,7 +92,7 @@ func (s *Server) resolveMailSendRecipientWithContext(ctx context.Context, recipi
 		if getErr != nil {
 			return "", getErr
 		}
-		address := apiSessionMailboxAddress(bead)
+		address := session.MailboxAddress(bead)
 		if address == "" {
 			return "", fmt.Errorf("session %q has no mailbox identity", recipient)
 		}
@@ -142,7 +142,7 @@ func (s *Server) resolveMailQueryRecipientsWithContext(ctx context.Context, reci
 		return []string{recipient}
 	}
 	if bead, getErr := store.Get(resolved); getErr == nil {
-		if recipients := apiSessionMailboxAddresses(bead); len(recipients) > 0 {
+		if recipients := session.MailboxAddressesIncludingRuntimeName(bead); len(recipients) > 0 {
 			return recipients
 		}
 	}
@@ -177,7 +177,7 @@ func (s *Server) mailRecipientsForNamedSession(store beads.Store, spec apiNamedS
 			continue
 		}
 		seen[b.ID] = true
-		recipients = append(recipients, apiSessionMailboxAddresses(b)...)
+		recipients = append(recipients, session.MailboxAddressesIncludingRuntimeName(b)...)
 	}
 	recipients = uniqueNonEmptyMailRecipients(recipients)
 	sort.Strings(recipients)
@@ -213,36 +213,6 @@ func (s *Server) configuredNamedMailIdentities(identifier string) []string {
 type apiResolvedMailTarget struct {
 	display    string
 	recipients []string
-}
-
-func apiSessionMailboxAddress(b beads.Bead) string {
-	if alias := strings.TrimSpace(b.Metadata["alias"]); alias != "" {
-		return alias
-	}
-	if b.ID != "" {
-		return b.ID
-	}
-	return strings.TrimSpace(b.Metadata["session_name"])
-}
-
-func apiSessionMailboxAddresses(b beads.Bead) []string {
-	seen := map[string]bool{}
-	var addresses []string
-	add := func(value string) {
-		value = strings.TrimSpace(value)
-		if value == "" || seen[value] {
-			return
-		}
-		seen[value] = true
-		addresses = append(addresses, value)
-	}
-	add(apiSessionMailboxAddress(b))
-	add(b.ID)
-	for _, alias := range session.AliasHistory(b.Metadata) {
-		add(alias)
-	}
-	add(b.Metadata["session_name"])
-	return addresses
 }
 
 func (s *Server) resolveLiveConfiguredNamedMailTarget(store beads.Store, identifier string) (apiResolvedMailTarget, bool, error) {
@@ -281,11 +251,11 @@ func (s *Server) resolveLiveConfiguredNamedMailTarget(store beads.Store, identif
 		if identity == "" || session.TargetBasename(identity) != identifier {
 			continue
 		}
-		addresses := apiSessionMailboxAddresses(b)
+		addresses := session.MailboxAddressesIncludingRuntimeName(b)
 		if len(addresses) == 0 {
 			continue
 		}
-		display := apiSessionMailboxAddress(b)
+		display := session.MailboxAddress(b)
 		if display == "" {
 			display = addresses[0]
 		}

--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -491,8 +491,10 @@ func (s *Server) handleSessionWake(w http.ResponseWriter, r *http.Request) {
 		log.Printf("gc api: withdrawing queued wait nudges after wake %s: %v", id, err)
 	}
 	// Clear in-memory crash tracker so the reconciler doesn't immediately
-	// re-quarantine the session based on stale crash history.
-	sessionName := b.Metadata["session_name"]
+	// re-quarantine the session based on stale crash history. Read the RAW
+	// SessionNameMetadata (not Info.SessionName, which falls back to
+	// sessionNameFor(ID)) to preserve the skip-when-unset behavior.
+	sessionName := session.InfoFromPersistedBead(b).SessionNameMetadata
 	if sessionName != "" {
 		s.state.ClearCrashHistory(sessionName)
 	}
@@ -757,7 +759,7 @@ func (s *Server) handleSessionPatch(w http.ResponseWriter, r *http.Request) {
 		return catalog.UpdatePresentation(id, titlePtr, aliasPtr)
 	}
 	if aliasPtr != nil {
-		if strings.TrimSpace(b.Metadata["agent_name"]) != "" {
+		if strings.TrimSpace(session.InfoFromPersistedBead(b).AgentName) != "" {
 			writeError(w, http.StatusForbidden, "forbidden", "alias is controller-managed for this session")
 			return
 		}

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -430,7 +430,7 @@ func (s *Server) humaHandleSessionPatch(_ context.Context, input *SessionPatchIn
 		return mgr.UpdatePresentation(id, titlePtr, aliasPtr)
 	}
 	if aliasPtr != nil {
-		if strings.TrimSpace(b.Metadata["agent_name"]) != "" {
+		if strings.TrimSpace(session.InfoFromPersistedBead(b).AgentName) != "" {
 			return nil, huma.Error403Forbidden("forbidden: alias is controller-managed for this session")
 		}
 		if lockErr := session.WithCitySessionAliasLock(s.state.CityPath(), *aliasPtr, func() error {
@@ -887,7 +887,9 @@ func (s *Server) humaHandleSessionWake(ctx context.Context, input *SessionIDInpu
 	if err := withdrawQueuedWaitNudges(s.state.NudgesBeadStore(), s.state.CityPath(), nudgeIDs); err != nil {
 		log.Printf("gc api: withdrawing queued wait nudges after wake %s: %v", id, err)
 	}
-	sessionName := b.Metadata["session_name"]
+	// RAW SessionNameMetadata (not Info.SessionName, which falls back to
+	// sessionNameFor(ID)) to preserve the skip-when-unset behavior.
+	sessionName := session.InfoFromPersistedBead(b).SessionNameMetadata
 	if sessionName != "" {
 		s.state.ClearCrashHistory(sessionName)
 	}

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -163,7 +163,7 @@ func (s *Server) retireContinuityIneligibleNamedSessionIdentifiers(store beads.S
 			retired = append(retired, b)
 			continue
 		}
-		if sessionName := strings.TrimSpace(b.Metadata["session_name"]); sessionName != "" && s.state.SessionProvider() != nil {
+		if sessionName := strings.TrimSpace(session.InfoFromPersistedBead(b).SessionNameMetadata); sessionName != "" && s.state.SessionProvider() != nil {
 			if handle, err := s.workerHandleForSession(store, b.ID); err == nil {
 				_ = handle.Kill(context.Background())
 			}
@@ -432,7 +432,9 @@ func resolveLiveSessionByPathAlias(store beads.Store, identifier string) (string
 		if strings.TrimSpace(b.Title) != identifier {
 			continue
 		}
-		state := session.State(b.Metadata["state"])
+		// MetadataState is the RAW state mirror; Info.State is normalizeInfoState-
+		// folded (awake->active), which would change this predicate.
+		state := session.State(session.InfoFromPersistedBead(b).MetadataState)
 		if state != session.StateActive && state != session.StateAwake && state != session.StateNone {
 			continue
 		}

--- a/internal/session/assignee_identities.go
+++ b/internal/session/assignee_identities.go
@@ -1,0 +1,65 @@
+package session
+
+import "strings"
+
+// This file is the confined session-class assignee-identity vocabulary: the
+// forms under which a work bead may be assigned to a session. It is shared by
+// the reconciler orphan-release loops (which enumerate every form a live
+// session answers to) and the API assignee list filter and assign stamper
+// (which enumerate the same set and pick the durable stamp form). Confining it
+// here keeps the session-bead metadata keys (session_name / alias /
+// configured_named_identity / alias_history) out of cmd/gc and internal/api, so
+// those callers speak session identities via session.Info instead of cracking
+// beads.Bead.Metadata directly.
+//
+// All reads use the RAW Info mirrors (SessionNameMetadata, not SessionName)
+// because Info.SessionName falls back to sessionNameFor(ID); admitting that
+// derived runtime name into the assignee set would match work the session was
+// never assigned.
+
+// AssigneeIdentities returns every identifier under which a work bead could be
+// assigned to this session: the session bead ID, session_name,
+// configured_named_identity, current alias, and any prior aliases preserved in
+// alias_history — each trimmed, empty values skipped, in that order. Pool
+// polecat aliases (e.g. "nux") are first-class assignment identities, so
+// leaving them out of orphan-detection resets in-progress work under a live
+// owner — see the SkipsLiveSessionAssignedByAlias regression tests.
+func AssigneeIdentities(i Info) []string {
+	identities := make([]string, 0, 5)
+	if id := strings.TrimSpace(i.ID); id != "" {
+		identities = append(identities, id)
+	}
+	if sn := strings.TrimSpace(i.SessionNameMetadata); sn != "" {
+		identities = append(identities, sn)
+	}
+	if ni := strings.TrimSpace(i.ConfiguredNamedIdentity); ni != "" {
+		identities = append(identities, ni)
+	}
+	if al := strings.TrimSpace(i.Alias); al != "" {
+		identities = append(identities, al)
+	}
+	for _, prior := range i.AliasHistory {
+		if prior = strings.TrimSpace(prior); prior != "" {
+			identities = append(identities, prior)
+		}
+	}
+	return identities
+}
+
+// AssigneeIdentifier returns the durable agent-facing identity form of a
+// session — its session_name, else alias, else configured named identity —
+// falling back to the bead ID when no name metadata is present so a resolved
+// assignment is never silently cleared. This is the form the agent claims and
+// verifies work with (BEADS_ACTOR / GC_SESSION_NAME), so stamping it keeps
+// assign/update consistent with the claim path (which already stores the raw
+// session-name) and with the form-agnostic matching in AssigneeIdentities.
+// Stamping the bare bead ID here instead made template-routed continuation work
+// unclaimable by name-matching agents.
+func AssigneeIdentifier(i Info) string {
+	for _, v := range []string{i.SessionNameMetadata, i.Alias, i.ConfiguredNamedIdentity} {
+		if v = strings.TrimSpace(v); v != "" {
+			return v
+		}
+	}
+	return i.ID
+}

--- a/internal/session/assignee_identities_test.go
+++ b/internal/session/assignee_identities_test.go
@@ -1,0 +1,170 @@
+package session
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// The assignee-identity codec is the confined vocabulary shared by the
+// reconciler orphan-release loops and the API assignee list filter/stamper.
+// These tests pin AssigneeIdentities to the cmd/gc sessionBeadAssigneeIdentities
+// case table it replaces (via InfoFromPersistedBead, proving bead<->Info
+// agreement) and pin AssigneeIdentifier to the internal/api
+// sessionBeadAssigneeIdentifier precedence it replaces, so the enumerated term
+// set and the stamped identity form stay byte-identical after the dedup. A
+// direct-Info case proves the RAW SessionNameMetadata field is read (no
+// sessionNameFor(ID) fallback leak).
+
+func TestAssigneeIdentities(t *testing.T) {
+	tests := []struct {
+		name string
+		bead beads.Bead
+		want []string
+	}{
+		{
+			name: "empty bead produces no identities",
+			bead: beads.Bead{},
+			want: []string{},
+		},
+		{
+			name: "id only",
+			bead: beads.Bead{ID: "mc-xyz"},
+			want: []string{"mc-xyz"},
+		},
+		{
+			name: "session_name only",
+			bead: beads.Bead{Metadata: map[string]string{"session_name": "worker-mc-live"}},
+			want: []string{"worker-mc-live"},
+		},
+		{
+			name: "configured_named_identity only",
+			bead: beads.Bead{Metadata: map[string]string{"configured_named_identity": "reviewer"}},
+			want: []string{"reviewer"},
+		},
+		{
+			name: "alias only",
+			bead: beads.Bead{Metadata: map[string]string{"alias": "nux"}},
+			want: []string{"nux"},
+		},
+		{
+			name: "alias_history single entry",
+			bead: beads.Bead{Metadata: map[string]string{"alias_history": "previous"}},
+			want: []string{"previous"},
+		},
+		{
+			name: "alias_history multiple entries",
+			bead: beads.Bead{Metadata: map[string]string{"alias_history": "first,second,third"}},
+			want: []string{"first", "second", "third"},
+		},
+		{
+			name: "all fields populated",
+			bead: beads.Bead{
+				ID: "mc-xyz",
+				Metadata: map[string]string{
+					"session_name":              "worker-mc-live",
+					"configured_named_identity": "reviewer",
+					"alias":                     "rictus",
+					"alias_history":             "nux",
+				},
+			},
+			want: []string{"mc-xyz", "worker-mc-live", "reviewer", "rictus", "nux"},
+		},
+		{
+			name: "whitespace-only values are trimmed and skipped",
+			bead: beads.Bead{
+				ID: "  ",
+				Metadata: map[string]string{
+					"session_name":              "   ",
+					"configured_named_identity": "\t",
+					"alias":                     " ",
+					"alias_history":             "  ,  , real ,  ",
+				},
+			},
+			want: []string{"real"},
+		},
+		{
+			name: "values with surrounding whitespace are trimmed",
+			bead: beads.Bead{
+				ID: "  mc-xyz  ",
+				Metadata: map[string]string{
+					"session_name":              "  worker-mc-live  ",
+					"configured_named_identity": "  reviewer  ",
+					"alias":                     "  nux  ",
+				},
+			},
+			want: []string{"mc-xyz", "worker-mc-live", "reviewer", "nux"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AssigneeIdentities(InfoFromPersistedBead(tt.bead))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d identities %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for i, id := range got {
+				if id != tt.want[i] {
+					t.Errorf("identity[%d] = %q, want %q (full got=%v, want=%v)", i, id, tt.want[i], got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// TestAssigneeIdentitiesReadsRawSessionName proves AssigneeIdentities reads the
+// RAW SessionNameMetadata field, not Info.SessionName (which falls back to
+// sessionNameFor(ID)). A blank SessionNameMetadata must not leak the derived
+// runtime name into the identity set.
+func TestAssigneeIdentitiesReadsRawSessionName(t *testing.T) {
+	i := Info{ID: "s1", SessionName: "s-gc-derived", SessionNameMetadata: ""}
+	if got, want := AssigneeIdentities(i), []string{"s1"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("AssigneeIdentities = %#v, want %#v (must not leak sessionNameFor(ID))", got, want)
+	}
+}
+
+func TestAssigneeIdentifier(t *testing.T) {
+	tests := []struct {
+		name string
+		info Info
+		want string
+	}{
+		{
+			name: "session_name wins",
+			info: Info{ID: "s1", SessionNameMetadata: "sn", Alias: "al", ConfiguredNamedIdentity: "ni"},
+			want: "sn",
+		},
+		{
+			name: "alias when no session_name",
+			info: Info{ID: "s1", Alias: "al", ConfiguredNamedIdentity: "ni"},
+			want: "al",
+		},
+		{
+			name: "configured named identity when no session_name or alias",
+			info: Info{ID: "s1", ConfiguredNamedIdentity: "ni"},
+			want: "ni",
+		},
+		{
+			name: "bead id fallback when no name metadata",
+			info: Info{ID: "s1"},
+			want: "s1",
+		},
+		{
+			name: "whitespace-only values skipped, falls through to id",
+			info: Info{ID: "s1", SessionNameMetadata: "  ", Alias: "\t", ConfiguredNamedIdentity: " "},
+			want: "s1",
+		},
+		{
+			name: "values trimmed",
+			info: Info{ID: "s1", SessionNameMetadata: "  sn  "},
+			want: "sn",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AssigneeIdentifier(tt.info); got != tt.want {
+				t.Errorf("AssigneeIdentifier = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/session/mailbox_address.go
+++ b/internal/session/mailbox_address.go
@@ -34,6 +34,30 @@ func MailboxAddress(b beads.Bead) string {
 // is the canonical home of the logic the mail CLI previously inlined as
 // sessionMailboxAddresses.
 func MailboxAddresses(b beads.Bead) []string {
+	return mailboxAddresses(b, false)
+}
+
+// MailboxAddressesIncludingRuntimeName returns every mailbox address a session
+// bead can receive mail at, always including its runtime session_name (appended
+// last), even when other addresses already resolved. This is the API read
+// semantics introduced by bf576b04a ("fix: include runtime session mailboxes in
+// API reads"): mail persisted under a session's runtime name must stay
+// reachable via API inbox/count queries, guarded by
+// TestMailAPIQueriesAllResolvedSessionMailboxAddresses.
+//
+// It deliberately forks from MailboxAddresses, which appends session_name only
+// as a last-resort fallback. That CLI/API fork is a documented product decision
+// (the CLI inbox can miss mail persisted under a runtime session_name the API
+// finds); reconciling the two recipient views is tracked as a follow-up.
+func MailboxAddressesIncludingRuntimeName(b beads.Bead) []string {
+	return mailboxAddresses(b, true)
+}
+
+// mailboxAddresses is the shared body behind MailboxAddresses (CLI fallback-only
+// session_name) and MailboxAddressesIncludingRuntimeName (API unconditional
+// session_name). When includeRuntimeName is true the session_name is always
+// added; otherwise it is only added when nothing else resolved.
+func mailboxAddresses(b beads.Bead, includeRuntimeName bool) []string {
 	seen := map[string]bool{}
 	var addresses []string
 	add := func(value string) {
@@ -49,7 +73,9 @@ func MailboxAddresses(b beads.Bead) []string {
 	for _, alias := range AliasHistory(b.Metadata) {
 		add(alias)
 	}
-	if len(addresses) == 0 {
+	if includeRuntimeName {
+		add(b.Metadata["session_name"])
+	} else if len(addresses) == 0 {
 		add(strings.TrimSpace(b.Metadata["session_name"]))
 	}
 	return addresses

--- a/internal/session/mailbox_address_test.go
+++ b/internal/session/mailbox_address_test.go
@@ -95,6 +95,53 @@ func TestMailboxAddressesCodec(t *testing.T) {
 	}
 }
 
+// TestMailboxAddressesIncludingRuntimeNameCodec pins the API-dup semantics that
+// MailboxAddressesIncludingRuntimeName preserves: unlike MailboxAddresses (the
+// CLI fork, tested above), it appends session_name UNCONDITIONALLY (last),
+// keeping runtime session mailboxes reachable via API reads (bf576b04a).
+func TestMailboxAddressesIncludingRuntimeNameCodec(t *testing.T) {
+	tests := []struct {
+		name string
+		bead beads.Bead
+		want []string
+	}{
+		{
+			name: "session_name appended last even when other addresses resolve",
+			bead: beads.Bead{
+				ID: "sess-1",
+				Metadata: map[string]string{
+					"alias":         "mayor",
+					"alias_history": "deacon,mayor,polecat",
+					"session_name":  "sn-1",
+				},
+			},
+			want: []string{"mayor", "sess-1", "deacon", "polecat", "sn-1"},
+		},
+		{
+			name: "session_name deduped against primary",
+			bead: beads.Bead{Metadata: map[string]string{"session_name": "sn-1"}},
+			want: []string{"sn-1"},
+		},
+		{
+			name: "id only",
+			bead: beads.Bead{ID: "sess-1"},
+			want: []string{"sess-1"},
+		},
+		{
+			name: "empty everything",
+			bead: beads.Bead{},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MailboxAddressesIncludingRuntimeName(tt.bead); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MailboxAddressesIncludingRuntimeName = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtmsgHandleSourceCodec(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

Deletes `internal/api` re-implementations of confined `internal/session`
codecs and routes the remaining API-side session-metadata cracks through
`session.Info` projections.

- **Mailbox address dedup** — `apiSessionMailboxAddress` deleted → `session.MailboxAddress`.
  `apiSessionMailboxAddresses` was **not** identical to `session.MailboxAddresses`
  (the API variant appends `session_name` *unconditionally last*, the CLI codec
  only as a last-resort fallback — a deliberate prior fix, `bf576b04a`), so rather
  than collapse them, a new `session.MailboxAddressesIncludingRuntimeName` shares a
  `mailboxAddresses(b, includeRuntimeName bool)` body and preserves the API semantics.
- **Assignee identities** — new `session.AssigneeIdentities`/`AssigneeIdentifier`
  replace `internal/api`'s `sessionBeadAssigneeIdentifier`; `handler_beads.go`
  assignee enumeration routes through the codec.
- **Session-metadata cracks** — `handler_sessions.go`, `huma_handlers_sessions_command.go`,
  `session_resolution.go`, and `cmd/gc/pool_session_name.go` read `session.Info`
  projections instead of raw `b.Metadata[...]`. `session_resolution.go` deliberately
  uses the raw `MetadataState` mirror (not `Info.State`, which folds awake→active).

## Behavior preservation

All three equivalences verified byte-for-byte: mailbox address set + order,
assignee identity forms (the assignee-term ordering delta is inert — the sole
consumer dedupes by `(rig, ID)` and re-sorts with a total order), and the
`MetadataState`-vs-`Info.State` distinction. The `cmd/gc` bead-form peer stays
inline in the hot reconciler loop, guarded by the classifier-equivalence oracle.

## Verification

- `go build ./...`, `go vet ./internal/session ./internal/api ./cmd/gc` clean; `gofmt` clean
- `go test ./internal/session ./internal/api` green; `go test ./cmd/gc -run 'SessionBeadAssigneeIdentities|InfoEquiv|Classifier'` green
- `bf576b04a` oracle `TestMailAPIQueriesAllResolvedSessionMailboxAddresses` + `TestOpenAPISpecInSync` green; `make test` exit 0
- TDD: `MailboxAddressesIncludingRuntimeName` / `AssigneeIdentities` / `AssigneeIdentifier` pin tests written first
- Fable adversarial review: approve (all equivalences confirmed)

## Follow-up (pre-existing, out of scope)

Sibling raw session-metadata cracks remain at `internal/api/handler_status.go`
(~503-505, 740) and `huma_handlers_sessions_query.go:296` — a later slice can
route them through `session.InfoFromPersistedBead` (the raw mirrors already exist).

Part of the raw-bead-leak cleanup epic. Refs `ga-7jftpc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
