### PR TITLE
refactor(nudge): confine terminal-key vocabulary in Store.SweepStale, read via DecodeShadow

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1137,7 +1137,7 @@ func resolveNudgeTarget(identifier string, warningWriter ...io.Writer) (nudgeTar
 			if getErr != nil {
 				return nudgeTarget{}, getErr
 			}
-			return resolveNudgeTargetFromSessionBead(cityPath, cfg, b), nil
+			return resolveNudgeTargetFromSessionInfo(cityPath, cfg, session.InfoFromPersistedBead(b)), nil
 		}
 		if !errors.Is(err, session.ErrSessionNotFound) {
 			return nudgeTarget{}, err
@@ -1147,8 +1147,8 @@ func resolveNudgeTarget(identifier string, warningWriter ...io.Writer) (nudgeTar
 }
 
 // nudgeTargetFields carries the pre-extracted session attributes buildNudgeTarget
-// needs. Both resolvers (raw bead and typed session.Info) populate it from their
-// own source, so the identity-resolution tail lives in exactly one place.
+// needs. resolveNudgeTargetFromSessionInfo populates it from a session.Info
+// projection, so the identity-resolution tail lives in exactly one place.
 type nudgeTargetFields struct {
 	sessionID         string
 	sessionName       string
@@ -1162,30 +1162,11 @@ type nudgeTargetFields struct {
 	continuationEpoch string
 }
 
-func resolveNudgeTargetFromSessionBead(cityPath string, cfg *config.City, b beads.Bead) nudgeTarget {
-	sessionName := strings.TrimSpace(b.Metadata["session_name"])
-	if sessionName == "" {
-		sessionName = sessionNameFromBeadID(b.ID)
-	}
-	return buildNudgeTarget(cityPath, cfg, nudgeTargetFields{
-		sessionID:         b.ID,
-		sessionName:       sessionName,
-		alias:             strings.TrimSpace(b.Metadata["alias"]),
-		agentName:         strings.TrimSpace(b.Metadata["agent_name"]),
-		template:          strings.TrimSpace(b.Metadata["template"]),
-		commonName:        strings.TrimSpace(b.Metadata["common_name"]),
-		aliasHistory:      session.AliasHistory(b.Metadata),
-		transport:         strings.TrimSpace(b.Metadata["transport"]),
-		provider:          strings.TrimSpace(b.Metadata["provider"]),
-		continuationEpoch: strings.TrimSpace(b.Metadata["continuation_epoch"]),
-	})
-}
-
-// resolveNudgeTargetFromSessionInfo is the typed front-door sibling of
-// resolveNudgeTargetFromSessionBead: it reads the same session attributes from a
-// session.Info projection instead of the raw bead. Note the transport source is
-// i.TransportMetadata (the RAW value), not i.Transport (which normalizeTransport
-// would make non-empty), so the found.Session fallback below fires identically.
+// resolveNudgeTargetFromSessionInfo reads the session attributes buildNudgeTarget
+// needs from a session.Info projection (the typed front door) rather than cracking
+// the raw session bead. Note the transport source is i.TransportMetadata (the RAW
+// value), not i.Transport (which normalizeTransport would make non-empty), so the
+// found.Session fallback below fires identically.
 func resolveNudgeTargetFromSessionInfo(cityPath string, cfg *config.City, i session.Info) nudgeTarget {
 	sessionName := strings.TrimSpace(i.SessionNameMetadata)
 	if sessionName == "" {
@@ -1484,14 +1465,15 @@ func withNudgeTargetFence(store beads.Store, target nudgeTarget) nudgeTarget {
 		return target
 	}
 	for _, b := range open {
-		if b.Metadata["session_name"] != target.sessionName {
+		info := session.InfoFromPersistedBead(b)
+		if info.SessionNameMetadata != target.sessionName {
 			continue
 		}
 		if target.sessionID == "" {
 			target.sessionID = b.ID
 		}
 		if target.continuationEpoch == "" {
-			target.continuationEpoch = b.Metadata["continuation_epoch"]
+			target.continuationEpoch = info.ContinuationEpoch
 		}
 		return target
 	}

--- a/cmd/gc/nudge_mail_sweep.go
+++ b/cmd/gc/nudge_mail_sweep.go
@@ -37,7 +37,8 @@ type nudgeMailSweepResult struct {
 //
 // Nudge candidates are open beads with label gc:nudge created before now-nudgeTTL
 // whose nudge_id is not present in nudgeState.Pending or nudgeState.InFlight.
-// Terminal metadata is recorded before each close so the bead audit trail is intact.
+// Terminal metadata is stamped via nudgequeue.Store.SweepStale before each close
+// so the bead audit trail is intact.
 //
 // Mail candidates are open message beads with label "read" created before now-mailTTL.
 //
@@ -54,6 +55,7 @@ func sweepStaleNudgeMail(nudgeStore beads.NudgesStore, mailStore beads.MailStore
 	var beadErrs []error
 
 	liveIDs := liveNudgeIDSet(nudgeState)
+	nq := nudgequeue.NewStore(nudgeStore)
 
 	// Phase 1: close stale nudge beads.
 	nudgeCutoff := now.Add(-nudgeTTL)
@@ -74,22 +76,12 @@ func sweepStaleNudgeMail(nudgeStore beads.NudgesStore, mailStore beads.MailStore
 		if b.Status != "open" {
 			continue
 		}
-		nudgeID := strings.TrimSpace(b.Metadata["nudge_id"])
+		nudgeID := strings.TrimSpace(nudgequeue.DecodeShadow(b).ID)
 		if nudgeID != "" && liveIDs[nudgeID] {
 			continue
 		}
-		if err := nudgeStore.SetMetadataBatch(b.ID, map[string]string{
-			"state":           "gc-swept",
-			"terminal_reason": "gc-swept-stale",
-			"commit_boundary": "gc-swept",
-			"terminal_at":     now.UTC().Format(time.RFC3339),
-			"close_reason":    nudgeMailSweepNudgeCloseReason,
-		}); err != nil {
-			beadErrs = append(beadErrs, fmt.Errorf("nudge %s: set metadata: %w", b.ID, err))
-			continue
-		}
-		if err := nudgeStore.Close(b.ID); err != nil {
-			beadErrs = append(beadErrs, fmt.Errorf("nudge %s: close: %w", b.ID, err))
+		if err := nq.SweepStale(b.ID, nudgeMailSweepNudgeCloseReason, now); err != nil {
+			beadErrs = append(beadErrs, err)
 			continue
 		}
 		result.NudgeClosed++
@@ -155,7 +147,7 @@ func countStaleNudgeMail(nudgeStore beads.NudgesStore, mailStore beads.MailStore
 		if b.Status != "open" {
 			continue
 		}
-		nudgeID := strings.TrimSpace(b.Metadata["nudge_id"])
+		nudgeID := strings.TrimSpace(nudgequeue.DecodeShadow(b).ID)
 		if nudgeID != "" && liveIDs[nudgeID] {
 			continue
 		}

--- a/cmd/gc/nudge_target_info_equiv_test.go
+++ b/cmd/gc/nudge_target_info_equiv_test.go
@@ -9,14 +9,18 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
-// TestNudgeTargetInfoEquivalence is the byte-identical oracle for migrating the
-// nudge dispatcher off raw session beads. resolveNudgeTargetFromSessionInfo must
-// produce exactly the nudgeTarget that resolveNudgeTargetFromSessionBead does for
-// the same bead once projected through InfoFromPersistedBead. The transport cases
-// specifically guard the fidelity trap: the resolver reads the RAW transport
-// metadata (via i.TransportMetadata), not the normalized i.Transport, so the
-// empty/whitespace-transport beads must still take the found.Session fallback.
-func TestNudgeTargetInfoEquivalence(t *testing.T) {
+// TestNudgeTargetFromSessionInfoGolden pins the behavior of
+// resolveNudgeTargetFromSessionInfo directly. It began life as an equivalence
+// oracle against the now-deleted raw-bead sibling
+// (resolveNudgeTargetFromSessionBead); that oracle completed its migration
+// purpose once the dispatcher and resolveNudgeTarget both moved onto the Info
+// path, so this test now hard-codes the goldens the oracle proved.
+//
+// The transport cases still guard the fidelity trap: the resolver reads the RAW
+// transport metadata (via i.TransportMetadata), not the normalized i.Transport,
+// so the empty- and whitespace-transport beads must still take the found.Session
+// fallback ("tmux"). ga-no-sn / ga-bare guard the sessionNameFromBeadID fallback.
+func TestNudgeTargetFromSessionInfoGolden(t *testing.T) {
 	cityPath := "/tmp/test-city"
 	cfg := &config.City{
 		Workspace: config.Workspace{Provider: "claude"},
@@ -25,74 +29,203 @@ func TestNudgeTargetInfoEquivalence(t *testing.T) {
 		},
 	}
 
-	beadsIn := []beads.Bead{
+	cases := []struct {
+		name                  string
+		bead                  beads.Bead
+		wantSessionID         string
+		wantSessionName       string
+		wantIdentity          string
+		wantAlias             string
+		wantAliasHistory      []string
+		wantTransport         string
+		wantProvider          string
+		wantContinuationEpoch string
+	}{
 		{
-			ID:     "ga-full",
-			Type:   session.BeadType,
-			Title:  "full",
-			Labels: []string{session.LabelSession},
-			Metadata: map[string]string{
-				"template":           "frontend/worker",
-				"agent_name":         "frontend/worker-1",
-				"common_name":        "the-worker",
-				"alias":              "worker-alias",
-				"provider":           "claude",
-				"transport":          "acp",
-				"session_name":       "worker-session",
-				"continuation_epoch": "3",
-				"alias_history":      "old-alias,older-alias",
+			name: "full",
+			bead: beads.Bead{
+				ID:     "ga-full",
+				Type:   session.BeadType,
+				Title:  "full",
+				Labels: []string{session.LabelSession},
+				Metadata: map[string]string{
+					"template":           "frontend/worker",
+					"agent_name":         "frontend/worker-1",
+					"common_name":        "the-worker",
+					"alias":              "worker-alias",
+					"provider":           "claude",
+					"transport":          "acp",
+					"session_name":       "worker-session",
+					"continuation_epoch": "3",
+					"alias_history":      "old-alias,older-alias",
+				},
 			},
+			wantSessionID:         "ga-full",
+			wantSessionName:       "worker-session",
+			wantIdentity:          "frontend/worker-1",
+			wantAlias:             "worker-alias",
+			wantAliasHistory:      []string{"old-alias", "older-alias"},
+			wantTransport:         "acp",
+			wantProvider:          "claude",
+			wantContinuationEpoch: "3",
 		},
 		{
 			// Empty transport → resolver must fall back to the agent's Session.
-			ID:     "ga-empty-transport",
-			Type:   session.BeadType,
-			Title:  "empty-transport",
-			Labels: []string{session.LabelSession},
-			Metadata: map[string]string{
-				"template":     "worker",
-				"provider":     "claude",
-				"session_name": "empty-transport-session",
+			name: "empty-transport",
+			bead: beads.Bead{
+				ID:     "ga-empty-transport",
+				Type:   session.BeadType,
+				Title:  "empty-transport",
+				Labels: []string{session.LabelSession},
+				Metadata: map[string]string{
+					"template":     "worker",
+					"provider":     "claude",
+					"session_name": "empty-transport-session",
+				},
 			},
+			wantSessionID:   "ga-empty-transport",
+			wantSessionName: "empty-transport-session",
+			wantIdentity:    "worker",
+			wantTransport:   "tmux",
+			wantProvider:    "claude",
 		},
 		{
-			// Whitespace transport → TrimSpace on both raw and Info must agree.
-			ID:     "ga-ws-transport",
-			Type:   session.BeadType,
-			Title:  "ws-transport",
-			Labels: []string{session.LabelSession},
-			Metadata: map[string]string{
-				"template":     "worker",
-				"transport":    "   ",
-				"provider":     "claude",
-				"session_name": "ws-transport-session",
+			// Whitespace transport → TrimSpace on the raw value yields "", so the
+			// found.Session fallback fires identically to the empty case.
+			name: "ws-transport",
+			bead: beads.Bead{
+				ID:     "ga-ws-transport",
+				Type:   session.BeadType,
+				Title:  "ws-transport",
+				Labels: []string{session.LabelSession},
+				Metadata: map[string]string{
+					"template":     "worker",
+					"transport":    "   ",
+					"provider":     "claude",
+					"session_name": "ws-transport-session",
+				},
 			},
+			wantSessionID:   "ga-ws-transport",
+			wantSessionName: "ws-transport-session",
+			wantIdentity:    "worker",
+			wantTransport:   "tmux",
+			wantProvider:    "claude",
 		},
 		{
-			// No session_name → sessionNameFromBeadID fallback on both sides.
-			ID:     "ga-no-sn",
-			Type:   session.BeadType,
-			Title:  "no-sn",
-			Labels: []string{session.LabelSession},
-			Metadata: map[string]string{
-				"template": "scribe",
+			// No session_name → sessionNameFromBeadID fallback; unknown template
+			// resolves no agent, so transport/provider stay their raw (empty) values.
+			name: "no-session-name",
+			bead: beads.Bead{
+				ID:     "ga-no-sn",
+				Type:   session.BeadType,
+				Title:  "no-sn",
+				Labels: []string{session.LabelSession},
+				Metadata: map[string]string{
+					"template": "scribe",
+				},
 			},
+			wantSessionID:   "ga-no-sn",
+			wantSessionName: "s-ga-no-sn",
+			wantIdentity:    "scribe",
 		},
 		{
-			// Bare metadata, only an ID.
-			ID:       "ga-bare",
-			Type:     session.BeadType,
-			Title:    "bare",
-			Labels:   []string{session.LabelSession},
-			Metadata: map[string]string{},
+			// Bare metadata, only an ID → identity falls through to the session name.
+			name: "bare",
+			bead: beads.Bead{
+				ID:       "ga-bare",
+				Type:     session.BeadType,
+				Title:    "bare",
+				Labels:   []string{session.LabelSession},
+				Metadata: map[string]string{},
+			},
+			wantSessionID:   "ga-bare",
+			wantSessionName: "s-ga-bare",
+			wantIdentity:    "s-ga-bare",
 		},
 	}
 
-	for _, b := range beadsIn {
-		want := resolveNudgeTargetFromSessionBead(cityPath, cfg, b)
-		got := resolveNudgeTargetFromSessionInfo(cityPath, cfg, session.InfoFromPersistedBead(b))
-		if !reflect.DeepEqual(want, got) {
-			t.Errorf("bead %q: resolveNudgeTargetFromSessionInfo = %#v, want (bead form) %#v", b.ID, got, want)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveNudgeTargetFromSessionInfo(cityPath, cfg, session.InfoFromPersistedBead(tc.bead))
+
+			if got.sessionID != tc.wantSessionID {
+				t.Errorf("sessionID = %q, want %q", got.sessionID, tc.wantSessionID)
+			}
+			if got.sessionName != tc.wantSessionName {
+				t.Errorf("sessionName = %q, want %q", got.sessionName, tc.wantSessionName)
+			}
+			if got.identity != tc.wantIdentity {
+				t.Errorf("identity = %q, want %q", got.identity, tc.wantIdentity)
+			}
+			if got.alias != tc.wantAlias {
+				t.Errorf("alias = %q, want %q", got.alias, tc.wantAlias)
+			}
+			if !reflect.DeepEqual(got.aliasHistory, tc.wantAliasHistory) {
+				t.Errorf("aliasHistory = %#v, want %#v", got.aliasHistory, tc.wantAliasHistory)
+			}
+			if got.transport != tc.wantTransport {
+				t.Errorf("transport = %q, want %q", got.transport, tc.wantTransport)
+			}
+			provider := ""
+			if got.resolved != nil {
+				provider = got.resolved.Name
+			}
+			if provider != tc.wantProvider {
+				t.Errorf("resolved provider = %q, want %q", provider, tc.wantProvider)
+			}
+			if got.continuationEpoch != tc.wantContinuationEpoch {
+				t.Errorf("continuationEpoch = %q, want %q", got.continuationEpoch, tc.wantContinuationEpoch)
+			}
+		})
+	}
+}
+
+// TestNudgeTargetFromSessionInfoFullGolden pins the ENTIRE nudgeTarget for the
+// richest bead via reflect.DeepEqual, so a regression in any field buildNudgeTarget
+// derives — including the ones the field-level cases above do not assert
+// (cityPath, cityName, cfg wiring, and the parsed agent value) — is still caught.
+func TestNudgeTargetFromSessionInfoFullGolden(t *testing.T) {
+	cityPath := "/tmp/test-city"
+	cfg := &config.City{
+		Workspace: config.Workspace{Provider: "claude"},
+		Agents: []config.Agent{
+			{Name: "worker", Provider: "claude", Session: "tmux"},
+		},
+	}
+	b := beads.Bead{
+		ID:     "ga-full",
+		Type:   session.BeadType,
+		Title:  "full",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"template":           "frontend/worker",
+			"agent_name":         "frontend/worker-1",
+			"common_name":        "the-worker",
+			"alias":              "worker-alias",
+			"provider":           "claude",
+			"transport":          "acp",
+			"session_name":       "worker-session",
+			"continuation_epoch": "3",
+			"alias_history":      "old-alias,older-alias",
+		},
+	}
+
+	got := resolveNudgeTargetFromSessionInfo(cityPath, cfg, session.InfoFromPersistedBead(b))
+	want := nudgeTarget{
+		cityPath:          "/tmp/test-city",
+		cityName:          "test-city",
+		cfg:               cfg,
+		alias:             "worker-alias",
+		aliasHistory:      []string{"old-alias", "older-alias"},
+		identity:          "frontend/worker-1",
+		transport:         "acp",
+		agent:             config.Agent{Name: "worker-1", Dir: "frontend"},
+		resolved:          &config.ResolvedProvider{Name: "claude"},
+		sessionID:         "ga-full",
+		continuationEpoch: "3",
+		sessionName:       "worker-session",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("full nudgeTarget mismatch:\n got=%#v\nwant=%#v", got, want)
 	}
 }

--- a/internal/nudgequeue/store.go
+++ b/internal/nudgequeue/store.go
@@ -3,6 +3,7 @@ package nudgequeue
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -278,6 +279,42 @@ func (s *Store) RollbackEnqueue(beadID string) error {
 		errs = errors.Join(errs, err)
 	}
 	return errs
+}
+
+// SweepStale stamps the gc-swept terminal vocabulary on a stale nudge shadow bead
+// past the gc retention window and closes it. It is the retention-sweep sibling of
+// Terminalize/RollbackEnqueue: the gc-swept terminal-key vocabulary (state /
+// terminal_reason / commit_boundary / terminal_at / close_reason) is now confined
+// here alongside Terminalize's canonicalCloseReason vocabulary, so the cmd/gc
+// sweep no longer re-stamps these keys inline. closeReason is caller-supplied —
+// cmd/gc keeps ownership of the human message constant — and must satisfy the
+// >=20-char validation.on-close floor.
+//
+// SweepStale emits byte-identical bead writes to the prior inline stamp+close
+// block in cmd/gc/nudge_mail_sweep.go: a single SetMetadataBatch with the same
+// five keys, then Close. A SetMetadataBatch failure returns without closing,
+// matching the sweep's continue-without-close semantics, and both error strings
+// preserve the caller's prior "nudge %s: set metadata/close: %w" text so
+// joined-error assertions keep passing. Unlike Terminalize it adds no missing-bead
+// tolerance, matching the inline sweep it replaces.
+func (s *Store) SweepStale(beadID, closeReason string, now time.Time) error {
+	if s == nil || s.store.Store == nil {
+		return nil
+	}
+	update := map[string]string{
+		"state":           "gc-swept",
+		"terminal_reason": "gc-swept-stale",
+		"commit_boundary": "gc-swept",
+		"terminal_at":     now.UTC().Format(time.RFC3339),
+		"close_reason":    closeReason,
+	}
+	if err := s.store.SetMetadataBatch(beadID, update); err != nil {
+		return fmt.Errorf("nudge %s: set metadata: %w", beadID, err)
+	}
+	if err := s.store.Close(beadID); err != nil {
+		return fmt.Errorf("nudge %s: close: %w", beadID, err)
+	}
+	return nil
 }
 
 // Find returns the OPEN (or terminal-but-decodable) nudge shadow for nudgeID as

--- a/internal/nudgequeue/store_test.go
+++ b/internal/nudgequeue/store_test.go
@@ -2,7 +2,9 @@ package nudgequeue
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -208,6 +210,94 @@ func TestRollbackEnqueueEmitsByteIdenticalWrites(t *testing.T) {
 	closes := rec.CallsForOp("Close")
 	if len(closes) != 1 || closes[0].ID != beadID {
 		t.Errorf("Close = %+v, want one close of %q", closes, beadID)
+	}
+}
+
+// TestSweepStaleEmitsByteIdenticalWrites proves SweepStale stamps the exact
+// five-key gc-swept terminal map and then closes the bead — the byte-identical
+// contract for the prior inline stamp+close block in cmd/gc/nudge_mail_sweep.go.
+func TestSweepStaleEmitsByteIdenticalWrites(t *testing.T) {
+	st, rec := newRecordingNudgeStore(t)
+	beadID, _, err := st.Save(sampleNudgeItem())
+	if err != nil {
+		t.Fatalf("Save err = %v", err)
+	}
+	rec.Reset()
+
+	now := time.Date(2026, 6, 2, 9, 30, 0, 0, time.UTC)
+	const closeReason = "nudge gc-swept: stale nudge bead past gc retention window"
+	if err := st.SweepStale(beadID, closeReason, now); err != nil {
+		t.Fatalf("SweepStale err = %v", err)
+	}
+
+	batches := rec.CallsForOp("SetMetadataBatch")
+	if len(batches) != 1 {
+		t.Fatalf("SetMetadataBatch calls = %d, want 1", len(batches))
+	}
+	wantUpdate := map[string]string{
+		"state":           "gc-swept",
+		"terminal_reason": "gc-swept-stale",
+		"commit_boundary": "gc-swept",
+		"terminal_at":     "2026-06-02T09:30:00Z",
+		"close_reason":    closeReason,
+	}
+	if !reflect.DeepEqual(batches[0].Metadata, wantUpdate) {
+		t.Errorf("update map mismatch:\n got=%#v\nwant=%#v", batches[0].Metadata, wantUpdate)
+	}
+	if batches[0].ID != beadID {
+		t.Errorf("SetMetadataBatch id = %q, want %q", batches[0].ID, beadID)
+	}
+	closes := rec.CallsForOp("Close")
+	if len(closes) != 1 || closes[0].ID != beadID {
+		t.Errorf("Close calls = %+v, want one close of %q", closes, beadID)
+	}
+}
+
+// failingSetMetadataBatchStore wraps a beads.Store but fails every
+// SetMetadataBatch, so a test can prove SweepStale skips Close when the metadata
+// write fails.
+type failingSetMetadataBatchStore struct {
+	beads.Store
+	err error
+}
+
+func (f failingSetMetadataBatchStore) SetMetadataBatch(string, map[string]string) error {
+	return f.err
+}
+
+// TestSweepStaleSetMetadataFailureSkipsClose proves a failed SetMetadataBatch
+// returns a bead-ID-bearing error and never reaches Close, preserving the sweep's
+// current continue-without-close semantics.
+func TestSweepStaleSetMetadataFailureSkipsClose(t *testing.T) {
+	rec := beadstest.NewRecordingStore(beads.NewMemStore())
+	failing := failingSetMetadataBatchStore{Store: rec, err: errors.New("batch boom")}
+	st := NewStore(beads.NudgesStore{Store: failing})
+
+	err := st.SweepStale("nb-fail", "nudge gc-swept: stale nudge bead past gc retention window", time.Now().UTC())
+	if err == nil {
+		t.Fatalf("SweepStale err = nil, want non-nil on SetMetadataBatch failure")
+	}
+	if !strings.Contains(err.Error(), "nb-fail") || !strings.Contains(err.Error(), "set metadata") {
+		t.Errorf("err = %q, want it to contain the bead id and \"set metadata\"", err)
+	}
+	if n := len(rec.CallsForOp("Close")); n != 0 {
+		t.Errorf("Close calls = %d, want 0 (SetMetadataBatch failure must skip Close)", n)
+	}
+}
+
+// TestSweepStaleNilStoreIsNoOp pins the nil-safety contract shared by every Store
+// method: a nil *Store and a Store over a nil embedded store both no-op.
+func TestSweepStaleNilStoreIsNoOp(t *testing.T) {
+	const reason = "nudge gc-swept: stale nudge bead past gc retention window"
+	now := time.Now().UTC()
+
+	var s *Store // nil receiver: shadow bead store unavailable
+	if err := s.SweepStale("gc-1", reason, now); err != nil {
+		t.Errorf("SweepStale on nil store = %v, want nil no-op", err)
+	}
+	empty := NewStore(beads.NudgesStore{}) // Store over a nil embedded store
+	if err := empty.SweepStale("gc-1", reason, now); err != nil {
+		t.Errorf("SweepStale on nil embedded store = %v, want nil no-op", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Finishes the nudge Phase-2 migration so `cmd/gc` stops cracking raw nudge/session
beads and stops re-stamping vocabulary the store owns.

- **`nudgequeue.Store.SweepStale(beadID, closeReason, now)`** (new) confines the
  `gc-swept` terminal-key vocabulary (`state` / `terminal_reason` / `commit_boundary`
  / `terminal_at` / `close_reason`). `cmd/gc/nudge_mail_sweep.go` calls it instead of
  the inline `SetMetadataBatch` + `Close` block.
- Nudge ids read via **`nudgequeue.DecodeShadow(b).ID`** (the read codec exported for
  exactly this) instead of `b.Metadata["nudge_id"]` at both sweep call sites.
- `cmd/gc/cmd_nudge.go` reads `session_name`/`continuation_epoch` off a
  `session.InfoFromPersistedBead` projection; the raw-bead resolver
  `resolveNudgeTargetFromSessionBead` is deleted (single `session.Info` resolver now).

## Behavior preservation

`SweepStale` mirrors the deleted inline sweep byte-for-byte: same five keys/values,
same `SetMetadataBatch`-fail-skips-`Close` ordering, identical
`"nudge %s: set metadata/close: %w"` error text, nil-receiver safe.
`DecodeShadow(b).ID` and the `session.Info` mirrors (`SessionNameMetadata`,
`ContinuationEpoch`) are verbatim untrimmed/trimmed reads matching the deleted forms.

## Verification

- `gofmt` clean; `go vet ./internal/nudgequeue ./cmd/gc` clean; `go build ./...` clean
- `go test ./internal/nudgequeue` green; `go test ./cmd/gc -run 'Nudge|Sweep'` green; `make test` exit 0
- TDD: `TestSweepStaleEmitsByteIdenticalWrites` (golden 5-key map + one Close),
  fail-skips-Close, nil-no-op; resolver equivalence goldens captured empirically before
  deleting the bead form — including a full-struct `reflect.DeepEqual` golden pinning
  derived fields (`cityPath`/`cityName`/parsed agent/resolved provider)
- Fable adversarial review: approve (writes byte-identical); two nits applied
  (stale-comment reword + restored full-struct golden)

Part of the raw-bead-leak cleanup epic. Refs `ga-4ikiot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
