### PR TITLE
docs(security): warn about malicious "fix" attachment spam

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,32 @@ security advisory. If a fix is needed, it will be released before public
 disclosure unless there is an active exploitation risk that requires faster
 notice.
 
+## Malicious "fix" attachments in issues, PRs, and discussions
+
+Automated spam accounts have been posting on newly-opened issues across GitHub —
+including in this project — with a friendly, issue-specific message and an
+attached archive (for example a file named like `*_fix.zip`, `fix_win.zip`, or a
+"patched build") that claims to solve your problem. **These files are malware. Do
+not download or run them.**
+
+How to stay safe:
+
+- **Official builds and releases come only from this repository's
+  [Releases](https://github.com/gastownhall/gascity/releases) page** and the project's documented install
+  instructions. Maintainers will never ask you to download a zip or executable
+  posted in an issue, pull request, or discussion comment.
+- A link that points to `github.com/user-attachments/files/...` is a file
+  someone attached to a comment — it is **not** a vetted release asset, even
+  though the URL is hosted on `github.com`.
+- Be especially wary of a brand-new account offering a "fix" as a download
+  within minutes of your post, or telling you to run an install command for a
+  package or module that is not an official project source.
+
+If you see one of these comments, please **report it** (the comment's `...` menu
+→ *Report content*) and do not click the attachment. Note that deleting the
+comment does not remove the uploaded file from GitHub's servers, so also report
+the attachment to GitHub Support so it can be taken down.
+
 ## Supported Versions
 
 Security fixes target the current stable major release unless a separate support


### PR DESCRIPTION
Adds a user-facing advisory to `SECURITY.md` about the active malware-spam campaign: burner accounts reply to fresh issues with an attached `*_fix.zip` (hosted on GitHub's `user-attachments` CDN) that claims to be a fix. The note tells users official builds come only from Releases, that `user-attachments/files/...` links are unvetted, and how to report the comment + attachment.

Part of the org-wide response (interaction limits + moderation). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)