### PR TITLE
refactor(session,wait): route gc wait through a typed session.WaitInfo codec

### DIFF
--- a/cmd/gc/bead_policy_store_test.go
+++ b/cmd/gc/bead_policy_store_test.go
@@ -569,22 +569,26 @@ func TestPolicyReadPathsIncludeHistoryAndNoHistoryRows(t *testing.T) {
 		t.Fatalf("new session row = %+v, want no_history parsed", sessions[1])
 	}
 
-	waits, err := loadWaitBeads(store)
+	// loadWaits returns session.WaitInfo, which deliberately omits the NoHistory
+	// storage detail (mirroring session.Info). The no-history row still flows
+	// through the retyped policy read path, so assert both wait IDs are present;
+	// the no_history parse assertion remains covered by the loadSessionBeads half
+	// above and by the bdstore tests.
+	waits, err := loadWaits(store)
 	if err != nil {
-		t.Fatalf("loadWaitBeads: %v", err)
+		t.Fatalf("loadWaits: %v", err)
 	}
 	if len(waits) != 2 {
 		t.Fatalf("waits = %+v, want history and no-history rows", waits)
 	}
-	foundNoHistoryWait := false
+	waitIDs := map[string]bool{}
 	for _, wait := range waits {
-		if wait.ID == "bd-new-wait" {
-			foundNoHistoryWait = wait.NoHistory
-			break
-		}
+		waitIDs[wait.ID] = true
 	}
-	if !foundNoHistoryWait {
-		t.Fatalf("waits = %+v, want bd-new-wait with no_history parsed", waits)
+	for _, id := range []string{"bd-old-wait", "bd-new-wait"} {
+		if !waitIDs[id] {
+			t.Fatalf("waits = %+v, want both history and no-history rows (missing %s)", waits, id)
+		}
 	}
 }
 

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -270,7 +270,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 		fmt.Fprintf(stderr, "gc session wait: creating wait: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	ready, depErr := depsWaitReadyDetailedForCity(cityPath, store, waitBead)
+	ready, depErr := depsWaitReadyDetailedForCity(cityPath, store, sessionpkg.WaitInfoFromBead(waitBead))
 	if depErr != nil {
 		if err := setWaitTerminalState(sessStore, waitBead.ID, map[string]string{
 			"state":      waitStateFailed,
@@ -370,7 +370,7 @@ func routeWaitList(cityPath string, c *api.Client, nilReason, stateFilter, sessi
 // a stray non-wait bead tagged gc:wait would otherwise leak through. IsWaitBead
 // also covers the legacy "wait" type for back-compat with older stores.
 func renderWaitListFromAPI(cityPath string, cr api.CachedRead[[]beads.Bead], stateFilter, sessionFilter string, jsonOutput bool, stdout, stderr io.Writer) int {
-	items := make([]beads.Bead, 0, len(cr.Body))
+	items := make([]sessionpkg.WaitInfo, 0, len(cr.Body))
 	for _, item := range cr.Body {
 		if item.Status == "closed" {
 			continue
@@ -378,7 +378,7 @@ func renderWaitListFromAPI(cityPath string, cr api.CachedRead[[]beads.Bead], sta
 		if !sessionpkg.IsWaitBead(item) {
 			continue
 		}
-		items = append(items, item)
+		items = append(items, sessionpkg.WaitInfoFromBead(item))
 	}
 	sort.SliceStable(items, func(i, j int) bool { return items[i].CreatedAt.Before(items[j].CreatedAt) })
 	filtered := filterWaitListItems(items, stateFilter, sessionFilter)
@@ -405,11 +405,11 @@ func doWaitListFallback(cityPath, stateFilter, sessionFilter string, jsonOutput 
 	// Route SESSION/wait access to the session coordination-class store; identity today.
 	cfg, _ := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
 	sessStore := cliSessionStore(store, cfg, cityPath)
-	var items []beads.Bead
+	var items []sessionpkg.WaitInfo
 	if sessionFilter != "" {
-		items, err = loadSessionWaitBeads(sessStore, sessionFilter)
+		items, err = loadSessionWaits(sessStore, sessionFilter)
 	} else {
-		items, err = loadWaitBeads(sessStore)
+		items, err = loadWaits(sessStore)
 	}
 	if err != nil {
 		if !isWaitLookupLimitError(err) {
@@ -427,13 +427,13 @@ func doWaitListFallback(cityPath, stateFilter, sessionFilter string, jsonOutput 
 	return 0
 }
 
-func filterWaitListItems(items []beads.Bead, stateFilter, sessionFilter string) []beads.Bead {
-	filtered := make([]beads.Bead, 0, len(items))
+func filterWaitListItems(items []sessionpkg.WaitInfo, stateFilter, sessionFilter string) []sessionpkg.WaitInfo {
+	filtered := make([]sessionpkg.WaitInfo, 0, len(items))
 	for _, item := range items {
-		if stateFilter != "" && item.Metadata["state"] != stateFilter {
+		if stateFilter != "" && item.State != stateFilter {
 			continue
 		}
-		if sessionFilter != "" && item.Metadata["session_id"] != sessionFilter {
+		if sessionFilter != "" && item.SessionID != sessionFilter {
 			continue
 		}
 		filtered = append(filtered, item)
@@ -441,15 +441,15 @@ func filterWaitListItems(items []beads.Bead, stateFilter, sessionFilter string) 
 	return filtered
 }
 
-func writeWaitListTable(items []beads.Bead, stdout io.Writer) {
+func writeWaitListTable(items []sessionpkg.WaitInfo, stdout io.Writer) {
 	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "WAIT\tSESSION\tSTATE\tKIND\tNOTE") //nolint:errcheck
 	for _, item := range items {
-		note := item.Description
+		note := item.Note
 		if note == "" {
 			note = "-"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", item.ID, item.Metadata["session_id"], item.Metadata["state"], item.Metadata["kind"], note) //nolint:errcheck
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", item.ID, item.SessionID, item.State, item.Kind, note) //nolint:errcheck
 	}
 	_ = tw.Flush()
 }
@@ -500,10 +500,11 @@ func renderWaitInspectFromAPI(cityPath string, cr api.CachedRead[beads.Bead], wa
 		fmt.Fprintf(stderr, "gc wait inspect: %s is not a wait\n", waitID) //nolint:errcheck
 		return 1
 	}
+	wait := sessionpkg.WaitInfoFromBead(cr.Body)
 	if jsonOutput {
-		return writeWaitInspectJSON(stdout, stderr, cityPath, cr.Body)
+		return writeWaitInspectJSON(stdout, stderr, cityPath, wait)
 	}
-	writeWaitDetail(cr.Body, stdout)
+	writeWaitDetail(wait, stdout)
 	if cr.AgeSeconds > cacheAgeBannerThresholdSeconds {
 		fmt.Fprintf(stdout, "(cache age: %.0fs — reconciler may be lagging)\n", cr.AgeSeconds) //nolint:errcheck
 	}
@@ -532,23 +533,24 @@ func doWaitInspectFallback(cityPath, waitID string, jsonOutput bool, stdout, std
 		fmt.Fprintf(stderr, "gc wait inspect: %s is not a wait\n", waitID) //nolint:errcheck
 		return 1
 	}
+	wait := sessionpkg.WaitInfoFromBead(b)
 	if jsonOutput {
-		return writeWaitInspectJSON(stdout, stderr, cityPath, b)
+		return writeWaitInspectJSON(stdout, stderr, cityPath, wait)
 	}
-	writeWaitDetail(b, stdout)
+	writeWaitDetail(wait, stdout)
 	return 0
 }
 
-func writeWaitDetail(b beads.Bead, stdout io.Writer) {
-	fmt.Fprintf(stdout, "Wait:       %s\n", b.ID)                                               //nolint:errcheck
-	fmt.Fprintf(stdout, "Session:    %s\n", b.Metadata["session_id"])                           //nolint:errcheck
-	fmt.Fprintf(stdout, "State:      %s\n", b.Metadata["state"])                                //nolint:errcheck
-	fmt.Fprintf(stdout, "Kind:       %s\n", b.Metadata["kind"])                                 //nolint:errcheck
-	fmt.Fprintf(stdout, "Deps:       %s (%s)\n", b.Metadata["dep_ids"], b.Metadata["dep_mode"]) //nolint:errcheck
-	fmt.Fprintf(stdout, "Epoch:      %s\n", b.Metadata["registered_epoch"])                     //nolint:errcheck
-	fmt.Fprintf(stdout, "Attempt:    %s\n", b.Metadata["delivery_attempt"])                     //nolint:errcheck
-	fmt.Fprintf(stdout, "Nudge:      %s\n", b.Metadata["nudge_id"])                             //nolint:errcheck
-	fmt.Fprintf(stdout, "Note:       %s\n", b.Description)                                      //nolint:errcheck
+func writeWaitDetail(w sessionpkg.WaitInfo, stdout io.Writer) {
+	fmt.Fprintf(stdout, "Wait:       %s\n", w.ID)                                        //nolint:errcheck
+	fmt.Fprintf(stdout, "Session:    %s\n", w.SessionID)                                 //nolint:errcheck
+	fmt.Fprintf(stdout, "State:      %s\n", w.State)                                     //nolint:errcheck
+	fmt.Fprintf(stdout, "Kind:       %s\n", w.Kind)                                      //nolint:errcheck
+	fmt.Fprintf(stdout, "Deps:       %s (%s)\n", strings.Join(w.DepIDs, ","), w.DepMode) //nolint:errcheck
+	fmt.Fprintf(stdout, "Epoch:      %s\n", w.RegisteredEpoch)                           //nolint:errcheck
+	fmt.Fprintf(stdout, "Attempt:    %s\n", w.DeliveryAttempt)                           //nolint:errcheck
+	fmt.Fprintf(stdout, "Nudge:      %s\n", w.NudgeID)                                   //nolint:errcheck
+	fmt.Fprintf(stdout, "Note:       %s\n", w.Note)                                      //nolint:errcheck
 }
 
 type waitJSON struct {
@@ -579,42 +581,28 @@ type waitInspectJSONEnvelope struct {
 	Wait          waitJSON `json:"wait"`
 }
 
-func waitJSONFromBead(b beads.Bead) waitJSON {
+func waitJSONFromInfo(w sessionpkg.WaitInfo) waitJSON {
 	return waitJSON{
-		ID:              b.ID,
-		SessionID:       b.Metadata["session_id"],
-		SessionName:     b.Metadata["session_name"],
-		State:           b.Metadata["state"],
-		Kind:            b.Metadata["kind"],
-		DepIDs:          splitWaitIDs(b.Metadata["dep_ids"]),
-		DepMode:         b.Metadata["dep_mode"],
-		RegisteredEpoch: b.Metadata["registered_epoch"],
-		DeliveryAttempt: b.Metadata["delivery_attempt"],
-		NudgeID:         b.Metadata["nudge_id"],
-		Note:            b.Description,
-		Status:          b.Status,
-		CreatedAt:       formatOptionalTime(b.CreatedAt),
+		ID:              w.ID,
+		SessionID:       w.SessionID,
+		SessionName:     w.SessionName,
+		State:           w.State,
+		Kind:            w.Kind,
+		DepIDs:          w.DepIDs,
+		DepMode:         w.DepMode,
+		RegisteredEpoch: w.RegisteredEpoch,
+		DeliveryAttempt: w.DeliveryAttempt,
+		NudgeID:         w.NudgeID,
+		Note:            w.Note,
+		Status:          w.Status,
+		CreatedAt:       formatOptionalTime(w.CreatedAt),
 	}
 }
 
-func splitWaitIDs(value string) []string {
-	if strings.TrimSpace(value) == "" {
-		return nil
-	}
-	parts := strings.Split(value, ",")
-	out := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if trimmed := strings.TrimSpace(part); trimmed != "" {
-			out = append(out, trimmed)
-		}
-	}
-	return out
-}
-
-func writeWaitListJSON(stdout, stderr io.Writer, cityPath string, waits []beads.Bead) int {
+func writeWaitListJSON(stdout, stderr io.Writer, cityPath string, waits []sessionpkg.WaitInfo) int {
 	rows := make([]waitJSON, 0, len(waits))
 	for _, wait := range waits {
-		rows = append(rows, waitJSONFromBead(wait))
+		rows = append(rows, waitJSONFromInfo(wait))
 	}
 	payload := waitListJSONEnvelope{
 		SchemaVersion: "1",
@@ -628,11 +616,11 @@ func writeWaitListJSON(stdout, stderr io.Writer, cityPath string, waits []beads.
 	return 0
 }
 
-func writeWaitInspectJSON(stdout, stderr io.Writer, cityPath string, wait beads.Bead) int {
+func writeWaitInspectJSON(stdout, stderr io.Writer, cityPath string, wait sessionpkg.WaitInfo) int {
 	payload := waitInspectJSONEnvelope{
 		SchemaVersion: "1",
 		CityPath:      cityPath,
-		Wait:          waitJSONFromBead(wait),
+		Wait:          waitJSONFromInfo(wait),
 	}
 	if err := writeCLIJSONLine(stdout, payload); err != nil {
 		fmt.Fprintf(stderr, "gc wait inspect: encode JSON: %v\n", err) //nolint:errcheck
@@ -666,6 +654,9 @@ func cmdWaitSetStateResult(waitID, state string, stdout, stderr io.Writer) (wait
 		fmt.Fprintf(stderr, "gc wait: %s is not a wait\n", waitID) //nolint:errcheck
 		return result, 1
 	}
+	// Reads go through the typed WaitInfo projection; retryClosedWait keeps the
+	// raw bead because it clones metadata and re-creates the bead (write edge).
+	w := sessionpkg.WaitInfoFromBead(b)
 	if state == waitStateReady {
 		if err := waitLifecycleEnabled(); err != nil {
 			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
@@ -673,7 +664,7 @@ func cmdWaitSetStateResult(waitID, state string, stdout, stderr io.Writer) (wait
 		}
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	if state == waitStateReady && b.Status == "closed" {
+	if state == waitStateReady && w.Status == "closed" {
 		retried, err := retryClosedWait(sessStore, nudges, b, now)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
@@ -690,7 +681,7 @@ func cmdWaitSetStateResult(waitID, state string, stdout, stderr io.Writer) (wait
 	switch state {
 	case waitStateReady:
 		batch["ready_at"] = now
-		nextAttempt, err := nextWaitDeliveryAttempt(nudgeFrontDoor(nudges), b)
+		nextAttempt, err := nextWaitDeliveryAttempt(nudgeFrontDoor(nudges), w)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
 			return result, 1
@@ -720,12 +711,12 @@ func cmdWaitSetStateResult(waitID, state string, stdout, stderr io.Writer) (wait
 	}
 	if state == waitStateCanceled {
 		if cityPath, err := resolveCity(); err == nil {
-			if err := withdrawQueuedWaitNudges(cityPath, []string{b.Metadata["nudge_id"]}); err != nil {
+			if err := withdrawQueuedWaitNudges(cityPath, []string{w.NudgeID}); err != nil {
 				fmt.Fprintf(stderr, "gc wait: withdrawing queued nudge: %v\n", err) //nolint:errcheck
 				return result, 1
 			}
 		}
-		if err := clearSessionWaitHoldIfIdle(sessStore, b.Metadata["session_id"]); err != nil {
+		if err := clearSessionWaitHoldIfIdle(sessStore, w.SessionID); err != nil {
 			fmt.Fprintf(stderr, "gc wait: clearing session wait hold: %v\n", err) //nolint:errcheck
 			return result, 1
 		}
@@ -734,11 +725,11 @@ func cmdWaitSetStateResult(waitID, state string, stdout, stderr io.Writer) (wait
 	return result, 0
 }
 
-func loadWaitBeads(store beads.Store) ([]beads.Bead, error) {
+func loadWaits(store beads.Store) ([]sessionpkg.WaitInfo, error) {
 	if store == nil {
 		return nil, nil
 	}
-	return loadWaitBeadsByLabel(store)
+	return loadWaitsByLabel(store)
 }
 
 // readyWaitSetForList returns the set of session IDs that have a ready wait
@@ -750,22 +741,21 @@ func loadWaitBeads(store beads.Store) ([]beads.Bead, error) {
 // than in the session command file; `gc session list` consumes it to surface a
 // "wait" wake reason.
 func readyWaitSetForList(store beads.Store) (map[string]bool, error) {
-	items, err := loadWaitBeads(store)
+	items, err := loadWaits(store)
 	ready := make(map[string]bool)
 	for _, item := range items {
-		if item.Metadata["state"] != waitStateReady {
+		if item.State != waitStateReady {
 			continue
 		}
-		sessionID := item.Metadata["session_id"]
-		if sessionID != "" {
-			ready[sessionID] = true
+		if item.SessionID != "" {
+			ready[item.SessionID] = true
 		}
 	}
 	return ready, err
 }
 
-func loadSessionWaitBeads(store beads.Store, sessionID string) ([]beads.Bead, error) {
-	return sessionpkg.ListSessionWaitBeads(store, sessionID)
+func loadSessionWaits(store beads.Store, sessionID string) ([]sessionpkg.WaitInfo, error) {
+	return sessionpkg.ListSessionWaits(store, sessionID)
 }
 
 const waitLookupLimit = sessionpkg.SessionWaitLookupLimit
@@ -802,7 +792,7 @@ func stampGlobalWaitLookupCapDiagnostics(sessFront *sessionpkg.Store, sessionBea
 	}
 }
 
-func loadWaitBeadsByLabel(store beads.Store) ([]beads.Bead, error) {
+func loadWaitsByLabel(store beads.Store) ([]sessionpkg.WaitInfo, error) {
 	all, err := store.List(beads.ListQuery{
 		Label: waitBeadLabel,
 		Limit: waitLookupLimit + 1,
@@ -815,7 +805,7 @@ func loadWaitBeadsByLabel(store beads.Store) ([]beads.Bead, error) {
 	if capped {
 		all = all[:waitLookupLimit]
 	}
-	result := make([]beads.Bead, 0, len(all))
+	result := make([]sessionpkg.WaitInfo, 0, len(all))
 	for _, item := range all {
 		if item.Status == "closed" {
 			continue
@@ -823,7 +813,7 @@ func loadWaitBeadsByLabel(store beads.Store) ([]beads.Bead, error) {
 		if !sessionpkg.IsWaitBead(item) {
 			continue
 		}
-		result = append(result, item)
+		result = append(result, sessionpkg.WaitInfoFromBead(item))
 	}
 	if capped {
 		return result, beads.LookupLimitError{Kind: "wait", Label: waitBeadLabel, Limit: waitLookupLimit}
@@ -831,15 +821,15 @@ func loadWaitBeadsByLabel(store beads.Store) ([]beads.Bead, error) {
 	return result, nil
 }
 
-func loadWaitBeadsForWakeState(sessStore beads.Store, sessionBeads *sessionBeadSnapshot) ([]beads.Bead, error) {
+func loadWaitsForWakeState(sessStore beads.Store, sessionBeads *sessionBeadSnapshot) ([]sessionpkg.WaitInfo, error) {
 	// Open sessions get per-session coverage; waits tied only to closed
 	// sessions can fall outside the newest global capped window under
 	// saturation, with cap diagnostics as the operator signal.
-	waits, seen, err := loadWaitBeadsForOpenSessionsWithSeen(sessStore, sessionBeads)
+	waits, seen, err := loadWaitsForOpenSessionsWithSeen(sessStore, sessionBeads)
 	if err != nil {
 		return nil, err
 	}
-	globalWaits, err := loadWaitBeads(sessStore)
+	globalWaits, err := loadWaits(sessStore)
 	if err != nil {
 		if !isWaitLookupLimitError(err) {
 			return nil, err
@@ -857,19 +847,19 @@ func loadWaitBeadsForWakeState(sessStore beads.Store, sessionBeads *sessionBeadS
 	return waits, nil
 }
 
-func loadWaitBeadsForOpenSessions(sessStore beads.Store, sessionBeads *sessionBeadSnapshot) ([]beads.Bead, error) {
-	waits, _, err := loadWaitBeadsForOpenSessionsWithSeen(sessStore, sessionBeads)
+func loadWaitsForOpenSessions(sessStore beads.Store, sessionBeads *sessionBeadSnapshot) ([]sessionpkg.WaitInfo, error) {
+	waits, _, err := loadWaitsForOpenSessionsWithSeen(sessStore, sessionBeads)
 	return waits, err
 }
 
-func loadWaitBeadsForOpenSessionsWithSeen(sessStore beads.Store, sessionBeads *sessionBeadSnapshot) ([]beads.Bead, map[string]bool, error) {
+func loadWaitsForOpenSessionsWithSeen(sessStore beads.Store, sessionBeads *sessionBeadSnapshot) ([]sessionpkg.WaitInfo, map[string]bool, error) {
 	seen := map[string]bool{}
 	if sessStore == nil || sessionBeads == nil {
 		return nil, seen, nil
 	}
-	waits := []beads.Bead(nil)
+	waits := []sessionpkg.WaitInfo(nil)
 	for _, sessionInfo := range sessionBeads.OpenInfos() {
-		sessionWaits, err := loadSessionWaitBeads(sessStore, sessionInfo.ID)
+		sessionWaits, err := loadSessionWaits(sessStore, sessionInfo.ID)
 		if err != nil {
 			if !isWaitLookupLimitError(err) {
 				return nil, seen, err
@@ -888,28 +878,21 @@ func loadWaitBeadsForOpenSessionsWithSeen(sessStore beads.Store, sessionBeads *s
 	return waits, seen, nil
 }
 
-func depsWaitReady(store beads.Store, wait beads.Bead) bool {
+func depsWaitReady(store beads.Store, wait sessionpkg.WaitInfo) bool {
 	ready, err := depsWaitReadyDetailed(store, wait)
 	return err == nil && ready
 }
 
-func depsWaitReadyDetailed(store beads.Store, wait beads.Bead) (bool, error) {
+func depsWaitReadyDetailed(store beads.Store, wait sessionpkg.WaitInfo) (bool, error) {
 	return depsWaitReadyDetailedForCity("", store, wait)
 }
 
-func depsWaitReadyDetailedForCity(cityPath string, store beads.Store, wait beads.Bead) (bool, error) {
-	rawDepIDs := strings.Split(wait.Metadata["dep_ids"], ",")
-	depIDs := make([]string, 0, len(rawDepIDs))
-	for _, depID := range rawDepIDs {
-		depID = strings.TrimSpace(depID)
-		if depID != "" {
-			depIDs = append(depIDs, depID)
-		}
-	}
+func depsWaitReadyDetailedForCity(cityPath string, store beads.Store, wait sessionpkg.WaitInfo) (bool, error) {
+	depIDs := wait.DepIDs
 	if len(depIDs) == 0 {
 		return false, nil
 	}
-	mode := wait.Metadata["dep_mode"]
+	mode := wait.DepMode
 	closedCount := 0
 	foundAny := false
 	var missingErr error
@@ -1031,14 +1014,14 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, sessStore beads.Se
 			return nil, err
 		}
 	}
-	waits, err := loadWaitBeadsForWakeState(sessStore.Store, sessionBeads)
+	waits, err := loadWaitsForWakeState(sessStore.Store, sessionBeads)
 	if err != nil {
 		return nil, err
 	}
 	readyWaitSet := make(map[string]bool)
 	for _, wait := range waits {
-		state := wait.Metadata["state"]
-		sessionID := wait.Metadata["session_id"]
+		state := wait.State
+		sessionID := wait.SessionID
 		if sessionID == "" {
 			continue
 		}
@@ -1047,7 +1030,7 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, sessStore beads.Se
 		}
 		sessionInfo, ok := sessionBeads.FindInfoByID(sessionID)
 		if !ok {
-			if wait.Metadata["registered_epoch"] != "" {
+			if wait.RegisteredEpoch != "" {
 				var found bool
 				sessionInfo, found, err = lookupSessionBeadByIDInfo(sessStore.Store, sessionID)
 				if err != nil {
@@ -1060,7 +1043,7 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, sessStore beads.Se
 				continue
 			}
 		}
-		if epoch := wait.Metadata["registered_epoch"]; epoch != "" && sessionInfo.ContinuationEpoch != "" && epoch != sessionInfo.ContinuationEpoch {
+		if epoch := wait.RegisteredEpoch; epoch != "" && sessionInfo.ContinuationEpoch != "" && epoch != sessionInfo.ContinuationEpoch {
 			if err := setWaitTerminalState(sessStore.Store, wait.ID, map[string]string{
 				"state":       waitStateCanceled,
 				"canceled_at": now.UTC().Format(time.RFC3339),
@@ -1086,7 +1069,7 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, sessStore beads.Se
 		if !ok {
 			continue
 		}
-		if expiresAt := wait.Metadata["expires_at"]; expiresAt != "" {
+		if expiresAt := wait.ExpiresAt; expiresAt != "" {
 			if ts, err := time.Parse(time.RFC3339, expiresAt); err == nil && !ts.After(now) {
 				if err := setWaitTerminalState(sessStore, wait.ID, map[string]string{
 					"state":      waitStateExpired,
@@ -1116,7 +1099,7 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, sessStore beads.Se
 			readyWaitSet[sessionID] = true
 			continue
 		}
-		if wait.Metadata["kind"] != "deps" {
+		if wait.Kind != "deps" {
 			continue
 		}
 		// Dependency beads are WORK class — read them from the work store.
@@ -1193,15 +1176,15 @@ func dispatchReadyWaitNudgesWithSnapshot(cityPath string, cfg *config.City, sess
 			return err
 		}
 	}
-	waits, err := loadWaitBeadsForOpenSessions(sessStore.Store, sessionBeads)
+	waits, err := loadWaitsForOpenSessions(sessStore.Store, sessionBeads)
 	if err != nil {
 		return err
 	}
 	for _, wait := range waits {
-		if wait.Metadata["state"] != waitStateReady {
+		if wait.State != waitStateReady {
 			continue
 		}
-		sessionID := wait.Metadata["session_id"]
+		sessionID := wait.SessionID
 		if sessionID == "" {
 			continue
 		}
@@ -1227,7 +1210,7 @@ func dispatchReadyWaitNudgesWithSnapshot(cityPath string, cfg *config.City, sess
 		if ok {
 			continue
 		}
-		message := strings.TrimSpace(wait.Description)
+		message := strings.TrimSpace(wait.Note)
 		if message == "" {
 			message = "Wait satisfied."
 		}
@@ -1235,7 +1218,7 @@ func dispatchReadyWaitNudgesWithSnapshot(cityPath string, cfg *config.City, sess
 		item := newQueuedNudgeWithOptions(waitNudgeAgent(sessionBead), message, "wait", now, queuedNudgeOptions{
 			ID:                nudgeID,
 			SessionID:         sessionID,
-			ContinuationEpoch: wait.Metadata["registered_epoch"],
+			ContinuationEpoch: wait.RegisteredEpoch,
 			Reference:         &nudgeReference{Kind: "bead", ID: wait.ID},
 		})
 		if err := enqueueQueuedNudgeWithStore(cityPath, nudges, item); err != nil {
@@ -1279,8 +1262,8 @@ func cachedSessionCanReceiveWaitNudge(sessionBead beads.Bead) bool {
 // terminal state. sessStore is the session coordination-class store for the wait
 // bead and cap-diagnostic stamp; nudges is the nudges-class store for the shadow
 // nudge lookup. Identity today (both wrap the same work store).
-func finalizeReadyWaitFromNudge(sessStore beads.Store, nudges beads.NudgesStore, wait beads.Bead, now time.Time) (bool, error) {
-	nudgeID := wait.Metadata["nudge_id"]
+func finalizeReadyWaitFromNudge(sessStore beads.Store, nudges beads.NudgesStore, wait sessionpkg.WaitInfo, now time.Time) (bool, error) {
+	nudgeID := wait.NudgeID
 	if nudgeID == "" {
 		nudgeID = waitNudgeID(wait)
 	}
@@ -1290,7 +1273,7 @@ func finalizeReadyWaitFromNudge(sessStore beads.Store, nudges beads.NudgesStore,
 	nudge, ok, err := nudgeFrontDoor(nudges).FindIncludingTerminal(nudgeID)
 	if err != nil {
 		if beads.IsLookupLimitError(err) {
-			stampWaitLookupCapDiagnostic(sessionFrontDoor(sessStore), wait.Metadata["session_id"], err, now, "ready-wait-finalize-nudge")
+			stampWaitLookupCapDiagnostic(sessionFrontDoor(sessStore), wait.SessionID, err, now, "ready-wait-finalize-nudge")
 			return false, nil
 		}
 		return false, err
@@ -1365,13 +1348,13 @@ func clearSessionWaitHoldIfIdle(sessStore beads.Store, sessionID string) error {
 }
 
 func hasNonTerminalWaits(store beads.Store, sessionID string) (bool, error) {
-	waits, err := loadSessionWaitBeads(store, sessionID)
+	waits, err := loadSessionWaits(store, sessionID)
 	if err != nil && !isWaitLookupLimitError(err) {
 		return false, err
 	}
 	capped := err != nil
 	for _, wait := range waits {
-		if !isWaitTerminal(wait.Metadata["state"]) {
+		if !isWaitTerminal(wait.State) {
 			return true, nil
 		}
 	}
@@ -1386,12 +1369,12 @@ func isWaitTerminal(state string) bool {
 	return sessionpkg.IsWaitTerminalState(state)
 }
 
-func waitNudgeID(wait beads.Bead) string {
-	attempt := wait.Metadata["delivery_attempt"]
+func waitNudgeID(wait sessionpkg.WaitInfo) string {
+	attempt := wait.DeliveryAttempt
 	if attempt == "" {
 		attempt = "1"
 	}
-	epoch := wait.Metadata["registered_epoch"]
+	epoch := wait.RegisteredEpoch
 	if epoch == "" {
 		epoch = "0"
 	}
@@ -1425,12 +1408,15 @@ func setWaitTerminalState(store beads.Store, waitID string, batch map[string]str
 // coordination-class store for the wait bead and session marker reads; nudges is
 // the nudges-class store for the delivery-attempt lookup. Identity today.
 func retryClosedWait(sessStore beads.Store, nudges beads.NudgesStore, wait beads.Bead, now string) (beads.Bead, error) {
-	nextAttempt, err := nextWaitDeliveryAttempt(nudgeFrontDoor(nudges), wait)
+	// Reads go through the typed WaitInfo projection; the metadata-clone and
+	// Create below stay on the raw bead — this is the wait write/serialization edge.
+	w := sessionpkg.WaitInfoFromBead(wait)
+	nextAttempt, err := nextWaitDeliveryAttempt(nudgeFrontDoor(nudges), w)
 	if err != nil {
 		return beads.Bead{}, err
 	}
 	if nextAttempt == "" {
-		nextAttempt = wait.Metadata["delivery_attempt"]
+		nextAttempt = w.DeliveryAttempt
 		if nextAttempt == "" {
 			nextAttempt = "1"
 		}
@@ -1448,7 +1434,7 @@ func retryClosedWait(sessStore beads.Store, nudges beads.NudgesStore, wait beads
 	meta["canceled_at"] = ""
 	meta["created_at"] = now
 	meta["retried_from_wait"] = wait.ID
-	if sessionID := wait.Metadata["session_id"]; sessionID != "" && sessStore != nil {
+	if sessionID := w.SessionID; sessionID != "" && sessStore != nil {
 		if markers, err := sessionFrontDoor(sessStore).PersistedMarkers(sessionID); err == nil {
 			if epoch := markers.ContinuationEpoch; epoch != "" {
 				meta["registered_epoch"] = epoch
@@ -1467,16 +1453,16 @@ func retryClosedWait(sessStore beads.Store, nudges beads.NudgesStore, wait beads
 	})
 }
 
-func nextWaitDeliveryAttempt(front *nudgequeue.Store, wait beads.Bead) (string, error) {
-	state := wait.Metadata["state"]
+func nextWaitDeliveryAttempt(front *nudgequeue.Store, wait sessionpkg.WaitInfo) (string, error) {
+	state := wait.State
 	if state == waitStatePending || state == waitStateReady {
 		return "", nil
 	}
-	attempt, err := strconv.Atoi(wait.Metadata["delivery_attempt"])
+	attempt, err := strconv.Atoi(wait.DeliveryAttempt)
 	if err != nil || attempt <= 0 {
 		attempt = 1
 	}
-	nudgeID := wait.Metadata["nudge_id"]
+	nudgeID := wait.NudgeID
 	if nudgeID == "" {
 		nudgeID = waitNudgeID(wait)
 	}

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -323,11 +324,89 @@ func TestWaitJSONEncoderErrorsWriteDiagnostics(t *testing.T) {
 	}
 
 	stderr.Reset()
-	if code := writeWaitInspectJSON(failingWriter{}, &stderr, "/city", beads.Bead{}); code != 1 {
+	if code := writeWaitInspectJSON(failingWriter{}, &stderr, "/city", sessionpkg.WaitInfo{}); code != 1 {
 		t.Fatalf("writeWaitInspectJSON = %d, want 1", code)
 	}
 	if !strings.Contains(stderr.String(), "gc wait inspect: encode JSON: write failed") {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+// TestWaitJSONFromInfo_MatchesBeadProjection locks the schema_version-1 CLI JSON
+// contract byte-for-byte across the WaitInfo refactor: a fully-populated wait
+// bead projected through the session codec and mapped to waitJSON must equal the
+// hand-written literal the inline waitJSONFromBead previously produced.
+func TestWaitJSONFromInfo_MatchesBeadProjection(t *testing.T) {
+	created := time.Date(2026, 5, 15, 9, 30, 0, 0, time.UTC)
+	b := beads.Bead{
+		ID:          "gc-wait-1",
+		Type:        waitBeadType,
+		Status:      "closed",
+		Title:       "wait:worker",
+		Description: "Continue after review closes.",
+		CreatedAt:   created,
+		Labels:      []string{waitBeadLabel, "session:gc-session"},
+		Metadata: map[string]string{
+			"session_id":       "gc-session",
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"dep_ids":          "gc-1,gc-2",
+			"dep_mode":         "all",
+			"registered_epoch": "3",
+			"delivery_attempt": "2",
+			"nudge_id":         "wait-gc-wait-1-3-2",
+		},
+	}
+	got := waitJSONFromInfo(sessionpkg.WaitInfoFromBead(b))
+	want := waitJSON{
+		ID:              "gc-wait-1",
+		SessionID:       "gc-session",
+		SessionName:     "worker",
+		State:           waitStateReady,
+		Kind:            "deps",
+		DepIDs:          []string{"gc-1", "gc-2"},
+		DepMode:         "all",
+		RegisteredEpoch: "3",
+		DeliveryAttempt: "2",
+		NudgeID:         "wait-gc-wait-1-3-2",
+		Note:            "Continue after review closes.",
+		Status:          "closed",
+		CreatedAt:       created.UTC().Format(time.RFC3339),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("waitJSONFromInfo = %#v, want %#v", got, want)
+	}
+}
+
+// TestWriteWaitDetail_RendersWaitInfo pins the human wait-inspect render,
+// including the comma-joined DepIDs on the Deps line.
+func TestWriteWaitDetail_RendersWaitInfo(t *testing.T) {
+	w := sessionpkg.WaitInfo{
+		ID:              "gc-wait-1",
+		SessionID:       "gc-session",
+		State:           waitStateReady,
+		Kind:            "deps",
+		DepIDs:          []string{"a", "b"},
+		DepMode:         "all",
+		RegisteredEpoch: "3",
+		DeliveryAttempt: "2",
+		NudgeID:         "wait-gc-wait-1-3-2",
+		Note:            "Continue after review closes.",
+	}
+	var buf bytes.Buffer
+	writeWaitDetail(w, &buf)
+	want := "Wait:       gc-wait-1\n" +
+		"Session:    gc-session\n" +
+		"State:      ready\n" +
+		"Kind:       deps\n" +
+		"Deps:       a,b (all)\n" +
+		"Epoch:      3\n" +
+		"Attempt:    2\n" +
+		"Nudge:      wait-gc-wait-1-3-2\n" +
+		"Note:       Continue after review closes.\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("writeWaitDetail =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -553,9 +632,9 @@ func TestLoadWaitBeadsByLabelUsesBoundedLookup(t *testing.T) {
 	}
 	store := &waitListQueryCaptureStore{Store: mem}
 
-	waits, err := loadWaitBeadsByLabel(store)
+	waits, err := loadWaitsByLabel(store)
 	if err != nil {
-		t.Fatalf("loadWaitBeadsByLabel: %v", err)
+		t.Fatalf("loadWaitsByLabel: %v", err)
 	}
 	if len(waits) != 1 {
 		t.Fatalf("wait count = %d, want 1", len(waits))
@@ -583,9 +662,9 @@ func TestLoadWaitBeadsByLabelAllowsExactLookupLimit(t *testing.T) {
 		}
 	}
 
-	waits, err := loadWaitBeadsByLabel(mem)
+	waits, err := loadWaitsByLabel(mem)
 	if err != nil {
-		t.Fatalf("loadWaitBeadsByLabel: %v", err)
+		t.Fatalf("loadWaitsByLabel: %v", err)
 	}
 	if len(waits) != waitLookupLimit {
 		t.Fatalf("wait count = %d, want %d", len(waits), waitLookupLimit)
@@ -593,9 +672,9 @@ func TestLoadWaitBeadsByLabelAllowsExactLookupLimit(t *testing.T) {
 }
 
 func TestLoadWaitBeadsByLabelReportsLookupLimit(t *testing.T) {
-	_, err := loadWaitBeadsByLabel(waitLookupLimitStore{Store: beads.NewMemStore()})
+	_, err := loadWaitsByLabel(waitLookupLimitStore{Store: beads.NewMemStore()})
 	if err == nil || !strings.Contains(err.Error(), "wait lookup hit limit") {
-		t.Fatalf("loadWaitBeadsByLabel error = %v, want wait lookup limit", err)
+		t.Fatalf("loadWaitsByLabel error = %v, want wait lookup limit", err)
 	}
 }
 
@@ -1026,7 +1105,7 @@ func TestPrepareWaitWakeState_FinalizesFromNudge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create wait bead: %v", err)
 	}
-	nudgeID := waitNudgeID(waitBead)
+	nudgeID := waitNudgeID(sessionpkg.WaitInfoFromBead(waitBead))
 	nudge, err := store.Create(beads.Bead{
 		Type:   nudgeBeadType,
 		Title:  "nudge:" + nudgeID,
@@ -1471,12 +1550,12 @@ func TestDepsWaitReady_IgnoresEmptyDependencyEntries(t *testing.T) {
 		t.Fatalf("close dep bead: %v", err)
 	}
 
-	ready := depsWaitReady(store, beads.Bead{
+	ready := depsWaitReady(store, sessionpkg.WaitInfoFromBead(beads.Bead{
 		Metadata: map[string]string{
 			"dep_ids":  dep.ID + ", ,",
 			"dep_mode": "all",
 		},
-	})
+	}))
 	if !ready {
 		t.Fatal("depsWaitReady = false, want true with only one real closed dependency")
 	}
@@ -1496,7 +1575,7 @@ func TestNextWaitDeliveryAttempt_IncrementsAfterTerminalNudge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create wait bead: %v", err)
 	}
-	nudgeID := waitNudgeID(wait)
+	nudgeID := waitNudgeID(sessionpkg.WaitInfoFromBead(wait))
 	nudge, err := store.Create(beads.Bead{
 		Type:   nudgeBeadType,
 		Title:  "nudge:" + nudgeID,
@@ -1513,7 +1592,7 @@ func TestNextWaitDeliveryAttempt_IncrementsAfterTerminalNudge(t *testing.T) {
 		t.Fatalf("close nudge bead: %v", err)
 	}
 
-	next, err := nextWaitDeliveryAttempt(nudgeFrontDoor(beads.NudgesStore{Store: store}), wait)
+	next, err := nextWaitDeliveryAttempt(nudgeFrontDoor(beads.NudgesStore{Store: store}), sessionpkg.WaitInfoFromBead(wait))
 	if err != nil {
 		t.Fatalf("nextWaitDeliveryAttempt: %v", err)
 	}
@@ -1552,7 +1631,7 @@ func TestRetryClosedWait_CreatesReplacement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create wait bead: %v", err)
 	}
-	nudgeID := waitNudgeID(wait)
+	nudgeID := waitNudgeID(sessionpkg.WaitInfoFromBead(wait))
 	nudge, err := store.Create(beads.Bead{
 		Type:   nudgeBeadType,
 		Title:  "nudge:" + nudgeID,
@@ -1745,7 +1824,7 @@ func TestDispatchReadyWaitNudges_EnqueuesDeterministicNudge(t *testing.T) {
 	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
 		t.Fatalf("pending=%d inFlight=%d dead=%d, want 1/0/0", len(pending), len(inFlight), len(dead))
 	}
-	wantID := waitNudgeID(waitBead)
+	wantID := waitNudgeID(sessionpkg.WaitInfoFromBead(waitBead))
 	if pending[0].ID != wantID {
 		t.Fatalf("queued nudge id = %q, want %q", pending[0].ID, wantID)
 	}
@@ -1864,8 +1943,8 @@ func TestDispatchReadyWaitNudges_ProcessesOpenSessionWaitsWithoutGlobalWaitList(
 	if err != nil {
 		t.Fatalf("listQueuedNudges: %v", err)
 	}
-	if len(pending) != 1 || pending[0].ID != waitNudgeID(waitBead) {
-		t.Fatalf("pending nudges = %#v, want one wait nudge %q", pending, waitNudgeID(waitBead))
+	if len(pending) != 1 || pending[0].ID != waitNudgeID(sessionpkg.WaitInfoFromBead(waitBead)) {
+		t.Fatalf("pending nudges = %#v, want one wait nudge %q", pending, waitNudgeID(sessionpkg.WaitInfoFromBead(waitBead)))
 	}
 }
 
@@ -2307,26 +2386,31 @@ func TestCancelWaitsForSessionReturnsNilAfterCappedConvergence(t *testing.T) {
 func TestLoadSessionWaitBeads_IncludesLegacyWaitType(t *testing.T) {
 	store := beads.NewMemStore()
 	sessionID := "gc-session"
-	if _, err := store.Create(beads.Bead{
+	// loadSessionWaits returns session.WaitInfo, which omits the storage-level
+	// bead Type. The legacy-type wait still flows through the lookup, so assert
+	// the created legacy bead is returned by ID (the IsWaitBead legacy-type
+	// coverage stays enforced by internal/session's IsWaitBead tests).
+	legacy, err := store.Create(beads.Bead{
 		Type:   sessionpkg.LegacyWaitBeadType,
 		Labels: []string{waitBeadLabel, "session:" + sessionID},
 		Metadata: map[string]string{
 			"session_id": sessionID,
 			"state":      waitStatePending,
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("create legacy wait bead: %v", err)
 	}
 
-	waits, err := loadSessionWaitBeads(store, sessionID)
+	waits, err := loadSessionWaits(store, sessionID)
 	if err != nil {
-		t.Fatalf("loadSessionWaitBeads: %v", err)
+		t.Fatalf("loadSessionWaits: %v", err)
 	}
 	if len(waits) != 1 {
-		t.Fatalf("loadSessionWaitBeads returned %d waits, want 1", len(waits))
+		t.Fatalf("loadSessionWaits returned %d waits, want 1", len(waits))
 	}
-	if waits[0].Type != sessionpkg.LegacyWaitBeadType {
-		t.Fatalf("wait type = %q, want legacy %q", waits[0].Type, sessionpkg.LegacyWaitBeadType)
+	if waits[0].ID != legacy.ID {
+		t.Fatalf("wait ID = %q, want legacy wait %q", waits[0].ID, legacy.ID)
 	}
 }
 

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -843,7 +843,7 @@ func cancelStateAssignedToRetiredSessionBead(store beads.Store, sessionID string
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	if _, err := session.ListSessionWaitBeads(store, sessionID); beads.IsLookupLimitError(err) {
+	if _, err := session.ListSessionWaits(store, sessionID); beads.IsLookupLimitError(err) {
 		stampWaitLookupCapDiagnostic(sessionFrontDoor(store), sessionID, err, now, "retired-session-cleanup")
 	}
 	if err := session.CancelWaits(store, sessionID, now); err != nil {

--- a/internal/coordclass/classify_test.go
+++ b/internal/coordclass/classify_test.go
@@ -57,7 +57,7 @@ func TestClassifyGoldenTable(t *testing.T) {
 		// label; it classifies via the gc:wait class signal.
 		{"wait bead with per-entity session label", beads.Bead{Type: "gate", Labels: []string{"gc:wait", "session:gc-7"}}, ClassSessions},
 		// Federation-correctness guard: the per-entity session:<id> label is NOT a
-		// class signal. ListSessionWaitBeads queries by Label="session:<id>", which a
+		// class signal. ListSessionWaits queries by Label="session:<id>", which a
 		// route-by-query adapter would mis-route to the session store — but the
 		// federating Router classifies by the class-level signal (gc:wait/gc:session/
 		// type=session), so a bead carrying ONLY session:<id> stays ClassWork. This

--- a/internal/session/waits.go
+++ b/internal/session/waits.go
@@ -85,8 +85,97 @@ func IsWaitBead(b beads.Bead) bool {
 	return sessionID != "" && beadHasLabel(b, "session:"+sessionID)
 }
 
-// ListSessionWaitBeads returns open durable wait beads for one session.
-func ListSessionWaitBeads(store beads.Store, sessionID string) ([]beads.Bead, error) {
+// WaitInfo is the typed projection of a durable session wait bead: the domain
+// view of a wait that callers read and decide against without touching
+// *beads.Bead. It carries only bead-stored facts (metadata keys, description,
+// status, created-at, labels), so a wait bead round-trips to the same WaitInfo
+// regardless of which backend stored it.
+//
+// Bead serialization for waits is confined to this file: WaitInfoFromBead is the
+// only place the wait-read paths learn these facts come from a bead. The wait
+// write paths (metadata batches, retry clones, create) still speak *beads.Bead —
+// that is the deliberate serialization edge, mirroring session.Store.
+type WaitInfo struct {
+	// ID is the wait bead ID.
+	ID string
+	// SessionID is the session bead ID the wait is registered against (metadata session_id).
+	SessionID string
+	// SessionName is the runtime session name recorded at registration (metadata session_name).
+	SessionName string
+	// Kind is the wait kind, e.g. "deps" or "probe" (metadata kind).
+	Kind string
+	// State is the wait lifecycle state, e.g. "pending"/"ready" (metadata state).
+	State string
+	// DepIDs are the dependency bead IDs the wait watches, comma-split and
+	// trimmed with empties dropped (metadata dep_ids). It is nil when unset.
+	DepIDs []string
+	// DepMode is "all" or "any" (metadata dep_mode).
+	DepMode string
+	// RegisteredEpoch is the session continuation epoch at registration (metadata registered_epoch).
+	RegisteredEpoch string
+	// DeliveryAttempt is the current delivery attempt counter (metadata delivery_attempt).
+	DeliveryAttempt string
+	// NudgeID is the shadow wait-nudge ID once dispatched (metadata nudge_id).
+	NudgeID string
+	// ExpiresAt is the raw RFC3339 expiry string kept verbatim; consumers parse
+	// it and tolerate malformed values (metadata expires_at).
+	ExpiresAt string
+	// Note is the reminder text delivered when the wait is satisfied (bead Description, untrimmed).
+	Note string
+	// Status is the persisted bead status ("open"/"closed").
+	Status string
+	// CreatedAt is the bead creation time.
+	CreatedAt time.Time
+	// Labels are the bead labels.
+	Labels []string
+}
+
+// WaitInfoFromBead projects a durable wait bead onto WaitInfo. It is pure,
+// side-effect-free, and backend-invariant: it reads only stored bead fields and
+// applies the same key-for-key decoding (and dep_ids split/trim) the wait render
+// and decision paths previously performed inline.
+func WaitInfoFromBead(b beads.Bead) WaitInfo {
+	return WaitInfo{
+		ID:              b.ID,
+		SessionID:       b.Metadata["session_id"],
+		SessionName:     b.Metadata["session_name"],
+		Kind:            b.Metadata["kind"],
+		State:           b.Metadata["state"],
+		DepIDs:          splitWaitDepIDs(b.Metadata["dep_ids"]),
+		DepMode:         b.Metadata["dep_mode"],
+		RegisteredEpoch: b.Metadata["registered_epoch"],
+		DeliveryAttempt: b.Metadata["delivery_attempt"],
+		NudgeID:         b.Metadata["nudge_id"],
+		ExpiresAt:       b.Metadata["expires_at"],
+		Note:            b.Description,
+		Status:          b.Status,
+		CreatedAt:       b.CreatedAt,
+		Labels:          b.Labels,
+	}
+}
+
+// splitWaitDepIDs splits a comma-separated dep_ids value into trimmed, non-empty
+// IDs, returning nil for a blank value. It is the confined codec for the wait
+// dependency-ID list (formerly cmd/gc's splitWaitIDs).
+func splitWaitDepIDs(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// ListSessionWaits returns the WaitInfo projection of open durable wait beads for
+// one session. No raw beads cross this boundary; the IsWaitBead and session_id
+// filters run on the listed beads before projection because this function is the
+// codec edge.
+func ListSessionWaits(store beads.Store, sessionID string) ([]WaitInfo, error) {
 	if store == nil || sessionID == "" {
 		return nil, nil
 	}
@@ -107,7 +196,7 @@ func ListSessionWaitBeads(store beads.Store, sessionID string) ([]beads.Bead, er
 	if capped {
 		waits = waits[:SessionWaitLookupLimit]
 	}
-	result := make([]beads.Bead, 0, len(waits))
+	result := make([]WaitInfo, 0, len(waits))
 	for _, wait := range waits {
 		if !IsWaitBead(wait) {
 			continue
@@ -115,7 +204,7 @@ func ListSessionWaitBeads(store beads.Store, sessionID string) ([]beads.Bead, er
 		if wait.Metadata["session_id"] != sessionID {
 			continue
 		}
-		result = append(result, wait)
+		result = append(result, WaitInfoFromBead(wait))
 	}
 	if capped {
 		return result, beads.LookupLimitError{Kind: "wait", Label: "session:" + sessionID, Limit: SessionWaitLookupLimit}
@@ -125,19 +214,18 @@ func ListSessionWaitBeads(store beads.Store, sessionID string) ([]beads.Bead, er
 
 // WaitNudgeIDs returns queued nudge IDs for the session's currently open waits.
 func WaitNudgeIDs(store beads.Store, sessionID string) ([]string, error) {
-	waits, err := ListSessionWaitBeads(store, sessionID)
+	waits, err := ListSessionWaits(store, sessionID)
 	if err != nil && !beads.IsLookupLimitError(err) {
 		return nil, err
 	}
 	ids := make([]string, 0, len(waits))
 	seen := make(map[string]bool, len(waits))
 	for _, wait := range waits {
-		nudgeID := wait.Metadata["nudge_id"]
-		if nudgeID == "" || seen[nudgeID] {
+		if wait.NudgeID == "" || seen[wait.NudgeID] {
 			continue
 		}
-		seen[nudgeID] = true
-		ids = append(ids, nudgeID)
+		seen[wait.NudgeID] = true
+		ids = append(ids, wait.NudgeID)
 	}
 	return ids, err
 }
@@ -162,14 +250,14 @@ func ReassignWaits(store beads.Store, oldSessionID, newSessionID string) error {
 	oldLabel := "session:" + oldSessionID
 	newLabel := "session:" + newSessionID
 	for {
-		waits, err := ListSessionWaitBeads(store, oldSessionID)
+		waits, err := ListSessionWaits(store, oldSessionID)
 		if err != nil && !beads.IsLookupLimitError(err) {
 			return err
 		}
 		lookupCapped := beads.IsLookupLimitError(err)
 		progressed := 0
 		for _, wait := range waits {
-			if IsWaitTerminalState(wait.Metadata["state"]) {
+			if IsWaitTerminalState(wait.State) {
 				if err := store.Close(wait.ID); err != nil {
 					return fmt.Errorf("closing terminal wait %s for session %s: %w", wait.ID, oldSessionID, err)
 				}
@@ -177,7 +265,7 @@ func ReassignWaits(store beads.Store, oldSessionID, newSessionID string) error {
 				continue
 			}
 			labels := []string(nil)
-			if !beadHasLabel(wait, newLabel) {
+			if !labelsContain(wait.Labels, newLabel) {
 				labels = []string{newLabel}
 			}
 			if err := store.Update(wait.ID, beads.UpdateOpts{
@@ -256,7 +344,7 @@ func cancelWaitsAndCollectNudgeIDs(store beads.Store, sessionID string, now time
 		"canceled_at": now.UTC().Format(time.RFC3339),
 	}
 	for {
-		waits, err := ListSessionWaitBeads(store, sessionID)
+		waits, err := ListSessionWaits(store, sessionID)
 		if err != nil && !beads.IsLookupLimitError(err) {
 			return ids, capped, err
 		}
@@ -265,11 +353,11 @@ func cancelWaitsAndCollectNudgeIDs(store beads.Store, sessionID string, now time
 		cancelIDs := make([]string, 0, len(waits))
 		terminalIDs := make([]string, 0, len(waits))
 		for _, wait := range waits {
-			if nudgeID := wait.Metadata["nudge_id"]; nudgeID != "" && !seen[nudgeID] {
-				seen[nudgeID] = true
-				ids = append(ids, nudgeID)
+			if wait.NudgeID != "" && !seen[wait.NudgeID] {
+				seen[wait.NudgeID] = true
+				ids = append(ids, wait.NudgeID)
 			}
-			if IsWaitTerminalState(wait.Metadata["state"]) {
+			if IsWaitTerminalState(wait.State) {
 				terminalIDs = append(terminalIDs, wait.ID)
 				continue
 			}
@@ -302,7 +390,11 @@ func CancelWaits(store beads.Store, sessionID string, now time.Time) error {
 }
 
 func beadHasLabel(b beads.Bead, want string) bool {
-	for _, label := range b.Labels {
+	return labelsContain(b.Labels, want)
+}
+
+func labelsContain(labels []string, want string) bool {
+	for _, label := range labels {
 		if label == want {
 			return true
 		}

--- a/internal/session/waits_test.go
+++ b/internal/session/waits_test.go
@@ -3,12 +3,108 @@ package session
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
+
+func TestWaitInfoFromBead_ProjectsAllFields(t *testing.T) {
+	created := time.Date(2026, 5, 15, 9, 30, 0, 0, time.UTC)
+	b := beads.Bead{
+		ID:          "gc-wait-1",
+		Type:        WaitBeadType,
+		Status:      "closed",
+		Title:       "wait:worker",
+		Description: "Continue after review closes.",
+		CreatedAt:   created,
+		Labels:      []string{WaitBeadLabel, "session:gc-session"},
+		Metadata: map[string]string{
+			"session_id":       "gc-session",
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            "ready",
+			"dep_ids":          "gc-1,gc-2",
+			"dep_mode":         "all",
+			"registered_epoch": "3",
+			"delivery_attempt": "2",
+			"nudge_id":         "wait-gc-wait-1-3-2",
+			"expires_at":       "2026-05-16T09:30:00Z",
+		},
+	}
+	got := WaitInfoFromBead(b)
+	want := WaitInfo{
+		ID:              "gc-wait-1",
+		SessionID:       "gc-session",
+		SessionName:     "worker",
+		Kind:            "deps",
+		State:           "ready",
+		DepIDs:          []string{"gc-1", "gc-2"},
+		DepMode:         "all",
+		RegisteredEpoch: "3",
+		DeliveryAttempt: "2",
+		NudgeID:         "wait-gc-wait-1-3-2",
+		ExpiresAt:       "2026-05-16T09:30:00Z",
+		Note:            "Continue after review closes.",
+		Status:          "closed",
+		CreatedAt:       created,
+		Labels:          []string{WaitBeadLabel, "session:gc-session"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("WaitInfoFromBead = %#v, want %#v", got, want)
+	}
+}
+
+func TestWaitInfoFromBead_DepIDsSplitTrimEmpty(t *testing.T) {
+	cases := []struct {
+		name   string
+		depIDs string
+		want   []string
+	}{
+		{"trims and drops empties", " a , b ,,c ", []string{"a", "b", "c"}},
+		{"empty string", "", nil},
+		{"single id", "gc-1", []string{"gc-1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WaitInfoFromBead(beads.Bead{Metadata: map[string]string{"dep_ids": tc.depIDs}}).DepIDs
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("DepIDs = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+	if got := WaitInfoFromBead(beads.Bead{}).DepIDs; got != nil {
+		t.Fatalf("DepIDs for absent dep_ids key = %#v, want nil", got)
+	}
+}
+
+func TestListSessionWaits_ReturnsProjectedWaitInfo(t *testing.T) {
+	store := beads.NewMemStore()
+	created, err := store.Create(beads.Bead{
+		Type:   WaitBeadType,
+		Labels: []string{WaitBeadLabel, "session:gc-session"},
+		Metadata: map[string]string{
+			"session_id": "gc-session",
+			"state":      "ready",
+			"nudge_id":   "wait-nudge",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create wait: %v", err)
+	}
+	waits, err := ListSessionWaits(store, "gc-session")
+	if err != nil {
+		t.Fatalf("ListSessionWaits: %v", err)
+	}
+	if len(waits) != 1 {
+		t.Fatalf("wait count = %d, want 1", len(waits))
+	}
+	if w := waits[0]; w.ID != created.ID || w.SessionID != "gc-session" || w.State != "ready" || w.NudgeID != "wait-nudge" {
+		t.Fatalf("WaitInfo = %#v, want id=%s session=gc-session state=ready nudge=wait-nudge", w, created.ID)
+	}
+}
 
 type rejectLegacyWaitTypeQueryStore struct {
 	*beads.MemStore
@@ -144,22 +240,22 @@ func TestWaitNudgeIDs_UsesBoundedDeterministicSessionLookup(t *testing.T) {
 	}
 }
 
-func TestListSessionWaitBeads_AllowsExactLookupLimit(t *testing.T) {
+func TestListSessionWaits_AllowsExactLookupLimit(t *testing.T) {
 	store := &sessionWaitExactLimitStore{Store: beads.NewMemStore()}
 
-	waits, err := ListSessionWaitBeads(store, "gc-session")
+	waits, err := ListSessionWaits(store, "gc-session")
 	if err != nil {
-		t.Fatalf("ListSessionWaitBeads: %v", err)
+		t.Fatalf("ListSessionWaits: %v", err)
 	}
 	if len(waits) != SessionWaitLookupLimit {
 		t.Fatalf("wait count = %d, want %d", len(waits), SessionWaitLookupLimit)
 	}
 }
 
-func TestListSessionWaitBeads_ReportsLimitWithFilteredPartial(t *testing.T) {
-	waits, err := ListSessionWaitBeads(sessionWaitLimitStore{Store: beads.NewMemStore()}, "gc-session")
+func TestListSessionWaits_ReportsLimitWithFilteredPartial(t *testing.T) {
+	waits, err := ListSessionWaits(sessionWaitLimitStore{Store: beads.NewMemStore()}, "gc-session")
 	if !beads.IsLookupLimitError(err) {
-		t.Fatalf("ListSessionWaitBeads error = %v, want lookup limit", err)
+		t.Fatalf("ListSessionWaits error = %v, want lookup limit", err)
 	}
 	if len(waits) != SessionWaitLookupLimit {
 		t.Fatalf("wait count = %d, want filtered partial count %d", len(waits), SessionWaitLookupLimit)


### PR DESCRIPTION
## Summary

Introduces a typed `session.WaitInfo` codec (confined to `internal/session/waits.go`)
and routes `gc wait`'s read/render/decision paths through it, eliminating the
inline `objectFromBead(bead).<property>` cracking — the clearest textbook instance
of the antipattern.

- `internal/session/waits.go` — new `WaitInfo` + `WaitInfoFromBead` codec (+ `splitWaitDepIDs`,
  a verbatim move of the old `splitWaitIDs`); `ListSessionWaitBeads` → `ListSessionWaits`
  returning `[]WaitInfo`; the 3 in-package consumers retyped.
- `cmd/gc/cmd_wait.go` — `waitJSONFromBead`→`waitJSONFromInfo`, `writeWaitDetail`, all
  loaders, deps-readiness, `waitNudgeID`, `nextWaitDeliveryAttempt`, `readyWaitSetForList`
  build from `WaitInfo`. **Metadata reads dropped 48 → 4** (the 4 survivors are
  *session*-bead readers — the separate session.Info opportunity, out of scope).
- Write codecs (`retryClosedWait`, `setWaitTerminalState`, the `cmdSessionWait` meta map)
  deliberately stay on raw beads — no over-reach.

## Behavior preservation

`WaitInfoFromBead` decodes the same 10 keys with identical absent-key defaults;
the `schema_version`-1 CLI JSON is byte-identical (pinned by
`TestWaitJSONFromInfo_MatchesBeadProjection`, re-run independently by review).

**One display-only nit (documented, accepted):** `writeWaitDetail`'s Deps line now
renders the normalized (trimmed, empties-dropped) `DepIDs` join. This is byte-identical
for every in-tree writer (the only writer joins comma-no-space; retry clones verbatim);
it differs only for out-of-band hand-edited metadata like `"gc-1, gc-2"`, which no
system code produces. Reverting would re-introduce a raw `b.Metadata` read, so it's
left as the normalized form.

## Verification

- `gofmt` clean; `go build ./...`, `go vet ./internal/session ./cmd/gc` and `go vet ./...` clean
- `go test ./internal/session` green; `go test ./cmd/gc -run Wait` green (incl. new equivalence + golden tests); acceptance `Wait` green — all independently re-run at the branch tip
- No wire/OpenAPI/dashboard impact
- Fable adversarial review: approve (equivalence independently re-verified; the one-off `make test` blip is the documented `eventfeed TestMuxSource` parallel-sweep flake, not a regression)

Part of the raw-bead-leak cleanup epic. Refs `ga-qjcta7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
