### PR TITLE
refactor(session): migrate reconciler heal/health reads onto session.Info

### DIFF
--- a/cmd/gc/session_classifier_info_equiv_test.go
+++ b/cmd/gc/session_classifier_info_equiv_test.go
@@ -667,6 +667,39 @@ func TestSessionClassifierInfoEquivalence(t *testing.T) {
 				"stranded_event_emitted_at":          pastRFC3339,
 			},
 		},
+		"rapid-crash-candidate": {
+			// Dead crash candidate: awake with a recent last_woke_at (well within
+			// stabilityThreshold), no deliberate sleep_reason and no pending-create
+			// claim, so DecideSessionExit on sessionExitFacts(alive=false) classifies
+			// it ExitRapidCrash. Drives the sessionExitFacts ↔ sessionExitFactsInfo
+			// struct-equivalence block through the real crash lane, not a trivial
+			// both-ExitNone pass.
+			ID:     "ga-rapidcrash",
+			Type:   session.BeadType,
+			Title:  "rapidcrash",
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"template":     "worker",
+				"state":        "awake",
+				"last_woke_at": clk.Now().Add(-15 * time.Second).UTC().Format(time.RFC3339),
+			},
+		},
+		"wake-attempts-overflow": {
+			// wake_attempts beyond int64 range: strconv.Atoi returns the clamped
+			// value together with ErrRange. Pins the recordWakeFailure counter lane,
+			// which parses the raw WakeAttemptsMetadata string (not the pre-parsed
+			// WakeAttempts int, which zeroes on ErrRange), so sessionWakeAttempts and
+			// sessionWakeAttemptsInfo must still agree here while WakeAttemptsMetadata
+			// keeps the raw bytes verbatim.
+			ID:     "ga-wakeoverflow",
+			Type:   session.BeadType,
+			Title:  "wakeoverflow",
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"template":      "worker",
+				"wake_attempts": "999999999999999999999",
+			},
+		},
 	}
 
 	const tmpl = "worker"
@@ -1016,6 +1049,14 @@ func TestSessionClassifierInfoEquivalence(t *testing.T) {
 				return pendingResumePreservingNamedRestartInfo(i, clk, leaseStartupTimeout)
 			},
 		},
+		"stableLongEnough": {
+			func(b beads.Bead) bool { return stableLongEnough(b, clk) },
+			func(i session.Info) bool { return stableLongEnoughInfo(i, clk) },
+		},
+		"productiveLongEnough": {
+			func(b beads.Bead) bool { return productiveLongEnough(b, clk) },
+			func(i session.Info) bool { return productiveLongEnoughInfo(i, clk) },
+		},
 	}
 
 	// The "pending-resume-preserve" fixture must hit the true branch under
@@ -1034,6 +1075,19 @@ func TestSessionClassifierInfoEquivalence(t *testing.T) {
 	// branch so its equivalence case is a real comparison, not a both-empty pass.
 	if lifecycleTimerBlocker(beadsByShape["hold-and-quarantine"].Metadata, clk.Now()) == "" {
 		t.Fatal(`lifecycleTimerBlocker(hold-and-quarantine) = ""; fixture no longer exercises the blocker branch`)
+	}
+	// The rapid-crash-candidate fixture must classify ExitRapidCrash under
+	// alive=false so the sessionExitFacts ↔ sessionExitFactsInfo struct-equivalence
+	// block exercises the crash lane, not a trivial both-ExitNone pass.
+	rapidCrash := beadsByShape["rapid-crash-candidate"]
+	if got := session.DecideSessionExit(sessionExitFacts(&rapidCrash, leaseCfg, false, nil, clk)); got != session.ExitRapidCrash {
+		t.Fatalf("DecideSessionExit(rapid-crash-candidate, alive=false) = %v; want ExitRapidCrash — fixture no longer exercises the crash lane", got)
+	}
+	// stableLongEnough must be true on the old-marker fixture (pastRFC3339
+	// last_woke_at) so its clkBoolChecks equivalence case is a real true-branch
+	// comparison, not a trivial both-false pass.
+	if !stableLongEnough(beadsByShape["pending-create-claim-old-markers"], clk) {
+		t.Fatal("stableLongEnough(pending-create-claim-old-markers) = false; fixture no longer exercises the stable-long-enough true branch")
 	}
 
 	for shape, b := range beadsByShape {
@@ -1096,6 +1150,18 @@ func TestSessionClassifierInfoEquivalence(t *testing.T) {
 			infoS, infoT, infoOK := resetPendingCommittedAtInfo(info)
 			if rawS != infoS || !rawT.Equal(infoT) || rawOK != infoOK {
 				t.Errorf("resetPendingCommittedAt: info=(%q,%v,%v) bead=(%q,%v,%v)", infoS, infoT, infoOK, rawS, rawT, rawOK)
+			}
+			// sessionExitFacts ↔ sessionExitFactsInfo must produce byte-identical
+			// ExitFacts for every shape under both liveness values — the struct-level
+			// analogue of the scalar checks above. nil dt ⇒ DrainPending false on both
+			// forms; the alive=true pass proves the Alive field threads identically.
+			bb := b
+			for _, alive := range []bool{false, true} {
+				rawFacts := sessionExitFacts(&bb, leaseCfg, alive, nil, clk)
+				infoFacts := sessionExitFactsInfo(info, leaseCfg, alive, nil, clk)
+				if !reflect.DeepEqual(rawFacts, infoFacts) {
+					t.Errorf("sessionExitFacts(alive=%v): bead=%+v info=%+v", alive, rawFacts, infoFacts)
+				}
 			}
 		})
 	}

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -2109,7 +2109,9 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 	// tp.DisplayName() is the exact identity the start counter records, so a
 	// quarantine triggered by repeated start failures joins the start series
 	// even for a namepool-themed pool instance whose bead predates agent_name.
-	recordWakeFailure(session, sessFront, clk, tp.DisplayName())
+	// Fresh projection is coherent: the SetMarker success path above mirrored
+	// last_woke_at="" onto session.Metadata before this call.
+	recordWakeFailure(session, sessionpkg.InfoFromPersistedBead(*session), sessFront, clk, tp.DisplayName())
 	if trace != nil {
 		trace.RecordOperation(TraceSiteLifecycleStartFailed, TraceReasonStart, TraceOutcomeCode(result.outcome), "", tp.TemplateName, name, 0, traceRecordPayload{
 			"error": formatLifecycleError(result.err),

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -420,21 +420,29 @@ func agentTemplateIdentitiesEquivalent(cfg *config.City, a, b string) bool {
 }
 
 // healExpiredTimers clears expired held_until and quarantined_until.
-// Separate from wakeReasons() to keep that function pure.
-func healExpiredTimers(session *beads.Bead, sessFront *sessionpkg.Store, clk clock.Clock) {
-	if h := session.Metadata["held_until"]; h != "" {
+// Separate from wakeReasons() to keep that function pure. Decision reads route
+// through the typed info snapshot, which must equal InfoFromPersistedBead(*session)
+// at call time; the raw session.Metadata mirror loops are kept because the Phase-0
+// caller runs before the coherent infoByID snapshot exists and later reads still
+// project from the mutated bead.
+func healExpiredTimers(session *beads.Bead, info sessionpkg.Info, sessFront *sessionpkg.Store, clk clock.Clock) {
+	if h := info.HeldUntil; h != "" {
 		if t, _ := time.Parse(time.RFC3339, h); !t.IsZero() && clk.Now().After(t) {
-			batch := sessionpkg.ClearExpiredHoldPatch(session.Metadata["sleep_reason"])
+			batch := sessionpkg.ClearExpiredHoldPatch(info.SleepReason)
 			if err := sessFront.ApplyPatch(session.ID, batch); err == nil {
 				for k, v := range batch {
 					session.Metadata[k] = v
 				}
+				// Fold the hold-clear batch onto the local Info so the quarantine
+				// block below reads the post-hold sleep_reason (ClearExpiredHoldPatch
+				// can blank it) exactly as the raw session.Metadata read did today.
+				info = info.ApplyPatch(batch)
 			}
 		}
 	}
-	if q := session.Metadata["quarantined_until"]; q != "" {
+	if q := info.QuarantinedUntil; q != "" {
 		if t, _ := time.Parse(time.RFC3339, q); !t.IsZero() && clk.Now().After(t) {
-			batch := sessionpkg.ClearExpiredQuarantinePatch(session.Metadata["sleep_reason"])
+			batch := sessionpkg.ClearExpiredQuarantinePatch(info.SleepReason)
 			if err := sessFront.ApplyPatch(session.ID, batch); err == nil {
 				for k, v := range batch {
 					session.Metadata[k] = v
@@ -461,14 +469,18 @@ func healExpiredTimers(session *beads.Bead, sessFront *sessionpkg.Store, clk clo
 // forward-pass caller can fold it via ApplyPatch (front-door migration Step 6d,
 // STEP6-PREPASS-AUDIT group 2). Returns (false, nil) otherwise; ApplyPatch(nil)
 // is a no-op.
-func checkStability(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, sessFront *sessionpkg.Store, clk clock.Clock, peek func(lines int) (string, error)) (bool, map[string]string) {
-	if handled, rlBatch, err := checkRateLimitStability(session, cfg, alive, dt, sessFront, clk, peek); handled || err != nil {
+//
+// Coherence precondition: info must equal InfoFromPersistedBead(*session) at
+// call time — the Step-6d fold invariant the forward-pass caller maintains by
+// folding every prior in-iteration write onto the snapshot before this call.
+func checkStability(session *beads.Bead, info sessionpkg.Info, cfg *config.City, alive bool, dt *drainTracker, sessFront *sessionpkg.Store, clk clock.Clock, peek func(lines int) (string, error)) (bool, map[string]string) {
+	if handled, rlBatch, err := checkRateLimitStability(session, info, cfg, alive, dt, sessFront, clk, peek); handled || err != nil {
 		return true, rlBatch
 	}
-	if sessionpkg.DecideSessionExit(sessionExitFacts(session, cfg, alive, dt, clk)) != sessionpkg.ExitRapidCrash {
+	if sessionpkg.DecideSessionExit(sessionExitFactsInfo(info, cfg, alive, dt, clk)) != sessionpkg.ExitRapidCrash {
 		return false, nil
 	}
-	wfBatch := recordWakeFailure(session, sessFront, clk, sessionAgentMetricIdentity(*session, cfg))
+	wfBatch := recordWakeFailure(session, info, sessFront, clk, sessionAgentMetricIdentityInfo(info, cfg))
 	clearBatch := clearLastWokeAt(session, sessFront)
 	return true, mergeMetadataPatch(wfBatch, clearBatch)
 }
@@ -489,11 +501,11 @@ func checkStability(session *beads.Bead, cfg *config.City, alive bool, dt *drain
 // ApplyPatch (front-door migration Step 6d, STEP6-PREPASS-AUDIT group 1).
 // batch is nil on every path that mirrors nothing (no-hit, nil session, or
 // persist error); ApplyPatch(nil) is a no-op.
-func checkRateLimitStability(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, sessFront *sessionpkg.Store, clk clock.Clock, peek func(lines int) (string, error)) (bool, map[string]string, error) {
+func checkRateLimitStability(session *beads.Bead, info sessionpkg.Info, cfg *config.City, alive bool, dt *drainTracker, sessFront *sessionpkg.Store, clk clock.Clock, peek func(lines int) (string, error)) (bool, map[string]string, error) {
 	if session == nil {
 		return false, nil, nil
 	}
-	facts := sessionExitFacts(session, cfg, alive, dt, clk)
+	facts := sessionExitFactsInfo(info, cfg, alive, dt, clk)
 	facts.ScreenAvailable = peek != nil
 	dec := sessionpkg.DecideSessionExit(facts)
 	for dec == sessionpkg.ExitGatherScreen {
@@ -540,6 +552,33 @@ func sessionExitFacts(session *beads.Bead, cfg *config.City, alive bool, dt *dra
 		PendingCreateStartInFlight: pendingCreateStartInFlight(*session, clk, startupTimeout),
 		SleepReason:                session.Metadata["sleep_reason"],
 		LastWokeAt:                 session.Metadata["last_woke_at"],
+		Now:                        clk.Now(),
+		StabilityThreshold:         stabilityThreshold,
+		ProductivityThreshold:      churnProductivityThreshold,
+	}
+}
+
+// sessionExitFactsInfo is the session.Info sibling of sessionExitFacts, reading
+// the typed exit-decision mirrors instead of raw bead metadata. Info already
+// applies the identical TrimSpace=="true" for PendingCreateClaim, and its
+// SleepReason/LastWokeAt fields are verbatim raw mirrors, so the two forms
+// produce byte-identical ExitFacts for any info == InfoFromPersistedBead(*session)
+// (equivalence-proven, TestSessionClassifierInfoEquivalence).
+func sessionExitFactsInfo(info sessionpkg.Info, cfg *config.City, alive bool, dt *drainTracker, clk clock.Clock) sessionpkg.ExitFacts {
+	var startupTimeout time.Duration
+	subprocess := false
+	if cfg != nil {
+		startupTimeout = cfg.Session.StartupTimeoutDuration()
+		subprocess = cfg.Session.Provider == "subprocess"
+	}
+	return sessionpkg.ExitFacts{
+		Alive:                      alive,
+		SubprocessProvider:         subprocess,
+		DrainPending:               dt != nil && dt.get(info.ID) != nil,
+		PendingCreateClaim:         info.PendingCreateClaim,
+		PendingCreateStartInFlight: pendingCreateStartInFlightInfo(info, clk, startupTimeout),
+		SleepReason:                info.SleepReason,
+		LastWokeAt:                 info.LastWokeAt,
 		Now:                        clk.Now(),
 		StabilityThreshold:         stabilityThreshold,
 		ProductivityThreshold:      churnProductivityThreshold,
@@ -650,8 +689,12 @@ func sessionHasProviderTerminalErrorInfo(info sessionpkg.Info) bool {
 // Returns nil only when no keys were mirrored (a quarantined accrual whose
 // persist failed is excluded from the batch). agentIdentity is the
 // start-path-joinable agent label for gc.agent.quarantines.total.
-func recordWakeFailure(session *beads.Bead, sessFront *sessionpkg.Store, clk clock.Clock, agentIdentity string) map[string]string {
-	attempts, _ := strconv.Atoi(session.Metadata["wake_attempts"])
+func recordWakeFailure(session *beads.Bead, info sessionpkg.Info, sessFront *sessionpkg.Store, clk clock.Clock, agentIdentity string) map[string]string {
+	// Parse the raw wake_attempts mirror (not the pre-parsed info.WakeAttempts,
+	// which zeroes on strconv.ErrRange) so an out-of-range counter yields the
+	// same clamped value the old strconv.Atoi(session.Metadata[...]) path did —
+	// byte-identical, mirroring how recordChurn treats info.ChurnCount.
+	attempts, _ := strconv.Atoi(info.WakeAttemptsMetadata)
 
 	if session.Metadata == nil {
 		session.Metadata = make(map[string]string)
@@ -668,7 +711,7 @@ func recordWakeFailure(session *beads.Bead, sessFront *sessionpkg.Store, clk clo
 	// recovery remains correct in that call order and for any skewed state
 	// left behind by older builds.
 	var merged map[string]string
-	if session.Metadata["session_key"] != "" || session.Metadata["started_config_hash"] != "" {
+	if info.SessionKey != "" || info.StartedConfigHash != "" {
 		reset := sessionpkg.ConversationResetPatch(true)
 		_ = sessFront.ApplyPatch(session.ID, reset)
 		for k, v := range reset {
@@ -698,12 +741,14 @@ func recordWakeFailure(session *beads.Bead, sessFront *sessionpkg.Store, clk clo
 // Returns the mirrored batch on the persist path, nil when there is nothing to
 // clear (both fields already absent/zero). The caller folds the returned batch
 // onto the typed snapshot via ApplyPatch (nil is a no-op).
-func clearWakeFailures(session *beads.Bead, sessFront *sessionpkg.Store) map[string]string {
+func clearWakeFailures(session *beads.Bead, info sessionpkg.Info, sessFront *sessionpkg.Store) map[string]string {
 	batch := make(map[string]string, 2)
-	if session.Metadata["wake_attempts"] != "" && session.Metadata["wake_attempts"] != "0" {
+	// WakeAttemptsMetadata (the raw string mirror), not the parsed WakeAttempts int:
+	// the != "0" distinction distinguishes an absent counter from a persisted "0".
+	if info.WakeAttemptsMetadata != "" && info.WakeAttemptsMetadata != "0" {
 		batch["wake_attempts"] = "0"
 	}
-	if session.Metadata["quarantined_until"] != "" {
+	if info.QuarantinedUntil != "" {
 		batch["quarantined_until"] = ""
 	}
 	if len(batch) == 0 {
@@ -732,10 +777,10 @@ func clearWakeFailures(session *beads.Bead, sessFront *sessionpkg.Store) map[str
 // so the caller can fold it via ApplyPatch regardless of the bool return
 // (front-door migration Step 6d, STEP6-PREPASS-AUDIT group 5).
 // batch is nil when nothing was mirrored. ApplyPatch(nil) is a no-op.
-func checkChurn(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, sessFront *sessionpkg.Store, clk clock.Clock) (bool, map[string]string) {
-	switch sessionpkg.DecideSessionExit(sessionExitFacts(session, cfg, alive, dt, clk)) {
+func checkChurn(session *beads.Bead, info sessionpkg.Info, cfg *config.City, alive bool, dt *drainTracker, sessFront *sessionpkg.Store, clk clock.Clock) (bool, map[string]string) {
+	switch sessionpkg.DecideSessionExit(sessionExitFactsInfo(info, cfg, alive, dt, clk)) {
 	case sessionpkg.ExitChurn:
-		churnBatch := recordChurn(session, sessFront, clk, sessionAgentMetricIdentity(*session, cfg))
+		churnBatch := recordChurn(session, info, sessFront, clk, sessionAgentMetricIdentityInfo(info, cfg))
 		// Clear last_woke_at so this death is not re-counted next tick
 		// (edge-triggered, same pattern as checkStability).
 		clearBatch := clearLastWokeAt(session, sessFront)
@@ -743,7 +788,7 @@ func checkChurn(session *beads.Bead, cfg *config.City, alive bool, dt *drainTrac
 	case sessionpkg.ExitProductiveDeath:
 		// Session was productive — clear any stale churn count so it
 		// doesn't carry over and cause premature quarantine next time.
-		return false, clearChurn(session, sessFront)
+		return false, clearChurn(session, info, sessFront)
 	default:
 		// Rapid crashes belong to checkStability, which ran first.
 		return false, nil
@@ -768,8 +813,8 @@ func isDeliberateSleepReason(reason string) bool {
 //   - {"churn_count": next} on the non-quarantine path
 //
 // agentIdentity is the start-path-joinable agent label for gc.agent.quarantines.total.
-func recordChurn(session *beads.Bead, sessFront *sessionpkg.Store, clk clock.Clock, agentIdentity string) map[string]string {
-	count, _ := strconv.Atoi(session.Metadata["churn_count"])
+func recordChurn(session *beads.Bead, info sessionpkg.Info, sessFront *sessionpkg.Store, clk clock.Clock, agentIdentity string) map[string]string {
+	count, _ := strconv.Atoi(info.ChurnCount)
 
 	if session.Metadata == nil {
 		session.Metadata = make(map[string]string)
@@ -779,7 +824,7 @@ func recordChurn(session *beads.Bead, sessFront *sessionpkg.Store, clk clock.Clo
 	// conversation itself is the problem. A fresh conversation avoids
 	// re-hitting the same wall.
 	var merged map[string]string
-	if session.Metadata["session_key"] != "" {
+	if info.SessionKey != "" {
 		reset := sessionpkg.ConversationResetPatch(false)
 		_ = sessFront.ApplyPatch(session.ID, reset)
 		for k, v := range reset {
@@ -810,8 +855,8 @@ func recordChurn(session *beads.Bead, sessFront *sessionpkg.Store, clk clock.Clo
 // Returns the mirrored batch {"churn_count":"0"} when a clear is persisted, nil
 // when churn_count is already absent or zero (no-op). The caller folds the
 // returned batch onto the typed snapshot via ApplyPatch (nil is a no-op).
-func clearChurn(session *beads.Bead, sessFront *sessionpkg.Store) map[string]string {
-	if session.Metadata["churn_count"] == "" || session.Metadata["churn_count"] == "0" {
+func clearChurn(session *beads.Bead, info sessionpkg.Info, sessFront *sessionpkg.Store) map[string]string {
+	if info.ChurnCount == "" || info.ChurnCount == "0" {
 		return nil
 	}
 	_ = sessFront.SetMarker(session.ID, "churn_count", "0")
@@ -846,15 +891,49 @@ func stableLongEnough(session beads.Bead, clk clock.Clock) bool {
 	return clk.Now().Sub(t) >= stabilityThreshold
 }
 
+// productiveLongEnoughInfo is the session.Info sibling of productiveLongEnough,
+// reading info.LastWokeAt (the verbatim raw last_woke_at mirror) instead of raw
+// bead metadata. Equivalence-proven (TestSessionClassifierInfoEquivalence).
+func productiveLongEnoughInfo(info sessionpkg.Info, clk clock.Clock) bool {
+	lastWoke := info.LastWokeAt
+	if lastWoke == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, lastWoke)
+	if err != nil {
+		return false
+	}
+	return clk.Now().Sub(t) >= churnProductivityThreshold
+}
+
+// stableLongEnoughInfo is the session.Info sibling of stableLongEnough, reading
+// info.LastWokeAt (the verbatim raw last_woke_at mirror) instead of raw bead
+// metadata. Equivalence-proven (TestSessionClassifierInfoEquivalence).
+func stableLongEnoughInfo(info sessionpkg.Info, clk clock.Clock) bool {
+	lastWoke := info.LastWokeAt
+	if lastWoke == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, lastWoke)
+	if err != nil {
+		return false
+	}
+	return clk.Now().Sub(t) >= stabilityThreshold
+}
+
 // sessionWakeAttempts returns the current wake attempt count.
 func sessionWakeAttempts(session beads.Bead) int {
 	n, _ := strconv.Atoi(session.Metadata["wake_attempts"])
 	return n
 }
 
-// sessionWakeAttemptsInfo is the session.Info mirror of sessionWakeAttempts.
+// sessionWakeAttemptsInfo is the session.Info mirror of sessionWakeAttempts. It
+// parses the raw WakeAttemptsMetadata string (rather than returning the
+// pre-parsed i.WakeAttempts, which zeroes on strconv.ErrRange) so it stays
+// byte-identical to sessionWakeAttempts even for an out-of-range counter.
 func sessionWakeAttemptsInfo(i sessionpkg.Info) int {
-	return i.WakeAttempts
+	n, _ := strconv.Atoi(i.WakeAttemptsMetadata)
+	return n
 }
 
 // sessionIsQuarantined returns true if the session has an active quarantine.

--- a/cmd/gc/session_reconcile_ratelimit_test.go
+++ b/cmd/gc/session_reconcile_ratelimit_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/clock"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 // TestCheckStability_RateLimitScreen_DoesNotCountAsCrash pins the desired
@@ -47,7 +48,7 @@ func TestCheckStability_RateLimitScreen_DoesNotCountAsCrash(t *testing.T) {
 		return paneContent, nil
 	}
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
 		t.Fatal("checkStability should return true when it records a rate-limit hold")
 	}
 
@@ -107,7 +108,7 @@ func TestCheckStability_RateLimitPendingCreateClearsStartedAt(t *testing.T) {
 		return "You've hit your limit, Pro plan\n\n/rate-limit-options", nil
 	}
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
 		t.Fatal("checkStability should return true when it records a rate-limit hold")
 	}
 	if session.Metadata["pending_create_claim"] != "" {
@@ -135,7 +136,7 @@ func TestCheckRateLimitStability_BeforeHealPreservesResumeMetadata(t *testing.T)
 		return "You've hit your limit, Pro plan\n\n/rate-limit-options", nil
 	}
 
-	handled, _, err := checkRateLimitStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek)
+	handled, _, err := checkRateLimitStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek)
 	if err != nil {
 		t.Fatalf("recording rate-limit rapid exit: %v", err)
 	}
@@ -180,7 +181,7 @@ func TestCheckRateLimitStability_BatchFailureDoesNotClearLastWokeAt(t *testing.T
 		return "You've hit your limit, Pro plan\n\n/rate-limit-options", nil
 	}
 
-	handled, _, err := checkRateLimitStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek)
+	handled, _, err := checkRateLimitStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek)
 	if err == nil {
 		t.Fatal("rate-limit batch failure should be returned")
 	}
@@ -204,7 +205,7 @@ func TestCheckRateLimitStability_BatchFailureDoesNotClearLastWokeAt(t *testing.T
 	}
 
 	store.metadataBatchErr = nil
-	handled, _, err = checkRateLimitStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek)
+	handled, _, err = checkRateLimitStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek)
 	if err != nil {
 		t.Fatalf("retrying rate-limit detection: %v", err)
 	}
@@ -245,7 +246,7 @@ func TestCheckRateLimitStability_BatchFailureRetriesAfterStabilityThreshold(t *t
 		return "You've hit your limit, Pro plan\n\n/rate-limit-options", nil
 	}
 
-	handled, _, err := checkRateLimitStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek)
+	handled, _, err := checkRateLimitStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek)
 	if err == nil {
 		t.Fatal("initial failed batch should be returned")
 	}
@@ -255,7 +256,7 @@ func TestCheckRateLimitStability_BatchFailureRetriesAfterStabilityThreshold(t *t
 
 	clk.Time = now.Add(stabilityThreshold + time.Second)
 	store.metadataBatchErr = nil
-	handled, _, err = checkRateLimitStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek)
+	handled, _, err = checkRateLimitStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek)
 	if err != nil {
 		t.Fatalf("retrying after stability threshold: %v", err)
 	}
@@ -295,7 +296,7 @@ func TestCheckStability_RateLimitScreen_EmptyPaneStillCountsAsCrash(t *testing.T
 
 	peek := func(_ int) (string, error) { return "", nil }
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
 		t.Error("rapid exit with no rate-limit signature should report stability failure")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "1" {
@@ -318,7 +319,7 @@ func TestCheckStability_RateLimitScreen_NilPeekFallsBackToCrash(t *testing.T) {
 		"wake_attempts": "0",
 	})
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, nil); !stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, nil); !stab {
 		t.Error("rapid exit with nil peek should fall back to crash-counting behavior")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "1" {
@@ -341,7 +342,7 @@ func TestCheckStability_RateLimitScreen_PeekErrorFallsBackToCrash(t *testing.T) 
 		return "", errors.New("peek failed")
 	}
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
 		t.Error("rapid exit with peek error should fall back to crash-counting behavior")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "1" {
@@ -370,7 +371,7 @@ func TestCheckStability_TerminalErrorScreen_MarksTerminalNotCrash(t *testing.T) 
 		return "model_not_found: gpt-5.3-codex-spark", nil
 	}
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, peek); !stab {
 		t.Fatal("checkStability should return true when it records a terminal provider error")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "3" {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1050,7 +1050,7 @@ func TestHealExpiredTimers_ClearsExpiredHold(t *testing.T) {
 		"sleep_reason": "user-hold",
 	})
 
-	healExpiredTimers(&session, sessionFrontDoor(store), clk)
+	healExpiredTimers(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk)
 
 	if session.Metadata["held_until"] != "" {
 		t.Error("expected held_until to be cleared")
@@ -1071,7 +1071,7 @@ func TestHealExpiredTimers_KeepsActiveHold(t *testing.T) {
 		"sleep_reason": "user-hold",
 	})
 
-	healExpiredTimers(&session, sessionFrontDoor(store), clk)
+	healExpiredTimers(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk)
 
 	if session.Metadata["held_until"] != future {
 		t.Error("active hold should not be cleared")
@@ -1089,7 +1089,7 @@ func TestHealExpiredTimers_ClearsExpiredQuarantine(t *testing.T) {
 		"sleep_reason":      "quarantine",
 	})
 
-	healExpiredTimers(&session, sessionFrontDoor(store), clk)
+	healExpiredTimers(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk)
 
 	if session.Metadata["quarantined_until"] != "" {
 		t.Error("expected quarantined_until to be cleared")
@@ -1102,6 +1102,50 @@ func TestHealExpiredTimers_ClearsExpiredQuarantine(t *testing.T) {
 	}
 }
 
+// TestHealExpiredTimers_ExpiredHoldThenExpiredQuarantineSameCall pins the
+// COMBINED final metadata of a single healExpiredTimers call that clears both an
+// expired hold and an expired quarantine: held_until/quarantined_until cleared,
+// wake_attempts/churn_count reset, and the final sleep_reason. Written against
+// the raw implementation first; it must stay byte-identical through the
+// session.Info read conversion.
+//
+// The conversion adds an intra-call `info = info.ApplyPatch(batch)` fold between
+// the two blocks so the quarantine-clear block reads the post-hold sleep_reason
+// exactly as the raw session.Metadata read did. That fold is extensionally
+// unobservable today — ClearExpiredHoldPatch blanks sleep_reason only for
+// "user-hold", and ClearExpiredQuarantinePatch reacts only to
+// {quarantine,context-churn,rate-limit}, so the two sets do not overlap. This
+// test therefore guards the combined clear, and would only expose the fold's
+// effect if the patch helpers' sleep_reason sets later overlap.
+func TestHealExpiredTimers_ExpiredHoldThenExpiredQuarantineSameCall(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+
+	past := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	session := makeBead("b1", map[string]string{
+		"held_until":        past,
+		"quarantined_until": past,
+		"sleep_reason":      "user-hold",
+		"wake_attempts":     "4",
+		"churn_count":       "3",
+	})
+
+	healExpiredTimers(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk)
+
+	for _, tc := range []struct{ key, want string }{
+		{"held_until", ""},
+		{"quarantined_until", ""},
+		{"sleep_reason", ""},
+		{"wake_attempts", "0"},
+		{"churn_count", "0"},
+	} {
+		if got := session.Metadata[tc.key]; got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
 func TestCheckStability_AliveReturnsFalse(t *testing.T) {
 	clk := &clock.Fake{Time: time.Now()}
 	store := newTestStore()
@@ -1111,7 +1155,7 @@ func TestCheckStability_AliveReturnsFalse(t *testing.T) {
 		"last_woke_at": clk.Now().Add(-10 * time.Second).Format(time.RFC3339),
 	})
 
-	if stab, _ := checkStability(&session, nil, true, dt, sessionFrontDoor(store), clk, nil); stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, true, dt, sessionFrontDoor(store), clk, nil); stab {
 		t.Error("alive session should not report stability failure")
 	}
 }
@@ -1127,7 +1171,7 @@ func TestCheckStability_RapidExit(t *testing.T) {
 		"wake_attempts": "0",
 	})
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, nil); !stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, nil); !stab {
 		t.Error("rapid exit should report stability failure")
 	}
 
@@ -1153,7 +1197,7 @@ func TestCheckStability_PendingCreateInFlightNotCounted(t *testing.T) {
 		"wake_attempts":        "0",
 	})
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, nil); stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, nil); stab {
 		t.Fatal("in-flight pending create should not be counted as a rapid exit")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "0" {
@@ -1175,7 +1219,7 @@ func TestCheckStability_PendingCreateClaimNotCountedAfterStartupLeaseExpires(t *
 		"wake_attempts":        "0",
 	})
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, nil); stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, nil); stab {
 		t.Fatal("pending_create_claim should suppress stability counting until create recovery clears the claim")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "0" {
@@ -1194,7 +1238,7 @@ func TestCheckStability_DrainingNotCounted(t *testing.T) {
 		"last_woke_at": now.Add(-10 * time.Second).Format(time.RFC3339),
 	})
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, nil); stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, nil); stab {
 		t.Error("draining session death should not count as stability failure")
 	}
 }
@@ -1210,7 +1254,7 @@ func TestCheckStability_StableSession(t *testing.T) {
 		"last_woke_at": now.Add(-2 * time.Minute).Format(time.RFC3339),
 	})
 
-	if stab, _ := checkStability(&session, nil, false, dt, sessionFrontDoor(store), clk, nil); stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk, nil); stab {
 		t.Error("session that lived past threshold should not be stability failure")
 	}
 }
@@ -1229,7 +1273,7 @@ func TestCheckStability_SubprocessProviderSkipsCrashCounting(t *testing.T) {
 		"wake_attempts": "0",
 	})
 
-	if stab, _ := checkStability(&session, cfg, false, dt, sessionFrontDoor(store), clk, nil); stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), cfg, false, dt, sessionFrontDoor(store), clk, nil); stab {
 		t.Fatal("subprocess rapid exit should not be counted as a crash")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "0" {
@@ -1249,7 +1293,7 @@ func TestRecordWakeFailure_Quarantine(t *testing.T) {
 		"wake_attempts": "4", // one below threshold
 	})
 
-	recordWakeFailure(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+	recordWakeFailure(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 	if session.Metadata["wake_attempts"] != "5" {
 		t.Errorf("wake_attempts = %q, want 5", session.Metadata["wake_attempts"])
@@ -1271,7 +1315,7 @@ func TestRecordWakeFailure_BelowThreshold(t *testing.T) {
 		"wake_attempts": "1",
 	})
 
-	recordWakeFailure(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+	recordWakeFailure(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 	if session.Metadata["wake_attempts"] != "2" {
 		t.Errorf("wake_attempts = %q, want 2", session.Metadata["wake_attempts"])
@@ -1291,7 +1335,7 @@ func TestRecordWakeFailure_ClearsStartedConfigHash(t *testing.T) {
 		"started_config_hash": "abc123",
 	})
 
-	recordWakeFailure(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+	recordWakeFailure(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 	if session.Metadata["session_key"] != "" {
 		t.Errorf("session_key = %q, want empty", session.Metadata["session_key"])
@@ -1310,7 +1354,7 @@ func TestRecordWakeFailure_ClearsStartedConfigHashWhenSessionKeyAlreadyEmpty(t *
 		"started_config_hash": "abc123",
 	})
 
-	recordWakeFailure(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+	recordWakeFailure(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 	if session.Metadata["started_config_hash"] != "" {
 		t.Errorf("started_config_hash = %q, want empty", session.Metadata["started_config_hash"])
@@ -1328,7 +1372,7 @@ func TestClearWakeFailures(t *testing.T) {
 		"quarantined_until": "2026-03-08T12:00:00Z",
 	})
 
-	clearWakeFailures(&session, sessionFrontDoor(store))
+	clearWakeFailures(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store))
 
 	if session.Metadata["wake_attempts"] != "0" {
 		t.Errorf("wake_attempts = %q, want 0", session.Metadata["wake_attempts"])
@@ -1354,7 +1398,7 @@ func TestClearWakeFailuresSkipsNoOpClear(t *testing.T) {
 			store := newTestStore()
 			session := makeBead("b1", tt.metadata)
 
-			clearWakeFailures(&session, sessionFrontDoor(store))
+			clearWakeFailures(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store))
 
 			if store.metadataBatchCalls != 0 {
 				t.Fatalf("SetMetadataBatch called %d times with %v, want 0", store.metadataBatchCalls, store.metadataBatchPatches)
@@ -1394,7 +1438,7 @@ func TestClearWakeFailuresWritesOnlyChangedFields(t *testing.T) {
 			store := newTestStore()
 			session := makeBead("b1", tt.metadata)
 
-			clearWakeFailures(&session, sessionFrontDoor(store))
+			clearWakeFailures(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store))
 
 			if store.metadataBatchCalls != 1 {
 				t.Fatalf("SetMetadataBatch called %d times, want 1", store.metadataBatchCalls)
@@ -2197,7 +2241,7 @@ func TestCheckStability_RapidExitAfterHealStateKeepsStartedConfigHashCleared(t *
 	if session.Metadata["started_config_hash"] != "" {
 		t.Fatalf("healState started_config_hash = %q, want empty", session.Metadata["started_config_hash"])
 	}
-	if stab, _ := checkStability(&session, nil, false, nil, sessionFrontDoor(store), clk, nil); !stab {
+	if stab, _ := checkStability(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, nil, sessionFrontDoor(store), clk, nil); !stab {
 		t.Fatal("checkStability should record the rapid exit")
 	}
 	if session.Metadata["started_config_hash"] != "" {
@@ -2477,7 +2521,7 @@ func TestCheckChurn_AliveReturnsFalse(t *testing.T) {
 		"last_woke_at": now.Add(-90 * time.Second).Format(time.RFC3339),
 	})
 
-	if churn, _ := checkChurn(&session, nil, true, dt, sessionFrontDoor(store), clk); churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), nil, true, dt, sessionFrontDoor(store), clk); churn {
 		t.Error("alive session should not trigger churn")
 	}
 }
@@ -2495,7 +2539,7 @@ func TestCheckChurn_NonProductiveDeath(t *testing.T) {
 		"churn_count":  "0",
 	})
 
-	if churn, _ := checkChurn(&session, nil, false, dt, sessionFrontDoor(store), clk); !churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk); !churn {
 		t.Error("non-productive death should trigger churn")
 	}
 	if session.Metadata["churn_count"] != "1" {
@@ -2518,7 +2562,7 @@ func TestCheckChurn_RapidExitIgnored(t *testing.T) {
 		"last_woke_at": now.Add(-10 * time.Second).Format(time.RFC3339),
 	})
 
-	if churn, _ := checkChurn(&session, nil, false, dt, sessionFrontDoor(store), clk); churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk); churn {
 		t.Error("rapid exit should not trigger churn (handled by checkStability)")
 	}
 }
@@ -2534,7 +2578,7 @@ func TestCheckChurn_PendingCreateClaimNotCountedAfterStartupLeaseExpires(t *test
 		"churn_count":          "0",
 	})
 
-	if churn, _ := checkChurn(&session, nil, false, dt, sessionFrontDoor(store), clk); churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk); churn {
 		t.Fatal("pending_create_claim should suppress churn counting until create recovery clears the claim")
 	}
 	if got := session.Metadata["churn_count"]; got != "0" {
@@ -2553,7 +2597,7 @@ func TestCheckChurn_ProductiveSessionIgnored(t *testing.T) {
 		"last_woke_at": now.Add(-10 * time.Minute).Format(time.RFC3339),
 	})
 
-	if churn, _ := checkChurn(&session, nil, false, dt, sessionFrontDoor(store), clk); churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk); churn {
 		t.Error("productive session death should not trigger churn")
 	}
 }
@@ -2572,7 +2616,7 @@ func TestCheckChurn_DeadProductiveSessionClearsChurnCount(t *testing.T) {
 		"churn_count":  "2",
 	})
 
-	if churn, _ := checkChurn(&session, nil, false, dt, sessionFrontDoor(store), clk); churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk); churn {
 		t.Error("dead productive session should not trigger churn")
 	}
 	if session.Metadata["churn_count"] != "0" {
@@ -2594,7 +2638,7 @@ func TestCheckChurn_ClearedLastWokeAtSkipsChurn(t *testing.T) {
 		"churn_count":  "2",
 	})
 
-	if churn, _ := checkChurn(&session, nil, false, dt, sessionFrontDoor(store), clk); churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk); churn {
 		t.Error("session with cleared last_woke_at should not trigger churn")
 	}
 	if session.Metadata["churn_count"] != "2" {
@@ -2613,7 +2657,7 @@ func TestCheckChurn_DrainingNotCounted(t *testing.T) {
 		"last_woke_at": now.Add(-90 * time.Second).Format(time.RFC3339),
 	})
 
-	if churn, _ := checkChurn(&session, nil, false, dt, sessionFrontDoor(store), clk); churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), nil, false, dt, sessionFrontDoor(store), clk); churn {
 		t.Error("draining session death should not count as churn")
 	}
 }
@@ -2631,7 +2675,7 @@ func TestCheckChurn_SubprocessProviderSkipped(t *testing.T) {
 		"last_woke_at": now.Add(-90 * time.Second).Format(time.RFC3339),
 	})
 
-	if churn, _ := checkChurn(&session, cfg, false, dt, sessionFrontDoor(store), clk); churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), cfg, false, dt, sessionFrontDoor(store), clk); churn {
 		t.Error("subprocess sessions should not trigger churn")
 	}
 }
@@ -2650,7 +2694,7 @@ func TestCheckChurn_CityStopSleepReasonSkipped(t *testing.T) {
 		"continuation_reset_pending": "",
 	})
 
-	if churn, _ := checkChurn(&session, &config.City{}, false, dt, sessionFrontDoor(store), clk); churn {
+	if churn, _ := checkChurn(&session, sessionpkg.InfoFromPersistedBead(session), &config.City{}, false, dt, sessionFrontDoor(store), clk); churn {
 		t.Fatal("city-stop sessions should not trigger churn")
 	}
 	if got := session.Metadata["session_key"]; got != "resume-key" {
@@ -2676,7 +2720,7 @@ func TestRecordChurn_Quarantine(t *testing.T) {
 		"churn_count": "2", // one below threshold (defaultMaxChurnCycles=3)
 	})
 
-	recordChurn(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+	recordChurn(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 	if session.Metadata["churn_count"] != "3" {
 		t.Errorf("churn_count = %q, want 3", session.Metadata["churn_count"])
@@ -2698,7 +2742,7 @@ func TestRecordChurn_BelowThreshold(t *testing.T) {
 		"churn_count": "0",
 	})
 
-	recordChurn(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+	recordChurn(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 	if session.Metadata["churn_count"] != "1" {
 		t.Errorf("churn_count = %q, want 1", session.Metadata["churn_count"])
@@ -2718,7 +2762,7 @@ func TestRecordChurn_ClearsSessionKey(t *testing.T) {
 		"session_key": "old-key-123",
 	})
 
-	recordChurn(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+	recordChurn(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 	if session.Metadata["session_key"] != "" {
 		t.Error("session_key should be cleared on churn")
@@ -2735,7 +2779,7 @@ func TestClearChurn(t *testing.T) {
 		"churn_count": "2",
 	})
 
-	clearChurn(&session, sessionFrontDoor(store))
+	clearChurn(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store))
 
 	if session.Metadata["churn_count"] != "0" {
 		t.Errorf("churn_count = %q, want 0", session.Metadata["churn_count"])
@@ -2749,7 +2793,7 @@ func TestClearChurn_NoopWhenZero(t *testing.T) {
 		"churn_count": "0",
 	})
 
-	clearChurn(&session, sessionFrontDoor(store))
+	clearChurn(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store))
 
 	// Should not have written to store (no-op).
 	if _, ok := store.metadata["b1"]; ok {
@@ -2804,7 +2848,7 @@ func TestHealExpiredTimers_ClearsChurnOnQuarantineExpiry(t *testing.T) {
 		"sleep_reason":      "context-churn",
 	})
 
-	healExpiredTimers(&session, sessionFrontDoor(store), clk)
+	healExpiredTimers(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk)
 
 	if session.Metadata["quarantined_until"] != "" {
 		t.Error("quarantined_until should be cleared")

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1320,7 +1320,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	// Phase 0: Heal expired timers on all sessions.
 	phaseStart = time.Now()
 	for i := range sessions {
-		healExpiredTimers(&sessions[i], sessFront, clk)
+		// Phase 0 runs before the coherent infoByID snapshot exists (built at
+		// ~1421), so project this session's bead directly; healExpiredTimers keeps
+		// the raw mirror so that later snapshot build stays coherent.
+		healExpiredTimers(&sessions[i], sessionpkg.InfoFromPersistedBead(sessions[i]), sessFront, clk)
 	}
 	if cfg != nil {
 		bySessionName := make(map[string]beads.Bead, len(sessions))
@@ -1562,7 +1565,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						template = info.Template
 					}
 					peek := cachedSessionPeek(cityPath, store, sp, cfg, session.ID, nil)
-					rateLimitHit, rlBatch, rateLimitErr := checkRateLimitStability(session, cfg, providerAlive, dt, sessFront, clk, peek)
+					rateLimitHit, rlBatch, rateLimitErr := checkRateLimitStability(session, info, cfg, providerAlive, dt, sessFront, clk, peek)
 					if rateLimitHit || rateLimitErr != nil {
 						// Fold the rate-limit batch onto the snapshot (Step 6d write-returns-Info).
 						// Pre-pass-masked (STEP6-PREPASS-AUDIT group 1).
@@ -1619,7 +1622,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					obs, obsErr := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, session.ID, preservedTP.Hints.ProcessNames)
 					rateLimitAlive := rateLimitAliveFromObservation(obs.Alive, obsErr)
 					peek := cachedSessionPeek(cityPath, store, sp, cfg, session.ID, preservedTP.Hints.ProcessNames)
-					rateLimitHit, rlBatchNamed, rateLimitErr = checkRateLimitStability(session, cfg, rateLimitAlive, dt, sessFront, clk, peek)
+					rateLimitHit, rlBatchNamed, rateLimitErr = checkRateLimitStability(session, info, cfg, rateLimitAlive, dt, sessFront, clk, peek)
 				}
 			}
 			if rateLimitHit || rateLimitErr != nil {
@@ -2041,7 +2044,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				startupTimeout = cfg.Session.StartupTimeoutDuration()
 			}
 			if pendingCreateLeaseExpiredForRollbackInfo(infoPostZombie, clk, startupTimeout) {
-				rateLimitHit, rlBatch, rateLimitErr := checkRateLimitStability(session, cfg, alive, dt, sessFront, clk, peek)
+				rateLimitHit, rlBatch, rateLimitErr := checkRateLimitStability(session, infoPostZombie, cfg, alive, dt, sessFront, clk, peek)
 				if rateLimitHit || rateLimitErr != nil {
 					// Fold the rate-limit batch onto the snapshot (Step 6d write-returns-Info).
 					// Pre-pass-masked (STEP6-PREPASS-AUDIT group 1).
@@ -2387,7 +2390,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 		policy := resolveSessionSleepPolicy(*session, cfg, sp)
 
-		rateLimitHit, rlBatchFwd, rateLimitErr := checkRateLimitStability(session, cfg, alive, dt, sessFront, clk, peek)
+		rateLimitHit, rlBatchFwd, rateLimitErr := checkRateLimitStability(session, infoByID[session.ID], cfg, alive, dt, sessFront, clk, peek)
 		if rateLimitHit || rateLimitErr != nil {
 			// Fold the rate-limit batch onto the snapshot (Step 6d write-returns-Info).
 			// Pre-pass-masked (STEP6-PREPASS-AUDIT group 1).
@@ -2440,7 +2443,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// Fold the returned batch onto the snapshot (Step 6d write-returns-Info);
 		// nil (no-op) when no stability event was recorded.
 		// Pre-pass-masked (STEP6-PREPASS-AUDIT group 2).
-		if stab, stabBatch := checkStability(session, cfg, alive, dt, sessFront, clk, nil); stab {
+		if stab, stabBatch := checkStability(session, infoByID[session.ID], cfg, alive, dt, sessFront, clk, nil); stab {
 			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(stabBatch)
 			continue // rapid exit recorded, skip further processing
 		}
@@ -2452,7 +2455,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// Fold the returned batch onto the snapshot (Step 6d write-returns-Info)
 		// regardless of the bool — ExitProductiveDeath may clear churn_count.
 		// Pre-pass-masked (STEP6-PREPASS-AUDIT group 5).
-		churn, churnBatch := checkChurn(session, cfg, alive, dt, sessFront, clk)
+		churn, churnBatch := checkChurn(session, infoByID[session.ID], cfg, alive, dt, sessFront, clk)
 		infoByID[session.ID] = infoByID[session.ID].ApplyPatch(churnBatch)
 		if churn {
 			continue // churn recorded, skip further processing
@@ -2461,14 +2464,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// Clear wake failures for sessions that have been stable long enough.
 		// Fold the returned batch onto the snapshot (Step 6d write-returns-Info);
 		// nil (no-op) when nothing was cleared. Pre-pass-masked (STEP6-PREPASS-AUDIT group 5).
-		if alive && stableLongEnough(*session, clk) {
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(clearWakeFailures(session, sessFront))
+		if alive && stableLongEnoughInfo(infoByID[session.ID], clk) {
+			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(clearWakeFailures(session, infoByID[session.ID], sessFront))
 		}
 		// Clear churn counter for sessions that have been productive.
 		// Fold the returned batch onto the snapshot (Step 6d write-returns-Info);
 		// nil (no-op) when churn_count was already absent/zero. Pre-pass-masked (STEP6-PREPASS-AUDIT group 5).
-		if alive && productiveLongEnough(*session, clk) {
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(clearChurn(session, sessFront))
+		if alive && productiveLongEnoughInfo(infoByID[session.ID], clk) {
+			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(clearChurn(session, infoByID[session.ID], sessFront))
 		}
 		if alive && shouldRollbackPendingCreate(session) {
 			switch stateBeforeHeal {

--- a/cmd/gc/telemetry_lifecycle_metrics_test.go
+++ b/cmd/gc/telemetry_lifecycle_metrics_test.go
@@ -416,7 +416,7 @@ func TestRecordWakeFailure_QuarantineRecordsMetric(t *testing.T) {
 			"session_name":  "gascity--gc__worker",
 		})
 
-		recordWakeFailure(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+		recordWakeFailure(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 		if session.Metadata["quarantined_until"] == "" {
 			t.Fatal("fixture must quarantine at max attempts")
@@ -438,7 +438,7 @@ func TestRecordWakeFailure_QuarantineRecordsMetric(t *testing.T) {
 			"session_name":  "worker-1",
 		})
 
-		recordWakeFailure(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+		recordWakeFailure(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 		if session.Metadata["quarantined_until"] != "" {
 			t.Fatal("fixture must not quarantine below threshold")
@@ -457,7 +457,7 @@ func TestRecordWakeFailure_QuarantineRecordsMetric(t *testing.T) {
 			"session_name":  "gc-city-dog-1",
 		})
 
-		recordWakeFailure(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+		recordWakeFailure(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 		points := collectCounterDataPoints(t, reader, "gc.agent.quarantines.total")
 		if !hasDataPointWithStringAttrs(points, map[string]string{"agent": "dog-1"}) {
@@ -482,7 +482,7 @@ func TestRecordChurn_QuarantineRecordsMetric(t *testing.T) {
 		"session_name": "gascity--gc__worker",
 	})
 
-	recordChurn(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+	recordChurn(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 	if session.Metadata["quarantined_until"] == "" {
 		t.Fatal("fixture must quarantine at max churn cycles")
@@ -892,7 +892,7 @@ func TestRecordWakeFailure_QuarantineLegacyPooledIdentity(t *testing.T) {
 			"session_name":  "s-dog-3-legacy",
 		})
 
-		recordWakeFailure(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+		recordWakeFailure(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 		if session.Metadata["quarantined_until"] == "" {
 			t.Fatal("fixture must quarantine at max attempts")
@@ -919,7 +919,7 @@ func TestRecordWakeFailure_QuarantineLegacyPooledIdentity(t *testing.T) {
 			"session_name":  "s-fenrir-legacy",
 		})
 
-		recordWakeFailure(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, cfg))
+		recordWakeFailure(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, cfg))
 
 		if session.Metadata["quarantined_until"] == "" {
 			t.Fatal("fixture must quarantine at max attempts")
@@ -950,7 +950,7 @@ func TestRecordChurn_QuarantineLegacyPooledIdentity(t *testing.T) {
 			"session_name": "s-dog-3-legacy",
 		})
 
-		recordChurn(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
+		recordChurn(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, nil))
 
 		if session.Metadata["quarantined_until"] == "" {
 			t.Fatal("fixture must quarantine at max churn cycles")
@@ -977,7 +977,7 @@ func TestRecordChurn_QuarantineLegacyPooledIdentity(t *testing.T) {
 			"session_name": "s-wolf-legacy",
 		})
 
-		recordChurn(&session, sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, cfg))
+		recordChurn(&session, sessionpkg.InfoFromPersistedBead(session), sessionFrontDoor(store), clk, sessionAgentMetricIdentity(session, cfg))
 
 		if session.Metadata["quarantined_until"] == "" {
 			t.Fatal("fixture must quarantine at max churn cycles")

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -921,8 +921,8 @@ func TestLifecycleHighRiskWritersStayOnPatchHelpers(t *testing.T) {
 		{
 			file: "cmd/gc/session_reconcile.go",
 			required: []string{
-				`sessionpkg.ClearExpiredHoldPatch(session.Metadata["sleep_reason"])`,
-				`sessionpkg.ClearExpiredQuarantinePatch(session.Metadata["sleep_reason"])`,
+				`sessionpkg.ClearExpiredHoldPatch(info.SleepReason)`,
+				`sessionpkg.ClearExpiredQuarantinePatch(info.SleepReason)`,
 			},
 			forbidden: []string{
 				`batch := map[string]string{"held_until": ""}`,


### PR DESCRIPTION
## Summary

Migrates the reconciler's heal/health **decision reads** onto the coherent
`session.Info` snapshot the loop already holds, so the stability/churn/heal path
stops cracking raw session-bead metadata inline. The `session.Info` codec was
already complete (from O1/O2 + the reconciler simplification campaign), so this is
a pure read migration — **no codec/struct change**.

- 8 functions gained an `info session.Info` param and read `info.*`
  (`HeldUntil`/`QuarantinedUntil`/`SleepReason`/`WakeAttempts`/`SessionKey`/
  `StartedConfigHash`/`ChurnCount`/`LastWokeAt`) instead of `session.Metadata[...]`:
  `healExpiredTimers`, `checkStability`, `checkRateLimitStability`,
  `recordWakeFailure`, `checkChurn`, `recordChurn`, `clearWakeFailures`, `clearChurn`.
- Adds the `sessionExitFactsInfo` / `stableLongEnoughInfo` / `productiveLongEnoughInfo`
  Info siblings and extends the equivalence oracle (`reflect.DeepEqual` under
  `alive=false` **and** `alive=true`, a `rapid-crash-candidate` fixture asserted to
  hit `ExitRapidCrash`, and a `wake-attempts-overflow` fixture pinning the
  `strconv.ErrRange` counter lane).
- **Write path unchanged** — every write still goes through `sessFront.ApplyPatch`/`SetMarker`.

## Behavior preservation

Each migrated read decodes the exact same metadata key + default as the raw read
it replaced; counter parses use the raw metadata string (`WakeAttemptsMetadata`,
`ChurnCount`) so even `ErrRange`-corrupt input behaves identically to the old
`Atoi`. Caller coherence traced at every site (Phase-0 heal projects fresh
per-bead before the snapshot exists; the forward pass folds every intermediate
patch onto `infoByID` before each dependent read). `healExpiredTimers` folds the
hold-clear patch before the quarantine read to reproduce the old sequential
raw-read semantics.

> **Stacked PR** — final of the session-class adoption stack: O1 (#4055) → O2 (#4057) → **O4**.
> Based on `refactor/leak-opp2-session-info-adopt`; review/merge O1 and O2 first.

## Verification

- `go build ./...`, `go vet ./internal/session ./cmd/gc`, `gofmt` clean
- `TestSessionClassifierInfoEquivalence` (extended oracle) green; new
  `TestHealExpiredTimers_ExpiredHoldThenExpiredQuarantineSameCall` golden green
- `go test ./cmd/gc -run 'Stability|Churn|Heal|Reconcil|Session|Classifier|InfoEquiv|Lifecycle'` `ok 172s`; `go test ./internal/session` green (independently re-run)
- The `TestLifecycleHighRiskWritersStayOnPatchHelpers` guard still enforces patch-helper routing (only its pinned read-arg strings updated)
- Fable adversarial review: approve — all 8 migrations, caller coherence, guard intent, and write-path-unchanged independently re-verified; two nits applied (strict-equiv counter parse + doc reword)

Third/final slice of the session-class adoption stack. Refs `ga-sn2h7v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
