### PR TITLE
simplify(S26b): finish the typed trace surface (pool-cap rejection + remaining outcomes)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -371,11 +371,11 @@ func evaluatePendingPools(
 			}
 			evalResults[idx] = poolEvalResult{desired: d, err: err}
 			if trace != nil {
-				outcome := "success"
+				outcome := TraceOutcomeSuccess
 				if err != nil {
-					outcome = "failed"
+					outcome = TraceOutcomeFailed
 				}
-				trace.RecordOperation(TraceSiteScaleCheckExec, TraceReasonScaleCheck, TraceOutcomeCode(outcome), "", template, "", time.Since(started), traceRecordPayload{
+				trace.RecordOperation(TraceSiteScaleCheckExec, TraceReasonScaleCheck, outcome, "", template, "", time.Since(started), traceRecordPayload{
 					"pool_dir":       dir,
 					"command":        sp.Check,
 					"desired":        d,

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -459,7 +459,7 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, aliasHeldTempl
 		}
 		if site, reason, payload, rejected := usage.rejection(req, limits); rejected {
 			if trace != nil {
-				trace.RecordDecision(TraceSiteCode(site), TraceReasonCode(reason), TraceOutcomeRejected, template, "", payload)
+				trace.RecordDecision(site, reason, TraceOutcomeRejected, template, "", payload)
 			}
 			continue
 		}
@@ -634,10 +634,10 @@ func (u nestedCapUsage) isDuplicateSessionRequest(req SessionRequest) bool {
 	return req.SessionBeadID != "" && u.seenSessionBead[req.SessionBeadID]
 }
 
-func (u nestedCapUsage) rejection(req SessionRequest, limits nestedCapLimits) (string, string, traceRecordPayload, bool) {
+func (u nestedCapUsage) rejection(req SessionRequest, limits nestedCapLimits) (TraceSiteCode, TraceReasonCode, traceRecordPayload, bool) {
 	template := req.Template
 	if agentMax := limits.agentMax[template]; agentMax >= 0 && u.agentCount[template] >= agentMax {
-		return "reconciler.pool.agent_cap", "agent_cap", traceRecordPayload{
+		return TraceSitePoolAgentCap, TraceReasonAgentCap, traceRecordPayload{
 			"agent_max": agentMax,
 			"current":   u.agentCount[template],
 			"tier":      req.Tier,
@@ -650,7 +650,7 @@ func (u nestedCapUsage) rejection(req SessionRequest, limits nestedCapLimits) (s
 			rigMax = -1
 		}
 		if rigMax >= 0 && u.rigCount[rig] >= rigMax {
-			return "reconciler.pool.rig_cap", "rig_cap", traceRecordPayload{
+			return TraceSitePoolRigCap, TraceReasonRigCap, traceRecordPayload{
 				"rig":     rig,
 				"rig_max": rigMax,
 				"current": u.rigCount[rig],
@@ -659,7 +659,7 @@ func (u nestedCapUsage) rejection(req SessionRequest, limits nestedCapLimits) (s
 		}
 	}
 	if limits.workspaceMax >= 0 && u.workspaceCount >= limits.workspaceMax {
-		return "reconciler.pool.workspace_cap", "workspace_cap", traceRecordPayload{
+		return TraceSitePoolWorkspaceCap, TraceReasonWorkspaceCap, traceRecordPayload{
 			"workspace_max": limits.workspaceMax,
 			"current":       u.workspaceCount,
 			"tier":          req.Tier,
@@ -706,7 +706,7 @@ func recordNewDemandCapTrace(
 			blockingWork = append(blockingWork, req.WorkBeadID)
 		}
 	}
-	trace.RecordDecision(TraceSiteCode(site), TraceReasonCode(reason), TraceOutcomeRejected, template, "", traceRecordPayload{
+	trace.RecordDecision(site, reason, TraceOutcomeRejected, template, "", traceRecordPayload{
 		"scale_check":          scaleCount,
 		"accepted_new":         newCount,
 		"blocked_new":          scaleCount - newCount,
@@ -714,7 +714,7 @@ func recordNewDemandCapTrace(
 		"max":                  capMax,
 		"blocking_sessions":    blockingSessions,
 		"blocking_work_beads":  blockingWork,
-		"active_capacity_kind": reason,
+		"active_capacity_kind": string(reason),
 	})
 }
 
@@ -724,9 +724,9 @@ func newDemandBlockingScope(
 	limits nestedCapLimits,
 	usage nestedCapUsage,
 	newCount int,
-) (string, string, int, int, []SessionRequest) {
+) (TraceSiteCode, TraceReasonCode, int, int, []SessionRequest) {
 	if agentMax := limits.agentMax[template]; agentMax >= 0 && agentMax-usage.agentCount[template] <= newCount {
-		return string(TraceSitePoolNewDemandCap), string(TraceReasonAgentCap), agentMax, usage.agentCount[template], filterCapBlockers(usage.requests, func(req SessionRequest) bool {
+		return TraceSitePoolNewDemandCap, TraceReasonAgentCap, agentMax, usage.agentCount[template], filterCapBlockers(usage.requests, func(req SessionRequest) bool {
 			return req.Template == template
 		})
 	}
@@ -737,14 +737,14 @@ func newDemandBlockingScope(
 				rigMax = -1
 			}
 			if rigMax >= 0 && rigMax-usage.rigCount[rig] <= newCount {
-				return string(TraceSitePoolNewDemandCap), string(TraceReasonRigCap), rigMax, usage.rigCount[rig], filterCapBlockers(usage.requests, func(req SessionRequest) bool {
+				return TraceSitePoolNewDemandCap, TraceReasonRigCap, rigMax, usage.rigCount[rig], filterCapBlockers(usage.requests, func(req SessionRequest) bool {
 					return limits.agentRig[req.Template] == rig
 				})
 			}
 		}
 	}
 	if limits.workspaceMax >= 0 && limits.workspaceMax-usage.workspaceCount <= newCount {
-		return string(TraceSitePoolNewDemandCap), string(TraceReasonWorkspaceCap), limits.workspaceMax, usage.workspaceCount, usage.requests
+		return TraceSitePoolNewDemandCap, TraceReasonWorkspaceCap, limits.workspaceMax, usage.workspaceCount, usage.requests
 	}
 	return "", "", 0, 0, nil
 }

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -11,6 +11,77 @@ import (
 
 func intPtr(n int) *int { return &n }
 
+// TestNestedCapUsageRejectionTyped verifies that the retyped rejection producer
+// returns the typed site/reason constants for each cap kind, and that the
+// underlying string values are byte-identical to the pre-S26b literals.
+func TestNestedCapUsageRejectionTyped(t *testing.T) {
+	cases := []struct {
+		name       string
+		cfg        *config.City
+		wantSite   TraceSiteCode
+		wantReason TraceReasonCode
+		wantSiteS  string
+		wantRsnS   string
+	}{
+		{
+			name:       "agent_cap",
+			cfg:        &config.City{Agents: []config.Agent{poolAgent("claude", "rig", intPtr(1), 0)}},
+			wantSite:   TraceSitePoolAgentCap,
+			wantReason: TraceReasonAgentCap,
+			wantSiteS:  "reconciler.pool.agent_cap",
+			wantRsnS:   "agent_cap",
+		},
+		{
+			name: "rig_cap",
+			cfg: &config.City{
+				Rigs:   []config.Rig{{Name: "rig", Path: "/tmp/rig", MaxActiveSessions: intPtr(1)}},
+				Agents: []config.Agent{poolAgent("claude", "rig", intPtr(5), 0)},
+			},
+			wantSite:   TraceSitePoolRigCap,
+			wantReason: TraceReasonRigCap,
+			wantSiteS:  "reconciler.pool.rig_cap",
+			wantRsnS:   "rig_cap",
+		},
+		{
+			name: "workspace_cap",
+			cfg: &config.City{
+				Workspace: config.Workspace{MaxActiveSessions: intPtr(1)},
+				Agents:    []config.Agent{poolAgent("claude", "", intPtr(5), 0)},
+			},
+			wantSite:   TraceSitePoolWorkspaceCap,
+			wantReason: TraceReasonWorkspaceCap,
+			wantSiteS:  "reconciler.pool.workspace_cap",
+			wantRsnS:   "workspace_cap",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			limits := newNestedCapLimits(tc.cfg)
+			usage := newNestedCapUsage()
+			template := tc.cfg.Agents[0].QualifiedName()
+			// Fill to the cap so the next request is rejected.
+			usage.accept(SessionRequest{Template: template, Tier: "new"}, limits)
+
+			site, reason, _, rejected := usage.rejection(SessionRequest{Template: template, Tier: "new"}, limits)
+			if !rejected {
+				t.Fatalf("expected rejection at cap")
+			}
+			if site != tc.wantSite {
+				t.Errorf("site = %q, want %q", site, tc.wantSite)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+			if string(site) != tc.wantSiteS {
+				t.Errorf("string(site) = %q, want legacy literal %q", string(site), tc.wantSiteS)
+			}
+			if string(reason) != tc.wantRsnS {
+				t.Errorf("string(reason) = %q, want legacy literal %q", string(reason), tc.wantRsnS)
+			}
+		})
+	}
+}
+
 func workBead(id, routedTo, assignee, status string, priority int) beads.Bead {
 	p := priority
 	return beads.Bead{

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -198,7 +198,7 @@ type preparedStart struct {
 type startResult struct {
 	prepared        preparedStart
 	err             error
-	outcome         string
+	outcome         TraceOutcomeCode
 	started         time.Time
 	finished        time.Time
 	rollbackPending bool
@@ -1225,7 +1225,7 @@ func runPreparedStartCandidate(
 			result = startResult{
 				prepared: item,
 				err:      fmt.Errorf("panic during start: %v\n%s", recovered, stack),
-				outcome:  "panic_recovered",
+				outcome:  TraceOutcomePanicRecovered,
 				started:  started,
 				finished: time.Now(),
 			}
@@ -1291,47 +1291,47 @@ func runPreparedStartCandidate(
 		return startResult{
 			prepared:        item,
 			err:             nil,
-			outcome:         "start_error_converged",
+			outcome:         TraceOutcomeStartErrorConverged,
 			started:         started,
 			finished:        finished,
 			rollbackPending: false,
 			phases:          phases,
 		}
 	}
-	var outcome string
+	var outcome TraceOutcomeCode
 	switch {
 	case errors.Is(err, runtime.ErrSessionInitializing):
-		outcome = "session_initializing"
+		outcome = TraceOutcomeSessionInitializing
 		err = nil
 	case startCtxErr == context.DeadlineExceeded:
-		outcome = "deadline_exceeded"
+		outcome = TraceOutcomeDeadlineExceeded
 		if err == nil {
 			err = fmt.Errorf("session %q startup: %w", item.candidate.name(), context.DeadlineExceeded)
 		}
 	case startCtxErr == context.Canceled:
-		outcome = "canceled"
+		outcome = TraceOutcomeCanceled
 		if err == nil {
 			err = fmt.Errorf("session %q startup: %w", item.candidate.name(), context.Canceled)
 		}
 	case err == nil:
-		outcome = "success"
+		outcome = TraceOutcomeSuccess
 	case errors.Is(err, runtime.ErrSessionExists):
 		obs, runningErr := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, item.candidate.name(), item.cfg.ProcessNames)
 		switch {
 		case runningErr != nil || !runtimeObservationLive(obs):
-			outcome = "provider_error"
+			outcome = TraceOutcomeProviderError
 		case rollbackPending && !rateLimitScreen && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp):
-			outcome = "session_exists_converged"
+			outcome = TraceOutcomeSessionExistsConverged
 			err = nil
 			rollbackPending = false
 		case rollbackPending:
-			outcome = "session_exists"
+			outcome = TraceOutcomeSessionExists
 		default:
-			outcome = "session_exists"
+			outcome = TraceOutcomeSessionExists
 			err = nil
 		}
 	default:
-		outcome = "provider_error"
+		outcome = TraceOutcomeProviderError
 	}
 	if err == nil {
 		rateLimitScreen = false
@@ -1420,7 +1420,7 @@ func enqueuePreparedStartWaveForCity(
 		now := time.Now()
 		results[i] = startResult{
 			prepared: item,
-			outcome:  "start_enqueued",
+			outcome:  TraceOutcomeStartEnqueued,
 			started:  now,
 			finished: now,
 		}
@@ -1509,7 +1509,7 @@ func commitAsyncStartResultWithContext(
 	}
 	if refreshed.err != nil && refreshed.rollbackPending && runningSessionMatchesPendingCreate(refreshed.prepared.candidate.session, refreshed.prepared.candidate.name(), sp) {
 		refreshed.err = nil
-		refreshed.outcome = "session_exists_converged"
+		refreshed.outcome = TraceOutcomeSessionExistsConverged
 		refreshed.rollbackPending = false
 	}
 	if ctx != nil && ctx.Err() != nil {
@@ -1523,7 +1523,7 @@ func commitAsyncStartResultWithContext(
 		logLifecycleOutcome(stderr, "start", wave, name, template, "context_canceled", refreshed.started, time.Now(), ctx.Err(), refreshed.phases)
 		return false
 	}
-	if sp != nil && refreshed.err == nil && refreshed.outcome != "session_initializing" {
+	if sp != nil && refreshed.err == nil && refreshed.outcome != TraceOutcomeSessionInitializing {
 		_ = clearReconcilerDrainAckMetadata(sp, refreshed.prepared.candidate.name())
 	}
 	return commitStartResultTraced(refreshed, sessFront, clk, rec, wave, stdout, stderr, trace)
@@ -1919,9 +1919,9 @@ func commitStartResultTraced(
 	tp := result.prepared.candidate.tp
 	// Session still starting up — back off silently without recording failure.
 	// The reconciler will retry on the next patrol tick.
-	if result.outcome == "session_initializing" {
+	if result.outcome == TraceOutcomeSessionInitializing {
 		clearPendingStartInFlightLease(session, sessFront, stderr)
-		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil, result.phases)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, nil, result.phases)
 		return false
 	}
 	if result.err != nil {
@@ -2028,7 +2028,7 @@ func commitStartResultTraced(
 			"field":    "started_config_hash",
 		})
 	}
-	logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil, result.phases)
+	logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, nil, result.phases)
 	return true
 }
 
@@ -2047,7 +2047,7 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 			fmt.Fprintf(stderr, "session reconciler: marking terminal provider error for %s: %v\n", name, err) //nolint:errcheck
 		}
 		if trace != nil {
-			trace.RecordOperation(TraceSiteLifecycleStartTerminalProviderError, TraceReasonStart, TraceOutcomeCode(result.outcome), "", tp.TemplateName, name, 0, traceRecordPayload{
+			trace.RecordOperation(TraceSiteLifecycleStartTerminalProviderError, TraceReasonStart, result.outcome, "", tp.TemplateName, name, 0, traceRecordPayload{
 				"error":  formatLifecycleError(result.err),
 				"reason": reason,
 			})
@@ -2055,7 +2055,7 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 		if result.rollbackPending {
 			rollbackPendingCreate(session, sessFront, clk.Now().UTC(), stderr)
 		}
-		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, result.err, result.phases)
 		return
 	}
 	if result.rateLimitScreen {
@@ -2067,7 +2067,7 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 					"cause": err.Error(),
 				})
 			}
-			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
+			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, result.err, result.phases)
 			return
 		}
 		if trace != nil {
@@ -2075,7 +2075,7 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 				"error": formatLifecycleError(result.err),
 			})
 		}
-		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, result.err, result.phases)
 		return
 	}
 	if result.rollbackPending {
@@ -2093,12 +2093,12 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 		// Genuine wake-failure accounting happens on the non-rollback path
 		// below via recordWakeFailure.
 		if trace != nil {
-			trace.RecordOperation(TraceSiteLifecycleStartRollback, TraceReasonStart, TraceOutcomeCode(result.outcome), "", tp.TemplateName, name, 0, traceRecordPayload{
+			trace.RecordOperation(TraceSiteLifecycleStartRollback, TraceReasonStart, result.outcome, "", tp.TemplateName, name, 0, traceRecordPayload{
 				"error": formatLifecycleError(result.err),
 			})
 		}
 		rollbackPendingCreate(session, sessFront, clk.Now().UTC(), stderr)
-		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, result.err, result.phases)
 		return
 	}
 	if err := sessFront.SetMarker(session.ID, "last_woke_at", ""); err != nil {
@@ -2111,11 +2111,11 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 	// even for a namepool-themed pool instance whose bead predates agent_name.
 	recordWakeFailure(session, sessFront, clk, tp.DisplayName())
 	if trace != nil {
-		trace.RecordOperation(TraceSiteLifecycleStartFailed, TraceReasonStart, TraceOutcomeCode(result.outcome), "", tp.TemplateName, name, 0, traceRecordPayload{
+		trace.RecordOperation(TraceSiteLifecycleStartFailed, TraceReasonStart, result.outcome, "", tp.TemplateName, name, 0, traceRecordPayload{
 			"error": formatLifecycleError(result.err),
 		})
 	}
-	logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
+	logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, result.err, result.phases)
 }
 
 // recoverRunningPendingCreate heals an already-active bead whose
@@ -2589,17 +2589,17 @@ func executePlannedStartsTraced(
 			}
 			for _, result := range results {
 				if trace != nil {
-					trace.RecordOperation(TraceSiteLifecycleStartRun, TraceReasonStart, TraceOutcomeCode(result.outcome), "", result.prepared.candidate.tp.TemplateName, result.prepared.candidate.name(), result.finished.Sub(result.started), traceRecordPayload{
+					trace.RecordOperation(TraceSiteLifecycleStartRun, TraceReasonStart, result.outcome, "", result.prepared.candidate.tp.TemplateName, result.prepared.candidate.name(), result.finished.Sub(result.started), traceRecordPayload{
 						"rollback_pending": result.rollbackPending,
 						"duration_ms":      result.finished.Sub(result.started).Milliseconds(),
 					})
 				}
-				if result.outcome == "start_enqueued" {
-					logLifecycleOutcome(stderr, "start", wave, result.prepared.candidate.name(), result.prepared.candidate.logicalTemplate(cfg), result.outcome, result.started, result.finished, nil)
+				if result.outcome == TraceOutcomeStartEnqueued {
+					logLifecycleOutcome(stderr, "start", wave, result.prepared.candidate.name(), result.prepared.candidate.logicalTemplate(cfg), string(result.outcome), result.started, result.finished, nil)
 					wakeCount++
 					continue
 				}
-				if result.err == nil && result.outcome != "session_initializing" {
+				if result.err == nil && result.outcome != TraceOutcomeSessionInitializing {
 					_ = clearReconcilerDrainAckMetadata(sp, result.prepared.candidate.name())
 				}
 				if commitStartResultTraced(result, sessFront, clk, rec, wave, stdout, stderr, trace) {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -71,6 +71,52 @@ func isDrainAckStopPending(session beads.Bead) bool {
 		strings.TrimSpace(session.Metadata["state_reason"]) == sessionpkg.DrainAckStopPendingReason
 }
 
+// timerTraceCodes maps a lifecycle-timer decision's trace reason/outcome onto
+// the typed Trace*Code vocabulary. TimerDecision.TraceReason/TraceOutcome are
+// plain strings owned by internal/session (Layer 0-1), which cannot import the
+// cmd/gc trace types — so the conversion lives here at the projection boundary.
+// The switches are exhaustive over the closed value sets that
+// DecideMaxSessionAge and DecideIdleTimeout emit today; each default arm is an
+// identity passthrough, so recorded bytes stay truthful even if a ladder grows
+// a value before this map does. TestTimerTraceCodesTotal converts that drift
+// into a red test rather than a silent un-typing.
+func timerTraceCodes(dec sessionpkg.TimerDecision) (TraceReasonCode, TraceOutcomeCode) {
+	var reason TraceReasonCode
+	switch dec.TraceReason {
+	case string(TraceReasonMaxSessionAge):
+		reason = TraceReasonMaxSessionAge
+	case string(TraceReasonIdleTimeout):
+		reason = TraceReasonIdleTimeout
+	case string(TraceReasonUserHold):
+		reason = TraceReasonUserHold
+	case string(TraceReasonQuarantine):
+		reason = TraceReasonQuarantine
+	case string(TraceReasonPending):
+		reason = TraceReasonPending
+	case string(TraceReasonAssignedWork):
+		reason = TraceReasonAssignedWork
+	default:
+		reason = TraceReasonCode(dec.TraceReason)
+	}
+
+	var outcome TraceOutcomeCode
+	switch dec.TraceOutcome {
+	case string(TraceOutcomeStop):
+		outcome = TraceOutcomeStop
+	case string(TraceOutcomeDeferredUserHold):
+		outcome = TraceOutcomeDeferredUserHold
+	case string(TraceOutcomeDeferredQuarantine):
+		outcome = TraceOutcomeDeferredQuarantine
+	case string(TraceOutcomeDeferredPending):
+		outcome = TraceOutcomeDeferredPending
+	case string(TraceOutcomeDeferredBusy):
+		outcome = TraceOutcomeDeferredBusy
+	default:
+		outcome = TraceOutcomeCode(dec.TraceOutcome)
+	}
+	return reason, outcome
+}
+
 // isDrainAckStopPendingInfo is the session.Info sibling of isDrainAckStopPending:
 // it reports whether a session is parked in the drain-ack stop-pending state from
 // the typed Info.MetadataState (raw "state") / Info.StateReason mirrors, with the
@@ -1628,11 +1674,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if template == "" {
 						template = info.Template
 					}
-					result := "held"
+					result := TraceOutcomeHeld
 					if rateLimitErr != nil {
-						result = "hold_deferred"
+						result = TraceOutcomeHoldDeferred
 					}
-					trace.RecordDecision(TraceSiteReconcilerPreserveConfiguredNamed, TraceReasonRateLimit, TraceOutcomeCode(result), template, name, traceRecordPayload{
+					trace.RecordDecision(TraceSiteReconcilerPreserveConfiguredNamed, TraceReasonRateLimit, result, template, name, traceRecordPayload{
 						"provider_alive": providerAlive,
 					})
 				}
@@ -1742,10 +1788,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					desired = true
 				}
 				if trace != nil {
-					trace.RecordDecision(TraceSiteReconcilerPreserveConfiguredNamed, TraceReasonPreserve, TraceOutcomeCode(map[bool]string{
-						true:  "kept_open",
-						false: "resolution_failed",
-					}[desired]), template, name, traceRecordPayload{
+					outcome := TraceOutcomeResolutionFailed
+					if desired {
+						outcome = TraceOutcomeKeptOpen
+					}
+					trace.RecordDecision(TraceSiteReconcilerPreserveConfiguredNamed, TraceReasonPreserve, outcome, template, name, traceRecordPayload{
 						"provider_alive": providerAlive,
 						"degraded":       preserveErr != nil,
 					})
@@ -2895,12 +2942,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				// by wake evaluation: bypass the max-age restart so SleepPatch
 				// does not rewrite the intended sleep state.
 				if trace != nil {
-					trace.RecordDecision(TraceSiteReconcilerMaxSessionAge, TraceReasonCode(dec.TraceReason), TraceOutcomeCode(dec.TraceOutcome), tp.TemplateName, name, nil)
+					reason, outcome := timerTraceCodes(dec)
+					trace.RecordDecision(TraceSiteReconcilerMaxSessionAge, reason, outcome, tp.TemplateName, name, nil)
 				}
 			case sessionpkg.TimerActionStop:
 				fmt.Fprintf(stderr, "session reconciler: preemptive max-age restart for %s (age=%s)\n", tp.DisplayName(), clk.Now().Sub(creationCompleteAt).Round(time.Second)) //nolint:errcheck // best-effort stderr
 				if trace != nil {
-					trace.RecordDecision(TraceSiteReconcilerMaxSessionAge, TraceReasonCode(dec.TraceReason), TraceOutcomeCode(dec.TraceOutcome), tp.TemplateName, name, nil)
+					reason, outcome := timerTraceCodes(dec)
+					trace.RecordDecision(TraceSiteReconcilerMaxSessionAge, reason, outcome, tp.TemplateName, name, nil)
 				}
 				if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
 					fmt.Fprintf(stderr, "session reconciler: stopping aged %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
@@ -2976,7 +3025,8 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					payload = traceRecordPayload{"drain_canceled": drainCancelled}
 				}
 				if trace != nil {
-					trace.RecordDecision(TraceSiteReconcilerIdleTimeout, TraceReasonCode(dec.TraceReason), TraceOutcomeCode(dec.TraceOutcome), tp.TemplateName, name, payload)
+					reason, outcome := timerTraceCodes(dec)
+					trace.RecordDecision(TraceSiteReconcilerIdleTimeout, reason, outcome, tp.TemplateName, name, payload)
 				}
 				if dec.SkipWakePass {
 					continue
@@ -2984,7 +3034,8 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			case sessionpkg.TimerActionStop:
 				fmt.Fprintf(stderr, "session reconciler: idle timeout for %s\n", tp.DisplayName()) //nolint:errcheck // best-effort stderr
 				if trace != nil {
-					trace.RecordDecision(TraceSiteReconcilerIdleTimeout, TraceReasonCode(dec.TraceReason), TraceOutcomeCode(dec.TraceOutcome), tp.TemplateName, name, nil)
+					reason, outcome := timerTraceCodes(dec)
+					trace.RecordDecision(TraceSiteReconcilerIdleTimeout, reason, outcome, tp.TemplateName, name, nil)
 				}
 				if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
 					fmt.Fprintf(stderr, "session reconciler: stopping idle %s: %v\n", name, err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/session_reconciler_timer_trace_test.go
+++ b/cmd/gc/session_reconciler_timer_trace_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// TestTimerTraceCodesTotal drives every reachable TimerDecision from
+// DecideMaxSessionAge and DecideIdleTimeout (all TimerFacts combinations,
+// including both blocker kinds) and asserts that timerTraceCodes (a) maps each
+// traced reason/outcome onto a NAMED constant — never falling through to the
+// identity default arm — and (b) round-trips to the exact producer strings.
+// When the timer ladders grow a new traced value, this test goes red instead
+// of silently un-typing the vocabulary.
+func TestTimerTraceCodesTotal(t *testing.T) {
+	namedReasons := map[TraceReasonCode]bool{
+		TraceReasonMaxSessionAge: true,
+		TraceReasonIdleTimeout:   true,
+		TraceReasonUserHold:      true,
+		TraceReasonQuarantine:    true,
+		TraceReasonPending:       true,
+		TraceReasonAssignedWork:  true,
+	}
+	namedOutcomes := map[TraceOutcomeCode]bool{
+		TraceOutcomeStop:               true,
+		TraceOutcomeDeferredUserHold:   true,
+		TraceOutcomeDeferredQuarantine: true,
+		TraceOutcomeDeferredPending:    true,
+		TraceOutcomeDeferredBusy:       true,
+	}
+
+	blockers := []string{"", "user_hold", "quarantine"}
+	pendings := []sessionpkg.PendingFact{
+		sessionpkg.PendingUnknown, sessionpkg.PendingNo, sessionpkg.PendingYes,
+	}
+	assigned := []sessionpkg.AssignedWorkFact{
+		sessionpkg.AssignedWorkUnknown, sessionpkg.AssignedWorkNone, sessionpkg.AssignedWorkHas,
+	}
+
+	var decisions []sessionpkg.TimerDecision
+	for _, b := range blockers {
+		for _, p := range pendings {
+			for _, a := range assigned {
+				facts := sessionpkg.TimerFacts{Triggered: true, Blocker: b, Pending: p, AssignedWork: a}
+				decisions = append(decisions, sessionpkg.DecideMaxSessionAge(facts))
+				decisions = append(decisions, sessionpkg.DecideIdleTimeout(facts))
+			}
+		}
+	}
+
+	sawTraced := false
+	for _, dec := range decisions {
+		// Only Defer/Stop decisions carry trace codes and reach a
+		// RecordDecision call site; gather/none actions leave them empty.
+		if dec.Action != sessionpkg.TimerActionDefer && dec.Action != sessionpkg.TimerActionStop {
+			continue
+		}
+		sawTraced = true
+		reason, outcome := timerTraceCodes(dec)
+		if string(reason) != dec.TraceReason {
+			t.Errorf("reason round-trip: got %q, want %q", string(reason), dec.TraceReason)
+		}
+		if string(outcome) != dec.TraceOutcome {
+			t.Errorf("outcome round-trip: got %q, want %q", string(outcome), dec.TraceOutcome)
+		}
+		if !namedReasons[reason] {
+			t.Errorf("reason %q fell through to the identity default arm (unnamed vocabulary)", string(reason))
+		}
+		if !namedOutcomes[outcome] {
+			t.Errorf("outcome %q fell through to the identity default arm (unnamed vocabulary)", string(outcome))
+		}
+	}
+	if !sawTraced {
+		t.Fatal("no traced TimerDecision exercised — enumeration is broken")
+	}
+}

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -190,6 +190,10 @@ const (
 	TraceReasonFreshCycle                    TraceReasonCode = "fresh_cycle"
 	TraceReasonScaleCheck                    TraceReasonCode = "scale_check"
 	TraceReasonStart                         TraceReasonCode = "start"
+
+	TraceReasonMaxSessionAge TraceReasonCode = "max_session_age"
+	TraceReasonUserHold      TraceReasonCode = "user_hold"
+	TraceReasonQuarantine    TraceReasonCode = "quarantine"
 )
 
 type TraceOutcomeCode string
@@ -258,6 +262,14 @@ const (
 	TraceOutcomeHoldDeferred        TraceOutcomeCode = "hold_deferred"
 	TraceOutcomeHeld                TraceOutcomeCode = "held"
 	TraceOutcomeHealed              TraceOutcomeCode = "healed"
+
+	TraceOutcomeResolutionFailed    TraceOutcomeCode = "resolution_failed"
+	TraceOutcomeStartErrorConverged TraceOutcomeCode = "start_error_converged"
+	TraceOutcomeSessionInitializing TraceOutcomeCode = "session_initializing"
+	TraceOutcomeStartEnqueued       TraceOutcomeCode = "start_enqueued"
+	TraceOutcomeDeferredUserHold    TraceOutcomeCode = "deferred_user_hold"
+	TraceOutcomeDeferredQuarantine  TraceOutcomeCode = "deferred_quarantine"
+	TraceOutcomeDeferredBusy        TraceOutcomeCode = "deferred_busy"
 )
 
 type TraceCompletionStatus string

--- a/cmd/gc/session_reconciler_trace_types_test.go
+++ b/cmd/gc/session_reconciler_trace_types_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+// TestTraceCodeConstantValues pins every trace-code constant added by S26b to
+// its exact recorded string. A typo here would silently change the bytes that
+// land in the trace JSONL (site_code/reason_code/outcome_code) — this test is
+// the guard against that class of corruption.
+func TestTraceCodeConstantValues(t *testing.T) {
+	reasons := map[TraceReasonCode]string{
+		TraceReasonMaxSessionAge: "max_session_age",
+		TraceReasonUserHold:      "user_hold",
+		TraceReasonQuarantine:    "quarantine",
+	}
+	for got, want := range reasons {
+		if string(got) != want {
+			t.Errorf("reason constant = %q, want %q", string(got), want)
+		}
+	}
+
+	outcomes := map[TraceOutcomeCode]string{
+		TraceOutcomeResolutionFailed:    "resolution_failed",
+		TraceOutcomeStartErrorConverged: "start_error_converged",
+		TraceOutcomeSessionInitializing: "session_initializing",
+		TraceOutcomeStartEnqueued:       "start_enqueued",
+		TraceOutcomeDeferredUserHold:    "deferred_user_hold",
+		TraceOutcomeDeferredQuarantine:  "deferred_quarantine",
+		TraceOutcomeDeferredBusy:        "deferred_busy",
+	}
+	for got, want := range outcomes {
+		if string(got) != want {
+			t.Errorf("outcome constant = %q, want %q", string(got), want)
+		}
+	}
+}

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -629,20 +629,20 @@ func advanceSessionDrainsWithSessionsTraced(
 				ds.followUp = true
 			}
 			if trace != nil {
-				outcome := "success"
+				outcome := TraceOutcomeSuccess
 				fields := traceRecordPayload{
 					"reason":          ds.reason,
 					"deferred_signal": true,
 				}
 				if err != nil {
-					outcome = "failed"
+					outcome = TraceOutcomeFailed
 					fields["error"] = err.Error()
 				}
 				fields["template"] = normalizedSessionTemplateInfo(info, cfg)
 				fields["before"] = ""
 				fields["after"] = "1"
 				fields["field"] = "GC_DRAIN_ACK"
-				trace.RecordMutation(TraceSiteMutationRuntimeMeta, TraceReasonUnknown, TraceOutcomeCode(outcome), "provider_meta", name, "GC_DRAIN_ACK", fields)
+				trace.RecordMutation(TraceSiteMutationRuntimeMeta, TraceReasonUnknown, outcome, "provider_meta", name, "GC_DRAIN_ACK", fields)
 			}
 		}
 


### PR DESCRIPTION
Follow-on to merged S26 (#4036): closes the last stringly trace outcomes by finishing the typed trace surface (pool-cap rejection + remaining outcomes). Part of #3789. Gates green; Fable-reviewed, behavior-preserved. Spec at engdocs/simplification/specs/S26b-finish-typed-trace-spec.md. Spike/staged for review, not auto-merge.