### PR TITLE
simplify(S09b): table-driven Info codec + cmd/gc sleep-reason migration

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 type sweepLivenessProvider struct {
@@ -771,8 +772,8 @@ func TestCityRuntimeShutdownMarksCityStopSleepReason(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.Metadata["sleep_reason"] != sleepReasonCityStop {
-		t.Fatalf("sleep_reason = %q, want %q", got.Metadata["sleep_reason"], sleepReasonCityStop)
+	if got.Metadata["sleep_reason"] != string(sessionpkg.SleepReasonCityStop) {
+		t.Fatalf("sleep_reason = %q, want %q", got.Metadata["sleep_reason"], string(sessionpkg.SleepReasonCityStop))
 	}
 }
 

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -54,8 +54,6 @@ straight to kill.`,
 
 var sessionProviderForStopCity = newSessionProviderForCity
 
-const sleepReasonCityStop = "city-stop"
-
 // cmdStop stops the city by terminating all configured agent sessions.
 // If a path is given, operates there; otherwise uses cwd.
 //
@@ -366,7 +364,7 @@ func markCityStopSessionSleepReason(sessFront *session.Store, stderr io.Writer) 
 		if strings.TrimSpace(s.Metadata["sleep_reason"]) != "" {
 			continue
 		}
-		if err := sessFront.SetMarker(s.ID, "sleep_reason", sleepReasonCityStop); err != nil {
+		if err := sessFront.SetMarker(s.ID, "sleep_reason", string(session.SleepReasonCityStop)); err != nil {
 			fmt.Fprintf(stderr, "gc stop: marking session %s: %v\n", s.ID, err) //nolint:errcheck // best-effort warning
 		}
 	}

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 type recordingStopProvider struct {
@@ -921,8 +922,8 @@ func TestMarkCityStopSessionSleepReasonSkipsCreatingSessions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := activeUpdated.Metadata["sleep_reason"]; got != sleepReasonCityStop {
-		t.Fatalf("active sleep_reason = %q, want %q", got, sleepReasonCityStop)
+	if got := activeUpdated.Metadata["sleep_reason"]; got != string(sessionpkg.SleepReasonCityStop) {
+		t.Fatalf("active sleep_reason = %q, want %q", got, string(sessionpkg.SleepReasonCityStop))
 	}
 	creatingUpdated, err := store.Get(creating.ID)
 	if err != nil {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -1346,7 +1346,7 @@ func clearSessionWaitHold(sessFront *sessionpkg.Store, sessionID string) error {
 		"sleep_intent": "",
 	}
 	if sessFront != nil {
-		if markers, err := sessFront.PersistedMarkers(sessionID); err == nil && markers.SleepReason == "wait-hold" {
+		if markers, err := sessFront.PersistedMarkers(sessionID); err == nil && markers.SleepReason == string(sessionpkg.SleepReasonWaitHold) {
 			batch["sleep_reason"] = ""
 		}
 	}

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -430,7 +430,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// Drain-ack agents are unaffected — they manage their own
 		// lifecycle by calling drain-ack before this check matters.
 		if !decision.ShouldWake && !bead.Drained && !bead.WaitHold &&
-			bead.SleepReason != "idle-timeout" {
+			bead.SleepReason != string(sessionpkg.SleepReasonIdleTimeout) {
 			if input.RunningSessions[name] && isOnDemandSession(input.NamedSessions, bead) {
 				decision.ShouldWake = true
 				decision.Reason = "on-demand:running"
@@ -645,7 +645,7 @@ func countMinActiveCovered(beads []AwakeSessionBead, desired map[string]string, 
 func cityStopPoolBeads(beads []AwakeSessionBead, template string) []AwakeSessionBead {
 	var out []AwakeSessionBead
 	for _, b := range beads {
-		if isMinActivePoolBead(b, template) && b.State == "asleep" && b.SleepReason == "city-stop" {
+		if isMinActivePoolBead(b, template) && b.State == "asleep" && b.SleepReason == string(sessionpkg.SleepReasonCityStop) {
 			out = append(out, b)
 		}
 	}

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -3052,14 +3052,14 @@ func cityStopSessionMarked(store beads.Store, sessionID string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(b.Metadata["sleep_reason"]) == sleepReasonCityStop
+	return strings.TrimSpace(b.Metadata["sleep_reason"]) == string(sessionpkg.SleepReasonCityStop)
 }
 
 func markCityStopSessionAsAsleep(sessFront *sessionpkg.Store, sessionID string, stderr io.Writer) {
 	if sessFront == nil || strings.TrimSpace(sessionID) == "" {
 		return
 	}
-	if err := sessFront.Sleep(sessionID, sleepReasonCityStop, time.Now().UTC()); err != nil && stderr != nil {
+	if err := sessFront.Sleep(sessionID, string(sessionpkg.SleepReasonCityStop), time.Now().UTC()); err != nil && stderr != nil {
 		fmt.Fprintf(stderr, "gc stop: marking session %s asleep: %v\n", sessionID, err) //nolint:errcheck
 	}
 }

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -6705,7 +6705,7 @@ func TestStopTargetThroughWorkerBoundary_CityStopLeavesSessionAsleep(t *testing.
 			"session_name": "control-dispatcher",
 			"template":     "control-dispatcher",
 			"state":        "active",
-			"sleep_reason": sleepReasonCityStop,
+			"sleep_reason": string(sessionpkg.SleepReasonCityStop),
 		},
 	})
 	if err != nil {
@@ -6731,8 +6731,8 @@ func TestStopTargetThroughWorkerBoundary_CityStopLeavesSessionAsleep(t *testing.
 	if got.Metadata["state"] != string(sessionpkg.StateAsleep) {
 		t.Fatalf("state = %q, want %q", got.Metadata["state"], sessionpkg.StateAsleep)
 	}
-	if got.Metadata["sleep_reason"] != sleepReasonCityStop {
-		t.Fatalf("sleep_reason = %q, want %q", got.Metadata["sleep_reason"], sleepReasonCityStop)
+	if got.Metadata["sleep_reason"] != string(sessionpkg.SleepReasonCityStop) {
+		t.Fatalf("sleep_reason = %q, want %q", got.Metadata["sleep_reason"], string(sessionpkg.SleepReasonCityStop))
 	}
 	if got.Metadata["suspended_at"] != "" {
 		t.Fatalf("suspended_at = %q, want empty", got.Metadata["suspended_at"])

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -39,13 +39,6 @@ type wakeEvaluation struct {
 	HasAssignedWork  bool
 }
 
-const sleepReasonRuntimeMissing = "runtime-missing"
-
-// sleepReasonProviderTerminalError parks a session that hit a terminal
-// (non-retryable) provider error. markProviderTerminalError writes it; the
-// pool-slot freeable allowlist reads it to reap the dead bead + its worktree.
-const sleepReasonProviderTerminalError = "provider-terminal-error"
-
 const (
 	sessionHealthStateMetadataKey           = "session_health"
 	sessionHealthReasonMetadataKey          = "session_health_reason"
@@ -788,7 +781,7 @@ func markProviderTerminalError(session *beads.Bead, sessFront *sessionpkg.Store,
 	}
 	batch := map[string]string{
 		"state":                                 string(sessionpkg.StateAsleep),
-		"sleep_reason":                          sleepReasonProviderTerminalError,
+		"sleep_reason":                          string(sessionpkg.SleepReasonProviderTerminalError),
 		"last_woke_at":                          "",
 		"pending_create_claim":                  "",
 		"pending_create_started_at":             "",
@@ -1170,7 +1163,7 @@ func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock,
 			batch["state"] = string(sessionpkg.StateAsleep)
 		}
 		if strings.TrimSpace(meta["sleep_reason"]) == "" {
-			batch["sleep_reason"] = "drained"
+			batch["sleep_reason"] = string(sessionpkg.SleepReasonDrained)
 		}
 		return emptyNil(batch)
 	}
@@ -1230,12 +1223,12 @@ func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock,
 	if meta["state"] != target {
 		batch["state"] = target
 		if target == string(sessionpkg.StateAsleep) && (view.ResetContinuation || stalePendingCreateRollback) && strings.TrimSpace(meta["sleep_reason"]) == "" {
-			batch["sleep_reason"] = sleepReasonRuntimeMissing
+			batch["sleep_reason"] = string(sessionpkg.SleepReasonRuntimeMissing)
 		}
 	}
 	if target == string(sessionpkg.StateAsleep) {
 		if strings.TrimSpace(meta["sleep_reason"]) == "" && strings.TrimSpace(meta["state"]) == "failed-create" {
-			batch["sleep_reason"] = "failed-create"
+			batch["sleep_reason"] = string(sessionpkg.SleepReasonFailedCreate)
 		}
 		if view.ResetContinuation || stalePendingCreateRollback {
 			if !isNamedSessionBead(session) || namedSessionMode(session) != "always" {

--- a/cmd/gc/session_reconcile_ratelimit_test.go
+++ b/cmd/gc/session_reconcile_ratelimit_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/clock"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 // TestCheckStability_RateLimitScreen_DoesNotCountAsCrash pins the desired
@@ -379,8 +380,8 @@ func TestCheckStability_TerminalErrorScreen_MarksTerminalNotCrash(t *testing.T) 
 	if got := session.Metadata["state"]; got != "asleep" {
 		t.Errorf("state = %q, want asleep", got)
 	}
-	if got := session.Metadata["sleep_reason"]; got != sleepReasonProviderTerminalError {
-		t.Errorf("sleep_reason = %q, want %q", got, sleepReasonProviderTerminalError)
+	if got := session.Metadata["sleep_reason"]; got != string(sessionpkg.SleepReasonProviderTerminalError) {
+		t.Errorf("sleep_reason = %q, want %q", got, string(sessionpkg.SleepReasonProviderTerminalError))
 	}
 	if got := session.Metadata[sessionProviderTerminalErrorMetadataKey]; got != "model_not_found" {
 		t.Errorf("%s = %q, want model_not_found", sessionProviderTerminalErrorMetadataKey, got)

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1752,8 +1752,8 @@ func TestHealState_StaleCreatingPendingClaimDoesNotOscillateBackToCreating(t *te
 	if got := session.Metadata["state"]; got != "asleep" {
 		t.Fatalf("after first heal: state = %q, want asleep", got)
 	}
-	if got := session.Metadata["sleep_reason"]; got != sleepReasonRuntimeMissing {
-		t.Fatalf("after first heal: sleep_reason = %q, want %q", got, sleepReasonRuntimeMissing)
+	if got := session.Metadata["sleep_reason"]; got != string(sessionpkg.SleepReasonRuntimeMissing) {
+		t.Fatalf("after first heal: sleep_reason = %q, want %q", got, string(sessionpkg.SleepReasonRuntimeMissing))
 	}
 	if got := session.Metadata["pending_create_claim"]; got != "" {
 		t.Fatalf("after first heal: pending_create_claim = %q, want empty", got)
@@ -1894,7 +1894,7 @@ func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 			}(),
 			want: map[string]string{
 				"state":                      "asleep",
-				"sleep_reason":               sleepReasonRuntimeMissing,
+				"sleep_reason":               string(sessionpkg.SleepReasonRuntimeMissing),
 				"session_key":                "",
 				"started_config_hash":        "",
 				"continuation_reset_pending": "true",
@@ -1973,7 +1973,7 @@ func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 			}(),
 			want: map[string]string{
 				"state":                      "asleep",
-				"sleep_reason":               sleepReasonRuntimeMissing,
+				"sleep_reason":               string(sessionpkg.SleepReasonRuntimeMissing),
 				"session_key":                "",
 				"started_config_hash":        "",
 				"continuation_reset_pending": "true",
@@ -2165,7 +2165,7 @@ func TestHealState_ClearsStaleResumeMetadata(t *testing.T) {
 		{
 			name:                   "city stop — resume metadata preserved",
 			prevState:              "active",
-			sleepReason:            sleepReasonCityStop,
+			sleepReason:            string(sessionpkg.SleepReasonCityStop),
 			sessionKey:             "abc-123",
 			startedConfigHash:      "hash-before",
 			wantKeyCleared:         false,
@@ -2717,7 +2717,7 @@ func TestCheckChurn_CityStopSleepReasonSkipped(t *testing.T) {
 
 	session := makeBead("b1", map[string]string{
 		"last_woke_at":               now.Add(-90 * time.Second).Format(time.RFC3339),
-		"sleep_reason":               sleepReasonCityStop,
+		"sleep_reason":               string(sessionpkg.SleepReasonCityStop),
 		"churn_count":                "0",
 		"session_key":                "resume-key",
 		"continuation_reset_pending": "",

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -511,7 +511,7 @@ func finalizeDrainAckStoppedSession(
 	}
 	batch := sessionpkg.AcknowledgeDrainPatch(info.WakeMode == "fresh")
 	if hasAssignedWork {
-		batch = sessionpkg.CompleteDrainPatch(clk.Now().UTC(), "idle", info.WakeMode == "fresh")
+		batch = sessionpkg.CompleteDrainPatch(clk.Now().UTC(), string(sessionpkg.SleepReasonIdle), info.WakeMode == "fresh")
 	}
 	// A drain-ack that completes a restart-request cycle (gc session reset →
 	// agent drain-ack) must also consume restart_requested. The drain-ack
@@ -2475,7 +2475,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// the same SleepPatch reproduces the mirror exactly (slept_at /
 			// sleep_policy_fingerprint are non-Info). Pre-pass-masked (STEP6-PREPASS-AUDIT
 			// group 6).
-			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(sessionpkg.SleepPatch(clk.Now().UTC(), "idle"))
+			infoByID[session.ID] = infoByID[session.ID].ApplyPatch(sessionpkg.SleepPatch(clk.Now().UTC(), string(sessionpkg.SleepReasonIdle)))
 		}
 		// Fold detached_at change onto the snapshot (Step 6d write-returns-Info).
 		// reconcileDetachedAt returns the {"detached_at": <value>} batch it mirrored,

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2837,7 +2837,7 @@ func TestReconcileSessionBeads_CloseGatePreservesSleepReason(t *testing.T) {
 	}{
 		{"idle", "idle", "idle"},
 		{"idle-timeout", "idle-timeout", "idle-timeout"},
-		{"city-stop", sleepReasonCityStop, sleepReasonCityStop},
+		{"city-stop", string(sessionpkg.SleepReasonCityStop), string(sessionpkg.SleepReasonCityStop)},
 		{"drained-reason", "drained", "drained"},
 		{"missing-reason", "", "drained"}, // fallback
 	}

--- a/cmd/gc/session_sleep.go
+++ b/cmd/gc/session_sleep.go
@@ -224,10 +224,10 @@ func configWakeSuppressed(
 	if !policy.enabled() {
 		return false
 	}
-	if session.Metadata["sleep_reason"] == "idle-timeout" {
+	if session.Metadata["sleep_reason"] == string(sessionpkg.SleepReasonIdleTimeout) {
 		return false
 	}
-	if session.Metadata["sleep_reason"] == "idle" &&
+	if session.Metadata["sleep_reason"] == string(sessionpkg.SleepReasonIdle) &&
 		session.Metadata["sleep_policy_fingerprint"] != "" &&
 		session.Metadata["sleep_policy_fingerprint"] == policy.Fingerprint {
 		return true
@@ -271,7 +271,7 @@ func persistSleepPolicyMetadata(
 	}
 	fingerprint := policy.Fingerprint
 	if ((session.Metadata["state"] == "asleep" &&
-		session.Metadata["sleep_reason"] == "idle") ||
+		session.Metadata["sleep_reason"] == string(sessionpkg.SleepReasonIdle)) ||
 		session.Metadata["sleep_intent"] == "idle-stop-pending") &&
 		session.Metadata["sleep_policy_fingerprint"] != "" {
 		// Preserve the fingerprint that initiated an in-flight idle drain so the
@@ -336,7 +336,7 @@ func recoverPendingIdleSleep(
 	if session == nil || sessFront == nil || running || session.Metadata["sleep_intent"] != "idle-stop-pending" {
 		return false
 	}
-	batch := sessionpkg.SleepPatch(clk.Now(), "idle")
+	batch := sessionpkg.SleepPatch(clk.Now(), string(sessionpkg.SleepReasonIdle))
 	if fingerprint := session.Metadata["sleep_policy_fingerprint"]; fingerprint != "" {
 		batch["sleep_policy_fingerprint"] = fingerprint
 	}

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -12,7 +12,7 @@ func isDrainedSessionMetadata(meta map[string]string) bool {
 	if state == "drained" {
 		return true
 	}
-	return state == "asleep" && strings.TrimSpace(meta["sleep_reason"]) == "drained"
+	return state == "asleep" && strings.TrimSpace(meta["sleep_reason"]) == string(sessionpkg.SleepReasonDrained)
 }
 
 func isDrainedSessionBead(session beads.Bead) bool {
@@ -27,7 +27,7 @@ func isDrainedSessionInfo(i sessionpkg.Info) bool {
 	if state == "drained" {
 		return true
 	}
-	return state == "asleep" && strings.TrimSpace(i.SleepReason) == "drained"
+	return state == "asleep" && strings.TrimSpace(i.SleepReason) == string(sessionpkg.SleepReasonDrained)
 }
 
 // poolSessionIsLive reports whether a pool session bead represents an
@@ -75,8 +75,9 @@ func isPoolSessionSlotFreeable(session beads.Bead) bool {
 	}
 	reason := strings.TrimSpace(session.Metadata["sleep_reason"])
 	switch reason {
-	case "idle", "idle-timeout", sleepReasonCityStop, "failed-create", sleepReasonRuntimeMissing,
-		sleepReasonProviderTerminalError:
+	case string(sessionpkg.SleepReasonIdle), string(sessionpkg.SleepReasonIdleTimeout),
+		string(sessionpkg.SleepReasonCityStop), string(sessionpkg.SleepReasonFailedCreate),
+		string(sessionpkg.SleepReasonRuntimeMissing), string(sessionpkg.SleepReasonProviderTerminalError):
 		return true
 	}
 	return false
@@ -92,8 +93,9 @@ func isPoolSessionSlotFreeableInfo(i sessionpkg.Info) bool {
 	}
 	reason := strings.TrimSpace(i.SleepReason)
 	switch reason {
-	case "idle", "idle-timeout", sleepReasonCityStop, "failed-create", sleepReasonRuntimeMissing,
-		sleepReasonProviderTerminalError:
+	case string(sessionpkg.SleepReasonIdle), string(sessionpkg.SleepReasonIdleTimeout),
+		string(sessionpkg.SleepReasonCityStop), string(sessionpkg.SleepReasonFailedCreate),
+		string(sessionpkg.SleepReasonRuntimeMissing), string(sessionpkg.SleepReasonProviderTerminalError):
 		return true
 	}
 	return false

--- a/cmd/gc/session_state_helpers_test.go
+++ b/cmd/gc/session_state_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 // TestPoolSessionIsLive_Matrix exercises the liveness predicate used by the
@@ -52,10 +53,10 @@ func TestIsPoolSessionSlotFreeable_Matrix(t *testing.T) {
 		{"asleep+drained-reason", map[string]string{"state": "asleep", "sleep_reason": "drained"}, true},
 		{"asleep+idle", map[string]string{"state": "asleep", "sleep_reason": "idle"}, true},
 		{"asleep+idle-timeout", map[string]string{"state": "asleep", "sleep_reason": "idle-timeout"}, true},
-		{"asleep+city-stop", map[string]string{"state": "asleep", "sleep_reason": sleepReasonCityStop}, true},
+		{"asleep+city-stop", map[string]string{"state": "asleep", "sleep_reason": string(sessionpkg.SleepReasonCityStop)}, true},
 		{"asleep+failed-create", map[string]string{"state": "asleep", "sleep_reason": "failed-create"}, true},
-		{"asleep+runtime-missing", map[string]string{"state": "asleep", "sleep_reason": sleepReasonRuntimeMissing}, true},
-		{"asleep+provider-terminal-error", map[string]string{"state": "asleep", "sleep_reason": sleepReasonProviderTerminalError}, true},
+		{"asleep+runtime-missing", map[string]string{"state": "asleep", "sleep_reason": string(sessionpkg.SleepReasonRuntimeMissing)}, true},
+		{"asleep+provider-terminal-error", map[string]string{"state": "asleep", "sleep_reason": string(sessionpkg.SleepReasonProviderTerminalError)}, true},
 		{"asleep+empty-reason", map[string]string{"state": "asleep", "sleep_reason": ""}, false},
 		{"asleep+missing-reason", map[string]string{"state": "asleep"}, false},
 		{"asleep+wait-hold", map[string]string{"state": "asleep", "sleep_reason": "wait-hold"}, false},

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -50,10 +50,10 @@ func preWakeCommit(
 	}
 
 	sleepReason := ""
-	if session.Metadata["sleep_reason"] == "idle-timeout" {
+	if session.Metadata["sleep_reason"] == string(sessions.SleepReasonIdleTimeout) {
 		// Preserve the idle-timeout wake override until the replacement
 		// session has actually started. Failed starts must retry next tick.
-		sleepReason = "idle-timeout"
+		sleepReason = string(sessions.SleepReasonIdleTimeout)
 	}
 
 	freshWake := session.Metadata["wake_mode"] == "fresh" || pendingContinuationResetNeedsFreshStart(session.Metadata)

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -26,7 +26,10 @@ func appendMetadataAttachedChildren(store beads.Store, parent beads.Bead, childr
 	for _, child := range children {
 		seen[child.ID] = struct{}{}
 	}
-	for _, key := range []string{"molecule_id", "workflow_id"} {
+	// NOTE: "workflow_id" is the bare (non-prefixed) metadata key, distinct
+	// from beadmeta.WorkflowIDMetadataKey ("gc.workflow_id") — do NOT substitute
+	// the prefixed constant here or this would surface a different key.
+	for _, key := range []string{beadmeta.MoleculeIDMetadataKey, "workflow_id"} {
 		attachedID := strings.TrimSpace(parent.Metadata[key])
 		if attachedID == "" {
 			continue

--- a/internal/runproj/summary.go
+++ b/internal/runproj/summary.go
@@ -272,7 +272,7 @@ func runRootID(issue runIssue) string {
 	if stringValue(md[beadmeta.KindMetadataKey]) == "run" || issue.issueType == "molecule" {
 		return issue.id
 	}
-	if moleculeID := stringValue(md["molecule_id"]); moleculeID != "" {
+	if moleculeID := stringValue(md[beadmeta.MoleculeIDMetadataKey]); moleculeID != "" {
 		return moleculeID
 	}
 	return issue.id

--- a/internal/runtime/t3bridge/provider.go
+++ b/internal/runtime/t3bridge/provider.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -1731,7 +1732,7 @@ func activityFromBeadEvent(ev events.Event, bead beads.Bead) (string, string, ma
 			"beadStatus": bead.Status,
 			"assignee":   bead.Assignee,
 			"formula":    bead.Ref,
-			"moleculeId": bead.Metadata["molecule_id"],
+			"moleculeId": bead.Metadata[beadmeta.MoleculeIDMetadataKey],
 			"eventType":  ev.Type,
 		}
 	case ev.Type == events.BeadUpdated:
@@ -1745,7 +1746,7 @@ func activityFromBeadEvent(ev events.Event, bead beads.Bead) (string, string, ma
 			"beadStatus": bead.Status,
 			"assignee":   bead.Assignee,
 			"formula":    bead.Ref,
-			"moleculeId": bead.Metadata["molecule_id"],
+			"moleculeId": bead.Metadata[beadmeta.MoleculeIDMetadataKey],
 			"eventType":  ev.Type,
 		}
 	default:
@@ -1755,7 +1756,7 @@ func activityFromBeadEvent(ev events.Event, bead beads.Bead) (string, string, ma
 			"beadStatus": bead.Status,
 			"assignee":   bead.Assignee,
 			"formula":    bead.Ref,
-			"moleculeId": bead.Metadata["molecule_id"],
+			"moleculeId": bead.Metadata[beadmeta.MoleculeIDMetadataKey],
 			"eventType":  ev.Type,
 		}
 	}
@@ -1796,7 +1797,7 @@ func (p *Provider) refreshAssignmentProjection(threadID string, envelope Startup
 	next.Assignment.ConvoyTotalCount = convoyTotalCount
 	next.Assignment.Formula = bead.Ref
 	if next.Assignment.MoleculeID == "" {
-		next.Assignment.MoleculeID = bead.Metadata["molecule_id"]
+		next.Assignment.MoleculeID = bead.Metadata[beadmeta.MoleculeIDMetadataKey]
 	}
 	_ = p.dispatchThreadMeta(threadID, buildGCMetadata(next, providerName, nil))
 }

--- a/internal/session/info_apply_patch.go
+++ b/internal/session/info_apply_patch.go
@@ -1,13 +1,5 @@
 package session
 
-import (
-	"strconv"
-	"strings"
-	"time"
-
-	"github.com/gastownhall/gascity/internal/beadmeta"
-)
-
 // ApplyPatch returns a copy of info with a MetadataPatch applied to its
 // metadata-derived fields. It is the typed "write-returns-Info" half of the
 // session front door (front-door migration Step 6d): the reconciler applies a
@@ -30,187 +22,21 @@ import (
 // a metadata patch — a status close is a separate refresh case (Store.Get) —
 // so ApplyPatch reads the carried-forward Closed and never flips it.
 //
-// The mapping is deliberately parallel to InfoFromPersistedBead;
-// TestInfoApplyPatchMatchesReprojection is the equivalence oracle that guards
-// the two against drift, exactly as TestSessionClassifierInfoEquivalence guards
-// the classifier siblings.
+// The fold shares one codec table with InfoFromPersistedBead (info_codec.go):
+// each key's setter is the SAME closure both directions run, so fold ==
+// re-projection by construction. TestInfoApplyPatchMatchesReprojection is kept
+// as the equivalence oracle that gates the two against drift, exactly as
+// TestSessionClassifierInfoEquivalence guards the classifier siblings.
 func (info Info) ApplyPatch(patch MetadataPatch) Info {
 	for key, v := range patch {
-		switch key {
-		case "session_name":
-			info.SessionNameMetadata = v
-			if v == "" {
-				info.SessionName = sessionNameFor(info.ID)
-			} else {
-				info.SessionName = v
-			}
-		case "state":
-			info.MetadataState = v
-			if info.Closed {
-				info.State = "" // closed beads have no runtime state
-			} else {
-				info.State = normalizeInfoState(State(v))
-			}
-		case "template":
-			info.Template = v
-		case "alias":
-			info.Alias = v
-		case "agent_name":
-			info.AgentName = v
-		case "provider":
-			info.Provider = v
-			info.Transport = normalizeTransport(v, info.TransportMetadata)
-		case "transport":
-			info.TransportMetadata = v
-			info.Transport = normalizeTransport(info.Provider, v)
-		case "command":
-			info.Command = v
-		case "work_dir":
-			info.WorkDir = v
-		case "session_key":
-			info.SessionKey = v
-		case "resume_flag":
-			info.ResumeFlag = v
-		case "resume_style":
-			info.ResumeStyle = v
-		case "resume_command":
-			info.ResumeCommand = v
-		case "continuation_epoch":
-			info.ContinuationEpoch = v
-		case "sleep_reason":
-			info.SleepReason = v
-		case NamedSessionIdentityMetadata:
-			info.ConfiguredNamedIdentity = v
-		case NamedSessionMetadataKey:
-			info.ConfiguredNamedSession = strings.TrimSpace(v) == "true"
-		case NamedSessionModeMetadata:
-			info.ConfiguredNamedMode = v
-		case "common_name":
-			info.CommonName = v
-		case "pool_slot":
-			info.PoolSlot = v
-		case "pool_managed":
-			info.PoolManaged = strings.TrimSpace(v) == "true"
-		case "session_origin":
-			info.SessionOrigin = v
-		case "dependency_only":
-			info.DependencyOnly = strings.TrimSpace(v) == "true"
-			info.DependencyOnlyMetadata = v
-		case "manual_session":
-			info.ManualSession = strings.TrimSpace(v) == "true"
-			info.ManualSessionMetadata = v
-		case MCPIdentityMetadataKey:
-			info.MCPIdentity = v
-		case MCPServersSnapshotMetadataKey:
-			info.MCPServersSnapshot = v
-		case "provider_terminal_error":
-			info.ProviderTerminalError = v
-		case "session_health":
-			info.HealthState = v
-		case "session_health_reason":
-			info.HealthReason = v
-		case "session_drainable":
-			info.Drainable = strings.TrimSpace(v) == "true"
-		case beadmeta.TriggerBeadIDMetadataKey:
-			info.TriggerBeadID = v
-		case beadmeta.TriggerBeadStoreRefMetadataKey:
-			info.TriggerBeadStoreRef = v
-		case beadmeta.BrainParentSIDMetadataKey:
-			info.BrainParentSID = v
-		case beadmeta.PackMetadataKey:
-			info.Pack = v
-		case "pending_create_claim":
-			info.PendingCreateClaim = strings.TrimSpace(v) == "true"
-			info.PendingCreateClaimMetadata = v
-		case "pending_create_started_at":
-			info.PendingCreateStartedAt = v
-		case "quarantined_until":
-			info.QuarantinedUntil = v
-		case aliasHistoryMetadataKey:
-			info.AliasHistory = normalizeAliasList(strings.Split(v, ","), "")
-		case "continuity_eligible":
-			info.ContinuityEligible = v
-		case "last_woke_at":
-			info.LastWokeAt = v
-		case "state_reason":
-			info.StateReason = v
-		case "creation_complete_at":
-			info.CreationCompleteAt = v
-		case "continuation_reset_pending":
-			info.ContinuationResetPending = v
-		case ResetCommittedAtKey:
-			info.ResetCommittedAt = v
-		case "generation":
-			info.Generation = v
-		case "started_config_hash":
-			info.StartedConfigHash = v
-		case "pin_awake":
-			info.PinAwake = v
-		case "held_until":
-			info.HeldUntil = v
-		case "wait_hold":
-			info.WaitHold = v
-		case "churn_count":
-			info.ChurnCount = v
-		case "wake_mode":
-			info.WakeMode = v
-		case "sleep_intent":
-			info.SleepIntent = v
-		case "instance_token":
-			info.InstanceToken = v
-		case "detached_at":
-			info.DetachedAt = v
-		case CurrentBeadIDKey:
-			info.CurrentlyProcessingBeadID = v
-		case "core_hash_breakdown":
-			info.CoreHashBreakdown = v
-		case "started_provision_hash":
-			info.StartedProvisionHash = v
-		case "started_launch_hash":
-			info.StartedLaunchHash = v
-		case "started_live_hash":
-			info.StartedLiveHash = v
-		case "config_drift_deferred_at":
-			info.ConfigDriftDeferredAt = v
-		case "config_drift_deferred_key":
-			info.ConfigDriftDeferredKey = v
-		case "attached_config_drift_deferred_at":
-			info.AttachedConfigDriftDeferredAt = v
-		case "attached_config_drift_deferred_key":
-			info.AttachedConfigDriftDeferredKey = v
-		case "stranded_event_emitted_at":
-			info.StrandedEventEmittedAt = v
-		case "session_name_explicit":
-			info.SessionNameExplicit = v
-		case "wake_request":
-			info.WakeRequest = v
-		case "restart_requested":
-			info.RestartRequested = v
-		case "session_id_flag":
-			info.SessionIDFlag = v
-		case "template_overrides":
-			info.TemplateOverrides = v
-		case "wake_attempts":
-			info.WakeAttemptsMetadata = v
-			if n, err := strconv.Atoi(v); err == nil {
-				info.WakeAttempts = n
-			} else {
-				info.WakeAttempts = 0
-			}
-		case "provider_kind":
-			info.ProviderKind = v
-		case MetadataLastNudgeDeliveredAt:
-			info.LastNudgeDeliveredAt = time.Time{}
-			if raw := strings.TrimSpace(v); raw != "" {
-				if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
-					info.LastNudgeDeliveredAt = parsed
-				}
-			}
-		default:
-			// Keys InfoFromPersistedBead does not project (e.g. live_hash,
-			// startup_dialog_verified, env.*) have no Info field, so a patch to
-			// them changes no Info fact. Ignoring them keeps ApplyPatch
-			// byte-identical to a full re-projection.
+		// A key InfoFromPersistedBead projects folds through its shared codec
+		// setter — the SAME closure the projection runs — so the fold is a
+		// re-projection of that one key by construction. Keys the projection
+		// does not read (e.g. live_hash, startup_dialog_verified, env.*) miss
+		// the index and carry no Info field, keeping ApplyPatch byte-identical
+		// to a full re-projection.
+		if spec, ok := infoKeyIndex[key]; ok {
+			spec.set(&info, v)
 		}
 	}
 	return info

--- a/internal/session/info_codec.go
+++ b/internal/session/info_codec.go
@@ -1,0 +1,199 @@
+package session
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+)
+
+// infoKeySpec is one metadata key's codec: how a raw metadata value becomes
+// Info fields. The SAME closure drives both directions of the metadata⇄Info
+// codec — projection (InfoFromPersistedBead) and fold (Info.ApplyPatch) — so a
+// fold is a re-projection of that one key by construction, and the two can no
+// longer drift apart.
+//
+// Contract of set: it is total over the empty string and correct ONLY when
+// applied to a fresh (zero-valued) Info in projection order, OR folded onto a
+// coherent Info snapshot in patch semantics. In both regimes an absent key
+// reads as "" and every setter produces the correctly-cleared state for "".
+// Do not reuse a setter against an arbitrary partially-mutated Info outside
+// those two regimes — the projection/patch equivalence assumes one of them.
+type infoKeySpec struct {
+	key string                     // exact on-store metadata key (byte-identical to today)
+	set func(info *Info, v string) // typed setter: writes ALL Info fields derived from this key
+}
+
+// infoKeyCodec is the single source of truth for the metadata-derived half of
+// the Info projection. Ordering is irrelevant for correctness EXCEPT for two
+// documented dependencies (invariant I6):
+//   - the bead-level prologue (ID, Closed, …) in InfoFromPersistedBead runs
+//     before this table, because session_name reads info.ID and state reads
+//     info.Closed;
+//   - provider is listed before transport, so both raw mirrors are in scope
+//     when the derived Transport is finalized (they converge to the same
+//     value in either order — see the provider/transport entries).
+//
+// Every other pair of entries writes a disjoint set of Info fields (asserted by
+// TestInfoCodecFieldsDisjoint). The clustering mirrors the old struct literal
+// so review provenance survives.
+var infoKeyCodec = []infoKeySpec{
+	// core / identity cluster
+	{"template", func(i *Info, v string) { i.Template = v }},
+	{"alias", func(i *Info, v string) { i.Alias = v }},
+	{"agent_name", func(i *Info, v string) { i.AgentName = v }},
+	{"command", func(i *Info, v string) { i.Command = v }},
+	{"work_dir", func(i *Info, v string) { i.WorkDir = v }},
+	{"session_key", func(i *Info, v string) { i.SessionKey = v }},
+	{"resume_flag", func(i *Info, v string) { i.ResumeFlag = v }},
+	{"resume_style", func(i *Info, v string) { i.ResumeStyle = v }},
+	{"resume_command", func(i *Info, v string) { i.ResumeCommand = v }},
+	{"continuation_epoch", func(i *Info, v string) { i.ContinuationEpoch = v }},
+	{"sleep_reason", func(i *Info, v string) { i.SleepReason = v }},
+
+	// session_name: fallback-defaulted; reads info.ID (set in the prologue).
+	{"session_name", func(i *Info, v string) {
+		i.SessionNameMetadata = v
+		if v == "" {
+			i.SessionName = sessionNameFor(i.ID)
+		} else {
+			i.SessionName = v
+		}
+	}},
+
+	// state: normalize + closed-blank; reads info.Closed (set in the prologue).
+	{"state", func(i *Info, v string) {
+		i.MetadataState = v
+		if i.Closed {
+			i.State = "" // closed beads have no runtime state
+		} else {
+			i.State = normalizeInfoState(State(v))
+		}
+	}},
+
+	// provider/transport cross-field pair: each setter re-derives Transport from
+	// the sibling's current raw mirror. provider MUST precede transport so both
+	// raw values are in scope when Transport is finalized; the two converge to
+	// normalizeTransport(provider, transport) regardless of arrival order.
+	{"provider", func(i *Info, v string) {
+		i.Provider = v
+		i.Transport = normalizeTransport(v, i.TransportMetadata)
+	}},
+	{"transport", func(i *Info, v string) {
+		i.TransportMetadata = v
+		i.Transport = normalizeTransport(i.Provider, v)
+	}},
+
+	// identity / pool / named-session cluster
+	{NamedSessionIdentityMetadata, func(i *Info, v string) { i.ConfiguredNamedIdentity = v }},
+	{NamedSessionMetadataKey, func(i *Info, v string) { i.ConfiguredNamedSession = strings.TrimSpace(v) == "true" }},
+	{NamedSessionModeMetadata, func(i *Info, v string) { i.ConfiguredNamedMode = v }},
+	{"common_name", func(i *Info, v string) { i.CommonName = v }},
+	{"pool_slot", func(i *Info, v string) { i.PoolSlot = v }},
+	{"pool_managed", func(i *Info, v string) { i.PoolManaged = strings.TrimSpace(v) == "true" }},
+	{"session_origin", func(i *Info, v string) { i.SessionOrigin = v }},
+	{"dependency_only", func(i *Info, v string) {
+		i.DependencyOnly = strings.TrimSpace(v) == "true"
+		i.DependencyOnlyMetadata = v
+	}},
+	{"manual_session", func(i *Info, v string) {
+		i.ManualSession = strings.TrimSpace(v) == "true"
+		i.ManualSessionMetadata = v
+	}},
+	{MCPIdentityMetadataKey, func(i *Info, v string) { i.MCPIdentity = v }},
+	{MCPServersSnapshotMetadataKey, func(i *Info, v string) { i.MCPServersSnapshot = v }},
+
+	// health / provider-terminal-error cluster
+	{"provider_terminal_error", func(i *Info, v string) { i.ProviderTerminalError = v }},
+	{"session_health", func(i *Info, v string) { i.HealthState = v }},
+	{"session_health_reason", func(i *Info, v string) { i.HealthReason = v }},
+	{"session_drainable", func(i *Info, v string) { i.Drainable = strings.TrimSpace(v) == "true" }},
+
+	// trigger / brain-parent cluster (canonical gc.* keys via beadmeta)
+	{beadmeta.TriggerBeadIDMetadataKey, func(i *Info, v string) { i.TriggerBeadID = v }},
+	{beadmeta.TriggerBeadStoreRefMetadataKey, func(i *Info, v string) { i.TriggerBeadStoreRef = v }},
+	{beadmeta.BrainParentSIDMetadataKey, func(i *Info, v string) { i.BrainParentSID = v }},
+	{beadmeta.PackMetadataKey, func(i *Info, v string) { i.Pack = v }},
+
+	// state / bookkeeping cluster
+	{"pending_create_claim", func(i *Info, v string) {
+		i.PendingCreateClaim = strings.TrimSpace(v) == "true"
+		i.PendingCreateClaimMetadata = v
+	}},
+	{"pending_create_started_at", func(i *Info, v string) { i.PendingCreateStartedAt = v }},
+	{"quarantined_until", func(i *Info, v string) { i.QuarantinedUntil = v }},
+	{aliasHistoryMetadataKey, func(i *Info, v string) {
+		i.AliasHistory = normalizeAliasList(strings.Split(v, ","), "")
+	}},
+	{"continuity_eligible", func(i *Info, v string) { i.ContinuityEligible = v }},
+	{"last_woke_at", func(i *Info, v string) { i.LastWokeAt = v }},
+	{"state_reason", func(i *Info, v string) { i.StateReason = v }},
+	{"creation_complete_at", func(i *Info, v string) { i.CreationCompleteAt = v }},
+	{"continuation_reset_pending", func(i *Info, v string) { i.ContinuationResetPending = v }},
+	{ResetCommittedAtKey, func(i *Info, v string) { i.ResetCommittedAt = v }},
+	{"generation", func(i *Info, v string) { i.Generation = v }},
+	{"started_config_hash", func(i *Info, v string) { i.StartedConfigHash = v }},
+	{"pin_awake", func(i *Info, v string) { i.PinAwake = v }},
+
+	// reconciler decision-read cluster (front-door Phase 5)
+	{"held_until", func(i *Info, v string) { i.HeldUntil = v }},
+	{"wait_hold", func(i *Info, v string) { i.WaitHold = v }},
+	{"churn_count", func(i *Info, v string) { i.ChurnCount = v }},
+	{"wake_mode", func(i *Info, v string) { i.WakeMode = v }},
+	{"sleep_intent", func(i *Info, v string) { i.SleepIntent = v }},
+	{"instance_token", func(i *Info, v string) { i.InstanceToken = v }},
+	{"detached_at", func(i *Info, v string) { i.DetachedAt = v }},
+	{CurrentBeadIDKey, func(i *Info, v string) { i.CurrentlyProcessingBeadID = v }},
+	{"core_hash_breakdown", func(i *Info, v string) { i.CoreHashBreakdown = v }},
+	{"started_provision_hash", func(i *Info, v string) { i.StartedProvisionHash = v }},
+	{"started_launch_hash", func(i *Info, v string) { i.StartedLaunchHash = v }},
+	{"started_live_hash", func(i *Info, v string) { i.StartedLiveHash = v }},
+	{"config_drift_deferred_at", func(i *Info, v string) { i.ConfigDriftDeferredAt = v }},
+	{"config_drift_deferred_key", func(i *Info, v string) { i.ConfigDriftDeferredKey = v }},
+	{"attached_config_drift_deferred_at", func(i *Info, v string) { i.AttachedConfigDriftDeferredAt = v }},
+	{"attached_config_drift_deferred_key", func(i *Info, v string) { i.AttachedConfigDriftDeferredKey = v }},
+	{"stranded_event_emitted_at", func(i *Info, v string) { i.StrandedEventEmittedAt = v }},
+	{"session_name_explicit", func(i *Info, v string) { i.SessionNameExplicit = v }},
+	{"wake_request", func(i *Info, v string) { i.WakeRequest = v }},
+	{"restart_requested", func(i *Info, v string) { i.RestartRequested = v }},
+	{"session_id_flag", func(i *Info, v string) { i.SessionIDFlag = v }},
+	{"template_overrides", func(i *Info, v string) { i.TemplateOverrides = v }},
+	{"provider_kind", func(i *Info, v string) { i.ProviderKind = v }},
+
+	// wake_attempts: int + raw mirror. The total form (explicit = 0 on parse
+	// failure) matches ApplyPatch and, on a fresh Info, agrees with the old
+	// projection's no-set-on-failure. Atoi accepts leading +/- but not
+	// whitespace — no trimming, to stay byte-identical.
+	{"wake_attempts", func(i *Info, v string) {
+		i.WakeAttemptsMetadata = v
+		if n, err := strconv.Atoi(v); err == nil {
+			i.WakeAttempts = n
+		} else {
+			i.WakeAttempts = 0
+		}
+	}},
+
+	// last_nudge_delivered_at: RFC3339 time. Reset-to-zero first (clears a
+	// carried-forward value in the patch direction; a no-op on a fresh Info).
+	{MetadataLastNudgeDeliveredAt, func(i *Info, v string) {
+		i.LastNudgeDeliveredAt = time.Time{}
+		if raw := strings.TrimSpace(v); raw != "" {
+			if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+				i.LastNudgeDeliveredAt = parsed
+			}
+		}
+	}},
+}
+
+// infoKeyIndex maps each metadata key to its codec spec for O(1) ApplyPatch
+// lookup. Built once in init() and never mutated afterward, so concurrent
+// reads by reconciler goroutines are race-free by construction.
+var infoKeyIndex = func() map[string]*infoKeySpec {
+	idx := make(map[string]*infoKeySpec, len(infoKeyCodec))
+	for i := range infoKeyCodec {
+		spec := &infoKeyCodec[i]
+		idx[spec.key] = spec
+	}
+	return idx
+}()

--- a/internal/session/info_codec_test.go
+++ b/internal/session/info_codec_test.go
@@ -1,0 +1,342 @@
+package session
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// infoFromPersistedBeadFrozen is a verbatim copy of the pre-S09b struct-literal
+// projection of InfoFromPersistedBead. It is the INDEPENDENT oracle for the
+// table-driven codec: TestInfoCodecProjectionParity asserts the new table loop
+// reproduces this frozen reference byte-for-byte. It must NOT be refactored to
+// call the table — its whole value is being written a different way. If a
+// genuine projection change is ever intended, this frozen copy fails loudly and
+// forces an explicit decision.
+func infoFromPersistedBeadFrozen(b beads.Bead) Info {
+	sessName := b.Metadata["session_name"]
+	if sessName == "" {
+		sessName = sessionNameFor(b.ID)
+	}
+	closed := b.Status == "closed"
+
+	state := normalizeInfoState(State(b.Metadata["state"]))
+	if closed {
+		state = ""
+	}
+
+	info := Info{
+		ID:            b.ID,
+		Type:          b.Type,
+		Template:      b.Metadata["template"],
+		State:         state,
+		Closed:        closed,
+		Title:         b.Title,
+		Alias:         b.Metadata["alias"],
+		AgentName:     b.Metadata["agent_name"],
+		Provider:      b.Metadata["provider"],
+		Transport:     transportFromMetadata(b),
+		Command:       b.Metadata["command"],
+		WorkDir:       b.Metadata["work_dir"],
+		SessionName:   sessName,
+		SessionKey:    b.Metadata["session_key"],
+		ResumeFlag:    b.Metadata["resume_flag"],
+		ResumeStyle:   b.Metadata["resume_style"],
+		ResumeCommand: b.Metadata["resume_command"],
+		CreatedAt:     b.CreatedAt,
+
+		ContinuationEpoch: b.Metadata["continuation_epoch"],
+		SleepReason:       b.Metadata["sleep_reason"],
+
+		ConfiguredNamedIdentity: b.Metadata[NamedSessionIdentityMetadata],
+		ConfiguredNamedSession:  strings.TrimSpace(b.Metadata[NamedSessionMetadataKey]) == "true",
+		ConfiguredNamedMode:     b.Metadata[NamedSessionModeMetadata],
+		CommonName:              b.Metadata["common_name"],
+		PoolSlot:                b.Metadata["pool_slot"],
+		PoolManaged:             strings.TrimSpace(b.Metadata["pool_managed"]) == "true",
+		SessionOrigin:           b.Metadata["session_origin"],
+		DependencyOnly:          strings.TrimSpace(b.Metadata["dependency_only"]) == "true",
+		DependencyOnlyMetadata:  b.Metadata["dependency_only"],
+		ManualSession:           strings.TrimSpace(b.Metadata["manual_session"]) == "true",
+		ManualSessionMetadata:   b.Metadata["manual_session"],
+		Labels:                  b.Labels,
+		MCPIdentity:             b.Metadata[MCPIdentityMetadataKey],
+		MCPServersSnapshot:      b.Metadata[MCPServersSnapshotMetadataKey],
+
+		ProviderTerminalError: b.Metadata["provider_terminal_error"],
+		HealthState:           b.Metadata["session_health"],
+		HealthReason:          b.Metadata["session_health_reason"],
+		Drainable:             strings.TrimSpace(b.Metadata["session_drainable"]) == "true",
+
+		TriggerBeadID:       b.Metadata[beadmeta.TriggerBeadIDMetadataKey],
+		TriggerBeadStoreRef: b.Metadata[beadmeta.TriggerBeadStoreRefMetadataKey],
+		BrainParentSID:      b.Metadata[beadmeta.BrainParentSIDMetadataKey],
+		Pack:                b.Metadata[beadmeta.PackMetadataKey],
+
+		MetadataState:              b.Metadata["state"],
+		SessionNameMetadata:        b.Metadata["session_name"],
+		PendingCreateClaim:         strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true",
+		PendingCreateClaimMetadata: b.Metadata["pending_create_claim"],
+		PendingCreateStartedAt:     b.Metadata["pending_create_started_at"],
+		QuarantinedUntil:           b.Metadata["quarantined_until"],
+		AliasHistory:               AliasHistory(b.Metadata),
+		ContinuityEligible:         b.Metadata["continuity_eligible"],
+		TransportMetadata:          b.Metadata["transport"],
+		LastWokeAt:                 b.Metadata["last_woke_at"],
+		StateReason:                b.Metadata["state_reason"],
+		CreationCompleteAt:         b.Metadata["creation_complete_at"],
+		ContinuationResetPending:   b.Metadata["continuation_reset_pending"],
+		ResetCommittedAt:           b.Metadata[ResetCommittedAtKey],
+		Generation:                 b.Metadata["generation"],
+		StartedConfigHash:          b.Metadata["started_config_hash"],
+		PinAwake:                   b.Metadata["pin_awake"],
+
+		HeldUntil:                      b.Metadata["held_until"],
+		WaitHold:                       b.Metadata["wait_hold"],
+		ChurnCount:                     b.Metadata["churn_count"],
+		WakeMode:                       b.Metadata["wake_mode"],
+		SleepIntent:                    b.Metadata["sleep_intent"],
+		InstanceToken:                  b.Metadata["instance_token"],
+		DetachedAt:                     b.Metadata["detached_at"],
+		CurrentlyProcessingBeadID:      b.Metadata[CurrentBeadIDKey],
+		CoreHashBreakdown:              b.Metadata["core_hash_breakdown"],
+		StartedProvisionHash:           b.Metadata["started_provision_hash"],
+		StartedLaunchHash:              b.Metadata["started_launch_hash"],
+		StartedLiveHash:                b.Metadata["started_live_hash"],
+		ConfigDriftDeferredAt:          b.Metadata["config_drift_deferred_at"],
+		ConfigDriftDeferredKey:         b.Metadata["config_drift_deferred_key"],
+		AttachedConfigDriftDeferredAt:  b.Metadata["attached_config_drift_deferred_at"],
+		AttachedConfigDriftDeferredKey: b.Metadata["attached_config_drift_deferred_key"],
+		StrandedEventEmittedAt:         b.Metadata["stranded_event_emitted_at"],
+		SessionNameExplicit:            b.Metadata["session_name_explicit"],
+		WakeRequest:                    b.Metadata["wake_request"],
+		RestartRequested:               b.Metadata["restart_requested"],
+		SessionIDFlag:                  b.Metadata["session_id_flag"],
+		TemplateOverrides:              b.Metadata["template_overrides"],
+		WakeAttemptsMetadata:           b.Metadata["wake_attempts"],
+		ProviderKind:                   b.Metadata["provider_kind"],
+	}
+	if n, err := strconv.Atoi(b.Metadata["wake_attempts"]); err == nil {
+		info.WakeAttempts = n
+	}
+	if raw := strings.TrimSpace(b.Metadata[MetadataLastNudgeDeliveredAt]); raw != "" {
+		if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+			info.LastNudgeDeliveredAt = parsed
+		}
+	}
+	return info
+}
+
+// TestInfoCodecProjectionParity (T2) is the independent projection oracle: the
+// new table-driven InfoFromPersistedBead must equal the frozen pre-S09b
+// struct-literal projection byte-for-byte, over the diverse oracle base beads
+// (populated/closed/no-name/acp/sparse) plus per-key edge fixtures that reach
+// the parsed/coupled branches (Atoi failure, RFC3339 garbage, alias
+// normalization, whitespace bools, awake/drained state remap). Unlike the
+// fold==reprojection oracle (which compares two table-driven paths), this pins
+// the table against a copy of the OLD code, so a shared table bug is caught.
+func TestInfoCodecProjectionParity(t *testing.T) {
+	beadsToCheck := oracleBaseBeads()
+
+	created := time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC)
+	edgeMeta := []map[string]string{
+		{"wake_attempts": "not-an-int"},
+		{"wake_attempts": "12"},
+		{"wake_attempts": " 3 "}, // Atoi rejects whitespace -> 0
+		{MetadataLastNudgeDeliveredAt: "garbage"},
+		{MetadataLastNudgeDeliveredAt: " 2025-06-01T00:00:00Z "},
+		{aliasHistoryMetadataKey: " a , b ,a, c "},
+		{aliasHistoryMetadataKey: ""},
+		{"pool_managed": " true ", "dependency_only": " true ", "manual_session": "TRUE"},
+		{"state": "awake"},
+		{"state": "drained"},
+		{"provider": "acp"},                     // provider fallback -> transport "acp"
+		{"provider": "acp", "transport": ""},    // explicit empty transport, provider fallback
+		{"provider": "claude", "transport": ""}, // no fallback -> transport ""
+		{"session_name": ""},                    // sessionNameFor fallback
+	}
+	for i, m := range edgeMeta {
+		beadsToCheck = append(beadsToCheck,
+			beads.Bead{ID: "edge-" + strconv.Itoa(i), Type: "gc:session", Status: "open", Title: "E", Labels: []string{"gc:session"}, CreatedAt: created, Metadata: m},
+			beads.Bead{ID: "edge-closed-" + strconv.Itoa(i), Type: "gc:session", Status: "closed", Title: "E", Labels: []string{"gc:session"}, CreatedAt: created, Metadata: m},
+		)
+	}
+
+	for _, b := range beadsToCheck {
+		got := InfoFromPersistedBead(b)
+		want := infoFromPersistedBeadFrozen(b)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("bead=%s: table projection diverged from frozen reference\n got=%+v\nwant=%+v", b.ID, got, want)
+		}
+	}
+}
+
+// TestInfoCodecKeysMatchProjectedList (T1) asserts the table's key set equals
+// the hand-maintained allProjectedMetadataKeys list used by the fold oracle.
+// A silently dropped or extra table entry is caught here even if the fold
+// oracle's key list drifts in lockstep.
+func TestInfoCodecKeysMatchProjectedList(t *testing.T) {
+	tableKeys := map[string]bool{}
+	for i := range infoKeyCodec {
+		k := infoKeyCodec[i].key
+		if tableKeys[k] {
+			t.Errorf("duplicate key %q in infoKeyCodec", k)
+		}
+		tableKeys[k] = true
+	}
+	listKeys := map[string]bool{}
+	for _, k := range allProjectedMetadataKeys {
+		listKeys[k] = true
+	}
+	for k := range tableKeys {
+		if !listKeys[k] {
+			t.Errorf("infoKeyCodec key %q missing from allProjectedMetadataKeys", k)
+		}
+	}
+	for k := range listKeys {
+		if !tableKeys[k] {
+			t.Errorf("allProjectedMetadataKeys key %q missing from infoKeyCodec", k)
+		}
+	}
+	if len(infoKeyIndex) != len(infoKeyCodec) {
+		t.Errorf("infoKeyIndex size %d != infoKeyCodec size %d (duplicate key collapsed?)", len(infoKeyIndex), len(infoKeyCodec))
+	}
+}
+
+// TestInfoCodecEmptyStringClears (T3) drives the empty-string-clear invariant
+// (I3) off the table: for every key, folding {key: ""} onto a fully-populated
+// projection must equal projecting the same bead with that key deleted.
+func TestInfoCodecEmptyStringClears(t *testing.T) {
+	base := oracleBaseBeads()[0] // fully-populated open bead
+	baseInfo := InfoFromPersistedBead(base)
+	for i := range infoKeyCodec {
+		key := infoKeyCodec[i].key
+		cleared := baseInfo.ApplyPatch(MetadataPatch{key: ""})
+
+		deletedMeta := make(map[string]string, len(base.Metadata))
+		for k, v := range base.Metadata {
+			if k == key {
+				continue
+			}
+			deletedMeta[k] = v
+		}
+		deleted := base
+		deleted.Metadata = deletedMeta
+		want := InfoFromPersistedBead(deleted)
+
+		if !reflect.DeepEqual(cleared, want) {
+			t.Errorf("key=%q: empty-string clear diverged from key-deleted projection\n got=%+v\nwant=%+v", key, cleared, want)
+		}
+	}
+}
+
+// TestInfoCodecFieldsDisjoint (T4) locks invariant I6: every pair of table
+// setters writes a disjoint set of Info fields, EXCEPT the documented
+// provider/transport pair (both derive Transport). It also asserts
+// provider precedes transport in the table so the derived Transport is
+// finalized with both raw mirrors in scope.
+func TestInfoCodecFieldsDisjoint(t *testing.T) {
+	// touchedFields applies a setter with a sentinel value to a zero Info and
+	// returns the set of struct field indices it changed.
+	touchedFields := func(set func(*Info, string), v string) map[int]bool {
+		var info Info
+		set(&info, v)
+		changed := map[int]bool{}
+		zero := Info{}
+		rv, rz := reflect.ValueOf(info), reflect.ValueOf(zero)
+		for f := 0; f < rv.NumField(); f++ {
+			if !reflect.DeepEqual(rv.Field(f).Interface(), rz.Field(f).Interface()) {
+				changed[f] = true
+			}
+		}
+		return changed
+	}
+
+	fields := make([]map[int]bool, len(infoKeyCodec))
+	for i := range infoKeyCodec {
+		// A distinctive non-empty value so string/bool/int/slice setters all
+		// move their field off the zero value. "1" trims to a truthy bool and
+		// parses as an int; a non-time string leaves LastNudgeDeliveredAt zero
+		// (that key touches only a time field, still detected via its raw mirror
+		// where one exists — wake_attempts mirror moves).
+		fields[i] = touchedFields(infoKeyCodec[i].set, "1")
+	}
+
+	providerIdx, transportIdx := -1, -1
+	for i := range infoKeyCodec {
+		switch infoKeyCodec[i].key {
+		case "provider":
+			providerIdx = i
+		case "transport":
+			transportIdx = i
+		}
+	}
+	if providerIdx == -1 || transportIdx == -1 {
+		t.Fatal("provider/transport keys not found in table")
+	}
+	if providerIdx >= transportIdx {
+		t.Errorf("provider (idx %d) must precede transport (idx %d) in infoKeyCodec", providerIdx, transportIdx)
+	}
+
+	isProviderTransportPair := func(a, b int) bool {
+		return (a == providerIdx && b == transportIdx) || (a == transportIdx && b == providerIdx)
+	}
+
+	for a := range infoKeyCodec {
+		for b := a + 1; b < len(infoKeyCodec); b++ {
+			if isProviderTransportPair(a, b) {
+				continue
+			}
+			for f := range fields[a] {
+				if fields[b][f] {
+					t.Errorf("keys %q and %q both write Info field index %d (non-disjoint)", infoKeyCodec[a].key, infoKeyCodec[b].key, f)
+				}
+			}
+		}
+	}
+}
+
+// TestInfoCodecProviderTransportOrderConverges (part of R2 mitigation) applies
+// a two-key provider+transport patch in BOTH iteration orders and asserts the
+// final Transport matches the from-scratch projection either way. Guards the
+// E-5 convergence property against a future reorder.
+func TestInfoCodecProviderTransportOrderConverges(t *testing.T) {
+	base := oracleBaseBeads()[3] // acp base: provider fallback is live
+	baseInfo := InfoFromPersistedBead(base)
+
+	quadrants := []struct{ provider, transport string }{
+		{"gemini", "tmux"},
+		{"acp", ""},
+		{"claude", ""},
+		{"", "acp"},
+		{"", ""},
+	}
+	for _, q := range quadrants {
+		// Apply as separate single-key patches in each order (single-key
+		// ApplyPatch calls make the ordering explicit and deterministic).
+		fwd := baseInfo.ApplyPatch(MetadataPatch{"provider": q.provider}).ApplyPatch(MetadataPatch{"transport": q.transport})
+		rev := baseInfo.ApplyPatch(MetadataPatch{"transport": q.transport}).ApplyPatch(MetadataPatch{"provider": q.provider})
+
+		wantMeta := make(map[string]string, len(base.Metadata))
+		for k, v := range base.Metadata {
+			wantMeta[k] = v
+		}
+		wantMeta["provider"] = q.provider
+		wantMeta["transport"] = q.transport
+		wantBead := base
+		wantBead.Metadata = wantMeta
+		want := InfoFromPersistedBead(wantBead)
+
+		if fwd.Transport != want.Transport {
+			t.Errorf("provider=%q transport=%q: fwd Transport=%q, want %q", q.provider, q.transport, fwd.Transport, want.Transport)
+		}
+		if rev.Transport != want.Transport {
+			t.Errorf("provider=%q transport=%q: rev Transport=%q, want %q", q.provider, q.transport, rev.Transport, want.Transport)
+		}
+	}
+}

--- a/internal/session/info_codec_test.go
+++ b/internal/session/info_codec_test.go
@@ -257,14 +257,29 @@ func TestInfoCodecFieldsDisjoint(t *testing.T) {
 		return changed
 	}
 
+	// sentinelFor returns a per-key value that actually moves every field the
+	// key's setter writes off its zero value, so each setter contributes a
+	// non-empty touched-field set to the pairwise check. The default "1" trims
+	// to a truthy int and a non-empty string, but the `== "true"` boolean
+	// setters only flip their bool on "true", and the RFC3339-only
+	// last_nudge_delivered_at setter only moves on a valid timestamp; without
+	// these overrides those setters report an empty set and silently drop out of
+	// the disjointness assertion — the exact invariant this test exists to prove.
+	sentinelFor := func(key string) string {
+		switch key {
+		case NamedSessionMetadataKey, "pool_managed", "dependency_only",
+			"manual_session", "session_drainable", "pending_create_claim":
+			return "true"
+		case MetadataLastNudgeDeliveredAt:
+			return "2025-06-01T00:00:00Z"
+		default:
+			return "1"
+		}
+	}
+
 	fields := make([]map[int]bool, len(infoKeyCodec))
 	for i := range infoKeyCodec {
-		// A distinctive non-empty value so string/bool/int/slice setters all
-		// move their field off the zero value. "1" trims to a truthy bool and
-		// parses as an int; a non-time string leaves LastNudgeDeliveredAt zero
-		// (that key touches only a time field, still detected via its raw mirror
-		// where one exists — wake_attempts mirror moves).
-		fields[i] = touchedFields(infoKeyCodec[i].set, "1")
+		fields[i] = touchedFields(infoKeyCodec[i].set, sentinelFor(infoKeyCodec[i].key))
 	}
 
 	providerIdx, transportIdx := -1, -1

--- a/internal/session/info_store.go
+++ b/internal/session/info_store.go
@@ -2,11 +2,8 @@ package session
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
-	"time"
 
-	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
@@ -21,129 +18,26 @@ import (
 // Info. Callers that need live runtime state (Attached, runtime-downgraded
 // State, detected transport) must go through Manager, not this function.
 func InfoFromPersistedBead(b beads.Bead) Info {
-	sessName := b.Metadata["session_name"]
-	if sessName == "" {
-		sessName = sessionNameFor(b.ID)
-	}
-	closed := b.Status == "closed"
-
-	state := normalizeInfoState(State(b.Metadata["state"]))
-	if closed {
-		state = "" // closed beads have no runtime state
-	}
-
+	// Bead-level prologue: fields that are not metadata-derived. These MUST be
+	// set before the codec table runs — the session_name setter reads info.ID
+	// for its sessionNameFor fallback, and the state setter reads info.Closed to
+	// blank State on closed beads (invariant I6).
 	info := Info{
-		ID:            b.ID,
-		Type:          b.Type,
-		Template:      b.Metadata["template"],
-		State:         state,
-		Closed:        closed,
-		Title:         b.Title,
-		Alias:         b.Metadata["alias"],
-		AgentName:     b.Metadata["agent_name"],
-		Provider:      b.Metadata["provider"],
-		Transport:     transportFromMetadata(b),
-		Command:       b.Metadata["command"],
-		WorkDir:       b.Metadata["work_dir"],
-		SessionName:   sessName,
-		SessionKey:    b.Metadata["session_key"],
-		ResumeFlag:    b.Metadata["resume_flag"],
-		ResumeStyle:   b.Metadata["resume_style"],
-		ResumeCommand: b.Metadata["resume_command"],
-		CreatedAt:     b.CreatedAt,
-
-		ContinuationEpoch: b.Metadata["continuation_epoch"],
-		SleepReason:       b.Metadata["sleep_reason"],
-
-		// identity / pool / named-session cluster
-		ConfiguredNamedIdentity: b.Metadata[NamedSessionIdentityMetadata],
-		ConfiguredNamedSession:  strings.TrimSpace(b.Metadata[NamedSessionMetadataKey]) == "true",
-		ConfiguredNamedMode:     b.Metadata[NamedSessionModeMetadata],
-		CommonName:              b.Metadata["common_name"],
-		PoolSlot:                b.Metadata["pool_slot"],
-		PoolManaged:             strings.TrimSpace(b.Metadata["pool_managed"]) == "true",
-		SessionOrigin:           b.Metadata["session_origin"],
-		DependencyOnly:          strings.TrimSpace(b.Metadata["dependency_only"]) == "true",
-		DependencyOnlyMetadata:  b.Metadata["dependency_only"],
-		ManualSession:           strings.TrimSpace(b.Metadata["manual_session"]) == "true",
-		ManualSessionMetadata:   b.Metadata["manual_session"],
-		Labels:                  b.Labels,
-		MCPIdentity:             b.Metadata[MCPIdentityMetadataKey],
-		MCPServersSnapshot:      b.Metadata[MCPServersSnapshotMetadataKey],
-
-		// health / provider-terminal-error cluster. The key literals mirror the
-		// cmd/gc session_reconcile constants (session_health, session_drainable,
-		// …); the classifier-equivalence test guards against drift.
-		ProviderTerminalError: b.Metadata["provider_terminal_error"],
-		HealthState:           b.Metadata["session_health"],
-		HealthReason:          b.Metadata["session_health_reason"],
-		Drainable:             strings.TrimSpace(b.Metadata["session_drainable"]) == "true",
-
-		// trigger / brain-parent cluster (canonical gc.* keys via beadmeta).
-		TriggerBeadID:       b.Metadata[beadmeta.TriggerBeadIDMetadataKey],
-		TriggerBeadStoreRef: b.Metadata[beadmeta.TriggerBeadStoreRefMetadataKey],
-		BrainParentSID:      b.Metadata[beadmeta.BrainParentSIDMetadataKey],
-		Pack:                b.Metadata[beadmeta.PackMetadataKey],
-
-		// state / bookkeeping cluster. MetadataState is the RAW state metadata,
-		// kept verbatim so the reconciler classifiers read the same value the
-		// bead carried (Info.State above is the normalized, closed-blanked form).
-		MetadataState:              b.Metadata["state"],
-		SessionNameMetadata:        b.Metadata["session_name"],
-		PendingCreateClaim:         strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true",
-		PendingCreateClaimMetadata: b.Metadata["pending_create_claim"],
-		PendingCreateStartedAt:     b.Metadata["pending_create_started_at"],
-		QuarantinedUntil:           b.Metadata["quarantined_until"],
-		AliasHistory:               AliasHistory(b.Metadata),
-		ContinuityEligible:         b.Metadata["continuity_eligible"],
-		TransportMetadata:          b.Metadata["transport"],
-		LastWokeAt:                 b.Metadata["last_woke_at"],
-		StateReason:                b.Metadata["state_reason"],
-		CreationCompleteAt:         b.Metadata["creation_complete_at"],
-		ContinuationResetPending:   b.Metadata["continuation_reset_pending"],
-		ResetCommittedAt:           b.Metadata[ResetCommittedAtKey],
-		Generation:                 b.Metadata["generation"],
-		StartedConfigHash:          b.Metadata["started_config_hash"],
-		PinAwake:                   b.Metadata["pin_awake"],
-
-		// reconciler decision-read cluster (front-door Phase 5). Raw mirrors of
-		// the keys the reconciler decision paths still crack inline. The key
-		// literals mirror the cmd/gc reconciler constants (config_drift_deferred_*,
-		// attached_config_drift_deferred_*, stranded_event_emitted_at, …); the
-		// classifier-equivalence oracle feeds those constants and so guards these
-		// literals against drift. CurrentBeadIDKey is a session-package constant.
-		HeldUntil:                      b.Metadata["held_until"],
-		WaitHold:                       b.Metadata["wait_hold"],
-		ChurnCount:                     b.Metadata["churn_count"],
-		WakeMode:                       b.Metadata["wake_mode"],
-		SleepIntent:                    b.Metadata["sleep_intent"],
-		InstanceToken:                  b.Metadata["instance_token"],
-		DetachedAt:                     b.Metadata["detached_at"],
-		CurrentlyProcessingBeadID:      b.Metadata[CurrentBeadIDKey],
-		CoreHashBreakdown:              b.Metadata["core_hash_breakdown"],
-		StartedProvisionHash:           b.Metadata["started_provision_hash"],
-		StartedLaunchHash:              b.Metadata["started_launch_hash"],
-		StartedLiveHash:                b.Metadata["started_live_hash"],
-		ConfigDriftDeferredAt:          b.Metadata["config_drift_deferred_at"],
-		ConfigDriftDeferredKey:         b.Metadata["config_drift_deferred_key"],
-		AttachedConfigDriftDeferredAt:  b.Metadata["attached_config_drift_deferred_at"],
-		AttachedConfigDriftDeferredKey: b.Metadata["attached_config_drift_deferred_key"],
-		StrandedEventEmittedAt:         b.Metadata["stranded_event_emitted_at"],
-		SessionNameExplicit:            b.Metadata["session_name_explicit"],
-		WakeRequest:                    b.Metadata["wake_request"],
-		RestartRequested:               b.Metadata["restart_requested"],
-		SessionIDFlag:                  b.Metadata["session_id_flag"],
-		TemplateOverrides:              b.Metadata["template_overrides"],
-		WakeAttemptsMetadata:           b.Metadata["wake_attempts"],
-		ProviderKind:                   b.Metadata["provider_kind"],
+		ID:        b.ID,
+		Type:      b.Type,
+		Title:     b.Title,
+		Labels:    b.Labels,
+		CreatedAt: b.CreatedAt,
+		Closed:    b.Status == "closed",
 	}
-	if n, err := strconv.Atoi(b.Metadata["wake_attempts"]); err == nil {
-		info.WakeAttempts = n
-	}
-	if raw := strings.TrimSpace(b.Metadata[MetadataLastNudgeDeliveredAt]); raw != "" {
-		if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
-			info.LastNudgeDeliveredAt = parsed
-		}
+	// Project every metadata-derived field through the shared codec table. An
+	// absent key reads as "" (Go map default), matching the old struct literal's
+	// zero-valued reads; each setter is total over "". Starting from a fresh
+	// zero-valued Info, the table's ApplyPatch-form setters reproduce the old
+	// projection exactly (invariant I1, gated by the parity oracle tests).
+	for i := range infoKeyCodec {
+		spec := &infoKeyCodec[i]
+		spec.set(&info, b.Metadata[spec.key])
 	}
 	return info
 }


### PR DESCRIPTION
Follow-on to merged S09 (#4033). Part 1 introduces a table-driven Info codec (parity-gated) and migrates cmd/gc sleep-reason literals to the codec. Part of #3789.

- Gates green (fast suite, vet, pre-commit)
- Fable-reviewed, behavior-preserved
- Spec: engdocs/simplification/specs/S09b-info-codec-spec.md

Spike/staged for review, not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)