### PR TITLE
fix(worker): use correct `mimo --never-ask` flag for mimocode provider

### DIFF
--- a/cmd/gc/template_resolve_phase2_test.go
+++ b/cmd/gc/template_resolve_phase2_test.go
@@ -115,7 +115,7 @@ func selectedPhase2ProviderCases(t *testing.T) []phase2ProviderCase {
 		{
 			profileID:             "mimocode/tmux-cli",
 			family:                "mimocode",
-			wantCommand:           "mimo --never-ask-questions",
+			wantCommand:           "mimo --never-ask",
 			wantPromptMode:        "flag",
 			wantPromptFlag:        "--prompt",
 			wantReadyDelayMs:      8000,
@@ -235,7 +235,7 @@ func resolveMimoCodeDefaultTransportTemplate(t *testing.T, session string) Templ
 
 // TestResolveTemplateMimoCodeDefaultTransportStaysOnCLI pins the out-of-box
 // launch for `provider = "mimocode"` with no session override. The headless
-// gate suppression flag (--never-ask-questions) is a TUI-surface flag that
+// gate suppression flag (--never-ask) is a TUI-surface flag that
 // the `mimo acp` subcommand does not take, and live conformance coverage for
 // mimocode exists only on the CLI transport, so the default launch must be
 // the CLI command, not `mimo acp`.
@@ -244,8 +244,8 @@ func TestResolveTemplateMimoCodeDefaultTransportStaysOnCLI(t *testing.T) {
 	if tp.IsACP {
 		t.Fatal("IsACP = true for default mimocode session, want CLI transport")
 	}
-	if tp.Command != "mimo --never-ask-questions" {
-		t.Fatalf("Command = %q, want %q", tp.Command, "mimo --never-ask-questions")
+	if tp.Command != "mimo --never-ask" {
+		t.Fatalf("Command = %q, want %q", tp.Command, "mimo --never-ask")
 	}
 }
 

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -331,7 +331,7 @@ func (rp *ResolvedProvider) ProviderSessionCreateTransport() string {
 		return ""
 	}
 	if family == "mimocode" {
-		// MiMo Code supports explicit ACP sessions, but --never-ask-questions
+		// MiMo Code supports explicit ACP sessions, but --never-ask
 		// — the flag that suppresses the question/plan gates headless runs
 		// require — is not taken by the `mimo acp` subcommand, and ACPArgs
 		// replaces Args, so an ACP default would compose a launch without it.

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -795,7 +795,7 @@ func TestProviderSessionCreateTransportBuiltinMimoCodeStaysOnCLIByDefault(t *tes
 			rp: ResolvedProvider{
 				Name:        "mimocode",
 				Command:     "mimo",
-				Args:        []string{"--never-ask-questions"},
+				Args:        []string{"--never-ask"},
 				SupportsACP: true,
 				ACPArgs:     []string{"acp"},
 			},
@@ -806,7 +806,7 @@ func TestProviderSessionCreateTransportBuiltinMimoCodeStaysOnCLIByDefault(t *tes
 				Name:            "custom-mimocode",
 				BuiltinAncestor: "mimocode",
 				Command:         "mimo",
-				Args:            []string{"--never-ask-questions"},
+				Args:            []string{"--never-ask"},
 				SupportsACP:     true,
 				ACPArgs:         []string{"acp"},
 			},
@@ -825,7 +825,7 @@ func TestProviderSessionCreateTransportBuiltinMimoCodeStaysOnCLIByDefault(t *tes
 			if got := ResolveSessionCreateTransport("acp", &rp); got != "acp" {
 				t.Fatalf("ResolveSessionCreateTransport(acp) = %q, want acp", got)
 			}
-			if got := rp.CommandString(); got != "mimo --never-ask-questions" {
+			if got := rp.CommandString(); got != "mimo --never-ask" {
 				t.Fatalf("CommandString() = %q, want headless MiMo CLI command", got)
 			}
 			if got := rp.ACPCommandString(); got != "mimo acp" {

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -540,7 +540,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		// MiMo Code (Xiaomi's `mimo` CLI) is an OpenCode fork. Permission
 		// defaults are already permissive for bash/edit; only the
 		// question/plan interaction gates block headless runs, so
-		// --never-ask-questions is the only default arg needed. The flag is
+		// --never-ask is the only default arg needed. The flag is
 		// not taken by the `mimo acp` subcommand, so sessions default to the
 		// CLI transport (config.ProviderSessionCreateTransport) and ACP stays
 		// explicit opt-in until `mimo acp` has equivalent non-interactive
@@ -548,7 +548,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		// would clobber user config.
 		DisplayName:      "MiMo Code",
 		Command:          "mimo",
-		Args:             []string{"--never-ask-questions"},
+		Args:             []string{"--never-ask"},
 		PromptMode:       "flag",
 		PromptFlag:       "--prompt",
 		ReadyDelayMs:     8000,

--- a/internal/worker/builtin/profiles_test.go
+++ b/internal/worker/builtin/profiles_test.go
@@ -41,8 +41,8 @@ func TestBuiltinProviderMimoCodeSpec(t *testing.T) {
 	if spec.DisplayName != "MiMo Code" {
 		t.Errorf("mimocode DisplayName = %q, want %q", spec.DisplayName, "MiMo Code")
 	}
-	if len(spec.Args) != 1 || spec.Args[0] != "--never-ask-questions" {
-		t.Errorf("mimocode Args = %v, want [--never-ask-questions]", spec.Args)
+	if len(spec.Args) != 1 || spec.Args[0] != "--never-ask" {
+		t.Errorf("mimocode Args = %v, want [--never-ask]", spec.Args)
 	}
 	if spec.PromptMode != "flag" || spec.PromptFlag != "--prompt" {
 		t.Errorf("mimocode prompt = (%q, %q), want (flag, --prompt)", spec.PromptMode, spec.PromptFlag)

--- a/test/acceptance/worker_inference/worker_inference_test.go
+++ b/test/acceptance/worker_inference/worker_inference_test.go
@@ -1678,7 +1678,7 @@ func noSkillLiveProviderDefaults(provider string) (promptMode, promptFlag string
 	case "opencode":
 		return "flag", "--prompt", 8000, nil
 	case "mimocode":
-		return "flag", "--prompt", 8000, []string{"--never-ask-questions"}
+		return "flag", "--prompt", 8000, []string{"--never-ask"}
 	case "antigravity":
 		return "flag", "--prompt-interactive", 5000, []string{"--dangerously-skip-permissions"}
 	default:


### PR DESCRIPTION
## Summary

The mimocode builtin provider launched `mimo --never-ask-questions`, but the correct flag is `--never-ask`. Fix the default Args in internal/worker/builtin/profiles.go and align all comments and tests (config, cmd/gc phase2, worker builtin, acceptance) that referenced the old flag name.

Fixes #4075 

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
  > **Note:** `docs/` is authored for [docs.gascityhall.com](https://docs.gascityhall.com) (Mintlify), not for direct GitHub viewing. Use extensionless page links (e.g. `/tutorials/01-beads`, not `/tutorials/01-beads.md`). If something looks broken on GitHub but works on the live site, that's intentional.
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes
