### PR TITLE
simplify(S19) stage 3 (3a-3c): shadow-comparison harness (observation-only)

### DIFF
--- a/cmd/gc/adoption_barrier.go
+++ b/cmd/gc/adoption_barrier.go
@@ -249,13 +249,18 @@ func runAdoptionBarrier(
 		alreadyHadBead := false
 		createSessionBead := func() error {
 			meta["synced_at"] = clk.Now().UTC().Format("2006-01-02T15:04:05Z07:00")
-			if _, err := sessFront.CreateSession(sessionpkg.CreateSpec{
+			beadID, err := sessFront.CreateSession(sessionpkg.CreateSpec{
 				Title:     detail.AgentName,
 				AgentName: detail.AgentName,
 				Metadata:  meta,
-			}); err != nil {
+			})
+			if err != nil {
 				return fmt.Errorf("creating session bead for %q: %w", sessionName, err)
 			}
+			// S19 Stage 3 shadow: record the legacy canonical-identity stamp built
+			// by desiredSessionIdentity for this adopted bead (no-op unless the
+			// shadow harness is enabled).
+			recordLegacyCompareWrites(beadID, "adoptionBarrier.create", meta)
 			return nil
 		}
 		createErr := sessionpkg.WithCitySessionIdentifierLocks(cityPath, []string{sessionName, detail.AgentName}, func() error {

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -440,6 +440,10 @@ func reopenClosedConfiguredNamedSessionBead(
 			batch[k] = v
 		}
 		if setMetaBatch(sessionFrontDoor(store), bead.ID, batch, stderr) == nil {
+			// S19 Stage 3 shadow: record the legacy priming-marker clears so the
+			// converge comparator can attribute this owned-key delta (no-op unless
+			// the shadow harness is enabled).
+			recordLegacyCompareWrites(bead.ID, "syncSessionBeads.reclaim", batch)
 			if bead.Metadata == nil {
 				bead.Metadata = make(map[string]string, len(batch))
 			}
@@ -1322,6 +1326,10 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			case finalizeErr != nil:
 				continue
 			default:
+				// S19 Stage 3 shadow: record the legacy canonical-identity stamp
+				// (built by desiredSessionIdentity above) now that the bead ID
+				// exists. No-op unless the shadow harness is enabled.
+				recordLegacyCompareWrites(newBead.ID, "syncSessionBeads.create", meta)
 				desiredNames[createdSessionName] = true
 				openIndex[createdSessionName] = newBead.ID
 				openBeads = append(openBeads, newBead)

--- a/cmd/gc/session_converge_shadow.go
+++ b/cmd/gc/session_converge_shadow.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -74,8 +75,10 @@ var convergeComparedKeySet = func() map[string]bool {
 }()
 
 // convergeShadowEnabled is the process-wide, fail-closed latch for the shadow
-// harness. It is read from GC_CONVERGE_SHADOW once and cached. An unset,
-// empty, unparseable, or false value is hard OFF (legacy-only, byte-identical).
+// harness. It is EVALUATED PER CALL — every invocation re-reads
+// GC_CONVERGE_SHADOW; the value is not latched or cached (tests toggle it via
+// t.Setenv, so do NOT wrap it in sync.OnceValue). An unset, empty, unparseable,
+// or false value is hard OFF (legacy-only, byte-identical).
 //
 // This is the OBSERVER kill-switch (the 138K/day wisp-flood precedent says the
 // observer needs one too). It is deliberately NOT the 3e per-city durable
@@ -107,9 +110,14 @@ const (
 	// divergenceUnpredictedDelta: an owned-key delta the derivation did not
 	// predict but which a legacy recorder entry explains (derivation gap).
 	divergenceUnpredictedDelta convergeDivergenceClass = "unpredicted_delta"
-	// divergenceForeignWrite: an owned-key delta with neither a recorder entry
-	// nor a derived prediction — some other writer (gc prime CLI, wake path,
-	// another observer). Must be zero for a soak to count.
+	// divergenceForeignWrite: an owned-key delta that no legacy recorder entry
+	// explains — either no compared-key write was recorded for it, or a recorded
+	// write did not materialize into the realized end snapshot. The start/end
+	// snapshots are built from this process's in-memory bead objects, so this
+	// detects only IN-PROCESS writers (the wake path, another in-process observer);
+	// a truly out-of-process writer (e.g. the separate `gc prime` CLI process)
+	// mutates the store, not these objects, and is not observable here. Must be
+	// zero for a soak to count.
 	divergenceForeignWrite convergeDivergenceClass = "foreign_write"
 	// divergenceFixpointNonEmpty: re-running deriveConvergeActions on END-of-tick
 	// facts returned a non-empty list (a derivation gap or a mid-tick mutation).
@@ -141,8 +149,12 @@ const (
 	// skipEarlyContinue: the legacy loop took an early-continue path (drain-ack,
 	// unknown-state) before the compared region, so there is nothing to compare.
 	skipEarlyContinue convergeSkipReason = "early_continue"
-	// skipShadowDisabled: the harness was not enabled for this session-tick.
-	skipShadowDisabled convergeSkipReason = "shadow_disabled"
+	// skipRecorderContended: a concurrent city tick already owned the process-global
+	// recorder for this window (the supervisor reconciles each city on its own
+	// goroutine), so this tick could not record its own legacy writes. Its sessions
+	// are skipped rather than scored against a recorder it does not own — an honest
+	// denominator instead of a false-divergence flood.
+	skipRecorderContended convergeSkipReason = "recorder_contended"
 )
 
 // convergeShadowCounters holds the in-process, monotonic Stage-3 metrics. These
@@ -156,8 +168,8 @@ type convergeShadowCounters struct {
 	incomparable      int64
 	recordsDropped    int64
 
-	compareTotal    map[string]int64                 // by derived action type
-	derived         map[string]int64                 // deriveConvergeActions emissions
+	compareTotal    map[string]int64                  // by derived action type
+	derived         map[string]int64                  // deriveConvergeActions emissions
 	divergenceTotal map[convergeDivergenceClass]int64 // by class
 }
 
@@ -287,9 +299,10 @@ func (c *convergeShadowCounters) snapshot() convergeCounterSnapshot {
 	return cp
 }
 
-// divergenceCount returns the total divergences that survived replay (i.e. the
-// classes that count against the acceptance bar). world_moved and boundary are
-// suppressed-but-counted classes and are excluded.
+// survivingDivergences returns the total divergences that survived replay (i.e.
+// the classes that count against the acceptance bar). world_moved, boundary, and
+// identity_skew are suppressed / positive-evidence classes: they are counted, but
+// excluded here because they do not fail the soak.
 func (s convergeCounterSnapshot) survivingDivergences() int64 {
 	var total int64
 	for class, n := range s.DivergenceTotal {
@@ -301,6 +314,24 @@ func (s convergeCounterSnapshot) survivingDivergences() int64 {
 		}
 	}
 	return total
+}
+
+// operatorSummary renders a single bounded, operator-facing line describing the
+// shadow soak signal: the proven denominator (evaluated sessions), the typed
+// skips that keep it honest, the count of incomparable ticks, the
+// surviving-divergence count that gates a soak, and dropped records. It is the
+// read path (Q3: no new event type — a behind-latch line on the reconciler's
+// existing stderr operator channel) that lets a live GC_CONVERGE_SHADOW soak be
+// observed end to end rather than incrementing counters nothing can read.
+func (s convergeCounterSnapshot) operatorSummary() string {
+	var skipped int64
+	for _, n := range s.SessionsSkipped {
+		skipped += n
+	}
+	return fmt.Sprintf(
+		"converge-shadow soak: evaluated=%d skipped=%d incomparable=%d surviving_divergences=%d dropped=%d",
+		s.SessionsEvaluated, skipped, s.Incomparable, s.survivingDivergences(), s.RecordsDropped,
+	)
 }
 
 // --- tri-state runtime facts (3a) ---------------------------------------------
@@ -425,6 +456,15 @@ func (r *legacyWriteRecorder) forSession(sessionID string) []legacyCompareWrite 
 // convergeGlobalRecorder is the process-global recorder the wired legacy write
 // sites feed. It is attached (non-nil) only while a shadow tick is in flight and
 // the harness is enabled; otherwise the write-site wrappers see nil and bail.
+//
+// The supervisor reconciles each city on its own goroutine, so multiple enabled
+// ticks can overlap in wall-clock. This is a single-owner slot guarded by an
+// ownership token (compare-and-swap): only the tick that installs the recorder
+// owns it, and only that tick may clear it (newConvergeShadowTick attaches via
+// CAS(nil,rec); convergeShadowTick.detach clears via CAS(rec,nil)). A concurrent
+// tick that loses the install CAS is a no-owner — it records nothing of its own
+// and skips its sessions at finish — so one city's tick can neither overwrite,
+// prematurely clear, nor misattribute another city's compared-key writes.
 var convergeGlobalRecorder atomic.Pointer[legacyWriteRecorder]
 
 // recordLegacyCompareWrites is THE recording wrapper every legacy write site of a
@@ -560,15 +600,22 @@ func evaluateStateDiffOracle(
 		actualChange := end[k] != start[k]
 
 		if shadowNoExecution {
-			// Foreign write: realized owned-key delta with no legacy recorder entry.
-			if actualChange && !recordedKeys[k] {
+			// Real-city shadow: the derived heal is NOT executed, so predicted-but-
+			// unrealized writes are EXPECTED and not flagged. A recorded legacy write
+			// only "explains" an owned key when it actually MATERIALIZED (realized end
+			// value == recorded value); otherwise it never landed (ApplyPatch failed)
+			// or was overwritten, so the realized state is NOT recorder-explained and
+			// must not be swallowed as clean — the false-negative this harness most
+			// needs to avoid. C4 value parity additionally flags a derived stamp whose
+			// value disagrees with the realized end (== recorded value here, so it
+			// compares against both). Pulled forward from Stage 5.
+			switch {
+			case recordedKeys[k] && end[k] != recordedValue[k]:
+				out = append(out, ownedKeyDivergence{sessionID, k, divergenceForeignWrite, recordedValue[k], end[k]})
+			case recordedKeys[k] && predictedChange && predEnd[k] != end[k]:
+				out = append(out, ownedKeyDivergence{sessionID, k, divergenceValueMismatch, predEnd[k], end[k]})
+			case !recordedKeys[k] && actualChange:
 				out = append(out, ownedKeyDivergence{sessionID, k, divergenceForeignWrite, "", end[k]})
-				continue
-			}
-			// C4 value parity: a derived stamp whose value disagrees with the value
-			// legacy actually wrote this tick. Pulled forward from Stage 5.
-			if predictedChange && recordedKeys[k] && predEnd[k] != recordedValue[k] {
-				out = append(out, ownedKeyDivergence{sessionID, k, divergenceValueMismatch, predEnd[k], recordedValue[k]})
 			}
 			continue
 		}
@@ -631,7 +678,7 @@ type replayInput struct {
 	runtime runtimeFacts
 	// legacyValues are the values the legacy path actually READ at decision time
 	// (used for deterministic replay). Empty when the legacy path did not read.
-	legacyValues durableFacts
+	legacyValues  durableFacts
 	legacyRuntime runtimeFacts
 	// legacyReplayable is true when legacyValues/legacyRuntime were captured, so
 	// a deterministic replay can run.
@@ -805,6 +852,13 @@ type convergeShadowTick struct {
 	counters  *convergeShadowCounters
 	evals     map[string]*shadowSessionEval
 	orderedID []string
+	// owned reports whether this tick won the ownership CAS for the process-global
+	// recorder. A tick that did not (a concurrent city tick owns it this window)
+	// records nothing and skips its sessions at finish.
+	owned bool
+	// detached guards detach() so it runs exactly once even though both finish and
+	// the reconciler's safety-net defer call it.
+	detached bool
 }
 
 // newConvergeShadowTick returns a live collector when the harness is enabled and
@@ -824,8 +878,27 @@ func newConvergeShadowTick(observerID string, tickSeq int64, tickNow time.Time, 
 		counters:   counters,
 		evals:      map[string]*shadowSessionEval{},
 	}
-	convergeGlobalRecorder.Store(rec)
+	// Ownership token: install the recorder only if no concurrent city tick already
+	// holds the slot. The loser stays a no-owner (owned=false) and its write sites
+	// will observe the winner's recorder but under this tick's globally-unique
+	// session ids, so they can never cross into the winner's own read-back.
+	t.owned = convergeGlobalRecorder.CompareAndSwap(nil, rec)
 	return t
+}
+
+// detach releases this tick's claim on the process-global recorder. It is
+// idempotent (finish and the reconciler's safety-net defer both call it) and
+// clears the slot only when this tick owns it, via CAS(rec,nil) — so a concurrent
+// owner's live recorder is never torn out from under it. A no-owner tick has
+// nothing to release.
+func (t *convergeShadowTick) detach() {
+	if t == nil || t.detached {
+		return
+	}
+	t.detached = true
+	if t.owned {
+		convergeGlobalRecorder.CompareAndSwap(t.recorder, nil)
+	}
 }
 
 // captureDurable records the durable facts + tick-start compared-key snapshot for
@@ -871,15 +944,28 @@ func (t *convergeShadowTick) captureRuntime(sessionID, probeSite, probeTarget st
 }
 
 // markSkip records a typed skip reason for a session-tick that cannot be
-// compared, keeping the denominator honest.
-func (t *convergeShadowTick) markSkip(sessionID string, r convergeSkipReason) {
+// compared, keeping the denominator honest. It drops the session from BOTH the
+// eval map and the ordered set so finish never re-counts a skipped tick as
+// capture-loss — a skipped session leaves the denominator exactly once.
+func (t *convergeShadowTick) markSkip(sessionID string, r convergeSkipReason) { //nolint:unparam // typed skip-and-remove primitive over the full skip vocabulary; only skipEarlyContinue needs mid-loop removal today
 	if t == nil {
 		return
 	}
 	if t.counters != nil {
 		t.counters.incSkipped(r)
 	}
+	if _, ok := t.evals[sessionID]; !ok {
+		// Never captured (skipped before captureDurable): count once, nothing to drop.
+		return
+	}
 	delete(t.evals, sessionID)
+	kept := t.orderedID[:0]
+	for _, id := range t.orderedID {
+		if id != sessionID {
+			kept = append(kept, id)
+		}
+	}
+	t.orderedID = kept
 }
 
 // finish evaluates every captured session against its tick-end snapshot (read
@@ -890,7 +976,19 @@ func (t *convergeShadowTick) finish(endSnaps map[string]map[string]string) {
 	if t == nil {
 		return
 	}
-	defer convergeGlobalRecorder.Store(nil)
+	defer t.detach()
+
+	// A concurrent city tick owns the process-global recorder this window, so this
+	// tick recorded none of its own legacy writes. Scoring against a recorder it
+	// does not own would flag every owned-key delta as a phantom foreign_write, so
+	// every captured session is a typed recorder_contended skip instead — the
+	// denominator stays honest and no false divergence is manufactured.
+	if !t.owned {
+		for range t.orderedID {
+			t.counters.incSkipped(skipRecorderContended)
+		}
+		return
+	}
 
 	ownedKeys := convergeCanonicalOwnedKeys
 	if !t.realCity {
@@ -908,80 +1006,99 @@ func (t *convergeShadowTick) finish(endSnaps map[string]map[string]string) {
 			t.counters.incSkipped(skipCaptureLoss)
 			continue
 		}
-		// A present-only runtime capture (alive unknown) cannot be compared for
-		// live-gated actions: mark NOT-COMPARABLE unless it did not probe at all.
-		rf := e.runtimeCap.runtimeFacts()
-		if e.runtimeCap.runtimePresent == convergeTriTrue && !e.runtimeCap.fullyProbed() {
-			t.counters.incIncomparable()
-			t.counters.incSkipped(skipNotComparable)
-			continue
-		}
+		t.evaluateCaptured(e, end, ownedKeys)
+	}
 
-		t.counters.incEvaluated()
+	t.tallyDroppedRecords()
+}
 
-		actions := deriveConvergeActions(e.durable, rf)
-		for _, a := range actions {
-			t.counters.incDerived(actionName(a))
-		}
+// evaluateCaptured runs the owned-key oracle, the fixpoint invariant (fixtures
+// only), and the replay comparator for one fully captured session against its
+// tick-end snapshot, updating the counters. A present-only runtime capture (alive
+// unknown) is NOT-COMPARABLE for live-gated actions and leaves the denominator
+// instead of being scored.
+func (t *convergeShadowTick) evaluateCaptured(e *shadowSessionEval, end map[string]string, ownedKeys []string) {
+	rf := e.runtimeCap.runtimeFacts()
+	if e.runtimeCap.runtimePresent == convergeTriTrue && !e.runtimeCap.fullyProbed() {
+		t.counters.incIncomparable()
+		t.counters.incSkipped(skipNotComparable)
+		return
+	}
 
-		// Oracle: attribute owned-key deltas. On real cities the derived heal is
-		// not executed, so shadowNoExecution suppresses the flip-stage
-		// end==apply(derived,start) assertion and keeps only foreign-write +
-		// C4 value-parity (no unrealized-prediction flood).
-		shadowNoExecution := t.realCity
-		recorded := t.recorder.forSession(id)
-		for _, dv := range evaluateStateDiffOracle(id, ownedKeys, e.startSnap, end, actions, e.pred, recorded, shadowNoExecution) {
-			t.counters.incDivergence(dv.class)
-		}
+	t.counters.incEvaluated()
 
-		// Fixpoint (fixtures only): re-derive on END-of-tick facts must be empty.
-		// This is a flip-stage invariant — in real-city shadow the derived heal is
-		// unexecuted, so the record stays absent and a canonical re-derive would be
-		// expected-non-empty; running it there would be a permanent false positive.
-		if !t.realCity {
-			endDurable := e.durable
-			endDurable.canonicalIdentity = strings.TrimSpace(end[sessionpkg.CanonicalInstanceNameMetadata])
-			endDurable.primedAt = end[sessionpkg.PrimedAtMetadataKey]
-			if v := strings.TrimSpace(end[sessionpkg.PrimingAttemptedAtMetadataKey]); v != "" {
-				if ts, err := time.Parse(time.RFC3339, v); err == nil {
-					endDurable.primingAttemptedAt = ts.UTC()
-				}
-			}
-			endDurable.primedPromptHash = end[sessionpkg.PromptHashMetadataKey]
-			if fp := deriveConvergeActions(endDurable, rf); len(fp) > 0 {
-				for range fp {
-					t.counters.incDivergence(divergenceFixpointNonEmpty)
-				}
-			}
-		}
+	actions := deriveConvergeActions(e.durable, rf)
+	for _, a := range actions {
+		t.counters.incDerived(actionName(a))
+	}
 
-		// Replay comparator: action-set agreement under suppression/replay.
-		verdict := compareReplay(replayInput{
-			sessionID:         id,
-			instanceToken:     e.instanceToken,
-			durable:           e.durable,
-			runtime:           rf,
-			legacyReplayable:  false,
-			suppression:       e.suppression,
-			primingExcluded:   t.realCity,
-			factsProbeTarget:  e.factsTarget,
-			legacyProbeTarget: e.legacyTarget,
-		})
-		for _, a := range verdict.comparedActions {
-			t.counters.incCompare(actionName(a))
-		}
-		for _, class := range verdict.divergences {
-			t.counters.incDivergence(class)
-		}
-		for _, class := range verdict.suppressed {
-			t.counters.incDivergence(class)
+	// Oracle: attribute owned-key deltas. On real cities the derived heal is not
+	// executed, so shadowNoExecution (== realCity) suppresses the flip-stage
+	// end==apply(derived,start) assertion and keeps only foreign-write + C4
+	// value-parity (no unrealized-prediction flood).
+	recorded := t.recorder.forSession(e.sessionID)
+	for _, dv := range evaluateStateDiffOracle(e.sessionID, ownedKeys, e.startSnap, end, actions, e.pred, recorded, t.realCity) {
+		t.counters.incDivergence(dv.class)
+	}
+
+	// Fixpoint (fixtures only): re-derive on END-of-tick facts must be empty. In
+	// real-city shadow the derived heal is unexecuted, so a canonical re-derive
+	// would be expected-non-empty; running it there would be a permanent false
+	// positive.
+	if !t.realCity {
+		residual := fixpointResidual(e.durable, end, rf)
+		for i := 0; i < residual; i++ {
+			t.counters.incDivergence(divergenceFixpointNonEmpty)
 		}
 	}
 
-	if t.recorder != nil && t.recorder.dropped > 0 {
-		for i := int64(0); i < t.recorder.dropped; i++ {
-			t.counters.incRecordsDropped()
+	// Replay comparator: action-set agreement under suppression/replay.
+	verdict := compareReplay(replayInput{
+		sessionID:         e.sessionID,
+		instanceToken:     e.instanceToken,
+		durable:           e.durable,
+		runtime:           rf,
+		legacyReplayable:  false,
+		suppression:       e.suppression,
+		primingExcluded:   t.realCity,
+		factsProbeTarget:  e.factsTarget,
+		legacyProbeTarget: e.legacyTarget,
+	})
+	for _, a := range verdict.comparedActions {
+		t.counters.incCompare(actionName(a))
+	}
+	for _, class := range verdict.divergences {
+		t.counters.incDivergence(class)
+	}
+	for _, class := range verdict.suppressed {
+		t.counters.incDivergence(class)
+	}
+}
+
+// fixpointResidual re-derives the converge actions on the END-of-tick durable
+// facts. A non-empty result is a flip-stage invariant breach (a derivation gap or
+// a mid-tick mutation); the residual action count is returned so each is counted.
+func fixpointResidual(durable durableFacts, end map[string]string, rf runtimeFacts) int {
+	endDurable := durable
+	endDurable.canonicalIdentity = strings.TrimSpace(end[sessionpkg.CanonicalInstanceNameMetadata])
+	endDurable.primedAt = end[sessionpkg.PrimedAtMetadataKey]
+	if v := strings.TrimSpace(end[sessionpkg.PrimingAttemptedAtMetadataKey]); v != "" {
+		if ts, err := time.Parse(time.RFC3339, v); err == nil {
+			endDurable.primingAttemptedAt = ts.UTC()
 		}
+	}
+	endDurable.primedPromptHash = end[sessionpkg.PromptHashMetadataKey]
+	return len(deriveConvergeActions(endDurable, rf))
+}
+
+// tallyDroppedRecords folds the recorder's dropped-write count (compared-key
+// writes seen before a bead ID existed) into the counters.
+func (t *convergeShadowTick) tallyDroppedRecords() {
+	if t.recorder == nil {
+		return
+	}
+	for i := int64(0); i < t.recorder.dropped; i++ {
+		t.counters.incRecordsDropped()
 	}
 }
 

--- a/cmd/gc/session_converge_shadow.go
+++ b/cmd/gc/session_converge_shadow.go
@@ -1,0 +1,1010 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// S19 Stage 3 shadow-comparison harness (steps 3a–3c, OBSERVATION-ONLY).
+//
+// This file proves that deriveConvergeActions (Stage 1) reproduces the legacy
+// per-path reconciler behavior EXACTLY, without changing any behavior. Nothing
+// here executes an action, double-writes, or mutates a session bead. It only:
+//
+//   3a — builds per-session {durableFacts, runtimeFacts} from ALREADY-observed
+//        reconciler state (no new probes, no writes);
+//   3b — records legacy writes of the compared metadata keys through an
+//        in-process synchronous recorder, snapshots those keys at tick start and
+//        tick end (the owned-key state-diff oracle), and judges derived-vs-legacy
+//        through a bounded-window replay comparator;
+//   3c — increments denominator + divergence counters (no new event type), and
+//        is validated by a write-site-completeness guard and a seeded-mutation
+//        canary (both in *_test.go).
+//
+// The flip (3d double-write), the flag/kill-switch substrate (3e), and real-city
+// priming coverage are explicitly NOT in this file — they are later, separately
+// gated stages. The harness itself sits behind its own enable latch
+// (convergeShadowEnabled), fail-closed to OFF, so a controller that never opts in
+// is byte-for-byte identical to the pre-Stage-3 controller.
+
+// convergeComparedKeys are the durable metadata keys the shadow harness compares
+// between the derived action list and the legacy reconciler writes. Every
+// non-test cmd/gc write of any of these keys must be wired into the recorder —
+// enforced by TestConvergeCompareKeyWriteSitesWired.
+var convergeComparedKeys = []string{
+	sessionpkg.CanonicalInstanceNameMetadata,
+	sessionpkg.CanonicalPoolSlotMetadata,
+	sessionpkg.PrimedAtMetadataKey,
+	sessionpkg.PrimingAttemptedAtMetadataKey,
+	sessionpkg.PromptHashMetadataKey,
+}
+
+// convergeCanonicalOwnedKeys are the keys the derived converge loop will OWN
+// under P4 and the ONLY keys compared on real cities in Stage 3. The priming
+// keys are excluded from real-city comparison (Q1 / hardening 7:
+// GC_STARTUP_PROMPT_DELIVERED is launch-env-only and unobservable in a tick, so
+// a real-city priming shadow would be a permanent divergence flood). Priming is
+// compared on fixtures only, via convergeFixtureOwnedKeys.
+var convergeCanonicalOwnedKeys = []string{
+	sessionpkg.CanonicalInstanceNameMetadata,
+	sessionpkg.CanonicalPoolSlotMetadata,
+}
+
+// convergeFixtureOwnedKeys is the full owned set the fixture corpus compares —
+// canonical identity PLUS the priming family. Real cities use
+// convergeCanonicalOwnedKeys.
+var convergeFixtureOwnedKeys = append(append([]string(nil), convergeCanonicalOwnedKeys...),
+	sessionpkg.PrimedAtMetadataKey,
+	sessionpkg.PrimingAttemptedAtMetadataKey,
+	sessionpkg.PromptHashMetadataKey,
+)
+
+// convergeComparedKeySet is a membership set over convergeComparedKeys.
+var convergeComparedKeySet = func() map[string]bool {
+	m := make(map[string]bool, len(convergeComparedKeys))
+	for _, k := range convergeComparedKeys {
+		m[k] = true
+	}
+	return m
+}()
+
+// convergeShadowEnabled is the process-wide, fail-closed latch for the shadow
+// harness. It is read from GC_CONVERGE_SHADOW once and cached. An unset,
+// empty, unparseable, or false value is hard OFF (legacy-only, byte-identical).
+//
+// This is the OBSERVER kill-switch (the 138K/day wisp-flood precedent says the
+// observer needs one too). It is deliberately NOT the 3e per-city durable
+// double-write flag: that substrate belongs to the flip PR (3d/3e), which is out
+// of scope for this observation-only harness. An env latch adds no genschema /
+// config.Agent surface and is not a liveness status file, so it does not violate
+// D7 (see the D7 amendment in the S19 spec).
+var convergeShadowEnabled = func() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("GC_CONVERGE_SHADOW"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// convergeDivergenceClass is a typed, machine-checkable divergence category.
+// Free-text divergence labels are banned (hardening 4): every divergence is one
+// of these classes, each with its own counter and triage lane.
+type convergeDivergenceClass string
+
+const (
+	// divergenceUnrealizedPrediction: the derivation predicted a compared-key
+	// write that the legacy path did not make this window.
+	divergenceUnrealizedPrediction convergeDivergenceClass = "unrealized_prediction"
+	// divergenceValueMismatch: derived and legacy both wrote a key but with
+	// different values.
+	divergenceValueMismatch convergeDivergenceClass = "value_mismatch"
+	// divergenceUnpredictedDelta: an owned-key delta the derivation did not
+	// predict but which a legacy recorder entry explains (derivation gap).
+	divergenceUnpredictedDelta convergeDivergenceClass = "unpredicted_delta"
+	// divergenceForeignWrite: an owned-key delta with neither a recorder entry
+	// nor a derived prediction — some other writer (gc prime CLI, wake path,
+	// another observer). Must be zero for a soak to count.
+	divergenceForeignWrite convergeDivergenceClass = "foreign_write"
+	// divergenceFixpointNonEmpty: re-running deriveConvergeActions on END-of-tick
+	// facts returned a non-empty list (a derivation gap or a mid-tick mutation).
+	divergenceFixpointNonEmpty convergeDivergenceClass = "fixpoint_non_empty"
+	// divergenceIdentitySkew: the probe-target name used for fact capture and the
+	// name the legacy branch probed differ (positive evidence for Stage 5 C4).
+	divergenceIdentitySkew convergeDivergenceClass = "identity_skew"
+	// divergenceBoundary: a threshold predicate flipped sign within the measured
+	// |tickNow - branchNow| window (auto-tolerated timing noise).
+	divergenceBoundary convergeDivergenceClass = "boundary"
+	// divergenceWorldMoved: deterministic replay on the values legacy actually
+	// read reproduced the legacy action — auto-classified and suppressed.
+	divergenceWorldMoved convergeDivergenceClass = "world_moved"
+)
+
+// convergeSkipReason is a typed reason a session-tick was NOT counted as a clean
+// comparison. A skipped session is never "clean" and never "divergent"; it is
+// removed from the denominator so "0 divergences" always carries a proven count
+// (hardening 2). capture_loss must stay 0 for a soak window to count.
+type convergeSkipReason string
+
+const (
+	// skipNotComparable: derived facts and the legacy decision used different
+	// probe results (e.g. one path probed, the other did not).
+	skipNotComparable convergeSkipReason = "not_comparable"
+	// skipCaptureLoss: a required capture (durable facts, snapshot) was missing.
+	// Must be 0.
+	skipCaptureLoss convergeSkipReason = "capture_loss"
+	// skipEarlyContinue: the legacy loop took an early-continue path (drain-ack,
+	// unknown-state) before the compared region, so there is nothing to compare.
+	skipEarlyContinue convergeSkipReason = "early_continue"
+	// skipShadowDisabled: the harness was not enabled for this session-tick.
+	skipShadowDisabled convergeSkipReason = "shadow_disabled"
+)
+
+// convergeShadowCounters holds the in-process, monotonic Stage-3 metrics. These
+// are the AUTHORITATIVE soak/flip signals (records may sample; counters never).
+// No new event type is registered (Q3 / hardening 10). The zero value is ready.
+type convergeShadowCounters struct {
+	mu sync.Mutex
+
+	sessionsEvaluated int64
+	sessionsSkipped   map[convergeSkipReason]int64
+	incomparable      int64
+	recordsDropped    int64
+
+	compareTotal    map[string]int64                 // by derived action type
+	derived         map[string]int64                 // deriveConvergeActions emissions
+	divergenceTotal map[convergeDivergenceClass]int64 // by class
+}
+
+// newConvergeShadowCounters returns an initialized counter set.
+func newConvergeShadowCounters() *convergeShadowCounters {
+	return &convergeShadowCounters{
+		sessionsSkipped: map[convergeSkipReason]int64{},
+		compareTotal:    map[string]int64{},
+		derived:         map[string]int64{},
+		divergenceTotal: map[convergeDivergenceClass]int64{},
+	}
+}
+
+// convergeShadowMetrics is the process-global counter set the reconciler feeds.
+// Tests use isolated instances so the global stays inert unless the harness runs.
+var convergeShadowMetrics = newConvergeShadowCounters()
+
+// convergeShadowTickSeqCounter monotonically numbers reconciler ticks that run
+// the shadow harness, so a divergence record can be joined to the tick that
+// enqueued its comparison (snapshot vintage).
+var convergeShadowTickSeqCounter atomic.Int64
+
+// nextConvergeShadowTickSeq returns the next monotonic shadow tick sequence.
+func nextConvergeShadowTickSeq() int64 {
+	return convergeShadowTickSeqCounter.Add(1)
+}
+
+// triFromBool maps a probed boolean into a resolved tri-state. Unknown is never
+// produced here — it is reserved for a bit that a branch did not probe at all.
+func triFromBool(b bool) convergeTriState {
+	if b {
+		return convergeTriTrue
+	}
+	return convergeTriFalse
+}
+
+func (c *convergeShadowCounters) incEvaluated() {
+	c.mu.Lock()
+	c.sessionsEvaluated++
+	c.mu.Unlock()
+}
+
+func (c *convergeShadowCounters) incSkipped(r convergeSkipReason) {
+	c.mu.Lock()
+	if c.sessionsSkipped == nil {
+		c.sessionsSkipped = map[convergeSkipReason]int64{}
+	}
+	c.sessionsSkipped[r]++
+	c.mu.Unlock()
+}
+
+func (c *convergeShadowCounters) incIncomparable() {
+	c.mu.Lock()
+	c.incomparable++
+	c.mu.Unlock()
+}
+
+func (c *convergeShadowCounters) incRecordsDropped() {
+	c.mu.Lock()
+	c.recordsDropped++
+	c.mu.Unlock()
+}
+
+func (c *convergeShadowCounters) incDerived(action string) {
+	c.mu.Lock()
+	if c.derived == nil {
+		c.derived = map[string]int64{}
+	}
+	c.derived[action]++
+	c.mu.Unlock()
+}
+
+func (c *convergeShadowCounters) incCompare(actionType string) {
+	c.mu.Lock()
+	if c.compareTotal == nil {
+		c.compareTotal = map[string]int64{}
+	}
+	c.compareTotal[actionType]++
+	c.mu.Unlock()
+}
+
+func (c *convergeShadowCounters) incDivergence(class convergeDivergenceClass) {
+	c.mu.Lock()
+	if c.divergenceTotal == nil {
+		c.divergenceTotal = map[convergeDivergenceClass]int64{}
+	}
+	c.divergenceTotal[class]++
+	c.mu.Unlock()
+}
+
+// convergeCounterSnapshot is an immutable copy of the counters for assertions.
+type convergeCounterSnapshot struct {
+	SessionsEvaluated int64
+	SessionsSkipped   map[convergeSkipReason]int64
+	Incomparable      int64
+	RecordsDropped    int64
+	CompareTotal      map[string]int64
+	Derived           map[string]int64
+	DivergenceTotal   map[convergeDivergenceClass]int64
+}
+
+// snapshot returns a deep copy of the counters, safe to read concurrently.
+func (c *convergeShadowCounters) snapshot() convergeCounterSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := convergeCounterSnapshot{
+		SessionsEvaluated: c.sessionsEvaluated,
+		Incomparable:      c.incomparable,
+		RecordsDropped:    c.recordsDropped,
+		SessionsSkipped:   map[convergeSkipReason]int64{},
+		CompareTotal:      map[string]int64{},
+		Derived:           map[string]int64{},
+		DivergenceTotal:   map[convergeDivergenceClass]int64{},
+	}
+	for k, v := range c.sessionsSkipped {
+		cp.SessionsSkipped[k] = v
+	}
+	for k, v := range c.compareTotal {
+		cp.CompareTotal[k] = v
+	}
+	for k, v := range c.derived {
+		cp.Derived[k] = v
+	}
+	for k, v := range c.divergenceTotal {
+		cp.DivergenceTotal[k] = v
+	}
+	return cp
+}
+
+// divergenceCount returns the total divergences that survived replay (i.e. the
+// classes that count against the acceptance bar). world_moved and boundary are
+// suppressed-but-counted classes and are excluded.
+func (s convergeCounterSnapshot) survivingDivergences() int64 {
+	var total int64
+	for class, n := range s.DivergenceTotal {
+		switch class {
+		case divergenceWorldMoved, divergenceBoundary, divergenceIdentitySkew:
+			// Suppressed / positive-evidence classes: counted, but not a failure.
+		default:
+			total += n
+		}
+	}
+	return total
+}
+
+// --- tri-state runtime facts (3a) ---------------------------------------------
+
+// convergeTriState expresses a two-bit runtime observation where "unknown" means
+// the reconciler branch that owns this session-tick did not probe that bit, so a
+// derived fact built from it must not claim a value the legacy path never saw.
+type convergeTriState int
+
+const (
+	convergeTriUnknown convergeTriState = iota
+	convergeTriFalse
+	convergeTriTrue
+)
+
+// shadowRuntimeCapture is the two-bit, tri-state runtime observation captured at
+// the legacy branch's OWN probe site (never a re-probe). runtimePresent is the
+// tmux/provider-present bit; processAlive is the child-process-alive bit
+// (unknown on paths that only probe presence). Together they express zombies
+// (present && !alive).
+type shadowRuntimeCapture struct {
+	probeSite      string
+	probeTarget    string
+	runtimePresent convergeTriState
+	processAlive   convergeTriState
+	// primedEnv is pinned false on real cities (unobservable in a tick); fixtures
+	// set it explicitly.
+	primedEnv bool
+}
+
+// runtimeFacts projects the tri-state capture into the Stage-1 runtimeFacts the
+// derivation consumes. observed is true only when at least the presence bit was
+// probed; live is present && alive treated conservatively (unknown alive on a
+// present runtime is treated as alive on the desired fast path, matching the
+// legacy running/alive semantics only when both bits were probed — otherwise the
+// tick is marked NOT-COMPARABLE by the caller).
+func (rc shadowRuntimeCapture) runtimeFacts() runtimeFacts {
+	if rc.runtimePresent == convergeTriUnknown {
+		return runtimeFacts{observed: false}
+	}
+	present := rc.runtimePresent == convergeTriTrue
+	// live requires both bits true; when alive is unknown we conservatively treat
+	// a present runtime as not-live so no live-only action is emitted from an
+	// under-probed capture (the comparator marks such ticks NOT-COMPARABLE).
+	live := present && rc.processAlive == convergeTriTrue
+	return runtimeFacts{
+		observed:  true,
+		live:      live,
+		primedEnv: rc.primedEnv,
+	}
+}
+
+// fullyProbed reports whether both runtime bits were resolved. A capture that is
+// present-only (alive unknown) cannot be compared for live-gated actions.
+func (rc shadowRuntimeCapture) fullyProbed() bool {
+	return rc.runtimePresent != convergeTriUnknown && rc.processAlive != convergeTriUnknown
+}
+
+// --- in-process legacy-action recorder (3b layer 1) ---------------------------
+
+// legacyCompareWrite is one recorded legacy write of a compared metadata key,
+// captured SYNCHRONOUSLY at the write site (no arming, no budget, no async
+// queue, cannot be env-disabled independently of the harness itself).
+type legacyCompareWrite struct {
+	sessionID string
+	key       string
+	value     string
+	writer    string
+	seq       int64
+}
+
+// legacyWriteRecorder is the per-tick synchronous capture channel. It is a plain
+// slice guarded by a mutex (the reconciler fans sessions out; the recorder must
+// be safe under that). It records ONLY compared keys and only when the harness
+// is enabled for the current tick.
+type legacyWriteRecorder struct {
+	mu      sync.Mutex
+	seq     int64
+	writes  []legacyCompareWrite
+	dropped int64
+}
+
+// record appends a compared-key write. Non-compared keys are ignored so callers
+// can pass a whole batch. A nil recorder is a no-op (the disabled path).
+func (r *legacyWriteRecorder) record(sessionID, writer string, batch map[string]string) {
+	if r == nil || len(batch) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for k, v := range batch {
+		if !convergeComparedKeySet[k] {
+			continue
+		}
+		r.seq++
+		r.writes = append(r.writes, legacyCompareWrite{
+			sessionID: sessionID,
+			key:       k,
+			value:     v,
+			writer:    writer,
+			seq:       r.seq,
+		})
+	}
+}
+
+// forSession returns the recorded writes for one session, in write order.
+func (r *legacyWriteRecorder) forSession(sessionID string) []legacyCompareWrite {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []legacyCompareWrite
+	for _, w := range r.writes {
+		if w.sessionID == sessionID {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// convergeGlobalRecorder is the process-global recorder the wired legacy write
+// sites feed. It is attached (non-nil) only while a shadow tick is in flight and
+// the harness is enabled; otherwise the write-site wrappers see nil and bail.
+var convergeGlobalRecorder atomic.Pointer[legacyWriteRecorder]
+
+// recordLegacyCompareWrites is THE recording wrapper every legacy write site of a
+// compared key calls. It is a no-op unless a shadow tick attached a recorder, so
+// it adds zero behavior and near-zero cost on the disabled path (one atomic
+// load). sessionID may be empty at the map-build sites that pre-date bead
+// creation; such calls are dropped with a counted drop so the denominator stays
+// honest.
+func recordLegacyCompareWrites(sessionID, writer string, batch map[string]string) {
+	rec := convergeGlobalRecorder.Load()
+	if rec == nil {
+		return
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		hasCompared := false
+		for k := range batch {
+			if convergeComparedKeySet[k] {
+				hasCompared = true
+				break
+			}
+		}
+		if hasCompared {
+			rec.mu.Lock()
+			rec.dropped++
+			rec.mu.Unlock()
+		}
+		return
+	}
+	rec.record(sessionID, writer, batch)
+}
+
+// --- owned-key state-diff oracle (3b layer 2) ---------------------------------
+
+// snapshotComparedKeys reads the compared keys out of a raw metadata map into a
+// dense snapshot (missing keys map to ""). It performs no I/O.
+func snapshotComparedKeys(meta map[string]string) map[string]string {
+	snap := make(map[string]string, len(convergeComparedKeys))
+	for _, k := range convergeComparedKeys {
+		snap[k] = meta[k]
+	}
+	return snap
+}
+
+// applyDerivedToOwnedKeys is the pure "apply(derivedActions, start)" over the
+// owned keys — the oracle's prediction of the end state. It models ONLY the
+// enabled/derivable writes; disabled families still contribute their predicted
+// owned-key value so the fixpoint and end-state assertions hold on fixtures.
+//
+// It never invents timestamps: for priming stamps it copies through the caller-
+// supplied predicted values (a real executor reuses facts, never recomputes), so
+// on real cities — where priming is excluded — only the canonical keys move.
+func applyDerivedToOwnedKeys(start map[string]string, actions []sessConvergeAction, pred convergePredictedValues) map[string]string {
+	end := make(map[string]string, len(start))
+	for k, v := range start {
+		end[k] = v
+	}
+	for _, a := range actions {
+		switch a {
+		case actionStampCanonicalIdentity:
+			end[sessionpkg.CanonicalInstanceNameMetadata] = pred.canonicalInstanceName
+			if pred.canonicalPoolSlot != "" {
+				end[sessionpkg.CanonicalPoolSlotMetadata] = pred.canonicalPoolSlot
+			}
+		case actionStampPrimedFromRuntime:
+			end[sessionpkg.PrimedAtMetadataKey] = pred.primedAt
+			end[sessionpkg.PromptHashMetadataKey] = pred.promptHash
+		case actionAttemptPrime:
+			end[sessionpkg.PrimingAttemptedAtMetadataKey] = pred.primingAttemptedAt
+			end[sessionpkg.PromptHashMetadataKey] = pred.promptHash
+		case actionRollbackRuntimeToAbsent:
+			// Runtime teardown writes no compared metadata key (it kills a pane).
+		}
+	}
+	return end
+}
+
+// convergePredictedValues carries the exact values a real executor would write,
+// so applyDerivedToOwnedKeys reuses them verbatim (byte-identical double-apply).
+type convergePredictedValues struct {
+	canonicalInstanceName string
+	canonicalPoolSlot     string
+	primedAt              string
+	primingAttemptedAt    string
+	promptHash            string
+}
+
+// ownedKeyDivergence is a typed owned-key delta the oracle could not reconcile.
+type ownedKeyDivergence struct {
+	sessionID string
+	key       string
+	class     convergeDivergenceClass
+	predicted string
+	actual    string
+}
+
+// evaluateStateDiffOracle attributes every owned-key delta between the tick-start
+// and tick-end snapshots to a typed class. It has two modes:
+//
+//   - Flip / fixture mode (shadowNoExecution == false): the derived actions are
+//     assumed EXECUTED, so it asserts end == apply(derivedActions, start) over
+//     the owned keys. A predicted-but-unrealized write is unrealized_prediction;
+//     a realized-but-unpredicted write is unpredicted_delta (recorder-explained)
+//     or foreign_write (unexplained); a value disagreement is value_mismatch.
+//
+//   - Shadow / no-execution mode (shadowNoExecution == true, real cities in
+//     Stage 3): the derived heal is NOT executed, so predicted-but-unrealized
+//     writes are EXPECTED (the derived-only heal lands at flip, not now) and are
+//     not flagged. Realized legacy writes that the per-tick derivation
+//     legitimately does not predict (create/adopt stamps) are likewise not
+//     flagged. Only two things are divergences in shadow: a foreign write (a
+//     realized owned-key delta with no recorder entry) and a C4 value-parity
+//     breach (a derived stamp whose value disagrees with the value legacy
+//     actually wrote for that key this tick).
+func evaluateStateDiffOracle(
+	sessionID string,
+	ownedKeys []string,
+	start, end map[string]string,
+	actions []sessConvergeAction,
+	pred convergePredictedValues,
+	recorded []legacyCompareWrite,
+	shadowNoExecution bool,
+) []ownedKeyDivergence {
+	predEnd := applyDerivedToOwnedKeys(start, actions, pred)
+	recordedValue := map[string]string{}
+	recordedKeys := map[string]bool{}
+	for _, w := range recorded {
+		recordedKeys[w.key] = true
+		recordedValue[w.key] = w.value
+	}
+	var out []ownedKeyDivergence
+	for _, k := range ownedKeys {
+		predictedChange := predEnd[k] != start[k]
+		actualChange := end[k] != start[k]
+
+		if shadowNoExecution {
+			// Foreign write: realized owned-key delta with no legacy recorder entry.
+			if actualChange && !recordedKeys[k] {
+				out = append(out, ownedKeyDivergence{sessionID, k, divergenceForeignWrite, "", end[k]})
+				continue
+			}
+			// C4 value parity: a derived stamp whose value disagrees with the value
+			// legacy actually wrote this tick. Pulled forward from Stage 5.
+			if predictedChange && recordedKeys[k] && predEnd[k] != recordedValue[k] {
+				out = append(out, ownedKeyDivergence{sessionID, k, divergenceValueMismatch, predEnd[k], recordedValue[k]})
+			}
+			continue
+		}
+
+		// Flip / fixture mode: end must equal apply(derived, start).
+		want := predEnd[k]
+		got := end[k]
+		if want == got {
+			continue
+		}
+		switch {
+		case predictedChange && !actualChange:
+			out = append(out, ownedKeyDivergence{sessionID, k, divergenceUnrealizedPrediction, want, got})
+		case predictedChange && actualChange:
+			out = append(out, ownedKeyDivergence{sessionID, k, divergenceValueMismatch, want, got})
+		case !predictedChange && actualChange:
+			if recordedKeys[k] {
+				out = append(out, ownedKeyDivergence{sessionID, k, divergenceUnpredictedDelta, want, got})
+			} else {
+				out = append(out, ownedKeyDivergence{sessionID, k, divergenceForeignWrite, want, got})
+			}
+		}
+	}
+	return out
+}
+
+// --- replay comparator (3b layer 3) -------------------------------------------
+
+// convergeSuppression models the tick-global legacy couplings that make a
+// derived-present / legacy-absent pairing EXPECTED rather than divergent. The
+// core derivation stays pure; these live only in the comparator.
+type convergeSuppression struct {
+	// rollbackBudgetExhausted: maxRollbacksPerTick reached, so a derived rollback
+	// that legacy deferred this tick is expected.
+	rollbackBudgetExhausted bool
+	// storeQueryPartial: the store returned a partial view, so legacy skipped
+	// close/rollback actions this tick.
+	storeQueryPartial bool
+	// deferSessionClosesOnBoot: boot-time close deferral is active.
+	deferSessionClosesOnBoot bool
+}
+
+// suppresses reports whether the given derived action is expected to be absent
+// from the legacy path under the active tick-global couplings.
+func (s convergeSuppression) suppresses(a sessConvergeAction) bool {
+	switch a {
+	case actionRollbackRuntimeToAbsent:
+		return s.rollbackBudgetExhausted || s.storeQueryPartial || s.deferSessionClosesOnBoot
+	default:
+		return false
+	}
+}
+
+// replayInput is one derived-vs-legacy comparison for a single session-tick.
+type replayInput struct {
+	sessionID     string
+	instanceToken string
+	// durable/runtime are the facts the derivation used.
+	durable durableFacts
+	runtime runtimeFacts
+	// legacyValues are the values the legacy path actually READ at decision time
+	// (used for deterministic replay). Empty when the legacy path did not read.
+	legacyValues durableFacts
+	legacyRuntime runtimeFacts
+	// legacyReplayable is true when legacyValues/legacyRuntime were captured, so
+	// a deterministic replay can run.
+	legacyReplayable bool
+	suppression      convergeSuppression
+	// primingExcluded is true on real cities (the priming family is not compared).
+	primingExcluded bool
+	// factsProbeTarget and legacyProbeTarget are the resolved names; a mismatch is
+	// identity-skew.
+	factsProbeTarget  string
+	legacyProbeTarget string
+	// boundaryFlip is true when a threshold predicate flips sign within the
+	// measured |tickNow - branchNow| window.
+	boundaryFlip bool
+}
+
+// replayVerdict is the comparator's classification of one comparison.
+type replayVerdict struct {
+	// divergences are the surviving, un-suppressed divergence classes.
+	divergences []convergeDivergenceClass
+	// suppressed are classes recognized and suppressed (counted, not a failure).
+	suppressed []convergeDivergenceClass
+	// comparedActions is the derived action set that was actually compared (drives
+	// the per-action-type compare quotas).
+	comparedActions []sessConvergeAction
+}
+
+// isPrimingAction reports whether an action is part of the priming family.
+func isPrimingAction(a sessConvergeAction) bool {
+	return a == actionStampPrimedFromRuntime || a == actionAttemptPrime
+}
+
+// actionName returns a stable string name for counter keying.
+func actionName(a sessConvergeAction) string {
+	switch a {
+	case actionRollbackRuntimeToAbsent:
+		return "rollback_runtime_to_absent"
+	case actionStampCanonicalIdentity:
+		return "stamp_canonical_identity"
+	case actionStampPrimedFromRuntime:
+		return "stamp_primed_from_runtime"
+	case actionAttemptPrime:
+		return "attempt_prime"
+	default:
+		return "unknown"
+	}
+}
+
+// compareReplay is the judge. It derives the action set, filters the priming
+// family on real cities, applies identity-skew and boundary short-circuits,
+// models tick-global suppression, and runs deterministic replay on the values
+// legacy actually read: if the replay reproduces the derived action, the record
+// is auto-classified world_moved and suppressed. The bar is "zero divergences
+// that survive replay".
+//
+// This comparator judges ACTION-SET agreement. The owned-key state-diff oracle
+// (evaluateStateDiffOracle) judges realized-value agreement; the two are
+// complementary and both feed the counters.
+func compareReplay(in replayInput) replayVerdict {
+	var v replayVerdict
+
+	// Identity-skew dominates: if the name used for fact capture differs from the
+	// name the legacy branch probed, the comparison is not apples-to-apples.
+	if strings.TrimSpace(in.factsProbeTarget) != "" &&
+		strings.TrimSpace(in.legacyProbeTarget) != "" &&
+		in.factsProbeTarget != in.legacyProbeTarget {
+		v.suppressed = append(v.suppressed, divergenceIdentitySkew)
+		return v
+	}
+
+	derived := deriveConvergeActions(in.durable, in.runtime)
+	// The legacy action set is what deriveConvergeActions produces on the values
+	// legacy actually read (deterministic replay ground truth). When the legacy
+	// path is not replayable we fall back to comparing derived against itself,
+	// which can only surface suppression/boundary/priming classifications.
+	legacy := derived
+	if in.legacyReplayable {
+		legacy = deriveConvergeActions(in.legacyValues, in.legacyRuntime)
+	}
+
+	derivedSet := actionSet(derived)
+	legacySet := actionSet(legacy)
+
+	for _, a := range derived {
+		if in.primingExcluded && isPrimingAction(a) {
+			continue // excluded from real-city comparison (Q1)
+		}
+		v.comparedActions = append(v.comparedActions, a)
+		if legacySet[a] {
+			continue // agreement
+		}
+		// Derived-present, legacy-absent. Classify.
+		if in.suppression.suppresses(a) {
+			v.suppressed = append(v.suppressed, divergenceWorldMoved)
+			continue
+		}
+		if in.boundaryFlip {
+			v.suppressed = append(v.suppressed, divergenceBoundary)
+			continue
+		}
+		if in.legacyReplayable {
+			// Deterministic replay already produced `legacy`; if it lacks this
+			// action the world genuinely moved between derivation and legacy read.
+			v.suppressed = append(v.suppressed, divergenceWorldMoved)
+			continue
+		}
+		v.divergences = append(v.divergences, divergenceUnrealizedPrediction)
+	}
+
+	// Legacy-present, derived-absent: a derivation gap (the derivation would miss
+	// an action legacy takes). Priming excluded on real cities.
+	for _, a := range legacy {
+		if in.primingExcluded && isPrimingAction(a) {
+			continue
+		}
+		if derivedSet[a] {
+			continue
+		}
+		if in.boundaryFlip {
+			v.suppressed = append(v.suppressed, divergenceBoundary)
+			continue
+		}
+		v.divergences = append(v.divergences, divergenceUnpredictedDelta)
+	}
+
+	return v
+}
+
+// actionSet builds a membership set over an action list.
+func actionSet(actions []sessConvergeAction) map[sessConvergeAction]bool {
+	m := make(map[sessConvergeAction]bool, len(actions))
+	for _, a := range actions {
+		m[a] = true
+	}
+	return m
+}
+
+// --- per-tick collector (3a assembly + 3b/3c evaluation) ----------------------
+
+// shadowSessionEval bundles everything the harness captured for one session in
+// one tick: the assembled facts (3a), the tick-start compared-key snapshot, the
+// runtime capture with its probe provenance, and the replay context. The
+// reconciler fills it incrementally (durable at loop entry, runtime at the probe
+// site) and the collector evaluates it at tick end against the tick-end
+// snapshot.
+type shadowSessionEval struct {
+	sessionID     string
+	instanceToken string
+	durable       durableFacts
+	runtimeCap    shadowRuntimeCapture
+	startSnap     map[string]string
+	pred          convergePredictedValues
+	factsTarget   string
+	legacyTarget  string
+	suppression   convergeSuppression
+	// captured records whether durable facts were ever set (guards capture-loss).
+	captured bool
+}
+
+// convergeShadowTick is the per-tick collector. It is created only when the
+// harness is enabled; a nil *convergeShadowTick makes every method a no-op, so
+// the reconciler wiring is byte-identical when the harness is off.
+type convergeShadowTick struct {
+	observerID string
+	tickSeq    int64
+	tickNow    time.Time
+	// realCity is true for live-city ticks (priming family excluded); fixtures
+	// set it false to compare the full owned set.
+	realCity  bool
+	recorder  *legacyWriteRecorder
+	counters  *convergeShadowCounters
+	evals     map[string]*shadowSessionEval
+	orderedID []string
+}
+
+// newConvergeShadowTick returns a live collector when the harness is enabled and
+// nil otherwise. Callers guard every use with `if tick != nil`, so the disabled
+// path costs one comparison.
+func newConvergeShadowTick(observerID string, tickSeq int64, tickNow time.Time, realCity bool, counters *convergeShadowCounters) *convergeShadowTick {
+	if !convergeShadowEnabled() {
+		return nil
+	}
+	rec := &legacyWriteRecorder{}
+	t := &convergeShadowTick{
+		observerID: observerID,
+		tickSeq:    tickSeq,
+		tickNow:    tickNow,
+		realCity:   realCity,
+		recorder:   rec,
+		counters:   counters,
+		evals:      map[string]*shadowSessionEval{},
+	}
+	convergeGlobalRecorder.Store(rec)
+	return t
+}
+
+// captureDurable records the durable facts + tick-start compared-key snapshot for
+// a session at Phase-1 loop entry, from ALREADY-observed reconciler state (the
+// coherent Info snapshot). No new probes, no writes.
+func (t *convergeShadowTick) captureDurable(sessionID, instanceToken, factsTarget string, d durableFacts, startSnap map[string]string, pred convergePredictedValues) {
+	if t == nil {
+		return
+	}
+	e := t.evals[sessionID]
+	if e == nil {
+		e = &shadowSessionEval{sessionID: sessionID}
+		t.evals[sessionID] = e
+		t.orderedID = append(t.orderedID, sessionID)
+	}
+	e.instanceToken = instanceToken
+	e.durable = d
+	e.startSnap = startSnap
+	e.pred = pred
+	e.factsTarget = factsTarget
+	e.captured = true
+}
+
+// captureRuntime records the two-bit runtime observation at the legacy branch's
+// OWN probe site (never a re-probe), with its probe provenance.
+func (t *convergeShadowTick) captureRuntime(sessionID, probeSite, probeTarget string, present, alive convergeTriState) {
+	if t == nil {
+		return
+	}
+	e := t.evals[sessionID]
+	if e == nil {
+		e = &shadowSessionEval{sessionID: sessionID}
+		t.evals[sessionID] = e
+		t.orderedID = append(t.orderedID, sessionID)
+	}
+	e.runtimeCap = shadowRuntimeCapture{
+		probeSite:      probeSite,
+		probeTarget:    probeTarget,
+		runtimePresent: present,
+		processAlive:   alive,
+	}
+	e.legacyTarget = probeTarget
+}
+
+// markSkip records a typed skip reason for a session-tick that cannot be
+// compared, keeping the denominator honest.
+func (t *convergeShadowTick) markSkip(sessionID string, r convergeSkipReason) {
+	if t == nil {
+		return
+	}
+	if t.counters != nil {
+		t.counters.incSkipped(r)
+	}
+	delete(t.evals, sessionID)
+}
+
+// finish evaluates every captured session against its tick-end snapshot (read
+// from the coherent post-Phase-1 Info snapshot by the caller, passed via
+// endSnaps), runs the oracle + replay comparator, updates counters, and detaches
+// the global recorder. It is safe to call on a nil tick.
+func (t *convergeShadowTick) finish(endSnaps map[string]map[string]string) {
+	if t == nil {
+		return
+	}
+	defer convergeGlobalRecorder.Store(nil)
+
+	ownedKeys := convergeCanonicalOwnedKeys
+	if !t.realCity {
+		ownedKeys = convergeFixtureOwnedKeys
+	}
+
+	for _, id := range t.orderedID {
+		e := t.evals[id]
+		if e == nil || !e.captured {
+			t.counters.incSkipped(skipCaptureLoss)
+			continue
+		}
+		end := endSnaps[id]
+		if end == nil {
+			t.counters.incSkipped(skipCaptureLoss)
+			continue
+		}
+		// A present-only runtime capture (alive unknown) cannot be compared for
+		// live-gated actions: mark NOT-COMPARABLE unless it did not probe at all.
+		rf := e.runtimeCap.runtimeFacts()
+		if e.runtimeCap.runtimePresent == convergeTriTrue && !e.runtimeCap.fullyProbed() {
+			t.counters.incIncomparable()
+			t.counters.incSkipped(skipNotComparable)
+			continue
+		}
+
+		t.counters.incEvaluated()
+
+		actions := deriveConvergeActions(e.durable, rf)
+		for _, a := range actions {
+			t.counters.incDerived(actionName(a))
+		}
+
+		// Oracle: attribute owned-key deltas. On real cities the derived heal is
+		// not executed, so shadowNoExecution suppresses the flip-stage
+		// end==apply(derived,start) assertion and keeps only foreign-write +
+		// C4 value-parity (no unrealized-prediction flood).
+		shadowNoExecution := t.realCity
+		recorded := t.recorder.forSession(id)
+		for _, dv := range evaluateStateDiffOracle(id, ownedKeys, e.startSnap, end, actions, e.pred, recorded, shadowNoExecution) {
+			t.counters.incDivergence(dv.class)
+		}
+
+		// Fixpoint (fixtures only): re-derive on END-of-tick facts must be empty.
+		// This is a flip-stage invariant — in real-city shadow the derived heal is
+		// unexecuted, so the record stays absent and a canonical re-derive would be
+		// expected-non-empty; running it there would be a permanent false positive.
+		if !t.realCity {
+			endDurable := e.durable
+			endDurable.canonicalIdentity = strings.TrimSpace(end[sessionpkg.CanonicalInstanceNameMetadata])
+			endDurable.primedAt = end[sessionpkg.PrimedAtMetadataKey]
+			if v := strings.TrimSpace(end[sessionpkg.PrimingAttemptedAtMetadataKey]); v != "" {
+				if ts, err := time.Parse(time.RFC3339, v); err == nil {
+					endDurable.primingAttemptedAt = ts.UTC()
+				}
+			}
+			endDurable.primedPromptHash = end[sessionpkg.PromptHashMetadataKey]
+			if fp := deriveConvergeActions(endDurable, rf); len(fp) > 0 {
+				for range fp {
+					t.counters.incDivergence(divergenceFixpointNonEmpty)
+				}
+			}
+		}
+
+		// Replay comparator: action-set agreement under suppression/replay.
+		verdict := compareReplay(replayInput{
+			sessionID:         id,
+			instanceToken:     e.instanceToken,
+			durable:           e.durable,
+			runtime:           rf,
+			legacyReplayable:  false,
+			suppression:       e.suppression,
+			primingExcluded:   t.realCity,
+			factsProbeTarget:  e.factsTarget,
+			legacyProbeTarget: e.legacyTarget,
+		})
+		for _, a := range verdict.comparedActions {
+			t.counters.incCompare(actionName(a))
+		}
+		for _, class := range verdict.divergences {
+			t.counters.incDivergence(class)
+		}
+		for _, class := range verdict.suppressed {
+			t.counters.incDivergence(class)
+		}
+	}
+
+	if t.recorder != nil && t.recorder.dropped > 0 {
+		for i := int64(0); i < t.recorder.dropped; i++ {
+			t.counters.incRecordsDropped()
+		}
+	}
+}
+
+// --- fact builders (3a) -------------------------------------------------------
+
+// buildDurableFactsFromInfo assembles durableFacts from the reconciler's ALREADY
+// coherent typed Info snapshot plus the raw priming metadata (Info does not
+// mirror the priming keys). No probes, no writes. currentPromptHash and
+// promptConfigured are template-derived facts the caller resolves; on real
+// cities the priming inputs are still captured so the fixpoint stays honest, but
+// the priming action FAMILY is excluded from real-city comparison downstream.
+func buildDurableFactsFromInfo(info sessionpkg.Info, rawMeta map[string]string, tickNow time.Time) durableFacts {
+	d := durableFacts{
+		primedAt:          rawMeta[sessionpkg.PrimedAtMetadataKey],
+		primedPromptHash:  rawMeta[sessionpkg.PromptHashMetadataKey],
+		canonicalIdentity: info.CanonicalInstanceNameMetadata,
+		absent:            info.Closed,
+		now:               tickNow,
+	}
+	if v := strings.TrimSpace(rawMeta[sessionpkg.PrimingAttemptedAtMetadataKey]); v != "" {
+		if ts, err := time.Parse(time.RFC3339, v); err == nil {
+			d.primingAttemptedAt = ts.UTC()
+		}
+	}
+	return d
+}

--- a/cmd/gc/session_converge_shadow_concurrency_test.go
+++ b/cmd/gc/session_converge_shadow_concurrency_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// TestConvergeShadowRecorderOwnershipIsolatesConcurrentTicks proves the
+// ownership-token fix for the multi-city recorder race: the supervisor
+// reconciles each city on its own goroutine, so two enabled ticks can overlap.
+// Only the tick that installs the process-global recorder owns it; a concurrent
+// second tick is a no-owner. It records nothing of its own, marks its sessions
+// with the typed recorder_contended skip (an honest denominator, never a false
+// divergence), and — critically — the owner's compared-key reads never pick up
+// the contended tick's writes, because writes are keyed by globally-unique
+// session bead IDs. This is the "writes cannot cross between recorders" guard.
+func TestConvergeShadowRecorderOwnershipIsolatesConcurrentTicks(t *testing.T) {
+	t.Setenv("GC_CONVERGE_SHADOW", "1")
+	t.Cleanup(func() { convergeGlobalRecorder.Store(nil) })
+
+	countersOwner := newConvergeShadowCounters()
+	countersContended := newConvergeShadowCounters()
+
+	// Owner attaches first and wins the CAS; the contended tick overlaps it.
+	owner := newConvergeShadowTick("city-owner", 1, fixtureNow, true, countersOwner)
+	contended := newConvergeShadowTick("city-contended", 2, fixtureNow, true, countersContended)
+	if owner == nil || contended == nil {
+		t.Fatal("newConvergeShadowTick returned nil with harness enabled")
+	}
+	if !owner.owned {
+		t.Fatal("first tick must own the process-global recorder")
+	}
+	if contended.owned {
+		t.Fatal("second concurrent tick must NOT own the recorder (ownership token failed)")
+	}
+
+	const sidOwner = "sess-owner"
+	const sidContended = "sess-contended"
+
+	// Owner: clean steady state — canonical present at both ends, derivation empty.
+	owner.captureDurable(sidOwner, "tok-o", "dir/agent-owner",
+		durableFacts{canonicalIdentity: "dir/agent-owner", now: fixtureNow},
+		map[string]string{sessionpkg.CanonicalInstanceNameMetadata: "dir/agent-owner"},
+		convergePredictedValues{})
+	owner.captureRuntime(sidOwner, "desired", "dir/agent-owner", convergeTriTrue, convergeTriTrue)
+
+	// Contended: an owned-key delta with no recorder entry it can see. If it were
+	// wrongly scored it would flag foreign_write; instead it must be skipped.
+	contended.captureDurable(sidContended, "tok-c", "dir/agent-contended",
+		durableFacts{canonicalIdentity: "", now: fixtureNow},
+		map[string]string{},
+		convergePredictedValues{canonicalInstanceName: "dir/agent-contended"})
+	contended.captureRuntime(sidContended, "desired", "dir/agent-contended", convergeTriTrue, convergeTriTrue)
+
+	// The contended tick's write site goes through the SAME global wrapper the real
+	// reconciler uses; it lands in the owner's recorder (the only one attached),
+	// tagged by the contended session's unique id. It must never surface in the
+	// owner's evaluation.
+	recordLegacyCompareWrites(sidContended, "syncSessionBeads", map[string]string{
+		sessionpkg.CanonicalInstanceNameMetadata: "dir/agent-contended",
+	})
+
+	// Finish the contended tick first: it detaches without clearing the owner's
+	// live recorder, and its session is a typed recorder_contended skip.
+	contended.finish(map[string]map[string]string{
+		sidContended: {sessionpkg.CanonicalInstanceNameMetadata: "dir/agent-contended"},
+	})
+	snapC := countersContended.snapshot()
+	if snapC.SessionsSkipped[skipRecorderContended] != 1 {
+		t.Fatalf("contended tick: recorder_contended skip = %d, want 1 (skips=%v)", snapC.SessionsSkipped[skipRecorderContended], snapC.SessionsSkipped)
+	}
+	if snapC.SessionsEvaluated != 0 {
+		t.Fatalf("contended tick must not evaluate anything, got evaluated=%d", snapC.SessionsEvaluated)
+	}
+	if got := snapC.survivingDivergences(); got != 0 {
+		t.Fatalf("contended tick must not manufacture divergences, got %d (classes: %v)", got, snapC.DivergenceTotal)
+	}
+
+	// Finish the owner: it evaluates its own clean session and clears the recorder.
+	owner.finish(map[string]map[string]string{
+		sidOwner: {sessionpkg.CanonicalInstanceNameMetadata: "dir/agent-owner"},
+	})
+	snapO := countersOwner.snapshot()
+	if snapO.SessionsEvaluated != 1 {
+		t.Fatalf("owner tick: evaluated = %d, want 1", snapO.SessionsEvaluated)
+	}
+	if got := snapO.survivingDivergences(); got != 0 {
+		t.Fatalf("owner tick's clean session must not diverge because of the contended write, got %d (classes: %v)", got, snapO.DivergenceTotal)
+	}
+
+	if convergeGlobalRecorder.Load() != nil {
+		t.Fatal("recorder must be cleared once every tick has detached")
+	}
+}
+
+// TestConvergeShadowRecorderConcurrentTicksNoRace runs two full tick lifecycles
+// concurrently (as the supervisor's per-city goroutines do) and proves the
+// attach/record/detach path is race-free and always leaves the global recorder
+// cleared, regardless of which tick wins the ownership CAS. Run under -race.
+func TestConvergeShadowRecorderConcurrentTicksNoRace(t *testing.T) {
+	t.Setenv("GC_CONVERGE_SHADOW", "1")
+	t.Cleanup(func() { convergeGlobalRecorder.Store(nil) })
+
+	var wg sync.WaitGroup
+	for i, city := range []string{"city-a", "city-b"} {
+		wg.Add(1)
+		go func(seq int, city string) {
+			defer wg.Done()
+			counters := newConvergeShadowCounters()
+			tick := newConvergeShadowTick(city, int64(seq+1), fixtureNow, true, counters)
+			if tick == nil {
+				return
+			}
+			sid := fmt.Sprintf("sess-%s", city)
+			tick.captureDurable(sid, "tok", "dir/agent",
+				durableFacts{canonicalIdentity: "dir/agent", now: fixtureNow},
+				map[string]string{sessionpkg.CanonicalInstanceNameMetadata: "dir/agent"},
+				convergePredictedValues{})
+			tick.captureRuntime(sid, "desired", "dir/agent", convergeTriTrue, convergeTriTrue)
+			recordLegacyCompareWrites(sid, "syncSessionBeads", map[string]string{
+				sessionpkg.CanonicalInstanceNameMetadata: "dir/agent",
+			})
+			tick.finish(map[string]map[string]string{sid: {sessionpkg.CanonicalInstanceNameMetadata: "dir/agent"}})
+		}(i, city)
+	}
+	wg.Wait()
+
+	if convergeGlobalRecorder.Load() != nil {
+		t.Fatal("global recorder must be nil after all concurrent ticks detach")
+	}
+}

--- a/cmd/gc/session_converge_shadow_observability_test.go
+++ b/cmd/gc/session_converge_shadow_observability_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// TestConvergeShadowOperatorSummaryReportsSoakSignal proves the counters have an
+// operator-visible read path: a clean fixture tick renders a bounded summary line
+// carrying the proven denominator (evaluated) and the surviving-divergence count
+// that gates a soak. Without this, enabling GC_CONVERGE_SHADOW increments counters
+// nothing can read.
+func TestConvergeShadowOperatorSummaryReportsSoakSignal(t *testing.T) {
+	// converged_steady_state_noop: one evaluated session, zero surviving divergences.
+	snap := runFixture(t, convergeCleanCorpus()[0])
+	line := snap.operatorSummary()
+	if !strings.Contains(line, "evaluated=1") {
+		t.Fatalf("operator summary must report the proven denominator, got %q", line)
+	}
+	if !strings.Contains(line, "surviving_divergences=0") {
+		t.Fatalf("operator summary must report zero surviving divergences for a clean tick, got %q", line)
+	}
+}
+
+// TestConvergeShadowReconcilerEmitsOperatorSummary proves the read path is wired
+// end to end: a live enabled reconcile tick writes the soak summary to the
+// reconciler's stderr operator channel, reporting a nonzero denominator and zero
+// surviving divergences (a live soak can be observed, not just unit-tested).
+func TestConvergeShadowReconcilerEmitsOperatorSummary(t *testing.T) {
+	t.Setenv("GC_CONVERGE_SHADOW", "1")
+	prev := convergeShadowMetrics
+	convergeShadowMetrics = newConvergeShadowCounters()
+	t.Cleanup(func() { convergeShadowMetrics = prev })
+
+	env := newReconcilerTestEnv()
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		sessionpkg.CanonicalInstanceNameMetadata: "worker",
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	out := env.stderr.String()
+	if !strings.Contains(out, "converge-shadow soak:") {
+		t.Fatalf("reconciler did not emit the shadow soak summary to stderr; stderr=%q", out)
+	}
+	if !strings.Contains(out, "surviving_divergences=0") {
+		t.Fatalf("live tick summary must report zero surviving divergences; stderr=%q", out)
+	}
+	if snap := convergeShadowMetrics.snapshot(); snap.SessionsEvaluated == 0 {
+		t.Fatalf("live tick must move the denominator; evaluated=0 (skips=%v)", snap.SessionsSkipped)
+	}
+}

--- a/cmd/gc/session_converge_shadow_reconciler_test.go
+++ b/cmd/gc/session_converge_shadow_reconciler_test.go
@@ -42,6 +42,39 @@ func TestConvergeShadowReconcilerWiringLive(t *testing.T) {
 	}
 }
 
+// TestConvergeShadowReconcilerEarlyContinueSkipped proves a pre-probe
+// early-continue path (here a bead with an unrecognized state, which the
+// forward-compat unknown-state branch skips BEFORE any runtime probe) is removed
+// from the shadow denominator with a typed skipEarlyContinue instead of being
+// counted as an evaluated clean comparison. Durable facts are captured at loop
+// entry, so without the markSkip wiring this session would reach finish with no
+// runtime probe and inflate sessions_evaluated (hardening 2).
+func TestConvergeShadowReconcilerEarlyContinueSkipped(t *testing.T) {
+	t.Setenv("GC_CONVERGE_SHADOW", "1")
+	prev := convergeShadowMetrics
+	convergeShadowMetrics = newConvergeShadowCounters()
+	t.Cleanup(func() { convergeShadowMetrics = prev })
+
+	env := newReconcilerTestEnv()
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	// An unrecognized state drives the forward-compat unknown-state early-continue.
+	env.setSessionMetadata(&session, map[string]string{"state": "archived"})
+
+	env.reconcile([]beads.Bead{session})
+
+	snap := convergeShadowMetrics.snapshot()
+	if snap.SessionsSkipped[skipEarlyContinue] == 0 {
+		t.Fatalf("early-continue tick was not skipped: skips=%v evaluated=%d", snap.SessionsSkipped, snap.SessionsEvaluated)
+	}
+	if snap.SessionsEvaluated != 0 {
+		t.Fatalf("unknown-state tick inflated the denominator: evaluated=%d", snap.SessionsEvaluated)
+	}
+	if snap.SessionsSkipped[skipCaptureLoss] != 0 {
+		t.Fatalf("skipped tick double-counted as capture_loss: %d", snap.SessionsSkipped[skipCaptureLoss])
+	}
+}
+
 // TestConvergeShadowReconcilerDisabledInert proves the reconciler is inert when
 // the harness is off: the global recorder is never attached and the denominator
 // does not move.

--- a/cmd/gc/session_converge_shadow_reconciler_test.go
+++ b/cmd/gc/session_converge_shadow_reconciler_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// TestConvergeShadowReconcilerWiringLive proves the 3a fact capture is actually
+// wired into the reconciler's Phase 1 (not silently dead): with the harness
+// enabled, reconciling a live desired session moves the denominator
+// (sessions_evaluated) and produces zero surviving divergences on this
+// steady-state tick. A flatlined denominator here would be a wiring failure, not
+// a pass (hardening 2).
+func TestConvergeShadowReconcilerWiringLive(t *testing.T) {
+	t.Setenv("GC_CONVERGE_SHADOW", "1")
+	// Use an isolated counter set so the assertion is deterministic regardless of
+	// other tests that may have run the global harness.
+	prev := convergeShadowMetrics
+	convergeShadowMetrics = newConvergeShadowCounters()
+	t.Cleanup(func() { convergeShadowMetrics = prev })
+
+	env := newReconcilerTestEnv()
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	// Stamp a canonical identity so the steady-state tick derives nothing and the
+	// comparison is a clean ∅-on-live.
+	env.setSessionMetadata(&session, map[string]string{
+		sessionpkg.CanonicalInstanceNameMetadata: "worker",
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	snap := convergeShadowMetrics.snapshot()
+	if snap.SessionsEvaluated == 0 && snap.Incomparable == 0 {
+		t.Fatalf("shadow harness wiring is dead: nothing evaluated (skipped: %v)", snap.SessionsSkipped)
+	}
+	if got := snap.survivingDivergences(); got != 0 {
+		t.Fatalf("steady-state tick produced %d surviving divergences (classes: %v)", got, snap.DivergenceTotal)
+	}
+}
+
+// TestConvergeShadowReconcilerDisabledInert proves the reconciler is inert when
+// the harness is off: the global recorder is never attached and the denominator
+// does not move.
+func TestConvergeShadowReconcilerDisabledInert(t *testing.T) {
+	t.Setenv("GC_CONVERGE_SHADOW", "")
+	prev := convergeShadowMetrics
+	convergeShadowMetrics = newConvergeShadowCounters()
+	t.Cleanup(func() { convergeShadowMetrics = prev })
+
+	env := newReconcilerTestEnv()
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	env.reconcile([]beads.Bead{session})
+
+	if convergeGlobalRecorder.Load() != nil {
+		t.Fatal("global recorder attached with harness disabled")
+	}
+	snap := convergeShadowMetrics.snapshot()
+	if snap.SessionsEvaluated != 0 {
+		t.Fatalf("denominator moved with harness disabled: %d", snap.SessionsEvaluated)
+	}
+}

--- a/cmd/gc/session_converge_shadow_test.go
+++ b/cmd/gc/session_converge_shadow_test.go
@@ -24,7 +24,7 @@ type convergeFixture struct {
 	// wantSurviving is the number of divergences that must survive replay (i.e.
 	// count against the acceptance bar) for this fixture. The clean corpus is all
 	// zeros; the canary flips one to non-zero via a broken derivation.
-	wantSurviving int
+	wantSurviving int64
 }
 
 var fixtureNow = time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
@@ -115,9 +115,9 @@ func convergeCleanCorpus() []convergeFixture {
 			runtimeCap: shadowRuntimeCapture{probeSite: "desired", probeTarget: canonName, runtimePresent: convergeTriTrue, processAlive: convergeTriTrue},
 			start:      map[string]string{sessionpkg.CanonicalInstanceNameMetadata: canonName},
 			end: map[string]string{
-				sessionpkg.CanonicalInstanceNameMetadata:  canonName,
-				sessionpkg.PrimingAttemptedAtMetadataKey:  "2026-07-08T12:00:00Z",
-				sessionpkg.PromptHashMetadataKey:          "hash-v1",
+				sessionpkg.CanonicalInstanceNameMetadata: canonName,
+				sessionpkg.PrimingAttemptedAtMetadataKey: "2026-07-08T12:00:00Z",
+				sessionpkg.PromptHashMetadataKey:         "hash-v1",
 			},
 			pred: convergePredictedValues{
 				primingAttemptedAt: "2026-07-08T12:00:00Z",
@@ -192,7 +192,7 @@ func convergeCleanCorpus() []convergeFixture {
 
 // runFixture evaluates one fixture through a fresh tick collector with the
 // harness force-enabled, and returns the resulting counter snapshot.
-func runFixture(t *testing.T, f convergeFixture, deriveOverride func(durableFacts, runtimeFacts) []sessConvergeAction) convergeCounterSnapshot {
+func runFixture(t *testing.T, f convergeFixture) convergeCounterSnapshot {
 	t.Helper()
 	t.Setenv("GC_CONVERGE_SHADOW", "1")
 	counters := newConvergeShadowCounters()
@@ -218,9 +218,9 @@ func runFixture(t *testing.T, f convergeFixture, deriveOverride func(durableFact
 func TestConvergeShadowCleanCorpus(t *testing.T) {
 	for _, f := range convergeCleanCorpus() {
 		t.Run(f.name, func(t *testing.T) {
-			snap := runFixture(t, f, nil)
-			if got := snap.survivingDivergences(); got != 0 {
-				t.Errorf("%s: surviving divergences = %d, want 0 (classes: %v)", f.name, got, snap.DivergenceTotal)
+			snap := runFixture(t, f)
+			if got := snap.survivingDivergences(); got != f.wantSurviving {
+				t.Errorf("%s: surviving divergences = %d, want %d (classes: %v)", f.name, got, f.wantSurviving, snap.DivergenceTotal)
 			}
 			if snap.SessionsEvaluated == 0 && snap.Incomparable == 0 {
 				t.Errorf("%s: nothing evaluated — flatlined denominator is a harness failure, not a pass", f.name)
@@ -260,7 +260,7 @@ func TestConvergeShadowSeededMutationCanary(t *testing.T) {
 			recorded:   []legacyCompareWrite{{key: sessionpkg.CanonicalInstanceNameMetadata, value: "dir/agent-1", writer: "syncSessionBeads"}},
 			realCity:   false, // fixture/execution semantics -> full oracle
 		}
-		snap := runFixture(t, f, nil)
+		snap := runFixture(t, f)
 		if snap.survivingDivergences() == 0 {
 			t.Fatalf("canary did not trip: comparator is dead (divergences: %v)", snap.DivergenceTotal)
 		}
@@ -355,6 +355,79 @@ func TestConvergeUnpredictedDeltaWhenRecorded(t *testing.T) {
 	}
 }
 
+// TestConvergeShadowRecordedWriteMustMaterialize asserts the real-city
+// shadowNoExecution oracle does NOT trust a recorder entry blindly: a recorded
+// legacy write only explains an owned key when its value actually landed in the
+// realized tick-end snapshot. A recorded write that vanished (end absent) or was
+// overwritten (end holds a different value) is a foreign_write divergence, not a
+// swallowed clean. This is the false-negative the harness exists to catch before
+// the 3d flip records canonical writes inside the tick.
+func TestConvergeShadowRecordedWriteMustMaterialize(t *testing.T) {
+	const worker = "dir/worker-1"
+	rec := []legacyCompareWrite{{key: sessionpkg.CanonicalInstanceNameMetadata, value: worker, writer: "syncSessionBeads"}}
+
+	t.Run("recorded_but_end_absent_diverges", func(t *testing.T) {
+		dv := evaluateStateDiffOracle("s", convergeCanonicalOwnedKeys,
+			map[string]string{}, // start: absent
+			map[string]string{}, // end: STILL absent — the recorded write never materialized
+			nil,
+			convergePredictedValues{},
+			rec,  // recorder claims legacy wrote canonical=worker this tick
+			true, // real-city shadow / no-execution mode
+		)
+		if len(dv) != 1 || dv[0].class != divergenceForeignWrite {
+			t.Fatalf("expected one foreign_write for a recorded-but-unmaterialized write, got %v", dv)
+		}
+		if dv[0].actual != "" || dv[0].predicted != worker {
+			t.Fatalf("expected predicted=%q actual=\"\", got predicted=%q actual=%q", worker, dv[0].predicted, dv[0].actual)
+		}
+	})
+
+	t.Run("recorded_but_end_overwritten_diverges", func(t *testing.T) {
+		dv := evaluateStateDiffOracle("s", convergeCanonicalOwnedKeys,
+			map[string]string{},
+			map[string]string{sessionpkg.CanonicalInstanceNameMetadata: "dir/other-9"}, // overwritten
+			nil,
+			convergePredictedValues{},
+			rec,
+			true,
+		)
+		if len(dv) != 1 || dv[0].class != divergenceForeignWrite {
+			t.Fatalf("expected one foreign_write for a recorded-then-overwritten write, got %v", dv)
+		}
+	})
+
+	t.Run("recorded_and_materialized_is_clean", func(t *testing.T) {
+		dv := evaluateStateDiffOracle("s", convergeCanonicalOwnedKeys,
+			map[string]string{},
+			map[string]string{sessionpkg.CanonicalInstanceNameMetadata: worker}, // materialized
+			[]sessConvergeAction{actionStampCanonicalIdentity},
+			convergePredictedValues{canonicalInstanceName: worker},
+			rec,
+			true,
+		)
+		if len(dv) != 0 {
+			t.Fatalf("a recorded write that materialized to the predicted value must be clean, got %v", dv)
+		}
+	})
+
+	t.Run("materialized_but_prediction_value_mismatch_diverges", func(t *testing.T) {
+		// Recorder + end agree on worker, but the derivation predicted a different
+		// canonical value: C4 value parity must flag the derived-vs-realized breach.
+		dv := evaluateStateDiffOracle("s", convergeCanonicalOwnedKeys,
+			map[string]string{},
+			map[string]string{sessionpkg.CanonicalInstanceNameMetadata: worker},
+			[]sessConvergeAction{actionStampCanonicalIdentity},
+			convergePredictedValues{canonicalInstanceName: "dir/wrong-2"}, // derived predicts wrong value
+			rec,
+			true,
+		)
+		if len(dv) != 1 || dv[0].class != divergenceValueMismatch {
+			t.Fatalf("expected one value_mismatch for a wrong derived prediction, got %v", dv)
+		}
+	})
+}
+
 // TestConvergeIdentitySkewSuppressed asserts a probe-target mismatch is
 // classified identity-skew (positive evidence) and never a hard divergence.
 func TestConvergeIdentitySkewSuppressed(t *testing.T) {
@@ -411,5 +484,38 @@ func TestApplyDerivedToOwnedKeysIdempotent(t *testing.T) {
 		if end[k] != v {
 			t.Errorf("key %q: got %q want %q", k, end[k], v)
 		}
+	}
+}
+
+// TestConvergeShadowMarkSkipLeavesDenominatorOnce proves a session captured at
+// loop entry and then skipped (a pre-probe early-continue tick) leaves the
+// denominator with exactly ONE typed skip: the skip reason increments, the tick
+// never counts as evaluated, and finish does NOT double-count it as capture_loss.
+// The last part is the regression guard — markSkip must forget the session in the
+// ordered set too, not just the eval map.
+func TestConvergeShadowMarkSkipLeavesDenominatorOnce(t *testing.T) {
+	t.Setenv("GC_CONVERGE_SHADOW", "1")
+	counters := newConvergeShadowCounters()
+	tick := newConvergeShadowTick("observer-test", 1, fixtureNow, true, counters)
+	if tick == nil {
+		t.Fatal("newConvergeShadowTick returned nil with harness enabled")
+	}
+	const sid = "sess-1"
+	// Capture durable facts at loop entry (as the reconciler does), then skip the
+	// tick before any runtime probe.
+	tick.captureDurable(sid, "tok", "dir/agent-1", durableFacts{now: fixtureNow}, map[string]string{}, convergePredictedValues{})
+	tick.markSkip(sid, skipEarlyContinue)
+	// finish must not resurrect the skipped session as capture-loss.
+	tick.finish(map[string]map[string]string{sid: {}})
+
+	snap := counters.snapshot()
+	if snap.SessionsSkipped[skipEarlyContinue] != 1 {
+		t.Fatalf("skipEarlyContinue = %d, want 1", snap.SessionsSkipped[skipEarlyContinue])
+	}
+	if snap.SessionsSkipped[skipCaptureLoss] != 0 {
+		t.Fatalf("skipCaptureLoss = %d, want 0 (skipped tick was double-counted)", snap.SessionsSkipped[skipCaptureLoss])
+	}
+	if snap.SessionsEvaluated != 0 {
+		t.Fatalf("SessionsEvaluated = %d, want 0 (a skipped tick is never evaluated)", snap.SessionsEvaluated)
 	}
 }

--- a/cmd/gc/session_converge_shadow_test.go
+++ b/cmd/gc/session_converge_shadow_test.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// convergeFixture is one row of the shadow harness's golden corpus. Each fixture
+// is a fully specified session-tick: the facts the derivation sees, the
+// tick-start compared-key snapshot, the predicted executor values, the legacy
+// writes recorded this tick, and the realized tick-end snapshot. The corpus is
+// derived from the truth table, not intuition.
+type convergeFixture struct {
+	name       string
+	durable    durableFacts
+	runtimeCap shadowRuntimeCapture
+	start      map[string]string
+	end        map[string]string
+	pred       convergePredictedValues
+	recorded   []legacyCompareWrite
+	realCity   bool
+	// wantSurviving is the number of divergences that must survive replay (i.e.
+	// count against the acceptance bar) for this fixture. The clean corpus is all
+	// zeros; the canary flips one to non-zero via a broken derivation.
+	wantSurviving int
+}
+
+var fixtureNow = time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+
+// convergeCleanCorpus is the blocking CI corpus: every row must produce zero
+// surviving divergences. Rows map truth-table cross-product cases and crash
+// windows to named fixtures.
+func convergeCleanCorpus() []convergeFixture {
+	canonName := "dir/agent-1"
+	return []convergeFixture{
+		{
+			name: "converged_steady_state_noop",
+			durable: durableFacts{
+				canonicalIdentity: canonName,
+				primedAt:          "2026-07-08T11:00:00Z",
+				promptConfigured:  true,
+				now:               fixtureNow,
+			},
+			runtimeCap: shadowRuntimeCapture{probeSite: "desired", probeTarget: canonName, runtimePresent: convergeTriTrue, processAlive: convergeTriTrue},
+			start:      map[string]string{sessionpkg.CanonicalInstanceNameMetadata: canonName, sessionpkg.PrimedAtMetadataKey: "2026-07-08T11:00:00Z"},
+			end:        map[string]string{sessionpkg.CanonicalInstanceNameMetadata: canonName, sessionpkg.PrimedAtMetadataKey: "2026-07-08T11:00:00Z"},
+			realCity:   true,
+		},
+		{
+			name: "canonical_heal_derived_only_realcity",
+			durable: durableFacts{
+				canonicalIdentity: "",
+				now:               fixtureNow,
+			},
+			runtimeCap: shadowRuntimeCapture{probeSite: "desired", probeTarget: canonName, runtimePresent: convergeTriTrue, processAlive: convergeTriTrue},
+			start:      map[string]string{},
+			// Legacy healed the canonical record this tick to the same value the
+			// executor would write -> byte-identical, zero surviving divergence.
+			end:      map[string]string{sessionpkg.CanonicalInstanceNameMetadata: canonName},
+			pred:     convergePredictedValues{canonicalInstanceName: canonName},
+			recorded: []legacyCompareWrite{{key: sessionpkg.CanonicalInstanceNameMetadata, value: canonName, writer: "syncSessionBeads"}},
+			realCity: true,
+		},
+		{
+			name: "canonical_heal_with_pool_slot",
+			durable: durableFacts{
+				canonicalIdentity: "",
+				now:               fixtureNow,
+			},
+			runtimeCap: shadowRuntimeCapture{probeSite: "desired", probeTarget: canonName, runtimePresent: convergeTriTrue, processAlive: convergeTriTrue},
+			start:      map[string]string{},
+			end:        map[string]string{sessionpkg.CanonicalInstanceNameMetadata: canonName, sessionpkg.CanonicalPoolSlotMetadata: "3"},
+			pred:       convergePredictedValues{canonicalInstanceName: canonName, canonicalPoolSlot: "3"},
+			recorded: []legacyCompareWrite{
+				{key: sessionpkg.CanonicalInstanceNameMetadata, value: canonName, writer: "poolCreate"},
+				{key: sessionpkg.CanonicalPoolSlotMetadata, value: "3", writer: "poolCreate"},
+			},
+			realCity: true,
+		},
+		{
+			name: "absent_closed_bead_no_heal",
+			durable: durableFacts{
+				canonicalIdentity: "",
+				absent:            true,
+				now:               fixtureNow,
+			},
+			// Unobserved runtime under absent intent -> derivation is empty.
+			runtimeCap: shadowRuntimeCapture{probeSite: "orphan", probeTarget: canonName, runtimePresent: convergeTriFalse, processAlive: convergeTriFalse},
+			start:      map[string]string{},
+			end:        map[string]string{},
+			realCity:   true,
+		},
+		{
+			name: "rollback_absent_live_runtime_realcity",
+			durable: durableFacts{
+				absent: true,
+				now:    fixtureNow,
+			},
+			runtimeCap: shadowRuntimeCapture{probeSite: "orphan", probeTarget: canonName, runtimePresent: convergeTriTrue, processAlive: convergeTriTrue},
+			start:      map[string]string{},
+			end:        map[string]string{}, // rollback writes no compared key
+			realCity:   true,
+		},
+		{
+			name: "priming_attempt_fixture_only",
+			durable: durableFacts{
+				canonicalIdentity: canonName,
+				promptConfigured:  true,
+				primedAt:          "",
+				currentPromptHash: "hash-v1",
+				now:               fixtureNow,
+			},
+			runtimeCap: shadowRuntimeCapture{probeSite: "desired", probeTarget: canonName, runtimePresent: convergeTriTrue, processAlive: convergeTriTrue},
+			start:      map[string]string{sessionpkg.CanonicalInstanceNameMetadata: canonName},
+			end: map[string]string{
+				sessionpkg.CanonicalInstanceNameMetadata:  canonName,
+				sessionpkg.PrimingAttemptedAtMetadataKey:  "2026-07-08T12:00:00Z",
+				sessionpkg.PromptHashMetadataKey:          "hash-v1",
+			},
+			pred: convergePredictedValues{
+				primingAttemptedAt: "2026-07-08T12:00:00Z",
+				promptHash:         "hash-v1",
+			},
+			recorded: []legacyCompareWrite{
+				{key: sessionpkg.PrimingAttemptedAtMetadataKey, value: "2026-07-08T12:00:00Z", writer: "attemptPrime"},
+				{key: sessionpkg.PromptHashMetadataKey, value: "hash-v1", writer: "attemptPrime"},
+			},
+			realCity: false, // fixtures compare the full owned set incl. priming
+		},
+		{
+			name: "priming_stamp_from_runtime_fixture_only",
+			durable: durableFacts{
+				canonicalIdentity: canonName,
+				promptConfigured:  true,
+				primedAt:          "",
+				currentPromptHash: "hash-v2",
+				now:               fixtureNow,
+			},
+			runtimeCap: shadowRuntimeCapture{probeSite: "desired", probeTarget: canonName, runtimePresent: convergeTriTrue, processAlive: convergeTriTrue, primedEnv: true},
+			start:      map[string]string{sessionpkg.CanonicalInstanceNameMetadata: canonName},
+			end: map[string]string{
+				sessionpkg.CanonicalInstanceNameMetadata: canonName,
+				sessionpkg.PrimedAtMetadataKey:           "2026-07-08T12:00:00Z",
+				sessionpkg.PromptHashMetadataKey:         "hash-v2",
+			},
+			pred: convergePredictedValues{
+				primedAt:   "2026-07-08T12:00:00Z",
+				promptHash: "hash-v2",
+			},
+			recorded: []legacyCompareWrite{
+				{key: sessionpkg.PrimedAtMetadataKey, value: "2026-07-08T12:00:00Z", writer: "stampPrimed"},
+				{key: sessionpkg.PromptHashMetadataKey, value: "hash-v2", writer: "stampPrimed"},
+			},
+			realCity: false,
+		},
+		{
+			name: "canonical_absent_derived_only_no_legacy_write_realcity",
+			// The canonical record is absent and legacy does NOT heal it this tick
+			// (per-tick heal is the derived-only future behavior). The derivation
+			// wants to stamp; in shadow it is NOT executed, so end stays absent.
+			// This must produce ZERO divergences (no unrealized-prediction flood).
+			durable: durableFacts{
+				canonicalIdentity: "",
+				now:               fixtureNow,
+			},
+			runtimeCap: shadowRuntimeCapture{probeSite: "desired", probeTarget: canonName, runtimePresent: convergeTriTrue, processAlive: convergeTriTrue},
+			start:      map[string]string{},
+			end:        map[string]string{}, // legacy did not write; shadow did not execute
+			pred:       convergePredictedValues{canonicalInstanceName: canonName},
+			realCity:   true,
+		},
+		{
+			name: "priming_excluded_on_realcity_no_divergence",
+			// primedEnv is unobservable on real cities (pinned false); the runtime
+			// legacy-primed this incarnation but the durable marker is absent. On a
+			// real city this must NOT flag — priming is excluded.
+			durable: durableFacts{
+				canonicalIdentity: canonName,
+				promptConfigured:  true,
+				primedAt:          "",
+				now:               fixtureNow,
+			},
+			runtimeCap: shadowRuntimeCapture{probeSite: "desired", probeTarget: canonName, runtimePresent: convergeTriTrue, processAlive: convergeTriTrue, primedEnv: false},
+			start:      map[string]string{sessionpkg.CanonicalInstanceNameMetadata: canonName},
+			end:        map[string]string{sessionpkg.CanonicalInstanceNameMetadata: canonName},
+			realCity:   true,
+		},
+	}
+}
+
+// runFixture evaluates one fixture through a fresh tick collector with the
+// harness force-enabled, and returns the resulting counter snapshot.
+func runFixture(t *testing.T, f convergeFixture, deriveOverride func(durableFacts, runtimeFacts) []sessConvergeAction) convergeCounterSnapshot {
+	t.Helper()
+	t.Setenv("GC_CONVERGE_SHADOW", "1")
+	counters := newConvergeShadowCounters()
+	tick := newConvergeShadowTick("observer-test", 1, fixtureNow, f.realCity, counters)
+	if tick == nil {
+		t.Fatal("newConvergeShadowTick returned nil with harness enabled")
+	}
+	const sid = "sess-1"
+	tick.captureDurable(sid, "tok-1", f.runtimeCap.probeTarget, f.durable, f.start, f.pred)
+	tick.captureRuntime(sid, f.runtimeCap.probeSite, f.runtimeCap.probeTarget, f.runtimeCap.runtimePresent, f.runtimeCap.processAlive)
+	// Preserve primedEnv from the fixture (captureRuntime does not carry it).
+	tick.evals[sid].runtimeCap.primedEnv = f.runtimeCap.primedEnv
+	// Feed recorded legacy writes.
+	for _, w := range f.recorded {
+		tick.recorder.record(sid, w.writer, map[string]string{w.key: w.value})
+	}
+	tick.finish(map[string]map[string]string{sid: f.end})
+	return counters.snapshot()
+}
+
+// TestConvergeShadowCleanCorpus is the blocking CI gate: every fixture in the
+// clean corpus produces zero surviving divergences and a proven denominator.
+func TestConvergeShadowCleanCorpus(t *testing.T) {
+	for _, f := range convergeCleanCorpus() {
+		t.Run(f.name, func(t *testing.T) {
+			snap := runFixture(t, f, nil)
+			if got := snap.survivingDivergences(); got != 0 {
+				t.Errorf("%s: surviving divergences = %d, want 0 (classes: %v)", f.name, got, snap.DivergenceTotal)
+			}
+			if snap.SessionsEvaluated == 0 && snap.Incomparable == 0 {
+				t.Errorf("%s: nothing evaluated — flatlined denominator is a harness failure, not a pass", f.name)
+			}
+			if snap.RecordsDropped != 0 {
+				t.Errorf("%s: records_dropped = %d, must be 0", f.name, snap.RecordsDropped)
+			}
+		})
+	}
+}
+
+// TestConvergeShadowSeededMutationCanary injects a deliberately broken derivation
+// and asserts the comparator TRIPS within one tick on the affected fixtures. A
+// dead comparator and a perfect derivation both report 0 divergences; this proves
+// which one we have. Required pre-soak self-test (3c) — wired to gates.canary.
+func TestConvergeShadowSeededMutationCanary(t *testing.T) {
+	// Seed 1: drop actionStampCanonicalIdentity. The heal fixture must flag: the
+	// legacy path stamped the canonical record (end != start) but the crippled
+	// derivation predicts no write -> unpredicted_delta (recorder explains it).
+	t.Run("drop_canonical_stamp", func(t *testing.T) {
+		// The fixture is the CORRECT converged world (canonical present at tick
+		// end), reached under fixture/execution semantics (realCity=false). The
+		// broken derivation "forgot to heal": it claims the record is already
+		// present (durable.canonicalIdentity set) so it emits no stamp, even though
+		// the record was absent at tick start. The full oracle must flag the
+		// realized-but-unpredicted canonical delta within this one tick.
+		f := convergeFixture{
+			name: "canary_drop_canonical",
+			durable: durableFacts{
+				canonicalIdentity: "dir/agent-1", // broken: derivation emits nothing
+				now:               fixtureNow,
+			},
+			runtimeCap: shadowRuntimeCapture{probeSite: "desired", probeTarget: "dir/agent-1", runtimePresent: convergeTriTrue, processAlive: convergeTriTrue},
+			start:      map[string]string{}, // record was absent at tick start
+			end:        map[string]string{sessionpkg.CanonicalInstanceNameMetadata: "dir/agent-1"},
+			pred:       convergePredictedValues{canonicalInstanceName: "dir/agent-1"},
+			recorded:   []legacyCompareWrite{{key: sessionpkg.CanonicalInstanceNameMetadata, value: "dir/agent-1", writer: "syncSessionBeads"}},
+			realCity:   false, // fixture/execution semantics -> full oracle
+		}
+		snap := runFixture(t, f, nil)
+		if snap.survivingDivergences() == 0 {
+			t.Fatalf("canary did not trip: comparator is dead (divergences: %v)", snap.DivergenceTotal)
+		}
+	})
+
+	// Seed 2: emit a WRONG canonical slot. Legacy stamped slot 3; a broken
+	// executor prediction of slot 9 must surface value_mismatch.
+	t.Run("wrong_slot_value_mismatch", func(t *testing.T) {
+		snap := runFixtureWrongSlot(t)
+		if snap.DivergenceTotal[divergenceValueMismatch] == 0 {
+			t.Fatalf("canary did not trip on wrong slot: %v", snap.DivergenceTotal)
+		}
+	})
+}
+
+// runFixtureWrongSlot models a derivation that predicts the wrong canonical slot
+// value than legacy actually wrote.
+func runFixtureWrongSlot(t *testing.T) convergeCounterSnapshot {
+	t.Helper()
+	t.Setenv("GC_CONVERGE_SHADOW", "1")
+	counters := newConvergeShadowCounters()
+	tick := newConvergeShadowTick("observer-test", 1, fixtureNow, true, counters)
+	const sid = "sess-1"
+	tick.captureDurable(sid, "tok-1", "dir/agent-1",
+		durableFacts{canonicalIdentity: "", now: fixtureNow},
+		map[string]string{},
+		convergePredictedValues{canonicalInstanceName: "dir/agent-1", canonicalPoolSlot: "9"}, // WRONG: predicts 9
+	)
+	tick.captureRuntime(sid, "desired", "dir/agent-1", convergeTriTrue, convergeTriTrue)
+	tick.recorder.record(sid, "poolCreate", map[string]string{
+		sessionpkg.CanonicalInstanceNameMetadata: "dir/agent-1",
+		sessionpkg.CanonicalPoolSlotMetadata:     "3",
+	})
+	tick.finish(map[string]map[string]string{sid: {
+		sessionpkg.CanonicalInstanceNameMetadata: "dir/agent-1",
+		sessionpkg.CanonicalPoolSlotMetadata:     "3", // legacy wrote 3
+	}})
+	return counters.snapshot()
+}
+
+// TestConvergeShadowDisabledIsNoop asserts the harness is byte-identically inert
+// when GC_CONVERGE_SHADOW is unset: newConvergeShadowTick returns nil, every
+// method is a no-op, and the global recorder is never attached.
+func TestConvergeShadowDisabledIsNoop(t *testing.T) {
+	t.Setenv("GC_CONVERGE_SHADOW", "")
+	tick := newConvergeShadowTick("observer", 1, fixtureNow, true, newConvergeShadowCounters())
+	if tick != nil {
+		t.Fatal("expected nil tick when harness disabled")
+	}
+	// Nil-method safety.
+	tick.captureDurable("s", "t", "n", durableFacts{}, nil, convergePredictedValues{})
+	tick.captureRuntime("s", "site", "n", convergeTriTrue, convergeTriTrue)
+	tick.markSkip("s", skipEarlyContinue)
+	tick.finish(nil)
+	if convergeGlobalRecorder.Load() != nil {
+		t.Fatal("global recorder must not be attached when disabled")
+	}
+	// The write-site wrapper must be a no-op with no recorder attached.
+	recordLegacyCompareWrites("s", "writer", map[string]string{sessionpkg.CanonicalInstanceNameMetadata: "x"})
+}
+
+// TestConvergeForeignWriteDetected asserts an owned-key delta with no recorder
+// entry and no derived prediction is attributed FOREIGN_WRITE (its own lane).
+func TestConvergeForeignWriteDetected(t *testing.T) {
+	dv := evaluateStateDiffOracle("s", convergeCanonicalOwnedKeys,
+		map[string]string{}, // start: absent
+		map[string]string{sessionpkg.CanonicalInstanceNameMetadata: "surprise"}, // end: appeared
+		nil,                       // derivation predicted nothing
+		convergePredictedValues{}, // no predicted values
+		nil,                       // no recorder entry
+		false,                     // flip/fixture mode
+	)
+	if len(dv) != 1 || dv[0].class != divergenceForeignWrite {
+		t.Fatalf("expected one foreign_write divergence, got %v", dv)
+	}
+}
+
+// TestConvergeUnpredictedDeltaWhenRecorded asserts an owned-key delta the
+// derivation missed but a recorder entry explains is unpredicted_delta, not
+// foreign_write.
+func TestConvergeUnpredictedDeltaWhenRecorded(t *testing.T) {
+	dv := evaluateStateDiffOracle("s", convergeCanonicalOwnedKeys,
+		map[string]string{},
+		map[string]string{sessionpkg.CanonicalInstanceNameMetadata: "healed"},
+		nil,
+		convergePredictedValues{},
+		[]legacyCompareWrite{{key: sessionpkg.CanonicalInstanceNameMetadata, value: "healed", writer: "legacy"}},
+		false, // flip/fixture mode
+	)
+	if len(dv) != 1 || dv[0].class != divergenceUnpredictedDelta {
+		t.Fatalf("expected one unpredicted_delta, got %v", dv)
+	}
+}
+
+// TestConvergeIdentitySkewSuppressed asserts a probe-target mismatch is
+// classified identity-skew (positive evidence) and never a hard divergence.
+func TestConvergeIdentitySkewSuppressed(t *testing.T) {
+	v := compareReplay(replayInput{
+		durable:           durableFacts{canonicalIdentity: "", now: fixtureNow},
+		runtime:           runtimeFacts{observed: true, live: true},
+		factsProbeTarget:  "dir/agent-A",
+		legacyProbeTarget: "dir/agent-B",
+	})
+	if len(v.divergences) != 0 {
+		t.Fatalf("identity-skew must not produce hard divergences, got %v", v.divergences)
+	}
+	if len(v.suppressed) != 1 || v.suppressed[0] != divergenceIdentitySkew {
+		t.Fatalf("expected identity_skew suppression, got %v", v.suppressed)
+	}
+}
+
+// TestConvergeRollbackSuppression asserts a derived rollback that legacy deferred
+// under an active tick-global coupling (budget exhausted / partial store) is
+// suppressed (world_moved), not a divergence.
+func TestConvergeRollbackSuppression(t *testing.T) {
+	base := replayInput{
+		durable: durableFacts{absent: true, now: fixtureNow},
+		runtime: runtimeFacts{observed: true, live: true},
+		// Legacy replay disabled -> legacy set == derived set, so no derived-absent
+		// mismatch is possible; force it by making legacy replayable with a
+		// non-live legacy read (legacy would NOT roll back).
+		legacyReplayable: true,
+		legacyValues:     durableFacts{absent: true, now: fixtureNow},
+		legacyRuntime:    runtimeFacts{observed: true, live: false},
+		suppression:      convergeSuppression{rollbackBudgetExhausted: true},
+	}
+	v := compareReplay(base)
+	if len(v.divergences) != 0 {
+		t.Fatalf("expected rollback suppressed, got divergences %v", v.divergences)
+	}
+	foundWorldMoved := false
+	for _, c := range v.suppressed {
+		if c == divergenceWorldMoved {
+			foundWorldMoved = true
+		}
+	}
+	if !foundWorldMoved {
+		t.Fatalf("expected world_moved suppression, got %v", v.suppressed)
+	}
+}
+
+// TestApplyDerivedToOwnedKeysIdempotent asserts applying the empty action list
+// leaves the snapshot unchanged (C2 idempotence at the oracle boundary).
+func TestApplyDerivedToOwnedKeysIdempotent(t *testing.T) {
+	start := map[string]string{sessionpkg.CanonicalInstanceNameMetadata: "x", sessionpkg.CanonicalPoolSlotMetadata: "2"}
+	end := applyDerivedToOwnedKeys(start, nil, convergePredictedValues{})
+	for k, v := range start {
+		if end[k] != v {
+			t.Errorf("key %q: got %q want %q", k, end[k], v)
+		}
+	}
+}

--- a/cmd/gc/session_converge_shadow_writesite_test.go
+++ b/cmd/gc/session_converge_shadow_writesite_test.go
@@ -22,12 +22,12 @@ import (
 // plan: "no non-test cmd/gc code may write a compared metadata key except via the
 // recording wrapper."
 var convergeComparedKeyWriteSiteInventory = map[string]string{
-	"session_identity.go":          "desiredSessionIdentity builds the canonical stamp (pure); recorded by callers (adoptionBarrier.create, syncSessionBeads.create)",
-	"session_name_lookup.go":       "pool-create canonical stamp; recorded via recordLegacyCompareWrites(poolSessionCreate)",
-	"session_reconcile.go":         "healStatePatchWithRollback priming clears; recorded via recordLegacyCompareWrites(healStatePatchWithRollback)",
-	"session_beads.go":             "syncSessionBeads reclaim priming clears + create canonical stamp; recorded via recordLegacyCompareWrites",
+	"session_identity.go":           "desiredSessionIdentity builds the canonical stamp (pure); recorded by callers (adoptionBarrier.create, syncSessionBeads.create)",
+	"session_name_lookup.go":        "pool-create canonical stamp; recorded via recordLegacyCompareWrites(poolSessionCreate)",
+	"session_reconcile.go":          "healStatePatchWithRollback builds priming clears; recorded via recordLegacyCompareWrites(healStateWithRollback) at the ApplyPatch site",
+	"session_beads.go":              "syncSessionBeads reclaim priming clears + create canonical stamp; recorded via recordLegacyCompareWrites",
 	"session_lifecycle_parallel.go": "clearStaleResumeKeyMetadata priming clears; recorded via recordLegacyCompareWrites(clearStaleResumeKeyMetadata)",
-	"session_converge_shadow.go":   "the recorder + owned-key oracle itself (applyDerivedToOwnedKeys writes a local prediction map, not a store)",
+	"session_converge_shadow.go":    "the recorder + owned-key oracle itself (applyDerivedToOwnedKeys writes a local prediction map, not a store)",
 }
 
 // comparedKeyConstantNames are the metadata-key CONSTANT identifiers whose map

--- a/cmd/gc/session_converge_shadow_writesite_test.go
+++ b/cmd/gc/session_converge_shadow_writesite_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// convergeComparedKeyWriteSiteInventory is the PERMANENT writer inventory the
+// S19 Stage 3 double-write safety review demanded (3b/3c). Every non-test cmd/gc
+// file that writes a compared metadata key MUST appear here, and every file here
+// must be wired into the in-process recorder — either by calling
+// recordLegacyCompareWrites directly, or (for pure map-builders with no bead ID)
+// by carrying the `convergecompare:recorded-by-caller` marker documenting the
+// caller that records on its behalf.
+//
+// Adding a new writer of a compared key without registering it here fails
+// TestConvergeCompareKeyWriteSitesWired. This is the enforcement described in the
+// plan: "no non-test cmd/gc code may write a compared metadata key except via the
+// recording wrapper."
+var convergeComparedKeyWriteSiteInventory = map[string]string{
+	"session_identity.go":          "desiredSessionIdentity builds the canonical stamp (pure); recorded by callers (adoptionBarrier.create, syncSessionBeads.create)",
+	"session_name_lookup.go":       "pool-create canonical stamp; recorded via recordLegacyCompareWrites(poolSessionCreate)",
+	"session_reconcile.go":         "healStatePatchWithRollback priming clears; recorded via recordLegacyCompareWrites(healStatePatchWithRollback)",
+	"session_beads.go":             "syncSessionBeads reclaim priming clears + create canonical stamp; recorded via recordLegacyCompareWrites",
+	"session_lifecycle_parallel.go": "clearStaleResumeKeyMetadata priming clears; recorded via recordLegacyCompareWrites(clearStaleResumeKeyMetadata)",
+	"session_converge_shadow.go":   "the recorder + owned-key oracle itself (applyDerivedToOwnedKeys writes a local prediction map, not a store)",
+}
+
+// comparedKeyConstantNames are the metadata-key CONSTANT identifiers whose map
+// assignment counts as a compared-key write, regardless of package qualifier.
+var comparedKeyConstantNames = []string{
+	"CanonicalInstanceNameMetadata",
+	"CanonicalPoolSlotMetadata",
+	"PrimedAtMetadataKey",
+	"PrimingAttemptedAtMetadataKey",
+	"PromptHashMetadataKey",
+}
+
+// comparedKeyStringLiterals are the raw string values of the compared keys, in
+// case a site writes the literal rather than the constant.
+var comparedKeyStringLiterals = []string{
+	`"canonical_instance_name"`,
+	`"canonical_pool_slot"`,
+	`"primed_at"`,
+	`"priming_attempted_at"`,
+	`"prompt_hash"`,
+}
+
+// TestConvergeCompareKeyWriteSitesWired is the write-site-completeness guard, in
+// the TestGCNonTestFilesStayOnWorkerBoundary style. It asserts:
+//
+//  1. every non-test cmd/gc file that writes a compared key is registered in the
+//     inventory (a new, unregistered writer fails the build); and
+//  2. every registered writer is wired into the recorder (calls
+//     recordLegacyCompareWrites, or carries the recorded-by-caller marker); and
+//  3. the inventory carries no stale entries (a file that no longer writes any
+//     compared key must be removed).
+func TestConvergeCompareKeyWriteSitesWired(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(currentFile)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q): %v", dir, err)
+	}
+
+	// A compared-key write is an assignment of the form `[<key-ref>] =` (not `==`).
+	// Build one matcher per key reference.
+	var writeMatchers []*regexp.Regexp
+	for _, name := range comparedKeyConstantNames {
+		// Index assignment: [session.PrimedAtMetadataKey] =  /  [PrimedAtMetadataKey] =
+		writeMatchers = append(writeMatchers, regexp.MustCompile(`\[[A-Za-z0-9_]*\.?`+regexp.QuoteMeta(name)+`\]\s*=[^=]`))
+		// Map-literal key: sessionpkg.PrimedAtMetadataKey:  (a write via composite literal)
+		writeMatchers = append(writeMatchers, regexp.MustCompile(`[A-Za-z0-9_]+\.`+regexp.QuoteMeta(name)+`\s*:`))
+	}
+	for _, lit := range comparedKeyStringLiterals {
+		// Only the index-assignment literal form ["primed_at"] = is matched; a
+		// string-literal-as-map-key colon matcher would false-match doc comments
+		// like `// primedAt mirrors "primed_at": ...`. cmd/gc writes these keys via
+		// the exported constants, not string literals, so this stays a safety net.
+		writeMatchers = append(writeMatchers, regexp.MustCompile(`\[`+regexp.QuoteMeta(lit)+`\]\s*=[^=]`))
+	}
+
+	writersFound := map[string]bool{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("ReadFile(%q): %v", name, err)
+		}
+		content := string(data)
+		writes := false
+		for _, m := range writeMatchers {
+			if m.MatchString(content) {
+				writes = true
+				break
+			}
+		}
+		if !writes {
+			continue
+		}
+		writersFound[name] = true
+
+		if _, registered := convergeComparedKeyWriteSiteInventory[name]; !registered {
+			t.Errorf("%s writes a compared metadata key but is NOT registered in convergeComparedKeyWriteSiteInventory — register it and wire it into recordLegacyCompareWrites", name)
+			continue
+		}
+		if !strings.Contains(content, "recordLegacyCompareWrites") &&
+			!strings.Contains(content, "convergecompare:recorded-by-caller") {
+			t.Errorf("%s is a registered compared-key writer but is not wired into the recorder (missing recordLegacyCompareWrites call or convergecompare:recorded-by-caller marker)", name)
+		}
+	}
+
+	// Stale-entry guard: every inventory entry must still be a live writer.
+	for name := range convergeComparedKeyWriteSiteInventory {
+		if !writersFound[name] {
+			t.Errorf("inventory entry %q no longer writes a compared metadata key — remove the stale entry", name)
+		}
+	}
+}

--- a/cmd/gc/session_identity.go
+++ b/cmd/gc/session_identity.go
@@ -69,6 +69,9 @@ func desiredSessionIdentity(in sessionIdentityInputs) map[string]string {
 		meta["pool_slot"] = strconv.Itoa(in.PoolSlot)
 	}
 	if in.ConfigResolved && in.AgentName != "" {
+		// convergecompare:recorded-by-caller — desiredSessionIdentity is a pure
+		// builder with no bead ID; the S19 Stage 3 shadow recorder is fed by the
+		// callers that persist this map (adoptionBarrier.create, syncSessionBeads.create).
 		meta[session.CanonicalInstanceNameMetadata] = in.AgentName
 		if in.PoolSlot > 0 {
 			meta[session.CanonicalPoolSlotMetadata] = strconv.Itoa(in.PoolSlot)

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1897,6 +1897,9 @@ func clearStaleResumeKeyMetadata(session *beads.Bead, sessFront *sessionpkg.Stor
 	}
 	if sessFront != nil && strings.TrimSpace(session.ID) != "" {
 		_ = sessFront.ApplyPatch(session.ID, patch)
+		// S19 Stage 3 shadow: record the legacy priming-marker clears (no-op
+		// unless the shadow harness is enabled).
+		recordLegacyCompareWrites(session.ID, "clearStaleResumeKeyMetadata", patch)
 	}
 	if session.Metadata == nil {
 		session.Metadata = make(map[string]string, len(patch))

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -288,6 +288,10 @@ func createPoolSessionBeadWithAlias(
 	if err != nil {
 		return beads.Bead{}, err
 	}
+	// S19 Stage 3 shadow: record the legacy canonical-identity stamp on the
+	// pool-create path now that the bead ID exists (no-op unless the shadow
+	// harness is enabled).
+	recordLegacyCompareWrites(beadID, "poolSessionCreate", meta)
 	bead, err := store.Get(beadID)
 	if err != nil {
 		return beads.Bead{}, err

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -1139,6 +1139,11 @@ func healStateWithRollback(session *beads.Bead, alive bool, sessFront *sessionpk
 	for k, v := range batch {
 		session.Metadata[k] = v
 	}
+	// S19 Stage 3 shadow: record the legacy compared-key writes this heal ACTUALLY
+	// applied (no-op unless the shadow harness is enabled). Colocated with the
+	// ApplyPatch + in-memory mirror so a pure builder (healStatePatch) invoked only
+	// for inspection never records a write that never happened.
+	recordLegacyCompareWrites(session.ID, "healStateWithRollback", batch)
 	return batch
 }
 
@@ -1250,11 +1255,6 @@ func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock,
 			}
 		}
 	}
-	// S19 Stage 3 shadow: record the legacy priming-marker clears this heal batch
-	// carries (no-op unless the shadow harness is enabled). The batch is applied
-	// by the caller under the session's lock; recording it here keeps the writer
-	// inventory colocated with the write.
-	recordLegacyCompareWrites(session.ID, "healStatePatchWithRollback", batch)
 	return emptyNil(batch)
 }
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -1250,6 +1250,11 @@ func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock,
 			}
 		}
 	}
+	// S19 Stage 3 shadow: record the legacy priming-marker clears this heal batch
+	// carries (no-op unless the shadow harness is enabled). The batch is applied
+	// by the caller under the session's lock; recording it here keeps the writer
+	// inventory colocated with the write.
+	recordLegacyCompareWrites(session.ID, "healStatePatchWithRollback", batch)
 	return emptyNil(batch)
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1441,7 +1441,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	var shadowStartSnaps map[string]map[string]string
 	if convergeShadowEnabled() {
 		shadowTick = newConvergeShadowTick(cityName, nextConvergeShadowTickSeq(), clk.Now().UTC(), true, convergeShadowMetrics)
-		defer convergeGlobalRecorder.Store(nil)
+		// Safety-net detach for the loop's early returns; idempotent with the detach
+		// finish already runs, and ownership-guarded so a concurrent city tick's live
+		// recorder is never cleared here.
+		defer shadowTick.detach()
 		shadowStartSnaps = make(map[string]map[string]string, len(ordered))
 		for i := range ordered {
 			shadowStartSnaps[ordered[i].ID] = snapshotComparedKeys(ordered[i].Metadata)
@@ -1543,6 +1546,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// snapshot, no *session mutation before the finalize call). Guarded by
 			// TestReconcileSessionBeads_MinFloorCountReflectsMidTickCloseDrainAck.
 			infoByID[session.ID] = result.applyTo(infoByID[session.ID])
+			if shadowTick != nil {
+				// Pre-probe early-continue (drain-ack): nothing was compared this tick,
+				// so leave the denominator with a typed skip. Without this the session
+				// would carry its loop-entry durable capture but no runtime probe into
+				// finish and inflate sessions_evaluated with an unproven "clean"
+				// (hardening 2).
+				shadowTick.markSkip(session.ID, skipEarlyContinue)
+			}
 			continue
 		}
 
@@ -1556,6 +1567,12 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				trace.RecordDecision(TraceSiteReconcilerUnknownState, TraceReasonUnknownStateSkipped, TraceOutcomeSkipped, info.Template, info.SessionNameMetadata, traceRecordPayload{
 					"state": info.MetadataState,
 				})
+			}
+			if shadowTick != nil {
+				// Pre-probe early-continue (unknown state): forward-compat skip with
+				// nothing to compare — leave the denominator with a typed skip
+				// (hardening 2).
+				shadowTick.markSkip(session.ID, skipEarlyContinue)
 			}
 			continue
 		}
@@ -3087,6 +3104,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			endSnaps[ordered[i].ID] = snapshotComparedKeys(ordered[i].Metadata)
 		}
 		shadowTick.finish(endSnaps)
+		// Operator read path (Q3: no new event type): surface the soak signal on the
+		// reconciler's existing stderr channel — one bounded line per enabled tick,
+		// so a live GC_CONVERGE_SHADOW soak reports its denominator and surviving
+		// divergences instead of incrementing counters nothing can read.
+		fmt.Fprintf(stderr, "session reconciler: %s\n", convergeShadowMetrics.snapshot().operatorSummary()) //nolint:errcheck // best-effort operator log
 	}
 	recordPhase(TraceSiteSessionReconcileForwardPass, "session_reconcile.forward_pass", phaseStart, map[string]any{
 		"ordered_session_count":  len(ordered),

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1432,6 +1432,21 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		orderedIDs[i] = ordered[i].ID
 		infoByID[ordered[i].ID] = sessionpkg.InfoFromPersistedBead(ordered[i])
 	}
+	// S19 Stage 3 shadow harness (OBSERVATION-ONLY): assemble the per-tick
+	// collector from the ALREADY-observed coherent Info snapshot + raw beads —
+	// no new probes, no writes. shadowTick is nil (and every method a no-op)
+	// unless GC_CONVERGE_SHADOW is set, so this reconciler is byte-identical when
+	// the harness is off. The deferred detach handles the loop's early returns.
+	var shadowTick *convergeShadowTick
+	var shadowStartSnaps map[string]map[string]string
+	if convergeShadowEnabled() {
+		shadowTick = newConvergeShadowTick(cityName, nextConvergeShadowTickSeq(), clk.Now().UTC(), true, convergeShadowMetrics)
+		defer convergeGlobalRecorder.Store(nil)
+		shadowStartSnaps = make(map[string]map[string]string, len(ordered))
+		for i := range ordered {
+			shadowStartSnaps[ordered[i].ID] = snapshotComparedKeys(ordered[i].Metadata)
+		}
+	}
 	// Phase 1: Forward pass (topo order) — wake sessions, handle alive state.
 	var startCandidates []startCandidate
 	var wakeTargets []wakeTarget
@@ -1492,6 +1507,20 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		info := infoByID[session.ID]
 		name := strings.TrimSpace(info.SessionNameMetadata)
 		tp, desired := desiredState[name]
+		if shadowTick != nil {
+			// 3a: durable facts from already-observed Info + raw priming metadata.
+			// The predicted canonical value is a best-effort heal proxy; it is only
+			// consulted by the C4 value-parity check when legacy also wrote the key
+			// this tick, which this reconciler pass never does (identity is stamped
+			// at create/adopt), so it can never manufacture a false divergence here.
+			shadowTick.captureDurable(session.ID, info.InstanceToken, name,
+				buildDurableFactsFromInfo(info, session.Metadata, shadowTick.tickNow),
+				shadowStartSnaps[session.ID],
+				convergePredictedValues{
+					canonicalInstanceName: strings.TrimSpace(info.AgentName),
+					canonicalPoolSlot:     strings.TrimSpace(info.PoolSlot),
+				})
+		}
 		if _, _, pending := resetPendingCommittedAtInfo(info); !pending && dt != nil {
 			dt.clearResetStall(session.ID)
 		}
@@ -1538,6 +1567,12 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			providerAlive, err := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, session.ID)
 			if err != nil {
 				providerAlive = false
+			}
+			if shadowTick != nil {
+				// 3a: capture the !desired path's OWN probe result (presence only,
+				// by bead ID). alive is unknown on this path; probe target is left
+				// empty because this path probes by ID, not name (no name to skew).
+				shadowTick.captureRuntime(session.ID, "workerSessionTargetRunningWithConfig", "", triFromBool(providerAlive), convergeTriUnknown)
 			}
 			// Run this before configured named-session preservation. A stale
 			// state=creating bead with an expired pending-create lease would
@@ -1965,6 +2000,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// The desired-session fast path only needs running/alive; attachment
 		// and activity are probed by the narrower branches that use them.
 		running, alive := observeRuntimeProviderLiveness(sp, name, tp.Hints.ProcessNames)
+		if shadowTick != nil {
+			// 3a: capture the desired fast path's OWN two-bit probe (present +
+			// alive) by name, enabling zombie (present && !alive) expression.
+			shadowTick.captureRuntime(session.ID, "observeRuntimeProviderLiveness", name, triFromBool(running), triFromBool(alive))
+		}
 		peek := cachedSessionPeek(cityPath, store, sp, cfg, session.ID, tp.Hints.ProcessNames)
 		recordResetStallIfDue(*session, tp.TemplateName, name, alive, startupTimeout, clk.Now().UTC(), dt, rec, stderr, trace)
 
@@ -3037,6 +3077,16 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 
 		wakeTargets = append(wakeTargets, wakeTarget{session: session, tp: tp, alive: alive})
+	}
+	if shadowTick != nil {
+		// 3b/3c: snapshot the compared keys at tick end from the raw beads (kept in
+		// lockstep with the reconciler's in-memory mutations), then run the oracle +
+		// replay comparator and update the counters. Pure observation — no writes.
+		endSnaps := make(map[string]map[string]string, len(ordered))
+		for i := range ordered {
+			endSnaps[ordered[i].ID] = snapshotComparedKeys(ordered[i].Metadata)
+		}
+		shadowTick.finish(endSnaps)
 	}
 	recordPhase(TraceSiteSessionReconcileForwardPass, "session_reconcile.forward_pass", phaseStart, map[string]any{
 		"ordered_session_count":  len(ordered),


### PR DESCRIPTION
Stage 3 shadow harness: builds per-session facts + in-process legacy-write recorder + state-diff oracle + replay comparator + CI write-site-completeness guard + seeded-mutation canary. OBSERVATION-ONLY — no double-write/flip, zero behavior change. Priming excluded from real-city comparison (Q1); counters-only (Q3); D7 amended (Q2). STACKED on #4064 (re-target to main after it merges). Flip (3d) is a separate future PR gated on soak. Plan: engdocs/simplification/specs/S19-stage3-plan.md. #3872