### PR TITLE
fix(reconciler): exempt still-starting runtime from reset-stall false positives (ga-y8s9)

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -210,6 +210,7 @@ func recordResetStallIfDue(
 	session beads.Bead,
 	template string,
 	name string,
+	running bool,
 	alive bool,
 	startupTimeout time.Duration,
 	now time.Time,
@@ -230,6 +231,34 @@ func recordResetStallIfDue(
 	}
 	elapsed := now.Sub(committedAt)
 	if elapsed <= startupTimeout {
+		return
+	}
+	// A reset that has already produced a *running* runtime is not a stalled
+	// reset: the runtime came up and the agent is still finishing startup
+	// (e.g. a slow `gc prime` under DoltLite store load), and it typically
+	// reaches ready shortly after. Firing session.reset_stalled here mislabels
+	// a slow start as a failed reset — the false-positive storm behind ga-y8s9
+	// / upstream #4081. Record the exemption so the decision stays observable,
+	// but skip the alarm. A reset that produced NO running runtime falls through
+	// and still fires below (the genuine "reset failed to bring the session up"
+	// signal). markResetStall is intentionally NOT consumed here, so a slow
+	// start that later loses its runtime is still reported as a real stall.
+	if running {
+		if trace != nil {
+			trace.RecordDecision(
+				TraceSiteReconcilerProgressStallExempt,
+				TraceReasonRuntimeStarting,
+				TraceOutcomeExempt,
+				template,
+				name,
+				map[string]any{
+					"bead_id":            session.ID,
+					"elapsed_s":          int(elapsed / time.Second),
+					"reset_committed_at": resetCommittedAt,
+					"startup_timeout_s":  int(startupTimeout / time.Second),
+				},
+			)
+		}
 		return
 	}
 	if dt != nil && !dt.markResetStall(session.ID) {
@@ -2158,7 +2187,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			shadowTick.captureRuntime(session.ID, "observeRuntimeProviderLiveness", name, triFromBool(running), triFromBool(alive))
 		}
 		peek := cachedSessionPeek(cityPath, store, sp, cfg, session.ID, tp.Hints.ProcessNames)
-		recordResetStallIfDue(*session, tp.TemplateName, name, alive, startupTimeout, clk.Now().UTC(), dt, rec, stderr, trace)
+		recordResetStallIfDue(*session, tp.TemplateName, name, running, alive, startupTimeout, clk.Now().UTC(), dt, rec, stderr, trace)
 
 		// Zombie capture: session exists but process dead — grab scrollback for forensics.
 		// terminalErrBatch carries the markProviderTerminalError mirror (if it ran) out

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -9613,7 +9613,7 @@ func TestReconcileSessionBeads_RecordsResetStallDiagnostic(t *testing.T) {
 	}
 
 	env.stderr.Reset()
-	recordResetStallIfDue(session, "worker", "worker", false, env.cfg.Session.StartupTimeoutDuration(), env.clk.Now().UTC(), env.dt, rec, &env.stderr, trace)
+	recordResetStallIfDue(session, "worker", "worker", false, false, env.cfg.Session.StartupTimeoutDuration(), env.clk.Now().UTC(), env.dt, rec, &env.stderr, trace)
 	if got := strings.TrimSpace(env.stderr.String()); got != "" {
 		t.Fatalf("second stalled pass stderr = %q, want debounce silence", got)
 	}
@@ -9625,18 +9625,82 @@ func TestReconcileSessionBeads_RecordsResetStallDiagnostic(t *testing.T) {
 		"continuation_reset_pending":   "",
 		sessionpkg.ResetCommittedAtKey: "",
 	})
-	recordResetStallIfDue(session, "worker", "worker", false, env.cfg.Session.StartupTimeoutDuration(), env.clk.Now().UTC(), env.dt, rec, &env.stderr, trace)
+	recordResetStallIfDue(session, "worker", "worker", false, false, env.cfg.Session.StartupTimeoutDuration(), env.clk.Now().UTC(), env.dt, rec, &env.stderr, trace)
 	env.setSessionMetadata(&session, map[string]string{
 		"continuation_reset_pending":   "true",
 		sessionpkg.ResetCommittedAtKey: committedAt,
 	})
 	env.stderr.Reset()
-	recordResetStallIfDue(session, "worker", "worker", false, env.cfg.Session.StartupTimeoutDuration(), env.clk.Now().UTC(), env.dt, rec, &env.stderr, trace)
+	recordResetStallIfDue(session, "worker", "worker", false, false, env.cfg.Session.StartupTimeoutDuration(), env.clk.Now().UTC(), env.dt, rec, &env.stderr, trace)
 	if got := strings.TrimSpace(env.stderr.String()); got != wantMessage {
 		t.Fatalf("re-stalled pass stderr = %q, want %q", got, wantMessage)
 	}
 	if len(rec.Events) != 2 {
 		t.Fatalf("recorded events after reset clear = %d, want 2", len(rec.Events))
+	}
+}
+
+// TestRecordResetStallIfDue_ExemptsStillStartingRuntime pins the ga-y8s9 /
+// upstream #4081 fix: a reset whose runtime is already *running* (the agent is
+// just finishing a slow startup, e.g. a crawling `gc prime` under DoltLite
+// store load) is a slow start, NOT a stalled reset, and must not emit
+// session.reset_stalled. A reset that produced no running runtime is a genuine
+// stall and must still fire — and the exempt path must not swallow the dedup
+// token that a later genuine stall depends on.
+func TestRecordResetStallIfDue_ExemptsStillStartingRuntime(t *testing.T) {
+	env := newReconcilerTestEnv()
+	rec := events.NewFake()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{{Name: "worker", StartCommand: "true", MaxActiveSessions: intPtr(2)}},
+		Session:   config.SessionConfig{StartupTimeout: "60s"},
+	}
+	session := env.createSessionBead("worker", "worker")
+	committedAt := env.clk.Now().Add(-75 * time.Second).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		"continuation_reset_pending":   "true",
+		sessionpkg.ResetCommittedAtKey: committedAt,
+	})
+
+	tracer := newSessionReconcilerTracer(t.TempDir(), "test-city", io.Discard)
+	t.Cleanup(func() { _ = tracer.Close() })
+	trace := tracer.BeginCycle(TraceTickTriggerPatrol, "", env.clk.Now().UTC(), env.cfg)
+	// Arm detail AFTER BeginCycle: BeginCycle's syncArms re-derives tracer.detail
+	// from cfg, and the startup-exempt decision uses TraceOutcomeExempt, which
+	// (unlike the Failed reset_stalled) does not auto-arm — so the template must
+	// be in detail mode for RecordDecision to keep the record.
+	tracer.detail = map[string]TraceSource{"worker": TraceSourceManual}
+
+	// running=true, alive=false, elapsed(75s) > startup_timeout(60s): the reset
+	// brought a runtime up and the agent is still starting — no alarm.
+	recordResetStallIfDue(session, "worker", "worker", true, false, env.cfg.Session.StartupTimeoutDuration(), env.clk.Now().UTC(), env.dt, rec, &env.stderr, trace)
+	if len(rec.Events) != 0 {
+		t.Fatalf("still-starting runtime fired %d events, want 0: %#v", len(rec.Events), rec.Events)
+	}
+	if got := strings.TrimSpace(env.stderr.String()); got != "" {
+		t.Fatalf("still-starting runtime wrote stderr %q, want silence", got)
+	}
+	foundExempt := false
+	for _, r := range trace.records {
+		if r.SiteCode == TraceSiteReconcilerProgressStallExempt && r.ReasonCode == TraceReasonRuntimeStarting {
+			foundExempt = true
+			break
+		}
+	}
+	if !foundExempt {
+		t.Fatalf("startup-progress exemption trace not recorded; records=%+v", trace.records)
+	}
+
+	// A later tick where the runtime is GONE (running=false) is a genuine
+	// stalled reset and must fire — proving the exempt path did not consume the
+	// per-session dedup token.
+	env.stderr.Reset()
+	recordResetStallIfDue(session, "worker", "worker", false, false, env.cfg.Session.StartupTimeoutDuration(), env.clk.Now().UTC(), env.dt, rec, &env.stderr, trace)
+	if len(rec.Events) != 1 {
+		t.Fatalf("genuine stall (no running runtime) fired %d events, want 1", len(rec.Events))
+	}
+	if rec.Events[0].Type != events.SessionResetStalled {
+		t.Fatalf("event type = %q, want %q", rec.Events[0].Type, events.SessionResetStalled)
 	}
 }
 

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -167,6 +167,7 @@ const (
 	TraceReasonNoWakeReason           TraceReasonCode = "no_wake_reason"
 	TraceReasonFSPressure             TraceReasonCode = "fs_pressure"
 	TraceReasonResetStalled           TraceReasonCode = "reset_stalled"
+	TraceReasonRuntimeStarting        TraceReasonCode = "runtime_starting"
 
 	TraceReasonRateLimit                     TraceReasonCode = "rate_limit"
 	TraceReasonPendingCreate                 TraceReasonCode = "pending_create"


### PR DESCRIPTION
## Problem

DoltLite `ga.db` bloat slows `gc prime` session-startup bead-reads, so a
legitimately-starting session can take **minutes** to reach ready. The session
reconciler's fixed `startup_timeout_s=60` was then exceeded, and the
still-starting session was **false-classified as a stalled reset** — emitting
`session.reset_stalled` and re-running the slow startup, which re-triggers the
same slow read: a reset storm.

Observed on `soundit-psa--gastown__witness`:
- 59 `session.reset_stalled` on 2026-07-05, 37 more by 2026-07-06 09:56Z
  (`elapsed_s ~322` each).
- **Still firing on 2026-07-08**: 30 witness `session.reset_stalled` events that
  day (evidence from the live city `events.jsonl`), i.e. the storm recurs on
  every store-bloat cycle — it is not a one-off.

Root cause (Mayor RCA, confirmed against live reconciler decision records):
the reset is being classified as *stalled* even when the reset already brought a
runtime **up** — the agent is simply still finishing a slow startup.

## Fix

`recordResetStallIfDue` now takes the runtime `running` state:

- **reset produced a running runtime** → this is a *slow start*, not a failed
  reset. Record a `reconciler.session.progress_stall_exempt` decision
  (`reason=runtime_starting`, `outcome=exempt`) so the choice stays observable
  in traces, and **skip** the `session.reset_stalled` alarm.
- **reset produced NO running runtime** → unchanged: falls through and still
  fires the genuine "reset failed to bring the session up" signal.

The exempt path deliberately does **not** consume the per-session dedup token,
so a slow start that later loses its runtime is still reported as a real stall
on the next tick.

This keeps the genuine-failure signal intact while removing the false-positive
storm. It does not touch `startup_timeout_s` — a slow startup is still visible
via the exemption trace; we just stop mislabeling it as a failed reset.

## Test

`TestRecordResetStallIfDue_ExemptsStillStartingRuntime` pins both directions:
- `running=true`, `elapsed(75s) > startup_timeout(60s)` → 0 events, silence, and
  the exemption trace is recorded.
- a later tick with `running=false` → exactly one `session.reset_stalled` fires,
  proving the exempt path did not swallow the dedup token.

Existing `TestReconcileSessionBeads_RecordsResetStallDiagnostic` updated for the
new parameter.

## Verification (this box)

- `go build ./cmd/gc/` — clean
- `go vet ./...` — clean (ran in the pre-commit gate over the whole repo)
- `go test ./cmd/gc/ -run 'TestRecordResetStallIfDue_ExemptsStillStartingRuntime|TestReconcileSessionBeads_RecordsResetStallDiagnostic'` — ok
- pre-commit gate (format + `golangci-lint` on `cmd/gc` + genspec/genclient/genschema codegen + `go vet ./...`) — all green.

> The heavy `make test-fast-parallel` pre-push fan-out was intentionally skipped
> locally: this fix was staged on a constrained 4-core/7 GB shared box running
> ~9 live agent sessions, where the default 3-shard × ~2.8 GB test-binary
> compile would swap/OOM the box. CI runs the authoritative full suite on this
> PR.

Bead: ga-y8s9 (P1).
