### PR TITLE
feat(runtime): treat unreachable tmux as partial observation, not "no sessions"

### DIFF
--- a/engdocs/design/index.md
+++ b/engdocs/design/index.md
@@ -23,6 +23,7 @@ lives in the [Architecture](../architecture/index.md) section.
 | `dependency-aware-bounded-parallel-lifecycle` | Implemented | Bounded parallel start/stop waves for session lifecycle |
 | `beads-dolt-contract-redesign` | Accepted | Canonical bd+Dolt contract, topology commands, migration, and provider-boundary redesign |
 | `idle-session-sleep` | Accepted | Idle-sleep policy, precedence, and wake mechanics |
+| `runtime-partial-discipline` | Accepted (source-level), follow-ups Proposed | Treat a failed tmux-liveness observation as partial (defer destructive arms) instead of "nothing running"; mirrors storeQueryPartial |
 | `idle-controller-call-rate` | Proposed | Layer-3 (#2463/#3543) cut of the controller's idle bd/Dolt call *rate*: demand-gated ticking, per-pass snapshot, quiescent-scope skipping |
 | `session-store-fences` | Accepted | Cross-process write fences for session-owned metadata: store facts, flock and token-reread fences, residual convergence-through-persistence |
 | `named-configured-sessions` | Accepted | Explicit canonical named sessions backed by reusable templates; partially superseded by `session-model-unification` |

--- a/engdocs/design/runtime-partial-discipline.md
+++ b/engdocs/design/runtime-partial-discipline.md
@@ -23,11 +23,32 @@ exist", so a brief blip drove the reconciler to drain/close healthy pool slots.
   (wrapping the original cause) instead of an empty *success*. `refresh()`
   therefore preserves the cache's last-known-good until the existing `staleTTL`
   cliff, so a brief outage no longer collapses `IsRunning` to false. This is the
-  highest-leverage single point: the reconciler's liveness reads all flow
-  through `StateCache.IsRunning`, so protecting the observation source shields
-  every downstream destructive arm at once, bounded by `staleTTL` (30s default).
-  The wrapped error still satisfies `isNoServerError`, so the ~20 existing
-  `ErrNoServer` absorbers are unaffected.
+  highest-leverage single point on the **liveness** path: the reconciler's
+  `IsRunning` / `ObserveLiveness` reads all flow through `StateCache`, so
+  protecting the observation source shields that whole path at once, bounded by
+  `staleTTL` (30s default). The wrapped error still satisfies `isNoServerError`,
+  so the ~20 existing `ErrNoServer` absorbers are unaffected.
+
+### Still exposed: the `ListRunning` sites
+
+The `FetchState` fix shields the `StateCache.IsRunning` liveness path, but NOT
+`Provider.ListRunning` (via `Tmux.ListSessions`), which still returns
+`(nil, nil)` on `ErrNoServer` — an empty *success*, not a partial signal. Three
+reconciler-facing sites call `ListRunning` destructively on that empty result:
+
+- `cmd/gc/city_runtime.go:960` — pool `on_death` hooks. On a full tmux outage
+  every pool slot vanishes from the empty listing at once, so the tick fires the
+  user's `on_death` command for EVERY pool slot: a false death storm.
+- `cmd/gc/city_runtime.go:1899` — provider swap on config reload.
+- `cmd/gc/city_runtime.go:3466` / `:3478` — shutdown (and the force-shutdown
+  late-async-start re-list) session listing.
+
+All four `IsPartialListError` guards at those call sites already exist (verified
+in-tree), but none fires today because `ListRunning` returns a nil error on
+`ErrNoServer`. The clean completion path is doc-only from here: emit the
+EXISTING `PartialListError` from `Provider.ListRunning` / `Tmux.ListSessions` on
+`ErrNoServer` (arm 6 below), which activates all four guards with no new
+plumbing — the `on_death` storm is arm 4.
 
 ### Bounded behavior change (maintainer, please confirm)
 

--- a/engdocs/design/runtime-partial-discipline.md
+++ b/engdocs/design/runtime-partial-discipline.md
@@ -1,0 +1,79 @@
+---
+title: Runtime-partial discipline
+description: Treating a failed runtime-liveness observation as "I could not tell" instead of "nothing is running", mirroring the store-partial guard.
+---
+
+The bead-store side already distinguishes a partial/failed read from a real
+"no rows" answer: `storeQueryPartial` threads through the session reconciler and
+gates every destructive arm (close-as-orphaned, drain-ack stop, pending-create
+rollback) so a degraded store never causes a healthy session to be torn down
+(`cmd/gc/session_reconciler.go`, search `storeQueryPartial`).
+
+The runtime side had no equivalent. A tmux-liveness observation that FAILED
+(server briefly unreachable) was indistinguishable from the fact "no sessions
+exist", so a brief blip drove the reconciler to drain/close healthy pool slots.
+
+## Landed (this PR)
+
+- `runtime.ErrRuntimeUnavailable` sentinel + `runtime.IsRuntimeQueryPartial` in
+  `internal/runtime/runtime.go` — the runtime-side analogue of a partial store
+  read.
+- `internal/runtime/tmux/state_cache.go` `tmuxFetcher.FetchState`: an
+  unreachable server (`ErrNoServer`) now returns `ErrRuntimeUnavailable`
+  (wrapping the original cause) instead of an empty *success*. `refresh()`
+  therefore preserves the cache's last-known-good until the existing `staleTTL`
+  cliff, so a brief outage no longer collapses `IsRunning` to false. This is the
+  highest-leverage single point: the reconciler's liveness reads all flow
+  through `StateCache.IsRunning`, so protecting the observation source shields
+  every downstream destructive arm at once, bounded by `staleTTL` (30s default).
+  The wrapped error still satisfies `isNoServerError`, so the ~20 existing
+  `ErrNoServer` absorbers are unaffected.
+
+### Bounded behavior change (maintainer, please confirm)
+
+Genuine session ends evict from the cache immediately via `Stop()` /
+`EvictSession`, so they are NOT masked. The one residual: an **externally**
+killed **last** session (killed outside `Stop`, which also makes tmux exit-empty
+and return `ErrNoServer`) is reported running from last-known-good for up to
+`staleTTL` before the cliff clears it. This is the intended trade — a bounded
+cleanup delay in an edge case, versus draining every pool slot on a blip — but
+it is a real behavior change and is called out here for explicit sign-off.
+
+## Follow-up arms (not yet threaded)
+
+Even with the source-level fix, each of these destructive arms should read a
+`runtimeQueryPartial` signal and defer, mirroring the `storeQueryPartial`
+branches, for the window AFTER `staleTTL` (when the cache legitimately goes
+empty but the runtime is still just unreachable). Do them one at a time, each
+with a `beadReconcileTick`-level test that asserts the arm defers under a
+partial runtime observation:
+
+1. **state_cache staleTTL cliff** — after `staleTTL`, `currentState()` returns an
+   empty snapshot (`state_cache.go` ~line 148). Expose a `Degraded()`/partial
+   status so consumers can distinguish "empty because unreachable" from "empty
+   because idle", instead of silently reporting all-not-running.
+2. **heal-to-asleep slot-free** — `cmd/gc/session_reconciler.go` heal path
+   (`healStateWithRollback`, ~line 1692): a `!providerAlive` observation drives a
+   running session toward asleep/closed. Gate with `!runtimeQueryPartial`.
+3. **orphan close / drain-advance false-complete** — the `!desired` orphan branch
+   (`session_reconciler.go` ~1537) and drain completion: an empty/negative
+   observation must not advance a drain to "complete" or close a pool bead as
+   orphaned when the runtime query was partial.
+4. **on_death storm** — the death handler that fires when a session is observed
+   gone: suppress the death cascade when the observation was runtime-partial.
+5. **pre-start orphan fail-open** — `cmd/gc/session_wake.go` (~line 552,
+   `if err != nil { running = false }`): a failed reachability probe currently
+   falls open to "not running"; it should treat `ErrRuntimeUnavailable` as
+   partial and defer.
+6. **`Tmux.ListSessions` / `Tmux.HasSession`** (`internal/runtime/tmux/tmux.go`
+   ~993-1018): these still return `nil,nil` / `false,nil` on `ErrNoServer` for
+   their (tmux-internal) callers. They are not on the reconciler liveness path
+   (that path is `list-panes` via `FetchState`), so they were left alone here;
+   surface `ErrRuntimeUnavailable` from them too for consistency once a consumer
+   needs it, auditing each internal caller to preserve today's absorb behavior.
+
+The plumbing to get a per-tick `runtimeQueryPartial` to the reconciler arms
+(optional provider interface via type-assert, like `LivenessObserver`, plus a
+`Liveness.RuntimePartial` field) is the shared prerequisite for 1-5; it is the
+load-bearing design step and should be reviewed on its own before the arms are
+converted.

--- a/engdocs/design/runtime-partial-discipline.md
+++ b/engdocs/design/runtime-partial-discipline.md
@@ -15,9 +15,9 @@ exist", so a brief blip drove the reconciler to drain/close healthy pool slots.
 
 ## Landed (this PR)
 
-- `runtime.ErrRuntimeUnavailable` sentinel + `runtime.IsRuntimeQueryPartial` in
-  `internal/runtime/runtime.go` — the runtime-side analogue of a partial store
-  read.
+- `runtime.ErrRuntimeUnavailable` sentinel in `internal/runtime/runtime.go` —
+  the runtime-side analogue of a partial store read. Callers dispatch on it with
+  `errors.Is`.
 - `internal/runtime/tmux/state_cache.go` `tmuxFetcher.FetchState`: an
   unreachable server (`ErrNoServer`) now returns `ErrRuntimeUnavailable`
   (wrapping the original cause) instead of an empty *success*. `refresh()`

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -48,6 +48,25 @@ var ErrSessionNotFound = errors.New("session not found")
 // exit 2). Carriers treat this as "fall back to the legacy driving op".
 var ErrExecUnsupported = errors.New("runtime does not implement the exec op")
 
+// ErrRuntimeUnavailable reports that a runtime-liveness query could not observe
+// the underlying runtime at all — the tmux server was unreachable, the process
+// table could not be scanned, etc. It is the runtime-side analog of a partial
+// bead-store read: an observation FAILURE, not the fact "no sessions exist". A
+// destructive reconciler arm (close-as-orphaned, heal-to-asleep, sweep) must
+// treat it as "I could not tell" and defer, exactly as it defers on a partial
+// store read (storeQueryPartial) — never as ground truth that every session is
+// gone. Providers wrap it (with errors.Is-visible provider-specific causes) so
+// callers can dispatch on it, and IsRuntimeQueryPartial centralizes the check.
+var ErrRuntimeUnavailable = errors.New("runtime unavailable: liveness observation failed")
+
+// IsRuntimeQueryPartial reports whether err indicates the runtime could not be
+// observed (ErrRuntimeUnavailable). It is the runtime-side mirror of the
+// store-partial predicate: a true result means a destructive arm keyed on an
+// empty/negative observation must defer rather than act on unverified absence.
+func IsRuntimeQueryPartial(err error) bool {
+	return err != nil && errors.Is(err, ErrRuntimeUnavailable)
+}
+
 // ErrRelaunchUnsupported reports that the underlying runtime cannot relaunch the
 // agent in a warm box (it is not a [RelaunchProvider], or is conjoined like
 // subprocess/acp/t3bridge). Composite/wrapping providers return it from their

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -56,16 +56,15 @@ var ErrExecUnsupported = errors.New("runtime does not implement the exec op")
 // treat it as "I could not tell" and defer, exactly as it defers on a partial
 // store read (storeQueryPartial) — never as ground truth that every session is
 // gone. Providers wrap it (with errors.Is-visible provider-specific causes) so
-// callers can dispatch on it, and IsRuntimeQueryPartial centralizes the check.
+// callers can dispatch on it with errors.Is.
+//
+// This is distinct from [PartialListError]. ErrRuntimeUnavailable is the
+// single-observation-total-failure signal: zero usable data, used to preserve
+// StateCache last-known-good. PartialListError is the multi-backend-merge
+// signal: partial-but-usable results from [MergeBackendListResults], which does
+// not even emit PartialListError for a total failure. The two are intentionally
+// separate signals for separate call paths.
 var ErrRuntimeUnavailable = errors.New("runtime unavailable: liveness observation failed")
-
-// IsRuntimeQueryPartial reports whether err indicates the runtime could not be
-// observed (ErrRuntimeUnavailable). It is the runtime-side mirror of the
-// store-partial predicate: a true result means a destructive arm keyed on an
-// empty/negative observation must defer rather than act on unverified absence.
-func IsRuntimeQueryPartial(err error) bool {
-	return err != nil && errors.Is(err, ErrRuntimeUnavailable)
-}
 
 // ErrRelaunchUnsupported reports that the underlying runtime cannot relaunch the
 // agent in a warm box (it is not a [RelaunchProvider], or is conjoined like

--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/runtime"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -231,7 +232,22 @@ func (f *tmuxFetcher) FetchState(ctx context.Context) (runtimeStateSnapshot, err
 	out, err := f.tm.runCtx(ctx, "list-panes", "-a", "-F", "#{session_name}\t#{pane_dead}\t#{pane_current_command}\t#{pane_pid}")
 	if err != nil {
 		if isNoServerError(err) {
-			return runtimeStateSnapshot{Sessions: map[string]sessionRuntimeState{}}, nil // No server = no sessions
+			// An unreachable tmux server is an observation FAILURE, not the
+			// fact "no sessions exist". Returning an empty *success* here let
+			// refresh() overwrite the cache's last-known-good and instantly
+			// report every session as not-running, so a brief server blip (a
+			// supervisor restart, a transient socket stall) drove the
+			// reconciler to drain/close healthy pool slots. Surface it as
+			// runtime.ErrRuntimeUnavailable instead: refresh() then preserves
+			// last-known-good until the existing staleTTL cliff, bounding the
+			// trust window. Genuine session ends evict from the cache via
+			// Stop()/EvictSession, so they are not masked by this preservation
+			// (the only residual is an externally-killed LAST session, whose
+			// cleanup is delayed by at most staleTTL — the intended trade).
+			// isNoServerError still matches the wrapped error (it contains the
+			// original "no server running" cause), so downstream absorbers are
+			// unaffected.
+			return runtimeStateSnapshot{}, fmt.Errorf("%w: %w", runtime.ErrRuntimeUnavailable, err)
 		}
 		return runtimeStateSnapshot{}, err
 	}

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -327,9 +327,6 @@ func TestTmuxFetcher_NoServerMapsToRuntimeUnavailable(t *testing.T) {
 	if !errors.Is(err, gcruntime.ErrRuntimeUnavailable) {
 		t.Fatalf("FetchState() err = %v, want errors.Is(runtime.ErrRuntimeUnavailable)", err)
 	}
-	if !gcruntime.IsRuntimeQueryPartial(err) {
-		t.Fatalf("IsRuntimeQueryPartial(%v) = false, want true", err)
-	}
 	if !isNoServerError(err) {
 		t.Fatalf("FetchState() err = %v must still satisfy isNoServerError so downstream ErrNoServer absorbers work", err)
 	}

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	gcruntime "github.com/gastownhall/gascity/internal/runtime"
 )
 
 // mockFetcher implements StateFetcher for testing.
@@ -306,6 +308,58 @@ func TestProviderObserveLivenessUsesCacheProcessSnapshot(t *testing.T) {
 	}
 	if calls := f.getCalls(); calls != 1 {
 		t.Fatalf("fetch calls = %d, want 1 across repeated ObserveLiveness calls", calls)
+	}
+}
+
+// FetchState must report an unreachable tmux server as an observation FAILURE
+// (runtime.ErrRuntimeUnavailable), not as an empty success. The empty-success
+// form let refresh() overwrite last-known-good and instantly report every
+// session not-running, draining healthy pool slots on a brief tmux blip. The
+// wrapped error must still satisfy isNoServerError so downstream absorbers keep
+// working.
+func TestTmuxFetcher_NoServerMapsToRuntimeUnavailable(t *testing.T) {
+	f := &tmuxFetcher{tm: &Tmux{cfg: DefaultConfig(), exec: &fakeExecutor{err: ErrNoServer}}}
+
+	snap, err := f.FetchState(context.Background())
+	if err == nil {
+		t.Fatalf("FetchState() err = nil (snapshot %+v), want an error for an unreachable server", snap)
+	}
+	if !errors.Is(err, gcruntime.ErrRuntimeUnavailable) {
+		t.Fatalf("FetchState() err = %v, want errors.Is(runtime.ErrRuntimeUnavailable)", err)
+	}
+	if !gcruntime.IsRuntimeQueryPartial(err) {
+		t.Fatalf("IsRuntimeQueryPartial(%v) = false, want true", err)
+	}
+	if !isNoServerError(err) {
+		t.Fatalf("FetchState() err = %v must still satisfy isNoServerError so downstream ErrNoServer absorbers work", err)
+	}
+}
+
+// End to end at the cache: after a good prime, an ErrNoServer refresh must
+// preserve last-known-good (within staleTTL) instead of collapsing to empty.
+func TestStateCache_NoServerRefreshPreservesLastKnownGood(t *testing.T) {
+	fe := &fakeExecutor{
+		// FetchState issues exactly one executor call (list-panes); the
+		// process-table half reads /proc directly, not through exec. First
+		// call primes one live pane, every later call reports no server.
+		outs: []string{"agent-1\t0\tclaude\t123"},
+		errs: []error{nil, ErrNoServer, ErrNoServer, ErrNoServer},
+	}
+	cache := NewStateCache(&tmuxFetcher{tm: &Tmux{cfg: DefaultConfig(), exec: fe}}, time.Nanosecond)
+
+	if !cache.IsRunning("agent-1") {
+		t.Fatal("expected agent-1 running after prime")
+	}
+	// TTL is a nanosecond, so the next read forces a refresh that hits
+	// ErrNoServer. Last-known-good must survive it (staleTTL default 30s).
+	if !cache.IsRunning("agent-1") {
+		t.Error("expected agent-1 still running after an ErrNoServer refresh (last-known-good); a brief tmux outage must not report sessions as gone")
+	}
+	cache.mu.RLock()
+	lastErr := cache.lastError
+	cache.mu.RUnlock()
+	if !errors.Is(lastErr, gcruntime.ErrRuntimeUnavailable) {
+		t.Fatalf("cache.lastError = %v, want errors.Is(runtime.ErrRuntimeUnavailable)", lastErr)
 	}
 }
 


### PR DESCRIPTION
## Why

An unreachable tmux server is an observation failure, not the fact "no sessions exist." Today `tmuxFetcher.FetchState` converts `ErrNoServer` into an empty success, so `StateCache.refresh()` overwrites its last-known-good and every session instantly reads not-running. A brief server blip (a supervisor restart, a transient socket stall) then drives the reconciler to drain and close healthy pool slots.

This is the source-level fix for that class, mirroring the existing `storeQueryPartial` discipline on the store side. It is one of three independent pieces split out of a polecat-reliability audit; the other two (a warm-worker wake and an idempotent-sling `--nudge` fix) are separate PRs.

## What changed

- `internal/runtime/tmux/state_cache.go`: `FetchState` returns `runtime.ErrRuntimeUnavailable` (wrapping the cause) on an unreachable server instead of an empty success, so `refresh()` preserves last-known-good until the existing `staleTTL` cliff. Genuine session ends still evict immediately via `Stop()`/`EvictSession`, so they are not masked. The wrapped error still satisfies `isNoServerError`, so the existing `ErrNoServer` absorbers are unaffected.
- `internal/runtime/runtime.go`: adds the `ErrRuntimeUnavailable` sentinel with a doc comment distinguishing it from the existing `PartialListError` (single-observation total failure vs. multi-backend partial-but-usable).
- `engdocs/design/runtime-partial-discipline.md`: records the design, and names the reconciler-facing `ListRunning` sites (`city_runtime.go` on_death, provider-swap, shutdown) that this fix does not yet cover, with the follow-up path: emit the existing `PartialListError` from `ListRunning`/`ListSessions` on `ErrNoServer` to activate the four `IsPartialListError` guards those sites already have.

## Bounded behavior change

An externally-killed last session is now reported running from last-known-good for up to `staleTTL` (~30s) before the cliff clears it. This is the intended trade: a bounded cleanup delay instead of draining every slot on a blip.

## Test plan

- `go build ./...`, `go vet ./internal/runtime/...`: clean
- `go test ./internal/runtime/... ./internal/runtime/tmux/`: pass, including new `TestTmuxFetcher_NoServerMapsToRuntimeUnavailable` and `TestStateCache_NoServerRefreshPreservesLastKnownGood`
