### PR TITLE
fix(reconciler): wake warm tmux pool workers when routed work arrives (#1129)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2347,15 +2347,21 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.nudge_dispatch_tick", phaseStart, nil)
 
 	// Idle recovery: re-nudge pool slots that are running but never claimed
-	// their assigned trigger bead. Gated to runtimes the controller cannot see
-	// activity for (herdr): tmux self-heals a missed startup nudge through its
-	// relaunch/respawn path and reports activity, so it neither needs nor runs
-	// this. See nudgeStalledPoolClaims for the churn-free state machine.
-	if !cr.sp.Capabilities().CanReportActivity {
-		phaseStart = time.Now()
-		nudgeStalledPoolClaims(cr.sp, cr.cfg, sessStore, open, assignedWorkBeads, time.Now(), cr.stdout)
-		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.nudge_stalled_pool_claims", phaseStart, nil)
-	}
+	// their assigned trigger bead. Runs for every runtime, not just herdr.
+	// tmux's relaunch/respawn path only heals a session that DIED; it does
+	// nothing for a session that is alive but idle at its prompt on a trigger
+	// bead it never began (a warm slot resumed onto work whose submit-CR was
+	// swallowed, or that survived a `gc restart` and was never re-Started).
+	// Activity reporting lets the controller SEE such a slot as alive but never
+	// delivers the claim nudge, so tmux has no demand-driven wake for it. The
+	// backstop is churn-free by construction for either runtime: it keys on the
+	// trigger bead still being open (the instant a polecat claims, the bead
+	// flips to in_progress and stops matching), persists its bounded
+	// observe→nudge→backoff state on the session bead, and never spams a tick.
+	// See nudgeStalledPoolClaims for the full invariant.
+	phaseStart = time.Now()
+	nudgeStalledPoolClaims(cr.sp, cr.cfg, sessStore, open, assignedWorkBeads, time.Now(), cr.stdout)
+	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.nudge_stalled_pool_claims", phaseStart, nil)
 }
 
 // recordReconcileTraceInputs records the per-template baseline, the cycle input

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
@@ -3033,6 +3034,84 @@ func TestCityRuntimeBeadReconcileTick_TransientStoreQueryPartialKeepsRunningPool
 	}
 	if !sp.IsRunning("worker-bd-123") {
 		t.Fatal("recovered tick should keep the worker running")
+	}
+}
+
+// The idle-claim backstop must run even for a runtime that CAN report activity
+// (tmux/fake). Activity reporting makes the controller SEE a warm slot as alive
+// but never delivers its claim nudge, so an idle slot handed a trigger bead it
+// never began needs this demand-driven wake exactly as herdr does. Before the
+// call-site un-gate this was skipped whenever CanReportActivity was true,
+// leaving tmux warm slots with no wake path. The marker is pre-seeded past the
+// grace window so a single tick nudges (attempt count 0 -> 1).
+func TestCityRuntimeBeadReconcileTick_IdleClaimNudgeRunsForReportActivityRuntime(t *testing.T) {
+	sp := runtime.NewFake()
+	if !sp.Capabilities().CanReportActivity {
+		t.Fatal("precondition: fake runtime must report activity for this un-gate test to be meaningful")
+	}
+	if err := sp.Start(context.Background(), "worker-bd-idle", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	staleObs := time.Now().Add(-2 * idleClaimNudgeGrace).UTC().Format(time.RFC3339)
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":                    "worker-bd-idle",
+			"template":                        "worker",
+			"agent_name":                      "worker",
+			"pool_slot":                       "1",
+			poolManagedMetadataKey:            boolMetadata(true),
+			"state":                           "awake",
+			"generation":                      "1",
+			beadmeta.TriggerBeadIDMetadataKey: "w-idle",
+			// Pre-seed the backstop marker so we are already past the observe
+			// grace on attempt 0: a single tick should nudge.
+			idleClaimNudgeTriggerKey: "w-idle",
+			idleClaimNudgeCountKey:   "0",
+			idleClaimNudgeAtKey:      staleObs,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "maintainer-city",
+		cfg:                 &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5), Nudge: "Run gc hook --claim --json now."}}},
+		sp:                  sp,
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.Discard,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+
+	result := DesiredStateResult{
+		State:            map[string]TemplateParams{},
+		ScaleCheckCounts: map[string]int{"worker": 0},
+		AssignedWorkBeads: []beads.Bead{
+			// Open + unassigned == unclaimed: the slot's trigger bead the polecat
+			// never began. workBead sets gc.routed_to but leaves the assignee empty.
+			workBead("w-idle", "worker", "", "open", 5),
+		},
+	}
+	cr.beadReconcileTick(context.Background(), result, cr.loadSessionBeadSnapshot(), nil, false)
+
+	got, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get after tick: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("tick unexpectedly closed the idle pool session: %+v", got)
+	}
+	if c := got.Metadata[idleClaimNudgeCountKey]; c != "1" {
+		t.Fatalf("idle-claim nudge did not fire for a report-activity runtime: attempt count = %q, want 1", c)
 	}
 }
 

--- a/cmd/gc/idle_nudge.go
+++ b/cmd/gc/idle_nudge.go
@@ -32,15 +32,23 @@ const (
 	idleClaimNudgeMaxAttempts = 3                // then give up and log (manual re-nudge remains)
 )
 
-// nudgeStalledPoolClaims is a reconcile-tick backstop for runtimes the
-// controller is blind to (herdr). It re-delivers the claim nudge to a pool slot
-// that is running but whose assigned trigger bead is still UNCLAIMED (open, not
-// in_progress). Under herdr the startup nudge can be missed — a freshly-spawned
-// slot whose submit-CR was swallowed, or a warm slot that survived a `gc
-// restart` and was never re-Started — leaving the polecat idle at its prompt
-// with work it never began. tmux self-heals that through its relaunch/respawn
-// path (and reports activity), so it is gated out at the call site and never
-// runs here.
+// nudgeStalledPoolClaims is a reconcile-tick backstop that runs for every
+// runtime (herdr AND tmux). It re-delivers the claim nudge to a pool slot that
+// is running but whose assigned trigger bead is still UNCLAIMED (open, not
+// in_progress). The startup nudge can be missed — a freshly-spawned slot whose
+// submit-CR was swallowed, or a warm slot that survived a `gc restart` and was
+// never re-Started — leaving the polecat idle at its prompt with work it never
+// began. tmux's relaunch/respawn path only heals a session that DIED; a live
+// idle slot needs this demand-driven wake exactly as herdr does (activity
+// reporting makes the controller SEE the slot but never nudges it to claim).
+//
+// SCOPE (trigger-bead-key limitation): this keys on the slot's own
+// gc.trigger_bead_id, so it only rescues a slot the reconciler already bound to
+// a specific bead (resume / wake-known-identity tiers). A bead slung to the
+// pool AFTER the slot went idle and left UNASSIGNED (routed_to=pool, open, no
+// assignee) never stamps trigger_bead_id, so it is invisible here. Widening the
+// key to "any open+routed+unclaimed pool bead past the grace window" is the
+// documented follow-up (see engdocs/design/idle-claim-nudge-followups.md).
 //
 // Churn-free by construction — it inverts every failure mode that got the #312
 // idle-session nudger reverted:

--- a/engdocs/design/idle-claim-nudge-followups.md
+++ b/engdocs/design/idle-claim-nudge-followups.md
@@ -1,0 +1,45 @@
+# Idle-claim nudge — follow-ups
+
+The reconcile-tick backstop `nudgeStalledPoolClaims` (cmd/gc/idle_nudge.go)
+re-delivers a claim nudge to a pool slot that is running but whose assigned
+trigger bead is still unclaimed. It now runs for every runtime (herdr and
+tmux); the call-site capability gate was removed because tmux's relaunch/respawn
+path only heals a session that died, never a live-but-idle slot, and activity
+reporting lets the controller see such a slot without ever waking it to claim.
+
+## Open follow-up: widen the trigger key to unassigned pool-routed beads
+
+The backstop keys on the slot's own `gc.trigger_bead_id`. That value is stamped
+only when the desired-state builder binds a specific bead to the slot — the
+`resume` and `wake-known-identity` tiers, both of which act on work that already
+carries an assignee (`cmd/gc/pool_desired_state.go`). A bead slung to the pool
+**after** the slot went idle and left **unassigned** (`gc.routed_to = <pool>`,
+status `open`, no assignee) never stamps `trigger_bead_id`, so it is invisible
+to the backstop: `triggerID == ""` short-circuits the loop.
+
+Result: the un-gate closes the bound-slot case (the reconciler handed this slot
+a specific bead, but its submit-CR was swallowed or it survived a `gc restart`
+without a re-Start). The scale-from-zero-style case — an unclaimed pool bead
+waiting for any warm slot to notice it — is still not woken on tmux.
+
+### Sketch of the fix
+
+For each running pool slot with an empty `trigger_bead_id`, look for a bead
+where `gc.routed_to` resolves to the slot's template, status is `open`, and the
+assignee is empty; past the observe grace, nudge the slot to run its claim hook.
+
+Constraints to preserve the churn-free property:
+
+- Keep the persisted `observe → nudge → backoff → give-up` marker, but key it on
+  the candidate bead id (or the slot when no single candidate dominates) so a
+  restart cannot replay it.
+- The unclaimed pool bead may not be present in the reconciler's
+  `AssignedWorkBeads` snapshot (that slice is assignment-oriented). The widened
+  path needs a source of open+routed+unassigned pool beads; confirm which
+  snapshot already carries them before adding a new read to the hot path.
+- Multiple idle slots seeing one unclaimed bead will each nudge. That is bounded
+  by the grace/backoff/attempt caps and self-limits the instant the first slot
+  claims (the bead flips to `in_progress`), but measure it before shipping.
+
+This is deliberately left for its own PR: it changes what the backstop reads,
+not just when it runs, and the churn analysis is the load-bearing part.

--- a/engdocs/design/index.md
+++ b/engdocs/design/index.md
@@ -24,6 +24,7 @@ lives in the [Architecture](../architecture/index.md) section.
 | `beads-dolt-contract-redesign` | Accepted | Canonical bd+Dolt contract, topology commands, migration, and provider-boundary redesign |
 | `idle-session-sleep` | Accepted | Idle-sleep policy, precedence, and wake mechanics |
 | `runtime-partial-discipline` | Accepted (source-level), follow-ups Proposed | Treat a failed tmux-liveness observation as partial (defer destructive arms) instead of "nothing running"; mirrors storeQueryPartial |
+| `idle-claim-nudge-followups` | Proposed | Widen the stalled-pool-claim backstop key to unassigned pool-routed beads (the case the tmux warm-slot un-gate does not cover) |
 | `idle-controller-call-rate` | Proposed | Layer-3 (#2463/#3543) cut of the controller's idle bd/Dolt call *rate*: demand-gated ticking, per-pass snapshot, quiescent-scope skipping |
 | `session-store-fences` | Accepted | Cross-process write fences for session-owned metadata: store facts, flock and token-reread fences, residual convergence-through-persistence |
 | `named-configured-sessions` | Accepted | Explicit canonical named sessions backed by reusable templates; partially superseded by `session-model-unification` |


### PR DESCRIPTION
## Why

A warm idle pool worker on tmux has no wake path when work is routed to it. The reconciler binds the routed bead as the slot's trigger, but the session is already running with an unchanged config fingerprint, so no Start fires and no startup nudge is delivered. The one backstop that would catch this, `nudgeStalledPoolClaims`, is gated off for tmux on the premise that tmux self-heals a missed nudge through its relaunch path. That premise only holds when a session actually restarts; a healthy idle session never does, so the routed bead sits open and unclaimed. This is the structural form of #1129.

Split out of a polecat-reliability audit; the runtime-partial fix and the idempotent-sling `--nudge` fix are separate PRs.

## What changed

- `cmd/gc/city_runtime.go`: removes the `CanReportActivity` gate on the `nudgeStalledPoolClaims` call so the backstop runs for tmux warm slots. The function keys on the trigger bead still being open and unclaimed and persists bounded observe-then-nudge-then-backoff state on the session bead, so a claim (which flips the bead to in_progress) stops the match; it is churn-free on any runtime.
- `cmd/gc/idle_nudge.go`: comment update reflecting the un-gate.
- `engdocs/design/idle-claim-nudge-followups.md`: documents the residual gap this does not close (a bead slung to the pool after the slot went idle, and left unassigned, never stamps the slot's `trigger_bead_id`, so it stays invisible), scoped as its own follow-up.

## Coordination note

Touches `cmd/gc/city_runtime.go`, also touched by open PRs #3767 and #3772. The changes are in different regions and merge cleanly (verified via a 3-way merge-tree against both); no manual conflict resolution is needed regardless of merge order.

## Test plan

- `go build ./...`: clean
- `go test ./cmd/gc/ -run IdleClaimNudge`: pass, including new `TestCityRuntimeBeadReconcileTick_IdleClaimNudgeRunsForReportActivityRuntime`, which drives a reconcile tick with a report-activity runtime and asserts the nudge fires (attempt count 0 to 1) where the old gate left it at 0
