### PR TITLE
fix(sling): honor --nudge on idempotent re-slings

### DIFF
--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -126,6 +126,17 @@ func preflight(opts SlingOpts, deps SlingDeps, querier BeadQuerier) (SlingResult
 			result.DryRun = opts.DryRun
 			result.BeadID = opts.BeadOrFormula
 			result.Method = "bead"
+			// Honor --nudge even when the route is already in place. The bead is
+			// routed to the target, but a warm pool slot may have missed its
+			// wake (its startup nudge was swallowed, or work was routed after it
+			// went idle). Re-slinging with --nudge must still deliver a wake;
+			// otherwise the idempotent short-circuit silently drops it and the
+			// slot sits idle on work it never began. The claim path is
+			// idempotent/CAS-safe, so a redundant nudge is harmless. Suppressed
+			// for dry-run, which must not mutate or signal anything.
+			if opts.Nudge && !opts.DryRun {
+				result.NudgeAgent = &a
+			}
 			return result, nil
 		}
 		result.BeadWarnings = append(result.BeadWarnings, check.Warnings...)

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	beadsexec "github.com/gastownhall/gascity/internal/beads/exec"
 	"github.com/gastownhall/gascity/internal/config"
@@ -3112,6 +3113,76 @@ func TestDoSlingNudgeSignal(t *testing.T) {
 	}
 	if result.NudgeAgent == nil {
 		t.Error("expected NudgeAgent to be set")
+	}
+}
+
+func TestDoSlingIdempotentHonorsNudge(t *testing.T) {
+	// A warm pool slot may miss its wake, so re-slinging an already-routed bead
+	// with --nudge must still surface a nudge signal even though the route is
+	// idempotent (nothing to re-route). Without this the wake is silently lost.
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	// Seed a bead already routed to the target so the pre-flight check reports
+	// idempotent. NoConvoy avoids the convoy-recovery branch, which would fall
+	// through to a full (non-idempotent) finalize.
+	routed := beads.Bead{
+		ID:     "BL-1",
+		Title:  "BL-1",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: a.QualifiedName(),
+		},
+	}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{routed}, nil)
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+
+	result, err := DoSling(SlingOpts{
+		Target: a, BeadOrFormula: "BL-1", Nudge: true, NoConvoy: true,
+	}, deps, store)
+	if err != nil {
+		t.Fatalf("DoSling: %v", err)
+	}
+	if !result.Idempotent {
+		t.Fatalf("expected idempotent route, got %+v", result)
+	}
+	if result.NudgeAgent == nil {
+		t.Error("expected NudgeAgent to be set on an idempotent sling with Nudge")
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("idempotent sling must not re-route, got %d runner calls", len(runner.calls))
+	}
+}
+
+func TestDoSlingIdempotentDryRunSuppressesNudge(t *testing.T) {
+	// Dry-run must never signal a nudge even with --nudge on an idempotent route.
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	routed := beads.Bead{
+		ID:     "BL-1",
+		Title:  "BL-1",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: a.QualifiedName(),
+		},
+	}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{routed}, nil)
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+
+	result, err := DoSling(SlingOpts{
+		Target: a, BeadOrFormula: "BL-1", Nudge: true, NoConvoy: true, DryRun: true,
+	}, deps, store)
+	if err != nil {
+		t.Fatalf("DoSling: %v", err)
+	}
+	if result.NudgeAgent != nil {
+		t.Error("dry-run idempotent sling must not set NudgeAgent")
 	}
 }
 


### PR DESCRIPTION
## Why

Re-slinging a bead with `--nudge` silently drops the nudge. When a bead is already routed to the target, `preflight` short-circuits as idempotent and returns before `result.NudgeAgent` is ever set, and the CLI only delivers a nudge when that field is set. So the natural operator repair for a warm worker that missed its wake ("sling it again, with `--nudge`") is a no-op, and the bead stays unclaimed. This composes with the warm-worker wake gap into the "bead sits unclaimed forever" symptom.

Split out of a polecat-reliability audit; the runtime-partial fix and the warm-worker wake are separate PRs.

## What changed

- `internal/sling/sling_core.go`: on an idempotent sling result, when `opts.Nudge` is set and it is not a dry run, still set the nudge signal so the CLI delivers the wake. The claim path is CAS-safe, so a redundant nudge is harmless; this makes "re-sling with `--nudge`" a reliable repair verb.

## Coordination note

Touches `internal/sling/sling_core.go`, also touched by open PR #3768. The changes are in different regions and merge cleanly (verified via 3-way merge-tree); no manual conflict resolution is needed regardless of merge order.

## Test plan

- `go build ./...`: clean
- `go test ./internal/sling/`: pass, including new `TestDoSlingIdempotentHonorsNudge` and `TestDoSlingIdempotentDryRunSuppressesNudge`
