### PR TITLE
fix(tmux): prime empty snapshot on unprimed no-server; address post-merge review

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2355,7 +2355,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// Activity reporting lets the controller SEE such a slot as alive but never
 	// delivers the claim nudge, so tmux has no demand-driven wake for it. The
 	// backstop is churn-free by construction for either runtime: it keys on the
-	// trigger bead still being open (the instant a polecat claims, the bead
+	// trigger bead still being open (the instant a pool slot claims, the bead
 	// flips to in_progress and stops matching), persists its bounded
 	// observe→nudge→backoff state on the session bead, and never spams a tick.
 	// See nudgeStalledPoolClaims for the full invariant.

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -3096,8 +3096,8 @@ func TestCityRuntimeBeadReconcileTick_IdleClaimNudgeRunsForReportActivityRuntime
 		State:            map[string]TemplateParams{},
 		ScaleCheckCounts: map[string]int{"worker": 0},
 		AssignedWorkBeads: []beads.Bead{
-			// Open + unassigned == unclaimed: the slot's trigger bead the polecat
-			// never began. workBead sets gc.routed_to but leaves the assignee empty.
+			// Open + unassigned == unclaimed: the slot's trigger bead the warm pool
+			// worker never began. workBead sets gc.routed_to but leaves the assignee empty.
 			workBead("w-idle", "worker", "", "open", 5),
 		},
 	}

--- a/cmd/gc/idle_nudge.go
+++ b/cmd/gc/idle_nudge.go
@@ -37,7 +37,7 @@ const (
 // is running but whose assigned trigger bead is still UNCLAIMED (open, not
 // in_progress). The startup nudge can be missed — a freshly-spawned slot whose
 // submit-CR was swallowed, or a warm slot that survived a `gc restart` and was
-// never re-Started — leaving the polecat idle at its prompt with work it never
+// never re-Started — leaving the worker session idle at its prompt with work it never
 // began. tmux's relaunch/respawn path only heals a session that DIED; a live
 // idle slot needs this demand-driven wake exactly as herdr does (activity
 // reporting makes the controller SEE the slot but never nudges it to claim).
@@ -53,7 +53,7 @@ const (
 // Churn-free by construction — it inverts every failure mode that got the #312
 // idle-session nudger reverted:
 //   - Keys on bead state (trigger bead == open), never "idle for N minutes", so
-//     it is structurally invisible to a working agent: the instant a polecat
+//     it is structurally invisible to a working agent: the instant a pool slot
 //     claims, its trigger bead flips to in_progress and stops matching.
 //   - State is persisted on the session bead, so a restart cannot replay it.
 //   - Bounded per assignment: observe (grace) → nudge → backoff retries → give
@@ -149,7 +149,7 @@ func isUnclaimedTrigger(w beads.Bead, sessName string) bool {
 	return true
 }
 
-// claimNudgeFor resolves the slot's configured startup nudge (the polecat's
+// claimNudgeFor resolves the slot's configured startup nudge (the worker's
 // `gc hook --claim` line) from the agent template behind this session bead.
 func claimNudgeFor(cfg *config.City, session beads.Bead) string {
 	template := normalizedSessionTemplate(session, cfg)

--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -192,8 +192,29 @@ func (c *StateCache) refresh() {
 			log.Printf("tmux state cache: refresh failed in %v: %v", elapsed, err)
 			c.mu.Lock()
 			c.lastError = err
+			// Two distinct failure regimes, keyed on whether the cache was ever
+			// primed (fetchedAt set by a prior success):
+			//
+			//   UNPRIMED + genuine no-server (a fresh city with no tmux server
+			//   yet): initialize to an EMPTY snapshot so the cache is primed.
+			//   Without this, currentState() sees a nil Sessions map and forces
+			//   a fresh list-panes spawn plus a failure log on EVERY IsRunning()
+			//   call — a re-spawn/log storm in the exact steady state (no server)
+			//   where nothing will change until one is started. An empty primed
+			//   snapshot correctly reports all sessions not-running and holds as
+			//   a cache hit until the TTL lapses.
+			//
+			//   PRIMED then now-unreachable: preserve last-known-good (do NOT
+			//   touch fetchedAt or sessions) until the staleTTL cliff. A server
+			//   that was up then briefly vanished (supervisor restart, socket
+			//   stall) must not wipe a good snapshot and drain healthy pool slots
+			//   — that is #4082's intent.
+			if c.fetchedAt.IsZero() && isNoServerError(err) {
+				c.state = runtimeStateSnapshot{Sessions: make(map[string]sessionRuntimeState)}
+				c.fetchedAt = time.Now()
+				c.dirty = false
+			}
 			c.mu.Unlock()
-			// Preserve last-known-good — do NOT update fetchedAt or sessions.
 			return nil, err
 		}
 

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -342,13 +342,17 @@ func TestStateCache_NoServerRefreshPreservesLastKnownGood(t *testing.T) {
 		outs: []string{"agent-1\t0\tclaude\t123"},
 		errs: []error{nil, ErrNoServer, ErrNoServer, ErrNoServer},
 	}
-	cache := NewStateCache(&tmuxFetcher{tm: &Tmux{cfg: DefaultConfig(), exec: fe}}, time.Nanosecond)
+	// TTL 0 forces every read to refresh unconditionally (time.Since(fetchedAt)
+	// is never < 0). A nanosecond TTL is non-deterministic here: on a coarse
+	// monotonic clock time.Since can read 0 on the very next call, so the second
+	// IsRunning may skip the refresh and leave lastError nil (flaky).
+	cache := NewStateCache(&tmuxFetcher{tm: &Tmux{cfg: DefaultConfig(), exec: fe}}, 0)
 
 	if !cache.IsRunning("agent-1") {
 		t.Fatal("expected agent-1 running after prime")
 	}
-	// TTL is a nanosecond, so the next read forces a refresh that hits
-	// ErrNoServer. Last-known-good must survive it (staleTTL default 30s).
+	// TTL 0, so the next read forces a refresh that hits ErrNoServer.
+	// Last-known-good must survive it (staleTTL default 30s).
 	if !cache.IsRunning("agent-1") {
 		t.Error("expected agent-1 still running after an ErrNoServer refresh (last-known-good); a brief tmux outage must not report sessions as gone")
 	}
@@ -357,6 +361,44 @@ func TestStateCache_NoServerRefreshPreservesLastKnownGood(t *testing.T) {
 	cache.mu.RUnlock()
 	if !errors.Is(lastErr, gcruntime.ErrRuntimeUnavailable) {
 		t.Fatalf("cache.lastError = %v, want errors.Is(runtime.ErrRuntimeUnavailable)", lastErr)
+	}
+}
+
+// An UNPRIMED cache (never held a good state, fetchedAt zero) that hits a
+// genuine "no server" must prime itself to an empty snapshot rather than
+// re-spawning list-panes and re-logging the failure on every IsRunning. A
+// fresh city with no tmux server yet would otherwise storm the (absent) server
+// with one list-panes per liveness probe.
+func TestStateCache_UnprimedNoServerPrimesEmptyWithoutRefetch(t *testing.T) {
+	fe := &fakeExecutor{
+		// Every list-panes reports no server; the cache is never primed good.
+		errs: []error{ErrNoServer, ErrNoServer, ErrNoServer, ErrNoServer},
+	}
+	// A real TTL (not 0) so a successfully primed empty snapshot is a cache hit
+	// on the next read — proving priming stops the refetch storm.
+	cache := NewStateCache(&tmuxFetcher{tm: &Tmux{cfg: DefaultConfig(), exec: fe}}, time.Second)
+
+	if cache.IsRunning("agent-1") {
+		t.Fatal("expected agent-1 not running against a server-less city")
+	}
+	// The first read primed an empty snapshot with a single list-panes spawn.
+	// Every subsequent read within the TTL must be a cache hit — no refetch.
+	_ = cache.IsRunning("agent-1")
+	_ = cache.IsRunning("agent-2")
+	if calls := len(fe.calls); calls != 1 {
+		t.Fatalf("list-panes calls = %d, want 1: an unprimed no-server must prime empty once, not refetch on every IsRunning", calls)
+	}
+
+	// The cache is primed: fetchedAt set, and the failure recorded in lastError.
+	cache.mu.RLock()
+	fetchedAt := cache.fetchedAt
+	lastErr := cache.lastError
+	cache.mu.RUnlock()
+	if fetchedAt.IsZero() {
+		t.Error("expected fetchedAt to be set (cache primed) after an unprimed no-server refresh")
+	}
+	if !errors.Is(lastErr, gcruntime.ErrRuntimeUnavailable) {
+		t.Errorf("cache.lastError = %v, want errors.Is(runtime.ErrRuntimeUnavailable)", lastErr)
 	}
 }
 


### PR DESCRIPTION
## Why

Post-merge review follow-up addressing valid Copilot comments on #4082 and #4083.

## What changed

- **Prime an empty snapshot on an unprimed no-server state** (`internal/runtime/tmux/state_cache.go`). #4082 made `FetchState` return `ErrRuntimeUnavailable` on `ErrNoServer` so `refresh()` preserves last-known-good. That is correct once the cache has been primed, but on an unprimed cache (a fresh city with no tmux server yet) the failure path never sets `fetchedAt`, so `currentState()` re-enters `refresh()` and re-spawns `list-panes` plus re-logs on every `IsRunning()` call. The fix splits the failure path on `fetchedAt.IsZero()`: an unprimed genuine no-server initializes an empty non-nil snapshot (primes the cache, reports all sessions not-running, holds until the TTL), while a primed-then-unreachable cache still preserves last-known-good to the `staleTTL` cliff. The zero-check is the discriminator, so a mid-life blip can never take the prime-empty branch.
- **Deterministic cache-TTL test** (`state_cache_test.go`). A test used `time.Nanosecond` as the TTL to force a refresh, but `time.Since(fetchedAt)` can read `0` on the next call, so `0 < 1ns` was a cache hit and the second read skipped the refresh (flaky). Changed to TTL `0`, which makes `time.Since < 0` always false and forces the refresh unconditionally.
- **Neutral role terms in reconciler comments** (`cmd/gc/idle_nudge.go`, `city_runtime.go`, `city_runtime_test.go`). The zero-hardcoded-roles invariant (AGENTS.md) applies to Go source; three comments naming a specific role are reworded to "worker session" / "pool slot" / "warm pool worker". Comment-only, no behavior change.

## Test plan

- `go build ./...`, `go vet ./internal/runtime/... ./cmd/gc/...`: clean
- `go test ./internal/runtime/tmux/ ./cmd/gc/ -run 'StateCache|NoServer|StaleTTL|IdleClaimNudge'`: pass, including a new `TestStateCache_UnprimedNoServerPrimesEmptyWithoutRefetch` asserting exactly one `list-panes` call across three `IsRunning()` reads on an unprimed no-server cache
- New + fixed tests at `-count=100 -race`: clean
