### PR TITLE
feat(runtime): emit PartialListError from tmux ListRunning to activate reconciler guards

### DIFF
--- a/engdocs/design/runtime-partial-discipline.md
+++ b/engdocs/design/runtime-partial-discipline.md
@@ -29,26 +29,37 @@ exist", so a brief blip drove the reconciler to drain/close healthy pool slots.
   `staleTTL` (30s default). The wrapped error still satisfies `isNoServerError`,
   so the ~20 existing `ErrNoServer` absorbers are unaffected.
 
-### Still exposed: the `ListRunning` sites
+### Landed (arm 6): the `ListRunning` sites
 
-The `FetchState` fix shields the `StateCache.IsRunning` liveness path, but NOT
-`Provider.ListRunning` (via `Tmux.ListSessions`), which still returns
-`(nil, nil)` on `ErrNoServer` — an empty *success*, not a partial signal. Three
-reconciler-facing sites call `ListRunning` destructively on that empty result:
+`Provider.ListRunning` (`internal/runtime/tmux/adapter.go`) now reports a totally
+unreachable tmux server (`ErrNoServer`) as a `runtime.PartialListError` with a
+nil names slice, instead of the old empty *success* (`(nil, nil)`). This
+activates the `IsPartialListError` guards that already exist at every
+reconciler-facing site, with no new plumbing:
 
-- `cmd/gc/city_runtime.go:960` — pool `on_death` hooks. On a full tmux outage
-  every pool slot vanishes from the empty listing at once, so the tick fires the
-  user's `on_death` command for EVERY pool slot: a false death storm.
-- `cmd/gc/city_runtime.go:1899` — provider swap on config reload.
+- `cmd/gc/city_runtime.go:960` — pool `on_death` hooks. Previously a full tmux
+  outage made every pool slot vanish from the empty listing at once, firing the
+  user's `on_death` command for EVERY slot (a false death storm). The guard now
+  skips the whole death check on a partial listing.
+- `cmd/gc/city_runtime.go:1899` — provider swap on config reload: keeps the old
+  config rather than stopping every "vanished" agent.
 - `cmd/gc/city_runtime.go:3466` / `:3478` — shutdown (and the force-shutdown
-  late-async-start re-list) session listing.
+  late-async-start re-list): stops only the sessions it can still see (none,
+  under a total outage) rather than treating the blip as "all gone".
+- Plus the pre-existing guards at `cmd/gc/adoption_barrier.go`,
+  `cmd/gc/cmd_stop.go` (stopOrphans / doStop), `cmd/gc/controller.go`
+  (runningSessionSet falls back to per-session last-known-good),
+  `cmd/gc/session_beads.go` (dead-cleanup / closed-bead reap), and
+  `internal/doctor/checks.go` (orphan check + `--fix`).
 
-All four `IsPartialListError` guards at those call sites already exist (verified
-in-tree), but none fires today because `ListRunning` returns a nil error on
-`ErrNoServer`. The clean completion path is doc-only from here: emit the
-EXISTING `PartialListError` from `Provider.ListRunning` / `Tmux.ListSessions` on
-`ErrNoServer` (arm 6 below), which activates all four guards with no new
-plumbing — the `on_death` storm is arm 4.
+Implemented at the narrowest reconciler-facing layer: `Tmux.ListSessions` still
+absorbs `ErrNoServer` into an empty result for its tmux-internal callers
+(`FindSessionByWorkDir`, `CleanupOrphanedSessions`), which treat "server down"
+and "no sessions" identically; a private `Tmux.listSessionNames` variant
+propagates the cause so only `Provider.ListRunning` upgrades it to a partial
+signal. Composite providers (`auto`, `hybrid`) already fold a backend's
+`PartialListError` through `MergeBackendListResults`, so the signal propagates
+unchanged.
 
 ### Bounded behavior change (maintainer, please confirm)
 
@@ -86,12 +97,15 @@ partial runtime observation:
    `if err != nil { running = false }`): a failed reachability probe currently
    falls open to "not running"; it should treat `ErrRuntimeUnavailable` as
    partial and defer.
-6. **`Tmux.ListSessions` / `Tmux.HasSession`** (`internal/runtime/tmux/tmux.go`
-   ~993-1018): these still return `nil,nil` / `false,nil` on `ErrNoServer` for
-   their (tmux-internal) callers. They are not on the reconciler liveness path
-   (that path is `list-panes` via `FetchState`), so they were left alone here;
-   surface `ErrRuntimeUnavailable` from them too for consistency once a consumer
-   needs it, auditing each internal caller to preserve today's absorb behavior.
+6. **`Tmux.HasSession`** (`internal/runtime/tmux/tmux.go`): still returns
+   `false,nil` on `ErrNoServer` for its (tmux-internal) callers. It is not on the
+   reconciler liveness path (that path is `list-panes` via `FetchState`), so it
+   was left alone; surface `ErrRuntimeUnavailable` from it too for consistency
+   once a consumer needs it, auditing each internal caller to preserve today's
+   absorb behavior. (`Tmux.ListSessions` was the other half of this arm and is
+   now handled: `Provider.ListRunning` emits `PartialListError` on `ErrNoServer`
+   while `ListSessions` keeps absorbing it for its internal callers — see
+   "Landed (arm 6)" above.)
 
 The plumbing to get a per-tick `runtimeQueryPartial` to the reconciler arms
 (optional provider interface via type-assert, like `LivenessObserver`, plus a

--- a/engdocs/design/runtime-partial-discipline.md
+++ b/engdocs/design/runtime-partial-discipline.md
@@ -37,15 +37,23 @@ nil names slice, instead of the old empty *success* (`(nil, nil)`). This
 activates the `IsPartialListError` guards that already exist at every
 reconciler-facing site, with no new plumbing:
 
+Two sites had a genuine destructive-behavior change:
+
 - `cmd/gc/city_runtime.go:960` — pool `on_death` hooks. Previously a full tmux
   outage made every pool slot vanish from the empty listing at once, firing the
   user's `on_death` command for EVERY slot (a false death storm). The guard now
   skips the whole death check on a partial listing.
-- `cmd/gc/city_runtime.go:1899` — provider swap on config reload: keeps the old
-  config rather than stopping every "vanished" agent.
+- `cmd/gc/city_runtime.go:1899` — provider swap on config reload. Previously the
+  absorbed `(nil, nil)` let the swap proceed with zero visible sessions, silently
+  orphaning any still-alive session from tracking; the guard now keeps the old
+  config instead.
+
+The remaining site is diagnostics-only, not a safety change:
+
 - `cmd/gc/city_runtime.go:3466` / `:3478` — shutdown (and the force-shutdown
-  late-async-start re-list): stops only the sessions it can still see (none,
-  under a total outage) rather than treating the blip as "all gone".
+  late-async-start re-list). Its stop set was already empty under the old
+  absorbed-error path, so its stop behavior is unchanged; only the stderr
+  message changes (from silent to an explicit "partial listing" diagnostic).
 - Plus the pre-existing guards at `cmd/gc/adoption_barrier.go`,
   `cmd/gc/cmd_stop.go` (stopOrphans / doStop), `cmd/gc/controller.go`
   (runningSessionSet falls back to per-session last-known-good),

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -592,9 +592,22 @@ func (p *Provider) Peek(name string, lines int) (string, error) {
 }
 
 // ListRunning returns all tmux session names matching the given prefix.
+//
+// A totally unreachable tmux server (ErrNoServer) is reported as a
+// [runtime.PartialListError] with a nil names slice rather than an empty
+// success: a single-tmux outage is a failed observation, not proof that zero
+// sessions exist. This activates the reconciler-facing IsPartialListError
+// guards (pool on_death, provider swap, shutdown listing, orphan cleanup) so a
+// brief server blip defers destructive action instead of tearing down healthy
+// sessions. It mirrors the multi-backend degraded-but-usable signal that
+// [runtime.MergeBackendListResults] produces for composite providers, and is
+// the ListRunning-side analog of the StateCache liveness fix in #4082.
 func (p *Provider) ListRunning(prefix string) ([]string, error) {
-	all, err := p.tm.ListSessions()
+	all, err := p.tm.listSessionNames()
 	if err != nil {
+		if errors.Is(err, ErrNoServer) {
+			return nil, &runtime.PartialListError{Err: fmt.Errorf("tmux server unreachable: %w", err)}
+		}
 		return nil, err
 	}
 	var matched []string

--- a/internal/runtime/tmux/adapter_unit_test.go
+++ b/internal/runtime/tmux/adapter_unit_test.go
@@ -50,6 +50,60 @@ func TestProviderAttachMissingSessionWrapsRuntimeSentinel(t *testing.T) {
 	}
 }
 
+func TestProviderListRunningReportsPartialOnNoServer(t *testing.T) {
+	fe := &fakeExecutor{err: ErrNoServer}
+	p := NewProviderWithConfig(Config{SocketName: "x"})
+	p.tm.exec = fe
+
+	names, err := p.ListRunning("")
+	if names != nil {
+		t.Fatalf("ListRunning names = %v, want nil on unreachable server", names)
+	}
+	if !runtime.IsPartialListError(err) {
+		t.Fatalf("ListRunning err = %v, want runtime.PartialListError so reconciler guards defer", err)
+	}
+	if !errors.Is(err, ErrNoServer) {
+		t.Fatalf("ListRunning err = %v, want wrapped ErrNoServer cause", err)
+	}
+}
+
+func TestProviderListRunningPropagatesNonServerError(t *testing.T) {
+	sentinel := errors.New("tmux exploded")
+	fe := &fakeExecutor{err: sentinel}
+	p := NewProviderWithConfig(Config{SocketName: "x"})
+	p.tm.exec = fe
+
+	names, err := p.ListRunning("")
+	if names != nil {
+		t.Fatalf("ListRunning names = %v, want nil on error", names)
+	}
+	if runtime.IsPartialListError(err) {
+		t.Fatalf("ListRunning err = %v, want a plain error (not partial) for a real tmux failure", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("ListRunning err = %v, want the underlying tmux error", err)
+	}
+}
+
+// TestListSessionsAbsorbsNoServer pins the tmux-internal contract that the
+// change deliberately preserves: ListSessions still reports an unreachable
+// server as an empty result so FindSessionByWorkDir and CleanupOrphanedSessions
+// keep treating "server down" as "no sessions". Only Provider.ListRunning
+// surfaces the outage as a PartialListError.
+func TestListSessionsAbsorbsNoServer(t *testing.T) {
+	fe := &fakeExecutor{err: ErrNoServer}
+	tm := NewTmux()
+	tm.exec = fe
+
+	names, err := tm.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions err = %v, want nil (no server absorbed)", err)
+	}
+	if names != nil {
+		t.Fatalf("ListSessions names = %v, want nil", names)
+	}
+}
+
 func TestProviderAttachReportsHasSessionError(t *testing.T) {
 	fe := &fakeExecutor{
 		err: errors.New("tmux unavailable"),

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -1001,21 +1001,38 @@ func (t *Tmux) HasSession(name string) (bool, error) {
 	return true, nil
 }
 
-// ListSessions returns all session names.
-func (t *Tmux) ListSessions() ([]string, error) {
+// listSessionNames returns all session names, propagating ErrNoServer so
+// callers that must distinguish an unreachable server from a genuinely empty
+// session list can do so. [Tmux.ListSessions] absorbs ErrNoServer into an
+// empty result for its tmux-internal callers; the reconciler-facing
+// [Provider.ListRunning] uses this variant to surface a total outage as a
+// [runtime.PartialListError] instead of "no sessions".
+func (t *Tmux) listSessionNames() ([]string, error) {
 	out, err := t.run("list-sessions", "-F", "#{session_name}")
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
+}
+
+// ListSessions returns all session names. An unreachable tmux server is
+// absorbed into an empty result (no server = no sessions) for tmux-internal
+// callers (FindSessionByWorkDir, CleanupOrphanedSessions) that treat "server
+// down" and "no sessions" identically. Reconciler-facing liveness listing goes
+// through [Provider.ListRunning], which instead reports the outage as a
+// [runtime.PartialListError].
+func (t *Tmux) ListSessions() ([]string, error) {
+	names, err := t.listSessionNames()
 	if err != nil {
 		if errors.Is(err, ErrNoServer) {
 			return nil, nil // No server = no sessions
 		}
 		return nil, err
 	}
-
-	if out == "" {
-		return nil, nil
-	}
-
-	return strings.Split(out, "\n"), nil
+	return names, nil
 }
 
 // SessionSet provides O(1) session existence checks by caching session names.


### PR DESCRIPTION
## Why

Follow-up to #4082, which shielded the `StateCache` liveness path but left the reconciler-facing `ListRunning` sites reading a full tmux outage as "zero sessions." The repo already has the convention to prevent that (`PartialListError` / `IsPartialListError` in `internal/runtime/provider_core.go`) and four reconciler sites already guard on it, but nothing emitted the signal for a single-tmux total outage, so the guards were dark.

## What changed

- `internal/runtime/tmux/adapter.go`: `Provider.ListRunning` reports a totally unreachable tmux server (`ErrNoServer`) as a `runtime.PartialListError` (nil names) instead of the old empty success `(nil, nil)`, activating the existing guards with no new plumbing.
- `internal/runtime/tmux/tmux.go`: the raw `list-sessions` call moves to a private `listSessionNames()` that propagates `ErrNoServer`; `ListSessions()` stays a thin wrapper that re-absorbs `ErrNoServer → (nil, nil)` for its two tmux-internal callers (`FindSessionByWorkDir`, `CleanupOrphanedSessions`), whose behavior is unchanged. Emitting at the provider layer (not `ListSessions`) keeps the blast radius on the reconciler-facing path only.
- `engdocs/design/runtime-partial-discipline.md`: moves the `ListRunning` sites from "still exposed" to landed.

Two sites gain a genuine safety fix: the pool `on_death` hooks (`city_runtime.go:960`) no longer fire the user's on_death command for every slot on a blip (the false death storm), and the config-reload provider swap (`:1899`) no longer proceeds with zero visible sessions. The shutdown sites (`:3466`/`:3478`) were already a no-op stop set under the old path; only their diagnostic message changes.

## Blast-radius audit

All ~20 `ListRunning` callers were checked. None treats the new non-nil error as a trigger for destructive action: each either already guards on `IsPartialListError` and defers, degrades to the StateCache-backed per-session `IsRunning` (protected by #4082), or returns the same empty/nil result it produced under the old absorbed-error path. The auto/hybrid composites fold the signal through `MergeBackendListResults`; both `IsPartialListError` and `errors.Is(err, ErrNoServer)` still resolve through the nesting.

## Test plan

- `go build ./...`, `go vet ./internal/runtime/... ./cmd/gc/...`: clean
- `go test ./internal/runtime/...`: pass
- New `internal/runtime/tmux/adapter_unit_test.go`: provider emits `PartialListError` on no-server; a genuine tmux failure is not misclassified as partial; `ListSessions` still absorbs for internal callers. The pre-existing destructive-site guard tests (on_death, provider-swap) now exercise a reachable production path.
