### PR TITLE
fix(reconciler): repair stranded/dead-assignee work instead of only diagnosing

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2169,6 +2169,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		for _, r := range released {
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}
+		// Turn the otherwise-silent reopen into an observable signal. The reopen
+		// (clear dead assignee, reset in_progress→open) already ran above and is
+		// gated on confirmed non-liveness; emit the event BEFORE the snapshot
+		// filter so the dead assignee and route can still be read off the beads.
+		emitDeadAssigneeReopenedEvents(cr.rec, assignedWorkBeads, released, time.Now())
 		assignedWorkBeads, assignedWorkStoreRefs = filterReleasedAssignedWorkSnapshot(assignedWorkBeads, assignedWorkStoreRefs, released)
 	}
 	// Squatter guard (gastownhall/gascity#2930): a foreign Dolt that has bound

--- a/cmd/gc/dead_assignee_event.go
+++ b/cmd/gc/dead_assignee_event.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api"
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// emitDeadAssigneeReopenedEvents records one bead.dead_assignee_reopened event
+// for each work bead releaseOrphanedPoolAssignments just reopened because its
+// assignee resolved to no open session bead. The destructive reopen (clear
+// assignee, reset in_progress→open) already ran and is gated on confirmed
+// non-liveness (snapshot-complete deferral + liveWorkAssignmentStillReleasable
+// re-validation + liveOpenSessionAssignmentExists); this only makes the
+// otherwise-silent repair observable, so it never mutates a bead.
+//
+// released carries the ID and the index into assignedWorkBeads (the pre-reopen
+// snapshot) so the dead assignee and routed_to can be read off the bead as it
+// looked when it was reopened. A stale/out-of-range index is skipped rather
+// than fabricating a payload.
+func emitDeadAssigneeReopenedEvents(rec events.Recorder, assignedWorkBeads []beads.Bead, released []releasedPoolAssignment, now time.Time) {
+	if rec == nil || len(released) == 0 {
+		return
+	}
+	for _, r := range released {
+		deadAssignee := ""
+		routedTo := ""
+		if r.Index >= 0 && r.Index < len(assignedWorkBeads) && assignedWorkBeads[r.Index].ID == r.ID {
+			wb := assignedWorkBeads[r.Index]
+			deadAssignee = strings.TrimSpace(wb.Assignee)
+			routedTo = strings.TrimSpace(wb.Metadata[beadmeta.RoutedToMetadataKey])
+		}
+		rec.Record(events.Event{
+			Type:    events.BeadDeadAssigneeReopened,
+			Ts:      now.UTC(),
+			Actor:   "gc",
+			Subject: r.ID,
+			Message: formatDeadAssigneeReopenedMessage(r.ID, deadAssignee, routedTo),
+			Payload: api.BeadDeadAssigneeReopenedPayloadJSON(r.ID, deadAssignee, routedTo),
+		})
+	}
+}
+
+// formatDeadAssigneeReopenedMessage renders the operator-facing text for a
+// bead.dead_assignee_reopened event.
+func formatDeadAssigneeReopenedMessage(beadID, deadAssignee, routedTo string) string {
+	assignee := deadAssignee
+	if assignee == "" {
+		assignee = "<unknown>"
+	}
+	route := routedTo
+	if route == "" {
+		route = "<unrouted>"
+	}
+	return "reopened routed work " + beadID + " assigned to dead session " + assignee +
+		" (route " + route + "); assignee cleared so the pool can reclaim it"
+}

--- a/cmd/gc/dead_assignee_repair_test.go
+++ b/cmd/gc/dead_assignee_repair_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api"
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// strandedRepairFixture creates a session bead plus an in_progress work bead
+// assigned to it (by session ID), the stranded-pool-worker shape: the runtime
+// is gone but the bead still holds the session as assignee.
+func strandedRepairFixture(t *testing.T) (*beads.MemStore, beads.Bead, beads.Bead) {
+	t.Helper()
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:    "worker session",
+		Type:     sessionBeadType,
+		Status:   "open",
+		Metadata: map[string]string{"session_name": "worker-mc-dead", "pool_managed": "true"},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "stranded work",
+		Type:     "task",
+		Assignee: session.ID,
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("set work in_progress: %v", err)
+	}
+	work, _ = store.Get(work.ID)
+	return store, session, work
+}
+
+// A confirmed-stranded pool worker (marker aged past the confirmation window)
+// has its in_progress work unassigned + reopened and its session bead closed.
+func TestRepairStrandedPoolWorkerBead_ReopensAfterConfirmationWindow(t *testing.T) {
+	store, session, work := strandedRepairFixture(t)
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	// Diagnostic first observed the strand well past the confirmation window.
+	session.Metadata[strandedEventEmittedKey] = now.Add(-strandedRepairConfirmGrace - time.Minute).Format(time.RFC3339)
+
+	var stderr bytes.Buffer
+	repaired := repairStrandedPoolWorkerBead(store, nil, &session, "worker", &clock.Fake{Time: now}, &stderr)
+	if !repaired {
+		t.Fatalf("expected repair to close the session bead; stderr=%q", stderr.String())
+	}
+
+	gotWork, _ := store.Get(work.ID)
+	if gotWork.Status != "open" {
+		t.Fatalf("work status = %q, want open", gotWork.Status)
+	}
+	if gotWork.Assignee != "" {
+		t.Fatalf("work assignee = %q, want empty", gotWork.Assignee)
+	}
+	gotSession, _ := store.Get(session.ID)
+	if gotSession.Status != "closed" {
+		t.Fatalf("session status = %q, want closed", gotSession.Status)
+	}
+}
+
+// A single not-alive observation must never trigger the destructive clear: the
+// marker is fresh (inside the window), so the work and session stay untouched.
+func TestRepairStrandedPoolWorkerBead_DefersInsideConfirmationWindow(t *testing.T) {
+	store, session, work := strandedRepairFixture(t)
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	session.Metadata[strandedEventEmittedKey] = now.Format(time.RFC3339) // just observed
+
+	var stderr bytes.Buffer
+	if repairStrandedPoolWorkerBead(store, nil, &session, "worker", &clock.Fake{Time: now}, &stderr) {
+		t.Fatalf("must not repair inside the confirmation window")
+	}
+	gotWork, _ := store.Get(work.ID)
+	if gotWork.Status != "in_progress" || gotWork.Assignee != session.ID {
+		t.Fatalf("work should be untouched, got status=%q assignee=%q", gotWork.Status, gotWork.Assignee)
+	}
+	gotSession, _ := store.Get(session.ID)
+	if gotSession.Status != "open" {
+		t.Fatalf("session should stay open, got %q", gotSession.Status)
+	}
+}
+
+// Without a stranded marker the leak has not been confirmed this generation, so
+// the repair defers even if the caller reached it — the diagnostic gates the
+// destructive clear.
+func TestRepairStrandedPoolWorkerBead_DefersWithoutStrandedMarker(t *testing.T) {
+	store, session, work := strandedRepairFixture(t)
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+
+	var stderr bytes.Buffer
+	if repairStrandedPoolWorkerBead(store, nil, &session, "worker", &clock.Fake{Time: now}, &stderr) {
+		t.Fatalf("must not repair without a stranded marker")
+	}
+	gotWork, _ := store.Get(work.ID)
+	if gotWork.Status != "in_progress" {
+		t.Fatalf("work should be untouched, got status=%q", gotWork.Status)
+	}
+}
+
+// A live named session's assigned work must survive the reopen sweep: an open
+// session bead owning the identity means the session is not gone. Guards the
+// conservative liveness primitive (open session bead exists → skip).
+func TestReleaseOrphanedPoolAssignments_SkipsLiveAssigneeStaysAssigned(t *testing.T) {
+	store := beads.NewMemStore()
+	live, err := store.Create(beads.Bead{
+		Title:    "live worker",
+		Type:     sessionBeadType,
+		Status:   "open",
+		Metadata: map[string]string{"session_name": "worker-mc-live"},
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "routed work",
+		Assignee: live.Metadata["session_name"],
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("set in_progress: %v", err)
+	}
+	work, _ = store.Get(work.ID)
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		[]beads.Bead{live},
+		[]beads.Bead{work},
+		nil, nil, nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("live assignee must not be released, got %v", released)
+	}
+	got, _ := store.Get(work.ID)
+	if got.Assignee == "" {
+		t.Fatalf("live assignee cleared — should stay assigned")
+	}
+}
+
+// emitDeadAssigneeReopenedEvents records one typed event per reopened bead,
+// carrying the dead assignee and route read off the pre-filter snapshot.
+func TestEmitDeadAssigneeReopenedEvents_EmitsTypedPayload(t *testing.T) {
+	assigned := []beads.Bead{
+		{ID: "w-1", Assignee: "worker-mc-dead", Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"}},
+		{ID: "w-2"}, // not released
+	}
+	released := []releasedPoolAssignment{{ID: "w-1", Index: 0}}
+	rec := &capturingRecorder{}
+
+	emitDeadAssigneeReopenedEvents(rec, assigned, released, time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC))
+
+	if len(rec.events) != 1 {
+		t.Fatalf("event count = %d, want 1", len(rec.events))
+	}
+	e := rec.events[0]
+	if e.Type != events.BeadDeadAssigneeReopened {
+		t.Fatalf("type = %q, want %q", e.Type, events.BeadDeadAssigneeReopened)
+	}
+	if e.Subject != "w-1" {
+		t.Fatalf("subject = %q, want w-1", e.Subject)
+	}
+	var p api.BeadDeadAssigneeReopenedPayload
+	if err := json.Unmarshal(e.Payload, &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if p.BeadID != "w-1" || p.DeadAssignee != "worker-mc-dead" || p.RoutedTo != "worker" {
+		t.Fatalf("payload = %+v, want bead_id=w-1 dead_assignee=worker-mc-dead routed_to=worker", p)
+	}
+}
+
+// A nil recorder or empty release list is a no-op — no panic, no events.
+func TestEmitDeadAssigneeReopenedEvents_NoOpOnEmpty(t *testing.T) {
+	emitDeadAssigneeReopenedEvents(nil, nil, []releasedPoolAssignment{{ID: "x"}}, time.Now())
+	rec := &capturingRecorder{}
+	emitDeadAssigneeReopenedEvents(rec, nil, nil, time.Now())
+	if len(rec.events) != 0 {
+		t.Fatalf("expected no events, got %d", len(rec.events))
+	}
+}

--- a/cmd/gc/dead_assignee_repair_test.go
+++ b/cmd/gc/dead_assignee_repair_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,6 +93,45 @@ func TestRepairStrandedPoolWorkerBead_DefersInsideConfirmationWindow(t *testing.
 	gotSession, _ := store.Get(session.ID)
 	if gotSession.Status != "open" {
 		t.Fatalf("session should stay open, got %q", gotSession.Status)
+	}
+}
+
+// updateFailStore lists work normally but fails every Update, modeling a store
+// where the unassign (ReleaseWorkBead → Update) cannot land.
+type updateFailStore struct {
+	beads.Store
+}
+
+func (s updateFailStore) Update(string, beads.UpdateOpts) error {
+	return fmt.Errorf("simulated update failure")
+}
+
+// A partial failure (unassign does not land) must NOT be reported as a repair:
+// the session bead stays open and the work stays claimed, so the stale-assignee
+// item is left for the next-tick sweep rather than masked behind a "repaired"
+// close. Surfaces the failure on stderr for distinct observability.
+func TestRepairStrandedPoolWorkerBead_DefersAndKeepsSessionOpenWhenUnassignFails(t *testing.T) {
+	base, session, work := strandedRepairFixture(t)
+	store := updateFailStore{Store: base}
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	// Marker aged well past the confirmation window — the window is satisfied;
+	// only the failed unassign should hold the repair back.
+	session.Metadata[strandedEventEmittedKey] = now.Add(-strandedRepairConfirmGrace - time.Minute).Format(time.RFC3339)
+
+	var stderr bytes.Buffer
+	if repairStrandedPoolWorkerBead(store, nil, &session, "worker", &clock.Fake{Time: now}, &stderr) {
+		t.Fatal("repair must return false when an unassign does not land")
+	}
+	gotWork, _ := base.Get(work.ID)
+	if gotWork.Status != "in_progress" || gotWork.Assignee != session.ID {
+		t.Fatalf("work must stay claimed after a failed unassign, got status=%q assignee=%q", gotWork.Status, gotWork.Assignee)
+	}
+	gotSession, _ := base.Get(session.ID)
+	if gotSession.Status != "open" {
+		t.Fatalf("session must stay open after a failed unassign, got %q", gotSession.Status)
+	}
+	if !strings.Contains(stderr.String(), "unassign(s) failed") {
+		t.Fatalf("stderr must surface the failed unassign, got %q", stderr.String())
 	}
 }
 

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -818,6 +818,68 @@ func reassignWorkAssignedToRetiredSessionBead(
 	}
 }
 
+// strandedRepairConfirmGrace is the minimum age of the first stranded
+// observation (the stranded_event_emitted_at marker stamped by
+// emitSessionStrandedDiagnostic) before the reconciler will REPAIR — not merely
+// diagnose — a stranded pool worker. A single not-alive observation is never
+// acted on: the leak must persist across the window so a transient
+// runtime-liveness glitch cannot clear a live claim. Mirrors the
+// observe-before-act discipline of the idle-claim backstop (idleClaimNudgeGrace)
+// and the #3630 suspend-confirm window.
+const strandedRepairConfirmGrace = 2 * time.Minute
+
+// strandedRepairCloseReason is the close_reason stamped on a session bead
+// retired by the stranded-worker repair, distinguishing it from a clean drain
+// (drained) or an idle recycle in the forensic record.
+const strandedRepairCloseReason = "stranded-repair"
+
+// repairStrandedPoolWorkerBead closes the divergence loop that
+// emitSessionStrandedDiagnostic only reports: a pool session whose runtime
+// exited while it still held in_progress work as assignee, leaving that work
+// invisible to every actuator. It unassigns/reopens the stranded work (reusing
+// unclaimWorkAssignedToRetiredSessionBead so the bead returns to the routed
+// queue with a run_target fallback) and closes the session bead so the slot
+// frees and the pool reclaims the work.
+//
+// Confirmed non-liveness is the caller's contract: it only reaches here on a
+// pool session the reconciler already sees as not-alive (poolFreeable requires
+// !target.alive) with a non-degraded store read (!storeQueryPartial). To avoid
+// acting on a single transient not-alive observation, the destructive clear runs
+// only once the stranded condition has persisted past strandedRepairConfirmGrace
+// since the diagnostic first stamped stranded_event_emitted_at. An absent marker
+// means the leak has not been confirmed-stranded this session-bead generation
+// (the diagnostic early-returned — no recorder, or the work passed the
+// detached-probe liveness filter), so the repair defers.
+//
+// Returns true when it closed the session bead, so the caller mirrors MarkClosed
+// onto the snapshot and prunes the worktree exactly as the clean close path does.
+func repairStrandedPoolWorkerBead(
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	session *beads.Bead,
+	fallbackRoute string,
+	clk clock.Clock,
+	stderr io.Writer,
+) bool {
+	if store == nil || session == nil {
+		return false
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	since := strings.TrimSpace(session.Metadata[strandedEventEmittedKey])
+	if since == "" {
+		return false // not yet confirmed stranded this generation — defer
+	}
+	first := parseRFC3339OrZero(since)
+	now := clk.Now().UTC()
+	if first.IsZero() || now.Sub(first) < strandedRepairConfirmGrace {
+		return false // inside the confirmation window — defer the destructive clear
+	}
+	unclaimWorkAssignedToRetiredSessionBead(store, rigStores, *session, fallbackRoute, stderr)
+	return closeBead(store, session.ID, strandedRepairCloseReason, now, stderr)
+}
+
 func reassignStateAssignedToRetiredSessionBead(store beads.Store, oldSessionID, newSessionID string, now time.Time, stderr io.Writer) {
 	if store == nil || strings.TrimSpace(oldSessionID) == "" || strings.TrimSpace(newSessionID) == "" {
 		return

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -725,15 +725,28 @@ func workAssignmentStores(store beads.Store, rigStores map[string]beads.Store) [
 	return stores
 }
 
+// unclaimResult reports the outcome of one unassign sweep over a retired
+// session bead's owned work: Released counts work beads whose assignee was
+// successfully cleared/reopened, Failed counts ReleaseWorkBead errors (already
+// logged per item to stderr). Void callers (named-session retirement, closed-
+// session release) ignore it; the stranded-repair path reads Failed to avoid
+// reporting a clean repair — or closing the session bead — when an unassign did
+// not land, so a stale-assignee item is not masked behind a "repaired" close.
+type unclaimResult struct {
+	Released int
+	Failed   int
+}
+
 func unclaimWorkAssignedToRetiredSessionBead(
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	sessionBead beads.Bead,
 	fallbackRoute string,
 	stderr io.Writer,
-) {
+) unclaimResult {
+	var res unclaimResult
 	if store == nil || strings.TrimSpace(sessionBead.ID) == "" {
-		return
+		return res
 	}
 	if stderr == nil {
 		stderr = io.Discard
@@ -769,11 +782,15 @@ func unclaimWorkAssignedToRetiredSessionBead(
 					// reopen, orphan-pool, and closed-session release paths.
 					if err := wa.ReleaseWorkBead(item, fallbackRoute); err != nil {
 						fmt.Fprintf(stderr, "session beads: unclaiming work %s assigned to retired session %s: %v\n", item.ID, sessionBead.ID, err) //nolint:errcheck
+						res.Failed++
+						continue
 					}
+					res.Released++
 				}
 			}
 		}
 	}
+	return res
 }
 
 func reassignWorkAssignedToRetiredSessionBead(
@@ -818,12 +835,16 @@ func reassignWorkAssignedToRetiredSessionBead(
 	}
 }
 
-// strandedRepairConfirmGrace is the minimum age of the first stranded
-// observation (the stranded_event_emitted_at marker stamped by
+// strandedRepairConfirmGrace is the minimum age of the CURRENT stranding
+// episode's stranded_event_emitted_at marker (stamped by
 // emitSessionStrandedDiagnostic) before the reconciler will REPAIR — not merely
-// diagnose — a stranded pool worker. A single not-alive observation is never
-// acted on: the leak must persist across the window so a transient
-// runtime-liveness glitch cannot clear a live claim. Mirrors the
+// diagnose — a stranded pool worker. The marker tracks CONTINUOUS non-liveness:
+// clearStrandedEventMarker drops it on any alive observation, so the window
+// re-arms from zero each time the session recovers. A single not-alive
+// observation, or a worker that recovered and re-stranded, is never acted on
+// until the NEW episode persists across the window, so a transient
+// runtime-liveness glitch (or a recovered-then-cleanly-drained worker whose
+// bd close is mid-flight) cannot clear a live claim. Mirrors the
 // observe-before-act discipline of the idle-claim backstop (idleClaimNudgeGrace)
 // and the #3630 suspend-confirm window.
 const strandedRepairConfirmGrace = 2 * time.Minute
@@ -841,18 +862,32 @@ const strandedRepairCloseReason = "stranded-repair"
 // queue with a run_target fallback) and closes the session bead so the slot
 // frees and the pool reclaims the work.
 //
-// Confirmed non-liveness is the caller's contract: it only reaches here on a
+// Confirmed CONTINUOUS non-liveness is the contract: it only reaches here on a
 // pool session the reconciler already sees as not-alive (poolFreeable requires
-// !target.alive) with a non-degraded store read (!storeQueryPartial). To avoid
-// acting on a single transient not-alive observation, the destructive clear runs
-// only once the stranded condition has persisted past strandedRepairConfirmGrace
-// since the diagnostic first stamped stranded_event_emitted_at. An absent marker
-// means the leak has not been confirmed-stranded this session-bead generation
-// (the diagnostic early-returned — no recorder, or the work passed the
-// detached-probe liveness filter), so the repair defers.
+// !target.alive) with a non-degraded store read (!storeQueryPartial), and it
+// acts only once the CURRENT stranding episode's stranded_event_emitted_at
+// marker has aged past strandedRepairConfirmGrace. Because clearStrandedEventMarker
+// drops that marker on every alive observation, the marker cannot outlive the
+// episode that stamped it: a worker that stranded, was respawned on this same
+// session bead, and recovered starts a brand-new marker if it re-strands, so a
+// recovered-then-cleanly-drained worker (whose own bd close may be mid-flight
+// during the brief poolFreeable && hasAssignedWork window) can never be repaired
+// on a stale first-episode timestamp. An absent marker means no confirmed
+// stranding episode is in progress (the diagnostic early-returned — no recorder,
+// the work passed the detached-probe liveness filter, or the session recovered
+// and cleared it), so the repair defers.
 //
-// Returns true when it closed the session bead, so the caller mirrors MarkClosed
-// onto the snapshot and prunes the worktree exactly as the clean close path does.
+// The unassign step must land before the close: unclaimWorkAssignedToRetiredSessionBead
+// reports how many releases failed via unclaimResult. If any failed, the session
+// bead is left OPEN and false returned — closing it would retire the session
+// while work is still assigned to it (a stale-assignee item), masking the leak
+// behind a "repaired" close. A failed release is retried on the next tick (the
+// episode's marker is still aged and the session still not-alive), and the
+// self-healing next-tick sweep is the backstop.
+//
+// Returns true only when it BOTH cleared the stranded work AND closed the session
+// bead, so the caller mirrors MarkClosed onto the snapshot and prunes the
+// worktree exactly as the clean close path does.
 func repairStrandedPoolWorkerBead(
 	store beads.Store,
 	rigStores map[string]beads.Store,
@@ -869,14 +904,22 @@ func repairStrandedPoolWorkerBead(
 	}
 	since := strings.TrimSpace(session.Metadata[strandedEventEmittedKey])
 	if since == "" {
-		return false // not yet confirmed stranded this generation — defer
+		return false // no confirmed stranding episode in progress — defer
 	}
 	first := parseRFC3339OrZero(since)
 	now := clk.Now().UTC()
 	if first.IsZero() || now.Sub(first) < strandedRepairConfirmGrace {
 		return false // inside the confirmation window — defer the destructive clear
 	}
-	unclaimWorkAssignedToRetiredSessionBead(store, rigStores, *session, fallbackRoute, stderr)
+	res := unclaimWorkAssignedToRetiredSessionBead(store, rigStores, *session, fallbackRoute, stderr)
+	if res.Failed > 0 {
+		// At least one unassign did not land. Do NOT close the session bead or
+		// report a repair: closing now would strand the still-assigned work
+		// against a retired session. Leave the bead open so the next tick
+		// re-attempts (episode marker still aged, session still not-alive).
+		fmt.Fprintf(stderr, "session beads: stranded-repair for %s deferred: %d of %d unassign(s) failed; leaving session bead open for retry\n", session.ID, res.Failed, res.Failed+res.Released) //nolint:errcheck
+		return false
+	}
 	return closeBead(store, session.ID, strandedRepairCloseReason, now, stderr)
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -3203,6 +3203,18 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 		persistSleepPolicyMetadata(target.session, sessFront, eval.Policy, eval.ConfigSuppressed)
 
+		// Clear-on-recovery: a live tick ends any stranding episode. Drop the
+		// stranded confirmation marker so stranded_event_emitted_at tracks
+		// CONTINUOUS non-liveness, not a one-shot flag — a worker that stranded,
+		// was respawned on this same session bead, and recovered must age a FRESH
+		// marker before repairStrandedPoolWorkerBead may act, rather than
+		// inheriting the first episode's stale timestamp. See clearStrandedEventMarker.
+		if target.alive {
+			if fold := clearStrandedEventMarker(target.session, sessFront, stderr); fold != nil {
+				infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
+			}
+		}
+
 		if shouldWake && !target.alive {
 			// Session should be awake but isn't — wake it.
 			if isFailedCreateSessionInfo(info) {
@@ -3399,15 +3411,20 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if fold := emitSessionStrandedDiagnostic(cityPath, cfg, store, rigStores, target.session, target.tp.TemplateName, rec, clk, stderr); fold != nil {
 				infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
 			}
-			// Beyond diagnosis: once the stranded condition has been confirmed
+			// Beyond diagnosis: once THIS stranding episode has been confirmed
 			// across the confirmation window (stranded_event_emitted_at aged past
 			// strandedRepairConfirmGrace) and the store read is non-degraded,
 			// REPAIR the leak — unassign/reopen the stranded work so the pool can
 			// reclaim it, then close the session bead to free the slot. The
 			// storeQueryPartial gate ensures a transient store miss can never clear
-			// a live claim; the confirmation window guards against a transient
-			// not-alive observation. Reuses unclaimWorkAssignedToRetiredSessionBead,
-			// the same detach primitive named-session retirement uses.
+			// a live claim. The confirmation window tracks CONTINUOUS non-liveness:
+			// clearStrandedEventMarker (invoked on every alive tick, above) drops
+			// the marker the instant the session is seen alive again, so a worker
+			// that stranded, was respawned on this same bead, and recovered must
+			// re-age a FRESH marker here — a recovered-then-drained worker cannot
+			// fire the repair on the first episode's stale timestamp. Reuses
+			// unclaimWorkAssignedToRetiredSessionBead, the same detach primitive
+			// named-session retirement uses.
 			if !storeQueryPartial &&
 				repairStrandedPoolWorkerBead(store, rigStores, target.session, retiredSessionFallbackRoute(*target.session), clk, stderr) {
 				infoByID[target.session.ID] = infoByID[target.session.ID].MarkClosed()
@@ -3804,6 +3821,49 @@ func emitSessionStrandedDiagnostic(
 	// SetMarker store result — the in-memory marker above is the emit-once
 	// guard, and the snapshot must match it.
 	return sessionpkg.MetadataPatch{strandedEventEmittedKey: now.Format(time.RFC3339)}
+}
+
+// clearStrandedEventMarker drops the stranded_event_emitted_at marker whenever
+// the session is observed ALIVE again. This is the clear-on-recovery half of the
+// confirmation-window contract: strandedEventEmittedKey tracks CONTINUOUS
+// non-liveness, NOT a one-shot "ever stranded this generation" flag.
+//
+// Without it the marker is stamped once (emitSessionStrandedDiagnostic
+// early-returns while it is set) and only cleared by a full session-bead close,
+// so a pool worker that strands, is respawned on the SAME session bead
+// (shouldWake && !alive → normal pool re-wake), recovers, and runs clean past
+// strandedRepairConfirmGrace would inherit the stale first-episode timestamp. A
+// later brief poolFreeable && hasAssignedWork window (the documented pre-close
+// ownership race, session_reconciler.go ~3371-3374) would then let
+// repairStrandedPoolWorkerBead read that long-aged marker and fire IMMEDIATELY,
+// clearing a live claim on work the recovered worker finished cleanly.
+//
+// Clearing on any alive observation makes each distinct stranding episode age a
+// FRESH marker: emitSessionStrandedDiagnostic re-emits per episode (restoring
+// per-episode observability) and the repair must re-confirm non-liveness across
+// a new window before it acts. alive ⟹ runtime is up ⟹ not stranded, so the
+// clear is always safe here.
+//
+// Returns the metadata patch it applied so the reconciler folds it onto the
+// infoByID snapshot (write-returns-Info), or nil when there was nothing to
+// clear. Mirrors recordCurrentBeadIDOnWake: durable SetMarker first, then the
+// in-memory session.Metadata mirror (the raw bead may be carried across ticks).
+func clearStrandedEventMarker(session *beads.Bead, sessFront *sessionpkg.Store, stderr io.Writer) sessionpkg.MetadataPatch {
+	if session == nil || sessFront == nil {
+		return nil
+	}
+	if strings.TrimSpace(session.Metadata[strandedEventEmittedKey]) == "" {
+		return nil // no marker this generation — nothing to clear
+	}
+	// Empty value clears the key (SetMarker empty-string-clear contract).
+	if err := sessFront.SetMarker(session.ID, strandedEventEmittedKey, ""); err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "session reconciler: clearing %s for %s: %v\n", strandedEventEmittedKey, session.Metadata["session_name"], err) //nolint:errcheck
+		}
+		return nil
+	}
+	delete(session.Metadata, strandedEventEmittedKey)
+	return sessionpkg.MetadataPatch{strandedEventEmittedKey: ""}
 }
 
 type strandedAssignedWork struct {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -3399,6 +3399,20 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if fold := emitSessionStrandedDiagnostic(cityPath, cfg, store, rigStores, target.session, target.tp.TemplateName, rec, clk, stderr); fold != nil {
 				infoByID[target.session.ID] = infoByID[target.session.ID].ApplyPatch(fold)
 			}
+			// Beyond diagnosis: once the stranded condition has been confirmed
+			// across the confirmation window (stranded_event_emitted_at aged past
+			// strandedRepairConfirmGrace) and the store read is non-degraded,
+			// REPAIR the leak — unassign/reopen the stranded work so the pool can
+			// reclaim it, then close the session bead to free the slot. The
+			// storeQueryPartial gate ensures a transient store miss can never clear
+			// a live claim; the confirmation window guards against a transient
+			// not-alive observation. Reuses unclaimWorkAssignedToRetiredSessionBead,
+			// the same detach primitive named-session retirement uses.
+			if !storeQueryPartial &&
+				repairStrandedPoolWorkerBead(store, rigStores, target.session, retiredSessionFallbackRoute(*target.session), clk, stderr) {
+				infoByID[target.session.ID] = infoByID[target.session.ID].MarkClosed()
+				pruneAgentHomeWorktreeIfSafe(*target.session, cityPath, cfg, stderr)
+			}
 		}
 		if poolFreeable && !hasAssignedWork {
 			// Close directly rather than via closeSessionBeadIfUnassigned.

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2206,6 +2206,170 @@ func TestReconcileSessionBeads_PoolSlotWithStrandedWorkEmitsDiagnostic(t *testin
 	}
 }
 
+// strandedRepairReconcileEnv builds a pool-managed session whose runtime is dead
+// while it still holds one in_progress work bead as assignee — the exact shape
+// TestReconcileSessionBeads_PoolSlotWithStrandedWorkEmitsDiagnostic exercises,
+// so poolFreeable && hasAssignedWork holds and the diagnostic + repair path is
+// reached through the real reconcile call site.
+func strandedRepairReconcileEnv(t *testing.T) (*reconcilerTestEnv, beads.Bead, beads.Bead, *capturingRecorder) {
+	t.Helper()
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false) // runtime NOT running — dead
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "asleep",
+		"sleep_reason":         "idle",
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+	work, err := env.store.Create(beads.Bead{
+		Title:    "stranded implementation",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := env.store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("Update work bead status: %v", err)
+	}
+	work, _ = env.store.Get(work.ID)
+	rec := &capturingRecorder{}
+	env.rec = rec
+	return env, session, work, rec
+}
+
+// runStrandedReconcileTick drives one full reconcile tick through the real
+// call site with the standard stranded-repair fixture arguments.
+func runStrandedReconcileTick(t *testing.T, env *reconcilerTestEnv, sessions []beads.Bead) {
+	t.Helper()
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		sessions,
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		newFakeDrainOps(),
+		nil,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+}
+
+// After a genuine CONTINUOUS non-liveness window the reconciler must actually
+// REPAIR the stranded work end-to-end: unassign/reopen the work and close the
+// session bead. The existing tests only cover the defer path; this asserts the
+// fire path through the real reconcile.
+func TestReconcileSessionBeads_StrandedRepairFiresAfterContinuousWindow(t *testing.T) {
+	env, session, work, rec := strandedRepairReconcileEnv(t)
+
+	// Tick 1: diagnostic fires and stamps stranded_event_emitted_at; the repair
+	// defers because the marker is fresh (inside the confirmation window).
+	runStrandedReconcileTick(t, env, []beads.Bead{session})
+	if got := len(rec.strandedEvents()); got != 1 {
+		t.Fatalf("stranded events after tick 1 = %d, want 1; events: %+v", got, rec.events)
+	}
+	afterFirst, _ := env.store.Get(session.ID)
+	if afterFirst.Status == "closed" {
+		t.Fatal("session must not be closed inside the confirmation window")
+	}
+
+	// Advance past the confirmation window; the runtime stayed dead throughout
+	// (continuous non-liveness), so the marker is never cleared.
+	env.clk.Time = env.clk.Time.Add(strandedRepairConfirmGrace + time.Minute)
+	updated, _ := env.store.Get(session.ID)
+
+	// Tick 2: window satisfied → repair fires.
+	runStrandedReconcileTick(t, env, []beads.Bead{updated})
+
+	gotWork, _ := env.store.Get(work.ID)
+	if gotWork.Status != "open" {
+		t.Fatalf("work status = %q, want open (reopened by repair)", gotWork.Status)
+	}
+	if gotWork.Assignee != "" {
+		t.Fatalf("work assignee = %q, want empty (unassigned by repair)", gotWork.Assignee)
+	}
+	gotSession, _ := env.store.Get(session.ID)
+	if gotSession.Status != "closed" {
+		t.Fatalf("session status = %q, want closed (slot freed by repair)", gotSession.Status)
+	}
+}
+
+// Regression for the bypassable confirmation window: a worker that strands, is
+// respawned on the SAME session bead, recovers (observed alive for a tick), then
+// re-strands must NOT be repaired on the first episode's stale marker. The alive
+// tick clears stranded_event_emitted_at, so episode 2 stamps a FRESH marker and
+// the repair defers again even though wall-clock time is well past the window.
+func TestReconcileSessionBeads_StrandedRepairReArmsWindowAfterRecovery(t *testing.T) {
+	env, session, work, rec := strandedRepairReconcileEnv(t)
+
+	// Episode 1: dead runtime + assigned in_progress work → diagnostic stamps
+	// the confirmation marker.
+	runStrandedReconcileTick(t, env, []beads.Bead{session})
+	if got := len(rec.strandedEvents()); got != 1 {
+		t.Fatalf("stranded events after episode 1 = %d, want 1", got)
+	}
+	afterEp1, _ := env.store.Get(session.ID)
+	if strings.TrimSpace(afterEp1.Metadata[strandedEventEmittedKey]) == "" {
+		t.Fatal("episode 1 must stamp stranded_event_emitted_at")
+	}
+
+	// Recovery: the pool respawns the worker on the same session bead; the next
+	// tick observes it ALIVE. clearStrandedEventMarker must drop the marker.
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start (respawn): %v", err)
+	}
+	recovered, _ := env.store.Get(session.ID)
+	runStrandedReconcileTick(t, env, []beads.Bead{recovered})
+	afterRecovery, _ := env.store.Get(session.ID)
+	if got := strings.TrimSpace(afterRecovery.Metadata[strandedEventEmittedKey]); got != "" {
+		t.Fatalf("stranded marker must be cleared on an alive tick, got %q", got)
+	}
+
+	// Advance well past a window that episode 1's marker would have satisfied.
+	env.clk.Time = env.clk.Time.Add(strandedRepairConfirmGrace + time.Minute)
+
+	// Episode 2: the worker re-strands (runtime dead again) still holding the
+	// same in_progress work.
+	if err := env.sp.Stop("worker"); err != nil {
+		t.Fatalf("Stop (re-strand): %v", err)
+	}
+	restranded, _ := env.store.Get(session.ID)
+	runStrandedReconcileTick(t, env, []beads.Bead{restranded})
+
+	// The repair must DEFER: episode 2's marker was just stamped, so it is inside
+	// a fresh window. The live claim on the work must survive.
+	gotWork, _ := env.store.Get(work.ID)
+	if gotWork.Status != "in_progress" || gotWork.Assignee != session.ID {
+		t.Fatalf("work must stay claimed (repair fired on a stale window); got status=%q assignee=%q", gotWork.Status, gotWork.Assignee)
+	}
+	gotSession, _ := env.store.Get(session.ID)
+	if gotSession.Status == "closed" {
+		t.Fatal("session must stay open (repair fired on a stale window)")
+	}
+	// Per-episode observability: a distinct diagnostic fired for episode 2.
+	if got := len(rec.strandedEvents()); got != 2 {
+		t.Fatalf("stranded events = %d, want 2 (one per episode)", got)
+	}
+}
+
 func TestCollectSessionAssignedWorkIncludesAssignedWisp(t *testing.T) {
 	store := beads.NewMemStore()
 	session := beads.Bead{

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -1024,6 +1024,27 @@
         ],
         "type": "object"
       },
+      "BeadDeadAssigneeReopenedPayload": {
+        "additionalProperties": false,
+        "properties": {
+          "bead_id": {
+            "description": "ID of the reopened work bead (also the envelope Subject).",
+            "type": "string"
+          },
+          "dead_assignee": {
+            "description": "The assignee identity that resolved to no open session bead, cleared by the reopen.",
+            "type": "string"
+          },
+          "routed_to": {
+            "description": "The gc.routed_to target the bead stays routed to after the reopen, when set.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bead_id"
+        ],
+        "type": "object"
+      },
       "BeadDepsResponse": {
         "additionalProperties": false,
         "properties": {
@@ -2202,6 +2223,9 @@
           },
           {
             "$ref": "#/components/schemas/BeadClaimRejectedPayload"
+          },
+          {
+            "$ref": "#/components/schemas/BeadDeadAssigneeReopenedPayload"
           },
           {
             "$ref": "#/components/schemas/BeadEventPayload"
@@ -8234,6 +8258,7 @@
             "bead.claim_rejected": "#/components/schemas/TypedEventStreamEnvelopeBeadClaimRejected",
             "bead.closed": "#/components/schemas/TypedEventStreamEnvelopeBeadClosed",
             "bead.created": "#/components/schemas/TypedEventStreamEnvelopeBeadCreated",
+            "bead.dead_assignee_reopened": "#/components/schemas/TypedEventStreamEnvelopeBeadDeadAssigneeReopened",
             "bead.deleted": "#/components/schemas/TypedEventStreamEnvelopeBeadDeleted",
             "bead.updated": "#/components/schemas/TypedEventStreamEnvelopeBeadUpdated",
             "bead.worktree.reap_skipped": "#/components/schemas/TypedEventStreamEnvelopeBeadWorktreeReapSkipped",
@@ -8315,6 +8340,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeBeadCreated"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeBeadDeadAssigneeReopened"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeBeadDeleted"
@@ -8680,6 +8708,57 @@
           "payload"
         ],
         "title": "TypedEventStreamEnvelope bead.created",
+        "type": "object"
+      },
+      "TypedEventStreamEnvelopeBeadDeadAssigneeReopened": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/BeadDeadAssigneeReopenedPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "bead.dead_assignee_reopened",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope bead.dead_assignee_reopened",
         "type": "object"
       },
       "TypedEventStreamEnvelopeBeadDeleted": {
@@ -9350,6 +9429,7 @@
                 "bead.worktree.reaped",
                 "bead.worktree.reap_skipped",
                 "bead.claim_rejected",
+                "bead.dead_assignee_reopened",
                 "mail.sent",
                 "mail.read",
                 "mail.archived",
@@ -12332,6 +12412,7 @@
             "bead.claim_rejected": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadClaimRejected",
             "bead.closed": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadClosed",
             "bead.created": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadCreated",
+            "bead.dead_assignee_reopened": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened",
             "bead.deleted": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeleted",
             "bead.updated": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadUpdated",
             "bead.worktree.reap_skipped": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadWorktreeReapSkipped",
@@ -12413,6 +12494,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadCreated"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeleted"
@@ -12790,6 +12874,61 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope bead.created",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/BeadDeadAssigneeReopenedPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "bead.dead_assignee_reopened",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope bead.dead_assignee_reopened",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopeBeadDeleted": {
@@ -13511,6 +13650,7 @@
                 "bead.worktree.reaped",
                 "bead.worktree.reap_skipped",
                 "bead.claim_rejected",
+                "bead.dead_assignee_reopened",
                 "mail.sent",
                 "mail.read",
                 "mail.archived",

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -1024,6 +1024,27 @@
         ],
         "type": "object"
       },
+      "BeadDeadAssigneeReopenedPayload": {
+        "additionalProperties": false,
+        "properties": {
+          "bead_id": {
+            "description": "ID of the reopened work bead (also the envelope Subject).",
+            "type": "string"
+          },
+          "dead_assignee": {
+            "description": "The assignee identity that resolved to no open session bead, cleared by the reopen.",
+            "type": "string"
+          },
+          "routed_to": {
+            "description": "The gc.routed_to target the bead stays routed to after the reopen, when set.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bead_id"
+        ],
+        "type": "object"
+      },
       "BeadDepsResponse": {
         "additionalProperties": false,
         "properties": {
@@ -2202,6 +2223,9 @@
           },
           {
             "$ref": "#/components/schemas/BeadClaimRejectedPayload"
+          },
+          {
+            "$ref": "#/components/schemas/BeadDeadAssigneeReopenedPayload"
           },
           {
             "$ref": "#/components/schemas/BeadEventPayload"
@@ -8234,6 +8258,7 @@
             "bead.claim_rejected": "#/components/schemas/TypedEventStreamEnvelopeBeadClaimRejected",
             "bead.closed": "#/components/schemas/TypedEventStreamEnvelopeBeadClosed",
             "bead.created": "#/components/schemas/TypedEventStreamEnvelopeBeadCreated",
+            "bead.dead_assignee_reopened": "#/components/schemas/TypedEventStreamEnvelopeBeadDeadAssigneeReopened",
             "bead.deleted": "#/components/schemas/TypedEventStreamEnvelopeBeadDeleted",
             "bead.updated": "#/components/schemas/TypedEventStreamEnvelopeBeadUpdated",
             "bead.worktree.reap_skipped": "#/components/schemas/TypedEventStreamEnvelopeBeadWorktreeReapSkipped",
@@ -8315,6 +8340,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeBeadCreated"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeBeadDeadAssigneeReopened"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeBeadDeleted"
@@ -8680,6 +8708,57 @@
           "payload"
         ],
         "title": "TypedEventStreamEnvelope bead.created",
+        "type": "object"
+      },
+      "TypedEventStreamEnvelopeBeadDeadAssigneeReopened": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/BeadDeadAssigneeReopenedPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "bead.dead_assignee_reopened",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope bead.dead_assignee_reopened",
         "type": "object"
       },
       "TypedEventStreamEnvelopeBeadDeleted": {
@@ -9350,6 +9429,7 @@
                 "bead.worktree.reaped",
                 "bead.worktree.reap_skipped",
                 "bead.claim_rejected",
+                "bead.dead_assignee_reopened",
                 "mail.sent",
                 "mail.read",
                 "mail.archived",
@@ -12332,6 +12412,7 @@
             "bead.claim_rejected": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadClaimRejected",
             "bead.closed": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadClosed",
             "bead.created": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadCreated",
+            "bead.dead_assignee_reopened": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened",
             "bead.deleted": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeleted",
             "bead.updated": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadUpdated",
             "bead.worktree.reap_skipped": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadWorktreeReapSkipped",
@@ -12413,6 +12494,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadCreated"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeleted"
@@ -12790,6 +12874,61 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope bead.created",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/BeadDeadAssigneeReopenedPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "bead.dead_assignee_reopened",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope bead.dead_assignee_reopened",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopeBeadDeleted": {
@@ -13511,6 +13650,7 @@
                 "bead.worktree.reaped",
                 "bead.worktree.reap_skipped",
                 "bead.claim_rejected",
+                "bead.dead_assignee_reopened",
                 "mail.sent",
                 "mail.read",
                 "mail.archived",

--- a/internal/api/event_payloads.go
+++ b/internal/api/event_payloads.go
@@ -505,6 +505,34 @@ func SessionStrandedPayloadJSON(sessionID, sessionName, template string, workBea
 	return b
 }
 
+// BeadDeadAssigneeReopenedPayload is the typed payload for
+// bead.dead_assignee_reopened events. Emitted when the reconciler reopens a
+// routed work bead whose assignee no longer maps to any open session bead —
+// the owning session closed/retired while the bead stayed assigned, so it sat
+// open+routed but unclaimable. The reconciler clears DeadAssignee (empty-string
+// clear) so the RoutedTo pool can reclaim BeadID; the payload makes the repair
+// observable for eval/audit (mirrors BeadClaimRejectedPayload).
+type BeadDeadAssigneeReopenedPayload struct {
+	BeadID       string `json:"bead_id" doc:"ID of the reopened work bead (also the envelope Subject)."`
+	DeadAssignee string `json:"dead_assignee,omitempty" doc:"The assignee identity that resolved to no open session bead, cleared by the reopen."`
+	RoutedTo     string `json:"routed_to,omitempty" doc:"The gc.routed_to target the bead stays routed to after the reopen, when set."`
+}
+
+// IsEventPayload marks BeadDeadAssigneeReopenedPayload as an events.Payload variant.
+func (BeadDeadAssigneeReopenedPayload) IsEventPayload() {}
+
+// BeadDeadAssigneeReopenedPayloadJSON builds the JSON wire form for attachment
+// to an events.Event.Payload field. DeadAssignee and RoutedTo are emitted only
+// when non-empty.
+func BeadDeadAssigneeReopenedPayloadJSON(beadID, deadAssignee, routedTo string) json.RawMessage {
+	b, _ := json.Marshal(BeadDeadAssigneeReopenedPayload{
+		BeadID:       beadID,
+		DeadAssignee: deadAssignee,
+		RoutedTo:     routedTo,
+	})
+	return b
+}
+
 func init() {
 	// mail.* — all seven types share one payload shape.
 	events.RegisterPayload(events.MailSent, MailEventPayload{})
@@ -520,6 +548,7 @@ func init() {
 	events.RegisterPayload(events.BeadUpdated, BeadEventPayload{})
 	events.RegisterPayload(events.BeadClosed, BeadEventPayload{})
 	events.RegisterPayload(events.BeadDeleted, BeadEventPayload{})
+	events.RegisterPayload(events.BeadDeadAssigneeReopened, BeadDeadAssigneeReopenedPayload{})
 
 	// session.* / convoy.* / controller.* / city.* / order.* /
 	// provider.* — these events carry no structured payload today;

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -657,6 +657,18 @@ type BeadCreateInputBody struct {
 	Type *string `json:"type,omitempty"`
 }
 
+// BeadDeadAssigneeReopenedPayload defines model for BeadDeadAssigneeReopenedPayload.
+type BeadDeadAssigneeReopenedPayload struct {
+	// BeadId ID of the reopened work bead (also the envelope Subject).
+	BeadId string `json:"bead_id"`
+
+	// DeadAssignee The assignee identity that resolved to no open session bead, cleared by the reopen.
+	DeadAssignee *string `json:"dead_assignee,omitempty"`
+
+	// RoutedTo The gc.routed_to target the bead stays routed to after the reopen, when set.
+	RoutedTo *string `json:"routed_to,omitempty"`
+}
+
 // BeadDepsResponse defines model for BeadDepsResponse.
 type BeadDepsResponse struct {
 	Children *[]Bead `json:"children"`
@@ -3484,6 +3496,21 @@ type TypedEventStreamEnvelopeBeadCreated struct {
 	Workflow  *WorkflowEventProjection `json:"workflow,omitempty"`
 }
 
+// TypedEventStreamEnvelopeBeadDeadAssigneeReopened defines model for TypedEventStreamEnvelopeBeadDeadAssigneeReopened.
+type TypedEventStreamEnvelopeBeadDeadAssigneeReopened struct {
+	Actor     string                          `json:"actor"`
+	Message   *string                         `json:"message,omitempty"`
+	Payload   BeadDeadAssigneeReopenedPayload `json:"payload"`
+	RunId     *string                         `json:"run_id,omitempty"`
+	Seq       int64                           `json:"seq"`
+	SessionId *string                         `json:"session_id,omitempty"`
+	StepId    *string                         `json:"step_id,omitempty"`
+	Subject   *string                         `json:"subject,omitempty"`
+	Ts        time.Time                       `json:"ts"`
+	Type      string                          `json:"type"`
+	Workflow  *WorkflowEventProjection        `json:"workflow,omitempty"`
+}
+
 // TypedEventStreamEnvelopeBeadDeleted defines model for TypedEventStreamEnvelopeBeadDeleted.
 type TypedEventStreamEnvelopeBeadDeleted struct {
 	Actor     string                   `json:"actor"`
@@ -4585,6 +4612,22 @@ type TypedTaggedEventStreamEnvelopeBeadCreated struct {
 	Ts        time.Time                `json:"ts"`
 	Type      string                   `json:"type"`
 	Workflow  *WorkflowEventProjection `json:"workflow,omitempty"`
+}
+
+// TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened defines model for TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened.
+type TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened struct {
+	Actor     string                          `json:"actor"`
+	City      string                          `json:"city"`
+	Message   *string                         `json:"message,omitempty"`
+	Payload   BeadDeadAssigneeReopenedPayload `json:"payload"`
+	RunId     *string                         `json:"run_id,omitempty"`
+	Seq       int64                           `json:"seq"`
+	SessionId *string                         `json:"session_id,omitempty"`
+	StepId    *string                         `json:"step_id,omitempty"`
+	Subject   *string                         `json:"subject,omitempty"`
+	Ts        time.Time                       `json:"ts"`
+	Type      string                          `json:"type"`
+	Workflow  *WorkflowEventProjection        `json:"workflow,omitempty"`
 }
 
 // TypedTaggedEventStreamEnvelopeBeadDeleted defines model for TypedTaggedEventStreamEnvelopeBeadDeleted.
@@ -7106,6 +7149,32 @@ func (t *EventPayload) MergeBeadClaimRejectedPayload(v BeadClaimRejectedPayload)
 	return err
 }
 
+// AsBeadDeadAssigneeReopenedPayload returns the union data inside the EventPayload as a BeadDeadAssigneeReopenedPayload
+func (t EventPayload) AsBeadDeadAssigneeReopenedPayload() (BeadDeadAssigneeReopenedPayload, error) {
+	var body BeadDeadAssigneeReopenedPayload
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromBeadDeadAssigneeReopenedPayload overwrites any union data inside the EventPayload as the provided BeadDeadAssigneeReopenedPayload
+func (t *EventPayload) FromBeadDeadAssigneeReopenedPayload(v BeadDeadAssigneeReopenedPayload) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeBeadDeadAssigneeReopenedPayload performs a merge with any union data inside the EventPayload, using the provided BeadDeadAssigneeReopenedPayload
+func (t *EventPayload) MergeBeadDeadAssigneeReopenedPayload(v BeadDeadAssigneeReopenedPayload) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsBeadEventPayload returns the union data inside the EventPayload as a BeadEventPayload
 func (t EventPayload) AsBeadEventPayload() (BeadEventPayload, error) {
 	var body BeadEventPayload
@@ -8266,6 +8335,34 @@ func (t *TypedEventStreamEnvelope) FromTypedEventStreamEnvelopeBeadCreated(v Typ
 // MergeTypedEventStreamEnvelopeBeadCreated performs a merge with any union data inside the TypedEventStreamEnvelope, using the provided TypedEventStreamEnvelopeBeadCreated
 func (t *TypedEventStreamEnvelope) MergeTypedEventStreamEnvelopeBeadCreated(v TypedEventStreamEnvelopeBeadCreated) error {
 	v.Type = "bead.created"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsTypedEventStreamEnvelopeBeadDeadAssigneeReopened returns the union data inside the TypedEventStreamEnvelope as a TypedEventStreamEnvelopeBeadDeadAssigneeReopened
+func (t TypedEventStreamEnvelope) AsTypedEventStreamEnvelopeBeadDeadAssigneeReopened() (TypedEventStreamEnvelopeBeadDeadAssigneeReopened, error) {
+	var body TypedEventStreamEnvelopeBeadDeadAssigneeReopened
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromTypedEventStreamEnvelopeBeadDeadAssigneeReopened overwrites any union data inside the TypedEventStreamEnvelope as the provided TypedEventStreamEnvelopeBeadDeadAssigneeReopened
+func (t *TypedEventStreamEnvelope) FromTypedEventStreamEnvelopeBeadDeadAssigneeReopened(v TypedEventStreamEnvelopeBeadDeadAssigneeReopened) error {
+	v.Type = "bead.dead_assignee_reopened"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeTypedEventStreamEnvelopeBeadDeadAssigneeReopened performs a merge with any union data inside the TypedEventStreamEnvelope, using the provided TypedEventStreamEnvelopeBeadDeadAssigneeReopened
+func (t *TypedEventStreamEnvelope) MergeTypedEventStreamEnvelopeBeadDeadAssigneeReopened(v TypedEventStreamEnvelopeBeadDeadAssigneeReopened) error {
+	v.Type = "bead.dead_assignee_reopened"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -10258,6 +10355,8 @@ func (t TypedEventStreamEnvelope) ValueByDiscriminator() (interface{}, error) {
 		return t.AsTypedEventStreamEnvelopeBeadClosed()
 	case "bead.created":
 		return t.AsTypedEventStreamEnvelopeBeadCreated()
+	case "bead.dead_assignee_reopened":
+		return t.AsTypedEventStreamEnvelopeBeadDeadAssigneeReopened()
 	case "bead.deleted":
 		return t.AsTypedEventStreamEnvelopeBeadDeleted()
 	case "bead.updated":
@@ -10485,6 +10584,34 @@ func (t *TypedTaggedEventStreamEnvelope) FromTypedTaggedEventStreamEnvelopeBeadC
 // MergeTypedTaggedEventStreamEnvelopeBeadCreated performs a merge with any union data inside the TypedTaggedEventStreamEnvelope, using the provided TypedTaggedEventStreamEnvelopeBeadCreated
 func (t *TypedTaggedEventStreamEnvelope) MergeTypedTaggedEventStreamEnvelopeBeadCreated(v TypedTaggedEventStreamEnvelopeBeadCreated) error {
 	v.Type = "bead.created"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsTypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened returns the union data inside the TypedTaggedEventStreamEnvelope as a TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened
+func (t TypedTaggedEventStreamEnvelope) AsTypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened() (TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened, error) {
+	var body TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromTypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened overwrites any union data inside the TypedTaggedEventStreamEnvelope as the provided TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened
+func (t *TypedTaggedEventStreamEnvelope) FromTypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened(v TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened) error {
+	v.Type = "bead.dead_assignee_reopened"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeTypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened performs a merge with any union data inside the TypedTaggedEventStreamEnvelope, using the provided TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened
+func (t *TypedTaggedEventStreamEnvelope) MergeTypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened(v TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened) error {
+	v.Type = "bead.dead_assignee_reopened"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -12477,6 +12604,8 @@ func (t TypedTaggedEventStreamEnvelope) ValueByDiscriminator() (interface{}, err
 		return t.AsTypedTaggedEventStreamEnvelopeBeadClosed()
 	case "bead.created":
 		return t.AsTypedTaggedEventStreamEnvelopeBeadCreated()
+	case "bead.dead_assignee_reopened":
+		return t.AsTypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened()
 	case "bead.deleted":
 		return t.AsTypedTaggedEventStreamEnvelopeBeadDeleted()
 	case "bead.updated":

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -1024,6 +1024,27 @@
         ],
         "type": "object"
       },
+      "BeadDeadAssigneeReopenedPayload": {
+        "additionalProperties": false,
+        "properties": {
+          "bead_id": {
+            "description": "ID of the reopened work bead (also the envelope Subject).",
+            "type": "string"
+          },
+          "dead_assignee": {
+            "description": "The assignee identity that resolved to no open session bead, cleared by the reopen.",
+            "type": "string"
+          },
+          "routed_to": {
+            "description": "The gc.routed_to target the bead stays routed to after the reopen, when set.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bead_id"
+        ],
+        "type": "object"
+      },
       "BeadDepsResponse": {
         "additionalProperties": false,
         "properties": {
@@ -2202,6 +2223,9 @@
           },
           {
             "$ref": "#/components/schemas/BeadClaimRejectedPayload"
+          },
+          {
+            "$ref": "#/components/schemas/BeadDeadAssigneeReopenedPayload"
           },
           {
             "$ref": "#/components/schemas/BeadEventPayload"
@@ -8234,6 +8258,7 @@
             "bead.claim_rejected": "#/components/schemas/TypedEventStreamEnvelopeBeadClaimRejected",
             "bead.closed": "#/components/schemas/TypedEventStreamEnvelopeBeadClosed",
             "bead.created": "#/components/schemas/TypedEventStreamEnvelopeBeadCreated",
+            "bead.dead_assignee_reopened": "#/components/schemas/TypedEventStreamEnvelopeBeadDeadAssigneeReopened",
             "bead.deleted": "#/components/schemas/TypedEventStreamEnvelopeBeadDeleted",
             "bead.updated": "#/components/schemas/TypedEventStreamEnvelopeBeadUpdated",
             "bead.worktree.reap_skipped": "#/components/schemas/TypedEventStreamEnvelopeBeadWorktreeReapSkipped",
@@ -8315,6 +8340,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeBeadCreated"
+          },
+          {
+            "$ref": "#/components/schemas/TypedEventStreamEnvelopeBeadDeadAssigneeReopened"
           },
           {
             "$ref": "#/components/schemas/TypedEventStreamEnvelopeBeadDeleted"
@@ -8680,6 +8708,57 @@
           "payload"
         ],
         "title": "TypedEventStreamEnvelope bead.created",
+        "type": "object"
+      },
+      "TypedEventStreamEnvelopeBeadDeadAssigneeReopened": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/BeadDeadAssigneeReopenedPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "bead.dead_assignee_reopened",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload"
+        ],
+        "title": "TypedEventStreamEnvelope bead.dead_assignee_reopened",
         "type": "object"
       },
       "TypedEventStreamEnvelopeBeadDeleted": {
@@ -9350,6 +9429,7 @@
                 "bead.worktree.reaped",
                 "bead.worktree.reap_skipped",
                 "bead.claim_rejected",
+                "bead.dead_assignee_reopened",
                 "mail.sent",
                 "mail.read",
                 "mail.archived",
@@ -12332,6 +12412,7 @@
             "bead.claim_rejected": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadClaimRejected",
             "bead.closed": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadClosed",
             "bead.created": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadCreated",
+            "bead.dead_assignee_reopened": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened",
             "bead.deleted": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeleted",
             "bead.updated": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadUpdated",
             "bead.worktree.reap_skipped": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadWorktreeReapSkipped",
@@ -12413,6 +12494,9 @@
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadCreated"
+          },
+          {
+            "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened"
           },
           {
             "$ref": "#/components/schemas/TypedTaggedEventStreamEnvelopeBeadDeleted"
@@ -12790,6 +12874,61 @@
           "city"
         ],
         "title": "TypedTaggedEventStreamEnvelope bead.created",
+        "type": "object"
+      },
+      "TypedTaggedEventStreamEnvelopeBeadDeadAssigneeReopened": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/BeadDeadAssigneeReopenedPayload"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "seq": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "const": "bead.dead_assignee_reopened",
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowEventProjection"
+          }
+        },
+        "required": [
+          "seq",
+          "type",
+          "ts",
+          "actor",
+          "payload",
+          "city"
+        ],
+        "title": "TypedTaggedEventStreamEnvelope bead.dead_assignee_reopened",
         "type": "object"
       },
       "TypedTaggedEventStreamEnvelopeBeadDeleted": {
@@ -13511,6 +13650,7 @@
                 "bead.worktree.reaped",
                 "bead.worktree.reap_skipped",
                 "bead.claim_rejected",
+                "bead.dead_assignee_reopened",
                 "mail.sent",
                 "mail.read",
                 "mail.archived",

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -31,18 +31,27 @@ const (
 	// an idempotent no-op rather than fanning out a second concurrent claim.
 	// Turns the otherwise-silent lost-claim race (RCA gc-typpc: one bead, four
 	// concurrent polecat claims) into an observable signal. ADR-0009.
-	BeadClaimRejected  = "bead.claim_rejected"
-	MailSent           = "mail.sent"
-	MailRead           = "mail.read"
-	MailArchived       = "mail.archived"
-	MailMarkedRead     = "mail.marked_read"
-	MailMarkedUnread   = "mail.marked_unread"
-	MailReplied        = "mail.replied"
-	MailDeleted        = "mail.deleted"
-	SessionDraining    = "session.draining"
-	SessionUndrained   = "session.undrained"
-	SessionQuarantined = "session.quarantined"
-	SessionIdleKilled  = "session.idle_killed"
+	BeadClaimRejected = "bead.claim_rejected"
+	// BeadDeadAssigneeReopened fires when the reconciler reopens a routed work
+	// bead whose assignee resolves to no open session bead — the owning session
+	// closed/retired while the bead stayed assigned, leaving it open+routed but
+	// invisible to every claim probe (pool tier and demand require --unassigned;
+	// the hook requires an empty assignee). releaseOrphanedPoolAssignments clears
+	// the dead assignee so the pool can reclaim it; this event turns that
+	// otherwise-silent repair into an observable signal (mirrors the
+	// bead.claim_rejected shape).
+	BeadDeadAssigneeReopened = "bead.dead_assignee_reopened"
+	MailSent                 = "mail.sent"
+	MailRead                 = "mail.read"
+	MailArchived             = "mail.archived"
+	MailMarkedRead           = "mail.marked_read"
+	MailMarkedUnread         = "mail.marked_unread"
+	MailReplied              = "mail.replied"
+	MailDeleted              = "mail.deleted"
+	SessionDraining          = "session.draining"
+	SessionUndrained         = "session.undrained"
+	SessionQuarantined       = "session.quarantined"
+	SessionIdleKilled        = "session.idle_killed"
 	// SessionMaxAgeKilled fires when the controller preemptively restarts a
 	// long-running session because its wall-clock age exceeded the agent's
 	// max_session_age threshold. Motivating case: provider SDKs that cache
@@ -221,6 +230,7 @@ var KnownEventTypes = []string{
 	BeadCreated, BeadClosed, BeadDeleted, BeadUpdated,
 	BeadWorktreeReaped, BeadWorktreeReapSkipped,
 	BeadClaimRejected,
+	BeadDeadAssigneeReopened,
 	MailSent, MailRead, MailArchived, MailMarkedRead, MailMarkedUnread,
 	MailReplied, MailDeleted,
 	ConvoyCreated, ConvoyClosed,


### PR DESCRIPTION
## Why

Two divergence-state classes let beads stall invisibly. Stranded in_progress work whose assignee is a dead pool worker was only *diagnosed*, never repaired, so it sat assigned to a dead session forever. And an open + `gc.routed_to` + dead-assignee bead is invisible to every probe (they all require `--unassigned`), so the pool never reclaims it.

## What changed

- **Repair stranded pool-worker work** (`cmd/gc/session_reconciler.go`, `session_beads.go`): the stranded-pool-worker path now wires the existing, tested `unclaimWorkAssignedToRetiredSessionBead` + `closeBead` helpers to actually unassign/reopen the work and close the dead session bead, instead of only emitting a diagnostic. It fires only after confirmed continuous non-liveness (see below), and if any unassign fails it leaves the session bead open and retries next tick rather than closing over a stale assignee.
- **Continuous-non-liveness confirmation window**: the repair gates on the `stranded_event_emitted_at` marker aging past a 2-minute grace, and (this is the load-bearing part) the marker is cleared on any tick where the session is observed alive (`clearStrandedEventMarker`, gated on `target.alive`, the exact complement of the `!target.alive` strand condition). So every distinct stranding episode ages a fresh window; a worker that strands, gets respawned/recovered, then re-strands cannot be repaired on a stale marker from the earlier episode.
- **Observability for the existing Class-2 sweep** (`cmd/gc/dead_assignee_event.go`, `city_runtime.go`, event/openapi plumbing): the pre-existing `releaseOrphanedPoolAssignments` already clears open+routed+dead-assignee beads with full liveness gating; this adds a `bead.dead_assignee_reopened` event so those repairs are no longer silent. No new destructive path was added for Class 2.

## Test plan

- `go build ./...`, `go vet ./cmd/gc/`, `gofmt -l`: clean
- `go test ./cmd/gc/ -run 'Strand|DeadAssignee|Reassign|Unclaim|ReleaseOrphaned|Reconcile'`: pass
- New tests: recover-then-restrand re-arms the window (repair defers on the fresh episode); continuous-window repair fires end-to-end through the real reconcile; a failed unassign keeps the session bead open; the dead-assignee event carries the typed payload.

## Known follow-up

Narrow residual: if the *durable* marker-clear write fails repeatedly during a store outage aligned precisely with a respawn/re-strand window, a stale marker could survive and fire once. It is low-probability, defended by the `releaseOrphanedPoolAssignments` backstop, and is the same cross-restart durability tradeoff the diagnostic-emit path already accepts. A process-local recovered-since guard (mirroring the emit path) would close it; tracked as a follow-up rather than blocking this change.
