### PR TITLE
fix(session): confirm orphans dead before (re)starting a session; subreaper-aware reap; token-fenced async stop

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -283,7 +283,7 @@ func drainAckAsyncStopKey(sessionID, name string) string {
 // for the async drain-ack stop path (see queueDrainAckAsyncStop).
 var drainAckAsyncStopPokeController = pokeController
 
-func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, sessionID, name string, tracker *asyncStartTracker, stderr io.Writer) {
+func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, sessionID, name, expectedToken string, tracker *asyncStartTracker, stderr io.Writer) {
 	name = strings.TrimSpace(name)
 	if name == "" || sp == nil {
 		return
@@ -303,6 +303,19 @@ func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provi
 			}
 			done()
 		}()
+		// Token fence (mirrors verifiedStop): this kill targets the session by
+		// NAME and may fire long after it was queued. If the name was reused by
+		// a re-woken replacement in the meantime, its GC_INSTANCE_TOKEN differs
+		// from the one we intended to stop; killing it would take out a live,
+		// working session. Skip on a definite mismatch. An empty expected or
+		// live token means "cannot verify" and falls through to the kill,
+		// matching verifiedStop's conservative posture.
+		if expectedToken != "" {
+			if actualToken, _ := sp.GetMeta(name, "GC_INSTANCE_TOKEN"); actualToken != "" && actualToken != expectedToken {
+				fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s skipped: instance token mismatch (session was replaced)\n", name) //nolint:errcheck
+				return
+			}
+		}
 		if err := workerKillSessionTargetWithConfig(cityPath, store, sp, cfg, name); err != nil && !runtime.IsSessionGone(err) {
 			fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s: %v\n", name, err) //nolint:errcheck
 			return
@@ -577,7 +590,7 @@ func reconcileDrainAckStopPending(
 		// mutates only the async tracker, so the bead is untouched and the snapshot
 		// stays coherent — a zero result (applyTo no-op) matches the old refresh of
 		// the unmutated bead.
-		queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
+		queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, session.Metadata["instance_token"], asyncStopTracker, stderr)
 		return true, drainAckFinalizeResult{}
 	}
 	return true, finalizeDrainAckStoppedSession(
@@ -620,7 +633,7 @@ func finalizeDrainAckStopPendingSessions(
 		name := strings.TrimSpace(info.SessionNameMetadata)
 		obs, err := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, session.ID, nil)
 		if err != nil || obs.Running || obs.Alive {
-			queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
+			queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, session.Metadata["instance_token"], asyncStopTracker, stderr)
 			continue
 		}
 		// Pool-managed stop-pending beads close here instead of staying open as
@@ -1871,7 +1884,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								// reader. Pre-pass-masked (STEP6-PREPASS-AUDIT group 3).
 								infoByID[session.ID] = infoByID[session.ID].ApplyPatch(sessionpkg.DrainAckStopPendingPatch(clk.Now().UTC()))
 								clearDrainTrackerForStopPending(session, dt)
-								queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
+								queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, session.Metadata["instance_token"], asyncStopTracker, stderr)
 								if trace != nil {
 									trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonOrphaned, TraceOutcomeStopPending, template, name, nil)
 								}
@@ -2218,7 +2231,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							// orphan-arm site above (STEP6-PREPASS-AUDIT group 3).
 							infoByID[session.ID] = infoByID[session.ID].ApplyPatch(sessionpkg.DrainAckStopPendingPatch(clk.Now().UTC()))
 							clearDrainTrackerForStopPending(session, dt)
-							queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
+							queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, session.Metadata["instance_token"], asyncStopTracker, stderr)
 							if trace != nil {
 								trace.RecordDecision(TraceSiteReconcilerDrainAck, TraceReasonAcknowledged, TraceOutcomeStopPending, tp.TemplateName, name, nil)
 							}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1089,7 +1089,7 @@ func TestQueueDrainAckAsyncStopTracksShutdownWait(t *testing.T) {
 	}
 	var stderr synchronizedBuffer
 	tracker := &asyncStartTracker{}
-	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", tracker, &stderr)
+	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", "", tracker, &stderr)
 
 	select {
 	case <-sp.stopStarted:
@@ -1130,14 +1130,14 @@ func TestQueueDrainAckAsyncStopDedupScopedToTracker(t *testing.T) {
 	var stderr synchronizedBuffer
 	firstTracker := &asyncStartTracker{}
 	secondTracker := &asyncStartTracker{}
-	queueDrainAckAsyncStop("", store, first, &config.City{}, "gc-worker", "worker", firstTracker, &stderr)
+	queueDrainAckAsyncStop("", store, first, &config.City{}, "gc-worker", "worker", "", firstTracker, &stderr)
 	select {
 	case <-first.stopStarted:
 	case <-time.After(time.Second):
 		t.Fatal("first async drain-ack stop did not start")
 	}
 
-	queueDrainAckAsyncStop("", store, second, &config.City{}, "gc-worker", "worker", secondTracker, &stderr)
+	queueDrainAckAsyncStop("", store, second, &config.City{}, "gc-worker", "worker", "", secondTracker, &stderr)
 	select {
 	case <-second.stopStarted:
 	case <-time.After(time.Second):
@@ -1163,7 +1163,7 @@ func TestQueueDrainAckAsyncStopRecoversStopPanic(t *testing.T) {
 	}
 	var stderr synchronizedBuffer
 	tracker := &asyncStartTracker{}
-	queueDrainAckAsyncStop(t.TempDir(), store, sp, &config.City{}, "gc-worker", "worker", tracker, &stderr)
+	queueDrainAckAsyncStop(t.TempDir(), store, sp, &config.City{}, "gc-worker", "worker", "", tracker, &stderr)
 
 	select {
 	case <-sp.stopStarted:
@@ -1206,7 +1206,7 @@ func TestQueueDrainAckAsyncStopPokesAfterSuccessfulStop(t *testing.T) {
 	}
 	var stderr synchronizedBuffer
 	tracker := &asyncStartTracker{}
-	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", tracker, &stderr)
+	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", "", tracker, &stderr)
 	if !tracker.wait(time.Second) {
 		t.Fatal("async drain-ack stop did not complete")
 	}
@@ -1243,7 +1243,7 @@ func TestQueueDrainAckAsyncStopDoesNotPokeOnHardError(t *testing.T) {
 	sp.StopErrors = map[string]error{"worker": errors.New("hard kill error")}
 	var stderr synchronizedBuffer
 	tracker := &asyncStartTracker{}
-	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", tracker, &stderr)
+	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", "", tracker, &stderr)
 	if !tracker.wait(time.Second) {
 		t.Fatal("async drain-ack stop did not complete")
 	}
@@ -1253,6 +1253,82 @@ func TestQueueDrainAckAsyncStopDoesNotPokeOnHardError(t *testing.T) {
 	pokeMu.Unlock()
 	if got != 0 {
 		t.Fatalf("poke count = %d, want 0 (hard error must not poke)", got)
+	}
+}
+
+// TestQueueDrainAckAsyncStopTokenFenceSkipsReusedName verifies the async
+// drain-ack stop refuses to kill when the runtime's live GC_INSTANCE_TOKEN no
+// longer matches the token captured when the stop was queued: by kill time the
+// name has been reused by a re-woken replacement, and killing it would take out
+// a live session (mirrors verifiedStop).
+// Not parallel — modifies the package-level drainAckAsyncStopPokeController seam.
+func TestQueueDrainAckAsyncStopTokenFenceSkipsReusedName(t *testing.T) {
+	var pokeCalls int
+	var pokeMu sync.Mutex
+	old := drainAckAsyncStopPokeController
+	drainAckAsyncStopPokeController = func(string) error {
+		pokeMu.Lock()
+		pokeCalls++
+		pokeMu.Unlock()
+		return nil
+	}
+	t.Cleanup(func() { drainAckAsyncStopPokeController = old })
+
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// The live session belongs to a replacement with a fresh token.
+	if err := sp.SetMeta("worker", "GC_INSTANCE_TOKEN", "live-token"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+
+	var stderr synchronizedBuffer
+	tracker := &asyncStartTracker{}
+	// We queued the stop for the OLD session (stale token).
+	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", "stale-token", tracker, &stderr)
+	if !tracker.wait(time.Second) {
+		t.Fatal("async drain-ack stop did not complete")
+	}
+
+	if !sp.IsRunning("worker") {
+		t.Fatal("token-fenced async stop killed the name-reused replacement")
+	}
+	if got := stderr.String(); !strings.Contains(got, "instance token mismatch") {
+		t.Fatalf("stderr = %q, want token mismatch diagnostic", got)
+	}
+	pokeMu.Lock()
+	got := pokeCalls
+	pokeMu.Unlock()
+	if got != 0 {
+		t.Fatalf("poke count = %d, want 0 (fenced stop must not poke)", got)
+	}
+}
+
+// TestQueueDrainAckAsyncStopTokenFenceKillsMatchingSession verifies the fence
+// lets the kill proceed when the live token matches the queued token.
+func TestQueueDrainAckAsyncStopTokenFenceKillsMatchingSession(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := sp.SetMeta("worker", "GC_INSTANCE_TOKEN", "live-token"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+
+	var stderr synchronizedBuffer
+	tracker := &asyncStartTracker{}
+	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", "live-token", tracker, &stderr)
+	if !tracker.wait(time.Second) {
+		t.Fatal("async drain-ack stop did not complete")
+	}
+	if sp.IsRunning("worker") {
+		t.Fatal("matching-token async stop did not kill the session")
+	}
+	if got := stderr.String(); strings.Contains(got, "instance token mismatch") {
+		t.Fatalf("stderr = %q, unexpected mismatch on matching token", got)
 	}
 }
 
@@ -1271,7 +1347,7 @@ func TestCityRuntimeShutdownWaitsForTrackedAsyncDrainAckStopsBeforeStopSnapshot(
 		stdout:              ioDiscard{},
 		stderr:              ioDiscard{},
 	}
-	queueDrainAckAsyncStop("", store, sp, cr.cfg, "gc-worker", "worker", &cr.asyncStops, &synchronizedBuffer{})
+	queueDrainAckAsyncStop("", store, sp, cr.cfg, "gc-worker", "worker", "", &cr.asyncStops, &synchronizedBuffer{})
 
 	select {
 	case <-sp.stopStarted:

--- a/internal/pidutil/pidutil.go
+++ b/internal/pidutil/pidutil.go
@@ -4,6 +4,7 @@ package pidutil
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,6 +36,67 @@ func Alive(pid int) bool {
 		return false
 	}
 	return true
+}
+
+// StartTime returns a PID's start time — field 22 (starttime, in clock ticks
+// since boot) of /proc/<pid>/stat — as an opaque token used to disambiguate a
+// recycled PID from the original target. The kernel never reuses a (pid,
+// starttime) pair for the lifetime of a boot, so a changed start time on the
+// same PID proves the original process is gone and an unrelated one now holds
+// the number. It returns an error on platforms without /proc (e.g. darwin) or
+// when the process record is unreadable; callers treat that as "no identity
+// signal available" and fall back to plain liveness.
+//
+// The comm field (field 2) is wrapped in parens and may itself contain spaces
+// and parens, so parsing anchors on the final ')' and counts fields from
+// there: field 3 (state) is the first token after "') '", making field 22
+// (starttime) the token at index 19 of that suffix.
+func StartTime(pid int) (string, error) {
+	if pid <= 0 {
+		return "", fmt.Errorf("pidutil: invalid PID %d", pid)
+	}
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return "", err
+	}
+	stat := string(data)
+	rparen := strings.LastIndexByte(stat, ')')
+	if rparen < 0 || rparen+2 >= len(stat) {
+		return "", fmt.Errorf("pidutil: malformed stat for PID %d", pid)
+	}
+	fields := strings.Fields(stat[rparen+2:])
+	const starttimeIndexAfterComm = 19 // field 22 minus fields 1-3 offset
+	if len(fields) <= starttimeIndexAfterComm {
+		return "", fmt.Errorf("pidutil: stat for PID %d has %d post-comm fields, want > %d", pid, len(fields), starttimeIndexAfterComm)
+	}
+	return fields[starttimeIndexAfterComm], nil
+}
+
+// AliveWithStartTime reports whether pid is alive AND still the same process
+// identified by startTime. It closes the PID-reuse hole in Alive: during a
+// post-SIGKILL reap wait the target's PID can be reaped and recycled to an
+// unrelated new process inside the window, at which point plain Alive would
+// wrongly report the (dead) target as still alive.
+//
+// An empty startTime disables the identity check and falls back to Alive — used
+// on platforms without /proc start-time support (darwin) or when the original
+// start time could not be captured before the wait. A non-empty startTime that
+// no longer matches means the PID was recycled: the original target is dead, so
+// this returns false. When the current start time cannot be read despite Alive
+// reporting true (a transient race, no /proc), it keeps the conservative Alive
+// answer rather than inventing a death.
+func AliveWithStartTime(pid int, startTime string) bool {
+	if !Alive(pid) {
+		return false
+	}
+	if startTime == "" {
+		return true
+	}
+	current, err := StartTime(pid)
+	if err != nil {
+		return true
+	}
+	return current == startTime
 }
 
 // AliveWithCmdline reports whether a PID exists, is not a zombie, and its

--- a/internal/pidutil/pidutil_test.go
+++ b/internal/pidutil/pidutil_test.go
@@ -48,6 +48,71 @@ func TestPSReportsZombieReturnsWhenPSHangs(t *testing.T) {
 	}
 }
 
+func TestStartTimeStableForLivePID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("start-time reads /proc/<pid>/stat on linux")
+	}
+	first, err := StartTime(os.Getpid())
+	if err != nil {
+		t.Fatalf("StartTime(%d): %v", os.Getpid(), err)
+	}
+	if first == "" {
+		t.Fatalf("StartTime(%d) = empty, want a starttime token", os.Getpid())
+	}
+	second, err := StartTime(os.Getpid())
+	if err != nil {
+		t.Fatalf("StartTime(%d) second call: %v", os.Getpid(), err)
+	}
+	if first != second {
+		t.Fatalf("StartTime not stable across calls: %q vs %q", first, second)
+	}
+}
+
+func TestStartTimeRejectsInvalidPID(t *testing.T) {
+	if _, err := StartTime(0); err == nil {
+		t.Fatal("StartTime(0) = nil error, want error")
+	}
+}
+
+// TestAliveWithStartTimeDisambiguatesRecycledPID checks the three branches that
+// close the PID-reuse hole: a matching start time reports alive, a mismatched
+// one (the recycled-PID case) reports dead even though the PID is live, and an
+// empty start time falls back to plain liveness.
+func TestAliveWithStartTimeDisambiguatesRecycledPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("start-time identity uses /proc on linux")
+	}
+	self := os.Getpid()
+	st, err := StartTime(self)
+	if err != nil {
+		t.Fatalf("StartTime(%d): %v", self, err)
+	}
+
+	if !AliveWithStartTime(self, st) {
+		t.Fatalf("AliveWithStartTime(%d, matching) = false, want alive", self)
+	}
+	// A different start-time token models the PID having been reaped and reused
+	// by an unrelated process: the original target must read as dead.
+	if AliveWithStartTime(self, st+"0") {
+		t.Fatalf("AliveWithStartTime(%d, mismatched) = true, want dead (recycled)", self)
+	}
+	// Empty start time disables the identity check (darwin / uncaptured).
+	if !AliveWithStartTime(self, "") {
+		t.Fatalf("AliveWithStartTime(%d, empty) = false, want fallback to Alive", self)
+	}
+}
+
+func TestAliveWithStartTimeDeadPID(t *testing.T) {
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spawning test process: %v", err)
+	}
+	pid := cmd.ProcessState.Pid()
+	if AliveWithStartTime(pid, "12345") {
+		t.Fatalf("AliveWithStartTime(%d, ...) = true for exited process", pid)
+	}
+}
+
 func TestAliveWithCmdlineRejectsUnrelatedLivePID(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("cmdline detection uses /proc on linux")

--- a/internal/runtime/process_control.go
+++ b/internal/runtime/process_control.go
@@ -10,6 +10,14 @@ import (
 // provider-managed process termination from SIGTERM to SIGKILL.
 const ManagedProcessStopGrace = 5 * time.Second
 
+// ManagedProcessReapGrace bounds how long a kill waits, after SIGKILL, for the
+// target to actually leave the run/ready set before reporting it as
+// not-confirmed-dead. A process wedged in uninterruptible sleep (D-state) under
+// I/O can outlive its own SIGKILL until the I/O completes; waiting for
+// confirmed death (gone or zombie) before starting a replacement is what keeps
+// an escaped old process from racing the new one for the same work bead.
+const ManagedProcessReapGrace = 3 * time.Second
+
 // SignalProcessGroup sends sig to the managed process group when possible and
 // falls back to the direct process signal for older sessions or platforms that
 // cannot signal by group.

--- a/internal/runtime/proctable/kill_unix.go
+++ b/internal/runtime/proctable/kill_unix.go
@@ -8,42 +8,84 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/pidutil"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
 // KillByPID terminates pid with SIGTERM, then SIGKILL after
-// runtime.ManagedProcessStopGrace. Already-gone processes are success.
+// runtime.ManagedProcessStopGrace, then waits (bounded by
+// runtime.ManagedProcessReapGrace) for the process to be confirmed dead — gone
+// or a zombie — before returning. Already-gone processes are success. A process
+// that survives its own SIGKILL past the reap grace (e.g. wedged in D-state
+// under I/O) yields an error so callers can refuse to start a name-reused
+// replacement that would race it for the same work.
 func KillByPID(pid int) error {
+	return killByPID(
+		pid,
+		syscall.Kill,
+		pidAlive,
+		pidutil.Alive,
+		runtime.ManagedProcessStopGrace,
+		runtime.ManagedProcessReapGrace,
+	)
+}
+
+// killByPID is the signal/confirm core with its syscalls injected so the
+// confirmed-dead-before-return contract can be unit-tested without real
+// processes. termLive is the cheap kill(0) liveness used during the SIGTERM
+// grace window (a zombie still counts as live here, matching prior behavior).
+// runLive reports whether the process is still runnable — false once it is gone
+// or a zombie, since a zombie can no longer execute and therefore cannot race a
+// replacement.
+func killByPID(
+	pid int,
+	kill func(int, syscall.Signal) error,
+	termLive func(int) bool,
+	runLive func(int) bool,
+	grace, reapGrace time.Duration,
+) error {
 	if pid <= 1 {
 		return fmt.Errorf("proctable: refusing to kill PID %d", pid)
 	}
-	if !pidAlive(pid) {
+	if !termLive(pid) {
 		return nil
 	}
-	if err := signalPID(pid, syscall.SIGTERM); err != nil {
+	if err := signalPIDWith(pid, syscall.SIGTERM, kill); err != nil {
 		return fmt.Errorf("signal PID %d with SIGTERM: %w", pid, err)
 	}
-	deadline := time.NewTimer(runtime.ManagedProcessStopGrace)
+	if waitUntil(func() bool { return !termLive(pid) }, grace) {
+		return nil
+	}
+	if err := signalPIDWith(pid, syscall.SIGKILL, kill); err != nil {
+		return fmt.Errorf("signal PID %d with SIGKILL: %w", pid, err)
+	}
+	if waitUntil(func() bool { return !runLive(pid) }, reapGrace) {
+		return nil
+	}
+	return fmt.Errorf("proctable: PID %d still runnable %s after SIGKILL (not confirmed dead)", pid, reapGrace)
+}
+
+// waitUntil polls done at 25ms until it reports true or timeout elapses,
+// returning done's final result. Checked once up front so a zero timeout still
+// observes an already-satisfied condition.
+func waitUntil(done func() bool, timeout time.Duration) bool {
+	if done() {
+		return true
+	}
+	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(25 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-deadline.C:
-			if err := signalPID(pid, syscall.SIGKILL); err != nil {
-				return fmt.Errorf("signal PID %d with SIGKILL: %w", pid, err)
-			}
-			return nil
+			return done()
 		case <-ticker.C:
-			if !pidAlive(pid) {
-				return nil
+			if done() {
+				return true
 			}
 		}
 	}
-}
-
-func signalPID(pid int, sig syscall.Signal) error {
-	return signalPIDWith(pid, sig, syscall.Kill)
 }
 
 func signalPIDWith(pid int, sig syscall.Signal, kill func(int, syscall.Signal) error) error {

--- a/internal/runtime/proctable/kill_unix.go
+++ b/internal/runtime/proctable/kill_unix.go
@@ -20,11 +20,19 @@ import (
 // under I/O) yields an error so callers can refuse to start a name-reused
 // replacement that would race it for the same work.
 func KillByPID(pid int) error {
+	// Capture the target's start-time identity BEFORE signaling. During the
+	// post-SIGKILL reap wait the PID can be reaped and recycled to an unrelated
+	// process; without this, a recycled PID reads as "still alive" and we would
+	// wrongly report a target that is actually gone as not-confirmed-dead,
+	// spuriously refusing a legitimate Start. StartTime is empty on hosts
+	// without /proc (darwin) or when the record is unreadable, in which case
+	// runLive falls back to plain liveness — current behavior preserved.
+	startTime, _ := pidutil.StartTime(pid)
 	return killByPID(
 		pid,
 		syscall.Kill,
 		pidAlive,
-		pidutil.Alive,
+		func(p int) bool { return pidutil.AliveWithStartTime(p, startTime) },
 		runtime.ManagedProcessStopGrace,
 		runtime.ManagedProcessReapGrace,
 	)

--- a/internal/runtime/proctable/kill_unix_test.go
+++ b/internal/runtime/proctable/kill_unix_test.go
@@ -84,8 +84,10 @@ func TestKillByPIDConfirmedDeadBeforeReturn(t *testing.T) {
 	t.Run("survives SIGKILL -> error", func(t *testing.T) {
 		var signals []syscall.Signal
 		kill := func(_ int, sig syscall.Signal) error {
-			// Record only the positive-pid delivery so the group/direct
-			// fallback does not double-count.
+			// Record every delivery attempt. signalPIDWith signals the process
+			// group (negative pid) first and returns on success, so with this
+			// always-succeeding fake these are the group deliveries; the
+			// assertion below only checks the final escalation is SIGKILL.
 			signals = append(signals, sig)
 			return nil
 		}

--- a/internal/runtime/proctable/kill_unix_test.go
+++ b/internal/runtime/proctable/kill_unix_test.go
@@ -5,8 +5,10 @@ package proctable
 import (
 	"os/exec"
 	"slices"
+	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestKillByPIDRefusesLowPIDs(t *testing.T) {
@@ -71,5 +73,77 @@ func TestSignalPIDGroupSuccessSkipsFallback(t *testing.T) {
 	want := []int{-12345}
 	if !slices.Equal(got, want) {
 		t.Fatalf("signal calls = %v, want %v", got, want)
+	}
+}
+
+// TestKillByPIDConfirmedDeadBeforeReturn drives the injected core: a process
+// still runnable after SIGKILL (e.g. wedged in D-state) must yield an error so
+// a caller can refuse to start a racing replacement, while one that becomes
+// dead (gone or zombie) after SIGKILL returns nil.
+func TestKillByPIDConfirmedDeadBeforeReturn(t *testing.T) {
+	t.Run("survives SIGKILL -> error", func(t *testing.T) {
+		var signals []syscall.Signal
+		kill := func(_ int, sig syscall.Signal) error {
+			// Record only the positive-pid delivery so the group/direct
+			// fallback does not double-count.
+			signals = append(signals, sig)
+			return nil
+		}
+		termLive := func(int) bool { return true } // never exits on SIGTERM
+		runLive := func(int) bool { return true }  // survives SIGKILL too
+		err := killByPID(4321, kill, termLive, runLive, 5*time.Millisecond, 5*time.Millisecond)
+		if err == nil {
+			t.Fatal("killByPID returned nil for a process that survived SIGKILL")
+		}
+		if !strings.Contains(err.Error(), "not confirmed dead") {
+			t.Fatalf("error = %v, want 'not confirmed dead'", err)
+		}
+		if len(signals) == 0 || signals[len(signals)-1] != syscall.SIGKILL {
+			t.Fatalf("signals = %v, want SIGKILL escalation", signals)
+		}
+	})
+
+	t.Run("dies after SIGKILL -> nil", func(t *testing.T) {
+		kill := func(int, syscall.Signal) error { return nil }
+		termLive := func(int) bool { return true } // ignores SIGTERM
+		var kills int
+		runLive := func(int) bool {
+			kills++
+			return kills <= 1 // alive on first confirm poll, dead after
+		}
+		if err := killByPID(4321, kill, termLive, runLive, 5*time.Millisecond, time.Second); err != nil {
+			t.Fatalf("killByPID: %v", err)
+		}
+	})
+
+	t.Run("exits during SIGTERM grace -> no SIGKILL", func(t *testing.T) {
+		var sawKill bool
+		kill := func(_ int, sig syscall.Signal) error {
+			if sig == syscall.SIGKILL {
+				sawKill = true
+			}
+			return nil
+		}
+		var polls int
+		termLive := func(int) bool {
+			polls++
+			return polls <= 1 // alive at entry, exits before grace elapses
+		}
+		runLive := func(int) bool { return false }
+		if err := killByPID(4321, kill, termLive, runLive, time.Second, time.Second); err != nil {
+			t.Fatalf("killByPID: %v", err)
+		}
+		if sawKill {
+			t.Fatal("SIGKILL sent even though the process exited during grace")
+		}
+	})
+}
+
+func TestWaitUntilRespectsZeroTimeout(t *testing.T) {
+	if !waitUntil(func() bool { return true }, 0) {
+		t.Fatal("waitUntil should observe an already-satisfied condition at zero timeout")
+	}
+	if waitUntil(func() bool { return false }, 0) {
+		t.Fatal("waitUntil should report false when the condition never holds at zero timeout")
 	}
 }

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -324,9 +324,13 @@ func (p *Provider) FindRuntimesBySessionID(id string) ([]runtime.LiveRuntime, er
 	found, scanErr := proctable.ScanBySessionID(id)
 	running, listErr := p.ListRunning("")
 	if listErr != nil {
-		for i := range found {
-			found[i].IsTracked = true
-		}
+		// Fail CLOSED: without the live-session list we cannot prove which
+		// scanned roots are gc-tracked. Marking them all tracked (the previous
+		// behavior) told killExistingOrphans to skip every one, so an escaped
+		// old process for this exact session survived alongside its
+		// replacement. Leave IsTracked=false instead: the caller then targets
+		// the same-session, same-city roots the /proc scan surfaced, and only
+		// starts once they are confirmed dead.
 		return found, errors.Join(scanErr, fmt.Errorf("tmux list running: %w", listErr))
 	}
 

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -331,6 +331,23 @@ func (p *Provider) FindRuntimesBySessionID(id string) ([]runtime.LiveRuntime, er
 		// replacement. Leave IsTracked=false instead: the caller then targets
 		// the same-session, same-city roots the /proc scan surfaced, and only
 		// starts once they are confirmed dead.
+		//
+		// TRADE-OFF (gascity D1 / MEDIUM-2): when listErr is a *transient*
+		// tmux-list hiccup rather than a truly-gone server, a still-live
+		// session's root can land here untracked and be targeted for kill —
+		// the same tmux machinery backs ensureRunning's !IsRunning gate, so a
+		// blip flips both. We accept this over the alternative (a survivor
+		// racing the replacement for the same work bead, causing duplicate bd
+		// closes), because the survivor bug is silent and corrupts work state
+		// while a wrongful kill is loud and self-heals on the next reconcile.
+		// Two mitigations bound the blast radius: (1) KillByPID confirms death
+		// by PID + /proc start-time identity (pidutil.AliveWithStartTime), so a
+		// genuinely-live root is never misreported as dead — if it resists the
+		// kill it surfaces a real "not confirmed dead" error; and (2) that
+		// error propagates through killExistingOrphans to every gated Start,
+		// which then refuses rather than racing. Independently re-deriving
+		// "is this the current live session" here would require the very
+		// ListRunning that just failed, so it is intentionally not attempted.
 		return found, errors.Join(scanErr, fmt.Errorf("tmux list running: %w", listErr))
 	}
 

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -747,28 +747,42 @@ func computeExcludingKillSet(panePID string, descendants, reparented []string, e
 	return killList, !exclude[panePID]
 }
 
-// collectReparentedGroupMembers returns process group members that have been
-// reparented to init (PPID == 1) but are not in the known descendant set.
-// These are processes that were likely children in our tree but outlived their
-// parent and got reparented to init while keeping the original PGID.
-//
-// This is safer than killing the entire process group blindly with
-// syscall.Kill(-pgid, ...), which could hit unrelated processes if the PGID
-// is shared or has been reused after the group leader exited.
+// collectReparentedGroupMembers returns process group members that outlived
+// their parent inside our tree and were reparented away, but are not already in
+// the known descendant set. It shares the pane leader's PGID with every member;
+// since the leader is still alive when this runs, the PGID cannot have been
+// reused, so members carrying it descend from our tree rather than an unrelated
+// process. This is safer than killing the entire group blindly with
+// syscall.Kill(-pgid, ...).
 func collectReparentedGroupMembers(pgid string, knownPIDs map[string]bool) []string {
-	members := getProcessGroupMembers(pgid)
+	return reparentedOrphans(getProcessGroupMembers(pgid), knownPIDs, getParentPID)
+}
+
+// reparentedOrphans selects group members whose parent is outside the known
+// descendant set — the pure, IO-free core of collectReparentedGroupMembers.
+//
+// The prior test was literal PPID == 1, which only holds when init adopts the
+// orphan. Under a `user@.service` subreaper (systemd --user), an orphaned child
+// reparents to the subreaper's pid, not 1, so the PPID == 1 test missed it and
+// the tree kill left it alive next to the replacement. "Parent outside the
+// descendant set" captures both cases: init (pid 1 is never a descendant) and
+// the subreaper (its pid is never a descendant either), while a member whose
+// parent is still a live descendant is left to getAllDescendants. Members whose
+// parent cannot be read are skipped rather than killed.
+func reparentedOrphans(members []string, knownPIDs map[string]bool, parentOf func(string) string) []string {
 	var reparented []string
 	for _, member := range members {
 		if knownPIDs[member] {
-			continue // Already in descendant list, will be handled there
+			continue // Already in the descendant list; handled there.
 		}
-		// Check if reparented to init — probably was our child
-		ppid := getParentPID(member)
-		if ppid == "1" {
-			reparented = append(reparented, member)
+		ppid := strings.TrimSpace(parentOf(member))
+		if ppid == "" {
+			continue // Parent unknown (raced exit) — cannot prove it's ours.
 		}
-		// Otherwise skip — this process is not in our tree and not reparented,
-		// so it's likely unrelated and should not be killed
+		if knownPIDs[ppid] {
+			continue // Parent still a live descendant; getAllDescendants owns it.
+		}
+		reparented = append(reparented, member)
 	}
 	return reparented
 }

--- a/internal/runtime/tmux/tmux_test.go
+++ b/internal/runtime/tmux/tmux_test.go
@@ -1258,8 +1258,12 @@ func TestCleanupOrphanedSessions_NoSessions(t *testing.T) {
 
 func TestCollectReparentedGroupMembers(t *testing.T) {
 	// Test that collectReparentedGroupMembers correctly filters group members.
-	// Only processes reparented to init (PPID == 1) that aren't in the known set
-	// should be returned.
+	// A returned member must not be in the known set and must have a parent
+	// outside the known descendant set (parents that reparented to init OR to a
+	// user-session subreaper both qualify). The full parent-outside-set rule is
+	// covered deterministically with an injected parentOf by
+	// TestReparentedOrphans_* in tmux_unit_test.go; this test exercises the real
+	// getProcessGroupID/getParentPID integration.
 
 	// Test with current process's PGID
 	pid := fmt.Sprintf("%d", os.Getpid())
@@ -1277,17 +1281,18 @@ func TestCollectReparentedGroupMembers(t *testing.T) {
 		if rpid == pid {
 			t.Errorf("collectReparentedGroupMembers returned known PID %s", pid)
 		}
-		// Each reparented PID should have PPID == 1.
-		// The process may have exited between collection and this check
-		// (TOCTOU race), so skip verification if getParentPID returns empty.
+		// A returned member's parent must be outside the known set (the
+		// "parent outside the known descendant set" rule). The process may
+		// exit between collection and this check (TOCTOU race), so skip
+		// verification if getParentPID returns empty for a since-exited PID.
 		ppid := getParentPID(rpid)
 		if ppid == "" && runtime.GOOS != "windows" {
 			if err := exec.Command("kill", "-0", rpid).Run(); err != nil {
 				continue
 			}
 		}
-		if ppid != "1" {
-			t.Errorf("collectReparentedGroupMembers returned PID %s with PPID %s (expected 1)", rpid, ppid)
+		if knownPIDs[ppid] {
+			t.Errorf("collectReparentedGroupMembers returned PID %s whose parent %s is in the known set", rpid, ppid)
 		}
 	}
 }

--- a/internal/runtime/tmux/tmux_unit_test.go
+++ b/internal/runtime/tmux/tmux_unit_test.go
@@ -84,3 +84,44 @@ func TestComputeExcludingKillSet_ExcludedPaneLeaderSurvives(t *testing.T) {
 		t.Error("an excluded pane leader must not be killed directly")
 	}
 }
+
+// knownSet builds a descendant-set lookup from the given pids.
+func knownSet(pids ...string) map[string]bool {
+	m := make(map[string]bool, len(pids))
+	for _, p := range pids {
+		m[p] = true
+	}
+	return m
+}
+
+func TestReparentedOrphans_CollectsInitAndSubreaperOrphans(t *testing.T) {
+	// leader=100, one live descendant=200. Group also holds:
+	//   300 reparented to init (ppid 1) — classic case
+	//   400 reparented to systemd --user subreaper (ppid 900) — the case the
+	//        old PPID==1 test missed
+	//   500 still a child of a live descendant (ppid 200) — owned elsewhere
+	//   600 whose parent read failed ("") — must be skipped
+	known := knownSet("100", "200")
+	parents := map[string]string{
+		"300": "1",
+		"400": "900", // systemd --user pid, not init
+		"500": "200",
+		"600": "",
+	}
+	parentOf := func(pid string) string { return parents[pid] }
+
+	got := reparentedOrphans([]string{"200", "300", "400", "500", "600"}, known, parentOf)
+	slices.Sort(got)
+	want := []string{"300", "400"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("reparentedOrphans = %v, want %v", got, want)
+	}
+}
+
+func TestReparentedOrphans_SkipsKnownDescendants(t *testing.T) {
+	known := knownSet("100", "200", "300")
+	parentOf := func(string) string { return "1" }
+	if got := reparentedOrphans([]string{"200", "300"}, known, parentOf); len(got) != 0 {
+		t.Fatalf("reparentedOrphans = %v, want empty (all are known descendants)", got)
+	}
+}

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -202,7 +202,16 @@ func (m *Manager) retryFreshStartAfterStaleKey(
 		}
 	}
 	cfg.Command = freshCmd
-	m.killExistingOrphans(ctx, id)
+	// Refuse the fresh start if a prior escaped process for this session could
+	// not be confirmed dead: a survivor would race this replacement for the
+	// same work bead. This path reuses the existing bead ID, so there is no
+	// fresh-create to roll back — unroute and propagate the error before Start.
+	if orphanErr := m.killExistingOrphans(ctx, id); orphanErr != nil {
+		if unroute != nil {
+			unroute()
+		}
+		return false, fmt.Errorf("pre-start orphan cleanup: %w", orphanErr)
+	}
 	if err := m.sp.Start(ctx, sessName, cfg); err != nil {
 		if unroute != nil {
 			unroute()
@@ -371,7 +380,17 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 	}
 	cfg = runtime.SyncWorkDirEnv(cfg)
 	started := false
-	m.killExistingOrphans(ctx, id)
+	// Refuse to resume if a prior escaped process for this session could not be
+	// confirmed dead: a survivor would race this replacement for the same work
+	// bead (duplicate bd close). This is the stable/reused-bead-ID path — the
+	// exact "old process survives alongside its replacement" scenario. No
+	// fresh-create to roll back, so unroute and propagate before Start.
+	if orphanErr := m.killExistingOrphans(ctx, id); orphanErr != nil {
+		if unroute != nil {
+			unroute()
+		}
+		return fmt.Errorf("pre-start orphan cleanup: %w", orphanErr)
+	}
 	if err := m.sp.Start(ctx, sessName, cfg); err != nil {
 		if errors.Is(err, runtime.ErrSessionDiedDuringStartup) && b.Metadata["session_key"] != "" {
 			retried, err := m.retryFreshStartAfterStaleKey(ctx, id, &b, sessName, resumeCommand, cfg, unroute)
@@ -482,7 +501,16 @@ func (m *Manager) ensureRunningRuntimeOnly(ctx context.Context, id string, b bea
 	}
 	cfg = runtime.SyncWorkDirEnv(cfg)
 	started := false
-	m.killExistingOrphans(ctx, id)
+	// Refuse to respawn if a prior escaped process for this session could not
+	// be confirmed dead: a survivor would race this replacement for the same
+	// work bead. This is the reconciler respawn bridge on a stable/reused bead
+	// ID. No fresh-create to roll back, so unroute and propagate before Start.
+	if orphanErr := m.killExistingOrphans(ctx, id); orphanErr != nil {
+		if unroute != nil {
+			unroute()
+		}
+		return fmt.Errorf("pre-start orphan cleanup: %w", orphanErr)
+	}
 	if err := m.sp.Start(ctx, sessName, cfg); err != nil {
 		switch {
 		case errors.Is(err, runtime.ErrSessionDiedDuringStartup) && b.Metadata["session_key"] != "":

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -511,17 +511,25 @@ func (m *Manager) persistTransport(id, provider, transport string) {
 	_ = m.store.SetMetadata(id, "transport", transport)
 }
 
-func (m *Manager) killExistingOrphans(ctx context.Context, sessionID string) {
+// killExistingOrphans terminates any untracked runtime whose session ID and
+// city match the session about to start, then confirms each is dead. It returns
+// a non-nil error only when an orphan could not be confirmed dead, so callers
+// gating a Start can refuse rather than race a survivor for the same work. A
+// scan error is logged and treated as fail-closed (see FindRuntimesBySessionID):
+// the roots the scan did surface are still killed, and matching the started
+// replacement is impossible because it does not exist yet.
+func (m *Manager) killExistingOrphans(ctx context.Context, sessionID string) error {
 	_ = ctx
 	scanner, ok := m.sp.(runtime.ProcessTableScanner)
 	if !ok || sessionID == "" {
-		return
+		return nil
 	}
 	found, err := scanner.FindRuntimesBySessionID(sessionID)
 	if err != nil {
-		log.Printf("session: scanning for orphaned runtimes for %s: %v", sessionID, err)
+		log.Printf("session: scanning for orphaned runtimes for %s (failing closed): %v", sessionID, err)
 	}
 	cityPath := pathutil.NormalizePathForCompare(strings.TrimSpace(m.cityPath))
+	var termErrs []error
 	for _, live := range found {
 		if live.IsTracked || live.SessionID != sessionID {
 			continue
@@ -531,8 +539,13 @@ func (m *Manager) killExistingOrphans(ctx context.Context, sessionID string) {
 		}
 		if err := scanner.TerminateRuntime(live); err != nil {
 			log.Printf("session: terminating orphaned runtime for %s pid=%d provider_name=%q: %v", sessionID, live.PID, live.ProviderName, err)
+			termErrs = append(termErrs, fmt.Errorf("orphan pid=%d provider_name=%q: %w", live.PID, live.ProviderName, err))
 		}
 	}
+	if len(termErrs) > 0 {
+		return fmt.Errorf("%d orphaned runtime(s) not confirmed dead: %w", len(termErrs), errors.Join(termErrs...))
+	}
+	return nil
 }
 
 func (m *Manager) now() time.Time {
@@ -815,8 +828,15 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 		}
 		cfg = runtime.SyncWorkDirEnv(cfg)
 
-		// Start the runtime session.
-		m.killExistingOrphans(ctx, b.ID)
+		// Start the runtime session. Refuse to start if a prior escaped process
+		// for this session could not be confirmed dead: a survivor would race
+		// the replacement for the same work bead (duplicate bd close).
+		if orphanErr := m.killExistingOrphans(ctx, b.ID); orphanErr != nil {
+			if rbErr := rollbackFailedCreate(); rbErr != nil {
+				return errors.Join(fmt.Errorf("pre-start orphan cleanup: %w", orphanErr), rbErr)
+			}
+			return fmt.Errorf("pre-start orphan cleanup: %w", orphanErr)
+		}
 		if err := m.sp.Start(ctx, sessName, cfg); err != nil {
 			if runtimeSessionMatchesBead(m.sp, sessName, b.ID, meta["instance_token"]) {
 				if metaErr := m.confirmStartedRuntimeMetadata(b.ID, &b); metaErr != nil {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -405,7 +405,13 @@ func TestCreateKillsUntrackedOrphanFromSameCityBeforeStartWithNormalizedPath(t *
 	}
 }
 
-func TestCreateContinuesWhenOrphanCleanupFails(t *testing.T) {
+// TestCreateRefusesStartWhenOrphanNotConfirmedDead pins the fail-closed
+// contract: when an untracked same-session orphan cannot be confirmed dead
+// (TerminateRuntime errors — e.g. it survived SIGKILL), Create must refuse to
+// start a replacement rather than race the survivor for the same work bead. A
+// concurrent scan error is logged and treated as fail-closed, so the orphan the
+// scan did surface is still targeted. No Start is attempted.
+func TestCreateRefusesStartWhenOrphanNotConfirmedDead(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := &orphanScanProvider{
 		Fake:         runtime.NewFake(),
@@ -418,16 +424,23 @@ func TestCreateContinuesWhenOrphanCleanupFails(t *testing.T) {
 	}
 	mgr := NewManager(store, sp)
 
-	info, err := mgr.Create(context.Background(), "helper", "my chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
+	_, err := mgr.Create(context.Background(), "helper", "my chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err == nil {
+		t.Fatal("Create succeeded despite an orphan that could not be confirmed dead")
 	}
-	if !sp.IsRunning(info.SessionName) {
-		t.Fatalf("runtime session %q was not started after cleanup errors", info.SessionName)
+	if !strings.Contains(err.Error(), "orphan cleanup") {
+		t.Fatalf("Create error = %v, want pre-start orphan cleanup refusal", err)
 	}
-	want := []string{"find:" + info.ID, "terminate:" + info.ID, "start:" + info.ID}
-	if got := strings.Join(sp.events, ","); got != strings.Join(want, ",") {
-		t.Fatalf("events = %v, want %v", sp.events, want)
+	for _, e := range sp.events {
+		if strings.HasPrefix(e, "start:") {
+			t.Fatalf("Start was attempted despite unconfirmed orphan; events = %v", sp.events)
+		}
+	}
+	want := []string{"find:", "terminate:"}
+	for i, prefix := range want {
+		if i >= len(sp.events) || !strings.HasPrefix(sp.events[i], prefix) {
+			t.Fatalf("events = %v, want prefixes %v", sp.events, want)
+		}
 	}
 }
 
@@ -466,9 +479,12 @@ func TestRuntimeStartCallSitesCleanOrphansFirst(t *testing.T) {
 					continue
 				}
 				starts++
-				prev := previousNonBlankLine(lines, i)
-				if !strings.Contains(prev, "m.killExistingOrphans(ctx, "+tt.idExpr+")") {
-					t.Errorf("%s:%d Start is not immediately preceded by orphan cleanup using %s; previous line: %q", tt.file, i+1, tt.idExpr, prev)
+				// The cleanup call may sit a few lines above the Start when its
+				// result gates the Start (manager.go wraps it in an
+				// `if orphanErr := …; orphanErr != nil` refusal), so scan a
+				// short preceding window rather than only the immediate line.
+				if !orphanCleanupPrecedes(lines, i, tt.idExpr) {
+					t.Errorf("%s:%d Start is not preceded by orphan cleanup using %s", tt.file, i+1, tt.idExpr)
 				}
 			}
 			if starts == 0 {
@@ -478,13 +494,25 @@ func TestRuntimeStartCallSitesCleanOrphansFirst(t *testing.T) {
 	}
 }
 
-func previousNonBlankLine(lines []string, before int) string {
-	for i := before - 1; i >= 0; i-- {
-		if strings.TrimSpace(lines[i]) != "" {
-			return strings.TrimSpace(lines[i])
+// orphanCleanupPrecedes reports whether m.killExistingOrphans(ctx, idExpr)
+// appears within the short window of non-blank lines preceding the Start at
+// index before. The window keeps the "every Start is guarded by orphan
+// cleanup" invariant while tolerating the gate wrapper that consumes the
+// cleanup's error.
+func orphanCleanupPrecedes(lines []string, before int, idExpr string) bool {
+	needle := "m.killExistingOrphans(ctx, " + idExpr + ")"
+	const window = 10
+	seen := 0
+	for i := before - 1; i >= 0 && seen < window; i-- {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		seen++
+		if strings.Contains(lines[i], needle) {
+			return true
 		}
 	}
-	return ""
+	return false
 }
 
 func TestUpdateTemplateOverridesRejectsRunningSessionUnderLock(t *testing.T) {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -444,6 +444,207 @@ func TestCreateRefusesStartWhenOrphanNotConfirmedDead(t *testing.T) {
 	}
 }
 
+// acpOrphanScanProvider augments orphanScanProvider with ACP route bookkeeping
+// so a resume that reserves an ACP route before the pre-start orphan gate can
+// be observed unwinding that reservation when the gate refuses. RouteACP and
+// Unroute record into the same events slice as the scan/start calls.
+type acpOrphanScanProvider struct {
+	*orphanScanProvider
+}
+
+func (p *acpOrphanScanProvider) RouteACP(name string) { p.events = append(p.events, "route:"+name) }
+func (p *acpOrphanScanProvider) Unroute(name string)  { p.events = append(p.events, "unroute:"+name) }
+
+// seedSuspendedResumeTarget creates a session backed by a clean orphan scanner
+// and suspends it, so a subsequent Manager.Start/StartRuntimeOnly takes the
+// resume path (stopped runtime, non-empty resume command) and reaches the
+// pre-start orphan gate. It clears the recorded events after suspend so callers
+// observe only the resume attempt, and returns the provider ready to be armed
+// with an orphan.
+func seedSuspendedResumeTarget(t *testing.T) (*Manager, *orphanScanProvider, Info) {
+	t.Helper()
+	store := beads.NewMemStore()
+	sp := &orphanScanProvider{Fake: runtime.NewFake()}
+	mgr := NewManager(store, sp)
+	info, err := mgr.Create(context.Background(), "helper", "", "claude", t.TempDir(), "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+	sp.events = nil
+	return mgr, sp, info
+}
+
+func hasEventPrefix(events []string, prefix string) bool {
+	for _, e := range events {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// armUnconfirmedOrphan makes killExistingOrphans surface a same-session
+// untracked orphan whose termination fails, i.e. one that cannot be confirmed
+// dead. This is the fixture shape TestCreateRefusesStartWhenOrphanNotConfirmedDead
+// uses for the Create path.
+func armUnconfirmedOrphan(sp *orphanScanProvider) {
+	sp.results = []runtime.LiveRuntime{{PID: 1234, IsTracked: false}}
+	sp.terminateErr = errors.New("terminate failed")
+}
+
+// armConfirmedDeadOrphan makes killExistingOrphans surface a same-session
+// untracked orphan that terminates cleanly (confirmed dead), so the gate lets
+// the Start proceed.
+func armConfirmedDeadOrphan(sp *orphanScanProvider) {
+	sp.results = []runtime.LiveRuntime{{PID: 1234, IsTracked: false}}
+	sp.terminateErr = nil
+}
+
+// TestStartRefusesResumeWhenOrphanNotConfirmedDead drives the real
+// Manager.Start -> ensureRunning path (chat.go ~388) with the same
+// not-confirmed-dead orphan fixture the Create behavioral test uses, and pins
+// the runtime behavior of the fix: Start returns a pre-start orphan cleanup
+// error and no replacement runtime is started (sp.Start is never called). A
+// regression that swallowed the gate error (e.g. `if orphanErr != nil { /*
+// no-op */ }`) would pass errcheck and the structural scan but fail here.
+func TestStartRefusesResumeWhenOrphanNotConfirmedDead(t *testing.T) {
+	mgr, sp, info := seedSuspendedResumeTarget(t)
+	armUnconfirmedOrphan(sp)
+
+	err := mgr.Start(context.Background(), info.ID, BuildResumeCommand(info), runtime.Config{WorkDir: info.WorkDir})
+	if err == nil {
+		t.Fatal("Start succeeded despite an orphan that could not be confirmed dead")
+	}
+	if !strings.Contains(err.Error(), "orphan cleanup") {
+		t.Fatalf("Start error = %v, want pre-start orphan cleanup refusal", err)
+	}
+	if hasEventPrefix(sp.events, "start:") {
+		t.Fatalf("Start was attempted despite unconfirmed orphan; events = %v", sp.events)
+	}
+	want := []string{"find:", "terminate:"}
+	for i, prefix := range want {
+		if i >= len(sp.events) || !strings.HasPrefix(sp.events[i], prefix) {
+			t.Fatalf("events = %v, want prefixes %v", sp.events, want)
+		}
+	}
+}
+
+// TestStartRuntimeOnlyRefusesRespawnWhenOrphanNotConfirmedDead is the
+// StartRuntimeOnly (reconciler respawn bridge, chat.go ~508) counterpart of
+// TestStartRefusesResumeWhenOrphanNotConfirmedDead.
+func TestStartRuntimeOnlyRefusesRespawnWhenOrphanNotConfirmedDead(t *testing.T) {
+	mgr, sp, info := seedSuspendedResumeTarget(t)
+	armUnconfirmedOrphan(sp)
+
+	err := mgr.StartRuntimeOnly(context.Background(), info.ID, BuildResumeCommand(info), runtime.Config{WorkDir: info.WorkDir})
+	if err == nil {
+		t.Fatal("StartRuntimeOnly succeeded despite an orphan that could not be confirmed dead")
+	}
+	if !strings.Contains(err.Error(), "orphan cleanup") {
+		t.Fatalf("StartRuntimeOnly error = %v, want pre-start orphan cleanup refusal", err)
+	}
+	if hasEventPrefix(sp.events, "start:") {
+		t.Fatalf("Start was attempted despite unconfirmed orphan; events = %v", sp.events)
+	}
+	want := []string{"find:", "terminate:"}
+	for i, prefix := range want {
+		if i >= len(sp.events) || !strings.HasPrefix(sp.events[i], prefix) {
+			t.Fatalf("events = %v, want prefixes %v", sp.events, want)
+		}
+	}
+}
+
+// TestStartProceedsWhenOrphanConfirmedDead is the positive counterpart: when
+// the same-session orphan IS confirmed dead, Manager.Start proceeds and starts
+// the replacement runtime. It proves the gate does not over-refuse.
+func TestStartProceedsWhenOrphanConfirmedDead(t *testing.T) {
+	mgr, sp, info := seedSuspendedResumeTarget(t)
+	armConfirmedDeadOrphan(sp)
+
+	if err := mgr.Start(context.Background(), info.ID, BuildResumeCommand(info), runtime.Config{WorkDir: info.WorkDir}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	want := []string{"find:" + info.ID, "terminate:" + info.ID, "start:" + info.ID}
+	if got := strings.Join(sp.events, ","); got != strings.Join(want, ",") {
+		t.Fatalf("events = %v, want %v", sp.events, want)
+	}
+	if !sp.IsRunning(info.SessionName) {
+		t.Fatalf("runtime session %q not running after resume", info.SessionName)
+	}
+}
+
+// TestStartRuntimeOnlyProceedsWhenOrphanConfirmedDead is the StartRuntimeOnly
+// positive counterpart.
+func TestStartRuntimeOnlyProceedsWhenOrphanConfirmedDead(t *testing.T) {
+	mgr, sp, info := seedSuspendedResumeTarget(t)
+	armConfirmedDeadOrphan(sp)
+
+	if err := mgr.StartRuntimeOnly(context.Background(), info.ID, BuildResumeCommand(info), runtime.Config{WorkDir: info.WorkDir}); err != nil {
+		t.Fatalf("StartRuntimeOnly: %v", err)
+	}
+	want := []string{"find:" + info.ID, "terminate:" + info.ID, "start:" + info.ID}
+	if got := strings.Join(sp.events, ","); got != strings.Join(want, ",") {
+		t.Fatalf("events = %v, want %v", sp.events, want)
+	}
+	if !sp.IsRunning(info.SessionName) {
+		t.Fatalf("runtime session %q not running after respawn", info.SessionName)
+	}
+}
+
+// TestStartUnwindsACPRouteWhenOrphanNotConfirmedDead pins the route-unwinding
+// half of the fix: when the resume path reserved an ACP route before the
+// pre-start orphan gate, a refusal must call unroute() so the reservation is
+// released rather than leaked. It seeds an ACP-transport session bead directly
+// (mirroring the legacy-ACP fixtures elsewhere in this file) so ensureRunning
+// reserves a route via RouteACP, then arms a not-confirmed-dead orphan and
+// asserts Unroute fires and no runtime Start is attempted.
+func TestStartUnwindsACPRouteWhenOrphanNotConfirmedDead(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &acpOrphanScanProvider{orphanScanProvider: &orphanScanProvider{Fake: runtime.NewFake()}}
+	armUnconfirmedOrphan(sp.orphanScanProvider)
+	mgr := NewManager(store, sp)
+
+	b, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"state":     string(StateSuspended),
+			"provider":  "claude",
+			"transport": "acp",
+			"work_dir":  "/tmp",
+			"command":   "claude",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create bead: %v", err)
+	}
+	sessName := sessionNameFor(b.ID)
+	if err := store.SetMetadata(b.ID, "session_name", sessName); err != nil {
+		t.Fatalf("SetMetadata(session_name): %v", err)
+	}
+	sp.events = nil
+
+	err = mgr.Start(context.Background(), b.ID, "claude", runtime.Config{WorkDir: "/tmp"})
+	if err == nil {
+		t.Fatal("Start succeeded despite an orphan that could not be confirmed dead")
+	}
+	if !strings.Contains(err.Error(), "orphan cleanup") {
+		t.Fatalf("Start error = %v, want pre-start orphan cleanup refusal", err)
+	}
+	if hasEventPrefix(sp.events, "start:") {
+		t.Fatalf("Start was attempted despite unconfirmed orphan; events = %v", sp.events)
+	}
+	if !hasEventPrefix(sp.events, "route:") {
+		t.Fatalf("expected an ACP route reservation before the gate; events = %v", sp.events)
+	}
+	if !hasEventPrefix(sp.events, "unroute:") {
+		t.Fatalf("ACP route reservation was not unwound on refusal; events = %v", sp.events)
+	}
+}
+
 func TestCreateWithProviderWithoutProcessScannerStillStarts(t *testing.T) {
 	store := beads.NewMemStore()
 	fake := runtime.NewFake()

--- a/internal/workspacesvc/orphan_reap.go
+++ b/internal/workspacesvc/orphan_reap.go
@@ -26,7 +26,9 @@ import (
 // (see orphanIdentity.matchesLive):
 //
 //  1. it is alive and not a zombie;
-//  2. it has re-parented to init (ppid 1), so no live supervisor owns it;
+//  2. it has re-parented to a subreaper — init (ppid 1), or the detected
+//     `systemd --user` manager under a user@.service — so no live supervisor
+//     owns it (see orphanIdentity.parentIsSubreaper);
 //  3. its command line is exactly the service's configured command; and
 //  4. its environment carries GC_SERVICE_NAME=<service> and
 //     GC_SERVICE_STATE_ROOT=<this instance's state root>, proving a gc
@@ -55,6 +57,12 @@ type orphanIdentity struct {
 	serviceName string
 	stateRoot   string
 	command     []string
+	// subreaperPID is the pid of the `systemd --user` subreaper that adopts
+	// this user session's orphans, or 0 when there is none (plain init host /
+	// container). It is set at sweep time by reapOrphanedServiceProcesses;
+	// newOrphanIdentity leaves it 0 so the identity keeps the strict
+	// re-parented-to-init (ppid 1) rule until a subreaper is detected.
+	subreaperPID int
 }
 
 // newOrphanIdentity builds the sweep identity for one service instance.
@@ -84,7 +92,8 @@ func (id orphanIdentity) matchesLive(pid int) bool {
 	if !pidutil.Alive(pid) {
 		return false
 	}
-	if ppid, err := processParentPID(pid); err != nil || ppid != 1 {
+	ppid, err := processParentPID(pid)
+	if err != nil || !id.parentIsSubreaper(ppid) {
 		return false
 	}
 	if !processCmdlineEquals(pid, id.command) {
@@ -93,17 +102,75 @@ func (id orphanIdentity) matchesLive(pid int) bool {
 	return processEnvironMatchesService(pid, id.serviceName, id.stateRoot)
 }
 
+// parentIsSubreaper reports whether ppid is a subreaper that would own this
+// process only if the supervisor that spawned it has already exited: init
+// (pid 1) on hosts without a user subreaper, or the detected `systemd --user`
+// manager under a user@.service. A live gc supervisor is never a subreaper, so
+// a still-owned service child — whose ppid is its live supervisor's pid —
+// never matches, and neither does the sweeper's own supervisor process (it
+// fails the command/environ checks regardless). Rule 2 of the file header
+// ("no live supervisor owns it") thus holds under both the plain-init and
+// systemd --user reparenting models.
+func (id orphanIdentity) parentIsSubreaper(ppid int) bool {
+	if ppid == 1 {
+		return true
+	}
+	return id.subreaperPID > 1 && ppid == id.subreaperPID
+}
+
 // reapOrphanedServiceProcesses terminates orphaned survivors of previous
 // hard exits that match the service instance's identity. Best-effort: scan
 // or signal failures are logged and never block the spawn; on hosts without
 // /proc the sweep is a no-op.
 func reapOrphanedServiceProcesses(id orphanIdentity) {
+	// The sweeper runs under the same subreaper that adopts this supervisor's
+	// orphans, so detect it from the sweeper's own ancestry. On a plain-init
+	// host this stays 0 and matchesLive keeps the strict ppid==1 rule.
+	id.subreaperPID = detectUserSubreaperPID(os.Getpid())
 	pids := findOrphanedServiceProcesses(id)
 	if len(pids) == 0 {
 		return
 	}
 	log.Printf("workspacesvc: terminating %d orphaned process(es) for service %q: %v", len(pids), id.serviceName, pids)
 	terminateOrphanedProcesses(id, pids)
+}
+
+// detectUserSubreaperPID returns the pid of the `systemd --user` manager that
+// acts as the child subreaper for this user session, or 0 if there is none.
+//
+// Under a user@UID.service, systemd --user sets PR_SET_CHILD_SUBREAPER, so any
+// orphan in the session reparents to it (not to pid 1). The sweeper is itself a
+// descendant of that manager, so we walk the sweeper's parent chain and return
+// the nearest ancestor named "systemd" whose pid is not 1 — i.e. the user
+// manager, distinct from the system systemd at pid 1. The walk is bounded to
+// guard against malformed /proc data and stops at pid 1.
+func detectUserSubreaperPID(self int) int {
+	return detectUserSubreaperPIDWith(self, processParentPID, processComm)
+}
+
+func detectUserSubreaperPIDWith(self int, parentOf func(int) (int, error), commOf func(int) string) int {
+	pid := self
+	for depth := 0; depth < 64; depth++ {
+		ppid, err := parentOf(pid)
+		if err != nil || ppid <= 1 {
+			return 0
+		}
+		if commOf(ppid) == "systemd" {
+			return ppid
+		}
+		pid = ppid
+	}
+	return 0
+}
+
+// processComm returns the executable name from /proc/<pid>/comm, or "" if it
+// cannot be read.
+func processComm(pid int) string {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 // findOrphanedServiceProcesses scans /proc for processes matching id.

--- a/internal/workspacesvc/orphan_reap_test.go
+++ b/internal/workspacesvc/orphan_reap_test.go
@@ -387,3 +387,68 @@ func TestProxyProcessStartReapsOrphanedDuplicates(t *testing.T) {
 		t.Fatalf("LocalState = %q, want ready (reason=%q)", status.LocalState, status.Reason)
 	}
 }
+
+func TestParentIsSubreaper(t *testing.T) {
+	tests := []struct {
+		name         string
+		subreaperPID int
+		ppid         int
+		want         bool
+	}{
+		{name: "init always counts", subreaperPID: 0, ppid: 1, want: true},
+		{name: "init counts even with subreaper set", subreaperPID: 900, ppid: 1, want: true},
+		{name: "systemd --user subreaper counts", subreaperPID: 900, ppid: 900, want: true},
+		{name: "live supervisor pid does not count", subreaperPID: 900, ppid: 1234, want: false},
+		{name: "no subreaper detected -> only init", subreaperPID: 0, ppid: 900, want: false},
+		{name: "subreaper pid 1 is ignored as a subreaper key", subreaperPID: 1, ppid: 1234, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := orphanIdentity{subreaperPID: tt.subreaperPID}
+			if got := id.parentIsSubreaper(tt.ppid); got != tt.want {
+				t.Fatalf("parentIsSubreaper(%d) with subreaperPID=%d = %v, want %v", tt.ppid, tt.subreaperPID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectUserSubreaperPID(t *testing.T) {
+	// Ancestry: self(500) -> shell(400) -> systemd --user(900) -> systemd(1).
+	t.Run("finds systemd --user manager", func(t *testing.T) {
+		parents := map[int]int{500: 400, 400: 900, 900: 1}
+		comms := map[int]string{400: "bash", 900: "systemd", 1: "systemd"}
+		parentOf := func(pid int) (int, error) { return parents[pid], nil }
+		commOf := func(pid int) string { return comms[pid] }
+		if got := detectUserSubreaperPIDWith(500, parentOf, commOf); got != 900 {
+			t.Fatalf("detectUserSubreaperPID = %d, want 900", got)
+		}
+	})
+
+	t.Run("plain init host returns 0", func(t *testing.T) {
+		// self(500) -> supervisor(400) -> init(1); only systemd is pid 1.
+		parents := map[int]int{500: 400, 400: 1}
+		comms := map[int]string{400: "gc", 1: "systemd"}
+		parentOf := func(pid int) (int, error) { return parents[pid], nil }
+		commOf := func(pid int) string { return comms[pid] }
+		if got := detectUserSubreaperPIDWith(500, parentOf, commOf); got != 0 {
+			t.Fatalf("detectUserSubreaperPID = %d, want 0 (no user subreaper)", got)
+		}
+	})
+
+	t.Run("unreadable parent returns 0", func(t *testing.T) {
+		parentOf := func(int) (int, error) { return 0, fmt.Errorf("no /proc") }
+		commOf := func(int) string { return "" }
+		if got := detectUserSubreaperPIDWith(500, parentOf, commOf); got != 0 {
+			t.Fatalf("detectUserSubreaperPID = %d, want 0", got)
+		}
+	})
+
+	t.Run("cyclic ancestry terminates", func(t *testing.T) {
+		// Malformed /proc reporting a cycle must not loop forever.
+		parentOf := func(int) (int, error) { return 700, nil }
+		commOf := func(int) string { return "notsystemd" }
+		if got := detectUserSubreaperPIDWith(700, parentOf, commOf); got != 0 {
+			t.Fatalf("detectUserSubreaperPID = %d, want 0", got)
+		}
+	})
+}


### PR DESCRIPTION
## Why

Two agent processes could end up working one bead because a respawn happened while the old process was still alive. Four related process-lifecycle defects, from a prior audit.

## What changed

- **Fail-closed orphan scan** (`internal/runtime/tmux/adapter.go`, `internal/session/manager.go`): when `ListRunning` errors during the pre-start orphan scan, `FindRuntimesBySessionID` no longer marks every scanned process "tracked" (which made `killExistingOrphans` skip them and let `Start` proceed). It returns the same-session roots untracked so they are killed, bounded to same-session-ID + same-city.
- **Confirmed-dead-before-start** (`internal/runtime/proctable/kill_unix.go`, `internal/runtime/process_control.go`): after SIGKILL, `KillByPID` waits (bounded by `ManagedProcessReapGrace`, 3s) until the pid is gone-or-zombie and returns an error if it survives. **All four** `killExistingOrphans` call sites now gate on that error before starting: the `Create` path plus the three resume/respawn paths (`ensureRunning`, `ensureRunningRuntimeOnly`, `retryFreshStartAfterStaleKey`), which operate on a stable reused bead ID and are where a surviving orphan actually occurs. A recycled pid is disambiguated by `/proc/<pid>/stat` start-time so it isn't misread as still-alive.
- **Subreaper-aware orphan reap** (`internal/runtime/tmux/tmux.go`, `internal/workspacesvc/orphan_reap.go`): the reparent test is now "parent outside the known descendant set" (tmux) / `ppid == 1 OR ppid == detected subreaper pid` (workspacesvc), so orphans that reparent to `systemd --user` under a `user@.service` subreaper are still collected. Detection failure falls back to strict `ppid == 1` on plain-init hosts.
- **Token-fenced async drain-ack stop** (`cmd/gc/session_reconciler.go`): `queueDrainAckAsyncStop` threads the expected `GC_INSTANCE_TOKEN` (captured at queue time) and skips the kill on a definite mismatch, so a stalled async kill can't hit a name-reused replacement, mirroring `verifiedStop`.

## Test plan

- `go build ./...`, `go vet`, `golangci-lint run ./internal/session/... ./internal/runtime/proctable/...`: clean (0 issues)
- `go test ./internal/session/... ./internal/runtime/... ./internal/workspacesvc/... ./internal/pidutil/... ./cmd/gc/...`: pass
- New tests: `KillByPID` confirms death before returning; PID-reuse disambiguation (matching/recycled/empty); reparent collects init + subreaper orphans, skips known descendants; subreaper detection (systemd-user / plain-init / cyclic); token-fence skips a reused name and kills a matching session; and behavioral tests that `Start`/`StartRuntimeOnly` refuse (no `start:` event) and unwind the route when an orphan can't be confirmed dead, plus positive cases proving no over-refusal. The refusal tests were verified to fail if the gate is stubbed to a no-op.

## Note

A genuinely-wedged orphan can add up to `ManagedProcessStopGrace + ManagedProcessReapGrace` (~8s) to a single `Create`/respawn call while it confirms death, then refuses that attempt (retried next tick). It is bounded and on the per-request/respawn goroutine, not a shared serialized loop, but a caller behind a tight synchronous SLA will see the occasional multi-second stall when an orphan is actually stuck.
